### PR TITLE
Fix AppImage launches from Linux desktops

### DIFF
--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -8,7 +8,7 @@ import { inheritLoginShellEnv } from "./login-shell-env.js";
 
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { existsSync } from "node:fs";
+import { existsSync, statSync, constants } from "node:fs";
 import { execFileSync } from "node:child_process";
 import {
   app,
@@ -309,11 +309,19 @@ if (forcedUserDataDir) {
   }
 }
 
-// AppImage runtimes mount the app from /tmp under the user's UID, so the SUID
-// chrome-sandbox helper we ship in .deb/.rpm cannot work there. Disable the
-// sandbox only in that case; .deb/.rpm keep the sandbox on, matching VS Code.
-if (process.platform === "linux" && process.env.APPIMAGE) {
-  app.commandLine.appendSwitch("no-sandbox");
+// chrome-sandbox only works with the SUID bit set. AppImage FUSE mounts
+// strip SUID; .deb/.rpm preserve it. Check the file directly instead of
+// relying on environment variables that get stripped by systemd launchers.
+if (process.platform === "linux") {
+  try {
+    const sandboxPath = path.join(process.resourcesPath, "..", "chrome-sandbox");
+    const st = statSync(sandboxPath);
+    if (!(st.mode & constants.S_ISUID)) {
+      app.commandLine.appendSwitch("no-sandbox");
+    }
+  } catch {
+    app.commandLine.appendSwitch("no-sandbox");
+  }
 }
 
 // Allow users to pass Chromium flags via PASEO_ELECTRON_FLAGS for debugging

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -315,6 +315,7 @@ configureLinuxSandbox({
   resourcesPath: process.resourcesPath,
   statSandbox: (sandboxPath) => statSync(sandboxPath),
   disableSandbox: () => app.commandLine.appendSwitch("no-sandbox"),
+  reportInspectionError: (error) => log.error("[linux-sandbox] failed to inspect helper", error),
 });
 
 // Allow users to pass Chromium flags via PASEO_ELECTRON_FLAGS for debugging

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -8,7 +8,7 @@ import { inheritLoginShellEnv } from "./login-shell-env.js";
 
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { existsSync, statSync, constants } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import {
   app,
@@ -40,6 +40,7 @@ import {
   buildStandardContextMenuItems,
 } from "./window/window-manager.js";
 import { setupDarwinCompositorWatchdog } from "./window/compositor-watchdog/index.js";
+import { configureLinuxSandbox } from "./system/linux-sandbox.js";
 import { registerDialogHandlers } from "./features/dialogs.js";
 import {
   registerNotificationHandlers,
@@ -309,20 +310,12 @@ if (forcedUserDataDir) {
   }
 }
 
-// chrome-sandbox only works with the SUID bit set. AppImage FUSE mounts
-// strip SUID; .deb/.rpm preserve it. Check the file directly instead of
-// relying on environment variables that get stripped by systemd launchers.
-if (process.platform === "linux") {
-  try {
-    const sandboxPath = path.join(process.resourcesPath, "..", "chrome-sandbox");
-    const st = statSync(sandboxPath);
-    if (!(st.mode & constants.S_ISUID)) {
-      app.commandLine.appendSwitch("no-sandbox");
-    }
-  } catch {
-    app.commandLine.appendSwitch("no-sandbox");
-  }
-}
+configureLinuxSandbox({
+  platform: process.platform,
+  resourcesPath: process.resourcesPath,
+  statSandbox: (sandboxPath) => statSync(sandboxPath),
+  disableSandbox: () => app.commandLine.appendSwitch("no-sandbox"),
+});
 
 // Allow users to pass Chromium flags via PASEO_ELECTRON_FLAGS for debugging
 // rendering issues (e.g. "--disable-gpu --ozone-platform=x11").

--- a/packages/desktop/src/system/linux-sandbox.test.ts
+++ b/packages/desktop/src/system/linux-sandbox.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { configureLinuxSandbox } from "./linux-sandbox";
+
+interface SandboxMetadata {
+  mode: number;
+  uid: number;
+}
+
+function configureWithSandbox(
+  sandbox: SandboxMetadata | null,
+  platform: NodeJS.Platform = "linux",
+) {
+  const disabledSwitches: string[] = [];
+
+  configureLinuxSandbox({
+    platform,
+    resourcesPath: "/opt/Paseo/resources",
+    statSandbox: () => {
+      if (sandbox === null) {
+        throw new Error("chrome-sandbox is unavailable");
+      }
+      return sandbox;
+    },
+    disableSandbox: () => disabledSwitches.push("no-sandbox"),
+  });
+
+  return disabledSwitches;
+}
+
+describe("configureLinuxSandbox", () => {
+  it("disables the sandbox when an AppImage mount strips SUID", () => {
+    expect(configureWithSandbox({ uid: 1000, mode: 0o755 })).toEqual(["no-sandbox"]);
+  });
+
+  it("keeps the sandbox for a root-owned 4755 helper", () => {
+    expect(configureWithSandbox({ uid: 0, mode: 0o4755 })).toEqual([]);
+  });
+
+  it("disables the sandbox when a SUID helper is not root-owned", () => {
+    expect(configureWithSandbox({ uid: 1000, mode: 0o4755 })).toEqual(["no-sandbox"]);
+  });
+
+  it("disables the sandbox when the helper cannot be inspected", () => {
+    expect(configureWithSandbox(null)).toEqual(["no-sandbox"]);
+  });
+
+  it("does not inspect or configure the sandbox outside Linux", () => {
+    expect(configureWithSandbox(null, "darwin")).toEqual([]);
+  });
+});

--- a/packages/desktop/src/system/linux-sandbox.test.ts
+++ b/packages/desktop/src/system/linux-sandbox.test.ts
@@ -7,44 +7,76 @@ interface SandboxMetadata {
 }
 
 function configureWithSandbox(
-  sandbox: SandboxMetadata | null,
+  sandbox: SandboxMetadata | Error,
   platform: NodeJS.Platform = "linux",
 ) {
   const disabledSwitches: string[] = [];
+  const inspectionErrors: unknown[] = [];
 
   configureLinuxSandbox({
     platform,
     resourcesPath: "/opt/Paseo/resources",
     statSandbox: () => {
-      if (sandbox === null) {
-        throw new Error("chrome-sandbox is unavailable");
+      if (sandbox instanceof Error) {
+        throw sandbox;
       }
       return sandbox;
     },
     disableSandbox: () => disabledSwitches.push("no-sandbox"),
+    reportInspectionError: (error) => inspectionErrors.push(error),
   });
 
-  return disabledSwitches;
+  return { disabledSwitches, inspectionErrors };
+}
+
+function createFileSystemError(code: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(code);
+  error.code = code;
+  return error;
 }
 
 describe("configureLinuxSandbox", () => {
   it("disables the sandbox when an AppImage mount strips SUID", () => {
-    expect(configureWithSandbox({ uid: 1000, mode: 0o755 })).toEqual(["no-sandbox"]);
+    expect(configureWithSandbox({ uid: 1000, mode: 0o755 })).toEqual({
+      disabledSwitches: ["no-sandbox"],
+      inspectionErrors: [],
+    });
   });
 
   it("keeps the sandbox for a root-owned 4755 helper", () => {
-    expect(configureWithSandbox({ uid: 0, mode: 0o4755 })).toEqual([]);
+    expect(configureWithSandbox({ uid: 0, mode: 0o4755 })).toEqual({
+      disabledSwitches: [],
+      inspectionErrors: [],
+    });
   });
 
   it("disables the sandbox when a SUID helper is not root-owned", () => {
-    expect(configureWithSandbox({ uid: 1000, mode: 0o4755 })).toEqual(["no-sandbox"]);
+    expect(configureWithSandbox({ uid: 1000, mode: 0o4755 })).toEqual({
+      disabledSwitches: ["no-sandbox"],
+      inspectionErrors: [],
+    });
   });
 
-  it("disables the sandbox when the helper cannot be inspected", () => {
-    expect(configureWithSandbox(null)).toEqual(["no-sandbox"]);
+  it("disables the sandbox when the helper is missing", () => {
+    expect(configureWithSandbox(createFileSystemError("ENOENT"))).toEqual({
+      disabledSwitches: ["no-sandbox"],
+      inspectionErrors: [],
+    });
+  });
+
+  it("keeps the sandbox and reports unexpected inspection failures", () => {
+    const permissionError = createFileSystemError("EACCES");
+
+    expect(configureWithSandbox(permissionError)).toEqual({
+      disabledSwitches: [],
+      inspectionErrors: [permissionError],
+    });
   });
 
   it("does not inspect or configure the sandbox outside Linux", () => {
-    expect(configureWithSandbox(null, "darwin")).toEqual([]);
+    expect(configureWithSandbox(createFileSystemError("EACCES"), "darwin")).toEqual({
+      disabledSwitches: [],
+      inspectionErrors: [],
+    });
   });
 });

--- a/packages/desktop/src/system/linux-sandbox.ts
+++ b/packages/desktop/src/system/linux-sandbox.ts
@@ -13,6 +13,11 @@ interface LinuxSandboxConfiguration {
   resourcesPath: string;
   statSandbox: (sandboxPath: string) => SandboxMetadata;
   disableSandbox: () => void;
+  reportInspectionError: (error: unknown) => void;
+}
+
+function isMissingSandbox(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
 export function configureLinuxSandbox(input: LinuxSandboxConfiguration): void {
@@ -29,7 +34,12 @@ export function configureLinuxSandbox(input: LinuxSandboxConfiguration): void {
     if (!hasUsableSandbox) {
       input.disableSandbox();
     }
-  } catch {
-    input.disableSandbox();
+  } catch (error) {
+    if (isMissingSandbox(error)) {
+      input.disableSandbox();
+      return;
+    }
+
+    input.reportInspectionError(error);
   }
 }

--- a/packages/desktop/src/system/linux-sandbox.ts
+++ b/packages/desktop/src/system/linux-sandbox.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+
+const REQUIRED_SANDBOX_MODE = 0o4755;
+const PERMISSION_BITS = 0o7777;
+
+interface SandboxMetadata {
+  mode: number;
+  uid: number;
+}
+
+interface LinuxSandboxConfiguration {
+  platform: NodeJS.Platform;
+  resourcesPath: string;
+  statSandbox: (sandboxPath: string) => SandboxMetadata;
+  disableSandbox: () => void;
+}
+
+export function configureLinuxSandbox(input: LinuxSandboxConfiguration): void {
+  if (input.platform !== "linux") {
+    return;
+  }
+
+  try {
+    const sandboxPath = path.join(input.resourcesPath, "..", "chrome-sandbox");
+    const sandbox = input.statSandbox(sandboxPath);
+    const hasUsableSandbox =
+      sandbox.uid === 0 && (sandbox.mode & PERMISSION_BITS) === REQUIRED_SANDBOX_MODE;
+
+    if (!hasUsableSandbox) {
+      input.disableSandbox();
+    }
+  } catch {
+    input.disableSandbox();
+  }
+}


### PR DESCRIPTION
### Linked issue

Closes #2437
Refs #1016

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Linux desktop startup now checks whether the bundled Chromium sandbox helper is actually usable instead of relying on the `APPIMAGE` environment variable. AppImage mounts and other installs without a root-owned `4755` helper disable the sandbox so the app can launch, while `.deb` and RPM installs with a valid helper keep the sandbox enabled.

The sandbox decision lives in a focused system module with regression coverage for valid, missing, non-SUID, and non-root-owned helpers.

### How did you verify it

The contributor verified the AppImage on KDE neon 24.04 Wayland: the patched build launched from both the terminal and its desktop-managed service without a command-line `--no-sandbox`; the unpatched AppImage crashed on double-click.

Local verification after rebasing onto current `main`:

- `npx vitest run packages/desktop/src/system/linux-sandbox.test.ts --bail=1` (5 tests passed)
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

CI still needs to exercise the packaged Linux desktop smoke. The automated matrix does not reproduce a FUSE-mounted AppImage launched by a desktop-managed service.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI change)
- [x] Tests added or updated where it made sense