### PR TITLE
fix(app): stop Escape from interrupting the agent while an overlay is open

### DIFF
--- a/packages/app/e2e/browser/escape-overlay-agent-interrupt.spec.ts
+++ b/packages/app/e2e/browser/escape-overlay-agent-interrupt.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from "../support/fixtures";
+import { openAgentRoute, seedMockAgentWorkspace } from "../support/helpers/mock-agent";
+import { getServerId } from "../support/helpers/server-id";
+import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
+
+function stopButton(page: Page) {
+  return page.getByRole("button", { name: /stop|cancel/i }).first();
+}
+
+async function expectAgentStillRunning(page: Page) {
+  await expect(stopButton(page)).toBeVisible({ timeout: 10_000 });
+}
+
+// Escape belongs to the topmost overlay. The global shortcut dispatcher and the
+// overlay key handling are both capture-phase window listeners, and the dispatcher
+// registers first (at app mount) — so before the `overlay: false` gate on the
+// `agent-interrupt` binding, closing any overlay with Escape also stopped the
+// running agent. See #1705.
+//
+// This drives the exact reported path through the real app: sidebar → workspace
+// ⋯ menu → Rename workspace → Escape, against a genuinely streaming agent. The
+// final step is the positive control: with nothing open, Escape must still
+// interrupt, so a gate that over-suppresses cannot pass this test either.
+test("Escape closes sidebar overlays without interrupting the running agent", async ({ page }) => {
+  test.setTimeout(120_000);
+  const serverId = getServerId();
+  const agent = await seedMockAgentWorkspace({
+    repoPrefix: "escape-overlay-interrupt-",
+    title: "Escape overlay interrupt",
+    // A minute of headroom: the overlay interactions below must happen while the
+    // turn is unambiguously still streaming.
+    model: "one-minute-stream",
+  });
+
+  try {
+    await openAgentRoute(page, { workspaceId: agent.workspaceId, agentId: agent.agentId });
+    await waitForSidebarHydration(page);
+    await agent.client.sendAgentMessage(agent.agentId, "Stream while overlays open and close.");
+    await expect(stopButton(page)).toBeVisible({ timeout: 30_000 });
+
+    const row = page.getByTestId(`sidebar-workspace-row-${serverId}:${agent.workspaceId}`);
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    const kebab = page.getByTestId(`sidebar-workspace-kebab-${serverId}:${agent.workspaceId}`);
+    const renameItem = page.getByTestId(
+      `sidebar-workspace-menu-rename-${serverId}:${agent.workspaceId}`,
+    );
+    const renameInput = page.getByTestId(
+      `sidebar-workspace-rename-modal-${serverId}:${agent.workspaceId}-input`,
+    );
+
+    await test.step("Escape closes the ⋯ menu and the agent keeps streaming", async () => {
+      await row.hover();
+      await kebab.click();
+      await expect(renameItem).toBeVisible({ timeout: 10_000 });
+
+      await page.keyboard.press("Escape");
+      await expect(renameItem).toBeHidden({ timeout: 10_000 });
+      await expectAgentStillRunning(page);
+    });
+
+    await test.step("Escape cancels the rename dialog and the agent keeps streaming", async () => {
+      await row.hover();
+      await kebab.click();
+      await expect(renameItem).toBeVisible({ timeout: 10_000 });
+      await renameItem.click();
+      await expect(renameInput).toBeVisible({ timeout: 10_000 });
+
+      await page.keyboard.press("Escape");
+      await expect(renameInput).toHaveCount(0, { timeout: 10_000 });
+      await expectAgentStillRunning(page);
+    });
+
+    await test.step("Escape with no overlay open still interrupts the agent", async () => {
+      await page.keyboard.press("Escape");
+      await expect(stopButton(page)).toHaveCount(0, { timeout: 30_000 });
+    });
+  } finally {
+    await agent.cleanup();
+  }
+});

--- a/packages/app/src/components/attachment-lightbox.tsx
+++ b/packages/app/src/components/attachment-lightbox.tsx
@@ -9,6 +9,7 @@ import type { AttachmentMetadata } from "@/attachments/types";
 import { useAttachmentPreviewUrl } from "@/attachments/use-attachment-preview-url";
 import { isWeb } from "@/constants/platform";
 import { WindowChromeRootRegion, WindowChromeSafeArea } from "@/utils/desktop-window";
+import { pushEscapeDismissHandler } from "@/keyboard/escape-dismiss-stack";
 
 interface AttachmentLightboxProps {
   metadata: AttachmentMetadata | null;
@@ -26,17 +27,12 @@ export function AttachmentLightbox({ metadata, onClose }: AttachmentLightboxProp
     setErrored(false);
   }, [metadata?.id]);
 
+  // Own Escape via the shared stack while open: closes the lightbox and flips
+  // hasEscapeDismissHandler() so the global dispatcher suppresses agent.interrupt
+  // instead of stopping a running agent (see escape-dismiss-stack).
   useEffect(() => {
     if (!isWeb || !metadata) return;
-    function handleKeydown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    }
-    window.addEventListener("keydown", handleKeydown);
-    return () => {
-      window.removeEventListener("keydown", handleKeydown);
-    };
+    return pushEscapeDismissHandler(onClose);
   }, [metadata, onClose]);
 
   const closeButtonRowStyle = useMemo(

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -98,6 +98,7 @@ import { createMessageSubmissionWriter } from "@/composer/submission/writer";
 import { ComposerKeyboardScopeProvider } from "@/composer/keyboard-scope";
 import { useAppSettings } from "@/hooks/use-settings";
 import { isWeb, isNative } from "@/constants/platform";
+import { pushEscapeDismissHandler } from "@/keyboard/escape-dismiss-stack";
 import type { ForgeSearchItem } from "@getpaseo/protocol/messages";
 import type {
   AttachmentMetadata,
@@ -1177,6 +1178,14 @@ export function Composer({
   });
   const autocompleteOnKeyPressRef = useRef(autocomplete.onKeyPress);
   autocompleteOnKeyPressRef.current = autocomplete.onKeyPress;
+
+  // While the autocomplete popover is open, own Escape via the shared stack: it
+  // dismisses the popover and flips hasEscapeDismissHandler() so the global
+  // dispatcher suppresses agent.interrupt instead of stopping the running agent.
+  useEffect(() => {
+    if (!isWeb || !autocomplete.isVisible || !isPaneFocused) return;
+    return pushEscapeDismissHandler(autocomplete.dismiss);
+  }, [autocomplete.isVisible, autocomplete.dismiss, isPaneFocused]);
 
   // Clear send error when user edits the input
   useEffect(() => {

--- a/packages/app/src/hooks/use-agent-autocomplete.test.tsx
+++ b/packages/app/src/hooks/use-agent-autocomplete.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import "@/test/window-local-storage";
+import { i18n as testI18n } from "@/i18n/i18next";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import React, { type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useAgentAutocomplete } from "./use-agent-autocomplete";
+
+void testI18n;
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+// Regression for the escape-dismiss fix. Escape dismisses the autocomplete popover
+// (the composer registers `dismiss` with the shared escape-dismiss stack) WITHOUT
+// clearing the input, and typing re-opens it. The removed `onEscape` used to clear
+// a start-position slash command on Escape; that path is intentionally gone.
+describe("useAgentAutocomplete dismiss", () => {
+  it("hides the popover on dismiss without touching the input, then re-opens on new input", () => {
+    const setUserInput = vi.fn();
+    const { result, rerender } = renderHook(
+      (props: { userInput: string }) =>
+        useAgentAutocomplete({
+          userInput: props.userInput,
+          cursorIndex: props.userInput.length,
+          setUserInput,
+          serverId: "s1",
+          agentId: "a1",
+          draftConfig: { provider: "claude", cwd: "/tmp" },
+        }),
+      { wrapper: Wrapper, initialProps: { userInput: "@src/foo" } },
+    );
+
+    // A file mention is active, so the popover is visible.
+    expect(result.current.isVisible).toBe(true);
+
+    // dismiss() is what Escape triggers via the shared stack: hide the popover,
+    // and crucially do NOT rewrite the input text.
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.isVisible).toBe(false);
+    expect(setUserInput).not.toHaveBeenCalled();
+
+    // Typing more changes the active mention target, which re-opens the popover.
+    rerender({ userInput: "@src/food" });
+    expect(result.current.isVisible).toBe(true);
+  });
+});

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -57,6 +57,8 @@ interface AgentAutocompleteResult {
   emptyText: string;
   onSelectOption: (option: AutocompleteOption) => void;
   onKeyPress: (event: { key: string; preventDefault: () => void }) => boolean;
+  /** Hide the popover until the active mention/command target changes. */
+  dismiss: () => void;
 }
 
 interface DirectorySuggestionEntry {
@@ -319,6 +321,15 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     return () => clearTimeout(timer);
   }, [fileFilterQuery]);
 
+  // Escape dismisses the popover (via the shared escape-dismiss stack in the
+  // composer) without interrupting the agent. Reset whenever the active target
+  // changes so typing more re-opens it.
+  const [dismissed, setDismissed] = useState(false);
+  const dismiss = useCallback(() => setDismissed(true), []);
+  useEffect(() => {
+    setDismissed(false);
+  }, [activeSlashCommand, activeFileMention]);
+
   const normalizedDraftConfig = useMemo(
     () => normalizeDraftCommandConfig(draftConfig),
     [draftConfig],
@@ -361,7 +372,7 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     draftConfig: queryDraftConfig,
   });
 
-  const isVisible = canShowAutocomplete && !(mode === "command" && isCommandsLoading);
+  const isVisible = canShowAutocomplete && !dismissed && !(mode === "command" && isCommandsLoading);
 
   const fileSuggestionsQuery = useQuery({
     queryKey: [
@@ -473,15 +484,14 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     ],
   );
 
+  // No onEscape: while the popover is open the composer registers `dismiss` with
+  // the shared escape-dismiss stack, which intercepts Escape in the capture phase
+  // (and suppresses agent.interrupt), so an onEscape handler here would never run.
   const { selectedIndex, onKeyPress } = useAutocomplete({
     isVisible,
     options,
     query: mode === "command" ? commandFilterQuery : fileFilterQuery,
     onSelectOption,
-    onEscape:
-      mode === "command" && activeSlashCommand?.position === "start"
-        ? () => setUserInput("")
-        : undefined,
   });
 
   const isLoading = resolveAutocompleteIsLoading({
@@ -516,5 +526,6 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     emptyText,
     onSelectOption,
     onKeyPress,
+    dismiss,
   };
 }

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -14,6 +14,8 @@ import {
   getWorkspaceIndexJumpModifierKey,
 } from "@/keyboard/keyboard-shortcuts";
 import { resolveKeyboardFocusScope } from "@/keyboard/focus-scope";
+import { hasEscapeDismissHandler } from "@/keyboard/escape-dismiss-stack";
+import { hasOpenWebOverlay } from "@/lib/overlay-root";
 import {
   buildBrowserKeyboardPolicy,
   parseBrowserShortcutInput,
@@ -238,6 +240,7 @@ export function useKeyboardShortcuts({
           isDesktop: isDesktopApp,
           focusScope: input.focusScope,
           commandCenterOpen: store.commandCenterOpen,
+          overlayOpen: hasOpenWebOverlay() || hasEscapeDismissHandler(),
         },
         chordState: chordStateRef.current,
         onChordReset: () => {

--- a/packages/app/src/keyboard/escape-dismiss-stack.browser.test.ts
+++ b/packages/app/src/keyboard/escape-dismiss-stack.browser.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasEscapeDismissHandler, pushEscapeDismissHandler } from "./escape-dismiss-stack";
+import { resolveKeyboardShortcut, type ChordState } from "./keyboard-shortcuts";
+
+// This proves the actual bug end-to-end in a real browser: two window capture
+// listeners (the global dispatcher + the overlay's escape stack) plus shared
+// state. The unit tests can only cover the pure pieces — in Node `window` is
+// undefined, so the stack never attaches its listener and the integration the
+// bug lives in goes unexercised.
+
+// Mimic the global dispatcher's keydown listener (use-keyboard-shortcuts.ts):
+// a window capture listener that resolves shortcuts with overlayOpen fed from
+// the shared stack. It records whether agent.interrupt WOULD have fired.
+function installDispatcherProbe() {
+  const interrupts: string[] = [];
+  const chordState: ChordState = { candidateIndices: [], step: 0, timeoutId: null };
+  const listener = (event: KeyboardEvent) => {
+    const result = resolveKeyboardShortcut({
+      event,
+      context: {
+        isMac: false,
+        isDesktop: true,
+        // Escape interrupts even from the message input — the gate must be the
+        // open overlay, not the focus scope.
+        focusScope: "message-input",
+        commandCenterOpen: false,
+        overlayOpen: hasEscapeDismissHandler(),
+      },
+      chordState,
+      onChordReset: () => {},
+    });
+    if (result.match?.action === "agent.interrupt") {
+      interrupts.push(result.match.action);
+    }
+  };
+  // Register BEFORE any overlay opens — the dispatcher mounts at app start, which
+  // is the exact ordering that made the modal's stopPropagation insufficient.
+  window.addEventListener("keydown", listener, true);
+  return { interrupts, dispose: () => window.removeEventListener("keydown", listener, true) };
+}
+
+function pressEscape(): KeyboardEvent {
+  // Real Escape keydown carries both key and code; the binding matches on code.
+  const event = new KeyboardEvent("keydown", {
+    key: "Escape",
+    code: "Escape",
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("escape-dismiss-stack integration (browser)", () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.();
+    }
+  });
+
+  it("closes the overlay and does NOT interrupt the agent when Escape is pressed with a dialog open", () => {
+    const probe = installDispatcherProbe();
+    cleanups.push(probe.dispose);
+
+    const close = vi.fn();
+    cleanups.push(pushEscapeDismissHandler(close));
+
+    const event = pressEscape();
+
+    expect(close).toHaveBeenCalledTimes(1); // shared stack closed the overlay
+    expect(probe.interrupts).toEqual([]); // dispatcher suppressed agent.interrupt
+    expect(event.defaultPrevented).toBe(true); // stack listener claimed the key
+  });
+
+  it("interrupts the agent on Escape once the overlay is gone", () => {
+    const probe = installDispatcherProbe();
+    cleanups.push(probe.dispose);
+
+    const close = vi.fn();
+    const disposeHandler = pushEscapeDismissHandler(close);
+    disposeHandler(); // overlay closed / unmounted
+
+    pressEscape();
+
+    expect(close).not.toHaveBeenCalled();
+    expect(probe.interrupts).toEqual(["agent.interrupt"]);
+  });
+
+  it("routes Escape to the topmost overlay only (nested dialogs)", () => {
+    const probe = installDispatcherProbe();
+    cleanups.push(probe.dispose);
+
+    const closeOuter = vi.fn();
+    const closeInner = vi.fn();
+    cleanups.push(pushEscapeDismissHandler(closeOuter));
+    const disposeInner = pushEscapeDismissHandler(closeInner);
+
+    pressEscape();
+    expect(closeInner).toHaveBeenCalledTimes(1);
+    expect(closeOuter).not.toHaveBeenCalled();
+    expect(probe.interrupts).toEqual([]);
+
+    disposeInner(); // inner dialog closed; outer is now topmost
+    pressEscape();
+    expect(closeOuter).toHaveBeenCalledTimes(1);
+    expect(probe.interrupts).toEqual([]);
+  });
+});

--- a/packages/app/src/keyboard/escape-dismiss-stack.test.ts
+++ b/packages/app/src/keyboard/escape-dismiss-stack.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  hasEscapeDismissHandler,
+  pushEscapeDismissHandler,
+  runTopEscapeDismissHandler,
+} from "./escape-dismiss-stack";
+
+// The module is a process-wide singleton. Drain whatever a test leaves behind so
+// cases stay order-independent.
+const cleanups: Array<() => void> = [];
+
+function push(handler: () => void): () => void {
+  const dispose = pushEscapeDismissHandler(handler);
+  cleanups.push(dispose);
+  return dispose;
+}
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+describe("escape-dismiss-stack", () => {
+  it("reports no handler and runs nothing when empty", () => {
+    expect(hasEscapeDismissHandler()).toBe(false);
+    expect(runTopEscapeDismissHandler()).toBe(false);
+  });
+
+  it("runs the most recently pushed handler", () => {
+    const calls: string[] = [];
+    push(() => calls.push("first"));
+    push(() => calls.push("second"));
+
+    expect(hasEscapeDismissHandler()).toBe(true);
+    expect(runTopEscapeDismissHandler()).toBe(true);
+    expect(calls).toEqual(["second"]);
+  });
+
+  it("stops reporting a handler once its disposer runs", () => {
+    const dispose = push(() => undefined);
+    expect(hasEscapeDismissHandler()).toBe(true);
+
+    dispose();
+    expect(hasEscapeDismissHandler()).toBe(false);
+    expect(runTopEscapeDismissHandler()).toBe(false);
+  });
+
+  it("removes only the disposed handler and runs the new top", () => {
+    const calls: string[] = [];
+    const disposeFirst = push(() => calls.push("first"));
+    push(() => calls.push("second"));
+
+    disposeFirst();
+    expect(hasEscapeDismissHandler()).toBe(true);
+    expect(runTopEscapeDismissHandler()).toBe(true);
+    expect(calls).toEqual(["second"]);
+  });
+
+  it("falls back to the previous handler after the top is disposed", () => {
+    const calls: string[] = [];
+    push(() => calls.push("first"));
+    const disposeSecond = push(() => calls.push("second"));
+
+    disposeSecond();
+    expect(runTopEscapeDismissHandler()).toBe(true);
+    expect(calls).toEqual(["first"]);
+  });
+});

--- a/packages/app/src/keyboard/escape-dismiss-stack.ts
+++ b/packages/app/src/keyboard/escape-dismiss-stack.ts
@@ -1,0 +1,76 @@
+// A stack of dismissible web overlays (dialogs, sheets, popovers) that claim the
+// Escape key. It carries two responsibilities:
+//
+//   1. Run the topmost overlay's close handler when Escape is pressed. This
+//      module owns the window keydown listener, so overlays still close on
+//      Escape even on routes where the global keyboard-shortcut dispatcher is
+//      disabled.
+//   2. Expose `hasEscapeDismissHandler()` so the dispatcher can suppress the
+//      Escape-bound `agent.interrupt` shortcut while an overlay is open.
+//
+// Without (2), cancelling a dialog with Escape also interrupts a running agent:
+// the dispatcher's capture-phase window listener registers first (at app mount)
+// and routes `agent.interrupt` before this listener — registered later, when the
+// overlay opens — gets to close the overlay. `stopPropagation` cannot prevent
+// that because both listeners sit on the same target (window) in the same phase.
+//
+// The stack core is pure and DOM-free; the window listener is a thin adapter
+// guarded by `typeof window`, so the LIFO behaviour is exercised in plain Node.
+//
+// Scope: this stack serves overlays that keep focus outside themselves — the
+// composer autocomplete popover (the text input must stay focused), the inline
+// review-comment editor, the attachment lightbox. Layered overlays that trap
+// focus (dialogs, dropdowns, comboboxes) register with `useWebOverlayRegistration`
+// in `@/lib/overlay-root` instead; the dispatcher gate reads both via
+// `hasOpenWebOverlay() || hasEscapeDismissHandler()`.
+
+type EscapeDismissHandler = () => void;
+
+const handlers: EscapeDismissHandler[] = [];
+let listenerAttached = false;
+
+/** Run the topmost overlay's close handler. Returns false if none are open. */
+export function runTopEscapeDismissHandler(): boolean {
+  const handler = handlers[handlers.length - 1];
+  if (!handler) return false;
+  handler();
+  return true;
+}
+
+/** True while at least one dismissible overlay is open. */
+export function hasEscapeDismissHandler(): boolean {
+  return handlers.length > 0;
+}
+
+function handleEscapeKeyDown(event: KeyboardEvent) {
+  if (event.key !== "Escape") return;
+  if (!runTopEscapeDismissHandler()) return;
+  // The overlay owns this Escape — keep it from reaching the terminal or any
+  // bubble-phase handler now that the topmost overlay has handled it.
+  event.stopPropagation();
+  event.preventDefault();
+}
+
+/**
+ * Register `handler` as the close action for a newly opened overlay. The returned
+ * disposer removes it again; call it when the overlay closes/unmounts.
+ */
+export function pushEscapeDismissHandler(handler: EscapeDismissHandler): () => void {
+  // All callers register only from web overlays (e.g. AdaptiveModalSheet gates on
+  // `isWeb`), so `window` always exists here and the invariant "stack non-empty ⇒
+  // listener attached" holds. If a non-browser caller is ever added, the handler
+  // would sit on the stack with no listener until a later browser-side push.
+  handlers.push(handler);
+  if (!listenerAttached && typeof window !== "undefined") {
+    window.addEventListener("keydown", handleEscapeKeyDown, true);
+    listenerAttached = true;
+  }
+  return () => {
+    const index = handlers.lastIndexOf(handler);
+    if (index !== -1) handlers.splice(index, 1);
+    if (handlers.length === 0 && listenerAttached && typeof window !== "undefined") {
+      window.removeEventListener("keydown", handleEscapeKeyDown, true);
+      listenerAttached = false;
+    }
+  };
+}

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -32,6 +32,7 @@ function shortcutContext(
     isDesktop: false,
     focusScope: "other",
     commandCenterOpen: false,
+    overlayOpen: false,
     ...overrides,
   };
 }
@@ -496,6 +497,11 @@ describe("keyboard-shortcuts", () => {
       name: "does not interrupt agent when command center is open",
       event: { key: "Escape", code: "Escape" },
       context: { commandCenterOpen: true },
+    },
+    {
+      name: "does not interrupt agent when a dismissible overlay is open",
+      event: { key: "Escape", code: "Escape" },
+      context: { focusScope: "message-input", overlayOpen: true },
     },
     {
       name: "does not bind pane shortcuts on non-mac platforms",

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -17,6 +17,12 @@ export interface KeyboardShortcutContext {
   isDesktop: boolean;
   focusScope: KeyboardFocusScope;
   commandCenterOpen: boolean;
+  /**
+   * A dismissible overlay (dialog/sheet/popover) is open and owns Escape.
+   * Optional: callers that never open overlays (e.g. browser-shortcut policy)
+   * can omit it, and `undefined` reads as "no overlay open".
+   */
+  overlayOpen?: boolean;
 }
 
 export interface KeyboardShortcutInput {
@@ -72,6 +78,8 @@ interface ShortcutWhen {
   terminal?: false;
   /** false = disabled when command center is open */
   commandCenter?: false;
+  /** false = disabled when a dismissible overlay (dialog/sheet/popover) is open */
+  overlay?: false;
   /** Exact focus scope match */
   focusScope?: KeyboardFocusScope;
 }
@@ -1028,7 +1036,9 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
     id: "agent-interrupt",
     action: "agent.interrupt",
     combo: "Escape",
-    when: { commandCenter: false, terminal: false },
+    // `overlay: false` keeps Escape from interrupting the agent while a dialog
+    // is open — Escape belongs to the topmost overlay, which closes itself.
+    when: { commandCenter: false, terminal: false, overlay: false },
     preventDefault: false,
     stopPropagation: false,
     help: {
@@ -1171,6 +1181,7 @@ export function matchesKeyboardShortcutContext(
   }
   if (when.terminal === false && context.focusScope === "terminal") return false;
   if (when.commandCenter === false && context.commandCenterOpen) return false;
+  if (when.overlay === false && context.overlayOpen) return false;
   if (when.focusScope !== undefined && context.focusScope !== when.focusScope) return false;
   return true;
 }

--- a/packages/app/src/lib/overlay-root.test.tsx
+++ b/packages/app/src/lib/overlay-root.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { hasOpenWebOverlay, useWebOverlayRegistration } from "./overlay-root";
+
+// Regression for the Escape-interrupt fix. Focus-trapping overlays (dialogs,
+// dropdowns, comboboxes) register here, and the keyboard dispatcher reads
+// `hasOpenWebOverlay()` to stand down from the Escape-bound `agent.interrupt`
+// while one of them owns Escape. If registration stops flipping this query,
+// cancelling a dialog with Escape silently interrupts the running agent again.
+describe("hasOpenWebOverlay", () => {
+  function renderOverlay(active: boolean) {
+    return renderHook(
+      ({ active: isActive }: { active: boolean }) => {
+        const setScope = useWebOverlayRegistration({
+          active: isActive,
+          layer: 20,
+          onKeyDown: () => false,
+        });
+        return setScope;
+      },
+      { initialProps: { active } },
+    );
+  }
+
+  it("reports no overlay before anything registers", () => {
+    expect(hasOpenWebOverlay()).toBe(false);
+  });
+
+  it("stays closed while active but without a focus scope", () => {
+    const { result, unmount } = renderOverlay(true);
+    void result.current;
+    expect(hasOpenWebOverlay()).toBe(false);
+    unmount();
+  });
+
+  it("opens once an active overlay attaches its scope, and closes on unmount", () => {
+    const { result, unmount } = renderOverlay(true);
+    result.current(document.createElement("div"));
+    expect(hasOpenWebOverlay()).toBe(true);
+
+    unmount();
+    expect(hasOpenWebOverlay()).toBe(false);
+  });
+
+  it("closes when the overlay goes inactive without unmounting", () => {
+    const { result, rerender, unmount } = renderOverlay(true);
+    result.current(document.createElement("div"));
+    expect(hasOpenWebOverlay()).toBe(true);
+
+    rerender({ active: false });
+    expect(hasOpenWebOverlay()).toBe(false);
+    unmount();
+  });
+});

--- a/packages/app/src/lib/overlay-root.ts
+++ b/packages/app/src/lib/overlay-root.ts
@@ -89,6 +89,15 @@ let webOverlayOrder = 0;
 let webOverlayListenersAttached = false;
 let webOverlayFocusCheckQueued = false;
 
+/**
+ * True while a registered web overlay is open. Only the topmost overlay receives
+ * keyboard input, so global shortcuts that a closing overlay would also consume
+ * (Escape) must stand down while this is true.
+ */
+export function hasOpenWebOverlay(): boolean {
+  return webOverlayEntries.length > 0;
+}
+
 function getTopWebOverlay(): WebOverlayEntry | undefined {
   return webOverlayEntries.reduce<WebOverlayEntry | undefined>((top, entry) => {
     if (!top) return entry;

--- a/packages/app/src/review/surface.test.tsx
+++ b/packages/app/src/review/surface.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { useReviewDraftStore, type ReviewDraftComment } from "./store";
 import { buildReviewableDiffTargetKey, type ReviewableDiffTarget } from "@/utils/diff-layout";
+import { hasEscapeDismissHandler } from "@/keyboard/escape-dismiss-stack";
 import {
   getInlineReviewThreadState,
   getInlineReviewThreadViewportStyle,
@@ -410,6 +411,39 @@ describe("InlineReviewEditor", () => {
 
     fireEvent.keyDown(input, { key: "Enter", metaKey: true });
     expect(onSave).toHaveBeenCalledWith("ready");
+  });
+
+  // Regression: the editor must own Escape only while focused. A blurred or
+  // background editor that keeps Escape would swallow the agent-interrupt
+  // shortcut and cancel the wrong comment. See escape-dismiss-stack.
+  it("owns Escape only while focused, releasing it on blur", () => {
+    const onCancel = vi.fn();
+    const { getByTestId } = render(
+      <InlineReviewEditor
+        initialBody="ready"
+        onCancel={onCancel}
+        onSave={vi.fn()}
+        testID="editor"
+      />,
+    );
+    const input = getByTestId("editor-input");
+
+    // Blurred: not registered with the shared stack, so Escape is NOT swallowed
+    // (it stays available for the agent-interrupt shortcut).
+    fireEvent.blur(input);
+    expect(hasEscapeDismissHandler()).toBe(false);
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+
+    // Focused: registered, so Escape cancels this editor.
+    fireEvent.focus(input);
+    expect(hasEscapeDismissHandler()).toBe(true);
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    // Blur again releases ownership.
+    fireEvent.blur(input);
+    expect(hasEscapeDismissHandler()).toBe(false);
   });
 
   it("shows shared shortcut hints while focused on a fine-pointer screen", () => {

--- a/packages/app/src/review/surface.tsx
+++ b/packages/app/src/review/surface.tsx
@@ -16,6 +16,7 @@ import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { Button } from "@/components/ui/button";
 import { Shortcut } from "@/components/ui/shortcut";
 import { isWeb } from "@/constants/platform";
+import { pushEscapeDismissHandler } from "@/keyboard/escape-dismiss-stack";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import type { Theme } from "@/styles/theme";
 import type { ShortcutKey } from "@/utils/format-shortcut";
@@ -544,6 +545,16 @@ export function InlineReviewEditor({
     inputRef.current?.focus();
   }, []);
 
+  // Own Escape via the shared stack only while the editor is focused: cancels the
+  // comment and flips hasEscapeDismissHandler() so the global dispatcher suppresses
+  // agent.interrupt. Gating on focus (not just mount) keeps a blurred or
+  // background editor from swallowing Escape meant to interrupt the agent, and
+  // scopes ownership to the active editor when several are mounted.
+  useEffect(() => {
+    if (!isWeb || !isFocused) return;
+    return pushEscapeDismissHandler(onCancel);
+  }, [isFocused, onCancel]);
+
   const handleFocus = useCallback(() => {
     focus.unfocus();
     setIsFocused(true);
@@ -568,14 +579,9 @@ export function InlineReviewEditor({
       return;
     }
 
+    // Escape is owned by the shared escape-dismiss stack (effect above); this
+    // listener only handles Cmd/Ctrl+Enter to save.
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        event.stopPropagation();
-        onCancel();
-        return;
-      }
-
       if (event.key !== "Enter" || event.shiftKey) {
         return;
       }
@@ -594,7 +600,7 @@ export function InlineReviewEditor({
     return () => {
       element.removeEventListener("keydown", handleKeyDown);
     };
-  }, [canSave, handleSave, onCancel]);
+  }, [canSave, handleSave]);
 
   const inputStyle = useMemo<StyleProp<TextStyle>>(
     () => [styles.editorInput, isFocused && styles.editorInputFocused],


### PR DESCRIPTION
### Linked issue

Closes #1705

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

### What does this PR do

Pressing Escape to cancel an overlay also fires `agent.interrupt`, stopping a
running agent. Repro from the issue: sidebar → workspace ⋯ menu → Rename
workspace → Escape. The dialog closes *and* the agent stops.

Root cause is listener registration order, not propagation. The global shortcut
dispatcher (`use-keyboard-shortcuts`) and the overlay key handling in
`lib/overlay-root` are both **capture-phase listeners on `window`**. Same-target
listeners in the same phase fire in registration order, and the dispatcher
registers at app mount — before any overlay exists. So the dispatcher routes
Escape to `agent.interrupt` first; the overlay's `stopImmediatePropagation` runs
too late to prevent it, and `stopPropagation` could never have helped.

The fix makes the interrupt *not match* while an overlay owns Escape, so it does
not depend on listener order at all:

- `ShortcutWhen` gains `overlay?: false`, `KeyboardShortcutContext` gains an
  optional `overlayOpen`, and the `agent-interrupt` binding declares
  `overlay: false`. One resolver check, no new branching in the dispatcher.
- `lib/overlay-root` exports `hasOpenWebOverlay()`. This covers everything already
  registered with `useWebOverlayRegistration` — `AdaptiveModalSheet` (so every
  dialog, including the one in the issue), dropdown menus, comboboxes, the
  command center, the project flow, the host chooser — with no changes to those
  components.
- New `keyboard/escape-dismiss-stack.ts` (LIFO, owns one lazily-attached window
  listener) covers the three Escape-dismissible surfaces that deliberately do
  *not* trap focus and therefore can't use the overlay registry: the composer
  autocomplete popover (the text input must keep focus), the inline
  review-comment editor, and the attachment lightbox. Each had its own ad-hoc
  Escape listener that lost the same race; they now share one seam.

The dispatcher reads `hasOpenWebOverlay() || hasEscapeDismissHandler()`.

Two details worth a reviewer's attention:

- **The inline review editor now owns Escape only while focused**, not while
  mounted. Several editors can be mounted at once, and a blurred one used to
  swallow Escape meant for the agent.
- **Behaviour change in the composer autocomplete.** Escape previously did
  nothing to the popover (it only interrupted the agent) except for a
  start-position `/command`, where `onEscape` cleared the whole input. Now Escape
  dismisses the popover and leaves the text alone; typing re-opens it. That
  removes the input-clearing path. I think dismiss-without-clearing is the
  expected behaviour, but it is a UX call rather than a bug fix — happy to split
  it into a follow-up PR and keep this one purely about the interrupt leak.

Out of scope: whether the newer project-picker flow (`open-project-screen`)
has the same leak — noted on #1705, not verified here.

### How did you verify it

**Automated** — added and run:

- `e2e/escape-overlay-agent-interrupt.spec.ts` — Playwright, drives the reported
  path through the real app against a streaming mock agent: sidebar → workspace
  ⋯ menu → Rename workspace → Escape, asserting the agent is still streaming
  after closing each overlay. The last step is a positive control — with nothing
  open, Escape must still interrupt — so a gate that over-suppresses fails too.
  Confirmed it catches the bug: reverting `overlay: false` on the
  `agent-interrupt` binding fails the spec on the first Escape with the stop
  button gone (and the stream cut short, 6 assistant messages vs 26).
- `keyboard/escape-dismiss-stack.browser.test.ts` — real-Chromium reproduction.
  It installs a dispatcher probe as a window capture listener *registered before*
  any overlay (mirroring app mount order) and dispatches a real Escape event.
  Covers: overlay open → closes, no `agent.interrupt`, `defaultPrevented`;
  overlay disposed → interrupt fires again; nested overlays → only the topmost
  closes.
- `lib/overlay-root.test.tsx` — registration flips `hasOpenWebOverlay()`, and it
  clears on both unmount and going inactive. This is the assertion the dialog in
  the issue depends on.
- `keyboard/escape-dismiss-stack.test.ts` — pure LIFO core, no DOM.
- `review/surface.test.tsx` — the review editor owns Escape only while focused
  and releases it on blur.
- `hooks/use-agent-autocomplete.test.tsx` — `dismiss()` hides the popover without
  touching the input, and new input re-opens it.
  path through the real app against a streaming mock agent: sidebar → workspace
  ⋯ menu → Rename workspace → Escape, asserting the agent is still streaming
  after closing each overlay. The last step is a positive control — with nothing
  open, Escape must still interrupt — so a gate that over-suppresses fails too.
  Confirmed it catches the bug: reverting `overlay: false` on the
  `agent-interrupt` binding fails the spec on the first Escape with the stop
  button gone (and the stream cut short, 6 assistant messages vs 26).

98 unit tests and 3 browser tests pass in `packages/app`; `npm run typecheck`,
`npm run lint`, and `npm run format:check` are clean.

**Manual**

https://github.com/user-attachments/assets/a139f74a-c664-428b-945f-b18b4e4dab09


### Checklist

- [x] The PR is focused on a single change
- [x] `npm run typecheck`, `npm run lint`, and `npm run format:check` pass
- [x] Tests cover the fix
- [x] Linked issue
- [x] Screenshots/video for every affected platform
