### PR TITLE
fix(app): center mounted desktop chat history

### DIFF
--- a/packages/app/src/agent-stream/strategy-web.browser.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.browser.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
+import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+import type { StreamItem } from "@/types/stream";
+import type { StreamViewportHandle } from "./strategy";
+import { createWebStreamStrategy } from "./strategy-web";
+
+interface MountedStream {
+  host: HTMLDivElement;
+  root: Root;
+}
+
+const mountedStreams: MountedStream[] = [];
+const COMPLETED_HISTORY_MESSAGE_STYLE = {
+  alignSelf: "center",
+  height: 24,
+  maxWidth: MAX_CONTENT_WIDTH,
+  width: "100%",
+};
+
+function historyMessage(): StreamItem {
+  return {
+    kind: "user_message",
+    id: "history-message",
+    text: "Historical message",
+    timestamp: new Date("2026-07-29T00:00:00.000Z"),
+  };
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+afterEach(() => {
+  for (const { host, root } of mountedStreams.splice(0)) {
+    root.unmount();
+    host.remove();
+  }
+});
+
+describe("web stream mounted history", () => {
+  it("keeps an already-completed message centered in the conversation column", async () => {
+    await page.viewport(1200, 800);
+
+    const host = document.createElement("div");
+    host.style.cssText = "width:1200px;height:600px;display:flex;flex-direction:column";
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedStreams.push({ host, root });
+
+    const strategy = createWebStreamStrategy({ isMobileBreakpoint: false });
+    const viewportRef = React.createRef<StreamViewportHandle>();
+    flushSync(() => {
+      root.render(
+        strategy.render({
+          agentId: "agent",
+          segments: {
+            historyVirtualized: [],
+            historyMounted: [historyMessage()],
+            liveHead: [],
+          },
+          boundary: {
+            hasVirtualizedHistory: false,
+            hasMountedHistory: true,
+            hasLiveHead: false,
+          },
+          renderers: {
+            renderHistoryVirtualizedRow: () => null,
+            renderHistoryMountedRow: () => (
+              <div
+                data-testid="completed-history-message"
+                style={COMPLETED_HISTORY_MESSAGE_STYLE}
+              />
+            ),
+            renderLiveHeadRow: () => null,
+            renderLiveAuxiliary: () => null,
+          },
+          listEmptyComponent: null,
+          viewportRef,
+          routeBottomAnchorRequest: null,
+          isAuthoritativeHistoryReady: true,
+          onNearBottomChange: () => {},
+          onNearHistoryStart: () => true,
+          isLoadingOlderHistory: false,
+          hasOlderHistory: false,
+          olderHistoryProgressKey: null,
+          scrollEnabled: true,
+          listStyle: null,
+          baseListContentContainerStyle: null,
+          forwardListContentContainerStyle: null,
+        }),
+      );
+    });
+    await nextFrame();
+
+    const message = host.querySelector<HTMLElement>('[data-testid="completed-history-message"]');
+    if (!message) {
+      throw new Error("Expected completed history message");
+    }
+    const hostRect = host.getBoundingClientRect();
+    const messageRect = message.getBoundingClientRect();
+
+    expect(messageRect.width).toBe(MAX_CONTENT_WIDTH);
+    expect(
+      Math.abs(messageRect.left + messageRect.width / 2 - (hostRect.left + hostRect.width / 2)),
+    ).toBeLessThan(1);
+  });
+});

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -48,6 +48,13 @@ const historyStartSlotStyle: CSSProperties = {
   paddingBottom: 8,
 };
 
+// Keep the measurable history anchor in the DOM without breaking the item's
+// centered flex layout inside the conversation column.
+const mountedHistoryRowStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+};
+
 function isScrollContainerNearBottom(
   scrollContainer: Pick<HTMLElement, "scrollTop" | "clientHeight" | "scrollHeight">,
   thresholdPx = AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
@@ -580,9 +587,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
   const mountedHistoryRows = useMemo(() => {
     return segments.historyMounted.map((item, index) => (
-      <Fragment key={item.id}>
+      <div key={item.id} data-history-row-id={item.id} style={mountedHistoryRowStyle}>
         {renderHistoryMountedRow(item, index, segments.historyMounted)}
-      </Fragment>
+      </div>
     ));
   }, [renderHistoryMountedRow, segments.historyMounted]);
   const liveHeadRows = useMemo(() => {


### PR DESCRIPTION
### Linked issue

Closes #2583

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

#2490 added measurable DOM wrappers around mounted history rows for pagination anchoring. Those wrappers were ordinary block elements, so the stream row's `alignSelf: "center"` no longer participated in a flex parent and completed messages rendered in a left-pinned column.

This keeps the `data-history-row-id` anchor while making its wrapper a flex column, restoring the centered conversation column for browser web and Electron. Native does not use this strategy.

### How did you verify it

- Added a real Chromium regression test that renders a completed history row in a 1200px viewport and asserts its 820px conversation column is centered.
- `npm run test:browser --workspace=@getpaseo/app -- src/agent-stream/strategy-web.browser.test.tsx --bail=1`
- `npm run test --workspace=@getpaseo/app -- src/agent-stream/strategy-web.test.tsx --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- Manual packaged-desktop verification confirmed the completed history column is centered again.

### Screenshots or video

<img width="1605" height="1034" alt="image" src="https://github.com/user-attachments/assets/05cddfe3-4b89-438c-bc1c-a8083e35cf25" />

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense