### PR TITLE
Configure agent thinking from the CLI

### DIFF
--- a/packages/cli/src/cli-surface.test.ts
+++ b/packages/cli/src/cli-surface.test.ts
@@ -35,14 +35,17 @@ describe("canonical CLI surface", () => {
     expect(run?.helpInformation()).not.toContain("--detach");
   });
 
-  it("offers thinking configuration when creating and updating agents", () => {
+  it("offers thinking configuration when running, updating, and scheduling agents", () => {
     const cli = createCli();
     const run = cli.commands.find((command) => command.name() === "run");
     const agent = cli.commands.find((command) => command.name() === "agent");
     const update = agent?.commands.find((command) => command.name() === "update");
+    const schedule = cli.commands.find((command) => command.name() === "schedule");
+    const scheduleCreate = schedule?.commands.find((command) => command.name() === "create");
 
     expect(run?.helpInformation()).toContain("--thinking <id>");
     expect(update?.helpInformation()).toContain("--thinking <id>");
+    expect(scheduleCreate?.helpInformation()).toContain("--thinking <id>");
   });
 
   it("offers opening an existing agent in the desktop app", () => {

--- a/packages/cli/src/cli-surface.test.ts
+++ b/packages/cli/src/cli-surface.test.ts
@@ -35,6 +35,16 @@ describe("canonical CLI surface", () => {
     expect(run?.helpInformation()).not.toContain("--detach");
   });
 
+  it("offers thinking configuration when creating and updating agents", () => {
+    const cli = createCli();
+    const run = cli.commands.find((command) => command.name() === "run");
+    const agent = cli.commands.find((command) => command.name() === "agent");
+    const update = agent?.commands.find((command) => command.name() === "update");
+
+    expect(run?.helpInformation()).toContain("--thinking <id>");
+    expect(update?.helpInformation()).toContain("--thinking <id>");
+  });
+
   it("offers opening an existing agent in the desktop app", () => {
     const agent = createCli().commands.find((command) => command.name() === "agent");
     const open = agent?.commands.find((command) => command.name() === "open");

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -92,9 +92,10 @@ export function createAgentCommand(): Command {
   addJsonAndDaemonHostOptions(
     agent
       .command("update")
-      .description("Update an agent's metadata")
+      .description("Update an agent's settings or metadata")
       .argument("<id>", "Agent ID (or prefix)")
       .option("--name <name>", "Update the agent's display name")
+      .option("--thinking <id>", "Update the agent's thinking option ID")
       .option(
         "--label <label>",
         "Add/set label(s) on the agent (can be used multiple times or comma-separated)",

--- a/packages/cli/src/commands/agent/update.test.ts
+++ b/packages/cli/src/commands/agent/update.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { applyAgentChanges, type AgentMetadataChanges, type AgentUpdateClient } from "./update.js";
+
+class RecordingAgentUpdateClient implements AgentUpdateClient {
+  readonly metadataUpdates: Array<{
+    agentId: string;
+    updates: AgentMetadataChanges;
+  }> = [];
+  readonly thinkingUpdates: Array<{ agentId: string; thinkingOptionId: string }> = [];
+
+  async updateAgent(agentId: string, updates: AgentMetadataChanges): Promise<void> {
+    this.metadataUpdates.push({ agentId, updates });
+  }
+
+  async setAgentThinkingOption(agentId: string, thinkingOptionId: string): Promise<void> {
+    this.thinkingUpdates.push({ agentId, thinkingOptionId });
+  }
+}
+
+describe("applyAgentChanges", () => {
+  it("updates an agent's thinking without issuing an empty metadata update", async () => {
+    const client = new RecordingAgentUpdateClient();
+
+    await applyAgentChanges(client, "agent-1", { thinkingOptionId: "high" });
+
+    expect(client.metadataUpdates).toEqual([]);
+    expect(client.thinkingUpdates).toEqual([{ agentId: "agent-1", thinkingOptionId: "high" }]);
+  });
+});

--- a/packages/cli/src/commands/agent/update.test.ts
+++ b/packages/cli/src/commands/agent/update.test.ts
@@ -33,10 +33,17 @@ describe("applyAgentChanges", () => {
   it("updates an agent's thinking without issuing an empty metadata update", async () => {
     const client = new RecordingAgentUpdateClient();
 
-    await applyAgentChanges(client, "agent-1", { type: "thinking", thinkingOptionId: "high" });
+    const result = await applyAgentChanges(client, "agent-1", {
+      type: "thinking",
+      thinkingOptionId: "high",
+    });
 
     expect(client.metadataUpdates).toEqual([]);
     expect(client.thinkingUpdates).toEqual([{ agentId: "agent-1", thinkingOptionId: "high" }]);
+    expect(result).toEqual({
+      thinkingOptionId: "high",
+      notice: null,
+    });
   });
 
   it("requires a daemon that advertises thinking updates", async () => {
@@ -65,8 +72,11 @@ describe("applyAgentChanges", () => {
     });
 
     expect(notice).toEqual({
-      type: "warning",
-      message: "Thinking changes apply to the next turn.",
+      thinkingOptionId: "high",
+      notice: {
+        type: "warning",
+        message: "Thinking changes apply to the next turn.",
+      },
     });
   });
 });

--- a/packages/cli/src/commands/agent/update.test.ts
+++ b/packages/cli/src/commands/agent/update.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { AgentProviderNotice } from "@getpaseo/protocol/agent-types";
-import { applyAgentChanges, type AgentMetadataChanges, type AgentUpdateClient } from "./update.js";
+import {
+  applyAgentChanges,
+  toAgentUpdateResult,
+  type AgentMetadataChanges,
+  type AgentUpdateClient,
+} from "./update.js";
 
 class RecordingAgentUpdateClient implements AgentUpdateClient {
   readonly metadataUpdates: Array<{
@@ -41,7 +46,6 @@ describe("applyAgentChanges", () => {
     expect(client.metadataUpdates).toEqual([]);
     expect(client.thinkingUpdates).toEqual([{ agentId: "agent-1", thinkingOptionId: "high" }]);
     expect(result).toEqual({
-      thinkingOptionId: "high",
       notice: null,
     });
   });
@@ -72,11 +76,33 @@ describe("applyAgentChanges", () => {
     });
 
     expect(notice).toEqual({
-      thinkingOptionId: "high",
       notice: {
         type: "warning",
         message: "Thinking changes apply to the next turn.",
       },
+    });
+  });
+});
+
+describe("toAgentUpdateResult", () => {
+  it("reports the current thinking option after a metadata update", () => {
+    const result = toAgentUpdateResult(
+      {
+        id: "agent-1",
+        title: "Renamed agent",
+        labels: { team: "platform" },
+        effectiveThinkingOptionId: "high",
+      },
+      { notice: null },
+    );
+
+    expect(result).toEqual({
+      agentId: "agent-1",
+      name: "Renamed agent",
+      labels: "team=platform",
+      thinkingOptionId: "high",
+      noticeType: null,
+      notice: null,
     });
   });
 });

--- a/packages/cli/src/commands/agent/update.test.ts
+++ b/packages/cli/src/commands/agent/update.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { AgentProviderNotice } from "@getpaseo/protocol/agent-types";
 import { applyAgentChanges, type AgentMetadataChanges, type AgentUpdateClient } from "./update.js";
 
 class RecordingAgentUpdateClient implements AgentUpdateClient {
@@ -7,13 +8,24 @@ class RecordingAgentUpdateClient implements AgentUpdateClient {
     updates: AgentMetadataChanges;
   }> = [];
   readonly thinkingUpdates: Array<{ agentId: string; thinkingOptionId: string }> = [];
+  thinkingNotice: AgentProviderNotice | null = null;
+
+  constructor(private readonly supportsThinkingUpdate = true) {}
+
+  getLastServerInfoMessage() {
+    return { features: { agentThinkingUpdate: this.supportsThinkingUpdate } };
+  }
 
   async updateAgent(agentId: string, updates: AgentMetadataChanges): Promise<void> {
     this.metadataUpdates.push({ agentId, updates });
   }
 
-  async setAgentThinkingOption(agentId: string, thinkingOptionId: string): Promise<void> {
+  async setAgentThinkingOption(
+    agentId: string,
+    thinkingOptionId: string,
+  ): Promise<AgentProviderNotice | null> {
     this.thinkingUpdates.push({ agentId, thinkingOptionId });
+    return this.thinkingNotice;
   }
 }
 
@@ -21,9 +33,40 @@ describe("applyAgentChanges", () => {
   it("updates an agent's thinking without issuing an empty metadata update", async () => {
     const client = new RecordingAgentUpdateClient();
 
-    await applyAgentChanges(client, "agent-1", { thinkingOptionId: "high" });
+    await applyAgentChanges(client, "agent-1", { type: "thinking", thinkingOptionId: "high" });
 
     expect(client.metadataUpdates).toEqual([]);
     expect(client.thinkingUpdates).toEqual([{ agentId: "agent-1", thinkingOptionId: "high" }]);
+  });
+
+  it("requires a daemon that advertises thinking updates", async () => {
+    const client = new RecordingAgentUpdateClient(false);
+
+    await expect(
+      applyAgentChanges(client, "agent-1", { type: "thinking", thinkingOptionId: "high" }),
+    ).rejects.toMatchObject({
+      code: "DAEMON_UPDATE_REQUIRED",
+      message: "Update the host to use agent thinking updates.",
+    });
+    expect(client.metadataUpdates).toEqual([]);
+    expect(client.thinkingUpdates).toEqual([]);
+  });
+
+  it("returns the provider notice from a thinking update", async () => {
+    const client = new RecordingAgentUpdateClient();
+    client.thinkingNotice = {
+      type: "warning",
+      message: "Thinking changes apply to the next turn.",
+    };
+
+    const notice = await applyAgentChanges(client, "agent-1", {
+      type: "thinking",
+      thinkingOptionId: "high",
+    });
+
+    expect(notice).toEqual({
+      type: "warning",
+      message: "Thinking changes apply to the next turn.",
+    });
   });
 });

--- a/packages/cli/src/commands/agent/update.ts
+++ b/packages/cli/src/commands/agent/update.ts
@@ -27,10 +27,42 @@ export const updateSchema: OutputSchema<AgentUpdateResult> = {
 export interface AgentUpdateOptions extends CommandOptions {
   name?: string;
   label?: string[];
+  thinking?: string;
   host?: string;
 }
 
 export type AgentUpdateCommandResult = SingleResult<AgentUpdateResult>;
+
+export interface AgentMetadataChanges {
+  name?: string;
+  labels?: Record<string, string>;
+}
+
+export interface AgentUpdateClient {
+  updateAgent(agentId: string, updates: AgentMetadataChanges): Promise<void>;
+  setAgentThinkingOption(agentId: string, thinkingOptionId: string): Promise<unknown>;
+}
+
+export interface AgentChanges extends AgentMetadataChanges {
+  thinkingOptionId?: string;
+}
+
+export async function applyAgentChanges(
+  client: AgentUpdateClient,
+  agentId: string,
+  changes: AgentChanges,
+): Promise<void> {
+  const hasLabels = changes.labels && Object.keys(changes.labels).length > 0;
+  if (changes.name || hasLabels) {
+    await client.updateAgent(agentId, {
+      ...(changes.name ? { name: changes.name } : {}),
+      ...(hasLabels ? { labels: changes.labels } : {}),
+    });
+  }
+  if (changes.thinkingOptionId) {
+    await client.setAgentThinkingOption(agentId, changes.thinkingOptionId);
+  }
+}
 
 function parseLabelOptions(labels: string[] | undefined): Record<string, string> {
   const parsed: Record<string, string> = {};
@@ -81,6 +113,43 @@ function formatLabels(labels: Record<string, string>): string {
   return entries.map(([key, value]) => `${key}=${value}`).join(",");
 }
 
+function parseAgentChanges(options: AgentUpdateOptions): AgentChanges {
+  const name = options.name?.trim();
+  if (options.name !== undefined && !name) {
+    throw {
+      code: "INVALID_NAME",
+      message: "Name cannot be empty",
+      details: "Use --name <name> with a non-empty value",
+    } satisfies CommandError;
+  }
+
+  const labels = parseLabelOptions(options.label);
+  const thinkingOptionId = options.thinking?.trim();
+  if (options.thinking !== undefined && !thinkingOptionId) {
+    throw {
+      code: "INVALID_THINKING_OPTION",
+      message: "--thinking cannot be empty",
+      details:
+        'Provide a thinking option ID. Use "paseo provider models <provider> --thinking" to list valid IDs.',
+    } satisfies CommandError;
+  }
+
+  const hasMetadataUpdates = Boolean(name) || Object.keys(labels).length > 0;
+  if (!hasMetadataUpdates && !thinkingOptionId) {
+    throw {
+      code: "NO_CHANGES_PROVIDED",
+      message: "Nothing to update",
+      details: "Provide at least one of: --name <name>, --label <key=value>, --thinking <id>",
+    } satisfies CommandError;
+  }
+
+  return {
+    ...(name ? { name } : {}),
+    ...(Object.keys(labels).length > 0 ? { labels } : {}),
+    ...(thinkingOptionId ? { thinkingOptionId } : {}),
+  };
+}
+
 export async function runUpdateCommand(
   agentIdArg: string,
   options: AgentUpdateOptions,
@@ -98,25 +167,7 @@ export async function runUpdateCommand(
     throw error;
   }
 
-  const name = options.name?.trim();
-  if (options.name !== undefined && !name) {
-    const error: CommandError = {
-      code: "INVALID_NAME",
-      message: "Name cannot be empty",
-      details: "Use --name <name> with a non-empty value",
-    };
-    throw error;
-  }
-
-  const labels = parseLabelOptions(options.label);
-  if (!name && Object.keys(labels).length === 0) {
-    const error: CommandError = {
-      code: "NO_CHANGES_PROVIDED",
-      message: "Nothing to update",
-      details: "Provide at least one of: --name <name>, --label <key=value>",
-    };
-    throw error;
-  }
+  const changes = parseAgentChanges(options);
 
   let client;
   try {
@@ -143,10 +194,7 @@ export async function runUpdateCommand(
     }
     const agentId = fetchResult.agent.id;
 
-    await client.updateAgent(agentId, {
-      ...(name ? { name } : {}),
-      ...(Object.keys(labels).length > 0 ? { labels } : {}),
-    });
+    await applyAgentChanges(client, agentId, changes);
 
     const updatedResult = await client.fetchAgent({ agentId });
     if (!updatedResult) {

--- a/packages/cli/src/commands/agent/update.ts
+++ b/packages/cli/src/commands/agent/update.ts
@@ -13,6 +13,7 @@ export interface AgentUpdateResult {
   agentId: string;
   name: string | null;
   labels: string;
+  thinkingOptionId: string | null;
   noticeType: AgentProviderNotice["type"] | null;
   notice: string | null;
 }
@@ -24,6 +25,7 @@ export const updateSchema: OutputSchema<AgentUpdateResult> = {
     { header: "AGENT ID", field: "agentId" },
     { header: "NAME", field: "name" },
     { header: "LABELS", field: "labels" },
+    { header: "THINKING", field: "thinkingOptionId" },
     { header: "NOTICE", field: "notice" },
   ],
 };
@@ -59,11 +61,16 @@ export type AgentChanges =
   | { type: "metadata"; updates: AgentMetadataChanges }
   | { type: "thinking"; thinkingOptionId: string };
 
+export interface AppliedAgentChanges {
+  thinkingOptionId: string | null;
+  notice: AgentProviderNotice | null;
+}
+
 export async function applyAgentChanges(
   client: AgentUpdateClient,
   agentId: string,
   changes: AgentChanges,
-): Promise<AgentProviderNotice | null> {
+): Promise<AppliedAgentChanges> {
   if (changes.type === "thinking") {
     // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.
     if (client.getLastServerInfoMessage()?.features?.agentThinkingUpdate !== true) {
@@ -72,10 +79,11 @@ export async function applyAgentChanges(
         message: "Update the host to use agent thinking updates.",
       } satisfies CommandError;
     }
-    return client.setAgentThinkingOption(agentId, changes.thinkingOptionId);
+    const notice = await client.setAgentThinkingOption(agentId, changes.thinkingOptionId);
+    return { thinkingOptionId: changes.thinkingOptionId, notice };
   }
   await client.updateAgent(agentId, changes.updates);
-  return null;
+  return { thinkingOptionId: null, notice: null };
 }
 
 function parseLabelOptions(labels: string[] | undefined): Record<string, string> {
@@ -220,7 +228,7 @@ export async function runUpdateCommand(
     }
     const agentId = fetchResult.agent.id;
 
-    const notice = await applyAgentChanges(client, agentId, changes);
+    const appliedChanges = await applyAgentChanges(client, agentId, changes);
 
     const updatedResult = await client.fetchAgent({ agentId });
     if (!updatedResult) {
@@ -235,8 +243,9 @@ export async function runUpdateCommand(
         agentId,
         name: updatedResult.agent.title,
         labels: formatLabels(updatedResult.agent.labels),
-        noticeType: notice?.type ?? null,
-        notice: notice?.message ?? null,
+        thinkingOptionId: appliedChanges.thinkingOptionId,
+        noticeType: appliedChanges.notice?.type ?? null,
+        notice: appliedChanges.notice?.message ?? null,
       },
       schema: updateSchema,
     };

--- a/packages/cli/src/commands/agent/update.ts
+++ b/packages/cli/src/commands/agent/update.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import type { AgentProviderNotice } from "@getpaseo/protocol/agent-types";
+import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type {
   CommandOptions,
@@ -62,8 +63,21 @@ export type AgentChanges =
   | { type: "thinking"; thinkingOptionId: string };
 
 export interface AppliedAgentChanges {
-  thinkingOptionId: string | null;
   notice: AgentProviderNotice | null;
+}
+
+export function toAgentUpdateResult(
+  agent: Pick<AgentSnapshotPayload, "id" | "title" | "labels" | "effectiveThinkingOptionId">,
+  appliedChanges: AppliedAgentChanges,
+): AgentUpdateResult {
+  return {
+    agentId: agent.id,
+    name: agent.title,
+    labels: formatLabels(agent.labels),
+    thinkingOptionId: agent.effectiveThinkingOptionId ?? null,
+    noticeType: appliedChanges.notice?.type ?? null,
+    notice: appliedChanges.notice?.message ?? null,
+  };
 }
 
 export async function applyAgentChanges(
@@ -80,10 +94,10 @@ export async function applyAgentChanges(
       } satisfies CommandError;
     }
     const notice = await client.setAgentThinkingOption(agentId, changes.thinkingOptionId);
-    return { thinkingOptionId: changes.thinkingOptionId, notice };
+    return { notice };
   }
   await client.updateAgent(agentId, changes.updates);
-  return { thinkingOptionId: null, notice: null };
+  return { notice: null };
 }
 
 function parseLabelOptions(labels: string[] | undefined): Record<string, string> {
@@ -239,14 +253,7 @@ export async function runUpdateCommand(
 
     return {
       type: "single",
-      data: {
-        agentId,
-        name: updatedResult.agent.title,
-        labels: formatLabels(updatedResult.agent.labels),
-        thinkingOptionId: appliedChanges.thinkingOptionId,
-        noticeType: appliedChanges.notice?.type ?? null,
-        notice: appliedChanges.notice?.message ?? null,
-      },
+      data: toAgentUpdateResult(updatedResult.agent, appliedChanges),
       schema: updateSchema,
     };
   } catch (err) {

--- a/packages/cli/src/commands/agent/update.ts
+++ b/packages/cli/src/commands/agent/update.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import type { AgentProviderNotice } from "@getpaseo/protocol/agent-types";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type {
   CommandOptions,
@@ -12,6 +13,8 @@ export interface AgentUpdateResult {
   agentId: string;
   name: string | null;
   labels: string;
+  noticeType: AgentProviderNotice["type"] | null;
+  notice: string | null;
 }
 
 /** Schema for update command output */
@@ -21,6 +24,7 @@ export const updateSchema: OutputSchema<AgentUpdateResult> = {
     { header: "AGENT ID", field: "agentId" },
     { header: "NAME", field: "name" },
     { header: "LABELS", field: "labels" },
+    { header: "NOTICE", field: "notice" },
   ],
 };
 
@@ -38,30 +42,40 @@ export interface AgentMetadataChanges {
   labels?: Record<string, string>;
 }
 
-export interface AgentUpdateClient {
-  updateAgent(agentId: string, updates: AgentMetadataChanges): Promise<void>;
-  setAgentThinkingOption(agentId: string, thinkingOptionId: string): Promise<unknown>;
+interface AgentUpdateServerInfo {
+  features?: { agentThinkingUpdate?: boolean };
 }
 
-export interface AgentChanges extends AgentMetadataChanges {
-  thinkingOptionId?: string;
+export interface AgentUpdateClient {
+  getLastServerInfoMessage(): AgentUpdateServerInfo | null;
+  updateAgent(agentId: string, updates: AgentMetadataChanges): Promise<void>;
+  setAgentThinkingOption(
+    agentId: string,
+    thinkingOptionId: string,
+  ): Promise<AgentProviderNotice | null>;
 }
+
+export type AgentChanges =
+  | { type: "metadata"; updates: AgentMetadataChanges }
+  | { type: "thinking"; thinkingOptionId: string };
 
 export async function applyAgentChanges(
   client: AgentUpdateClient,
   agentId: string,
   changes: AgentChanges,
-): Promise<void> {
-  const hasLabels = changes.labels && Object.keys(changes.labels).length > 0;
-  if (changes.name || hasLabels) {
-    await client.updateAgent(agentId, {
-      ...(changes.name ? { name: changes.name } : {}),
-      ...(hasLabels ? { labels: changes.labels } : {}),
-    });
+): Promise<AgentProviderNotice | null> {
+  if (changes.type === "thinking") {
+    // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.
+    if (client.getLastServerInfoMessage()?.features?.agentThinkingUpdate !== true) {
+      throw {
+        code: "DAEMON_UPDATE_REQUIRED",
+        message: "Update the host to use agent thinking updates.",
+      } satisfies CommandError;
+    }
+    return client.setAgentThinkingOption(agentId, changes.thinkingOptionId);
   }
-  if (changes.thinkingOptionId) {
-    await client.setAgentThinkingOption(agentId, changes.thinkingOptionId);
-  }
+  await client.updateAgent(agentId, changes.updates);
+  return null;
 }
 
 function parseLabelOptions(labels: string[] | undefined): Record<string, string> {
@@ -135,6 +149,13 @@ function parseAgentChanges(options: AgentUpdateOptions): AgentChanges {
   }
 
   const hasMetadataUpdates = Boolean(name) || Object.keys(labels).length > 0;
+  if (hasMetadataUpdates && thinkingOptionId) {
+    throw {
+      code: "INVALID_OPTIONS",
+      message: "--thinking cannot be combined with --name or --label",
+      details: "Run separate agent update commands for runtime settings and metadata.",
+    } satisfies CommandError;
+  }
   if (!hasMetadataUpdates && !thinkingOptionId) {
     throw {
       code: "NO_CHANGES_PROVIDED",
@@ -143,10 +164,15 @@ function parseAgentChanges(options: AgentUpdateOptions): AgentChanges {
     } satisfies CommandError;
   }
 
+  if (thinkingOptionId) {
+    return { type: "thinking", thinkingOptionId };
+  }
   return {
-    ...(name ? { name } : {}),
-    ...(Object.keys(labels).length > 0 ? { labels } : {}),
-    ...(thinkingOptionId ? { thinkingOptionId } : {}),
+    type: "metadata",
+    updates: {
+      ...(name ? { name } : {}),
+      ...(Object.keys(labels).length > 0 ? { labels } : {}),
+    },
   };
 }
 
@@ -194,7 +220,7 @@ export async function runUpdateCommand(
     }
     const agentId = fetchResult.agent.id;
 
-    await applyAgentChanges(client, agentId, changes);
+    const notice = await applyAgentChanges(client, agentId, changes);
 
     const updatedResult = await client.fetchAgent({ agentId });
     if (!updatedResult) {
@@ -209,6 +235,8 @@ export async function runUpdateCommand(
         agentId,
         name: updatedResult.agent.title,
         labels: formatLabels(updatedResult.agent.labels),
+        noticeType: notice?.type ?? null,
+        notice: notice?.message ?? null,
       },
       schema: updateSchema,
     };

--- a/packages/cli/src/commands/schedule/create.ts
+++ b/packages/cli/src/commands/schedule/create.ts
@@ -18,6 +18,7 @@ export interface ScheduleCreateOptions extends ScheduleCommandOptions {
   target?: string;
   provider?: string;
   mode?: string;
+  thinking?: string;
   cwd?: string;
   maxRuns?: string;
   expiresIn?: string;
@@ -40,6 +41,7 @@ export async function runCreateCommand(
     target: options.target,
     provider: options.provider,
     mode: options.mode,
+    thinking: options.thinking,
     cwd: options.cwd,
     host: options.host,
     maxRuns: options.maxRuns,

--- a/packages/cli/src/commands/schedule/index.ts
+++ b/packages/cli/src/commands/schedule/index.ts
@@ -32,6 +32,7 @@ export function createScheduleCommand(): Command {
         "--mode <mode>",
         "Provider-specific mode (e.g. claude bypassPermissions, opencode build)",
       )
+      .option("--thinking <id>", "Thinking option ID for new-agent runs")
       .option("--cwd <path>", "Working directory (default: current; required with --host)")
       .option("--run-now", "Fire one immediate run on creation")
       .option("--max-runs <n>", "Maximum number of runs")

--- a/packages/cli/src/commands/schedule/shared.test.ts
+++ b/packages/cli/src/commands/schedule/shared.test.ts
@@ -116,6 +116,25 @@ describe("parseScheduleCreateInput first-run timing", () => {
   });
 });
 
+describe("parseScheduleCreateInput thinking", () => {
+  test("sets the thinking option for each scheduled new-agent run", () => {
+    const input = parseScheduleCreateInput({
+      ...baseOptions,
+      cwd: "/project",
+      thinking: "  high  ",
+    });
+
+    expect(input.target).toEqual({
+      type: "new-agent",
+      config: {
+        provider: "claude",
+        cwd: "/project",
+        thinkingOptionId: "high",
+      },
+    });
+  });
+});
+
 describe("parseScheduleUpdateInput", () => {
   test("rejects calls with no fields to update", () => {
     expect(() => parseScheduleUpdateInput({ id: "abc" })).toThrow(

--- a/packages/cli/src/commands/schedule/shared.ts
+++ b/packages/cli/src/commands/schedule/shared.ts
@@ -114,7 +114,7 @@ function resolveScheduleTarget(args: {
   if (hasExplicitNewAgentOption) {
     throw {
       code: "INVALID_TARGET",
-      message: "--provider/--mode can only be used with a new-agent target",
+      message: "--provider/--mode/--thinking can only be used with a new-agent target",
       details: "Use --target new-agent or omit --target to create a new agent schedule",
     } satisfies CommandError;
   }
@@ -144,6 +144,7 @@ export function parseScheduleCreateInput(options: {
   target?: string;
   provider?: string;
   mode?: string;
+  thinking?: string;
   cwd?: string;
   host?: string;
   maxRuns?: string;
@@ -179,7 +180,15 @@ export function parseScheduleCreateInput(options: {
 
   const targetValue = options.target?.trim();
   const modeId = options.mode?.trim();
-  const hasExplicitNewAgentOption = options.provider !== undefined || options.mode !== undefined;
+  const thinkingOptionId = options.thinking?.trim();
+  if (options.thinking !== undefined && !thinkingOptionId) {
+    throw {
+      code: "INVALID_THINKING_OPTION",
+      message: "--thinking cannot be empty",
+    } satisfies CommandError;
+  }
+  const hasExplicitNewAgentOption =
+    options.provider !== undefined || options.mode !== undefined || options.thinking !== undefined;
   const createNewAgentTarget = (): ScheduleTarget => {
     const resolvedProviderModel = resolveProviderAndModel({
       provider: options.provider,
@@ -191,6 +200,7 @@ export function parseScheduleCreateInput(options: {
         cwd: cwdInput ?? process.cwd(),
         ...(resolvedProviderModel.model ? { model: resolvedProviderModel.model } : {}),
         ...(modeId ? { modeId } : {}),
+        ...(thinkingOptionId ? { thinkingOptionId } : {}),
       },
     };
   };

--- a/packages/cli/tests/16-agent-update.test.ts
+++ b/packages/cli/tests/16-agent-update.test.ts
@@ -33,6 +33,7 @@ try {
     assert.strictEqual(result.exitCode, 0, "agent update --help should exit 0");
     assert(result.stdout.includes("--name"), "help should mention --name flag");
     assert(result.stdout.includes("--label"), "help should mention --label flag");
+    assert(result.stdout.includes("--thinking"), "help should mention --thinking flag");
     assert(result.stdout.includes("--host"), "help should mention --host option");
     assert(result.stdout.includes("<id>"), "help should mention required id argument");
     console.log("✓ agent update --help shows options\n");
@@ -102,6 +103,16 @@ try {
     assert.strictEqual(result.exitCode, 0, "agent --help should exit 0");
     assert(result.stdout.includes("update"), "help should mention update subcommand");
     console.log("✓ agent --help shows update subcommand\n");
+  }
+
+  // Test 7: agent update accepts thinking as an update field
+  {
+    console.log("Test 7: agent update accepts thinking as an update field");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo agent update abc123 --thinking high`.nothrow();
+    const output = result.stdout + result.stderr;
+    assert(!output.includes("Nothing to update"), "should treat --thinking as an update field");
+    console.log("✓ agent update accepts thinking as an update field\n");
   }
 } finally {
   // Clean up temp directory

--- a/packages/cli/tests/16-agent-update.test.ts
+++ b/packages/cli/tests/16-agent-update.test.ts
@@ -114,6 +114,20 @@ try {
     assert(!output.includes("Nothing to update"), "should treat --thinking as an update field");
     console.log("✓ agent update accepts thinking as an update field\n");
   }
+
+  // Test 8: thinking cannot be combined with metadata updates
+  {
+    console.log("Test 8: thinking cannot be combined with metadata updates");
+    const result =
+      await $`PASEO_HOST=localhost:${port} PASEO_HOME=${paseoHome} npx paseo agent update abc123 --name renamed --thinking high`.nothrow();
+    assert.notStrictEqual(result.exitCode, 0, "should reject a combined update");
+    const output = result.stdout + result.stderr;
+    assert(
+      output.includes("--thinking cannot be combined with --name or --label"),
+      "should explain that thinking and metadata updates are separate operations",
+    );
+    console.log("✓ thinking cannot be combined with metadata updates\n");
+  }
 } finally {
   // Clean up temp directory
   await rm(paseoHome, { recursive: true, force: true });

--- a/packages/cli/tests/31-loop-schedule.test.ts
+++ b/packages/cli/tests/31-loop-schedule.test.ts
@@ -100,6 +100,8 @@ try {
         "10m",
         "--provider",
         "codex/gpt-5.4",
+        "--thinking",
+        "high",
         "--json",
       ],
       { timeout: 30000 },
@@ -113,6 +115,7 @@ try {
     const inspectedJson = JSON.parse(inspected.stdout);
     assert.strictEqual(inspectedJson.target.config.provider, "codex");
     assert.strictEqual(inspectedJson.target.config.model, "gpt-5.4");
+    assert.strictEqual(inspectedJson.target.config.thinkingOptionId, "high");
 
     const deleted = await ctx.paseo(["schedule", "delete", createdJson.id, "--json"]);
     assert.strictEqual(deleted.exitCode, 0, deleted.stderr);

--- a/packages/protocol/src/messages.project-command-center.test.ts
+++ b/packages/protocol/src/messages.project-command-center.test.ts
@@ -168,4 +168,14 @@ describe("project command-center protocol", () => {
     expect(parsed.features?.projectGithubClone).toBeUndefined();
     expect(parsed.features?.projectCreateDirectory).toBeUndefined();
   });
+
+  it("parses the agent thinking update capability", () => {
+    const parsed = parseServerInfoStatusPayload({
+      status: "server_info",
+      serverId: "server-new",
+      features: { agentThinkingUpdate: true },
+    });
+
+    expect(parsed.features?.agentThinkingUpdate).toBe(true);
+  });
 });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2792,6 +2792,8 @@ export const ServerInfoStatusPayloadSchema = z
         providerUsageList: z.boolean().optional(),
         // COMPAT(agentDetach): added in v0.1.98, remove gate after 2026-12-19 once daemon floor >= v0.1.98.
         agentDetach: z.boolean().optional(),
+        // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.
+        agentThinkingUpdate: z.boolean().optional(),
         // COMPAT(daemonDiagnostics): added in v0.1.100, remove gate after 2026-12-25 once daemon floor >= v0.1.100.
         daemonDiagnostics: z.boolean().optional(),
         // COMPAT(daemonSelfUpdate): added in v0.1.93, remove gate after 2026-12-13.

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1540,6 +1540,8 @@ export class VoiceAssistantWebSocketServer {
         providerUsageList: true,
         // COMPAT(agentDetach): added in v0.1.98, remove gate after 2026-12-19 once daemon floor >= v0.1.98.
         agentDetach: true,
+        // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.
+        agentThinkingUpdate: true,
         // COMPAT(daemonDiagnostics): added in v0.1.100, remove gate after 2026-12-25 once daemon floor >= v0.1.100.
         daemonDiagnostics: true,
         // COMPAT(daemonSelfUpdate): added in v0.1.93, remove gate after 2026-12-13.


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Exposes `--thinking <id>` across the CLI paths that configure agents:

- `paseo run` already supported it.
- `paseo agent update` now uses the dedicated runtime operation, surfaces provider notices, and requires an advertised daemon capability. Metadata and thinking updates are separate command states so one invocation cannot partially apply both operations.
- `paseo schedule create` now stores the selected thinking option in the existing new-agent schedule config for every scheduled run.

### How did you verify it

- Confirmed CLI surface tests failed before the update and schedule options were added and passed afterward.
- Confirmed agent update behavior, capability gating, provider notices, and combined-update rejection with focused tests.
- Confirmed schedule parsing failed to retain the thinking option before implementation and passed afterward.
- Ran the real isolated-daemon schedule CLI test and inspected the stored `thinkingOptionId`.
- Focused CLI Vitest coverage: 46 tests passed.
- Targeted CLI update command test: all 8 checks passed.
- Ran `npm run build:server`, `npm run typecheck`, `npm run lint`, and `npm run format`.

Risk is limited to CLI argument parsing, the agent-update operation, and an optional backward-compatible `server_info.features.agentThinkingUpdate` flag. The schedule API and persistence shape already supported `thinkingOptionId`.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable)
- [x] Tests added or updated where it made sense
