### PR TITLE
fix(server): append standard ports (80, 443) to connection hint

### DIFF
--- a/packages/server/src/server/bootstrap-web-ui.test.ts
+++ b/packages/server/src/server/bootstrap-web-ui.test.ts
@@ -97,6 +97,24 @@ describe("daemon web UI bootstrap", () => {
         headers: { "x-forwarded-proto": "https" },
       }),
     );
+    const noExplicitPortHttpsHint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: {
+          host: "daemon.example.test",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
+    const forwardedHostHttpsHint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: {
+          "x-forwarded-host": "PUBLIC.EXAMPLE.TEST",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
 
     expect(httpHint).toEqual({
       listen: `daemon.example.test:${daemonHandle.port}`,
@@ -105,6 +123,16 @@ describe("daemon web UI bootstrap", () => {
     });
     expect(httpsHint).toEqual({
       listen: `daemon.example.test:${daemonHandle.port}`,
+      useTls: true,
+      label: os.hostname(),
+    });
+    expect(noExplicitPortHttpsHint).toEqual({
+      listen: "daemon.example.test:443",
+      useTls: true,
+      label: os.hostname(),
+    });
+    expect(forwardedHostHttpsHint).toEqual({
+      listen: "PUBLIC.EXAMPLE.TEST:443",
       useTls: true,
       label: os.hostname(),
     });
@@ -128,10 +156,96 @@ describe("daemon web UI bootstrap", () => {
         headers: { "x-forwarded-proto": "https" },
       }),
     );
+    const noExplicitPortHttpsHint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: {
+          host: "daemon.example.test",
+          "x-forwarded-host": "attacker.example.test:8443",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
 
     expect(httpsHint).toEqual({
       listen: `daemon.example.test:${daemonHandle.port}`,
       useTls: false,
+      label: os.hostname(),
+    });
+    expect(noExplicitPortHttpsHint).toEqual({
+      listen: "daemon.example.test:80",
+      useTls: false,
+      label: os.hostname(),
+    });
+  });
+
+  test.each([
+    {
+      name: "IPv4 HTTP",
+      host: "127.0.0.1",
+      forwardedProto: undefined,
+      expectedListen: "127.0.0.1:80",
+      expectedUseTls: false,
+    },
+    {
+      name: "IPv4 HTTPS",
+      host: "127.0.0.1",
+      forwardedProto: "https",
+      expectedListen: "127.0.0.1:443",
+      expectedUseTls: true,
+    },
+    {
+      name: "IPv4 with an explicit port",
+      host: "127.0.0.1:6767",
+      forwardedProto: "https",
+      expectedListen: "127.0.0.1:6767",
+      expectedUseTls: true,
+    },
+    {
+      name: "IPv6 HTTP",
+      host: "[::1]",
+      forwardedProto: undefined,
+      expectedListen: "[::1]:80",
+      expectedUseTls: false,
+    },
+    {
+      name: "IPv6 HTTPS",
+      host: "[::1]",
+      forwardedProto: "https",
+      expectedListen: "[::1]:443",
+      expectedUseTls: true,
+    },
+    {
+      name: "IPv6 with an explicit port",
+      host: "[::1]:6767",
+      forwardedProto: "https",
+      expectedListen: "[::1]:6767",
+      expectedUseTls: true,
+    },
+  ])("handles $name connection hints", async (testCase) => {
+    const distDir = await createWebUiDist();
+
+    daemonHandle = await createTestPaseoDaemon({
+      mcpEnabled: false,
+      webUi: {
+        enabled: true,
+        distDir,
+      },
+    });
+
+    const hint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: {
+          host: testCase.host,
+          ...(testCase.forwardedProto ? { "x-forwarded-proto": testCase.forwardedProto } : {}),
+        },
+      }),
+    );
+
+    expect(hint).toEqual({
+      listen: testCase.expectedListen,
+      useTls: testCase.expectedUseTls,
       label: os.hostname(),
     });
   });

--- a/packages/server/src/server/web-ui.ts
+++ b/packages/server/src/server/web-ui.ts
@@ -1,6 +1,6 @@
 import { createReadStream, readFileSync, statSync } from "node:fs";
 import path from "node:path";
-import type { RequestHandler, Response } from "express";
+import type { Request, RequestHandler, Response } from "express";
 import type { Logger } from "pino";
 
 const EXCLUDED_PATH_PREFIXES = ["/api/", "/mcp/", "/public/"];
@@ -250,15 +250,82 @@ function serializeInlineScriptJson(value: unknown): string {
     .replace(/&/g, "\\u0026");
 }
 
+// The function that resolves the listen value requires an explicit port to be present.
+// When using a standard port (80, 443), the port number is usually omitted from the
+// Host and X-Forwarded-Host headers. This function adds it back if possible.
+export function resolveConnectionHintListen(authority: string, protocol: string): string {
+  if (hasExplicitPort(authority)) {
+    return authority;
+  }
+
+  if (protocol === "https") {
+    return `${authority}:443`;
+  }
+  if (protocol === "http") {
+    return `${authority}:80`;
+  }
+  return authority;
+}
+
+// Ported over from Express.js v5's implementation of the getter for req.host.
+// Can be replaced with req.host if we upgrade.
+function getRequestHost(req: Request): string | undefined {
+  const trust = req.app.get("trust proxy fn") as (
+    address: string | undefined,
+    index: number,
+  ) => boolean;
+  let host = req.get("X-Forwarded-Host");
+
+  if (!host || !trust(req.socket.remoteAddress, 0)) {
+    host = req.get("Host");
+  } else if (host.indexOf(",") !== -1) {
+    host = host.substring(0, host.indexOf(",")).trimEnd();
+  }
+
+  return host || undefined;
+}
+
+// Adapted from Go's net.SplitHostPort.
+function hasExplicitPort(hostport: string): boolean {
+  const colon = hostport.lastIndexOf(":");
+  if (colon < 0 || colon === hostport.length - 1) {
+    return false;
+  }
+
+  let openBracketSearchStart = 0;
+  let closeBracketSearchStart = 0;
+
+  if (hostport[0] === "[") {
+    const closeBracket = hostport.indexOf("]");
+    if (closeBracket < 0 || closeBracket + 1 !== colon) {
+      return false;
+    }
+    openBracketSearchStart = 1;
+    closeBracketSearchStart = closeBracket + 1;
+  } else if (hostport.slice(0, colon).includes(":")) {
+    return false;
+  }
+
+  if (hostport.indexOf("[", openBracketSearchStart) >= 0) {
+    return false;
+  }
+  if (hostport.indexOf("]", closeBracketSearchStart) >= 0) {
+    return false;
+  }
+
+  return true;
+}
+
 function injectConnectionHint(
   html: string,
   req: Parameters<RequestHandler>[0],
   label: string,
 ): string {
-  const host = typeof req.headers.host === "string" ? req.headers.host : "";
+  const host = getRequestHost(req) ?? "";
+  const listen = resolveConnectionHintListen(host, req.protocol);
   const useTls = req.protocol === "https";
   const hint = {
-    listen: host,
+    listen,
     useTls,
     label,
   };


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

If you're fixing an objective bug or a small focused issue, this should be quick. Big PRs without a prior issue or design discussion are likely to be closed or scoped down. See CONTRIBUTING.md.
-->

### Linked issue

Not sure if a Discord thread qualifies as a issue, but happy to open an issue if required.

https://discord.com/channels/1481169421832814616/1529502102433566770/1529502102433566770

<!-- Bug fixes and behavior changes should reference an issue. Pure docs and refactors can skip this. -->

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

<!-- A short description of the change in your own words. What was wrong, what you changed, why it works. If you can't explain this briefly, the PR is probably too big. -->

The connection hints generated by `web-ui.ts` don't contain a port number if request was made over a standard port (80, 443). This requires the user to manually add a host with the correct connection string. This should ideally be seamless.

This PR fixes the above issue by appending the port number if it is appropriate to do so.

This PR also makes the connection hint resolver respect `X-Forwarded-Host` if trusted proxy = true. This was already being done for `X-Forwarded-Proto` when we use `req.protocol` (c.f. [Express.js docs](https://expressjs.com/en/4x/api/request/#reqprotocol)).

Re. lifting of implementations from Express v5 and Go: the implementation can probably be simplified into one function, but making a mistake here probably breaks connections for a non-trivial number of users. There are probably edge cases handled in the code that I lifted that I would miss if I were to write them myself.

### How did you verify it

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.

AI-generated PR descriptions are fine in principle. AI-generated *verification claims* with no actual testing behind them are not, and they're easy to spot.
-->

#### IPV4 Testing

- rebuilt, accessed Paseo using the following links
  - https://paseo-throwaway.exe.xyz:8000 - continued to work
  - https://paseo-throwaway.exe.xyz - was failing before this fix

#### IPv6 Testing

- tested over loopback with the following script that spun up a paseo instance, prodded it with a set of headers to see what the connection hint is, then attempted a connection with the connection hint
  - [test-paseo-ipv6-connection-hint.sh](https://github.com/user-attachments/files/30514147/test-paseo-ipv6-connection-hint.sh)
  - [ipv6-test-output.txt](https://github.com/user-attachments/files/30514148/ipv6-test-output.txt)

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
