### PR TITLE
fix: preserve context window data when turn_completed lacks usage

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4757,7 +4757,7 @@ test("replaceAgentRun stays running when a stale old terminal arrives before the
   unsubscribe();
 });
 
-test("applies live autonomous events while no foreground run is active", async () => {
+test("applies live autonomous events and preserves usage omitted from completion", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-live-events-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
@@ -4817,6 +4817,16 @@ test("applies live autonomous events while no foreground run is active", async (
     turnId: autonomousTurnId,
   });
   capturedSession!.pushEvent({
+    type: "usage_updated",
+    provider: "codex",
+    usage: {
+      inputTokens: 10,
+      contextWindowMaxTokens: 200_000,
+      contextWindowUsedTokens: 175,
+    },
+    turnId: autonomousTurnId,
+  });
+  capturedSession!.pushEvent({
     type: "timeline",
     provider: "codex",
     item: { type: "assistant_message", text: "AUTONOMOUS_PUMP_MESSAGE" },
@@ -4831,6 +4841,11 @@ test("applies live autonomous events while no foreground run is active", async (
 
   const updated = manager.getAgent(snapshot.id);
   expect(updated?.lifecycle).toBe("idle");
+  expect(updated?.lastUsage).toEqual({
+    inputTokens: 10,
+    contextWindowMaxTokens: 200_000,
+    contextWindowUsedTokens: 175,
+  });
   expect(manager.getTimeline(snapshot.id)).toContainEqual({
     type: "assistant_message",
     text: "AUTONOMOUS_PUMP_MESSAGE",

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3636,7 +3636,12 @@ export class AgentManager {
       },
       "agent.manager.turn.completed",
     );
-    agent.lastUsage = event.usage;
+    if (event.usage) {
+      agent.lastUsage = { ...agent.lastUsage, ...event.usage };
+    }
+    // If no usage on turn_completed, keep lastUsage as-is so context window
+    // data accumulated during streaming isn't lost when the provider omits
+    // it from the completion event.
     agent.lastError = undefined;
     if (!isForegroundEvent && agent.lifecycle !== "idle" && !agent.pendingReplacement) {
       (agent as ActiveManagedAgent).lifecycle = "idle";


### PR DESCRIPTION
### Linked issue

Closes #2493

<!-- TODO: create/link issue before submitting -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The context window meter in the composer disappears when an agent finishes its turn. `onStreamTurnCompleted` replaced `agent.lastUsage` wholesale with `event.usage`, but providers like Claude (autonomous turns) and OpenCode emit `turn_completed` without any usage payload — wiping the `contextWindowMaxTokens`/`contextWindowUsedTokens` accumulated during streaming `usage_updated` events. Changed the assignment to merge incoming usage into the existing object, so fields omitted by the provider are preserved.

### How did you verify it

Traced the full flow from `AgentStreamEvent` → `agent.lastUsage` → client selector → `renderContextWindowMeter`. Confirmed which providers emit `turn_completed` without usage by reading their source (Claude autonomous at `claude/agent.ts:3350`, OpenCode at `opencode-agent.ts:2064`). Ran agent-projections tests and codex usage-related tests — all pass. Lint and format clean. This is a server-side behavior change with no UI modification, so no screenshots needed. The meter persistence itself should be verified end-to-end on a device by starting an agent that streams usage then completes autonomously.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense

<!-- Typecheck checkbox unchecked: workspace-wide typecheck has pre-existing failures in client/server relay transport and app Codemirror modules unrelated to this change. Targeted typecheck of the modified file is clean. -->