### PR TITLE
Stop the daemon when you quit the desktop app

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -382,5 +382,5 @@ $PASEO_HOME/
 ## Deployment models
 
 1. **Local daemon** (default): `paseo daemon start` on `127.0.0.1:6767`
-2. **Managed desktop**: Electron app spawns daemon as subprocess
+2. **Managed desktop**: Electron app spawns daemon as subprocess, and stops it again on quit so that "restart the app" is a complete reset. Settings > Host > "Keep daemon running after quit" opts out. Only a daemon the desktop started is stopped — a daemon you started yourself with `paseo daemon start` is left alone (`paseo.pid` records `desktopManaged`).
 3. **Remote + relay**: Daemon behind firewall, relay bridges with E2E encryption

--- a/docs/product.md
+++ b/docs/product.md
@@ -43,7 +43,8 @@ This architecture means:
 
 - The daemon can run on any machine: laptop, VM, remote server
 - Multiple clients can connect simultaneously
-- Agents keep running when you close the app
+- Agents keep running when a client disconnects — the daemon owns them, not the client
+- Quitting the desktop app stops the daemon it started, so "restart the app" is a real fix; a daemon you run yourself is unaffected
 
 ## Target user
 

--- a/packages/app/src/desktop/settings/desktop-settings.ts
+++ b/packages/app/src/desktop/settings/desktop-settings.ts
@@ -28,7 +28,7 @@ export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   releaseChannel: "stable",
   daemon: {
     manageBuiltInDaemon: true,
-    keepRunningAfterQuit: true,
+    keepRunningAfterQuit: false,
   },
 };
 

--- a/packages/app/src/hooks/use-settings/fakes.ts
+++ b/packages/app/src/hooks/use-settings/fakes.ts
@@ -31,7 +31,7 @@ const DEFAULT_DESKTOP: DesktopSettings = {
   releaseChannel: "stable",
   daemon: {
     manageBuiltInDaemon: true,
-    keepRunningAfterQuit: true,
+    keepRunningAfterQuit: false,
   },
 };
 

--- a/packages/desktop/src/daemon/quit-lifecycle.test.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.test.ts
@@ -7,12 +7,12 @@ import {
   stopDesktopManagedDaemonOnQuitIfNeeded,
 } from "./quit-lifecycle";
 
-const SETTINGS_KEEP_RUNNING = DEFAULT_DESKTOP_SETTINGS;
-const SETTINGS_STOP_ON_QUIT = {
+const SETTINGS_STOP_ON_QUIT = DEFAULT_DESKTOP_SETTINGS;
+const SETTINGS_KEEP_RUNNING = {
   ...DEFAULT_DESKTOP_SETTINGS,
   daemon: {
     ...DEFAULT_DESKTOP_SETTINGS.daemon,
-    keepRunningAfterQuit: false,
+    keepRunningAfterQuit: true,
   },
 };
 
@@ -29,7 +29,7 @@ function waitForQuitLifecycle(): Promise<void> {
 }
 
 describe("quit-lifecycle", () => {
-  it("only stops when keepRunningAfterQuit is explicitly disabled", () => {
+  it("stops by default and only keeps running when keepRunningAfterQuit is enabled", () => {
     expect(shouldStopDesktopManagedDaemonOnQuit(SETTINGS_STOP_ON_QUIT)).toBe(true);
     expect(shouldStopDesktopManagedDaemonOnQuit(SETTINGS_KEEP_RUNNING)).toBe(false);
   });

--- a/packages/desktop/src/settings/desktop-settings.test.ts
+++ b/packages/desktop/src/settings/desktop-settings.test.ts
@@ -162,6 +162,50 @@ describe("desktop-settings", () => {
     expect(persisted).toBe(raw);
   });
 
+  it("resets the pre-existing keep-running default so the daemon stops with the app", async () => {
+    const userDataPath = await createTempUserDataDir();
+    directories.add(userDataPath);
+    await writeFile(
+      settingsFilePath(userDataPath),
+      JSON.stringify({
+        version: 1,
+        settings: {
+          releaseChannel: "stable",
+          daemon: { manageBuiltInDaemon: true, keepRunningAfterQuit: true },
+        },
+        migrations: { legacyRendererSettingsImported: true },
+      }),
+    );
+    const store = createDesktopSettingsStore({ userDataPath });
+
+    const settings = await store.get();
+
+    expect(settings.daemon.keepRunningAfterQuit).toBe(false);
+  });
+
+  it("keeps an explicit keep-running choice across restarts", async () => {
+    const userDataPath = await createTempUserDataDir();
+    directories.add(userDataPath);
+    await writeFile(
+      settingsFilePath(userDataPath),
+      JSON.stringify({
+        version: 1,
+        settings: {
+          releaseChannel: "stable",
+          daemon: { manageBuiltInDaemon: true, keepRunningAfterQuit: true },
+        },
+        migrations: { legacyRendererSettingsImported: true },
+      }),
+    );
+    await createDesktopSettingsStore({ userDataPath }).patch({
+      daemon: { keepRunningAfterQuit: true },
+    });
+
+    const settings = await createDesktopSettingsStore({ userDataPath }).get();
+
+    expect(settings.daemon.keepRunningAfterQuit).toBe(true);
+  });
+
   it("migrates desktop-owned values from legacy renderer settings once", async () => {
     const userDataPath = await createTempUserDataDir();
     directories.add(userDataPath);

--- a/packages/desktop/src/settings/desktop-settings.ts
+++ b/packages/desktop/src/settings/desktop-settings.ts
@@ -22,6 +22,11 @@ interface PersistedDesktopSettingsDocument {
   settings: DesktopSettings;
   migrations: {
     legacyRendererSettingsImported: boolean;
+    // Installs created before the stop-on-quit default persisted the old
+    // `keepRunningAfterQuit: true` default to disk, so the new default alone
+    // would only reach fresh installs. Reset it once; a later explicit toggle
+    // persists this flag and is never overridden again.
+    daemonStopOnQuitDefaultApplied: boolean;
   };
 }
 
@@ -35,7 +40,7 @@ export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   releaseChannel: "stable",
   daemon: {
     manageBuiltInDaemon: true,
-    keepRunningAfterQuit: true,
+    keepRunningAfterQuit: false,
   },
 };
 
@@ -72,6 +77,7 @@ function buildDefaultDocument(): PersistedDesktopSettingsDocument {
     },
     migrations: {
       legacyRendererSettingsImported: false,
+      daemonStopOnQuitDefaultApplied: true,
     },
   };
 }
@@ -180,10 +186,17 @@ function coerceDocument(input: unknown): PersistedDesktopSettingsDocument {
   const migrations = isRecord(input.migrations)
     ? {
         legacyRendererSettingsImported: input.migrations.legacyRendererSettingsImported === true,
+        daemonStopOnQuitDefaultApplied: input.migrations.daemonStopOnQuitDefaultApplied === true,
       }
     : {
         legacyRendererSettingsImported: false,
+        daemonStopOnQuitDefaultApplied: false,
       };
+
+  if (!migrations.daemonStopOnQuitDefaultApplied) {
+    settings.daemon.keepRunningAfterQuit = DEFAULT_DESKTOP_SETTINGS.daemon.keepRunningAfterQuit;
+    migrations.daemonStopOnQuitDefaultApplied = true;
+  }
 
   return {
     version: 1,


### PR DESCRIPTION
## What changed

Quitting the desktop app now shuts down the daemon it started. Previously the daemon stayed alive after quit, so "restart the app" fixed nothing — support answers had to start by explaining what a daemon is and how to restart it separately. Now restarting the app is a genuine full reset.

The behavior is still a toggle: **Settings > Host > "Keep daemon running after quit"** opts back into the old behavior. Only the setting's default moved.

Two things deliberately unchanged:

- A daemon you started yourself (`paseo daemon start`) is never touched. The quit path already gated on the `desktopManaged` flag in `paseo.pid`; that guard does the work now that the default flipped.
- The daemon still owns agent lifetime, so agents survive a client disconnecting. What changes is that quitting the desktop app is no longer just a disconnect.

### Why the migration

Existing installs persisted `keepRunningAfterQuit: true` to `desktop-settings.json` from the old default, so changing `DEFAULT_DESKTOP_SETTINGS` alone would only ever reach fresh installs. A one-time migration, tracked by a `daemonStopOnQuitDefaultApplied` flag in the settings document, resets it. Once a user explicitly toggles the setting, the flag is persisted alongside their choice and is never overridden again.

Refs #1265 — quitting now has a real consequence on Windows/Linux, which makes a close-to-tray option more valuable than it was.

## How to verify beyond CI

Unit tests cover the decision logic (`quit-lifecycle`) and the migration against a real filesystem, but nothing in CI drives a real Electron quit. Worth checking on a packaged build:

- Quit the desktop app with an agent running, then `paseo daemon status` — the daemon should be gone, and the "Quitting Paseo… / Stopping the local daemon." overlay should appear during shutdown.
- Start a daemon yourself with `paseo daemon start`, open and quit the desktop app, and confirm your daemon survives.
- Upgrade over an existing install and confirm the Host settings toggle reads off; toggle it on, quit, relaunch, and confirm it stayed on.
- Windows and Linux quit paths — `window-all-closed` quits the app on non-macOS, so quitting is reached via a different route than Cmd+Q.

## Risk surface

- **Behavior change on upgrade.** Users who deliberately turned the setting on before this release are indistinguishable on disk from users who never touched it, so the migration resets both. Anyone relying on the daemon surviving quit for phone access has to re-enable it once.
- **Agents die with the daemon.** That's the point of the change, but it's a sharper edge than before for anyone who quits the desktop app while work is in flight.
- **Update-on-quit ordering.** Daemon shutdown runs before update revalidation in the quit lifecycle, and that path is now exercised on every quit rather than rarely. Covered by unit tests, but it is newly hot.