### PR TITLE
Keep Android bottom sheets above the software keyboard

### DIFF
--- a/packages/app/src/command-center/command-center.tsx
+++ b/packages/app/src/command-center/command-center.tsx
@@ -746,8 +746,9 @@ export function CommandCenter() {
         enablePanDownToClose
         backgroundStyle={styles.sheetBackground}
         handleIndicatorStyle={styles.sheetHandle}
-        keyboardBehavior="extend"
+        keyboardBehavior="interactive"
         keyboardBlurBehavior="restore"
+        android_keyboardInputMode="adjustPan"
         accessible={false}
       >
         <View style={[styles.bottomSheetHeader, styles.searchRow]} testID="command-center-header">

--- a/packages/app/src/components/adaptive-modal-sheet.tsx
+++ b/packages/app/src/components/adaptive-modal-sheet.tsx
@@ -644,8 +644,9 @@ export function AdaptiveModalSheet({
         enablePanDownToClose
         backgroundComponent={SheetBackground}
         handleIndicatorStyle={handleIndicatorStyle}
-        keyboardBehavior="extend"
+        keyboardBehavior="interactive"
         keyboardBlurBehavior="restore"
+        android_keyboardInputMode="adjustPan"
         accessible={false}
         presentation={presentation}
       >

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -994,8 +994,9 @@ function MobileComboboxBody(props: MobileBodyProps): ReactElement {
       enablePanDownToClose
       backgroundComponent={ComboboxSheetBackground}
       handleIndicatorStyle={props.handleIndicatorStyle}
-      keyboardBehavior="extend"
+      keyboardBehavior="interactive"
       keyboardBlurBehavior="none"
+      android_keyboardInputMode="adjustPan"
       presentation={props.presentation}
     >
       <View style={frameStyle}>

--- a/packages/app/src/components/ui/menu/menu-surface.tsx
+++ b/packages/app/src/components/ui/menu/menu-surface.tsx
@@ -408,6 +408,7 @@ function MenuSheetSurface({
       // sheet up instead, which is the only thing a content-sized sheet can usefully do.
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
+      android_keyboardInputMode="adjustPan"
     >
       <BottomSheetScrollView
         dataSet={sheetDataSet}


### PR DESCRIPTION
### Linked issue

Closes #2466

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

On Android the app runs edge-to-edge (`edgeToEdgeEnabled: true` — the Expo 54 default, and effectively forced once targeting SDK 35 / Android 15), so the window no longer resizes when the software keyboard opens; the IME draws over the app. All four gorhom sheet call sites used `keyboardBehavior="extend"`, which on keyboard open only moves the sheet to its highest detent **without subtracting the keyboard height** — that only avoided the keyboard back when `adjustResize` shrank the window. Sheets with a single detent (e.g. "Add custom model", fixed at 40%) therefore don't move at all and end up fully covered.

Switches all four call sites (`adaptive-modal-sheet`, `command-center`, `context-menu`, `combobox`) to `keyboardBehavior="interactive"`, which positions the sheet at `highestDetent − keyboardHeight`, so the sheet's bottom tracks the top of the keyboard regardless of window resizing. `android_keyboardInputMode="adjustPan"` comes along because gorhom skips the interactive offset when it believes the window is `adjustResize` — an assumption edge-to-edge breaks. `keyboardBlurBehavior` is unchanged at each site.

### How did you verify it

Release APK (0.2.2) built from this branch, installed on a physical Android phone:

- Before the fix (screenshot in #2466): Add custom model → tap Model ID → the keyboard covers the whole sheet; typing is blind and Cancel/Add are unreachable without dismissing the keyboard.
- After the fix: the same flow lifts the sheet so its bottom sits on top of the keyboard; the field and both buttons stay visible while typing (screenshot below). Dismissing the keyboard returns the sheet to its 40% detent, and dragging the sheet while the keyboard is open doesn't jump.
- The other three call sites got the identical two-prop change; I haven't exercised each of them individually on device.
- iOS not tested (same two props; `interactive` is gorhom's documented behavior there too). Web/desktop unaffected — these props only respond to the native software keyboard.

`npm run typecheck`, `npm run lint`, `npm run format` all pass.

After — the sheet riding on top of the keyboard, input and buttons visible:

<img width="909" height="1999" alt="image" src="https://github.com/user-attachments/assets/450b4875-7ff4-43ef-aa48-2daac4a12a8d" />

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (Android before/after attached; iOS not tested, stated above; web/desktop unaffected)
- [ ] Tests added or updated where it made sense (no keyboard-interaction test harness for sheets; prop-level change only)
