### PR TITLE
Make composer character configurable, add pills for skills

### DIFF
--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -123,3 +123,16 @@ existing controlled plain-text path.
 Web keeps rendering through the plain textarea instead of the mirror when the draft has
 no token. `ComposerTokenHighlightLayer` takes an `enabled` prop and installs no
 observers in that common path.
+
+## Sent messages: canonical data, configured presentation
+
+Submitted and queued text use the provider-compatible `/name` form. Sent-message
+bubbles recover token type from position — a leading slash is a command and a slash
+after whitespace is a skill — then display the token with the current configured
+command or skill sigil. The copy action, rewind, persistence and provider history still
+use the canonical text; only the rendered `Text` spans change.
+
+Unlike the controlled composer input, a sent message can safely use nested React Native
+`Text` spans, so pills render on web, Electron, iOS and Android without a mirror layer.
+Changing trigger settings consequently updates the presentation of existing history
+without rewriting that history.

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -70,7 +70,7 @@ with pills. The textarea paints its own text transparent (`color: transparent` p
 selection, IME and the native context menu.
 
 **THE INVARIANT: the mirror must lay out character-for-character identically to the
-textarea.** Two consequences, both load-bearing:
+textarea.** Three consequences, all load-bearing:
 
 1. Every property affecting line breaking is _copied from the live textarea_ via
    `getComputedStyle` (`COPIED_STYLES`), not restated in a stylesheet. The composer's
@@ -79,12 +79,21 @@ textarea.** Two consequences, both load-bearing:
 2. **A pill may not change the advance width of the text it decorates.** Horizontal
    padding is cancelled by an equal negative margin, so the pill grows visually around
    the glyphs without moving them. Never change one without the other.
+3. **The display sigil is not as wide as the canonical slash it stands in for.** The UI
+   font is proportional — `$` runs 3.2px wider than `/` at the default size — so an
+   uncorrected substitution shifts every glyph after the token to the right, leaving the
+   caret behind the text it belongs to, and can wrap the mirror onto a line the textarea
+   does not have. `useSigilAdvanceCorrections` measures both characters inside the mirror
+   (the font is user-configurable, so a hardcoded table would be wrong) and hands the
+   difference back as margins, half on each side, keeping the sigil centred on the slot
+   the slash occupies. Only the sigil itself overhangs; every other glyph lands exactly
+   where the textarea puts it.
 
-Consequence (2) is why the pill replaces only the canonical slash with the configured
-one-character display sigil (`$release-beta`) rather than adding an icon or prettified
-display name — either would add width and desynchronise the wrap, putting the caret off
-the glyphs. Getting icons and display names on web means replacing the textarea with a
-contenteditable editor; it cannot be done with a mirror.
+Consequences (2) and (3) are why the pill shows the token text under a one-character
+sigil rather than an icon or a prettified display name: correcting a whole substituted
+string means squeezing glyphs, not nudging one. Getting icons and display names on web
+means replacing the textarea with a contenteditable editor; it cannot be done with a
+mirror.
 
 ### Colors
 
@@ -109,10 +118,12 @@ Two smaller details that are easy to lose:
 - A trailing newline collapses unless something follows it, which would shift the
   mirror's last line relative to the textarea's. Hence the zero-width span.
 
-To re-verify alignment after touching any of this: render the same string in both
-layers with the textarea's text a visible color instead of transparent. The two sets of
-glyphs must coincide exactly, and the wrap point must match, including when a token
-straddles the wrap boundary.
+`e2e/browser/composer-tokens.spec.ts` guards alignment by measuring the mirror's last
+line against a probe holding the canonical draft in the same inherited font. To check by
+eye after touching any of this: render the same string in both layers with the
+textarea's text a visible color instead of transparent. The two sets of glyphs must
+coincide exactly, and the wrap point must match, including when a token straddles the
+wrap boundary.
 
 ## Native: plain text by design
 

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -13,8 +13,9 @@ token is stored anywhere.
 ```
 
 `packages/app/src/composer/tokens/tokens.ts` owns this. `collectComposerTokens` finds
-tokens; `segmentComposerText` splits the draft into alternating plain/token segments
-covering the whole string, each carrying its source offset.
+token-shaped text and keeps only names present in the current command/skill catalog;
+`segmentComposerText` splits the draft into alternating plain/token segments covering
+the whole string, each carrying its source offset.
 
 Because text is still the only source of truth, drafts, dictation and undo need no
 parallel token state. Deleting the sigil deletes the pill. Submission runs that string
@@ -30,6 +31,9 @@ Detection rules:
 - A trigger glued to a preceding word is prose, and slash-delimited paths are not
   tokens. `40$usd` and `/tmp/project` therefore stay plain text.
 - A name is `[A-Za-z][A-Za-z0-9:_-]*`. A bare sigil with no name is not a token.
+- A syntactically valid name that is absent from the current command catalog is prose.
+  This is the safety boundary that keeps shell variables such as `$HOME` and `$project`
+  from being rendered as skills or rewritten on submission.
 
 ## Sigils are configurable
 
@@ -49,9 +53,10 @@ In the settings UI, picking the character the _other_ menu already uses swaps th
 rather than rejecting the choice.
 
 The sigils configure editing, not the provider protocol. Before a prompt is sent,
-recognized tokens are normalized to `/name`. Without that boundary, choosing `!` for
+recognized catalog entries are normalized to `/name`. If the catalog has not loaded,
+submission preserves the user's exact text. Without those boundaries, choosing `!` for
 commands would silently turn executable provider and client commands into ordinary
-prompt text.
+prompt text, while `$` could silently rewrite shell variables.
 
 ## Web: a mirror layer
 

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -29,8 +29,8 @@ Detection rules:
   explicitly commits the chosen command or skill to canonical slash syntax.
 - Enter or Tab commits the highlighted autocomplete option, regardless of which
   configured trigger opened the menu. The exception is a `$` trigger whose name follows
-  the conventional uppercase shell-variable shape: Enter submits it as text, while Tab
-  or a click explicitly commits the colliding skill.
+  the shell-variable identifier shape: Enter submits it as text, while Tab or a click
+  explicitly commits the colliding skill.
 - A leading canonical slash means a command; a canonical slash after whitespace means a
   skill. Slash-delimited paths are not tokens.
 - A slash glued to a preceding word is prose. `and/or` and `/tmp/project` therefore stay

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -1,7 +1,7 @@
 # Composer Tokens
 
-Command and skill names typed into the web composer render as pills. This note covers
-the model, the web renderer, and why native deliberately stays plain text.
+Commands and skills selected from composer autocomplete render as pills on web. This
+note covers the model, the web renderer, and why native deliberately stays plain text.
 
 ## The model: tokens are a view, never state
 
@@ -9,31 +9,32 @@ A token is re-derived from the composer's plain text on every render. Nothing ab
 token is stored anywhere.
 
 ```
-"please run $release-beta"  →  collectComposerTokens()  →  [{ type: "skill", name: "release-beta", start: 11, end: 24 }]
+"please run /release-beta"  →  collectComposerTokens()  →  [{ type: "skill", name: "release-beta", start: 11, end: 24 }]
 ```
 
 `packages/app/src/composer/tokens/tokens.ts` owns this. `collectComposerTokens` finds
-token-shaped text and keeps only names present in the current command/skill catalog;
-`segmentComposerText` splits the draft into alternating plain/token segments covering
-the whole string, each carrying its source offset.
+canonical slash-shaped text and keeps only names present in the current command/skill
+catalog; `segmentComposerText` splits the draft into alternating plain/token segments
+covering the whole string, each carrying its source offset.
 
 Because text is still the only source of truth, drafts, dictation and undo need no
-parallel token state. Deleting the sigil deletes the pill. Submission runs that string
-through `normalizeComposerTokensForSubmission()` once so configurable UI triggers use
-the canonical `/name` syntax understood by the daemon and providers. Queueing stores
-the normalized string. **Do not add a parallel token array to composer state.**
+parallel token state. Choosing an autocomplete option replaces the configured trigger
+with canonical `/name` syntax immediately. Submission and queueing send that exact
+string without another interpretation pass. **Do not add a parallel token array to
+composer state.**
 
 Detection rules:
 
-- The command trigger means a command only at the start of the prompt.
-- Either trigger means a skill after whitespace. This preserves inline `/skill`
-  completion while adding a dedicated skills trigger.
-- A trigger glued to a preceding word is prose, and slash-delimited paths are not
-  tokens. `40$usd` and `/tmp/project` therefore stay plain text.
+- Configured triggers open autocomplete but are not tokens by themselves. A selection
+  explicitly commits the chosen command or skill to canonical slash syntax.
+- A leading canonical slash means a command; a canonical slash after whitespace means a
+  skill. Slash-delimited paths are not tokens.
+- A slash glued to a preceding word is prose. `and/or` and `/tmp/project` therefore stay
+  plain text.
 - A name is `[A-Za-z][A-Za-z0-9:_-]*`. A bare sigil with no name is not a token.
 - A syntactically valid name that is absent from the current command catalog is prose.
-  This is the safety boundary that keeps shell variables such as `$HOME` and `$project`
-  from being rendered as skills or rewritten on submission.
+- Unselected text is never rewritten. `$HOME` remains `$HOME` even if the provider
+  exposes a skill named `HOME`; only choosing that autocomplete option commits `/HOME`.
 
 ## Sigils are configurable
 
@@ -52,11 +53,12 @@ more load-bearing of the two.
 In the settings UI, picking the character the _other_ menu already uses swaps the two
 rather than rejecting the choice.
 
-The sigils configure editing, not the provider protocol. Before a prompt is sent,
-recognized catalog entries are normalized to `/name`. If the catalog has not loaded,
-submission preserves the user's exact text. Without those boundaries, choosing `!` for
-commands would silently turn executable provider and client commands into ordinary
-prompt text, while `$` could silently rewrite shell variables.
+The sigils configure autocomplete and presentation, not the provider protocol. Choosing
+an option writes provider-compatible `/name` into the draft; the web mirror displays the
+active configured sigil over that one-character canonical prefix. If the catalog has not
+loaded, there is nothing to choose and submission preserves the user's exact text. This
+explicit selection boundary prevents a configured `$` from silently rewriting shell
+variables.
 
 ## Web: a mirror layer
 
@@ -76,12 +78,11 @@ textarea.** Two consequences, both load-bearing:
    padding is cancelled by an equal negative margin, so the pill grows visually around
    the glyphs without moving them. Never change one without the other.
 
-Consequence (2) is why the pill shows the literal draft text (`$release-beta`) rather
-than an icon plus a prettified display name — either would add width and desynchronise
-the wrap, putting the caret off the glyphs. Submission may canonicalize the leading
-sigil, but it never changes the token name. Getting icons and display names on web
-means replacing the textarea with a contenteditable editor; it cannot be done with a
-mirror.
+Consequence (2) is why the pill replaces only the canonical slash with the configured
+one-character display sigil (`$release-beta`) rather than adding an icon or prettified
+display name — either would add width and desynchronise the wrap, putting the caret off
+the glyphs. Getting icons and display names on web means replacing the textarea with a
+contenteditable editor; it cannot be done with a mirror.
 
 ### Colors
 
@@ -121,7 +122,8 @@ selection, dictation and external draft updates unreliable.
 A native mirror would also have to reproduce the input's font metrics, wrapping and
 scroll exactly to keep the caret on the glyphs. Native pills therefore require a real
 attributed-input implementation or custom text view. Until then, native keeps the
-existing controlled plain-text path.
+existing controlled plain-text path and shows the canonical slash after an autocomplete
+selection.
 
 ## The web renderer opts out when there is no token
 

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -27,9 +27,9 @@ Detection rules:
 
 - Configured triggers open autocomplete but are not tokens by themselves. A selection
   explicitly commits the chosen command or skill to canonical slash syntax.
-- Enter submits text that still contains a non-canonical configured trigger. Committing
-  that autocomplete option requires Tab or a click, so a shell variable cannot be
-  rewritten by the composer's submit key.
+- Enter or Tab commits the highlighted autocomplete option, regardless of which
+  configured trigger opened the menu. Plain text is preserved only when no option is
+  available to select.
 - A leading canonical slash means a command; a canonical slash after whitespace means a
   skill. Slash-delimited paths are not tokens.
 - A slash glued to a preceding word is prose. `and/or` and `/tmp/project` therefore stay
@@ -59,9 +59,7 @@ rather than rejecting the choice.
 The sigils configure autocomplete and presentation, not the provider protocol. Choosing
 an option writes provider-compatible `/name` into the draft; the web mirror displays the
 active configured sigil over that one-character canonical prefix. If the catalog has not
-loaded, there is nothing to choose and submission preserves the user's exact text. This
-explicit selection boundary prevents a configured `$` from silently rewriting shell
-variables.
+loaded, there is nothing to choose and submission preserves the user's exact text.
 
 ## Web: a mirror layer
 

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -28,8 +28,9 @@ Detection rules:
 - Configured triggers open autocomplete but are not tokens by themselves. A selection
   explicitly commits the chosen command or skill to canonical slash syntax.
 - Enter or Tab commits the highlighted autocomplete option, regardless of which
-  configured trigger opened the menu. Plain text is preserved only when no option is
-  available to select.
+  configured trigger opened the menu. The exception is a `$` trigger whose name follows
+  the conventional uppercase shell-variable shape: Enter submits it as text, while Tab
+  or a click explicitly commits the colliding skill.
 - A leading canonical slash means a command; a canonical slash after whitespace means a
   skill. Slash-delimited paths are not tokens.
 - A slash glued to a preceding word is prose. `and/or` and `/tmp/project` therefore stay

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -1,0 +1,125 @@
+# Composer Tokens
+
+Command and skill names typed into the web composer render as pills. This note covers
+the model, the web renderer, and why native deliberately stays plain text.
+
+## The model: tokens are a view, never state
+
+A token is re-derived from the composer's plain text on every render. Nothing about a
+token is stored anywhere.
+
+```
+"please run $release-beta"  →  collectComposerTokens()  →  [{ type: "skill", name: "release-beta", start: 11, end: 24 }]
+```
+
+`packages/app/src/composer/tokens/tokens.ts` owns this. `collectComposerTokens` finds
+tokens; `segmentComposerText` splits the draft into alternating plain/token segments
+covering the whole string, each carrying its source offset.
+
+Because text is still the only source of truth, drafts, dictation and undo need no
+parallel token state. Deleting the sigil deletes the pill. Submission runs that string
+through `normalizeComposerTokensForSubmission()` once so configurable UI triggers use
+the canonical `/name` syntax understood by the daemon and providers. Queueing stores
+the normalized string. **Do not add a parallel token array to composer state.**
+
+Detection rules:
+
+- The command trigger means a command only at the start of the prompt.
+- Either trigger means a skill after whitespace. This preserves inline `/skill`
+  completion while adding a dedicated skills trigger.
+- A trigger glued to a preceding word is prose, and slash-delimited paths are not
+  tokens. `40$usd` and `/tmp/project` therefore stay plain text.
+- A name is `[A-Za-z][A-Za-z0-9:_-]*`. A bare sigil with no name is not a token.
+
+## Sigils are configurable
+
+`packages/app/src/composer/tokens/sigils.ts`. Two settings — `commandTriggerSigil` and
+`skillTriggerSigil` — default to `/` and `$`. The choices are an allowlist
+(`COMPOSER_SIGIL_CHOICES`), not free text: a letter or digit would open the menu
+constantly, and `@` is reserved for file mentions.
+
+`resolveComposerSigils()` coerces a stored pair into a valid, collision-free one, and
+**every consumer must go through it** (or through `useComposerSigils()`, which wraps it)
+rather than reading the two settings directly. A stored pair can go stale — a choice
+removed from the allowlist, or two clients writing the same character — and the composer
+still needs a usable pair. On collision the command sigil wins because it is the older,
+more load-bearing of the two.
+
+In the settings UI, picking the character the _other_ menu already uses swaps the two
+rather than rejecting the choice.
+
+The sigils configure editing, not the provider protocol. Before a prompt is sent,
+recognized tokens are normalized to `/name`. Without that boundary, choosing `!` for
+commands would silently turn executable provider and client commands into ordinary
+prompt text.
+
+## Web: a mirror layer
+
+`token-highlight.web.tsx`. A div sits behind the `<textarea>` rendering the same string
+with pills. The textarea paints its own text transparent (`color: transparent` plus
+`caretColor`) so the mirror is what the user reads, while the textarea keeps the caret,
+selection, IME and the native context menu.
+
+**THE INVARIANT: the mirror must lay out character-for-character identically to the
+textarea.** Two consequences, both load-bearing:
+
+1. Every property affecting line breaking is _copied from the live textarea_ via
+   `getComputedStyle` (`COPIED_STYLES`), not restated in a stylesheet. The composer's
+   font size is user-configurable and its width changes with panel layout; a stylesheet
+   drifts, a copy cannot.
+2. **A pill may not change the advance width of the text it decorates.** Horizontal
+   padding is cancelled by an equal negative margin, so the pill grows visually around
+   the glyphs without moving them. Never change one without the other.
+
+Consequence (2) is why the pill shows the literal draft text (`$release-beta`) rather
+than an icon plus a prettified display name — either would add width and desynchronise
+the wrap, putting the caret off the glyphs. Submission may canonicalize the leading
+sigil, but it never changes the token name. Getting icons and display names on web
+means replacing the textarea with a contenteditable editor; it cannot be done with a
+mirror.
+
+### Colors
+
+Fill, border and text all derive from **`accentBright`**, not `accent`. `accent`
+(`#20744A`) is the dark fill green; a tint of it under foreground-colored text goes
+muddy on dark and harsh on light. `accentBright` is the theme's accent-as-text token —
+the same one markdown links use — and reads in both themes.
+
+Colors reach this component as props via `withUnistyles` (alternative 3 in
+[unistyles.md](unistyles.md)), because it draws raw DOM rather than `style`-tracked RN
+views. **Do not reach for `var(--colors-*)`:** nothing in Unistyles emits those
+variables. `install-web-scrollbar-styles.web.ts` still references
+`var(--colors-scrollbar-handle)`, which therefore resolves to nothing — treat that as a
+bug to fix, not a pattern to copy.
+
+Two smaller details that are easy to lose:
+
+- The textarea sits _above_ the mirror, so its selection rectangle would paint over the
+  mirror's glyphs. A translucent `::selection` (installed once, scoped to
+  `[data-composer-tokenized]`) lets them read through. Without it, selecting tokenised
+  text blanks it out.
+- A trailing newline collapses unless something follows it, which would shift the
+  mirror's last line relative to the textarea's. Hence the zero-width span.
+
+To re-verify alignment after touching any of this: render the same string in both
+layers with the textarea's text a visible color instead of transparent. The two sets of
+glyphs must coincide exactly, and the wrap point must match, including when a token
+straddles the wrap boundary.
+
+## Native: plain text by design
+
+`token-highlight.native.tsx` is intentionally a no-op. Android React Native throws when
+a `TextInput` receives both a controlled `value` and children; iOS ignores those
+children. Dropping `value` would sacrifice the controlled-input contract and make
+selection, dictation and external draft updates unreliable.
+
+A native mirror would also have to reproduce the input's font metrics, wrapping and
+scroll exactly to keep the caret on the glyphs. Native pills therefore require a real
+attributed-input implementation or custom text view. Until then, native keeps the
+existing controlled plain-text path.
+
+## The web renderer opts out when there is no token
+
+Web keeps rendering through the plain textarea instead of the mirror when the draft has
+no token. `ComposerTokenHighlightLayer` takes an `enabled` prop and installs no
+observers in that common path.

--- a/docs/composer-tokens.md
+++ b/docs/composer-tokens.md
@@ -27,6 +27,9 @@ Detection rules:
 
 - Configured triggers open autocomplete but are not tokens by themselves. A selection
   explicitly commits the chosen command or skill to canonical slash syntax.
+- Enter submits text that still contains a non-canonical configured trigger. Committing
+  that autocomplete option requires Tab or a click, so a shell variable cannot be
+  rewritten by the composer's submit key.
 - A leading canonical slash means a command; a canonical slash after whitespace means a
   skill. Slash-delimited paths are not tokens.
 - A slash glued to a preceding word is prose. `and/or` and `/tmp/project` therefore stay

--- a/packages/app/e2e/browser/composer-tokens.spec.ts
+++ b/packages/app/e2e/browser/composer-tokens.spec.ts
@@ -27,6 +27,46 @@ async function expectStoredSigils(
     .toEqual(expected);
 }
 
+/**
+ * The mirror has to lay out character-for-character like the textarea, or the
+ * caret drifts away from the glyphs it belongs to. The display sigil is not the
+ * same width as the canonical slash it stands in for, so assert the rendered
+ * pills end where the draft text would: measure the mirror's last line against a
+ * probe holding the canonical draft in the same inherited font.
+ */
+async function expectMirrorAlignedWithDraft(
+  page: import("@playwright/test").Page,
+  draft: string,
+): Promise<void> {
+  const drift = await page.locator("[data-composer-token-mirror]").evaluate((node, canonical) => {
+    const layer = (node as HTMLElement).firstElementChild as HTMLElement;
+    // The pill's vertical padding lifts its rect above the plain spans on the
+    // same line, so group rects into lines by proximity rather than equality.
+    const lastLineRight = (rects: DOMRect[]) => {
+      const bottom = Math.max(...rects.map((rect) => rect.bottom));
+      return Math.max(
+        ...rects.filter((rect) => bottom - rect.bottom < 8).map((rect) => rect.right),
+      );
+    };
+
+    const renderedRange = document.createRange();
+    renderedRange.selectNodeContents(layer);
+    const renderedRight = lastLineRight(Array.from(renderedRange.getClientRects()));
+
+    const probe = document.createElement("div");
+    probe.textContent = canonical;
+    layer.append(probe);
+    const probeRange = document.createRange();
+    probeRange.selectNodeContents(probe);
+    const probeRight = lastLineRight(Array.from(probeRange.getClientRects()));
+    probe.remove();
+
+    return renderedRight - probeRight;
+  }, draft);
+
+  expect(Math.abs(drift)).toBeLessThan(0.5);
+}
+
 test("composer token pills and trigger settings stay aligned", async ({
   page,
   withWorkspace,
@@ -56,6 +96,7 @@ test("composer token pills and trigger settings stay aligned", async ({
   const mirror = page.locator("[data-composer-token-mirror]");
   await expect(mirror).toBeVisible();
   await expect(mirror.getByText("$release-beta", { exact: true })).toBeVisible();
+  await expectMirrorAlignedWithDraft(page, "please run /release-beta ");
   await expect
     .poll(() => composer.evaluate((element) => getComputedStyle(element).color))
     .toBe("rgba(0, 0, 0, 0)");
@@ -97,6 +138,7 @@ test("composer token pills and trigger settings stay aligned", async ({
   await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
   await expect(mirror.getByText("!release-beta", { exact: true })).toBeVisible();
+  await expectMirrorAlignedWithDraft(page, "please run /release-beta ");
 
   await composer.fill("plain draft");
   await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");

--- a/packages/app/e2e/browser/composer-tokens.spec.ts
+++ b/packages/app/e2e/browser/composer-tokens.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "./fixtures";
-import { composerLocator } from "./helpers/composer";
-import { openSettings } from "./helpers/app";
-import { clickSettingsBackToWorkspace } from "./helpers/settings";
+import { test, expect } from "../support/fixtures";
+import { composerLocator } from "../support/helpers/composer";
+import { openSettings } from "../support/helpers/app";
+import { clickSettingsBackToWorkspace } from "../support/helpers/settings";
 
 const APP_SETTINGS_KEY = "@paseo:app-settings";
 
@@ -38,12 +38,17 @@ test("composer token pills and trigger settings stay aligned", async ({
   await composer.fill("check $HOME");
   await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");
   await expect(page.locator("[data-composer-token-mirror]")).toHaveCount(0);
+  const autocomplete = page.getByTestId("composer-autocomplete-popover");
+  await expect(autocomplete.getByText("$HOME", { exact: true }).first()).toBeVisible({
+    timeout: 30_000,
+  });
   await composer.press("Enter");
   const shellVariableMessage = page.getByTestId("user-message").last();
   await expect(shellVariableMessage).toContainText("check $HOME");
   await expect(shellVariableMessage).not.toContainText("check /HOME");
 
   await composer.fill("please run $release-beta");
+  await expect(autocomplete.getByText("$release-beta", { exact: true }).first()).toBeVisible();
   await composer.press("Enter");
   await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");

--- a/packages/app/e2e/composer-tokens.spec.ts
+++ b/packages/app/e2e/composer-tokens.spec.ts
@@ -35,12 +35,16 @@ test("composer token pills and trigger settings stay aligned", async ({
   await workspace.navigateTo();
 
   const composer = composerLocator(page);
-  await composer.fill("check $HOME and $project");
+  await composer.fill("check $HOME");
   await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");
   await expect(page.locator("[data-composer-token-mirror]")).toHaveCount(0);
+  await composer.press("Enter");
+  const shellVariableMessage = page.getByTestId("user-message").last();
+  await expect(shellVariableMessage).toContainText("check $HOME");
+  await expect(shellVariableMessage).not.toContainText("check /HOME");
 
   await composer.fill("please run $release-beta");
-  await composer.press("Enter");
+  await composer.press("Tab");
   await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
 
@@ -84,7 +88,7 @@ test("composer token pills and trigger settings stay aligned", async ({
 
   await clickSettingsBackToWorkspace(page);
   await composer.fill("please run !release-beta");
-  await composer.press("Enter");
+  await composer.press("Tab");
   await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
   await expect(mirror.getByText("!release-beta", { exact: true })).toBeVisible();
@@ -94,7 +98,7 @@ test("composer token pills and trigger settings stay aligned", async ({
   await expect(mirror).toHaveCount(0);
 
   await composer.fill("please run !release-beta");
-  await composer.press("Enter");
+  await composer.press("Tab");
   await expect(composer).toHaveValue("please run /release-beta ");
   await composer.press("Enter");
   const sentMessage = page.getByTestId("user-message").last();

--- a/packages/app/e2e/composer-tokens.spec.ts
+++ b/packages/app/e2e/composer-tokens.spec.ts
@@ -44,7 +44,7 @@ test("composer token pills and trigger settings stay aligned", async ({
   await expect(shellVariableMessage).not.toContainText("check /HOME");
 
   await composer.fill("please run $release-beta");
-  await composer.press("Tab");
+  await composer.press("Enter");
   await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
 
@@ -88,7 +88,7 @@ test("composer token pills and trigger settings stay aligned", async ({
 
   await clickSettingsBackToWorkspace(page);
   await composer.fill("please run !release-beta");
-  await composer.press("Tab");
+  await composer.press("Enter");
   await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
   await expect(mirror.getByText("!release-beta", { exact: true })).toBeVisible();

--- a/packages/app/e2e/composer-tokens.spec.ts
+++ b/packages/app/e2e/composer-tokens.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "./fixtures";
+import { composerLocator } from "./helpers/composer";
+import { openSettings } from "./helpers/app";
+import { clickSettingsBackToWorkspace } from "./helpers/settings";
+
+const APP_SETTINGS_KEY = "@paseo:app-settings";
+
+async function expectStoredSigils(
+  page: import("@playwright/test").Page,
+  expected: { command: string; skill: string },
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const raw = await page.evaluate((key) => localStorage.getItem(key), APP_SETTINGS_KEY);
+      if (!raw) {
+        return null;
+      }
+      const settings = JSON.parse(raw) as {
+        commandTriggerSigil?: string;
+        skillTriggerSigil?: string;
+      };
+      return {
+        command: settings.commandTriggerSigil,
+        skill: settings.skillTriggerSigil,
+      };
+    })
+    .toEqual(expected);
+}
+
+test("composer token pills and trigger settings stay aligned", async ({
+  page,
+  withWorkspace,
+}, testInfo) => {
+  const workspace = await withWorkspace({ prefix: "composer-tokens-" });
+  await workspace.navigateTo();
+
+  const composer = composerLocator(page);
+  await composer.fill("please run $release-beta");
+  await expect(composer).toHaveAttribute("data-composer-tokenized", "");
+
+  const mirror = page.locator("[data-composer-token-mirror]");
+  await expect(mirror).toBeVisible();
+  await expect(mirror.getByText("$release-beta", { exact: true })).toBeVisible();
+  await expect
+    .poll(() => composer.evaluate((element) => getComputedStyle(element).color))
+    .toBe("rgba(0, 0, 0, 0)");
+
+  const composerScreenshot = testInfo.outputPath("composer-token-pill.png");
+  await page
+    .getByTestId("message-input-root")
+    .filter({ visible: true })
+    .first()
+    .screenshot({ path: composerScreenshot });
+  await testInfo.attach("composer-token-pill", {
+    path: composerScreenshot,
+    contentType: "image/png",
+  });
+
+  await openSettings(page);
+  const commandTrigger = page.getByTestId("settings-command-trigger");
+  const skillTrigger = page.getByTestId("settings-skill-trigger");
+  await expect(commandTrigger).toBeVisible();
+  await expect(skillTrigger).toBeVisible();
+
+  await commandTrigger.getByRole("button", { name: "!", exact: true }).click();
+  await skillTrigger.getByRole("button", { name: "#", exact: true }).click();
+  await expectStoredSigils(page, { command: "!", skill: "#" });
+
+  await commandTrigger.getByRole("button", { name: "#", exact: true }).click();
+  await expectStoredSigils(page, { command: "#", skill: "!" });
+
+  const settingsScreenshot = testInfo.outputPath("composer-trigger-settings.png");
+  await commandTrigger.locator("xpath=..").screenshot({ path: settingsScreenshot });
+  await testInfo.attach("composer-trigger-settings", {
+    path: settingsScreenshot,
+    contentType: "image/png",
+  });
+
+  await clickSettingsBackToWorkspace(page);
+  await composer.fill("please run !release-beta");
+  await expect(composer).toHaveAttribute("data-composer-tokenized", "");
+  await expect(mirror.getByText("!release-beta", { exact: true })).toBeVisible();
+
+  await composer.fill("plain draft");
+  await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");
+  await expect(mirror).toHaveCount(0);
+
+  await expect(
+    page.locator("[data-nextjs-dialog], .vite-error-overlay, #webpack-dev-server-client-overlay"),
+  ).toHaveCount(0);
+});

--- a/packages/app/e2e/composer-tokens.spec.ts
+++ b/packages/app/e2e/composer-tokens.spec.ts
@@ -40,6 +40,8 @@ test("composer token pills and trigger settings stay aligned", async ({
   await expect(page.locator("[data-composer-token-mirror]")).toHaveCount(0);
 
   await composer.fill("please run $release-beta");
+  await composer.press("Enter");
+  await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
 
   const mirror = page.locator("[data-composer-token-mirror]");
@@ -82,6 +84,8 @@ test("composer token pills and trigger settings stay aligned", async ({
 
   await clickSettingsBackToWorkspace(page);
   await composer.fill("please run !release-beta");
+  await composer.press("Enter");
+  await expect(composer).toHaveValue("please run /release-beta ");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
   await expect(mirror.getByText("!release-beta", { exact: true })).toBeVisible();
 
@@ -89,7 +93,9 @@ test("composer token pills and trigger settings stay aligned", async ({
   await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");
   await expect(mirror).toHaveCount(0);
 
-  await composer.fill("please run !release-beta ");
+  await composer.fill("please run !release-beta");
+  await composer.press("Enter");
+  await expect(composer).toHaveValue("please run /release-beta ");
   await composer.press("Enter");
   const sentMessage = page.getByTestId("user-message").last();
   const sentToken = sentMessage.getByTestId("sent-message-token");

--- a/packages/app/e2e/composer-tokens.spec.ts
+++ b/packages/app/e2e/composer-tokens.spec.ts
@@ -35,6 +35,10 @@ test("composer token pills and trigger settings stay aligned", async ({
   await workspace.navigateTo();
 
   const composer = composerLocator(page);
+  await composer.fill("check $HOME and $project");
+  await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");
+  await expect(page.locator("[data-composer-token-mirror]")).toHaveCount(0);
+
   await composer.fill("please run $release-beta");
   await expect(composer).toHaveAttribute("data-composer-tokenized", "");
 
@@ -85,7 +89,7 @@ test("composer token pills and trigger settings stay aligned", async ({
   await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");
   await expect(mirror).toHaveCount(0);
 
-  await composer.fill("please run !release-beta");
+  await composer.fill("please run !release-beta ");
   await composer.press("Enter");
   const sentMessage = page.getByTestId("user-message").last();
   const sentToken = sentMessage.getByTestId("sent-message-token");

--- a/packages/app/e2e/composer-tokens.spec.ts
+++ b/packages/app/e2e/composer-tokens.spec.ts
@@ -85,6 +85,21 @@ test("composer token pills and trigger settings stay aligned", async ({
   await expect(composer).not.toHaveAttribute("data-composer-tokenized", "");
   await expect(mirror).toHaveCount(0);
 
+  await composer.fill("please run !release-beta");
+  await composer.press("Enter");
+  const sentMessage = page.getByTestId("user-message").last();
+  const sentToken = sentMessage.getByTestId("sent-message-token");
+  await expect(sentMessage).toBeVisible();
+  await expect(sentToken).toHaveText("!release-beta");
+  await expect(sentMessage).not.toContainText("/release-beta");
+
+  const sentMessageScreenshot = testInfo.outputPath("sent-message-token-pill.png");
+  await sentMessage.screenshot({ path: sentMessageScreenshot });
+  await testInfo.attach("sent-message-token-pill", {
+    path: sentMessageScreenshot,
+    contentType: "image/png",
+  });
+
   await expect(
     page.locator("[data-nextjs-dialog], .vite-error-overlay, #webpack-dev-server-client-overlay"),
   ).toHaveCount(0);

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -27,7 +27,7 @@ import { useMutation } from "@tanstack/react-query";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { Check, ChevronDown, X } from "lucide-react-native";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
-import { openExplorerSurface } from "@/workspace-tabs/explorer-surface";
+import { openExplorerSidebarView } from "@/workspace-tabs/explorer-sidebar";
 import {
   AssistantMessage,
   SpeakMessage,
@@ -51,6 +51,7 @@ import type {
 } from "@getpaseo/protocol/agent-types";
 import type { AgentScreenAgent } from "@/hooks/use-agent-screen-state-machine";
 import { useSessionStore } from "@/stores/session-store";
+import { useRevealedText } from "@/hooks/use-revealed-text";
 import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
 import { useLoadOlderAgentHistory } from "@/hooks/use-load-older-agent-history";
 import { useSettings } from "@/hooks/use-settings";
@@ -106,6 +107,9 @@ import type { Theme } from "@/styles/theme";
 import { recordRenderProfileReasons } from "@/utils/render-profiler";
 import { useRetainedPanelActive } from "@/components/retained-panel";
 import { useComposerSigils } from "@/composer/tokens/use-composer-sigils";
+import { useStreamHistoryWindow } from "./use-stream-history-window";
+import { PluginTimelineItemView, useInstalledTimelineTransform } from "@/plugins/timeline";
+import { projectPluginTimelineItems } from "@/plugins/timeline/projection";
 
 function renderLiveAuxiliaryNode(input: {
   pendingPermissions: ReactNode;
@@ -218,6 +222,22 @@ function renderListEmptyComponent(input: {
   );
 }
 
+// History rows sit inside FlatList cells that rerender on every data change (RN recreates each
+// CellRenderer with a fresh ref and, in a newest-first list, a shifted index). This boundary is
+// what stops that churn: a row renders again only when its stream item identity, its layout item
+// identity, or the renderer itself changes. Item identity is the revision signal the strategy
+// already uses (`useRevisedHistoryRows` clones items whose content or display state changed).
+const HistoryStreamRow = memo(function HistoryStreamRow({
+  layoutItem,
+  renderStreamItem,
+}: {
+  item: StreamItem;
+  layoutItem: StreamLayoutItem;
+  renderStreamItem: (layoutItem: StreamLayoutItem) => ReactNode;
+}) {
+  return <>{renderStreamItem(layoutItem)}</>;
+});
+
 function renderHistoryStreamItem(input: {
   item: StreamItem;
   layoutItemById: Map<string, StreamLayoutItem>;
@@ -227,7 +247,13 @@ function renderHistoryStreamItem(input: {
   if (!layoutItem) {
     return null;
   }
-  return input.renderStreamItem(layoutItem);
+  return (
+    <HistoryStreamRow
+      item={input.item}
+      layoutItem={layoutItem}
+      renderStreamItem={input.renderStreamItem}
+    />
+  );
 }
 
 function renderLiveHeadStreamItem(input: {
@@ -260,6 +286,8 @@ export interface AgentStreamViewProps {
   isAuthoritativeHistoryReady?: boolean;
   /** Tail space required by a transparent overlay rendered at the bottom edge. */
   bottomOverlayTailClearance?: number;
+  /** Bottom offset required for controls floating above that overlay. */
+  bottomOverlayControlClearance?: number;
   toast?: ToastApi | null;
   onOpenWorkspaceFile?: (request: WorkspaceFileOpenRequest) => void;
   readOnly?: boolean;
@@ -295,6 +323,10 @@ function useRetainedValue<T>(value: T, active: boolean): T {
 const EMPTY_PENDING_MESSAGE_SUBMISSIONS: readonly PendingMessageSubmission[] = [];
 const GROUPED_TOOL_CALL_DETAIL_MAX_HEIGHT = 200;
 
+function resolveBottomOverlayControlOffset(clearance: number | undefined): number {
+  return Math.max(16, clearance ?? 0);
+}
+
 const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamViewProps>(
   function AgentStreamView(
     {
@@ -309,6 +341,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       routeBottomAnchorRequest = null,
       isAuthoritativeHistoryReady = true,
       bottomOverlayTailClearance = 0,
+      bottomOverlayControlClearance,
       toast,
       onOpenWorkspaceFile,
       readOnly = false,
@@ -317,10 +350,10 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     ref,
   ) {
     const { t } = useTranslation();
+    const composerSigils = useComposerSigils();
     const autoExpandReasoning = useSettings((settings) => settings.autoExpandReasoning);
     const toolCallDetailLevel = useSettings((settings) => settings.toolCallDetailLevel);
     const chatOutlineEnabled = useSettings((settings) => settings.chatOutlineEnabled);
-    const composerSigils = useComposerSigils();
     const viewportRef = useRef<StreamViewportHandle | null>(null);
     const pendingClientMessageIds = useMemo(
       () => new Set(pendingMessageSubmissions.map((submission) => submission.clientMessageId)),
@@ -345,6 +378,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
     // Get serverId (fallback to agent's serverId if not provided)
     const resolvedServerId = serverId ?? context.serverId ?? "";
+    const transformTimelineItem = useInstalledTimelineTransform(resolvedServerId);
 
     const client = useSessionStore((state) => state.sessions[resolvedServerId]?.client ?? null);
     const sessionStreamHead = useSessionStore((state) =>
@@ -378,7 +412,12 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       agentId,
       toast,
     });
-    const { isLoadingOlder, hasOlder, progressKey, loadOlder } = historyPagination
+    const {
+      isLoadingOlder: remoteIsLoadingOlder,
+      hasOlder: remoteHasOlder,
+      progressKey: remoteProgressKey,
+      loadOlder: loadRemoteOlder,
+    } = historyPagination
       ? {
           isLoadingOlder: historyPagination.isLoadingOlder,
           hasOlder: historyPagination.hasOlder,
@@ -446,7 +485,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           setCurrentPath: false,
         });
 
-        openExplorerSurface({
+        openExplorerSidebarView({
           isCompact: isMobile,
           workspaceKey: buildWorkspaceTabPersistenceKey({
             serverId: resolvedServerId,
@@ -463,7 +502,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     );
 
     const handleToolCallOpenFile = useStableEvent((filePath: string) => {
-      handleInlinePathPress({ raw: filePath, path: filePath }, "side");
+      handleInlinePathPress({ raw: filePath, path: filePath }, "preferred");
     });
 
     const handleForkAssistantTurn: AssistantTurnForkHandler = useStableEvent(
@@ -522,22 +561,44 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
         toolCallDetailLevel,
       ],
     );
+    const projectedPlugins = useMemo(
+      () => ({
+        tail: projectPluginTimelineItems(projectedToolCalls.tail, transformTimelineItem),
+        head: projectPluginTimelineItems(projectedToolCalls.head, transformTimelineItem),
+      }),
+      [projectedToolCalls.head, projectedToolCalls.tail, transformTimelineItem],
+    );
+    const {
+      start: historyWindowStart,
+      hasLocalHistory,
+      revealLoadedHistory,
+      loadOlder,
+    } = useStreamHistoryWindow({
+      agentId,
+      items: projectedPlugins.tail,
+      loadRemoteOlder,
+    });
+    const isLoadingOlder = remoteIsLoadingOlder;
+    const hasOlder = hasLocalHistory || remoteHasOlder;
+    const progressKey = `${remoteProgressKey ?? "local"}:${historyWindowStart}`;
 
     const baseRenderModel = useMemo(() => {
       return buildAgentStreamRenderModel({
         isTurnActive,
         activeTurnStartedAt: effectiveTurnPresentation.startedAt,
-        tail: projectedToolCalls.tail,
-        head: projectedToolCalls.head,
+        tail: projectedPlugins.tail,
+        head: projectedPlugins.head,
         platform: isWeb ? "web" : "native",
         isMobileBreakpoint: isMobile,
+        historyStart: historyWindowStart,
       });
     }, [
       isMobile,
       isTurnActive,
-      projectedToolCalls.head,
-      projectedToolCalls.tail,
+      projectedPlugins.head,
+      projectedPlugins.tail,
       effectiveTurnPresentation.startedAt,
+      historyWindowStart,
     ]);
     const streamLayout = useMemo(
       () =>
@@ -559,6 +620,13 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const handleTimelineHistoryLoadError = useCallback(() => {
       toast?.error(t("agentStream.historyLoadFailed"));
     }, [t, toast]);
+    const visibleHistoryItemIds = useMemo(
+      () =>
+        new Set(
+          [...baseRenderModel.history, ...baseRenderModel.segments.liveHead].map((item) => item.id),
+        ),
+      [baseRenderModel.history, baseRenderModel.segments.liveHead],
+    );
     const chatOutline = useChatOutline({
       agentId,
       serverId: resolvedServerId,
@@ -568,6 +636,8 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       enabled: supportsChatOutline && chatOutlineEnabled,
       viewportRef,
       onJumpError: handleTimelineHistoryLoadError,
+      visibleItemIds: visibleHistoryItemIds,
+      revealLoadedItem: revealLoadedHistory,
     });
 
     useImperativeHandle(
@@ -690,15 +760,13 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const renderThoughtItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "thought" }>) => {
         return (
-          <ToolCallSlot
+          <ThoughtSlot
             itemId={item.id}
             onInlineDetailsExpandedChangeByItemId={setInlineDetailsExpanded}
-            toolName="thinking"
-            args={item.text}
-            status={item.status === "ready" ? "completed" : "executing"}
+            text={item.text}
+            status={item.status}
             isLastInSequence={layoutItem.isLastInToolSequence}
             defaultExpanded={autoExpandReasoning}
-            forceInline={autoExpandReasoning}
           />
         );
       },
@@ -762,9 +830,14 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       [context.cwd, setInlineDetailsExpanded, handleToolCallOpenFile],
     );
 
+    // Read through a stable event so live group updates do not change the renderer identity
+    // every tick; history hosts whose group changed are revised through `historyRowRevision`.
+    const getToolCallGroup = useStableEvent((hostId: string) =>
+      projectedToolCalls.groupsByHostId.get(hostId),
+    );
     const renderToolCallItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "tool_call" }>) => {
-        const group = projectedToolCalls.groupsByHostId.get(item.id);
+        const group = getToolCallGroup(item.id);
         if (!group) {
           return renderSingleToolCallItem(item, layoutItem.isLastInToolSequence);
         }
@@ -791,8 +864,8 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
         );
       },
       [
-        projectedToolCalls.groupsByHostId,
         expandedToolCallGroupIds,
+        getToolCallGroup,
         renderSingleToolCallItem,
         setToolCallGroupExpanded,
       ],
@@ -836,11 +909,23 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               />
             );
 
+          case "plugin":
+            return (
+              <PluginTimelineItemView agentId={agentId} item={item} serverId={resolvedServerId} />
+            );
+
           default:
             return null;
         }
       },
-      [renderUserMessageItem, renderAssistantMessageItem, renderThoughtItem, renderToolCallItem],
+      [
+        agentId,
+        renderUserMessageItem,
+        renderAssistantMessageItem,
+        renderThoughtItem,
+        renderToolCallItem,
+        resolvedServerId,
+      ],
     );
 
     const bottomTurnFooterHost = streamLayout.auxiliaryTurnFooter;
@@ -914,6 +999,13 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     }, [baseRenderModel, pendingPermissionsNode, turnFooterNode]);
 
     const emptyStateStyle = useMemo(() => [stylesheet.emptyState, stylesheet.contentWrapper], []);
+    const scrollToBottomContainerStyle = useMemo(
+      () => [
+        stylesheet.scrollToBottomContainer,
+        { bottom: resolveBottomOverlayControlOffset(bottomOverlayControlClearance) },
+      ],
+      [bottomOverlayControlClearance],
+    );
     const listEmptyComponent = useMemo(
       () =>
         renderListEmptyComponent({
@@ -1045,7 +1137,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             onJumpToPrompt={chatOutline.jumpToPrompt}
           />
           {(!isNearBottom || isTimelineDetached) && (
-            <View style={stylesheet.scrollToBottomContainer} pointerEvents="box-none">
+            <View style={scrollToBottomContainerStyle} pointerEvents="box-none">
               <Animated.View entering={scrollIndicatorFadeIn} exiting={scrollIndicatorFadeOut}>
                 <Pressable
                   style={stylesheet.scrollToBottomButton}
@@ -1194,6 +1286,39 @@ interface ToolCallSlotProps extends Omit<
 > {
   itemId: string;
   onInlineDetailsExpandedChangeByItemId: (itemId: string, expanded: boolean) => void;
+}
+
+interface ThoughtSlotProps {
+  itemId: string;
+  onInlineDetailsExpandedChangeByItemId: (itemId: string, expanded: boolean) => void;
+  text: string;
+  status: Extract<StreamItem, { kind: "thought" }>["status"];
+  isLastInSequence: boolean;
+  defaultExpanded: boolean;
+}
+
+// Reasoning text is paced the same way assistant text is; see @/hooks/use-revealed-text.
+function ThoughtSlot({
+  itemId,
+  onInlineDetailsExpandedChangeByItemId,
+  text,
+  status,
+  isLastInSequence,
+  defaultExpanded,
+}: ThoughtSlotProps) {
+  const revealedText = useRevealedText(text, status === "ready" ? "complete" : "streaming");
+  return (
+    <ToolCallSlot
+      itemId={itemId}
+      onInlineDetailsExpandedChangeByItemId={onInlineDetailsExpandedChangeByItemId}
+      toolName="thinking"
+      args={revealedText}
+      status={status === "ready" ? "completed" : "executing"}
+      isLastInSequence={isLastInSequence}
+      defaultExpanded={defaultExpanded}
+      forceInline={defaultExpanded}
+    />
+  );
 }
 
 function ToolCallSlot({
@@ -1554,7 +1679,6 @@ const stylesheet = StyleSheet.create((theme) => ({
   },
   scrollToBottomContainer: {
     position: "absolute",
-    bottom: 16,
     left: 0,
     right: 0,
     alignItems: "center",

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -27,7 +27,7 @@ import { useMutation } from "@tanstack/react-query";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { Check, ChevronDown, X } from "lucide-react-native";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
-import { openExplorerSidebarView } from "@/workspace-tabs/explorer-sidebar";
+import { openExplorerSurface } from "@/workspace-tabs/explorer-surface";
 import {
   AssistantMessage,
   SpeakMessage,
@@ -51,7 +51,6 @@ import type {
 } from "@getpaseo/protocol/agent-types";
 import type { AgentScreenAgent } from "@/hooks/use-agent-screen-state-machine";
 import { useSessionStore } from "@/stores/session-store";
-import { useRevealedText } from "@/hooks/use-revealed-text";
 import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
 import { useLoadOlderAgentHistory } from "@/hooks/use-load-older-agent-history";
 import { useSettings } from "@/hooks/use-settings";
@@ -106,9 +105,7 @@ import { isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
 import { recordRenderProfileReasons } from "@/utils/render-profiler";
 import { useRetainedPanelActive } from "@/components/retained-panel";
-import { useStreamHistoryWindow } from "./use-stream-history-window";
-import { PluginTimelineItemView, useInstalledTimelineTransform } from "@/plugins/timeline";
-import { projectPluginTimelineItems } from "@/plugins/timeline/projection";
+import { useComposerSigils } from "@/composer/tokens/use-composer-sigils";
 
 function renderLiveAuxiliaryNode(input: {
   pendingPermissions: ReactNode;
@@ -221,22 +218,6 @@ function renderListEmptyComponent(input: {
   );
 }
 
-// History rows sit inside FlatList cells that rerender on every data change (RN recreates each
-// CellRenderer with a fresh ref and, in a newest-first list, a shifted index). This boundary is
-// what stops that churn: a row renders again only when its stream item identity, its layout item
-// identity, or the renderer itself changes. Item identity is the revision signal the strategy
-// already uses (`useRevisedHistoryRows` clones items whose content or display state changed).
-const HistoryStreamRow = memo(function HistoryStreamRow({
-  layoutItem,
-  renderStreamItem,
-}: {
-  item: StreamItem;
-  layoutItem: StreamLayoutItem;
-  renderStreamItem: (layoutItem: StreamLayoutItem) => ReactNode;
-}) {
-  return <>{renderStreamItem(layoutItem)}</>;
-});
-
 function renderHistoryStreamItem(input: {
   item: StreamItem;
   layoutItemById: Map<string, StreamLayoutItem>;
@@ -246,13 +227,7 @@ function renderHistoryStreamItem(input: {
   if (!layoutItem) {
     return null;
   }
-  return (
-    <HistoryStreamRow
-      item={input.item}
-      layoutItem={layoutItem}
-      renderStreamItem={input.renderStreamItem}
-    />
-  );
+  return input.renderStreamItem(layoutItem);
 }
 
 function renderLiveHeadStreamItem(input: {
@@ -285,8 +260,6 @@ export interface AgentStreamViewProps {
   isAuthoritativeHistoryReady?: boolean;
   /** Tail space required by a transparent overlay rendered at the bottom edge. */
   bottomOverlayTailClearance?: number;
-  /** Bottom offset required for controls floating above that overlay. */
-  bottomOverlayControlClearance?: number;
   toast?: ToastApi | null;
   onOpenWorkspaceFile?: (request: WorkspaceFileOpenRequest) => void;
   readOnly?: boolean;
@@ -322,10 +295,6 @@ function useRetainedValue<T>(value: T, active: boolean): T {
 const EMPTY_PENDING_MESSAGE_SUBMISSIONS: readonly PendingMessageSubmission[] = [];
 const GROUPED_TOOL_CALL_DETAIL_MAX_HEIGHT = 200;
 
-function resolveBottomOverlayControlOffset(clearance: number | undefined): number {
-  return Math.max(16, clearance ?? 0);
-}
-
 const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamViewProps>(
   function AgentStreamView(
     {
@@ -340,7 +309,6 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       routeBottomAnchorRequest = null,
       isAuthoritativeHistoryReady = true,
       bottomOverlayTailClearance = 0,
-      bottomOverlayControlClearance,
       toast,
       onOpenWorkspaceFile,
       readOnly = false,
@@ -352,6 +320,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const autoExpandReasoning = useSettings((settings) => settings.autoExpandReasoning);
     const toolCallDetailLevel = useSettings((settings) => settings.toolCallDetailLevel);
     const chatOutlineEnabled = useSettings((settings) => settings.chatOutlineEnabled);
+    const composerSigils = useComposerSigils();
     const viewportRef = useRef<StreamViewportHandle | null>(null);
     const pendingClientMessageIds = useMemo(
       () => new Set(pendingMessageSubmissions.map((submission) => submission.clientMessageId)),
@@ -376,7 +345,6 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
     // Get serverId (fallback to agent's serverId if not provided)
     const resolvedServerId = serverId ?? context.serverId ?? "";
-    const transformTimelineItem = useInstalledTimelineTransform(resolvedServerId);
 
     const client = useSessionStore((state) => state.sessions[resolvedServerId]?.client ?? null);
     const sessionStreamHead = useSessionStore((state) =>
@@ -410,12 +378,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       agentId,
       toast,
     });
-    const {
-      isLoadingOlder: remoteIsLoadingOlder,
-      hasOlder: remoteHasOlder,
-      progressKey: remoteProgressKey,
-      loadOlder: loadRemoteOlder,
-    } = historyPagination
+    const { isLoadingOlder, hasOlder, progressKey, loadOlder } = historyPagination
       ? {
           isLoadingOlder: historyPagination.isLoadingOlder,
           hasOlder: historyPagination.hasOlder,
@@ -483,7 +446,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           setCurrentPath: false,
         });
 
-        openExplorerSidebarView({
+        openExplorerSurface({
           isCompact: isMobile,
           workspaceKey: buildWorkspaceTabPersistenceKey({
             serverId: resolvedServerId,
@@ -500,7 +463,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     );
 
     const handleToolCallOpenFile = useStableEvent((filePath: string) => {
-      handleInlinePathPress({ raw: filePath, path: filePath }, "preferred");
+      handleInlinePathPress({ raw: filePath, path: filePath }, "side");
     });
 
     const handleForkAssistantTurn: AssistantTurnForkHandler = useStableEvent(
@@ -559,44 +522,22 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
         toolCallDetailLevel,
       ],
     );
-    const projectedPlugins = useMemo(
-      () => ({
-        tail: projectPluginTimelineItems(projectedToolCalls.tail, transformTimelineItem),
-        head: projectPluginTimelineItems(projectedToolCalls.head, transformTimelineItem),
-      }),
-      [projectedToolCalls.head, projectedToolCalls.tail, transformTimelineItem],
-    );
-    const {
-      start: historyWindowStart,
-      hasLocalHistory,
-      revealLoadedHistory,
-      loadOlder,
-    } = useStreamHistoryWindow({
-      agentId,
-      items: projectedPlugins.tail,
-      loadRemoteOlder,
-    });
-    const isLoadingOlder = remoteIsLoadingOlder;
-    const hasOlder = hasLocalHistory || remoteHasOlder;
-    const progressKey = `${remoteProgressKey ?? "local"}:${historyWindowStart}`;
 
     const baseRenderModel = useMemo(() => {
       return buildAgentStreamRenderModel({
         isTurnActive,
         activeTurnStartedAt: effectiveTurnPresentation.startedAt,
-        tail: projectedPlugins.tail,
-        head: projectedPlugins.head,
+        tail: projectedToolCalls.tail,
+        head: projectedToolCalls.head,
         platform: isWeb ? "web" : "native",
         isMobileBreakpoint: isMobile,
-        historyStart: historyWindowStart,
       });
     }, [
       isMobile,
       isTurnActive,
-      projectedPlugins.head,
-      projectedPlugins.tail,
+      projectedToolCalls.head,
+      projectedToolCalls.tail,
       effectiveTurnPresentation.startedAt,
-      historyWindowStart,
     ]);
     const streamLayout = useMemo(
       () =>
@@ -618,13 +559,6 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const handleTimelineHistoryLoadError = useCallback(() => {
       toast?.error(t("agentStream.historyLoadFailed"));
     }, [t, toast]);
-    const visibleHistoryItemIds = useMemo(
-      () =>
-        new Set(
-          [...baseRenderModel.history, ...baseRenderModel.segments.liveHead].map((item) => item.id),
-        ),
-      [baseRenderModel.history, baseRenderModel.segments.liveHead],
-    );
     const chatOutline = useChatOutline({
       agentId,
       serverId: resolvedServerId,
@@ -634,8 +568,6 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       enabled: supportsChatOutline && chatOutlineEnabled,
       viewportRef,
       onJumpError: handleTimelineHistoryLoadError,
-      visibleItemIds: visibleHistoryItemIds,
-      revealLoadedItem: revealLoadedHistory,
     });
 
     useImperativeHandle(
@@ -704,6 +636,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             agentId={agentId}
             messageId={item.messageId}
             message={item.text}
+            sigils={composerSigils}
             images={item.images}
             attachments={item.attachments}
             timestamp={item.timestamp.getTime()}
@@ -718,7 +651,14 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           />
         );
       },
-      [context.capabilities, agentId, client, pendingClientMessageIds, resolvedServerId],
+      [
+        context.capabilities,
+        agentId,
+        client,
+        composerSigils,
+        pendingClientMessageIds,
+        resolvedServerId,
+      ],
     );
 
     const renderAssistantMessageItem = useCallback(
@@ -750,13 +690,15 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const renderThoughtItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "thought" }>) => {
         return (
-          <ThoughtSlot
+          <ToolCallSlot
             itemId={item.id}
             onInlineDetailsExpandedChangeByItemId={setInlineDetailsExpanded}
-            text={item.text}
-            status={item.status}
+            toolName="thinking"
+            args={item.text}
+            status={item.status === "ready" ? "completed" : "executing"}
             isLastInSequence={layoutItem.isLastInToolSequence}
             defaultExpanded={autoExpandReasoning}
+            forceInline={autoExpandReasoning}
           />
         );
       },
@@ -820,14 +762,9 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       [context.cwd, setInlineDetailsExpanded, handleToolCallOpenFile],
     );
 
-    // Read through a stable event so live group updates do not change the renderer identity
-    // every tick; history hosts whose group changed are revised through `historyRowRevision`.
-    const getToolCallGroup = useStableEvent((hostId: string) =>
-      projectedToolCalls.groupsByHostId.get(hostId),
-    );
     const renderToolCallItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "tool_call" }>) => {
-        const group = getToolCallGroup(item.id);
+        const group = projectedToolCalls.groupsByHostId.get(item.id);
         if (!group) {
           return renderSingleToolCallItem(item, layoutItem.isLastInToolSequence);
         }
@@ -854,8 +791,8 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
         );
       },
       [
+        projectedToolCalls.groupsByHostId,
         expandedToolCallGroupIds,
-        getToolCallGroup,
         renderSingleToolCallItem,
         setToolCallGroupExpanded,
       ],
@@ -899,23 +836,11 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               />
             );
 
-          case "plugin":
-            return (
-              <PluginTimelineItemView agentId={agentId} item={item} serverId={resolvedServerId} />
-            );
-
           default:
             return null;
         }
       },
-      [
-        agentId,
-        renderUserMessageItem,
-        renderAssistantMessageItem,
-        renderThoughtItem,
-        renderToolCallItem,
-        resolvedServerId,
-      ],
+      [renderUserMessageItem, renderAssistantMessageItem, renderThoughtItem, renderToolCallItem],
     );
 
     const bottomTurnFooterHost = streamLayout.auxiliaryTurnFooter;
@@ -989,13 +914,6 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     }, [baseRenderModel, pendingPermissionsNode, turnFooterNode]);
 
     const emptyStateStyle = useMemo(() => [stylesheet.emptyState, stylesheet.contentWrapper], []);
-    const scrollToBottomContainerStyle = useMemo(
-      () => [
-        stylesheet.scrollToBottomContainer,
-        { bottom: resolveBottomOverlayControlOffset(bottomOverlayControlClearance) },
-      ],
-      [bottomOverlayControlClearance],
-    );
     const listEmptyComponent = useMemo(
       () =>
         renderListEmptyComponent({
@@ -1127,7 +1045,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             onJumpToPrompt={chatOutline.jumpToPrompt}
           />
           {(!isNearBottom || isTimelineDetached) && (
-            <View style={scrollToBottomContainerStyle} pointerEvents="box-none">
+            <View style={stylesheet.scrollToBottomContainer} pointerEvents="box-none">
               <Animated.View entering={scrollIndicatorFadeIn} exiting={scrollIndicatorFadeOut}>
                 <Pressable
                   style={stylesheet.scrollToBottomButton}
@@ -1276,39 +1194,6 @@ interface ToolCallSlotProps extends Omit<
 > {
   itemId: string;
   onInlineDetailsExpandedChangeByItemId: (itemId: string, expanded: boolean) => void;
-}
-
-interface ThoughtSlotProps {
-  itemId: string;
-  onInlineDetailsExpandedChangeByItemId: (itemId: string, expanded: boolean) => void;
-  text: string;
-  status: Extract<StreamItem, { kind: "thought" }>["status"];
-  isLastInSequence: boolean;
-  defaultExpanded: boolean;
-}
-
-// Reasoning text is paced the same way assistant text is; see @/hooks/use-revealed-text.
-function ThoughtSlot({
-  itemId,
-  onInlineDetailsExpandedChangeByItemId,
-  text,
-  status,
-  isLastInSequence,
-  defaultExpanded,
-}: ThoughtSlotProps) {
-  const revealedText = useRevealedText(text, status === "ready" ? "complete" : "streaming");
-  return (
-    <ToolCallSlot
-      itemId={itemId}
-      onInlineDetailsExpandedChangeByItemId={onInlineDetailsExpandedChangeByItemId}
-      toolName="thinking"
-      args={revealedText}
-      status={status === "ready" ? "completed" : "executing"}
-      isLastInSequence={isLastInSequence}
-      defaultExpanded={defaultExpanded}
-      forceInline={defaultExpanded}
-    />
-  );
 }
 
 function ToolCallSlot({
@@ -1669,6 +1554,7 @@ const stylesheet = StyleSheet.create((theme) => ({
   },
   scrollToBottomContainer: {
     position: "absolute",
+    bottom: 16,
     left: 0,
     right: 0,
     alignItems: "center",

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -97,6 +97,8 @@ import {
 } from "@/assistant-file-links";
 import { getCompactionMarkerLabel } from "./message-compaction-label";
 import { useAssistantImage } from "@/assistant-image/use-assistant-image";
+import { SentComposerTokenText } from "@/composer/tokens/sent-text";
+import type { ComposerSigils } from "@/composer/tokens/sigils";
 import {
   AttachmentFrame,
   AttachmentLabel,
@@ -125,6 +127,7 @@ interface UserMessageProps {
   agentId?: string;
   messageId?: string;
   message: string;
+  sigils: ComposerSigils;
   images?: UserMessageImageAttachment[];
   attachments?: AgentAttachment[];
   timestamp: number;
@@ -426,6 +429,7 @@ export const UserMessage = memo(function UserMessage({
   agentId,
   messageId,
   message,
+  sigils,
   images = [],
   attachments = [],
   timestamp,
@@ -540,9 +544,11 @@ export const UserMessage = memo(function UserMessage({
             </View>
           ) : null}
           {hasText ? (
-            <Text selectable style={userMessageStylesheet.text}>
-              {message}
-            </Text>
+            <SentComposerTokenText
+              text={message}
+              sigils={sigils}
+              style={userMessageStylesheet.text}
+            />
           ) : null}
         </View>
         {hasText ? (

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -104,7 +104,6 @@ import { submitAgentInput } from "@/composer/submit";
 import { createMessageSubmissionWriter } from "@/composer/submission/writer";
 import { ComposerKeyboardScopeProvider, useComposerKeyboardScope } from "@/composer/keyboard-scope";
 import { useComposerSigils } from "@/composer/tokens/use-composer-sigils";
-import { normalizeComposerTokensForSubmission } from "@/composer/tokens/tokens";
 import { useAppSettings } from "@/hooks/use-settings";
 import { RenderProfile } from "@/utils/render-profiler";
 import { AfterPaintPublication } from "@/composer/after-paint-publication";
@@ -1577,13 +1576,8 @@ function ComposerContentImpl({
   const handleSubmit = useCallback(
     (payload: MessagePayload) => {
       const outgoingAttachments = buildOutgoingAttachments(attachments);
-      const submissionText = normalizeComposerTokensForSubmission(
-        payload.text,
-        composerSigils,
-        autocomplete.tokenCatalog,
-      );
       const clientSlashCommand = resolveClientSlashCommand({
-        text: submissionText,
+        text: payload.text,
         hasAttachments: outgoingAttachments.length > 0,
       });
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
@@ -1593,14 +1587,12 @@ function ComposerContentImpl({
       if (blurOnSubmit) {
         messageInputRef.current?.blur();
       }
-      void sendMessageWithContent(submissionText, outgoingAttachments, payload.forceSend);
+      void sendMessageWithContent(payload.text, outgoingAttachments, payload.forceSend);
     },
     [
       attachments,
       blurOnSubmit,
       buildOutgoingAttachments,
-      composerSigils,
-      autocomplete.tokenCatalog,
       runClientSlashCommand,
       sendMessageWithContent,
     ],
@@ -1844,28 +1836,16 @@ function ComposerContentImpl({
   const handleQueue = useCallback(
     (payload: MessagePayload) => {
       const outgoingAttachments = buildOutgoingAttachments(attachments);
-      const submissionText = normalizeComposerTokensForSubmission(
-        payload.text,
-        composerSigils,
-        autocomplete.tokenCatalog,
-      );
       const clientSlashCommand = resolveClientSlashCommand({
-        text: submissionText,
+        text: payload.text,
         hasAttachments: outgoingAttachments.length > 0,
       });
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
-      queueMessage(submissionText, outgoingAttachments);
+      queueMessage(payload.text, outgoingAttachments);
     },
-    [
-      attachments,
-      autocomplete.tokenCatalog,
-      buildOutgoingAttachments,
-      composerSigils,
-      queueMessage,
-      runClientSlashCommand,
-    ],
+    [attachments, buildOutgoingAttachments, queueMessage, runClientSlashCommand],
   );
 
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -53,7 +53,7 @@ import {
   type ComposerKeyPressEvent,
   type MessageInputRef,
 } from "./input/input";
-import type { ImageAttachment, MessagePayload, TextReplacement } from "./types";
+import type { ImageAttachment, MessagePayload } from "./types";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
 import { encodeImages } from "@/utils/encode-images";
@@ -62,14 +62,14 @@ import {
   cancelComposerAgent,
   dispatchComposerAgentMessage,
   editQueuedComposerMessage,
-  findForgeItemByOption,
-  isAttachmentSelectedForForgeItem,
+  findGithubItemByOption,
+  isAttachmentSelectedForGithubItem,
   openComposerAttachment,
   pickAndPersistImages,
   queueComposerMessage,
   removeComposerAttachmentAtIndex,
   sendQueuedComposerMessageNow,
-  toggleForgeAttachmentFromPicker,
+  toggleGithubAttachmentFromPicker,
   uploadFileAttachments,
   type AttachmentPersister,
   type QueueWriter,
@@ -83,11 +83,6 @@ import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { AutocompletePopover } from "@/components/ui/autocomplete-popover";
 import type { AutocompleteOption } from "@/components/ui/autocomplete";
 import { useAgentAutocomplete } from "@/hooks/use-agent-autocomplete";
-import { usePluginClientSlashCommands } from "@/plugins/client-slash-commands";
-import {
-  executePluginClientSlashCommand,
-  resolvePluginClientSlashCommand,
-} from "@/plugins/client-slash-commands/model";
 import {
   useHostRuntimeAgentDirectoryStatus,
   useHostRuntimeClient,
@@ -108,6 +103,8 @@ import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
 import { submitAgentInput } from "@/composer/submit";
 import { createMessageSubmissionWriter } from "@/composer/submission/writer";
 import { ComposerKeyboardScopeProvider, useComposerKeyboardScope } from "@/composer/keyboard-scope";
+import { useComposerSigils } from "@/composer/tokens/use-composer-sigils";
+import { normalizeComposerTokensForSubmission } from "@/composer/tokens/tokens";
 import { useAppSettings } from "@/hooks/use-settings";
 import { RenderProfile } from "@/utils/render-profiler";
 import { AfterPaintPublication } from "@/composer/after-paint-publication";
@@ -128,7 +125,7 @@ import { droppedItemsToPickedFiles } from "@/composer/attachments/drop";
 import { getFileTypeLabel } from "@/attachments/file-types";
 import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
 import { AttachmentLabel, AttachmentPill, AttachmentThumbnail } from "@/components/attachment-pill";
-import { AttachmentLightbox, type ImageLightboxSource } from "@/components/attachment-lightbox";
+import { AttachmentLightbox } from "@/components/attachment-lightbox";
 import { openExternalUrl } from "@/utils/open-external-url";
 import { useIsDictationReady } from "@/hooks/use-is-dictation-ready";
 import { useForgeSearchQuery } from "@/git/use-forge-search-query";
@@ -136,7 +133,7 @@ import { useCheckoutStatusQuery } from "@/git/use-status-query";
 import { useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
 import { getForgePresentation } from "@/git/forge";
 import { ForgeBrandIcon } from "@/git/forge-icon";
-import { useComposerForgeAutoAttach } from "./forge-auto-attach";
+import { useComposerGithubAutoAttach } from "./github/auto-attach";
 import { readClipboardImage } from "./clipboard-image";
 import { normalizeNativePastedImages, type NativePastedFile } from "./native-pasted-image";
 import { PluginResourceAttachmentPill, usePluginAttachmentPicker } from "@/plugins";
@@ -928,20 +925,20 @@ interface ComposerProps {
   submitIcon?: "arrow" | "return";
   /** Externally controlled loading state. When true, disables the submit button. */
   isSubmitLoading?: boolean;
-  /** When true, waits for pasted forge links to resolve before enabling submit. */
-  waitForForgeAutoAttachOnSubmit?: boolean;
+  /** When true, waits for pasted GitHub links to resolve before enabling submit. */
+  waitForGithubAutoAttachOnSubmit?: boolean;
   submitBehavior?: "clear" | "preserve-and-lock";
   /** When true, blurs the input immediately when submitting. */
   blurOnSubmit?: boolean;
   value: string;
   onChangeText: (text: string) => void;
-  textReplacement: TextReplacement;
+  textReplacementKey: string;
   attachments: UserComposerAttachment[];
   attachmentScopeKeys?: readonly string[];
   onOpenWorkspaceAttachment?: (attachment: WorkspaceComposerAttachment) => void;
   onChangeAttachments: (updater: AttachmentListUpdater) => void;
-  onForgeChangeRequestDetected?: () => void;
-  onForgeChangeRequestAutoAttach?: (item: ForgeSearchItem) => void;
+  onGithubPrDetected?: () => void;
+  onGithubPrAutoAttach?: (item: ForgeSearchItem) => void;
   cwd: string;
   clearDraft: (lifecycle: "sent" | "abandoned") => void;
   /** When true, auto-focuses the text input on web. */
@@ -1152,18 +1149,18 @@ function ComposerContentImpl({
   submitButtonTestID,
   submitIcon = "arrow",
   isSubmitLoading = false,
-  waitForForgeAutoAttachOnSubmit = false,
+  waitForGithubAutoAttachOnSubmit = false,
   submitBehavior = "clear",
   blurOnSubmit = false,
   value,
   onChangeText,
-  textReplacement,
+  textReplacementKey,
   attachments,
   attachmentScopeKeys = EMPTY_ATTACHMENT_SCOPE_KEYS,
   onOpenWorkspaceAttachment,
   onChangeAttachments,
-  onForgeChangeRequestDetected,
-  onForgeChangeRequestAutoAttach,
+  onGithubPrDetected,
+  onGithubPrAutoAttach,
   cwd,
   clearDraft,
   autoFocus = false,
@@ -1218,6 +1215,7 @@ function ComposerContentImpl({
   const isDesktopLayout = resolveIsDesktopWebBreakpoint(isCompactLayout);
   const messagePlaceholder = resolveMessagePlaceholder(inputMode, isDesktopLayout, t, placeholder);
   const userInput = value;
+  const composerSigils = useComposerSigils();
   const setUserInput = onChangeText;
   const workspaceAttachments = useWorkspaceAttachmentsForScopes(attachmentScopeKeys);
   const {
@@ -1239,7 +1237,7 @@ function ComposerContentImpl({
   const supportsForgeSearch = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.forgeSearch === true,
   );
-  const forgeAutoAttach = useComposerForgeAutoAttach({
+  const githubAutoAttach = useComposerGithubAutoAttach({
     text: userInput,
     remoteUrl: resolveCheckoutRemoteUrl(checkoutStatusQuery.status),
     attachments,
@@ -1249,8 +1247,8 @@ function ComposerContentImpl({
     cwd,
     supportsForgeSearch,
     setAttachments: setSelectedAttachments,
-    onChangeRequestDetected: onForgeChangeRequestDetected,
-    onChangeRequestAdded: onForgeChangeRequestAutoAttach,
+    onPullRequestDetected: onGithubPrDetected,
+    onPullRequestAdded: onGithubPrAutoAttach,
   });
   const [cursorIndex, setCursorIndex] = useState(0);
   const cursorPublication = useMemo(() => new AfterPaintPublication<number>(setCursorIndex), []);
@@ -1271,11 +1269,6 @@ function ComposerContentImpl({
     attachments,
     onChangeAttachments: setSelectedAttachments,
     anchorRef: attachButtonRef,
-  });
-  const pluginClientSlashCommands = usePluginClientSlashCommands({
-    serverId,
-    workspaceId,
-    agentId,
   });
   const isComposerLocked = resolveIsComposerLocked(submitBehavior, isSubmitLoading);
   const keyboardHandlerIdRef = useRef(
@@ -1328,27 +1321,6 @@ function ComposerContentImpl({
     ],
   );
 
-  const runPluginClientSlashCommand = useCallback(
-    (resolved: { command: (typeof pluginClientSlashCommands)[number]; args: string }): boolean => {
-      if (blurOnSubmit) messageInputRef.current?.blur();
-      clearDraft("sent");
-      replaceUserInput("");
-      setSelectedAttachments([]);
-      resetSuppression();
-      setSendError(null);
-      executePluginClientSlashCommand({
-        command: resolved.command,
-        args: resolved.args,
-        onError(error) {
-          console.error("[Composer] Failed to run plugin client slash command:", error);
-          toastErrorRef.current(error instanceof Error ? error.message : String(error));
-        },
-      });
-      return true;
-    },
-    [blurOnSubmit, clearDraft, replaceUserInput, resetSuppression, setSelectedAttachments],
-  );
-
   const autocomplete = useAgentAutocomplete({
     userInput,
     cursorIndex,
@@ -1357,8 +1329,8 @@ function ComposerContentImpl({
     agentId,
     draftConfig: commandDraftConfig,
     canExecuteClientSlashCommand: buildOutgoingAttachments(attachments).length === 0,
+    sigils: composerSigils,
     onClientSlashCommand: runClientSlashCommand,
-    pluginClientSlashCommands,
     onAutocompleteApplied: () => {
       messageInputRef.current?.focus();
     },
@@ -1508,20 +1480,6 @@ function ComposerContentImpl({
   const beginAgentCancellation = useSessionStore((state) => state.beginAgentCancellation);
   const settleAgentCancellation = useSessionStore((state) => state.settleAgentCancellation);
   const isAgentRunning = hasActiveTurn;
-  // Queueing behind a permission prompt would strand the message: the turn is
-  // parked until the request is answered.
-  const hasPendingPermission = useSessionStore((state) => {
-    const pendingPermissions = state.sessions[serverId]?.pendingPermissions;
-    if (!pendingPermissions) return false;
-    for (const permission of pendingPermissions.values()) {
-      if (permission.agentId === agentId) return true;
-    }
-    return false;
-  });
-  const activeSendBehavior = resolveActiveSendBehavior(
-    appSettings.sendBehavior,
-    hasPendingPermission,
-  );
   const hasAgent = agentState.status !== null;
 
   const queueWriter = useMemo<QueueWriter>(
@@ -1619,32 +1577,26 @@ function ComposerContentImpl({
   const handleSubmit = useCallback(
     (payload: MessagePayload) => {
       const outgoingAttachments = buildOutgoingAttachments(attachments);
+      const submissionText = normalizeComposerTokensForSubmission(payload.text, composerSigils);
       const clientSlashCommand = resolveClientSlashCommand({
-        text: payload.text,
+        text: submissionText,
         hasAttachments: outgoingAttachments.length > 0,
       });
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
-      const pluginSlashCommand = resolvePluginClientSlashCommand({
-        text: payload.text,
-        hasAttachments: outgoingAttachments.length > 0,
-        commands: pluginClientSlashCommands,
-      });
-      if (pluginSlashCommand && runPluginClientSlashCommand(pluginSlashCommand)) return;
 
       if (blurOnSubmit) {
         messageInputRef.current?.blur();
       }
-      void sendMessageWithContent(payload.text, outgoingAttachments, payload.forceSend);
+      void sendMessageWithContent(submissionText, outgoingAttachments, payload.forceSend);
     },
     [
       attachments,
       blurOnSubmit,
       buildOutgoingAttachments,
+      composerSigils,
       runClientSlashCommand,
-      pluginClientSlashCommands,
-      runPluginClientSlashCommand,
       sendMessageWithContent,
     ],
   );
@@ -1773,7 +1725,7 @@ function ComposerContentImpl({
 
   const handleRemoveAttachment = useCallback(
     (index: number) => {
-      forgeAutoAttach.markForgeAttachmentRemoved(selectedAttachments[index]);
+      githubAutoAttach.markGithubAttachmentRemoved(selectedAttachments[index]);
       const didRemoveWorkspaceAttachment = removeAttachment({
         selectedAttachments,
         index,
@@ -1785,7 +1737,7 @@ function ComposerContentImpl({
         removeComposerAttachmentAtIndex({ attachments: prev, index, deleteAttachments }),
       );
     },
-    [forgeAutoAttach, removeAttachment, selectedAttachments, setSelectedAttachments],
+    [githubAutoAttach, removeAttachment, selectedAttachments, setSelectedAttachments],
   );
 
   const handleOpenAttachment = useCallback(
@@ -1887,29 +1839,17 @@ function ComposerContentImpl({
   const handleQueue = useCallback(
     (payload: MessagePayload) => {
       const outgoingAttachments = buildOutgoingAttachments(attachments);
+      const submissionText = normalizeComposerTokensForSubmission(payload.text, composerSigils);
       const clientSlashCommand = resolveClientSlashCommand({
-        text: payload.text,
+        text: submissionText,
         hasAttachments: outgoingAttachments.length > 0,
       });
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
-      const pluginSlashCommand = resolvePluginClientSlashCommand({
-        text: payload.text,
-        hasAttachments: outgoingAttachments.length > 0,
-        commands: pluginClientSlashCommands,
-      });
-      if (pluginSlashCommand && runPluginClientSlashCommand(pluginSlashCommand)) return;
-      queueMessage(payload.text, outgoingAttachments);
+      queueMessage(submissionText, outgoingAttachments);
     },
-    [
-      attachments,
-      buildOutgoingAttachments,
-      pluginClientSlashCommands,
-      queueMessage,
-      runClientSlashCommand,
-      runPluginClientSlashCommand,
-    ],
+    [attachments, buildOutgoingAttachments, composerSigils, queueMessage, runClientSlashCommand],
   );
 
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
@@ -2129,10 +2069,10 @@ function ComposerContentImpl({
 
   const handleToggleGithubItem = useCallback(
     (item: ForgeSearchItem) => {
-      const nextAttachments = toggleForgeAttachmentFromPicker({
+      const nextAttachments = toggleGithubAttachmentFromPicker({
         current: attachments,
         item,
-        markForgeAttachmentRemoved: forgeAutoAttach.markForgeAttachmentRemoved,
+        markGithubAttachmentRemoved: githubAutoAttach.markGithubAttachmentRemoved,
       });
       setSelectedAttachments(nextAttachments);
       setIsGithubPickerOpen(false);
@@ -2140,7 +2080,7 @@ function ComposerContentImpl({
     },
     [
       attachments,
-      forgeAutoAttach,
+      githubAutoAttach,
       setSelectedAttachments,
       setGithubSearchQuery,
       setIsGithubPickerOpen,
@@ -2188,10 +2128,6 @@ function ComposerContentImpl({
   const handleLightboxClose = useCallback(() => {
     setLightboxMetadata(null);
   }, []);
-  const lightboxSource = useMemo<ImageLightboxSource | null>(
-    () => (lightboxMetadata ? { type: "attachment", metadata: lightboxMetadata } : null),
-    [lightboxMetadata],
-  );
 
   const handleGithubPickerOpenChange = useCallback(
     (open: boolean) => {
@@ -2205,11 +2141,11 @@ function ComposerContentImpl({
 
   const renderGithubPickerOption = useCallback(
     ({ option, active }: { option: ComboboxOption; selected: boolean; active: boolean }) => {
-      const item = findForgeItemByOption(githubSearchItems, option.id);
+      const item = findGithubItemByOption(githubSearchItems, option.id);
       if (!item) {
         return <View key={option.id} />;
       }
-      const selected = isAttachmentSelectedForForgeItem(selectedAttachments, item);
+      const selected = isAttachmentSelectedForGithubItem(selectedAttachments, item);
       return (
         <GithubPickerOption
           key={option.id}
@@ -2267,7 +2203,7 @@ function ComposerContentImpl({
   const isSubmitLoadingVisible =
     isProcessing || isSubmitLoading || isUploadingFile || pendingNativeImagePastes > 0;
   const isSubmitDisabled =
-    isSubmitLoadingVisible || (waitForForgeAutoAttachOnSubmit && forgeAutoAttach.isResolving);
+    isSubmitLoadingVisible || (waitForGithubAutoAttachOnSubmit && githubAutoAttach.isResolving);
 
   // Disable drops while submitting/uploading: the submit path clears and restores attachments,
   // so a drop in that window would be lost or land on a locked draft. `disabled` hides the
@@ -2367,7 +2303,7 @@ function ComposerContentImpl({
                   voiceServerId={serverId}
                   voiceAgentId={agentId}
                   isAgentRunning={isAgentRunning}
-                  defaultSendBehavior={activeSendBehavior}
+                  defaultSendBehavior={appSettings.sendBehavior}
                   onQueue={handleQueue}
                   onSubmitLoadingPress={submitLoadingPressHandler}
                   onKeyPress={handleCommandKeyPress}
@@ -2378,7 +2314,7 @@ function ComposerContentImpl({
                   attachmentSlot={attachmentTray}
                   inputMode={inputMode}
                   readOnly={readOnly}
-                  textReplacement={textReplacement}
+                  textReplacementKey={textReplacementKey}
                   submitLabel={submitLabel}
                 />
               </RenderProfile>
@@ -2414,9 +2350,6 @@ function ComposerContentImpl({
 const animatedStaticStyles = RNStyleSheet.create({
   container: {
     flexDirection: "column",
-    // KeyboardDock reduces the available column height with bottom padding.
-    // Keep the composer's constraint chain shrinkable down to its scrolling input.
-    flexShrink: 1,
     position: "relative",
   },
 });
@@ -2427,7 +2360,6 @@ const styles = StyleSheet.create((theme: Theme) => ({
     backgroundColor: theme.colors.border,
   },
   inputAreaContainer: {
-    flexShrink: 1,
     position: "relative",
     minHeight: FOOTER_HEIGHT,
     marginHorizontal: "auto",
@@ -2441,13 +2373,11 @@ const styles = StyleSheet.create((theme: Theme) => ({
     opacity: 0.6,
   },
   inputAreaContent: {
-    flexShrink: 1,
     width: "100%",
     maxWidth: MAX_CONTENT_WIDTH,
     gap: theme.spacing[3],
   },
   messageInputContainer: {
-    flexShrink: 1,
     position: "relative",
     width: "100%",
     gap: theme.spacing[3],

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -1577,7 +1577,11 @@ function ComposerContentImpl({
   const handleSubmit = useCallback(
     (payload: MessagePayload) => {
       const outgoingAttachments = buildOutgoingAttachments(attachments);
-      const submissionText = normalizeComposerTokensForSubmission(payload.text, composerSigils);
+      const submissionText = normalizeComposerTokensForSubmission(
+        payload.text,
+        composerSigils,
+        autocomplete.tokenCatalog,
+      );
       const clientSlashCommand = resolveClientSlashCommand({
         text: submissionText,
         hasAttachments: outgoingAttachments.length > 0,
@@ -1596,6 +1600,7 @@ function ComposerContentImpl({
       blurOnSubmit,
       buildOutgoingAttachments,
       composerSigils,
+      autocomplete.tokenCatalog,
       runClientSlashCommand,
       sendMessageWithContent,
     ],
@@ -1839,7 +1844,11 @@ function ComposerContentImpl({
   const handleQueue = useCallback(
     (payload: MessagePayload) => {
       const outgoingAttachments = buildOutgoingAttachments(attachments);
-      const submissionText = normalizeComposerTokensForSubmission(payload.text, composerSigils);
+      const submissionText = normalizeComposerTokensForSubmission(
+        payload.text,
+        composerSigils,
+        autocomplete.tokenCatalog,
+      );
       const clientSlashCommand = resolveClientSlashCommand({
         text: submissionText,
         hasAttachments: outgoingAttachments.length > 0,
@@ -1849,7 +1858,14 @@ function ComposerContentImpl({
       }
       queueMessage(submissionText, outgoingAttachments);
     },
-    [attachments, buildOutgoingAttachments, composerSigils, queueMessage, runClientSlashCommand],
+    [
+      attachments,
+      autocomplete.tokenCatalog,
+      buildOutgoingAttachments,
+      composerSigils,
+      queueMessage,
+      runClientSlashCommand,
+    ],
   );
 
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
@@ -2274,6 +2290,7 @@ function ComposerContentImpl({
                 <StableMessageInput
                   ref={messageInputRef}
                   value={userInput}
+                  tokenCatalog={autocomplete.tokenCatalog}
                   onChangeText={setUserInput}
                   onSubmit={handleSubmit}
                   hasExternalContent={hasExternalContent}

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -53,7 +53,7 @@ import {
   type ComposerKeyPressEvent,
   type MessageInputRef,
 } from "./input/input";
-import type { ImageAttachment, MessagePayload } from "./types";
+import type { ImageAttachment, MessagePayload, TextReplacement } from "./types";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
 import { encodeImages } from "@/utils/encode-images";
@@ -62,14 +62,14 @@ import {
   cancelComposerAgent,
   dispatchComposerAgentMessage,
   editQueuedComposerMessage,
-  findGithubItemByOption,
-  isAttachmentSelectedForGithubItem,
+  findForgeItemByOption,
+  isAttachmentSelectedForForgeItem,
   openComposerAttachment,
   pickAndPersistImages,
   queueComposerMessage,
   removeComposerAttachmentAtIndex,
   sendQueuedComposerMessageNow,
-  toggleGithubAttachmentFromPicker,
+  toggleForgeAttachmentFromPicker,
   uploadFileAttachments,
   type AttachmentPersister,
   type QueueWriter,
@@ -83,6 +83,11 @@ import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
 import { AutocompletePopover } from "@/components/ui/autocomplete-popover";
 import type { AutocompleteOption } from "@/components/ui/autocomplete";
 import { useAgentAutocomplete } from "@/hooks/use-agent-autocomplete";
+import { usePluginClientSlashCommands } from "@/plugins/client-slash-commands";
+import {
+  executePluginClientSlashCommand,
+  resolvePluginClientSlashCommand,
+} from "@/plugins/client-slash-commands/model";
 import {
   useHostRuntimeAgentDirectoryStatus,
   useHostRuntimeClient,
@@ -124,7 +129,7 @@ import { droppedItemsToPickedFiles } from "@/composer/attachments/drop";
 import { getFileTypeLabel } from "@/attachments/file-types";
 import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
 import { AttachmentLabel, AttachmentPill, AttachmentThumbnail } from "@/components/attachment-pill";
-import { AttachmentLightbox } from "@/components/attachment-lightbox";
+import { AttachmentLightbox, type ImageLightboxSource } from "@/components/attachment-lightbox";
 import { openExternalUrl } from "@/utils/open-external-url";
 import { useIsDictationReady } from "@/hooks/use-is-dictation-ready";
 import { useForgeSearchQuery } from "@/git/use-forge-search-query";
@@ -132,7 +137,7 @@ import { useCheckoutStatusQuery } from "@/git/use-status-query";
 import { useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
 import { getForgePresentation } from "@/git/forge";
 import { ForgeBrandIcon } from "@/git/forge-icon";
-import { useComposerGithubAutoAttach } from "./github/auto-attach";
+import { useComposerForgeAutoAttach } from "./forge-auto-attach";
 import { readClipboardImage } from "./clipboard-image";
 import { normalizeNativePastedImages, type NativePastedFile } from "./native-pasted-image";
 import { PluginResourceAttachmentPill, usePluginAttachmentPicker } from "@/plugins";
@@ -924,20 +929,20 @@ interface ComposerProps {
   submitIcon?: "arrow" | "return";
   /** Externally controlled loading state. When true, disables the submit button. */
   isSubmitLoading?: boolean;
-  /** When true, waits for pasted GitHub links to resolve before enabling submit. */
-  waitForGithubAutoAttachOnSubmit?: boolean;
+  /** When true, waits for pasted forge links to resolve before enabling submit. */
+  waitForForgeAutoAttachOnSubmit?: boolean;
   submitBehavior?: "clear" | "preserve-and-lock";
   /** When true, blurs the input immediately when submitting. */
   blurOnSubmit?: boolean;
   value: string;
   onChangeText: (text: string) => void;
-  textReplacementKey: string;
+  textReplacement: TextReplacement;
   attachments: UserComposerAttachment[];
   attachmentScopeKeys?: readonly string[];
   onOpenWorkspaceAttachment?: (attachment: WorkspaceComposerAttachment) => void;
   onChangeAttachments: (updater: AttachmentListUpdater) => void;
-  onGithubPrDetected?: () => void;
-  onGithubPrAutoAttach?: (item: ForgeSearchItem) => void;
+  onForgeChangeRequestDetected?: () => void;
+  onForgeChangeRequestAutoAttach?: (item: ForgeSearchItem) => void;
   cwd: string;
   clearDraft: (lifecycle: "sent" | "abandoned") => void;
   /** When true, auto-focuses the text input on web. */
@@ -1148,18 +1153,18 @@ function ComposerContentImpl({
   submitButtonTestID,
   submitIcon = "arrow",
   isSubmitLoading = false,
-  waitForGithubAutoAttachOnSubmit = false,
+  waitForForgeAutoAttachOnSubmit = false,
   submitBehavior = "clear",
   blurOnSubmit = false,
   value,
   onChangeText,
-  textReplacementKey,
+  textReplacement,
   attachments,
   attachmentScopeKeys = EMPTY_ATTACHMENT_SCOPE_KEYS,
   onOpenWorkspaceAttachment,
   onChangeAttachments,
-  onGithubPrDetected,
-  onGithubPrAutoAttach,
+  onForgeChangeRequestDetected,
+  onForgeChangeRequestAutoAttach,
   cwd,
   clearDraft,
   autoFocus = false,
@@ -1236,7 +1241,7 @@ function ComposerContentImpl({
   const supportsForgeSearch = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.forgeSearch === true,
   );
-  const githubAutoAttach = useComposerGithubAutoAttach({
+  const forgeAutoAttach = useComposerForgeAutoAttach({
     text: userInput,
     remoteUrl: resolveCheckoutRemoteUrl(checkoutStatusQuery.status),
     attachments,
@@ -1246,8 +1251,8 @@ function ComposerContentImpl({
     cwd,
     supportsForgeSearch,
     setAttachments: setSelectedAttachments,
-    onPullRequestDetected: onGithubPrDetected,
-    onPullRequestAdded: onGithubPrAutoAttach,
+    onChangeRequestDetected: onForgeChangeRequestDetected,
+    onChangeRequestAdded: onForgeChangeRequestAutoAttach,
   });
   const [cursorIndex, setCursorIndex] = useState(0);
   const cursorPublication = useMemo(() => new AfterPaintPublication<number>(setCursorIndex), []);
@@ -1268,6 +1273,11 @@ function ComposerContentImpl({
     attachments,
     onChangeAttachments: setSelectedAttachments,
     anchorRef: attachButtonRef,
+  });
+  const pluginClientSlashCommands = usePluginClientSlashCommands({
+    serverId,
+    workspaceId,
+    agentId,
   });
   const isComposerLocked = resolveIsComposerLocked(submitBehavior, isSubmitLoading);
   const keyboardHandlerIdRef = useRef(
@@ -1320,6 +1330,27 @@ function ComposerContentImpl({
     ],
   );
 
+  const runPluginClientSlashCommand = useCallback(
+    (resolved: { command: (typeof pluginClientSlashCommands)[number]; args: string }): boolean => {
+      if (blurOnSubmit) messageInputRef.current?.blur();
+      clearDraft("sent");
+      replaceUserInput("");
+      setSelectedAttachments([]);
+      resetSuppression();
+      setSendError(null);
+      executePluginClientSlashCommand({
+        command: resolved.command,
+        args: resolved.args,
+        onError(error) {
+          console.error("[Composer] Failed to run plugin client slash command:", error);
+          toastErrorRef.current(error instanceof Error ? error.message : String(error));
+        },
+      });
+      return true;
+    },
+    [blurOnSubmit, clearDraft, replaceUserInput, resetSuppression, setSelectedAttachments],
+  );
+
   const autocomplete = useAgentAutocomplete({
     userInput,
     cursorIndex,
@@ -1330,6 +1361,7 @@ function ComposerContentImpl({
     canExecuteClientSlashCommand: buildOutgoingAttachments(attachments).length === 0,
     sigils: composerSigils,
     onClientSlashCommand: runClientSlashCommand,
+    pluginClientSlashCommands,
     onAutocompleteApplied: () => {
       messageInputRef.current?.focus();
     },
@@ -1479,6 +1511,20 @@ function ComposerContentImpl({
   const beginAgentCancellation = useSessionStore((state) => state.beginAgentCancellation);
   const settleAgentCancellation = useSessionStore((state) => state.settleAgentCancellation);
   const isAgentRunning = hasActiveTurn;
+  // Queueing behind a permission prompt would strand the message: the turn is
+  // parked until the request is answered.
+  const hasPendingPermission = useSessionStore((state) => {
+    const pendingPermissions = state.sessions[serverId]?.pendingPermissions;
+    if (!pendingPermissions) return false;
+    for (const permission of pendingPermissions.values()) {
+      if (permission.agentId === agentId) return true;
+    }
+    return false;
+  });
+  const activeSendBehavior = resolveActiveSendBehavior(
+    appSettings.sendBehavior,
+    hasPendingPermission,
+  );
   const hasAgent = agentState.status !== null;
 
   const queueWriter = useMemo<QueueWriter>(
@@ -1583,6 +1629,12 @@ function ComposerContentImpl({
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
+      const pluginSlashCommand = resolvePluginClientSlashCommand({
+        text: payload.text,
+        hasAttachments: outgoingAttachments.length > 0,
+        commands: pluginClientSlashCommands,
+      });
+      if (pluginSlashCommand && runPluginClientSlashCommand(pluginSlashCommand)) return;
 
       if (blurOnSubmit) {
         messageInputRef.current?.blur();
@@ -1594,6 +1646,8 @@ function ComposerContentImpl({
       blurOnSubmit,
       buildOutgoingAttachments,
       runClientSlashCommand,
+      pluginClientSlashCommands,
+      runPluginClientSlashCommand,
       sendMessageWithContent,
     ],
   );
@@ -1722,7 +1776,7 @@ function ComposerContentImpl({
 
   const handleRemoveAttachment = useCallback(
     (index: number) => {
-      githubAutoAttach.markGithubAttachmentRemoved(selectedAttachments[index]);
+      forgeAutoAttach.markForgeAttachmentRemoved(selectedAttachments[index]);
       const didRemoveWorkspaceAttachment = removeAttachment({
         selectedAttachments,
         index,
@@ -1734,7 +1788,7 @@ function ComposerContentImpl({
         removeComposerAttachmentAtIndex({ attachments: prev, index, deleteAttachments }),
       );
     },
-    [githubAutoAttach, removeAttachment, selectedAttachments, setSelectedAttachments],
+    [forgeAutoAttach, removeAttachment, selectedAttachments, setSelectedAttachments],
   );
 
   const handleOpenAttachment = useCallback(
@@ -1843,9 +1897,22 @@ function ComposerContentImpl({
       if (clientSlashCommand && runClientSlashCommand(clientSlashCommand)) {
         return;
       }
+      const pluginSlashCommand = resolvePluginClientSlashCommand({
+        text: payload.text,
+        hasAttachments: outgoingAttachments.length > 0,
+        commands: pluginClientSlashCommands,
+      });
+      if (pluginSlashCommand && runPluginClientSlashCommand(pluginSlashCommand)) return;
       queueMessage(payload.text, outgoingAttachments);
     },
-    [attachments, buildOutgoingAttachments, queueMessage, runClientSlashCommand],
+    [
+      attachments,
+      buildOutgoingAttachments,
+      pluginClientSlashCommands,
+      queueMessage,
+      runClientSlashCommand,
+      runPluginClientSlashCommand,
+    ],
   );
 
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
@@ -2065,10 +2132,10 @@ function ComposerContentImpl({
 
   const handleToggleGithubItem = useCallback(
     (item: ForgeSearchItem) => {
-      const nextAttachments = toggleGithubAttachmentFromPicker({
+      const nextAttachments = toggleForgeAttachmentFromPicker({
         current: attachments,
         item,
-        markGithubAttachmentRemoved: githubAutoAttach.markGithubAttachmentRemoved,
+        markForgeAttachmentRemoved: forgeAutoAttach.markForgeAttachmentRemoved,
       });
       setSelectedAttachments(nextAttachments);
       setIsGithubPickerOpen(false);
@@ -2076,7 +2143,7 @@ function ComposerContentImpl({
     },
     [
       attachments,
-      githubAutoAttach,
+      forgeAutoAttach,
       setSelectedAttachments,
       setGithubSearchQuery,
       setIsGithubPickerOpen,
@@ -2124,6 +2191,10 @@ function ComposerContentImpl({
   const handleLightboxClose = useCallback(() => {
     setLightboxMetadata(null);
   }, []);
+  const lightboxSource = useMemo<ImageLightboxSource | null>(
+    () => (lightboxMetadata ? { type: "attachment", metadata: lightboxMetadata } : null),
+    [lightboxMetadata],
+  );
 
   const handleGithubPickerOpenChange = useCallback(
     (open: boolean) => {
@@ -2137,11 +2208,11 @@ function ComposerContentImpl({
 
   const renderGithubPickerOption = useCallback(
     ({ option, active }: { option: ComboboxOption; selected: boolean; active: boolean }) => {
-      const item = findGithubItemByOption(githubSearchItems, option.id);
+      const item = findForgeItemByOption(githubSearchItems, option.id);
       if (!item) {
         return <View key={option.id} />;
       }
-      const selected = isAttachmentSelectedForGithubItem(selectedAttachments, item);
+      const selected = isAttachmentSelectedForForgeItem(selectedAttachments, item);
       return (
         <GithubPickerOption
           key={option.id}
@@ -2199,7 +2270,7 @@ function ComposerContentImpl({
   const isSubmitLoadingVisible =
     isProcessing || isSubmitLoading || isUploadingFile || pendingNativeImagePastes > 0;
   const isSubmitDisabled =
-    isSubmitLoadingVisible || (waitForGithubAutoAttachOnSubmit && githubAutoAttach.isResolving);
+    isSubmitLoadingVisible || (waitForForgeAutoAttachOnSubmit && forgeAutoAttach.isResolving);
 
   // Disable drops while submitting/uploading: the submit path clears and restores attachments,
   // so a drop in that window would be lost or land on a locked draft. `disabled` hides the
@@ -2300,7 +2371,7 @@ function ComposerContentImpl({
                   voiceServerId={serverId}
                   voiceAgentId={agentId}
                   isAgentRunning={isAgentRunning}
-                  defaultSendBehavior={appSettings.sendBehavior}
+                  defaultSendBehavior={activeSendBehavior}
                   onQueue={handleQueue}
                   onSubmitLoadingPress={submitLoadingPressHandler}
                   onKeyPress={handleCommandKeyPress}
@@ -2311,7 +2382,7 @@ function ComposerContentImpl({
                   attachmentSlot={attachmentTray}
                   inputMode={inputMode}
                   readOnly={readOnly}
-                  textReplacementKey={textReplacementKey}
+                  textReplacement={textReplacement}
                   submitLabel={submitLabel}
                 />
               </RenderProfile>
@@ -2347,6 +2418,9 @@ function ComposerContentImpl({
 const animatedStaticStyles = RNStyleSheet.create({
   container: {
     flexDirection: "column",
+    // KeyboardDock reduces the available column height with bottom padding.
+    // Keep the composer's constraint chain shrinkable down to its scrolling input.
+    flexShrink: 1,
     position: "relative",
   },
 });
@@ -2357,6 +2431,7 @@ const styles = StyleSheet.create((theme: Theme) => ({
     backgroundColor: theme.colors.border,
   },
   inputAreaContainer: {
+    flexShrink: 1,
     position: "relative",
     minHeight: FOOTER_HEIGHT,
     marginHorizontal: "auto",
@@ -2370,11 +2445,13 @@ const styles = StyleSheet.create((theme: Theme) => ({
     opacity: 0.6,
   },
   inputAreaContent: {
+    flexShrink: 1,
     width: "100%",
     maxWidth: MAX_CONTENT_WIDTH,
     gap: theme.spacing[3],
   },
   messageInputContainer: {
+    flexShrink: 1,
     position: "relative",
     width: "100%",
     gap: theme.spacing[3],

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -4,11 +4,12 @@ import {
   Text,
   useWindowDimensions,
   NativeSyntheticEvent,
-  TextInputContentSizeChangeEventData,
   TextInputKeyPressEventData,
   TextInputSelectionChangeEventData,
+  type LayoutChangeEvent,
+  type StyleProp,
+  type TextStyle,
 } from "react-native";
-import type { StyleProp, TextStyle } from "react-native";
 import {
   useState,
   useRef,
@@ -36,7 +37,7 @@ import {
   filesToImageAttachments,
 } from "@/utils/image-attachments-from-files";
 import type { ComposerAttachment } from "@/attachments/types";
-import type { ImageAttachment, MessagePayload } from "@/composer/types";
+import type { ImageAttachment, MessagePayload, TextReplacement } from "@/composer/types";
 import { useComposerSigils } from "@/composer/tokens/use-composer-sigils";
 import type { ComposerSigils } from "@/composer/tokens/sigils";
 import { collectComposerTokens, type ComposerTokenCatalog } from "@/composer/tokens/tokens";
@@ -60,7 +61,7 @@ import { isWeb } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useComposerKeyboardScope } from "@/composer/keyboard-scope";
 import { RenderProfile } from "@/utils/render-profiler";
-import { useComposerHeightMirror } from "./height-mirror";
+import { useComposerHeight } from "./height";
 import { resolveComposerInputMode, type ComposerInputMode } from "@/composer/input-mode";
 import type { NativePastedFile } from "@/composer/native-pasted-image";
 import {
@@ -90,9 +91,6 @@ import {
 
 const DEFAULT_SEND_KEYS: ShortcutKey[][] = [["Enter"]];
 const COMPOSER_INPUT_DATASET = { composerInput: "" } as const;
-// Adds the marker the tokenized-selection stylesheet targets. Only applied while
-// the draft actually contains a token, so an ordinary draft keeps ordinary
-// selection behavior.
 const COMPOSER_INPUT_TOKENIZED_DATASET = { composerInput: "", composerTokenized: "" } as const;
 
 export interface AttachmentMenuItem {
@@ -179,8 +177,8 @@ export interface MessageInputProps {
   inputMode?: ComposerInputMode;
   /** Renders `value` as static text on the same surface, for content there is nothing to type into. */
   readOnly?: boolean;
-  /** Changes only when application state must replace native-owned text. */
-  textReplacementKey: string;
+  /** Command issued when application state must replace native-owned text. */
+  textReplacement: TextReplacement;
   /** Replaces the submit icon with this label, still inside the composer's own toolbar row. */
   submitLabel?: string;
 }
@@ -652,7 +650,6 @@ interface ComposerTextSurfaceProps {
   editable: boolean;
   scrollEnabled: boolean;
   autoFocus: boolean;
-  onContentSizeChange: (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => void;
   onKeyPress: ((event: WebTextInputKeyPressEvent) => void) | undefined;
   onSelectionChange: (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => void;
   onPasteImages: ((files: readonly NativePastedFile[]) => void) | undefined;
@@ -698,7 +695,6 @@ function ComposerTextSurface(props: ComposerTextSurfaceProps): React.ReactElemen
         style={props.textInputStyle}
         multiline
         scrollEnabled={props.scrollEnabled}
-        onContentSizeChange={props.onContentSizeChange}
         editable={props.editable}
         onKeyPress={props.onKeyPress}
         onSelectionChange={props.onSelectionChange}
@@ -1010,39 +1006,13 @@ function resolveMaxInputHeight(windowHeight: number): number {
   return Math.max(DEFAULT_MAX_INPUT_HEIGHT, Math.floor(windowHeight * MAX_INPUT_VIEWPORT_RATIO));
 }
 
-function computeTextInputHeightStyle(inputHeight: number, maxInputHeight: number) {
-  if (isWeb) {
-    return {
-      height: inputHeight,
-      minHeight: MIN_INPUT_HEIGHT,
-      maxHeight: maxInputHeight,
-    };
-  }
-  return {
-    minHeight: MIN_INPUT_HEIGHT,
-    maxHeight: maxInputHeight,
-  };
-}
-
-/**
- * Resolve how the draft's command/skill tokens should be drawn on this platform.
- *
- * Tokens are re-derived from the draft text on every change — nothing about a token
- * is persisted, so drafts, dictation and undo need no knowledge of them.
- *
- * Web opts out when the draft has no token and keeps rendering through the plain
- * textarea instead of the mirror. Native always keeps its controlled plain-text
- * path because React Native TextInput cannot safely render styled spans.
- */
 function useComposerTokenRendering(
   value: string,
   tokenCatalog: ComposerTokenCatalog,
 ): {
   sigils: ComposerSigils;
   showTokenMirror: boolean;
-  /** Marks the input for the tokenized-selection stylesheet while a token exists. */
   dataSet: typeof COMPOSER_INPUT_DATASET;
-  /** Makes the input's own glyphs transparent while the mirror draws them. */
   inputTextStyle: StyleProp<TextStyle>;
 } {
   const sigils = useComposerSigils();
@@ -1154,7 +1124,7 @@ interface ResolvedMessageInputProps {
   attachmentSlot: React.ReactNode;
   inputMode: ComposerInputMode;
   readOnly: boolean;
-  textReplacementKey: string;
+  textReplacement: TextReplacement;
   submitLabel: string | undefined;
 }
 
@@ -1202,7 +1172,7 @@ function resolveMessageInputProps(props: MessageInputProps): ResolvedMessageInpu
     attachmentSlot: props.attachmentSlot,
     inputMode: props.inputMode ?? "chat",
     readOnly: props.readOnly ?? false,
-    textReplacementKey: props.textReplacementKey,
+    textReplacement: props.textReplacement,
     submitLabel: props.submitLabel,
   };
 }
@@ -1258,7 +1228,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       attachmentSlot,
       inputMode,
       readOnly,
-      textReplacementKey,
+      textReplacement,
       submitLabel,
     } = resolveMessageInputProps(props);
     const mode = resolveComposerInputMode(inputMode);
@@ -1272,7 +1242,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const voiceMuteToggleKeys = useShortcutKeys("voice-mute-toggle");
     const dictationToggleKeys = useShortcutKeys("dictation-toggle");
     const focusInputKeys = useShortcutKeys("focus-message-input");
-    const [inputHeight, setInputHeight] = useState(MIN_INPUT_HEIGHT);
     const [isInputFocused, setIsInputFocused] = useState(false);
     // Web text is DOM-owned between deferred draft publications. The action button only needs
     // this boundary, so publish empty/non-empty transitions without rerendering for every key.
@@ -1285,7 +1254,23 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const isInputFocusedRef = useRef(false);
     const valueRef = useRef(value);
     const selectionRef = useRef({ start: value.length, end: value.length });
-    const appliedTextReplacementKeyRef = useRef(textReplacementKey);
+    const appliedTextReplacementKeyRef = useRef(textReplacement.key);
+    const webTextareaRef = useRef<HTMLElement | null>(null);
+    const composerHeight = useComposerHeight({
+      value,
+      textareaRef: webTextareaRef,
+      minHeight: MIN_INPUT_HEIGHT,
+      maxHeight: maxInputHeight,
+    });
+    const { style: composerHeightStyle, scrollEnabled: isComposerScrollEnabled } = composerHeight;
+    const measuredComposerHeight = composerHeight.mode === "measured" ? composerHeight : undefined;
+    const updateComposerHeightForText = measuredComposerHeight?.onTextChange;
+    const resetComposerHeight = measuredComposerHeight?.reset;
+
+    const handleComposerLayout = useCallback(
+      (event: LayoutChangeEvent) => onHeightChange?.(event.nativeEvent.layout.height),
+      [onHeightChange],
+    );
 
     const updateLiveTextPresence = useCallback((text: string) => {
       const nextHasLiveText = text.trim().length > 0;
@@ -1296,13 +1281,14 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     const replaceText = useCallback(
       (nextText: string, selection?: { start: number; end: number }) => {
+        updateComposerHeightForText?.(valueRef.current, nextText);
         valueRef.current = nextText;
         updateLiveTextPresence(nextText);
         selectionRef.current = selection ?? { start: nextText.length, end: nextText.length };
         textInputRef.current?.replaceText(nextText, selection);
         onChangeText(nextText);
       },
-      [onChangeText, updateLiveTextPresence],
+      [onChangeText, updateComposerHeightForText, updateLiveTextPresence],
     );
 
     useImperativeHandle(ref, () => ({
@@ -1332,7 +1318,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         }),
       getNativeElement: () => (isWeb ? getTextInputNativeElement(textInputRef.current) : null),
     }));
-    const inputHeightRef = useRef(MIN_INPUT_HEIGHT);
     const sendAfterTranscriptRef = useRef(false);
     const serverInfo = useSessionStore(
       useCallback(
@@ -1347,12 +1332,13 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     );
 
     useEffect(() => {
-      if (appliedTextReplacementKeyRef.current === textReplacementKey) return;
-      appliedTextReplacementKeyRef.current = textReplacementKey;
-      valueRef.current = value;
-      updateLiveTextPresence(value);
-      textInputRef.current?.replaceText(value);
-    }, [textReplacementKey, updateLiveTextPresence, value]);
+      if (appliedTextReplacementKeyRef.current === textReplacement.key) return;
+      appliedTextReplacementKeyRef.current = textReplacement.key;
+      updateComposerHeightForText?.(valueRef.current, textReplacement.text);
+      valueRef.current = textReplacement.text;
+      updateLiveTextPresence(textReplacement.text);
+      textInputRef.current?.replaceText(textReplacement.text);
+    }, [textReplacement, updateComposerHeightForText, updateLiveTextPresence]);
 
     useEffect(() => {
       return () => {
@@ -1549,10 +1535,8 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     ]);
 
     const minimizeInputHeight = useCallback(() => {
-      inputHeightRef.current = MIN_INPUT_HEIGHT;
-      setInputHeight(MIN_INPUT_HEIGHT);
-      onHeightChange?.(MIN_INPUT_HEIGHT);
-    }, [onHeightChange]);
+      resetComposerHeight?.();
+    }, [resetComposerHeight]);
 
     const handleSendMessage = useCallback(() => {
       const liveValue = textInputRef.current?.getText() ?? valueRef.current;
@@ -1620,8 +1604,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       [],
     );
 
-    const webTextareaRef = useRef<HTMLElement | null>(null);
-
     useLayoutEffect(() => {
       if (isWeb) {
         webTextareaRef.current = getWebTextArea() as HTMLElement | null;
@@ -1636,37 +1618,6 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       isRealtimeVoiceForCurrentAgent,
       onAddImages,
     });
-
-    const setBoundedInputHeight = useCallback(
-      (nextHeight: number) => {
-        const bounded = Math.max(MIN_INPUT_HEIGHT, Math.min(maxInputHeight, nextHeight));
-        if (Math.abs(inputHeightRef.current - bounded) < 1) return;
-        inputHeightRef.current = bounded;
-        setInputHeight(bounded);
-        onHeightChange?.(bounded);
-      },
-      [maxInputHeight, onHeightChange],
-    );
-
-    useEffect(() => {
-      setBoundedInputHeight(inputHeightRef.current);
-    }, [setBoundedInputHeight]);
-
-    const measureComposerHeight = useComposerHeightMirror({
-      value,
-      textareaRef: webTextareaRef,
-      minHeight: MIN_INPUT_HEIGHT,
-      maxHeight: maxInputHeight,
-      onHeight: setBoundedInputHeight,
-    });
-
-    const handleContentSizeChange = useCallback(
-      (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => {
-        if (isWeb) return;
-        setBoundedInputHeight(event.nativeEvent.contentSize.height);
-      },
-      [setBoundedInputHeight],
-    );
 
     const handleSelectionChange = useCallback(
       (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
@@ -1754,12 +1705,12 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     const handleInputChange = useCallback(
       (nextValue: string) => {
+        updateComposerHeightForText?.(valueRef.current, nextValue);
         valueRef.current = nextValue;
-        measureComposerHeight(nextValue);
         updateLiveTextPresence(nextValue);
         onChangeText(nextValue);
       },
-      [measureComposerHeight, onChangeText, updateLiveTextPresence],
+      [onChangeText, updateComposerHeightForText, updateLiveTextPresence],
     );
 
     const handleInputFocus = useCallback(() => {
@@ -1820,15 +1771,14 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     // `fontFamily` here is silently dropped while every other property lands.
     // An inline style outranks both classes. See docs/unistyles.md.
     const tokenRendering = useComposerTokenRendering(value, tokenCatalog);
-
     const textInputStyle = useMemo(
       () => [
         styles.textInput,
         mode.isMonospace && styles.textInputMonospace,
-        computeTextInputHeightStyle(inputHeight, maxInputHeight),
+        composerHeightStyle,
         tokenRendering.inputTextStyle,
       ],
-      [inputHeight, maxInputHeight, mode.isMonospace, tokenRendering.inputTextStyle],
+      [composerHeightStyle, mode.isMonospace, tokenRendering.inputTextStyle],
     );
     // Static content has no textarea to mirror, so it grows with its own text
     // instead of the measured input height.
@@ -1873,7 +1823,12 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     );
 
     return (
-      <View ref={rootRef} style={styles.container} testID="message-input-root">
+      <View
+        ref={rootRef}
+        style={styles.container}
+        testID="message-input-root"
+        onLayout={handleComposerLayout}
+      >
         <MessageInputAutoFocus
           enabled={autoFocus}
           autoFocusKey={autoFocusKey}
@@ -1903,9 +1858,8 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               onFocus={handleInputFocus}
               onBlur={handleInputBlur}
               editable={!isDictating && !isRealtimeVoiceForCurrentAgent && !disabled}
-              scrollEnabled={isWeb ? inputHeight >= maxInputHeight : true}
+              scrollEnabled={isComposerScrollEnabled}
               autoFocus={false}
-              onContentSizeChange={handleContentSizeChange}
               onKeyPress={shouldHandleWebKeyPress ? handleDesktopKeyPress : undefined}
               onSelectionChange={handleSelectionChange}
               onPasteImages={onPasteImages}
@@ -2001,9 +1955,11 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
 const styles = StyleSheet.create((theme: Theme) => ({
   container: {
+    flexShrink: 1,
     position: "relative",
   },
   inputWrapper: {
+    flexShrink: 1,
     flexDirection: "column",
     gap: theme.spacing[3],
     backgroundColor: theme.colors.surface1,
@@ -2032,6 +1988,7 @@ const styles = StyleSheet.create((theme: Theme) => ({
     borderStyle: "dotted",
   },
   textInputScrollWrapper: {
+    flexShrink: 1,
     position: "relative",
   },
   focusHintText: {
@@ -2043,11 +2000,13 @@ const styles = StyleSheet.create((theme: Theme) => ({
     opacity: 0.5,
   },
   textInput: {
+    // Preserve the controls when an ancestor constrains an overlong draft.
+    flexShrink: 1,
     width: "100%",
     color: theme.colors.foreground,
-    fontSize: theme.fontSize.base,
+    fontSize: theme.fontSize.content,
     fontWeight: theme.fontWeight.normal,
-    lineHeight: theme.fontSize.base * 1.4,
+    lineHeight: theme.fontSize.content * 1.4,
     ...(isWeb
       ? ({
           outlineStyle: "none",
@@ -2059,22 +2018,16 @@ const styles = StyleSheet.create((theme: Theme) => ({
   textInputMonospace: {
     fontFamily: theme.fontFamily.mono,
   },
+  textInputMirrored: {
+    color: "transparent",
+    ...(isWeb ? ({ caretColor: theme.colors.foreground } as object) : {}),
+  },
   readOnlyText: {
     minHeight: MIN_INPUT_HEIGHT,
     color: theme.colors.foregroundMuted,
   },
-  // Hands the glyphs to the mirror layer while the textarea keeps the caret,
-  // selection and IME. `caretColor` has no React Native equivalent, hence the
-  // web-only escape.
-  textInputMirrored: {
-    color: "transparent",
-    ...(isWeb
-      ? ({
-          caretColor: theme.colors.foreground,
-        } as object)
-      : {}),
-  },
   buttonRow: {
+    flexShrink: 0,
     flexDirection: "row",
     alignItems: "flex-end",
     justifyContent: "space-between",

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -4,10 +4,11 @@ import {
   Text,
   useWindowDimensions,
   NativeSyntheticEvent,
+  TextInputContentSizeChangeEventData,
   TextInputKeyPressEventData,
   TextInputSelectionChangeEventData,
-  type LayoutChangeEvent,
 } from "react-native";
+import type { StyleProp, TextStyle } from "react-native";
 import {
   useState,
   useRef,
@@ -35,7 +36,11 @@ import {
   filesToImageAttachments,
 } from "@/utils/image-attachments-from-files";
 import type { ComposerAttachment } from "@/attachments/types";
-import type { ImageAttachment, MessagePayload, TextReplacement } from "@/composer/types";
+import type { ImageAttachment, MessagePayload } from "@/composer/types";
+import { useComposerSigils } from "@/composer/tokens/use-composer-sigils";
+import type { ComposerSigils } from "@/composer/tokens/sigils";
+import { collectComposerTokens } from "@/composer/tokens/tokens";
+import { ComposerTokenHighlightLayer } from "./token-highlight";
 import { focusWithRetries } from "@/utils/web-focus";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Shortcut } from "@/components/ui/shortcut";
@@ -55,7 +60,7 @@ import { isWeb } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useComposerKeyboardScope } from "@/composer/keyboard-scope";
 import { RenderProfile } from "@/utils/render-profiler";
-import { useComposerHeight } from "./height";
+import { useComposerHeightMirror } from "./height-mirror";
 import { resolveComposerInputMode, type ComposerInputMode } from "@/composer/input-mode";
 import type { NativePastedFile } from "@/composer/native-pasted-image";
 import {
@@ -85,6 +90,10 @@ import {
 
 const DEFAULT_SEND_KEYS: ShortcutKey[][] = [["Enter"]];
 const COMPOSER_INPUT_DATASET = { composerInput: "" } as const;
+// Adds the marker the tokenized-selection stylesheet targets. Only applied while
+// the draft actually contains a token, so an ordinary draft keeps ordinary
+// selection behavior.
+const COMPOSER_INPUT_TOKENIZED_DATASET = { composerInput: "", composerTokenized: "" } as const;
 
 export interface AttachmentMenuItem {
   id: string;
@@ -169,8 +178,8 @@ export interface MessageInputProps {
   inputMode?: ComposerInputMode;
   /** Renders `value` as static text on the same surface, for content there is nothing to type into. */
   readOnly?: boolean;
-  /** Command issued when application state must replace native-owned text. */
-  textReplacement: TextReplacement;
+  /** Changes only when application state must replace native-owned text. */
+  textReplacementKey: string;
   /** Replaces the submit icon with this label, still inside the composer's own toolbar row. */
   submitLabel?: string;
 }
@@ -631,6 +640,8 @@ interface ComposerTextSurfaceProps {
   textInputRef: React.Ref<ComposerTextInputHandle>;
   textInputStyle: EditingTextInputProps["style"];
   readOnlyTextStyle: React.ComponentProps<typeof Text>["style"];
+  tokenRendering: ReturnType<typeof useComposerTokenRendering>;
+  tokenTextareaRef: React.RefObject<HTMLElement | null>;
   placeholder: string;
   accessibilityLabel: string;
   onChangeText: (text: string) => void;
@@ -639,6 +650,7 @@ interface ComposerTextSurfaceProps {
   editable: boolean;
   scrollEnabled: boolean;
   autoFocus: boolean;
+  onContentSizeChange: (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => void;
   onKeyPress: ((event: WebTextInputKeyPressEvent) => void) | undefined;
   onSelectionChange: (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => void;
   onPasteImages: ((files: readonly NativePastedFile[]) => void) | undefined;
@@ -665,9 +677,15 @@ function ComposerTextSurface(props: ComposerTextSurfaceProps): React.ReactElemen
   }
   return (
     <View style={styles.textInputScrollWrapper}>
+      <ComposerTokenHighlightLayer
+        enabled={props.tokenRendering.showTokenMirror}
+        value={props.value}
+        sigils={props.tokenRendering.sigils}
+        textareaRef={props.tokenTextareaRef}
+      />
       <ComposerTextInput
         ref={props.textInputRef}
-        dataSet={COMPOSER_INPUT_DATASET}
+        dataSet={props.tokenRendering.dataSet}
         initialValue={props.value}
         onChangeText={props.onChangeText}
         placeholder={props.placeholder}
@@ -677,6 +695,7 @@ function ComposerTextSurface(props: ComposerTextSurfaceProps): React.ReactElemen
         style={props.textInputStyle}
         multiline
         scrollEnabled={props.scrollEnabled}
+        onContentSizeChange={props.onContentSizeChange}
         editable={props.editable}
         onKeyPress={props.onKeyPress}
         onSelectionChange={props.onSelectionChange}
@@ -988,6 +1007,50 @@ function resolveMaxInputHeight(windowHeight: number): number {
   return Math.max(DEFAULT_MAX_INPUT_HEIGHT, Math.floor(windowHeight * MAX_INPUT_VIEWPORT_RATIO));
 }
 
+function computeTextInputHeightStyle(inputHeight: number, maxInputHeight: number) {
+  if (isWeb) {
+    return {
+      height: inputHeight,
+      minHeight: MIN_INPUT_HEIGHT,
+      maxHeight: maxInputHeight,
+    };
+  }
+  return {
+    minHeight: MIN_INPUT_HEIGHT,
+    maxHeight: maxInputHeight,
+  };
+}
+
+/**
+ * Resolve how the draft's command/skill tokens should be drawn on this platform.
+ *
+ * Tokens are re-derived from the draft text on every change — nothing about a token
+ * is persisted, so drafts, dictation and undo need no knowledge of them.
+ *
+ * Web opts out when the draft has no token and keeps rendering through the plain
+ * textarea instead of the mirror. Native always keeps its controlled plain-text
+ * path because React Native TextInput cannot safely render styled spans.
+ */
+function useComposerTokenRendering(value: string): {
+  sigils: ComposerSigils;
+  showTokenMirror: boolean;
+  /** Marks the input for the tokenized-selection stylesheet while a token exists. */
+  dataSet: typeof COMPOSER_INPUT_DATASET;
+  /** Makes the input's own glyphs transparent while the mirror draws them. */
+  inputTextStyle: StyleProp<TextStyle>;
+} {
+  const sigils = useComposerSigils();
+  const hasTokens = useMemo(() => collectComposerTokens(value, sigils).length > 0, [value, sigils]);
+  const showTokenMirror = isWeb && hasTokens;
+
+  return {
+    sigils,
+    showTokenMirror,
+    dataSet: showTokenMirror ? COMPOSER_INPUT_TOKENIZED_DATASET : COMPOSER_INPUT_DATASET,
+    inputTextStyle: showTokenMirror ? styles.textInputMirrored : null,
+  };
+}
+
 function isTextAreaLike(v: unknown): v is TextAreaHandle {
   return typeof v === "object" && v !== null && "scrollHeight" in v;
 }
@@ -1081,7 +1144,7 @@ interface ResolvedMessageInputProps {
   attachmentSlot: React.ReactNode;
   inputMode: ComposerInputMode;
   readOnly: boolean;
-  textReplacement: TextReplacement;
+  textReplacementKey: string;
   submitLabel: string | undefined;
 }
 
@@ -1128,7 +1191,7 @@ function resolveMessageInputProps(props: MessageInputProps): ResolvedMessageInpu
     attachmentSlot: props.attachmentSlot,
     inputMode: props.inputMode ?? "chat",
     readOnly: props.readOnly ?? false,
-    textReplacement: props.textReplacement,
+    textReplacementKey: props.textReplacementKey,
     submitLabel: props.submitLabel,
   };
 }
@@ -1183,7 +1246,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       attachmentSlot,
       inputMode,
       readOnly,
-      textReplacement,
+      textReplacementKey,
       submitLabel,
     } = resolveMessageInputProps(props);
     const mode = resolveComposerInputMode(inputMode);
@@ -1197,6 +1260,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const voiceMuteToggleKeys = useShortcutKeys("voice-mute-toggle");
     const dictationToggleKeys = useShortcutKeys("dictation-toggle");
     const focusInputKeys = useShortcutKeys("focus-message-input");
+    const [inputHeight, setInputHeight] = useState(MIN_INPUT_HEIGHT);
     const [isInputFocused, setIsInputFocused] = useState(false);
     // Web text is DOM-owned between deferred draft publications. The action button only needs
     // this boundary, so publish empty/non-empty transitions without rerendering for every key.
@@ -1209,23 +1273,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     const isInputFocusedRef = useRef(false);
     const valueRef = useRef(value);
     const selectionRef = useRef({ start: value.length, end: value.length });
-    const appliedTextReplacementKeyRef = useRef(textReplacement.key);
-    const webTextareaRef = useRef<HTMLElement | null>(null);
-    const composerHeight = useComposerHeight({
-      value,
-      textareaRef: webTextareaRef,
-      minHeight: MIN_INPUT_HEIGHT,
-      maxHeight: maxInputHeight,
-    });
-    const { style: composerHeightStyle, scrollEnabled: isComposerScrollEnabled } = composerHeight;
-    const measuredComposerHeight = composerHeight.mode === "measured" ? composerHeight : undefined;
-    const updateComposerHeightForText = measuredComposerHeight?.onTextChange;
-    const resetComposerHeight = measuredComposerHeight?.reset;
-
-    const handleComposerLayout = useCallback(
-      (event: LayoutChangeEvent) => onHeightChange?.(event.nativeEvent.layout.height),
-      [onHeightChange],
-    );
+    const appliedTextReplacementKeyRef = useRef(textReplacementKey);
 
     const updateLiveTextPresence = useCallback((text: string) => {
       const nextHasLiveText = text.trim().length > 0;
@@ -1236,14 +1284,13 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     const replaceText = useCallback(
       (nextText: string, selection?: { start: number; end: number }) => {
-        updateComposerHeightForText?.(valueRef.current, nextText);
         valueRef.current = nextText;
         updateLiveTextPresence(nextText);
         selectionRef.current = selection ?? { start: nextText.length, end: nextText.length };
         textInputRef.current?.replaceText(nextText, selection);
         onChangeText(nextText);
       },
-      [onChangeText, updateComposerHeightForText, updateLiveTextPresence],
+      [onChangeText, updateLiveTextPresence],
     );
 
     useImperativeHandle(ref, () => ({
@@ -1273,6 +1320,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         }),
       getNativeElement: () => (isWeb ? getTextInputNativeElement(textInputRef.current) : null),
     }));
+    const inputHeightRef = useRef(MIN_INPUT_HEIGHT);
     const sendAfterTranscriptRef = useRef(false);
     const serverInfo = useSessionStore(
       useCallback(
@@ -1287,13 +1335,12 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     );
 
     useEffect(() => {
-      if (appliedTextReplacementKeyRef.current === textReplacement.key) return;
-      appliedTextReplacementKeyRef.current = textReplacement.key;
-      updateComposerHeightForText?.(valueRef.current, textReplacement.text);
-      valueRef.current = textReplacement.text;
-      updateLiveTextPresence(textReplacement.text);
-      textInputRef.current?.replaceText(textReplacement.text);
-    }, [textReplacement, updateComposerHeightForText, updateLiveTextPresence]);
+      if (appliedTextReplacementKeyRef.current === textReplacementKey) return;
+      appliedTextReplacementKeyRef.current = textReplacementKey;
+      valueRef.current = value;
+      updateLiveTextPresence(value);
+      textInputRef.current?.replaceText(value);
+    }, [textReplacementKey, updateLiveTextPresence, value]);
 
     useEffect(() => {
       return () => {
@@ -1490,8 +1537,10 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     ]);
 
     const minimizeInputHeight = useCallback(() => {
-      resetComposerHeight?.();
-    }, [resetComposerHeight]);
+      inputHeightRef.current = MIN_INPUT_HEIGHT;
+      setInputHeight(MIN_INPUT_HEIGHT);
+      onHeightChange?.(MIN_INPUT_HEIGHT);
+    }, [onHeightChange]);
 
     const handleSendMessage = useCallback(() => {
       const liveValue = textInputRef.current?.getText() ?? valueRef.current;
@@ -1559,6 +1608,8 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       [],
     );
 
+    const webTextareaRef = useRef<HTMLElement | null>(null);
+
     useLayoutEffect(() => {
       if (isWeb) {
         webTextareaRef.current = getWebTextArea() as HTMLElement | null;
@@ -1573,6 +1624,37 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       isRealtimeVoiceForCurrentAgent,
       onAddImages,
     });
+
+    const setBoundedInputHeight = useCallback(
+      (nextHeight: number) => {
+        const bounded = Math.max(MIN_INPUT_HEIGHT, Math.min(maxInputHeight, nextHeight));
+        if (Math.abs(inputHeightRef.current - bounded) < 1) return;
+        inputHeightRef.current = bounded;
+        setInputHeight(bounded);
+        onHeightChange?.(bounded);
+      },
+      [maxInputHeight, onHeightChange],
+    );
+
+    useEffect(() => {
+      setBoundedInputHeight(inputHeightRef.current);
+    }, [setBoundedInputHeight]);
+
+    const measureComposerHeight = useComposerHeightMirror({
+      value,
+      textareaRef: webTextareaRef,
+      minHeight: MIN_INPUT_HEIGHT,
+      maxHeight: maxInputHeight,
+      onHeight: setBoundedInputHeight,
+    });
+
+    const handleContentSizeChange = useCallback(
+      (event: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => {
+        if (isWeb) return;
+        setBoundedInputHeight(event.nativeEvent.contentSize.height);
+      },
+      [setBoundedInputHeight],
+    );
 
     const handleSelectionChange = useCallback(
       (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
@@ -1660,12 +1742,12 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
     const handleInputChange = useCallback(
       (nextValue: string) => {
-        updateComposerHeightForText?.(valueRef.current, nextValue);
         valueRef.current = nextValue;
+        measureComposerHeight(nextValue);
         updateLiveTextPresence(nextValue);
         onChangeText(nextValue);
       },
-      [onChangeText, updateComposerHeightForText, updateLiveTextPresence],
+      [measureComposerHeight, onChangeText, updateLiveTextPresence],
     );
 
     const handleInputFocus = useCallback(() => {
@@ -1725,9 +1807,16 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     // `.css-textinput-*` class and loses on source order — so a themed
     // `fontFamily` here is silently dropped while every other property lands.
     // An inline style outranks both classes. See docs/unistyles.md.
+    const tokenRendering = useComposerTokenRendering(value);
+
     const textInputStyle = useMemo(
-      () => [styles.textInput, mode.isMonospace && styles.textInputMonospace, composerHeightStyle],
-      [composerHeightStyle, mode.isMonospace],
+      () => [
+        styles.textInput,
+        mode.isMonospace && styles.textInputMonospace,
+        computeTextInputHeightStyle(inputHeight, maxInputHeight),
+        tokenRendering.inputTextStyle,
+      ],
+      [inputHeight, maxInputHeight, mode.isMonospace, tokenRendering.inputTextStyle],
     );
     // Static content has no textarea to mirror, so it grows with its own text
     // instead of the measured input height.
@@ -1772,12 +1861,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     );
 
     return (
-      <View
-        ref={rootRef}
-        style={styles.container}
-        testID="message-input-root"
-        onLayout={handleComposerLayout}
-      >
+      <View ref={rootRef} style={styles.container} testID="message-input-root">
         <MessageInputAutoFocus
           enabled={autoFocus}
           autoFocusKey={autoFocusKey}
@@ -1798,14 +1882,17 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               textInputRef={textInputRef}
               textInputStyle={textInputStyle}
               readOnlyTextStyle={readOnlyTextStyle}
+              tokenRendering={tokenRendering}
+              tokenTextareaRef={webTextareaRef}
               placeholder={placeholder ?? t("composer.placeholders.fallback")}
               accessibilityLabel={t(mode.accessibilityLabelKey)}
               onChangeText={handleInputChange}
               onFocus={handleInputFocus}
               onBlur={handleInputBlur}
               editable={!isDictating && !isRealtimeVoiceForCurrentAgent && !disabled}
-              scrollEnabled={isComposerScrollEnabled}
+              scrollEnabled={isWeb ? inputHeight >= maxInputHeight : true}
               autoFocus={false}
+              onContentSizeChange={handleContentSizeChange}
               onKeyPress={shouldHandleWebKeyPress ? handleDesktopKeyPress : undefined}
               onSelectionChange={handleSelectionChange}
               onPasteImages={onPasteImages}
@@ -1901,11 +1988,9 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
 
 const styles = StyleSheet.create((theme: Theme) => ({
   container: {
-    flexShrink: 1,
     position: "relative",
   },
   inputWrapper: {
-    flexShrink: 1,
     flexDirection: "column",
     gap: theme.spacing[3],
     backgroundColor: theme.colors.surface1,
@@ -1934,7 +2019,6 @@ const styles = StyleSheet.create((theme: Theme) => ({
     borderStyle: "dotted",
   },
   textInputScrollWrapper: {
-    flexShrink: 1,
     position: "relative",
   },
   focusHintText: {
@@ -1946,13 +2030,11 @@ const styles = StyleSheet.create((theme: Theme) => ({
     opacity: 0.5,
   },
   textInput: {
-    // Preserve the controls when an ancestor constrains an overlong draft.
-    flexShrink: 1,
     width: "100%",
     color: theme.colors.foreground,
-    fontSize: theme.fontSize.content,
+    fontSize: theme.fontSize.base,
     fontWeight: theme.fontWeight.normal,
-    lineHeight: theme.fontSize.content * 1.4,
+    lineHeight: theme.fontSize.base * 1.4,
     ...(isWeb
       ? ({
           outlineStyle: "none",
@@ -1968,8 +2050,18 @@ const styles = StyleSheet.create((theme: Theme) => ({
     minHeight: MIN_INPUT_HEIGHT,
     color: theme.colors.foregroundMuted,
   },
+  // Hands the glyphs to the mirror layer while the textarea keeps the caret,
+  // selection and IME. `caretColor` has no React Native equivalent, hence the
+  // web-only escape.
+  textInputMirrored: {
+    color: "transparent",
+    ...(isWeb
+      ? ({
+          caretColor: theme.colors.foreground,
+        } as object)
+      : {}),
+  },
   buttonRow: {
-    flexShrink: 0,
     flexDirection: "row",
     alignItems: "flex-end",
     justifyContent: "space-between",

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -39,7 +39,7 @@ import type { ComposerAttachment } from "@/attachments/types";
 import type { ImageAttachment, MessagePayload } from "@/composer/types";
 import { useComposerSigils } from "@/composer/tokens/use-composer-sigils";
 import type { ComposerSigils } from "@/composer/tokens/sigils";
-import { collectComposerTokens } from "@/composer/tokens/tokens";
+import { collectComposerTokens, type ComposerTokenCatalog } from "@/composer/tokens/tokens";
 import { ComposerTokenHighlightLayer } from "./token-highlight";
 import { focusWithRetries } from "@/utils/web-focus";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -116,6 +116,7 @@ export interface ComposerKeyPressEvent {
 
 export interface MessageInputProps {
   value: string;
+  tokenCatalog: ComposerTokenCatalog;
   onChangeText: (text: string) => void;
   onSubmit: (payload: MessagePayload) => void;
   /** When true, the submit button is enabled even without text or images (e.g. external attachment selected). */
@@ -641,6 +642,7 @@ interface ComposerTextSurfaceProps {
   textInputStyle: EditingTextInputProps["style"];
   readOnlyTextStyle: React.ComponentProps<typeof Text>["style"];
   tokenRendering: ReturnType<typeof useComposerTokenRendering>;
+  tokenCatalog: ComposerTokenCatalog;
   tokenTextareaRef: React.RefObject<HTMLElement | null>;
   placeholder: string;
   accessibilityLabel: string;
@@ -681,6 +683,7 @@ function ComposerTextSurface(props: ComposerTextSurfaceProps): React.ReactElemen
         enabled={props.tokenRendering.showTokenMirror}
         value={props.value}
         sigils={props.tokenRendering.sigils}
+        tokenCatalog={props.tokenCatalog}
         textareaRef={props.tokenTextareaRef}
       />
       <ComposerTextInput
@@ -1031,7 +1034,10 @@ function computeTextInputHeightStyle(inputHeight: number, maxInputHeight: number
  * textarea instead of the mirror. Native always keeps its controlled plain-text
  * path because React Native TextInput cannot safely render styled spans.
  */
-function useComposerTokenRendering(value: string): {
+function useComposerTokenRendering(
+  value: string,
+  tokenCatalog: ComposerTokenCatalog,
+): {
   sigils: ComposerSigils;
   showTokenMirror: boolean;
   /** Marks the input for the tokenized-selection stylesheet while a token exists. */
@@ -1040,7 +1046,10 @@ function useComposerTokenRendering(value: string): {
   inputTextStyle: StyleProp<TextStyle>;
 } {
   const sigils = useComposerSigils();
-  const hasTokens = useMemo(() => collectComposerTokens(value, sigils).length > 0, [value, sigils]);
+  const hasTokens = useMemo(
+    () => collectComposerTokens(value, sigils, tokenCatalog).length > 0,
+    [value, sigils, tokenCatalog],
+  );
   const showTokenMirror = isWeb && hasTokens;
 
   return {
@@ -1104,6 +1113,7 @@ function computeSendButtonState(input: SendButtonStateInput): SendButtonStateOut
 
 interface ResolvedMessageInputProps {
   value: string;
+  tokenCatalog: ComposerTokenCatalog;
   onChangeText: (text: string) => void;
   onSubmit: (payload: MessagePayload) => void;
   hasExternalContent: boolean;
@@ -1151,6 +1161,7 @@ interface ResolvedMessageInputProps {
 function resolveMessageInputProps(props: MessageInputProps): ResolvedMessageInputProps {
   return {
     value: props.value,
+    tokenCatalog: props.tokenCatalog,
     onChangeText: props.onChangeText,
     onSubmit: props.onSubmit,
     hasExternalContent: props.hasExternalContent ?? false,
@@ -1206,6 +1217,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
   function MessageInput(props, ref) {
     const {
       value,
+      tokenCatalog,
       onChangeText,
       onSubmit,
       hasExternalContent,
@@ -1807,7 +1819,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
     // `.css-textinput-*` class and loses on source order — so a themed
     // `fontFamily` here is silently dropped while every other property lands.
     // An inline style outranks both classes. See docs/unistyles.md.
-    const tokenRendering = useComposerTokenRendering(value);
+    const tokenRendering = useComposerTokenRendering(value, tokenCatalog);
 
     const textInputStyle = useMemo(
       () => [
@@ -1883,6 +1895,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               textInputStyle={textInputStyle}
               readOnlyTextStyle={readOnlyTextStyle}
               tokenRendering={tokenRendering}
+              tokenCatalog={tokenCatalog}
               tokenTextareaRef={webTextareaRef}
               placeholder={placeholder ?? t("composer.placeholders.fallback")}
               accessibilityLabel={t(mode.accessibilityLabelKey)}

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -1047,8 +1047,8 @@ function useComposerTokenRendering(
 } {
   const sigils = useComposerSigils();
   const hasTokens = useMemo(
-    () => collectComposerTokens(value, sigils, tokenCatalog).length > 0,
-    [value, sigils, tokenCatalog],
+    () => collectComposerTokens(value, tokenCatalog).length > 0,
+    [value, tokenCatalog],
   );
   const showTokenMirror = isWeb && hasTokens;
 

--- a/packages/app/src/composer/input/token-highlight-types.ts
+++ b/packages/app/src/composer/input/token-highlight-types.ts
@@ -1,0 +1,15 @@
+import type { RefObject } from "react";
+import type { ComposerSigils } from "@/composer/tokens/sigils";
+
+export interface ComposerTokenHighlightProps {
+  /**
+   * False when the draft has no token, or on native. The component renders nothing
+   * and installs no observers, so the untokenised path costs nothing — the gate
+   * lives here rather than at the call site to keep the composer's render simple.
+   */
+  enabled: boolean;
+  value: string;
+  sigils: ComposerSigils;
+  /** The underlying `<textarea>` on web; unused on native. */
+  textareaRef: RefObject<unknown>;
+}

--- a/packages/app/src/composer/input/token-highlight-types.ts
+++ b/packages/app/src/composer/input/token-highlight-types.ts
@@ -1,5 +1,6 @@
 import type { RefObject } from "react";
 import type { ComposerSigils } from "@/composer/tokens/sigils";
+import type { ComposerTokenCatalog } from "@/composer/tokens/tokens";
 
 export interface ComposerTokenHighlightProps {
   /**
@@ -10,6 +11,7 @@ export interface ComposerTokenHighlightProps {
   enabled: boolean;
   value: string;
   sigils: ComposerSigils;
+  tokenCatalog: ComposerTokenCatalog;
   /** The underlying `<textarea>` on web; unused on native. */
   textareaRef: RefObject<unknown>;
 }

--- a/packages/app/src/composer/input/token-highlight.d.ts
+++ b/packages/app/src/composer/input/token-highlight.d.ts
@@ -1,0 +1,1 @@
+export * from "./token-highlight.native";

--- a/packages/app/src/composer/input/token-highlight.native.tsx
+++ b/packages/app/src/composer/input/token-highlight.native.tsx
@@ -1,0 +1,12 @@
+import type { ComposerTokenHighlightProps } from "./token-highlight-types";
+
+export type { ComposerTokenHighlightProps };
+
+/**
+ * Native TextInput cannot safely render styled spans: Android rejects `value`
+ * together with children, while iOS ignores the children. Keep the controlled
+ * plain-text path until native has a real attributed-input implementation.
+ */
+export function ComposerTokenHighlightLayer(_props: ComposerTokenHighlightProps): null {
+  return null;
+}

--- a/packages/app/src/composer/input/token-highlight.web.tsx
+++ b/packages/app/src/composer/input/token-highlight.web.tsx
@@ -189,6 +189,7 @@ function ComposerTokenHighlight({
   enabled,
   value,
   sigils,
+  tokenCatalog,
   textareaRef,
   accentBrightColor,
   foregroundColor,
@@ -217,8 +218,9 @@ function ComposerTokenHighlight({
   }, [enabled, textareaRef]);
 
   const segments = useMemo(
-    () => (enabled ? segmentComposerText(value, collectComposerTokens(value, sigils)) : []),
-    [enabled, value, sigils],
+    () =>
+      enabled ? segmentComposerText(value, collectComposerTokens(value, sigils, tokenCatalog)) : [],
+    [enabled, value, sigils, tokenCatalog],
   );
 
   const containerStyle = useMemo<CSSProperties>(

--- a/packages/app/src/composer/input/token-highlight.web.tsx
+++ b/packages/app/src/composer/input/token-highlight.web.tsx
@@ -1,0 +1,278 @@
+/**
+ * Composer token pills — web.
+ *
+ * A mirror layer sits directly behind the composer's `<textarea>`, rendering the
+ * same string with command/skill tokens wrapped in rounded pills. The textarea
+ * paints its own text transparent, so the mirror is what the user reads while the
+ * textarea still owns the caret, selection, IME and the native context menu.
+ *
+ * THE INVARIANT: the mirror must lay out character-for-character identically to
+ * the textarea, or the pills drift away from the caret. That has two
+ * consequences, both load-bearing:
+ *
+ *  1. Every font/box property that affects line breaking is copied from the live
+ *     textarea (see COPIED_STYLES) rather than restated in a stylesheet. A
+ *     stylesheet drifts out of sync; a copy cannot.
+ *  2. A pill may not change the advance width of the text it decorates. Its
+ *     horizontal padding is cancelled by an equal negative margin, so the pill
+ *     grows *visually* around the glyphs without moving them. This is also why
+ *     the pill shows the literal token text (`$release-beta`) rather than an icon
+ *     plus a prettified display name — either would add width and desynchronise
+ *     the wrap. The upside is that what you read is exactly what gets sent.
+ *
+ * Theme colors arrive as props through `withUnistyles` (alternative 3 in
+ * docs/unistyles.md) because this component draws raw DOM rather than `style`-tracked
+ * RN views, so only the wrapper re-renders on a theme change. Do NOT reach for
+ * `var(--colors-*)` here: nothing in Unistyles emits those variables.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties, RefObject } from "react";
+import { withUnistyles } from "react-native-unistyles";
+import { collectComposerTokens, segmentComposerText } from "@/composer/tokens/tokens";
+import type { Theme } from "@/styles/theme";
+import type { ComposerTokenHighlightProps } from "./token-highlight-types";
+
+export type { ComposerTokenHighlightProps };
+
+interface ThemedProps extends Omit<ComposerTokenHighlightProps, "textareaRef"> {
+  textareaRef: RefObject<HTMLElement | null>;
+  /** The theme's accent-as-text token — the same one markdown links use. */
+  accentBrightColor: string;
+  foregroundColor: string;
+}
+
+const COPIED_STYLES = [
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "fontVariant",
+  "fontStretch",
+  "fontKerning",
+  "fontFeatureSettings",
+  "fontOpticalSizing",
+  "fontVariationSettings",
+  "lineHeight",
+  "letterSpacing",
+  "wordSpacing",
+  "textTransform",
+  "textIndent",
+  "whiteSpace",
+  "wordWrap",
+  "overflowWrap",
+  "wordBreak",
+  "tabSize",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "direction",
+  "textAlign",
+  "textRendering",
+] as const;
+
+type CopiedStyle = (typeof COPIED_STYLES)[number];
+
+const SELECTION_STYLE_ID = "paseo-composer-token-selection";
+let installedSelectionColor: string | null = null;
+
+/**
+ * The textarea sits above the mirror, so its selection rectangle would paint over
+ * the glyphs the mirror is drawing. A translucent selection lets them read
+ * through — without this, selecting tokenised text blanks it out.
+ *
+ * `::selection` cannot be expressed inline, so the rule is injected and rewritten
+ * whenever the theme's accent changes.
+ */
+function installSelectionStyles(accentBrightColor: string): void {
+  if (typeof document === "undefined" || installedSelectionColor === accentBrightColor) {
+    return;
+  }
+  const style = document.getElementById(SELECTION_STYLE_ID) ?? document.createElement("style");
+  style.id = SELECTION_STYLE_ID;
+  style.textContent = `
+[data-composer-tokenized]::selection {
+  background: color-mix(in srgb, ${accentBrightColor} 35%, transparent);
+  color: transparent;
+}
+`;
+  if (!style.isConnected) {
+    document.head.append(style);
+  }
+  installedSelectionColor = accentBrightColor;
+}
+
+/**
+ * Mirror the textarea's computed layout styles into React style props.
+ *
+ * Re-read whenever the element's box or style attributes change: the composer's
+ * font size is user-configurable and its width changes with the panel layout. A
+ * stale copy surfaces as misaligned pills rather than as an error.
+ */
+function useMirroredStyles(
+  textareaRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+): CSSProperties {
+  // Values come straight off `getComputedStyle`, so they are strings rather than
+  // the narrow literal unions CSSProperties declares for keywords like
+  // `direction`. The browser produced them, so they are valid by construction.
+  const [styles, setStyles] = useState<CSSProperties>({});
+  const previousRef = useRef("");
+
+  useEffect(() => {
+    const source = textareaRef.current;
+    if (
+      !enabled ||
+      !source ||
+      typeof window === "undefined" ||
+      !(source instanceof window.HTMLElement)
+    ) {
+      return;
+    }
+
+    const read = () => {
+      const computed = window.getComputedStyle(source);
+      const next: Partial<Record<CopiedStyle, string>> = {};
+      for (const property of COPIED_STYLES) {
+        next[property] = computed[property];
+      }
+      const signature = JSON.stringify(next);
+      if (signature === previousRef.current) {
+        return;
+      }
+      previousRef.current = signature;
+      setStyles(next as CSSProperties);
+    };
+
+    read();
+
+    const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(read);
+    resizeObserver?.observe(source);
+
+    const mutationObserver =
+      typeof MutationObserver === "undefined" ? null : new MutationObserver(read);
+    mutationObserver?.observe(source, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+    };
+  }, [textareaRef, enabled]);
+
+  return styles;
+}
+
+/**
+ * Tint and text both derive from `accentBright`, not `accent`. `accent` is the dark
+ * fill green: a 30% tint of it under foreground-colored text goes muddy on dark and
+ * harsh on light. Keeping fill, border and text on one bright hue reads as a single
+ * quiet object in both themes.
+ */
+function pillStyle(accentBrightColor: string): CSSProperties {
+  return {
+    backgroundColor: `color-mix(in srgb, ${accentBrightColor} 14%, transparent)`,
+    boxShadow: `inset 0 0 0 1px color-mix(in srgb, ${accentBrightColor} 30%, transparent)`,
+    color: accentBrightColor,
+    borderRadius: 6,
+    // Padding grows the pill; the matching negative margin gives the width back, so
+    // glyph positions are untouched. Never change one without the other.
+    padding: "2px 4px",
+    margin: "0 -4px",
+  };
+}
+
+function ComposerTokenHighlight({
+  enabled,
+  value,
+  sigils,
+  textareaRef,
+  accentBrightColor,
+  foregroundColor,
+}: ThemedProps) {
+  const mirroredStyles = useMirroredStyles(textareaRef, enabled);
+  const scrollLayerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    installSelectionStyles(accentBrightColor);
+  }, [enabled, accentBrightColor]);
+
+  useEffect(() => {
+    const source = textareaRef.current;
+    const scrollLayer = scrollLayerRef.current;
+    if (!enabled || !source || !scrollLayer) {
+      return;
+    }
+
+    const syncScroll = () => {
+      scrollLayer.style.transform = `translateY(${-source.scrollTop}px)`;
+    };
+    syncScroll();
+    source.addEventListener("scroll", syncScroll, { passive: true });
+    return () => source.removeEventListener("scroll", syncScroll);
+  }, [enabled, textareaRef]);
+
+  const segments = useMemo(
+    () => (enabled ? segmentComposerText(value, collectComposerTokens(value, sigils)) : []),
+    [enabled, value, sigils],
+  );
+
+  const containerStyle = useMemo<CSSProperties>(
+    () => ({
+      ...mirroredStyles,
+      position: "absolute",
+      inset: 0,
+      overflow: "hidden",
+      pointerEvents: "none",
+      color: foregroundColor,
+      boxSizing: "border-box",
+    }),
+    [mirroredStyles, foregroundColor],
+  );
+
+  const tokenStyle = useMemo(() => pillStyle(accentBrightColor), [accentBrightColor]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <div aria-hidden="true" data-composer-token-mirror="" style={containerStyle}>
+      <div ref={scrollLayerRef}>
+        {segments.map((segment) =>
+          segment.kind === "text" ? (
+            <span key={segment.start}>{segment.text}</span>
+          ) : (
+            <span key={segment.start} style={tokenStyle}>
+              {segment.text}
+            </span>
+          ),
+        )}
+        {/* A trailing newline collapses without something after it, which would
+            shift the mirror's last line relative to the textarea's. */}
+        {value.endsWith("\n") ? <span>{"​"}</span> : null}
+      </div>
+    </div>
+  );
+}
+
+const composerTokenHighlightColorMapping = (theme: Theme) => ({
+  accentBrightColor: theme.colors.accentBright,
+  foregroundColor: theme.colors.foreground,
+});
+
+const ThemedComposerTokenHighlight = withUnistyles(ComposerTokenHighlight);
+
+export function ComposerTokenHighlightLayer(props: ComposerTokenHighlightProps) {
+  return (
+    <ThemedComposerTokenHighlight
+      {...props}
+      textareaRef={props.textareaRef as RefObject<HTMLElement | null>}
+      uniProps={composerTokenHighlightColorMapping}
+    />
+  );
+}

--- a/packages/app/src/composer/input/token-highlight.web.tsx
+++ b/packages/app/src/composer/input/token-highlight.web.tsx
@@ -19,6 +19,10 @@
  *     the pill shows the literal token text (`$release-beta`) rather than an icon
  *     plus a prettified display name — either would add width and desynchronise
  *     the wrap. The upside is that what you read is exactly what gets sent.
+ *  3. Swapping the canonical slash for the configured sigil is a one-character
+ *     substitution but *not* a width-neutral one: the UI font is proportional, so
+ *     `$` is 3.2px wider than `/` at the default size. The difference is measured
+ *     and given back as margins on the sigil — see useSigilAdvanceCorrections.
  *
  * Theme colors arrive as props through `withUnistyles` (alternative 3 in
  * docs/unistyles.md) because this component draws raw DOM rather than `style`-tracked
@@ -26,13 +30,15 @@
  * `var(--colors-*)` here: nothing in Unistyles emits those variables.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, RefObject } from "react";
 import { withUnistyles } from "react-native-unistyles";
+import { DEFAULT_COMMAND_SIGIL, type ComposerSigils } from "@/composer/tokens/sigils";
 import {
   collectComposerTokens,
-  getComposerTokenDisplayText,
+  getComposerTokenSigil,
   segmentComposerText,
+  type ComposerTokenType,
 } from "@/composer/tokens/tokens";
 import type { Theme } from "@/styles/theme";
 import type { ComposerTokenHighlightProps } from "./token-highlight-types";
@@ -117,11 +123,14 @@ function installSelectionStyles(accentBrightColor: string): void {
 function useMirroredStyles(
   textareaRef: RefObject<HTMLElement | null>,
   enabled: boolean,
-): CSSProperties {
+): { styles: CSSProperties; signature: string } {
   // Values come straight off `getComputedStyle`, so they are strings rather than
   // the narrow literal unions CSSProperties declares for keywords like
   // `direction`. The browser produced them, so they are valid by construction.
-  const [styles, setStyles] = useState<CSSProperties>({});
+  const [mirrored, setMirrored] = useState<{ styles: CSSProperties; signature: string }>({
+    styles: {},
+    signature: "",
+  });
   const previousRef = useRef("");
 
   useEffect(() => {
@@ -146,7 +155,7 @@ function useMirroredStyles(
         return;
       }
       previousRef.current = signature;
-      setStyles(next as CSSProperties);
+      setMirrored({ styles: next as CSSProperties, signature });
     };
 
     read();
@@ -167,7 +176,76 @@ function useMirroredStyles(
     };
   }, [textareaRef, enabled]);
 
-  return styles;
+  return mirrored;
+}
+
+type SigilAdvanceCorrections = Record<ComposerTokenType, number>;
+
+const NO_SIGIL_CORRECTIONS: SigilAdvanceCorrections = { command: 0, skill: 0 };
+
+/**
+ * The canonical slash's advance width minus each configured display sigil's, in
+ * CSS pixels — negative when the sigil is the wider glyph, which `$` is.
+ *
+ * Substituting one character for another is not width-neutral in a proportional
+ * font: `$` is 3.2px wider than `/` at the default 16px UI font. Left uncorrected
+ * the mirror's glyphs drift right of the textarea's from the first token onward,
+ * so the caret trails the text it belongs to, and a token near the wrap point can
+ * push the mirror onto a line the textarea does not have.
+ *
+ * Measured in the mirror itself rather than tabulated, because the font family and
+ * size are both user-configurable.
+ */
+function useSigilAdvanceCorrections(
+  containerRef: RefObject<HTMLDivElement | null>,
+  enabled: boolean,
+  sigils: ComposerSigils,
+  styleSignature: string,
+): SigilAdvanceCorrections {
+  const [corrections, setCorrections] = useState<SigilAdvanceCorrections>(NO_SIGIL_CORRECTIONS);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!enabled || !container) {
+      return;
+    }
+
+    const probe = document.createElement("span");
+    probe.style.position = "absolute";
+    probe.style.visibility = "hidden";
+    probe.style.whiteSpace = "pre";
+    container.append(probe);
+    const advanceOf = (character: string) => {
+      probe.textContent = character;
+      return probe.getBoundingClientRect().width;
+    };
+    const canonical = advanceOf(DEFAULT_COMMAND_SIGIL);
+    const next: SigilAdvanceCorrections = {
+      command: canonical - advanceOf(sigils.command),
+      skill: canonical - advanceOf(sigils.skill),
+    };
+    probe.remove();
+
+    setCorrections((previous) =>
+      previous.command === next.command && previous.skill === next.skill ? previous : next,
+    );
+  }, [containerRef, enabled, sigils.command, sigils.skill, styleSignature]);
+
+  return corrections;
+}
+
+/**
+ * Give the correction back as margins, half on each side, so the sigil stays
+ * centred on the slot the canonical slash occupies in the textarea. Every glyph
+ * after the sigil then lands exactly where the textarea puts it; only the sigil
+ * itself overhangs, into the pill's own padding on the left and into the gap
+ * before the name on the right.
+ */
+function sigilStyle(correction: number): CSSProperties | undefined {
+  if (correction === 0) {
+    return undefined;
+  }
+  return { marginLeft: correction / 2, marginRight: correction / 2 };
 }
 
 /**
@@ -198,8 +276,13 @@ function ComposerTokenHighlight({
   accentBrightColor,
   foregroundColor,
 }: ThemedProps) {
-  const mirroredStyles = useMirroredStyles(textareaRef, enabled);
+  const { styles: mirroredStyles, signature: mirroredSignature } = useMirroredStyles(
+    textareaRef,
+    enabled,
+  );
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const scrollLayerRef = useRef<HTMLDivElement | null>(null);
+  const corrections = useSigilAdvanceCorrections(containerRef, enabled, sigils, mirroredSignature);
 
   useEffect(() => {
     if (!enabled) return;
@@ -240,20 +323,30 @@ function ComposerTokenHighlight({
   );
 
   const tokenStyle = useMemo(() => pillStyle(accentBrightColor), [accentBrightColor]);
+  const sigilStyles = useMemo(
+    () => ({
+      command: sigilStyle(corrections.command),
+      skill: sigilStyle(corrections.skill),
+    }),
+    [corrections],
+  );
 
   if (!enabled) {
     return null;
   }
 
   return (
-    <div aria-hidden="true" data-composer-token-mirror="" style={containerStyle}>
+    <div ref={containerRef} aria-hidden="true" data-composer-token-mirror="" style={containerStyle}>
       <div ref={scrollLayerRef}>
         {segments.map((segment) =>
           segment.kind === "text" ? (
             <span key={segment.start}>{segment.text}</span>
           ) : (
             <span key={segment.start} style={tokenStyle}>
-              {getComposerTokenDisplayText(segment.token, sigils)}
+              <span style={sigilStyles[segment.token.type]}>
+                {getComposerTokenSigil(segment.token, sigils)}
+              </span>
+              {segment.token.name}
             </span>
           ),
         )}

--- a/packages/app/src/composer/input/token-highlight.web.tsx
+++ b/packages/app/src/composer/input/token-highlight.web.tsx
@@ -29,7 +29,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, RefObject } from "react";
 import { withUnistyles } from "react-native-unistyles";
-import { collectComposerTokens, segmentComposerText } from "@/composer/tokens/tokens";
+import {
+  collectComposerTokens,
+  getComposerTokenDisplayText,
+  segmentComposerText,
+} from "@/composer/tokens/tokens";
 import type { Theme } from "@/styles/theme";
 import type { ComposerTokenHighlightProps } from "./token-highlight-types";
 
@@ -218,9 +222,8 @@ function ComposerTokenHighlight({
   }, [enabled, textareaRef]);
 
   const segments = useMemo(
-    () =>
-      enabled ? segmentComposerText(value, collectComposerTokens(value, sigils, tokenCatalog)) : [],
-    [enabled, value, sigils, tokenCatalog],
+    () => (enabled ? segmentComposerText(value, collectComposerTokens(value, tokenCatalog)) : []),
+    [enabled, value, tokenCatalog],
   );
 
   const containerStyle = useMemo<CSSProperties>(
@@ -250,7 +253,7 @@ function ComposerTokenHighlight({
             <span key={segment.start}>{segment.text}</span>
           ) : (
             <span key={segment.start} style={tokenStyle}>
-              {segment.text}
+              {getComposerTokenDisplayText(segment.token, sigils)}
             </span>
           ),
         )}

--- a/packages/app/src/composer/tokens/sent-text.tsx
+++ b/packages/app/src/composer/tokens/sent-text.tsx
@@ -1,0 +1,52 @@
+import { memo, useMemo } from "react";
+import { Text, type StyleProp, type TextStyle } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import type { ComposerSigils } from "./sigils";
+import {
+  collectSubmittedComposerTokens,
+  getComposerTokenDisplayText,
+  segmentComposerText,
+} from "./tokens";
+
+interface SentComposerTokenTextProps {
+  text: string;
+  sigils: ComposerSigils;
+  style: StyleProp<TextStyle>;
+}
+
+export const SentComposerTokenText = memo(function SentComposerTokenText({
+  text,
+  sigils,
+  style,
+}: SentComposerTokenTextProps) {
+  const segments = useMemo(
+    () => segmentComposerText(text, collectSubmittedComposerTokens(text)),
+    [text],
+  );
+
+  return (
+    <Text selectable style={style}>
+      {segments.map((segment) =>
+        segment.kind === "text" ? (
+          segment.text
+        ) : (
+          <Text key={segment.start} testID="sent-message-token" style={styles.token}>
+            {getComposerTokenDisplayText(segment.token, sigils)}
+          </Text>
+        ),
+      )}
+    </Text>
+  );
+});
+
+const styles = StyleSheet.create((theme) => ({
+  token: {
+    backgroundColor: theme.colors.surface2,
+    borderColor: theme.colors.accentBright,
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    color: theme.colors.accentBright,
+    paddingHorizontal: theme.spacing[1],
+    paddingVertical: 1,
+  },
+}));

--- a/packages/app/src/composer/tokens/sigils.test.ts
+++ b/packages/app/src/composer/tokens/sigils.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMPOSER_SIGIL_CHOICES,
+  DEFAULT_COMMAND_SIGIL,
+  DEFAULT_SKILL_SIGIL,
+  MENTION_SIGIL,
+  parseComposerSigil,
+  resolveComposerSigils,
+} from "./sigils";
+
+describe("COMPOSER_SIGIL_CHOICES", () => {
+  it("never offers the character reserved for file mentions", () => {
+    expect(COMPOSER_SIGIL_CHOICES).not.toContain(MENTION_SIGIL);
+  });
+
+  it("offers more choices than there are slots, so collisions can always resolve", () => {
+    expect(COMPOSER_SIGIL_CHOICES.length).toBeGreaterThan(2);
+  });
+});
+
+describe("parseComposerSigil", () => {
+  it("accepts an allowlisted character", () => {
+    expect(parseComposerSigil("$")).toBe("$");
+  });
+
+  it("rejects anything off the allowlist", () => {
+    for (const value of ["a", "1", "@", "", " ", "//", null, undefined, 7, {}]) {
+      expect(parseComposerSigil(value)).toBeNull();
+    }
+  });
+});
+
+describe("resolveComposerSigils", () => {
+  it("defaults an absent pair", () => {
+    expect(resolveComposerSigils({})).toEqual({
+      command: DEFAULT_COMMAND_SIGIL,
+      skill: DEFAULT_SKILL_SIGIL,
+    });
+  });
+
+  it("keeps a valid custom pair", () => {
+    expect(resolveComposerSigils({ command: "!", skill: "#" })).toEqual({
+      command: "!",
+      skill: "#",
+    });
+  });
+
+  it("falls back per field rather than discarding the whole pair", () => {
+    expect(resolveComposerSigils({ command: "nonsense", skill: "#" })).toEqual({
+      command: DEFAULT_COMMAND_SIGIL,
+      skill: "#",
+    });
+  });
+
+  it("breaks a collision by moving the skill sigil", () => {
+    const resolved = resolveComposerSigils({ command: "$", skill: "$" });
+    expect(resolved.command).toBe("$");
+    expect(resolved.skill).not.toBe("$");
+  });
+
+  it("breaks a collision created by the skill default", () => {
+    // Command takes `$`, so skill cannot keep its default and must move.
+    const resolved = resolveComposerSigils({ command: "$" });
+    expect(resolved.command).toBe("$");
+    expect(resolved.skill).not.toBe("$");
+  });
+
+  it("always returns a distinct pair for every allowlisted command choice", () => {
+    for (const command of COMPOSER_SIGIL_CHOICES) {
+      for (const skill of COMPOSER_SIGIL_CHOICES) {
+        const resolved = resolveComposerSigils({ command, skill });
+        expect(resolved.command).not.toBe(resolved.skill);
+      }
+    }
+  });
+});

--- a/packages/app/src/composer/tokens/sigils.ts
+++ b/packages/app/src/composer/tokens/sigils.ts
@@ -1,0 +1,63 @@
+/**
+ * Composer trigger sigils.
+ *
+ * Two menus are triggered from the composer: the command menu (full slash-command
+ * list, at line start) and the skill menu (skills only, anywhere in the message).
+ * Which character opens each is user-configurable; the pair must stay distinct so
+ * a single keystroke never means two things.
+ *
+ * The choices are an allowlist rather than free text: a sigil that collides with
+ * ordinary prose (a letter, a digit, a quote) would open the menu constantly, and
+ * `@` is reserved for file mentions.
+ */
+
+export const COMPOSER_SIGIL_CHOICES = ["/", "$", "!", "#", ">", "%"] as const;
+
+export type ComposerSigil = (typeof COMPOSER_SIGIL_CHOICES)[number];
+
+export const DEFAULT_COMMAND_SIGIL: ComposerSigil = "/";
+export const DEFAULT_SKILL_SIGIL: ComposerSigil = "$";
+
+/** Reserved for file mentions; never selectable as a command or skill sigil. */
+export const MENTION_SIGIL = "@";
+
+export interface ComposerSigils {
+  command: ComposerSigil;
+  skill: ComposerSigil;
+}
+
+export const DEFAULT_COMPOSER_SIGILS: ComposerSigils = {
+  command: DEFAULT_COMMAND_SIGIL,
+  skill: DEFAULT_SKILL_SIGIL,
+};
+
+export function isComposerSigil(value: unknown): value is ComposerSigil {
+  return typeof value === "string" && (COMPOSER_SIGIL_CHOICES as readonly string[]).includes(value);
+}
+
+export function parseComposerSigil(value: unknown): ComposerSigil | null {
+  return isComposerSigil(value) ? value : null;
+}
+
+function firstSigilExcluding(...taken: readonly string[]): ComposerSigil {
+  const available = COMPOSER_SIGIL_CHOICES.find((choice) => !taken.includes(choice));
+  // COMPOSER_SIGIL_CHOICES is longer than the number of slots, so this always resolves.
+  return available ?? DEFAULT_COMMAND_SIGIL;
+}
+
+/**
+ * Coerce stored/partial sigil settings into a valid, collision-free pair.
+ *
+ * Invalid values fall back to their default. If the two would collide, the
+ * command sigil wins and the skill sigil moves to the first free choice — the
+ * command menu is the older, more load-bearing of the two.
+ */
+export function resolveComposerSigils(input: {
+  command?: unknown;
+  skill?: unknown;
+}): ComposerSigils {
+  const command = parseComposerSigil(input.command) ?? DEFAULT_COMMAND_SIGIL;
+  const requestedSkill = parseComposerSigil(input.skill) ?? DEFAULT_SKILL_SIGIL;
+  const skill = requestedSkill === command ? firstSigilExcluding(command) : requestedSkill;
+  return { command, skill };
+}

--- a/packages/app/src/composer/tokens/tokens.test.ts
+++ b/packages/app/src/composer/tokens/tokens.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_COMPOSER_SIGILS } from "./sigils";
 import {
   collectComposerTokens,
+  collectSubmittedComposerTokens,
+  getComposerTokenDisplayText,
   normalizeComposerTokensForSubmission,
   segmentComposerText,
 } from "./tokens";
@@ -88,6 +90,27 @@ describe("normalizeComposerTokensForSubmission", () => {
     expect(
       normalizeComposerTokensForSubmission("important! cost 40$usd; read /tmp/project", sigils),
     ).toBe("important! cost 40$usd; read /tmp/project");
+  });
+});
+
+describe("submitted composer token presentation", () => {
+  it("recovers command and skill tokens from canonical slash syntax", () => {
+    expect(collectSubmittedComposerTokens("/plan then /release-beta")).toEqual([
+      { type: "command", name: "plan", start: 0, end: 5 },
+      { type: "skill", name: "release-beta", start: 11, end: 24 },
+    ]);
+  });
+
+  it("maps canonical tokens back to the active display sigils", () => {
+    const remapped = { command: "#", skill: "!" } as const;
+    expect(getComposerTokenDisplayText({ type: "command", name: "plan" }, remapped)).toBe("#plan");
+    expect(getComposerTokenDisplayText({ type: "skill", name: "release-beta" }, remapped)).toBe(
+      "!release-beta",
+    );
+  });
+
+  it("keeps paths and ordinary slash prose out of sent-message pills", () => {
+    expect(collectSubmittedComposerTokens("read /tmp/project and/or continue")).toEqual([]);
   });
 });
 

--- a/packages/app/src/composer/tokens/tokens.test.ts
+++ b/packages/app/src/composer/tokens/tokens.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_COMPOSER_SIGILS } from "./sigils";
+import {
+  collectComposerTokens,
+  normalizeComposerTokensForSubmission,
+  segmentComposerText,
+} from "./tokens";
+
+const sigils = DEFAULT_COMPOSER_SIGILS;
+
+describe("collectComposerTokens", () => {
+  it("finds a skill token mid-sentence", () => {
+    expect(collectComposerTokens("please run $release-beta now", sigils)).toEqual([
+      { type: "skill", name: "release-beta", start: 11, end: 24 },
+    ]);
+  });
+
+  it("finds a command token only at the start of the prompt", () => {
+    expect(collectComposerTokens("/review", sigils)).toEqual([
+      { type: "command", name: "review", start: 0, end: 7 },
+    ]);
+    expect(collectComposerTokens("first\n/review", sigils)).toEqual([
+      { type: "skill", name: "review", start: 6, end: 13 },
+    ]);
+  });
+
+  it("treats the command trigger as a skill trigger inline", () => {
+    expect(collectComposerTokens("and/or, read a/b", sigils)).toEqual([]);
+    expect(collectComposerTokens("use /review here", sigils)).toEqual([
+      { type: "skill", name: "review", start: 4, end: 11 },
+    ]);
+  });
+
+  it("does not treat slash-delimited paths as tokens", () => {
+    expect(collectComposerTokens("read /tmp/project", sigils)).toEqual([]);
+  });
+
+  it("ignores a skill sigil glued to a preceding word", () => {
+    expect(collectComposerTokens("cost is 40$usd", sigils)).toEqual([]);
+  });
+
+  it("ignores a bare sigil with no name", () => {
+    expect(collectComposerTokens("$ / $1 /2", sigils)).toEqual([]);
+  });
+
+  it("collects several tokens in one draft", () => {
+    const text = "/plan then $release-beta and $release-stable";
+    expect(collectComposerTokens(text, sigils).map((token) => token.name)).toEqual([
+      "plan",
+      "release-beta",
+      "release-stable",
+    ]);
+  });
+
+  it("follows remapped sigils", () => {
+    const remapped = { command: "!", skill: "#" } as const;
+    expect(collectComposerTokens("!plan and #release-beta", remapped).map((t) => t.name)).toEqual([
+      "plan",
+      "release-beta",
+    ]);
+    // The defaults carry no meaning once remapped away.
+    expect(collectComposerTokens("/plan and $release-beta", remapped)).toEqual([]);
+  });
+
+  it("stops a name at the first character outside the token charset", () => {
+    expect(collectComposerTokens("$release-beta, then", sigils)).toEqual([
+      { type: "skill", name: "release-beta", start: 0, end: 13 },
+    ]);
+  });
+});
+
+describe("normalizeComposerTokensForSubmission", () => {
+  it("converts the dedicated skill trigger to the provider-compatible slash form", () => {
+    expect(normalizeComposerTokensForSubmission("please run $release-beta", sigils)).toBe(
+      "please run /release-beta",
+    );
+  });
+
+  it("normalizes remapped command and skill triggers", () => {
+    const remapped = { command: "!", skill: "#" } as const;
+    expect(normalizeComposerTokensForSubmission("!plan then #release-beta", remapped)).toBe(
+      "/plan then /release-beta",
+    );
+  });
+
+  it("leaves ordinary prose, prices, and paths unchanged", () => {
+    expect(
+      normalizeComposerTokensForSubmission("important! cost 40$usd; read /tmp/project", sigils),
+    ).toBe("important! cost 40$usd; read /tmp/project");
+  });
+});
+
+describe("segmentComposerText", () => {
+  it("covers the whole string in order", () => {
+    const text = "please run $release-beta now";
+    const segments = segmentComposerText(text, collectComposerTokens(text, sigils));
+
+    expect(segments).toEqual([
+      { kind: "text", text: "please run ", start: 0 },
+      {
+        kind: "token",
+        text: "$release-beta",
+        start: 11,
+        token: { type: "skill", name: "release-beta", start: 11, end: 24 },
+      },
+      { kind: "text", text: " now", start: 24 },
+    ]);
+    expect(segments.map((segment) => segment.text).join("")).toBe(text);
+  });
+
+  it("returns a single text segment when there are no tokens", () => {
+    expect(segmentComposerText("plain draft", [])).toEqual([
+      { kind: "text", text: "plain draft", start: 0 },
+    ]);
+  });
+
+  it("returns nothing for an empty draft", () => {
+    expect(segmentComposerText("", [])).toEqual([]);
+  });
+
+  it("keeps adjacent tokens contiguous", () => {
+    const text = "$one $two";
+    const segments = segmentComposerText(text, collectComposerTokens(text, sigils));
+    expect(segments.map((segment) => segment.text).join("")).toBe(text);
+  });
+});

--- a/packages/app/src/composer/tokens/tokens.test.ts
+++ b/packages/app/src/composer/tokens/tokens.test.ts
@@ -7,48 +7,59 @@ import {
   getComposerTokenDisplayText,
   normalizeComposerTokensForSubmission,
   segmentComposerText,
+  type ComposerTokenCatalog,
 } from "./tokens";
 
 const sigils = DEFAULT_COMPOSER_SIGILS;
+const tokenCatalog = {
+  commandNames: new Set(["plan", "review"]),
+  skillNames: new Set(["one", "release-beta", "release-stable", "review", "two"]),
+} satisfies ComposerTokenCatalog;
 
 describe("collectComposerTokens", () => {
   it("finds a skill token mid-sentence", () => {
-    expect(collectComposerTokens("please run $release-beta now", sigils)).toEqual([
+    expect(collectComposerTokens("please run $release-beta now", sigils, tokenCatalog)).toEqual([
       { type: "skill", name: "release-beta", start: 11, end: 24 },
     ]);
   });
 
   it("finds a command token only at the start of the prompt", () => {
-    expect(collectComposerTokens("/review", sigils)).toEqual([
+    expect(collectComposerTokens("/review", sigils, tokenCatalog)).toEqual([
       { type: "command", name: "review", start: 0, end: 7 },
     ]);
-    expect(collectComposerTokens("first\n/review", sigils)).toEqual([
+    expect(collectComposerTokens("first\n/review", sigils, tokenCatalog)).toEqual([
       { type: "skill", name: "review", start: 6, end: 13 },
     ]);
   });
 
   it("treats the command trigger as a skill trigger inline", () => {
-    expect(collectComposerTokens("and/or, read a/b", sigils)).toEqual([]);
-    expect(collectComposerTokens("use /review here", sigils)).toEqual([
+    expect(collectComposerTokens("and/or, read a/b", sigils, tokenCatalog)).toEqual([]);
+    expect(collectComposerTokens("use /review here", sigils, tokenCatalog)).toEqual([
       { type: "skill", name: "review", start: 4, end: 11 },
     ]);
   });
 
   it("does not treat slash-delimited paths as tokens", () => {
-    expect(collectComposerTokens("read /tmp/project", sigils)).toEqual([]);
+    expect(collectComposerTokens("read /tmp/project", sigils, tokenCatalog)).toEqual([]);
   });
 
   it("ignores a skill sigil glued to a preceding word", () => {
-    expect(collectComposerTokens("cost is 40$usd", sigils)).toEqual([]);
+    expect(collectComposerTokens("cost is 40$usd", sigils, tokenCatalog)).toEqual([]);
   });
 
   it("ignores a bare sigil with no name", () => {
-    expect(collectComposerTokens("$ / $1 /2", sigils)).toEqual([]);
+    expect(collectComposerTokens("$ / $1 /2", sigils, tokenCatalog)).toEqual([]);
+  });
+
+  it("ignores token-shaped text that is not in the command catalog", () => {
+    expect(
+      collectComposerTokens("check $HOME and $project before #heading", sigils, tokenCatalog),
+    ).toEqual([]);
   });
 
   it("collects several tokens in one draft", () => {
     const text = "/plan then $release-beta and $release-stable";
-    expect(collectComposerTokens(text, sigils).map((token) => token.name)).toEqual([
+    expect(collectComposerTokens(text, sigils, tokenCatalog).map((token) => token.name)).toEqual([
       "plan",
       "release-beta",
       "release-stable",
@@ -57,16 +68,15 @@ describe("collectComposerTokens", () => {
 
   it("follows remapped sigils", () => {
     const remapped = { command: "!", skill: "#" } as const;
-    expect(collectComposerTokens("!plan and #release-beta", remapped).map((t) => t.name)).toEqual([
-      "plan",
-      "release-beta",
-    ]);
+    expect(
+      collectComposerTokens("!plan and #release-beta", remapped, tokenCatalog).map((t) => t.name),
+    ).toEqual(["plan", "release-beta"]);
     // The defaults carry no meaning once remapped away.
-    expect(collectComposerTokens("/plan and $release-beta", remapped)).toEqual([]);
+    expect(collectComposerTokens("/plan and $release-beta", remapped, tokenCatalog)).toEqual([]);
   });
 
   it("stops a name at the first character outside the token charset", () => {
-    expect(collectComposerTokens("$release-beta, then", sigils)).toEqual([
+    expect(collectComposerTokens("$release-beta, then", sigils, tokenCatalog)).toEqual([
       { type: "skill", name: "release-beta", start: 0, end: 13 },
     ]);
   });
@@ -74,22 +84,36 @@ describe("collectComposerTokens", () => {
 
 describe("normalizeComposerTokensForSubmission", () => {
   it("converts the dedicated skill trigger to the provider-compatible slash form", () => {
-    expect(normalizeComposerTokensForSubmission("please run $release-beta", sigils)).toBe(
-      "please run /release-beta",
-    );
+    expect(
+      normalizeComposerTokensForSubmission("please run $release-beta", sigils, tokenCatalog),
+    ).toBe("please run /release-beta");
   });
 
   it("normalizes remapped command and skill triggers", () => {
     const remapped = { command: "!", skill: "#" } as const;
-    expect(normalizeComposerTokensForSubmission("!plan then #release-beta", remapped)).toBe(
-      "/plan then /release-beta",
-    );
+    expect(
+      normalizeComposerTokensForSubmission("!plan then #release-beta", remapped, tokenCatalog),
+    ).toBe("/plan then /release-beta");
   });
 
   it("leaves ordinary prose, prices, and paths unchanged", () => {
     expect(
-      normalizeComposerTokensForSubmission("important! cost 40$usd; read /tmp/project", sigils),
+      normalizeComposerTokensForSubmission(
+        "important! cost 40$usd; read /tmp/project",
+        sigils,
+        tokenCatalog,
+      ),
     ).toBe("important! cost 40$usd; read /tmp/project");
+  });
+
+  it("preserves shell variables and unknown token-shaped prose", () => {
+    expect(
+      normalizeComposerTokensForSubmission(
+        "check $HOME and $project before sending",
+        sigils,
+        tokenCatalog,
+      ),
+    ).toBe("check $HOME and $project before sending");
   });
 });
 
@@ -117,7 +141,7 @@ describe("submitted composer token presentation", () => {
 describe("segmentComposerText", () => {
   it("covers the whole string in order", () => {
     const text = "please run $release-beta now";
-    const segments = segmentComposerText(text, collectComposerTokens(text, sigils));
+    const segments = segmentComposerText(text, collectComposerTokens(text, sigils, tokenCatalog));
 
     expect(segments).toEqual([
       { kind: "text", text: "please run ", start: 0 },
@@ -144,7 +168,7 @@ describe("segmentComposerText", () => {
 
   it("keeps adjacent tokens contiguous", () => {
     const text = "$one $two";
-    const segments = segmentComposerText(text, collectComposerTokens(text, sigils));
+    const segments = segmentComposerText(text, collectComposerTokens(text, sigils, tokenCatalog));
     expect(segments.map((segment) => segment.text).join("")).toBe(text);
   });
 });

--- a/packages/app/src/composer/tokens/tokens.test.ts
+++ b/packages/app/src/composer/tokens/tokens.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_COMPOSER_SIGILS } from "./sigils";
 import {
   collectComposerTokens,
   collectSubmittedComposerTokens,
   getComposerTokenDisplayText,
-  normalizeComposerTokensForSubmission,
   segmentComposerText,
   type ComposerTokenCatalog,
 } from "./tokens";
 
-const sigils = DEFAULT_COMPOSER_SIGILS;
 const tokenCatalog = {
   commandNames: new Set(["plan", "review"]),
   skillNames: new Set(["one", "release-beta", "release-stable", "review", "two"]),
@@ -18,102 +15,65 @@ const tokenCatalog = {
 
 describe("collectComposerTokens", () => {
   it("finds a skill token mid-sentence", () => {
-    expect(collectComposerTokens("please run $release-beta now", sigils, tokenCatalog)).toEqual([
+    expect(collectComposerTokens("please run /release-beta now", tokenCatalog)).toEqual([
       { type: "skill", name: "release-beta", start: 11, end: 24 },
     ]);
   });
 
   it("finds a command token only at the start of the prompt", () => {
-    expect(collectComposerTokens("/review", sigils, tokenCatalog)).toEqual([
+    expect(collectComposerTokens("/review", tokenCatalog)).toEqual([
       { type: "command", name: "review", start: 0, end: 7 },
     ]);
-    expect(collectComposerTokens("first\n/review", sigils, tokenCatalog)).toEqual([
+    expect(collectComposerTokens("first\n/review", tokenCatalog)).toEqual([
       { type: "skill", name: "review", start: 6, end: 13 },
     ]);
   });
 
-  it("treats the command trigger as a skill trigger inline", () => {
-    expect(collectComposerTokens("and/or, read a/b", sigils, tokenCatalog)).toEqual([]);
-    expect(collectComposerTokens("use /review here", sigils, tokenCatalog)).toEqual([
+  it("treats canonical slash syntax as a skill inline", () => {
+    expect(collectComposerTokens("and/or, read a/b", tokenCatalog)).toEqual([]);
+    expect(collectComposerTokens("use /review here", tokenCatalog)).toEqual([
       { type: "skill", name: "review", start: 4, end: 11 },
     ]);
   });
 
   it("does not treat slash-delimited paths as tokens", () => {
-    expect(collectComposerTokens("read /tmp/project", sigils, tokenCatalog)).toEqual([]);
+    expect(collectComposerTokens("read /tmp/project", tokenCatalog)).toEqual([]);
   });
 
-  it("ignores a skill sigil glued to a preceding word", () => {
-    expect(collectComposerTokens("cost is 40$usd", sigils, tokenCatalog)).toEqual([]);
-  });
-
-  it("ignores a bare sigil with no name", () => {
-    expect(collectComposerTokens("$ / $1 /2", sigils, tokenCatalog)).toEqual([]);
-  });
-
-  it("ignores token-shaped text that is not in the command catalog", () => {
+  it("does not treat uncommitted configured sigils as tokens", () => {
+    const shellCollisionCatalog = {
+      commandNames: new Set(["HOME", "project"]),
+      skillNames: new Set(["HOME", "project", "release-beta"]),
+    };
     expect(
-      collectComposerTokens("check $HOME and $project before #heading", sigils, tokenCatalog),
+      collectComposerTokens(
+        "check $HOME and $project, then run $release-beta",
+        shellCollisionCatalog,
+      ),
     ).toEqual([]);
   });
 
+  it("ignores a bare sigil with no name", () => {
+    expect(collectComposerTokens("/ /2", tokenCatalog)).toEqual([]);
+  });
+
+  it("ignores token-shaped text that is not in the command catalog", () => {
+    expect(collectComposerTokens("use /unknown before /heading", tokenCatalog)).toEqual([]);
+  });
+
   it("collects several tokens in one draft", () => {
-    const text = "/plan then $release-beta and $release-stable";
-    expect(collectComposerTokens(text, sigils, tokenCatalog).map((token) => token.name)).toEqual([
+    const text = "/plan then /release-beta and /release-stable";
+    expect(collectComposerTokens(text, tokenCatalog).map((token) => token.name)).toEqual([
       "plan",
       "release-beta",
       "release-stable",
     ]);
   });
 
-  it("follows remapped sigils", () => {
-    const remapped = { command: "!", skill: "#" } as const;
-    expect(
-      collectComposerTokens("!plan and #release-beta", remapped, tokenCatalog).map((t) => t.name),
-    ).toEqual(["plan", "release-beta"]);
-    // The defaults carry no meaning once remapped away.
-    expect(collectComposerTokens("/plan and $release-beta", remapped, tokenCatalog)).toEqual([]);
-  });
-
   it("stops a name at the first character outside the token charset", () => {
-    expect(collectComposerTokens("$release-beta, then", sigils, tokenCatalog)).toEqual([
-      { type: "skill", name: "release-beta", start: 0, end: 13 },
+    expect(collectComposerTokens("run /release-beta, then", tokenCatalog)).toEqual([
+      { type: "skill", name: "release-beta", start: 4, end: 17 },
     ]);
-  });
-});
-
-describe("normalizeComposerTokensForSubmission", () => {
-  it("converts the dedicated skill trigger to the provider-compatible slash form", () => {
-    expect(
-      normalizeComposerTokensForSubmission("please run $release-beta", sigils, tokenCatalog),
-    ).toBe("please run /release-beta");
-  });
-
-  it("normalizes remapped command and skill triggers", () => {
-    const remapped = { command: "!", skill: "#" } as const;
-    expect(
-      normalizeComposerTokensForSubmission("!plan then #release-beta", remapped, tokenCatalog),
-    ).toBe("/plan then /release-beta");
-  });
-
-  it("leaves ordinary prose, prices, and paths unchanged", () => {
-    expect(
-      normalizeComposerTokensForSubmission(
-        "important! cost 40$usd; read /tmp/project",
-        sigils,
-        tokenCatalog,
-      ),
-    ).toBe("important! cost 40$usd; read /tmp/project");
-  });
-
-  it("preserves shell variables and unknown token-shaped prose", () => {
-    expect(
-      normalizeComposerTokensForSubmission(
-        "check $HOME and $project before sending",
-        sigils,
-        tokenCatalog,
-      ),
-    ).toBe("check $HOME and $project before sending");
   });
 });
 
@@ -140,14 +100,14 @@ describe("submitted composer token presentation", () => {
 
 describe("segmentComposerText", () => {
   it("covers the whole string in order", () => {
-    const text = "please run $release-beta now";
-    const segments = segmentComposerText(text, collectComposerTokens(text, sigils, tokenCatalog));
+    const text = "please run /release-beta now";
+    const segments = segmentComposerText(text, collectComposerTokens(text, tokenCatalog));
 
     expect(segments).toEqual([
       { kind: "text", text: "please run ", start: 0 },
       {
         kind: "token",
-        text: "$release-beta",
+        text: "/release-beta",
         start: 11,
         token: { type: "skill", name: "release-beta", start: 11, end: 24 },
       },
@@ -167,8 +127,8 @@ describe("segmentComposerText", () => {
   });
 
   it("keeps adjacent tokens contiguous", () => {
-    const text = "$one $two";
-    const segments = segmentComposerText(text, collectComposerTokens(text, sigils, tokenCatalog));
+    const text = "/one /two";
+    const segments = segmentComposerText(text, collectComposerTokens(text, tokenCatalog));
     expect(segments.map((segment) => segment.text).join("")).toBe(text);
   });
 });

--- a/packages/app/src/composer/tokens/tokens.ts
+++ b/packages/app/src/composer/tokens/tokens.ts
@@ -28,6 +28,10 @@ export type ComposerTextSegment =
 
 const NAME_START = /[A-Za-z]/;
 const NAME_BODY = /[A-Za-z0-9:_-]/;
+const CANONICAL_SUBMISSION_SIGILS: ComposerSigils = {
+  command: DEFAULT_COMMAND_SIGIL,
+  skill: DEFAULT_COMMAND_SIGIL,
+};
 
 function readTokenName(text: string, nameStart: number): number {
   if (nameStart >= text.length || !NAME_START.test(text[nameStart] ?? "")) {
@@ -83,6 +87,25 @@ export function collectComposerTokens(text: string, sigils: ComposerSigils): Com
   }
 
   return tokens;
+}
+
+/**
+ * Read the canonical slash syntax stored in submitted user messages.
+ *
+ * Submission no longer carries the configured editing sigils. Position recovers
+ * the distinction: a leading slash is a command and a slash after whitespace is
+ * a skill.
+ */
+export function collectSubmittedComposerTokens(text: string): ComposerToken[] {
+  return collectComposerTokens(text, CANONICAL_SUBMISSION_SIGILS);
+}
+
+export function getComposerTokenDisplayText(
+  token: Pick<ComposerToken, "type" | "name">,
+  sigils: ComposerSigils,
+): string {
+  const sigil = token.type === "command" ? sigils.command : sigils.skill;
+  return `${sigil}${token.name}`;
 }
 
 /**

--- a/packages/app/src/composer/tokens/tokens.ts
+++ b/packages/app/src/composer/tokens/tokens.ts
@@ -7,7 +7,7 @@
  * is still the only source of truth. Deleting the canonical slash deletes the pill.
  */
 
-import { DEFAULT_COMMAND_SIGIL, type ComposerSigils } from "./sigils";
+import { DEFAULT_COMMAND_SIGIL, type ComposerSigil, type ComposerSigils } from "./sigils";
 
 export type ComposerTokenType = "command" | "skill";
 
@@ -119,12 +119,18 @@ export function collectSubmittedComposerTokens(text: string): ComposerToken[] {
   return scanComposerTokens(text, CANONICAL_SUBMISSION_SIGILS);
 }
 
+export function getComposerTokenSigil(
+  token: Pick<ComposerToken, "type">,
+  sigils: ComposerSigils,
+): ComposerSigil {
+  return token.type === "command" ? sigils.command : sigils.skill;
+}
+
 export function getComposerTokenDisplayText(
   token: Pick<ComposerToken, "type" | "name">,
   sigils: ComposerSigils,
 ): string {
-  const sigil = token.type === "command" ? sigils.command : sigils.skill;
-  return `${sigil}${token.name}`;
+  return `${getComposerTokenSigil(token, sigils)}${token.name}`;
 }
 
 /**

--- a/packages/app/src/composer/tokens/tokens.ts
+++ b/packages/app/src/composer/tokens/tokens.ts
@@ -21,6 +21,11 @@ export interface ComposerToken {
   end: number;
 }
 
+export interface ComposerTokenCatalog {
+  commandNames: ReadonlySet<string>;
+  skillNames: ReadonlySet<string>;
+}
+
 /** `start` is the segment's offset in the source text and its React key. */
 export type ComposerTextSegment =
   | { kind: "text"; text: string; start: number }
@@ -49,13 +54,14 @@ function isBoundary(char: string | undefined): boolean {
 }
 
 /**
- * Find every command/skill token in `text`.
+ * Find token-shaped ranges in `text`. Callers must still check the catalog before
+ * treating a range as a command or skill.
  *
  * The command trigger represents a command only at the start of the prompt.
  * Either trigger represents a skill after whitespace, preserving the existing
  * inline slash-skill flow while adding a dedicated skills trigger.
  */
-export function collectComposerTokens(text: string, sigils: ComposerSigils): ComposerToken[] {
+function scanComposerTokens(text: string, sigils: ComposerSigils): ComposerToken[] {
   const tokens: ComposerToken[] = [];
 
   for (let index = 0; index < text.length; index += 1) {
@@ -89,6 +95,19 @@ export function collectComposerTokens(text: string, sigils: ComposerSigils): Com
   return tokens;
 }
 
+function isRecognizedToken(token: ComposerToken, catalog: ComposerTokenCatalog): boolean {
+  const names = token.type === "command" ? catalog.commandNames : catalog.skillNames;
+  return names.has(token.name);
+}
+
+export function collectComposerTokens(
+  text: string,
+  sigils: ComposerSigils,
+  catalog: ComposerTokenCatalog,
+): ComposerToken[] {
+  return scanComposerTokens(text, sigils).filter((token) => isRecognizedToken(token, catalog));
+}
+
 /**
  * Read the canonical slash syntax stored in submitted user messages.
  *
@@ -97,7 +116,7 @@ export function collectComposerTokens(text: string, sigils: ComposerSigils): Com
  * a skill.
  */
 export function collectSubmittedComposerTokens(text: string): ComposerToken[] {
-  return collectComposerTokens(text, CANONICAL_SUBMISSION_SIGILS);
+  return scanComposerTokens(text, CANONICAL_SUBMISSION_SIGILS);
 }
 
 export function getComposerTokenDisplayText(
@@ -112,8 +131,12 @@ export function getComposerTokenDisplayText(
  * Convert configurable UI triggers to the slash form understood by the daemon
  * and every agent provider.
  */
-export function normalizeComposerTokensForSubmission(text: string, sigils: ComposerSigils): string {
-  const tokens = collectComposerTokens(text, sigils);
+export function normalizeComposerTokensForSubmission(
+  text: string,
+  sigils: ComposerSigils,
+  catalog: ComposerTokenCatalog,
+): string {
+  const tokens = collectComposerTokens(text, sigils, catalog);
   if (tokens.length === 0) {
     return text;
   }

--- a/packages/app/src/composer/tokens/tokens.ts
+++ b/packages/app/src/composer/tokens/tokens.ts
@@ -1,0 +1,139 @@
+/**
+ * Composer inline tokens.
+ *
+ * A token is a *view* over the composer's plain text, re-derived on every render
+ * from the same string that gets submitted. Nothing is stored alongside the text:
+ * drafts, dictation, undo and the wire format all keep working because the text
+ * is still the only source of truth. Deleting the sigil deletes the pill.
+ */
+
+import { DEFAULT_COMMAND_SIGIL, type ComposerSigils } from "./sigils";
+
+export type ComposerTokenType = "command" | "skill";
+
+export interface ComposerToken {
+  type: ComposerTokenType;
+  /** Token text without the sigil, e.g. `release-beta`. */
+  name: string;
+  /** Index of the sigil. */
+  start: number;
+  /** Index one past the last name character. */
+  end: number;
+}
+
+/** `start` is the segment's offset in the source text and its React key. */
+export type ComposerTextSegment =
+  | { kind: "text"; text: string; start: number }
+  | { kind: "token"; text: string; start: number; token: ComposerToken };
+
+const NAME_START = /[A-Za-z]/;
+const NAME_BODY = /[A-Za-z0-9:_-]/;
+
+function readTokenName(text: string, nameStart: number): number {
+  if (nameStart >= text.length || !NAME_START.test(text[nameStart] ?? "")) {
+    return nameStart;
+  }
+  let index = nameStart + 1;
+  while (index < text.length && NAME_BODY.test(text[index] ?? "")) {
+    index += 1;
+  }
+  return index;
+}
+
+function isBoundary(char: string | undefined): boolean {
+  return char === undefined || /\s/.test(char);
+}
+
+/**
+ * Find every command/skill token in `text`.
+ *
+ * The command trigger represents a command only at the start of the prompt.
+ * Either trigger represents a skill after whitespace, preserving the existing
+ * inline slash-skill flow while adding a dedicated skills trigger.
+ */
+export function collectComposerTokens(text: string, sigils: ComposerSigils): ComposerToken[] {
+  const tokens: ComposerToken[] = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const isCommandSigil = char === sigils.command;
+    const isSkillSigil = char === sigils.skill;
+    if (!isCommandSigil && !isSkillSigil) {
+      continue;
+    }
+
+    const previous = index > 0 ? text[index - 1] : undefined;
+    if (!isBoundary(previous)) {
+      continue;
+    }
+
+    const nameEnd = readTokenName(text, index + 1);
+    const continuesAsPath = text[nameEnd] === "/";
+    if (nameEnd === index + 1 || continuesAsPath) {
+      continue;
+    }
+
+    tokens.push({
+      type: isCommandSigil && index === 0 ? "command" : "skill",
+      name: text.slice(index + 1, nameEnd),
+      start: index,
+      end: nameEnd,
+    });
+    index = nameEnd - 1;
+  }
+
+  return tokens;
+}
+
+/**
+ * Convert configurable UI triggers to the slash form understood by the daemon
+ * and every agent provider.
+ */
+export function normalizeComposerTokensForSubmission(text: string, sigils: ComposerSigils): string {
+  const tokens = collectComposerTokens(text, sigils);
+  if (tokens.length === 0) {
+    return text;
+  }
+
+  let normalized = "";
+  let cursor = 0;
+  for (const token of tokens) {
+    normalized += text.slice(cursor, token.start);
+    normalized += DEFAULT_COMMAND_SIGIL;
+    normalized += text.slice(token.start + 1, token.end);
+    cursor = token.end;
+  }
+  normalized += text.slice(cursor);
+  return normalized;
+}
+
+/**
+ * Split `text` into alternating plain and token segments covering the whole
+ * string, so a renderer can walk it once without doing its own slicing.
+ */
+export function segmentComposerText(
+  text: string,
+  tokens: readonly ComposerToken[],
+): ComposerTextSegment[] {
+  const segments: ComposerTextSegment[] = [];
+  let cursor = 0;
+
+  for (const token of tokens) {
+    if (token.start > cursor) {
+      segments.push({ kind: "text", text: text.slice(cursor, token.start), start: cursor });
+    }
+    segments.push({
+      kind: "token",
+      text: text.slice(token.start, token.end),
+      start: token.start,
+      token,
+    });
+    cursor = token.end;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ kind: "text", text: text.slice(cursor), start: cursor });
+  }
+
+  return segments;
+}

--- a/packages/app/src/composer/tokens/tokens.ts
+++ b/packages/app/src/composer/tokens/tokens.ts
@@ -4,7 +4,7 @@
  * A token is a *view* over the composer's plain text, re-derived on every render
  * from the same string that gets submitted. Nothing is stored alongside the text:
  * drafts, dictation, undo and the wire format all keep working because the text
- * is still the only source of truth. Deleting the sigil deletes the pill.
+ * is still the only source of truth. Deleting the canonical slash deletes the pill.
  */
 
 import { DEFAULT_COMMAND_SIGIL, type ComposerSigils } from "./sigils";
@@ -57,9 +57,8 @@ function isBoundary(char: string | undefined): boolean {
  * Find token-shaped ranges in `text`. Callers must still check the catalog before
  * treating a range as a command or skill.
  *
- * The command trigger represents a command only at the start of the prompt.
- * Either trigger represents a skill after whitespace, preserving the existing
- * inline slash-skill flow while adding a dedicated skills trigger.
+ * A configured command sigil represents a command only at the start of the
+ * prompt. Either configured sigil represents a skill after whitespace.
  */
 function scanComposerTokens(text: string, sigils: ComposerSigils): ComposerToken[] {
   const tokens: ComposerToken[] = [];
@@ -102,10 +101,11 @@ function isRecognizedToken(token: ComposerToken, catalog: ComposerTokenCatalog):
 
 export function collectComposerTokens(
   text: string,
-  sigils: ComposerSigils,
   catalog: ComposerTokenCatalog,
 ): ComposerToken[] {
-  return scanComposerTokens(text, sigils).filter((token) => isRecognizedToken(token, catalog));
+  return scanComposerTokens(text, CANONICAL_SUBMISSION_SIGILS).filter((token) =>
+    isRecognizedToken(token, catalog),
+  );
 }
 
 /**
@@ -125,32 +125,6 @@ export function getComposerTokenDisplayText(
 ): string {
   const sigil = token.type === "command" ? sigils.command : sigils.skill;
   return `${sigil}${token.name}`;
-}
-
-/**
- * Convert configurable UI triggers to the slash form understood by the daemon
- * and every agent provider.
- */
-export function normalizeComposerTokensForSubmission(
-  text: string,
-  sigils: ComposerSigils,
-  catalog: ComposerTokenCatalog,
-): string {
-  const tokens = collectComposerTokens(text, sigils, catalog);
-  if (tokens.length === 0) {
-    return text;
-  }
-
-  let normalized = "";
-  let cursor = 0;
-  for (const token of tokens) {
-    normalized += text.slice(cursor, token.start);
-    normalized += DEFAULT_COMMAND_SIGIL;
-    normalized += text.slice(token.start + 1, token.end);
-    cursor = token.end;
-  }
-  normalized += text.slice(cursor);
-  return normalized;
 }
 
 /**

--- a/packages/app/src/composer/tokens/use-composer-sigils.ts
+++ b/packages/app/src/composer/tokens/use-composer-sigils.ts
@@ -1,0 +1,16 @@
+import { useMemo } from "react";
+import { useSettings } from "@/hooks/use-settings";
+import { resolveComposerSigils, type ComposerSigils } from "./sigils";
+
+/**
+ * The composer's active trigger characters.
+ *
+ * Resolution happens here rather than at the storage layer so a stored pair that
+ * has gone stale (a choice removed from the allowlist, or two settings written
+ * to the same character by different clients) still yields a usable pair.
+ */
+export function useComposerSigils(): ComposerSigils {
+  const command = useSettings((settings) => settings.commandTriggerSigil);
+  const skill = useSettings((settings) => settings.skillTriggerSigil);
+  return useMemo(() => resolveComposerSigils({ command, skill }), [command, skill]);
+}

--- a/packages/app/src/hooks/use-agent-autocomplete.test.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveAutocompleteIsVisible } from "./use-agent-autocomplete";
+
+describe("resolveAutocompleteIsVisible", () => {
+  const commandBase = {
+    mode: "command" as const,
+    canLoadCommands: true,
+    serverId: "server-1",
+    autocompleteCwd: "/repo",
+    isCommandsLoading: false,
+    isDraftContext: false,
+  };
+
+  it("stays open while a draft composer spins up its provider session", () => {
+    expect(
+      resolveAutocompleteIsVisible({
+        ...commandBase,
+        isCommandsLoading: true,
+        isDraftContext: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the in-session flash while commands load", () => {
+    expect(
+      resolveAutocompleteIsVisible({
+        ...commandBase,
+        isCommandsLoading: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("opens once commands resolve in either context", () => {
+    expect(resolveAutocompleteIsVisible(commandBase)).toBe(true);
+    expect(resolveAutocompleteIsVisible({ ...commandBase, isDraftContext: true })).toBe(true);
+  });
+
+  it("stays closed when commands cannot be loaded at all", () => {
+    expect(
+      resolveAutocompleteIsVisible({
+        ...commandBase,
+        canLoadCommands: false,
+        isDraftContext: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps file mentions gated on a resolved workspace directory", () => {
+    expect(
+      resolveAutocompleteIsVisible({ ...commandBase, mode: "file", autocompleteCwd: "" }),
+    ).toBe(false);
+    expect(
+      resolveAutocompleteIsVisible({ ...commandBase, mode: "file", isCommandsLoading: true }),
+    ).toBe(true);
+  });
+});

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -13,8 +13,6 @@ import { useAutocomplete } from "./use-autocomplete";
 import { useSessionStore } from "@/stores/session-store";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { CLIENT_SLASH_COMMANDS, type ClientSlashCommand } from "@/client-slash-commands";
-import type { PluginClientSlashCommand } from "@/plugins/client-slash-commands";
-import { mergeSlashCommandSources } from "@/plugins/client-slash-commands/model";
 import {
   applySlashCommandReplacement,
   filterAndRankCommandAutocompleteEntries,
@@ -27,6 +25,7 @@ import {
   findActiveFileMention,
   type FileMentionRange,
 } from "@/utils/file-mention-autocomplete";
+import type { ComposerSigils } from "@/composer/tokens/sigils";
 
 interface UseAgentAutocompleteInput {
   userInput: string;
@@ -38,7 +37,7 @@ interface UseAgentAutocompleteInput {
   onAutocompleteApplied?: () => void;
   onClientSlashCommand?: (command: ClientSlashCommand) => void;
   canExecuteClientSlashCommand?: boolean;
-  pluginClientSlashCommands?: readonly PluginClientSlashCommand[];
+  sigils: ComposerSigils;
 }
 
 interface AgentAutocompleteKeyPressEvent {
@@ -54,10 +53,6 @@ interface AgentAutocompleteInputSnapshot {
 
 type AgentAutocompleteOption =
   | (AutocompleteOption & { type: "client_command"; command: ClientSlashCommand })
-  | (AutocompleteOption & {
-      type: "plugin_command";
-      command: PluginClientSlashCommand;
-    })
   | (AutocompleteOption & { type: "provider_command" })
   | (AutocompleteOption & {
       type: "workspace_entry";
@@ -114,7 +109,6 @@ interface DirectorySuggestionEntry {
 
 type AvailableCommand =
   | { source: "client"; command: ClientSlashCommand }
-  | { source: "plugin"; command: PluginClientSlashCommand }
   | { source: "provider"; command: AgentSlashCommand };
 
 function normalizeDraftCommandConfig(
@@ -166,11 +160,15 @@ function mapDirectorySuggestionsToEntries(payload: {
   }));
 }
 
-function mapCommandToOption(entry: AvailableCommand, t: TFunction): AgentAutocompleteOption {
+function mapCommandToOption(
+  entry: AvailableCommand,
+  t: TFunction,
+  sigil: string,
+): AgentAutocompleteOption {
   const command = entry.command;
   const base = {
     id: command.name,
-    label: `/${command.name}`,
+    label: `${sigil}${command.name}`,
     detail: command.argumentHint || undefined,
     description:
       entry.source === "client" ? t(entry.command.descriptionKey) : entry.command.description,
@@ -182,9 +180,6 @@ function mapCommandToOption(entry: AvailableCommand, t: TFunction): AgentAutocom
       type: "client_command",
       command: entry.command,
     };
-  }
-  if (entry.source === "plugin") {
-    return { ...base, type: "plugin_command", command: entry.command };
   }
   return {
     ...base,
@@ -198,12 +193,12 @@ interface BuildAutocompleteOptionsInput {
   isVisible: boolean;
   mode: AutocompleteMode;
   commands: AgentSlashCommand[];
-  pluginCommands: readonly PluginClientSlashCommand[];
   isDraftContext: boolean;
   commandFilterQuery: string;
   activeSlashCommand: SlashCommandRange | null;
   activeFileMention: FileMentionRange | null;
   fileSuggestions: DirectorySuggestionEntry[];
+  sigils: ComposerSigils;
   t: TFunction;
 }
 
@@ -213,35 +208,32 @@ function buildCommandAutocompleteOptions(input: BuildAutocompleteOptionsInput) {
   }
 
   if (input.mode === "command") {
-    const providerCommands = input.commands.map((command) => ({
-      source: "provider" as const,
-      command,
-    }));
-    const rootCommands: AvailableCommand[] = mergeSlashCommandSources({
-      builtIn: CLIENT_SLASH_COMMANDS,
-      plugins: input.pluginCommands,
-      provider: input.commands,
-      onPluginCollision(command, winner) {
-        console.warn(
-          `[Plugins] Client slash command /${command.name} from ${command.pluginId} ignored; ${winner} command wins`,
-        );
-      },
-    })
-      .filter((entry) => !input.isDraftContext || entry.source !== "built-in")
-      .map((entry): AvailableCommand => {
-        if (entry.source === "built-in") return { source: "client", command: entry.command };
-        return entry;
-      });
-    const availableCommands: AvailableCommand[] =
-      input.activeSlashCommand?.position === "inline"
-        ? filterInlineSkillCommandEntries(providerCommands)
-        : rootCommands;
+    const providerCommands = input.commands.map(
+      (command): AvailableCommand => ({ source: "provider", command }),
+    );
+    const clientCommandNames = new Set(CLIENT_SLASH_COMMANDS.map((command) => command.name));
+    const rootCommands: AvailableCommand[] = input.isDraftContext
+      ? providerCommands
+      : [
+          ...CLIENT_SLASH_COMMANDS.map(
+            (command): AvailableCommand => ({ source: "client", command }),
+          ),
+          ...providerCommands.filter((entry) => !clientCommandNames.has(entry.command.name)),
+        ];
+    // The skill sigil always means skills-only. The command sigil keeps its
+    // existing split: full list at the start of the message, skills inline.
+    const skillsOnly =
+      input.activeSlashCommand?.menu === "skill" || input.activeSlashCommand?.position === "inline";
+    const availableCommands = skillsOnly
+      ? filterInlineSkillCommandEntries(providerCommands)
+      : rootCommands;
     const matches = filterAndRankCommandAutocompleteEntries(
       availableCommands,
       input.commandFilterQuery,
     );
     const orderedMatches = orderAutocompleteOptions(matches);
-    return orderedMatches.map((entry) => mapCommandToOption(entry, input.t));
+    const sigil = input.activeSlashCommand?.sigil ?? input.sigils.command;
+    return orderedMatches.map((entry) => mapCommandToOption(entry, input.t, sigil));
   }
 
   const activeFileMention = input.activeFileMention;
@@ -349,7 +341,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     onAutocompleteApplied,
     onClientSlashCommand,
     canExecuteClientSlashCommand,
-    pluginClientSlashCommands = [],
+    sigils,
   } = input;
 
   const activeSlashCommand = useMemo(
@@ -357,8 +349,9 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
       findActiveSlashCommand({
         text: userInput,
         cursorIndex,
+        sigils,
       }),
-    [cursorIndex, userInput],
+    [cursorIndex, userInput, sigils],
   );
   const showCommandAutocomplete = activeSlashCommand !== null;
   const commandFilterQuery = activeSlashCommand?.query ?? "";
@@ -466,12 +459,12 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         activeFileMention,
         commandFilterQuery,
         commands,
-        pluginCommands: pluginClientSlashCommands,
         activeSlashCommand,
         fileSuggestions: fileSuggestionsQuery.data ?? [],
         isDraftContext,
         isVisible,
         mode,
+        sigils,
         t,
       }),
     [
@@ -479,11 +472,11 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
       activeSlashCommand,
       commandFilterQuery,
       commands,
-      pluginClientSlashCommands,
       fileSuggestionsQuery.data,
       isDraftContext,
       isVisible,
       mode,
+      sigils,
       t,
     ],
   );
@@ -499,9 +492,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         activeFileMention,
       });
       const selectedIsCommand =
-        selected.type === "client_command" ||
-        selected.type === "plugin_command" ||
-        selected.type === "provider_command";
+        selected.type === "client_command" || selected.type === "provider_command";
       if (snapshot && selectedIsCommand && !current.slashCommand) return;
       if (
         selected.type === "client_command" &&
@@ -515,7 +506,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
 
       if (selectedIsCommand) {
         if (!current.slashCommand) {
-          setUserInput(`/${selected.id} `);
+          setUserInput(`${sigils.command}${selected.id} `);
           onAutocompleteApplied?.();
           return;
         }
@@ -548,6 +539,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
       cursorIndex,
       activeFileMention,
       activeSlashCommand,
+      sigils,
     ],
   );
 

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -13,6 +13,8 @@ import { useAutocomplete } from "./use-autocomplete";
 import { useSessionStore } from "@/stores/session-store";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { CLIENT_SLASH_COMMANDS, type ClientSlashCommand } from "@/client-slash-commands";
+import type { PluginClientSlashCommand } from "@/plugins/client-slash-commands";
+import { mergeSlashCommandSources } from "@/plugins/client-slash-commands/model";
 import {
   applySlashCommandReplacement,
   filterAndRankCommandAutocompleteEntries,
@@ -39,6 +41,7 @@ interface UseAgentAutocompleteInput {
   onAutocompleteApplied?: () => void;
   onClientSlashCommand?: (command: ClientSlashCommand) => void;
   canExecuteClientSlashCommand?: boolean;
+  pluginClientSlashCommands?: readonly PluginClientSlashCommand[];
   sigils: ComposerSigils;
 }
 
@@ -55,6 +58,10 @@ interface AgentAutocompleteInputSnapshot {
 
 type AgentAutocompleteOption =
   | (AutocompleteOption & { type: "client_command"; command: ClientSlashCommand })
+  | (AutocompleteOption & {
+      type: "plugin_command";
+      command: PluginClientSlashCommand;
+    })
   | (AutocompleteOption & { type: "provider_command" })
   | (AutocompleteOption & {
       type: "workspace_entry";
@@ -113,6 +120,7 @@ interface DirectorySuggestionEntry {
 
 type AvailableCommand =
   | { source: "client"; command: ClientSlashCommand }
+  | { source: "plugin"; command: PluginClientSlashCommand }
   | { source: "provider"; command: AgentSlashCommand };
 
 function normalizeDraftCommandConfig(
@@ -185,6 +193,9 @@ function mapCommandToOption(
       command: entry.command,
     };
   }
+  if (entry.source === "plugin") {
+    return { ...base, type: "plugin_command", command: entry.command };
+  }
   return {
     ...base,
     type: "provider_command",
@@ -197,6 +208,7 @@ interface BuildAutocompleteOptionsInput {
   isVisible: boolean;
   mode: AutocompleteMode;
   commands: AgentSlashCommand[];
+  pluginCommands: readonly PluginClientSlashCommand[];
   isDraftContext: boolean;
   commandFilterQuery: string;
   activeSlashCommand: SlashCommandRange | null;
@@ -212,23 +224,28 @@ function buildCommandAutocompleteOptions(input: BuildAutocompleteOptionsInput) {
   }
 
   if (input.mode === "command") {
-    const providerCommands = input.commands.map(
-      (command): AvailableCommand => ({ source: "provider", command }),
-    );
-    const clientCommandNames = new Set(CLIENT_SLASH_COMMANDS.map((command) => command.name));
-    const rootCommands: AvailableCommand[] = input.isDraftContext
-      ? providerCommands
-      : [
-          ...CLIENT_SLASH_COMMANDS.map(
-            (command): AvailableCommand => ({ source: "client", command }),
-          ),
-          ...providerCommands.filter((entry) => !clientCommandNames.has(entry.command.name)),
-        ];
-    // The skill sigil always means skills-only. The command sigil keeps its
-    // existing split: full list at the start of the message, skills inline.
+    const providerCommands = input.commands.map((command) => ({
+      source: "provider" as const,
+      command,
+    }));
+    const rootCommands: AvailableCommand[] = mergeSlashCommandSources({
+      builtIn: CLIENT_SLASH_COMMANDS,
+      plugins: input.pluginCommands,
+      provider: input.commands,
+      onPluginCollision(command, winner) {
+        console.warn(
+          `[Plugins] Client slash command /${command.name} from ${command.pluginId} ignored; ${winner} command wins`,
+        );
+      },
+    })
+      .filter((entry) => !input.isDraftContext || entry.source !== "built-in")
+      .map((entry): AvailableCommand => {
+        if (entry.source === "built-in") return { source: "client", command: entry.command };
+        return entry;
+      });
     const skillsOnly =
       input.activeSlashCommand?.menu === "skill" || input.activeSlashCommand?.position === "inline";
-    const availableCommands = skillsOnly
+    const availableCommands: AvailableCommand[] = skillsOnly
       ? filterInlineSkillCommandEntries(providerCommands)
       : rootCommands;
     const matches = filterAndRankCommandAutocompleteEntries(
@@ -278,15 +295,7 @@ export function resolveAutocompleteIsVisible(args: {
   isDraftContext: boolean;
 }): boolean {
   if (args.mode === "command") {
-    if (!args.canLoadCommands) {
-      return false;
-    }
-    // A draft composer has no agent session yet, so its first command listing
-    // has to spin up a provider session: seconds at best, an error if the
-    // provider cannot start. Staying hidden through all of that makes the
-    // trigger character look dead — show the loading and error states instead.
-    // In-session listings resolve fast enough that hiding the flash still wins.
-    return args.isDraftContext || !args.isCommandsLoading;
+    return args.canLoadCommands && (args.isDraftContext || !args.isCommandsLoading);
   }
   if (args.mode === "file") {
     return Boolean(args.serverId) && args.autocompleteCwd.length > 0;
@@ -355,6 +364,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     onAutocompleteApplied,
     onClientSlashCommand,
     canExecuteClientSlashCommand,
+    pluginClientSlashCommands = [],
     sigils,
   } = input;
 
@@ -414,7 +424,6 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   const isConnected = useHostRuntimeIsConnected(serverId);
 
   const mode = resolveAutocompleteMode({ showFileAutocomplete, showCommandAutocomplete });
-
   const {
     commands,
     isLoading: isCommandsLoading,
@@ -429,6 +438,9 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
 
   const tokenCatalog = useMemo<ComposerTokenCatalog>(() => {
     const commandNames = new Set(CLIENT_SLASH_COMMANDS.map((command) => command.name));
+    for (const command of pluginClientSlashCommands) {
+      commandNames.add(command.name);
+    }
     const skillNames = new Set<string>();
     for (const command of commands) {
       commandNames.add(command.name);
@@ -437,7 +449,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
       }
     }
     return { commandNames, skillNames };
-  }, [commands]);
+  }, [commands, pluginClientSlashCommands]);
 
   const isVisible = resolveAutocompleteIsVisible({
     mode,
@@ -490,6 +502,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         activeFileMention,
         commandFilterQuery,
         commands,
+        pluginCommands: pluginClientSlashCommands,
         activeSlashCommand,
         fileSuggestions: fileSuggestionsQuery.data ?? [],
         isDraftContext,
@@ -503,6 +516,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
       activeSlashCommand,
       commandFilterQuery,
       commands,
+      pluginClientSlashCommands,
       fileSuggestionsQuery.data,
       isDraftContext,
       isVisible,
@@ -524,7 +538,9 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         activeFileMention,
       });
       const selectedIsCommand =
-        selected.type === "client_command" || selected.type === "provider_command";
+        selected.type === "client_command" ||
+        selected.type === "plugin_command" ||
+        selected.type === "provider_command";
       if (snapshot && selectedIsCommand && !current.slashCommand) return;
       if (
         selected.type === "client_command" &&

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -18,6 +18,7 @@ import {
   filterAndRankCommandAutocompleteEntries,
   filterInlineSkillCommandEntries,
   findActiveSlashCommand,
+  shouldSubmitShellVariable,
   type SlashCommandRange,
 } from "@/utils/agent-command-autocomplete";
 import {
@@ -578,8 +579,13 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         : undefined,
   });
   const onKeyPress = useCallback(
-    (event: AgentAutocompleteKeyPressEvent) => onAutocompleteKeyPress(event),
-    [onAutocompleteKeyPress],
+    (event: AgentAutocompleteKeyPressEvent) => {
+      if (shouldSubmitShellVariable({ key: event.key, command: activeSlashCommand })) {
+        return false;
+      }
+      return onAutocompleteKeyPress(event);
+    },
+    [activeSlashCommand, onAutocompleteKeyPress],
   );
 
   const isLoading = resolveAutocompleteIsLoading({

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -18,6 +18,7 @@ import {
   filterAndRankCommandAutocompleteEntries,
   filterInlineSkillCommandEntries,
   findActiveSlashCommand,
+  shouldSubmitUncommittedTrigger,
   type SlashCommandRange,
 } from "@/utils/agent-command-autocomplete";
 import {
@@ -567,7 +568,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     [onSelectOption],
   );
 
-  const { selectedIndex, onKeyPress } = useAutocomplete({
+  const { selectedIndex, onKeyPress: onAutocompleteKeyPress } = useAutocomplete({
     isVisible,
     options,
     query: mode === "command" ? commandFilterQuery : fileFilterQuery,
@@ -577,6 +578,15 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         ? () => setUserInput("")
         : undefined,
   });
+  const onKeyPress = useCallback(
+    (event: AgentAutocompleteKeyPressEvent) => {
+      if (shouldSubmitUncommittedTrigger({ key: event.key, command: activeSlashCommand })) {
+        return false;
+      }
+      return onAutocompleteKeyPress(event);
+    },
+    [activeSlashCommand, onAutocompleteKeyPress],
+  );
 
   const isLoading = resolveAutocompleteIsLoading({
     mode,

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -85,6 +85,7 @@ function resolveAgentAutocompleteSnapshot(input: {
   input?: AgentAutocompleteInputSnapshot;
   userInput: string;
   cursorIndex: number;
+  sigils: ComposerSigils;
   activeSlashCommand: SlashCommandRange | null;
   activeFileMention: FileMentionRange | null;
 }): AgentAutocompleteSnapshot {
@@ -100,7 +101,7 @@ function resolveAgentAutocompleteSnapshot(input: {
   const cursorIndex = input.input.selection.start;
   return {
     text,
-    slashCommand: findActiveSlashCommand({ text, cursorIndex }),
+    slashCommand: findActiveSlashCommand({ text, cursorIndex, sigils: input.sigils }),
     fileMention: findActiveFileMention({ text, cursorIndex }),
   };
 }
@@ -518,6 +519,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         input: snapshot,
         userInput,
         cursorIndex,
+        sigils,
         activeSlashCommand,
         activeFileMention,
       });

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -18,7 +18,6 @@ import {
   filterAndRankCommandAutocompleteEntries,
   filterInlineSkillCommandEntries,
   findActiveSlashCommand,
-  shouldSubmitUncommittedTrigger,
   type SlashCommandRange,
 } from "@/utils/agent-command-autocomplete";
 import {
@@ -579,13 +578,8 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
         : undefined,
   });
   const onKeyPress = useCallback(
-    (event: AgentAutocompleteKeyPressEvent) => {
-      if (shouldSubmitUncommittedTrigger({ key: event.key, command: activeSlashCommand })) {
-        return false;
-      }
-      return onAutocompleteKeyPress(event);
-    },
-    [activeSlashCommand, onAutocompleteKeyPress],
+    (event: AgentAutocompleteKeyPressEvent) => onAutocompleteKeyPress(event),
+    [onAutocompleteKeyPress],
   );
 
   const isLoading = resolveAutocompleteIsLoading({

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -25,7 +25,7 @@ import {
   findActiveFileMention,
   type FileMentionRange,
 } from "@/utils/file-mention-autocomplete";
-import type { ComposerSigils } from "@/composer/tokens/sigils";
+import { DEFAULT_COMMAND_SIGIL, type ComposerSigils } from "@/composer/tokens/sigils";
 import type { ComposerTokenCatalog } from "@/composer/tokens/tokens";
 
 interface UseAgentAutocompleteInput {
@@ -356,7 +356,10 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     [cursorIndex, userInput, sigils],
   );
   const showCommandAutocomplete = activeSlashCommand !== null;
-  const hasTokenCandidate = userInput.includes(sigils.command) || userInput.includes(sigils.skill);
+  const hasTokenCandidate =
+    userInput.includes(DEFAULT_COMMAND_SIGIL) ||
+    userInput.includes(sigils.command) ||
+    userInput.includes(sigils.skill);
   const commandFilterQuery = activeSlashCommand?.query ?? "";
 
   const activeFileMention = useMemo(

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -268,14 +268,24 @@ function resolveAutocompleteMode(args: {
   return null;
 }
 
-function resolveAutocompleteIsVisible(args: {
+export function resolveAutocompleteIsVisible(args: {
   mode: AutocompleteMode;
   canLoadCommands: boolean;
   serverId: string;
   autocompleteCwd: string;
+  isCommandsLoading: boolean;
+  isDraftContext: boolean;
 }): boolean {
   if (args.mode === "command") {
-    return args.canLoadCommands;
+    if (!args.canLoadCommands) {
+      return false;
+    }
+    // A draft composer has no agent session yet, so its first command listing
+    // has to spin up a provider session: seconds at best, an error if the
+    // provider cannot start. Staying hidden through all of that makes the
+    // trigger character look dead — show the loading and error states instead.
+    // In-session listings resolve fast enough that hiding the flash still wins.
+    return args.isDraftContext || !args.isCommandsLoading;
   }
   if (args.mode === "file") {
     return Boolean(args.serverId) && args.autocompleteCwd.length > 0;
@@ -403,12 +413,6 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   const isConnected = useHostRuntimeIsConnected(serverId);
 
   const mode = resolveAutocompleteMode({ showFileAutocomplete, showCommandAutocomplete });
-  const canShowAutocomplete = resolveAutocompleteIsVisible({
-    mode,
-    canLoadCommands,
-    serverId,
-    autocompleteCwd,
-  });
 
   const {
     commands,
@@ -434,7 +438,14 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     return { commandNames, skillNames };
   }, [commands]);
 
-  const isVisible = canShowAutocomplete && !(mode === "command" && isCommandsLoading);
+  const isVisible = resolveAutocompleteIsVisible({
+    mode,
+    canLoadCommands,
+    serverId,
+    autocompleteCwd,
+    isCommandsLoading,
+    isDraftContext,
+  });
 
   const fileSuggestionsQuery = useQuery({
     queryKey: [

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -26,6 +26,7 @@ import {
   type FileMentionRange,
 } from "@/utils/file-mention-autocomplete";
 import type { ComposerSigils } from "@/composer/tokens/sigils";
+import type { ComposerTokenCatalog } from "@/composer/tokens/tokens";
 
 interface UseAgentAutocompleteInput {
   userInput: string;
@@ -68,6 +69,7 @@ interface AgentAutocompleteResult {
   errorMessage?: string;
   loadingText: string;
   emptyText: string;
+  tokenCatalog: ComposerTokenCatalog;
   onSelectOption: (option: AutocompleteOption, input?: AgentAutocompleteInputSnapshot) => void;
   onKeyPress: (event: AgentAutocompleteKeyPressEvent) => boolean;
 }
@@ -354,6 +356,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     [cursorIndex, userInput, sigils],
   );
   const showCommandAutocomplete = activeSlashCommand !== null;
+  const hasTokenCandidate = userInput.includes(sigils.command) || userInput.includes(sigils.skill);
   const commandFilterQuery = activeSlashCommand?.query ?? "";
 
   const activeFileMention = useMemo(
@@ -411,9 +414,21 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
   } = useAgentCommandsQuery({
     serverId,
     agentId,
-    enabled: mode === "command" && canLoadCommands,
+    enabled: hasTokenCandidate && canLoadCommands,
     draftConfig: queryDraftConfig,
   });
+
+  const tokenCatalog = useMemo<ComposerTokenCatalog>(() => {
+    const commandNames = new Set(CLIENT_SLASH_COMMANDS.map((command) => command.name));
+    const skillNames = new Set<string>();
+    for (const command of commands) {
+      commandNames.add(command.name);
+      if (command.kind === "skill") {
+        skillNames.add(command.name);
+      }
+    }
+    return { commandNames, skillNames };
+  }, [commands]);
 
   const isVisible = canShowAutocomplete && !(mode === "command" && isCommandsLoading);
 
@@ -590,6 +605,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     errorMessage,
     loadingText,
     emptyText,
+    tokenCatalog,
     onSelectOption,
     onKeyPress,
   };

--- a/packages/app/src/hooks/use-agent-commands-query.test.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.test.ts
@@ -64,4 +64,32 @@ describe("fetchAgentCommands", () => {
 
     expect(client.calls).toEqual([{ agentId: "agent-1", draftConfig: undefined }]);
   });
+
+  it("reports a failed draft listing instead of reading it as an empty catalog", async () => {
+    const client = createClient({
+      requestId: "req_commands",
+      agentId: "new-workspace",
+      error: "Codex app-server exited with code 1",
+      commands: [],
+    });
+
+    await expect(
+      fetchAgentCommands({
+        client,
+        agentId: "new-workspace",
+        draftConfig: { provider: "codex", cwd: "/repo" },
+      }),
+    ).rejects.toThrow("Codex app-server exited with code 1");
+  });
+
+  it("treats a draft surface with no config yet as an ordinary empty catalog", async () => {
+    const client = createClient({
+      requestId: "req_commands",
+      agentId: "new-workspace",
+      error: "Agent not found: new-workspace",
+      commands: [],
+    });
+
+    await expect(fetchAgentCommands({ client, agentId: "new-workspace" })).resolves.toEqual([]);
+  });
 });

--- a/packages/app/src/hooks/use-agent-commands-query.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.ts
@@ -36,6 +36,14 @@ export async function fetchAgentCommands(input: {
     agentId: input.agentId,
     draftConfig: input.draftConfig,
   });
+  // Draft listings spin up a provider session on demand, so a failure here is a
+  // real failure the user needs to see: without this the daemon's error is
+  // dropped and a broken provider is indistinguishable from "no skills". Only
+  // draft listings throw — a draft surface with no config yet answers "agent not
+  // found", which is an ordinary state rather than something worth reporting.
+  if (response.error && input.draftConfig) {
+    throw new Error(response.error);
+  }
   return response.commands as AgentSlashCommand[];
 }
 
@@ -68,7 +76,9 @@ export function useAgentCommandsQuery({
     },
     enabled: queryEnabled && !!client && isConnected && (!!agentId || !!draftConfig),
     staleTime: draftConfig ? DRAFT_COMMANDS_STALE_TIME : SESSION_COMMANDS_STALE_TIME,
-    retry: 3,
+    // Each draft attempt spawns and tears down a provider session, so a broken
+    // provider should report once rather than four times.
+    retry: draftConfig ? 0 : 3,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 5000),
   });
 

--- a/packages/app/src/hooks/use-agent-commands-query.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.ts
@@ -7,6 +7,7 @@ import { agentCommandsQueryKey, type AgentCommandsDraftConfig } from "@/hooks/ag
 
 const DRAFT_COMMANDS_STALE_TIME = Number.POSITIVE_INFINITY;
 const SESSION_COMMANDS_STALE_TIME = 60_000;
+const EMPTY_AGENT_SLASH_COMMANDS: AgentSlashCommand[] = [];
 
 export interface AgentSlashCommand {
   name: string;
@@ -76,7 +77,7 @@ export function useAgentCommandsQuery({
   const isLoading = query.isPending || query.isLoading;
 
   return {
-    commands: query.data ?? [],
+    commands: query.data ?? EMPTY_AGENT_SLASH_COMMANDS,
     isLoading,
     isError: query.isError,
     error: query.error,

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -6,8 +6,10 @@ import {
   DEFAULT_APP_SETTINGS,
   DEFAULT_CLIENT_SETTINGS,
   DEFAULT_CODE_FONT_SIZE,
+  DEFAULT_CONTENT_FONT_SIZE,
   DEFAULT_UI_BASE_FONT_SIZE,
   defaultUiBaseFontSize,
+  defaultContentFontSize,
   loadAppSettingsFromStorage,
   loadSettingsFromStorage,
   parseClampedFontSize,
@@ -48,6 +50,28 @@ describe("loadAppSettingsFromStorage", () => {
     });
     expect((await loadAppSettingsFromStorage(deps)).sendBehavior).toBe("steer");
   });
+
+  it("keeps valid settings when another build wrote unknown fields or enum values", async () => {
+    const stored = {
+      theme: "dark",
+      contentFontSize: 16,
+      sendBehavior: "future-mode",
+      futureSetting: { enabled: true },
+      sidebarRowItems: { host: false, futureRowItem: true },
+    };
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify(stored),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.theme).toBe("dark");
+    expect(result.sendBehavior).toBe(DEFAULT_CLIENT_SETTINGS.sendBehavior);
+    expect(result.sidebarRowItems.host).toBe(false);
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(stored);
+  });
   it("migrates a stored interrupt to steer and persists it", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({
@@ -61,6 +85,32 @@ describe("loadAppSettingsFromStorage", () => {
     expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "{}").sendBehavior).toBe(
       "steer",
     );
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "{}")).not.toHaveProperty(
+      "needsWrite",
+    );
+  });
+
+  it("keeps an explicit services choice over the legacy scripts fallback", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          contentFontSize: 16,
+          sidebarRowItems: { scripts: false, services: true },
+        }),
+      }),
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).sidebarRowItems.services).toBe(true);
+
+    await saveAppSettings({
+      queryClient: new QueryClient(),
+      updates: {
+        sidebarRowItems: { ...DEFAULT_SIDEBAR_ROW_ITEMS, services: true },
+      },
+      deps,
+    });
+
+    expect((await loadAppSettingsFromStorage(deps)).sidebarRowItems.services).toBe(true);
   });
 
   it("keeps an interrupt the user picked after the migration ran", async () => {
@@ -106,8 +156,8 @@ describe("loadAppSettingsFromStorage", () => {
 
     expect(result).toEqual(DEFAULT_CLIENT_SETTINGS);
     expect(DEFAULT_CLIENT_SETTINGS.language).toBe("system");
-    expect(deps.storage.entries.get(APP_SETTINGS_KEY)).toBe(
-      JSON.stringify(DEFAULT_CLIENT_SETTINGS),
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(
+      DEFAULT_CLIENT_SETTINGS,
     );
   });
 
@@ -147,6 +197,77 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.chatOutlineEnabled).toBe(false);
   });
 
+  it("defaults sidebar navigation items to an empty preference list", async () => {
+    const deps = makeDeps();
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.sidebarNavItems).toEqual([]);
+  });
+
+  it("loads stored sidebar navigation items in order", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          sidebarNavItems: [
+            { key: "history", visible: false },
+            { key: "new-workspace", visible: true },
+          ],
+        }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.sidebarNavItems).toEqual([
+      { key: "history", visible: false },
+      { key: "new-workspace", visible: true },
+    ]);
+  });
+
+  it("falls back to the default sidebar navigation items when the stored list is malformed", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ sidebarNavItems: [{ key: 3 }] }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.sidebarNavItems).toEqual([]);
+  });
+
+  it("collapses legacy diff destinations into the former Explorer choice", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          openInSidePane: { explorerChanges: true, changesLinks: false },
+        }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.openInSidePane.diffs).toBe(true);
+    expect(result.openInSidePane).not.toHaveProperty("explorerChanges");
+    expect(result.openInSidePane).not.toHaveProperty("changesLinks");
+  });
+
+  it("defaults PRs to Explorer and preserves the legacy side choice", async () => {
+    const defaults = await loadAppSettingsFromStorage(makeDeps());
+    const legacySide = await loadAppSettingsFromStorage(
+      makeDeps({
+        storage: createInMemoryKeyValueStorage({
+          [APP_SETTINGS_KEY]: JSON.stringify({ openInSidePane: { pullRequests: true } }),
+        }),
+      }),
+    );
+
+    expect(defaults.pullRequestOpenLocation).toBe("explorer");
+    expect(legacySide.pullRequestOpenLocation).toBe("side");
+    expect(legacySide.openInSidePane).not.toHaveProperty("pullRequests");
+  });
+
   it("uses the native terminal renderer by default", async () => {
     const deps = makeDeps();
 
@@ -167,10 +288,8 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.useLegacyTerminalRenderer).toBe(true);
   });
 
-  it("defaults the composer trigger sigils to / and $", async () => {
-    const deps = makeDeps();
-
-    const result = await loadAppSettingsFromStorage(deps);
+  it("defaults the composer trigger sigils", async () => {
+    const result = await loadAppSettingsFromStorage(makeDeps());
 
     expect(result.commandTriggerSigil).toBe("/");
     expect(result.skillTriggerSigil).toBe("$");
@@ -192,7 +311,7 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.skillTriggerSigil).toBe("#");
   });
 
-  it("falls back to the default sigil when a stored value is off the allowlist", async () => {
+  it("falls back when stored composer trigger sigils are invalid", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({
         [APP_SETTINGS_KEY]: JSON.stringify({
@@ -288,8 +407,47 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_CLIENT_SETTINGS,
       theme: "dark",
+      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
     });
-    expect(deps.storage.entries.get(APP_SETTINGS_KEY)).toBe(JSON.stringify(result));
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual({
+      manageBuiltInDaemon: false,
+      releaseChannel: "beta",
+      ...result,
+    });
+  });
+
+  it("preserves the legacy key's explicit interface size as content size", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [LEGACY_SETTINGS_KEY]: JSON.stringify({ uiBaseFontSize: 17 }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.uiBaseFontSize).toBe(17);
+    expect(result.contentFontSize).toBe(17);
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
+      uiBaseFontSize: 17,
+      contentFontSize: 17,
+    });
+  });
+
+  it("preserves the legacy interface scale as content size", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [LEGACY_SETTINGS_KEY]: JSON.stringify({ uiFontSize: 17 }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.uiBaseFontSize).toBe(15);
+    expect(result.contentFontSize).toBe(15);
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
+      uiBaseFontSize: 15,
+      contentFontSize: 15,
+    });
   });
 
   it("loads a persisted explicit language", async () => {
@@ -314,6 +472,44 @@ describe("loadAppSettingsFromStorage", () => {
     const result = await loadAppSettingsFromStorage(deps);
 
     expect(result.language).toBe("system");
+  });
+});
+
+describe("saveAppSettings", () => {
+  it("applies consecutive functional updates to the latest cached settings", async () => {
+    const deps = makeDeps();
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(APP_SETTINGS_QUERY_KEY, DEFAULT_CLIENT_SETTINGS);
+
+    await Promise.all([
+      saveAppSettings({
+        queryClient,
+        updates: (current) => ({
+          sidebarNavItems: [...current.sidebarNavItems, { key: "history", visible: false }],
+        }),
+        deps,
+      }),
+      saveAppSettings({
+        queryClient,
+        updates: (current) => ({
+          sidebarNavItems: [...current.sidebarNavItems, { key: "search", visible: true }],
+        }),
+        deps,
+      }),
+    ]);
+
+    expect(queryClient.getQueryData(APP_SETTINGS_QUERY_KEY)).toMatchObject({
+      sidebarNavItems: [
+        { key: "history", visible: false },
+        { key: "search", visible: true },
+      ],
+    });
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
+      sidebarNavItems: [
+        { key: "history", visible: false },
+        { key: "search", visible: true },
+      ],
+    });
   });
 });
 
@@ -349,6 +545,7 @@ describe("loadSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_APP_SETTINGS,
       theme: "light",
+      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
     });
   });
 
@@ -392,6 +589,7 @@ describe("loadSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_APP_SETTINGS,
       theme: "light",
+      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
       manageBuiltInDaemon: false,
       releaseChannel: "beta",
     });
@@ -412,11 +610,42 @@ describe("loadSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_APP_SETTINGS,
       theme: "light",
+      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
     });
   });
 });
 
 describe("saveAppSettings", () => {
+  it("round-trips fields written by a newer build", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          theme: "dark",
+          contentFontSize: 16,
+          sendBehavior: "future-mode",
+          futureSetting: { enabled: true },
+          sidebarRowItems: { host: false, futureRowItem: true },
+        }),
+      }),
+    });
+
+    await loadAppSettingsFromStorage(deps);
+    await saveAppSettings({
+      queryClient: new QueryClient(),
+      updates: { theme: "light" },
+      deps,
+    });
+
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
+      theme: "light",
+      futureSetting: { enabled: true },
+      sidebarRowItems: {
+        host: false,
+        futureRowItem: true,
+      },
+    });
+  });
+
   it("saves terminal scrollback through app settings persistence", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({
@@ -456,9 +685,26 @@ describe("saveAppSettings", () => {
     expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual({
       ...DEFAULT_CLIENT_SETTINGS,
       theme: "light",
+      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
       toolCallDetailLevel: "overview",
     });
   });
+
+  it("persists a selected plugin theme", async () => {
+    const deps = makeDeps();
+    const queryClient = new QueryClient();
+
+    await saveAppSettings({
+      queryClient,
+      updates: { theme: "plugin", pluginThemeId: "catppuccin/theme/mocha" },
+      deps,
+    });
+
+    const loaded = await loadAppSettingsFromStorage(deps);
+    expect(loaded.theme).toBe("plugin");
+    expect(loaded.pluginThemeId).toBe("catppuccin/theme/mocha");
+  });
+
   // The row items are written as one object through one strict schema, so an item the schema
   // does not know does not just fail to persist itself — it takes every sibling toggle with it.
   it.each(SIDEBAR_ROW_ITEMS)("persists the %s row item being switched off", async (item) => {
@@ -508,6 +754,7 @@ describe("appearance settings", () => {
     expect(result.uiFontFamily).toBe("");
     expect(result.monoFontFamily).toBe("");
     expect(result.uiBaseFontSize).toBe(DEFAULT_UI_BASE_FONT_SIZE);
+    expect(result.contentFontSize).toBe(DEFAULT_UI_BASE_FONT_SIZE);
     expect(result.codeFontSize).toBe(DEFAULT_CODE_FONT_SIZE);
     expect(result.syntaxTheme).toBe("one");
     expect(result.toolCallDetailLevel).toBe("detailed");
@@ -561,6 +808,51 @@ describe("appearance settings", () => {
     expect(defaultUiBaseFontSize(false)).toBe(14);
   });
 
+  it("uses a 16px content default on mobile and a 15px default on web", () => {
+    expect(defaultContentFontSize(true)).toBe(16);
+    expect(defaultContentFontSize(false)).toBe(15);
+    expect(DEFAULT_CONTENT_FONT_SIZE).toBe(defaultContentFontSize(false));
+  });
+
+  it("derives and persists content size from an existing interface-size preference", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ uiBaseFontSize: 17 }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+    const persisted = JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null");
+
+    expect(result.contentFontSize).toBe(17);
+    expect(persisted).toMatchObject({ uiBaseFontSize: 17, contentFontSize: 17 });
+  });
+
+  it("clamps the content font size into range and rejects non-numeric values", async () => {
+    const high = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ contentFontSize: 999 }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(high)).contentFontSize).toBe(21);
+
+    const low = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ contentFontSize: 8 }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(low)).contentFontSize).toBe(10);
+
+    const bogus = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ contentFontSize: "abc" }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(bogus)).contentFontSize).toBe(
+      DEFAULT_CONTENT_FONT_SIZE,
+    );
+  });
+
   it.each([
     { legacySize: 16, baseSize: 14 },
     { legacySize: 17, baseSize: 15 },
@@ -579,7 +871,7 @@ describe("appearance settings", () => {
 
       expect(result.uiBaseFontSize).toBe(baseSize);
       expect(persisted).toMatchObject({ uiBaseFontSize: baseSize });
-      expect(persisted).not.toHaveProperty("uiFontSize");
+      expect(persisted.uiFontSize).toBe(legacySize);
     },
   );
 
@@ -591,6 +883,20 @@ describe("appearance settings", () => {
     });
 
     expect((await loadAppSettingsFromStorage(deps)).uiBaseFontSize).toBe(16);
+  });
+
+  it("falls back to a valid legacy interface scale when the explicit base size is invalid", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ uiBaseFontSize: "abc", uiFontSize: 17 }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+    const persisted = JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null");
+
+    expect(result.uiBaseFontSize).toBe(15);
+    expect(persisted).toMatchObject({ uiBaseFontSize: 15, uiFontSize: 17 });
   });
 
   it("clamps the UI base font size into range and rejects non-numeric values", async () => {

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -6,10 +6,8 @@ import {
   DEFAULT_APP_SETTINGS,
   DEFAULT_CLIENT_SETTINGS,
   DEFAULT_CODE_FONT_SIZE,
-  DEFAULT_CONTENT_FONT_SIZE,
   DEFAULT_UI_BASE_FONT_SIZE,
   defaultUiBaseFontSize,
-  defaultContentFontSize,
   loadAppSettingsFromStorage,
   loadSettingsFromStorage,
   parseClampedFontSize,
@@ -50,28 +48,6 @@ describe("loadAppSettingsFromStorage", () => {
     });
     expect((await loadAppSettingsFromStorage(deps)).sendBehavior).toBe("steer");
   });
-
-  it("keeps valid settings when another build wrote unknown fields or enum values", async () => {
-    const stored = {
-      theme: "dark",
-      contentFontSize: 16,
-      sendBehavior: "future-mode",
-      futureSetting: { enabled: true },
-      sidebarRowItems: { host: false, futureRowItem: true },
-    };
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify(stored),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-
-    expect(result.theme).toBe("dark");
-    expect(result.sendBehavior).toBe(DEFAULT_CLIENT_SETTINGS.sendBehavior);
-    expect(result.sidebarRowItems.host).toBe(false);
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(stored);
-  });
   it("migrates a stored interrupt to steer and persists it", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({
@@ -85,32 +61,6 @@ describe("loadAppSettingsFromStorage", () => {
     expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "{}").sendBehavior).toBe(
       "steer",
     );
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "{}")).not.toHaveProperty(
-      "needsWrite",
-    );
-  });
-
-  it("keeps an explicit services choice over the legacy scripts fallback", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({
-          contentFontSize: 16,
-          sidebarRowItems: { scripts: false, services: true },
-        }),
-      }),
-    });
-
-    expect((await loadAppSettingsFromStorage(deps)).sidebarRowItems.services).toBe(true);
-
-    await saveAppSettings({
-      queryClient: new QueryClient(),
-      updates: {
-        sidebarRowItems: { ...DEFAULT_SIDEBAR_ROW_ITEMS, services: true },
-      },
-      deps,
-    });
-
-    expect((await loadAppSettingsFromStorage(deps)).sidebarRowItems.services).toBe(true);
   });
 
   it("keeps an interrupt the user picked after the migration ran", async () => {
@@ -156,8 +106,8 @@ describe("loadAppSettingsFromStorage", () => {
 
     expect(result).toEqual(DEFAULT_CLIENT_SETTINGS);
     expect(DEFAULT_CLIENT_SETTINGS.language).toBe("system");
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual(
-      DEFAULT_CLIENT_SETTINGS,
+    expect(deps.storage.entries.get(APP_SETTINGS_KEY)).toBe(
+      JSON.stringify(DEFAULT_CLIENT_SETTINGS),
     );
   });
 
@@ -197,77 +147,6 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.chatOutlineEnabled).toBe(false);
   });
 
-  it("defaults sidebar navigation items to an empty preference list", async () => {
-    const deps = makeDeps();
-
-    const result = await loadAppSettingsFromStorage(deps);
-
-    expect(result.sidebarNavItems).toEqual([]);
-  });
-
-  it("loads stored sidebar navigation items in order", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({
-          sidebarNavItems: [
-            { key: "history", visible: false },
-            { key: "new-workspace", visible: true },
-          ],
-        }),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-
-    expect(result.sidebarNavItems).toEqual([
-      { key: "history", visible: false },
-      { key: "new-workspace", visible: true },
-    ]);
-  });
-
-  it("falls back to the default sidebar navigation items when the stored list is malformed", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({ sidebarNavItems: [{ key: 3 }] }),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-
-    expect(result.sidebarNavItems).toEqual([]);
-  });
-
-  it("collapses legacy diff destinations into the former Explorer choice", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({
-          openInSidePane: { explorerChanges: true, changesLinks: false },
-        }),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-
-    expect(result.openInSidePane.diffs).toBe(true);
-    expect(result.openInSidePane).not.toHaveProperty("explorerChanges");
-    expect(result.openInSidePane).not.toHaveProperty("changesLinks");
-  });
-
-  it("defaults PRs to Explorer and preserves the legacy side choice", async () => {
-    const defaults = await loadAppSettingsFromStorage(makeDeps());
-    const legacySide = await loadAppSettingsFromStorage(
-      makeDeps({
-        storage: createInMemoryKeyValueStorage({
-          [APP_SETTINGS_KEY]: JSON.stringify({ openInSidePane: { pullRequests: true } }),
-        }),
-      }),
-    );
-
-    expect(defaults.pullRequestOpenLocation).toBe("explorer");
-    expect(legacySide.pullRequestOpenLocation).toBe("side");
-    expect(legacySide.openInSidePane).not.toHaveProperty("pullRequests");
-  });
-
   it("uses the native terminal renderer by default", async () => {
     const deps = makeDeps();
 
@@ -286,6 +165,63 @@ describe("loadAppSettingsFromStorage", () => {
     const result = await loadAppSettingsFromStorage(deps);
 
     expect(result.useLegacyTerminalRenderer).toBe(true);
+  });
+
+  it("defaults the composer trigger sigils to / and $", async () => {
+    const deps = makeDeps();
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.commandTriggerSigil).toBe("/");
+    expect(result.skillTriggerSigil).toBe("$");
+  });
+
+  it("loads remapped composer trigger sigils", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          commandTriggerSigil: "!",
+          skillTriggerSigil: "#",
+        }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.commandTriggerSigil).toBe("!");
+    expect(result.skillTriggerSigil).toBe("#");
+  });
+
+  it("falls back to the default sigil when a stored value is off the allowlist", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          commandTriggerSigil: "@",
+          skillTriggerSigil: "abc",
+        }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.commandTriggerSigil).toBe("/");
+    expect(result.skillTriggerSigil).toBe("$");
+  });
+
+  it("resolves colliding stored composer trigger sigils", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({
+          commandTriggerSigil: "$",
+          skillTriggerSigil: "$",
+        }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.commandTriggerSigil).toBe("$");
+    expect(result.skillTriggerSigil).toBe("/");
   });
 
   it("loads configured terminal scrollback lines from app settings", async () => {
@@ -352,47 +288,8 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_CLIENT_SETTINGS,
       theme: "dark",
-      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
     });
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual({
-      manageBuiltInDaemon: false,
-      releaseChannel: "beta",
-      ...result,
-    });
-  });
-
-  it("preserves the legacy key's explicit interface size as content size", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [LEGACY_SETTINGS_KEY]: JSON.stringify({ uiBaseFontSize: 17 }),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-
-    expect(result.uiBaseFontSize).toBe(17);
-    expect(result.contentFontSize).toBe(17);
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
-      uiBaseFontSize: 17,
-      contentFontSize: 17,
-    });
-  });
-
-  it("preserves the legacy interface scale as content size", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [LEGACY_SETTINGS_KEY]: JSON.stringify({ uiFontSize: 17 }),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-
-    expect(result.uiBaseFontSize).toBe(15);
-    expect(result.contentFontSize).toBe(15);
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
-      uiBaseFontSize: 15,
-      contentFontSize: 15,
-    });
+    expect(deps.storage.entries.get(APP_SETTINGS_KEY)).toBe(JSON.stringify(result));
   });
 
   it("loads a persisted explicit language", async () => {
@@ -417,44 +314,6 @@ describe("loadAppSettingsFromStorage", () => {
     const result = await loadAppSettingsFromStorage(deps);
 
     expect(result.language).toBe("system");
-  });
-});
-
-describe("saveAppSettings", () => {
-  it("applies consecutive functional updates to the latest cached settings", async () => {
-    const deps = makeDeps();
-    const queryClient = new QueryClient();
-    queryClient.setQueryData(APP_SETTINGS_QUERY_KEY, DEFAULT_CLIENT_SETTINGS);
-
-    await Promise.all([
-      saveAppSettings({
-        queryClient,
-        updates: (current) => ({
-          sidebarNavItems: [...current.sidebarNavItems, { key: "history", visible: false }],
-        }),
-        deps,
-      }),
-      saveAppSettings({
-        queryClient,
-        updates: (current) => ({
-          sidebarNavItems: [...current.sidebarNavItems, { key: "search", visible: true }],
-        }),
-        deps,
-      }),
-    ]);
-
-    expect(queryClient.getQueryData(APP_SETTINGS_QUERY_KEY)).toMatchObject({
-      sidebarNavItems: [
-        { key: "history", visible: false },
-        { key: "search", visible: true },
-      ],
-    });
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
-      sidebarNavItems: [
-        { key: "history", visible: false },
-        { key: "search", visible: true },
-      ],
-    });
   });
 });
 
@@ -490,7 +349,6 @@ describe("loadSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_APP_SETTINGS,
       theme: "light",
-      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
     });
   });
 
@@ -534,7 +392,6 @@ describe("loadSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_APP_SETTINGS,
       theme: "light",
-      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
       manageBuiltInDaemon: false,
       releaseChannel: "beta",
     });
@@ -555,42 +412,11 @@ describe("loadSettingsFromStorage", () => {
     expect(result).toEqual({
       ...DEFAULT_APP_SETTINGS,
       theme: "light",
-      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
     });
   });
 });
 
 describe("saveAppSettings", () => {
-  it("round-trips fields written by a newer build", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({
-          theme: "dark",
-          contentFontSize: 16,
-          sendBehavior: "future-mode",
-          futureSetting: { enabled: true },
-          sidebarRowItems: { host: false, futureRowItem: true },
-        }),
-      }),
-    });
-
-    await loadAppSettingsFromStorage(deps);
-    await saveAppSettings({
-      queryClient: new QueryClient(),
-      updates: { theme: "light" },
-      deps,
-    });
-
-    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
-      theme: "light",
-      futureSetting: { enabled: true },
-      sidebarRowItems: {
-        host: false,
-        futureRowItem: true,
-      },
-    });
-  });
-
   it("saves terminal scrollback through app settings persistence", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({
@@ -630,26 +456,9 @@ describe("saveAppSettings", () => {
     expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toEqual({
       ...DEFAULT_CLIENT_SETTINGS,
       theme: "light",
-      contentFontSize: DEFAULT_UI_BASE_FONT_SIZE,
       toolCallDetailLevel: "overview",
     });
   });
-
-  it("persists a selected plugin theme", async () => {
-    const deps = makeDeps();
-    const queryClient = new QueryClient();
-
-    await saveAppSettings({
-      queryClient,
-      updates: { theme: "plugin", pluginThemeId: "catppuccin/theme/mocha" },
-      deps,
-    });
-
-    const loaded = await loadAppSettingsFromStorage(deps);
-    expect(loaded.theme).toBe("plugin");
-    expect(loaded.pluginThemeId).toBe("catppuccin/theme/mocha");
-  });
-
   // The row items are written as one object through one strict schema, so an item the schema
   // does not know does not just fail to persist itself — it takes every sibling toggle with it.
   it.each(SIDEBAR_ROW_ITEMS)("persists the %s row item being switched off", async (item) => {
@@ -660,6 +469,22 @@ describe("saveAppSettings", () => {
     await saveAppSettings({ queryClient, updates: { sidebarRowItems }, deps });
 
     expect((await loadAppSettingsFromStorage(deps)).sidebarRowItems).toEqual(sidebarRowItems);
+  });
+
+  it("keeps saved composer trigger sigils distinct", async () => {
+    const deps = makeDeps();
+    const queryClient = new QueryClient();
+
+    await saveAppSettings({
+      queryClient,
+      updates: { commandTriggerSigil: "$" },
+      deps,
+    });
+
+    expect(JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null")).toMatchObject({
+      commandTriggerSigil: "$",
+      skillTriggerSigil: "/",
+    });
   });
 });
 
@@ -683,7 +508,6 @@ describe("appearance settings", () => {
     expect(result.uiFontFamily).toBe("");
     expect(result.monoFontFamily).toBe("");
     expect(result.uiBaseFontSize).toBe(DEFAULT_UI_BASE_FONT_SIZE);
-    expect(result.contentFontSize).toBe(DEFAULT_UI_BASE_FONT_SIZE);
     expect(result.codeFontSize).toBe(DEFAULT_CODE_FONT_SIZE);
     expect(result.syntaxTheme).toBe("one");
     expect(result.toolCallDetailLevel).toBe("detailed");
@@ -737,51 +561,6 @@ describe("appearance settings", () => {
     expect(defaultUiBaseFontSize(false)).toBe(14);
   });
 
-  it("uses a 16px content default on mobile and a 15px default on web", () => {
-    expect(defaultContentFontSize(true)).toBe(16);
-    expect(defaultContentFontSize(false)).toBe(15);
-    expect(DEFAULT_CONTENT_FONT_SIZE).toBe(defaultContentFontSize(false));
-  });
-
-  it("derives and persists content size from an existing interface-size preference", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({ uiBaseFontSize: 17 }),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-    const persisted = JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null");
-
-    expect(result.contentFontSize).toBe(17);
-    expect(persisted).toMatchObject({ uiBaseFontSize: 17, contentFontSize: 17 });
-  });
-
-  it("clamps the content font size into range and rejects non-numeric values", async () => {
-    const high = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({ contentFontSize: 999 }),
-      }),
-    });
-    expect((await loadAppSettingsFromStorage(high)).contentFontSize).toBe(21);
-
-    const low = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({ contentFontSize: 8 }),
-      }),
-    });
-    expect((await loadAppSettingsFromStorage(low)).contentFontSize).toBe(10);
-
-    const bogus = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({ contentFontSize: "abc" }),
-      }),
-    });
-    expect((await loadAppSettingsFromStorage(bogus)).contentFontSize).toBe(
-      DEFAULT_CONTENT_FONT_SIZE,
-    );
-  });
-
   it.each([
     { legacySize: 16, baseSize: 14 },
     { legacySize: 17, baseSize: 15 },
@@ -800,7 +579,7 @@ describe("appearance settings", () => {
 
       expect(result.uiBaseFontSize).toBe(baseSize);
       expect(persisted).toMatchObject({ uiBaseFontSize: baseSize });
-      expect(persisted.uiFontSize).toBe(legacySize);
+      expect(persisted).not.toHaveProperty("uiFontSize");
     },
   );
 
@@ -812,20 +591,6 @@ describe("appearance settings", () => {
     });
 
     expect((await loadAppSettingsFromStorage(deps)).uiBaseFontSize).toBe(16);
-  });
-
-  it("falls back to a valid legacy interface scale when the explicit base size is invalid", async () => {
-    const deps = makeDeps({
-      storage: createInMemoryKeyValueStorage({
-        [APP_SETTINGS_KEY]: JSON.stringify({ uiBaseFontSize: "abc", uiFontSize: 17 }),
-      }),
-    });
-
-    const result = await loadAppSettingsFromStorage(deps);
-    const persisted = JSON.parse(deps.storage.entries.get(APP_SETTINGS_KEY) ?? "null");
-
-    expect(result.uiBaseFontSize).toBe(15);
-    expect(persisted).toMatchObject({ uiBaseFontSize: 15, uiFontSize: 17 });
   });
 
   it("clamps the UI base font size into range and rejects non-numeric values", async () => {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -8,22 +8,25 @@ import {
   type ComposerSigil,
 } from "@/composer/tokens/sigils";
 import type { DesktopSettings } from "@/desktop/settings/desktop-settings";
-import { parseAppLanguage, type AppLanguage } from "@/i18n/locales";
+import type { AppLanguage } from "@/i18n/locales";
+import type { SidebarNavPreference } from "@/sidebar-nav/model";
 import {
   DEFAULT_SIDEBAR_CHECKS_DISPLAY,
-  parseSidebarChecksDisplay,
   type SidebarChecksDisplay,
 } from "@/components/sidebar/display-preferences/checks-display";
 import {
   DEFAULT_SIDEBAR_ROW_ITEMS,
   isChecksHiddenByLegacyRowItem,
-  parseSidebarRowItems,
   type SidebarRowItems,
 } from "@/components/sidebar/display-preferences/row-items";
 import { isNative } from "@/constants/platform";
-import { FONT_SIZE, THEME_OPTIONS, type ThemePreference } from "@/styles/theme";
+import {
+  FONT_SIZE,
+  PLUGIN_THEME_PREFERENCE,
+  THEME_OPTIONS,
+  type ThemePreference,
+} from "@/styles/theme";
 import { z } from "zod";
-import { readValidatedJson } from "@/storage/validated-storage";
 import { APP_SETTINGS_KEY, LEGACY_SETTINGS_KEY } from "./keys";
 import { migrateAppSettings } from "./migrations";
 
@@ -34,20 +37,17 @@ export type SendBehavior = ActiveTurnBehavior | "queue";
 export type ReleaseChannel = "stable" | "beta";
 export type ServiceUrlBehavior = "ask" | "in-app" | "external";
 export type WorkspaceTitleSource = "title" | "branch";
+export type PullRequestOpenLocation = "main" | "side" | "explorer";
 /** What a sidebar workspace row shows in the space to the right of its title. */
 export type SidebarWorkspaceTrailing = "diff" | "timestamp" | "none";
 export type ToolCallDetailLevel = "overview" | "detailed";
 
-const VALID_THEMES = new Set<string>(THEME_OPTIONS.map((option) => option.name));
-const ThemePreferenceSchema = z.enum(THEME_OPTIONS.map((option) => option.name));
-const VALID_SERVICE_URL_BEHAVIORS = new Set<ServiceUrlBehavior>(["ask", "in-app", "external"]);
-const VALID_WORKSPACE_TITLE_SOURCES = new Set<WorkspaceTitleSource>(["title", "branch"]);
-const VALID_SIDEBAR_WORKSPACE_TRAILINGS = new Set<SidebarWorkspaceTrailing>([
-  "diff",
-  "timestamp",
-  "none",
+const ThemePreferenceSchema = z.enum([
+  ...THEME_OPTIONS.map((option) => option.name),
+  PLUGIN_THEME_PREFERENCE,
 ]);
-const VALID_TOOL_CALL_DETAIL_LEVELS = new Set<ToolCallDetailLevel>(["overview", "detailed"]);
+/** Where the theme picker lands when the persisted preference cannot be honoured. */
+export const DEFAULT_THEME_PREFERENCE = "auto" satisfies ThemePreference;
 export const DEFAULT_TERMINAL_SCROLLBACK_LINES = 10_000;
 export const MIN_TERMINAL_SCROLLBACK_LINES = 0;
 export const MAX_TERMINAL_SCROLLBACK_LINES = 1_000_000;
@@ -58,6 +58,13 @@ export function defaultUiBaseFontSize(native: boolean): number {
 export const DEFAULT_UI_BASE_FONT_SIZE = defaultUiBaseFontSize(isNative);
 export const MIN_UI_BASE_FONT_SIZE = 10;
 export const MAX_UI_BASE_FONT_SIZE = 21;
+export function defaultContentFontSize(native: boolean): number {
+  return native ? 16 : FONT_SIZE.content;
+}
+
+export const DEFAULT_CONTENT_FONT_SIZE = defaultContentFontSize(isNative);
+export const MIN_CONTENT_FONT_SIZE = 10;
+export const MAX_CONTENT_FONT_SIZE = 21;
 export const DEFAULT_CODE_FONT_SIZE = 12; // == FONT_SIZE.code
 export const MIN_CODE_FONT_SIZE = 9;
 export const MAX_CODE_FONT_SIZE = 22; // line-height 1.5×22=33 stays safe
@@ -65,6 +72,8 @@ export const MAX_FONT_FAMILY_LENGTH = 200;
 
 export interface AppSettings {
   theme: ThemePreference;
+  /** Which contributed theme `theme: "plugin"` selects. */
+  pluginThemeId: string | null;
   language: AppLanguage;
   sendBehavior: SendBehavior;
   serviceUrlBehavior: ServiceUrlBehavior;
@@ -73,12 +82,15 @@ export interface AppSettings {
   uiFontFamily: string; // "" = platform default UI stack
   monoFontFamily: string; // "" = platform default mono stack
   uiBaseFontSize: number; // clamped px, platform default 14 or 15
+  contentFontSize: number; // clamped px, platform default 15 or 16
   codeFontSize: number; // clamped px, default 12
   syntaxTheme: SyntaxThemeId; // default "one"
   workspaceTitleSource: WorkspaceTitleSource;
   sidebarWorkspaceTrailing: SidebarWorkspaceTrailing;
   sidebarRowItems: SidebarRowItems;
   sidebarChecksDisplay: SidebarChecksDisplay;
+  /** Top-level sidebar rows in display order; empty means the default order, all visible. */
+  sidebarNavItems: SidebarNavPreference[];
   autoExpandReasoning: boolean;
   toolCallDetailLevel: ToolCallDetailLevel;
   chatOutlineEnabled: boolean;
@@ -87,66 +99,39 @@ export interface AppSettings {
   commandTriggerSigil: ComposerSigil;
   /** Character that opens the skills-only menu anywhere in a message. */
   skillTriggerSigil: ComposerSigil;
+  /** Desktop-only preferences for implicit opens into the ordinary side pane. */
+  openInSidePane: OpenInSidePanePreferences;
+  pullRequestOpenLocation: PullRequestOpenLocation;
 }
+
+export type AppSettingsUpdate =
+  | Partial<AppSettings>
+  | ((current: AppSettings) => Partial<AppSettings>);
+
+export interface OpenInSidePanePreferences {
+  explorerFiles: boolean;
+  diffs: boolean;
+  chatFiles: boolean;
+  diffFiles: boolean;
+  subagents: boolean;
+}
+
+export const DEFAULT_OPEN_IN_SIDE_PANE_PREFERENCES: OpenInSidePanePreferences = {
+  explorerFiles: false,
+  diffs: false,
+  chatFiles: false,
+  diffFiles: false,
+  subagents: false,
+};
 
 export interface Settings extends AppSettings {
   manageBuiltInDaemon: boolean;
   releaseChannel: ReleaseChannel;
 }
 
-// Strict, so every item in SIDEBAR_ROW_ITEMS needs a key here the day it is added: the whole
-// settings write is one validation, and one unknown key silently loses every other toggle in it.
-// `checks` and `scripts` are gone from the item list and stay here for the COMPAT reads in
-// row-items.ts.
-const SidebarRowItemsSchema = z.strictObject({
-  branch: z.boolean().optional(),
-  project: z.boolean().optional(),
-  host: z.boolean().optional(),
-  changeRequest: z.boolean().optional(),
-  services: z.boolean().optional(),
-  labels: z.boolean().optional(),
-  checks: z.boolean().optional(),
-  scripts: z.boolean().optional(),
-});
-
-const StoredAppSettingsSchema = z.strictObject({
-  theme: ThemePreferenceSchema.optional(),
-  language: z
-    .enum(["system", "ar", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN"])
-    .optional(),
-  sendBehavior: z.enum(["interrupt", "steer", "queue"]).optional(),
-  serviceUrlBehavior: z.enum(["ask", "in-app", "external"]).optional(),
-  terminalScrollbackLines: z.union([z.number(), z.string()]).optional(),
-  useLegacyTerminalRenderer: z.boolean().optional(),
-  uiFontFamily: z.string().optional(),
-  monoFontFamily: z.string().optional(),
-  uiBaseFontSize: z.union([z.number(), z.string()]).optional(),
-  // COMPAT(uiFontSizeScale): replaced by the literal base size in v0.4, remove after 2027-08-17.
-  uiFontSize: z.union([z.number(), z.string()]).optional(),
-  codeFontSize: z.union([z.number(), z.string()]).optional(),
-  syntaxTheme: z.string().refine(isSyntaxThemeId).optional(),
-  workspaceTitleSource: z.enum(["title", "branch"]).optional(),
-  sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).optional(),
-  sidebarRowItems: SidebarRowItemsSchema.optional(),
-  sidebarChecksDisplay: z.enum(["iconAndText", "icon", "none"]).optional(),
-  autoExpandReasoning: z.boolean().optional(),
-  toolCallDetailLevel: z.enum(["overview", "detailed"]).optional(),
-  compactToolCalls: z.boolean().optional(),
-  chatOutlineEnabled: z.boolean().optional(),
-  vimKeybindings: z.boolean().optional(),
-  commandTriggerSigil: z.string().optional(),
-  skillTriggerSigil: z.string().optional(),
-  // COMPAT(rendererDesktopSettings): these fields used to share this renderer-owned key.
-  manageBuiltInDaemon: z.boolean().optional(),
-  releaseChannel: z.enum(["stable", "beta"]).optional(),
-});
-
-const LegacyRendererSettingsSchema = StoredAppSettingsSchema;
-
-type StoredAppSettings = z.infer<typeof StoredAppSettingsSchema>;
-
 export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
-  theme: "auto",
+  theme: DEFAULT_THEME_PREFERENCE,
+  pluginThemeId: null,
   language: "system",
   sendBehavior: "steer",
   serviceUrlBehavior: "ask",
@@ -155,18 +140,22 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   uiFontFamily: "",
   monoFontFamily: "",
   uiBaseFontSize: DEFAULT_UI_BASE_FONT_SIZE,
+  contentFontSize: DEFAULT_CONTENT_FONT_SIZE,
   codeFontSize: DEFAULT_CODE_FONT_SIZE,
   syntaxTheme: "one",
   workspaceTitleSource: "title",
   sidebarWorkspaceTrailing: "diff",
   sidebarRowItems: DEFAULT_SIDEBAR_ROW_ITEMS,
   sidebarChecksDisplay: DEFAULT_SIDEBAR_CHECKS_DISPLAY,
+  sidebarNavItems: [],
   autoExpandReasoning: false,
   toolCallDetailLevel: "detailed",
   chatOutlineEnabled: true,
   vimKeybindings: false,
   commandTriggerSigil: DEFAULT_COMMAND_SIGIL,
   skillTriggerSigil: DEFAULT_SKILL_SIGIL,
+  openInSidePane: DEFAULT_OPEN_IN_SIDE_PANE_PREFERENCES,
+  pullRequestOpenLocation: "explorer",
 };
 
 export const DEFAULT_APP_SETTINGS: Settings = {
@@ -174,6 +163,168 @@ export const DEFAULT_APP_SETTINGS: Settings = {
   manageBuiltInDaemon: true,
   releaseChannel: "stable",
 };
+
+function clampedNumber(min: number, max: number) {
+  return z
+    .unknown()
+    .transform((value) => parseClampedFontSize(value, { min, max }))
+    .pipe(z.number());
+}
+
+function sanitizedFontFamily() {
+  return z.unknown().transform(sanitizeFontFamily).pipe(z.string());
+}
+
+const SidebarRowItemsSchema = z
+  .looseObject({
+    branch: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.branch),
+    project: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.project),
+    host: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.host),
+    changeRequest: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.changeRequest),
+    services: z.boolean().optional().catch(undefined),
+    labels: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.labels),
+    // COMPAT(sidebarRowItemsChecks): migrated in v0.3.0, remove after 2027-08-05.
+    checks: z.boolean().optional().catch(undefined),
+    // COMPAT(sidebarRowItemsScripts): migrated in v0.3.0, remove after 2027-08-05.
+    scripts: z.boolean().optional().catch(undefined),
+  })
+  .catch(DEFAULT_SIDEBAR_ROW_ITEMS);
+
+type StoredAppSettingsFallback = AppSettings & {
+  uiFontSize?: number;
+  compactToolCalls?: boolean;
+  manageBuiltInDaemon?: boolean;
+  releaseChannel?: ReleaseChannel;
+  needsWrite: boolean;
+};
+
+const DEFAULT_STORED_APP_SETTINGS = {
+  ...DEFAULT_CLIENT_SETTINGS,
+  needsWrite: false,
+} satisfies StoredAppSettingsFallback;
+
+const StoredAppSettingsSchema = z
+  .looseObject({
+    theme: ThemePreferenceSchema.catch(DEFAULT_THEME_PREFERENCE),
+    pluginThemeId: z.string().nullable().catch(null),
+    language: z
+      .enum(["system", "ar", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN"])
+      .catch("system"),
+    sendBehavior: z.enum(["interrupt", "steer", "queue"]).catch("steer"),
+    serviceUrlBehavior: z.enum(["ask", "in-app", "external"]).catch("ask"),
+    terminalScrollbackLines: clampedNumber(
+      MIN_TERMINAL_SCROLLBACK_LINES,
+      MAX_TERMINAL_SCROLLBACK_LINES,
+    ).catch(DEFAULT_TERMINAL_SCROLLBACK_LINES),
+    useLegacyTerminalRenderer: z.boolean().catch(false),
+    uiFontFamily: sanitizedFontFamily().catch(""),
+    monoFontFamily: sanitizedFontFamily().catch(""),
+    uiBaseFontSize: clampedNumber(MIN_UI_BASE_FONT_SIZE, MAX_UI_BASE_FONT_SIZE)
+      .optional()
+      .catch(undefined),
+    contentFontSize: clampedNumber(MIN_CONTENT_FONT_SIZE, MAX_CONTENT_FONT_SIZE)
+      .optional()
+      .catch(DEFAULT_CONTENT_FONT_SIZE),
+    // COMPAT(uiFontSizeScale): replaced by the literal base size in v0.4, remove after 2027-08-17.
+    uiFontSize: clampedNumber(11, 24).optional().catch(undefined),
+    codeFontSize: clampedNumber(MIN_CODE_FONT_SIZE, MAX_CODE_FONT_SIZE).catch(
+      DEFAULT_CODE_FONT_SIZE,
+    ),
+    syntaxTheme: z.string().refine(isSyntaxThemeId).catch("one"),
+    workspaceTitleSource: z.enum(["title", "branch"]).catch("title"),
+    sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).catch("diff"),
+    sidebarRowItems: SidebarRowItemsSchema,
+    sidebarChecksDisplay: z
+      .enum(["iconAndText", "icon", "none"])
+      .optional()
+      .catch(DEFAULT_SIDEBAR_CHECKS_DISPLAY),
+    sidebarNavItems: z.array(z.object({ key: z.string(), visible: z.boolean() })).catch([]),
+    autoExpandReasoning: z.boolean().catch(false),
+    toolCallDetailLevel: z
+      .enum(["overview", "detailed"])
+      .or(z.literal("concise").transform(() => "overview" as const))
+      .optional()
+      .catch("detailed"),
+    // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
+    compactToolCalls: z.boolean().optional().catch(undefined),
+    chatOutlineEnabled: z.boolean().catch(true),
+    vimKeybindings: z.boolean().catch(false),
+    commandTriggerSigil: z.string().optional(),
+    skillTriggerSigil: z.string().optional(),
+    openInSidePane: z
+      .object({
+        explorerFiles: z.boolean().catch(false),
+        diffs: z.boolean().optional(),
+        // COMPAT(diffDestinationPreference): legacy split preferences, remove after 2027-02-26.
+        explorerChanges: z.boolean().optional(),
+        changesLinks: z.boolean().optional(),
+        chatFiles: z.boolean().catch(false),
+        diffFiles: z.boolean().catch(false),
+        subagents: z.boolean().catch(false),
+        // COMPAT(pullRequestOpenLocation): legacy side-pane toggle, remove after 2027-02-26.
+        pullRequests: z.boolean().optional(),
+      })
+      .transform(({ explorerChanges, changesLinks, pullRequests, ...preferences }) => ({
+        ...preferences,
+        diffs: preferences.diffs ?? explorerChanges ?? changesLinks ?? false,
+        legacyPullRequestsInSidePane: pullRequests,
+      }))
+      .catch({
+        ...DEFAULT_OPEN_IN_SIDE_PANE_PREFERENCES,
+        legacyPullRequestsInSidePane: undefined,
+      }),
+    pullRequestOpenLocation: z.enum(["main", "side", "explorer"]).optional(),
+    // COMPAT(explorerSidebarRouting): replaced by source-specific side-pane preferences in v0.6.
+    openSupportingTabsInSidePanel: z.boolean().optional().catch(undefined),
+    // COMPAT(rendererDesktopSettings): these fields used to share this renderer-owned key.
+    manageBuiltInDaemon: z.boolean().optional().catch(undefined),
+    releaseChannel: z.enum(["stable", "beta"]).optional().catch(undefined),
+  })
+  .transform((stored) => {
+    const { legacyPullRequestsInSidePane, ...openInSidePane } = stored.openInSidePane;
+    const composerSigils = resolveComposerSigils({
+      command: stored.commandTriggerSigil,
+      skill: stored.skillTriggerSigil,
+    });
+    const needsWrite =
+      (stored.uiBaseFontSize === undefined && stored.uiFontSize !== undefined) ||
+      stored.contentFontSize === undefined;
+    const uiBaseFontSize =
+      stored.uiBaseFontSize ??
+      (stored.uiFontSize === undefined
+        ? DEFAULT_UI_BASE_FONT_SIZE
+        : Math.round((FONT_SIZE.base * stored.uiFontSize) / 16));
+    const sidebarChecksDisplay =
+      stored.sidebarChecksDisplay ??
+      (isChecksHiddenByLegacyRowItem(stored.sidebarRowItems)
+        ? "none"
+        : DEFAULT_SIDEBAR_CHECKS_DISPLAY);
+    const toolCallDetailLevel =
+      stored.toolCallDetailLevel ?? (stored.compactToolCalls ? "overview" : "detailed");
+    return {
+      ...stored,
+      commandTriggerSigil: composerSigils.command,
+      skillTriggerSigil: composerSigils.skill,
+      openInSidePane,
+      pullRequestOpenLocation:
+        stored.pullRequestOpenLocation ?? (legacyPullRequestsInSidePane ? "side" : "explorer"),
+      uiBaseFontSize,
+      contentFontSize: stored.contentFontSize ?? uiBaseFontSize,
+      sidebarChecksDisplay,
+      sidebarRowItems: {
+        ...stored.sidebarRowItems,
+        services:
+          stored.sidebarRowItems.services ??
+          (stored.sidebarRowItems.scripts === false ? false : DEFAULT_SIDEBAR_ROW_ITEMS.services),
+      },
+      toolCallDetailLevel,
+      needsWrite,
+    };
+  })
+  .catch(DEFAULT_STORED_APP_SETTINGS);
+
+type StoredAppSettings = z.output<typeof StoredAppSettingsSchema>;
+export type PersistedAppSettings = Omit<StoredAppSettings, "needsWrite">;
 
 export interface KeyValueStorage {
   getItem(key: string): Promise<string | null>;
@@ -197,25 +348,32 @@ export interface SettingsDeps {
 
 export async function saveAppSettings(input: {
   queryClient: QueryClient;
-  updates: Partial<AppSettings>;
+  updates: AppSettingsUpdate;
   deps: SettingsDeps;
 }): Promise<void> {
   const storedCurrent =
     input.queryClient.getQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY) ??
     (await loadAppSettingsFromStorage(input.deps));
   const current = normalizeAppSettings(storedCurrent);
-  const next = normalizeAppSettings({ ...current, ...input.updates });
+  const updates = typeof input.updates === "function" ? input.updates(current) : input.updates;
+  const next = normalizeAppSettings({ ...current, ...updates });
   input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
-  await input.deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
+  await writeAppSettings(
+    input.deps.storage,
+    (await readSettingsObject(input.deps.storage, APP_SETTINGS_KEY)) ??
+      StoredAppSettingsSchema.parse({}),
+    next,
+  );
 }
 
 export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<AppSettings> {
   try {
     const read = await readAppSettings(deps);
     if (read.needsWrite) {
-      await deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(read.settings));
+      await writeAppSettings(deps.storage, read.stored, read.settings);
     }
-    return await migrateAppSettings(read.settings, deps.storage);
+    const { needsWrite: _needsWrite, ...stored } = read.stored;
+    return await migrateAppSettings(read.settings, deps.storage, stored, { native: isNative });
   } catch (error) {
     console.error("[AppSettings] Failed to load settings:", error);
     throw error;
@@ -228,21 +386,18 @@ export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<Ap
  */
 async function readAppSettings(
   deps: SettingsDeps,
-): Promise<{ settings: AppSettings; needsWrite: boolean }> {
-  const stored = await readValidatedJson(deps.storage, APP_SETTINGS_KEY, StoredAppSettingsSchema);
+): Promise<{ settings: AppSettings; needsWrite: boolean; stored: StoredAppSettings }> {
+  const stored = await readSettingsObject(deps.storage, APP_SETTINGS_KEY);
   if (stored) {
     return {
       settings: normalizeAppSettings(stored),
       // COMPAT(uiFontSizeScale): persist the converted base size, remove after 2027-08-17.
-      needsWrite: stored.uiBaseFontSize === undefined && stored.uiFontSize !== undefined,
+      needsWrite: stored.needsWrite,
+      stored,
     };
   }
 
-  const legacyStored = await readValidatedJson(
-    deps.storage,
-    LEGACY_SETTINGS_KEY,
-    LegacyRendererSettingsSchema,
-  );
+  const legacyStored = await readSettingsObject(deps.storage, LEGACY_SETTINGS_KEY);
   if (legacyStored) {
     return {
       settings: {
@@ -250,10 +405,12 @@ async function readAppSettings(
         ...pickAppSettingsFromLegacy(legacyStored),
       } satisfies AppSettings,
       needsWrite: true,
+      stored: legacyStored,
     };
   }
 
-  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true };
+  const defaultStored = StoredAppSettingsSchema.parse({});
+  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true, stored: defaultStored };
 }
 
 export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Settings> {
@@ -283,177 +440,25 @@ export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Setti
 }
 
 export function normalizeAppSettings(value: unknown): AppSettings {
-  const result = StoredAppSettingsSchema.safeParse(value);
+  const {
+    needsWrite: _needsWrite,
+    manageBuiltInDaemon: _manageBuiltInDaemon,
+    releaseChannel: _releaseChannel,
+    compactToolCalls: _compactToolCalls,
+    uiFontSize: _uiFontSize,
+    ...settings
+  } = StoredAppSettingsSchema.parse(value);
+  return settings;
+}
+
+function pickAppSettingsFromLegacy(legacy: StoredAppSettings): AppSettings {
+  const settings = normalizeAppSettings(legacy);
   return {
-    ...DEFAULT_CLIENT_SETTINGS,
-    ...pickAppSettings(result.success ? result.data : {}),
+    ...settings,
+    // The legacy key rendered content on the interface ramp. Freeze that
+    // rendered value into the new independent preference during migration.
+    contentFontSize: legacy.uiBaseFontSize,
   };
-}
-
-function parseToolCallDetailLevel(stored: StoredAppSettings): ToolCallDetailLevel | null {
-  if (stored.toolCallDetailLevel !== undefined) {
-    if (
-      typeof stored.toolCallDetailLevel === "string" &&
-      VALID_TOOL_CALL_DETAIL_LEVELS.has(stored.toolCallDetailLevel)
-    ) {
-      return stored.toolCallDetailLevel;
-    }
-    // COMPAT(toolCallDetailLevelConcise): removed in v0.1.107; legacy "concise" values
-    // deliberately follow the unknown-value fallback. Remove after 2027-01-14.
-    return "overview";
-  }
-  if (typeof stored.compactToolCalls === "boolean") {
-    // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
-    return stored.compactToolCalls ? "overview" : "detailed";
-  }
-  return null;
-}
-
-function parseStoredSidebarChecksDisplay(stored: StoredAppSettings): SidebarChecksDisplay | null {
-  const display = parseSidebarChecksDisplay(stored.sidebarChecksDisplay);
-  if (display !== null) {
-    return display;
-  }
-  // COMPAT(sidebarRowItemsChecks): migrated in v0.3.0, remove after 2027-08-05.
-  return isChecksHiddenByLegacyRowItem(stored.sidebarRowItems) ? "none" : null;
-}
-
-function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  if (typeof stored.useLegacyTerminalRenderer === "boolean") {
-    result.useLegacyTerminalRenderer = stored.useLegacyTerminalRenderer;
-  }
-  if (typeof stored.vimKeybindings === "boolean") {
-    result.vimKeybindings = stored.vimKeybindings;
-  }
-  if (typeof stored.chatOutlineEnabled === "boolean") {
-    result.chatOutlineEnabled = stored.chatOutlineEnabled;
-  }
-  return result;
-}
-
-/**
- * The settings whose stored value only has to be a member of a fixed set. Grouped like the
- * boolean settings are: the numeric and font settings need real parsing and clamping, these
- * need a membership check and nothing else.
- */
-function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  if (typeof stored.theme === "string" && VALID_THEMES.has(stored.theme)) {
-    result.theme = stored.theme;
-  }
-  if (
-    stored.sendBehavior === "interrupt" ||
-    stored.sendBehavior === "steer" ||
-    stored.sendBehavior === "queue"
-  ) {
-    result.sendBehavior = stored.sendBehavior;
-  }
-  if (
-    typeof stored.serviceUrlBehavior === "string" &&
-    VALID_SERVICE_URL_BEHAVIORS.has(stored.serviceUrlBehavior)
-  ) {
-    result.serviceUrlBehavior = stored.serviceUrlBehavior;
-  }
-  if (typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme)) {
-    result.syntaxTheme = stored.syntaxTheme;
-  }
-  if (
-    typeof stored.workspaceTitleSource === "string" &&
-    VALID_WORKSPACE_TITLE_SOURCES.has(stored.workspaceTitleSource)
-  ) {
-    result.workspaceTitleSource = stored.workspaceTitleSource;
-  }
-  if (
-    typeof stored.sidebarWorkspaceTrailing === "string" &&
-    VALID_SIDEBAR_WORKSPACE_TRAILINGS.has(stored.sidebarWorkspaceTrailing)
-  ) {
-    result.sidebarWorkspaceTrailing = stored.sidebarWorkspaceTrailing;
-  }
-  return result;
-}
-
-function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  Object.assign(result, pickEnumAppSettings(stored));
-  if (stored.sidebarRowItems !== undefined) {
-    result.sidebarRowItems = parseSidebarRowItems(stored.sidebarRowItems);
-  }
-  const sidebarChecksDisplay = parseStoredSidebarChecksDisplay(stored);
-  if (sidebarChecksDisplay !== null) {
-    result.sidebarChecksDisplay = sidebarChecksDisplay;
-  }
-  const language = parseAppLanguage(stored.language);
-  if (language !== null) {
-    result.language = language;
-  }
-  const terminalScrollbackLines = parseTerminalScrollbackLines(stored.terminalScrollbackLines);
-  if (terminalScrollbackLines !== null) {
-    result.terminalScrollbackLines = terminalScrollbackLines;
-  }
-  const uiFontFamily = sanitizeFontFamily(stored.uiFontFamily);
-  if (uiFontFamily !== null) {
-    result.uiFontFamily = uiFontFamily;
-  }
-  const monoFontFamily = sanitizeFontFamily(stored.monoFontFamily);
-  if (monoFontFamily !== null) {
-    result.monoFontFamily = monoFontFamily;
-  }
-  const uiBaseFontSize = parseClampedFontSize(stored.uiBaseFontSize, {
-    min: MIN_UI_BASE_FONT_SIZE,
-    max: MAX_UI_BASE_FONT_SIZE,
-  });
-  if (uiBaseFontSize !== null) {
-    result.uiBaseFontSize = uiBaseFontSize;
-  } else {
-    const legacyUiFontSize = parseClampedFontSize(stored.uiFontSize, {
-      min: 11,
-      max: 24,
-    });
-    if (legacyUiFontSize !== null) {
-      result.uiBaseFontSize = Math.round((FONT_SIZE.base * legacyUiFontSize) / 16);
-    }
-  }
-  const codeFontSize = parseClampedFontSize(stored.codeFontSize, {
-    min: MIN_CODE_FONT_SIZE,
-    max: MAX_CODE_FONT_SIZE,
-  });
-  if (codeFontSize !== null) {
-    result.codeFontSize = codeFontSize;
-  }
-  Object.assign(result, pickBooleanAppSettings(stored));
-  if (typeof stored.autoExpandReasoning === "boolean") {
-    result.autoExpandReasoning = stored.autoExpandReasoning;
-  }
-  const toolCallDetailLevel = parseToolCallDetailLevel(stored);
-  if (toolCallDetailLevel !== null) {
-    result.toolCallDetailLevel = toolCallDetailLevel;
-  }
-  Object.assign(result, pickComposerSigils(stored));
-  return result;
-}
-
-function pickComposerSigils(
-  stored: StoredAppSettings,
-): Pick<AppSettings, "commandTriggerSigil" | "skillTriggerSigil"> {
-  const sigils = resolveComposerSigils({
-    command: stored.commandTriggerSigil,
-    skill: stored.skillTriggerSigil,
-  });
-  return {
-    commandTriggerSigil: sigils.command,
-    skillTriggerSigil: sigils.skill,
-  };
-}
-
-function pickAppSettingsFromLegacy(
-  legacy: z.infer<typeof LegacyRendererSettingsSchema>,
-): Partial<AppSettings> {
-  const result: Partial<AppSettings> = {};
-  if (legacy.theme === "dark" || legacy.theme === "light" || legacy.theme === "auto") {
-    result.theme = legacy.theme;
-  }
-  return result;
 }
 
 export function parseTerminalScrollbackLines(value: unknown): number | null {
@@ -522,10 +527,10 @@ async function loadLegacyDesktopSettingsFromStorage(storage: KeyValueStorage): P
     releaseChannel?: ReleaseChannel;
   } = {};
 
-  if (typeof stored.manageBuiltInDaemon === "boolean") {
+  if (stored.manageBuiltInDaemon !== undefined) {
     result.manageBuiltInDaemon = stored.manageBuiltInDaemon;
   }
-  if (stored.releaseChannel === "stable" || stored.releaseChannel === "beta") {
+  if (stored.releaseChannel !== undefined) {
     result.releaseChannel = stored.releaseChannel;
   }
 
@@ -534,11 +539,48 @@ async function loadLegacyDesktopSettingsFromStorage(storage: KeyValueStorage): P
 
 async function loadRendererSettingsPayload(
   storage: KeyValueStorage,
-): Promise<z.infer<typeof LegacyRendererSettingsSchema> | null> {
-  const current = await readValidatedJson(storage, APP_SETTINGS_KEY, LegacyRendererSettingsSchema);
+): Promise<StoredAppSettings | null> {
+  const current = await readSettingsObject(storage, APP_SETTINGS_KEY);
   if (current) {
     return current;
   }
 
-  return readValidatedJson(storage, LEGACY_SETTINGS_KEY, LegacyRendererSettingsSchema);
+  return readSettingsObject(storage, LEGACY_SETTINGS_KEY);
+}
+
+async function readSettingsObject(
+  storage: KeyValueStorage,
+  key: string,
+): Promise<StoredAppSettings | null> {
+  const raw = await storage.getItem(key);
+  if (raw === null) {
+    return null;
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    console.warn(`[AppSettings] Removing corrupt ${key}: invalid JSON.`);
+    await storage.removeItem(key);
+    return null;
+  }
+  return StoredAppSettingsSchema.parse(decoded);
+}
+
+async function writeAppSettings(
+  storage: KeyValueStorage,
+  stored: StoredAppSettings,
+  settings: AppSettings,
+): Promise<void> {
+  const { needsWrite: _needsWrite, ...persistedStored } = stored;
+  const storedSidebarRowItems = persistedStored.sidebarRowItems;
+  await storage.setItem(
+    APP_SETTINGS_KEY,
+    JSON.stringify({
+      ...persistedStored,
+      ...settings,
+      sidebarRowItems: { ...storedSidebarRowItems, ...settings.sidebarRowItems },
+    }),
+  );
 }

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -1,26 +1,29 @@
 import { isSyntaxThemeId, type SyntaxThemeId } from "@getpaseo/highlight";
 import type { ActiveTurnBehavior } from "@getpaseo/protocol/messages";
 import type { QueryClient } from "@tanstack/react-query";
+import {
+  DEFAULT_COMMAND_SIGIL,
+  DEFAULT_SKILL_SIGIL,
+  resolveComposerSigils,
+  type ComposerSigil,
+} from "@/composer/tokens/sigils";
 import type { DesktopSettings } from "@/desktop/settings/desktop-settings";
-import type { AppLanguage } from "@/i18n/locales";
-import type { SidebarNavPreference } from "@/sidebar-nav/model";
+import { parseAppLanguage, type AppLanguage } from "@/i18n/locales";
 import {
   DEFAULT_SIDEBAR_CHECKS_DISPLAY,
+  parseSidebarChecksDisplay,
   type SidebarChecksDisplay,
 } from "@/components/sidebar/display-preferences/checks-display";
 import {
   DEFAULT_SIDEBAR_ROW_ITEMS,
   isChecksHiddenByLegacyRowItem,
+  parseSidebarRowItems,
   type SidebarRowItems,
 } from "@/components/sidebar/display-preferences/row-items";
 import { isNative } from "@/constants/platform";
-import {
-  FONT_SIZE,
-  PLUGIN_THEME_PREFERENCE,
-  THEME_OPTIONS,
-  type ThemePreference,
-} from "@/styles/theme";
+import { FONT_SIZE, THEME_OPTIONS, type ThemePreference } from "@/styles/theme";
 import { z } from "zod";
+import { readValidatedJson } from "@/storage/validated-storage";
 import { APP_SETTINGS_KEY, LEGACY_SETTINGS_KEY } from "./keys";
 import { migrateAppSettings } from "./migrations";
 
@@ -31,17 +34,20 @@ export type SendBehavior = ActiveTurnBehavior | "queue";
 export type ReleaseChannel = "stable" | "beta";
 export type ServiceUrlBehavior = "ask" | "in-app" | "external";
 export type WorkspaceTitleSource = "title" | "branch";
-export type PullRequestOpenLocation = "main" | "side" | "explorer";
 /** What a sidebar workspace row shows in the space to the right of its title. */
 export type SidebarWorkspaceTrailing = "diff" | "timestamp" | "none";
 export type ToolCallDetailLevel = "overview" | "detailed";
 
-const ThemePreferenceSchema = z.enum([
-  ...THEME_OPTIONS.map((option) => option.name),
-  PLUGIN_THEME_PREFERENCE,
+const VALID_THEMES = new Set<string>(THEME_OPTIONS.map((option) => option.name));
+const ThemePreferenceSchema = z.enum(THEME_OPTIONS.map((option) => option.name));
+const VALID_SERVICE_URL_BEHAVIORS = new Set<ServiceUrlBehavior>(["ask", "in-app", "external"]);
+const VALID_WORKSPACE_TITLE_SOURCES = new Set<WorkspaceTitleSource>(["title", "branch"]);
+const VALID_SIDEBAR_WORKSPACE_TRAILINGS = new Set<SidebarWorkspaceTrailing>([
+  "diff",
+  "timestamp",
+  "none",
 ]);
-/** Where the theme picker lands when the persisted preference cannot be honoured. */
-export const DEFAULT_THEME_PREFERENCE = "auto" satisfies ThemePreference;
+const VALID_TOOL_CALL_DETAIL_LEVELS = new Set<ToolCallDetailLevel>(["overview", "detailed"]);
 export const DEFAULT_TERMINAL_SCROLLBACK_LINES = 10_000;
 export const MIN_TERMINAL_SCROLLBACK_LINES = 0;
 export const MAX_TERMINAL_SCROLLBACK_LINES = 1_000_000;
@@ -52,13 +58,6 @@ export function defaultUiBaseFontSize(native: boolean): number {
 export const DEFAULT_UI_BASE_FONT_SIZE = defaultUiBaseFontSize(isNative);
 export const MIN_UI_BASE_FONT_SIZE = 10;
 export const MAX_UI_BASE_FONT_SIZE = 21;
-export function defaultContentFontSize(native: boolean): number {
-  return native ? 16 : FONT_SIZE.content;
-}
-
-export const DEFAULT_CONTENT_FONT_SIZE = defaultContentFontSize(isNative);
-export const MIN_CONTENT_FONT_SIZE = 10;
-export const MAX_CONTENT_FONT_SIZE = 21;
 export const DEFAULT_CODE_FONT_SIZE = 12; // == FONT_SIZE.code
 export const MIN_CODE_FONT_SIZE = 9;
 export const MAX_CODE_FONT_SIZE = 22; // line-height 1.5×22=33 stays safe
@@ -66,8 +65,6 @@ export const MAX_FONT_FAMILY_LENGTH = 200;
 
 export interface AppSettings {
   theme: ThemePreference;
-  /** Which contributed theme `theme: "plugin"` selects. */
-  pluginThemeId: string | null;
   language: AppLanguage;
   sendBehavior: SendBehavior;
   serviceUrlBehavior: ServiceUrlBehavior;
@@ -76,52 +73,80 @@ export interface AppSettings {
   uiFontFamily: string; // "" = platform default UI stack
   monoFontFamily: string; // "" = platform default mono stack
   uiBaseFontSize: number; // clamped px, platform default 14 or 15
-  contentFontSize: number; // clamped px, platform default 15 or 16
   codeFontSize: number; // clamped px, default 12
   syntaxTheme: SyntaxThemeId; // default "one"
   workspaceTitleSource: WorkspaceTitleSource;
   sidebarWorkspaceTrailing: SidebarWorkspaceTrailing;
   sidebarRowItems: SidebarRowItems;
   sidebarChecksDisplay: SidebarChecksDisplay;
-  /** Top-level sidebar rows in display order; empty means the default order, all visible. */
-  sidebarNavItems: SidebarNavPreference[];
   autoExpandReasoning: boolean;
   toolCallDetailLevel: ToolCallDetailLevel;
   chatOutlineEnabled: boolean;
   vimKeybindings: boolean;
-  /** Desktop-only preferences for implicit opens into the ordinary side pane. */
-  openInSidePane: OpenInSidePanePreferences;
-  pullRequestOpenLocation: PullRequestOpenLocation;
+  /** Character that opens the full command menu at the start of a prompt. */
+  commandTriggerSigil: ComposerSigil;
+  /** Character that opens the skills-only menu anywhere in a message. */
+  skillTriggerSigil: ComposerSigil;
 }
-
-export type AppSettingsUpdate =
-  | Partial<AppSettings>
-  | ((current: AppSettings) => Partial<AppSettings>);
-
-export interface OpenInSidePanePreferences {
-  explorerFiles: boolean;
-  diffs: boolean;
-  chatFiles: boolean;
-  diffFiles: boolean;
-  subagents: boolean;
-}
-
-export const DEFAULT_OPEN_IN_SIDE_PANE_PREFERENCES: OpenInSidePanePreferences = {
-  explorerFiles: false,
-  diffs: false,
-  chatFiles: false,
-  diffFiles: false,
-  subagents: false,
-};
 
 export interface Settings extends AppSettings {
   manageBuiltInDaemon: boolean;
   releaseChannel: ReleaseChannel;
 }
 
+// Strict, so every item in SIDEBAR_ROW_ITEMS needs a key here the day it is added: the whole
+// settings write is one validation, and one unknown key silently loses every other toggle in it.
+// `checks` and `scripts` are gone from the item list and stay here for the COMPAT reads in
+// row-items.ts.
+const SidebarRowItemsSchema = z.strictObject({
+  branch: z.boolean().optional(),
+  project: z.boolean().optional(),
+  host: z.boolean().optional(),
+  changeRequest: z.boolean().optional(),
+  services: z.boolean().optional(),
+  labels: z.boolean().optional(),
+  checks: z.boolean().optional(),
+  scripts: z.boolean().optional(),
+});
+
+const StoredAppSettingsSchema = z.strictObject({
+  theme: ThemePreferenceSchema.optional(),
+  language: z
+    .enum(["system", "ar", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN"])
+    .optional(),
+  sendBehavior: z.enum(["interrupt", "steer", "queue"]).optional(),
+  serviceUrlBehavior: z.enum(["ask", "in-app", "external"]).optional(),
+  terminalScrollbackLines: z.union([z.number(), z.string()]).optional(),
+  useLegacyTerminalRenderer: z.boolean().optional(),
+  uiFontFamily: z.string().optional(),
+  monoFontFamily: z.string().optional(),
+  uiBaseFontSize: z.union([z.number(), z.string()]).optional(),
+  // COMPAT(uiFontSizeScale): replaced by the literal base size in v0.4, remove after 2027-08-17.
+  uiFontSize: z.union([z.number(), z.string()]).optional(),
+  codeFontSize: z.union([z.number(), z.string()]).optional(),
+  syntaxTheme: z.string().refine(isSyntaxThemeId).optional(),
+  workspaceTitleSource: z.enum(["title", "branch"]).optional(),
+  sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).optional(),
+  sidebarRowItems: SidebarRowItemsSchema.optional(),
+  sidebarChecksDisplay: z.enum(["iconAndText", "icon", "none"]).optional(),
+  autoExpandReasoning: z.boolean().optional(),
+  toolCallDetailLevel: z.enum(["overview", "detailed"]).optional(),
+  compactToolCalls: z.boolean().optional(),
+  chatOutlineEnabled: z.boolean().optional(),
+  vimKeybindings: z.boolean().optional(),
+  commandTriggerSigil: z.string().optional(),
+  skillTriggerSigil: z.string().optional(),
+  // COMPAT(rendererDesktopSettings): these fields used to share this renderer-owned key.
+  manageBuiltInDaemon: z.boolean().optional(),
+  releaseChannel: z.enum(["stable", "beta"]).optional(),
+});
+
+const LegacyRendererSettingsSchema = StoredAppSettingsSchema;
+
+type StoredAppSettings = z.infer<typeof StoredAppSettingsSchema>;
+
 export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
-  theme: DEFAULT_THEME_PREFERENCE,
-  pluginThemeId: null,
+  theme: "auto",
   language: "system",
   sendBehavior: "steer",
   serviceUrlBehavior: "ask",
@@ -130,20 +155,18 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   uiFontFamily: "",
   monoFontFamily: "",
   uiBaseFontSize: DEFAULT_UI_BASE_FONT_SIZE,
-  contentFontSize: DEFAULT_CONTENT_FONT_SIZE,
   codeFontSize: DEFAULT_CODE_FONT_SIZE,
   syntaxTheme: "one",
   workspaceTitleSource: "title",
   sidebarWorkspaceTrailing: "diff",
   sidebarRowItems: DEFAULT_SIDEBAR_ROW_ITEMS,
   sidebarChecksDisplay: DEFAULT_SIDEBAR_CHECKS_DISPLAY,
-  sidebarNavItems: [],
   autoExpandReasoning: false,
   toolCallDetailLevel: "detailed",
   chatOutlineEnabled: true,
   vimKeybindings: false,
-  openInSidePane: DEFAULT_OPEN_IN_SIDE_PANE_PREFERENCES,
-  pullRequestOpenLocation: "explorer",
+  commandTriggerSigil: DEFAULT_COMMAND_SIGIL,
+  skillTriggerSigil: DEFAULT_SKILL_SIGIL,
 };
 
 export const DEFAULT_APP_SETTINGS: Settings = {
@@ -151,160 +174,6 @@ export const DEFAULT_APP_SETTINGS: Settings = {
   manageBuiltInDaemon: true,
   releaseChannel: "stable",
 };
-
-function clampedNumber(min: number, max: number) {
-  return z
-    .unknown()
-    .transform((value) => parseClampedFontSize(value, { min, max }))
-    .pipe(z.number());
-}
-
-function sanitizedFontFamily() {
-  return z.unknown().transform(sanitizeFontFamily).pipe(z.string());
-}
-
-const SidebarRowItemsSchema = z
-  .looseObject({
-    branch: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.branch),
-    project: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.project),
-    host: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.host),
-    changeRequest: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.changeRequest),
-    services: z.boolean().optional().catch(undefined),
-    labels: z.boolean().catch(DEFAULT_SIDEBAR_ROW_ITEMS.labels),
-    // COMPAT(sidebarRowItemsChecks): migrated in v0.3.0, remove after 2027-08-05.
-    checks: z.boolean().optional().catch(undefined),
-    // COMPAT(sidebarRowItemsScripts): migrated in v0.3.0, remove after 2027-08-05.
-    scripts: z.boolean().optional().catch(undefined),
-  })
-  .catch(DEFAULT_SIDEBAR_ROW_ITEMS);
-
-type StoredAppSettingsFallback = AppSettings & {
-  uiFontSize?: number;
-  compactToolCalls?: boolean;
-  manageBuiltInDaemon?: boolean;
-  releaseChannel?: ReleaseChannel;
-  needsWrite: boolean;
-};
-
-const DEFAULT_STORED_APP_SETTINGS = {
-  ...DEFAULT_CLIENT_SETTINGS,
-  needsWrite: false,
-} satisfies StoredAppSettingsFallback;
-
-const StoredAppSettingsSchema = z
-  .looseObject({
-    theme: ThemePreferenceSchema.catch(DEFAULT_THEME_PREFERENCE),
-    pluginThemeId: z.string().nullable().catch(null),
-    language: z
-      .enum(["system", "ar", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN"])
-      .catch("system"),
-    sendBehavior: z.enum(["interrupt", "steer", "queue"]).catch("steer"),
-    serviceUrlBehavior: z.enum(["ask", "in-app", "external"]).catch("ask"),
-    terminalScrollbackLines: clampedNumber(
-      MIN_TERMINAL_SCROLLBACK_LINES,
-      MAX_TERMINAL_SCROLLBACK_LINES,
-    ).catch(DEFAULT_TERMINAL_SCROLLBACK_LINES),
-    useLegacyTerminalRenderer: z.boolean().catch(false),
-    uiFontFamily: sanitizedFontFamily().catch(""),
-    monoFontFamily: sanitizedFontFamily().catch(""),
-    uiBaseFontSize: clampedNumber(MIN_UI_BASE_FONT_SIZE, MAX_UI_BASE_FONT_SIZE)
-      .optional()
-      .catch(undefined),
-    contentFontSize: clampedNumber(MIN_CONTENT_FONT_SIZE, MAX_CONTENT_FONT_SIZE)
-      .optional()
-      .catch(DEFAULT_CONTENT_FONT_SIZE),
-    // COMPAT(uiFontSizeScale): replaced by the literal base size in v0.4, remove after 2027-08-17.
-    uiFontSize: clampedNumber(11, 24).optional().catch(undefined),
-    codeFontSize: clampedNumber(MIN_CODE_FONT_SIZE, MAX_CODE_FONT_SIZE).catch(
-      DEFAULT_CODE_FONT_SIZE,
-    ),
-    syntaxTheme: z.string().refine(isSyntaxThemeId).catch("one"),
-    workspaceTitleSource: z.enum(["title", "branch"]).catch("title"),
-    sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).catch("diff"),
-    sidebarRowItems: SidebarRowItemsSchema,
-    sidebarChecksDisplay: z
-      .enum(["iconAndText", "icon", "none"])
-      .optional()
-      .catch(DEFAULT_SIDEBAR_CHECKS_DISPLAY),
-    sidebarNavItems: z.array(z.object({ key: z.string(), visible: z.boolean() })).catch([]),
-    autoExpandReasoning: z.boolean().catch(false),
-    toolCallDetailLevel: z
-      .enum(["overview", "detailed"])
-      .or(z.literal("concise").transform(() => "overview" as const))
-      .optional()
-      .catch("detailed"),
-    // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
-    compactToolCalls: z.boolean().optional().catch(undefined),
-    chatOutlineEnabled: z.boolean().catch(true),
-    vimKeybindings: z.boolean().catch(false),
-    openInSidePane: z
-      .object({
-        explorerFiles: z.boolean().catch(false),
-        diffs: z.boolean().optional(),
-        // COMPAT(diffDestinationPreference): legacy split preferences, remove after 2027-02-26.
-        explorerChanges: z.boolean().optional(),
-        changesLinks: z.boolean().optional(),
-        chatFiles: z.boolean().catch(false),
-        diffFiles: z.boolean().catch(false),
-        subagents: z.boolean().catch(false),
-        // COMPAT(pullRequestOpenLocation): legacy side-pane toggle, remove after 2027-02-26.
-        pullRequests: z.boolean().optional(),
-      })
-      .transform(({ explorerChanges, changesLinks, pullRequests, ...preferences }) => ({
-        ...preferences,
-        diffs: preferences.diffs ?? explorerChanges ?? changesLinks ?? false,
-        legacyPullRequestsInSidePane: pullRequests,
-      }))
-      .catch({
-        ...DEFAULT_OPEN_IN_SIDE_PANE_PREFERENCES,
-        legacyPullRequestsInSidePane: undefined,
-      }),
-    pullRequestOpenLocation: z.enum(["main", "side", "explorer"]).optional(),
-    // COMPAT(explorerSidebarRouting): replaced by source-specific side-pane preferences in v0.6.
-    openSupportingTabsInSidePanel: z.boolean().optional().catch(undefined),
-    // COMPAT(rendererDesktopSettings): these fields used to share this renderer-owned key.
-    manageBuiltInDaemon: z.boolean().optional().catch(undefined),
-    releaseChannel: z.enum(["stable", "beta"]).optional().catch(undefined),
-  })
-  .transform((stored) => {
-    const { legacyPullRequestsInSidePane, ...openInSidePane } = stored.openInSidePane;
-    const needsWrite =
-      (stored.uiBaseFontSize === undefined && stored.uiFontSize !== undefined) ||
-      stored.contentFontSize === undefined;
-    const uiBaseFontSize =
-      stored.uiBaseFontSize ??
-      (stored.uiFontSize === undefined
-        ? DEFAULT_UI_BASE_FONT_SIZE
-        : Math.round((FONT_SIZE.base * stored.uiFontSize) / 16));
-    const sidebarChecksDisplay =
-      stored.sidebarChecksDisplay ??
-      (isChecksHiddenByLegacyRowItem(stored.sidebarRowItems)
-        ? "none"
-        : DEFAULT_SIDEBAR_CHECKS_DISPLAY);
-    const toolCallDetailLevel =
-      stored.toolCallDetailLevel ?? (stored.compactToolCalls ? "overview" : "detailed");
-    return {
-      ...stored,
-      openInSidePane,
-      pullRequestOpenLocation:
-        stored.pullRequestOpenLocation ?? (legacyPullRequestsInSidePane ? "side" : "explorer"),
-      uiBaseFontSize,
-      contentFontSize: stored.contentFontSize ?? uiBaseFontSize,
-      sidebarChecksDisplay,
-      sidebarRowItems: {
-        ...stored.sidebarRowItems,
-        services:
-          stored.sidebarRowItems.services ??
-          (stored.sidebarRowItems.scripts === false ? false : DEFAULT_SIDEBAR_ROW_ITEMS.services),
-      },
-      toolCallDetailLevel,
-      needsWrite,
-    };
-  })
-  .catch(DEFAULT_STORED_APP_SETTINGS);
-
-type StoredAppSettings = z.output<typeof StoredAppSettingsSchema>;
-export type PersistedAppSettings = Omit<StoredAppSettings, "needsWrite">;
 
 export interface KeyValueStorage {
   getItem(key: string): Promise<string | null>;
@@ -328,32 +197,25 @@ export interface SettingsDeps {
 
 export async function saveAppSettings(input: {
   queryClient: QueryClient;
-  updates: AppSettingsUpdate;
+  updates: Partial<AppSettings>;
   deps: SettingsDeps;
 }): Promise<void> {
   const storedCurrent =
     input.queryClient.getQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY) ??
     (await loadAppSettingsFromStorage(input.deps));
   const current = normalizeAppSettings(storedCurrent);
-  const updates = typeof input.updates === "function" ? input.updates(current) : input.updates;
-  const next = { ...current, ...updates };
+  const next = normalizeAppSettings({ ...current, ...input.updates });
   input.queryClient.setQueryData<AppSettings>(APP_SETTINGS_QUERY_KEY, next);
-  await writeAppSettings(
-    input.deps.storage,
-    (await readSettingsObject(input.deps.storage, APP_SETTINGS_KEY)) ??
-      StoredAppSettingsSchema.parse({}),
-    next,
-  );
+  await input.deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(next));
 }
 
 export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<AppSettings> {
   try {
     const read = await readAppSettings(deps);
     if (read.needsWrite) {
-      await writeAppSettings(deps.storage, read.stored, read.settings);
+      await deps.storage.setItem(APP_SETTINGS_KEY, JSON.stringify(read.settings));
     }
-    const { needsWrite: _needsWrite, ...stored } = read.stored;
-    return await migrateAppSettings(read.settings, deps.storage, stored, { native: isNative });
+    return await migrateAppSettings(read.settings, deps.storage);
   } catch (error) {
     console.error("[AppSettings] Failed to load settings:", error);
     throw error;
@@ -366,18 +228,21 @@ export async function loadAppSettingsFromStorage(deps: SettingsDeps): Promise<Ap
  */
 async function readAppSettings(
   deps: SettingsDeps,
-): Promise<{ settings: AppSettings; needsWrite: boolean; stored: StoredAppSettings }> {
-  const stored = await readSettingsObject(deps.storage, APP_SETTINGS_KEY);
+): Promise<{ settings: AppSettings; needsWrite: boolean }> {
+  const stored = await readValidatedJson(deps.storage, APP_SETTINGS_KEY, StoredAppSettingsSchema);
   if (stored) {
     return {
       settings: normalizeAppSettings(stored),
       // COMPAT(uiFontSizeScale): persist the converted base size, remove after 2027-08-17.
-      needsWrite: stored.needsWrite,
-      stored,
+      needsWrite: stored.uiBaseFontSize === undefined && stored.uiFontSize !== undefined,
     };
   }
 
-  const legacyStored = await readSettingsObject(deps.storage, LEGACY_SETTINGS_KEY);
+  const legacyStored = await readValidatedJson(
+    deps.storage,
+    LEGACY_SETTINGS_KEY,
+    LegacyRendererSettingsSchema,
+  );
   if (legacyStored) {
     return {
       settings: {
@@ -385,12 +250,10 @@ async function readAppSettings(
         ...pickAppSettingsFromLegacy(legacyStored),
       } satisfies AppSettings,
       needsWrite: true,
-      stored: legacyStored,
     };
   }
 
-  const defaultStored = StoredAppSettingsSchema.parse({});
-  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true, stored: defaultStored };
+  return { settings: DEFAULT_CLIENT_SETTINGS, needsWrite: true };
 }
 
 export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Settings> {
@@ -420,25 +283,177 @@ export async function loadSettingsFromStorage(deps: SettingsDeps): Promise<Setti
 }
 
 export function normalizeAppSettings(value: unknown): AppSettings {
-  const {
-    needsWrite: _needsWrite,
-    manageBuiltInDaemon: _manageBuiltInDaemon,
-    releaseChannel: _releaseChannel,
-    compactToolCalls: _compactToolCalls,
-    uiFontSize: _uiFontSize,
-    ...settings
-  } = StoredAppSettingsSchema.parse(value);
-  return settings;
+  const result = StoredAppSettingsSchema.safeParse(value);
+  return {
+    ...DEFAULT_CLIENT_SETTINGS,
+    ...pickAppSettings(result.success ? result.data : {}),
+  };
 }
 
-function pickAppSettingsFromLegacy(legacy: StoredAppSettings): AppSettings {
-  const settings = normalizeAppSettings(legacy);
+function parseToolCallDetailLevel(stored: StoredAppSettings): ToolCallDetailLevel | null {
+  if (stored.toolCallDetailLevel !== undefined) {
+    if (
+      typeof stored.toolCallDetailLevel === "string" &&
+      VALID_TOOL_CALL_DETAIL_LEVELS.has(stored.toolCallDetailLevel)
+    ) {
+      return stored.toolCallDetailLevel;
+    }
+    // COMPAT(toolCallDetailLevelConcise): removed in v0.1.107; legacy "concise" values
+    // deliberately follow the unknown-value fallback. Remove after 2027-01-14.
+    return "overview";
+  }
+  if (typeof stored.compactToolCalls === "boolean") {
+    // COMPAT(compactToolCalls): migrated in v0.1.105, remove after 2027-01-12.
+    return stored.compactToolCalls ? "overview" : "detailed";
+  }
+  return null;
+}
+
+function parseStoredSidebarChecksDisplay(stored: StoredAppSettings): SidebarChecksDisplay | null {
+  const display = parseSidebarChecksDisplay(stored.sidebarChecksDisplay);
+  if (display !== null) {
+    return display;
+  }
+  // COMPAT(sidebarRowItemsChecks): migrated in v0.3.0, remove after 2027-08-05.
+  return isChecksHiddenByLegacyRowItem(stored.sidebarRowItems) ? "none" : null;
+}
+
+function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
+  const result: Partial<AppSettings> = {};
+  if (typeof stored.useLegacyTerminalRenderer === "boolean") {
+    result.useLegacyTerminalRenderer = stored.useLegacyTerminalRenderer;
+  }
+  if (typeof stored.vimKeybindings === "boolean") {
+    result.vimKeybindings = stored.vimKeybindings;
+  }
+  if (typeof stored.chatOutlineEnabled === "boolean") {
+    result.chatOutlineEnabled = stored.chatOutlineEnabled;
+  }
+  return result;
+}
+
+/**
+ * The settings whose stored value only has to be a member of a fixed set. Grouped like the
+ * boolean settings are: the numeric and font settings need real parsing and clamping, these
+ * need a membership check and nothing else.
+ */
+function pickEnumAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
+  const result: Partial<AppSettings> = {};
+  if (typeof stored.theme === "string" && VALID_THEMES.has(stored.theme)) {
+    result.theme = stored.theme;
+  }
+  if (
+    stored.sendBehavior === "interrupt" ||
+    stored.sendBehavior === "steer" ||
+    stored.sendBehavior === "queue"
+  ) {
+    result.sendBehavior = stored.sendBehavior;
+  }
+  if (
+    typeof stored.serviceUrlBehavior === "string" &&
+    VALID_SERVICE_URL_BEHAVIORS.has(stored.serviceUrlBehavior)
+  ) {
+    result.serviceUrlBehavior = stored.serviceUrlBehavior;
+  }
+  if (typeof stored.syntaxTheme === "string" && isSyntaxThemeId(stored.syntaxTheme)) {
+    result.syntaxTheme = stored.syntaxTheme;
+  }
+  if (
+    typeof stored.workspaceTitleSource === "string" &&
+    VALID_WORKSPACE_TITLE_SOURCES.has(stored.workspaceTitleSource)
+  ) {
+    result.workspaceTitleSource = stored.workspaceTitleSource;
+  }
+  if (
+    typeof stored.sidebarWorkspaceTrailing === "string" &&
+    VALID_SIDEBAR_WORKSPACE_TRAILINGS.has(stored.sidebarWorkspaceTrailing)
+  ) {
+    result.sidebarWorkspaceTrailing = stored.sidebarWorkspaceTrailing;
+  }
+  return result;
+}
+
+function pickAppSettings(stored: StoredAppSettings): Partial<AppSettings> {
+  const result: Partial<AppSettings> = {};
+  Object.assign(result, pickEnumAppSettings(stored));
+  if (stored.sidebarRowItems !== undefined) {
+    result.sidebarRowItems = parseSidebarRowItems(stored.sidebarRowItems);
+  }
+  const sidebarChecksDisplay = parseStoredSidebarChecksDisplay(stored);
+  if (sidebarChecksDisplay !== null) {
+    result.sidebarChecksDisplay = sidebarChecksDisplay;
+  }
+  const language = parseAppLanguage(stored.language);
+  if (language !== null) {
+    result.language = language;
+  }
+  const terminalScrollbackLines = parseTerminalScrollbackLines(stored.terminalScrollbackLines);
+  if (terminalScrollbackLines !== null) {
+    result.terminalScrollbackLines = terminalScrollbackLines;
+  }
+  const uiFontFamily = sanitizeFontFamily(stored.uiFontFamily);
+  if (uiFontFamily !== null) {
+    result.uiFontFamily = uiFontFamily;
+  }
+  const monoFontFamily = sanitizeFontFamily(stored.monoFontFamily);
+  if (monoFontFamily !== null) {
+    result.monoFontFamily = monoFontFamily;
+  }
+  const uiBaseFontSize = parseClampedFontSize(stored.uiBaseFontSize, {
+    min: MIN_UI_BASE_FONT_SIZE,
+    max: MAX_UI_BASE_FONT_SIZE,
+  });
+  if (uiBaseFontSize !== null) {
+    result.uiBaseFontSize = uiBaseFontSize;
+  } else {
+    const legacyUiFontSize = parseClampedFontSize(stored.uiFontSize, {
+      min: 11,
+      max: 24,
+    });
+    if (legacyUiFontSize !== null) {
+      result.uiBaseFontSize = Math.round((FONT_SIZE.base * legacyUiFontSize) / 16);
+    }
+  }
+  const codeFontSize = parseClampedFontSize(stored.codeFontSize, {
+    min: MIN_CODE_FONT_SIZE,
+    max: MAX_CODE_FONT_SIZE,
+  });
+  if (codeFontSize !== null) {
+    result.codeFontSize = codeFontSize;
+  }
+  Object.assign(result, pickBooleanAppSettings(stored));
+  if (typeof stored.autoExpandReasoning === "boolean") {
+    result.autoExpandReasoning = stored.autoExpandReasoning;
+  }
+  const toolCallDetailLevel = parseToolCallDetailLevel(stored);
+  if (toolCallDetailLevel !== null) {
+    result.toolCallDetailLevel = toolCallDetailLevel;
+  }
+  Object.assign(result, pickComposerSigils(stored));
+  return result;
+}
+
+function pickComposerSigils(
+  stored: StoredAppSettings,
+): Pick<AppSettings, "commandTriggerSigil" | "skillTriggerSigil"> {
+  const sigils = resolveComposerSigils({
+    command: stored.commandTriggerSigil,
+    skill: stored.skillTriggerSigil,
+  });
   return {
-    ...settings,
-    // The legacy key rendered content on the interface ramp. Freeze that
-    // rendered value into the new independent preference during migration.
-    contentFontSize: legacy.uiBaseFontSize,
+    commandTriggerSigil: sigils.command,
+    skillTriggerSigil: sigils.skill,
   };
+}
+
+function pickAppSettingsFromLegacy(
+  legacy: z.infer<typeof LegacyRendererSettingsSchema>,
+): Partial<AppSettings> {
+  const result: Partial<AppSettings> = {};
+  if (legacy.theme === "dark" || legacy.theme === "light" || legacy.theme === "auto") {
+    result.theme = legacy.theme;
+  }
+  return result;
 }
 
 export function parseTerminalScrollbackLines(value: unknown): number | null {
@@ -507,10 +522,10 @@ async function loadLegacyDesktopSettingsFromStorage(storage: KeyValueStorage): P
     releaseChannel?: ReleaseChannel;
   } = {};
 
-  if (stored.manageBuiltInDaemon !== undefined) {
+  if (typeof stored.manageBuiltInDaemon === "boolean") {
     result.manageBuiltInDaemon = stored.manageBuiltInDaemon;
   }
-  if (stored.releaseChannel !== undefined) {
+  if (stored.releaseChannel === "stable" || stored.releaseChannel === "beta") {
     result.releaseChannel = stored.releaseChannel;
   }
 
@@ -519,48 +534,11 @@ async function loadLegacyDesktopSettingsFromStorage(storage: KeyValueStorage): P
 
 async function loadRendererSettingsPayload(
   storage: KeyValueStorage,
-): Promise<StoredAppSettings | null> {
-  const current = await readSettingsObject(storage, APP_SETTINGS_KEY);
+): Promise<z.infer<typeof LegacyRendererSettingsSchema> | null> {
+  const current = await readValidatedJson(storage, APP_SETTINGS_KEY, LegacyRendererSettingsSchema);
   if (current) {
     return current;
   }
 
-  return readSettingsObject(storage, LEGACY_SETTINGS_KEY);
-}
-
-async function readSettingsObject(
-  storage: KeyValueStorage,
-  key: string,
-): Promise<StoredAppSettings | null> {
-  const raw = await storage.getItem(key);
-  if (raw === null) {
-    return null;
-  }
-
-  let decoded: unknown;
-  try {
-    decoded = JSON.parse(raw);
-  } catch {
-    console.warn(`[AppSettings] Removing corrupt ${key}: invalid JSON.`);
-    await storage.removeItem(key);
-    return null;
-  }
-  return StoredAppSettingsSchema.parse(decoded);
-}
-
-async function writeAppSettings(
-  storage: KeyValueStorage,
-  stored: StoredAppSettings,
-  settings: AppSettings,
-): Promise<void> {
-  const { needsWrite: _needsWrite, ...persistedStored } = stored;
-  const storedSidebarRowItems = persistedStored.sidebarRowItems;
-  await storage.setItem(
-    APP_SETTINGS_KEY,
-    JSON.stringify({
-      ...persistedStored,
-      ...settings,
-      sidebarRowItems: { ...storedSidebarRowItems, ...settings.sidebarRowItems },
-    }),
-  );
+  return readValidatedJson(storage, LEGACY_SETTINGS_KEY, LegacyRendererSettingsSchema);
 }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1995,6 +1995,14 @@ export const ar: TranslationResources = {
           queue: "طابور",
         },
       },
+      commandTrigger: {
+        label: "مُشغِّل الأوامر",
+        description: "يفتح قائمة الأوامر الكاملة في بداية الرسالة.",
+      },
+      skillTrigger: {
+        label: "مُشغِّل المهارات",
+        description: "يفتح قائمة المهارات في أي موضع من الرسالة.",
+      },
       serviceUrls: {
         label: "عناوين URL للخدمة",
         description: "مكان فتح عناوين URL من تشغيل البرامج النصية",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2094,6 +2094,14 @@ export const en = {
           queue: "Queue",
         },
       },
+      commandTrigger: {
+        label: "Command trigger",
+        description: "Opens the full command list at the start of a message.",
+      },
+      skillTrigger: {
+        label: "Skill trigger",
+        description: "Opens the skills list anywhere in a message.",
+      },
       serviceUrls: {
         label: "Service URLs",
         description: "Where to open URLs from running scripts",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2044,6 +2044,14 @@ export const es: TranslationResources = {
           queue: "Cola",
         },
       },
+      commandTrigger: {
+        label: "Activador de comandos",
+        description: "Abre la lista completa de comandos al inicio de un mensaje.",
+      },
+      skillTrigger: {
+        label: "Activador de habilidades",
+        description: "Abre la lista de habilidades en cualquier parte de un mensaje.",
+      },
       serviceUrls: {
         label: "URL de servicio",
         description: "Dónde abrir URL desde scripts en ejecución",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2048,6 +2048,14 @@ export const fr: TranslationResources = {
           queue: "File d'attente",
         },
       },
+      commandTrigger: {
+        label: "Déclencheur de commandes",
+        description: "Ouvre la liste complète des commandes en début de message.",
+      },
+      skillTrigger: {
+        label: "Déclencheur de compétences",
+        description: "Ouvre la liste des compétences n'importe où dans un message.",
+      },
       serviceUrls: {
         label: "URL de services",
         description: "Où ouvrir les URL à partir de scripts en cours d'exécution",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -2012,6 +2012,14 @@ export const ja: TranslationResources = {
           queue: "キュー",
         },
       },
+      commandTrigger: {
+        label: "コマンドのトリガー",
+        description: "メッセージの先頭でコマンド一覧を開きます。",
+      },
+      skillTrigger: {
+        label: "スキルのトリガー",
+        description: "メッセージ内のどこでもスキル一覧を開きます。",
+      },
       serviceUrls: {
         label: "サービスURL",
         description: "実行中のスクリプトからURLを開く場所",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -2006,6 +2006,14 @@ export const ko: TranslationResources = {
           queue: "대기열",
         },
       },
+      commandTrigger: {
+        label: "명령 트리거",
+        description: "메시지 시작에서 전체 명령 목록을 엽니다.",
+      },
+      skillTrigger: {
+        label: "스킬 트리거",
+        description: "메시지 어디에서나 스킬 목록을 엽니다.",
+      },
       serviceUrls: {
         label: "서비스 URL",
         description: "실행 중인 스크립트의 URL을 열 위치",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -2028,6 +2028,14 @@ export const ptBR: TranslationResources = {
           queue: "Fila",
         },
       },
+      commandTrigger: {
+        label: "Gatilho de comandos",
+        description: "Abre a lista completa de comandos no início de uma mensagem.",
+      },
+      skillTrigger: {
+        label: "Gatilho de habilidades",
+        description: "Abre a lista de habilidades em qualquer ponto de uma mensagem.",
+      },
       serviceUrls: {
         label: "URLs de serviço",
         description: "Onde abrir URLs de scripts em execução",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2028,6 +2028,14 @@ export const ru: TranslationResources = {
           queue: "Поставить в очередь",
         },
       },
+      commandTrigger: {
+        label: "Триггер команд",
+        description: "Открывает полный список команд в начале сообщения.",
+      },
+      skillTrigger: {
+        label: "Триггер навыков",
+        description: "Открывает список навыков в любом месте сообщения.",
+      },
       serviceUrls: {
         label: "URL-адреса сервисов",
         description: "Где открывать URL-адреса запущенных скриптов",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1971,6 +1971,14 @@ export const zhCN: TranslationResources = {
           queue: "排队",
         },
       },
+      commandTrigger: {
+        label: "命令触发符",
+        description: "在消息开头打开完整的命令列表。",
+      },
+      skillTrigger: {
+        label: "技能触发符",
+        description: "在消息中的任意位置打开技能列表。",
+      },
       serviceUrls: {
         label: "服务 URL",
         description: "运行脚本中的 URL 打开位置",

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -38,7 +38,6 @@ import {
   Smartphone,
   Sparkles,
   Blocks,
-  PanelsTopLeft,
 } from "lucide-react-native";
 import { DropdownTrigger } from "@/components/ui/dropdown-trigger";
 import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
@@ -50,7 +49,6 @@ import { ScreenTitle } from "@/components/headers/screen-title";
 import { HeaderIconBadge } from "@/components/headers/header-icon-badge";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { AppearanceSection } from "@/screens/settings/appearance/appearance-section";
-import { LayoutSection } from "@/screens/settings/layout/layout-section";
 import {
   useAppSettings,
   useSettings,
@@ -74,7 +72,6 @@ import { BackHeader } from "@/components/headers/back-header";
 import { ScreenHeader } from "@/components/headers/screen-header";
 import { AddHostMethodModal } from "@/components/add-host-method-modal";
 import { AddHostModal } from "@/components/add-host-modal";
-import { AddRemoteSshHostModal } from "@/components/add-remote-ssh-host-modal";
 import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
 import { EditorSection } from "@/screens/settings/editor-section";
@@ -82,6 +79,11 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { CommunityLinks } from "@/components/community-links";
 import { SegmentedControl } from "@/components/ui/segmented-control";
+import {
+  COMPOSER_SIGIL_CHOICES,
+  resolveComposerSigils,
+  type ComposerSigil,
+} from "@/composer/tokens/sigils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { DesktopPermissionsSection } from "@/desktop/components/desktop-permissions-section";
 import { DesktopNotificationsSection } from "@/desktop/components/desktop-notifications-section";
@@ -132,6 +134,11 @@ import { useLastWorkspaceSelection } from "@/stores/navigation-active-workspace-
 import { returnFromSettings, type SettingsView } from "@/navigation/settings-navigation";
 import { isNative, isWeb } from "@/constants/platform";
 
+const COMPOSER_SIGIL_OPTIONS = COMPOSER_SIGIL_CHOICES.map((choice) => ({
+  value: choice,
+  label: choice,
+}));
+
 // ---------------------------------------------------------------------------
 // View model
 // ---------------------------------------------------------------------------
@@ -147,12 +154,6 @@ interface SidebarSectionItem {
 const SIDEBAR_SECTION_ITEMS: SidebarSectionItem[] = [
   { id: "general", labelKey: "settings.sections.general", icon: Settings },
   { id: "appearance", labelKey: "settings.sections.appearance", icon: Palette },
-  {
-    id: "layout",
-    labelKey: "settings.sections.layout",
-    icon: PanelsTopLeft,
-    desktopOnly: true,
-  },
   { id: "editor", labelKey: "settings.sections.editor", icon: Code2, webOnly: true },
   { id: "shortcuts", labelKey: "settings.sections.shortcuts", icon: Keyboard, desktopOnly: true },
   {
@@ -282,6 +283,8 @@ interface GeneralSectionProps {
   handleServiceUrlBehaviorChange: (behavior: ServiceUrlBehavior) => void;
   handleLanguageChange: (language: AppLanguage) => void;
   handleTerminalScrollbackLinesChange: (lines: number) => void;
+  handleCommandTriggerSigilChange: (sigil: ComposerSigil) => void;
+  handleSkillTriggerSigilChange: (sigil: ComposerSigil) => void;
 }
 
 interface ServiceUrlBehaviorMenuItemProps {
@@ -289,24 +292,6 @@ interface ServiceUrlBehaviorMenuItemProps {
   label: string;
   selected: boolean;
   onChange: (value: ServiceUrlBehavior) => void;
-}
-
-interface SendBehaviorMenuItemProps {
-  value: SendBehavior;
-  label: string;
-  selected: boolean;
-  onChange: (value: SendBehavior) => void;
-}
-
-function SendBehaviorMenuItem({ value, label, selected, onChange }: SendBehaviorMenuItemProps) {
-  const handleSelect = useCallback(() => {
-    onChange(value);
-  }, [onChange, value]);
-  return (
-    <DropdownMenuItem selected={selected} onSelect={handleSelect}>
-      {label}
-    </DropdownMenuItem>
-  );
 }
 
 function ServiceUrlBehaviorMenuItem({
@@ -356,13 +341,18 @@ function GeneralSection({
   handleServiceUrlBehaviorChange,
   handleLanguageChange,
   handleTerminalScrollbackLinesChange,
+  handleCommandTriggerSigilChange,
+  handleSkillTriggerSigilChange,
 }: GeneralSectionProps) {
   const { t, i18n } = useTranslation();
   const activeLocale = getActiveLocale(i18n.language);
   const sendBehaviorOptions = useMemo(() => getSendBehaviorOptions(t), [t]);
-  const selectedSendBehaviorLabel =
-    sendBehaviorOptions.find((option) => option.value === settings.sendBehavior)?.label ??
-    settings.sendBehavior;
+  // Displayed rather than stored: a stale or colliding stored pair still shows the
+  // pair the composer is actually using.
+  const activeSigils = resolveComposerSigils({
+    command: settings.commandTriggerSigil,
+    skill: settings.skillTriggerSigil,
+  });
   const sendBehaviorDescriptionKey = `settings.general.defaultSend.descriptions.${settings.sendBehavior}`;
   const selectedLanguageOption = LANGUAGE_OPTIONS.find(
     (option) => option.value === settings.language,
@@ -407,26 +397,44 @@ function GeneralSection({
             <Text style={settingsStyles.rowTitle}>{t("settings.general.defaultSend.label")}</Text>
             <Text style={settingsStyles.rowHint}>{t(sendBehaviorDescriptionKey)}</Text>
           </View>
-          <DropdownMenu>
-            <DropdownTrigger
-              accessibilityRole="button"
-              accessibilityLabel={`${t("settings.general.defaultSend.label")}: ${selectedSendBehaviorLabel}`}
-              style={themeTriggerStyle}
-            >
-              <Text style={styles.themeTriggerText}>{selectedSendBehaviorLabel}</Text>
-            </DropdownTrigger>
-            <DropdownMenuContent side="bottom" align="end" width={200}>
-              {sendBehaviorOptions.map((option) => (
-                <SendBehaviorMenuItem
-                  key={option.value}
-                  value={option.value}
-                  label={option.label}
-                  selected={settings.sendBehavior === option.value}
-                  onChange={handleSendBehaviorChange}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <SegmentedControl
+            size="sm"
+            value={settings.sendBehavior}
+            onValueChange={handleSendBehaviorChange}
+            options={sendBehaviorOptions}
+          />
+        </View>
+        <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>
+              {t("settings.general.commandTrigger.label")}
+            </Text>
+            <Text style={settingsStyles.rowHint}>
+              {t("settings.general.commandTrigger.description")}
+            </Text>
+          </View>
+          <SegmentedControl
+            size="sm"
+            testID="settings-command-trigger"
+            value={activeSigils.command}
+            onValueChange={handleCommandTriggerSigilChange}
+            options={COMPOSER_SIGIL_OPTIONS}
+          />
+        </View>
+        <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>{t("settings.general.skillTrigger.label")}</Text>
+            <Text style={settingsStyles.rowHint}>
+              {t("settings.general.skillTrigger.description")}
+            </Text>
+          </View>
+          <SegmentedControl
+            size="sm"
+            testID="settings-skill-trigger"
+            value={activeSigils.skill}
+            onValueChange={handleSkillTriggerSigilChange}
+            options={COMPOSER_SIGIL_OPTIONS}
+          />
         </View>
         <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
           <View style={settingsStyles.rowContent}>
@@ -1188,7 +1196,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const { settings, isLoading: settingsLoading, updateSettings } = useAppSettings();
   const [isAddHostMethodVisible, setIsAddHostMethodVisible] = useState(false);
   const [isDirectHostVisible, setIsDirectHostVisible] = useState(false);
-  const [isRemoteSshVisible, setIsRemoteSshVisible] = useState(false);
   const [isPasteLinkVisible, setIsPasteLinkVisible] = useState(false);
   const [isPlaybackTestRunning, setIsPlaybackTestRunning] = useState(false);
   const [playbackTestResult, setPlaybackTestResult] = useState<string | null>(null);
@@ -1240,6 +1247,39 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
       void updateSettings({ serviceUrlBehavior: behavior });
     },
     [updateSettings],
+  );
+
+  // Picking the character the other menu already uses swaps the two rather than
+  // rejecting the choice — the user asked for that character, and a swap is the
+  // only outcome that both honours the pick and keeps the pair distinct.
+  const handleCommandTriggerSigilChange = useCallback(
+    (sigil: ComposerSigil) => {
+      const current = resolveComposerSigils({
+        command: settings.commandTriggerSigil,
+        skill: settings.skillTriggerSigil,
+      });
+      void updateSettings(
+        sigil === current.skill
+          ? { commandTriggerSigil: sigil, skillTriggerSigil: current.command }
+          : { commandTriggerSigil: sigil },
+      );
+    },
+    [settings.commandTriggerSigil, settings.skillTriggerSigil, updateSettings],
+  );
+
+  const handleSkillTriggerSigilChange = useCallback(
+    (sigil: ComposerSigil) => {
+      const current = resolveComposerSigils({
+        command: settings.commandTriggerSigil,
+        skill: settings.skillTriggerSigil,
+      });
+      void updateSettings(
+        sigil === current.command
+          ? { skillTriggerSigil: sigil, commandTriggerSigil: current.skill }
+          : { skillTriggerSigil: sigil },
+      );
+    },
+    [settings.commandTriggerSigil, settings.skillTriggerSigil, updateSettings],
   );
 
   const handleLanguageChange = useCallback(
@@ -1295,13 +1335,11 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const closeAddConnectionFlow = useCallback(() => {
     setIsAddHostMethodVisible(false);
     setIsDirectHostVisible(false);
-    setIsRemoteSshVisible(false);
     setIsPasteLinkVisible(false);
   }, []);
 
   const goBackToAddConnectionMethods = useCallback(() => {
     setIsDirectHostVisible(false);
-    setIsRemoteSshVisible(false);
     setIsPasteLinkVisible(false);
     setIsAddHostMethodVisible(true);
   }, []);
@@ -1321,11 +1359,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const handleSelectDirectConnection = useCallback(() => {
     setIsAddHostMethodVisible(false);
     setIsDirectHostVisible(true);
-  }, []);
-
-  const handleSelectRemoteSsh = useCallback(() => {
-    setIsAddHostMethodVisible(false);
-    setIsRemoteSshVisible(true);
   }, []);
 
   const handleSelectPasteLink = useCallback(() => {
@@ -1446,76 +1479,73 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     return null;
   })();
 
-  let content: ReactNode;
-  if (view.kind === "section" && view.section === "layout") {
-    content = isDesktopApp ? <LayoutSection /> : null;
-  } else {
-    content = (() => {
-      if (view.kind === "host") {
-        return renderHostSettingsContent(view, handleHostRemoved);
-      }
-      if (view.kind === "project") {
-        return (
-          <ProjectSettingsScreen
-            serverId={view.serverId}
-            projectId={view.projectId}
-            onBackToProjects={handleBackFromDetail}
-            showBackToProjects={!isCompactLayout}
-          />
-        );
-      }
-      if (view.kind === "section") {
-        switch (view.section) {
-          case "general":
-            return (
-              <>
-                <GeneralSection
-                  settings={settings}
-                  isDesktopApp={isDesktopApp}
-                  handleSendBehaviorChange={handleSendBehaviorChange}
-                  handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
-                  handleLanguageChange={handleLanguageChange}
-                  handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
-                />
-                {isDesktopApp ? <BrowserDataSection /> : null}
-              </>
-            );
-          case "appearance":
-            return <AppearanceSection />;
-          case "editor":
-            return isWeb ? <EditorSection /> : null;
-          case "shortcuts":
-            return isDesktopApp ? <KeyboardShortcutsSection /> : null;
-          case "integrations":
-            return isDesktopApp ? <IntegrationsSection /> : null;
-          case "notifications":
-            return isDesktopApp ? <DesktopNotificationsSection /> : null;
-          case "permissions":
-            return isDesktopApp ? <DesktopPermissionsSection /> : null;
-          case "diagnostics":
-            return (
-              <DiagnosticsSection
-                useLegacyTerminalRenderer={settings.useLegacyTerminalRenderer}
-                onUseLegacyTerminalRendererChange={handleUseLegacyTerminalRendererChange}
-                voiceAudioEngine={voiceAudioEngine}
-                isPlaybackTestRunning={isPlaybackTestRunning}
-                playbackTestResult={playbackTestResult}
-                handlePlaybackTest={handlePlaybackTest}
-              />
-            );
-          case "about":
-            return (
-              <AboutSection
-                appVersion={appVersion}
-                appVersionText={appVersionText}
+  const content = (() => {
+    if (view.kind === "host") {
+      return renderHostSettingsContent(view, handleHostRemoved);
+    }
+    if (view.kind === "project") {
+      return (
+        <ProjectSettingsScreen
+          serverId={view.serverId}
+          projectId={view.projectId}
+          onBackToProjects={handleBackFromDetail}
+          showBackToProjects={!isCompactLayout}
+        />
+      );
+    }
+    if (view.kind === "section") {
+      switch (view.section) {
+        case "general":
+          return (
+            <>
+              <GeneralSection
+                settings={settings}
                 isDesktopApp={isDesktopApp}
+                handleSendBehaviorChange={handleSendBehaviorChange}
+                handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
+                handleLanguageChange={handleLanguageChange}
+                handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
+                handleCommandTriggerSigilChange={handleCommandTriggerSigilChange}
+                handleSkillTriggerSigilChange={handleSkillTriggerSigilChange}
               />
-            );
-        }
+              {isDesktopApp ? <BrowserDataSection /> : null}
+            </>
+          );
+        case "appearance":
+          return <AppearanceSection />;
+        case "editor":
+          return isWeb ? <EditorSection /> : null;
+        case "shortcuts":
+          return isDesktopApp ? <KeyboardShortcutsSection /> : null;
+        case "integrations":
+          return isDesktopApp ? <IntegrationsSection /> : null;
+        case "notifications":
+          return isDesktopApp ? <DesktopNotificationsSection /> : null;
+        case "permissions":
+          return isDesktopApp ? <DesktopPermissionsSection /> : null;
+        case "diagnostics":
+          return (
+            <DiagnosticsSection
+              useLegacyTerminalRenderer={settings.useLegacyTerminalRenderer}
+              onUseLegacyTerminalRendererChange={handleUseLegacyTerminalRendererChange}
+              voiceAudioEngine={voiceAudioEngine}
+              isPlaybackTestRunning={isPlaybackTestRunning}
+              playbackTestResult={playbackTestResult}
+              handlePlaybackTest={handlePlaybackTest}
+            />
+          );
+        case "about":
+          return (
+            <AboutSection
+              appVersion={appVersion}
+              appVersionText={appVersionText}
+              isDesktopApp={isDesktopApp}
+            />
+          );
       }
-      return null;
-    })();
-  }
+    }
+    return null;
+  })();
 
   if (settingsLoading) {
     return (
@@ -1541,18 +1571,11 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
         visible={isAddHostMethodVisible}
         onClose={closeAddConnectionFlow}
         onDirectConnection={handleSelectDirectConnection}
-        onRemoteSsh={handleSelectRemoteSsh}
         onPasteLink={handleSelectPasteLink}
         onScanQr={handleScanQr}
       />
       <AddHostModal
         visible={isDirectHostVisible}
-        onClose={closeAddConnectionFlow}
-        onCancel={goBackToAddConnectionMethods}
-        onSaved={handleHostAdded}
-      />
-      <AddRemoteSshHostModal
-        visible={isRemoteSshVisible}
         onClose={closeAddConnectionFlow}
         onCancel={goBackToAddConnectionMethods}
         onSaved={handleHostAdded}

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -38,6 +38,7 @@ import {
   Smartphone,
   Sparkles,
   Blocks,
+  PanelsTopLeft,
 } from "lucide-react-native";
 import { DropdownTrigger } from "@/components/ui/dropdown-trigger";
 import { ComboboxTrigger } from "@/components/ui/combobox-trigger";
@@ -49,6 +50,7 @@ import { ScreenTitle } from "@/components/headers/screen-title";
 import { HeaderIconBadge } from "@/components/headers/header-icon-badge";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { AppearanceSection } from "@/screens/settings/appearance/appearance-section";
+import { LayoutSection } from "@/screens/settings/layout/layout-section";
 import {
   useAppSettings,
   useSettings,
@@ -72,6 +74,7 @@ import { BackHeader } from "@/components/headers/back-header";
 import { ScreenHeader } from "@/components/headers/screen-header";
 import { AddHostMethodModal } from "@/components/add-host-method-modal";
 import { AddHostModal } from "@/components/add-host-modal";
+import { AddRemoteSshHostModal } from "@/components/add-remote-ssh-host-modal";
 import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
 import { EditorSection } from "@/screens/settings/editor-section";
@@ -154,6 +157,12 @@ interface SidebarSectionItem {
 const SIDEBAR_SECTION_ITEMS: SidebarSectionItem[] = [
   { id: "general", labelKey: "settings.sections.general", icon: Settings },
   { id: "appearance", labelKey: "settings.sections.appearance", icon: Palette },
+  {
+    id: "layout",
+    labelKey: "settings.sections.layout",
+    icon: PanelsTopLeft,
+    desktopOnly: true,
+  },
   { id: "editor", labelKey: "settings.sections.editor", icon: Code2, webOnly: true },
   { id: "shortcuts", labelKey: "settings.sections.shortcuts", icon: Keyboard, desktopOnly: true },
   {
@@ -294,6 +303,24 @@ interface ServiceUrlBehaviorMenuItemProps {
   onChange: (value: ServiceUrlBehavior) => void;
 }
 
+interface SendBehaviorMenuItemProps {
+  value: SendBehavior;
+  label: string;
+  selected: boolean;
+  onChange: (value: SendBehavior) => void;
+}
+
+function SendBehaviorMenuItem({ value, label, selected, onChange }: SendBehaviorMenuItemProps) {
+  const handleSelect = useCallback(() => {
+    onChange(value);
+  }, [onChange, value]);
+  return (
+    <DropdownMenuItem selected={selected} onSelect={handleSelect}>
+      {label}
+    </DropdownMenuItem>
+  );
+}
+
 function ServiceUrlBehaviorMenuItem({
   value,
   label,
@@ -347,8 +374,9 @@ function GeneralSection({
   const { t, i18n } = useTranslation();
   const activeLocale = getActiveLocale(i18n.language);
   const sendBehaviorOptions = useMemo(() => getSendBehaviorOptions(t), [t]);
-  // Displayed rather than stored: a stale or colliding stored pair still shows the
-  // pair the composer is actually using.
+  const selectedSendBehaviorLabel =
+    sendBehaviorOptions.find((option) => option.value === settings.sendBehavior)?.label ??
+    settings.sendBehavior;
   const activeSigils = resolveComposerSigils({
     command: settings.commandTriggerSigil,
     skill: settings.skillTriggerSigil,
@@ -397,12 +425,26 @@ function GeneralSection({
             <Text style={settingsStyles.rowTitle}>{t("settings.general.defaultSend.label")}</Text>
             <Text style={settingsStyles.rowHint}>{t(sendBehaviorDescriptionKey)}</Text>
           </View>
-          <SegmentedControl
-            size="sm"
-            value={settings.sendBehavior}
-            onValueChange={handleSendBehaviorChange}
-            options={sendBehaviorOptions}
-          />
+          <DropdownMenu>
+            <DropdownTrigger
+              accessibilityRole="button"
+              accessibilityLabel={`${t("settings.general.defaultSend.label")}: ${selectedSendBehaviorLabel}`}
+              style={themeTriggerStyle}
+            >
+              <Text style={styles.themeTriggerText}>{selectedSendBehaviorLabel}</Text>
+            </DropdownTrigger>
+            <DropdownMenuContent side="bottom" align="end" width={200}>
+              {sendBehaviorOptions.map((option) => (
+                <SendBehaviorMenuItem
+                  key={option.value}
+                  value={option.value}
+                  label={option.label}
+                  selected={settings.sendBehavior === option.value}
+                  onChange={handleSendBehaviorChange}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </View>
         <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
           <View style={settingsStyles.rowContent}>
@@ -1196,6 +1238,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const { settings, isLoading: settingsLoading, updateSettings } = useAppSettings();
   const [isAddHostMethodVisible, setIsAddHostMethodVisible] = useState(false);
   const [isDirectHostVisible, setIsDirectHostVisible] = useState(false);
+  const [isRemoteSshVisible, setIsRemoteSshVisible] = useState(false);
   const [isPasteLinkVisible, setIsPasteLinkVisible] = useState(false);
   const [isPlaybackTestRunning, setIsPlaybackTestRunning] = useState(false);
   const [playbackTestResult, setPlaybackTestResult] = useState<string | null>(null);
@@ -1249,9 +1292,6 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     [updateSettings],
   );
 
-  // Picking the character the other menu already uses swaps the two rather than
-  // rejecting the choice — the user asked for that character, and a swap is the
-  // only outcome that both honours the pick and keeps the pair distinct.
   const handleCommandTriggerSigilChange = useCallback(
     (sigil: ComposerSigil) => {
       const current = resolveComposerSigils({
@@ -1335,11 +1375,13 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const closeAddConnectionFlow = useCallback(() => {
     setIsAddHostMethodVisible(false);
     setIsDirectHostVisible(false);
+    setIsRemoteSshVisible(false);
     setIsPasteLinkVisible(false);
   }, []);
 
   const goBackToAddConnectionMethods = useCallback(() => {
     setIsDirectHostVisible(false);
+    setIsRemoteSshVisible(false);
     setIsPasteLinkVisible(false);
     setIsAddHostMethodVisible(true);
   }, []);
@@ -1359,6 +1401,11 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const handleSelectDirectConnection = useCallback(() => {
     setIsAddHostMethodVisible(false);
     setIsDirectHostVisible(true);
+  }, []);
+
+  const handleSelectRemoteSsh = useCallback(() => {
+    setIsAddHostMethodVisible(false);
+    setIsRemoteSshVisible(true);
   }, []);
 
   const handleSelectPasteLink = useCallback(() => {
@@ -1479,73 +1526,78 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
     return null;
   })();
 
-  const content = (() => {
-    if (view.kind === "host") {
-      return renderHostSettingsContent(view, handleHostRemoved);
-    }
-    if (view.kind === "project") {
-      return (
-        <ProjectSettingsScreen
-          serverId={view.serverId}
-          projectId={view.projectId}
-          onBackToProjects={handleBackFromDetail}
-          showBackToProjects={!isCompactLayout}
-        />
-      );
-    }
-    if (view.kind === "section") {
-      switch (view.section) {
-        case "general":
-          return (
-            <>
-              <GeneralSection
-                settings={settings}
-                isDesktopApp={isDesktopApp}
-                handleSendBehaviorChange={handleSendBehaviorChange}
-                handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
-                handleLanguageChange={handleLanguageChange}
-                handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
-                handleCommandTriggerSigilChange={handleCommandTriggerSigilChange}
-                handleSkillTriggerSigilChange={handleSkillTriggerSigilChange}
-              />
-              {isDesktopApp ? <BrowserDataSection /> : null}
-            </>
-          );
-        case "appearance":
-          return <AppearanceSection />;
-        case "editor":
-          return isWeb ? <EditorSection /> : null;
-        case "shortcuts":
-          return isDesktopApp ? <KeyboardShortcutsSection /> : null;
-        case "integrations":
-          return isDesktopApp ? <IntegrationsSection /> : null;
-        case "notifications":
-          return isDesktopApp ? <DesktopNotificationsSection /> : null;
-        case "permissions":
-          return isDesktopApp ? <DesktopPermissionsSection /> : null;
-        case "diagnostics":
-          return (
-            <DiagnosticsSection
-              useLegacyTerminalRenderer={settings.useLegacyTerminalRenderer}
-              onUseLegacyTerminalRendererChange={handleUseLegacyTerminalRendererChange}
-              voiceAudioEngine={voiceAudioEngine}
-              isPlaybackTestRunning={isPlaybackTestRunning}
-              playbackTestResult={playbackTestResult}
-              handlePlaybackTest={handlePlaybackTest}
-            />
-          );
-        case "about":
-          return (
-            <AboutSection
-              appVersion={appVersion}
-              appVersionText={appVersionText}
-              isDesktopApp={isDesktopApp}
-            />
-          );
+  let content: ReactNode;
+  if (view.kind === "section" && view.section === "layout") {
+    content = isDesktopApp ? <LayoutSection /> : null;
+  } else {
+    content = (() => {
+      if (view.kind === "host") {
+        return renderHostSettingsContent(view, handleHostRemoved);
       }
-    }
-    return null;
-  })();
+      if (view.kind === "project") {
+        return (
+          <ProjectSettingsScreen
+            serverId={view.serverId}
+            projectId={view.projectId}
+            onBackToProjects={handleBackFromDetail}
+            showBackToProjects={!isCompactLayout}
+          />
+        );
+      }
+      if (view.kind === "section") {
+        switch (view.section) {
+          case "general":
+            return (
+              <>
+                <GeneralSection
+                  settings={settings}
+                  isDesktopApp={isDesktopApp}
+                  handleSendBehaviorChange={handleSendBehaviorChange}
+                  handleServiceUrlBehaviorChange={handleServiceUrlBehaviorChange}
+                  handleLanguageChange={handleLanguageChange}
+                  handleTerminalScrollbackLinesChange={handleTerminalScrollbackLinesChange}
+                  handleCommandTriggerSigilChange={handleCommandTriggerSigilChange}
+                  handleSkillTriggerSigilChange={handleSkillTriggerSigilChange}
+                />
+                {isDesktopApp ? <BrowserDataSection /> : null}
+              </>
+            );
+          case "appearance":
+            return <AppearanceSection />;
+          case "editor":
+            return isWeb ? <EditorSection /> : null;
+          case "shortcuts":
+            return isDesktopApp ? <KeyboardShortcutsSection /> : null;
+          case "integrations":
+            return isDesktopApp ? <IntegrationsSection /> : null;
+          case "notifications":
+            return isDesktopApp ? <DesktopNotificationsSection /> : null;
+          case "permissions":
+            return isDesktopApp ? <DesktopPermissionsSection /> : null;
+          case "diagnostics":
+            return (
+              <DiagnosticsSection
+                useLegacyTerminalRenderer={settings.useLegacyTerminalRenderer}
+                onUseLegacyTerminalRendererChange={handleUseLegacyTerminalRendererChange}
+                voiceAudioEngine={voiceAudioEngine}
+                isPlaybackTestRunning={isPlaybackTestRunning}
+                playbackTestResult={playbackTestResult}
+                handlePlaybackTest={handlePlaybackTest}
+              />
+            );
+          case "about":
+            return (
+              <AboutSection
+                appVersion={appVersion}
+                appVersionText={appVersionText}
+                isDesktopApp={isDesktopApp}
+              />
+            );
+        }
+      }
+      return null;
+    })();
+  }
 
   if (settingsLoading) {
     return (
@@ -1571,11 +1623,18 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
         visible={isAddHostMethodVisible}
         onClose={closeAddConnectionFlow}
         onDirectConnection={handleSelectDirectConnection}
+        onRemoteSsh={handleSelectRemoteSsh}
         onPasteLink={handleSelectPasteLink}
         onScanQr={handleScanQr}
       />
       <AddHostModal
         visible={isDirectHostVisible}
+        onClose={closeAddConnectionFlow}
+        onCancel={goBackToAddConnectionMethods}
+        onSaved={handleHostAdded}
+      />
+      <AddRemoteSshHostModal
+        visible={isRemoteSshVisible}
         onClose={closeAddConnectionFlow}
         onCancel={goBackToAddConnectionMethods}
         onSaved={handleHostAdded}

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -6,6 +6,7 @@ import {
   filterAndRankCommandAutocompleteEntries,
   filterInlineSkillCommandEntries,
   findActiveSlashCommand,
+  shouldSubmitUncommittedTrigger,
 } from "./agent-command-autocomplete";
 
 describe("filterAndRankCommandAutocompleteEntries", () => {
@@ -219,6 +220,31 @@ describe("applySlashCommandReplacement", () => {
         commandName: "release-beta",
       }),
     ).toBe("run /release-beta ");
+  });
+});
+
+describe("shouldSubmitUncommittedTrigger", () => {
+  const configuredSkill = {
+    start: 6,
+    end: 11,
+    query: "HOME",
+    position: "inline",
+    menu: "skill",
+    sigil: "$",
+  } as const;
+
+  it("reserves Enter for submission when a configured trigger is still plain text", () => {
+    expect(shouldSubmitUncommittedTrigger({ key: "Enter", command: configuredSkill })).toBe(true);
+  });
+
+  it("allows Tab to commit configured triggers and Enter to select canonical slash", () => {
+    expect(shouldSubmitUncommittedTrigger({ key: "Tab", command: configuredSkill })).toBe(false);
+    expect(
+      shouldSubmitUncommittedTrigger({
+        key: "Enter",
+        command: { ...configuredSkill, sigil: "/" },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -241,6 +241,12 @@ describe("shouldSubmitShellVariable", () => {
         command: { ...shellVariable, query: "XDG_CONFIG_HOME" },
       }),
     ).toBe(true);
+    expect(
+      shouldSubmitShellVariable({
+        key: "Enter",
+        command: { ...shellVariable, query: "path" },
+      }),
+    ).toBe(true);
   });
 
   it("protects shell variables when the dollar sigil is the command trigger", () => {

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -202,7 +202,7 @@ describe("applySlashCommandReplacement", () => {
     ).toBe("/taste ");
   });
 
-  it("writes back the sigil that opened the trigger", () => {
+  it("commits a configured trigger as canonical slash syntax", () => {
     const text = "run $rel";
 
     expect(
@@ -218,7 +218,7 @@ describe("applySlashCommandReplacement", () => {
         },
         commandName: "release-beta",
       }),
-    ).toBe("run $release-beta ");
+    ).toBe("run /release-beta ");
   });
 });
 

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -243,6 +243,21 @@ describe("shouldSubmitShellVariable", () => {
     ).toBe(true);
   });
 
+  it("protects shell variables when the dollar sigil is the command trigger", () => {
+    expect(
+      shouldSubmitShellVariable({
+        key: "Enter",
+        command: { ...shellVariable, menu: "command" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSubmitShellVariable({
+        key: "Tab",
+        command: { ...shellVariable, menu: "command" },
+      }),
+    ).toBe(false);
+  });
+
   it("allows explicit selection and ordinary configured triggers", () => {
     expect(shouldSubmitShellVariable({ key: "Tab", command: shellVariable })).toBe(false);
     expect(

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -6,7 +6,6 @@ import {
   filterAndRankCommandAutocompleteEntries,
   filterInlineSkillCommandEntries,
   findActiveSlashCommand,
-  shouldSubmitUncommittedTrigger,
 } from "./agent-command-autocomplete";
 
 describe("filterAndRankCommandAutocompleteEntries", () => {
@@ -220,31 +219,6 @@ describe("applySlashCommandReplacement", () => {
         commandName: "release-beta",
       }),
     ).toBe("run /release-beta ");
-  });
-});
-
-describe("shouldSubmitUncommittedTrigger", () => {
-  const configuredSkill = {
-    start: 6,
-    end: 11,
-    query: "HOME",
-    position: "inline",
-    menu: "skill",
-    sigil: "$",
-  } as const;
-
-  it("reserves Enter for submission when a configured trigger is still plain text", () => {
-    expect(shouldSubmitUncommittedTrigger({ key: "Enter", command: configuredSkill })).toBe(true);
-  });
-
-  it("allows Tab to commit configured triggers and Enter to select canonical slash", () => {
-    expect(shouldSubmitUncommittedTrigger({ key: "Tab", command: configuredSkill })).toBe(false);
-    expect(
-      shouldSubmitUncommittedTrigger({
-        key: "Enter",
-        command: { ...configuredSkill, sigil: "/" },
-      }),
-    ).toBe(false);
   });
 });
 

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { DEFAULT_COMPOSER_SIGILS } from "@/composer/tokens/sigils";
 import {
   applySlashCommandReplacement,
   filterAndRankCommandAutocompleteEntries,
@@ -34,6 +35,8 @@ describe("filterAndRankCommandAutocompleteEntries", () => {
 });
 
 describe("findActiveSlashCommand", () => {
+  const sigils = DEFAULT_COMPOSER_SIGILS;
+
   it("detects a slash command token in the middle of the prompt", () => {
     const text = "use /tas before implementation";
 
@@ -41,12 +44,15 @@ describe("findActiveSlashCommand", () => {
       findActiveSlashCommand({
         text,
         cursorIndex: "use /tas".length,
+        sigils,
       }),
     ).toEqual({
       start: 4,
       end: "use /tas".length,
       query: "tas",
       position: "inline",
+      menu: "command",
+      sigil: "/",
     });
   });
 
@@ -55,12 +61,15 @@ describe("findActiveSlashCommand", () => {
       findActiveSlashCommand({
         text: "/rew",
         cursorIndex: "/rew".length,
+        sigils,
       }),
     ).toEqual({
       start: 0,
       end: "/rew".length,
       query: "rew",
       position: "start",
+      menu: "command",
+      sigil: "/",
     });
   });
 
@@ -69,6 +78,7 @@ describe("findActiveSlashCommand", () => {
       findActiveSlashCommand({
         text: "use /taste now",
         cursorIndex: "use /taste now".length,
+        sigils,
       }),
     ).toBeNull();
   });
@@ -78,6 +88,57 @@ describe("findActiveSlashCommand", () => {
       findActiveSlashCommand({
         text: "read /tmp/project",
         cursorIndex: "read /tmp/project".length,
+        sigils,
+      }),
+    ).toBeNull();
+  });
+
+  it("opens the skills-only menu for the skill sigil anywhere in the prompt", () => {
+    const text = "please run $rel";
+
+    expect(
+      findActiveSlashCommand({
+        text,
+        cursorIndex: text.length,
+        sigils,
+      }),
+    ).toEqual({
+      start: "please run ".length,
+      end: text.length,
+      query: "rel",
+      position: "inline",
+      menu: "skill",
+      sigil: "$",
+    });
+  });
+
+  it("lets the sigil nearest the cursor win", () => {
+    const text = "/review then $rel";
+
+    expect(findActiveSlashCommand({ text, cursorIndex: text.length, sigils })?.menu).toBe("skill");
+  });
+
+  it("honours remapped sigils", () => {
+    const remapped = { command: "!", skill: "#" } as const;
+    const text = "!dep";
+
+    expect(findActiveSlashCommand({ text, cursorIndex: text.length, sigils: remapped })).toEqual({
+      start: 0,
+      end: text.length,
+      query: "dep",
+      position: "start",
+      menu: "command",
+      sigil: "!",
+    });
+    // `/` is ordinary prose once it is not a configured sigil.
+    expect(findActiveSlashCommand({ text: "/dep", cursorIndex: 4, sigils: remapped })).toBeNull();
+    // It still delimits paths, so remapping `/` must not make path-like queries valid.
+    const pathLike = "#tmp/project";
+    expect(
+      findActiveSlashCommand({
+        text: pathLike,
+        cursorIndex: pathLike.length,
+        sigils: remapped,
       }),
     ).toBeNull();
   });
@@ -90,7 +151,14 @@ describe("applySlashCommandReplacement", () => {
     expect(
       applySlashCommandReplacement({
         text,
-        command: { start: 4, end: "use /tas".length, query: "tas", position: "inline" },
+        command: {
+          start: 4,
+          end: "use /tas".length,
+          query: "tas",
+          position: "inline",
+          menu: "command",
+          sigil: "/",
+        },
         commandName: "taste",
       }),
     ).toBe("use /taste before implementation");
@@ -102,7 +170,14 @@ describe("applySlashCommandReplacement", () => {
     expect(
       applySlashCommandReplacement({
         text,
-        command: { start: 4, end: text.length, query: "tas", position: "inline" },
+        command: {
+          start: 4,
+          end: text.length,
+          query: "tas",
+          position: "inline",
+          menu: "command",
+          sigil: "/",
+        },
         commandName: "taste",
       }),
     ).toBe("use /taste ");
@@ -114,10 +189,36 @@ describe("applySlashCommandReplacement", () => {
     expect(
       applySlashCommandReplacement({
         text,
-        command: { start: 0, end: text.length, query: "tas", position: "start" },
+        command: {
+          start: 0,
+          end: text.length,
+          query: "tas",
+          position: "start",
+          menu: "command",
+          sigil: "/",
+        },
         commandName: "taste",
       }),
     ).toBe("/taste ");
+  });
+
+  it("writes back the sigil that opened the trigger", () => {
+    const text = "run $rel";
+
+    expect(
+      applySlashCommandReplacement({
+        text,
+        command: {
+          start: 4,
+          end: text.length,
+          query: "rel",
+          position: "inline",
+          menu: "skill",
+          sigil: "$",
+        },
+        commandName: "release-beta",
+      }),
+    ).toBe("run $release-beta ");
   });
 });
 

--- a/packages/app/src/utils/agent-command-autocomplete.test.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.test.ts
@@ -6,6 +6,7 @@ import {
   filterAndRankCommandAutocompleteEntries,
   filterInlineSkillCommandEntries,
   findActiveSlashCommand,
+  shouldSubmitShellVariable,
 } from "./agent-command-autocomplete";
 
 describe("filterAndRankCommandAutocompleteEntries", () => {
@@ -219,6 +220,43 @@ describe("applySlashCommandReplacement", () => {
         commandName: "release-beta",
       }),
     ).toBe("run /release-beta ");
+  });
+});
+
+describe("shouldSubmitShellVariable", () => {
+  const shellVariable = {
+    start: 6,
+    end: 11,
+    query: "HOME",
+    position: "inline",
+    menu: "skill",
+    sigil: "$",
+  } as const;
+
+  it("reserves Enter for shell-variable-shaped dollar triggers", () => {
+    expect(shouldSubmitShellVariable({ key: "Enter", command: shellVariable })).toBe(true);
+    expect(
+      shouldSubmitShellVariable({
+        key: "Enter",
+        command: { ...shellVariable, query: "XDG_CONFIG_HOME" },
+      }),
+    ).toBe(true);
+  });
+
+  it("allows explicit selection and ordinary configured triggers", () => {
+    expect(shouldSubmitShellVariable({ key: "Tab", command: shellVariable })).toBe(false);
+    expect(
+      shouldSubmitShellVariable({
+        key: "Enter",
+        command: { ...shellVariable, query: "release-beta" },
+      }),
+    ).toBe(false);
+    expect(
+      shouldSubmitShellVariable({
+        key: "Enter",
+        command: { ...shellVariable, sigil: "!" },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -1,3 +1,4 @@
+import type { ComposerSigil, ComposerSigils } from "@/composer/tokens/sigils";
 import {
   compareMatchScores,
   type MatchScore,
@@ -18,16 +19,26 @@ interface InlineSkillCommandEntry extends CommandAutocompleteEntry {
 
 export type SlashCommandPosition = "start" | "inline";
 
+/**
+ * Which menu the trigger opens. `command` is the full slash-command list;
+ * `skill` is the skills-only list opened by the dedicated skill sigil.
+ */
+export type SlashCommandMenu = "command" | "skill";
+
 export interface SlashCommandRange {
   start: number;
   end: number;
   query: string;
   position: SlashCommandPosition;
+  menu: SlashCommandMenu;
+  /** The sigil that opened this trigger, so replacement can write it back. */
+  sigil: ComposerSigil;
 }
 
 interface FindActiveSlashCommandInput {
   text: string;
   cursorIndex: number;
+  sigils: ComposerSigils;
 }
 
 interface ApplySlashCommandReplacementInput {
@@ -82,34 +93,54 @@ export function filterInlineSkillCommandEntries<TEntry extends InlineSkillComman
   return entries.filter((entry) => entry.source === "provider" && entry.command.kind === "skill");
 }
 
-const INVALID_SLASH_COMMAND_QUERY_CHARS = /[/\s\n\r\t"']/;
+const INVALID_QUERY_CHARS = /[/\s\n\r\t"']/;
 
+function isInvalidQuery(query: string, sigils: ComposerSigils): boolean {
+  // A second sigil inside the query means the earlier one was not the live
+  // trigger — the nearer sigil owns the cursor.
+  return (
+    INVALID_QUERY_CHARS.test(query) ||
+    query.includes(sigils.command) ||
+    query.includes(sigils.skill)
+  );
+}
+
+/**
+ * Find the trigger the cursor currently sits inside, scanning backwards so the
+ * sigil nearest the cursor wins.
+ */
 export function findActiveSlashCommand(
   input: FindActiveSlashCommandInput,
 ): SlashCommandRange | null {
   const clampedCursor = Math.max(0, Math.min(input.cursorIndex, input.text.length));
   const beforeCursor = input.text.slice(0, clampedCursor);
+  const { sigils } = input;
 
-  for (
-    let slashIndex = beforeCursor.lastIndexOf("/");
-    slashIndex >= 0;
-    slashIndex = slashIndex === 0 ? -1 : beforeCursor.lastIndexOf("/", slashIndex - 1)
-  ) {
-    const previousCharacter = slashIndex > 0 ? input.text[slashIndex - 1] : "";
+  for (let index = clampedCursor - 1; index >= 0; index -= 1) {
+    const character = beforeCursor[index];
+    const isCommandSigil = character === sigils.command;
+    const isSkillSigil = character === sigils.skill;
+    if (!isCommandSigil && !isSkillSigil) {
+      continue;
+    }
+
+    const previousCharacter = index > 0 ? input.text[index - 1] : "";
     if (previousCharacter && !/\s/.test(previousCharacter)) {
       continue;
     }
 
-    const query = beforeCursor.slice(slashIndex + 1);
-    if (INVALID_SLASH_COMMAND_QUERY_CHARS.test(query)) {
+    const query = beforeCursor.slice(index + 1);
+    if (isInvalidQuery(query, sigils)) {
       continue;
     }
 
     return {
-      start: slashIndex,
+      start: index,
       end: clampedCursor,
       query,
-      position: slashIndex === 0 ? "start" : "inline",
+      position: index === 0 ? "start" : "inline",
+      menu: isSkillSigil ? "skill" : "command",
+      sigil: character,
     };
   }
 
@@ -119,6 +150,6 @@ export function findActiveSlashCommand(
 export function applySlashCommandReplacement(input: ApplySlashCommandReplacementInput): string {
   const before = input.text.slice(0, input.command.start);
   const after = input.text.slice(input.command.end);
-  const replacement = `${before}/${input.commandName}${after}`;
+  const replacement = `${before}${input.command.sigil}${input.commandName}${after}`;
   return input.command.end === input.text.length ? `${replacement} ` : replacement;
 }

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -157,3 +157,13 @@ export function applySlashCommandReplacement(input: ApplySlashCommandReplacement
   const replacement = `${before}${DEFAULT_COMMAND_SIGIL}${input.commandName}${after}`;
   return input.command.end === input.text.length ? `${replacement} ` : replacement;
 }
+
+export function shouldSubmitUncommittedTrigger(input: {
+  key: string;
+  command: SlashCommandRange | null;
+}): boolean {
+  const isSubmitKey = input.key === "Enter";
+  const isNonCanonicalTrigger =
+    input.command !== null && input.command.sigil !== DEFAULT_COMMAND_SIGIL;
+  return isSubmitKey && isNonCanonicalTrigger;
+}

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -157,13 +157,3 @@ export function applySlashCommandReplacement(input: ApplySlashCommandReplacement
   const replacement = `${before}${DEFAULT_COMMAND_SIGIL}${input.commandName}${after}`;
   return input.command.end === input.text.length ? `${replacement} ` : replacement;
 }
-
-export function shouldSubmitUncommittedTrigger(input: {
-  key: string;
-  command: SlashCommandRange | null;
-}): boolean {
-  const isSubmitKey = input.key === "Enter";
-  const isNonCanonicalTrigger =
-    input.command !== null && input.command.sigil !== DEFAULT_COMMAND_SIGIL;
-  return isSubmitKey && isNonCanonicalTrigger;
-}

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -1,4 +1,8 @@
-import type { ComposerSigil, ComposerSigils } from "@/composer/tokens/sigils";
+import {
+  DEFAULT_COMMAND_SIGIL,
+  type ComposerSigil,
+  type ComposerSigils,
+} from "@/composer/tokens/sigils";
 import {
   compareMatchScores,
   type MatchScore,
@@ -31,7 +35,7 @@ export interface SlashCommandRange {
   query: string;
   position: SlashCommandPosition;
   menu: SlashCommandMenu;
-  /** The sigil that opened this trigger, so replacement can write it back. */
+  /** The configured sigil that opened this trigger. */
   sigil: ComposerSigil;
 }
 
@@ -150,6 +154,6 @@ export function findActiveSlashCommand(
 export function applySlashCommandReplacement(input: ApplySlashCommandReplacementInput): string {
   const before = input.text.slice(0, input.command.start);
   const after = input.text.slice(input.command.end);
-  const replacement = `${before}${input.command.sigil}${input.commandName}${after}`;
+  const replacement = `${before}${DEFAULT_COMMAND_SIGIL}${input.commandName}${after}`;
   return input.command.end === input.text.length ? `${replacement} ` : replacement;
 }

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -98,6 +98,7 @@ export function filterInlineSkillCommandEntries<TEntry extends InlineSkillComman
 }
 
 const INVALID_QUERY_CHARS = /[/\s\n\r\t"']/;
+const SHELL_VARIABLE_QUERY = /^[A-Z_][A-Z0-9_]*$/;
 
 function isInvalidQuery(query: string, sigils: ComposerSigils): boolean {
   // A second sigil inside the query means the earlier one was not the live
@@ -156,4 +157,15 @@ export function applySlashCommandReplacement(input: ApplySlashCommandReplacement
   const after = input.text.slice(input.command.end);
   const replacement = `${before}${DEFAULT_COMMAND_SIGIL}${input.commandName}${after}`;
   return input.command.end === input.text.length ? `${replacement} ` : replacement;
+}
+
+export function shouldSubmitShellVariable(input: {
+  key: string;
+  command: SlashCommandRange | null;
+}): boolean {
+  return (
+    input.key === "Enter" &&
+    input.command?.sigil === "$" &&
+    SHELL_VARIABLE_QUERY.test(input.command.query)
+  );
 }

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -159,6 +159,14 @@ export function applySlashCommandReplacement(input: ApplySlashCommandReplacement
   return input.command.end === input.text.length ? `${replacement} ` : replacement;
 }
 
+/**
+ * `$NAME` is shell-variable shaped because of the `$` character, not because of
+ * which menu it happens to open. The check keys off the sigil and deliberately
+ * ignores `command.menu`: if the user assigns `$` to the command trigger,
+ * `check $HOME` must still submit verbatim rather than being rewritten to
+ * `check /HOME`. Tab and click remain the explicit commit actions in both
+ * assignments.
+ */
 export function shouldSubmitShellVariable(input: {
   key: string;
   command: SlashCommandRange | null;

--- a/packages/app/src/utils/agent-command-autocomplete.ts
+++ b/packages/app/src/utils/agent-command-autocomplete.ts
@@ -98,7 +98,7 @@ export function filterInlineSkillCommandEntries<TEntry extends InlineSkillComman
 }
 
 const INVALID_QUERY_CHARS = /[/\s\n\r\t"']/;
-const SHELL_VARIABLE_QUERY = /^[A-Z_][A-Z0-9_]*$/;
+const SHELL_VARIABLE_QUERY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function isInvalidQuery(query: string, sigils: ComposerSigils): boolean {
   // A second sigil inside the query means the earlier one was not the live
@@ -160,7 +160,7 @@ export function applySlashCommandReplacement(input: ApplySlashCommandReplacement
 }
 
 /**
- * `$NAME` is shell-variable shaped because of the `$` character, not because of
+ * `$name` is shell-variable shaped because of the `$` character, not because of
  * which menu it happens to open. The check keys off the sigil and deliberately
  * ignores `command.menu`: if the user assigns `$` to the command trigger,
  * `check $HOME` must still submit verbatim rather than being rewritten to

--- a/packages/server/src/server/agent/providers/mock-load-test-agent.test.ts
+++ b/packages/server/src/server/agent/providers/mock-load-test-agent.test.ts
@@ -49,6 +49,28 @@ describe("MockLoadTestAgentClient", () => {
     });
   });
 
+  test("lists mock skills for draft and live sessions", async () => {
+    const client = new MockLoadTestAgentClient();
+    const config = {
+      provider: "mock",
+      cwd: process.cwd(),
+      model: "ten-second-stream",
+    } as const;
+    const expectedCommands = [
+      {
+        name: "release-beta",
+        description: "Simulate a provider skill in development.",
+        argumentHint: "",
+        kind: "skill",
+      },
+    ];
+
+    await expect(client.listCommands(config)).resolves.toEqual(expectedCommands);
+
+    const session = await client.createSession(config);
+    await expect(session.listCommands?.()).resolves.toEqual(expectedCommands);
+  });
+
   test("rejects the configured number of prompts before starting a retry", async () => {
     const client = new MockLoadTestAgentClient();
     const session = await client.createSession({

--- a/packages/server/src/server/agent/providers/mock-load-test-agent.test.ts
+++ b/packages/server/src/server/agent/providers/mock-load-test-agent.test.ts
@@ -58,6 +58,12 @@ describe("MockLoadTestAgentClient", () => {
     } as const;
     const expectedCommands = [
       {
+        name: "HOME",
+        description: "Exercise shell-variable collisions in development.",
+        argumentHint: "",
+        kind: "skill",
+      },
+      {
         name: "release-beta",
         description: "Simulate a provider skill in development.",
         argumentHint: "",

--- a/packages/server/src/server/agent/providers/mock-load-test-agent.ts
+++ b/packages/server/src/server/agent/providers/mock-load-test-agent.ts
@@ -48,6 +48,12 @@ const ONE_PIXEL_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl4Kj8AAAAASUVORK5CYII=";
 const MOCK_LOAD_TEST_COMMANDS: readonly AgentSlashCommand[] = [
   {
+    name: "HOME",
+    description: "Exercise shell-variable collisions in development.",
+    argumentHint: "",
+    kind: "skill",
+  },
+  {
     name: "release-beta",
     description: "Simulate a provider skill in development.",
     argumentHint: "",

--- a/packages/server/src/server/agent/providers/mock-load-test-agent.ts
+++ b/packages/server/src/server/agent/providers/mock-load-test-agent.ts
@@ -18,6 +18,7 @@ import type {
   AgentRuntimeInfo,
   AgentSession,
   AgentSessionConfig,
+  AgentSlashCommand,
   AgentStreamEvent,
   AgentTimelineItem,
   FetchCatalogOptions,
@@ -45,6 +46,14 @@ function getPositiveFeatureInteger(value: unknown): number {
 }
 const ONE_PIXEL_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl4Kj8AAAAASUVORK5CYII=";
+const MOCK_LOAD_TEST_COMMANDS: readonly AgentSlashCommand[] = [
+  {
+    name: "release-beta",
+    description: "Simulate a provider skill in development.",
+    argumentHint: "",
+    kind: "skill",
+  },
+];
 
 const CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: true,
@@ -690,6 +699,10 @@ export class MockLoadTestAgentClient implements AgentClient {
     };
   }
 
+  async listCommands(_config: AgentSessionConfig): Promise<AgentSlashCommand[]> {
+    return [...MOCK_LOAD_TEST_COMMANDS];
+  }
+
   async listImportableSessions(): Promise<ImportableProviderSession[]> {
     return [];
   }
@@ -768,6 +781,10 @@ export class MockLoadTestAgentSession implements AgentSession {
     this.remainingSteerFailures = getPositiveFeatureInteger(
       options.config.featureValues?.mockSteerAmbiguousFailures,
     );
+  }
+
+  async listCommands(): Promise<AgentSlashCommand[]> {
+    return [...MOCK_LOAD_TEST_COMMANDS];
   }
 
   async run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult> {


### PR DESCRIPTION
### Linked issue

Closes #2531

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Adds separate, configurable command and skill triggers to the composer (defaulting to `/` and `$`).

- Keeps the full command menu at the start of a prompt and filters the dedicated skill trigger to provider skills.
- Renders recognized command/skill text as width-preserving pills in the web/Electron composer while retaining a plain-text controlled input.
- Treats configured sigils as autocomplete triggers only; Tab or a click explicitly commits canonical `/name` into the plain-text draft, while Enter submits uncommitted trigger text verbatim and submit/queue paths send that exact text without reinterpretation.
- Renders canonical tokens in sent-message bubbles with the active configured sigils on every platform, without changing copy, rewind, persistence, or provider history text.
- Persists a collision-free trigger pair and swaps assignments when the user selects the other trigger's character.
- Leaves native composer input plain text because controlled React Native `TextInput` cannot safely render attributed children; sent messages safely use nested `Text` spans.
- Documents the token model, submission boundary, sent-message presentation, and mirror-layout invariant.

Harsh pre-PR and review-feedback passes caught and corrected six substantive problems in the implementation:

1. custom trigger characters would have reached providers literally instead of executing as canonical slash commands;
2. the native styled-input approach violated Android's `TextInput` contract and was ignored by iOS;
3. mirror scrolling caused full composer rerenders and style observers were recreated on every keystroke;
4. remapping `/` could make path-like autocomplete queries disagree with token parsing;
5. token-shaped shell variables such as `$HOME` could be mistaken for skills and rewritten before reaching the provider; autocomplete selection is now the explicit boundary that commits canonical command/skill syntax;
6. Enter could still select an exact provider skill collision such as `HOME`; Enter now submits non-canonical trigger text unchanged, while Tab/click commits autocomplete.

### How did you verify it

Automated checks:

- `npm run build:server` — passed
- `npm run typecheck` — passed across all workspaces
- `npm run lint` — 0 warnings, 0 errors
- `npm run format` and `npm run format:check` — passed
- `npx vitest run packages/server/src/server/agent/providers/mock-load-test-agent.test.ts packages/app/src/composer/tokens/tokens.test.ts packages/app/src/utils/agent-command-autocomplete.test.ts --bail=1` — 3 files, 41 tests passed
- `npm run test --workspace=@getpaseo/app -- src/hooks/use-agent-commands-query.test.ts --bail=1` — 1 file, 2 tests passed
- `env -u PASEO_PASSWORD PLAYWRIGHT_BROWSERS_PATH=/tmp/paseo-playwright-browsers-1208 npm run test:e2e --workspace=@getpaseo/app -- e2e/composer-tokens.spec.ts` — 1 Desktop Chrome scenario passed

The browser scenario verifies:

- an exact provider skill collision named `HOME` still leaves `$HOME` plain, and pressing Enter sends `check $HOME` unchanged;
- selecting a recognized skill with Tab commits canonical `/release-beta` while the mirror displays the configured sigil and keeps the textarea text transparent;
- command and skill settings persist;
- selecting the other menu's character swaps the assignments;
- the remapped skill trigger immediately renders as a composer token;
- removing all composer tokens removes the mirror;
- a canonical submitted skill renders in the sent bubble with the active `!` skill sigil;
- no framework error overlay appears.

Visual evidence captured by the passing Playwright scenario:

- composer: `please run $release-beta`, with `$release-beta` shown as a green pill;
- settings: the `/ $ ! # > %` command-trigger control, with `#` selected after the collision swap;
- sent message: `please run !release-beta`, with `!release-beta` shown as a bordered green pill.

Platform coverage: Desktop Chrome was exercised and captured. Browser web and Electron use the same composer renderer but were not separately run. Sent-message pills use cross-platform nested React Native `Text` spans. iOS and Android were not manually tested or captured; native intentionally retains plain composer text, while sent bubbles and the settings rows receive the new presentation. I am leaving the all-platform screenshot checkbox unchecked to make that limitation explicit.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
