### PR TITLE
fix(server): disable unsupported summaries for Codex Spark

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -112,7 +112,11 @@ function createConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSession
 
 function createSession(
   configOverrides: Partial<AgentSessionConfig> = {},
-  options: { goalsEnabled?: boolean; autoReviewEnabled?: boolean } = {},
+  options: {
+    goalsEnabled?: boolean;
+    autoReviewEnabled?: boolean;
+    customProvider?: { id: string; label: string; extends: string };
+  } = {},
 ): CodexTestSession {
   const session = new CodexAppServerAgentSession(
     createConfig(configOverrides),
@@ -121,7 +125,7 @@ function createSession(
     () => {
       throw new Error("Test session cannot spawn Codex app-server");
     },
-    {},
+    options.customProvider ? { customProvider: options.customProvider } : {},
     false,
     options.goalsEnabled === true,
     options.autoReviewEnabled === true,
@@ -1986,6 +1990,49 @@ describe("Codex app-server provider", () => {
     expect(turnStart?.[1]).toEqual(
       expect.objectContaining({
         summary: "none",
+      }),
+    );
+  });
+
+  test("preserves reasoning summaries for a custom Codex-derived Spark provider", async () => {
+    const session = createSession(
+      {
+        model: "gpt-5.3-codex-spark",
+        thinkingOptionId: "medium",
+        extra: { codex: { model_reasoning_summary: "concise" } },
+      },
+      {
+        customProvider: {
+          id: "custom-codex",
+          label: "Custom Codex",
+          extends: "codex",
+        },
+      },
+    );
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") return { thread: { id: "custom-spark-thread" } };
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    session.currentThreadId = null;
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({ request });
+
+    await session.startTurn("Use custom Spark");
+
+    const threadStart = request.mock.calls.find(([method]) => method === "thread/start");
+    expect(threadStart?.[1]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          model_reasoning_summary: "concise",
+        }),
+      }),
+    );
+    const turnStart = request.mock.calls.find(([method]) => method === "turn/start");
+    expect(turnStart?.[1]).not.toEqual(
+      expect.objectContaining({
+        summary: expect.anything(),
       }),
     );
   });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -1956,6 +1956,132 @@ describe("Codex app-server provider", () => {
     );
   });
 
+  test("disables reasoning summaries when starting a built-in Spark thread", async () => {
+    const session = createSession({
+      model: "gpt-5.3-codex-spark",
+      thinkingOptionId: "medium",
+      extra: { codex: { model_reasoning_summary: "concise" } },
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") return { thread: { id: "spark-thread" } };
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    session.currentThreadId = null;
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({ request });
+
+    await session.startTurn("Use Spark");
+
+    const threadStart = request.mock.calls.find(([method]) => method === "thread/start");
+    expect(threadStart?.[1]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          model_reasoning_summary: "none",
+        }),
+      }),
+    );
+    const turnStart = request.mock.calls.find(([method]) => method === "turn/start");
+    expect(turnStart?.[1]).toEqual(
+      expect.objectContaining({
+        summary: "none",
+      }),
+    );
+  });
+
+  test("disables reasoning summaries when resuming a built-in Spark thread", async () => {
+    const session = createSession({
+      model: "gpt-5.3-codex-spark",
+      thinkingOptionId: "medium",
+      extra: { codex: { model_reasoning_summary: "concise" } },
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/loaded/list") return { data: [] };
+      if (method === "thread/resume") return {};
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({ request });
+
+    await session.startTurn("Resume Spark");
+
+    const threadResume = request.mock.calls.find(([method]) => method === "thread/resume");
+    expect(threadResume?.[1]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          model_reasoning_summary: "none",
+        }),
+      }),
+    );
+    const turnStart = request.mock.calls.find(([method]) => method === "turn/start");
+    expect(turnStart?.[1]).toEqual(
+      expect.objectContaining({
+        summary: "none",
+      }),
+    );
+  });
+
+  test("restores configured reasoning summaries when switching away from Spark", async () => {
+    const session = createSession({
+      model: "gpt-5.6-sol",
+      thinkingOptionId: "medium",
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/loaded/list") return { data: ["test-thread"] };
+      if (method === "getUserSavedConfig") return { config: {} };
+      if (method === "config/read") {
+        return { config: { model_reasoning_summary: "concise" } };
+      }
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({ request });
+
+    await session.startTurn("Use Sol");
+    session.activeForegroundTurnId = null;
+    await session.setModel("gpt-5.3-codex-spark");
+    await session.startTurn("Use Spark");
+    session.activeForegroundTurnId = null;
+    await session.setModel("gpt-5.6-terra");
+    await session.startTurn("Use Terra");
+
+    const summaries = request.mock.calls
+      .filter(([method]) => method === "turn/start")
+      .map(([, params]) => (params as Record<string, unknown>).summary);
+    expect(summaries).toEqual(["concise", "none", "concise"]);
+  });
+
+  test("does not invent a reasoning summary when Codex has none configured", async () => {
+    const session = createSession({
+      model: "gpt-5.6-terra",
+      thinkingOptionId: "medium",
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/loaded/list") return { data: ["test-thread"] };
+      if (method === "getUserSavedConfig") return { config: {} };
+      if (method === "config/read") return { config: {} };
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected request: ${method}`);
+    });
+
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({ request });
+
+    await session.startTurn("Use Terra");
+
+    const turnStart = request.mock.calls.find(([method]) => method === "turn/start");
+    expect(turnStart?.[1]).not.toEqual(
+      expect.objectContaining({
+        summary: expect.anything(),
+      }),
+    );
+  });
+
   test("resolves Codex skill slash commands into app-server skill input", async () => {
     const session = createSession();
     const request = vi.fn(async (method: string) => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -148,8 +148,9 @@ function applyCodexModelCompatibilityOverrides(
   config: Record<string, unknown>,
   provider: string,
   model: string | undefined,
+  isCustomProvider: boolean,
 ): void {
-  if (provider === CODEX_PROVIDER && model === CODEX_SPARK_MODEL_ID) {
+  if (!isCustomProvider && provider === CODEX_PROVIDER && model === CODEX_SPARK_MODEL_ID) {
     config.model_reasoning_summary = "none";
   }
 }
@@ -4990,7 +4991,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   }
 
   private async resolveTurnReasoningSummary(): Promise<CodexReasoningSummary | undefined> {
-    if (this.config.provider !== CODEX_PROVIDER) {
+    if (this.config.provider !== CODEX_PROVIDER || this.deps.customProvider) {
       return undefined;
     }
     if (this.config.model === CODEX_SPARK_MODEL_ID) {
@@ -5077,7 +5078,12 @@ export class CodexAppServerAgentSession implements AgentSession {
       innerConfig.mcp_servers = mcpServers;
     }
 const configured = applyCodexToolPolicy(innerConfig, this.config.toolPolicy);
-    applyCodexModelCompatibilityOverrides(configured, this.config.provider, this.config.model);
+    applyCodexModelCompatibilityOverrides(
+      configured,
+      this.config.provider,
+      this.config.model,
+      this.deps.customProvider !== undefined,
+    );
     return Object.keys(configured).length > 0 ? configured : null;
   }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -138,6 +138,22 @@ function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolea
 const TURN_START_TIMEOUT_MS = 90 * 1000;
 const INTERRUPT_TIMEOUT_MS = 2_000;
 const CODEX_PROVIDER = "codex" as const;
+const CODEX_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const CODEX_REASONING_SUMMARIES = new Set(["auto", "concise", "detailed", "none"] as const);
+type CodexReasoningSummary = "auto" | "concise" | "detailed" | "none";
+
+// COMPAT(codexSparkReasoningSummary): added in v0.2.4; remove after 2027-01-30.
+// Codex 0.144.4 sends reasoning.summary, which Spark rejects.
+function applyCodexModelCompatibilityOverrides(
+  config: Record<string, unknown>,
+  provider: string,
+  model: string | undefined,
+): void {
+  if (provider === CODEX_PROVIDER && model === CODEX_SPARK_MODEL_ID) {
+    config.model_reasoning_summary = "none";
+  }
+}
+
 // Codex treats most app-server client names as the model-request originator.
 // This reserved Codex name is non-originating, so requests keep Codex's default
 // CLI identity instead of showing up as Paseo in provider usage logs.
@@ -351,6 +367,12 @@ function normalizeCodexModelId(modelId: string | null | undefined): string | und
   return normalized;
 }
 
+function normalizeCodexReasoningSummary(value: unknown): CodexReasoningSummary | undefined {
+  return typeof value === "string" && CODEX_REASONING_SUMMARIES.has(value as CodexReasoningSummary)
+    ? (value as CodexReasoningSummary)
+    : undefined;
+}
+
 function normalizeCodexModelLabel(displayName: string): string {
   return displayName.replace(/\bgpt\b/gi, "GPT");
 }
@@ -424,6 +446,7 @@ export function normalizeCodexOutputSchema(schema: unknown): Record<string, unkn
 interface CodexConfiguredDefaults {
   model?: string;
   thinkingOptionId?: string;
+  reasoningSummary?: CodexReasoningSummary;
 }
 
 interface PersistedTimelineEntry {
@@ -448,6 +471,7 @@ function mergeCodexConfiguredDefaults(
   return {
     model: primary.model ?? fallback.model,
     thinkingOptionId: primary.thinkingOptionId ?? fallback.thinkingOptionId,
+    reasoningSummary: primary.reasoningSummary ?? fallback.reasoningSummary,
   };
 }
 
@@ -3017,12 +3041,17 @@ async function readCodexConfiguredDefaults(
     savedConfigDefaults = {
       model: normalizeCodexModelId(modelValue),
       thinkingOptionId: normalizeCodexThinkingOptionId(thinkingOptionValue),
+      reasoningSummary: normalizeCodexReasoningSummary(config?.modelReasoningSummary),
     };
   } catch (error) {
     logger.debug({ error }, "Failed to read Codex saved config defaults");
   }
 
-  if (savedConfigDefaults.model && savedConfigDefaults.thinkingOptionId) {
+  if (
+    savedConfigDefaults.model &&
+    savedConfigDefaults.thinkingOptionId &&
+    savedConfigDefaults.reasoningSummary
+  ) {
     return savedConfigDefaults;
   }
 
@@ -3036,6 +3065,7 @@ async function readCodexConfiguredDefaults(
     configReadDefaults = {
       model: normalizeCodexModelId(modelValue),
       thinkingOptionId: normalizeCodexThinkingOptionId(thinkingOptionValue),
+      reasoningSummary: normalizeCodexReasoningSummary(config?.model_reasoning_summary),
     };
   } catch (error) {
     logger.debug({ error }, "Failed to read Codex config defaults");
@@ -3294,6 +3324,7 @@ export class CodexAppServerAgentSession implements AgentSession {
   private connected = false;
   private connectionPromise: Promise<void> | null = null;
   private closed = false;
+  private configuredDefaultsPromise: Promise<CodexConfiguredDefaults> | null = null;
   private collaborationModes: Array<{
     name: string;
     mode?: string | null;
@@ -3942,6 +3973,10 @@ export class CodexAppServerAgentSession implements AgentSession {
     const thinkingOptionId = normalizeCodexThinkingOptionId(this.config.thinkingOptionId);
     if (thinkingOptionId) {
       params.effort = thinkingOptionId;
+    }
+    const reasoningSummary = await this.resolveTurnReasoningSummary();
+    if (reasoningSummary) {
+      params.summary = reasoningSummary;
     }
     if (this.serviceTier) {
       params.serviceTier = this.serviceTier;
@@ -4901,7 +4936,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     let model = this.config.model;
     let thinkingOptionId = normalizeCodexThinkingOptionId(this.config.thinkingOptionId);
     if (!model || !thinkingOptionId) {
-      configuredDefaults = await readCodexConfiguredDefaults(this.client, this.logger);
+      configuredDefaults = await this.getConfiguredDefaults();
     }
     if (!model) {
       model = configuredDefaults.model;
@@ -4944,6 +4979,26 @@ export class CodexAppServerAgentSession implements AgentSession {
       throw new Error("Unable to resolve Codex model");
     }
     return { model, thinkingOptionId };
+  }
+
+  private async getConfiguredDefaults(): Promise<CodexConfiguredDefaults> {
+    if (!this.client) {
+      return {};
+    }
+    this.configuredDefaultsPromise ??= readCodexConfiguredDefaults(this.client, this.logger);
+    return await this.configuredDefaultsPromise;
+  }
+
+  private async resolveTurnReasoningSummary(): Promise<CodexReasoningSummary | undefined> {
+    if (this.config.provider !== CODEX_PROVIDER) {
+      return undefined;
+    }
+    if (this.config.model === CODEX_SPARK_MODEL_ID) {
+      return "none";
+    }
+    const sessionConfig = this.buildCodexInnerConfig();
+    const sessionSummary = normalizeCodexReasoningSummary(sessionConfig?.model_reasoning_summary);
+    return sessionSummary ?? (await this.getConfiguredDefaults()).reasoningSummary;
   }
 
   private async ensureThread(): Promise<void> {
@@ -5021,7 +5076,8 @@ export class CodexAppServerAgentSession implements AgentSession {
       }
       innerConfig.mcp_servers = mcpServers;
     }
-    const configured = applyCodexToolPolicy(innerConfig, this.config.toolPolicy);
+const configured = applyCodexToolPolicy(innerConfig, this.config.toolPolicy);
+    applyCodexModelCompatibilityOverrides(configured, this.config.provider, this.config.model);
     return Object.keys(configured).length > 0 ? configured : null;
   }
 


### PR DESCRIPTION
### Linked issue

Closes #2646

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Codex 0.144.4 applies the global reasoning-summary setting to Spark, but `gpt-5.3-codex-spark` rejects `reasoning.summary` with a 400 `unsupported_parameter` response.

This change scopes the compatibility override to the built-in Codex provider and Spark model:

- `thread/start` and `thread/resume` receive `model_reasoning_summary = "none"`.
- Every Spark `turn/start` uses the protocol-supported `summary: "none"` override.
- Switching away from Spark restores the configured Codex summary value for subsequent turns.
- Custom Codex-derived providers and users with no configured summary are left unchanged.

The per-turn override matters for already-loaded threads: `turn/start.config` is not part of the Codex app-server protocol, while `turn/start.summary` is.

### How did you verify it

Automated coverage in `codex-app-server-agent.test.ts` verifies:

- a new Spark thread;
- a resumed Spark thread;
- Sol → Spark → Terra in one existing thread (`concise` → `none` → `concise`);
- a custom Codex-derived provider using the Spark model ID;
- a non-Spark model with no configured summary.

Commands run on the final branch after rebasing onto `origin/main`:

- `npm run build:server`
- `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1` — 119/119 passed
- `npm run typecheck`
- `npm run lint` — 0 warnings, 0 errors
- `npm run format:check`
- `git diff --check origin/main...HEAD`

Real provider verification:

1. Ran the patched daemon with Codex CLI 0.144.4 and `model_reasoning_summary = "concise"`.
2. Created a real `codex/gpt-5.3-codex-spark` agent through Paseo with low thinking and auto-review mode.
3. Sent `Reply with exactly SPARK_OK. Do not use tools.`
4. The agent completed with `SPARK_OK`; the daemon log contained no `unsupported_parameter` or `reasoning.summary` failure for that agent.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [x] UI evidence is not applicable (server-only fix)
- [x] Tests added or updated where it made sense
