### PR TITLE
fix(server): stop Codex guardian subagents stuck as running

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -2280,6 +2280,227 @@ describe("Codex app-server provider", () => {
     }
   });
 
+  test("keeps a settled child completed after a late child item completion", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      const resultPromise = session.run("Delegate the guardian review.");
+      await appServer.waitForTurnStart();
+
+      appServer.startsSubAgent({
+        callId: "spawn-guardian-late-item",
+        threadId: "guardian-thread-late-item",
+        agentPath: "/root/guardian",
+      });
+      appServer.says({
+        threadId: "guardian-thread-late-item",
+        itemId: "guardian-decision",
+        text: "Approve with notes.",
+      });
+      appServer.completeTurn({ threadId: "guardian-thread-late-item" });
+      appServer.says({
+        threadId: "guardian-thread-late-item",
+        itemId: "guardian-late-decision",
+        text: "Late trailing decision.",
+      });
+      appServer.completeTurn();
+
+      const result = await resultPromise;
+      expect(result.timeline.findLast((item) => item.type === "tool_call")).toMatchObject({
+        callId: "spawn-guardian-late-item",
+        status: "completed",
+        detail: {
+          type: "sub_agent",
+          log: expect.stringContaining("Late trailing decision."),
+        },
+      });
+      const providerUpserts = events.flatMap((event) =>
+        event.type === "provider_subagent" && event.event.type === "upsert" ? [event.event] : [],
+      );
+      expect(providerUpserts.at(-1)).toMatchObject({
+        type: "upsert",
+        id: "guardian-thread-late-item",
+        status: "completed",
+      });
+      expect(providerUpserts.some((event) => event.status === "running")).toBe(true);
+      expect(
+        providerUpserts.findLastIndex((event) => event.status === "completed"),
+      ).toBeGreaterThan(providerUpserts.findLastIndex((event) => event.status === "running"));
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("keeps a settled child completed after a late new-id interacted activity", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      const resultPromise = session.run("Delegate the guardian review.");
+      await appServer.waitForTurnStart();
+
+      appServer.startsSubAgent({
+        callId: "spawn-guardian-late-interacted",
+        threadId: "guardian-thread-late-interacted",
+        agentPath: "/root/guardian",
+      });
+      appServer.completeTurn({ threadId: "guardian-thread-late-interacted" });
+      appServer.beginsSubAgentActivity({
+        callId: "late-guardian-interacted",
+        threadId: "guardian-thread-late-interacted",
+        agentPath: "/root/guardian",
+        kind: "interacted",
+      });
+      appServer.completesSubAgentActivity({
+        callId: "late-guardian-interacted",
+        threadId: "guardian-thread-late-interacted",
+        agentPath: "/root/guardian",
+        kind: "interacted",
+      });
+      appServer.completeTurn();
+
+      const result = await resultPromise;
+      expect(result.timeline.findLast((item) => item.type === "tool_call")).toMatchObject({
+        callId: "spawn-guardian-late-interacted",
+        status: "completed",
+      });
+      expect(
+        events
+          .flatMap((event) =>
+            event.type === "provider_subagent" && event.event.type === "upsert"
+              ? [event.event]
+              : [],
+          )
+          .at(-1),
+      ).toMatchObject({
+        type: "upsert",
+        id: "guardian-thread-late-interacted",
+        status: "completed",
+      });
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("keeps an active child running while its turn is still open", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "spawn-active-child",
+        kind: "started",
+        agentThreadId: "active-child-thread",
+        agentPath: "/root/active-child",
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "active-child-thread",
+      item: {
+        type: "agentMessage",
+        id: "active-child-message",
+        text: "Still working.",
+      },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: {
+        type: "subAgentActivity",
+        id: "active-child-interacted",
+        kind: "interacted",
+        agentThreadId: "active-child-thread",
+        agentPath: "/root/active-child",
+      },
+    });
+
+    expect(events.at(-1)).toMatchObject({
+      type: "timeline",
+      item: {
+        callId: "spawn-active-child",
+        status: "running",
+        detail: {
+          type: "sub_agent",
+          log: "[Assistant] Still working.",
+        },
+      },
+    });
+    expect(
+      events
+        .flatMap((event) =>
+          event.type === "provider_subagent" && event.event.type === "upsert" ? [event.event] : [],
+        )
+        .at(-1),
+    ).toMatchObject({
+      type: "upsert",
+      id: "active-child-thread",
+      status: "running",
+    });
+  });
+
+  test("cancels a settled child when a late interrupted activity arrives", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    try {
+      const resultPromise = session.run("Delegate the investigation.");
+      await appServer.waitForTurnStart();
+
+      appServer.startsSubAgent({
+        callId: "spawn-child-interrupt-after-settle",
+        threadId: "child-thread-interrupt-after-settle",
+        agentPath: "/root/interrupt-after-settle",
+      });
+      appServer.completeTurn({ threadId: "child-thread-interrupt-after-settle" });
+      appServer.beginsSubAgentActivity({
+        callId: "late-interrupt-after-settle",
+        threadId: "child-thread-interrupt-after-settle",
+        agentPath: "/root/interrupt-after-settle",
+        kind: "interrupted",
+      });
+      appServer.completesSubAgentActivity({
+        callId: "late-interrupt-after-settle",
+        threadId: "child-thread-interrupt-after-settle",
+        agentPath: "/root/interrupt-after-settle",
+        kind: "interrupted",
+      });
+      appServer.completeTurn();
+
+      const result = await resultPromise;
+      expect(result.timeline.findLast((item) => item.type === "tool_call")).toMatchObject({
+        callId: "spawn-child-interrupt-after-settle",
+        status: "canceled",
+      });
+      appServer.assertNoErrors();
+    } finally {
+      await session.close();
+    }
+  });
+
   test("preserves a completed child status when replaying a late compaction", async () => {
     const appServer = createFakeCodexAppServer();
     const session = new CodexAppServerAgentSession(
@@ -3045,6 +3266,10 @@ describe("Codex app-server provider", () => {
 
     const liveEvents: AgentStreamEvent[] = [];
     session.subscribe((event) => liveEvents.push(event));
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "v2-child-thread",
+      turn: { id: "v2-child-turn-after-resume" },
+    });
     asInternals(session).handleNotification("item/completed", {
       threadId: "test-thread",
       item: {
@@ -3073,6 +3298,10 @@ describe("Codex app-server provider", () => {
     });
 
     liveEvents.length = 0;
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "legacy-child-thread",
+      turn: { id: "legacy-child-turn-after-resume" },
+    });
     asInternals(session).handleNotification("item/agentMessage/delta", {
       threadId: "legacy-child-thread",
       itemId: "legacy-child-message-after-resume",

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -1654,6 +1654,12 @@ function shouldIgnoreMirroredLifecycleItem(source: "item" | "codex_event", item:
   return source === "codex_event" && !readCodexSubAgentActivity(item);
 }
 
+function isTerminalSubAgentToolCallStatus(
+  status: ToolCallTimelineItem["status"],
+): status is "completed" | "failed" | "canceled" {
+  return status === "completed" || status === "failed" || status === "canceled";
+}
+
 function settleHistoricalSubAgentActivity(
   item: ToolCallTimelineItem,
   kind: CodexSubAgentActivity["kind"],
@@ -4605,7 +4611,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private dispatchSubAgentNotification(parsed: ParsedCodexNotification, callId: string): void {
     switch (parsed.kind) {
       case "thread_started":
-        this.emitSubAgentActivityUpdate(callId, "running");
+        this.emitSubAgentActivityUpdate(callId, "running", { reopen: true });
         return;
       case "turn_started":
       case "turn_completed":
@@ -4878,10 +4884,16 @@ export class CodexAppServerAgentSession implements AgentSession {
         },
       };
     }
-    this.emitSubAgentActivityUpdate(
-      callId,
-      activity.kind === "interrupted" ? "canceled" : "running",
-    );
+    // Non-interrupted activity is live `running` only while the child is
+    // non-terminal. After turn settle, late started/interacted ids must not
+    // reopen the card; interrupted may still cancel a settled child.
+    let nextStatus: ToolCallTimelineItem["status"] | undefined = "running";
+    if (activity.kind === "interrupted") {
+      nextStatus = "canceled";
+    } else if (isTerminalSubAgentToolCallStatus(state.toolCall.status)) {
+      nextStatus = undefined;
+    }
+    this.emitSubAgentActivityUpdate(callId, nextStatus);
     return true;
   }
 
@@ -4965,6 +4977,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private emitSubAgentActivityUpdate(
     callId: string,
     status?: ToolCallTimelineItem["status"],
+    options?: { reopen?: boolean },
   ): void {
     const state = this.subAgentCallsByCallId.get(callId);
     if (!state || state.toolCall.detail.type !== "sub_agent") {
@@ -4975,7 +4988,18 @@ export class CodexAppServerAgentSession implements AgentSession {
       childTimeline.length > 0
         ? curateAgentActivity(childTimeline, { labelAssistantMessages: true })
         : "";
-    const resolvedStatus = status ?? state.toolCall.status;
+    // Child turn settle is authoritative. Late item/activity traffic must not
+    // reopen a terminal card to `running` unless a new turn/thread start
+    // explicitly reopens multi-turn reuse. Terminal→canceled (interrupt) and
+    // other terminal transitions remain allowed.
+    let resolvedStatus = status ?? state.toolCall.status;
+    if (
+      status === "running" &&
+      !options?.reopen &&
+      isTerminalSubAgentToolCallStatus(state.toolCall.status)
+    ) {
+      resolvedStatus = state.toolCall.status;
+    }
     for (const childThreadId of state.childThreadIds) {
       this.emitProviderSubagentUpsert(childThreadId, state, resolvedStatus);
     }
@@ -5114,7 +5138,9 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.pendingCommandOutputDeltas.delete(itemId);
       this.pendingFileChangeOutputDeltas.delete(itemId);
     }
-    this.emitSubAgentActivityUpdate(callId, "running");
+    // Preserve status (including terminal settle). Forcing `running` here
+    // reopened finished Auto-review guardians on late child item/completed.
+    this.emitSubAgentActivityUpdate(callId);
   }
 
   private handleSubAgentContextCompactionItem(
@@ -5250,7 +5276,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   ): void {
     const subAgentCallId = this.getSubAgentCallIdForThread(parsed.threadId);
     if (subAgentCallId) {
-      this.emitSubAgentActivityUpdate(subAgentCallId, "running");
+      this.emitSubAgentActivityUpdate(subAgentCallId, "running", { reopen: true });
       return;
     }
     this.currentTurnId = parsed.turnId;


### PR DESCRIPTION
## Summary
- After a Codex Auto-review guardian (provider subagent) settles to completed/failed/canceled, late child `item/completed` and new-id `interacted` events no longer force status back to `running`.
- Hide finished / header counts can clear finished guardians again.

Fixes #2326

## Test plan
- [x] `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1`
- [x] typecheck + lint
- [ ] Manual: run Codex Auto-review, wait for guardians to finish, confirm header is not `1 running` and hide finished removes them


Made with [Cursor](https://cursor.com)