### PR TITLE
fix(schedule): retain failed schedule run workspaces

### DIFF
--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -701,7 +701,7 @@ describe("ScheduleService", () => {
     );
   });
 
-  test("archives the run workspace when scheduled agent creation fails before archive opt-out can preserve an agent", async () => {
+  test("retains the run workspace when scheduled agent creation fails", async () => {
     const {
       workspaceRegistry,
       createDirectoryWorkspace: createScheduleDirectoryWorkspace,
@@ -753,7 +753,7 @@ describe("ScheduleService", () => {
     expect(await workspaceRegistry.list()).toEqual([
       expect.objectContaining({
         cwd: tempDir,
-        archivedAt: expect.any(String),
+        archivedAt: null,
       }),
     ]);
   });
@@ -1016,6 +1016,73 @@ describe("ScheduleService", () => {
     );
   });
 
+  test("scheduled new-agent run with no activity fails and retains its workspace", async () => {
+    const archiveWorkspace = vi.fn();
+    const manager = new AgentManager({
+      logger: createTestLogger(),
+      clients: createTestAgentClients(),
+      registry: agentStorage,
+    });
+    manager.runAgent = async () => ({
+      sessionId: "scheduled-empty-run",
+      finalText: "",
+      timeline: [],
+    });
+    manager.waitForAgentEvent = async () => ({
+      status: "idle",
+      permission: null,
+      lastMessage: null,
+    });
+    const service = createScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: manager,
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      archiveWorkspace,
+      createAgent: async (input) => {
+        const snapshot = {
+          id: "00000000-0000-0000-0000-000000000325",
+          provider: "claude",
+          cwd: input.cwd ?? tempDir,
+          workspaceId: input.workspaceId,
+          status: "idle",
+          lifecycle: "idle",
+        };
+        return {
+          snapshot: snapshot as Awaited<
+            ReturnType<ScheduleServiceOptions["createAgent"]>
+          >["snapshot"],
+          liveSnapshot: snapshot as Awaited<
+            ReturnType<ScheduleServiceOptions["createAgent"]>
+          >["liveSnapshot"],
+          background: true,
+          initialPromptStarted: false,
+          initialPromptError: null,
+        };
+      },
+      now: () => now,
+    });
+
+    const created = await service.create({
+      prompt: "run this task",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: {
+        type: "new-agent",
+        config: { provider: "claude", cwd: tempDir, archiveOnFinish: true },
+      },
+      maxRuns: 1,
+    });
+
+    await service.runOnce(created.id);
+
+    expect((await service.inspect(created.id)).runs[0]).toMatchObject({
+      status: "failed",
+      error: "Scheduled agent 00000000-0000-0000-0000-000000000325 completed without activity",
+    });
+    expect(archiveWorkspace).not.toHaveBeenCalled();
+  });
+
   test("scheduled new-agent cancellations fail the run", async () => {
     const manager = new AgentManager({
       logger: createTestLogger(),
@@ -1079,12 +1146,9 @@ describe("ScheduleService", () => {
     });
   });
 
-  test("failed new-agent run keeps run error when workspace archive also fails", async () => {
+  test("failed new-agent run retains its workspace without attempting archive", async () => {
     const logger = createTestLogger();
-    const warn = vi.fn();
-    logger.warn = warn as typeof logger.warn;
-    logger.child = (() => logger) as typeof logger.child;
-    const archiveError = new Error("archive exploded");
+    const archiveWorkspace = vi.fn();
     const manager = new AgentManager({
       logger: createTestLogger(),
       clients: createTestAgentClients(),
@@ -1121,9 +1185,7 @@ describe("ScheduleService", () => {
           initialPromptError: null,
         };
       },
-      archiveWorkspace: async () => {
-        throw archiveError;
-      },
+      archiveWorkspace,
       now: () => now,
     });
 
@@ -1141,16 +1203,7 @@ describe("ScheduleService", () => {
       error: "run exploded",
       agentId,
     });
-    expect(warn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        err: archiveError,
-        agentId,
-        workspaceId: expect.stringMatching(/^wks_/),
-        scheduleId: created.id,
-        runId: expect.any(String),
-      }),
-      expect.stringContaining("Failed to archive scheduled workspace"),
-    );
+    expect(archiveWorkspace).not.toHaveBeenCalled();
   });
 
   test("shows scheduled new-agent prompts as normal user turns", async () => {
@@ -1520,7 +1573,7 @@ describe("ScheduleService", () => {
     expect(storedAgent?.archivedAt).toBeTruthy();
   });
 
-  test("records prompt-start failures as failed and archives the scheduled agent", async () => {
+  test("records prompt-start failures as failed and retains the scheduled agent", async () => {
     class StartFailureScheduleSession implements AgentSession {
       readonly provider = "claude";
       readonly capabilities = SCHEDULE_TEST_CAPABILITIES;
@@ -1630,9 +1683,7 @@ describe("ScheduleService", () => {
     const storedAgents = await agentStorage.list();
     expect(storedAgents).toHaveLength(1);
     expect(inspected.runs[0]?.agentId).toBe(storedAgents[0]?.id);
-    expect(storedAgents[0]).toMatchObject({
-      archivedAt: expect.any(String),
-    });
+    expect(storedAgents[0]?.archivedAt ?? null).toBeNull();
   });
 
   test("defaults new-agent modeId to provider's unattended mode", async () => {

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -3,7 +3,7 @@ import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import type { Logger } from "pino";
 import type { AgentManager } from "../agent/agent-manager.js";
-import type { AgentSessionConfig } from "../agent/agent-sdk-types.js";
+import type { AgentRunResult, AgentSessionConfig } from "../agent/agent-sdk-types.js";
 import type { AgentStorage } from "../agent/agent-storage.js";
 import { curateAgentActivity } from "../agent/activity-curator.js";
 import { ensureAgentLoaded } from "../agent/agent-loading.js";
@@ -131,6 +131,21 @@ function shouldArchiveScheduleRunWorkspace(input: {
   archiveOnFinish?: boolean;
 }): boolean {
   return input.agentId === null || (input.archiveOnFinish ?? true);
+}
+
+function assertScheduledAgentActivity(input: {
+  agentId: string;
+  result: AgentRunResult;
+  lastMessage: string | null;
+}): void {
+  if (
+    input.result.timeline.length === 0 &&
+    input.result.finalText.trim() === "" &&
+    (input.lastMessage?.trim() ?? "") === "" &&
+    !input.result.usage
+  ) {
+    throw new Error(`Scheduled agent ${input.agentId} completed without activity`);
+  }
 }
 
 function shouldCompleteSchedule(schedule: StoredSchedule, now: Date): boolean {
@@ -874,6 +889,7 @@ export class ScheduleService {
     await this.assertNewAgentCwdDirectory(config.cwd);
     let workspace: PersistedWorkspaceRecord | null = null;
     let agentId: string | null = null;
+    let completed = false;
     try {
       workspace = await this.createScheduleRunWorkspace(config, schedule.prompt);
       await this.recordRunWorkspace({
@@ -926,7 +942,13 @@ export class ScheduleService {
       if (waitResult.status === "error") {
         throw new Error(waitResult.lastMessage ?? `Scheduled agent ${agent.id} failed`);
       }
+      assertScheduledAgentActivity({
+        agentId: agent.id,
+        result,
+        lastMessage: waitResult.lastMessage,
+      });
       const timelineText = curateAgentActivity(result.timeline);
+      completed = true;
       return {
         agentId: agent.id,
         output: buildRunOutput({
@@ -936,10 +958,7 @@ export class ScheduleService {
         }),
       };
     } finally {
-      if (
-        workspace &&
-        shouldArchiveScheduleRunWorkspace({ agentId, archiveOnFinish: config.archiveOnFinish })
-      ) {
+      if (workspace && completed && (config.archiveOnFinish ?? true)) {
         try {
           await this.archiveWorkspace(workspace.workspaceId);
         } catch (error) {


### PR DESCRIPTION
Fixes #2569.

## Summary

A scheduled agent can finish locally without producing any provider activity. Paseo currently records that as a successful run and immediately archives the schedule workspace, which removes the evidence needed to diagnose why no provider turn occurred.

This PR reports that condition as a failed run and keeps its workspace available. It does not change normal successful-run cleanup.

## Problem

A new-agent schedule can receive a completed turn with no timeline entries, output, or usage. Paseo records that run as successful and, when Archive on finish is enabled, removes the workspace immediately.

The run then appears as "No activity to display", while the associated agent cannot be inspected because its working directory is gone.

## Reproduction

1. Create a new-agent schedule with worktree isolation and Archive on finish enabled.
2. Use a provider session that completes without emitting output, timeline activity, or usage.
3. Run the schedule once.

Expected: the run is marked failed and its workspace remains available for diagnosis.

Actual: the run is marked succeeded with no activity, then its workspace is archived.

## Change

- Mark a new-agent schedule run as failed when it completed without output, timeline activity, or usage.
- Archive a schedule workspace only after a successful run.
- Retain workspaces for agent-creation failures, prompt-start failures, and run failures so they can be inspected.

## Validation

- Added a regression test for an empty completion with Archive on finish enabled.
- Updated failure lifecycle tests to assert workspace retention.
- `node packages/server/node_modules/vitest/vitest.mjs run packages/server/src/server/schedule/service.test.ts`
- `npm run typecheck`
- Pre-commit lint and formatting checks