### PR TITLE
Focus the file pane when clicking its editor

### DIFF
--- a/packages/app/e2e/file-editing.spec.ts
+++ b/packages/app/e2e/file-editing.spec.ts
@@ -95,6 +95,34 @@ test.describe("CodeMirror workspace file editing", () => {
     }
   });
 
+  test("clicking the editor focuses its pane beside an agent", async ({ page }) => {
+    const target = "target.ts:42";
+    const session = await seedAgentWithFileLink(target);
+
+    try {
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await openAgentRoute(page, session);
+
+      await page.getByRole("button", { name: "Split pane right" }).first().click();
+      await expect(page.getByTestId("workspace-tabs-row").filter({ visible: true })).toHaveCount(2);
+      await openWorkspaceFile(page, "target.ts");
+
+      await page
+        .getByTestId(`workspace-tab-agent_${session.agentId}`)
+        .filter({ visible: true })
+        .click();
+      await editor(page).click();
+      await page.keyboard.press("Alt+Shift+W");
+
+      await expect(page.getByTestId("workspace-tab-file_target.ts")).not.toBeVisible();
+      await expect(
+        page.getByTestId(`workspace-tab-agent_${session.agentId}`).filter({ visible: true }),
+      ).toBeVisible();
+    } finally {
+      await session.cleanup();
+    }
+  });
+
   test("shows the full file path and keeps editor controls stable", async ({
     page,
     withWorkspace,

--- a/packages/app/src/components/split-container-pane-focus.ts
+++ b/packages/app/src/components/split-container-pane-focus.ts
@@ -4,7 +4,6 @@ const INTERACTIVE_TARGET_SELECTOR = [
   "select",
   "[role='button']",
   "[role='link']",
-  "[contenteditable='true']",
   "[data-paseo-pane-focus-exempt='true']",
 ].join(", ");
 


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

When an agent and file are open side by side, clicking inside the file editor now makes the file pane the focused pane. Previously the split-pane interaction filter exempted all `contenteditable` surfaces, so CodeMirror gained DOM focus without transferring Paseo's pane focus; pane-scoped shortcuts could still act on the agent.

The fix lets editable document surfaces claim pane focus, matching the existing behavior for composer inputs and textareas.

### How did you verify it

- Added a Playwright regression that opens an agent and file side by side, focuses the agent, clicks CodeMirror, then invokes Close current tab. Before the fix it failed because the agent closed and the file stayed open; after the fix the file closes and the agent stays open.
- `npm run test:e2e --workspace=@getpaseo/app -- e2e/file-editing.spec.ts --grep "clicking the editor focuses its pane beside an agent"`
- `npx vitest run packages/app/src/components/split-container-pane-focus.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Risk surface

This changes web split-pane focus handling for `contenteditable` surfaces, shared by browser web and Electron. Explicitly exempt links, buttons, selects, and marked controls remain unchanged; native rendering is unaffected. There is no visual change, so screenshots are not applicable.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable: no visual change)
- [x] Tests added or updated where it made sense
