### PR TITLE
Hide Markdown source controls on read-only hosts

### DIFF
--- a/packages/app/src/file-pane/pane.tsx
+++ b/packages/app/src/file-pane/pane.tsx
@@ -459,6 +459,7 @@ export function FilePane({
     preview,
     supportsEditing,
   });
+  const canToggleMarkdownMode = isMarkdown && editable;
   const lineCount =
     preview?.kind === "text" ? (preview.content ?? "").split("\n").length : undefined;
   const errorMessage = getFileErrorMessage(query.error, t("panels.file.failedToLoad"));
@@ -471,8 +472,8 @@ export function FilePane({
       preview={preview}
       version={version}
       filename={getFileNameFromPath(location.path) ?? location.path}
-      markdownMode={isMarkdown ? markdownMode : undefined}
-      onMarkdownModeChange={isMarkdown ? setMarkdownMode : undefined}
+      markdownMode={canToggleMarkdownMode ? markdownMode : undefined}
+      onMarkdownModeChange={canToggleMarkdownMode ? setMarkdownMode : undefined}
       lineCount={lineCount}
       editable={editable}
       disconnectedMessage={t("workspace.terminal.hostDisconnected")}


### PR DESCRIPTION
### Linked issue

No matching open issue found.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Hides the Preview/Source control for Markdown files when the current host cannot edit the file. The control now uses the same editability decision as the editor, so read-only hosts only show the Markdown preview instead of advertising an unavailable source mode.

### How did you verify it

- `npm run typecheck`
- `npm run lint`
- `npm run format`
- Confirmed the mode props are only supplied when the Markdown file is editable; the existing file panel bar renders the toggle only when both props are present.

Visual capture was not produced for the unsupported-host configuration.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

### Risk surface

This only changes the file-pane control visibility. Editable Markdown files keep the existing Preview/Source behavior; read-only Markdown files keep the existing rendered preview.