### PR TITLE
fix(server): preserve nested MCP tool schemas

### DIFF
--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -1137,6 +1137,48 @@ describe("create_agent MCP tool", () => {
   });
   const ensureWorkspaceForCreate = async () => "workspace-created";
 
+  it("publishes explicit JSON schemas for provider feature values", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      ensureWorkspaceForCreate,
+      logger,
+    });
+    const client = await connectInMemoryMcpClient(server);
+
+    try {
+      const listedTools = await client.listTools();
+
+      for (const toolName of ["create_agent", "update_agent", "inspect_provider"]) {
+        const tool = listedTools.tools.find((candidate) => candidate.name === toolName);
+        expect(tool, `${toolName} tool definition`).toBeDefined();
+
+        const inputSchema = z
+          .object({ properties: z.record(z.string(), z.unknown()) })
+          .passthrough()
+          .parse(tool?.inputSchema);
+        const settingsSchema = z
+          .object({ properties: z.record(z.string(), z.unknown()) })
+          .passthrough()
+          .parse(inputSchema.properties.settings);
+        const featuresSchema = z
+          .object({
+            type: z.literal("object"),
+            additionalProperties: z.object({ $ref: z.string() }).passthrough(),
+          })
+          .passthrough()
+          .parse(settingsSchema.properties.features);
+
+        expect(featuresSchema.additionalProperties.$ref).toMatch(/^#\/definitions\//);
+      }
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
   it("requires a concise title no longer than 60 characters", async () => {
     const { agentManager, agentStorage } = createTestDeps();
     const server = await createAgentMcpServer({

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -835,14 +835,14 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       },
       { message: "provider must be provider or provider/model, for example codex/gpt-5.4" },
     );
+  const ProviderFeatureValuesInputSchema = z.record(z.string(), z.json());
   const CreateAgentSettingsInputSchema = z
     .object({
       modeId: z.string().optional().describe("Session mode to configure before the first run."),
       thinkingOptionId: z.string().optional().describe("Thinking option ID."),
-      features: z
-        .record(z.string(), z.unknown())
-        .optional()
-        .describe("Provider-specific feature values, for example { fast_mode: true } for Codex."),
+      features: ProviderFeatureValuesInputSchema.optional().describe(
+        "Provider-specific feature values, for example { fast_mode: true } for Codex.",
+      ),
     })
     .strict();
   const UpdateAgentSettingsInputSchema = z
@@ -854,10 +854,9 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         .nullable()
         .optional()
         .describe("Thinking option ID. Pass null to clear."),
-      features: z
-        .record(z.string(), z.unknown())
-        .optional()
-        .describe("Provider-specific feature values, for example { fast_mode: true } for Codex."),
+      features: ProviderFeatureValuesInputSchema.optional().describe(
+        "Provider-specific feature values, for example { fast_mode: true } for Codex.",
+      ),
     })
     .strict();
   const InspectProviderSettingsInputSchema = z
@@ -865,10 +864,9 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       modeId: z.string().optional().describe("Draft session mode ID."),
       model: z.string().optional().describe("Draft model ID."),
       thinkingOptionId: z.string().optional().describe("Draft thinking option ID."),
-      features: z
-        .record(z.string(), z.unknown())
-        .optional()
-        .describe("Draft provider feature values."),
+      features: ProviderFeatureValuesInputSchema.optional().describe(
+        "Draft provider feature values.",
+      ),
     })
     .strict();
   const AgentRelationshipInputSchema = z.discriminatedUnion("kind", [


### PR DESCRIPTION
### Linked issue

Closes #2057

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The MCP SDK generated `additionalProperties: {}` for the provider `features` records because their Zod value schema was `z.unknown()`. Clients could then lose the nested object shape and send `create_agent` arguments such as `relationship` and `workspace` as JSON strings.

This replaces the three affected feature-value records with one `z.json()`-backed schema. The generated definitions now explicitly describe recursive JSON values for `create_agent`, `update_agent`, and `inspect_provider`, while keeping all provider-specific JSON values valid.

Repro before the fix:

1. Request `tools/list` from the in-memory MCP client.
2. Inspect `settings.features.additionalProperties` for the three affected tools.
3. Observe an empty schema with no recursive JSON type or reference.

### How did you verify it

Before the implementation, the focused regression failed because `additionalProperties.$ref` was missing:

```
npx --no-install vitest run packages/server/src/server/agent/mcp-server.test.ts -t "publishes explicit JSON schemas for provider feature values" --bail=1
```

After the implementation:

- The focused regression passes (1/1).
- `npx --no-install vitest run packages/server/src/server/agent/mcp-server.test.ts --bail=1` — 114/114 passed.
- `npm run typecheck` — passed for all workspaces.
- `npm run lint -- packages/server/src/server/agent/tools/paseo-tools.ts packages/server/src/server/agent/mcp-server.test.ts` — 0 warnings, 0 errors.
- `npm run format` — completed; only the two intended files remain changed.
- `gitleaks protect --staged --no-banner --redact` — no leaks found.

Testing scope: Linux dev container. This is a server/MCP schema-only change with no UI changes, so iOS, Android, desktop, and web screenshots are not applicable.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A — server-only)
- [x] Tests added or updated where it made sense