### PR TITLE
fix(server): stop OpenCode serve rotation on catalog refresh

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.list-models-timeout.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.list-models-timeout.test.ts
@@ -64,7 +64,7 @@ test("allows a slow provider.list call to succeed instead of failing after 10 se
   expect(openCodeClient.calls.providerList).toHaveLength(1);
 });
 
-test("uses a new server for explicit catalog refresh", async () => {
+test("uses the current server for explicit catalog refresh", async () => {
   const runtime = new TestOpenCodeHarness();
   const openCodeClient = new TestOpenCodeClient();
   openCodeClient.providerListResponse = {
@@ -82,7 +82,47 @@ test("uses a new server for explicit catalog refresh", async () => {
 
   await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/opencode-models", force: true });
 
-  expect(runtime.acquisitions).toEqual([{ kind: "new", releaseCount: 1 }]);
+  expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
+});
+
+test("forced catalog refresh does not rotate the server while a session holds a ref", async () => {
+  const runtime = new TestOpenCodeHarness();
+  const firstClient = new TestOpenCodeClient();
+  firstClient.providerListResponse = {
+    data: {
+      connected: ["openai"],
+      all: [{ id: "openai", name: "OpenAI", models: {} }],
+    },
+  };
+  const secondClient = new TestOpenCodeClient();
+  secondClient.providerListResponse = {
+    data: {
+      connected: ["openai"],
+      all: [{ id: "openai", name: "OpenAI", models: {} }],
+    },
+  };
+  runtime.enqueueClient(firstClient);
+  runtime.enqueueClient(secondClient);
+
+  const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+    serverManager: runtime,
+    createClient: runtime.createClient,
+  });
+
+  // Session-like held ref on the current generation.
+  const sessionAcquisition = await runtime.acquireCurrent();
+
+  await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/opencode-models", force: true });
+  await client.fetchCatalog({ scope: "workspace", cwd: "/tmp/opencode-models", force: true });
+
+  expect(runtime.acquisitions).toEqual([
+    { kind: "current", releaseCount: 0 },
+    { kind: "current", releaseCount: 1 },
+    { kind: "current", releaseCount: 1 },
+  ]);
+  expect(runtime.acquisitions.some((acquisition) => acquisition.kind === "new")).toBe(false);
+
+  await sessionAcquisition.release();
 });
 
 test("includes models from api-source providers not in connected", async () => {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -1388,9 +1388,10 @@ export class OpenCodeAgentClient implements AgentClient {
   }
 
   async fetchCatalog(options: FetchCatalogOptions): Promise<ProviderCatalog> {
-    const acquisition = options.force
-      ? await this.serverManager.acquireNew()
-      : await this.serverManager.acquireCurrent();
+    // Always reuse the current generation. force still bypasses the Paseo catalog
+    // cache and re-probes via HTTP; rotating the server is not required for that
+    // and leaks retired processes while sessions hold refs (issue #2370).
+    const acquisition = await this.serverManager.acquireCurrent();
     const { url } = acquisition.server;
     const isGlobalCatalog = options.scope === "global";
 


### PR DESCRIPTION
## Summary
- Force provider catalog refresh no longer calls `acquireNew()`, which retired the shared `opencode serve` while sessions still held refs and leaked ~300MB processes per refresh.
- Catalog refresh always uses `acquireCurrent()` so Paseo still bypasses its snapshot cache and re-probes over HTTP without rotating helper processes.
- Tests updated/added to lock in the no-rotation behavior under held session refs.

Fixes #2370

## Test plan
- [x] `npx vitest run packages/server/src/server/agent/providers/opencode-agent.list-models-timeout.test.ts --bail=1`
- [x] typecheck + lint on touched files
- [ ] Manual: open 3 OpenCode agents, refresh providers several times, confirm `opencode serve` count stays ~1


Made with [Cursor](https://cursor.com)