### PR TITLE
feat(cli): add agent unarchive command

### DIFF
--- a/packages/cli/src/cli-surface.test.ts
+++ b/packages/cli/src/cli-surface.test.ts
@@ -42,4 +42,12 @@ describe("canonical CLI surface", () => {
     expect(open?.helpInformation()).toContain("<agent-id>");
     expect(open?.helpInformation()).toContain("--server <server-id>");
   });
+
+  it("offers unarchive at the top level and under agent", () => {
+    const cli = createCli();
+    const agent = cli.commands.find((command) => command.name() === "agent");
+
+    expect(cli.commands.some((command) => command.name() === "unarchive")).toBe(true);
+    expect(agent?.commands.some((command) => command.name() === "unarchive")).toBe(true);
+  });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,6 +26,7 @@ import { addSendOptions, runSendCommand } from "./commands/agent/send.js";
 import { addInspectOptions, runInspectCommand } from "./commands/agent/inspect.js";
 import { addWaitOptions, runWaitCommand } from "./commands/agent/wait.js";
 import { addArchiveOptions, runArchiveCommand } from "./commands/agent/archive.js";
+import { addUnarchiveOptions, runUnarchiveCommand } from "./commands/agent/unarchive.js";
 import { addAttachOptions, runAttachCommand } from "./commands/agent/attach.js";
 import { addImportOptions, runImportCommand } from "./commands/agent/import.js";
 import { withOutput } from "./output/index.js";
@@ -111,6 +112,10 @@ export function createCli(): Command {
 
   addJsonAndDaemonHostOptions(addArchiveOptions(program.command("archive"))).action(
     withOutput(runArchiveCommand),
+  );
+
+  addJsonAndDaemonHostOptions(addUnarchiveOptions(program.command("unarchive"))).action(
+    withOutput(runUnarchiveCommand),
   );
 
   // Top-level local daemon shortcuts

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { runModeCommand } from "./mode.js";
 import { addArchiveOptions, runArchiveCommand } from "./archive.js";
+import { addUnarchiveOptions, runUnarchiveCommand } from "./unarchive.js";
 import { addDeleteOptions, runDeleteCommand } from "./delete.js";
 import { addLsOptions, runLsCommand } from "./ls.js";
 import { addRunOptions, runRunCommand } from "./run.js";
@@ -76,6 +77,10 @@ export function createAgentCommand(): Command {
 
   addJsonAndDaemonHostOptions(addArchiveOptions(agent.command("archive"))).action(
     withOutput(runArchiveCommand),
+  );
+
+  addJsonAndDaemonHostOptions(addUnarchiveOptions(agent.command("unarchive"))).action(
+    withOutput(runUnarchiveCommand),
   );
 
   addJsonAndDaemonHostOptions(addReloadOptions(agent.command("reload"))).action(

--- a/packages/cli/src/commands/agent/unarchive.test.ts
+++ b/packages/cli/src/commands/agent/unarchive.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runUnarchiveCommand } from "./unarchive.js";
+
+const mocks = vi.hoisted(() => ({
+  archivedAt: "2026-07-26T12:00:00.000Z" as string | null,
+  refreshAgent: vi.fn(async (agentId: string) => ({ agentId, timelineSize: 4 })),
+  close: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../utils/client.js", () => ({
+  connectToDaemon: vi.fn(async () => ({
+    fetchAgents: vi.fn(async () => ({
+      entries: [
+        {
+          agent: {
+            id: "11111111-1111-4111-8111-111111111111",
+            title: "Archived agent",
+            archivedAt: mocks.archivedAt,
+          },
+        },
+      ],
+    })),
+    refreshAgent: mocks.refreshAgent,
+    close: mocks.close,
+  })),
+  getDaemonHost: vi.fn(() => "ws://127.0.0.1:6767"),
+  resolveAgentId: vi.fn((id: string) => id),
+}));
+
+describe("runUnarchiveCommand", () => {
+  beforeEach(() => {
+    mocks.archivedAt = "2026-07-26T12:00:00.000Z";
+    vi.clearAllMocks();
+  });
+
+  it("unarchives and reloads an archived agent", async () => {
+    const agentId = "11111111-1111-4111-8111-111111111111";
+
+    const result = await runUnarchiveCommand(agentId, {}, {} as never);
+
+    expect(mocks.refreshAgent).toHaveBeenCalledWith(agentId);
+    expect(result.data).toEqual({
+      agentId,
+      status: "unarchived",
+      timelineSize: 4,
+    });
+  });
+
+  it("rejects an agent that is already active", async () => {
+    mocks.archivedAt = null;
+
+    await expect(
+      runUnarchiveCommand("11111111-1111-4111-8111-111111111111", {}, {} as never),
+    ).rejects.toMatchObject({ code: "AGENT_NOT_ARCHIVED" });
+    expect(mocks.refreshAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/agent/unarchive.ts
+++ b/packages/cli/src/commands/agent/unarchive.ts
@@ -1,0 +1,120 @@
+import { Command } from "commander";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { connectToDaemon, getDaemonHost, resolveAgentId } from "../../utils/client.js";
+import type {
+  CommandOptions,
+  SingleResult,
+  OutputSchema,
+  CommandError,
+} from "../../output/index.js";
+
+export interface AgentUnarchiveResult {
+  agentId: string;
+  status: "unarchived";
+  timelineSize: number;
+}
+
+export const unarchiveSchema: OutputSchema<AgentUnarchiveResult> = {
+  idField: "agentId",
+  columns: [
+    { header: "AGENT ID", field: "agentId" },
+    { header: "STATUS", field: "status" },
+    { header: "TIMELINE", field: "timelineSize" },
+  ],
+};
+
+export function addUnarchiveOptions(cmd: Command): Command {
+  return cmd
+    .description("Unarchive and reload an agent")
+    .argument("<id>", "Agent ID, prefix, or name");
+}
+
+export interface AgentUnarchiveOptions extends CommandOptions {
+  host?: string;
+}
+
+export type AgentUnarchiveCommandResult = SingleResult<AgentUnarchiveResult>;
+
+export async function runUnarchiveCommand(
+  agentIdArg: string,
+  options: AgentUnarchiveOptions,
+  _command: Command,
+): Promise<AgentUnarchiveCommandResult> {
+  const host = getDaemonHost({ host: options.host });
+
+  if (!agentIdArg || agentIdArg.trim().length === 0) {
+    const error: CommandError = {
+      code: "MISSING_AGENT_ID",
+      message: "Agent ID is required",
+      details: "Usage: paseo agent unarchive <id-or-name>",
+    };
+    throw error;
+  }
+
+  let client: DaemonClient;
+  try {
+    client = await connectToDaemon({ host: options.host });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "DAEMON_NOT_RUNNING",
+      message: `Cannot connect to daemon at ${host}: ${message}`,
+      details: "Start the daemon with: paseo daemon start",
+    };
+    throw error;
+  }
+
+  try {
+    const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
+    const agents = agentsPayload.entries.map((entry) => entry.agent);
+    const agentId = resolveAgentId(agentIdArg, agents);
+    if (!agentId) {
+      const error: CommandError = {
+        code: "AGENT_NOT_FOUND",
+        message: `Agent not found: ${agentIdArg}`,
+        details: 'Use "paseo ls --all" to list archived agents',
+      };
+      throw error;
+    }
+
+    const agent = agents.find((entry) => entry.id === agentId);
+    if (!agent) {
+      throw new Error(`Resolved agent missing from fetched agents: ${agentId}`);
+    }
+    if (!agent.archivedAt) {
+      const error: CommandError = {
+        code: "AGENT_NOT_ARCHIVED",
+        message: `Agent ${agentId.slice(0, 7)} is not archived`,
+        details: "Only archived agents can be unarchived",
+      };
+      throw error;
+    }
+
+    const result = await client.refreshAgent(agentId);
+
+    await client.close();
+
+    return {
+      type: "single",
+      data: {
+        agentId: result.agentId,
+        status: "unarchived",
+        timelineSize: result.timelineSize ?? 0,
+      },
+      schema: unarchiveSchema,
+    };
+  } catch (err) {
+    await client.close().catch(() => {});
+
+    if (err && typeof err === "object" && "code" in err) {
+      throw err;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "UNARCHIVE_FAILED",
+      message: `Failed to unarchive agent: ${message}`,
+    };
+    throw error;
+  }
+}

--- a/packages/cli/tests/e2e/agent-unarchive.test.ts
+++ b/packages/cli/tests/e2e/agent-unarchive.test.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env npx tsx
+
+import assert from "node:assert";
+
+import { createE2ETestContext, type TestDaemonContext } from "../helpers/test-daemon.ts";
+
+interface E2EContext extends TestDaemonContext {
+  paseo: (
+    args: string[],
+    opts?: { timeout?: number; cwd?: string },
+  ) => Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }>;
+}
+
+interface ListedAgent {
+  id: string;
+}
+
+interface UnarchiveOutput {
+  agentId: string;
+  status: string;
+  timelineSize: number;
+}
+
+function expectSuccess(result: Awaited<ReturnType<E2EContext["paseo"]>>, command: string): void {
+  assert.strictEqual(
+    result.exitCode,
+    0,
+    `${command} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
+async function main(): Promise<void> {
+  let ctx: E2EContext | undefined;
+
+  try {
+    ctx = await createE2ETestContext({
+      timeout: 45_000,
+      env: { PASEO_NODE_ENV: "development" },
+    });
+
+    const run = await ctx.paseo([
+      "--quiet",
+      "run",
+      "--background",
+      "--provider",
+      "mock",
+      "--model",
+      "ten-second-stream",
+      "--mode",
+      "load-test",
+      "Create an agent for the unarchive end-to-end test",
+    ]);
+    expectSuccess(run, "paseo run");
+    const agentId = run.stdout.trim();
+    assert.match(agentId, /^[0-9a-f-]{36}$/i, "run should return the created agent ID");
+
+    const archive = await ctx.paseo(["--json", "archive", "--force", agentId]);
+    expectSuccess(archive, "paseo archive");
+
+    const activeAfterArchive = await ctx.paseo(["--json", "ls", "--global"]);
+    expectSuccess(activeAfterArchive, "paseo ls --global");
+    assert(
+      !(JSON.parse(activeAfterArchive.stdout) as ListedAgent[]).some(
+        (agent) => agent.id === agentId,
+      ),
+      "archived agent should be absent from the default list",
+    );
+
+    const unarchive = await ctx.paseo(["--json", "agent", "unarchive", agentId]);
+    expectSuccess(unarchive, "paseo agent unarchive");
+    const unarchiveOutput = JSON.parse(unarchive.stdout) as UnarchiveOutput;
+    assert.strictEqual(unarchiveOutput.agentId, agentId);
+    assert.strictEqual(unarchiveOutput.status, "unarchived");
+    assert(
+      Number.isInteger(unarchiveOutput.timelineSize) && unarchiveOutput.timelineSize >= 0,
+      "unarchive should report the reloaded timeline size",
+    );
+
+    const activeAfterUnarchive = await ctx.paseo(["--json", "ls", "--global"]);
+    expectSuccess(activeAfterUnarchive, "paseo ls --global");
+    assert(
+      (JSON.parse(activeAfterUnarchive.stdout) as ListedAgent[]).some(
+        (agent) => agent.id === agentId,
+      ),
+      "unarchived agent should return to the default list",
+    );
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await ctx?.stop();
+  }
+}
+
+void main();


### PR DESCRIPTION
### Linked issue

Closes #957

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds the symmetric `paseo agent unarchive <id>` command and the top-level `paseo unarchive <id>` alias. The command resolves archived agents by ID, prefix, or title, rejects active agents with `AGENT_NOT_ARCHIVED`, and reuses `refreshAgent` so its documented behavior accurately says that unarchiving also reloads the underlying session.

The output reports the agent ID, `unarchived` status, and reloaded timeline size without inventing a client-side timestamp.

### How did you verify it

- Confirmed the current CLI help listed `archive` but no `unarchive` at either the top level or under `agent`; after the change, both `paseo unarchive --help` and `paseo agent unarchive --help` describe `Unarchive and reload an agent`.
- Ran focused Vitest coverage for the command and CLI surface: 8 tests passed, including archived-agent refresh, active-agent rejection, and both command registrations.
- Ran `packages/cli/tests/e2e/agent-unarchive.test.ts` through `tsx` against a real isolated daemon on an ephemeral port with the development mock provider. The real CLI created an agent, archived it, confirmed the default list hid it, unarchived/reloaded it, and confirmed it returned to the default list. The stable daemon on port 6767 was not touched.
- Ran the full monorepo `npm run typecheck`: all workspace type checks passed.
- Ran focused `npm run lint` and `npm run format:check:files` checks for every changed file: 0 warnings/errors and formatting clean.
- Ran `gitleaks protect --staged`: no leaks found.
- No UI changed.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — not applicable; CLI only
- [x] Tests added or updated where it made sense
