### PR TITLE
feat(app): cycle sidebar grouping with Cmd/Ctrl+Shift+G

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -78,6 +78,7 @@ import { loadDesktopSettings } from "@/desktop/settings/desktop-settings";
 import { RosettaCalloutSource } from "@/desktop/updates/rosetta-callout-source";
 import { UpdateCalloutSource } from "@/desktop/updates/update-callout-source";
 import { useActiveWorktreeNewAction } from "@/hooks/use-active-worktree-new-action";
+import { useGlobalGroupModeCycleAction } from "@/hooks/use-global-group-mode-cycle-action";
 import { useGlobalNewWorkspaceAction } from "@/hooks/use-global-new-workspace-action";
 import { useLatchedBoolean } from "@/hooks/use-latched-boolean";
 import { useFaviconStatus } from "@/hooks/use-favicon-status";
@@ -489,6 +490,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
 
   useActiveWorktreeNewAction();
   useGlobalNewWorkspaceAction();
+  useGlobalGroupModeCycleAction();
 
   const appContentMinimumWidth = resolveDesktopAppContentMinimum({
     isSettingsRoute: pathname.includes("/settings"),

--- a/packages/app/src/hooks/use-global-group-mode-cycle-action.ts
+++ b/packages/app/src/hooks/use-global-group-mode-cycle-action.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
+import type { KeyboardActionId } from "@/keyboard/keyboard-action-dispatcher";
+import { nextGroupMode, useSidebarViewStore } from "@/stores/sidebar-view-store";
+
+const GROUP_MODE_CYCLE_ACTIONS: readonly KeyboardActionId[] = ["sidebar.cycle.group-mode"];
+
+/**
+ * Registers the global handler for the "Cycle sidebar grouping" shortcut.
+ * Steps the sidebar group mode through its cycle (project -> status -> ...).
+ * The binding lives in SHORTCUT_BINDINGS (Cmd+Shift+G on macOS, Ctrl+Shift+G
+ * elsewhere) and is rebindable in Settings. Mounted once at the app root, like
+ * useGlobalNewWorkspaceAction.
+ */
+export function useGlobalGroupModeCycleAction() {
+  const handle = useCallback(() => {
+    const { groupMode, setGroupMode } = useSidebarViewStore.getState();
+    setGroupMode(nextGroupMode(groupMode));
+    return true;
+  }, []);
+
+  useKeyboardActionHandler({
+    handlerId: "group-mode-cycle-global",
+    actions: GROUP_MODE_CYCLE_ACTIONS,
+    enabled: true,
+    priority: 0,
+    handle,
+  });
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1912,6 +1912,7 @@ export const ar: TranslationResources = {
         agentInput: "إدخال Agent",
       },
       help: {
+        cycleGroupMode: "تبديل تجميع الشريط الجانبي",
         openProject: "مشروع مفتوح",
         newWorkspace: "مساحة عمل جديدة",
         newWorktree: "شجرة عمل جديدة",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1922,6 +1922,7 @@ export const en = {
         agentInput: "Agent Input",
       },
       help: {
+        cycleGroupMode: "Cycle sidebar grouping",
         openProject: "Open project",
         newWorkspace: "New workspace",
         newWorktree: "New worktree",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1960,6 +1960,7 @@ export const es: TranslationResources = {
         agentInput: "EntradaAgent",
       },
       help: {
+        cycleGroupMode: "Cambiar agrupación de la barra lateral",
         openProject: "Abrir proyecto",
         newWorkspace: "Nuevo espacio de trabajo",
         newWorktree: "Nuevo árbol de trabajo",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1963,6 +1963,7 @@ export const fr: TranslationResources = {
         agentInput: "EntréeAgent",
       },
       help: {
+        cycleGroupMode: "Changer le regroupement de la barre latérale",
         openProject: "Projet ouvert",
         newWorkspace: "Nouvel espace de travail",
         newWorktree: "Nouvel arbre de travail",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1928,6 +1928,7 @@ export const ja: TranslationResources = {
         agentInput: "エージェント入力",
       },
       help: {
+        cycleGroupMode: "サイドバーのグループ化を切り替え",
         openProject: "プロジェクトを開く",
         newWorkspace: "新しいワークスペース",
         newWorktree: "新しいワークツリー",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1923,6 +1923,7 @@ export const ko: TranslationResources = {
         agentInput: "에이전트 입력",
       },
       help: {
+        cycleGroupMode: "사이드바 그룹화 순환",
         openProject: "프로젝트 열기",
         newWorkspace: "새 워크스페이스",
         newWorktree: "새 워크트리",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1943,6 +1943,7 @@ export const ptBR: TranslationResources = {
         agentInput: "Entrada do agente",
       },
       help: {
+        cycleGroupMode: "Alternar agrupamento da barra lateral",
         openProject: "Abrir projeto",
         newWorkspace: "Novo workspace",
         newWorktree: "Novo worktree",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1950,6 +1950,7 @@ export const ru: TranslationResources = {
         agentInput: "Вход Agent",
       },
       help: {
+        cycleGroupMode: "Переключить группировку боковой панели",
         openProject: "Открыть проект",
         newWorkspace: "Новое рабочее пространство",
         newWorktree: "Новое рабочее дерево",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1890,6 +1890,7 @@ export const zhCN: TranslationResources = {
         agentInput: "Agent 输入",
       },
       help: {
+        cycleGroupMode: "切换侧边栏分组",
         openProject: "打开项目",
         newWorkspace: "新建 workspace",
         newWorktree: "新建 worktree",

--- a/packages/app/src/keyboard/actions.ts
+++ b/packages/app/src/keyboard/actions.ts
@@ -39,6 +39,7 @@ export type KeyboardActionId =
   | "sidebar.toggle.left"
   | "sidebar.toggle.right"
   | "sidebar.toggle.both"
+  | "sidebar.cycle.group-mode"
   | "settings.toggle"
   | "command-center.toggle"
   | "shortcuts.dialog.toggle"

--- a/packages/app/src/keyboard/keyboard-action-dispatcher.ts
+++ b/packages/app/src/keyboard/keyboard-action-dispatcher.ts
@@ -29,6 +29,7 @@ export type KeyboardActionId =
   | "workspace.terminal.new"
   | "workspace.browser.new"
   | "sidebar.toggle.right"
+  | "sidebar.cycle.group-mode"
   | "workspace.new"
   | "workspace.project.pick"
   | "worktree.new"
@@ -64,6 +65,7 @@ export type KeyboardActionDefinition =
   | { id: "workspace.terminal.new"; scope: KeyboardActionScope }
   | { id: "workspace.browser.new"; scope: KeyboardActionScope }
   | { id: "sidebar.toggle.right"; scope: KeyboardActionScope }
+  | { id: "sidebar.cycle.group-mode"; scope: KeyboardActionScope }
   | { id: "workspace.new"; scope: KeyboardActionScope }
   | { id: "workspace.project.pick"; scope: KeyboardActionScope }
   | { id: "worktree.new"; scope: KeyboardActionScope }

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -3,6 +3,7 @@ import {
   buildKeyboardShortcutHelpSections,
   buildEffectiveBindings,
   getBindingIdForAction,
+  getDefaultKeysForAction,
   getWorkspaceIndexJumpModifierKey,
   resolveKeyboardShortcut,
   type ChordState,
@@ -713,5 +714,83 @@ describe("getWorkspaceIndexJumpModifierKey", () => {
 
   it("uses Ctrl on desktop non-Mac, not Meta or Alt", () => {
     expect(getWorkspaceIndexJumpModifierKey({ isMac: false, isDesktop: true })).toBe("Control");
+  });
+});
+
+describe("cycle sidebar grouping shortcut", () => {
+  const platforms = [
+    {
+      context: { isMac: true, isDesktop: true },
+      bindingId: "sidebar-group-mode-cycle-cmd-shift-g-mac",
+    },
+    {
+      context: { isMac: false, isDesktop: false },
+      bindingId: "sidebar-group-mode-cycle-ctrl-shift-g-non-mac",
+    },
+  ];
+
+  function findHelpRow(context: { isMac: boolean; isDesktop: boolean }, id: string) {
+    for (const section of buildKeyboardShortcutHelpSections(context)) {
+      const row = section.rows.find((candidate) => candidate.id === id);
+      if (row) return { row, sectionId: section.id };
+    }
+    return null;
+  }
+
+  it("fires on Cmd+Shift+G on Mac", () => {
+    expectShortcutResolution({
+      event: { key: "G", code: "KeyG", metaKey: true, shiftKey: true },
+      context: { isMac: true },
+      action: "sidebar.cycle.group-mode",
+    });
+  });
+
+  it("fires on Ctrl+Shift+G off Mac", () => {
+    expectShortcutResolution({
+      event: { key: "G", code: "KeyG", ctrlKey: true, shiftKey: true },
+      context: { isMac: false },
+      action: "sidebar.cycle.group-mode",
+    });
+  });
+
+  it("does not fire on the other platform's modifier", () => {
+    expectNoShortcutResolution({
+      event: { key: "G", code: "KeyG", ctrlKey: true, shiftKey: true },
+      context: { isMac: true },
+    });
+  });
+
+  it.each([
+    { isMac: true, focusScope: "terminal" },
+    { isMac: true, commandCenterOpen: true },
+  ] satisfies Partial<KeyboardShortcutContext>[])(
+    "stays out of the terminal and the command center (%j)",
+    (context) => {
+      expectNoShortcutResolution({
+        event: { key: "G", code: "KeyG", metaKey: true, shiftKey: true },
+        context,
+      });
+    },
+  );
+
+  it.each(platforms)("shows one Panels help row on $context.isMac", ({ context, bindingId }) => {
+    const found = findHelpRow(context, "cycle-group-mode");
+    expect(found?.sectionId).toBe("panels");
+    expect(found?.row.keys).toEqual(["mod", "shift", "G"]);
+    expect(found?.row.labelKey).toBe("settings.shortcuts.help.cycleGroupMode");
+    expect(getBindingIdForAction("cycle-group-mode", context)).toBe(bindingId);
+    expect(getDefaultKeysForAction("cycle-group-mode", context)).toEqual(["mod", "shift", "G"]);
+  });
+
+  it("stays rebindable to a user-chosen combo", () => {
+    const bindings = buildEffectiveBindings({
+      "sidebar-group-mode-cycle-cmd-shift-g-mac": "Cmd+J",
+    });
+    const result = resolveShortcut({
+      event: { key: "j", code: "KeyJ", metaKey: true },
+      context: { isMac: true },
+      bindings,
+    });
+    expect(result.match?.action).toBe("sidebar.cycle.group-mode");
   });
 });

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -168,6 +168,7 @@ const SHORTCUT_HELP_LABEL_KEYS: Record<string, string> = {
   "dictation-toggle": "settings.shortcuts.help.startStopDictation",
   "agent-interrupt": "settings.shortcuts.help.interruptAgent",
   "voice-mute-toggle": "settings.shortcuts.help.muteUnmuteVoiceMode",
+  "cycle-group-mode": "settings.shortcuts.help.cycleGroupMode",
 };
 
 const SHORTCUT_HELP_NOTE_KEYS: Record<string, string> = {
@@ -1058,6 +1059,30 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       section: "agent-input",
       label: "Mute/unmute voice mode",
       keys: ["Space"],
+    },
+  },
+  {
+    id: "sidebar-group-mode-cycle-cmd-shift-g-mac",
+    action: "sidebar.cycle.group-mode",
+    combo: "Cmd+Shift+G",
+    when: { mac: true, commandCenter: false, terminal: false },
+    help: {
+      id: "cycle-group-mode",
+      section: "panels",
+      label: "Cycle sidebar grouping",
+      keys: ["mod", "shift", "G"],
+    },
+  },
+  {
+    id: "sidebar-group-mode-cycle-ctrl-shift-g-non-mac",
+    action: "sidebar.cycle.group-mode",
+    combo: "Ctrl+Shift+G",
+    when: { mac: false, commandCenter: false, terminal: false },
+    help: {
+      id: "cycle-group-mode",
+      section: "panels",
+      label: "Cycle sidebar grouping",
+      keys: ["mod", "shift", "G"],
     },
   },
 ];

--- a/packages/app/src/keyboard/route-shortcut.test.ts
+++ b/packages/app/src/keyboard/route-shortcut.test.ts
@@ -37,6 +37,7 @@ describe("routeKeyboardShortcut — dispatch passthroughs", () => {
     ["workspace.terminal.new", { id: "workspace.terminal.new", scope: "workspace" }],
     ["workspace.tab.close.current", { id: "workspace.tab.close-current", scope: "workspace" }],
     ["sidebar.toggle.right", { id: "sidebar.toggle.right", scope: "sidebar" }],
+    ["sidebar.cycle.group-mode", { id: "sidebar.cycle.group-mode", scope: "sidebar" }],
     ["workspace.pane.split.right", { id: "workspace.pane.split.right", scope: "workspace" }],
     ["workspace.pane.split.down", { id: "workspace.pane.split.down", scope: "workspace" }],
     ["workspace.pane.focus.left", { id: "workspace.pane.focus.left", scope: "workspace" }],

--- a/packages/app/src/keyboard/route-shortcut.ts
+++ b/packages/app/src/keyboard/route-shortcut.ts
@@ -49,6 +49,7 @@ const PASSTHROUGH_DISPATCH: Record<string, KeyboardActionDefinition> = {
   "workspace.terminal.new": { id: "workspace.terminal.new", scope: "workspace" },
   "workspace.tab.close.current": { id: "workspace.tab.close-current", scope: "workspace" },
   "sidebar.toggle.right": { id: "sidebar.toggle.right", scope: "sidebar" },
+  "sidebar.cycle.group-mode": { id: "sidebar.cycle.group-mode", scope: "sidebar" },
   "workspace.pane.split.right": { id: "workspace.pane.split.right", scope: "workspace" },
   "workspace.pane.split.down": { id: "workspace.pane.split.down", scope: "workspace" },
   "workspace.pane.focus.left": { id: "workspace.pane.focus.left", scope: "workspace" },

--- a/packages/app/src/stores/sidebar-view-store.test.ts
+++ b/packages/app/src/stores/sidebar-view-store.test.ts
@@ -3,6 +3,7 @@ import type { StateStorage } from "zustand/middleware";
 import {
   createSidebarViewStorage,
   migrateSidebarViewState,
+  nextGroupMode,
   useSidebarViewStore,
 } from "./sidebar-view-store";
 
@@ -34,6 +35,20 @@ function createMemoryStorage(entries: Record<string, string | null>): MemoryStor
     },
   };
 }
+
+describe("nextGroupMode", () => {
+  it("advances project to status", () => {
+    expect(nextGroupMode("project")).toBe("status");
+  });
+
+  it("advances status back to project", () => {
+    expect(nextGroupMode("status")).toBe("project");
+  });
+
+  it("wraps around so cycling twice returns to the start", () => {
+    expect(nextGroupMode(nextGroupMode("project"))).toBe("project");
+  });
+});
 
 describe("sidebar view store", () => {
   beforeEach(() => {

--- a/packages/app/src/stores/sidebar-view-store.ts
+++ b/packages/app/src/stores/sidebar-view-store.ts
@@ -4,6 +4,20 @@ import { createJSONStorage, persist, type StateStorage } from "zustand/middlewar
 
 export type SidebarGroupMode = "project" | "status";
 
+/** Ordered grouping modes the "Cycle sidebar grouping" shortcut steps through. */
+export const GROUP_MODE_ORDER: readonly SidebarGroupMode[] = ["project", "status"];
+
+/**
+ * The next grouping mode in the cycle — used by the cycle-grouping keyboard
+ * shortcut. Wraps around GROUP_MODE_ORDER, so adding a mode there is all that's
+ * needed to include it (future-proof for a third grouping). Falls back to the
+ * first mode for an unrecognized input.
+ */
+export function nextGroupMode(mode: SidebarGroupMode): SidebarGroupMode {
+  const index = GROUP_MODE_ORDER.indexOf(mode);
+  return GROUP_MODE_ORDER[(index + 1) % GROUP_MODE_ORDER.length];
+}
+
 const SIDEBAR_VIEW_STORAGE_KEY = "sidebar-view";
 const LEGACY_SIDEBAR_GROUP_MODE_STORAGE_KEY = "sidebar-group-mode";
 const SIDEBAR_VIEW_STORE_VERSION = 2;


### PR DESCRIPTION
### Type of change

- [x] Enhancement

### Reasoning

The sidebar's Group by preference is buried in the Display preferences dropdown, so switching it costs three pointer actions: open the gear menu, move to Group by, click the mode. I switch constantly - Project when I'm looking for something in a specific repo, Status when I want to see what needs attention - and that round trip adds up over a day. This binds Cmd+Shift+G (Ctrl+Shift+G off Mac) to cycle Group by, so a view I change dozens of times a day costs one keystroke.

### Goals

- Cmd+Shift+G on macOS, Ctrl+Shift+G elsewhere, cycles the sidebar Group by preference.
- The shortcut appears once under Settings > Keyboard Shortcuts > Panels and is rebindable there like any other.
- The existing Display preferences dropdown keeps working and its checkmark follows the shortcut.
- The shortcut is inert while the terminal or the command center has focus, matching the sibling panel shortcuts, and still fires with the composer focused.
- Adding a third grouping mode later requires only a new entry in `GROUP_MODE_ORDER`.
- Automated coverage for both platform combos, the suppression contexts, and the help row.

### Non-goals

- No change to what the grouping modes are or how the sidebar renders them; this only changes how you reach the existing preference.
- No mobile surface: keyboard shortcuts are desktop and web only, and the Settings section already says so on native.
- No unbind affordance: a shortcut cannot currently be removed, only rebound or reset to its default, and changing that is a separate change to the shortcut system.
- No Command Center entry for grouping. That is a second discovery surface and belongs in its own change.

### QA

Pressed Cmd+Shift+G with the sidebar visible and watched the grouping switch between Project and Status, with the Display preferences checkmark following it. Opened Settings > Keyboard Shortcuts > Panels and confirmed the Cycle sidebar grouping row shows the combo.

Tested on desktop (Electron, macOS). Not tested: web, and the Ctrl+Shift+G side of the binding on Windows or Linux.

<img width="721" height="148" alt="image" src="https://github.com/user-attachments/assets/eae2a6c9-e69c-4030-b158-0fea2d197220" />

https://github.com/user-attachments/assets/97b9fdab-18ff-4379-b0d1-9381676e3039

**Tests:**

- `packages/app/src/keyboard/keyboard-shortcuts.test.ts` (extended) - that each platform's combo resolves to the cycle action and the other platform's modifier does not, that the terminal and the command center suppress it, and that the help row lands in Panels with the right binding id and default keys.
- `packages/app/src/keyboard/route-shortcut.test.ts` (extended) - the action reaches the dispatcher through the passthrough table.
- `packages/app/src/stores/sidebar-view-store.test.ts` (extended) - `nextGroupMode` advances through the modes and wraps back to the first.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
