### PR TITLE
Explain how to recover from an expired Claude login

### DIFF
--- a/public-docs/claude-code.md
+++ b/public-docs/claude-code.md
@@ -20,6 +20,8 @@ You still need a Claude plan that includes Claude Code, and your plan's usual us
 
 Install and sign in to the Claude Code CLI on the machine running Paseo. Paseo uses that existing installation and account when you start a Claude Code agent.
 
+If your Claude login expires, re-authenticate with the Claude Code CLI, then start a new Claude Code session in Paseo. Existing Paseo sessions keep the authentication they started with, so re-authenticating does not update a session that is already running.
+
 ## Use Claude Code in the Paseo terminal
 
 Claude Code also works great inside the Paseo terminal. If you prefer the standard CLI experience, open a terminal in your workspace and run `claude` as usual.


### PR DESCRIPTION
### Linked issue

None. Docs-only change.

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Explains how to recover when a Claude Code login expires: re-authenticate through the Claude Code CLI, then start a new Paseo session. Existing sessions keep the authentication they started with and do not pick up the refreshed login.

### How did you verify it

- Ran `npm run format`
- Ran `npm run typecheck`
- Ran `npm run lint`
- Reviewed the rendered Markdown source for the Claude Code public docs page

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [ ] Tests added or updated where it made sense