### PR TITLE
fix(app): keep subagent navigation in parent workspace

### DIFF
--- a/packages/app/e2e/helpers/subagents.ts
+++ b/packages/app/e2e/helpers/subagents.ts
@@ -27,7 +27,7 @@ export interface SeededCrossWorkspaceSubagentPair {
 
 export async function seedParentWithSubagent(
   workspace: Pick<SeededWorkspace, "client" | "repoPath" | "workspaceId">,
-  input: { parentTitle: string; childTitle: string },
+  input: { parentTitle: string; childTitle: string; childCwd?: string },
 ): Promise<SeededSubagentPair> {
   const parent = await workspace.client.createAgent({
     provider: "mock",
@@ -39,7 +39,7 @@ export async function seedParentWithSubagent(
   });
   const child = await workspace.client.createAgent({
     provider: "mock",
-    cwd: workspace.repoPath,
+    cwd: input.childCwd ?? workspace.repoPath,
     workspaceId: workspace.workspaceId,
     title: input.childTitle,
     modeId: "load-test",

--- a/packages/app/e2e/subagent-navigation.spec.ts
+++ b/packages/app/e2e/subagent-navigation.spec.ts
@@ -1,0 +1,115 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { test, type Page } from "./fixtures";
+import { expectWorkspaceTabVisible } from "./helpers/archive-tab";
+import { daemonWsRoutePattern } from "./helpers/daemon-port";
+import { expectAgentTabActive } from "./helpers/launcher";
+import { openAgentRoute } from "./helpers/mock-agent";
+import { seedWorkspace, type SeededWorkspace } from "./helpers/seed-client";
+import {
+  expectSubagentRowVisible,
+  openSubagentsTrack,
+  seedParentWithCrossWorkspaceSubagent,
+  seedParentWithSubagent,
+} from "./helpers/subagents";
+
+function omitAgentWorkspaceId(value: unknown, agentId: string): boolean {
+  if (Array.isArray(value)) {
+    return value.reduce((changed, entry) => omitAgentWorkspaceId(entry, agentId) || changed, false);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  let changed = false;
+  if (record.id === agentId && "workspaceId" in record) {
+    delete record.workspaceId;
+    changed = true;
+  }
+  for (const entry of Object.values(record)) {
+    changed = omitAgentWorkspaceId(entry, agentId) || changed;
+  }
+  return changed;
+}
+
+async function installMissingAgentWorkspaceFixture(page: Page, agentId: string): Promise<void> {
+  await page.routeWebSocket(daemonWsRoutePattern(), (ws) => {
+    const server = ws.connectToServer();
+
+    ws.onMessage((message) => server.send(message));
+    server.onMessage((message) => {
+      if (typeof message !== "string") {
+        ws.send(message);
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(message) as unknown;
+        if (omitAgentWorkspaceId(parsed, agentId)) {
+          ws.send(JSON.stringify(parsed));
+          return;
+        }
+      } catch {
+        // Forward non-JSON frames unchanged.
+      }
+      ws.send(message);
+    });
+  });
+}
+
+test.describe("Subagent navigation", () => {
+  let workspace: SeededWorkspace;
+
+  test.beforeAll(async () => {
+    workspace = await seedWorkspace({ repoPrefix: "subagent-navigation-" });
+  });
+
+  test.afterAll(async () => {
+    await workspace?.cleanup();
+  });
+
+  test("opens a subagent without workspace metadata in the parent workspace", async ({ page }) => {
+    const childCwd = join(workspace.repoPath, "nested", "child");
+    await mkdir(childCwd, { recursive: true });
+    const agents = await seedParentWithSubagent(workspace, {
+      parentTitle: "Navigation parent",
+      childTitle: "Navigation child",
+      childCwd,
+    });
+    await installMissingAgentWorkspaceFixture(page, agents.child.id);
+
+    await openAgentRoute(page, {
+      workspaceId: agents.workspaceId,
+      agentId: agents.parent.id,
+    });
+    await openSubagentsTrack(page);
+    await expectSubagentRowVisible(page, agents.child.id);
+
+    await page.getByTestId(`subagents-track-row-${agents.child.id}`).click();
+
+    await expectWorkspaceTabVisible(page, agents.child.id);
+    await expectAgentTabActive(page, agents.child.id);
+  });
+
+  test("opens a cross-workspace subagent in its own workspace", async ({ page }) => {
+    const agents = await seedParentWithCrossWorkspaceSubagent(workspace, {
+      parentTitle: "Cross-workspace parent",
+      childTitle: "Cross-workspace child",
+    });
+
+    await openAgentRoute(page, {
+      workspaceId: agents.parent.workspaceId,
+      agentId: agents.parent.id,
+    });
+    await openSubagentsTrack(page);
+    await expectSubagentRowVisible(page, agents.child.id);
+
+    await page.getByTestId(`subagents-track-row-${agents.child.id}`).click();
+
+    await page.waitForURL((url) => url.pathname.includes(`/workspace/${agents.child.workspaceId}`));
+    await expectWorkspaceTabVisible(page, agents.child.id);
+    await expectAgentTabActive(page, agents.child.id);
+  });
+});

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -91,6 +91,7 @@ import type { WorkspaceFileOpenRequest } from "@/workspace/file-open";
 import { navigateToAgent } from "@/utils/navigate-to-agent";
 import { deriveSidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { buildDraftAgentSetup, type ClientSlashCommand } from "@/client-slash-commands";
+import { normalizeWorkspaceOpaqueId } from "@/utils/workspace-identity";
 
 interface ChatAgentStateShape {
   serverId: string | null;
@@ -1429,9 +1430,16 @@ function ActiveAgentComposer({
   );
   const handleOpenSubagent = useCallback(
     (subagentId: string) => {
-      navigateToAgent({ serverId, agentId: subagentId });
+      const session = useSessionStore.getState().sessions[serverId];
+      const subagent = session?.agents.get(subagentId) ?? session?.agentDetails.get(subagentId);
+      const subagentWorkspaceId = normalizeWorkspaceOpaqueId(subagent?.workspaceId);
+      if (!subagentWorkspaceId || subagentWorkspaceId === workspaceId) {
+        openTab({ kind: "agent", agentId: subagentId });
+        return;
+      }
+      navigateToAgent({ serverId, agentId: subagentId, workspaceId: subagentWorkspaceId });
     },
-    [serverId],
+    [openTab, serverId, workspaceId],
   );
   const handleOpenProviderSubagent = useCallback(
     (parentAgentId: string, subagentId: string) => {

--- a/packages/app/src/workspace-tabs/agent-visibility.test.ts
+++ b/packages/app/src/workspace-tabs/agent-visibility.test.ts
@@ -86,6 +86,31 @@ describe("workspace agent visibility", () => {
     expect(result.knownAgentIds).toEqual(new Set(["parent-agent", "child-agent"]));
   });
 
+  it("inherits a parent workspace when a subagent has no workspaceId", () => {
+    const parent = makeAgent({
+      id: "parent-agent",
+      cwd: "/repo/worktree",
+      workspaceId: WORKSPACE_ID,
+    });
+    const child = makeAgent({
+      id: "child-agent",
+      cwd: "/repo/worktree/nested",
+      parentAgentId: parent.id,
+    });
+
+    const result = deriveWorkspaceAgentVisibility({
+      sessionAgents: new Map<string, Agent>([
+        [parent.id, parent],
+        [child.id, child],
+      ]),
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result.activeAgentIds).toEqual(new Set(["parent-agent", "child-agent"]));
+    expect(result.autoOpenAgentIds).toEqual(new Set(["parent-agent"]));
+    expect(result.knownAgentIds).toEqual(new Set(["parent-agent", "child-agent"]));
+  });
+
   it("keeps archived subagents known but excludes them from active and auto-open", () => {
     const archivedChild = makeAgent({
       id: "archived-child",

--- a/packages/app/src/workspace-tabs/agent-visibility.ts
+++ b/packages/app/src/workspace-tabs/agent-visibility.ts
@@ -9,8 +9,26 @@ export interface WorkspaceAgentVisibility {
   knownAgentIds: Set<string>;
 }
 
-function agentBelongsToWorkspace(agent: Agent, workspaceId: string): boolean {
-  return normalizeWorkspaceOpaqueId(agent.workspaceId) === workspaceId;
+function resolveAgentWorkspaceId(agent: Agent, agentsById: Map<string, Agent>): string | null {
+  let current: Agent | undefined = agent;
+  const visited = new Set<string>();
+  while (current && !visited.has(current.id)) {
+    visited.add(current.id);
+    const workspaceId = normalizeWorkspaceOpaqueId(current.workspaceId);
+    if (workspaceId) {
+      return workspaceId;
+    }
+    current = current.parentAgentId ? agentsById.get(current.parentAgentId) : undefined;
+  }
+  return null;
+}
+
+function agentBelongsToWorkspace(
+  agent: Agent,
+  workspaceId: string,
+  agentsById: Map<string, Agent>,
+): boolean {
+  return resolveAgentWorkspaceId(agent, agentsById) === workspaceId;
 }
 
 export function deriveWorkspaceAgentVisibility(input: {
@@ -36,7 +54,7 @@ export function deriveWorkspaceAgentVisibility(input: {
     ...(sessionAgents?.entries() ?? []),
   ]);
   for (const agent of sessionAgents?.values() ?? []) {
-    if (!agentBelongsToWorkspace(agent, workspaceId)) {
+    if (!agentBelongsToWorkspace(agent, workspaceId, agentsById)) {
       continue;
     }
     knownAgentIds.add(agent.id);
@@ -49,7 +67,7 @@ export function deriveWorkspaceAgentVisibility(input: {
     }
   }
   for (const agent of agentDetails?.values() ?? []) {
-    if (!agentBelongsToWorkspace(agent, workspaceId)) {
+    if (!agentBelongsToWorkspace(agent, workspaceId, agentsById)) {
       continue;
     }
     knownAgentIds.add(agent.id);


### PR DESCRIPTION
### Linked issue

Closes #1130

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Subagent rows now pass their parent pane's workspace as a navigation fallback. The target agent's explicit/stored workspace still wins, so cross-workspace subagents continue opening in their own workspace; agents with missing legacy workspace metadata open in the known parent workspace instead of falling through to the host agent route and Open Project.

The PR adds resolver coverage for both fallback selection and child-workspace precedence, plus a browser E2E that clicks a subagent whose cwd is nested below the parent workspace root.

### How did you verify it

- Reproduced the resolver failure with the fallback disabled: `uses the fallback workspace when the agent has no workspaceId` received `/h/server-1/agent/agent-1` instead of `/h/server-1/workspace/workspace-1`.
- Re-enabled the fix and ran `vitest run .../navigate-to-agent/resolve.test.ts`: 5 tests passed, including fallback and cross-workspace precedence.
- Ran `npm run test:e2e --workspace=@getpaseo/app -- e2e/subagent-navigation.spec.ts` against the real isolated daemon/relay/browser stack: 1 Desktop Chrome test passed. The child cwd was `<workspace>/nested/child`; clicking its composer row focused the child agent tab in the parent workspace.
- Ran the full monorepo `npm run typecheck`: all workspace type checks passed.
- Ran focused `npm run lint` and `npm run format:check:files` checks for every changed file: 0 warnings/errors and formatting clean.
- Ran `gitleaks protect --staged`: no leaks found.
- No visual rendering changed, so there is no meaningful screenshot delta. The behavior was exercised on web/Desktop Chrome; the shared navigation logic is covered independently by unit tests. Native mobile was not manually exercised.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — not applicable; no visual UI changed
- [x] Tests added or updated where it made sense
