### PR TITLE
Use portable Bash shebangs

### DIFF
--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -14,6 +14,10 @@ For testing rules, see [testing.md](testing.md).
 - **`interface`** over `type` when both work.
 - **No `index.ts` barrel files** that only re-export — they create indirection and circular-dep risk. Import from the source.
 
+## Shell scripts
+
+- Bash scripts always use `#!/usr/bin/env bash`. Never hard-code `/bin/bash` or `/usr/bin/bash`; those paths are not portable to environments such as NixOS.
+
 ## Comments and noise
 
 - Delete any comment where removing it loses zero information. Comments explain _why_, not _what_.

--- a/packages/desktop/scripts/dev.sh
+++ b/packages/desktop/scripts/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/dev-daemon.sh
+++ b/scripts/dev-daemon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/dev-home.sh
+++ b/scripts/dev-home.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 default_dev_paseo_root() {
   git rev-parse --show-toplevel 2>/dev/null || pwd

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 exec npm run dev:server

--- a/scripts/paseo-ios-simulator-service.sh
+++ b/scripts/paseo-ios-simulator-service.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### Linked issue

Closes #2535

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo development commands executed tracked Bash scripts through a hard-coded `/bin/bash` shebang. NixOS does not provide that path, so commands such as `npm run cli -- --help` failed before Paseo could start.

This changes every affected Bash entrypoint to `#!/usr/bin/env bash`, allowing the interpreter to resolve through `PATH`, and records that portability requirement in the coding standards.

### How did you verify it

Reproduced on NixOS 26.11pre-git before the change:

```text
> ./scripts/dev-home.sh npx tsx packages/cli/src/index.js --help
sh: ./scripts/dev-home.sh: /bin/bash: bad interpreter: No such file or directory
```

After the change:

- `npm run cli -- --help` printed the complete CLI help successfully.
- `npm run cli -- --version` printed `0.2.3`.
- `bash -n` passed for all six changed shell entrypoints.
- The isolated daemon health test passed: `npx vitest run packages/server/src/server/bootstrap.smoke.test.ts --bail=1 -t 'starts and serves health endpoint'`.
- `npm run build:server` passed.
- `npm run typecheck` passed.
- `npm run lint` passed with zero warnings and errors.
- `npm run format` completed successfully.

No UI surfaces changed, so screenshots are not applicable.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (not applicable; no UI changes)
- [x] Tests added or updated where it made sense
