### PR TITLE
Pin paseo-committee to Opus 5 at xhigh

### DIFF
--- a/skills/paseo-committee/SKILL.md
+++ b/skills/paseo-committee/SKILL.md
@@ -16,14 +16,16 @@ The purpose is to step back, not double down. The committee may propose a comple
 
 Read the **paseo** skill. Before choosing committee members, read `~/.paseo/orchestration-preferences.json` unless the user explicitly named providers in this request. Do not create committee agents until you have read it.
 
-Contrast is the point of a committee, so pick across providers deliberately using the configured preferences rather than hardcoded defaults.
+The Claude seat is pinned to `claude/claude-opus-5` with `xhigh` thinking unless the user explicitly overrides it. Verify that exact model is available before creating the committee. If it is unavailable, stop and ask the user; never substitute Opus 4.8.
+
+Contrast is the point of a committee, so use the configured preferences to select the other provider.
 
 ## Composition
 
-Two members with different reasoning styles, selected from orchestration preferences:
+Two members with different reasoning styles:
 
-- one planning/research-strength provider
-- one contrasting high-reasoning provider
+- Claude `claude/claude-opus-5` with `xhigh` thinking
+- one contrasting high-reasoning provider selected from orchestration preferences
 
 Override only when the user explicitly asks for different members.
 


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [x] Docs

### What does this PR do

Pins the Claude seat in `paseo-committee` to `claude/claude-opus-5` with `xhigh` thinking while leaving the contrasting seat preference-driven.

The skill now verifies that exact model before creating the committee and stops for user input instead of silently substituting Opus 4.8. This removes the underspecified fallback that previously selected the provider default when orchestration preferences were absent.

### How did you verify it

- Fresh-context baseline selected Opus 4.8 with the previous skill.
- Fresh-context check with the updated skill stopped instead of substituting 4.8 when Opus 5 was unavailable.
- `npm run build:server`
- `npm run format:check -- skills/paseo-committee/SKILL.md`
- `npm run lint`
- `npm run typecheck`
- `npx vitest run packages/server/src/server/agent/providers/claude/models.test.ts --bail=1` — 33 tests passed.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
