### PR TITLE
fix(dev): make worktree setup run on Windows

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -242,6 +242,14 @@ commands use the same non-login Bash behavior on macOS/Linux, but preserve their
 existing `cmd.exe /c` string semantics on Windows. Service scripts are separate:
 they launch in a terminal and receive the service environment described below.
 
+Because the shell differs per platform, a lifecycle command that must run
+everywhere cannot use POSIX-only syntax — `VAR=1 cmd` env prefixes, `$VAR`
+expansion, `cp`/`rm`, or a `./scripts/*.sh` entrypoint all fail under PowerShell,
+and `bash` is not guaranteed to exist on Windows. Put that logic in a Node script
+that reads what it needs from `process.env` and invoke it as
+`node ./scripts/<name>.mjs`. This repo's own setup does exactly that in
+`scripts/seed-worktree-dev-state.mjs` and `scripts/seed-ios-native-cache.mjs`.
+
 ```json
 {
   "worktree": {

--- a/paseo.json
+++ b/paseo.json
@@ -3,10 +3,9 @@
     "setup": [
       "npm ci",
       "node ./scripts/seed-ios-native-cache.mjs",
-      "PASEO_DEV_MANAGED_HOME=1 PASEO_DEV_SEED_HOME=\"$PASEO_SOURCE_CHECKOUT_PATH/.dev/paseo-home\" PASEO_HOME=\"$PWD/.dev/paseo-home\" ./scripts/dev-home.sh",
+      "node ./scripts/seed-worktree-dev-state.mjs",
       "npm run build:server",
-      "npm run build --workspace=@getpaseo/expo-two-way-audio",
-      "cp \"$PASEO_SOURCE_CHECKOUT_PATH/packages/server/.env\" \"$PWD/packages/server/.env\""
+      "npm run build --workspace=@getpaseo/expo-two-way-audio"
     ]
   },
   "scripts": {

--- a/scripts/seed-worktree-dev-state.mjs
+++ b/scripts/seed-worktree-dev-state.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// Worktree setup runs through a stable script shell: bash on macOS/Linux, but PowerShell
+// on Windows. POSIX-only command strings (`VAR=1 cmd` env prefixes, `$VAR` expansion, `cp`,
+// `./scripts/*.sh`) cannot express this step portably, so the seeding lives in Node — the
+// one interpreter every Paseo checkout already depends on.
+
+const sourceRoot = process.env.PASEO_SOURCE_CHECKOUT_PATH;
+const targetRoot = process.env.PASEO_WORKTREE_PATH || process.cwd();
+
+if (!sourceRoot || sourceRoot === targetRoot) {
+  process.exit(0);
+}
+
+seedPaseoHome();
+copyServerEnv();
+
+function seedPaseoHome() {
+  const source = process.env.PASEO_DEV_SEED_HOME || join(sourceRoot, ".dev/paseo-home");
+  const target = join(targetRoot, ".dev/paseo-home");
+
+  if (!existsSync(source)) {
+    console.log(`  Seed:    skipped (${source} missing)`);
+    return;
+  }
+
+  if (source === target) {
+    console.log("  Seed:    skipped (source is target)");
+    return;
+  }
+
+  if (process.env.PASEO_DEV_RESET_HOME === "1") {
+    rmSync(target, { recursive: true, force: true });
+  } else if (hasEntries(target)) {
+    console.log(`  Seed:    skipped (${target} already has data)`);
+    return;
+  }
+
+  mkdirSync(target, { recursive: true });
+  console.log(`  Seed:    copying metadata from ${source}`);
+  copyJsonTree(join(source, "agents"), join(target, "agents"));
+  copyJsonTree(join(source, "projects"), join(target, "projects"));
+
+  const config = join(source, "config.json");
+  if (existsSync(config)) {
+    cpSync(config, join(target, "config.json"));
+  }
+
+  console.log(`  Seed:    copied metadata from ${source}`);
+}
+
+// Durable JSON metadata only. Runtime files (pid files, sockets, logs) must not be copied.
+function copyJsonTree(source, target) {
+  if (!existsSync(source)) {
+    return;
+  }
+
+  cpSync(source, target, {
+    recursive: true,
+    filter: (path) => isDirectory(path) || path.endsWith(".json"),
+  });
+}
+
+function copyServerEnv() {
+  const source = join(sourceRoot, "packages/server/.env");
+  const target = join(targetRoot, "packages/server/.env");
+
+  // Untracked local config. A checkout without one is normal, so this is not a setup failure.
+  if (!existsSync(source)) {
+    console.log(`  Env:     skipped (${source} missing)`);
+    return;
+  }
+
+  mkdirSync(dirname(target), { recursive: true });
+  cpSync(source, target);
+  console.log(`  Env:     copied ${source}`);
+}
+
+function hasEntries(path) {
+  try {
+    return readdirSync(path).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
### Linked issue

Closes #2430

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Creating a Paseo-managed worktree of this repo on Windows failed at `worktree.setup` step 3:

```
PASEO_DEV_MANAGED_HOME=1 : The term 'PASEO_DEV_MANAGED_HOME=1' is not recognized as the name of a
cmdlet, function, script file, or operable program.
```

Lifecycle commands run through `bash` on macOS/Linux but **PowerShell** on Windows, and PowerShell has no `VAR=value cmd` env-prefix syntax. Two entries in this repo's own `paseo.json` were POSIX-only:

- **`paseo.json:6`** — env prefixes, plus `./scripts/dev-home.sh` needs bash to run at all.
- **`paseo.json:9`** — `cp "$PASEO_SOURCE_CHECKOUT_PATH/packages/server/.env" ...`. In PowerShell that `$VAR` is an undefined *PowerShell* variable rather than an env var, so it expanded to empty and the copy resolved to `/packages/server/.env`. Already broken, just masked by the earlier failure.

Neither can be expressed portably in a single shell string, and `bash -c` isn't a general answer — Git Bash isn't guaranteed installed on Windows, and Paseo's own Windows terminal is cmd. So both steps move into one Node script that reads its inputs from `process.env`. Node is the only interpreter every Paseo checkout already depends on, and this matches the existing `node ./scripts/seed-ios-native-cache.mjs` entry one line above. One code path for every platform, no platform branching, two fewer setup entries.

`scripts/dev-home.sh` is **unchanged** and still sourced by `dev-daemon.sh`, `dev-app.sh`, `packages/desktop/scripts/dev.sh`, and the `cli` npm script. Only the setup-time seeding is ported: at setup time `PASEO_LISTEN` is unset, so `configure_dev_daemon_config` was already a no-op and the script's only effect was seeding. The port preserves the `PASEO_DEV_SEED_HOME` override, the `PASEO_DEV_RESET_HOME=1` reset, the "already has data" skip, and copying durable `*.json` metadata only — no pid files, sockets, or logs.

**One intentional behavior change:** a missing `packages/server/.env` in the source checkout is now skipped with a log instead of aborting setup. It's untracked local config, and the old `cp` hard-failed worktree creation for anyone without one — including on macOS.

### How did you verify it

**Reproduced the bug first.** Creating a worktree of this repo on Windows 11 failed with the `CommandNotFoundException` above, aborting setup at step 3 and rolling the worktree back.

**After the change**, ran the setup entry on Windows 11 in both shells Paseo can use — PowerShell (the lifecycle shell) and `cmd.exe` — against a real seed home at `<checkout>/.dev/paseo-home`:

```
> node ./scripts/seed-worktree-dev-state.mjs
  Seed:    copying metadata from ...\happy-bell\.dev\paseo-home
  Seed:    copied metadata from ...\happy-bell\.dev\paseo-home
  Env:     skipped (...\happy-bell\packages\server\.env missing)
exit=0
```

Then checked what actually landed:

- **Only `agents/`, `projects/`, `config.json` copied — 0 non-JSON files.** Verified by counting: the source home contains `daemon.log`, `daemon.log.txt`, `paseo.pid`, `cli-client-id`, `daemon-keypair.json`, `server-id`, and `runtime/`, `chats/`, `loops/`, `schedules/` directories. Target ended up with 9 files, all `.json`, no runtime state — matching the old `rsync --include='*.json' --exclude='*'` behavior.
- **Idempotent:** second run reports `Seed: skipped (... already has data)` and makes no changes. Third run via `cmd /c` same result, exit 0.
- **`.env` skip path exercised:** my source checkout genuinely has no `packages/server/.env`, which is why that line reads `skipped` above — i.e. this is the case where the old `cp` would have aborted setup.

**Not run:** the full test suite, and `npm run typecheck`. This PR changes `paseo.json`, one new `.mjs` script, and a docs paragraph — no TypeScript and no server code, so typecheck output is unaffected by the diff. Flagging rather than ticking the box.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes — not run; no TypeScript in this diff (see above)
- [x] `npm run lint` passes — `oxlint` on the new script: 0 warnings, 0 errors
- [x] `npm run format` ran — `npm run format:files` (oxfmt) on all three changed files
- [x] UI changes include screenshots or video for every affected platform — n/a, no UI
- [ ] Tests added or updated where it made sense — see note below

On tests: the repo has no existing coverage for `paseo.json`'s own setup entries, and the ported logic is a dev-environment seeding script rather than shipped code. Happy to add a unit test around the JSON-only copy filter if you'd like one.

### Related, not covered here

The `scripts` service entries in the same `paseo.json` (`daemon`, `app`, `desktop`, `ios-simulator`) use the same POSIX env-prefix syntax and will hit the same wall on Windows. Left out to keep this PR to one focused change; noted in #2430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)