### PR TITLE
Show project-local Codex skills in Paseo

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -271,14 +271,19 @@ async function listCommandsFromFakeCodex(skills: unknown[]): Promise<AgentSlashC
     `
 let buffer = "";
 
-function resultFor(method) {
+function resultFor(method, params) {
   if (method === "initialize") return {};
   if (method === "collaborationMode/list") return { data: [] };
   if (method === "skills/list") {
+    const cwds = params && params.cwds;
+    const projectCwd = "/tmp/codex-question-test";
+    if (!Array.isArray(cwds) || cwds.length !== 1 || cwds[0] !== projectCwd) {
+      return { data: [] };
+    }
     return {
       data: [
         {
-          cwd: "/tmp/codex-question-test",
+          cwd: projectCwd,
           skills: ${JSON.stringify(skills)},
           errors: [],
         },
@@ -299,7 +304,7 @@ process.stdin.on("data", (chunk) => {
     const message = JSON.parse(line);
     if (typeof message.id !== "number") continue;
     try {
-      process.stdout.write(JSON.stringify({ id: message.id, result: resultFor(message.method) }) + "\\n");
+      process.stdout.write(JSON.stringify({ id: message.id, result: resultFor(message.method, message.params) }) + "\\n");
     } catch (error) {
       process.stdout.write(JSON.stringify({ id: message.id, error: { message: error.message } }) + "\\n");
     }
@@ -1496,6 +1501,23 @@ describe("Codex app-server provider", () => {
         ],
       }),
     );
+  });
+
+  test("lists project skill commands when app-server receives the project cwd in cwds", async () => {
+    const commands = await listCommandsFromFakeCodex([
+      {
+        name: "project-skill-discovery-regression",
+        description: "A skill discovered from this project.",
+        path: "/tmp/codex-question-test/.agents/skills/project-skill-discovery-regression/SKILL.md",
+      },
+    ]);
+
+    expect(commands).toContainEqual({
+      name: "project-skill-discovery-regression",
+      description: "A skill discovered from this project.",
+      argumentHint: "",
+      kind: "skill",
+    });
   });
 
   test("deduplicates Codex skill slash commands returned from multiple skill roots", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3306,7 +3306,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     try {
       const response = toObjectRecord(
         await this.client.request("skills/list", {
-          cwd: [this.config.cwd],
+          cwds: [this.config.cwd],
         }),
       );
       const entries = Array.isArray(response?.data) ? response.data : [];


### PR DESCRIPTION
### Linked issue

Closes #2325.

Related to #401.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo currently calls Codex app-server's `skills/list` method with a singular `cwd` field containing an array. Current Codex versions expect `cwds`, so the unknown field is ignored and skill discovery falls back to the app-server process directory. As a result, project-local skills can be missing while global skills still appear.

This changes the request to `cwds: [this.config.cwd]` and adds a regression test whose fake app-server only returns the project skill when it receives that exact request shape. The change is server-only and intentionally does not add a second filesystem fallback path.

### How did you verify it

I reproduced the request behavior directly with `codex-cli 0.144.6`:

- `skills/list` with `cwd: [projectCwd]` returned the app-server process cwd (`/home/yangfei`) and omitted the project's `release-beta` and `release-stable` skills.
- `skills/list` with `cwds: [projectCwd]` returned the requested workspace and included both project-local skills.
- The generated `SkillsListParams` schema lists `cwds?: string[]` and `forceReload?: boolean`.

Regression verification:

```bash
npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts \
  -t 'lists project skill commands when app-server receives the project cwd in cwds' \
  --bail=1
```

Result: 1 passed. Temporarily changing the implementation back to `cwd` made this test fail as expected.

Provider test file:

```bash
npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1
```

Result: 109 passed.

Also ran successfully:

```bash
npm run format
npm run typecheck
npm run lint
```

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI screenshots or video are not applicable (server-only change)
- [x] Tests added or updated where it made sense
