### PR TITLE
Keep plan approval focused on the latest proposal

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4046,7 +4046,6 @@ describe("Codex app-server provider", () => {
     expect(events).toContainEqual({
       type: "permission_resolved",
       provider: "codex",
-      turnId: expect.any(String),
       requestId: pendingPlan!.id,
       resolution: {
         behavior: "deny",
@@ -4055,7 +4054,7 @@ describe("Codex app-server provider", () => {
     });
   });
 
-  test("makes the old plan non-actionable while a new prompt is being accepted", async () => {
+  test("makes the old plan non-actionable while a new prompt is being prepared", async () => {
     const session = createSession({
       featureValues: { plan_mode: true },
     });
@@ -4072,27 +4071,28 @@ describe("Codex app-server provider", () => {
     const pendingPlan = session.getPendingPermissions()[0];
     expect(pendingPlan).toBeDefined();
 
-    let acceptPrompt: (() => void) | undefined;
-    let markPromptRequested: (() => void) | undefined;
-    const promptRequested = new Promise<void>((resolve) => {
-      markPromptRequested = resolve;
+    let continuePromptSetup: (() => void) | undefined;
+    let markPromptSetupStarted: (() => void) | undefined;
+    const promptSetupStarted = new Promise<void>((resolve) => {
+      markPromptSetupStarted = resolve;
     });
     session.activeForegroundTurnId = null;
     session.client = createStub<CodexClientLike>({
       request: async (method) => {
-        if (method === "thread/loaded/list") return { data: ["test-thread"] };
-        if (method === "turn/start") {
-          markPromptRequested?.();
-          return await new Promise<void>((resolve) => {
-            acceptPrompt = resolve;
+        if (method === "thread/loaded/list") {
+          markPromptSetupStarted?.();
+          await new Promise<void>((resolve) => {
+            continuePromptSetup = resolve;
           });
+          return { data: ["test-thread"] };
         }
+        if (method === "turn/start") return {};
         throw new Error(`Unexpected request: ${method}`);
       },
     });
 
     const startTurn = session.startTurn("Revise the plan");
-    await promptRequested;
+    await promptSetupStarted;
 
     expect(session.getPendingPermissions()).toEqual([]);
     await expect(
@@ -4104,7 +4104,7 @@ describe("Codex app-server provider", () => {
       `No pending Codex app-server permission request with id '${pendingPlan!.id}'`,
     );
 
-    acceptPrompt?.();
+    continuePromptSetup?.();
     await startTurn;
   });
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -3914,8 +3914,8 @@ describe("Codex app-server provider", () => {
         },
         actions: [
           expect.objectContaining({
-            id: "reject",
-            label: "Reject",
+            id: "dismiss",
+            label: "Dismiss",
             behavior: "deny",
           }),
           expect.objectContaining({
@@ -3977,6 +3977,113 @@ describe("Codex app-server provider", () => {
         },
       }),
     });
+  });
+
+  test("replaces a pending synthetic plan approval when a later plan completes", () => {
+    const session = createSession({
+      featureValues: { plan_mode: true },
+    });
+
+    asInternals(session).handleNotification("turn/started", {
+      turn: { id: "turn-plan-first" },
+    });
+    asInternals(session).handleNotification("turn/plan/updated", {
+      plan: [{ step: "Implement the first plan", status: "pending" }],
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      turn: { status: "completed", error: null },
+    });
+
+    asInternals(session).handleNotification("turn/started", {
+      turn: { id: "turn-plan-second" },
+    });
+    asInternals(session).handleNotification("turn/plan/updated", {
+      plan: [{ step: "Implement the revised plan", status: "pending" }],
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      turn: { status: "completed", error: null },
+    });
+
+    expect(session.getPendingPermissions()).toEqual([
+      expect.objectContaining({
+        kind: "plan",
+        input: { plan: "- Implement the revised plan" },
+      }),
+    ]);
+  });
+
+  test("dismisses a pending synthetic plan approval after a new prompt is accepted", async () => {
+    const session = createSession({
+      featureValues: { plan_mode: true },
+    });
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    asInternals(session).handleNotification("turn/started", {
+      turn: { id: "turn-plan-pending" },
+    });
+    asInternals(session).handleNotification("turn/plan/updated", {
+      plan: [{ step: "Implement the original plan", status: "pending" }],
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      turn: { status: "completed", error: null },
+    });
+    const pendingPlan = session.getPendingPermissions()[0];
+    expect(pendingPlan).toBeDefined();
+
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({
+      request: async (method) => {
+        if (method === "thread/loaded/list") return { data: ["test-thread"] };
+        if (method === "turn/start") return {};
+        throw new Error(`Unexpected request: ${method}`);
+      },
+    });
+
+    await session.startTurn("Revise the plan to include tests");
+
+    expect(session.getPendingPermissions()).toEqual([]);
+    expect(events).toContainEqual({
+      type: "permission_resolved",
+      provider: "codex",
+      turnId: expect.any(String),
+      requestId: pendingPlan!.id,
+      resolution: {
+        behavior: "deny",
+        message: "Dismissed by a new prompt",
+      },
+    });
+  });
+
+  test("keeps a pending synthetic plan approval when a new prompt is rejected", async () => {
+    const session = createSession({
+      featureValues: { plan_mode: true },
+    });
+
+    asInternals(session).handleNotification("turn/started", {
+      turn: { id: "turn-plan-pending" },
+    });
+    asInternals(session).handleNotification("turn/plan/updated", {
+      plan: [{ step: "Implement the original plan", status: "pending" }],
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      turn: { status: "completed", error: null },
+    });
+    const pendingPlan = session.getPendingPermissions()[0];
+    expect(pendingPlan).toBeDefined();
+
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({
+      request: async (method) => {
+        if (method === "thread/loaded/list") return { data: ["test-thread"] };
+        if (method === "turn/start") throw new Error("Prompt rejected");
+        throw new Error(`Unexpected request: ${method}`);
+      },
+    });
+
+    await expect(session.startTurn("Revise the plan")).rejects.toThrow("Prompt rejected");
+
+    expect(session.getPendingPermissions()).toEqual([pendingPlan]);
   });
 
   test("emits imageView paths with spaces as valid assistant markdown images", () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4158,7 +4158,7 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
-  test("keeps a pending synthetic plan approval when a new prompt is rejected", async () => {
+  test("keeps a synthetic plan dismissed when a new prompt is rejected", async () => {
     const session = createSession({
       featureValues: { plan_mode: true },
     });
@@ -4186,7 +4186,7 @@ describe("Codex app-server provider", () => {
 
     await expect(session.startTurn("Revise the plan")).rejects.toThrow("Prompt rejected");
 
-    expect(session.getPendingPermissions()).toEqual([pendingPlan]);
+    expect(session.getPendingPermissions()).toEqual([]);
   });
 
   test("emits imageView paths with spaces as valid assistant markdown images", () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4055,6 +4055,109 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("makes the old plan non-actionable while a new prompt is being accepted", async () => {
+    const session = createSession({
+      featureValues: { plan_mode: true },
+    });
+
+    asInternals(session).handleNotification("turn/started", {
+      turn: { id: "turn-plan-pending" },
+    });
+    asInternals(session).handleNotification("turn/plan/updated", {
+      plan: [{ step: "Implement the original plan", status: "pending" }],
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      turn: { status: "completed", error: null },
+    });
+    const pendingPlan = session.getPendingPermissions()[0];
+    expect(pendingPlan).toBeDefined();
+
+    let acceptPrompt: (() => void) | undefined;
+    let markPromptRequested: (() => void) | undefined;
+    const promptRequested = new Promise<void>((resolve) => {
+      markPromptRequested = resolve;
+    });
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({
+      request: async (method) => {
+        if (method === "thread/loaded/list") return { data: ["test-thread"] };
+        if (method === "turn/start") {
+          markPromptRequested?.();
+          return await new Promise<void>((resolve) => {
+            acceptPrompt = resolve;
+          });
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      },
+    });
+
+    const startTurn = session.startTurn("Revise the plan");
+    await promptRequested;
+
+    expect(session.getPendingPermissions()).toEqual([]);
+    await expect(
+      session.respondToPermission(pendingPlan!.id, {
+        behavior: "allow",
+        selectedActionId: "implement",
+      }),
+    ).rejects.toThrow(
+      `No pending Codex app-server permission request with id '${pendingPlan!.id}'`,
+    );
+
+    acceptPrompt?.();
+    await startTurn;
+  });
+
+  test("does not dismiss a new plan approval emitted while a prompt is being accepted", async () => {
+    const session = createSession({
+      featureValues: { plan_mode: true },
+    });
+
+    asInternals(session).handleNotification("turn/started", {
+      turn: { id: "turn-plan-pending" },
+    });
+    asInternals(session).handleNotification("turn/plan/updated", {
+      plan: [{ step: "Implement the original plan", status: "pending" }],
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      turn: { status: "completed", error: null },
+    });
+
+    let acceptPrompt: (() => void) | undefined;
+    let markPromptRequested: (() => void) | undefined;
+    const promptRequested = new Promise<void>((resolve) => {
+      markPromptRequested = resolve;
+    });
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({
+      request: async (method) => {
+        if (method === "thread/loaded/list") return { data: ["test-thread"] };
+        if (method === "turn/start") {
+          markPromptRequested?.();
+          return await new Promise<void>((resolve) => {
+            acceptPrompt = resolve;
+          });
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      },
+    });
+
+    const startTurn = session.startTurn("Revise the plan");
+    await promptRequested;
+    asInternals(session).handleNotification("turn/plan/updated", {
+      plan: [{ step: "Implement the newer plan", status: "pending" }],
+    });
+    asInternals(session).handleNotification("turn/completed", {
+      turn: { status: "completed", error: null },
+    });
+    acceptPrompt?.();
+    await startTurn;
+
+    expect(session.getPendingPermissions()).toEqual([
+      expect.objectContaining({ input: { plan: "- Implement the newer plan" } }),
+    ]);
+  });
+
   test("keeps a pending synthetic plan approval when a new prompt is rejected", async () => {
     const session = createSession({
       featureValues: { plan_mode: true },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3099,11 +3099,6 @@ interface CodexPendingPermissionHandler {
   planText?: string;
 }
 
-interface DismissedCodexPlanApproval {
-  request: AgentPermissionRequest;
-  handler: CodexPendingPermissionHandler;
-}
-
 export class CodexAppServerAgentSession implements AgentSession {
   readonly provider = CODEX_PROVIDER;
   readonly capabilities = CODEX_APP_SERVER_CAPABILITIES;
@@ -3843,7 +3838,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       throw new Error("A foreground turn is already active");
     }
 
-    const dismissedPlanApprovals = this.dismissPendingPlanApprovals("Dismissed by a new prompt");
+    this.dismissPendingPlanApprovals("Dismissed by a new prompt");
 
     try {
       await this.connect();
@@ -3882,7 +3877,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     } catch (error) {
       this.activeForegroundTurnId = null;
       this.activeClientMessageId = null;
-      this.restoreDismissedPlanApprovals(dismissedPlanApprovals);
       throw error;
     }
   }
@@ -4152,32 +4146,13 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
   }
 
-  private dismissPendingPlanApprovals(message: string): DismissedCodexPlanApproval[] {
-    const approvals = Array.from(this.pendingPermissionHandlers)
+  private dismissPendingPlanApprovals(message: string): void {
+    const requestIds = Array.from(this.pendingPermissionHandlers)
       .filter(([, pending]) => pending.kind === "plan")
-      .flatMap(([requestId, handler]) => {
-        const request = this.pendingPermissions.get(requestId);
-        return request ? [{ request, handler }] : [];
-      });
+      .map(([requestId]) => requestId);
 
-    for (const { request } of approvals) {
-      this.resolvePlanPermission(request.id, { behavior: "deny", message });
-    }
-
-    return approvals;
-  }
-
-  private restoreDismissedPlanApprovals(approvals: DismissedCodexPlanApproval[]): void {
-    const hasNewerPlanApproval = Array.from(this.pendingPermissionHandlers.values()).some(
-      (pending) => pending.kind === "plan",
-    );
-    if (hasNewerPlanApproval) return;
-
-    for (const { request, handler } of approvals) {
-      this.resolvedPermissionRequests.delete(request.id);
-      this.pendingPermissions.set(request.id, request);
-      this.pendingPermissionHandlers.set(request.id, handler);
-      this.emitEvent({ type: "permission_requested", provider: CODEX_PROVIDER, request });
+    for (const requestId of requestIds) {
+      this.resolvePlanPermission(requestId, { behavior: "deny", message });
     }
   }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -963,8 +963,8 @@ function buildPlanPermissionActions(options?: {
 }): AgentPermissionAction[] {
   const actions: AgentPermissionAction[] = [
     {
-      id: "reject",
-      label: "Reject",
+      id: "dismiss",
+      label: "Dismiss",
       behavior: "deny",
       variant: "danger",
       intent: "dismiss",
@@ -3430,6 +3430,8 @@ export class CodexAppServerAgentSession implements AgentSession {
   }
 
   private emitSyntheticPlanApprovalRequest(planText: string): void {
+    this.dismissPendingPlanApprovals("Superseded by a newer plan");
+
     const requestId = `permission-${randomUUID()}`;
     const request: AgentPermissionRequest = {
       id: requestId,
@@ -3871,6 +3873,7 @@ export class CodexAppServerAgentSession implements AgentSession {
         hasCodexConfig: turnStart.hasCodexConfig,
       });
       await this.client.request("turn/start", turnStart.params, TURN_START_TIMEOUT_MS);
+      this.dismissPendingPlanApprovals("Dismissed by a new prompt");
     } catch (error) {
       this.activeForegroundTurnId = null;
       this.activeClientMessageId = null;
@@ -4144,6 +4147,23 @@ export class CodexAppServerAgentSession implements AgentSession {
       });
     }
 
+    this.resolvePlanPermission(requestId, response);
+    if (followUpPrompt) {
+      return { followUpPrompt };
+    }
+  }
+
+  private dismissPendingPlanApprovals(message: string): void {
+    const requestIds = Array.from(this.pendingPermissionHandlers)
+      .filter(([, pending]) => pending.kind === "plan")
+      .map(([requestId]) => requestId);
+
+    for (const requestId of requestIds) {
+      this.resolvePlanPermission(requestId, { behavior: "deny", message });
+    }
+  }
+
+  private resolvePlanPermission(requestId: string, resolution: AgentPermissionResponse): void {
     this.pendingPermissionHandlers.delete(requestId);
     this.pendingPermissions.delete(requestId);
     this.resolvedPermissionRequests.add(requestId);
@@ -4151,11 +4171,8 @@ export class CodexAppServerAgentSession implements AgentSession {
       type: "permission_resolved",
       provider: CODEX_PROVIDER,
       requestId,
-      resolution: response,
+      resolution,
     });
-    if (followUpPrompt) {
-      return { followUpPrompt };
-    }
   }
 
   private emitDeniedToolCallTimelineEvent(params: {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3092,6 +3092,18 @@ interface CodexSubAgentCallState {
   childThreadIds: Set<string>;
 }
 
+interface CodexPendingPermissionHandler {
+  resolve: (value: unknown) => void;
+  kind: "command" | "file" | "question" | "mcp_elicitation" | "plan";
+  questions?: CodexQuestionPrompt[];
+  planText?: string;
+}
+
+interface DismissedCodexPlanApproval {
+  request: AgentPermissionRequest;
+  handler: CodexPendingPermissionHandler;
+}
+
 export class CodexAppServerAgentSession implements AgentSession {
   readonly provider = CODEX_PROVIDER;
   readonly capabilities = CODEX_APP_SERVER_CAPABILITIES;
@@ -3115,15 +3127,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private persistedProviderSubagentEvents: AgentStreamEvent[] = [];
   private pendingPermissions = new Map<string, AgentPermissionRequest>();
   private mcpElicitationPermissionIds = new Map<number, string>();
-  private pendingPermissionHandlers = new Map<
-    string,
-    {
-      resolve: (value: unknown) => void;
-      kind: "command" | "file" | "question" | "mcp_elicitation" | "plan";
-      questions?: CodexQuestionPrompt[];
-      planText?: string;
-    }
-  >();
+  private pendingPermissionHandlers = new Map<string, CodexPendingPermissionHandler>();
   private resolvedPermissionRequests = new Set<string>();
   private pendingAgentMessages = new Map<string, string>();
   private pendingReasoning = new Map<string, string[]>();
@@ -3861,6 +3865,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.activeForegroundTurnId = turnId;
     this.activeClientMessageId = options?.clientMessageId ?? null;
     this.currentTurnId = null;
+    const dismissedPlanApprovals = this.dismissPendingPlanApprovals("Dismissed by a new prompt");
 
     try {
       this.logTurnStartSummary({
@@ -3873,10 +3878,10 @@ export class CodexAppServerAgentSession implements AgentSession {
         hasCodexConfig: turnStart.hasCodexConfig,
       });
       await this.client.request("turn/start", turnStart.params, TURN_START_TIMEOUT_MS);
-      this.dismissPendingPlanApprovals("Dismissed by a new prompt");
     } catch (error) {
       this.activeForegroundTurnId = null;
       this.activeClientMessageId = null;
+      this.restoreDismissedPlanApprovals(dismissedPlanApprovals);
       throw error;
     }
 
@@ -4131,12 +4136,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private handlePlanPermissionResponse(params: {
     requestId: string;
     response: AgentPermissionResponse;
-    pending: {
-      resolve: (value: unknown) => void;
-      kind: "command" | "file" | "question" | "mcp_elicitation" | "plan";
-      questions?: CodexQuestionPrompt[];
-      planText?: string;
-    };
+    pending: CodexPendingPermissionHandler;
     pendingRequest: AgentPermissionRequest | null;
   }): AgentPermissionResult | void {
     const { requestId, response, pending, pendingRequest } = params;
@@ -4153,13 +4153,32 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
   }
 
-  private dismissPendingPlanApprovals(message: string): void {
-    const requestIds = Array.from(this.pendingPermissionHandlers)
+  private dismissPendingPlanApprovals(message: string): DismissedCodexPlanApproval[] {
+    const approvals = Array.from(this.pendingPermissionHandlers)
       .filter(([, pending]) => pending.kind === "plan")
-      .map(([requestId]) => requestId);
+      .flatMap(([requestId, handler]) => {
+        const request = this.pendingPermissions.get(requestId);
+        return request ? [{ request, handler }] : [];
+      });
 
-    for (const requestId of requestIds) {
-      this.resolvePlanPermission(requestId, { behavior: "deny", message });
+    for (const { request } of approvals) {
+      this.resolvePlanPermission(request.id, { behavior: "deny", message });
+    }
+
+    return approvals;
+  }
+
+  private restoreDismissedPlanApprovals(approvals: DismissedCodexPlanApproval[]): void {
+    const hasNewerPlanApproval = Array.from(this.pendingPermissionHandlers.values()).some(
+      (pending) => pending.kind === "plan",
+    );
+    if (hasNewerPlanApproval) return;
+
+    for (const { request, handler } of approvals) {
+      this.resolvedPermissionRequests.delete(request.id);
+      this.pendingPermissions.set(request.id, request);
+      this.pendingPermissionHandlers.set(request.id, handler);
+      this.emitEvent({ type: "permission_requested", provider: CODEX_PROVIDER, request });
     }
   }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3843,31 +3843,31 @@ export class CodexAppServerAgentSession implements AgentSession {
       throw new Error("A foreground turn is already active");
     }
 
-    await this.connect();
-    if (!this.client) {
-      throw new Error("Codex client not initialized");
-    }
-
-    const slashCommand = await this.resolveSlashCommandInvocation(prompt);
-    const effectivePrompt = slashCommand
-      ? await this.buildCommandPromptInput(slashCommand.commandName, slashCommand.args)
-      : prompt;
-
-    if (this.currentThreadId) {
-      await this.ensureThreadLoaded();
-    } else {
-      await this.ensureThread();
-    }
-
-    const turnStart = await this.buildTurnStartParams(effectivePrompt, options);
-
-    const turnId = this.createTurnId();
-    this.activeForegroundTurnId = turnId;
-    this.activeClientMessageId = options?.clientMessageId ?? null;
-    this.currentTurnId = null;
     const dismissedPlanApprovals = this.dismissPendingPlanApprovals("Dismissed by a new prompt");
 
     try {
+      await this.connect();
+      if (!this.client) {
+        throw new Error("Codex client not initialized");
+      }
+
+      const slashCommand = await this.resolveSlashCommandInvocation(prompt);
+      const effectivePrompt = slashCommand
+        ? await this.buildCommandPromptInput(slashCommand.commandName, slashCommand.args)
+        : prompt;
+
+      if (this.currentThreadId) {
+        await this.ensureThreadLoaded();
+      } else {
+        await this.ensureThread();
+      }
+
+      const turnStart = await this.buildTurnStartParams(effectivePrompt, options);
+      const turnId = this.createTurnId();
+      this.activeForegroundTurnId = turnId;
+      this.activeClientMessageId = options?.clientMessageId ?? null;
+      this.currentTurnId = null;
+
       this.logTurnStartSummary({
         turnId,
         thinkingOptionId: turnStart.thinkingOptionId,
@@ -3878,14 +3878,13 @@ export class CodexAppServerAgentSession implements AgentSession {
         hasCodexConfig: turnStart.hasCodexConfig,
       });
       await this.client.request("turn/start", turnStart.params, TURN_START_TIMEOUT_MS);
+      return { turnId };
     } catch (error) {
       this.activeForegroundTurnId = null;
       this.activeClientMessageId = null;
       this.restoreDismissedPlanApprovals(dismissedPlanApprovals);
       throw error;
     }
-
-    return { turnId };
   }
 
   private rememberCodexUserMessageTurn(messageId: string | null | undefined): boolean {


### PR DESCRIPTION
### Linked issue

None — reported through community feedback.

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Plan mode now presents one current proposal. Submitting a follow-up prompt dismisses the existing proposal immediately, and a newer plan replaces any stale proposal. The non-implementation action is labeled “Dismiss” to match what it does.

The bug came from synthetic plan approvals receiving a new permission ID on every planning turn without resolving the previous permission, so the client correctly rendered every accumulated approval. Prompt submission is the dismissal event, which keeps the old proposal non-actionable across slow setup, concurrent clients, provider timeouts, and failure cleanup without trying to resurrect stale state.

### How did you verify it

- Added a failing reproduction proving that two planning turns accumulated two approvals before the fix.
- Added coverage for prompt submission dismissing the current proposal even when submission later fails.
- Added concurrency coverage proving stale proposals become non-actionable before asynchronous setup and proposals emitted during submission remain intact.
- Ran the full provider test file: 114 tests passed.
- Ran `npm run typecheck`.
- Ran `npm run lint`.
- Ran `npm run format` and `npm run format:check`.
- Ran the web app against an isolated daemon built from this branch with a real Codex Plan mode session. Verified the first plan showed one Dismiss/Implement card, submitting a revision removed its actions immediately, the revised plan became the only actionable card, and explicit Dismiss removed the final actions.

The CI matrix and live daemon-to-client flow cover the affected surface; no extra verification is needed before merge.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense