### PR TITLE
Open project and workspace folders from the sidebar

### DIFF
--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -39,6 +39,7 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
+  FolderOpen,
   GitPullRequest,
   Settings,
   MoreVertical,
@@ -131,6 +132,7 @@ import {
   getIsElectron,
 } from "@/constants/platform";
 import { getDesktopHost } from "@/desktop/host";
+import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
@@ -150,6 +152,7 @@ const ThemedPlus = withUnistyles(Plus);
 const ThemedMoreVertical = withUnistyles(MoreVertical);
 const ThemedTrash2 = withUnistyles(Trash2);
 const ThemedSettings = withUnistyles(Settings);
+const ThemedFolderOpen = withUnistyles(FolderOpen);
 
 const foregroundColorMapping = (theme: Theme) => ({
   color: theme.colors.foreground,
@@ -537,6 +540,7 @@ const settingsLeadingIcon = <ThemedSettings size={14} uniProps={foregroundMutedC
 const openInNewWindowLeadingIcon = (
   <ThemedExternalLink size={14} uniProps={foregroundMutedColorMapping} />
 );
+const folderOpenLeadingIcon = <ThemedFolderOpen size={14} uniProps={foregroundMutedColorMapping} />;
 
 function renderKebabTriggerIcon({ hovered }: { hovered?: boolean }) {
   return (
@@ -579,6 +583,26 @@ function ProjectKebabMenu({
         toast.error(t("sidebar.project.actions.openNewWindowFailed"));
       });
   }, [projectPath, t, toast]);
+  const { targets: desktopOpenTargets } = useDesktopOpenTargets({
+    isLocalExecution: getIsElectron(),
+  });
+  const fileManagerTarget = useMemo(
+    () => desktopOpenTargets.find((target) => target.kind === "file-manager"),
+    [desktopOpenTargets],
+  );
+  const canOpenInFileManager =
+    getIsElectron() && projectPath.trim().length > 0 && fileManagerTarget !== undefined;
+  const handleOpenInFileManager = useCallback(() => {
+    const trimmedPath = projectPath.trim();
+    if (trimmedPath.length === 0 || !fileManagerTarget) return;
+    void openDesktopTarget({
+      editorId: fileManagerTarget.id,
+      workspacePath: trimmedPath,
+    }).catch((error) => {
+      console.warn("[sidebar] openInFileManager failed", error);
+      toast.error(t("sidebar.project.actions.openFolderFailed"));
+    });
+  }, [projectPath, fileManagerTarget, t, toast]);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -607,6 +631,15 @@ function ProjectKebabMenu({
             onSelect={handleOpenInNewWindow}
           >
             {t("sidebar.project.actions.openNewWindow")}
+          </DropdownMenuItem>
+        ) : null}
+        {canOpenInFileManager ? (
+          <DropdownMenuItem
+            testID={`sidebar-project-menu-open-folder-${projectKey}`}
+            leading={folderOpenLeadingIcon}
+            onSelect={handleOpenInFileManager}
+          >
+            {t("sidebar.project.actions.openFolder")}
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuItem
@@ -661,6 +694,26 @@ function WorkspaceRowRightGroup({
   onTogglePin?: () => void;
 }) {
   const { t } = useTranslation();
+  const toast = useToast();
+  const { targets: desktopOpenTargets } = useDesktopOpenTargets({
+    isLocalExecution: getIsElectron(),
+  });
+  const fileManagerTarget = useMemo(
+    () => desktopOpenTargets.find((target) => target.kind === "file-manager"),
+    [desktopOpenTargets],
+  );
+  const workspacePath = workspace.workspaceDirectory ?? workspace.projectRootPath;
+  const handleOpenInFileManager = useCallback(() => {
+    const trimmedPath = (workspacePath ?? "").trim();
+    if (trimmedPath.length === 0 || !fileManagerTarget) return;
+    void openDesktopTarget({
+      editorId: fileManagerTarget.id,
+      workspacePath: trimmedPath,
+    }).catch((error) => {
+      console.warn("[sidebar] openInFileManager failed", error);
+      toast.error(t("sidebar.project.actions.openFolderFailed"));
+    });
+  }, [workspacePath, fileManagerTarget, t, toast]);
   const showShortcut = showShortcutBadge && shortcutNumber !== null;
   const showKebab = Boolean(onArchive && (isHovered || isTouchPlatform));
   const showKebabInSlot = showKebab && !showShortcut;
@@ -698,6 +751,7 @@ function WorkspaceRowRightGroup({
                 archiveShortcutKeys={archiveShortcutKeys}
                 isPinned={isPinned}
                 onTogglePin={onTogglePin}
+                onOpenInFileManager={handleOpenInFileManager}
               />
             ) : null}
           </SidebarWorkspaceTrailingActionOverlay>

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -39,7 +39,6 @@ import {
   ChevronDown,
   ChevronRight,
   ExternalLink,
-  FolderOpen,
   GitPullRequest,
   Settings,
   MoreVertical,
@@ -132,7 +131,7 @@ import {
   getIsElectron,
 } from "@/constants/platform";
 import { getDesktopHost } from "@/desktop/host";
-import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+import { OpenInFileManagerMenuItem } from "@/workspace/open-in-file-manager/menu-item";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
@@ -152,7 +151,6 @@ const ThemedPlus = withUnistyles(Plus);
 const ThemedMoreVertical = withUnistyles(MoreVertical);
 const ThemedTrash2 = withUnistyles(Trash2);
 const ThemedSettings = withUnistyles(Settings);
-const ThemedFolderOpen = withUnistyles(FolderOpen);
 
 const foregroundColorMapping = (theme: Theme) => ({
   color: theme.colors.foreground,
@@ -540,7 +538,6 @@ const settingsLeadingIcon = <ThemedSettings size={14} uniProps={foregroundMutedC
 const openInNewWindowLeadingIcon = (
   <ThemedExternalLink size={14} uniProps={foregroundMutedColorMapping} />
 );
-const folderOpenLeadingIcon = <ThemedFolderOpen size={14} uniProps={foregroundMutedColorMapping} />;
 
 function renderKebabTriggerIcon({ hovered }: { hovered?: boolean }) {
   return (
@@ -583,26 +580,6 @@ function ProjectKebabMenu({
         toast.error(t("sidebar.project.actions.openNewWindowFailed"));
       });
   }, [projectPath, t, toast]);
-  const { targets: desktopOpenTargets } = useDesktopOpenTargets({
-    isLocalExecution: getIsElectron(),
-  });
-  const fileManagerTarget = useMemo(
-    () => desktopOpenTargets.find((target) => target.kind === "file-manager"),
-    [desktopOpenTargets],
-  );
-  const canOpenInFileManager =
-    getIsElectron() && projectPath.trim().length > 0 && fileManagerTarget !== undefined;
-  const handleOpenInFileManager = useCallback(() => {
-    const trimmedPath = projectPath.trim();
-    if (trimmedPath.length === 0 || !fileManagerTarget) return;
-    void openDesktopTarget({
-      editorId: fileManagerTarget.id,
-      workspacePath: trimmedPath,
-    }).catch((error) => {
-      console.warn("[sidebar] openInFileManager failed", error);
-      toast.error(t("sidebar.project.actions.openFolderFailed"));
-    });
-  }, [projectPath, fileManagerTarget, t, toast]);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -633,15 +610,10 @@ function ProjectKebabMenu({
             {t("sidebar.project.actions.openNewWindow")}
           </DropdownMenuItem>
         ) : null}
-        {canOpenInFileManager ? (
-          <DropdownMenuItem
-            testID={`sidebar-project-menu-open-folder-${projectKey}`}
-            leading={folderOpenLeadingIcon}
-            onSelect={handleOpenInFileManager}
-          >
-            {t("sidebar.project.actions.openFolder")}
-          </DropdownMenuItem>
-        ) : null}
+        <OpenInFileManagerMenuItem
+          path={projectPath}
+          testID={`sidebar-project-menu-open-folder-${projectKey}`}
+        />
         <DropdownMenuItem
           testID={`sidebar-project-menu-remove-${projectKey}`}
           leading={trash2LeadingIcon}
@@ -693,27 +665,8 @@ function WorkspaceRowRightGroup({
   isPinned?: boolean;
   onTogglePin?: () => void;
 }) {
-  const { t } = useTranslation();
-  const toast = useToast();
-  const { targets: desktopOpenTargets } = useDesktopOpenTargets({
-    isLocalExecution: getIsElectron(),
-  });
-  const fileManagerTarget = useMemo(
-    () => desktopOpenTargets.find((target) => target.kind === "file-manager"),
-    [desktopOpenTargets],
-  );
   const workspacePath = workspace.workspaceDirectory ?? workspace.projectRootPath;
-  const handleOpenInFileManager = useCallback(() => {
-    const trimmedPath = (workspacePath ?? "").trim();
-    if (trimmedPath.length === 0 || !fileManagerTarget) return;
-    void openDesktopTarget({
-      editorId: fileManagerTarget.id,
-      workspacePath: trimmedPath,
-    }).catch((error) => {
-      console.warn("[sidebar] openInFileManager failed", error);
-      toast.error(t("sidebar.project.actions.openFolderFailed"));
-    });
-  }, [workspacePath, fileManagerTarget, t, toast]);
+  const { t } = useTranslation();
   const showShortcut = showShortcutBadge && shortcutNumber !== null;
   const showKebab = Boolean(onArchive && (isHovered || isTouchPlatform));
   const showKebabInSlot = showKebab && !showShortcut;
@@ -751,7 +704,7 @@ function WorkspaceRowRightGroup({
                 archiveShortcutKeys={archiveShortcutKeys}
                 isPinned={isPinned}
                 onTogglePin={onTogglePin}
-                onOpenInFileManager={handleOpenInFileManager}
+                openInFileManagerPath={workspacePath}
               />
             ) : null}
           </SidebarWorkspaceTrailingActionOverlay>

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
@@ -2,17 +2,8 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableStateCallbackType } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import {
-  Archive,
-  CircleCheck,
-  Copy,
-  FolderOpen,
-  MoreVertical,
-  Pencil,
-  Pin,
-  PinOff,
-} from "lucide-react-native";
-import { getIsElectron, isNative, isWeb } from "@/constants/platform";
+import { Archive, CircleCheck, Copy, MoreVertical, Pencil, Pin, PinOff } from "lucide-react-native";
+import { isNative, isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
 import type { ShortcutKey } from "@/utils/format-shortcut";
 import {
@@ -22,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Shortcut } from "@/components/ui/shortcut";
+import { OpenInFileManagerMenuItem } from "@/workspace/open-in-file-manager/menu-item";
 
 const foregroundColorMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const foregroundMutedColorMapping = (theme: Theme) => ({
@@ -35,7 +27,6 @@ const ThemedPencil = withUnistyles(Pencil);
 const ThemedCircleCheck = withUnistyles(CircleCheck);
 const ThemedPin = withUnistyles(Pin);
 const ThemedPinOff = withUnistyles(PinOff);
-const ThemedFolderOpen = withUnistyles(FolderOpen);
 
 const copyLeadingIcon = <ThemedCopy size={14} uniProps={foregroundMutedColorMapping} />;
 const renameLeadingIcon = <ThemedPencil size={14} uniProps={foregroundMutedColorMapping} />;
@@ -45,7 +36,6 @@ const markAsReadLeadingIcon = (
 const archiveLeadingIcon = <ThemedArchive size={14} uniProps={foregroundMutedColorMapping} />;
 const pinLeadingIcon = <ThemedPin size={14} uniProps={foregroundMutedColorMapping} />;
 const unpinLeadingIcon = <ThemedPinOff size={14} uniProps={foregroundMutedColorMapping} />;
-const folderOpenLeadingIcon = <ThemedFolderOpen size={14} uniProps={foregroundMutedColorMapping} />;
 
 function renderTriggerIcon({ hovered }: { hovered?: boolean }) {
   return (
@@ -69,7 +59,7 @@ interface SidebarWorkspaceMenuProps {
   archiveShortcutKeys?: ShortcutKey[][] | null;
   isPinned?: boolean;
   onTogglePin?: () => void;
-  onOpenInFileManager?: () => void;
+  openInFileManagerPath?: string | null;
 }
 
 export function SidebarWorkspaceMenu({
@@ -85,7 +75,7 @@ export function SidebarWorkspaceMenu({
   archiveShortcutKeys,
   isPinned,
   onTogglePin,
-  onOpenInFileManager,
+  openInFileManagerPath,
 }: SidebarWorkspaceMenuProps) {
   const { t } = useTranslation();
   const archiveTrailing = useMemo(
@@ -150,15 +140,10 @@ export function SidebarWorkspaceMenu({
             {isPinned ? t("sidebar.workspace.actions.unpin") : t("sidebar.workspace.actions.pin")}
           </DropdownMenuItem>
         ) : null}
-        {onOpenInFileManager && getIsElectron() ? (
-          <DropdownMenuItem
-            testID={`sidebar-workspace-menu-open-folder-${workspaceKey}`}
-            leading={folderOpenLeadingIcon}
-            onSelect={onOpenInFileManager}
-          >
-            {t("sidebar.project.actions.openFolder")}
-          </DropdownMenuItem>
-        ) : null}
+        <OpenInFileManagerMenuItem
+          path={openInFileManagerPath}
+          testID={`sidebar-workspace-menu-open-folder-${workspaceKey}`}
+        />
         <DropdownMenuItem
           testID={`sidebar-workspace-menu-archive-${workspaceKey}`}
           leading={archiveLeadingIcon}

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
@@ -2,8 +2,17 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableStateCallbackType } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { Archive, CircleCheck, Copy, MoreVertical, Pencil, Pin, PinOff } from "lucide-react-native";
-import { isNative, isWeb } from "@/constants/platform";
+import {
+  Archive,
+  CircleCheck,
+  Copy,
+  FolderOpen,
+  MoreVertical,
+  Pencil,
+  Pin,
+  PinOff,
+} from "lucide-react-native";
+import { getIsElectron, isNative, isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
 import type { ShortcutKey } from "@/utils/format-shortcut";
 import {
@@ -26,6 +35,7 @@ const ThemedPencil = withUnistyles(Pencil);
 const ThemedCircleCheck = withUnistyles(CircleCheck);
 const ThemedPin = withUnistyles(Pin);
 const ThemedPinOff = withUnistyles(PinOff);
+const ThemedFolderOpen = withUnistyles(FolderOpen);
 
 const copyLeadingIcon = <ThemedCopy size={14} uniProps={foregroundMutedColorMapping} />;
 const renameLeadingIcon = <ThemedPencil size={14} uniProps={foregroundMutedColorMapping} />;
@@ -35,6 +45,7 @@ const markAsReadLeadingIcon = (
 const archiveLeadingIcon = <ThemedArchive size={14} uniProps={foregroundMutedColorMapping} />;
 const pinLeadingIcon = <ThemedPin size={14} uniProps={foregroundMutedColorMapping} />;
 const unpinLeadingIcon = <ThemedPinOff size={14} uniProps={foregroundMutedColorMapping} />;
+const folderOpenLeadingIcon = <ThemedFolderOpen size={14} uniProps={foregroundMutedColorMapping} />;
 
 function renderTriggerIcon({ hovered }: { hovered?: boolean }) {
   return (
@@ -58,6 +69,7 @@ interface SidebarWorkspaceMenuProps {
   archiveShortcutKeys?: ShortcutKey[][] | null;
   isPinned?: boolean;
   onTogglePin?: () => void;
+  onOpenInFileManager?: () => void;
 }
 
 export function SidebarWorkspaceMenu({
@@ -73,6 +85,7 @@ export function SidebarWorkspaceMenu({
   archiveShortcutKeys,
   isPinned,
   onTogglePin,
+  onOpenInFileManager,
 }: SidebarWorkspaceMenuProps) {
   const { t } = useTranslation();
   const archiveTrailing = useMemo(
@@ -135,6 +148,15 @@ export function SidebarWorkspaceMenu({
             onSelect={onTogglePin}
           >
             {isPinned ? t("sidebar.workspace.actions.unpin") : t("sidebar.workspace.actions.pin")}
+          </DropdownMenuItem>
+        ) : null}
+        {onOpenInFileManager && getIsElectron() ? (
+          <DropdownMenuItem
+            testID={`sidebar-workspace-menu-open-folder-${workspaceKey}`}
+            leading={folderOpenLeadingIcon}
+            onSelect={onOpenInFileManager}
+          >
+            {t("sidebar.project.actions.openFolder")}
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuItem

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -908,6 +908,8 @@ export const ar: TranslationResources = {
         openSettings: "افتح إعدادات المشروع",
         openNewWindow: "Open in new window",
         openNewWindowFailed: "Couldn't open a new window",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "إزالة المشروع",
         removing: "جارٍ الإزالة...",
       },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -918,6 +918,8 @@ export const en = {
         openSettings: "Open project settings",
         openNewWindow: "Open in new window",
         openNewWindowFailed: "Couldn't open a new window",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "Remove project",
         removing: "Removing...",
       },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -939,6 +939,8 @@ export const es: TranslationResources = {
         openSettings: "Abrir la configuración del proyecto",
         openNewWindow: "Open in new window",
         openNewWindowFailed: "Couldn't open a new window",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "Eliminar proyecto",
         removing: "Eliminando...",
       },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -938,6 +938,8 @@ export const fr: TranslationResources = {
         openSettings: "Ouvrir les paramètres du projet",
         openNewWindow: "Open in new window",
         openNewWindowFailed: "Couldn't open a new window",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "Supprimer le projet",
         removing: "Suppression...",
       },

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -919,6 +919,8 @@ export const ja: TranslationResources = {
         openSettings: "プロジェクト設定を開く",
         openNewWindow: "新しいウィンドウで開く",
         openNewWindowFailed: "新しいウィンドウを開けませんでした",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "プロジェクトを削除",
         removing: "削除中...",
       },

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -930,6 +930,8 @@ export const ptBR: TranslationResources = {
         openSettings: "Abrir configurações do projeto",
         openNewWindow: "Abrir em nova janela",
         openNewWindowFailed: "Não foi possível abrir uma nova janela",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "Remover projeto",
         removing: "Removendo...",
       },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -930,6 +930,8 @@ export const ru: TranslationResources = {
         openSettings: "Открыть настройки проекта",
         openNewWindow: "Open in new window",
         openNewWindowFailed: "Couldn't open a new window",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "Удалить проект",
         removing: "Удаление...",
       },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -899,6 +899,8 @@ export const zhCN: TranslationResources = {
         openSettings: "打开 project 设置",
         openNewWindow: "在新窗口中打开",
         openNewWindowFailed: "无法打开新窗口",
+        openFolder: "Open in file manager",
+        openFolderFailed: "Couldn't open folder",
         remove: "移除 project",
         removing: "正在移除...",
       },

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { FolderOpen } from "lucide-react-native";
+import { withUnistyles } from "react-native-unistyles";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { getIsElectron } from "@/constants/platform";
+import { useToast } from "@/contexts/toast-context";
+import type { Theme } from "@/styles/theme";
+import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+
+interface OpenInFileManagerMenuItemProps {
+  path?: string | null;
+  testID: string;
+}
+
+const ThemedFolderOpen = withUnistyles(FolderOpen);
+
+const foregroundMutedColorMapping = (theme: Theme) => ({
+  color: theme.colors.foregroundMuted,
+});
+
+const leadingIcon = <ThemedFolderOpen size={14} uniProps={foregroundMutedColorMapping} />;
+
+export function OpenInFileManagerMenuItem({ path, testID }: OpenInFileManagerMenuItemProps) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const isElectron = getIsElectron();
+  const workspacePath = path?.trim() ?? "";
+  const { targets } = useDesktopOpenTargets({
+    isLocalExecution: isElectron && workspacePath.length > 0,
+  });
+  const fileManagerTarget = targets.find((target) => target.kind === "file-manager");
+
+  const openInFileManager = useCallback(() => {
+    if (!fileManagerTarget || workspacePath.length === 0) return;
+    void openDesktopTarget({
+      editorId: fileManagerTarget.id,
+      workspacePath,
+    }).catch((error) => {
+      console.warn("[open-in-file-manager] open failed", error);
+      toast.error(t("sidebar.project.actions.openFolderFailed"));
+    });
+  }, [fileManagerTarget, t, toast, workspacePath]);
+
+  if (!isElectron || !fileManagerTarget || workspacePath.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenuItem testID={testID} leading={leadingIcon} onSelect={openInFileManager}>
+      {t("sidebar.project.actions.openFolder")}
+    </DropdownMenuItem>
+  );
+}


### PR DESCRIPTION
### Linked issue

Closes #2487

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds an **Open in file manager** action to project and workspace context menus in the desktop sidebar. It opens the selected local root in File Explorer, Finder, or the default Linux file manager.

The Electron gating, target discovery, menu presentation, launch behavior, and error handling live in one feature module; sidebar menus provide only the path.

### How did you verify it

- Launched Desktop dev on Windows with `npm run dev:win:desktop`.
- Opened a project root and workspace root from their sidebar context menus in File Explorer.
- Verified the action is hidden in a non-Electron web browser.
- Ran `npm run format`, `npm run typecheck`, and `npm run lint`.
- Ran `npx vitest run packages/app/src/components/sidebar-workspace-list.test.tsx --bail=1` (4/4 passing after `npm run build:client`).

The action is Electron-only. Windows received manual coverage; macOS and Linux use the existing desktop open-target bridge and remain platform-specific risk surfaces.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense