### PR TITLE
Add SSH remote host support for tunneling daemon connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/forge-providers.md](docs/forge-providers.md)                 | Adding a git forge: registry/manifest, drop-in checklist, self-host/GHES, the two facts tiers                                  |
 | [docs/custom-providers.md](docs/custom-providers.md)               | Custom provider config: Z.AI, Alibaba/Qwen, ACP agents, profiles, custom binaries                                              |
 | [docs/service-proxy.md](docs/service-proxy.md)                     | Service proxy: exposing workspace scripts at public URLs, DNS setup, reverse proxy config                                      |
+| [docs/ssh.md](docs/ssh.md)                                         | SSH remote hosts: single-connection tunnel, ensure script contract, which remote `paseo` runs, askpass and Origin gotchas      |
 | [docs/development.md](docs/development.md)                         | Dev server, build sync gotchas, CLI reference, agent state, Playwright MCP                                                     |
 | [docs/rpc-namespacing.md](docs/rpc-namespacing.md)                 | WebSocket RPC naming convention — dotted namespaces and `.request`/`.response` pairs                                           |
 | [docs/protocol-validation.md](docs/protocol-validation.md)         | zod-aot generated inbound WebSocket validation, patched compiler regressions, schema-purity rules                              |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,30 @@ CORS is not a complete security boundary. It controls which browser origins can 
 
 Paseo validates the `Host` header on every HTTP request and every WebSocket upgrade against an allowlist (Vite-style semantics). By default, only `localhost`, `*.localhost`, and any literal IP address (IPv4 or IPv6) are accepted. Additional hostnames can be configured via `hostnames` in `config.json` or the `PASEO_HOSTNAMES` env var (comma-separated; entries beginning with `.` match a domain and its subdomains; the value `true` disables the allowlist entirely). Requests with unrecognized hosts are rejected with `403 Host not allowed`.
 
+## SSH tunnels
+
+The CLI and desktop app can reach a daemon on another machine over `ssh -L`
+(see [docs/ssh.md](docs/ssh.md)). The remote daemon binds `127.0.0.1` and is
+launched with `--no-relay --no-mcp`, so the tunnel is the only path to it, and
+SSH provides the authentication and transport encryption.
+
+Two properties worth stating explicitly:
+
+**Host keys are trust-on-first-use.** Connections use
+`StrictHostKeyChecking=accept-new`: an unknown host key is accepted silently,
+a _changed_ one still fails. The desktop UI has no way to present a fingerprint
+for confirmation, so a first connection made from the GUI accepts the key
+without showing it. Connect once from the CLI if you want to verify a
+fingerprint by hand.
+
+**The desktop strips `Origin` for tunneled WebSocket upgrades.** A renderer's
+origin can never match a tunnel's ephemeral loopback port, so the daemon's
+same-origin check would reject every tunneled connection. The header is removed
+only for ports the main process is currently forwarding — never for loopback
+generally, which would also disable the check for a directly-connected local
+daemon. Untrusted web content runs in a separate Electron session
+(`PASEO_BROWSER_PROFILE_PARTITION`) that the rule is not installed on.
+
 ## Agent authentication
 
 Paseo wraps agent CLIs (Claude Code, Codex, OpenCode) but does not manage their authentication. Each agent provider handles its own credentials. Paseo never stores or transmits provider API keys. Agents run in your user context with your existing credentials.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -379,3 +379,4 @@ $PASEO_HOME/
 1. **Local daemon** (default): `paseo daemon start` on `127.0.0.1:6767`
 2. **Managed desktop**: Electron app spawns daemon as subprocess
 3. **Remote + relay**: Daemon behind firewall, relay bridges with E2E encryption
+4. **Remote + SSH tunnel**: CLI or desktop forwards a loopback-bound remote daemon over `ssh -L`, installing and launching it if needed. See [ssh.md](ssh.md)

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -1,0 +1,284 @@
+# SSH remote hosts
+
+Connecting to a Paseo daemon on another machine over SSH, from the CLI
+(`--host ssh://user@host`) or the desktop app's **Add connection → SSH**.
+
+Paseo opens one SSH connection that does three things at once: authenticates,
+makes sure a daemon is running on the far side, and forwards the daemon's port
+to a local one. The WebSocket client then connects to `127.0.0.1:<localPort>`
+as if the daemon were local.
+
+## Why one connection
+
+An earlier design used two connections — one to run the ensure step, one for
+the port forward — multiplexed with `ControlMaster`. That meant two
+authentications (two password prompts) and a dependency on a control socket
+that behaves differently across OpenSSH versions.
+
+Instead, the SSH connection's remote command is `exec /bin/sh` while `-L`
+forwards the port, and the ensure script is piped to that shell over stdin.
+
+**The remote command is not the script, and that is deliberate.** sshd runs a
+remote command as `<user's shell> -c "<command>"`, taking the shell from the
+password database — see `session.c`, which sets `argv[0]=shell0; argv[1]="-c";
+argv[2]=command`. It is not a _login_ shell (no `-l`, argv[0] is not
+dash-prefixed, so `~/.bash_profile` is not sourced), but it **is** the user's
+shell binary. On a host where someone has `chsh`'d to fish or tcsh, our POSIX
+script would be handed to fish or tcsh and fail outright.
+
+Wrapping it as `/bin/sh -c '<script>'` does not help: that outer string still
+goes through the user's shell, and neither fish nor csh can carry the single
+quotes and embedded newlines the script contains. Reducing the command to three
+metacharacter-free words is what makes it shell-agnostic — every shell agrees
+on what `exec /bin/sh` means.
+
+Two things fall out of this for free: nothing needs shell-escaping on the way
+in, and the script no longer appears in the remote host's process list, where
+any other user could read it.
+
+Consequences for the script itself:
+
+- **The keepalive is the absence of an exit.** `sh` reading a script from a
+  pipe executes incrementally and blocks for the next line, so falling off the
+  end holds the connection open. No `cat`, and no `sleep infinity` — BusyBox
+  and older BSD `sleep` reject `infinity`. Closing stdin is the teardown.
+- **The exit code has to be preserved by hand.** `ensure_daemon && ...`
+  collapses every failure to exit 1 and loses the reason. The script ends with
+  `ensure_daemon; rc=$?; [ $rc -eq 0 ] || exit $rc`.
+- **Children must not read stdin.** The script is _on_ stdin, so anything that
+  reads it would swallow the remainder. `npm install` and the daemon launch
+  both get `</dev/null`.
+
+## Readiness: `READY:` not prose
+
+The local port forward accepts connections the moment SSH connects — before the
+remote daemon is listening. Waiting on the local port is therefore a false
+positive, and the tunnel would hand a dead socket to the client.
+
+Readiness comes from the ensure script writing a `READY:` line to stderr.
+
+`PROGRESS:` and `READY:` are deliberately separate markers:
+
+- `PROGRESS:<text>` is human-facing status. Reword it freely.
+- `READY:<reason>` is the machine contract. Changing it breaks the tunnel.
+
+Matching readiness against the text of a progress message — which an earlier
+version did — means rewording a status string silently turns into a five-minute
+hang.
+
+## Which `paseo` runs on the remote host
+
+In order:
+
+1. **Something already listening on the daemon port** → use it, touch nothing.
+2. **`paseo` on `PATH`** (global npm, system package manager, nix) → launch it.
+3. **Neither** → install into `installDir` (`~/.paseo/cli` by default) and
+   launch that.
+
+Step 2 exists for correctness, not disk space. If Paseo installed its own copy
+alongside a system install, a user on the remote host could start _their_
+daemon from the system binary while we run a different build against the same
+`PASEO_HOME` — two daemons fighting over the port and the agent state.
+
+**Paseo only ever installs or upgrades inside `installDir`.** A binary it did
+not put there is never touched, upgraded, or replaced.
+
+### Versions
+
+The CLI pins the remote install to its own version so both ends run the same
+build, and re-installs when the managed copy drifts. Two consequences:
+
+- A source checkout or unpublished beta has no registry entry. The script
+  detects the failed install and retries with `@latest` rather than hard
+  failing, so connecting from a dev build works.
+- Version pinning only applies to the managed copy. A `PATH` install is used
+  as-is at whatever version it happens to be, and an already-running daemon is
+  never restarted to change its version. Capability mismatches there are the
+  job of `server_info.features.*`, not of this script.
+
+## Exit codes
+
+The script's exit codes are the contract with `describeEnsureFailure`:
+
+| Code | Meaning                                          |
+| ---- | ------------------------------------------------ |
+| 0    | Daemon ready                                     |
+| 10   | Node.js missing                                  |
+| 11   | Install failed                                   |
+| 12   | Never listened                                   |
+| 13   | npm missing                                      |
+| 255  | SSH itself failed (auth, DNS, host key, refused) |
+
+Anything else falls through to `describeSshFailure`, which surfaces SSH's own
+stderr. Retaining that stderr takes deliberate effort: attaching a `data`
+listener to parse progress markers puts the stream in flowing mode, so a later
+`stream.read()` returns nothing. `readSshStderr` buffers as it parses,
+otherwise every failure reports an empty reason.
+
+## Shell requirements
+
+The remote host needs `/bin/sh` and nothing else — the user's own shell can be
+fish, tcsh, or anything at all, because it only ever sees `exec /bin/sh` (see
+"Why one connection" above).
+
+Every interpolated value (hostnames, paths, version specs) is still
+single-quoted through `shellQuote`, so paths with spaces, quotes, or `$` work
+and cannot inject. That is defense in depth rather than the primary boundary
+now, but the script is still assembled as text and the quoting has to be right.
+
+`~`-relative paths are rendered as `"$HOME"/'rest/of/path'`: the tilde expands,
+the remainder cannot be reinterpreted.
+
+## Ports and `~/.ssh/config`
+
+`SshHostConfig.port` is deliberately **not** defaulted to 22, and the protocol
+schema leaves it optional without a default. "Unset" has to stay
+distinguishable from "22" — passing `-p 22` unconditionally would override a
+`Port` directive the user configured for that host. Everything else in their
+SSH config (`IdentityFile`, `ProxyJump`, `User`) applies as usual.
+
+The Add SSH Host modal leaves the port field blank with a `22` placeholder for
+the same reason.
+
+## Password prompts
+
+SSH only takes a secret from a program's stdout, and only asks through
+`SSH_ASKPASS` when there is no tty. So there is always a small askpass program
+— but what it does differs between the two clients.
+
+**Desktop** uses `createAskpassChannel`. Paseo starts a unix socket in a
+private `mkdtemp` directory and writes two files next to it: a POSIX shell
+wrapper (the thing SSH executes) and a Node helper that relays. The prompt
+travels to the main process, which asks the renderer, and the answer comes back
+down the socket to the helper's stdout.
+
+That means the dialog is Paseo's own — styled, localized, and able to say
+whether it wants a key passphrase or an account password. It replaces shelling
+out to `zenity` / `kdialog` / `osascript`, which cost us an unstyled dialog we
+could not control and a pile of GTK-specific escaping (underscores read as
+mnemonic accelerators, Pango markup parsing).
+
+Two details worth keeping:
+
+- **The helper is written at runtime, not shipped.** Nothing has to be resolved
+  or unpacked from inside an asar archive.
+- **The wrapper sets `ELECTRON_RUN_AS_NODE=1`.** Under the desktop app the
+  runtime is the Electron binary in Node mode; the variable is inert for a
+  plain `node`, so one wrapper shape serves the CLI too.
+
+`SSH_ASKPASS` must be an executable path, which is why a plain socket is not
+enough on its own — a POSIX shell cannot speak one. A FIFO pair would avoid the
+helper entirely, but a dismissed prompt or a missing window leaves `cat`
+blocked and SSH hanging; a socket fails fast instead and multiplexes
+concurrent attempts naturally.
+
+**CLI** keeps `createTerminalAskpassScript`, which prompts on `/dev/tty` and
+suppresses echo with `stty -echo` — not `read -s`, a bash/zsh extension that
+fails under dash, which is `/bin/sh` on Debian and Ubuntu.
+
+### Cancelling
+
+SSH gives askpass no way to report a cancellation: it discards the program's
+exit status and simply retries up to `NumberOfPasswordPrompts`. A dismissed
+dialog is therefore indistinguishable from a wrong password and comes straight
+back.
+
+The two clients solve that differently, because each knows something SSH does
+not:
+
+- **Desktop:** declining aborts `AskpassChannel.signal`, and `SshTunnel.open`
+  kills the SSH process on abort and throws `SshCancelledError`.
+- **CLI:** the terminal script writes `ASKPASS_CANCELLED_MARKER` to stderr,
+  which is inherited by ssh (only stdout is redirected to the password pipe)
+  and so lands in the stream the tunnel already parses.
+
+Both abort on the first refusal. Note that SSH's default of three attempts is
+deliberately left alone — a _typo_ should still be retryable, and only an
+explicit refusal ends the attempt.
+
+## Desktop: the Origin header
+
+The renderer's `Origin` never matches the tunnel's ephemeral loopback port, so
+the remote daemon's same-origin check rejects the upgrade and the socket closes
+with 1006.
+
+The fix strips `Origin` — but **only for ports the main process is currently
+forwarding** (`sshTunnelPorts`). That check is the daemon's DNS-rebinding
+defense (see [SECURITY.md](../SECURITY.md)); disabling it for all of loopback
+would also disable it for a directly-connected local daemon. The rule is
+installed once per session, since Electron allows a single
+`onBeforeSendHeaders` listener per session and a per-window registration
+silently replaces the previous one.
+
+## Multiple hosts, multiple tunnels
+
+Each saved host gets its own `HostRuntimeController`, and they all run at once
+(`ensureConnectedAll`, `runProbeCycleNow` fan out over every controller). So N
+connected SSH hosts means N `ssh` processes and N local port forwards.
+
+The ports themselves need no coordination:
+
+- Every tunnel takes a fresh ephemeral port from `findFreeLocalPort()`, which
+  binds `:0` and lets the OS pick. Two tunnels cannot be handed the same port
+  in practice, and `ExitOnForwardFailure=yes` turns the residual bind race into
+  a loud failure rather than a silent misroute.
+- The remote side is always `remotePort` (6767 by default) on a _different
+  machine_, so it never collides across hosts.
+- The desktop keys live tunnels by a UUID in `sshTunnels`, with `sshTunnelPorts`
+  mapping id → local port for the Origin rule.
+
+What does need managing is the _number_ of tunnels, and two things keep it
+bounded:
+
+**Probes never open a throwaway tunnel.** The probe cycle exists to time
+connections so the adaptive switcher can pick the fastest. For a TCP endpoint
+that is cheap. For SSH it means spawning `ssh`, authenticating, and running the
+ensure script — every 120s, per host, re-prompting anything using password auth.
+So a non-active SSH connection is simply not probed. It is only "probed" when it
+is already the live client, where reading `getLastLivenessRttMs()` is free, or
+when nothing is online and connecting is the point anyway.
+
+The tradeoff: an SSH connection carries no latency number while another
+transport is online, so `selectBestConnection` will never adaptively switch
+_onto_ a tunnel on RTT alone. That is the behavior we want — silently migrating
+a live session onto an SSH tunnel because loopback measured 2ms would be
+surprising. Failover is unaffected: when the active connection drops,
+`hasActiveOnlineConnection` goes false and SSH becomes eligible on the next
+cycle.
+
+**Every discarded client releases its transport.** See below.
+
+## Tunnel ownership
+
+An SSH-backed `DaemonClient` owns a tunnel the client itself knows nothing
+about. `closeClientAndTransport` in `test-daemon-connection.ts` is the only
+correct way to dispose one — a bare `client.close()` leaves the `ssh` process
+and the port forward alive for the lifetime of the app.
+
+The disposer lives in a `WeakMap` keyed by client rather than being threaded
+through every intermediate signature between the probe and the eventual close.
+Any one of those forgetting to pass it along is a leak that is invisible at the
+call site.
+
+## Daemons must outlive their session
+
+`paseo daemon start` wraps the launch in `systemd-run --user --scope` where
+available. Under systemd-logind with `KillUserProcesses=yes` a detached daemon
+inherits the launching session's cgroup and dies with it — when an SSH
+connection closes, when a desktop session logs out, or when the terminal that
+started it exits. The transient scope escapes that, and `loginctl
+enable-linger` keeps the user's systemd instance alive after the last session
+closes.
+
+This is not SSH-specific; it is a general property of detached daemons on
+systemd, and the SSH flow just makes it obvious.
+
+## Trust
+
+- The remote daemon binds `127.0.0.1` and is only reachable through the tunnel.
+  It is launched with `--no-relay --no-mcp`.
+- Host keys use `StrictHostKeyChecking=accept-new`: first connection is
+  trust-on-first-use, and a _changed_ key still fails. The desktop UI has no
+  way to show a fingerprint for confirmation, so a first connection from the
+  GUI accepts the key without showing it. Connect once from the CLI first if
+  you want to verify a fingerprint by hand.

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -38,6 +38,7 @@ import { RootErrorBoundary } from "@/components/root-error-boundary";
 import { WorkspaceSetupDialog } from "@/components/workspace-setup-dialog";
 import { WorkspaceShortcutTargetsSubscriber } from "@/components/workspace-shortcut-targets-subscriber";
 import { FloatingPanelPortalHost } from "@/components/ui/floating-panel-portal";
+import { SshPasswordPromptHost } from "@/components/ssh-password-prompt-host";
 import { HostChooserModal, useHostChooser } from "@/hosts/host-chooser";
 import {
   getIsElectronRuntime,
@@ -554,6 +555,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
       <CommandCenter />
       <AddProjectFlowHost />
       <HostChooserModal />
+      <SshPasswordPromptHost />
       <ProviderSettingsHost />
       <WorkspaceSetupDialog />
       <KeyboardShortcutsDialog />

--- a/packages/app/src/components/add-host-method-modal.tsx
+++ b/packages/app/src/components/add-host-method-modal.tsx
@@ -2,10 +2,10 @@ import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, Text, View } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import { QrCode, Link2, ClipboardPaste } from "lucide-react-native";
+import { QrCode, Link2, ClipboardPaste, Terminal } from "lucide-react-native";
 import { AdaptiveModalSheet, type SheetHeader } from "./adaptive-modal-sheet";
 import { isFdroidBuild } from "@/constants/build-profile";
-import { isNative } from "@/constants/platform";
+import { isNative, isWeb } from "@/constants/platform";
 
 const styles = StyleSheet.create((theme) => ({
   option: {
@@ -39,6 +39,7 @@ export interface AddHostMethodModalProps {
   onDirectConnection: () => void;
   onScanQr: () => void;
   onPasteLink: () => void;
+  onSshConnection: () => void;
 }
 
 export function AddHostMethodModal({
@@ -47,6 +48,7 @@ export function AddHostMethodModal({
   onDirectConnection,
   onScanQr,
   onPasteLink,
+  onSshConnection,
 }: AddHostMethodModalProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -63,6 +65,10 @@ export function AddHostMethodModal({
   const handlePaste = useCallback(() => {
     onPasteLink();
   }, [onPasteLink]);
+
+  const handleSsh = useCallback(() => {
+    onSshConnection();
+  }, [onSshConnection]);
 
   return (
     <AdaptiveModalSheet
@@ -100,6 +106,21 @@ export function AddHostMethodModal({
             <Text style={styles.optionSubtext}>
               {t("pairing.connectionMethods.scanQr.description")}
             </Text>
+          </View>
+        </Pressable>
+      ) : null}
+      {isWeb ? (
+        <Pressable
+          style={styles.option}
+          onPress={handleSsh}
+          accessibilityRole="button"
+          accessibilityLabel="SSH"
+          testID="add-host-method-ssh"
+        >
+          <Terminal size={18} color={theme.colors.foreground} />
+          <View style={styles.optionBody}>
+            <Text style={styles.optionText}>SSH</Text>
+            <Text style={styles.optionSubtext}>Connect to a remote host via SSH tunnel</Text>
           </View>
         </Pressable>
       ) : null}

--- a/packages/app/src/components/add-host-method-modal.tsx
+++ b/packages/app/src/components/add-host-method-modal.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { QrCode, Link2, ClipboardPaste, Terminal } from "lucide-react-native";
 import { AdaptiveModalSheet, type SheetHeader } from "./adaptive-modal-sheet";
 import { isFdroidBuild } from "@/constants/build-profile";
-import { isNative, isWeb } from "@/constants/platform";
+import { isNative, getIsElectron } from "@/constants/platform";
 
 const styles = StyleSheet.create((theme) => ({
   option: {
@@ -52,6 +52,7 @@ export function AddHostMethodModal({
 }: AddHostMethodModalProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
+  const isElectron = getIsElectron();
   const header = useMemo<SheetHeader>(() => ({ title: t("pairing.connectionMethods.title") }), [t]);
 
   const handleDirect = useCallback(() => {
@@ -109,18 +110,22 @@ export function AddHostMethodModal({
           </View>
         </Pressable>
       ) : null}
-      {isWeb ? (
+      {/* Spawning `ssh` needs a main process, so this is desktop-only — not
+          merely web. Browser web would show the option and dead-end. */}
+      {isElectron ? (
         <Pressable
           style={styles.option}
           onPress={handleSsh}
           accessibilityRole="button"
-          accessibilityLabel="SSH"
+          accessibilityLabel={t("pairing.connectionMethods.ssh.title")}
           testID="add-host-method-ssh"
         >
           <Terminal size={18} color={theme.colors.foreground} />
           <View style={styles.optionBody}>
-            <Text style={styles.optionText}>SSH</Text>
-            <Text style={styles.optionSubtext}>Connect to a remote host via SSH tunnel</Text>
+            <Text style={styles.optionText}>{t("pairing.connectionMethods.ssh.title")}</Text>
+            <Text style={styles.optionSubtext}>
+              {t("pairing.connectionMethods.ssh.description")}
+            </Text>
           </View>
         </Pressable>
       ) : null}

--- a/packages/app/src/components/add-ssh-host-modal.tsx
+++ b/packages/app/src/components/add-ssh-host-modal.tsx
@@ -46,6 +46,11 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.destructive,
     marginTop: theme.spacing[2],
   },
+  progress: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+    marginTop: theme.spacing[1],
+  },
   buttonRow: {
     flexDirection: "row",
     gap: theme.spacing[2],
@@ -67,6 +72,7 @@ export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshH
 
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [progressMessage, setProgressMessage] = useState("");
   const [host, setHost] = useState("");
   const [port, setPort] = useState("22");
   const [user, setUser] = useState("");
@@ -79,6 +85,7 @@ export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshH
     setPort("22");
     setUser("");
     setErrorMessage("");
+    setProgressMessage("");
   }, []);
 
   const handleClose = useCallback(() => {
@@ -105,10 +112,12 @@ export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshH
     try {
       setIsSaving(true);
       setErrorMessage("");
+      setProgressMessage("");
       const { serverId, hostname } = await probeAndUpsertSshConnection({
         host: trimmedHost,
         port: port.trim() ? Number(port) : undefined,
         ...(trimmedUser ? { user: trimmedUser } : {}),
+        onProgress: (msg) => setProgressMessage(msg),
       });
       onSaved?.({ serverId, hostname });
       handleClose();
@@ -185,6 +194,7 @@ export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshH
       </View>
 
       {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+      {isSaving && progressMessage ? <Text style={styles.progress}>{progressMessage}</Text> : null}
 
       <View style={styles.buttonRow}>
         <Button variant="ghost" onPress={handleCancel} disabled={isSaving}>

--- a/packages/app/src/components/add-ssh-host-modal.tsx
+++ b/packages/app/src/components/add-ssh-host-modal.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { Terminal } from "lucide-react-native";
+import { AdaptiveModalSheet, AdaptiveTextInput, type SheetHeader } from "./adaptive-modal-sheet";
+import { Button } from "@/components/ui/button";
+import { useHostMutations } from "@/runtime/host-runtime";
+import { useIsCompactFormFactor } from "@/constants/layout";
+
+const styles = StyleSheet.create((theme) => ({
+  helper: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    marginBottom: theme.spacing[4],
+  },
+  field: {
+    marginBottom: theme.spacing[3],
+  },
+  hostField: {
+    flex: 1,
+  },
+  portField: {
+    width: 90,
+  },
+  row: {
+    flexDirection: "row",
+    gap: theme.spacing[3],
+  },
+  label: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    marginBottom: 4,
+  },
+  input: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[2],
+    fontSize: theme.fontSize.base,
+    color: theme.colors.foreground,
+  },
+  error: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.destructive,
+    marginTop: theme.spacing[2],
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+    marginTop: theme.spacing[4],
+  },
+}));
+
+export interface AddSshHostModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onCancel?: () => void;
+  onSaved?: (result: { serverId: string; hostname: string | null }) => void;
+}
+
+export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshHostModalProps) {
+  const { t } = useTranslation();
+  const { probeAndUpsertSshConnection } = useHostMutations();
+  const isMobile = useIsCompactFormFactor();
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [host, setHost] = useState("");
+  const [port, setPort] = useState("22");
+  const [user, setUser] = useState("");
+
+  const header = useMemo<SheetHeader>(() => ({ title: "SSH Connection" }), []);
+  const icon = useMemo(() => <Terminal size={16} />, []);
+
+  const clearInput = useCallback(() => {
+    setHost("");
+    setPort("22");
+    setUser("");
+    setErrorMessage("");
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (isSaving) return;
+    clearInput();
+    onClose();
+  }, [isSaving, clearInput, onClose]);
+
+  const handleCancel = useCallback(() => {
+    if (isSaving) return;
+    clearInput();
+    (onCancel ?? onClose)();
+  }, [isSaving, onCancel, onClose, clearInput]);
+
+  const handleSave = useCallback(async () => {
+    if (isSaving) return;
+    const trimmedHost = host.trim();
+    const trimmedUser = user.trim();
+    if (!trimmedHost) {
+      setErrorMessage("Host is required.");
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      setErrorMessage("");
+      const { serverId, hostname } = await probeAndUpsertSshConnection({
+        host: trimmedHost,
+        port: port.trim() ? Number(port) : undefined,
+        ...(trimmedUser ? { user: trimmedUser } : {}),
+      });
+      onSaved?.({ serverId, hostname });
+      handleClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setErrorMessage(message);
+      if (!isMobile) {
+        Alert.alert("SSH connection failed", message);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }, [host, user, port, isSaving, isMobile, onSaved, handleClose, probeAndUpsertSshConnection]);
+
+  return (
+    <AdaptiveModalSheet
+      header={header}
+      visible={visible}
+      onClose={handleClose}
+      testID="add-ssh-host-modal"
+    >
+      <Text style={styles.helper}>
+        Connect to a remote Paseo daemon over SSH. Paseo will install and launch the daemon on the
+        remote host if needed.
+      </Text>
+
+      <View style={styles.row}>
+        <View style={[styles.field, styles.hostField]}>
+          <Text style={styles.label}>Host</Text>
+          <AdaptiveTextInput
+            testID="ssh-host-input"
+            accessibilityLabel="Host"
+            value={host}
+            onChangeText={setHost}
+            placeholder="server.example.com"
+            style={styles.input}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            editable={!isSaving}
+            returnKeyType="next"
+          />
+        </View>
+        <View style={[styles.field, styles.portField]}>
+          <Text style={styles.label}>Port</Text>
+          <AdaptiveTextInput
+            testID="ssh-port-input"
+            accessibilityLabel="Port"
+            value={port}
+            onChangeText={setPort}
+            placeholder="22"
+            style={styles.input}
+            keyboardType="number-pad"
+            editable={!isSaving}
+            returnKeyType="next"
+          />
+        </View>
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>User (optional)</Text>
+        <AdaptiveTextInput
+          testID="ssh-user-input"
+          accessibilityLabel="User"
+          value={user}
+          onChangeText={setUser}
+          placeholder="username"
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isSaving}
+          returnKeyType="next"
+        />
+      </View>
+
+      {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+
+      <View style={styles.buttonRow}>
+        <Button variant="ghost" onPress={handleCancel} disabled={isSaving}>
+          {t("common.actions.cancel")}
+        </Button>
+        <Button
+          variant="default"
+          onPress={handleSave}
+          disabled={isSaving}
+          leftIcon={icon}
+          testID="add-ssh-host-connect"
+        >
+          {isSaving ? "Connecting…" : "Connect"}
+        </Button>
+      </View>
+    </AdaptiveModalSheet>
+  );
+}

--- a/packages/app/src/components/add-ssh-host-modal.tsx
+++ b/packages/app/src/components/add-ssh-host-modal.tsx
@@ -1,12 +1,11 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, Text, View } from "react-native";
+import { Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { Terminal } from "lucide-react-native";
 import { AdaptiveModalSheet, AdaptiveTextInput, type SheetHeader } from "./adaptive-modal-sheet";
 import { Button } from "@/components/ui/button";
 import { useHostMutations } from "@/runtime/host-runtime";
-import { useIsCompactFormFactor } from "@/constants/layout";
 
 const styles = StyleSheet.create((theme) => ({
   helper: {
@@ -21,11 +20,16 @@ const styles = StyleSheet.create((theme) => ({
     flex: 1,
   },
   portField: {
-    width: 90,
+    // Wide enough for "Port (Optional)" on one line; the input itself only
+    // needs room for five digits.
+    width: 130,
   },
   row: {
     flexDirection: "row",
     gap: theme.spacing[3],
+    // Keep the inputs level even when a longer translation wraps the port
+    // label onto a second line.
+    alignItems: "flex-end",
   },
   label: {
     color: theme.colors.foregroundMuted,
@@ -68,69 +72,99 @@ export interface AddSshHostModalProps {
 export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshHostModalProps) {
   const { t } = useTranslation();
   const { probeAndUpsertSshConnection } = useHostMutations();
-  const isMobile = useIsCompactFormFactor();
 
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [progressMessage, setProgressMessage] = useState("");
   const [host, setHost] = useState("");
-  const [port, setPort] = useState("22");
+  const [port, setPort] = useState("");
   const [user, setUser] = useState("");
+  // Bumped on cancel so a connect that is already in flight stops reporting
+  // into a modal the user has walked away from.
+  const attemptRef = useRef(0);
 
-  const header = useMemo<SheetHeader>(() => ({ title: "SSH Connection" }), []);
+  const header = useMemo<SheetHeader>(() => ({ title: t("pairing.ssh.title") }), [t]);
   const icon = useMemo(() => <Terminal size={16} />, []);
 
   const clearInput = useCallback(() => {
     setHost("");
-    setPort("22");
+    setPort("");
     setUser("");
     setErrorMessage("");
     setProgressMessage("");
   }, []);
 
+  const abandonAttempt = useCallback(() => {
+    attemptRef.current += 1;
+    setIsSaving(false);
+    setProgressMessage("");
+  }, []);
+
   const handleClose = useCallback(() => {
-    if (isSaving) return;
+    abandonAttempt();
     clearInput();
     onClose();
-  }, [isSaving, clearInput, onClose]);
+  }, [abandonAttempt, clearInput, onClose]);
 
   const handleCancel = useCallback(() => {
-    if (isSaving) return;
+    abandonAttempt();
     clearInput();
     (onCancel ?? onClose)();
-  }, [isSaving, onCancel, onClose, clearInput]);
+  }, [abandonAttempt, clearInput, onCancel, onClose]);
 
   const handleSave = useCallback(async () => {
     if (isSaving) return;
     const trimmedHost = host.trim();
     const trimmedUser = user.trim();
+    const trimmedPort = port.trim();
     if (!trimmedHost) {
-      setErrorMessage("Host is required.");
+      setErrorMessage(t("pairing.ssh.errors.hostRequired"));
       return;
     }
+    // Left blank on purpose means "whatever ~/.ssh/config says", so only a
+    // non-empty value is validated.
+    let parsedPort: number | undefined;
+    if (trimmedPort) {
+      parsedPort = Number(trimmedPort);
+      if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+        setErrorMessage(t("pairing.ssh.errors.invalidPort"));
+        return;
+      }
+    }
 
+    const attempt = attemptRef.current;
+    const isCurrent = () => attemptRef.current === attempt;
+
+    setIsSaving(true);
+    setErrorMessage("");
+    setProgressMessage("");
     try {
-      setIsSaving(true);
-      setErrorMessage("");
-      setProgressMessage("");
       const { serverId, hostname } = await probeAndUpsertSshConnection({
         host: trimmedHost,
-        port: port.trim() ? Number(port) : undefined,
+        ...(parsedPort !== undefined ? { port: parsedPort } : {}),
         ...(trimmedUser ? { user: trimmedUser } : {}),
-        onProgress: (msg) => setProgressMessage(msg),
+        onProgress: (message) => {
+          if (isCurrent()) setProgressMessage(message);
+        },
       });
+      if (!isCurrent()) return;
       onSaved?.({ serverId, hostname });
       handleClose();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setErrorMessage(message);
-      if (!isMobile) {
-        Alert.alert("SSH connection failed", message);
-      }
+      if (!isCurrent()) return;
+      setErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
-      setIsSaving(false);
+      if (isCurrent()) setIsSaving(false);
     }
-  }, [host, user, port, isSaving, isMobile, onSaved, handleClose, probeAndUpsertSshConnection]);
+  }, [host, user, port, isSaving, onSaved, handleClose, probeAndUpsertSshConnection, t]);
+
+  // Enter connects from any field rather than advancing focus: every field
+  // except the host is optional, so there is usually nothing left to fill in.
+  // `handleSave` is async, so it has to be voided rather than handed straight
+  // to a sync handler.
+  const handleSubmitEditing = useCallback(() => {
+    void handleSave();
+  }, [handleSave]);
 
   return (
     <AdaptiveModalSheet
@@ -139,57 +173,61 @@ export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshH
       onClose={handleClose}
       testID="add-ssh-host-modal"
     >
-      <Text style={styles.helper}>
-        Connect to a remote Paseo daemon over SSH. Paseo will install and launch the daemon on the
-        remote host if needed.
-      </Text>
+      <Text style={styles.helper}>{t("pairing.ssh.helper")}</Text>
 
       <View style={styles.row}>
         <View style={[styles.field, styles.hostField]}>
-          <Text style={styles.label}>Host</Text>
+          <Text style={styles.label}>{t("pairing.ssh.fields.host")}</Text>
           <AdaptiveTextInput
             testID="ssh-host-input"
-            accessibilityLabel="Host"
+            accessibilityLabel={t("pairing.ssh.fields.host")}
             value={host}
             onChangeText={setHost}
-            placeholder="server.example.com"
+            placeholder={t("pairing.ssh.placeholders.host")}
             style={styles.input}
             autoCapitalize="none"
             autoCorrect={false}
             keyboardType="url"
             editable={!isSaving}
-            returnKeyType="next"
+            returnKeyType="done"
+            onSubmitEditing={handleSubmitEditing}
           />
         </View>
         <View style={[styles.field, styles.portField]}>
-          <Text style={styles.label}>Port</Text>
+          <Text style={styles.label}>
+            {t("pairing.ssh.fields.port")} ({t("pairing.ssh.fields.optional")})
+          </Text>
           <AdaptiveTextInput
             testID="ssh-port-input"
-            accessibilityLabel="Port"
+            accessibilityLabel={t("pairing.ssh.fields.port")}
             value={port}
             onChangeText={setPort}
-            placeholder="22"
+            placeholder={t("pairing.ssh.placeholders.port")}
             style={styles.input}
             keyboardType="number-pad"
             editable={!isSaving}
-            returnKeyType="next"
+            returnKeyType="done"
+            onSubmitEditing={handleSubmitEditing}
           />
         </View>
       </View>
 
       <View style={styles.field}>
-        <Text style={styles.label}>User (optional)</Text>
+        <Text style={styles.label}>
+          {t("pairing.ssh.fields.user")} ({t("pairing.ssh.fields.optional")})
+        </Text>
         <AdaptiveTextInput
           testID="ssh-user-input"
-          accessibilityLabel="User"
+          accessibilityLabel={t("pairing.ssh.fields.user")}
           value={user}
           onChangeText={setUser}
-          placeholder="username"
+          placeholder={t("pairing.ssh.placeholders.user")}
           style={styles.input}
           autoCapitalize="none"
           autoCorrect={false}
           editable={!isSaving}
-          returnKeyType="next"
+          returnKeyType="done"
+          onSubmitEditing={handleSubmitEditing}
         />
       </View>
 
@@ -197,8 +235,10 @@ export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshH
       {isSaving && progressMessage ? <Text style={styles.progress}>{progressMessage}</Text> : null}
 
       <View style={styles.buttonRow}>
-        <Button variant="ghost" onPress={handleCancel} disabled={isSaving}>
-          {t("common.actions.cancel")}
+        {/* Deliberately enabled while connecting: an ensure that installs Paseo
+            can run for minutes, and the user needs a way out. */}
+        <Button variant="ghost" onPress={handleCancel}>
+          {t("pairing.ssh.actions.cancel")}
         </Button>
         <Button
           variant="default"
@@ -207,7 +247,7 @@ export function AddSshHostModal({ visible, onClose, onCancel, onSaved }: AddSshH
           leftIcon={icon}
           testID="add-ssh-host-connect"
         >
-          {isSaving ? "Connecting…" : "Connect"}
+          {isSaving ? t("pairing.ssh.actions.connecting") : t("pairing.ssh.actions.connect")}
         </Button>
       </View>
     </AdaptiveModalSheet>

--- a/packages/app/src/components/ssh-password-prompt-host.test.tsx
+++ b/packages/app/src/components/ssh-password-prompt-host.test.tsx
@@ -1,0 +1,232 @@
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { theme, desktopState, inputState } = vi.hoisted(() => ({
+  theme: {
+    spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+    fontSize: { sm: 13, base: 15 },
+    fontWeight: { medium: "500" },
+    borderRadius: { lg: 8 },
+    colors: { surface2: "#222", foreground: "#fff", foregroundMuted: "#aaa" },
+  },
+  inputState: { onChangeText: null as ((v: string) => void) | null },
+  desktopState: {
+    handlers: [] as ((payload: unknown) => void)[],
+    submitted: [] as { requestId: string; secret: string | null }[],
+    unsubscribed: 0,
+  },
+}));
+
+vi.mock("react-native-unistyles", () => ({
+  StyleSheet: {
+    create: (factory: unknown) => (typeof factory === "function" ? factory(theme) : factory),
+  },
+  useUnistyles: () => ({ theme }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/components/ui/button", async () => {
+  const ReactModule = await import("react");
+  return {
+    Button: ({
+      children,
+      onPress,
+      testID,
+    }: {
+      children: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+    }) =>
+      ReactModule.createElement(
+        "button",
+        { type: "button", "data-testid": testID, onClick: onPress },
+        children,
+      ),
+  };
+});
+
+vi.mock("./adaptive-modal-sheet", async () => {
+  const ReactModule = await import("react");
+  return {
+    AdaptiveModalSheet: ({
+      visible,
+      header,
+      children,
+      testID,
+    }: {
+      visible: boolean;
+      header: { title: string };
+      children: React.ReactNode;
+      testID?: string;
+    }) =>
+      visible
+        ? ReactModule.createElement(
+            "div",
+            { "data-testid": testID, "data-title": header.title },
+            children,
+          )
+        : null,
+    AdaptiveTextInput: (props: Record<string, unknown>) => {
+      const p = props as { testID?: string; onChangeText?: (v: string) => void; value?: string };
+      inputState.onChangeText = p.onChangeText ?? null;
+      return ReactModule.createElement("input", {
+        "data-testid": p.testID,
+        readOnly: true,
+        value: p.value ?? "",
+      });
+    },
+  };
+});
+
+vi.mock("@/desktop/host", () => ({
+  getDesktopHost: () => ({
+    events: {
+      on: (_event: string, handler: (payload: unknown) => void) => {
+        desktopState.handlers.push(handler);
+        return Promise.resolve(() => {
+          desktopState.unsubscribed += 1;
+        });
+      },
+    },
+    ssh: {
+      submitPassword: (payload: { requestId: string; secret: string | null }) => {
+        desktopState.submitted.push(payload);
+        return Promise.resolve();
+      },
+    },
+  }),
+}));
+
+import { SshPasswordPromptHost } from "./ssh-password-prompt-host";
+
+let dom: JSDOM;
+let container: HTMLElement;
+let root: Root;
+
+function emit(payload: unknown): void {
+  act(() => {
+    for (const handler of desktopState.handlers) handler(payload);
+  });
+}
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+beforeEach(async () => {
+  dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>");
+  // JSX compiles to React.createElement in this setup, so component modules
+  // resolve React from the global — same as the other component tests here.
+  vi.stubGlobal("React", React);
+  vi.stubGlobal("window", dom.window);
+  vi.stubGlobal("document", dom.window.document);
+  vi.stubGlobal("navigator", dom.window.navigator);
+  vi.stubGlobal("HTMLElement", dom.window.HTMLElement);
+  vi.stubGlobal("HTMLInputElement", dom.window.HTMLInputElement);
+  vi.stubGlobal("Event", dom.window.Event);
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  desktopState.handlers.length = 0;
+  desktopState.submitted.length = 0;
+  desktopState.unsubscribed = 0;
+  inputState.onChangeText = null;
+  container = dom.window.document.getElementById("root") as HTMLElement;
+  root = createRoot(container);
+  // Mount with no add-host flow in sight — this component lives at the app
+  // root precisely so a prompt can arrive at any time.
+  await act(async () => {
+    root.render(React.createElement(SshPasswordPromptHost));
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+});
+
+describe("SshPasswordPromptHost", () => {
+  it("renders nothing until SSH actually asks for something", () => {
+    expect(query("ssh-password-prompt")).toBeNull();
+  });
+
+  it("shows a prompt that arrives outside any add-host flow", () => {
+    emit({
+      requestId: "r1",
+      host: "server.example.com",
+      prompt: "alice@server.example.com's password:",
+      kind: "password",
+    });
+
+    const modal = query("ssh-password-prompt");
+    expect(modal).not.toBeNull();
+    // SSH's own prompt is shown verbatim: it names the host or the key file.
+    expect(modal?.textContent).toContain("alice@server.example.com's password:");
+    expect(modal?.getAttribute("data-title")).toBe("pairing.ssh.prompt.password");
+  });
+
+  it("titles a key passphrase differently from an account password", () => {
+    emit({
+      requestId: "r1",
+      host: "h",
+      prompt: "Enter passphrase for key '/home/a/.ssh/id_ed25519':",
+      kind: "passphrase",
+    });
+    expect(query("ssh-password-prompt")?.getAttribute("data-title")).toBe(
+      "pairing.ssh.prompt.passphrase",
+    );
+  });
+
+  it("returns the typed secret to the waiting ssh process", () => {
+    emit({ requestId: "r1", host: "h", prompt: "p", kind: "password" });
+    act(() => {
+      inputState.onChangeText?.("hunter2");
+    });
+    act(() => {
+      (query("ssh-password-submit") as HTMLElement).click();
+    });
+
+    expect(desktopState.submitted).toEqual([{ requestId: "r1", secret: "hunter2" }]);
+    expect(query("ssh-password-prompt")).toBeNull();
+  });
+
+  it("reports a declined prompt as a null secret", () => {
+    emit({ requestId: "r1", host: "h", prompt: "p", kind: "password" });
+    act(() => {
+      (query("ssh-password-cancel") as HTMLElement).click();
+    });
+
+    // Null is what aborts the attempt; an empty string would be tried as a
+    // password and SSH would simply ask again.
+    expect(desktopState.submitted).toEqual([{ requestId: "r1", secret: null }]);
+    expect(query("ssh-password-prompt")).toBeNull();
+  });
+
+  it("ignores malformed events instead of opening an empty prompt", () => {
+    emit({ nope: true });
+    emit(null);
+    expect(query("ssh-password-prompt")).toBeNull();
+  });
+
+  it("does not drop a second prompt that arrives while the first is open", () => {
+    // Two hosts reconnecting at once is normal at startup: ensureConnectedAll
+    // fans out over every controller.
+    emit({ requestId: "r1", host: "one", prompt: "one's password:", kind: "password" });
+    emit({ requestId: "r2", host: "two", prompt: "two's password:", kind: "password" });
+
+    act(() => {
+      (query("ssh-password-cancel") as HTMLElement).click();
+    });
+    // Answering the first must not strand the second: ssh is blocked on it and
+    // would sit there until the channel's timeout.
+    expect(query("ssh-password-prompt")).not.toBeNull();
+    expect(query("ssh-password-prompt")?.textContent).toContain("two's password:");
+
+    act(() => {
+      (query("ssh-password-cancel") as HTMLElement).click();
+    });
+    expect(desktopState.submitted.map((s) => s.requestId)).toEqual(["r1", "r2"]);
+  });
+});

--- a/packages/app/src/components/ssh-password-prompt-host.tsx
+++ b/packages/app/src/components/ssh-password-prompt-host.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { KeyRound } from "lucide-react-native";
+import { AdaptiveModalSheet, AdaptiveTextInput, type SheetHeader } from "./adaptive-modal-sheet";
+import { Button } from "@/components/ui/button";
+import { getDesktopHost, type SshPasswordRequestEvent } from "@/desktop/host";
+
+const styles = StyleSheet.create((theme) => ({
+  prompt: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    marginBottom: theme.spacing[3],
+  },
+  label: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    marginBottom: 4,
+  },
+  input: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[2],
+    fontSize: theme.fontSize.base,
+    color: theme.colors.foreground,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+    marginTop: theme.spacing[4],
+  },
+}));
+
+/**
+ * Append unless already queued. The main process sends one event per prompt,
+ * but a duplicate delivery must not make the user answer the same one twice.
+ */
+function enqueueRequest(
+  pending: SshPasswordRequestEvent[],
+  incoming: SshPasswordRequestEvent,
+): SshPasswordRequestEvent[] {
+  const alreadyQueued = pending.some((entry) => entry.requestId === incoming.requestId);
+  return alreadyQueued ? pending : [...pending, incoming];
+}
+
+function isPasswordRequest(payload: unknown): payload is SshPasswordRequestEvent {
+  if (!payload || typeof payload !== "object") return false;
+  const event = payload as Partial<SshPasswordRequestEvent>;
+  return typeof event.requestId === "string" && typeof event.prompt === "string";
+}
+
+/**
+ * Renders SSH's password and key-passphrase prompts in Paseo's own UI.
+ *
+ * SSH will only take a secret from a program's stdout, so the desktop main
+ * process runs a relay askpass that forwards the prompt here and waits for the
+ * answer. That replaces shelling out to `zenity`/`kdialog`/`osascript`, which
+ * meant an unstyled, unlocalized dialog we could not control.
+ *
+ * Mounted globally rather than inside the Add SSH Host modal: SSH can ask for
+ * a secret on any later reconnect too, when no modal is open.
+ */
+export function SshPasswordPromptHost() {
+  const { t } = useTranslation();
+  // A queue, not a single slot: several hosts can reconnect at once (startup
+  // fans out over every host), and each waiting ssh process is blocked until
+  // its own prompt is answered. Dropping one would strand it until the
+  // channel's timeout.
+  const [queue, setQueue] = useState<SshPasswordRequestEvent[]>([]);
+  const [secret, setSecret] = useState("");
+  const request = queue[0] ?? null;
+
+  useEffect(() => {
+    const events = getDesktopHost()?.events;
+    if (!events?.on) return;
+    let unsubscribe: (() => void) | null = null;
+    let disposed = false;
+
+    void Promise.resolve(
+      events.on("ssh-password-request", (payload) => {
+        if (!isPasswordRequest(payload)) return;
+        setQueue((pending) => enqueueRequest(pending, payload));
+      }),
+    ).then((off) => {
+      if (disposed) off();
+      else unsubscribe = off;
+      return undefined;
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, []);
+
+  const answer = useCallback(
+    (value: string | null) => {
+      if (!request) return;
+      setQueue((pending) => pending.filter((entry) => entry.requestId !== request.requestId));
+      setSecret("");
+      // Answering is what unblocks ssh; declining aborts that attempt in the
+      // main process, so there is nothing further to clean up here.
+      void getDesktopHost()
+        ?.ssh?.submitPassword({ requestId: request.requestId, secret: value })
+        .catch(() => undefined);
+    },
+    [request],
+  );
+
+  const handleSubmit = useCallback(() => answer(secret), [answer, secret]);
+  const handleCancel = useCallback(() => answer(null), [answer]);
+
+  const kind = request?.kind ?? "password";
+  const header = useMemo<SheetHeader>(
+    () => ({
+      title:
+        kind === "passphrase"
+          ? t("pairing.ssh.prompt.passphrase")
+          : t("pairing.ssh.prompt.password"),
+    }),
+    [kind, t],
+  );
+  const icon = useMemo(() => <KeyRound size={16} />, []);
+
+  if (!request) return null;
+
+  return (
+    <AdaptiveModalSheet header={header} visible onClose={handleCancel} testID="ssh-password-prompt">
+      {/* SSH's own prompt: it carries the key path or user@host, and the user
+          may have several of either in play. */}
+      <Text style={styles.prompt}>{request.prompt}</Text>
+
+      <Text style={styles.label}>{t("pairing.ssh.prompt.secret")}</Text>
+      <AdaptiveTextInput
+        testID="ssh-password-input"
+        accessibilityLabel={t("pairing.ssh.prompt.secret")}
+        value={secret}
+        onChangeText={setSecret}
+        style={styles.input}
+        secureTextEntry
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoFocus
+        onSubmitEditing={handleSubmit}
+        returnKeyType="go"
+      />
+
+      <View style={styles.buttonRow}>
+        <Button variant="ghost" onPress={handleCancel} testID="ssh-password-cancel">
+          {t("pairing.ssh.prompt.cancel")}
+        </Button>
+        <Button
+          variant="default"
+          onPress={handleSubmit}
+          leftIcon={icon}
+          testID="ssh-password-submit"
+        >
+          {t("pairing.ssh.prompt.submit")}
+        </Button>
+      </View>
+    </AdaptiveModalSheet>
+  );
+}

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
 import { getElectronHost } from "@/desktop/electron/host";
 import type { BrowserKeyboardPolicy } from "@/keyboard/browser-shortcuts";
+import type { NormalizedSshHostConnection } from "@getpaseo/protocol/host-connection-schema";
 import type { SessionInboundMessage, SessionOutboundMessage } from "@getpaseo/protocol/messages";
 
 type BrowserAutomationExecuteRequest = Extract<
@@ -169,6 +170,18 @@ export interface DesktopInvokeBridge {
   invoke?: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
 }
 
+export type SshBridgeConfig = Omit<NormalizedSshHostConnection, "id" | "type">;
+
+export interface DesktopSshBridge {
+  openTunnel: (config: SshBridgeConfig) => Promise<{ tunnelId: string; localPort: number }>;
+  closeTunnel: (tunnelId: string) => Promise<void>;
+  ensureRemoteDaemon: (config: SshBridgeConfig) => Promise<{
+    installed: boolean;
+    launched: boolean;
+    ready: boolean;
+  }>;
+}
+
 export interface DesktopHostBridge {
   platform?: string;
   invoke?: DesktopInvokeBridge["invoke"];
@@ -183,6 +196,7 @@ export interface DesktopHostBridge {
   webUtils?: DesktopWebUtilsBridge;
   menu?: DesktopMenuBridge;
   browser?: DesktopBrowserBridge;
+  ssh?: DesktopSshBridge;
 }
 
 declare global {

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -170,11 +170,27 @@ export interface DesktopInvokeBridge {
   invoke?: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
 }
 
-export type SshBridgeConfig = Omit<NormalizedSshHostConnection, "id" | "type">;
+export type SshBridgeConfig = Omit<NormalizedSshHostConnection, "id" | "type"> & {
+  /** Correlates `ssh-progress` events with this specific open request. */
+  requestId?: string;
+};
+
+/** Which secret SSH is asking for, classified by the CLI askpass channel. */
+export type SshPromptKind = "passphrase" | "password";
+
+export interface SshPasswordRequestEvent {
+  requestId: string;
+  host: string;
+  /** SSH's own prompt — carries the key path or `user@host`. */
+  prompt: string;
+  kind: SshPromptKind;
+}
 
 export interface DesktopSshBridge {
   openTunnel: (config: SshBridgeConfig) => Promise<{ tunnelId: string; localPort: number }>;
   closeTunnel: (tunnelId: string) => Promise<void>;
+  /** Answer a pending prompt. A null secret means the user declined. */
+  submitPassword: (payload: { requestId: string; secret: string | null }) => Promise<void>;
 }
 
 export interface DesktopHostBridge {

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -175,11 +175,6 @@ export type SshBridgeConfig = Omit<NormalizedSshHostConnection, "id" | "type">;
 export interface DesktopSshBridge {
   openTunnel: (config: SshBridgeConfig) => Promise<{ tunnelId: string; localPort: number }>;
   closeTunnel: (tunnelId: string) => Promise<void>;
-  ensureRemoteDaemon: (config: SshBridgeConfig) => Promise<{
-    installed: boolean;
-    launched: boolean;
-    ready: boolean;
-  }>;
 }
 
 export interface DesktopHostBridge {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1324,6 +1324,44 @@ export const ar: TranslationResources = {
         title: "الصق رابط الاقتران",
         description: "اتصال التتابع المشفر.",
       },
+      ssh: {
+        title: "SSH",
+        description: "الاتصال بمضيف بعيد عبر نفق SSH.",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "عبارة مرور مفتاح SSH",
+        password: "كلمة مرور SSH",
+        submit: "فتح",
+        cancel: "إلغاء",
+        secret: "كلمة المرور",
+      },
+      title: "اتصال SSH",
+      helper:
+        "اتصل بخادم Paseo بعيد عبر SSH. سيقوم Paseo بتثبيت الخدمة وتشغيلها على المضيف البعيد إذا لم تكن قيد التشغيل.",
+      fields: {
+        host: "المضيف",
+        port: "المنفذ",
+        user: "المستخدم",
+        optional: "اختياري",
+      },
+      placeholders: {
+        host: "server.example.com",
+        port: "22",
+        user: "اسم المستخدم",
+      },
+      actions: {
+        cancel: "إلغاء",
+        connect: "اتصال",
+        connecting: "جارٍ الاتصال...",
+      },
+      errors: {
+        hostRequired: "المضيف مطلوب",
+        invalidPort: "يجب أن يكون المنفذ بين 1 و65535",
+        cancelled: "تم إلغاء الاتصال.",
+        desktopOnly: "تتطلب اتصالات SSH تطبيق Paseo لسطح المكتب.",
+      },
     },
     direct: {
       title: "اتصال مباشر",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1335,6 +1335,44 @@ export const en = {
         title: "Paste pairing link",
         description: "Encrypted relay connection.",
       },
+      ssh: {
+        title: "SSH",
+        description: "Connect to a remote host through an SSH tunnel.",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "SSH key passphrase",
+        password: "SSH password",
+        submit: "Unlock",
+        cancel: "Cancel",
+        secret: "Password",
+      },
+      title: "SSH connection",
+      helper:
+        "Connect to a remote Paseo daemon over SSH. Paseo installs and launches the daemon on the remote host if it isn't running.",
+      fields: {
+        host: "Host",
+        port: "Port",
+        user: "User",
+        optional: "Optional",
+      },
+      placeholders: {
+        host: "server.example.com",
+        port: "22",
+        user: "username",
+      },
+      actions: {
+        cancel: "Cancel",
+        connect: "Connect",
+        connecting: "Connecting...",
+      },
+      errors: {
+        hostRequired: "Host is required",
+        invalidPort: "Port must be between 1 and 65535",
+        cancelled: "Connection cancelled.",
+        desktopOnly: "SSH connections require the Paseo desktop app.",
+      },
     },
     direct: {
       title: "Direct connection",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1365,6 +1365,44 @@ export const es: TranslationResources = {
         title: "Pegar enlace de emparejamiento",
         description: "Conexión de retransmisión cifrada.",
       },
+      ssh: {
+        title: "SSH",
+        description: "Conéctate a un host remoto a través de un túnel SSH.",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "Frase de contraseña de la clave SSH",
+        password: "Contraseña SSH",
+        submit: "Desbloquear",
+        cancel: "Cancelar",
+        secret: "Contraseña",
+      },
+      title: "Conexión SSH",
+      helper:
+        "Conéctate a un daemon de Paseo remoto por SSH. Paseo instalará e iniciará el daemon en el host remoto si no está en ejecución.",
+      fields: {
+        host: "Host",
+        port: "Puerto",
+        user: "Usuario",
+        optional: "Opcional",
+      },
+      placeholders: {
+        host: "servidor.ejemplo.com",
+        port: "22",
+        user: "usuario",
+      },
+      actions: {
+        cancel: "Cancelar",
+        connect: "Conectar",
+        connecting: "Conectando...",
+      },
+      errors: {
+        hostRequired: "El host es obligatorio",
+        invalidPort: "El puerto debe estar entre 1 y 65535",
+        cancelled: "Conexión cancelada.",
+        desktopOnly: "Las conexiones SSH requieren la aplicación de escritorio de Paseo.",
+      },
     },
     direct: {
       title: "Conexión directa",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1368,6 +1368,44 @@ export const fr: TranslationResources = {
         title: "Coller le lien d'association",
         description: "Connexion relais cryptée.",
       },
+      ssh: {
+        title: "SSH",
+        description: "Se connecter à un hôte distant via un tunnel SSH.",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "Phrase secrète de la clé SSH",
+        password: "Mot de passe SSH",
+        submit: "Déverrouiller",
+        cancel: "Annuler",
+        secret: "Mot de passe",
+      },
+      title: "Connexion SSH",
+      helper:
+        "Connectez-vous à un démon Paseo distant via SSH. Paseo installera et lancera le démon sur l'hôte distant s'il n'est pas démarré.",
+      fields: {
+        host: "Hôte",
+        port: "Port",
+        user: "Utilisateur",
+        optional: "Facultatif",
+      },
+      placeholders: {
+        host: "serveur.exemple.com",
+        port: "22",
+        user: "utilisateur",
+      },
+      actions: {
+        cancel: "Annuler",
+        connect: "Connecter",
+        connecting: "Connexion...",
+      },
+      errors: {
+        hostRequired: "L'hôte est requis",
+        invalidPort: "Le port doit être compris entre 1 et 65535",
+        cancelled: "Connexion annulée.",
+        desktopOnly: "Les connexions SSH nécessitent l'application de bureau Paseo.",
+      },
     },
     direct: {
       title: "Connexion directe",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1338,6 +1338,44 @@ export const ja: TranslationResources = {
         title: "ペアリングリンクを貼り付け",
         description: "暗号化されたリレー接続。",
       },
+      ssh: {
+        title: "SSH",
+        description: "SSH トンネル経由でリモートホストに接続します。",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "SSH 鍵のパスフレーズ",
+        password: "SSH パスワード",
+        submit: "ロック解除",
+        cancel: "キャンセル",
+        secret: "パスワード",
+      },
+      title: "SSH 接続",
+      helper:
+        "SSH 経由でリモートの Paseo デーモンに接続します。デーモンが起動していない場合は、Paseo がリモートホストにインストールして起動します。",
+      fields: {
+        host: "ホスト",
+        port: "ポート",
+        user: "ユーザー",
+        optional: "任意",
+      },
+      placeholders: {
+        host: "server.example.com",
+        port: "22",
+        user: "ユーザー名",
+      },
+      actions: {
+        cancel: "キャンセル",
+        connect: "接続",
+        connecting: "接続中...",
+      },
+      errors: {
+        hostRequired: "ホストは必須です",
+        invalidPort: "ポートは 1 から 65535 の間で指定してください",
+        cancelled: "接続をキャンセルしました。",
+        desktopOnly: "SSH 接続には Paseo デスクトップアプリが必要です。",
+      },
     },
     direct: {
       title: "直接接続",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1351,6 +1351,44 @@ export const ptBR: TranslationResources = {
         title: "Colar link de pareamento",
         description: "Conexão relay criptografada.",
       },
+      ssh: {
+        title: "SSH",
+        description: "Conecte-se a um host remoto por um túnel SSH.",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "Senha da chave SSH",
+        password: "Senha SSH",
+        submit: "Desbloquear",
+        cancel: "Cancelar",
+        secret: "Senha",
+      },
+      title: "Conexão SSH",
+      helper:
+        "Conecte-se a um daemon do Paseo remoto via SSH. O Paseo instala e inicia o daemon no host remoto se ele não estiver em execução.",
+      fields: {
+        host: "Host",
+        port: "Porta",
+        user: "Usuário",
+        optional: "Opcional",
+      },
+      placeholders: {
+        host: "servidor.exemplo.com",
+        port: "22",
+        user: "usuário",
+      },
+      actions: {
+        cancel: "Cancelar",
+        connect: "Conectar",
+        connecting: "Conectando...",
+      },
+      errors: {
+        hostRequired: "O host é obrigatório",
+        invalidPort: "A porta deve estar entre 1 e 65535",
+        cancelled: "Conexão cancelada.",
+        desktopOnly: "Conexões SSH exigem o aplicativo de desktop do Paseo.",
+      },
     },
     direct: {
       title: "Conexão direta",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1356,6 +1356,44 @@ export const ru: TranslationResources = {
         title: "Вставьте ссылку на сопряжение",
         description: "Зашифрованное релейное соединение.",
       },
+      ssh: {
+        title: "SSH",
+        description: "Подключение к удалённому хосту через SSH-туннель.",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "Пароль SSH-ключа",
+        password: "Пароль SSH",
+        submit: "Разблокировать",
+        cancel: "Отмена",
+        secret: "Пароль",
+      },
+      title: "SSH-подключение",
+      helper:
+        "Подключитесь к удалённому демону Paseo по SSH. Paseo установит и запустит демон на удалённом хосте, если он не запущен.",
+      fields: {
+        host: "Хост",
+        port: "Порт",
+        user: "Пользователь",
+        optional: "Необязательно",
+      },
+      placeholders: {
+        host: "server.example.com",
+        port: "22",
+        user: "пользователь",
+      },
+      actions: {
+        cancel: "Отмена",
+        connect: "Подключить",
+        connecting: "Подключение...",
+      },
+      errors: {
+        hostRequired: "Укажите хост",
+        invalidPort: "Порт должен быть от 1 до 65535",
+        cancelled: "Подключение отменено.",
+        desktopOnly: "SSH-подключения доступны только в десктопном приложении Paseo.",
+      },
     },
     direct: {
       title: "Прямое подключение",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1307,6 +1307,44 @@ export const zhCN: TranslationResources = {
         title: "粘贴配对链接",
         description: "加密 relay 连接。",
       },
+      ssh: {
+        title: "SSH",
+        description: "通过 SSH 隧道连接到远程主机。",
+      },
+    },
+    ssh: {
+      prompt: {
+        passphrase: "SSH 密钥口令",
+        password: "SSH 密码",
+        submit: "解锁",
+        cancel: "取消",
+        secret: "密码",
+      },
+      title: "SSH 连接",
+      helper:
+        "通过 SSH 连接到远程 Paseo 守护进程。如果守护进程未运行，Paseo 会在远程主机上安装并启动它。",
+      fields: {
+        host: "主机",
+        port: "端口",
+        user: "用户",
+        optional: "可选",
+      },
+      placeholders: {
+        host: "server.example.com",
+        port: "22",
+        user: "用户名",
+      },
+      actions: {
+        cancel: "取消",
+        connect: "连接",
+        connecting: "连接中...",
+      },
+      errors: {
+        hostRequired: "请填写主机",
+        invalidPort: "端口必须在 1 到 65535 之间",
+        cancelled: "连接已取消。",
+        desktopOnly: "SSH 连接需要 Paseo 桌面应用。",
+      },
     },
     direct: {
       title: "直接连接",

--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -21,6 +21,7 @@ import {
   type HostRuntimeStorage,
 } from "./host-runtime";
 import { ReplicaCache } from "./replica-cache";
+import { registerTransportDisposer } from "@/utils/test-daemon-connection";
 
 class FakeDaemonClient {
   private state: ConnectionState = { status: "idle" };
@@ -1266,6 +1267,177 @@ describe("HostRuntimeController", () => {
     expect(snapshot.lastError).toBeNull();
     expect(createdClients).toHaveLength(2);
     expect(createdClients[0]?.isDisposed()).toBe(true);
+  });
+
+  it("labels an SSH connection without inventing a user or port", async () => {
+    // Both are unset when ~/.ssh/config supplies them. Interpolating them
+    // blindly renders "@host:undefined" in the host picker, and guessing a
+    // username would be worse: ssh resolves the effective user, not us.
+    const host = makeHost({
+      preferredConnectionId: "ssh:remote",
+      connections: [{ id: "ssh:remote", type: "ssh", host: "server.example.com" }],
+    });
+    const controller = new HostRuntimeController({
+      host,
+      deps: {
+        createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
+        connectToDaemon: async ({ host: hostProfile }) => ({
+          client: makeConnectedProbeClient(5) as unknown as DaemonClient,
+          serverId: hostProfile.serverId,
+          hostname: hostProfile.label ?? null,
+        }),
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+
+    await controller.activateConnection({ connectionId: "ssh:remote" });
+
+    const active = controller.getSnapshot().activeConnection;
+    expect(active?.endpoint).toBe("server.example.com");
+    expect(active?.display).toBe("server.example.com");
+    expect(active?.endpoint).not.toContain("undefined");
+    expect(active?.endpoint).not.toContain("@");
+  });
+
+  it("does not open a throwaway SSH tunnel just to time a probe", async () => {
+    // Opening an SSH connection spawns ssh, authenticates, and runs the ensure
+    // script. Doing that on the probe timer would re-prompt password-auth hosts
+    // every cycle and orphan a tunnel each time.
+    useHostRuntimeClock();
+    const host = makeHost({
+      preferredConnectionId: "direct:lan:6767",
+      connections: [
+        { id: "direct:lan:6767", type: "directTcp", endpoint: "lan:6767" },
+        // A second cheap connection, so the cycle has something to probe and a
+        // no-op cycle cannot masquerade as "SSH was skipped".
+        { id: "direct:wan:6767", type: "directTcp", endpoint: "wan:6767" },
+        { id: "ssh:deploy@remote", type: "ssh", host: "remote", user: "deploy" },
+      ],
+    });
+    const probedConnectionIds: string[] = [];
+
+    const controller = new HostRuntimeController({
+      host,
+      deps: {
+        createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
+        connectToDaemon: async ({ host: hostProfile, connection }) => {
+          probedConnectionIds.push(connection.id);
+          return {
+            client: makeConnectedProbeClient(
+              connection.id === "direct:lan:6767" ? 5 : 200,
+            ) as unknown as DaemonClient,
+            serverId: hostProfile.serverId,
+            hostname: hostProfile.label ?? null,
+          };
+        },
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+
+    // Nothing online yet: SSH is eligible, because connecting is the point.
+    await controller.runProbeCycleNow();
+    expect(controller.getSnapshot().connectionStatus).toBe("online");
+    expect(probedConnectionIds).toContain("ssh:deploy@remote");
+
+    // Past the inactive-while-online interval, so only the interval gate is no
+    // longer what is holding SSH back.
+    probedConnectionIds.length = 0;
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    await controller.runProbeCycleNow();
+
+    expect(probedConnectionIds).toContain("direct:wan:6767");
+    expect(probedConnectionIds).not.toContain("ssh:deploy@remote");
+  });
+
+  it("closes the tunnel behind a throwaway probe client", async () => {
+    // A probe that is not adopted as the active client must release its
+    // transport, not just the WebSocket.
+    const host = makeHost({
+      preferredConnectionId: "direct:lan:6767",
+      connections: [
+        { id: "direct:lan:6767", type: "directTcp", endpoint: "lan:6767" },
+        { id: "direct:wan:6767", type: "directTcp", endpoint: "wan:6767" },
+      ],
+    });
+    const released: string[] = [];
+
+    const controller = new HostRuntimeController({
+      host,
+      deps: {
+        createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
+        connectToDaemon: async ({ host: hostProfile, connection }) => {
+          const client = makeConnectedProbeClient(connection.id === "direct:lan:6767" ? 5 : 50);
+          registerTransportDisposer(client as unknown as DaemonClient, async () => {
+            released.push(connection.id);
+          });
+          return {
+            client: client as unknown as DaemonClient,
+            serverId: hostProfile.serverId,
+            hostname: hostProfile.label ?? null,
+          };
+        },
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+
+    await controller.runProbeCycleNow();
+
+    // The slower one was probed and discarded; its transport must be gone.
+    expect(released).toContain("direct:wan:6767");
+  });
+
+  it("leaves the winning connection alone when a superseded switch unwinds", async () => {
+    // A switch that loses the race must abandon only its own work. Unwinding it
+    // takes an await (closing the client it was handed), and the winner can
+    // finish during that window. If the loser then falls through to disposing
+    // the active client, it tears down the connection that superseded it and
+    // the user drops offline for no reason.
+    const host = makeHost();
+    const createdClients: FakeDaemonClient[] = [];
+    const clientIdGate = createDeferred<string>();
+    const closeGate = createDeferred<void>();
+
+    // Handed to the switch that loses; its close() is what parks the unwind.
+    const losingClient = {
+      close: () => closeGate.promise,
+      setReconnectEnabled: () => {},
+    } as unknown as DaemonClient;
+
+    const controller = new HostRuntimeController({
+      host,
+      deps: {
+        createClient: () => {
+          const client = new FakeDaemonClient();
+          createdClients.push(client);
+          return client as unknown as DaemonClient;
+        },
+        connectToDaemon: async () => {
+          throw new Error("connectToDaemon should not be called");
+        },
+        getClientId: () => clientIdGate.promise,
+      },
+    });
+
+    // Both park on the same pending client id; the second one wins the race.
+    const superseded = controller.activateConnection({
+      connectionId: "relay:relay.paseo.sh:443",
+      existingClient: losingClient,
+    });
+    const winning = controller.activateConnection({ connectionId: "direct:lan:6767" });
+
+    clientIdGate.resolve("client_test");
+    await winning;
+
+    const winner = controller.getSnapshot().client;
+    expect(winner).toBeTruthy();
+    expect(controller.getSnapshot().activeConnectionId).toBe("direct:lan:6767");
+
+    // Let the superseded switch finish unwinding.
+    closeGate.resolve();
+    await superseded;
+
+    expect(controller.getSnapshot().activeConnectionId).toBe("direct:lan:6767");
+    expect((winner as unknown as FakeDaemonClient).isDisposed()).toBe(false);
   });
 
   it("coalesces overlapping probe cycles instead of invalidating the in-flight result", async () => {

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -26,7 +26,7 @@ import { resolveAppVersion } from "@/utils/app-version";
 import { ConnectionOfferSchema, type ConnectionOffer } from "@getpaseo/protocol/connection-offer";
 import { shouldUseDesktopDaemon } from "@/desktop/daemon/desktop-daemon";
 import { isWeb } from "@/constants/platform";
-import { connectToDaemon } from "@/utils/test-daemon-connection";
+import { connectToDaemon, closeClientAndTransport } from "@/utils/test-daemon-connection";
 import { getOrCreateClientId } from "@/utils/client-id";
 import {
   selectBestConnection,
@@ -206,10 +206,16 @@ function toActiveConnection(connection: HostConnection): ActiveConnection {
     };
   }
   if (connection.type === "ssh") {
+    // Both user and port are legitimately unset when ~/.ssh/config supplies
+    // them, so neither can be interpolated unconditionally — that renders as
+    // "@host:undefined" in the host picker. Showing just the host is also the
+    // honest thing: the effective user is resolved by ssh, not by us, so we
+    // must not imply a username we do not actually know.
+    const authority = connection.user ? `${connection.user}@${connection.host}` : connection.host;
     return {
       type: "ssh",
-      endpoint: `${connection.user ?? ""}@${connection.host}:${connection.port}`,
-      display: connection.user ? `${connection.user}@${connection.host}` : connection.host,
+      endpoint: connection.port ? `${authority}:${connection.port}` : authority,
+      display: authority,
     };
   }
   return {
@@ -771,6 +777,23 @@ export class HostRuntimeController {
     const hasActiveOnlineConnection = isOnline && activeConnectionId !== null;
 
     const connectionsToProbe = this.host.connections.filter((connection) => {
+      // Probing a non-active SSH connection means spawning ssh, authenticating,
+      // and running the ensure script just to time a round trip — then throwing
+      // the tunnel away. On a password-auth host that re-prompts the user every
+      // cycle. Only probe SSH when it is already the live client (reading its
+      // liveness RTT is free) or when nothing is online and connecting is the
+      // point. The cost is that SSH never carries a latency number while
+      // another transport is up, so the adaptive switcher will not move *onto*
+      // a tunnel on RTT alone — which is the behavior we want anyway. Failover
+      // still works: once the active connection drops, this predicate opens up
+      // again on the next cycle.
+      if (
+        connection.type === "ssh" &&
+        hasActiveOnlineConnection &&
+        connection.id !== activeConnectionId
+      ) {
+        return false;
+      }
       const lastProbed = this.connectionLastProbedAt.get(connection.id);
       if (lastProbed == null) {
         return true;
@@ -954,7 +977,7 @@ export class HostRuntimeController {
                 if (isPlaceholderServerId(this.host.serverId) && this.onReconcileServerId) {
                   this.onReconcileServerId(this.host.serverId, serverId);
                 } else {
-                  await client.close().catch(() => undefined);
+                  await closeClientAndTransport(client);
                   throw new Error(
                     `Connection resolved to ${serverId}, expected ${this.host.serverId}.`,
                   );
@@ -1006,7 +1029,9 @@ export class HostRuntimeController {
             }
           } finally {
             if (connectedClient && shouldCloseClient) {
-              await connectedClient.close().catch(() => undefined);
+              // Throwaway probe clients can own an SSH tunnel; closing the
+              // client alone would orphan the ssh process every cycle.
+              await closeClientAndTransport(connectedClient);
             }
             settleProbe();
           }
@@ -1097,7 +1122,9 @@ export class HostRuntimeController {
 
   private async abortSwitchWithClient(client: DaemonClient | undefined): Promise<void> {
     if (client) {
-      await client.close().catch(() => undefined);
+      // Not a bare close(): a probed SSH client owns a tunnel, and abandoning
+      // the switch has to reap it too.
+      await closeClientAndTransport(client);
     }
   }
 
@@ -1142,13 +1169,7 @@ export class HostRuntimeController {
     if (this.activeClient) {
       const previousClient = this.activeClient;
       this.activeClient = null;
-      const tunnelId = (previousClient as DaemonClient & { __sshTunnelId?: string }).__sshTunnelId;
-      if (tunnelId) {
-        getDesktopHost()
-          ?.ssh?.closeTunnel(tunnelId)
-          .catch(() => undefined);
-      }
-      await previousClient.close().catch(() => undefined);
+      await closeClientAndTransport(previousClient);
     }
   }
 
@@ -1189,6 +1210,7 @@ export class HostRuntimeController {
 
     if (!this.isSwitchStillValid(requestVersion, expectedProbeVersion)) {
       await this.abortSwitchWithClient(existingClient);
+      return;
     }
 
     await this.disposePreviousActiveClient();
@@ -1223,7 +1245,7 @@ export class HostRuntimeController {
     }
 
     if (!this.isSwitchStillValid(requestVersion, expectedProbeVersion)) {
-      await client.close().catch(() => undefined);
+      await closeClientAndTransport(client);
       return;
     }
 

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -1742,6 +1742,7 @@ export class HostRuntimeStore {
     user?: string;
     remotePort?: number;
     remoteHome?: string;
+    installDir?: string;
     label?: string;
     onProgress?: (message: string) => void;
   }): Promise<{ profile: HostProfile; serverId: string; hostname: string | null }> {
@@ -2450,9 +2451,11 @@ export interface HostMutations {
     host: string;
     port?: number;
     user?: string;
+    remotePort?: number;
+    remoteHome?: string;
+    installDir?: string;
     label?: string;
     onProgress?: (message: string) => void;
-    installDir?: string;
   }) => Promise<{ profile: HostProfile; serverId: string; hostname: string | null }>;
   upsertRelayConnection: (input: {
     serverId: string;

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -146,6 +146,7 @@ export interface HostRuntimeControllerDeps {
     host: HostProfile;
     connection: HostConnection;
     timeoutMs?: number;
+    onProgress?: (message: string) => void;
   }) => Promise<{
     client: DaemonClient;
     serverId: string;
@@ -529,11 +530,12 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
         },
       });
     },
-    connectToDaemon: ({ host, connection, timeoutMs }) =>
+    connectToDaemon: ({ host, connection, timeoutMs, onProgress }) =>
       connectToDaemon(connection, {
         ...(host.serverId ? { serverId: host.serverId } : {}),
         ...(timeoutMs !== undefined ? { timeoutMs } : {}),
         capabilities: appCapabilities,
+        ...(onProgress ? { onProgress } : {}),
       }),
     getClientId: () => getOrCreateClientId(),
     mountClientHandlers: ({ client, host }) => {
@@ -1685,6 +1687,7 @@ export class HostRuntimeStore {
     connection: HostConnection;
     label?: string;
     timeoutMs?: number;
+    onProgress?: (message: string) => void;
   }): Promise<{ profile: HostProfile; serverId: string; hostname: string | null }> {
     if (input.connection.type === "relay") {
       throw new Error("Cannot probe a relay connection without a server id.");
@@ -1702,6 +1705,7 @@ export class HostRuntimeStore {
       host: probeHost,
       connection: input.connection,
       ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.onProgress ? { onProgress: input.onProgress } : {}),
     });
     const profile = await this.upsertHostConnection({
       serverId,
@@ -1738,8 +1742,8 @@ export class HostRuntimeStore {
     user?: string;
     remotePort?: number;
     remoteHome?: string;
-    installDir?: string;
     label?: string;
+    onProgress?: (message: string) => void;
   }): Promise<{ profile: HostProfile; serverId: string; hostname: string | null }> {
     const connection = normalizeSshConnection({
       id: input.user ? `ssh:${input.user}@${input.host}` : `ssh:${input.host}`,
@@ -1753,6 +1757,7 @@ export class HostRuntimeStore {
     return this.probeAndUpsertConnection({
       label: input.label ?? (input.user ? `${input.user}@${input.host}` : input.host),
       connection,
+      ...(input.onProgress ? { onProgress: input.onProgress } : {}),
     });
   }
 
@@ -2445,10 +2450,9 @@ export interface HostMutations {
     host: string;
     port?: number;
     user?: string;
-    remotePort?: number;
-    remoteHome?: string;
-    installDir?: string;
     label?: string;
+    onProgress?: (message: string) => void;
+    installDir?: string;
   }) => Promise<{ profile: HostProfile; serverId: string; hostname: string | null }>;
   upsertRelayConnection: (input: {
     serverId: string;

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -14,6 +14,7 @@ import {
   type HostConnection,
   type HostProfile,
 } from "@/types/host-connection";
+import { normalizeSshConnection } from "@getpaseo/protocol/host-connection-schema";
 import {
   buildDaemonWebSocketUrl,
   buildRelayWebSocketUrl,
@@ -65,7 +66,8 @@ export type ActiveConnection =
   | { type: "directTcp"; endpoint: string; display: string }
   | { type: "directSocket"; endpoint: string; display: "socket" }
   | { type: "directPipe"; endpoint: string; display: "pipe" }
-  | { type: "relay"; endpoint: string; display: "relay" };
+  | { type: "relay"; endpoint: string; display: "relay" }
+  | { type: "ssh"; endpoint: string; display: string };
 
 export type HostRuntimeAgentDirectoryStatus =
   | "idle"
@@ -200,6 +202,13 @@ function toActiveConnection(connection: HostConnection): ActiveConnection {
       type: "directTcp",
       endpoint: connection.endpoint,
       display: connection.endpoint,
+    };
+  }
+  if (connection.type === "ssh") {
+    return {
+      type: "ssh",
+      endpoint: `${connection.user ?? ""}@${connection.host}:${connection.port}`,
+      display: connection.user ? `${connection.user}@${connection.host}` : connection.host,
     };
   }
   return {
@@ -503,6 +512,9 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
           }),
           ...(connection.password ? { password: connection.password } : {}),
         });
+      }
+      if (connection.type === "ssh") {
+        throw new Error("SSH connections are established through the probe path, not createClient");
       }
       return new DaemonClient({
         ...base,
@@ -1128,6 +1140,12 @@ export class HostRuntimeController {
     if (this.activeClient) {
       const previousClient = this.activeClient;
       this.activeClient = null;
+      const tunnelId = (previousClient as DaemonClient & { __sshTunnelId?: string }).__sshTunnelId;
+      if (tunnelId) {
+        getDesktopHost()
+          ?.ssh?.closeTunnel(tunnelId)
+          .catch(() => undefined);
+      }
       await previousClient.close().catch(() => undefined);
     }
   }
@@ -1169,7 +1187,6 @@ export class HostRuntimeController {
 
     if (!this.isSwitchStillValid(requestVersion, expectedProbeVersion)) {
       await this.abortSwitchWithClient(existingClient);
-      return;
     }
 
     await this.disposePreviousActiveClient();
@@ -1180,17 +1197,28 @@ export class HostRuntimeController {
     }
 
     const nextGeneration = this.snapshot.clientGeneration + 1;
+    let client: DaemonClient;
     if (existingClient) {
       existingClient.setReconnectEnabled(true);
-    }
-    const client =
-      existingClient ??
-      this.deps.createClient({
+      client = existingClient;
+    } else if (connection.type === "ssh") {
+      // SSH connections need a tunnel opened before the client can connect.
+      // The probe path (connectToDaemon) handles this and passes existingClient;
+      // this branch covers manual activation without a prior probe.
+      const { client: probedClient } = await this.deps.connectToDaemon({
+        host: this.host,
+        connection,
+      });
+      probedClient.setReconnectEnabled(true);
+      client = probedClient;
+    } else {
+      client = this.deps.createClient({
         host: this.host,
         connection,
         clientId,
         runtimeGeneration: nextGeneration,
       });
+    }
 
     if (!this.isSwitchStillValid(requestVersion, expectedProbeVersion)) {
       await client.close().catch(() => undefined);
@@ -1233,7 +1261,7 @@ export class HostRuntimeController {
     });
 
     try {
-      if (!existingClient) {
+      if (!existingClient && connection.type !== "ssh") {
         await client.connect();
       }
     } catch (error) {
@@ -1701,6 +1729,30 @@ export class HostRuntimeStore {
         useTls: input.useTls ?? false,
         ...(password ? { password } : {}),
       },
+    });
+  }
+
+  async probeAndUpsertSshConnection(input: {
+    host: string;
+    port?: number;
+    user?: string;
+    remotePort?: number;
+    remoteHome?: string;
+    installDir?: string;
+    label?: string;
+  }): Promise<{ profile: HostProfile; serverId: string; hostname: string | null }> {
+    const connection = normalizeSshConnection({
+      id: input.user ? `ssh:${input.user}@${input.host}` : `ssh:${input.host}`,
+      host: input.host,
+      ...(input.user ? { user: input.user } : {}),
+      port: input.port,
+      remotePort: input.remotePort,
+      remoteHome: input.remoteHome,
+      installDir: input.installDir,
+    });
+    return this.probeAndUpsertConnection({
+      label: input.label ?? (input.user ? `${input.user}@${input.host}` : input.host),
+      connection,
     });
   }
 
@@ -2358,6 +2410,7 @@ export function useHosts(): HostProfile[] {
 
 export function useHostRegistryStatus(): HostRegistryStatus {
   const store = getHostRuntimeStore();
+
   return useSyncExternalStore(
     (onStoreChange) => store.subscribeHostList(onStoreChange),
     () => store.getHostRegistryStatus(),
@@ -2388,6 +2441,15 @@ export interface HostMutations {
     password?: string;
     label?: string;
   }) => Promise<{ profile: HostProfile; serverId: string; hostname: string | null }>;
+  probeAndUpsertSshConnection: (input: {
+    host: string;
+    port?: number;
+    user?: string;
+    remotePort?: number;
+    remoteHome?: string;
+    installDir?: string;
+    label?: string;
+  }) => Promise<{ profile: HostProfile; serverId: string; hostname: string | null }>;
   upsertRelayConnection: (input: {
     serverId: string;
     relayEndpoint: string;
@@ -2412,6 +2474,7 @@ export function useHostMutations(): HostMutations {
       upsertDirectConnection: (input) => store.upsertDirectConnection(input),
       probeAndUpsertDirectConnection: (input) => store.probeAndUpsertDirectConnection(input),
       upsertRelayConnection: (input) => store.upsertRelayConnection(input),
+      probeAndUpsertSshConnection: (input) => store.probeAndUpsertSshConnection(input),
       upsertConnectionFromOffer: (offer, label) => store.upsertConnectionFromOffer(offer, label),
       upsertConnectionFromOfferUrl: (url, label) => store.upsertConnectionFromOfferUrl(url, label),
       renameHost: (serverId, label) => store.renameHost(serverId, label),

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -68,6 +68,7 @@ import { BackHeader } from "@/components/headers/back-header";
 import { ScreenHeader } from "@/components/headers/screen-header";
 import { AddHostMethodModal } from "@/components/add-host-method-modal";
 import { AddHostModal } from "@/components/add-host-modal";
+import { AddSshHostModal } from "@/components/add-ssh-host-modal";
 import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
 import { EditorSection } from "@/screens/settings/editor-section";
@@ -1133,6 +1134,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const [isAddHostMethodVisible, setIsAddHostMethodVisible] = useState(false);
   const [isDirectHostVisible, setIsDirectHostVisible] = useState(false);
   const [isPasteLinkVisible, setIsPasteLinkVisible] = useState(false);
+  const [isSshHostVisible, setIsSshHostVisible] = useState(false);
   const [isPlaybackTestRunning, setIsPlaybackTestRunning] = useState(false);
   const [playbackTestResult, setPlaybackTestResult] = useState<string | null>(null);
   const lastOpenedAddHostIntentRef = useRef<string | null>(null);
@@ -1227,14 +1229,15 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     setIsAddHostMethodVisible(false);
     setIsDirectHostVisible(false);
     setIsPasteLinkVisible(false);
+    setIsSshHostVisible(false);
   }, []);
 
   const goBackToAddConnectionMethods = useCallback(() => {
     setIsDirectHostVisible(false);
     setIsPasteLinkVisible(false);
+    setIsSshHostVisible(false);
     setIsAddHostMethodVisible(true);
   }, []);
-
   const handleAddHost = useCallback(() => {
     setIsAddHostMethodVisible(true);
   }, []);
@@ -1252,6 +1255,10 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     setIsDirectHostVisible(true);
   }, []);
 
+  const handleSelectSshConnection = useCallback(() => {
+    setIsAddHostMethodVisible(false);
+    setIsSshHostVisible(true);
+  }, []);
   const handleSelectPasteLink = useCallback(() => {
     setIsAddHostMethodVisible(false);
     setIsPasteLinkVisible(true);
@@ -1462,6 +1469,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
         onDirectConnection={handleSelectDirectConnection}
         onPasteLink={handleSelectPasteLink}
         onScanQr={handleScanQr}
+        onSshConnection={handleSelectSshConnection}
       />
       <AddHostModal
         visible={isDirectHostVisible}
@@ -1471,6 +1479,12 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
       />
       <PairLinkModal
         visible={isPasteLinkVisible}
+        onClose={closeAddConnectionFlow}
+        onCancel={goBackToAddConnectionMethods}
+        onSaved={handleHostAdded}
+      />
+      <AddSshHostModal
+        visible={isSshHostVisible}
         onClose={closeAddConnectionFlow}
         onCancel={goBackToAddConnectionMethods}
         onSaved={handleHostAdded}

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -108,6 +108,9 @@ function formatHostConnectionLabel(connection: HostConnection, t: TFunction): st
   if (connection.type === "directSocket" || connection.type === "directPipe") {
     return `${t("settings.host.badges.local")} (${connection.path})`;
   }
+  if (connection.type === "ssh") {
+    return `SSH (${connection.user ? `${connection.user}@${connection.host}` : connection.host})`;
+  }
   return `TCP (${connection.endpoint})`;
 }
 

--- a/packages/app/src/types/host-connection.ts
+++ b/packages/app/src/types/host-connection.ts
@@ -5,9 +5,16 @@ import {
 import {
   DirectTcpHostConnectionSchema,
   type DirectTcpHostConnection,
+  SshHostConnectionSchema,
+  type SshHostConnection,
 } from "@getpaseo/protocol/host-connection-schema";
 
-export { DirectTcpHostConnectionSchema, type DirectTcpHostConnection };
+export {
+  DirectTcpHostConnectionSchema,
+  type DirectTcpHostConnection,
+  SshHostConnectionSchema,
+  type SshHostConnection,
+};
 
 export interface DirectSocketHostConnection {
   id: string;
@@ -28,12 +35,12 @@ export interface RelayHostConnection {
   useTls?: boolean;
   daemonPublicKeyB64: string;
 }
-
 export type HostConnection =
   | DirectTcpHostConnection
   | DirectSocketHostConnection
   | DirectPipeHostConnection
-  | RelayHostConnection;
+  | RelayHostConnection
+  | SshHostConnection;
 
 export type HostLifecycle = Record<string, never>;
 
@@ -98,6 +105,15 @@ export function resolveActiveHostServerId(params: {
   );
 }
 
+function sshConnectionEquals(left: SshHostConnection, right: SshHostConnection): boolean {
+  return (
+    left.host === right.host &&
+    left.port === right.port &&
+    left.user === right.user &&
+    left.remotePort === right.remotePort
+  );
+}
+
 function hostConnectionEquals(left: HostConnection, right: HostConnection): boolean {
   if (left.type !== right.type || left.id !== right.id) {
     return false;
@@ -122,6 +138,9 @@ function hostConnectionEquals(left: HostConnection, right: HostConnection): bool
       left.useTls === right.useTls &&
       left.daemonPublicKeyB64 === right.daemonPublicKeyB64
     );
+  }
+  if (left.type === "ssh" && right.type === "ssh") {
+    return sshConnectionEquals(left, right);
   }
 
   return false;
@@ -285,6 +304,43 @@ function toObjectRecord(value: unknown): Record<string, unknown> | undefined {
   return isPlainRecord(value) ? value : undefined;
 }
 
+function parseSshConnectionRecord(record: Record<string, unknown>): SshHostConnection | null {
+  try {
+    const host = typeof record.host === "string" ? record.host.trim() : "";
+    const user = typeof record.user === "string" ? record.user.trim() : "";
+    if (!host) return null;
+    return SshHostConnectionSchema.parse({
+      id: user ? `ssh:${user}@${host}` : `ssh:${host}`,
+      type: "ssh",
+      host,
+      port: record.port,
+      ...(user ? { user } : {}),
+      remotePort: record.remotePort,
+      remoteHome: record.remoteHome,
+      installDir: record.installDir,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDirectTcpConnection(record: Record<string, unknown>): HostConnection | null {
+  try {
+    const endpoint = normalizeLoopbackToLocalhost(
+      normalizeHostPort(typeof record.endpoint === "string" ? record.endpoint : ""),
+    );
+    return DirectTcpHostConnectionSchema.parse({
+      id: `direct:${endpoint}`,
+      type: "directTcp",
+      endpoint,
+      useTls: record.useTls,
+      ...(typeof record.password === "string" ? { password: record.password } : {}),
+    });
+  } catch {
+    return null;
+  }
+}
+
 function normalizeStoredConnection(connection: unknown): HostConnection | null {
   const record = toObjectRecord(connection);
   if (!record) {
@@ -292,21 +348,9 @@ function normalizeStoredConnection(connection: unknown): HostConnection | null {
   }
   const type = record.type;
   if (type === "directTcp") {
-    try {
-      const endpoint = normalizeLoopbackToLocalhost(
-        normalizeHostPort(typeof record.endpoint === "string" ? record.endpoint : ""),
-      );
-      return DirectTcpHostConnectionSchema.parse({
-        id: `direct:${endpoint}`,
-        type: "directTcp",
-        endpoint,
-        useTls: record.useTls,
-        ...(typeof record.password === "string" ? { password: record.password } : {}),
-      });
-    } catch {
-      return null;
-    }
+    return normalizeDirectTcpConnection(record);
   }
+
   if (type === "directSocket") {
     const path = (typeof record.path === "string" ? record.path : "").trim();
     return path ? { id: `socket:${path}`, type: "directSocket", path } : null;
@@ -335,6 +379,9 @@ function normalizeStoredConnection(connection: unknown): HostConnection | null {
     } catch {
       return null;
     }
+  }
+  if (type === "ssh") {
+    return parseSshConnectionRecord(record);
   }
 
   return null;

--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -230,6 +230,7 @@ interface ProbeOptions {
   serverId?: string;
   timeoutMs?: number;
   capabilities?: DaemonClientConfig["capabilities"];
+  onProgress?: (message: string) => void;
 }
 
 function resolveTimeout(connection: HostConnection, options?: ProbeOptions): number {
@@ -266,30 +267,49 @@ async function connectToDaemonViaSsh(
     remoteHome: sshConfig.remoteHome,
     installDir: sshConfig.installDir,
   };
-  const { tunnelId, localPort } = await sshBridge.openTunnel(bridgeConfig);
-
-  const config = await buildClientConfig(
-    {
-      id: connection.id,
-      type: "directTcp",
-      endpoint: `127.0.0.1:${localPort}`,
-      useTls: false,
-    },
-    options?.serverId,
-    options,
-    deps,
-  );
+  // Subscribe to SSH progress events from the desktop main process.
+  const events = getDesktopHost()?.events;
+  let unsubscribeProgress: (() => void) | null = null;
+  if (events?.on && options?.onProgress) {
+    const unsub = events.on("ssh-progress", (payload) => {
+      if (payload && typeof payload === "object" && "message" in payload) {
+        const msg = (payload as { message: string }).message;
+        if (sshConfig.host === (payload as { host?: string }).host) {
+          options.onProgress!(msg);
+        }
+      }
+    });
+    if (unsub) unsubscribeProgress = typeof unsub === "function" ? unsub : null;
+  }
 
   try {
-    const result = await connectAndProbe(config, resolveTimeout(connection, options), deps);
-    // Attach the tunnelId to the client so it can be closed when the client closes.
-    // The DaemonClient doesn't have a hook for this, so we store it on the client
-    // and the host runtime closes the tunnel when disposing the client.
-    (result.client as DaemonClient & { __sshTunnelId?: string }).__sshTunnelId = tunnelId;
-    return result;
-  } catch (error) {
-    await sshBridge.closeTunnel(tunnelId).catch(() => undefined);
-    throw error;
+    const { tunnelId, localPort } = await sshBridge.openTunnel(bridgeConfig);
+
+    const config = await buildClientConfig(
+      {
+        id: connection.id,
+        type: "directTcp",
+        endpoint: `127.0.0.1:${localPort}`,
+        useTls: false,
+      },
+      options?.serverId,
+      options,
+      deps,
+    );
+
+    try {
+      const result = await connectAndProbe(config, resolveTimeout(connection, options), deps);
+      // Attach the tunnelId to the client so it can be closed when the client closes.
+      // The DaemonClient doesn't have a hook for this, so we store it on the client
+      // and the host runtime closes the tunnel when disposing the client.
+      (result.client as DaemonClient & { __sshTunnelId?: string }).__sshTunnelId = tunnelId;
+      return result;
+    } catch (error) {
+      await sshBridge.closeTunnel(tunnelId).catch(() => undefined);
+      throw error;
+    }
+  } finally {
+    unsubscribeProgress?.();
   }
 }
 

--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -266,9 +266,6 @@ async function connectToDaemonViaSsh(
     remoteHome: sshConfig.remoteHome,
     installDir: sshConfig.installDir,
   };
-
-  await sshBridge.ensureRemoteDaemon(bridgeConfig);
-
   const { tunnelId, localPort } = await sshBridge.openTunnel(bridgeConfig);
 
   const config = await buildClientConfig(

--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -1,6 +1,7 @@
 import { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { DaemonClientConfig } from "@getpaseo/client/internal/daemon-client";
 import type { HostConnection } from "@/types/host-connection";
+import { normalizeSshConnection } from "@getpaseo/protocol/host-connection-schema";
 import { getOrCreateClientId } from "./client-id";
 import { resolveAppVersion } from "./app-version";
 import {
@@ -12,6 +13,7 @@ import {
   buildLocalDaemonTransportUrl,
   createDesktopLocalDaemonTransportFactory,
 } from "@/desktop/daemon/desktop-daemon-transport";
+import { getDesktopHost } from "@/desktop/host";
 
 export interface DaemonProbeClient {
   readonly lastError: string | null;
@@ -136,6 +138,10 @@ export async function buildClientConfig(
     };
   }
 
+  if (connection.type === "ssh") {
+    throw new Error("SSH connections must be probed via connectToDaemonViaSsh");
+  }
+
   if (!serverId) {
     throw new Error("serverId is required to probe a relay connection");
   }
@@ -228,7 +234,66 @@ interface ProbeOptions {
 
 function resolveTimeout(connection: HostConnection, options?: ProbeOptions): number {
   if (options?.timeoutMs) return options.timeoutMs;
+  if (connection.type === "ssh") return 30_000;
   return connection.type === "relay" ? 10_000 : 6_000;
+}
+async function connectToDaemonViaSsh(
+  connection: Extract<HostConnection, { type: "ssh" }>,
+  options: ProbeOptions | undefined,
+  deps: DaemonConnectionDependencies<DaemonProbeClient>,
+): Promise<{ client: DaemonProbeClient; serverId: string; hostname: string | null }> {
+  const sshBridge = getDesktopHost()?.ssh;
+  if (!sshBridge) {
+    throw new DaemonConnectionTestError("SSH connections require the Paseo desktop app.", {
+      reason: "SSH not available",
+      lastError: null,
+    });
+  }
+  const sshConfig = normalizeSshConnection({
+    id: connection.id,
+    host: connection.host,
+    user: connection.user,
+    port: connection.port,
+    remotePort: connection.remotePort,
+    remoteHome: connection.remoteHome,
+    installDir: connection.installDir,
+  });
+  const bridgeConfig = {
+    host: sshConfig.host,
+    port: sshConfig.port,
+    user: sshConfig.user,
+    remotePort: sshConfig.remotePort,
+    remoteHome: sshConfig.remoteHome,
+    installDir: sshConfig.installDir,
+  };
+
+  await sshBridge.ensureRemoteDaemon(bridgeConfig);
+
+  const { tunnelId, localPort } = await sshBridge.openTunnel(bridgeConfig);
+
+  const config = await buildClientConfig(
+    {
+      id: connection.id,
+      type: "directTcp",
+      endpoint: `127.0.0.1:${localPort}`,
+      useTls: false,
+    },
+    options?.serverId,
+    options,
+    deps,
+  );
+
+  try {
+    const result = await connectAndProbe(config, resolveTimeout(connection, options), deps);
+    // Attach the tunnelId to the client so it can be closed when the client closes.
+    // The DaemonClient doesn't have a hook for this, so we store it on the client
+    // and the host runtime closes the tunnel when disposing the client.
+    (result.client as DaemonClient & { __sshTunnelId?: string }).__sshTunnelId = tunnelId;
+    return result;
+  } catch (error) {
+    await sshBridge.closeTunnel(tunnelId).catch(() => undefined);
+    throw error;
+  }
 }
 
 export function connectToDaemon(
@@ -245,6 +310,9 @@ export async function connectToDaemon(
   options?: ProbeOptions,
   deps: DaemonConnectionDependencies<DaemonProbeClient> = defaultDaemonConnectionDependencies,
 ): Promise<{ client: DaemonProbeClient; serverId: string; hostname: string | null }> {
+  if (connection.type === "ssh") {
+    return connectToDaemonViaSsh(connection, options, deps);
+  }
   const config = await buildClientConfig(connection, options?.serverId, options, deps);
   return connectAndProbe(config, resolveTimeout(connection, options), deps);
 }

--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -14,6 +14,7 @@ import {
   createDesktopLocalDaemonTransportFactory,
 } from "@/desktop/daemon/desktop-daemon-transport";
 import { getDesktopHost } from "@/desktop/host";
+import { i18n } from "@/i18n/i18next";
 
 export interface DaemonProbeClient {
   readonly lastError: string | null;
@@ -82,6 +83,37 @@ function isIncorrectPasswordFailure(input: {
     details.includes("unauthorized") ||
     details.includes("code 1006")
   );
+}
+
+/**
+ * Cleanup for transport resources a client was handed but does not own — today
+ * that means the SSH tunnel its WebSocket runs through.
+ *
+ * A WeakMap rather than a field on the client: the tunnel's lifetime is tied to
+ * the client instance, but every intermediate signature between the probe and
+ * the eventual close would otherwise have to carry it, and any one of them
+ * forgetting leaks an `ssh` process for the lifetime of the app.
+ */
+const transportDisposers = new WeakMap<DaemonProbeClient, () => Promise<void>>();
+
+export function registerTransportDisposer(
+  client: DaemonProbeClient,
+  dispose: () => Promise<void>,
+): void {
+  transportDisposers.set(client, dispose);
+}
+
+/**
+ * Close a client and release its transport. Every path that disposes a client
+ * must go through here — closing the client alone leaves the tunnel open.
+ */
+export async function closeClientAndTransport(client: DaemonProbeClient): Promise<void> {
+  const dispose = transportDisposers.get(client);
+  transportDisposers.delete(client);
+  await client.close().catch(() => undefined);
+  if (dispose) {
+    await dispose().catch(() => undefined);
+  }
 }
 
 export class DaemonConnectionTestError extends Error {
@@ -238,6 +270,10 @@ function resolveTimeout(connection: HostConnection, options?: ProbeOptions): num
   if (connection.type === "ssh") return 30_000;
   return connection.type === "relay" ? 10_000 : 6_000;
 }
+
+/** Distinguishes concurrent SSH probes so their progress streams don't mix. */
+let probeSequence = 0;
+
 async function connectToDaemonViaSsh(
   connection: Extract<HostConnection, { type: "ssh" }>,
   options: ProbeOptions | undefined,
@@ -245,7 +281,7 @@ async function connectToDaemonViaSsh(
 ): Promise<{ client: DaemonProbeClient; serverId: string; hostname: string | null }> {
   const sshBridge = getDesktopHost()?.ssh;
   if (!sshBridge) {
-    throw new DaemonConnectionTestError("SSH connections require the Paseo desktop app.", {
+    throw new DaemonConnectionTestError(i18n.t("pairing.ssh.errors.desktopOnly"), {
       reason: "SSH not available",
       lastError: null,
     });
@@ -267,23 +303,26 @@ async function connectToDaemonViaSsh(
     remoteHome: sshConfig.remoteHome,
     installDir: sshConfig.installDir,
   };
-  // Subscribe to SSH progress events from the desktop main process.
+  // The main process reports ensure-script progress out of band, tagged with
+  // the request id so concurrent connects to the same host don't cross streams.
+  const requestId = `ssh-${connection.id}-${probeSequence++}`;
   const events = getDesktopHost()?.events;
   let unsubscribeProgress: (() => void) | null = null;
   if (events?.on && options?.onProgress) {
-    const unsub = events.on("ssh-progress", (payload) => {
-      if (payload && typeof payload === "object" && "message" in payload) {
-        const msg = (payload as { message: string }).message;
-        if (sshConfig.host === (payload as { host?: string }).host) {
-          options.onProgress!(msg);
-        }
+    // The Electron bridge resolves the unsubscribe asynchronously; awaiting it
+    // is what makes the listener removable at all.
+    unsubscribeProgress = await events.on("ssh-progress", (payload) => {
+      if (!payload || typeof payload !== "object") return;
+      const event = payload as { requestId?: string; message?: string };
+      if (event.requestId === requestId && typeof event.message === "string") {
+        options.onProgress?.(event.message);
       }
     });
-    if (unsub) unsubscribeProgress = typeof unsub === "function" ? unsub : null;
   }
 
   try {
-    const { tunnelId, localPort } = await sshBridge.openTunnel(bridgeConfig);
+    const { tunnelId, localPort } = await sshBridge.openTunnel({ ...bridgeConfig, requestId });
+    const closeTunnel = () => sshBridge.closeTunnel(tunnelId).then(() => undefined);
 
     const config = await buildClientConfig(
       {
@@ -299,15 +338,22 @@ async function connectToDaemonViaSsh(
 
     try {
       const result = await connectAndProbe(config, resolveTimeout(connection, options), deps);
-      // Attach the tunnelId to the client so it can be closed when the client closes.
-      // The DaemonClient doesn't have a hook for this, so we store it on the client
-      // and the host runtime closes the tunnel when disposing the client.
-      (result.client as DaemonClient & { __sshTunnelId?: string }).__sshTunnelId = tunnelId;
+      registerTransportDisposer(result.client, closeTunnel);
       return result;
     } catch (error) {
-      await sshBridge.closeTunnel(tunnelId).catch(() => undefined);
+      await closeTunnel().catch(() => undefined);
       throw error;
     }
+  } catch (error) {
+    // The tunnel reports a declined prompt as a cancellation; say so plainly
+    // rather than surfacing the authentication error it produced.
+    if (error instanceof Error && /cancelled/i.test(error.message)) {
+      throw new DaemonConnectionTestError(i18n.t("pairing.ssh.errors.cancelled"), {
+        reason: "cancelled",
+        lastError: null,
+      });
+    }
+    throw error;
   } finally {
     unsubscribeProgress?.();
   }

--- a/packages/app/test-stubs/lucide-react-native.ts
+++ b/packages/app/test-stubs/lucide-react-native.ts
@@ -59,6 +59,7 @@ export const Inbox = StubIcon;
 export const Info = StubIcon;
 export const Layers = StubIcon;
 export const Link = StubIcon;
+export const KeyRound = StubIcon;
 export const Link2 = StubIcon;
 export const MessageSquare = StubIcon;
 export const MessageSquarePlus = StubIcon;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,25 @@
     "!dist/**/*.map"
   ],
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./ssh": {
+      "types": "./dist/ssh/index.d.ts",
+      "source": "./src/ssh/index.ts",
+      "default": "./dist/ssh/index.js"
+    },
+    "./dist/*": {
+      "default": "./dist/*"
+    },
+    "./bin/*": {
+      "default": "./bin/*"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/commands/daemon/local-daemon.supervision.test.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.supervision.test.ts
@@ -40,9 +40,19 @@ class FakeDaemonRuntime implements DaemonLaunchRuntime {
   readonly daemonProcess = new FakeDaemonProcess();
   foregroundStatus = 0;
   runnerEntry = "/repo/packages/server/scripts/supervisor-entrypoint.ts";
+  systemdScope = false;
+  lingerEnabledCount = 0;
 
   resolveRunnerEntry(): string {
     return this.runnerEntry;
+  }
+
+  useSystemdScope(): boolean {
+    return this.systemdScope;
+  }
+
+  enableSystemdLinger(): void {
+    this.lingerEnabledCount += 1;
   }
 
   resolveHome(env: NodeJS.ProcessEnv): string {
@@ -119,7 +129,7 @@ describe("local daemon launch supervision", () => {
     const runtime = new FakeDaemonRuntime();
 
     const resultPromise = startLocalDaemonDetached(
-      { home: "/tmp/paseo-test", mcp: false, forceNoSystemdRun: true },
+      { home: "/tmp/paseo-test", mcp: false },
       runtime,
     );
     await vi.advanceTimersByTimeAsync(1200);
@@ -133,6 +143,29 @@ describe("local daemon launch supervision", () => {
     expect(launch?.command).toBe(process.execPath);
     expectSupervisorLaunch(launch?.args ?? []);
     expect(launch?.args).toContain("--no-mcp");
+    expect(runtime.lingerEnabledCount).toBe(0);
+  });
+
+  test("detached start escapes the session cgroup when systemd scopes are available", async () => {
+    vi.useFakeTimers();
+    const runtime = new FakeDaemonRuntime();
+    runtime.systemdScope = true;
+
+    const resultPromise = startLocalDaemonDetached(
+      { home: "/tmp/paseo-test", mcp: false },
+      runtime,
+    );
+    await vi.advanceTimersByTimeAsync(1200);
+    await resultPromise;
+
+    const launch = runtime.recordedLaunches[0];
+    expect(launch?.command).toBe("systemd-run");
+    // The scope wrapper must sit in front of the node invocation, not replace
+    // it: everything after `--quiet` is the daemon launch we would have run.
+    expect(launch?.args.slice(0, 4)).toEqual(["--user", "--scope", "--quiet", process.execPath]);
+    expectSupervisorLaunch(launch?.args.slice(4) ?? []);
+    // Without linger the transient scope dies with the user's last session.
+    expect(runtime.lingerEnabledCount).toBe(1);
   });
 
   test("relay TLS flag is passed to the supervised daemon", async () => {

--- a/packages/cli/src/commands/daemon/local-daemon.supervision.test.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.supervision.test.ts
@@ -119,7 +119,7 @@ describe("local daemon launch supervision", () => {
     const runtime = new FakeDaemonRuntime();
 
     const resultPromise = startLocalDaemonDetached(
-      { home: "/tmp/paseo-test", mcp: false },
+      { home: "/tmp/paseo-test", mcp: false, forceNoSystemdRun: true },
       runtime,
     );
     await vi.advanceTimersByTimeAsync(1200);

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -7,17 +7,19 @@ import treeKill from "tree-kill";
 import { tryConnectToDaemon } from "../../utils/client.js";
 
 /**
- * Detect whether `systemd-run --user` is available. When it is, wrapping the
- * daemon launch in `systemd-run --user --scope` moves the daemon into a new
- * cgroup scope that survives the originating session (e.g. an SSH session)
- * closing. Without this, systemd-logind with `KillUserProcesses=yes` kills the
- * daemon when the SSH session that started it ends.
+ * Detect whether `systemd-run --user` is available.
  *
- * Requires `loginctl enable-linger` so the user's systemd instance persists
- * after the last session closes. Without linger, the user manager is stopped
- * when the session ends, killing the scope along with it.
+ * A detached daemon has to outlive the session that started it. Under
+ * systemd-logind with `KillUserProcesses=yes` it does not: the daemon inherits
+ * the launching session's cgroup and is killed when that session ends —
+ * closing an SSH connection, logging out of a desktop session, or exiting the
+ * terminal that ran `paseo daemon start`. `systemd-run --user --scope` moves
+ * the daemon into its own transient scope so it survives all of those.
+ *
+ * Pairs with `loginctl enable-linger`: without linger the user's systemd
+ * instance is stopped at last logout, taking the scope with it.
  */
-function isSystemdRunUserAvailable(): boolean {
+function detectSystemdScopeSupport(): boolean {
   if (process.platform !== "linux") return false;
   if (!process.env.XDG_RUNTIME_DIR) return false;
   try {
@@ -25,6 +27,19 @@ function isSystemdRunUserAvailable(): boolean {
     return result.status === 0;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Best-effort `loginctl enable-linger`. May be denied by polkit, and may
+ * already be on; neither is fatal, the daemon just reverts to dying with the
+ * user's last session.
+ */
+function enableSystemdLinger(): void {
+  try {
+    spawnSync("loginctl", ["enable-linger"], { timeout: 2000, stdio: "ignore" });
+  } catch {
+    // Linger may already be enabled, or polkit may deny it.
   }
 }
 
@@ -38,8 +53,6 @@ export interface DaemonStartOptions {
   mcp?: boolean;
   injectMcp?: boolean;
   webUi?: boolean;
-  /** Skip systemd-run cgroup escape (for tests). */
-  forceNoSystemdRun?: boolean;
   hostnames?: string;
 }
 
@@ -106,6 +119,13 @@ export interface ForegroundDaemonProcessResult {
 export interface DaemonLaunchRuntime {
   resolveRunnerEntry(): string;
   resolveHome(env: NodeJS.ProcessEnv): string;
+  /**
+   * Whether to wrap the launch in a systemd scope so it survives the session
+   * that started it. See {@link detectSystemdScopeSupport}.
+   */
+  useSystemdScope(): boolean;
+  /** Keep the user's systemd instance alive after the last session closes. */
+  enableSystemdLinger(): void;
   spawnDetached(
     command: string,
     args: string[],
@@ -133,6 +153,8 @@ const defaultDaemonLaunchRuntime: DaemonLaunchRuntime = {
   resolveHome: resolvePaseoHome,
   spawnDetached: spawnProcess,
   spawnForeground: spawnSync,
+  useSystemdScope: detectSystemdScopeSupport,
+  enableSystemdLinger,
 };
 
 const startupReady = (): DetachedStartupResult => ({ exitedEarly: false });
@@ -611,19 +633,15 @@ export async function startLocalDaemonDetached(
   const paseoHome = runtime.resolveHome(childEnv);
   const logPath = path.join(paseoHome, DAEMON_LOG_FILENAME);
   const daemonArgs = [...process.execArgv, daemonRunnerEntry, ...buildRunnerArgs(options)];
-  const useSystemdRun = !options.forceNoSystemdRun && isSystemdRunUserAvailable();
-  if (useSystemdRun) {
-    // Enable linger so the user's systemd instance persists after the session
-    // closes. Best-effort — may require polkit privileges.
-    try {
-      spawnSync("loginctl", ["enable-linger"], { timeout: 2000, stdio: "ignore" });
-    } catch {
-      // Linger may already be enabled or polkit may deny it.
-    }
+  const useSystemdScope = runtime.useSystemdScope();
+  if (useSystemdScope) {
+    runtime.enableSystemdLinger();
   }
   const child = runtime.spawnDetached(
-    useSystemdRun ? "systemd-run" : process.execPath,
-    useSystemdRun ? ["--user", "--scope", "--quiet", process.execPath, ...daemonArgs] : daemonArgs,
+    useSystemdScope ? "systemd-run" : process.execPath,
+    useSystemdScope
+      ? ["--user", "--scope", "--quiet", process.execPath, ...daemonArgs]
+      : daemonArgs,
     {
       detached: true,
       envMode: "internal",

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -15,39 +15,17 @@ import { tryConnectToDaemon } from "../../utils/client.js";
  *
  * Requires `loginctl enable-linger` so the user's systemd instance persists
  * after the last session closes. Without linger, the user manager is stopped
+ * when the session ends, killing the scope along with it.
  */
-let systemdRunUserAvailable: boolean | null = null;
-
 function isSystemdRunUserAvailable(): boolean {
-  if (systemdRunUserAvailable !== null) return systemdRunUserAvailable;
-  if (process.platform !== "linux") {
-    systemdRunUserAvailable = false;
-    return false;
-  }
-  // systemd-run --user requires a user session bus (XDG_RUNTIME_DIR is set by
-  // pam_systemd when a session is created).
-  if (!process.env.XDG_RUNTIME_DIR) {
-    systemdRunUserAvailable = false;
-    return false;
-  }
+  if (process.platform !== "linux") return false;
+  if (!process.env.XDG_RUNTIME_DIR) return false;
   try {
     const result = spawnSync("systemd-run", ["--version"], { timeout: 2000, stdio: "ignore" });
-    systemdRunUserAvailable = result.status === 0;
+    return result.status === 0;
   } catch {
-    systemdRunUserAvailable = false;
+    return false;
   }
-  // Enable linger so the user's systemd instance persists after the session
-  // closes. Without this, systemd-logind kills the user manager (and our
-  // scope) when the last session ends. Best-effort — may require polkit
-  // privileges; if it fails, the scope still works during the session.
-  if (systemdRunUserAvailable) {
-    try {
-      spawnSync("loginctl", ["enable-linger"], { timeout: 2000, stdio: "ignore" });
-    } catch {
-      // Best-effort — linger may already be enabled or polkit may deny it.
-    }
-  }
-  return systemdRunUserAvailable;
 }
 
 export interface DaemonStartOptions {
@@ -60,6 +38,8 @@ export interface DaemonStartOptions {
   mcp?: boolean;
   injectMcp?: boolean;
   webUi?: boolean;
+  /** Skip systemd-run cgroup escape (for tests). */
+  forceNoSystemdRun?: boolean;
   hostnames?: string;
 }
 
@@ -631,7 +611,16 @@ export async function startLocalDaemonDetached(
   const paseoHome = runtime.resolveHome(childEnv);
   const logPath = path.join(paseoHome, DAEMON_LOG_FILENAME);
   const daemonArgs = [...process.execArgv, daemonRunnerEntry, ...buildRunnerArgs(options)];
-  const useSystemdRun = isSystemdRunUserAvailable();
+  const useSystemdRun = !options.forceNoSystemdRun && isSystemdRunUserAvailable();
+  if (useSystemdRun) {
+    // Enable linger so the user's systemd instance persists after the session
+    // closes. Best-effort — may require polkit privileges.
+    try {
+      spawnSync("loginctl", ["enable-linger"], { timeout: 2000, stdio: "ignore" });
+    } catch {
+      // Linger may already be enabled or polkit may deny it.
+    }
+  }
   const child = runtime.spawnDetached(
     useSystemdRun ? "systemd-run" : process.execPath,
     useSystemdRun ? ["--user", "--scope", "--quiet", process.execPath, ...daemonArgs] : daemonArgs,

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -6,6 +6,50 @@ import { loadConfig, resolvePaseoHome, spawnProcess } from "@getpaseo/server";
 import treeKill from "tree-kill";
 import { tryConnectToDaemon } from "../../utils/client.js";
 
+/**
+ * Detect whether `systemd-run --user` is available. When it is, wrapping the
+ * daemon launch in `systemd-run --user --scope` moves the daemon into a new
+ * cgroup scope that survives the originating session (e.g. an SSH session)
+ * closing. Without this, systemd-logind with `KillUserProcesses=yes` kills the
+ * daemon when the SSH session that started it ends.
+ *
+ * Requires `loginctl enable-linger` so the user's systemd instance persists
+ * after the last session closes. Without linger, the user manager is stopped
+ */
+let systemdRunUserAvailable: boolean | null = null;
+
+function isSystemdRunUserAvailable(): boolean {
+  if (systemdRunUserAvailable !== null) return systemdRunUserAvailable;
+  if (process.platform !== "linux") {
+    systemdRunUserAvailable = false;
+    return false;
+  }
+  // systemd-run --user requires a user session bus (XDG_RUNTIME_DIR is set by
+  // pam_systemd when a session is created).
+  if (!process.env.XDG_RUNTIME_DIR) {
+    systemdRunUserAvailable = false;
+    return false;
+  }
+  try {
+    const result = spawnSync("systemd-run", ["--version"], { timeout: 2000, stdio: "ignore" });
+    systemdRunUserAvailable = result.status === 0;
+  } catch {
+    systemdRunUserAvailable = false;
+  }
+  // Enable linger so the user's systemd instance persists after the session
+  // closes. Without this, systemd-logind kills the user manager (and our
+  // scope) when the last session ends. Best-effort — may require polkit
+  // privileges; if it fails, the scope still works during the session.
+  if (systemdRunUserAvailable) {
+    try {
+      spawnSync("loginctl", ["enable-linger"], { timeout: 2000, stdio: "ignore" });
+    } catch {
+      // Best-effort — linger may already be enabled or polkit may deny it.
+    }
+  }
+  return systemdRunUserAvailable;
+}
+
 export interface DaemonStartOptions {
   port?: string;
   listen?: string;
@@ -586,9 +630,11 @@ export async function startLocalDaemonDetached(
 
   const paseoHome = runtime.resolveHome(childEnv);
   const logPath = path.join(paseoHome, DAEMON_LOG_FILENAME);
+  const daemonArgs = [...process.execArgv, daemonRunnerEntry, ...buildRunnerArgs(options)];
+  const useSystemdRun = isSystemdRunUserAvailable();
   const child = runtime.spawnDetached(
-    process.execPath,
-    [...process.execArgv, daemonRunnerEntry, ...buildRunnerArgs(options)],
+    useSystemdRun ? "systemd-run" : process.execPath,
+    useSystemdRun ? ["--user", "--scope", "--quiet", process.execPath, ...daemonArgs] : daemonArgs,
     {
       detached: true,
       envMode: "internal",

--- a/packages/cli/src/ssh/askpass-channel.ts
+++ b/packages/cli/src/ssh/askpass-channel.ts
@@ -1,0 +1,216 @@
+import { createServer, type Server, type Socket } from "node:net";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { shellQuote } from "./remote-daemon.js";
+
+/**
+ * Which secret SSH is asking for. The raw prompt is the only signal SSH gives,
+ * and the two need visibly different treatment: one unlocks a local key file,
+ * the other is the remote account's password. Classifying here means the UI
+ * does not have to parse English prompt text.
+ */
+export type AskpassKind = "passphrase" | "password";
+
+export interface AskpassRequest {
+  /** SSH's own prompt, verbatim — carries the key path or `user@host`. */
+  prompt: string;
+  kind: AskpassKind;
+}
+
+export interface AskpassChannelOptions {
+  /**
+   * Resolve with the secret, or `null` when the user declines. Declining
+   * aborts {@link AskpassChannel.signal}, which the tunnel uses to stop
+   * immediately rather than letting SSH burn its remaining attempts.
+   */
+  onPrompt: (request: AskpassRequest) => Promise<string | null>;
+  /**
+   * How long to wait for an answer before treating the prompt as declined.
+   * Without this a prompt nobody is listening for would hang SSH forever.
+   */
+  promptTimeoutMs?: number;
+}
+
+export interface AskpassChannel {
+  /** Path to hand SSH as `SSH_ASKPASS`. */
+  readonly askpassPath: string;
+  /** Aborts as soon as a prompt is declined or times out. */
+  readonly signal: AbortSignal;
+  close(): void;
+}
+
+const DEFAULT_PROMPT_TIMEOUT_MS = 120_000;
+
+export function classifyAskpassPrompt(prompt: string): AskpassKind {
+  return /passphrase/i.test(prompt) ? "passphrase" : "password";
+}
+
+/**
+ * The program SSH runs. It cannot be the Node helper directly — SSH_ASKPASS
+ * must be an executable, and under Electron the runtime is the app binary in
+ * Node mode. `ELECTRON_RUN_AS_NODE` is inert for a plain `node`, so one shape
+ * serves both the desktop app and the CLI.
+ */
+function buildWrapperScript(execPath: string, helperPath: string): string {
+  return `#!/bin/sh
+ELECTRON_RUN_AS_NODE=1 exec ${shellQuote(execPath)} ${shellQuote(helperPath)} "$@"
+`;
+}
+
+/**
+ * Runs as a child of `ssh`: hands the prompt to Paseo over the socket and
+ * prints whatever comes back on stdout, which is where SSH reads the secret
+ * from. Exiting non-zero on refusal is not itself meaningful to SSH — it
+ * ignores the status — but it keeps an empty answer from being offered as a
+ * password.
+ *
+ * Written to disk at runtime rather than shipped, so there is no packaged
+ * asset to resolve inside an asar archive.
+ */
+function buildHelperScript(socketPath: string): string {
+  return `"use strict";
+const net = require("node:net");
+const socketPath = ${JSON.stringify(socketPath)};
+const prompt = process.argv[2] ?? "";
+
+const socket = net.connect(socketPath);
+let buffered = "";
+
+socket.on("connect", () => {
+  socket.write(JSON.stringify({ prompt }) + "\\n");
+});
+
+socket.on("data", (chunk) => {
+  buffered += chunk.toString("utf8");
+  const newline = buffered.indexOf("\\n");
+  if (newline < 0) return;
+  let message;
+  try {
+    message = JSON.parse(buffered.slice(0, newline));
+  } catch {
+    process.exit(1);
+  }
+  if (message && message.ok === true && typeof message.secret === "string") {
+    process.stdout.write(message.secret, () => process.exit(0));
+    return;
+  }
+  process.exit(1);
+});
+
+// No listener, a closed channel, or a refused connection all mean we cannot
+// answer; exiting beats hanging the SSH process indefinitely.
+socket.on("error", () => process.exit(1));
+socket.on("close", () => process.exit(1));
+`;
+}
+
+/**
+ * A private channel that lets Paseo answer SSH's password prompts itself,
+ * instead of shelling out to `zenity`, `kdialog`, or `osascript`.
+ *
+ * SSH will only take a secret from a program's stdout, so there is still a
+ * small program — but all it does is relay. The prompt travels to whatever UI
+ * the caller owns and the answer comes back, which means the dialog is Paseo's
+ * own: styled, localized, and able to say whether it wants a key passphrase or
+ * an account password.
+ *
+ * Everything lives in a private `mkdtemp` directory (mode 0700), so the socket
+ * is not reachable by other users on the machine.
+ */
+export function createAskpassChannel(options: AskpassChannelOptions): Promise<AskpassChannel> {
+  const dir = mkdtempSync(path.join(tmpdir(), "paseo-askpass-"));
+  const socketPath = path.join(dir, "askpass.sock");
+  const helperPath = path.join(dir, "askpass-helper.cjs");
+  const askpassPath = path.join(dir, "askpass.sh");
+  const timeoutMs = options.promptTimeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS;
+
+  writeFileSync(helperPath, buildHelperScript(socketPath), { mode: 0o600 });
+  writeFileSync(askpassPath, buildWrapperScript(process.execPath, helperPath), { mode: 0o700 });
+  chmodSync(askpassPath, 0o700);
+
+  const controller = new AbortController();
+
+  const handleConnection = (socket: Socket): void => {
+    let buffered = "";
+    socket.setEncoding("utf8");
+    socket.on("error", () => socket.destroy());
+    socket.on("data", (chunk: string) => {
+      buffered += chunk;
+      const newline = buffered.indexOf("\n");
+      if (newline < 0) return;
+      const line = buffered.slice(0, newline);
+      buffered = "";
+
+      let prompt: string;
+      try {
+        const parsed: unknown = JSON.parse(line);
+        prompt =
+          parsed && typeof parsed === "object" && typeof (parsed as { prompt?: unknown }).prompt
+            ? String((parsed as { prompt: string }).prompt)
+            : "";
+      } catch {
+        socket.end(`${JSON.stringify({ ok: false })}\n`);
+        return;
+      }
+
+      const decline = (): void => {
+        socket.end(`${JSON.stringify({ ok: false })}\n`);
+        controller.abort();
+      };
+
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        decline();
+      }, timeoutMs);
+      timer.unref();
+
+      void options
+        .onPrompt({ prompt, kind: classifyAskpassPrompt(prompt) })
+        .then((secret) => {
+          if (settled) return undefined;
+          settled = true;
+          clearTimeout(timer);
+          if (secret === null) {
+            decline();
+            return undefined;
+          }
+          socket.end(`${JSON.stringify({ ok: true, secret })}\n`);
+          return undefined;
+        })
+        .catch(() => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          decline();
+        });
+    });
+  };
+
+  const server: Server = createServer(handleConnection);
+
+  return new Promise<AskpassChannel>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.removeListener("error", reject);
+      server.on("error", () => {
+        // A dead channel just means prompts go unanswered; the tunnel's own
+        // failure path reports that far more usefully than a crash here.
+      });
+      resolve({
+        askpassPath,
+        signal: controller.signal,
+        close: () => {
+          server.close();
+          try {
+            rmSync(dir, { recursive: true, force: true });
+          } catch {
+            // Best-effort cleanup.
+          }
+        },
+      });
+    });
+  });
+}

--- a/packages/cli/src/ssh/index.ts
+++ b/packages/cli/src/ssh/index.ts
@@ -5,8 +5,13 @@ export {
   findFreeLocalPort,
   waitForLocalPort,
   createAskpassScript,
+  createTerminalAskpassScript,
   cleanupAskpassScript,
 } from "./ssh-process.js";
-export { ensureRemoteDaemon, type EnsureRemoteDaemonResult } from "./remote-daemon.js";
+export {
+  ensureRemoteDaemon,
+  buildEnsureScript,
+  type EnsureRemoteDaemonResult,
+} from "./remote-daemon.js";
 export { normalizeSshHostConfig, type SshHostConfig } from "./ssh-host-config.js";
 export type { SshHostConnection } from "@getpaseo/protocol/host-connection-schema";

--- a/packages/cli/src/ssh/index.ts
+++ b/packages/cli/src/ssh/index.ts
@@ -1,0 +1,12 @@
+export {
+  SshTunnel,
+  sshExec,
+  buildSshBaseArgs,
+  findFreeLocalPort,
+  waitForLocalPort,
+  createAskpassScript,
+  cleanupAskpassScript,
+} from "./ssh-process.js";
+export { ensureRemoteDaemon, type EnsureRemoteDaemonResult } from "./remote-daemon.js";
+export { normalizeSshHostConfig, type SshHostConfig } from "./ssh-host-config.js";
+export type { SshHostConnection } from "@getpaseo/protocol/host-connection-schema";

--- a/packages/cli/src/ssh/index.ts
+++ b/packages/cli/src/ssh/index.ts
@@ -1,17 +1,27 @@
 export {
   SshTunnel,
-  sshExec,
   buildSshBaseArgs,
   findFreeLocalPort,
-  waitForLocalPort,
-  createAskpassScript,
   createTerminalAskpassScript,
-  cleanupAskpassScript,
+  SshCancelledError,
+  type AskpassScript,
+  type SshTunnelOptions,
 } from "./ssh-process.js";
 export {
-  ensureRemoteDaemon,
   buildEnsureScript,
-  type EnsureRemoteDaemonResult,
+  describeEnsureFailure,
+  describeSshFailure,
+  ENSURE_EXIT,
+  PROGRESS_MARKER,
+  READY_MARKER,
+  ASKPASS_CANCELLED_MARKER,
 } from "./remote-daemon.js";
+export {
+  createAskpassChannel,
+  classifyAskpassPrompt,
+  type AskpassChannel,
+  type AskpassKind,
+  type AskpassRequest,
+} from "./askpass-channel.js";
 export { normalizeSshHostConfig, type SshHostConfig } from "./ssh-host-config.js";
 export type { SshHostConnection } from "@getpaseo/protocol/host-connection-schema";

--- a/packages/cli/src/ssh/remote-daemon.ts
+++ b/packages/cli/src/ssh/remote-daemon.ts
@@ -1,49 +1,34 @@
 import type { SshHostConfig } from "./ssh-host-config.js";
-import { sshExec, type SshExecResult } from "./ssh-process.js";
 
 /**
- * Detect whether an sshExec failure is an SSH connection/auth error rather
- * than a genuine command failure. SSH exits 255 for auth, connection refused,
- * host key, and DNS failures — all of which should surface the SSH error, not
- * a misleading "node not found" message.
+ * Quote a value for safe interpolation into a POSIX shell script. Everything
+ * the ensure script embeds — hostnames, paths, version specs — comes from user
+ * config, so it must survive quotes, `$`, backticks, and spaces intact.
  */
-function isSshConnectionFailure(result: SshExecResult): boolean {
-  if (result.exitCode !== 255) return false;
-  const stderr = result.stderr.toLowerCase();
-  return (
-    stderr.includes("permission denied") ||
-    stderr.includes("connection refused") ||
-    stderr.includes("connection timed out") ||
-    stderr.includes("could not resolve hostname") ||
-    stderr.includes("host key verification failed") ||
-    stderr.includes("operation timed out") ||
-    stderr.includes("no route to host") ||
-    stderr.includes("network is unreachable")
-  );
-}
-
-function describeSshFailure(result: SshExecResult, host: string): string {
-  const stderr = result.stderr.trim();
-  if (stderr) return `SSH connection to ${host} failed: ${stderr}`;
-  return `SSH connection to ${host} failed (exit code ${result.exitCode}).`;
-}
-
-/** Throw a descriptive error if the sshExec result is an SSH connection/auth failure. */
-function assertNotSshFailure(result: SshExecResult, host: string): void {
-  if (isSshConnectionFailure(result)) {
-    throw new Error(describeSshFailure(result, host));
-  }
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 /**
  * Expand a leading `~` to `$HOME` for use inside a remote command. The remote
- * shell expands `$HOME` (even inside double quotes) but not `~` (inside quotes),
- * so remote commands use `$HOME`-spelled paths.
+ * shell expands `$HOME` but not a `~` that survives quoting, so remote paths
+ * are spelled with `$HOME` and concatenated outside the quotes.
  */
 export function remoteExpandHome(p: string): string {
   if (p === "~") return "$HOME";
   if (p.startsWith("~/")) return `$HOME/${p.slice(2)}`;
   return p;
+}
+
+/**
+ * Render a path as a single shell word. `~`-relative paths become `"$HOME"`
+ * followed by a single-quoted remainder, so the tilde expands but nothing in
+ * the rest of the path can be reinterpreted by the shell.
+ */
+export function shellPath(p: string): string {
+  if (p === "~") return `"$HOME"`;
+  if (p.startsWith("~/")) return `"$HOME"/${shellQuote(p.slice(2))}`;
+  return shellQuote(p);
 }
 
 /** Remote PASEO_HOME, with `~` expanded to `$HOME`. */
@@ -56,169 +41,255 @@ export function remoteInstallPath(config: SshHostConfig): string {
   return remoteExpandHome(config.installDir);
 }
 
-/** Path to the installed `paseo` binary on the remote host. */
-export function remotePaseoBin(config: SshHostConfig): string {
-  return `"${remoteInstallPath(config)}/node_modules/.bin/paseo"`;
-}
+/**
+ * Exit codes the ensure script reports back through SSH. They are the contract
+ * between {@link buildEnsureScript} and {@link describeEnsureFailure}.
+ */
+export const ENSURE_EXIT = {
+  ready: 0,
+  nodeMissing: 10,
+  installFailed: 11,
+  notReady: 12,
+  npmMissing: 13,
+} as const;
+
+/**
+ * Structured markers the ensure script writes to stderr. `PROGRESS:` lines are
+ * human-facing status text and may be reworded freely; `READY:` is the machine
+ * contract that tells the tunnel the daemon is accepting connections. Keeping
+ * the two separate means rewording user-facing status cannot silently break
+ * readiness detection.
+ */
+export const PROGRESS_MARKER = "PROGRESS:";
+export const READY_MARKER = "READY:";
+
+/**
+ * Emitted by the askpass program when the user dismisses the prompt.
+ *
+ * SSH gives askpass no way to report a cancellation — it ignores the program's
+ * exit status and simply retries up to `NumberOfPasswordPrompts`, so a
+ * dismissed prompt is indistinguishable from a wrong password and reappears.
+ * But askpass is *our* program and it does know the difference, and its stderr
+ * is inherited by ssh (only stdout is redirected to the password pipe), so it
+ * can say so on the same stream the tunnel already parses.
+ *
+ * Used by the CLI's terminal prompt. The desktop app answers prompts over
+ * {@link ../askpass-channel.js} instead and signals cancellation directly.
+ */
+export const ASKPASS_CANCELLED_MARKER = "PASEO_ASKPASS:cancelled";
+
+/**
+ * The command `ssh` runs on the remote host.
+ *
+ * sshd executes a remote command as `<user's shell> -c "<command>"`, using the
+ * shell from the password database. That is not a login shell, but it *is* the
+ * user's shell binary — so a host where someone has `chsh`'d to fish or tcsh
+ * would try to parse our POSIX script with fish or tcsh and fail outright.
+ *
+ * Wrapping the script as `/bin/sh -c '<script>'` does not help: the outer
+ * string still goes through that shell, and neither fish nor csh can carry the
+ * quotes and newlines the script contains. So the command is reduced to three
+ * words with no metacharacters at all — every shell agrees on what that
+ * means — and the script itself is piped in over stdin.
+ *
+ * Two things fall out of this for free: nothing needs shell-escaping on the way
+ * in, and the script no longer shows up in the remote host's process list,
+ * where any other user could read it.
+ */
+export const REMOTE_SHELL_COMMAND = "exec /bin/sh";
+
+/** How long the remote script waits for the daemon to start listening. */
+export const REMOTE_READY_TIMEOUT_MS = 30_000;
+// Whole seconds: POSIX `sleep` only guarantees integer arguments, and BusyBox
+// builds without FANCY_SLEEP reject "0.5".
+const REMOTE_POLL_INTERVAL_MS = 1_000;
 
 /**
  * Build a single self-contained shell script that ensures a Paseo daemon is
  * running on the remote host. The script:
  *
- * 1. Checks if the daemon port is already listening (exit 0)
- * 2. Verifies node and npm are installed (exit 10 if not)
- * 3. Installs @getpaseo/cli if missing (exit 11 on install failure)
+ * 1. Returns immediately if the daemon port is already listening
+ * 2. Prefers a `paseo` already on `PATH` (global npm, system package manager)
+ * 3. Otherwise installs — or upgrades — a Paseo-managed copy under `installDir`
  * 4. Launches the daemon detached
- * 5. Waits for the port to accept connections (exit 12 on timeout)
+ * 5. Waits for the port to accept connections
  *
- * Progress markers are written to stderr as `PROGRESS:<message>` lines so the
- * caller can report status. The script runs in a single SSH call — one auth,
- * one connection, no multiplexing needed.
+ * Preferring a `PATH` install matters for correctness, not just disk: if we
+ * installed a second copy, a user on the remote host could start *their*
+ * daemon from the system binary while we run a different build against the
+ * same `PASEO_HOME`, and the two would fight over the port and the agent
+ * state. Paseo only ever installs or upgrades inside `installDir` — never a
+ * binary it did not put there.
  *
- * Exit codes: 0 = ready, 10 = node missing, 11 = install failed,
- * 12 = not ready in time, 255 = SSH failure (from ssh itself).
+ * The script is piped to a remote `/bin/sh` over the SSH connection's stdin
+ * rather than passed as the remote command, so the user's own shell never has
+ * to parse it. See {@link REMOTE_SHELL_COMMAND}.
+ *
+ * On success it deliberately falls off the end without exiting: `sh` reading a
+ * script from a pipe blocks for more input, which is what holds the port
+ * forward open. Closing stdin is the teardown signal. On failure it exits with
+ * a code from {@link ENSURE_EXIT}, which `ssh` reports as its own exit code.
+ *
+ * The script runs in a single SSH call — one auth, one connection, no
+ * multiplexing.
  */
 export function buildEnsureScript(config: SshHostConfig, version: string): string {
-  const home = remoteHomePath(config);
-  const installDir = remoteInstallPath(config);
-  const bin = `"${installDir}/node_modules/.bin/paseo"`;
-  const port = config.remotePort;
-  const spec = version.trim() ? `@getpaseo/cli@${version}` : "@getpaseo/cli";
-  const readyTimeoutMs = 30_000;
-  const pollIntervalMs = 500;
-  const maxPolls = Math.floor(readyTimeoutMs / pollIntervalMs);
+  const home = shellPath(config.remoteHome);
+  const installDir = shellPath(config.installDir);
+  const host = config.host;
+  const wanted = version.trim() || "latest";
+  const maxPolls = Math.floor(REMOTE_READY_TIMEOUT_MS / REMOTE_POLL_INTERVAL_MS);
 
-  // A node one-liner that exits 0 if the port accepts a connection, 1 otherwise.
-  const portCheck = `node -e 'const n=require("net");const s=n.connect({port:${port},host:"127.0.0.1"});s.on("connect",()=>{s.end();process.exit(0)});s.on("error",()=>process.exit(1));setTimeout(()=>{s.destroy();process.exit(1)},3000)'`;
+  // Exits 0 if the port accepts a connection, 1 otherwise. Node is the only
+  // runtime we can rely on (Paseo itself needs it), so the check uses it
+  // rather than nc or bash-isms that vary across remote hosts.
+  const portCheck = `node -e 'const n=require("net");const s=n.connect({port:${config.remotePort},host:"127.0.0.1"});s.on("connect",()=>{s.end();process.exit(0)});s.on("error",()=>process.exit(1));setTimeout(()=>{s.destroy();process.exit(1)},3000)'`;
 
   return [
+    // Wrapped in a function so `return` unwinds to the caller instead of
+    // killing the shell — the tunnel needs this shell to stay alive.
     `ensure_daemon() {`,
-    `# 1. Already running?`,
-    `${portCheck} && { echo "PROGRESS:Remote daemon is already running." >&2; return 0; }`,
-    `# 2. Check node and npm`,
+    `  paseo_home=${home}`,
+    `  paseo_dir=${installDir}`,
+    `  paseo_want=${shellQuote(wanted)}`,
     ``,
-    `node -v >/dev/null 2>&1 && npm -v >/dev/null 2>&1 || { echo "PROGRESS:Node.js and npm are required on ${config.host}." >&2; return 10; }`,
+    `  if ! command -v node >/dev/null 2>&1; then`,
+    `    echo "${PROGRESS_MARKER}Node.js is required on ${host} to run the Paseo daemon." >&2`,
+    `    return ${ENSURE_EXIT.nodeMissing}`,
+    `  fi`,
     ``,
-    `# 3. Install Paseo if missing`,
-    `if [ ! -x ${bin} ]; then`,
-    `  echo "PROGRESS:Installing Paseo ${version} into ${config.installDir} on ${config.host}…" >&2`,
-    `  mkdir -p "${installDir}"`,
-    `  npm install --prefix "${installDir}" "${spec}" || { echo "PROGRESS:Failed to install Paseo on ${config.host}." >&2; return 11; }`,
-    `  echo "PROGRESS:Paseo installed on the remote host." >&2`,
-    `else`,
-    `  echo "PROGRESS:Paseo is already installed on the remote host." >&2`,
-    `fi`,
-    `# 4. Launch the daemon`,
-    `echo "PROGRESS:Launching the Paseo daemon on ${config.host}…" >&2`,
-    `mkdir -p "${home}"`,
-    `${bin} daemon start --home "${home}" --port ${port} --no-relay --no-mcp`,
+    `  # 1. Already running? Whatever owns the port keeps it; never double-start.`,
+    `  if ${portCheck}; then`,
+    `    echo "${PROGRESS_MARKER}Remote daemon is already running." >&2`,
+    `    echo "${READY_MARKER}running" >&2`,
+    `    return 0`,
+    `  fi`,
     ``,
-    `# 5. Wait for the port to accept connections`,
-    `echo "PROGRESS:Waiting for the remote daemon to become ready…" >&2`,
-    `i=0`,
-    `while [ $i -lt ${maxPolls} ]; do`,
-    `  ${portCheck} && { echo "PROGRESS:Remote daemon is ready." >&2; return 0; }`,
-    `  sleep ${pollIntervalMs / 1000}`,
-    `  i=$((i + 1))`,
-    `done`,
-    `echo "PROGRESS:The Paseo daemon was launched on ${config.host} but did not become ready on port ${port}. Check ${config.remoteHome}/daemon.log on the remote host." >&2`,
-    `return 12`,
+    `  # 2. Prefer a paseo the host already provides (global npm, system package`,
+    `  #    manager, nix, ...) so we never run a second, conflicting daemon.`,
+    `  paseo_bin=$(command -v paseo 2>/dev/null || true)`,
+    `  if [ -n "$paseo_bin" ]; then`,
+    `    echo "${PROGRESS_MARKER}Using the Paseo already installed on ${host} ($paseo_bin)." >&2`,
+    `  else`,
+    `    paseo_bin="$paseo_dir/node_modules/.bin/paseo"`,
+    `    # 3. Install or upgrade the copy Paseo manages under its own directory.`,
+    `    paseo_have=""`,
+    `    if [ -x "$paseo_bin" ]; then`,
+    `      paseo_have=$(cd "$paseo_dir" && node -p "require('./node_modules/@getpaseo/cli/package.json').version" 2>/dev/null || true)`,
+    `    fi`,
+    `    if [ "$paseo_have" = "$paseo_want" ]; then`,
+    `      echo "${PROGRESS_MARKER}Paseo $paseo_want is already installed on ${host}." >&2`,
+    `    else`,
+    `      if ! command -v npm >/dev/null 2>&1; then`,
+    `        echo "${PROGRESS_MARKER}npm is required on ${host} to install Paseo." >&2`,
+    `        return ${ENSURE_EXIT.npmMissing}`,
+    `      fi`,
+    `      if [ -n "$paseo_have" ]; then`,
+    `        echo "${PROGRESS_MARKER}Updating Paseo on ${host} from $paseo_have to $paseo_want…" >&2`,
+    `      else`,
+    `        echo "${PROGRESS_MARKER}Installing Paseo $paseo_want on ${host}…" >&2`,
+    `      fi`,
+    `      mkdir -p "$paseo_dir"`,
+    `      if ! npm install --prefix "$paseo_dir" "@getpaseo/cli@$paseo_want" </dev/null >&2; then`,
+    // A source checkout or an unpublished beta has no registry entry. Falling
+    // back keeps "connect from a dev build" working instead of hard-failing.
+    `        if [ "$paseo_want" = latest ]; then`,
+    `          echo "${PROGRESS_MARKER}Failed to install Paseo on ${host}." >&2`,
+    `          return ${ENSURE_EXIT.installFailed}`,
+    `        fi`,
+    `        echo "${PROGRESS_MARKER}Paseo $paseo_want is not published; installing the latest release instead…" >&2`,
+    `        if ! npm install --prefix "$paseo_dir" "@getpaseo/cli@latest" </dev/null >&2; then`,
+    `          echo "${PROGRESS_MARKER}Failed to install Paseo on ${host}." >&2`,
+    `          return ${ENSURE_EXIT.installFailed}`,
+    `        fi`,
+    `      fi`,
+    `      echo "${PROGRESS_MARKER}Paseo installed on ${host}." >&2`,
+    `    fi`,
+    `  fi`,
+    ``,
+    `  # 4. Launch the daemon. Output goes to stderr so it lands in the`,
+    `  #    diagnostics we surface on failure; stdin is closed because this`,
+    `  #    script is itself arriving on stdin and a child that reads it would`,
+    `  #    swallow the rest of the script.`,
+    `  echo "${PROGRESS_MARKER}Launching the Paseo daemon on ${host}…" >&2`,
+    `  mkdir -p "$paseo_home"`,
+    `  "$paseo_bin" daemon start --home "$paseo_home" --port ${config.remotePort} --no-relay --no-mcp </dev/null >&2`,
+    ``,
+    `  # 5. Wait for the port to accept connections.`,
+    `  echo "${PROGRESS_MARKER}Waiting for the remote daemon to become ready…" >&2`,
+    `  paseo_i=0`,
+    `  while [ $paseo_i -lt ${maxPolls} ]; do`,
+    `    if ${portCheck}; then`,
+    `      echo "${PROGRESS_MARKER}Remote daemon is ready." >&2`,
+    `      echo "${READY_MARKER}launched" >&2`,
+    `      return 0`,
+    `    fi`,
+    `    sleep ${REMOTE_POLL_INTERVAL_MS / 1000}`,
+    `    paseo_i=$((paseo_i + 1))`,
+    `  done`,
+    `  echo "${PROGRESS_MARKER}The daemon was launched on ${host} but never started listening." >&2`,
+    `  return ${ENSURE_EXIT.notReady}`,
     `}`,
-    `ensure_daemon`,
+    // Preserve the exit code: `ensure_daemon && ...` would collapse every
+    // failure to 1 and lose the reason.
+    //
+    // On success there is deliberately no `exit` and no keepalive command. This
+    // script arrives on `sh`'s stdin, so falling off the end leaves `sh`
+    // blocked reading the next line — that block *is* the keepalive, and it
+    // needs no `cat` or `sleep infinity` (which BusyBox and older BSD sleep
+    // reject anyway). The tunnel closes stdin to tear it down.
+    `ensure_daemon; paseo_rc=$?; [ $paseo_rc -eq 0 ] || exit $paseo_rc`,
   ].join("\n");
 }
 
-export interface EnsureRemoteDaemonOptions {
-  config: SshHostConfig;
-  /** @getpaseo/cli version to install if Paseo is missing. */
-  version?: string;
-  /** Progress callback for user-facing status messages. */
-  onProgress?: (message: string) => void;
-  /** Override the ssh exec implementation (for tests). */
-  exec?: (command: string) => Promise<SshExecResult>;
-  /** Per-command timeout in milliseconds (default 120s; install may be slow). */
-  commandTimeoutMs?: number;
-  /** Path to an SSH_ASKPASS program for interactive password prompts. */
-  askpassPath?: string;
-  /** Allocate a PTY for SSH (terminal password prompts). */
-  tty?: boolean;
+/**
+ * Describe a failure that came from `ssh` itself rather than the ensure
+ * script. SSH exits 255 for auth, connection, host-key, and DNS failures; its
+ * stderr is the only useful diagnostic, so it is surfaced verbatim.
+ */
+export function describeSshFailure(host: string, exitCode: number | null, stderr: string): string {
+  const detail = stderr.trim();
+  if (exitCode === 255) {
+    return `SSH connection to ${host} failed.${detail ? `\n${detail}` : ""}`;
+  }
+  if (detail) {
+    return `Failed to start the Paseo daemon on ${host}.\n${detail}`;
+  }
+  return `Failed to start the Paseo daemon on ${host} (exit code ${exitCode ?? "unknown"}).`;
 }
-
-export interface EnsureRemoteDaemonResult {
-  /** True if Paseo was installed during this call. */
-  installed: boolean;
-  /** True if the daemon was launched during this call. */
-  launched: boolean;
-  /** True if the remote daemon port is accepting connections. */
-  ready: boolean;
-}
-
-const DEFAULT_COMMAND_TIMEOUT_MS = 300_000;
 
 /**
- * Make sure a Paseo daemon is running on the remote host and accepting
- * connections on {@link SshHostConfig.remotePort}. Makes a single SSH call
- * with an inline script that checks, installs, launches, and waits — one auth,
- * one connection.
+ * Turn an ensure-script exit code into an actionable message. The tunnel runs
+ * the script inline over the same SSH connection, so this is the only place
+ * that knows what a non-zero exit meant.
  */
-export async function ensureRemoteDaemon(
-  options: EnsureRemoteDaemonOptions,
-): Promise<EnsureRemoteDaemonResult> {
-  const { config, onProgress } = options;
-  const version = options.version ?? config.packageVersion ?? "latest";
-  const commandTimeoutMs = options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
-  const exec =
-    options.exec ??
-    ((command: string) =>
-      sshExec(config, command, {
-        timeoutMs: commandTimeoutMs,
-        askpassPath: options.askpassPath,
-        tty: options.tty,
-      }));
-
-  const progress = (message: string) => onProgress?.(message);
-
-  progress(`Ensuring remote daemon on ${config.host}:${config.remotePort}…`);
-
-  const script = buildEnsureScript(config, version);
-  const result = await exec(script);
-
-  // Parse PROGRESS: lines from stderr and forward them.
-  for (const line of result.stderr.split("\n")) {
-    const match = line.match(/^PROGRESS:(.*)$/);
-    if (match) {
-      progress(match[1]);
-    }
+export function describeEnsureFailure(input: {
+  config: SshHostConfig;
+  exitCode: number | null;
+  stderr: string;
+}): string {
+  const { config } = input;
+  const stderr = input.stderr.trim();
+  switch (input.exitCode) {
+    case ENSURE_EXIT.nodeMissing:
+      return (
+        `Node.js is required on ${config.host} to run the Paseo daemon. ` +
+        `Install Node.js (https://nodejs.org) on the remote host and retry.`
+      );
+    case ENSURE_EXIT.npmMissing:
+      return (
+        `npm is required on ${config.host} to install Paseo. ` +
+        `Install npm there, or install Paseo on the remote host yourself and retry.`
+      );
+    case ENSURE_EXIT.installFailed:
+      return `Failed to install Paseo on ${config.host}.${stderr ? `\n${stderr}` : ""}`;
+    case ENSURE_EXIT.notReady:
+      return (
+        `The Paseo daemon was launched on ${config.host} but did not start listening on port ` +
+        `${config.remotePort} within ${REMOTE_READY_TIMEOUT_MS / 1000}s. ` +
+        `Check ${config.remoteHome}/daemon.log on the remote host.`
+      );
+    default:
+      return describeSshFailure(config.host, input.exitCode, stderr);
   }
-
-  if (result.exitCode === 0) {
-    return { installed: false, launched: false, ready: true };
-  }
-
-  assertNotSshFailure(result, config.host);
-
-  if (result.exitCode === 10) {
-    throw new Error(
-      `Node.js and npm are required on ${config.host} to run the Paseo daemon. ` +
-        `Install Node.js (https://nodejs.org) on the remote host and retry.`,
-    );
-  }
-
-  if (result.exitCode === 11) {
-    throw new Error(
-      `Failed to install Paseo on ${config.host}: ${result.stderr.trim() || result.stdout.trim() || "npm error"}`,
-    );
-  }
-
-  if (result.exitCode === 12) {
-    throw new Error(
-      `The Paseo daemon was launched on ${config.host} but did not become ready ` +
-        `on port ${config.remotePort} within 30s. ` +
-        `Check ${config.remoteHome}/daemon.log on the remote host.`,
-    );
-  }
-
-  throw new Error(
-    `Failed to ensure remote daemon on ${config.host}: ${result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`}`,
-  );
 }

--- a/packages/cli/src/ssh/remote-daemon.ts
+++ b/packages/cli/src/ssh/remote-daemon.ts
@@ -1,0 +1,224 @@
+import type { SshHostConfig } from "./ssh-host-config.js";
+import { sshExec, type SshExecResult } from "./ssh-process.js";
+
+/**
+ * Detect whether an sshExec failure is an SSH connection/auth error rather
+ * than a genuine command failure. SSH exits 255 for auth, connection refused,
+ * host key, and DNS failures — all of which should surface the SSH error, not
+ * a misleading "node not found" message.
+ */
+function isSshConnectionFailure(result: SshExecResult): boolean {
+  if (result.exitCode !== 255) return false;
+  const stderr = result.stderr.toLowerCase();
+  return (
+    stderr.includes("permission denied") ||
+    stderr.includes("connection refused") ||
+    stderr.includes("connection timed out") ||
+    stderr.includes("could not resolve hostname") ||
+    stderr.includes("host key verification failed") ||
+    stderr.includes("operation timed out") ||
+    stderr.includes("no route to host") ||
+    stderr.includes("network is unreachable")
+  );
+}
+
+function describeSshFailure(result: SshExecResult, host: string): string {
+  const stderr = result.stderr.trim();
+  if (stderr) return `SSH connection to ${host} failed: ${stderr}`;
+  return `SSH connection to ${host} failed (exit code ${result.exitCode}).`;
+}
+
+/** Throw a descriptive error if the sshExec result is an SSH connection/auth failure. */
+function assertNotSshFailure(result: SshExecResult, host: string): void {
+  if (isSshConnectionFailure(result)) {
+    throw new Error(describeSshFailure(result, host));
+  }
+}
+
+/**
+ * Expand a leading `~` to `$HOME` for use inside a remote command. The remote
+ * shell expands `$HOME` (even inside double quotes) but not `~` (inside quotes),
+ * so remote commands use `$HOME`-spelled paths.
+ */
+export function remoteExpandHome(p: string): string {
+  if (p === "~") return "$HOME";
+  if (p.startsWith("~/")) return `$HOME/${p.slice(2)}`;
+  return p;
+}
+
+/** Remote PASEO_HOME, with `~` expanded to `$HOME`. */
+export function remoteHomePath(config: SshHostConfig): string {
+  return remoteExpandHome(config.remoteHome);
+}
+
+/** Remote Paseo install directory, with `~` expanded to `$HOME`. */
+export function remoteInstallPath(config: SshHostConfig): string {
+  return remoteExpandHome(config.installDir);
+}
+
+/** Path to the installed `paseo` binary on the remote host. */
+export function remotePaseoBin(config: SshHostConfig): string {
+  return `"${remoteInstallPath(config)}/node_modules/.bin/paseo"`;
+}
+
+/**
+ * Build a single self-contained shell script that ensures a Paseo daemon is
+ * running on the remote host. The script:
+ *
+ * 1. Checks if the daemon port is already listening (exit 0)
+ * 2. Verifies node and npm are installed (exit 10 if not)
+ * 3. Installs @getpaseo/cli if missing (exit 11 on install failure)
+ * 4. Launches the daemon detached
+ * 5. Waits for the port to accept connections (exit 12 on timeout)
+ *
+ * Progress markers are written to stderr as `PROGRESS:<message>` lines so the
+ * caller can report status. The script runs in a single SSH call — one auth,
+ * one connection, no multiplexing needed.
+ *
+ * Exit codes: 0 = ready, 10 = node missing, 11 = install failed,
+ * 12 = not ready in time, 255 = SSH failure (from ssh itself).
+ */
+export function buildEnsureScript(config: SshHostConfig, version: string): string {
+  const home = remoteHomePath(config);
+  const installDir = remoteInstallPath(config);
+  const bin = `"${installDir}/node_modules/.bin/paseo"`;
+  const port = config.remotePort;
+  const spec = version.trim() ? `@getpaseo/cli@${version}` : "@getpaseo/cli";
+  const readyTimeoutMs = 30_000;
+  const pollIntervalMs = 500;
+  const maxPolls = Math.floor(readyTimeoutMs / pollIntervalMs);
+
+  // A node one-liner that exits 0 if the port accepts a connection, 1 otherwise.
+  const portCheck = `node -e 'const n=require("net");const s=n.connect({port:${port},host:"127.0.0.1"});s.on("connect",()=>{s.end();process.exit(0)});s.on("error",()=>process.exit(1));setTimeout(()=>{s.destroy();process.exit(1)},3000)'`;
+
+  return [
+    `# 1. Already running?`,
+    `${portCheck} && { echo "PROGRESS:Remote daemon is already running." >&2; exit 0; }`,
+    `# 2. Check node and npm`,
+    ``,
+    `node -v >/dev/null 2>&1 && npm -v >/dev/null 2>&1 || { echo "PROGRESS:Node.js and npm are required on ${config.host}." >&2; exit 10; }`,
+    ``,
+    `# 3. Install Paseo if missing`,
+    `if [ ! -x ${bin} ]; then`,
+    `  echo "PROGRESS:Installing Paseo ${version} into ${config.installDir} on ${config.host}…" >&2`,
+    `  mkdir -p "${installDir}"`,
+    `  npm install --prefix "${installDir}" "${spec}" || { echo "PROGRESS:Failed to install Paseo on ${config.host}." >&2; exit 11; }`,
+    `  echo "PROGRESS:Paseo installed on the remote host." >&2`,
+    `else`,
+    `  echo "PROGRESS:Paseo is already installed on the remote host." >&2`,
+    `fi`,
+    `# 4. Launch the daemon`,
+    `echo "PROGRESS:Launching the Paseo daemon on ${config.host}…" >&2`,
+    `mkdir -p "${home}"`,
+    `${bin} daemon start --home "${home}" --port ${port} --no-relay --no-mcp`,
+    ``,
+    `# 5. Wait for the port to accept connections`,
+    `echo "PROGRESS:Waiting for the remote daemon to become ready…" >&2`,
+    `i=0`,
+    `while [ $i -lt ${maxPolls} ]; do`,
+    `  ${portCheck} && { echo "PROGRESS:Remote daemon is ready." >&2; exit 0; }`,
+    `  sleep ${pollIntervalMs / 1000}`,
+    `  i=$((i + 1))`,
+    `done`,
+    `echo "PROGRESS:The Paseo daemon was launched on ${config.host} but did not become ready on port ${port}. Check ${config.remoteHome}/daemon.log on the remote host." >&2`,
+    `exit 12`,
+  ].join("\n");
+}
+
+export interface EnsureRemoteDaemonOptions {
+  config: SshHostConfig;
+  /** @getpaseo/cli version to install if Paseo is missing. */
+  version?: string;
+  /** Progress callback for user-facing status messages. */
+  onProgress?: (message: string) => void;
+  /** Override the ssh exec implementation (for tests). */
+  exec?: (command: string) => Promise<SshExecResult>;
+  /** Per-command timeout in milliseconds (default 120s; install may be slow). */
+  commandTimeoutMs?: number;
+  /** Path to an SSH_ASKPASS program for interactive password prompts. */
+  askpassPath?: string;
+  /** SSH ControlMaster socket path for connection multiplexing. */
+  controlPath?: string;
+  /** Allocate a PTY for SSH (terminal password prompts). */
+  tty?: boolean;
+}
+
+export interface EnsureRemoteDaemonResult {
+  /** True if Paseo was installed during this call. */
+  installed: boolean;
+  /** True if the daemon was launched during this call. */
+  launched: boolean;
+  /** True if the remote daemon port is accepting connections. */
+  ready: boolean;
+}
+
+const DEFAULT_COMMAND_TIMEOUT_MS = 300_000;
+
+/**
+ * Make sure a Paseo daemon is running on the remote host and accepting
+ * connections on {@link SshHostConfig.remotePort}. Makes a single SSH call
+ * with an inline script that checks, installs, launches, and waits — one auth,
+ * one connection.
+ */
+export async function ensureRemoteDaemon(
+  options: EnsureRemoteDaemonOptions,
+): Promise<EnsureRemoteDaemonResult> {
+  const { config, onProgress } = options;
+  const version = options.version ?? config.packageVersion ?? "latest";
+  const commandTimeoutMs = options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+  const exec =
+    options.exec ??
+    ((command: string) =>
+      sshExec(config, command, {
+        timeoutMs: commandTimeoutMs,
+        askpassPath: options.askpassPath,
+        controlPath: options.controlPath,
+        tty: options.tty,
+      }));
+
+  const progress = (message: string) => onProgress?.(message);
+
+  progress(`Ensuring remote daemon on ${config.host}:${config.remotePort}…`);
+
+  const script = buildEnsureScript(config, version);
+  const result = await exec(script);
+
+  // Parse PROGRESS: lines from stderr and forward them.
+  for (const line of result.stderr.split("\n")) {
+    const match = line.match(/^PROGRESS:(.*)$/);
+    if (match) {
+      progress(match[1]);
+    }
+  }
+
+  if (result.exitCode === 0) {
+    return { installed: false, launched: false, ready: true };
+  }
+
+  assertNotSshFailure(result, config.host);
+
+  if (result.exitCode === 10) {
+    throw new Error(
+      `Node.js and npm are required on ${config.host} to run the Paseo daemon. ` +
+        `Install Node.js (https://nodejs.org) on the remote host and retry.`,
+    );
+  }
+
+  if (result.exitCode === 11) {
+    throw new Error(
+      `Failed to install Paseo on ${config.host}: ${result.stderr.trim() || result.stdout.trim() || "npm error"}`,
+    );
+  }
+
+  if (result.exitCode === 12) {
+    throw new Error(
+      `The Paseo daemon was launched on ${config.host} but did not become ready ` +
+        `on port ${config.remotePort} within 30s. ` +
+        `Check ${config.remoteHome}/daemon.log on the remote host.`,
+    );
+  }
+
+  throw new Error(
+    `Failed to ensure remote daemon on ${config.host}: ${result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`}`,
+  );
+}

--- a/packages/cli/src/ssh/remote-daemon.ts
+++ b/packages/cli/src/ssh/remote-daemon.ts
@@ -92,17 +92,18 @@ export function buildEnsureScript(config: SshHostConfig, version: string): strin
   const portCheck = `node -e 'const n=require("net");const s=n.connect({port:${port},host:"127.0.0.1"});s.on("connect",()=>{s.end();process.exit(0)});s.on("error",()=>process.exit(1));setTimeout(()=>{s.destroy();process.exit(1)},3000)'`;
 
   return [
+    `ensure_daemon() {`,
     `# 1. Already running?`,
-    `${portCheck} && { echo "PROGRESS:Remote daemon is already running." >&2; exit 0; }`,
+    `${portCheck} && { echo "PROGRESS:Remote daemon is already running." >&2; return 0; }`,
     `# 2. Check node and npm`,
     ``,
-    `node -v >/dev/null 2>&1 && npm -v >/dev/null 2>&1 || { echo "PROGRESS:Node.js and npm are required on ${config.host}." >&2; exit 10; }`,
+    `node -v >/dev/null 2>&1 && npm -v >/dev/null 2>&1 || { echo "PROGRESS:Node.js and npm are required on ${config.host}." >&2; return 10; }`,
     ``,
     `# 3. Install Paseo if missing`,
     `if [ ! -x ${bin} ]; then`,
     `  echo "PROGRESS:Installing Paseo ${version} into ${config.installDir} on ${config.host}…" >&2`,
     `  mkdir -p "${installDir}"`,
-    `  npm install --prefix "${installDir}" "${spec}" || { echo "PROGRESS:Failed to install Paseo on ${config.host}." >&2; exit 11; }`,
+    `  npm install --prefix "${installDir}" "${spec}" || { echo "PROGRESS:Failed to install Paseo on ${config.host}." >&2; return 11; }`,
     `  echo "PROGRESS:Paseo installed on the remote host." >&2`,
     `else`,
     `  echo "PROGRESS:Paseo is already installed on the remote host." >&2`,
@@ -116,12 +117,14 @@ export function buildEnsureScript(config: SshHostConfig, version: string): strin
     `echo "PROGRESS:Waiting for the remote daemon to become ready…" >&2`,
     `i=0`,
     `while [ $i -lt ${maxPolls} ]; do`,
-    `  ${portCheck} && { echo "PROGRESS:Remote daemon is ready." >&2; exit 0; }`,
+    `  ${portCheck} && { echo "PROGRESS:Remote daemon is ready." >&2; return 0; }`,
     `  sleep ${pollIntervalMs / 1000}`,
     `  i=$((i + 1))`,
     `done`,
     `echo "PROGRESS:The Paseo daemon was launched on ${config.host} but did not become ready on port ${port}. Check ${config.remoteHome}/daemon.log on the remote host." >&2`,
-    `exit 12`,
+    `return 12`,
+    `}`,
+    `ensure_daemon`,
   ].join("\n");
 }
 
@@ -137,8 +140,6 @@ export interface EnsureRemoteDaemonOptions {
   commandTimeoutMs?: number;
   /** Path to an SSH_ASKPASS program for interactive password prompts. */
   askpassPath?: string;
-  /** SSH ControlMaster socket path for connection multiplexing. */
-  controlPath?: string;
   /** Allocate a PTY for SSH (terminal password prompts). */
   tty?: boolean;
 }
@@ -172,7 +173,6 @@ export async function ensureRemoteDaemon(
       sshExec(config, command, {
         timeoutMs: commandTimeoutMs,
         askpassPath: options.askpassPath,
-        controlPath: options.controlPath,
         tty: options.tty,
       }));
 

--- a/packages/cli/src/ssh/ssh-connection.ts
+++ b/packages/cli/src/ssh/ssh-connection.ts
@@ -1,9 +1,10 @@
 import { DaemonClient, type WebSocketLike } from "@getpaseo/client/internal/daemon-client";
 import { resolveSshHostConfig, type SshHostConfig } from "./ssh-host-config.js";
-import { SshTunnel, createTerminalAskpassScript, cleanupAskpassScript } from "./ssh-process.js";
+import { SshTunnel, createTerminalAskpassScript } from "./ssh-process.js";
 export { isSshHostUri } from "./ssh-host-config.js";
 import { buildEnsureScript } from "./remote-daemon.js";
 import { createNodeWebSocketFactory } from "../utils/client.js";
+import { resolveCliVersion } from "../version.js";
 
 export interface ConnectViaSshOptions {
   /** Connect timeout in milliseconds. */
@@ -12,7 +13,12 @@ export interface ConnectViaSshOptions {
   clientId: string;
   /** CLI version reported in the hello handshake. */
   appVersion: string;
-  /** @getpaseo/cli version to install on the remote if Paseo is missing. */
+  /**
+   * @getpaseo/cli version to install on the remote if Paseo is missing.
+   * Defaults to this CLI's own version so both ends run the same build; the
+   * remote falls back to the latest release when that version is not
+   * published, which is the normal case for a source checkout.
+   */
   version?: string;
   /** Progress callback for ensure/launch status. */
   onProgress?: (message: string) => void;
@@ -45,16 +51,22 @@ export async function connectViaSshConfig(
   config: SshHostConfig,
   options: ConnectViaSshOptions,
 ): Promise<DaemonClient> {
-  const version = options.version ?? config.packageVersion ?? "latest";
-  const askpassPath = createTerminalAskpassScript();
-  process.once("exit", () => cleanupAskpassScript(askpassPath));
+  const version = options.version ?? config.packageVersion ?? resolveCliVersion();
+  const askpass = createTerminalAskpassScript();
   const ensureScript = buildEnsureScript(config, version);
 
-  const tunnel = await SshTunnel.open(config, config.remotePort, {
-    ensureScript,
-    askpassPath,
-    onProgress: options.onProgress,
-  });
+  let tunnel: SshTunnel;
+  try {
+    tunnel = await SshTunnel.open(config, config.remotePort, {
+      ensureScript,
+      askpassPath: askpass.path,
+      ...(options.onProgress ? { onProgress: options.onProgress } : {}),
+    });
+  } finally {
+    // SSH has either authenticated or given up by now; the script is no longer
+    // needed and should not outlive a failed connect.
+    askpass.cleanup();
+  }
 
   const url = `ws://127.0.0.1:${tunnel.localPort}/ws`;
   const webSocketFactory = options.webSocketFactory ?? createNodeWebSocketFactory();
@@ -68,7 +80,9 @@ export async function connectViaSshConfig(
     webSocketFactory: (
       target: string,
       wsOptions?: { headers?: Record<string, string>; protocols?: string[] },
-    ) => webSocketFactory(target, { headers: wsOptions?.headers }),
+    ) => webSocketFactory(target, wsOptions),
+    // Reconnecting is pointless once the tunnel is gone: the local port stops
+    // being served and no retry can bring it back.
     reconnect: { enabled: false },
   });
 

--- a/packages/cli/src/ssh/ssh-connection.ts
+++ b/packages/cli/src/ssh/ssh-connection.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DaemonClient, type WebSocketLike } from "@getpaseo/client/internal/daemon-client";
+import {
+  resolveSshHostConfig,
+  type SshHostConfig,
+} from "./ssh-host-config.js";
+import { SshTunnel } from "./ssh-process.js";
+export { isSshHostUri } from "./ssh-host-config.js";
+import { ensureRemoteDaemon } from "./remote-daemon.js";
+import { createNodeWebSocketFactory } from "../utils/client.js";
+
+export interface ConnectViaSshOptions {
+  /** Connect timeout in milliseconds. */
+  timeoutMs?: number;
+  /** CLI client id for the hello handshake. */
+  clientId: string;
+  /** CLI version reported in the hello handshake. */
+  appVersion: string;
+  /** @getpaseo/cli version to install on the remote if Paseo is missing. */
+  version?: string;
+  /** Progress callback for ensure/launch status. */
+  onProgress?: (message: string) => void;
+  /** Override the WebSocket factory (for tests). */
+  webSocketFactory?: (url: string, options?: { headers?: Record<string, string> }) => WebSocketLike;
+}
+
+/**
+ * Connect to a remote Paseo daemon over SSH. Resolves the {@link SshHostConfig}
+ * from an `ssh://` URI, ensures a daemon is running on the remote host
+ * (installing Paseo first if needed), opens an SSH local port-forward, and
+ * returns a connected {@link DaemonClient} whose traffic is tunneled.
+ *
+ * The tunnel is reaped when the client is closed or the process exits.
+ */
+export async function connectViaSsh(
+  host: string,
+  options: ConnectViaSshOptions,
+): Promise<DaemonClient> {
+  const config = resolveSshHostConfig(host);
+  if (!config) {
+    throw new Error(`Not an SSH host URI: ${host}`);
+  }
+  return connectViaSshConfig(config, options);
+}
+
+function sshControlPath(config: { host: string; port: number; user?: string }): string {
+  const key = `${config.user ?? ""}@${config.host}:${config.port}`;
+  const hash = createHash("sha256").update(key).digest("hex").slice(0, 12);
+  return path.join(tmpdir(), `paseo-ssh-${hash}.sock`);
+}
+
+/** Connect using an already-resolved {@link SshHostConfig}. */
+export async function connectViaSshConfig(
+  config: SshHostConfig,
+  options: ConnectViaSshOptions,
+): Promise<DaemonClient> {
+  const tty = process.stdin.isTTY === true;
+  const controlPath = sshControlPath(config);
+  const sshOptions = { controlPath, ...(tty ? { tty } : {}) };
+
+  await ensureRemoteDaemon({
+    config,
+    version: options.version,
+    onProgress: options.onProgress,
+    ...sshOptions,
+  });
+
+  const tunnel = await SshTunnel.open(config, config.remotePort, sshOptions);
+
+  const url = `ws://127.0.0.1:${tunnel.localPort}/ws`;
+  const webSocketFactory = options.webSocketFactory ?? createNodeWebSocketFactory();
+
+  const client = new DaemonClient({
+    url,
+    clientId: options.clientId,
+    clientType: "cli",
+    appVersion: options.appVersion,
+    connectTimeoutMs: options.timeoutMs,
+    webSocketFactory: (
+      target: string,
+      wsOptions?: { headers?: Record<string, string>; protocols?: string[] },
+    ) => webSocketFactory(target, { headers: wsOptions?.headers }),
+    reconnect: { enabled: false },
+  });
+
+  // Reap the tunnel when the client is closed. The tunnel also registers its
+  // own process-exit handler, so short-lived commands that never call close()
+  // still clean up.
+  const unsubscribe = client.subscribeConnectionStatus((state) => {
+    if (state.status === "disposed") {
+      tunnel.close();
+      unsubscribe();
+    }
+  });
+
+  try {
+    await client.connect();
+  } catch (error) {
+    tunnel.close();
+    throw error;
+  }
+
+  return client;
+}

--- a/packages/cli/src/ssh/ssh-connection.ts
+++ b/packages/cli/src/ssh/ssh-connection.ts
@@ -1,14 +1,8 @@
-import { createHash } from "node:crypto";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import { DaemonClient, type WebSocketLike } from "@getpaseo/client/internal/daemon-client";
-import {
-  resolveSshHostConfig,
-  type SshHostConfig,
-} from "./ssh-host-config.js";
-import { SshTunnel } from "./ssh-process.js";
+import { resolveSshHostConfig, type SshHostConfig } from "./ssh-host-config.js";
+import { SshTunnel, createTerminalAskpassScript, cleanupAskpassScript } from "./ssh-process.js";
 export { isSshHostUri } from "./ssh-host-config.js";
-import { ensureRemoteDaemon } from "./remote-daemon.js";
+import { buildEnsureScript } from "./remote-daemon.js";
 import { createNodeWebSocketFactory } from "../utils/client.js";
 
 export interface ConnectViaSshOptions {
@@ -28,9 +22,10 @@ export interface ConnectViaSshOptions {
 
 /**
  * Connect to a remote Paseo daemon over SSH. Resolves the {@link SshHostConfig}
- * from an `ssh://` URI, ensures a daemon is running on the remote host
- * (installing Paseo first if needed), opens an SSH local port-forward, and
- * returns a connected {@link DaemonClient} whose traffic is tunneled.
+ * from an `ssh://` URI, opens a single SSH connection that both ensures a
+ * daemon is running on the remote host (installing Paseo first if needed) and
+ * forwards the daemon port to a local port. Returns a connected
+ * {@link DaemonClient} whose traffic is tunneled.
  *
  * The tunnel is reaped when the client is closed or the process exits.
  */
@@ -45,29 +40,21 @@ export async function connectViaSsh(
   return connectViaSshConfig(config, options);
 }
 
-function sshControlPath(config: { host: string; port: number; user?: string }): string {
-  const key = `${config.user ?? ""}@${config.host}:${config.port}`;
-  const hash = createHash("sha256").update(key).digest("hex").slice(0, 12);
-  return path.join(tmpdir(), `paseo-ssh-${hash}.sock`);
-}
-
 /** Connect using an already-resolved {@link SshHostConfig}. */
 export async function connectViaSshConfig(
   config: SshHostConfig,
   options: ConnectViaSshOptions,
 ): Promise<DaemonClient> {
-  const tty = process.stdin.isTTY === true;
-  const controlPath = sshControlPath(config);
-  const sshOptions = { controlPath, ...(tty ? { tty } : {}) };
+  const version = options.version ?? config.packageVersion ?? "latest";
+  const askpassPath = createTerminalAskpassScript();
+  process.once("exit", () => cleanupAskpassScript(askpassPath));
+  const ensureScript = buildEnsureScript(config, version);
 
-  await ensureRemoteDaemon({
-    config,
-    version: options.version,
+  const tunnel = await SshTunnel.open(config, config.remotePort, {
+    ensureScript,
+    askpassPath,
     onProgress: options.onProgress,
-    ...sshOptions,
   });
-
-  const tunnel = await SshTunnel.open(config, config.remotePort, sshOptions);
 
   const url = `ws://127.0.0.1:${tunnel.localPort}/ws`;
   const webSocketFactory = options.webSocketFactory ?? createNodeWebSocketFactory();

--- a/packages/cli/src/ssh/ssh-host-config.ts
+++ b/packages/cli/src/ssh/ssh-host-config.ts
@@ -1,4 +1,9 @@
-import { SshHostConnectionSchema } from "@getpaseo/protocol/host-connection-schema";
+import {
+  SshHostConnectionSchema,
+  DEFAULT_SSH_PORT,
+} from "@getpaseo/protocol/host-connection-schema";
+
+export { DEFAULT_SSH_PORT };
 
 /**
  * A remote SSH host. The CLI tunnels daemon WebSocket traffic through an
@@ -12,8 +17,11 @@ export interface SshHostConfig {
   label: string;
   /** Remote hostname or IP address. */
   host: string;
-  /** SSH port (default 22). */
-  port: number;
+  /**
+   * SSH port. Undefined means "not specified", which lets `ssh` apply its own
+   * default or a `Port` directive from the user's `~/.ssh/config`.
+   */
+  port?: number;
   /** SSH user (optional — falls back to ssh config or current user). */
   user?: string;
   /** Remote daemon port to forward to (default 6767). */
@@ -22,7 +30,7 @@ export interface SshHostConfig {
   remoteHome: string;
   /** Remote Paseo install directory (default ~/.paseo/cli). */
   installDir: string;
-  /** Optional @getpaseo/cli version to install (default: the local CLI version). */
+  /** @getpaseo/cli version to install if Paseo is missing on the remote host. */
   packageVersion?: string;
 }
 
@@ -33,7 +41,6 @@ const SSH_DEFAULTS = SshHostConnectionSchema.parse({
   user: "defaults",
 });
 
-export const DEFAULT_SSH_PORT = SSH_DEFAULTS.port;
 export const DEFAULT_REMOTE_PORT = SSH_DEFAULTS.remotePort;
 export const DEFAULT_REMOTE_HOME = SSH_DEFAULTS.remoteHome;
 export const DEFAULT_INSTALL_DIR = SSH_DEFAULTS.installDir;
@@ -71,7 +78,8 @@ export function normalizeSshHostConfig(
   if (!host) throw new Error("SSH host is required");
   const user = input.user?.trim() || undefined;
 
-  const port = validatePort(input.port ?? DEFAULT_SSH_PORT, "SSH port");
+  // Left undefined when unspecified so `ssh` and ~/.ssh/config decide.
+  const port = input.port === undefined ? undefined : validatePort(input.port, "SSH port");
   const remotePort = validatePort(input.remotePort ?? DEFAULT_REMOTE_PORT, "remote daemon port");
   const label = (input.label ?? "").trim() || sshHostLabel(user, host);
   const remoteHome = (input.remoteHome ?? "").trim() || DEFAULT_REMOTE_HOME;
@@ -82,7 +90,7 @@ export function normalizeSshHostConfig(
     id: input.id,
     label,
     host,
-    port,
+    ...(port !== undefined ? { port } : {}),
     ...(user ? { user } : {}),
     remotePort,
     remoteHome,
@@ -104,10 +112,23 @@ export interface ParsedSshHostUri {
  *
  * Query params: remotePort, remoteHome, installDir, label, version.
  */
+/** Parse a decimal port, rejecting NaN and anything out of range. */
+function parsePort(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
+}
+
 function parseSshUriOverrides(params: URLSearchParams): Partial<SshHostConfig> {
   const overrides: Partial<SshHostConfig> = {};
   const remotePortParam = params.get("remotePort");
-  if (remotePortParam) overrides.remotePort = Number(remotePortParam);
+  if (remotePortParam) {
+    const remotePort = parsePort(remotePortParam);
+    if (remotePort === null) {
+      throw new Error(`Invalid remotePort in ssh:// URI: ${remotePortParam}`);
+    }
+    overrides.remotePort = remotePort;
+  }
   const remoteHome = params.get("remoteHome");
   if (remoteHome) overrides.remoteHome = remoteHome;
   const installDir = params.get("installDir");
@@ -126,17 +147,19 @@ function splitHostPort(hostPort: string): { host: string; port?: number } | null
     if (close < 0) return null;
     const host = hostPort.slice(1, close);
     const after = hostPort.slice(close + 1);
-    if (after.startsWith(":")) {
-      return { host, port: Number(after.slice(1)) };
-    }
-    return { host };
+    if (!after) return { host };
+    if (!after.startsWith(":")) return null;
+    const port = parsePort(after.slice(1));
+    return port === null ? null : { host, port };
   }
   const lastColon = hostPort.lastIndexOf(":");
   if (lastColon >= 0) {
-    const maybePort = Number(hostPort.slice(lastColon + 1));
-    if (Number.isInteger(maybePort) && maybePort > 0) {
-      return { host: hostPort.slice(0, lastColon), port: maybePort };
-    }
+    const port = parsePort(hostPort.slice(lastColon + 1));
+    // A trailing colon with a non-numeric suffix is a typo, not a hostname —
+    // treating "host:2222x" as a hostname would fail much later and less
+    // clearly than rejecting it here.
+    if (port === null) return null;
+    return { host: hostPort.slice(0, lastColon), port };
   }
   return { host: hostPort };
 }

--- a/packages/cli/src/ssh/ssh-host-config.ts
+++ b/packages/cli/src/ssh/ssh-host-config.ts
@@ -1,0 +1,188 @@
+import { SshHostConnectionSchema } from "@getpaseo/protocol/host-connection-schema";
+
+/**
+ * A remote SSH host. The CLI tunnels daemon WebSocket traffic through an
+ * SSH local port-forward to {@link remotePort} on the remote host, after making
+ * sure a Paseo daemon is running there (installing Paseo first if needed).
+ */
+export interface SshHostConfig {
+  /** Stable slug identifier (lowercase alphanumerics and hyphens). */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  /** Remote hostname or IP address. */
+  host: string;
+  /** SSH port (default 22). */
+  port: number;
+  /** SSH user (optional — falls back to ssh config or current user). */
+  user?: string;
+  /** Remote daemon port to forward to (default 6767). */
+  remotePort: number;
+  /** Remote PASEO_HOME (default ~/.paseo). */
+  remoteHome: string;
+  /** Remote Paseo install directory (default ~/.paseo/cli). */
+  installDir: string;
+  /** Optional @getpaseo/cli version to install (default: the local CLI version). */
+  packageVersion?: string;
+}
+
+const SSH_DEFAULTS = SshHostConnectionSchema.parse({
+  id: "defaults",
+  type: "ssh",
+  host: "defaults",
+  user: "defaults",
+});
+
+export const DEFAULT_SSH_PORT = SSH_DEFAULTS.port;
+export const DEFAULT_REMOTE_PORT = SSH_DEFAULTS.remotePort;
+export const DEFAULT_REMOTE_HOME = SSH_DEFAULTS.remoteHome;
+export const DEFAULT_INSTALL_DIR = SSH_DEFAULTS.installDir;
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+export function isValidSshHostId(id: string): boolean {
+  return ID_PATTERN.test(id);
+}
+
+function validatePort(value: number, label: string): number {
+  if (!Number.isInteger(value) || value < 1 || value > 65535) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return value;
+}
+
+function sshHostLabel(user: string | undefined, host: string): string {
+  return user ? `${user}@${host}` : host;
+}
+
+/**
+ * Validate and apply defaults to a raw SSH host config record. Throws on invalid
+ * input so callers surface a clear error rather than silently persisting junk.
+ */
+export function normalizeSshHostConfig(
+  input: Partial<SshHostConfig> & { id: string; host: string },
+): SshHostConfig {
+  if (!isValidSshHostId(input.id)) {
+    throw new Error(
+      `Invalid SSH host id "${input.id}": use lowercase alphanumerics and hyphens (max 63 chars).`,
+    );
+  }
+  const host = input.host.trim();
+  if (!host) throw new Error("SSH host is required");
+  const user = input.user?.trim() || undefined;
+
+  const port = validatePort(input.port ?? DEFAULT_SSH_PORT, "SSH port");
+  const remotePort = validatePort(input.remotePort ?? DEFAULT_REMOTE_PORT, "remote daemon port");
+  const label = (input.label ?? "").trim() || sshHostLabel(user, host);
+  const remoteHome = (input.remoteHome ?? "").trim() || DEFAULT_REMOTE_HOME;
+  const installDir = (input.installDir ?? "").trim() || DEFAULT_INSTALL_DIR;
+  const packageVersion = input.packageVersion?.trim() || undefined;
+
+  return {
+    id: input.id,
+    label,
+    host,
+    port,
+    ...(user ? { user } : {}),
+    remotePort,
+    remoteHome,
+    installDir,
+    ...(packageVersion ? { packageVersion } : {}),
+  };
+}
+
+/** A parsed `ssh://` URI — always an inline host. */
+export interface ParsedSshHostUri {
+  kind: "inline";
+  config: SshHostConfig;
+}
+
+/**
+ * Parse an `ssh://` URI into a structured form. Returns null for non-ssh URIs.
+ *
+ * Form: `ssh://[user@]host[:port]` — inline ad-hoc host with optional query params.
+ *
+ * Query params: remotePort, remoteHome, installDir, label, version.
+ */
+function parseSshUriOverrides(params: URLSearchParams): Partial<SshHostConfig> {
+  const overrides: Partial<SshHostConfig> = {};
+  const remotePortParam = params.get("remotePort");
+  if (remotePortParam) overrides.remotePort = Number(remotePortParam);
+  const remoteHome = params.get("remoteHome");
+  if (remoteHome) overrides.remoteHome = remoteHome;
+  const installDir = params.get("installDir");
+  if (installDir) overrides.installDir = installDir;
+  const label = params.get("label");
+  if (label) overrides.label = label;
+  const version = params.get("version");
+  if (version) overrides.packageVersion = version;
+  return overrides;
+}
+
+/** Split a `host[:port]` authority into host and optional port (IPv6-aware). */
+function splitHostPort(hostPort: string): { host: string; port?: number } | null {
+  if (hostPort.startsWith("[")) {
+    const close = hostPort.indexOf("]");
+    if (close < 0) return null;
+    const host = hostPort.slice(1, close);
+    const after = hostPort.slice(close + 1);
+    if (after.startsWith(":")) {
+      return { host, port: Number(after.slice(1)) };
+    }
+    return { host };
+  }
+  const lastColon = hostPort.lastIndexOf(":");
+  if (lastColon >= 0) {
+    const maybePort = Number(hostPort.slice(lastColon + 1));
+    if (Number.isInteger(maybePort) && maybePort > 0) {
+      return { host: hostPort.slice(0, lastColon), port: maybePort };
+    }
+  }
+  return { host: hostPort };
+}
+
+export function parseSshHostUri(uri: string): ParsedSshHostUri | null {
+  const trimmed = uri.trim();
+  if (!trimmed.startsWith("ssh://")) return null;
+
+  const rest = trimmed.slice("ssh://".length);
+  const queryIndex = rest.indexOf("?");
+  const authority = queryIndex >= 0 ? rest.slice(0, queryIndex) : rest;
+  const query = queryIndex >= 0 ? rest.slice(queryIndex + 1) : "";
+  const params = new URLSearchParams(query);
+
+  const overrides = parseSshUriOverrides(params);
+
+  // `ssh://[user@]host[:port]` is an inline host.
+  const atIndex = authority.lastIndexOf("@");
+  const user = atIndex >= 0 ? authority.slice(0, atIndex) || undefined : undefined;
+  const hostPort = atIndex >= 0 ? authority.slice(atIndex + 1) : authority;
+  if (!hostPort) return null;
+
+  const split = splitHostPort(hostPort);
+  if (!split) return null;
+  const { host, port } = split;
+
+  const config = normalizeSshHostConfig({
+    id: (user ? `${user}@${host}` : host).replace(/[^a-z0-9-]/gi, "-").toLowerCase(),
+    host,
+    ...(user ? { user } : {}),
+    ...(port ? { port } : {}),
+    ...overrides,
+  });
+
+  return { kind: "inline", config };
+}
+
+export function isSshHostUri(uri: string): boolean {
+  return typeof uri === "string" && uri.trim().startsWith("ssh://");
+}
+
+/**
+ * Resolve an `ssh://` URI to a concrete config. Returns null for non-ssh URIs.
+ */
+export function resolveSshHostConfig(uri: string): SshHostConfig | null {
+  const parsed = parseSshHostUri(uri);
+  if (!parsed) return null;
+  return parsed.config;
+}

--- a/packages/cli/src/ssh/ssh-process.ts
+++ b/packages/cli/src/ssh/ssh-process.ts
@@ -1,0 +1,309 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { createServer, createConnection, type Server, type Socket } from "node:net";
+import { writeFileSync, chmodSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { SshHostConfig } from "./ssh-host-config.js";
+
+/**
+ * Base SSH arguments. When `askpassPath` is set, BatchMode is dropped so SSH
+ * can prompt for a password via the SSH_ASKPASS program. Without it, BatchMode
+ * ensures auth fails fast instead of hanging on a prompt the user can't see.
+ * When `controlPath` is set, SSH connection multiplexing (ControlMaster) is
+ * enabled so multiple sshExec calls and the tunnel share a single TCP
+ * connection — the user authenticates once, not once per command.
+ */
+export function buildSshBaseArgs(
+  config: SshHostConfig,
+  options?: { askpassPath?: string; controlPath?: string; tty?: boolean },
+): string[] {
+  const args = [
+    "-p",
+    String(config.port),
+    "-o",
+    "StrictHostKeyChecking=accept-new",
+    "-o",
+    "ConnectTimeout=10",
+  ];
+  if (options?.controlPath) {
+    args.push(
+      "-o",
+      "ControlMaster=auto",
+      "-o",
+      `ControlPath=${options.controlPath}`,
+      "-o",
+      "ControlPersist=300",
+    );
+  }
+  if (!options?.askpassPath && !options?.tty) {
+    args.push("-o", "BatchMode=yes");
+  }
+  args.push(config.user ? `${config.user}@${config.host}` : config.host);
+  return args;
+}
+
+export interface SshExecOptions {
+  /** Per-command timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Path to an SSH_ASKPASS program. When set, BatchMode is dropped. */
+  askpassPath?: string;
+  /** SSH ControlMaster socket path for connection multiplexing. */
+  controlPath?: string;
+  /** Allocate a PTY for the SSH process (terminal password prompts). */
+  tty?: boolean;
+}
+
+export interface SshExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+}
+
+/**
+ * Run a command on the remote host via `ssh`. The command string is passed as a
+ * single argument and interpreted by the remote user's login shell, so `$HOME`
+ * and `~` expand remotely. Resolves with the captured result (never throws on
+ * non-zero exit — callers inspect {@link SshExecResult.exitCode}).
+ */
+export function sshExec(
+  config: SshHostConfig,
+  command: string,
+  options?: SshExecOptions,
+): Promise<SshExecResult> {
+  return new Promise((resolve) => {
+    const sshArgs = [
+      ...buildSshBaseArgs(config, {
+        askpassPath: options?.askpassPath,
+        controlPath: options?.controlPath,
+        tty: options?.tty,
+      }),
+      ...(options?.tty ? ["-tt"] : []),
+      command,
+    ];
+    const spawnOpts: SpawnOptions = {
+      stdio: options?.tty ? "inherit" : ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    };
+    const child = spawn("ssh", sshArgs, spawnOpts);
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let timedOut = false;
+    let settled = false;
+
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      callback();
+    };
+
+    const timer =
+      options?.timeoutMs && options.timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGTERM");
+          }, options.timeoutMs)
+        : null;
+
+    let errored: string | null = null;
+    child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+    child.on("error", (error) => {
+      errored = error.message;
+    });
+    child.once("close", (code, signal) => {
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      settle(() => {
+        resolve({
+          stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+          stderr: errored ? `${stderr}${errored}` : stderr,
+          exitCode: code,
+          signal,
+          timedOut,
+        });
+      });
+    });
+  });
+}
+
+/** Acquire a free ephemeral TCP port by briefly listening on :0. */
+export function findFreeLocalPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server: Server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/** Poll a local TCP port until it accepts a connection or times out. */
+export function waitForLocalPort(
+  port: number,
+  options?: { timeoutMs?: number; intervalMs?: number },
+): Promise<boolean> {
+  const timeoutMs = options?.timeoutMs ?? 15_000;
+  const intervalMs = options?.intervalMs ?? 200;
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve) => {
+    const attempt = () => {
+      const socket: Socket = createConnection({ port, host: "127.0.0.1" });
+      const cleanup = () => {
+        socket.removeAllListeners();
+        socket.destroy();
+      };
+      socket.on("connect", () => {
+        cleanup();
+        resolve(true);
+      });
+      socket.on("error", () => {
+        cleanup();
+        if (Date.now() >= deadline) {
+          resolve(false);
+        } else {
+          setTimeout(attempt, intervalMs);
+        }
+      });
+    };
+    attempt();
+  });
+}
+
+/**
+ * An SSH local port-forward (`ssh -L`) kept open for the life of a tunneled
+ * daemon connection. The tunnel is unref'd so it does not keep the Node event
+ * loop alive on its own; {@link close} kills it (also registered on process
+ * exit) so no orphaned `ssh` processes are left behind.
+ */
+export class SshTunnel {
+  private constructor(
+    private readonly child: ChildProcess,
+    readonly localPort: number,
+    readonly remotePort: number,
+  ) {
+    child.unref();
+  }
+
+  /**
+   * `127.0.0.1:<remotePort>`. Resolves once the local port accepts connections.
+   */
+  static async open(
+    config: SshHostConfig,
+    remotePort: number,
+    options?: {
+      localPort?: number;
+      readyTimeoutMs?: number;
+      askpassPath?: string;
+      controlPath?: string;
+      tty?: boolean;
+    },
+  ): Promise<SshTunnel> {
+    const localPort = options?.localPort ?? (await findFreeLocalPort());
+    const sshBaseArgs = buildSshBaseArgs(config, {
+      askpassPath: options?.askpassPath,
+      controlPath: options?.controlPath,
+      tty: options?.tty,
+    });
+    const args = [
+      "-L",
+      `${localPort}:127.0.0.1:${remotePort}`,
+      "-N",
+      "-o",
+      "ExitOnForwardFailure=yes",
+      ...sshBaseArgs,
+    ];
+    const spawnOpts: SpawnOptions = {
+      stdio: options?.tty ? "inherit" : ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    };
+    if (options?.askpassPath) {
+      spawnOpts.env = {
+        ...process.env,
+        SSH_ASKPASS: options.askpassPath,
+        SSH_ASKPASS_REQUIRE: "force",
+        DISPLAY: process.env.DISPLAY ?? ":0",
+      };
+    }
+    const child = spawn("ssh", args, spawnOpts);
+
+    const ready = waitForLocalPort(localPort, {
+      timeoutMs: options?.readyTimeoutMs ?? 15_000,
+    });
+
+    // If ssh dies before the port opens, surface its stderr.
+    const exited = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+      child.once("error", () => resolve(null));
+    });
+
+    const race = await Promise.race([
+      ready.then((ok) => ({ ok, code: null as number | null })),
+      exited.then((code) => ({ ok: false, code })),
+    ]);
+
+    if (!race.ok) {
+      const stderr = child.stderr?.read()?.toString("utf8") ?? "";
+      child.kill("SIGKILL");
+      if (race.code !== null) {
+        throw new Error(
+          `SSH tunnel exited (code ${race.code}) before the port forward opened.${stderr ? ` ${stderr.trim()}` : ""}`,
+        );
+      }
+      throw new Error(
+        `SSH tunnel did not become ready on local port ${localPort} within the timeout.${stderr ? ` ${stderr.trim()}` : ""}`,
+      );
+    }
+
+    const tunnel = new SshTunnel(child, localPort, remotePort);
+    process.once("exit", () => tunnel.close());
+    return tunnel;
+  }
+
+  close(): void {
+    if (!this.child.killed) {
+      this.child.kill("SIGTERM");
+      const child = this.child;
+      const killTimer = setTimeout(() => {
+        if (!child.killed) child.kill("SIGKILL");
+      }, 2_000);
+      killTimer.unref();
+      this.child.once("close", () => clearTimeout(killTimer));
+    }
+  }
+}
+
+/**
+ * Create a temporary SSH_ASKPASS script that shows a native OS password
+ * dialog. SSH calls this program (with the prompt as argv[1]) when it needs
+ * a password and no tty is available. The password goes to stdout and is
+ * never stored. Returns the script path; call `cleanupAskpassScript` to
+ * remove it.
+ */
+export function createAskpassScript(): string {
+  const scriptPath = path.join(tmpdir(), `paseo-askpass-${process.pid}.sh`);
+  // macOS uses osascript; Linux tries zenity then kdialog.
+  const script = `#!/bin/sh
+if [ "$(uname)" = "Darwin" ]; then
+  osascript -e 'display dialog "$1" default answer "" with hidden answer' -e 'text returned of result' 2>/dev/null
+else
+  zenity --password --title="$1" 2>/dev/null || kdialog --password "$1" 2>/dev/null
+fi
+`;
+  writeFileSync(scriptPath, script, { mode: 0o700 });
+  chmodSync(scriptPath, 0o700);
+  return scriptPath;
+}
+
+/** Remove the temporary askpass script. */
+export function cleanupAskpassScript(scriptPath: string): void {
+  try {
+    unlinkSync(scriptPath);
+  } catch {
+    // Best-effort cleanup.
+  }
+}

--- a/packages/cli/src/ssh/ssh-process.ts
+++ b/packages/cli/src/ssh/ssh-process.ts
@@ -1,118 +1,64 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { createServer, createConnection, type Server, type Socket } from "node:net";
-import { writeFileSync, chmodSync, unlinkSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { writeFileSync, chmodSync, rmSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { SshHostConfig } from "./ssh-host-config.js";
+import {
+  ASKPASS_CANCELLED_MARKER,
+  PROGRESS_MARKER,
+  READY_MARKER,
+  REMOTE_SHELL_COMMAND,
+  describeEnsureFailure,
+  describeSshFailure,
+} from "./remote-daemon.js";
+
+/** Keep the connection alive across NAT timeouts and detect a dead peer. */
+const SERVER_ALIVE_INTERVAL_SECONDS = 15;
+const SERVER_ALIVE_COUNT_MAX = 3;
+
+/** Cap retained stderr so a chatty `npm install` cannot grow without bound. */
+const MAX_STDERR_BYTES = 16_384;
 
 /**
- * Base SSH arguments. When `askpassPath` is set, BatchMode is dropped so SSH
- * can prompt for a password via the SSH_ASKPASS program. Without it, BatchMode
- * ensures auth fails fast instead of hanging on a prompt the user can't see.
- * When `tty` is set, a PTY is allocated (`-tt`) for interactive password
- * prompts directly on the terminal.
+ * Base SSH arguments.
+ *
+ * `-p` is only passed when the port was set explicitly: passing it
+ * unconditionally would override a `Port` directive the user configured for
+ * this host in `~/.ssh/config`. Everything else in their SSH config
+ * (`IdentityFile`, `ProxyJump`, `User`, ...) applies as usual.
+ *
+ * When `askpassPath` is set, BatchMode is dropped so SSH can prompt for a
+ * password via the SSH_ASKPASS program. Without it, BatchMode makes auth fail
+ * fast instead of hanging on a prompt the user cannot see.
  */
 export function buildSshBaseArgs(
   config: SshHostConfig,
   options?: { askpassPath?: string; tty?: boolean },
 ): string[] {
-  const args = [
-    "-p",
-    String(config.port),
+  const args: string[] = [];
+  if (config.port !== undefined) {
+    args.push("-p", String(config.port));
+  }
+  args.push(
     "-o",
     "StrictHostKeyChecking=accept-new",
     "-o",
     "ConnectTimeout=10",
-  ];
+    "-o",
+    `ServerAliveInterval=${SERVER_ALIVE_INTERVAL_SECONDS}`,
+    "-o",
+    `ServerAliveCountMax=${SERVER_ALIVE_COUNT_MAX}`,
+  );
   if (!options?.askpassPath && !options?.tty) {
     args.push("-o", "BatchMode=yes");
   }
+  // Note: SSH's default of 3 password attempts is left alone on purpose, so a
+  // typo is retryable. A *cancelled* prompt is handled out of band — the
+  // askpass program reports it via ASKPASS_CANCELLED_MARKER and the tunnel
+  // tears the connection down at once, rather than being limited to one try.
   args.push(config.user ? `${config.user}@${config.host}` : config.host);
   return args;
-}
-
-export interface SshExecOptions {
-  /** Per-command timeout in milliseconds. */
-  timeoutMs?: number;
-  /** Path to an SSH_ASKPASS program. When set, BatchMode is dropped. */
-  askpassPath?: string;
-  /** Allocate a PTY for the SSH process (terminal password prompts). */
-  tty?: boolean;
-}
-
-export interface SshExecResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number | null;
-  signal: NodeJS.Signals | null;
-  timedOut: boolean;
-}
-
-/**
- * Run a command on the remote host via `ssh`. The command string is passed as a
- * single argument and interpreted by the remote user's login shell, so `$HOME`
- * and `~` expand remotely. Resolves with the captured result (never throws on
- * non-zero exit — callers inspect {@link SshExecResult.exitCode}).
- */
-export function sshExec(
-  config: SshHostConfig,
-  command: string,
-  options?: SshExecOptions,
-): Promise<SshExecResult> {
-  return new Promise((resolve) => {
-    const sshArgs = [
-      ...buildSshBaseArgs(config, {
-        askpassPath: options?.askpassPath,
-        tty: options?.tty,
-      }),
-      ...(options?.tty ? ["-tt"] : []),
-      command,
-    ];
-    const spawnOpts: SpawnOptions = {
-      stdio: options?.tty ? "inherit" : ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-    };
-    const child = spawn("ssh", sshArgs, spawnOpts);
-
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
-    let timedOut = false;
-    let settled = false;
-
-    const settle = (callback: () => void) => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      callback();
-    };
-
-    const timer =
-      options?.timeoutMs && options.timeoutMs > 0
-        ? setTimeout(() => {
-            timedOut = true;
-            child.kill("SIGTERM");
-          }, options.timeoutMs)
-        : null;
-
-    let errored: string | null = null;
-    child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
-    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
-    child.on("error", (error) => {
-      errored = error.message;
-    });
-    child.once("close", (code, signal) => {
-      const stderr = Buffer.concat(stderrChunks).toString("utf8");
-      settle(() => {
-        resolve({
-          stdout: Buffer.concat(stdoutChunks).toString("utf8"),
-          stderr: errored ? `${stderr}${errored}` : stderr,
-          exitCode: code,
-          signal,
-          timedOut,
-        });
-      });
-    });
-  });
 }
 
 /** Acquire a free ephemeral TCP port by briefly listening on :0. */
@@ -128,246 +74,319 @@ export function findFreeLocalPort(): Promise<number> {
   });
 }
 
-/** Poll a local TCP port until it accepts a connection or times out. */
-export function waitForLocalPort(
-  port: number,
-  options?: { timeoutMs?: number; intervalMs?: number },
-): Promise<boolean> {
-  const timeoutMs = options?.timeoutMs ?? 15_000;
-  const intervalMs = options?.intervalMs ?? 200;
-  const deadline = Date.now() + timeoutMs;
-  return new Promise((resolve) => {
-    const attempt = () => {
-      const socket: Socket = createConnection({ port, host: "127.0.0.1" });
-      const cleanup = () => {
-        socket.removeAllListeners();
-        socket.destroy();
-      };
-      socket.on("connect", () => {
-        cleanup();
-        resolve(true);
-      });
-      socket.on("error", () => {
-        cleanup();
-        if (Date.now() >= deadline) {
-          resolve(false);
-        } else {
-          setTimeout(attempt, intervalMs);
-        }
-      });
-    };
-    attempt();
-  });
+interface SshStderrReader {
+  /** Everything SSH and the ensure script wrote, capped at a sane size. */
+  text(): string;
 }
-function attachProgressParser(child: ChildProcess, onProgress?: (message: string) => void): void {
-  if (!onProgress || !child.stderr) return;
-  let stderrBuffer = "";
+
+/**
+ * Watch the SSH process's stderr for the ensure script's structured markers
+ * while also retaining the raw text.
+ *
+ * Retaining matters: attaching a `data` listener puts the stream in flowing
+ * mode, so a later `stream.read()` returns nothing. Without buffering here,
+ * every failure — bad password, missing Node, failed install — would surface
+ * with an empty reason.
+ */
+function readSshStderr(
+  child: ChildProcess,
+  handlers: {
+    onProgress?: (message: string) => void;
+    onReady: () => void;
+    onCancelled: () => void;
+  },
+): SshStderrReader {
+  let retained = "";
+  let pending = "";
+  if (!child.stderr) {
+    return { text: () => retained };
+  }
   child.stderr.on("data", (chunk: Buffer) => {
-    stderrBuffer += chunk.toString("utf8");
-    const lines = stderrBuffer.split("\n");
-    stderrBuffer = lines.pop() ?? "";
+    const text = chunk.toString("utf8");
+    retained = (retained + text).slice(-MAX_STDERR_BYTES);
+    pending += text;
+    const lines = pending.split("\n");
+    pending = lines.pop() ?? "";
     for (const line of lines) {
-      const match = line.match(/^PROGRESS:(.*)$/);
-      if (match) onProgress(match[1]);
+      // A PTY turns "\n" into "\r\n"; strip the remnant before matching.
+      const clean = line.endsWith("\r") ? line.slice(0, -1) : line;
+      if (clean.startsWith(READY_MARKER)) {
+        handlers.onReady();
+      } else if (clean.startsWith(ASKPASS_CANCELLED_MARKER)) {
+        handlers.onCancelled();
+      } else if (clean.startsWith(PROGRESS_MARKER)) {
+        handlers.onProgress?.(clean.slice(PROGRESS_MARKER.length));
+      }
     }
+  });
+  return { text: () => retained };
+}
+
+function buildTunnelEnv(askpassPath: string | undefined): NodeJS.ProcessEnv | undefined {
+  if (!askpassPath) return undefined;
+  return {
+    ...process.env,
+    SSH_ASKPASS: askpassPath,
+    SSH_ASKPASS_REQUIRE: "force",
+    // OpenSSH only consults SSH_ASKPASS when it believes a display exists.
+    // SSH_ASKPASS_REQUIRE=force covers modern OpenSSH; DISPLAY covers the rest.
+    DISPLAY: process.env.DISPLAY ?? ":0",
+  };
+}
+
+/**
+ * The user dismissed the password prompt. Distinct from an authentication
+ * failure: nothing was wrong, they declined, so callers can say so plainly
+ * instead of reporting a permission error.
+ */
+export class SshCancelledError extends Error {
+  readonly host: string;
+
+  constructor(host: string) {
+    super(`Connection to ${host} was cancelled.`);
+    this.name = "SshCancelledError";
+    this.host = host;
+  }
+}
+
+/** Tunnels that must be reaped if the process exits without closing them. */
+const liveTunnels = new Set<SshTunnel>();
+let exitHookInstalled = false;
+
+function trackTunnel(tunnel: SshTunnel): void {
+  liveTunnels.add(tunnel);
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+  process.once("exit", () => {
+    for (const open of liveTunnels) open.close();
   });
 }
 
-function buildTunnelSpawnOpts(options?: {
+export interface SshTunnelOptions {
+  /**
+   * Shell script piped to the remote `/bin/sh` over this connection's stdin.
+   * On success it must fall through without exiting, so the remote shell keeps
+   * blocking for input and the port forward outlives it (see
+   * `buildEnsureScript`).
+   */
+  ensureScript: string;
+  localPort?: number;
+  readyTimeoutMs?: number;
   askpassPath?: string;
-  tty?: boolean;
-  ensureScript?: string;
-}): SpawnOptions {
-  // When an ensure script is provided, always pipe stderr for progress parsing.
-  // tty is only for password prompts, but with an ensure script we use askpass.
-  const useTty = options?.tty && !options?.ensureScript;
-  const spawnOpts: SpawnOptions = {
-    stdio: useTty ? "inherit" : ["pipe", "pipe", "pipe"],
-    windowsHide: true,
-  };
-  if (options?.askpassPath) {
-    spawnOpts.env = {
-      ...process.env,
-      SSH_ASKPASS: options.askpassPath,
-      SSH_ASKPASS_REQUIRE: "force",
-      DISPLAY: process.env.DISPLAY ?? ":0",
-    };
-  }
-  return spawnOpts;
+  /**
+   * Aborts when the user declines a password prompt. SSH ignores the askpass
+   * program's exit status and simply retries, so without this a dismissed
+   * prompt would reappear until the attempts run out.
+   */
+  cancelSignal?: AbortSignal;
+  onProgress?: (message: string) => void;
+  /** Called if the tunnel dies on its own, i.e. not via {@link SshTunnel.close}. */
+  onClose?: (reason: string) => void;
 }
 
 /**
  * An SSH local port-forward (`ssh -L`) kept open for the life of a tunneled
- * daemon connection. The tunnel is unref'd so it does not keep the Node event
- * loop alive on its own; {@link close} kills it (also registered on process
- * exit) so no orphaned `ssh` processes are left behind.
+ * daemon connection.
+ *
+ * The ensure script runs inline on the same connection, so bringing up a
+ * remote daemon costs one authentication rather than two. The port forward is
+ * live from the moment SSH connects, but the daemon behind it may not be — so
+ * readiness comes from the script's `READY:` marker, not from the local port
+ * accepting connections, which would be a false positive.
  */
 export class SshTunnel {
+  private closedByUs = false;
+
   private constructor(
     private readonly child: ChildProcess,
+    private readonly config: SshHostConfig,
     readonly localPort: number,
     readonly remotePort: number,
-  ) {
-    // Don't unref — the SSH process should keep the event loop alive so
-    // close() can kill it before the process exits.
-  }
-  /**
-   * Open an SSH local port-forward to `127.0.0.1:<remotePort>`. Resolves once
-   * the local port accepts connections.
-   *
-   * When `ensureScript` is provided, it is run on the remote host through the
-   * same SSH connection (no separate ensure call, no ControlMaster needed).
-   * The port forward is active from the moment SSH connects, so the script can
-   * launch the daemon and the local port becomes ready as soon as the daemon
-   * listens. After the script exits, `exec cat` keeps the connection alive by
-   * blocking on stdin forever — closing the tunnel (or the SSH process) drops
-   * the connection.
-   */
+  ) {}
+
   static async open(
     config: SshHostConfig,
     remotePort: number,
-    options?: {
-      localPort?: number;
-      readyTimeoutMs?: number;
-      askpassPath?: string;
-      tty?: boolean;
-      ensureScript?: string;
-      onProgress?: (message: string) => void;
-    },
+    options: SshTunnelOptions,
   ): Promise<SshTunnel> {
-    const localPort = options?.localPort ?? (await findFreeLocalPort());
-    const sshBaseArgs = buildSshBaseArgs(config, {
-      askpassPath: options?.askpassPath,
-      tty: options?.tty,
-    });
+    const localPort = options.localPort ?? (await findFreeLocalPort());
     const args = [
       "-L",
       `${localPort}:127.0.0.1:${remotePort}`,
       "-o",
       "ExitOnForwardFailure=yes",
-      ...sshBaseArgs,
+      ...buildSshBaseArgs(config, { askpassPath: options.askpassPath }),
+      REMOTE_SHELL_COMMAND,
     ];
-    // When running an ensure script, keep the connection alive after the script
-    // exits with `exec sleep infinity` (blocks on SIGTERM). Without a script,
-    // use -N (no remote command, just port forwarding).
-    if (options?.ensureScript) {
-      args.push(`${options.ensureScript}; [ $? -eq 0 ] && exec sleep infinity`);
-    } else {
-      args.push("-N");
+    const spawnOpts: SpawnOptions = {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    };
+    const env = buildTunnelEnv(options.askpassPath);
+    if (env) spawnOpts.env = env;
+
+    const child = spawn("ssh", args, spawnOpts);
+
+    // The script goes to the remote `sh` over stdin, not as the remote command:
+    // sshd would hand a command string to the user's own shell, which may not
+    // be POSIX. Stdin is left open on purpose — `sh` blocking on the next line
+    // is what holds the port forward up, and closing it is the teardown.
+    child.stdin?.on("error", () => {
+      // A failed auth closes the pipe before the script lands; the exit code
+      // and stderr are the real diagnostics, so this is not worth surfacing.
+    });
+    child.stdin?.write(
+      options.ensureScript.endsWith("\n") ? options.ensureScript : `${options.ensureScript}\n`,
+    );
+
+    let signalReady: () => void = () => {};
+    const ready = new Promise<void>((resolve) => {
+      signalReady = resolve;
+    });
+    // Set as soon as the askpass program reports a dismissed prompt, so the
+    // failure that follows is reported as a cancellation rather than as an
+    // authentication error.
+    let cancelled = false;
+    const cancel = () => {
+      cancelled = true;
+      // Don't wait for ssh to burn the remaining password attempts.
+      child.kill("SIGTERM");
+    };
+    if (options.cancelSignal) {
+      if (options.cancelSignal.aborted) cancel();
+      else options.cancelSignal.addEventListener("abort", cancel, { once: true });
     }
-    const progressCallbacks: ((msg: string) => void)[] = [];
-    if (options?.onProgress) progressCallbacks.push(options.onProgress);
-    const child = spawn("ssh", args, buildTunnelSpawnOpts(options));
-    attachProgressParser(child, (msg) => {
-      for (const cb of progressCallbacks) cb(msg);
+    const stderr = readSshStderr(child, {
+      ...(options.onProgress ? { onProgress: options.onProgress } : {}),
+      onReady: () => signalReady(),
+      onCancelled: cancel,
     });
 
-    // When an ensure script is provided, wait for the "Remote daemon is ready"
-    // or "already running" progress message — the local port forward accepts
-    // connections before the remote daemon is actually listening, so
-    // waitForLocalPort would give a false positive. Without a script, the port
-    // forward is to an already-running daemon, so waitForLocalPort is reliable.
-    let ready: Promise<boolean>;
-    if (options?.ensureScript) {
-      ready = Promise.race([
-        new Promise<boolean>((resolve) => {
-          progressCallbacks.push((msg: string) => {
-            if (msg.includes("daemon is ready") || msg.includes("already running")) {
-              resolve(true);
-            }
-          });
-        }),
-        new Promise<boolean>((resolve) => {
-          const timer = setTimeout(() => resolve(false), options?.readyTimeoutMs ?? 300_000);
-          timer.unref();
-        }),
-      ]);
-    } else {
-      ready = waitForLocalPort(localPort, {
-        timeoutMs: options?.readyTimeoutMs ?? 300_000,
-      });
-    }
-
-    // If ssh dies before the port opens, surface its stderr.
-    const exited = new Promise<number | null>((resolve) => {
-      child.once("close", (code) => resolve(code));
-      child.once("error", () => resolve(null));
+    const exited = new Promise<{ code: number | null; error?: Error }>((resolve) => {
+      child.once("close", (code) => resolve({ code }));
+      child.once("error", (error) => resolve({ code: null, error }));
+    });
+    const timedOut = new Promise<"timeout">((resolve) => {
+      const timer = setTimeout(() => resolve("timeout"), options.readyTimeoutMs ?? 300_000);
+      timer.unref();
     });
 
-    const race = await Promise.race([
-      ready.then((ok) => ({ ok, code: null as number | null })),
-      exited.then((code) => ({ ok: false, code })),
+    const outcome = await Promise.race([
+      ready.then(() => "ready" as const),
+      exited.then((result) => result),
+      timedOut,
     ]);
 
-    if (!race.ok) {
-      const stderr = child.stderr?.read()?.toString("utf8") ?? "";
+    if (outcome !== "ready") {
       child.kill("SIGKILL");
-      if (race.code !== null) {
+      if (cancelled) {
+        throw new SshCancelledError(config.host);
+      }
+      if (outcome === "timeout") {
         throw new Error(
-          `SSH tunnel exited (code ${race.code}) before the port forward opened.${stderr ? ` ${stderr.trim()}` : ""}`,
+          `Timed out waiting for the Paseo daemon on ${config.host}.${
+            stderr.text().trim() ? `\n${stderr.text().trim()}` : ""
+          }`,
         );
       }
+      if (outcome.error) {
+        throw new Error(`Failed to run ssh: ${outcome.error.message}`);
+      }
       throw new Error(
-        `SSH tunnel did not become ready on local port ${localPort} within the timeout.${stderr ? ` ${stderr.trim()}` : ""}`,
+        describeEnsureFailure({ config, exitCode: outcome.code, stderr: stderr.text() }),
       );
     }
-    const tunnel = new SshTunnel(child, localPort, remotePort);
-    process.once("exit", () => tunnel.close());
+
+    const tunnel = new SshTunnel(child, config, localPort, remotePort);
+    trackTunnel(tunnel);
+    // The forward is live but the SSH process can still die later — a dropped
+    // network, a rebooted host, a killed remote shell. Tell the owner so it can
+    // surface a disconnect instead of retrying against a port nothing serves.
+    exited
+      .then((result) => {
+        liveTunnels.delete(tunnel);
+        if (!tunnel.closedByUs) {
+          options.onClose?.(
+            result.error
+              ? result.error.message
+              : describeSshFailure(config.host, result.code, stderr.text()),
+          );
+        }
+        return undefined;
+      })
+      .catch(() => undefined);
     return tunnel;
   }
 
+  /** The host this tunnel forwards to, for diagnostics. */
+  get host(): string {
+    return this.config.host;
+  }
+
   close(): void {
+    this.closedByUs = true;
+    liveTunnels.delete(this);
     if (!this.child.killed) {
       this.child.stdin?.destroy();
       this.child.kill("SIGKILL");
     }
   }
 }
-/**
- * Create a temporary SSH_ASKPASS script that shows a native OS password
- * dialog. SSH calls this program (with the prompt as argv[1]) when it needs
- * a password and no tty is available. The password goes to stdout and is
- * never stored. Returns the script path; call `cleanupAskpassScript` to
- * remove it.
- */
-export function createAskpassScript(): string {
-  const scriptPath = path.join(tmpdir(), `paseo-askpass-${process.pid}.sh`);
-  // macOS uses osascript; Linux tries zenity then kdialog.
-  const script = `#!/bin/sh
-if [ "$(uname)" = "Darwin" ]; then
-  osascript -e 'display dialog "$1" default answer "" with hidden answer' -e 'text returned of result' 2>/dev/null
-else
-  zenity --password --title="$1" 2>/dev/null || kdialog --password "$1" 2>/dev/null
-fi
-`;
-  writeFileSync(scriptPath, script, { mode: 0o700 });
+
+/** A temporary askpass script plus the private directory holding it. */
+export interface AskpassScript {
+  path: string;
+  cleanup: () => void;
+}
+
+function writeAskpassScript(prefix: string, body: string): AskpassScript {
+  // A private directory, not a predictable /tmp filename: on a shared host a
+  // pid-named path in a world-writable directory is a symlink-attack target.
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  const scriptPath = path.join(dir, "askpass.sh");
+  writeFileSync(scriptPath, body, { mode: 0o700 });
   chmodSync(scriptPath, 0o700);
-  return scriptPath;
+  return {
+    path: scriptPath,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup.
+      }
+    },
+  };
 }
 
 /**
  * Create a temporary SSH_ASKPASS script that prompts on the terminal via
- * /dev/tty. Used by the CLI where no GUI dialog is available. SSH invokes
- * this program with the prompt as argv[1]; the password goes to stdout.
+ * `/dev/tty`. Used by the CLI, where no GUI dialog is available.
+ *
+ * Echo is suppressed with `stty` rather than `read -s`: `-s` is a bash/zsh
+ * extension, and `/bin/sh` is dash on Debian and Ubuntu, where it would fail
+ * outright and hand SSH an empty password.
  */
-export function createTerminalAskpassScript(): string {
-  const scriptPath = path.join(tmpdir(), `paseo-askpass-term-${process.pid}.sh`);
-  const script = `#!/bin/sh
-printf "%s: " "$1" >/dev/tty 2>&1
-read -rs password </dev/tty
-printf "\\n" >/dev/tty
-printf "%s" "$password"
+export function createTerminalAskpassScript(): AskpassScript {
+  const body = `#!/bin/sh
+prompt=\${1:-Password:}
+printf '%s ' "$prompt" >/dev/tty
+saved=$(stty -g </dev/tty 2>/dev/null) || saved=""
+[ -n "$saved" ] && stty -echo </dev/tty
+if read -r password </dev/tty; then
+  answered=1
+else
+  answered=0
+fi
+[ -n "$saved" ] && stty "$saved" </dev/tty
+printf '\\n' >/dev/tty
+if [ "$answered" = "1" ]; then
+  printf '%s' "$password"
+else
+  # EOF (Ctrl-D) is this prompt's Cancel; say so rather than handing ssh an
+  # empty password and getting asked again.
+  echo "${ASKPASS_CANCELLED_MARKER}" >&2
+  exit 1
+fi
 `;
-  writeFileSync(scriptPath, script, { mode: 0o700 });
-  chmodSync(scriptPath, 0o700);
-  return scriptPath;
-}
-
-/** Remove the temporary askpass script. */
-export function cleanupAskpassScript(scriptPath: string): void {
-  try {
-    unlinkSync(scriptPath);
-  } catch {
-    // Best-effort cleanup.
-  }
+  return writeAskpassScript("paseo-askpass-term-", body);
 }

--- a/packages/cli/src/ssh/ssh-process.ts
+++ b/packages/cli/src/ssh/ssh-process.ts
@@ -9,13 +9,12 @@ import type { SshHostConfig } from "./ssh-host-config.js";
  * Base SSH arguments. When `askpassPath` is set, BatchMode is dropped so SSH
  * can prompt for a password via the SSH_ASKPASS program. Without it, BatchMode
  * ensures auth fails fast instead of hanging on a prompt the user can't see.
- * When `controlPath` is set, SSH connection multiplexing (ControlMaster) is
- * enabled so multiple sshExec calls and the tunnel share a single TCP
- * connection — the user authenticates once, not once per command.
+ * When `tty` is set, a PTY is allocated (`-tt`) for interactive password
+ * prompts directly on the terminal.
  */
 export function buildSshBaseArgs(
   config: SshHostConfig,
-  options?: { askpassPath?: string; controlPath?: string; tty?: boolean },
+  options?: { askpassPath?: string; tty?: boolean },
 ): string[] {
   const args = [
     "-p",
@@ -25,16 +24,6 @@ export function buildSshBaseArgs(
     "-o",
     "ConnectTimeout=10",
   ];
-  if (options?.controlPath) {
-    args.push(
-      "-o",
-      "ControlMaster=auto",
-      "-o",
-      `ControlPath=${options.controlPath}`,
-      "-o",
-      "ControlPersist=300",
-    );
-  }
   if (!options?.askpassPath && !options?.tty) {
     args.push("-o", "BatchMode=yes");
   }
@@ -47,8 +36,6 @@ export interface SshExecOptions {
   timeoutMs?: number;
   /** Path to an SSH_ASKPASS program. When set, BatchMode is dropped. */
   askpassPath?: string;
-  /** SSH ControlMaster socket path for connection multiplexing. */
-  controlPath?: string;
   /** Allocate a PTY for the SSH process (terminal password prompts). */
   tty?: boolean;
 }
@@ -76,7 +63,6 @@ export function sshExec(
     const sshArgs = [
       ...buildSshBaseArgs(config, {
         askpassPath: options?.askpassPath,
-        controlPath: options?.controlPath,
         tty: options?.tty,
       }),
       ...(options?.tty ? ["-tt"] : []),
@@ -173,6 +159,42 @@ export function waitForLocalPort(
     attempt();
   });
 }
+function attachProgressParser(child: ChildProcess, onProgress?: (message: string) => void): void {
+  if (!onProgress || !child.stderr) return;
+  let stderrBuffer = "";
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderrBuffer += chunk.toString("utf8");
+    const lines = stderrBuffer.split("\n");
+    stderrBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const match = line.match(/^PROGRESS:(.*)$/);
+      if (match) onProgress(match[1]);
+    }
+  });
+}
+
+function buildTunnelSpawnOpts(options?: {
+  askpassPath?: string;
+  tty?: boolean;
+  ensureScript?: string;
+}): SpawnOptions {
+  // When an ensure script is provided, always pipe stderr for progress parsing.
+  // tty is only for password prompts, but with an ensure script we use askpass.
+  const useTty = options?.tty && !options?.ensureScript;
+  const spawnOpts: SpawnOptions = {
+    stdio: useTty ? "inherit" : ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  };
+  if (options?.askpassPath) {
+    spawnOpts.env = {
+      ...process.env,
+      SSH_ASKPASS: options.askpassPath,
+      SSH_ASKPASS_REQUIRE: "force",
+      DISPLAY: process.env.DISPLAY ?? ":0",
+    };
+  }
+  return spawnOpts;
+}
 
 /**
  * An SSH local port-forward (`ssh -L`) kept open for the life of a tunneled
@@ -186,11 +208,20 @@ export class SshTunnel {
     readonly localPort: number,
     readonly remotePort: number,
   ) {
-    child.unref();
+    // Don't unref — the SSH process should keep the event loop alive so
+    // close() can kill it before the process exits.
   }
-
   /**
-   * `127.0.0.1:<remotePort>`. Resolves once the local port accepts connections.
+   * Open an SSH local port-forward to `127.0.0.1:<remotePort>`. Resolves once
+   * the local port accepts connections.
+   *
+   * When `ensureScript` is provided, it is run on the remote host through the
+   * same SSH connection (no separate ensure call, no ControlMaster needed).
+   * The port forward is active from the moment SSH connects, so the script can
+   * launch the daemon and the local port becomes ready as soon as the daemon
+   * listens. After the script exits, `exec cat` keeps the connection alive by
+   * blocking on stdin forever — closing the tunnel (or the SSH process) drops
+   * the connection.
    */
   static async open(
     config: SshHostConfig,
@@ -199,41 +230,63 @@ export class SshTunnel {
       localPort?: number;
       readyTimeoutMs?: number;
       askpassPath?: string;
-      controlPath?: string;
       tty?: boolean;
+      ensureScript?: string;
+      onProgress?: (message: string) => void;
     },
   ): Promise<SshTunnel> {
     const localPort = options?.localPort ?? (await findFreeLocalPort());
     const sshBaseArgs = buildSshBaseArgs(config, {
       askpassPath: options?.askpassPath,
-      controlPath: options?.controlPath,
       tty: options?.tty,
     });
     const args = [
       "-L",
       `${localPort}:127.0.0.1:${remotePort}`,
-      "-N",
       "-o",
       "ExitOnForwardFailure=yes",
       ...sshBaseArgs,
     ];
-    const spawnOpts: SpawnOptions = {
-      stdio: options?.tty ? "inherit" : ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-    };
-    if (options?.askpassPath) {
-      spawnOpts.env = {
-        ...process.env,
-        SSH_ASKPASS: options.askpassPath,
-        SSH_ASKPASS_REQUIRE: "force",
-        DISPLAY: process.env.DISPLAY ?? ":0",
-      };
+    // When running an ensure script, keep the connection alive after the script
+    // exits with `exec sleep infinity` (blocks on SIGTERM). Without a script,
+    // use -N (no remote command, just port forwarding).
+    if (options?.ensureScript) {
+      args.push(`${options.ensureScript}; [ $? -eq 0 ] && exec sleep infinity`);
+    } else {
+      args.push("-N");
     }
-    const child = spawn("ssh", args, spawnOpts);
-
-    const ready = waitForLocalPort(localPort, {
-      timeoutMs: options?.readyTimeoutMs ?? 15_000,
+    const progressCallbacks: ((msg: string) => void)[] = [];
+    if (options?.onProgress) progressCallbacks.push(options.onProgress);
+    const child = spawn("ssh", args, buildTunnelSpawnOpts(options));
+    attachProgressParser(child, (msg) => {
+      for (const cb of progressCallbacks) cb(msg);
     });
+
+    // When an ensure script is provided, wait for the "Remote daemon is ready"
+    // or "already running" progress message — the local port forward accepts
+    // connections before the remote daemon is actually listening, so
+    // waitForLocalPort would give a false positive. Without a script, the port
+    // forward is to an already-running daemon, so waitForLocalPort is reliable.
+    let ready: Promise<boolean>;
+    if (options?.ensureScript) {
+      ready = Promise.race([
+        new Promise<boolean>((resolve) => {
+          progressCallbacks.push((msg: string) => {
+            if (msg.includes("daemon is ready") || msg.includes("already running")) {
+              resolve(true);
+            }
+          });
+        }),
+        new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(false), options?.readyTimeoutMs ?? 300_000);
+          timer.unref();
+        }),
+      ]);
+    } else {
+      ready = waitForLocalPort(localPort, {
+        timeoutMs: options?.readyTimeoutMs ?? 300_000,
+      });
+    }
 
     // If ssh dies before the port opens, surface its stderr.
     const exited = new Promise<number | null>((resolve) => {
@@ -258,7 +311,6 @@ export class SshTunnel {
         `SSH tunnel did not become ready on local port ${localPort} within the timeout.${stderr ? ` ${stderr.trim()}` : ""}`,
       );
     }
-
     const tunnel = new SshTunnel(child, localPort, remotePort);
     process.once("exit", () => tunnel.close());
     return tunnel;
@@ -266,17 +318,11 @@ export class SshTunnel {
 
   close(): void {
     if (!this.child.killed) {
-      this.child.kill("SIGTERM");
-      const child = this.child;
-      const killTimer = setTimeout(() => {
-        if (!child.killed) child.kill("SIGKILL");
-      }, 2_000);
-      killTimer.unref();
-      this.child.once("close", () => clearTimeout(killTimer));
+      this.child.stdin?.destroy();
+      this.child.kill("SIGKILL");
     }
   }
 }
-
 /**
  * Create a temporary SSH_ASKPASS script that shows a native OS password
  * dialog. SSH calls this program (with the prompt as argv[1]) when it needs
@@ -293,6 +339,24 @@ if [ "$(uname)" = "Darwin" ]; then
 else
   zenity --password --title="$1" 2>/dev/null || kdialog --password "$1" 2>/dev/null
 fi
+`;
+  writeFileSync(scriptPath, script, { mode: 0o700 });
+  chmodSync(scriptPath, 0o700);
+  return scriptPath;
+}
+
+/**
+ * Create a temporary SSH_ASKPASS script that prompts on the terminal via
+ * /dev/tty. Used by the CLI where no GUI dialog is available. SSH invokes
+ * this program with the prompt as argv[1]; the password goes to stdout.
+ */
+export function createTerminalAskpassScript(): string {
+  const scriptPath = path.join(tmpdir(), `paseo-askpass-term-${process.pid}.sh`);
+  const script = `#!/bin/sh
+printf "%s: " "$1" >/dev/tty 2>&1
+read -rs password </dev/tty
+printf "\\n" >/dev/tty
+printf "%s" "$password"
 `;
   writeFileSync(scriptPath, script, { mode: 0o700 });
   chmodSync(scriptPath, 0o700);

--- a/packages/cli/src/utils/client.ts
+++ b/packages/cli/src/utils/client.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import { WebSocket } from "ws";
 import { getOrCreateCliClientId } from "./client-id.js";
 import { resolveCliVersion } from "../version.js";
+import { connectViaSsh, isSshHostUri } from "../ssh/ssh-connection.js";
 
 export interface ConnectOptions {
   host?: string;
@@ -59,7 +60,8 @@ export function buildDaemonConnectionCommandError(options: {
   return {
     code: "DAEMON_NOT_RUNNING",
     message: `Cannot connect to daemon at ${host}: ${message}`,
-    details: "Start the daemon with: paseo daemon start",
+    details:
+      "Start the daemon with: paseo daemon start, or connect to a remote host with --host ssh://user@host:port.",
   };
 }
 
@@ -248,7 +250,7 @@ export function resolveDaemonPassword(host: string): string | undefined {
 /**
  * Create a WebSocket factory that works in Node.js
  */
-function createNodeWebSocketFactory() {
+export function createNodeWebSocketFactory() {
   return (
     url: string,
     options?: { headers?: Record<string, string>; protocols?: string[]; socketPath?: string },
@@ -354,6 +356,13 @@ export async function connectToDaemon(options?: ConnectOptions): Promise<DaemonC
   const nodeWebSocketFactory = createNodeWebSocketFactory();
 
   const explicitHost = options?.host ?? process.env.PASEO_HOST;
+  if (explicitHost && isSshHostUri(explicitHost)) {
+    return connectViaSsh(explicitHost, {
+      timeoutMs: timeout,
+      clientId,
+      appVersion: resolveCliVersion(),
+    });
+  }
   const offer = parseHostOfferOrNull(explicitHost);
   if (offer) {
     return connectViaRelayOffer(offer, clientId, timeout, nodeWebSocketFactory);

--- a/packages/cli/tests/askpass-channel.test.ts
+++ b/packages/cli/tests/askpass-channel.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  classifyAskpassPrompt,
+  createAskpassChannel,
+  type AskpassRequest,
+} from "../src/ssh/askpass-channel.js";
+
+/** Invoke the generated askpass exactly as ssh does: prompt as argv[1]. */
+function runAskpass(
+  askpassPath: string,
+  prompt: string,
+): Promise<{ stdout: string; code: number | null }> {
+  return new Promise((resolve) => {
+    execFile(askpassPath, [prompt], { timeout: 20_000 }, (error, stdout) => {
+      if (!error) {
+        resolve({ stdout, code: 0 });
+        return;
+      }
+      const reported = (error as { code?: unknown }).code;
+      resolve({ stdout, code: typeof reported === "number" ? reported : 1 });
+    });
+  });
+}
+
+describe("askpass-channel: prompt classification", () => {
+  it("tells a key passphrase from an account password", () => {
+    expect(classifyAskpassPrompt("Enter passphrase for key '/home/a/.ssh/id_ed25519': ")).toBe(
+      "passphrase",
+    );
+    expect(classifyAskpassPrompt("alice@example.com's password: ")).toBe("password");
+    // Unknown prompts default to the far more common case.
+    expect(classifyAskpassPrompt("Password: ")).toBe("password");
+  });
+});
+
+describe("askpass-channel", () => {
+  it("relays the prompt to the handler and the answer back on stdout", async () => {
+    const seen: AskpassRequest[] = [];
+    const channel = await createAskpassChannel({
+      onPrompt: async (request) => {
+        seen.push(request);
+        return "s3cret";
+      },
+    });
+    try {
+      const result = await runAskpass(channel.askpassPath, "alice@example.com's password: ");
+      // stdout is the only channel ssh reads a secret from.
+      expect(result.stdout).toBe("s3cret");
+      expect(result.code).toBe(0);
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.kind).toBe("password");
+      expect(seen[0]?.prompt).toBe("alice@example.com's password: ");
+    } finally {
+      channel.close();
+    }
+  });
+
+  it("aborts the signal and emits nothing when the prompt is declined", async () => {
+    const channel = await createAskpassChannel({ onPrompt: async () => null });
+    try {
+      expect(channel.signal.aborted).toBe(false);
+      const result = await runAskpass(channel.askpassPath, "alice@example.com's password: ");
+      // An empty answer must never be offered to ssh as a password.
+      expect(result.stdout).toBe("");
+      expect(result.code).not.toBe(0);
+      expect(channel.signal.aborted).toBe(true);
+    } finally {
+      channel.close();
+    }
+  });
+
+  it("declines rather than hanging ssh when no answer arrives in time", async () => {
+    const channel = await createAskpassChannel({
+      onPrompt: () => new Promise<string | null>(() => {}),
+      promptTimeoutMs: 250,
+    });
+    try {
+      const result = await runAskpass(channel.askpassPath, "alice@example.com's password: ");
+      expect(result.stdout).toBe("");
+      expect(channel.signal.aborted).toBe(true);
+    } finally {
+      channel.close();
+    }
+  });
+
+  it("exits instead of blocking when the channel is already closed", async () => {
+    const channel = await createAskpassChannel({ onPrompt: async () => "unused" });
+    const askpassPath = channel.askpassPath;
+    channel.close();
+    // The socket is gone; ssh must not be left waiting on a dead relay.
+    const result = await runAskpass(askpassPath, "alice@example.com's password: ");
+    expect(result.stdout).toBe("");
+    expect(result.code).not.toBe(0);
+  });
+
+  it("keeps the socket and helper in a private directory", async () => {
+    const channel = await createAskpassChannel({ onPrompt: async () => null });
+    try {
+      const wrapper = readFileSync(channel.askpassPath, "utf8");
+      // The helper needs a runtime; under Electron that is the app binary in
+      // Node mode, which is inert for a plain node.
+      expect(wrapper).toContain("ELECTRON_RUN_AS_NODE=1");
+      expect(wrapper).toContain(path.dirname(channel.askpassPath));
+      // Written at runtime, so there is no packaged asset to unpack from asar.
+      expect(
+        readFileSync(path.join(path.dirname(channel.askpassPath), "askpass-helper.cjs"), "utf8"),
+      ).toContain("net.connect");
+    } finally {
+      channel.close();
+    }
+  });
+});

--- a/packages/cli/tests/ssh-host-config.test.ts
+++ b/packages/cli/tests/ssh-host-config.test.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_INSTALL_DIR,
   DEFAULT_REMOTE_HOME,
   DEFAULT_REMOTE_PORT,
-  DEFAULT_SSH_PORT,
   isSshHostUri,
   isValidSshHostId,
   normalizeSshHostConfig,
@@ -18,7 +17,8 @@ describe("ssh-host-config: normalizeSshHostConfig", () => {
       host: "10.0.0.5",
       user: "deploy",
     });
-    expect(config.port).toBe(DEFAULT_SSH_PORT);
+    // Port stays unset so ~/.ssh/config can supply one.
+    expect(config.port).toBeUndefined();
     expect(config.remotePort).toBe(DEFAULT_REMOTE_PORT);
     expect(config.remoteHome).toBe(DEFAULT_REMOTE_HOME);
     expect(config.installDir).toBe(DEFAULT_INSTALL_DIR);
@@ -105,12 +105,23 @@ describe("ssh-host-config: parseSshHostUri", () => {
     }
   });
 
-  it("parses an inline host with default port", () => {
+  it("leaves the port unset when the URI omits one", () => {
     const parsed = parseSshHostUri("ssh://bob@server.example.com");
     expect(parsed?.kind).toBe("inline");
     if (parsed?.kind === "inline") {
-      expect(parsed.config.port).toBe(DEFAULT_SSH_PORT);
+      expect(parsed.config.port).toBeUndefined();
     }
+  });
+
+  it("rejects a non-numeric port instead of folding it into the hostname", () => {
+    expect(parseSshHostUri("ssh://bob@host:2222x")).toBeNull();
+    expect(parseSshHostUri("ssh://bob@host:")).toBeNull();
+    expect(parseSshHostUri("ssh://bob@host:99999")).toBeNull();
+  });
+
+  it("rejects an out-of-range remotePort override", () => {
+    expect(() => parseSshHostUri("ssh://bob@host?remotePort=abc")).toThrow(/remotePort/);
+    expect(() => parseSshHostUri("ssh://bob@host?remotePort=70000")).toThrow(/remotePort/);
   });
 
   it("parses an IPv6 host", () => {

--- a/packages/cli/tests/ssh-host-config.test.ts
+++ b/packages/cli/tests/ssh-host-config.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_INSTALL_DIR,
+  DEFAULT_REMOTE_HOME,
+  DEFAULT_REMOTE_PORT,
+  DEFAULT_SSH_PORT,
+  isSshHostUri,
+  isValidSshHostId,
+  normalizeSshHostConfig,
+  parseSshHostUri,
+  resolveSshHostConfig,
+} from "../src/ssh/ssh-host-config.js";
+
+describe("ssh-host-config: normalizeSshHostConfig", () => {
+  it("applies defaults for omitted fields", () => {
+    const config = normalizeSshHostConfig({
+      id: "prod",
+      host: "10.0.0.5",
+      user: "deploy",
+    });
+    expect(config.port).toBe(DEFAULT_SSH_PORT);
+    expect(config.remotePort).toBe(DEFAULT_REMOTE_PORT);
+    expect(config.remoteHome).toBe(DEFAULT_REMOTE_HOME);
+    expect(config.installDir).toBe(DEFAULT_INSTALL_DIR);
+    expect(config.label).toBe("deploy@10.0.0.5");
+    expect(config.packageVersion).toBeUndefined();
+  });
+
+  it("preserves explicit values", () => {
+    const config = normalizeSshHostConfig({
+      id: "prod",
+      host: "10.0.0.5",
+      user: "deploy",
+      port: 2222,
+      remotePort: 7000,
+      remoteHome: "/data/paseo",
+      installDir: "/opt/paseo",
+      label: "Production",
+      packageVersion: "0.2.0",
+    });
+    expect(config).toMatchObject({
+      port: 2222,
+      remotePort: 7000,
+      remoteHome: "/data/paseo",
+      installDir: "/opt/paseo",
+      label: "Production",
+      packageVersion: "0.2.0",
+    });
+  });
+
+  it("rejects invalid ids", () => {
+    expect(() => normalizeSshHostConfig({ id: "Bad ID", host: "h", user: "u" })).toThrow();
+    expect(() => normalizeSshHostConfig({ id: "", host: "h", user: "u" })).toThrow();
+    expect(() => normalizeSshHostConfig({ id: "1".repeat(64), host: "h", user: "u" })).toThrow();
+  });
+
+  it("rejects empty host but accepts empty user", () => {
+    expect(() => normalizeSshHostConfig({ id: "x", host: "  " })).toThrow();
+    expect(() => normalizeSshHostConfig({ id: "x", host: "h" })).not.toThrow();
+  });
+
+  it("rejects out-of-range ports", () => {
+    expect(() => normalizeSshHostConfig({ id: "x", host: "h", user: "u", port: 0 })).toThrow();
+    expect(() => normalizeSshHostConfig({ id: "x", host: "h", user: "u", port: 99999 })).toThrow();
+    expect(() =>
+      normalizeSshHostConfig({ id: "x", host: "h", user: "u", remotePort: 0 }),
+    ).toThrow();
+  });
+});
+
+describe("ssh-host-config: isValidSshHostId / isSshHostUri", () => {
+  it("validates id pattern", () => {
+    expect(isValidSshHostId("my-host")).toBe(true);
+    expect(isValidSshHostId("a")).toBe(true);
+    expect(isValidSshHostId("My_Host")).toBe(false);
+    expect(isValidSshHostId("-leading")).toBe(false);
+  });
+
+  it("detects ssh URIs", () => {
+    expect(isSshHostUri("ssh://myhost")).toBe(true);
+    expect(isSshHostUri("ssh://user@host")).toBe(true);
+    expect(isSshHostUri("tcp://localhost:6767")).toBe(false);
+    expect(isSshHostUri("localhost:6767")).toBe(false);
+    expect(isSshHostUri("")).toBe(false);
+  });
+});
+
+describe("ssh-host-config: parseSshHostUri", () => {
+  it("parses a bare hostname (no user) as an inline host", () => {
+    const parsed = parseSshHostUri("ssh://server.example.com");
+    expect(parsed?.kind).toBe("inline");
+    if (parsed?.kind === "inline") {
+      expect(parsed.config.user).toBeUndefined();
+      expect(parsed.config.host).toBe("server.example.com");
+    }
+  });
+
+  it("parses an inline host", () => {
+    const parsed = parseSshHostUri("ssh://bob@10.0.0.5:2222");
+    expect(parsed?.kind).toBe("inline");
+    if (parsed?.kind === "inline") {
+      expect(parsed.config.user).toBe("bob");
+      expect(parsed.config.host).toBe("10.0.0.5");
+      expect(parsed.config.port).toBe(2222);
+    }
+  });
+
+  it("parses an inline host with default port", () => {
+    const parsed = parseSshHostUri("ssh://bob@server.example.com");
+    expect(parsed?.kind).toBe("inline");
+    if (parsed?.kind === "inline") {
+      expect(parsed.config.port).toBe(DEFAULT_SSH_PORT);
+    }
+  });
+
+  it("parses an IPv6 host", () => {
+    const parsed = parseSshHostUri("ssh://bob@[::1]:2222");
+    expect(parsed?.kind).toBe("inline");
+    if (parsed?.kind === "inline") {
+      expect(parsed.config.host).toBe("::1");
+      expect(parsed.config.port).toBe(2222);
+    }
+  });
+
+  it("parses an inline host with query overrides", () => {
+    const parsed = parseSshHostUri(
+      "ssh://bob@host?remoteHome=/data/p&installDir=/opt/p&version=1.0.0",
+    );
+    expect(parsed?.kind).toBe("inline");
+    if (parsed?.kind === "inline") {
+      expect(parsed.config.remoteHome).toBe("/data/p");
+      expect(parsed.config.installDir).toBe("/opt/p");
+      expect(parsed.config.packageVersion).toBe("1.0.0");
+    }
+  });
+
+  it("returns null for non-ssh URIs", () => {
+    expect(parseSshHostUri("tcp://localhost:6767")).toBeNull();
+    expect(parseSshHostUri("https://example.com")).toBeNull();
+  });
+
+  it("returns null for malformed ssh URIs", () => {
+    expect(parseSshHostUri("ssh://")).toBeNull();
+    expect(parseSshHostUri("ssh://@host")?.kind).toBe("inline");
+  });
+});
+
+describe("ssh-host-config: resolveSshHostConfig", () => {
+  it("resolves an inline host", () => {
+    const config = resolveSshHostConfig("ssh://carol@1.2.3.4");
+    expect(config?.user).toBe("carol");
+    expect(config?.host).toBe("1.2.3.4");
+  });
+
+  it("returns null for non-ssh URIs", () => {
+    expect(resolveSshHostConfig("tcp://localhost:6767")).toBeNull();
+  });
+});

--- a/packages/cli/tests/ssh-process.test.ts
+++ b/packages/cli/tests/ssh-process.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { buildSshBaseArgs } from "../src/ssh/ssh-process.js";
+import {
+  buildEnsureScript,
+  ensureRemoteDaemon,
+  remoteExpandHome,
+  remoteHomePath,
+  remoteInstallPath,
+  remotePaseoBin,
+  type EnsureRemoteDaemonOptions,
+  type SshExecResult,
+} from "../src/ssh/remote-daemon.js";
+import { normalizeSshHostConfig, type SshHostConfig } from "../src/ssh/ssh-host-config.js";
+function makeConfig(overrides: Partial<SshHostConfig> = {}): SshHostConfig {
+  return normalizeSshHostConfig({
+    id: "myhost",
+    host: "server.example.com",
+    user: "alice",
+    ...overrides,
+  });
+}
+
+describe("ssh-process: buildSshBaseArgs", () => {
+  it("includes port, BatchMode, host key, and user@host", () => {
+    const args = buildSshBaseArgs(makeConfig());
+    expect(args).toContain("-p");
+    expect(args).toContain("22");
+    expect(args).toContain("BatchMode=yes");
+    expect(args).toContain("StrictHostKeyChecking=accept-new");
+    expect(args).toContain("alice@server.example.com");
+  });
+
+
+  it("uses the configured SSH port", () => {
+    const args = buildSshBaseArgs(makeConfig({ port: 2222 }));
+    expect(args).toContain("2222");
+  });
+});
+
+describe("remote-daemon: path helpers", () => {
+  it("expands ~ to $HOME", () => {
+    expect(remoteExpandHome("~")).toBe("$HOME");
+    expect(remoteExpandHome("~/foo")).toBe("$HOME/foo");
+    expect(remoteExpandHome("/abs/path")).toBe("/abs/path");
+  });
+
+  it("derives remote home and install paths", () => {
+    const config = makeConfig();
+    expect(remoteHomePath(config)).toBe("$HOME/.paseo");
+    expect(remoteInstallPath(config)).toBe("$HOME/.paseo/cli");
+  });
+
+  it("derives the paseo bin path", () => {
+    const config = makeConfig();
+    expect(remotePaseoBin(config)).toBe('"$HOME/.paseo/cli/node_modules/.bin/paseo"');
+  });
+});
+describe("remote-daemon: buildEnsureScript", () => {
+  it("includes port check, node check, install, launch, and ready wait", () => {
+    const config = makeConfig({ remotePort: 6767 });
+    const script = buildEnsureScript(config, "1.2.3");
+    expect(script).toContain("6767");
+    expect(script).toContain("node -e");
+    expect(script).toContain("node -v");
+    expect(script).toContain("npm -v");
+    expect(script).toContain("npm install");
+    expect(script).toContain("@getpaseo/cli@1.2.3");
+    expect(script).toContain("$HOME/.paseo/cli");
+    expect(script).toContain("daemon start");
+    expect(script).toContain("--no-relay");
+    expect(script).toContain("--no-mcp");
+    expect(script).toContain("$HOME/.paseo");
+    expect(script).toContain("PROGRESS:");
+  });
+
+  it("uses latest when version is empty", () => {
+    const config = makeConfig();
+    const script = buildEnsureScript(config, "");
+    expect(script).toContain("@getpaseo/cli");
+    expect(script).not.toContain("@getpaseo/cli@");
+  });
+});
+
+/** A sequential fake exec: returns responses in order, matching by pattern. */
+function fakeExec(
+  responses: { command: RegExp; result: Partial<SshExecResult> }[],
+): (command: string) => Promise<SshExecResult> {
+  let index = 0;
+  return async (command: string) => {
+    const entry = responses[index];
+    index += 1;
+    if (!entry || !entry.command.test(command)) {
+      throw new Error(
+        `Unexpected exec #${index} (expected ${entry?.command?.source ?? "end"}): ${command}`,
+      );
+    }
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      ...entry.result,
+    };
+  };
+}
+
+function makeEnsureOptions(
+  exec: (command: string) => Promise<SshExecResult>,
+  overrides: Partial<EnsureRemoteDaemonOptions> = {},
+): EnsureRemoteDaemonOptions {
+  return {
+    config: makeConfig(),
+    exec,
+    ...overrides,
+  };
+}
+
+describe("remote-daemon: ensureRemoteDaemon", () => {
+  it("returns ready when the script exits 0 (daemon already running)", async () => {
+    const exec = fakeExec([
+      {
+        command: /.*/,
+        result: { exitCode: 0, stderr: "PROGRESS:Remote daemon is already running.\n" },
+      },
+    ]);
+    const result = await ensureRemoteDaemon(makeEnsureOptions(exec));
+    expect(result).toEqual({ installed: false, launched: false, ready: true });
+  });
+
+  it("returns ready when the script exits 0 after install and launch", async () => {
+    const exec = fakeExec([
+      {
+        command: /.*/,
+        result: {
+          exitCode: 0,
+          stderr: "PROGRESS:Installing Paseo…\nPROGRESS:Remote daemon is ready.\n",
+        },
+      },
+    ]);
+    const result = await ensureRemoteDaemon(makeEnsureOptions(exec));
+    expect(result).toEqual({ installed: false, launched: false, ready: true });
+  });
+
+  it("throws when node is missing (exit 10)", async () => {
+    const exec = fakeExec([{ command: /.*/, result: { exitCode: 10 } }]);
+    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(/Node.js/);
+  });
+
+  it("throws when install fails (exit 11)", async () => {
+    const exec = fakeExec([{ command: /.*/, result: { exitCode: 11, stderr: "npm ERR\n" } }]);
+    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(/Failed to install/);
+  });
+
+  it("throws when daemon does not become ready (exit 12)", async () => {
+    const exec = fakeExec([{ command: /.*/, result: { exitCode: 12 } }]);
+    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(
+      /did not become ready/,
+    );
+  });
+
+  it("throws SSH auth error when permission denied (exit 255)", async () => {
+    const exec = fakeExec([
+      { command: /.*/, result: { exitCode: 255, stderr: "Permission denied (publickey).\n" } },
+    ]);
+    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(
+      /SSH connection to .* failed: Permission denied/,
+    );
+  });
+
+  it("throws on unexpected exit code", async () => {
+    const exec = fakeExec([{ command: /.*/, result: { exitCode: 99, stderr: "weird\n" } }]);
+    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(/Failed to ensure/);
+  });
+
+  it("reports progress from stderr PROGRESS: lines", async () => {
+    const messages: string[] = [];
+    const exec = fakeExec([
+      {
+        command: /.*/,
+        result: { exitCode: 0, stderr: "PROGRESS:Remote daemon is already running.\n" },
+      },
+    ]);
+    await ensureRemoteDaemon({
+      ...makeEnsureOptions(exec),
+      onProgress: (m) => messages.push(m),
+    });
+    expect(messages).toContain("Remote daemon is already running.");
+  });
+});

--- a/packages/cli/tests/ssh-process.test.ts
+++ b/packages/cli/tests/ssh-process.test.ts
@@ -1,16 +1,25 @@
-import { describe, expect, it } from "vitest";
-import { buildSshBaseArgs } from "../src/ssh/ssh-process.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { buildSshBaseArgs, createTerminalAskpassScript } from "../src/ssh/ssh-process.js";
 import {
+  ASKPASS_CANCELLED_MARKER,
+  ENSURE_EXIT,
+  READY_MARKER,
+  REMOTE_SHELL_COMMAND,
   buildEnsureScript,
-  ensureRemoteDaemon,
+  describeEnsureFailure,
+  describeSshFailure,
   remoteExpandHome,
   remoteHomePath,
   remoteInstallPath,
-  remotePaseoBin,
-  type EnsureRemoteDaemonOptions,
-  type SshExecResult,
+  shellPath,
+  shellQuote,
 } from "../src/ssh/remote-daemon.js";
 import { normalizeSshHostConfig, type SshHostConfig } from "../src/ssh/ssh-host-config.js";
+
 function makeConfig(overrides: Partial<SshHostConfig> = {}): SshHostConfig {
   return normalizeSshHostConfig({
     id: "myhost",
@@ -21,23 +30,51 @@ function makeConfig(overrides: Partial<SshHostConfig> = {}): SshHostConfig {
 }
 
 describe("ssh-process: buildSshBaseArgs", () => {
-  it("includes port, BatchMode, host key, and user@host", () => {
+  it("includes BatchMode, host key policy, keepalives, and user@host", () => {
     const args = buildSshBaseArgs(makeConfig());
-    expect(args).toContain("-p");
-    expect(args).toContain("22");
     expect(args).toContain("BatchMode=yes");
     expect(args).toContain("StrictHostKeyChecking=accept-new");
+    expect(args).toContain("ServerAliveInterval=15");
+    expect(args).toContain("ServerAliveCountMax=3");
     expect(args).toContain("alice@server.example.com");
   });
 
-  it("uses the configured SSH port", () => {
+  it("omits -p entirely when no port is configured so ~/.ssh/config wins", () => {
+    expect(buildSshBaseArgs(makeConfig())).not.toContain("-p");
+  });
+
+  it("passes -p only when the port was set explicitly", () => {
     const args = buildSshBaseArgs(makeConfig({ port: 2222 }));
-    expect(args).toContain("2222");
+    expect(args[args.indexOf("-p") + 1]).toBe("2222");
+  });
+
+  it("drops BatchMode when an askpass program can answer the prompt", () => {
+    const args = buildSshBaseArgs(makeConfig(), { askpassPath: "/tmp/askpass.sh" });
+    expect(args).not.toContain("BatchMode=yes");
+  });
+
+  it("leaves the retry count alone so a typo stays retryable", () => {
+    // Cancellation is handled by the askpass marker instead, so there is no
+    // need to spend the user's retries to make Cancel work.
+    const args = buildSshBaseArgs(makeConfig(), { askpassPath: "/tmp/askpass.sh" });
+    expect(args.join(" ")).not.toContain("NumberOfPasswordPrompts");
   });
 });
 
-describe("remote-daemon: path helpers", () => {
-  it("expands ~ to $HOME", () => {
+describe("remote-daemon: shell quoting", () => {
+  it("neutralizes quotes, expansions, and backticks", () => {
+    expect(shellQuote("plain")).toBe("'plain'");
+    expect(shellQuote("it's")).toBe(`'it'\\''s'`);
+    expect(shellQuote("$(id)`id`")).toBe("'$(id)`id`'");
+  });
+
+  it("expands a leading tilde but quotes the rest of the path", () => {
+    expect(shellPath("~")).toBe(`"$HOME"`);
+    expect(shellPath("~/.paseo")).toBe(`"$HOME"/'.paseo'`);
+    expect(shellPath("/opt/p aseo")).toBe("'/opt/p aseo'");
+  });
+
+  it("expands ~ to $HOME for display paths", () => {
     expect(remoteExpandHome("~")).toBe("$HOME");
     expect(remoteExpandHome("~/foo")).toBe("$HOME/foo");
     expect(remoteExpandHome("/abs/path")).toBe("/abs/path");
@@ -48,142 +85,336 @@ describe("remote-daemon: path helpers", () => {
     expect(remoteHomePath(config)).toBe("$HOME/.paseo");
     expect(remoteInstallPath(config)).toBe("$HOME/.paseo/cli");
   });
-
-  it("derives the paseo bin path", () => {
-    const config = makeConfig();
-    expect(remotePaseoBin(config)).toBe('"$HOME/.paseo/cli/node_modules/.bin/paseo"');
-  });
 });
+
+/**
+ * Run a generated script the way the tunnel does: piped into a bare `sh` over
+ * stdin, exactly as `REMOTE_SHELL_COMMAND` arranges on the remote host.
+ * spawnSync closes stdin once the script is written, which stands in for the
+ * tunnel tearing the connection down.
+ */
+function runEnsureScript(
+  script: string,
+  options: { path: string; home?: string },
+): { status: number | null; stderr: string } {
+  const result = spawnSync("sh", {
+    encoding: "utf8",
+    input: script,
+    timeout: 30_000,
+    env: { PATH: options.path, HOME: options.home ?? tmpdir() },
+  });
+  return { status: result.status, stderr: result.stderr };
+}
+
+/**
+ * A PATH directory holding real coreutils plus the given stubs, so the ensure
+ * script runs for real against a controlled idea of what the "remote" host has
+ * installed.
+ */
+function makeBinDir(stubs: Record<string, string>): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "paseo-bin-"));
+  for (const tool of ["sh", "sleep", "mkdir", "printf", "echo", "cat", "true", "rm"]) {
+    if (stubs[tool]) continue;
+    const resolved = spawnSync("sh", ["-c", `command -v ${tool}`], { encoding: "utf8" });
+    const target = resolved.stdout.trim();
+    if (target) symlinkSync(target, path.join(dir, tool));
+  }
+  for (const [name, body] of Object.entries(stubs)) {
+    writeFileSync(path.join(dir, name), body, { mode: 0o755 });
+  }
+  return dir;
+}
+
 describe("remote-daemon: buildEnsureScript", () => {
-  it("includes port check, node check, install, launch, and ready wait", () => {
-    const config = makeConfig({ remotePort: 6767 });
-    const script = buildEnsureScript(config, "1.2.3");
+  it("is valid POSIX shell", () => {
+    const script = buildEnsureScript(makeConfig(), "1.2.3");
+    const result = spawnSync("sh", ["-n"], { input: script, encoding: "utf8" });
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+
+  it("covers check, install, launch, and readiness wait", () => {
+    const script = buildEnsureScript(makeConfig({ remotePort: 6767 }), "1.2.3");
     expect(script).toContain("6767");
-    expect(script).toContain("node -e");
-    expect(script).toContain("node -v");
-    expect(script).toContain("npm -v");
+    expect(script).toContain("command -v paseo");
     expect(script).toContain("npm install");
-    expect(script).toContain("@getpaseo/cli@1.2.3");
-    expect(script).toContain("$HOME/.paseo/cli");
+    expect(script).toContain("@getpaseo/cli@$paseo_want");
     expect(script).toContain("daemon start");
     expect(script).toContain("--no-relay");
     expect(script).toContain("--no-mcp");
-    expect(script).toContain("$HOME/.paseo");
-    expect(script).toContain("PROGRESS:");
+    expect(script).toContain(READY_MARKER);
   });
 
-  it("uses latest when version is empty", () => {
-    const config = makeConfig();
-    const script = buildEnsureScript(config, "");
-    expect(script).toContain("@getpaseo/cli");
-    expect(script).not.toContain("@getpaseo/cli@");
+  it("holds the connection open by falling through, with no keepalive command", () => {
+    // The script arrives on the remote sh's stdin, so running off the end
+    // leaves sh blocked for more input. `sleep infinity` (rejected by BusyBox
+    // and older BSD sleep) and `cat` are both unnecessary.
+    const script = buildEnsureScript(makeConfig(), "1.2.3");
+    expect(script).not.toContain("sleep infinity");
+    expect(script).not.toContain("exec cat");
+    expect(script.trimEnd().endsWith("[ $paseo_rc -eq 0 ] || exit $paseo_rc")).toBe(true);
+  });
+
+  it("propagates the ensure exit code instead of collapsing it to 1", () => {
+    const script = buildEnsureScript(makeConfig(), "1.2.3");
+    expect(script).toContain("exit $paseo_rc");
+  });
+
+  it("closes stdin for children that could otherwise swallow the script", () => {
+    // The script is on stdin; a child inheriting it and reading would eat the
+    // remainder of the script.
+    const script = buildEnsureScript(makeConfig(), "1.2.3");
+    for (const line of script.split("\n")) {
+      if (line.includes("npm install") || line.includes("daemon start")) {
+        expect(line).toContain("</dev/null");
+      }
+    }
+  });
+
+  it("neutralizes shell metacharacters in host paths", () => {
+    const script = buildEnsureScript(
+      makeConfig({ installDir: "~/a'b", remoteHome: "~/$(touch /tmp/pwned)" }),
+      "1.2.3",
+    );
+    expect(spawnSync("sh", ["-n"], { input: script, encoding: "utf8" }).status).toBe(0);
+    // Inside single quotes the expansion is inert.
+    expect(script).toContain(`"$HOME"/'$(touch /tmp/pwned)'`);
+  });
+
+  it("defaults to latest when no version is given", () => {
+    const script = buildEnsureScript(makeConfig(), "");
+    expect(script).toContain("paseo_want='latest'");
+  });
+
+  it("only falls back to latest when a specific version was requested", () => {
+    expect(buildEnsureScript(makeConfig(), "1.2.3")).toContain("@getpaseo/cli@latest");
+    // Already asking for latest: a second attempt would be pointless.
+    expect(buildEnsureScript(makeConfig(), "latest")).toContain('[ "$paseo_want" = latest ]');
   });
 });
 
-/** A sequential fake exec: returns responses in order, matching by pattern. */
-function fakeExec(
-  responses: { command: RegExp; result: Partial<SshExecResult> }[],
-): (command: string) => Promise<SshExecResult> {
-  let index = 0;
-  return async (command: string) => {
-    const entry = responses[index];
-    index += 1;
-    if (!entry || !entry.command.test(command)) {
-      throw new Error(
-        `Unexpected exec #${index} (expected ${entry?.command?.source ?? "end"}): ${command}`,
-      );
-    }
-    return {
-      stdout: "",
-      stderr: "",
-      exitCode: null,
-      signal: null,
-      timedOut: false,
-      ...entry.result,
-    };
-  };
-}
-
-function makeEnsureOptions(
-  exec: (command: string) => Promise<SshExecResult>,
-  overrides: Partial<EnsureRemoteDaemonOptions> = {},
-): EnsureRemoteDaemonOptions {
-  return {
-    config: makeConfig(),
-    exec,
-    ...overrides,
-  };
-}
-
-describe("remote-daemon: ensureRemoteDaemon", () => {
-  it("returns ready when the script exits 0 (daemon already running)", async () => {
-    const exec = fakeExec([
-      {
-        command: /.*/,
-        result: { exitCode: 0, stderr: "PROGRESS:Remote daemon is already running.\n" },
-      },
-    ]);
-    const result = await ensureRemoteDaemon(makeEnsureOptions(exec));
-    expect(result).toEqual({ installed: false, launched: false, ready: true });
-  });
-
-  it("returns ready when the script exits 0 after install and launch", async () => {
-    const exec = fakeExec([
-      {
-        command: /.*/,
-        result: {
-          exitCode: 0,
-          stderr: "PROGRESS:Installing Paseo…\nPROGRESS:Remote daemon is ready.\n",
-        },
-      },
-    ]);
-    const result = await ensureRemoteDaemon(makeEnsureOptions(exec));
-    expect(result).toEqual({ installed: false, launched: false, ready: true });
-  });
-
-  it("throws when node is missing (exit 10)", async () => {
-    const exec = fakeExec([{ command: /.*/, result: { exitCode: 10 } }]);
-    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(/Node.js/);
-  });
-
-  it("throws when install fails (exit 11)", async () => {
-    const exec = fakeExec([{ command: /.*/, result: { exitCode: 11, stderr: "npm ERR\n" } }]);
-    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(/Failed to install/);
-  });
-
-  it("throws when daemon does not become ready (exit 12)", async () => {
-    const exec = fakeExec([{ command: /.*/, result: { exitCode: 12 } }]);
-    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(
-      /did not become ready/,
-    );
-  });
-
-  it("throws SSH auth error when permission denied (exit 255)", async () => {
-    const exec = fakeExec([
-      { command: /.*/, result: { exitCode: 255, stderr: "Permission denied (publickey).\n" } },
-    ]);
-    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(
-      /SSH connection to .* failed: Permission denied/,
-    );
-  });
-
-  it("throws on unexpected exit code", async () => {
-    const exec = fakeExec([{ command: /.*/, result: { exitCode: 99, stderr: "weird\n" } }]);
-    await expect(ensureRemoteDaemon(makeEnsureOptions(exec))).rejects.toThrow(/Failed to ensure/);
-  });
-
-  it("reports progress from stderr PROGRESS: lines", async () => {
-    const messages: string[] = [];
-    const exec = fakeExec([
-      {
-        command: /.*/,
-        result: { exitCode: 0, stderr: "PROGRESS:Remote daemon is already running.\n" },
-      },
-    ]);
-    await ensureRemoteDaemon({
-      ...makeEnsureOptions(exec),
-      onProgress: (m) => messages.push(m),
+/**
+ * These run the generated script through a real `sh` against stubbed
+ * executables. Asserting on the emitted markers and exit codes is what proves
+ * the contract the tunnel depends on, which string matching on the script
+ * source cannot.
+ */
+describe("remote-daemon: keepalive over stdin", () => {
+  it("keeps the shell alive after a successful run and exits when stdin closes", async () => {
+    // The whole port forward depends on this: the remote shell must still be
+    // running once the script succeeds, and must exit when we close stdin.
+    const bin = makeBinDir({ node: `#!/bin/sh\nexit 0\n` });
+    // `sh -c "exec /bin/sh"` is what sshd does with REMOTE_SHELL_COMMAND.
+    const child = spawn("sh", ["-c", REMOTE_SHELL_COMMAND], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { PATH: bin, HOME: tmpdir() },
     });
-    expect(messages).toContain("Remote daemon is already running.");
+    const exited = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.stdin.write(`${buildEnsureScript(makeConfig(), "1.2.3")}\n`);
+    await vi.waitFor(() => expect(stderr).toContain(`${READY_MARKER}running`));
+
+    // Ready, and still running with stdin held open.
+    expect(child.exitCode).toBeNull();
+
+    child.stdin.end();
+    expect(await exited).toBe(0);
+    rmSync(bin, { recursive: true, force: true });
+  });
+});
+
+describe("remote-daemon: REMOTE_SHELL_COMMAND", () => {
+  it("is metacharacter-free so any login shell parses it identically", () => {
+    // sshd runs `<user's shell> -c "<command>"` with the shell from the
+    // password database, so this string may be parsed by fish or tcsh.
+    expect(REMOTE_SHELL_COMMAND).toBe("exec /bin/sh");
+    expect(REMOTE_SHELL_COMMAND).not.toMatch(/['"`$\\\n;&|<>()]/);
+  });
+});
+
+describe("remote-daemon: ensure script behavior", () => {
+  const cleanups: string[] = [];
+  const bin = (stubs: Record<string, string>): string => {
+    const dir = makeBinDir(stubs);
+    cleanups.push(dir);
+    return dir;
+  };
+  afterEach(() => {
+    for (const dir of cleanups.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Stub `node` so the port probe succeeds only once `marker` exists. */
+  const nodeProbe = (marker?: string) =>
+    marker ? `#!/bin/sh\n[ -f ${marker} ] && exit 0\nexit 1\n` : `#!/bin/sh\nexit 1\n`;
+
+  it("reports READY:running and exits 0 when the daemon is already listening", () => {
+    const dir = bin({ node: `#!/bin/sh\nexit 0\n` });
+    const { status, stderr } = runEnsureScript(buildEnsureScript(makeConfig(), "1.2.3"), {
+      path: dir,
+    });
+    expect(status).toBe(0);
+    expect(stderr).toContain(`${READY_MARKER}running`);
+    // Nothing should have been installed or launched.
+    expect(stderr).not.toContain("Launching");
+  });
+
+  it("exits nodeMissing when the host has no node", () => {
+    const { status, stderr } = runEnsureScript(buildEnsureScript(makeConfig(), "1.2.3"), {
+      path: bin({}),
+    });
+    expect(status).toBe(ENSURE_EXIT.nodeMissing);
+    expect(stderr).toContain("Node.js is required");
+  });
+
+  it("prefers a paseo already on PATH over installing a second copy", () => {
+    const markerDir = mkdtempSync(path.join(tmpdir(), "paseo-marker-"));
+    cleanups.push(markerDir);
+    const marker = path.join(markerDir, "launched");
+    const dir = bin({
+      node: nodeProbe(marker),
+      paseo: `#!/bin/sh\necho "$*" > ${marker}\nexit 0\n`,
+      // Reaching npm at all would mean a conflicting second daemon.
+      npm: `#!/bin/sh\necho SHOULD_NOT_INSTALL >&2\nexit 0\n`,
+    });
+    const { status, stderr } = runEnsureScript(buildEnsureScript(makeConfig(), "1.2.3"), {
+      path: dir,
+    });
+    expect(status).toBe(0);
+    expect(stderr).toContain("Using the Paseo already installed");
+    expect(stderr).not.toContain("SHOULD_NOT_INSTALL");
+    expect(stderr).toContain(`${READY_MARKER}launched`);
+    expect(readFileSync(marker, "utf8")).toContain("daemon start");
+  });
+
+  it("passes the configured home and port to the daemon it launches", () => {
+    const markerDir = mkdtempSync(path.join(tmpdir(), "paseo-marker-"));
+    cleanups.push(markerDir);
+    const marker = path.join(markerDir, "launched");
+    const dir = bin({
+      node: nodeProbe(marker),
+      paseo: `#!/bin/sh\necho "$*" > ${marker}\nexit 0\n`,
+    });
+    const config = makeConfig({ remotePort: 7777, remoteHome: "/tmp/paseo-remote-home" });
+    runEnsureScript(buildEnsureScript(config, "1.2.3"), { path: dir });
+    const argv = readFileSync(marker, "utf8");
+    expect(argv).toContain("--home /tmp/paseo-remote-home");
+    expect(argv).toContain("--port 7777");
+    expect(argv).toContain("--no-relay");
+  });
+
+  it("exits npmMissing when it must install but npm is absent", () => {
+    const { status, stderr } = runEnsureScript(buildEnsureScript(makeConfig(), "1.2.3"), {
+      path: bin({ node: nodeProbe() }),
+    });
+    expect(status).toBe(ENSURE_EXIT.npmMissing);
+    expect(stderr).toContain("npm is required");
+  });
+
+  it("falls back to latest when the pinned version is not published", () => {
+    const markerDir = mkdtempSync(path.join(tmpdir(), "paseo-marker-"));
+    cleanups.push(markerDir);
+    const marker = path.join(markerDir, "launched");
+    const installDir = path.join(markerDir, "cli");
+    const dir = bin({
+      node: nodeProbe(marker),
+      // Reject the pinned spec the way the registry would for a dev build,
+      // accept @latest, and drop the managed binary in place.
+      npm: `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    *@latest)
+      mkdir -p "${installDir}/node_modules/.bin"
+      printf '#!/bin/sh\\necho "$*" > ${marker}\\n' > "${installDir}/node_modules/.bin/paseo"
+      chmod +x "${installDir}/node_modules/.bin/paseo"
+      exit 0 ;;
+    *@9.9.9-unpublished) echo "npm ERR! 404 Not Found" >&2; exit 1 ;;
+  esac
+done
+exit 1
+`,
+      chmod: `#!/bin/sh\nexec /usr/bin/chmod "$@"\n`,
+    });
+    const config = makeConfig({ installDir });
+    const { status, stderr } = runEnsureScript(buildEnsureScript(config, "9.9.9-unpublished"), {
+      path: dir,
+    });
+    expect(stderr).toContain("is not published");
+    expect(status).toBe(0);
+    expect(stderr).toContain(`${READY_MARKER}launched`);
+  });
+});
+
+describe("remote-daemon: failure descriptions", () => {
+  const config = makeConfig();
+
+  it("explains a missing runtime", () => {
+    const message = describeEnsureFailure({
+      config,
+      exitCode: ENSURE_EXIT.nodeMissing,
+      stderr: "",
+    });
+    expect(message).toMatch(/Node\.js is required/);
+    expect(message).toMatch(/nodejs\.org/);
+  });
+
+  it("includes npm output when the install fails", () => {
+    const message = describeEnsureFailure({
+      config,
+      exitCode: ENSURE_EXIT.installFailed,
+      stderr: "npm ERR! 404 Not Found",
+    });
+    expect(message).toContain("npm ERR! 404 Not Found");
+  });
+
+  it("points at the remote log when the daemon never listens", () => {
+    const message = describeEnsureFailure({ config, exitCode: ENSURE_EXIT.notReady, stderr: "" });
+    expect(message).toContain("~/.paseo/daemon.log");
+  });
+
+  it("surfaces the ssh diagnostic rather than an opaque exit code", () => {
+    // The single most common failure: SSH itself refused the connection.
+    const message = describeEnsureFailure({
+      config,
+      exitCode: 255,
+      stderr: "alice@server.example.com: Permission denied (publickey).",
+    });
+    expect(message).toContain("SSH connection to server.example.com failed");
+    expect(message).toContain("Permission denied (publickey)");
+  });
+
+  it("falls back to the exit code only when there is no stderr at all", () => {
+    expect(describeSshFailure("h", 7, "")).toContain("exit code 7");
+  });
+});
+
+describe("ssh-process: terminal askpass", () => {
+  it("produces valid POSIX shell without bash-only `read -s`", () => {
+    const askpass = createTerminalAskpassScript();
+    expect(spawnSync("sh", ["-n", askpass.path], { encoding: "utf8" }).status).toBe(0);
+    const body = readFileSync(askpass.path, "utf8");
+    // dash is /bin/sh on Debian and Ubuntu and rejects `read -s`.
+    expect(body).not.toMatch(/read\s+-\w*s/);
+    expect(body).toContain("stty -echo");
+    askpass.cleanup();
+  });
+
+  it("reports EOF as a cancellation rather than an empty password", () => {
+    const askpass = createTerminalAskpassScript();
+    expect(readFileSync(askpass.path, "utf8")).toContain(`echo "${ASKPASS_CANCELLED_MARKER}" >&2`);
+    askpass.cleanup();
+  });
+
+  it("writes into a private directory and removes it on cleanup", () => {
+    const askpass = createTerminalAskpassScript();
+    const dir = path.dirname(askpass.path);
+    expect(dir).not.toBe(tmpdir());
+    askpass.cleanup();
+    expect(spawnSync("test", ["-d", dir]).status).not.toBe(0);
   });
 });

--- a/packages/cli/tests/ssh-process.test.ts
+++ b/packages/cli/tests/ssh-process.test.ts
@@ -30,7 +30,6 @@ describe("ssh-process: buildSshBaseArgs", () => {
     expect(args).toContain("alice@server.example.com");
   });
 
-
   it("uses the configured SSH port", () => {
     const args = buildSshBaseArgs(makeConfig({ port: 2222 }));
     expect(args).toContain("2222");

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -7,11 +7,10 @@ log.initialize({ spyRendererConsole: true });
 import { inheritLoginShellEnv } from "./login-shell-env.js";
 
 import path from "node:path";
-import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { existsSync } from "node:fs";
-import { execFileSync } from "node:child_process";
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import {
   app,
   autoUpdater as electronAutoUpdater,
@@ -100,10 +99,10 @@ import {
 import { AgentNavigationInbox, parseAgentDeepLinkFromArgv } from "./agent-navigation.js";
 import {
   SshTunnel,
-  ensureRemoteDaemon,
   normalizeSshHostConfig,
   createAskpassScript,
   cleanupAskpassScript,
+  buildEnsureScript,
 } from "@getpaseo/cli/ssh";
 
 const DEV_SERVER_URL = process.env.EXPO_DEV_URL ?? "http://localhost:8081";
@@ -607,12 +606,6 @@ ipcMain.handle("paseo:browser:copy-element", (_event, payload: unknown): boolean
   return false;
 });
 
-function sshControlPath(config: { host: string; port: number; user?: string }): string {
-  const key = `${config.user ?? ""}@${config.host}:${config.port}`;
-  const hash = createHash("sha256").update(key).digest("hex").slice(0, 12);
-  return path.join(tmpdir(), `paseo-ssh-${hash}.sock`);
-}
-
 function parseSshConfig(config: Record<string, unknown>) {
   return normalizeSshHostConfig({
     id: "desktop",
@@ -629,9 +622,13 @@ ipcMain.handle("paseo:ssh:open-tunnel", async (_event, config: Record<string, un
   const sshConfig = parseSshConfig(config);
   console.log("[ssh] open-tunnel:", sshConfig.host, "port", sshConfig.port);
   try {
+    const version =
+      typeof config.version === "string" ? config.version : (sshConfig.packageVersion ?? "latest");
+    const ensureScript = buildEnsureScript(sshConfig, version);
     const tunnel = await SshTunnel.open(sshConfig, sshConfig.remotePort, {
       askpassPath: sshAskpassScript,
-      controlPath: sshControlPath(sshConfig),
+      ensureScript,
+      onProgress: (msg) => console.log("[ssh] progress:", msg),
     });
     const tunnelId = randomUUID();
     sshTunnels.set(tunnelId, tunnel);
@@ -651,26 +648,6 @@ ipcMain.handle("paseo:ssh:close-tunnel", async (_event, tunnelId: string) => {
     sshTunnels.delete(tunnelId);
   }
 });
-ipcMain.handle(
-  "paseo:ssh:ensure-remote-daemon",
-  async (_event, config: Record<string, unknown>) => {
-    const sshConfig = parseSshConfig(config);
-    console.log("[ssh] ensure-remote-daemon:", sshConfig.host, "port", sshConfig.port);
-    try {
-      const result = await ensureRemoteDaemon({
-        config: sshConfig,
-        askpassPath: sshAskpassScript,
-        controlPath: sshControlPath(sshConfig),
-        onProgress: (msg) => console.log("[ssh] ensure progress:", msg),
-      });
-      console.log("[ssh] ensure result:", JSON.stringify(result));
-      return result;
-    } catch (err) {
-      console.error("[ssh] ensure failed:", err instanceof Error ? err.message : String(err));
-      throw err;
-    }
-  },
-);
 
 protocol.registerSchemesAsPrivileged([
   {

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -7,9 +7,11 @@ log.initialize({ spyRendererConsole: true });
 import { inheritLoginShellEnv } from "./login-shell-env.js";
 
 import path from "node:path";
+import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
 import {
   app,
   autoUpdater as electronAutoUpdater,
@@ -96,15 +98,25 @@ import {
   type AgentDeepLinkTarget,
 } from "@getpaseo/protocol/agent-deep-link";
 import { AgentNavigationInbox, parseAgentDeepLinkFromArgv } from "./agent-navigation.js";
+import {
+  SshTunnel,
+  ensureRemoteDaemon,
+  normalizeSshHostConfig,
+  createAskpassScript,
+  cleanupAskpassScript,
+} from "@getpaseo/cli/ssh";
 
 const DEV_SERVER_URL = process.env.EXPO_DEV_URL ?? "http://localhost:8081";
 const APP_SCHEME = "paseo";
 const PASEO_DEBUG = process.env.PASEO_DEBUG === "1";
+const sshAskpassScript = createAskpassScript();
+app.on("will-quit", () => cleanupAskpassScript(sshAskpassScript));
 const DISABLE_SINGLE_INSTANCE_LOCK = process.env.PASEO_DISABLE_SINGLE_INSTANCE_LOCK === "1";
 const APP_NAME = process.env.PASEO_TEST_APP_NAME?.trim() || "Paseo";
 const UPDATE_QUIT_DEADLINE_MS = 5_000;
 const pendingBrowserWindowOpenRequests = new PendingBrowserWindowOpenRequests();
 const agentNavigationInbox = new AgentNavigationInbox();
+const sshTunnels = new Map<string, SshTunnel>();
 
 // A second-instance launch can arrive before the packaged protocol handler,
 // IPC handlers, and first window exist. Wait for full bootstrap, not just
@@ -595,6 +607,71 @@ ipcMain.handle("paseo:browser:copy-element", (_event, payload: unknown): boolean
   return false;
 });
 
+function sshControlPath(config: { host: string; port: number; user?: string }): string {
+  const key = `${config.user ?? ""}@${config.host}:${config.port}`;
+  const hash = createHash("sha256").update(key).digest("hex").slice(0, 12);
+  return path.join(tmpdir(), `paseo-ssh-${hash}.sock`);
+}
+
+function parseSshConfig(config: Record<string, unknown>) {
+  return normalizeSshHostConfig({
+    id: "desktop",
+    label: "desktop",
+    host: String(config.host ?? ""),
+    user: String(config.user ?? ""),
+    port: typeof config.port === "number" ? config.port : undefined,
+    remotePort: typeof config.remotePort === "number" ? config.remotePort : undefined,
+    remoteHome: typeof config.remoteHome === "string" ? config.remoteHome : undefined,
+    installDir: typeof config.installDir === "string" ? config.installDir : undefined,
+  });
+}
+ipcMain.handle("paseo:ssh:open-tunnel", async (_event, config: Record<string, unknown>) => {
+  const sshConfig = parseSshConfig(config);
+  console.log("[ssh] open-tunnel:", sshConfig.host, "port", sshConfig.port);
+  try {
+    const tunnel = await SshTunnel.open(sshConfig, sshConfig.remotePort, {
+      askpassPath: sshAskpassScript,
+      controlPath: sshControlPath(sshConfig),
+    });
+    const tunnelId = randomUUID();
+    sshTunnels.set(tunnelId, tunnel);
+    console.log("[ssh] tunnel open:", tunnelId, "localPort", tunnel.localPort);
+    return { tunnelId, localPort: tunnel.localPort };
+  } catch (err) {
+    console.error("[ssh] tunnel open failed:", err instanceof Error ? err.message : String(err));
+    throw err;
+  }
+});
+
+ipcMain.handle("paseo:ssh:close-tunnel", async (_event, tunnelId: string) => {
+  console.log("[ssh] close-tunnel:", tunnelId);
+  const tunnel = sshTunnels.get(tunnelId);
+  if (tunnel) {
+    tunnel.close();
+    sshTunnels.delete(tunnelId);
+  }
+});
+ipcMain.handle(
+  "paseo:ssh:ensure-remote-daemon",
+  async (_event, config: Record<string, unknown>) => {
+    const sshConfig = parseSshConfig(config);
+    console.log("[ssh] ensure-remote-daemon:", sshConfig.host, "port", sshConfig.port);
+    try {
+      const result = await ensureRemoteDaemon({
+        config: sshConfig,
+        askpassPath: sshAskpassScript,
+        controlPath: sshControlPath(sshConfig),
+        onProgress: (msg) => console.log("[ssh] ensure progress:", msg),
+      });
+      console.log("[ssh] ensure result:", JSON.stringify(result));
+      return result;
+    } catch (err) {
+      console.error("[ssh] ensure failed:", err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  },
+);
+
 protocol.registerSchemesAsPrivileged([
   {
     scheme: APP_SCHEME,
@@ -713,6 +790,21 @@ async function createWindow(
       webviewTag: true,
     },
   });
+
+  // Strip the Origin header for WebSocket upgrades to loopback addresses.
+  // The Electron renderer's Origin (e.g. http://localhost:8083 from Metro) won't
+  // match the SSH tunnel port (e.g. 127.0.0.1:35173). The daemon's same-origin
+  // check rejects the mismatch, causing 1006. Without an Origin header, the
+  // daemon accepts the connection — the SSH tunnel itself is the trust boundary.
+  mainWindow.webContents.session.webRequest.onBeforeSendHeaders(
+    { urls: ["ws://127.0.0.1:*/*", "ws://localhost:*/*"] },
+    (details, callback) => {
+      if (details.resourceType === "webSocket") {
+        delete details.requestHeaders.Origin;
+      }
+      callback({ requestHeaders: details.requestHeaders });
+    },
+  );
 
   const webContentsId = mainWindow.webContents.id;
   pendingOpenProjectStore.set(webContentsId, options.pendingOpenProjectPath);

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -628,7 +628,12 @@ ipcMain.handle("paseo:ssh:open-tunnel", async (_event, config: Record<string, un
     const tunnel = await SshTunnel.open(sshConfig, sshConfig.remotePort, {
       askpassPath: sshAskpassScript,
       ensureScript,
-      onProgress: (msg) => console.log("[ssh] progress:", msg),
+      onProgress: (msg) => {
+        console.log("[ssh] progress:", msg);
+        for (const win of BrowserWindow.getAllWindows()) {
+          win.webContents.send("paseo:event:ssh-progress", { host: sshConfig.host, message: msg });
+        }
+      },
     });
     const tunnelId = randomUUID();
     sshTunnels.set(tunnelId, tunnel);

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -100,22 +100,113 @@ import { AgentNavigationInbox, parseAgentDeepLinkFromArgv } from "./agent-naviga
 import {
   SshTunnel,
   normalizeSshHostConfig,
-  createAskpassScript,
-  cleanupAskpassScript,
+  createAskpassChannel,
+  type AskpassRequest,
   buildEnsureScript,
 } from "@getpaseo/cli/ssh";
 
 const DEV_SERVER_URL = process.env.EXPO_DEV_URL ?? "http://localhost:8081";
 const APP_SCHEME = "paseo";
 const PASEO_DEBUG = process.env.PASEO_DEBUG === "1";
-const sshAskpassScript = createAskpassScript();
-app.on("will-quit", () => cleanupAskpassScript(sshAskpassScript));
 const DISABLE_SINGLE_INSTANCE_LOCK = process.env.PASEO_DISABLE_SINGLE_INSTANCE_LOCK === "1";
 const APP_NAME = process.env.PASEO_TEST_APP_NAME?.trim() || "Paseo";
 const UPDATE_QUIT_DEADLINE_MS = 5_000;
 const pendingBrowserWindowOpenRequests = new PendingBrowserWindowOpenRequests();
 const agentNavigationInbox = new AgentNavigationInbox();
 const sshTunnels = new Map<string, SshTunnel>();
+
+/**
+ * Password prompts waiting on the renderer. SSH asks through our own askpass
+ * channel rather than a system dialog, so the prompt is rendered by Paseo and
+ * the answer comes back through IPC.
+ */
+const pendingSshPrompts = new Map<string, (secret: string | null) => void>();
+
+function requestSshSecretFromRenderer(input: {
+  requestId: string;
+  host: string;
+  request: AskpassRequest;
+}): Promise<string | null> {
+  return new Promise((resolve) => {
+    pendingSshPrompts.set(input.requestId, resolve);
+    broadcastToRenderers("paseo:event:ssh-password-request", {
+      requestId: input.requestId,
+      host: input.host,
+      prompt: input.request.prompt,
+      kind: input.request.kind,
+    });
+  });
+}
+
+function settleSshPrompt(requestId: string, secret: string | null): void {
+  const resolve = pendingSshPrompts.get(requestId);
+  if (!resolve) return;
+  pendingSshPrompts.delete(requestId);
+  resolve(secret);
+}
+
+/**
+ * Local ports this process currently forwards over SSH.
+ *
+ * The renderer's Origin (`http://localhost:8081` in dev, `paseo://…` when
+ * packaged) never matches a tunnel's ephemeral loopback port, so the remote
+ * daemon's same-origin check rejects the upgrade and the socket closes with
+ * 1006. Stripping Origin is the fix, but only for these ports: the check is
+ * the daemon's DNS-rebinding defense, and disabling it for all of loopback
+ * would also disable it for a directly-connected local daemon.
+ */
+const sshTunnelPorts = new Map<string, number>();
+
+function rememberTunnelPort(tunnelId: string, localPort: number): void {
+  sshTunnelPorts.set(tunnelId, localPort);
+}
+
+function forgetTunnelPort(tunnelId: string): void {
+  sshTunnelPorts.delete(tunnelId);
+}
+
+function isSshTunnelUrl(rawUrl: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost") return false;
+  const port = Number(parsed.port);
+  if (!Number.isInteger(port)) return false;
+  for (const tunnelPort of sshTunnelPorts.values()) {
+    if (tunnelPort === port) return true;
+  }
+  return false;
+}
+
+/**
+ * Install the Origin-stripping rule once per session. `onBeforeSendHeaders`
+ * allows a single listener per session, so registering it per window would
+ * silently replace whatever was registered before.
+ */
+const sessionsWithSshHeaderRule = new WeakSet<Electron.Session>();
+
+function installSshOriginRule(targetSession: Electron.Session): void {
+  if (sessionsWithSshHeaderRule.has(targetSession)) return;
+  sessionsWithSshHeaderRule.add(targetSession);
+  targetSession.webRequest.onBeforeSendHeaders(
+    { urls: ["ws://127.0.0.1:*/*", "ws://localhost:*/*"] },
+    (details, callback) => {
+      if (details.resourceType !== "webSocket" || !isSshTunnelUrl(details.url)) {
+        callback({ requestHeaders: details.requestHeaders });
+        return;
+      }
+      // Header names are case-insensitive on the wire; Chromium's casing here
+      // is not contractual, so match rather than delete a fixed spelling.
+      const requestHeaders = Object.fromEntries(
+        Object.entries(details.requestHeaders).filter(([name]) => name.toLowerCase() !== "origin"),
+      );
+      callback({ requestHeaders });
+    },
+  );
+}
 
 // A second-instance launch can arrive before the packaged protocol handler,
 // IPC handlers, and first window exist. Wait for full bootstrap, not just
@@ -612,46 +703,86 @@ function parseSshConfig(config: Record<string, unknown>) {
     label: "desktop",
     host: String(config.host ?? ""),
     user: String(config.user ?? ""),
+    // Undefined, not 22: an unset port lets the user's ~/.ssh/config decide.
     port: typeof config.port === "number" ? config.port : undefined,
     remotePort: typeof config.remotePort === "number" ? config.remotePort : undefined,
     remoteHome: typeof config.remoteHome === "string" ? config.remoteHome : undefined,
     installDir: typeof config.installDir === "string" ? config.installDir : undefined,
   });
 }
+
+function broadcastToRenderers(channel: string, payload: unknown): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(channel, payload);
+  }
+}
+
 ipcMain.handle("paseo:ssh:open-tunnel", async (_event, config: Record<string, unknown>) => {
   const sshConfig = parseSshConfig(config);
-  console.log("[ssh] open-tunnel:", sshConfig.host, "port", sshConfig.port);
+  const requestId = typeof config.requestId === "string" ? config.requestId : randomUUID();
+  log.info("[ssh] open-tunnel", { host: sshConfig.host, port: sshConfig.port, requestId });
+
+  // One channel per attempt: SSH answers prompts through Paseo's own UI, and
+  // the channel's signal is how a declined prompt stops the connection at once
+  // instead of letting SSH retry.
+  const askpass = await createAskpassChannel({
+    onPrompt: (request) =>
+      requestSshSecretFromRenderer({ requestId, host: sshConfig.host, request }),
+  });
+
   try {
     const version =
       typeof config.version === "string" ? config.version : (sshConfig.packageVersion ?? "latest");
-    const ensureScript = buildEnsureScript(sshConfig, version);
+    const tunnelId = randomUUID();
     const tunnel = await SshTunnel.open(sshConfig, sshConfig.remotePort, {
-      askpassPath: sshAskpassScript,
-      ensureScript,
-      onProgress: (msg) => {
-        console.log("[ssh] progress:", msg);
-        for (const win of BrowserWindow.getAllWindows()) {
-          win.webContents.send("paseo:event:ssh-progress", { host: sshConfig.host, message: msg });
-        }
+      askpassPath: askpass.askpassPath,
+      cancelSignal: askpass.signal,
+      ensureScript: buildEnsureScript(sshConfig, version),
+      onProgress: (message) => {
+        // Tagged with requestId so two connects to the same host don't mix.
+        broadcastToRenderers("paseo:event:ssh-progress", { requestId, message });
+      },
+      onClose: (reason) => {
+        log.warn("[ssh] tunnel closed unexpectedly", { tunnelId, reason });
+        forgetTunnelPort(tunnelId);
+        sshTunnels.delete(tunnelId);
+        broadcastToRenderers("paseo:event:ssh-closed", { tunnelId, host: sshConfig.host, reason });
       },
     });
-    const tunnelId = randomUUID();
     sshTunnels.set(tunnelId, tunnel);
-    console.log("[ssh] tunnel open:", tunnelId, "localPort", tunnel.localPort);
+    rememberTunnelPort(tunnelId, tunnel.localPort);
+    log.info("[ssh] tunnel open", { tunnelId, localPort: tunnel.localPort });
     return { tunnelId, localPort: tunnel.localPort };
-  } catch (err) {
-    console.error("[ssh] tunnel open failed:", err instanceof Error ? err.message : String(err));
-    throw err;
+  } catch (error) {
+    log.error("[ssh] tunnel open failed", {
+      host: sshConfig.host,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    // Authentication is over either way; nothing should be able to prompt now.
+    settleSshPrompt(requestId, null);
+    askpass.close();
   }
 });
 
+ipcMain.handle(
+  "paseo:ssh:submit-password",
+  (_event, payload: { requestId?: unknown; secret?: unknown }) => {
+    const requestId = typeof payload?.requestId === "string" ? payload.requestId : null;
+    if (!requestId) return;
+    // A null secret is the user declining, which is a real answer.
+    settleSshPrompt(requestId, typeof payload.secret === "string" ? payload.secret : null);
+  },
+);
+
 ipcMain.handle("paseo:ssh:close-tunnel", async (_event, tunnelId: string) => {
-  console.log("[ssh] close-tunnel:", tunnelId);
   const tunnel = sshTunnels.get(tunnelId);
-  if (tunnel) {
-    tunnel.close();
-    sshTunnels.delete(tunnelId);
-  }
+  if (!tunnel) return;
+  log.info("[ssh] close-tunnel", { tunnelId });
+  tunnel.close();
+  sshTunnels.delete(tunnelId);
+  forgetTunnelPort(tunnelId);
 });
 
 protocol.registerSchemesAsPrivileged([
@@ -773,20 +904,7 @@ async function createWindow(
     },
   });
 
-  // Strip the Origin header for WebSocket upgrades to loopback addresses.
-  // The Electron renderer's Origin (e.g. http://localhost:8083 from Metro) won't
-  // match the SSH tunnel port (e.g. 127.0.0.1:35173). The daemon's same-origin
-  // check rejects the mismatch, causing 1006. Without an Origin header, the
-  // daemon accepts the connection — the SSH tunnel itself is the trust boundary.
-  mainWindow.webContents.session.webRequest.onBeforeSendHeaders(
-    { urls: ["ws://127.0.0.1:*/*", "ws://localhost:*/*"] },
-    (details, callback) => {
-      if (details.resourceType === "webSocket") {
-        delete details.requestHeaders.Origin;
-      }
-      callback({ requestHeaders: details.requestHeaders });
-    },
-  );
+  installSshOriginRule(mainWindow.webContents.session);
 
   const webContentsId = mainWindow.webContents.id;
   pendingOpenProjectStore.set(webContentsId, options.pendingOpenProjectPath);

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -128,5 +128,7 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
     openTunnel: (config: Record<string, unknown>) =>
       ipcRenderer.invoke("paseo:ssh:open-tunnel", config),
     closeTunnel: (tunnelId: string) => ipcRenderer.invoke("paseo:ssh:close-tunnel", tunnelId),
+    submitPassword: (payload: { requestId: string; secret: string | null }) =>
+      ipcRenderer.invoke("paseo:ssh:submit-password", payload),
   },
 });

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -128,7 +128,5 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
     openTunnel: (config: Record<string, unknown>) =>
       ipcRenderer.invoke("paseo:ssh:open-tunnel", config),
     closeTunnel: (tunnelId: string) => ipcRenderer.invoke("paseo:ssh:close-tunnel", tunnelId),
-    ensureRemoteDaemon: (config: Record<string, unknown>) =>
-      ipcRenderer.invoke("paseo:ssh:ensure-remote-daemon", config),
   },
 });

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -124,4 +124,11 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
     copyElement: (payload: { text?: string; imageDataUrl?: string }) =>
       ipcRenderer.invoke("paseo:browser:copy-element", payload),
   },
+  ssh: {
+    openTunnel: (config: Record<string, unknown>) =>
+      ipcRenderer.invoke("paseo:ssh:open-tunnel", config),
+    closeTunnel: (tunnelId: string) => ipcRenderer.invoke("paseo:ssh:close-tunnel", tunnelId),
+    ensureRemoteDaemon: (config: Record<string, unknown>) =>
+      ipcRenderer.invoke("paseo:ssh:ensure-remote-daemon", config),
+  },
 });

--- a/packages/protocol/src/host-connection-schema.ts
+++ b/packages/protocol/src/host-connection-schema.ts
@@ -11,13 +11,21 @@ export const DirectTcpHostConnectionSchema = z.object({
 export type DirectTcpHostConnection = z.input<typeof DirectTcpHostConnectionSchema>;
 export type NormalizedDirectTcpHostConnection = z.output<typeof DirectTcpHostConnectionSchema>;
 
+/** Port `ssh` itself uses when neither Paseo nor `~/.ssh/config` names one. */
+export const DEFAULT_SSH_PORT = 22;
+/** Port the remote daemon listens on, and the far end of the tunnel. */
+export const DEFAULT_SSH_REMOTE_PORT = 6767;
+
 export const SshHostConnectionSchema = z.object({
   id: z.string(),
   type: z.literal("ssh"),
   host: z.string(),
-  port: z.number().int().min(1).max(65535).optional().default(22),
+  // Deliberately *not* defaulted. "Unset" has to stay distinguishable from
+  // "22" so the CLI can omit `-p` and let a `Port` directive in the user's
+  // ~/.ssh/config win. Display code falls back to DEFAULT_SSH_PORT.
+  port: z.number().int().min(1).max(65535).optional(),
   user: z.string().optional(),
-  remotePort: z.number().int().min(1).max(65535).optional().default(6767),
+  remotePort: z.number().int().min(1).max(65535).optional().default(DEFAULT_SSH_REMOTE_PORT),
   remoteHome: z.string().optional().default("~/.paseo"),
   installDir: z.string().optional().default("~/.paseo/cli"),
 });
@@ -27,9 +35,9 @@ export type NormalizedSshHostConnection = z.output<typeof SshHostConnectionSchem
 
 /**
  * Apply defaults to an SSH connection. Fields that are undefined get the
- * schema defaults (port 22, remotePort 6767, remoteHome ~/.paseo, installDir
- * ~/.paseo/cli). Shared by the CLI, desktop, and app so the defaults live in
- * one place — the protocol schema.
+ * schema defaults (remotePort 6767, remoteHome ~/.paseo, installDir
+ * ~/.paseo/cli); `port` stays undefined on purpose. Shared by the CLI,
+ * desktop, and app so the defaults live in one place — the protocol schema.
  */
 export function normalizeSshConnection(
   input: Partial<SshHostConnection> & { id: string; host: string },

--- a/packages/protocol/src/host-connection-schema.ts
+++ b/packages/protocol/src/host-connection-schema.ts
@@ -10,3 +10,32 @@ export const DirectTcpHostConnectionSchema = z.object({
 
 export type DirectTcpHostConnection = z.input<typeof DirectTcpHostConnectionSchema>;
 export type NormalizedDirectTcpHostConnection = z.output<typeof DirectTcpHostConnectionSchema>;
+
+export const SshHostConnectionSchema = z.object({
+  id: z.string(),
+  type: z.literal("ssh"),
+  host: z.string(),
+  port: z.number().int().min(1).max(65535).optional().default(22),
+  user: z.string().optional(),
+  remotePort: z.number().int().min(1).max(65535).optional().default(6767),
+  remoteHome: z.string().optional().default("~/.paseo"),
+  installDir: z.string().optional().default("~/.paseo/cli"),
+});
+
+export type SshHostConnection = z.input<typeof SshHostConnectionSchema>;
+export type NormalizedSshHostConnection = z.output<typeof SshHostConnectionSchema>;
+
+/**
+ * Apply defaults to an SSH connection. Fields that are undefined get the
+ * schema defaults (port 22, remotePort 6767, remoteHome ~/.paseo, installDir
+ * ~/.paseo/cli). Shared by the CLI, desktop, and app so the defaults live in
+ * one place — the protocol schema.
+ */
+export function normalizeSshConnection(
+  input: Partial<SshHostConnection> & { id: string; host: string },
+): NormalizedSshHostConnection {
+  return SshHostConnectionSchema.parse({
+    type: "ssh",
+    ...input,
+  });
+}


### PR DESCRIPTION
## Summary

Connect to a remote Paseo daemon over SSH from the CLI (`--host ssh://user@host`) and the desktop app. The CLI ensures a daemon is running on the remote host (installing Paseo if needed), opens an SSH local port-forward, and tunnels the WebSocket connection through it — all over a single SSH connection.

See [docs/ssh.md](docs/ssh.md) for the design and the gotchas behind it.

## How it works

**One connection.** The remote command is `exec /bin/sh` while `-L` forwards the port, and the ensure script is piped to that shell over stdin. sshd hands a remote command to the user's *own* shell (from the password database), which may be fish or tcsh — so the command is reduced to three metacharacter-free words that every shell agrees on, and the script never has to survive their quoting rules. It also keeps the script out of the remote host's process list.

On success the script deliberately doesn't exit: `sh` reading from a pipe blocks for the next line, and that block *is* the keepalive. Closing stdin is the teardown.

**Readiness is a `READY:` marker**, not prose. The port forward accepts connections before the remote daemon is listening, so waiting on the local port is a false positive.

**Which remote `paseo` runs**, in order: anything already listening on the port → a `paseo` on `PATH` (global npm, system package manager) → a Paseo-managed install under `installDir`. Preferring `PATH` is about correctness, not disk: a second copy would let someone on the remote host start a conflicting daemon against the same `PASEO_HOME`. Paseo only ever installs or upgrades inside `installDir`. The managed copy is pinned to the local CLI version, falling back to `latest` when that version isn't published (source checkouts, betas).

**Password prompts are rendered by Paseo.** SSH only takes a secret from a program's stdout, so there is still a small askpass program — but it just relays over a unix socket to the app, which shows a styled, localized prompt that says whether it wants a key passphrase or an account password. The helper is written at runtime, so nothing needs unpacking from an asar archive. This replaced `zenity`/`kdialog`/`osascript`, along with their GTK baggage (underscores read as mnemonic accelerators, Pango markup parsing, AppleScript escaping).

**Cancelling ends the attempt.** SSH ignores an askpass program's exit status and simply retries, so cancellation is signalled out of band — the desktop aborts an `AbortSignal`; the CLI's terminal prompt writes a marker to stderr. SSH's three attempts are left intact so a *typo* stays retryable.

## Changes

- **CLI** (`packages/cli/src/ssh/`): `ssh-host-config` (parse `ssh://` URIs), `ssh-process` (SSH args, tunnel, terminal askpass), `ssh-connection` (ensure + tunnel), `remote-daemon` (ensure script and failure messages), `askpass-channel` (socket relay for GUI prompts)
- **CLI** (`local-daemon.ts`): `systemd-run --user --scope` + `loginctl enable-linger` so a detached daemon survives the session that started it, behind a `DaemonLaunchRuntime` seam
- **Protocol**: `SshHostConnectionSchema`. `port` is deliberately *not* defaulted — "unset" has to stay distinguishable from "22" so a `Port` directive in `~/.ssh/config` wins
- **App**: SSH connection type end to end, add-host modal, and a globally mounted password prompt so reconnects outside the add-host flow are covered
- **Desktop** (`main.ts`, `preload.ts`): SSH bridge IPC — open/close tunnel, progress events, password relay

## Notes for review

- **Origin stripping is scoped.** A renderer's origin can never match a tunnel's ephemeral loopback port, so the daemon's same-origin check would reject every tunneled connection. The header is removed only for ports the main process is currently forwarding — never for loopback generally, which would also disable the check for a directly-connected local daemon. Untrusted web content runs in a separate Electron session the rule isn't installed on.
- **Host keys are trust-on-first-use** (`StrictHostKeyChecking=accept-new`). A *changed* key still fails, but a first connection from the GUI accepts an unknown key without showing a fingerprint. Noted in SECURITY.md.
- **Non-active SSH connections are not latency-probed.** Probing one means spawning ssh, authenticating, and running the ensure script — every 120s, re-prompting password-auth hosts. The tradeoff is that the adaptive switcher won't move *onto* a tunnel on RTT alone, which is the behavior we want anyway. Failover is unaffected.
- **Requires a POSIX remote** with `/bin/sh` and Node. The local GUI prompt path is POSIX-only too (Windows would need a named pipe).

## Test plan

- [x] `paseo ls -a --host ssh://submit82.mit.edu` — single password prompt, agents listed, clean exit
- [x] Fresh daemon start on remote host — ensure script installs/launches, tunnel connects
- [x] Desktop SSH connection — progress messages displayed, WebSocket connects through tunnel
- [x] Askpass channel driven exactly as ssh drives it (prompt as argv[1], secret on stdout): relay, decline, timeout, closed-channel
- [x] Cancel vs. wrong password measured against a live sshd — declining aborts on the first prompt (~120ms); a wrong password still retries
- [x] Ensure script executed through a real `sh` against stubbed PATHs — ready/node-missing/npm-missing/`PATH`-preferred/unpublished-version paths
- [x] typecheck, lint, format, and 186 unit tests across cli/app/protocol/desktop
