### PR TITLE
fix(server): redact sensitive agent status metadata

### DIFF
--- a/packages/server/src/server/agent/agent-projections.test.ts
+++ b/packages/server/src/server/agent/agent-projections.test.ts
@@ -254,6 +254,32 @@ describe("toAgentPayload", () => {
     }
   });
 
+  it("redacts sensitive headers from legacy stored runtime metadata", () => {
+    const authorization = "Bearer legacy-runtime-secret-must-not-escape";
+    const storedRecord = toStoredAgentRecord(createManagedAgent());
+
+    // Simulate a legacy record written before runtime metadata redaction was introduced.
+    storedRecord.runtimeInfo = {
+      provider: "claude",
+      sessionId: "session-123",
+      extra: {
+        headers: {
+          Authorization: authorization,
+          "X-Non-Secret": "preserved",
+        },
+      },
+    };
+
+    const payload = buildStoredAgentPayload(storedRecord, ["claude"]);
+    const headers = payload.runtimeInfo?.extra?.headers;
+
+    expect(JSON.stringify(payload)).not.toContain(authorization);
+    expect(headers).toEqual({
+      Authorization: "[REDACTED]",
+      "X-Non-Secret": "preserved",
+    });
+  });
+
   it("serializes dates, clones arrays, and hides session", () => {
     const permissionA = createPermission({ id: "perm-a" });
     const permissionB = createPermission({

--- a/packages/server/src/server/agent/agent-projections.test.ts
+++ b/packages/server/src/server/agent/agent-projections.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { AGENT_LIFECYCLE_STATUSES } from "./agent-manager.js";
 import {
+  buildStoredAgentPayload,
   toAgentPayload,
   toRecentProviderSessionDescriptorPayload,
   toStoredAgentRecord,
@@ -217,6 +218,42 @@ describe("toStoredAgentRecord", () => {
 });
 
 describe("toAgentPayload", () => {
+  it("redacts sensitive headers from live and stored status snapshots", () => {
+    const authorization = "Bearer regression-secret-must-not-escape";
+    const persistence: AgentPersistenceHandle = {
+      provider: "claude",
+      sessionId: "persist-sensitive",
+      metadata: {
+        mcpServers: {
+          paseo: {
+            type: "http",
+            url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-123",
+            headers: {
+              Authorization: authorization,
+              "X-Non-Secret": "preserved",
+            },
+          },
+        },
+      },
+    };
+    const agent = createManagedAgent({ persistence });
+    const livePayload = toAgentPayload(agent);
+    const storedRecord = toStoredAgentRecord(agent);
+
+    // Simulate a legacy record written before metadata redaction was introduced.
+    storedRecord.persistence = persistence;
+    const storedPayload = buildStoredAgentPayload(storedRecord, ["claude"]);
+
+    for (const payload of [livePayload, storedPayload]) {
+      const headers = payload.persistence?.metadata?.mcpServers?.paseo?.headers;
+      expect(JSON.stringify(payload)).not.toContain(authorization);
+      expect(headers).toEqual({
+        Authorization: "[REDACTED]",
+        "X-Non-Secret": "preserved",
+      });
+    }
+  });
+
   it("serializes dates, clones arrays, and hides session", () => {
     const permissionA = createPermission({ id: "perm-a" });
     const permissionB = createPermission({

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -169,8 +169,9 @@ function buildStoredRuntimeInfo(record: StoredAgentRecord): AgentRuntimeInfo | u
   if (Object.prototype.hasOwnProperty.call(ri, "modeId")) {
     runtimeInfo.modeId = ri.modeId ?? null;
   }
-  if (ri.extra) {
-    runtimeInfo.extra = ri.extra;
+  const extra = sanitizeMetadata(ri.extra);
+  if (extra !== undefined) {
+    runtimeInfo.extra = extra;
   }
   return runtimeInfo;
 }

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -182,7 +182,7 @@ function buildStoredPersistenceHandle(
   if (!isStoredAgentProviderAvailable(record, validProviders)) {
     return null;
   }
-  return toAgentPersistenceHandle(validProviders, record.persistence);
+  return sanitizePersistenceHandle(toAgentPersistenceHandle(validProviders, record.persistence));
 }
 
 export function buildStoredAgentPayload(
@@ -371,7 +371,18 @@ function normalizeFeatures(features: AgentFeature[] | null | undefined): AgentFe
   return Array.isArray(features) ? features.map((feature) => ({ ...feature })) : [];
 }
 
-function sanitizeOptionalJson(value: unknown): JsonValue | undefined {
+const SENSITIVE_METADATA_KEYS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+]);
+
+function sanitizeOptionalJson(value: unknown, key?: string): JsonValue | undefined {
+  if (key && SENSITIVE_METADATA_KEYS.has(key.toLowerCase())) {
+    return "[REDACTED]";
+  }
   if (value === undefined) {
     return undefined;
   }
@@ -389,10 +400,10 @@ function sanitizeOptionalJson(value: unknown): JsonValue | undefined {
   }
   if (typeof value === "object") {
     const result: { [key: string]: JsonValue } = {};
-    for (const [key, val] of Object.entries(value)) {
-      const sanitized = sanitizeOptionalJson(val);
+    for (const [entryKey, val] of Object.entries(value)) {
+      const sanitized = sanitizeOptionalJson(val, entryKey);
       if (sanitized !== undefined) {
-        result[key] = sanitized;
+        result[entryKey] = sanitized;
       }
     }
     return Object.keys(result).length ? result : undefined;


### PR DESCRIPTION
## Summary
- redact sensitive keys recursively from live and stored agent persistence metadata
- sanitize legacy stored runtime metadata before status projection
- preserve non-sensitive neighboring fields

## Regression proof
- new legacy stored-runtime snapshot test fails before the fix and passes after it
- `npx vitest run packages/server/src/server/agent/agent-projections.test.ts --bail=1` (18/18)
- `npm run typecheck --workspace=@getpaseo/server`

No production deployment is included.