### PR TITLE
fix(server): materialize provider images under the paseo home

### DIFF
--- a/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.posix.test.ts
@@ -1,24 +1,49 @@
-import { existsSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { materializeProviderImage } from "./provider-image-output.js";
+import {
+  __resetMaterializedImageAttachmentDirForTests,
+  materializeProviderImage,
+} from "./provider-image-output.js";
 
 describe.skipIf(process.platform === "win32")("materializeProviderImage", () => {
-  test("writes image attachments under a private temp directory", () => {
+  const originalPaseoHome = process.env.PASEO_HOME;
+  let testHome: string | null = null;
+
+  beforeEach(() => {
+    testHome = mkdtempSync(path.join(os.tmpdir(), "paseo-provider-images-posix-"));
+    process.env.PASEO_HOME = testHome;
+    __resetMaterializedImageAttachmentDirForTests();
+  });
+
+  afterEach(() => {
+    if (originalPaseoHome === undefined) {
+      delete process.env.PASEO_HOME;
+    } else {
+      process.env.PASEO_HOME = originalPaseoHome;
+    }
+    if (testHome) {
+      rmSync(testHome, { recursive: true, force: true });
+      testHome = null;
+    }
+    __resetMaterializedImageAttachmentDirForTests();
+  });
+
+  test("writes image attachments under a private directory in the paseo home", () => {
     const materialized = materializeProviderImage({
       data: "YWJjMTIz",
       mimeType: "image/png",
     });
     const attachmentDir = path.dirname(materialized.path);
 
-    try {
-      expect(path.basename(attachmentDir)).toMatch(/^paseo-attachments-/);
-      expect(existsSync(materialized.path)).toBe(true);
-      expect(statSync(attachmentDir).mode & 0o777).toBe(0o700);
-      expect(statSync(materialized.path).mode & 0o777).toBe(0o600);
-    } finally {
-      rmSync(attachmentDir, { recursive: true, force: true });
-    }
+    // Exactly "paseo-attachments" — no mkdtemp suffix. The old per-process temp
+    // directory is what let the OS reap these images out from under the app.
+    expect(path.basename(attachmentDir)).toBe("paseo-attachments");
+    expect(attachmentDir).toBe(path.join(testHome as string, "paseo-attachments"));
+    expect(existsSync(materialized.path)).toBe(true);
+    expect(statSync(attachmentDir).mode & 0o777).toBe(0o700);
+    expect(statSync(materialized.path).mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -1,14 +1,35 @@
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, utimesSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
+  __resetMaterializedImageAttachmentDirForTests,
   isProviderImageMarkdown,
   materializeProviderImage,
   renderProviderImageOutputAsAssistantMarkdown,
 } from "./provider-image-output.js";
 
 const HASH = "a".repeat(64);
+
+// Materialized images live under the paseo home now, so without this every test
+// run would read and delete the developer's real provider images.
+const originalPaseoHome = process.env.PASEO_HOME;
+let testHome: string | null = null;
+
+function useTempPaseoHome(): string {
+  testHome = mkdtempSync(path.join(os.tmpdir(), "paseo-provider-images-"));
+  process.env.PASEO_HOME = testHome;
+  __resetMaterializedImageAttachmentDirForTests();
+  return testHome;
+}
+
+function attachmentsDir(): string {
+  if (!testHome) {
+    throw new Error("useTempPaseoHome() must run before reading the attachments dir.");
+  }
+  return path.join(testHome, "paseo-attachments");
+}
 
 function renderImageMarkdown(imagePath: string): string {
   const item = renderProviderImageOutputAsAssistantMarkdown({ path: imagePath });
@@ -90,26 +111,99 @@ describe("isProviderImageMarkdown", () => {
 });
 
 describe("materializeProviderImage", () => {
-  test("recreates the private temp directory if the cached directory is removed", () => {
+  beforeEach(() => {
+    useTempPaseoHome();
+  });
+
+  afterEach(() => {
+    if (originalPaseoHome === undefined) {
+      delete process.env.PASEO_HOME;
+    } else {
+      process.env.PASEO_HOME = originalPaseoHome;
+    }
+    if (testHome) {
+      rmSync(testHome, { recursive: true, force: true });
+      testHome = null;
+    }
+    __resetMaterializedImageAttachmentDirForTests();
+  });
+
+  test("recreates the private directory if the cached directory is removed", () => {
     const first = materializeProviderImage({
       data: "YWJjMTIz",
       mimeType: "image/png",
     });
-    const firstDir = path.dirname(first.path);
     expect(existsSync(first.path)).toBe(true);
 
-    rmSync(firstDir, { recursive: true, force: true });
+    rmSync(path.dirname(first.path), { recursive: true, force: true });
 
     const second = materializeProviderImage({
       data: "ZGVmNDU2",
       mimeType: "image/png",
     });
-    const secondDir = path.dirname(second.path);
 
-    try {
-      expect(existsSync(second.path)).toBe(true);
-    } finally {
-      rmSync(secondDir, { recursive: true, force: true });
+    expect(existsSync(second.path)).toBe(true);
+  });
+
+  test("stores images in a stable directory under the paseo home", () => {
+    const result = materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
+
+    // A fixed directory, not a per-process mkdtemp one — the old shape is what
+    // let the OS reap these images out from under the app after ~3 days.
+    expect(path.dirname(result.path)).toBe(attachmentsDir());
+    expect(path.basename(path.dirname(result.path))).toBe("paseo-attachments");
+    expect(statSync(attachmentsDir()).mode & 0o777).toBe(0o700);
+    expect(statSync(result.path).mode & 0o777).toBe(0o600);
+  });
+
+  test("is idempotent for the same bytes across daemon restarts", () => {
+    const first = materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
+
+    // A fresh daemon process: module state is cleared but the directory persists.
+    __resetMaterializedImageAttachmentDirForTests();
+    const second = materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
+
+    expect(second.path).toBe(first.path);
+    expect(readdirSync(attachmentsDir())).toHaveLength(1);
+  });
+
+  test("emits markdown that isProviderImageMarkdown still recognizes", () => {
+    const item = renderProviderImageOutputAsAssistantMarkdown(
+      { data: "YWJjMTIz", mimeType: "image/png" },
+      { materialize: materializeProviderImage },
+    );
+
+    if (!item || item.type !== "assistant_message") {
+      throw new Error("Expected provider image output to render as assistant markdown.");
     }
+    expect(isProviderImageMarkdown(item.text)).toBe(true);
+  });
+
+  test("sweeps images older than the retention window and keeps fresh ones", () => {
+    const stale = materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
+    const fresh = materializeProviderImage({ data: "ZGVmNDU2", mimeType: "image/png" });
+
+    const longAgoSeconds = Date.now() / 1000 - 31 * 24 * 60 * 60;
+    utimesSync(stale.path, longAgoSeconds, longAgoSeconds);
+
+    // The sweep runs once per process, on the first image materialized.
+    __resetMaterializedImageAttachmentDirForTests();
+    materializeProviderImage({ data: "Z2hpNzg5", mimeType: "image/png" });
+
+    expect(existsSync(stale.path)).toBe(false);
+    expect(existsSync(fresh.path)).toBe(true);
+  });
+
+  test("re-materializing a stale image keeps it alive", () => {
+    const image = materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
+    const longAgoSeconds = Date.now() / 1000 - 31 * 24 * 60 * 60;
+    utimesSync(image.path, longAgoSeconds, longAgoSeconds);
+
+    // Rendering it again rewrites the bytes, refreshing mtime before any sweep.
+    materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
+    __resetMaterializedImageAttachmentDirForTests();
+    materializeProviderImage({ data: "Z2hpNzg5", mimeType: "image/png" });
+
+    expect(existsSync(image.path)).toBe(true);
   });
 });

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, utimesSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -152,8 +152,8 @@ describe("materializeProviderImage", () => {
     // let the OS reap these images out from under the app after ~3 days.
     expect(path.dirname(result.path)).toBe(attachmentsDir());
     expect(path.basename(path.dirname(result.path))).toBe("paseo-attachments");
-    expect(statSync(attachmentsDir()).mode & 0o777).toBe(0o700);
-    expect(statSync(result.path).mode & 0o777).toBe(0o600);
+    // Mode assertions live in the .posix suite: Windows ignores mkdir/writeFile
+    // modes and reports 0o666, so asserting them here fails on that runner.
   });
 
   test("is idempotent for the same bytes across daemon restarts", () => {

--- a/packages/server/src/server/agent/providers/provider-image-output.test.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.test.ts
@@ -179,28 +179,17 @@ describe("materializeProviderImage", () => {
     expect(isProviderImageMarkdown(item.text)).toBe(true);
   });
 
-  test("sweeps images older than the retention window and keeps fresh ones", () => {
-    const stale = materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
-    const fresh = materializeProviderImage({ data: "ZGVmNDU2", mimeType: "image/png" });
-
-    const longAgoSeconds = Date.now() / 1000 - 31 * 24 * 60 * 60;
-    utimesSync(stale.path, longAgoSeconds, longAgoSeconds);
-
-    // The sweep runs once per process, on the first image materialized.
-    __resetMaterializedImageAttachmentDirForTests();
-    materializeProviderImage({ data: "Z2hpNzg5", mimeType: "image/png" });
-
-    expect(existsSync(stale.path)).toBe(false);
-    expect(existsSync(fresh.path)).toBe(true);
-  });
-
-  test("re-materializing a stale image keeps it alive", () => {
+  // The whole point of moving out of the temp dir is that nothing deletes these
+  // behind the user's back. An age-based sweep would reintroduce that on a
+  // longer fuse, because mtime cannot tell a referenced image from an abandoned
+  // one and reading a transcript never touches the file.
+  test("keeps images no matter how old they are", () => {
     const image = materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
-    const longAgoSeconds = Date.now() / 1000 - 31 * 24 * 60 * 60;
+    const longAgoSeconds = Date.now() / 1000 - 365 * 24 * 60 * 60;
     utimesSync(image.path, longAgoSeconds, longAgoSeconds);
 
-    // Rendering it again rewrites the bytes, refreshing mtime before any sweep.
-    materializeProviderImage({ data: "YWJjMTIz", mimeType: "image/png" });
+    // A fresh daemon process materializing an unrelated image: the oldest point
+    // at which a startup sweep would run.
     __resetMaterializedImageAttachmentDirForTests();
     materializeProviderImage({ data: "Z2hpNzg5", mimeType: "image/png" });
 

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -24,15 +24,23 @@ export interface MaterializedProviderImage {
 const PROVIDER_IMAGE_ATTACHMENT_DIR = "paseo-attachments";
 const PRIVATE_ATTACHMENT_DIR_MODE = 0o700;
 const MATERIALIZED_IMAGE_FILE_MODE = 0o600;
-// Materialized images used to live in os.tmpdir(), which the OS reaps (macOS
+// Materialized images used to live in os.tmpdir(), which the OS may reap (macOS
 // clears /var/folders after ~3 days). That silently orphaned every image in any
 // transcript older than the reap window: the markdown still pointed at a path
-// whose bytes were gone, and nothing could re-create them. They now live under
-// the paseo home, so this sweep is what bounds the directory instead.
-const MATERIALIZED_IMAGE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+// whose bytes were gone, and nothing could re-create them.
+//
+// Nothing deletes these now, deliberately. An age-based sweep here would only
+// move the same bug to a longer fuse — mtime cannot distinguish an image a
+// transcript still references from an abandoned one, and reading a transcript
+// does not touch the file. It would also be a regression on hosts whose temp
+// dir is not reaped on a schedule, where these images currently survive
+// indefinitely. Bounding this directory needs to be reference-aware, against
+// the agent timelines that point into it.
+//
+// Growth is bounded in practice by content addressing: filenames are a hash of
+// the bytes, so re-emitting or replaying an image reuses its existing file.
 
 let materializedImageAttachmentDir: string | null = null;
-let sweptMaterializedImageAttachments = false;
 
 function canReuseMaterializedImageAttachmentDir(dir: string): boolean {
   try {
@@ -44,38 +52,6 @@ function canReuseMaterializedImageAttachmentDir(dir: string): boolean {
     return true;
   } catch {
     return false;
-  }
-}
-
-// Runs once per process, on the first image materialized. Re-materializing an
-// image rewrites it, refreshing mtime, so an image still being rendered keeps
-// itself alive and only genuinely cold ones age out.
-function sweepMaterializedImageAttachments(dir: string): void {
-  if (sweptMaterializedImageAttachments) {
-    return;
-  }
-  sweptMaterializedImageAttachments = true;
-
-  const cutoffMs = Date.now() - MATERIALIZED_IMAGE_MAX_AGE_MS;
-  let entries: fsSync.Dirent[];
-  try {
-    entries = fsSync.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-
-  for (const entry of entries) {
-    if (!entry.isFile()) {
-      continue;
-    }
-    const filePath = path.join(dir, entry.name);
-    try {
-      if (fsSync.statSync(filePath).mtimeMs < cutoffMs) {
-        fsSync.rmSync(filePath, { force: true });
-      }
-    } catch {
-      // Raced with another writer or already gone. Sweeping is best-effort.
-    }
   }
 }
 
@@ -91,14 +67,12 @@ function getMaterializedImageAttachmentDir(): string {
   fsSync.mkdirSync(dir, { recursive: true, mode: PRIVATE_ATTACHMENT_DIR_MODE });
   fsSync.chmodSync(dir, PRIVATE_ATTACHMENT_DIR_MODE);
   materializedImageAttachmentDir = dir;
-  sweepMaterializedImageAttachments(dir);
   return dir;
 }
 
-/** Test-only hook: the sweep and the resolved directory are process-scoped. */
+/** Test-only hook: the resolved directory is process-scoped. */
 export function __resetMaterializedImageAttachmentDirForTests(): void {
   materializedImageAttachmentDir = null;
-  sweptMaterializedImageAttachments = false;
 }
 
 function getImageExtension(mimeType: string): string {
@@ -134,7 +108,8 @@ function normalizeImageData(mimeType: string, data: string): { mimeType: string;
 // across daemon restarts, so re-materializing the same image reuses the existing
 // file instead of leaking a fresh one for repeated image blocks or history
 // replay. Under the old per-process temp directory this deduplication only held
-// within a single daemon process.
+// within a single daemon process — which is also why this directory does not
+// grow per render, only per distinct image.
 export function materializeProviderImage(image: {
   data: string;
   mimeType: string | null;

--- a/packages/server/src/server/agent/providers/provider-image-output.ts
+++ b/packages/server/src/server/agent/providers/provider-image-output.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
 import * as fsSync from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import type { AgentTimelineItem } from "../agent-sdk-types.js";
+import { resolvePaseoHome } from "../../paseo-home.js";
 
 export interface ProviderImageOutput {
   path?: string | null;
@@ -17,12 +17,22 @@ export interface MaterializedProviderImage {
   path: string;
 }
 
+// The directory basename stays "paseo-attachments" because PROVIDER_IMAGE_MARKDOWN
+// below matches on it, and history written by older builds used
+// mkdtemp(os.tmpdir(), "paseo-attachments-") — the optional "-<suffix>" group in
+// that regex is what lets one pattern match both shapes.
 const PROVIDER_IMAGE_ATTACHMENT_DIR = "paseo-attachments";
-const PROVIDER_IMAGE_ATTACHMENT_DIR_PREFIX = `${PROVIDER_IMAGE_ATTACHMENT_DIR}-`;
 const PRIVATE_ATTACHMENT_DIR_MODE = 0o700;
 const MATERIALIZED_IMAGE_FILE_MODE = 0o600;
+// Materialized images used to live in os.tmpdir(), which the OS reaps (macOS
+// clears /var/folders after ~3 days). That silently orphaned every image in any
+// transcript older than the reap window: the markdown still pointed at a path
+// whose bytes were gone, and nothing could re-create them. They now live under
+// the paseo home, so this sweep is what bounds the directory instead.
+const MATERIALIZED_IMAGE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
 let materializedImageAttachmentDir: string | null = null;
+let sweptMaterializedImageAttachments = false;
 
 function canReuseMaterializedImageAttachmentDir(dir: string): boolean {
   try {
@@ -37,6 +47,38 @@ function canReuseMaterializedImageAttachmentDir(dir: string): boolean {
   }
 }
 
+// Runs once per process, on the first image materialized. Re-materializing an
+// image rewrites it, refreshing mtime, so an image still being rendered keeps
+// itself alive and only genuinely cold ones age out.
+function sweepMaterializedImageAttachments(dir: string): void {
+  if (sweptMaterializedImageAttachments) {
+    return;
+  }
+  sweptMaterializedImageAttachments = true;
+
+  const cutoffMs = Date.now() - MATERIALIZED_IMAGE_MAX_AGE_MS;
+  let entries: fsSync.Dirent[];
+  try {
+    entries = fsSync.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const filePath = path.join(dir, entry.name);
+    try {
+      if (fsSync.statSync(filePath).mtimeMs < cutoffMs) {
+        fsSync.rmSync(filePath, { force: true });
+      }
+    } catch {
+      // Raced with another writer or already gone. Sweeping is best-effort.
+    }
+  }
+}
+
 function getMaterializedImageAttachmentDir(): string {
   if (
     materializedImageAttachmentDir &&
@@ -45,11 +87,18 @@ function getMaterializedImageAttachmentDir(): string {
     return materializedImageAttachmentDir;
   }
 
-  materializedImageAttachmentDir = fsSync.mkdtempSync(
-    path.join(os.tmpdir(), PROVIDER_IMAGE_ATTACHMENT_DIR_PREFIX),
-  );
-  fsSync.chmodSync(materializedImageAttachmentDir, PRIVATE_ATTACHMENT_DIR_MODE);
-  return materializedImageAttachmentDir;
+  const dir = path.join(resolvePaseoHome(), PROVIDER_IMAGE_ATTACHMENT_DIR);
+  fsSync.mkdirSync(dir, { recursive: true, mode: PRIVATE_ATTACHMENT_DIR_MODE });
+  fsSync.chmodSync(dir, PRIVATE_ATTACHMENT_DIR_MODE);
+  materializedImageAttachmentDir = dir;
+  sweepMaterializedImageAttachments(dir);
+  return dir;
+}
+
+/** Test-only hook: the sweep and the resolved directory are process-scoped. */
+export function __resetMaterializedImageAttachmentDirForTests(): void {
+  materializedImageAttachmentDir = null;
+  sweptMaterializedImageAttachments = false;
 }
 
 function getImageExtension(mimeType: string): string {
@@ -81,9 +130,11 @@ function normalizeImageData(mimeType: string, data: string): { mimeType: string;
   return { mimeType, data };
 }
 
-// Filenames are a content hash of the bytes so re-materializing the same image
-// within a process reuses the existing temp file instead of leaking a fresh one
-// for repeated image blocks or history replay.
+// Filenames are a content hash of the bytes, and the directory is now stable
+// across daemon restarts, so re-materializing the same image reuses the existing
+// file instead of leaking a fresh one for repeated image blocks or history
+// replay. Under the old per-process temp directory this deduplication only held
+// within a single daemon process.
 export function materializeProviderImage(image: {
   data: string;
   mimeType: string | null;


### PR DESCRIPTION
### Linked issue

Closes #2592

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Provider images (agent screenshots, generated diagrams, image tool output) were
materialized into a fresh `mkdtemp` directory under `os.tmpdir()`. On macOS that
is the per-user darwin temp dir, which `com.apple.bsd.dirhelper` sweeps daily at
03:35 with `CLEAN_FILES_OLDER_THAN_DAYS=3`. Around three days after an image
arrives, the file is deleted and the transcript is left pointing at a path that
no longer exists. The bytes lived nowhere else, so the image is gone for good.

This moves materialization to `resolvePaseoHome()/paseo-attachments/`, which is
persistent storage the system does not reap. Nothing deletes these files — see
Retention below, which is the part worth arguing about.

The directory is also now stable across daemon restarts, which makes the content
hashing actually pay off: filenames are a sha256 of the bytes, so re-emitting or
replaying the same image reuses its existing file instead of writing a fresh
copy. Under the old per-process `mkdtemp` directory that deduplication only held
within a single daemon process.

The directory basename stays `paseo-attachments`. `PROVIDER_IMAGE_MARKDOWN`
matches on it, and history written by older builds used
`mkdtemp(os.tmpdir(), "paseo-attachments-")` — the optional `-<suffix>` group in
that regex is what lets one pattern match both the old and new shapes, so
existing transcripts keep resolving.

Directory and file modes are unchanged (`0700` / `0600`). The directory now
lives somewhere long-lived, so it is `chmod`ed on every resolve rather than
trusted from creation.

### Retention

I first shipped this with a 30-day mtime sweep, described as refreshing mtime
"when an image is served". That was wrong on both counts, and @greptile-apps was
right to push on it twice.

There is no `utimes` call in in the production path and no serve hook in this module: the
client reads through the generic file-read RPC, which does not touch mtime. Only
re-materializing identical bytes refreshes it. So an image older than the window,
sitting in a transcript you only ever *read*, would have been swept — the same
data-loss bug as #2592, on a longer fuse.

It was also a regression in the other direction. Not every host reaps its temp
dir on a schedule; on those, these images previously survived indefinitely, and
adding our own deleter would have made them mortal for the first time.

So the sweep is gone, and I don't want to paper over what that costs: the
directory is now genuinely unbounded. On macOS this trades "the OS deletes your
images after 3 days" for "nothing ever deletes them". Content addressing keeps
growth proportional to distinct images rather than renders, but an agent doing
screenshot work produces genuinely distinct images.

Correct cleanup keys on references rather than a clock, and the hook already
exists: `AgentManager.deleteAgentState()` already tears down an agent's committed
timeline, so image files referenced only by that timeline could go with it. That
needs a cross-timeline check — content-addressed files can be shared between
agents — and it reaches well outside these three files. Happy to file a follow-up or
do it here instead.

Rejected along the way, for the record: a size cap with LRU eviction (still a
clock, reads still don't update it) and refreshing mtime on read (puts an mtime
write into the read path used by every file, not just images).

### Compatibility

Nothing changes on the wire — the image is still a markdown link holding an
absolute path, so no schema, no capability gate. `PROVIDER_IMAGE_MARKDOWN` is
byte-identical to before (I only added a comment), which is what makes it
two-way: a new daemon's suffix-less paths are recognized by older builds too.
`resolvePaseoHome()` returns an absolute path, so the client resolves it through
the same branch it already uses for `$TMPDIR` paths — an unchanged client reads
the new location.

**Forward-only, deliberately.** Images already in the temp dir are not migrated:
they keep rendering until the OS reaps them, and once reaped there are no bytes
left to migrate. Copying survivors across wouldn't rewrite the paths baked into
old transcripts, so it would salvage nothing without a read fallback too — not
worth it for a ≤3-day window. Happy to add it if you disagree.

### How did you verify it

- `npx vitest run packages/server/src/server/agent/providers/provider-image-output.test.ts packages/server/src/server/agent/providers/provider-image-output.posix.test.ts` — 14 tests pass. Coverage added for: images landing under the paseo home rather than the temp dir, an image being kept regardless of age (including across the daemon restart where a startup sweep would have run), deduplication across restarts, POSIX directory/file modes, and `PROVIDER_IMAGE_MARKDOWN` still matching both the old `paseo-attachments-<suffix>` and the new `paseo-attachments` shapes.
- `npm run typecheck` and `npm run lint` pass across the monorepo. `npm run format` ran.
- Confirmed the reaping mechanism on the affected platform rather than assuming it:
  ```
  $ node -e 'console.log(require("os").tmpdir())'
  /var/folders/d3/8pw4_k8s6gd1_hp7m75zqsvh0000gn/T
  $ plutil -p /System/Library/LaunchDaemons/com.apple.bsd.dirhelper.plist
    "EnvironmentVariables" => { "CLEAN_FILES_OLDER_THAN_DAYS" => "3" }
    "StartCalendarInterval" => { "Hour" => 3, "Minute" => 35 }
  ```
- Ran a live daemon from this branch and confirmed the image lands in the new
  location rather than `$TMPDIR`:
  ```
  > ls $PASEO_HOME/paseo-attachments
  de59df292050c80930b10c8a47eeec07975ceb7c29edd492e5f5366630b46df2.png
  ```
- The POSIX mode assertions live only in the `.posix` suite, which skips on
  win32 — Windows ignores mkdir/writeFile modes and reports `0o666`, which is
  what the first CI run caught.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform — n/a, no UI
- [x] Tests added or updated where it made sense
