### PR TITLE
fix(app): size iPad selector popovers

### DIFF
--- a/packages/app/src/composer/agent-controls/index.tsx
+++ b/packages/app/src/composer/agent-controls/index.tsx
@@ -853,6 +853,7 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
             onOpenChange={handleThinkingOpenChange}
             anchorRef={thinkingAnchorRef}
             desktopPlacement="top-start"
+            desktopMinWidth={200}
             renderOption={renderThinkingOption}
           />
         </>

--- a/packages/app/src/composer/agent-controls/mode-control.tsx
+++ b/packages/app/src/composer/agent-controls/mode-control.tsx
@@ -269,6 +269,7 @@ function AgentModeControlView({
         onOpenChange={handleOpenChange}
         anchorRef={anchorRef}
         desktopPlacement="top-start"
+        desktopMinWidth={260}
         header={sheetHeader}
         renderOption={renderOption}
       />

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -1382,6 +1382,7 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
         open={project.openState}
         onOpenChange={project.onOpenChange}
         desktopPlacement="bottom-start"
+        desktopMinWidth={360}
         anchorRef={project.anchorRef}
         emptyText="No projects available."
         renderOption={project.renderOption}
@@ -1402,6 +1403,7 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
         searchable={false}
         title="Host"
         desktopPlacement="bottom-start"
+        desktopMinWidth={200}
         hostOptionTestID={newWorkspaceHostOptionTestID}
       >
         <Pressable


### PR DESCRIPTION
### Linked issue

Closes #2359

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Fixes overly narrow popovers in the iPad desktop layout.

The Project, Host, Thinking Effort, and Mode pickers now set explicit minimum desktop widths so their content remains readable:

- Project: 360px
- Host: 200px
- Thinking Effort: 200px
- Mode: 260px

This PR follows the approach and discussion in PR https://github.com/getpaseo/paseo/pull/981 (add `desktopMinWidth`).

### How did you verify it

- Reproduced the issue on `main` in landscape on an iPad Pro 13-inch (M5) Simulator.
- Built and installed this branch against the daemon.
- Confirmed that the Project, Host, Thinking Effort, and Mode pickers render without unnecessary ellipsis.
- Attached iPad screenshots for all four pickers.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [ ] Tests added or updated where it made sense

Screenshots are attached.

<img width="2752" height="2016" alt="agent-mode" src="https://github.com/user-attachments/assets/4f67ee1a-2531-42a3-9279-b2587e3e4e25" />
<img width="2752" height="2016" alt="machine-name" src="https://github.com/user-attachments/assets/1f772f56-a1ca-49c1-9fef-381a5fae8eab" />
<img width="2752" height="2016" alt="project-name" src="https://github.com/user-attachments/assets/1076a9da-8501-4fad-8cfd-e13bab9ede71" />
<img width="2752" height="2016" alt="thinking-effort" src="https://github.com/user-attachments/assets/6a40102a-3779-4844-989d-1ce20d83569a" />

