### PR TITLE
feat(subagents): show the model on provider subagent rows

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -132,6 +132,17 @@ Clicking either kind opens a workspace tab. A Paseo subagent tab is a normal int
 
 Provider timelines use the same structural timeline item format but deliberately have a separate lifecycle and transport. A provider thread/session identifier is not a Paseo agent identifier, and closing its tab is always layout-only.
 
+### What a provider subagent row can say about its model
+
+A subagent can run a different model from its parent — via the `Agent` tool's `model` override or a `.claude/agents/*.md` frontmatter model — so the row reports its own.
+
+- **The model is observable, per message.** Every Claude sidechain assistant message is an ordinary `SDKAssistantMessage` whose `message.model` is required, so `ClaudeSidechainTracker` reads it off each message rather than off the spawn. It is captured **write-last**: a run can switch models mid-flight (fallback), and the last observed model is what the run is actually on. `subagent_type`/`task_description` are captured **write-once**, because they are spawn facts that the tool-input path also supplies, and two sources writing the same field every message produce oscillating upserts.
+- **The label is resolved on the daemon, not the client.** The row payload carries both `model` (canonical id) and `modelLabel` (display string). The client has no cwd-scoped provider snapshot at the layer that renders these rows, rows carry a per-row provider, and each provider owns its own model manifest — so resolution belongs next to the manifest. Display labels already travel on the wire (`AgentModelDefinitionSchema.label`), so this is the existing pattern.
+- **An unrecognized id degrades to itself.** `normalizeClaudeRuntimeModelId` returns `null` for ids it doesn't know (new models, Bedrock ARNs, bare aliases) — it does not pass them through. The resolver falls back to the raw id for both fields. Showing an unfamiliar id beats confidently showing a _different_ model's name.
+- **Effort is not available on the live path.** The SDK declares `effort` on agent definitions and hook input, but never on an assistant message, and no reasoning-budget field appears on the wire. The CLI-written JSONL transcript _does_ record `effort` per sidechain entry, so replay could show it while live rows could not — which is why the track shows a model and no effort at all rather than an indicator that appears only after a resume.
+
+Replay derives the same fields from JSONL in `buildClaudePersistedSidechainAgentEvents`, and must match the live path (last model wins). That path runs on **session resume**, not on client reconnect: reloading a client only re-lists the daemon's in-memory store, so verifying replay means restarting the agent or the daemon.
+
 Archived Paseo subagents disappear from the track, by design. To remove one from the track without closing its tab, use the **archive button** on the row — it opens a confirm dialog and archives the subagent on confirm. Provider-owned rows have no individual Paseo lifecycle controls.
 
 The track header's **Archive finished** action hides finished provider-owned rows in the current app session. Their native sessions and timelines are untouched, and managed Paseo subagents are not archived by this bulk action. If a hidden provider child starts running again, the app brings it back to the track.

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1464,6 +1464,7 @@ export const ar: TranslationResources = {
     archiveTooltip: "أرشفة الوكيل الفرعي",
     archiveFinishedAction: "أرشفة الوكلاء الفرعيين المكتملين",
     archiveFinishedTooltip: "أرشفة المكتملين",
+    rowAccessibilityLabelWithModel: "{{label}}، {{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1475,6 +1475,7 @@ export const en = {
     archiveTooltip: "Archive subagent",
     archiveFinishedAction: "Archive finished subagents",
     archiveFinishedTooltip: "Archive finished",
+    rowAccessibilityLabelWithModel: "{{label}}, {{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1507,6 +1507,7 @@ export const es: TranslationResources = {
     archiveTooltip: "Subagente de archivo",
     archiveFinishedAction: "Archivar subagentes finalizados",
     archiveFinishedTooltip: "Archivar finalizados",
+    rowAccessibilityLabelWithModel: "{{label}}, {{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1510,6 +1510,7 @@ export const fr: TranslationResources = {
     archiveTooltip: "Sous-agent d'archivage",
     archiveFinishedAction: "Archiver les sous-agents terminés",
     archiveFinishedTooltip: "Archiver les terminés",
+    rowAccessibilityLabelWithModel: "{{label}}, {{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1480,6 +1480,7 @@ export const ja: TranslationResources = {
     archiveTooltip: "サブエージェントをアーカイブ",
     archiveFinishedAction: "完了したサブエージェントをアーカイブ",
     archiveFinishedTooltip: "完了した項目をアーカイブ",
+    rowAccessibilityLabelWithModel: "{{label}}、{{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1493,6 +1493,7 @@ export const ptBR: TranslationResources = {
     archiveTooltip: "Arquivar subagente",
     archiveFinishedAction: "Arquivar subagentes concluídos",
     archiveFinishedTooltip: "Arquivar concluídos",
+    rowAccessibilityLabelWithModel: "{{label}}, {{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1498,6 +1498,7 @@ export const ru: TranslationResources = {
     archiveTooltip: "Архивный субагент",
     archiveFinishedAction: "Архивировать завершенные субагенты",
     archiveFinishedTooltip: "Архивировать завершенные",
+    rowAccessibilityLabelWithModel: "{{label}}, {{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1445,6 +1445,7 @@ export const zhCN: TranslationResources = {
     archiveTooltip: "归档 subagent",
     archiveFinishedAction: "归档已完成的 subagent",
     archiveFinishedTooltip: "归档已完成项",
+    rowAccessibilityLabelWithModel: "{{label}}，{{model}}",
   },
   panels: {
     draft: {

--- a/packages/app/src/panels/provider-subagent-panel.tsx
+++ b/packages/app/src/panels/provider-subagent-panel.tsx
@@ -46,9 +46,13 @@ function useProviderSubagentDescriptor(
   );
   const provider = descriptor?.provider ?? parentProvider ?? "agent";
   const label = descriptor?.title?.trim() || descriptor?.description?.trim() || "Subagent";
+  const modelLabel = descriptor?.modelLabel?.trim();
+  const subtitle = modelLabel
+    ? `${formatProviderLabel(provider)} subagent · ${modelLabel}`
+    : `${formatProviderLabel(provider)} subagent`;
   return {
     label,
-    subtitle: `${formatProviderLabel(provider)} subagent`,
+    subtitle,
     tooltip: label,
     titleState: descriptor ? "ready" : "loading",
     icon: getProviderIcon(provider),

--- a/packages/app/src/subagents/select.test.ts
+++ b/packages/app/src/subagents/select.test.ts
@@ -94,6 +94,59 @@ describe("selectSubagentsForParent", () => {
     ).toEqual(["provider-child"]);
   });
 
+  it("carries the daemon-resolved model label onto provider rows", () => {
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: "provider-child",
+        parentAgentId: "parent-a",
+        provider: "claude",
+        title: "Explore",
+        description: null,
+        status: "running",
+        createdAt: "2026-03-08T10:01:00.000Z",
+        updatedAt: "2026-03-08T10:02:00.000Z",
+        toolCallId: "call-1",
+        model: "claude-opus-4-8",
+        modelLabel: "Opus 4.8",
+      },
+    });
+
+    expect(
+      selectProviderSubagentsForParent(
+        useProviderSubagentStore.getState(),
+        { serverId: SERVER_ID, parentAgentId: "parent-a" },
+        true,
+      )[0]?.modelLabel,
+    ).toBe("Opus 4.8");
+  });
+
+  // A daemon that predates the field omits it entirely; the row still has to build.
+  it("leaves the model label null when the host reports no model", () => {
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: "provider-child",
+        parentAgentId: "parent-a",
+        provider: "codex",
+        title: "Provider child",
+        description: null,
+        status: "running",
+        createdAt: "2026-03-08T10:01:00.000Z",
+        updatedAt: "2026-03-08T10:02:00.000Z",
+        toolCallId: "call-1",
+      },
+    });
+
+    expect(
+      selectProviderSubagentsForParent(
+        useProviderSubagentStore.getState(),
+        { serverId: SERVER_ID, parentAgentId: "parent-a" },
+        true,
+      )[0]?.modelLabel,
+    ).toBe(null);
+  });
+
   it("hides locally dismissed provider children while retaining their descriptor", () => {
     const store = useProviderSubagentStore.getState();
     store.applyUpdate(SERVER_ID, {

--- a/packages/app/src/subagents/select.ts
+++ b/packages/app/src/subagents/select.ts
@@ -25,6 +25,11 @@ export interface ProviderSubagentRow {
   status: ProviderSubagentDescriptorPayload["status"];
   requiresAttention: boolean;
   createdAt: Date;
+  /**
+   * Display label for the model the subagent is running, already resolved by the daemon.
+   * Null when the host predates the field or the provider reports no model.
+   */
+  modelLabel: string | null;
 }
 
 export type SubagentRow = PaseoSubagentRow | ProviderSubagentRow;
@@ -101,6 +106,8 @@ export function selectProviderSubagentsForParent(
       status: subagent.status,
       requiresAttention: subagent.status === "failed",
       createdAt: new Date(subagent.createdAt),
+      // COMPAT(providerSubagentModel): added in v0.2.X, remove the ?? null when floor >= v0.2.X.
+      modelLabel: subagent.modelLabel ?? null,
     });
   }
   rows.sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime());

--- a/packages/app/src/subagents/track-presentation.test.ts
+++ b/packages/app/src/subagents/track-presentation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PaseoSubagentRow, SubagentRow } from "./select";
+import type { PaseoSubagentRow, ProviderSubagentRow, SubagentRow } from "./select";
 import {
   buildSubagentRowPresentationData,
   countFinishedSubagents,
@@ -18,6 +18,22 @@ function row(
     status: overrides.status ?? "idle",
     requiresAttention: overrides.requiresAttention ?? false,
     createdAt: overrides.createdAt ?? new Date("2026-04-20T00:00:00.000Z"),
+  };
+}
+
+function providerRow(
+  overrides: Partial<ProviderSubagentRow> & Pick<ProviderSubagentRow, "id">,
+): ProviderSubagentRow {
+  return {
+    kind: "provider",
+    id: overrides.id,
+    parentAgentId: overrides.parentAgentId ?? "parent",
+    provider: overrides.provider ?? "claude",
+    title: overrides.title ?? `Subagent ${overrides.id}`,
+    status: overrides.status ?? "running",
+    requiresAttention: overrides.requiresAttention ?? false,
+    createdAt: overrides.createdAt ?? new Date("2026-04-20T00:00:00.000Z"),
+    modelLabel: overrides.modelLabel ?? null,
   };
 }
 
@@ -76,26 +92,14 @@ describe("formatHeaderLabel", () => {
 describe("countFinishedSubagents", () => {
   it("counts only terminal provider-owned children", () => {
     const providerRows: SubagentRow[] = [
-      {
-        kind: "provider",
-        id: "native-running",
-        parentAgentId: "parent",
-        provider: "claude",
-        title: "running",
-        status: "running",
-        requiresAttention: false,
-        createdAt: new Date("2026-04-20T00:00:00.000Z"),
-      },
-      {
-        kind: "provider",
+      providerRow({ id: "native-running", title: "running", status: "running" }),
+      providerRow({
         id: "native-failed",
-        parentAgentId: "parent",
-        provider: "claude",
         title: "failed",
         status: "failed",
         requiresAttention: true,
         createdAt: new Date("2026-04-20T00:00:01.000Z"),
-      },
+      }),
     ];
 
     expect(
@@ -164,5 +168,22 @@ describe("buildSubagentRowPresentationData", () => {
       buildSubagentRowPresentationData(row({ id: "a", status: "idle", requiresAttention: true }))
         .statusBucket,
     ).toBe("done");
+  });
+
+  it("surfaces the model label a provider row reports", () => {
+    expect(
+      buildSubagentRowPresentationData(providerRow({ id: "a", modelLabel: "Opus 4.8" })).modelLabel,
+    ).toBe("Opus 4.8");
+  });
+
+  // An older daemon sends no model at all; the row must simply render without a chip.
+  it("leaves the model label null when a provider row reports none", () => {
+    expect(
+      buildSubagentRowPresentationData(providerRow({ id: "a", modelLabel: null })).modelLabel,
+    ).toBe(null);
+  });
+
+  it("leaves the model label null for paseo rows", () => {
+    expect(buildSubagentRowPresentationData(row({ id: "a" })).modelLabel).toBe(null);
   });
 });

--- a/packages/app/src/subagents/track-presentation.ts
+++ b/packages/app/src/subagents/track-presentation.ts
@@ -15,6 +15,12 @@ export interface SubagentRowPresentationData {
   subtitle: string;
   titleState: "ready" | "loading";
   statusBucket: SidebarStateBucket | null;
+  /**
+   * Model label to show alongside the title, or null to show nothing. Only provider
+   * sidechains report a model today; paseo children carry one on their agent record but
+   * resolving its label needs a provider snapshot this layer does not have.
+   */
+  modelLabel: string | null;
 }
 
 export function buildSubagentRowPresentationData(row: SubagentRow): SubagentRowPresentationData {
@@ -26,6 +32,7 @@ export function buildSubagentRowPresentationData(row: SubagentRow): SubagentRowP
     label: label ?? "",
     subtitle: "",
     titleState: label ? "ready" : "loading",
+    modelLabel: row.kind === "provider" ? row.modelLabel : null,
     statusBucket: deriveSidebarStateBucket({
       status,
       requiresAttention: false,

--- a/packages/app/src/subagents/track.test.tsx
+++ b/packages/app/src/subagents/track.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { i18n as testI18n } from "@/i18n/i18next";
+import React from "react";
+import { act, fireEvent } from "@testing-library/react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  (globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+  // react-native-reanimated reads matchMedia at import time to detect reduced motion, and
+  // jsdom does not implement it.
+  if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+});
+
+vi.mock("expo-router", () => ({
+  router: { dismissTo: vi.fn() },
+  useLocalSearchParams: () => ({}),
+  usePathname: () => "/",
+}));
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn().mockResolvedValue(null),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// The shared unistyles test stub carries a trimmed theme, and the real tooltip reads keys it
+// does not define (borderWidth, shadow) at module scope. Tooltips are irrelevant to the model
+// chip, so stub them rather than widening a fixture every other app test depends on.
+vi.mock("@/components/ui/tooltip", () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => children ?? null;
+  return { Tooltip: passthrough, TooltipTrigger: passthrough, TooltipContent: () => null };
+});
+
+// WorkspaceTabIcon transitively registers every panel, which drags xterm and the editor into
+// the module graph. The row's icon is not what these assertions are about.
+vi.mock("@/screens/workspace/workspace-tab-presentation", () => ({
+  WorkspaceTabIcon: () => null,
+}));
+
+// App sources compile with the classic JSX transform (tsconfig `jsx: "react-native"`), so a
+// component file that never imports React still emits `React.createElement`. Every render test
+// in this repo stubs React globally for that reason.
+vi.stubGlobal("React", React);
+vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+import { SubagentsTrack } from "@/subagents/track";
+import type { ProviderSubagentRow } from "@/subagents/select";
+
+void testI18n;
+
+function providerRow(overrides: Partial<ProviderSubagentRow> = {}): ProviderSubagentRow {
+  return {
+    kind: "provider",
+    id: "child-1",
+    parentAgentId: "parent-1",
+    provider: "claude",
+    title: "Explore",
+    status: "running",
+    requiresAttention: false,
+    createdAt: new Date("2026-04-20T00:00:00.000Z"),
+    modelLabel: null,
+    ...overrides,
+  };
+}
+
+const noop = () => undefined;
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function renderExpandedTrack(rows: ProviderSubagentRow[]): void {
+  act(() => {
+    root.render(
+      <SubagentsTrack
+        rows={rows}
+        onOpenSubagent={noop}
+        onOpenProviderSubagent={noop}
+        onArchiveSubagent={noop}
+      />,
+    );
+  });
+  const header = container.querySelector('[data-testid="subagents-track-header"]');
+  if (!header) {
+    throw new Error("expected the subagents track header to render");
+  }
+  act(() => {
+    fireEvent.click(header);
+  });
+}
+
+describe("SubagentsTrack model chip", () => {
+  it("renders the model beside the subagent title", () => {
+    renderExpandedTrack([providerRow({ modelLabel: "Opus 4.8" })]);
+
+    expect(
+      container.querySelector('[data-testid="subagents-track-model-child-1"]')?.textContent,
+    ).toBe("Opus 4.8");
+  });
+
+  it("renders no chip when the host reports no model", () => {
+    renderExpandedTrack([providerRow({ modelLabel: null })]);
+
+    expect(container.querySelector('[data-testid="subagents-track-model-child-1"]')).toBeNull();
+  });
+
+  // The chip is the only place the model appears on screen, so a screen reader would miss it
+  // entirely unless it is folded into the row's accessible name. Asserting the rendered string
+  // (not just the resource key) is what catches a typo'd t() call, which would otherwise
+  // silently render the raw key.
+  it("includes the model in the row's accessible name", () => {
+    renderExpandedTrack([providerRow({ modelLabel: "Opus 4.8" })]);
+
+    const row = container.querySelector('[data-testid="subagents-track-row-child-1"]');
+    expect(row?.getAttribute("aria-label")).toBe("Explore, Opus 4.8");
+  });
+
+  it("falls back to the plain title when there is no model", () => {
+    renderExpandedTrack([providerRow({ modelLabel: null })]);
+
+    const row = container.querySelector('[data-testid="subagents-track-row-child-1"]');
+    expect(row?.getAttribute("aria-label")).toBe("Explore");
+  });
+});

--- a/packages/app/src/subagents/track.tsx
+++ b/packages/app/src/subagents/track.tsx
@@ -213,10 +213,15 @@ function SubagentsTrackRow({
               {displayLabel}
             </Text>
             {modelLabel ? (
-              // No numberOfLines: on web it compiles to a maxWidth clamp that survives
-              // flexShrink: 0, which would make the chip ellipsize itself instead of
-              // holding its width and letting the title absorb the squeeze.
-              <Text style={styles.rowModelLabel} testID={`subagents-track-model-${row.id}`}>
+              // numberOfLines only bites past rowModelLabel's maxWidth: a manifest label is
+              // far shorter than the cap and still holds its full width, while an
+              // unrecognized model's raw id — a Bedrock ARN runs past 80 characters —
+              // ellipsizes instead of squeezing the title out of the row.
+              <Text
+                style={styles.rowModelLabel}
+                numberOfLines={1}
+                testID={`subagents-track-model-${row.id}`}
+              >
                 {modelLabel}
               </Text>
             ) : null}
@@ -408,7 +413,11 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
   },
   rowModelLabel: {
+    // flexShrink: 0 keeps a normal label whole and makes the title absorb the squeeze;
+    // maxWidth bounds the pathological case, since an unrecognized model falls back to its
+    // raw id and would otherwise take the row's whole width and overflow it.
     flexShrink: 0,
+    maxWidth: "40%",
     fontSize: theme.fontSize.xs,
     color: theme.colors.foregroundMuted,
   },

--- a/packages/app/src/subagents/track.tsx
+++ b/packages/app/src/subagents/track.tsx
@@ -40,7 +40,9 @@ export interface SubagentsTrackProps {
 
 const SUBAGENTS_LIST_MAX_HEIGHT = 200;
 
-function buildRowPresentation(row: SubagentRow): WorkspaceTabPresentation {
+function buildRowPresentation(
+  row: SubagentRow,
+): WorkspaceTabPresentation & { modelLabel: string | null } {
   const data = buildSubagentRowPresentationData(row);
   return {
     ...data,
@@ -169,6 +171,12 @@ function SubagentsTrackRow({
   const presentation = useMemo(() => buildRowPresentation(row), [row]);
   const displayLabel =
     presentation.titleState === "loading" ? t("common.states.loading") : presentation.label;
+  const modelLabel = presentation.modelLabel;
+  // The model is only rendered as a trailing chip, so it would be invisible to a screen
+  // reader without folding it into the row's own label.
+  const accessibilityLabel = modelLabel
+    ? t("subagents.rowAccessibilityLabelWithModel", { label: displayLabel, model: modelLabel })
+    : displayLabel;
   const handlePress = useCallback(() => {
     if (row.kind === "provider") {
       onOpenProviderSubagent(row.parentAgentId, row.id);
@@ -194,7 +202,7 @@ function SubagentsTrackRow({
     <View onPointerEnter={handlePointerEnter} onPointerLeave={handlePointerLeave}>
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={displayLabel}
+        accessibilityLabel={accessibilityLabel}
         testID={`subagents-track-row-${row.id}`}
         onPress={handlePress}
       >
@@ -204,6 +212,14 @@ function SubagentsTrackRow({
             <Text style={styles.rowLabel} numberOfLines={1}>
               {displayLabel}
             </Text>
+            {modelLabel ? (
+              // No numberOfLines: on web it compiles to a maxWidth clamp that survives
+              // flexShrink: 0, which would make the chip ellipsize itself instead of
+              // holding its width and letting the title absorb the squeeze.
+              <Text style={styles.rowModelLabel} testID={`subagents-track-model-${row.id}`}>
+                {modelLabel}
+              </Text>
+            ) : null}
             {row.kind === "paseo" ? (
               <SubagentRowActions
                 rowId={row.id}
@@ -390,6 +406,11 @@ const styles = StyleSheet.create((theme) => ({
     minWidth: 0,
     fontSize: theme.fontSize.sm,
     color: theme.colors.foreground,
+  },
+  rowModelLabel: {
+    flexShrink: 0,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
   },
   actionClusterVisible: {
     flexDirection: "row",

--- a/packages/app/test-stubs/react-native-unistyles.ts
+++ b/packages/app/test-stubs/react-native-unistyles.ts
@@ -10,6 +10,7 @@ const testTheme = {
     surface1: "#fafafa",
     surface2: "#f4f4f5",
     border: "#e4e4e7",
+    borderAccent: "#ececf1",
   },
   spacing: [0, 4, 8, 12, 16, 20, 24, 28, 32],
   fontSize: {
@@ -23,6 +24,12 @@ const testTheme = {
   borderRadius: {
     base: 4,
     md: 6,
+    "2xl": 16,
+  },
+  borderWidth: {
+    0: 0,
+    1: 1,
+    2: 2,
   },
 };
 

--- a/packages/protocol/src/messages.provider-subagents.test.ts
+++ b/packages/protocol/src/messages.provider-subagents.test.ts
@@ -73,4 +73,50 @@ describe("provider subagent protocol", () => {
       }),
     ).toMatchObject({ payload: { subagents: [{ id: "child-1" }] } });
   });
+
+  test("accepts a provider child model while remaining compatible when absent", () => {
+    const descriptor = {
+      id: "child-1",
+      parentAgentId: "parent-1",
+      provider: "claude",
+      title: "Explore",
+      description: null,
+      status: "running",
+      createdAt: "2026-07-12T10:00:00.000Z",
+      updatedAt: "2026-07-12T10:00:00.000Z",
+      toolCallId: null,
+    };
+
+    expect(
+      SessionOutboundMessageSchema.parse({
+        type: "agent.provider_subagents.update",
+        payload: {
+          kind: "upsert",
+          subagent: { ...descriptor, model: "claude-opus-4-8", modelLabel: "Opus 4.8" },
+        },
+      }),
+    ).toMatchObject({
+      payload: { subagent: { model: "claude-opus-4-8", modelLabel: "Opus 4.8" } },
+    });
+
+    // A daemon that predates the field sends neither key; parsing must still succeed so an
+    // old daemon keeps working against a new client.
+    expect(
+      SessionOutboundMessageSchema.parse({
+        type: "agent.provider_subagents.update",
+        payload: { kind: "upsert", subagent: descriptor },
+      }),
+    ).toMatchObject({ payload: { subagent: { id: "child-1" } } });
+
+    // A provider that has no model to report may send an explicit null.
+    expect(
+      SessionOutboundMessageSchema.parse({
+        type: "agent.provider_subagents.update",
+        payload: {
+          kind: "upsert",
+          subagent: { ...descriptor, model: null, modelLabel: null },
+        },
+      }),
+    ).toMatchObject({ payload: { subagent: { model: null, modelLabel: null } } });
+  });
 });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3538,6 +3538,12 @@ export const ProviderSubagentDescriptorPayloadSchema = z.object({
   updatedAt: z.string(),
   toolCallId: z.string().nullable(),
   cwd: z.string().nullable().optional(),
+  // COMPAT(providerSubagentModel): added in v0.2.X, remove optional after 2027-01-28.
+  // `model` is the canonical id; `modelLabel` is resolved against the provider's own model
+  // manifest on the daemon, because the client has no cwd-scoped provider snapshot at the
+  // layer that renders subagent rows.
+  model: z.string().nullable().optional(),
+  modelLabel: z.string().nullable().optional(),
 });
 
 export type ProviderSubagentDescriptorPayload = z.infer<

--- a/packages/server/src/server/agent/provider-subagents/store.test.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.test.ts
@@ -103,4 +103,70 @@ describe("ProviderSubagentStore", () => {
     expect(page.rows.at(-1)?.seq).toBe(101);
     expect(page.hasOlder).toBe(false);
   });
+
+  // The provider reports the model once, then sends status-only upserts as the subagent
+  // finishes. Those must not blank out what was already learned.
+  test("retains the model across upserts that do not mention it", () => {
+    const subagents = new ProviderSubagentStore();
+
+    subagents.apply("parent-a", "claude", {
+      type: "upsert",
+      id: "child-1",
+      title: "Explore",
+      status: "running",
+      model: "claude-opus-4-8",
+      modelLabel: "Opus 4.8",
+    });
+    subagents.apply("parent-a", "claude", {
+      type: "upsert",
+      id: "child-1",
+      status: "completed",
+    });
+
+    expect(subagents.get("parent-a", "child-1")).toMatchObject({
+      status: "completed",
+      model: "claude-opus-4-8",
+      modelLabel: "Opus 4.8",
+    });
+  });
+
+  test("clears the model only when a provider explicitly reports none", () => {
+    const subagents = new ProviderSubagentStore();
+
+    subagents.apply("parent-a", "claude", {
+      type: "upsert",
+      id: "child-1",
+      status: "running",
+      model: "claude-opus-4-8",
+      modelLabel: "Opus 4.8",
+    });
+    subagents.apply("parent-a", "claude", {
+      type: "upsert",
+      id: "child-1",
+      status: "running",
+      model: null,
+      modelLabel: null,
+    });
+
+    expect(subagents.get("parent-a", "child-1")).toMatchObject({
+      model: null,
+      modelLabel: null,
+    });
+  });
+
+  test("defaults the model to null for providers that never report one", () => {
+    const subagents = new ProviderSubagentStore();
+
+    subagents.apply("parent-a", "opencode", {
+      type: "upsert",
+      id: "child-1",
+      title: "Explore",
+      status: "running",
+    });
+
+    expect(subagents.get("parent-a", "child-1")).toMatchObject({
+      model: null,
+      modelLabel: null,
+    });
+  });
 });

--- a/packages/server/src/server/agent/provider-subagents/store.ts
+++ b/packages/server/src/server/agent/provider-subagents/store.ts
@@ -21,6 +21,10 @@ export interface ProviderSubagentDescriptor {
   updatedAt: string;
   toolCallId: string | null;
   cwd: string | null;
+  /** Canonical model id the subagent is running, when the provider reports one. */
+  model: string | null;
+  /** Display label for `model`, resolved against the provider's own model manifest. */
+  modelLabel: string | null;
 }
 
 export type ProviderSubagentInputEvent =
@@ -32,6 +36,8 @@ export type ProviderSubagentInputEvent =
       status: ProviderSubagentStatus;
       toolCallId?: string | null;
       cwd?: string | null;
+      model?: string | null;
+      modelLabel?: string | null;
       timestamp?: string;
     }
   | {
@@ -56,6 +62,22 @@ export type ProviderSubagentStoreEvent =
 
 function storeKey(parentAgentId: string, subagentId: string): string {
   return `${parentAgentId}\0${subagentId}`;
+}
+
+/**
+ * Merge one descriptor field across upserts.
+ *
+ * Providers send partial upserts — a `finish` event carries a status and nothing else — so an
+ * omitted field must keep the value already on record. An explicit `null` still clears it.
+ */
+function mergeDescriptorField<T>(
+  next: T | null | undefined,
+  previous: T | null | undefined,
+): T | null {
+  if (next === undefined) {
+    return previous ?? null;
+  }
+  return next;
 }
 
 export class ProviderSubagentStore {
@@ -100,15 +122,15 @@ export class ProviderSubagentStore {
       id: event.id,
       parentAgentId,
       provider,
-      title: event.title === undefined ? (previous?.title ?? null) : event.title,
-      description:
-        event.description === undefined ? (previous?.description ?? null) : event.description,
+      title: mergeDescriptorField(event.title, previous?.title),
+      description: mergeDescriptorField(event.description, previous?.description),
       status: event.status,
       createdAt: previous?.createdAt ?? timestamp,
       updatedAt: timestamp,
-      toolCallId:
-        event.toolCallId === undefined ? (previous?.toolCallId ?? null) : event.toolCallId,
-      cwd: event.cwd === undefined ? (previous?.cwd ?? null) : event.cwd,
+      toolCallId: mergeDescriptorField(event.toolCallId, previous?.toolCallId),
+      cwd: mergeDescriptorField(event.cwd, previous?.cwd),
+      model: mergeDescriptorField(event.model, previous?.model),
+      modelLabel: mergeDescriptorField(event.modelLabel, previous?.modelLabel),
     };
     this.descriptors.set(key, subagent);
     return { type: "upsert", subagent };

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -30,9 +30,11 @@ import {
   mapTaskNotificationUserContentToToolCall,
 } from "./task-notification-tool-call.js";
 import {
+  type ClaudeModelIdentity,
   findClaudeModel,
   getClaudeModelsWithSettings,
   normalizeClaudeRuntimeModelId,
+  resolveClaudeModelIdentity,
 } from "./models.js";
 import {
   CLAUDE_DISABLED_THINKING_OPTION_ID,
@@ -5248,8 +5250,44 @@ function buildClaudePersistedSidechainEvents(
 
 function resolveClaudeHistoricalSubagentTitle(
   toolCall: ClaudeHistoricalSubagentToolCall | undefined,
+  attributionAgent: string | undefined,
 ): string {
-  return toolCall?.name ?? toolCall?.subagentType ?? "Claude subagent";
+  return toolCall?.name ?? toolCall?.subagentType ?? attributionAgent ?? "Claude subagent";
+}
+
+/**
+ * The subagent type as recorded on the sidechain's own entries. The parent tool call is the
+ * better source when it survives, but it is missing whenever the parent transcript no longer
+ * holds the Task block, so this keeps replayed rows titled instead of falling through to the
+ * generic literal.
+ */
+function readClaudeHistoricalAttributionAgent(entries: ClaudeHistoryEntry[]): string | undefined {
+  for (const entry of entries) {
+    const attributionAgent = readNonEmptyString(entry.attributionAgent);
+    if (attributionAgent) {
+      return attributionAgent;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Take the last model the sidechain actually ran on. The live tracker overwrites its model on
+ * every assistant message, so a run that switched models mid-flight ends on the newest one;
+ * replay has to land on the same value or a resumed agent would disagree with what the user
+ * just watched happen.
+ */
+function readClaudeHistoricalSidechainModel(
+  entries: ClaudeHistoryEntry[],
+): ClaudeModelIdentity | null {
+  let identity: ClaudeModelIdentity | null = null;
+  for (const entry of entries) {
+    const candidate = resolveClaudeModelIdentity(readNonEmptyString(entry.message?.model));
+    if (candidate) {
+      identity = candidate;
+    }
+  }
+  return identity;
 }
 
 function buildClaudePersistedSidechainAgentEvents(
@@ -5263,6 +5301,7 @@ function buildClaudePersistedSidechainAgentEvents(
   const id = result?.toolCallId ?? agentId;
   const toolCall = result ? toolCalls.get(result.toolCallId) : undefined;
   const firstTimestamp = normalizeProviderReplayTimestamp(entries[0]?.timestamp);
+  const modelIdentity = readClaudeHistoricalSidechainModel(entries);
   const events: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [
     {
       type: "provider_subagent",
@@ -5270,10 +5309,14 @@ function buildClaudePersistedSidechainAgentEvents(
       event: {
         type: "upsert",
         id,
-        title: resolveClaudeHistoricalSubagentTitle(toolCall),
+        title: resolveClaudeHistoricalSubagentTitle(
+          toolCall,
+          readClaudeHistoricalAttributionAgent(entries),
+        ),
         description: toolCall?.description ?? null,
         status: "running",
         toolCallId: result?.toolCallId ?? null,
+        ...modelIdentity,
         ...(firstTimestamp ? { timestamp: firstTimestamp } : {}),
       },
     },

--- a/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.voice-history-regression.test.ts
@@ -152,6 +152,7 @@ describe("ClaudeAgentSession history replay regression", () => {
           type: "assistant",
           isSidechain: true,
           agentId: "history-child",
+          attributionAgent: "Explore",
           uuid: "history-child-message",
           timestamp: "2026-07-12T10:00:01.000Z",
           sessionId: "history-session",
@@ -159,7 +160,26 @@ describe("ClaudeAgentSession history replay regression", () => {
           message: {
             id: "history-child-message",
             role: "assistant",
+            model: "claude-sonnet-5",
             content: [{ type: "text", text: HISTORY_SIDECHAIN_MARKER }],
+          },
+        }),
+        // A second turn on a different model: a sidechain can switch models mid-run, and the
+        // live tracker ends on the newest one, so replay has to agree.
+        JSON.stringify({
+          type: "assistant",
+          isSidechain: true,
+          agentId: "history-child",
+          attributionAgent: "Explore",
+          uuid: "history-child-message-2",
+          timestamp: "2026-07-12T10:00:02.000Z",
+          sessionId: "history-session",
+          cwd,
+          message: {
+            id: "history-child-message-2",
+            role: "assistant",
+            model: "claude-opus-4-8",
+            content: [{ type: "text", text: "second sidechain turn" }],
           },
         }),
         JSON.stringify({
@@ -324,6 +344,105 @@ describe("ClaudeAgentSession history replay regression", () => {
         type: "upsert",
         id: "history-task-call",
         status: "completed",
+      }),
+    });
+  });
+
+  test("replays the last model a persisted sidechain ran on", async () => {
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.resumeSession(
+      {
+        provider: "claude",
+        sessionId: "history-session",
+        nativeHandle: "history-session",
+        metadata: { provider: "claude", cwd },
+      },
+      { cwd },
+    );
+    const historyEvents: AgentStreamEvent[] = [];
+
+    try {
+      for await (const event of session.streamHistory()) historyEvents.push(event);
+    } finally {
+      await session.close();
+    }
+
+    expect(historyEvents).toContainEqual({
+      type: "provider_subagent",
+      provider: "claude",
+      event: expect.objectContaining({
+        type: "upsert",
+        id: "history-task-call",
+        status: "running",
+        model: "claude-opus-4-8",
+        modelLabel: "Opus 4.8",
+      }),
+    });
+  });
+
+  // The parent transcript is where the subagent's name lives, but it can be absent — the
+  // Task block may have been compacted away, or the sidechain may be all that survives.
+  // The sidechain's own attributionAgent keeps the row titled instead of "Claude subagent".
+  test("titles a replayed sidechain from attributionAgent when the parent call is gone", async () => {
+    const historyDir = claudeProjectDirSync(cwd, { configDir });
+    writeFileSync(
+      path.join(historyDir, "orphan-session.jsonl"),
+      [
+        JSON.stringify({
+          type: "assistant",
+          isSidechain: true,
+          agentId: "orphan-child",
+          attributionAgent: "Explore",
+          uuid: "orphan-child-message",
+          timestamp: "2026-07-12T11:00:00.000Z",
+          sessionId: "orphan-session",
+          cwd,
+          message: {
+            id: "orphan-child-message",
+            role: "assistant",
+            model: "claude-haiku-4-5",
+            content: [{ type: "text", text: "orphan sidechain turn" }],
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.resumeSession(
+      {
+        provider: "claude",
+        sessionId: "orphan-session",
+        nativeHandle: "orphan-session",
+        metadata: { provider: "claude", cwd },
+      },
+      { cwd },
+    );
+    const historyEvents: AgentStreamEvent[] = [];
+
+    try {
+      for await (const event of session.streamHistory()) historyEvents.push(event);
+    } finally {
+      await session.close();
+    }
+
+    expect(historyEvents).toContainEqual({
+      type: "provider_subagent",
+      provider: "claude",
+      event: expect.objectContaining({
+        type: "upsert",
+        id: "orphan-child",
+        title: "Explore",
+        model: "claude-haiku-4-5",
+        modelLabel: "Haiku 4.5",
       }),
     });
   });

--- a/packages/server/src/server/agent/providers/claude/models.ts
+++ b/packages/server/src/server/agent/providers/claude/models.ts
@@ -31,6 +31,32 @@ export function findClaudeModel(
   return getClaudeModels().find((model) => model.id === normalizedModelId);
 }
 
+export interface ClaudeModelIdentity {
+  model: string;
+  modelLabel: string;
+}
+
+/**
+ * Resolve an observed runtime model string to a canonical id plus a display label.
+ *
+ * A model the manifest does not know keeps its raw id for both. Substituting a known
+ * model's label would report the wrong model with full confidence, which is worse than
+ * showing an unfamiliar id.
+ */
+export function resolveClaudeModelIdentity(
+  value: string | null | undefined,
+): ClaudeModelIdentity | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) {
+    return null;
+  }
+  const definition = findClaudeModel(trimmed);
+  return {
+    model: definition?.id ?? trimmed,
+    modelLabel: definition?.label ?? trimmed,
+  };
+}
+
 export async function getClaudeModelsWithSettings(
   logger: Logger,
   configDir?: string,

--- a/packages/server/src/server/agent/providers/claude/sidechain-tracker.test.ts
+++ b/packages/server/src/server/agent/providers/claude/sidechain-tracker.test.ts
@@ -3,6 +3,46 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import { ClaudeSidechainTracker } from "./sidechain-tracker.js";
 
+type ProviderSubagentUpsert = Extract<
+  Extract<
+    ReturnType<ClaudeSidechainTracker["handleMessage"]>[number],
+    { type: "provider_subagent" }
+  >["event"],
+  { type: "upsert" }
+>;
+
+/**
+ * Sidechain assistant message as the SDK actually delivers it: `message.model` is a
+ * required field of the underlying BetaMessage, and `subagent_type`/`task_description`
+ * sit on the SDK wrapper rather than inside `message`.
+ */
+function assistantMessage(
+  fields: {
+    model?: string;
+    subagentType?: string;
+    taskDescription?: string;
+  } = {},
+): SDKMessage {
+  return {
+    type: "assistant",
+    parent_tool_use_id: "task-1",
+    ...(fields.subagentType === undefined ? {} : { subagent_type: fields.subagentType }),
+    ...(fields.taskDescription === undefined ? {} : { task_description: fields.taskDescription }),
+    message: {
+      content: [],
+      ...(fields.model === undefined ? {} : { model: fields.model }),
+    },
+  } as unknown as SDKMessage;
+}
+
+function upsertOf(events: ReturnType<ClaudeSidechainTracker["handleMessage"]>) {
+  const first = events[0];
+  if (!first || first.type !== "provider_subagent" || first.event.type !== "upsert") {
+    throw new Error("expected the first event to be a provider_subagent upsert");
+  }
+  return first.event satisfies ProviderSubagentUpsert;
+}
+
 describe("ClaudeSidechainTracker", () => {
   it("uses Claude's native agent name for the provider subagent title", () => {
     const tracker = new ClaudeSidechainTracker({
@@ -34,5 +74,167 @@ describe("ClaudeSidechainTracker", () => {
         toolCallId: "task-1",
       },
     });
+  });
+
+  describe("model capture", () => {
+    it("reports the model the sidechain is actually running", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+
+      const upsert = upsertOf(
+        tracker.handleMessage(assistantMessage({ model: "claude-opus-4-8" }), "task-1"),
+      );
+
+      expect(upsert.model).toBe("claude-opus-4-8");
+      expect(upsert.modelLabel).toBe("Opus 4.8");
+    });
+
+    it("resolves dated and 1M runtime model ids to their manifest label", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+
+      const dated = upsertOf(
+        tracker.handleMessage(assistantMessage({ model: "claude-sonnet-5-20260101" }), "task-1"),
+      );
+      expect(dated.model).toBe("claude-sonnet-5");
+      expect(dated.modelLabel).toBe("Sonnet 5");
+
+      const oneMillion = upsertOf(
+        tracker.handleMessage(assistantMessage({ model: "claude-opus-4-8[1m]" }), "task-2"),
+      );
+      expect(oneMillion.model).toBe("claude-opus-4-8[1m]");
+      expect(oneMillion.modelLabel).toBe("Opus 4.8 1M");
+    });
+
+    // A model Paseo's manifest has never heard of must degrade to the raw id. Resolving it
+    // to *some other* model's label would be a confidently wrong answer, which is worse
+    // than showing the user an unfamiliar string.
+    it("falls back to the raw id for a model the manifest does not know", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+
+      const upsert = upsertOf(
+        tracker.handleMessage(assistantMessage({ model: "claude-opus-99-9" }), "task-1"),
+      );
+
+      expect(upsert.model).toBe("claude-opus-99-9");
+      expect(upsert.modelLabel).toBe("claude-opus-99-9");
+    });
+
+    it("keeps the most recently observed model when it changes mid-run", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+
+      tracker.handleMessage(assistantMessage({ model: "claude-opus-4-8" }), "task-1");
+      const upsert = upsertOf(
+        tracker.handleMessage(assistantMessage({ model: "claude-haiku-4-5" }), "task-1"),
+      );
+
+      expect(upsert.model).toBe("claude-haiku-4-5");
+      expect(upsert.modelLabel).toBe("Haiku 4.5");
+    });
+
+    it("emits no further events while the model stays the same", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+
+      const first = tracker.handleMessage(assistantMessage({ model: "claude-opus-4-8" }), "task-1");
+      const second = tracker.handleMessage(
+        assistantMessage({ model: "claude-opus-4-8" }),
+        "task-1",
+      );
+
+      expect(first.length).toBeGreaterThan(0);
+      expect(second).toEqual([]);
+    });
+
+    it("omits the model when the sidechain never reports one", () => {
+      const tracker = new ClaudeSidechainTracker({
+        getToolInput: () => ({ subagent_type: "Explore" }),
+      });
+
+      const upsert = upsertOf(tracker.handleMessage(assistantMessage(), "task-1"));
+
+      expect(upsert.model).toBeUndefined();
+      expect(upsert.modelLabel).toBeUndefined();
+    });
+
+    it("retains the model when the sidechain finishes", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+      tracker.handleMessage(assistantMessage({ model: "claude-opus-4-8" }), "task-1");
+
+      const upsert = upsertOf(tracker.finish("task-1", "completed"));
+
+      expect(upsert.status).toBe("completed");
+      expect(upsert.model).toBe("claude-opus-4-8");
+      expect(upsert.modelLabel).toBe("Opus 4.8");
+    });
+
+    it("retains the model when every sidechain is finished at once", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+      tracker.handleMessage(assistantMessage({ model: "claude-opus-4-8" }), "task-1");
+
+      const upsert = upsertOf(tracker.finishAll("canceled"));
+
+      expect(upsert.status).toBe("canceled");
+      expect(upsert.model).toBe("claude-opus-4-8");
+    });
+  });
+
+  describe("title from the message", () => {
+    // Backgrounded agents return their tool_result immediately, so the tool-input cache
+    // entry can be evicted before the sidechain streams anything. The subagent type still
+    // arrives on every assistant message, which is what keeps the row titled.
+    it("titles the row from the message when no tool input is cached", () => {
+      const tracker = new ClaudeSidechainTracker({ getToolInput: () => null });
+
+      const upsert = upsertOf(
+        tracker.handleMessage(
+          assistantMessage({ subagentType: "Explore", taskDescription: "Survey the repo" }),
+          "task-1",
+        ),
+      );
+
+      expect(upsert.title).toBe("Explore");
+      expect(upsert.description).toBe("Survey the repo");
+    });
+
+    it("prefers the tool input's agent name over the message's subagent type", () => {
+      const tracker = new ClaudeSidechainTracker({
+        getToolInput: () => ({ name: "repo_researcher" }),
+      });
+
+      const upsert = upsertOf(
+        tracker.handleMessage(assistantMessage({ subagentType: "Explore" }), "task-1"),
+      );
+
+      expect(upsert.title).toBe("repo_researcher");
+    });
+
+    // The subagent type is a fact about how the sidechain was spawned, so whichever source
+    // reports it first wins. Letting the two sources overwrite each other would emit an
+    // upsert on every message for the lifetime of the subagent.
+    it("does not let the message overwrite an already-known subagent type", () => {
+      const tracker = new ClaudeSidechainTracker({
+        getToolInput: () => ({ subagent_type: "Explore" }),
+      });
+
+      const first = tracker.handleMessage(assistantMessage({ subagentType: "Plan" }), "task-1");
+      const second = tracker.handleMessage(assistantMessage({ subagentType: "Plan" }), "task-1");
+
+      expect(upsertOf(first).title).toBe("Explore");
+      expect(second).toEqual([]);
+    });
+  });
+
+  it("ignores non-assistant messages without recording a model", () => {
+    const tracker = new ClaudeSidechainTracker({
+      getToolInput: () => ({ subagent_type: "Explore" }),
+    });
+
+    const upsert = upsertOf(
+      tracker.handleMessage(
+        { type: "result", parent_tool_use_id: "task-1" } as unknown as SDKMessage,
+        "task-1",
+      ),
+    );
+
+    expect(upsert.title).toBe("Explore");
+    expect(upsert.model).toBeUndefined();
   });
 });

--- a/packages/server/src/server/agent/providers/claude/sidechain-tracker.ts
+++ b/packages/server/src/server/agent/providers/claude/sidechain-tracker.ts
@@ -1,5 +1,6 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
+import { resolveClaudeModelIdentity } from "./models.js";
 import {
   mapClaudeCompletedToolCall,
   mapClaudeFailedToolCall,
@@ -8,6 +9,7 @@ import {
 import { buildToolCallDisplayModel } from "@getpaseo/protocol/tool-call-display";
 
 import type { AgentMetadata, AgentStreamEvent, AgentTimelineItem } from "../../agent-sdk-types.js";
+import type { ProviderSubagentInputEvent } from "../../provider-subagents/store.js";
 
 interface ClaudeContentChunk {
   type: string;
@@ -25,6 +27,8 @@ interface SubAgentActivityState {
   name?: string;
   subAgentType?: string;
   description?: string;
+  model?: string;
+  modelLabel?: string;
   actions: SubAgentActionEntry[];
   actionKeys: string[];
   nextActionIndex: number;
@@ -75,7 +79,9 @@ export class ClaudeSidechainTracker {
       } satisfies SubAgentActivityState);
     this.activeSidechains.set(parentToolUseId, state);
 
-    const contextUpdated = this.updateSubAgentContextFromTaskInput(state, parentToolUseId);
+    const taskInputUpdated = this.updateSubAgentContextFromTaskInput(state, parentToolUseId);
+    const messageContextUpdated = this.updateSubAgentContextFromMessage(state, message);
+    const contextUpdated = taskInputUpdated || messageContextUpdated;
     const actionCandidates = this.extractSubAgentActionCandidates(message);
     const childTimelineItems = [
       ...this.extractSubAgentTimelineItems(message),
@@ -128,14 +134,7 @@ export class ClaudeSidechainTracker {
       {
         type: "provider_subagent",
         provider: "claude",
-        event: {
-          type: "upsert",
-          id: parentToolUseId,
-          title: state.name ?? state.subAgentType ?? "Claude subagent",
-          description: state.description ?? null,
-          status: "running",
-          toolCallId: parentToolUseId,
-        },
+        event: this.buildUpsertEvent(parentToolUseId, state, "running"),
       },
       ...childTimelineItems.map(
         (item): AgentStreamEvent => ({
@@ -161,14 +160,7 @@ export class ClaudeSidechainTracker {
       events.push({
         type: "provider_subagent",
         provider: "claude",
-        event: {
-          type: "upsert",
-          id,
-          title: state.name ?? state.subAgentType ?? "Claude subagent",
-          description: state.description ?? null,
-          status,
-          toolCallId: id,
-        },
+        event: this.buildUpsertEvent(id, state, status),
       });
     }
     this.activeSidechains.clear();
@@ -183,16 +175,25 @@ export class ClaudeSidechainTracker {
       {
         type: "provider_subagent",
         provider: "claude",
-        event: {
-          type: "upsert",
-          id,
-          title: state.name ?? state.subAgentType ?? "Claude subagent",
-          description: state.description ?? null,
-          status,
-          toolCallId: id,
-        },
+        event: this.buildUpsertEvent(id, state, status),
       },
     ];
+  }
+
+  private buildUpsertEvent(
+    id: string,
+    state: SubAgentActivityState,
+    status: "running" | "completed" | "failed" | "canceled",
+  ): Extract<ProviderSubagentInputEvent, { type: "upsert" }> {
+    return {
+      type: "upsert",
+      id,
+      title: state.name ?? state.subAgentType ?? "Claude subagent",
+      description: state.description ?? null,
+      status,
+      toolCallId: id,
+      ...(state.model ? { model: state.model, modelLabel: state.modelLabel ?? state.model } : {}),
+    };
   }
 
   delete(toolUseId: string): void {
@@ -285,6 +286,55 @@ export class ClaudeSidechainTracker {
       state.description = nextDescription;
       changed = true;
     }
+    return changed;
+  }
+
+  /**
+   * Read context the SDK puts on the message itself rather than in the Task tool input.
+   *
+   * The model is only observable here — it is a field of every sidechain assistant message
+   * and is never restated in the tool input. `subagent_type`/`task_description` are also on
+   * the message, which matters because the tool-input cache entry is dropped when the tool
+   * result arrives; for a backgrounded agent that happens before the sidechain streams, so
+   * the message is the only source that still has them.
+   *
+   * Precedence: the model is write-last (a run can switch models on fallback, and the newest
+   * observation is the truth), while the spawn facts are write-once so the two sources cannot
+   * overwrite each other and emit an upsert on every message.
+   */
+  private updateSubAgentContextFromMessage(
+    state: SubAgentActivityState,
+    message: SDKMessage,
+  ): boolean {
+    if (message.type !== "assistant") {
+      return false;
+    }
+
+    let changed = false;
+
+    const identity = resolveClaudeModelIdentity(readTrimmedString(message.message?.model));
+    if (identity && (identity.model !== state.model || identity.modelLabel !== state.modelLabel)) {
+      state.model = identity.model;
+      state.modelLabel = identity.modelLabel;
+      changed = true;
+    }
+
+    const messageRecord = message as unknown as Record<string, unknown>;
+    if (!state.subAgentType) {
+      const nextSubAgentType = this.normalizeSubAgentText(messageRecord.subagent_type);
+      if (nextSubAgentType) {
+        state.subAgentType = nextSubAgentType;
+        changed = true;
+      }
+    }
+    if (!state.description) {
+      const nextDescription = this.normalizeSubAgentText(messageRecord.task_description);
+      if (nextDescription) {
+        state.description = nextDescription;
+        changed = true;
+      }
+    }
+
     return changed;
   }
 


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

A subagent can run a different model from its parent — via the Agent tool's `model`
override or a `.claude/agents/*.md` frontmatter model — and nothing in the UI said which.
Fan out three subagents and the track was three identical rows.

This came up while moving my skill agents onto cheaper models to cut token cost. The
mechanical part is easy; confirming it took effect was not. A skill's subagents get their
model from agent frontmatter or a call-site override, and if either is wrong or ignored the
run still succeeds — it just quietly costs what it always did. The only way to check was to
go digging through transcripts after the fact. Paseo already shows the whole fan-out in the
subagents track, so the model belongs on the row: glance at the track mid-run and see
whether the cheap model is actually the one doing the work.

The model was already arriving and being thrown away. Every Claude sidechain assistant
message is an ordinary `SDKAssistantMessage` whose `message.model` is required, and
`ClaudeSidechainTracker` read only `message.id`. It now captures the model per message and
the row renders it as a muted trailing label:

```
3 subagents · 3 running
⠿ general-purpose                                   Opus 5
⠿ general-purpose                                   Sonnet 5
⠿ general-purpose                                   Haiku 4.5
```


Three decisions worth calling out, since they're the ones I'd question in review:

**The label is resolved on the daemon, not the client.** The client has no cwd-scoped
provider snapshot at the layer that renders these rows, rows carry a per-row `provider`, and
display labels already travel on the wire today (`AgentModelDefinitionSchema.label` is a
required string). Resolving client-side would have meant threading `serverId`/`cwd` through
`SubagentsTrackProps`, a second snapshot for the detail panel, and a models-still-loading
state. The wire carries `model` (canonical id) and `modelLabel` (display string); the client
displays the label and never interprets the id.

**An unrecognized model shows its raw id, never another model's name.**
`normalizeClaudeRuntimeModelId` returns `null` for ids it doesn't know rather than passing
them through, and the existing client-side `resolveAgentModelSelection` substitutes the
*provider default's* label in that case. For a new model id or a Bedrock ARN that would
render a confidently wrong model name, which is the worst failure this feature can have.
`resolveClaudeModelIdentity` falls back to the raw string for both fields.

**Effort is deliberately not shown.** The SDK declares `effort` on agent definitions and
hook input, never on an assistant message. The persisted JSONL transcript *does* record it
per sidechain entry, so a replayed row could show an effort a live row never can. An
indicator that only appears after a resume is worse than no indicator. Recorded in
`docs/agent-lifecycle.md` for whoever revisits it.

**Bonus fix in the same change:** rows titled "Claude subagent". `subagent_type` comes from
the Task tool-input cache, and that entry is deleted when the tool result arrives — which for
`run_in_background: true` is immediately, so backgrounded subagents lost their title. The
same assistant message carries `subagent_type` and `task_description` directly, so the title
is now correct regardless of cache timing. Written write-once so the two sources can't
oscillate; the model is write-last, since a run can switch models on fallback.

Replay derives the same fields from JSONL (taking the *last* assistant model, to match the
live path) and uses `attributionAgent` for the title.

Both wire fields are optional and tagged `COMPAT(providerSubagentModel)`. An older daemon
sends neither and the row renders exactly as it does today — no chip, no placeholder. Codex
and OpenCode emit the same event shape and simply don't set them yet.

### How did you verify it

Ran the branch daemon on `:6768` with the Expo web client against it, and drove a real agent
end to end.

**Distinct model per row, and the title fix.** Prompted an agent to fan out two `Agent`
subagents — `Explore` on haiku with `run_in_background: true`, and `Explore` on opus:

<img width="1280" height="720" alt="issue-track-expanded" src="https://github.com/user-attachments/assets/0181c038-83a8-4917-9f05-0343e3daa1ed" />

The on-disk transcripts carry `claude-haiku-4-5-20251001` and `claude-opus-5`, and the UI
shows `Haiku 4.5` and `Opus 5`, so the manifest lookup and the dated-id normalization are
both doing real work rather than echoing the input. Both rows are titled `Explore`, not
"Claude subagent" — including the backgrounded one, which is the case that was broken.

Separately, three concurrent subagents on `general-purpose`, one per model, rendered
`Opus 5` / `Sonnet 5` / `Haiku 4.5`:

<img width="774" height="687" alt="image" src="https://github.com/user-attachments/assets/a8824f09-a194-44a7-b43e-f96a1e3f3ac4" />

**Replay — restarted the daemon, not the client.** A client reload only re-lists the
daemon's in-memory store and proves nothing about the JSONL path. Killed the branch daemon
(pid 34697), started it again (pid 36893) so `ProviderSubagentStore` was empty, then reloaded
and reopened the agent. Rows came back identical, same titles and same models:

<img width="1280" height="720" alt="replay-track" src="https://github.com/user-attachments/assets/e3edc1e2-64ac-457c-9705-597287b8c06e" />


**Long title.** Forced a 74-character title into a row: the title ellipsizes
(`scrollWidth 489` vs `clientWidth 249`) and the chip holds its full width intact
(`scrollWidth 53 == clientWidth 53`), no overlap:

<img width="390" height="844" alt="track-long-title" src="https://github.com/user-attachments/assets/3beb6282-f4e9-4cf8-9124-b05659e0ea61" />


**Compact width.** Same at 390×844 — chip right-aligned, unclipped:

<img width="390" height="844" alt="track-mobile" src="https://github.com/user-attachments/assets/6110f5ff-f224-4e32-9f46-62fe524f83d5" />

**Accessibility.** The chip is the only place the model appears, so it's folded into the
row's accessible name through an interpolated resource rather than string concatenation
(concatenating a translated label with an untranslated qualifier produces a bilingual
screen-reader string that passes every parity test and is invisible on screen). Verified
live: `aria-label="Explore, Haiku 4.5"`, and `"Explore"` with no model.

**Older daemon.** Pointed the same client build at a daemon running released server code —
it boots, renders, and no new console errors. I did not get a provider subagent row onto that
daemon to watch the no-chip case live, so that path is covered by tests only: the protocol
test parses a descriptor with both fields absent, `select.test.ts` asserts `modelLabel` is
null when the host reports none, and the render test asserts no chip appears.

**Platforms:** verified on web and Electron desktop. **I did not test iOS or Android.** The
chip has no platform-specific code path — the only platform gate in `track.tsx` is the
pre-existing action-cluster visibility, which doesn't render on provider rows at all — but I
haven't watched it on a device, so I'm not claiming it.

`npm run typecheck`, `npm run lint`, and `npm run format` are clean. Targeted test runs:
26 server, 37 app, 3 protocol, 49 i18n.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — web/desktop only, stated above
- [x] Tests added or updated where it made sense