### PR TITLE
Fix Android workspace restore after process recreation

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -63,6 +63,7 @@ import {
   startHostRuntimeBootstrap,
   type StartupBlocker,
 } from "@/navigation/host-runtime-bootstrap";
+import { resolveOfferLinkNavigationRoute } from "@/navigation/offer-link-navigation";
 import { registerWorkspaceRouteNavigationRef } from "@/navigation/workspace-route-navigation";
 import { ThemedStack } from "@/navigation/themed-stack";
 import { shouldUseDesktopDaemon } from "@/desktop/daemon/desktop-daemon";
@@ -111,7 +112,6 @@ import {
   WindowChromeSafeArea,
 } from "@/utils/desktop-window";
 import {
-  buildOpenProjectRoute,
   parseHostWorkspaceRouteFromPathname,
   parseServerIdFromPathname,
 } from "@/utils/host-routes";
@@ -698,9 +698,9 @@ function OfferLinkListener({
       void upsertDaemonFromOfferUrl(url)
         .then((profile) => {
           if (cancelled) return;
-          const serverId = (profile as { serverId?: unknown } | null)?.serverId;
-          if (typeof serverId !== "string" || !serverId) return;
-          router.replace(buildOpenProjectRoute());
+          const route = resolveOfferLinkNavigationRoute(profile);
+          if (!route) return;
+          router.replace(route);
           return;
         })
         .catch((error) => {

--- a/packages/app/src/navigation/offer-link-navigation.test.ts
+++ b/packages/app/src/navigation/offer-link-navigation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveOfferLinkNavigationRoute } from "./offer-link-navigation";
+
+describe("resolveOfferLinkNavigationRoute", () => {
+  it("enters through the paired host so startup can restore its remembered workspace", () => {
+    expect(resolveOfferLinkNavigationRoute({ serverId: "server-saved" })).toBe("/h/server-saved");
+  });
+
+  it("rejects a missing server id", () => {
+    expect(resolveOfferLinkNavigationRoute({})).toBeNull();
+  });
+
+  it("rejects a non-string server id", () => {
+    expect(resolveOfferLinkNavigationRoute({ serverId: 42 })).toBeNull();
+  });
+});

--- a/packages/app/src/navigation/offer-link-navigation.ts
+++ b/packages/app/src/navigation/offer-link-navigation.ts
@@ -1,0 +1,14 @@
+import type { Href } from "expo-router";
+import { buildHostRootRoute } from "@/utils/host-routes";
+
+export function resolveOfferLinkNavigationRoute(profile: unknown): Href | null {
+  const serverId = (profile as { serverId?: unknown } | null)?.serverId;
+  if (typeof serverId !== "string" || !serverId) {
+    return null;
+  }
+
+  // Android may redeliver the Activity's original pairing intent after the app
+  // process is reclaimed. Enter through the host index so its startup policy can
+  // restore a remembered workspace instead of always reopening project setup.
+  return buildHostRootRoute(serverId);
+}


### PR DESCRIPTION
Fixes #2383.

## Problem

After Android reclaims the app process, reopening Paseo can replay the Activity's original pairing intent. `OfferLinkListener` imports that stale offer again and then unconditionally navigates to the global project setup route, overriding the remembered workspace restored during startup.

## Change

Route successful offer imports through the paired host root instead of directly to global project setup. The existing host startup policy then:

- restores the remembered workspace when one exists for that host;
- keeps first-time pairing behavior by opening project setup when no workspace is remembered.

The route decision is isolated in a small navigation helper with focused tests, including invalid profile handling.

## Reproduction evidence

The bug was reproduced consistently on Android v0.2.0-beta.3 with a v0.2.0-beta.3 workstation. A screen recording shows the app process-recreation splash followed by the unexpected Add project screen.

## QA

- `npm --workspace @getpaseo/app test -- src/navigation/offer-link-navigation.test.ts src/navigation/host-runtime-bootstrap.test.ts --bail=1` — 29 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed with 0 warnings and 0 errors
- `npm run format:files -- packages/app/src/app/_layout.tsx packages/app/src/navigation/offer-link-navigation.ts packages/app/src/navigation/offer-link-navigation.test.ts` — passed

The original bug was reproduced on Android. The patched branch has not yet been installed on a physical Android device; automated coverage verifies the navigation policy and existing workspace restore behavior.
