### PR TITLE
Stop attachment GC from deleting rendered image previews

### DIFF
--- a/packages/app/src/attachments/attachment-file-system.ts
+++ b/packages/app/src/attachments/attachment-file-system.ts
@@ -2,7 +2,13 @@ import { File } from "expo-file-system";
 import * as FileSystem from "expo-file-system/legacy";
 
 export type AttachmentFileInfo =
-  | { exists: true; isDirectory: boolean; size: number | null }
+  | {
+      exists: true;
+      isDirectory: boolean;
+      size: number | null;
+      /** Epoch milliseconds, or null when the platform does not report one. */
+      modificationTimeMs: number | null;
+    }
   | { exists: false };
 
 export interface AttachmentFileSystem {
@@ -28,7 +34,14 @@ export function createExpoAttachmentFileSystem(): AttachmentFileSystem {
         typeof (info as { size?: number }).size === "number"
           ? (info as { size: number }).size
           : null;
-      return { exists: true, isDirectory: info.isDirectory ?? false, size };
+      // expo-file-system reports modificationTime in seconds.
+      const modificationTime = (info as { modificationTime?: number }).modificationTime;
+      return {
+        exists: true,
+        isDirectory: info.isDirectory ?? false,
+        size,
+        modificationTimeMs: typeof modificationTime === "number" ? modificationTime * 1000 : null,
+      };
     },
     async makeDirectory(uri, options) {
       await FileSystem.makeDirectoryAsync(uri, options);

--- a/packages/app/src/attachments/gc-policy.test.ts
+++ b/packages/app/src/attachments/gc-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { PREVIEW_ATTACHMENT_MAX_AGE_MS, shouldDeleteAttachmentDuringGc } from "./gc-policy";
+
+const NOW = 1_800_000_000_000;
+
+describe("shouldDeleteAttachmentDuringGc", () => {
+  it("keeps referenced attachments", () => {
+    expect(
+      shouldDeleteAttachmentDuringGc({
+        id: "abc123",
+        isReferenced: true,
+        createdAtMs: 0,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("deletes unreferenced composer attachments", () => {
+    expect(
+      shouldDeleteAttachmentDuringGc({
+        id: "abc123",
+        isReferenced: false,
+        createdAtMs: NOW,
+        nowMs: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps unreferenced previews that are still within the max age", () => {
+    expect(
+      shouldDeleteAttachmentDuringGc({
+        id: "preview_1024_deadbeef",
+        isReferenced: false,
+        createdAtMs: NOW - PREVIEW_ATTACHMENT_MAX_AGE_MS + 1,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("deletes unreferenced previews once they exceed the max age", () => {
+    expect(
+      shouldDeleteAttachmentDuringGc({
+        id: "preview_1024_deadbeef",
+        isReferenced: false,
+        createdAtMs: NOW - PREVIEW_ATTACHMENT_MAX_AGE_MS - 1,
+        nowMs: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps previews whose age cannot be established", () => {
+    expect(
+      shouldDeleteAttachmentDuringGc({
+        id: "preview_1024_deadbeef",
+        isReferenced: false,
+        createdAtMs: null,
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/attachments/gc-policy.ts
+++ b/packages/app/src/attachments/gc-policy.ts
@@ -5,6 +5,11 @@ import { isPreviewAttachmentId } from "@/attachments/utils";
 // is every keystroke in the composer. They are a cache of bytes the daemon still owns, so
 // they expire on age instead. Anything without a usable timestamp is kept: a preview whose
 // age we cannot establish is cheaper to keep than to delete out from under a mounted image.
+//
+// Age is a lifetime for previews nothing is showing. A preview a mounted component is
+// displaying arrives here with `isReferenced` already true — `garbageCollectAttachments`
+// unions the retentions from live-attachments.ts into the referenced set — so this policy
+// never expires an image that is on screen, however long it stays there.
 export const PREVIEW_ATTACHMENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function shouldDeleteAttachmentDuringGc(input: {

--- a/packages/app/src/attachments/gc-policy.ts
+++ b/packages/app/src/attachments/gc-policy.ts
@@ -1,0 +1,26 @@
+import { isPreviewAttachmentId } from "@/attachments/utils";
+
+// Preview attachments are never rooted in drafts, queued messages, or the create flow, so
+// reference-based collection would delete them the moment anything touches a draft — which
+// is every keystroke in the composer. They are a cache of bytes the daemon still owns, so
+// they expire on age instead. Anything without a usable timestamp is kept: a preview whose
+// age we cannot establish is cheaper to keep than to delete out from under a mounted image.
+export const PREVIEW_ATTACHMENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function shouldDeleteAttachmentDuringGc(input: {
+  id: string;
+  isReferenced: boolean;
+  createdAtMs: number | null;
+  nowMs: number;
+}): boolean {
+  if (input.isReferenced) {
+    return false;
+  }
+  if (!isPreviewAttachmentId(input.id)) {
+    return true;
+  }
+  if (input.createdAtMs === null || !Number.isFinite(input.createdAtMs)) {
+    return false;
+  }
+  return input.nowMs - input.createdAtMs > PREVIEW_ATTACHMENT_MAX_AGE_MS;
+}

--- a/packages/app/src/attachments/live-attachments.ts
+++ b/packages/app/src/attachments/live-attachments.ts
@@ -1,0 +1,40 @@
+/**
+ * Attachment ids that a mounted component is currently displaying.
+ *
+ * Preview attachments are not rooted in drafts, queued messages, or the create flow, so
+ * garbage collection falls back to an age-based lifetime for them (see gc-policy.ts). Age
+ * alone cannot see a preview that is on screen right now: a thread or file pane left open
+ * past the max age would have the bytes behind a rendered image deleted by the next
+ * draft-triggered sweep. Hooks that resolve a preview URL retain the id here for as long as
+ * they hold it, and garbage collection treats retained ids as referenced.
+ */
+const retainCountById = new Map<string, number>();
+
+/** Retains `id` until the returned release function is called. Safe to call twice. */
+export function retainLiveAttachment(id: string): () => void {
+  retainCountById.set(id, (retainCountById.get(id) ?? 0) + 1);
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const remaining = (retainCountById.get(id) ?? 0) - 1;
+    if (remaining > 0) {
+      retainCountById.set(id, remaining);
+    } else {
+      retainCountById.delete(id);
+    }
+  };
+}
+
+export function collectLiveAttachmentIds(into: Set<string>): void {
+  for (const id of retainCountById.keys()) {
+    into.add(id);
+  }
+}
+
+/** Test-only hook to drop retentions leaked by an unmounted render tree. */
+export function __resetLiveAttachmentsForTests(): void {
+  retainCountById.clear();
+}

--- a/packages/app/src/attachments/local-file-attachment-store.test.ts
+++ b/packages/app/src/attachments/local-file-attachment-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { PREVIEW_ATTACHMENT_MAX_AGE_MS } from "./gc-policy";
 import { createLocalFileAttachmentStore } from "./local-file-attachment-store";
 import { createTestAttachmentFileSystem } from "./test-attachment-file-system";
 
@@ -31,5 +32,46 @@ describe("local file attachment store", () => {
       new Uint8Array([0, 1, 2, 3]),
     );
     expect(fileSystem.directories.has("file:///cache/preview-assets")).toBe(true);
+  });
+
+  describe("garbageCollect", () => {
+    function createStore() {
+      const fileSystem = createTestAttachmentFileSystem();
+      const store = createLocalFileAttachmentStore({
+        storageType: "native-file",
+        baseDirectoryName: "preview-assets",
+        fileSystem,
+        resolvePreviewUrl: async (attachment) => `file://${attachment.storageKey}`,
+      });
+      return { fileSystem, store };
+    }
+
+    it("keeps unreferenced previews so composer edits do not evict rendered images", async () => {
+      const { fileSystem, store } = createStore();
+      fileSystem.setFile("file:///cache/preview-assets/preview_4_abc.png", new Uint8Array([1]));
+      fileSystem.setFile("file:///cache/preview-assets/att_unreferenced.png", new Uint8Array([2]));
+      fileSystem.setFile("file:///cache/preview-assets/att_kept.png", new Uint8Array([3]));
+
+      await store.garbageCollect({ referencedIds: new Set(["att_kept"]) });
+
+      expect([...fileSystem.files.keys()].sort()).toEqual([
+        "file:///cache/preview-assets/att_kept.png",
+        "file:///cache/preview-assets/preview_4_abc.png",
+      ]);
+    });
+
+    it("evicts previews older than the max age", async () => {
+      const { fileSystem, store } = createStore();
+      const freshUri = "file:///cache/preview-assets/preview_4_fresh.png";
+      const staleUri = "file:///cache/preview-assets/preview_4_stale.png";
+      fileSystem.setFile(freshUri, new Uint8Array([1]));
+      fileSystem.setFile(staleUri, new Uint8Array([2]));
+      fileSystem.setModificationTimeMs(freshUri, Date.now());
+      fileSystem.setModificationTimeMs(staleUri, Date.now() - PREVIEW_ATTACHMENT_MAX_AGE_MS - 1);
+
+      await store.garbageCollect({ referencedIds: new Set() });
+
+      expect([...fileSystem.files.keys()]).toEqual([freshUri]);
+    });
   });
 });

--- a/packages/app/src/attachments/local-file-attachment-store.ts
+++ b/packages/app/src/attachments/local-file-attachment-store.ts
@@ -9,10 +9,12 @@ import {
   fileUriToPath,
   generateAttachmentId,
   getFileExtensionFromName,
+  isPreviewAttachmentId,
   normalizeMimeType,
   parseDataUrl,
   pathToFileUri,
 } from "@/attachments/utils";
+import { shouldDeleteAttachmentDuringGc } from "@/attachments/gc-policy";
 
 const IMAGE_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
   "image/png": ".png",
@@ -42,6 +44,14 @@ async function ensureDirectory(fileSystem: AttachmentFileSystem, uri: string): P
     return;
   }
   await fileSystem.makeDirectory(uri, { intermediates: true });
+}
+
+async function readModificationTimeMs(
+  fileSystem: AttachmentFileSystem,
+  uri: string,
+): Promise<number | null> {
+  const info = await fileSystem.getInfo(uri);
+  return info.exists ? info.modificationTimeMs : null;
 }
 
 async function dataUrlToBytes(dataUrl: string): Promise<Uint8Array> {
@@ -190,15 +200,31 @@ export function createLocalFileAttachmentStore(params: {
       }
       await ensureDirectory(fileSystem, baseDirectory);
       const entries = await fileSystem.listDirectory(baseDirectory);
+      const nowMs = Date.now();
       await Promise.all(
         entries.map(async (entryName) => {
           const id = entryName.split(".", 1)[0] ?? "";
-          if (!id || referencedIds.has(id)) {
+          if (!id) {
             return;
           }
-          await fileSystem.delete(`${baseDirectory}${entryName}`, {
-            idempotent: true,
-          });
+          const uri = `${baseDirectory}${entryName}`;
+          // Only previews need an age, and only when they are unreferenced — skip the stat
+          // for everything else so the common composer-attachment sweep stays a plain listing.
+          const createdAtMs =
+            !referencedIds.has(id) && isPreviewAttachmentId(id)
+              ? await readModificationTimeMs(fileSystem, uri)
+              : null;
+          if (
+            !shouldDeleteAttachmentDuringGc({
+              id,
+              isReferenced: referencedIds.has(id),
+              createdAtMs,
+              nowMs,
+            })
+          ) {
+            return;
+          }
+          await fileSystem.delete(uri, { idempotent: true });
         }),
       );
     },

--- a/packages/app/src/attachments/service.ts
+++ b/packages/app/src/attachments/service.ts
@@ -1,5 +1,6 @@
 import type { AttachmentMetadata } from "@/attachments/types";
 import { getAttachmentStore } from "@/attachments/store";
+import { collectLiveAttachmentIds } from "@/attachments/live-attachments";
 
 export async function persistAttachmentFromBlob(input: {
   blob: Blob;
@@ -134,5 +135,11 @@ export async function garbageCollectAttachments(input: {
   referencedIds: ReadonlySet<string>;
 }): Promise<void> {
   const store = await getAttachmentStore();
-  await store.garbageCollect({ referencedIds: input.referencedIds });
+  // Whatever a mounted component is displaying right now is reachable, even when no draft
+  // or queued message roots it. Previews depend on this: their only other protection is the
+  // age fallback in gc-policy.ts, which would otherwise delete the bytes behind an image
+  // that is still on screen once it outlives the max age.
+  const referencedIds = new Set(input.referencedIds);
+  collectLiveAttachmentIds(referencedIds);
+  await store.garbageCollect({ referencedIds });
 }

--- a/packages/app/src/attachments/test-attachment-file-system.ts
+++ b/packages/app/src/attachments/test-attachment-file-system.ts
@@ -5,6 +5,7 @@ export interface TestAttachmentFileSystem extends AttachmentFileSystem {
   readonly directories: ReadonlySet<string>;
   setFile(uri: string, bytes: Uint8Array): void;
   setDirectory(uri: string): void;
+  setModificationTimeMs(uri: string, modificationTimeMs: number): void;
 }
 
 export function createTestAttachmentFileSystem(options?: {
@@ -12,6 +13,7 @@ export function createTestAttachmentFileSystem(options?: {
 }): TestAttachmentFileSystem {
   const files = new Map<string, Uint8Array>();
   const directories = new Set<string>();
+  const modificationTimesMs = new Map<string, number>();
   const cacheDirectory =
     options && Object.hasOwn(options, "cacheDirectory")
       ? (options.cacheDirectory ?? null)
@@ -19,11 +21,16 @@ export function createTestAttachmentFileSystem(options?: {
 
   function describe(uri: string): AttachmentFileInfo {
     if (directories.has(uri) || directories.has(stripTrailingSlash(uri))) {
-      return { exists: true, isDirectory: true, size: null };
+      return { exists: true, isDirectory: true, size: null, modificationTimeMs: null };
     }
     const bytes = files.get(uri);
     if (bytes) {
-      return { exists: true, isDirectory: false, size: bytes.byteLength };
+      return {
+        exists: true,
+        isDirectory: false,
+        size: bytes.byteLength,
+        modificationTimeMs: modificationTimesMs.get(uri) ?? null,
+      };
     }
     return { exists: false };
   }
@@ -37,6 +44,9 @@ export function createTestAttachmentFileSystem(options?: {
     },
     setDirectory(uri) {
       directories.add(stripTrailingSlash(uri));
+    },
+    setModificationTimeMs(uri, modificationTimeMs) {
+      modificationTimesMs.set(uri, modificationTimeMs);
     },
     async getInfo(uri) {
       return describe(uri);
@@ -62,6 +72,7 @@ export function createTestAttachmentFileSystem(options?: {
       return toBase64(bytes);
     },
     async delete(uri, deleteOptions) {
+      modificationTimesMs.delete(uri);
       if (!files.delete(uri) && !deleteOptions.idempotent) {
         throw new Error(`delete: file does not exist: ${uri}`);
       }

--- a/packages/app/src/attachments/use-attachment-preview-url.test.tsx
+++ b/packages/app/src/attachments/use-attachment-preview-url.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AttachmentMetadata } from "@/attachments/types";
+
+const resolveAttachmentPreviewUrl = vi.fn<(attachment: AttachmentMetadata) => Promise<string>>();
+const releaseAttachmentPreviewUrl =
+  vi.fn<(input: { attachment: AttachmentMetadata; url: string }) => Promise<void>>();
+
+vi.mock("@/attachments/service", () => ({
+  resolveAttachmentPreviewUrl: (attachment: AttachmentMetadata) =>
+    resolveAttachmentPreviewUrl(attachment),
+  releaseAttachmentPreviewUrl: (input: { attachment: AttachmentMetadata; url: string }) =>
+    releaseAttachmentPreviewUrl(input),
+}));
+
+const { useAttachmentPreviewUrlState } = await import("@/attachments/use-attachment-preview-url");
+
+const ATTACHMENT: AttachmentMetadata = {
+  id: "preview_4_abc",
+  mimeType: "image/png",
+  storageType: "web-indexeddb",
+  storageKey: "preview_4_abc",
+  fileName: "shot.png",
+  byteSize: 4,
+  createdAt: 0,
+};
+
+describe("useAttachmentPreviewUrlState", () => {
+  beforeEach(() => {
+    resolveAttachmentPreviewUrl.mockReset();
+    releaseAttachmentPreviewUrl.mockReset();
+    releaseAttachmentPreviewUrl.mockResolvedValue(undefined);
+  });
+
+  it("reports resolving before the url lands so callers do not paint a failure", async () => {
+    resolveAttachmentPreviewUrl.mockResolvedValue("blob:ready");
+
+    const { result } = renderHook(() => useAttachmentPreviewUrlState(ATTACHMENT));
+
+    expect(result.current).toEqual({ status: "resolving" });
+    await waitFor(() => expect(result.current).toEqual({ status: "ready", url: "blob:ready" }));
+  });
+
+  it("retries a failed resolve when the reload key changes", async () => {
+    resolveAttachmentPreviewUrl.mockRejectedValueOnce(new Error("not found"));
+    resolveAttachmentPreviewUrl.mockResolvedValueOnce("blob:recovered");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result, rerender } = renderHook(
+      ({ reloadKey }: { reloadKey: number }) =>
+        useAttachmentPreviewUrlState(ATTACHMENT, { reloadKey }),
+      { initialProps: { reloadKey: 1 } },
+    );
+
+    await waitFor(() => expect(result.current).toEqual({ status: "failed" }));
+
+    rerender({ reloadKey: 2 });
+
+    await waitFor(() => expect(result.current).toEqual({ status: "ready", url: "blob:recovered" }));
+    expect(resolveAttachmentPreviewUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a resolved url when the reload key changes after success", async () => {
+    resolveAttachmentPreviewUrl.mockResolvedValue("blob:ready");
+
+    const { result, rerender } = renderHook(
+      ({ reloadKey }: { reloadKey: number }) =>
+        useAttachmentPreviewUrlState(ATTACHMENT, { reloadKey }),
+      { initialProps: { reloadKey: 1 } },
+    );
+
+    await waitFor(() => expect(result.current).toEqual({ status: "ready", url: "blob:ready" }));
+
+    rerender({ reloadKey: 2 });
+
+    expect(result.current).toEqual({ status: "ready", url: "blob:ready" });
+    expect(resolveAttachmentPreviewUrl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/attachments/use-attachment-preview-url.test.tsx
+++ b/packages/app/src/attachments/use-attachment-preview-url.test.tsx
@@ -1,21 +1,12 @@
 // @vitest-environment jsdom
 
 import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AttachmentMetadata } from "@/attachments/types";
-
-const resolveAttachmentPreviewUrl = vi.fn<(attachment: AttachmentMetadata) => Promise<string>>();
-const releaseAttachmentPreviewUrl =
-  vi.fn<(input: { attachment: AttachmentMetadata; url: string }) => Promise<void>>();
-
-vi.mock("@/attachments/service", () => ({
-  resolveAttachmentPreviewUrl: (attachment: AttachmentMetadata) =>
-    resolveAttachmentPreviewUrl(attachment),
-  releaseAttachmentPreviewUrl: (input: { attachment: AttachmentMetadata; url: string }) =>
-    releaseAttachmentPreviewUrl(input),
-}));
-
-const { useAttachmentPreviewUrlState } = await import("@/attachments/use-attachment-preview-url");
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AttachmentMetadata, AttachmentStore } from "@/attachments/types";
+import { __setAttachmentStoreForTests } from "@/attachments/store";
+import { garbageCollectAttachments } from "@/attachments/service";
+import { __resetLiveAttachmentsForTests } from "@/attachments/live-attachments";
+import { useAttachmentPreviewUrlState } from "@/attachments/use-attachment-preview-url";
 
 const ATTACHMENT: AttachmentMetadata = {
   id: "preview_4_abc",
@@ -27,26 +18,116 @@ const ATTACHMENT: AttachmentMetadata = {
   createdAt: 0,
 };
 
+interface FakeAttachmentStore {
+  store: AttachmentStore;
+  /** Ids whose bytes are present, i.e. what a `resolvePreviewUrl` read would find. */
+  storedIds: Set<string>;
+  releasedUrls: string[];
+  gcReferencedIds: Array<Set<string>>;
+  resolveCount: () => number;
+  /** Holds the next resolve open so a reload can land while it is in flight. */
+  blockNextResolve: () => { release: () => void };
+}
+
+/**
+ * In-memory stand-in for a real attachment store: bytes either exist or they do not, and
+ * garbage collection deletes whatever the caller did not mark as referenced. The hook is
+ * driven through the real `@/attachments/service` functions on top of it, so a break in the
+ * service/store integration or the preview-URL release lifecycle fails these tests.
+ */
+function createFakeAttachmentStore(): FakeAttachmentStore {
+  const storedIds = new Set<string>();
+  const releasedUrls: string[] = [];
+  const gcReferencedIds: Array<Set<string>> = [];
+  let resolveCount = 0;
+  let urlSequence = 0;
+  let gate: { promise: Promise<void>; release: () => void } | null = null;
+
+  const store: AttachmentStore = {
+    storageType: "web-indexeddb",
+    async save() {
+      throw new Error("save is not exercised by these tests");
+    },
+    async encodeBase64() {
+      throw new Error("encodeBase64 is not exercised by these tests");
+    },
+    async resolvePreviewUrl({ attachment }) {
+      resolveCount += 1;
+      // Presence is captured when the read starts, as in a real store: bytes that land after
+      // an attempt is already in flight do not rescue that attempt.
+      const found = storedIds.has(attachment.storageKey);
+      const pending = gate;
+      gate = null;
+      if (pending) {
+        await pending.promise;
+      }
+      if (!found) {
+        throw new Error(`No attachment bytes for ${attachment.storageKey}`);
+      }
+      urlSequence += 1;
+      return `blob:${attachment.storageKey}#${urlSequence}`;
+    },
+    async releasePreviewUrl({ url }) {
+      releasedUrls.push(url);
+    },
+    async delete({ attachment }) {
+      storedIds.delete(attachment.storageKey);
+    },
+    async garbageCollect({ referencedIds }) {
+      gcReferencedIds.push(new Set(referencedIds));
+      const collected = [...storedIds].filter((id) => !referencedIds.has(id));
+      for (const id of collected) {
+        storedIds.delete(id);
+      }
+    },
+  };
+
+  return {
+    store,
+    storedIds,
+    releasedUrls,
+    gcReferencedIds,
+    resolveCount: () => resolveCount,
+    blockNextResolve: () => {
+      let release = (): void => {};
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      gate = { promise, release };
+      return { release: () => release() };
+    },
+  };
+}
+
+/** The hook logs every failed resolve; these tests provoke failures on purpose. */
+function expectResolveFailures(): void {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
 describe("useAttachmentPreviewUrlState", () => {
-  beforeEach(() => {
-    resolveAttachmentPreviewUrl.mockReset();
-    releaseAttachmentPreviewUrl.mockReset();
-    releaseAttachmentPreviewUrl.mockResolvedValue(undefined);
+  afterEach(() => {
+    __setAttachmentStoreForTests(null);
+    __resetLiveAttachmentsForTests();
+    vi.restoreAllMocks();
   });
 
   it("reports resolving before the url lands so callers do not paint a failure", async () => {
-    resolveAttachmentPreviewUrl.mockResolvedValue("blob:ready");
+    const fake = createFakeAttachmentStore();
+    fake.storedIds.add(ATTACHMENT.id);
+    __setAttachmentStoreForTests(fake.store);
 
     const { result } = renderHook(() => useAttachmentPreviewUrlState(ATTACHMENT));
 
     expect(result.current).toEqual({ status: "resolving" });
-    await waitFor(() => expect(result.current).toEqual({ status: "ready", url: "blob:ready" }));
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: "ready", url: "blob:preview_4_abc#1" }),
+    );
   });
 
   it("retries a failed resolve when the reload key changes", async () => {
-    resolveAttachmentPreviewUrl.mockRejectedValueOnce(new Error("not found"));
-    resolveAttachmentPreviewUrl.mockResolvedValueOnce("blob:recovered");
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fake = createFakeAttachmentStore();
+    __setAttachmentStoreForTests(fake.store);
+    expectResolveFailures();
 
     const { result, rerender } = renderHook(
       ({ reloadKey }: { reloadKey: number }) =>
@@ -56,14 +137,20 @@ describe("useAttachmentPreviewUrlState", () => {
 
     await waitFor(() => expect(result.current).toEqual({ status: "failed" }));
 
+    fake.storedIds.add(ATTACHMENT.id);
     rerender({ reloadKey: 2 });
 
-    await waitFor(() => expect(result.current).toEqual({ status: "ready", url: "blob:recovered" }));
-    expect(resolveAttachmentPreviewUrl).toHaveBeenCalledTimes(2);
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: "ready", url: "blob:preview_4_abc#1" }),
+    );
+    expect(fake.resolveCount()).toBe(2);
   });
 
-  it("keeps a resolved url when the reload key changes after success", async () => {
-    resolveAttachmentPreviewUrl.mockResolvedValue("blob:ready");
+  it("retries when a reload lands while the resolve that fails is still in flight", async () => {
+    const fake = createFakeAttachmentStore();
+    __setAttachmentStoreForTests(fake.store);
+    expectResolveFailures();
+    const blocked = fake.blockNextResolve();
 
     const { result, rerender } = renderHook(
       ({ reloadKey }: { reloadKey: number }) =>
@@ -71,11 +158,79 @@ describe("useAttachmentPreviewUrlState", () => {
       { initialProps: { reloadKey: 1 } },
     );
 
-    await waitFor(() => expect(result.current).toEqual({ status: "ready", url: "blob:ready" }));
+    // Wait for the read to reach the store, so it has already missed the bytes.
+    await waitFor(() => expect(fake.resolveCount()).toBe(1));
+    expect(result.current).toEqual({ status: "resolving" });
+
+    // The refetch lands while the first read is still open, so the reload signal arrives
+    // before the failure it should answer.
+    fake.storedIds.add(ATTACHMENT.id);
+    rerender({ reloadKey: 2 });
+    blocked.release();
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: "ready", url: "blob:preview_4_abc#1" }),
+    );
+    expect(fake.resolveCount()).toBe(2);
+  });
+
+  it("keeps a resolved url when the reload key changes after success", async () => {
+    const fake = createFakeAttachmentStore();
+    fake.storedIds.add(ATTACHMENT.id);
+    __setAttachmentStoreForTests(fake.store);
+
+    const { result, rerender } = renderHook(
+      ({ reloadKey }: { reloadKey: number }) =>
+        useAttachmentPreviewUrlState(ATTACHMENT, { reloadKey }),
+      { initialProps: { reloadKey: 1 } },
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: "ready", url: "blob:preview_4_abc#1" }),
+    );
 
     rerender({ reloadKey: 2 });
 
-    expect(result.current).toEqual({ status: "ready", url: "blob:ready" });
-    expect(resolveAttachmentPreviewUrl).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({ status: "ready", url: "blob:preview_4_abc#1" });
+    expect(fake.resolveCount()).toBe(1);
+  });
+
+  it("releases the resolved preview url when the caller unmounts", async () => {
+    const fake = createFakeAttachmentStore();
+    fake.storedIds.add(ATTACHMENT.id);
+    __setAttachmentStoreForTests(fake.store);
+
+    const { result, unmount } = renderHook(() => useAttachmentPreviewUrlState(ATTACHMENT));
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: "ready", url: "blob:preview_4_abc#1" }),
+    );
+
+    unmount();
+
+    await waitFor(() => expect(fake.releasedUrls).toEqual(["blob:preview_4_abc#1"]));
+  });
+
+  it("keeps a displayed preview out of an unreferenced sweep until it unmounts", async () => {
+    const fake = createFakeAttachmentStore();
+    fake.storedIds.add(ATTACHMENT.id);
+    __setAttachmentStoreForTests(fake.store);
+
+    const { result, unmount } = renderHook(() => useAttachmentPreviewUrlState(ATTACHMENT));
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: "ready", url: "blob:preview_4_abc#1" }),
+    );
+
+    // A composer keystroke sweeps with no preview in its roots; the mounted image is still
+    // reachable, so its bytes must survive regardless of how old the preview is.
+    await garbageCollectAttachments({ referencedIds: new Set<string>() });
+    expect(fake.gcReferencedIds.at(-1)?.has(ATTACHMENT.id)).toBe(true);
+    expect(fake.storedIds.has(ATTACHMENT.id)).toBe(true);
+
+    unmount();
+
+    await garbageCollectAttachments({ referencedIds: new Set<string>() });
+    expect(fake.gcReferencedIds.at(-1)?.has(ATTACHMENT.id)).toBe(false);
+    expect(fake.storedIds.has(ATTACHMENT.id)).toBe(false);
   });
 });

--- a/packages/app/src/attachments/use-attachment-preview-url.ts
+++ b/packages/app/src/attachments/use-attachment-preview-url.ts
@@ -2,18 +2,51 @@ import { useEffect, useRef, useState } from "react";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { releaseAttachmentPreviewUrl, resolveAttachmentPreviewUrl } from "@/attachments/service";
 
-export function useAttachmentPreviewUrl(
+export type AttachmentPreviewUrlState =
+  | { status: "idle" }
+  | { status: "resolving" }
+  | { status: "ready"; url: string }
+  | { status: "failed" };
+
+export interface UseAttachmentPreviewUrlOptions {
+  /**
+   * Signals that the bytes behind the attachment may have been rewritten. Preview attachment
+   * ids are content-derived and therefore stable, so without this a single failed resolve
+   * would stick until the component remounted — refetching the bytes could not clear it.
+   * Only a *failed* resolve is retried, so a routine refetch never drops a rendered image
+   * back to a spinner. Callers driven by a query can pass `dataUpdatedAt`.
+   */
+  reloadKey?: number | string;
+}
+
+export function useAttachmentPreviewUrlState(
   attachment: AttachmentMetadata | null | undefined,
-): string | null {
-  const [url, setUrl] = useState<string | null>(null);
+  options?: UseAttachmentPreviewUrlOptions,
+): AttachmentPreviewUrlState {
+  const [state, setState] = useState<AttachmentPreviewUrlState>({ status: "idle" });
+  const [retryAttempt, setRetryAttempt] = useState(0);
   const activeAttachmentRef = useRef<AttachmentMetadata | null>(null);
   const attachmentRef = useRef(attachment);
   attachmentRef.current = attachment;
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   const id = attachment?.id;
   const storageType = attachment?.storageType;
   const storageKey = attachment?.storageKey;
   const mimeType = attachment?.mimeType;
+  const reloadKey = options?.reloadKey;
+  const hasSeenReloadKeyRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasSeenReloadKeyRef.current) {
+      hasSeenReloadKeyRef.current = true;
+      return;
+    }
+    if (stateRef.current.status === "failed") {
+      setRetryAttempt((attempt) => attempt + 1);
+    }
+  }, [reloadKey]);
 
   useEffect(() => {
     let disposed = false;
@@ -22,9 +55,11 @@ export function useAttachmentPreviewUrl(
 
     activeAttachmentRef.current = current ?? null;
     if (!current) {
-      setUrl(null);
+      setState({ status: "idle" });
       return;
     }
+
+    setState({ status: "resolving" });
 
     void (async () => {
       try {
@@ -34,14 +69,14 @@ export function useAttachmentPreviewUrl(
           return;
         }
         currentUrl = resolved;
-        setUrl(resolved);
+        setState({ status: "ready", url: resolved });
       } catch (error) {
         console.error("[attachments] Failed to resolve preview URL", {
           attachmentId: current.id,
           error,
         });
         if (!disposed) {
-          setUrl(null);
+          setState({ status: "failed" });
         }
       }
     })();
@@ -57,7 +92,15 @@ export function useAttachmentPreviewUrl(
         url: currentUrl,
       });
     };
-  }, [id, storageType, storageKey, mimeType]);
+  }, [id, storageType, storageKey, mimeType, retryAttempt]);
 
-  return url;
+  return state;
+}
+
+export function useAttachmentPreviewUrl(
+  attachment: AttachmentMetadata | null | undefined,
+  options?: UseAttachmentPreviewUrlOptions,
+): string | null {
+  const state = useAttachmentPreviewUrlState(attachment, options);
+  return state.status === "ready" ? state.url : null;
 }

--- a/packages/app/src/attachments/use-attachment-preview-url.ts
+++ b/packages/app/src/attachments/use-attachment-preview-url.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { releaseAttachmentPreviewUrl, resolveAttachmentPreviewUrl } from "@/attachments/service";
+import { retainLiveAttachment } from "@/attachments/live-attachments";
 
 export type AttachmentPreviewUrlState =
   | { status: "idle" }
@@ -37,6 +38,20 @@ export function useAttachmentPreviewUrlState(
   const mimeType = attachment?.mimeType;
   const reloadKey = options?.reloadKey;
   const hasSeenReloadKeyRef = useRef(false);
+  // A reload signal that arrived while a resolve was still in flight. That attempt read the
+  // store before the refreshed bytes landed, so its failure says nothing about them — retry
+  // instead of latching "failed", which nothing else would clear once the caller's key stops
+  // changing.
+  const pendingReloadRef = useRef(false);
+
+  // Garbage collection may not delete bytes we are displaying. Retaining by id (rather than
+  // waiting for a resolved URL) also covers the window where the resolve is still in flight.
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+    return retainLiveAttachment(id);
+  }, [id]);
 
   useEffect(() => {
     if (!hasSeenReloadKeyRef.current) {
@@ -45,6 +60,10 @@ export function useAttachmentPreviewUrlState(
     }
     if (stateRef.current.status === "failed") {
       setRetryAttempt((attempt) => attempt + 1);
+      return;
+    }
+    if (stateRef.current.status === "resolving") {
+      pendingReloadRef.current = true;
     }
   }, [reloadKey]);
 
@@ -54,6 +73,8 @@ export function useAttachmentPreviewUrlState(
     const current = attachmentRef.current;
 
     activeAttachmentRef.current = current ?? null;
+    // A fresh attempt supersedes any reload that arrived during the previous one.
+    pendingReloadRef.current = false;
     if (!current) {
       setState({ status: "idle" });
       return;
@@ -75,9 +96,15 @@ export function useAttachmentPreviewUrlState(
           attachmentId: current.id,
           error,
         });
-        if (!disposed) {
-          setState({ status: "failed" });
+        if (disposed) {
+          return;
         }
+        if (pendingReloadRef.current) {
+          pendingReloadRef.current = false;
+          setRetryAttempt((attempt) => attempt + 1);
+          return;
+        }
+        setState({ status: "failed" });
       }
     })();
 

--- a/packages/app/src/attachments/utils.ts
+++ b/packages/app/src/attachments/utils.ts
@@ -81,6 +81,16 @@ export function getFileNameFromPath(path: string | null | undefined): string | n
   return fileName || null;
 }
 
+// Preview attachments are a content-addressed cache of images the daemon already owns
+// (assistant markdown images, file explorer previews), not user data. They are keyed by
+// this prefix so attachment garbage collection can tell them apart from composer
+// attachments, which are rooted in drafts and queued messages.
+export const PREVIEW_ATTACHMENT_ID_PREFIX = "preview_";
+
+export function isPreviewAttachmentId(id: string): boolean {
+  return id.startsWith(PREVIEW_ATTACHMENT_ID_PREFIX);
+}
+
 export function createPreviewAttachmentId(input: {
   mimeType: string;
   path?: string | null;
@@ -93,7 +103,7 @@ export function createPreviewAttachmentId(input: {
   const modifiedAt = input.modifiedAt?.trim() ?? "";
   const contentLength = Number.isFinite(input.contentLength) ? String(input.contentLength) : "";
   const hash = hashString(`${input.mimeType}\0${path}\0${size}\0${modifiedAt}\0${contentLength}`);
-  return `preview_${size || contentLength || "unknown"}_${hash}`;
+  return `${PREVIEW_ATTACHMENT_ID_PREFIX}${size || contentLength || "unknown"}_${hash}`;
 }
 
 export async function blobToBase64(blob: Blob): Promise<string> {

--- a/packages/app/src/attachments/web/indexeddb-attachment-store.ts
+++ b/packages/app/src/attachments/web/indexeddb-attachment-store.ts
@@ -9,6 +9,7 @@ import {
   normalizeMimeType,
   parseDataUrl,
 } from "@/attachments/utils";
+import { shouldDeleteAttachmentDuringGc } from "@/attachments/gc-policy";
 
 interface StoredBlobRecord {
   id: string;
@@ -190,6 +191,7 @@ export function createIndexedDbAttachmentStore(): AttachmentStore {
 
     async garbageCollect({ referencedIds }): Promise<void> {
       const db = await openAttachmentDb();
+      const nowMs = Date.now();
       try {
         await new Promise<void>((resolve, reject) => {
           const tx = db.transaction(STORE_NAME, "readwrite");
@@ -210,7 +212,15 @@ export function createIndexedDbAttachmentStore(): AttachmentStore {
             }
 
             const key = String(cursor.key);
-            if (!referencedIds.has(key)) {
+            const record = cursor.value as StoredBlobRecord | undefined;
+            if (
+              shouldDeleteAttachmentDuringGc({
+                id: key,
+                isReferenced: referencedIds.has(key),
+                createdAtMs: typeof record?.createdAt === "number" ? record.createdAt : null,
+                nowMs,
+              })
+            ) {
               cursor.delete();
             }
             cursor.continue();

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -102,7 +102,10 @@ import {
   useAssistantLinkPress,
 } from "@/assistant-file-links";
 import { getCompactionMarkerLabel } from "./message-compaction-label";
-import { useAttachmentPreviewUrl } from "@/attachments/use-attachment-preview-url";
+import {
+  type AttachmentPreviewUrlState,
+  useAttachmentPreviewUrlState,
+} from "@/attachments/use-attachment-preview-url";
 import { persistAttachmentFromBytes, persistAttachmentFromDataUrl } from "@/attachments/service";
 import {
   AttachmentFrame,
@@ -984,8 +987,14 @@ function AssistantMarkdownImage({
     },
   });
 
-  const fileAssetUri = useAttachmentPreviewUrl(query.data);
-  const dataImageAssetUri = useAttachmentPreviewUrl(dataImageQuery.data);
+  const filePreview = useAttachmentPreviewUrlState(query.data, {
+    reloadKey: query.dataUpdatedAt,
+  });
+  const dataImagePreview = useAttachmentPreviewUrlState(dataImageQuery.data, {
+    reloadKey: dataImageQuery.dataUpdatedAt,
+  });
+  const fileAssetUri = previewUrlOrNull(filePreview);
+  const dataImageAssetUri = previewUrlOrNull(dataImagePreview);
   const directUri = resolution?.kind === "direct" && !dataImage ? resolution.uri : null;
   const resolvedUri = directUri ?? dataImageAssetUri ?? fileAssetUri ?? null;
 
@@ -1012,7 +1021,13 @@ function AssistantMarkdownImage({
     );
   }
 
-  if (query.isLoading || dataImageQuery.isLoading) {
+  // Resolving the preview URL is a second async hop after the bytes land, so treat it as
+  // part of loading — otherwise the failure text paints for a frame on every success.
+  if (
+    query.isLoading ||
+    dataImageQuery.isLoading ||
+    isAnyPreviewResolving(filePreview, dataImagePreview)
+  ) {
     return (
       <View style={stateFrameStyle}>
         <ThemedLoadingSpinner size="small" uniProps={foregroundMutedColorMapping} />
@@ -1031,6 +1046,14 @@ function AssistantMarkdownImage({
       <Text style={assistantMessageStylesheet.imageErrorText}>{errorText}</Text>
     </View>
   );
+}
+
+function previewUrlOrNull(state: AttachmentPreviewUrlState): string | null {
+  return state.status === "ready" ? state.url : null;
+}
+
+function isAnyPreviewResolving(...states: readonly AttachmentPreviewUrlState[]): boolean {
+  return states.some((state) => state.status === "resolving");
 }
 
 function resolveAssistantImageErrorText(

--- a/packages/app/src/file-pane/pane.tsx
+++ b/packages/app/src/file-pane/pane.tsx
@@ -454,6 +454,7 @@ export function FilePane({
   const preview = resolvedPreview.key === previewKey ? resolvedPreview.file : null;
   const imagePreviewUri = useAttachmentPreviewUrl(
     resolvedPreview.key === previewKey ? resolvedPreview.imageAttachment : null,
+    { reloadKey: query.dataUpdatedAt },
   );
   const isMarkdown = isMarkdownPreview(preview, location.path);
   const editable = isEditableTextFile({

--- a/packages/desktop/src/features/attachments.test.ts
+++ b/packages/desktop/src/features/attachments.test.ts
@@ -1,8 +1,13 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { copyAttachmentFileToManagedStorage } from "./attachments";
+import {
+  copyAttachmentFileToManagedStorage,
+  garbageCollectManagedAttachmentFiles,
+} from "./attachments";
+
+const PREVIEW_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 const originalPaseoHome = process.env.PASEO_HOME;
 let testHome: string | null = null;
@@ -61,5 +66,53 @@ describe("desktop attachment files", () => {
       byteSize: 9,
     });
     await expect(readFile(result.path, "utf8")).resolves.toBe("# Report\n");
+  });
+
+  describe("garbageCollectManagedAttachmentFiles", () => {
+    async function seedAttachmentsDir(
+      paseoHome: string,
+      files: readonly { name: string; ageMs?: number }[],
+    ): Promise<string> {
+      const dirPath = path.join(paseoHome, "desktop-attachments");
+      await mkdir(dirPath, { recursive: true });
+      for (const file of files) {
+        const filePath = path.join(dirPath, file.name);
+        await writeFile(filePath, "bytes");
+        if (file.ageMs !== undefined) {
+          const seconds = (Date.now() - file.ageMs) / 1000;
+          await utimes(filePath, seconds, seconds);
+        }
+      }
+      return dirPath;
+    }
+
+    it("keeps unreferenced previews so composer edits do not evict rendered images", async () => {
+      const paseoHome = await useTempPaseoHome();
+      const dirPath = await seedAttachmentsDir(paseoHome, [
+        { name: "preview_4_abc.png" },
+        { name: "att_unreferenced.png" },
+        { name: "att_kept.png" },
+      ]);
+
+      const deleted = await garbageCollectManagedAttachmentFiles({
+        referencedIds: ["att_kept"],
+      });
+
+      expect(deleted).toBe(1);
+      expect((await readdir(dirPath)).sort()).toEqual(["att_kept.png", "preview_4_abc.png"]);
+    });
+
+    it("evicts previews older than the max age", async () => {
+      const paseoHome = await useTempPaseoHome();
+      const dirPath = await seedAttachmentsDir(paseoHome, [
+        { name: "preview_4_fresh.png", ageMs: 0 },
+        { name: "preview_4_stale.png", ageMs: PREVIEW_MAX_AGE_MS + 60_000 },
+      ]);
+
+      const deleted = await garbageCollectManagedAttachmentFiles({ referencedIds: [] });
+
+      expect(deleted).toBe(1);
+      expect(await readdir(dirPath)).toEqual(["preview_4_fresh.png"]);
+    });
   });
 });

--- a/packages/desktop/src/features/attachments.ts
+++ b/packages/desktop/src/features/attachments.ts
@@ -6,6 +6,13 @@ const ATTACHMENTS_DIRNAME = "desktop-attachments";
 const ATTACHMENT_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const EXTENSION_PATTERN = /^\.[A-Za-z0-9]{1,16}$/;
 
+// Mirrors the renderer's attachment GC policy (packages/app/src/attachments/gc-policy.ts).
+// Preview attachments cache bytes the daemon still owns and are never rooted in drafts, so
+// reference-based collection would delete them on every composer keystroke. They expire on
+// age instead. Keep the prefix and max age in sync with the renderer.
+const PREVIEW_ATTACHMENT_ID_PREFIX = "preview_";
+const PREVIEW_ATTACHMENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
 interface AttachmentFileResult {
   path: string;
   byteSize: number;
@@ -173,12 +180,36 @@ export async function garbageCollectManagedAttachmentFiles(input: {
       )
     : new Set<string>();
 
+  const nowMs = Date.now();
   const entries = await readdir(dirPath, { withFileTypes: true });
-  const toDelete = entries.filter(
+  const unreferenced = entries.filter(
     (entry) => entry.isFile() && !referencedIds.has(path.parse(entry.name).name),
   );
 
-  await Promise.all(toDelete.map((entry) => rm(path.join(dirPath, entry.name), { force: true })));
+  const deletions = await Promise.all(
+    unreferenced.map(async (entry) => {
+      const filePath = path.join(dirPath, entry.name);
+      if (path.parse(entry.name).name.startsWith(PREVIEW_ATTACHMENT_ID_PREFIX)) {
+        const expired = await isExpiredPreviewFile(filePath, nowMs);
+        if (!expired) {
+          return false;
+        }
+      }
+      await rm(filePath, { force: true });
+      return true;
+    }),
+  );
 
-  return toDelete.length;
+  return deletions.filter(Boolean).length;
+}
+
+// A preview whose age cannot be established is kept: keeping it costs disk, deleting it
+// breaks an image that is very likely still on screen.
+async function isExpiredPreviewFile(filePath: string, nowMs: number): Promise<boolean> {
+  try {
+    const stats = await stat(filePath);
+    return nowMs - stats.mtimeMs > PREVIEW_ATTACHMENT_MAX_AGE_MS;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Fixes #2554.

## The bug

Assistant image previews are persisted into the same attachment store as composer attachments, but the GC roots in `runAttachmentGc` only cover drafts, queued messages, create-flow images, and browser-element screenshots. Preview attachments (`preview_<size>_<hash>`, from `createPreviewAttachmentId`) are never in that set, so every draft mutation — including each composer keystroke — deleted the bytes behind images that were still on screen. `resolvePreviewUrl` then threw, `useAttachmentPreviewUrl` swallowed it and returned `null`, and `AssistantMarkdownImage` fell through to **"Unable to load image preview."**

Codex sessions hit this hardest because Codex emits `imageView` / `imageGeneration` thread items, so nearly every image it views or generates becomes one of these previews. Claude only produces them from tool results carrying image content.

Symptom on an affected machine: `~/.paseo/desktop-attachments/` was completely empty.

## The fix

Previews are a content-addressed cache of bytes the daemon still owns, so they get an age-based lifetime instead of reference counting. New `packages/app/src/attachments/gc-policy.ts`:

- referenced → keep
- unreferenced non-preview → delete (unchanged)
- unreferenced preview → delete only once older than `PREVIEW_ATTACHMENT_MAX_AGE_MS` (7 days)
- preview whose age can't be established → keep

Applied in all three stores. The Electron main process can't import from the app, so `packages/desktop/src/features/attachments.ts` mirrors the prefix and max age with a comment pointing back at the renderer policy. `AttachmentFileInfo` gained `modificationTimeMs` (expo reports seconds; converted at the boundary) so the native store can age previews; it only stats entries that are both unreferenced and previews, so the common sweep stays a plain listing.

Two secondary fixes for cases where the failure showed even with the bytes present:

- **No loading state for URL resolution.** Resolving the preview URL is a second async hop after the bytes land, so the failure text painted for a frame on every *successful* load. `useAttachmentPreviewUrlState` now reports `resolving`, and `message.tsx` treats it as loading.
- **Failures were permanent.** Preview ids are content-derived and stable, so the hook's effect deps never changed and a single failed resolve stuck until the component remounted — refetching the bytes couldn't clear it. Callers can now pass a `reloadKey` (`query.dataUpdatedAt`). Only a *failed* resolve retries, so a routine refetch never drops a rendered image back to a spinner.

`useAttachmentPreviewUrl` keeps its existing `string | null` signature for the other four call sites.

## Testing

- `gc-policy.test.ts` — the policy table
- `local-file-attachment-store.test.ts` — unreferenced previews survive a sweep; stale ones are evicted
- `packages/desktop/src/features/attachments.test.ts` — same two cases against the real filesystem
- `use-attachment-preview-url.test.tsx` — reports `resolving` before the URL lands; retries a failed resolve on `reloadKey` change; keeps a resolved URL when `reloadKey` changes after success

51 tests pass in `packages/app/src/attachments`, 4 in the desktop attachments suite. `npm run typecheck`, `npm run lint`, and `npm run format` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
