### PR TITLE
fix(app): reconnect stale host connections on foreground

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -92,6 +92,7 @@ import { queryClient } from "@/data/query-client";
 import {
   getHostRuntimeStore,
   hasConfiguredLocalDaemonOverride,
+  reconnectStaleHostConnections,
   useHostRegistryLoaded,
   useHostMutations,
   useHostRuntimeClient,
@@ -977,7 +978,12 @@ export default function RootLayout() {
     const subscription = AppState.addEventListener("change", (nextState) => {
       if (nextState !== "active") {
         void flushDraftPersistStorage();
+        return;
       }
+      // OS suspension freezes client heartbeats and can kill sockets without
+      // a close frame; reconnect anything stale now rather than waiting out
+      // the heartbeat backoff.
+      reconnectStaleHostConnections();
     });
     return () => subscription.remove();
   }, []);

--- a/packages/app/src/components/add-project-flow.tsx
+++ b/packages/app/src/components/add-project-flow.tsx
@@ -412,7 +412,9 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
     },
     enabled: Boolean(client && searchesDirectories),
     dataShape: "value",
-    retry: false,
+    // Retry: the first attempt can race connection recovery (e.g. right
+    // after the app regains foreground) and fail into an empty list.
+    retry: 2,
     staleTimeMs: 15_000,
   });
   const githubQuery = useFetchQuery({

--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -2733,12 +2733,20 @@ describe("HostRuntimeStore", () => {
   });
 
   it("reconnectStaleConnections pokes every live client", async () => {
-    const fakeClient = new FakeDaemonClient();
+    const clientsByServerId: Record<string, FakeDaemonClient> = {
+      srv_stale_a: new FakeDaemonClient(),
+      srv_stale_b: new FakeDaemonClient(),
+    };
+    const clientFor = (serverId: string) => {
+      const fake = clientsByServerId[serverId];
+      if (!fake) throw new Error(`no fake client for ${serverId}`);
+      return fake as unknown as DaemonClient;
+    };
     const store = new HostRuntimeStore({
       deps: {
-        createClient: () => fakeClient as unknown as DaemonClient,
+        createClient: ({ host }) => clientFor(host.serverId),
         connectToDaemon: async ({ host }) => ({
-          client: fakeClient as unknown as DaemonClient,
+          client: clientFor(host.serverId),
           serverId: host.serverId,
           hostname: host.label ?? null,
         }),
@@ -2747,16 +2755,28 @@ describe("HostRuntimeStore", () => {
     });
 
     await store.upsertDirectConnection({
-      serverId: "srv_stale",
+      serverId: "srv_stale_a",
       endpoint: "lan:6767",
-      label: "stale host",
+      label: "stale host a",
     });
-    const fakeClientAsDaemon = fakeClient as unknown as DaemonClient;
+    await store.upsertDirectConnection({
+      serverId: "srv_stale_b",
+      endpoint: "lan:6768",
+      label: "stale host b",
+    });
+    const clientAdopted = (serverId: string) =>
+      store.getSnapshot(serverId)?.client === clientFor(serverId);
     await new Promise<void>((resolve) => {
-      if (store.getSnapshot("srv_stale")?.client === fakeClientAsDaemon) return resolve();
-      const unsubscribe = store.subscribe("srv_stale", () => {
-        if (store.getSnapshot("srv_stale")?.client === fakeClientAsDaemon) {
-          unsubscribe();
+      if (clientAdopted("srv_stale_a") && clientAdopted("srv_stale_b")) return resolve();
+      const unsubA = store.subscribe("srv_stale_a", () => {
+        if (clientAdopted("srv_stale_a") && clientAdopted("srv_stale_b")) {
+          unsubA();
+          resolve();
+        }
+      });
+      const unsubB = store.subscribe("srv_stale_b", () => {
+        if (clientAdopted("srv_stale_a") && clientAdopted("srv_stale_b")) {
+          unsubB();
           resolve();
         }
       });
@@ -2764,7 +2784,8 @@ describe("HostRuntimeStore", () => {
 
     store.reconnectStaleConnections();
 
-    expect(fakeClient.reconnectIfStaleCalls).toBe(1);
+    expect(clientsByServerId.srv_stale_a.reconnectIfStaleCalls).toBe(1);
+    expect(clientsByServerId.srv_stale_b.reconnectIfStaleCalls).toBe(1);
     store.syncHosts([]);
   });
 

--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -30,6 +30,7 @@ class FakeDaemonClient {
   private latencyMeasurementFailure: Error | null = null;
   private latencyMeasurementsRequested: Array<{ timeoutMs?: number }> = [];
   public connectCalls = 0;
+  public reconnectIfStaleCalls = 0;
   public fetchAgentsCalls: FetchAgentsOptions[] = [];
   public fetchAgentsResponses: Array<
     Awaited<ReturnType<DaemonClient["fetchAgents"]>> | ReturnType<DaemonClient["fetchAgents"]>
@@ -74,6 +75,10 @@ class FakeDaemonClient {
   async connect(): Promise<void> {
     this.connectCalls += 1;
     this.setConnectionState({ status: "connected" });
+  }
+
+  reconnectIfStale(): void {
+    this.reconnectIfStaleCalls += 1;
   }
 
   async close(): Promise<void> {
@@ -2724,6 +2729,42 @@ describe("HostRuntimeStore", () => {
     const renamed = store.getHosts().find((h) => h.serverId === "srv_rename");
     expect(renamed?.label).toBe("new name");
 
+    store.syncHosts([]);
+  });
+
+  it("reconnectStaleConnections pokes every live client", async () => {
+    const fakeClient = new FakeDaemonClient();
+    const store = new HostRuntimeStore({
+      deps: {
+        createClient: () => fakeClient as unknown as DaemonClient,
+        connectToDaemon: async ({ host }) => ({
+          client: fakeClient as unknown as DaemonClient,
+          serverId: host.serverId,
+          hostname: host.label ?? null,
+        }),
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+
+    await store.upsertDirectConnection({
+      serverId: "srv_stale",
+      endpoint: "lan:6767",
+      label: "stale host",
+    });
+    const fakeClientAsDaemon = fakeClient as unknown as DaemonClient;
+    await new Promise<void>((resolve) => {
+      if (store.getSnapshot("srv_stale")?.client === fakeClientAsDaemon) return resolve();
+      const unsubscribe = store.subscribe("srv_stale", () => {
+        if (store.getSnapshot("srv_stale")?.client === fakeClientAsDaemon) {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    store.reconnectStaleConnections();
+
+    expect(fakeClient.reconnectIfStaleCalls).toBe(1);
     store.syncHosts([]);
   });
 

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -2101,6 +2101,17 @@ export class HostRuntimeStore {
     return this.controllers.get(serverId)?.getSnapshot() ?? null;
   }
 
+  /**
+   * Reconnect every live client whose connection is stale. Called when the
+   * app regains foreground: OS suspension can kill sockets without a close
+   * frame, leaving zombie "connected" clients that requests hang against.
+   */
+  reconnectStaleConnections(): void {
+    for (const controller of this.controllers.values()) {
+      controller.getSnapshot().client?.reconnectIfStale();
+    }
+  }
+
   getVersion(): number {
     return this.version;
   }
@@ -2267,6 +2278,13 @@ export function useHostRuntimeSnapshot(serverId: string): HostRuntimeSnapshot | 
     () => store.getSnapshot(serverId),
     () => store.getSnapshot(serverId),
   );
+}
+
+/**
+ * Reconnect any stale host connections (app foreground recovery).
+ */
+export function reconnectStaleHostConnections(): void {
+  getHostRuntimeStore().reconnectStaleConnections();
 }
 
 export function useHostRuntimeClient(serverId: string): DaemonClient | null {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -2927,6 +2927,139 @@ test("reconnects after relay close with replaced-by-new-connection reason", asyn
   }
 });
 
+test("reconnectIfStale probes a healthy connection without reconnecting", async () => {
+  const mock = createMockTransport();
+  const transportFactory = vi.fn(() => mock.transport);
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_stale_healthy",
+    reconnect: { enabled: false },
+    transportFactory,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  client.reconnectIfStale();
+
+  // The probe ping went out; the healthy pong keeps the connection as-is.
+  expect(mock.sent.map(assertStr)).toContain(JSON.stringify({ type: "ping" }));
+  await vi.waitFor(() => {
+    expect(client.getConnectionState().status).toBe("connected");
+  });
+  expect(transportFactory).toHaveBeenCalledTimes(1);
+});
+
+test("reconnectIfStale reconnects immediately when the probe fails", async () => {
+  useHeartbeatClock();
+  try {
+    const first = createMockTransport();
+    const second = createMockTransport();
+    const transports = [first, second];
+    let transportIndex = 0;
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_stale_zombie",
+      reconnect: { enabled: true, baseDelayMs: 5, maxDelayMs: 5 },
+      transportFactory: () => {
+        const next = transports[Math.min(transportIndex, transports.length - 1)];
+        transportIndex += 1;
+        return next.transport;
+      },
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    first.triggerOpen();
+    await connectPromise;
+
+    // Zombie socket: writes are accepted but pings never get a pong.
+    const healthySend = first.transport.send;
+    first.transport.send = (data) => {
+      if (typeof data === "string" && JSON.parse(data).type === "ping") {
+        first.sent.push(data);
+        return;
+      }
+      healthySend(data);
+    };
+
+    client.reconnectIfStale({ probeTimeoutMs: 50 });
+    await vi.advanceTimersByTimeAsync(60);
+
+    // The failed probe bypassed the heartbeat threshold and reconnected.
+    expect(client.getConnectionState().status).not.toBe("connected");
+    await vi.advanceTimersByTimeAsync(10);
+    second.triggerOpen();
+    expect(client.getConnectionState().status).toBe("connected");
+    expect(transportIndex).toBe(2);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("reconnectIfStale connects immediately instead of waiting out reconnect backoff", async () => {
+  useHeartbeatClock();
+  try {
+    const first = createMockTransport();
+    const second = createMockTransport();
+    const transports = [first, second];
+    let transportIndex = 0;
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_stale_backoff",
+      reconnect: { enabled: true, baseDelayMs: 60_000, maxDelayMs: 60_000 },
+      transportFactory: () => {
+        const next = transports[Math.min(transportIndex, transports.length - 1)];
+        transportIndex += 1;
+        return next.transport;
+      },
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    first.triggerOpen();
+    await connectPromise;
+
+    first.triggerClose({ code: 1006, reason: "abnormal" });
+    expect(client.getConnectionState().status).toBe("disconnected");
+
+    // 60s of backoff is armed; the poke skips it without advancing timers.
+    client.reconnectIfStale();
+    expect(client.getConnectionState().status).toBe("connecting");
+
+    second.triggerOpen();
+    expect(client.getConnectionState().status).toBe("connected");
+    expect(transportIndex).toBe(2);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("reconnectIfStale is a no-op after close", async () => {
+  const mock = createMockTransport();
+  const transportFactory = vi.fn(() => mock.transport);
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_stale_closed",
+    reconnect: { enabled: false },
+    transportFactory,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+  await client.close();
+
+  client.reconnectIfStale();
+
+  expect(transportFactory).toHaveBeenCalledTimes(1);
+});
+
 test("requires non-empty clientId", () => {
   expect(() => {
     const _client = new DaemonClient({

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -1421,6 +1421,38 @@ export class DaemonClient {
     return this.connectionState;
   }
 
+  /**
+   * Reconnect immediately if the current connection is suspect. Intended
+   * for foreground recovery: OS suspension freezes the heartbeat and can
+   * kill the socket without delivering a close frame, leaving a zombie
+   * "connected" state that requests then hang against. A "connected"
+   * client gets one bounded liveness probe — on failure it reconnects now,
+   * bypassing the steady-state failure threshold; a "disconnected" client
+   * skips any pending reconnect backoff and connects now; other states are
+   * already recovering (or terminally closed) and are left alone.
+   */
+  reconnectIfStale(params?: { probeTimeoutMs?: number }): void {
+    if (this.connectionState.status === "connected") {
+      const timeoutMs = Math.max(1, params?.probeTimeoutMs ?? DEFAULT_LIVENESS_TIMEOUT_MS);
+      this.livenessPing({ timeoutMs }).catch((error: unknown) => {
+        if (this.connectionState.status !== "connected") {
+          return;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        this.scheduleReconnect({ reason: message, event: "STALE_PROBE_FAILED" });
+      });
+      return;
+    }
+    if (this.connectionState.status !== "disconnected" || !this.shouldReconnect) {
+      return;
+    }
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+    void this.connect().catch(() => undefined);
+  }
+
   subscribeConnectionStatus(listener: (status: ConnectionState) => void): () => void {
     this.connectionListeners.add(listener);
     listener(this.connectionState);


### PR DESCRIPTION
## Problem

After the app sits idle for hours (iOS suspends it), the Add Project directory autocomplete doesn't populate (#2615). The WebSocket dies while the app is suspended, but the client never sees a close frame and its liveness heartbeat is frozen — so it still reports `connected`. Requests fired in that window hang against the dead socket and fail without retry. Unrelated traffic (a chat send) tears the zombie down, which is why the feature "starts working again" afterward.

The mechanism is platform-independent: any OS suspension of the JS runtime produces the same zombie.

## Fix

- **`DaemonClient.reconnectIfStale()`** (client): one bounded liveness probe when `connected` — on failure it reconnects immediately, bypassing the steady-state failure threshold (which exists for flap avoidance, the wrong tool for a one-shot staleness decision). When `disconnected`, it skips any pending reconnect backoff and connects now. Healthy connections cost one ping, no churn.
- **`HostRuntimeStore.reconnectStaleConnections()`** (app): pokes every live client; wired to `AppState → active` in the root layout.
- **Add Project directory query**: `retry: 2` so a first attempt that races connection recovery self-heals.

## Tests

- Client: healthy probe (no reconnect), failed probe → immediate reconnect, backoff skip, post-close no-op.
- Store: `reconnectStaleConnections` reaches every live client.

## Verification

Reproduced the zombie against a dev daemon frozen with `SIGSTOP` (socket half-open, writes vanish — the same state iOS suspension leaves): the directory query stalls on "Loading…", and after `SIGCONT` the connection re-establishes and autocomplete populates. Client + app test suites green (109 + 60), typecheck/lint/format clean.

The AppState → active path is native; verified by unit tests (web's visibility-driven suspension doesn't fully freeze timers the same way).

Fixes #2615
