### PR TITLE
fix(omp): accept nullable model context windows

### DIFF
--- a/packages/server/src/server/agent/providers/omp/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/omp/cli-runtime.test.ts
@@ -186,6 +186,40 @@ describe("OMP CLI runtime", () => {
     ]);
   });
 
+  test("accepts model catalogs with null contextWindow from NVIDIA", async () => {
+    const child = createOmpChild();
+    replyToCommands(child, () => ({
+      models: [
+        {
+          provider: "nvidia",
+          id: "minimaxai/minimax-m3",
+          name: "MiniMax-M3",
+          contextWindow: null,
+        },
+        {
+          provider: "zai",
+          id: "glm-5.2",
+          name: "GLM-5.2",
+          contextWindow: 131_072,
+        },
+      ],
+    }));
+    const session = await createRuntime(child).startSession({ cwd: "/workspace/project" });
+
+    await expect(session.getAvailableModels()).resolves.toEqual([
+      expect.objectContaining({
+        provider: "nvidia",
+        id: "minimaxai/minimax-m3",
+        contextWindow: null,
+      }),
+      expect.objectContaining({
+        provider: "zai",
+        id: "glm-5.2",
+        contextWindow: 131_072,
+      }),
+    ]);
+  });
+
   test("wraps OMP subagent RPC commands", async () => {
     const child = createOmpChild();
     const commands: Record<string, unknown>[] = [];

--- a/packages/server/src/server/agent/providers/omp/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/omp/rpc-types.ts
@@ -103,7 +103,7 @@ export const OmpModelSchema = z
     name: z.string().optional(),
     reasoning: z.boolean().optional(),
     thinking: OmpModelThinkingSchema.optional(),
-    contextWindow: z.number().optional(),
+    contextWindow: z.number().nullable().optional(),
     maxTokens: z.number().nullable().optional(),
     api: z.string().optional(),
     baseUrl: z.string().optional(),


### PR DESCRIPTION
### Linked issue

Closes #2405

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

OMP parses the model list as one combined response. NVIDIA can return
`contextWindow: null`, while Paseo's OMP schema previously accepted only a
number or an absent field. One nullable NVIDIA entry therefore rejected the
whole catalog and hid models from every OMP provider.

This change accepts `number | null | undefined` for `contextWindow`. It does not
filter models, invent a context-window value, or weaken validation for other
fields. A regression test covers a mixed catalog containing an NVIDIA model
with a null context window and a Z.AI model with a numeric context window.

### How did you verify it

- Reproduced before the schema change with the focused regression test:
  `npx vitest run packages/server/src/server/agent/providers/omp/cli-runtime.test.ts --bail=1`
  failed with `expected number, received null` at
  `models[0].contextWindow`.
- After the change, the same focused test file passed: 9/9 tests.
- `npm run build:server` passed.
- `npm run typecheck` passed.
- `npm run lint` passed with 0 warnings and 0 errors.
- `npm run format` and `npm run format:check` passed.
- `git diff --check origin/main...HEAD` passed.

No UI behavior changed, so screenshots are not applicable.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform (N/A: no UI changes)
- [x] Tests added or updated where it made sense
