### PR TITLE
fix(app): open existing host projects from Add Project search

### DIFF
--- a/packages/app/src/add-project-flow/options.test.ts
+++ b/packages/app/src/add-project-flow/options.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildExistingProjectChoices } from "./options";
+
+const PROJECTS = [
+  {
+    projectKey: "prj_existing",
+    projectName: "Existing App",
+    projectKind: "git" as const,
+    iconWorkingDir: "/projects/existing-app",
+    hosts: [
+      {
+        serverId: "host-a",
+        iconWorkingDir: "/projects/existing-app",
+        canCreateWorktree: true,
+      },
+    ],
+    workspaceKeys: ["host-a:ws-existing"],
+  },
+  {
+    projectKey: "prj_other",
+    projectName: "Other App",
+    projectKind: "directory" as const,
+    iconWorkingDir: "/projects/other-app",
+    hosts: [
+      {
+        serverId: "host-a",
+        iconWorkingDir: "/projects/other-app",
+        canCreateWorktree: false,
+      },
+    ],
+    workspaceKeys: ["host-a:ws-other"],
+  },
+];
+
+describe("buildExistingProjectChoices", () => {
+  it("returns direct-selectable existing projects that match the search", () => {
+    expect(
+      buildExistingProjectChoices({ projects: PROJECTS, serverId: "host-a", query: "existing" }),
+    ).toEqual([
+      {
+        project: PROJECTS[0],
+        sourceDirectory: "/projects/existing-app",
+      },
+    ]);
+  });
+
+  it("does not offer projects from another host", () => {
+    expect(
+      buildExistingProjectChoices({ projects: PROJECTS, serverId: "host-b", query: "" }),
+    ).toEqual([]);
+  });
+});

--- a/packages/app/src/add-project-flow/options.ts
+++ b/packages/app/src/add-project-flow/options.ts
@@ -4,6 +4,7 @@ import {
   parseGitRemoteLocation,
 } from "@getpaseo/protocol/git-remote";
 import { shortenPath } from "@/utils/shorten-path";
+import { getHostProjectSourceDirectory, type HostProjectListItem } from "@/projects/host-projects";
 import type { AddProjectHost, GithubRepositoryChoice } from "./model";
 
 export type AddProjectMethodId = "directory-search" | "browse" | "github" | "new-directory";
@@ -21,6 +22,37 @@ export interface AddProjectPathOption {
   displayPath: string;
   secondaryText: string | null;
   disabled: boolean;
+}
+
+export interface ExistingProjectChoice {
+  project: HostProjectListItem;
+  sourceDirectory: string;
+}
+
+/**
+ * Existing project roots are already registered by the daemon. Selecting one
+ * must route to it directly instead of treating the same directory as a new
+ * project-add request.
+ */
+export function buildExistingProjectChoices(input: {
+  projects: readonly HostProjectListItem[];
+  serverId: string;
+  query: string;
+  limit?: number;
+}): ExistingProjectChoice[] {
+  const normalizedQuery = input.query.trim().toLocaleLowerCase();
+  const limit = input.limit ?? 30;
+  return input.projects
+    .flatMap((project) => {
+      const sourceDirectory = getHostProjectSourceDirectory(project, input.serverId);
+      if (!sourceDirectory) return [];
+      const haystack = [project.projectName, project.projectKey, sourceDirectory]
+        .join("\n")
+        .toLocaleLowerCase();
+      if (normalizedQuery && !haystack.includes(normalizedQuery)) return [];
+      return [{ project, sourceDirectory }];
+    })
+    .slice(0, limit);
 }
 
 export function filterAddProjectHosts(hosts: AddProjectHost[], query: string): AddProjectHost[] {

--- a/packages/app/src/components/add-project-flow.tsx
+++ b/packages/app/src/components/add-project-flow.tsx
@@ -46,6 +46,7 @@ import {
 import {
   buildAddProjectMethods,
   addProjectMethodEmptyText,
+  buildExistingProjectChoices,
   buildCloneLocationOptions,
   buildManualGithubRepositoryChoices,
   buildSuggestedParentDirectories,
@@ -71,6 +72,7 @@ import {
   useHostRuntimeClient,
   useHostRuntimeConnectionStatuses,
 } from "@/runtime/host-runtime";
+import { useHostProjects } from "@/projects/host-projects";
 import { useHostFeatureMap } from "@/runtime/host-features";
 import { useSessionStore } from "@/stores/session-store";
 import { useRecommendedProjectPaths } from "@/stores/session-store-hooks";
@@ -350,6 +352,8 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
   const client = useHostRuntimeClient(hostId ?? "");
   const isLocalDaemon = useIsLocalDaemon(hostId ?? "");
   const recommendedPaths = useRecommendedProjectPaths(hostId);
+  const projectHostIds = useMemo(() => (hostId ? [hostId] : []), [hostId]);
+  const existingProjects = useHostProjects(projectHostIds);
   const openProject = useOpenProject(hostId);
   const cloneGithubProject = useCloneGithubProject(hostId);
   const addEmptyProject = useSessionStore((store) => store.addEmptyProject);
@@ -516,6 +520,17 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
       }),
     [directoryPaths, query, recommendedPaths],
   );
+  const existingProjectChoices = useMemo(
+    () =>
+      page.kind === "directory-search" && hostId
+        ? buildExistingProjectChoices({
+            projects: existingProjects,
+            serverId: hostId,
+            query,
+          })
+        : [],
+    [existingProjects, hostId, page.kind, query],
+  );
   const cloneRepository = useCallback(
     async (locationPage: GithubLocationPage, parentPath: string) => {
       if (submissionInFlightRef.current) return;
@@ -601,17 +616,37 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
         }));
     }
     if (page.kind === "directory-search") {
-      return pathOptions.map((option) => {
-        const shortPath = shortenPath(option.path);
-        return {
-          id: option.path,
-          title: shortPath,
-          subtitle: directoryOptionSubtitle(option, shortPath),
-          icon: Folder,
-          testID: pathTestId(option.path),
-          select: () => void openAddedProject(option.path, "directory-search"),
-        };
-      });
+      const existingSourceDirectories = new Set(
+        existingProjectChoices.map((choice) => choice.sourceDirectory),
+      );
+      const existingRows = existingProjectChoices.map((choice) => ({
+        id: `existing-project:${choice.project.projectKey}`,
+        title: choice.project.projectName,
+        subtitle: `Existing project · ${shortenPath(choice.sourceDirectory)}`,
+        icon: FolderOpen,
+        testID: `add-project-flow-existing-project-${choice.project.projectKey}`,
+        select: () =>
+          openNewWorkspaceForProject(page.hostId, {
+            projectId: choice.project.projectKey,
+            projectRootPath: choice.sourceDirectory,
+            projectDisplayName: choice.project.projectName,
+            projectKind: choice.project.projectKind,
+          }),
+      }));
+      const directoryRows = pathOptions
+        .filter((option) => !existingSourceDirectories.has(option.path))
+        .map((option) => {
+          const shortPath = shortenPath(option.path);
+          return {
+            id: option.path,
+            title: shortPath,
+            subtitle: directoryOptionSubtitle(option, shortPath),
+            icon: Folder,
+            testID: pathTestId(option.path),
+            select: () => void openAddedProject(option.path, "directory-search"),
+          };
+        });
+      return [...existingRows, ...directoryRows];
     }
     if (page.kind === "github-search") {
       const search = githubQuery.data?.query === page.query ? githubQuery.data.payload : null;
@@ -679,10 +714,12 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
   }, [
     cloneRepository,
     directoryPaths,
+    existingProjectChoices,
     githubQuery.data,
     host,
     onClose,
     openAddedProject,
+    openNewWorkspaceForProject,
     page,
     pathOptions,
     recommendedPaths,


### PR DESCRIPTION
### Linked issue

Closes #2374

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Add Project search now recognizes already-registered host projects and selecting one routes to the existing project instead of issuing another project-add for the same directory.

### How did you verify it

- `npx vitest run packages/app/src/add-project-flow/options.test.ts --bail=1` (2 passed)
- Manual: search for an already-added project directory and confirm it opens the existing project
- lint/format/typecheck via pre-commit hook

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Linked issue present for bug fix / behavior change
- [x] Verification section filled with what *I* actually ran


Made with [Cursor](https://cursor.com)