### PR TITLE
Use OpenCode busy status for background activity

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -2048,6 +2048,10 @@ describe("OpenCode adapter startTurn error handling", () => {
         },
       });
       openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_deferred_autonomous", status: { type: "busy" } },
+      });
+      openCode.emitEvent({
         type: "message.part.updated",
         properties: {
           part: {
@@ -2181,6 +2185,10 @@ describe("OpenCode adapter startTurn error handling", () => {
           },
         },
       });
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_serialized_replay", status: { type: "busy" } },
+      });
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(openCode.calls.sessionPromptAsync).toHaveLength(1);
@@ -2268,6 +2276,10 @@ describe("OpenCode adapter startTurn error handling", () => {
             role: "user",
           },
         },
+      });
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_stop_during_replay", status: { type: "busy" } },
       });
       openCode.emitEvent({
         type: "permission.asked",
@@ -2496,6 +2508,13 @@ describe("OpenCode adapter startTurn error handling", () => {
                 })) {
                   yield event;
                 }
+                yield {
+                  type: "session.status",
+                  properties: {
+                    sessionID: "ses_stream_reconnect",
+                    status: { type: "busy" },
+                  },
+                };
                 wakeEventsSent.resolve();
                 yield {
                   type: "session.idle",
@@ -2840,6 +2859,13 @@ describe("OpenCode adapter startTurn error handling", () => {
                 })) {
                   yield event;
                 }
+                yield {
+                  type: "session.status",
+                  properties: {
+                    sessionID: "ses_persistent_stop_observer_failure",
+                    status: { type: "busy" },
+                  },
+                };
                 for (const event of assistantTurnEvents({
                   sessionId: "ses_persistent_stop_observer_failure",
                   text: "Dormant reconnect wake completed.",

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -3563,6 +3563,22 @@ describe("OpenCode provider subagent contract", () => {
         openCode.emitEvent(event);
       }
       openCode.emitEvent({
+        type: "session.created",
+        properties: {
+          info: {
+            id: "ses_plugin_wake_drain_marker",
+            parentID: "ses_parent_plugin_wake",
+            title: "Pre-busy drain marker",
+          },
+        },
+      });
+      await vi.waitFor(() => {
+        expect(events).toContainEqual(expect.objectContaining({ type: "provider_subagent" }));
+      });
+      expect(events.filter((event) => event.type !== "provider_subagent")).toEqual([]);
+      events.length = 0;
+
+      openCode.emitEvent({
         type: "session.status",
         properties: { sessionID: "ses_parent_plugin_wake", status: { type: "busy" } },
       });
@@ -3590,6 +3606,35 @@ describe("OpenCode provider subagent contract", () => {
           }),
         }),
       );
+    } finally {
+      await parent.close();
+    }
+  });
+
+  test("starts autonomous activity from busy without requiring an initiating message", async () => {
+    const { parent, openCode } = await createParentSession("ses_parent_busy_only");
+    const events: AgentStreamEvent[] = [];
+    parent.subscribe((event) => events.push(event));
+
+    try {
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_busy_only", status: { type: "busy" } },
+      });
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_busy_only",
+        text: "Autonomous response after busy.",
+      })) {
+        openCode.emitEvent(event);
+      }
+
+      await vi.waitFor(() => {
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+          ["turn_completed", "opencode-turn-0"],
+        ]);
+      });
     } finally {
       await parent.close();
     }
@@ -3655,6 +3700,10 @@ describe("OpenCode provider subagent contract", () => {
           text: "Autonomous wake",
         })[0],
       );
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_active_wake", status: { type: "busy" } },
+      });
       await vi.waitFor(() => {
         expect(events).toEqual([
           { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
@@ -3796,6 +3845,10 @@ describe("OpenCode provider subagent contract", () => {
       }
     });
 
+    childClient.emitEvent({
+      type: "session.status",
+      properties: { sessionID: "ses_child_external", status: { type: "busy" } },
+    });
     childClient.emitEvent({
       type: "permission.asked",
       properties: {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -4723,3 +4723,53 @@ function waitForAbort(signal: AbortSignal): Promise<void> {
     signal.addEventListener("abort", () => resolve(), { once: true });
   });
 }
+
+describe("OpenCode snapshot summary false-idle regression", () => {
+  test("user message.updated carrying snapshot diffs does not start a turn", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCodeClient = new TestOpenCodeClient();
+    openCodeClient.sessionCreateResponse = { data: { id: "ses_snapshot" } };
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession(
+      { provider: "opencode", cwd: "/workspace/repo" },
+      { env: { PASEO_AGENT_ID: "snapshot-agent" } },
+    );
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    // Captured live shape: after the turn goes idle OpenCode writes the filesystem
+    // snapshot diff onto the user message, with no time.end on the message.
+    openCodeClient.emitEvent({
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_snapshot_user",
+          sessionID: "ses_snapshot",
+          role: "user",
+          time: { created: 1000 },
+          summary: {
+            diffs: [{ file: "packages/server/src/thing.ts", additions: 3, deletions: 1 }],
+          },
+        },
+      },
+    });
+    // Drain marker: events are processed in order, so observing this one proves
+    // the snapshot update above was already handled.
+    openCodeClient.emitEvent({
+      type: "session.created",
+      properties: {
+        info: { id: "ses_snapshot_child", parentID: "ses_snapshot", title: "Drain marker" },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(events).toContainEqual(expect.objectContaining({ type: "provider_subagent" }));
+    });
+
+    expect(events.some((event) => event.type === "turn_started")).toBe(false);
+    await session.close();
+  });
+});

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -103,6 +103,7 @@ const OPENCODE_LEGACY_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
+const OPENCODE_PENDING_AUTONOMOUS_EVENT_LIMIT = 64;
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
@@ -2923,6 +2924,8 @@ class OpenCodeAgentSession implements AgentSession {
   private nextTurnOrdinal = 0;
   private turnState: OpenCodeTurnState = { status: "idle" };
   private runBoundary: OpenCodeRunBoundaryState | null = null;
+  /** Exact-session content OpenCode persists immediately before its runner reports busy. */
+  private readonly pendingAutonomousEvents: AgentStreamEvent[] = [];
   private readonly runningToolCalls = new Map<string, ToolCallTimelineItem>();
   private subAgentsByCallId = new Map<string, OpenCodeSubAgentActivityState>();
   private subAgentCallIdByChildSessionId = new Map<string, string>();
@@ -3173,6 +3176,7 @@ class OpenCodeAgentSession implements AgentSession {
       throw new Error("OpenCode is still stopping the previous turn");
     }
 
+    this.clearPendingAutonomousEvents();
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
     this.subAgentCallIdByChildSessionId.clear();
@@ -3651,10 +3655,16 @@ class OpenCodeAgentSession implements AgentSession {
         foregroundEvents.push(translatedEvent);
       }
     }
-    if (!turnId && this.shouldStartAutonomousTurn(event, foregroundEvents)) {
+    if (!turnId && this.shouldStartAutonomousTurn(event)) {
       turnId = this.startAutonomousTurn();
+      foregroundEvents.unshift(...this.takePendingAutonomousEvents());
     }
     if (!turnId) {
+      if (isOpenCodeTerminalEvent(event, this.sessionId)) {
+        this.clearPendingAutonomousEvents();
+      } else if (getOpenCodeEventSessionId(event) === this.sessionId) {
+        this.stagePendingAutonomousEvents(foregroundEvents);
+      }
       this.emitBackgroundPermissionRequests(foregroundEvents);
       this.traceOpenCode("provider.opencode.event.skip", {
         n: eventCount,
@@ -3748,43 +3758,44 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private shouldStartAutonomousTurn(
-    event: OpenCodeEvent,
-    foregroundEvents: readonly AgentStreamEvent[],
-  ): boolean {
+  private shouldStartAutonomousTurn(event: OpenCodeEvent): boolean {
     if (this.turnState.status !== "idle") {
       return false;
     }
     if (getOpenCodeEventSessionId(event) !== this.sessionId) {
       return false;
     }
-    // OpenCode publishes the persisted user message before it marks the runner
-    // busy. That message is the earliest unambiguous boundary for a plugin-
-    // initiated parent turn; session metadata and assistant echoes are not.
-    if (this.isAutonomousWakeBoundary(event)) {
-      return true;
-    }
-    if (!this.externallyDriven) {
-      return false;
-    }
-    if (
-      foregroundEvents.some(
-        (foregroundEvent) =>
-          foregroundEvent.type !== "thread_started" && !toTerminalTurnEvent(foregroundEvent),
-      )
-    ) {
-      return true;
-    }
-    return event.type === "session.status" && event.properties.status.type === "busy";
+    return this.isAutonomousWakeBoundary(event);
   }
 
   private isAutonomousWakeBoundary(event: OpenCodeEvent): boolean {
-    return (
-      this.isUnseenUserWakeBoundary(event) ||
-      (this.externallyDriven &&
-        event.type === "session.status" &&
-        event.properties.status.type === "busy")
-    );
+    // Message records are mutable and can be patched after the runner stops.
+    // Only OpenCode's execution status is authoritative for autonomous activity.
+    return event.type === "session.status" && event.properties.status.type === "busy";
+  }
+
+  private stagePendingAutonomousEvents(events: readonly AgentStreamEvent[]): void {
+    for (const event of events) {
+      if (
+        event.type === "thread_started" ||
+        event.type === "permission_requested" ||
+        toTerminalTurnEvent(event)
+      ) {
+        continue;
+      }
+      if (this.pendingAutonomousEvents.length === OPENCODE_PENDING_AUTONOMOUS_EVENT_LIMIT) {
+        this.pendingAutonomousEvents.shift();
+      }
+      this.pendingAutonomousEvents.push(event);
+    }
+  }
+
+  private takePendingAutonomousEvents(): AgentStreamEvent[] {
+    return this.pendingAutonomousEvents.splice(0);
+  }
+
+  private clearPendingAutonomousEvents(): void {
+    this.pendingAutonomousEvents.length = 0;
   }
 
   private isUnseenUserWakeBoundary(event: OpenCodeEvent): boolean {
@@ -3830,6 +3841,7 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
+    this.clearPendingAutonomousEvents();
     this.turnState = { status: "idle" };
     this.abortController = null;
     this.notifySubscribers(event, turnId);
@@ -3863,6 +3875,7 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
+    this.clearPendingAutonomousEvents();
     this.abortController = null;
     const stopping: OpenCodeRunBoundaryState = {
       idle,
@@ -3950,6 +3963,7 @@ class OpenCodeAgentSession implements AgentSession {
     this.accumulatedUsage = contextWindowMaxTokens !== undefined ? { contextWindowMaxTokens } : {};
     stopping.providerIdleObserved = true;
     stopping.reconcilingProviderStatus = false;
+    this.clearPendingAutonomousEvents();
     stopping.idle.resolve();
     if (stopping.observationFailed) {
       this.armStopQuiescence(stopping);
@@ -4206,6 +4220,7 @@ class OpenCodeAgentSession implements AgentSession {
         this.runBoundary.idle.resolve();
       }
       this.runBoundary = null;
+      this.clearPendingAutonomousEvents();
       this.turnState = { status: "idle" };
     } finally {
       await this.releaseServer?.();

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3146,14 +3146,8 @@ class OpenCodeAgentSession implements AgentSession {
       const statusType = readNonEmptyString(status?.type);
       if (!status || statusType === "idle") {
         if (this.externallyDriven && stopping.deferredEvents.length > 0) {
-          const wakeStart = stopping.deferredEvents.findIndex(({ rawEvent }) => {
-            const deferredEvent = unwrapOpenCodeGlobalEvent(rawEvent);
-            return deferredEvent ? this.isUnseenUserWakeBoundary(deferredEvent) : false;
-          });
-          stopping.deferredEvents.splice(
-            0,
-            wakeStart < 0 ? stopping.deferredEvents.length : wakeStart,
-          );
+          // The current status lookup supersedes provisional reconnect events.
+          stopping.deferredEvents.length = 0;
         }
         this.finishStoppingTurn(stopping);
         return;
@@ -3718,29 +3712,36 @@ class OpenCodeAgentSession implements AgentSession {
     if (stopping.replayedTurnActive) {
       return false;
     }
-    const retainReconciledWake =
+    const wakeAlreadyDeferred = stopping.deferredEvents.some(({ rawEvent }) => {
+      const deferredEvent = unwrapOpenCodeGlobalEvent(rawEvent);
+      return deferredEvent ? this.isAutonomousWakeBoundary(deferredEvent) : false;
+    });
+    if (
       stopping.reconcilingProviderStatus &&
-      (this.isAutonomousWakeBoundary(event) ||
-        stopping.deferredEvents.some(({ rawEvent }) => {
-          const deferredEvent = unwrapOpenCodeGlobalEvent(rawEvent);
-          return deferredEvent ? this.isAutonomousWakeBoundary(deferredEvent) : false;
-        }));
-    const retainEvent = stopping.providerIdleObserved || retainReconciledWake;
+      this.isAutonomousWakeBoundary(event) &&
+      !wakeAlreadyDeferred
+    ) {
+      // Output preceding the provider's first busy boundary still belongs to
+      // the canceled run. Keep only the new run from its authoritative start.
+      stopping.deferredEvents.length = 0;
+    }
+    // Preserve exact-session ordering while the status request decides whether
+    // these events belong to a new provider run. If it reports idle, everything
+    // before the first authoritative busy boundary is discarded.
+    const retainEvent = stopping.providerIdleObserved || stopping.reconcilingProviderStatus;
     if (isOpenCodeTerminalEvent(event, this.sessionId) && !stopping.providerIdleObserved) {
-      const userWakeIndex = stopping.deferredEvents.findIndex(({ rawEvent }) => {
+      const wakeStart = stopping.deferredEvents.findIndex(({ rawEvent }) => {
         const deferredEvent = unwrapOpenCodeGlobalEvent(rawEvent);
-        return deferredEvent ? this.isUnseenUserWakeBoundary(deferredEvent) : false;
+        return deferredEvent ? this.isAutonomousWakeBoundary(deferredEvent) : false;
       });
-      const hasWakeOutput = stopping.deferredEvents
-        .slice(userWakeIndex + 1)
-        .some(({ rawEvent }) => {
-          const deferredEvent = unwrapOpenCodeGlobalEvent(rawEvent);
-          return (
-            deferredEvent?.type === "message.updated" &&
-            deferredEvent.properties.info.role === "assistant"
-          );
-        });
-      if (retainEvent && userWakeIndex >= 0 && hasWakeOutput) {
+      const hasWakeOutput = stopping.deferredEvents.slice(wakeStart + 1).some(({ rawEvent }) => {
+        const deferredEvent = unwrapOpenCodeGlobalEvent(rawEvent);
+        return (
+          deferredEvent?.type === "message.updated" &&
+          deferredEvent.properties.info.role === "assistant"
+        );
+      });
+      if (retainEvent && wakeStart >= 0 && hasWakeOutput) {
         stopping.deferredEvents.push(params);
       }
       this.finishStoppingTurn(stopping);
@@ -3796,15 +3797,6 @@ class OpenCodeAgentSession implements AgentSession {
 
   private clearPendingAutonomousEvents(): void {
     this.pendingAutonomousEvents.length = 0;
-  }
-
-  private isUnseenUserWakeBoundary(event: OpenCodeEvent): boolean {
-    return (
-      event.type === "message.updated" &&
-      event.properties.info.role === "user" &&
-      !event.properties.info.summary?.diffs &&
-      !this.emittedUserMessageIds.has(event.properties.info.id)
-    );
   }
 
   private startAutonomousTurn(): string {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3791,6 +3791,7 @@ class OpenCodeAgentSession implements AgentSession {
     return (
       event.type === "message.updated" &&
       event.properties.info.role === "user" &&
+      !event.properties.info.summary?.diffs &&
       !this.emittedUserMessageIds.has(event.properties.info.id)
     );
   }

--- a/packages/server/src/server/daemon-e2e/opencode-omo-autonomous.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/opencode-omo-autonomous.real.e2e.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { expect, test } from "vitest";
@@ -11,6 +11,7 @@ const CHILD_TOKEN = "PASEO_OMO_CHILD_READY";
 const ROOT_IDLE_TOKEN = "PASEO_OMO_ROOT_WAITING";
 const FINAL_TOKEN = "PASEO_OMO_AUTONOMOUS_FINAL";
 const ROOT_IDLE_BARRIER = ".paseo-omo-root-idle";
+const ROOT_SNAPSHOT_FILE = ".paseo-omo-snapshot-source";
 
 test("OpenCode remains idle while an OMO child works and completes the autonomous wake", async () => {
   const runtime = await createOpenCodeOmoRealRuntime();
@@ -30,6 +31,7 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     await runtime.client.sendMessage(
       agent.id,
       [
+        `First use bash to write PASEO_OMO_SNAPSHOT_EDIT to ${ROOT_SNAPSHOT_FILE}.`,
         "Use the OMO task tool exactly once with category quick and run_in_background=true.",
         `Tell the child: use bash to wait until ${ROOT_IDLE_BARRIER} exists in the workspace, sleep 5, then return exactly ${CHILD_TOKEN}.`,
         `After the background task starts, reply exactly ${ROOT_IDLE_TOKEN} and stop.`,
@@ -42,6 +44,13 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     expect(firstFinish.status).toBe("idle");
     const firstTimeline = await runtime.client.fetchAgentTimeline(agent.id, { limit: 240 });
     expect(assistantTexts(firstTimeline.entries).join("\n")).toContain(ROOT_IDLE_TOKEN);
+    const firstTerminal = firstTerminalIndex(collector.messages, agent.id);
+    await waitForSnapshotDiff(runtime.artifacts, ROOT_SNAPSHOT_FILE);
+    expect(
+      collector.messages
+        .slice(firstTerminal + 1)
+        .some((message) => isAgentStreamEvent(message, agent.id, "turn_started")),
+    ).toBe(false);
     await writeFile(join(runtime.workspace, ROOT_IDLE_BARRIER), "root idle\n", "utf8");
 
     const completedChild = await waitForCompletedChildWithToken(
@@ -50,7 +59,6 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
       CHILD_TOKEN,
     );
 
-    const firstTerminal = firstTerminalIndex(collector.messages, agent.id);
     await waitForMessage(
       collector.messages,
       (message, index) =>
@@ -99,6 +107,7 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     expect(childRunningIndex).toBeGreaterThan(rootRunningIndex);
     expect(rootIdleIndex).toBeGreaterThan(childRunningIndex);
     expect(childCompletedIndex).toBeGreaterThan(rootIdleIndex);
+    expect(wakeStartIndex).toBeGreaterThan(childCompletedIndex);
     expect(wakeStartIndex).toBeGreaterThan(-1);
     expect(autonomousTerminalIndex).toBeGreaterThan(wakeStartIndex);
     expect(cancellationAfterWake).toBe(false);
@@ -124,6 +133,19 @@ function assistantTexts(
   return entries.flatMap((entry) =>
     entry.item.type === "assistant_message" ? [entry.item.text] : [],
   );
+}
+
+async function waitForSnapshotDiff(artifacts: string, filename: string): Promise<void> {
+  const daemonLog = join(artifacts, "daemon.log");
+  const deadline = Date.now() + 240_000;
+  while (Date.now() < deadline) {
+    const contents = await readFile(daemonLog, "utf8").catch(() => "");
+    if (contents.includes('"diffs"') && contents.includes(filename)) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for an OpenCode snapshot diff for ${filename}`);
 }
 
 function isAgentStreamEvent(


### PR DESCRIPTION
### Linked issue

Refs #2637

Builds on #2662.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Keeps OpenCode agents idle when late message metadata arrives, while still showing running status and streamed output when background work legitimately wakes the parent session.

Instead of classifying individual `message.updated` shapes, Paseo now waits for OpenCode exact-session `busy` status before opening background activity. Content that arrives immediately before that status is held in a small bounded queue and emitted once activity is confirmed. The same busy boundary is used by the stop/replay reconciliation introduced by #2662, so the stacked changes share one source of truth.

### How did you verify it

- Ran the focused OpenCode adapter suite: 83 tests passed.
- Ran the pinned real OpenCode/background-agent integration test. It generated a real late filesystem snapshot diff after the root became idle, confirmed no false restart, then observed the child completion wake the root, stream output, and return to idle.
- Drove the web app and isolated daemon in a real browser: submitted `launch an agent in the background to run sleep 5`, observed the root idle with one child running, then observed the parent self-start with a visible Stop control and streamed background output before returning to idle.
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Risk surface

This changes event ordering around background OpenCode activity and stop/replay reconciliation. Coverage includes synthetic ordering cases plus the pinned real-provider flow; no protocol or persisted-data shape changes are involved.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] No UI code changed; web behavior was manually captured
- [x] Tests added or updated where it made sense