### PR TITLE
build(android): add Nix toolchain and release runner

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,7 @@ on:
       - "packages/relay/**"
       - "packages/cli/**"
       - "scripts/build-daemon-web-ui.mjs"
+      - "scripts/build-android-apk.sh"
       - "scripts/update-nix.sh"
       - "scripts/fix-lockfile.mjs"
       - ".github/workflows/nix.yml"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -46,6 +46,23 @@ jobs:
       - name: Update lockfile + Nix hash if stale
         run: ./scripts/update-nix.sh
 
+      # Realizing .#android-release-runner would pull the whole Android
+      # SDK/NDK closure (~7.5 GB), which does not fit a GitHub-hosted runner.
+      # Evaluating it is enough to catch the failure mode that matters:
+      # androidenv rejects unknown build-tools/platform/NDK/CMake versions at
+      # eval time ("The version X is missing in package build-tools"), so SDK
+      # composition regressions fail here without downloading anything.
+      - name: Check Android release runner evaluates
+        run: nix build --dry-run .#android-release-runner
+
+      # writeShellApplication shellchecks the runner script when it builds,
+      # which the eval-only check above skips, so lint the script directly.
+      # It has no shebang because flake.nix splices it into the wrapper.
+      - name: Lint Android release script
+        run: |
+          bash -n scripts/build-android-apk.sh
+          nix run nixpkgs#shellcheck -- --shell=bash scripts/build-android-apk.sh
+
       - name: Build Nix package
         run: nix build .#default -o result
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -104,6 +104,24 @@ Run `nix run .#android-release -- --help` for the full interface. Set
 invoking the app outside the repository root, or pass additional Gradle
 arguments after `--`.
 
+The output directory is pruned of `*.apk` files before the new artifacts land,
+so switching `--architecture` or `--fdroid` between runs cannot leave a stale
+APK sitting beside the current one. Pruning is limited to `*.apk` files
+directly in that directory — anything else you keep there survives — and is
+skipped entirely if you point `--output` at Gradle's own output directory.
+
+### Why CI does not build the runner
+
+`.#android-release-runner` has a ~7.5 GB closure (the composed Android SDK
+alone is ~6.8 GB), so the `Nix` workflow never realizes it. It runs
+`nix build --dry-run .#android-release-runner` instead, which still catches the
+regression that actually bites: `androidenv.composeAndroidPackages` validates
+build-tools, platform, NDK, and CMake versions at **evaluation** time and fails
+with `The version X is missing in package build-tools`. The workflow separately
+shellchecks `scripts/build-android-apk.sh`, because `writeShellApplication`
+only lints it as part of the build we are skipping. Real APK builds happen in
+`android-apk-release.yml` on tags.
+
 ## Local build + install
 
 From repo root:

--- a/docs/android.md
+++ b/docs/android.md
@@ -27,7 +27,23 @@ The formula reserves three digits each for minor and patch. If either reaches `1
 
 ## Prerequisites (local dev)
 
-Local Android builds run on macOS (or Linux) and need the Android toolchain, pinned in `.tool-versions` (`java 21`, `android-sdk 21.0`) and wired up by `.mise.toml` (which derives `ANDROID_HOME` and the command-line tool paths from the `android-sdk` entry). With [mise](https://mise.jdx.dev):
+On x86_64 Linux, Nix provides the complete Android SDK, NDK, CMake, Java 21,
+Node.js 22, and Python toolchain:
+
+```bash
+nix develop .#android
+```
+
+The SDK components match Expo SDK 54 and React Native 0.81: Android platforms
+35 and 36, build-tools 35.0.0 and 36.0.0, NDK 27.1.12297006, the
+react-native-unistyles fallback NDK 27.0.12077973, and CMake 3.22.1. The Nix
+shell sets `ANDROID_HOME`, `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`, `JAVA_HOME`,
+and the NixOS-compatible AAPT2 override.
+
+Local Android builds also run on macOS (or Linux without Nix) with the Android
+toolchain pinned in `.tool-versions` (`java 21`, `android-sdk 21.0`) and wired
+up by `.mise.toml` (which derives `ANDROID_HOME` and the command-line tool
+paths from the `android-sdk` entry). With [mise](https://mise.jdx.dev):
 
 ```bash
 mise install        # java 21 + android-sdk 21.0 command-line tools
@@ -56,6 +72,37 @@ emulator @paseo     # start it; leave running
 ```
 
 Gradle auto-fetches the platform/build-tools it needs once licenses are accepted, so adjust `android-35` only if it asks for a different level.
+
+## Nix release build (x86_64 Linux)
+
+Install the JavaScript dependencies once, then build from the repository root:
+
+```bash
+npm ci
+nix run .#android-release
+```
+
+The command performs the workspace prerequisite builds, regenerates the Expo
+Android project, runs Gradle serially, and copies the resulting APKs to
+`result/android/`. Nix pins the host toolchain; npm and Gradle still populate
+their normal dependency caches.
+
+Build a single architecture by passing `--architecture`:
+
+```bash
+nix run .#android-release -- --architecture arm64-v8a
+```
+
+Use the same command for Paseo's source-only F-Droid profile:
+
+```bash
+nix run .#android-release -- --fdroid --architecture arm64-v8a
+```
+
+Run `nix run .#android-release -- --help` for the full interface. Set
+`PASEO_ANDROID_OUTPUT_DIR` to change the artifact directory, `PASEO_ROOT` when
+invoking the app outside the repository root, or pass additional Gradle
+arguments after `--`.
 
 ## Local build + install
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,86 @@
         "aarch64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      pkgsFor = system: import nixpkgs { inherit system; };
+      pkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            android_sdk.accept_license = true;
+          };
+        };
+      androidFor =
+        system:
+        let
+          pkgs = pkgsFor system;
+          buildToolsVersion = "36.0.0";
+          cmdLineToolsVersion = "19.0";
+          ndkVersion = "27.1.12297006";
+          unistylesNdkVersion = "27.0.12077973";
+          androidComposition = pkgs.androidenv.composeAndroidPackages {
+            inherit cmdLineToolsVersion;
+            platformToolsVersion = "36.0.2";
+            buildToolsVersions = [
+              "35.0.0"
+              buildToolsVersion
+            ];
+            platformVersions = [
+              "35"
+              "36"
+            ];
+            includeEmulator = false;
+            includeSources = false;
+            includeSystemImages = false;
+            includeNDK = true;
+            ndkVersions = [
+              ndkVersion
+              # react-native-unistyles does not inherit Expo's root NDK
+              # version, so AGP resolves its own default side-by-side NDK.
+              unistylesNdkVersion
+            ];
+            cmakeVersions = [ "3.22.1" ];
+          };
+          androidSdk = androidComposition.androidsdk;
+          androidHome = "${androidSdk}/libexec/android-sdk";
+          androidEnvironment = {
+            ANDROID_HOME = androidHome;
+            ANDROID_SDK_ROOT = androidHome;
+            ANDROID_NDK_HOME = "${androidHome}/ndk/${ndkVersion}";
+            JAVA_HOME = pkgs.jdk21_headless.home;
+            GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidHome}/build-tools/${buildToolsVersion}/aapt2";
+          };
+          releaseRunner = pkgs.writeShellApplication {
+            name = "paseo-android-release";
+            runtimeInputs = [
+              androidSdk
+              pkgs.coreutils
+              pkgs.findutils
+              pkgs.jdk21_headless
+              pkgs.nodejs_22
+              pkgs.python3
+            ];
+            text = ''
+              export ANDROID_HOME=${androidEnvironment.ANDROID_HOME}
+              export ANDROID_SDK_ROOT=${androidEnvironment.ANDROID_SDK_ROOT}
+              export ANDROID_NDK_HOME=${androidEnvironment.ANDROID_NDK_HOME}
+              export JAVA_HOME=${androidEnvironment.JAVA_HOME}
+              export GRADLE_OPTS=${androidEnvironment.GRADLE_OPTS}
+              export PATH=${androidHome}/platform-tools:${androidHome}/cmdline-tools/${cmdLineToolsVersion}/bin:$PATH
+
+              ${builtins.readFile ./scripts/build-android-apk.sh}
+            '';
+          };
+        in
+        {
+          inherit
+            androidEnvironment
+            androidHome
+            androidSdk
+            cmdLineToolsVersion
+            releaseRunner
+            ;
+        };
     in
     {
       packages = forAllSystems (
@@ -37,6 +116,20 @@
         }
         // nixpkgs.lib.optionalAttrs isLinux {
           desktop = pkgs.callPackage ./nix/desktop-package.nix { inherit paseo; };
+        }
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          android-sdk = (androidFor system).androidSdk;
+          android-release-runner = (androidFor system).releaseRunner;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          android-release = {
+            type = "app";
+            program = "${(androidFor system).releaseRunner}/bin/paseo-android-release";
+          };
         }
       );
 
@@ -60,6 +153,34 @@
               pkgs.python3
             ];
           };
+        }
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          android =
+            let
+              android = androidFor system;
+            in
+            pkgs.mkShell (
+              android.androidEnvironment
+              // {
+                packages = [
+                  android.androidSdk
+                  pkgs.jdk21_headless
+                  pkgs.nodejs_22
+                  pkgs.python3
+                ];
+
+                shellHook = ''
+                  export PATH=${android.androidHome}/platform-tools:${android.androidHome}/cmdline-tools/${android.cmdLineToolsVersion}/bin:$PATH
+
+                  echo "Paseo Android development shell"
+                  echo "  Node: $(node --version)"
+                  echo "  Java: $(java -version 2>&1 | head -n 1)"
+                  echo "  ANDROID_HOME: $ANDROID_HOME"
+                  echo
+                  echo "Build a release APK with: nix run .#android-release"
+                '';
+              }
+            );
         }
       );
     };

--- a/scripts/build-android-apk.sh
+++ b/scripts/build-android-apk.sh
@@ -1,0 +1,139 @@
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Build Paseo's production Android APK with the Nix-provided Android toolchain.
+
+Usage:
+  nix run .#android-release -- [options] [-- GRADLE_ARG...]
+
+Options:
+  --architecture ABI  Build one of: armeabi-v7a, arm64-v8a, x86, x86_64
+  --fdroid            Enable Paseo's source-only F-Droid build profile
+  --output DIR        Copy APKs to DIR (default: result/android)
+  -h, --help          Show this help
+
+The command expects JavaScript dependencies to have been installed with
+`npm ci`. APP_VARIANT, PASEO_FDROID_BUILD, and PASEO_ANDROID_OUTPUT_DIR can
+also be supplied through the environment.
+EOF
+}
+
+repo="${PASEO_ROOT:-$PWD}"
+architecture="${PASEO_ANDROID_ARCHITECTURE:-}"
+fdroid_build="${PASEO_FDROID_BUILD:-0}"
+output_dir="${PASEO_ANDROID_OUTPUT_DIR:-result/android}"
+gradle_args=()
+
+while (($# > 0)); do
+  case "$1" in
+    --architecture)
+      if (($# < 2)); then
+        echo "--architecture requires an ABI" >&2
+        exit 2
+      fi
+      architecture="$2"
+      shift 2
+      ;;
+    --fdroid)
+      fdroid_build=1
+      shift
+      ;;
+    --output)
+      if (($# < 2)); then
+        echo "--output requires a directory" >&2
+        exit 2
+      fi
+      output_dir="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      gradle_args=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$architecture" in
+  "" | armeabi-v7a | arm64-v8a | x86 | x86_64) ;;
+  *)
+    echo "Unsupported Android architecture: $architecture" >&2
+    exit 2
+    ;;
+esac
+
+case "$fdroid_build" in
+  0 | 1) ;;
+  *)
+    echo "PASEO_FDROID_BUILD must be 0 or 1" >&2
+    exit 2
+    ;;
+esac
+
+cd "$repo"
+
+if [[ ! -f package.json || ! -f packages/app/package.json ]]; then
+  echo "Run this command from the Paseo repository root, or set PASEO_ROOT." >&2
+  exit 1
+fi
+
+if [[ ! -x node_modules/.bin/expo ]]; then
+  echo "JavaScript dependencies are missing. Run npm ci first." >&2
+  exit 1
+fi
+
+app_variant="${APP_VARIANT:-production}"
+
+npm run build:app-deps
+npm --prefix packages/app run build:terminal-webview
+
+(
+  cd packages/app
+  CI=1 \
+    APP_VARIANT="$app_variant" \
+    PASEO_FDROID_BUILD="$fdroid_build" \
+    npx --no-install expo prebuild --platform android --clean
+
+  cd android
+
+  build_args=(
+    assembleRelease
+    --no-daemon
+    --console plain
+    --max-workers=1
+    -Dorg.gradle.parallel=false
+  )
+
+  if [[ -n "$architecture" ]]; then
+    build_args+=("-PreactNativeArchitectures=$architecture")
+  fi
+
+  APP_VARIANT="$app_variant" \
+    PASEO_FDROID_BUILD="$fdroid_build" \
+    ./gradlew "${build_args[@]}" "${gradle_args[@]}"
+)
+
+artifact_dir="packages/app/android/app/build/outputs/apk/release"
+mapfile -d '' apks < <(find "$artifact_dir" -maxdepth 1 -type f -name '*.apk' -print0)
+
+if ((${#apks[@]} == 0)); then
+  echo "No release APKs were produced in $artifact_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$output_dir"
+for apk in "${apks[@]}"; do
+  destination="$output_dir/$(basename "$apk")"
+  cp "$apk" "$destination"
+  echo "$destination"
+done

--- a/scripts/build-android-apk.sh
+++ b/scripts/build-android-apk.sh
@@ -10,7 +10,9 @@ Usage:
 Options:
   --architecture ABI  Build one of: armeabi-v7a, arm64-v8a, x86, x86_64
   --fdroid            Enable Paseo's source-only F-Droid build profile
-  --output DIR        Copy APKs to DIR (default: result/android)
+  --output DIR        Copy APKs to DIR (default: result/android). Existing
+                      *.apk files directly in DIR are removed first so the
+                      directory only describes the build that just ran.
   -h, --help          Show this help
 
 The command expects JavaScript dependencies to have been installed with
@@ -132,8 +134,27 @@ if ((${#apks[@]} == 0)); then
 fi
 
 mkdir -p "$output_dir"
+
+artifact_dir_path="$(cd "$artifact_dir" && pwd -P)"
+output_dir_path="$(cd "$output_dir" && pwd -P)"
+
+if [[ "$output_dir_path" == "$artifact_dir_path" ]]; then
+  # The caller pointed --output at Gradle's own output directory, so the APKs
+  # are already in place. Never prune here: these are the files we just built.
+  for apk in "${apks[@]}"; do
+    echo "$apk"
+  done
+  exit 0
+fi
+
+# Reusing an output directory across builds that differ in architecture or
+# variant otherwise leaves the previous run's APKs sitting next to the current
+# ones, making the artifact set ambiguous. Prune only *.apk files directly in
+# the directory so unrelated files a caller keeps there are left alone.
+find "$output_dir_path" -maxdepth 1 -type f -name '*.apk' -delete
+
 for apk in "${apks[@]}"; do
-  destination="$output_dir/$(basename "$apk")"
+  destination="$output_dir_path/$(basename "$apk")"
   cp "$apk" "$destination"
   echo "$destination"
 done


### PR DESCRIPTION
## Summary

- compose a pinned Android SDK, NDK, CMake, JDK, and Node toolchain with Nix
- expose nix develop .#android and nix run .#android-release for local and CI builds
- support ABI selection and the source-only F-Droid build profile
- document the workflow and include the runner in Nix CI path filtering

## Verification

- nix build .#android-release-runner
- verified Node, JDK, sdkmanager, adb, AAPT2, CMake, and both required NDKs in nix develop .#android
- built an arm64 F-Droid-profile release APK through the Nix environment and verified its ABI and signature
- npm run format
- npm run build:server
- npm run typecheck
- npm run lint