### PR TITLE
fix(app): hide open in file manager action for remote host workspaces

### DIFF
--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -57,6 +57,8 @@ import {
 import { useSidebarCollapsedSectionsStore } from "@/stores/sidebar-collapsed-sections-store";
 import { useHostFeatureMap } from "@/runtime/host-features";
 import { useIsCompactFormFactor } from "@/constants/layout";
+import { useLocalDaemonServerId } from "@/hooks/use-is-local-daemon";
+import { resolveProjectFileManagerPlacement } from "@/components/sidebar/sidebar-project-host-selection";
 import { useProjectIconDataByProjectKey } from "@/projects/project-icons";
 import {
   buildNewWorkspaceRoute,
@@ -505,9 +507,11 @@ function ProjectRowTrailingActions({
   removeProjectStatus: "idle" | "pending" | "success";
 }) {
   const actionsVisible = isHovered || platformIsNative || isMobileBreakpoint;
-  const projectServerId =
-    project.hosts.find((host) => host.iconWorkingDir === project.iconWorkingDir)?.serverId ??
-    project.hosts[0]?.serverId;
+  const localServerId = useLocalDaemonServerId();
+  const { projectPath, projectServerId } = resolveProjectFileManagerPlacement(
+    project,
+    localServerId,
+  );
 
   return (
     <View style={styles.projectTrailingActions}>
@@ -527,7 +531,7 @@ function ProjectRowTrailingActions({
         >
           <ProjectKebabMenu
             projectKey={project.projectKey}
-            projectPath={project.iconWorkingDir}
+            projectPath={projectPath}
             serverId={projectServerId}
             onRemoveProject={onRemoveProject}
             removeProjectStatus={removeProjectStatus}

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -505,6 +505,10 @@ function ProjectRowTrailingActions({
   removeProjectStatus: "idle" | "pending" | "success";
 }) {
   const actionsVisible = isHovered || platformIsNative || isMobileBreakpoint;
+  const projectServerId =
+    project.hosts.find((host) => host.iconWorkingDir === project.iconWorkingDir)?.serverId ??
+    project.hosts[0]?.serverId;
+
   return (
     <View style={styles.projectTrailingActions}>
       {worktreeTarget ? (
@@ -524,7 +528,7 @@ function ProjectRowTrailingActions({
           <ProjectKebabMenu
             projectKey={project.projectKey}
             projectPath={project.iconWorkingDir}
-            serverId={project.hosts[0]?.serverId}
+            serverId={projectServerId}
             onRemoveProject={onRemoveProject}
             removeProjectStatus={removeProjectStatus}
           />

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -524,6 +524,7 @@ function ProjectRowTrailingActions({
           <ProjectKebabMenu
             projectKey={project.projectKey}
             projectPath={project.iconWorkingDir}
+            serverId={project.hosts[0]?.serverId}
             onRemoveProject={onRemoveProject}
             removeProjectStatus={removeProjectStatus}
           />
@@ -551,11 +552,13 @@ function renderKebabTriggerIcon({ hovered }: { hovered?: boolean }) {
 function ProjectKebabMenu({
   projectKey,
   projectPath,
+  serverId,
   onRemoveProject,
   removeProjectStatus,
 }: {
   projectKey: string;
   projectPath: string;
+  serverId?: string | null;
   onRemoveProject: () => void;
   removeProjectStatus: "idle" | "pending" | "success";
 }) {
@@ -612,6 +615,7 @@ function ProjectKebabMenu({
         ) : null}
         <OpenInFileManagerMenuItem
           path={projectPath}
+          serverId={serverId}
           testID={`sidebar-project-menu-open-folder-${projectKey}`}
         />
         <DropdownMenuItem
@@ -693,6 +697,7 @@ function WorkspaceRowRightGroup({
             {onArchive ? (
               <SidebarWorkspaceMenu
                 workspaceKey={workspace.workspaceKey}
+                serverId={workspace.serverId}
                 onCopyPath={onCopyPath}
                 onCopyBranchName={onCopyBranchName}
                 onRename={onRename}

--- a/packages/app/src/components/sidebar/sidebar-project-host-selection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-project-host-selection.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { resolveProjectFileManagerPlacement } from "./sidebar-project-host-selection";
+
+describe("resolveProjectFileManagerPlacement", () => {
+  it("selects local placement when remote host is first and local host is second with identical path", () => {
+    const project = {
+      iconWorkingDir: "/home/user/app",
+      hosts: [
+        { serverId: "remote-daemon-1", iconWorkingDir: "/home/user/app" },
+        { serverId: "local-daemon-1", iconWorkingDir: "/home/user/app" },
+      ],
+    };
+
+    const placement = resolveProjectFileManagerPlacement(project, "local-daemon-1");
+
+    expect(placement).toEqual({
+      projectPath: "/home/user/app",
+      projectServerId: "local-daemon-1",
+    });
+  });
+
+  it("selects local placement when local host is first and remote host is second", () => {
+    const project = {
+      iconWorkingDir: "/Users/local/app",
+      hosts: [
+        { serverId: "local-daemon-1", iconWorkingDir: "/Users/local/app" },
+        { serverId: "remote-daemon-1", iconWorkingDir: "/home/user/app" },
+      ],
+    };
+
+    const placement = resolveProjectFileManagerPlacement(project, "local-daemon-1");
+
+    expect(placement).toEqual({
+      projectPath: "/Users/local/app",
+      projectServerId: "local-daemon-1",
+    });
+  });
+
+  it("uses local placement path when local and remote hosts have different paths", () => {
+    const project = {
+      iconWorkingDir: "/home/user/remote-app",
+      hosts: [
+        { serverId: "remote-daemon-1", iconWorkingDir: "/home/user/remote-app" },
+        { serverId: "local-daemon-1", iconWorkingDir: "C:\\Users\\local\\app" },
+      ],
+    };
+
+    const placement = resolveProjectFileManagerPlacement(project, "local-daemon-1");
+
+    expect(placement).toEqual({
+      projectPath: "C:\\Users\\local\\app",
+      projectServerId: "local-daemon-1",
+    });
+  });
+
+  it("falls back to project.iconWorkingDir and remote serverId when project is only on remote host", () => {
+    const project = {
+      iconWorkingDir: "/home/user/remote-only",
+      hosts: [{ serverId: "remote-daemon-1", iconWorkingDir: "/home/user/remote-only" }],
+    };
+
+    const placement = resolveProjectFileManagerPlacement(project, "local-daemon-1");
+
+    expect(placement).toEqual({
+      projectPath: "/home/user/remote-only",
+      projectServerId: "remote-daemon-1",
+    });
+  });
+
+  it("falls back to project.iconWorkingDir when local daemon serverId is null", () => {
+    const project = {
+      iconWorkingDir: "/some/path",
+      hosts: [{ serverId: "some-daemon", iconWorkingDir: "/some/path" }],
+    };
+
+    const placement = resolveProjectFileManagerPlacement(project, null);
+
+    expect(placement).toEqual({
+      projectPath: "/some/path",
+      projectServerId: "some-daemon",
+    });
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-project-host-selection.ts
+++ b/packages/app/src/components/sidebar/sidebar-project-host-selection.ts
@@ -1,0 +1,28 @@
+export interface ProjectHostPlacementLike {
+  serverId: string;
+  iconWorkingDir: string;
+}
+
+export interface SidebarProjectEntryLike {
+  iconWorkingDir: string;
+  hosts: ProjectHostPlacementLike[];
+}
+
+export interface ProjectFileManagerPlacement {
+  projectPath: string;
+  projectServerId?: string | null;
+}
+
+export function resolveProjectFileManagerPlacement(
+  project: SidebarProjectEntryLike,
+  localServerId: string | null,
+): ProjectFileManagerPlacement {
+  const localPlacement = localServerId
+    ? project.hosts.find((host) => host.serverId === localServerId)
+    : undefined;
+
+  return {
+    projectPath: localPlacement ? localPlacement.iconWorkingDir : project.iconWorkingDir,
+    projectServerId: localPlacement ? localPlacement.serverId : project.hosts[0]?.serverId,
+  };
+}

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.test.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.test.tsx
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  */
 import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.hoisted(() => {
   Object.defineProperty(window, "matchMedia", {
@@ -90,6 +91,39 @@ vi.mock("lucide-react-native", () => {
 vi.mock("@/constants/platform", () => ({
   isNative: false,
   isWeb: true,
+  getIsElectron: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/desktop/daemon/desktop-daemon", () => ({
+  getDesktopDaemonStatus: vi.fn().mockResolvedValue({
+    serverId: "local-server",
+    status: "running",
+    listen: "127.0.0.1:6768",
+    hostname: "localhost",
+    pid: 1234,
+    home: "/home/user",
+    version: "0.2.3",
+    desktopManaged: true,
+    error: null,
+  }),
+  shouldUseDesktopDaemon: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/desktop/host", () => ({
+  getDesktopHost: vi.fn().mockReturnValue({
+    editor: {
+      listTargets: vi.fn().mockResolvedValue([
+        {
+          id: "explorer",
+          label: "Explorer",
+          kind: "file-manager",
+          icon: { kind: "symbol", name: "folder" },
+        },
+      ]),
+      openTarget: vi.fn(),
+    },
+  }),
+  isElectronRuntime: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
@@ -132,6 +166,7 @@ const mockT = vi.fn((key: string) => {
     "sidebar.workspace.actions.archiving": "Archiving",
     "sidebar.workspace.actions.unpin": "Unpin",
     "sidebar.workspace.actions.pin": "Pin",
+    "sidebar.project.actions.openFolder": "Open in file manager",
   };
   return map[key] ?? key;
 });
@@ -140,35 +175,30 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: mockT }),
 }));
 
-vi.mock("@/constants/platform", () => ({
-  isNative: false,
-  isWeb: true,
-  getIsElectron: vi.fn().mockReturnValue(true),
-}));
-
-vi.mock("@/hooks/use-is-local-daemon", () => ({
-  useIsLocalDaemon: vi.fn(),
-}));
-
-vi.mock("@/workspace/desktop-open-targets", () => ({
-  useDesktopOpenTargets: vi.fn(),
-  openDesktopTarget: vi.fn(),
-}));
-
 vi.mock("@/contexts/toast-context", () => ({
   useToast: () => ({ error: vi.fn() }),
 }));
 
 import { getIsElectron } from "@/constants/platform";
-import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
-import { useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
-describe("SidebarWorkspaceMenu", () => {
+describe("SidebarWorkspaceMenu (integration coverage)", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+  });
+
   const baseProps = {
     workspaceKey: "test-workspace",
     onArchive: vi.fn(),
@@ -183,15 +213,16 @@ describe("SidebarWorkspaceMenu", () => {
     },
   ];
 
-  it("renders 'Open in file manager' when workspace is local", () => {
-    vi.mocked(getIsElectron).mockReturnValue(true);
-    vi.mocked(useIsLocalDaemon).mockReturnValue(true);
-    vi.mocked(useDesktopOpenTargets).mockReturnValue({
-      targets: fileManagerTargets,
-      isAvailable: true,
-    });
+  function renderWithProviders(ui: React.ReactElement) {
+    return render(React.createElement(QueryClientProvider, { client: queryClient }, ui));
+  }
 
-    const { queryByTestId } = render(
+  it("renders 'Open in file manager' through unmocked hooks when workspace matches local daemon serverId", () => {
+    vi.mocked(getIsElectron).mockReturnValue(true);
+    queryClient.setQueryData(["desktop-daemon-server-id"], { serverId: "local-server" });
+    queryClient.setQueryData(["desktop-open-targets"], fileManagerTargets);
+
+    const { queryByTestId } = renderWithProviders(
       <SidebarWorkspaceMenu
         {...baseProps}
         serverId="local-server"
@@ -202,15 +233,12 @@ describe("SidebarWorkspaceMenu", () => {
     expect(queryByTestId("sidebar-workspace-menu-open-folder-test-workspace")).not.toBeNull();
   });
 
-  it("hides 'Open in file manager' when workspace is on a remote host", () => {
+  it("hides 'Open in file manager' through unmocked locality and target discovery hooks when workspace is on a remote host", () => {
     vi.mocked(getIsElectron).mockReturnValue(true);
-    vi.mocked(useIsLocalDaemon).mockReturnValue(false);
-    vi.mocked(useDesktopOpenTargets).mockReturnValue({
-      targets: [],
-      isAvailable: false,
-    });
+    queryClient.setQueryData(["desktop-daemon-server-id"], { serverId: "local-server" });
+    queryClient.setQueryData(["desktop-open-targets"], fileManagerTargets);
 
-    const { queryByTestId } = render(
+    const { queryByTestId } = renderWithProviders(
       <SidebarWorkspaceMenu
         {...baseProps}
         serverId="remote-server"
@@ -221,17 +249,18 @@ describe("SidebarWorkspaceMenu", () => {
     expect(queryByTestId("sidebar-workspace-menu-open-folder-test-workspace")).toBeNull();
   });
 
-  it("passes serverId to useIsLocalDaemon correctly", () => {
+  it("evaluates locality boundary dynamically when serverId matches local daemon", () => {
     vi.mocked(getIsElectron).mockReturnValue(true);
+    queryClient.setQueryData(["desktop-daemon-server-id"], { serverId: "daemon-xyz" });
+    queryClient.setQueryData(["desktop-open-targets"], fileManagerTargets);
 
-    render(
+    const { queryByTestId: queryLocal } = renderWithProviders(
       <SidebarWorkspaceMenu
         {...baseProps}
-        serverId="server-abc"
+        serverId="daemon-xyz"
         openInFileManagerPath="/some/path"
       />,
     );
-
-    expect(useIsLocalDaemon).toHaveBeenCalledWith("server-abc");
+    expect(queryLocal("sidebar-workspace-menu-open-folder-test-workspace")).not.toBeNull();
   });
 });

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.test.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+});
+
+import React from "react";
+import { SidebarWorkspaceMenu } from "./sidebar-workspace-menu";
+
+const { theme } = vi.hoisted(() => ({
+  theme: {
+    spacing: { 1: 4, 2: 8, 3: 12 },
+    borderWidth: { 1: 1 },
+    borderRadius: { md: 6 },
+    fontSize: { xs: 11, sm: 13, base: 15 },
+    fontWeight: { normal: "400" },
+    iconSize: { sm: 14 },
+    shadow: { md: {} },
+    colors: {
+      foreground: "#fff",
+      foregroundMuted: "#aaa",
+      surface0: "#000",
+      surface1: "#111",
+      surface2: "#222",
+      surface3: "#333",
+      border: "#444",
+      borderAccent: "#555",
+      palette: {
+        green: { 500: "#22c55e" },
+        amber: { 500: "#f59e0b" },
+        red: { 500: "#ef4444" },
+        blue: { 500: "#3b82f6" },
+      },
+    },
+  },
+}));
+
+vi.mock("react-native-unistyles", () => ({
+  useUnistyles: () => ({ theme }),
+  StyleSheet: {
+    create: (factory: unknown) => (typeof factory === "function" ? factory(theme) : factory),
+  },
+  withUnistyles:
+    (Component: React.ComponentType<Record<string, unknown>>) =>
+    ({
+      uniProps,
+      ...rest
+    }: {
+      uniProps?: (theme: unknown) => Record<string, unknown>;
+    } & Record<string, unknown>) => {
+      const themed = uniProps ? uniProps(theme) : {};
+      return React.createElement(Component, { ...rest, ...themed });
+    },
+}));
+
+vi.mock("lucide-react-native", () => {
+  const icon = (name: string) => {
+    const Icon = () => React.createElement("span", { "data-icon": name });
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    Archive: icon("Archive"),
+    CircleCheck: icon("CircleCheck"),
+    Copy: icon("Copy"),
+    MoreVertical: icon("MoreVertical"),
+    Pencil: icon("Pencil"),
+    Pin: icon("Pin"),
+    PinOff: icon("PinOff"),
+  };
+});
+
+vi.mock("@/constants/platform", () => ({
+  isNative: false,
+  isWeb: true,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuTrigger: ({
+    children,
+  }: {
+    children?: React.ReactNode | ((state: { hovered: boolean }) => React.ReactNode);
+  }) => {
+    if (typeof children === "function") {
+      return React.createElement(React.Fragment, null, children({ hovered: false }));
+    }
+    return React.createElement(React.Fragment, null, children);
+  },
+  DropdownMenuItem: ({
+    children,
+    testID,
+    leading,
+  }: {
+    children?: React.ReactNode;
+    testID?: string;
+    leading?: React.ReactNode;
+  }) => React.createElement("button", { type: "button", "data-testid": testID }, leading, children),
+}));
+
+vi.mock("@/components/ui/shortcut", () => ({
+  Shortcut: () => null,
+}));
+
+const mockT = vi.fn((key: string) => {
+  const map: Record<string, string> = {
+    "sidebar.workspace.actions.menu": "Workspace menu",
+    "sidebar.workspace.actions.copyPath": "Copy path",
+    "sidebar.workspace.actions.copyBranchName": "Copy branch name",
+    "sidebar.workspace.actions.rename": "Rename",
+    "sidebar.workspace.actions.archive": "Archive",
+    "sidebar.workspace.actions.archiving": "Archiving",
+    "sidebar.workspace.actions.unpin": "Unpin",
+    "sidebar.workspace.actions.pin": "Pin",
+  };
+  return map[key] ?? key;
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: mockT }),
+}));
+
+// Mock OpenInFileManagerMenuItem so we can assert on its props.
+const OpenInFileManagerMenuItemSpy = vi.fn((_props: Record<string, unknown>) =>
+  React.createElement(
+    "span",
+    { "data-testid": "open-in-file-manager-item" },
+    "Open in file manager",
+  ),
+);
+
+vi.mock("@/workspace/open-in-file-manager/menu-item", () => ({
+  OpenInFileManagerMenuItem: (props: Record<string, unknown>) =>
+    OpenInFileManagerMenuItemSpy(props),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SidebarWorkspaceMenu", () => {
+  const baseProps = {
+    workspaceKey: "test-workspace",
+    onArchive: vi.fn(),
+  };
+
+  it("forwards serverId to OpenInFileManagerMenuItem", () => {
+    render(
+      <SidebarWorkspaceMenu
+        {...baseProps}
+        serverId="server-abc"
+        openInFileManagerPath="/some/path"
+      />,
+    );
+
+    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "server-abc",
+        path: "/some/path",
+      }),
+    );
+  });
+
+  it("forwards null serverId to OpenInFileManagerMenuItem", () => {
+    render(
+      <SidebarWorkspaceMenu {...baseProps} serverId={null} openInFileManagerPath="/some/path" />,
+    );
+
+    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ serverId: null }),
+    );
+  });
+
+  it("forwards undefined serverId when not provided", () => {
+    render(<SidebarWorkspaceMenu {...baseProps} openInFileManagerPath="/some/path" />);
+
+    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ serverId: undefined }),
+    );
+  });
+
+  it("forwards path as undefined when openInFileManagerPath is not set", () => {
+    render(<SidebarWorkspaceMenu {...baseProps} serverId="server-abc" />);
+
+    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "server-abc",
+        path: undefined,
+      }),
+    );
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.test.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.test.tsx
@@ -79,6 +79,7 @@ vi.mock("lucide-react-native", () => {
     Archive: icon("Archive"),
     CircleCheck: icon("CircleCheck"),
     Copy: icon("Copy"),
+    FolderOpen: icon("FolderOpen"),
     MoreVertical: icon("MoreVertical"),
     Pencil: icon("Pencil"),
     Pin: icon("Pin"),
@@ -139,19 +140,28 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: mockT }),
 }));
 
-// Mock OpenInFileManagerMenuItem so we can assert on its props.
-const OpenInFileManagerMenuItemSpy = vi.fn((_props: Record<string, unknown>) =>
-  React.createElement(
-    "span",
-    { "data-testid": "open-in-file-manager-item" },
-    "Open in file manager",
-  ),
-);
-
-vi.mock("@/workspace/open-in-file-manager/menu-item", () => ({
-  OpenInFileManagerMenuItem: (props: Record<string, unknown>) =>
-    OpenInFileManagerMenuItemSpy(props),
+vi.mock("@/constants/platform", () => ({
+  isNative: false,
+  isWeb: true,
+  getIsElectron: vi.fn().mockReturnValue(true),
 }));
+
+vi.mock("@/hooks/use-is-local-daemon", () => ({
+  useIsLocalDaemon: vi.fn(),
+}));
+
+vi.mock("@/workspace/desktop-open-targets", () => ({
+  useDesktopOpenTargets: vi.fn(),
+  openDesktopTarget: vi.fn(),
+}));
+
+vi.mock("@/contexts/toast-context", () => ({
+  useToast: () => ({ error: vi.fn() }),
+}));
+
+import { getIsElectron } from "@/constants/platform";
+import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
+import { useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 
 afterEach(() => {
   cleanup();
@@ -164,7 +174,56 @@ describe("SidebarWorkspaceMenu", () => {
     onArchive: vi.fn(),
   };
 
-  it("forwards serverId to OpenInFileManagerMenuItem", () => {
+  const fileManagerTargets = [
+    {
+      id: "explorer",
+      label: "Explorer",
+      kind: "file-manager" as const,
+      icon: { kind: "symbol" as const, name: "folder" as const },
+    },
+  ];
+
+  it("renders 'Open in file manager' when workspace is local", () => {
+    vi.mocked(getIsElectron).mockReturnValue(true);
+    vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+    vi.mocked(useDesktopOpenTargets).mockReturnValue({
+      targets: fileManagerTargets,
+      isAvailable: true,
+    });
+
+    const { queryByTestId } = render(
+      <SidebarWorkspaceMenu
+        {...baseProps}
+        serverId="local-server"
+        openInFileManagerPath="/some/local/path"
+      />,
+    );
+
+    expect(queryByTestId("sidebar-workspace-menu-open-folder-test-workspace")).not.toBeNull();
+  });
+
+  it("hides 'Open in file manager' when workspace is on a remote host", () => {
+    vi.mocked(getIsElectron).mockReturnValue(true);
+    vi.mocked(useIsLocalDaemon).mockReturnValue(false);
+    vi.mocked(useDesktopOpenTargets).mockReturnValue({
+      targets: [],
+      isAvailable: false,
+    });
+
+    const { queryByTestId } = render(
+      <SidebarWorkspaceMenu
+        {...baseProps}
+        serverId="remote-server"
+        openInFileManagerPath="/home/user/project"
+      />,
+    );
+
+    expect(queryByTestId("sidebar-workspace-menu-open-folder-test-workspace")).toBeNull();
+  });
+
+  it("passes serverId to useIsLocalDaemon correctly", () => {
+    vi.mocked(getIsElectron).mockReturnValue(true);
+
     render(
       <SidebarWorkspaceMenu
         {...baseProps}
@@ -173,40 +232,6 @@ describe("SidebarWorkspaceMenu", () => {
       />,
     );
 
-    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        serverId: "server-abc",
-        path: "/some/path",
-      }),
-    );
-  });
-
-  it("forwards null serverId to OpenInFileManagerMenuItem", () => {
-    render(
-      <SidebarWorkspaceMenu {...baseProps} serverId={null} openInFileManagerPath="/some/path" />,
-    );
-
-    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ serverId: null }),
-    );
-  });
-
-  it("forwards undefined serverId when not provided", () => {
-    render(<SidebarWorkspaceMenu {...baseProps} openInFileManagerPath="/some/path" />);
-
-    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ serverId: undefined }),
-    );
-  });
-
-  it("forwards path as undefined when openInFileManagerPath is not set", () => {
-    render(<SidebarWorkspaceMenu {...baseProps} serverId="server-abc" />);
-
-    expect(OpenInFileManagerMenuItemSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        serverId: "server-abc",
-        path: undefined,
-      }),
-    );
+    expect(useIsLocalDaemon).toHaveBeenCalledWith("server-abc");
   });
 });

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { type PressableStateCallbackType } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
@@ -48,6 +48,7 @@ function renderTriggerIcon({ hovered }: { hovered?: boolean }) {
 
 interface SidebarWorkspaceMenuProps {
   workspaceKey: string;
+  serverId?: string | null;
   onCopyPath?: () => void;
   onCopyBranchName?: () => void;
   onRename?: () => void;
@@ -64,6 +65,7 @@ interface SidebarWorkspaceMenuProps {
 
 export function SidebarWorkspaceMenu({
   workspaceKey,
+  serverId,
   onCopyPath,
   onCopyBranchName,
   onRename,
@@ -142,6 +144,7 @@ export function SidebarWorkspaceMenu({
         ) : null}
         <OpenInFileManagerMenuItem
           path={openInFileManagerPath}
+          serverId={serverId}
           testID={`sidebar-workspace-menu-open-folder-${workspaceKey}`}
         />
         <DropdownMenuItem

--- a/packages/app/src/workspace/desktop-open-targets.test.ts
+++ b/packages/app/src/workspace/desktop-open-targets.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useDesktopOpenTargets } from "./desktop-open-targets";
+
+vi.mock("@/desktop/host", () => ({
+  getDesktopHost: vi.fn().mockReturnValue({
+    editor: {
+      listTargets: vi.fn().mockResolvedValue([
+        {
+          id: "explorer",
+          label: "Explorer",
+          kind: "file-manager",
+          icon: { kind: "symbol", name: "folder" },
+        },
+      ]),
+      openTarget: vi.fn(),
+    },
+  }),
+}));
+
+describe("useDesktopOpenTargets hook - stale cache behavior", () => {
+  it("does not leak stale cached targets when isLocalExecution is false", () => {
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(
+      ["desktop-open-targets"],
+      [
+        {
+          id: "explorer",
+          label: "Explorer",
+          kind: "file-manager",
+          icon: { kind: "symbol", name: "folder" },
+        },
+      ],
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useDesktopOpenTargets({ isLocalExecution: false }), {
+      wrapper,
+    });
+
+    expect(result.current.targets).toEqual([]);
+    expect(result.current.isAvailable).toBe(false);
+  });
+
+  it("returns targets when isLocalExecution is true", () => {
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(
+      ["desktop-open-targets"],
+      [
+        {
+          id: "explorer",
+          label: "Explorer",
+          kind: "file-manager",
+          icon: { kind: "symbol", name: "folder" },
+        },
+      ],
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useDesktopOpenTargets({ isLocalExecution: true }), {
+      wrapper,
+    });
+
+    expect(result.current.targets).toEqual([
+      {
+        id: "explorer",
+        label: "Explorer",
+        kind: "file-manager",
+        icon: { kind: "symbol", name: "folder" },
+      },
+    ]);
+    expect(result.current.isAvailable).toBe(true);
+  });
+});

--- a/packages/app/src/workspace/desktop-open-targets.ts
+++ b/packages/app/src/workspace/desktop-open-targets.ts
@@ -69,7 +69,7 @@ export function useDesktopOpenTargets(input: { isLocalExecution: boolean }) {
   });
 
   return {
-    targets: query.data ?? [],
+    targets: canListTargets ? (query.data ?? []) : [],
     isAvailable: canListTargets,
   };
 }

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx
@@ -197,6 +197,24 @@ describe("OpenInFileManagerMenuItem", () => {
   });
 
   describe("serverId prop - remote host detection", () => {
+    it("does not render for a remote daemon even when stale targets exist", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(false);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: false,
+      });
+
+      const { container } = render(
+        <OpenInFileManagerMenuItem
+          path="/home/user/project"
+          serverId="remote-host-123"
+          testID="test-menu"
+        />,
+      );
+      expect(container.innerHTML).toBe("");
+    });
+
     it("renders null when serverId is provided and daemon is remote", () => {
       vi.mocked(getIsElectron).mockReturnValue(true);
       vi.mocked(useIsLocalDaemon).mockReturnValue(false);

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx
@@ -1,0 +1,357 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+});
+
+import React from "react";
+import { OpenInFileManagerMenuItem } from "./menu-item";
+
+const { theme } = vi.hoisted(() => ({
+  theme: {
+    spacing: { 1: 4, 2: 8, 3: 12 },
+    borderWidth: { 1: 1 },
+    borderRadius: { md: 6 },
+    fontSize: { xs: 11, sm: 13, base: 15 },
+    fontWeight: { normal: "400" },
+    iconSize: { sm: 14 },
+    shadow: { md: {} },
+    colors: {
+      foreground: "#fff",
+      foregroundMuted: "#aaa",
+      surface0: "#000",
+      surface1: "#111",
+      surface2: "#222",
+      surface3: "#333",
+      border: "#444",
+      borderAccent: "#555",
+      palette: {
+        green: { 500: "#22c55e" },
+        amber: { 500: "#f59e0b" },
+        red: { 500: "#ef4444" },
+        blue: { 500: "#3b82f6" },
+      },
+    },
+  },
+}));
+
+vi.mock("react-native-unistyles", () => ({
+  useUnistyles: () => ({ theme }),
+  StyleSheet: {
+    create: (factory: unknown) => (typeof factory === "function" ? factory(theme) : factory),
+  },
+  withUnistyles:
+    (Component: React.ComponentType<Record<string, unknown>>) =>
+    ({
+      uniProps,
+      ...rest
+    }: {
+      uniProps?: (theme: unknown) => Record<string, unknown>;
+    } & Record<string, unknown>) => {
+      const themed = uniProps ? uniProps(theme) : {};
+      return React.createElement(Component, { ...rest, ...themed });
+    },
+}));
+
+vi.mock("lucide-react-native", () => ({
+  FolderOpen: () => React.createElement("span", { "data-icon": "FolderOpen" }),
+}));
+
+vi.mock("@/constants/platform", () => ({
+  getIsElectron: vi.fn(),
+  isWeb: true,
+  isNative: false,
+  isDev: false,
+  getIsElectronMac: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/hooks/use-is-local-daemon", () => ({
+  useIsLocalDaemon: vi.fn(),
+}));
+
+vi.mock("@/workspace/desktop-open-targets", () => ({
+  useDesktopOpenTargets: vi.fn(),
+  openDesktopTarget: vi.fn(),
+}));
+
+const mockT = vi.fn((key: string) => {
+  const map: Record<string, string> = {
+    "sidebar.project.actions.openFolder": "Open in file manager",
+    "sidebar.project.actions.openFolderFailed": "Couldn't open folder",
+  };
+  return map[key] ?? key;
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: mockT }),
+}));
+
+vi.mock("@/contexts/toast-context", () => ({
+  useToast: () => ({ error: vi.fn() }),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuItem: ({
+    children,
+    testID,
+    leading,
+  }: {
+    children?: React.ReactNode;
+    testID?: string;
+    leading?: React.ReactNode;
+  }) => React.createElement("button", { type: "button", "data-testid": testID }, leading, children),
+}));
+
+import { getIsElectron } from "@/constants/platform";
+import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
+import { useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function createFileManagerTargets() {
+  return [
+    {
+      id: "explorer",
+      label: "Explorer",
+      kind: "file-manager" as const,
+      icon: { kind: "symbol" as const, name: "folder" as const },
+    },
+  ];
+}
+
+describe("OpenInFileManagerMenuItem", () => {
+  describe("visibility", () => {
+    it("renders null when not in Electron", () => {
+      vi.mocked(getIsElectron).mockReturnValue(false);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { container } = render(
+        <OpenInFileManagerMenuItem path="/home/user/project" testID="test-menu" />,
+      );
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("renders null when path is empty", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { container } = render(<OpenInFileManagerMenuItem path="" testID="test-menu" />);
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("renders null when path is only whitespace", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { container } = render(<OpenInFileManagerMenuItem path="   " testID="test-menu" />);
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("renders null when no file-manager targets are available", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({ targets: [], isAvailable: false });
+
+      const { container } = render(
+        <OpenInFileManagerMenuItem path="/home/user/project" testID="test-menu" />,
+      );
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  describe("serverId prop - remote host detection", () => {
+    it("renders null when serverId is provided and daemon is remote", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(false);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({ targets: [], isAvailable: false });
+
+      const { container } = render(
+        <OpenInFileManagerMenuItem
+          path="/home/user/project"
+          serverId="remote-host-123"
+          testID="test-menu"
+        />,
+      );
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("passes isLocalExecution=false to useDesktopOpenTargets when serverId is remote", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(false);
+
+      render(
+        <OpenInFileManagerMenuItem
+          path="/home/user/project"
+          serverId="remote-host-123"
+          testID="test-menu"
+        />,
+      );
+
+      expect(useDesktopOpenTargets).toHaveBeenCalledWith({ isLocalExecution: false });
+    });
+
+    it("renders menu item when serverId is provided and daemon is local", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { getByText } = render(
+        <OpenInFileManagerMenuItem
+          path="/home/user/project"
+          serverId="local-host-123"
+          testID="test-menu"
+        />,
+      );
+      expect(getByText("Open in file manager")).toBeDefined();
+    });
+
+    it("passes isLocalExecution=true to useDesktopOpenTargets when serverId is local", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+
+      render(
+        <OpenInFileManagerMenuItem
+          path="/home/user/project"
+          serverId="local-host-123"
+          testID="test-menu"
+        />,
+      );
+
+      expect(useDesktopOpenTargets).toHaveBeenCalledWith({ isLocalExecution: true });
+    });
+
+    it("calls useIsLocalDaemon with the provided serverId", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+
+      render(
+        <OpenInFileManagerMenuItem
+          path="/home/user/project"
+          serverId="some-host-456"
+          testID="test-menu"
+        />,
+      );
+
+      expect(useIsLocalDaemon).toHaveBeenCalledWith("some-host-456");
+    });
+
+    it("trims serverId before passing to useIsLocalDaemon", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+
+      render(
+        <OpenInFileManagerMenuItem
+          path="/home/user/project"
+          serverId="  spaced-host  "
+          testID="test-menu"
+        />,
+      );
+
+      expect(useIsLocalDaemon).toHaveBeenCalledWith("spaced-host");
+    });
+  });
+
+  describe("backward compatibility - no serverId prop", () => {
+    it("renders menu item when serverId is not provided and all other conditions are met", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { getByText } = render(
+        <OpenInFileManagerMenuItem path="/home/user/project" testID="test-menu" />,
+      );
+      expect(getByText("Open in file manager")).toBeDefined();
+    });
+
+    it("passes isLocalExecution=true to useDesktopOpenTargets when serverId is absent", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+
+      render(<OpenInFileManagerMenuItem path="/home/user/project" testID="test-menu" />);
+
+      expect(useDesktopOpenTargets).toHaveBeenCalledWith({ isLocalExecution: true });
+    });
+
+    it("renders menu item when serverId is null and all other conditions are met", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { getByText } = render(
+        <OpenInFileManagerMenuItem path="/home/user/project" serverId={null} testID="test-menu" />,
+      );
+      expect(getByText("Open in file manager")).toBeDefined();
+    });
+  });
+
+  describe("rendering", () => {
+    it("renders the menu item with correct testID", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { getByTestId } = render(
+        <OpenInFileManagerMenuItem path="/home/user/project" testID="custom-test-id" />,
+      );
+      expect(getByTestId("custom-test-id")).toBeDefined();
+    });
+
+    it("renders the translated 'Open in file manager' label", () => {
+      vi.mocked(getIsElectron).mockReturnValue(true);
+      vi.mocked(useIsLocalDaemon).mockReturnValue(true);
+      vi.mocked(useDesktopOpenTargets).mockReturnValue({
+        targets: createFileManagerTargets(),
+        isAvailable: true,
+      });
+
+      const { getByText } = render(
+        <OpenInFileManagerMenuItem path="/home/user/project" testID="test-menu" />,
+      );
+      expect(getByText("Open in file manager")).toBeDefined();
+    });
+  });
+});

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
@@ -1,16 +1,18 @@
-import { useCallback } from "react";
+import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { FolderOpen } from "lucide-react-native";
 import { withUnistyles } from "react-native-unistyles";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { getIsElectron } from "@/constants/platform";
 import { useToast } from "@/contexts/toast-context";
+import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import type { Theme } from "@/styles/theme";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
 
 interface OpenInFileManagerMenuItemProps {
   path?: string | null;
   testID: string;
+  serverId?: string | null;
 }
 
 const ThemedFolderOpen = withUnistyles(FolderOpen);
@@ -21,13 +23,19 @@ const foregroundMutedColorMapping = (theme: Theme) => ({
 
 const leadingIcon = <ThemedFolderOpen size={14} uniProps={foregroundMutedColorMapping} />;
 
-export function OpenInFileManagerMenuItem({ path, testID }: OpenInFileManagerMenuItemProps) {
+export function OpenInFileManagerMenuItem({
+  path,
+  testID,
+  serverId,
+}: OpenInFileManagerMenuItemProps) {
   const { t } = useTranslation();
   const toast = useToast();
   const isElectron = getIsElectron();
   const workspacePath = path?.trim() ?? "";
+  const isLocalDaemon = useIsLocalDaemon(serverId?.trim() ?? "");
+  const hasServerId = serverId != null && serverId.trim().length > 0;
   const { targets } = useDesktopOpenTargets({
-    isLocalExecution: isElectron && workspacePath.length > 0,
+    isLocalExecution: isElectron && workspacePath.length > 0 && (!hasServerId || isLocalDaemon),
   });
   const fileManagerTarget = targets.find((target) => target.kind === "file-manager");
 

--- a/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
+++ b/packages/app/src/workspace/open-in-file-manager/menu-item.tsx
@@ -34,13 +34,16 @@ export function OpenInFileManagerMenuItem({
   const workspacePath = path?.trim() ?? "";
   const isLocalDaemon = useIsLocalDaemon(serverId?.trim() ?? "");
   const hasServerId = serverId != null && serverId.trim().length > 0;
+  const canOpenLocally = isElectron && workspacePath.length > 0 && (!hasServerId || isLocalDaemon);
   const { targets } = useDesktopOpenTargets({
-    isLocalExecution: isElectron && workspacePath.length > 0 && (!hasServerId || isLocalDaemon),
+    isLocalExecution: canOpenLocally,
   });
-  const fileManagerTarget = targets.find((target) => target.kind === "file-manager");
+  const fileManagerTarget = canOpenLocally
+    ? targets.find((target) => target.kind === "file-manager")
+    : undefined;
 
   const openInFileManager = useCallback(() => {
-    if (!fileManagerTarget || workspacePath.length === 0) return;
+    if (!canOpenLocally || !fileManagerTarget || workspacePath.length === 0) return;
     void openDesktopTarget({
       editorId: fileManagerTarget.id,
       workspacePath,
@@ -48,9 +51,9 @@ export function OpenInFileManagerMenuItem({
       console.warn("[open-in-file-manager] open failed", error);
       toast.error(t("sidebar.project.actions.openFolderFailed"));
     });
-  }, [fileManagerTarget, t, toast, workspacePath]);
+  }, [canOpenLocally, fileManagerTarget, t, toast, workspacePath]);
 
-  if (!isElectron || !fileManagerTarget || workspacePath.length === 0) {
+  if (!canOpenLocally || !fileManagerTarget) {
     return null;
   }
 


### PR DESCRIPTION
### Linked issue

Closes #2509

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Hides the "Open in file manager" sidebar context menu action for projects/workspaces that belong to a remote host daemon (`isLocalDaemon === false`). 

Previously, on a desktop client connected to a remote host (e.g. Windows client to Ubuntu host), selecting this action attempted to open remote POSIX paths like `/home/user/project` in the local file manager and failed with the generic `Couldn't open folder` toast error.

### How did you verify it

- Added unit tests in `packages/app/src/workspace/open-in-file-manager/menu-item.test.tsx` verifying that `OpenInFileManagerMenuItem` renders `null` when `serverId` belongs to a remote daemon (`isLocalDaemon === false`).
- Verified all 15 unit tests in `menu-item.test.tsx` pass.
- Verified `SidebarWorkspaceMenu` forwards `serverId` correctly.
- Ran `npm run typecheck`, `npx oxlint`, and `npx oxfmt` across modified files.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] Tests added or updated where it made sense
