### PR TITLE
add optional aggregation of gh/glab/tea binaries

### DIFF
--- a/.github/workflows/update-forge-cli-versions.yml
+++ b/.github/workflows/update-forge-cli-versions.yml
@@ -1,0 +1,41 @@
+name: Update Forge CLI Versions
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.PASEO_BOT_APP_ID }}
+          private-key: ${{ secrets.PASEO_BOT_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Check for forge CLI version updates
+        run: node scripts/update-forge-cli-versions.mjs
+
+      - name: Commit version/checksum updates
+        run: |
+          git diff --quiet packages/server/src/services/forge-cli/forge-cli-versions.json && exit 0
+          git config user.name "paseo-ai[bot]"
+          git config user.email "266920839+paseo-ai[bot]@users.noreply.github.com"
+          git add packages/server/src/services/forge-cli/forge-cli-versions.json
+          git commit -m "chore: bump forge cli versions [skip ci]"
+          git push

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -111,6 +111,39 @@ Provider environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 `OPENAI_BASE_URL`, or `ANTHROPIC_BASE_URL` can be passed through `docker run -e`
 or `compose.environment`; Paseo passes them to launched agents.
 
+## Git Forge CLIs
+
+The base image also leaves out the git forge CLIs (`gh` for GitHub, `glab` for
+GitLab, `tea` for the Gitea/Forgejo/Codeberg family) for the same reason it
+leaves out agent CLIs. Forge features (PR/MR status, create, merge, CI checks)
+need one of these installed.
+
+By default the daemon downloads the official release binary itself the first
+time a forge feature needs it, over HTTPS from the CLI's own release host
+(`github.com`, `gitlab.com`, `dl.gitea.com`). This is a container-only
+feature: it only runs on `linux/amd64` and `linux/arm64`, matching the image.
+The binary is cached at `$PASEO_HOME/tools/<cli>/<cli>` (inside the
+`/home/paseo` volume), so it persists across restarts and downloads only
+once. A CLI already on `PATH` (installed in a child image, or mounted from
+the host) always wins over auto-install.
+
+Disable auto-install entirely with:
+
+```yaml
+environment:
+  PASEO_FORGE_CLI_AUTOINSTALL: "0"
+```
+
+For air-gapped or otherwise offline deployments, install the CLI in a child
+image instead (same pattern as [Installing Agents](#installing-agents) above):
+
+```Dockerfile
+FROM ghcr.io/getpaseo/paseo:latest
+
+USER root
+RUN apt-get update && apt-get install -y gh
+```
+
 ## Volumes
 
 | Mount         | Purpose                                                                  |
@@ -232,6 +265,11 @@ The published image is multi-arch for `linux/amd64` and `linux/arm64`.
 - **403 Host not allowed**: set `PASEO_HOSTNAMES` to the DNS names you use.
 - **Provider not available**: install that agent CLI in a child image or mount a
   runtime where the binary is on `PATH`.
+- **Forge CLI (`gh`/`glab`/`tea`) not available**: the daemon auto-installs it
+  on first use unless `PASEO_FORGE_CLI_AUTOINSTALL=0` is set, or the platform
+  is unsupported (only `linux/amd64` and `linux/arm64` are covered today).
+  Check `docker logs paseo` for the download attempt, or install the CLI in a
+  child image.
 - **Permission errors in `/workspace`**: make the mounted directory writable by
   uid/gid `1000:1000`, or run the container as the host uid/gid.
 - **Logs**: inspect `docker logs paseo` or

--- a/docs/forge-providers.md
+++ b/docs/forge-providers.md
@@ -84,6 +84,15 @@ Register the adapter in `defaultForgeRegistry` with:
 - `matchesHost` from manifest `cloudHosts`
 - `probeHost` when self-hosted/Enterprise detection is supported
 
+If the new forge shells out to a CLI (like `gh`/`glab`/`tea`), add an entry to
+`forge-cli-catalog.ts` (pinned version + a pure `(platform, arch) => asset`
+resolver, linux only) and wire the adapter's `resolveXPath()` to call
+`resolveForgeCliPath()` from `forge-cli-autoinstall-default.ts`. That's the
+one place that does "PATH first, then download into
+`$PASEO_HOME/tools/<cli>/<cli>`", gated by `PASEO_FORGE_CLI_AUTOINSTALL`.
+Follow the `gh`/`glab`/`tea` resolvers in `github-service.ts` /
+`gitlab-service.ts` / `gitea-service.ts` as examples.
+
 Current change-request lookup uses two identities deliberately:
 
 - An open PR/MR belongs to the checkout when its head branch and head repository

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -118,6 +118,7 @@ export async function fanOutReconciledWorkspaceUpdates(input: {
 
 import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
 import { createGitHubService } from "../services/github-service.js";
+import { resolveForgeCliPath } from "../services/forge-cli/forge-cli-autoinstall-default.js";
 import { createPaseoWorktree as createRegisteredPaseoWorktree } from "./paseo-worktree-service.js";
 import { createWorkspaceProvisioningService } from "./session/workspace-provisioning/workspace-provisioning-service.js";
 import { createPaseoWorktreeWorkflow } from "./worktree-session.js";
@@ -787,11 +788,21 @@ export async function createPaseoDaemon(
     paseoHome: config.paseoHome,
     logger,
   });
-  const github = createGitHubService();
+  const github = createGitHubService({
+    resolveGhPath: () =>
+      resolveForgeCliPath("gh", {
+        paseoHome: config.paseoHome,
+        toolsDir: config.toolsDir,
+        autoInstallEnabled: config.forgeCliAutoInstall,
+        logger,
+      }),
+  });
   const workspaceGitService = new WorkspaceGitServiceImpl({
     logger,
     paseoHome: config.paseoHome,
     worktreesRoot: config.worktreesRoot,
+    toolsDir: config.toolsDir,
+    forgeCliAutoInstall: config.forgeCliAutoInstall,
     deps: {
       forgeOverrides: { github },
     },

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -388,6 +388,8 @@ export interface PaseoDaemonConfig {
   mcpInjectIntoAgents?: boolean;
   browserToolsEnabled?: boolean;
   autoArchiveAfterMerge?: boolean;
+  forgeCliAutoInstall?: boolean;
+  toolsDir?: string;
   enableTerminalAgentHooks?: boolean;
   appendSystemPrompt?: string;
   terminalProfiles?: TerminalProfile[];

--- a/packages/server/src/server/config.test.ts
+++ b/packages/server/src/server/config.test.ts
@@ -26,6 +26,35 @@ describe("server config", () => {
     expect(standaloneConfig.desktopManaged).toBe(false);
   });
 
+  test("defaults forge CLI auto-install to enabled", async () => {
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-config-forge-cli-"));
+    roots.push(paseoHome);
+
+    const config = loadConfig(paseoHome, { env: {} });
+
+    expect(config.forgeCliAutoInstall).toBe(true);
+    expect(config.toolsDir).toBe(path.join(paseoHome, "tools"));
+  });
+
+  test("disables forge CLI auto-install via PASEO_FORGE_CLI_AUTOINSTALL", async () => {
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-config-forge-cli-off-"));
+    roots.push(paseoHome);
+
+    const config = loadConfig(paseoHome, { env: { PASEO_FORGE_CLI_AUTOINSTALL: "0" } });
+
+    expect(config.forgeCliAutoInstall).toBe(false);
+  });
+
+  test("overrides the tools dir via PASEO_TOOLS_DIR", async () => {
+    const paseoHome = await mkdtemp(path.join(os.tmpdir(), "paseo-config-tools-dir-"));
+    roots.push(paseoHome);
+    const toolsDir = path.join(os.tmpdir(), "paseo-tools-override");
+
+    const config = loadConfig(paseoHome, { env: { PASEO_TOOLS_DIR: toolsDir } });
+
+    expect(config.toolsDir).toBe(toolsDir);
+  });
+
   test("resolves bundled web UI path from source-tree modules", () => {
     const root = path.parse(process.cwd()).root;
     expect(

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -419,6 +419,25 @@ function resolveBrowserToolsEnabled(persisted: ReturnType<typeof loadPersistedCo
   return persisted.daemon?.browserTools?.enabled ?? false;
 }
 
+function resolveForgeCliAutoInstall(
+  env: NodeJS.ProcessEnv,
+  persisted: ReturnType<typeof loadPersistedConfig>,
+): boolean {
+  return (
+    parseBooleanEnv(env.PASEO_FORGE_CLI_AUTOINSTALL) ??
+    persisted.daemon?.forgeCliAutoInstall ??
+    true
+  );
+}
+
+function resolveToolsDir(paseoHome: string, env: NodeJS.ProcessEnv): string {
+  const configured = env.PASEO_TOOLS_DIR?.trim();
+  if (!configured) {
+    return path.join(paseoHome, "tools");
+  }
+  return path.isAbsolute(configured) ? configured : path.resolve(paseoHome, configured);
+}
+
 function resolveStaticLoadConfigSettings(
   env: NodeJS.ProcessEnv,
   cli: CliConfigOverrides | undefined,
@@ -464,6 +483,8 @@ export function loadConfig(
     trustedProxies,
     appBaseUrl,
   } = resolveStaticLoadConfigSettings(env, options?.cli, persisted);
+  const forgeCliAutoInstall = resolveForgeCliAutoInstall(env, persisted);
+  const toolsDir = resolveToolsDir(paseoHome, env);
 
   const relay = resolveRelayConfig({
     env,
@@ -497,6 +518,8 @@ export function loadConfig(
     mcpInjectIntoAgents,
     browserToolsEnabled,
     autoArchiveAfterMerge,
+    forgeCliAutoInstall,
+    toolsDir,
     enableTerminalAgentHooks: persisted.daemon?.enableTerminalAgentHooks ?? false,
     appendSystemPrompt,
     terminalProfiles,

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -249,6 +249,7 @@ export const PersistedConfigSchema = z
           .passthrough()
           .optional(),
         autoArchiveAfterMerge: z.boolean().optional(),
+        forgeCliAutoInstall: z.boolean().optional(),
         enableTerminalAgentHooks: z.boolean().optional(),
         appendSystemPrompt: z.string().optional(),
         terminalProfiles: z.array(TerminalProfileSchema).optional(),

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -295,6 +295,8 @@ interface WorkspaceGitServiceOptions {
   logger: pino.Logger;
   paseoHome: string;
   worktreesRoot?: string;
+  toolsDir?: string;
+  forgeCliAutoInstall?: boolean;
   deps?: Partial<WorkspaceGitServiceDependencies>;
 }
 
@@ -431,7 +433,14 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
     this.worktreesRoot = options.worktreesRoot;
     this.deps = resolveWorkspaceGitServiceDeps(options.deps);
     this.forgeResolver = createForgeResolver({
-      createService: (forge) => this.deps.forgeOverrides?.[forge] ?? createForgeService(forge),
+      createService: (forge) =>
+        this.deps.forgeOverrides?.[forge] ??
+        createForgeService(forge, {
+          paseoHome: this.paseoHome,
+          logger: this.logger,
+          toolsDir: options.toolsDir,
+          forgeCliAutoInstall: options.forgeCliAutoInstall,
+        }),
     });
   }
 

--- a/packages/server/src/services/forge-cli/ensure-forge-cli.test.ts
+++ b/packages/server/src/services/forge-cli/ensure-forge-cli.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -7,6 +8,10 @@ import pino from "pino";
 import { describe, expect, test } from "vitest";
 
 import { ensureForgeCli, type EnsureForgeCliOptions } from "./ensure-forge-cli.js";
+
+function sha256Hex(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
 
 const logger = pino({ level: "silent" });
 
@@ -21,15 +26,16 @@ function fakeResponse(body: Buffer, init?: { ok?: boolean; status?: number }): R
 }
 
 /** A bare-binary asset (tea-shaped): the "download" is a shell script printing a version. */
-function makeBareBinaryFetch(): typeof fetch {
+function makeBareBinaryFetch(): { fetchImpl: typeof fetch; body: Buffer } {
   const script = "#!/bin/sh\necho 'tea version 0.3.0'\n";
   const body = Buffer.from(script, "utf8");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (async () => fakeResponse(body)) as any;
+  const fetchImpl = (async () => fakeResponse(body)) as any;
+  return { fetchImpl, body };
 }
 
 /** A tar.gz asset (gh/glab-shaped): builds a real tarball containing a fake gh binary. */
-function makeTarGzFetch(binaryRelPath: string): typeof fetch {
+function makeTarGzFetch(binaryRelPath: string): { fetchImpl: typeof fetch; body: Buffer } {
   const stageDir = makeTmpDir();
   const binaryAbsPath = path.join(stageDir, binaryRelPath);
   mkdirSync(path.dirname(binaryAbsPath), { recursive: true });
@@ -41,7 +47,8 @@ function makeTarGzFetch(binaryRelPath: string): typeof fetch {
   const tarball = execFileSync("cat", [archivePath]);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (async () => fakeResponse(tarball)) as any;
+  const fetchImpl = (async () => fakeResponse(tarball)) as any;
+  return { fetchImpl, body: tarball };
 }
 
 function baseOptions(overrides: Partial<EnsureForgeCliOptions> = {}): EnsureForgeCliOptions {
@@ -106,7 +113,8 @@ describe("ensureForgeCli", () => {
     const result = await ensureForgeCli("tea", {
       paseoHome,
       logger,
-      fetchImpl: makeBareBinaryFetch(),
+      fetchImpl: makeBareBinaryFetch().fetchImpl,
+      getForgeCliChecksumImpl: () => null,
       probeExecutableImpl: async (executablePath) => {
         probeCallCount += 1;
         // First probe (cache check) reports absent so we take the download
@@ -134,7 +142,8 @@ describe("ensureForgeCli", () => {
     const result = await ensureForgeCli("gh", {
       paseoHome,
       logger,
-      fetchImpl: makeTarGzFetch("gh_2.96.0_linux_amd64/bin/gh"),
+      fetchImpl: makeTarGzFetch("gh_2.96.0_linux_amd64/bin/gh").fetchImpl,
+      getForgeCliChecksumImpl: () => null,
       probeExecutableImpl: async () => {
         probeCallCount += 1;
         return probeCallCount > 1;
@@ -156,7 +165,8 @@ describe("ensureForgeCli", () => {
     const result = await ensureForgeCli("tea", {
       paseoHome,
       logger,
-      fetchImpl: makeBareBinaryFetch(),
+      fetchImpl: makeBareBinaryFetch().fetchImpl,
+      getForgeCliChecksumImpl: () => null,
       probeExecutableImpl: async () => false,
     });
 
@@ -183,6 +193,7 @@ describe("ensureForgeCli", () => {
       paseoHome,
       logger,
       fetchImpl,
+      getForgeCliChecksumImpl: () => null,
       probeExecutableImpl: async () => {
         probeCallCount += 1;
         // First probe is the shared cache check (miss); second is the
@@ -199,5 +210,128 @@ describe("ensureForgeCli", () => {
     expect(first).toBe(path.join(paseoHome, "tools", "tea", "tea"));
     expect(second).toBe(first);
     expect(fetchCalls).toBe(1);
+  });
+
+  test("downloads a bare binary whose checksum matches the pinned value", async () => {
+    const paseoHome = makeTmpDir();
+    const { fetchImpl, body } = makeBareBinaryFetch();
+    let probeCallCount = 0;
+
+    const result = await ensureForgeCli("tea", {
+      paseoHome,
+      logger,
+      fetchImpl,
+      getForgeCliChecksumImpl: (_cli, assetFilename) =>
+        assetFilename === "tea-0.3.0-linux-amd64" || assetFilename === "tea-0.3.0-linux-arm64"
+          ? sha256Hex(body)
+          : null,
+      probeExecutableImpl: async () => {
+        probeCallCount += 1;
+        return probeCallCount > 1;
+      },
+      platform: "linux",
+      arch: "x64",
+    });
+
+    expect(result).toBe(path.join(paseoHome, "tools", "tea", "tea"));
+  });
+
+  test("downloads a tar.gz asset whose checksum matches the pinned value", async () => {
+    const paseoHome = makeTmpDir();
+    const { fetchImpl, body } = makeTarGzFetch("gh_2.96.0_linux_amd64/bin/gh");
+    let probeCallCount = 0;
+
+    const result = await ensureForgeCli("gh", {
+      paseoHome,
+      logger,
+      fetchImpl,
+      getForgeCliChecksumImpl: (_cli, assetFilename) =>
+        assetFilename === "gh_2.96.0_linux_amd64.tar.gz" ? sha256Hex(body) : null,
+      probeExecutableImpl: async () => {
+        probeCallCount += 1;
+        return probeCallCount > 1;
+      },
+      platform: "linux",
+      arch: "x64",
+    });
+
+    expect(result).toBe(path.join(paseoHome, "tools", "gh", "gh"));
+  });
+
+  test("cleans up and returns null when the checksum doesn't match the pinned value", async () => {
+    const paseoHome = makeTmpDir();
+    let probeCallCount = 0;
+
+    const result = await ensureForgeCli("tea", {
+      paseoHome,
+      logger,
+      fetchImpl: makeBareBinaryFetch().fetchImpl,
+      getForgeCliChecksumImpl: () => "0".repeat(64),
+      probeExecutableImpl: async () => {
+        probeCallCount += 1;
+        return false;
+      },
+      platform: "linux",
+      arch: "x64",
+    });
+
+    expect(result).toBeNull();
+    // Only the cache-check probe should have run; a checksum mismatch
+    // short-circuits before the post-download probe.
+    expect(probeCallCount).toBe(1);
+
+    const expectedPath = path.join(paseoHome, "tools", "tea", "tea");
+    await expect(stat(expectedPath)).rejects.toThrow();
+  });
+
+  test("cleans up and returns null when a tar.gz checksum doesn't match the pinned value", async () => {
+    const paseoHome = makeTmpDir();
+    let probeCallCount = 0;
+
+    const result = await ensureForgeCli("gh", {
+      paseoHome,
+      logger,
+      fetchImpl: makeTarGzFetch("gh_2.96.0_linux_amd64/bin/gh").fetchImpl,
+      getForgeCliChecksumImpl: () => "0".repeat(64),
+      probeExecutableImpl: async () => {
+        probeCallCount += 1;
+        return false;
+      },
+      platform: "linux",
+      arch: "x64",
+    });
+
+    expect(result).toBeNull();
+    // Only the cache-check probe should have run; a checksum mismatch
+    // short-circuits before the post-download probe.
+    expect(probeCallCount).toBe(1);
+
+    const expectedPath = path.join(paseoHome, "tools", "gh", "gh");
+    await expect(stat(expectedPath)).rejects.toThrow();
+  });
+
+  test("proceeds and warns when no pinned checksum exists for the asset", async () => {
+    const paseoHome = makeTmpDir();
+    let probeCallCount = 0;
+    let checksumLookupCalled = false;
+
+    const result = await ensureForgeCli("tea", {
+      paseoHome,
+      logger,
+      fetchImpl: makeBareBinaryFetch().fetchImpl,
+      getForgeCliChecksumImpl: () => {
+        checksumLookupCalled = true;
+        return null;
+      },
+      probeExecutableImpl: async () => {
+        probeCallCount += 1;
+        return probeCallCount > 1;
+      },
+      platform: "linux",
+      arch: "x64",
+    });
+
+    expect(checksumLookupCalled).toBe(true);
+    expect(result).toBe(path.join(paseoHome, "tools", "tea", "tea"));
   });
 });

--- a/packages/server/src/services/forge-cli/ensure-forge-cli.test.ts
+++ b/packages/server/src/services/forge-cli/ensure-forge-cli.test.ts
@@ -1,0 +1,203 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pino from "pino";
+import { describe, expect, test } from "vitest";
+
+import { ensureForgeCli, type EnsureForgeCliOptions } from "./ensure-forge-cli.js";
+
+const logger = pino({ level: "silent" });
+
+function makeTmpDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "paseo-forge-cli-"));
+}
+
+function fakeResponse(body: Buffer, init?: { ok?: boolean; status?: number }): Response {
+  const ok = init?.ok ?? true;
+  const status = init?.status ?? (ok ? 200 : 500);
+  return new Response(new Uint8Array(body), { status });
+}
+
+/** A bare-binary asset (tea-shaped): the "download" is a shell script printing a version. */
+function makeBareBinaryFetch(): typeof fetch {
+  const script = "#!/bin/sh\necho 'tea version 0.3.0'\n";
+  const body = Buffer.from(script, "utf8");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (async () => fakeResponse(body)) as any;
+}
+
+/** A tar.gz asset (gh/glab-shaped): builds a real tarball containing a fake gh binary. */
+function makeTarGzFetch(binaryRelPath: string): typeof fetch {
+  const stageDir = makeTmpDir();
+  const binaryAbsPath = path.join(stageDir, binaryRelPath);
+  mkdirSync(path.dirname(binaryAbsPath), { recursive: true });
+  writeFileSync(binaryAbsPath, "#!/bin/sh\necho 'gh version 2.96.0'\n");
+  execFileSync("chmod", ["+x", binaryAbsPath]);
+
+  const archivePath = path.join(stageDir, "asset.tar.gz");
+  execFileSync("tar", ["czf", archivePath, "-C", stageDir, binaryRelPath.split("/")[0] ?? "."]);
+  const tarball = execFileSync("cat", [archivePath]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (async () => fakeResponse(tarball)) as any;
+}
+
+function baseOptions(overrides: Partial<EnsureForgeCliOptions> = {}): EnsureForgeCliOptions {
+  return {
+    paseoHome: makeTmpDir(),
+    logger,
+    probeExecutableImpl: async () => true,
+    ...overrides,
+  };
+}
+
+describe("ensureForgeCli", () => {
+  test("returns the cached path without downloading when it already probes ok", async () => {
+    const paseoHome = makeTmpDir();
+    const cliPath = path.join(paseoHome, "tools", "tea", "tea");
+    mkdirSync(path.dirname(cliPath), { recursive: true });
+    writeFileSync(cliPath, "#!/bin/sh\necho ok\n");
+
+    let fetchCalls = 0;
+    const fetchImpl: typeof fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error("should not fetch when cache hits");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+    const result = await ensureForgeCli("tea", {
+      paseoHome,
+      logger,
+      fetchImpl,
+      probeExecutableImpl: async () => true,
+    });
+
+    expect(result).toBe(cliPath);
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("returns null for an unsupported arch without touching the network", async () => {
+    let fetchCalls = 0;
+    const fetchImpl: typeof fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error("should not fetch for unsupported arch");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+    const result = await ensureForgeCli(
+      "tea",
+      baseOptions({
+        fetchImpl,
+        probeExecutableImpl: async () => false,
+        arch: "ia32",
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("downloads a bare binary (tea-shaped), chmods it, and probes it", async () => {
+    const paseoHome = makeTmpDir();
+    let probeCallCount = 0;
+
+    const result = await ensureForgeCli("tea", {
+      paseoHome,
+      logger,
+      fetchImpl: makeBareBinaryFetch(),
+      probeExecutableImpl: async (executablePath) => {
+        probeCallCount += 1;
+        // First probe (cache check) reports absent so we take the download
+        // path; second probe (post-download verification) succeeds.
+        if (probeCallCount === 1) return false;
+        expect(executablePath).toBe(path.join(paseoHome, "tools", "tea", "tea"));
+        return true;
+      },
+    });
+
+    const expectedPath = path.join(paseoHome, "tools", "tea", "tea");
+    expect(result).toBe(expectedPath);
+
+    const stats = await stat(expectedPath);
+    expect(stats.mode & 0o777).toBe(0o755);
+
+    const contents = await readFile(expectedPath, "utf8");
+    expect(contents).toContain("tea version 0.3.0");
+  });
+
+  test("downloads and extracts a tar.gz asset (gh-shaped) from the archive", async () => {
+    const paseoHome = makeTmpDir();
+    let probeCallCount = 0;
+
+    const result = await ensureForgeCli("gh", {
+      paseoHome,
+      logger,
+      fetchImpl: makeTarGzFetch("gh_2.96.0_linux_amd64/bin/gh"),
+      probeExecutableImpl: async () => {
+        probeCallCount += 1;
+        return probeCallCount > 1;
+      },
+      platform: "linux",
+      arch: "x64",
+    });
+
+    const expectedPath = path.join(paseoHome, "tools", "gh", "gh");
+    expect(result).toBe(expectedPath);
+
+    const contents = await readFile(expectedPath, "utf8");
+    expect(contents).toContain("gh version 2.96.0");
+  });
+
+  test("cleans up and returns null when the post-download probe fails", async () => {
+    const paseoHome = makeTmpDir();
+
+    const result = await ensureForgeCli("tea", {
+      paseoHome,
+      logger,
+      fetchImpl: makeBareBinaryFetch(),
+      probeExecutableImpl: async () => false,
+    });
+
+    expect(result).toBeNull();
+
+    const expectedPath = path.join(paseoHome, "tools", "tea", "tea");
+    await expect(stat(expectedPath)).rejects.toThrow();
+  });
+
+  test("dedupes concurrent calls for the same cli into a single download", async () => {
+    const paseoHome = makeTmpDir();
+    let fetchCalls = 0;
+    let probeCallCount = 0;
+
+    const fetchImpl: typeof fetch = (async () => {
+      fetchCalls += 1;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const script = "#!/bin/sh\necho 'tea version 0.3.0'\n";
+      return fakeResponse(Buffer.from(script, "utf8"));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+    const options: EnsureForgeCliOptions = {
+      paseoHome,
+      logger,
+      fetchImpl,
+      probeExecutableImpl: async () => {
+        probeCallCount += 1;
+        // First probe is the shared cache check (miss); second is the
+        // post-download verification (success).
+        return probeCallCount > 1;
+      },
+    };
+
+    const [first, second] = await Promise.all([
+      ensureForgeCli("tea", options),
+      ensureForgeCli("tea", options),
+    ]);
+
+    expect(first).toBe(path.join(paseoHome, "tools", "tea", "tea"));
+    expect(second).toBe(first);
+    expect(fetchCalls).toBe(1);
+  });
+});

--- a/packages/server/src/services/forge-cli/ensure-forge-cli.ts
+++ b/packages/server/src/services/forge-cli/ensure-forge-cli.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
-import { createWriteStream } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
 import { chmod, copyFile, mkdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -8,7 +8,7 @@ import type pino from "pino";
 
 import { probeExecutable } from "../../executable-resolution/executable-resolution.js";
 import { spawnProcess } from "../../utils/spawn.js";
-import { resolveForgeCliAsset, type ForgeCliId } from "./forge-cli-catalog.js";
+import { getForgeCliChecksum, resolveForgeCliAsset, type ForgeCliId } from "./forge-cli-catalog.js";
 
 export interface EnsureForgeCliOptions {
   paseoHome: string;
@@ -19,6 +19,8 @@ export interface EnsureForgeCliOptions {
   fetchImpl?: typeof fetch;
   /** Injectable for tests; defaults to the real `--version` probe. */
   probeExecutableImpl?: (executablePath: string) => Promise<boolean>;
+  /** Injectable for tests; defaults to the real forge-cli-versions.json lookup. */
+  getForgeCliChecksumImpl?: (cli: ForgeCliId, assetFilename: string) => string | null;
   /** Injectable for tests; defaults to process.platform. */
   platform?: NodeJS.Platform;
   /** Injectable for tests; defaults to process.arch. */
@@ -66,6 +68,12 @@ async function downloadToFile(
   }
 }
 
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  await pipeline(createReadStream(filePath), hash);
+  return hash.digest("hex");
+}
+
 async function extractTarArchive(archivePath: string, destDir: string): Promise<void> {
   await mkdir(destDir, { recursive: true });
 
@@ -111,6 +119,43 @@ export function ensureForgeCli(
   return promise;
 }
 
+interface VerifyChecksumParams {
+  cli: ForgeCliId;
+  filePath: string;
+  assetFilename: string;
+  lookupChecksum: (cli: ForgeCliId, assetFilename: string) => string | null;
+  logger: pino.Logger;
+}
+
+// Returns false only on an actual mismatch (caller should treat that as a
+// hard failure, same as a failed post-download probe). A missing catalog
+// entry (mid version-bump, or an arch/platform combo we haven't published
+// checksums for yet) isn't fatal on its own -- the post-download
+// probeExecutable() check downstream is a lesser but non-zero safety net,
+// so we log and let the download proceed rather than block auto-install
+// entirely on the checksum data being complete.
+async function verifyChecksum(params: VerifyChecksumParams): Promise<boolean> {
+  const { cli, filePath, assetFilename, lookupChecksum, logger } = params;
+  const expected = lookupChecksum(cli, assetFilename);
+  if (!expected) {
+    logger.warn(
+      { assetFilename },
+      "no pinned checksum for this forge CLI asset, skipping verification",
+    );
+    return true;
+  }
+
+  const actual = await sha256File(filePath);
+  if (actual !== expected) {
+    logger.error(
+      { assetFilename, expected, actual },
+      "forge CLI checksum mismatch, removing download",
+    );
+    return false;
+  }
+  return true;
+}
+
 async function ensureForgeCliUncached(
   cli: ForgeCliId,
   options: EnsureForgeCliOptions,
@@ -119,6 +164,7 @@ async function ensureForgeCliUncached(
   const binaryPath = managedCliPath(options, cli);
   const fetchImpl = options.fetchImpl ?? fetch;
   const probe = options.probeExecutableImpl ?? probeExecutable;
+  const lookupChecksum = options.getForgeCliChecksumImpl ?? getForgeCliChecksum;
 
   if (await probe(binaryPath)) {
     return binaryPath;
@@ -140,13 +186,42 @@ async function ensureForgeCliUncached(
   try {
     const cliDir = path.dirname(binaryPath);
     await mkdir(cliDir, { recursive: true });
+    const assetFilename = path.basename(new URL(asset.url).pathname);
 
     if (asset.archive === "none") {
       await downloadToFile(fetchImpl, asset.url, binaryPath);
+
+      if (
+        !(await verifyChecksum({
+          cli,
+          filePath: binaryPath,
+          assetFilename,
+          lookupChecksum,
+          logger,
+        }))
+      ) {
+        await rm(binaryPath, { force: true }).catch(() => undefined);
+        return null;
+      }
     } else {
       const downloadsDir = path.join(toolsDirFor(options), ".downloads", cli);
-      const archivePath = path.join(downloadsDir, path.basename(new URL(asset.url).pathname));
+      const archivePath = path.join(downloadsDir, assetFilename);
       await downloadToFile(fetchImpl, asset.url, archivePath);
+
+      // gh/glab publish checksums against the .tar.gz itself, not the
+      // extracted binary, so verify before we ever touch tar.
+      if (
+        !(await verifyChecksum({
+          cli,
+          filePath: archivePath,
+          assetFilename,
+          lookupChecksum,
+          logger,
+        }))
+      ) {
+        await rm(archivePath, { force: true }).catch(() => undefined);
+        return null;
+      }
 
       const extractDir = path.join(downloadsDir, `${cli}-extract-${randomUUID()}`);
       await extractTarArchive(archivePath, extractDir);

--- a/packages/server/src/services/forge-cli/ensure-forge-cli.ts
+++ b/packages/server/src/services/forge-cli/ensure-forge-cli.ts
@@ -144,7 +144,7 @@ async function ensureForgeCliUncached(
     if (asset.archive === "none") {
       await downloadToFile(fetchImpl, asset.url, binaryPath);
     } else {
-      const downloadsDir = path.join(toolsDirFor(options), ".downloads");
+      const downloadsDir = path.join(toolsDirFor(options), ".downloads", cli);
       const archivePath = path.join(downloadsDir, path.basename(new URL(asset.url).pathname));
       await downloadToFile(fetchImpl, asset.url, archivePath);
 

--- a/packages/server/src/services/forge-cli/ensure-forge-cli.ts
+++ b/packages/server/src/services/forge-cli/ensure-forge-cli.ts
@@ -1,0 +1,178 @@
+import { randomUUID } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { chmod, copyFile, mkdir, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type pino from "pino";
+
+import { probeExecutable } from "../../executable-resolution/executable-resolution.js";
+import { spawnProcess } from "../../utils/spawn.js";
+import { resolveForgeCliAsset, type ForgeCliId } from "./forge-cli-catalog.js";
+
+export interface EnsureForgeCliOptions {
+  paseoHome: string;
+  logger: pino.Logger;
+  /** Root dir for downloaded tools. Defaults to `<paseoHome>/tools`. */
+  toolsDir?: string;
+  /** Injectable for tests; defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injectable for tests; defaults to the real `--version` probe. */
+  probeExecutableImpl?: (executablePath: string) => Promise<boolean>;
+  /** Injectable for tests; defaults to process.platform. */
+  platform?: NodeJS.Platform;
+  /** Injectable for tests; defaults to process.arch. */
+  arch?: string;
+}
+
+const EXECUTABLE_MODE = 0o755;
+
+function toolsDirFor(options: EnsureForgeCliOptions): string {
+  return options.toolsDir ?? path.join(options.paseoHome, "tools");
+}
+
+function managedCliPath(options: EnsureForgeCliOptions, cli: ForgeCliId): string {
+  return path.join(toolsDirFor(options), cli, cli);
+}
+
+async function downloadToFile(
+  fetchImpl: typeof fetch,
+  url: string,
+  outputPath: string,
+): Promise<void> {
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`Failed to download ${url}: ${res.status} ${res.statusText}`);
+  }
+  if (!res.body) {
+    throw new Error(`Failed to download ${url}: missing response body`);
+  }
+
+  // randomUUID, not Date.now(). Two installs racing on the same shared
+  // PASEO_TOOLS_DIR (e.g. two daemons) could land in the same millisecond.
+  const tmpPath = `${outputPath}.tmp-${randomUUID()}`;
+  await mkdir(path.dirname(outputPath), { recursive: true });
+
+  // The fetch ReadableStream type is slightly different from what Readable.fromWeb expects
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nodeStream = Readable.fromWeb(res.body as any);
+
+  try {
+    await pipeline(nodeStream, createWriteStream(tmpPath));
+    await rename(tmpPath, outputPath);
+  } catch (error) {
+    await rm(tmpPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function extractTarArchive(archivePath: string, destDir: string): Promise<void> {
+  await mkdir(destDir, { recursive: true });
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawnProcess("tar", ["xf", archivePath, "-C", destDir], {
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`tar exited with code ${code}`));
+    });
+  });
+}
+
+// Downloads gh/glab/tea into $PASEO_HOME/tools/<cli>/<cli> when it's missing
+// from PATH. Only meant for the Docker image, where we control the base and
+// know it's linux. forge-cli-catalog.ts only has assets for linux, so
+// darwin/win32 just no-op below. Not something we want to do on someone's
+// actual mac or dev box.
+//
+// Shape is fetch -> tmp file -> atomic rename -> extract -> chmod -> probe,
+// same idea as the sherpa ONNX model downloader. Every failure (bad
+// platform, download error, probe failure) just resolves to null and logs,
+// never throws the daemon down.
+const inFlightByCli = new Map<ForgeCliId, Promise<string | null>>();
+
+export function ensureForgeCli(
+  cli: ForgeCliId,
+  options: EnsureForgeCliOptions,
+): Promise<string | null> {
+  const existing = inFlightByCli.get(cli);
+  if (existing) {
+    return existing;
+  }
+
+  const promise = ensureForgeCliUncached(cli, options).finally(() => {
+    if (inFlightByCli.get(cli) === promise) {
+      inFlightByCli.delete(cli);
+    }
+  });
+  inFlightByCli.set(cli, promise);
+  return promise;
+}
+
+async function ensureForgeCliUncached(
+  cli: ForgeCliId,
+  options: EnsureForgeCliOptions,
+): Promise<string | null> {
+  const logger = options.logger.child({ module: "forge-cli", component: "ensure-forge-cli", cli });
+  const binaryPath = managedCliPath(options, cli);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const probe = options.probeExecutableImpl ?? probeExecutable;
+
+  if (await probe(binaryPath)) {
+    return binaryPath;
+  }
+
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  const asset = resolveForgeCliAsset(cli, platform, arch);
+  if (!asset) {
+    // Only linux is in the catalog right now (this is a container-only
+    // feature), so this fires on darwin/win32/unsupported arch. Not an
+    // error, just nothing to do here.
+    logger.warn({ platform, arch }, "no forge CLI asset for this platform/arch, skipping");
+    return null;
+  }
+
+  logger.info({ url: asset.url }, "downloading forge CLI");
+
+  try {
+    const cliDir = path.dirname(binaryPath);
+    await mkdir(cliDir, { recursive: true });
+
+    if (asset.archive === "none") {
+      await downloadToFile(fetchImpl, asset.url, binaryPath);
+    } else {
+      const downloadsDir = path.join(toolsDirFor(options), ".downloads");
+      const archivePath = path.join(downloadsDir, path.basename(new URL(asset.url).pathname));
+      await downloadToFile(fetchImpl, asset.url, archivePath);
+
+      const extractDir = path.join(downloadsDir, `${cli}-extract-${randomUUID()}`);
+      await extractTarArchive(archivePath, extractDir);
+
+      if (!asset.binaryPathInArchive) {
+        throw new Error(`Catalog entry for ${cli} is missing binaryPathInArchive`);
+      }
+      await copyFile(path.join(extractDir, asset.binaryPathInArchive), binaryPath);
+
+      await rm(archivePath, { force: true }).catch(() => undefined);
+      await rm(extractDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+
+    await chmod(binaryPath, EXECUTABLE_MODE);
+
+    if (!(await probe(binaryPath))) {
+      logger.error({ binaryPath }, "downloaded forge CLI won't run, removing it");
+      await rm(binaryPath, { force: true }).catch(() => undefined);
+      return null;
+    }
+
+    logger.info({ binaryPath }, "forge CLI download done");
+    return binaryPath;
+  } catch (error) {
+    logger.error({ err: error }, "forge CLI download failed");
+    await rm(binaryPath, { force: true }).catch(() => undefined);
+    return null;
+  }
+}

--- a/packages/server/src/services/forge-cli/forge-cli-autoinstall-default.test.ts
+++ b/packages/server/src/services/forge-cli/forge-cli-autoinstall-default.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import {
+  ensureForgeCliWithDefaults,
+  isForgeCliAutoInstallEnabled,
+} from "./forge-cli-autoinstall-default.js";
+
+describe("isForgeCliAutoInstallEnabled", () => {
+  test("defaults to enabled when the env var is unset", () => {
+    expect(isForgeCliAutoInstallEnabled({})).toBe(true);
+  });
+
+  test("disables when PASEO_FORGE_CLI_AUTOINSTALL is falsy", () => {
+    expect(isForgeCliAutoInstallEnabled({ PASEO_FORGE_CLI_AUTOINSTALL: "0" })).toBe(false);
+    expect(isForgeCliAutoInstallEnabled({ PASEO_FORGE_CLI_AUTOINSTALL: "false" })).toBe(false);
+  });
+
+  test("enables when PASEO_FORGE_CLI_AUTOINSTALL is truthy", () => {
+    expect(isForgeCliAutoInstallEnabled({ PASEO_FORGE_CLI_AUTOINSTALL: "1" })).toBe(true);
+  });
+});
+
+describe("ensureForgeCliWithDefaults", () => {
+  test("short-circuits to null without touching the network when auto-install is disabled", async () => {
+    const result = await ensureForgeCliWithDefaults("tea", { autoInstallEnabled: false });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/server/src/services/forge-cli/forge-cli-autoinstall-default.ts
+++ b/packages/server/src/services/forge-cli/forge-cli-autoinstall-default.ts
@@ -1,0 +1,84 @@
+import pino from "pino";
+import { resolvePaseoHome } from "../../server/paseo-home.js";
+import { findExecutable } from "../../executable-resolution/executable-resolution.js";
+import { ensureForgeCli, type EnsureForgeCliOptions } from "./ensure-forge-cli.js";
+import type { ForgeCliId } from "./forge-cli-catalog.js";
+
+// Fallback logger for call sites that don't have a real daemon logger to
+// pass in (the zero-arg createGitHubService()/createGitLabService()/
+// createGiteaService() call sites in session.ts, websocket-server.ts,
+// checkout-git.ts). Logs still go somewhere, stdout at warn+, instead of
+// vanishing, since a failed auto-install with no visible reason is
+// annoying to debug.
+let defaultLogger: pino.Logger | undefined;
+
+function getDefaultLogger(): pino.Logger {
+  defaultLogger ??= pino({ level: "warn" });
+  return defaultLogger;
+}
+
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+export function isForgeCliAutoInstallEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseBooleanEnv(env.PASEO_FORGE_CLI_AUTOINSTALL) ?? true;
+}
+
+export interface EnsureForgeCliWithDefaultsOptions {
+  paseoHome?: string;
+  logger?: pino.Logger;
+  toolsDir?: string;
+  autoInstallEnabled?: boolean;
+}
+
+/**
+ * Ensure a forge CLI is available, falling back to module-level defaults
+ * (real $PASEO_HOME, a warn-level logger, live env for the enable flag) for
+ * whatever the caller didn't pass in. Lets the bare `createXService()` call
+ * sites (session.ts/websocket-server.ts fallbacks, checkout-git.ts default
+ * params) get auto-install without needing to thread real daemon config.
+ */
+export function ensureForgeCliWithDefaults(
+  cli: ForgeCliId,
+  options: EnsureForgeCliWithDefaultsOptions = {},
+): Promise<string | null> {
+  const autoInstallEnabled = options.autoInstallEnabled ?? isForgeCliAutoInstallEnabled();
+  if (!autoInstallEnabled) {
+    return Promise.resolve(null);
+  }
+
+  const ensureOptions: EnsureForgeCliOptions = {
+    paseoHome: options.paseoHome ?? resolvePaseoHome(),
+    logger: options.logger ?? getDefaultLogger(),
+    toolsDir: options.toolsDir,
+  };
+  return ensureForgeCli(cli, ensureOptions);
+}
+
+// The one place that decides "PATH first, then auto-install" for a forge
+// CLI. Both the bare module-level resolveGhPath()/resolveGlabPath()/
+// resolveTeaPath() (github-service.ts etc, used when nothing is injected)
+// and forge-registry.ts's context-aware resolver call this, so there's
+// only one fallback implementation, just two different option bags feeding
+// it depending on whether real daemon config is available yet.
+export async function resolveForgeCliPath(
+  cli: ForgeCliId,
+  options: EnsureForgeCliWithDefaultsOptions = {},
+): Promise<string | null> {
+  const found = await findExecutable(cli);
+  if (found) {
+    return found;
+  }
+  return ensureForgeCliWithDefaults(cli, options);
+}

--- a/packages/server/src/services/forge-cli/forge-cli-catalog.test.ts
+++ b/packages/server/src/services/forge-cli/forge-cli-catalog.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { getForgeCliVersion, resolveForgeCliAsset } from "./forge-cli-catalog.js";
+
+describe("resolveForgeCliAsset", () => {
+  it("resolves gh linux amd64", () => {
+    expect(resolveForgeCliAsset("gh", "linux", "x64")).toEqual({
+      url: "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz",
+      archive: "tar.gz",
+      binaryPathInArchive: "gh_2.96.0_linux_amd64/bin/gh",
+    });
+  });
+
+  it("resolves gh linux arm64", () => {
+    expect(resolveForgeCliAsset("gh", "linux", "arm64")).toEqual({
+      url: "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_arm64.tar.gz",
+      archive: "tar.gz",
+      binaryPathInArchive: "gh_2.96.0_linux_arm64/bin/gh",
+    });
+  });
+
+  it("resolves glab linux amd64", () => {
+    expect(resolveForgeCliAsset("glab", "linux", "x64")).toEqual({
+      url: "https://gitlab.com/gitlab-org/cli/-/releases/v1.109.0/downloads/glab_1.109.0_linux_amd64.tar.gz",
+      archive: "tar.gz",
+      binaryPathInArchive: "bin/glab",
+    });
+  });
+
+  it("resolves glab linux arm64", () => {
+    expect(resolveForgeCliAsset("glab", "linux", "arm64")).toEqual({
+      url: "https://gitlab.com/gitlab-org/cli/-/releases/v1.109.0/downloads/glab_1.109.0_linux_arm64.tar.gz",
+      archive: "tar.gz",
+      binaryPathInArchive: "bin/glab",
+    });
+  });
+
+  it("resolves tea linux amd64 as a bare binary", () => {
+    expect(resolveForgeCliAsset("tea", "linux", "x64")).toEqual({
+      url: "https://dl.gitea.com/tea/0.3.0/tea-0.3.0-linux-amd64",
+      archive: "none",
+    });
+  });
+
+  it("resolves tea linux arm64 as a bare binary", () => {
+    expect(resolveForgeCliAsset("tea", "linux", "arm64")).toEqual({
+      url: "https://dl.gitea.com/tea/0.3.0/tea-0.3.0-linux-arm64",
+      archive: "none",
+    });
+  });
+
+  it("returns null for an unsupported arch", () => {
+    expect(resolveForgeCliAsset("gh", "linux", "ia32")).toBeNull();
+    expect(resolveForgeCliAsset("glab", "linux", "ia32")).toBeNull();
+    expect(resolveForgeCliAsset("tea", "linux", "ia32")).toBeNull();
+  });
+
+  it("returns null for darwin (not yet supported, zip archives unhandled)", () => {
+    expect(resolveForgeCliAsset("gh", "darwin", "arm64")).toBeNull();
+  });
+
+  it("returns null for an unsupported platform", () => {
+    expect(resolveForgeCliAsset("gh", "win32", "x64")).toBeNull();
+    expect(resolveForgeCliAsset("glab", "win32", "x64")).toBeNull();
+    expect(resolveForgeCliAsset("tea", "win32", "x64")).toBeNull();
+  });
+
+  it("exposes the pinned version per cli", () => {
+    expect(getForgeCliVersion("gh")).toBe("2.96.0");
+    expect(getForgeCliVersion("glab")).toBe("1.109.0");
+    expect(getForgeCliVersion("tea")).toBe("0.3.0");
+  });
+});

--- a/packages/server/src/services/forge-cli/forge-cli-catalog.test.ts
+++ b/packages/server/src/services/forge-cli/forge-cli-catalog.test.ts
@@ -1,26 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { getForgeCliVersion, resolveForgeCliAsset } from "./forge-cli-catalog.js";
+import {
+  getForgeCliChecksum,
+  getForgeCliVersion,
+  resolveForgeCliAsset,
+} from "./forge-cli-catalog.js";
+import forgeCliVersions from "./forge-cli-versions.json" with { type: "json" };
+
+// Versions/checksums come from forge-cli-versions.json (bumped by
+// scripts/update-forge-cli-versions.mjs), so these tests read the JSON
+// instead of hardcoding version strings that a routine bump would break.
+const ghVersion = forgeCliVersions.gh.version;
+const glabVersion = forgeCliVersions.glab.version;
+const teaVersion = forgeCliVersions.tea.version;
 
 describe("resolveForgeCliAsset", () => {
   it("resolves gh linux amd64", () => {
     expect(resolveForgeCliAsset("gh", "linux", "x64")).toEqual({
-      url: "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz",
+      url: `https://github.com/cli/cli/releases/download/v${ghVersion}/gh_${ghVersion}_linux_amd64.tar.gz`,
       archive: "tar.gz",
-      binaryPathInArchive: "gh_2.96.0_linux_amd64/bin/gh",
+      binaryPathInArchive: `gh_${ghVersion}_linux_amd64/bin/gh`,
     });
   });
 
   it("resolves gh linux arm64", () => {
     expect(resolveForgeCliAsset("gh", "linux", "arm64")).toEqual({
-      url: "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_arm64.tar.gz",
+      url: `https://github.com/cli/cli/releases/download/v${ghVersion}/gh_${ghVersion}_linux_arm64.tar.gz`,
       archive: "tar.gz",
-      binaryPathInArchive: "gh_2.96.0_linux_arm64/bin/gh",
+      binaryPathInArchive: `gh_${ghVersion}_linux_arm64/bin/gh`,
     });
   });
 
   it("resolves glab linux amd64", () => {
     expect(resolveForgeCliAsset("glab", "linux", "x64")).toEqual({
-      url: "https://gitlab.com/gitlab-org/cli/-/releases/v1.109.0/downloads/glab_1.109.0_linux_amd64.tar.gz",
+      url: `https://gitlab.com/gitlab-org/cli/-/releases/v${glabVersion}/downloads/glab_${glabVersion}_linux_amd64.tar.gz`,
       archive: "tar.gz",
       binaryPathInArchive: "bin/glab",
     });
@@ -28,7 +40,7 @@ describe("resolveForgeCliAsset", () => {
 
   it("resolves glab linux arm64", () => {
     expect(resolveForgeCliAsset("glab", "linux", "arm64")).toEqual({
-      url: "https://gitlab.com/gitlab-org/cli/-/releases/v1.109.0/downloads/glab_1.109.0_linux_arm64.tar.gz",
+      url: `https://gitlab.com/gitlab-org/cli/-/releases/v${glabVersion}/downloads/glab_${glabVersion}_linux_arm64.tar.gz`,
       archive: "tar.gz",
       binaryPathInArchive: "bin/glab",
     });
@@ -36,14 +48,14 @@ describe("resolveForgeCliAsset", () => {
 
   it("resolves tea linux amd64 as a bare binary", () => {
     expect(resolveForgeCliAsset("tea", "linux", "x64")).toEqual({
-      url: "https://dl.gitea.com/tea/0.3.0/tea-0.3.0-linux-amd64",
+      url: `https://dl.gitea.com/tea/${teaVersion}/tea-${teaVersion}-linux-amd64`,
       archive: "none",
     });
   });
 
   it("resolves tea linux arm64 as a bare binary", () => {
     expect(resolveForgeCliAsset("tea", "linux", "arm64")).toEqual({
-      url: "https://dl.gitea.com/tea/0.3.0/tea-0.3.0-linux-arm64",
+      url: `https://dl.gitea.com/tea/${teaVersion}/tea-${teaVersion}-linux-arm64`,
       archive: "none",
     });
   });
@@ -65,8 +77,24 @@ describe("resolveForgeCliAsset", () => {
   });
 
   it("exposes the pinned version per cli", () => {
-    expect(getForgeCliVersion("gh")).toBe("2.96.0");
-    expect(getForgeCliVersion("glab")).toBe("1.109.0");
-    expect(getForgeCliVersion("tea")).toBe("0.3.0");
+    expect(getForgeCliVersion("gh")).toBe(ghVersion);
+    expect(getForgeCliVersion("glab")).toBe(glabVersion);
+    expect(getForgeCliVersion("tea")).toBe(teaVersion);
+  });
+});
+
+describe("getForgeCliChecksum", () => {
+  it("returns the pinned sha256 for a known cli + asset filename", () => {
+    const ghFilename = `gh_${ghVersion}_linux_amd64.tar.gz`;
+    const teaFilename = `tea-${teaVersion}-linux-arm64`;
+    expect(getForgeCliChecksum("gh", ghFilename)).toBe(forgeCliVersions.gh.checksums[ghFilename]);
+    expect(getForgeCliChecksum("tea", teaFilename)).toBe(
+      forgeCliVersions.tea.checksums[teaFilename],
+    );
+  });
+
+  it("returns null for an unknown asset filename", () => {
+    expect(getForgeCliChecksum("gh", "gh_2.96.0_darwin_amd64.tar.gz")).toBeNull();
+    expect(getForgeCliChecksum("gh", "not-a-real-asset")).toBeNull();
   });
 });

--- a/packages/server/src/services/forge-cli/forge-cli-catalog.ts
+++ b/packages/server/src/services/forge-cli/forge-cli-catalog.ts
@@ -1,0 +1,83 @@
+export type ForgeCliId = "gh" | "glab" | "tea";
+
+export type ForgeCliArchiveKind = "tar.gz" | "none";
+
+export interface ForgeCliAsset {
+  url: string;
+  archive: ForgeCliArchiveKind;
+  /** Path of the binary inside the extracted archive. Unused when archive is "none". */
+  binaryPathInArchive?: string;
+}
+
+type ForgeCliAssetResolver = (platform: NodeJS.Platform, arch: string) => ForgeCliAsset | null;
+
+interface ForgeCliCatalogEntry {
+  version: string;
+  resolveAsset: ForgeCliAssetResolver;
+}
+
+// linux/darwin arch names in gh/glab/tea release assets use "amd64"/"arm64",
+// not node's "x64"/"arm64".
+function normalizeArch(arch: string): string | null {
+  if (arch === "x64") return "amd64";
+  if (arch === "arm64") return "arm64";
+  return null;
+}
+
+const GH_VERSION = "2.96.0";
+const GLAB_VERSION = "1.109.0";
+const TEA_VERSION = "0.3.0";
+
+// Auto-install only targets the linux container image, see ensureForgeCli.
+// Keeping the platform check here too so a direct resolveForgeCliAsset()
+// call can't accidentally hand back a darwin/win32 url.
+function resolveGhAsset(platform: NodeJS.Platform, arch: string): ForgeCliAsset | null {
+  const normalizedArch = normalizeArch(arch);
+  if (!normalizedArch || platform !== "linux") return null;
+
+  const dirname = `gh_${GH_VERSION}_linux_${normalizedArch}`;
+  return {
+    url: `https://github.com/cli/cli/releases/download/v${GH_VERSION}/${dirname}.tar.gz`,
+    archive: "tar.gz",
+    binaryPathInArchive: `${dirname}/bin/gh`,
+  };
+}
+
+function resolveGlabAsset(platform: NodeJS.Platform, arch: string): ForgeCliAsset | null {
+  const normalizedArch = normalizeArch(arch);
+  if (!normalizedArch || platform !== "linux") return null;
+
+  return {
+    url: `https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${normalizedArch}.tar.gz`,
+    archive: "tar.gz",
+    binaryPathInArchive: "bin/glab",
+  };
+}
+
+function resolveTeaAsset(platform: NodeJS.Platform, arch: string): ForgeCliAsset | null {
+  const normalizedArch = normalizeArch(arch);
+  if (!normalizedArch || platform !== "linux") return null;
+
+  return {
+    url: `https://dl.gitea.com/tea/${TEA_VERSION}/tea-${TEA_VERSION}-linux-${normalizedArch}`,
+    archive: "none",
+  };
+}
+
+const FORGE_CLI_CATALOG: Record<ForgeCliId, ForgeCliCatalogEntry> = {
+  gh: { version: GH_VERSION, resolveAsset: resolveGhAsset },
+  glab: { version: GLAB_VERSION, resolveAsset: resolveGlabAsset },
+  tea: { version: TEA_VERSION, resolveAsset: resolveTeaAsset },
+};
+
+export function getForgeCliVersion(cli: ForgeCliId): string {
+  return FORGE_CLI_CATALOG[cli].version;
+}
+
+export function resolveForgeCliAsset(
+  cli: ForgeCliId,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): ForgeCliAsset | null {
+  return FORGE_CLI_CATALOG[cli].resolveAsset(platform, arch);
+}

--- a/packages/server/src/services/forge-cli/forge-cli-catalog.ts
+++ b/packages/server/src/services/forge-cli/forge-cli-catalog.ts
@@ -1,3 +1,5 @@
+import forgeCliVersions from "./forge-cli-versions.json" with { type: "json" };
+
 export type ForgeCliId = "gh" | "glab" | "tea";
 
 export type ForgeCliArchiveKind = "tar.gz" | "none";
@@ -24,9 +26,12 @@ function normalizeArch(arch: string): string | null {
   return null;
 }
 
-const GH_VERSION = "2.96.0";
-const GLAB_VERSION = "1.109.0";
-const TEA_VERSION = "0.3.0";
+// Pinned versions + sha256 checksums live in forge-cli-versions.json, not
+// here, so a version bump is a JSON diff (bumpable by scripts/update-forge-cli-versions.mjs
+// and the weekly CI workflow) instead of a TypeScript PR.
+const GH_VERSION = forgeCliVersions.gh.version;
+const GLAB_VERSION = forgeCliVersions.glab.version;
+const TEA_VERSION = forgeCliVersions.tea.version;
 
 // Auto-install only targets the linux container image, see ensureForgeCli.
 // Keeping the platform check here too so a direct resolveForgeCliAsset()
@@ -72,6 +77,17 @@ const FORGE_CLI_CATALOG: Record<ForgeCliId, ForgeCliCatalogEntry> = {
 
 export function getForgeCliVersion(cli: ForgeCliId): string {
   return FORGE_CLI_CATALOG[cli].version;
+}
+
+/**
+ * Looks up the pinned sha256 for a downloaded asset filename (e.g.
+ * "gh_2.96.0_linux_amd64.tar.gz" or "tea-0.3.0-linux-amd64"). Returns null
+ * when the filename isn't in forge-cli-versions.json — callers should treat
+ * that as "can't verify" rather than a hard failure, see ensure-forge-cli.ts.
+ */
+export function getForgeCliChecksum(cli: ForgeCliId, assetFilename: string): string | null {
+  const checksums: Record<string, string> = forgeCliVersions[cli].checksums;
+  return checksums[assetFilename] ?? null;
 }
 
 export function resolveForgeCliAsset(

--- a/packages/server/src/services/forge-cli/forge-cli-versions.json
+++ b/packages/server/src/services/forge-cli/forge-cli-versions.json
@@ -1,0 +1,23 @@
+{
+  "gh": {
+    "version": "2.96.0",
+    "checksums": {
+      "gh_2.96.0_linux_amd64.tar.gz": "83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60",
+      "gh_2.96.0_linux_arm64.tar.gz": "06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909"
+    }
+  },
+  "glab": {
+    "version": "1.109.0",
+    "checksums": {
+      "glab_1.109.0_linux_amd64.tar.gz": "67b4a8557727a058f44e0839babdcf214ea6f6f829062cf0bae02f7b25814e5d",
+      "glab_1.109.0_linux_arm64.tar.gz": "288155229b7a0824aaca5fbdc36000d0c41fe5d8b4a4c3cbe9908e75f4e4ec2e"
+    }
+  },
+  "tea": {
+    "version": "0.14.2",
+    "checksums": {
+      "tea-0.14.2-linux-amd64": "be4ab135752825ab223cfa87d30e7f328312a24120b70176b67c1bd4aba19cc3",
+      "tea-0.14.2-linux-arm64": "f201f6ba4136f1129e99e6318af07900c0c16a92030648bd186ff27067b34568"
+    }
+  }
+}

--- a/packages/server/src/services/forge-registry.test.ts
+++ b/packages/server/src/services/forge-registry.test.ts
@@ -1,7 +1,13 @@
 import { FORGE_IDS } from "@getpaseo/protocol/forge-manifest";
+import pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 
-import { createForgeService, defaultForgeRegistry, ForgeRegistry } from "./forge-registry.js";
+import {
+  createForgeService,
+  defaultForgeRegistry,
+  ForgeRegistry,
+  type ForgeServiceContext,
+} from "./forge-registry.js";
 import { createGitHubService } from "./github-service.js";
 
 describe("forge registry", () => {
@@ -20,6 +26,31 @@ describe("forge registry", () => {
 
   it("returns null for an unregistered forge", () => {
     expect(createForgeService("bitbucket")).toBeNull();
+  });
+
+  it("threads the daemon context (paseoHome/logger/toolsDir) into an adapter's factory", () => {
+    let receivedContext: ForgeServiceContext | undefined;
+    const registry = new ForgeRegistry([
+      [
+        "contextual",
+        {
+          createService: (context) => {
+            receivedContext = context;
+            return createGitHubService();
+          },
+        },
+      ],
+    ]);
+
+    const context: ForgeServiceContext = {
+      paseoHome: "/tmp/paseo-home",
+      logger: pino({ level: "silent" }),
+      toolsDir: "/tmp/paseo-home/tools",
+      forgeCliAutoInstall: false,
+    };
+    registry.create("contextual", context);
+
+    expect(receivedContext).toBe(context);
   });
 
   it("keeps the built-in registry in sync with the forge manifest", () => {

--- a/packages/server/src/services/forge-registry.ts
+++ b/packages/server/src/services/forge-registry.ts
@@ -1,11 +1,27 @@
+import type pino from "pino";
 import { getForgeDefinition } from "@getpaseo/protocol/forge-manifest";
 import { normalizeHost } from "@getpaseo/protocol/git-remote";
+import { resolveForgeCliPath } from "./forge-cli/forge-cli-autoinstall-default.js";
+import type { ForgeCliId } from "./forge-cli/forge-cli-catalog.js";
 import { createGitHubService, probeGitHubHost } from "./github-service.js";
 import type { ForgeService } from "./forge-service.js";
 import { createGiteaService, resolveGiteaFamilyForge } from "./gitea-service.js";
 import { createGitLabService, probeGitLabHost } from "./gitlab-service.js";
 
-export type ForgeServiceFactory = () => ForgeService;
+/**
+ * Real daemon config (paseoHome/logger/auto-install flag), passed down to
+ * each adapter's CLI resolver so it doesn't fall back to module-level
+ * defaults. Optional because createForgeService("gitlab") with no context
+ * still works, it just uses ensureForgeCliWithDefaults's own fallbacks.
+ */
+export interface ForgeServiceContext {
+  paseoHome: string;
+  logger: pino.Logger;
+  toolsDir?: string;
+  forgeCliAutoInstall?: boolean;
+}
+
+export type ForgeServiceFactory = (context?: ForgeServiceContext) => ForgeService;
 
 export interface ForgeAdapterRegistration {
   createService: ForgeServiceFactory;
@@ -52,13 +68,13 @@ export class ForgeRegistry {
     return normalizedForge ? this.#adapters.has(normalizedForge) : false;
   }
 
-  create(forge: string): ForgeService | null {
+  create(forge: string, context?: ForgeServiceContext): ForgeService | null {
     const normalizedForge = parseForgeId(forge);
     if (!normalizedForge) {
       return null;
     }
     const adapter = this.#adapters.get(normalizedForge);
-    return adapter ? adapter.createService() : null;
+    return adapter ? adapter.createService(context) : null;
   }
 
   matchHost(host: string): string | null {
@@ -130,6 +146,22 @@ function matchesCloudHost(forgeId: string): ((host: string) => boolean) | undefi
   return (host) => normalized.has(normalizeHost(host));
 }
 
+// Wraps resolveForgeCliPath (the single PATH-then-install resolver, shared
+// with github-service.ts/gitlab-service.ts/gitea-service.ts's own bare
+// resolveXPath fallbacks) with whatever context this registry call has.
+function resolveCliPathWithAutoInstall(
+  cli: ForgeCliId,
+  context: ForgeServiceContext | undefined,
+): () => Promise<string | null> {
+  return () =>
+    resolveForgeCliPath(cli, {
+      paseoHome: context?.paseoHome,
+      logger: context?.logger,
+      toolsDir: context?.toolsDir,
+      autoInstallEnabled: context?.forgeCliAutoInstall,
+    });
+}
+
 export const defaultForgeRegistry = new ForgeRegistry([
   // GitHub Enterprise Server is recognized at runtime by probeHost, exactly like
   // self-hosted GitLab/Gitea: github.com short-circuits via matchHost, so the
@@ -138,7 +170,8 @@ export const defaultForgeRegistry = new ForgeRegistry([
   [
     "github",
     {
-      createService: createGitHubService,
+      createService: (context) =>
+        createGitHubService({ resolveGhPath: resolveCliPathWithAutoInstall("gh", context) }),
       matchesHost: matchesCloudHost("github"),
       probeHost: probeGitHubHost,
     },
@@ -146,7 +179,8 @@ export const defaultForgeRegistry = new ForgeRegistry([
   [
     "gitlab",
     {
-      createService: createGitLabService,
+      createService: (context) =>
+        createGitLabService({ resolveGlabPath: resolveCliPathWithAutoInstall("glab", context) }),
       matchesHost: matchesCloudHost("gitlab"),
       probeHost: probeGitLabHost,
     },
@@ -154,7 +188,8 @@ export const defaultForgeRegistry = new ForgeRegistry([
   [
     "gitea",
     {
-      createService: createGiteaService,
+      createService: (context) =>
+        createGiteaService({ resolveTeaPath: resolveCliPathWithAutoInstall("tea", context) }),
       matchesHost: matchesCloudHost("gitea"),
       probeHost: async (host) => (await resolveGiteaFamilyForge(host)) === "gitea",
     },
@@ -162,15 +197,26 @@ export const defaultForgeRegistry = new ForgeRegistry([
   [
     "forgejo",
     {
-      createService: createGiteaService,
+      createService: (context) =>
+        createGiteaService({ resolveTeaPath: resolveCliPathWithAutoInstall("tea", context) }),
       probeHost: async (host) => (await resolveGiteaFamilyForge(host)) === "forgejo",
     },
   ],
-  ["codeberg", { createService: createGiteaService, matchesHost: matchesCloudHost("codeberg") }],
+  [
+    "codeberg",
+    {
+      createService: (context) =>
+        createGiteaService({ resolveTeaPath: resolveCliPathWithAutoInstall("tea", context) }),
+      matchesHost: matchesCloudHost("codeberg"),
+    },
+  ],
 ]);
 
-export function createForgeService(forge: string): ForgeService | null {
-  return defaultForgeRegistry.create(forge);
+export function createForgeService(
+  forge: string,
+  context?: ForgeServiceContext,
+): ForgeService | null {
+  return defaultForgeRegistry.create(forge, context);
 }
 
 export function probeRegisteredForgeHost(host: string): Promise<string | null> {

--- a/packages/server/src/services/gitea-service.ts
+++ b/packages/server/src/services/gitea-service.ts
@@ -4,6 +4,7 @@ import { parseGitHubRemoteIdentity, parseGitRemoteLocation } from "@getpaseo/pro
 import { findExecutable } from "../executable-resolution/executable-resolution.js";
 import { runGitCommand } from "../utils/run-git-command.js";
 import { execCommand } from "../utils/spawn.js";
+import { resolveForgeCliPath } from "./forge-cli/forge-cli-autoinstall-default.js";
 import {
   createCachedCliPathResolver,
   createForgeCliRunner,
@@ -368,7 +369,7 @@ interface GiteaTimelineBucket<T> {
 }
 
 async function resolveTeaPath(): Promise<string | null> {
-  return findExecutable("tea");
+  return resolveForgeCliPath("tea");
 }
 
 const teaCliRunner = createForgeCliRunner({

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -8,6 +8,7 @@ import { findExecutable } from "../executable-resolution/executable-resolution.j
 import { runGitCommand } from "../utils/run-git-command.js";
 import { execCommand } from "../utils/spawn.js";
 import { resolveSshHostname } from "../utils/ssh-hostname.js";
+import { resolveForgeCliPath } from "./forge-cli/forge-cli-autoinstall-default.js";
 import {
   CLI_AUTH_PROBE_TIMEOUT_MS,
   createForgeCliRunner,
@@ -1710,7 +1711,7 @@ function isGitHubStatusPending(status: CurrentPullRequestStatus | null): boolean
 }
 
 async function resolveGhPath(): Promise<string | null> {
-  return findExecutable("gh");
+  return resolveForgeCliPath("gh");
 }
 
 /**

--- a/packages/server/src/services/gitlab-service.ts
+++ b/packages/server/src/services/gitlab-service.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { parseGitRemoteLocation } from "@getpaseo/protocol/git-remote";
-import { findExecutable } from "../executable-resolution/executable-resolution.js";
+import { resolveForgeCliPath } from "./forge-cli/forge-cli-autoinstall-default.js";
 import {
   createCachedCliPathResolver,
   createForgeCliRunner,
@@ -256,7 +256,7 @@ type GitLabApprovals = z.infer<typeof GitLabApprovalsSchema>;
 const TIMELINE_PAGE_SIZE = 100;
 
 async function resolveGlabPath(): Promise<string | null> {
-  return findExecutable("glab");
+  return resolveForgeCliPath("glab");
 }
 
 const glabCliRunner = createForgeCliRunner({

--- a/public-docs/docker.md
+++ b/public-docs/docker.md
@@ -95,6 +95,14 @@ docker exec -it --user paseo paseo claude
 
 Agent credentials persist in `/home/paseo`.
 
+## Git forge CLIs
+
+Forge features (PR/MR status, create, merge, CI checks) need the matching CLI: `gh` for GitHub, `glab` for GitLab, `tea` for Gitea, Forgejo, and Codeberg. The base image doesn't bundle these either, but the daemon downloads the official release binary itself the first time a forge feature needs one, no separate install step required. This is a container-only feature, `linux/amd64` and `linux/arm64` only.
+
+The downloaded binary is cached under `/home/paseo/.paseo/tools`, so it persists across restarts and downloads once. A CLI already on `PATH` (from a child image or a host mount) always takes priority over auto-install.
+
+Disable this with `PASEO_FORGE_CLI_AUTOINSTALL: "0"` in `compose.environment`, and install the CLI yourself in a child image for offline or air-gapped setups.
+
 ## Volumes
 
 Mount two paths for most deployments:
@@ -160,5 +168,6 @@ See [Security](/docs/security) for the full daemon trust model.
 - **The UI loads but cannot connect:** if `PASEO_PASSWORD` is set, add a direct connection with the same password.
 - **403 Host not allowed:** set `PASEO_HOSTNAMES` to the DNS names you use.
 - **Provider not available:** install that agent CLI in a child image or make sure the binary is on `PATH`.
+- **Forge CLI (`gh`/`glab`/`tea`) not available:** the daemon auto-installs it on first use unless `PASEO_FORGE_CLI_AUTOINSTALL=0` is set, or your platform isn't covered yet (`linux/amd64` and `linux/arm64` only, for now). Check `docker logs paseo` for the download attempt.
 - **Permission errors in `/workspace`:** make the mounted directory writable by uid/gid `1000:1000`, or run the container as the host uid/gid.
 - **Logs:** run `docker logs paseo`, or inspect `/home/paseo/.paseo/daemon.log` inside the container.

--- a/scripts/update-forge-cli-versions.mjs
+++ b/scripts/update-forge-cli-versions.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Checks gh/glab/tea for new releases and refreshes the pinned version +
+// sha256 checksums in packages/server/src/services/forge-cli/forge-cli-versions.json.
+// Companion to scripts/update-nix.sh but for the forge CLI auto-installer
+// instead of the Nix build hash.
+//
+// Usage:
+//   node scripts/update-forge-cli-versions.mjs
+//
+// Exits 0 whether or not anything changed -- the caller (CI workflow) diffs
+// the file itself to decide whether to commit. One CLI's API being down
+// doesn't block updating the other two; failures are logged and skipped.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VERSIONS_PATH = path.join(
+  __dirname,
+  "..",
+  "packages/server/src/services/forge-cli/forge-cli-versions.json",
+);
+
+const ASSET_ARCHES = ["linux_amd64", "linux_arm64"];
+
+async function fetchJson(url, headers) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`GET ${url}: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+async function fetchText(url, headers) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`GET ${url}: ${res.status} ${res.statusText}`);
+  }
+  return res.text();
+}
+
+// Parses "sha256  filename" lines (two spaces, as gh/glab publish them).
+function parseChecksumsFile(text) {
+  const byFilename = new Map();
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^([a-f0-9]{64})\s+(.+)$/i);
+    if (!match) continue;
+    byFilename.set(match[2], match[1].toLowerCase());
+  }
+  return byFilename;
+}
+
+function pickLinuxChecksums(byFilename) {
+  const picked = {};
+  for (const [filename, sha256] of byFilename) {
+    if (ASSET_ARCHES.some((arch) => filename.includes(arch))) {
+      picked[filename] = sha256;
+    }
+  }
+  return picked;
+}
+
+async function updateGh(current) {
+  const release = await fetchJson("https://api.github.com/repos/cli/cli/releases/latest", {
+    Accept: "application/vnd.github+json",
+  });
+  const version = release.tag_name.replace(/^v/, "");
+  if (version === current?.version) {
+    console.log(`gh: up to date (${version})`);
+    return current;
+  }
+
+  const checksumsAsset = release.assets.find((a) => a.name === `gh_${version}_checksums.txt`);
+  if (!checksumsAsset) {
+    throw new Error(`gh ${version}: no checksums.txt asset found`);
+  }
+  const text = await fetchText(checksumsAsset.browser_download_url);
+  const checksums = pickLinuxChecksums(parseChecksumsFile(text));
+
+  console.log(`gh: ${current?.version ?? "(none)"} -> ${version}`);
+  return { version, checksums };
+}
+
+async function updateGlab(current) {
+  const release = await fetchJson(
+    "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest",
+  );
+  const version = release.tag_name.replace(/^v/, "");
+  if (version === current?.version) {
+    console.log(`glab: up to date (${version})`);
+    return current;
+  }
+
+  const checksumsLink = release.assets.links.find((a) => a.name === "checksums.txt");
+  if (!checksumsLink) {
+    throw new Error(`glab ${version}: no checksums.txt asset link found`);
+  }
+  const text = await fetchText(checksumsLink.direct_asset_url);
+  const checksums = pickLinuxChecksums(parseChecksumsFile(text));
+
+  console.log(`glab: ${current?.version ?? "(none)"} -> ${version}`);
+  return { version, checksums };
+}
+
+async function updateTea(current) {
+  const release = await fetchJson("https://gitea.com/api/v1/repos/gitea/tea/releases/latest");
+  const version = release.tag_name.replace(/^v/, "");
+  if (version === current?.version) {
+    console.log(`tea: up to date (${version})`);
+    return current;
+  }
+
+  // Older tea releases only published per-binary ".sha256" sidecars.
+  // Current releases (0.14.x+) also publish a combined checksums.txt
+  // covering the bare linux binaries directly -- same format as gh/glab,
+  // so reuse the same parser instead of the sidecar convention.
+  const checksumsAsset = release.assets.find((a) => a.name === "checksums.txt");
+  if (!checksumsAsset) {
+    throw new Error(`tea ${version}: no checksums.txt asset found`);
+  }
+  const text = await fetchText(checksumsAsset.browser_download_url);
+  const byFilename = parseChecksumsFile(text);
+  const checksums = {};
+  for (const arch of ["amd64", "arm64"]) {
+    const binaryName = `tea-${version}-linux-${arch}`;
+    const sha256 = byFilename.get(binaryName);
+    if (!sha256) {
+      throw new Error(`tea ${version}: no checksum for ${binaryName} in checksums.txt`);
+    }
+    checksums[binaryName] = sha256;
+  }
+
+  console.log(`tea: ${current?.version ?? "(none)"} -> ${version}`);
+  return { version, checksums };
+}
+
+async function main() {
+  const raw = await fs.readFile(VERSIONS_PATH, "utf8");
+  const current = JSON.parse(raw);
+
+  const updaters = [
+    ["gh", updateGh],
+    ["glab", updateGlab],
+    ["tea", updateTea],
+  ];
+
+  const result = { ...current };
+  for (const [cli, updater] of updaters) {
+    try {
+      result[cli] = await updater(current[cli]);
+    } catch (error) {
+      console.error(`${cli}: failed to check for updates: ${error.message}`);
+    }
+  }
+
+  // Preserve stable key ordering so the diff stays minimal.
+  const ordered = { gh: result.gh, glab: result.glab, tea: result.tea };
+  await fs.writeFile(VERSIONS_PATH, `${JSON.stringify(ordered, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

- https://github.com/getpaseo/paseo/issues/1616#issuecomment-5004619100
- https://github.com/getpaseo/paseo/discussions/2230
- https://github.com/getpaseo/paseo/pull/1913

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

#1913 added pluggable forge support (GitLab via `glab`, Gitea/Forgejo/Codeberg via `tea`, GitHub via `gh`).
However, this PR didn't add a way to actually get the binaries.
Anyone running Paseo against a self-hosted GitLab/Gitea/Forgejo instance in the container got a forge with no working CLI behind it.

This auto-installs the missing CLI when a container starts and the resolver can't find it on PATH:

- Downloads gh/glab/tea into `$PASEO_HOME/tools/<cli>/<cli>` (namespaced per CLI to avoid collisions) instead of requiring a Dockerfile change per CLI
- Verifies a pinned checksum before chmod/exec
- Gated behind `PASEO_FORGE_CLI_AUTOINSTALL` (default true) and container-only/Linux only
- Versions and checksums live in `forge-cli-versions.json`
- `scripts/update-forge-cli-versions.mjs` checks the three release APIs and refreshes stale entries
- a weekly CI workflow (`update-forge-cli-versions.yml` similar to the `nix-update-hash.yml` bot-commit pattern) runs it and auto-commits

### How did you verify it

- `npx vitest run packages/server/src/services/forge-cli`
- Ran `scripts/update-forge-cli-versions.mjs` live against the real gh/glab/tea release APIs
- `npm run typecheck` and `npm run lint` clean

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
