### PR TITLE
fix(server): keep service proxy routes synced with PASEO_URL

### DIFF
--- a/docs/service-proxy.md
+++ b/docs/service-proxy.md
@@ -97,6 +97,19 @@ server {
 
 ## Environment variables
 
+When a service starts, Paseo injects:
+
+| Variable                             | Description                                                                                  |
+| ------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `HOST`                               | Bind address for the service process (`127.0.0.1` for loopback daemons, otherwise `0.0.0.0`) |
+| `PASEO_PORT`                         | Allocated backend port                                                                       |
+| `PASEO_URL`                          | Proxy URL for this service (public alias when configured, otherwise localhost)               |
+| `PASEO_SERVICE_<NAME>_PORT` / `_URL` | Peer service ports and proxy URLs in the same workspace                                      |
+
+`PASEO_URL` / `PASEO_SERVICE_*_URL` are fixed at spawn from the registered route identity. A later branch rename updates the proxy's **canonical** hostname and keeps the spawn-time hostname(s) as aliases to the same backend until the service stops or restarts. Restarting the service re-registers under the current branch and drops prior aliases.
+
+Routes are keyed by `(workspaceId, scriptName)`: re-registering the same script replaces any prior hostname for that pair. Archive and process exit remove the workspace's proxy routes so projections never advertise an unregistered live URL.
+
 The listen address and public base URL can also be set via environment variables, which take precedence over `config.json`:
 
 | Variable                              | Description                                                               |

--- a/packages/server/src/server/script-route-branch-handler.test.ts
+++ b/packages/server/src/server/script-route-branch-handler.test.ts
@@ -73,7 +73,7 @@ function registerRoute(
 }
 
 describe("script-route-branch-handler", () => {
-  it("updates routes on branch rename by removing old hostnames and registering new ones", () => {
+  it("updates routes on branch rename while keeping prior hostnames as aliases", () => {
     const routeStore = new ScriptRouteStore();
     registerRoute(routeStore, {
       hostname: "api--feature-auth--paseo.localhost",
@@ -89,7 +89,10 @@ describe("script-route-branch-handler", () => {
 
     handleBranchChange("workspace-a", "feature/auth", "feature/billing");
 
-    expect(routeStore.findRoute("api--feature-auth--paseo.localhost")).toBeNull();
+    expect(routeStore.findRoute("api--feature-auth--paseo.localhost")).toEqual({
+      hostname: "api--feature-billing--paseo.localhost",
+      port: 3001,
+    });
     expect(routeStore.findRoute("api--feature-billing--paseo.localhost")).toEqual({
       hostname: "api--feature-billing--paseo.localhost",
       port: 3001,
@@ -175,7 +178,10 @@ describe("script-route-branch-handler", () => {
 
     handleBranchChange("workspace-a", "feature/auth", "feature/billing");
 
-    expect(routeStore.findRoute("api--feature-auth--paseo.services.example.com")).toBeNull();
+    expect(routeStore.findRoute("api--feature-auth--paseo.services.example.com")).toEqual({
+      hostname: "api--feature-billing--paseo.localhost",
+      port: 3001,
+    });
     expect(routeStore.findRoute("api--feature-billing--paseo.services.example.com")).toEqual({
       hostname: "api--feature-billing--paseo.localhost",
       port: 3001,
@@ -185,6 +191,10 @@ describe("script-route-branch-handler", () => {
         hostname: "api--feature-billing--paseo.localhost",
         publicHostname: "api--feature-billing--paseo.services.example.com",
         publicBaseUrl: "https://services.example.com:8443",
+        previousHostnames: [
+          "api--feature-auth--paseo.localhost",
+          "api--feature-auth--paseo.services.example.com",
+        ],
         port: 3001,
         workspaceId: "workspace-a",
         projectSlug: "paseo",
@@ -224,6 +234,7 @@ describe("script-route-branch-handler", () => {
     expect(routeStore.listRoutesForWorkspace("workspace-a")).toEqual([
       {
         hostname: "api--feature-billing--paseo.localhost",
+        previousHostnames: ["api--feature-auth--paseo.localhost"],
         port: 3001,
         workspaceId: "workspace-a",
         projectSlug: "paseo",
@@ -231,6 +242,7 @@ describe("script-route-branch-handler", () => {
       },
       {
         hostname: "web--feature-billing--paseo.localhost",
+        previousHostnames: ["web--feature-auth--paseo.localhost"],
         port: 3002,
         workspaceId: "workspace-a",
         projectSlug: "paseo",
@@ -298,6 +310,7 @@ describe("script-route-branch-handler", () => {
       expect(routeStore.listRoutesForWorkspace(workspace.repoDir)).toEqual([
         {
           hostname: "api--feature-billing--repo.localhost",
+          previousHostnames: ["api--feature-auth--repo.localhost"],
           port: 3001,
           workspaceId: workspace.repoDir,
           projectSlug: "repo",

--- a/packages/server/src/server/script-status-projection.test.ts
+++ b/packages/server/src/server/script-status-projection.test.ts
@@ -596,4 +596,57 @@ describe("script-status-projection", () => {
       workspace.cleanup();
     }
   });
+
+  it("does not advertise predicted proxy URLs for a running service without a registered route", () => {
+    const workspaceId = "workspace-unregistered-running";
+    const workspace = createWorkspaceRepo({
+      paseoConfig: {
+        scripts: {
+          web: { type: "service", command: "npm run web", port: 3000 },
+        },
+      },
+    });
+    const routeStore = new ScriptRouteStore();
+    const runtimeStore = new WorkspaceScriptRuntimeStore();
+    runtimeStore.set({
+      workspaceId,
+      scriptName: "web",
+      type: "service",
+      lifecycle: "running",
+      terminalId: "term-web",
+      exitCode: null,
+    });
+
+    try {
+      expect(
+        buildPayloads({
+          workspaceId,
+          workspaceDirectory: workspace.repoDir,
+          routeStore,
+          runtimeStore,
+          daemonPort: 6767,
+          gitMetadata: {
+            projectSlug: "repo",
+            currentBranch: "topic/current",
+          },
+        }),
+      ).toEqual([
+        {
+          scriptName: "web",
+          type: "service",
+          hostname: "web--topic-current--repo.localhost",
+          port: null,
+          localProxyUrl: null,
+          publicProxyUrl: null,
+          proxyUrl: null,
+          lifecycle: "running",
+          health: null,
+          exitCode: null,
+          terminalId: "term-web",
+        },
+      ]);
+    } finally {
+      workspace.cleanup();
+    }
+  });
 });

--- a/packages/server/src/server/script-status-projection.ts
+++ b/packages/server/src/server/script-status-projection.ts
@@ -10,6 +10,7 @@ import { deriveProjectSlug } from "./workspace-git-metadata.js";
 import type { ScriptHealthEntry, ScriptHealthState } from "./script-health-monitor.js";
 import type {
   ServiceProxySubsystem,
+  ServiceProxyUrlProjection,
   ServiceProxyWorkspaceScriptProjection,
 } from "./service-proxy.js";
 import type { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-store.js";
@@ -113,6 +114,38 @@ function buildConfiguredPlainScriptPayload(
   };
 }
 
+function emptyServiceUrls(): ServiceProxyUrlProjection {
+  return { localProxyUrl: null, publicProxyUrl: null, proxyUrl: null };
+}
+
+function resolveProjectedServiceUrls(params: {
+  registeredState: ServiceProxyWorkspaceScriptProjection | null;
+  predicted: ServiceProxyUrlProjection;
+  lifecycle: WorkspaceScriptPayload["lifecycle"];
+}): ServiceProxyUrlProjection {
+  if (params.registeredState) {
+    return params.registeredState;
+  }
+  if (params.lifecycle === "running") {
+    return emptyServiceUrls();
+  }
+  return params.predicted;
+}
+
+function resolveProjectedServicePort(params: {
+  registeredState: ServiceProxyWorkspaceScriptProjection | null;
+  lifecycle: WorkspaceScriptPayload["lifecycle"];
+  configuredPort: number | null;
+}): number | null {
+  if (params.registeredState) {
+    return params.registeredState.port;
+  }
+  if (params.lifecycle === "running") {
+    return null;
+  }
+  return params.configuredPort;
+}
+
 function buildConfiguredScriptPayload(
   scriptName: string,
   config: ReturnType<typeof getScriptConfigs> extends Map<string, infer V> ? V : never,
@@ -127,7 +160,9 @@ function buildConfiguredScriptPayload(
 
   const type = "service";
   const configuredPort = config.port ?? null;
-  const hostname = (
+  const lifecycle = runtimeEntry?.lifecycle ?? "stopped";
+  const registeredState = serviceState !== null && serviceState.port !== null ? serviceState : null;
+  const predicted =
     serviceState ??
     ctx.serviceProxy.projectWorkspaceService({
       projectSlug: ctx.projectSlug,
@@ -135,28 +170,20 @@ function buildConfiguredScriptPayload(
       scriptName,
       daemonPort: ctx.daemonPort,
       publicBaseUrl: ctx.serviceProxyPublicBaseUrl,
-    })
-  ).hostname;
-
-  const urls =
-    serviceState ??
-    ctx.serviceProxy.projectUrls({
-      projectSlug: ctx.projectSlug,
-      branchName: ctx.branchName,
-      scriptName,
-      daemonPort: ctx.daemonPort,
-      publicBaseUrl: ctx.serviceProxyPublicBaseUrl,
     });
+
+  const hostname = registeredState ? registeredState.hostname : predicted.hostname;
+  const urls = resolveProjectedServiceUrls({ registeredState, predicted, lifecycle });
 
   return {
     scriptName,
     type,
     hostname,
-    port: serviceState?.port ?? configuredPort,
+    port: resolveProjectedServicePort({ registeredState, lifecycle, configuredPort }),
     localProxyUrl: urls.localProxyUrl,
     publicProxyUrl: urls.publicProxyUrl,
     proxyUrl: urls.proxyUrl,
-    lifecycle: runtimeEntry?.lifecycle ?? "stopped",
+    lifecycle,
     health: toWireHealth(ctx.resolveHealth?.(hostname) ?? null),
     exitCode: runtimeEntry?.exitCode ?? null,
     terminalId: runtimeEntry?.terminalId ?? null,
@@ -169,43 +196,47 @@ function buildOrphanRuntimePayload(
   ctx: BuildPayloadContext,
 ): WorkspaceScriptPayload {
   const type = runtimeEntry.type;
-  const hostname =
-    type === "service"
-      ? (
-          serviceState ??
-          ctx.serviceProxy.projectWorkspaceService({
-            projectSlug: ctx.projectSlug,
-            branchName: ctx.branchName,
-            scriptName: runtimeEntry.scriptName,
-            daemonPort: ctx.daemonPort,
-            publicBaseUrl: ctx.serviceProxyPublicBaseUrl,
-          })
-        ).hostname
-      : runtimeEntry.scriptName;
-  const urls =
+  if (type !== "service") {
+    return {
+      scriptName: runtimeEntry.scriptName,
+      type,
+      hostname: runtimeEntry.scriptName,
+      port: null,
+      proxyUrl: null,
+      lifecycle: runtimeEntry.lifecycle,
+      health: null,
+      exitCode: runtimeEntry.exitCode,
+      terminalId: runtimeEntry.terminalId,
+    };
+  }
+
+  const registeredState = serviceState !== null && serviceState.port !== null ? serviceState : null;
+  const predicted =
     serviceState ??
-    ctx.serviceProxy.projectUrls({
+    ctx.serviceProxy.projectWorkspaceService({
       projectSlug: ctx.projectSlug,
       branchName: ctx.branchName,
       scriptName: runtimeEntry.scriptName,
       daemonPort: ctx.daemonPort,
       publicBaseUrl: ctx.serviceProxyPublicBaseUrl,
     });
+  const hostname = registeredState?.hostname ?? predicted.hostname;
+  const urls = resolveProjectedServiceUrls({
+    registeredState,
+    predicted,
+    lifecycle: runtimeEntry.lifecycle,
+  });
 
   return {
     scriptName: runtimeEntry.scriptName,
     type,
     hostname,
-    port: type === "service" ? (serviceState?.port ?? null) : null,
-    ...(type === "service"
-      ? { localProxyUrl: urls.localProxyUrl, publicProxyUrl: urls.publicProxyUrl }
-      : {}),
-    proxyUrl: type === "service" ? urls.proxyUrl : null,
+    port: registeredState?.port ?? null,
+    localProxyUrl: urls.localProxyUrl,
+    publicProxyUrl: urls.publicProxyUrl,
+    proxyUrl: urls.proxyUrl,
     lifecycle: runtimeEntry.lifecycle,
-    health:
-      type === "service" && serviceState?.port !== null
-        ? toWireHealth(ctx.resolveHealth?.(hostname) ?? null)
-        : null,
+    health: registeredState ? toWireHealth(ctx.resolveHealth?.(hostname) ?? null) : null,
     exitCode: runtimeEntry.exitCode,
     terminalId: runtimeEntry.terminalId,
   };

--- a/packages/server/src/server/service-proxy.test.ts
+++ b/packages/server/src/server/service-proxy.test.ts
@@ -293,4 +293,137 @@ describe("service proxy subsystem shape", () => {
       port: 4000,
     });
   });
+
+  it("replaces prior hostnames when the same workspace/script registers under a new branch", () => {
+    const serviceProxy = createServiceProxySubsystem({ logger });
+    serviceProxy.registerWorkspaceService({
+      workspaceId: "workspace-a",
+      projectSlug: "example-app",
+      branchName: "topic/old",
+      scriptName: "web",
+      port: 64064,
+    });
+    serviceProxy.registerWorkspaceService({
+      workspaceId: "workspace-a",
+      projectSlug: "example-app",
+      branchName: "topic/new",
+      scriptName: "web",
+      port: 64065,
+    });
+
+    expect(
+      serviceProxy.getHealthTargetForHostname("web--topic-old--example-app.localhost"),
+    ).toBeNull();
+    expect(
+      serviceProxy.getHealthTargetForHostname("web--topic-new--example-app.localhost"),
+    ).toMatchObject({
+      workspaceId: "workspace-a",
+      scriptName: "web",
+      port: 64065,
+    });
+    expect(serviceProxy.getWorkspaceHealthTargets("workspace-a")).toEqual([
+      expect.objectContaining({
+        hostname: "web--topic-new--example-app.localhost",
+        port: 64065,
+      }),
+    ]);
+  });
+
+  it("removeWorkspaceService clears every route for the workspace script", () => {
+    const routes = new ServiceProxyRouteRegistry();
+    routes.registerRoute({
+      hostname: "web--topic-old--example-app.localhost",
+      port: 64064,
+      workspaceId: "workspace-a",
+      projectSlug: "example-app",
+      scriptName: "web",
+    });
+    routes.registerRoute({
+      hostname: "web--topic-new--example-app.localhost",
+      port: 64065,
+      workspaceId: "workspace-a",
+      projectSlug: "example-app",
+      scriptName: "web",
+    });
+
+    routes.removeWorkspaceService({ workspaceId: "workspace-a", scriptName: "web" });
+
+    expect(routes.listRoutesForWorkspace("workspace-a")).toEqual([]);
+    expect(routes.getRouteEntry("web--topic-old--example-app.localhost")).toBeNull();
+    expect(routes.getRouteEntry("web--topic-new--example-app.localhost")).toBeNull();
+  });
+
+  it("removeRoutesForWorkspace clears all routes for the workspace", () => {
+    const serviceProxy = createServiceProxySubsystem({ logger });
+    serviceProxy.registerWorkspaceService({
+      workspaceId: "workspace-a",
+      projectSlug: "repo",
+      branchName: "main",
+      scriptName: "api",
+      port: 3000,
+    });
+    serviceProxy.registerWorkspaceService({
+      workspaceId: "workspace-a",
+      projectSlug: "repo",
+      branchName: "main",
+      scriptName: "web",
+      port: 3001,
+    });
+    serviceProxy.registerWorkspaceService({
+      workspaceId: "workspace-b",
+      projectSlug: "other",
+      branchName: "main",
+      scriptName: "api",
+      port: 3002,
+    });
+
+    serviceProxy.removeRoutesForWorkspace("workspace-a");
+
+    expect(serviceProxy.getWorkspaceHealthTargets("workspace-a")).toEqual([]);
+    expect(serviceProxy.getHealthTargetForHostname("api--other.localhost")).toMatchObject({
+      workspaceId: "workspace-b",
+      port: 3002,
+    });
+  });
+
+  it("keeps prior hostnames as aliases when branch routes are replaced", () => {
+    const routes = new ServiceProxyRouteRegistry();
+    routes.registerWorkspaceService({
+      workspaceId: "workspace-a",
+      projectSlug: "paseo",
+      branchName: "feature/auth",
+      scriptName: "api",
+      port: 3001,
+      publicBaseUrl: "https://services.example.com",
+    });
+
+    expect(
+      routes.replaceWorkspaceBranchRoutes({
+        workspaceId: "workspace-a",
+        newBranch: "feature/billing",
+      }),
+    ).toBe(true);
+
+    expect(routes.findRoute("api--feature-billing--paseo.localhost")).toEqual({
+      hostname: "api--feature-billing--paseo.localhost",
+      port: 3001,
+    });
+    expect(routes.findRoute("api--feature-auth--paseo.localhost")).toEqual({
+      hostname: "api--feature-billing--paseo.localhost",
+      port: 3001,
+    });
+    expect(routes.findRoute("api--feature-auth--paseo.services.example.com")).toEqual({
+      hostname: "api--feature-billing--paseo.localhost",
+      port: 3001,
+    });
+    expect(routes.getRouteEntry("api--feature-billing--paseo.localhost")).toMatchObject({
+      hostname: "api--feature-billing--paseo.localhost",
+      publicHostname: "api--feature-billing--paseo.services.example.com",
+      previousHostnames: [
+        "api--feature-auth--paseo.localhost",
+        "api--feature-auth--paseo.services.example.com",
+      ],
+      port: 3001,
+    });
+  });
 });

--- a/packages/server/src/server/service-proxy.ts
+++ b/packages/server/src/server/service-proxy.ts
@@ -23,6 +23,8 @@ export interface ServiceProxyRouteEntry extends ServiceProxyRoute {
   localHostname?: string;
   publicHostname?: string | null;
   publicBaseUrl?: string | null;
+  /** Prior local/public hostnames kept as aliases after identity changes (e.g. branch rename). */
+  previousHostnames?: string[];
 }
 
 export interface ServiceProxyUrlProjection {
@@ -353,6 +355,33 @@ function sameRouteOwner(left: ServiceProxyRouteEntry, right: ServiceProxyRouteEn
   return left.workspaceId === right.workspaceId && left.scriptName === right.scriptName;
 }
 
+function collectPreviousHostnames(params: {
+  route: ServiceProxyRouteEntry;
+  nextHostname: string;
+  nextPublicHostname: string | null;
+}): string[] {
+  const nextHostnames = new Set(
+    [params.nextHostname, params.nextPublicHostname]
+      .filter((hostname): hostname is string => Boolean(hostname))
+      .map((hostname) => hostname.toLowerCase()),
+  );
+  const collected: string[] = [];
+  const seen = new Set<string>();
+  for (const hostname of [
+    ...(params.route.previousHostnames ?? []),
+    params.route.hostname,
+    ...(params.route.publicHostname ? [params.route.publicHostname] : []),
+  ]) {
+    const normalized = hostname.toLowerCase();
+    if (nextHostnames.has(normalized) || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    collected.push(hostname);
+  }
+  return collected;
+}
+
 export class ServiceProxyRouteCollisionError extends Error {
   constructor(
     public readonly hostname: string,
@@ -395,6 +424,14 @@ export class ServiceProxyRouteRegistry {
       projectSlug: input.projectSlug,
       scriptName: input.scriptName,
     };
+    const existingForScript = this.listRoutesForWorkspace(input.workspaceId).filter(
+      (route) => route.scriptName === input.scriptName,
+    );
+    const replacingHostnames = new Set(existingForScript.map((route) => route.hostname));
+    this.assertCanRegister(entry, replacingHostnames);
+    for (const existing of existingForScript) {
+      this.removeRoute(existing.hostname);
+    }
     this.registerRoute(entry);
     return { ...entry };
   }
@@ -421,25 +458,35 @@ export class ServiceProxyRouteRegistry {
     if (routes.length === 0) {
       return false;
     }
-    const updates = routes.map((route) => ({
-      oldHostname: route.hostname,
-      entry: this.toStoredEntry({
-        ...route,
-        hostname: buildLocalServiceHostname({
-          projectSlug: route.projectSlug,
-          branchName: params.newBranch,
-          scriptName: route.scriptName,
+    const updates = routes.map((route) => {
+      const hostname = buildLocalServiceHostname({
+        projectSlug: route.projectSlug,
+        branchName: params.newBranch,
+        scriptName: route.scriptName,
+      });
+      const publicHostname = route.publicBaseUrl
+        ? buildPublicServiceHostname({
+            projectSlug: route.projectSlug,
+            branchName: params.newBranch,
+            scriptName: route.scriptName,
+            publicBaseUrl: route.publicBaseUrl,
+          })
+        : null;
+      const previousHostnames = collectPreviousHostnames({
+        route,
+        nextHostname: hostname,
+        nextPublicHostname: publicHostname,
+      });
+      return {
+        oldHostname: route.hostname,
+        entry: this.toStoredEntry({
+          ...route,
+          hostname,
+          publicHostname,
+          ...(previousHostnames.length > 0 ? { previousHostnames } : {}),
         }),
-        publicHostname: route.publicBaseUrl
-          ? buildPublicServiceHostname({
-              projectSlug: route.projectSlug,
-              branchName: params.newBranch,
-              scriptName: route.scriptName,
-              publicBaseUrl: route.publicBaseUrl,
-            })
-          : null,
-      }),
-    }));
+      };
+    });
 
     if (
       updates.every(
@@ -480,16 +527,21 @@ export class ServiceProxyRouteRegistry {
   }
 
   removeRouteForWorkspaceScript(params: { workspaceId: string; scriptName: string }): void {
-    const route = this.listRoutesForWorkspace(params.workspaceId).find(
-      (entry) => entry.scriptName === params.scriptName,
-    );
-    if (route) {
-      this.removeRoute(route.hostname);
+    for (const route of this.listRoutesForWorkspace(params.workspaceId)) {
+      if (route.scriptName === params.scriptName) {
+        this.removeRoute(route.hostname);
+      }
     }
   }
 
   removeWorkspaceService(params: { workspaceId: string; scriptName: string }): void {
     this.removeRouteForWorkspaceScript(params);
+  }
+
+  removeRoutesForWorkspace(workspaceId: string): void {
+    for (const route of this.listRoutesForWorkspace(workspaceId)) {
+      this.removeRoute(route.hostname);
+    }
   }
 
   projectUrls(input: {
@@ -651,11 +703,12 @@ export class ServiceProxyRouteRegistry {
   }
 
   private toStoredEntry(entry: ServiceProxyRouteEntry): ServiceProxyRouteEntry {
-    const { publicHostname, publicBaseUrl, ...requiredEntry } = entry;
+    const { publicHostname, publicBaseUrl, previousHostnames, ...requiredEntry } = entry;
     return {
       ...requiredEntry,
       ...(publicHostname ? { publicHostname } : {}),
       ...(publicBaseUrl ? { publicBaseUrl } : {}),
+      ...(previousHostnames && previousHostnames.length > 0 ? { previousHostnames } : {}),
     };
   }
 
@@ -665,11 +718,13 @@ export class ServiceProxyRouteRegistry {
   }
 
   private getRouteHostnames(
-    entry: Pick<ServiceProxyRouteEntry, "hostname" | "publicHostname">,
+    entry: Pick<ServiceProxyRouteEntry, "hostname" | "publicHostname" | "previousHostnames">,
   ): string[] {
-    return [entry.hostname, ...(entry.publicHostname ? [entry.publicHostname] : [])].map((host) =>
-      host.toLowerCase(),
-    );
+    return [
+      entry.hostname,
+      ...(entry.publicHostname ? [entry.publicHostname] : []),
+      ...(entry.previousHostnames ?? []),
+    ].map((host) => host.toLowerCase());
   }
 
   private addHostnameToWorkspaceIndex(workspaceId: string, hostname: string): void {
@@ -748,6 +803,7 @@ export function createScriptProxyUpgradeHandler({
 export interface ServiceProxySubsystem {
   registerWorkspaceService(input: RegisterWorkspaceServiceInput): ServiceProxyRouteEntry;
   removeWorkspaceService(params: { workspaceId: string; scriptName: string }): void;
+  removeRoutesForWorkspace(workspaceId: string): void;
   removeServiceRoutesByHostnames(hostnames: string[]): void;
   replaceWorkspaceBranchRoutes(params: { workspaceId: string; newBranch: string | null }): boolean;
   getHealthCheckTargets(): ServiceProxyHealthTarget[];
@@ -813,6 +869,10 @@ class NodeServiceProxySubsystem implements ServiceProxySubsystem {
 
   removeWorkspaceService(params: { workspaceId: string; scriptName: string }): void {
     this.routes.removeRouteForWorkspaceScript(params);
+  }
+
+  removeRoutesForWorkspace(workspaceId: string): void {
+    this.routes.removeRoutesForWorkspace(workspaceId);
   }
 
   removeServiceRoutesByHostnames(hostnames: string[]): void {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4405,6 +4405,7 @@ export class Session {
 
   private async teardownArchivedWorkspace(workspaceId: string): Promise<void> {
     this.workspaceGitObserver.removeForWorkspaceId(workspaceId);
+    this.serviceProxy?.removeRoutesForWorkspace(workspaceId);
     this.scriptRuntimeStore?.removeForWorkspace(workspaceId);
     releaseWorkspaceServicePortPlan(workspaceId);
   }

--- a/packages/server/src/server/workspace-service-env.test.ts
+++ b/packages/server/src/server/workspace-service-env.test.ts
@@ -166,6 +166,27 @@ describe("buildWorkspaceServiceEnv", () => {
     });
   });
 
+  it("prefers the registered self route for PASEO_URL over the branch formula", () => {
+    expect(
+      buildWorkspaceServiceEnv({
+        scriptName: "web",
+        projectSlug: "paseo",
+        branchName: "feature-new",
+        daemonPort: 6767,
+        daemonListenHost: null,
+        peers: [{ scriptName: "web", port: 5173 }],
+        registeredSelfRoute: {
+          hostname: "web--feature-spawned--paseo.localhost",
+          projectSlug: "paseo",
+          scriptName: "web",
+        },
+      }),
+    ).toMatchObject({
+      PASEO_URL: "http://web--feature-spawned--paseo.localhost:6767",
+      PASEO_SERVICE_WEB_URL: "http://web--feature-spawned--paseo.localhost:6767",
+    });
+  });
+
   it("throws when normalized peer env names collide", () => {
     expect(() =>
       buildWorkspaceServiceEnv({

--- a/packages/server/src/server/workspace-service-env.ts
+++ b/packages/server/src/server/workspace-service-env.ts
@@ -1,4 +1,8 @@
-import { projectServiceProxyUrls } from "./service-proxy.js";
+import {
+  projectRegisteredServiceProxyUrls,
+  projectServiceProxyUrls,
+  type ServiceProxyRouteEntry,
+} from "./service-proxy.js";
 
 export interface WorkspaceServicePeer {
   scriptName: string;
@@ -13,6 +17,11 @@ export interface BuildWorkspaceServiceEnvOptions {
   daemonListenHost: string | null | undefined;
   serviceProxyPublicBaseUrl?: string | null;
   peers: readonly WorkspaceServicePeer[];
+  /** When set, self PASEO_URL comes from the registered route (spawn identity snapshot). */
+  registeredSelfRoute?: Pick<
+    ServiceProxyRouteEntry,
+    "hostname" | "publicHostname" | "publicBaseUrl" | "projectSlug" | "scriptName"
+  >;
 }
 
 export function normalizeServiceEnvName(scriptName: string): string {
@@ -38,13 +47,18 @@ export function buildWorkspaceServiceEnv(
     PASEO_PORT: String(selfPeer.port),
   };
 
-  const selfProxyUrl = buildServiceProxyUrl({
-    projectSlug: options.projectSlug,
-    branchName: options.branchName,
-    scriptName: options.scriptName,
-    daemonPort: options.daemonPort,
-    serviceProxyPublicBaseUrl: options.serviceProxyPublicBaseUrl,
-  });
+  const selfProxyUrl = options.registeredSelfRoute
+    ? projectRegisteredServiceProxyUrls({
+        route: options.registeredSelfRoute,
+        daemonPort: options.daemonPort,
+      }).proxyUrl
+    : buildServiceProxyUrl({
+        projectSlug: options.projectSlug,
+        branchName: options.branchName,
+        scriptName: options.scriptName,
+        daemonPort: options.daemonPort,
+        serviceProxyPublicBaseUrl: options.serviceProxyPublicBaseUrl,
+      });
   if (selfProxyUrl) {
     env.PASEO_URL = selfProxyUrl;
   }
@@ -53,13 +67,16 @@ export function buildWorkspaceServiceEnv(
     const envName = normalizeServiceEnvName(peer.scriptName);
     env[`PASEO_SERVICE_${envName}_PORT`] = String(peer.port);
 
-    const peerProxyUrl = buildServiceProxyUrl({
-      projectSlug: options.projectSlug,
-      branchName: options.branchName,
-      scriptName: peer.scriptName,
-      daemonPort: options.daemonPort,
-      serviceProxyPublicBaseUrl: options.serviceProxyPublicBaseUrl,
-    });
+    const peerProxyUrl =
+      peer.scriptName === options.scriptName && options.registeredSelfRoute
+        ? selfProxyUrl
+        : buildServiceProxyUrl({
+            projectSlug: options.projectSlug,
+            branchName: options.branchName,
+            scriptName: peer.scriptName,
+            daemonPort: options.daemonPort,
+            serviceProxyPublicBaseUrl: options.serviceProxyPublicBaseUrl,
+          });
     if (peerProxyUrl) {
       env[`PASEO_SERVICE_${envName}_URL`] = peerProxyUrl;
     }

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -804,6 +804,14 @@ async function setupServiceScriptRoute(params: {
     });
   }
 
+  const registeredRoute = serviceProxy.registerWorkspaceService({
+    port,
+    workspaceId,
+    projectSlug,
+    branchName,
+    scriptName,
+    publicBaseUrl: serviceProxyPublicBaseUrl ?? null,
+  });
   const env = buildWorkspaceServiceEnv({
     scriptName,
     projectSlug,
@@ -812,15 +820,7 @@ async function setupServiceScriptRoute(params: {
     daemonListenHost,
     serviceProxyPublicBaseUrl,
     peers,
-  });
-
-  const registeredRoute = serviceProxy.registerWorkspaceService({
-    port,
-    workspaceId,
-    projectSlug,
-    branchName,
-    scriptName,
-    publicBaseUrl: serviceProxyPublicBaseUrl ?? null,
+    registeredSelfRoute: registeredRoute,
   });
   return { hostname: registeredRoute.hostname, port, env };
 }


### PR DESCRIPTION
## Summary
- Register/remove service-proxy routes by `(workspaceId, scriptName)` so branch/slug changes cannot leave a stale hostname (502) while the injected `PASEO_URL` is unregistered (404).
- Keep prior hostnames as aliases across branch renames so spawn-time env URLs keep resolving; clear all workspace routes on archive.
- Stop projecting live proxy URLs when a running service has no registered route; spawn registers before injecting env from the registered route.

Fixes #2397

## Test plan
- [x] Targeted vitest: service-proxy, script-route-branch-handler, script-status-projection, workspace-service-env
- [x] typecheck + lint
- [ ] Manual: start a workspace service, curl `Host: <PASEO_URL host>` against the daemon; rename branch / restart and confirm no 404+502 split


Made with [Cursor](https://cursor.com)