### PR TITLE
fix(cli): make daemon set-password work under Windows Electron

### DIFF
--- a/packages/cli/src/commands/daemon/index.ts
+++ b/packages/cli/src/commands/daemon/index.ts
@@ -69,6 +69,10 @@ export function createDaemonCommand(): Command {
       .description("Prompt for and save a hashed daemon password to config.json"),
   )
     .option("--home <path>", "Paseo home directory (default: ~/.paseo)")
+    .option(
+      "--password <value>",
+      "Set password non-interactively (skips prompts; prefer PASEO_SET_PASSWORD)",
+    )
     .action(withOutput(runSetPasswordCommand));
 
   return daemon;

--- a/packages/cli/src/commands/daemon/set-password.ts
+++ b/packages/cli/src/commands/daemon/set-password.ts
@@ -14,9 +14,17 @@ import type {
   OutputSchema,
   SingleResult,
 } from "../../output/index.js";
+import {
+  isInteractiveTerminal,
+  isWindowsElectronRunAsNode,
+  PASSWORD_ALTERNATES_DETAILS,
+  promptPasswordViaWindowsConsole,
+  type InteractivePasswordProcess,
+} from "../../utils/interactive-password.js";
 import { resolveLocalPaseoHome } from "./local-daemon.js";
 
 const CONFIG_FILENAME = "config.json";
+const SET_PASSWORD_ENV = "PASEO_SET_PASSWORD";
 
 interface SetPasswordResult {
   action: "password_set";
@@ -29,7 +37,11 @@ export type PromptPassword = (message: string) => Promise<string | symbol>;
 
 export interface SetPasswordOptions {
   home?: string;
+  password?: string;
   promptPassword?: PromptPassword;
+  promptWindowsConsole?: PromptPassword;
+  process?: InteractivePasswordProcess;
+  env?: NodeJS.ProcessEnv;
 }
 
 const setPasswordResultSchema: OutputSchema<SetPasswordResult> = {
@@ -57,6 +69,20 @@ function createCommandError(code: string, message: string, details?: string): Co
   return { code, message, ...(details ? { details } : {}) };
 }
 
+function resolveProvidedPassword(options: SetPasswordOptions): string | undefined {
+  if (typeof options.password === "string") {
+    return options.password;
+  }
+
+  const env = options.env ?? process.env;
+  const fromEnv = env[SET_PASSWORD_ENV];
+  if (typeof fromEnv === "string" && fromEnv.length > 0) {
+    return fromEnv;
+  }
+
+  return undefined;
+}
+
 async function promptForPassword(promptPassword: PromptPassword): Promise<string> {
   const first = await promptPassword("New daemon password");
   if (isCancel(first)) {
@@ -75,6 +101,73 @@ async function promptForPassword(promptPassword: PromptPassword): Promise<string
   }
 
   return first;
+}
+
+function throwPromptUnavailable(message: string, cause?: unknown): never {
+  let causeMessage: string | undefined;
+  if (cause instanceof Error) {
+    causeMessage = cause.message;
+  } else if (cause !== undefined) {
+    causeMessage = String(cause);
+  }
+  const details = causeMessage
+    ? `${causeMessage}\n\n${PASSWORD_ALTERNATES_DETAILS}`
+    : PASSWORD_ALTERNATES_DETAILS;
+  throw createCommandError("PASSWORD_PROMPT_UNAVAILABLE", message, details);
+}
+
+async function resolveNewPassword(options: SetPasswordOptions): Promise<string> {
+  const provided = resolveProvidedPassword(options);
+  if (provided !== undefined) {
+    if (provided.length === 0) {
+      throw createCommandError("PASSWORD_REQUIRED", "Password cannot be empty");
+    }
+    return provided;
+  }
+
+  if (typeof options.promptPassword === "function") {
+    return await promptForPassword(options.promptPassword);
+  }
+
+  const processLike = options.process ?? process;
+  const windowsElectron = isWindowsElectronRunAsNode(processLike);
+
+  if (!isInteractiveTerminal(processLike) && !windowsElectron) {
+    throwPromptUnavailable(
+      "Non-interactive terminal detected; provide --password or set PASEO_SET_PASSWORD.",
+    );
+  }
+
+  if (windowsElectron) {
+    const promptWindows =
+      typeof options.promptWindowsConsole === "function"
+        ? options.promptWindowsConsole
+        : (message: string) => promptPasswordViaWindowsConsole(message);
+    try {
+      return await promptForPassword(promptWindows);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        typeof (error as CommandError).code === "string"
+      ) {
+        throw error;
+      }
+      throwPromptUnavailable(
+        "Could not read a password from the Windows console under the desktop CLI.",
+        error,
+      );
+    }
+  }
+
+  if (!isInteractiveTerminal(processLike)) {
+    throwPromptUnavailable(
+      "Non-interactive terminal detected; provide --password or set PASEO_SET_PASSWORD.",
+    );
+  }
+
+  return await promptForPassword((message) => passwordPrompt({ message }));
 }
 
 export async function setDaemonPasswordInConfig(
@@ -109,13 +202,30 @@ export async function runSetPasswordCommand(
   options: CommandOptions,
   _command: Command,
 ): Promise<SingleResult<SetPasswordResult>> {
-  const promptPassword =
-    typeof options.promptPassword === "function"
-      ? (options.promptPassword as PromptPassword)
-      : (message: string) => passwordPrompt({ message });
-  const newPassword = await promptForPassword(promptPassword);
-  const result = await setDaemonPasswordInConfig(newPassword, {
+  const setPasswordOptions: SetPasswordOptions = {
     home: typeof options.home === "string" ? options.home : undefined,
+    password: typeof options.password === "string" ? options.password : undefined,
+    promptPassword:
+      typeof options.promptPassword === "function"
+        ? (options.promptPassword as PromptPassword)
+        : undefined,
+    promptWindowsConsole:
+      typeof options.promptWindowsConsole === "function"
+        ? (options.promptWindowsConsole as PromptPassword)
+        : undefined,
+    process:
+      options.process && typeof options.process === "object"
+        ? (options.process as InteractivePasswordProcess)
+        : undefined,
+    env:
+      options.env && typeof options.env === "object"
+        ? (options.env as NodeJS.ProcessEnv)
+        : undefined,
+  };
+
+  const newPassword = await resolveNewPassword(setPasswordOptions);
+  const result = await setDaemonPasswordInConfig(newPassword, {
+    home: setPasswordOptions.home,
   });
 
   return {

--- a/packages/cli/src/utils/interactive-password.ts
+++ b/packages/cli/src/utils/interactive-password.ts
@@ -1,0 +1,110 @@
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptions } from "node:child_process";
+
+export interface InteractivePasswordProcess {
+  platform: NodeJS.Platform;
+  versions: NodeJS.ProcessVersions;
+  env: NodeJS.ProcessEnv;
+  execPath: string;
+  stdin: { isTTY?: boolean };
+  stdout: { isTTY?: boolean };
+}
+
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildProcessWithoutNullStreams | ReturnType<typeof spawn>;
+
+const WINDOWS_READ_HOST_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$secure = Read-Host -Prompt $env:PASEO_PASSWORD_PROMPT -AsSecureString
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+try {
+  [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+} finally {
+  [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+}
+`.trim();
+
+export function isWindowsElectronRunAsNode(
+  processLike: Pick<
+    InteractivePasswordProcess,
+    "platform" | "versions" | "env" | "execPath"
+  > = process,
+): boolean {
+  if (processLike.platform !== "win32") {
+    return false;
+  }
+
+  const electronVersion = processLike.versions.electron;
+  if (typeof electronVersion === "string" && electronVersion.length > 0) {
+    return true;
+  }
+
+  const runAsNode = processLike.env.ELECTRON_RUN_AS_NODE;
+  if (runAsNode !== "1" && runAsNode !== "true") {
+    return false;
+  }
+
+  return /(?:^|[\\/])paseo\.exe$/i.test(processLike.execPath);
+}
+
+export function isInteractiveTerminal(
+  processLike: Pick<InteractivePasswordProcess, "stdin" | "stdout"> = process,
+): boolean {
+  return Boolean(processLike.stdin.isTTY && processLike.stdout.isTTY);
+}
+
+/**
+ * Prompt for a password via a Windows console-subsystem child.
+ *
+ * Packaged desktop CLI runs as GUI-subsystem Electron (`Paseo.exe` +
+ * ELECTRON_RUN_AS_NODE). AttachConsole can drive stdout while Node/libuv
+ * stdin is unusable for @clack — so we never read process.stdin here.
+ */
+export async function promptPasswordViaWindowsConsole(
+  message: string,
+  spawnImpl: SpawnFn = spawn,
+): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawnImpl(
+      "powershell.exe",
+      ["-NoProfile", "-Command", WINDOWS_READ_HOST_SCRIPT],
+      {
+        env: {
+          ...process.env,
+          PASEO_PASSWORD_PROMPT: message,
+        },
+        stdio: ["inherit", "pipe", "inherit"],
+        windowsHide: false,
+      },
+    );
+
+    let stdout = "";
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string | Buffer) => {
+      stdout += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    });
+    child.on("error", (error) => {
+      reject(error);
+    });
+    child.on("close", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Windows console password prompt terminated by signal ${signal}`));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(`Windows console password prompt exited with code ${code ?? "null"}`));
+        return;
+      }
+      resolve(stdout.replace(/\r?\n$/, ""));
+    });
+  });
+}
+
+export const PASSWORD_ALTERNATES_DETAILS = [
+  "Use one of:",
+  "  paseo daemon set-password --password <value>",
+  "  PASEO_SET_PASSWORD=<value> paseo daemon set-password",
+  "  npx -y @getpaseo/cli daemon set-password",
+].join("\n");

--- a/packages/cli/tests/32-daemon-set-password.test.ts
+++ b/packages/cli/tests/32-daemon-set-password.test.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env npx tsx
 
 import assert from "node:assert";
+import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import type { Command } from "commander";
 import { isBearerTokenValid } from "@getpaseo/server";
 import {
@@ -11,13 +13,20 @@ import {
   setDaemonPasswordInConfig,
   type PromptPassword,
 } from "../src/commands/daemon/set-password.ts";
+import {
+  isInteractiveTerminal,
+  isWindowsElectronRunAsNode,
+  PASSWORD_ALTERNATES_DETAILS,
+  promptPasswordViaWindowsConsole,
+  type SpawnFn,
+} from "../src/utils/interactive-password.ts";
 
 console.log("=== Daemon Set Password Command ===\n");
 
 const root = await mkdtemp(join(tmpdir(), "paseo-set-password-"));
 const paseoHome = join(root, ".paseo");
 
-function promptSequence(values: string[]): PromptPassword {
+function promptSequence(values: Array<string | symbol>): PromptPassword {
   return async () => {
     const value = values.shift();
     if (value === undefined) {
@@ -25,6 +34,21 @@ function promptSequence(values: string[]): PromptPassword {
     }
     return value;
   };
+}
+
+function createFakeChild(stdoutText: string, exitCode = 0) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+  };
+  child.stdout = new PassThrough();
+  queueMicrotask(() => {
+    child.stdout.write(stdoutText);
+    child.stdout.end();
+    queueMicrotask(() => {
+      child.emit("close", exitCode, null);
+    });
+  });
+  return child;
 }
 
 try {
@@ -99,6 +123,258 @@ try {
         error.code === "PASSWORD_MISMATCH",
     );
     console.log("✓ command refuses password mismatch\n");
+  }
+
+  {
+    console.log("Test 4: --password skips prompts and writes hash");
+    let prompted = false;
+    const result = await runSetPasswordCommand(
+      {
+        home: paseoHome,
+        password: "flag-secret",
+        promptPassword: async () => {
+          prompted = true;
+          return "should-not-run";
+        },
+      },
+      {} as Command,
+    );
+    const config = JSON.parse(await readFile(join(paseoHome, "config.json"), "utf-8"));
+
+    assert.strictEqual(prompted, false);
+    assert.strictEqual(result.data.action, "password_set");
+    assert.strictEqual(
+      isBearerTokenValid({ password: config.daemon.auth.password, token: "flag-secret" }),
+      true,
+    );
+    console.log("✓ --password skips prompts\n");
+  }
+
+  {
+    console.log("Test 5: PASEO_SET_PASSWORD env skips prompts");
+    let prompted = false;
+    const result = await runSetPasswordCommand(
+      {
+        home: paseoHome,
+        env: { PASEO_SET_PASSWORD: "env-secret" },
+        promptPassword: async () => {
+          prompted = true;
+          return "should-not-run";
+        },
+      },
+      {} as Command,
+    );
+    const config = JSON.parse(await readFile(join(paseoHome, "config.json"), "utf-8"));
+
+    assert.strictEqual(prompted, false);
+    assert.strictEqual(result.data.action, "password_set");
+    assert.strictEqual(
+      isBearerTokenValid({ password: config.daemon.auth.password, token: "env-secret" }),
+      true,
+    );
+    console.log("✓ PASEO_SET_PASSWORD skips prompts\n");
+  }
+
+  {
+    console.log("Test 6: empty --password is rejected");
+    await assert.rejects(
+      runSetPasswordCommand(
+        {
+          home: paseoHome,
+          password: "",
+        },
+        {} as Command,
+      ),
+      (error: unknown) =>
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "PASSWORD_REQUIRED",
+    );
+    console.log("✓ empty --password rejected\n");
+  }
+
+  {
+    console.log("Test 7: non-interactive terminal without password fails clearly");
+    await assert.rejects(
+      runSetPasswordCommand(
+        {
+          home: paseoHome,
+          process: {
+            platform: "linux",
+            versions: {} as NodeJS.ProcessVersions,
+            env: {},
+            execPath: "/usr/bin/node",
+            stdin: { isTTY: false },
+            stdout: { isTTY: false },
+          },
+        },
+        {} as Command,
+      ),
+      (error: unknown) => {
+        if (typeof error !== "object" || error === null || !("code" in error)) {
+          return false;
+        }
+        const commandError = error as { code: string; details?: string };
+        return (
+          commandError.code === "PASSWORD_PROMPT_UNAVAILABLE" &&
+          typeof commandError.details === "string" &&
+          commandError.details.includes("--password") &&
+          commandError.details.includes("npx -y @getpaseo/cli daemon set-password") &&
+          commandError.details.includes(PASSWORD_ALTERNATES_DETAILS.split("\n")[0]!)
+        );
+      },
+    );
+    console.log("✓ non-interactive failure points to --password / npx\n");
+  }
+
+  {
+    console.log("Test 8: Windows Electron path uses console bridge, not injected clack path");
+    let windowsPrompts = 0;
+    const result = await runSetPasswordCommand(
+      {
+        home: paseoHome,
+        process: {
+          platform: "win32",
+          versions: { electron: "39.0.0" } as NodeJS.ProcessVersions,
+          env: { ELECTRON_RUN_AS_NODE: "1" },
+          execPath: "C:\\Users\\chenx\\AppData\\Local\\Programs\\Paseo\\Paseo.exe",
+          stdin: { isTTY: true },
+          stdout: { isTTY: true },
+        },
+        promptWindowsConsole: async () => {
+          windowsPrompts += 1;
+          return "bridge-secret";
+        },
+      },
+      {} as Command,
+    );
+    const config = JSON.parse(await readFile(join(paseoHome, "config.json"), "utf-8"));
+
+    assert.strictEqual(windowsPrompts, 2);
+    assert.strictEqual(result.data.action, "password_set");
+    assert.strictEqual(
+      isBearerTokenValid({ password: config.daemon.auth.password, token: "bridge-secret" }),
+      true,
+    );
+    console.log("✓ Windows Electron uses console bridge\n");
+  }
+
+  {
+    console.log("Test 9: Windows Electron bridge failure surfaces actionable error");
+    await assert.rejects(
+      runSetPasswordCommand(
+        {
+          home: paseoHome,
+          process: {
+            platform: "win32",
+            versions: { electron: "39.0.0" } as NodeJS.ProcessVersions,
+            env: { ELECTRON_RUN_AS_NODE: "1" },
+            execPath: "C:\\Program Files\\Paseo\\Paseo.exe",
+            stdin: { isTTY: true },
+            stdout: { isTTY: true },
+          },
+          promptWindowsConsole: async () => {
+            throw new Error("spawn powershell.exe ENOENT");
+          },
+        },
+        {} as Command,
+      ),
+      (error: unknown) => {
+        if (typeof error !== "object" || error === null || !("code" in error)) {
+          return false;
+        }
+        const commandError = error as { code: string; details?: string; message?: string };
+        return (
+          commandError.code === "PASSWORD_PROMPT_UNAVAILABLE" &&
+          typeof commandError.details === "string" &&
+          commandError.details.includes("spawn powershell.exe ENOENT") &&
+          commandError.details.includes("paseo daemon set-password --password")
+        );
+      },
+    );
+    console.log("✓ bridge failure includes --password / npx guidance\n");
+  }
+
+  {
+    console.log("Test 10: isWindowsElectronRunAsNode detection");
+    assert.strictEqual(
+      isWindowsElectronRunAsNode({
+        platform: "win32",
+        versions: { electron: "39.0.0" } as NodeJS.ProcessVersions,
+        env: {},
+        execPath: "C:\\Program Files\\Paseo\\Paseo.exe",
+      }),
+      true,
+    );
+    assert.strictEqual(
+      isWindowsElectronRunAsNode({
+        platform: "win32",
+        versions: {} as NodeJS.ProcessVersions,
+        env: { ELECTRON_RUN_AS_NODE: "1" },
+        execPath: "C:\\Program Files\\Paseo\\Paseo.exe",
+      }),
+      true,
+    );
+    assert.strictEqual(
+      isWindowsElectronRunAsNode({
+        platform: "win32",
+        versions: {} as NodeJS.ProcessVersions,
+        env: { ELECTRON_RUN_AS_NODE: "1" },
+        execPath: "C:\\Program Files\\nodejs\\node.exe",
+      }),
+      false,
+    );
+    assert.strictEqual(
+      isWindowsElectronRunAsNode({
+        platform: "linux",
+        versions: { electron: "39.0.0" } as NodeJS.ProcessVersions,
+        env: { ELECTRON_RUN_AS_NODE: "1" },
+        execPath: "/opt/Paseo/paseo",
+      }),
+      false,
+    );
+    assert.strictEqual(
+      isInteractiveTerminal({
+        stdin: { isTTY: true },
+        stdout: { isTTY: true },
+      }),
+      true,
+    );
+    assert.strictEqual(
+      isInteractiveTerminal({
+        stdin: { isTTY: false },
+        stdout: { isTTY: true },
+      }),
+      false,
+    );
+    console.log("✓ Electron/TTY detection helpers\n");
+  }
+
+  {
+    console.log("Test 11: promptPasswordViaWindowsConsole builds PowerShell spawn");
+    let captured: { command: string; args: readonly string[]; options: unknown } | undefined;
+    const spawnImpl: SpawnFn = ((command, args, options) => {
+      captured = { command, args, options };
+      return createFakeChild("bridged-password\n") as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    const value = await promptPasswordViaWindowsConsole("New daemon password", spawnImpl);
+    assert.strictEqual(value, "bridged-password");
+    assert.ok(captured);
+    assert.strictEqual(captured.command, "powershell.exe");
+    assert.deepStrictEqual(captured.args.slice(0, 2), ["-NoProfile", "-Command"]);
+    assert.match(String(captured.args[2]), /Read-Host/);
+    assert.match(String(captured.args[2]), /AsSecureString/);
+    const options = captured.options as {
+      env?: NodeJS.ProcessEnv;
+      stdio?: unknown;
+      windowsHide?: boolean;
+    };
+    assert.strictEqual(options.env?.PASEO_PASSWORD_PROMPT, "New daemon password");
+    assert.deepStrictEqual(options.stdio, ["inherit", "pipe", "inherit"]);
+    assert.strictEqual(options.windowsHide, false);
+    console.log("✓ Windows console spawn argv/env\n");
   }
 } finally {
   await rm(root, { recursive: true, force: true });

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -146,6 +146,14 @@ paseo daemon set-password
 
 This prompts for a password, writes the bcrypt hash to `config.json`, and tells you to restart the daemon.
 
+On Windows, the desktop-bundled CLI (`paseo.cmd`) runs under Electron and cannot always read interactive stdin. Prefer a non-interactive form, or use the standalone npm CLI:
+
+```bash
+paseo daemon set-password --password my-secret
+PASEO_SET_PASSWORD=my-secret paseo daemon set-password
+npx -y @getpaseo/cli daemon set-password
+```
+
 Alternatively, set the `PASEO_PASSWORD` environment variable (plaintext, hashed automatically at startup):
 
 ```bash


### PR DESCRIPTION
## Summary
- Detect Windows Electron-as-Node and prompt via a console PowerShell bridge instead of broken `@clack` stdin.
- Add `--password` / `PASEO_SET_PASSWORD` and a clear actionable error when interactive input is unavailable (`npx` alternate documented).

Fixes #2291

## Test plan
- [x] `./node_modules/.bin/tsx packages/cli/tests/32-daemon-set-password.test.ts`
- [x] typecheck + lint
- [ ] Manual on Windows packaged `paseo.cmd daemon set-password` (interactive and `--password`)


Made with [Cursor](https://cursor.com)