### PR TITLE
fix: download files over the active relay connection

### DIFF
--- a/packages/app/src/hooks/use-file-download.ts
+++ b/packages/app/src/hooks/use-file-download.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { useHosts } from "@/runtime/host-runtime";
+import { useHosts, useHostRuntimeSnapshot } from "@/runtime/host-runtime";
 import { useDownloadStore } from "@/stores/download-store";
 import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
 
@@ -25,12 +25,13 @@ export function useFileDownload({
     () => daemons.find((daemon) => daemon.serverId === serverId),
     [daemons, serverId],
   );
+  const runtime = useHostRuntimeSnapshot(serverId);
   const normalizedWorkspaceRoot = useMemo(() => workspaceRoot.trim(), [workspaceRoot]);
   const workspaceScopeId = useMemo(
     () => workspaceId?.trim() || normalizedWorkspaceRoot,
     [normalizedWorkspaceRoot, workspaceId],
   );
-  const { requestFileDownloadToken } = useFileExplorerActions({
+  const { requestFileBytes, requestFileDownloadToken } = useFileExplorerActions({
     serverId,
     workspaceId,
     workspaceRoot: normalizedWorkspaceRoot,
@@ -48,9 +49,22 @@ export function useFileDownload({
         fileName,
         path,
         daemonProfile,
+        activeConnectionId: runtime?.activeConnectionId ?? null,
+        supportsRelayFileDownloads:
+          runtime?.client?.getLastServerInfoMessage()?.features?.relayFileDownloads === true,
         requestFileDownloadToken: (targetPath) => requestFileDownloadToken(targetPath),
+        requestFileBytes: (targetPath) => requestFileBytes(targetPath),
       });
     },
-    [daemonProfile, requestFileDownloadToken, serverId, startDownload, workspaceScopeId],
+    [
+      daemonProfile,
+      requestFileBytes,
+      requestFileDownloadToken,
+      runtime?.activeConnectionId,
+      runtime?.client,
+      serverId,
+      startDownload,
+      workspaceScopeId,
+    ],
   );
 }

--- a/packages/app/src/hooks/use-file-explorer-actions.ts
+++ b/packages/app/src/hooks/use-file-explorer-actions.ts
@@ -248,6 +248,19 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
     [client, normalizedWorkspaceRoot, t],
   );
 
+  const requestFileBytes = useCallback(
+    async (path: string) => {
+      if (!normalizedWorkspaceRoot) {
+        throw new Error(t("workspace.fileExplorer.states.unavailable"));
+      }
+      if (!client) {
+        throw new Error(t("workspace.terminal.hostDisconnected"));
+      }
+      return client.readFile(normalizedWorkspaceRoot, path);
+    },
+    [client, normalizedWorkspaceRoot, t],
+  );
+
   const selectExplorerEntry = useCallback(
     (path: string | null) => {
       updateExplorerState((state) => ({
@@ -263,6 +276,7 @@ export function useFileExplorerActions(params: { serverId: string } & FileExplor
     requestDirectoryListing,
     requestFilePreview,
     requestFileDownloadToken,
+    requestFileBytes,
     selectExplorerEntry,
   };
 }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1447,6 +1447,8 @@ export const ar: TranslationResources = {
   downloads: {
     requestTokenFailed: "فشل طلب رمز التنزيل.",
     hostUnavailable: "مضيف التنزيل غير متاح.",
+    relayFileTooLarge:
+      "This file is too large to download through the relay (max {{size}}). Add a direct connection to download it.",
     cancelled: "تم إلغاء التنزيل.",
     failed: "فشل تنزيل الملف.",
     shareFile: "مشاركة الملف",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1458,6 +1458,8 @@ export const en = {
   downloads: {
     requestTokenFailed: "Failed to request download token.",
     hostUnavailable: "Download host is unavailable.",
+    relayFileTooLarge:
+      "This file is too large to download through the relay (max {{size}}). Add a direct connection to download it.",
     cancelled: "Download was cancelled.",
     failed: "Failed to download file.",
     shareFile: "Share file",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1490,6 +1490,8 @@ export const es: TranslationResources = {
   downloads: {
     requestTokenFailed: "No se pudo solicitar el token de descarga.",
     hostUnavailable: "El host de descarga no está disponible.",
+    relayFileTooLarge:
+      "This file is too large to download through the relay (max {{size}}). Add a direct connection to download it.",
     cancelled: "La descarga fue cancelada.",
     failed: "No se pudo descargar el archivo.",
     shareFile: "compartir archivo",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1493,6 +1493,8 @@ export const fr: TranslationResources = {
   downloads: {
     requestTokenFailed: "Échec de la demande du jeton de téléchargement.",
     hostUnavailable: "L'hôte de téléchargement n'est pas disponible.",
+    relayFileTooLarge:
+      "This file is too large to download through the relay (max {{size}}). Add a direct connection to download it.",
     cancelled: "Le téléchargement a été annulé.",
     failed: "Échec du téléchargement du fichier.",
     shareFile: "Partager un fichier",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1463,6 +1463,8 @@ export const ja: TranslationResources = {
   downloads: {
     requestTokenFailed: "ダウンロードトークンのリクエストに失敗しました。",
     hostUnavailable: "ダウンロードホストが利用できません。",
+    relayFileTooLarge:
+      "This file is too large to download through the relay (max {{size}}). Add a direct connection to download it.",
     cancelled: "ダウンロードがキャンセルされました。",
     failed: "ファイルのダウンロードに失敗しました。",
     shareFile: "ファイルを共有",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1476,6 +1476,8 @@ export const ptBR: TranslationResources = {
   downloads: {
     requestTokenFailed: "Falha ao solicitar token de download.",
     hostUnavailable: "Host de download indisponível.",
+    relayFileTooLarge:
+      "This file is too large to download through the relay (max {{size}}). Add a direct connection to download it.",
     cancelled: "Download cancelado.",
     failed: "Falha ao baixar arquivo.",
     shareFile: "Compartilhar arquivo",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1481,6 +1481,8 @@ export const ru: TranslationResources = {
   downloads: {
     requestTokenFailed: "Не удалось запросить токен загрузки.",
     hostUnavailable: "Хост загрузки недоступен.",
+    relayFileTooLarge:
+      "This file is too large to download through the relay (max {{size}}). Add a direct connection to download it.",
     cancelled: "Загрузка отменена.",
     failed: "Не удалось загрузить файл.",
     shareFile: "Поделиться файлом",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1428,6 +1428,7 @@ export const zhCN: TranslationResources = {
   downloads: {
     requestTokenFailed: "请求下载 token 失败。",
     hostUnavailable: "下载 Host 不可用。",
+    relayFileTooLarge: "此文件太大，无法通过 relay 下载（最大 {{size}}）。请添加直连后再下载。",
     cancelled: "下载已取消。",
     failed: "下载文件失败。",
     shareFile: "共享文件",

--- a/packages/app/src/stores/download-store.test.ts
+++ b/packages/app/src/stores/download-store.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { HostProfile } from "@/types/host-connection";
+
+vi.mock("expo-file-system", () => ({
+  File: class {
+    exists = false;
+    uri = "file:///tmp/download";
+    write = vi.fn();
+  },
+  Paths: {
+    cache: "file:///tmp",
+    document: "file:///tmp",
+  },
+}));
+
+vi.mock("expo-file-system/legacy", () => ({
+  createDownloadResumable: vi.fn(),
+}));
+
+vi.mock("expo-sharing", () => ({
+  isAvailableAsync: vi.fn(async () => false),
+  shareAsync: vi.fn(),
+}));
+
+import { MAX_RELAY_DOWNLOAD_BYTES, useDownloadStore } from "./download-store";
+
+const profile: HostProfile = {
+  serverId: "server-1",
+  label: "Test server",
+  lifecycle: {},
+  connections: [
+    {
+      id: "direct:localhost:6767",
+      type: "directTcp",
+      endpoint: "localhost:6767",
+    },
+    {
+      id: "relay:relay.paseo.sh",
+      type: "relay",
+      relayEndpoint: "relay.paseo.sh",
+      daemonPublicKeyB64: "public-key",
+    },
+  ],
+  preferredConnectionId: "direct:localhost:6767",
+  createdAt: "2026-07-25T00:00:00.000Z",
+  updatedAt: "2026-07-25T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.restoreAllMocks();
+  vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:relay-download");
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+  useDownloadStore.setState({
+    downloads: new Map(),
+    activeDownloadId: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("download store relay fallback", () => {
+  test("uses relay bytes when the active connection is relay even if localhost is configured", async () => {
+    const requestFileBytes = vi.fn(async () => ({
+      bytes: new TextEncoder().encode("# Index"),
+      mime: "text/markdown",
+      size: 7,
+    }));
+
+    await useDownloadStore.getState().startDownload({
+      serverId: "server-1",
+      scopeId: "workspace-1",
+      fileName: "INDEX.md",
+      path: "INDEX.md",
+      daemonProfile: profile,
+      activeConnectionId: "relay:relay.paseo.sh",
+      supportsRelayFileDownloads: true,
+      requestFileDownloadToken: vi.fn(async () => ({
+        token: "unused-relay-token",
+        fileName: "INDEX.md",
+        mimeType: "text/markdown",
+        size: 7,
+        error: null,
+      })),
+      requestFileBytes,
+    });
+
+    expect(requestFileBytes).toHaveBeenCalledWith("INDEX.md");
+    expect([...useDownloadStore.getState().downloads.values()][0]?.status).toBe("complete");
+    expect(URL.createObjectURL).toHaveBeenCalledOnce();
+  });
+
+  test("keeps direct HTTP downloads on the active direct connection", async () => {
+    const requestFileBytes = vi.fn();
+
+    await useDownloadStore.getState().startDownload({
+      serverId: "server-1",
+      scopeId: "workspace-1",
+      fileName: "INDEX.md",
+      path: "INDEX.md",
+      daemonProfile: profile,
+      activeConnectionId: "direct:localhost:6767",
+      supportsRelayFileDownloads: true,
+      requestFileDownloadToken: vi.fn(async () => ({
+        token: "direct-token",
+        fileName: "INDEX.md",
+        mimeType: "text/markdown",
+        size: 7,
+        error: null,
+      })),
+      requestFileBytes,
+    });
+
+    expect(requestFileBytes).not.toHaveBeenCalled();
+    expect([...useDownloadStore.getState().downloads.values()][0]?.status).toBe("complete");
+  });
+
+  test("rejects oversized relay downloads before requesting file bytes", async () => {
+    const requestFileBytes = vi.fn();
+
+    await useDownloadStore.getState().startDownload({
+      serverId: "server-1",
+      scopeId: "workspace-1",
+      fileName: "archive.zip",
+      path: "archive.zip",
+      daemonProfile: profile,
+      activeConnectionId: "relay:relay.paseo.sh",
+      supportsRelayFileDownloads: true,
+      requestFileDownloadToken: vi.fn(async () => ({
+        token: "unused-relay-token",
+        fileName: "archive.zip",
+        mimeType: "application/zip",
+        size: MAX_RELAY_DOWNLOAD_BYTES + 1,
+        error: null,
+      })),
+      requestFileBytes,
+    });
+
+    expect(requestFileBytes).not.toHaveBeenCalled();
+    const result = [...useDownloadStore.getState().downloads.values()][0];
+    expect(result?.status).toBe("error");
+    expect(result?.message).toContain("32 MB");
+  });
+});

--- a/packages/app/src/stores/download-store.ts
+++ b/packages/app/src/stores/download-store.ts
@@ -37,12 +37,10 @@ interface DownloadState {
     fileName: string;
     path: string;
     daemonProfile: HostProfile | undefined;
-    requestFileDownloadToken: (path: string) => Promise<{
-      token: string | null;
-      fileName: string | null;
-      mimeType: string | null;
-      error: string | null;
-    }>;
+    activeConnectionId: string | null;
+    supportsRelayFileDownloads: boolean;
+    requestFileDownloadToken: (path: string) => Promise<DownloadTokenResult>;
+    requestFileBytes: (path: string) => Promise<RelayFileResult>;
   }) => Promise<void>;
 
   updateProgress: (id: string, progress: DownloadProgress) => void;
@@ -52,9 +50,27 @@ interface DownloadState {
   dismissAllCompleted: () => void;
 }
 
+interface DownloadTokenResult {
+  token: string | null;
+  fileName: string | null;
+  mimeType: string | null;
+  size: number | null;
+  error: string | null;
+}
+
+interface RelayFileResult {
+  bytes: Uint8Array;
+  mime: string;
+  size: number;
+}
+
 function generateDownloadId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
+
+// The existing binary read API assembles the file in memory on both peers.
+// Keep relay fallback bounded until the protocol grows a streaming download sink.
+export const MAX_RELAY_DOWNLOAD_BYTES = 32 * 1024 * 1024;
 
 export const useDownloadStore = create<DownloadState>()((set, get) => ({
   downloads: new Map(),
@@ -66,7 +82,10 @@ export const useDownloadStore = create<DownloadState>()((set, get) => ({
     fileName,
     path,
     daemonProfile,
+    activeConnectionId,
+    supportsRelayFileDownloads,
     requestFileDownloadToken,
+    requestFileBytes,
   }) => {
     const id = generateDownloadId();
     const download: Download = {
@@ -89,71 +108,35 @@ export const useDownloadStore = create<DownloadState>()((set, get) => ({
         throw new Error(tokenResponse.error ?? i18n.t("downloads.requestTokenFailed"));
       }
 
-      const downloadTarget = resolveDaemonDownloadTarget(daemonProfile);
-      if (!downloadTarget.baseUrl) {
-        throw new Error(i18n.t("downloads.hostUnavailable"));
-      }
-
       const resolvedFileName = tokenResponse.fileName ?? fileName;
-      const downloadUrl = buildDownloadUrl(
-        downloadTarget.baseUrl,
-        tokenResponse.token,
-        isWeb ? downloadTarget.authCredentials : null,
-      );
-
-      if (isWeb) {
-        triggerBrowserDownload(downloadUrl, resolvedFileName);
+      const downloadTarget = resolveDaemonDownloadTarget(daemonProfile, activeConnectionId);
+      if (!downloadTarget.baseUrl) {
+        const bytesWritten = await downloadViaRelay({
+          path,
+          fileName: resolvedFileName,
+          tokenResponse,
+          supportsRelayFileDownloads,
+          requestFileBytes,
+        });
+        get().updateProgress(id, {
+          percent: 1,
+          bytesWritten,
+          totalBytes: bytesWritten,
+          speed: 0,
+          eta: 0,
+        });
         get().completeDownload(id);
         return;
       }
 
-      const downloadStartTime = Date.now();
-      const targetFile = resolveDownloadTargetFile(resolvedFileName);
-      const downloadResumable = LegacyFileSystem.createDownloadResumable(
-        downloadUrl,
-        targetFile.uri,
-        downloadTarget.authHeader
-          ? { headers: { Authorization: downloadTarget.authHeader } }
-          : undefined,
-        (data) => {
-          const now = Date.now();
-          const { totalBytesWritten, totalBytesExpectedToWrite } = data;
-
-          if (totalBytesExpectedToWrite <= 0) {
-            return;
-          }
-
-          const percent = totalBytesWritten / totalBytesExpectedToWrite;
-          const elapsed = (now - downloadStartTime) / 1000;
-          const speed = elapsed > 0 ? totalBytesWritten / elapsed : 0;
-          const remaining = totalBytesExpectedToWrite - totalBytesWritten;
-          const eta = speed > 0 ? remaining / speed : 0;
-
-          get().updateProgress(id, {
-            percent,
-            bytesWritten: totalBytesWritten,
-            totalBytes: totalBytesExpectedToWrite,
-            speed,
-            eta,
-          });
-        },
-      );
-
-      const result = await downloadResumable.downloadAsync();
-      if (!result) {
-        throw new Error(i18n.t("downloads.cancelled"));
-      }
-
+      await downloadViaDirect({
+        target: { ...downloadTarget, baseUrl: downloadTarget.baseUrl },
+        token: tokenResponse.token,
+        fileName: resolvedFileName,
+        mimeType: tokenResponse.mimeType,
+        onProgress: (progress) => get().updateProgress(id, progress),
+      });
       get().completeDownload(id);
-
-      if (await Sharing.isAvailableAsync()) {
-        await Sharing.shareAsync(result.uri, {
-          mimeType: tokenResponse.mimeType ?? undefined,
-          dialogTitle: resolvedFileName
-            ? i18n.t("downloads.shareFileNamed", { fileName: resolvedFileName })
-            : i18n.t("downloads.shareFile"),
-        });
-      }
     } catch (error) {
       const message = error instanceof Error ? error.message : i18n.t("downloads.failed");
       if (isWeb) {
@@ -244,8 +227,13 @@ interface DownloadTarget {
   authCredentials: { username: string; password: string } | null;
 }
 
-function resolveDaemonDownloadTarget(daemon?: HostProfile): DownloadTarget {
-  const connection = daemon?.connections.find((conn) => conn.type === "directTcp") ?? null;
+function resolveDaemonDownloadTarget(
+  daemon: HostProfile | undefined,
+  activeConnectionId: string | null,
+): DownloadTarget {
+  const activeConnection =
+    daemon?.connections.find((connection) => connection.id === activeConnectionId) ?? null;
+  const connection = activeConnection?.type === "directTcp" ? activeConnection : null;
   if (!connection) {
     return { baseUrl: null, authHeader: null, authCredentials: null };
   }
@@ -299,6 +287,101 @@ function buildDownloadUrl(
   return url.toString();
 }
 
+async function downloadViaRelay(input: {
+  path: string;
+  fileName: string;
+  tokenResponse: DownloadTokenResult;
+  supportsRelayFileDownloads: boolean;
+  requestFileBytes: (path: string) => Promise<RelayFileResult>;
+}): Promise<number> {
+  if (!input.supportsRelayFileDownloads) {
+    throw new Error(i18n.t("downloads.hostUnavailable"));
+  }
+  assertRelayDownloadSize(input.tokenResponse.size);
+
+  const relayFile = await input.requestFileBytes(input.path);
+  assertRelayDownloadSize(relayFile.bytes.byteLength);
+  const mimeType = input.tokenResponse.mimeType ?? relayFile.mime;
+
+  if (isWeb) {
+    triggerBrowserByteDownload(relayFile.bytes, mimeType, input.fileName);
+    return relayFile.bytes.byteLength;
+  }
+
+  const targetFile = resolveDownloadTargetFile(input.fileName);
+  targetFile.write(relayFile.bytes);
+  await shareDownloadedFile(targetFile.uri, input.fileName, mimeType);
+  return relayFile.bytes.byteLength;
+}
+
+async function downloadViaDirect(input: {
+  target: DownloadTarget & { baseUrl: string };
+  token: string;
+  fileName: string;
+  mimeType: string | null;
+  onProgress: (progress: DownloadProgress) => void;
+}): Promise<void> {
+  const downloadUrl = buildDownloadUrl(
+    input.target.baseUrl,
+    input.token,
+    isWeb ? input.target.authCredentials : null,
+  );
+  if (isWeb) {
+    triggerBrowserDownload(downloadUrl, input.fileName);
+    return;
+  }
+
+  const downloadStartTime = Date.now();
+  const targetFile = resolveDownloadTargetFile(input.fileName);
+  const downloadResumable = LegacyFileSystem.createDownloadResumable(
+    downloadUrl,
+    targetFile.uri,
+    input.target.authHeader ? { headers: { Authorization: input.target.authHeader } } : undefined,
+    ({ totalBytesWritten, totalBytesExpectedToWrite }) => {
+      if (totalBytesExpectedToWrite <= 0) return;
+      const elapsed = (Date.now() - downloadStartTime) / 1000;
+      const speed = elapsed > 0 ? totalBytesWritten / elapsed : 0;
+      input.onProgress({
+        percent: totalBytesWritten / totalBytesExpectedToWrite,
+        bytesWritten: totalBytesWritten,
+        totalBytes: totalBytesExpectedToWrite,
+        speed,
+        eta: speed > 0 ? (totalBytesExpectedToWrite - totalBytesWritten) / speed : 0,
+      });
+    },
+  );
+
+  const result = await downloadResumable.downloadAsync();
+  if (!result) {
+    throw new Error(i18n.t("downloads.cancelled"));
+  }
+  await shareDownloadedFile(result.uri, input.fileName, input.mimeType);
+}
+
+function assertRelayDownloadSize(size: number | null): void {
+  if (size !== null && size > MAX_RELAY_DOWNLOAD_BYTES) {
+    throw new Error(
+      i18n.t("downloads.relayFileTooLarge", {
+        size: formatFileSize(MAX_RELAY_DOWNLOAD_BYTES),
+      }),
+    );
+  }
+}
+
+async function shareDownloadedFile(
+  uri: string,
+  fileName: string,
+  mimeType: string | null,
+): Promise<void> {
+  if (!(await Sharing.isAvailableAsync())) return;
+  await Sharing.shareAsync(uri, {
+    mimeType: mimeType ?? undefined,
+    dialogTitle: fileName
+      ? i18n.t("downloads.shareFileNamed", { fileName })
+      : i18n.t("downloads.shareFile"),
+  });
+}
+
 function triggerBrowserDownload(url: string, fileName: string) {
   if (typeof document === "undefined") {
     if (typeof window !== "undefined") {
@@ -314,6 +397,13 @@ function triggerBrowserDownload(url: string, fileName: string) {
   document.body.appendChild(link);
   link.click();
   link.remove();
+}
+
+function triggerBrowserByteDownload(bytes: Uint8Array, mimeType: string, fileName: string): void {
+  const blob = new Blob([new Uint8Array(bytes)], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  triggerBrowserDownload(url, fileName);
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }
 
 function resolveDownloadTargetFile(fileName: string): FSFile {
@@ -352,6 +442,10 @@ function splitFileName(fileName: string): { base: string; ext: string } {
     base: fileName.slice(0, lastDot),
     ext: fileName.slice(lastDot),
   };
+}
+
+function formatFileSize(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MB`;
 }
 
 export function formatSpeed(bytesPerSecond: number): string {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -1790,7 +1790,14 @@ test("readFile resolves from binary file frames when the daemon supports them", 
     encodeFileTransferFrame({
       opcode: FileTransferOpcode.FileChunk,
       requestId: "req-binary",
-      payload: new TextEncoder().encode("hello"),
+      payload: new TextEncoder().encode("he"),
+    }),
+  );
+  mock.triggerMessage(
+    encodeFileTransferFrame({
+      opcode: FileTransferOpcode.FileChunk,
+      requestId: "req-binary",
+      payload: new TextEncoder().encode("llo"),
     }),
   );
   mock.triggerMessage(

--- a/packages/protocol/src/messages.file-editing.test.ts
+++ b/packages/protocol/src/messages.file-editing.test.ts
@@ -11,13 +11,23 @@ import {
 
 describe("workspace file editing messages", () => {
   test("keeps the capability optional for older server info payloads", () => {
+    const features = ServerInfoStatusPayloadSchema.parse({
+      status: "server_info",
+      serverId: "server-1",
+      features: {},
+    }).features;
+    expect(features?.workspaceFileEditing).toBeUndefined();
+    expect(features?.relayFileDownloads).toBeUndefined();
+  });
+
+  test("parses the relay file download capability", () => {
     expect(
       ServerInfoStatusPayloadSchema.parse({
         status: "server_info",
         serverId: "server-1",
-        features: {},
-      }).features?.workspaceFileEditing,
-    ).toBeUndefined();
+        features: { relayFileDownloads: true },
+      }).features?.relayFileDownloads,
+    ).toBe(true);
   });
 
   test("parses subscribe, unsubscribe, and version update messages", () => {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2788,6 +2788,8 @@ export const ServerInfoStatusPayloadSchema = z
         workspaceRecovery: z.boolean().optional(),
         // COMPAT(workspaceFileEditing): added in v0.2.0, remove after 2027-01-18 once daemon floor >= v0.2.0.
         workspaceFileEditing: z.boolean().optional(),
+        // COMPAT(relayFileDownloads): added in v0.2.X, remove after 2027-01-25 once daemon floor includes chunked file reads.
+        relayFileDownloads: z.boolean().optional(),
         // COMPAT(providerUsageList): added in v0.1.98, drop the gate when daemon floor >= v0.1.98.
         providerUsageList: z.boolean().optional(),
         // COMPAT(agentDetach): added in v0.1.98, remove gate after 2026-12-19 once daemon floor >= v0.1.98.

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -714,6 +714,7 @@ export class Session {
         emit: (msg) => this.emit(msg),
         emitBinary: (frame) => this.emitBinary(frame),
         hasBinaryChannel: () => this.onBinaryMessage !== null,
+        getClientBufferedAmount: () => this.getTransportBufferedAmount(),
       },
       downloadTokenStore,
       paseoHome,

--- a/packages/server/src/server/session/files/workspace-files-session.test.ts
+++ b/packages/server/src/server/session/files/workspace-files-session.test.ts
@@ -10,6 +10,7 @@ import {
   type FileTransferFrame,
 } from "@getpaseo/protocol/binary-frames/index";
 import {
+  FILE_TRANSFER_CHUNK_BYTES,
   WorkspaceFilesSession,
   type WorkspaceFilesSessionHost,
 } from "./workspace-files-session.js";
@@ -38,6 +39,7 @@ function makeSubsystem(options: { hasBinaryChannel?: boolean } = {}) {
     emit: (msg) => emitted.push(msg),
     emitBinary: (frame) => binary.push(frame),
     hasBinaryChannel: () => hasBinary,
+    getClientBufferedAmount: () => 0,
   };
   const paseoHome = makeDir("workspace-files-home-");
   const subsystem = new WorkspaceFilesSession({
@@ -134,6 +136,34 @@ describe("WorkspaceFilesSession", () => {
       FileTransferOpcode.FileChunk,
       FileTransferOpcode.FileEnd,
     ]);
+  });
+
+  test("chunks binary file reads below the physical socket limit", async () => {
+    const cwd = makeDir("workspace-files-chunked-");
+    const contents = Buffer.alloc(FILE_TRANSFER_CHUNK_BYTES * 2 + 7, 0x61);
+    writeFileSync(join(cwd, "archive.bin"), contents);
+    const { subsystem, binary } = makeSubsystem({ hasBinaryChannel: true });
+
+    await subsystem.handleFileExplorerRequest({
+      type: "file_explorer_request",
+      cwd,
+      path: "archive.bin",
+      mode: "file",
+      requestId: "req-chunked",
+      acceptBinary: true,
+    });
+
+    const frames = binary.map((frame) => decodeFileTransferFrame(frame));
+    const chunks = frames.filter(
+      (frame): frame is Extract<FileTransferFrame, { opcode: 0x11 }> =>
+        frame?.opcode === FileTransferOpcode.FileChunk,
+    );
+    expect(chunks.map((frame) => frame.payload.byteLength)).toEqual([
+      FILE_TRANSFER_CHUNK_BYTES,
+      FILE_TRANSFER_CHUNK_BYTES,
+      7,
+    ]);
+    expect(Buffer.concat(chunks.map((frame) => Buffer.from(frame.payload)))).toEqual(contents);
   });
 
   test("rejects an empty file-explorer cwd with an error envelope", async () => {

--- a/packages/server/src/server/session/files/workspace-files-session.ts
+++ b/packages/server/src/server/session/files/workspace-files-session.ts
@@ -37,6 +37,7 @@ export interface WorkspaceFilesSessionHost {
   emit(msg: SessionOutboundMessage): void;
   emitBinary(frame: Uint8Array): void;
   hasBinaryChannel(): boolean;
+  getClientBufferedAmount(): number | null;
 }
 
 export interface WorkspaceFilesSessionOptions {
@@ -46,6 +47,12 @@ export interface WorkspaceFilesSessionOptions {
   logger: pino.Logger;
   fileObserver?: FileObserver;
 }
+
+export const FILE_TRANSFER_CHUNK_BYTES = 256 * 1024;
+// Encrypted relay frames expand during encryption + base64 transport. Stay
+// below the shared physical socket hard limit while the peer drains its queue.
+const FILE_TRANSFER_HIGH_WATER_BYTES = 4 * 1024 * 1024;
+const FILE_TRANSFER_BACKPRESSURE_POLL_MS = 10;
 
 /**
  * A client's workspace file-access surface: browsing directories, reading file
@@ -194,13 +201,24 @@ export class WorkspaceFilesSession {
               },
             }),
           );
-          this.host.emitBinary(
-            encodeFileTransferFrame({
-              opcode: FileTransferOpcode.FileChunk,
-              requestId,
-              payload: file.bytes,
-            }),
-          );
+          for (
+            let offset = 0;
+            offset < file.bytes.byteLength;
+            offset += FILE_TRANSFER_CHUNK_BYTES
+          ) {
+            await this.waitForBinaryCapacity();
+            this.host.emitBinary(
+              encodeFileTransferFrame({
+                opcode: FileTransferOpcode.FileChunk,
+                requestId,
+                payload: file.bytes.subarray(
+                  offset,
+                  Math.min(offset + FILE_TRANSFER_CHUNK_BYTES, file.bytes.byteLength),
+                ),
+              }),
+            );
+          }
+          await this.waitForBinaryCapacity();
           this.host.emitBinary(
             encodeFileTransferFrame({
               opcode: FileTransferOpcode.FileEnd,
@@ -356,6 +374,14 @@ export class WorkspaceFilesSession {
           error: getErrorMessage(error),
           requestId,
         },
+      });
+    }
+  }
+
+  private async waitForBinaryCapacity(): Promise<void> {
+    while ((this.host.getClientBufferedAmount() ?? 0) > FILE_TRANSFER_HIGH_WATER_BYTES) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, FILE_TRANSFER_BACKPRESSURE_POLL_MS);
       });
     }
   }

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1507,6 +1507,8 @@ export class VoiceAssistantWebSocketServer {
         workspaceRecovery: true,
         // COMPAT(workspaceFileEditing): added in v0.2.0, remove after 2027-01-18 once daemon floor >= v0.2.0.
         workspaceFileEditing: true,
+        // COMPAT(relayFileDownloads): added in v0.2.X, remove after 2027-01-25 once daemon floor includes chunked file reads.
+        relayFileDownloads: true,
         // COMPAT(providerUsageList): added in v0.1.98, drop the gate when daemon floor >= v0.1.98.
         providerUsageList: true,
         // COMPAT(agentDetach): added in v0.1.98, remove gate after 2026-12-19 once daemon floor >= v0.1.98.


### PR DESCRIPTION
### Linked issue

Closes #543

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Remote downloads currently select the first configured `directTcp` connection, even when the active connection is the relay. A profile that contains a local `localhost` endpoint therefore builds an unreachable HTTP download URL and reports `Download host is unavailable` from a remote device.

This change:

- resolves HTTP downloads from the active connection instead of any configured direct connection;
- falls back to the existing E2EE binary file channel when relay (or another non-HTTP transport) is active;
- advertises the fallback through an optional `relayFileDownloads` server feature gate;
- splits binary file reads into 256 KiB frames and waits above a 4 MiB outbound high-water mark so relay encryption/base64 expansion stays below the physical socket bound;
- caps the current in-memory relay fallback at 32 MiB and directs larger files to a direct connection.

Direct HTTP downloads remain unchanged when `directTcp` is the active connection.

### How did you verify it

Automated regression coverage:

- App store test with both `localhost` direct and relay configured verifies that an active relay downloads `INDEX.md` from binary bytes instead of constructing the localhost URL.
- App store test verifies that an active direct connection keeps using HTTP.
- App store test verifies that files over 32 MiB are rejected before bytes are requested.
- Server test verifies a binary file is emitted as multiple 256 KiB chunks and reassembles byte-for-byte.
- Client test verifies multiple file chunks reassemble correctly.
- Protocol test verifies the optional capability remains backward compatible.

Commands run:

- `npm exec --workspace=@getpaseo/app -- vitest run src/stores/download-store.test.ts` — 3 passed
- `npm exec --workspace=@getpaseo/server -- vitest run src/server/session/files/workspace-files-session.test.ts` — 9 passed
- `npm exec --workspace=@getpaseo/client -- vitest run src/daemon-client.test.ts -t "readFile resolves from binary file frames"` — 1 passed
- `npm exec --workspace=@getpaseo/protocol -- vitest run src/messages.file-editing.test.ts` — 4 passed
- `npm run typecheck` — passed for all workspaces after building internal dependencies
- `npm run lint` — 0 warnings, 0 errors
- `npm run format` — completed

This is a draft because I have not yet performed a real cross-machine UI download on iOS, Android, desktop, and web. There is no visual UI change, so no screenshots are included.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (no visual UI change)
- [x] Tests added or updated where it made sense
