### PR TITLE
fix(app): reopen closed agent tabs without archiving the workspace

### DIFF
--- a/packages/app/src/screens/workspace/workspace-empty-draft-seed.test.ts
+++ b/packages/app/src/screens/workspace/workspace-empty-draft-seed.test.ts
@@ -1,16 +1,73 @@
 import { describe, expect, it } from "vitest";
-import { shouldSeedEmptyWorkspaceDraft } from "./workspace-empty-draft-seed";
+import type { Agent } from "@/stores/session-store";
+import { deriveWorkspaceAgentVisibility } from "@/workspace-tabs/agent-visibility";
+import {
+  decideEmptyWorkspaceRecovery,
+  isEmptyWorkspaceLayoutReady,
+  selectRediscoverableHiddenAgentIds,
+  shouldSeedEmptyWorkspaceDraft,
+} from "./workspace-empty-draft-seed";
 
-const readyEmptyWorkspace = {
+function makeAgent(input: {
+  id: string;
+  cwd: string;
+  workspaceId?: string;
+  parentAgentId?: string | null;
+}): Agent {
+  const createdAt = new Date("2026-03-04T00:00:00.000Z");
+  return {
+    serverId: "srv",
+    id: input.id,
+    provider: "codex",
+    status: "idle",
+    createdAt,
+    updatedAt: createdAt,
+    lastUserMessageAt: null,
+    lastActivityAt: createdAt,
+    capabilities: {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    },
+    currentModeId: null,
+    availableModes: [],
+    pendingPermissions: [],
+    persistence: null,
+    runtimeInfo: {
+      provider: "codex",
+      sessionId: null,
+    },
+    title: null,
+    cwd: input.cwd,
+    workspaceId: input.workspaceId,
+    model: null,
+    thinkingOptionId: null,
+    parentAgentId: input.parentAgentId ?? null,
+    labels: {},
+    requiresAttention: false,
+    attentionReason: null,
+    attentionTimestamp: null,
+    archivedAt: null,
+  };
+}
+
+const readyEmptyLayout = {
   isRouteFocused: true,
   hasPersistenceKey: true,
   hasWorkspaceDirectory: true,
   hasHydratedWorkspaceLayoutStore: true,
   hasHydratedAgents: true,
   hasLoadedTerminals: true,
-  activeAgentCount: 0,
   terminalCount: 0,
   tabCount: 0,
+};
+
+const readyEmptyWorkspace = {
+  ...readyEmptyLayout,
+  activeAgentCount: 0,
 };
 
 describe("shouldSeedEmptyWorkspaceDraft", () => {
@@ -58,5 +115,124 @@ describe("shouldSeedEmptyWorkspaceDraft", () => {
 
   it("seeds once an empty focused workspace is fully known", () => {
     expect(shouldSeedEmptyWorkspaceDraft(readyEmptyWorkspace)).toBe(true);
+  });
+});
+
+describe("isEmptyWorkspaceLayoutReady", () => {
+  it("is ready with active agents when tabs and terminals are empty", () => {
+    expect(isEmptyWorkspaceLayoutReady(readyEmptyLayout)).toBe(true);
+  });
+
+  it("is not ready while tabs remain", () => {
+    expect(
+      isEmptyWorkspaceLayoutReady({
+        ...readyEmptyLayout,
+        tabCount: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("selectRediscoverableHiddenAgentIds", () => {
+  it("returns the intersection of hidden, auto-open, and active agent ids", () => {
+    expect(
+      selectRediscoverableHiddenAgentIds({
+        hiddenAgentIds: new Set(["child-a", "child-b", "hidden-only"]),
+        autoOpenAgentIds: new Set(["child-b", "child-a", "auto-only"]),
+        activeAgentIds: new Set(["child-a", "active-only", "child-b"]),
+      }),
+    ).toEqual(["child-a", "child-b"]);
+  });
+
+  it("returns an empty list when any set misses the candidate", () => {
+    expect(
+      selectRediscoverableHiddenAgentIds({
+        hiddenAgentIds: new Set(["child-agent"]),
+        autoOpenAgentIds: new Set(["child-agent"]),
+        activeAgentIds: new Set(),
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("decideEmptyWorkspaceRecovery", () => {
+  it("reopens a hidden cross-workspace child before seeding a draft", () => {
+    expect(
+      decideEmptyWorkspaceRecovery({
+        layoutReady: true,
+        rediscoverableHiddenAgentIds: ["child-agent"],
+        activeAgentCount: 1,
+      }),
+    ).toEqual({ kind: "reopen-hidden-agents", agentIds: ["child-agent"] });
+  });
+
+  it("seeds a draft only when nothing rediscoverable remains and no agents are active", () => {
+    expect(
+      decideEmptyWorkspaceRecovery({
+        layoutReady: true,
+        rediscoverableHiddenAgentIds: [],
+        activeAgentCount: 0,
+      }),
+    ).toEqual({ kind: "seed-draft" });
+  });
+
+  it("does not seed a draft over active same-workspace agents that are not auto-open", () => {
+    expect(
+      decideEmptyWorkspaceRecovery({
+        layoutReady: true,
+        rediscoverableHiddenAgentIds: [],
+        activeAgentCount: 1,
+      }),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("is a noop when the empty layout gate is closed", () => {
+    expect(
+      decideEmptyWorkspaceRecovery({
+        layoutReady: false,
+        rediscoverableHiddenAgentIds: ["child-agent"],
+        activeAgentCount: 1,
+      }),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("close → hide → empty-seed reopens a cross-workspace child", () => {
+    const parent = makeAgent({
+      id: "parent-agent",
+      cwd: "/repo",
+      workspaceId: "ws-parent",
+    });
+    const child = makeAgent({
+      id: "child-agent",
+      cwd: "/repo/worktree",
+      workspaceId: "ws-child",
+      parentAgentId: parent.id,
+    });
+    const visibility = deriveWorkspaceAgentVisibility({
+      sessionAgents: new Map([
+        [parent.id, parent],
+        [child.id, child],
+      ]),
+      workspaceId: "ws-child",
+    });
+
+    // Closing the child tab hides it without archiving (layout-only).
+    const hiddenAgentIds = new Set(["child-agent"]);
+    expect(child.archivedAt).toBeNull();
+    expect(visibility.autoOpenAgentIds).toEqual(new Set(["child-agent"]));
+    expect(visibility.activeAgentIds).toEqual(new Set(["child-agent"]));
+
+    const rediscoverableHiddenAgentIds = selectRediscoverableHiddenAgentIds({
+      hiddenAgentIds,
+      autoOpenAgentIds: visibility.autoOpenAgentIds,
+      activeAgentIds: visibility.activeAgentIds,
+    });
+    expect(
+      decideEmptyWorkspaceRecovery({
+        layoutReady: true,
+        rediscoverableHiddenAgentIds,
+        activeAgentCount: visibility.activeAgentIds.size,
+      }),
+    ).toEqual({ kind: "reopen-hidden-agents", agentIds: ["child-agent"] });
   });
 });

--- a/packages/app/src/screens/workspace/workspace-empty-draft-seed.ts
+++ b/packages/app/src/screens/workspace/workspace-empty-draft-seed.ts
@@ -1,11 +1,10 @@
-export function shouldSeedEmptyWorkspaceDraft(input: {
+export function isEmptyWorkspaceLayoutReady(input: {
   isRouteFocused: boolean;
   hasPersistenceKey: boolean;
   hasWorkspaceDirectory: boolean;
   hasHydratedWorkspaceLayoutStore: boolean;
   hasHydratedAgents: boolean;
   hasLoadedTerminals: boolean;
-  activeAgentCount: number;
   terminalCount: number;
   tabCount: number;
 }): boolean {
@@ -20,5 +19,58 @@ export function shouldSeedEmptyWorkspaceDraft(input: {
     return false;
   }
 
-  return input.activeAgentCount === 0 && input.terminalCount === 0 && input.tabCount === 0;
+  return input.terminalCount === 0 && input.tabCount === 0;
+}
+
+export function shouldSeedEmptyWorkspaceDraft(input: {
+  isRouteFocused: boolean;
+  hasPersistenceKey: boolean;
+  hasWorkspaceDirectory: boolean;
+  hasHydratedWorkspaceLayoutStore: boolean;
+  hasHydratedAgents: boolean;
+  hasLoadedTerminals: boolean;
+  activeAgentCount: number;
+  terminalCount: number;
+  tabCount: number;
+}): boolean {
+  return isEmptyWorkspaceLayoutReady(input) && input.activeAgentCount === 0;
+}
+
+export function selectRediscoverableHiddenAgentIds(input: {
+  hiddenAgentIds: ReadonlySet<string>;
+  autoOpenAgentIds: ReadonlySet<string>;
+  activeAgentIds: ReadonlySet<string>;
+}): string[] {
+  const rediscoverable: string[] = [];
+  for (const agentId of input.hiddenAgentIds) {
+    if (input.autoOpenAgentIds.has(agentId) && input.activeAgentIds.has(agentId)) {
+      rediscoverable.push(agentId);
+    }
+  }
+  return rediscoverable.sort();
+}
+
+export type EmptyWorkspaceRecovery =
+  | { kind: "noop" }
+  | { kind: "reopen-hidden-agents"; agentIds: string[] }
+  | { kind: "seed-draft" };
+
+export function decideEmptyWorkspaceRecovery(input: {
+  layoutReady: boolean;
+  rediscoverableHiddenAgentIds: readonly string[];
+  activeAgentCount: number;
+}): EmptyWorkspaceRecovery {
+  if (!input.layoutReady) {
+    return { kind: "noop" };
+  }
+  if (input.rediscoverableHiddenAgentIds.length > 0) {
+    return {
+      kind: "reopen-hidden-agents",
+      agentIds: [...input.rediscoverableHiddenAgentIds],
+    };
+  }
+  if (input.activeAgentCount === 0) {
+    return { kind: "seed-draft" };
+  }
+  return { kind: "noop" };
 }

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -160,14 +160,22 @@ import {
 } from "@/screens/workspace/workspace-pane-content";
 import { useMountedTabSet } from "@/screens/workspace/use-mounted-tab-set";
 import { WorkspaceFocusProvider } from "@/workspace/focus";
-import { shouldSeedEmptyWorkspaceDraft } from "@/screens/workspace/workspace-empty-draft-seed";
+import {
+  decideEmptyWorkspaceRecovery,
+  isEmptyWorkspaceLayoutReady,
+  selectRediscoverableHiddenAgentIds,
+} from "@/screens/workspace/workspace-empty-draft-seed";
 import {
   buildBulkCloseConfirmationMessage,
   type BulkCloseConfirmationLabels,
   classifyBulkClosableTabs,
   closeBulkWorkspaceTabs,
 } from "@/screens/workspace/workspace-bulk-close";
-import { resolveCloseAgentTabPolicy } from "@/subagents";
+import {
+  resolveAgentForCloseTabPolicy,
+  resolveCloseAgentTabPolicy,
+  shouldArchiveAgentOnTabClose,
+} from "@/subagents";
 import {
   getPanelInstanceAttributes,
   useModifiedPanelTabIds,
@@ -1996,7 +2004,7 @@ function WorkspaceScreenContent({
       ? (state.pinnedAgentIdsByWorkspace[persistenceKey] ?? EMPTY_PINNED_AGENT_IDS)
       : EMPTY_PINNED_AGENT_IDS,
   );
-  const _hiddenAgentIds = useWorkspaceLayoutStore((state) =>
+  const hiddenAgentIds = useWorkspaceLayoutStore((state) =>
     persistenceKey ? (state.hiddenAgentIdsByWorkspace[persistenceKey] ?? EMPTY_SET) : EMPTY_SET,
   );
   const pendingByDraftId = useCreateFlowStore((state) => state.pendingByDraftId);
@@ -2007,6 +2015,7 @@ function WorkspaceScreenContent({
     function closeWorkspaceTabWithCleanup(input: {
       tabId: string;
       target?: WorkspaceTabTarget | null;
+      hideAgent?: boolean;
     }) {
       const normalizedTabId = trimNonEmpty(input.tabId);
       if (!normalizedTabId || !persistenceKey) {
@@ -2015,7 +2024,9 @@ function WorkspaceScreenContent({
 
       if (input.target?.kind === "agent") {
         unpinWorkspaceAgent(persistenceKey, input.target.agentId);
-        hideWorkspaceAgent(persistenceKey, input.target.agentId);
+        if (input.hideAgent !== false) {
+          hideWorkspaceAgent(persistenceKey, input.target.agentId);
+        }
       }
       if (input.target?.kind === "browser") {
         const { browserId } = input.target;
@@ -2226,19 +2237,27 @@ function WorkspaceScreenContent({
   ]);
 
   useEffect(() => {
-    if (
-      !shouldSeedEmptyWorkspaceDraft({
-        isRouteFocused,
-        hasPersistenceKey: Boolean(persistenceKey),
-        hasWorkspaceDirectory: Boolean(workspaceDirectory),
-        hasHydratedWorkspaceLayoutStore,
-        hasHydratedAgents,
-        hasLoadedTerminals: terminalsQuery.isSuccess,
-        activeAgentCount: workspaceAgentVisibility.activeAgentIds.size,
-        terminalCount: terminals.length,
-        tabCount: tabs.length,
-      })
-    ) {
+    const layoutReady = isEmptyWorkspaceLayoutReady({
+      isRouteFocused,
+      hasPersistenceKey: Boolean(persistenceKey),
+      hasWorkspaceDirectory: Boolean(workspaceDirectory),
+      hasHydratedWorkspaceLayoutStore,
+      hasHydratedAgents,
+      hasLoadedTerminals: terminalsQuery.isSuccess,
+      terminalCount: terminals.length,
+      tabCount: tabs.length,
+    });
+    const rediscoverableHiddenAgentIds = selectRediscoverableHiddenAgentIds({
+      hiddenAgentIds,
+      autoOpenAgentIds: workspaceAgentVisibility.autoOpenAgentIds,
+      activeAgentIds: workspaceAgentVisibility.activeAgentIds,
+    });
+    const recovery = decideEmptyWorkspaceRecovery({
+      layoutReady,
+      rediscoverableHiddenAgentIds,
+      activeAgentCount: workspaceAgentVisibility.activeAgentIds.size,
+    });
+    if (recovery.kind === "noop") {
       emptyWorkspaceSeedRef.current = null;
       return;
     }
@@ -2247,20 +2266,32 @@ function WorkspaceScreenContent({
       return;
     }
     emptyWorkspaceSeedRef.current = workspaceKey;
+    if (recovery.kind === "reopen-hidden-agents") {
+      if (!persistenceKey) {
+        return;
+      }
+      for (const agentId of recovery.agentIds) {
+        openWorkspaceTabFocused(persistenceKey, { kind: "agent", agentId });
+      }
+      return;
+    }
     openWorkspaceDraftTab();
   }, [
     normalizedServerId,
     normalizedWorkspaceId,
     openWorkspaceDraftTab,
+    openWorkspaceTabFocused,
     persistenceKey,
     hasHydratedAgents,
     hasHydratedWorkspaceLayoutStore,
+    hiddenAgentIds,
     isRouteFocused,
     terminals.length,
     terminalsQuery.isSuccess,
     tabs.length,
     workspaceDirectory,
-    workspaceAgentVisibility.activeAgentIds.size,
+    workspaceAgentVisibility.activeAgentIds,
+    workspaceAgentVisibility.autoOpenAgentIds,
   ]);
 
   useEffect(() => {
@@ -2649,8 +2680,12 @@ function WorkspaceScreenContent({
           return;
         }
 
-        const agent =
-          useSessionStore.getState().sessions[normalizedServerId]?.agents?.get(agentId) ?? null;
+        const session = useSessionStore.getState().sessions[normalizedServerId];
+        const agent = resolveAgentForCloseTabPolicy({
+          agentId,
+          agents: session?.agents,
+          agentDetails: session?.agentDetails,
+        });
         const closePolicy = resolveCloseAgentTabPolicy(agent);
         const isRunning = agent?.status === "running";
 
@@ -2672,10 +2707,14 @@ function WorkspaceScreenContent({
           closeWorkspaceTabWithCleanup({
             tabId,
             target: { kind: "agent", agentId },
+            // Hide only for layout-only close so reconcile does not auto-reopen.
+            // Archive-on-close skips hide to avoid empty-seed rediscovering a root
+            // that is about to leave the active set.
+            hideAgent: closePolicy.kind === "layout-only",
           });
         }
 
-        if (closePolicy.kind === "layout-only") {
+        if (!shouldArchiveAgentOnTabClose(closePolicy)) {
           return;
         }
 

--- a/packages/app/src/subagents/close-tab-policy.test.ts
+++ b/packages/app/src/subagents/close-tab-policy.test.ts
@@ -1,5 +1,55 @@
 import { describe, expect, it } from "vitest";
-import { resolveCloseAgentTabPolicy } from "./close-tab-policy";
+import type { Agent } from "@/stores/session-store";
+import {
+  resolveAgentForCloseTabPolicy,
+  resolveCloseAgentTabPolicy,
+  shouldArchiveAgentOnTabClose,
+} from "./close-tab-policy";
+
+function makeAgent(input: {
+  id: string;
+  parentAgentId?: string | null;
+  archivedAt?: Date | null;
+}): Agent {
+  const createdAt = new Date("2026-03-04T00:00:00.000Z");
+  return {
+    serverId: "srv",
+    id: input.id,
+    provider: "codex",
+    status: "idle",
+    createdAt,
+    updatedAt: createdAt,
+    lastUserMessageAt: null,
+    lastActivityAt: createdAt,
+    capabilities: {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    },
+    currentModeId: null,
+    availableModes: [],
+    pendingPermissions: [],
+    persistence: null,
+    runtimeInfo: {
+      provider: "codex",
+      sessionId: null,
+    },
+    title: null,
+    cwd: "/repo",
+    workspaceId: "ws-1",
+    model: null,
+    thinkingOptionId: null,
+    parentAgentId: input.parentAgentId ?? null,
+    labels: {},
+    requiresAttention: false,
+    attentionReason: null,
+    attentionTimestamp: null,
+    archivedAt: input.archivedAt ?? null,
+  };
+}
 
 describe("resolveCloseAgentTabPolicy", () => {
   it("archives root agents when their tab closes", () => {
@@ -14,8 +64,53 @@ describe("resolveCloseAgentTabPolicy", () => {
     });
   });
 
-  it("preserves the existing archive fallback when the agent is missing", () => {
-    expect(resolveCloseAgentTabPolicy(null)).toEqual({ kind: "archive-on-close" });
-    expect(resolveCloseAgentTabPolicy(undefined)).toEqual({ kind: "archive-on-close" });
+  it("falls back to layout-only when the agent is missing", () => {
+    expect(resolveCloseAgentTabPolicy(null)).toEqual({ kind: "layout-only" });
+    expect(resolveCloseAgentTabPolicy(undefined)).toEqual({ kind: "layout-only" });
+  });
+});
+
+describe("resolveAgentForCloseTabPolicy", () => {
+  it("prefers the live agents map over agentDetails", () => {
+    const live = makeAgent({ id: "agent-1", parentAgentId: null });
+    const detail = makeAgent({ id: "agent-1", parentAgentId: "parent-agent" });
+
+    expect(
+      resolveAgentForCloseTabPolicy({
+        agentId: "agent-1",
+        agents: new Map([["agent-1", live]]),
+        agentDetails: new Map([["agent-1", detail]]),
+      }),
+    ).toBe(live);
+  });
+
+  it("resolves from agentDetails when the agent is absent from agents", () => {
+    const detail = makeAgent({ id: "child-agent", parentAgentId: "parent-agent" });
+    const resolved = resolveAgentForCloseTabPolicy({
+      agentId: "child-agent",
+      agents: new Map(),
+      agentDetails: new Map([["child-agent", detail]]),
+    });
+
+    expect(resolved).toBe(detail);
+    expect(resolveCloseAgentTabPolicy(resolved)).toEqual({ kind: "layout-only" });
+    expect(shouldArchiveAgentOnTabClose(resolveCloseAgentTabPolicy(resolved))).toBe(false);
+  });
+
+  it("returns null when the agent is missing from both maps", () => {
+    expect(
+      resolveAgentForCloseTabPolicy({
+        agentId: "missing",
+        agents: new Map(),
+        agentDetails: new Map(),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("shouldArchiveAgentOnTabClose", () => {
+  it("archives only for archive-on-close; layout-only does not set archivedAt", () => {
+    expect(shouldArchiveAgentOnTabClose({ kind: "archive-on-close" })).toBe(true);
+    expect(shouldArchiveAgentOnTabClose({ kind: "layout-only" })).toBe(false);
   });
 });

--- a/packages/app/src/subagents/close-tab-policy.ts
+++ b/packages/app/src/subagents/close-tab-policy.ts
@@ -5,9 +5,28 @@ export type CloseAgentTabPolicy = { kind: "archive-on-close" } | { kind: "layout
 export function resolveCloseAgentTabPolicy(
   agent: Pick<Agent, "parentAgentId"> | null | undefined,
 ): CloseAgentTabPolicy {
-  if (agent?.parentAgentId) {
+  // Never archive when parentage cannot be confirmed — missing agents may be
+  // subagents that only live in agentDetails or have not hydrated yet.
+  if (!agent) {
+    return { kind: "layout-only" };
+  }
+
+  if (agent.parentAgentId) {
     return { kind: "layout-only" };
   }
 
   return { kind: "archive-on-close" };
+}
+
+export function resolveAgentForCloseTabPolicy(input: {
+  agentId: string;
+  agents: Map<string, Agent> | undefined;
+  agentDetails: Map<string, Agent> | undefined;
+}): Agent | null {
+  const { agentId, agents, agentDetails } = input;
+  return agents?.get(agentId) ?? agentDetails?.get(agentId) ?? null;
+}
+
+export function shouldArchiveAgentOnTabClose(policy: CloseAgentTabPolicy): boolean {
+  return policy.kind === "archive-on-close";
 }

--- a/packages/app/src/subagents/index.ts
+++ b/packages/app/src/subagents/index.ts
@@ -6,5 +6,10 @@ export {
   useHideFinishedProviderSubagents,
   type UseHideFinishedProviderSubagentsInput,
 } from "./use-hide-finished-provider-subagents";
-export { resolveCloseAgentTabPolicy, type CloseAgentTabPolicy } from "./close-tab-policy";
+export {
+  resolveAgentForCloseTabPolicy,
+  resolveCloseAgentTabPolicy,
+  shouldArchiveAgentOnTabClose,
+  type CloseAgentTabPolicy,
+} from "./close-tab-policy";
 export { isWorkspaceRootAgent } from "./workspace-root-policy";

--- a/packages/app/src/subagents/policies.ts
+++ b/packages/app/src/subagents/policies.ts
@@ -5,5 +5,10 @@
 // The full module entry `@/subagents` re-exports these too, alongside the
 // UI surface. Use `@/subagents/policies` only when the caller is
 // non-RN infrastructure code; otherwise prefer `@/subagents`.
-export { resolveCloseAgentTabPolicy, type CloseAgentTabPolicy } from "./close-tab-policy";
+export {
+  resolveAgentForCloseTabPolicy,
+  resolveCloseAgentTabPolicy,
+  shouldArchiveAgentOnTabClose,
+  type CloseAgentTabPolicy,
+} from "./close-tab-policy";
 export { isWorkspaceRootAgent } from "./workspace-root-policy";


### PR DESCRIPTION
## Summary
- Resolve close-tab policy from `agents` or `agentDetails`, and treat a missing agent as layout-only so unknown parentage never archives.
- When a workspace empties of agent tabs, reopen hidden auto-open agents via `openTabFocused` before seeding a draft — so closed subagent/cross-workspace tabs are rediscoverable without archive+restore.

Fixes #2357

## Test plan
- [x] `npx vitest run packages/app/src/subagents/close-tab-policy.test.ts packages/app/src/screens/workspace/workspace-empty-draft-seed.test.ts --bail=1`
- [x] typecheck + lint
- [ ] Manual: open parent + subagent tabs, close only the subagent tab, reopen from track / empty-workspace recovery without archiving the workspace


Made with [Cursor](https://cursor.com)