### PR TITLE
Align inline code chips with the prose line on native

### DIFF
--- a/packages/app/src/styles/markdown-styles-native.test.ts
+++ b/packages/app/src/styles/markdown-styles-native.test.ts
@@ -24,7 +24,7 @@ describe("createMarkdownStyles on native", () => {
     });
     expect(createCompactMarkdownStyles(darkTheme).code_inline).toMatchObject({
       paddingVertical: 0,
-      lineHeight: proseLineHeight,
+      lineHeight: 20,
     });
   });
 });

--- a/packages/app/src/styles/markdown-styles-native.test.ts
+++ b/packages/app/src/styles/markdown-styles-native.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCompactMarkdownStyles, createMarkdownStyles } from "./markdown-styles";
+import { darkTheme } from "./theme";
+
+// markdown-styles reads `isWeb` once at module scope, so the native branch needs
+// its own file with the mock in place before the import is evaluated.
+vi.mock("@/constants/platform", () => ({
+  isWeb: false,
+  isNative: true,
+}));
+
+describe("createMarkdownStyles on native", () => {
+  it("keeps inline code the same height as the prose line it sits in", () => {
+    // Native paragraphs are wrapping flex rows of sibling <Text> spans, so a
+    // taller inline-code item is top-aligned rather than baseline-aligned: the
+    // chip background floats above the surrounding text and the wrapped row
+    // grows. Matching the prose line height (and dropping the vertical padding)
+    // keeps every span in the row the same height.
+    const proseLineHeight = Math.round(darkTheme.fontSize.base * 1.4);
+
+    expect(createMarkdownStyles(darkTheme).code_inline).toMatchObject({
+      paddingVertical: 0,
+      lineHeight: proseLineHeight,
+    });
+    expect(createCompactMarkdownStyles(darkTheme).code_inline).toMatchObject({
+      paddingVertical: 0,
+      lineHeight: proseLineHeight,
+    });
+  });
+});

--- a/packages/app/src/styles/markdown-styles.ts
+++ b/packages/app/src/styles/markdown-styles.ts
@@ -3,6 +3,18 @@ import { isWeb } from "@/constants/platform";
 
 const webSelectableTextStyle = isWeb ? { userSelect: "text" as const } : {};
 
+// On native, a paragraph is a flex-row wrapping <View> whose children are
+// sibling <Text> spans (see markdown-text.android.tsx / .ios.tsx), so an inline
+// code span is a flex item, not an inline run inside a line box. Any extra
+// vertical padding or a lineHeight taller than the prose line makes that item
+// taller than its neighbours: with `alignItems: "flex-start"` the chip's
+// background floats above the surrounding text baseline and the wrapped rows it
+// sits on grow unevenly. Web keeps the padded chip because there it really is
+// an inline run.
+const inlineCodeSurfaceStyle = isWeb ? { paddingVertical: 2 } : { paddingVertical: 0 };
+const inlineCodeLineHeight = (theme: Theme) =>
+  isWeb ? Math.round(theme.fontSize.code * 1.45) : Math.round(theme.fontSize.base * 1.4);
+
 /**
  * Creates comprehensive markdown styles for react-native-markdown-display.
  *
@@ -167,12 +179,12 @@ export function createMarkdownStyles(theme: Theme) {
       backgroundColor: theme.colors.surface2,
       color: theme.colors.foreground,
       paddingHorizontal: theme.spacing[1],
-      paddingVertical: 2,
+      ...inlineCodeSurfaceStyle,
       borderRadius: theme.borderRadius.md,
       borderWidth: 0,
       fontFamily: theme.fontFamily.mono,
       fontSize: theme.fontSize.code,
-      lineHeight: Math.round(theme.fontSize.code * 1.45),
+      lineHeight: inlineCodeLineHeight(theme),
     },
 
     code_block: {

--- a/packages/app/src/styles/markdown-styles.ts
+++ b/packages/app/src/styles/markdown-styles.ts
@@ -403,6 +403,7 @@ export function createCompactMarkdownStyles(theme: Theme) {
     code_inline: {
       ...baseStyles.code_inline,
       fontSize: theme.fontSize.code,
+      lineHeight: isWeb ? baseStyles.code_inline.lineHeight : 20,
     },
 
     code_block: {


### PR DESCRIPTION
### Linked issue

Closes #2580

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

On mobile, inline `code` spans render with their background chip floating above the surrounding text baseline, and wrapped lines containing inline code get uneven vertical spacing. See #2580 for the screenshot.

On native a markdown paragraph is a `flexDirection: "row"` wrapping `<View>` whose children are sibling `<Text>` spans (`markdown-text.android.tsx` / `.ios.tsx`), so an inline code span is a *flex item*, not an inline run inside a shared line box. `code_inline` set `paddingVertical: 2` and `lineHeight: round(fontSize.code * 1.45)`, both of which make that flex item taller than its plain-text neighbours. With the paragraph's `alignItems: "flex-start"` the taller item is top-aligned, so the chip background sits high relative to the text baseline and the row it lands on grows.

The fix drops the vertical padding on native and matches the inline-code line height to the prose line height (`round(fontSize.base * 1.4)`), so every span in the row is the same height. Web is unchanged — there inline code really is an inline run, so the padded chip stays.

### How did you verify it

Honest accounting of what was and wasn't checked:

- `npm run typecheck` — passes (all workspaces)
- `npm run lint` — passes, 0 warnings / 0 errors
- `npm run format` — ran (Biome), no changes
- `packages/app/src/styles/markdown-styles.test.ts` — passes
- Added `packages/app/src/styles/markdown-styles-native.test.ts` — the existing test file evaluates with `isWeb` true, so the native branch needs its own file with `vi.mock("@/constants/platform")` in place before the module is imported (the flag is read once at module scope). It asserts inline code gets `paddingVertical: 0` and the prose line height on native.
- **No "after" screenshots yet.** The bug was reported and reproduced on Android (screenshot in #2580); I have not captured post-fix visuals on Android, iOS, or web. The diagnosis is from reading the native paragraph layout, not from watching the pixels change. Happy to hold this until "after" shots are attached if you want the visual proof before review — flagging it rather than implying testing that did not happen.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform — **not done, see above**
- [x] Tests added or updated where it made sense