### PR TITLE
Build Paseo Desktop from the Nix flake on macOS

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -104,3 +104,27 @@ jobs:
 
       - name: Build Nix desktop package
         run: nix build .#desktop -o result-desktop
+
+  build-desktop-darwin:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build Nix desktop package
+        run: nix build .#desktop -o result-desktop
+
+      - name: Verify macOS application bundle
+        run: |
+          set -euo pipefail
+
+          app="result-desktop/Applications/Paseo.app"
+          test -x "$app/Contents/MacOS/Paseo"
+          test -L result-desktop/bin/paseo-desktop
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")" = "sh.paseo.desktop"
+          find "$app" -name Info.plist -print0 | xargs -0 -n 1 plutil -lint

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,6 +21,19 @@ Root checkout dev is intentionally split across terminals:
 
 `npm run dev` is only a shorthand for `npm run dev:server`. Keep `127.0.0.1:6767` for the packaged app and production-style `~/.paseo` state.
 
+## Nix desktop package
+
+The flake exposes `packages.<system>.desktop` on Linux and macOS:
+
+```bash
+nix build .#desktop
+```
+
+Linux produces the `paseo-desktop` launcher and desktop entry. macOS produces
+`Applications/Paseo.app` plus the `paseo-desktop` launcher. Both use the nixpkgs
+Electron runtime and the checkout's built daemon, client, and renderer rather
+than downloading a published desktop release.
+
 ### PASEO_HOME
 
 `PASEO_HOME` is the directory that holds runtime state (agents, worktrees, workspace config, sockets, daemon log). Resolution rules:

--- a/flake.nix
+++ b/flake.nix
@@ -26,16 +26,10 @@
         let
           pkgs = pkgsFor system;
           paseo = pkgs.callPackage ./nix/package.nix { };
-          isLinux = nixpkgs.lib.elem system [
-            "x86_64-linux"
-            "aarch64-linux"
-          ];
         in
         {
           default = paseo;
           paseo = paseo;
-        }
-        // nixpkgs.lib.optionalAttrs isLinux {
           desktop = pkgs.callPackage ./nix/desktop-package.nix { inherit paseo; };
         }
       );

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -16,57 +16,16 @@
   # the upstream hash via `paseo.override { npmDepsHash = "..."; }`.
   paseo,
 }:
-
-let
-  version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
-  darwinInfoPlist = builtins.toFile "Paseo-Info.plist" (
-    lib.generators.toPlist { escape = true; } {
-      CFBundleDisplayName = "Paseo";
-      CFBundleExecutable = "Paseo";
-      CFBundleIconFile = "Paseo.icns";
-      CFBundleIdentifier = "sh.paseo.desktop";
-      CFBundleInfoDictionaryVersion = "6.0";
-      CFBundleName = "Paseo";
-      CFBundlePackageType = "APPL";
-      CFBundleShortVersionString = version;
-      CFBundleURLTypes = [
-        {
-          CFBundleURLName = "Paseo agent link";
-          CFBundleURLSchemes = [ "paseo" ];
-        }
-      ];
-      CFBundleVersion = version;
-      LSApplicationCategoryType = "public.app-category.developer-tools";
-      LSEnvironment.MallocNanoZone = "0";
-      LSMinimumSystemVersion = "12.0";
-      NSAppTransportSecurity.NSAllowsArbitraryLoads = true;
-      NSAudioCaptureUsageDescription = "Paseo needs access to audio capture for voice input.";
-      NSBluetoothAlwaysUsageDescription = "Paseo needs access to Bluetooth audio devices.";
-      NSBluetoothPeripheralUsageDescription = "Paseo needs access to Bluetooth audio devices.";
-      NSCameraUsageDescription = "Paseo needs access to the camera for image attachments.";
-      NSHighResolutionCapable = true;
-      NSMainNibFile = "MainMenu";
-      NSMicrophoneUsageDescription = "Paseo needs access to the microphone for voice input.";
-      NSPrefersDisplaySafeAreaCompatibilityMode = false;
-      NSPrincipalClass = "AtomApplication";
-      NSQuitAlwaysKeepsWindows = false;
-      NSRequiresAquaSystemAppearance = false;
-      NSSupportsAutomaticGraphicsSwitching = true;
-    }
-  );
-in
 buildNpmPackage {
   pname = "paseo-desktop";
-  inherit version;
+  version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
 
   src = lib.cleanSourceWith {
     src = ./..;
-    filter =
-      path: type:
-      let
-        baseName = builtins.baseNameOf path;
-        relPath = lib.removePrefix (toString ./..) path;
-      in
+    filter = path: type: let
+      baseName = builtins.baseNameOf path;
+      relPath = lib.removePrefix (toString ./..) path;
+    in
       # Exclude mobile-only platform code (we only need the web/electron build)
       !(lib.hasPrefix "/packages/app/android" relPath)
       && !(lib.hasPrefix "/packages/app/ios" relPath)
@@ -102,15 +61,15 @@ buildNpmPackage {
 
   # Prevent onnxruntime-node's install script from running during automatic
   # npm rebuild. We manually rebuild only node-pty in buildPhase.
-  npmRebuildFlags = [ "--ignore-scripts" ];
+  npmRebuildFlags = ["--ignore-scripts"];
 
   nativeBuildInputs =
     [
       python3 # for node-gyp (node-pty)
-      makeWrapper
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       autoPatchelfHook
+      makeWrapper
       copyDesktopItems
     ];
 
@@ -143,8 +102,25 @@ buildNpmPackage {
     # Expo web export for the Electron renderer
     ( cd packages/app && PASEO_WEB_PLATFORM=electron npx expo export --platform web )
 
-    # Desktop main process (tsc only — NOT electron-builder)
+    # Desktop main process
     npm run build:main --workspace=@getpaseo/desktop
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # Let electron-builder create the native bundle layout (including helper
+      # app names and bundle identifiers), but source Electron from nixpkgs
+      # instead of downloading a release at build time.
+      (
+        cd packages/desktop
+        CSC_IDENTITY_AUTO_DISCOVERY=false \
+          ../../node_modules/.bin/electron-builder \
+            --config electron-builder.yml \
+            --dir \
+            --mac \
+            --publish never \
+            --config.electronDist=${electron}/Applications \
+            --config.mac.notarize=false
+      )
+    ''}
 
     runHook postBuild
   '';
@@ -152,47 +128,49 @@ buildNpmPackage {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/paseo-desktop $out/bin
-
-    # Materialize only the desktop and daemon runtime graphs. Copying the
-    # complete monorepo used to ship every build-time dependency (including
-    # Electron, Expo tooling, and cross-platform builder binaries), making the
-    # desktop output larger than 2 GiB.
-    PASEO_TRACE_DESKTOP=1 node scripts/trace-daemon.mjs > desktop-files.txt
-
-    while IFS= read -r path; do
-      [ -z "$path" ] && continue
-      mkdir -p "$out/share/paseo-desktop/$(dirname "$path")"
-      cp -a "$path" "$out/share/paseo-desktop/$path"
-    done < desktop-files.txt
-
-    # Keep the same unpackaged monorepo layout expected by main.js.
-    cp package.json $out/share/paseo-desktop/
-    mkdir -p $out/share/paseo-desktop/packages/app
-    cp -a packages/app/dist $out/share/paseo-desktop/packages/app/
-
-    for runtime_path in \
-      packages/desktop/dist/main.js \
-      packages/desktop/dist/preload.js \
-      packages/desktop/dist/features/browser-keyboard/guest-preload.js \
-      packages/desktop/package.json; do
-      if [ ! -e "$out/share/paseo-desktop/$runtime_path" ]; then
-        echo "desktop runtime trace omitted $runtime_path" >&2
-        exit 1
-      fi
-    done
-
-    if [ -e $out/share/paseo-desktop/node_modules/electron ]; then
-      echo "desktop runtime trace included npm Electron" >&2
-      exit 1
-    fi
-
-    # Skills directory referenced at runtime by some agents
-    if [ -d skills ]; then
-      cp -a skills $out/share/paseo-desktop/
-    fi
+    mkdir -p $out/bin
 
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p $out/share/paseo-desktop
+
+      # Materialize only the desktop and daemon runtime graphs. Copying the
+      # complete monorepo used to ship every build-time dependency (including
+      # Electron, Expo tooling, and cross-platform builder binaries), making the
+      # desktop output larger than 2 GiB.
+      PASEO_TRACE_DESKTOP=1 node scripts/trace-daemon.mjs > desktop-files.txt
+
+      while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        mkdir -p "$out/share/paseo-desktop/$(dirname "$path")"
+        cp -a "$path" "$out/share/paseo-desktop/$path"
+      done < desktop-files.txt
+
+      # Keep the same unpackaged monorepo layout expected by main.js.
+      cp package.json $out/share/paseo-desktop/
+      mkdir -p $out/share/paseo-desktop/packages/app
+      cp -a packages/app/dist $out/share/paseo-desktop/packages/app/
+
+      for runtime_path in \
+        packages/desktop/dist/main.js \
+        packages/desktop/dist/preload.js \
+        packages/desktop/dist/features/browser-keyboard/guest-preload.js \
+        packages/desktop/package.json; do
+        if [ ! -e "$out/share/paseo-desktop/$runtime_path" ]; then
+          echo "desktop runtime trace omitted $runtime_path" >&2
+          exit 1
+        fi
+      done
+
+      if [ -e $out/share/paseo-desktop/node_modules/electron ]; then
+        echo "desktop runtime trace included npm Electron" >&2
+        exit 1
+      fi
+
+      # Skills directory referenced at runtime by some agents
+      if [ -d skills ]; then
+        cp -a skills $out/share/paseo-desktop/
+      fi
+
       # Hicolor icon for desktop environments
       install -Dm644 packages/desktop/assets/icon.png \
         $out/share/icons/hicolor/512x512/apps/paseo-desktop.png
@@ -207,30 +185,13 @@ buildNpmPackage {
     ''}
 
     ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-      app="$out/Applications/Paseo.app"
-      mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
-
-      # Reuse nixpkgs' Electron framework through store symlinks so the Paseo
-      # output stays small while still presenting a normal application bundle
-      # to LaunchServices.
-      ln -s ${electron}/Applications/Electron.app/Contents/Frameworks \
-        "$app/Contents/Frameworks"
-      ln -s ${electron}/Applications/Electron.app/Contents/MacOS/Electron \
-        "$app/Contents/MacOS/Electron"
-      for resource in ${electron}/Applications/Electron.app/Contents/Resources/*; do
-        ln -s "$resource" "$app/Contents/Resources/$(basename "$resource")"
-      done
-
-      cp ${darwinInfoPlist} "$app/Contents/Info.plist"
-      cp ${electron}/Applications/Electron.app/Contents/PkgInfo "$app/Contents/PkgInfo"
-      cp packages/desktop/assets/icon.icns "$app/Contents/Resources/Paseo.icns"
-
-      # Keep the same unpackaged runtime layout as the Linux Nix package. The
-      # outer .app supplies native macOS identity, icon, and URL handling while
-      # the wrapper points Electron at the immutable built main process.
-      makeWrapper "$app/Contents/MacOS/Electron" "$app/Contents/MacOS/Paseo" \
-        --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
-        --set EXPO_DEV_URL "paseo://app/"
+      app="$(find packages/desktop/release -maxdepth 3 -type d -name Paseo.app -print -quit)"
+      if [ -z "$app" ]; then
+        echo "electron-builder did not produce Paseo.app" >&2
+        exit 1
+      fi
+      mkdir -p "$out/Applications"
+      cp -R "$app" "$out/Applications/Paseo.app"
       ln -s ../Applications/Paseo.app/Contents/MacOS/Paseo "$out/bin/paseo-desktop"
     ''}
 
@@ -245,7 +206,7 @@ buildNpmPackage {
       comment = "Self-hosted daemon for AI coding agents";
       exec = "paseo-desktop";
       icon = "paseo-desktop";
-      categories = [ "Development" ];
+      categories = ["Development"];
       startupWMClass = "Paseo";
     })
   ];

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -117,6 +117,8 @@ buildNpmPackage {
       chmod -R u+w "$electron_dist/Electron.app"
       (
         cd packages/desktop
+        # The Nix output is not a distributable DMG, so leave it unsigned and
+        # disable the hardened runtime that requires a matching signature.
         CSC_IDENTITY_AUTO_DISCOVERY=false \
           ../../node_modules/.bin/electron-builder \
             --config electron-builder.yml \
@@ -124,6 +126,8 @@ buildNpmPackage {
             --mac \
             --publish never \
             --config.electronDist="$electron_dist" \
+            --config.mac.identity=null \
+            --config.mac.hardenedRuntime=false \
             --config.mac.notarize=false
       )
     ''}

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -17,9 +17,47 @@
   paseo,
 }:
 
-buildNpmPackage rec {
-  pname = "paseo-desktop";
+let
   version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
+  darwinInfoPlist = builtins.toFile "Paseo-Info.plist" (
+    lib.generators.toPlist { escape = true; } {
+      CFBundleDisplayName = "Paseo";
+      CFBundleExecutable = "Paseo";
+      CFBundleIconFile = "Paseo.icns";
+      CFBundleIdentifier = "sh.paseo.desktop";
+      CFBundleInfoDictionaryVersion = "6.0";
+      CFBundleName = "Paseo";
+      CFBundlePackageType = "APPL";
+      CFBundleShortVersionString = version;
+      CFBundleURLTypes = [
+        {
+          CFBundleURLName = "Paseo agent link";
+          CFBundleURLSchemes = [ "paseo" ];
+        }
+      ];
+      CFBundleVersion = version;
+      LSApplicationCategoryType = "public.app-category.developer-tools";
+      LSEnvironment.MallocNanoZone = "0";
+      LSMinimumSystemVersion = "12.0";
+      NSAppTransportSecurity.NSAllowsArbitraryLoads = true;
+      NSAudioCaptureUsageDescription = "Paseo needs access to audio capture for voice input.";
+      NSBluetoothAlwaysUsageDescription = "Paseo needs access to Bluetooth audio devices.";
+      NSBluetoothPeripheralUsageDescription = "Paseo needs access to Bluetooth audio devices.";
+      NSCameraUsageDescription = "Paseo needs access to the camera for image attachments.";
+      NSHighResolutionCapable = true;
+      NSMainNibFile = "MainMenu";
+      NSMicrophoneUsageDescription = "Paseo needs access to the microphone for voice input.";
+      NSPrefersDisplaySafeAreaCompatibilityMode = false;
+      NSPrincipalClass = "AtomApplication";
+      NSQuitAlwaysKeepsWindows = false;
+      NSRequiresAquaSystemAppearance = false;
+      NSSupportsAutomaticGraphicsSwitching = true;
+    }
+  );
+in
+buildNpmPackage {
+  pname = "paseo-desktop";
+  inherit version;
 
   src = lib.cleanSourceWith {
     src = ./..;
@@ -66,14 +104,15 @@ buildNpmPackage rec {
   # npm rebuild. We manually rebuild only node-pty in buildPhase.
   npmRebuildFlags = [ "--ignore-scripts" ];
 
-  nativeBuildInputs = [
-    python3 # for node-gyp (node-pty)
-    makeWrapper
-    copyDesktopItems
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    autoPatchelfHook
-  ];
+  nativeBuildInputs =
+    [
+      python3 # for node-gyp (node-pty)
+      makeWrapper
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      autoPatchelfHook
+      copyDesktopItems
+    ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     libuv
@@ -153,31 +192,52 @@ buildNpmPackage rec {
       cp -a skills $out/share/paseo-desktop/
     fi
 
-    # Hicolor icon for desktop environments
-    install -Dm644 packages/desktop/assets/icon.png \
-      $out/share/icons/hicolor/512x512/apps/paseo-desktop.png
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      # Hicolor icon for desktop environments
+      install -Dm644 packages/desktop/assets/icon.png \
+        $out/share/icons/hicolor/512x512/apps/paseo-desktop.png
 
-    # Launcher wraps nixpkgs electron.
-    # --no-sandbox: Chromium's setuid sandbox can't live in /nix/store
-    # (immutable, no setuid). Acceptable for v1; a follow-up can wire
-    # `security.wrappers` via a NixOS module for users who want the sandbox.
-    #
-    # EXPO_DEV_URL: We run unpackaged via `electron path/to/main.js`, so
-    # `app.isPackaged` is false. In that mode main.ts loads `DEV_SERVER_URL`
-    # (defaults to http://localhost:8081 — the Expo dev server, which doesn't
-    # exist here). Point it at the `paseo://` protocol handler instead, which
-    # serves from `__dirname/../../app/dist` (our install layout matches).
-    makeWrapper ${electron}/bin/electron $out/bin/paseo-desktop \
-      --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
-      --add-flags "--no-sandbox" \
-      --set EXPO_DEV_URL "paseo://app/"
+      # Chromium's setuid sandbox cannot live in the immutable Nix store.
+      makeWrapper ${electron}/bin/electron $out/bin/paseo-desktop \
+        --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
+        --add-flags "--no-sandbox" \
+        --set EXPO_DEV_URL "paseo://app/"
 
-    copyDesktopItems
+      copyDesktopItems
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      app="$out/Applications/Paseo.app"
+      mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+
+      # Reuse nixpkgs' Electron framework through store symlinks so the Paseo
+      # output stays small while still presenting a normal application bundle
+      # to LaunchServices.
+      ln -s ${electron}/Applications/Electron.app/Contents/Frameworks \
+        "$app/Contents/Frameworks"
+      ln -s ${electron}/Applications/Electron.app/Contents/MacOS/Electron \
+        "$app/Contents/MacOS/Electron"
+      for resource in ${electron}/Applications/Electron.app/Contents/Resources/*; do
+        ln -s "$resource" "$app/Contents/Resources/$(basename "$resource")"
+      done
+
+      cp ${darwinInfoPlist} "$app/Contents/Info.plist"
+      cp ${electron}/Applications/Electron.app/Contents/PkgInfo "$app/Contents/PkgInfo"
+      cp packages/desktop/assets/icon.icns "$app/Contents/Resources/Paseo.icns"
+
+      # Keep the same unpackaged runtime layout as the Linux Nix package. The
+      # outer .app supplies native macOS identity, icon, and URL handling while
+      # the wrapper points Electron at the immutable built main process.
+      makeWrapper "$app/Contents/MacOS/Electron" "$app/Contents/MacOS/Paseo" \
+        --add-flags "$out/share/paseo-desktop/packages/desktop/dist/main.js" \
+        --set EXPO_DEV_URL "paseo://app/"
+      ln -s ../Applications/Paseo.app/Contents/MacOS/Paseo "$out/bin/paseo-desktop"
+    ''}
 
     runHook postInstall
   '';
 
-  desktopItems = [
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
     (makeDesktopItem {
       name = "paseo-desktop";
       desktopName = "Paseo";
@@ -195,6 +255,6 @@ buildNpmPackage rec {
     homepage = "https://github.com/getpaseo/paseo";
     license = lib.licenses.agpl3Plus;
     mainProgram = "paseo-desktop";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -108,7 +108,13 @@ buildNpmPackage {
     ${lib.optionalString stdenv.hostPlatform.isDarwin ''
       # Let electron-builder create the native bundle layout (including helper
       # app names and bundle identifiers), but source Electron from nixpkgs
-      # instead of downloading a release at build time.
+      # instead of downloading a release at build time. electron-builder edits
+      # the copied helper plists, so stage a writable distribution rather than
+      # pointing it directly at the read-only Nix store.
+      electron_dist="$NIX_BUILD_TOP/electron-dist"
+      mkdir -p "$electron_dist"
+      cp -R ${electron}/Applications/Electron.app "$electron_dist/"
+      chmod -R u+w "$electron_dist/Electron.app"
       (
         cd packages/desktop
         CSC_IDENTITY_AUTO_DISCOVERY=false \
@@ -117,7 +123,7 @@ buildNpmPackage {
             --dir \
             --mac \
             --publish never \
-            --config.electronDist=${electron}/Applications \
+            --config.electronDist="$electron_dist" \
             --config.mac.notarize=false
       )
     ''}


### PR DESCRIPTION
Closes #2555.

## Problem

The flake exposed the Desktop package only on Linux, so nix-darwin configurations could not install a current Desktop build from the same pinned Paseo source as the daemon.

## Change

- expose `packages.<system>.desktop` on Darwin
- use electron-builder to produce the native macOS bundle layout, helper names, bundle identifiers, resources, and URL scheme
- source Electron from nixpkgs through electron-builder's custom distribution support instead of downloading it
- stage a writable copy of the read-only Nix Electron app so electron-builder can update the helper metadata
- skip code signing and hardened runtime for the local Nix output
- retain the existing Linux launcher and desktop entry behavior
- document `nix build .#desktop` on Linux and macOS

## QA

- `nix flake show --all-systems`
- `nix build .#desktop --no-link` on x86_64-linux
- built PR head `b12e3b63b` on aarch64-darwin with `nix build`
- `plutil -lint` passed for the main app and helper app plists
- verified bundle version `0.2.3` and bundle ID `sh.paseo.desktop`
- launched the exact Nix store output on Apple Silicon and verified the main, GPU, network, and renderer processes remained alive
- verified no new macOS crash report was created
- verified Paseo Desktop remained client-only (`manageBuiltInDaemon=false`) and the separately managed launchd daemon retained the same PID through app startup
- `npm run format`
- `npm run lint`
- `npm run build:server`

`npm run typecheck` was also run. Every workspace except `@getpaseo/expo-two-way-audio` passed; that workspace currently fails on the branch baseline because `expo-module-scripts` is missing and React Native/DOM globals conflict. This change does not touch that workspace.
