### PR TITLE
fix(nix): shrink desktop runtime output

### DIFF
--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -132,6 +132,22 @@ buildNpmPackage rec {
     mkdir -p $out/share/paseo-desktop/packages/app
     cp -a packages/app/dist $out/share/paseo-desktop/packages/app/
 
+    for runtime_path in \
+      packages/desktop/dist/main.js \
+      packages/desktop/dist/preload.js \
+      packages/desktop/dist/features/browser-keyboard/guest-preload.js \
+      packages/desktop/package.json; do
+      if [ ! -e "$out/share/paseo-desktop/$runtime_path" ]; then
+        echo "desktop runtime trace omitted $runtime_path" >&2
+        exit 1
+      fi
+    done
+
+    if [ -e $out/share/paseo-desktop/node_modules/electron ]; then
+      echo "desktop runtime trace included npm Electron" >&2
+      exit 1
+    fi
+
     # Skills directory referenced at runtime by some agents
     if [ -d skills ]; then
       cp -a skills $out/share/paseo-desktop/

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -5,6 +5,7 @@
   nodejs_22,
   python3,
   makeWrapper,
+  autoPatchelfHook,
   copyDesktopItems,
   makeDesktopItem,
   electron,
@@ -69,9 +70,15 @@ buildNpmPackage rec {
     python3 # for node-gyp (node-pty)
     makeWrapper
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libuv ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libuv
+    stdenv.cc.cc.lib # libstdc++ for sherpa-onnx prebuilt binaries
+  ];
 
   dontNpmBuild = true;
 
@@ -108,19 +115,22 @@ buildNpmPackage rec {
 
     mkdir -p $out/share/paseo-desktop $out/bin
 
-    # Preserve the monorepo layout so main.js's dev-mode path resolution
-    # (`__dirname/../../app/dist`, `__dirname/../assets/icon.png`) works
-    # without patching: invoked unpackaged via `electron path/to/main.js`,
-    # `app.isPackaged` is false, so these relative paths are used.
-    #
-    # Copy the entire packages/ tree (not just built artifacts) because npm
-    # creates workspace symlinks from node_modules/@getpaseo/* into packages/*.
-    # Missing any workspace package leaves dangling symlinks and fails the
-    # noBrokenSymlinks output check. The cleanSourceWith filter above already
-    # drops the big platform-specific things (android/ios, website, tests).
+    # Materialize only the desktop and daemon runtime graphs. Copying the
+    # complete monorepo used to ship every build-time dependency (including
+    # Electron, Expo tooling, and cross-platform builder binaries), making the
+    # desktop output larger than 2 GiB.
+    PASEO_TRACE_DESKTOP=1 node scripts/trace-daemon.mjs > desktop-files.txt
+
+    while IFS= read -r path; do
+      [ -z "$path" ] && continue
+      mkdir -p "$out/share/paseo-desktop/$(dirname "$path")"
+      cp -a "$path" "$out/share/paseo-desktop/$path"
+    done < desktop-files.txt
+
+    # Keep the same unpackaged monorepo layout expected by main.js.
     cp package.json $out/share/paseo-desktop/
-    cp -a packages $out/share/paseo-desktop/
-    cp -a node_modules $out/share/paseo-desktop/
+    mkdir -p $out/share/paseo-desktop/packages/app
+    cp -a packages/app/dist $out/share/paseo-desktop/packages/app/
 
     # Skills directory referenced at runtime by some agents
     if [ -d skills ]; then

--- a/scripts/trace-daemon.mjs
+++ b/scripts/trace-daemon.mjs
@@ -105,7 +105,7 @@ const { fileList, warnings } = await nodeFileTrace(entries, {
     "**/*.e2e.test.js",
     // The Nix desktop package runs under nixpkgs' Electron. Tracing the npm
     // package would duplicate the complete Electron distribution in $out.
-    ...(traceDesktop ? ["electron/**"] : []),
+    ...(traceDesktop ? ["node_modules/electron/**"] : []),
   ],
 });
 

--- a/scripts/trace-daemon.mjs
+++ b/scripts/trace-daemon.mjs
@@ -28,14 +28,24 @@ const { sherpaPlatformPackageName } = await import(
   ).href
 );
 
+const traceDesktop = process.env.PASEO_TRACE_DESKTOP === "1";
+
 // Daemon entry points. Workers forked into their own Node processes have
 // independent require trees; nft does not follow fork boundaries, so trace
-// them separately.
+// them separately. The desktop derivation opts into tracing its Electron main
+// process and preloads as well.
 const entries = [
   "packages/cli/dist/index.js",
   "packages/server/dist/scripts/supervisor-entrypoint.js",
   "packages/server/dist/server/terminal/terminal-worker-process.js",
   "packages/server/dist/server/server/speech/providers/local/worker-process.js",
+  ...(traceDesktop
+    ? [
+        "packages/desktop/dist/main.js",
+        "packages/desktop/dist/preload.js",
+        "packages/desktop/dist/features/browser-keyboard/guest-preload.js",
+      ]
+    : []),
 ];
 
 // Files read at runtime via fs APIs rather than `require`. nft only
@@ -59,6 +69,16 @@ const additionalInputs = [
   // Copy the wrapper plus the host platform package explicitly.
   "node_modules/sherpa-onnx-node/**",
   `node_modules/${sherpaPlatformPackageName()}/**`,
+  ...(traceDesktop
+    ? [
+        // The unpackaged Nix launcher resolves these beside desktop/dist.
+        "packages/desktop/package.json",
+        "packages/desktop/assets/**",
+        // resolveExternalCliEntrypoint() looks up the workspace through this
+        // link at runtime; nft traces the target files but not the link.
+        "node_modules/@getpaseo/cli",
+      ]
+    : []),
 ];
 
 // Trace.
@@ -83,6 +103,9 @@ const { fileList, warnings } = await nodeFileTrace(entries, {
     // tries to walk into them via index files. Belt and suspenders.
     "**/*.test.js",
     "**/*.e2e.test.js",
+    // The Nix desktop package runs under nixpkgs' Electron. Tracing the npm
+    // package would duplicate the complete Electron distribution in $out.
+    ...(traceDesktop ? ["electron/**"] : []),
   ],
 });
 


### PR DESCRIPTION
### Linked issue

Closes #2552

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

The Nix desktop derivation copied the complete monorepo `packages/` tree and
root `node_modules` into its output. That included build-only Expo, React
Native, Electron Builder, Cloudflare, lint, typecheck, and cross-platform
binary packages, producing a 2.15 GB NAR (2.4 GB on disk).

This extends the existing `@vercel/nft` daemon tracer with an opt-in desktop
mode. The desktop derivation now materializes the combined desktop and daemon
runtime graph, adds the renderer export and runtime assets, and excludes npm's
Electron distribution because the launcher already uses nixpkgs Electron.
The explicit CLI workspace link covers the one dynamic package lookup that nft
cannot infer.

The rebuilt output is 74.4 MB as a NAR and 79 MB on disk. Its recursive closure
is 1.39 GB, down from 3.66 GB; most of the remaining closure is nixpkgs Electron
and its GTK/multimedia dependencies.

### How did you verify it

- Reproduced the old output size from the installed derivation:
  - `narSize`: `2,152,264,536`
  - recursive closure: `3,662,136,096`
  - `du -sh`: `2.4G`
- Rebased the branch onto current upstream `main`.
- Built the result with `nix build --no-link --print-out-paths .#desktop`.
- Measured the new result:
  - `narSize`: `74,435,256`
  - recursive closure: `1,385,303,568`
  - `du -sh`: `79M`
- Confirmed the output has no broken symlinks with `find -L`.
- Resolved the desktop's runtime package entry points from the built output,
  including `@getpaseo/server`, `@getpaseo/cli/bin/paseo`,
  `electron-log/main`, `electron-updater`, `ws`, `zod`, and
  `builder-util-runtime`.
- Ran the bundled CLI directly with Node and through Electron's
  `ELECTRON_RUN_AS_NODE` path; both reported `0.2.3`.
- `npm run typecheck --workspace=@getpaseo/desktop` passes.
- `npm run lint` passes with zero warnings or errors.
- `npm run format:check` passes.

The repository-wide `npm run typecheck` currently reports unrelated errors in
the Expo audio workspace and current-main server/CLI feature types. This change
does not touch TypeScript sources; the affected desktop workspace typecheck
passes.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform (N/A: packaging only)
- [x] Tests added or updated where it made sense (N/A: verified built closure and runtime entry points)
