### PR TITLE
feat: add custom JSON themes

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # Design
 
-Tokens — every color, font size, weight, spacing step, radius, icon size — live in `packages/app/src/styles/theme.ts`.
+Built-in tokens — colors, font sizes, weights, spacing, radii, and icon sizes — live in `packages/app/src/styles/theme.ts`. Imported custom theme colors are validated and expanded into the same token shape by `packages/app/src/styles/custom-theme.ts`.
 
 ---
 

--- a/docs/unistyles.md
+++ b/docs/unistyles.md
@@ -335,7 +335,7 @@ If we ever need to avoid the transition entirely, store at least the theme prefe
 
 ## Runtime Theme Patching For User Preferences
 
-Appearance settings (UI/mono font family, font sizes, syntax-highlight theme) are applied by patching every registered theme at runtime with `UnistylesRuntime.updateTheme(name, updater)` — not by threading preference reads through components. `applyAppearance` in `packages/app/src/screens/settings/appearance/apply-appearance.ts` runs from a `ProvidersWrapper` effect on settings load/change and loops all six theme keys, returning `{ ...theme, fontFamily, fontSize, lineHeight, colors.syntax }`.
+Appearance settings (UI/mono font family, font sizes, syntax-highlight theme) are applied by patching every registered theme at runtime with `UnistylesRuntime.updateTheme(name, updater)` — not by threading preference reads through components. `applyAppearance` in `packages/app/src/screens/settings/appearance/apply-appearance.ts` runs from a `ProvidersWrapper` effect on settings load/change and loops all seven theme keys, returning `{ ...theme, fontFamily, fontSize, lineHeight, colors.syntax }`.
 
 This works without `useUnistyles()` because every consumer already reads these tokens through `StyleSheet.create((theme) => …)` (or the `withUnistyles`/`uniProps` path for the markdown renderer), so patching the theme repaints tracked views through the native ShadowRegistry with no React re-render.
 

--- a/packages/app/e2e/browser/custom-theme-import.spec.ts
+++ b/packages/app/e2e/browser/custom-theme-import.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "./fixtures";
-import { gotoAppShell, openSettings } from "./helpers/app";
-import { openSettingsSection } from "./helpers/settings";
+import { expect, test } from "../support/fixtures";
+import { gotoAppShell, openSettings } from "../support/helpers/app";
+import { openSettingsSection } from "../support/helpers/settings";
 
 const VALID_THEME = {
   version: 1,

--- a/packages/app/e2e/custom-theme-import.spec.ts
+++ b/packages/app/e2e/custom-theme-import.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "./fixtures";
+import { gotoAppShell, openSettings } from "./helpers/app";
+import { openSettingsSection } from "./helpers/settings";
+
+const VALID_THEME = {
+  version: 1,
+  name: "Warm graphite",
+  appearance: "dark",
+  colors: {
+    background: "#222222",
+    foreground: "#dbd7ca",
+    raised: "#262626",
+    control: "#2b2b2b",
+    accent: "#393a34",
+    highlight: "#e6cc77",
+    mutedForeground: "#a9a397",
+    ring: "#777777",
+  },
+} as const;
+
+async function chooseThemeFile(page: import("@playwright/test").Page, theme: unknown) {
+  const chooser = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Import" }).click();
+  await (
+    await chooser
+  ).setFiles({
+    name: "theme.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(theme)),
+  });
+}
+
+test("imports valid custom themes and rejects invalid colors", async ({ page }) => {
+  await gotoAppShell(page);
+  await openSettings(page);
+  await openSettingsSection(page, "appearance");
+
+  await chooseThemeFile(page, {
+    ...VALID_THEME,
+    colors: { ...VALID_THEME.colors, background: "red" },
+  });
+  await expect(page.getByText("Must be a hex color")).toBeVisible();
+  await expect(page.getByText("Import a Paseo theme JSON file")).toBeVisible();
+
+  await chooseThemeFile(page, VALID_THEME);
+  await expect(page.getByText("Warm graphite")).toBeVisible();
+  await expect(page.getByText("Must be a hex color")).not.toBeVisible();
+});

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -111,6 +111,7 @@ import { selectIsAgentListOpen, usePanelStore } from "@/stores/panel-store";
 import { flushDraftPersistStorage } from "@/stores/draft-store";
 import { getNextThemePreference, THEME_TO_UNISTYLES } from "@/styles/theme";
 import { useSessionStore } from "@/stores/session-store";
+import { buildCustomTheme } from "@/styles/custom-theme";
 import { installWebScrollbarStyles } from "@/styles/install-web-scrollbar-styles";
 import type { HostProfile } from "@/types/host-connection";
 import { toggleDesktopSidebarsWithCheckoutIntent } from "@/utils/desktop-sidebar-toggle";
@@ -658,17 +659,20 @@ function ProvidersWrapper({ children }: { children: ReactNode }) {
   // Apply theme setting on mount and when it changes
   useEffect(() => {
     if (settingsLoading) return;
+    const customTheme = settings.customTheme;
+    if (customTheme !== null) {
+      UnistylesRuntime.updateTheme("custom", () => buildCustomTheme(customTheme));
+    }
     if (settings.theme === "auto") {
       UnistylesRuntime.setAdaptiveThemes(true);
     } else {
       UnistylesRuntime.setAdaptiveThemes(false);
       UnistylesRuntime.setTheme(THEME_TO_UNISTYLES[settings.theme]);
     }
-  }, [settingsLoading, settings.theme]);
+  }, [settings.customTheme, settingsLoading, settings.theme]);
 
   // Apply font / size / syntax appearance settings on mount and when they change.
-  // Sibling to the theme effect above; order is irrelevant because both patch all
-  // registered theme keys, so the active key is always current.
+  // This runs after the theme effect so imported custom themes receive persisted overrides.
   useEffect(() => {
     if (settingsLoading) return;
     applyAppearance({
@@ -679,6 +683,7 @@ function ProvidersWrapper({ children }: { children: ReactNode }) {
       syntaxTheme: settings.syntaxTheme,
     });
   }, [
+    settings.customTheme,
     settingsLoading,
     settings.uiFontFamily,
     settings.monoFontFamily,

--- a/packages/app/src/hooks/use-settings/index.ts
+++ b/packages/app/src/hooks/use-settings/index.ts
@@ -29,6 +29,7 @@ import {
   normalizeAppSettings,
   parseClampedFontSize,
   parseTerminalScrollbackLines,
+  resetAppSettings as resetAppSettingsPure,
   sanitizeFontFamily,
   saveAppSettings as saveAppSettingsPure,
   type AppSettings,
@@ -141,9 +142,7 @@ export function useAppSettings(): UseAppSettingsReturn {
 
   const resetSettings = useCallback(async () => {
     try {
-      const next = { ...DEFAULT_CLIENT_SETTINGS };
-      queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
-      await AsyncStorage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
+      await resetAppSettings({ queryClient });
     } catch (err) {
       console.error("[AppSettings] Failed to reset settings:", err);
       throw err;
@@ -236,6 +235,16 @@ export async function saveAppSettings(input: {
   await saveAppSettingsPure({
     queryClient: input.queryClient,
     updates: input.updates,
+    deps: input.deps ?? productionDeps,
+  });
+}
+
+export async function resetAppSettings(input: {
+  queryClient: QueryClient;
+  deps?: SettingsDeps;
+}): Promise<void> {
+  await resetAppSettingsPure({
+    queryClient: input.queryClient,
     deps: input.deps ?? productionDeps,
   });
 }

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -405,6 +405,9 @@ describe("saveAppSettings", () => {
         }
         entries.set(key, value);
       },
+      async removeItem(key) {
+        entries.delete(key);
+      },
     };
     const deps = { storage, desktop: createFakeDesktopBridge() };
     const queryClient = new QueryClient();
@@ -459,6 +462,9 @@ describe("saveAppSettings", () => {
         }
         entries.set(key, value);
       },
+      async removeItem(key) {
+        entries.delete(key);
+      },
     };
     const deps = { storage, desktop: createFakeDesktopBridge() };
     const queryClient = new QueryClient();
@@ -487,6 +493,7 @@ describe("saveAppSettings", () => {
       setItem: async () => {
         throw new Error("storage unavailable");
       },
+      removeItem: async () => {},
     };
     const queryClient = new QueryClient();
     queryClient.setQueryData(APP_SETTINGS_QUERY_KEY, DEFAULT_CLIENT_SETTINGS);

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -381,6 +381,60 @@ describe("saveAppSettings", () => {
     );
   });
 
+  it("serializes overlapping updates without losing either setting", async () => {
+    const entries = new Map([[APP_SETTINGS_KEY, JSON.stringify(DEFAULT_CLIENT_SETTINGS)]]);
+    let releaseFirstWrite = () => {};
+    const firstWriteGate = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let markFirstWriteStarted = () => {};
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve;
+    });
+    let writeCount = 0;
+    const storage: KeyValueStorage = {
+      async getItem(key) {
+        return entries.get(key) ?? null;
+      },
+      async setItem(key, value) {
+        writeCount += 1;
+        if (writeCount === 1) {
+          markFirstWriteStarted();
+          await firstWriteGate;
+        }
+        entries.set(key, value);
+      },
+    };
+    const deps = { storage, desktop: createFakeDesktopBridge() };
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(APP_SETTINGS_QUERY_KEY, DEFAULT_CLIENT_SETTINGS);
+
+    const themeSave = saveAppSettings({
+      queryClient,
+      updates: { theme: "light" },
+      deps,
+    });
+    await firstWriteStarted;
+    const scrollbackSave = saveAppSettings({
+      queryClient,
+      updates: { terminalScrollbackLines: 42_000 },
+      deps,
+    });
+
+    await Promise.resolve();
+    expect(writeCount).toBe(1);
+    releaseFirstWrite();
+    await Promise.all([themeSave, scrollbackSave]);
+
+    const expected = {
+      ...DEFAULT_CLIENT_SETTINGS,
+      theme: "light",
+      terminalScrollbackLines: 42_000,
+    };
+    expect(JSON.parse(entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(expected);
+    expect(queryClient.getQueryData(APP_SETTINGS_QUERY_KEY)).toEqual(expected);
+  });
+
   it("does not update the cache when persistence fails", async () => {
     const storage: KeyValueStorage = {
       getItem: async () => JSON.stringify(DEFAULT_CLIENT_SETTINGS),

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -11,6 +11,7 @@ import {
   loadSettingsFromStorage,
   parseClampedFontSize,
   parseTerminalScrollbackLines,
+  resetAppSettings,
   saveAppSettings,
   type KeyValueStorage,
   type SettingsDeps,
@@ -433,6 +434,51 @@ describe("saveAppSettings", () => {
     };
     expect(JSON.parse(entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(expected);
     expect(queryClient.getQueryData(APP_SETTINGS_QUERY_KEY)).toEqual(expected);
+  });
+
+  it("serializes reset after an in-flight update", async () => {
+    const entries = new Map([[APP_SETTINGS_KEY, JSON.stringify(DEFAULT_CLIENT_SETTINGS)]]);
+    let releaseFirstWrite = () => {};
+    const firstWriteGate = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let markFirstWriteStarted = () => {};
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve;
+    });
+    let writeCount = 0;
+    const storage: KeyValueStorage = {
+      async getItem(key) {
+        return entries.get(key) ?? null;
+      },
+      async setItem(key, value) {
+        writeCount += 1;
+        if (writeCount === 1) {
+          markFirstWriteStarted();
+          await firstWriteGate;
+        }
+        entries.set(key, value);
+      },
+    };
+    const deps = { storage, desktop: createFakeDesktopBridge() };
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(APP_SETTINGS_QUERY_KEY, DEFAULT_CLIENT_SETTINGS);
+
+    const save = saveAppSettings({
+      queryClient,
+      updates: { theme: "light" },
+      deps,
+    });
+    await firstWriteStarted;
+    const reset = resetAppSettings({ queryClient, deps });
+
+    await Promise.resolve();
+    expect(writeCount).toBe(1);
+    releaseFirstWrite();
+    await Promise.all([save, reset]);
+
+    expect(JSON.parse(entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(DEFAULT_CLIENT_SETTINGS);
+    expect(queryClient.getQueryData(APP_SETTINGS_QUERY_KEY)).toEqual(DEFAULT_CLIENT_SETTINGS);
   });
 
   it("does not update the cache when persistence fails", async () => {

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -12,8 +12,10 @@ import {
   parseClampedFontSize,
   parseTerminalScrollbackLines,
   saveAppSettings,
+  type KeyValueStorage,
   type SettingsDeps,
 } from "./storage";
+import { DEFAULT_CUSTOM_THEME_PRESET } from "@/styles/custom-theme";
 import { createFakeDesktopBridge, createInMemoryKeyValueStorage } from "./fakes";
 import { THEME_OPTIONS } from "@/styles/theme";
 
@@ -61,6 +63,39 @@ describe("loadAppSettingsFromStorage", () => {
     const result = await loadAppSettingsFromStorage(deps);
 
     expect(result.theme).toBe(name);
+  });
+
+  it("restores a valid custom theme", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          theme: "custom",
+          customTheme: DEFAULT_CUSTOM_THEME_PRESET,
+        }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.theme).toBe("custom");
+    expect(result.customTheme).toEqual(DEFAULT_CUSTOM_THEME_PRESET);
+  });
+
+  it("does not activate a custom theme with an invalid color", async () => {
+    const invalidCustomTheme = {
+      ...DEFAULT_CUSTOM_THEME_PRESET,
+      colors: { ...DEFAULT_CUSTOM_THEME_PRESET.colors, background: "red" },
+    };
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ theme: "custom", customTheme: invalidCustomTheme }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.theme).toBe("auto");
+    expect(result.customTheme).toBeNull();
   });
 
   it("seeds storage with the client defaults when nothing is persisted", async () => {
@@ -344,6 +379,26 @@ describe("saveAppSettings", () => {
         terminalScrollbackLines: 42_000,
       }),
     );
+  });
+
+  it("does not update the cache when persistence fails", async () => {
+    const storage: KeyValueStorage = {
+      getItem: async () => JSON.stringify(DEFAULT_CLIENT_SETTINGS),
+      setItem: async () => {
+        throw new Error("storage unavailable");
+      },
+    };
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(APP_SETTINGS_QUERY_KEY, DEFAULT_CLIENT_SETTINGS);
+
+    await expect(
+      saveAppSettings({
+        queryClient,
+        updates: { theme: "custom", customTheme: DEFAULT_CUSTOM_THEME_PRESET },
+        deps: { storage, desktop: createFakeDesktopBridge() },
+      }),
+    ).rejects.toThrow("storage unavailable");
+    expect(queryClient.getQueryData(APP_SETTINGS_QUERY_KEY)).toEqual(DEFAULT_CLIENT_SETTINGS);
   });
 
   it("normalizes a legacy cached settings shape before saving", async () => {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -17,6 +17,7 @@ import {
 import { THEME_OPTIONS, type ThemePreference } from "@/styles/theme";
 import { z } from "zod";
 import { readValidatedJson } from "@/storage/validated-storage";
+import { customThemeSchema, type CustomThemePreset } from "@/styles/custom-theme";
 
 export const APP_SETTINGS_KEY = "@paseo:app-settings";
 export const APP_SETTINGS_QUERY_KEY = ["app-settings"];
@@ -30,8 +31,11 @@ export type WorkspaceTitleSource = "title" | "branch";
 export type SidebarWorkspaceTrailing = "diff" | "timestamp" | "none";
 export type ToolCallDetailLevel = "overview" | "detailed";
 
-const VALID_THEMES = new Set<string>(THEME_OPTIONS.map((option) => option.name));
-const ThemePreferenceSchema = z.enum(THEME_OPTIONS.map((option) => option.name));
+const VALID_THEMES = new Set<string>([...THEME_OPTIONS.map((option) => option.name), "custom"]);
+const ThemePreferenceSchema = z.enum([
+  ...THEME_OPTIONS.map((option) => option.name),
+  "custom",
+]);
 const VALID_SERVICE_URL_BEHAVIORS = new Set<ServiceUrlBehavior>(["ask", "in-app", "external"]);
 const VALID_WORKSPACE_TITLE_SOURCES = new Set<WorkspaceTitleSource>(["title", "branch"]);
 const VALID_SIDEBAR_WORKSPACE_TRAILINGS = new Set<SidebarWorkspaceTrailing>([
@@ -53,6 +57,7 @@ export const MAX_FONT_FAMILY_LENGTH = 200;
 
 export interface AppSettings {
   theme: ThemePreference;
+  customTheme: CustomThemePreset | null;
   language: AppLanguage;
   sendBehavior: SendBehavior;
   serviceUrlBehavior: ServiceUrlBehavior;
@@ -90,6 +95,7 @@ const SidebarRowItemsSchema = z.strictObject({
 
 const StoredAppSettingsSchema = z.strictObject({
   theme: ThemePreferenceSchema.optional(),
+  customTheme: z.unknown().optional(),
   language: z
     .enum(["system", "ar", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN"])
     .optional(),
@@ -122,6 +128,7 @@ type StoredAppSettings = z.infer<typeof StoredAppSettingsSchema>;
 
 export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   theme: "auto",
+  customTheme: null,
   language: "system",
   sendBehavior: "interrupt",
   serviceUrlBehavior: "ask",
@@ -273,6 +280,25 @@ function parseStoredSidebarChecksDisplay(stored: StoredAppSettings): SidebarChec
   return isChecksHiddenByLegacyRowItem(stored.sidebarRowItems) ? "none" : null;
 }
 
+function pickThemeSettings(
+  stored: StoredAppSettings,
+): Pick<Partial<AppSettings>, "customTheme" | "theme"> {
+  const parsedCustomTheme = customThemeSchema.safeParse(stored.customTheme);
+  const customTheme = parsedCustomTheme.success ? parsedCustomTheme.data : null;
+  const result: Pick<Partial<AppSettings>, "customTheme" | "theme"> = {};
+  if (customTheme !== null) {
+    result.customTheme = customTheme;
+  }
+  if (
+    typeof stored.theme === "string" &&
+    VALID_THEMES.has(stored.theme) &&
+    (stored.theme !== "custom" || customTheme !== null)
+  ) {
+    result.theme = stored.theme;
+  }
+  return result;
+}
+
 function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
   if (typeof stored.useLegacyTerminalRenderer === "boolean") {
@@ -294,9 +320,6 @@ function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings>
  */
 function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
-  if (typeof stored.theme === "string" && VALID_THEMES.has(stored.theme)) {
-    result.theme = stored.theme;
-  }
   if (
     stored.sendBehavior === "interrupt" ||
     stored.sendBehavior === "steer" ||
@@ -330,7 +353,7 @@ function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
 
 function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
   const result: Partial<AppSettings> = {};
-  Object.assign(result, pickEnumAppSettings(stored));
+  Object.assign(result, pickEnumAppSettings(stored), pickThemeSettings(stored));
   if (stored.sidebarRowItems !== undefined) {
     result.sidebarRowItems = parseSidebarRowItems(stored.sidebarRowItems);
   }

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -175,18 +175,38 @@ export interface SettingsDeps {
   desktop: DesktopSettingsBridge;
 }
 
+const appSettingsSaveQueues = new WeakMap<QueryClient, Promise<void>>();
+
 export async function saveAppSettings(input: {
   queryClient: QueryClient;
   updates: Partial<AppSettings>;
   deps: SettingsDeps;
 }): Promise<void> {
-  const storedCurrent =
-    input.queryClient.getQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY) ??
-    (await loadAppSettingsFromStorage(input.deps));
-  const current = normalizeAppSettings(storedCurrent);
-  const next = { ...current, ...input.updates };
-  input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
-  await input.deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
+  const previousSave = appSettingsSaveQueues.get(input.queryClient) ?? Promise.resolve();
+  const save = (async () => {
+    try {
+      await previousSave;
+    } catch {
+      // The previous caller receives its persistence error; this save must still run.
+    }
+
+    const storedCurrent =
+      input.queryClient.getQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY) ??
+      (await loadAppSettingsFromStorage(input.deps));
+    const current = normalizeAppSettings(storedCurrent);
+    const next = { ...current, ...input.updates };
+    await input.deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
+    input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
+  })();
+  appSettingsSaveQueues.set(input.queryClient, save);
+
+  try {
+    await save;
+  } finally {
+    if (appSettingsSaveQueues.get(input.queryClient) === save) {
+      appSettingsSaveQueues.delete(input.queryClient);
+    }
+  }
 }
 
 export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<AppSettings> {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -1,8 +1,6 @@
 import { isSyntaxThemeId, type SyntaxThemeId } from "@getpaseo/highlight";
 import type { ActiveTurnBehavior } from "@getpaseo/protocol/messages";
 import type { QueryClient } from "@tanstack/react-query";
-import type { DesktopSettings } from "@/desktop/settings/desktop-settings";
-import { parseAppLanguage, type AppLanguage } from "@/i18n/locales";
 import {
   DEFAULT_SIDEBAR_CHECKS_DISPLAY,
   parseSidebarChecksDisplay,
@@ -14,6 +12,8 @@ import {
   parseSidebarRowItems,
   type SidebarRowItems,
 } from "@/components/sidebar/display-preferences/row-items";
+import type { DesktopSettings } from "@/desktop/settings/desktop-settings";
+import { parseAppLanguage, type AppLanguage } from "@/i18n/locales";
 import { THEME_OPTIONS, type ThemePreference } from "@/styles/theme";
 import { z } from "zod";
 import { readValidatedJson } from "@/storage/validated-storage";

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -177,19 +177,36 @@ export interface SettingsDeps {
 
 const appSettingsSaveQueues = new WeakMap<QueryClient, Promise<void>>();
 
-export async function saveAppSettings(input: {
-  queryClient: QueryClient;
-  updates: Partial<AppSettings>;
-  deps: SettingsDeps;
-}): Promise<void> {
-  const previousSave = appSettingsSaveQueues.get(input.queryClient) ?? Promise.resolve();
+async function enqueueAppSettingsSave(
+  queryClient: QueryClient,
+  operation: () => Promise<void>,
+): Promise<void> {
+  const previousSave = appSettingsSaveQueues.get(queryClient) ?? Promise.resolve();
   const save = (async () => {
     try {
       await previousSave;
     } catch {
       // The previous caller receives its persistence error; this save must still run.
     }
+    await operation();
+  })();
+  appSettingsSaveQueues.set(queryClient, save);
 
+  try {
+    await save;
+  } finally {
+    if (appSettingsSaveQueues.get(queryClient) === save) {
+      appSettingsSaveQueues.delete(queryClient);
+    }
+  }
+}
+
+export async function saveAppSettings(input: {
+  queryClient: QueryClient;
+  updates: Partial<AppSettings>;
+  deps: SettingsDeps;
+}): Promise<void> {
+  await enqueueAppSettingsSave(input.queryClient, async () => {
     const storedCurrent =
       input.queryClient.getQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY) ??
       (await loadAppSettingsFromStorage(input.deps));
@@ -197,16 +214,18 @@ export async function saveAppSettings(input: {
     const next = { ...current, ...input.updates };
     await input.deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
     input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
-  })();
-  appSettingsSaveQueues.set(input.queryClient, save);
+  });
+}
 
-  try {
-    await save;
-  } finally {
-    if (appSettingsSaveQueues.get(input.queryClient) === save) {
-      appSettingsSaveQueues.delete(input.queryClient);
-    }
-  }
+export async function resetAppSettings(input: {
+  queryClient: QueryClient;
+  deps: SettingsDeps;
+}): Promise<void> {
+  await enqueueAppSettingsSave(input.queryClient, async () => {
+    const next = { ...DEFAULT_CLIENT_SETTINGS };
+    await input.deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
+    input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
+  });
 }
 
 export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<AppSettings> {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1965,7 +1965,14 @@ export const ar: TranslationResources = {
           claude: "كلود",
           ghostty: "شبحي",
           pureBlack: "أسود خالص",
+          custom: "مخصص",
           auto: "نظام",
+        },
+        custom: {
+          title: "سمة مخصصة",
+          none: "استورد ملف سمة Paseo بصيغة JSON",
+          import: "استيراد",
+          importing: "جارٍ الاستيراد...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2029,7 +2029,14 @@ export const en = {
           claude: "Claude",
           ghostty: "Ghostty",
           pureBlack: "Pure black",
+          custom: "Custom",
           auto: "System",
+        },
+        custom: {
+          title: "Custom theme",
+          none: "Import a Paseo theme JSON file",
+          import: "Import",
+          importing: "Importing...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2012,7 +2012,14 @@ export const es: TranslationResources = {
           claude: "claudio",
           ghostty: "fantasmal",
           pureBlack: "Negro puro",
+          custom: "Personalizado",
           auto: "Sistema",
+        },
+        custom: {
+          title: "Tema personalizado",
+          none: "Importa un archivo de tema de Paseo en JSON",
+          import: "Importar",
+          importing: "Importando...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2016,7 +2016,14 @@ export const fr: TranslationResources = {
           claude: "Claude",
           ghostty: "Fantôme",
           pureBlack: "Noir pur",
+          custom: "Personnalisé",
           auto: "Système",
+        },
+        custom: {
+          title: "Thème personnalisé",
+          none: "Importer un fichier de thème Paseo JSON",
+          import: "Importer",
+          importing: "Importation...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1981,7 +1981,14 @@ export const ja: TranslationResources = {
           claude: "Claude",
           ghostty: "Ghostty",
           pureBlack: "ピュアブラック",
+          custom: "カスタム",
           auto: "システム",
+        },
+        custom: {
+          title: "カスタムテーマ",
+          none: "PaseoテーマのJSONファイルをインポート",
+          import: "インポート",
+          importing: "インポート中...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1976,7 +1976,14 @@ export const ko: TranslationResources = {
           claude: "Claude",
           ghostty: "Ghostty",
           pureBlack: "순수 검정",
+          custom: "사용자 지정",
           auto: "시스템",
+        },
+        custom: {
+          title: "사용자 지정 테마",
+          none: "Paseo 테마 JSON 파일 가져오기",
+          import: "가져오기",
+          importing: "가져오는 중...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1996,7 +1996,14 @@ export const ptBR: TranslationResources = {
           claude: "Claude",
           ghostty: "Ghostty",
           pureBlack: "Preto puro",
+          custom: "Personalizado",
           auto: "Sistema",
+        },
+        custom: {
+          title: "Tema personalizado",
+          none: "Importe um arquivo de tema Paseo em JSON",
+          import: "Importar",
+          importing: "Importando...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2002,7 +2002,14 @@ export const ru: TranslationResources = {
           claude: "Клод",
           ghostty: "Призрачный",
           pureBlack: "Чистый чёрный",
+          custom: "Пользовательская",
           auto: "Система",
+        },
+        custom: {
+          title: "Пользовательская тема",
+          none: "Импортируйте JSON-файл темы Paseo",
+          import: "Импортировать",
+          importing: "Импорт...",
         },
       },
       detailLevel: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1942,7 +1942,14 @@ export const zhCN: TranslationResources = {
           claude: "Claude",
           ghostty: "Ghostty",
           pureBlack: "纯黑",
+          custom: "自定义",
           auto: "系统",
+        },
+        custom: {
+          title: "自定义主题",
+          none: "导入 Paseo 主题 JSON 文件",
+          import: "导入",
+          importing: "正在导入...",
         },
       },
       detailLevel: {

--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -38,7 +38,9 @@ import {
 } from "@/styles/theme";
 import { isNative } from "@/constants/platform";
 import { settingsStyles } from "@/styles/settings";
+import type { CustomThemePreset } from "@/styles/custom-theme";
 import { AppearancePreview } from "./appearance-preview";
+import { CustomThemeImportRow } from "./custom-theme-import-row";
 
 // ---------------------------------------------------------------------------
 // Theme-reactive leaf icons (withUnistyles + uniProps color mapping — no
@@ -83,9 +85,10 @@ function dropdownTriggerStyle({ pressed }: PressableStateCallbackType) {
 
 interface ThemeLeadingProps {
   themeValue: AppSettings["theme"];
+  customColor?: string;
 }
 
-function ThemeLeading({ themeValue }: ThemeLeadingProps) {
+function ThemeLeading({ themeValue, customColor }: ThemeLeadingProps) {
   switch (themeValue) {
     case "light":
       return <ThemedSun size={ICON_SIZE.md} uniProps={mutedColorMapping} />;
@@ -93,6 +96,8 @@ function ThemeLeading({ themeValue }: ThemeLeadingProps) {
       return <ThemedMoon size={ICON_SIZE.md} uniProps={mutedColorMapping} />;
     case "auto":
       return <ThemedMonitor size={ICON_SIZE.md} uniProps={mutedColorMapping} />;
+    case "custom":
+      return <ThemeSwatch color={customColor ?? THEME_SWATCHES.custom} />;
     default:
       return <ThemeSwatch color={THEME_SWATCHES[themeValue]} />;
   }
@@ -109,16 +114,20 @@ function ThemeSwatch({ color }: ThemeSwatchProps) {
 
 interface ThemeMenuItemProps {
   themeValue: AppSettings["theme"];
+  customColor?: string;
   selected: boolean;
   onChange: (theme: AppSettings["theme"]) => void;
 }
 
-function ThemeMenuItem({ themeValue, selected, onChange }: ThemeMenuItemProps) {
+function ThemeMenuItem({ themeValue, customColor, selected, onChange }: ThemeMenuItemProps) {
   const { t } = useTranslation();
   const handleSelect = useCallback(() => {
     onChange(themeValue);
   }, [onChange, themeValue]);
-  const leading = useMemo(() => <ThemeLeading themeValue={themeValue} />, [themeValue]);
+  const leading = useMemo(
+    () => <ThemeLeading themeValue={themeValue} customColor={customColor} />,
+    [customColor, themeValue],
+  );
   return (
     <DropdownMenuItem selected={selected} onSelect={handleSelect} leading={leading}>
       {getThemeLabel(t, themeValue)}
@@ -128,12 +137,14 @@ function ThemeMenuItem({ themeValue, selected, onChange }: ThemeMenuItemProps) {
 
 interface ThemeRowProps {
   value: AppSettings["theme"];
+  customTheme: CustomThemePreset | null;
   onChange: (theme: AppSettings["theme"]) => void;
 }
 
-function ThemeRow({ value, onChange }: ThemeRowProps) {
+function ThemeRow({ value, customTheme, onChange }: ThemeRowProps) {
   const { t } = useTranslation();
   const selectedLabel = getThemeLabel(t, value);
+  const customColor = customTheme?.colors.highlight ?? customTheme?.colors.accent;
   return (
     <View style={settingsStyles.row}>
       <View style={settingsStyles.rowContent}>
@@ -146,7 +157,7 @@ function ThemeRow({ value, onChange }: ThemeRowProps) {
             value: selectedLabel,
           })}
         >
-          <ThemeLeading themeValue={value} />
+          <ThemeLeading themeValue={value} customColor={customColor} />
           <Text style={styles.triggerText}>{selectedLabel}</Text>
           <ThemedChevronDown size={ICON_SIZE.sm} uniProps={mutedColorMapping} />
         </DropdownMenuTrigger>
@@ -166,6 +177,17 @@ function ThemeRow({ value, onChange }: ThemeRowProps) {
               </Fragment>
             );
           })}
+          {customTheme ? (
+            <>
+              <DropdownMenuSeparator />
+              <ThemeMenuItem
+                themeValue="custom"
+                customColor={customColor}
+                selected={value === "custom"}
+                onChange={onChange}
+              />
+            </>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
     </View>
@@ -488,6 +510,11 @@ export function AppearanceSection() {
     [updateSettings],
   );
 
+  const handleCustomThemeImport = useCallback(
+    (customTheme: CustomThemePreset) => updateSettings({ customTheme, theme: "custom" }),
+    [updateSettings],
+  );
+
   const handleSyntaxThemeChange = useCallback(
     (syntaxTheme: SyntaxThemeId) => {
       void updateSettings({ syntaxTheme });
@@ -593,7 +620,15 @@ export function AppearanceSection() {
     <View>
       <SettingsSection title={t("settings.appearance.theme.title")}>
         <View style={settingsStyles.card}>
-          <ThemeRow value={settings.theme} onChange={handleThemeChange} />
+          <ThemeRow
+            value={settings.theme}
+            customTheme={settings.customTheme}
+            onChange={handleThemeChange}
+          />
+          <CustomThemeImportRow
+            customThemeName={settings.customTheme?.name ?? null}
+            onImport={handleCustomThemeImport}
+          />
         </View>
       </SettingsSection>
       <SettingsSection title={t("settings.appearance.detailLevel.title")}>

--- a/packages/app/src/screens/settings/appearance/apply-appearance.test.ts
+++ b/packages/app/src/screens/settings/appearance/apply-appearance.test.ts
@@ -14,7 +14,7 @@ const { runtime, updateTheme } = vi.hoisted(() => {
 });
 vi.mock("react-native-unistyles", () => ({ UnistylesRuntime: runtime }));
 
-const ALL_THEME_KEYS = Object.keys(REGISTERED_THEMES);
+const ALL_THEME_KEYS = [...Object.keys(REGISTERED_THEMES), "custom"];
 
 // The signature of the updater passed to UnistylesRuntime.updateTheme.
 type ThemeUpdater = (theme: FakeTheme) => FakeTheme;

--- a/packages/app/src/screens/settings/appearance/apply-appearance.ts
+++ b/packages/app/src/screens/settings/appearance/apply-appearance.ts
@@ -9,7 +9,10 @@ import {
 } from "@/styles/theme";
 import { applyRootUiFont } from "./apply-root-font";
 
-const ALL_THEME_KEYS = Object.keys(REGISTERED_THEMES) as (keyof typeof REGISTERED_THEMES)[];
+const ALL_THEME_KEYS = [
+  ...(Object.keys(REGISTERED_THEMES) as (keyof typeof REGISTERED_THEMES)[]),
+  "custom",
+] as const;
 
 // The UI font size at which the FONT_SIZE ramp is authored (1.0 scale factor).
 const BASE_UI_REFERENCE = FONT_SIZE.base; // 16

--- a/packages/app/src/screens/settings/appearance/custom-theme-import-row.tsx
+++ b/packages/app/src/screens/settings/appearance/custom-theme-import-row.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Text, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { customThemeSchema, type CustomThemePreset } from "@/styles/custom-theme";
+import { settingsStyles } from "@/styles/settings";
+import { pickCustomThemeJson } from "./pick-custom-theme-file";
+
+type ImportState =
+  | { status: "idle" }
+  | { status: "pending" }
+  | { status: "error"; message: string };
+
+interface CustomThemeImportRowProps {
+  customThemeName: string | null;
+  onImport: (preset: CustomThemePreset) => Promise<void>;
+}
+
+export function CustomThemeImportRow({ customThemeName, onImport }: CustomThemeImportRowProps) {
+  const { t } = useTranslation();
+  const [state, setState] = useState<ImportState>({ status: "idle" });
+
+  const importTheme = useCallback(async () => {
+    setState({ status: "pending" });
+    try {
+      const json = await pickCustomThemeJson();
+      if (json === null) {
+        setState({ status: "idle" });
+        return;
+      }
+      const preset = customThemeSchema.parse(JSON.parse(json));
+      await onImport(preset);
+      setState({ status: "idle" });
+    } catch (error) {
+      setState({
+        status: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [onImport]);
+
+  const description = customThemeName ?? t("settings.appearance.theme.custom.none");
+
+  return (
+    <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
+      <View style={settingsStyles.rowContent}>
+        <Text style={settingsStyles.rowTitle}>{t("settings.appearance.theme.custom.title")}</Text>
+        <Text style={settingsStyles.rowHint}>{description}</Text>
+        {state.status === "error" ? (
+          <Text style={settingsStyles.rowError}>{state.message}</Text>
+        ) : null}
+      </View>
+      <Button
+        variant="outline"
+        size="sm"
+        loading={state.status === "pending"}
+        onPress={importTheme}
+      >
+        {state.status === "pending"
+          ? t("settings.appearance.theme.custom.importing")
+          : t("settings.appearance.theme.custom.import")}
+      </Button>
+    </View>
+  );
+}

--- a/packages/app/src/screens/settings/appearance/pick-custom-theme-file.ts
+++ b/packages/app/src/screens/settings/appearance/pick-custom-theme-file.ts
@@ -1,0 +1,24 @@
+import * as DocumentPicker from "expo-document-picker";
+import { File } from "expo-file-system";
+
+const MAX_CUSTOM_THEME_BYTES = 64 * 1024;
+
+export async function pickCustomThemeJson(): Promise<string | null> {
+  const result = await DocumentPicker.getDocumentAsync({
+    type: "application/json",
+    multiple: false,
+    copyToCacheDirectory: true,
+  });
+  if (result.canceled) {
+    return null;
+  }
+  const asset = result.assets[0];
+  if (!asset) {
+    return null;
+  }
+  const file = new File(asset.uri);
+  if (file.size > MAX_CUSTOM_THEME_BYTES) {
+    throw new RangeError("Theme files must be smaller than 64 KB");
+  }
+  return await file.text();
+}

--- a/packages/app/src/screens/settings/appearance/pick-custom-theme-file.web.ts
+++ b/packages/app/src/screens/settings/appearance/pick-custom-theme-file.web.ts
@@ -1,0 +1,37 @@
+const MAX_CUSTOM_THEME_BYTES = 64 * 1024;
+
+export function pickCustomThemeJson(): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "application/json,.json";
+    input.style.display = "none";
+
+    function finish(value: string | null) {
+      input.remove();
+      resolve(value);
+    }
+
+    input.addEventListener("change", async () => {
+      const file = input.files?.[0];
+      if (!file) {
+        finish(null);
+        return;
+      }
+      if (file.size > MAX_CUSTOM_THEME_BYTES) {
+        input.remove();
+        reject(new RangeError("Theme files must be smaller than 64 KB"));
+        return;
+      }
+      try {
+        finish(await file.text());
+      } catch (error) {
+        input.remove();
+        reject(error);
+      }
+    });
+    input.addEventListener("cancel", () => finish(null));
+    document.body.appendChild(input);
+    input.click();
+  });
+}

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -1472,6 +1472,17 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
   },
+  tabFocusIndicator: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 2,
+    backgroundColor: theme.colors.accentBright,
+  },
+  tabFocusIndicatorUnfocused: {
+    backgroundColor: theme.colors.accent,
+  },
   // The chip box stops at the slot's padding box, so the gap between two chips runs from
   // -TAB_CHIP_GAP to 0. Centre a TAB_DROP_INDICATOR_WIDTH pill in it.
   tabDropIndicator: {

--- a/packages/app/src/styles/custom-theme.test.ts
+++ b/packages/app/src/styles/custom-theme.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { darkTheme } from "./theme";
+import { buildCustomTheme, customThemeSchema } from "./custom-theme";
+
+const ORCA_THEME = {
+  version: 1,
+  name: "Jon",
+  appearance: "dark",
+  colors: {
+    background: "#222222",
+    foreground: "#dbd7ca",
+    raised: "#262626",
+    control: "#2b2b2b",
+    accent: "#393a34",
+    highlight: "#e6cc77",
+    mutedForeground: "#a9a397",
+    ring: "#777777",
+  },
+} as const;
+
+describe("customThemeSchema", () => {
+  it("accepts a version 1 custom theme", () => {
+    expect(customThemeSchema.parse(ORCA_THEME)).toEqual(ORCA_THEME);
+  });
+
+  it("rejects invalid color values", () => {
+    const invalid = {
+      ...ORCA_THEME,
+      colors: { ...ORCA_THEME.colors, background: "red" },
+    };
+
+    expect(() => customThemeSchema.parse(invalid)).toThrow("Must be a hex color");
+  });
+});
+
+describe("buildCustomTheme", () => {
+  it("maps compact custom colors onto Paseo semantic and terminal tokens", () => {
+    const theme = buildCustomTheme(customThemeSchema.parse(ORCA_THEME));
+
+    expect(theme.colors).toMatchObject({
+      surface0: "#222222",
+      surface1: "#262626",
+      surface2: "#2b2b2b",
+      surfaceSidebar: "#222222",
+      foreground: "#dbd7ca",
+      foregroundMuted: "#a9a397",
+      border: "#393a34",
+      accent: "#e6cc77",
+      accentBright: "#e6cc77",
+      accentForeground: "#222222",
+      ring: "#777777",
+      terminal: {
+        background: "#222222",
+        foreground: "#dbd7ca",
+        cursor: "#dbd7ca",
+        cursorAccent: "#222222",
+      },
+    });
+    expect(theme.colors.palette).toBe(darkTheme.colors.palette);
+    expect(theme.colors.syntax).toBe(darkTheme.colors.syntax);
+  });
+});

--- a/packages/app/src/styles/custom-theme.ts
+++ b/packages/app/src/styles/custom-theme.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { darkTheme } from "./theme";
+
+const hexColorSchema = z
+  .string()
+  .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/, "Must be a hex color");
+
+export const customThemeSchema = z
+  .object({
+    version: z.literal(1),
+    name: z.string().trim().min(1).max(60),
+    appearance: z.literal("dark"),
+    colors: z
+      .object({
+        background: hexColorSchema,
+        foreground: hexColorSchema,
+        raised: hexColorSchema,
+        control: hexColorSchema,
+        accent: hexColorSchema,
+        highlight: hexColorSchema.optional(),
+        mutedForeground: hexColorSchema,
+        ring: hexColorSchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+export type CustomThemePreset = z.infer<typeof customThemeSchema>;
+
+export function buildCustomTheme(preset: CustomThemePreset) {
+  const colors = preset.colors;
+  const primaryAccent = colors.highlight ?? colors.foreground;
+  return {
+    ...darkTheme,
+    colors: {
+      ...darkTheme.colors,
+      surface0: colors.background,
+      surface1: colors.raised,
+      surface2: colors.control,
+      surface3: colors.accent,
+      surface4: colors.ring,
+      surfaceDiffEmpty: colors.raised,
+      surfaceSidebar: colors.background,
+      surfaceSidebarHover: colors.raised,
+      surfaceWorkspace: colors.background,
+      foreground: colors.foreground,
+      foregroundMuted: colors.mutedForeground,
+      foregroundExtraMuted: colors.ring,
+      scrollbarHandle: colors.ring,
+      border: colors.accent,
+      borderAccent: colors.accent,
+      accent: primaryAccent,
+      accentBright: primaryAccent,
+      accentForeground: colors.background,
+      background: colors.background,
+      popover: colors.raised,
+      popoverForeground: colors.foreground,
+      primary: colors.foreground,
+      primaryForeground: colors.background,
+      secondary: colors.control,
+      secondaryForeground: colors.foreground,
+      muted: colors.control,
+      mutedForeground: colors.mutedForeground,
+      accentBorder: colors.accent,
+      input: colors.accent,
+      ring: colors.ring,
+      terminal: {
+        ...darkTheme.colors.terminal,
+        background: colors.background,
+        foreground: colors.foreground,
+        cursor: colors.foreground,
+        cursorAccent: colors.background,
+        selectionForeground: colors.foreground,
+        black: colors.background,
+        brightBlack: colors.ring,
+      },
+    },
+  };
+}
+
+export const DEFAULT_CUSTOM_THEME_PRESET: CustomThemePreset = {
+  version: 1,
+  name: "Custom",
+  appearance: "dark",
+  colors: {
+    background: "#181B1A",
+    foreground: "#fafafa",
+    raised: "#1E2120",
+    control: "#272A29",
+    accent: "#20744A",
+    mutedForeground: "#A1A5A4",
+    ring: "#717574",
+  },
+};
+
+export const customTheme = buildCustomTheme(DEFAULT_CUSTOM_THEME_PRESET);

--- a/packages/app/src/styles/theme.ts
+++ b/packages/app/src/styles/theme.ts
@@ -755,7 +755,7 @@ export const THEME_OPTIONS = [
   },
 ] as const;
 
-export type ThemePreference = (typeof THEME_OPTIONS)[number]["name"];
+export type ThemePreference = (typeof THEME_OPTIONS)[number]["name"] | "custom";
 export type ThemeName = Exclude<ThemePreference, "auto">;
 type ConcreteThemeOption = Exclude<(typeof THEME_OPTIONS)[number], { name: "auto" }>;
 export type Theme = ConcreteThemeOption["theme"];
@@ -765,24 +765,28 @@ const CONCRETE_THEME_OPTIONS = THEME_OPTIONS.filter(
 );
 
 type ThemeToUnistyles = {
-  [Name in ThemeName]: Extract<ConcreteThemeOption, { name: Name }>["unistylesName"];
-};
+  [Name in Exclude<ThemeName, "custom">]: Extract<ConcreteThemeOption, { name: Name }>["unistylesName"];
+} & { custom: "custom" };
 
 type ThemeSwatches = {
-  [Name in ThemeName]: Extract<ConcreteThemeOption, { name: Name }>["swatch"];
-};
+  [Name in Exclude<ThemeName, "custom">]: Extract<ConcreteThemeOption, { name: Name }>["swatch"];
+} & { custom: string };
 
 type RegisteredThemes = {
   [Option in ConcreteThemeOption as Option["unistylesName"]]: Option["theme"];
 };
 
-export const THEME_TO_UNISTYLES = Object.fromEntries(
-  CONCRETE_THEME_OPTIONS.map((option) => [option.name, option.unistylesName]),
-) as ThemeToUnistyles;
+export const THEME_TO_UNISTYLES = {
+  ...Object.fromEntries(
+    CONCRETE_THEME_OPTIONS.map((option) => [option.name, option.unistylesName]),
+  ),
+  custom: "custom",
+} as ThemeToUnistyles;
 
-export const THEME_SWATCHES = Object.fromEntries(
-  CONCRETE_THEME_OPTIONS.map((option) => [option.name, option.swatch]),
-) as ThemeSwatches;
+export const THEME_SWATCHES = {
+  ...Object.fromEntries(CONCRETE_THEME_OPTIONS.map((option) => [option.name, option.swatch])),
+  custom: "#20744A",
+} as ThemeSwatches;
 
 export const REGISTERED_THEMES = Object.fromEntries(
   CONCRETE_THEME_OPTIONS.map((option) => [option.unistylesName, option.theme]),

--- a/packages/app/src/styles/unistyles.ts
+++ b/packages/app/src/styles/unistyles.ts
@@ -1,8 +1,12 @@
 import { StyleSheet } from "react-native-unistyles";
 import { REGISTERED_THEMES } from "./theme";
+import { customTheme } from "./custom-theme";
 
 StyleSheet.configure({
-  themes: REGISTERED_THEMES,
+  themes: {
+    ...REGISTERED_THEMES,
+    custom: customTheme,
+  },
   breakpoints: {
     xs: 0,
     sm: 576,
@@ -16,7 +20,7 @@ StyleSheet.configure({
 });
 
 // Type augmentation for TypeScript
-type AppThemes = typeof REGISTERED_THEMES;
+type AppThemes = typeof REGISTERED_THEMES & { custom: typeof customTheme };
 
 interface AppBreakpoints {
   xs: number;


### PR DESCRIPTION
### Linked issue

No matching open issue found.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

- Adds JSON custom theme imports in Appearance settings.
- Validates theme files before saving or activating them.
- Applies custom colors across app surfaces, terminal colors, and active tab highlights.

### How did you verify it

- Imported the Ghostty and Herdr-inspired theme in desktop web.
- Custom theme import Playwright regression: 1 test passed.
- Focused custom theme coverage: 49 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

### UI Preview

<img width="3024" height="1936" alt="CleanShot 2026-07-26 at 14 06 36@2x" src="https://github.com/user-attachments/assets/25a4c868-745c-4db9-941c-922cd42314f0" />
<img width="2930" height="1920" alt="CleanShot 2026-07-26 at 14 07 01@2x" src="https://github.com/user-attachments/assets/19633b2f-db3f-4708-87ac-251d8086e1c0" />
