### PR TITLE
feat(app): find in conversation (Cmd/Ctrl+F)

### DIFF
--- a/packages/app/e2e/browser/find-in-conversation.spec.ts
+++ b/packages/app/e2e/browser/find-in-conversation.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "./fixtures";
-import { openAgentRoute, seedMockAgentWorkspace } from "./helpers/mock-agent";
+import { expect, test } from "../support/fixtures";
+import { openAgentRoute, seedMockAgentWorkspace } from "../support/helpers/mock-agent";
 
 const FIND_MODIFIER = process.platform === "darwin" ? "Meta" : "Control";
 
@@ -29,9 +29,13 @@ test.describe("Find in conversation", () => {
         workspace.agentId,
         "third prompt about zebra and zebra again",
       );
-      await expect(
-        page.getByTestId("user-message").filter({ hasText: "third prompt" }),
-      ).toBeVisible({ timeout: 30_000 });
+      const firstMatchMessage = page
+        .getByTestId("user-message")
+        .filter({ hasText: "first prompt" });
+      const thirdMatchMessage = page
+        .getByTestId("user-message")
+        .filter({ hasText: "third prompt" });
+      await expect(thirdMatchMessage).toBeVisible({ timeout: 30_000 });
 
       const findBar = page.getByTestId("session-find-bar");
       await expect(findBar).toBeHidden();
@@ -45,20 +49,25 @@ test.describe("Find in conversation", () => {
       // One occurrence in the first message, two in the third.
       const count = page.getByTestId("session-find-count");
       await expect(count).toHaveText("1/3");
+      await expect(firstMatchMessage).toBeInViewport();
 
       await page.getByTestId("session-find-next").click();
       await expect(count).toHaveText("2/3");
+      await expect(thirdMatchMessage).toBeInViewport();
 
       await page.getByTestId("session-find-next").click();
       await expect(count).toHaveText("3/3");
+      await expect(thirdMatchMessage).toBeInViewport();
 
       // Forward from the last match wraps to the first.
       await page.getByTestId("session-find-next").click();
       await expect(count).toHaveText("1/3");
+      await expect(firstMatchMessage).toBeInViewport();
 
       // Backward from the first match wraps to the last.
       await page.getByTestId("session-find-previous").click();
       await expect(count).toHaveText("3/3");
+      await expect(thirdMatchMessage).toBeInViewport();
 
       await page.keyboard.press("Escape");
       await expect(findBar).toBeHidden();

--- a/packages/app/e2e/find-in-conversation.spec.ts
+++ b/packages/app/e2e/find-in-conversation.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "./fixtures";
+import { openAgentRoute, seedMockAgentWorkspace } from "./helpers/mock-agent";
+
+const FIND_MODIFIER = process.platform === "darwin" ? "Meta" : "Control";
+
+/**
+ * Browser-level coverage for find-in-conversation: a real Cmd/Ctrl+F keystroke
+ * through the app's window listener, real find bar, and real scrolling. The
+ * transcript is built from user messages so the assertions do not depend on
+ * mock-provider streaming content.
+ */
+test.describe("Find in conversation", () => {
+  test("finds, counts, and navigates matches from a real keystroke", async ({ page }) => {
+    test.setTimeout(120_000);
+    const workspace = await seedMockAgentWorkspace({
+      repoPrefix: "find-in-conversation-",
+      title: "Find in conversation",
+    });
+
+    try {
+      await openAgentRoute(page, {
+        workspaceId: workspace.workspaceId,
+        agentId: workspace.agentId,
+      });
+
+      await workspace.client.sendAgentMessage(workspace.agentId, "first prompt about zebra");
+      await workspace.client.sendAgentMessage(workspace.agentId, "unrelated prompt");
+      await workspace.client.sendAgentMessage(
+        workspace.agentId,
+        "third prompt about zebra and zebra again",
+      );
+      await expect(
+        page.getByTestId("user-message").filter({ hasText: "third prompt" }),
+      ).toBeVisible({ timeout: 30_000 });
+
+      const findBar = page.getByTestId("session-find-bar");
+      await expect(findBar).toBeHidden();
+
+      await page.keyboard.press(`${FIND_MODIFIER}+f`);
+      await expect(findBar).toBeVisible();
+
+      // The find input takes focus on open, so the query can be typed directly.
+      await page.keyboard.type("zebra");
+
+      // One occurrence in the first message, two in the third.
+      const count = page.getByTestId("session-find-count");
+      await expect(count).toHaveText("1/3");
+
+      await page.getByTestId("session-find-next").click();
+      await expect(count).toHaveText("2/3");
+
+      await page.getByTestId("session-find-next").click();
+      await expect(count).toHaveText("3/3");
+
+      // Forward from the last match wraps to the first.
+      await page.getByTestId("session-find-next").click();
+      await expect(count).toHaveText("1/3");
+
+      // Backward from the first match wraps to the last.
+      await page.getByTestId("session-find-previous").click();
+      await expect(count).toHaveText("3/3");
+
+      await page.keyboard.press("Escape");
+      await expect(findBar).toBeHidden();
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  test("scrolls an off-screen match into view", async ({ page }) => {
+    test.setTimeout(120_000);
+    const workspace = await seedMockAgentWorkspace({
+      repoPrefix: "find-in-conversation-scroll-",
+      title: "Find in conversation scroll",
+    });
+
+    try {
+      await openAgentRoute(page, {
+        workspaceId: workspace.workspaceId,
+        agentId: workspace.agentId,
+      });
+
+      // The needle goes in the only user message; the mock's streamed reply then
+      // grows past the viewport while auto-scroll follows the bottom, pushing the
+      // marker off screen.
+      await workspace.client.sendAgentMessage(workspace.agentId, "needle marker message");
+      const marker = page.getByTestId("user-message").filter({ hasText: "needle marker" }).first();
+      await expect(marker).toBeVisible({ timeout: 30_000 });
+      await expect(marker).not.toBeInViewport({ timeout: 60_000 });
+
+      await page.keyboard.press(`${FIND_MODIFIER}+f`);
+      await expect(page.getByTestId("session-find-bar")).toBeVisible();
+      await page.keyboard.type("needle");
+
+      await expect(page.getByTestId("session-find-count")).toHaveText("1/1");
+      await expect(marker).toBeInViewport();
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+});

--- a/packages/app/src/agent-stream/find-bar.tsx
+++ b/packages/app/src/agent-stream/find-bar.tsx
@@ -176,7 +176,7 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
   },
   count: {
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.foregroundMuted,
     fontVariant: ["tabular-nums"],
   },

--- a/packages/app/src/agent-stream/find-bar.tsx
+++ b/packages/app/src/agent-stream/find-bar.tsx
@@ -4,13 +4,16 @@ import { useTranslation } from "react-i18next";
 import {
   Pressable,
   Text,
-  TextInput,
   View,
   type NativeSyntheticEvent,
   type PressableStateCallbackType,
   type TextInputKeyPressEventData,
 } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import {
+  EditingTextInput as TextInput,
+  type EditingTextInputHandle,
+} from "@/components/ui/text-input";
 import { isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
 
@@ -61,7 +64,7 @@ export function SessionFindBar({
   onClose,
 }: SessionFindBarProps) {
   const { t } = useTranslation();
-  const inputRef = useRef<TextInput>(null);
+  const inputRef = useRef<EditingTextInputHandle>(null);
 
   useEffect(() => {
     const input = inputRef.current;

--- a/packages/app/src/agent-stream/find-bar.tsx
+++ b/packages/app/src/agent-stream/find-bar.tsx
@@ -1,0 +1,196 @@
+import { ChevronDown, ChevronUp, X } from "lucide-react-native";
+import { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Pressable,
+  Text,
+  TextInput,
+  View,
+  type NativeSyntheticEvent,
+  type PressableStateCallbackType,
+  type TextInputKeyPressEventData,
+} from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { isWeb } from "@/constants/platform";
+import type { Theme } from "@/styles/theme";
+
+const ThemedFindInput = withUnistyles(TextInput);
+const ThemedChevronUp = withUnistyles(ChevronUp);
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedXIcon = withUnistyles(X);
+
+const iconColorMapping = (theme: Theme) => ({
+  color: theme.colors.foregroundMuted,
+});
+const inputColorMapping = (theme: Theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+});
+
+const iconButtonStyle = ({
+  pressed,
+  hovered = false,
+}: PressableStateCallbackType & { hovered?: boolean }) => [
+  styles.iconButton,
+  hovered ? styles.iconButtonHovered : null,
+  pressed ? styles.iconButtonPressed : null,
+];
+
+const disabledIconButtonStyle = () => [styles.iconButton, styles.iconButtonDisabled];
+
+export interface SessionFindBarProps {
+  query: string;
+  matchCount: number;
+  /** 1-based position of the active match; 0 when there is none. */
+  activeMatchNumber: number;
+  /** Bump to focus the input (and select its text) again. */
+  focusRequestId: number;
+  onQueryChange: (query: string) => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+}
+
+export function SessionFindBar({
+  query,
+  matchCount,
+  activeMatchNumber,
+  focusRequestId,
+  onQueryChange,
+  onNext,
+  onPrevious,
+  onClose,
+}: SessionFindBarProps) {
+  const { t } = useTranslation();
+  const inputRef = useRef<TextInput>(null);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+    input.focus();
+    if (isWeb) {
+      // On web the TextInput ref is the underlying input element; selecting
+      // the previous query lets a repeated Cmd+F overwrite it directly.
+      (input as unknown as { select?: () => void }).select?.();
+    }
+  }, [focusRequestId]);
+
+  const handleKeyPress = useCallback(
+    (event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+      const { key } = event.nativeEvent;
+      if (key === "Enter") {
+        const shiftKey = Boolean(
+          (event.nativeEvent as TextInputKeyPressEventData & { shiftKey?: boolean }).shiftKey,
+        );
+        if (shiftKey) {
+          onPrevious();
+        } else {
+          onNext();
+        }
+        return;
+      }
+      if (key === "Escape") {
+        onClose();
+      }
+    },
+    [onClose, onNext, onPrevious],
+  );
+
+  const hasMatches = matchCount > 0;
+
+  return (
+    <View style={styles.bar} testID="session-find-bar">
+      <ThemedFindInput
+        ref={inputRef}
+        // @ts-expect-error - outlineStyle is web-only
+        style={[styles.input, isWeb && { outlineStyle: "none" }]}
+        uniProps={inputColorMapping}
+        value={query}
+        onChangeText={onQueryChange}
+        onKeyPress={handleKeyPress}
+        placeholder={t("agentStream.find.placeholder")}
+        autoCapitalize="none"
+        autoCorrect={false}
+        blurOnSubmit={false}
+        testID="session-find-input"
+      />
+      {query.length > 0 ? (
+        <Text style={styles.count} testID="session-find-count">
+          {t("agentStream.find.matchCount", {
+            current: activeMatchNumber,
+            total: matchCount,
+          })}
+        </Text>
+      ) : null}
+      <Pressable
+        style={hasMatches ? iconButtonStyle : disabledIconButtonStyle}
+        onPress={onPrevious}
+        disabled={!hasMatches}
+        accessibilityRole="button"
+        accessibilityLabel={t("agentStream.find.previous")}
+        testID="session-find-previous"
+      >
+        <ThemedChevronUp size={14} uniProps={iconColorMapping} />
+      </Pressable>
+      <Pressable
+        style={hasMatches ? iconButtonStyle : disabledIconButtonStyle}
+        onPress={onNext}
+        disabled={!hasMatches}
+        accessibilityRole="button"
+        accessibilityLabel={t("agentStream.find.next")}
+        testID="session-find-next"
+      >
+        <ThemedChevronDown size={14} uniProps={iconColorMapping} />
+      </Pressable>
+      <Pressable
+        style={iconButtonStyle}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel={t("agentStream.find.close")}
+        testID="session-find-close"
+      >
+        <ThemedXIcon size={14} uniProps={iconColorMapping} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  bar: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: theme.spacing[1],
+    backgroundColor: theme.colors.surface1,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.lg,
+    ...theme.shadow.sm,
+  },
+  input: {
+    width: 200,
+    paddingVertical: theme.spacing[1],
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foreground,
+  },
+  count: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+    fontVariant: ["tabular-nums"],
+  },
+  iconButton: {
+    padding: theme.spacing[1],
+    borderRadius: theme.borderRadius.md,
+  },
+  iconButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  iconButtonPressed: {
+    opacity: 0.9,
+  },
+  iconButtonDisabled: {
+    opacity: theme.opacity[50],
+  },
+}));

--- a/packages/app/src/agent-stream/find-highlight.test.ts
+++ b/packages/app/src/agent-stream/find-highlight.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SessionFindState } from "./find-in-session";
+import {
+  acquireSessionFindHighlightOwner,
+  applySessionFindHighlights,
+  clearSessionFindHighlights,
+  releaseSessionFindHighlightOwner,
+} from "./find-highlight";
+
+class FakeHighlight {
+  readonly ranges: Range[];
+  constructor(...ranges: Range[]) {
+    this.ranges = ranges;
+  }
+}
+
+let registry: Map<string, FakeHighlight>;
+let containers: HTMLElement[];
+
+function withGlobals(): void {
+  registry = new Map();
+  (globalThis as { CSS?: unknown }).CSS = { highlights: registry, escape: (v: string) => v };
+  (globalThis as { Highlight?: unknown }).Highlight = FakeHighlight;
+}
+
+/** Builds a stream container whose rows hold the given text nodes per item. */
+function createContainer(rows: Array<{ itemId: string; textNodes: string[] }>): HTMLElement {
+  const container = document.createElement("div");
+  for (const row of rows) {
+    const rowElement = document.createElement("div");
+    rowElement.setAttribute("data-stream-item-id", row.itemId);
+    for (const text of row.textNodes) {
+      const span = document.createElement("span");
+      span.textContent = text;
+      rowElement.appendChild(span);
+    }
+    container.appendChild(rowElement);
+  }
+  document.body.appendChild(container);
+  containers.push(container);
+  return container;
+}
+
+function findState(overrides: Partial<SessionFindState> = {}): SessionFindState {
+  return {
+    query: "deploy",
+    activeItemId: "first",
+    activeOccurrenceIndex: 0,
+    activeItemOccurrenceCount: 1,
+    ...overrides,
+  };
+}
+
+function rangeTexts(name: string): string[] {
+  return (registry.get(name)?.ranges ?? []).map((range) => range.toString());
+}
+
+beforeEach(() => {
+  containers = [];
+  withGlobals();
+});
+
+afterEach(() => {
+  for (const container of containers) {
+    container.remove();
+  }
+  Reflect.deleteProperty(globalThis as { CSS?: unknown }, "CSS");
+  Reflect.deleteProperty(globalThis as { Highlight?: unknown }, "Highlight");
+  document.getElementById("paseo-session-find-highlight-style")?.remove();
+});
+
+describe("session find highlights", () => {
+  it("registers match and active ranges under the owner's own names", () => {
+    const owner = acquireSessionFindHighlightOwner();
+    const container = createContainer([
+      { itemId: "first", textNodes: ["deploy the service"] },
+      { itemId: "second", textNodes: ["deploy elsewhere"] },
+    ]);
+
+    applySessionFindHighlights({ owner, container, find: findState() });
+
+    expect(rangeTexts(owner.activeName)).toEqual(["deploy"]);
+    expect(rangeTexts(owner.matchName)).toEqual(["deploy"]);
+    expect(owner.matchName).not.toBe(owner.activeName);
+    releaseSessionFindHighlightOwner(owner);
+  });
+
+  // Retained tabs and split panes keep several viewports mounted; each one
+  // re-runs its highlight pass whenever its own agent streams.
+  it("keeps one viewport's highlights when another mounted viewport clears its own", () => {
+    const searchingOwner = acquireSessionFindHighlightOwner();
+    const backgroundOwner = acquireSessionFindHighlightOwner();
+    const container = createContainer([{ itemId: "first", textNodes: ["deploy the service"] }]);
+
+    applySessionFindHighlights({ owner: searchingOwner, container, find: findState() });
+    expect(rangeTexts(searchingOwner.activeName)).toEqual(["deploy"]);
+
+    // The background pane has no open find bar, so it clears its own slot.
+    clearSessionFindHighlights(backgroundOwner);
+
+    expect(rangeTexts(searchingOwner.activeName)).toEqual(["deploy"]);
+    expect(registry.has(backgroundOwner.activeName)).toBe(false);
+
+    releaseSessionFindHighlightOwner(searchingOwner);
+    releaseSessionFindHighlightOwner(backgroundOwner);
+  });
+
+  it("lets two open find bars hold different ranges at once", () => {
+    const left = acquireSessionFindHighlightOwner();
+    const right = acquireSessionFindHighlightOwner();
+    const leftContainer = createContainer([{ itemId: "first", textNodes: ["deploy the service"] }]);
+    const rightContainer = createContainer([
+      { itemId: "other", textNodes: ["restart the daemon"] },
+    ]);
+
+    applySessionFindHighlights({ owner: left, container: leftContainer, find: findState() });
+    applySessionFindHighlights({
+      owner: right,
+      container: rightContainer,
+      find: findState({ query: "restart", activeItemId: "other" }),
+    });
+
+    expect(rangeTexts(left.activeName)).toEqual(["deploy"]);
+    expect(rangeTexts(right.activeName)).toEqual(["restart"]);
+
+    releaseSessionFindHighlightOwner(left);
+    releaseSessionFindHighlightOwner(right);
+  });
+
+  it("releases the highlight entries and reuses the slot", () => {
+    const owner = acquireSessionFindHighlightOwner();
+    const container = createContainer([{ itemId: "first", textNodes: ["deploy the service"] }]);
+    applySessionFindHighlights({ owner, container, find: findState() });
+
+    releaseSessionFindHighlightOwner(owner);
+
+    expect(registry.has(owner.matchName)).toBe(false);
+    expect(registry.has(owner.activeName)).toBe(false);
+    expect(acquireSessionFindHighlightOwner().slot).toBe(owner.slot);
+  });
+
+  it("emphasizes the requested occurrence when the row's occurrences line up", () => {
+    const owner = acquireSessionFindHighlightOwner();
+    const container = createContainer([
+      { itemId: "first", textNodes: ["deploy once, then deploy twice"] },
+    ]);
+
+    applySessionFindHighlights({
+      owner,
+      container,
+      find: findState({ activeOccurrenceIndex: 1, activeItemOccurrenceCount: 2 }),
+    });
+
+    expect(registry.get(owner.activeName)?.ranges).toHaveLength(1);
+    expect(registry.get(owner.matchName)?.ranges).toHaveLength(1);
+    releaseSessionFindHighlightOwner(owner);
+  });
+
+  // The model counts occurrences in an item's source text while the renderer
+  // enumerates rendered text nodes; a needle split across an inline-formatting
+  // boundary makes the two disagree, so the ordinal cannot be trusted.
+  it("emphasizes every occurrence in the active row when the counts disagree", () => {
+    const owner = acquireSessionFindHighlightOwner();
+    const container = createContainer([
+      // Only the first "deploy" survives as a single text node.
+      { itemId: "first", textNodes: ["deploy now, dep", "loy again"] },
+    ]);
+
+    applySessionFindHighlights({
+      owner,
+      container,
+      find: findState({ activeOccurrenceIndex: 1, activeItemOccurrenceCount: 2 }),
+    });
+
+    expect(rangeTexts(owner.activeName)).toEqual(["deploy"]);
+    expect(registry.get(owner.matchName)?.ranges).toHaveLength(0);
+    releaseSessionFindHighlightOwner(owner);
+  });
+
+  it("registers nothing and does not throw without the Custom Highlight API", () => {
+    Reflect.deleteProperty(globalThis as { Highlight?: unknown }, "Highlight");
+    const owner = acquireSessionFindHighlightOwner();
+    const container = createContainer([{ itemId: "first", textNodes: ["deploy the service"] }]);
+
+    expect(() => applySessionFindHighlights({ owner, container, find: findState() })).not.toThrow();
+    expect(registry.size).toBe(0);
+    releaseSessionFindHighlightOwner(owner);
+  });
+});

--- a/packages/app/src/agent-stream/find-highlight.test.ts
+++ b/packages/app/src/agent-stream/find-highlight.test.ts
@@ -159,14 +159,28 @@ describe("session find highlights", () => {
     releaseSessionFindHighlightOwner(owner);
   });
 
-  // The model counts occurrences in an item's source text while the renderer
-  // enumerates rendered text nodes; a needle split across an inline-formatting
-  // boundary makes the two disagree, so the ordinal cannot be trusted.
-  it("emphasizes every occurrence in the active row when the counts disagree", () => {
+  // Syntax highlighting splits a contiguous source string into one span per
+  // token, so per-node matching would find nothing to highlight here.
+  it("highlights an occurrence the renderer split across text nodes", () => {
     const owner = acquireSessionFindHighlightOwner();
     const container = createContainer([
-      // Only the first "deploy" survives as a single text node.
-      { itemId: "first", textNodes: ["deploy now, dep", "loy again"] },
+      { itemId: "first", textNodes: ["npm ", "run", " ", "typecheck"] },
+    ]);
+
+    applySessionFindHighlights({
+      owner,
+      container,
+      find: findState({ query: "run typecheck" }),
+    });
+
+    expect(rangeTexts(owner.activeName)).toEqual(["run typecheck"]);
+    releaseSessionFindHighlightOwner(owner);
+  });
+
+  it("keeps occurrence order when matches span node boundaries", () => {
+    const owner = acquireSessionFindHighlightOwner();
+    const container = createContainer([
+      { itemId: "first", textNodes: ["dep", "loy once, then de", "ploy twice"] },
     ]);
 
     applySessionFindHighlights({
@@ -175,7 +189,28 @@ describe("session find highlights", () => {
       find: findState({ activeOccurrenceIndex: 1, activeItemOccurrenceCount: 2 }),
     });
 
+    // Both occurrences are found, so the ordinal is trusted: the second is active.
     expect(rangeTexts(owner.activeName)).toEqual(["deploy"]);
+    expect(rangeTexts(owner.matchName)).toEqual(["deploy"]);
+    releaseSessionFindHighlightOwner(owner);
+  });
+
+  // The model sees an item's source text; a row can still render extra text the
+  // model never searched, so the ordinal cannot be trusted unconditionally.
+  it("emphasizes every occurrence in the active row when the counts disagree", () => {
+    const owner = acquireSessionFindHighlightOwner();
+    const container = createContainer([
+      // Rendered chrome contributes an occurrence the match model never saw.
+      { itemId: "first", textNodes: ["deploy", "deploy once"] },
+    ]);
+
+    applySessionFindHighlights({
+      owner,
+      container,
+      find: findState({ activeOccurrenceIndex: 0, activeItemOccurrenceCount: 1 }),
+    });
+
+    expect(rangeTexts(owner.activeName)).toEqual(["deploy", "deploy"]);
     expect(registry.get(owner.matchName)?.ranges).toHaveLength(0);
     releaseSessionFindHighlightOwner(owner);
   });

--- a/packages/app/src/agent-stream/find-highlight.ts
+++ b/packages/app/src/agent-stream/find-highlight.ts
@@ -1,0 +1,136 @@
+import { baseColors } from "@/styles/theme";
+import type { SessionFindState } from "./find-in-session";
+
+/**
+ * Text-level match highlighting for find-in-session via the CSS Custom
+ * Highlight API. Ranges are registered against text nodes inside
+ * `[data-stream-item-id]` rows, so no React re-render or markdown rewriting is
+ * needed. On runtimes without the API (or native), everything degrades to
+ * scroll-to-row with no text highlight.
+ *
+ * CSS.highlights is document-global; if two panes run a find at once, the
+ * last-applied pass wins. That is acceptable for a transient overlay.
+ */
+
+const MATCH_HIGHLIGHT_NAME = "paseo-session-find-match";
+const ACTIVE_HIGHLIGHT_NAME = "paseo-session-find-active";
+const HIGHLIGHT_STYLE_ELEMENT_ID = "paseo-session-find-highlight-style";
+
+interface HighlightRegistry {
+  set(name: string, highlight: unknown): void;
+  delete(name: string): void;
+}
+
+interface HighlightConstructor {
+  new (...ranges: Range[]): unknown;
+}
+
+function getHighlightSupport(): {
+  registry: HighlightRegistry;
+  Highlight: HighlightConstructor;
+} | null {
+  if (typeof document === "undefined" || typeof CSS === "undefined") {
+    return null;
+  }
+  const css = CSS as unknown as { highlights?: HighlightRegistry };
+  const highlightCtor = (globalThis as { Highlight?: HighlightConstructor }).Highlight;
+  if (!css.highlights || typeof highlightCtor !== "function") {
+    return null;
+  }
+  return { registry: css.highlights, Highlight: highlightCtor };
+}
+
+function ensureHighlightStyles(): void {
+  if (document.getElementById(HIGHLIGHT_STYLE_ELEMENT_ID)) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.id = HIGHLIGHT_STYLE_ELEMENT_ID;
+  // Alpha-tinted palette values read on both light and dark surfaces; the
+  // active occurrence gets a solid fill so it stands out among matches.
+  style.textContent = [
+    `::highlight(${MATCH_HIGHLIGHT_NAME}) { background-color: ${baseColors.amber[500]}4d; }`,
+    `::highlight(${ACTIVE_HIGHLIGHT_NAME}) { background-color: ${baseColors.amber[500]}; color: ${baseColors.zinc[900]}; }`,
+  ].join("\n");
+  document.head.appendChild(style);
+}
+
+function collectTextNodes(root: Element): Text[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  let node = walker.nextNode();
+  while (node) {
+    nodes.push(node as Text);
+    node = walker.nextNode();
+  }
+  return nodes;
+}
+
+function collectRowRanges(row: Element, needle: string): Range[] {
+  const ranges: Range[] = [];
+  for (const textNode of collectTextNodes(row)) {
+    const haystack = textNode.textContent?.toLowerCase();
+    if (!haystack) {
+      continue;
+    }
+    let searchFrom = 0;
+    while (true) {
+      const foundAt = haystack.indexOf(needle, searchFrom);
+      if (foundAt < 0) {
+        break;
+      }
+      const range = document.createRange();
+      range.setStart(textNode, foundAt);
+      range.setEnd(textNode, foundAt + needle.length);
+      ranges.push(range);
+      searchFrom = foundAt + needle.length;
+    }
+  }
+  return ranges;
+}
+
+/**
+ * Re-scans the mounted rows inside `container` and replaces the registered
+ * highlight ranges. Occurrences are matched per text node, so a match split
+ * across inline formatting boundaries is skipped (best effort).
+ */
+export function applySessionFindHighlights(input: {
+  container: HTMLElement;
+  find: SessionFindState;
+}): void {
+  const support = getHighlightSupport();
+  if (!support) {
+    return;
+  }
+  ensureHighlightStyles();
+
+  const needle = input.find.query.toLowerCase();
+  const matchRanges: Range[] = [];
+  const activeRanges: Range[] = [];
+  if (needle.length > 0) {
+    const rows = input.container.querySelectorAll("[data-stream-item-id]");
+    for (const row of rows) {
+      const rowRanges = collectRowRanges(row, needle);
+      const isActiveRow = row.getAttribute("data-stream-item-id") === input.find.activeItemId;
+      rowRanges.forEach((range, occurrenceIndex) => {
+        if (isActiveRow && occurrenceIndex === input.find.activeOccurrenceIndex) {
+          activeRanges.push(range);
+        } else {
+          matchRanges.push(range);
+        }
+      });
+    }
+  }
+
+  support.registry.set(MATCH_HIGHLIGHT_NAME, new support.Highlight(...matchRanges));
+  support.registry.set(ACTIVE_HIGHLIGHT_NAME, new support.Highlight(...activeRanges));
+}
+
+export function clearSessionFindHighlights(): void {
+  const support = getHighlightSupport();
+  if (!support) {
+    return;
+  }
+  support.registry.delete(MATCH_HIGHLIGHT_NAME);
+  support.registry.delete(ACTIVE_HIGHLIGHT_NAME);
+}

--- a/packages/app/src/agent-stream/find-highlight.ts
+++ b/packages/app/src/agent-stream/find-highlight.ts
@@ -101,25 +101,79 @@ function collectTextNodes(root: Element): Text[] {
   return nodes;
 }
 
-function collectRowRanges(row: Element, needle: string): Range[] {
-  const ranges: Range[] = [];
-  for (const textNode of collectTextNodes(row)) {
-    const haystack = textNode.textContent?.toLowerCase();
-    if (!haystack) {
+interface RowTextSegment {
+  node: Text;
+  /** Offset of this node's text within the row's concatenated text. */
+  start: number;
+  end: number;
+}
+
+interface RowText {
+  lowerCaseText: string;
+  segments: RowTextSegment[];
+}
+
+/**
+ * Flattens a row's text nodes into one searchable string plus the offset map
+ * needed to turn a match back into a DOM range.
+ *
+ * Searching each text node separately would miss any occurrence the renderer
+ * split across nodes — which is the common case inside highlighted code blocks,
+ * where a contiguous source string becomes one span per syntax token. Ranges may
+ * span nodes, so matching over the concatenation and mapping the endpoints back
+ * finds those occurrences too.
+ */
+function buildRowText(row: Element): RowText {
+  const segments: RowTextSegment[] = [];
+  let text = "";
+  for (const node of collectTextNodes(row)) {
+    const content = node.textContent;
+    if (!content) {
       continue;
     }
-    let searchFrom = 0;
-    while (true) {
-      const foundAt = haystack.indexOf(needle, searchFrom);
-      if (foundAt < 0) {
-        break;
-      }
-      const range = document.createRange();
-      range.setStart(textNode, foundAt);
-      range.setEnd(textNode, foundAt + needle.length);
-      ranges.push(range);
-      searchFrom = foundAt + needle.length;
+    segments.push({ node, start: text.length, end: text.length + content.length });
+    text += content;
+  }
+  return { lowerCaseText: text.toLowerCase(), segments };
+}
+
+/** Maps a start offset in the concatenated text back to a node position. */
+function resolveStart(
+  segments: RowTextSegment[],
+  offset: number,
+): { node: Text; offset: number } | null {
+  const segment = segments.find((candidate) => offset >= candidate.start && offset < candidate.end);
+  return segment ? { node: segment.node, offset: offset - segment.start } : null;
+}
+
+/** Maps an exclusive end offset back to a node position. */
+function resolveEnd(
+  segments: RowTextSegment[],
+  offset: number,
+): { node: Text; offset: number } | null {
+  const segment = segments.find((candidate) => offset > candidate.start && offset <= candidate.end);
+  return segment ? { node: segment.node, offset: offset - segment.start } : null;
+}
+
+function collectRowRanges(row: Element, needle: string): Range[] {
+  const { lowerCaseText, segments } = buildRowText(row);
+  const ranges: Range[] = [];
+  let searchFrom = 0;
+  while (true) {
+    const foundAt = lowerCaseText.indexOf(needle, searchFrom);
+    if (foundAt < 0) {
+      break;
     }
+    searchFrom = foundAt + needle.length;
+    const start = resolveStart(segments, foundAt);
+    const end = resolveEnd(segments, foundAt + needle.length);
+    if (!start || !end) {
+      continue;
+    }
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+    ranges.push(range);
   }
   return ranges;
 }
@@ -128,14 +182,15 @@ function collectRowRanges(row: Element, needle: string): Range[] {
  * Splits the active row's DOM ranges into active and non-active occurrences.
  *
  * The match model enumerates occurrences in an item's source text, while these
- * ranges are enumerated over rendered text nodes. Those two sequences agree for
- * ordinary prose but not always: a needle straddling an inline-formatting or
- * syntax-token boundary yields no DOM range, and rendered chrome inside a row
- * can contribute a range the model never saw. Indexing blindly would then
- * emphasize an unrelated occurrence, so the ordinal is trusted only when the
- * two enumerations demonstrably agree on the row's occurrence count. Otherwise
- * every occurrence in the row is emphasized — the row is where navigation
- * scrolled to, so "your match is one of these" stays true.
+ * ranges are enumerated over the row's rendered text. Those two sequences agree
+ * for ordinary prose but cannot be assumed to: the model sees markdown syntax
+ * the reader never does, rendered chrome inside a row can contribute a range the
+ * model never saw, and concatenating the row's text can join across a visual
+ * block boundary. Indexing blindly would then emphasize an unrelated occurrence,
+ * so the ordinal is trusted only when the two enumerations demonstrably agree on
+ * the row's occurrence count. Otherwise every occurrence in the row is
+ * emphasized — the row is where navigation scrolled to, so "your match is one of
+ * these" stays true.
  */
 function partitionActiveRowRanges(
   rowRanges: Range[],

--- a/packages/app/src/agent-stream/find-highlight.ts
+++ b/packages/app/src/agent-stream/find-highlight.ts
@@ -8,13 +8,23 @@ import type { SessionFindState } from "./find-in-session";
  * needed. On runtimes without the API (or native), everything degrades to
  * scroll-to-row with no text highlight.
  *
- * CSS.highlights is document-global; if two panes run a find at once, the
- * last-applied pass wins. That is acceptable for a transient overlay.
+ * `CSS.highlights` is a document-global registry, but stream viewports are not:
+ * retained tabs and split panes keep several mounted at once, all of them
+ * re-running their highlight pass whenever their own agent streams. Each
+ * viewport therefore acquires its own highlight slot and only ever writes or
+ * deletes the two names belonging to that slot, so a background pane cannot
+ * clear the foreground pane's highlights and two open find bars do not
+ * overwrite each other. Slots are pooled on release, so the number of
+ * registered `::highlight()` rules stays bounded by peak concurrent viewports.
  */
 
-const MATCH_HIGHLIGHT_NAME = "paseo-session-find-match";
-const ACTIVE_HIGHLIGHT_NAME = "paseo-session-find-active";
 const HIGHLIGHT_STYLE_ELEMENT_ID = "paseo-session-find-highlight-style";
+
+export interface SessionFindHighlightOwner {
+  readonly slot: number;
+  readonly matchName: string;
+  readonly activeName: string;
+}
 
 interface HighlightRegistry {
   set(name: string, highlight: unknown): void;
@@ -24,6 +34,10 @@ interface HighlightRegistry {
 interface HighlightConstructor {
   new (...ranges: Range[]): unknown;
 }
+
+const releasedSlots: number[] = [];
+const slotsWithStyles = new Set<number>();
+let nextSlot = 0;
 
 function getHighlightSupport(): {
   registry: HighlightRegistry;
@@ -40,19 +54,40 @@ function getHighlightSupport(): {
   return { registry: css.highlights, Highlight: highlightCtor };
 }
 
-function ensureHighlightStyles(): void {
-  if (document.getElementById(HIGHLIGHT_STYLE_ELEMENT_ID)) {
+function ensureSlotStyles(owner: SessionFindHighlightOwner): void {
+  if (slotsWithStyles.has(owner.slot)) {
     return;
   }
-  const style = document.createElement("style");
-  style.id = HIGHLIGHT_STYLE_ELEMENT_ID;
+  let style = document.getElementById(HIGHLIGHT_STYLE_ELEMENT_ID);
+  if (!style) {
+    style = document.createElement("style");
+    style.id = HIGHLIGHT_STYLE_ELEMENT_ID;
+    document.head.appendChild(style);
+  }
   // Alpha-tinted palette values read on both light and dark surfaces; the
   // active occurrence gets a solid fill so it stands out among matches.
-  style.textContent = [
-    `::highlight(${MATCH_HIGHLIGHT_NAME}) { background-color: ${baseColors.amber[500]}4d; }`,
-    `::highlight(${ACTIVE_HIGHLIGHT_NAME}) { background-color: ${baseColors.amber[500]}; color: ${baseColors.zinc[900]}; }`,
+  style.textContent += [
+    `::highlight(${owner.matchName}) { background-color: ${baseColors.amber[500]}4d; }`,
+    `::highlight(${owner.activeName}) { background-color: ${baseColors.amber[500]}; color: ${baseColors.zinc[900]}; }`,
+    "",
   ].join("\n");
-  document.head.appendChild(style);
+  slotsWithStyles.add(owner.slot);
+}
+
+export function acquireSessionFindHighlightOwner(): SessionFindHighlightOwner {
+  const slot = releasedSlots.pop() ?? nextSlot++;
+  return {
+    slot,
+    matchName: `paseo-session-find-match-${slot}`,
+    activeName: `paseo-session-find-active-${slot}`,
+  };
+}
+
+export function releaseSessionFindHighlightOwner(owner: SessionFindHighlightOwner): void {
+  clearSessionFindHighlights(owner);
+  if (!releasedSlots.includes(owner.slot)) {
+    releasedSlots.push(owner.slot);
+  }
 }
 
 function collectTextNodes(root: Element): Text[] {
@@ -90,11 +125,44 @@ function collectRowRanges(row: Element, needle: string): Range[] {
 }
 
 /**
- * Re-scans the mounted rows inside `container` and replaces the registered
- * highlight ranges. Occurrences are matched per text node, so a match split
- * across inline formatting boundaries is skipped (best effort).
+ * Splits the active row's DOM ranges into active and non-active occurrences.
+ *
+ * The match model enumerates occurrences in an item's source text, while these
+ * ranges are enumerated over rendered text nodes. Those two sequences agree for
+ * ordinary prose but not always: a needle straddling an inline-formatting or
+ * syntax-token boundary yields no DOM range, and rendered chrome inside a row
+ * can contribute a range the model never saw. Indexing blindly would then
+ * emphasize an unrelated occurrence, so the ordinal is trusted only when the
+ * two enumerations demonstrably agree on the row's occurrence count. Otherwise
+ * every occurrence in the row is emphasized — the row is where navigation
+ * scrolled to, so "your match is one of these" stays true.
+ */
+function partitionActiveRowRanges(
+  rowRanges: Range[],
+  find: SessionFindState,
+): { active: Range[]; match: Range[] } {
+  const enumerationsAgree = rowRanges.length === find.activeItemOccurrenceCount;
+  if (!enumerationsAgree) {
+    return { active: rowRanges, match: [] };
+  }
+  const active: Range[] = [];
+  const match: Range[] = [];
+  rowRanges.forEach((range, occurrenceIndex) => {
+    if (occurrenceIndex === find.activeOccurrenceIndex) {
+      active.push(range);
+    } else {
+      match.push(range);
+    }
+  });
+  return { active, match };
+}
+
+/**
+ * Re-scans the mounted rows inside `container` and replaces the highlight
+ * ranges registered under `owner`'s slot.
  */
 export function applySessionFindHighlights(input: {
+  owner: SessionFindHighlightOwner;
   container: HTMLElement;
   find: SessionFindState;
 }): void {
@@ -102,7 +170,7 @@ export function applySessionFindHighlights(input: {
   if (!support) {
     return;
   }
-  ensureHighlightStyles();
+  ensureSlotStyles(input.owner);
 
   const needle = input.find.query.toLowerCase();
   const matchRanges: Range[] = [];
@@ -111,26 +179,25 @@ export function applySessionFindHighlights(input: {
     const rows = input.container.querySelectorAll("[data-stream-item-id]");
     for (const row of rows) {
       const rowRanges = collectRowRanges(row, needle);
-      const isActiveRow = row.getAttribute("data-stream-item-id") === input.find.activeItemId;
-      rowRanges.forEach((range, occurrenceIndex) => {
-        if (isActiveRow && occurrenceIndex === input.find.activeOccurrenceIndex) {
-          activeRanges.push(range);
-        } else {
-          matchRanges.push(range);
-        }
-      });
+      if (row.getAttribute("data-stream-item-id") !== input.find.activeItemId) {
+        matchRanges.push(...rowRanges);
+        continue;
+      }
+      const partitioned = partitionActiveRowRanges(rowRanges, input.find);
+      activeRanges.push(...partitioned.active);
+      matchRanges.push(...partitioned.match);
     }
   }
 
-  support.registry.set(MATCH_HIGHLIGHT_NAME, new support.Highlight(...matchRanges));
-  support.registry.set(ACTIVE_HIGHLIGHT_NAME, new support.Highlight(...activeRanges));
+  support.registry.set(input.owner.matchName, new support.Highlight(...matchRanges));
+  support.registry.set(input.owner.activeName, new support.Highlight(...activeRanges));
 }
 
-export function clearSessionFindHighlights(): void {
+export function clearSessionFindHighlights(owner: SessionFindHighlightOwner): void {
   const support = getHighlightSupport();
   if (!support) {
     return;
   }
-  support.registry.delete(MATCH_HIGHLIGHT_NAME);
-  support.registry.delete(ACTIVE_HIGHLIGHT_NAME);
+  support.registry.delete(owner.matchName);
+  support.registry.delete(owner.activeName);
 }

--- a/packages/app/src/agent-stream/find-in-session.test.ts
+++ b/packages/app/src/agent-stream/find-in-session.test.ts
@@ -89,6 +89,7 @@ describe("extractSearchableText", () => {
         { text: "first task", completed: true },
         { text: "second task", completed: false },
       ],
+      activity: { type: "created", count: 2 },
     };
     expect(extractSearchableText(item)).toBe("first task\nsecond task");
   });

--- a/packages/app/src/agent-stream/find-in-session.test.ts
+++ b/packages/app/src/agent-stream/find-in-session.test.ts
@@ -53,8 +53,13 @@ function bashToolCall(id: string, input: string): StreamItem {
 }
 
 describe("extractSearchableText", () => {
-  it("returns message text for user and assistant messages", () => {
-    expect(extractSearchableText(userMessage("u1", "hello world"))).toBe("hello world");
+  it("keeps user message Markdown markers because they render as literal text", () => {
+    expect(extractSearchableText(userMessage("u1", "Run `deploy` after **review**."))).toBe(
+      "Run `deploy` after **review**.",
+    );
+  });
+
+  it("returns assistant message text", () => {
     expect(extractSearchableText(assistantMessage("a1", "response text"))).toBe("response text");
   });
 
@@ -66,6 +71,22 @@ describe("extractSearchableText", () => {
     ]);
     expect(computeSessionFindMatches([item], "`deploy`")).toEqual([]);
     expect(computeSessionFindMatches([item], "**review**")).toEqual([]);
+  });
+
+  it("excludes image alt text that is not rendered as a DOM text node", () => {
+    const item = assistantMessage("a1", "Before ![deployment diagram](diagram.png) after");
+
+    expect(extractSearchableText(item)).toBe("Before  after");
+    expect(computeSessionFindMatches([item], "deployment diagram")).toEqual([]);
+  });
+
+  it("keeps escaped emphasis delimiters that render as text", () => {
+    const item = assistantMessage("a1", String.raw`Search for \*literal emphasis\* here.`);
+
+    expect(extractSearchableText(item)).toBe("Search for *literal emphasis* here.");
+    expect(computeSessionFindMatches([item], "*literal emphasis*")).toEqual([
+      { itemId: "a1", occurrenceIndex: 0 },
+    ]);
   });
 
   it("returns activity log messages", () => {

--- a/packages/app/src/agent-stream/find-in-session.test.ts
+++ b/packages/app/src/agent-stream/find-in-session.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { StreamItem } from "@/types/stream";
+import { computeSessionFindMatches, extractSearchableText } from "./find-in-session";
+
+function userMessage(id: string, text: string): StreamItem {
+  return { kind: "user_message", id, text, timestamp: new Date(0) };
+}
+
+function assistantMessage(id: string, text: string): StreamItem {
+  return { kind: "assistant_message", id, text, timestamp: new Date(0) };
+}
+
+function thought(id: string, text: string): StreamItem {
+  return { kind: "thought", id, text, timestamp: new Date(0), status: "ready" };
+}
+
+function speakToolCall(id: string, input: string): StreamItem {
+  return {
+    kind: "tool_call",
+    id,
+    timestamp: new Date(0),
+    payload: {
+      source: "agent",
+      data: {
+        provider: "claude",
+        callId: id,
+        name: "speak",
+        status: "completed",
+        error: null,
+        detail: { type: "unknown", input, output: null },
+      },
+    },
+  };
+}
+
+function bashToolCall(id: string, input: string): StreamItem {
+  return {
+    kind: "tool_call",
+    id,
+    timestamp: new Date(0),
+    payload: {
+      source: "agent",
+      data: {
+        provider: "claude",
+        callId: id,
+        name: "bash",
+        status: "completed",
+        error: null,
+        detail: { type: "unknown", input, output: null },
+      },
+    },
+  };
+}
+
+describe("extractSearchableText", () => {
+  it("returns message text for user and assistant messages", () => {
+    expect(extractSearchableText(userMessage("u1", "hello world"))).toBe("hello world");
+    expect(extractSearchableText(assistantMessage("a1", "response text"))).toBe("response text");
+  });
+
+  it("returns activity log messages", () => {
+    const item: StreamItem = {
+      kind: "activity_log",
+      id: "log1",
+      timestamp: new Date(0),
+      activityType: "error",
+      message: "something failed",
+    };
+    expect(extractSearchableText(item)).toBe("something failed");
+  });
+
+  it("joins todo list entries", () => {
+    const item: StreamItem = {
+      kind: "todo_list",
+      id: "todo1",
+      timestamp: new Date(0),
+      provider: "claude",
+      items: [
+        { text: "first task", completed: true },
+        { text: "second task", completed: false },
+      ],
+    };
+    expect(extractSearchableText(item)).toBe("first task\nsecond task");
+  });
+
+  it("includes speak tool calls but not other tool calls", () => {
+    expect(extractSearchableText(speakToolCall("s1", "spoken message"))).toBe("spoken message");
+    expect(extractSearchableText(bashToolCall("b1", "rg pattern"))).toBe("");
+  });
+
+  it("excludes collapsed reasoning text", () => {
+    expect(extractSearchableText(thought("t1", "hidden reasoning"))).toBe("");
+  });
+});
+
+describe("computeSessionFindMatches", () => {
+  it("returns no matches for an empty query", () => {
+    expect(computeSessionFindMatches([userMessage("u1", "hello")], "")).toEqual([]);
+  });
+
+  it("matches case-insensitively", () => {
+    const matches = computeSessionFindMatches(
+      [userMessage("u1", "Hello World"), assistantMessage("a1", "HELLO again")],
+      "hello",
+    );
+    expect(matches).toEqual([
+      { itemId: "u1", occurrenceIndex: 0 },
+      { itemId: "a1", occurrenceIndex: 0 },
+    ]);
+  });
+
+  it("enumerates multiple occurrences within one item in order", () => {
+    const matches = computeSessionFindMatches(
+      [assistantMessage("a1", "foo bar foo baz foo")],
+      "foo",
+    );
+    expect(matches).toEqual([
+      { itemId: "a1", occurrenceIndex: 0 },
+      { itemId: "a1", occurrenceIndex: 1 },
+      { itemId: "a1", occurrenceIndex: 2 },
+    ]);
+  });
+
+  it("does not count overlapping occurrences twice", () => {
+    const matches = computeSessionFindMatches([assistantMessage("a1", "aaaa")], "aa");
+    expect(matches).toEqual([
+      { itemId: "a1", occurrenceIndex: 0 },
+      { itemId: "a1", occurrenceIndex: 1 },
+    ]);
+  });
+
+  it("preserves display order across items", () => {
+    const matches = computeSessionFindMatches(
+      [
+        userMessage("u1", "needle"),
+        bashToolCall("b1", "needle inside tool args"),
+        assistantMessage("a1", "a needle and another needle"),
+      ],
+      "needle",
+    );
+    expect(matches).toEqual([
+      { itemId: "u1", occurrenceIndex: 0 },
+      { itemId: "a1", occurrenceIndex: 0 },
+      { itemId: "a1", occurrenceIndex: 1 },
+    ]);
+  });
+});

--- a/packages/app/src/agent-stream/find-in-session.test.ts
+++ b/packages/app/src/agent-stream/find-in-session.test.ts
@@ -89,6 +89,29 @@ describe("extractSearchableText", () => {
     ]);
   });
 
+  it("includes the list markers the renderer draws as text", () => {
+    const bullets = assistantMessage("a1", "- alpha\n- beta");
+    expect(extractSearchableText(bullets)).toBe("\u2022alpha\u2022beta");
+
+    const ordered = assistantMessage("a2", "3) alpha\n4) beta");
+    expect(extractSearchableText(ordered)).toBe("3)alpha4)beta");
+  });
+
+  it("numbers nested list markers independently of the outer list", () => {
+    const item = assistantMessage("a1", "1. outer\n   1. inner\n2. next");
+
+    expect(extractSearchableText(item)).toBe("1.outer1.inner2.next");
+  });
+
+  it("counts a rendered marker ahead of later occurrences of the same text", () => {
+    const item = assistantMessage("a1", "1. first step\n\nRepeat step 1. until done.");
+
+    expect(computeSessionFindMatches([item], "1.")).toEqual([
+      { itemId: "a1", occurrenceIndex: 0 },
+      { itemId: "a1", occurrenceIndex: 1 },
+    ]);
+  });
+
   it("returns activity log messages", () => {
     const item: StreamItem = {
       kind: "activity_log",

--- a/packages/app/src/agent-stream/find-in-session.test.ts
+++ b/packages/app/src/agent-stream/find-in-session.test.ts
@@ -112,12 +112,13 @@ describe("extractSearchableText", () => {
     ]);
   });
 
-  it("returns activity log messages", () => {
+  it("returns notification messages", () => {
     const item: StreamItem = {
-      kind: "activity_log",
+      kind: "notification",
       id: "log1",
       timestamp: new Date(0),
-      activityType: "error",
+      sourceType: "error",
+      level: "error",
       message: "something failed",
     };
     expect(extractSearchableText(item)).toBe("something failed");

--- a/packages/app/src/agent-stream/find-in-session.test.ts
+++ b/packages/app/src/agent-stream/find-in-session.test.ts
@@ -58,6 +58,16 @@ describe("extractSearchableText", () => {
     expect(extractSearchableText(assistantMessage("a1", "response text"))).toBe("response text");
   });
 
+  it("searches rendered Markdown text rather than its invisible source markers", () => {
+    const item = assistantMessage("a1", "Run `deploy` after **review**.");
+
+    expect(computeSessionFindMatches([item], "deploy")).toEqual([
+      { itemId: "a1", occurrenceIndex: 0 },
+    ]);
+    expect(computeSessionFindMatches([item], "`deploy`")).toEqual([]);
+    expect(computeSessionFindMatches([item], "**review**")).toEqual([]);
+  });
+
   it("returns activity log messages", () => {
     const item: StreamItem = {
       kind: "activity_log",

--- a/packages/app/src/agent-stream/find-in-session.ts
+++ b/packages/app/src/agent-stream/find-in-session.ts
@@ -10,6 +10,12 @@ export interface SessionFindState {
   query: string;
   activeItemId: string | null;
   activeOccurrenceIndex: number;
+  /**
+   * How many occurrences the match model found in the active item. Renderers
+   * compare this against what they can enumerate to decide whether
+   * `activeOccurrenceIndex` identifies the same occurrence they see.
+   */
+  activeItemOccurrenceCount: number;
 }
 
 /**

--- a/packages/app/src/agent-stream/find-in-session.ts
+++ b/packages/app/src/agent-stream/find-in-session.ts
@@ -1,5 +1,6 @@
 import type { StreamItem } from "@/types/stream";
 import { createAssistantMarkdownParser } from "@/utils/assistant-markdown-parser";
+import { getMarkdownListMarker } from "@/utils/markdown-list";
 import type Token from "markdown-it/lib/token.mjs";
 
 export interface SessionFindMatch {
@@ -43,8 +44,59 @@ function extractVisibleTokenText(token: Token): string {
   }
 }
 
+/**
+ * The list bullet and the ordered number are drawn by the renderer, not present
+ * in the source, and they land in the row as ordinary text nodes (see the
+ * `list_item` rule in `components/message.tsx`). Rebuilding them here through
+ * the renderer's own marker function keeps the projection and the rendered row
+ * in step, so a search for `1.` or a bullet matches, and the occurrence ordinals
+ * of everything after a list still line up.
+ */
+interface ListMarkerFrame {
+  listNode: { type: string; attributes?: { start?: number | string } };
+  itemCount: number;
+}
+
+function openListFrame(token: Token): ListMarkerFrame {
+  if (token.type === "ordered_list_open") {
+    const start = token.attrGet("start");
+    return {
+      listNode: { type: "ordered_list", attributes: { start: start ?? undefined } },
+      itemCount: 0,
+    };
+  }
+  return { listNode: { type: "bullet_list" }, itemCount: 0 };
+}
+
 function extractVisibleMarkdownText(markdown: string): string {
-  return assistantMarkdownParser.parse(markdown, {}).map(extractVisibleTokenText).join("");
+  const listStack: ListMarkerFrame[] = [];
+  let text = "";
+  for (const token of assistantMarkdownParser.parse(markdown, {})) {
+    switch (token.type) {
+      case "ordered_list_open":
+      case "bullet_list_open":
+        listStack.push(openListFrame(token));
+        break;
+      case "ordered_list_close":
+      case "bullet_list_close":
+        listStack.pop();
+        break;
+      case "list_item_open": {
+        const frame = listStack[listStack.length - 1];
+        text += getMarkdownListMarker(
+          { index: frame?.itemCount ?? 0, markup: token.markup },
+          frame?.listNode,
+        ).marker;
+        if (frame) {
+          frame.itemCount += 1;
+        }
+        break;
+      }
+      default:
+        text += extractVisibleTokenText(token);
+    }
+  }
+  return text;
 }
 
 /**

--- a/packages/app/src/agent-stream/find-in-session.ts
+++ b/packages/app/src/agent-stream/find-in-session.ts
@@ -18,6 +18,21 @@ export interface SessionFindState {
   activeItemOccurrenceCount: number;
 }
 
+function extractVisibleMarkdownText(markdown: string): string {
+  return markdown
+    .replace(/!\[([^\]]*)\]\((?:[^()\\]|\\.)*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\((?:[^()\\]|\\.)*\)/g, "$1")
+    .replace(/^\s*```[^\n]*$/gm, "")
+    .replace(/^\s*~~~[^\n]*$/gm, "")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s{0,3}>+\s?/gm, "")
+    .replace(/^\s{0,3}(?:[*+-]|\d+\.)\s+/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    .replace(/~~([^~]+)~~/g, "$1");
+}
+
 /**
  * Text that is visible in the stream by default. Collapsed content (reasoning,
  * tool call inputs/outputs) is intentionally excluded so every match can be
@@ -27,7 +42,7 @@ export function extractSearchableText(item: StreamItem): string {
   switch (item.kind) {
     case "user_message":
     case "assistant_message":
-      return item.text;
+      return extractVisibleMarkdownText(item.text);
     case "activity_log":
       return item.message;
     case "todo_list":

--- a/packages/app/src/agent-stream/find-in-session.ts
+++ b/packages/app/src/agent-stream/find-in-session.ts
@@ -1,0 +1,92 @@
+import type { StreamItem } from "@/types/stream";
+
+export interface SessionFindMatch {
+  itemId: string;
+  /** 0-based occurrence position within the item's searchable text. */
+  occurrenceIndex: number;
+}
+
+export interface SessionFindState {
+  query: string;
+  activeItemId: string | null;
+  activeOccurrenceIndex: number;
+}
+
+/**
+ * Text that is visible in the stream by default. Collapsed content (reasoning,
+ * tool call inputs/outputs) is intentionally excluded so every match can be
+ * scrolled to and seen without expanding anything.
+ */
+export function extractSearchableText(item: StreamItem): string {
+  switch (item.kind) {
+    case "user_message":
+    case "assistant_message":
+      return item.text;
+    case "activity_log":
+      return item.message;
+    case "todo_list":
+      return item.items.map((entry) => entry.text).join("\n");
+    case "tool_call": {
+      const { payload } = item;
+      // Speak tool calls render inline as chat messages (see SpeakMessage).
+      if (
+        payload.source === "agent" &&
+        payload.data.name === "speak" &&
+        payload.data.detail.type === "unknown" &&
+        typeof payload.data.detail.input === "string"
+      ) {
+        return payload.data.detail.input;
+      }
+      return "";
+    }
+    default:
+      return "";
+  }
+}
+
+// Stream items are immutable snapshots, so the lowercased text can be cached
+// per item to keep per-keystroke matching cheap on long sessions.
+const lowerCaseTextCache = new WeakMap<StreamItem, string>();
+
+function getLowerCaseSearchableText(item: StreamItem): string {
+  const cached = lowerCaseTextCache.get(item);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const text = extractSearchableText(item).toLowerCase();
+  lowerCaseTextCache.set(item, text);
+  return text;
+}
+
+/**
+ * Enumerates case-insensitive, non-overlapping occurrences of `query` across
+ * the stream in display order.
+ */
+export function computeSessionFindMatches(
+  items: readonly StreamItem[],
+  query: string,
+): SessionFindMatch[] {
+  if (query.length === 0) {
+    return [];
+  }
+  const needle = query.toLowerCase();
+  const matches: SessionFindMatch[] = [];
+  for (const item of items) {
+    const haystack = getLowerCaseSearchableText(item);
+    if (haystack.length === 0) {
+      continue;
+    }
+    let occurrenceIndex = 0;
+    let searchFrom = 0;
+    while (true) {
+      const foundAt = haystack.indexOf(needle, searchFrom);
+      if (foundAt < 0) {
+        break;
+      }
+      matches.push({ itemId: item.id, occurrenceIndex });
+      occurrenceIndex += 1;
+      searchFrom = foundAt + needle.length;
+    }
+  }
+  return matches;
+}

--- a/packages/app/src/agent-stream/find-in-session.ts
+++ b/packages/app/src/agent-stream/find-in-session.ts
@@ -110,7 +110,7 @@ export function extractSearchableText(item: StreamItem): string {
       return item.text;
     case "assistant_message":
       return extractVisibleMarkdownText(item.text);
-    case "activity_log":
+    case "notification":
       return item.message;
     case "todo_list":
       return item.items.map((entry) => entry.text).join("\n");

--- a/packages/app/src/agent-stream/find-in-session.ts
+++ b/packages/app/src/agent-stream/find-in-session.ts
@@ -1,4 +1,6 @@
 import type { StreamItem } from "@/types/stream";
+import { createAssistantMarkdownParser } from "@/utils/assistant-markdown-parser";
+import type Token from "markdown-it/lib/token.mjs";
 
 export interface SessionFindMatch {
   itemId: string;
@@ -18,19 +20,31 @@ export interface SessionFindState {
   activeItemOccurrenceCount: number;
 }
 
+const assistantMarkdownParser = createAssistantMarkdownParser();
+
+function extractVisibleTokenText(token: Token): string {
+  if (token.type === "image") {
+    return "";
+  }
+  if (token.children) {
+    return token.children.map(extractVisibleTokenText).join("");
+  }
+  switch (token.type) {
+    case "text":
+    case "code_inline":
+    case "code_block":
+    case "fence":
+      return token.content;
+    case "softbreak":
+    case "hardbreak":
+      return "\n";
+    default:
+      return "";
+  }
+}
+
 function extractVisibleMarkdownText(markdown: string): string {
-  return markdown
-    .replace(/!\[([^\]]*)\]\((?:[^()\\]|\\.)*\)/g, "$1")
-    .replace(/\[([^\]]+)\]\((?:[^()\\]|\\.)*\)/g, "$1")
-    .replace(/^\s*```[^\n]*$/gm, "")
-    .replace(/^\s*~~~[^\n]*$/gm, "")
-    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
-    .replace(/^\s{0,3}>+\s?/gm, "")
-    .replace(/^\s{0,3}(?:[*+-]|\d+\.)\s+/gm, "")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/(\*\*|__)(.*?)\1/g, "$2")
-    .replace(/(\*|_)(.*?)\1/g, "$2")
-    .replace(/~~([^~]+)~~/g, "$1");
+  return assistantMarkdownParser.parse(markdown, {}).map(extractVisibleTokenText).join("");
 }
 
 /**
@@ -41,6 +55,7 @@ function extractVisibleMarkdownText(markdown: string): string {
 export function extractSearchableText(item: StreamItem): string {
   switch (item.kind) {
     case "user_message":
+      return item.text;
     case "assistant_message":
       return extractVisibleMarkdownText(item.text);
     case "activity_log":

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -436,6 +436,65 @@ describe("createWebStreamStrategy", () => {
     expect(onReadingPositionChange).toHaveBeenLastCalledWith("message-2");
   });
 
+  it("scrolls a mounted stream item into view via its anchor", () => {
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollIntoView;
+    try {
+      const strategy = createWebStreamStrategy({ isMobileBreakpoint: false });
+      const viewportRef = React.createRef<StreamViewportHandle>();
+      container = document.createElement("div");
+      document.body.appendChild(container);
+      root = createRoot(container);
+
+      act(() => {
+        root?.render(
+          strategy.render({
+            agentId: "agent",
+            segments: {
+              historyVirtualized: [],
+              historyMounted: [userMessage(1), userMessage(2)],
+              liveHead: [],
+            },
+            boundary: {
+              hasVirtualizedHistory: false,
+              hasMountedHistory: true,
+              hasLiveHead: false,
+            },
+            renderers: createRenderers(vi.fn()),
+            listEmptyComponent: null,
+            viewportRef,
+            routeBottomAnchorRequest: null,
+            isAuthoritativeHistoryReady: true,
+            onNearBottomChange: vi.fn(),
+            onNearHistoryStart: vi.fn(),
+            isLoadingOlderHistory: false,
+            hasOlderHistory: false,
+            olderHistoryProgressKey: null,
+            scrollEnabled: true,
+            listStyle: null,
+            baseListContentContainerStyle: null,
+            forwardListContentContainerStyle: null,
+          }),
+        );
+      });
+
+      expect(container.querySelector('[data-stream-item-id="message-2"]')).not.toBeNull();
+
+      act(() => {
+        viewportRef.current?.scrollToItem?.("message-2");
+      });
+
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+    } finally {
+      if (originalScrollIntoView) {
+        Element.prototype.scrollIntoView = originalScrollIntoView;
+      } else {
+        Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+      }
+    }
+  });
+
   it("keeps bottom anchoring through subpixel browser rounding", () => {
     const scrollTo = vi.fn();
     HTMLElement.prototype.scrollTo = scrollTo;

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -436,10 +436,17 @@ describe("createWebStreamStrategy", () => {
     expect(onReadingPositionChange).toHaveBeenLastCalledWith("message-2");
   });
 
-  it("scrolls a mounted stream item into view via its anchor", () => {
-    const scrollIntoView = vi.fn();
+  // jsdom does not implement scrollIntoView at all, so it has to be supplied
+  // here. The assertion is about which row element the viewport resolved and
+  // targeted — the behavior find-in-session navigation depends on. The
+  // keystroke -> agent.find mapping is covered in keyboard-shortcuts.test.ts and
+  // the query -> item navigation in use-session-find.test.tsx.
+  it("resolves the requested stream item's anchor and scrolls that row into view", () => {
+    const scrolledElements: Element[] = [];
     const originalScrollIntoView = Element.prototype.scrollIntoView;
-    Element.prototype.scrollIntoView = scrollIntoView;
+    Element.prototype.scrollIntoView = function scrollIntoViewStub(this: Element) {
+      scrolledElements.push(this);
+    };
     try {
       const strategy = createWebStreamStrategy({ isMobileBreakpoint: false });
       const viewportRef = React.createRef<StreamViewportHandle>();
@@ -479,13 +486,21 @@ describe("createWebStreamStrategy", () => {
         );
       });
 
-      expect(container.querySelector('[data-stream-item-id="message-2"]')).not.toBeNull();
+      const targetRow = container.querySelector('[data-stream-item-id="message-2"]');
+      expect(targetRow).not.toBeNull();
 
       act(() => {
         viewportRef.current?.scrollToItem?.("message-2");
       });
 
-      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+      expect(scrolledElements).toEqual([targetRow]);
+
+      // An id with no anchor must not scroll some other row into view.
+      scrolledElements.length = 0;
+      act(() => {
+        viewportRef.current?.scrollToItem?.("message-404");
+      });
+      expect(scrolledElements).toEqual([]);
     } finally {
       if (originalScrollIntoView) {
         Element.prototype.scrollIntoView = originalScrollIntoView;

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -16,7 +16,13 @@ import type { Theme } from "@/styles/theme";
 import { WEB_SCROLLBAR_SIZE_PX } from "@/styles/web-scrollbar";
 import { DomOverlayScrollbar } from "@/components/ui/overlay-scrollbar/dom-overlay-scrollbar";
 import { estimateStreamItemHeight } from "./web-virtualization";
-import { applySessionFindHighlights, clearSessionFindHighlights } from "./find-highlight";
+import {
+  acquireSessionFindHighlightOwner,
+  applySessionFindHighlights,
+  clearSessionFindHighlights,
+  releaseSessionFindHighlightOwner,
+  type SessionFindHighlightOwner,
+} from "./find-highlight";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
 import { createStreamStrategy } from "./strategy";
 import {
@@ -311,6 +317,16 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const isActiveRef = useRef(isActive);
   const scrollContainerRef = useRef<HTMLElement | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
+  // Declared before the highlight effect so the slot exists by the time it runs.
+  const highlightOwnerRef = useRef<SessionFindHighlightOwner | null>(null);
+  useEffect(() => {
+    const owner = acquireSessionFindHighlightOwner();
+    highlightOwnerRef.current = owner;
+    return () => {
+      highlightOwnerRef.current = null;
+      releaseSessionFindHighlightOwner(owner);
+    };
+  }, []);
   const handleScrollContainerRef = useCallback((node: HTMLElement | null) => {
     scrollContainerRef.current = node;
   }, []);
@@ -1175,8 +1191,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current;
-    if (!sessionFind || !scrollContainer) {
-      clearSessionFindHighlights();
+    const owner = highlightOwnerRef.current;
+    if (!sessionFind || !scrollContainer || !owner) {
+      // Only this viewport's slot is cleared, so panes without an open find bar
+      // (including background tabs re-running this on every stream flush) cannot
+      // wipe the highlights of the pane the user is searching in.
+      if (owner) {
+        clearSessionFindHighlights(owner);
+      }
       return;
     }
     let pendingFrame: number | null = null;
@@ -1184,7 +1206,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       pendingFrame = null;
       const container = scrollContainerRef.current;
       if (container) {
-        applySessionFindHighlights({ container, find: sessionFind });
+        applySessionFindHighlights({ owner, container, find: sessionFind });
       }
     };
     // Rows mount and unmount as the virtualizer window moves, so re-scan on
@@ -1201,7 +1223,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       if (pendingFrame !== null) {
         window.cancelAnimationFrame(pendingFrame);
       }
-      clearSessionFindHighlights();
+      clearSessionFindHighlights(owner);
     };
   }, [
     sessionFind,

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -15,7 +15,10 @@ import { useStableEvent } from "@/hooks/use-stable-event";
 import type { Theme } from "@/styles/theme";
 import { WEB_SCROLLBAR_SIZE_PX } from "@/styles/web-scrollbar";
 import { DomOverlayScrollbar } from "@/components/ui/overlay-scrollbar/dom-overlay-scrollbar";
-import { estimateStreamItemHeight } from "./web-virtualization";
+import {
+  estimateStreamItemHeight,
+  shouldAdjustScrollForVirtualRowResize,
+} from "./web-virtualization";
 import {
   acquireSessionFindHighlightOwner,
   applySessionFindHighlights,
@@ -24,6 +27,7 @@ import {
   type SessionFindHighlightOwner,
 } from "./find-highlight";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
+import { useRevisedHistoryRows } from "./history-row-revision";
 import { createStreamStrategy } from "./strategy";
 import {
   abandonHistoryStartPaginationRequest,
@@ -295,7 +299,8 @@ function isScrollContainerOverscrolledPastBottom(
 
 function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: boolean }) {
   const {
-    segments,
+    segments: inputSegments,
+    historyRowRevision,
     liveHeadRowRevision,
     boundary,
     renderers,
@@ -313,6 +318,15 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     scrollEnabled,
     isMobileBreakpoint,
   } = props;
+  const historyVirtualized = useRevisedHistoryRows(
+    inputSegments.historyVirtualized,
+    historyRowRevision,
+  );
+  const historyMounted = useRevisedHistoryRows(inputSegments.historyMounted, historyRowRevision);
+  const segments = useMemo(
+    () => ({ ...inputSegments, historyVirtualized, historyMounted }),
+    [historyMounted, historyVirtualized, inputSegments],
+  );
   const isActive = useRetainedPanelActive();
   const isActiveRef = useRef(isActive);
   const scrollContainerRef = useRef<HTMLElement | null>(null);
@@ -400,14 +414,17 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     overscan: 8,
   });
   useEffect(() => {
-    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (_item, _delta, instance) => {
-      if (historyStartPrependAnchorActiveRef.current) {
-        return false;
-      }
+    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => {
       const viewportHeight = instance.scrollRect?.height ?? 0;
       const scrollOffset = instance.scrollOffset ?? 0;
       const remainingDistance = instance.getTotalSize() - (scrollOffset + viewportHeight);
-      return remainingDistance > AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
+      return shouldAdjustScrollForVirtualRowResize({
+        isHistoryStartPrependActive: historyStartPrependAnchorActiveRef.current,
+        rowStart: item.start,
+        scrollOffset,
+        remainingDistanceFromBottom: remainingDistance,
+        bottomThreshold: AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
+      });
     };
     return () => {
       rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = undefined;

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -15,12 +15,9 @@ import { useStableEvent } from "@/hooks/use-stable-event";
 import type { Theme } from "@/styles/theme";
 import { WEB_SCROLLBAR_SIZE_PX } from "@/styles/web-scrollbar";
 import { DomOverlayScrollbar } from "@/components/ui/overlay-scrollbar/dom-overlay-scrollbar";
-import {
-  estimateStreamItemHeight,
-  shouldAdjustScrollForVirtualRowResize,
-} from "./web-virtualization";
+import { estimateStreamItemHeight } from "./web-virtualization";
+import { applySessionFindHighlights, clearSessionFindHighlights } from "./find-highlight";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
-import { useRevisedHistoryRows } from "./history-row-revision";
 import { createStreamStrategy } from "./strategy";
 import {
   abandonHistoryStartPaginationRequest,
@@ -86,11 +83,23 @@ const historyStartSlotStyle: CSSProperties = {
   flexShrink: 0,
 };
 
-const streamRowStyle: CSSProperties = {
+// Per-item anchor for find-in-session scroll targeting and match highlighting.
+// Mirrors the virtualized row wrapper layout so `alignSelf`-centered stream
+// item wrappers keep behaving as flex children.
+const rowAnchorStyle: CSSProperties = {
   display: "flex",
   flexDirection: "column",
   width: "100%",
 };
+
+// CSS.escape is missing in some test DOMs; inside a double-quoted attribute
+// selector only quotes and backslashes need escaping.
+function escapeItemIdForSelector(itemId: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(itemId);
+  }
+  return itemId.replace(/["\\]/g, "\\$&");
+}
 
 function isScrollContainerNearBottom(
   scrollContainer: Pick<HTMLElement, "scrollTop" | "clientHeight" | "scrollHeight">,
@@ -280,8 +289,7 @@ function isScrollContainerOverscrolledPastBottom(
 
 function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: boolean }) {
   const {
-    segments: inputSegments,
-    historyRowRevision,
+    segments,
     liveHeadRowRevision,
     boundary,
     renderers,
@@ -295,18 +303,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     isLoadingOlderHistory,
     hasOlderHistory,
     olderHistoryProgressKey,
+    sessionFind = null,
     scrollEnabled,
     isMobileBreakpoint,
   } = props;
-  const historyVirtualized = useRevisedHistoryRows(
-    inputSegments.historyVirtualized,
-    historyRowRevision,
-  );
-  const historyMounted = useRevisedHistoryRows(inputSegments.historyMounted, historyRowRevision);
-  const segments = useMemo(
-    () => ({ ...inputSegments, historyVirtualized, historyMounted }),
-    [historyMounted, historyVirtualized, inputSegments],
-  );
   const isActive = useRetainedPanelActive();
   const isActiveRef = useRef(isActive);
   const scrollContainerRef = useRef<HTMLElement | null>(null);
@@ -384,17 +384,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     overscan: 8,
   });
   useEffect(() => {
-    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => {
+    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (_item, _delta, instance) => {
+      if (historyStartPrependAnchorActiveRef.current) {
+        return false;
+      }
       const viewportHeight = instance.scrollRect?.height ?? 0;
       const scrollOffset = instance.scrollOffset ?? 0;
       const remainingDistance = instance.getTotalSize() - (scrollOffset + viewportHeight);
-      return shouldAdjustScrollForVirtualRowResize({
-        isHistoryStartPrependActive: historyStartPrependAnchorActiveRef.current,
-        rowStart: item.start,
-        scrollOffset,
-        remainingDistanceFromBottom: remainingDistance,
-        bottomThreshold: AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
-      });
+      return remainingDistance > AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
     };
     return () => {
       rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = undefined;
@@ -1109,6 +1106,41 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     rearmHistoryStartFromUserIntent,
   ]);
 
+  const scrollRowIntoView = useCallback((itemId: string): boolean => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) {
+      return false;
+    }
+    const row = scrollContainer.querySelector(
+      `[data-stream-item-id="${escapeItemIdForSelector(itemId)}"]`,
+    );
+    if (!row) {
+      return false;
+    }
+    row.scrollIntoView({ block: "center" });
+    return true;
+  }, []);
+
+  const scrollToItem = useStableEvent((itemId: string) => {
+    cancelPendingStickToBottom();
+    setFollowOutput(false);
+    if (scrollRowIntoView(itemId)) {
+      return;
+    }
+    const virtualIndex = segments.historyVirtualized.findIndex((item) => item.id === itemId);
+    if (virtualIndex < 0) {
+      return;
+    }
+    rowVirtualizer.scrollToIndex(virtualIndex, { align: "center" });
+    // Dynamic row heights make the virtualizer jump approximate; re-center on
+    // the real element once it mounts and measures.
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        scrollRowIntoView(itemId);
+      });
+    });
+  });
+
   useEffect(() => {
     const handle: StreamViewportHandle = {
       scrollToBottom: () => {
@@ -1122,6 +1154,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         }
         scheduleStickToBottom();
       },
+      scrollToItem,
       scrollToMessage,
     };
     viewportRef.current = handle;
@@ -1136,7 +1169,46 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     forceStickToBottom,
     scheduleStickToBottom,
     scrollToMessage,
+    scrollToItem,
     viewportRef,
+  ]);
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!sessionFind || !scrollContainer) {
+      clearSessionFindHighlights();
+      return;
+    }
+    let pendingFrame: number | null = null;
+    const apply = () => {
+      pendingFrame = null;
+      const container = scrollContainerRef.current;
+      if (container) {
+        applySessionFindHighlights({ container, find: sessionFind });
+      }
+    };
+    // Rows mount and unmount as the virtualizer window moves, so re-scan on
+    // scroll in addition to content changes (covered by the effect deps).
+    const scheduleApply = () => {
+      if (pendingFrame === null) {
+        pendingFrame = window.requestAnimationFrame(apply);
+      }
+    };
+    apply();
+    scrollContainer.addEventListener("scroll", scheduleApply, { passive: true });
+    return () => {
+      scrollContainer.removeEventListener("scroll", scheduleApply);
+      if (pendingFrame !== null) {
+        window.cancelAnimationFrame(pendingFrame);
+      }
+      clearSessionFindHighlights();
+    };
+  }, [
+    sessionFind,
+    segments.historyMounted,
+    segments.historyVirtualized,
+    segments.liveHead,
+    virtualTotalSize,
   ]);
 
   const contentContainerStyle = useMemo((): CSSProperties => {
@@ -1192,7 +1264,12 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
   const mountedHistoryRows = useMemo(() => {
     return segments.historyMounted.map((item, index) => (
-      <div key={item.id} data-history-row-id={item.id} style={streamRowStyle}>
+      <div
+        key={item.id}
+        data-history-row-id={item.id}
+        data-stream-item-id={item.id}
+        style={rowAnchorStyle}
+      >
         {renderHistoryMountedRow(item, index, segments.historyMounted)}
       </div>
     ));
@@ -1200,7 +1277,12 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const liveHeadRows = useMemo(() => {
     void liveHeadRowRevision;
     return segments.liveHead.map((item, index) => (
-      <div key={item.id} data-history-row-id={item.id} style={streamRowStyle}>
+      <div
+        key={item.id}
+        data-history-row-id={item.id}
+        data-stream-item-id={item.id}
+        style={rowAnchorStyle}
+      >
         {renderLiveHeadRow(item, index, segments.liveHead)}
       </div>
     ));
@@ -1253,6 +1335,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
                     key={virtualRow.key}
                     data-index={virtualRow.index}
                     data-history-row-id={item.id}
+                    data-stream-item-id={item.id}
                     ref={measureVirtualizedRowElement}
                     style={renderVirtualRowStyle(virtualRow.start)}
                   >

--- a/packages/app/src/agent-stream/strategy.ts
+++ b/packages/app/src/agent-stream/strategy.ts
@@ -2,6 +2,7 @@ import type { ComponentType, ReactElement, ReactNode, RefObject } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 import type { StreamItem } from "@/types/stream";
 import { continuesResponse } from "./turn-membership";
+import type { SessionFindState } from "./find-in-session";
 import type { StreamHistoryBoundary, StreamRenderSegments } from "./model";
 import type {
   BottomAnchorLocalRequest,
@@ -44,6 +45,12 @@ export interface StreamViewportHandle {
   scrollToBottom: (reason?: BottomAnchorLocalRequest["reason"]) => void;
   prepareForViewportChange: () => void;
   scrollToMessage?: (itemId: string) => void;
+  /**
+   * Scrolls the stream item with the given id into view (centered) and stops
+   * following live output. Only the web strategy implements this; it backs
+   * find-in-session navigation, which is keyboard-driven and web-only.
+   */
+  scrollToItem?: (itemId: string) => void;
 }
 
 export interface StreamSegmentRenderers {
@@ -78,6 +85,8 @@ export interface StreamRenderInput {
   isLoadingOlderHistory: boolean;
   hasOlderHistory: boolean;
   olderHistoryProgressKey: string | null;
+  /** Active find-in-session state, or null when the find bar is closed. */
+  sessionFind?: SessionFindState | null;
   scrollEnabled: boolean;
   listStyle: StyleProp<ViewStyle>;
   baseListContentContainerStyle: StyleProp<ViewStyle>;

--- a/packages/app/src/agent-stream/use-session-find.test.tsx
+++ b/packages/app/src/agent-stream/use-session-find.test.tsx
@@ -2,9 +2,10 @@
  * @vitest-environment jsdom
  */
 import { act, renderHook } from "@testing-library/react";
-import { createRef } from "react";
+import React, { createRef, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { keyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher";
+import { createKeyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher";
+import { KeyboardActionDispatcherProvider } from "@/keyboard/keyboard-action-dispatcher-context";
 import { resolveKeyboardShortcut } from "@/keyboard/keyboard-shortcuts";
 import { routeKeyboardShortcut } from "@/keyboard/route-shortcut";
 import type { StreamItem } from "@/types/stream";
@@ -25,7 +26,10 @@ const ITEMS: StreamItem[] = [
   assistantMessage("third", "deploy again, then deploy once more"),
 ];
 
+type KeyboardActionDispatcher = ReturnType<typeof createKeyboardActionDispatcher>;
+
 function setup(items: readonly StreamItem[] = ITEMS) {
+  const dispatcher = createKeyboardActionDispatcher();
   const scrollToItem = vi.fn();
   const viewportRef = createRef<StreamViewportHandle>() as {
     current: StreamViewportHandle | null;
@@ -44,14 +48,21 @@ function setup(items: readonly StreamItem[] = ITEMS) {
         isPaneFocused: true,
         isPanelActive: true,
       }),
-    { initialProps: { agentId: "agent-1" } },
+    {
+      initialProps: { agentId: "agent-1" },
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <KeyboardActionDispatcherProvider dispatcher={dispatcher}>
+          {children}
+        </KeyboardActionDispatcherProvider>
+      ),
+    },
   );
-  return { ...rendered, scrollToItem };
+  return { ...rendered, dispatcher, scrollToItem };
 }
 
-function openFind(): void {
+function openFind(dispatcher: KeyboardActionDispatcher): void {
   act(() => {
-    keyboardActionDispatcher.dispatch({ id: "agent.find", scope: "workspace" });
+    dispatcher.dispatch({ id: "agent.find", scope: "workspace" });
   });
 }
 
@@ -60,7 +71,13 @@ function openFind(): void {
  * resolution, real routing, real dispatcher — so the find shortcut is covered
  * from the keystroke through to the handler rather than from the action alone.
  */
-function pressFindShortcut({ isMac }: { isMac: boolean }): void {
+function pressFindShortcut({
+  dispatcher,
+  isMac,
+}: {
+  dispatcher: KeyboardActionDispatcher;
+  isMac: boolean;
+}): void {
   const resolved = resolveKeyboardShortcut({
     event: {
       key: "f",
@@ -94,24 +111,24 @@ function pressFindShortcut({ isMac }: { isMac: boolean }): void {
     throw new Error(`expected a dispatch action, got ${routed.kind}`);
   }
   act(() => {
-    keyboardActionDispatcher.dispatch(routed.action);
+    dispatcher.dispatch(routed.action);
   });
 }
 
-function pressEscape(): boolean {
+function pressEscape(dispatcher: KeyboardActionDispatcher): boolean {
   let handled = false;
   act(() => {
-    handled = keyboardActionDispatcher.dispatch({ id: "agent.interrupt", scope: "global" });
+    handled = dispatcher.dispatch({ id: "agent.interrupt", scope: "global" });
   });
   return handled;
 }
 
 describe("useSessionFind", () => {
   it("starts closed and ignores Escape so the agent-interrupt handler still receives it", () => {
-    const { result } = setup();
+    const { dispatcher, result } = setup();
 
     expect(result.current.isOpen).toBe(false);
-    expect(pressEscape()).toBe(false);
+    expect(pressEscape(dispatcher)).toBe(false);
     expect(result.current.isOpen).toBe(false);
   });
 
@@ -119,9 +136,9 @@ describe("useSessionFind", () => {
     { platform: "mac", isMac: true },
     { platform: "non-mac", isMac: false },
   ])("opens and scrolls to the first match from a $platform find keystroke", ({ isMac }) => {
-    const { result, scrollToItem } = setup();
+    const { dispatcher, result, scrollToItem } = setup();
 
-    pressFindShortcut({ isMac });
+    pressFindShortcut({ dispatcher, isMac });
     expect(result.current.isOpen).toBe(true);
 
     act(() => {
@@ -133,11 +150,11 @@ describe("useSessionFind", () => {
   });
 
   it("opens on the agent.find keyboard action and requests input focus", () => {
-    const { result } = setup();
+    const { dispatcher, result } = setup();
     const focusRequestBefore = result.current.focusRequestId;
 
     act(() => {
-      keyboardActionDispatcher.dispatch({ id: "agent.find", scope: "workspace" });
+      dispatcher.dispatch({ id: "agent.find", scope: "workspace" });
     });
 
     expect(result.current.isOpen).toBe(true);
@@ -145,8 +162,8 @@ describe("useSessionFind", () => {
   });
 
   it("scrolls to the first match and counts every occurrence as the query is typed", () => {
-    const { result, scrollToItem } = setup();
-    openFind();
+    const { dispatcher, result, scrollToItem } = setup();
+    openFind(dispatcher);
 
     act(() => {
       result.current.onQueryChange("deploy");
@@ -165,8 +182,8 @@ describe("useSessionFind", () => {
   });
 
   it("steps forward through occurrences within and across items, then wraps", () => {
-    const { result, scrollToItem } = setup();
-    openFind();
+    const { dispatcher, result, scrollToItem } = setup();
+    openFind(dispatcher);
     act(() => {
       result.current.onQueryChange("deploy");
     });
@@ -202,8 +219,8 @@ describe("useSessionFind", () => {
   });
 
   it("steps backward with wrap-around to the last occurrence", () => {
-    const { result, scrollToItem } = setup();
-    openFind();
+    const { dispatcher, result, scrollToItem } = setup();
+    openFind(dispatcher);
     act(() => {
       result.current.onQueryChange("deploy");
     });
@@ -222,8 +239,8 @@ describe("useSessionFind", () => {
   });
 
   it("reports no matches and no active occurrence for a query that is absent", () => {
-    const { result, scrollToItem } = setup();
-    openFind();
+    const { dispatcher, result, scrollToItem } = setup();
+    openFind(dispatcher);
     scrollToItem.mockClear();
 
     act(() => {
@@ -241,14 +258,14 @@ describe("useSessionFind", () => {
   });
 
   it("consumes Escape while open and stops publishing find state once closed", () => {
-    const { result } = setup();
-    openFind();
+    const { dispatcher, result } = setup();
+    openFind(dispatcher);
     act(() => {
       result.current.onQueryChange("deploy");
     });
     expect(result.current.sessionFind).not.toBeNull();
 
-    expect(pressEscape()).toBe(true);
+    expect(pressEscape(dispatcher)).toBe(true);
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.sessionFind).toBeNull();
@@ -256,8 +273,8 @@ describe("useSessionFind", () => {
   });
 
   it("closes and clears the query when the pane switches to another agent", () => {
-    const { result, rerender } = setup();
-    openFind();
+    const { dispatcher, result, rerender } = setup();
+    openFind(dispatcher);
     act(() => {
       result.current.onQueryChange("deploy");
     });

--- a/packages/app/src/agent-stream/use-session-find.test.tsx
+++ b/packages/app/src/agent-stream/use-session-find.test.tsx
@@ -5,6 +5,8 @@ import { act, renderHook } from "@testing-library/react";
 import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { keyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher";
+import { resolveKeyboardShortcut } from "@/keyboard/keyboard-shortcuts";
+import { routeKeyboardShortcut } from "@/keyboard/route-shortcut";
 import type { StreamItem } from "@/types/stream";
 import type { StreamViewportHandle } from "./strategy";
 import { useSessionFind } from "./use-session-find";
@@ -53,6 +55,49 @@ function openFind(): void {
   });
 }
 
+/**
+ * Drives the same chain the app's window keydown listener does — real binding
+ * resolution, real routing, real dispatcher — so the find shortcut is covered
+ * from the keystroke through to the handler rather than from the action alone.
+ */
+function pressFindShortcut({ isMac }: { isMac: boolean }): void {
+  const resolved = resolveKeyboardShortcut({
+    event: {
+      key: "f",
+      code: "KeyF",
+      altKey: false,
+      ctrlKey: !isMac,
+      metaKey: isMac,
+      shiftKey: false,
+      repeat: false,
+    },
+    context: { isMac, isDesktop: true, focusScope: "other", commandCenterOpen: false },
+    chordState: { candidateIndices: [], step: 0, timeoutId: null },
+    onChordReset: () => undefined,
+  });
+  const match = resolved.match;
+  if (!match) {
+    throw new Error("expected the find shortcut to resolve to an action");
+  }
+  const routed = routeKeyboardShortcut(
+    { action: match.action, payload: match.payload },
+    {
+      pathname: "/host/local/workspace/ws-1",
+      isMobile: false,
+      sidebarShortcutTargets: [],
+      navigationActiveWorkspace: null,
+      commandCenterOpen: false,
+      shortcutsDialogOpen: false,
+    },
+  );
+  if (routed.kind !== "dispatch") {
+    throw new Error(`expected a dispatch action, got ${routed.kind}`);
+  }
+  act(() => {
+    keyboardActionDispatcher.dispatch(routed.action);
+  });
+}
+
 function pressEscape(): boolean {
   let handled = false;
   act(() => {
@@ -68,6 +113,23 @@ describe("useSessionFind", () => {
     expect(result.current.isOpen).toBe(false);
     expect(pressEscape()).toBe(false);
     expect(result.current.isOpen).toBe(false);
+  });
+
+  it.each([
+    { platform: "mac", isMac: true },
+    { platform: "non-mac", isMac: false },
+  ])("opens and scrolls to the first match from a $platform find keystroke", ({ isMac }) => {
+    const { result, scrollToItem } = setup();
+
+    pressFindShortcut({ isMac });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.onQueryChange("deploy");
+    });
+
+    expect(scrollToItem).toHaveBeenCalledWith("first");
+    expect(result.current.matches).toHaveLength(3);
   });
 
   it("opens on the agent.find keyboard action and requests input focus", () => {

--- a/packages/app/src/agent-stream/use-session-find.test.tsx
+++ b/packages/app/src/agent-stream/use-session-find.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { keyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher";
+import type { StreamItem } from "@/types/stream";
+import type { StreamViewportHandle } from "./strategy";
+import { useSessionFind } from "./use-session-find";
+
+function userMessage(id: string, text: string): StreamItem {
+  return { kind: "user_message", id, text, timestamp: new Date(0) };
+}
+
+function assistantMessage(id: string, text: string): StreamItem {
+  return { kind: "assistant_message", id, text, timestamp: new Date(0) };
+}
+
+const ITEMS: StreamItem[] = [
+  userMessage("first", "deploy the service"),
+  assistantMessage("second", "no matches in here"),
+  assistantMessage("third", "deploy again, then deploy once more"),
+];
+
+function setup(items: readonly StreamItem[] = ITEMS) {
+  const scrollToItem = vi.fn();
+  const viewportRef = createRef<StreamViewportHandle>() as {
+    current: StreamViewportHandle | null;
+  };
+  viewportRef.current = {
+    scrollToBottom: vi.fn(),
+    prepareForViewportChange: vi.fn(),
+    scrollToItem,
+  };
+  const rendered = renderHook(
+    ({ agentId }: { agentId: string }) =>
+      useSessionFind({
+        agentId,
+        items,
+        viewportRef,
+        isPaneFocused: true,
+        isPanelActive: true,
+      }),
+    { initialProps: { agentId: "agent-1" } },
+  );
+  return { ...rendered, scrollToItem };
+}
+
+function openFind(): void {
+  act(() => {
+    keyboardActionDispatcher.dispatch({ id: "agent.find", scope: "workspace" });
+  });
+}
+
+function pressEscape(): boolean {
+  let handled = false;
+  act(() => {
+    handled = keyboardActionDispatcher.dispatch({ id: "agent.interrupt", scope: "global" });
+  });
+  return handled;
+}
+
+describe("useSessionFind", () => {
+  it("starts closed and ignores Escape so the agent-interrupt handler still receives it", () => {
+    const { result } = setup();
+
+    expect(result.current.isOpen).toBe(false);
+    expect(pressEscape()).toBe(false);
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("opens on the agent.find keyboard action and requests input focus", () => {
+    const { result } = setup();
+    const focusRequestBefore = result.current.focusRequestId;
+
+    act(() => {
+      keyboardActionDispatcher.dispatch({ id: "agent.find", scope: "workspace" });
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.focusRequestId).toBeGreaterThan(focusRequestBefore);
+  });
+
+  it("scrolls to the first match and counts every occurrence as the query is typed", () => {
+    const { result, scrollToItem } = setup();
+    openFind();
+
+    act(() => {
+      result.current.onQueryChange("deploy");
+    });
+
+    // "first" has one occurrence, "third" has two.
+    expect(result.current.matches).toHaveLength(3);
+    expect(result.current.activeIndex).toBe(0);
+    expect(scrollToItem).toHaveBeenCalledWith("first");
+    expect(result.current.sessionFind).toEqual({
+      query: "deploy",
+      activeItemId: "first",
+      activeOccurrenceIndex: 0,
+      activeItemOccurrenceCount: 1,
+    });
+  });
+
+  it("steps forward through occurrences within and across items, then wraps", () => {
+    const { result, scrollToItem } = setup();
+    openFind();
+    act(() => {
+      result.current.onQueryChange("deploy");
+    });
+    scrollToItem.mockClear();
+
+    act(() => {
+      result.current.next();
+    });
+    expect(result.current.activeIndex).toBe(1);
+    expect(result.current.sessionFind).toMatchObject({
+      activeItemId: "third",
+      activeOccurrenceIndex: 0,
+      activeItemOccurrenceCount: 2,
+    });
+    expect(scrollToItem).toHaveBeenLastCalledWith("third");
+
+    // Second occurrence inside the same item: still the active row, next ordinal.
+    act(() => {
+      result.current.next();
+    });
+    expect(result.current.activeIndex).toBe(2);
+    expect(result.current.sessionFind).toMatchObject({
+      activeItemId: "third",
+      activeOccurrenceIndex: 1,
+    });
+
+    act(() => {
+      result.current.next();
+    });
+    expect(result.current.activeIndex).toBe(0);
+    expect(result.current.sessionFind).toMatchObject({ activeItemId: "first" });
+    expect(scrollToItem).toHaveBeenLastCalledWith("first");
+  });
+
+  it("steps backward with wrap-around to the last occurrence", () => {
+    const { result, scrollToItem } = setup();
+    openFind();
+    act(() => {
+      result.current.onQueryChange("deploy");
+    });
+    scrollToItem.mockClear();
+
+    act(() => {
+      result.current.previous();
+    });
+
+    expect(result.current.activeIndex).toBe(2);
+    expect(result.current.sessionFind).toMatchObject({
+      activeItemId: "third",
+      activeOccurrenceIndex: 1,
+    });
+    expect(scrollToItem).toHaveBeenLastCalledWith("third");
+  });
+
+  it("reports no matches and no active occurrence for a query that is absent", () => {
+    const { result, scrollToItem } = setup();
+    openFind();
+    scrollToItem.mockClear();
+
+    act(() => {
+      result.current.onQueryChange("nonexistent");
+    });
+
+    expect(result.current.matches).toHaveLength(0);
+    expect(result.current.activeIndex).toBe(-1);
+    expect(scrollToItem).not.toHaveBeenCalled();
+    expect(result.current.sessionFind).toMatchObject({
+      activeItemId: null,
+      activeOccurrenceIndex: -1,
+      activeItemOccurrenceCount: 0,
+    });
+  });
+
+  it("consumes Escape while open and stops publishing find state once closed", () => {
+    const { result } = setup();
+    openFind();
+    act(() => {
+      result.current.onQueryChange("deploy");
+    });
+    expect(result.current.sessionFind).not.toBeNull();
+
+    expect(pressEscape()).toBe(true);
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.sessionFind).toBeNull();
+    expect(result.current.matches).toHaveLength(0);
+  });
+
+  it("closes and clears the query when the pane switches to another agent", () => {
+    const { result, rerender } = setup();
+    openFind();
+    act(() => {
+      result.current.onQueryChange("deploy");
+    });
+
+    rerender({ agentId: "agent-2" });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.query).toBe("");
+    expect(result.current.sessionFind).toBeNull();
+  });
+});

--- a/packages/app/src/agent-stream/use-session-find.ts
+++ b/packages/app/src/agent-stream/use-session-find.ts
@@ -62,12 +62,16 @@ export function useSessionFind(input: {
     if (!isOpen || !query) {
       return null;
     }
+    const activeItemId = activeMatch?.itemId ?? null;
     return {
       query,
-      activeItemId: activeMatch?.itemId ?? null,
+      activeItemId,
       activeOccurrenceIndex: activeMatch?.occurrenceIndex ?? -1,
+      activeItemOccurrenceCount: activeItemId
+        ? matches.filter((match) => match.itemId === activeItemId).length
+        : 0,
     };
-  }, [activeMatch, isOpen, query]);
+  }, [activeMatch, isOpen, matches, query]);
 
   const goToMatch = useCallback(
     (nextMatches: SessionFindMatch[], index: number) => {

--- a/packages/app/src/agent-stream/use-session-find.ts
+++ b/packages/app/src/agent-stream/use-session-find.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useId, useMemo, useState, type RefObject } from "react";
+import { isWeb } from "@/constants/platform";
+import { useKeyboardActionHandler } from "@/hooks/use-keyboard-action-handler";
+import type { StreamItem } from "@/types/stream";
+import {
+  computeSessionFindMatches,
+  type SessionFindMatch,
+  type SessionFindState,
+} from "./find-in-session";
+import type { StreamViewportHandle } from "./strategy";
+
+const EMPTY_MATCHES: SessionFindMatch[] = [];
+
+export interface SessionFindController {
+  isOpen: boolean;
+  query: string;
+  matches: SessionFindMatch[];
+  /** Clamped active match index; -1 when there are no matches. */
+  activeIndex: number;
+  focusRequestId: number;
+  /** Render state for the stream strategy, or null while the bar is closed. */
+  sessionFind: SessionFindState | null;
+  onQueryChange: (query: string) => void;
+  next: () => void;
+  previous: () => void;
+  close: () => void;
+}
+
+/**
+ * Owns find-in-session (Cmd/Ctrl+F) state for one agent stream: the query,
+ * occurrence matches over the rendered items, active-match navigation, and the
+ * keyboard actions that open the bar (`agent.find`) and close it on Escape
+ * (consuming `agent.interrupt` ahead of the composer's handler at 100/200).
+ */
+export function useSessionFind(input: {
+  agentId: string;
+  items: readonly StreamItem[];
+  viewportRef: RefObject<StreamViewportHandle | null>;
+  isPaneFocused: boolean;
+  isPanelActive: boolean;
+}): SessionFindController {
+  const { agentId, items, viewportRef, isPaneFocused, isPanelActive } = input;
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [rawActiveIndex, setRawActiveIndex] = useState(0);
+  const [focusRequestId, setFocusRequestId] = useState(0);
+
+  useEffect(() => {
+    setIsOpen(false);
+    setQuery("");
+    setRawActiveIndex(0);
+  }, [agentId]);
+
+  const matches = useMemo(
+    () => (isOpen && query ? computeSessionFindMatches(items, query) : EMPTY_MATCHES),
+    [isOpen, items, query],
+  );
+  const activeIndex = matches.length === 0 ? -1 : Math.min(rawActiveIndex, matches.length - 1);
+  const activeMatch = activeIndex >= 0 ? matches[activeIndex] : undefined;
+
+  const sessionFind = useMemo<SessionFindState | null>(() => {
+    if (!isOpen || !query) {
+      return null;
+    }
+    return {
+      query,
+      activeItemId: activeMatch?.itemId ?? null,
+      activeOccurrenceIndex: activeMatch?.occurrenceIndex ?? -1,
+    };
+  }, [activeMatch, isOpen, query]);
+
+  const goToMatch = useCallback(
+    (nextMatches: SessionFindMatch[], index: number) => {
+      const match = nextMatches[index];
+      if (!match) {
+        return;
+      }
+      setRawActiveIndex(index);
+      viewportRef.current?.scrollToItem?.(match.itemId);
+    },
+    [viewportRef],
+  );
+
+  const onQueryChange = useCallback(
+    (nextQuery: string) => {
+      setQuery(nextQuery);
+      setRawActiveIndex(0);
+      if (!nextQuery) {
+        return;
+      }
+      goToMatch(computeSessionFindMatches(items, nextQuery), 0);
+    },
+    [goToMatch, items],
+  );
+
+  const next = useCallback(() => {
+    if (matches.length === 0) {
+      return;
+    }
+    goToMatch(matches, (activeIndex + 1) % matches.length);
+  }, [activeIndex, goToMatch, matches]);
+
+  const previous = useCallback(() => {
+    if (matches.length === 0) {
+      return;
+    }
+    goToMatch(matches, (activeIndex - 1 + matches.length) % matches.length);
+  }, [activeIndex, goToMatch, matches]);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    setFocusRequestId((value) => value + 1);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handlerId = useId();
+  useKeyboardActionHandler({
+    handlerId: `session-find-open:${handlerId}`,
+    actions: ["agent.find"],
+    enabled: isWeb,
+    priority: 100,
+    isActive: () => isPaneFocused && isPanelActive,
+    handle: () => {
+      open();
+      return true;
+    },
+  });
+  useKeyboardActionHandler({
+    handlerId: `session-find-close:${handlerId}`,
+    actions: ["agent.interrupt"],
+    enabled: isWeb,
+    priority: 300,
+    isActive: () => isOpen && isPaneFocused && isPanelActive,
+    handle: () => {
+      close();
+      return true;
+    },
+  });
+
+  return {
+    isOpen,
+    query,
+    matches,
+    activeIndex,
+    focusRequestId,
+    sessionFind,
+    onQueryChange,
+    next,
+    previous,
+    close,
+  };
+}

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -331,6 +331,8 @@ function resolveBottomOverlayControlOffset(clearance: number | undefined): numbe
 }
 
 const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamViewProps>(
+  // The stream view coordinates several independent rendering and navigation paths.
+  // oxlint-disable-next-line complexity
   function AgentStreamView(
     {
       agentId,

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -73,6 +73,8 @@ import { ChatOutlineRail } from "@/agent-stream/chat-outline/rail";
 import { useChatOutline } from "@/agent-stream/chat-outline/use-chat-outline";
 import { getHostRuntimeStore } from "@/runtime/host-runtime";
 import { planTimelineTailFetch } from "@/timeline/timeline-sync-plan";
+import { SessionFindBar } from "./find-bar";
+import { useSessionFind } from "./use-session-find";
 import {
   CompletedTurnFooterRow,
   TurnFooter,
@@ -289,6 +291,8 @@ export interface AgentStreamViewProps {
   bottomOverlayControlClearance?: number;
   toast?: ToastApi | null;
   onOpenWorkspaceFile?: (request: WorkspaceFileOpenRequest) => void;
+  /** Enables pane-scoped keyboard actions such as find-in-session (Cmd/Ctrl+F). */
+  isPaneFocused?: boolean;
   readOnly?: boolean;
   historyPagination?: {
     hasOlder: boolean;
@@ -343,6 +347,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       bottomOverlayControlClearance,
       toast,
       onOpenWorkspaceFile,
+      isPaneFocused = false,
       readOnly = false,
       historyPagination,
     },
@@ -579,6 +584,23 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const isLoadingOlder = remoteIsLoadingOlder;
     const hasOlder = hasLocalHistory || remoteHasOlder;
     const progressKey = `${remoteProgressKey ?? "local"}:${historyWindowStart}`;
+
+    // Matches are computed over the projected items, i.e. what the stream
+    // actually renders, in display order (tail then live head on web).
+    const findSearchItems = useMemo(() => {
+      if (projectedToolCalls.head.length === 0) {
+        return projectedToolCalls.tail;
+      }
+      return [...projectedToolCalls.tail, ...projectedToolCalls.head];
+    }, [projectedToolCalls.head, projectedToolCalls.tail]);
+    const find = useSessionFind({
+      agentId,
+      items: findSearchItems,
+      viewportRef,
+      isPaneFocused,
+      isPanelActive: isActive,
+    });
+    const sessionFind = find.sessionFind;
 
     const baseRenderModel = useMemo(() => {
       return buildAgentStreamRenderModel({
@@ -1108,12 +1130,27 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
               isLoadingOlderHistory: isLoadingOlder,
               hasOlderHistory: hasOlder,
               olderHistoryProgressKey: progressKey,
+              sessionFind,
               scrollEnabled: streamScrollEnabled,
               listStyle: stylesheet.list,
               baseListContentContainerStyle: stylesheet.listContentContainer,
               forwardListContentContainerStyle: stylesheet.forwardListContentContainer,
             })}
           </MessageOuterSpacingProvider>
+          {find.isOpen ? (
+            <View style={stylesheet.findBarContainer} pointerEvents="box-none">
+              <SessionFindBar
+                query={find.query}
+                matchCount={find.matches.length}
+                activeMatchNumber={find.activeIndex + 1}
+                focusRequestId={find.focusRequestId}
+                onQueryChange={find.onQueryChange}
+                onNext={find.next}
+                onPrevious={find.previous}
+                onClose={find.close}
+              />
+            </View>
+          ) : null}
           <ChatOutlineRail
             prompts={chatOutline.prompts}
             activePrompt={chatOutline.activePrompt}
@@ -1252,6 +1289,7 @@ function agentStreamViewPropsEqual(
   }
   if (left.toast !== right.toast) reasons.push("toast");
   if (left.onOpenWorkspaceFile !== right.onOpenWorkspaceFile) reasons.push("onOpenWorkspaceFile");
+  if (left.isPaneFocused !== right.isPaneFocused) reasons.push("isPaneFocused");
   if (left.readOnly !== right.readOnly) reasons.push("readOnly");
   if (!historyPaginationPropsEqual(left.historyPagination, right.historyPagination)) {
     reasons.push("historyPagination");
@@ -1659,6 +1697,12 @@ const stylesheet = StyleSheet.create((theme) => ({
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.base,
     textAlign: "center",
+  },
+  findBarContainer: {
+    position: "absolute",
+    top: theme.spacing[2],
+    right: theme.spacing[4],
+    alignItems: "flex-end",
   },
   scrollToBottomContainer: {
     position: "absolute",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -206,6 +206,13 @@ export const ar: TranslationResources = {
     empty: "ابدأ الدردشة مع هذا الوكيل...",
     scrollToBottom: "قم بالتمرير إلى الأسفل",
     historyLoadFailed: "تعذر تحميل سجل الوكيل",
+    find: {
+      placeholder: "البحث في المحادثة",
+      matchCount: "{{current}}/{{total}}",
+      previous: "التطابق السابق",
+      next: "التطابق التالي",
+      close: "إغلاق البحث",
+    },
     messageCapped: "تم اقتطاع هذه الرسالة ({{bytes}} بايت).",
     permission: {
       plan: "يخطط",
@@ -2216,6 +2223,7 @@ export const ar: TranslationResources = {
         queueMessage: "رسالة قائمة الانتظار",
         muteUnmuteVoiceMode: "كتم وضع الصوت /unmute",
         switchProject: "تبديل المشروع",
+        findInConversation: "البحث في المحادثة",
       },
       helpNotes: {
         showKeyboardShortcuts: "متاح عندما لا يكون التركيز في حقل نص أو محطة طرفية.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -203,6 +203,13 @@ export const en = {
     empty: "Start chatting with this agent...",
     scrollToBottom: "Scroll to bottom",
     historyLoadFailed: "Couldn't load agent history",
+    find: {
+      placeholder: "Find in conversation",
+      matchCount: "{{current}}/{{total}}",
+      previous: "Previous match",
+      next: "Next match",
+      close: "Close find",
+    },
     messageCapped: "This message was capped ({{bytes}} bytes).",
     permission: {
       plan: "Plan",
@@ -2320,6 +2327,7 @@ export const en = {
         queueMessage: "Queue message",
         muteUnmuteVoiceMode: "Mute/unmute voice mode",
         switchProject: "Switch project",
+        findInConversation: "Find in conversation",
       },
       helpNotes: {
         showKeyboardShortcuts: "Available when focus is not in a text field or terminal.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -206,6 +206,13 @@ export const es: TranslationResources = {
     empty: "Comience a chatear con este agente...",
     scrollToBottom: "Desplazarse hacia abajo",
     historyLoadFailed: "No se pudo cargar el historial del agente",
+    find: {
+      placeholder: "Buscar en la conversación",
+      matchCount: "{{current}}/{{total}}",
+      previous: "Coincidencia anterior",
+      next: "Siguiente coincidencia",
+      close: "Cerrar búsqueda",
+    },
     messageCapped: "Este mensaje fue truncado ({{bytes}} bytes).",
     permission: {
       plan: "Plan",
@@ -2268,6 +2275,7 @@ export const es: TranslationResources = {
         queueMessage: "mensaje de cola",
         muteUnmuteVoiceMode: "Silenciar el modo de voz/unmute",
         switchProject: "Cambiar proyecto",
+        findInConversation: "Buscar en la conversación",
       },
       helpNotes: {
         showKeyboardShortcuts: "Disponible cuando el foco no está en un campo de texto o terminal.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -208,6 +208,13 @@ export const fr: TranslationResources = {
     empty: "Commencez à discuter avec cet agent...",
     scrollToBottom: "Faire défiler vers le bas",
     historyLoadFailed: "Impossible de charger l’historique de l’agent",
+    find: {
+      placeholder: "Rechercher dans la conversation",
+      matchCount: "{{current}}/{{total}}",
+      previous: "Correspondance précédente",
+      next: "Correspondance suivante",
+      close: "Fermer la recherche",
+    },
     messageCapped: "Ce message a été tronqué ({{bytes}} octets).",
     permission: {
       plan: "Plan",
@@ -2271,6 +2278,7 @@ export const fr: TranslationResources = {
         queueMessage: "Message de file d'attente",
         muteUnmuteVoiceMode: "Mode vocal/unmutemuet",
         switchProject: "Changer de projet",
+        findInConversation: "Rechercher dans la conversation",
       },
       helpNotes: {
         showKeyboardShortcuts:

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -206,6 +206,13 @@ export const ja: TranslationResources = {
     empty: "このエージェントとチャットを始めましょう...",
     scrollToBottom: "下にスクロール",
     historyLoadFailed: "エージェントの履歴を読み込めませんでした",
+    find: {
+      placeholder: "会話内を検索",
+      matchCount: "{{current}}/{{total}}",
+      previous: "前の一致",
+      next: "次の一致",
+      close: "検索を閉じる",
+    },
     messageCapped: "このメッセージは上限で切り詰められました（{{bytes}}バイト）。",
     permission: {
       plan: "プラン",
@@ -2234,6 +2241,7 @@ export const ja: TranslationResources = {
         queueMessage: "メッセージをキューに追加",
         muteUnmuteVoiceMode: "音声モードのミュートを切り替え",
         switchProject: "プロジェクトを切り替え",
+        findInConversation: "会話内を検索",
       },
       helpNotes: {
         showKeyboardShortcuts:

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -206,6 +206,13 @@ export const ko: TranslationResources = {
     empty: "이 에이전트와 대화를 시작하세요...",
     scrollToBottom: "맨 아래로 스크롤",
     historyLoadFailed: "에이전트 기록을 로드할 수 없습니다.",
+    find: {
+      placeholder: "대화에서 찾기",
+      matchCount: "{{current}}/{{total}}",
+      previous: "이전 일치",
+      next: "다음 일치",
+      close: "찾기 닫기",
+    },
     messageCapped: "이 메시지는 길이 제한으로 잘렸습니다({{bytes}}바이트).",
     permission: {
       plan: "계획",
@@ -2226,6 +2233,7 @@ export const ko: TranslationResources = {
         queueMessage: "메시지 대기열에 추가",
         muteUnmuteVoiceMode: "음성 모드 음소거/해제",
         switchProject: "프로젝트 전환",
+        findInConversation: "대화에서 찾기",
       },
       helpNotes: {
         showKeyboardShortcuts: "포커스가 텍스트 필드나 터미널에 있지 않을 때 사용할 수 있습니다.",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -206,6 +206,13 @@ export const ptBR: TranslationResources = {
     empty: "Comece a conversar com este agente...",
     scrollToBottom: "Rolar para o fim",
     historyLoadFailed: "Não foi possível carregar o histórico do agente",
+    find: {
+      placeholder: "Buscar na conversa",
+      matchCount: "{{current}}/{{total}}",
+      previous: "Correspondência anterior",
+      next: "Próxima correspondência",
+      close: "Fechar busca",
+    },
     messageCapped: "Esta mensagem foi truncada ({{bytes}} bytes).",
     permission: {
       plan: "Plano",
@@ -2250,6 +2257,7 @@ export const ptBR: TranslationResources = {
         queueMessage: "Enfileirar mensagem",
         muteUnmuteVoiceMode: "Silenciar/ativar modo de voz",
         switchProject: "Trocar projeto",
+        findInConversation: "Buscar na conversa",
       },
       helpNotes: {
         showKeyboardShortcuts:

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -206,6 +206,13 @@ export const ru: TranslationResources = {
     empty: "Начните общаться с этим агентом...",
     scrollToBottom: "Прокрутить вниз",
     historyLoadFailed: "Не удалось загрузить историю агента",
+    find: {
+      placeholder: "Поиск по беседе",
+      matchCount: "{{current}}/{{total}}",
+      previous: "Предыдущее совпадение",
+      next: "Следующее совпадение",
+      close: "Закрыть поиск",
+    },
     messageCapped: "Это сообщение было обрезано ({{bytes}} байт).",
     permission: {
       plan: "План",
@@ -2254,6 +2261,7 @@ export const ru: TranslationResources = {
         queueMessage: "Поставить сообщение в очередь",
         muteUnmuteVoiceMode: "Выключить/включить звук в голосовом режиме",
         switchProject: "Сменить проект",
+        findInConversation: "Поиск по беседе",
       },
       helpNotes: {
         showKeyboardShortcuts: "Доступно, когда фокус находится не в текстовом поле или терминале.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -206,6 +206,13 @@ export const zhCN: TranslationResources = {
     empty: "开始和这个 Agent 对话...",
     scrollToBottom: "滚动到底部",
     historyLoadFailed: "无法加载智能体历史记录",
+    find: {
+      placeholder: "在会话中查找",
+      matchCount: "{{current}}/{{total}}",
+      previous: "上一个匹配项",
+      next: "下一个匹配项",
+      close: "关闭查找",
+    },
     messageCapped: "此消息已被截断（{{bytes}} 字节）。",
     permission: {
       plan: "Plan",
@@ -2190,6 +2197,7 @@ export const zhCN: TranslationResources = {
         queueMessage: "消息排队",
         muteUnmuteVoiceMode: "静音/取消静音语音模式",
         switchProject: "切换项目",
+        findInConversation: "在会话中查找",
       },
       helpNotes: {
         showKeyboardShortcuts: "焦点不在文本输入框或终端内时可用。",

--- a/packages/app/src/keyboard/actions.ts
+++ b/packages/app/src/keyboard/actions.ts
@@ -18,6 +18,7 @@ export type MessageInputKeyboardActionKind =
 
 export type KeyboardActionId =
   | "agent.interrupt"
+  | "agent.find"
   | "agent.new"
   | "workspace.tab.menu.open"
   | "workspace.tab.target.agent"

--- a/packages/app/src/keyboard/keyboard-action-dispatcher-context.tsx
+++ b/packages/app/src/keyboard/keyboard-action-dispatcher-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useRef } from "react";
+import React, { createContext, type ReactNode, useContext, useRef } from "react";
 
 import { createKeyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher";
 
@@ -6,14 +6,20 @@ type KeyboardActionDispatcher = ReturnType<typeof createKeyboardActionDispatcher
 
 const KeyboardActionDispatcherContext = createContext<KeyboardActionDispatcher | null>(null);
 
-export function KeyboardActionDispatcherProvider({ children }: { children: ReactNode }) {
+export function KeyboardActionDispatcherProvider({
+  children,
+  dispatcher,
+}: {
+  children: ReactNode;
+  dispatcher?: KeyboardActionDispatcher;
+}) {
   const dispatcherRef = useRef<KeyboardActionDispatcher | null>(null);
   if (!dispatcherRef.current) {
     dispatcherRef.current = createKeyboardActionDispatcher();
   }
 
   return (
-    <KeyboardActionDispatcherContext.Provider value={dispatcherRef.current}>
+    <KeyboardActionDispatcherContext.Provider value={dispatcher ?? dispatcherRef.current}>
       {children}
     </KeyboardActionDispatcherContext.Provider>
   );

--- a/packages/app/src/keyboard/keyboard-action-dispatcher.ts
+++ b/packages/app/src/keyboard/keyboard-action-dispatcher.ts
@@ -5,6 +5,7 @@ export type WorkspacePanelPlacement = "supporting" | "side-pane" | "focused-pane
 
 export type KeyboardActionId =
   | "agent.interrupt"
+  | "agent.find"
   | "message-input.focus"
   | "message-input.send"
   | "message-input.dictation-toggle"
@@ -58,6 +59,7 @@ export type KeyboardActionId =
 
 export type KeyboardActionDefinition =
   | { id: "agent.interrupt"; scope: KeyboardActionScope }
+  | { id: "agent.find"; scope: KeyboardActionScope }
   | { id: "message-input.focus"; scope: KeyboardActionScope }
   | { id: "message-input.send"; scope: KeyboardActionScope }
   | { id: "message-input.dictation-toggle"; scope: KeyboardActionScope }

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -388,6 +388,18 @@ describe("keyboard-shortcuts", () => {
       context: { isMac: true, isDesktop: false },
       action: "workspace.tab.close.current",
     },
+    {
+      name: "matches Cmd+F to find in conversation on mac",
+      event: { key: "f", code: "KeyF", metaKey: true },
+      context: { isMac: true, commandCenterOpen: false },
+      action: "agent.find",
+    },
+    {
+      name: "matches Ctrl+F to find in conversation on non-mac",
+      event: { key: "f", code: "KeyF", ctrlKey: true },
+      context: { isMac: false, commandCenterOpen: false, focusScope: "other" },
+      action: "agent.find",
+    },
   ];
 
   it.each(matchingCases)(
@@ -439,6 +451,11 @@ describe("keyboard-shortcuts", () => {
     {
       name: "does not switch project with Ctrl+P on non-mac while terminal is focused",
       event: { key: "p", code: "KeyP", ctrlKey: true },
+      context: { isMac: false, focusScope: "terminal" },
+    },
+    {
+      name: "does not open find with Ctrl+F on non-mac while terminal is focused",
+      event: { key: "f", code: "KeyF", ctrlKey: true },
       context: { isMac: false, focusScope: "terminal" },
     },
     {

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -246,6 +246,7 @@ const SHORTCUT_HELP_LABEL_KEYS: Record<string, string> = {
   "voice-toggle": "settings.shortcuts.help.toggleVoiceMode",
   "dictation-toggle": "settings.shortcuts.help.startStopDictation",
   "agent-interrupt": "settings.shortcuts.help.interruptAgent",
+  "find-in-conversation": "settings.shortcuts.help.findInConversation",
   "voice-mute-toggle": "settings.shortcuts.help.muteUnmuteVoiceMode",
 };
 
@@ -1133,6 +1134,31 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       id: "dictation-toggle",
       section: "agent-input",
       label: "Start/stop dictation",
+    },
+  },
+  // --- Find in conversation ---
+  {
+    id: "agent-find-cmd-f-mac",
+    action: "agent.find",
+    combo: "Cmd+F",
+    when: { mac: true, commandCenter: false },
+    help: {
+      id: "find-in-conversation",
+      section: "agent-input",
+      label: "Find in conversation",
+      keys: ["mod", "F"],
+    },
+  },
+  {
+    id: "agent-find-ctrl-f-non-mac",
+    action: "agent.find",
+    combo: "Ctrl+F",
+    when: { mac: false, commandCenter: false, terminal: false },
+    help: {
+      id: "find-in-conversation",
+      section: "agent-input",
+      label: "Find in conversation",
+      keys: ["mod", "F"],
     },
   },
   {

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -195,6 +195,7 @@ export const SHORTCUT_HELP_ROW_ORDER: Record<ShortcutSectionId, readonly string[
   layout: ["toggle-left-sidebar", "toggle-right-sidebar", "toggle-both-sidebars", "toggle-focus"],
   "agent-input": [
     "focus-message-input",
+    "find-in-conversation",
     "cycle-agent-mode",
     "voice-toggle",
     "dictation-toggle",
@@ -1146,7 +1147,6 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       id: "find-in-conversation",
       section: "agent-input",
       label: "Find in conversation",
-      keys: ["mod", "F"],
     },
   },
   {
@@ -1158,7 +1158,6 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       id: "find-in-conversation",
       section: "agent-input",
       label: "Find in conversation",
-      keys: ["mod", "F"],
     },
   },
   {

--- a/packages/app/src/keyboard/route-shortcut.test.ts
+++ b/packages/app/src/keyboard/route-shortcut.test.ts
@@ -28,6 +28,7 @@ function makeCtx(overrides: Partial<ShortcutRoutingContext> = {}): ShortcutRouti
 describe("routeKeyboardShortcut — dispatch passthroughs", () => {
   it.each([
     ["agent.interrupt", { id: "agent.interrupt", scope: "global" }],
+    ["agent.find", { id: "agent.find", scope: "workspace" }],
     ["workspace.tab.menu.open", { id: "workspace.tab.menu.open", scope: "workspace" }],
     ["workspace.tab.target.agent", { id: "workspace.tab.target.agent", scope: "workspace" }],
     ["workspace.tab.target.browser", { id: "workspace.tab.target.browser", scope: "workspace" }],

--- a/packages/app/src/keyboard/route-shortcut.ts
+++ b/packages/app/src/keyboard/route-shortcut.ts
@@ -40,6 +40,7 @@ const NONE: ShortcutAction = { kind: "none" };
 // Action ids whose routing is a no-payload pass-through to the dispatcher.
 const PASSTHROUGH_DISPATCH: Record<string, KeyboardActionDefinition> = {
   "agent.interrupt": { id: "agent.interrupt", scope: "global" },
+  "agent.find": { id: "agent.find", scope: "workspace" },
   "workspace.tab.menu.open": { id: "workspace.tab.menu.open", scope: "workspace" },
   "workspace.tab.target.agent": { id: "workspace.tab.target.agent", scope: "workspace" },
   "workspace.tab.target.browser": { id: "workspace.tab.target.browser", scope: "workspace" },

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1352,6 +1352,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
           workspaceId={workspaceId}
           agentId={agentId}
           agent={effectiveAgent}
+          isPaneFocused={isPaneFocused}
           routeBottomAnchorRequest={routeBottomAnchorRequest}
           hasAppliedAuthoritativeHistory={hasAppliedAuthoritativeHistory}
           hasActiveComposer={hasActiveComposer}
@@ -1449,6 +1450,7 @@ const AgentStreamSection = memo(function AgentStreamSection({
   workspaceId,
   agentId,
   agent,
+  isPaneFocused,
   routeBottomAnchorRequest,
   hasAppliedAuthoritativeHistory,
   hasActiveComposer,
@@ -1461,6 +1463,7 @@ const AgentStreamSection = memo(function AgentStreamSection({
   workspaceId: string;
   agentId?: string;
   agent: AgentScreenAgent;
+  isPaneFocused: boolean;
   routeBottomAnchorRequest: RouteBottomAnchorRequest;
   hasAppliedAuthoritativeHistory: boolean;
   hasActiveComposer: boolean;
@@ -1539,6 +1542,7 @@ const AgentStreamSection = memo(function AgentStreamSection({
       pendingMessageSubmissions={pendingMessageSubmissions}
       turnPresentation={turnPresentation}
       onOpenWorkspaceFile={onOpenWorkspaceFile}
+      isPaneFocused={isPaneFocused}
     />
   );
 });

--- a/packages/app/src/panels/provider-subagent-panel.tsx
+++ b/packages/app/src/panels/provider-subagent-panel.tsx
@@ -13,7 +13,7 @@ import { ComposerTrackBar } from "@/composer/tracks";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import type { AgentScreenAgent } from "@/hooks/use-agent-screen-state-machine";
 import { usePaneContext, usePaneFocus } from "@/panels/pane-context";
-import type { PanelDescriptor, PanelRegistration } from "@/panels/panel-registry";
+import { definePanel, type PanelDescriptor } from "@/panels/panel-registry";
 import { useSessionStore } from "@/stores/session-store";
 import { useSubagentsForParent } from "@/subagents/select";
 import { SubagentsTrack } from "@/subagents/track";
@@ -290,8 +290,7 @@ const styles = StyleSheet.create((theme) => ({
   unsupportedText: { color: theme.colors.foregroundMuted, textAlign: "center" },
 }));
 
-export const providerSubagentPanelRegistration: PanelRegistration<"provider_subagent"> = {
-  kind: "provider_subagent",
+export const providerSubagentPanelRegistration = definePanel("provider_subagent", {
   component: ProviderSubagentPanel,
   useDescriptor: useProviderSubagentDescriptor,
-};
+});

--- a/packages/app/src/panels/provider-subagent-panel.tsx
+++ b/packages/app/src/panels/provider-subagent-panel.tsx
@@ -12,8 +12,8 @@ import {
 import { ComposerTrackBar } from "@/composer/tracks";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import type { AgentScreenAgent } from "@/hooks/use-agent-screen-state-machine";
-import { usePaneContext } from "@/panels/pane-context";
-import { definePanel, type PanelDescriptor } from "@/panels/panel-registry";
+import { usePaneContext, usePaneFocus } from "@/panels/pane-context";
+import type { PanelDescriptor, PanelRegistration } from "@/panels/panel-registry";
 import { useSessionStore } from "@/stores/session-store";
 import { useSubagentsForParent } from "@/subagents/select";
 import { SubagentsTrack } from "@/subagents/track";
@@ -109,6 +109,7 @@ function useProviderSubagentDescriptor(
 function ProviderSubagentPanel() {
   const { t } = useTranslation();
   const { serverId, target, openFileInWorkspace, openTab } = usePaneContext();
+  const { isInteractive } = usePaneFocus();
   invariant(target.kind === "provider_subagent", "ProviderSubagentPanel requires provider target");
   const key = providerSubagentKey(serverId, target.parentAgentId, target.subagentId);
   const streamId = `provider:${encodeURIComponent(target.parentAgentId)}:${encodeURIComponent(target.subagentId)}`;
@@ -258,6 +259,7 @@ function ProviderSubagentPanel() {
         pendingPermissions={EMPTY_PERMISSIONS}
         isAuthoritativeHistoryReady
         onOpenWorkspaceFile={openFileInWorkspace}
+        isPaneFocused={isInteractive}
         readOnly
         historyPagination={historyPagination}
         bottomOverlayTailClearance={childTrackClearance.tail}
@@ -288,7 +290,8 @@ const styles = StyleSheet.create((theme) => ({
   unsupportedText: { color: theme.colors.foregroundMuted, textAlign: "center" },
 }));
 
-export const providerSubagentPanelRegistration = definePanel("provider_subagent", {
+export const providerSubagentPanelRegistration: PanelRegistration<"provider_subagent"> = {
+  kind: "provider_subagent",
   component: ProviderSubagentPanel,
   useDescriptor: useProviderSubagentDescriptor,
-});
+};


### PR DESCRIPTION
Closes #1920.

Adds find-in-session for agent conversations on web and desktop: press Cmd/Ctrl+F while an agent conversation pane is focused to open a floating find bar, type to jump to the first match, and step through occurrences with Enter / Shift+Enter or the arrow buttons. Escape closes the bar (and never interrupts the agent). When no conversation pane is focused, the key falls through to the browser's native find as before.

## How it works

- **Shortcut** — new `agent.find` keyboard action: Cmd+F on mac, Ctrl+F elsewhere (excluded while a terminal is focused). Wired through bindings → router → dispatcher like existing actions, shows up in the shortcuts dialog under Agent Input, and is rebindable. The focused pane's handler claims it via the dispatcher, so splits behave correctly.
- **Match model** (`agent-stream/find-in-session.ts`) — pure, unit-tested extraction of the *visible-by-default* text per stream item (user/assistant messages, `speak` tool calls, activity logs, todo entries — collapsed reasoning and tool payloads are excluded so every match can be seen without expanding anything), with case-insensitive occurrence enumeration and a per-item lowercase cache for cheap per-keystroke matching.
- **Find bar** (`agent-stream/find-bar.tsx` + `use-session-find.ts`) — floating bar overlaid top-right of the stream with an `n/N` counter and prev/next/close controls, built from theme tokens. A priority-300 handler consumes the global Escape (`agent.interrupt`) while the bar is open so closing find can't cancel a running turn.
- **Scroll-to-match** — the web stream viewport gains an optional `scrollToItem`: rows carry `data-stream-item-id` anchors (mounted, live-head, and virtualized), navigation centers the row via the DOM and falls back to the tanstack virtualizer's `scrollToIndex` (with a post-mount re-center) for unmounted history. Live-output following pauses while navigating so streaming doesn't yank the viewport back to the bottom.
- **Highlighting** — occurrences are painted with the CSS Custom Highlight API (no re-render, no markdown rewriting), with a distinct fill for the active occurrence, re-scanned on scroll as virtualized rows mount. Browsers without the API degrade to scroll-to-row.
- **Scope** — read-only provider subagent panes get find too. Native is untouched: the feature is keyboard-driven, and the native FlatList strategy simply doesn't implement `scrollToItem`. Strings localized in all eight languages (parity test passes).

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean across all workspaces
- New unit tests for the match model (10) and a `scrollToItem` anchor test in the web strategy suite (10 total)
- Cmd+F/Ctrl+F matching, terminal-focus exclusion, and `agent.find` routing cases added to the keyboard suites (79 + 60 passing)
- i18n resources parity suite passes (32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)