### PR TITLE
Show recently archived workspaces in the status sidebar

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -90,6 +90,29 @@ leave both Paseo's `archivedAt` and the provider's native archive state unchange
 the only transition back to an interactive runtime: it runs the provider's native unarchive hook
 (including Codex `thread/unarchive`) before the normal agent resume and timeline hydration flow.
 
+### The recently-archived tail
+
+Status mode renders a greyed-out **Recently archived** group after every real status group, newest
+archive first, so a mis-archive is one click from being undone. It is an undo affordance, not an
+archive browser.
+
+The rows come from `workspace.archived.list.request` (capability
+`server_info.features.archivedWorkspacesList`), **not** from the workspace directory. This split is
+deliberate and load-bearing: every consumer of the session store's workspace map — project mode, the
+workspace switcher, status counts — treats a present descriptor as live. Archived workspaces must
+never enter that map, so they live only in the `archivedWorkspaces` query
+(`packages/app/src/hooks/use-archived-workspaces.ts`) and only status mode reads it. If you ever need
+archived workspaces somewhere else, add another reader of that query; do not widen the directory.
+
+`archived` is not a status bucket. It is deliberately excluded from `STATUS_BUCKET_ORDER` and from the
+1–9 keyboard shortcut index — archived workspaces have no live status and nothing to navigate to. The
+only action on a row is unarchive, which goes through the existing
+`workspace.recovery.restore.request`, so the daemon (not the client) still decides between plain
+unarchive and recreating a Paseo-owned worktree.
+
+The daemon caps its response and drops workspaces whose owning project is archived; unarchiving one
+would surface a workspace under a project the user cannot see.
+
 Provider session connection owns every process it spawns until the session is registered with
 `AgentManager`. If initialization, persisted-session resume, or initial history hydration fails,
 `connect()` must dispose that process before rethrowing; the manager cannot clean up a session it never

--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -113,6 +113,11 @@ unarchive and recreating a Paseo-owned worktree.
 The daemon caps its response and drops workspaces whose owning project is archived; unarchiving one
 would surface a workspace under a project the user cannot see.
 
+While status mode is mounted, its archived query listens to the existing `workspace_update`
+broadcast. A live-directory removal can mean a new archive, and an upsert for a row already in the
+archived cache means that row was restored elsewhere, so either transition refreshes the tail across
+clients without polling.
+
 Provider session connection owns every process it spawns until the session is registered with
 `AgentManager`. If initialization, persisted-session resume, or initial history hydration fails,
 `connect()` must dispose that process before rethrowing; the manager cannot clean up a session it never

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -48,7 +48,7 @@ import {
 import { NestableScrollContainer } from "react-native-draggable-flatlist";
 import { DraggableList, type DraggableRenderItemInfo } from "./draggable-list";
 import type { DraggableListDragHandleProps } from "./draggable-list.types";
-import { getHostRuntimeStore, useHosts } from "@/runtime/host-runtime";
+import { getHostRuntimeStore, useHostRegistryLoaded, useHosts } from "@/runtime/host-runtime";
 import type { PinnedSidebarGroups } from "@/hooks/use-sidebar-pins";
 import {
   useSidebarWorkspacePinController,
@@ -64,11 +64,13 @@ import {
   parseHostWorkspaceRouteFromPathname,
 } from "@/utils/host-routes";
 import {
+  resolveSidebarServerIds,
   shouldShowSidebarHostLabels,
   type SidebarProjectEntry,
   type SidebarWorkspaceEntry,
   type SidebarWorkspacePlacement,
 } from "@/hooks/use-sidebar-workspaces-list";
+import { useArchivedWorkspaces } from "@/hooks/use-archived-workspaces";
 import { useSidebarOrderStore } from "@/stores/sidebar-order-store";
 import { useSidebarViewStore } from "@/stores/sidebar-view-store";
 import { useShowShortcutBadges } from "@/hooks/use-show-shortcut-badges";
@@ -1950,6 +1952,7 @@ export function SidebarWorkspaceList({
     groupMode === "status" ? (
       <SidebarStatusModeWrapper
         statusGroups={statusGroups}
+        allServerIds={serverIds}
         pinnedGroups={pinnedGroups}
         workspaceEntriesByKey={workspaceEntriesByKey}
         projectNamesByKey={projectNamesByKey}
@@ -1988,6 +1991,7 @@ export function SidebarWorkspaceList({
 
 function SidebarStatusModeWrapper({
   statusGroups,
+  allServerIds,
   pinnedGroups,
   workspaceEntriesByKey,
   projectNamesByKey,
@@ -2000,6 +2004,7 @@ function SidebarStatusModeWrapper({
   listHeaderComponent,
 }: {
   statusGroups: StatusGroup[];
+  allServerIds: string[];
   pinnedGroups: PinnedSidebarGroups;
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
   projectNamesByKey: Map<string, string>;
@@ -2012,10 +2017,20 @@ function SidebarStatusModeWrapper({
   listHeaderComponent?: ReactElement | null;
 }) {
   const showShortcutBadges = useShowShortcutBadges();
+  // Only status mode renders the archived tail, so the query lives here rather
+  // than in the shared sidebar model — project mode never pays for it.
+  const hostFilters = useSidebarViewStore((state) => state.hostFilters);
+  const hostRegistryLoaded = useHostRegistryLoaded();
+  const archivedServerIds = useMemo(
+    () => resolveSidebarServerIds({ allServerIds, hostFilters, hostRegistryLoaded }),
+    [allServerIds, hostFilters, hostRegistryLoaded],
+  );
+  const archivedWorkspaces = useArchivedWorkspaces({ serverIds: archivedServerIds });
 
   return (
     <SidebarStatusWorkspaceList
       groups={statusGroups}
+      archivedWorkspaces={archivedWorkspaces}
       pinnedWorkspaces={pinnedGroups.pinnedChats.flatMap((workspace) => {
         const entry = workspaceEntriesByKey.get(workspace.workspaceKey);
         return entry ? [entry] : [];

--- a/packages/app/src/components/sidebar/sidebar-archived-group.test.tsx
+++ b/packages/app/src/components/sidebar/sidebar-archived-group.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArchivedWorkspaceEntry } from "@/hooks/use-archived-workspaces";
+
+const { theme } = vi.hoisted(() => ({
+  theme: {
+    spacing: { 1: 4, 2: 8, 3: 12 },
+    iconSize: { md: 18 },
+    borderRadius: { lg: 8 },
+    fontSize: { xs: 11, sm: 13 },
+    colors: {
+      foregroundMuted: "#aaa",
+      surfaceSidebarHover: "#222",
+      surface2: "#333",
+    },
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      (
+        ({
+          "sidebar.workspace.archived.groupTitle": "Recently archived",
+          "sidebar.workspace.archived.unarchive": "Unarchive",
+          "sidebar.workspace.archived.unarchiving": "Unarchiving…",
+        }) as Record<string, string>
+      )[key] ?? key,
+  }),
+}));
+
+vi.mock("react-native-unistyles", () => ({
+  StyleSheet: {
+    create: (factory: unknown) =>
+      typeof factory === "function"
+        ? (factory as (value: typeof theme) => unknown)(theme)
+        : factory,
+  },
+  withUnistyles: (component: unknown) => component,
+}));
+
+vi.mock("lucide-react-native", () => {
+  const createIcon = (name: string) => (props: Record<string, unknown>) =>
+    React.createElement("span", { ...props, "data-icon": name });
+  return {
+    Archive: createIcon("Archive"),
+    ArchiveRestore: createIcon("ArchiveRestore"),
+    ChevronDown: createIcon("ChevronDown"),
+    ChevronRight: createIcon("ChevronRight"),
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock("@/constants/platform", () => ({
+  isNative: false,
+  isWeb: true,
+}));
+
+vi.mock("@/constants/layout", () => ({
+  useIsCompactFormFactor: () => false,
+}));
+
+vi.mock("@/contexts/toast-context", () => ({
+  useToast: () => ({ error: vi.fn() }),
+}));
+
+vi.mock("@/runtime/host-runtime", () => ({
+  getHostRuntimeStore: () => ({ getClient: () => null }),
+}));
+
+vi.mock("@/stores/sidebar-collapsed-sections-store", () => ({
+  useSidebarCollapsedSectionsStore: (
+    selector: (state: {
+      collapsedStatusGroupKeys: Set<string>;
+      toggleStatusGroupCollapsed: () => void;
+    }) => unknown,
+  ) =>
+    selector({
+      collapsedStatusGroupKeys: new Set(),
+      toggleStatusGroupCollapsed: vi.fn(),
+    }),
+}));
+
+vi.mock("@/components/sidebar/sidebar-group-toggle-row", () => ({
+  SidebarGroupToggleRow: ({
+    expanded,
+    onPress,
+    testID,
+  }: {
+    expanded: boolean;
+    onPress: () => void;
+    testID: string;
+  }) =>
+    React.createElement(
+      "button",
+      { "data-testid": testID, onClick: onPress, type: "button" },
+      expanded ? "Show less" : "Show more",
+    ),
+}));
+
+vi.stubGlobal("React", React);
+vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+import { SidebarArchivedGroup } from "./sidebar-archived-group";
+
+function archivedEntry(index: number): ArchivedWorkspaceEntry {
+  return {
+    workspaceKey: `server:workspace-${index}`,
+    serverId: "server",
+    workspaceId: `workspace-${index}`,
+    projectName: "Paseo",
+    name: `Archived ${index}`,
+    archivedAt: new Date(Date.UTC(2026, 6, index)),
+  };
+}
+
+describe("SidebarArchivedGroup", () => {
+  let root: Root | null = null;
+  let container: HTMLElement | null = null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      flushSync(() => root?.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+  });
+
+  it("renders five recent rows before Show more expands the tail", () => {
+    const entries = Array.from({ length: 7 }, (_, index) => archivedEntry(index + 1));
+    flushSync(() => {
+      root?.render(
+        <SidebarArchivedGroup
+          entries={entries}
+          hostLabelByServerId={new Map([["server", "Local"]])}
+          showHostLabels
+        />,
+      );
+    });
+
+    expect(container?.textContent).toContain("Recently archived");
+    expect(container?.textContent).toContain("Archived 5");
+    expect(container?.textContent).not.toContain("Archived 6");
+    expect(container?.textContent).toContain("Paseo · Local");
+
+    const toggle = container?.querySelector(
+      '[data-testid="sidebar-archived-show-more"]',
+    ) as HTMLButtonElement | null;
+    expect(toggle?.textContent).toBe("Show more");
+
+    flushSync(() => toggle?.click());
+
+    expect(container?.textContent).toContain("Archived 6");
+    expect(container?.textContent).toContain("Archived 7");
+    expect(toggle?.textContent).toBe("Show less");
+  });
+
+  it("renders nothing when there are no archived workspaces", () => {
+    flushSync(() => {
+      root?.render(
+        <SidebarArchivedGroup
+          entries={[]}
+          hostLabelByServerId={new Map()}
+          showHostLabels={false}
+        />,
+      );
+    });
+
+    expect(container?.textContent).toBe("");
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-archived-group.tsx
+++ b/packages/app/src/components/sidebar/sidebar-archived-group.tsx
@@ -1,0 +1,346 @@
+import { memo, useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { View, Text, Pressable, type PressableStateCallbackType } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Archive, ArchiveRestore, ChevronDown, ChevronRight } from "lucide-react-native";
+import { isNative as platformIsNative, isWeb as platformIsWeb } from "@/constants/platform";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import { useToast } from "@/contexts/toast-context";
+import {
+  archivedWorkspacesQueryKey,
+  type ArchivedWorkspaceEntry,
+} from "@/hooks/use-archived-workspaces";
+import { ARCHIVED_GROUP_KEY } from "@/hooks/sidebar-status-view-model";
+import { getHostRuntimeStore } from "@/runtime/host-runtime";
+import { useSidebarCollapsedSectionsStore } from "@/stores/sidebar-collapsed-sections-store";
+import { SidebarGroupToggleRow } from "@/components/sidebar/sidebar-group-toggle-row";
+import { useLimitedSidebarGroup } from "@/components/sidebar/use-limited-sidebar-group";
+import type { Theme } from "@/styles/theme";
+
+const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+
+// Deliberately shorter than the shared sidebar group limit. This is a tail you
+// glance at right after a mis-archive, not a list you browse; show-more covers
+// the rest.
+const INITIAL_VISIBLE_ARCHIVED_ROWS = 5;
+
+const ThemedArchive = withUnistyles(Archive);
+const ThemedArchiveRestore = withUnistyles(ArchiveRestore);
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedChevronRight = withUnistyles(ChevronRight);
+
+/**
+ * The greyed-out tail of status mode: the last few workspaces you archived,
+ * newest first, so a mis-archive is one click away from being undone. These rows
+ * are not navigable — an archived workspace has no live surface to open — so the
+ * only action is unarchive.
+ */
+export function SidebarArchivedGroup({
+  entries,
+  hostLabelByServerId,
+  showHostLabels,
+}: {
+  entries: ArchivedWorkspaceEntry[];
+  hostLabelByServerId: ReadonlyMap<string, string>;
+  showHostLabels: boolean;
+}) {
+  const collapsed = useSidebarCollapsedSectionsStore((state) =>
+    state.collapsedStatusGroupKeys.has(ARCHIVED_GROUP_KEY),
+  );
+  const {
+    visibleItems: visibleEntries,
+    expanded,
+    canToggle,
+    toggleExpanded,
+  } = useLimitedSidebarGroup(entries, INITIAL_VISIBLE_ARCHIVED_ROWS);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.groupBlock}>
+      <ArchivedGroupHeader collapsed={collapsed} />
+      {!collapsed ? (
+        <View style={styles.rowListContainer} testID="sidebar-archived-group-rows">
+          {visibleEntries.map((entry) => (
+            <ArchivedWorkspaceRow
+              key={entry.workspaceKey}
+              entry={entry}
+              subtitle={buildArchivedRowSubtitle({
+                projectName: entry.projectName,
+                hostLabel: showHostLabels
+                  ? (hostLabelByServerId.get(entry.serverId) ?? entry.serverId)
+                  : null,
+              })}
+            />
+          ))}
+          {canToggle ? (
+            <SidebarGroupToggleRow
+              expanded={expanded}
+              onPress={toggleExpanded}
+              testID="sidebar-archived-show-more"
+            />
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function buildArchivedRowSubtitle({
+  projectName,
+  hostLabel,
+}: {
+  projectName: string;
+  hostLabel: string | null;
+}): string {
+  if (!hostLabel) {
+    return projectName;
+  }
+  return projectName ? `${projectName} · ${hostLabel}` : hostLabel;
+}
+
+function ArchivedGroupHeader({ collapsed }: { collapsed: boolean }) {
+  const { t } = useTranslation();
+  const [isHovered, setIsHovered] = useState(false);
+  const toggleStatusGroupCollapsed = useSidebarCollapsedSectionsStore(
+    (state) => state.toggleStatusGroupCollapsed,
+  );
+  const label = t("sidebar.workspace.archived.groupTitle");
+  const handlePress = useCallback(() => {
+    toggleStatusGroupCollapsed(ARCHIVED_GROUP_KEY);
+  }, [toggleStatusGroupCollapsed]);
+  const handleHoverIn = useCallback(() => setIsHovered(true), []);
+  const handleHoverOut = useCallback(() => setIsHovered(false), []);
+  const rowStyle = useCallback(
+    ({ pressed }: PressableStateCallbackType) => [
+      styles.groupRow,
+      isHovered && styles.groupRowHovered,
+      pressed && styles.groupRowPressed,
+    ],
+    [isHovered],
+  );
+  const accessibilityState = useMemo(() => ({ expanded: !collapsed }), [collapsed]);
+
+  return (
+    <View onPointerEnter={handleHoverIn} onPointerLeave={handleHoverOut}>
+      <Pressable
+        accessibilityRole={platformIsWeb ? undefined : "button"}
+        accessibilityLabel={`${label} group`}
+        accessibilityState={accessibilityState}
+        style={rowStyle}
+        onPress={handlePress}
+        testID={`sidebar-status-group-${ARCHIVED_GROUP_KEY}`}
+      >
+        <View style={styles.groupRowLeft}>
+          <View style={styles.groupLeadingVisualSlot}>
+            <ArchivedGroupLeadingVisual collapsed={collapsed} showChevron={isHovered} />
+          </View>
+          <Text style={styles.groupTitle} numberOfLines={1}>
+            {label}
+          </Text>
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+
+function ArchivedGroupLeadingVisual({
+  collapsed,
+  showChevron,
+}: {
+  collapsed: boolean;
+  showChevron: boolean;
+}) {
+  if (!showChevron) {
+    return <ThemedArchive size={14} uniProps={foregroundMutedColorMapping} />;
+  }
+  if (collapsed) {
+    return <ThemedChevronRight size={14} uniProps={foregroundMutedColorMapping} />;
+  }
+  return <ThemedChevronDown size={14} uniProps={foregroundMutedColorMapping} />;
+}
+
+const ArchivedWorkspaceRow = memo(function ArchivedWorkspaceRow({
+  entry,
+  subtitle,
+}: {
+  entry: ArchivedWorkspaceEntry;
+  subtitle: string;
+}) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const isCompact = useIsCompactFormFactor();
+  const [isHovered, setIsHovered] = useState(false);
+
+  const unarchiveMutation = useMutation({
+    mutationFn: async () => {
+      const client = getHostRuntimeStore().getClient(entry.serverId);
+      if (!client) {
+        throw new Error(t("workspace.terminal.hostDisconnected"));
+      }
+      // The daemon picks unarchive vs. worktree restore; the client never decides.
+      await client.restoreWorkspace(entry.workspaceId);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: archivedWorkspacesQueryKey(entry.serverId),
+      });
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        error instanceof Error ? error.message : t("sidebar.workspace.archived.unarchiveFailed"),
+      );
+    },
+  });
+
+  const isUnarchiving = unarchiveMutation.isPending;
+  const handleUnarchive = useCallback(() => {
+    if (isUnarchiving) return;
+    unarchiveMutation.mutate();
+  }, [isUnarchiving, unarchiveMutation]);
+
+  const handleHoverIn = useCallback(() => setIsHovered(true), []);
+  const handleHoverOut = useCallback(() => setIsHovered(false), []);
+
+  // Hover is web-only; on native and compact layouts the control is always visible.
+  const showUnarchive = isHovered || platformIsNative || isCompact;
+
+  return (
+    <View
+      style={styles.rowContainer}
+      onPointerEnter={handleHoverIn}
+      onPointerLeave={handleHoverOut}
+    >
+      <View style={[styles.row, isHovered && styles.rowHovered]}>
+        <View style={styles.rowTextGroup}>
+          <Text style={styles.rowName} numberOfLines={1}>
+            {entry.name}
+          </Text>
+          {subtitle ? (
+            <Text style={styles.rowSubtitle} numberOfLines={1}>
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+        {/*
+          Kept mounted and hidden with opacity rather than conditionally rendered:
+          mounting on hover would reflow the row under the cursor and cause the
+          hover flicker loop documented in docs/hover.md.
+        */}
+        <View
+          style={[styles.unarchiveSlot, !showUnarchive && styles.unarchiveSlotHidden]}
+          pointerEvents={showUnarchive ? "auto" : "none"}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t("sidebar.workspace.archived.unarchive")}
+            disabled={isUnarchiving}
+            onPress={handleUnarchive}
+            style={styles.unarchiveButton}
+            testID={`sidebar-archived-unarchive-${entry.workspaceKey}`}
+          >
+            <ThemedArchiveRestore size={14} uniProps={foregroundMutedColorMapping} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create((theme) => ({
+  groupBlock: {
+    marginBottom: theme.spacing[1],
+    // The whole tail reads as receded: it is history, not live state.
+    opacity: 0.55,
+  },
+  groupRow: {
+    minHeight: 36,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.lg,
+    marginBottom: theme.spacing[2],
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing[2],
+    userSelect: "none",
+  },
+  groupRowHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  groupRowPressed: {
+    backgroundColor: theme.colors.surface2,
+  },
+  groupRowLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    flex: 1,
+    minWidth: 0,
+  },
+  groupLeadingVisualSlot: {
+    position: "relative",
+    width: theme.iconSize.md,
+    height: theme.iconSize.md,
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  groupTitle: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: "400",
+    minWidth: 0,
+    flexShrink: 1,
+  },
+  rowListContainer: {},
+  rowContainer: {
+    position: "relative",
+  },
+  row: {
+    minHeight: 36,
+    marginBottom: theme.spacing[1],
+    paddingVertical: theme.spacing[2],
+    paddingLeft: theme.spacing[2],
+    paddingRight: theme.spacing[3],
+    borderRadius: theme.borderRadius.lg,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    userSelect: "none",
+  },
+  rowHovered: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  rowTextGroup: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowName: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: "400",
+  },
+  rowSubtitle: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  unarchiveSlot: {
+    width: theme.iconSize.md,
+    height: theme.iconSize.md,
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  unarchiveSlotHidden: {
+    opacity: 0,
+  },
+  unarchiveButton: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+}));

--- a/packages/app/src/components/sidebar/sidebar-archived-group.tsx
+++ b/packages/app/src/components/sidebar/sidebar-archived-group.tsx
@@ -2,15 +2,12 @@ import { memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { View, Text, Pressable, type PressableStateCallbackType } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { Archive, ArchiveRestore, ChevronDown, ChevronRight } from "lucide-react-native";
 import { isNative as platformIsNative, isWeb as platformIsWeb } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useToast } from "@/contexts/toast-context";
-import {
-  archivedWorkspacesQueryKey,
-  type ArchivedWorkspaceEntry,
-} from "@/hooks/use-archived-workspaces";
+import type { ArchivedWorkspaceEntry } from "@/hooks/use-archived-workspaces";
 import { ARCHIVED_GROUP_KEY } from "@/hooks/sidebar-status-view-model";
 import { getHostRuntimeStore } from "@/runtime/host-runtime";
 import { useSidebarCollapsedSectionsStore } from "@/stores/sidebar-collapsed-sections-store";
@@ -63,7 +60,7 @@ export function SidebarArchivedGroup({
     <View style={styles.groupBlock}>
       <ArchivedGroupHeader collapsed={collapsed} />
       {!collapsed ? (
-        <View style={styles.rowListContainer} testID="sidebar-archived-group-rows">
+        <View testID="sidebar-archived-group-rows">
           {visibleEntries.map((entry) => (
             <ArchivedWorkspaceRow
               key={entry.workspaceKey}
@@ -172,7 +169,6 @@ const ArchivedWorkspaceRow = memo(function ArchivedWorkspaceRow({
 }) {
   const { t } = useTranslation();
   const toast = useToast();
-  const queryClient = useQueryClient();
   const isCompact = useIsCompactFormFactor();
   const [isHovered, setIsHovered] = useState(false);
 
@@ -184,11 +180,6 @@ const ArchivedWorkspaceRow = memo(function ArchivedWorkspaceRow({
       }
       // The daemon picks unarchive vs. worktree restore; the client never decides.
       await client.restoreWorkspace(entry.workspaceId);
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: archivedWorkspacesQueryKey(entry.serverId),
-      });
     },
     onError: (error: unknown) => {
       toast.error(
@@ -237,7 +228,11 @@ const ArchivedWorkspaceRow = memo(function ArchivedWorkspaceRow({
         >
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel={t("sidebar.workspace.archived.unarchive")}
+            accessibilityLabel={t(
+              isUnarchiving
+                ? "sidebar.workspace.archived.unarchiving"
+                : "sidebar.workspace.archived.unarchive",
+            )}
             disabled={isUnarchiving}
             onPress={handleUnarchive}
             style={styles.unarchiveButton}
@@ -297,7 +292,6 @@ const styles = StyleSheet.create((theme) => ({
     minWidth: 0,
     flexShrink: 1,
   },
-  rowListContainer: {},
   rowContainer: {
     position: "relative",
   },

--- a/packages/app/src/components/sidebar/sidebar-archived-group.tsx
+++ b/packages/app/src/components/sidebar/sidebar-archived-group.tsx
@@ -4,8 +4,7 @@ import { View, Text, Pressable, type PressableStateCallbackType } from "react-na
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { useMutation } from "@tanstack/react-query";
 import { Archive, ArchiveRestore, ChevronDown, ChevronRight } from "lucide-react-native";
-import { isNative as platformIsNative, isWeb as platformIsWeb } from "@/constants/platform";
-import { useIsCompactFormFactor } from "@/constants/layout";
+import { isWeb as platformIsWeb } from "@/constants/platform";
 import { useToast } from "@/contexts/toast-context";
 import type { ArchivedWorkspaceEntry } from "@/hooks/use-archived-workspaces";
 import { ARCHIVED_GROUP_KEY } from "@/hooks/sidebar-status-view-model";
@@ -169,7 +168,6 @@ const ArchivedWorkspaceRow = memo(function ArchivedWorkspaceRow({
 }) {
   const { t } = useTranslation();
   const toast = useToast();
-  const isCompact = useIsCompactFormFactor();
   const [isHovered, setIsHovered] = useState(false);
 
   const unarchiveMutation = useMutation({
@@ -197,9 +195,6 @@ const ArchivedWorkspaceRow = memo(function ArchivedWorkspaceRow({
   const handleHoverIn = useCallback(() => setIsHovered(true), []);
   const handleHoverOut = useCallback(() => setIsHovered(false), []);
 
-  // Hover is web-only; on native and compact layouts the control is always visible.
-  const showUnarchive = isHovered || platformIsNative || isCompact;
-
   return (
     <View
       style={styles.rowContainer}
@@ -218,14 +213,12 @@ const ArchivedWorkspaceRow = memo(function ArchivedWorkspaceRow({
           ) : null}
         </View>
         {/*
-          Kept mounted and hidden with opacity rather than conditionally rendered:
-          mounting on hover would reflow the row under the cursor and cause the
-          hover flicker loop documented in docs/hover.md.
+          Always mounted and always visible. Unarchive is this row's only action, so
+          hiding it behind hover would strand it on touch and make the tail look
+          inert on desktop. Hover only lifts it out of its greyed resting state —
+          opacity never changes the slot's geometry, per docs/hover.md.
         */}
-        <View
-          style={[styles.unarchiveSlot, !showUnarchive && styles.unarchiveSlotHidden]}
-          pointerEvents={showUnarchive ? "auto" : "none"}
-        >
+        <View style={[styles.unarchiveSlot, !isHovered && styles.unarchiveSlotResting]}>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={t(
@@ -330,8 +323,10 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
   },
-  unarchiveSlotHidden: {
-    opacity: 0,
+  // The group already sits at reduced opacity; this only needs to pull the icon
+  // back a little further so it reads as available, not as the row's subject.
+  unarchiveSlotResting: {
+    opacity: 0.7,
   },
   unarchiveButton: {
     alignItems: "center",

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -44,6 +44,8 @@ import { SidebarWorkspaceMenu } from "@/components/sidebar/sidebar-workspace-men
 import { PinnedSectionHeader } from "@/components/sidebar/pinned-section-header";
 import { SidebarGroupToggleRow } from "@/components/sidebar/sidebar-group-toggle-row";
 import { useLimitedSidebarGroup } from "@/components/sidebar/use-limited-sidebar-group";
+import { SidebarArchivedGroup } from "@/components/sidebar/sidebar-archived-group";
+import type { ArchivedWorkspaceEntry } from "@/hooks/use-archived-workspaces";
 import type { ToggleSidebarWorkspacePin } from "@/hooks/use-sidebar-workspace-pin";
 
 // Themed icon wrappers
@@ -63,6 +65,7 @@ const ThemedCircleDot = withUnistyles(CircleDot);
 const ThemedCircleX = withUnistyles(CircleX);
 interface StatusWorkspaceListProps {
   groups: StatusGroup[];
+  archivedWorkspaces: ArchivedWorkspaceEntry[];
   pinnedWorkspaces: SidebarWorkspaceEntry[];
   projectNamesByKey: Map<string, string>;
   shortcutIndexByWorkspaceKey: Map<string, number>;
@@ -77,6 +80,7 @@ interface StatusWorkspaceListProps {
 
 export function SidebarStatusWorkspaceList({
   groups,
+  archivedWorkspaces,
   pinnedWorkspaces,
   projectNamesByKey,
   shortcutIndexByWorkspaceKey,
@@ -150,6 +154,11 @@ export function SidebarStatusWorkspaceList({
         showHostLabels={showHostLabels}
         supportsPinningByServerId={supportsPinningByServerId}
         onToggleWorkspacePin={onToggleWorkspacePin}
+      />
+      <SidebarArchivedGroup
+        entries={archivedWorkspaces}
+        hostLabelByServerId={hostLabelByServerId}
+        showHostLabels={showHostLabels}
       />
     </>
   );

--- a/packages/app/src/components/sidebar/use-limited-sidebar-group.ts
+++ b/packages/app/src/components/sidebar/use-limited-sidebar-group.ts
@@ -2,13 +2,16 @@ import { useCallback, useMemo, useState } from "react";
 
 const INITIAL_VISIBLE_ITEMS = 20;
 
-export function useLimitedSidebarGroup<T>(items: readonly T[]) {
+export function useLimitedSidebarGroup<T>(
+  items: readonly T[],
+  initialVisibleItems: number = INITIAL_VISIBLE_ITEMS,
+) {
   const [expanded, setExpanded] = useState(false);
   const visibleItems = useMemo(
-    () => (expanded ? items.slice() : items.slice(0, INITIAL_VISIBLE_ITEMS)),
-    [expanded, items],
+    () => (expanded ? items.slice() : items.slice(0, initialVisibleItems)),
+    [expanded, initialVisibleItems, items],
   );
-  const canToggle = items.length > INITIAL_VISIBLE_ITEMS;
+  const canToggle = items.length > initialVisibleItems;
   const toggleExpanded = useCallback(() => setExpanded((current) => !current), []);
 
   return { visibleItems, expanded, canToggle, toggleExpanded };

--- a/packages/app/src/hooks/sidebar-status-view-model.ts
+++ b/packages/app/src/hooks/sidebar-status-view-model.ts
@@ -2,6 +2,11 @@ import type { SidebarWorkspaceEntry } from "@/hooks/sidebar-workspaces-view-mode
 
 export type StatusBucket = SidebarWorkspaceEntry["statusBucket"];
 
+// The archived group is not a status bucket: archived workspaces have no live
+// status, and they must never enter STATUS_BUCKET_ORDER or the shortcut index.
+// It renders after every real group as a greyed-out tail.
+export const ARCHIVED_GROUP_KEY = "archived";
+
 export const STATUS_BUCKET_ORDER: readonly StatusBucket[] = [
   "needs_input",
   "failed",

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -10,6 +10,7 @@ import {
   computeSidebarOrderUpdates,
   createSidebarWorkspaceEntry,
   deriveSidebarLoadingState,
+  resolveSidebarServerIds,
   shouldShowSidebarHostLabels,
   type SidebarProjectEntry,
 } from "./sidebar-workspaces-view-model";
@@ -572,5 +573,45 @@ describe("deriveSidebarLoadingState", () => {
         hasProjects: false,
       }),
     ).toEqual({ isLoading: false, isInitialLoad: false, isRevalidating: false });
+  });
+});
+
+describe("resolveSidebarServerIds", () => {
+  const allServerIds = ["alpha", "beta", "gamma"];
+
+  it("shows every host when no filter is set", () => {
+    expect(
+      resolveSidebarServerIds({ allServerIds, hostFilters: [], hostRegistryLoaded: true }),
+    ).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("narrows to the filtered hosts, preserving registry order", () => {
+    expect(
+      resolveSidebarServerIds({
+        allServerIds,
+        hostFilters: ["gamma", "alpha"],
+        hostRegistryLoaded: true,
+      }),
+    ).toEqual(["alpha", "gamma"]);
+  });
+
+  it("falls back to every host once the registry settles with no surviving filter", () => {
+    expect(
+      resolveSidebarServerIds({
+        allServerIds,
+        hostFilters: ["deleted-host"],
+        hostRegistryLoaded: true,
+      }),
+    ).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("stays empty while the registry is still loading so hosts do not flash in", () => {
+    expect(
+      resolveSidebarServerIds({
+        allServerIds,
+        hostFilters: ["deleted-host"],
+        hostRegistryLoaded: false,
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -75,6 +75,28 @@ interface SidebarWorkspaceSessionSource {
   workspaceAgentActivity: Map<string, WorkspaceAgentActivity>;
 }
 
+/**
+ * The hosts the sidebar is currently showing. Every sidebar surface must agree on
+ * this set, or a filtered-out host leaks rows into one section but not another.
+ * Once the registry has settled and no pinned host still exists, fall back to
+ * every host rather than rendering an empty sidebar.
+ */
+export function resolveSidebarServerIds(input: {
+  allServerIds: readonly string[];
+  hostFilters: readonly string[];
+  hostRegistryLoaded: boolean;
+}): string[] {
+  if (input.hostFilters.length === 0) {
+    return [...input.allServerIds];
+  }
+  const selected = new Set(input.hostFilters);
+  const matched = input.allServerIds.filter((id) => selected.has(id));
+  if (input.hostRegistryLoaded && matched.length === 0) {
+    return [...input.allServerIds];
+  }
+  return matched;
+}
+
 export function selectSidebarWorkspaceSessions(
   sessions: Record<string, SidebarWorkspaceSessionSource | undefined>,
   serverIds: readonly string[],

--- a/packages/app/src/hooks/use-archived-workspaces.test.ts
+++ b/packages/app/src/hooks/use-archived-workspaces.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { mergeArchivedWorkspaces, type ArchivedWorkspaceEntry } from "./use-archived-workspaces";
+import {
+  mergeArchivedWorkspaces,
+  shouldRefreshArchivedWorkspaces,
+  type ArchivedWorkspaceEntry,
+} from "./use-archived-workspaces";
 
 function entry(input: {
   serverId: string;
@@ -10,10 +14,8 @@ function entry(input: {
     workspaceKey: `${input.serverId}:${input.workspaceId}`,
     serverId: input.serverId,
     workspaceId: input.workspaceId,
-    projectId: "prj",
     projectName: "repo",
     name: input.workspaceId,
-    workspaceDirectory: `/repo/${input.workspaceId}`,
     archivedAt: new Date(input.archivedAt),
   };
 }
@@ -82,5 +84,27 @@ describe("mergeArchivedWorkspaces", () => {
     expect(merged).toHaveLength(25);
     // Still the newest ones, not just the first host's slice.
     expect(new Set(merged.map((item) => item.serverId))).toEqual(new Set(["a", "b", "c"]));
+  });
+});
+
+describe("shouldRefreshArchivedWorkspaces", () => {
+  const cached = [
+    entry({
+      serverId: "a",
+      workspaceId: "archived",
+      archivedAt: "2026-03-03T00:00:00.000Z",
+    }),
+  ];
+
+  it("refreshes when a workspace disappears from the live directory", () => {
+    expect(shouldRefreshArchivedWorkspaces("remove", "newly-archived", cached)).toBe(true);
+  });
+
+  it("refreshes when a cached archived workspace returns to the live directory", () => {
+    expect(shouldRefreshArchivedWorkspaces("upsert", "archived", cached)).toBe(true);
+  });
+
+  it("ignores ordinary updates to live workspaces", () => {
+    expect(shouldRefreshArchivedWorkspaces("upsert", "live", cached)).toBe(false);
   });
 });

--- a/packages/app/src/hooks/use-archived-workspaces.test.ts
+++ b/packages/app/src/hooks/use-archived-workspaces.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { mergeArchivedWorkspaces, type ArchivedWorkspaceEntry } from "./use-archived-workspaces";
+
+function entry(input: {
+  serverId: string;
+  workspaceId: string;
+  archivedAt: string;
+}): ArchivedWorkspaceEntry {
+  return {
+    workspaceKey: `${input.serverId}:${input.workspaceId}`,
+    serverId: input.serverId,
+    workspaceId: input.workspaceId,
+    projectId: "prj",
+    projectName: "repo",
+    name: input.workspaceId,
+    workspaceDirectory: `/repo/${input.workspaceId}`,
+    archivedAt: new Date(input.archivedAt),
+  };
+}
+
+function hostSlice(serverId: string, count: number): ArchivedWorkspaceEntry[] {
+  const entries: ArchivedWorkspaceEntry[] = [];
+  for (let index = 0; index < count; index += 1) {
+    entries.push(
+      entry({
+        serverId,
+        workspaceId: `${serverId}-${index}`,
+        archivedAt: new Date(Date.UTC(2026, 2, 1, 0, index)).toISOString(),
+      }),
+    );
+  }
+  return entries;
+}
+
+describe("mergeArchivedWorkspaces", () => {
+  it("interleaves hosts by archive time, newest first", () => {
+    const merged = mergeArchivedWorkspaces([
+      [
+        entry({ serverId: "a", workspaceId: "a-old", archivedAt: "2026-03-01T00:00:00.000Z" }),
+        entry({ serverId: "a", workspaceId: "a-new", archivedAt: "2026-03-05T00:00:00.000Z" }),
+      ],
+      [entry({ serverId: "b", workspaceId: "b-mid", archivedAt: "2026-03-03T00:00:00.000Z" })],
+    ]);
+
+    expect(merged.map((item) => item.workspaceId)).toEqual(["a-new", "b-mid", "a-old"]);
+  });
+
+  it("ignores hosts that have not resolved yet", () => {
+    const merged = mergeArchivedWorkspaces([
+      undefined,
+      [entry({ serverId: "b", workspaceId: "b-one", archivedAt: "2026-03-03T00:00:00.000Z" })],
+      undefined,
+    ]);
+
+    expect(merged.map((item) => item.workspaceId)).toEqual(["b-one"]);
+  });
+
+  it("orders a cascade archive deterministically when timestamps tie", () => {
+    const sameInstant = "2026-03-04T00:00:00.000Z";
+    const forward = mergeArchivedWorkspaces([
+      [
+        entry({ serverId: "a", workspaceId: "child", archivedAt: sameInstant }),
+        entry({ serverId: "a", workspaceId: "parent", archivedAt: sameInstant }),
+      ],
+    ]);
+    const reversed = mergeArchivedWorkspaces([
+      [
+        entry({ serverId: "a", workspaceId: "parent", archivedAt: sameInstant }),
+        entry({ serverId: "a", workspaceId: "child", archivedAt: sameInstant }),
+      ],
+    ]);
+
+    expect(forward.map((item) => item.workspaceId)).toEqual(["child", "parent"]);
+    expect(reversed.map((item) => item.workspaceId)).toEqual(forward.map((i) => i.workspaceId));
+  });
+
+  it("caps the merged tail so many hosts cannot grow it without bound", () => {
+    const slices = ["a", "b", "c"].map((serverId) => hostSlice(serverId, 20));
+
+    const merged = mergeArchivedWorkspaces(slices);
+
+    expect(merged).toHaveLength(25);
+    // Still the newest ones, not just the first host's slice.
+    expect(new Set(merged.map((item) => item.serverId))).toEqual(new Set(["a", "b", "c"]));
+  });
+});

--- a/packages/app/src/hooks/use-archived-workspaces.ts
+++ b/packages/app/src/hooks/use-archived-workspaces.ts
@@ -1,0 +1,133 @@
+import { useRef } from "react";
+import { useShallow } from "zustand/shallow";
+import { useFetchQueries } from "@/data/query";
+import { getHostRuntimeStore, useHostRuntimeConnectionStatuses } from "@/runtime/host-runtime";
+import { useSessionStore } from "@/stores/session-store";
+
+// Recently-archived workspaces are an undo affordance, not an archive browser.
+// The daemon caps its own response; this is the client-side ceiling on the merged
+// cross-host list so a many-host sidebar can't grow an unbounded tail.
+const ARCHIVED_WORKSPACE_LIMIT = 25;
+const ARCHIVED_WORKSPACES_STALE_TIME = 30_000;
+
+export interface ArchivedWorkspaceEntry {
+  workspaceKey: string;
+  serverId: string;
+  workspaceId: string;
+  projectId: string;
+  projectName: string;
+  name: string;
+  workspaceDirectory: string;
+  archivedAt: Date;
+}
+
+export function archivedWorkspacesQueryKey(serverId: string): [string, string] {
+  return ["archivedWorkspaces", serverId];
+}
+
+interface ArchivedWorkspacesCache {
+  signature: string;
+  value: ArchivedWorkspaceEntry[];
+}
+
+const EMPTY_ARCHIVED_WORKSPACES_CACHE: ArchivedWorkspacesCache = { signature: "", value: [] };
+
+/**
+ * Archived workspaces are deliberately kept out of the session store's workspace
+ * map: everything that reads that map (project mode, switchers, counts) treats a
+ * present descriptor as live. These rows live only here, and only status mode
+ * renders them.
+ */
+export function useArchivedWorkspaces({
+  serverIds,
+}: {
+  serverIds: readonly string[];
+}): ArchivedWorkspaceEntry[] {
+  // COMPAT(archivedWorkspacesList): added in v0.2.0, drop the gate when floor >= v0.2.0.
+  // Single capability-detection site; hosts without the RPC simply contribute nothing.
+  const supportedServerIds = useSessionStore(
+    useShallow((state) =>
+      serverIds.filter(
+        (serverId) =>
+          state.sessions[serverId]?.serverInfo?.features?.archivedWorkspacesList === true,
+      ),
+    ),
+  );
+  // An offline host has no client to ask, so asking only burns retries. Its rows
+  // reappear when the connection does.
+  const connectionStatuses = useHostRuntimeConnectionStatuses(supportedServerIds);
+
+  const queries = useFetchQueries(
+    supportedServerIds.map((serverId) => ({
+      queryKey: archivedWorkspacesQueryKey(serverId),
+      queryFn: async (): Promise<ArchivedWorkspaceEntry[]> => {
+        const client = getHostRuntimeStore().getClient(serverId);
+        if (!client) {
+          throw new Error("Host disconnected");
+        }
+        const entries = await client.listArchivedWorkspaces({
+          limit: ARCHIVED_WORKSPACE_LIMIT,
+        });
+        return entries.map((entry) => ({
+          workspaceKey: `${serverId}:${entry.id}`,
+          serverId,
+          workspaceId: entry.id,
+          projectId: entry.projectId,
+          projectName: entry.projectDisplayName,
+          name: entry.name,
+          workspaceDirectory: entry.workspaceDirectory,
+          archivedAt: new Date(entry.archivedAt),
+        }));
+      },
+      enabled: connectionStatuses.get(serverId) === "online",
+      staleTimeMs: ARCHIVED_WORKSPACES_STALE_TIME,
+      dataShape: "list" as const,
+    })),
+  );
+
+  // useQueries hands back a fresh wrapper array every render, so the merged result
+  // must be cached on the data itself or every consumer re-renders forever. A
+  // useMemo can't express this (its dependency is derived from the same array it
+  // consumes), so cache explicitly: recompute only when the signature moves.
+  const dataSlices = queries.map((query) => query.data);
+  const signature = dataSlices
+    .map(
+      (slice) =>
+        slice?.map((entry) => `${entry.workspaceKey}@${entry.archivedAt.getTime()}`).join(",") ??
+        "",
+    )
+    .join("|");
+
+  const cache = useRef<ArchivedWorkspacesCache>(EMPTY_ARCHIVED_WORKSPACES_CACHE);
+  if (cache.current.signature !== signature) {
+    cache.current = { signature, value: mergeArchivedWorkspaces(dataSlices) };
+  }
+  return cache.current.value;
+}
+
+export function mergeArchivedWorkspaces(
+  slices: ReadonlyArray<ArchivedWorkspaceEntry[] | undefined>,
+): ArchivedWorkspaceEntry[] {
+  const merged: ArchivedWorkspaceEntry[] = [];
+  for (const slice of slices) {
+    if (slice) merged.push(...slice);
+  }
+  return merged
+    .sort((left, right) => compareArchivedWorkspaces(left, right))
+    .slice(0, ARCHIVED_WORKSPACE_LIMIT);
+}
+
+// Newest archive first. Entries archived in the same millisecond (a cascade
+// archive writes one timestamp across several workspaces) fall back to the key so
+// the order stays stable across refetches.
+function compareArchivedWorkspaces(
+  left: ArchivedWorkspaceEntry,
+  right: ArchivedWorkspaceEntry,
+): number {
+  const leftTime = left.archivedAt.getTime();
+  const rightTime = right.archivedAt.getTime();
+  if (leftTime !== rightTime) {
+    return rightTime - leftTime;
+  }
+  return left.workspaceKey.localeCompare(right.workspaceKey);
+}

--- a/packages/app/src/hooks/use-archived-workspaces.ts
+++ b/packages/app/src/hooks/use-archived-workspaces.ts
@@ -1,4 +1,5 @@
-import { useRef } from "react";
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useShallow } from "zustand/shallow";
 import { useFetchQueries } from "@/data/query";
 import { getHostRuntimeStore, useHostRuntimeConnectionStatuses } from "@/runtime/host-runtime";
@@ -14,23 +15,14 @@ export interface ArchivedWorkspaceEntry {
   workspaceKey: string;
   serverId: string;
   workspaceId: string;
-  projectId: string;
   projectName: string;
   name: string;
-  workspaceDirectory: string;
   archivedAt: Date;
 }
 
 export function archivedWorkspacesQueryKey(serverId: string): [string, string] {
   return ["archivedWorkspaces", serverId];
 }
-
-interface ArchivedWorkspacesCache {
-  signature: string;
-  value: ArchivedWorkspaceEntry[];
-}
-
-const EMPTY_ARCHIVED_WORKSPACES_CACHE: ArchivedWorkspacesCache = { signature: "", value: [] };
 
 /**
  * Archived workspaces are deliberately kept out of the session store's workspace
@@ -43,6 +35,7 @@ export function useArchivedWorkspaces({
 }: {
   serverIds: readonly string[];
 }): ArchivedWorkspaceEntry[] {
+  const queryClient = useQueryClient();
   // COMPAT(archivedWorkspacesList): added in v0.2.0, drop the gate when floor >= v0.2.0.
   // Single capability-detection site; hosts without the RPC simply contribute nothing.
   const supportedServerIds = useSessionStore(
@@ -65,17 +58,13 @@ export function useArchivedWorkspaces({
         if (!client) {
           throw new Error("Host disconnected");
         }
-        const entries = await client.listArchivedWorkspaces({
-          limit: ARCHIVED_WORKSPACE_LIMIT,
-        });
+        const entries = await client.listArchivedWorkspaces();
         return entries.map((entry) => ({
           workspaceKey: `${serverId}:${entry.id}`,
           serverId,
           workspaceId: entry.id,
-          projectId: entry.projectId,
           projectName: entry.projectDisplayName,
           name: entry.name,
-          workspaceDirectory: entry.workspaceDirectory,
           archivedAt: new Date(entry.archivedAt),
         }));
       },
@@ -85,24 +74,46 @@ export function useArchivedWorkspaces({
     })),
   );
 
-  // useQueries hands back a fresh wrapper array every render, so the merged result
-  // must be cached on the data itself or every consumer re-renders forever. A
-  // useMemo can't express this (its dependency is derived from the same array it
-  // consumes), so cache explicitly: recompute only when the signature moves.
-  const dataSlices = queries.map((query) => query.data);
-  const signature = dataSlices
-    .map(
-      (slice) =>
-        slice?.map((entry) => `${entry.workspaceKey}@${entry.archivedAt.getTime()}`).join(",") ??
-        "",
-    )
-    .join("|");
+  useEffect(() => {
+    const unsubscribes = supportedServerIds.flatMap((serverId) => {
+      if (connectionStatuses.get(serverId) !== "online") {
+        return [];
+      }
+      const client = getHostRuntimeStore().getClient(serverId);
+      if (!client) {
+        return [];
+      }
+      return [
+        client.on("workspace_update", (message) => {
+          const queryKey = archivedWorkspacesQueryKey(serverId);
+          const cached = queryClient.getQueryData<ArchivedWorkspaceEntry[]>(queryKey);
+          const workspaceId =
+            message.payload.kind === "remove" ? message.payload.id : message.payload.workspace.id;
+          if (shouldRefreshArchivedWorkspaces(message.payload.kind, workspaceId, cached)) {
+            void queryClient.invalidateQueries({ queryKey });
+          }
+        }),
+      ];
+    });
+    return () => {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe();
+      }
+    };
+  }, [connectionStatuses, queryClient, supportedServerIds]);
 
-  const cache = useRef<ArchivedWorkspacesCache>(EMPTY_ARCHIVED_WORKSPACES_CACHE);
-  if (cache.current.signature !== signature) {
-    cache.current = { signature, value: mergeArchivedWorkspaces(dataSlices) };
+  return mergeArchivedWorkspaces(queries.map((query) => query.data));
+}
+
+export function shouldRefreshArchivedWorkspaces(
+  kind: "remove" | "upsert",
+  workspaceId: string,
+  cached: readonly ArchivedWorkspaceEntry[] | undefined,
+): boolean {
+  if (kind === "remove") {
+    return true;
   }
-  return cache.current.value;
+  return Boolean(cached?.some((entry) => entry.workspaceId === workspaceId));
 }
 
 export function mergeArchivedWorkspaces(

--- a/packages/app/src/hooks/use-sidebar-workspaces-list.ts
+++ b/packages/app/src/hooks/use-sidebar-workspaces-list.ts
@@ -11,6 +11,7 @@ import {
   buildSidebarWorkspacePlacementModel,
   computeSidebarOrderUpdates,
   deriveSidebarLoadingState,
+  resolveSidebarServerIds,
   type SidebarProjectEntry,
   type SidebarWorkspaceEntry,
   type SidebarWorkspacePlacement,
@@ -25,6 +26,7 @@ export {
   buildSidebarWorkspacePlacementModel,
   computeSidebarOrderUpdates,
   deriveSidebarLoadingState,
+  resolveSidebarServerIds,
   shouldShowSidebarHostLabels,
   type SidebarLoadingState,
   type SidebarOrderUpdates,
@@ -65,19 +67,10 @@ export function useSidebarWorkspacesList(options?: {
   const reconcileHostFilters = useSidebarViewStore((state) => state.reconcileHostFilters);
   const isActive = options?.enabled !== false;
 
-  const serverIds = useMemo(() => {
-    if (hostFilters.length === 0) {
-      return allServerIds;
-    }
-    const selected = new Set(hostFilters);
-    const matched = allServerIds.filter((id) => selected.has(id));
-    // Registry has settled but none of the pinned hosts still exist — fall back to every
-    // host rather than leaving the sidebar empty.
-    if (hostRegistryLoaded && matched.length === 0) {
-      return allServerIds;
-    }
-    return matched;
-  }, [allServerIds, hostFilters, hostRegistryLoaded]);
+  const serverIds = useMemo(
+    () => resolveSidebarServerIds({ allServerIds, hostFilters, hostRegistryLoaded }),
+    [allServerIds, hostFilters, hostRegistryLoaded],
+  );
 
   useEffect(() => {
     if (!hostRegistryLoaded) {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -952,6 +952,12 @@ export const ar: TranslationResources = {
         archiving: "أرشفة...",
         hiding: "إخفاء...",
       },
+      archived: {
+        groupTitle: "المؤرشفة مؤخرًا",
+        unarchive: "إلغاء الأرشفة",
+        unarchiving: "جارٍ إلغاء الأرشفة...",
+        unarchiveFailed: "تعذر إلغاء أرشفة مساحة العمل",
+      },
       confirmations: {
         hideTitle: "إخفاء مساحة العمل؟",
         hideMessage:

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -962,6 +962,12 @@ export const en = {
         archiving: "Archiving...",
         hiding: "Hiding...",
       },
+      archived: {
+        groupTitle: "Recently archived",
+        unarchive: "Unarchive",
+        unarchiving: "Unarchiving...",
+        unarchiveFailed: "Failed to unarchive workspace",
+      },
       confirmations: {
         hideTitle: "Hide workspace?",
         hideMessage:

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -983,6 +983,12 @@ export const es: TranslationResources = {
         archiving: "Archivando...",
         hiding: "Ocultación...",
       },
+      archived: {
+        groupTitle: "Archivados recientemente",
+        unarchive: "Desarchivar",
+        unarchiving: "Desarchivando...",
+        unarchiveFailed: "No se pudo desarchivar el espacio de trabajo",
+      },
       confirmations: {
         hideTitle: "¿Ocultar espacio de trabajo?",
         hideMessage:

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -982,6 +982,12 @@ export const fr: TranslationResources = {
         archiving: "Archivage...",
         hiding: "Dissimulation...",
       },
+      archived: {
+        groupTitle: "Archivés récemment",
+        unarchive: "Désarchiver",
+        unarchiving: "Désarchivage...",
+        unarchiveFailed: "Échec du désarchivage de l'espace de travail",
+      },
       confirmations: {
         hideTitle: "Masquer l'espace de travail?",
         hideMessage:

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -963,6 +963,12 @@ export const ja: TranslationResources = {
         archiving: "アーカイブ中...",
         hiding: "非表示にしています...",
       },
+      archived: {
+        groupTitle: "最近アーカイブしたもの",
+        unarchive: "アーカイブ解除",
+        unarchiving: "アーカイブを解除しています...",
+        unarchiveFailed: "ワークスペースのアーカイブ解除に失敗しました",
+      },
       confirmations: {
         hideTitle: "ワークスペースを非表示にしますか？",
         hideMessage:

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -974,6 +974,12 @@ export const ptBR: TranslationResources = {
         archiving: "Arquivando...",
         hiding: "Ocultando...",
       },
+      archived: {
+        groupTitle: "Arquivados recentemente",
+        unarchive: "Desarquivar",
+        unarchiving: "Desarquivando...",
+        unarchiveFailed: "Falha ao desarquivar o workspace",
+      },
       confirmations: {
         hideTitle: "Ocultar workspace?",
         hideMessage:

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -974,6 +974,12 @@ export const ru: TranslationResources = {
         archiving: "Архивирование...",
         hiding: "Скрытие...",
       },
+      archived: {
+        groupTitle: "Недавно архивированные",
+        unarchive: "Разархивировать",
+        unarchiving: "Разархивирование...",
+        unarchiveFailed: "Не удалось разархивировать рабочее пространство",
+      },
       confirmations: {
         hideTitle: "Скрыть рабочее пространство?",
         hideMessage:

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -942,6 +942,12 @@ export const zhCN: TranslationResources = {
         archiving: "正在归档...",
         hiding: "正在隐藏...",
       },
+      archived: {
+        groupTitle: "最近归档",
+        unarchive: "取消归档",
+        unarchiving: "正在取消归档...",
+        unarchiveFailed: "取消归档 workspace 失败",
+      },
       confirmations: {
         hideTitle: "隐藏 workspace？",
         hideMessage: "从侧边栏隐藏「{{workspaceName}}」？\n\n磁盘上的文件不会被更改。",

--- a/packages/app/src/workspace/use-workspace-archive.ts
+++ b/packages/app/src/workspace/use-workspace-archive.ts
@@ -1,5 +1,7 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
+import { archivedWorkspacesQueryKey } from "@/hooks/use-archived-workspaces";
 import { getHostRuntimeStore } from "@/runtime/host-runtime";
 import { useToast } from "@/contexts/toast-context";
 import {
@@ -51,6 +53,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
   } = input;
   const { t } = useTranslation();
   const toast = useToast();
+  const queryClient = useQueryClient();
 
   const archiveWorkspaceRecord = useCallback(async () => {
     const client = getHostRuntimeStore().getClient(serverId);
@@ -69,6 +72,9 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
         },
       });
       purgeArchivedWorkspaceState({ serverId, workspaceId });
+      // Status mode's recently-archived tail is only useful if the workspace you
+      // just archived is already in it when you realize the mistake.
+      void queryClient.invalidateQueries({ queryKey: archivedWorkspacesQueryKey(serverId) });
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : t("sidebar.workspace.toasts.archiveFailed"),
@@ -76,7 +82,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     } finally {
       onSetHiding?.(false);
     }
-  }, [onArchiveStarted, onSetHiding, serverId, t, toast, workspaceId]);
+  }, [onArchiveStarted, onSetHiding, queryClient, serverId, t, toast, workspaceId]);
 
   const archive = useCallback(() => {
     void (async () => {

--- a/packages/app/src/workspace/use-workspace-archive.ts
+++ b/packages/app/src/workspace/use-workspace-archive.ts
@@ -1,7 +1,5 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { useQueryClient } from "@tanstack/react-query";
-import { archivedWorkspacesQueryKey } from "@/hooks/use-archived-workspaces";
 import { getHostRuntimeStore } from "@/runtime/host-runtime";
 import { useToast } from "@/contexts/toast-context";
 import {
@@ -53,7 +51,6 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
   } = input;
   const { t } = useTranslation();
   const toast = useToast();
-  const queryClient = useQueryClient();
 
   const archiveWorkspaceRecord = useCallback(async () => {
     const client = getHostRuntimeStore().getClient(serverId);
@@ -72,9 +69,6 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
         },
       });
       purgeArchivedWorkspaceState({ serverId, workspaceId });
-      // Status mode's recently-archived tail is only useful if the workspace you
-      // just archived is already in it when you realize the mistake.
-      void queryClient.invalidateQueries({ queryKey: archivedWorkspacesQueryKey(serverId) });
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : t("sidebar.workspace.toasts.archiveFailed"),
@@ -82,7 +76,7 @@ export function useWorkspaceArchive(input: ArchiveWorkspaceInput): WorkspaceArch
     } finally {
       onSetHiding?.(false);
     }
-  }, [onArchiveStarted, onSetHiding, queryClient, serverId, t, toast, workspaceId]);
+  }, [onArchiveStarted, onSetHiding, serverId, t, toast, workspaceId]);
 
   const archive = useCallback(() => {
     void (async () => {

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2583,16 +2583,12 @@ export class DaemonClient {
     return payload.state;
   }
 
-  async listArchivedWorkspaces(
-    options?: { limit?: number },
-    requestId?: string,
-  ): Promise<ArchivedWorkspacePayload[]> {
+  async listArchivedWorkspaces(requestId?: string): Promise<ArchivedWorkspacePayload[]> {
     const payload =
       await this.sendNamespacedCorrelatedSessionRequest<"workspace.archived.list.response">({
         requestId,
         message: {
           type: "workspace.archived.list.request",
-          ...(options?.limit === undefined ? {} : { limit: options.limit }),
         },
       });
     return payload.entries;

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -99,6 +99,7 @@ import type {
   PaseoConfigRevision,
   WorkspaceCreateRequest,
   WorkspaceRecoveryState,
+  ArchivedWorkspacePayload,
 } from "@getpaseo/protocol/messages";
 import type {
   AgentPermissionRequest,
@@ -2580,6 +2581,21 @@ export class DaemonClient {
         },
       });
     return payload.state;
+  }
+
+  async listArchivedWorkspaces(
+    options?: { limit?: number },
+    requestId?: string,
+  ): Promise<ArchivedWorkspacePayload[]> {
+    const payload =
+      await this.sendNamespacedCorrelatedSessionRequest<"workspace.archived.list.response">({
+        requestId,
+        message: {
+          type: "workspace.archived.list.request",
+          ...(options?.limit === undefined ? {} : { limit: options.limit }),
+        },
+      });
+    return payload.entries;
   }
 
   async restoreWorkspace(workspaceId: string, requestId?: string): Promise<void> {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -854,6 +854,15 @@ export const WorkspaceRecoveryRestoreRequestSchema = z.object({
   requestId: z.string(),
 });
 
+// Recently-archived workspaces, newest first. This is an undo affordance for the
+// sidebar's status view, not an archive browser: the daemon caps what it returns
+// and the client never merges these into the live workspace directory.
+export const WorkspaceArchivedListRequestSchema = z.object({
+  type: z.literal("workspace.archived.list.request"),
+  limit: z.number().int().positive().max(200).optional(),
+  requestId: z.string(),
+});
+
 export const SetVoiceModeMessageSchema = z.object({
   type: z.literal("set_voice_mode"),
   enabled: z.boolean(),
@@ -1564,6 +1573,25 @@ export const WorkspaceRecoveryStateSchema = z.discriminatedUnion("kind", [
     message: z.string(),
   }),
 ]);
+
+export const ArchivedWorkspacePayloadSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  projectDisplayName: z.string(),
+  name: z.string(),
+  // COMPAT(workspaces): keep legacy directory workspace kind parseable.
+  workspaceKind: z.enum(["directory", "local_checkout", "checkout", "worktree"]),
+  workspaceDirectory: z.string(),
+  archivedAt: z.string(),
+});
+
+export const WorkspaceArchivedListResponseSchema = z.object({
+  type: z.literal("workspace.archived.list.response"),
+  payload: z.object({
+    requestId: z.string(),
+    entries: z.array(ArchivedWorkspacePayloadSchema),
+  }),
+});
 
 export const WorkspaceRecoveryInspectResponseSchema = z.object({
   type: z.literal("workspace.recovery.inspect.response"),
@@ -2456,6 +2484,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   WorkspacePinSetRequestSchema,
   WorkspaceRecoveryInspectRequestSchema,
   WorkspaceRecoveryRestoreRequestSchema,
+  WorkspaceArchivedListRequestSchema,
   SetVoiceModeMessageSchema,
   SendAgentMessageRequestSchema,
   WaitForFinishRequestSchema,
@@ -2804,6 +2833,8 @@ export const ServerInfoStatusPayloadSchema = z
         providerSubagents: z.boolean().optional(),
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
         workspacePinning: z.boolean().optional(),
+        // COMPAT(archivedWorkspacesList): added in v0.2.0, remove gate after 2027-01-28.
+        archivedWorkspacesList: z.boolean().optional(),
         // COMPAT(hubRelationship): added in v0.1.X, drop the gate when floor >= v0.1.X.
         hubRelationship: z.boolean().optional(),
         // COMPAT(projectGithubClone): added in v0.1.108, remove gate after 2027-01-15.
@@ -5241,6 +5272,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   WorkspacePinSetResponseSchema,
   WorkspaceRecoveryInspectResponseSchema,
   WorkspaceRecoveryRestoreResponseSchema,
+  WorkspaceArchivedListResponseSchema,
   WaitForFinishResponseMessageSchema,
   AgentPermissionRequestMessageSchema,
   AgentPermissionResolvedMessageSchema,
@@ -5433,6 +5465,7 @@ export type WorkspaceRecoveryInspectResponse = z.infer<
 export type WorkspaceRecoveryRestoreResponse = z.infer<
   typeof WorkspaceRecoveryRestoreResponseSchema
 >;
+export type WorkspaceArchivedListResponse = z.infer<typeof WorkspaceArchivedListResponseSchema>;
 export type WorkspaceCreateRequest = z.infer<typeof WorkspaceCreateRequestSchema>;
 export type WorkspaceCreateResponse = z.infer<typeof WorkspaceCreateResponseSchema>;
 export type ProjectRenameResponsePayload = z.infer<typeof ProjectRenameResponsePayloadSchema>;
@@ -5570,6 +5603,8 @@ export type WorkspaceTitleSetRequest = z.infer<typeof WorkspaceTitleSetRequestSc
 export type WorkspacePinSetRequest = z.infer<typeof WorkspacePinSetRequestSchema>;
 export type WorkspaceRecoveryInspectRequest = z.infer<typeof WorkspaceRecoveryInspectRequestSchema>;
 export type WorkspaceRecoveryRestoreRequest = z.infer<typeof WorkspaceRecoveryRestoreRequestSchema>;
+export type WorkspaceArchivedListRequest = z.infer<typeof WorkspaceArchivedListRequestSchema>;
+export type ArchivedWorkspacePayload = z.infer<typeof ArchivedWorkspacePayloadSchema>;
 export type SetAgentModeRequestMessage = z.infer<typeof SetAgentModeRequestMessageSchema>;
 export type SetAgentModelRequestMessage = z.infer<typeof SetAgentModelRequestMessageSchema>;
 export type SetAgentThinkingRequestMessage = z.infer<typeof SetAgentThinkingRequestMessageSchema>;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -859,7 +859,6 @@ export const WorkspaceRecoveryRestoreRequestSchema = z.object({
 // and the client never merges these into the live workspace directory.
 export const WorkspaceArchivedListRequestSchema = z.object({
   type: z.literal("workspace.archived.list.request"),
-  limit: z.number().int().positive().max(200).optional(),
   requestId: z.string(),
 });
 
@@ -1576,12 +1575,8 @@ export const WorkspaceRecoveryStateSchema = z.discriminatedUnion("kind", [
 
 export const ArchivedWorkspacePayloadSchema = z.object({
   id: z.string(),
-  projectId: z.string(),
   projectDisplayName: z.string(),
   name: z.string(),
-  // COMPAT(workspaces): keep legacy directory workspace kind parseable.
-  workspaceKind: z.enum(["directory", "local_checkout", "checkout", "worktree"]),
-  workspaceDirectory: z.string(),
   archivedAt: z.string(),
 });
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -302,7 +302,7 @@ const FETCH_AGENTS_SORT_KEYS = ["status_priority", "created_at", "updated_at", "
 
 // The archived list backs an undo affordance, not an archive browser. Cap it so a
 // long-lived daemon never streams thousands of stale records to every client.
-const DEFAULT_ARCHIVED_WORKSPACES_LIMIT = 50;
+const ARCHIVED_WORKSPACES_LIMIT = 25;
 
 export function resolveWaitForFinishError(options: {
   status: "permission" | "error" | "idle";
@@ -2900,7 +2900,6 @@ export class Session {
   private async handleWorkspaceArchivedListRequest(
     request: Extract<SessionInboundMessage, { type: "workspace.archived.list.request" }>,
   ): Promise<void> {
-    const limit = request.limit ?? DEFAULT_ARCHIVED_WORKSPACES_LIMIT;
     const [workspaces, projects] = await Promise.all([
       this.workspaceRegistry.list(),
       this.projectRegistry.list(),
@@ -2920,17 +2919,14 @@ export class Session {
         return [
           {
             id: workspace.workspaceId,
-            projectId: workspace.projectId,
             projectDisplayName: resolveProjectDisplayName(project),
             name: resolveWorkspaceDisplayName(workspace),
-            workspaceKind: workspace.kind,
-            workspaceDirectory: workspace.cwd,
             archivedAt,
           },
         ];
       })
       .sort((left, right) => right.archivedAt.localeCompare(left.archivedAt))
-      .slice(0, limit);
+      .slice(0, ARCHIVED_WORKSPACES_LIMIT);
 
     this.emit({
       type: "workspace.archived.list.response",

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -300,6 +300,10 @@ function beginAgentDeleteIfSupported(agentStorage: AgentStorage, agentId: string
 
 const FETCH_AGENTS_SORT_KEYS = ["status_priority", "created_at", "updated_at", "title"] as const;
 
+// The archived list backs an undo affordance, not an archive browser. Cap it so a
+// long-lived daemon never streams thousands of stale records to every client.
+const DEFAULT_ARCHIVED_WORKSPACES_LIMIT = 50;
+
 export function resolveWaitForFinishError(options: {
   status: "permission" | "error" | "idle";
   final: AgentSnapshotPayload | null;
@@ -2145,6 +2149,8 @@ export class Session {
         return this.handleWorkspaceRecoveryInspectRequest(msg);
       case "workspace.recovery.restore.request":
         return this.handleWorkspaceRecoveryRestoreRequest(msg);
+      case "workspace.archived.list.request":
+        return this.handleWorkspaceArchivedListRequest(msg);
       default:
         return undefined;
     }
@@ -2878,6 +2884,59 @@ export class Session {
       payload: {
         requestId: request.requestId,
         state,
+      },
+    });
+  }
+
+  /**
+   * Recently-archived workspaces, newest archive first. Deliberately not part of
+   * the workspace directory: these records are archived, so they must never reach
+   * the live descriptor map that drives project mode, switchers, or counts. The
+   * caller gets a flat capped list and nothing else.
+   *
+   * Workspaces whose owning project is archived are omitted — unarchiving one
+   * would surface a workspace under a project the user cannot see.
+   */
+  private async handleWorkspaceArchivedListRequest(
+    request: Extract<SessionInboundMessage, { type: "workspace.archived.list.request" }>,
+  ): Promise<void> {
+    const limit = request.limit ?? DEFAULT_ARCHIVED_WORKSPACES_LIMIT;
+    const [workspaces, projects] = await Promise.all([
+      this.workspaceRegistry.list(),
+      this.projectRegistry.list(),
+    ]);
+    const activeProjects = new Map(
+      projects
+        .filter((project) => !project.archivedAt)
+        .map((project) => [project.projectId, project] as const),
+    );
+
+    const entries = workspaces
+      .flatMap((workspace) => {
+        const archivedAt = workspace.archivedAt;
+        if (!archivedAt) return [];
+        const project = activeProjects.get(workspace.projectId);
+        if (!project) return [];
+        return [
+          {
+            id: workspace.workspaceId,
+            projectId: workspace.projectId,
+            projectDisplayName: resolveProjectDisplayName(project),
+            name: resolveWorkspaceDisplayName(workspace),
+            workspaceKind: workspace.kind,
+            workspaceDirectory: workspace.cwd,
+            archivedAt,
+          },
+        ];
+      })
+      .sort((left, right) => right.archivedAt.localeCompare(left.archivedAt))
+      .slice(0, limit);
+
+    this.emit({
+      type: "workspace.archived.list.response",
+      payload: {
+        requestId: request.requestId,
+        entries,
       },
     });
   }

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -8915,12 +8915,11 @@ test("workspace.archived.list returns archived workspaces newest first", async (
   expect(payload?.entries[0]).toMatchObject({
     name: "newest",
     projectDisplayName: "repo",
-    workspaceKind: "worktree",
     archivedAt: "2026-03-05T00:00:00.000Z",
   });
 });
 
-test("workspace.archived.list honors the requested limit", async () => {
+test("workspace.archived.list caps its response", async () => {
   const emitted: SessionOutboundMessage[] = [];
   const project = createPersistedProjectRecord({
     projectId: "prj_active",
@@ -8935,7 +8934,7 @@ test("workspace.archived.list honors the requested limit", async () => {
   const session = createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) });
   session.projectRegistry.list = async () => [project];
   session.workspaceRegistry.list = async () =>
-    ["01", "02", "03", "04"].map((day) =>
+    Array.from({ length: 30 }, (_, index) => String(index + 1).padStart(2, "0")).map((day) =>
       createPersistedWorkspaceRecord({
         workspaceId: `ws-${day}`,
         projectId: project.projectId,
@@ -8951,14 +8950,14 @@ test("workspace.archived.list honors the requested limit", async () => {
   await session.handleMessage({
     type: "workspace.archived.list.request",
     requestId: "req-archived-limit",
-    limit: 2,
   });
 
-  expect(
-    findByType(emitted, "workspace.archived.list.response")?.payload.entries.map(
-      (entry) => entry.id,
-    ),
-  ).toEqual(["ws-04", "ws-03"]);
+  const ids = findByType(emitted, "workspace.archived.list.response")?.payload.entries.map(
+    (entry) => entry.id,
+  );
+  expect(ids).toHaveLength(25);
+  expect(ids?.slice(0, 2)).toEqual(["ws-30", "ws-29"]);
+  expect(ids?.at(-1)).toBe("ws-06");
 });
 
 test("workspace.archived.list omits workspaces whose project is archived", async () => {

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -8871,3 +8871,127 @@ test("workspace.create.request reports an archived explicit project", async () =
     errorCode: "archived_project",
   });
 });
+
+test("workspace.archived.list returns archived workspaces newest first", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const project = createPersistedProjectRecord({
+    projectId: "prj_active",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "repo",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    archivedAt: null,
+  });
+  const makeWorkspace = (input: { id: string; name: string; archivedAt: string | null }) =>
+    createPersistedWorkspaceRecord({
+      workspaceId: input.id,
+      projectId: project.projectId,
+      cwd: path.join(REPO_CWD, input.id),
+      kind: "worktree",
+      displayName: input.name,
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+      archivedAt: input.archivedAt,
+    });
+
+  const session = createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) });
+  session.projectRegistry.list = async () => [project];
+  session.workspaceRegistry.list = async () => [
+    makeWorkspace({ id: "ws-old", name: "old", archivedAt: "2026-03-02T00:00:00.000Z" }),
+    makeWorkspace({ id: "ws-active", name: "active", archivedAt: null }),
+    makeWorkspace({ id: "ws-newest", name: "newest", archivedAt: "2026-03-05T00:00:00.000Z" }),
+    makeWorkspace({ id: "ws-middle", name: "middle", archivedAt: "2026-03-03T00:00:00.000Z" }),
+  ];
+
+  await session.handleMessage({
+    type: "workspace.archived.list.request",
+    requestId: "req-archived-list",
+  });
+
+  const payload = findByType(emitted, "workspace.archived.list.response")?.payload;
+  expect(payload?.requestId).toBe("req-archived-list");
+  expect(payload?.entries.map((entry) => entry.id)).toEqual(["ws-newest", "ws-middle", "ws-old"]);
+  expect(payload?.entries[0]).toMatchObject({
+    name: "newest",
+    projectDisplayName: "repo",
+    workspaceKind: "worktree",
+    archivedAt: "2026-03-05T00:00:00.000Z",
+  });
+});
+
+test("workspace.archived.list honors the requested limit", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const project = createPersistedProjectRecord({
+    projectId: "prj_active",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "repo",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    archivedAt: null,
+  });
+
+  const session = createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) });
+  session.projectRegistry.list = async () => [project];
+  session.workspaceRegistry.list = async () =>
+    ["01", "02", "03", "04"].map((day) =>
+      createPersistedWorkspaceRecord({
+        workspaceId: `ws-${day}`,
+        projectId: project.projectId,
+        cwd: path.join(REPO_CWD, day),
+        kind: "worktree",
+        displayName: `ws-${day}`,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+        archivedAt: `2026-03-${day}T00:00:00.000Z`,
+      }),
+    );
+
+  await session.handleMessage({
+    type: "workspace.archived.list.request",
+    requestId: "req-archived-limit",
+    limit: 2,
+  });
+
+  expect(
+    findByType(emitted, "workspace.archived.list.response")?.payload.entries.map(
+      (entry) => entry.id,
+    ),
+  ).toEqual(["ws-04", "ws-03"]);
+});
+
+test("workspace.archived.list omits workspaces whose project is archived", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const archivedProject = createPersistedProjectRecord({
+    projectId: "prj_archived",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "gone",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    archivedAt: "2026-03-02T00:00:00.000Z",
+  });
+
+  const session = createSessionForWorkspaceTests({ onMessage: (message) => emitted.push(message) });
+  session.projectRegistry.list = async () => [archivedProject];
+  session.workspaceRegistry.list = async () => [
+    createPersistedWorkspaceRecord({
+      workspaceId: "ws-in-archived-project",
+      projectId: archivedProject.projectId,
+      cwd: REPO_CWD,
+      kind: "worktree",
+      displayName: "orphan",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+      archivedAt: "2026-03-03T00:00:00.000Z",
+    }),
+  ];
+
+  await session.handleMessage({
+    type: "workspace.archived.list.request",
+    requestId: "req-archived-project-filter",
+  });
+
+  expect(findByType(emitted, "workspace.archived.list.response")?.payload.entries).toEqual([]);
+});

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1534,6 +1534,8 @@ export class VoiceAssistantWebSocketServer {
         worktreeRestore: true,
         // COMPAT(workspaceRecovery): added in v0.1.105, remove after 2027-01-11 once daemon floor >= v0.1.105.
         workspaceRecovery: true,
+        // COMPAT(archivedWorkspacesList): added in v0.2.0, remove gate after 2027-01-28.
+        archivedWorkspacesList: true,
         // COMPAT(workspaceFileEditing): added in v0.2.0, remove after 2027-01-18 once daemon floor >= v0.2.0.
         workspaceFileEditing: true,
         // COMPAT(providerUsageList): added in v0.1.98, drop the gate when daemon floor >= v0.1.98.


### PR DESCRIPTION
### Linked issue

Closes #2523

### Type of change

- [x] New feature (with prior issue + design alignment)

> Opened alongside the issue rather than after it, so there's something concrete to react to. If the answer is "not this, or not now," close it — no hard feelings.

### What does this PR do

Archiving a workspace from the sidebar is one click and easy to misfire. Getting back took a detour through History. Status mode now ends with a greyed-out **Recently archived** tail: the 5 most recent archives, newest first, each with an unarchive button.

The rows come from a new `workspace.archived.list` RPC, **not** the workspace directory. That split is the load-bearing decision here — everything reading the session store's workspace map (project mode, the switcher, status counts) treats a present descriptor as live, so archived workspaces must never land in it. They live only in the `archivedWorkspaces` query, which only status mode reads.

`archived` is deliberately **not** a status bucket. It stays out of `STATUS_BUCKET_ORDER` and out of the 1–9 shortcut index, since archived workspaces have no live status and nothing to navigate to. Clicking a row does nothing; unarchive is the only action, and it reuses `workspace.recovery.restore` so the daemon still decides between a plain unarchive and recreating a Paseo-owned worktree.

Gated on `server_info.features.archivedWorkspacesList`. Older daemons contribute no rows — no fallback path.

Bounds: the daemon caps at 50 and drops workspaces whose project is archived (unarchiving one would surface it under an invisible project); the client requests 25 per host and caps the merged list at 25; the UI shows 5 with show-more. No pagination or infinite scroll — History remains the full archive.

One refactor rides along: host-filter resolution moved into `resolveSidebarServerIds` so the tail and the workspace list can't disagree about which hosts are visible. Shared by both call sites rather than duplicated, and covered by new tests.

### How did you verify it

**Platform coverage is incomplete — this was developed and verified on Linux.**

| Platform | Status |
| --- | --- |
| Web (browser) | ✅ Verified, screenshots below |
| Web (compact/phone viewport) | ✅ Verified, screenshot below — real code path (`useIsCompactFormFactor`), but a narrow browser window, **not** a device |
| Desktop (Electron) | ❌ Not verified. Electron launches, but the desktop dev harness' managed-daemon handshake fails on my NixOS box (daemon binds, app polls `errored`). Unrelated to this change; I couldn't get past it. |
| iOS | ❌ Not possible for me — Linux only, no macOS/simulator |
| Android | ❌ Not verified — no emulator binary or SDK installed, no device attached |

Happy for someone with a Mac and a device to sanity-check the two mobile platforms. There is no platform-specific code in the new component — no `isWeb`/`isNative` branches and no `.web.tsx`/`.native.tsx` split — so the risk is layout/visual rather than functional.

Driven through a Chromium session against an isolated daemon (`PASEO_HOME=/tmp/...`, non-default port) seeded with two scratch git projects, 5 active workspaces, and 8 archived at staggered timestamps.

1. Switched grouping to Status. The tail renders after **Done**, newest-archive-first, showing 5 rows with **Show more**. The unarchive icon is visible at rest on every row:

![Recently archived tail](https://raw.githubusercontent.com/colonelpanic8/paseo/pr-assets-recently-archived/01-archived-tail.png)

2. Hovering a row lifts the icon out of its resting opacity:

![Hover](https://raw.githubusercontent.com/colonelpanic8/paseo/pr-assets-recently-archived/02-hover.png)

3. Clicked unarchive. The workspace left the tail and reappeared at the top of **Done**, and the daemon confirmed independently — `paseo workspace ls` listed it as an active worktree again:

![After unarchive](https://raw.githubusercontent.com/colonelpanic8/paseo/pr-assets-recently-archived/03-after-unarchive.png)

4. Same tail at a 390x844 phone viewport, sidebar as an overlay. The unarchive icon is visible on every row without hover — which is the point of keeping it out of a hover reveal, since touch has no hover:

![Compact layout](https://raw.githubusercontent.com/colonelpanic8/paseo/pr-assets-recently-archived/04-compact.png)

Also verified: archiving from the sidebar puts the workspace in the tail immediately (the shared archive path invalidates the query), and collapse state persists per group.

Automated: 3 new server tests (ordering, `limit`, archived-project exclusion), 4 for the cross-host merge (interleaving, unresolved hosts, tie-break stability, cap), 4 for `resolveSidebarServerIds`. Existing sidebar projection, status view-model, and i18n suites pass. `npm run typecheck`, `npm run lint`, `npm run format` all clean.

**Known gaps I'd rather flag than hide:**
- The tail refreshes on archive/unarchive *from the sidebar*. Unarchiving via the workspace route's recovery action or from another client leaves a stale row until the 30s stale time lapses.
- Every seeded workspace sat in `done`, so the tail's visual separation from a populated `needs_input`/`Working` list isn't stress-tested.
- Translations for the 7 non-English locales are machine-produced; the type requires full parity, so they had to be filled in. Worth a native check.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [ ] UI changes include screenshots or video for every affected platform — **web + compact only; desktop/iOS/Android unverified, see table above**
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)