### PR TITLE
feat(app): always show user message timestamp and actions

### DIFF
--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -388,12 +388,6 @@ const userMessageStylesheet = StyleSheet.create((theme) => ({
     gap: theme.spacing[2],
     marginTop: theme.spacing[2],
   },
-  trailingRowHidden: {
-    opacity: 0,
-  },
-  trailingRowVisible: {
-    opacity: 1,
-  },
   timestampText: {
     color: theme.colors.foregroundMuted,
     fontSize: STREAM_METADATA_FONT_SIZE,
@@ -431,24 +425,19 @@ export const UserMessage = memo(function UserMessage({
   isLastInGroup = true,
   disableOuterSpacing,
 }: UserMessageProps) {
-  const isCompact = useIsCompactFormFactor();
   const { t } = useTranslation();
-  const [isHovered, setIsHovered] = useState(false);
   const [lightboxMetadata, setLightboxMetadata] = useState<UserMessageImageAttachment | null>(null);
   const handleLightboxClose = useCallback(() => setLightboxMetadata(null), []);
   const resolvedDisableOuterSpacing = useDisableOuterSpacing(disableOuterSpacing);
   const hasText = message.trim().length > 0;
   const hasImages = images.length > 0;
   const hasAttachments = attachments.length > 0;
-  const showTrailingRow = hasText && (isCompact || isNative || isHovered);
   const formattedTimestamp = useMemo(
     () => formatMessageTimestamp(new Date(timestamp)),
     [timestamp],
   );
   const rewindMutation = useRewindAgentMutation({ serverId, agentId, client, messageId });
 
-  const handlePointerEnter = useCallback(() => setIsHovered(true), []);
-  const handlePointerLeave = useCallback(() => setIsHovered(false), []);
   const getMessageContent = useCallback(() => message, [message]);
   const handleRewind = useCallback(
     (input: { mode: RewindMode; rewoundText: string }) => {
@@ -482,23 +471,9 @@ export const UserMessage = memo(function UserMessage({
     ],
     [hasText],
   );
-  const trailingRowStyle = useMemo(
-    () => [
-      userMessageStylesheet.trailingRow,
-      showTrailingRow
-        ? userMessageStylesheet.trailingRowVisible
-        : userMessageStylesheet.trailingRowHidden,
-    ],
-    [showTrailingRow],
-  );
-
   return (
     <View style={containerStyle} testID="user-message">
-      <View
-        style={userMessageStylesheet.content}
-        onPointerEnter={handlePointerEnter}
-        onPointerLeave={handlePointerLeave}
-      >
+      <View style={userMessageStylesheet.content}>
         <View style={userMessageStylesheet.bubble}>
           {hasImages ? (
             <View style={imagePreviewContainerStyle}>
@@ -537,7 +512,7 @@ export const UserMessage = memo(function UserMessage({
           ) : null}
         </View>
         {hasText ? (
-          <View style={trailingRowStyle} pointerEvents={showTrailingRow ? "auto" : "none"}>
+          <View style={userMessageStylesheet.trailingRow}>
             <Text style={userMessageStylesheet.timestampText}>{formattedTimestamp}</Text>
             {capabilities ? (
               <RewindMenu


### PR DESCRIPTION
### Linked issue

<!-- No prior issue; small self-contained UI behaviour change. -->

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The timestamp on your own messages shared a hover-gated row with the rewind menu and the copy button, so on a wide web/desktop layout none of them appeared until the pointer was over the message.

The row now renders unconditionally - timestamp and both actions together. 

The gate was `hasText && (isCompact || isNative || isHovered)`. `isNative` is iOS/Android only and `isCompact` is a width breakpoint, so on a maximised desktop window (Electron included) neither applies and only `isHovered` could reveal the row.

Revealing the timestamp but keeping the actions on hover was the first attempt, and it looked wrong: the timestamp floated alone against the right edge with an empty gap beside it where the buttons would later appear. Showing the whole row is both better balanced and simpler.

With nothing left to reveal, this removes the `isHovered` state, both pointer handlers, the `opacity`/`pointerEvents` toggle and the `trailingRowHidden`/`trailingRowVisible` styles - a pure deletion (+2/-27). No hover machinery is left behind to imply hover still matters, which `docs/hover.md` warns against.

No behaviour change on native or compact layouts: they already showed the whole row via the `isNative`/`isCompact` fallback.

Blast radius is confined to `UserMessage`. `userMessageStylesheet` is module-local to `message.tsx`, and the only renderer of the component is `agent-stream/view.tsx`; other `UserMessage` matches in the app are type/store references. `isNative` and `useIsCompactFormFactor` both retain other consumers in the file, so no imports are orphaned.

### How did you verify it

Windows 11, desktop Chrome at 1280x720, driving the repo's own Playwright e2e harness against a seeded mock agent and capturing the user bubble with and without hover, on both `upstream/main` and this branch.

| | before (`main`) | after (this PR) |
| --- | --- | --- |
| default | blank strip under the bubble | `11:51 PM` + rewind + copy |
| hovered | `6:44 PM` + rewind + copy | identical to default |

Before, the row was in the DOM but invisible: the element's text content read `Show me the message timestamps.6:44 PM` while rendering blank at `opacity: 0`. After, the hover and no-hover captures are byte-for-byte identical - that is the evidence the gate is gone.

Density and clutter is a potential risk but inspecting the UI with times / actions enabled doesn't look cluttered IMO.



<img width="1280" height="720" alt="assistant-full-no-hover" src="https://github.com/user-attachments/assets/11640435-fb3d-4587-b5ad-d3f2f0c5c8f4" />



Note: on Windows the e2e harness cannot start without #2212 (`test(e2e): make Playwright global-setup start on Windows`), which is still open. I ran against that branch's `global-setup.ts` locally.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x ] UI changes include screenshots or video for every affected platform - web/desktop (Windows 11)only; native not exercised
- [ ] Tests added or updated where it made sense - pure deletion of UI state with no new logic; `message.tsx` has no component-test harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
