### PR TITLE
feat(pi): steer mid-turn messages into the active turn instead of interrupting

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -517,6 +517,168 @@ async function createControlledInterruptFixture(options: {
   };
 }
 
+class HeldTurnSession extends TestAgentSession {
+  readonly heldTurnId = "held-turn";
+
+  override async startTurn(): Promise<{ turnId: string }> {
+    // Same deferred emission as TestAgentSession: events must arrive after
+    // the caller sets up the foreground waiter. Unlike the base class the
+    // turn never completes, keeping the run in flight for steer tests.
+    setTimeout(() => {
+      this.pushEvent({ type: "turn_started", provider: this.provider, turnId: this.heldTurnId });
+    }, 0);
+    return { turnId: this.heldTurnId };
+  }
+}
+
+class SteerableSession extends HeldTurnSession {
+  readonly steerCalls: Array<{ prompt: AgentPromptInput; clientMessageId?: string }> = [];
+  steerError: Error | null = null;
+  interruptCount = 0;
+
+  async steerActiveTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean> {
+    if (this.steerError) {
+      throw this.steerError;
+    }
+    this.steerCalls.push({ prompt, clientMessageId: options?.clientMessageId });
+    return true;
+  }
+
+  override async interrupt(): Promise<void> {
+    this.interruptCount += 1;
+  }
+}
+
+interface HeldTurnFixture<TSession extends TestAgentSession> {
+  agentId: string;
+  manager: AgentManager;
+  session: TSession;
+  cleanup(): void;
+}
+
+async function createHeldTurnFixture<TSession extends TestAgentSession>(
+  name: string,
+  session: TSession,
+  options?: { startRun?: boolean },
+): Promise<HeldTurnFixture<TSession>> {
+  const workdir = mkdtempSync(join(tmpdir(), `agent-manager-${name}-`));
+  const client = new (class extends TestAgentClient {
+    override async createSession(): Promise<AgentSession> {
+      return session;
+    }
+  })();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    logger,
+  });
+  const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  if (options?.startRun !== false) {
+    const run = manager.streamAgent(agent.id, "hold the turn");
+    void (async () => {
+      for await (const _event of run) {
+        // Keep the foreground stream subscribed so the turn stays in flight.
+      }
+    })();
+    await manager.waitForAgentRunStart(agent.id);
+  }
+  return {
+    agentId: agent.id,
+    manager,
+    session,
+    cleanup: () => rmSync(workdir, { recursive: true, force: true }),
+  };
+}
+
+test("trySteerActiveTurn delivers a plain prompt into the in-flight run", async () => {
+  const fixture = await createHeldTurnFixture(
+    "steer-deliver",
+    new SteerableSession({
+      provider: "codex",
+      cwd: "/tmp",
+    }),
+  );
+  try {
+    const steered = await fixture.manager.trySteerActiveTurn(fixture.agentId, "also do this", {
+      clientMessageId: "client-steer",
+    });
+
+    expect(steered).toBe(true);
+    expect(fixture.session.steerCalls).toEqual([
+      { prompt: "also do this", clientMessageId: "client-steer" },
+    ]);
+    expect(fixture.session.interruptCount).toBe(0);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("trySteerActiveTurn refuses slash commands so they keep the prompt path", async () => {
+  const fixture = await createHeldTurnFixture(
+    "steer-slash",
+    new SteerableSession({
+      provider: "codex",
+      cwd: "/tmp",
+    }),
+  );
+  try {
+    const steered = await fixture.manager.trySteerActiveTurn(fixture.agentId, "/compact");
+
+    expect(steered).toBe(false);
+    expect(fixture.session.steerCalls).toEqual([]);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("trySteerActiveTurn falls back when the session has no steer support", async () => {
+  const fixture = await createHeldTurnFixture(
+    "steer-unsupported",
+    new HeldTurnSession({
+      provider: "codex",
+      cwd: "/tmp",
+    }),
+  );
+  try {
+    const steered = await fixture.manager.trySteerActiveTurn(fixture.agentId, "also do this");
+
+    expect(steered).toBe(false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("trySteerActiveTurn falls back when no run is in flight", async () => {
+  const fixture = await createHeldTurnFixture(
+    "steer-idle",
+    new SteerableSession({ provider: "codex", cwd: "/tmp" }),
+    { startRun: false },
+  );
+  try {
+    const steered = await fixture.manager.trySteerActiveTurn(fixture.agentId, "also do this");
+
+    expect(steered).toBe(false);
+    expect(fixture.session.steerCalls).toEqual([]);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("trySteerActiveTurn swallows session steer failures for the replace fallback", async () => {
+  const session = new SteerableSession({ provider: "codex", cwd: "/tmp" });
+  session.steerError = new Error("steer RPC failed");
+  const fixture = await createHeldTurnFixture("steer-error", session);
+  try {
+    const steered = await fixture.manager.trySteerActiveTurn(fixture.agentId, "also do this");
+
+    expect(steered).toBe(false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 class HeldRuntimeInfoSession extends TestAgentSession {
   private readonly runtimeInfoRequested = deferred<void>();
   private readonly runtimeInfoAllowed = deferred<void>();

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -534,6 +534,7 @@ class HeldTurnSession extends TestAgentSession {
 class SteerableSession extends HeldTurnSession {
   readonly steerCalls: Array<{ prompt: AgentPromptInput; clientMessageId?: string }> = [];
   steerError: Error | null = null;
+  steerResult = true;
   interruptCount = 0;
 
   async steerActiveTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean> {
@@ -541,7 +542,7 @@ class SteerableSession extends HeldTurnSession {
       throw this.steerError;
     }
     this.steerCalls.push({ prompt, clientMessageId: options?.clientMessageId });
-    return true;
+    return this.steerResult;
   }
 
   override async interrupt(): Promise<void> {
@@ -615,19 +616,19 @@ test("trySteerActiveTurn delivers a plain prompt into the in-flight run", async 
   }
 });
 
-test("trySteerActiveTurn refuses slash commands so they keep the prompt path", async () => {
-  const fixture = await createHeldTurnFixture(
-    "steer-slash",
-    new SteerableSession({
-      provider: "codex",
-      cwd: "/tmp",
-    }),
-  );
+test("trySteerActiveTurn delegates slash commands to the session's own gate", async () => {
+  const session = new SteerableSession({ provider: "codex", cwd: "/tmp" });
+  session.steerResult = false;
+  const fixture = await createHeldTurnFixture("steer-slash", session);
   try {
+    // The manager does not pre-filter prompts; the provider session refuses
+    // slash commands after flattening (structured prompts included).
     const steered = await fixture.manager.trySteerActiveTurn(fixture.agentId, "/compact");
 
     expect(steered).toBe(false);
-    expect(fixture.session.steerCalls).toEqual([]);
+    expect(fixture.session.steerCalls).toEqual([
+      { prompt: "/compact", clientMessageId: undefined },
+    ]);
   } finally {
     fixture.cleanup();
   }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2178,11 +2178,6 @@ export class AgentManager {
     if (!this.hasInFlightRun(agentId)) {
       return false;
     }
-    // Slash commands must keep the prompt-RPC path (local commands, skills);
-    // runtimes reject "/" messages on the steer channel outright.
-    if (typeof prompt === "string" && prompt.trimStart().startsWith("/")) {
-      return false;
-    }
     const session = this.agents.get(agentId)?.session;
     if (!session?.steerActiveTurn) {
       return false;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2164,6 +2164,40 @@ export class AgentManager {
     }
   }
 
+  /**
+   * Try to deliver a user message into the in-flight turn without
+   * interrupting it. Only providers whose session implements
+   * `steerActiveTurn` participate; every other case returns false so the
+   * caller keeps interrupt-and-replace semantics.
+   */
+  async trySteerActiveTurn(
+    agentId: string,
+    prompt: AgentPromptInput,
+    options?: AgentRunOptions,
+  ): Promise<boolean> {
+    if (!this.hasInFlightRun(agentId)) {
+      return false;
+    }
+    // Slash commands must keep the prompt-RPC path (local commands, skills);
+    // runtimes reject "/" messages on the steer channel outright.
+    if (typeof prompt === "string" && prompt.trimStart().startsWith("/")) {
+      return false;
+    }
+    const session = this.agents.get(agentId)?.session;
+    if (!session?.steerActiveTurn) {
+      return false;
+    }
+    try {
+      return await session.steerActiveTurn(prompt, options);
+    } catch (error) {
+      this.logger.warn(
+        { err: error, agentId },
+        "Failed to steer the active turn; falling back to run replacement",
+      );
+      return false;
+    }
+  }
+
   async replaceAgentRun(
     agentId: string,
     prompt: AgentPromptInput,

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, test, vi } from "vitest";
+import { expect, it, test, vi, type Mock } from "vitest";
 import pino, { type Logger } from "pino";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
@@ -89,6 +89,7 @@ function createFinishNotificationScenario(
   });
   Reflect.set(agentManager, "tryRunOutOfBand", () => false);
   Reflect.set(agentManager, "hasInFlightRun", () => Boolean(options?.parentPromptError));
+  Reflect.set(agentManager, "trySteerActiveTurn", async () => false);
   Reflect.set(agentManager, "streamAgent", (_agentId: string, prompt: string) => {
     parentPrompted = true;
     resolveParentPrompt?.(prompt);
@@ -192,6 +193,82 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
     outputSchema: { type: "object" },
     clientMessageId: "msg-client-1",
   });
+});
+
+function createBusyPromptHarness(input: { steer: boolean }): {
+  agentManager: AgentManager;
+  agentStorage: AgentStorage;
+  trySteerSpy: Mock;
+  replaceAgentRunSpy: Mock;
+  streamAgentSpy: Mock;
+} {
+  const agent: ManagedAgent = Object.create(null);
+  Reflect.set(agent, "id", "agent-1");
+  Reflect.set(agent, "provider", "pi");
+
+  const trySteerSpy = vi.fn(async () => input.steer);
+  const replaceAgentRunSpy = vi.fn(() => (async function* noop() {})());
+  const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => agent),
+  );
+  Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(true));
+  Reflect.set(agentManager, "trySteerActiveTurn", trySteerSpy);
+  Reflect.set(agentManager, "replaceAgentRun", replaceAgentRunSpy);
+  Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(
+    agentStorage,
+    "get",
+    vi.fn(async () => null),
+  );
+
+  return { agentManager, agentStorage, trySteerSpy, replaceAgentRunSpy, streamAgentSpy };
+}
+
+test("sendPromptToAgent steers into the in-flight run instead of replacing it", async () => {
+  const { agentManager, agentStorage, trySteerSpy, replaceAgentRunSpy, streamAgentSpy } =
+    createBusyPromptHarness({ steer: true });
+
+  await sendPromptToAgent({
+    agentManager,
+    agentStorage,
+    agentId: "agent-1",
+    prompt: "also do this",
+    messageId: "msg-client-steer",
+    logger: createTestLogger(),
+  });
+
+  expect(trySteerSpy).toHaveBeenCalledWith("agent-1", "also do this", {
+    clientMessageId: "msg-client-steer",
+  });
+  expect(replaceAgentRunSpy).not.toHaveBeenCalled();
+  expect(streamAgentSpy).not.toHaveBeenCalled();
+});
+
+test("sendPromptToAgent falls back to replacing the run when steering is unavailable", async () => {
+  const { agentManager, agentStorage, trySteerSpy, replaceAgentRunSpy, streamAgentSpy } =
+    createBusyPromptHarness({ steer: false });
+
+  await sendPromptToAgent({
+    agentManager,
+    agentStorage,
+    agentId: "agent-1",
+    prompt: "replace with this",
+    messageId: "msg-client-replace",
+    logger: createTestLogger(),
+  });
+
+  expect(trySteerSpy).toHaveBeenCalled();
+  expect(replaceAgentRunSpy).toHaveBeenCalledWith("agent-1", "replace with this", {
+    clientMessageId: "msg-client-replace",
+  });
+  expect(streamAgentSpy).not.toHaveBeenCalled();
 });
 
 test("finish notifications tell the parent the child's last assistant message", async () => {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "pino";
 
-import type { AgentPromptInput, AgentRunOptions } from "./agent-sdk-types.js";
+import type { AgentPromptInput, AgentRunOptions, AgentStreamEvent } from "./agent-sdk-types.js";
 import type { AgentManager, ManagedAgent } from "./agent-manager.js";
 import type { AgentStorage } from "./agent-storage.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
@@ -10,12 +10,51 @@ export type AgentUnarchiveController = Pick<AgentManager, "notifyAgentState" | "
 
 export type AgentRunController = Pick<
   AgentManager,
-  "getAgent" | "tryRunOutOfBand" | "hasInFlightRun" | "replaceAgentRun" | "streamAgent"
+  | "getAgent"
+  | "tryRunOutOfBand"
+  | "hasInFlightRun"
+  | "replaceAgentRun"
+  | "streamAgent"
+  | "trySteerActiveTurn"
 >;
 
 export interface StartAgentRunOptions {
   replaceRunning?: boolean;
+  /**
+   * When the target has an in-flight run, deliver the prompt into that turn
+   * (provider steering) instead of interrupting it. Falls back to replace
+   * semantics when the provider can't steer. Only meaningful with
+   * `replaceRunning`.
+   */
+  steerRunning?: boolean;
   runOptions?: AgentRunOptions;
+}
+
+/**
+ * Resolve the run stream for a prompt. Returns null when the prompt was
+ * steered into the in-flight turn — no new stream exists in that case.
+ */
+async function openRunStream(
+  agentManager: AgentRunController,
+  agentId: string,
+  prompt: AgentPromptInput,
+  logger: Logger,
+  options?: StartAgentRunOptions,
+): Promise<AsyncGenerator<AgentStreamEvent> | null> {
+  const runOptions = options?.runOptions;
+  const shouldReplace = Boolean(options?.replaceRunning && agentManager.hasInFlightRun(agentId));
+  if (
+    shouldReplace &&
+    options?.steerRunning &&
+    (await agentManager.trySteerActiveTurn(agentId, prompt, runOptions))
+  ) {
+    logger.trace({ agentId }, "agent.session.start_stream.steered_active_turn");
+    return null;
+  }
+  if (shouldReplace) {
+    return agentManager.replaceAgentRun(agentId, prompt, runOptions);
+  }
+  return agentManager.streamAgent(agentId, prompt, runOptions);
 }
 
 export async function startAgentRun(
@@ -44,17 +83,18 @@ export async function startAgentRun(
   if (agentManager.tryRunOutOfBand(agentId, prompt)) {
     return { outOfBand: true };
   }
-  const shouldReplace = Boolean(options?.replaceRunning && agentManager.hasInFlightRun(agentId));
-  const runOptions = options?.runOptions;
-  const iterator = shouldReplace
-    ? await agentManager.replaceAgentRun(agentId, prompt, runOptions)
-    : agentManager.streamAgent(agentId, prompt, runOptions);
+  const iterator = await openRunStream(agentManager, agentId, prompt, logger, options);
+  if (!iterator) {
+    // Delivered into the in-flight turn via provider steering; the active
+    // run's stream carries the rest of the events.
+    return { outOfBand: false };
+  }
   logger.trace(
     {
       agentId,
       provider: snapshot?.provider,
       providerSessionId: snapshot?.persistence?.sessionId ?? undefined,
-      shouldReplace,
+      replaceRunning: Boolean(options?.replaceRunning),
     },
     "agent.session.start_stream.iterator_returned",
   );
@@ -203,6 +243,7 @@ export async function sendPromptToAgent(
 
   return await startAgentRun(params.agentManager, params.agentId, params.prompt, params.logger, {
     replaceRunning: true,
+    steerRunning: true,
     runOptions,
   });
 }

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -623,6 +623,13 @@ export interface AgentSession {
   readonly features?: AgentFeature[];
   run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult>;
   startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<{ turnId: string }>;
+  /**
+   * Deliver a user message into the in-flight turn without interrupting it
+   * (e.g. OMP's `steer` RPC). Optional: providers without mid-turn injection
+   * leave it undefined and callers keep interrupt-and-replace semantics.
+   * Returns false when no turn is active so the caller can fall back.
+   */
+  steerActiveTurn?(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean>;
   subscribe(callback: (event: AgentStreamEvent) => void): () => void;
   streamHistory(): AsyncGenerator<AgentStreamEvent>;
   getRuntimeInfo(): Promise<AgentRuntimeInfo>;

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -700,7 +700,7 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
-  test("correlates a steer drained into a later turn behind that turn's prompt", async () => {
+  test("correlates a leftover steer that auto-drains after an interrupt", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
 
@@ -710,15 +710,16 @@ describe("PiRpcAgentSession", () => {
     await session.steerActiveTurn("queued steer", { clientMessageId: "client-steer" });
     await session.interrupt();
 
-    // The next turn drains the queued steer behind its own prompt, so the
-    // runtime reports the new prompt's entry first.
-    await session.startTurn("second", { clientMessageId: "client-second" });
-    fakeSession.finishSubmittedUserMessage({ id: "entry-second", parentId: null, text: "second" });
+    // OMP drains the stranded steer into its own turn right after the
+    // abort — its marker arrives with no daemon turn active.
     fakeSession.finishSubmittedUserMessage({
       id: "entry-steer",
-      parentId: "entry-second",
+      parentId: "entry-first",
       text: "queued steer",
     });
+
+    await session.startTurn("second", { clientMessageId: "client-second" });
+    fakeSession.finishSubmittedUserMessage({ id: "entry-second", parentId: null, text: "second" });
 
     expect(events.timelineItems()).toEqual([
       {
@@ -729,15 +730,15 @@ describe("PiRpcAgentSession", () => {
       },
       {
         type: "user_message",
-        text: "second",
-        messageId: "entry-second",
-        clientMessageId: "client-second",
-      },
-      {
-        type: "user_message",
         text: "queued steer",
         messageId: "entry-steer",
         clientMessageId: "client-steer",
+      },
+      {
+        type: "user_message",
+        text: "second",
+        messageId: "entry-second",
+        clientMessageId: "client-second",
       },
     ]);
   });
@@ -751,18 +752,19 @@ describe("PiRpcAgentSession", () => {
     await session.steerActiveTurn("same text", { clientMessageId: "client-steer" });
     await session.interrupt();
 
-    // The user resends the identical message; the runtime persists the new
-    // prompt before draining the queued steer, so its marker arrives first
-    // and must keep the new submission's client message id.
+    // The stranded steer auto-drains after the abort; its marker arrives
+    // first and must keep the steered submission's client message id.
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer",
+      parentId: "entry-first",
+      text: "same text",
+    });
+
+    // The user resends the identical message.
     await session.startTurn("same text", { clientMessageId: "client-resent" });
     fakeSession.finishSubmittedUserMessage({
       id: "entry-resent",
-      parentId: null,
-      text: "same text",
-    });
-    fakeSession.finishSubmittedUserMessage({
-      id: "entry-steer",
-      parentId: "entry-resent",
+      parentId: "entry-steer",
       text: "same text",
     });
 
@@ -776,16 +778,63 @@ describe("PiRpcAgentSession", () => {
       {
         type: "user_message",
         text: "same text",
-        messageId: "entry-resent",
-        clientMessageId: "client-resent",
+        messageId: "entry-steer",
+        clientMessageId: "client-steer",
       },
       {
         type: "user_message",
         text: "same text",
-        messageId: "entry-steer",
-        clientMessageId: "client-steer",
+        messageId: "entry-resent",
+        clientMessageId: "client-resent",
       },
     ]);
+  });
+
+  test("converts a busy prompt rejection into a steer delivery", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    fakeSession.holdNextPrompt();
+    const { turnId } = await session.startTurn("deliver this", {
+      clientMessageId: "client-busy",
+    });
+    await fakeSession.failHeldPrompt(
+      new Error(
+        "prompt: Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion.",
+      ),
+    );
+
+    expect(fakeSession.steerRequests).toEqual([{ message: "deliver this", imageCount: 0 }]);
+    const cancellation = await events.nextTurnCancellation();
+    expect(cancellation).toMatchObject({ type: "turn_canceled", turnId });
+
+    // The submitted entry stays queued: its marker arrives in the busy turn
+    // with no daemon turn active and still correlates.
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-busy",
+      parentId: null,
+      text: "deliver this",
+    });
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "deliver this",
+        messageId: "entry-busy",
+        clientMessageId: "client-busy",
+      },
+    ]);
+  });
+
+  test("refuses to steer slash commands arriving as structured prompts", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("first");
+
+    await expect(session.steerActiveTurn([{ type: "text", text: "/compact" }])).resolves.toBe(
+      false,
+    );
+    expect(fakeSession.steerRequests).toEqual([]);
   });
 
   test("refuses to steer when no turn is active", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -700,7 +700,7 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
-  test("correlates a steer drained into a later turn by text", async () => {
+  test("correlates a steer drained into a later turn behind that turn's prompt", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
 
@@ -736,6 +736,52 @@ describe("PiRpcAgentSession", () => {
       {
         type: "user_message",
         text: "queued steer",
+        messageId: "entry-steer",
+        clientMessageId: "client-steer",
+      },
+    ]);
+  });
+
+  test("keeps correlations when an interrupted steer is resent verbatim", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("first", { clientMessageId: "client-first" });
+    fakeSession.finishSubmittedUserMessage({ id: "entry-first", parentId: null, text: "first" });
+    await session.steerActiveTurn("same text", { clientMessageId: "client-steer" });
+    await session.interrupt();
+
+    // The user resends the identical message; the runtime persists the new
+    // prompt before draining the queued steer, so its marker arrives first
+    // and must keep the new submission's client message id.
+    await session.startTurn("same text", { clientMessageId: "client-resent" });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-resent",
+      parentId: null,
+      text: "same text",
+    });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer",
+      parentId: "entry-resent",
+      text: "same text",
+    });
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "first",
+        messageId: "entry-first",
+        clientMessageId: "client-first",
+      },
+      {
+        type: "user_message",
+        text: "same text",
+        messageId: "entry-resent",
+        clientMessageId: "client-resent",
+      },
+      {
+        type: "user_message",
+        text: "same text",
         messageId: "entry-steer",
         clientMessageId: "client-steer",
       },

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -621,6 +621,171 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("steers a message into the active turn and correlates its submitted entry", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("first", { clientMessageId: "client-first" });
+    fakeSession.finishSubmittedUserMessage({ id: "entry-first", parentId: null, text: "first" });
+
+    const steered = await session.steerActiveTurn("also do this", {
+      clientMessageId: "client-steer",
+    });
+
+    expect(steered).toBe(true);
+    expect(fakeSession.steerRequests).toEqual([{ message: "also do this", imageCount: 0 }]);
+
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer",
+      parentId: "entry-first",
+      text: "also do this",
+    });
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "first",
+        messageId: "entry-first",
+        clientMessageId: "client-first",
+      },
+      {
+        type: "user_message",
+        text: "also do this",
+        messageId: "entry-steer",
+        clientMessageId: "client-steer",
+      },
+    ]);
+  });
+
+  test("keeps client message ids aligned across multiple steers in one turn", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("first", { clientMessageId: "client-first" });
+    fakeSession.finishSubmittedUserMessage({ id: "entry-first", parentId: null, text: "first" });
+
+    await session.steerActiveTurn("steer one", { clientMessageId: "client-steer-1" });
+    await session.steerActiveTurn("steer two", { clientMessageId: "client-steer-2" });
+
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer-1",
+      parentId: "entry-first",
+      text: "steer one",
+    });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer-2",
+      parentId: "entry-steer-1",
+      text: "steer two",
+    });
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "first",
+        messageId: "entry-first",
+        clientMessageId: "client-first",
+      },
+      {
+        type: "user_message",
+        text: "steer one",
+        messageId: "entry-steer-1",
+        clientMessageId: "client-steer-1",
+      },
+      {
+        type: "user_message",
+        text: "steer two",
+        messageId: "entry-steer-2",
+        clientMessageId: "client-steer-2",
+      },
+    ]);
+  });
+
+  test("correlates a steer drained into a later turn by text", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("first", { clientMessageId: "client-first" });
+    fakeSession.finishSubmittedUserMessage({ id: "entry-first", parentId: null, text: "first" });
+    // The steer is queued but not yet drained when the turn is interrupted.
+    await session.steerActiveTurn("queued steer", { clientMessageId: "client-steer" });
+    await session.interrupt();
+
+    // The next turn drains the queued steer behind its own prompt, so the
+    // runtime reports the new prompt's entry first.
+    await session.startTurn("second", { clientMessageId: "client-second" });
+    fakeSession.finishSubmittedUserMessage({ id: "entry-second", parentId: null, text: "second" });
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer",
+      parentId: "entry-second",
+      text: "queued steer",
+    });
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "first",
+        messageId: "entry-first",
+        clientMessageId: "client-first",
+      },
+      {
+        type: "user_message",
+        text: "second",
+        messageId: "entry-second",
+        clientMessageId: "client-second",
+      },
+      {
+        type: "user_message",
+        text: "queued steer",
+        messageId: "entry-steer",
+        clientMessageId: "client-steer",
+      },
+    ]);
+  });
+
+  test("refuses to steer when no turn is active", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await expect(session.steerActiveTurn("hello")).resolves.toBe(false);
+
+    expect(fakeSession.steerRequests).toEqual([]);
+  });
+
+  test("refuses to steer against runtimes without steering queues", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+    delete fakeSession.state.steeringMode;
+
+    await session.startTurn("first");
+
+    await expect(session.steerActiveTurn("also do this")).resolves.toBe(false);
+    expect(fakeSession.steerRequests).toEqual([]);
+  });
+
+  test("does not queue a submitted entry when the steer RPC fails", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.steerError = new Error("steer unsupported");
+
+    await session.startTurn("first", { clientMessageId: "client-first" });
+    await expect(
+      session.steerActiveTurn("nope", { clientMessageId: "client-nope" }),
+    ).rejects.toThrow("steer unsupported");
+
+    // The failed steer left no pending entry: the turn-start marker still
+    // correlates to the turn's own client message id.
+    fakeSession.finishSubmittedUserMessage({ id: "entry-first", parentId: null, text: "first" });
+
+    expect(events.timelineItems()).toEqual([
+      {
+        type: "user_message",
+        text: "first",
+        messageId: "entry-first",
+        clientMessageId: "client-first",
+      },
+    ]);
+  });
+
   test("uses the Pi entry attached to a submitted prompt after resuming old history", async () => {
     const pi = new FakePi();
     const client = createClient(pi);

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1223,6 +1223,19 @@ export class PiRpcAgentSession implements AgentSession {
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
   private activeTurnId: string | null = null;
   private activeClientMessageId: string | null = null;
+  /**
+   * FIFO of user messages submitted to the native process (turn prompts and
+   * mid-turn steers) awaiting their PASEO_SUBMITTED_USER_ENTRY marker. The
+   * marker carries no client identity, so correlation rides on this queue:
+   * exact text match first, oldest entry otherwise. Entries outlive turn
+   * boundaries on purpose — a steer queued but not yet drained when the turn
+   * is interrupted still produces its marker when a later turn drains it.
+   */
+  private readonly pendingSubmittedUserMessages: Array<{
+    text: string;
+    clientMessageId: string | null;
+  }> = [];
+  private activeTurnSubmittedEntry: { text: string; clientMessageId: string | null } | null = null;
   private activeAssistantMessageId: string | null = null;
   private activeTurnStarted = false;
   private activeNoTurnPromptText: string | null = null;
@@ -1291,6 +1304,9 @@ export class PiRpcAgentSession implements AgentSession {
     const turnId = randomUUID();
     this.activeTurnId = turnId;
     this.activeClientMessageId = options?.clientMessageId ?? null;
+    const submittedEntry = { text: payload.text, clientMessageId: this.activeClientMessageId };
+    this.pendingSubmittedUserMessages.push(submittedEntry);
+    this.activeTurnSubmittedEntry = submittedEntry;
     this.activeAssistantMessageId = null;
     this.activeTurnStarted = false;
     this.activePromptRequestId = null;
@@ -1320,6 +1336,8 @@ export class PiRpcAgentSession implements AgentSession {
         if (this.activeTurnId !== turnId) {
           return;
         }
+        this.removePendingSubmittedUserMessage(submittedEntry);
+        this.activeTurnSubmittedEntry = null;
         this.activeTurnId = null;
         this.activeClientMessageId = null;
         this.activeTurnStarted = false;
@@ -1344,6 +1362,58 @@ export class PiRpcAgentSession implements AgentSession {
     })();
 
     return { turnId };
+  }
+
+  /**
+   * Deliver a user message into the active turn via the runtime's `steer`
+   * RPC instead of interrupting it. The turn keeps its identity and events;
+   * the steered message surfaces through the normal submitted-entry marker
+   * flow. Returns false when no turn is active so the caller can fall back
+   * to startTurn / replace semantics.
+   */
+  async steerActiveTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean> {
+    if (!this.activeTurnId || this.closed) {
+      return false;
+    }
+    // Older Pi binaries lack steering queues (no `steer` RPC, no steeringMode
+    // in get_state); decline so the caller keeps replace semantics instead of
+    // risking an unanswered request.
+    if (this.state.steeringMode == null) {
+      return false;
+    }
+    const payload = convertPromptInput(prompt, { model: this.state.model });
+    await this.runtimeSession.steer(payload.text, payload.images);
+    this.pendingSubmittedUserMessages.push({
+      text: payload.text,
+      clientMessageId: options?.clientMessageId ?? null,
+    });
+    return true;
+  }
+
+  private removePendingSubmittedUserMessage(entry: {
+    text: string;
+    clientMessageId: string | null;
+  }): void {
+    const index = this.pendingSubmittedUserMessages.indexOf(entry);
+    if (index >= 0) {
+      this.pendingSubmittedUserMessages.splice(index, 1);
+    }
+  }
+
+  private takePendingSubmittedUserMessage(
+    text: string,
+  ): { text: string; clientMessageId: string | null } | undefined {
+    if (this.pendingSubmittedUserMessages.length === 0) {
+      return undefined;
+    }
+    // Prefer an exact text match: a steer queued behind an interrupt can
+    // drain into a later turn, breaking FIFO order. Fall back to the oldest
+    // pending entry when texts don't line up (e.g. prompt-template expansion
+    // on the runtime side rewrote the message).
+    const byText = this.pendingSubmittedUserMessages.findIndex((entry) => entry.text === text);
+    const index = byText >= 0 ? byText : 0;
+    const [entry] = this.pendingSubmittedUserMessages.splice(index, 1);
+    return entry;
   }
 
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
@@ -1573,6 +1643,12 @@ export class PiRpcAgentSession implements AgentSession {
     if (this.activeTurnId !== turnId || this.activeTurnStarted) {
       return;
     }
+    // Local-only prompts never produce a submitted-entry marker; drop the
+    // pending entry so it can't misalign a later marker's correlation.
+    if (this.activeTurnSubmittedEntry) {
+      this.removePendingSubmittedUserMessage(this.activeTurnSubmittedEntry);
+      this.activeTurnSubmittedEntry = null;
+    }
     this.emitBufferedNoTurnOutputs(turnId);
     this.completeTurn(turnId, []);
   }
@@ -1597,6 +1673,11 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
 
+    // Same local-only case as completeNoTurnPrompt.
+    if (this.activeTurnSubmittedEntry) {
+      this.removePendingSubmittedUserMessage(this.activeTurnSubmittedEntry);
+      this.activeTurnSubmittedEntry = null;
+    }
     this.emitBufferedNoTurnOutputs(turnId);
     this.completeTurn(turnId, []);
   }
@@ -1826,6 +1907,8 @@ export class PiRpcAgentSession implements AgentSession {
     if (!entry) {
       return true;
     }
+    const submitted = this.takePendingSubmittedUserMessage(entry.text);
+    const clientMessageId = submitted ? submitted.clientMessageId : this.activeClientMessageId;
     this.emit({
       type: "timeline",
       provider: this.provider,
@@ -1834,7 +1917,7 @@ export class PiRpcAgentSession implements AgentSession {
         type: "user_message",
         text: entry.text,
         messageId: entry.id,
-        ...(this.activeClientMessageId ? { clientMessageId: this.activeClientMessageId } : {}),
+        ...(clientMessageId ? { clientMessageId } : {}),
       },
     });
     return true;
@@ -1999,6 +2082,8 @@ export class PiRpcAgentSession implements AgentSession {
 
   private handleProcessExit(error: string): void {
     this.rejectAllExtensionResults(new Error(error));
+    this.pendingSubmittedUserMessages.splice(0, this.pendingSubmittedUserMessages.length);
+    this.activeTurnSubmittedEntry = null;
     if (!this.activeTurnId) {
       return;
     }
@@ -2250,6 +2335,7 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;
     this.activeTurnStarted = false;
+    this.activeTurnSubmittedEntry = null;
     this.clearNoTurnBuffers();
     const errorMessage = latestPiErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1224,11 +1224,11 @@ export class PiRpcAgentSession implements AgentSession {
   private activeTurnId: string | null = null;
   private activeClientMessageId: string | null = null;
   /**
-   * FIFO of user messages submitted to the native process (turn prompts and
+   * User messages submitted to the native process (turn prompts and
    * mid-turn steers) awaiting their PASEO_SUBMITTED_USER_ENTRY marker. The
-   * marker carries no client identity, so correlation rides on this queue:
-   * exact text match first, oldest entry otherwise. Entries outlive turn
-   * boundaries on purpose — a steer queued but not yet drained when the turn
+   * marker carries no client identity, so correlation rides on submission
+   * order — see takePendingSubmittedUserMessage. Entries outlive turn
+   * boundaries on purpose: a steer queued but not yet drained when the turn
    * is interrupted still produces its marker when a later turn drains it.
    */
   private readonly pendingSubmittedUserMessages: Array<{
@@ -1400,20 +1400,29 @@ export class PiRpcAgentSession implements AgentSession {
     }
   }
 
-  private takePendingSubmittedUserMessage(
-    text: string,
-  ): { text: string; clientMessageId: string | null } | undefined {
-    if (this.pendingSubmittedUserMessages.length === 0) {
-      return undefined;
+  private takePendingSubmittedUserMessage():
+    | {
+        text: string;
+        clientMessageId: string | null;
+      }
+    | undefined {
+    // Markers arrive in the order entries enter the native session tree. A
+    // turn's first marker always belongs to the prompt that started it: the
+    // runtime persists the prompt before draining any queued steer, even a
+    // steer left over from an interrupted turn. Later markers map to pending
+    // steers in submission order (leftover steers drain before steers queued
+    // in this turn). Matching by text instead would swap correlations when a
+    // resent message repeats the interrupted steer's text verbatim.
+    const turnEntry = this.activeTurnSubmittedEntry;
+    if (turnEntry) {
+      const index = this.pendingSubmittedUserMessages.indexOf(turnEntry);
+      if (index >= 0) {
+        this.pendingSubmittedUserMessages.splice(index, 1);
+        this.activeTurnSubmittedEntry = null;
+        return turnEntry;
+      }
     }
-    // Prefer an exact text match: a steer queued behind an interrupt can
-    // drain into a later turn, breaking FIFO order. Fall back to the oldest
-    // pending entry when texts don't line up (e.g. prompt-template expansion
-    // on the runtime side rewrote the message).
-    const byText = this.pendingSubmittedUserMessages.findIndex((entry) => entry.text === text);
-    const index = byText >= 0 ? byText : 0;
-    const [entry] = this.pendingSubmittedUserMessages.splice(index, 1);
-    return entry;
+    return this.pendingSubmittedUserMessages.shift();
   }
 
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
@@ -1907,7 +1916,7 @@ export class PiRpcAgentSession implements AgentSession {
     if (!entry) {
       return true;
     }
-    const submitted = this.takePendingSubmittedUserMessage(entry.text);
+    const submitted = this.takePendingSubmittedUserMessage();
     const clientMessageId = submitted ? submitted.clientMessageId : this.activeClientMessageId;
     this.emit({
       type: "timeline",

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -798,6 +798,16 @@ function isPiRequestAbortError(error: unknown): boolean {
   return /\brequest was aborted\b|\babort(ed)?\b/i.test(toDiagnosticErrorMessage(error));
 }
 
+/**
+ * OMP rejects a `prompt` RPC while a turn is streaming with AgentBusyError
+ * ("Agent is already processing. Use steer() or followUp()…"). Reachable
+ * when the runtime started a turn on its own — e.g. an interrupted steer's
+ * post-abort drain — and the daemon hadn't observed it yet.
+ */
+function isPiAgentBusyError(error: unknown): boolean {
+  return /\bagent is already processing\b/i.test(toDiagnosticErrorMessage(error));
+}
+
 function resolveThinkingOptionId(
   cachedThinkingOptionId: string | null,
   sessionThinkingLevel: PiThinkingLevel,
@@ -1336,6 +1346,35 @@ export class PiRpcAgentSession implements AgentSession {
         if (this.activeTurnId !== turnId) {
           return;
         }
+        if (isPiAgentBusyError(error) && this.state.steeringMode != null) {
+          // The runtime started a turn of its own first (e.g. an interrupted
+          // steer's post-abort drain). Deliver into that turn instead of
+          // failing: keep the submitted entry queued — its marker arrives in
+          // the busy turn — and close this turn out as canceled.
+          const steered = await this.runtimeSession.steer(payload.text, payload.images).then(
+            () => true,
+            () => false,
+          );
+          if (steered) {
+            if (this.activeTurnId !== turnId) {
+              return;
+            }
+            this.activeTurnId = null;
+            this.activeClientMessageId = null;
+            this.activeTurnStarted = false;
+            this.activeAssistantMessageId = null;
+            this.activeTurnSubmittedEntry = null;
+            this.clearNoTurnBuffers();
+            this.emit({
+              type: "turn_canceled",
+              provider: this.provider,
+              turnId,
+              reason: "Runtime was already streaming; message steered into the active turn",
+            });
+            return;
+          }
+          // Steer delivery failed too; fall through to the failure path.
+        }
         this.removePendingSubmittedUserMessage(submittedEntry);
         this.activeTurnSubmittedEntry = null;
         this.activeTurnId = null;
@@ -1382,11 +1421,24 @@ export class PiRpcAgentSession implements AgentSession {
       return false;
     }
     const payload = convertPromptInput(prompt, { model: this.state.model });
-    await this.runtimeSession.steer(payload.text, payload.images);
-    this.pendingSubmittedUserMessages.push({
-      text: payload.text,
-      clientMessageId: options?.clientMessageId ?? null,
-    });
+    // Slash commands must keep the prompt RPC path: the steer channel only
+    // rejects extension commands — builtins would be injected as literal
+    // text and never execute. Gate on the flattened payload so structured
+    // prompts (attachments) can't smuggle a command past the manager.
+    if (payload.text.trimStart().startsWith("/")) {
+      return false;
+    }
+    const entry = { text: payload.text, clientMessageId: options?.clientMessageId ?? null };
+    // Push before awaiting: the steer response and the submitted-entry
+    // marker can arrive in the same stdout chunk, and buffered frames are
+    // dispatched before the awaiting continuation runs.
+    this.pendingSubmittedUserMessages.push(entry);
+    try {
+      await this.runtimeSession.steer(payload.text, payload.images);
+    } catch (error) {
+      this.removePendingSubmittedUserMessage(entry);
+      throw error;
+    }
     return true;
   }
 

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -123,6 +123,17 @@ class PiCliRuntimeSession implements PiRuntimeSession {
     return { requestId };
   }
 
+  async steer(
+    message: string,
+    images?: Array<{ type: "image"; data: string; mimeType: string }>,
+  ): Promise<void> {
+    await this.request({
+      type: "steer",
+      message,
+      ...(images?.length ? { images } : {}),
+    });
+  }
+
   async compact(customInstructions?: string): Promise<void> {
     // Compact is a blocking LLM summarization job; Pi only returns the RPC
     // response after the summary is written. A control-plane 30s timeout falsely

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -88,6 +88,9 @@ export interface PiSessionState {
   thinkingLevel: PiThinkingLevel;
   isStreaming: boolean;
   isCompacting: boolean;
+  /** Present on runtimes with steering queues (OMP); absent on older Pi binaries. */
+  steeringMode?: "all" | "one-at-a-time";
+  followUpMode?: "all" | "one-at-a-time";
   autoCompactionEnabled?: boolean;
   sessionFile?: string;
   sessionId: string;
@@ -128,6 +131,7 @@ export interface PiRpcSlashCommand {
 
 export type PiRpcCommand =
   | { id?: string; type: "prompt"; message: string; images?: PiImageContent[] }
+  | { id?: string; type: "steer"; message: string; images?: PiImageContent[] }
   | { id?: string; type: "compact"; customInstructions?: string }
   | { id?: string; type: "set_auto_compaction"; enabled: boolean }
   | { id?: string; type: "abort" }

--- a/packages/server/src/server/agent/providers/pi/runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/runtime.ts
@@ -44,6 +44,10 @@ export interface PiRuntimeSession {
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
   ): Promise<PiPromptAck>;
+  steer(
+    message: string,
+    images?: Array<{ type: "image"; data: string; mimeType: string }>,
+  ): Promise<void>;
   compact(customInstructions?: string): Promise<void>;
   setAutoCompaction(enabled: boolean): Promise<void>;
   abort(): Promise<void>;

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -94,6 +94,8 @@ export class FakePi implements PiRuntime {
 
 export class FakePiSession implements PiRuntimeSession {
   readonly prompts: Array<{ message: string; imageCount: number }> = [];
+  readonly steerRequests: Array<{ message: string; imageCount: number }> = [];
+  steerError: Error | null = null;
   readonly compactRequests: Array<{ customInstructions?: string }> = [];
   readonly setAutoCompactionRequests: boolean[] = [];
   readonly subagentSubscriptionRequests: FakePiSubagentSubscriptionLevel[] = [];
@@ -142,6 +144,8 @@ export class FakePiSession implements PiRuntimeSession {
       thinkingLevel: "medium",
       isStreaming: false,
       isCompacting: false,
+      steeringMode: "one-at-a-time",
+      followUpMode: "one-at-a-time",
       autoCompactionEnabled: true,
       sessionFile: launch.session ?? "/tmp/pi-session",
       sessionId: "pi-session-1",
@@ -216,6 +220,16 @@ export class FakePiSession implements PiRuntimeSession {
       ...this.state,
       autoCompactionEnabled: enabled,
     };
+  }
+
+  async steer(
+    message: string,
+    images?: Array<{ type: "image"; data: string; mimeType: string }>,
+  ): Promise<void> {
+    if (this.steerError) {
+      throw this.steerError;
+    }
+    this.steerRequests.push({ message, imageCount: images?.length ?? 0 });
   }
 
   async abort(): Promise<void> {


### PR DESCRIPTION
## Problem

Sending a message while a Pi/OMP agent had a run in flight went through `replaceAgentRun`: **interrupt the active turn, then start a fresh prompt**. OMP's RPC protocol (protocol v2) supports mid-turn injection natively via the `steer` command, so the interrupt was needlessly destructive — in-flight tool work was aborted just to deliver a message.

## Change

- `AgentSession` gains an optional `steerActiveTurn(prompt, options)`. Providers without mid-turn injection leave it undefined and keep interrupt-and-replace semantics.
- `AgentManager.trySteerActiveTurn` gates on an in-flight run, refuses slash commands (they need the prompt RPC path — OMP's steer channel rejects "/" messages), and returns false on any steer failure so callers fall back to replace.
- `sendPromptToAgent` opts in via a new `steerRunning` flag on `startAgentRun`. The permission-response follow-up path deliberately keeps replace semantics: its turn is blocked on a permission dialog, which only an interrupt resolves.
- The Pi provider implements `steerActiveTurn` via the `steer` RPC, gated on the runtime reporting `steeringMode` in `get_state`, so older Pi binaries without steering queues (and no `steer` RPC) keep the old behavior instead of risking an unanswered request.

### clientMessageId correlation

A steered message produces no new turn — it surfaces through the existing `PASEO_SUBMITTED_USER_ENTRY` extension marker like any submitted user message. Since one turn can now carry several submitted messages, the Pi session tracks them in a FIFO queue and reconciles each marker to the right `clientMessageId`, preferring an exact text match (a steer queued behind an interrupt can drain into a *later* turn, breaking FIFO order). Local-only prompts (no-turn slash commands) drop their pending entry so they can't misalign later markers.

## Tests

- Pi session: steer delivery + marker correlation, multi-steer ordering, out-of-order drain after interrupt, idle refusal, capability gate, failed-RPC hygiene.
- Manager: steer delivery, slash refusal, unsupported session, idle refusal, error fallback.
- Send path: `sendPromptToAgent` steers instead of replacing; falls back to replace when steering is unavailable.

`npx vitest run` on the four touched test files: 232 passed. Typecheck/lint/format clean.