### PR TITLE
fix(nix): restore desktop app icon matching

### DIFF
--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -185,9 +185,18 @@ buildNpmPackage {
       install -Dm644 packages/desktop/assets/icon.png \
         $out/share/icons/hicolor/512x512/apps/paseo-desktop.png
 
+      # Electron derives Wayland's toplevel app_id from the package name in the
+      # app root it launches. Point it at a one-file app named "paseo-desktop"
+      # so shells can match the window to the desktop entry and hicolor icon.
+      mkdir -p $out/share/paseo-desktop/electron-app
+      printf '%s\n' "{ \"name\": \"paseo-desktop\", \"version\": \"$version\", \"main\": \"index.js\" }" \
+        > $out/share/paseo-desktop/electron-app/package.json
+      printf '%s\n' 'require("../packages/desktop/dist/main.js");' \
+        > $out/share/paseo-desktop/electron-app/index.js
+
       # Chromium's setuid sandbox cannot live in the immutable Nix store.
       makeWrapper ${electron}/bin/electron $out/bin/paseo-desktop \
-        --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
+        --add-flags "$out/share/paseo-desktop/electron-app" \
         --add-flags "--no-sandbox" \
         --add-flags "--class=paseo-desktop" \
         --set EXPO_DEV_URL "paseo://app/" \
@@ -220,6 +229,22 @@ buildNpmPackage {
       icon = "paseo-desktop";
       categories = ["Development"];
       startupWMClass = "paseo-desktop";
+    })
+    # Hidden alias entry. Which of the two names Electron ends up publishing as
+    # the Wayland app_id depends on the Electron version: 41 uses the app-root
+    # package.json `name` ("paseo-desktop"), 38 uses the runtime app name that
+    # main.ts sets ("Paseo"). Ship a NoDisplay entry for the second spelling so
+    # the icon resolves either way without a duplicate launcher item.
+    (makeDesktopItem {
+      name = "Paseo";
+      desktopName = "Paseo";
+      genericName = "AI Coding Agents";
+      comment = "Self-hosted daemon for AI coding agents";
+      exec = "paseo-desktop";
+      icon = "paseo-desktop";
+      categories = [ "Development" ];
+      startupWMClass = "Paseo";
+      noDisplay = true;
     })
   ];
 

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -189,7 +189,9 @@ buildNpmPackage {
       makeWrapper ${electron}/bin/electron $out/bin/paseo-desktop \
         --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
         --add-flags "--no-sandbox" \
-        --set EXPO_DEV_URL "paseo://app/"
+        --add-flags "--class=paseo-desktop" \
+        --set EXPO_DEV_URL "paseo://app/" \
+        --set CHROME_DESKTOP "paseo-desktop.desktop"
 
       copyDesktopItems
     ''}
@@ -217,7 +219,7 @@ buildNpmPackage {
       exec = "paseo-desktop";
       icon = "paseo-desktop";
       categories = ["Development"];
-      startupWMClass = "Paseo";
+      startupWMClass = "paseo-desktop";
     })
   ];
 

--- a/packages/desktop/src/daemon/cli/passthrough.test.ts
+++ b/packages/desktop/src/daemon/cli/passthrough.test.ts
@@ -65,6 +65,23 @@ describe("passthrough CLI", () => {
     ).toBeNull();
   });
 
+  it("ignores Linux desktop identity arguments injected by the Nix wrapper", () => {
+    expect(
+      parsePassthroughCliArgs({
+        argv: [
+          "/nix/store/electron/bin/electron",
+          "/nix/store/paseo-desktop/share/paseo-desktop/electron-app",
+          "--no-sandbox",
+          "--class=paseo-desktop",
+          "daemon",
+          "status",
+        ],
+        isDefaultApp: true,
+        forceCli: false,
+      }),
+    ).toEqual(["daemon", "status"]);
+  });
+
   it("ignores Electron remote debugging switches", () => {
     expect(
       parsePassthroughCliArgs({

--- a/packages/desktop/src/daemon/cli/passthrough.ts
+++ b/packages/desktop/src/daemon/cli/passthrough.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from "node:url";
 import { resolvePassthroughCliEntrypoint } from "./entrypoints.js";
 
 const DESKTOP_CLI_ENV = "PASEO_DESKTOP_CLI";
-const IGNORED_ARG_PREFIXES = ["-psn_", "--no-sandbox", "--remote-debugging-port="];
+const IGNORED_ARG_PREFIXES = ["-psn_", "--class=", "--no-sandbox", "--remote-debugging-port="];
 
 export type PassthroughCliRunner = (argv: string[]) => Promise<number>;
 


### PR DESCRIPTION
## What changed

- launch Electron with a generated one-file app root whose `package.json` name is `paseo-desktop`, instead of pointing it straight at `dist/main.js`
- keep `CHROME_DESKTOP=paseo-desktop.desktop`, `--class=paseo-desktop`, and `StartupWMClass=paseo-desktop` for X11 and desktop-entry matching
- ship a `NoDisplay=true` alias desktop entry named `Paseo` for Electron versions that publish the runtime app name as the app ID

## Why

The Nix package runs Paseo through the generic, unpackaged `electron` executable, so the window advertised the default `electron` application identity and shells drew the generic Electron icon instead of the installed `paseo-desktop` icon.

The earlier `--class` / `CHROME_DESKTOP` pass was not enough on Wayland. Measured on Hyprland with Electron 41:

| launcher | resulting Wayland `app_id` |
| --- | --- |
| `electron main.js` | `electron` |
| `+ --class=paseo-desktop` | `electron` |
| `+ CHROME_DESKTOP=paseo-desktop.desktop` | `electron` |
| `+ exec -a paseo-desktop` | `electron` |
| `+ app.setName(...)` in main | `electron` |
| `electron <dir with package.json name>` | that name |

The app ID is fixed during Electron startup from the app root's `package.json` name, which is why neither the command-line class nor `main.ts`'s `app.setName("Paseo")` can move it. Launching `packages/desktop` directly is no good either — its name is `@getpaseo/desktop` — so the derivation now writes a tiny app root named `paseo-desktop` that just requires the real main. `main.ts` still calls `app.setName("Paseo")`, so the user-data directory and window title are unchanged.

Electron 38 (current nixpkgs) resolves the app ID from the runtime app name instead, yielding `Paseo`. The hidden alias entry covers that spelling so the icon resolves on both, without a second visible launcher item.

## Validation

- `nix build .#desktop` succeeds; the output contains `share/paseo-desktop/electron-app/package.json` with `"name": "paseo-desktop"`, plus both `paseo-desktop.desktop` and the `NoDisplay` `Paseo.desktop`
- launching the built app root under Hyprland reports a non-generic `app_id` (`paseo-desktop` on Electron 41, `Paseo` on Electron 38), so the shell resolves the installed `paseo-desktop` icon