### PR TITLE
fix(desktop): reclaim unreachable desktop pid locks after reboot

### DIFF
--- a/packages/desktop/src/daemon/daemon-manager.test.ts
+++ b/packages/desktop/src/daemon/daemon-manager.test.ts
@@ -484,6 +484,40 @@ describe("daemon-manager commands", () => {
     );
   });
 
+  it("reclaims a stale unreachable desktop pid lock after reboot", async () => {
+    mocks.runExternalCliJsonCommand.mockResolvedValue({
+      localDaemon: "stale_pid",
+      connectedDaemon: "unreachable",
+      serverId: "",
+      pid: 44160,
+      listen: "127.0.0.1:6767",
+      desktopManaged: true,
+    });
+    mocks.spawnProcess.mockImplementation(() => {
+      const child = createMockChildProcess();
+      scheduleFailedStartup(child);
+      return child;
+    });
+
+    await expect(createDaemonCommandHandlers().start_desktop_daemon()).rejects.toThrow(
+      "Daemon failed to start: exit code 1",
+    );
+
+    expect(mocks.createNodeEntrypointInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ["--reclaim-stale-pid-lock"] }),
+    );
+    expect(mocks.spawnProcess).toHaveBeenCalledWith(
+      "node",
+      [],
+      expect.objectContaining({
+        detached: true,
+        envOverlay: expect.objectContaining({
+          PASEO_DESKTOP_MANAGED: "1",
+        }),
+      }),
+    );
+  });
+
   it("does not pass stale lock reclaim when the status command fails", async () => {
     mocks.runExternalCliJsonCommand.mockRejectedValue(new Error("status command failed"));
     mocks.spawnProcess.mockImplementation(() => {
@@ -499,6 +533,29 @@ describe("daemon-manager commands", () => {
     expect(mocks.createNodeEntrypointInvocation).toHaveBeenCalledWith(
       expect.objectContaining({ args: [] }),
     );
+  });
+
+  it("starts a non-managed stopped daemon without reclaiming the pid lock", async () => {
+    mocks.runExternalCliJsonCommand.mockResolvedValue({
+      localDaemon: "stopped",
+      connectedDaemon: "unreachable",
+      serverId: "",
+      desktopManaged: false,
+    });
+    mocks.spawnProcess.mockImplementation(() => {
+      const child = createMockChildProcess();
+      scheduleFailedStartup(child);
+      return child;
+    });
+
+    await expect(createDaemonCommandHandlers().start_desktop_daemon()).rejects.toThrow(
+      "Daemon failed to start: exit code 1",
+    );
+
+    expect(mocks.createNodeEntrypointInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({ args: [] }),
+    );
+    expect(mocks.spawnProcess).toHaveBeenCalled();
   });
 
   it("returns the Electron main-process log tail from electron-log", () => {

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -389,12 +389,14 @@ async function startDaemon(): Promise<DesktopDaemonStatus> {
   }
 
   const daemonRunner = resolveDaemonRunnerEntrypoint();
-  const reclaimStalePidLock =
-    current.status === "errored" && current.desktopManaged && current.error === null;
+  // Reclaim for desktop-managed locks that are not a live/reachable daemon:
+  // unresponsive (errored) and stale_pid after reboot (stopped + desktopManaged).
+  const needsStaleLockReclaim =
+    current.desktopManaged === true && current.error === null && current.status !== "running";
   const invocation = createNodeEntrypointInvocation({
     entrypoint: daemonRunner,
     argvMode: "node-script",
-    args: reclaimStalePidLock ? ["--reclaim-stale-pid-lock"] : [],
+    args: needsStaleLockReclaim ? ["--reclaim-stale-pid-lock"] : [],
     baseEnv: process.env,
   });
 


### PR DESCRIPTION
## Summary
- Desktop-managed daemon start now reclaims stale pid locks whenever status is not `running` (covers post-reboot dead PID + closed port).
- Reachable daemons still reuse without reclaim; non-managed stopped starts still skip reclaim.

Fixes #2386

## Test plan
- [x] `npx vitest run packages/desktop/src/daemon/daemon-manager.test.ts --bail=1`
- [x] typecheck + lint
- [ ] Manual on Windows: reboot with keepRunningAfterQuit, open desktop, confirm daemon auto-starts without Restart daemon


Made with [Cursor](https://cursor.com)