### PR TITLE
fix(usage): surface account email on provider usage cards

### DIFF
--- a/packages/app/src/provider-usage/card.tsx
+++ b/packages/app/src/provider-usage/card.tsx
@@ -48,6 +48,10 @@ export function ProviderUsageCard({
   const footer = footerText(usage);
   const balances = usage.balances ?? [];
   const details = usage.details ?? [];
+  const accountDetail = details.find((detail) => detail.id === "account_email") ?? null;
+  const remainingDetails = accountDetail
+    ? details.filter((detail) => detail.id !== accountDetail.id)
+    : details;
 
   const containerStyle = useMemo(
     () => [styles.container, compact ? styles.containerCompact : styles.containerPadded],
@@ -79,6 +83,12 @@ export function ProviderUsageCard({
         ) : null}
       </View>
 
+      {accountDetail ? (
+        <Text style={styles.account} numberOfLines={1}>
+          {accountDetail.value}
+        </Text>
+      ) : null}
+
       {usage.error ? (
         <Text style={styles.error} numberOfLines={3}>
           {usage.error}
@@ -96,9 +106,9 @@ export function ProviderUsageCard({
         </View>
       ) : null}
 
-      {details.length > 0 ? (
+      {remainingDetails.length > 0 ? (
         <View style={styles.details}>
-          {details.map((detail) => (
+          {remainingDetails.map((detail) => (
             <View key={detail.id} style={styles.detailRow}>
               <Text style={styles.detailLabel} numberOfLines={1}>
                 {detail.label}
@@ -163,6 +173,10 @@ const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.statusDanger,
   },
   statusLabel: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  account: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.xs,
   },

--- a/packages/server/src/services/quota-fetcher/providers/codex.ts
+++ b/packages/server/src/services/quota-fetcher/providers/codex.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import type {
   ProviderUsage,
   ProviderUsageBalance,
+  ProviderUsageDetail,
   ProviderUsageWindow,
 } from "../../../server/messages.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
@@ -182,6 +183,11 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
       });
     }
 
+    const details: ProviderUsageDetail[] = [];
+    if (resp.email) {
+      details.push({ id: "account_email", label: "Account email", value: resp.email });
+    }
+
     return {
       providerId: this.providerId,
       displayName: this.displayName,
@@ -189,7 +195,7 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
       planLabel: resp.plan_type ?? null,
       windows,
       balances,
-      details: [],
+      details,
       error: null,
     };
   }

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -562,6 +562,7 @@ describe("real provider usage fetchers", () => {
         expect.objectContaining({ id: "weekly", usedPct: 8 }),
       ]),
       balances: [expect.objectContaining({ id: "credits", remaining: 0 })],
+      details: [{ id: "account_email", label: "Account email", value: "user@example.com" }],
     });
   });
 


### PR DESCRIPTION
### Linked issue

Closes #2373

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

- Provider usage cards promote `account_email` out of the generic details list
- Codex quota fetcher maps billing `email` into `details` (it was parsed but discarded)

### How did you verify it

- `npx vitest run packages/server/src/services/quota-fetcher/service.test.ts -t "Codex" --bail=1` (4 passed)
- Manual: Codex usage response includes email; card renders it above the bars
- lint/format/typecheck via pre-commit hook

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Linked issue present for bug fix / behavior change
- [x] Verification section filled with what *I* actually ran


Made with [Cursor](https://cursor.com)