### PR TITLE
feat(forge): add Alibaba Cloud Codeup support

### DIFF
--- a/docs/forge-providers.md
+++ b/docs/forge-providers.md
@@ -142,6 +142,49 @@ Facts modules use one source of truth: a Zod schema. Helpers like
 derive guards from `schema.safeParse` and re-parse before invoking typed
 derivers/renderers. That keeps typed derivers away from the open wire envelope.
 
+## Codeup
+
+Codeup uses the official Alibaba Cloud CLI and its DevOps OpenAPI rather than a
+Codeup PAT. Install `aliyun`, then configure an AK or STS-backed profile with:
+
+```bash
+aliyun configure
+```
+
+Paseo neither stores nor sends the AK/SK itself. The daemon invokes the CLI on
+the host, probes credentials with `aliyun sts GetCallerIdentity`, and sends
+Codeup requests through the CLI's built-in DevOps `2021-06-25` metadata at the
+fixed `devops.cn-hangzhou.aliyuncs.com` endpoint in `cn-hangzhou`. Do not pass
+`--version`: CLI v3.4.8 rejects an explicit version as unchecked. The configured
+identity needs repository/MR read access and, for create or merge operations,
+the corresponding write access.
+
+Only `codeup.aliyun.com` remotes are recognized. Their first path segment is the
+Codeup `organizationId`; the complete path, including that segment, is the
+repository identity passed to `GetRepository`:
+
+```text
+git@codeup.aliyun.com:<organizationId>/<group...>/<repository>.git
+https://codeup.aliyun.com/<organizationId>/<group...>/<repository>.git
+```
+
+The organization must use Codeup's new merge requests. Paseo deliberately adds
+`filter=new` to MR queries because the old MR model does not expose the facts
+needed by the shared Forge contract.
+
+The Codeup adapter covers MR search/status, review and comment activity,
+check-runs and commit statuses, check details, create, merge, and same- or
+cross-repository checkout. It does not expose repository Issues, auto-merge,
+Projex work items, pipeline management, or comment/review writes. Codeup source
+tree/blob links are also omitted until their routes, branch encoding, and line
+anchors are verified against a live account; emitting no link is safer than a
+plausible but invalid URL.
+
+The real adapter test requires the host's default `aliyun configure` profile
+plus `CODEUP_E2E_REPOSITORY_URL` and `CODEUP_E2E_BASE_BRANCH`. The repository
+must be dedicated to integration testing and allow the test identity to push a
+temporary branch, create a new MR, squash-merge it, and delete the branch.
+
 ## Checklist
 
 To add `acme`:

--- a/packages/app/src/components/icons/codeup-icon.tsx
+++ b/packages/app/src/components/icons/codeup-icon.tsx
@@ -1,0 +1,10 @@
+import { SvgPathIcon, type SvgPathIconProps } from "./svg-path-icon";
+
+// Monochrome form of Codeup's circular C mark. The view module applies the
+// official Alibaba Cloud orange brand treatment at call sites.
+const CODEUP_ICON_PATH =
+  "M12 1.5A10.5 10.5 0 1 0 20.07 18.72l-3.18-3.18A6 6 0 1 1 16.31 8l3.62-2.72A10.47 10.47 0 0 0 12 1.5Zm7.5 2.25a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z";
+
+export function CodeupIcon(props: SvgPathIconProps) {
+  return <SvgPathIcon {...props} viewBox="0 0 24 24" path={CODEUP_ICON_PATH} />;
+}

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -1,82 +1,47 @@
-import {
-  useState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-  memo,
-  type ReactElement,
-  type ReactNode,
-} from "react";
+import { useState, useCallback, useMemo, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { DiffStat } from "@/components/diff-stat";
 import { TreeRail } from "@/components/tree-rail";
+import { DiffStat } from "@/components/diff-stat";
 import {
   View,
   Text,
   Pressable,
   FlatList,
-  type LayoutChangeEvent,
-  type NativeSyntheticEvent,
-  type NativeScrollEvent,
   type PressableStateCallbackType,
-  type FlatListProps,
   type StyleProp,
   type ViewStyle,
-  type TextStyle,
 } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { BORDER_WIDTH, ICON_SIZE, SPACING, type Theme } from "@/styles/theme";
+import { ICON_SIZE, SPACING, type Theme } from "@/styles/theme";
 import { useIsCompactFormFactor, WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
 import {
   AlignJustify,
   ChevronDown,
   Columns2,
   FolderTree,
-  List,
   ListChevronsDownUp,
   ListChevronsUpDown,
   Maximize2,
+  MoreHorizontal,
   Pilcrow,
   RotateCw,
   WrapText,
 } from "lucide-react-native";
-import { type ParsedDiffFile, type DiffLine, type HighlightToken } from "@/git/use-diff-query";
-import { buildDiffFlatItems, sumHeightsBefore, type DiffFlatItem } from "@/git/diff-flat-items";
+import { type ParsedDiffFile } from "@/git/use-diff-query";
+import { DiffDocument, type WorkingDiffMode } from "@/git/diff-document";
+import { FileHeader } from "@/git/file-header";
 import {
-  createDiffRowWindow,
-  createDiffViewport,
-  type DiffRowWindow,
-  type DiffViewport,
-} from "@/git/diff-virtualization";
-import { buildDiffTree, collectDirPaths, compressSingleChildChains } from "@/git/diff-tree";
+  buildDiffTree,
+  collectDirPaths,
+  compressSingleChildChains,
+  flattenDiffTree,
+  type DiffTreeRow,
+} from "@/git/diff-tree";
 import { DiffFolderRow } from "@/git/diff-folder-row";
-import {
-  TreeIndentGuides,
-  treeRowPaddingLeft,
-  WORKSPACE_FILE_ROW_TRAILING_PADDING,
-  WORKSPACE_FILE_ROW_VERTICAL_PADDING,
-  WORKSPACE_TREE_ICON_LABEL_GAP,
-  WORKSPACE_TREE_ICON_SIZE,
-} from "@/components/tree-primitives";
-import { MaterialFileIcon } from "@/components/material-file-icon";
-import { FileChangeIcon } from "@/components/file-change-icon";
 import { useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
 import { CommitsSection } from "@/git/commits-section/commits-section";
 import { useChangesPreferences } from "@/hooks/use-changes-preferences";
 import { useAppSettings } from "@/hooks/use-settings";
-import { DiffScroll } from "@/components/diff-scroll";
-import { syntaxTokenStyleFor } from "@/styles/syntax-token-styles";
-import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
-import { shouldAnchorHeaderBeforeCollapse } from "@/git/diff-scroll";
-import {
-  buildSplitDiffRows,
-  buildUnifiedDiffLines,
-  type ReviewableDiffTarget,
-  type SplitDiffDisplayLine,
-  type SplitDiffRow,
-} from "@/utils/diff-layout";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -85,47 +50,26 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import * as Clipboard from "expo-clipboard";
-import { FileActionsContextMenuContent } from "@/components/file-actions-menu";
-import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { useFileDownload } from "@/hooks/use-file-download";
 import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import { buildAbsoluteExplorerPath } from "@/utils/explorer-paths";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { lineNumberGutterWidth } from "@/components/code-insets";
 import { GitActionsSplitButton } from "@/git/actions-split-button";
+import type { GitActions } from "@/git/policy";
 import { BranchSwitcher } from "@/components/branch-switcher";
 import { useGitActions } from "@/git/use-actions";
 import { GIT_ACTION_ICONS } from "@/git/action-icons";
-import { getForgePresentation } from "@/git/forge";
 import { buildForgeSetupMessage, computeForgeSetupState } from "@/git/forge-setup";
 import { useCheckoutGitActionsStore } from "@/git/actions-store";
 import { useToast } from "@/contexts/toast-context";
 import { useSessionStore } from "@/stores/session-store";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { useOverlayFlatListScrollbar } from "@/components/ui/overlay-scrollbar/use-overlay-flat-list-scrollbar";
-import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { usePanelStore } from "@/stores/panel-store";
 import { collectAllTabs, useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
-import {
-  compactHighlightTokens,
-  formatDiffContentText,
-  formatDiffGutterText,
-  hasVisibleDiffTokens,
-} from "@/utils/diff-rendering";
-import { isWeb, isNative } from "@/constants/platform";
-import { useWorkspaceFileDragSource } from "@/attachments/use-workspace-file-drag-source";
-import {
-  type ReviewDraftComment,
-  getInlineReviewThreadState,
-  getSplitInlineReviewThreadState,
-  InlineReviewGutterCell,
-  InlineReviewThread,
-  isInlineReviewEditorForTarget,
-  type InlineReviewActions,
-} from "@/review";
+import { isWeb } from "@/constants/platform";
 import { usePublishWorkingDiffAttachment, useWorkingDiff } from "@/git/use-working-diff";
 import { DiffTooLargeState } from "@/git/diff-too-large-state";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
@@ -139,116 +83,21 @@ export function resolveDiffLayout(
   return canUseSplitLayout ? layout : "unified";
 }
 
-function fileHeaderPressableStyle(
-  { hovered, pressed }: PressableStateCallbackType & { hovered?: boolean },
-  isSelected: boolean,
-) {
-  return [
-    styles.fileHeader,
-    (Boolean(hovered) || pressed || isSelected) && styles.fileHeaderActive,
-  ];
-}
-
-interface HighlightedTextProps {
-  tokens: HighlightToken[];
-  textMetricsStyle: TextStyle;
-  wrapLines?: boolean;
-  testID?: string;
-}
-
-type WrappedWebTextStyle = TextStyle & {
-  whiteSpace?: "pre" | "pre-wrap";
-  overflowWrap?: "normal" | "anywhere";
-};
-
-function getWrappedTextStyle(wrapLines: boolean): WrappedWebTextStyle | undefined {
-  if (isNative) {
-    return undefined;
+function computeSelectedDiffStat(
+  files: ParsedDiffFile[],
+  isLoading: boolean,
+): { additions: number; deletions: number } | null {
+  if (isLoading) {
+    return null;
   }
-  return wrapLines
-    ? { whiteSpace: "pre-wrap", overflowWrap: "anywhere" }
-    : { whiteSpace: "pre", overflowWrap: "normal" };
-}
-
-function getNumericLineHeight(textMetricsStyle: TextStyle): number | undefined {
-  const { lineHeight } = textMetricsStyle;
-  return typeof lineHeight === "number" && Number.isFinite(lineHeight) ? lineHeight : undefined;
-}
-
-function useDiffRowMetricsStyle(textMetricsStyle: TextStyle): StyleProp<ViewStyle> {
-  const lineHeight = getNumericLineHeight(textMetricsStyle);
-  return useMemo(
-    () => (lineHeight !== undefined ? inlineUnistylesStyle({ minHeight: lineHeight }) : null),
-    [lineHeight],
+  return files.reduce(
+    (total, file) => ({
+      additions: total.additions + file.additions,
+      deletions: total.deletions + file.deletions,
+    }),
+    { additions: 0, deletions: 0 },
   );
 }
-
-function HighlightedToken({ token }: { token: HighlightToken }) {
-  return <Text style={syntaxTokenStyleFor(token.style)}>{token.text}</Text>;
-}
-
-const HighlightedText = memo(function HighlightedText({
-  tokens,
-  textMetricsStyle,
-  wrapLines = false,
-  testID,
-}: HighlightedTextProps) {
-  const containerStyle = useMemo(
-    () => [
-      styles.diffTextMetrics,
-      textMetricsStyle,
-      styles.diffLineText,
-      getWrappedTextStyle(wrapLines),
-    ],
-    [textMetricsStyle, wrapLines],
-  );
-
-  const keyedTokens = useMemo(() => {
-    let characterOffset = 0;
-    return compactHighlightTokens(tokens).map((token) => {
-      const keyedToken = { key: `${characterOffset}-${token.style ?? "base"}`, token };
-      characterOffset += token.text.length;
-      return keyedToken;
-    });
-  }, [tokens]);
-
-  return (
-    <Text style={containerStyle} testID={testID}>
-      {keyedTokens.map(({ key, token }) => (
-        <HighlightedToken key={key} token={token} />
-      ))}
-    </Text>
-  );
-});
-
-interface DiffFileSectionProps {
-  file: ParsedDiffFile;
-  workspaceFileDragScope?: { serverId: string; workspaceId: string };
-  isExpanded: boolean;
-  isSelected?: boolean;
-  /** Tree indentation level (0 on the flat/mobile path). */
-  depth?: number;
-  /** Show the muted directory suffix (flat list); false inside the folder tree. */
-  showDir?: boolean;
-  interactive?: boolean;
-  onToggle?: (path: string) => void;
-  onSelect?: (path: string) => void;
-  onOpenFile?: (path: string) => void;
-  onAddToChat?: (path: string) => void;
-  onCopyPath?: (path: string) => void;
-  onCopyRelativePath?: (path: string) => void;
-  onReveal?: (path: string) => void;
-  revealTargetName?: string;
-  onDownload?: (path: string) => void;
-  onDuplicate?: (path: string) => void;
-  onRevert?: (path: string, oldPath?: string) => void;
-  onHeaderHeightChange?: (path: string, height: number) => void;
-  testID?: string;
-}
-
-const EMPTY_COMMENTS: readonly ReviewDraftComment[] = [];
-
-function noopStartComment(): void {}
 
 function useDiscardChangesAction({
   serverId,
@@ -301,1280 +150,14 @@ function useDiscardChangesAction({
   return discardSupported && diffMode === "uncommitted" ? handleDiscardPath : undefined;
 }
 
-const DIFF_LINE_HOVER_STYLE = isWeb ? ({ cursor: "auto" } as const) : null;
-
-function LongPressableLine({
-  reviewTarget,
-  reviewActions,
-  onHoverChange,
-  hoverTargetKey,
-  onHoverTargetChange,
-  style,
-  children,
-}: {
-  reviewTarget: ReviewableDiffTarget | null | undefined;
-  reviewActions: InlineReviewActions | undefined;
-  onHoverChange?: (hovered: boolean) => void;
-  hoverTargetKey?: string | null;
-  onHoverTargetChange?: (key: string | null) => void;
-  style: StyleProp<ViewStyle>;
-  children: ReactNode;
-}) {
-  const onStartComment = reviewActions?.onStartComment;
-  const handlePress = useCallback(() => {
-    const selection = isWeb ? window.getSelection() : null;
-    if (selection && !selection.isCollapsed && selection.toString().length > 0) {
-      return;
-    }
-    if (reviewTarget && onStartComment) {
-      onStartComment(reviewTarget);
-    }
-  }, [reviewTarget, onStartComment]);
-
-  const handleHoverIn = useCallback(() => {
-    onHoverChange?.(true);
-    if (hoverTargetKey) {
-      onHoverTargetChange?.(hoverTargetKey);
-    }
-  }, [hoverTargetKey, onHoverChange, onHoverTargetChange]);
-  const handleHoverOut = useCallback(() => {
-    onHoverChange?.(false);
-    if (hoverTargetKey) {
-      onHoverTargetChange?.(null);
-    }
-  }, [hoverTargetKey, onHoverChange, onHoverTargetChange]);
-  const hoverStyle = useMemo(() => [style, DIFF_LINE_HOVER_STYLE], [style]);
-
-  if (isWeb && (onHoverChange || onHoverTargetChange)) {
-    return (
-      <Pressable onHoverIn={handleHoverIn} onHoverOut={handleHoverOut} style={hoverStyle}>
-        {children}
-      </Pressable>
-    );
-  }
-
-  if (!isNative || !reviewTarget || !onStartComment) {
-    return <View style={style}>{children}</View>;
-  }
-  return (
-    <Pressable onPress={handlePress} style={style}>
-      {children}
-    </Pressable>
-  );
-}
-
-function lineTypeBackground(type: DiffLine["type"] | undefined | null) {
-  if (!type) return styles.emptySplitCell;
-  if (type === "add") return styles.addLineContainer;
-  if (type === "remove") return styles.removeLineContainer;
-  if (type === "header") return styles.headerLineContainer;
-  return styles.contextLineContainer;
-}
-
-function DiffGutterCell({
-  lineNumber,
-  type,
-  gutterWidth,
-  textMetricsStyle,
-  reviewTarget,
-  reviewActions,
-  isLineHovered,
-  style,
-  textTestID,
-  actionTestID,
-}: {
-  lineNumber: number | null;
-  type: DiffLine["type"] | undefined | null;
-  gutterWidth: number;
-  textMetricsStyle: TextStyle;
-  reviewTarget?: ReviewableDiffTarget | null;
-  reviewActions?: InlineReviewActions;
-  isLineHovered?: boolean;
-  style?: StyleProp<ViewStyle>;
-  textTestID?: string;
-  actionTestID?: string;
-}) {
-  const lineHeight = getNumericLineHeight(textMetricsStyle);
-  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
-  const containerStyle = useMemo(
-    () => [
-      styles.gutterCell,
-      lineTypeBackground(type),
-      rowMetricsStyle,
-      inlineUnistylesStyle({ width: gutterWidth }),
-      style,
-    ],
-    [type, rowMetricsStyle, gutterWidth, style],
-  );
-  const textStyle = useMemo(
-    () => [
-      styles.diffTextMetrics,
-      textMetricsStyle,
-      styles.lineNumberText,
-      type === "add" && styles.addLineNumberText,
-      type === "remove" && styles.removeLineNumberText,
-    ],
-    [textMetricsStyle, type],
-  );
-  const comments = useMemo(
-    () =>
-      reviewTarget
-        ? (reviewActions?.commentsByTarget.get(reviewTarget.key) ?? EMPTY_COMMENTS)
-        : EMPTY_COMMENTS,
-    [reviewTarget, reviewActions?.commentsByTarget],
-  );
-  const isEditorOpen = isInlineReviewEditorForTarget(reviewActions?.editor ?? null, reviewTarget);
-  const onStartComment = reviewActions?.onStartComment ?? noopStartComment;
-
-  return (
-    <InlineReviewGutterCell
-      reviewTarget={reviewTarget}
-      comments={comments}
-      isEditorOpen={isEditorOpen}
-      isLineHovered={isLineHovered}
-      lineHeight={lineHeight}
-      onStartComment={onStartComment}
-      style={containerStyle}
-      actionTestID={actionTestID}
-    >
-      <Text numberOfLines={1} style={textStyle} testID={textTestID}>
-        {formatDiffGutterText(lineNumber)}
-      </Text>
-    </InlineReviewGutterCell>
-  );
-}
-
-function DiffTextLine({
-  line,
-  wrapLines,
-  textMetricsStyle,
-  reviewTarget,
-  reviewActions,
-  onHoverChange,
-  hoverTargetKey,
-  onHoverTargetChange,
-  textTestID,
-}: {
-  line: DiffLine;
-  wrapLines: boolean;
-  textMetricsStyle: TextStyle;
-  reviewTarget?: ReviewableDiffTarget | null;
-  reviewActions?: InlineReviewActions;
-  onHoverChange?: (hovered: boolean) => void;
-  hoverTargetKey?: string | null;
-  onHoverTargetChange?: (key: string | null) => void;
-  textTestID?: string;
-}) {
-  const visibleTokens = hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
-  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
-
-  const containerStyle = useMemo(
-    () => [styles.textLineContainer, lineTypeBackground(line.type), rowMetricsStyle],
-    [line.type, rowMetricsStyle],
-  );
-  const textStyle = useMemo(
-    () => [
-      styles.diffTextMetrics,
-      textMetricsStyle,
-      styles.diffLineText,
-      getWrappedTextStyle(wrapLines),
-      line.type === "add" && styles.addLineText,
-      line.type === "remove" && styles.removeLineText,
-      line.type === "header" && styles.headerLineText,
-      line.type === "context" && styles.contextLineText,
-    ],
-    [line.type, textMetricsStyle, wrapLines],
-  );
-
-  return (
-    <LongPressableLine
-      reviewTarget={reviewTarget}
-      reviewActions={reviewActions}
-      onHoverChange={onHoverChange}
-      hoverTargetKey={hoverTargetKey}
-      onHoverTargetChange={onHoverTargetChange}
-      style={containerStyle}
-    >
-      {line.type !== "header" && visibleTokens ? (
-        <HighlightedText
-          tokens={visibleTokens}
-          textMetricsStyle={textMetricsStyle}
-          wrapLines={wrapLines}
-          testID={textTestID}
-        />
-      ) : (
-        <Text style={textStyle} testID={textTestID}>
-          {formatDiffContentText(line.content)}
-        </Text>
-      )}
-    </LongPressableLine>
-  );
-}
-
-function SplitTextLine({
-  line,
-  wrapLines,
-  textMetricsStyle,
-  reviewActions,
-  onHoverChange,
-  hoverTargetKey,
-  onHoverTargetChange,
-}: {
-  line: SplitDiffDisplayLine | null;
-  wrapLines: boolean;
-  textMetricsStyle: TextStyle;
-  reviewActions?: InlineReviewActions;
-  onHoverChange?: (hovered: boolean) => void;
-  hoverTargetKey?: string | null;
-  onHoverTargetChange?: (key: string | null) => void;
-}) {
-  const visibleTokens = line && hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
-  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
-
-  const containerStyle = useMemo(
-    () => [styles.textLineContainer, lineTypeBackground(line?.type), rowMetricsStyle],
-    [line?.type, rowMetricsStyle],
-  );
-  const textStyle = useMemo(
-    () => [
-      styles.diffTextMetrics,
-      textMetricsStyle,
-      styles.diffLineText,
-      getWrappedTextStyle(wrapLines),
-      line?.type === "add" && styles.addLineText,
-      line?.type === "remove" && styles.removeLineText,
-      line?.type === "context" && styles.contextLineText,
-      !line && styles.emptySplitCellText,
-    ],
-    [line, textMetricsStyle, wrapLines],
-  );
-
-  return (
-    <LongPressableLine
-      reviewTarget={line?.reviewTarget}
-      reviewActions={reviewActions}
-      onHoverChange={onHoverChange}
-      hoverTargetKey={hoverTargetKey}
-      onHoverTargetChange={onHoverTargetChange}
-      style={containerStyle}
-    >
-      {visibleTokens ? (
-        <HighlightedText
-          tokens={visibleTokens}
-          textMetricsStyle={textMetricsStyle}
-          wrapLines={wrapLines}
-        />
-      ) : (
-        <Text style={textStyle}>{formatDiffContentText(line?.content)}</Text>
-      )}
-    </LongPressableLine>
-  );
-}
-
-function DiffLineView({
-  line,
-  lineNumber,
-  gutterWidth,
-  wrapLines,
-  textMetricsStyle,
-  reviewTarget,
-  reviewActions,
-}: {
-  line: DiffLine;
-  lineNumber: number | null;
-  gutterWidth: number;
-  wrapLines: boolean;
-  textMetricsStyle: TextStyle;
-  reviewTarget?: ReviewableDiffTarget | null;
-  reviewActions?: InlineReviewActions;
-}) {
-  const [isLineHovered, setIsLineHovered] = useState(false);
-  const visibleTokens = hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
-  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
-
-  const containerStyle = useMemo(
-    () => [styles.diffLineContainer, lineTypeBackground(line.type), rowMetricsStyle],
-    [line.type, rowMetricsStyle],
-  );
-  const textStyle = useMemo(
-    () => [
-      styles.diffTextMetrics,
-      textMetricsStyle,
-      styles.diffLineText,
-      getWrappedTextStyle(wrapLines),
-      line.type === "add" && styles.addLineText,
-      line.type === "remove" && styles.removeLineText,
-      line.type === "header" && styles.headerLineText,
-      line.type === "context" && styles.contextLineText,
-    ],
-    [line.type, textMetricsStyle, wrapLines],
-  );
-
-  return (
-    <LongPressableLine
-      reviewTarget={reviewTarget}
-      reviewActions={reviewActions}
-      onHoverChange={setIsLineHovered}
-      style={containerStyle}
-    >
-      <DiffGutterCell
-        lineNumber={lineNumber}
-        type={line.type}
-        gutterWidth={gutterWidth}
-        textMetricsStyle={textMetricsStyle}
-        reviewTarget={reviewTarget}
-        reviewActions={reviewActions}
-        isLineHovered={isLineHovered}
-        style={styles.lineNumberGutter}
-      />
-      {line.type !== "header" && visibleTokens ? (
-        <HighlightedText
-          tokens={visibleTokens}
-          textMetricsStyle={textMetricsStyle}
-          wrapLines={wrapLines}
-        />
-      ) : (
-        <Text style={textStyle}>{formatDiffContentText(line.content)}</Text>
-      )}
-    </LongPressableLine>
-  );
-}
-
-function SplitDiffLine({
-  line,
-  gutterWidth,
-  wrapLines,
-  textMetricsStyle,
-  reviewActions,
-}: {
-  line: SplitDiffDisplayLine | null;
-  gutterWidth: number;
-  wrapLines: boolean;
-  textMetricsStyle: TextStyle;
-  reviewActions?: InlineReviewActions;
-}) {
-  const [isLineHovered, setIsLineHovered] = useState(false);
-  const visibleTokens = line && hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
-  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
-
-  const containerStyle = useMemo(
-    () => [styles.diffLineContainer, lineTypeBackground(line?.type), rowMetricsStyle],
-    [line?.type, rowMetricsStyle],
-  );
-  const textStyle = useMemo(
-    () => [
-      styles.diffTextMetrics,
-      textMetricsStyle,
-      styles.diffLineText,
-      getWrappedTextStyle(wrapLines),
-      line?.type === "add" && styles.addLineText,
-      line?.type === "remove" && styles.removeLineText,
-      line?.type === "context" && styles.contextLineText,
-      !line && styles.emptySplitCellText,
-    ],
-    [line, textMetricsStyle, wrapLines],
-  );
-
-  return (
-    <LongPressableLine
-      reviewTarget={line?.reviewTarget}
-      reviewActions={reviewActions}
-      onHoverChange={setIsLineHovered}
-      style={containerStyle}
-    >
-      <DiffGutterCell
-        lineNumber={line?.lineNumber ?? null}
-        type={line?.type}
-        gutterWidth={gutterWidth}
-        textMetricsStyle={textMetricsStyle}
-        reviewTarget={line?.reviewTarget}
-        reviewActions={reviewActions}
-        isLineHovered={isLineHovered}
-        style={styles.lineNumberGutter}
-      />
-      {visibleTokens ? (
-        <HighlightedText
-          tokens={visibleTokens}
-          textMetricsStyle={textMetricsStyle}
-          wrapLines={wrapLines}
-        />
-      ) : (
-        <Text style={textStyle}>{formatDiffContentText(line?.content)}</Text>
-      )}
-    </LongPressableLine>
-  );
-}
-
-function InlineReviewThreadContent({
-  reviewTarget,
-  reviewActions,
-  reservedHeight,
-  viewportWidth,
-  pinToViewport,
-}: {
-  reviewTarget: ReviewableDiffTarget | null | undefined;
-  reviewActions?: InlineReviewActions;
-  reservedHeight?: number;
-  viewportWidth?: number;
-  pinToViewport?: boolean;
-}) {
-  const threadState = getInlineReviewThreadState({ reviewTarget, reviewActions });
-  const height = reservedHeight ?? threadState?.height ?? 0;
-  const placeholderStyle = useMemo<ViewStyle>(
-    () => inlineUnistylesStyle({ minHeight: height }),
-    [height],
-  );
-  if (height === 0) {
-    return null;
-  }
-  if (!reviewTarget || !reviewActions || !threadState) {
-    return <View style={placeholderStyle} />;
-  }
-
-  return (
-    <InlineReviewThread
-      reviewTarget={reviewTarget}
-      reviewActions={reviewActions}
-      height={height}
-      viewportWidth={viewportWidth}
-      pinToViewport={pinToViewport}
-      testID={`review-thread-${reviewTarget.key}`}
-    />
-  );
-}
-
-function InlineReviewGutterSpacer({
-  reviewTarget,
-  reviewActions,
-  gutterWidth,
-  reservedHeight,
-  style,
-}: {
-  reviewTarget: ReviewableDiffTarget | null | undefined;
-  reviewActions?: InlineReviewActions;
-  gutterWidth: number;
-  reservedHeight?: number;
-  style?: StyleProp<ViewStyle>;
-}) {
-  const threadState = getInlineReviewThreadState({ reviewTarget, reviewActions });
-  const height = reservedHeight ?? threadState?.height ?? 0;
-  const spacerStyle = useMemo<StyleProp<ViewStyle>>(
-    () => [
-      styles.inlineReviewGutterSpacer,
-      inlineUnistylesStyle({ width: gutterWidth, minHeight: height }),
-      style,
-    ],
-    [gutterWidth, height, style],
-  );
-  if (height === 0) {
-    return null;
-  }
-
-  return <View style={spacerStyle} />;
-}
-
-function InlineReviewRow({
-  reviewTarget,
-  reviewActions,
-  gutterWidth,
-  reservedHeight,
-}: {
-  reviewTarget: ReviewableDiffTarget | null | undefined;
-  reviewActions?: InlineReviewActions;
-  gutterWidth: number;
-  reservedHeight?: number;
-}) {
-  const threadState = getInlineReviewThreadState({ reviewTarget, reviewActions });
-  const height = reservedHeight ?? threadState?.height ?? 0;
-  const gutterSpacerStyle = useMemo<StyleProp<ViewStyle>>(
-    () => [styles.inlineReviewGutterSpacer, inlineUnistylesStyle({ width: gutterWidth })],
-    [gutterWidth],
-  );
-  const placeholderStyle = useMemo<ViewStyle>(
-    () => inlineUnistylesStyle({ minHeight: height }),
-    [height],
-  );
-  if (height === 0) {
-    return null;
-  }
-
-  return (
-    <View style={styles.inlineReviewRow}>
-      <View style={gutterSpacerStyle} />
-      {reviewTarget && reviewActions && threadState ? (
-        <InlineReviewThread
-          reviewTarget={reviewTarget}
-          reviewActions={reviewActions}
-          height={height}
-          testID={`review-thread-${reviewTarget.key}`}
-        />
-      ) : (
-        <View style={placeholderStyle} />
-      )}
-    </View>
-  );
-}
-
-const DIFF_ROW_OVERSCAN = 900;
-const FULL_DIFF_VIEWPORT = { top: 0, height: Number.MAX_SAFE_INTEGER };
-const subscribeToNothing = () => () => {};
-const getFullDiffViewport = () => FULL_DIFF_VIEWPORT;
-
-function useDiffRowWindow({
-  viewport,
-  bodyOffset,
-  rowHeights,
-  enabled,
-}: {
-  viewport?: DiffViewport;
-  bodyOffset: number;
-  rowHeights: readonly number[];
-  enabled: boolean;
-}): DiffRowWindow {
-  const viewportSnapshot = useSyncExternalStore(
-    viewport?.subscribe ?? subscribeToNothing,
-    viewport?.getSnapshot ?? getFullDiffViewport,
-    viewport?.getSnapshot ?? getFullDiffViewport,
-  );
-  return useMemo(() => {
-    if (!enabled) {
-      return createDiffRowWindow(rowHeights, {
-        viewportTop: 0,
-        viewportHeight: Number.MAX_SAFE_INTEGER,
-        overscan: 0,
-      });
-    }
-    return createDiffRowWindow(rowHeights, {
-      viewportTop: viewportSnapshot.top - bodyOffset - BORDER_WIDTH[1],
-      viewportHeight: viewportSnapshot.height,
-      overscan: DIFF_ROW_OVERSCAN,
-    });
-  }, [bodyOffset, enabled, rowHeights, viewportSnapshot.height, viewportSnapshot.top]);
-}
-
-function DiffRowSpacer({ height }: { height: number }) {
-  if (height <= 0) {
-    return null;
-  }
-  return <View style={inlineUnistylesStyle({ height })} />;
-}
-
-function SplitDiffColumn({
-  rows,
-  rowWindow,
-  side,
-  gutterWidth,
-  wrapLines,
-  textMetricsStyle,
-  reviewActions,
-  showDivider = false,
-}: {
-  rows: SplitDiffRow[];
-  rowWindow: DiffRowWindow;
-  side: "left" | "right";
-  gutterWidth: number;
-  wrapLines: boolean;
-  textMetricsStyle: TextStyle;
-  reviewActions?: InlineReviewActions;
-  showDivider?: boolean;
-}) {
-  const [scrollWidth, setScrollWidth] = useState(0);
-  const [hoveredReviewTargetKey, setHoveredReviewTargetKey] = useState<string | null>(null);
-
-  const wrapCellStyle = useMemo(
-    () => [styles.splitCell, showDivider && styles.splitCellWithDivider],
-    [showDivider],
-  );
-  const rowCellStyle = useMemo(
-    () => [styles.splitCell, showDivider && styles.splitCellWithDivider, styles.splitCellRow],
-    [showDivider],
-  );
-  const linesContainerRowStyle = useMemo(
-    () => [
-      styles.linesContainer,
-      scrollWidth > 0 && inlineUnistylesStyle({ minWidth: scrollWidth }),
-    ],
-    [scrollWidth],
-  );
-  const headerLineTextStyle = useMemo(
-    () => [styles.diffTextMetrics, textMetricsStyle, styles.diffLineText, styles.headerLineText],
-    [textMetricsStyle],
-  );
-
-  const keyedRows = useMemo(
-    () =>
-      rows.slice(rowWindow.startIndex, rowWindow.endIndex).map((row, index) => ({
-        key: `row-${rowWindow.startIndex + index}`,
-        row,
-      })),
-    [rowWindow.endIndex, rowWindow.startIndex, rows],
-  );
-
-  if (wrapLines) {
-    return (
-      <View style={wrapCellStyle}>
-        <View style={styles.linesContainer}>
-          <DiffRowSpacer height={rowWindow.beforeHeight} />
-          {keyedRows.map(({ key, row }) => {
-            if (row.kind === "header") {
-              return (
-                <View key={key} style={styles.splitHeaderRow}>
-                  <Text style={headerLineTextStyle}>{row.content}</Text>
-                </View>
-              );
-            }
-            const line = side === "left" ? row.left : row.right;
-            const reviewRowState = getSplitInlineReviewThreadState({
-              left: row.left?.reviewTarget,
-              right: row.right?.reviewTarget,
-              reviewActions,
-            });
-            return (
-              <View key={key}>
-                <SplitDiffLine
-                  line={line}
-                  gutterWidth={gutterWidth}
-                  wrapLines={wrapLines}
-                  textMetricsStyle={textMetricsStyle}
-                  reviewActions={reviewActions}
-                />
-                <InlineReviewRow
-                  reviewTarget={line?.reviewTarget}
-                  reviewActions={reviewActions}
-                  gutterWidth={gutterWidth}
-                  reservedHeight={reviewRowState?.height}
-                />
-              </View>
-            );
-          })}
-          <DiffRowSpacer height={rowWindow.afterHeight} />
-        </View>
-      </View>
-    );
-  }
-
-  return (
-    <View style={rowCellStyle}>
-      <View style={styles.gutterColumn}>
-        <DiffRowSpacer height={rowWindow.beforeHeight} />
-        {keyedRows.map(({ key, row }) => {
-          if (row.kind === "header") {
-            return (
-              <DiffGutterCell
-                key={key}
-                lineNumber={null}
-                type="header"
-                gutterWidth={gutterWidth}
-                textMetricsStyle={textMetricsStyle}
-              />
-            );
-          }
-          const line = side === "left" ? row.left : row.right;
-          const reviewTargetKey = line?.reviewTarget?.key ?? null;
-          const reviewRowState = getSplitInlineReviewThreadState({
-            left: row.left?.reviewTarget,
-            right: row.right?.reviewTarget,
-            reviewActions,
-          });
-          return (
-            <View key={key}>
-              <DiffGutterCell
-                lineNumber={line?.lineNumber ?? null}
-                type={line?.type}
-                gutterWidth={gutterWidth}
-                textMetricsStyle={textMetricsStyle}
-                reviewTarget={line?.reviewTarget}
-                reviewActions={reviewActions}
-                isLineHovered={
-                  reviewTargetKey !== null && hoveredReviewTargetKey === reviewTargetKey
-                }
-              />
-              <InlineReviewGutterSpacer
-                reviewTarget={line?.reviewTarget}
-                reviewActions={reviewActions}
-                gutterWidth={gutterWidth}
-                reservedHeight={reviewRowState?.height}
-              />
-            </View>
-          );
-        })}
-        <DiffRowSpacer height={rowWindow.afterHeight} />
-      </View>
-      <DiffScroll
-        scrollViewWidth={scrollWidth}
-        onScrollViewWidthChange={setScrollWidth}
-        style={styles.splitColumnScroll}
-        contentContainerStyle={styles.diffContentInner}
-      >
-        <View style={linesContainerRowStyle}>
-          <DiffRowSpacer height={rowWindow.beforeHeight} />
-          {keyedRows.map(({ key, row }) => {
-            if (row.kind === "header") {
-              return (
-                <View key={key} style={styles.splitHeaderRow}>
-                  <Text style={headerLineTextStyle}>{row.content}</Text>
-                </View>
-              );
-            }
-            const line = side === "left" ? row.left : row.right;
-            const reviewTargetKey = line?.reviewTarget?.key ?? null;
-            const reviewRowState = getSplitInlineReviewThreadState({
-              left: row.left?.reviewTarget,
-              right: row.right?.reviewTarget,
-              reviewActions,
-            });
-            return (
-              <View key={key}>
-                <SplitTextLine
-                  line={line}
-                  wrapLines={false}
-                  textMetricsStyle={textMetricsStyle}
-                  reviewActions={reviewActions}
-                  hoverTargetKey={reviewTargetKey}
-                  onHoverTargetChange={setHoveredReviewTargetKey}
-                />
-                <InlineReviewThreadContent
-                  reviewTarget={line?.reviewTarget}
-                  reviewActions={reviewActions}
-                  reservedHeight={reviewRowState?.height}
-                  viewportWidth={scrollWidth}
-                  pinToViewport
-                />
-              </View>
-            );
-          })}
-          <DiffRowSpacer height={rowWindow.afterHeight} />
-        </View>
-      </DiffScroll>
-    </View>
-  );
-}
-
-function DiffFileActionsContextMenuContent({
-  file,
-  onOpenFile,
-  onAddToChat,
-  onCopyPath,
-  onCopyRelativePath,
-  onReveal,
-  revealTargetName,
-  onDownload,
-  onDuplicate,
-  onRevert,
-  testID,
-}: Pick<
-  DiffFileSectionProps,
-  | "file"
-  | "onOpenFile"
-  | "onAddToChat"
-  | "onCopyPath"
-  | "onCopyRelativePath"
-  | "onReveal"
-  | "revealTargetName"
-  | "onDownload"
-  | "onDuplicate"
-  | "onRevert"
-  | "testID"
->) {
-  const handleOpenFile = useCallback(() => onOpenFile?.(file.path), [file.path, onOpenFile]);
-  const handleAddToChat = useCallback(() => onAddToChat?.(file.path), [file.path, onAddToChat]);
-  const handleCopyPath = useCallback(() => onCopyPath?.(file.path), [file.path, onCopyPath]);
-  const handleCopyRelativePath = useCallback(
-    () => onCopyRelativePath?.(file.path),
-    [file.path, onCopyRelativePath],
-  );
-  const handleReveal = useCallback(() => onReveal?.(file.path), [file.path, onReveal]);
-  const handleDownload = useCallback(() => onDownload?.(file.path), [file.path, onDownload]);
-  const handleDuplicate = useCallback(() => onDuplicate?.(file.path), [file.path, onDuplicate]);
-  const handleRevert = useCallback(
-    () => onRevert?.(file.path, file.oldPath),
-    [file.oldPath, file.path, onRevert],
-  );
-
-  return (
-    <FileActionsContextMenuContent
-      fileKind="file"
-      fileExists={!file.isDeleted}
-      onOpenFile={onOpenFile ? handleOpenFile : undefined}
-      onCopyPath={onCopyPath ? handleCopyPath : undefined}
-      onCopyRelativePath={onCopyRelativePath ? handleCopyRelativePath : undefined}
-      onReveal={onReveal ? handleReveal : undefined}
-      revealTargetName={revealTargetName}
-      onDownload={onDownload ? handleDownload : undefined}
-      onAddToChat={onAddToChat ? handleAddToChat : undefined}
-      onDuplicate={!file.isDeleted && onDuplicate ? handleDuplicate : undefined}
-      onRevert={onRevert ? handleRevert : undefined}
-      testIDPrefix={testID}
-    />
-  );
-}
-
-const DiffFileHeader = memo(function DiffFileHeader({
-  file,
-  workspaceFileDragScope,
-  isExpanded,
-  isSelected = false,
-  depth = 0,
-  showDir = true,
-  interactive = true,
-  onToggle,
-  onSelect,
-  onOpenFile,
-  onAddToChat,
-  onCopyPath,
-  onCopyRelativePath,
-  onReveal,
-  revealTargetName,
-  onDownload,
-  onDuplicate,
-  onRevert,
-  onHeaderHeightChange,
-  testID,
-}: DiffFileSectionProps) {
-  const dragSourceRef = useWorkspaceFileDragSource({
-    enabled: interactive,
-    disabled: file.isDeleted,
-    workspaceId: null,
-    path: file.path,
-    ...workspaceFileDragScope,
-  });
-  const layoutYRef = useRef<number | null>(null);
-  const pressHandledRef = useRef(false);
-  const pressInRef = useRef<{ ts: number; pageX: number; pageY: number } | null>(null);
-
-  const handleSelect = useCallback(() => {
-    if (interactive) {
-      onSelect?.(file.path);
-    }
-  }, [file.path, interactive, onSelect]);
-
-  const toggleExpanded = useCallback(() => {
-    if (!interactive) {
-      return;
-    }
-    const selection = isWeb ? window.getSelection() : null;
-    if (selection && !selection.isCollapsed && selection.toString().length > 0) {
-      return;
-    }
-    pressHandledRef.current = true;
-    handleSelect();
-    onToggle?.(file.path);
-  }, [file.path, handleSelect, interactive, onToggle]);
-
-  const handleLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      layoutYRef.current = event.nativeEvent.layout.y;
-      onHeaderHeightChange?.(file.path, event.nativeEvent.layout.height);
-    },
-    [file.path, onHeaderHeightChange],
-  );
-
-  const handlePressIn = useCallback((event: { nativeEvent: { pageX: number; pageY: number } }) => {
-    pressHandledRef.current = false;
-    pressInRef.current = {
-      ts: Date.now(),
-      pageX: event.nativeEvent.pageX,
-      pageY: event.nativeEvent.pageY,
-    };
-  }, []);
-
-  const handleLongPress = useCallback(() => {
-    pressHandledRef.current = true;
-    handleSelect();
-  }, [handleSelect]);
-
-  const handlePressOut = useCallback(
-    (event: { nativeEvent: { pageX: number; pageY: number } }) => {
-      if (
-        interactive &&
-        isNative &&
-        !pressHandledRef.current &&
-        layoutYRef.current === 0 &&
-        pressInRef.current
-      ) {
-        const durationMs = Date.now() - pressInRef.current.ts;
-        const dx = event.nativeEvent.pageX - pressInRef.current.pageX;
-        const dy = event.nativeEvent.pageY - pressInRef.current.pageY;
-        const distance = Math.hypot(dx, dy);
-        if (durationMs <= 500 && distance <= 12) {
-          toggleExpanded();
-        }
-      }
-    },
-    [interactive, toggleExpanded],
-  );
-
-  const containerStyle = useMemo(
-    () => [styles.fileSectionHeaderContainer, isExpanded && styles.fileSectionHeaderExpanded],
-    [isExpanded],
-  );
-  const accessibilityState = useMemo(
-    () => ({ expanded: isExpanded, selected: isSelected }),
-    [isExpanded, isSelected],
-  );
-
-  const headerPressableStyle = useCallback(
-    (state: PressableStateCallbackType) =>
-      depth > 0
-        ? [
-            fileHeaderPressableStyle(state, isSelected),
-            inlineUnistylesStyle({ paddingLeft: treeRowPaddingLeft(depth) }),
-          ]
-        : fileHeaderPressableStyle(state, isSelected),
-    [depth, isSelected],
-  );
-
-  const fileName = file.path.split("/").pop() ?? file.path;
-  const headerContent = (
-    <>
-      <View
-        ref={dragSourceRef}
-        style={showDir ? styles.fileHeaderLeft : [styles.fileHeaderLeft, styles.fileHeaderLeftTree]}
-      >
-        {showDir ? null : (
-          <View style={styles.fileIcon}>
-            <MaterialFileIcon fileName={fileName} size={WORKSPACE_TREE_ICON_SIZE} />
-          </View>
-        )}
-        <Text style={styles.fileName} numberOfLines={1}>
-          {fileName}
-        </Text>
-        {showDir ? (
-          <Text style={styles.fileDir} numberOfLines={1}>
-            {file.path.includes("/") ? ` ${file.path.slice(0, file.path.lastIndexOf("/"))}` : ""}
-          </Text>
-        ) : (
-          // Flex spacer in tree mode (no dir suffix) so the New/Deleted badge
-          // stays right-aligned next to the diff stats, as in the flat list.
-          <View style={styles.fileDirSpacer} />
-        )}
-        {file.isNew && <FileChangeIcon change="added" />}
-        {file.isDeleted && <FileChangeIcon change="deleted" />}
-      </View>
-      <View style={styles.fileHeaderRight}>
-        <DiffStat
-          additions={file.additions}
-          deletions={file.deletions}
-          testID={testID ? `${testID}-stat` : undefined}
-        />
-      </View>
-    </>
-  );
-
-  let trigger: ReactElement;
-  if (!interactive) {
-    trigger = (
-      <View
-        {...{
-          onContextMenu: (event: { preventDefault?: () => void }) => event.preventDefault?.(),
-        }}
-        style={headerPressableStyle({ hovered: false, pressed: false })}
-      >
-        {headerContent}
-      </View>
-    );
-  } else {
-    trigger = (
-      <ContextMenuTrigger
-        testID={testID ? `${testID}-toggle` : undefined}
-        style={headerPressableStyle}
-        // Android: prevent parent pan/scroll gestures from canceling the tap release.
-        cancelable={false}
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
-        onLongPress={handleLongPress}
-        onContextMenu={handleSelect}
-        onPress={toggleExpanded}
-        accessibilityState={accessibilityState}
-        aria-selected={isSelected}
-      >
-        {headerContent}
-      </ContextMenuTrigger>
-    );
-  }
-
-  return (
-    <View style={containerStyle} onLayout={handleLayout} testID={testID}>
-      <TreeIndentGuides depth={depth} />
-      <ContextMenu>
-        <Tooltip delayDuration={300} enabledOnDesktop enabledOnMobile={false}>
-          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
-          <TooltipContent side="bottom" align="start" offset={6} maxWidth={520}>
-            <Text style={styles.tooltipText}>{file.path}</Text>
-          </TooltipContent>
-        </Tooltip>
-        {interactive ? (
-          <DiffFileActionsContextMenuContent
-            file={file}
-            onOpenFile={onOpenFile}
-            onAddToChat={onAddToChat}
-            onCopyPath={onCopyPath}
-            onCopyRelativePath={onCopyRelativePath}
-            onReveal={onReveal}
-            revealTargetName={revealTargetName}
-            onDownload={onDownload}
-            onDuplicate={onDuplicate}
-            onRevert={onRevert}
-            testID={testID}
-          />
-        ) : null}
-      </ContextMenu>
-    </View>
-  );
-});
-
-export function DiffFileBody({
-  file,
-  viewport,
-  bodyOffset = 0,
-  layout,
-  wrapLines,
-  codeFontSize,
-  textMetricsStyle,
-  reviewActions,
-  onBodyHeightChange,
-  testID,
-}: {
-  file: ParsedDiffFile;
-  viewport?: DiffViewport;
-  bodyOffset?: number;
-  layout: "unified" | "split";
-  wrapLines: boolean;
-  codeFontSize: number;
-  textMetricsStyle: TextStyle;
-  reviewActions?: InlineReviewActions;
-  onBodyHeightChange?: (file: ParsedDiffFile, height: number) => void;
-  testID?: string;
-}) {
-  const [scrollViewWidth, setScrollViewWidth] = useState(0);
-  const [bodyWidth, setBodyWidth] = useState(0);
-  const [hoveredReviewTargetKey, setHoveredReviewTargetKey] = useState<string | null>(null);
-  const { t } = useTranslation();
-  const canRenderRows = file.status !== "too_large" && file.status !== "binary";
-  const splitRows = useMemo(
-    () => (canRenderRows && layout === "split" ? getCachedSplitDiffRows(file) : []),
-    [canRenderRows, file, layout],
-  );
-  const unifiedLines = useMemo(
-    () => (canRenderRows && layout === "unified" ? getCachedUnifiedDiffLines(file) : []),
-    [canRenderRows, file, layout],
-  );
-  const rowHeights = useMemo(() => {
-    const lineHeight = getNumericLineHeight(textMetricsStyle) ?? Math.round(codeFontSize * 1.5);
-    if (layout === "split") {
-      return splitRows.map((row) => {
-        if (row.kind === "header") {
-          return lineHeight;
-        }
-        return (
-          lineHeight +
-          (getSplitInlineReviewThreadState({
-            left: row.left?.reviewTarget,
-            right: row.right?.reviewTarget,
-            reviewActions,
-          })?.height ?? 0)
-        );
-      });
-    }
-    return unifiedLines.map(
-      ({ reviewTarget }) =>
-        lineHeight + (getInlineReviewThreadState({ reviewTarget, reviewActions })?.height ?? 0),
-    );
-  }, [codeFontSize, layout, reviewActions, splitRows, textMetricsStyle, unifiedLines]);
-  const rowWindow = useDiffRowWindow({
-    viewport,
-    bodyOffset,
-    rowHeights,
-    enabled: Boolean(viewport) && canRenderRows && !wrapLines,
-  });
-  const visibleUnifiedLines = useMemo(
-    () =>
-      unifiedLines
-        .slice(rowWindow.startIndex, rowWindow.endIndex)
-        .map((entry, index) => ({ entry, index: rowWindow.startIndex + index })),
-    [rowWindow.endIndex, rowWindow.startIndex, unifiedLines],
-  );
-
-  const handleLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      setBodyWidth(event.nativeEvent.layout.width);
-      onBodyHeightChange?.(file, event.nativeEvent.layout.height);
-    },
-    [file, onBodyHeightChange],
-  );
-
-  const availableWidth = bodyWidth > 0 ? bodyWidth : scrollViewWidth;
-  const linesContainerRowStyle = useMemo(
-    () => [
-      styles.linesContainer,
-      availableWidth > 0 && inlineUnistylesStyle({ minWidth: availableWidth }),
-    ],
-    [availableWidth],
-  );
-
-  return (
-    <View
-      style={[styles.fileSectionBodyContainer, styles.fileSectionBorder]}
-      onLayout={handleLayout}
-      testID={testID}
-    >
-      {(() => {
-        if (file.status === "too_large" || file.status === "binary") {
-          return (
-            <View style={styles.statusMessageContainer}>
-              <Text style={styles.statusMessageText}>
-                {file.status === "binary"
-                  ? t("workspace.git.diff.binaryFile")
-                  : t("workspace.git.diff.tooLarge")}
-              </Text>
-            </View>
-          );
-        }
-
-        let maxLineNo = 0;
-        for (const hunk of file.hunks) {
-          maxLineNo = Math.max(
-            maxLineNo,
-            hunk.oldStart + hunk.oldCount,
-            hunk.newStart + hunk.newCount,
-          );
-        }
-        const gutterWidth = lineNumberGutterWidth(maxLineNo, codeFontSize);
-
-        if (layout === "split") {
-          return (
-            <View style={[styles.diffContent, styles.splitRow]} dataSet={CODE_SURFACE_DATASET}>
-              <SplitDiffColumn
-                rows={splitRows}
-                rowWindow={rowWindow}
-                side="left"
-                gutterWidth={gutterWidth}
-                wrapLines={wrapLines}
-                textMetricsStyle={textMetricsStyle}
-                reviewActions={reviewActions}
-              />
-              <SplitDiffColumn
-                rows={splitRows}
-                rowWindow={rowWindow}
-                side="right"
-                gutterWidth={gutterWidth}
-                wrapLines={wrapLines}
-                textMetricsStyle={textMetricsStyle}
-                reviewActions={reviewActions}
-                showDivider
-              />
-            </View>
-          );
-        }
-
-        if (wrapLines) {
-          return (
-            <View style={styles.diffContent} dataSet={CODE_SURFACE_DATASET}>
-              <View style={styles.linesContainer}>
-                <DiffRowSpacer height={rowWindow.beforeHeight} />
-                {visibleUnifiedLines.map(
-                  ({ entry: { line, lineNumber, key, reviewTarget }, index }) => (
-                    <View key={key} testID={`diff-wrapped-row-${index}`}>
-                      <DiffLineView
-                        line={line}
-                        lineNumber={lineNumber}
-                        gutterWidth={gutterWidth}
-                        wrapLines={wrapLines}
-                        textMetricsStyle={textMetricsStyle}
-                        reviewTarget={reviewTarget}
-                        reviewActions={reviewActions}
-                      />
-                      <InlineReviewRow
-                        reviewTarget={reviewTarget}
-                        reviewActions={reviewActions}
-                        gutterWidth={gutterWidth}
-                      />
-                    </View>
-                  ),
-                )}
-                <DiffRowSpacer height={rowWindow.afterHeight} />
-              </View>
-            </View>
-          );
-        }
-
-        const textViewportWidth =
-          scrollViewWidth > 0 ? scrollViewWidth : Math.max(0, bodyWidth - gutterWidth);
-        return (
-          <View style={[styles.diffContent, styles.diffContentRow]} dataSet={CODE_SURFACE_DATASET}>
-            <View style={styles.gutterColumn}>
-              <DiffRowSpacer height={rowWindow.beforeHeight} />
-              {visibleUnifiedLines.map(
-                ({ entry: { line, lineNumber, key, reviewTarget }, index }) => (
-                  <View key={key} testID={`diff-gutter-row-${index}`}>
-                    <DiffGutterCell
-                      lineNumber={lineNumber}
-                      type={line.type}
-                      gutterWidth={gutterWidth}
-                      textMetricsStyle={textMetricsStyle}
-                      reviewTarget={reviewTarget}
-                      reviewActions={reviewActions}
-                      isLineHovered={
-                        reviewTarget?.key !== undefined &&
-                        hoveredReviewTargetKey === reviewTarget.key
-                      }
-                      textTestID={`diff-gutter-text-${index}`}
-                      actionTestID={`diff-gutter-action-${index}`}
-                    />
-                    <InlineReviewGutterSpacer
-                      reviewTarget={reviewTarget}
-                      reviewActions={reviewActions}
-                      gutterWidth={gutterWidth}
-                    />
-                  </View>
-                ),
-              )}
-              <DiffRowSpacer height={rowWindow.afterHeight} />
-            </View>
-            <DiffScroll
-              scrollViewWidth={scrollViewWidth}
-              onScrollViewWidthChange={setScrollViewWidth}
-              style={styles.splitColumnScroll}
-              contentContainerStyle={styles.diffContentInner}
-            >
-              <View style={linesContainerRowStyle}>
-                <DiffRowSpacer height={rowWindow.beforeHeight} />
-                {visibleUnifiedLines.map(({ entry: { line, key, reviewTarget }, index }) => (
-                  <View key={key} testID={`diff-code-row-${index}`}>
-                    <DiffTextLine
-                      line={line}
-                      wrapLines={false}
-                      textMetricsStyle={textMetricsStyle}
-                      reviewTarget={reviewTarget}
-                      reviewActions={reviewActions}
-                      hoverTargetKey={reviewTarget?.key ?? null}
-                      onHoverTargetChange={setHoveredReviewTargetKey}
-                      textTestID={`diff-code-text-${index}`}
-                    />
-                    <InlineReviewThreadContent
-                      reviewTarget={reviewTarget}
-                      reviewActions={reviewActions}
-                      viewportWidth={textViewportWidth}
-                      pinToViewport
-                    />
-                  </View>
-                ))}
-                <DiffRowSpacer height={rowWindow.afterHeight} />
-              </View>
-            </DiffScroll>
-          </View>
-        );
-      })()}
-    </View>
-  );
-}
-
-interface GitDiffPaneProps {
+interface ChangesSurfaceProps {
   serverId: string;
   workspaceId?: string | null;
   cwd: string;
   enabled?: boolean;
   host: "explorer" | "panel";
+  focusPath?: string;
+  focusRequestId?: number;
   onOpenFile?: (path: string) => void;
   onAddToChat?: (path: string) => void;
 }
@@ -1590,17 +173,29 @@ const ThemedAlignJustify = withUnistyles(AlignJustify);
 const ThemedColumns2 = withUnistyles(Columns2);
 const ThemedPilcrow = withUnistyles(Pilcrow);
 const ThemedWrapText = withUnistyles(WrapText);
+const ThemedFolderTree = withUnistyles(FolderTree);
 const ThemedListChevronsDownUp = withUnistyles(ListChevronsDownUp);
 const ThemedListChevronsUpDown = withUnistyles(ListChevronsUpDown);
-const ThemedFolderTree = withUnistyles(FolderTree);
-const ThemedList = withUnistyles(List);
 const ThemedMaximize2 = withUnistyles(Maximize2);
 const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedMoreHorizontal = withUnistyles(MoreHorizontal);
 const DIFF_OPTIONS_WHITESPACE_ICON = (
   <ThemedPilcrow size={14} uniProps={foregroundMutedIconColorMapping} />
 );
 const DIFF_OPTIONS_WRAP_ICON = (
   <ThemedWrapText size={14} uniProps={foregroundMutedIconColorMapping} />
+);
+const DIFF_OPTIONS_SPLIT_ICON = (
+  <ThemedColumns2 size={14} uniProps={foregroundMutedIconColorMapping} />
+);
+const DIFF_OPTIONS_COLLAPSE_ICON = (
+  <ThemedListChevronsDownUp size={14} uniProps={foregroundMutedIconColorMapping} />
+);
+const DIFF_OPTIONS_EXPAND_ICON = (
+  <ThemedListChevronsUpDown size={14} uniProps={foregroundMutedIconColorMapping} />
+);
+const DIFF_OPTIONS_CHANGES_TAB_ICON = (
+  <ThemedMaximize2 size={14} uniProps={foregroundMutedIconColorMapping} />
 );
 
 interface DiffLayoutToggleProps {
@@ -1610,7 +205,6 @@ interface DiffLayoutToggleProps {
   toggleStyle?: PressableStyleFn;
   onToggle: () => void;
 }
-
 export function DiffLayoutToggle({
   layout,
   isMobile,
@@ -1619,7 +213,7 @@ export function DiffLayoutToggle({
   onToggle,
 }: DiffLayoutToggleProps) {
   const defaultToggleStyle = useMemo(
-    () => buildToggleButtonStyle(false, styles.expandAllButton),
+    () => buildToggleButtonStyle(false, styles.toolbarIconButton),
     [],
   );
   const { t } = useTranslation();
@@ -1654,12 +248,6 @@ export function DiffLayoutToggle({
   );
 }
 
-interface ChangesTabToggleProps {
-  isMobile: boolean;
-  selected: boolean;
-  onPress: () => void;
-}
-
 function resolveChangesTabOpen(host: "explorer" | "panel", changesTabOpen: boolean): boolean {
   return host === "explorer" ? changesTabOpen : false;
 }
@@ -1669,18 +257,6 @@ function resolveChangesFilePress(
   onChangesFilePress: ((path?: string) => void) | undefined,
 ): ((path?: string) => void) | undefined {
   return host === "explorer" ? onChangesFilePress : undefined;
-}
-
-function ChangesTabToggleForHost({
-  host,
-  isMobile,
-  selected,
-  onPress,
-}: ChangesTabToggleProps & { host: "explorer" | "panel" }) {
-  if (host === "panel") {
-    return null;
-  }
-  return <ChangesTabToggle isMobile={isMobile} selected={selected} onPress={onPress} />;
 }
 
 interface DiffModeMenuProps {
@@ -1737,78 +313,30 @@ export function DiffModeMenu({
   );
 }
 
-function ChangesTabToggle({ isMobile, selected, onPress }: ChangesTabToggleProps) {
-  const { t } = useTranslation();
-  const buttonStyle = useMemo(
-    () => buildToggleButtonStyle(selected, styles.expandAllButton),
-    [selected],
-  );
-  const label = t(
-    selected ? "workspace.git.diff.closeChangesTab" : "workspace.git.diff.openChangesTab",
-  );
-  if (isMobile) {
-    return null;
-  }
-  return (
-    <Tooltip delayDuration={300}>
-      <TooltipTrigger asChild>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={label}
-          testID="changes-open-tab"
-          onPress={onPress}
-          style={buttonStyle}
-        >
-          <ThemedMaximize2 size={14} uniProps={foregroundMutedIconColorMapping} />
-        </Pressable>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <Text style={styles.tooltipText}>{label}</Text>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-interface DiffViewModeToggleProps {
-  viewMode: "flat" | "tree";
-  isMobile: boolean;
+interface DesktopTreeToggleProps {
+  visible: boolean;
   toggleStyle?: PressableStyleFn;
   onToggle: () => void;
 }
 
-export function DiffViewModeToggle({
-  viewMode,
-  isMobile,
-  toggleStyle,
-  onToggle,
-}: DiffViewModeToggleProps) {
+function DesktopTreeToggle({ visible, toggleStyle, onToggle }: DesktopTreeToggleProps) {
   const { t } = useTranslation();
   const defaultToggleStyle = useMemo(
-    () => buildToggleButtonStyle(viewMode === "tree", styles.expandAllButton),
-    [viewMode],
+    () => buildToggleButtonStyle(visible, styles.toolbarIconButton),
+    [visible],
   );
-  const label =
-    viewMode === "flat"
-      ? t("workspace.git.diff.showTreeView")
-      : t("workspace.git.diff.showFlatView");
+  const label = t(visible ? "workspace.git.diff.hideTreeView" : "workspace.git.diff.showTreeView");
   return (
     <Tooltip delayDuration={300}>
       <TooltipTrigger asChild>
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={label}
-          testID="changes-toggle-view-mode"
+          testID="changes-toggle-tree"
           style={toggleStyle ?? defaultToggleStyle}
           onPress={onToggle}
         >
-          {viewMode === "flat" ? (
-            <ThemedFolderTree
-              size={isMobile ? 18 : 14}
-              uniProps={foregroundMutedIconColorMapping}
-            />
-          ) : (
-            <ThemedList size={isMobile ? 18 : 14} uniProps={foregroundMutedIconColorMapping} />
-          )}
+          <ThemedFolderTree size={14} uniProps={foregroundMutedIconColorMapping} />
         </Pressable>
       </TooltipTrigger>
       <TooltipContent side="bottom">
@@ -1818,100 +346,164 @@ export function DiffViewModeToggle({
   );
 }
 
-interface DiffFilesToolbarProps {
-  allFileDiffsExpanded: boolean;
+interface ChangesToolbarProps {
+  branchName: string | null;
+  allFilesCollapsed: boolean;
+  canUseSplitLayout: boolean;
+  changesTabOpen: boolean;
+  committedDescription?: string;
+  cwd: string;
+  desktopTreeVisible: boolean;
+  diffMode: "uncommitted" | "base";
+  gitActions: GitActions;
+  hasFiles: boolean;
+  hideWhitespace: boolean;
+  host: "explorer" | "panel";
   isMobile: boolean;
-  testID?: string;
-  expandAllToggleStyle?: PressableStyleFn;
-  onToggleExpandAll: () => void;
+  isRefreshing: boolean;
+  layout: "unified" | "split";
+  overflowToggleStyle: PressableStyleFn;
+  refreshSupported: boolean;
+  selectedDiffStat: { additions: number; deletions: number } | null;
+  serverId: string;
+  treeToggleStyle: PressableStyleFn;
+  workspaceId?: string | null;
+  wrapLines: boolean;
+  onRefresh: () => void;
+  onCollapseAll: () => void;
+  onExpandAll: () => void;
+  onSelectBase: () => void;
+  onSelectUncommitted: () => void;
+  onToggleChangesTab: () => void;
+  onToggleDesktopTree: () => void;
+  onToggleHideWhitespace: () => void;
+  onToggleLayout: () => void;
+  onToggleWrapLines: () => void;
 }
 
-export function DiffFilesToolbar({
-  allFileDiffsExpanded,
-  isMobile,
-  testID,
-  expandAllToggleStyle,
-  onToggleExpandAll,
-}: DiffFilesToolbarProps) {
-  const defaultToggleStyle = useMemo(() => buildExpandAllButtonStyle(), []);
-  const { t } = useTranslation();
-  const expandAllLabel = allFileDiffsExpanded
-    ? t("workspace.git.diff.collapseAll")
-    : t("workspace.git.diff.expandAll");
+// One row: the diff-mode and branch pickers lead, the git actions and the
+// overflow menu trail. The tree toggle is the only icon action that stays out
+// of the menu, and it only exists on desktop, so a phone-width row holds two
+// pickers, the split button, and the trigger without wrapping.
+function ChangesToolbar(props: ChangesToolbarProps) {
+  const {
+    branchName,
+    committedDescription,
+    cwd,
+    desktopTreeVisible,
+    diffMode,
+    gitActions,
+    hasFiles,
+    isMobile,
+    selectedDiffStat,
+    serverId,
+    treeToggleStyle,
+    workspaceId,
+    onSelectBase,
+    onSelectUncommitted,
+    onToggleDesktopTree,
+  } = props;
   return (
-    <View style={styles.diffStatusButtons}>
-      <Tooltip delayDuration={300}>
-        <TooltipTrigger asChild>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={expandAllLabel}
-            testID={testID}
-            style={expandAllToggleStyle ?? defaultToggleStyle}
-            onPress={onToggleExpandAll}
-          >
-            {allFileDiffsExpanded ? (
-              <ThemedListChevronsDownUp
-                size={isMobile ? 18 : 14}
-                uniProps={foregroundMutedIconColorMapping}
-              />
-            ) : (
-              <ThemedListChevronsUpDown
-                size={isMobile ? 18 : 14}
-                uniProps={foregroundMutedIconColorMapping}
-              />
-            )}
-          </Pressable>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <Text style={styles.tooltipText}>{expandAllLabel}</Text>
-        </TooltipContent>
-      </Tooltip>
+    <View style={styles.changesToolbar} testID="changes-header">
+      <View style={styles.changesToolbarIdentity}>
+        <DiffModeMenu
+          diffMode={diffMode}
+          committedDescription={committedDescription}
+          onSelectUncommitted={onSelectUncommitted}
+          onSelectBase={onSelectBase}
+        />
+        <BranchSwitcher
+          currentBranchName={branchName}
+          serverId={serverId}
+          workspaceId={workspaceId ?? cwd}
+          workspaceDirectory={cwd}
+          isGitCheckout
+          testID="changes-branch-switcher"
+        />
+        {!isMobile && selectedDiffStat ? (
+          <DiffStat
+            additions={selectedDiffStat.additions}
+            deletions={selectedDiffStat.deletions}
+            testID="changes-selected-diff-stat"
+          />
+        ) : null}
+      </View>
+      <View style={styles.changesToolbarControls}>
+        {!isMobile && hasFiles ? (
+          <DesktopTreeToggle
+            visible={desktopTreeVisible}
+            toggleStyle={treeToggleStyle}
+            onToggle={onToggleDesktopTree}
+          />
+        ) : null}
+        {isMobile ? <GitActionsSplitButton gitActions={gitActions} /> : null}
+        <ChangesOptionsMenu {...props} />
+      </View>
     </View>
   );
 }
 
-interface DiffOptionsMenuProps {
-  brand?: string;
-  hideWhitespace: boolean;
-  isMobile: boolean;
-  isRefreshing?: boolean;
-  overflowToggleStyle?: PressableStyleFn;
-  refreshSupported?: boolean;
-  testIDPrefix?: string;
-  wrapLines: boolean;
-  onRefresh?: () => void;
-  onToggleHideWhitespace: () => void;
-  onToggleWrapLines: () => void;
-}
+type ChangesOptionsMenuProps = Pick<
+  ChangesToolbarProps,
+  | "allFilesCollapsed"
+  | "canUseSplitLayout"
+  | "changesTabOpen"
+  | "hasFiles"
+  | "hideWhitespace"
+  | "host"
+  | "isMobile"
+  | "isRefreshing"
+  | "layout"
+  | "overflowToggleStyle"
+  | "refreshSupported"
+  | "wrapLines"
+  | "onCollapseAll"
+  | "onExpandAll"
+  | "onRefresh"
+  | "onToggleChangesTab"
+  | "onToggleHideWhitespace"
+  | "onToggleLayout"
+  | "onToggleWrapLines"
+>;
 
-export function DiffOptionsMenu({
-  brand,
+function ChangesOptionsMenu({
+  allFilesCollapsed,
+  canUseSplitLayout,
+  changesTabOpen,
+  hasFiles,
   hideWhitespace,
+  host,
   isMobile,
-  isRefreshing = false,
+  isRefreshing,
+  layout,
   overflowToggleStyle,
-  refreshSupported = false,
-  testIDPrefix = "changes",
+  refreshSupported,
   wrapLines,
+  onCollapseAll,
+  onExpandAll,
   onRefresh,
+  onToggleChangesTab,
   onToggleHideWhitespace,
+  onToggleLayout,
   onToggleWrapLines,
-}: DiffOptionsMenuProps) {
+}: ChangesOptionsMenuProps) {
   const { t } = useTranslation();
-  const defaultToggleStyle = useMemo(() => buildOverflowButtonStyle(), []);
+  const optionsLabel = t("workspace.git.diff.options");
+  const collapseLabel = t(
+    allFilesCollapsed ? "workspace.git.diff.expandAllFiles" : "workspace.git.diff.collapseAllFiles",
+  );
+  const changesTabLabel = t(
+    changesTabOpen ? "workspace.git.diff.closeChangesTab" : "workspace.git.diff.openChangesTab",
+  );
   const whitespaceLabel = hideWhitespace
     ? t("workspace.git.diff.showWhitespace")
     : t("workspace.git.diff.hideWhitespace");
   const wrapLinesLabel = wrapLines
     ? t("workspace.git.diff.scrollLongLines")
     : t("workspace.git.diff.wrapLongLines");
-  const optionsLabel = t("workspace.git.diff.options");
-  let refreshLabel = t("workspace.git.diff.refresh");
-  if (isRefreshing) {
-    refreshLabel = t("workspace.git.diff.refreshing");
-  } else if (brand) {
-    refreshLabel = t("workspace.git.diff.refreshState", { brand });
-  }
+  const refreshLabel = isRefreshing
+    ? t("workspace.git.diff.refreshing")
+    : t("workspace.git.diff.refresh");
   const refreshIcon = useMemo(
     () =>
       isRefreshing ? (
@@ -1922,6 +514,9 @@ export function DiffOptionsMenu({
     [isRefreshing],
   );
 
+  const showChangesTab = host === "explorer" && !isMobile;
+  const showLayout = canUseSplitLayout && !changesTabOpen;
+
   return (
     <DropdownMenu>
       <Tooltip delayDuration={300}>
@@ -1929,10 +524,10 @@ export function DiffOptionsMenu({
           <DropdownMenuTrigger
             accessibilityRole="button"
             accessibilityLabel={optionsLabel}
-            testID={`${testIDPrefix}-options-menu`}
-            style={overflowToggleStyle ?? defaultToggleStyle}
+            testID="changes-options-menu"
+            style={overflowToggleStyle}
           >
-            <ThemedChevronDown
+            <ThemedMoreHorizontal
               size={isMobile ? 18 : 14}
               uniProps={foregroundMutedIconColorMapping}
             />
@@ -1942,11 +537,40 @@ export function DiffOptionsMenu({
           <Text style={styles.tooltipText}>{optionsLabel}</Text>
         </TooltipContent>
       </Tooltip>
-      <DropdownMenuContent align="end" width={240} testID={`${testIDPrefix}-options-menu-content`}>
+      <DropdownMenuContent align="end" width={240} testID="changes-options-menu-content">
+        {hasFiles ? (
+          <DropdownMenuItem
+            leading={allFilesCollapsed ? DIFF_OPTIONS_EXPAND_ICON : DIFF_OPTIONS_COLLAPSE_ICON}
+            testID="changes-toggle-collapse-all"
+            onSelect={allFilesCollapsed ? onExpandAll : onCollapseAll}
+          >
+            {collapseLabel}
+          </DropdownMenuItem>
+        ) : null}
+        {showChangesTab ? (
+          <DropdownMenuItem
+            leading={DIFF_OPTIONS_CHANGES_TAB_ICON}
+            testID="changes-open-tab"
+            onSelect={onToggleChangesTab}
+          >
+            {changesTabLabel}
+          </DropdownMenuItem>
+        ) : null}
+        {hasFiles || showChangesTab ? <DropdownMenuSeparator /> : null}
+        {showLayout ? (
+          <DropdownMenuItem
+            leading={DIFF_OPTIONS_SPLIT_ICON}
+            selected={layout === "split"}
+            testID="changes-toggle-layout"
+            onSelect={onToggleLayout}
+          >
+            {t("workspace.git.diff.split")}
+          </DropdownMenuItem>
+        ) : null}
         <DropdownMenuItem
           leading={DIFF_OPTIONS_WHITESPACE_ICON}
           selected={hideWhitespace}
-          testID={`${testIDPrefix}-toggle-whitespace`}
+          testID="changes-toggle-whitespace"
           onSelect={onToggleHideWhitespace}
         >
           {whitespaceLabel}
@@ -1954,18 +578,18 @@ export function DiffOptionsMenu({
         <DropdownMenuItem
           leading={DIFF_OPTIONS_WRAP_ICON}
           selected={wrapLines}
-          testID={`${testIDPrefix}-toggle-wrap-lines`}
+          testID="changes-toggle-wrap-lines"
           onSelect={onToggleWrapLines}
         >
           {wrapLinesLabel}
         </DropdownMenuItem>
-        {refreshSupported && onRefresh ? (
+        {refreshSupported ? (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               leading={refreshIcon}
               disabled={isRefreshing}
-              testID={`${testIDPrefix}-refresh`}
+              testID="changes-refresh"
               onSelect={onRefresh}
             >
               {refreshLabel}
@@ -1979,56 +603,7 @@ export function DiffOptionsMenu({
 
 const ThemedRotateCw = withUnistyles(RotateCw);
 
-type DiffFlatItemLayoutGetter = NonNullable<FlatListProps<DiffFlatItem>["getItemLayout"]>;
 const EMPTY_PATH_LIST: string[] = [];
-
-interface DiffFileMetrics {
-  contentLength: number;
-  splitRows?: SplitDiffRow[];
-  splitLineCount?: number;
-  unifiedLines?: ReturnType<typeof buildUnifiedDiffLines>;
-  unifiedLineCount: number;
-}
-
-const diffFileMetricsCache = new WeakMap<ParsedDiffFile, DiffFileMetrics>();
-
-function getDiffFileMetrics(file: ParsedDiffFile): DiffFileMetrics {
-  const cached = diffFileMetricsCache.get(file);
-  if (cached) {
-    return cached;
-  }
-  let contentLength = 0;
-  let unifiedLineCount = 0;
-  for (const hunk of file.hunks) {
-    unifiedLineCount += hunk.lines.length;
-    for (const line of hunk.lines) {
-      contentLength += line.content.length;
-    }
-  }
-  const metrics = { contentLength, unifiedLineCount };
-  diffFileMetricsCache.set(file, metrics);
-  return metrics;
-}
-
-function getSplitDiffLineCount(file: ParsedDiffFile): number {
-  const metrics = getDiffFileMetrics(file);
-  if (metrics.splitLineCount === undefined) {
-    metrics.splitLineCount = getCachedSplitDiffRows(file).length;
-  }
-  return metrics.splitLineCount;
-}
-
-function getCachedSplitDiffRows(file: ParsedDiffFile): SplitDiffRow[] {
-  const metrics = getDiffFileMetrics(file);
-  metrics.splitRows ??= buildSplitDiffRows(file);
-  return metrics.splitRows;
-}
-
-function getCachedUnifiedDiffLines(file: ParsedDiffFile): ReturnType<typeof buildUnifiedDiffLines> {
-  const metrics = getDiffFileMetrics(file);
-  metrics.unifiedLines ??= buildUnifiedDiffLines(file);
-  return metrics.unifiedLines;
-}
 
 function computeEmptyMessage(
   hideWhitespace: boolean,
@@ -2125,615 +700,6 @@ function DiffBodyContent({
   return children;
 }
 
-interface SharedDiffViewProps {
-  files: ParsedDiffFile[];
-  displayPreferences: {
-    layout: "unified" | "split";
-    wrapLines: boolean;
-    codeFontSize: number;
-    monoFontFamily: string;
-  };
-  mode:
-    | {
-        kind: "working_tree";
-        viewMode: "flat" | "tree";
-        expandedPaths: string[];
-        collapsedFolders: string[];
-        reviewActions?: InlineReviewActions;
-        onFilePress?: (path: string) => void;
-        workspaceFileDragScope?: { serverId: string; workspaceId: string };
-        onOpenFile?: (path: string) => void;
-        onAddToChat?: (path: string) => void;
-        onCopyPath?: (path: string) => void;
-        onCopyRelativePath?: (path: string) => void;
-        onReveal?: (path: string) => void;
-        revealTargetName?: string;
-        onDownload?: (path: string) => void;
-        onDuplicate?: (path: string) => void;
-        onRevert?: (path: string, oldPath?: string) => void;
-        onExpandedPathsChange: (paths: string[]) => void;
-        onCollapsedFoldersChange: (paths: string[]) => void;
-      }
-    | {
-        kind: "working_tab";
-        expandedPaths: string[] | null;
-        reviewActions: InlineReviewActions;
-        focusPath?: string;
-        focusRequestId?: number;
-        onExpandedPathsChange: (paths: string[]) => void;
-      }
-    | {
-        kind: "commit";
-      };
-}
-
-type WorkingTreeDiffMode = Extract<SharedDiffViewProps["mode"], { kind: "working_tree" }>;
-
-export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffViewProps) {
-  const isCompact = useIsCompactFormFactor();
-  const { layout, wrapLines, codeFontSize, monoFontFamily } = displayPreferences;
-  const diffBodyLineHeight = Math.round(codeFontSize * 1.5);
-  const typographyKey = [monoFontFamily, codeFontSize, diffBodyLineHeight].join(":");
-  const textMetricsStyle = useMemo<TextStyle>(() => {
-    const trimmedMonoFontFamily = monoFontFamily.trim();
-    return {
-      fontSize: codeFontSize,
-      lineHeight: diffBodyLineHeight,
-      ...(trimmedMonoFontFamily ? { fontFamily: trimmedMonoFontFamily } : null),
-    };
-  }, [codeFontSize, diffBodyLineHeight, monoFontFamily]);
-  const viewMode = mode.kind === "working_tree" ? mode.viewMode : "flat";
-  const expandedPathsArray = useMemo(() => {
-    if (mode.kind === "working_tree") {
-      return mode.expandedPaths;
-    }
-    if (mode.kind === "working_tab" && mode.expandedPaths !== null) {
-      return mode.expandedPaths;
-    }
-    return files.map((file) => file.path);
-  }, [files, mode]);
-  const expandedPaths = useMemo(() => new Set(expandedPathsArray), [expandedPathsArray]);
-  const collapsedFoldersArray =
-    mode.kind === "working_tree" ? mode.collapsedFolders : EMPTY_PATH_LIST;
-  const collapsedFolders = useMemo(() => new Set(collapsedFoldersArray), [collapsedFoldersArray]);
-  const stickyHeaders = mode.kind !== "commit";
-  const interactive = mode.kind !== "commit";
-  const reviewActions = mode.kind === "commit" ? undefined : mode.reviewActions;
-  const onFilePress = mode.kind === "working_tree" ? mode.onFilePress : undefined;
-  const focusPath = mode.kind === "working_tab" ? mode.focusPath : undefined;
-  const focusRequestId = mode.kind === "working_tab" ? mode.focusRequestId : undefined;
-  const onOpenFile = mode.kind === "working_tree" ? mode.onOpenFile : undefined;
-  const onAddToChat = mode.kind === "working_tree" ? mode.onAddToChat : undefined;
-  const workspaceFileDragScope =
-    mode.kind === "working_tree" ? mode.workspaceFileDragScope : undefined;
-  const onCopyPath = mode.kind === "working_tree" ? mode.onCopyPath : undefined;
-  const onCopyRelativePath = mode.kind === "working_tree" ? mode.onCopyRelativePath : undefined;
-  const onReveal = mode.kind === "working_tree" ? mode.onReveal : undefined;
-  const revealTargetName = mode.kind === "working_tree" ? mode.revealTargetName : undefined;
-  const onDownload = mode.kind === "working_tree" ? mode.onDownload : undefined;
-  const onDuplicate = mode.kind === "working_tree" ? mode.onDuplicate : undefined;
-  const onRevert = mode.kind === "working_tree" ? mode.onRevert : undefined;
-  // Keep selection independent from expansion so future keyboard actions (such as R to rename)
-  // can target the current VCS file or folder without changing its open state.
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const handleSelectPath = useCallback((path: string) => setSelectedPath(path), []);
-  const compressedTree = useMemo(() => compressSingleChildChains(buildDiffTree(files)), [files]);
-  const allFolderPaths = useMemo(() => collectDirPaths(compressedTree), [compressedTree]);
-  const allFolderPathSet = useMemo(() => new Set(allFolderPaths), [allFolderPaths]);
-  useEffect(() => {
-    if (
-      selectedPath &&
-      !allFolderPathSet.has(selectedPath) &&
-      !files.some((file) => file.path === selectedPath)
-    ) {
-      setSelectedPath(null);
-    }
-  }, [allFolderPathSet, files, selectedPath]);
-  const effectiveCollapsedFolders = useMemo(
-    () => new Set(Array.from(collapsedFolders).filter((path) => allFolderPathSet.has(path))),
-    [allFolderPathSet, collapsedFolders],
-  );
-  const diffListRef = useRef<FlatList<DiffFlatItem>>(null);
-  const diffViewport = useMemo(() => createDiffViewport(), []);
-  useEffect(() => () => diffViewport.dispose(), [diffViewport]);
-  const scrollbar = useOverlayFlatListScrollbar(diffListRef, { enabled: !isCompact });
-  const { onLayout: updateScrollbarLayout, onScroll: updateScrollbarOffset } = scrollbar;
-  const consumedFocusRequestRef = useRef<string | null>(null);
-  const pendingFocusRequestRef = useRef<string | null>(null);
-  const diffListScrollOffsetRef = useRef(0);
-  const diffListViewportHeightRef = useRef(0);
-  const headerHeightByPathRef = useRef<Record<string, number>>({});
-  const bodyHeightByKeyRef = useRef<Record<string, number>>({});
-  const folderRowHeightRef = useRef<number>(0);
-  const defaultHeaderHeightRef = useRef<number>(44);
-  const [heightVersion, setHeightVersion] = useState(0);
-  const heightVersionFrameRef = useRef<number | null>(null);
-  const scheduleHeightVersionUpdate = useCallback(() => {
-    if (heightVersionFrameRef.current !== null) {
-      return;
-    }
-    heightVersionFrameRef.current = requestAnimationFrame(() => {
-      heightVersionFrameRef.current = null;
-      setHeightVersion((version) => version + 1);
-    });
-  }, []);
-  useEffect(
-    () => () => {
-      if (heightVersionFrameRef.current !== null) {
-        cancelAnimationFrame(heightVersionFrameRef.current);
-      }
-    },
-    [],
-  );
-  const diffBodyChromeHeight = BORDER_WIDTH[1] * 2;
-  const statusBodyHeightEstimate = diffBodyChromeHeight + SPACING[4] * 2 + diffBodyLineHeight;
-
-  const { flatItems, stickyHeaderIndices } = useMemo(() => {
-    const { items, stickyHeaderIndices: stickyIndices } = buildDiffFlatItems({
-      files,
-      viewMode,
-      tree: compressedTree,
-      collapsedFolders: effectiveCollapsedFolders,
-      expandedPaths,
-    });
-    return {
-      flatItems: items,
-      stickyHeaderIndices: stickyHeaders ? stickyIndices : [],
-    };
-  }, [compressedTree, effectiveCollapsedFolders, expandedPaths, files, stickyHeaders, viewMode]);
-
-  const getBodyHeightKey = useCallback(
-    (file: ParsedDiffFile): string => {
-      if (file.status === "too_large" || file.status === "binary") {
-        return `${layout}:${wrapLines ? "wrap" : "scroll"}:${typographyKey}:${file.path}:${file.status}`;
-      }
-
-      const metrics = getDiffFileMetrics(file);
-      return [
-        layout,
-        wrapLines ? "wrap" : "scroll",
-        typographyKey,
-        file.path,
-        file.status ?? "ok",
-        file.additions,
-        file.deletions,
-        file.hunks.length,
-        metrics.unifiedLineCount,
-        metrics.contentLength,
-      ].join(":");
-    },
-    [layout, typographyKey, wrapLines],
-  );
-
-  const estimateBodyHeight = useCallback(
-    (file: ParsedDiffFile): number => {
-      if (file.status === "too_large" || file.status === "binary") {
-        return statusBodyHeightEstimate;
-      }
-
-      const lineCount =
-        layout === "split"
-          ? getSplitDiffLineCount(file)
-          : getDiffFileMetrics(file).unifiedLineCount;
-      return diffBodyChromeHeight + lineCount * diffBodyLineHeight;
-    },
-    [diffBodyChromeHeight, diffBodyLineHeight, layout, statusBodyHeightEstimate],
-  );
-
-  const getFlatItemHeight = useCallback(
-    (item: DiffFlatItem): number => {
-      if (item.type === "folder") {
-        return folderRowHeightRef.current || defaultHeaderHeightRef.current;
-      }
-      if (item.type === "header") {
-        return headerHeightByPathRef.current[item.file.path] ?? defaultHeaderHeightRef.current;
-      }
-      const bodyHeightKey = getBodyHeightKey(item.file);
-      return bodyHeightByKeyRef.current[bodyHeightKey] ?? estimateBodyHeight(item.file);
-    },
-    [estimateBodyHeight, getBodyHeightKey],
-  );
-
-  const handleFolderRowHeightChange = useCallback(
-    (height: number) => {
-      if (!Number.isFinite(height) || height <= 0) {
-        return;
-      }
-      const previousHeight = folderRowHeightRef.current;
-      if (previousHeight > 0 && Math.abs(previousHeight - height) <= DIFF_HEIGHT_CHANGE_EPSILON) {
-        return;
-      }
-      folderRowHeightRef.current = height;
-      scheduleHeightVersionUpdate();
-    },
-    [scheduleHeightVersionUpdate],
-  );
-
-  const handleHeaderHeightChange = useCallback(
-    (path: string, height: number) => {
-      if (!Number.isFinite(height) || height <= 0) {
-        return;
-      }
-      const previousHeight = headerHeightByPathRef.current[path];
-      if (
-        previousHeight !== undefined &&
-        Math.abs(previousHeight - height) <= DIFF_HEIGHT_CHANGE_EPSILON
-      ) {
-        return;
-      }
-      headerHeightByPathRef.current[path] = height;
-      defaultHeaderHeightRef.current = height;
-      scheduleHeightVersionUpdate();
-    },
-    [scheduleHeightVersionUpdate],
-  );
-
-  const handleBodyHeightChange = useCallback(
-    (file: ParsedDiffFile, height: number) => {
-      if (!Number.isFinite(height) || height < 0) {
-        return;
-      }
-      const heightKey = getBodyHeightKey(file);
-      const previousHeight = bodyHeightByKeyRef.current[heightKey];
-      if (
-        previousHeight !== undefined &&
-        Math.abs(previousHeight - height) <= DIFF_HEIGHT_CHANGE_EPSILON
-      ) {
-        return;
-      }
-      bodyHeightByKeyRef.current[heightKey] = height;
-      scheduleHeightVersionUpdate();
-    },
-    [getBodyHeightKey, scheduleHeightVersionUpdate],
-  );
-
-  const handleDiffListScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      diffListScrollOffsetRef.current = event.nativeEvent.contentOffset.y;
-      diffViewport.update({
-        top: diffListScrollOffsetRef.current,
-        height: diffListViewportHeightRef.current,
-      });
-      updateScrollbarOffset(event);
-    },
-    [diffViewport, updateScrollbarOffset],
-  );
-
-  const handleDiffListLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      const height = event.nativeEvent.layout.height;
-      if (!Number.isFinite(height) || height <= 0) {
-        return;
-      }
-      diffListViewportHeightRef.current = height;
-      diffViewport.update({ top: diffListScrollOffsetRef.current, height });
-      updateScrollbarLayout(event);
-    },
-    [diffViewport, updateScrollbarLayout],
-  );
-
-  const computeItemOffset = useCallback(
-    (predicate: (item: DiffFlatItem) => boolean): number | null => {
-      const index = flatItems.findIndex(predicate);
-      if (index < 0) {
-        return null;
-      }
-      return sumHeightsBefore(flatItems, index, getFlatItemHeight);
-    },
-    [flatItems, getFlatItemHeight],
-  );
-
-  const computeHeaderOffset = useCallback(
-    (path: string): number =>
-      computeItemOffset((item) => item.type === "header" && item.file.path === path) ?? 0,
-    [computeItemOffset],
-  );
-
-  useEffect(() => {
-    if (!focusPath) {
-      return;
-    }
-    const focusRequestKey = `${focusRequestId ?? "initial"}:${focusPath}`;
-    if (
-      consumedFocusRequestRef.current === focusRequestKey ||
-      pendingFocusRequestRef.current === focusRequestKey
-    ) {
-      return;
-    }
-    const hasTarget = flatItems.some(
-      (item) => item.type === "header" && item.file.path === focusPath,
-    );
-    if (!hasTarget) {
-      return;
-    }
-    pendingFocusRequestRef.current = focusRequestKey;
-    const frame = requestAnimationFrame(() => {
-      diffListRef.current?.scrollToOffset({
-        offset: computeHeaderOffset(focusPath),
-        animated: false,
-      });
-      consumedFocusRequestRef.current = focusRequestKey;
-      pendingFocusRequestRef.current = null;
-    });
-    return () => {
-      cancelAnimationFrame(frame);
-      if (pendingFocusRequestRef.current === focusRequestKey) {
-        pendingFocusRequestRef.current = null;
-      }
-    };
-  }, [computeHeaderOffset, flatItems, focusPath, focusRequestId]);
-
-  const handleToggleExpanded = useCallback(
-    (path: string) => {
-      if (mode.kind === "commit") {
-        return;
-      }
-      const isCurrentlyExpanded = expandedPaths.has(path);
-      const nextExpanded = !isCurrentlyExpanded;
-      const targetOffset = isCurrentlyExpanded ? computeHeaderOffset(path) : null;
-      const headerHeight = headerHeightByPathRef.current[path] ?? defaultHeaderHeightRef.current;
-      const shouldAnchor =
-        isCurrentlyExpanded &&
-        targetOffset !== null &&
-        shouldAnchorHeaderBeforeCollapse({
-          headerOffset: targetOffset,
-          headerHeight,
-          viewportOffset: diffListScrollOffsetRef.current,
-          viewportHeight: diffListViewportHeightRef.current,
-        });
-
-      if (shouldAnchor && targetOffset !== null) {
-        diffListRef.current?.scrollToOffset({
-          offset: targetOffset,
-          animated: false,
-        });
-      }
-
-      mode.onExpandedPathsChange(
-        nextExpanded
-          ? [...expandedPaths, path]
-          : Array.from(expandedPaths).filter((expandedPath) => expandedPath !== path),
-      );
-    },
-    [computeHeaderOffset, expandedPaths, mode],
-  );
-
-  const handleToggleFolder = useCallback(
-    (dirPath: string) => {
-      if (mode.kind !== "working_tree") {
-        return;
-      }
-      const isCurrentlyCollapsed = effectiveCollapsedFolders.has(dirPath);
-      if (!isCurrentlyCollapsed) {
-        const targetOffset = computeItemOffset(
-          (item) => item.type === "folder" && item.dirPath === dirPath,
-        );
-        const folderHeight = folderRowHeightRef.current || defaultHeaderHeightRef.current;
-        if (
-          targetOffset !== null &&
-          shouldAnchorHeaderBeforeCollapse({
-            headerOffset: targetOffset,
-            headerHeight: folderHeight,
-            viewportOffset: diffListScrollOffsetRef.current,
-            viewportHeight: diffListViewportHeightRef.current,
-          })
-        ) {
-          diffListRef.current?.scrollToOffset({ offset: targetOffset, animated: false });
-        }
-      }
-
-      mode.onCollapsedFoldersChange(
-        isCurrentlyCollapsed
-          ? Array.from(effectiveCollapsedFolders).filter((path) => path !== dirPath)
-          : [...effectiveCollapsedFolders, dirPath],
-      );
-    },
-    [computeItemOffset, effectiveCollapsedFolders, mode],
-  );
-
-  const handleCollapseFolder = useCallback(
-    (dirPath: string) => {
-      if (mode.kind !== "working_tree") {
-        return;
-      }
-      const targetOffset = computeItemOffset(
-        (item) => item.type === "folder" && item.dirPath === dirPath,
-      );
-      const folderHeight = folderRowHeightRef.current || defaultHeaderHeightRef.current;
-      if (
-        targetOffset !== null &&
-        shouldAnchorHeaderBeforeCollapse({
-          headerOffset: targetOffset,
-          headerHeight: folderHeight,
-          viewportOffset: diffListScrollOffsetRef.current,
-          viewportHeight: diffListViewportHeightRef.current,
-        })
-      ) {
-        diffListRef.current?.scrollToOffset({ offset: targetOffset, animated: false });
-      }
-
-      const pathPrefix = `${dirPath}/`;
-      mode.onCollapsedFoldersChange([
-        ...new Set([
-          ...effectiveCollapsedFolders,
-          ...allFolderPaths.filter(
-            (folderPath) => folderPath === dirPath || folderPath.startsWith(pathPrefix),
-          ),
-        ]),
-      ]);
-    },
-    [allFolderPaths, computeItemOffset, effectiveCollapsedFolders, mode],
-  );
-
-  const renderFlatItem = useCallback(
-    ({ item, index }: { item: DiffFlatItem; index: number }) => {
-      if (item.type === "folder") {
-        return (
-          <DiffFolderRow
-            dirPath={item.dirPath}
-            displayName={item.displayName}
-            depth={item.depth}
-            collapsed={item.collapsed}
-            isSelected={selectedPath === item.dirPath}
-            additions={item.additions}
-            deletions={item.deletions}
-            onToggle={handleToggleFolder}
-            onCollapse={handleCollapseFolder}
-            onSelect={handleSelectPath}
-            onHeightChange={handleFolderRowHeightChange}
-            onCopyPath={onCopyPath}
-            onCopyRelativePath={onCopyRelativePath}
-            onReveal={onReveal}
-            revealTargetName={revealTargetName}
-            onDuplicate={onDuplicate}
-            onRevert={onRevert}
-            testID={`diff-folder-${item.dirPath}`}
-          />
-        );
-      }
-      if (item.type === "header") {
-        return (
-          <DiffFileHeader
-            file={item.file}
-            workspaceFileDragScope={workspaceFileDragScope}
-            isExpanded={item.isExpanded}
-            isSelected={selectedPath === item.file.path}
-            depth={item.depth}
-            showDir={viewMode === "flat"}
-            interactive={interactive}
-            onToggle={interactive ? (onFilePress ?? handleToggleExpanded) : undefined}
-            onSelect={handleSelectPath}
-            onOpenFile={onOpenFile}
-            onAddToChat={onAddToChat}
-            onCopyPath={onCopyPath}
-            onCopyRelativePath={onCopyRelativePath}
-            onReveal={onReveal}
-            revealTargetName={revealTargetName}
-            onDownload={onDownload}
-            onDuplicate={onDuplicate}
-            onRevert={onRevert}
-            onHeaderHeightChange={handleHeaderHeightChange}
-            testID={`diff-file-${item.fileIndex}`}
-          />
-        );
-      }
-      return (
-        <DiffFileBody
-          file={item.file}
-          viewport={diffViewport}
-          bodyOffset={sumHeightsBefore(flatItems, index, getFlatItemHeight)}
-          layout={layout}
-          wrapLines={wrapLines}
-          codeFontSize={codeFontSize}
-          textMetricsStyle={textMetricsStyle}
-          reviewActions={reviewActions}
-          onBodyHeightChange={handleBodyHeightChange}
-          testID={`diff-file-${item.fileIndex}-body`}
-        />
-      );
-    },
-    [
-      codeFontSize,
-      diffViewport,
-      flatItems,
-      getFlatItemHeight,
-      handleBodyHeightChange,
-      handleFolderRowHeightChange,
-      handleHeaderHeightChange,
-      handleCollapseFolder,
-      handleSelectPath,
-      handleToggleExpanded,
-      handleToggleFolder,
-      layout,
-      reviewActions,
-      workspaceFileDragScope,
-      textMetricsStyle,
-      viewMode,
-      wrapLines,
-      interactive,
-      onFilePress,
-      onOpenFile,
-      onAddToChat,
-      onCopyPath,
-      onCopyRelativePath,
-      onReveal,
-      revealTargetName,
-      onDownload,
-      onDuplicate,
-      onRevert,
-      selectedPath,
-    ],
-  );
-
-  const flatKeyExtractor = useCallback(
-    (item: DiffFlatItem) =>
-      item.type === "folder" ? `folder-${item.dirPath}` : `${item.type}-${item.file.path}`,
-    [],
-  );
-
-  const getFlatItemLayout = useCallback<DiffFlatItemLayoutGetter>(
-    (_data, index) => {
-      const offset = sumHeightsBefore(flatItems, index, getFlatItemHeight);
-      const item = flatItems[index];
-      const length = item ? getFlatItemHeight(item) : 0;
-      return { length, offset, index };
-    },
-    [flatItems, getFlatItemHeight],
-  );
-
-  const flatExtraData = useMemo(
-    () => ({
-      expandedPathsArray,
-      collapsedFoldersArray,
-      layout,
-      typographyKey,
-      heightVersion,
-      viewMode,
-      wrapLines,
-      reviewActions,
-      workspaceFileDragScope,
-    }),
-    [
-      expandedPathsArray,
-      collapsedFoldersArray,
-      heightVersion,
-      layout,
-      reviewActions,
-      typographyKey,
-      viewMode,
-      workspaceFileDragScope,
-      wrapLines,
-    ],
-  );
-
-  return (
-    <View style={styles.scrollContainer}>
-      <FlatList
-        ref={diffListRef}
-        data={flatItems}
-        renderItem={renderFlatItem}
-        keyExtractor={flatKeyExtractor}
-        getItemLayout={getFlatItemLayout}
-        stickyHeaderIndices={stickyHeaderIndices}
-        extraData={flatExtraData}
-        style={styles.scrollView}
-        contentContainerStyle={styles.contentContainer}
-        testID="git-diff-scroll"
-        onLayout={handleDiffListLayout}
-        onScroll={handleDiffListScroll}
-        onContentSizeChange={scrollbar.onContentSizeChange}
-        scrollEventThrottle={16}
-        showsVerticalScrollIndicator={!scrollbar.enabled}
-        removeClippedSubviews={false}
-        initialNumToRender={12}
-        maxToRenderPerBatch={12}
-        windowSize={10}
-      />
-      {scrollbar.overlay}
-    </View>
-  );
-}
-
 function computeBaseRefLabel(baseRef: string | undefined, fallbackLabel: string): string {
   if (!baseRef) return fallbackLabel;
   const trimmed = baseRef.replace(/^refs\/(heads|remotes)\//, "").trim();
@@ -2765,13 +731,6 @@ function buildDiffModeTriggerStyle(): PressableStyleFn {
   ];
 }
 
-function buildExpandAllButtonStyle(): PressableStyleFn {
-  return ({ hovered, pressed }) => [
-    styles.expandAllButton,
-    (Boolean(hovered) || pressed) && styles.toggleButtonSelected,
-  ];
-}
-
 function buildOverflowButtonStyle(): PressableStyleFn {
   return ({ hovered, pressed }) => [
     styles.overflowButton,
@@ -2789,20 +748,12 @@ function buildToggleButtonStyle(
   ];
 }
 
-function useChangesTreeState({
+function useCollapsedDiffFolders({
   workspaceId,
   cwd,
-  files,
-  viewMode,
-  changesTabOpen,
-  onViewModeChange,
 }: {
   workspaceId?: string | null;
   cwd: string;
-  files: ParsedDiffFile[];
-  viewMode: "flat" | "tree";
-  changesTabOpen: boolean;
-  onViewModeChange: (viewMode: "flat" | "tree") => void;
 }) {
   const workspaceStateKey = useMemo(
     () =>
@@ -2812,73 +763,11 @@ function useChangesTreeState({
       }),
     [cwd, workspaceId],
   );
-  const expandedPaths = usePanelStore((state) =>
-    workspaceStateKey ? state.diffExpandedPathsByWorkspace[workspaceStateKey] : undefined,
-  );
   const collapsedFolders = usePanelStore((state) =>
     workspaceStateKey ? state.diffCollapsedFoldersByWorkspace[workspaceStateKey] : undefined,
   );
-  const setExpandedPaths = usePanelStore((state) => state.setDiffExpandedPathsForWorkspace);
   const setCollapsedFolders = usePanelStore((state) => state.setDiffCollapsedFoldersForWorkspace);
-  const stableExpandedPaths = expandedPaths ?? EMPTY_PATH_LIST;
   const stableCollapsedFolders = collapsedFolders ?? EMPTY_PATH_LIST;
-  const folderPaths = useMemo(
-    () => collectDirPaths(compressSingleChildChains(buildDiffTree(files))),
-    [files],
-  );
-  const folderPathSet = useMemo(() => new Set(folderPaths), [folderPaths]);
-  const allExpanded = useMemo(() => {
-    if (files.length === 0 || changesTabOpen) {
-      return false;
-    }
-    const everyFileExpanded = files.every((file) => stableExpandedPaths.includes(file.path));
-    const everyFolderExpanded =
-      viewMode !== "tree" ||
-      stableCollapsedFolders.every((folderPath) => !folderPathSet.has(folderPath));
-    return everyFileExpanded && everyFolderExpanded;
-  }, [changesTabOpen, files, folderPathSet, stableCollapsedFolders, stableExpandedPaths, viewMode]);
-  const toggleViewMode = useCallback(() => {
-    const nextViewMode = viewMode === "flat" ? "tree" : "flat";
-    if (nextViewMode === "tree" && workspaceStateKey) {
-      setCollapsedFolders(workspaceStateKey, []);
-    }
-    onViewModeChange(nextViewMode);
-  }, [onViewModeChange, setCollapsedFolders, viewMode, workspaceStateKey]);
-  const toggleExpandAll = useCallback(() => {
-    if (!workspaceStateKey) {
-      return;
-    }
-    if (allExpanded) {
-      setExpandedPaths(workspaceStateKey, []);
-      if (viewMode === "tree") {
-        setCollapsedFolders(workspaceStateKey, folderPaths);
-      }
-      return;
-    }
-    setExpandedPaths(
-      workspaceStateKey,
-      files.map((file) => file.path),
-    );
-    if (viewMode === "tree") {
-      setCollapsedFolders(workspaceStateKey, []);
-    }
-  }, [
-    allExpanded,
-    files,
-    folderPaths,
-    setCollapsedFolders,
-    setExpandedPaths,
-    viewMode,
-    workspaceStateKey,
-  ]);
-  const updateExpandedPaths = useCallback(
-    (paths: string[]) => {
-      if (workspaceStateKey) {
-        setExpandedPaths(workspaceStateKey, paths);
-      }
-    },
-    [setExpandedPaths, workspaceStateKey],
-  );
   const updateCollapsedFolders = useCallback(
     (paths: string[]) => {
       if (workspaceStateKey) {
@@ -2889,67 +778,158 @@ function useChangesTreeState({
   );
 
   return {
-    expandedPaths: changesTabOpen ? EMPTY_PATH_LIST : stableExpandedPaths,
     collapsedFolders: stableCollapsedFolders,
-    allExpanded,
-    toggleViewMode,
-    toggleExpandAll,
-    updateExpandedPaths,
     updateCollapsedFolders,
   };
 }
 
-export function ChangedFilesTree({
+function ChangedFilesTree({
   workspaceId,
   cwd,
   files,
-  displayPreferences,
-  workingTreeMode,
+  mode,
+  onSelectFile,
 }: {
   workspaceId?: string | null;
   cwd: string;
   files: ParsedDiffFile[];
-  displayPreferences: SharedDiffViewProps["displayPreferences"];
-  workingTreeMode: WorkingTreeDiffMode;
+  mode: WorkingDiffMode;
+  onSelectFile: (path: string) => void;
 }) {
-  const treeState = useChangesTreeState({
-    workspaceId,
-    cwd,
-    files,
-    viewMode: "tree",
-    changesTabOpen: false,
-    onViewModeChange: () => {},
-  });
-  const mode = useMemo(
-    () => ({
-      ...workingTreeMode,
-      viewMode: "tree" as const,
-      expandedPaths: EMPTY_PATH_LIST,
-      collapsedFolders: treeState.collapsedFolders,
-      onExpandedPathsChange: () => {},
-      onCollapsedFoldersChange: treeState.updateCollapsedFolders,
-    }),
-    [treeState.collapsedFolders, treeState.updateCollapsedFolders, workingTreeMode],
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const { collapsedFolders: collapsedFolderPaths, updateCollapsedFolders } =
+    useCollapsedDiffFolders({ workspaceId, cwd });
+  const compressedTree = useMemo(() => compressSingleChildChains(buildDiffTree(files)), [files]);
+  const allFolderPaths = useMemo(() => collectDirPaths(compressedTree), [compressedTree]);
+  const collapsedFolders = useMemo(() => new Set(collapsedFolderPaths), [collapsedFolderPaths]);
+  const items = useMemo(
+    () => flattenDiffTree(compressedTree, collapsedFolders),
+    [collapsedFolders, compressedTree],
   );
-  return <SharedDiffView files={files} displayPreferences={displayPreferences} mode={mode} />;
+  const handleSelectPath = useCallback((path: string) => setSelectedPath(path), []);
+  const handleSelectFile = useCallback(
+    (path: string) => {
+      setSelectedPath(path);
+      onSelectFile(path);
+    },
+    [onSelectFile],
+  );
+  const handleToggleFolder = useCallback(
+    (dirPath: string) => {
+      const next = collapsedFolders.has(dirPath)
+        ? Array.from(collapsedFolders).filter((path) => path !== dirPath)
+        : [...collapsedFolders, dirPath];
+      updateCollapsedFolders(next);
+    },
+    [collapsedFolders, updateCollapsedFolders],
+  );
+  const handleCollapseFolder = useCallback(
+    (dirPath: string) => {
+      const prefix = `${dirPath}/`;
+      updateCollapsedFolders([
+        ...new Set([
+          ...collapsedFolders,
+          ...allFolderPaths.filter(
+            (folderPath) => folderPath === dirPath || folderPath.startsWith(prefix),
+          ),
+        ]),
+      ]);
+    },
+    [allFolderPaths, collapsedFolders, updateCollapsedFolders],
+  );
+  const renderItem = useCallback(
+    ({ item }: { item: DiffTreeRow }) => {
+      if (item.kind === "folder") {
+        return (
+          <DiffFolderRow
+            dirPath={item.dirPath}
+            displayName={item.displayName}
+            depth={item.depth}
+            collapsed={collapsedFolders.has(item.dirPath)}
+            isSelected={selectedPath === item.dirPath}
+            additions={item.additions}
+            deletions={item.deletions}
+            onToggle={handleToggleFolder}
+            onCollapse={handleCollapseFolder}
+            onSelect={handleSelectPath}
+            onCopyPath={mode.onCopyPath}
+            onCopyRelativePath={mode.onCopyRelativePath}
+            onReveal={mode.onReveal}
+            revealTargetName={mode.revealTargetName}
+            onDuplicate={mode.onDuplicate}
+            onRevert={mode.onRevert}
+            testID={`diff-folder-${item.dirPath}`}
+          />
+        );
+      }
+      return (
+        <FileHeader
+          file={item.file}
+          workspaceFileDragScope={mode.workspaceFileDragScope}
+          bodyVisible={false}
+          showsBodyState={false}
+          isSelected={selectedPath === item.file.path}
+          depth={item.depth}
+          showDir={false}
+          onActivate={handleSelectFile}
+          onSelect={handleSelectPath}
+          onOpenFile={mode.onOpenFile}
+          onAddToChat={mode.onAddToChat}
+          onCopyPath={mode.onCopyPath}
+          onCopyRelativePath={mode.onCopyRelativePath}
+          onReveal={mode.onReveal}
+          revealTargetName={mode.revealTargetName}
+          onDownload={mode.onDownload}
+          onDuplicate={mode.onDuplicate}
+          onRevert={mode.onRevert}
+          testID={`diff-tree-file-${item.fileIndex}`}
+        />
+      );
+    },
+    [
+      handleCollapseFolder,
+      handleSelectFile,
+      handleSelectPath,
+      handleToggleFolder,
+      collapsedFolders,
+      mode,
+      selectedPath,
+    ],
+  );
+  const keyExtractor = useCallback(
+    (item: DiffTreeRow) =>
+      item.kind === "folder" ? `folder-${item.dirPath}` : `file-${item.file.path}`,
+    [],
+  );
+
+  return (
+    <FlatList
+      data={items}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      style={styles.scrollView}
+      contentContainerStyle={styles.contentContainer}
+      testID="changes-file-tree"
+    />
+  );
 }
 
-function GitDiffTreeRail({
+function ChangesTreeRail({
   shown,
   children,
   workspaceId,
   cwd,
   files,
-  displayPreferences,
-  workingTreeMode,
+  mode,
+  onSelectFile,
 }: {
   shown: boolean;
   children: ReactElement;
   workspaceId?: string | null;
   cwd: string;
   files: ParsedDiffFile[];
-  displayPreferences: SharedDiffViewProps["displayPreferences"];
-  workingTreeMode: WorkingTreeDiffMode;
+  mode: WorkingDiffMode;
+  onSelectFile: (path: string) => void;
 }) {
   if (!shown) return children;
   return (
@@ -2959,24 +939,10 @@ function GitDiffTreeRail({
         workspaceId={workspaceId}
         cwd={cwd}
         files={files}
-        displayPreferences={displayPreferences}
-        workingTreeMode={workingTreeMode}
+        mode={mode}
+        onSelectFile={onSelectFile}
       />
     </TreeRail>
-  );
-}
-
-function resolveWorkingTreeMode<T>(isMobile: boolean, mobileMode: T, desktopMode: T): T {
-  return isMobile ? mobileMode : desktopMode;
-}
-
-function shouldShowTreeRail(viewMode: "flat" | "tree", isMobile: boolean): boolean {
-  return viewMode === "tree" && !isMobile;
-}
-
-function useCodeupForgeSupported(serverId: string): boolean {
-  return useSessionStore(
-    (state) => state.sessions[serverId]?.serverInfo?.features?.codeupForge === true,
   );
 }
 
@@ -3046,15 +1012,17 @@ function useDiffTabNavigation({
   };
 }
 
-export function GitDiffPane({
+export function ChangesSurface({
   serverId,
   workspaceId,
   cwd,
   enabled,
   host,
+  focusPath,
+  focusRequestId,
   onOpenFile,
   onAddToChat,
-}: GitDiffPaneProps) {
+}: ChangesSurfaceProps) {
   const { settings: appSettings } = useAppSettings();
   const { t } = useTranslation();
   const isMobile = useIsCompactFormFactor();
@@ -3062,8 +1030,24 @@ export function GitDiffPane({
   const { preferences: changesPreferences, updatePreferences: updateChangesPreferences } =
     useChangesPreferences();
   const wrapLines = changesPreferences.wrapLines;
-  const viewMode = changesPreferences.viewMode;
+  const desktopTreeVisible = changesPreferences.desktopTreeVisible;
   const effectiveLayout = resolveDiffLayout(changesPreferences.layout, canUseSplitLayout);
+  const collapsedFilesWorkspaceKey = `${serverId}:${workspaceId ?? cwd}`;
+  const persistedCollapsedFilePaths = usePanelStore(
+    (state) => state.collapsedFilePathsByWorkspace[collapsedFilesWorkspaceKey],
+  );
+  const setCollapsedFilePaths = usePanelStore((state) => state.setCollapsedFilePathsForWorkspace);
+  const collapsedFilePaths = persistedCollapsedFilePaths ?? EMPTY_PATH_LIST;
+  const updateCollapsedFilePaths = useCallback(
+    (paths: string[]) => {
+      setCollapsedFilePaths(collapsedFilesWorkspaceKey, paths);
+    },
+    [collapsedFilesWorkspaceKey, setCollapsedFilePaths],
+  );
+  const collapseState = useMemo(
+    () => ({ paths: collapsedFilePaths, onChange: updateCollapsedFilePaths }),
+    [collapsedFilePaths, updateCollapsedFilePaths],
+  );
 
   const handleToggleWrapLines = useCallback(() => {
     void updateChangesPreferences({ wrapLines: !wrapLines });
@@ -3080,17 +1064,10 @@ export function GitDiffPane({
   }, [changesPreferences.layout, updateChangesPreferences]);
 
   const codeFontSize = appSettings.codeFontSize;
-  const layoutToggleStyle = useMemo(
-    () => buildToggleButtonStyle(false, styles.expandAllButton),
-    [],
+  const treeToggleStyle = useMemo(
+    () => buildToggleButtonStyle(desktopTreeVisible, styles.toolbarIconButton),
+    [desktopTreeVisible],
   );
-
-  const viewModeToggleStyle = useMemo(
-    () => buildToggleButtonStyle(viewMode === "tree", styles.expandAllButton),
-    [viewMode],
-  );
-
-  const expandAllToggleStyle = useMemo(() => buildExpandAllButtonStyle(), []);
 
   const overflowToggleStyle = useMemo(() => buildOverflowButtonStyle(), []);
 
@@ -3174,7 +1151,9 @@ export function GitDiffPane({
   const forgeProvidersSupported = useSessionStore(
     (s) => s.sessions[serverId]?.serverInfo?.features?.forgeProviders === true,
   );
-  const codeupForgeSupported = useCodeupForgeSupported(serverId);
+  const codeupForgeSupported = useSessionStore(
+    (s) => s.sessions[serverId]?.serverInfo?.features?.codeupForge === true,
+  );
   const remoteUrl = status?.remoteUrl;
   const forgeSetupState = computeForgeSetupState({
     forge,
@@ -3193,20 +1172,9 @@ export function GitDiffPane({
       }),
     [forgeSetupState.action, forgeSetupState.forge, remoteUrl, t],
   );
-  const handleViewModeChange = useCallback(
-    (nextViewMode: "flat" | "tree") => {
-      void updateChangesPreferences({ viewMode: nextViewMode });
-    },
-    [updateChangesPreferences],
-  );
-  const changesTree = useChangesTreeState({
-    workspaceId,
-    cwd,
-    files,
-    viewMode,
-    changesTabOpen,
-    onViewModeChange: handleViewModeChange,
-  });
+  const handleToggleDesktopTree = useCallback(() => {
+    void updateChangesPreferences({ desktopTreeVisible: !desktopTreeVisible });
+  }, [desktopTreeVisible, updateChangesPreferences]);
   const sharedDisplayPreferences = useMemo(
     () => ({
       layout: effectiveLayout,
@@ -3270,14 +1238,32 @@ export function GitDiffPane({
     [client, cwd, t, toast],
   );
   const onRevertPath = useDiscardChangesAction({ serverId, cwd, diffMode });
-  const workingTreeMode = useMemo(
+  const [localFocusRequest, setLocalFocusRequest] = useState<{
+    path: string;
+    revision: number;
+  } | null>(null);
+  const externalFocusRequest = useMemo(
+    () => (focusPath ? { path: focusPath, revision: focusRequestId ?? 0 } : null),
+    [focusPath, focusRequestId],
+  );
+  const documentFocusRequest =
+    localFocusRequest &&
+    (!externalFocusRequest || localFocusRequest.revision >= externalFocusRequest.revision)
+      ? localFocusRequest
+      : externalFocusRequest;
+  const handleSelectTreeFile = useCallback((path: string) => {
+    setLocalFocusRequest((current) => ({
+      path,
+      revision: Math.max(Date.now(), (current?.revision ?? 0) + 1),
+    }));
+  }, []);
+  const workingMode = useMemo(
     () => ({
-      kind: "working_tree" as const,
-      viewMode,
-      expandedPaths: changesTree.expandedPaths,
-      collapsedFolders: changesTree.collapsedFolders,
+      kind: "working" as const,
       reviewActions,
       onFilePress: onChangesFilePress,
+      focusPath: documentFocusRequest?.path,
+      focusRequestId: documentFocusRequest?.revision,
       workspaceFileDragScope: workspaceId ? { serverId, workspaceId } : undefined,
       onOpenFile,
       onAddToChat,
@@ -3288,15 +1274,12 @@ export function GitDiffPane({
       onDownload: handleDownloadPath,
       onDuplicate: fsEntryDuplicateEnabled ? handleDuplicatePath : undefined,
       onRevert: onRevertPath,
-      onExpandedPathsChange: changesTree.updateExpandedPaths,
-      onCollapsedFoldersChange: changesTree.updateCollapsedFolders,
     }),
     [
-      viewMode,
-      changesTree.expandedPaths,
-      changesTree.collapsedFolders,
       reviewActions,
       onChangesFilePress,
+      documentFocusRequest?.path,
+      documentFocusRequest?.revision,
       serverId,
       workspaceId,
       onOpenFile,
@@ -3309,12 +1292,24 @@ export function GitDiffPane({
       fileManagerTarget,
       fsEntryDuplicateEnabled,
       onRevertPath,
-      changesTree.updateExpandedPaths,
-      changesTree.updateCollapsedFolders,
     ],
   );
 
   const hasChanges = files.length > 0;
+  const selectedDiffStat = useMemo(
+    () => computeSelectedDiffStat(files, isDiffLoading),
+    [files, isDiffLoading],
+  );
+  const allFilesCollapsed =
+    hasChanges && files.every((file) => collapsedFilePaths.includes(file.path));
+  const handleCollapseAllFiles = useCallback(
+    () => updateCollapsedFilePaths(files.map((file) => file.path)),
+    [files, updateCollapsedFilePaths],
+  );
+  const handleExpandAllFiles = useCallback(
+    () => updateCollapsedFilePaths([]),
+    [updateCollapsedFilePaths],
+  );
   const diffErrorMessage = diffPayloadError?.message ?? null;
   const prErrorMessage = computePrErrorMessage(githubFeaturesEnabled, prPayloadError);
   const baseRefLabel = useMemo(
@@ -3341,15 +1336,6 @@ export function GitDiffPane({
     },
   );
 
-  const flatWorkingTreeMode = useMemo(
-    () => ({ ...workingTreeMode, viewMode: "flat" as const }),
-    [workingTreeMode],
-  );
-  const primaryWorkingTreeMode = resolveWorkingTreeMode(
-    isMobile,
-    workingTreeMode,
-    flatWorkingTreeMode,
-  );
   const diffContent: ReactElement = (
     <DiffBodyContent
       isStatusLoading={isStatusLoading}
@@ -3363,24 +1349,25 @@ export function GitDiffPane({
       checkingRepositoryLabel={t("workspace.git.diff.checkingRepository")}
       notRepositoryLabel={t("workspace.git.diff.notRepository")}
     >
-      <SharedDiffView
+      <DiffDocument
         files={files}
+        collapseState={collapseState}
         displayPreferences={sharedDisplayPreferences}
-        mode={primaryWorkingTreeMode}
+        mode={workingMode}
       />
     </DiffBodyContent>
   );
   const bodyContent = (
-    <GitDiffTreeRail
-      shown={shouldShowTreeRail(viewMode, isMobile)}
+    <ChangesTreeRail
+      shown={desktopTreeVisible && !isMobile && files.length > 0}
       workspaceId={workspaceId}
       cwd={cwd}
       files={files}
-      displayPreferences={sharedDisplayPreferences}
-      workingTreeMode={workingTreeMode}
+      mode={workingMode}
+      onSelectFile={handleSelectTreeFile}
     >
       {diffContent}
-    </GitDiffTreeRail>
+    </ChangesTreeRail>
   );
 
   return (
@@ -3390,75 +1377,41 @@ export function GitDiffPane({
       }}
       style={styles.container}
     >
-      {isGit && (currentBranchName || isMobile) ? (
-        <View style={styles.header} testID="changes-header">
-          <BranchSwitcher
-            currentBranchName={currentBranchName}
-            serverId={serverId}
-            workspaceId={workspaceId ?? cwd}
-            workspaceDirectory={cwd}
-            isGitCheckout={isGit}
-            testID="changes-branch-switcher"
-          />
-          {isMobile ? <GitActionsSplitButton gitActions={gitActions} /> : null}
-        </View>
-      ) : null}
-
       {isGit ? (
-        <View style={styles.diffStatusContainer}>
-          <View style={styles.diffStatusInner}>
-            <DiffModeMenu
-              diffMode={diffMode}
-              committedDescription={committedDiffDescription}
-              onSelectUncommitted={handleSelectUncommitted}
-              onSelectBase={handleSelectBase}
-            />
-            <View style={styles.diffStatusButtons}>
-              <ChangesTabToggleForHost
-                host={host}
-                isMobile={isMobile}
-                selected={changesTabOpen}
-                onPress={handleToggleChangesTab}
-              />
-              {canUseSplitLayout && !changesTabOpen ? (
-                <DiffLayoutToggle
-                  layout={changesPreferences.layout}
-                  isMobile={isMobile}
-                  toggleStyle={layoutToggleStyle}
-                  onToggle={handleToggleLayout}
-                />
-              ) : null}
-              {files.length > 0 ? (
-                <DiffViewModeToggle
-                  viewMode={viewMode}
-                  isMobile={isMobile}
-                  toggleStyle={viewModeToggleStyle}
-                  onToggle={changesTree.toggleViewMode}
-                />
-              ) : null}
-              {files.length > 0 && !changesTabOpen ? (
-                <DiffFilesToolbar
-                  allFileDiffsExpanded={changesTree.allExpanded}
-                  isMobile={isMobile}
-                  expandAllToggleStyle={expandAllToggleStyle}
-                  onToggleExpandAll={changesTree.toggleExpandAll}
-                />
-              ) : null}
-              <DiffOptionsMenu
-                brand={getForgePresentation(forge).brandLabel}
-                hideWhitespace={changesPreferences.hideWhitespace}
-                isMobile={isMobile}
-                isRefreshing={isRefreshing}
-                overflowToggleStyle={overflowToggleStyle}
-                refreshSupported={refreshSupported}
-                wrapLines={wrapLines}
-                onRefresh={handleRefresh}
-                onToggleHideWhitespace={handleToggleHideWhitespace}
-                onToggleWrapLines={handleToggleWrapLines}
-              />
-            </View>
-          </View>
-        </View>
+        <ChangesToolbar
+          branchName={currentBranchName}
+          allFilesCollapsed={allFilesCollapsed}
+          canUseSplitLayout={canUseSplitLayout}
+          changesTabOpen={changesTabOpen}
+          committedDescription={committedDiffDescription}
+          cwd={cwd}
+          desktopTreeVisible={desktopTreeVisible}
+          diffMode={diffMode}
+          gitActions={gitActions}
+          hasFiles={hasChanges}
+          hideWhitespace={changesPreferences.hideWhitespace}
+          host={host}
+          isMobile={isMobile}
+          isRefreshing={isRefreshing}
+          layout={changesPreferences.layout}
+          overflowToggleStyle={overflowToggleStyle}
+          refreshSupported={refreshSupported}
+          selectedDiffStat={selectedDiffStat}
+          serverId={serverId}
+          treeToggleStyle={treeToggleStyle}
+          workspaceId={workspaceId}
+          wrapLines={wrapLines}
+          onCollapseAll={handleCollapseAllFiles}
+          onExpandAll={handleExpandAllFiles}
+          onRefresh={handleRefresh}
+          onSelectBase={handleSelectBase}
+          onSelectUncommitted={handleSelectUncommitted}
+          onToggleChangesTab={handleToggleChangesTab}
+          onToggleDesktopTree={handleToggleDesktopTree}
+          onToggleHideWhitespace={handleToggleHideWhitespace}
+          onToggleLayout={handleToggleLayout}
+          onToggleWrapLines={handleToggleWrapLines}
+        />
       ) : null}
 
       {forgeSetupMessage ? (
@@ -3481,35 +1434,37 @@ const styles = StyleSheet.create((theme) => ({
     flex: 1,
     minHeight: 0,
   },
-  header: {
+  changesToolbar: {
+    minHeight: WORKSPACE_SECONDARY_HEADER_HEIGHT,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
     gap: theme.spacing[2],
-    paddingHorizontal: theme.spacing[3],
-    paddingVertical: theme.spacing[2],
+    paddingLeft: theme.spacing[2],
+    paddingRight: theme.spacing[3],
     borderBottomWidth: 1,
     borderBottomColor: theme.colors.border,
+    flexShrink: 0,
   },
-  diffStatusContainer: {
-    height: WORKSPACE_SECONDARY_HEADER_HEIGHT,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-  },
-  diffStatusInner: {
-    flex: 1,
+  changesToolbarIdentity: {
+    minWidth: 0,
+    flexShrink: 1,
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    paddingRight: theme.spacing[3],
+    gap: theme.spacing[1],
+  },
+  changesToolbarControls: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: theme.spacing[1],
+    flexShrink: 0,
   },
   diffModeTrigger: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
     gap: theme.spacing[1],
-    // Align text with header branch icon (at spacing[3] from edge, minus our horizontal padding)
-    marginLeft: theme.spacing[3] - theme.spacing[1],
     paddingHorizontal: theme.spacing[1],
     height: {
       xs: 28,
@@ -3529,23 +1484,17 @@ const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.surface2,
   },
   diffStatusText: {
-    fontSize: theme.fontSize.xs,
-    lineHeight: theme.fontSize.xs * 1.25,
+    fontSize: theme.fontSize.sm,
+    lineHeight: theme.fontSize.sm * 1.25,
     color: theme.colors.foregroundMuted,
   },
   diffStatusIconHidden: {
     opacity: 0,
   },
-  diffStatusButtons: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[1],
-    flexWrap: "wrap",
-  },
   toggleButtonSelected: {
     backgroundColor: theme.colors.surface2,
   },
-  expandAllButton: {
+  toolbarIconButton: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
@@ -3583,7 +1532,7 @@ const styles = StyleSheet.create((theme) => ({
   actionErrorText: {
     paddingHorizontal: theme.spacing[3],
     paddingBottom: theme.spacing[1],
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.destructive,
   },
   forgeSetupCallout: {
@@ -3597,7 +1546,7 @@ const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.surface1,
   },
   forgeSetupCalloutText: {
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.foregroundMuted,
   },
   diffContainer: {
@@ -3646,240 +1595,11 @@ const styles = StyleSheet.create((theme) => ({
     paddingTop: theme.spacing[16],
   },
   emptyText: {
-    fontSize: theme.fontSize.lg,
+    fontSize: theme.fontSize.base,
     color: theme.colors.foregroundMuted,
-  },
-  fileSection: {
-    overflow: "hidden",
-    backgroundColor: theme.colors.surface2,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-  },
-  fileSectionHeaderContainer: {
-    overflow: "hidden",
-  },
-  fileSectionHeaderExpanded: {
-    backgroundColor: theme.colors.surface1,
-  },
-  fileSectionBodyContainer: {
-    overflow: "hidden",
-    backgroundColor: theme.colors.surface2,
-  },
-  fileSectionBorder: {
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.border,
-  },
-  fileHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingLeft: theme.spacing[3],
-    paddingRight: WORKSPACE_FILE_ROW_TRAILING_PADDING,
-    paddingVertical: WORKSPACE_FILE_ROW_VERTICAL_PADDING,
-    gap: theme.spacing[1],
-    minWidth: 0,
-    zIndex: 2,
-    elevation: 2,
-  },
-  fileHeaderActive: {
-    backgroundColor: theme.colors.surfaceSidebarHover,
-  },
-  fileHeaderLeft: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[1],
-    flex: 1,
-    minWidth: 0,
-  },
-  fileHeaderLeftTree: {
-    gap: WORKSPACE_TREE_ICON_LABEL_GAP,
-  },
-  fileHeaderRight: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[1],
-    flexShrink: 0,
-  },
-  fileIcon: {
-    width: WORKSPACE_TREE_ICON_SIZE,
-    height: WORKSPACE_TREE_ICON_SIZE,
-    flexShrink: 0,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  fileName: {
-    fontSize: theme.fontSize.sm,
-    fontWeight: theme.fontWeight.normal,
-    color: theme.colors.foreground,
-    flexShrink: 1,
-    minWidth: 0,
-    userSelect: "none",
-  },
-  fileDir: {
-    fontSize: theme.fontSize.sm,
-    fontWeight: theme.fontWeight.normal,
-    color: theme.colors.foregroundMuted,
-    flex: 1,
-    minWidth: 0,
-    userSelect: "none",
-  },
-  fileDirSpacer: {
-    flex: 1,
-    minWidth: 0,
-  },
-  diffContent: {
-    borderTopWidth: theme.borderWidth[1],
-    borderTopColor: theme.colors.border,
-    backgroundColor: theme.colors.surface1,
-  },
-  diffContentRow: {
-    flexDirection: "row",
-    alignItems: "stretch",
-  },
-  diffContentInner: {
-    flexDirection: "column",
-  },
-  linesContainer: {
-    backgroundColor: theme.colors.surface1,
-  },
-  gutterColumn: {
-    backgroundColor: theme.colors.surface1,
-    zIndex: 4,
-    elevation: 4,
-    overflow: "visible",
-  },
-  gutterCell: {
-    borderRightWidth: theme.borderWidth[1],
-    borderRightColor: theme.colors.border,
-    justifyContent: "flex-start",
-    zIndex: 4,
-    elevation: 4,
-    overflow: "visible",
-  },
-  inlineReviewRow: {
-    flexDirection: "row",
-    alignItems: "stretch",
-    backgroundColor: theme.colors.surface1,
-  },
-  inlineReviewGutterSpacer: {
-    borderRightWidth: theme.borderWidth[1],
-    borderRightColor: theme.colors.border,
-    backgroundColor: theme.colors.surface1,
-    flexShrink: 0,
-  },
-  textLineContainer: {
-    flexDirection: "row",
-    alignItems: "stretch",
-    paddingLeft: theme.spacing[2],
-  },
-  splitRow: {
-    flexDirection: "row",
-    alignItems: "stretch",
-  },
-  splitColumnScroll: {
-    flex: 1,
-  },
-  splitHeaderRow: {
-    backgroundColor: theme.colors.surface2,
-    paddingHorizontal: theme.spacing[3],
-  },
-  splitCell: {
-    flex: 1,
-    flexBasis: 0,
-    backgroundColor: theme.colors.surface2,
-  },
-  splitCellRow: {
-    flexDirection: "row",
-    alignItems: "stretch",
-  },
-  emptySplitCell: {
-    backgroundColor: theme.colors.surfaceDiffEmpty,
-  },
-  splitCellWithDivider: {
-    borderLeftWidth: theme.borderWidth[1],
-    borderLeftColor: theme.colors.border,
-  },
-  diffLineContainer: {
-    flexDirection: "row",
-    alignItems: "stretch",
-    overflow: "visible",
-  },
-  lineNumberGutter: {
-    borderRightWidth: theme.borderWidth[1],
-    borderRightColor: theme.colors.border,
-    marginRight: theme.spacing[2],
-    alignSelf: "stretch",
-    justifyContent: "flex-start",
-    zIndex: 4,
-    elevation: 4,
-    overflow: "visible",
-  },
-  diffTextMetrics: {
-    fontSize: theme.fontSize.code,
-    lineHeight: theme.lineHeight.diff,
-    fontFamily: theme.fontFamily.mono,
-  },
-  lineNumberText: {
-    width: "100%",
-    textAlign: "right",
-    paddingRight: theme.spacing[2],
-    color: theme.colors.foregroundMuted,
-    userSelect: "none",
-  },
-  addLineNumberText: {
-    color: theme.colors.diffAddition,
-  },
-  removeLineNumberText: {
-    color: theme.colors.diffDeletion,
-  },
-  diffLineText: {
-    flex: 1,
-    paddingRight: theme.spacing[3],
-    color: theme.colors.foreground,
-    userSelect: "text",
-  },
-  addLineContainer: {
-    backgroundColor: "rgba(46, 160, 67, 0.15)", // GitHub green
-  },
-  addLineText: {
-    color: theme.colors.foreground,
-  },
-  removeLineContainer: {
-    backgroundColor: "rgba(248, 81, 73, 0.1)", // GitHub red
-  },
-  removeLineText: {
-    color: theme.colors.foreground,
-  },
-  headerLineContainer: {
-    backgroundColor: theme.colors.surface2,
-  },
-  headerLineText: {
-    color: theme.colors.foregroundMuted,
-  },
-  contextLineContainer: {
-    backgroundColor: theme.colors.surface1,
-  },
-  contextLineText: {
-    color: theme.colors.foregroundMuted,
-  },
-  emptySplitCellText: {
-    color: "transparent",
-  },
-  statusMessageContainer: {
-    borderTopWidth: theme.borderWidth[1],
-    borderTopColor: theme.colors.border,
-    backgroundColor: theme.colors.surface1,
-    paddingHorizontal: theme.spacing[3],
-    paddingVertical: theme.spacing[4],
-  },
-  statusMessageText: {
-    fontSize: theme.fontSize.sm,
-    color: theme.colors.foregroundMuted,
-    fontStyle: "italic",
   },
   tooltipText: {
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.foreground,
   },
 }));
-
-const DIFF_HEIGHT_CHANGE_EPSILON = 0.5;

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -1,48 +1,82 @@
-import { useState, useCallback, useMemo, type ReactElement } from "react";
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+  memo,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { useTranslation } from "react-i18next";
-import type { TFunction } from "i18next";
-import { TreeRail } from "@/components/tree-rail";
 import { DiffStat } from "@/components/diff-stat";
+import { TreeRail } from "@/components/tree-rail";
 import {
   View,
   Text,
   Pressable,
   FlatList,
+  type LayoutChangeEvent,
+  type NativeSyntheticEvent,
+  type NativeScrollEvent,
   type PressableStateCallbackType,
+  type FlatListProps,
   type StyleProp,
   type ViewStyle,
+  type TextStyle,
 } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { ICON_SIZE, SPACING, type Theme } from "@/styles/theme";
+import { BORDER_WIDTH, ICON_SIZE, SPACING, type Theme } from "@/styles/theme";
 import { useIsCompactFormFactor, WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
 import {
   AlignJustify,
   ChevronDown,
   Columns2,
   FolderTree,
+  List,
   ListChevronsDownUp,
   ListChevronsUpDown,
   Maximize2,
-  MoreHorizontal,
   Pilcrow,
   RotateCw,
   WrapText,
 } from "lucide-react-native";
-import { type ParsedDiffFile } from "@/git/use-diff-query";
-import { DiffDocument, type WorkingDiffMode } from "@/git/diff-document";
-import { FileHeader } from "@/git/file-header";
+import { type ParsedDiffFile, type DiffLine, type HighlightToken } from "@/git/use-diff-query";
+import { buildDiffFlatItems, sumHeightsBefore, type DiffFlatItem } from "@/git/diff-flat-items";
 import {
-  buildDiffTree,
-  collectDirPaths,
-  compressSingleChildChains,
-  flattenDiffTree,
-  type DiffTreeRow,
-} from "@/git/diff-tree";
+  createDiffRowWindow,
+  createDiffViewport,
+  type DiffRowWindow,
+  type DiffViewport,
+} from "@/git/diff-virtualization";
+import { buildDiffTree, collectDirPaths, compressSingleChildChains } from "@/git/diff-tree";
 import { DiffFolderRow } from "@/git/diff-folder-row";
+import {
+  TreeIndentGuides,
+  treeRowPaddingLeft,
+  WORKSPACE_FILE_ROW_TRAILING_PADDING,
+  WORKSPACE_FILE_ROW_VERTICAL_PADDING,
+  WORKSPACE_TREE_ICON_LABEL_GAP,
+  WORKSPACE_TREE_ICON_SIZE,
+} from "@/components/tree-primitives";
+import { MaterialFileIcon } from "@/components/material-file-icon";
+import { FileChangeIcon } from "@/components/file-change-icon";
 import { useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
 import { CommitsSection } from "@/git/commits-section/commits-section";
 import { useChangesPreferences } from "@/hooks/use-changes-preferences";
 import { useAppSettings } from "@/hooks/use-settings";
+import { DiffScroll } from "@/components/diff-scroll";
+import { syntaxTokenStyleFor } from "@/styles/syntax-token-styles";
+import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
+import { shouldAnchorHeaderBeforeCollapse } from "@/git/diff-scroll";
+import {
+  buildSplitDiffRows,
+  buildUnifiedDiffLines,
+  type ReviewableDiffTarget,
+  type SplitDiffDisplayLine,
+  type SplitDiffRow,
+} from "@/utils/diff-layout";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -51,28 +85,47 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import * as Clipboard from "expo-clipboard";
+import { FileActionsContextMenuContent } from "@/components/file-actions-menu";
+import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { useFileDownload } from "@/hooks/use-file-download";
 import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import { buildAbsoluteExplorerPath } from "@/utils/explorer-paths";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { lineNumberGutterWidth } from "@/components/code-insets";
 import { GitActionsSplitButton } from "@/git/actions-split-button";
-import type { GitActions } from "@/git/policy";
 import { BranchSwitcher } from "@/components/branch-switcher";
 import { useGitActions } from "@/git/use-actions";
 import { GIT_ACTION_ICONS } from "@/git/action-icons";
-import { buildForgeSignInCommand, getForgePresentation, type Forge } from "@/git/forge";
-import { parseGitRemoteLocation } from "@getpaseo/protocol/git-remote";
-import type { ForgeAuthState } from "@getpaseo/protocol/messages";
+import { getForgePresentation } from "@/git/forge";
+import { buildForgeSetupMessage, computeForgeSetupState } from "@/git/forge-setup";
 import { useCheckoutGitActionsStore } from "@/git/actions-store";
 import { useToast } from "@/contexts/toast-context";
 import { useSessionStore } from "@/stores/session-store";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { useOverlayFlatListScrollbar } from "@/components/ui/overlay-scrollbar/use-overlay-flat-list-scrollbar";
+import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { usePanelStore } from "@/stores/panel-store";
 import { collectAllTabs, useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
-import { isWeb } from "@/constants/platform";
+import {
+  compactHighlightTokens,
+  formatDiffContentText,
+  formatDiffGutterText,
+  hasVisibleDiffTokens,
+} from "@/utils/diff-rendering";
+import { isWeb, isNative } from "@/constants/platform";
+import { useWorkspaceFileDragSource } from "@/attachments/use-workspace-file-drag-source";
+import {
+  type ReviewDraftComment,
+  getInlineReviewThreadState,
+  getSplitInlineReviewThreadState,
+  InlineReviewGutterCell,
+  InlineReviewThread,
+  isInlineReviewEditorForTarget,
+  type InlineReviewActions,
+} from "@/review";
 import { usePublishWorkingDiffAttachment, useWorkingDiff } from "@/git/use-working-diff";
 import { DiffTooLargeState } from "@/git/diff-too-large-state";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
@@ -86,21 +139,116 @@ export function resolveDiffLayout(
   return canUseSplitLayout ? layout : "unified";
 }
 
-function computeSelectedDiffStat(
-  files: ParsedDiffFile[],
-  isLoading: boolean,
-): { additions: number; deletions: number } | null {
-  if (isLoading) {
-    return null;
+function fileHeaderPressableStyle(
+  { hovered, pressed }: PressableStateCallbackType & { hovered?: boolean },
+  isSelected: boolean,
+) {
+  return [
+    styles.fileHeader,
+    (Boolean(hovered) || pressed || isSelected) && styles.fileHeaderActive,
+  ];
+}
+
+interface HighlightedTextProps {
+  tokens: HighlightToken[];
+  textMetricsStyle: TextStyle;
+  wrapLines?: boolean;
+  testID?: string;
+}
+
+type WrappedWebTextStyle = TextStyle & {
+  whiteSpace?: "pre" | "pre-wrap";
+  overflowWrap?: "normal" | "anywhere";
+};
+
+function getWrappedTextStyle(wrapLines: boolean): WrappedWebTextStyle | undefined {
+  if (isNative) {
+    return undefined;
   }
-  return files.reduce(
-    (total, file) => ({
-      additions: total.additions + file.additions,
-      deletions: total.deletions + file.deletions,
-    }),
-    { additions: 0, deletions: 0 },
+  return wrapLines
+    ? { whiteSpace: "pre-wrap", overflowWrap: "anywhere" }
+    : { whiteSpace: "pre", overflowWrap: "normal" };
+}
+
+function getNumericLineHeight(textMetricsStyle: TextStyle): number | undefined {
+  const { lineHeight } = textMetricsStyle;
+  return typeof lineHeight === "number" && Number.isFinite(lineHeight) ? lineHeight : undefined;
+}
+
+function useDiffRowMetricsStyle(textMetricsStyle: TextStyle): StyleProp<ViewStyle> {
+  const lineHeight = getNumericLineHeight(textMetricsStyle);
+  return useMemo(
+    () => (lineHeight !== undefined ? inlineUnistylesStyle({ minHeight: lineHeight }) : null),
+    [lineHeight],
   );
 }
+
+function HighlightedToken({ token }: { token: HighlightToken }) {
+  return <Text style={syntaxTokenStyleFor(token.style)}>{token.text}</Text>;
+}
+
+const HighlightedText = memo(function HighlightedText({
+  tokens,
+  textMetricsStyle,
+  wrapLines = false,
+  testID,
+}: HighlightedTextProps) {
+  const containerStyle = useMemo(
+    () => [
+      styles.diffTextMetrics,
+      textMetricsStyle,
+      styles.diffLineText,
+      getWrappedTextStyle(wrapLines),
+    ],
+    [textMetricsStyle, wrapLines],
+  );
+
+  const keyedTokens = useMemo(() => {
+    let characterOffset = 0;
+    return compactHighlightTokens(tokens).map((token) => {
+      const keyedToken = { key: `${characterOffset}-${token.style ?? "base"}`, token };
+      characterOffset += token.text.length;
+      return keyedToken;
+    });
+  }, [tokens]);
+
+  return (
+    <Text style={containerStyle} testID={testID}>
+      {keyedTokens.map(({ key, token }) => (
+        <HighlightedToken key={key} token={token} />
+      ))}
+    </Text>
+  );
+});
+
+interface DiffFileSectionProps {
+  file: ParsedDiffFile;
+  workspaceFileDragScope?: { serverId: string; workspaceId: string };
+  isExpanded: boolean;
+  isSelected?: boolean;
+  /** Tree indentation level (0 on the flat/mobile path). */
+  depth?: number;
+  /** Show the muted directory suffix (flat list); false inside the folder tree. */
+  showDir?: boolean;
+  interactive?: boolean;
+  onToggle?: (path: string) => void;
+  onSelect?: (path: string) => void;
+  onOpenFile?: (path: string) => void;
+  onAddToChat?: (path: string) => void;
+  onCopyPath?: (path: string) => void;
+  onCopyRelativePath?: (path: string) => void;
+  onReveal?: (path: string) => void;
+  revealTargetName?: string;
+  onDownload?: (path: string) => void;
+  onDuplicate?: (path: string) => void;
+  onRevert?: (path: string, oldPath?: string) => void;
+  onHeaderHeightChange?: (path: string, height: number) => void;
+  testID?: string;
+}
+
+const EMPTY_COMMENTS: readonly ReviewDraftComment[] = [];
+
+function noopStartComment(): void {}
 
 function useDiscardChangesAction({
   serverId,
@@ -153,14 +301,1280 @@ function useDiscardChangesAction({
   return discardSupported && diffMode === "uncommitted" ? handleDiscardPath : undefined;
 }
 
-interface ChangesSurfaceProps {
+const DIFF_LINE_HOVER_STYLE = isWeb ? ({ cursor: "auto" } as const) : null;
+
+function LongPressableLine({
+  reviewTarget,
+  reviewActions,
+  onHoverChange,
+  hoverTargetKey,
+  onHoverTargetChange,
+  style,
+  children,
+}: {
+  reviewTarget: ReviewableDiffTarget | null | undefined;
+  reviewActions: InlineReviewActions | undefined;
+  onHoverChange?: (hovered: boolean) => void;
+  hoverTargetKey?: string | null;
+  onHoverTargetChange?: (key: string | null) => void;
+  style: StyleProp<ViewStyle>;
+  children: ReactNode;
+}) {
+  const onStartComment = reviewActions?.onStartComment;
+  const handlePress = useCallback(() => {
+    const selection = isWeb ? window.getSelection() : null;
+    if (selection && !selection.isCollapsed && selection.toString().length > 0) {
+      return;
+    }
+    if (reviewTarget && onStartComment) {
+      onStartComment(reviewTarget);
+    }
+  }, [reviewTarget, onStartComment]);
+
+  const handleHoverIn = useCallback(() => {
+    onHoverChange?.(true);
+    if (hoverTargetKey) {
+      onHoverTargetChange?.(hoverTargetKey);
+    }
+  }, [hoverTargetKey, onHoverChange, onHoverTargetChange]);
+  const handleHoverOut = useCallback(() => {
+    onHoverChange?.(false);
+    if (hoverTargetKey) {
+      onHoverTargetChange?.(null);
+    }
+  }, [hoverTargetKey, onHoverChange, onHoverTargetChange]);
+  const hoverStyle = useMemo(() => [style, DIFF_LINE_HOVER_STYLE], [style]);
+
+  if (isWeb && (onHoverChange || onHoverTargetChange)) {
+    return (
+      <Pressable onHoverIn={handleHoverIn} onHoverOut={handleHoverOut} style={hoverStyle}>
+        {children}
+      </Pressable>
+    );
+  }
+
+  if (!isNative || !reviewTarget || !onStartComment) {
+    return <View style={style}>{children}</View>;
+  }
+  return (
+    <Pressable onPress={handlePress} style={style}>
+      {children}
+    </Pressable>
+  );
+}
+
+function lineTypeBackground(type: DiffLine["type"] | undefined | null) {
+  if (!type) return styles.emptySplitCell;
+  if (type === "add") return styles.addLineContainer;
+  if (type === "remove") return styles.removeLineContainer;
+  if (type === "header") return styles.headerLineContainer;
+  return styles.contextLineContainer;
+}
+
+function DiffGutterCell({
+  lineNumber,
+  type,
+  gutterWidth,
+  textMetricsStyle,
+  reviewTarget,
+  reviewActions,
+  isLineHovered,
+  style,
+  textTestID,
+  actionTestID,
+}: {
+  lineNumber: number | null;
+  type: DiffLine["type"] | undefined | null;
+  gutterWidth: number;
+  textMetricsStyle: TextStyle;
+  reviewTarget?: ReviewableDiffTarget | null;
+  reviewActions?: InlineReviewActions;
+  isLineHovered?: boolean;
+  style?: StyleProp<ViewStyle>;
+  textTestID?: string;
+  actionTestID?: string;
+}) {
+  const lineHeight = getNumericLineHeight(textMetricsStyle);
+  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
+  const containerStyle = useMemo(
+    () => [
+      styles.gutterCell,
+      lineTypeBackground(type),
+      rowMetricsStyle,
+      inlineUnistylesStyle({ width: gutterWidth }),
+      style,
+    ],
+    [type, rowMetricsStyle, gutterWidth, style],
+  );
+  const textStyle = useMemo(
+    () => [
+      styles.diffTextMetrics,
+      textMetricsStyle,
+      styles.lineNumberText,
+      type === "add" && styles.addLineNumberText,
+      type === "remove" && styles.removeLineNumberText,
+    ],
+    [textMetricsStyle, type],
+  );
+  const comments = useMemo(
+    () =>
+      reviewTarget
+        ? (reviewActions?.commentsByTarget.get(reviewTarget.key) ?? EMPTY_COMMENTS)
+        : EMPTY_COMMENTS,
+    [reviewTarget, reviewActions?.commentsByTarget],
+  );
+  const isEditorOpen = isInlineReviewEditorForTarget(reviewActions?.editor ?? null, reviewTarget);
+  const onStartComment = reviewActions?.onStartComment ?? noopStartComment;
+
+  return (
+    <InlineReviewGutterCell
+      reviewTarget={reviewTarget}
+      comments={comments}
+      isEditorOpen={isEditorOpen}
+      isLineHovered={isLineHovered}
+      lineHeight={lineHeight}
+      onStartComment={onStartComment}
+      style={containerStyle}
+      actionTestID={actionTestID}
+    >
+      <Text numberOfLines={1} style={textStyle} testID={textTestID}>
+        {formatDiffGutterText(lineNumber)}
+      </Text>
+    </InlineReviewGutterCell>
+  );
+}
+
+function DiffTextLine({
+  line,
+  wrapLines,
+  textMetricsStyle,
+  reviewTarget,
+  reviewActions,
+  onHoverChange,
+  hoverTargetKey,
+  onHoverTargetChange,
+  textTestID,
+}: {
+  line: DiffLine;
+  wrapLines: boolean;
+  textMetricsStyle: TextStyle;
+  reviewTarget?: ReviewableDiffTarget | null;
+  reviewActions?: InlineReviewActions;
+  onHoverChange?: (hovered: boolean) => void;
+  hoverTargetKey?: string | null;
+  onHoverTargetChange?: (key: string | null) => void;
+  textTestID?: string;
+}) {
+  const visibleTokens = hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
+  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
+
+  const containerStyle = useMemo(
+    () => [styles.textLineContainer, lineTypeBackground(line.type), rowMetricsStyle],
+    [line.type, rowMetricsStyle],
+  );
+  const textStyle = useMemo(
+    () => [
+      styles.diffTextMetrics,
+      textMetricsStyle,
+      styles.diffLineText,
+      getWrappedTextStyle(wrapLines),
+      line.type === "add" && styles.addLineText,
+      line.type === "remove" && styles.removeLineText,
+      line.type === "header" && styles.headerLineText,
+      line.type === "context" && styles.contextLineText,
+    ],
+    [line.type, textMetricsStyle, wrapLines],
+  );
+
+  return (
+    <LongPressableLine
+      reviewTarget={reviewTarget}
+      reviewActions={reviewActions}
+      onHoverChange={onHoverChange}
+      hoverTargetKey={hoverTargetKey}
+      onHoverTargetChange={onHoverTargetChange}
+      style={containerStyle}
+    >
+      {line.type !== "header" && visibleTokens ? (
+        <HighlightedText
+          tokens={visibleTokens}
+          textMetricsStyle={textMetricsStyle}
+          wrapLines={wrapLines}
+          testID={textTestID}
+        />
+      ) : (
+        <Text style={textStyle} testID={textTestID}>
+          {formatDiffContentText(line.content)}
+        </Text>
+      )}
+    </LongPressableLine>
+  );
+}
+
+function SplitTextLine({
+  line,
+  wrapLines,
+  textMetricsStyle,
+  reviewActions,
+  onHoverChange,
+  hoverTargetKey,
+  onHoverTargetChange,
+}: {
+  line: SplitDiffDisplayLine | null;
+  wrapLines: boolean;
+  textMetricsStyle: TextStyle;
+  reviewActions?: InlineReviewActions;
+  onHoverChange?: (hovered: boolean) => void;
+  hoverTargetKey?: string | null;
+  onHoverTargetChange?: (key: string | null) => void;
+}) {
+  const visibleTokens = line && hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
+  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
+
+  const containerStyle = useMemo(
+    () => [styles.textLineContainer, lineTypeBackground(line?.type), rowMetricsStyle],
+    [line?.type, rowMetricsStyle],
+  );
+  const textStyle = useMemo(
+    () => [
+      styles.diffTextMetrics,
+      textMetricsStyle,
+      styles.diffLineText,
+      getWrappedTextStyle(wrapLines),
+      line?.type === "add" && styles.addLineText,
+      line?.type === "remove" && styles.removeLineText,
+      line?.type === "context" && styles.contextLineText,
+      !line && styles.emptySplitCellText,
+    ],
+    [line, textMetricsStyle, wrapLines],
+  );
+
+  return (
+    <LongPressableLine
+      reviewTarget={line?.reviewTarget}
+      reviewActions={reviewActions}
+      onHoverChange={onHoverChange}
+      hoverTargetKey={hoverTargetKey}
+      onHoverTargetChange={onHoverTargetChange}
+      style={containerStyle}
+    >
+      {visibleTokens ? (
+        <HighlightedText
+          tokens={visibleTokens}
+          textMetricsStyle={textMetricsStyle}
+          wrapLines={wrapLines}
+        />
+      ) : (
+        <Text style={textStyle}>{formatDiffContentText(line?.content)}</Text>
+      )}
+    </LongPressableLine>
+  );
+}
+
+function DiffLineView({
+  line,
+  lineNumber,
+  gutterWidth,
+  wrapLines,
+  textMetricsStyle,
+  reviewTarget,
+  reviewActions,
+}: {
+  line: DiffLine;
+  lineNumber: number | null;
+  gutterWidth: number;
+  wrapLines: boolean;
+  textMetricsStyle: TextStyle;
+  reviewTarget?: ReviewableDiffTarget | null;
+  reviewActions?: InlineReviewActions;
+}) {
+  const [isLineHovered, setIsLineHovered] = useState(false);
+  const visibleTokens = hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
+  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
+
+  const containerStyle = useMemo(
+    () => [styles.diffLineContainer, lineTypeBackground(line.type), rowMetricsStyle],
+    [line.type, rowMetricsStyle],
+  );
+  const textStyle = useMemo(
+    () => [
+      styles.diffTextMetrics,
+      textMetricsStyle,
+      styles.diffLineText,
+      getWrappedTextStyle(wrapLines),
+      line.type === "add" && styles.addLineText,
+      line.type === "remove" && styles.removeLineText,
+      line.type === "header" && styles.headerLineText,
+      line.type === "context" && styles.contextLineText,
+    ],
+    [line.type, textMetricsStyle, wrapLines],
+  );
+
+  return (
+    <LongPressableLine
+      reviewTarget={reviewTarget}
+      reviewActions={reviewActions}
+      onHoverChange={setIsLineHovered}
+      style={containerStyle}
+    >
+      <DiffGutterCell
+        lineNumber={lineNumber}
+        type={line.type}
+        gutterWidth={gutterWidth}
+        textMetricsStyle={textMetricsStyle}
+        reviewTarget={reviewTarget}
+        reviewActions={reviewActions}
+        isLineHovered={isLineHovered}
+        style={styles.lineNumberGutter}
+      />
+      {line.type !== "header" && visibleTokens ? (
+        <HighlightedText
+          tokens={visibleTokens}
+          textMetricsStyle={textMetricsStyle}
+          wrapLines={wrapLines}
+        />
+      ) : (
+        <Text style={textStyle}>{formatDiffContentText(line.content)}</Text>
+      )}
+    </LongPressableLine>
+  );
+}
+
+function SplitDiffLine({
+  line,
+  gutterWidth,
+  wrapLines,
+  textMetricsStyle,
+  reviewActions,
+}: {
+  line: SplitDiffDisplayLine | null;
+  gutterWidth: number;
+  wrapLines: boolean;
+  textMetricsStyle: TextStyle;
+  reviewActions?: InlineReviewActions;
+}) {
+  const [isLineHovered, setIsLineHovered] = useState(false);
+  const visibleTokens = line && hasVisibleDiffTokens(line.tokens) ? line.tokens : null;
+  const rowMetricsStyle = useDiffRowMetricsStyle(textMetricsStyle);
+
+  const containerStyle = useMemo(
+    () => [styles.diffLineContainer, lineTypeBackground(line?.type), rowMetricsStyle],
+    [line?.type, rowMetricsStyle],
+  );
+  const textStyle = useMemo(
+    () => [
+      styles.diffTextMetrics,
+      textMetricsStyle,
+      styles.diffLineText,
+      getWrappedTextStyle(wrapLines),
+      line?.type === "add" && styles.addLineText,
+      line?.type === "remove" && styles.removeLineText,
+      line?.type === "context" && styles.contextLineText,
+      !line && styles.emptySplitCellText,
+    ],
+    [line, textMetricsStyle, wrapLines],
+  );
+
+  return (
+    <LongPressableLine
+      reviewTarget={line?.reviewTarget}
+      reviewActions={reviewActions}
+      onHoverChange={setIsLineHovered}
+      style={containerStyle}
+    >
+      <DiffGutterCell
+        lineNumber={line?.lineNumber ?? null}
+        type={line?.type}
+        gutterWidth={gutterWidth}
+        textMetricsStyle={textMetricsStyle}
+        reviewTarget={line?.reviewTarget}
+        reviewActions={reviewActions}
+        isLineHovered={isLineHovered}
+        style={styles.lineNumberGutter}
+      />
+      {visibleTokens ? (
+        <HighlightedText
+          tokens={visibleTokens}
+          textMetricsStyle={textMetricsStyle}
+          wrapLines={wrapLines}
+        />
+      ) : (
+        <Text style={textStyle}>{formatDiffContentText(line?.content)}</Text>
+      )}
+    </LongPressableLine>
+  );
+}
+
+function InlineReviewThreadContent({
+  reviewTarget,
+  reviewActions,
+  reservedHeight,
+  viewportWidth,
+  pinToViewport,
+}: {
+  reviewTarget: ReviewableDiffTarget | null | undefined;
+  reviewActions?: InlineReviewActions;
+  reservedHeight?: number;
+  viewportWidth?: number;
+  pinToViewport?: boolean;
+}) {
+  const threadState = getInlineReviewThreadState({ reviewTarget, reviewActions });
+  const height = reservedHeight ?? threadState?.height ?? 0;
+  const placeholderStyle = useMemo<ViewStyle>(
+    () => inlineUnistylesStyle({ minHeight: height }),
+    [height],
+  );
+  if (height === 0) {
+    return null;
+  }
+  if (!reviewTarget || !reviewActions || !threadState) {
+    return <View style={placeholderStyle} />;
+  }
+
+  return (
+    <InlineReviewThread
+      reviewTarget={reviewTarget}
+      reviewActions={reviewActions}
+      height={height}
+      viewportWidth={viewportWidth}
+      pinToViewport={pinToViewport}
+      testID={`review-thread-${reviewTarget.key}`}
+    />
+  );
+}
+
+function InlineReviewGutterSpacer({
+  reviewTarget,
+  reviewActions,
+  gutterWidth,
+  reservedHeight,
+  style,
+}: {
+  reviewTarget: ReviewableDiffTarget | null | undefined;
+  reviewActions?: InlineReviewActions;
+  gutterWidth: number;
+  reservedHeight?: number;
+  style?: StyleProp<ViewStyle>;
+}) {
+  const threadState = getInlineReviewThreadState({ reviewTarget, reviewActions });
+  const height = reservedHeight ?? threadState?.height ?? 0;
+  const spacerStyle = useMemo<StyleProp<ViewStyle>>(
+    () => [
+      styles.inlineReviewGutterSpacer,
+      inlineUnistylesStyle({ width: gutterWidth, minHeight: height }),
+      style,
+    ],
+    [gutterWidth, height, style],
+  );
+  if (height === 0) {
+    return null;
+  }
+
+  return <View style={spacerStyle} />;
+}
+
+function InlineReviewRow({
+  reviewTarget,
+  reviewActions,
+  gutterWidth,
+  reservedHeight,
+}: {
+  reviewTarget: ReviewableDiffTarget | null | undefined;
+  reviewActions?: InlineReviewActions;
+  gutterWidth: number;
+  reservedHeight?: number;
+}) {
+  const threadState = getInlineReviewThreadState({ reviewTarget, reviewActions });
+  const height = reservedHeight ?? threadState?.height ?? 0;
+  const gutterSpacerStyle = useMemo<StyleProp<ViewStyle>>(
+    () => [styles.inlineReviewGutterSpacer, inlineUnistylesStyle({ width: gutterWidth })],
+    [gutterWidth],
+  );
+  const placeholderStyle = useMemo<ViewStyle>(
+    () => inlineUnistylesStyle({ minHeight: height }),
+    [height],
+  );
+  if (height === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.inlineReviewRow}>
+      <View style={gutterSpacerStyle} />
+      {reviewTarget && reviewActions && threadState ? (
+        <InlineReviewThread
+          reviewTarget={reviewTarget}
+          reviewActions={reviewActions}
+          height={height}
+          testID={`review-thread-${reviewTarget.key}`}
+        />
+      ) : (
+        <View style={placeholderStyle} />
+      )}
+    </View>
+  );
+}
+
+const DIFF_ROW_OVERSCAN = 900;
+const FULL_DIFF_VIEWPORT = { top: 0, height: Number.MAX_SAFE_INTEGER };
+const subscribeToNothing = () => () => {};
+const getFullDiffViewport = () => FULL_DIFF_VIEWPORT;
+
+function useDiffRowWindow({
+  viewport,
+  bodyOffset,
+  rowHeights,
+  enabled,
+}: {
+  viewport?: DiffViewport;
+  bodyOffset: number;
+  rowHeights: readonly number[];
+  enabled: boolean;
+}): DiffRowWindow {
+  const viewportSnapshot = useSyncExternalStore(
+    viewport?.subscribe ?? subscribeToNothing,
+    viewport?.getSnapshot ?? getFullDiffViewport,
+    viewport?.getSnapshot ?? getFullDiffViewport,
+  );
+  return useMemo(() => {
+    if (!enabled) {
+      return createDiffRowWindow(rowHeights, {
+        viewportTop: 0,
+        viewportHeight: Number.MAX_SAFE_INTEGER,
+        overscan: 0,
+      });
+    }
+    return createDiffRowWindow(rowHeights, {
+      viewportTop: viewportSnapshot.top - bodyOffset - BORDER_WIDTH[1],
+      viewportHeight: viewportSnapshot.height,
+      overscan: DIFF_ROW_OVERSCAN,
+    });
+  }, [bodyOffset, enabled, rowHeights, viewportSnapshot.height, viewportSnapshot.top]);
+}
+
+function DiffRowSpacer({ height }: { height: number }) {
+  if (height <= 0) {
+    return null;
+  }
+  return <View style={inlineUnistylesStyle({ height })} />;
+}
+
+function SplitDiffColumn({
+  rows,
+  rowWindow,
+  side,
+  gutterWidth,
+  wrapLines,
+  textMetricsStyle,
+  reviewActions,
+  showDivider = false,
+}: {
+  rows: SplitDiffRow[];
+  rowWindow: DiffRowWindow;
+  side: "left" | "right";
+  gutterWidth: number;
+  wrapLines: boolean;
+  textMetricsStyle: TextStyle;
+  reviewActions?: InlineReviewActions;
+  showDivider?: boolean;
+}) {
+  const [scrollWidth, setScrollWidth] = useState(0);
+  const [hoveredReviewTargetKey, setHoveredReviewTargetKey] = useState<string | null>(null);
+
+  const wrapCellStyle = useMemo(
+    () => [styles.splitCell, showDivider && styles.splitCellWithDivider],
+    [showDivider],
+  );
+  const rowCellStyle = useMemo(
+    () => [styles.splitCell, showDivider && styles.splitCellWithDivider, styles.splitCellRow],
+    [showDivider],
+  );
+  const linesContainerRowStyle = useMemo(
+    () => [
+      styles.linesContainer,
+      scrollWidth > 0 && inlineUnistylesStyle({ minWidth: scrollWidth }),
+    ],
+    [scrollWidth],
+  );
+  const headerLineTextStyle = useMemo(
+    () => [styles.diffTextMetrics, textMetricsStyle, styles.diffLineText, styles.headerLineText],
+    [textMetricsStyle],
+  );
+
+  const keyedRows = useMemo(
+    () =>
+      rows.slice(rowWindow.startIndex, rowWindow.endIndex).map((row, index) => ({
+        key: `row-${rowWindow.startIndex + index}`,
+        row,
+      })),
+    [rowWindow.endIndex, rowWindow.startIndex, rows],
+  );
+
+  if (wrapLines) {
+    return (
+      <View style={wrapCellStyle}>
+        <View style={styles.linesContainer}>
+          <DiffRowSpacer height={rowWindow.beforeHeight} />
+          {keyedRows.map(({ key, row }) => {
+            if (row.kind === "header") {
+              return (
+                <View key={key} style={styles.splitHeaderRow}>
+                  <Text style={headerLineTextStyle}>{row.content}</Text>
+                </View>
+              );
+            }
+            const line = side === "left" ? row.left : row.right;
+            const reviewRowState = getSplitInlineReviewThreadState({
+              left: row.left?.reviewTarget,
+              right: row.right?.reviewTarget,
+              reviewActions,
+            });
+            return (
+              <View key={key}>
+                <SplitDiffLine
+                  line={line}
+                  gutterWidth={gutterWidth}
+                  wrapLines={wrapLines}
+                  textMetricsStyle={textMetricsStyle}
+                  reviewActions={reviewActions}
+                />
+                <InlineReviewRow
+                  reviewTarget={line?.reviewTarget}
+                  reviewActions={reviewActions}
+                  gutterWidth={gutterWidth}
+                  reservedHeight={reviewRowState?.height}
+                />
+              </View>
+            );
+          })}
+          <DiffRowSpacer height={rowWindow.afterHeight} />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={rowCellStyle}>
+      <View style={styles.gutterColumn}>
+        <DiffRowSpacer height={rowWindow.beforeHeight} />
+        {keyedRows.map(({ key, row }) => {
+          if (row.kind === "header") {
+            return (
+              <DiffGutterCell
+                key={key}
+                lineNumber={null}
+                type="header"
+                gutterWidth={gutterWidth}
+                textMetricsStyle={textMetricsStyle}
+              />
+            );
+          }
+          const line = side === "left" ? row.left : row.right;
+          const reviewTargetKey = line?.reviewTarget?.key ?? null;
+          const reviewRowState = getSplitInlineReviewThreadState({
+            left: row.left?.reviewTarget,
+            right: row.right?.reviewTarget,
+            reviewActions,
+          });
+          return (
+            <View key={key}>
+              <DiffGutterCell
+                lineNumber={line?.lineNumber ?? null}
+                type={line?.type}
+                gutterWidth={gutterWidth}
+                textMetricsStyle={textMetricsStyle}
+                reviewTarget={line?.reviewTarget}
+                reviewActions={reviewActions}
+                isLineHovered={
+                  reviewTargetKey !== null && hoveredReviewTargetKey === reviewTargetKey
+                }
+              />
+              <InlineReviewGutterSpacer
+                reviewTarget={line?.reviewTarget}
+                reviewActions={reviewActions}
+                gutterWidth={gutterWidth}
+                reservedHeight={reviewRowState?.height}
+              />
+            </View>
+          );
+        })}
+        <DiffRowSpacer height={rowWindow.afterHeight} />
+      </View>
+      <DiffScroll
+        scrollViewWidth={scrollWidth}
+        onScrollViewWidthChange={setScrollWidth}
+        style={styles.splitColumnScroll}
+        contentContainerStyle={styles.diffContentInner}
+      >
+        <View style={linesContainerRowStyle}>
+          <DiffRowSpacer height={rowWindow.beforeHeight} />
+          {keyedRows.map(({ key, row }) => {
+            if (row.kind === "header") {
+              return (
+                <View key={key} style={styles.splitHeaderRow}>
+                  <Text style={headerLineTextStyle}>{row.content}</Text>
+                </View>
+              );
+            }
+            const line = side === "left" ? row.left : row.right;
+            const reviewTargetKey = line?.reviewTarget?.key ?? null;
+            const reviewRowState = getSplitInlineReviewThreadState({
+              left: row.left?.reviewTarget,
+              right: row.right?.reviewTarget,
+              reviewActions,
+            });
+            return (
+              <View key={key}>
+                <SplitTextLine
+                  line={line}
+                  wrapLines={false}
+                  textMetricsStyle={textMetricsStyle}
+                  reviewActions={reviewActions}
+                  hoverTargetKey={reviewTargetKey}
+                  onHoverTargetChange={setHoveredReviewTargetKey}
+                />
+                <InlineReviewThreadContent
+                  reviewTarget={line?.reviewTarget}
+                  reviewActions={reviewActions}
+                  reservedHeight={reviewRowState?.height}
+                  viewportWidth={scrollWidth}
+                  pinToViewport
+                />
+              </View>
+            );
+          })}
+          <DiffRowSpacer height={rowWindow.afterHeight} />
+        </View>
+      </DiffScroll>
+    </View>
+  );
+}
+
+function DiffFileActionsContextMenuContent({
+  file,
+  onOpenFile,
+  onAddToChat,
+  onCopyPath,
+  onCopyRelativePath,
+  onReveal,
+  revealTargetName,
+  onDownload,
+  onDuplicate,
+  onRevert,
+  testID,
+}: Pick<
+  DiffFileSectionProps,
+  | "file"
+  | "onOpenFile"
+  | "onAddToChat"
+  | "onCopyPath"
+  | "onCopyRelativePath"
+  | "onReveal"
+  | "revealTargetName"
+  | "onDownload"
+  | "onDuplicate"
+  | "onRevert"
+  | "testID"
+>) {
+  const handleOpenFile = useCallback(() => onOpenFile?.(file.path), [file.path, onOpenFile]);
+  const handleAddToChat = useCallback(() => onAddToChat?.(file.path), [file.path, onAddToChat]);
+  const handleCopyPath = useCallback(() => onCopyPath?.(file.path), [file.path, onCopyPath]);
+  const handleCopyRelativePath = useCallback(
+    () => onCopyRelativePath?.(file.path),
+    [file.path, onCopyRelativePath],
+  );
+  const handleReveal = useCallback(() => onReveal?.(file.path), [file.path, onReveal]);
+  const handleDownload = useCallback(() => onDownload?.(file.path), [file.path, onDownload]);
+  const handleDuplicate = useCallback(() => onDuplicate?.(file.path), [file.path, onDuplicate]);
+  const handleRevert = useCallback(
+    () => onRevert?.(file.path, file.oldPath),
+    [file.oldPath, file.path, onRevert],
+  );
+
+  return (
+    <FileActionsContextMenuContent
+      fileKind="file"
+      fileExists={!file.isDeleted}
+      onOpenFile={onOpenFile ? handleOpenFile : undefined}
+      onCopyPath={onCopyPath ? handleCopyPath : undefined}
+      onCopyRelativePath={onCopyRelativePath ? handleCopyRelativePath : undefined}
+      onReveal={onReveal ? handleReveal : undefined}
+      revealTargetName={revealTargetName}
+      onDownload={onDownload ? handleDownload : undefined}
+      onAddToChat={onAddToChat ? handleAddToChat : undefined}
+      onDuplicate={!file.isDeleted && onDuplicate ? handleDuplicate : undefined}
+      onRevert={onRevert ? handleRevert : undefined}
+      testIDPrefix={testID}
+    />
+  );
+}
+
+const DiffFileHeader = memo(function DiffFileHeader({
+  file,
+  workspaceFileDragScope,
+  isExpanded,
+  isSelected = false,
+  depth = 0,
+  showDir = true,
+  interactive = true,
+  onToggle,
+  onSelect,
+  onOpenFile,
+  onAddToChat,
+  onCopyPath,
+  onCopyRelativePath,
+  onReveal,
+  revealTargetName,
+  onDownload,
+  onDuplicate,
+  onRevert,
+  onHeaderHeightChange,
+  testID,
+}: DiffFileSectionProps) {
+  const dragSourceRef = useWorkspaceFileDragSource({
+    enabled: interactive,
+    disabled: file.isDeleted,
+    workspaceId: null,
+    path: file.path,
+    ...workspaceFileDragScope,
+  });
+  const layoutYRef = useRef<number | null>(null);
+  const pressHandledRef = useRef(false);
+  const pressInRef = useRef<{ ts: number; pageX: number; pageY: number } | null>(null);
+
+  const handleSelect = useCallback(() => {
+    if (interactive) {
+      onSelect?.(file.path);
+    }
+  }, [file.path, interactive, onSelect]);
+
+  const toggleExpanded = useCallback(() => {
+    if (!interactive) {
+      return;
+    }
+    const selection = isWeb ? window.getSelection() : null;
+    if (selection && !selection.isCollapsed && selection.toString().length > 0) {
+      return;
+    }
+    pressHandledRef.current = true;
+    handleSelect();
+    onToggle?.(file.path);
+  }, [file.path, handleSelect, interactive, onToggle]);
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      layoutYRef.current = event.nativeEvent.layout.y;
+      onHeaderHeightChange?.(file.path, event.nativeEvent.layout.height);
+    },
+    [file.path, onHeaderHeightChange],
+  );
+
+  const handlePressIn = useCallback((event: { nativeEvent: { pageX: number; pageY: number } }) => {
+    pressHandledRef.current = false;
+    pressInRef.current = {
+      ts: Date.now(),
+      pageX: event.nativeEvent.pageX,
+      pageY: event.nativeEvent.pageY,
+    };
+  }, []);
+
+  const handleLongPress = useCallback(() => {
+    pressHandledRef.current = true;
+    handleSelect();
+  }, [handleSelect]);
+
+  const handlePressOut = useCallback(
+    (event: { nativeEvent: { pageX: number; pageY: number } }) => {
+      if (
+        interactive &&
+        isNative &&
+        !pressHandledRef.current &&
+        layoutYRef.current === 0 &&
+        pressInRef.current
+      ) {
+        const durationMs = Date.now() - pressInRef.current.ts;
+        const dx = event.nativeEvent.pageX - pressInRef.current.pageX;
+        const dy = event.nativeEvent.pageY - pressInRef.current.pageY;
+        const distance = Math.hypot(dx, dy);
+        if (durationMs <= 500 && distance <= 12) {
+          toggleExpanded();
+        }
+      }
+    },
+    [interactive, toggleExpanded],
+  );
+
+  const containerStyle = useMemo(
+    () => [styles.fileSectionHeaderContainer, isExpanded && styles.fileSectionHeaderExpanded],
+    [isExpanded],
+  );
+  const accessibilityState = useMemo(
+    () => ({ expanded: isExpanded, selected: isSelected }),
+    [isExpanded, isSelected],
+  );
+
+  const headerPressableStyle = useCallback(
+    (state: PressableStateCallbackType) =>
+      depth > 0
+        ? [
+            fileHeaderPressableStyle(state, isSelected),
+            inlineUnistylesStyle({ paddingLeft: treeRowPaddingLeft(depth) }),
+          ]
+        : fileHeaderPressableStyle(state, isSelected),
+    [depth, isSelected],
+  );
+
+  const fileName = file.path.split("/").pop() ?? file.path;
+  const headerContent = (
+    <>
+      <View
+        ref={dragSourceRef}
+        style={showDir ? styles.fileHeaderLeft : [styles.fileHeaderLeft, styles.fileHeaderLeftTree]}
+      >
+        {showDir ? null : (
+          <View style={styles.fileIcon}>
+            <MaterialFileIcon fileName={fileName} size={WORKSPACE_TREE_ICON_SIZE} />
+          </View>
+        )}
+        <Text style={styles.fileName} numberOfLines={1}>
+          {fileName}
+        </Text>
+        {showDir ? (
+          <Text style={styles.fileDir} numberOfLines={1}>
+            {file.path.includes("/") ? ` ${file.path.slice(0, file.path.lastIndexOf("/"))}` : ""}
+          </Text>
+        ) : (
+          // Flex spacer in tree mode (no dir suffix) so the New/Deleted badge
+          // stays right-aligned next to the diff stats, as in the flat list.
+          <View style={styles.fileDirSpacer} />
+        )}
+        {file.isNew && <FileChangeIcon change="added" />}
+        {file.isDeleted && <FileChangeIcon change="deleted" />}
+      </View>
+      <View style={styles.fileHeaderRight}>
+        <DiffStat
+          additions={file.additions}
+          deletions={file.deletions}
+          testID={testID ? `${testID}-stat` : undefined}
+        />
+      </View>
+    </>
+  );
+
+  let trigger: ReactElement;
+  if (!interactive) {
+    trigger = (
+      <View
+        {...{
+          onContextMenu: (event: { preventDefault?: () => void }) => event.preventDefault?.(),
+        }}
+        style={headerPressableStyle({ hovered: false, pressed: false })}
+      >
+        {headerContent}
+      </View>
+    );
+  } else {
+    trigger = (
+      <ContextMenuTrigger
+        testID={testID ? `${testID}-toggle` : undefined}
+        style={headerPressableStyle}
+        // Android: prevent parent pan/scroll gestures from canceling the tap release.
+        cancelable={false}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        onLongPress={handleLongPress}
+        onContextMenu={handleSelect}
+        onPress={toggleExpanded}
+        accessibilityState={accessibilityState}
+        aria-selected={isSelected}
+      >
+        {headerContent}
+      </ContextMenuTrigger>
+    );
+  }
+
+  return (
+    <View style={containerStyle} onLayout={handleLayout} testID={testID}>
+      <TreeIndentGuides depth={depth} />
+      <ContextMenu>
+        <Tooltip delayDuration={300} enabledOnDesktop enabledOnMobile={false}>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent side="bottom" align="start" offset={6} maxWidth={520}>
+            <Text style={styles.tooltipText}>{file.path}</Text>
+          </TooltipContent>
+        </Tooltip>
+        {interactive ? (
+          <DiffFileActionsContextMenuContent
+            file={file}
+            onOpenFile={onOpenFile}
+            onAddToChat={onAddToChat}
+            onCopyPath={onCopyPath}
+            onCopyRelativePath={onCopyRelativePath}
+            onReveal={onReveal}
+            revealTargetName={revealTargetName}
+            onDownload={onDownload}
+            onDuplicate={onDuplicate}
+            onRevert={onRevert}
+            testID={testID}
+          />
+        ) : null}
+      </ContextMenu>
+    </View>
+  );
+});
+
+export function DiffFileBody({
+  file,
+  viewport,
+  bodyOffset = 0,
+  layout,
+  wrapLines,
+  codeFontSize,
+  textMetricsStyle,
+  reviewActions,
+  onBodyHeightChange,
+  testID,
+}: {
+  file: ParsedDiffFile;
+  viewport?: DiffViewport;
+  bodyOffset?: number;
+  layout: "unified" | "split";
+  wrapLines: boolean;
+  codeFontSize: number;
+  textMetricsStyle: TextStyle;
+  reviewActions?: InlineReviewActions;
+  onBodyHeightChange?: (file: ParsedDiffFile, height: number) => void;
+  testID?: string;
+}) {
+  const [scrollViewWidth, setScrollViewWidth] = useState(0);
+  const [bodyWidth, setBodyWidth] = useState(0);
+  const [hoveredReviewTargetKey, setHoveredReviewTargetKey] = useState<string | null>(null);
+  const { t } = useTranslation();
+  const canRenderRows = file.status !== "too_large" && file.status !== "binary";
+  const splitRows = useMemo(
+    () => (canRenderRows && layout === "split" ? getCachedSplitDiffRows(file) : []),
+    [canRenderRows, file, layout],
+  );
+  const unifiedLines = useMemo(
+    () => (canRenderRows && layout === "unified" ? getCachedUnifiedDiffLines(file) : []),
+    [canRenderRows, file, layout],
+  );
+  const rowHeights = useMemo(() => {
+    const lineHeight = getNumericLineHeight(textMetricsStyle) ?? Math.round(codeFontSize * 1.5);
+    if (layout === "split") {
+      return splitRows.map((row) => {
+        if (row.kind === "header") {
+          return lineHeight;
+        }
+        return (
+          lineHeight +
+          (getSplitInlineReviewThreadState({
+            left: row.left?.reviewTarget,
+            right: row.right?.reviewTarget,
+            reviewActions,
+          })?.height ?? 0)
+        );
+      });
+    }
+    return unifiedLines.map(
+      ({ reviewTarget }) =>
+        lineHeight + (getInlineReviewThreadState({ reviewTarget, reviewActions })?.height ?? 0),
+    );
+  }, [codeFontSize, layout, reviewActions, splitRows, textMetricsStyle, unifiedLines]);
+  const rowWindow = useDiffRowWindow({
+    viewport,
+    bodyOffset,
+    rowHeights,
+    enabled: Boolean(viewport) && canRenderRows && !wrapLines,
+  });
+  const visibleUnifiedLines = useMemo(
+    () =>
+      unifiedLines
+        .slice(rowWindow.startIndex, rowWindow.endIndex)
+        .map((entry, index) => ({ entry, index: rowWindow.startIndex + index })),
+    [rowWindow.endIndex, rowWindow.startIndex, unifiedLines],
+  );
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      setBodyWidth(event.nativeEvent.layout.width);
+      onBodyHeightChange?.(file, event.nativeEvent.layout.height);
+    },
+    [file, onBodyHeightChange],
+  );
+
+  const availableWidth = bodyWidth > 0 ? bodyWidth : scrollViewWidth;
+  const linesContainerRowStyle = useMemo(
+    () => [
+      styles.linesContainer,
+      availableWidth > 0 && inlineUnistylesStyle({ minWidth: availableWidth }),
+    ],
+    [availableWidth],
+  );
+
+  return (
+    <View
+      style={[styles.fileSectionBodyContainer, styles.fileSectionBorder]}
+      onLayout={handleLayout}
+      testID={testID}
+    >
+      {(() => {
+        if (file.status === "too_large" || file.status === "binary") {
+          return (
+            <View style={styles.statusMessageContainer}>
+              <Text style={styles.statusMessageText}>
+                {file.status === "binary"
+                  ? t("workspace.git.diff.binaryFile")
+                  : t("workspace.git.diff.tooLarge")}
+              </Text>
+            </View>
+          );
+        }
+
+        let maxLineNo = 0;
+        for (const hunk of file.hunks) {
+          maxLineNo = Math.max(
+            maxLineNo,
+            hunk.oldStart + hunk.oldCount,
+            hunk.newStart + hunk.newCount,
+          );
+        }
+        const gutterWidth = lineNumberGutterWidth(maxLineNo, codeFontSize);
+
+        if (layout === "split") {
+          return (
+            <View style={[styles.diffContent, styles.splitRow]} dataSet={CODE_SURFACE_DATASET}>
+              <SplitDiffColumn
+                rows={splitRows}
+                rowWindow={rowWindow}
+                side="left"
+                gutterWidth={gutterWidth}
+                wrapLines={wrapLines}
+                textMetricsStyle={textMetricsStyle}
+                reviewActions={reviewActions}
+              />
+              <SplitDiffColumn
+                rows={splitRows}
+                rowWindow={rowWindow}
+                side="right"
+                gutterWidth={gutterWidth}
+                wrapLines={wrapLines}
+                textMetricsStyle={textMetricsStyle}
+                reviewActions={reviewActions}
+                showDivider
+              />
+            </View>
+          );
+        }
+
+        if (wrapLines) {
+          return (
+            <View style={styles.diffContent} dataSet={CODE_SURFACE_DATASET}>
+              <View style={styles.linesContainer}>
+                <DiffRowSpacer height={rowWindow.beforeHeight} />
+                {visibleUnifiedLines.map(
+                  ({ entry: { line, lineNumber, key, reviewTarget }, index }) => (
+                    <View key={key} testID={`diff-wrapped-row-${index}`}>
+                      <DiffLineView
+                        line={line}
+                        lineNumber={lineNumber}
+                        gutterWidth={gutterWidth}
+                        wrapLines={wrapLines}
+                        textMetricsStyle={textMetricsStyle}
+                        reviewTarget={reviewTarget}
+                        reviewActions={reviewActions}
+                      />
+                      <InlineReviewRow
+                        reviewTarget={reviewTarget}
+                        reviewActions={reviewActions}
+                        gutterWidth={gutterWidth}
+                      />
+                    </View>
+                  ),
+                )}
+                <DiffRowSpacer height={rowWindow.afterHeight} />
+              </View>
+            </View>
+          );
+        }
+
+        const textViewportWidth =
+          scrollViewWidth > 0 ? scrollViewWidth : Math.max(0, bodyWidth - gutterWidth);
+        return (
+          <View style={[styles.diffContent, styles.diffContentRow]} dataSet={CODE_SURFACE_DATASET}>
+            <View style={styles.gutterColumn}>
+              <DiffRowSpacer height={rowWindow.beforeHeight} />
+              {visibleUnifiedLines.map(
+                ({ entry: { line, lineNumber, key, reviewTarget }, index }) => (
+                  <View key={key} testID={`diff-gutter-row-${index}`}>
+                    <DiffGutterCell
+                      lineNumber={lineNumber}
+                      type={line.type}
+                      gutterWidth={gutterWidth}
+                      textMetricsStyle={textMetricsStyle}
+                      reviewTarget={reviewTarget}
+                      reviewActions={reviewActions}
+                      isLineHovered={
+                        reviewTarget?.key !== undefined &&
+                        hoveredReviewTargetKey === reviewTarget.key
+                      }
+                      textTestID={`diff-gutter-text-${index}`}
+                      actionTestID={`diff-gutter-action-${index}`}
+                    />
+                    <InlineReviewGutterSpacer
+                      reviewTarget={reviewTarget}
+                      reviewActions={reviewActions}
+                      gutterWidth={gutterWidth}
+                    />
+                  </View>
+                ),
+              )}
+              <DiffRowSpacer height={rowWindow.afterHeight} />
+            </View>
+            <DiffScroll
+              scrollViewWidth={scrollViewWidth}
+              onScrollViewWidthChange={setScrollViewWidth}
+              style={styles.splitColumnScroll}
+              contentContainerStyle={styles.diffContentInner}
+            >
+              <View style={linesContainerRowStyle}>
+                <DiffRowSpacer height={rowWindow.beforeHeight} />
+                {visibleUnifiedLines.map(({ entry: { line, key, reviewTarget }, index }) => (
+                  <View key={key} testID={`diff-code-row-${index}`}>
+                    <DiffTextLine
+                      line={line}
+                      wrapLines={false}
+                      textMetricsStyle={textMetricsStyle}
+                      reviewTarget={reviewTarget}
+                      reviewActions={reviewActions}
+                      hoverTargetKey={reviewTarget?.key ?? null}
+                      onHoverTargetChange={setHoveredReviewTargetKey}
+                      textTestID={`diff-code-text-${index}`}
+                    />
+                    <InlineReviewThreadContent
+                      reviewTarget={reviewTarget}
+                      reviewActions={reviewActions}
+                      viewportWidth={textViewportWidth}
+                      pinToViewport
+                    />
+                  </View>
+                ))}
+                <DiffRowSpacer height={rowWindow.afterHeight} />
+              </View>
+            </DiffScroll>
+          </View>
+        );
+      })()}
+    </View>
+  );
+}
+
+interface GitDiffPaneProps {
   serverId: string;
   workspaceId?: string | null;
   cwd: string;
   enabled?: boolean;
   host: "explorer" | "panel";
-  focusPath?: string;
-  focusRequestId?: number;
   onOpenFile?: (path: string) => void;
   onAddToChat?: (path: string) => void;
 }
@@ -176,29 +1590,17 @@ const ThemedAlignJustify = withUnistyles(AlignJustify);
 const ThemedColumns2 = withUnistyles(Columns2);
 const ThemedPilcrow = withUnistyles(Pilcrow);
 const ThemedWrapText = withUnistyles(WrapText);
-const ThemedFolderTree = withUnistyles(FolderTree);
 const ThemedListChevronsDownUp = withUnistyles(ListChevronsDownUp);
 const ThemedListChevronsUpDown = withUnistyles(ListChevronsUpDown);
+const ThemedFolderTree = withUnistyles(FolderTree);
+const ThemedList = withUnistyles(List);
 const ThemedMaximize2 = withUnistyles(Maximize2);
 const ThemedChevronDown = withUnistyles(ChevronDown);
-const ThemedMoreHorizontal = withUnistyles(MoreHorizontal);
 const DIFF_OPTIONS_WHITESPACE_ICON = (
   <ThemedPilcrow size={14} uniProps={foregroundMutedIconColorMapping} />
 );
 const DIFF_OPTIONS_WRAP_ICON = (
   <ThemedWrapText size={14} uniProps={foregroundMutedIconColorMapping} />
-);
-const DIFF_OPTIONS_SPLIT_ICON = (
-  <ThemedColumns2 size={14} uniProps={foregroundMutedIconColorMapping} />
-);
-const DIFF_OPTIONS_COLLAPSE_ICON = (
-  <ThemedListChevronsDownUp size={14} uniProps={foregroundMutedIconColorMapping} />
-);
-const DIFF_OPTIONS_EXPAND_ICON = (
-  <ThemedListChevronsUpDown size={14} uniProps={foregroundMutedIconColorMapping} />
-);
-const DIFF_OPTIONS_CHANGES_TAB_ICON = (
-  <ThemedMaximize2 size={14} uniProps={foregroundMutedIconColorMapping} />
 );
 
 interface DiffLayoutToggleProps {
@@ -208,6 +1610,7 @@ interface DiffLayoutToggleProps {
   toggleStyle?: PressableStyleFn;
   onToggle: () => void;
 }
+
 export function DiffLayoutToggle({
   layout,
   isMobile,
@@ -216,7 +1619,7 @@ export function DiffLayoutToggle({
   onToggle,
 }: DiffLayoutToggleProps) {
   const defaultToggleStyle = useMemo(
-    () => buildToggleButtonStyle(false, styles.toolbarIconButton),
+    () => buildToggleButtonStyle(false, styles.expandAllButton),
     [],
   );
   const { t } = useTranslation();
@@ -251,6 +1654,12 @@ export function DiffLayoutToggle({
   );
 }
 
+interface ChangesTabToggleProps {
+  isMobile: boolean;
+  selected: boolean;
+  onPress: () => void;
+}
+
 function resolveChangesTabOpen(host: "explorer" | "panel", changesTabOpen: boolean): boolean {
   return host === "explorer" ? changesTabOpen : false;
 }
@@ -260,6 +1669,18 @@ function resolveChangesFilePress(
   onChangesFilePress: ((path?: string) => void) | undefined,
 ): ((path?: string) => void) | undefined {
   return host === "explorer" ? onChangesFilePress : undefined;
+}
+
+function ChangesTabToggleForHost({
+  host,
+  isMobile,
+  selected,
+  onPress,
+}: ChangesTabToggleProps & { host: "explorer" | "panel" }) {
+  if (host === "panel") {
+    return null;
+  }
+  return <ChangesTabToggle isMobile={isMobile} selected={selected} onPress={onPress} />;
 }
 
 interface DiffModeMenuProps {
@@ -316,30 +1737,29 @@ export function DiffModeMenu({
   );
 }
 
-interface DesktopTreeToggleProps {
-  visible: boolean;
-  toggleStyle?: PressableStyleFn;
-  onToggle: () => void;
-}
-
-function DesktopTreeToggle({ visible, toggleStyle, onToggle }: DesktopTreeToggleProps) {
+function ChangesTabToggle({ isMobile, selected, onPress }: ChangesTabToggleProps) {
   const { t } = useTranslation();
-  const defaultToggleStyle = useMemo(
-    () => buildToggleButtonStyle(visible, styles.toolbarIconButton),
-    [visible],
+  const buttonStyle = useMemo(
+    () => buildToggleButtonStyle(selected, styles.expandAllButton),
+    [selected],
   );
-  const label = t(visible ? "workspace.git.diff.hideTreeView" : "workspace.git.diff.showTreeView");
+  const label = t(
+    selected ? "workspace.git.diff.closeChangesTab" : "workspace.git.diff.openChangesTab",
+  );
+  if (isMobile) {
+    return null;
+  }
   return (
     <Tooltip delayDuration={300}>
       <TooltipTrigger asChild>
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={label}
-          testID="changes-toggle-tree"
-          style={toggleStyle ?? defaultToggleStyle}
-          onPress={onToggle}
+          testID="changes-open-tab"
+          onPress={onPress}
+          style={buttonStyle}
         >
-          <ThemedFolderTree size={14} uniProps={foregroundMutedIconColorMapping} />
+          <ThemedMaximize2 size={14} uniProps={foregroundMutedIconColorMapping} />
         </Pressable>
       </TooltipTrigger>
       <TooltipContent side="bottom">
@@ -349,164 +1769,149 @@ function DesktopTreeToggle({ visible, toggleStyle, onToggle }: DesktopTreeToggle
   );
 }
 
-interface ChangesToolbarProps {
-  branchName: string | null;
-  allFilesCollapsed: boolean;
-  canUseSplitLayout: boolean;
-  changesTabOpen: boolean;
-  committedDescription?: string;
-  cwd: string;
-  desktopTreeVisible: boolean;
-  diffMode: "uncommitted" | "base";
-  gitActions: GitActions;
-  hasFiles: boolean;
-  hideWhitespace: boolean;
-  host: "explorer" | "panel";
+interface DiffViewModeToggleProps {
+  viewMode: "flat" | "tree";
   isMobile: boolean;
-  isRefreshing: boolean;
-  layout: "unified" | "split";
-  overflowToggleStyle: PressableStyleFn;
-  refreshSupported: boolean;
-  selectedDiffStat: { additions: number; deletions: number } | null;
-  serverId: string;
-  treeToggleStyle: PressableStyleFn;
-  workspaceId?: string | null;
-  wrapLines: boolean;
-  onRefresh: () => void;
-  onCollapseAll: () => void;
-  onExpandAll: () => void;
-  onSelectBase: () => void;
-  onSelectUncommitted: () => void;
-  onToggleChangesTab: () => void;
-  onToggleDesktopTree: () => void;
-  onToggleHideWhitespace: () => void;
-  onToggleLayout: () => void;
-  onToggleWrapLines: () => void;
+  toggleStyle?: PressableStyleFn;
+  onToggle: () => void;
 }
 
-// One row: the diff-mode and branch pickers lead, the git actions and the
-// overflow menu trail. The tree toggle is the only icon action that stays out
-// of the menu, and it only exists on desktop, so a phone-width row holds two
-// pickers, the split button, and the trigger without wrapping.
-function ChangesToolbar(props: ChangesToolbarProps) {
-  const {
-    branchName,
-    committedDescription,
-    cwd,
-    desktopTreeVisible,
-    diffMode,
-    gitActions,
-    hasFiles,
-    isMobile,
-    selectedDiffStat,
-    serverId,
-    treeToggleStyle,
-    workspaceId,
-    onSelectBase,
-    onSelectUncommitted,
-    onToggleDesktopTree,
-  } = props;
+export function DiffViewModeToggle({
+  viewMode,
+  isMobile,
+  toggleStyle,
+  onToggle,
+}: DiffViewModeToggleProps) {
+  const { t } = useTranslation();
+  const defaultToggleStyle = useMemo(
+    () => buildToggleButtonStyle(viewMode === "tree", styles.expandAllButton),
+    [viewMode],
+  );
+  const label =
+    viewMode === "flat"
+      ? t("workspace.git.diff.showTreeView")
+      : t("workspace.git.diff.showFlatView");
   return (
-    <View style={styles.changesToolbar} testID="changes-header">
-      <View style={styles.changesToolbarIdentity}>
-        <DiffModeMenu
-          diffMode={diffMode}
-          committedDescription={committedDescription}
-          onSelectUncommitted={onSelectUncommitted}
-          onSelectBase={onSelectBase}
-        />
-        <BranchSwitcher
-          currentBranchName={branchName}
-          serverId={serverId}
-          workspaceId={workspaceId ?? cwd}
-          workspaceDirectory={cwd}
-          isGitCheckout
-          testID="changes-branch-switcher"
-        />
-        {!isMobile && selectedDiffStat ? (
-          <DiffStat
-            additions={selectedDiffStat.additions}
-            deletions={selectedDiffStat.deletions}
-            testID="changes-selected-diff-stat"
-          />
-        ) : null}
-      </View>
-      <View style={styles.changesToolbarControls}>
-        {!isMobile && hasFiles ? (
-          <DesktopTreeToggle
-            visible={desktopTreeVisible}
-            toggleStyle={treeToggleStyle}
-            onToggle={onToggleDesktopTree}
-          />
-        ) : null}
-        {isMobile ? <GitActionsSplitButton gitActions={gitActions} /> : null}
-        <ChangesOptionsMenu {...props} />
-      </View>
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={label}
+          testID="changes-toggle-view-mode"
+          style={toggleStyle ?? defaultToggleStyle}
+          onPress={onToggle}
+        >
+          {viewMode === "flat" ? (
+            <ThemedFolderTree
+              size={isMobile ? 18 : 14}
+              uniProps={foregroundMutedIconColorMapping}
+            />
+          ) : (
+            <ThemedList size={isMobile ? 18 : 14} uniProps={foregroundMutedIconColorMapping} />
+          )}
+        </Pressable>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <Text style={styles.tooltipText}>{label}</Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+interface DiffFilesToolbarProps {
+  allFileDiffsExpanded: boolean;
+  isMobile: boolean;
+  testID?: string;
+  expandAllToggleStyle?: PressableStyleFn;
+  onToggleExpandAll: () => void;
+}
+
+export function DiffFilesToolbar({
+  allFileDiffsExpanded,
+  isMobile,
+  testID,
+  expandAllToggleStyle,
+  onToggleExpandAll,
+}: DiffFilesToolbarProps) {
+  const defaultToggleStyle = useMemo(() => buildExpandAllButtonStyle(), []);
+  const { t } = useTranslation();
+  const expandAllLabel = allFileDiffsExpanded
+    ? t("workspace.git.diff.collapseAll")
+    : t("workspace.git.diff.expandAll");
+  return (
+    <View style={styles.diffStatusButtons}>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={expandAllLabel}
+            testID={testID}
+            style={expandAllToggleStyle ?? defaultToggleStyle}
+            onPress={onToggleExpandAll}
+          >
+            {allFileDiffsExpanded ? (
+              <ThemedListChevronsDownUp
+                size={isMobile ? 18 : 14}
+                uniProps={foregroundMutedIconColorMapping}
+              />
+            ) : (
+              <ThemedListChevronsUpDown
+                size={isMobile ? 18 : 14}
+                uniProps={foregroundMutedIconColorMapping}
+              />
+            )}
+          </Pressable>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <Text style={styles.tooltipText}>{expandAllLabel}</Text>
+        </TooltipContent>
+      </Tooltip>
     </View>
   );
 }
 
-type ChangesOptionsMenuProps = Pick<
-  ChangesToolbarProps,
-  | "allFilesCollapsed"
-  | "canUseSplitLayout"
-  | "changesTabOpen"
-  | "hasFiles"
-  | "hideWhitespace"
-  | "host"
-  | "isMobile"
-  | "isRefreshing"
-  | "layout"
-  | "overflowToggleStyle"
-  | "refreshSupported"
-  | "wrapLines"
-  | "onCollapseAll"
-  | "onExpandAll"
-  | "onRefresh"
-  | "onToggleChangesTab"
-  | "onToggleHideWhitespace"
-  | "onToggleLayout"
-  | "onToggleWrapLines"
->;
+interface DiffOptionsMenuProps {
+  brand?: string;
+  hideWhitespace: boolean;
+  isMobile: boolean;
+  isRefreshing?: boolean;
+  overflowToggleStyle?: PressableStyleFn;
+  refreshSupported?: boolean;
+  testIDPrefix?: string;
+  wrapLines: boolean;
+  onRefresh?: () => void;
+  onToggleHideWhitespace: () => void;
+  onToggleWrapLines: () => void;
+}
 
-function ChangesOptionsMenu({
-  allFilesCollapsed,
-  canUseSplitLayout,
-  changesTabOpen,
-  hasFiles,
+export function DiffOptionsMenu({
+  brand,
   hideWhitespace,
-  host,
   isMobile,
-  isRefreshing,
-  layout,
+  isRefreshing = false,
   overflowToggleStyle,
-  refreshSupported,
+  refreshSupported = false,
+  testIDPrefix = "changes",
   wrapLines,
-  onCollapseAll,
-  onExpandAll,
   onRefresh,
-  onToggleChangesTab,
   onToggleHideWhitespace,
-  onToggleLayout,
   onToggleWrapLines,
-}: ChangesOptionsMenuProps) {
+}: DiffOptionsMenuProps) {
   const { t } = useTranslation();
-  const optionsLabel = t("workspace.git.diff.options");
-  const collapseLabel = t(
-    allFilesCollapsed ? "workspace.git.diff.expandAllFiles" : "workspace.git.diff.collapseAllFiles",
-  );
-  const changesTabLabel = t(
-    changesTabOpen ? "workspace.git.diff.closeChangesTab" : "workspace.git.diff.openChangesTab",
-  );
+  const defaultToggleStyle = useMemo(() => buildOverflowButtonStyle(), []);
   const whitespaceLabel = hideWhitespace
     ? t("workspace.git.diff.showWhitespace")
     : t("workspace.git.diff.hideWhitespace");
   const wrapLinesLabel = wrapLines
     ? t("workspace.git.diff.scrollLongLines")
     : t("workspace.git.diff.wrapLongLines");
-  const refreshLabel = isRefreshing
-    ? t("workspace.git.diff.refreshing")
-    : t("workspace.git.diff.refresh");
+  const optionsLabel = t("workspace.git.diff.options");
+  let refreshLabel = t("workspace.git.diff.refresh");
+  if (isRefreshing) {
+    refreshLabel = t("workspace.git.diff.refreshing");
+  } else if (brand) {
+    refreshLabel = t("workspace.git.diff.refreshState", { brand });
+  }
   const refreshIcon = useMemo(
     () =>
       isRefreshing ? (
@@ -517,9 +1922,6 @@ function ChangesOptionsMenu({
     [isRefreshing],
   );
 
-  const showChangesTab = host === "explorer" && !isMobile;
-  const showLayout = canUseSplitLayout && !changesTabOpen;
-
   return (
     <DropdownMenu>
       <Tooltip delayDuration={300}>
@@ -527,10 +1929,10 @@ function ChangesOptionsMenu({
           <DropdownMenuTrigger
             accessibilityRole="button"
             accessibilityLabel={optionsLabel}
-            testID="changes-options-menu"
-            style={overflowToggleStyle}
+            testID={`${testIDPrefix}-options-menu`}
+            style={overflowToggleStyle ?? defaultToggleStyle}
           >
-            <ThemedMoreHorizontal
+            <ThemedChevronDown
               size={isMobile ? 18 : 14}
               uniProps={foregroundMutedIconColorMapping}
             />
@@ -540,40 +1942,11 @@ function ChangesOptionsMenu({
           <Text style={styles.tooltipText}>{optionsLabel}</Text>
         </TooltipContent>
       </Tooltip>
-      <DropdownMenuContent align="end" width={240} testID="changes-options-menu-content">
-        {hasFiles ? (
-          <DropdownMenuItem
-            leading={allFilesCollapsed ? DIFF_OPTIONS_EXPAND_ICON : DIFF_OPTIONS_COLLAPSE_ICON}
-            testID="changes-toggle-collapse-all"
-            onSelect={allFilesCollapsed ? onExpandAll : onCollapseAll}
-          >
-            {collapseLabel}
-          </DropdownMenuItem>
-        ) : null}
-        {showChangesTab ? (
-          <DropdownMenuItem
-            leading={DIFF_OPTIONS_CHANGES_TAB_ICON}
-            testID="changes-open-tab"
-            onSelect={onToggleChangesTab}
-          >
-            {changesTabLabel}
-          </DropdownMenuItem>
-        ) : null}
-        {hasFiles || showChangesTab ? <DropdownMenuSeparator /> : null}
-        {showLayout ? (
-          <DropdownMenuItem
-            leading={DIFF_OPTIONS_SPLIT_ICON}
-            selected={layout === "split"}
-            testID="changes-toggle-layout"
-            onSelect={onToggleLayout}
-          >
-            {t("workspace.git.diff.split")}
-          </DropdownMenuItem>
-        ) : null}
+      <DropdownMenuContent align="end" width={240} testID={`${testIDPrefix}-options-menu-content`}>
         <DropdownMenuItem
           leading={DIFF_OPTIONS_WHITESPACE_ICON}
           selected={hideWhitespace}
-          testID="changes-toggle-whitespace"
+          testID={`${testIDPrefix}-toggle-whitespace`}
           onSelect={onToggleHideWhitespace}
         >
           {whitespaceLabel}
@@ -581,18 +1954,18 @@ function ChangesOptionsMenu({
         <DropdownMenuItem
           leading={DIFF_OPTIONS_WRAP_ICON}
           selected={wrapLines}
-          testID="changes-toggle-wrap-lines"
+          testID={`${testIDPrefix}-toggle-wrap-lines`}
           onSelect={onToggleWrapLines}
         >
           {wrapLinesLabel}
         </DropdownMenuItem>
-        {refreshSupported ? (
+        {refreshSupported && onRefresh ? (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               leading={refreshIcon}
               disabled={isRefreshing}
-              testID="changes-refresh"
+              testID={`${testIDPrefix}-refresh`}
               onSelect={onRefresh}
             >
               {refreshLabel}
@@ -606,7 +1979,56 @@ function ChangesOptionsMenu({
 
 const ThemedRotateCw = withUnistyles(RotateCw);
 
+type DiffFlatItemLayoutGetter = NonNullable<FlatListProps<DiffFlatItem>["getItemLayout"]>;
 const EMPTY_PATH_LIST: string[] = [];
+
+interface DiffFileMetrics {
+  contentLength: number;
+  splitRows?: SplitDiffRow[];
+  splitLineCount?: number;
+  unifiedLines?: ReturnType<typeof buildUnifiedDiffLines>;
+  unifiedLineCount: number;
+}
+
+const diffFileMetricsCache = new WeakMap<ParsedDiffFile, DiffFileMetrics>();
+
+function getDiffFileMetrics(file: ParsedDiffFile): DiffFileMetrics {
+  const cached = diffFileMetricsCache.get(file);
+  if (cached) {
+    return cached;
+  }
+  let contentLength = 0;
+  let unifiedLineCount = 0;
+  for (const hunk of file.hunks) {
+    unifiedLineCount += hunk.lines.length;
+    for (const line of hunk.lines) {
+      contentLength += line.content.length;
+    }
+  }
+  const metrics = { contentLength, unifiedLineCount };
+  diffFileMetricsCache.set(file, metrics);
+  return metrics;
+}
+
+function getSplitDiffLineCount(file: ParsedDiffFile): number {
+  const metrics = getDiffFileMetrics(file);
+  if (metrics.splitLineCount === undefined) {
+    metrics.splitLineCount = getCachedSplitDiffRows(file).length;
+  }
+  return metrics.splitLineCount;
+}
+
+function getCachedSplitDiffRows(file: ParsedDiffFile): SplitDiffRow[] {
+  const metrics = getDiffFileMetrics(file);
+  metrics.splitRows ??= buildSplitDiffRows(file);
+  return metrics.splitRows;
+}
+
+function getCachedUnifiedDiffLines(file: ParsedDiffFile): ReturnType<typeof buildUnifiedDiffLines> {
+  const metrics = getDiffFileMetrics(file);
+  metrics.unifiedLines ??= buildUnifiedDiffLines(file);
+  return metrics.unifiedLines;
+}
 
 function computeEmptyMessage(
   hideWhitespace: boolean,
@@ -703,6 +2125,615 @@ function DiffBodyContent({
   return children;
 }
 
+interface SharedDiffViewProps {
+  files: ParsedDiffFile[];
+  displayPreferences: {
+    layout: "unified" | "split";
+    wrapLines: boolean;
+    codeFontSize: number;
+    monoFontFamily: string;
+  };
+  mode:
+    | {
+        kind: "working_tree";
+        viewMode: "flat" | "tree";
+        expandedPaths: string[];
+        collapsedFolders: string[];
+        reviewActions?: InlineReviewActions;
+        onFilePress?: (path: string) => void;
+        workspaceFileDragScope?: { serverId: string; workspaceId: string };
+        onOpenFile?: (path: string) => void;
+        onAddToChat?: (path: string) => void;
+        onCopyPath?: (path: string) => void;
+        onCopyRelativePath?: (path: string) => void;
+        onReveal?: (path: string) => void;
+        revealTargetName?: string;
+        onDownload?: (path: string) => void;
+        onDuplicate?: (path: string) => void;
+        onRevert?: (path: string, oldPath?: string) => void;
+        onExpandedPathsChange: (paths: string[]) => void;
+        onCollapsedFoldersChange: (paths: string[]) => void;
+      }
+    | {
+        kind: "working_tab";
+        expandedPaths: string[] | null;
+        reviewActions: InlineReviewActions;
+        focusPath?: string;
+        focusRequestId?: number;
+        onExpandedPathsChange: (paths: string[]) => void;
+      }
+    | {
+        kind: "commit";
+      };
+}
+
+type WorkingTreeDiffMode = Extract<SharedDiffViewProps["mode"], { kind: "working_tree" }>;
+
+export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffViewProps) {
+  const isCompact = useIsCompactFormFactor();
+  const { layout, wrapLines, codeFontSize, monoFontFamily } = displayPreferences;
+  const diffBodyLineHeight = Math.round(codeFontSize * 1.5);
+  const typographyKey = [monoFontFamily, codeFontSize, diffBodyLineHeight].join(":");
+  const textMetricsStyle = useMemo<TextStyle>(() => {
+    const trimmedMonoFontFamily = monoFontFamily.trim();
+    return {
+      fontSize: codeFontSize,
+      lineHeight: diffBodyLineHeight,
+      ...(trimmedMonoFontFamily ? { fontFamily: trimmedMonoFontFamily } : null),
+    };
+  }, [codeFontSize, diffBodyLineHeight, monoFontFamily]);
+  const viewMode = mode.kind === "working_tree" ? mode.viewMode : "flat";
+  const expandedPathsArray = useMemo(() => {
+    if (mode.kind === "working_tree") {
+      return mode.expandedPaths;
+    }
+    if (mode.kind === "working_tab" && mode.expandedPaths !== null) {
+      return mode.expandedPaths;
+    }
+    return files.map((file) => file.path);
+  }, [files, mode]);
+  const expandedPaths = useMemo(() => new Set(expandedPathsArray), [expandedPathsArray]);
+  const collapsedFoldersArray =
+    mode.kind === "working_tree" ? mode.collapsedFolders : EMPTY_PATH_LIST;
+  const collapsedFolders = useMemo(() => new Set(collapsedFoldersArray), [collapsedFoldersArray]);
+  const stickyHeaders = mode.kind !== "commit";
+  const interactive = mode.kind !== "commit";
+  const reviewActions = mode.kind === "commit" ? undefined : mode.reviewActions;
+  const onFilePress = mode.kind === "working_tree" ? mode.onFilePress : undefined;
+  const focusPath = mode.kind === "working_tab" ? mode.focusPath : undefined;
+  const focusRequestId = mode.kind === "working_tab" ? mode.focusRequestId : undefined;
+  const onOpenFile = mode.kind === "working_tree" ? mode.onOpenFile : undefined;
+  const onAddToChat = mode.kind === "working_tree" ? mode.onAddToChat : undefined;
+  const workspaceFileDragScope =
+    mode.kind === "working_tree" ? mode.workspaceFileDragScope : undefined;
+  const onCopyPath = mode.kind === "working_tree" ? mode.onCopyPath : undefined;
+  const onCopyRelativePath = mode.kind === "working_tree" ? mode.onCopyRelativePath : undefined;
+  const onReveal = mode.kind === "working_tree" ? mode.onReveal : undefined;
+  const revealTargetName = mode.kind === "working_tree" ? mode.revealTargetName : undefined;
+  const onDownload = mode.kind === "working_tree" ? mode.onDownload : undefined;
+  const onDuplicate = mode.kind === "working_tree" ? mode.onDuplicate : undefined;
+  const onRevert = mode.kind === "working_tree" ? mode.onRevert : undefined;
+  // Keep selection independent from expansion so future keyboard actions (such as R to rename)
+  // can target the current VCS file or folder without changing its open state.
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const handleSelectPath = useCallback((path: string) => setSelectedPath(path), []);
+  const compressedTree = useMemo(() => compressSingleChildChains(buildDiffTree(files)), [files]);
+  const allFolderPaths = useMemo(() => collectDirPaths(compressedTree), [compressedTree]);
+  const allFolderPathSet = useMemo(() => new Set(allFolderPaths), [allFolderPaths]);
+  useEffect(() => {
+    if (
+      selectedPath &&
+      !allFolderPathSet.has(selectedPath) &&
+      !files.some((file) => file.path === selectedPath)
+    ) {
+      setSelectedPath(null);
+    }
+  }, [allFolderPathSet, files, selectedPath]);
+  const effectiveCollapsedFolders = useMemo(
+    () => new Set(Array.from(collapsedFolders).filter((path) => allFolderPathSet.has(path))),
+    [allFolderPathSet, collapsedFolders],
+  );
+  const diffListRef = useRef<FlatList<DiffFlatItem>>(null);
+  const diffViewport = useMemo(() => createDiffViewport(), []);
+  useEffect(() => () => diffViewport.dispose(), [diffViewport]);
+  const scrollbar = useOverlayFlatListScrollbar(diffListRef, { enabled: !isCompact });
+  const { onLayout: updateScrollbarLayout, onScroll: updateScrollbarOffset } = scrollbar;
+  const consumedFocusRequestRef = useRef<string | null>(null);
+  const pendingFocusRequestRef = useRef<string | null>(null);
+  const diffListScrollOffsetRef = useRef(0);
+  const diffListViewportHeightRef = useRef(0);
+  const headerHeightByPathRef = useRef<Record<string, number>>({});
+  const bodyHeightByKeyRef = useRef<Record<string, number>>({});
+  const folderRowHeightRef = useRef<number>(0);
+  const defaultHeaderHeightRef = useRef<number>(44);
+  const [heightVersion, setHeightVersion] = useState(0);
+  const heightVersionFrameRef = useRef<number | null>(null);
+  const scheduleHeightVersionUpdate = useCallback(() => {
+    if (heightVersionFrameRef.current !== null) {
+      return;
+    }
+    heightVersionFrameRef.current = requestAnimationFrame(() => {
+      heightVersionFrameRef.current = null;
+      setHeightVersion((version) => version + 1);
+    });
+  }, []);
+  useEffect(
+    () => () => {
+      if (heightVersionFrameRef.current !== null) {
+        cancelAnimationFrame(heightVersionFrameRef.current);
+      }
+    },
+    [],
+  );
+  const diffBodyChromeHeight = BORDER_WIDTH[1] * 2;
+  const statusBodyHeightEstimate = diffBodyChromeHeight + SPACING[4] * 2 + diffBodyLineHeight;
+
+  const { flatItems, stickyHeaderIndices } = useMemo(() => {
+    const { items, stickyHeaderIndices: stickyIndices } = buildDiffFlatItems({
+      files,
+      viewMode,
+      tree: compressedTree,
+      collapsedFolders: effectiveCollapsedFolders,
+      expandedPaths,
+    });
+    return {
+      flatItems: items,
+      stickyHeaderIndices: stickyHeaders ? stickyIndices : [],
+    };
+  }, [compressedTree, effectiveCollapsedFolders, expandedPaths, files, stickyHeaders, viewMode]);
+
+  const getBodyHeightKey = useCallback(
+    (file: ParsedDiffFile): string => {
+      if (file.status === "too_large" || file.status === "binary") {
+        return `${layout}:${wrapLines ? "wrap" : "scroll"}:${typographyKey}:${file.path}:${file.status}`;
+      }
+
+      const metrics = getDiffFileMetrics(file);
+      return [
+        layout,
+        wrapLines ? "wrap" : "scroll",
+        typographyKey,
+        file.path,
+        file.status ?? "ok",
+        file.additions,
+        file.deletions,
+        file.hunks.length,
+        metrics.unifiedLineCount,
+        metrics.contentLength,
+      ].join(":");
+    },
+    [layout, typographyKey, wrapLines],
+  );
+
+  const estimateBodyHeight = useCallback(
+    (file: ParsedDiffFile): number => {
+      if (file.status === "too_large" || file.status === "binary") {
+        return statusBodyHeightEstimate;
+      }
+
+      const lineCount =
+        layout === "split"
+          ? getSplitDiffLineCount(file)
+          : getDiffFileMetrics(file).unifiedLineCount;
+      return diffBodyChromeHeight + lineCount * diffBodyLineHeight;
+    },
+    [diffBodyChromeHeight, diffBodyLineHeight, layout, statusBodyHeightEstimate],
+  );
+
+  const getFlatItemHeight = useCallback(
+    (item: DiffFlatItem): number => {
+      if (item.type === "folder") {
+        return folderRowHeightRef.current || defaultHeaderHeightRef.current;
+      }
+      if (item.type === "header") {
+        return headerHeightByPathRef.current[item.file.path] ?? defaultHeaderHeightRef.current;
+      }
+      const bodyHeightKey = getBodyHeightKey(item.file);
+      return bodyHeightByKeyRef.current[bodyHeightKey] ?? estimateBodyHeight(item.file);
+    },
+    [estimateBodyHeight, getBodyHeightKey],
+  );
+
+  const handleFolderRowHeightChange = useCallback(
+    (height: number) => {
+      if (!Number.isFinite(height) || height <= 0) {
+        return;
+      }
+      const previousHeight = folderRowHeightRef.current;
+      if (previousHeight > 0 && Math.abs(previousHeight - height) <= DIFF_HEIGHT_CHANGE_EPSILON) {
+        return;
+      }
+      folderRowHeightRef.current = height;
+      scheduleHeightVersionUpdate();
+    },
+    [scheduleHeightVersionUpdate],
+  );
+
+  const handleHeaderHeightChange = useCallback(
+    (path: string, height: number) => {
+      if (!Number.isFinite(height) || height <= 0) {
+        return;
+      }
+      const previousHeight = headerHeightByPathRef.current[path];
+      if (
+        previousHeight !== undefined &&
+        Math.abs(previousHeight - height) <= DIFF_HEIGHT_CHANGE_EPSILON
+      ) {
+        return;
+      }
+      headerHeightByPathRef.current[path] = height;
+      defaultHeaderHeightRef.current = height;
+      scheduleHeightVersionUpdate();
+    },
+    [scheduleHeightVersionUpdate],
+  );
+
+  const handleBodyHeightChange = useCallback(
+    (file: ParsedDiffFile, height: number) => {
+      if (!Number.isFinite(height) || height < 0) {
+        return;
+      }
+      const heightKey = getBodyHeightKey(file);
+      const previousHeight = bodyHeightByKeyRef.current[heightKey];
+      if (
+        previousHeight !== undefined &&
+        Math.abs(previousHeight - height) <= DIFF_HEIGHT_CHANGE_EPSILON
+      ) {
+        return;
+      }
+      bodyHeightByKeyRef.current[heightKey] = height;
+      scheduleHeightVersionUpdate();
+    },
+    [getBodyHeightKey, scheduleHeightVersionUpdate],
+  );
+
+  const handleDiffListScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      diffListScrollOffsetRef.current = event.nativeEvent.contentOffset.y;
+      diffViewport.update({
+        top: diffListScrollOffsetRef.current,
+        height: diffListViewportHeightRef.current,
+      });
+      updateScrollbarOffset(event);
+    },
+    [diffViewport, updateScrollbarOffset],
+  );
+
+  const handleDiffListLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const height = event.nativeEvent.layout.height;
+      if (!Number.isFinite(height) || height <= 0) {
+        return;
+      }
+      diffListViewportHeightRef.current = height;
+      diffViewport.update({ top: diffListScrollOffsetRef.current, height });
+      updateScrollbarLayout(event);
+    },
+    [diffViewport, updateScrollbarLayout],
+  );
+
+  const computeItemOffset = useCallback(
+    (predicate: (item: DiffFlatItem) => boolean): number | null => {
+      const index = flatItems.findIndex(predicate);
+      if (index < 0) {
+        return null;
+      }
+      return sumHeightsBefore(flatItems, index, getFlatItemHeight);
+    },
+    [flatItems, getFlatItemHeight],
+  );
+
+  const computeHeaderOffset = useCallback(
+    (path: string): number =>
+      computeItemOffset((item) => item.type === "header" && item.file.path === path) ?? 0,
+    [computeItemOffset],
+  );
+
+  useEffect(() => {
+    if (!focusPath) {
+      return;
+    }
+    const focusRequestKey = `${focusRequestId ?? "initial"}:${focusPath}`;
+    if (
+      consumedFocusRequestRef.current === focusRequestKey ||
+      pendingFocusRequestRef.current === focusRequestKey
+    ) {
+      return;
+    }
+    const hasTarget = flatItems.some(
+      (item) => item.type === "header" && item.file.path === focusPath,
+    );
+    if (!hasTarget) {
+      return;
+    }
+    pendingFocusRequestRef.current = focusRequestKey;
+    const frame = requestAnimationFrame(() => {
+      diffListRef.current?.scrollToOffset({
+        offset: computeHeaderOffset(focusPath),
+        animated: false,
+      });
+      consumedFocusRequestRef.current = focusRequestKey;
+      pendingFocusRequestRef.current = null;
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      if (pendingFocusRequestRef.current === focusRequestKey) {
+        pendingFocusRequestRef.current = null;
+      }
+    };
+  }, [computeHeaderOffset, flatItems, focusPath, focusRequestId]);
+
+  const handleToggleExpanded = useCallback(
+    (path: string) => {
+      if (mode.kind === "commit") {
+        return;
+      }
+      const isCurrentlyExpanded = expandedPaths.has(path);
+      const nextExpanded = !isCurrentlyExpanded;
+      const targetOffset = isCurrentlyExpanded ? computeHeaderOffset(path) : null;
+      const headerHeight = headerHeightByPathRef.current[path] ?? defaultHeaderHeightRef.current;
+      const shouldAnchor =
+        isCurrentlyExpanded &&
+        targetOffset !== null &&
+        shouldAnchorHeaderBeforeCollapse({
+          headerOffset: targetOffset,
+          headerHeight,
+          viewportOffset: diffListScrollOffsetRef.current,
+          viewportHeight: diffListViewportHeightRef.current,
+        });
+
+      if (shouldAnchor && targetOffset !== null) {
+        diffListRef.current?.scrollToOffset({
+          offset: targetOffset,
+          animated: false,
+        });
+      }
+
+      mode.onExpandedPathsChange(
+        nextExpanded
+          ? [...expandedPaths, path]
+          : Array.from(expandedPaths).filter((expandedPath) => expandedPath !== path),
+      );
+    },
+    [computeHeaderOffset, expandedPaths, mode],
+  );
+
+  const handleToggleFolder = useCallback(
+    (dirPath: string) => {
+      if (mode.kind !== "working_tree") {
+        return;
+      }
+      const isCurrentlyCollapsed = effectiveCollapsedFolders.has(dirPath);
+      if (!isCurrentlyCollapsed) {
+        const targetOffset = computeItemOffset(
+          (item) => item.type === "folder" && item.dirPath === dirPath,
+        );
+        const folderHeight = folderRowHeightRef.current || defaultHeaderHeightRef.current;
+        if (
+          targetOffset !== null &&
+          shouldAnchorHeaderBeforeCollapse({
+            headerOffset: targetOffset,
+            headerHeight: folderHeight,
+            viewportOffset: diffListScrollOffsetRef.current,
+            viewportHeight: diffListViewportHeightRef.current,
+          })
+        ) {
+          diffListRef.current?.scrollToOffset({ offset: targetOffset, animated: false });
+        }
+      }
+
+      mode.onCollapsedFoldersChange(
+        isCurrentlyCollapsed
+          ? Array.from(effectiveCollapsedFolders).filter((path) => path !== dirPath)
+          : [...effectiveCollapsedFolders, dirPath],
+      );
+    },
+    [computeItemOffset, effectiveCollapsedFolders, mode],
+  );
+
+  const handleCollapseFolder = useCallback(
+    (dirPath: string) => {
+      if (mode.kind !== "working_tree") {
+        return;
+      }
+      const targetOffset = computeItemOffset(
+        (item) => item.type === "folder" && item.dirPath === dirPath,
+      );
+      const folderHeight = folderRowHeightRef.current || defaultHeaderHeightRef.current;
+      if (
+        targetOffset !== null &&
+        shouldAnchorHeaderBeforeCollapse({
+          headerOffset: targetOffset,
+          headerHeight: folderHeight,
+          viewportOffset: diffListScrollOffsetRef.current,
+          viewportHeight: diffListViewportHeightRef.current,
+        })
+      ) {
+        diffListRef.current?.scrollToOffset({ offset: targetOffset, animated: false });
+      }
+
+      const pathPrefix = `${dirPath}/`;
+      mode.onCollapsedFoldersChange([
+        ...new Set([
+          ...effectiveCollapsedFolders,
+          ...allFolderPaths.filter(
+            (folderPath) => folderPath === dirPath || folderPath.startsWith(pathPrefix),
+          ),
+        ]),
+      ]);
+    },
+    [allFolderPaths, computeItemOffset, effectiveCollapsedFolders, mode],
+  );
+
+  const renderFlatItem = useCallback(
+    ({ item, index }: { item: DiffFlatItem; index: number }) => {
+      if (item.type === "folder") {
+        return (
+          <DiffFolderRow
+            dirPath={item.dirPath}
+            displayName={item.displayName}
+            depth={item.depth}
+            collapsed={item.collapsed}
+            isSelected={selectedPath === item.dirPath}
+            additions={item.additions}
+            deletions={item.deletions}
+            onToggle={handleToggleFolder}
+            onCollapse={handleCollapseFolder}
+            onSelect={handleSelectPath}
+            onHeightChange={handleFolderRowHeightChange}
+            onCopyPath={onCopyPath}
+            onCopyRelativePath={onCopyRelativePath}
+            onReveal={onReveal}
+            revealTargetName={revealTargetName}
+            onDuplicate={onDuplicate}
+            onRevert={onRevert}
+            testID={`diff-folder-${item.dirPath}`}
+          />
+        );
+      }
+      if (item.type === "header") {
+        return (
+          <DiffFileHeader
+            file={item.file}
+            workspaceFileDragScope={workspaceFileDragScope}
+            isExpanded={item.isExpanded}
+            isSelected={selectedPath === item.file.path}
+            depth={item.depth}
+            showDir={viewMode === "flat"}
+            interactive={interactive}
+            onToggle={interactive ? (onFilePress ?? handleToggleExpanded) : undefined}
+            onSelect={handleSelectPath}
+            onOpenFile={onOpenFile}
+            onAddToChat={onAddToChat}
+            onCopyPath={onCopyPath}
+            onCopyRelativePath={onCopyRelativePath}
+            onReveal={onReveal}
+            revealTargetName={revealTargetName}
+            onDownload={onDownload}
+            onDuplicate={onDuplicate}
+            onRevert={onRevert}
+            onHeaderHeightChange={handleHeaderHeightChange}
+            testID={`diff-file-${item.fileIndex}`}
+          />
+        );
+      }
+      return (
+        <DiffFileBody
+          file={item.file}
+          viewport={diffViewport}
+          bodyOffset={sumHeightsBefore(flatItems, index, getFlatItemHeight)}
+          layout={layout}
+          wrapLines={wrapLines}
+          codeFontSize={codeFontSize}
+          textMetricsStyle={textMetricsStyle}
+          reviewActions={reviewActions}
+          onBodyHeightChange={handleBodyHeightChange}
+          testID={`diff-file-${item.fileIndex}-body`}
+        />
+      );
+    },
+    [
+      codeFontSize,
+      diffViewport,
+      flatItems,
+      getFlatItemHeight,
+      handleBodyHeightChange,
+      handleFolderRowHeightChange,
+      handleHeaderHeightChange,
+      handleCollapseFolder,
+      handleSelectPath,
+      handleToggleExpanded,
+      handleToggleFolder,
+      layout,
+      reviewActions,
+      workspaceFileDragScope,
+      textMetricsStyle,
+      viewMode,
+      wrapLines,
+      interactive,
+      onFilePress,
+      onOpenFile,
+      onAddToChat,
+      onCopyPath,
+      onCopyRelativePath,
+      onReveal,
+      revealTargetName,
+      onDownload,
+      onDuplicate,
+      onRevert,
+      selectedPath,
+    ],
+  );
+
+  const flatKeyExtractor = useCallback(
+    (item: DiffFlatItem) =>
+      item.type === "folder" ? `folder-${item.dirPath}` : `${item.type}-${item.file.path}`,
+    [],
+  );
+
+  const getFlatItemLayout = useCallback<DiffFlatItemLayoutGetter>(
+    (_data, index) => {
+      const offset = sumHeightsBefore(flatItems, index, getFlatItemHeight);
+      const item = flatItems[index];
+      const length = item ? getFlatItemHeight(item) : 0;
+      return { length, offset, index };
+    },
+    [flatItems, getFlatItemHeight],
+  );
+
+  const flatExtraData = useMemo(
+    () => ({
+      expandedPathsArray,
+      collapsedFoldersArray,
+      layout,
+      typographyKey,
+      heightVersion,
+      viewMode,
+      wrapLines,
+      reviewActions,
+      workspaceFileDragScope,
+    }),
+    [
+      expandedPathsArray,
+      collapsedFoldersArray,
+      heightVersion,
+      layout,
+      reviewActions,
+      typographyKey,
+      viewMode,
+      workspaceFileDragScope,
+      wrapLines,
+    ],
+  );
+
+  return (
+    <View style={styles.scrollContainer}>
+      <FlatList
+        ref={diffListRef}
+        data={flatItems}
+        renderItem={renderFlatItem}
+        keyExtractor={flatKeyExtractor}
+        getItemLayout={getFlatItemLayout}
+        stickyHeaderIndices={stickyHeaderIndices}
+        extraData={flatExtraData}
+        style={styles.scrollView}
+        contentContainerStyle={styles.contentContainer}
+        testID="git-diff-scroll"
+        onLayout={handleDiffListLayout}
+        onScroll={handleDiffListScroll}
+        onContentSizeChange={scrollbar.onContentSizeChange}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={!scrollbar.enabled}
+        removeClippedSubviews={false}
+        initialNumToRender={12}
+        maxToRenderPerBatch={12}
+        windowSize={10}
+      />
+      {scrollbar.overlay}
+    </View>
+  );
+}
+
 function computeBaseRefLabel(baseRef: string | undefined, fallbackLabel: string): string {
   if (!baseRef) return fallbackLabel;
   const trimmed = baseRef.replace(/^refs\/(heads|remotes)\//, "").trim();
@@ -727,69 +2758,17 @@ function computePrErrorMessage(
   return prPayloadError?.message ?? null;
 }
 
-// The precise setup step a workspace needs before its forge features work, or
-// null when nothing is actionable (authenticated, or no forge remote at all).
-type ForgeSetupAction = "install_cli" | "sign_in" | null;
-
-// Drive the onboarding callout from the forge's auth state so the message names
-// the exact next step (install the CLI vs sign in) for whichever forge backs the
-// workspace — GitHub included. GitLab additionally requires the host to advertise
-// GitLab support, matching the rest of the GitLab UI.
-function computeForgeSetupAction(input: {
-  forge: Forge;
-  forgeProvidersSupported: boolean;
-  authState: ForgeAuthState | undefined;
-}): ForgeSetupAction {
-  // A daemon without pluggable forge support can't operate any non-GitHub forge,
-  // so don't offer a setup action for one it can't drive.
-  if (input.forge !== "github" && !input.forgeProvidersSupported) {
-    return null;
-  }
-  switch (input.authState) {
-    case "cli_missing":
-      return "install_cli";
-    case "unauthenticated":
-      return "sign_in";
-    case "authenticated":
-    case "no_remote":
-    case "error":
-      return null;
-    default:
-      return null;
-  }
-}
-
-function parseForgeHost(url: string | null | undefined): string | null {
-  return url ? (parseGitRemoteLocation(url)?.host ?? null) : null;
-}
-
-function buildForgeSetupMessage(input: {
-  action: ForgeSetupAction;
-  forge: Forge;
-  host: string | null;
-  t: TFunction;
-}): string | null {
-  if (!input.action) {
-    return null;
-  }
-  const { brandLabel, signInCli } = getForgePresentation(input.forge);
-  // A forge with no known CLI (an unknown/third-party forge rendered neutrally)
-  // has no install/sign-in command to interpolate — show neutral guidance
-  // rather than the GitLab-specific callout or a null command.
-  if (signInCli === null) {
-    return input.t("workspace.git.forgeSetup.generic", { brand: brandLabel });
-  }
-  if (input.action === "install_cli") {
-    return input.t("workspace.git.forgeSetup.installCli", { cli: signInCli, brand: brandLabel });
-  }
-  const command = buildForgeSignInCommand(input.forge, input.host);
-  return input.t("workspace.git.forgeSetup.signIn", { command, brand: brandLabel });
-}
-
 function buildDiffModeTriggerStyle(): PressableStyleFn {
   return ({ hovered, pressed, open }) => [
     styles.diffModeTrigger,
     (Boolean(hovered) || pressed || Boolean(open)) && styles.diffModeTriggerHovered,
+  ];
+}
+
+function buildExpandAllButtonStyle(): PressableStyleFn {
+  return ({ hovered, pressed }) => [
+    styles.expandAllButton,
+    (Boolean(hovered) || pressed) && styles.toggleButtonSelected,
   ];
 }
 
@@ -810,12 +2789,20 @@ function buildToggleButtonStyle(
   ];
 }
 
-function useCollapsedDiffFolders({
+function useChangesTreeState({
   workspaceId,
   cwd,
+  files,
+  viewMode,
+  changesTabOpen,
+  onViewModeChange,
 }: {
   workspaceId?: string | null;
   cwd: string;
+  files: ParsedDiffFile[];
+  viewMode: "flat" | "tree";
+  changesTabOpen: boolean;
+  onViewModeChange: (viewMode: "flat" | "tree") => void;
 }) {
   const workspaceStateKey = useMemo(
     () =>
@@ -825,11 +2812,73 @@ function useCollapsedDiffFolders({
       }),
     [cwd, workspaceId],
   );
+  const expandedPaths = usePanelStore((state) =>
+    workspaceStateKey ? state.diffExpandedPathsByWorkspace[workspaceStateKey] : undefined,
+  );
   const collapsedFolders = usePanelStore((state) =>
     workspaceStateKey ? state.diffCollapsedFoldersByWorkspace[workspaceStateKey] : undefined,
   );
+  const setExpandedPaths = usePanelStore((state) => state.setDiffExpandedPathsForWorkspace);
   const setCollapsedFolders = usePanelStore((state) => state.setDiffCollapsedFoldersForWorkspace);
+  const stableExpandedPaths = expandedPaths ?? EMPTY_PATH_LIST;
   const stableCollapsedFolders = collapsedFolders ?? EMPTY_PATH_LIST;
+  const folderPaths = useMemo(
+    () => collectDirPaths(compressSingleChildChains(buildDiffTree(files))),
+    [files],
+  );
+  const folderPathSet = useMemo(() => new Set(folderPaths), [folderPaths]);
+  const allExpanded = useMemo(() => {
+    if (files.length === 0 || changesTabOpen) {
+      return false;
+    }
+    const everyFileExpanded = files.every((file) => stableExpandedPaths.includes(file.path));
+    const everyFolderExpanded =
+      viewMode !== "tree" ||
+      stableCollapsedFolders.every((folderPath) => !folderPathSet.has(folderPath));
+    return everyFileExpanded && everyFolderExpanded;
+  }, [changesTabOpen, files, folderPathSet, stableCollapsedFolders, stableExpandedPaths, viewMode]);
+  const toggleViewMode = useCallback(() => {
+    const nextViewMode = viewMode === "flat" ? "tree" : "flat";
+    if (nextViewMode === "tree" && workspaceStateKey) {
+      setCollapsedFolders(workspaceStateKey, []);
+    }
+    onViewModeChange(nextViewMode);
+  }, [onViewModeChange, setCollapsedFolders, viewMode, workspaceStateKey]);
+  const toggleExpandAll = useCallback(() => {
+    if (!workspaceStateKey) {
+      return;
+    }
+    if (allExpanded) {
+      setExpandedPaths(workspaceStateKey, []);
+      if (viewMode === "tree") {
+        setCollapsedFolders(workspaceStateKey, folderPaths);
+      }
+      return;
+    }
+    setExpandedPaths(
+      workspaceStateKey,
+      files.map((file) => file.path),
+    );
+    if (viewMode === "tree") {
+      setCollapsedFolders(workspaceStateKey, []);
+    }
+  }, [
+    allExpanded,
+    files,
+    folderPaths,
+    setCollapsedFolders,
+    setExpandedPaths,
+    viewMode,
+    workspaceStateKey,
+  ]);
+  const updateExpandedPaths = useCallback(
+    (paths: string[]) => {
+      if (workspaceStateKey) {
+        setExpandedPaths(workspaceStateKey, paths);
+      }
+    },
+    [setExpandedPaths, workspaceStateKey],
+  );
   const updateCollapsedFolders = useCallback(
     (paths: string[]) => {
       if (workspaceStateKey) {
@@ -840,158 +2889,67 @@ function useCollapsedDiffFolders({
   );
 
   return {
+    expandedPaths: changesTabOpen ? EMPTY_PATH_LIST : stableExpandedPaths,
     collapsedFolders: stableCollapsedFolders,
+    allExpanded,
+    toggleViewMode,
+    toggleExpandAll,
+    updateExpandedPaths,
     updateCollapsedFolders,
   };
 }
 
-function ChangedFilesTree({
+export function ChangedFilesTree({
   workspaceId,
   cwd,
   files,
-  mode,
-  onSelectFile,
+  displayPreferences,
+  workingTreeMode,
 }: {
   workspaceId?: string | null;
   cwd: string;
   files: ParsedDiffFile[];
-  mode: WorkingDiffMode;
-  onSelectFile: (path: string) => void;
+  displayPreferences: SharedDiffViewProps["displayPreferences"];
+  workingTreeMode: WorkingTreeDiffMode;
 }) {
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const { collapsedFolders: collapsedFolderPaths, updateCollapsedFolders } =
-    useCollapsedDiffFolders({ workspaceId, cwd });
-  const compressedTree = useMemo(() => compressSingleChildChains(buildDiffTree(files)), [files]);
-  const allFolderPaths = useMemo(() => collectDirPaths(compressedTree), [compressedTree]);
-  const collapsedFolders = useMemo(() => new Set(collapsedFolderPaths), [collapsedFolderPaths]);
-  const items = useMemo(
-    () => flattenDiffTree(compressedTree, collapsedFolders),
-    [collapsedFolders, compressedTree],
+  const treeState = useChangesTreeState({
+    workspaceId,
+    cwd,
+    files,
+    viewMode: "tree",
+    changesTabOpen: false,
+    onViewModeChange: () => {},
+  });
+  const mode = useMemo(
+    () => ({
+      ...workingTreeMode,
+      viewMode: "tree" as const,
+      expandedPaths: EMPTY_PATH_LIST,
+      collapsedFolders: treeState.collapsedFolders,
+      onExpandedPathsChange: () => {},
+      onCollapsedFoldersChange: treeState.updateCollapsedFolders,
+    }),
+    [treeState.collapsedFolders, treeState.updateCollapsedFolders, workingTreeMode],
   );
-  const handleSelectPath = useCallback((path: string) => setSelectedPath(path), []);
-  const handleSelectFile = useCallback(
-    (path: string) => {
-      setSelectedPath(path);
-      onSelectFile(path);
-    },
-    [onSelectFile],
-  );
-  const handleToggleFolder = useCallback(
-    (dirPath: string) => {
-      const next = collapsedFolders.has(dirPath)
-        ? Array.from(collapsedFolders).filter((path) => path !== dirPath)
-        : [...collapsedFolders, dirPath];
-      updateCollapsedFolders(next);
-    },
-    [collapsedFolders, updateCollapsedFolders],
-  );
-  const handleCollapseFolder = useCallback(
-    (dirPath: string) => {
-      const prefix = `${dirPath}/`;
-      updateCollapsedFolders([
-        ...new Set([
-          ...collapsedFolders,
-          ...allFolderPaths.filter(
-            (folderPath) => folderPath === dirPath || folderPath.startsWith(prefix),
-          ),
-        ]),
-      ]);
-    },
-    [allFolderPaths, collapsedFolders, updateCollapsedFolders],
-  );
-  const renderItem = useCallback(
-    ({ item }: { item: DiffTreeRow }) => {
-      if (item.kind === "folder") {
-        return (
-          <DiffFolderRow
-            dirPath={item.dirPath}
-            displayName={item.displayName}
-            depth={item.depth}
-            collapsed={collapsedFolders.has(item.dirPath)}
-            isSelected={selectedPath === item.dirPath}
-            additions={item.additions}
-            deletions={item.deletions}
-            onToggle={handleToggleFolder}
-            onCollapse={handleCollapseFolder}
-            onSelect={handleSelectPath}
-            onCopyPath={mode.onCopyPath}
-            onCopyRelativePath={mode.onCopyRelativePath}
-            onReveal={mode.onReveal}
-            revealTargetName={mode.revealTargetName}
-            onDuplicate={mode.onDuplicate}
-            onRevert={mode.onRevert}
-            testID={`diff-folder-${item.dirPath}`}
-          />
-        );
-      }
-      return (
-        <FileHeader
-          file={item.file}
-          workspaceFileDragScope={mode.workspaceFileDragScope}
-          bodyVisible={false}
-          showsBodyState={false}
-          isSelected={selectedPath === item.file.path}
-          depth={item.depth}
-          showDir={false}
-          onActivate={handleSelectFile}
-          onSelect={handleSelectPath}
-          onOpenFile={mode.onOpenFile}
-          onAddToChat={mode.onAddToChat}
-          onCopyPath={mode.onCopyPath}
-          onCopyRelativePath={mode.onCopyRelativePath}
-          onReveal={mode.onReveal}
-          revealTargetName={mode.revealTargetName}
-          onDownload={mode.onDownload}
-          onDuplicate={mode.onDuplicate}
-          onRevert={mode.onRevert}
-          testID={`diff-tree-file-${item.fileIndex}`}
-        />
-      );
-    },
-    [
-      handleCollapseFolder,
-      handleSelectFile,
-      handleSelectPath,
-      handleToggleFolder,
-      collapsedFolders,
-      mode,
-      selectedPath,
-    ],
-  );
-  const keyExtractor = useCallback(
-    (item: DiffTreeRow) =>
-      item.kind === "folder" ? `folder-${item.dirPath}` : `file-${item.file.path}`,
-    [],
-  );
-
-  return (
-    <FlatList
-      data={items}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      style={styles.scrollView}
-      contentContainerStyle={styles.contentContainer}
-      testID="changes-file-tree"
-    />
-  );
+  return <SharedDiffView files={files} displayPreferences={displayPreferences} mode={mode} />;
 }
 
-function ChangesTreeRail({
+function GitDiffTreeRail({
   shown,
   children,
   workspaceId,
   cwd,
   files,
-  mode,
-  onSelectFile,
+  displayPreferences,
+  workingTreeMode,
 }: {
   shown: boolean;
   children: ReactElement;
   workspaceId?: string | null;
   cwd: string;
   files: ParsedDiffFile[];
-  mode: WorkingDiffMode;
-  onSelectFile: (path: string) => void;
+  displayPreferences: SharedDiffViewProps["displayPreferences"];
+  workingTreeMode: WorkingTreeDiffMode;
 }) {
   if (!shown) return children;
   return (
@@ -1001,10 +2959,24 @@ function ChangesTreeRail({
         workspaceId={workspaceId}
         cwd={cwd}
         files={files}
-        mode={mode}
-        onSelectFile={onSelectFile}
+        displayPreferences={displayPreferences}
+        workingTreeMode={workingTreeMode}
       />
     </TreeRail>
+  );
+}
+
+function resolveWorkingTreeMode<T>(isMobile: boolean, mobileMode: T, desktopMode: T): T {
+  return isMobile ? mobileMode : desktopMode;
+}
+
+function shouldShowTreeRail(viewMode: "flat" | "tree", isMobile: boolean): boolean {
+  return viewMode === "tree" && !isMobile;
+}
+
+function useCodeupForgeSupported(serverId: string): boolean {
+  return useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.codeupForge === true,
   );
 }
 
@@ -1074,17 +3046,15 @@ function useDiffTabNavigation({
   };
 }
 
-export function ChangesSurface({
+export function GitDiffPane({
   serverId,
   workspaceId,
   cwd,
   enabled,
   host,
-  focusPath,
-  focusRequestId,
   onOpenFile,
   onAddToChat,
-}: ChangesSurfaceProps) {
+}: GitDiffPaneProps) {
   const { settings: appSettings } = useAppSettings();
   const { t } = useTranslation();
   const isMobile = useIsCompactFormFactor();
@@ -1092,24 +3062,8 @@ export function ChangesSurface({
   const { preferences: changesPreferences, updatePreferences: updateChangesPreferences } =
     useChangesPreferences();
   const wrapLines = changesPreferences.wrapLines;
-  const desktopTreeVisible = changesPreferences.desktopTreeVisible;
+  const viewMode = changesPreferences.viewMode;
   const effectiveLayout = resolveDiffLayout(changesPreferences.layout, canUseSplitLayout);
-  const collapsedFilesWorkspaceKey = `${serverId}:${workspaceId ?? cwd}`;
-  const persistedCollapsedFilePaths = usePanelStore(
-    (state) => state.collapsedFilePathsByWorkspace[collapsedFilesWorkspaceKey],
-  );
-  const setCollapsedFilePaths = usePanelStore((state) => state.setCollapsedFilePathsForWorkspace);
-  const collapsedFilePaths = persistedCollapsedFilePaths ?? EMPTY_PATH_LIST;
-  const updateCollapsedFilePaths = useCallback(
-    (paths: string[]) => {
-      setCollapsedFilePaths(collapsedFilesWorkspaceKey, paths);
-    },
-    [collapsedFilesWorkspaceKey, setCollapsedFilePaths],
-  );
-  const collapseState = useMemo(
-    () => ({ paths: collapsedFilePaths, onChange: updateCollapsedFilePaths }),
-    [collapsedFilePaths, updateCollapsedFilePaths],
-  );
 
   const handleToggleWrapLines = useCallback(() => {
     void updateChangesPreferences({ wrapLines: !wrapLines });
@@ -1126,10 +3080,17 @@ export function ChangesSurface({
   }, [changesPreferences.layout, updateChangesPreferences]);
 
   const codeFontSize = appSettings.codeFontSize;
-  const treeToggleStyle = useMemo(
-    () => buildToggleButtonStyle(desktopTreeVisible, styles.toolbarIconButton),
-    [desktopTreeVisible],
+  const layoutToggleStyle = useMemo(
+    () => buildToggleButtonStyle(false, styles.expandAllButton),
+    [],
   );
+
+  const viewModeToggleStyle = useMemo(
+    () => buildToggleButtonStyle(viewMode === "tree", styles.expandAllButton),
+    [viewMode],
+  );
+
+  const expandAllToggleStyle = useMemo(() => buildExpandAllButtonStyle(), []);
 
   const overflowToggleStyle = useMemo(() => buildOverflowButtonStyle(), []);
 
@@ -1213,24 +3174,39 @@ export function ChangesSurface({
   const forgeProvidersSupported = useSessionStore(
     (s) => s.sessions[serverId]?.serverInfo?.features?.forgeProviders === true,
   );
-  const forgeSetupAction = computeForgeSetupAction({
+  const codeupForgeSupported = useCodeupForgeSupported(serverId);
+  const remoteUrl = status?.remoteUrl;
+  const forgeSetupState = computeForgeSetupState({
     forge,
+    remoteUrl,
     forgeProvidersSupported,
+    codeupForgeSupported,
     authState,
   });
   const forgeSetupMessage = useMemo(
     () =>
       buildForgeSetupMessage({
-        action: forgeSetupAction,
-        forge,
-        host: parseForgeHost(status?.remoteUrl),
+        action: forgeSetupState.action,
+        forge: forgeSetupState.forge,
+        remoteUrl,
         t,
       }),
-    [forgeSetupAction, forge, status?.remoteUrl, t],
+    [forgeSetupState.action, forgeSetupState.forge, remoteUrl, t],
   );
-  const handleToggleDesktopTree = useCallback(() => {
-    void updateChangesPreferences({ desktopTreeVisible: !desktopTreeVisible });
-  }, [desktopTreeVisible, updateChangesPreferences]);
+  const handleViewModeChange = useCallback(
+    (nextViewMode: "flat" | "tree") => {
+      void updateChangesPreferences({ viewMode: nextViewMode });
+    },
+    [updateChangesPreferences],
+  );
+  const changesTree = useChangesTreeState({
+    workspaceId,
+    cwd,
+    files,
+    viewMode,
+    changesTabOpen,
+    onViewModeChange: handleViewModeChange,
+  });
   const sharedDisplayPreferences = useMemo(
     () => ({
       layout: effectiveLayout,
@@ -1294,32 +3270,14 @@ export function ChangesSurface({
     [client, cwd, t, toast],
   );
   const onRevertPath = useDiscardChangesAction({ serverId, cwd, diffMode });
-  const [localFocusRequest, setLocalFocusRequest] = useState<{
-    path: string;
-    revision: number;
-  } | null>(null);
-  const externalFocusRequest = useMemo(
-    () => (focusPath ? { path: focusPath, revision: focusRequestId ?? 0 } : null),
-    [focusPath, focusRequestId],
-  );
-  const documentFocusRequest =
-    localFocusRequest &&
-    (!externalFocusRequest || localFocusRequest.revision >= externalFocusRequest.revision)
-      ? localFocusRequest
-      : externalFocusRequest;
-  const handleSelectTreeFile = useCallback((path: string) => {
-    setLocalFocusRequest((current) => ({
-      path,
-      revision: Math.max(Date.now(), (current?.revision ?? 0) + 1),
-    }));
-  }, []);
-  const workingMode = useMemo(
+  const workingTreeMode = useMemo(
     () => ({
-      kind: "working" as const,
+      kind: "working_tree" as const,
+      viewMode,
+      expandedPaths: changesTree.expandedPaths,
+      collapsedFolders: changesTree.collapsedFolders,
       reviewActions,
       onFilePress: onChangesFilePress,
-      focusPath: documentFocusRequest?.path,
-      focusRequestId: documentFocusRequest?.revision,
       workspaceFileDragScope: workspaceId ? { serverId, workspaceId } : undefined,
       onOpenFile,
       onAddToChat,
@@ -1330,12 +3288,15 @@ export function ChangesSurface({
       onDownload: handleDownloadPath,
       onDuplicate: fsEntryDuplicateEnabled ? handleDuplicatePath : undefined,
       onRevert: onRevertPath,
+      onExpandedPathsChange: changesTree.updateExpandedPaths,
+      onCollapsedFoldersChange: changesTree.updateCollapsedFolders,
     }),
     [
+      viewMode,
+      changesTree.expandedPaths,
+      changesTree.collapsedFolders,
       reviewActions,
       onChangesFilePress,
-      documentFocusRequest?.path,
-      documentFocusRequest?.revision,
       serverId,
       workspaceId,
       onOpenFile,
@@ -1348,24 +3309,12 @@ export function ChangesSurface({
       fileManagerTarget,
       fsEntryDuplicateEnabled,
       onRevertPath,
+      changesTree.updateExpandedPaths,
+      changesTree.updateCollapsedFolders,
     ],
   );
 
   const hasChanges = files.length > 0;
-  const selectedDiffStat = useMemo(
-    () => computeSelectedDiffStat(files, isDiffLoading),
-    [files, isDiffLoading],
-  );
-  const allFilesCollapsed =
-    hasChanges && files.every((file) => collapsedFilePaths.includes(file.path));
-  const handleCollapseAllFiles = useCallback(
-    () => updateCollapsedFilePaths(files.map((file) => file.path)),
-    [files, updateCollapsedFilePaths],
-  );
-  const handleExpandAllFiles = useCallback(
-    () => updateCollapsedFilePaths([]),
-    [updateCollapsedFilePaths],
-  );
   const diffErrorMessage = diffPayloadError?.message ?? null;
   const prErrorMessage = computePrErrorMessage(githubFeaturesEnabled, prPayloadError);
   const baseRefLabel = useMemo(
@@ -1392,6 +3341,15 @@ export function ChangesSurface({
     },
   );
 
+  const flatWorkingTreeMode = useMemo(
+    () => ({ ...workingTreeMode, viewMode: "flat" as const }),
+    [workingTreeMode],
+  );
+  const primaryWorkingTreeMode = resolveWorkingTreeMode(
+    isMobile,
+    workingTreeMode,
+    flatWorkingTreeMode,
+  );
   const diffContent: ReactElement = (
     <DiffBodyContent
       isStatusLoading={isStatusLoading}
@@ -1405,25 +3363,24 @@ export function ChangesSurface({
       checkingRepositoryLabel={t("workspace.git.diff.checkingRepository")}
       notRepositoryLabel={t("workspace.git.diff.notRepository")}
     >
-      <DiffDocument
+      <SharedDiffView
         files={files}
-        collapseState={collapseState}
         displayPreferences={sharedDisplayPreferences}
-        mode={workingMode}
+        mode={primaryWorkingTreeMode}
       />
     </DiffBodyContent>
   );
   const bodyContent = (
-    <ChangesTreeRail
-      shown={desktopTreeVisible && !isMobile && files.length > 0}
+    <GitDiffTreeRail
+      shown={shouldShowTreeRail(viewMode, isMobile)}
       workspaceId={workspaceId}
       cwd={cwd}
       files={files}
-      mode={workingMode}
-      onSelectFile={handleSelectTreeFile}
+      displayPreferences={sharedDisplayPreferences}
+      workingTreeMode={workingTreeMode}
     >
       {diffContent}
-    </ChangesTreeRail>
+    </GitDiffTreeRail>
   );
 
   return (
@@ -1433,41 +3390,75 @@ export function ChangesSurface({
       }}
       style={styles.container}
     >
+      {isGit && (currentBranchName || isMobile) ? (
+        <View style={styles.header} testID="changes-header">
+          <BranchSwitcher
+            currentBranchName={currentBranchName}
+            serverId={serverId}
+            workspaceId={workspaceId ?? cwd}
+            workspaceDirectory={cwd}
+            isGitCheckout={isGit}
+            testID="changes-branch-switcher"
+          />
+          {isMobile ? <GitActionsSplitButton gitActions={gitActions} /> : null}
+        </View>
+      ) : null}
+
       {isGit ? (
-        <ChangesToolbar
-          branchName={currentBranchName}
-          allFilesCollapsed={allFilesCollapsed}
-          canUseSplitLayout={canUseSplitLayout}
-          changesTabOpen={changesTabOpen}
-          committedDescription={committedDiffDescription}
-          cwd={cwd}
-          desktopTreeVisible={desktopTreeVisible}
-          diffMode={diffMode}
-          gitActions={gitActions}
-          hasFiles={hasChanges}
-          hideWhitespace={changesPreferences.hideWhitespace}
-          host={host}
-          isMobile={isMobile}
-          isRefreshing={isRefreshing}
-          layout={changesPreferences.layout}
-          overflowToggleStyle={overflowToggleStyle}
-          refreshSupported={refreshSupported}
-          selectedDiffStat={selectedDiffStat}
-          serverId={serverId}
-          treeToggleStyle={treeToggleStyle}
-          workspaceId={workspaceId}
-          wrapLines={wrapLines}
-          onCollapseAll={handleCollapseAllFiles}
-          onExpandAll={handleExpandAllFiles}
-          onRefresh={handleRefresh}
-          onSelectBase={handleSelectBase}
-          onSelectUncommitted={handleSelectUncommitted}
-          onToggleChangesTab={handleToggleChangesTab}
-          onToggleDesktopTree={handleToggleDesktopTree}
-          onToggleHideWhitespace={handleToggleHideWhitespace}
-          onToggleLayout={handleToggleLayout}
-          onToggleWrapLines={handleToggleWrapLines}
-        />
+        <View style={styles.diffStatusContainer}>
+          <View style={styles.diffStatusInner}>
+            <DiffModeMenu
+              diffMode={diffMode}
+              committedDescription={committedDiffDescription}
+              onSelectUncommitted={handleSelectUncommitted}
+              onSelectBase={handleSelectBase}
+            />
+            <View style={styles.diffStatusButtons}>
+              <ChangesTabToggleForHost
+                host={host}
+                isMobile={isMobile}
+                selected={changesTabOpen}
+                onPress={handleToggleChangesTab}
+              />
+              {canUseSplitLayout && !changesTabOpen ? (
+                <DiffLayoutToggle
+                  layout={changesPreferences.layout}
+                  isMobile={isMobile}
+                  toggleStyle={layoutToggleStyle}
+                  onToggle={handleToggleLayout}
+                />
+              ) : null}
+              {files.length > 0 ? (
+                <DiffViewModeToggle
+                  viewMode={viewMode}
+                  isMobile={isMobile}
+                  toggleStyle={viewModeToggleStyle}
+                  onToggle={changesTree.toggleViewMode}
+                />
+              ) : null}
+              {files.length > 0 && !changesTabOpen ? (
+                <DiffFilesToolbar
+                  allFileDiffsExpanded={changesTree.allExpanded}
+                  isMobile={isMobile}
+                  expandAllToggleStyle={expandAllToggleStyle}
+                  onToggleExpandAll={changesTree.toggleExpandAll}
+                />
+              ) : null}
+              <DiffOptionsMenu
+                brand={getForgePresentation(forge).brandLabel}
+                hideWhitespace={changesPreferences.hideWhitespace}
+                isMobile={isMobile}
+                isRefreshing={isRefreshing}
+                overflowToggleStyle={overflowToggleStyle}
+                refreshSupported={refreshSupported}
+                wrapLines={wrapLines}
+                onRefresh={handleRefresh}
+                onToggleHideWhitespace={handleToggleHideWhitespace}
+                onToggleWrapLines={handleToggleWrapLines}
+              />
+            </View>
+          </View>
+        </View>
       ) : null}
 
       {forgeSetupMessage ? (
@@ -1490,37 +3481,35 @@ const styles = StyleSheet.create((theme) => ({
     flex: 1,
     minHeight: 0,
   },
-  changesToolbar: {
-    minHeight: WORKSPACE_SECONDARY_HEADER_HEIGHT,
+  header: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
     gap: theme.spacing[2],
-    paddingLeft: theme.spacing[2],
-    paddingRight: theme.spacing[3],
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
     borderBottomWidth: 1,
     borderBottomColor: theme.colors.border,
-    flexShrink: 0,
   },
-  changesToolbarIdentity: {
-    minWidth: 0,
-    flexShrink: 1,
+  diffStatusContainer: {
+    height: WORKSPACE_SECONDARY_HEADER_HEIGHT,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  diffStatusInner: {
+    flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    gap: theme.spacing[1],
-  },
-  changesToolbarControls: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "flex-end",
-    gap: theme.spacing[1],
-    flexShrink: 0,
+    justifyContent: "space-between",
+    paddingRight: theme.spacing[3],
   },
   diffModeTrigger: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
     gap: theme.spacing[1],
+    // Align text with header branch icon (at spacing[3] from edge, minus our horizontal padding)
+    marginLeft: theme.spacing[3] - theme.spacing[1],
     paddingHorizontal: theme.spacing[1],
     height: {
       xs: 28,
@@ -1540,17 +3529,23 @@ const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.surface2,
   },
   diffStatusText: {
-    fontSize: theme.fontSize.sm,
-    lineHeight: theme.fontSize.sm * 1.25,
+    fontSize: theme.fontSize.xs,
+    lineHeight: theme.fontSize.xs * 1.25,
     color: theme.colors.foregroundMuted,
   },
   diffStatusIconHidden: {
     opacity: 0,
   },
+  diffStatusButtons: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    flexWrap: "wrap",
+  },
   toggleButtonSelected: {
     backgroundColor: theme.colors.surface2,
   },
-  toolbarIconButton: {
+  expandAllButton: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
@@ -1588,7 +3583,7 @@ const styles = StyleSheet.create((theme) => ({
   actionErrorText: {
     paddingHorizontal: theme.spacing[3],
     paddingBottom: theme.spacing[1],
-    fontSize: theme.fontSize.sm,
+    fontSize: theme.fontSize.xs,
     color: theme.colors.destructive,
   },
   forgeSetupCallout: {
@@ -1602,7 +3597,7 @@ const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.surface1,
   },
   forgeSetupCalloutText: {
-    fontSize: theme.fontSize.sm,
+    fontSize: theme.fontSize.xs,
     color: theme.colors.foregroundMuted,
   },
   diffContainer: {
@@ -1651,11 +3646,240 @@ const styles = StyleSheet.create((theme) => ({
     paddingTop: theme.spacing[16],
   },
   emptyText: {
-    fontSize: theme.fontSize.base,
+    fontSize: theme.fontSize.lg,
     color: theme.colors.foregroundMuted,
   },
-  tooltipText: {
+  fileSection: {
+    overflow: "hidden",
+    backgroundColor: theme.colors.surface2,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  fileSectionHeaderContainer: {
+    overflow: "hidden",
+  },
+  fileSectionHeaderExpanded: {
+    backgroundColor: theme.colors.surface1,
+  },
+  fileSectionBodyContainer: {
+    overflow: "hidden",
+    backgroundColor: theme.colors.surface2,
+  },
+  fileSectionBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  fileHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingLeft: theme.spacing[3],
+    paddingRight: WORKSPACE_FILE_ROW_TRAILING_PADDING,
+    paddingVertical: WORKSPACE_FILE_ROW_VERTICAL_PADDING,
+    gap: theme.spacing[1],
+    minWidth: 0,
+    zIndex: 2,
+    elevation: 2,
+  },
+  fileHeaderActive: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  fileHeaderLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    flex: 1,
+    minWidth: 0,
+  },
+  fileHeaderLeftTree: {
+    gap: WORKSPACE_TREE_ICON_LABEL_GAP,
+  },
+  fileHeaderRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    flexShrink: 0,
+  },
+  fileIcon: {
+    width: WORKSPACE_TREE_ICON_SIZE,
+    height: WORKSPACE_TREE_ICON_SIZE,
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  fileName: {
     fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.normal,
+    color: theme.colors.foreground,
+    flexShrink: 1,
+    minWidth: 0,
+    userSelect: "none",
+  },
+  fileDir: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.normal,
+    color: theme.colors.foregroundMuted,
+    flex: 1,
+    minWidth: 0,
+    userSelect: "none",
+  },
+  fileDirSpacer: {
+    flex: 1,
+    minWidth: 0,
+  },
+  diffContent: {
+    borderTopWidth: theme.borderWidth[1],
+    borderTopColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
+  },
+  diffContentRow: {
+    flexDirection: "row",
+    alignItems: "stretch",
+  },
+  diffContentInner: {
+    flexDirection: "column",
+  },
+  linesContainer: {
+    backgroundColor: theme.colors.surface1,
+  },
+  gutterColumn: {
+    backgroundColor: theme.colors.surface1,
+    zIndex: 4,
+    elevation: 4,
+    overflow: "visible",
+  },
+  gutterCell: {
+    borderRightWidth: theme.borderWidth[1],
+    borderRightColor: theme.colors.border,
+    justifyContent: "flex-start",
+    zIndex: 4,
+    elevation: 4,
+    overflow: "visible",
+  },
+  inlineReviewRow: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    backgroundColor: theme.colors.surface1,
+  },
+  inlineReviewGutterSpacer: {
+    borderRightWidth: theme.borderWidth[1],
+    borderRightColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
+    flexShrink: 0,
+  },
+  textLineContainer: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    paddingLeft: theme.spacing[2],
+  },
+  splitRow: {
+    flexDirection: "row",
+    alignItems: "stretch",
+  },
+  splitColumnScroll: {
+    flex: 1,
+  },
+  splitHeaderRow: {
+    backgroundColor: theme.colors.surface2,
+    paddingHorizontal: theme.spacing[3],
+  },
+  splitCell: {
+    flex: 1,
+    flexBasis: 0,
+    backgroundColor: theme.colors.surface2,
+  },
+  splitCellRow: {
+    flexDirection: "row",
+    alignItems: "stretch",
+  },
+  emptySplitCell: {
+    backgroundColor: theme.colors.surfaceDiffEmpty,
+  },
+  splitCellWithDivider: {
+    borderLeftWidth: theme.borderWidth[1],
+    borderLeftColor: theme.colors.border,
+  },
+  diffLineContainer: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    overflow: "visible",
+  },
+  lineNumberGutter: {
+    borderRightWidth: theme.borderWidth[1],
+    borderRightColor: theme.colors.border,
+    marginRight: theme.spacing[2],
+    alignSelf: "stretch",
+    justifyContent: "flex-start",
+    zIndex: 4,
+    elevation: 4,
+    overflow: "visible",
+  },
+  diffTextMetrics: {
+    fontSize: theme.fontSize.code,
+    lineHeight: theme.lineHeight.diff,
+    fontFamily: theme.fontFamily.mono,
+  },
+  lineNumberText: {
+    width: "100%",
+    textAlign: "right",
+    paddingRight: theme.spacing[2],
+    color: theme.colors.foregroundMuted,
+    userSelect: "none",
+  },
+  addLineNumberText: {
+    color: theme.colors.diffAddition,
+  },
+  removeLineNumberText: {
+    color: theme.colors.diffDeletion,
+  },
+  diffLineText: {
+    flex: 1,
+    paddingRight: theme.spacing[3],
+    color: theme.colors.foreground,
+    userSelect: "text",
+  },
+  addLineContainer: {
+    backgroundColor: "rgba(46, 160, 67, 0.15)", // GitHub green
+  },
+  addLineText: {
+    color: theme.colors.foreground,
+  },
+  removeLineContainer: {
+    backgroundColor: "rgba(248, 81, 73, 0.1)", // GitHub red
+  },
+  removeLineText: {
+    color: theme.colors.foreground,
+  },
+  headerLineContainer: {
+    backgroundColor: theme.colors.surface2,
+  },
+  headerLineText: {
+    color: theme.colors.foregroundMuted,
+  },
+  contextLineContainer: {
+    backgroundColor: theme.colors.surface1,
+  },
+  contextLineText: {
+    color: theme.colors.foregroundMuted,
+  },
+  emptySplitCellText: {
+    color: "transparent",
+  },
+  statusMessageContainer: {
+    borderTopWidth: theme.borderWidth[1],
+    borderTopColor: theme.colors.border,
+    backgroundColor: theme.colors.surface1,
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[4],
+  },
+  statusMessageText: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foregroundMuted,
+    fontStyle: "italic",
+  },
+  tooltipText: {
+    fontSize: theme.fontSize.xs,
     color: theme.colors.foreground,
   },
 }));
+
+const DIFF_HEIGHT_CHANGE_EPSILON = 0.5;

--- a/packages/app/src/git/forge-icon.test.ts
+++ b/packages/app/src/git/forge-icon.test.ts
@@ -46,4 +46,10 @@ describe("getForgeBrandColorMapping", () => {
   it("returns null for unknown icon kinds", () => {
     expect(getForgeBrandColorMapping("some-unknown-forge")).toBeNull();
   });
+
+  it("uses the Codeup orange in both color schemes", () => {
+    const mapping = getForgeBrandColorMapping("codeup");
+    expect(mapping?.({ colorScheme: "light" } as never)).toEqual({ color: "#FF6A00" });
+    expect(mapping?.({ colorScheme: "dark" } as never)).toEqual({ color: "#FF6A00" });
+  });
 });

--- a/packages/app/src/git/forge-setup.test.ts
+++ b/packages/app/src/git/forge-setup.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildForgeSetupMessage, computeForgeSetupState } from "./forge-setup";
+
+const CODEUP_REMOTE = "git@codeup.aliyun.com:org/team/repo.git";
+
+describe("computeForgeSetupState", () => {
+  it("requires a host update for a Codeup remote on an old daemon", () => {
+    expect(
+      computeForgeSetupState({
+        forge: "github",
+        remoteUrl: CODEUP_REMOTE,
+        forgeProvidersSupported: false,
+        codeupForgeSupported: false,
+        authState: "cli_missing",
+      }),
+    ).toEqual({ action: "update_host", forge: "codeup" });
+  });
+
+  it("makes the Codeup host-update action take precedence over auth prompts", () => {
+    expect(
+      computeForgeSetupState({
+        forge: "codeup",
+        remoteUrl: CODEUP_REMOTE,
+        forgeProvidersSupported: true,
+        codeupForgeSupported: false,
+        authState: "unauthenticated",
+      }),
+    ).toEqual({ action: "update_host", forge: "codeup" });
+  });
+
+  it("uses normal Codeup auth onboarding when the daemon supports Codeup", () => {
+    expect(
+      computeForgeSetupState({
+        forge: "codeup",
+        remoteUrl: CODEUP_REMOTE,
+        forgeProvidersSupported: true,
+        codeupForgeSupported: true,
+        authState: "cli_missing",
+      }),
+    ).toEqual({ action: "install_cli", forge: "codeup" });
+    expect(
+      computeForgeSetupState({
+        forge: "codeup",
+        remoteUrl: CODEUP_REMOTE,
+        forgeProvidersSupported: true,
+        codeupForgeSupported: true,
+        authState: "unauthenticated",
+      }),
+    ).toEqual({ action: "sign_in", forge: "codeup" });
+  });
+
+  it("does not gate unrelated forge remotes on the Codeup capability", () => {
+    expect(
+      computeForgeSetupState({
+        forge: "gitlab",
+        remoteUrl: "git@gitlab.com:org/repo.git",
+        forgeProvidersSupported: true,
+        codeupForgeSupported: false,
+        authState: "authenticated",
+      }),
+    ).toEqual({ action: null, forge: "gitlab" });
+  });
+
+  it("builds the host-update prompt with Codeup branding", () => {
+    const t = vi.fn((key: string, values: { brand: string }) => `${key}:${values.brand}`);
+    expect(
+      buildForgeSetupMessage({
+        action: "update_host",
+        forge: "codeup",
+        remoteUrl: CODEUP_REMOTE,
+        t: t as never,
+      }),
+    ).toBe("workspace.git.forgeSetup.updateHost:Codeup");
+  });
+});

--- a/packages/app/src/git/forge-setup.ts
+++ b/packages/app/src/git/forge-setup.ts
@@ -1,0 +1,79 @@
+import type { TFunction } from "i18next";
+import type { ForgeAuthState } from "@getpaseo/protocol/messages";
+import { parseGitRemoteLocation } from "@getpaseo/protocol/git-remote";
+import {
+  buildForgeSignInCommand,
+  forgeFromRemoteUrl,
+  getForgePresentation,
+  type Forge,
+} from "@/git/forge";
+
+export type ForgeSetupAction = "update_host" | "install_cli" | "sign_in" | null;
+
+export interface ForgeSetupState {
+  action: ForgeSetupAction;
+  forge: Forge;
+}
+
+// The precise setup step a workspace needs before its forge features work, or
+// null when nothing is actionable (authenticated, or no forge remote at all).
+export function computeForgeSetupState(input: {
+  forge: Forge;
+  remoteUrl: string | null | undefined;
+  forgeProvidersSupported: boolean;
+  codeupForgeSupported: boolean;
+  authState: ForgeAuthState | undefined;
+}): ForgeSetupState {
+  const configuredForge = forgeFromRemoteUrl(input.remoteUrl);
+
+  // COMPAT(codeupForge): added in v0.2.0, remove after 2027-01-20 when the
+  // minimum supported daemon advertises native Codeup Forge support.
+  if (configuredForge === "codeup" && !input.codeupForgeSupported) {
+    return { action: "update_host", forge: "codeup" };
+  }
+
+  // A daemon without pluggable forge support can't operate any non-GitHub forge,
+  // so don't offer a setup action for one it can't drive.
+  if (input.forge !== "github" && !input.forgeProvidersSupported) {
+    return { action: null, forge: input.forge };
+  }
+
+  switch (input.authState) {
+    case "cli_missing":
+      return { action: "install_cli", forge: input.forge };
+    case "unauthenticated":
+      return { action: "sign_in", forge: input.forge };
+    case "authenticated":
+    case "no_remote":
+    case "error":
+      return { action: null, forge: input.forge };
+    default:
+      return { action: null, forge: input.forge };
+  }
+}
+
+export function buildForgeSetupMessage(input: {
+  action: ForgeSetupAction;
+  forge: Forge;
+  remoteUrl: string | null | undefined;
+  t: TFunction;
+}): string | null {
+  if (input.action === null) {
+    return null;
+  }
+  const { brandLabel, signInCli } = getForgePresentation(input.forge);
+  if (input.action === "update_host") {
+    return input.t("workspace.git.forgeSetup.updateHost", { brand: brandLabel });
+  }
+  // A forge with no known CLI (an unknown/third-party forge rendered neutrally)
+  // has no install/sign-in command to interpolate — show neutral guidance.
+  if (signInCli === null) {
+    return input.t("workspace.git.forgeSetup.generic", { brand: brandLabel });
+  }
+  if (input.action === "install_cli") {
+    return input.t("workspace.git.forgeSetup.installCli", { cli: signInCli, brand: brandLabel });
+  }
+  const host = input.remoteUrl ? (parseGitRemoteLocation(input.remoteUrl)?.host ?? null) : null;
+  const command = buildForgeSignInCommand(input.forge, host);
+  return input.t("workspace.git.forgeSetup.signIn", { command, brand: brandLabel });
+}

--- a/packages/app/src/git/forge.test.ts
+++ b/packages/app/src/git/forge.test.ts
@@ -67,6 +67,22 @@ describe("getForgePresentation", () => {
       signInCli: "tea",
     });
   });
+
+  it("presents Codeup with merge-request vocabulary and the aliyun CLI", () => {
+    expect(getForgePresentation("codeup")).toMatchObject({
+      forge: "codeup",
+      icon: "codeup",
+      brandLabel: "Codeup",
+      changeRequestAbbrev: "MR",
+      changeRequestNoun: "merge request",
+      numberPrefix: "!",
+      issueNumberPrefix: "#",
+      signInCli: "aliyun",
+      changeRequestContext: "mr",
+      buildBlobUrl: null,
+      buildBranchTreeUrl: null,
+    });
+  });
 });
 
 describe("forgeFromRemoteUrl", () => {
@@ -74,6 +90,7 @@ describe("forgeFromRemoteUrl", () => {
     expect(forgeFromRemoteUrl("https://codeberg.org/example/repo.git")).toBe("codeberg");
     expect(forgeFromRemoteUrl("https://gitlab.com/example/repo.git")).toBe("gitlab");
     expect(forgeFromRemoteUrl("https://gitea.com/example/repo.git")).toBe("gitea");
+    expect(forgeFromRemoteUrl("git@codeup.aliyun.com:org/team/repo.git")).toBe("codeup");
   });
 
   it("does not classify self-managed hosts by substring", () => {
@@ -99,6 +116,10 @@ describe("buildForgeSignInCommand", () => {
     expect(buildForgeSignInCommand("gitlab", "gitlab.acme.com")).toBe(
       "glab auth login --hostname gitlab.acme.com",
     );
+  });
+
+  it("uses aliyun configure for Codeup", () => {
+    expect(buildForgeSignInCommand("codeup", "codeup.aliyun.com")).toBe("aliyun configure");
   });
 
   it("returns no sign-in command for an unknown forge with no known CLI", () => {

--- a/packages/app/src/git/forges/codeup.ts
+++ b/packages/app/src/git/forges/codeup.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import {
+  defineForgeFacts,
+  type ClientForgeLogicModule,
+  type MergeCapability,
+} from "@/git/client-forge-module";
+import type { CheckoutPrMergeMethod } from "@getpaseo/protocol/messages";
+
+const CodeupRequirementChecksSchema = z
+  .object({
+    mergeConflict: z.boolean().nullable().optional().default(null),
+    comments: z.boolean().nullable().optional().default(null),
+    ci: z.boolean().nullable().optional().default(null),
+    reviewerApproved: z.boolean().nullable().optional().default(null),
+  })
+  .passthrough();
+
+export const CodeupMergeFactsSchema = z
+  .object({
+    forge: z.literal("codeup"),
+    status: z.string().optional().default(""),
+    allRequirementsPass: z.boolean().optional().default(false),
+    requirementChecks: CodeupRequirementChecksSchema.optional().default({
+      mergeConflict: null,
+      comments: null,
+      ci: null,
+      reviewerApproved: null,
+    }),
+  })
+  .passthrough();
+
+export type CodeupMergeFacts = z.infer<typeof CodeupMergeFactsSchema>;
+
+const CODEUP_MERGE_METHODS: CheckoutPrMergeMethod[] = ["merge", "squash", "rebase"];
+
+function deriveCodeupMergeCapability(codeup: CodeupMergeFacts): MergeCapability {
+  return {
+    directMergeReady:
+      codeup.status === "TO_BE_MERGED" &&
+      codeup.allRequirementsPass &&
+      Object.values(codeup.requirementChecks).every((check) => check !== false),
+    canEnableAutoMerge: false,
+    autoMergeEnabled: false,
+    canDisableAutoMerge: false,
+    mergeBlockedByQueue: false,
+    allowedMethods: CODEUP_MERGE_METHODS,
+    preferredMethod: null,
+  };
+}
+
+export const codeupForgeLogic = {
+  id: "codeup",
+  facts: defineForgeFacts({
+    family: "codeup",
+    schema: CodeupMergeFactsSchema,
+    deriveMergeCapability: deriveCodeupMergeCapability,
+  }),
+} satisfies ClientForgeLogicModule<CodeupMergeFacts>;

--- a/packages/app/src/git/forges/codeup.view.tsx
+++ b/packages/app/src/git/forges/codeup.view.tsx
@@ -1,0 +1,11 @@
+import { CodeupIcon } from "@/components/icons/codeup-icon";
+import type { ClientForgeViewModule } from "@/git/client-forge-module";
+
+export const codeupForgeView = {
+  id: "codeup",
+  icon: CodeupIcon,
+  brandColor: {
+    light: "#FF6A00",
+    dark: "#FF6A00",
+  },
+} satisfies ClientForgeViewModule;

--- a/packages/app/src/git/forges/index.ts
+++ b/packages/app/src/git/forges/index.ts
@@ -1,5 +1,6 @@
 import type { ClientForgeLogicModule, ForgeSpecificEnvelope } from "@/git/client-forge-module";
 import { codebergForgeLogic } from "./codeberg";
+import { codeupForgeLogic } from "./codeup";
 import { forgejoForgeLogic } from "./forgejo";
 import { giteaForgeLogic } from "./gitea";
 import { githubForgeLogic } from "./github";
@@ -14,6 +15,7 @@ import { gitlabForgeLogic } from "./gitlab";
 export const CLIENT_FORGE_LOGIC_MODULES: readonly ClientForgeLogicModule[] = [
   githubForgeLogic,
   gitlabForgeLogic,
+  codeupForgeLogic,
   giteaForgeLogic,
   forgejoForgeLogic,
   codebergForgeLogic,

--- a/packages/app/src/git/forges/view.ts
+++ b/packages/app/src/git/forges/view.ts
@@ -1,5 +1,6 @@
 import type { ClientForgeViewModule } from "@/git/client-forge-module";
 import { codebergForgeView } from "./codeberg.view";
+import { codeupForgeView } from "./codeup.view";
 import { forgejoForgeView } from "./forgejo.view";
 import { giteaForgeView } from "./gitea.view";
 import { githubForgeView } from "./github.view";
@@ -13,6 +14,7 @@ import { gitlabForgeView } from "./gitlab.view";
 export const CLIENT_FORGE_VIEW_MODULES: readonly ClientForgeViewModule[] = [
   githubForgeView,
   gitlabForgeView,
+  codeupForgeView,
   giteaForgeView,
   forgejoForgeView,
   codebergForgeView,

--- a/packages/app/src/git/merge-capability.test.ts
+++ b/packages/app/src/git/merge-capability.test.ts
@@ -45,6 +45,18 @@ type GiteaMergeFactsFixture = ForgeSpecificStatusFacts & {
   ciStatus: string | null;
 };
 
+type CodeupMergeFactsFixture = ForgeSpecificStatusFacts & {
+  forge: "codeup";
+  status: string;
+  allRequirementsPass: boolean;
+  requirementChecks: {
+    mergeConflict: boolean | null;
+    comments: boolean | null;
+    ci: boolean | null;
+    reviewerApproved: boolean | null;
+  };
+};
+
 function facts(overrides: Partial<GithubMergeFactsFixture> = {}): GithubMergeFactsFixture {
   return {
     forge: "github",
@@ -89,6 +101,21 @@ function giteaFacts(overrides: Partial<GiteaMergeFactsFixture> = {}): GiteaMerge
     mergeable: true,
     hasMerged: false,
     ciStatus: "success",
+    ...overrides,
+  };
+}
+
+function codeupFacts(overrides: Partial<CodeupMergeFactsFixture> = {}): CodeupMergeFactsFixture {
+  return {
+    forge: "codeup",
+    status: "TO_BE_MERGED",
+    allRequirementsPass: true,
+    requirementChecks: {
+      mergeConflict: true,
+      comments: true,
+      ci: true,
+      reviewerApproved: true,
+    },
     ...overrides,
   };
 }
@@ -296,5 +323,34 @@ describe("deriveMergeCapability (gitea)", () => {
     expect(capability?.canEnableAutoMerge).toBe(false);
     expect(capability?.autoMergeEnabled).toBe(false);
     expect(capability?.canDisableAutoMerge).toBe(false);
+  });
+});
+
+describe("deriveMergeCapability (codeup)", () => {
+  it("allows direct merge only after Codeup reports every requirement passed", () => {
+    expect(deriveMergeCapability(codeupFacts())?.directMergeReady).toBe(true);
+    expect(
+      deriveMergeCapability(codeupFacts({ allRequirementsPass: false }))?.directMergeReady,
+    ).toBe(false);
+    expect(
+      deriveMergeCapability(
+        codeupFacts({ requirementChecks: { ...codeupFacts().requirementChecks, ci: false } }),
+      )?.directMergeReady,
+    ).toBe(false);
+    expect(deriveMergeCapability(codeupFacts({ status: "UNDER_REVIEW" }))?.directMergeReady).toBe(
+      false,
+    );
+  });
+
+  it("offers all direct merge methods and never exposes auto-merge", () => {
+    expect(deriveMergeCapability(codeupFacts())).toEqual({
+      directMergeReady: true,
+      canEnableAutoMerge: false,
+      autoMergeEnabled: false,
+      canDisableAutoMerge: false,
+      mergeBlockedByQueue: false,
+      allowedMethods: ["merge", "squash", "rebase"],
+      preferredMethod: null,
+    });
   });
 });

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -954,6 +954,7 @@ export const ar: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "حدّث هذا المضيف لاستخدام ميزات {{brand}}.",
         installCli: "ثبّت واجهة سطر الأوامر {{cli}} لاستخدام ميزات {{brand}}.",
         signIn: "نفّذ {{command}} لاستخدام ميزات {{brand}}.",
         generic: "قم بإعداد {{brand}} على هذا المضيف لاستخدام ميزاته.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -963,6 +963,7 @@ export const en = {
         },
       },
       forgeSetup: {
+        updateHost: "Update this host to use {{brand}} features.",
         installCli: "Install the {{cli}} CLI to use {{brand}} features.",
         signIn: "Run {{command}} to use {{brand}} features.",
         generic: "Set up {{brand}} on this host to use its features.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -985,6 +985,7 @@ export const es: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "Actualiza este host para usar las funciones de {{brand}}.",
         installCli: "Instala la CLI de {{cli}} para usar las funciones de {{brand}}.",
         signIn: "Ejecuta {{command}} para usar las funciones de {{brand}}.",
         generic: "Configura {{brand}} en este host para usar sus funciones.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -984,6 +984,7 @@ export const fr: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "Mettez à jour cet hôte pour utiliser les fonctionnalités {{brand}}.",
         installCli: "Installez la CLI {{cli}} pour utiliser les fonctionnalités {{brand}}.",
         signIn: "Exécutez {{command}} pour utiliser les fonctionnalités {{brand}}.",
         generic: "Configurez {{brand}} sur cet hôte pour utiliser ses fonctionnalités.",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -965,6 +965,7 @@ export const ja: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "{{brand}} の機能を使うには、このホストを更新してください。",
         installCli: "{{brand}} の機能を使うには {{cli}} CLI をインストールしてください。",
         signIn: "{{brand}} の機能を使うには {{command}} を実行してください。",
         generic: "このホストで {{brand}} をセットアップすると、その機能を使えます。",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -961,6 +961,7 @@ export const ko: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "{{brand}} 기능을 사용하려면 이 호스트를 업데이트하세요.",
         installCli: "{{brand}} 기능을 사용하려면 {{cli}} CLI를 설치하세요.",
         signIn: "{{brand}} 기능을 사용하려면 {{command}}를 실행하세요.",
         generic: "해당 기능을 사용하려면 이 호스트에 {{brand}}를 설정하세요.",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -976,6 +976,7 @@ export const ptBR: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "Atualize este host para usar os recursos do {{brand}}.",
         installCli: "Instale a CLI {{cli}} para usar os recursos do {{brand}}.",
         signIn: "Execute {{command}} para usar os recursos do {{brand}}.",
         generic: "Configure o {{brand}} neste host para usar seus recursos.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -976,6 +976,7 @@ export const ru: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "Обновите этот хост, чтобы использовать возможности {{brand}}.",
         installCli: "Установите CLI {{cli}}, чтобы использовать возможности {{brand}}.",
         signIn: "Выполните {{command}}, чтобы использовать возможности {{brand}}.",
         generic: "Настройте {{brand}} на этом хосте, чтобы использовать его функции.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -946,6 +946,7 @@ export const zhCN: TranslationResources = {
         },
       },
       forgeSetup: {
+        updateHost: "更新此 Host 以使用 {{brand}} 功能。",
         installCli: "安装 {{cli}} CLI 以使用 {{brand}} 功能。",
         signIn: "运行 {{command}} 以使用 {{brand}} 功能。",
         generic: "在此主机上设置 {{brand}} 以使用其功能。",

--- a/packages/protocol/src/forge-manifest.ts
+++ b/packages/protocol/src/forge-manifest.ts
@@ -79,6 +79,17 @@ export const FORGE_DEFINITIONS: ForgeDefinition[] = [
     cloudHosts: ["gitlab.com"],
   },
   {
+    id: "codeup",
+    displayName: "Codeup",
+    changeRequestAbbrev: "MR",
+    changeRequestNoun: "merge request",
+    changeRequestNumberPrefix: "!",
+    issueNumberPrefix: "#",
+    iconKind: "codeup",
+    signIn: { cli: "aliyun", command: "aliyun configure" },
+    cloudHosts: ["codeup.aliyun.com"],
+  },
+  {
     id: "gitea",
     displayName: "Gitea",
     changeRequestAbbrev: "PR",

--- a/packages/protocol/src/messages.checkout-pr-schema.test.ts
+++ b/packages/protocol/src/messages.checkout-pr-schema.test.ts
@@ -721,6 +721,19 @@ describe("checkout PR schemas", () => {
     });
   });
 
+  test("accepts the optional Codeup Forge server_info feature flag", () => {
+    expect(
+      ServerInfoStatusPayloadSchema.parse({
+        status: "server_info",
+        serverId: "srv_test",
+        features: { codeupForge: true },
+      }).features,
+    ).toEqual({ codeupForge: true });
+    expect(
+      ServerInfoStatusPayloadSchema.parse({ status: "server_info", serverId: "srv_old" }).features,
+    ).toBeUndefined();
+  });
+
   test("accepts the project removal server_info feature flag", () => {
     expect(
       ServerInfoStatusPayloadSchema.parse({

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3392,6 +3392,8 @@ export const ServerInfoStatusPayloadSchema = z
         // Daemon advertises pluggable non-GitHub forge support (the forge registry);
         // the client gates non-GitHub setup UI on it.
         forgeProviders: z.boolean().optional(),
+        /** Daemon has the Codeup Forge adapter, not only generic Forge routing. */
+        codeupForge: z.boolean().optional(),
         // COMPAT(selectiveAgentTimeline): added in v0.1.106, remove after 2027-01-12.
         selectiveAgentTimeline: z.boolean().optional(),
         // COMPAT(canonicalSubmittedPrompts): added in v0.2.6, remove gate after 2027-01-30.

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1742,6 +1742,7 @@ export class VoiceAssistantWebSocketServer {
         importSessionWorkspaceTarget: true,
         // COMPAT(forgeProviders): added in v0.1.106, drop the gate when daemon floor >= v0.1.106.
         forgeProviders: true,
+        codeupForge: true,
         // COMPAT(selectiveAgentTimeline): added in v0.1.106, remove after 2027-01-12.
         selectiveAgentTimeline: true,
         // COMPAT(canonicalSubmittedPrompts): added in v0.2.6, remove gate after 2027-01-30.

--- a/packages/server/src/services/codeup-facts.ts
+++ b/packages/server/src/services/codeup-facts.ts
@@ -1,0 +1,32 @@
+import type { ForgeSpecificStatusFacts } from "./forge-service.js";
+
+export interface CodeupRequirementChecks {
+  mergeConflict: boolean | null;
+  comments: boolean | null;
+  ci: boolean | null;
+  reviewerApproved: boolean | null;
+}
+
+export interface CodeupStatusFacts {
+  status: string;
+  allRequirementsPass: boolean;
+  requirementChecks: CodeupRequirementChecks;
+}
+
+export type CodeupForgeSpecificStatusFacts = ForgeSpecificStatusFacts & {
+  forge: "codeup";
+} & CodeupStatusFacts;
+
+export function isCodeupStatusFacts(
+  facts: ForgeSpecificStatusFacts | null | undefined,
+): facts is CodeupForgeSpecificStatusFacts {
+  return facts?.forge === "codeup";
+}
+
+export function isCodeupDirectMergeReady(facts: CodeupStatusFacts): boolean {
+  return (
+    facts.status === "TO_BE_MERGED" &&
+    facts.allRequirementsPass &&
+    Object.values(facts.requirementChecks).every((check) => check !== false)
+  );
+}

--- a/packages/server/src/services/codeup-service.real.e2e.test.ts
+++ b/packages/server/src/services/codeup-service.real.e2e.test.ts
@@ -1,0 +1,220 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { createCodeupService, parseCodeupRemoteIdentity } from "./codeup-service.js";
+
+const execFileAsync = promisify(execFile);
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required for the real Codeup Forge integration test`);
+  }
+  return value;
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    timeout: 120_000,
+  });
+  return result.stdout.trim();
+}
+
+async function codeupApi<T>(
+  cwd: string,
+  action: string,
+  parameters: ReadonlyArray<readonly [string, string]>,
+): Promise<T> {
+  const args = [
+    "--region",
+    "cn-hangzhou",
+    "--endpoint",
+    "devops.cn-hangzhou.aliyuncs.com",
+    "--language",
+    "en",
+    "devops",
+    action,
+  ];
+  for (const [name, value] of parameters) args.push(`--${name}`, value);
+  const result = await execFileAsync("aliyun", args, { cwd, timeout: 120_000 });
+  return JSON.parse(result.stdout) as T;
+}
+
+async function eventually<T>(
+  operation: () => Promise<T>,
+  accept: (value: T) => boolean,
+  description: string,
+): Promise<T> {
+  const deadline = Date.now() + 90_000;
+  let last: T | undefined;
+  while (Date.now() < deadline) {
+    last = await operation();
+    if (accept(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`Timed out waiting for ${description}; last value: ${JSON.stringify(last)}`);
+}
+
+describe("Codeup Forge real integration", () => {
+  it("creates, reads, checks out, and squash-merges a new Codeup merge request", async () => {
+    const repositoryUrl = requiredEnvironment("CODEUP_E2E_REPOSITORY_URL");
+    const baseBranch = requiredEnvironment("CODEUP_E2E_BASE_BRANCH");
+    const remoteIdentity = parseCodeupRemoteIdentity(repositoryUrl);
+    if (!remoteIdentity) throw new Error("CODEUP_E2E_REPOSITORY_URL is not a Codeup remote");
+    const checkout = await mkdtemp(path.join(tmpdir(), "paseo-codeup-e2e-"));
+    const suffix = `${Date.now()}-${randomUUID().slice(0, 8)}`;
+    const branch = `paseo/codeup-e2e-${suffix}`;
+    const title = `Paseo Codeup Forge E2E ${suffix}`;
+    const fixturePath = `.paseo-codeup-e2e-${suffix}.txt`;
+    const service = createCodeupService();
+    let repositoryId: number | null = null;
+    let createdMergeRequestNumber: number | null = null;
+    let merged = false;
+
+    try {
+      const repositoryResponse = await codeupApi<{
+        success?: boolean;
+        repository?: { id?: number };
+      }>(checkout, "GetRepository", [
+        ["organizationId", remoteIdentity.organizationId],
+        ["identity", remoteIdentity.repositoryIdentity],
+      ]);
+      repositoryId = repositoryResponse.repository?.id ?? null;
+      if (repositoryResponse.success !== true || repositoryId === null) {
+        throw new Error("Codeup did not return the E2E repository id");
+      }
+      await git(checkout, ["clone", "--branch", baseBranch, repositoryUrl, "."]);
+      await git(checkout, ["config", "user.email", "paseo-codeup-e2e@example.invalid"]);
+      await git(checkout, ["config", "user.name", "Paseo Codeup E2E"]);
+      await git(checkout, ["checkout", "-b", branch]);
+      await writeFile(path.join(checkout, fixturePath), `${title}\n`, "utf8");
+      await git(checkout, ["add", fixturePath]);
+      await git(checkout, ["-c", "commit.gpgsign=false", "commit", "-m", title]);
+      const headSha = await git(checkout, ["rev-parse", "HEAD"]);
+      await git(checkout, ["push", "-u", "origin", branch]);
+
+      await expect(service.isAuthenticated({ cwd: checkout })).resolves.toBe(true);
+      const created = await service.createPullRequest({
+        cwd: checkout,
+        title,
+        body: "Created by the Paseo Codeup Forge real integration test.",
+        head: branch,
+        base: baseBranch,
+      });
+      createdMergeRequestNumber = created.number;
+      expect(created.number).toBeGreaterThan(0);
+      expect(created.url).toContain("codeup.aliyun.com");
+
+      await expect(
+        service.listPullRequests({ cwd: checkout, query: title, limit: 10 }),
+      ).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ number: created.number })]),
+      );
+      await expect(
+        service.searchIssuesAndPrs({
+          cwd: checkout,
+          query: title,
+          kinds: ["change_request"],
+          limit: 10,
+        }),
+      ).resolves.toMatchObject({
+        authState: "authenticated",
+        items: expect.arrayContaining([expect.objectContaining({ number: created.number })]),
+      });
+      await expect(
+        service.searchIssuesAndPrs({ cwd: checkout, query: title, kinds: ["issue"] }),
+      ).resolves.toMatchObject({ authState: "authenticated", items: [] });
+
+      const status = await eventually(
+        () =>
+          service.getCurrentPullRequestStatus({
+            cwd: checkout,
+            headRef: branch,
+            headSha,
+            force: true,
+            reason: "Codeup real integration MR readiness",
+          }),
+        (value) =>
+          value?.forgeSpecific?.forge === "codeup" &&
+          value.forgeSpecific.status === "TO_BE_MERGED" &&
+          value.forgeSpecific.allRequirementsPass === true,
+        "Codeup MR readiness",
+      );
+      expect(status).toMatchObject({
+        number: created.number,
+        headRefName: branch,
+        forgeSpecific: { forge: "codeup", allRequirementsPass: true },
+      });
+      expect(Array.isArray(status?.checks)).toBe(true);
+
+      const timeline = await service.getPullRequestTimeline({
+        cwd: checkout,
+        prNumber: created.number,
+        repoOwner: "codeup",
+        repoName: "e2e",
+      });
+      expect(timeline.error).toBeNull();
+      expect(Array.isArray(timeline.items)).toBe(true);
+
+      const detailedCheck = status?.checks.find((check) => check.checkRunId !== undefined);
+      if (detailedCheck?.checkRunId !== undefined) {
+        await expect(
+          service.getCheckDetails({ cwd: checkout, checkRunId: detailedCheck.checkRunId }),
+        ).resolves.toMatchObject({ checkRunId: detailedCheck.checkRunId });
+      }
+
+      const target = await service.getPullRequestCheckoutTarget({
+        cwd: checkout,
+        number: created.number,
+      });
+      const checkoutRef = target.checkoutRefs?.[0];
+      expect(checkoutRef).toBeDefined();
+      if (!checkoutRef) throw new Error("Codeup did not provide a checkout ref");
+      const fetchSource = checkoutRef.remoteUrl ?? checkoutRef.remoteName ?? "origin";
+      await git(checkout, [
+        "fetch",
+        fetchSource,
+        `+${checkoutRef.remoteRef}:refs/remotes/paseo-codeup-e2e/head`,
+        "--force",
+      ]);
+      await expect(
+        git(checkout, ["rev-parse", "refs/remotes/paseo-codeup-e2e/head"]),
+      ).resolves.toBe(headSha);
+
+      await expect(
+        service.mergePullRequest({
+          cwd: checkout,
+          prNumber: created.number,
+          mergeMethod: "squash",
+          status: { forgeSpecific: status?.forgeSpecific },
+        }),
+      ).resolves.toEqual({ success: true });
+      merged = true;
+      await eventually(
+        () => service.getPullRequest({ cwd: checkout, number: created.number }),
+        (value) => value.state === "merged",
+        "Codeup MR merge completion",
+      );
+    } finally {
+      try {
+        if (createdMergeRequestNumber !== null && repositoryId !== null && !merged) {
+          await codeupApi(checkout, "CloseMergeRequest", [
+            ["organizationId", remoteIdentity.organizationId],
+            ["repositoryId", String(repositoryId)],
+            ["localId", String(createdMergeRequestNumber)],
+          ]);
+        }
+      } finally {
+        await git(checkout, ["push", "origin", "--delete", branch]).catch(() => undefined);
+        service.invalidate({ cwd: checkout });
+        await rm(checkout, { recursive: true, force: true });
+      }
+    }
+  }, 240_000);
+});

--- a/packages/server/src/services/codeup-service.test.ts
+++ b/packages/server/src/services/codeup-service.test.ts
@@ -1,0 +1,980 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ForgeSpecificStatusFacts } from "./forge-service.js";
+import {
+  AliyunAuthenticationError,
+  AliyunCliMissingError,
+  AliyunCommandError,
+  createCodeupService,
+  parseCodeupRemoteIdentity,
+  type CodeupCommandRunner,
+  type CreateCodeupServiceOptions,
+} from "./codeup-service.js";
+
+type Responder = (action: string, args: string[]) => unknown;
+
+const repository = {
+  id: 42,
+  name: "repo",
+  pathWithNamespace: "org/team/repo",
+  defaultBranch: "main",
+  sshUrlToRepository: "git@codeup.aliyun.com:org/team/repo.git",
+  httpUrlToRepository: "https://codeup.aliyun.com/org/team/repo.git",
+  webUrl: "https://codeup.aliyun.com/org/team/repo",
+};
+
+const listMr = {
+  localId: 7,
+  projectId: 42,
+  sourceProjectId: 42,
+  targetProjectId: 42,
+  sourceBranch: "feature/codeup",
+  targetBranch: "main",
+  title: "Add Codeup",
+  description: "MR body",
+  state: "opened",
+  workInProgress: false,
+  labels: [{ id: "label-1", name: "feature" }],
+  updatedAt: "2026-07-20T01:00:00Z",
+  detailUrl: "https://codeup.aliyun.com/org/team/repo/merge_request/7",
+  nameWithNamespace: "team/repo",
+};
+
+const detailMr = {
+  localId: 7,
+  projectId: 42,
+  sourceProjectId: 42,
+  targetProjectId: 42,
+  sourceBranch: "feature/codeup",
+  targetBranch: "main",
+  title: "Add Codeup",
+  description: "MR body",
+  status: "TO_BE_MERGED",
+  updateTime: "2026-07-20T01:00:00Z",
+  detailUrl: "https://codeup.aliyun.com/org/team/repo/merge_request/7",
+  reviewers: [
+    {
+      id: 9,
+      username: "reviewer",
+      avatarUrl: "https://example.test/avatar.png",
+      hasReviewed: true,
+      reviewOpinionStatus: "PASS",
+      reviewTime: "2026-07-20T00:30:00Z",
+    },
+  ],
+  allRequirementsPass: true,
+  todoList: {
+    requirementCheckItems: [
+      { itemType: "MERGE_CONFLICT_CHECK", pass: true },
+      { itemType: "CI_CHECK", pass: true },
+      { itemType: "REVIEWER_APPROVED_CHECK", pass: true },
+    ],
+  },
+};
+
+function actionOf(args: string[]): string {
+  const productIndex = args.indexOf("devops");
+  if (productIndex >= 0) return args[productIndex + 1] ?? "";
+  const stsIndex = args.indexOf("sts");
+  return stsIndex >= 0 ? `sts:${args[stsIndex + 1] ?? ""}` : "";
+}
+
+function argValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(`--${name}`);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function defaultResponder(action: string): unknown {
+  switch (action) {
+    case "sts:GetCallerIdentity":
+      return { AccountId: "123" };
+    case "GetRepository":
+      return { success: true, repository };
+    case "ListMergeRequests":
+      return { success: true, result: [listMr], total: 1 };
+    case "GetMergeRequest":
+      return { success: true, result: detailMr };
+    case "ListMergeRequestPatchSets":
+      return {
+        success: true,
+        result: [
+          {
+            patchSetNo: 2,
+            relatedMergeItemType: "MERGE_SOURCE",
+            commitId: "head-sha",
+          },
+          {
+            patchSetNo: 1,
+            relatedMergeItemType: "MERGE_SOURCE",
+            commitId: "old-sha",
+          },
+        ],
+      };
+    case "ListCheckRuns":
+      return {
+        success: true,
+        total: 1,
+        result: [
+          {
+            id: 501,
+            name: "unit",
+            status: "completed",
+            conclusion: "success",
+            detailsUrl: "https://ci.example.test/unit",
+            startedAt: "2026-07-20T00:00:00Z",
+            completedAt: "2026-07-20T00:01:05Z",
+          },
+        ],
+      };
+    case "ListCommitStatuses":
+      return {
+        success: true,
+        total: 1,
+        result: [
+          {
+            id: 601,
+            context: "security",
+            state: "failure",
+            targetUrl: "https://ci.example.test/security",
+          },
+        ],
+      };
+    case "ListMergeRequestComments":
+      return { success: true, result: [] };
+    case "GetCheckRun":
+      return {
+        success: true,
+        result: {
+          id: 501,
+          name: "unit",
+          status: "completed",
+          conclusion: "failure",
+          detailsUrl: "https://ci.example.test/unit",
+          output: { title: "Unit tests", summary: "One failed", text: "details" },
+          annotations: [
+            {
+              path: "src/index.ts",
+              startLine: 3,
+              endLine: 4,
+              annotationLevel: "failure",
+              message: "Expected true",
+            },
+          ],
+        },
+      };
+    case "CreateMergeRequest":
+      return { success: true, result: { ...detailMr, sourceProjectId: undefined } };
+    case "MergeMergeRequest":
+      return { success: true, result: { result: true, localId: 7 } };
+    default:
+      throw new Error(`Unexpected Codeup action: ${action}`);
+  }
+}
+
+function makeService(
+  responder: Responder = defaultResponder,
+  overrides: Partial<CreateCodeupServiceOptions> = {},
+) {
+  const runner = vi.fn<CodeupCommandRunner>(async (args) => ({
+    stdout: JSON.stringify(responder(actionOf(args), args)),
+    stderr: "",
+  }));
+  const service = createCodeupService({
+    runner,
+    resolveAliyunPath: async () => "/usr/bin/aliyun",
+    resolveRemoteUrl: async () => "git@codeup.aliyun.com:org/team/repo.git",
+    ...overrides,
+  });
+  return { service, runner };
+}
+
+function mergeFacts(overrides: Partial<Record<string, unknown>> = {}): ForgeSpecificStatusFacts {
+  return {
+    forge: "codeup",
+    status: "TO_BE_MERGED",
+    allRequirementsPass: true,
+    requirementChecks: {
+      mergeConflict: true,
+      comments: true,
+      ci: true,
+      reviewerApproved: true,
+    },
+    ...overrides,
+  };
+}
+
+function mergeRequestPage(count: number, offset: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    ...listMr,
+    localId: offset + index + 1,
+  }));
+}
+
+function nonmatchingMergeRequestPage(page: number) {
+  const offset = (page - 1) * 100;
+  return Array.from({ length: 100 }, (_, index) => ({
+    ...listMr,
+    localId: offset + index + 1,
+    sourceBranch: `other/${offset + index + 1}`,
+  }));
+}
+
+describe("parseCodeupRemoteIdentity", () => {
+  it("parses SSH and HTTPS remotes into organization and repository identity", () => {
+    expect(parseCodeupRemoteIdentity("git@codeup.aliyun.com:org/group/sub/repo.git")).toEqual({
+      organizationId: "org",
+      repositoryIdentity: "org/group/sub/repo",
+    });
+    expect(parseCodeupRemoteIdentity("https://codeup.aliyun.com/org/group/repo.git")).toEqual({
+      organizationId: "org",
+      repositoryIdentity: "org/group/repo",
+    });
+  });
+
+  it("rejects remotes without both organization and repository path", () => {
+    expect(parseCodeupRemoteIdentity("https://codeup.aliyun.com/org.git")).toBeNull();
+    expect(parseCodeupRemoteIdentity("not a remote")).toBeNull();
+  });
+});
+
+describe("createCodeupService", () => {
+  it("classifies a missing CLI and invalid Alibaba Cloud credentials", async () => {
+    const missing = createCodeupService({
+      resolveAliyunPath: async () => null,
+      resolveRemoteUrl: async () => "git@codeup.aliyun.com:org/team/repo.git",
+    });
+    await expect(missing.isAuthenticated({ cwd: "/repo" })).rejects.toBeInstanceOf(
+      AliyunCliMissingError,
+    );
+
+    const invalid = createCodeupService({
+      runner: async () => {
+        throw { code: 1, stderr: "InvalidAccessKeyId.NotFound" };
+      },
+      resolveAliyunPath: async () => "/usr/bin/aliyun",
+      resolveRemoteUrl: async () => "git@codeup.aliyun.com:org/team/repo.git",
+    });
+    await expect(invalid.isAuthenticated({ cwd: "/repo" })).rejects.toBeInstanceOf(
+      AliyunAuthenticationError,
+    );
+
+    const unconfigured = createCodeupService({
+      runner: async () => {
+        throw {
+          code: 3,
+          stderr: "profile default is not configure yet; Configuration failed",
+        };
+      },
+      resolveAliyunPath: async () => "/usr/bin/aliyun",
+      resolveRemoteUrl: async () => "git@codeup.aliyun.com:org/team/repo.git",
+    });
+    await expect(unconfigured.isAuthenticated({ cwd: "/repo" })).rejects.toBeInstanceOf(
+      AliyunAuthenticationError,
+    );
+  });
+
+  it("uses STS identity for the throwing auth probe", async () => {
+    const { service, runner } = makeService();
+    await expect(service.isAuthenticated({ cwd: "/repo" })).resolves.toBe(true);
+    expect(actionOf(runner.mock.calls[0]?.[0] ?? [])).toBe("sts:GetCallerIdentity");
+    expect(service.authProbeCanThrow).toBe(true);
+  });
+
+  it("uses the complete remote path with the CLI's built-in DevOps API version", async () => {
+    const { service, runner } = makeService();
+    await service.getPullRequest({ cwd: "/repo", number: 7 });
+    const args = runner.mock.calls.find(
+      ([callArgs]) => actionOf(callArgs) === "GetRepository",
+    )?.[0];
+    expect(argValue(args ?? [], "identity")).toBe("org/team/repo");
+    expect(args).not.toContain("--version");
+  });
+
+  it("maps an open Codeup MR, requirements, reviews, checks, and commit statuses", async () => {
+    const { service } = makeService();
+    const status = await service.getCurrentPullRequestStatus({
+      cwd: "/repo",
+      headRef: "feature/codeup",
+      headSha: "local-ahead-sha",
+    });
+    expect(status).toEqual(
+      expect.objectContaining({
+        number: 7,
+        projectPath: "org/team/repo",
+        state: "open",
+        mergeable: "MERGEABLE",
+        reviewDecision: "approved",
+        checksStatus: "failure",
+        forgeSpecific: {
+          forge: "codeup",
+          status: "TO_BE_MERGED",
+          allRequirementsPass: true,
+          requirementChecks: {
+            mergeConflict: true,
+            comments: null,
+            ci: true,
+            reviewerApproved: true,
+          },
+        },
+      }),
+    );
+    expect(status?.checks).toEqual([
+      {
+        name: "unit",
+        status: "success",
+        url: "https://ci.example.test/unit",
+        checkRunId: 501,
+        duration: "1m 5s",
+      },
+      {
+        name: "security",
+        status: "failure",
+        url: "https://ci.example.test/security",
+      },
+    ]);
+  });
+
+  it("preserves cancelled and skipped check-run outcomes", async () => {
+    const { service } = makeService((action, args) => {
+      if (action === "ListCheckRuns") {
+        return {
+          success: true,
+          total: 2,
+          result: [
+            { id: 1, name: "cancelled", status: "completed", conclusion: "cancelled" },
+            { id: 2, name: "skipped", status: "completed", conclusion: "skipped" },
+          ],
+        };
+      }
+      if (action === "ListCommitStatuses") {
+        return { success: true, total: 0, result: [] };
+      }
+      return defaultResponder(action, args);
+    });
+    const status = await service.getCurrentPullRequestStatus({
+      cwd: "/repo",
+      headRef: "feature/codeup",
+    });
+    expect(status?.checks).toEqual([
+      { name: "cancelled", status: "cancelled", url: null, checkRunId: 1 },
+      { name: "skipped", status: "skipped", url: null, checkRunId: 2 },
+    ]);
+  });
+
+  it("paginates checks and commit statuses when total is omitted", async () => {
+    const firstCheckPage = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      name: `check-${index + 1}`,
+      status: "completed",
+      conclusion: "success",
+    }));
+    const firstStatusPage = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      context: `status-${index + 1}`,
+      state: "success",
+    }));
+    const { service, runner } = makeService((action, args) => {
+      const page = argValue(args, "page");
+      if (action === "ListCheckRuns") {
+        return {
+          success: true,
+          result:
+            page === "1"
+              ? firstCheckPage
+              : [{ id: 101, name: "check-101", status: "completed", conclusion: "success" }],
+        };
+      }
+      if (action === "ListCommitStatuses") {
+        return {
+          success: true,
+          result:
+            page === "1" ? firstStatusPage : [{ id: 101, context: "status-101", state: "success" }],
+        };
+      }
+      return defaultResponder(action, args);
+    });
+
+    const status = await service.getCurrentPullRequestStatus({
+      cwd: "/repo",
+      headRef: "feature/codeup",
+    });
+    expect(status?.checks).toHaveLength(202);
+    expect(status?.checks[100]).toMatchObject({ name: "check-101", checkRunId: 101 });
+    expect(status?.checks[201]).toMatchObject({ name: "status-101" });
+    for (const action of ["ListCheckRuns", "ListCommitStatuses"]) {
+      const calls = runner.mock.calls.filter(([args]) => actionOf(args) === action);
+      expect(calls.map(([args]) => argValue(args, "page"))).toEqual(["1", "2"]);
+    }
+  });
+
+  it("maps draft, conflict, and rejected-review status", async () => {
+    const { service } = makeService((action, args) => {
+      if (action === "GetMergeRequest") {
+        return {
+          success: true,
+          result: {
+            ...detailMr,
+            status: "UNDER_DEV",
+            allRequirementsPass: false,
+            reviewers: [
+              {
+                id: 10,
+                username: "reviewer",
+                hasReviewed: true,
+                reviewOpinionStatus: "NOT_PASS",
+                reviewTime: "2026-07-20T00:40:00Z",
+              },
+            ],
+            todoList: {
+              requirementCheckItems: [
+                { itemType: "MERGE_CONFLICT_CHECK", pass: false },
+                { itemType: "REVIEWER_APPROVED_CHECK", pass: false },
+              ],
+            },
+          },
+        };
+      }
+      return defaultResponder(action, args);
+    });
+    await expect(
+      service.getCurrentPullRequestStatus({ cwd: "/repo", headRef: "feature/codeup" }),
+    ).resolves.toMatchObject({
+      isDraft: true,
+      mergeable: "CONFLICTING",
+      reviewDecision: "changes_requested",
+      forgeSpecific: {
+        forge: "codeup",
+        status: "UNDER_DEV",
+        allRequirementsPass: false,
+        requirementChecks: {
+          mergeConflict: false,
+          reviewerApproved: false,
+        },
+      },
+    });
+    await expect(
+      service.getPullRequestTimeline({
+        cwd: "/repo",
+        prNumber: 7,
+        repoOwner: "team",
+        repoName: "repo",
+      }),
+    ).resolves.toMatchObject({
+      items: [expect.objectContaining({ kind: "review", reviewState: "changes_requested" })],
+    });
+  });
+
+  it("does not attach a terminal MR until its latest source patch matches HEAD", async () => {
+    const stale = { ...listMr, localId: 6, state: "merged", updatedAt: "2026-07-20T02:00:00Z" };
+    const matching = { ...listMr, localId: 5, state: "closed" };
+    const { service } = makeService((action, args) => {
+      if (action === "ListMergeRequests") {
+        return { success: true, result: [stale, matching], total: 2 };
+      }
+      if (action === "ListMergeRequestPatchSets") {
+        return {
+          success: true,
+          result: [
+            {
+              commentBizId: "system",
+              commentTime: "2026-07-20T00:05:00Z",
+              commentType: "SYSTEM_COMMENT",
+              content: "System event",
+            },
+            {
+              patchSetNo: 1,
+              relatedMergeItemType: "MERGE_SOURCE",
+              commitId: argValue(args, "localId") === "5" ? "current-head" : "stale-head",
+            },
+          ],
+        };
+      }
+      if (action === "GetMergeRequest") {
+        return {
+          success: true,
+          result: { ...detailMr, localId: Number(argValue(args, "localId")), status: "CLOSED" },
+        };
+      }
+      return defaultResponder(action, args);
+    });
+
+    await expect(
+      service.getCurrentPullRequestStatus({
+        cwd: "/repo",
+        headRef: "feature/codeup",
+        headSha: "current-head",
+      }),
+    ).resolves.toMatchObject({ number: 5, state: "closed" });
+  });
+
+  it("finds the current MR beyond the first page of recently updated requests", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      ...listMr,
+      localId: index + 1,
+      sourceBranch: `other/${index + 1}`,
+    }));
+    const target = { ...listMr, localId: 101 };
+    const { service, runner } = makeService((action, args) => {
+      if (action === "ListMergeRequests") {
+        return {
+          success: true,
+          result: argValue(args, "page") === "1" ? firstPage : [target],
+        };
+      }
+      if (action === "GetMergeRequest") {
+        return { success: true, result: { ...detailMr, localId: target.localId } };
+      }
+      return defaultResponder(action, args);
+    });
+
+    await expect(
+      service.getCurrentPullRequestStatus({ cwd: "/repo", headRef: target.sourceBranch }),
+    ).resolves.toMatchObject({ number: target.localId, state: "open" });
+    const listCalls = runner.mock.calls.filter(
+      ([callArgs]) => actionOf(callArgs) === "ListMergeRequests",
+    );
+    expect(listCalls.map(([args]) => argValue(args, "page"))).toEqual(["1", "2"]);
+    expect(listCalls.map(([args]) => argValue(args, "pageSize"))).toEqual(["100", "100"]);
+  });
+
+  it("fails when current-MR pagination repeats a full page without total", async () => {
+    const repeatedPage = nonmatchingMergeRequestPage(1);
+    const { service, runner } = makeService((action, args) => {
+      if (action === "ListMergeRequests") {
+        const page = Number(argValue(args, "page"));
+        if (page > 2) throw new Error("pagination continued past the repeated page");
+        return { success: true, result: repeatedPage };
+      }
+      return defaultResponder(action, args);
+    });
+
+    await expect(
+      service.getCurrentPullRequestStatus({ cwd: "/repo", headRef: "feature/codeup" }),
+    ).rejects.toThrow("repeated a full page");
+    const listCalls = runner.mock.calls.filter(
+      ([callArgs]) => actionOf(callArgs) === "ListMergeRequests",
+    );
+    expect(listCalls.map(([args]) => argValue(args, "page"))).toEqual(["1", "2"]);
+  });
+
+  it("returns a current MR from the final page allowed without total", async () => {
+    const target = { ...listMr, localId: 10_001 };
+    const { service, runner } = makeService((action, args) => {
+      if (action === "ListMergeRequests") {
+        const page = Number(argValue(args, "page"));
+        if (page > 101) throw new Error("pagination continued past the safety cap");
+        const result = nonmatchingMergeRequestPage(page);
+        if (page === 101) result[0] = target;
+        return { success: true, result };
+      }
+      if (action === "GetMergeRequest") {
+        return { success: true, result: { ...detailMr, localId: target.localId } };
+      }
+      return defaultResponder(action, args);
+    });
+
+    await expect(
+      service.getCurrentPullRequestStatus({ cwd: "/repo", headRef: target.sourceBranch }),
+    ).resolves.toMatchObject({ number: target.localId, state: "open" });
+    const listCalls = runner.mock.calls.filter(
+      ([callArgs]) => actionOf(callArgs) === "ListMergeRequests",
+    );
+    expect(argValue(listCalls.at(-1)?.[0] ?? [], "page")).toBe("101");
+  });
+
+  it("caps current-MR pagination when full pages omit total", async () => {
+    const { service, runner } = makeService((action, args) => {
+      if (action === "ListMergeRequests") {
+        const page = Number(argValue(args, "page"));
+        if (page > 101) throw new Error("pagination continued past the safety cap");
+        return { success: true, result: nonmatchingMergeRequestPage(page) };
+      }
+      return defaultResponder(action, args);
+    });
+
+    await expect(
+      service.getCurrentPullRequestStatus({ cwd: "/repo", headRef: "feature/codeup" }),
+    ).rejects.toThrow("exceeded 100 continuations");
+    const listCalls = runner.mock.calls.filter(
+      ([callArgs]) => actionOf(callArgs) === "ListMergeRequests",
+    );
+    expect(argValue(listCalls.at(-1)?.[0] ?? [], "page")).toBe("101");
+  });
+
+  it("requires the source repository identity when the worktree came from a fork", async () => {
+    const forkMr = { ...listMr, sourceProjectId: 99 };
+    const { service } = makeService((action, args) => {
+      if (action === "GetRepository" && argValue(args, "identity") === "99") {
+        return {
+          success: true,
+          repository: {
+            ...repository,
+            id: 99,
+            pathWithNamespace: "org/contributor/repo",
+            sshUrlToRepository: "git@codeup.aliyun.com:org/contributor/repo.git",
+            httpUrlToRepository: "https://codeup.aliyun.com/org/contributor/repo.git",
+          },
+        };
+      }
+      if (action === "ListMergeRequests") {
+        return { success: true, result: [forkMr], total: 1 };
+      }
+      return defaultResponder(action, args);
+    });
+
+    await expect(
+      service.getCurrentPullRequestStatus({
+        cwd: "/repo",
+        headRef: "feature/codeup",
+        headRepositoryOwner: "someone-else/repo",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      service.getCurrentPullRequestStatus({
+        cwd: "/repo",
+        headRef: "feature/codeup",
+        headRepositoryOwner: "org/contributor/repo",
+      }),
+    ).resolves.toMatchObject({ number: 7 });
+  });
+
+  it("fetches cross-repository checkout heads directly from the source repository URL", async () => {
+    const { service } = makeService((action, args) => {
+      if (action === "GetMergeRequest") {
+        return { success: true, result: { ...detailMr, sourceProjectId: 99 } };
+      }
+      if (action === "GetRepository" && argValue(args, "identity") === "99") {
+        return {
+          success: true,
+          repository: {
+            ...repository,
+            id: 99,
+            pathWithNamespace: "org/contributor/repo",
+            sshUrlToRepository: "git@codeup.aliyun.com:org/contributor/repo.git",
+            httpUrlToRepository: "https://codeup.aliyun.com/org/contributor/repo.git",
+          },
+        };
+      }
+      return defaultResponder(action, args);
+    });
+    await expect(
+      service.getPullRequestCheckoutTarget({ cwd: "/repo", number: 7 }),
+    ).resolves.toEqual({
+      number: 7,
+      baseRefName: "main",
+      headRefName: "feature/codeup",
+      checkoutRefs: [
+        {
+          remoteName: "origin",
+          remoteUrl: "git@codeup.aliyun.com:org/contributor/repo.git",
+          remoteRef: "refs/heads/feature/codeup",
+        },
+      ],
+      headOwnerLogin: "org/contributor/repo",
+      headRepositorySshUrl: "git@codeup.aliyun.com:org/contributor/repo.git",
+      headRepositoryUrl: "https://codeup.aliyun.com/org/contributor/repo.git",
+      isCrossRepository: true,
+    });
+  });
+
+  it("rejects a cross-repository checkout without a source clone URL", async () => {
+    const { service } = makeService((action, args) => {
+      if (action === "GetMergeRequest") {
+        return { success: true, result: { ...detailMr, sourceProjectId: 99 } };
+      }
+      if (action === "GetRepository" && argValue(args, "identity") === "99") {
+        return {
+          success: true,
+          repository: {
+            ...repository,
+            id: 99,
+            pathWithNamespace: "org/contributor/repo",
+            sshUrlToRepository: null,
+            httpUrlToRepository: null,
+          },
+        };
+      }
+      return defaultResponder(action, args);
+    });
+    await expect(service.getPullRequestCheckoutTarget({ cwd: "/repo", number: 7 })).rejects.toThrow(
+      "did not return a clone URL",
+    );
+  });
+
+  it("maps reviewer opinions and a three-level comment thread into the neutral timeline", async () => {
+    const { service } = makeService((action, args) => {
+      if (action === "ListMergeRequestComments") {
+        return {
+          success: true,
+          result: [
+            {
+              commentBizId: "root",
+              commentTime: "2026-07-20T00:10:00Z",
+              commentType: "INLINE_COMMENT",
+              content: "Root comment",
+              filePath: "src/index.ts",
+              lineNumber: "12",
+              resolved: true,
+              author: { username: "author" },
+              childComments: [
+                {
+                  commentBizId: "reply",
+                  rootCommentBizId: "root",
+                  commentTime: "2026-07-20T00:20:00Z",
+                  commentType: "GLOBAL_COMMENT",
+                  content: "Reply",
+                  author: { username: "reviewer" },
+                  finalChildComments: [
+                    {
+                      commentBizId: "deleted",
+                      rootCommentBizId: "root",
+                      commentTime: "2026-07-20T00:25:00Z",
+                      deleted: true,
+                      content: "deleted",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+      }
+      return defaultResponder(action, args);
+    });
+
+    const timeline = await service.getPullRequestTimeline({
+      cwd: "/repo",
+      prNumber: 7,
+      repoOwner: "team",
+      repoName: "repo",
+    });
+    expect(timeline.error).toBeNull();
+    expect(timeline.items.map((item) => item.id)).toEqual([
+      "root",
+      "reply",
+      "review:9:2026-07-20T00:30:00Z",
+    ]);
+    expect(timeline.items[0]).toMatchObject({
+      kind: "comment",
+      threadId: "root",
+      location: { path: "src/index.ts", line: 12, threadId: "root", isResolved: true },
+    });
+    expect(timeline.items[2]).toMatchObject({ kind: "review", reviewState: "approved" });
+  });
+
+  it("returns review activity together with an actionable comment API error", async () => {
+    const { service } = makeService((action, args) => {
+      if (action === "ListMergeRequestComments") {
+        throw { code: 1, stderr: "403 Forbidden" };
+      }
+      return defaultResponder(action, args);
+    });
+    const timeline = await service.getPullRequestTimeline({
+      cwd: "/repo",
+      prNumber: 7,
+      repoOwner: "team",
+      repoName: "repo",
+    });
+    expect(timeline.items).toHaveLength(1);
+    expect(timeline.error).toEqual({ kind: "forbidden", message: "403 Forbidden" });
+  });
+
+  it("returns check-run output and annotations for chat attachment", async () => {
+    const { service } = makeService();
+    await expect(service.getCheckDetails({ cwd: "/repo", checkRunId: 501 })).resolves.toMatchObject(
+      {
+        checkRunId: 501,
+        conclusion: "failure",
+        output: { title: "Unit tests", summary: "One failed", text: "details" },
+        annotations: [
+          {
+            path: "src/index.ts",
+            startLine: 3,
+            endLine: 4,
+            annotationLevel: "failure",
+            message: "Expected true",
+          },
+        ],
+      },
+    );
+  });
+
+  it("lists and searches only Codeup merge requests, while issue-only search stays empty", async () => {
+    const { service } = makeService();
+    await expect(
+      service.listPullRequests({ cwd: "/repo", query: "Codeup", limit: 5 }),
+    ).resolves.toEqual([
+      {
+        number: 7,
+        title: "Add Codeup",
+        url: "https://codeup.aliyun.com/org/team/repo/merge_request/7",
+        state: "open",
+        body: "MR body",
+        projectPath: "team/repo",
+        baseRefName: "main",
+        headRefName: "feature/codeup",
+        labels: ["feature"],
+        updatedAt: "2026-07-20T01:00:00Z",
+      },
+    ]);
+    await expect(
+      service.searchIssuesAndPrs({ cwd: "/repo", query: "", kinds: ["issue"] }),
+    ).resolves.toMatchObject({ items: [], featuresEnabled: true, authState: "authenticated" });
+    await expect(service.listIssues({ cwd: "/repo" })).resolves.toEqual([]);
+  });
+
+  it("paginates merge-request lists up to the requested limit when total is omitted", async () => {
+    const { service, runner } = makeService((action, args) => {
+      if (action === "ListMergeRequests") {
+        const page = Number(argValue(args, "page"));
+        const count = page === 1 ? 100 : 50;
+        const offset = page === 1 ? 0 : 100;
+        return {
+          success: true,
+          result: mergeRequestPage(count, offset),
+        };
+      }
+      return defaultResponder(action, args);
+    });
+    await expect(service.listPullRequests({ cwd: "/repo", limit: 150 })).resolves.toHaveLength(150);
+    const listCalls = runner.mock.calls.filter(
+      ([callArgs]) => actionOf(callArgs) === "ListMergeRequests",
+    );
+    expect(listCalls.map(([args]) => argValue(args, "page"))).toEqual(["1", "2"]);
+    expect(listCalls.map(([args]) => argValue(args, "pageSize"))).toEqual(["100", "50"]);
+  });
+
+  it.each(["reopened", "accepted", "locked"])(
+    "keeps the Codeup %s list state open",
+    async (state) => {
+      const { service } = makeService((action, args) => {
+        if (action === "ListMergeRequests") {
+          return { success: true, result: [{ ...listMr, state }], total: 1 };
+        }
+        return defaultResponder(action, args);
+      });
+      await expect(service.listPullRequests({ cwd: "/repo" })).resolves.toEqual([
+        expect.objectContaining({ state: "open" }),
+      ]);
+    },
+  );
+
+  it("creates an MR with the current repository as source and target", async () => {
+    const { service, runner } = makeService();
+    await expect(
+      service.createPullRequest({
+        cwd: "/repo",
+        title: "Create MR",
+        body: "body",
+        head: "feature/codeup",
+        base: "main",
+      }),
+    ).resolves.toEqual({
+      number: 7,
+      url: "https://codeup.aliyun.com/org/team/repo/merge_request/7",
+    });
+    const args = runner.mock.calls.find(
+      ([callArgs]) => actionOf(callArgs) === "CreateMergeRequest",
+    )?.[0];
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--endpoint",
+        "devops.cn-hangzhou.aliyuncs.com",
+        "--organizationId",
+        "org",
+        "--repositoryId",
+        "42",
+      ]),
+    );
+    expect(JSON.parse(argValue(args ?? [], "body") ?? "null")).toEqual({
+      sourceProjectId: 42,
+      sourceBranch: "feature/codeup",
+      targetProjectId: 42,
+      targetBranch: "main",
+      title: "Create MR",
+      createFrom: "WEB",
+      description: "body",
+    });
+  });
+
+  it.each([
+    ["merge", "no-fast-forward"],
+    ["squash", "squash"],
+    ["rebase", "rebase"],
+  ] as const)("maps the %s merge method to Codeup %s", async (method, expectedType) => {
+    const { service, runner } = makeService();
+    await expect(
+      service.mergePullRequest({
+        cwd: "/repo",
+        prNumber: 7,
+        mergeMethod: method,
+        status: { forgeSpecific: mergeFacts() },
+      }),
+    ).resolves.toEqual({ success: true });
+    const args = runner.mock.calls.find(
+      ([callArgs]) => actionOf(callArgs) === "MergeMergeRequest",
+    )?.[0];
+    expect(JSON.parse(argValue(args ?? [], "body") ?? "null")).toMatchObject({
+      mergeType: expectedType,
+      removeSourceBranch: false,
+    });
+    expect(argValue(args ?? [], "localId")).toBe("7");
+  });
+
+  it("refuses merge without ready Codeup facts and never exposes auto-merge", async () => {
+    const { service } = makeService();
+    await expect(
+      service.mergePullRequest({
+        cwd: "/repo",
+        prNumber: 7,
+        mergeMethod: "merge",
+        status: {
+          forgeSpecific: mergeFacts({ status: "UNDER_REVIEW", allRequirementsPass: false }),
+        },
+      }),
+    ).rejects.toThrow("Codeup does not report this merge request as ready");
+    expect(() =>
+      service.enablePullRequestAutoMerge({ cwd: "/repo", prNumber: 7, mergeMethod: "merge" }),
+    ).toThrow("not supported on Codeup");
+    expect(() => service.disablePullRequestAutoMerge({ cwd: "/repo", prNumber: 7 })).toThrow(
+      "not supported on Codeup",
+    );
+  });
+
+  it("treats success=false as a command error and retries repository resolution after invalidate", async () => {
+    let repositoryCalls = 0;
+    const { service } = makeService((action, args) => {
+      if (action === "GetRepository") {
+        repositoryCalls += 1;
+        if (repositoryCalls === 1) {
+          return { success: false, errorCode: "Openapi.RequestError", errorMessage: "denied" };
+        }
+      }
+      return defaultResponder(action, args);
+    });
+    await expect(service.getPullRequest({ cwd: "/repo", number: 7 })).rejects.toBeInstanceOf(
+      AliyunCommandError,
+    );
+    await expect(service.getPullRequest({ cwd: "/repo", number: 7 })).resolves.toMatchObject({
+      number: 7,
+    });
+    service.invalidate({ cwd: "/repo" });
+    await service.getPullRequest({ cwd: "/repo", number: 7 });
+    expect(repositoryCalls).toBe(3);
+  });
+
+  it("classifies credential failures returned with success=false", async () => {
+    const { service } = makeService((action, args) => {
+      if (action === "GetRepository") {
+        return {
+          success: false,
+          errorCode: "InvalidAccessKeyId.NotFound",
+          errorMessage: "The AccessKey ID does not exist",
+        };
+      }
+      return defaultResponder(action, args);
+    });
+    await expect(service.getPullRequest({ cwd: "/repo", number: 7 })).rejects.toBeInstanceOf(
+      AliyunAuthenticationError,
+    );
+  });
+});

--- a/packages/server/src/services/codeup-service.ts
+++ b/packages/server/src/services/codeup-service.ts
@@ -1,0 +1,1455 @@
+import { z } from "zod";
+import { parseGitRemoteLocation } from "@getpaseo/protocol/git-remote";
+import { findExecutable } from "../executable-resolution/executable-resolution.js";
+import {
+  createCachedCliPathResolver,
+  createForgeCliRunner,
+  defaultResolveRemoteUrl,
+  ForgeAuthenticationError,
+  ForgeCliMissingError,
+  ForgeCommandError,
+  parseCliJsonOutput,
+  type ForgeCommandFailureParams,
+} from "./forge-cli-command.js";
+import {
+  compareTimelineItems,
+  computeChecksStatus,
+  createUnavailableSearchResult,
+  normalizeForgeSearchKinds,
+  parseOptionalTime,
+} from "./forge-service.js";
+import type {
+  CheckDetails,
+  CreatePullRequestOptions,
+  CurrentPullRequestStatus,
+  DisablePullRequestAutoMergeOptions,
+  EnablePullRequestAutoMergeOptions,
+  ForgeReadOptions,
+  ForgeService,
+  GetCheckDetailsOptions,
+  GetPullRequestOptions,
+  GetPullRequestTimelineOptions,
+  IssueSummary,
+  ListIssuesOptions,
+  ListPullRequestsOptions,
+  MergePullRequestOptions,
+  PullRequestAutoMergeResult,
+  PullRequestCheck,
+  PullRequestCheckoutTarget,
+  PullRequestCreateResult,
+  PullRequestMergeable,
+  PullRequestMergeResult,
+  PullRequestSummary,
+  PullRequestTimeline,
+  PullRequestTimelineCommentLocation,
+  PullRequestTimelineError,
+  PullRequestTimelineItem,
+  SearchIssuesAndPrsOptions,
+  SearchResult,
+} from "./forge-service.js";
+import {
+  isCodeupDirectMergeReady,
+  isCodeupStatusFacts,
+  type CodeupRequirementChecks,
+  type CodeupStatusFacts,
+} from "./codeup-facts.js";
+
+const ALIYUN_ENV = {
+  GIT_TERMINAL_PROMPT: "0",
+  LC_ALL: "C",
+} as const;
+
+const ALIYUN_COMMAND_TIMEOUT_MS = 30_000;
+const CODEUP_REGION = "cn-hangzhou";
+const CODEUP_ENDPOINT = "devops.cn-hangzhou.aliyuncs.com";
+const CODEUP_PAGE_SIZE = 100;
+const CODEUP_MAX_CONTINUATIONS_WITHOUT_TOTAL = 100;
+
+function assertCodeupPageProgress(input: {
+  itemCount: number;
+  pageSize: number;
+  pageKeys: readonly string[];
+  seenFullPageFingerprints: Set<string>;
+}): void {
+  if (input.itemCount < input.pageSize) return;
+  const fingerprint = JSON.stringify(input.pageKeys);
+  if (input.seenFullPageFingerprints.has(fingerprint)) {
+    throw new Error("Codeup pagination repeated a full page without making progress");
+  }
+  input.seenFullPageFingerprints.add(fingerprint);
+}
+
+function hasNextCodeupPage(input: {
+  itemCount: number;
+  pageSize: number;
+  page: number;
+  visited: number;
+  total: number | undefined;
+}): boolean {
+  if (input.itemCount < input.pageSize) return false;
+  if (input.total !== undefined) return input.visited < input.total;
+  if (input.page > CODEUP_MAX_CONTINUATIONS_WITHOUT_TOTAL) {
+    throw new Error(
+      `Codeup pagination exceeded ${CODEUP_MAX_CONTINUATIONS_WITHOUT_TOTAL} continuations without total`,
+    );
+  }
+  return true;
+}
+
+export class AliyunCliMissingError extends ForgeCliMissingError {
+  constructor() {
+    super("Alibaba Cloud CLI (aliyun) is not installed or not in PATH");
+    this.name = "AliyunCliMissingError";
+  }
+}
+
+export class AliyunAuthenticationError extends ForgeAuthenticationError {
+  constructor(params: { stderr: string }) {
+    super("Alibaba Cloud CLI authentication failed", params);
+    this.name = "AliyunAuthenticationError";
+  }
+}
+
+export class AliyunCommandError extends ForgeCommandError {
+  constructor(params: ForgeCommandFailureParams) {
+    super({ brand: "Codeup", binary: "aliyun" }, params);
+    this.name = "AliyunCommandError";
+  }
+}
+
+export interface CodeupCommandRunnerOptions {
+  cwd: string;
+  envOverlay?: Record<string, string>;
+}
+
+export interface CodeupCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type CodeupCommandRunner = (
+  args: string[],
+  options: CodeupCommandRunnerOptions,
+) => Promise<CodeupCommandResult>;
+
+export interface CreateCodeupServiceOptions {
+  runner?: CodeupCommandRunner;
+  resolveAliyunPath?: () => Promise<string | null>;
+  resolveRemoteUrl?: (cwd: string) => Promise<string | null>;
+}
+
+export interface CodeupRemoteIdentity {
+  organizationId: string;
+  repositoryIdentity: string;
+}
+
+const CodeupApiEnvelopeSchema = z
+  .object({
+    success: z.boolean().optional(),
+    errorCode: z.union([z.string(), z.number()]).nullable().optional(),
+    errorMessage: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const CodeupRepositorySchema = z
+  .object({
+    id: z.number(),
+    name: z.string().optional(),
+    path: z.string().optional(),
+    pathWithNamespace: z.string(),
+    defaultBranch: z.string().optional(),
+    sshUrlToRepository: z.string().nullable().optional(),
+    httpUrlToRepository: z.string().nullable().optional(),
+    webUrl: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const CodeupGetRepositoryResponseSchema = CodeupApiEnvelopeSchema.extend({
+  repository: CodeupRepositorySchema.optional(),
+});
+
+const CodeupUserSchema = z
+  .object({
+    id: z.number().optional(),
+    name: z.string().optional(),
+    username: z.string().optional(),
+    avatarUrl: z.string().nullable().optional(),
+    hasReviewed: z.boolean().optional(),
+    reviewOpinionStatus: z.string().nullable().optional(),
+    reviewTime: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const CodeupLabelSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string(),
+  })
+  .passthrough();
+
+const CodeupMergeRequestListItemSchema = z
+  .object({
+    id: z.number().optional(),
+    iid: z.number().optional(),
+    localId: z.number(),
+    projectId: z.number(),
+    sourceProjectId: z.number(),
+    targetProjectId: z.number(),
+    sourceBranch: z.string(),
+    targetBranch: z.string(),
+    title: z.string(),
+    description: z.string().nullable().optional(),
+    state: z.string(),
+    workInProgress: z.boolean().optional(),
+    labels: z.array(CodeupLabelSchema).optional(),
+    updatedAt: z.string().optional(),
+    detailUrl: z.string().nullable().optional(),
+    webUrl: z.string().nullable().optional(),
+    nameWithNamespace: z.string().optional(),
+  })
+  .passthrough();
+
+const CodeupListMergeRequestsResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: z.array(CodeupMergeRequestListItemSchema).optional(),
+  total: z.number().optional(),
+});
+
+const CodeupRequirementCheckSchema = z
+  .object({
+    itemType: z.string(),
+    pass: z.boolean(),
+  })
+  .passthrough();
+
+const CodeupMergeRequestDetailSchema = z
+  .object({
+    localId: z.number(),
+    projectId: z.number(),
+    sourceProjectId: z.number(),
+    targetProjectId: z.number(),
+    sourceBranch: z.string(),
+    targetBranch: z.string(),
+    title: z.string(),
+    description: z.string().nullable().optional(),
+    status: z.string(),
+    createTime: z.string().optional(),
+    updateTime: z.string().optional(),
+    reviewers: z.array(CodeupUserSchema).optional(),
+    allRequirementsPass: z.boolean().optional(),
+    todoList: z
+      .object({
+        requirementCheckItems: z.array(CodeupRequirementCheckSchema).optional(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
+    detailUrl: z.string().nullable().optional(),
+    webUrl: z.string().nullable().optional(),
+    targetProjectPathWithNamespace: z.string().optional(),
+    mergedRevision: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const CodeupGetMergeRequestResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: CodeupMergeRequestDetailSchema.optional(),
+});
+
+const CodeupPatchSetSchema = z
+  .object({
+    commitId: z.string().optional(),
+    patchSetNo: z.number().optional(),
+    relatedMergeItemType: z.string().optional(),
+  })
+  .passthrough();
+
+const CodeupListPatchSetsResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: z.array(CodeupPatchSetSchema).optional(),
+});
+
+const CodeupCheckOutputSchema = z
+  .object({
+    title: z.string().nullable().optional(),
+    summary: z.string().nullable().optional(),
+    text: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const CodeupCheckAnnotationSchema = z
+  .object({
+    path: z.string().optional(),
+    startLine: z.number().optional(),
+    endLine: z.number().optional(),
+    annotationLevel: z.string().optional(),
+    message: z.string().optional(),
+    title: z.string().optional(),
+    rawDetails: z.string().optional(),
+  })
+  .passthrough();
+
+const CodeupCheckRunSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    status: z.string(),
+    conclusion: z.string().nullable().optional(),
+    detailsUrl: z.string().nullable().optional(),
+    startedAt: z.string().nullable().optional(),
+    completedAt: z.string().nullable().optional(),
+    output: CodeupCheckOutputSchema.nullable().optional(),
+    annotations: z.array(CodeupCheckAnnotationSchema).optional(),
+  })
+  .passthrough();
+
+const CodeupListCheckRunsResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: z.array(CodeupCheckRunSchema).optional(),
+  total: z.number().optional(),
+});
+
+const CodeupGetCheckRunResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: CodeupCheckRunSchema.optional(),
+});
+
+const CodeupCommitStatusSchema = z
+  .object({
+    id: z.number().optional(),
+    context: z.string().optional(),
+    description: z.string().nullable().optional(),
+    state: z.string(),
+    targetUrl: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const CodeupListCommitStatusesResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: z.array(CodeupCommitStatusSchema).optional(),
+  total: z.number().optional(),
+});
+
+const CodeupCommentSchema = z
+  .object({
+    commentBizId: z.string(),
+    parentCommentBizId: z.string().nullable().optional(),
+    rootCommentBizId: z.string().nullable().optional(),
+    commentTime: z.string().nullable().optional(),
+    commentType: z.string().optional(),
+    content: z.string().nullable().optional(),
+    deleted: z.boolean().optional(),
+    filePath: z.string().nullable().optional(),
+    lineNumber: z.string().nullable().optional(),
+    resolved: z.boolean().optional(),
+    author: CodeupUserSchema.nullable().optional(),
+    childComments: z.array(z.unknown()).optional(),
+    finalChildComments: z.array(z.unknown()).optional(),
+  })
+  .passthrough();
+
+const CodeupListCommentsResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: z.array(z.unknown()).optional(),
+});
+
+const CodeupCreateMergeRequestResponseSchema = CodeupApiEnvelopeSchema.extend({
+  // The create response is intentionally smaller than GetMergeRequest (for
+  // example, Codeup omits sourceProjectId even though the request supplied it).
+  result: z
+    .object({
+      localId: z.number(),
+      detailUrl: z.string().nullable().optional(),
+      webUrl: z.string().nullable().optional(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+const CodeupMergeResponseSchema = CodeupApiEnvelopeSchema.extend({
+  result: z
+    .object({
+      result: z.boolean().optional(),
+      localId: z.number().optional(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+type CodeupApiEnvelope = z.infer<typeof CodeupApiEnvelopeSchema>;
+type CodeupRepository = z.infer<typeof CodeupRepositorySchema>;
+type CodeupMergeRequestListItem = z.infer<typeof CodeupMergeRequestListItemSchema>;
+type CodeupMergeRequestDetail = z.infer<typeof CodeupMergeRequestDetailSchema>;
+type CodeupCheckRun = z.infer<typeof CodeupCheckRunSchema>;
+type CodeupCommitStatus = z.infer<typeof CodeupCommitStatusSchema>;
+type CodeupComment = z.infer<typeof CodeupCommentSchema>;
+
+interface CodeupRepositoryContext {
+  organizationId: string;
+  repositoryIdentity: string;
+  repository: CodeupRepository;
+}
+
+const aliyunCliRunner = createForgeCliRunner({
+  binary: "aliyun",
+  envOverlay: ALIYUN_ENV,
+  timeoutMs: ALIYUN_COMMAND_TIMEOUT_MS,
+  isAuthFailureText,
+  errorClasses: {
+    isAlreadyClassified: (candidate) =>
+      candidate instanceof AliyunAuthenticationError || candidate instanceof AliyunCliMissingError,
+    isCommandError: (candidate): candidate is AliyunCommandError =>
+      candidate instanceof AliyunCommandError,
+    createAuthError: (stderr) => new AliyunAuthenticationError({ stderr }),
+    createMissingError: () => new AliyunCliMissingError(),
+    createCommandError: (params) => new AliyunCommandError(params),
+  },
+});
+
+async function runAliyunCommand(
+  args: string[],
+  options: CodeupCommandRunnerOptions,
+): Promise<CodeupCommandResult> {
+  return aliyunCliRunner.run(args, options);
+}
+
+async function resolveAliyunPath(): Promise<string | null> {
+  return findExecutable("aliyun");
+}
+
+export function parseCodeupRemoteIdentity(remoteUrl: string): CodeupRemoteIdentity | null {
+  const location = parseGitRemoteLocation(remoteUrl);
+  if (!location) {
+    return null;
+  }
+  const segments = location.path.split("/").filter(Boolean);
+  const organizationId = segments.shift();
+  if (!organizationId || segments.length === 0) {
+    return null;
+  }
+  return { organizationId, repositoryIdentity: location.path };
+}
+
+function isAuthFailureText(text: string): boolean {
+  return /\b(InvalidAccessKeyId|SignatureDoesNotMatch|InvalidSecurityToken|MissingAccessKeyId|ExpiredSecurityToken|AuthFailure|Unauthorized|not configure(?:d)?|configuration failed)\b/i.test(
+    text,
+  );
+}
+
+function isNoPermissionText(text: string): boolean {
+  return /\b(403|forbidden|no.?permission|access.?denied|Forbidden\.RAM)\b/i.test(text);
+}
+
+function isNotFoundText(text: string): boolean {
+  return /\b(404|not.?found|repositorynotfound|mergerequestnotfound)\b/i.test(text);
+}
+
+function apiArgs(action: string, parameters: ReadonlyArray<readonly [string, string]>): string[] {
+  // The official aliyun CLI's built-in `devops` metadata selects 2021-06-25.
+  // Passing --version explicitly makes v3.4.8 reject the command as an
+  // "unchecked version", even with the otherwise valid fixed endpoint.
+  const args = [
+    "--region",
+    CODEUP_REGION,
+    "--endpoint",
+    CODEUP_ENDPOINT,
+    "--language",
+    "en",
+    "devops",
+    action,
+  ];
+  for (const [name, value] of parameters) {
+    args.push(`--${name}`, value);
+  }
+  return args;
+}
+
+function apiErrorText(response: CodeupApiEnvelope): string {
+  return [response.errorCode, response.errorMessage]
+    .filter((value) => value !== null && value !== undefined && String(value).length > 0)
+    .join(": ");
+}
+
+function mapListState(state: string): string {
+  if (["opened", "reopened", "accepted", "locked"].includes(state)) return "open";
+  if (state === "merged") return "merged";
+  return "closed";
+}
+
+function mapDetailState(status: string): string {
+  if (status === "MERGED") return "merged";
+  if (status === "CLOSED") return "closed";
+  return "open";
+}
+
+function detailUrl(mr: { detailUrl?: string | null; webUrl?: string | null }): string {
+  return mr.detailUrl?.trim() || mr.webUrl?.trim() || "";
+}
+
+function listItemToSummary(mr: CodeupMergeRequestListItem): PullRequestSummary {
+  return {
+    number: mr.localId,
+    title: mr.title,
+    url: detailUrl(mr),
+    state: mapListState(mr.state),
+    body: mr.description ?? null,
+    ...(mr.nameWithNamespace ? { projectPath: mr.nameWithNamespace } : {}),
+    baseRefName: mr.targetBranch,
+    headRefName: mr.sourceBranch,
+    labels: (mr.labels ?? []).map((label) => label.name),
+    updatedAt: mr.updatedAt ?? "",
+  };
+}
+
+function toSearchChangeRequest(mr: PullRequestSummary): SearchResult["items"][number] {
+  const item: SearchResult["items"][number] = {
+    kind: "change_request",
+    forge: "codeup",
+    number: mr.number,
+    title: mr.title,
+    url: mr.url,
+    state: mr.state,
+    body: mr.body,
+    labels: mr.labels,
+    baseRefName: mr.baseRefName,
+    headRefName: mr.headRefName,
+    updatedAt: mr.updatedAt,
+  };
+  if (mr.projectPath) item.projectPath = mr.projectPath;
+  return item;
+}
+
+function detailToSummary(mr: CodeupMergeRequestDetail, projectPath?: string): PullRequestSummary {
+  return {
+    number: mr.localId,
+    title: mr.title,
+    url: detailUrl(mr),
+    state: mapDetailState(mr.status),
+    body: mr.description ?? null,
+    ...(projectPath ? { projectPath } : {}),
+    baseRefName: mr.targetBranch,
+    headRefName: mr.sourceBranch,
+    labels: [],
+    updatedAt: mr.updateTime ?? "",
+  };
+}
+
+function toRequirementChecks(mr: CodeupMergeRequestDetail): CodeupRequirementChecks {
+  const byType = new Map(
+    (mr.todoList?.requirementCheckItems ?? []).map((item) => [item.itemType, item.pass]),
+  );
+  return {
+    mergeConflict: byType.get("MERGE_CONFLICT_CHECK") ?? null,
+    comments: byType.get("COMMENTS_CHECK") ?? null,
+    ci: byType.get("CI_CHECK") ?? null,
+    reviewerApproved: byType.get("REVIEWER_APPROVED_CHECK") ?? null,
+  };
+}
+
+function toStatusFacts(mr: CodeupMergeRequestDetail): CodeupStatusFacts {
+  return {
+    status: mr.status,
+    allRequirementsPass: mr.allRequirementsPass ?? false,
+    requirementChecks: toRequirementChecks(mr),
+  };
+}
+
+function mapMergeable(mr: CodeupMergeRequestDetail): PullRequestMergeable {
+  const facts = toStatusFacts(mr);
+  if (facts.requirementChecks.mergeConflict === false) {
+    return "CONFLICTING";
+  }
+  return isCodeupDirectMergeReady(facts) ? "MERGEABLE" : "UNKNOWN";
+}
+
+function mapReviewDecision(
+  reviewers: z.infer<typeof CodeupUserSchema>[] | undefined,
+): CurrentPullRequestStatus["reviewDecision"] {
+  if (!reviewers || reviewers.length === 0) return null;
+  if (reviewers.some((reviewer) => reviewer.reviewOpinionStatus === "NOT_PASS")) {
+    return "changes_requested";
+  }
+  if (
+    reviewers.every(
+      (reviewer) => reviewer.hasReviewed === true && reviewer.reviewOpinionStatus === "PASS",
+    )
+  ) {
+    return "approved";
+  }
+  return "pending";
+}
+
+function mapCheckRunStatus(check: CodeupCheckRun): PullRequestCheck["status"] {
+  if (check.status !== "completed") return "pending";
+  switch (check.conclusion) {
+    case "success":
+    case "neutral":
+      return "success";
+    case "failure":
+    case "timed_out":
+      return "failure";
+    case "cancelled":
+      return "cancelled";
+    case "skipped":
+      return "skipped";
+    default:
+      return "pending";
+  }
+}
+
+function mapCommitStatus(status: string): PullRequestCheck["status"] {
+  switch (status) {
+    case "success":
+      return "success";
+    case "failure":
+    case "error":
+      return "failure";
+    default:
+      return "pending";
+  }
+}
+
+function formatDuration(
+  startedAt?: string | null,
+  completedAt?: string | null,
+): string | undefined {
+  const start = parseOptionalTime(startedAt);
+  const end = parseOptionalTime(completedAt);
+  if (start <= 0 || end <= start) return undefined;
+  const seconds = Math.floor((end - start) / 1_000);
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return minutes > 0 ? `${minutes}m ${remaining}s` : `${remaining}s`;
+}
+
+function toPullRequestCheck(check: CodeupCheckRun): PullRequestCheck {
+  const duration = formatDuration(check.startedAt, check.completedAt);
+  return {
+    name: check.name,
+    status: mapCheckRunStatus(check),
+    url: check.detailsUrl ?? null,
+    checkRunId: check.id,
+    ...(duration ? { duration } : {}),
+  };
+}
+
+function toCommitStatusCheck(status: CodeupCommitStatus): PullRequestCheck {
+  return {
+    name: status.context?.trim() || "Commit status",
+    status: mapCommitStatus(status.state),
+    url: status.targetUrl ?? null,
+  };
+}
+
+function splitProjectPath(projectPath: string): { owner?: string; name?: string } {
+  const segments = projectPath.split("/").filter(Boolean);
+  if (segments.length === 0) return {};
+  return { owner: segments[0], name: segments[segments.length - 1] };
+}
+
+function toCurrentStatus(
+  mr: CodeupMergeRequestDetail,
+  repository: CodeupRepository,
+  checks: PullRequestCheck[],
+): CurrentPullRequestStatus {
+  const projectPath = repository.pathWithNamespace;
+  const { owner, name } = splitProjectPath(projectPath);
+  return {
+    number: mr.localId,
+    ...(owner ? { repoOwner: owner } : {}),
+    ...(name ? { repoName: name } : {}),
+    projectPath,
+    url: detailUrl(mr),
+    title: mr.title,
+    state: mapDetailState(mr.status),
+    baseRefName: mr.targetBranch,
+    headRefName: mr.sourceBranch,
+    isMerged: mr.status === "MERGED",
+    isDraft: mr.status === "UNDER_DEV",
+    mergeable: mapMergeable(mr),
+    checks,
+    checksStatus: computeChecksStatus(checks),
+    reviewDecision: mapReviewDecision(mr.reviewers),
+    forgeSpecific: { forge: "codeup", ...toStatusFacts(mr) },
+  };
+}
+
+function mapTimelineError(error: unknown): PullRequestTimelineError {
+  let message: string;
+  if (error instanceof AliyunCommandError) {
+    message = error.stderr || error.message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  } else {
+    message = String(error);
+  }
+  if (isNotFoundText(message)) return { kind: "not_found", message };
+  if (isNoPermissionText(message) || error instanceof AliyunAuthenticationError) {
+    return { kind: "forbidden", message };
+  }
+  return { kind: "unknown", message };
+}
+
+function reviewTimelineItems(mr: CodeupMergeRequestDetail, url: string): PullRequestTimelineItem[] {
+  return (mr.reviewers ?? []).flatMap((reviewer) => {
+    if (reviewer.hasReviewed !== true || !reviewer.reviewTime) return [];
+    let reviewState: "approved" | "changes_requested" | "commented" = "commented";
+    if (reviewer.reviewOpinionStatus === "PASS") {
+      reviewState = "approved";
+    } else if (reviewer.reviewOpinionStatus === "NOT_PASS") {
+      reviewState = "changes_requested";
+    }
+    const author = reviewer.username ?? reviewer.name ?? "unknown";
+    return [
+      {
+        kind: "review" as const,
+        id: `review:${reviewer.id ?? author}:${reviewer.reviewTime}`,
+        author,
+        authorUrl: null,
+        avatarUrl: reviewer.avatarUrl ?? null,
+        body: "",
+        createdAt: parseOptionalTime(reviewer.reviewTime),
+        url,
+        reviewState,
+      },
+    ];
+  });
+}
+
+function parseComment(value: unknown): CodeupComment | null {
+  const parsed = CodeupCommentSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function toCommentLocation(
+  comment: CodeupComment,
+  threadId: string,
+): PullRequestTimelineCommentLocation | undefined {
+  if (!comment.filePath) return undefined;
+  const line = Number.parseInt(comment.lineNumber ?? "", 10);
+  const location: PullRequestTimelineCommentLocation = {
+    path: comment.filePath,
+    threadId,
+  };
+  if (Number.isFinite(line) && line > 0) location.line = line;
+  if (comment.resolved !== undefined) location.isResolved = comment.resolved;
+  return location;
+}
+
+function toCommentTimelineItem(input: {
+  comment: CodeupComment;
+  url: string;
+  threadId: string;
+  belongsToThread: boolean;
+}): PullRequestTimelineItem | null {
+  const { comment } = input;
+  if (comment.deleted === true || comment.commentType?.includes("SYSTEM")) return null;
+  const item: Extract<PullRequestTimelineItem, { kind: "comment" }> = {
+    kind: "comment",
+    id: comment.commentBizId,
+    author: comment.author?.username ?? comment.author?.name ?? "unknown",
+    authorUrl: null,
+    avatarUrl: comment.author?.avatarUrl ?? null,
+    body: comment.content ?? "",
+    createdAt: parseOptionalTime(comment.commentTime),
+    url: input.url,
+  };
+  if (input.belongsToThread) item.threadId = input.threadId;
+  const location = toCommentLocation(comment, input.threadId);
+  if (location) {
+    item.location = location;
+  } else if (comment.resolved !== undefined) {
+    item.threadIsResolved = comment.resolved;
+  }
+  return item;
+}
+
+function commentTimelineItems(rawComments: unknown[], url: string): PullRequestTimelineItem[] {
+  const items: PullRequestTimelineItem[] = [];
+
+  function visit(value: unknown, rootId?: string, groupSize = 1): void {
+    const comment = parseComment(value);
+    if (!comment) return;
+    const children = [...(comment.childComments ?? []), ...(comment.finalChildComments ?? [])];
+    const resolvedRootId = rootId ?? comment.rootCommentBizId ?? comment.commentBizId;
+    const item = toCommentTimelineItem({
+      comment,
+      url,
+      threadId: resolvedRootId,
+      belongsToThread:
+        groupSize > 1 ||
+        children.length > 0 ||
+        Boolean(comment.parentCommentBizId || comment.rootCommentBizId),
+    });
+    if (item) items.push(item);
+    for (const child of children) {
+      visit(child, resolvedRootId, Math.max(groupSize, children.length + 1));
+    }
+  }
+
+  for (const comment of rawComments) visit(comment);
+  return items;
+}
+
+function assertDirectMergeReady(input: Pick<MergePullRequestOptions, "status">): void {
+  const facts = input.status?.forgeSpecific;
+  if (!isCodeupStatusFacts(facts)) {
+    throw new Error("Codeup merge facts are unavailable for this merge request");
+  }
+  if (!isCodeupDirectMergeReady(facts)) {
+    throw new Error("Codeup does not report this merge request as ready for direct merge");
+  }
+}
+
+function notSupported(method: string): never {
+  throw new Error(`${method} is not supported on Codeup`);
+}
+
+export function createCodeupService(options: CreateCodeupServiceOptions = {}): ForgeService {
+  const runner = options.runner ?? runAliyunCommand;
+  const resolveAliyun = createCachedCliPathResolver(options.resolveAliyunPath ?? resolveAliyunPath);
+  const resolveRemoteUrl = options.resolveRemoteUrl ?? defaultResolveRemoteUrl;
+  const repositoryContextByCwd = new Map<string, Promise<CodeupRepositoryContext>>();
+  const repositoryByIdentity = new Map<string, Promise<CodeupRepository>>();
+
+  async function run(args: string[], runOptions: CodeupCommandRunnerOptions): Promise<string> {
+    const aliyunPath = await resolveAliyun();
+    if (!aliyunPath) throw new AliyunCliMissingError();
+    try {
+      const result = await runner(args, runOptions);
+      return result.stdout.trim();
+    } catch (error) {
+      throw aliyunCliRunner.normalizeError(error, { args, cwd: runOptions.cwd });
+    }
+  }
+
+  async function runJson<T>(args: string[], cwd: string, schema: z.ZodType<T>): Promise<T> {
+    const stdout = await run(args, { cwd });
+    const parsed = parseCliJsonOutput({
+      commandName: "aliyun",
+      args,
+      cwd,
+      stdout,
+      schema,
+      createCommandError: (params) => new AliyunCommandError(params),
+    });
+    const envelope = CodeupApiEnvelopeSchema.safeParse(parsed);
+    if (envelope.success && envelope.data.success === false) {
+      const stderr = apiErrorText(envelope.data) || "Codeup API returned success=false";
+      if (isAuthFailureText(stderr)) {
+        throw new AliyunAuthenticationError({ stderr });
+      }
+      throw new AliyunCommandError({ args, cwd, exitCode: 0, stderr });
+    }
+    return parsed;
+  }
+
+  async function runApiJson<T>(
+    action: string,
+    parameters: ReadonlyArray<readonly [string, string]>,
+    cwd: string,
+    schema: z.ZodType<T>,
+  ): Promise<T> {
+    return runJson(apiArgs(action, parameters), cwd, schema);
+  }
+
+  async function loadRepository(
+    cwd: string,
+    organizationId: string,
+    identity: string,
+  ): Promise<CodeupRepository> {
+    const cacheKey = `${organizationId}:${identity}`;
+    let pending = repositoryByIdentity.get(cacheKey);
+    if (!pending) {
+      pending = runApiJson(
+        "GetRepository",
+        [
+          ["organizationId", organizationId],
+          ["identity", identity],
+        ],
+        cwd,
+        CodeupGetRepositoryResponseSchema,
+      )
+        .then((response) => {
+          if (!response.repository) {
+            throw new Error(`Codeup repository was not returned for ${identity}`);
+          }
+          return response.repository;
+        })
+        .catch((error: unknown) => {
+          repositoryByIdentity.delete(cacheKey);
+          throw error;
+        });
+      repositoryByIdentity.set(cacheKey, pending);
+    }
+    return pending;
+  }
+
+  async function getRepositoryContext(cwd: string): Promise<CodeupRepositoryContext> {
+    let pending = repositoryContextByCwd.get(cwd);
+    if (!pending) {
+      pending = (async () => {
+        const remoteUrl = await resolveRemoteUrl(cwd);
+        const identity = remoteUrl ? parseCodeupRemoteIdentity(remoteUrl) : null;
+        if (!identity) {
+          throw new Error("Codeup remote must include organization id and repository path");
+        }
+        const repository = await loadRepository(
+          cwd,
+          identity.organizationId,
+          identity.repositoryIdentity,
+        );
+        return { ...identity, repository };
+      })().catch((error: unknown) => {
+        repositoryContextByCwd.delete(cwd);
+        throw error;
+      });
+      repositoryContextByCwd.set(cwd, pending);
+    }
+    return pending;
+  }
+
+  async function listMergeRequestPage(
+    input: {
+      cwd: string;
+      state: "opened" | "closed" | "merged" | "all";
+      query?: string;
+      page: number;
+      pageSize: number;
+    },
+    context: CodeupRepositoryContext,
+  ): Promise<{ items: CodeupMergeRequestListItem[]; total: number | undefined }> {
+    const parameters: Array<readonly [string, string]> = [
+      ["organizationId", context.organizationId],
+      ["projectIds", String(context.repository.id)],
+      ["state", input.state],
+      ["filter", "new"],
+      ["orderBy", "updated_at"],
+      ["sort", "desc"],
+      ["page", String(input.page)],
+      ["pageSize", String(input.pageSize)],
+    ];
+    if (input.query?.trim()) parameters.push(["search", input.query.trim()]);
+    const response = await runApiJson(
+      "ListMergeRequests",
+      parameters,
+      input.cwd,
+      CodeupListMergeRequestsResponseSchema,
+    );
+    return { items: response.result ?? [], total: response.total };
+  }
+
+  async function listMergeRequests(input: {
+    cwd: string;
+    state: "opened" | "closed" | "merged" | "all";
+    query?: string;
+    limit?: number;
+  }): Promise<CodeupMergeRequestListItem[]> {
+    const context = await getRepositoryContext(input.cwd);
+    const requestedLimit = Math.max(1, input.limit ?? 20);
+    const items: CodeupMergeRequestListItem[] = [];
+    const seenFullPageFingerprints = new Set<string>();
+    let page = 1;
+    while (items.length < requestedLimit) {
+      const pageSize = Math.min(CODEUP_PAGE_SIZE, requestedLimit - items.length);
+      const response = await listMergeRequestPage({ ...input, page, pageSize }, context);
+      const pageItems = response.items;
+      assertCodeupPageProgress({
+        itemCount: pageItems.length,
+        pageSize,
+        pageKeys: pageItems.map((item) => String(item.localId)),
+        seenFullPageFingerprints,
+      });
+      items.push(...pageItems);
+      if (items.length >= requestedLimit) break;
+      const hasNextPage = hasNextCodeupPage({
+        itemCount: pageItems.length,
+        pageSize,
+        page,
+        visited: items.length,
+        total: response.total,
+      });
+      if (!hasNextPage) break;
+      page += 1;
+    }
+    return items.slice(0, requestedLimit);
+  }
+
+  async function getMergeRequest(
+    cwd: string,
+    number: number,
+    existingContext?: CodeupRepositoryContext,
+  ): Promise<CodeupMergeRequestDetail> {
+    const context = existingContext ?? (await getRepositoryContext(cwd));
+    const response = await runApiJson(
+      "GetMergeRequest",
+      [
+        ["organizationId", context.organizationId],
+        ["repositoryId", String(context.repository.id)],
+        ["localId", String(number)],
+      ],
+      cwd,
+      CodeupGetMergeRequestResponseSchema,
+    );
+    if (!response.result) throw new Error(`Codeup merge request !${number} was not returned`);
+    return response.result;
+  }
+
+  async function getLatestSourceSha(
+    cwd: string,
+    context: CodeupRepositoryContext,
+    number: number,
+  ): Promise<string | null> {
+    const response = await runApiJson(
+      "ListMergeRequestPatchSets",
+      [
+        ["organizationId", context.organizationId],
+        ["repositoryIdentity", String(context.repository.id)],
+        ["localId", String(number)],
+      ],
+      cwd,
+      CodeupListPatchSetsResponseSchema,
+    );
+    return (
+      (response.result ?? [])
+        .filter((patch) => patch.relatedMergeItemType === "MERGE_SOURCE" && patch.commitId)
+        .sort((left, right) => (right.patchSetNo ?? 0) - (left.patchSetNo ?? 0))[0]?.commitId ??
+      null
+    );
+  }
+
+  async function listCheckRuns(
+    cwd: string,
+    context: CodeupRepositoryContext,
+    sha: string,
+  ): Promise<CodeupCheckRun[]> {
+    const items: CodeupCheckRun[] = [];
+    const seenFullPageFingerprints = new Set<string>();
+    let page = 1;
+    while (true) {
+      const response = await runApiJson(
+        "ListCheckRuns",
+        [
+          ["organizationId", context.organizationId],
+          ["repositoryIdentity", String(context.repository.id)],
+          ["ref", sha],
+          ["page", String(page)],
+          ["pageSize", String(CODEUP_PAGE_SIZE)],
+        ],
+        cwd,
+        CodeupListCheckRunsResponseSchema,
+      );
+      const pageItems = response.result ?? [];
+      assertCodeupPageProgress({
+        itemCount: pageItems.length,
+        pageSize: CODEUP_PAGE_SIZE,
+        pageKeys: pageItems.map((item) => String(item.id)),
+        seenFullPageFingerprints,
+      });
+      items.push(...pageItems);
+      const hasNextPage = hasNextCodeupPage({
+        itemCount: pageItems.length,
+        pageSize: CODEUP_PAGE_SIZE,
+        page,
+        visited: items.length,
+        total: response.total,
+      });
+      if (!hasNextPage) break;
+      page += 1;
+    }
+    return items;
+  }
+
+  async function listCommitStatuses(
+    cwd: string,
+    context: CodeupRepositoryContext,
+    sha: string,
+  ): Promise<CodeupCommitStatus[]> {
+    const items: CodeupCommitStatus[] = [];
+    const seenFullPageFingerprints = new Set<string>();
+    let page = 1;
+    while (true) {
+      const response = await runApiJson(
+        "ListCommitStatuses",
+        [
+          ["organizationId", context.organizationId],
+          ["repositoryIdentity", String(context.repository.id)],
+          ["sha", sha],
+          ["page", String(page)],
+          ["pageSize", String(CODEUP_PAGE_SIZE)],
+        ],
+        cwd,
+        CodeupListCommitStatusesResponseSchema,
+      );
+      const pageItems = response.result ?? [];
+      assertCodeupPageProgress({
+        itemCount: pageItems.length,
+        pageSize: CODEUP_PAGE_SIZE,
+        pageKeys: pageItems.map((item) =>
+          item.id === undefined
+            ? JSON.stringify([item.context, item.state, item.targetUrl])
+            : String(item.id),
+        ),
+        seenFullPageFingerprints,
+      });
+      items.push(...pageItems);
+      const hasNextPage = hasNextCodeupPage({
+        itemCount: pageItems.length,
+        pageSize: CODEUP_PAGE_SIZE,
+        page,
+        visited: items.length,
+        total: response.total,
+      });
+      if (!hasNextPage) break;
+      page += 1;
+    }
+    return items;
+  }
+
+  async function loadChecks(
+    cwd: string,
+    context: CodeupRepositoryContext,
+    sha: string | null,
+  ): Promise<PullRequestCheck[]> {
+    if (!sha) return [];
+    const [runs, statuses] = await Promise.all([
+      listCheckRuns(cwd, context, sha),
+      listCommitStatuses(cwd, context, sha),
+    ]);
+    return [...runs.map(toPullRequestCheck), ...statuses.map(toCommitStatusCheck)];
+  }
+
+  async function sourceRepositoryMatches(
+    cwd: string,
+    context: CodeupRepositoryContext,
+    candidate: CodeupMergeRequestListItem,
+    headRepositoryOwner?: string,
+  ): Promise<boolean> {
+    if (!headRepositoryOwner) return candidate.sourceProjectId === context.repository.id;
+    const source = await loadRepository(
+      cwd,
+      context.organizationId,
+      String(candidate.sourceProjectId),
+    );
+    return source.pathWithNamespace === headRepositoryOwner;
+  }
+
+  async function resolveCurrentMergeRequest(input: {
+    cwd: string;
+    headRef: string;
+    headSha?: string;
+    headRepositoryOwner?: string;
+  }): Promise<{ detail: CodeupMergeRequestDetail; sha: string | null } | null> {
+    const context = await getRepositoryContext(input.cwd);
+    const seenFullPageFingerprints = new Set<string>();
+    let page = 1;
+    let visited = 0;
+    while (true) {
+      const response = await listMergeRequestPage(
+        { cwd: input.cwd, state: "all", page, pageSize: CODEUP_PAGE_SIZE },
+        context,
+      );
+      assertCodeupPageProgress({
+        itemCount: response.items.length,
+        pageSize: CODEUP_PAGE_SIZE,
+        pageKeys: response.items.map((item) => String(item.localId)),
+        seenFullPageFingerprints,
+      });
+      for (const candidate of response.items) {
+        if (
+          candidate.sourceBranch !== input.headRef ||
+          candidate.targetProjectId !== context.repository.id
+        ) {
+          continue;
+        }
+        if (
+          !(await sourceRepositoryMatches(input.cwd, context, candidate, input.headRepositoryOwner))
+        ) {
+          continue;
+        }
+        const state = mapListState(candidate.state);
+        if (state === "open") {
+          return {
+            detail: await getMergeRequest(input.cwd, candidate.localId, context),
+            sha: await getLatestSourceSha(input.cwd, context, candidate.localId),
+          };
+        }
+        if (!input.headSha) continue;
+        const sha = await getLatestSourceSha(input.cwd, context, candidate.localId);
+        if (sha === input.headSha) {
+          return { detail: await getMergeRequest(input.cwd, candidate.localId, context), sha };
+        }
+      }
+      visited += response.items.length;
+      const hasNextPage = hasNextCodeupPage({
+        itemCount: response.items.length,
+        pageSize: CODEUP_PAGE_SIZE,
+        page,
+        visited,
+        total: response.total,
+      });
+      if (!hasNextPage) break;
+      page += 1;
+    }
+    return null;
+  }
+
+  return {
+    authProbeCanThrow: true,
+
+    async isAuthenticated(input: { cwd: string } & ForgeReadOptions): Promise<boolean> {
+      await run(["--language", "en", "sts", "GetCallerIdentity"], { cwd: input.cwd });
+      return true;
+    },
+
+    async getCurrentPullRequestStatus(input): Promise<CurrentPullRequestStatus | null> {
+      const current = await resolveCurrentMergeRequest(input);
+      if (!current) return null;
+      const context = await getRepositoryContext(input.cwd);
+      const checks = await loadChecks(input.cwd, context, current.sha);
+      return toCurrentStatus(current.detail, context.repository, checks);
+    },
+
+    async getPullRequest(input: GetPullRequestOptions): Promise<PullRequestSummary> {
+      const context = await getRepositoryContext(input.cwd);
+      return detailToSummary(
+        await getMergeRequest(input.cwd, input.number, context),
+        context.repository.pathWithNamespace,
+      );
+    },
+
+    async getPullRequestHeadRef(input: GetPullRequestOptions): Promise<string> {
+      return (await getMergeRequest(input.cwd, input.number)).sourceBranch;
+    },
+
+    async getPullRequestCheckoutTarget(
+      input: GetPullRequestOptions,
+    ): Promise<PullRequestCheckoutTarget> {
+      const context = await getRepositoryContext(input.cwd);
+      const mr = await getMergeRequest(input.cwd, input.number, context);
+      const isCrossRepository = mr.sourceProjectId !== mr.targetProjectId;
+      const sourceRepository = isCrossRepository
+        ? await loadRepository(input.cwd, context.organizationId, String(mr.sourceProjectId))
+        : context.repository;
+      const sourceRemoteUrl =
+        sourceRepository.sshUrlToRepository ?? sourceRepository.httpUrlToRepository ?? null;
+      if (isCrossRepository && !sourceRemoteUrl) {
+        throw new Error("Codeup did not return a clone URL for the source repository");
+      }
+      return {
+        number: mr.localId,
+        baseRefName: mr.targetBranch,
+        headRefName: mr.sourceBranch,
+        checkoutRefs: [
+          {
+            ...(isCrossRepository && sourceRemoteUrl ? { remoteUrl: sourceRemoteUrl } : {}),
+            remoteName: "origin",
+            remoteRef: `refs/heads/${mr.sourceBranch}`,
+          },
+        ],
+        headOwnerLogin: isCrossRepository ? sourceRepository.pathWithNamespace : null,
+        headRepositorySshUrl: sourceRepository.sshUrlToRepository ?? null,
+        headRepositoryUrl: sourceRepository.httpUrlToRepository ?? null,
+        isCrossRepository,
+      };
+    },
+
+    async listPullRequests(input: ListPullRequestsOptions): Promise<PullRequestSummary[]> {
+      return (
+        await listMergeRequests({
+          cwd: input.cwd,
+          state: "opened",
+          query: input.query,
+          limit: input.limit,
+        })
+      ).map(listItemToSummary);
+    },
+
+    async listIssues(_input: ListIssuesOptions): Promise<IssueSummary[]> {
+      return [];
+    },
+
+    async createPullRequest(input: CreatePullRequestOptions): Promise<PullRequestCreateResult> {
+      const context = await getRepositoryContext(input.cwd);
+      const response = await runApiJson(
+        "CreateMergeRequest",
+        [
+          ["organizationId", context.organizationId],
+          ["repositoryId", String(context.repository.id)],
+          [
+            "body",
+            JSON.stringify({
+              sourceProjectId: context.repository.id,
+              sourceBranch: input.head,
+              targetProjectId: context.repository.id,
+              targetBranch: input.base,
+              title: input.title,
+              createFrom: "WEB",
+              description: input.body ?? "",
+            }),
+          ],
+        ],
+        input.cwd,
+        CodeupCreateMergeRequestResponseSchema,
+      );
+      if (!response.result) throw new Error("Codeup did not return the created merge request");
+      let url = detailUrl(response.result);
+      if (!url) {
+        url = detailUrl(await getMergeRequest(input.cwd, response.result.localId, context));
+      }
+      if (!url) throw new Error("Codeup merge request was created but no URL was returned");
+      return { url, number: response.result.localId };
+    },
+
+    async mergePullRequest(input: MergePullRequestOptions): Promise<PullRequestMergeResult> {
+      assertDirectMergeReady(input);
+      const context = await getRepositoryContext(input.cwd);
+      const mergeType = input.mergeMethod === "merge" ? "no-fast-forward" : input.mergeMethod;
+      const response = await runApiJson(
+        "MergeMergeRequest",
+        [
+          ["organizationId", context.organizationId],
+          ["repositoryId", String(context.repository.id)],
+          ["localId", String(input.prNumber)],
+          ["body", JSON.stringify({ mergeType, removeSourceBranch: false })],
+        ],
+        input.cwd,
+        CodeupMergeResponseSchema,
+      );
+      if (response.result?.result !== true) {
+        throw new Error("Codeup did not confirm that the merge request was merged");
+      }
+      return { success: true };
+    },
+
+    async getPullRequestTimeline(
+      input: GetPullRequestTimelineOptions,
+    ): Promise<PullRequestTimeline> {
+      const identity = {
+        prNumber: input.prNumber,
+        repoOwner: input.repoOwner,
+        repoName: input.repoName,
+      };
+      try {
+        const context = await getRepositoryContext(input.cwd);
+        const mr = await getMergeRequest(input.cwd, input.prNumber, context);
+        const url = detailUrl(mr);
+        const reviews = reviewTimelineItems(mr, url);
+        try {
+          const response = await runApiJson(
+            "ListMergeRequestComments",
+            [
+              ["organizationId", context.organizationId],
+              ["repositoryIdentity", String(context.repository.id)],
+              ["localId", String(input.prNumber)],
+            ],
+            input.cwd,
+            CodeupListCommentsResponseSchema,
+          );
+          return {
+            ...identity,
+            items: [...reviews, ...commentTimelineItems(response.result ?? [], url)].sort(
+              compareTimelineItems,
+            ),
+            truncated: false,
+            error: null,
+          };
+        } catch (error) {
+          return {
+            ...identity,
+            items: reviews.sort(compareTimelineItems),
+            truncated: false,
+            error: mapTimelineError(error),
+          };
+        }
+      } catch (error) {
+        return { ...identity, items: [], truncated: false, error: mapTimelineError(error) };
+      }
+    },
+
+    async getCheckDetails(input: GetCheckDetailsOptions): Promise<CheckDetails> {
+      if (input.checkRunId === undefined) {
+        throw new Error("Codeup check details require a checkRunId");
+      }
+      const context = await getRepositoryContext(input.cwd);
+      const response = await runApiJson(
+        "GetCheckRun",
+        [
+          ["organizationId", context.organizationId],
+          ["repositoryIdentity", String(context.repository.id)],
+          ["checkRunId", String(input.checkRunId)],
+        ],
+        input.cwd,
+        CodeupGetCheckRunResponseSchema,
+      );
+      const check = response.result;
+      if (!check) throw new Error(`Codeup check run ${input.checkRunId} was not returned`);
+      return {
+        checkRunId: check.id,
+        name: check.name,
+        status: check.status,
+        conclusion: check.conclusion ?? null,
+        url: check.detailsUrl ?? null,
+        detailsUrl: check.detailsUrl ?? null,
+        output: check.output ?? null,
+        annotations: check.annotations ?? [],
+        failedJobs: [],
+        truncated: false,
+      };
+    },
+
+    async searchIssuesAndPrs(input: SearchIssuesAndPrsOptions): Promise<SearchResult> {
+      if (input.force && !input.reason) {
+        throw new Error("ForgeService forced read requires a reason");
+      }
+      const kinds = normalizeForgeSearchKinds(input.kinds);
+      try {
+        if (!kinds.includes("change_request")) {
+          await this.isAuthenticated({ cwd: input.cwd });
+          return {
+            items: [],
+            featuresEnabled: true,
+            authState: "authenticated",
+            githubFeaturesEnabled: true,
+          };
+        }
+        const mergeRequests = await listMergeRequests({
+          cwd: input.cwd,
+          state: "opened",
+          query: input.query,
+          limit: input.limit,
+        });
+        return {
+          items: mergeRequests
+            .map(listItemToSummary)
+            .map(toSearchChangeRequest)
+            .sort(
+              (left, right) =>
+                parseOptionalTime(right.updatedAt) - parseOptionalTime(left.updatedAt),
+            ),
+          featuresEnabled: true,
+          authState: "authenticated",
+          githubFeaturesEnabled: true,
+        };
+      } catch (error) {
+        if (error instanceof AliyunCliMissingError) {
+          return createUnavailableSearchResult("cli_missing");
+        }
+        if (error instanceof AliyunAuthenticationError) {
+          return createUnavailableSearchResult("unauthenticated");
+        }
+        throw error;
+      }
+    },
+
+    enablePullRequestAutoMerge(
+      _input: EnablePullRequestAutoMergeOptions,
+    ): Promise<PullRequestAutoMergeResult> {
+      return notSupported("enablePullRequestAutoMerge");
+    },
+
+    disablePullRequestAutoMerge(
+      _input: DisablePullRequestAutoMergeOptions,
+    ): Promise<PullRequestAutoMergeResult> {
+      return notSupported("disablePullRequestAutoMerge");
+    },
+
+    invalidate(input: { cwd: string }): void {
+      repositoryContextByCwd.delete(input.cwd);
+      repositoryByIdentity.clear();
+    },
+  };
+}

--- a/packages/server/src/services/forge-registry.test.ts
+++ b/packages/server/src/services/forge-registry.test.ts
@@ -8,11 +8,13 @@ describe("forge registry", () => {
   it("builds the registered adapters", () => {
     const github = createForgeService("github");
     const gitlab = createForgeService("gitlab");
+    const codeup = createForgeService("codeup");
     const gitea = createForgeService("gitea");
     const forgejo = createForgeService("forgejo");
     const codeberg = createForgeService("codeberg");
     expect(github?.getCurrentPullRequestStatus).toBeTypeOf("function");
     expect(gitlab?.getCurrentPullRequestStatus).toBeTypeOf("function");
+    expect(codeup?.getCurrentPullRequestStatus).toBeTypeOf("function");
     expect(gitea?.getCurrentPullRequestStatus).toBeTypeOf("function");
     expect(forgejo?.getCurrentPullRequestStatus).toBeTypeOf("function");
     expect(codeberg?.getCurrentPullRequestStatus).toBeTypeOf("function");
@@ -29,12 +31,13 @@ describe("forge registry", () => {
   it("knows which forges are registered", () => {
     expect(defaultForgeRegistry.has("github")).toBe(true);
     expect(defaultForgeRegistry.has("gitlab")).toBe(true);
+    expect(defaultForgeRegistry.has("codeup")).toBe(true);
     expect(defaultForgeRegistry.has("gitea")).toBe(true);
     expect(defaultForgeRegistry.has("forgejo")).toBe(true);
     expect(defaultForgeRegistry.has("codeberg")).toBe(true);
     expect(defaultForgeRegistry.has("bitbucket")).toBe(false);
     expect(defaultForgeRegistry.ids()).toEqual(
-      expect.arrayContaining(["github", "gitlab", "gitea", "forgejo", "codeberg"]),
+      expect.arrayContaining(["github", "gitlab", "codeup", "gitea", "forgejo", "codeberg"]),
     );
   });
 

--- a/packages/server/src/services/forge-registry.ts
+++ b/packages/server/src/services/forge-registry.ts
@@ -1,5 +1,6 @@
 import { getForgeDefinition } from "@getpaseo/protocol/forge-manifest";
 import { normalizeHost } from "@getpaseo/protocol/git-remote";
+import { createCodeupService } from "./codeup-service.js";
 import { createGitHubService, probeGitHubHost } from "./github-service.js";
 import type { ForgeService } from "./forge-service.js";
 import { createGiteaService, resolveGiteaFamilyForge } from "./gitea-service.js";
@@ -149,6 +150,13 @@ export const defaultForgeRegistry = new ForgeRegistry([
       createService: createGitLabService,
       matchesHost: matchesCloudHost("gitlab"),
       probeHost: probeGitLabHost,
+    },
+  ],
+  [
+    "codeup",
+    {
+      createService: createCodeupService,
+      matchesHost: matchesCloudHost("codeup"),
     },
   ],
   [

--- a/packages/server/src/services/forge-resolver.test.ts
+++ b/packages/server/src/services/forge-resolver.test.ts
@@ -28,6 +28,7 @@ describe("forgeForHost", () => {
   it("maps public registered forge hosts without resolver-specific branches", () => {
     expect(forgeForHost("github.com")).toBe("github");
     expect(forgeForHost("gitlab.com")).toBe("gitlab");
+    expect(forgeForHost("codeup.aliyun.com")).toBe("codeup");
     expect(forgeForHost("gitea.com")).toBe("gitea");
     expect(forgeForHost("codeberg.org")).toBe("codeberg");
   });
@@ -167,6 +168,20 @@ describe("createForgeResolver", () => {
       forge: "codeberg",
       host: "codeberg.org",
     });
+  });
+
+  it("resolves a Codeup cloud remote without probing the host", async () => {
+    const probeForge = vi.fn(async () => null);
+    const resolver = createForgeResolver({
+      resolveRemoteUrl: async () => "git@codeup.aliyun.com:org/team/repo.git",
+      probeForge,
+    });
+
+    await expect(resolver.resolve("/codeup")).resolves.toMatchObject({
+      forge: "codeup",
+      host: "codeup.aliyun.com",
+    });
+    expect(probeForge).not.toHaveBeenCalled();
   });
 
   it("does not classify an overlapping gitea-forgejo hostname without a probe", async () => {

--- a/packages/server/src/services/forge-service.ts
+++ b/packages/server/src/services/forge-service.ts
@@ -42,6 +42,8 @@ export interface PullRequestCheckoutTarget {
 
 export interface PullRequestCheckoutRef {
   remoteName?: string;
+  /** Direct fetch URL for cross-repository heads that are not exposed on origin. */
+  remoteUrl?: string;
   remoteRef: string;
 }
 

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -427,6 +427,58 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(currentBranch).toBe("Feature.X");
     });
 
+    it("fetches a cross-repository change request from its direct remote URL", async () => {
+      const originDir = join(tempDir, "origin.git");
+      const forkDir = join(tempDir, "fork.git");
+      const forkCloneDir = join(tempDir, "fork-clone");
+      execFileSync("git", ["clone", "--bare", repoDir, originDir]);
+      execFileSync("git", ["clone", "--bare", repoDir, forkDir]);
+      execFileSync("git", ["remote", "add", "origin", originDir], { cwd: repoDir });
+      execFileSync("git", ["clone", forkDir, forkCloneDir]);
+      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: forkCloneDir });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: forkCloneDir });
+      execFileSync("git", ["checkout", "-b", "contributor/codeup"], { cwd: forkCloneDir });
+      writeFileSync(join(forkCloneDir, "file.txt"), "from-codeup-fork\n");
+      execFileSync("git", ["add", "file.txt"], { cwd: forkCloneDir });
+      execFileSync(
+        "git",
+        ["-c", "commit.gpgsign=false", "commit", "-m", "cross repository branch"],
+        { cwd: forkCloneDir },
+      );
+      execFileSync("git", ["push", "origin", "contributor/codeup"], { cwd: forkCloneDir });
+
+      const result = await createLegacyWorktreeForTest({
+        cwd: repoDir,
+        worktreeSlug: "codeup-cross-repo",
+        source: {
+          kind: "checkout-change-request",
+          forge: "codeup",
+          changeRequestNumber: 7,
+          headRef: "contributor/codeup",
+          headRepositoryOwner: "contributor/repo",
+          baseRefName: "main",
+          checkoutRefs: [
+            {
+              remoteUrl: forkDir,
+              remoteRef: "refs/heads/contributor/codeup",
+            },
+          ],
+          pushRemoteUrl: forkDir,
+        },
+        runSetup: false,
+        paseoHome,
+      });
+
+      expect(readFileSync(join(result.worktreePath, "file.txt"), "utf8")).toBe(
+        "from-codeup-fork\n",
+      );
+      expect(
+        execFileSync("git", ["branch", "--show-current"], { cwd: result.worktreePath })
+          .toString()
+          .trim(),
+      ).toBe("contributor/codeup");
+    });
+
     it("uses the selected local or origin ref when both exist", async () => {
       const remoteDir = join(tempDir, "remote.git");
       const remoteCloneDir = join(tempDir, "remote-clone");

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -175,6 +175,7 @@ export interface WorktreeRootOptions {
 
 export interface WorktreeCheckoutRef {
   remoteName?: string;
+  remoteUrl?: string;
   remoteRef: string;
 }
 
@@ -1487,7 +1488,7 @@ async function fetchWorktreeCheckoutRefs(options: {
     lastResult = await runGitCommand(
       [
         "fetch",
-        checkoutRef.remoteName ?? "origin",
+        checkoutRef.remoteUrl ?? checkoutRef.remoteName ?? "origin",
         `+${checkoutRef.remoteRef}:refs/heads/${options.localBranchName}`,
         "--force",
       ],
@@ -1502,7 +1503,10 @@ async function fetchWorktreeCheckoutRefs(options: {
     }
   }
   const attemptedRefs = options.checkoutRefs
-    .map((checkoutRef) => `${checkoutRef.remoteName ?? "origin"} ${checkoutRef.remoteRef}`)
+    .map(
+      (checkoutRef) =>
+        `${checkoutRef.remoteUrl ?? checkoutRef.remoteName ?? "origin"} ${checkoutRef.remoteRef}`,
+    )
     .join(", ");
   throw new Error(
     `Unable to fetch change request refs for worktree branch ${options.localBranchName}: ${attemptedRefs}${lastResult?.stderr ? `\n${lastResult.stderr}` : ""}`,


### PR DESCRIPTION
### Linked issue

Closes #2278

Prior scope and architecture alignment was confirmed with the maintainer after the issue discussion.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Adds first-party Alibaba Cloud Codeup support to Paseo's existing pluggable forge abstraction, limited to hosted `codeup.aliyun.com`.

The adapter uses the official `aliyun` CLI and the DevOps `2021-06-25` OpenAPI. Paseo invokes the host's existing AK/STS-backed CLI profile; it does not collect, persist, or transmit Alibaba Cloud credentials itself.

Supported behavior:

- resolve Codeup SSH and HTTPS remotes, including nested repository paths
- find the current branch's new-version merge request and list/search open MRs
- show MR state, merge requirements, reviews, threaded comments, commit statuses, check runs, and check annotations in the existing neutral forge UI
- create and check out MRs, including cross-repository heads
- merge with Codeup's merge, squash, and rebase strategies after server-side requirements pass
- show actionable install/auth guidance and an update-host gate when the daemon lacks the Codeup adapter

The implementation follows the forge litmus test: Codeup behavior stays in a dedicated server adapter and app logic/view modules, with one manifest/registry entry per layer. Shared changes are limited to the additive capability flag and a generic direct-fetch URL for cross-repository checkout.

Deliberately out of scope: repository Issues, auto-merge, Projex work items, pipeline management, comment/review writes, and unverified source tree/blob URL grammar.

The diff is split into three reviewable commits:

1. Codeup server adapter, protocol registration, and generic checkout support
2. App module, icon, setup guidance, and capability gate
3. Focused tests, real-E2E harness, and provider documentation

For complexity context, the diff contains 1,696 added production lines and 1,442 added test lines; 1,645 of the production additions are isolated in new Codeup-specific files.

### How did you verify it

Automated verification completed on the final tree:

- `codeup-service`, forge registry/resolver: 71 tests passed
- POSIX worktree checkout: 50 tests passed, 1 platform test skipped
- checkout protocol schema: 37 tests passed
- app forge setup/icon/presentation/merge capability: 43 tests passed
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm run format:check`

Each of the three commits also passed the repository pre-commit lint, format, and full typecheck hooks independently.

Historical live verification:

- The real Codeup E2E ran against a dedicated repository on 2026-07-20 using the official `aliyun` CLI and its configured AK/STS profile: 1/1 test passed in 15.11s.
- The run covered creating and reading a merge request, resolving its checkout target, and squash-merging it. A follow-up API/remote check confirmed the merge completed and the temporary source branch was removed.
- The live E2E predates the pagination fixes added during review. It was not rerun on the current HEAD, so this remains historical live evidence; the pagination changes are covered by focused adapter tests and current CI.

Visual verification:

- Cross-platform UI screenshots/video have been captured and added.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense






