### PR TITLE
Show a single 1M-context Claude Opus 5 model

### DIFF
--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -109,16 +109,6 @@ const EXPECTED_CLAUDE_MODELS = [
 
 const EXPECTED_CLAUDE_CONTEXT_MODELS = [
   {
-    id: "claude-opus-5[1m]",
-    model: "Opus 5 1M",
-    descriptionFragment: "1M context window",
-  },
-  {
-    id: "claude-opus-5",
-    model: "Opus 5",
-    descriptionFragment: "200K context window",
-  },
-  {
     id: "claude-fable-5[1m]",
     model: "Fable 5 1M",
     descriptionFragment: "1M context window",

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -416,7 +416,6 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
       });
 
       expect(models.map((m) => m.id)).toEqual([
-        "claude-opus-5[1m]",
         "claude-opus-5",
         "claude-fable-5[1m]",
         "claude-fable-5",
@@ -439,7 +438,7 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
       }
 
       const defaultModel = models.find((m) => m.isDefault);
-      expect(defaultModel?.id).toBe("claude-opus-5[1m]");
+      expect(defaultModel?.id).toBe("claude-opus-5");
     } finally {
       await fs.rm(emptyConfigDir, { recursive: true, force: true });
     }
@@ -461,7 +460,7 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
         force: false,
       });
 
-      expect(models.find((model) => model.isDefault)?.id).toBe("claude-opus-5[1m]");
+      expect(models.find((model) => model.isDefault)?.id).toBe("claude-opus-5");
       expect(models.map((model) => model.id)).toContain("claude-fable-5[1m]");
     } finally {
       await fs.rm(emptyConfigDir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/providers/claude/model-manifest.ts
+++ b/packages/server/src/server/agent/providers/claude/model-manifest.ts
@@ -32,21 +32,12 @@ export const CLAUDE_ULTRACODE_THINKING_OPTION_ID = "ultracode";
 
 export const CLAUDE_MODEL_MANIFEST = [
   {
-    id: "claude-opus-5[1m]",
-    label: "Opus 5 1M",
-    description: "Opus 5 with 1M context window",
+    id: "claude-opus-5",
+    label: "Opus 5",
+    description: "Opus 5 · Latest release",
     defaultPriority: 2,
     minimumClaudeCodeVersion: "2.1.219",
     contextWindowMaxTokens: 1_000_000,
-    effortLevels: CLAUDE_EFFORT_LEVELS.xhigh,
-    supportsThinkingDisabled: true,
-  },
-  {
-    id: "claude-opus-5",
-    label: "Opus 5",
-    description: "Opus 5 · 200K context window",
-    minimumClaudeCodeVersion: "2.1.219",
-    contextWindowMaxTokens: 200_000,
     effortLevels: CLAUDE_EFFORT_LEVELS.xhigh,
     supportsThinkingDisabled: true,
   },

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -50,7 +50,6 @@ describe("getClaudeModels", () => {
   it("returns all claude models", () => {
     const models = getClaudeModels();
     expect(models.map((m) => m.id)).toEqual([
-      "claude-opus-5[1m]",
       "claude-opus-5",
       "claude-fable-5[1m]",
       "claude-fable-5",
@@ -72,7 +71,7 @@ describe("getClaudeModels", () => {
     const models = getClaudeModels();
     const defaults = models.filter((m) => m.isDefault);
     expect(defaults).toHaveLength(1);
-    expect(defaults[0].id).toBe("claude-opus-5[1m]");
+    expect(defaults[0].id).toBe("claude-opus-5");
   });
 
   it("defines context window sizes in the catalog", () => {
@@ -82,8 +81,7 @@ describe("getClaudeModels", () => {
 
     expect(contextWindows).toEqual(
       new Map([
-        ["claude-opus-5[1m]", 1_000_000],
-        ["claude-opus-5", 200_000],
+        ["claude-opus-5", 1_000_000],
         ["claude-fable-5[1m]", 1_000_000],
         ["claude-fable-5", 200_000],
         ["claude-opus-4-8[1m]", 1_000_000],
@@ -103,10 +101,8 @@ describe("getClaudeModels", () => {
 
   it("filters models by their minimum Claude Code version", () => {
     const oldVersionModels = getClaudeModels("2.1.218");
-    expect(oldVersionModels.map((model) => model.id)).not.toContain("claude-opus-5[1m]");
     expect(oldVersionModels.map((model) => model.id)).not.toContain("claude-opus-5");
     expect(oldVersionModels.find((model) => model.isDefault)?.id).toBe("claude-opus-4-8");
-    expect(getClaudeModels("2.1.219").map((model) => model.id)).toContain("claude-opus-5[1m]");
     expect(getClaudeModels("2.1.219").map((model) => model.id)).toContain("claude-opus-5");
 
     expect(getClaudeModels("2.1.168").map((model) => model.id)).not.toContain("claude-fable-5[1m]");
@@ -347,7 +343,6 @@ describe("ClaudeAgentClient.fetchCatalog", () => {
 
 describe("normalizeClaudeRuntimeModelId", () => {
   it("returns exact match for known model IDs", () => {
-    expect(normalizeClaudeRuntimeModelId("claude-opus-5[1m]")).toBe("claude-opus-5[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-opus-5")).toBe("claude-opus-5");
     expect(normalizeClaudeRuntimeModelId("claude-fable-5")).toBe("claude-fable-5");
     expect(normalizeClaudeRuntimeModelId("claude-fable-5[1m]")).toBe("claude-fable-5[1m]");
@@ -366,7 +361,6 @@ describe("normalizeClaudeRuntimeModelId", () => {
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6-20260101")).toBe("claude-opus-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-4-6-20260101")).toBe("claude-sonnet-4-6");
     expect(normalizeClaudeRuntimeModelId("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5");
-    expect(normalizeClaudeRuntimeModelId("claude-opus-5-20260724[1m]")).toBe("claude-opus-5[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-fable-5-20260301[1m]")).toBe("claude-fable-5[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-5-20260101[1m]")).toBe(
       "claude-sonnet-5[1m]",
@@ -374,7 +368,6 @@ describe("normalizeClaudeRuntimeModelId", () => {
   });
 
   it("preserves [1m] suffix from runtime model strings", () => {
-    expect(normalizeClaudeRuntimeModelId("claude-opus-5[1m]")).toBe("claude-opus-5[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-fable-5[1m]")).toBe("claude-fable-5[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-sonnet-5[1m]")).toBe("claude-sonnet-5[1m]");
     expect(normalizeClaudeRuntimeModelId("claude-opus-4-6[1m]")).toBe("claude-opus-4-6[1m]");
@@ -418,6 +411,32 @@ describe("findClaudeModel", () => {
     expect(findClaudeModel("us.anthropic.claude-opus-4-8[1m]")?.contextWindowMaxTokens).toBe(
       1_000_000,
     );
+  });
+});
+
+describe("Claude Opus 5 catalog", () => {
+  it("offers a single Opus 5 entry with a 1M context window", () => {
+    const opus5Models = getClaudeModels()
+      .filter((model) => model.id.startsWith("claude-opus-5"))
+      .map(({ id, label, contextWindowMaxTokens }) => ({ id, label, contextWindowMaxTokens }));
+
+    expect(opus5Models).toEqual([
+      { id: "claude-opus-5", label: "Opus 5", contextWindowMaxTokens: 1_000_000 },
+    ]);
+  });
+
+  it("resolves retired and dated Opus 5 IDs to the single catalog entry", () => {
+    expect(findClaudeModel("claude-opus-5[1m]")?.id).toBe("claude-opus-5");
+    expect(findClaudeModel("claude-opus-5-20260724")?.id).toBe("claude-opus-5");
+    expect(findClaudeModel("claude-opus-5-20260724[1m]")?.id).toBe("claude-opus-5");
+    expect(findClaudeModel("claude-opus-5[1m]")?.contextWindowMaxTokens).toBe(1_000_000);
+  });
+
+  it("keeps disabled thinking available for agents persisted on the retired 1M ID", () => {
+    expect(resolveClaudeDisabledThinkingForModel("claude-opus-5[1m]")).toEqual({
+      supported: true,
+      fallbackThinkingOptionId: "low",
+    });
   });
 });
 


### PR DESCRIPTION
### Linked issue

No matching open issue found.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The Claude model catalog offered two Opus 5 entries — "Opus 5 1M" (`claude-opus-5[1m]`, 1M) and "Opus 5" (`claude-opus-5`, described as 200K). The 200K variant does not exist. Opus 5 has a 1M context window as both its default and its maximum, so the second entry advertised a choice that was never real, and picking it ran at 1M anyway while the UI reported 200K.

This collapses the two into a single canonical entry: `claude-opus-5`, labelled "Opus 5", at 1M. Verified against the local Claude Code CLI (2.1.220), which reports the same result for both forms:

```
--model claude-opus-5      -> contextWindow 1000000, canonicalModel "claude-opus-5"
--model 'claude-opus-5[1m]' -> contextWindow 1000000, canonicalModel "claude-opus-5"
```

The bare ID is what Claude Code itself considers canonical, so the `[1m]` suffix carried no meaning for this model and the label no longer needs to disambiguate.

Existing selections keep working with no migration code. Runtime, persisted, and dated `claude-opus-5[1m]` IDs already resolve to the bare ID through the manifest's existing suffix fallback, so agents resume with their context window and thinking options intact, and any stored selection of the retired ID lands on the surviving entry (which is also the catalog default).

### How did you verify it

- Added the catalog regression test first and observed it fail: the catalog returned two Opus 5 entries, and `claude-opus-5[1m]` resolved to itself rather than to a single canonical entry.
- Added a guard that disabled thinking stays available for agents persisted on the retired `[1m]` ID, so the suffix fallback cannot be removed without a failing test.
- `npx vitest run packages/server/src/server/agent/providers/claude/models.test.ts --bail=1` — 33 passed.
- `npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts --bail=1` — 60 passed.
- `npx tsx packages/cli/tests/15-provider.test.ts` against a real isolated daemon with an empty Claude config dir — all 11 provider tests passed, covering the catalog as rendered by `provider models claude`.
- Probed the real Claude Code CLI directly for both model ID forms (output above).
- `npm run typecheck`, `npm run lint` (0 warnings, 0 errors), `npm run format` — all pass.

### Risk surface

Limited to the Claude model manifest and its tests. No client, protocol, or persistence changes. The only user-visible effects are that the catalog lists one Opus 5 instead of two, and that anyone who had explicitly selected the retired 1M entry now sees the same model under the plain "Opus 5" name. Model resolution, context-window reporting, and thinking-option capability are unchanged for every other model.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no client code changed)
- [x] Tests added or updated where it made sense
