### PR TITLE
test(app): cover manual sidebar order across host filter switches

### DIFF
--- a/packages/app/e2e/sidebar-host-filter-order.spec.ts
+++ b/packages/app/e2e/sidebar-host-filter-order.spec.ts
@@ -1,0 +1,128 @@
+import type { Locator } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect, test } from "./fixtures";
+import { gotoAppShell } from "./helpers/app";
+import { addOfflineHostAndReload, selectAllHostsFilter, toggleHostFilter } from "./helpers/hosts";
+import { seedWorkspace } from "./helpers/seed-client";
+import { getServerId } from "./helpers/server-id";
+import { waitForSidebarHydration } from "./helpers/workspace-ui";
+
+const SECONDARY_HOST_ID = "host-filter-order-secondary";
+
+async function rowTestIds(rows: Locator) {
+  return rows.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("data-testid")),
+  );
+}
+
+async function visibleBoundingBox(row: Locator) {
+  const box = await row.boundingBox();
+  if (!box) throw new Error("Expected a visible draggable row");
+  return box;
+}
+
+// Retry the trigger click: the freshly booted web bundle can re-render the sidebar while the
+// first click is in flight, which closes the dropdown before its content mounts.
+async function openSidebarDisplayPreferences(page: Page) {
+  await expect(async () => {
+    await page.getByTestId("sidebar-display-preferences-menu").click();
+    await expect(page.getByTestId("sidebar-display-preferences-content")).toBeVisible({
+      timeout: 2_000,
+    });
+  }).toPass({ timeout: 30_000 });
+}
+
+async function quickDragFirstRowAfterSecond(rows: Locator) {
+  await expect(rows).toHaveCount(2);
+  const before = await rowTestIds(rows);
+  const sourceBox = await visibleBoundingBox(rows.nth(0));
+  const targetBox = await visibleBoundingBox(rows.nth(1));
+
+  const page = rows.page();
+  const source = { x: sourceBox.x + sourceBox.width / 2, y: sourceBox.y + sourceBox.height / 2 };
+  const target = { x: targetBox.x + targetBox.width / 2, y: targetBox.y + targetBox.height / 2 };
+
+  await page.mouse.move(source.x, source.y);
+  await page.mouse.down();
+  await page.mouse.move(source.x, source.y + 7);
+  await page.mouse.move(target.x, target.y, { steps: 4 });
+  await page.mouse.up();
+
+  await expect.poll(() => rowTestIds(rows)).toEqual([before[1], before[0]]);
+  return { before };
+}
+
+test.describe("Sidebar host filter keeps manual order", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test("manual workspace order survives switching the host filter away and back", async ({
+    page,
+  }) => {
+    const seeded = await seedWorkspace({ repoPrefix: "host-filter-order-" });
+    const serverId = getServerId();
+
+    try {
+      const secondWorkspace = await seeded.client.createWorkspace({
+        source: {
+          kind: "directory",
+          path: seeded.repoPath,
+          projectId: seeded.projectId,
+        },
+        title: "Second workspace",
+      });
+      if (!secondWorkspace.workspace) {
+        throw new Error(secondWorkspace.error ?? "Failed to seed a second workspace");
+      }
+
+      await gotoAppShell(page);
+      await addOfflineHostAndReload(page, {
+        serverId: SECONDARY_HOST_ID,
+        label: "Secondary Host",
+      });
+      await waitForSidebarHydration(page);
+
+      const firstRowTestId = `sidebar-workspace-row-${serverId}:${seeded.workspaceId}`;
+      const secondRowTestId = `sidebar-workspace-row-${serverId}:${secondWorkspace.workspace.id}`;
+      const rows = page.locator(
+        `[data-testid="${firstRowTestId}"], [data-testid="${secondRowTestId}"]`,
+      );
+      await expect(rows).toHaveCount(2);
+
+      // Step 1: pin the sidebar to the primary host.
+      await openSidebarDisplayPreferences(page);
+      await toggleHostFilter(page, serverId);
+      await page.keyboard.press("Escape");
+      await expect(rows).toHaveCount(2);
+
+      // Step 2: manually reorder the workspaces.
+      const { before } = await quickDragFirstRowAfterSecond(rows);
+      const reordered = [before[1], before[0]];
+
+      // Step 3: switch the filter to only the secondary host.
+      await openSidebarDisplayPreferences(page);
+      await toggleHostFilter(page, SECONDARY_HOST_ID);
+      await toggleHostFilter(page, serverId);
+      await page.keyboard.press("Escape");
+      await expect(rows).toHaveCount(0, { timeout: 10_000 });
+
+      // Step 4: switch the filter back to only the primary host.
+      await openSidebarDisplayPreferences(page);
+      await toggleHostFilter(page, serverId);
+      await toggleHostFilter(page, SECONDARY_HOST_ID);
+      await page.keyboard.press("Escape");
+      await expect(rows).toHaveCount(2, { timeout: 10_000 });
+
+      // The manual order must survive the round trip.
+      await expect.poll(() => rowTestIds(rows)).toEqual(reordered);
+
+      // Also check the all-hosts view keeps it.
+      await openSidebarDisplayPreferences(page);
+      await selectAllHostsFilter(page);
+      await page.keyboard.press("Escape");
+      await expect(rows).toHaveCount(2, { timeout: 10_000 });
+      await expect.poll(() => rowTestIds(rows)).toEqual(reordered);
+    } finally {
+      await seeded.cleanup();
+    }
+  });
+});

--- a/packages/app/src/hooks/use-sidebar-workspaces-list.test.tsx
+++ b/packages/app/src/hooks/use-sidebar-workspaces-list.test.tsx
@@ -1,0 +1,342 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "@testing-library/react";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import React from "react";
+
+vi.hoisted(() => {
+  (globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+});
+
+vi.mock("expo-router", () => ({
+  router: {
+    dismissTo: vi.fn(),
+  },
+  useLocalSearchParams: () => ({}),
+  usePathname: () => "/",
+}));
+
+const asyncStorageState = vi.hoisted(() => ({
+  resolveGetItem: null as ((value: string | null) => void) | null,
+  deferNextGetItem: false,
+}));
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(() => {
+      if (asyncStorageState.deferNextGetItem) {
+        asyncStorageState.deferNextGetItem = false;
+        return new Promise<string | null>((resolve) => {
+          asyncStorageState.resolveGetItem = resolve;
+        });
+      }
+      return Promise.resolve(null);
+    }),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import {
+  useSidebarWorkspacesList,
+  type SidebarProjectEntry,
+  type SidebarWorkspacePlacement,
+} from "@/hooks/use-sidebar-workspaces-list";
+import { getHostRuntimeStore } from "@/runtime/host-runtime";
+import type { HostProfile } from "@/types/host-connection";
+import { useSessionStore, type WorkspaceDescriptor } from "@/stores/session-store";
+import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
+import { useSidebarViewStore } from "@/stores/sidebar-view-store";
+import { hasVisibleOrderChanged, mergeWithRemainder } from "@/utils/sidebar-reorder";
+
+const SERVER_A = "host-filter-server-a";
+const SERVER_B = "host-filter-server-b";
+
+function workspace(input: {
+  id: string;
+  projectId: string;
+  projectDisplayName: string;
+  name: string;
+}): WorkspaceDescriptor {
+  return {
+    id: input.id,
+    projectId: input.projectId,
+    projectDisplayName: input.projectDisplayName,
+    projectRootPath: `/repo/${input.projectId}`,
+    workspaceDirectory: `/repo/${input.projectId}/${input.id}`,
+    projectKind: "git",
+    workspaceKind: input.name === "main" ? "local_checkout" : "worktree",
+    name: input.name,
+    status: "done",
+    statusEnteredAt: null,
+    archivingAt: null,
+    diffStat: null,
+    scripts: [],
+  };
+}
+
+function hostAWorkspaces(): WorkspaceDescriptor[] {
+  return [
+    workspace({
+      id: "a-main",
+      projectId: "project-a",
+      projectDisplayName: "Project A",
+      name: "main",
+    }),
+    workspace({
+      id: "a-one",
+      projectId: "project-a",
+      projectDisplayName: "Project A",
+      name: "one",
+    }),
+    workspace({
+      id: "a-two",
+      projectId: "project-a",
+      projectDisplayName: "Project A",
+      name: "two",
+    }),
+  ];
+}
+
+function hostBWorkspaces(): WorkspaceDescriptor[] {
+  return [
+    workspace({
+      id: "b-main",
+      projectId: "project-b",
+      projectDisplayName: "Project B",
+      name: "main",
+    }),
+    workspace({
+      id: "b-one",
+      projectId: "project-b",
+      projectDisplayName: "Project B",
+      name: "one",
+    }),
+  ];
+}
+
+function makeHost(serverId: string, label: string): HostProfile {
+  const now = "2026-04-19T00:00:00.000Z";
+  return {
+    serverId,
+    label,
+    lifecycle: {},
+    connections: [],
+    preferredConnectionId: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function setHostProfiles(hosts: HostProfile[]): void {
+  (
+    getHostRuntimeStore() as unknown as {
+      setHostsAndSync: (hosts: HostProfile[]) => void;
+    }
+  ).setHostsAndSync(hosts);
+}
+
+function initializeHost(serverId: string, workspaces: WorkspaceDescriptor[]): void {
+  useSessionStore.getState().initializeSession(serverId, null as unknown as DaemonClient);
+  useSessionStore
+    .getState()
+    .setWorkspaces(serverId, new Map(workspaces.map((entry) => [entry.id, entry])));
+  useSessionStore.getState().setHasHydratedWorkspaces(serverId, true);
+}
+
+interface ProbeResult {
+  projects: SidebarProjectEntry[];
+}
+
+function Probe({ result }: { result: ProbeResult }): null {
+  const { projects } = useSidebarWorkspacesList();
+  result.projects = projects;
+  return null;
+}
+
+// Mirrors handleWorkspaceReorder in sidebar-workspace-list.tsx: the sidebar hands the
+// reordered visible placements to the order store through mergeWithRemainder.
+function simulateWorkspaceDrag(
+  projectKey: string,
+  reorderedWorkspaces: SidebarWorkspacePlacement[],
+): void {
+  const reorderedWorkspaceKeys = reorderedWorkspaces.map((entry) => entry.workspaceKey);
+  const orderStore = useSidebarOrderStore.getState();
+  const currentWorkspaceOrder = orderStore.getWorkspaceOrder(projectKey);
+  if (
+    !hasVisibleOrderChanged({
+      currentOrder: currentWorkspaceOrder,
+      reorderedVisibleKeys: reorderedWorkspaceKeys,
+    })
+  ) {
+    return;
+  }
+  orderStore.setWorkspaceOrder(
+    projectKey,
+    mergeWithRemainder({
+      currentOrder: currentWorkspaceOrder,
+      reorderedVisibleKeys: reorderedWorkspaceKeys,
+    }),
+  );
+}
+
+function workspaceIdsOf(result: ProbeResult, projectKey: string): string[] {
+  const project = result.projects.find((entry) => entry.projectKey === projectKey);
+  return project ? project.workspaces.map((entry) => entry.workspaceId) : [];
+}
+
+async function setHostFilters(filters: string[]): Promise<void> {
+  await act(async () => {
+    useSidebarViewStore.setState({ hostFilters: filters });
+  });
+}
+
+describe("useSidebarWorkspacesList host filter ordering", () => {
+  let root: Root | null = null;
+  let container: HTMLElement | null = null;
+
+  beforeEach(() => {
+    act(() => {
+      setHostProfiles([makeHost(SERVER_A, "Host A"), makeHost(SERVER_B, "Host B")]);
+      initializeHost(SERVER_A, hostAWorkspaces());
+      initializeHost(SERVER_B, hostBWorkspaces());
+      useSidebarOrderStore.setState({
+        projectOrder: [],
+        workspaceOrderByProject: {},
+      });
+      useSidebarViewStore.setState({ hostFilters: [SERVER_A] });
+    });
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    act(() => {
+      setHostProfiles([]);
+      useSessionStore.getState().clearSession(SERVER_A);
+      useSessionStore.getState().clearSession(SERVER_B);
+      useSidebarOrderStore.setState({
+        projectOrder: [],
+        workspaceOrderByProject: {},
+      });
+      useSidebarViewStore.setState({ hostFilters: [] });
+    });
+  });
+
+  async function renderProbe(result: ProbeResult): Promise<void> {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(<Probe result={result} />);
+    });
+  }
+
+  it("keeps a manual workspace order after switching the host filter away and back", async () => {
+    const result: ProbeResult = { projects: [] };
+    await renderProbe(result);
+
+    expect(workspaceIdsOf(result, "project-a")).toEqual(["a-main", "a-one", "a-two"]);
+
+    // Drag "a-two" to the top while filtered to host A.
+    const projectA = result.projects.find((entry) => entry.projectKey === "project-a");
+    expect(projectA).toBeDefined();
+    const reordered = [
+      projectA!.workspaces[2]!,
+      projectA!.workspaces[0]!,
+      projectA!.workspaces[1]!,
+    ];
+    await act(async () => {
+      simulateWorkspaceDrag("project-a", reordered);
+    });
+    expect(workspaceIdsOf(result, "project-a")).toEqual(["a-two", "a-main", "a-one"]);
+
+    // Switch the sidebar filter to host B, then back to host A.
+    await setHostFilters([SERVER_B]);
+    expect(workspaceIdsOf(result, "project-b")).toEqual(["b-main", "b-one"]);
+
+    await setHostFilters([SERVER_A]);
+
+    expect(workspaceIdsOf(result, "project-a")).toEqual(["a-two", "a-main", "a-one"]);
+    expect(useSidebarOrderStore.getState().workspaceOrderByProject["project-a"]).toEqual([
+      `${SERVER_A}:a-two`,
+      `${SERVER_A}:a-main`,
+      `${SERVER_A}:a-one`,
+    ]);
+  });
+
+  it("keeps the persisted custom order when writes land before persist hydration resolves", async () => {
+    // Simulates the persist race: the reconcile effect (or a drag) writes against the
+    // pre-hydration empty store, then AsyncStorage hydration resolves with the user's
+    // stored custom order. zustand's persist merge must let the persisted order win.
+    asyncStorageState.deferNextGetItem = true;
+    vi.resetModules();
+    const { useSidebarOrderStore: freshStore } = await import("@/stores/sidebar-order-store");
+
+    // Pre-hydration write: reconcile-style default seeding.
+    freshStore
+      .getState()
+      .setWorkspaceOrder("project-a", [
+        `${SERVER_A}:a-main`,
+        `${SERVER_A}:a-one`,
+        `${SERVER_A}:a-two`,
+      ]);
+
+    // Hydration resolves afterwards with the user's custom order.
+    asyncStorageState.resolveGetItem?.(
+      JSON.stringify({
+        state: {
+          projectOrder: ["project-a"],
+          workspaceOrderByProject: {
+            "project-a": [`${SERVER_A}:a-two`, `${SERVER_A}:a-main`, `${SERVER_A}:a-one`],
+          },
+        },
+        version: 1,
+      }),
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(freshStore.getState().workspaceOrderByProject["project-a"]).toEqual([
+      `${SERVER_A}:a-two`,
+      `${SERVER_A}:a-main`,
+      `${SERVER_A}:a-one`,
+    ]);
+  });
+
+  it("keeps a manual workspace order when the filter passes through the all-hosts state", async () => {
+    const result: ProbeResult = { projects: [] };
+    await renderProbe(result);
+
+    const projectA = result.projects.find((entry) => entry.projectKey === "project-a");
+    expect(projectA).toBeDefined();
+    const reordered = [
+      projectA!.workspaces[2]!,
+      projectA!.workspaces[0]!,
+      projectA!.workspaces[1]!,
+    ];
+    await act(async () => {
+      simulateWorkspaceDrag("project-a", reordered);
+    });
+    expect(workspaceIdsOf(result, "project-a")).toEqual(["a-two", "a-main", "a-one"]);
+
+    // Toggling filters in the UI walks through intermediate states:
+    // [A] -> [] (all hosts) -> [B] -> [] -> [A]
+    await setHostFilters([]);
+    await setHostFilters([SERVER_B]);
+    await setHostFilters([]);
+    await setHostFilters([SERVER_A]);
+
+    expect(workspaceIdsOf(result, "project-a")).toEqual(["a-two", "a-main", "a-one"]);
+  });
+});


### PR DESCRIPTION
While trying to reproduce #1871 I could not get the manual workspace order to reset on either current main or v0.1.103 (the version it was reported on). I went through the full pipeline: the sidebar order store, the reconcile effect in `use-sidebar-workspaces-list`, `mergeWithRemainder` on drag end, and the dnd-kit drag path. Every writer is either strictly additive or driven by a genuine drag event, and zustand's persist rehydration always resolves in favor of the persisted order, so none of them can clobber a saved custom order during filter switches.

Since this area had no coverage for the multi-host filter scenario, this PR adds it so the invariant stays locked:

- `packages/app/src/hooks/use-sidebar-workspaces-list.test.tsx`: integration tests with two online hosts and real stores. Reorder while filtered to host A, switch to B and back (including the all-hosts intermediate), asserting both the resulting order and the persisted store contents. Also covers the pre-hydration write race explicitly.
- `packages/app/e2e/sidebar-host-filter-order.spec.ts`: Playwright spec following the exact repro steps from #1871 with a real mouse drag and host filter menu round trips.

All four existing sidebar-order suites still pass (33/33), oxlint and oxfmt are clean on the new files, and the app workspace typechecks.

One adjacent thing I noticed while auditing, separate from #1871: the reconcile effect computes `setProjectOrder` from the render-time `persistedProjectOrder` snapshot, so two simultaneously mounted instances of the hook could in theory revert each other's project-order write. Workspace orders are not affected (they are read fresh via `getState()`). Happy to follow up with a patch if that seems worth hardening.

Refs #1871
