### PR TITLE
feat(app): show file-type icons in the Changes flat list

### DIFF
--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -1195,11 +1195,9 @@ const DiffFileHeader = memo(function DiffFileHeader({
         style={showDir ? styles.fileHeaderLeft : [styles.fileHeaderLeft, styles.fileHeaderLeftTree]}
       >
         {showDir ? null : <View style={styles.fileChevronSpacer} />}
-        {showDir ? null : (
-          <View style={styles.fileIcon}>
-            <MaterialFileIcon fileName={fileName} size={WORKSPACE_TREE_ICON_SIZE} />
-          </View>
-        )}
+        <View style={styles.fileIcon}>
+          <MaterialFileIcon fileName={fileName} size={WORKSPACE_TREE_ICON_SIZE} />
+        </View>
         <Text style={styles.fileName} numberOfLines={1}>
           {fileName}
         </Text>


### PR DESCRIPTION
### Linked issue

Discussed in discord. This is the leftover half of #1918, which added the file-type icons
to the Changes list but wired them into tree mode only.

### Type of change

- [ ] Bug fix
- [X] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Renders the file-type icon on flat-list rows, the same icon tree mode has
had since #1918.

The icon was behind a `showDir ? null : ...` branch — `showDir` is true in
flat mode and false in tree mode, so the icon only ever appeared in the
tree. Dropping the branch renders it in both. `showDir` now controls only
the muted inline directory suffix, which is what its name says.

Nothing else about the flat list changes: the directory suffix stays inline
on the row, rows stay unindented, and the item model is untouched. Tree mode
is unchanged — it already rendered this icon. Client-only, no protocol or
server change, and the icon comes from the existing `getFileIconSvg`.

Three insertions, five deletions, one file.

### How did you verify it

- `npm run typecheck`, `npm run lint`, `npm run format` clean.
- Live in Desktop App against a real diff: icons
  resolve per file type in the flat list, the directory suffix and `+/-`
  stats are unchanged, and toggling to tree and back leaves tree mode as it
  was.
- No test changes: the change is one JSX branch in the header row, and the
  `src/git/` unit tests cover the pure item-model modules, which this does
  not touch. The `diff-row-alignment` e2e helper asserts the flat row
  contains both the filename and its directory — still true.

Before:

<img width="325" height="280" alt="image" src="https://github.com/user-attachments/assets/760ccc10-9144-4a77-9e5b-2af35aa0fd83" />

After:

<img width="329" height="293" alt="image" src="https://github.com/user-attachments/assets/f5b27b80-fb59-4316-a598-672fff39ef43" />

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
