### PR TITLE
test(cli): include Opus 5 in provider expectations

### DIFF
--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -46,6 +46,11 @@ interface ProviderListRow {
 
 const EXPECTED_CLAUDE_MODELS = [
   {
+    id: "claude-opus-5",
+    model: "Opus 5",
+    descriptionFragment: "Latest release",
+  },
+  {
     id: "claude-fable-5",
     model: "Fable 5",
     descriptionFragment: "Most powerful",
@@ -58,7 +63,7 @@ const EXPECTED_CLAUDE_MODELS = [
   {
     id: "claude-opus-4-8",
     model: "Opus 4.8",
-    descriptionFragment: "Latest release",
+    descriptionFragment: "Previous release",
   },
   {
     id: "claude-sonnet-5",


### PR DESCRIPTION
### Linked issue

Closes #2424.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The Claude model manifest now contains 12 entries after Opus 5 was added, but the CLI provider integration test still expected 11. That made `cli-tests (shard 2/3)` fail deterministically before it could verify the remaining provider commands.

This updates the CLI expectations to:

- include `claude-opus-5` as the latest release
- describe `claude-opus-4-8` as the previous release

The change is limited to the stale provider-test expectations.

### How did you verify it

Before the change, I built the server stack and ran `packages/cli/tests/15-provider.test.ts`. The Claude assertion failed with:

```text
AssertionError: claude output should match the current catalog size
12 !== 11
```

After the change, I ran the same provider test with the CI-pinned Codex CLI (`@openai/codex@0.105.0`), OpenCode, and an isolated `CODEX_HOME`. All 11 provider command tests passed, including the Claude catalog assertion.

I also ran:

```bash
npm run build:server
npm run format
npm run typecheck
npm run lint
```

Lint completed with 0 warnings and 0 errors.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; test-only change)
- [x] Tests added or updated where it made sense
