### PR TITLE
fix(nix): keep docs and CI out of the derivation sources

### DIFF
--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -33,6 +33,21 @@ buildNpmPackage rec {
       && !(lib.hasPrefix "/packages/app/ios" relPath)
       # Website is unrelated to the desktop app
       && !(lib.hasPrefix "/packages/website" relPath)
+      # Documentation, CI definitions and agent/editor configuration. None of
+      # these reach the build, but every one of them is part of `src`, so a
+      # docs-only or workflow-only commit currently invalidates the whole
+      # desktop derivation and pays for a full Expo export to produce a
+      # byte-identical result.
+      && !(lib.hasPrefix "/docs" relPath)
+      && !(lib.hasPrefix "/.github" relPath)
+      && !(lib.hasPrefix "/.agents" relPath)
+      && !(lib.hasPrefix "/.claude" relPath)
+      && !(lib.hasPrefix "/.codex" relPath)
+      && !(lib.hasPrefix "/docker" relPath)
+      # Top-level prose only (README, CHANGELOG, AGENTS...). Deeper markdown is
+      # not necessarily documentation: skills/*/SKILL.md is a runtime file the
+      # installPhase copies into the output.
+      && builtins.match "/[^/]+\\.md" relPath == null
       # Test fixtures and build artifacts
       && !(lib.hasSuffix ".test.ts" baseName)
       && !(lib.hasSuffix ".e2e.test.ts" baseName)

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -37,6 +37,21 @@ buildNpmPackage rec {
       && !(lib.hasPrefix "/packages/website/public" relPath)
       && !(lib.hasPrefix "/packages/desktop/src" relPath)
       && !(lib.hasPrefix "/packages/desktop/src-tauri" relPath)
+      # Documentation, CI definitions and agent/editor configuration. None of
+      # these reach the build. Excluding them here also matters for the desktop
+      # derivation, which inherits this package's npmDeps: leaving them in makes
+      # a docs-only commit produce a new npm-deps .drv, and so a new desktop
+      # .drv, and so a full rebuild for a byte-identical result.
+      && !(lib.hasPrefix "/docs" relPath)
+      && !(lib.hasPrefix "/.github" relPath)
+      && !(lib.hasPrefix "/.agents" relPath)
+      && !(lib.hasPrefix "/.claude" relPath)
+      && !(lib.hasPrefix "/.codex" relPath)
+      && !(lib.hasPrefix "/docker" relPath)
+      # Top-level prose only (README, CHANGELOG, AGENTS...). Deeper markdown is
+      # not necessarily documentation: skills/*/SKILL.md is a runtime file the
+      # daemon's trace script copies into the output.
+      && builtins.match "/[^/]+\\.md" relPath == null
       # Exclude test fixtures and debug files
       && !(lib.hasSuffix ".test.ts" baseName)
       && !(lib.hasSuffix ".e2e.test.ts" baseName)


### PR DESCRIPTION
## Problem

`nix/package.nix` and `nix/desktop-package.nix` both take the whole repository
as `src` and exclude only a handful of paths. That leaves `docs/`, `.github/`,
`docker/`, the agent/editor config directories and the top-level markdown as
build inputs of both derivations.

None of them reach the build, but any one of them changing produces a new
derivation and therefore a full rebuild — including the Expo web export, which
dominates the build — to arrive at a byte-identical result. A docs-only or
workflow-only commit currently costs a complete desktop rebuild.

## The npmDeps coupling

Tightening the desktop filter alone does nothing, which is worth spelling out:
`desktop-package.nix` inherits `npmDeps` from the daemon, so the daemon's `src`
feeds the desktop derivation too. With only the desktop filter changed, a
docs-only edit still produced a new `npm-deps` derivation, hence a new desktop
derivation, hence a full rebuild. Both filters have to move together.

## Markdown scope

Markdown is excluded at the top level only (`README`, `CHANGELOG`, `AGENTS`...).
`skills/*/SKILL.md` is a runtime file both derivations copy into their output,
so a repository-wide `*.md` exclusion would silently ship empty skill
directories — the derivation hash test would not have caught that.

## Verification

- `nix eval .#desktop.drvPath` and `.#paseo.drvPath` are now unchanged across
  edits to `docs/`, `.github/workflows/`, `docker/` and `README.md`; before this
  change both paths moved.
- `nix build .#desktop` succeeds, and the output still contains all 5
  `skills/*/SKILL.md` files, with no `docs/` or `.github/` in the result.