### PR TITLE
Give Android store builds more memory

### DIFF
--- a/packages/app/eas.json
+++ b/packages/app/eas.json
@@ -19,6 +19,9 @@
       "channel": "production",
       "env": {
         "APP_VARIANT": "production"
+      },
+      "android": {
+        "resourceClass": "large"
       }
     },
     "production-apk": {


### PR DESCRIPTION
The production Android store build can compile native ABIs while Hermes bundles JavaScript. On the default worker, that exhausted memory and killed `hermesc` with exit code 137 during the v0.2.0 release.

This gives production Android builds the same large resource class already used by the release APK profile. App code and build outputs are unchanged.

Verification:
- JSON validation passed
- Formatting passed
- Repository typecheck passed in the pre-commit hook
- A v0.2.0 retry is running on the large worker from the exact release commit