### PR TITLE
fix(server): re-probe a provider when it is enabled

### DIFF
--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -989,18 +989,12 @@ describe("ProviderSnapshotManager applyMutableProviderConfig", () => {
       manager.destroy();
     }
   });
+
   test("re-enabling a provider clears the disabled entry's unavailable verdict", async () => {
     const cwd = "/tmp/project";
-    const isAvailable = vi.fn(async () => true);
-    const fetchCatalog = vi.fn(async () => ({
-      models: [
-        { provider: "codex", id: "gpt-5.4-mini", label: "GPT 5.4 Mini" },
-      ] as AgentModelDefinition[],
-      modes: [] as AgentMode[],
-    }));
     const manager = new ProviderSnapshotManager({
       logger: createTestLogger(),
-      extraClients: { codex: createExtraClient("codex", { isAvailable, fetchCatalog }) },
+      extraClients: { codex: createExtraClient("codex", { isAvailable: async () => true }) },
     });
     try {
       const [warm] = await manager.listProviders({ cwd, providers: ["codex"], wait: true });
@@ -1014,16 +1008,69 @@ describe("ProviderSnapshotManager applyMutableProviderConfig", () => {
 
       manager.applyMutableProviderConfig({ codex: { enabled: true } });
 
-      // The disabled entry's `unavailable` must not survive re-enabling: the
-      // provider has no verdict under the new configuration, so it reads as
-      // `loading` until a probe produces one.
+      // Read synchronously, before the probe scheduled by the re-enable resolves:
+      // the disabled entry's `unavailable` must not have survived the transition.
       expect(manager.getSnapshot(cwd).find((entry) => entry.provider === "codex")).toMatchObject({
         status: "loading",
         enabled: true,
       });
+    } finally {
+      manager.destroy();
+    }
+  });
 
-      const [reprobed] = await manager.listProviders({ cwd, providers: ["codex"], wait: true });
-      expect(reprobed).toMatchObject({ provider: "codex", status: "ready", enabled: true });
+  test("re-enabling a provider probes it without waiting for a snapshot read", async () => {
+    const cwd = "/tmp/project";
+    const isAvailable = vi.fn(async () => true);
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      extraClients: { codex: createExtraClient("codex", { isAvailable }) },
+    });
+    try {
+      await manager.listProviders({ cwd, providers: ["codex"], wait: true });
+      expect(isAvailable).toHaveBeenCalledTimes(1);
+
+      manager.applyMutableProviderConfig({ codex: { enabled: false } });
+      manager.applyMutableProviderConfig({ codex: { enabled: true } });
+
+      // No read in between: the probe has to come from applyMutableProviderConfig
+      // itself, otherwise the entry would sit at `loading` until something else
+      // happened to warm it.
+      await vi.waitFor(() => {
+        expect(isAvailable).toHaveBeenCalledTimes(2);
+      });
+      expect(manager.getSnapshot(cwd).find((entry) => entry.provider === "codex")).toMatchObject({
+        status: "ready",
+        enabled: true,
+      });
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("a configuration change does not probe providers it did not enable", async () => {
+    const cwd = "/tmp/project";
+    const codexAvailable = vi.fn(async () => true);
+    const claudeAvailable = vi.fn(async () => true);
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      extraClients: {
+        codex: createExtraClient("codex", { isAvailable: codexAvailable }),
+        claude: createExtraClient("claude", { isAvailable: claudeAvailable }),
+      },
+    });
+    try {
+      await manager.listProviders({ cwd, providers: ["codex"], wait: true });
+      expect(codexAvailable).toHaveBeenCalledTimes(1);
+      const claudeCallsBefore = claudeAvailable.mock.calls.length;
+
+      manager.applyMutableProviderConfig({ codex: { enabled: false } });
+      manager.applyMutableProviderConfig({ codex: { enabled: true } });
+
+      await vi.waitFor(() => {
+        expect(codexAvailable).toHaveBeenCalledTimes(2);
+      });
+      expect(claudeAvailable).toHaveBeenCalledTimes(claudeCallsBefore);
     } finally {
       manager.destroy();
     }

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -989,6 +989,45 @@ describe("ProviderSnapshotManager applyMutableProviderConfig", () => {
       manager.destroy();
     }
   });
+  test("re-enabling a provider clears the disabled entry's unavailable verdict", async () => {
+    const cwd = "/tmp/project";
+    const isAvailable = vi.fn(async () => true);
+    const fetchCatalog = vi.fn(async () => ({
+      models: [
+        { provider: "codex", id: "gpt-5.4-mini", label: "GPT 5.4 Mini" },
+      ] as AgentModelDefinition[],
+      modes: [] as AgentMode[],
+    }));
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      extraClients: { codex: createExtraClient("codex", { isAvailable, fetchCatalog }) },
+    });
+    try {
+      const [warm] = await manager.listProviders({ cwd, providers: ["codex"], wait: true });
+      expect(warm).toMatchObject({ provider: "codex", status: "ready", enabled: true });
+
+      manager.applyMutableProviderConfig({ codex: { enabled: false } });
+      expect(manager.getSnapshot(cwd).find((entry) => entry.provider === "codex")).toMatchObject({
+        status: "unavailable",
+        enabled: false,
+      });
+
+      manager.applyMutableProviderConfig({ codex: { enabled: true } });
+
+      // The disabled entry's `unavailable` must not survive re-enabling: the
+      // provider has no verdict under the new configuration, so it reads as
+      // `loading` until a probe produces one.
+      expect(manager.getSnapshot(cwd).find((entry) => entry.provider === "codex")).toMatchObject({
+        status: "loading",
+        enabled: true,
+      });
+
+      const [reprobed] = await manager.listProviders({ cwd, providers: ["codex"], wait: true });
+      expect(reprobed).toMatchObject({ provider: "codex", status: "ready", enabled: true });
+    } finally {
+      manager.destroy();
+    }
+  });
 
   test("removes startup provider overrides from the live registry", () => {
     const manager = new ProviderSnapshotManager({

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -400,8 +400,22 @@ export class ProviderSnapshotManager {
       this.baseProviderOverrides,
       mutableProviders,
     );
+    const wasEnabled: Partial<Record<AgentProvider, boolean>> = {};
+    for (const provider of this.getProviderIds()) {
+      wasEnabled[provider] = this.providerRegistry[provider]?.enabled ?? false;
+    }
     this.providerRegistry = this.buildRegistry();
     this.providerClients = { ...this.extraClients } as Record<AgentProvider, AgentClient>;
+
+    // Only providers this update actually switched on need a probe. Warming every
+    // unresolved entry instead would launch provider binaries and catalog requests
+    // for providers the update never touched.
+    const newlyEnabled: Partial<Record<AgentProvider, true>> = {};
+    for (const provider of this.getProviderIds()) {
+      if ((this.providerRegistry[provider]?.enabled ?? false) && !wasEnabled[provider]) {
+        newlyEnabled[provider] = true;
+      }
+    }
 
     const awaitingProbe: Array<{ cwd: string; providers: AgentProvider[] }> = [];
     for (const cwd of this.snapshots.keys()) {
@@ -409,7 +423,7 @@ export class ProviderSnapshotManager {
       const reconciled = this.reconcileSnapshotForRegistry(cwd);
       this.snapshots.set(cwd, reconciled);
       const providers = Array.from(reconciled.values())
-        .filter((entry) => entry.enabled && entry.status === "loading")
+        .filter((entry) => newlyEnabled[entry.provider] === true && entry.status === "loading")
         .map((entry) => entry.provider);
       if (providers.length > 0) {
         awaitingProbe.push({ cwd, providers });
@@ -418,9 +432,8 @@ export class ProviderSnapshotManager {
     }
 
     // Enabling a provider is the moment it becomes usable again, so it has to be
-    // the moment it gets probed. Without this the reconciled entry sits at
-    // `loading` until something else happens to force a refresh, which is what
-    // left working providers reading as unavailable for the CLI (#2456).
+    // the moment it gets probed. Otherwise the reconciled entry sits at `loading`
+    // until a later read happens to warm it (#2456).
     for (const { cwd, providers } of awaitingProbe) {
       const target = isGlobalProviderSnapshotKey(cwd)
         ? createGlobalSnapshotTarget()

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -403,10 +403,34 @@ export class ProviderSnapshotManager {
     this.providerRegistry = this.buildRegistry();
     this.providerClients = { ...this.extraClients } as Record<AgentProvider, AgentClient>;
 
+    const awaitingProbe: Array<{ cwd: string; providers: AgentProvider[] }> = [];
     for (const cwd of this.snapshots.keys()) {
       this.providerLoads.delete(cwd);
-      this.snapshots.set(cwd, this.reconcileSnapshotForRegistry(cwd));
+      const reconciled = this.reconcileSnapshotForRegistry(cwd);
+      this.snapshots.set(cwd, reconciled);
+      const providers = Array.from(reconciled.values())
+        .filter((entry) => entry.enabled && entry.status === "loading")
+        .map((entry) => entry.provider);
+      if (providers.length > 0) {
+        awaitingProbe.push({ cwd, providers });
+      }
       this.emitChange(cwd);
+    }
+
+    // Enabling a provider is the moment it becomes usable again, so it has to be
+    // the moment it gets probed. Without this the reconciled entry sits at
+    // `loading` until something else happens to force a refresh, which is what
+    // left working providers reading as unavailable for the CLI (#2456).
+    for (const { cwd, providers } of awaitingProbe) {
+      const target = isGlobalProviderSnapshotKey(cwd)
+        ? createGlobalSnapshotTarget()
+        : createWorkspaceSnapshotTarget(cwd);
+      void this.warmUp(target, providers).catch((error: unknown) => {
+        this.logger.warn(
+          { err: error, cwd, providers },
+          "Failed to probe providers after a configuration change",
+        );
+      });
     }
 
     return this.getAgentManagerProviderState();
@@ -601,12 +625,17 @@ export class ProviderSnapshotManager {
         defaultModeId: definition?.defaultModeId ?? null,
       };
 
-      if (!definition?.enabled || !current || current.status === "loading") {
-        entries.set(provider, {
-          ...metadata,
-          status: "unavailable",
-          enabled: definition?.enabled ?? true,
-        });
+      if (!definition?.enabled) {
+        entries.set(provider, { ...metadata, status: "unavailable", enabled: false });
+        continue;
+      }
+
+      // An enabled provider carries a verdict only once it has been probed under
+      // the current configuration. Inheriting the previous entry's `unavailable`
+      // across a disable → enable cycle reported a working provider as broken;
+      // "not probed yet" is `loading` (#2456).
+      if (!current || current.status === "loading" || !current.enabled) {
+        entries.set(provider, { ...metadata, status: "loading" });
         continue;
       }
 


### PR DESCRIPTION
Fixes #2456.

## The problem

Disabling a provider and re-enabling it leaves the provider reading as `unavailable` while `Enabled`, until something unrelated forces a probe. `paseo provider ls` shows it as unavailable and `paseo provider models <id>` refuses, even though the binary resolves and works — as the issue shows, a single `provider_diagnostic_request` flips the same provider straight to `Ready` with a full model list, with nothing about the environment having changed.

## Why

Two things, both in `ProviderSnapshotManager`.

`reconcileSnapshotForRegistry` resets an entry only when the provider is disabled, missing, or still loading:

```ts
if (!definition?.enabled || !current || current.status === "loading") {
  entries.set(provider, { ...metadata, status: "unavailable", enabled: definition?.enabled ?? true });
  continue;
}
entries.set(provider, { ...current, ...metadata });   // ← re-enabled lands here
```

While the provider is disabled its entry becomes `{ status: "unavailable", enabled: false }`. On re-enable, `definition.enabled` is `true`, `current` exists, and its status is `unavailable` rather than `loading` — so the guard does not fire and the entry falls through to the merge, which carries `status: "unavailable"` forward and only flips `enabled` to `true`. That single combination is the reported state.

Second, nothing probes afterwards, and the read path cannot recover it either. `applyMutableProviderConfig` clears `providerLoads` so a *future* load would re-probe, but never triggers one. Reads do warm — `getSnapshotForTarget` calls `warmUp` — but only for entries `resolveProvidersToWarm` considers eligible, and that is `status === "loading"`. An `unavailable` entry is never warm-eligible, so the stale verdict survives every `provider ls` until a diagnostic, refresh, or restart forces the issue.

## The change

An enabled provider that has not been probed under the current configuration is `loading`, not `unavailable` — the disabled entry's verdict no longer survives the transition. `applyMutableProviderConfig` then warms up exactly those entries, so enabling a provider is also the moment it gets probed.

`loading` is an existing `ProviderStatus`, and `provider ls` already renders non-`ready` statuses verbatim, so this also gives the CLI the "not probed yet" vs "unavailable" distinction the issue asks for as a minimum.

Disabled providers still report `unavailable`, unchanged.

## Repro

Deterministic, as the added unit test:

1. warm a provider to `ready`
2. `applyMutableProviderConfig({ codex: { enabled: false } })` → `unavailable` / disabled, correct
3. `applyMutableProviderConfig({ codex: { enabled: true } })`

Before: `{ status: "unavailable", enabled: true }` — the reported state.
After: `{ status: "loading", enabled: true }`, and the probe that follows resolves it to `ready`.

## Testing

macOS 26.4, arm64, Node 24.16.0. **Daemon-side only — no UI surface, so no screenshots apply.** I have not exercised iOS/Android/desktop, because nothing in this change reaches them.

```
npx vitest run packages/server/src/server/agent/provider-snapshot-manager.test.ts
  Test Files  1 passed (1)
       Tests  44 passed (44)          # 43 pre-existing + 1 new

npx vitest run packages/server/src/server/bootstrap-provider-availability.test.ts   → 1 passed
npx vitest run packages/protocol/src/messages.providers-snapshot.test.ts            → 6 passed

npm run typecheck     → exit 0
npm run lint          → 0 warnings, 0 errors
npm run format:check  → all matched files use the correct format
```

The new test fails on `main` with exactly the reported symptom, which is what pins the regression:

```
AssertionError: expected { provider: 'codex', …(8) } to match object { status: 'loading', enabled: true }
-   "status": "loading",
+   "status": "unavailable",
```

Per `AGENTS.md` I ran only the affected test files rather than the full suite.

## Notes

The issue mentions two smaller observations from the same session — the status column conflating *disabled* with *unavailable*, and hand-edits to `~/.paseo/config.json` not reaching a running daemon. Both are separate from this root cause and are left alone here to keep the change focused; happy to open follow-ups if you want them addressed.

