### PR TITLE
fix(server): pin ALPN http/1.1 for outbound relay WebSockets

### DIFF
--- a/packages/server/src/server/relay-transport.test.ts
+++ b/packages/server/src/server/relay-transport.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type pino from "pino";
-import { startRelayTransport } from "./relay-transport";
+import { RELAY_WEBSOCKET_OPTIONS, startRelayTransport } from "./relay-transport";
 
 function createMockLogger() {
   const messages: { level: "debug" | "info" | "warn" | "error"; args: unknown[] }[] = [];
@@ -115,6 +115,16 @@ function createFakeWebSockets() {
     },
   };
 }
+
+describe("relay-transport websocket options", () => {
+  test("pins HTTP/1.1 ALPN for outbound relay sockets", () => {
+    expect(RELAY_WEBSOCKET_OPTIONS).toMatchObject({
+      handshakeTimeout: 10_000,
+      perMessageDeflate: false,
+      ALPNProtocols: ["http/1.1"],
+    });
+  });
+});
 
 describe("relay-transport control lifecycle", () => {
   const controllers: Array<{ stop: () => Promise<void> }> = [];

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -54,7 +54,12 @@ type ControlMessage =
 const CONTROL_PING_INTERVAL_MS = 10_000;
 const CONTROL_STALE_TIMEOUT_MS = 30_000;
 const CONTROL_READY_TIMEOUT_MS = 8_000;
-const RELAY_WEBSOCKET_OPTIONS = { handshakeTimeout: 10_000, perMessageDeflate: false } as const;
+// Pin HTTP/1.1 ALPN so Node/WSL TLS does not negotiate h2 and hang the WS handshake.
+export const RELAY_WEBSOCKET_OPTIONS = {
+  handshakeTimeout: 10_000,
+  perMessageDeflate: false,
+  ALPNProtocols: ["http/1.1"],
+} as const;
 
 function createDefaultRelayWebSocket(url: string): RelayWebSocketLike {
   return new WebSocket(url, RELAY_WEBSOCKET_OPTIONS);


### PR DESCRIPTION
## Summary
- Pin `ALPNProtocols: ["http/1.1"]` on outbound relay WebSocket options so the handshake does not hang when TLS would negotiate HTTP/2 (reproduced on WSL + Node 22/24).
- Add a regression assertion on the shared `RELAY_WEBSOCKET_OPTIONS` used by control and data sockets.

Fixes #2362

## Test plan
- [x] `npx vitest run packages/server/src/server/relay-transport.test.ts --bail=1`
- [x] `npm run typecheck` / lint on touched files
- [ ] Optional: on WSL, `paseo daemon start` and confirm `relay_control_connected` without handshake timeout


Made with [Cursor](https://cursor.com)