### PR TITLE
fix(pi): use get_available_commands RPC name for OMP compatibility

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -1398,7 +1398,7 @@ describe("PiRpcAgentClient", () => {
     ]);
   });
 
-  test("lists Pi compact even when RPC get_commands omits built-in slash commands", async () => {
+  test("lists Pi compact even when RPC get_available_commands omits built-in slash commands", async () => {
     const { pi, session } = await createSession();
     pi.latestSession().commands = [
       { name: "review", description: "Review changes", source: "extension" },
@@ -1418,7 +1418,7 @@ describe("PiRpcAgentClient", () => {
     });
   });
 
-  test("preserves known argument hints when RPC get_commands returns built-in slash commands", async () => {
+  test("preserves known argument hints when RPC get_available_commands returns built-in slash commands", async () => {
     const { pi, session } = await createSession();
     pi.latestSession().commands = [
       { name: "compact", description: "Compact from RPC", source: "extension" },

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1208,7 +1208,7 @@ function createRuntime(logger: Logger, runtimeSettings?: ProviderRuntimeSettings
     logger,
     runtimeSettings,
     command: [PI_BINARY_COMMAND],
-    commandsRpcName: "get_commands",
+    commandsRpcName: "get_available_commands",
   });
 }
 

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
@@ -242,7 +242,7 @@ describe("PiCliRuntime", () => {
     expect(events).toEqual([{ type: "turn_start" }]);
   });
 
-  test("lists commands through the default Pi get_commands RPC", async () => {
+  test("lists commands through the default Pi get_available_commands RPC", async () => {
     const child = createPiChild();
     const commandTypes: string[] = [];
     replyToCommands(child, (command) => {
@@ -256,7 +256,7 @@ describe("PiCliRuntime", () => {
     await expect(session.getCommands()).resolves.toEqual([
       { name: "review", description: "Review changes", source: "extension" },
     ]);
-    expect(commandTypes).toEqual(["get_commands"]);
+    expect(commandTypes).toEqual(["get_available_commands"]);
   });
 
   test("keeps unicode line separators inside one JSONL record", async () => {

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -28,7 +28,7 @@ import type {
 const DEFAULT_PI_COMMAND: [string, ...string[]] = [
   process.env.PI_COMMAND ?? process.env.PI_ACP_PI_COMMAND ?? "pi",
 ];
-const DEFAULT_COMMANDS_RPC_NAME = "get_commands";
+const DEFAULT_COMMANDS_RPC_NAME = "get_available_commands";
 
 /**
  * Pi RPC timeout policy:


### PR DESCRIPTION
The Pi CLI runtime used `get_commands` which OMP renamed to `get_available_commands`. This caused slash commands and skills to fail loading with OMP. OMP returns an error without an `id` field for unknown commands, which caused Paseo to time out after 30s instead of failing fast.

Fixes #1692