### PR TITLE
feat(app): always show assistant turn timestamp

### DIFF
--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -580,30 +580,19 @@ const assistantTurnFooterStylesheet = StyleSheet.create((theme) => ({
     marginTop: 0,
     marginLeft: -theme.spacing[1],
   },
-  labelWrapper: {
-    position: "relative",
-  },
-  labelSizer: {
+  metaText: {
     color: theme.colors.foregroundMuted,
     fontSize: STREAM_METADATA_FONT_SIZE,
-    opacity: 0,
-  },
-  labelOverlay: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    color: theme.colors.foregroundMuted,
-    fontSize: STREAM_METADATA_FONT_SIZE,
+    // Wrap rather than overflow the footer row on narrow layouts, where
+    // "Worked for 1m 12s · 12 Mar 2026, 14:32" doesn't fit on one line.
+    flexShrink: 1,
   },
 }));
 
-const TIMESTAMP_REVEAL_MS = 3000;
-
 /**
  * Footer rendered next to the copy button at the end of an assistant turn.
- * Always shows the turn duration; swaps to the end timestamp on hover (web)
- * or tap (native). The hidden sizer keeps the label width stable while the
- * visible text swaps.
+ * Shows the turn duration and the end timestamp together, both always
+ * visible — no hover or tap needed to reveal either.
  */
 export const AssistantTurnFooter = memo(function AssistantTurnFooter({
   getContent,
@@ -611,19 +600,6 @@ export const AssistantTurnFooter = memo(function AssistantTurnFooter({
   durationMs,
   onFork,
 }: AssistantTurnFooterProps) {
-  const [hovered, setHovered] = useState(false);
-  const [pressedReveal, setPressedReveal] = useState(false);
-  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (revealTimerRef.current) {
-        clearTimeout(revealTimerRef.current);
-        revealTimerRef.current = null;
-      }
-    };
-  }, []);
-
   const durationLabel = useMemo(
     () => (durationMs !== undefined ? `Worked for ${formatDuration(durationMs)}` : ""),
     [durationMs],
@@ -633,22 +609,13 @@ export const AssistantTurnFooter = memo(function AssistantTurnFooter({
     [completedAt],
   );
 
-  const canSwap = Boolean(timestampLabel);
-  const showTimestamp = canSwap && (isWeb ? hovered : pressedReveal);
+  // A turn can be missing either half: no duration while it is still
+  // streaming, no timestamp until it completes.
+  const metaLabel = useMemo(
+    () => [durationLabel, timestampLabel].filter(Boolean).join(" · "),
+    [durationLabel, timestampLabel],
+  );
 
-  const handleHoverIn = useCallback(() => setHovered(true), []);
-  const handleHoverOut = useCallback(() => setHovered(false), []);
-  const handlePress = useCallback(() => {
-    if (isWeb || !canSwap) return;
-    if (revealTimerRef.current) {
-      clearTimeout(revealTimerRef.current);
-    }
-    setPressedReveal((prev) => !prev);
-    revealTimerRef.current = setTimeout(() => {
-      setPressedReveal(false);
-      revealTimerRef.current = null;
-    }, TIMESTAMP_REVEAL_MS);
-  }, [canSwap]);
   const handleFork = useCallback(
     (target: AssistantForkTarget) => {
       return onFork?.(target);
@@ -664,26 +631,7 @@ export const AssistantTurnFooter = memo(function AssistantTurnFooter({
         containerStyle={assistantTurnFooterStylesheet.copyButton}
       />
       {canFork ? <AssistantForkMenu onFork={handleFork} /> : null}
-      {durationLabel ? (
-        <Pressable
-          onPress={handlePress}
-          onHoverIn={handleHoverIn}
-          onHoverOut={handleHoverOut}
-          accessibilityRole={canSwap ? "button" : undefined}
-          accessibilityLabel={canSwap ? `${durationLabel}, ended ${timestampLabel}` : durationLabel}
-        >
-          <View style={assistantTurnFooterStylesheet.labelWrapper}>
-            {/* Sizer reserves space for whichever label is longer so the
-                container width is stable across hover transitions. */}
-            <Text style={assistantTurnFooterStylesheet.labelSizer} aria-hidden>
-              {durationLabel.length >= timestampLabel.length ? durationLabel : timestampLabel}
-            </Text>
-            <Text style={assistantTurnFooterStylesheet.labelOverlay}>
-              {showTimestamp ? timestampLabel : durationLabel}
-            </Text>
-          </View>
-        </Pressable>
-      ) : null}
+      {metaLabel ? <Text style={assistantTurnFooterStylesheet.metaText}>{metaLabel}</Text> : null}
     </View>
   );
 });


### PR DESCRIPTION
### Linked issue

<!-- No prior issue; small self-contained UI behaviour change. -->

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The assistant turn footer always showed `Worked for 12s` and swapped it for the end timestamp on hover (web) or a 3-second tap reveal (native). The two were never visible together, so on desktop you had to park the pointer on the label to find out when a turn finished — and doing so took the duration away.

Both halves are now shown together as one label, and hover does nothing:

```
Worked for 10s - 11:22 PM
```

Because nothing changes width any more, this also deletes the hover state, the press-reveal state, the 3s reveal timer and its cleanup effect, and the hidden sizer `<Text>` + absolutely-positioned overlay that existed purely to keep the label width stable across the swap. The wrapping `Pressable` and its `accessibilityRole="button"` / "..., ended <time>" label go too: with nothing to reveal, the footer is plain text. Net -52 lines.

Two details worth calling out:

- The halves are joined with a filter, so a turn missing either one still renders: no duration while streaming, no timestamp until the turn completes.
- `metaText` gets `flexShrink: 1` so the longest form (`Worked for 1m 12s - 12 Mar 2026, 14:32`) wraps instead of overflowing the footer row on narrow layouts. `formatMessageTimestamp` is unchanged and already adapts: `14:32` today, `Wednesday 14:32` this week, `12 Mar 2026, 14:32` older.

### How did you verify it

Windows 11, desktop Chrome at 1280x720, driving the repo's own Playwright e2e harness against a seeded mock agent (`ten-second-stream`) and capturing the footer with and without hover on both `upstream/main` and this branch.

| | before (`main`) | after (this PR) |
| --- | --- | --- |
| default | `Worked for 10s` | `Worked for 10s - 11:22 PM` |
| hovered | `6:44 PM` (duration disappears) | identical to default |

The hover and no-hover captures on this branch are byte-for-byte identical - that is the evidence that the swap is gone, not a capture artifact.

<img width="1280" height="720" alt="assistant-full-no-hover" src="https://github.com/user-attachments/assets/030e3338-3e3b-47a3-99ee-1e6c2b301551" />

((Unhovered Image)



Note: on Windows the e2e harness cannot start without #2212 (`test(e2e): make Playwright global-setup start on Windows`), which is still open. I ran against that branch's `global-setup.ts` locally.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform - web/desktop (Windows) only;
- [ ] Tests added or updated where it made sense - net deletion of UI state with no new logic; `message.tsx` has no component-test harness and its import graph would need mocking wholesale

🤖 Generated with [Claude Code](https://claude.com/claude-code)
