### PR TITLE
fix(acp): retry prompts while provider turn is busy

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -35,6 +35,21 @@ runtime.
 
 Cancellation changes lifecycle state only after the provider acknowledges the interrupt or emits a terminal turn event. If the interrupt is rejected or times out, the agent remains `running` with its active foreground turn intact. Follow-up actions such as replacement, reload, rewind, and Stop must report that failure instead of accepting work they cannot perform. Synthesizing a local cancellation without provider acknowledgment creates a split-brain session: Paseo accepts a new prompt while the provider still owns the previous foreground turn.
 
+### Provider-declared busy turns
+
+An ACP provider may start autonomous work outside a Paseo foreground prompt. If a new
+`session/prompt` is rejected with JSON-RPC `data.code === "turn.agent_busy"`, the generic ACP
+adapter keeps the Paseo turn `running` and retries the same prompt and message ID with jittered
+exponential backoff (250 ms, capped at 5 seconds). The canonical user timeline row is emitted only
+once. Provider content received while the busy retry is waiting, including autonomous tool updates,
+remains out-of-prompt and unscoped.
+Other `-32600` errors remain terminal because their retry safety is unknown.
+
+Stop during a busy retry first waits for the provider to acknowledge `session/cancel`; only then
+does Paseo cancel the queued turn and clear its retry timer. A rejected cancel leaves the retry and
+foreground lifecycle intact. Closing or reloading the session aborts pending retry timers so no
+prompt or lifecycle event can arrive from the disposed runtime.
+
 ## Relationships
 
 Agents can launch other agents via the agent-scoped `create_agent` MCP tool. Agent-scoped creation is always asynchronous and always stamps `paseo.parent-agent-id`, pointing back at the caller. Omit `workspaceId` to use the caller's workspace, or pass an existing workspace ID returned by `create_workspace`. Placement never changes parentage.

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -86,7 +86,10 @@ describe("buildACPClientCapabilities", () => {
 
 interface ACPSessionInternals {
   sessionId: string | null;
-  connection: { prompt: (...args: unknown[]) => Promise<PromptResponse> };
+  connection: {
+    prompt: (...args: unknown[]) => Promise<PromptResponse>;
+    cancel?: (...args: unknown[]) => Promise<void>;
+  };
   activeForegroundTurnId: string | null;
   configOptions: SessionConfigOption[];
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
@@ -124,7 +127,15 @@ interface ACPConfiguredOverrideInternals {
   applyConfiguredOverrides(): Promise<void>;
 }
 
-function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
+interface TestPromptBusyRetry {
+  wait: (delayMs: number, signal: AbortSignal) => Promise<boolean>;
+  random: () => number;
+}
+
+function createSession(
+  terminateProcess?: ProcessTerminator,
+  promptBusyRetry?: TestPromptBusyRetry,
+): ACPAgentSession {
   return new ACPAgentSession(
     {
       provider: "claude-acp",
@@ -144,8 +155,68 @@ function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
         supportsToolInvocations: true,
       },
       ...(terminateProcess ? { terminateProcess } : {}),
+      ...(promptBusyRetry
+        ? {
+            promptBusyRetryWait: promptBusyRetry.wait,
+            promptBusyRetryRandom: promptBusyRetry.random,
+          }
+        : {}),
     },
   );
+}
+
+interface PendingTestRetry {
+  signal: AbortSignal;
+  resolve: (elapsed: boolean) => void;
+  handleAbort: () => void;
+}
+
+class FakePromptBusyRetry implements TestPromptBusyRetry {
+  readonly delays: number[] = [];
+  private readonly pending: PendingTestRetry[] = [];
+  readonly random = (): number => this.randomValue;
+
+  constructor(private readonly randomValue = 0.5) {}
+
+  readonly wait = (delayMs: number, signal: AbortSignal): Promise<boolean> => {
+    this.delays.push(delayMs);
+    if (signal.aborted) {
+      return Promise.resolve(false);
+    }
+    return new Promise((resolve) => {
+      const entry: PendingTestRetry = {
+        signal,
+        resolve,
+        handleAbort: () => this.settle(entry, false),
+      };
+      this.pending.push(entry);
+      signal.addEventListener("abort", entry.handleAbort, { once: true });
+    });
+  };
+
+  releaseNext(): void {
+    const entry = this.pending[0];
+    if (!entry) {
+      return;
+    }
+    this.settle(entry, true);
+  }
+
+  private settle(entry: PendingTestRetry, elapsed: boolean): void {
+    const index = this.pending.indexOf(entry);
+    if (index === -1) {
+      return;
+    }
+    this.pending.splice(index, 1);
+    entry.signal.removeEventListener("abort", entry.handleAbort);
+    entry.resolve(elapsed);
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 // Typed substitute for the real tree-kill terminator. Records which child
@@ -2316,6 +2387,495 @@ describe("ACPAgentSession", () => {
       turnId,
     });
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("queues turn.agent_busy rejections and retries the same prompt until it succeeds", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    const busyError = new RequestError(-32600, "Cannot launch a new turn", {
+      code: "turn.agent_busy",
+      details: { turnId: 9 },
+    });
+    const prompt = vi
+      .fn()
+      .mockRejectedValueOnce(busyError)
+      .mockRejectedValueOnce(busyError)
+      .mockResolvedValueOnce({ stopReason: "end_turn" } satisfies PromptResponse);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello", { clientMessageId: "message-1" });
+    await flushMicrotasks();
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(retry.delays).toEqual([250]);
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBe(turnId);
+    expect(events.filter((event) => event.type === "turn_failed")).toEqual([]);
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "autonomous-message",
+        content: { type: "text", text: "Background work completed" },
+      } as SessionUpdate,
+    });
+    expect(
+      events.find(
+        (event) =>
+          event.type === "timeline" &&
+          event.item.type === "assistant_message" &&
+          event.item.messageId === "autonomous-message",
+      ),
+    ).toEqual({
+      type: "timeline",
+      provider: session.provider,
+      item: {
+        type: "assistant_message",
+        text: "Background work completed",
+        messageId: "autonomous-message",
+      },
+    });
+    expect(events.filter((event) => event.type.startsWith("turn_"))).toEqual([
+      expect.objectContaining({ type: "turn_started", turnId }),
+    ]);
+
+    retry.releaseNext();
+    await flushMicrotasks();
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(retry.delays).toEqual([250, 500]);
+
+    retry.releaseNext();
+    await flushMicrotasks();
+    expect(prompt).toHaveBeenCalledTimes(3);
+    expect(prompt.mock.calls[1]?.[0]).toEqual(prompt.mock.calls[0]?.[0]);
+    expect(prompt.mock.calls[2]?.[0]).toEqual(prompt.mock.calls[0]?.[0]);
+    expect(
+      events.filter((event) => event.type === "timeline" && event.item.type === "user_message"),
+    ).toHaveLength(1);
+    expect(events.filter((event) => event.type === "turn_failed")).toEqual([]);
+    expect(events.filter((event) => event.type === "turn_completed")).toEqual([
+      expect.objectContaining({ type: "turn_completed", turnId }),
+    ]);
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("does not retry generic JSON-RPC invalid-request errors", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn().mockRejectedValue(
+      new RequestError(-32600, "Invalid request", {
+        code: "session.invalid_state",
+        details: { turnId: 9 },
+      }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(retry.delays).toEqual([]);
+    expect(events.filter((event) => event.type === "turn_failed")).toEqual([
+      expect.objectContaining({ type: "turn_failed", turnId, code: "-32600" }),
+    ]);
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("caps jittered busy retry delays at five seconds", async () => {
+    const retry = new FakePromptBusyRetry(1);
+    const session = createSession(undefined, retry);
+    const prompt = vi.fn().mockRejectedValue(
+      new RequestError(-32600, "Cannot launch a new turn", {
+        code: "turn.agent_busy",
+        details: { turnId: 9 },
+      }),
+    );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+
+    await session.startTurn("hello");
+    await flushMicrotasks();
+    for (const expectedDelays of [
+      [300],
+      [300, 600],
+      [300, 600, 1_200],
+      [300, 600, 1_200, 2_400],
+      [300, 600, 1_200, 2_400, 4_800],
+      [300, 600, 1_200, 2_400, 4_800, 5_000],
+    ]) {
+      expect(retry.delays).toEqual(expectedDelays);
+      if (expectedDelays.length < 6) {
+        retry.releaseNext();
+        await flushMicrotasks();
+      }
+    }
+
+    expect(prompt).toHaveBeenCalledTimes(6);
+    await session.close();
+  });
+
+  test("cancels a queued busy retry only after the ACP provider acknowledges cancel", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn().mockRejectedValue(
+      new RequestError(-32600, "Cannot launch a new turn", {
+        code: "turn.agent_busy",
+        details: { turnId: 11 },
+      }),
+    );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+    expect(retry.delays).toEqual([250]);
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "background-tool",
+        title: "Background tool",
+        kind: "execute",
+        status: "in_progress",
+      } as SessionUpdate,
+    });
+
+    await session.interrupt();
+    await flushMicrotasks();
+    retry.releaseNext();
+    await flushMicrotasks();
+
+    expect(cancel).toHaveBeenCalledWith({ sessionId: "session-1" });
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(events.filter((event) => event.type === "turn_canceled")).toEqual([
+      expect.objectContaining({ type: "turn_canceled", turnId }),
+    ]);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "timeline" &&
+          event.item.type === "tool_call" &&
+          event.item.callId === "background-tool" &&
+          event.item.status === "canceled",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        turnId: undefined,
+        item: expect.objectContaining({ callId: "background-tool", status: "canceled" }),
+      }),
+    ]);
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("does not reprompt when busy backoff elapses while ACP cancel is in flight", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn().mockRejectedValue(
+      new RequestError(-32600, "Cannot launch a new turn", {
+        code: "turn.agent_busy",
+        details: { turnId: 11 },
+      }),
+    );
+    let acknowledgeCancel!: () => void;
+    const cancel = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          acknowledgeCancel = resolve;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+    const interrupt = session.interrupt();
+    retry.releaseNext();
+    await flushMicrotasks();
+
+    expect(prompt).toHaveBeenCalledOnce();
+    acknowledgeCancel();
+    await interrupt;
+    await flushMicrotasks();
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(events.filter((event) => event.type === "turn_canceled")).toEqual([
+      expect.objectContaining({ type: "turn_canceled", turnId }),
+    ]);
+  });
+
+  test("denying an autonomous busy permission with interrupt cancels the queued prompt", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn().mockRejectedValue(
+      new RequestError(-32600, "Cannot launch a new turn", {
+        code: "turn.agent_busy",
+        details: { turnId: 11 },
+      }),
+    );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "autonomous-tool",
+        title: "Background tool",
+        kind: "execute",
+        status: "pending",
+      },
+      options: [{ optionId: "reject-once", name: "Reject", kind: "reject_once" }],
+    } satisfies RequestPermissionRequest);
+    await flushMicrotasks();
+    const request = events.find((event) => event.type === "permission_requested");
+    expect(request).toMatchObject({ type: "permission_requested", turnId: undefined });
+
+    await session.respondToPermission(
+      (request as Extract<AgentStreamEvent, { type: "permission_requested" }>).request.id,
+      { behavior: "deny", interrupt: true },
+    );
+    await expect(permission).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "reject-once" },
+    });
+    retry.releaseNext();
+    await flushMicrotasks();
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(events.filter((event) => event.type === "turn_canceled")).toEqual([
+      expect.objectContaining({ type: "turn_canceled", turnId }),
+    ]);
+  });
+
+  test("denying an unscoped autonomous permission with interrupt still cancels ACP", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    const cancel = vi.fn().mockResolvedValue(undefined);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { cancel };
+    session.subscribe((event) => events.push(event));
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "autonomous-tool",
+        title: "Background tool",
+        kind: "execute",
+        status: "pending",
+      },
+      options: [{ optionId: "reject-once", name: "Reject", kind: "reject_once" }],
+    } satisfies RequestPermissionRequest);
+    await flushMicrotasks();
+    const request = events.find((event) => event.type === "permission_requested");
+    expect(request).toMatchObject({ type: "permission_requested", turnId: undefined });
+
+    await session.respondToPermission(
+      (request as Extract<AgentStreamEvent, { type: "permission_requested" }>).request.id,
+      { behavior: "deny", interrupt: true },
+    );
+
+    await expect(permission).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "reject-once" },
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith({ sessionId: "session-1" });
+  });
+
+  test("cancel acknowledged while a retried prompt is in flight wins over a late error", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    let rejectRetriedPrompt!: (error: Error) => void;
+    const prompt = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new RequestError(-32600, "Cannot launch a new turn", {
+          code: "turn.agent_busy",
+          details: { turnId: 11 },
+        }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<PromptResponse>((_resolve, reject) => {
+            rejectRetriedPrompt = reject;
+          }),
+      );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+    retry.releaseNext();
+    await flushMicrotasks();
+    expect(prompt).toHaveBeenCalledTimes(2);
+
+    await session.interrupt();
+    rejectRetriedPrompt(new Error("late provider error"));
+    await flushMicrotasks();
+
+    expect(events.filter((event) => event.type === "turn_canceled")).toEqual([
+      expect.objectContaining({ type: "turn_canceled", turnId }),
+    ]);
+    expect(events.filter((event) => event.type === "turn_failed")).toEqual([]);
+  });
+
+  test("cancel acknowledged while a retried prompt is in flight wins over a late success", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    let resolveRetriedPrompt!: (response: PromptResponse) => void;
+    const prompt = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new RequestError(-32600, "Cannot launch a new turn", {
+          code: "turn.agent_busy",
+          details: { turnId: 11 },
+        }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<PromptResponse>((resolve) => {
+            resolveRetriedPrompt = resolve;
+          }),
+      );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+    retry.releaseNext();
+    await flushMicrotasks();
+    expect(prompt).toHaveBeenCalledTimes(2);
+
+    await session.interrupt();
+    resolveRetriedPrompt({ stopReason: "end_turn" });
+    await flushMicrotasks();
+
+    expect(events.filter((event) => event.type === "turn_canceled")).toEqual([
+      expect.objectContaining({ type: "turn_canceled", turnId }),
+    ]);
+    expect(events.filter((event) => event.type === "turn_completed")).toEqual([]);
+  });
+
+  test("keeps a queued busy retry alive when ACP cancel is rejected", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new RequestError(-32600, "Cannot launch a new turn", {
+          code: "turn.agent_busy",
+          details: { turnId: 11 },
+        }),
+      )
+      .mockResolvedValueOnce({ stopReason: "end_turn" } satisfies PromptResponse);
+    const cancel = vi.fn().mockRejectedValue(new Error("cancel rejected"));
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+    await expect(session.interrupt()).rejects.toThrow("cancel rejected");
+
+    retry.releaseNext();
+    await flushMicrotasks();
+
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(events.filter((event) => event.type === "turn_canceled")).toEqual([]);
+    expect(events.filter((event) => event.type === "turn_completed")).toEqual([
+      expect.objectContaining({ type: "turn_completed", turnId }),
+    ]);
+  });
+
+  test("converts an unexpected busy retry wait rejection into turn_failed", async () => {
+    const session = createSession(undefined, {
+      wait: async () => {
+        throw new Error("retry scheduler failed");
+      },
+      random: () => 0.5,
+    });
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn().mockRejectedValue(
+      new RequestError(-32600, "Cannot launch a new turn", {
+        code: "turn.agent_busy",
+        details: { turnId: 11 },
+      }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("hello");
+    await flushMicrotasks();
+
+    expect(events.filter((event) => event.type === "turn_failed")).toEqual([
+      expect.objectContaining({ type: "turn_failed", turnId, error: "retry scheduler failed" }),
+    ]);
+    expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
+  });
+
+  test("close aborts a queued busy retry without a late prompt or lifecycle event", async () => {
+    const retry = new FakePromptBusyRetry();
+    const session = createSession(undefined, retry);
+    const events: AgentStreamEvent[] = [];
+    const prompt = vi.fn().mockRejectedValue(
+      new RequestError(-32600, "Cannot launch a new turn", {
+        code: "turn.agent_busy",
+        details: { turnId: 11 },
+      }),
+    );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+    session.subscribe((event) => events.push(event));
+
+    await session.startTurn("hello");
+    await flushMicrotasks();
+    await session.close();
+    retry.releaseNext();
+    await flushMicrotasks();
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(
+      events.filter((event) =>
+        ["turn_completed", "turn_failed", "turn_canceled"].includes(event.type),
+      ),
+    ).toEqual([]);
   });
 
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
+import { setTimeout as waitForTimeout } from "node:timers/promises";
 
 import { terminateWithTreeKill } from "../../../utils/tree-kill.js";
 import type { ProcessTerminator } from "../../../utils/tree-kill.js";
@@ -128,6 +129,48 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isACPError(value: unknown): value is ACPError {
   return isRecord(value) && typeof value.message === "string" && typeof value.code === "number";
+}
+
+const ACP_AGENT_BUSY_CODE = "turn.agent_busy";
+const ACP_AGENT_BUSY_RETRY_INITIAL_MS = 250;
+const ACP_AGENT_BUSY_RETRY_MAX_MS = 5_000;
+const ACP_AGENT_BUSY_RETRY_JITTER = 0.2;
+
+function isACPAgentBusyError(error: unknown): error is ACPError {
+  return isACPError(error) && isRecord(error.data) && error.data.code === ACP_AGENT_BUSY_CODE;
+}
+
+function extractACPAgentBusyTurnId(error: ACPError): string | number | null {
+  if (!isRecord(error.data) || !isRecord(error.data.details)) {
+    return null;
+  }
+  const turnId = error.data.details.turnId;
+  return typeof turnId === "string" || typeof turnId === "number" ? turnId : null;
+}
+
+function calculateACPAgentBusyRetryDelay(attempt: number, random: () => number): number {
+  const exponentialDelay = Math.min(
+    ACP_AGENT_BUSY_RETRY_INITIAL_MS * 2 ** Math.max(0, attempt - 1),
+    ACP_AGENT_BUSY_RETRY_MAX_MS,
+  );
+  const jitterFactor = 1 - ACP_AGENT_BUSY_RETRY_JITTER + random() * ACP_AGENT_BUSY_RETRY_JITTER * 2;
+  return Math.min(ACP_AGENT_BUSY_RETRY_MAX_MS, Math.round(exponentialDelay * jitterFactor));
+}
+
+async function waitForACPAgentBusyRetry(delayMs: number, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) {
+    return false;
+  }
+
+  try {
+    await waitForTimeout(delayMs, undefined, { signal });
+    return true;
+  } catch (error) {
+    if (signal.aborted) {
+      return false;
+    }
+    throw error;
+  }
 }
 
 function extractACPErrorDataMessage(data: unknown): string | null {
@@ -427,6 +470,18 @@ interface ACPAgentSessionOptions {
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
+  promptBusyRetryWait?: (delayMs: number, signal: AbortSignal) => Promise<boolean>;
+  promptBusyRetryRandom?: () => number;
+}
+
+interface PendingPromptBusyRetry {
+  turnId: string;
+  controller: AbortController;
+}
+
+interface ForegroundInterrupt {
+  turnId: string;
+  promise: Promise<void>;
 }
 
 export interface SpawnedACPProcess {
@@ -1325,12 +1380,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
+  private providerBusyForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
+  private pendingPromptBusyRetry: PendingPromptBusyRetry | null = null;
+  private foregroundInterrupt: ForegroundInterrupt | null = null;
+  private acknowledgedInterruptTurnId: string | null = null;
   private closed = false;
   private historyPending = false;
   private replayingHistory = false;
   private bootstrapThreadEventPending = false;
   private readonly terminateProcess: ProcessTerminator;
+  private readonly promptBusyRetryWait: (delayMs: number, signal: AbortSignal) => Promise<boolean>;
+  private readonly promptBusyRetryRandom: () => number;
 
   constructor(config: AgentSessionConfig, options: ACPAgentSessionOptions) {
     this.provider = options.provider;
@@ -1363,6 +1424,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.promptBusyRetryWait = options.promptBusyRetryWait ?? waitForACPAgentBusyRetry;
+    this.promptBusyRetryRandom = options.promptBusyRetryRandom ?? Math.random;
   }
 
   get id(): string | null {
@@ -1494,31 +1557,20 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.activeForegroundTurnId = turnId;
     this.fallbackAssistantMessageId = null;
     this.submittedUserMessageTurnId = null;
+    this.acknowledgedInterruptTurnId = null;
     this.emitBootstrapThreadEvent();
     this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
     this.emitSubmittedUserMessage(prompt, messageId, turnId, options?.clientMessageId);
 
-    void this.connection
-      .prompt({
+    void this.submitPromptWithBusyRetry(
+      this.connection,
+      {
         sessionId: this.sessionId,
         messageId,
         prompt: toACPContentBlocks(prompt),
-      })
-      .then((response) => {
-        this.handlePromptResponse(response, turnId);
-        return;
-      })
-      .catch((error) => {
-        const summary = summarizeACPRequestError(error);
-        this.finishTurn({
-          type: "turn_failed",
-          provider: this.provider,
-          error: summary.message,
-          code: summary.code,
-          diagnostic: this.collectDiagnostic(summary.diagnostic ?? summary.message),
-          turnId,
-        });
-      });
+      },
+      turnId,
+    ).catch((error) => this.failForegroundTurn(error, turnId));
 
     return { turnId };
   }
@@ -1998,8 +2050,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       turnId: pending.turnId ?? undefined,
     });
 
-    if (response.behavior === "deny" && response.interrupt && this.connection && this.sessionId) {
-      await this.connection.cancel({ sessionId: this.sessionId });
+    if (response.behavior === "deny" && response.interrupt) {
+      await this.interrupt();
     }
   }
 
@@ -2028,8 +2080,37 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
     this.pendingPermissions.clear();
 
-    if (this.activeForegroundTurnId) {
-      await this.connection.cancel({ sessionId: this.sessionId });
+    const turnId = this.activeForegroundTurnId;
+    const promise = this.connection.cancel({ sessionId: this.sessionId });
+    if (!turnId) {
+      await promise;
+      return;
+    }
+
+    const interrupt = { turnId, promise };
+    this.foregroundInterrupt = interrupt;
+    try {
+      await promise;
+    } catch (error) {
+      if (this.foregroundInterrupt === interrupt) {
+        this.foregroundInterrupt = null;
+      }
+      throw error;
+    }
+
+    if (this.foregroundInterrupt === interrupt) {
+      this.foregroundInterrupt = null;
+    }
+    if (this.activeForegroundTurnId !== turnId) {
+      return;
+    }
+
+    this.acknowledgedInterruptTurnId = turnId;
+    if (
+      this.pendingPromptBusyRetry?.turnId === turnId ||
+      this.providerBusyForegroundTurnId === turnId
+    ) {
+      this.finishAcknowledgedQueuedTurn(turnId);
     }
   }
 
@@ -2038,6 +2119,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       return;
     }
     this.closed = true;
+    this.abortPendingPromptBusyRetry();
 
     this.deliverTranslatedEvents(this.flushPendingUserMessage());
     this.settleCommandsReady();
@@ -2080,6 +2162,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.connection = null;
     this.child = null;
     this.activeForegroundTurnId = null;
+    this.providerBusyForegroundTurnId = null;
+    this.foregroundInterrupt = null;
+    this.acknowledgedInterruptTurnId = null;
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
@@ -2099,7 +2184,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         options: params.options,
         resolve,
         reject,
-        turnId: this.activeForegroundTurnId,
+        turnId: this.currentProviderEventTurnId() ?? null,
       });
     });
 
@@ -2107,7 +2192,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       type: "permission_requested",
       provider: this.provider,
       request,
-      turnId: this.activeForegroundTurnId ?? undefined,
+      turnId: this.currentProviderEventTurnId(),
     });
     return promise;
   }
@@ -2132,7 +2217,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
-        turnId: this.activeForegroundTurnId ?? undefined,
+        turnId: this.currentProviderEventTurnId(),
         rawEvent: params,
         events,
       },
@@ -2540,6 +2625,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.fallbackAssistantMessageId = null;
     if (
       this.activeForegroundTurnId &&
+      this.providerBusyForegroundTurnId !== this.activeForegroundTurnId &&
       this.submittedUserMessageTurnId === this.activeForegroundTurnId
     ) {
       return [];
@@ -2711,12 +2797,150 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
+  private async submitPromptWithBusyRetry(
+    connection: ClientSideConnection,
+    request: Parameters<ClientSideConnection["prompt"]>[0],
+    turnId: string,
+  ): Promise<void> {
+    let busyAttempts = 0;
+
+    for (;;) {
+      if (!this.isCurrentForegroundTurn(turnId)) {
+        return;
+      }
+      if (this.acknowledgedInterruptTurnId === turnId) {
+        this.finishAcknowledgedQueuedTurn(turnId);
+        return;
+      }
+
+      const interrupt = this.foregroundInterrupt;
+      if (interrupt?.turnId === turnId) {
+        try {
+          await interrupt.promise;
+        } catch {
+          // interrupt() reports the failure; the original prompt remains eligible for retry.
+        }
+        if (!this.isCurrentForegroundTurn(turnId)) {
+          return;
+        }
+        if (this.acknowledgedInterruptTurnId === turnId) {
+          this.finishAcknowledgedQueuedTurn(turnId);
+          return;
+        }
+      }
+
+      if (this.providerBusyForegroundTurnId === turnId) {
+        this.providerBusyForegroundTurnId = null;
+      }
+
+      try {
+        const response = await connection.prompt(request);
+        if (this.isCurrentForegroundTurn(turnId)) {
+          if (this.acknowledgedInterruptTurnId === turnId) {
+            this.finishAcknowledgedQueuedTurn(turnId);
+          } else {
+            this.handlePromptResponse(response, turnId);
+          }
+        }
+        return;
+      } catch (error) {
+        if (!this.isCurrentForegroundTurn(turnId)) {
+          return;
+        }
+        if (this.acknowledgedInterruptTurnId === turnId) {
+          this.finishAcknowledgedQueuedTurn(turnId);
+          return;
+        }
+        if (!isACPAgentBusyError(error)) {
+          this.failForegroundTurn(error, turnId);
+          return;
+        }
+
+        this.providerBusyForegroundTurnId = turnId;
+        busyAttempts += 1;
+        const delayMs = calculateACPAgentBusyRetryDelay(busyAttempts, this.promptBusyRetryRandom);
+        const logContext = {
+          agentId: this.agentId,
+          sessionId: this.sessionId,
+          turnId,
+          providerTurnId: extractACPAgentBusyTurnId(error),
+          attempt: busyAttempts,
+          delayMs,
+        };
+        if (busyAttempts === 1) {
+          this.logger.warn(logContext, "ACP provider is busy; queued prompt for retry");
+        } else {
+          this.logger.debug(logContext, "ACP provider remains busy; retrying queued prompt");
+        }
+
+        const pendingRetry: PendingPromptBusyRetry = {
+          turnId,
+          controller: new AbortController(),
+        };
+        this.pendingPromptBusyRetry = pendingRetry;
+        const elapsed = await this.promptBusyRetryWait(delayMs, pendingRetry.controller.signal);
+        if (this.pendingPromptBusyRetry === pendingRetry) {
+          this.pendingPromptBusyRetry = null;
+        }
+        if (!elapsed || !this.isCurrentForegroundTurn(turnId)) {
+          return;
+        }
+      }
+    }
+  }
+
+  private isCurrentForegroundTurn(turnId: string): boolean {
+    return !this.closed && this.activeForegroundTurnId === turnId;
+  }
+
+  private failForegroundTurn(error: unknown, turnId: string): void {
+    if (!this.isCurrentForegroundTurn(turnId)) {
+      return;
+    }
+    const summary = summarizeACPRequestError(error);
+    this.finishTurn({
+      type: "turn_failed",
+      provider: this.provider,
+      error: summary.message,
+      code: summary.code,
+      diagnostic: this.collectDiagnostic(summary.diagnostic ?? summary.message),
+      turnId,
+    });
+  }
+
+  private finishAcknowledgedQueuedTurn(turnId: string): void {
+    if (this.acknowledgedInterruptTurnId !== turnId || !this.isCurrentForegroundTurn(turnId)) {
+      return;
+    }
+    if (this.pendingPromptBusyRetry?.turnId === turnId) {
+      this.abortPendingPromptBusyRetry();
+    }
+    this.synthesizeCanceledToolCalls();
+    this.finishTurn({
+      type: "turn_canceled",
+      provider: this.provider,
+      reason: "Interrupted",
+      turnId,
+    });
+  }
+
+  private currentProviderEventTurnId(): string | undefined {
+    return this.providerBusyForegroundTurnId === this.activeForegroundTurnId
+      ? undefined
+      : (this.activeForegroundTurnId ?? undefined);
+  }
+
+  private abortPendingPromptBusyRetry(): void {
+    this.pendingPromptBusyRetry?.controller.abort();
+    this.pendingPromptBusyRetry = null;
+  }
+
   private wrapTimeline(item: AgentTimelineItem): AgentStreamEvent {
     return {
       type: "timeline",
       provider: this.provider,
       item,
-      turnId: this.activeForegroundTurnId ?? undefined,
+      turnId: this.currentProviderEventTurnId(),
     };
   }
 
@@ -2726,7 +2950,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         agentId: this.agentId,
         provider: this.provider,
         sessionId: this.sessionId,
-        turnId: getAgentStreamEventTurnId(event) ?? this.activeForegroundTurnId ?? undefined,
+        turnId: getAgentStreamEventTurnId(event) ?? this.currentProviderEventTurnId(),
         event,
       },
       "provider.acp.event_emit",
@@ -2778,8 +3002,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
   ): void {
     this.deliverTranslatedEvents(this.flushPendingUserMessage());
+    if (this.pendingPromptBusyRetry?.turnId === event.turnId) {
+      this.abortPendingPromptBusyRetry();
+    }
     this.activeForegroundTurnId = null;
+    this.providerBusyForegroundTurnId = null;
     this.fallbackAssistantMessageId = null;
+    this.foregroundInterrupt = null;
+    this.acknowledgedInterruptTurnId = null;
     if (this.submittedUserMessageTurnId === event.turnId) {
       this.submittedUserMessageTurnId = null;
     }


### PR DESCRIPTION
## Summary

- retry only ACP errors whose `data.code` is exactly `turn.agent_busy`, preserving the Paseo turn, message ID, and single user timeline row
- use jittered exponential backoff from 250 ms up to 5 seconds while keeping autonomous provider events unscoped
- make cancel, permission denial, close, and late provider responses lifecycle-safe without changing public interfaces or the ACP protocol
- document provider-declared busy turn semantics

## Validation

- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1` — 96 passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- isolated Kimi ACP reproduction on port 6779: background command completed, concurrent prompt queued on `turn.agent_busy`, then delivered once after the autonomous turn

The main Paseo daemon was not restarted or modified during validation.