### PR TITLE
fix: filter orphan Claude provider subagents

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.sub-agent-sidechain.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.sub-agent-sidechain.test.ts
@@ -402,6 +402,83 @@ describe("ClaudeAgentSession sub-agent sidechain updates", () => {
     });
   });
 
+  test("ignores nested provider events for non-subagent parent tools", async () => {
+    queryFactory.mockImplementation(() =>
+      buildQueryMock([
+        {
+          type: "system",
+          subtype: "init",
+          session_id: "nested-tool-session",
+          permissionMode: "default",
+          model: "opus",
+        },
+        {
+          type: "stream_event",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "bash-call-1",
+              name: "Bash",
+              input: { command: "npm test" },
+            },
+          },
+        },
+        {
+          type: "stream_event",
+          parent_tool_use_id: "bash-call-1",
+          event: {
+            type: "content_block_start",
+            index: 1,
+            content_block: {
+              type: "tool_use",
+              id: "nested-read-1",
+              name: "Read",
+              input: { file_path: "package.json" },
+            },
+          },
+        },
+        {
+          type: "assistant",
+          parent_tool_use_id: null,
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "bash-call-1",
+                tool_name: "Bash",
+                content: "done",
+                is_error: false,
+              },
+            ],
+          },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            output_tokens: 1,
+          },
+          total_cost_usd: 0,
+        },
+      ]),
+    );
+    const session = await new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    }).createSession({ provider: "claude", cwd: process.cwd() });
+
+    const events = await collectUntilTerminal(streamSession(session, "run nested tool"));
+    await session.close();
+
+    expect(events.some((event) => event.type === "provider_subagent")).toBe(false);
+  });
+
   test("keeps a failed Task subagent failed when the parent turn succeeds", async () => {
     const failedEvents = buildTailScenarioEvents(1);
     const taskResult = failedEvents.find(

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -3712,6 +3712,10 @@ class ClaudeAgentSession implements AgentSession {
   ): AgentStreamEvent[] {
     const parentToolUseId = readClaudeParentToolUseId(message);
     if (parentToolUseId) {
+      const parentToolUse = this.toolUseCache.get(parentToolUseId);
+      if (!isClaudeSubagentToolName(parentToolUse?.name)) {
+        return [];
+      }
       return this.sidechainTracker.handleMessage(message, parentToolUseId);
     }
 
@@ -5233,6 +5237,9 @@ function buildClaudePersistedSidechainEvents(
   const toolCalls = readClaudeHistoricalSubagentToolCalls(parentEntries);
   const toolResults = readClaudeHistoricalSubagentToolResults(parentEntries);
   for (const [agentId, entries] of groupClaudeSidechainEntries(sidechainEntries)) {
+    if (!toolResults.has(agentId)) {
+      continue;
+    }
     events.push(
       ...buildClaudePersistedSidechainAgentEvents(
         agentId,

--- a/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
@@ -16,6 +16,7 @@ const LIVE_REPLY_MARKER = "LIVE_ONLY_REPLY_MARKER";
 const HISTORY_USER_MARKER = "HISTORY_ONLY_USER_MARKER";
 const HISTORY_ASSISTANT_MARKER = "HISTORY_ONLY_ASSISTANT_MARKER";
 const HISTORY_SIDECHAIN_MARKER = "HISTORY_ONLY_SIDECHAIN_MARKER";
+const ORPHAN_SIDECHAIN_MARKER = "ORPHAN_SIDECHAIN_MARKER";
 
 function buildSdkQueryMock() {
   const events = [
@@ -160,6 +161,20 @@ describe("ClaudeAgentSession history replay regression", () => {
             id: "history-child-message",
             role: "assistant",
             content: [{ type: "text", text: HISTORY_SIDECHAIN_MARKER }],
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          isSidechain: true,
+          agentId: "orphan-child",
+          uuid: "orphan-child-message",
+          timestamp: "2026-07-12T10:00:02.000Z",
+          sessionId: "history-session",
+          cwd,
+          message: {
+            id: "orphan-child-message",
+            role: "assistant",
+            content: [{ type: "text", text: ORPHAN_SIDECHAIN_MARKER }],
           },
         }),
         JSON.stringify({
@@ -326,6 +341,20 @@ describe("ClaudeAgentSession history replay regression", () => {
         status: "completed",
       }),
     });
+    expect(historyEvents).not.toContainEqual({
+      type: "provider_subagent",
+      provider: "claude",
+      event: expect.objectContaining({ id: "orphan-child" }),
+    });
+    expect(
+      historyEvents.some(
+        (event) =>
+          event.type === "provider_subagent" &&
+          event.event.type === "timeline" &&
+          event.event.item.type === "assistant_message" &&
+          event.event.item.text.includes(ORPHAN_SIDECHAIN_MARKER),
+      ),
+    ).toBe(false);
   });
 
   test("listCommands includes rewind command", async () => {


### PR DESCRIPTION
### Linked issue

Closes #2445

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Claude provider-subagent tracking was too permissive in two places:

- Live SDK messages with any `parent_tool_use_id` were treated as Claude subagent sidechain events, even when the parent tool was not Claude's `Task`/`Agent` tool.
- Persisted sidechain replay generated provider-subagent rows even when a sidechain `agentId` could not be linked back to a parent Task/Agent tool result.

That can surface generic `Claude subagent` rows in the subagents track that do not correspond to a real openable child timeline.

This PR tightens admission so Claude provider subagents are emitted only when the parent tool is known to be `Task`/`Agent`, and persisted sidechains are replayed only when the parent history proves the `agentId -> tool_use_id` relationship.

### How did you verify it

Ran targeted regression tests:

- `npx vitest run packages/server/src/server/agent/providers/claude/agent.sub-agent-sidechain.test.ts --bail=1` passed
- `npx vitest run packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts --bail=1` passed

Ran repository checks/builds:

- `npm run build:server` passed
- `npm run lint` passed
- `npm run typecheck` passed

Pre-commit also reran format, lint, and typecheck successfully. Before the final successful typecheck, an ignored local Expo Router cache file under `packages/app/.expo/types/router.d.ts` was stale and had to be deleted; no generated or ignored files are included in this PR.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

No UI implementation changed; this is daemon/provider filtering for rows already rendered by the existing subagents track.