### PR TITLE
Keep development tool versions consistent across version managers

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,10 @@
+[vars]
+android_sdk_version = '{{ read_file(path=".tool-versions") | split(pat="android-sdk") | last | trim | split(pat="\n") | first | trim }}'
+
 [env]
-ANDROID_HOME = { value = "{{ tools['android-sdk'].path }}", tools = true }
-_.path = { path = [
-  "{{ tools['android-sdk'].path }}/cmdline-tools/{{ tools['android-sdk'].version }}/bin",
-  "{{ tools['android-sdk'].path }}/platform-tools",
-  "{{ tools['android-sdk'].path }}/emulator",
-], tools = true }
+ANDROID_HOME = "{{ env.HOME }}/.local/share/mise/installs/android-sdk/{{ vars.android_sdk_version }}"
+_.path = [
+  "{{ env.HOME }}/.local/share/mise/installs/android-sdk/{{ vars.android_sdk_version }}/cmdline-tools/{{ vars.android_sdk_version }}/bin",
+  "{{ env.HOME }}/.local/share/mise/installs/android-sdk/{{ vars.android_sdk_version }}/platform-tools",
+  "{{ env.HOME }}/.local/share/mise/installs/android-sdk/{{ vars.android_sdk_version }}/emulator",
+]

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,10 +1,7 @@
 [env]
-ANDROID_HOME = "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0"
-_.path = [
-  "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0/cmdline-tools/21.0/bin",
-  "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0/platform-tools",
-  "{{env.HOME}}/.local/share/mise/installs/android-sdk/21.0/emulator",
-]
-
-[tools]
-java = "21"
+ANDROID_HOME = { value = "{{ tools['android-sdk'].path }}", tools = true }
+_.path = { path = [
+  "{{ tools['android-sdk'].path }}/cmdline-tools/{{ tools['android-sdk'].version }}/bin",
+  "{{ tools['android-sdk'].path }}/platform-tools",
+  "{{ tools['android-sdk'].path }}/emulator",
+], tools = true }

--- a/docs/android.md
+++ b/docs/android.md
@@ -27,7 +27,7 @@ The formula reserves three digits each for minor and patch. If either reaches `1
 
 ## Prerequisites (local dev)
 
-Local Android builds run on macOS (or Linux) and need the Android toolchain, pinned in `.tool-versions` (`java 21`, `android-sdk 21.0`) and wired up by `.mise.toml` (which derives `ANDROID_HOME` and the command-line tool paths from the resolved Android SDK). With [mise](https://mise.jdx.dev):
+Local Android builds run on macOS (or Linux) and need the Android toolchain, pinned in `.tool-versions` (`java 21`, `android-sdk 21.0`) and wired up by `.mise.toml` (which derives `ANDROID_HOME` and the command-line tool paths from the `android-sdk` entry). With [mise](https://mise.jdx.dev):
 
 ```bash
 mise install        # java 21 + android-sdk 21.0 command-line tools

--- a/docs/android.md
+++ b/docs/android.md
@@ -27,13 +27,13 @@ The formula reserves three digits each for minor and patch. If either reaches `1
 
 ## Prerequisites (local dev)
 
-Local Android builds run on macOS (or Linux) and need the Android toolchain, pinned in `.tool-versions` (`java 21`, `android-sdk 21.0`) and wired up by `.mise.toml` (which sets `ANDROID_HOME` and puts `cmdline-tools/21.0/bin`, `platform-tools`, and `emulator` on `PATH`). With [mise](https://mise.jdx.dev):
+Local Android builds run on macOS (or Linux) and need the Android toolchain, pinned in `.tool-versions` (`java 21`, `android-sdk 21.0`) and wired up by `.mise.toml` (which derives `ANDROID_HOME` and the command-line tool paths from the resolved Android SDK). With [mise](https://mise.jdx.dev):
 
 ```bash
 mise install        # java 21 + android-sdk 21.0 command-line tools
 ```
 
-> **Pin a real `android-sdk` version, not `latest`.** The mise `android-sdk` plugin's `latest` resolved to the ancient `1.0` bundle, whose `sdkmanager` (3.6.0) predates the `emulator` package and fails with `Failed to find package emulator`. `21.0` ships a current `sdkmanager`. If you bump it, update the version in `.tool-versions` and in all four paths in `.mise.toml`.
+> **Pin a real `android-sdk` version, not `latest`.** The mise `android-sdk` plugin's `latest` resolved to the ancient `1.0` bundle, whose `sdkmanager` (3.6.0) predates the `emulator` package and fails with `Failed to find package emulator`. `21.0` ships a current `sdkmanager`. If you bump it, update only the version in `.tool-versions`; `.mise.toml` derives its paths from that tool entry.
 
 `mise install` only lays down the command-line tools. Install the rest and create an emulator. On Apple Silicon:
 


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps `.tool-versions` as the single source of truth for development tool versions, so asdf and mise resolve the same Node.js, Rust, Java, and Android SDK versions. The mise config now contains only mise-specific Android environment setup and derives its paths from the `android-sdk` entry instead of repeating its version.

### How did you verify it

- Ran mise 2026.7.12 against an isolated copy of both config files and confirmed Node.js, Rust, Java, and Android SDK all resolve from `.tool-versions`.
- Ran clean-machine `mise install --dry-run` and environment probes on mise 2026.4.28 and 2026.7.12.
- Confirmed `ANDROID_HOME`, cmdline-tools, platform-tools, and emulator paths all resolve from `android-sdk 21.0` before the SDK is installed.
- `npm run typecheck`
- `npm run lint`
- `npm run format`

CI covers the repository checks. No platform-specific runtime verification is needed for this config-only change.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable)
- [x] Tests added or updated where it made sense (isolated mise config probes)