### PR TITLE
Restore a workspace's agents when the workspace is unarchived

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -105,9 +105,19 @@ archived workspace. History navigation must not infer workspace lifecycle from `
 or mutate either lifecycle. The workspace route asks the daemon for authoritative recovery state;
 only the route's explicit Unarchive or Restore action changes the archived workspace.
 
+**Workspace unarchive restores the workspace's agents.** Archiving a workspace archives every agent
+that belongs to it (`archiveWorkspaceContents`), and each agent taken from unarchived to archived by
+that gesture is stamped with `archivedWithWorkspaceId` on its stored record. The stamp is
+storage-only — it never crosses the wire. Unarchiving the workspace
+(`unarchiveWorkspaceContents`) restores exactly the stamped agents — running each one's
+provider-native unarchive hook and clearing the stamp — so the workspace comes back with the threads
+it had when it was archived. Agents the user archived individually before the workspace archive
+carry no stamp and stay archived; they remain recoverable from History. Unarchiving an agent
+individually also clears its stamp, so a later workspace restore leaves it alone.
+
 History navigation preserves the selected agent as an explicit recovery target. If both that agent
-and its workspace are archived, the workspace recovery action restores the workspace and unarchives
-the selected agent as one user action. Other archived agents in the restored workspace remain
+and its workspace are archived, the workspace recovery action restores the workspace along with the
+agents stamped by its archive gesture. Individually-archived agents in the restored workspace remain
 recoverable from History. Opening one pins its tab and renders the archived-agent callout. Authoritative
 timeline catch-up may load provider history with a runtime-only `history` resume purpose, which must
 leave both Paseo's `archivedAt` and the provider's native archive state unchanged. **Unarchive** remains

--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -119,12 +119,13 @@ History navigation preserves the selected agent as an explicit recovery target. 
 and its workspace are archived, the workspace recovery action restores the workspace along with the
 agents stamped by its archive gesture. Individually-archived agents in the restored workspace remain
 recoverable from History. Opening one pins its tab and renders the archived-agent callout. Authoritative
-timeline catch-up may load provider history with a runtime-only `history` resume purpose, which must
-leave both Paseo's `archivedAt` and the provider's native archive state unchanged. **Unarchive** remains
-the only transition back to an interactive runtime: it runs the provider's native unarchive hook
-(including Codex `thread/unarchive`) before the normal agent resume and timeline hydration flow. A
-provider session can be archived outside Paseo while its Paseo agent remains active. Interactive
-resume repairs that drift through the provider's native unarchive hook; history resume does not.
+timeline catch-up restores its conversation read-only. It may load provider history with a runtime-only
+`history` resume purpose, which must leave both Paseo's `archivedAt` and the provider's native archive
+state unchanged. **Unarchive** remains the only transition back to an interactive runtime: it runs the
+provider's native unarchive hook (including Codex `thread/unarchive`) before the normal agent resume and
+timeline hydration flow. A provider session can be archived outside Paseo while its Paseo agent remains
+active. Interactive resume repairs that drift through the provider's native unarchive hook; history
+resume does not.
 
 Provider session connection owns every process it spawns until the session is registered with
 `AgentManager`. If initialization, persisted-session resume, or initial history hydration fails,

--- a/packages/app/e2e/browser/archived-codex-agent.real.spec.ts
+++ b/packages/app/e2e/browser/archived-codex-agent.real.spec.ts
@@ -14,13 +14,6 @@ import type { SeedDaemonClient } from "../support/helpers/seed-client";
 import { getServerId } from "../support/helpers/server-id";
 import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
 
-interface TimelineClient extends SeedDaemonClient {
-  fetchAgentTimeline(
-    agentId: string,
-    options: { direction: "tail"; projection: "projected"; limit: number },
-  ): Promise<unknown>;
-}
-
 const INITIAL_PROMPT = "Reply with exactly CODEX_ARCHIVE_TIMELINE_SENTINEL and nothing else.";
 const INITIAL_REPLY = "CODEX_ARCHIVE_TIMELINE_SENTINEL";
 const FOLLOW_UP_PROMPT = "Reply with exactly CODEX_UNARCHIVED_SENTINEL and nothing else.";
@@ -34,7 +27,7 @@ async function historyContainsAgent(client: SeedDaemonClient, agentId: string): 
 test.describe("archived Codex agent recovery", () => {
   test.setTimeout(600_000);
 
-  test("cold-opens without provider history, then unarchives and restores the conversation", async ({
+  test("cold-opens with its conversation, then unarchives and continues the thread", async ({
     page,
   }) => {
     const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "paseo-archived-codex-")));
@@ -63,14 +56,6 @@ test.describe("archived Codex agent recovery", () => {
         )
         .not.toBeNull();
 
-      const timelineClient = handle.client as TimelineClient;
-      await expect(
-        timelineClient.fetchAgentTimeline(handle.agentId, {
-          direction: "tail",
-          projection: "projected",
-          limit: 100,
-        }),
-      ).rejects.toThrow(/archiv/i);
       await expect
         .poll(async () => (handle ? historyContainsAgent(handle.client, handle.agentId) : false), {
           timeout: 30_000,
@@ -90,7 +75,10 @@ test.describe("archived Codex agent recovery", () => {
       });
       await expect(page.getByTestId("agent-load-error")).toHaveCount(0);
       await expect(page.getByTestId("agent-timeline-sync-error")).toHaveCount(0);
-      await expect(page.getByTestId("user-message")).toHaveCount(0);
+      await assertChatTranscript(handle, [
+        { role: "user", text: INITIAL_PROMPT },
+        { role: "assistant", text: INITIAL_REPLY },
+      ]);
 
       await page.getByRole("button", { name: "Unarchive" }).click();
       await expect(page.getByRole("button", { name: "Unarchive" })).toHaveCount(0, {

--- a/packages/app/e2e/browser/worktree-restore.spec.ts
+++ b/packages/app/e2e/browser/worktree-restore.spec.ts
@@ -265,9 +265,7 @@ test.describe("Worktree restore", () => {
     ).toHaveText(switchedBranch, { timeout: 30_000 });
   });
 
-  test("recovers the selected agent with its workspace and later rescues another archived agent", async ({
-    page,
-  }) => {
+  test("recovers every agent that was archived with the workspace", async ({ page }) => {
     const { agents, worktree } = await createArchivedMissingWorktree("restore-agents", {
       agentCount: 2,
       keepAgentsArchived: true,
@@ -299,18 +297,19 @@ test.describe("Worktree restore", () => {
       timeout: 30_000,
     });
 
+    // Restoring the workspace restores the agents the archive took with it, so the
+    // second agent comes back without a separate Unarchive step.
+    await expect
+      .poll(() => fetchAgentArchivedAt(client, secondAgent.id), { timeout: 30_000 })
+      .toBeNull();
     await openSessions(page);
     await page.getByTestId(`agent-row-${getServerId()}-${secondAgent.id}`).click();
     await expect(
       page.getByTestId(`workspace-tab-agent_${secondAgent.id}`).filter({ visible: true }).first(),
     ).toBeVisible({ timeout: 30_000 });
-    await expect(page.getByRole("button", { name: "Unarchive" })).toBeVisible({
+    await expect(page.getByRole("button", { name: "Unarchive" })).toHaveCount(0, {
       timeout: 30_000,
     });
-    await page.getByRole("button", { name: "Unarchive" }).click();
-    await expect
-      .poll(() => fetchAgentArchivedAt(client, secondAgent.id), { timeout: 30_000 })
-      .toBeNull();
   });
 
   test("restore failure stays visible and permits a successful retry", async ({ page }) => {

--- a/packages/app/src/hooks/use-agent-screen-state-machine.test.ts
+++ b/packages/app/src/hooks/use-agent-screen-state-machine.test.ts
@@ -422,7 +422,7 @@ describe("deriveAgentScreenViewState", () => {
     expect(result.memory.lastReadyAgent).toBeNull();
   });
 
-  it("renders an archived agent before provider history is initialized", () => {
+  it("keeps an archived agent usable while its provider history is restored", () => {
     const result = deriveAgentScreenViewState({
       input: {
         ...createBaseInput(),
@@ -435,7 +435,7 @@ describe("deriveAgentScreenViewState", () => {
 
     const ready = expectReadyState(result.state);
     expect(ready.agent.id).toBe("agent-1");
-    expect(ready.sync).toEqual({ status: "idle" });
+    expect(ready.sync).toEqual({ status: "catching_up", ui: "overlay" });
   });
 
   it("keeps optimistic create non-blocking while timeline and authoritative history catch up", () => {

--- a/packages/app/src/hooks/use-agent-screen-state-machine.ts
+++ b/packages/app/src/hooks/use-agent-screen-state-machine.ts
@@ -175,9 +175,6 @@ function resolveAgentScreenSync(args: {
   hadInitialSyncFailure: boolean;
 }): AgentScreenReadySyncState {
   const { input, hadInitialSyncFailure } = args;
-  if (input.isArchived) {
-    return { status: "idle" };
-  }
   if (!input.isConnected) {
     return { status: "reconnecting" };
   }

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1078,9 +1078,6 @@ function ChatAgentContent({
     if (!agentId) {
       return;
     }
-    if (agentState.archivedAt) {
-      return;
-    }
     if (agentState.id && hasAppliedAuthoritativeHistory) {
       if (
         missingAgentState.kind === "resolving" ||
@@ -1153,7 +1150,6 @@ function ChatAgentContent({
       });
   }, [
     agentState.id,
-    agentState.archivedAt,
     hasAppliedAuthoritativeHistory,
     agentId,
     client,

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -10471,6 +10471,7 @@ test("onWorkspaceStateMayHaveChanged is not called for running shell tool calls"
   expect(onWorkspaceStateMayHaveChanged).not.toHaveBeenCalled();
 });
 
+// eslint-disable-next-line complexity
 test("workspace archive stamps its agents and workspace unarchive restores exactly those", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-workspace-unarchive-"));
   const storagePath = join(workdir, "agents");
@@ -10493,6 +10494,22 @@ test("workspace archive stamps its agents and workspace unarchive restores exact
     undefined,
     { workspaceId },
   );
+  const crossWorkspaceChild = await manager.createAgent(
+    { provider: "codex", cwd: workdir, title: "Cross-workspace child" },
+    undefined,
+    {
+      workspaceId: "ws-other",
+      labels: { [PARENT_AGENT_ID_LABEL]: agentA.id },
+    },
+  );
+  const crossWorkspaceGrandchild = await manager.createAgent(
+    { provider: "codex", cwd: workdir, title: "Cross-workspace grandchild" },
+    undefined,
+    {
+      workspaceId: "ws-third",
+      labels: { [PARENT_AGENT_ID_LABEL]: crossWorkspaceChild.id },
+    },
+  );
   const individuallyArchived = await manager.createAgent(
     { provider: "codex", cwd: workdir, title: "Archived by hand" },
     undefined,
@@ -10510,7 +10527,7 @@ test("workspace archive stamps its agents and workspace unarchive restores exact
   const individuallyArchivedAt = (await storage.get(individuallyArchived.id))?.archivedAt;
   expect(individuallyArchivedAt).toEqual(expect.any(String));
 
-  await archiveWorkspaceContents(
+  const archivedAgentIds = await archiveWorkspaceContents(
     {
       agentManager: manager,
       agentStorage: storage,
@@ -10520,14 +10537,26 @@ test("workspace archive stamps its agents and workspace unarchive restores exact
     workspaceId,
   );
 
+  // The archive result includes children reached through the recursive cascade,
+  // even when those children belong to another workspace.
+  expect([...archivedAgentIds]).toEqual(
+    expect.arrayContaining([crossWorkspaceChild.id, crossWorkspaceGrandchild.id]),
+  );
+
   const storedA = await storage.get(agentA.id);
   const storedB = await storage.get(agentB.id);
+  const storedChild = await storage.get(crossWorkspaceChild.id);
+  const storedGrandchild = await storage.get(crossWorkspaceGrandchild.id);
   const storedIndividual = await storage.get(individuallyArchived.id);
   const storedOther = await storage.get(otherWorkspaceAgent.id);
   expect(storedA?.archivedAt).toEqual(expect.any(String));
   expect(storedA?.archivedWithWorkspaceId).toBe(workspaceId);
   expect(storedB?.archivedAt).toEqual(expect.any(String));
   expect(storedB?.archivedWithWorkspaceId).toBe(workspaceId);
+  expect(storedChild?.archivedAt).toEqual(expect.any(String));
+  expect(storedChild?.archivedWithWorkspaceId).toBe(workspaceId);
+  expect(storedGrandchild?.archivedAt).toEqual(expect.any(String));
+  expect(storedGrandchild?.archivedWithWorkspaceId).toBe(workspaceId);
   expect(storedIndividual?.archivedAt).toBe(individuallyArchivedAt);
   expect(storedIndividual?.archivedWithWorkspaceId ?? null).toBeNull();
   expect(storedOther?.archivedAt ?? null).toBeNull();
@@ -10553,23 +10582,76 @@ test("workspace archive stamps its agents and workspace unarchive restores exact
   );
   unsubscribe();
 
-  expect(new Set(restored.map((record) => record.id))).toEqual(new Set([agentA.id, agentB.id]));
+  expect(new Set(restored.map((record) => record.id))).toEqual(
+    new Set([agentA.id, agentB.id, crossWorkspaceChild.id, crossWorkspaceGrandchild.id]),
+  );
   const restoredA = await storage.get(agentA.id);
   const restoredB = await storage.get(agentB.id);
+  const restoredChild = await storage.get(crossWorkspaceChild.id);
+  const restoredGrandchild = await storage.get(crossWorkspaceGrandchild.id);
   expect(restoredA?.archivedAt).toBeNull();
   expect(restoredA?.archivedWithWorkspaceId).toBeNull();
   expect(restoredB?.archivedAt).toBeNull();
   expect(restoredB?.archivedWithWorkspaceId).toBeNull();
+  expect(restoredChild?.archivedAt).toBeNull();
+  expect(restoredChild?.archivedWithWorkspaceId).toBeNull();
+  expect(restoredGrandchild?.archivedAt).toBeNull();
+  expect(restoredGrandchild?.archivedWithWorkspaceId).toBeNull();
 
   // The individually archived agent stays where the user put it.
   const untouchedIndividual = await storage.get(individuallyArchived.id);
   expect(untouchedIndividual?.archivedAt).toBe(individuallyArchivedAt);
 
   // Provider-native unarchive ran for exactly the restored agents.
-  expect(client.unarchivedHandles.length - unarchivedNativeCountBefore).toBe(2);
+  expect(client.unarchivedHandles.length - unarchivedNativeCountBefore).toBe(4);
 
   // Restored stored agents are dispatched so connected clients see them return.
   expect(dispatchedAgentIds).toContain(agentA.id);
   expect(dispatchedAgentIds).toContain(agentB.id);
+  expect(dispatchedAgentIds).toContain(crossWorkspaceChild.id);
+  expect(dispatchedAgentIds).toContain(crossWorkspaceGrandchild.id);
   expect(dispatchedAgentIds).not.toContain(individuallyArchived.id);
+});
+
+test("workspace unarchive propagates provider failures so recovery can be retried", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-workspace-unarchive-failure-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const client = new NativeArchiveRecordingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  const workspaceId = "ws-provider-failure";
+  const agent = await manager.createAgent(
+    { provider: "codex", cwd: workdir, title: "Provider failure" },
+    undefined,
+    { workspaceId },
+  );
+  await archiveWorkspaceContents(
+    {
+      agentManager: manager,
+      agentStorage: storage,
+      killTerminalsForWorkspace: async () => {},
+      sessionLogger: logger,
+    },
+    workspaceId,
+  );
+
+  client.unarchiveFailure = new Error("native unarchive failed");
+  await expect(
+    unarchiveWorkspaceContents(
+      {
+        agentManager: manager,
+        agentStorage: storage,
+        sessionLogger: logger,
+      },
+      workspaceId,
+    ),
+  ).rejects.toThrow("native unarchive failed");
+
+  const stillArchived = await storage.get(agent.id);
+  expect(stillArchived?.archivedAt).toEqual(expect.any(String));
+  expect(stillArchived?.archivedWithWorkspaceId).toBe(workspaceId);
 });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -48,6 +48,10 @@ import type {
 } from "./agent-sdk-types.js";
 import type { PaseoToolCatalog } from "./tools/types.js";
 import type { ProviderDefinition } from "./provider-registry.js";
+import {
+  archiveWorkspaceContents,
+  unarchiveWorkspaceContents,
+} from "../workspace-archive-service.js";
 
 const DESKTOP_OPEN_AGENT_TAB_LABEL = getOpenAgentTabLabel("desktop-client");
 const MOBILE_OPEN_AGENT_TAB_LABEL = getOpenAgentTabLabel("mobile-client");
@@ -10465,4 +10469,107 @@ test("onWorkspaceStateMayHaveChanged is not called for running shell tool calls"
   await manager.runAgent(snapshot.id, { text: "merge it" });
 
   expect(onWorkspaceStateMayHaveChanged).not.toHaveBeenCalled();
+});
+
+test("workspace archive stamps its agents and workspace unarchive restores exactly those", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-workspace-unarchive-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const client = new NativeArchiveRecordingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  const workspaceId = "ws-cascade";
+  const agentA = await manager.createAgent(
+    { provider: "codex", cwd: workdir, title: "Cascade A" },
+    undefined,
+    { workspaceId },
+  );
+  const agentB = await manager.createAgent(
+    { provider: "codex", cwd: workdir, title: "Cascade B" },
+    undefined,
+    { workspaceId },
+  );
+  const individuallyArchived = await manager.createAgent(
+    { provider: "codex", cwd: workdir, title: "Archived by hand" },
+    undefined,
+    { workspaceId },
+  );
+  const otherWorkspaceAgent = await manager.createAgent(
+    { provider: "codex", cwd: workdir, title: "Other workspace" },
+    undefined,
+    { workspaceId: "ws-other" },
+  );
+
+  // The user archived this agent before the workspace archive gesture: a later
+  // workspace restore must leave it archived.
+  await manager.archiveAgent(individuallyArchived.id);
+  const individuallyArchivedAt = (await storage.get(individuallyArchived.id))?.archivedAt;
+  expect(individuallyArchivedAt).toEqual(expect.any(String));
+
+  await archiveWorkspaceContents(
+    {
+      agentManager: manager,
+      agentStorage: storage,
+      killTerminalsForWorkspace: async () => {},
+      sessionLogger: logger,
+    },
+    workspaceId,
+  );
+
+  const storedA = await storage.get(agentA.id);
+  const storedB = await storage.get(agentB.id);
+  const storedIndividual = await storage.get(individuallyArchived.id);
+  const storedOther = await storage.get(otherWorkspaceAgent.id);
+  expect(storedA?.archivedAt).toEqual(expect.any(String));
+  expect(storedA?.archivedWithWorkspaceId).toBe(workspaceId);
+  expect(storedB?.archivedAt).toEqual(expect.any(String));
+  expect(storedB?.archivedWithWorkspaceId).toBe(workspaceId);
+  expect(storedIndividual?.archivedAt).toBe(individuallyArchivedAt);
+  expect(storedIndividual?.archivedWithWorkspaceId ?? null).toBeNull();
+  expect(storedOther?.archivedAt ?? null).toBeNull();
+
+  const dispatchedAgentIds: string[] = [];
+  const unsubscribe = manager.subscribe(
+    (event) => {
+      if (event.type === "agent_state") {
+        dispatchedAgentIds.push(event.agent.id);
+      }
+    },
+    { replayState: false },
+  );
+  const unarchivedNativeCountBefore = client.unarchivedHandles.length;
+
+  const restored = await unarchiveWorkspaceContents(
+    {
+      agentManager: manager,
+      agentStorage: storage,
+      sessionLogger: logger,
+    },
+    workspaceId,
+  );
+  unsubscribe();
+
+  expect(new Set(restored.map((record) => record.id))).toEqual(new Set([agentA.id, agentB.id]));
+  const restoredA = await storage.get(agentA.id);
+  const restoredB = await storage.get(agentB.id);
+  expect(restoredA?.archivedAt).toBeNull();
+  expect(restoredA?.archivedWithWorkspaceId).toBeNull();
+  expect(restoredB?.archivedAt).toBeNull();
+  expect(restoredB?.archivedWithWorkspaceId).toBeNull();
+
+  // The individually archived agent stays where the user put it.
+  const untouchedIndividual = await storage.get(individuallyArchived.id);
+  expect(untouchedIndividual?.archivedAt).toBe(individuallyArchivedAt);
+
+  // Provider-native unarchive ran for exactly the restored agents.
+  expect(client.unarchivedHandles.length - unarchivedNativeCountBefore).toBe(2);
+
+  // Restored stored agents are dispatched so connected clients see them return.
+  expect(dispatchedAgentIds).toContain(agentA.id);
+  expect(dispatchedAgentIds).toContain(agentB.id);
+  expect(dispatchedAgentIds).not.toContain(individuallyArchived.id);
 });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -377,10 +377,14 @@ class NativeArchiveRecordingClient extends TestAgentClient {
   readonly unarchivedHandles: AgentPersistenceHandle[] = [];
   readArchivedAtDuringUnarchive: (() => Promise<string | null | undefined>) | null = null;
   archivedAtDuringUnarchive: string | null | undefined;
+  archiveFailure: Error | null = null;
   unarchiveFailure: Error | null = null;
 
   async archiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
     this.archivedHandles.push(handle);
+    if (this.archiveFailure) {
+      throw this.archiveFailure;
+    }
   }
 
   async unarchiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
@@ -7585,6 +7589,39 @@ test("fires onAgentArchived for stored-only snapshot archives", async () => {
 
   await manager.archiveSnapshot(storedOnly.id, new Date().toISOString());
   expect(archivedIds).toEqual([storedOnly.id]);
+});
+
+test("archiveSnapshot keeps the stored record active when required native archive fails", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-native-archive-failure-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const client = new NativeArchiveRecordingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  const agent = await manager.createAgent(
+    {
+      provider: "codex",
+      cwd: workdir,
+      title: "Required native archive target",
+    },
+    undefined,
+    { workspaceId: undefined },
+  );
+  await manager.closeAgent(agent.id);
+  client.archiveFailure = new Error("provider archive failed");
+
+  await expect(
+    manager.archiveSnapshot(agent.id, new Date().toISOString(), {
+      nativeArchiveMode: "required",
+    }),
+  ).rejects.toThrow("provider archive failed");
+
+  expect((await storage.get(agent.id))?.archivedAt).toBeUndefined();
+  expect(client.archivedHandles).toHaveLength(1);
 });
 
 test("unarchiveSnapshot skips native provider unarchive for active records", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -150,6 +150,10 @@ interface TimeoutOptions {
   onLateError?: (error: unknown) => void;
 }
 
+export interface ArchiveSnapshotOptions {
+  nativeArchiveMode: "best-effort" | "required";
+}
+
 function formatProviderList(providers: readonly string[]): string {
   return providers.length > 0 ? providers.join(", ") : "none";
 }
@@ -1981,7 +1985,11 @@ export class AgentManager {
     }
   }
 
-  async archiveSnapshot(agentId: string, archivedAt: string): Promise<StoredAgentRecord> {
+  async archiveSnapshot(
+    agentId: string,
+    archivedAt: string,
+    options: ArchiveSnapshotOptions = { nativeArchiveMode: "best-effort" },
+  ): Promise<StoredAgentRecord> {
     const registry = this.requireRegistry();
     const liveAgent = this.getAgent(agentId);
     if (liveAgent) {
@@ -1995,10 +2003,16 @@ export class AgentManager {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
+    if (options.nativeArchiveMode === "required") {
+      await this.syncNativeArchiveState(record.provider, record.persistence, "archive-required");
+    }
+
     const nextRecord = buildArchivedAgentRecord(record, { archivedAt });
     await registry.upsert(nextRecord);
 
-    await this.syncNativeArchiveState(record.provider, record.persistence, "archive");
+    if (options.nativeArchiveMode === "best-effort") {
+      await this.syncNativeArchiveState(record.provider, record.persistence, "archive");
+    }
 
     if (this.agents.has(agentId)) {
       this.notifyAgentState(agentId);
@@ -5011,14 +5025,14 @@ export class AgentManager {
   private async syncNativeArchiveState(
     provider: AgentProvider,
     persistence: AgentPersistenceHandle | null | undefined,
-    state: "archive" | "restore",
+    state: "archive" | "archive-required" | "restore",
   ): Promise<void> {
     if (!persistence) return;
     const client = this.clients.get(provider);
     const sync =
-      state === "archive" ? client?.archiveNativeSession : client?.unarchiveNativeSession;
+      state === "restore" ? client?.unarchiveNativeSession : client?.archiveNativeSession;
     if (!sync) return;
-    if (state === "restore") {
+    if (state !== "archive") {
       await sync.call(client, persistence);
       return;
     }
@@ -5031,7 +5045,6 @@ export class AgentManager {
       );
     }
   }
-
   private requireAgent(id: string): LiveManagedAgent {
     const normalizedId = validateAgentId(id, "requireAgent");
     const agent = this.agents.get(normalizedId);

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1716,7 +1716,7 @@ export class AgentManager {
     if (this.agents.has(record.id)) {
       this.notifyAgentState(record.id);
     } else if (!archivedRecord.internal) {
-      this.dispatchArchivedStoredAgent(archivedRecord);
+      this.dispatchStoredAgentState(archivedRecord);
     }
 
     await this.fireAgentArchived(record.id);
@@ -1736,7 +1736,7 @@ export class AgentManager {
     }
   }
 
-  private dispatchArchivedStoredAgent(record: StoredAgentRecord): void {
+  private dispatchStoredAgentState(record: StoredAgentRecord): void {
     const updatedAt = new Date(record.updatedAt);
     this.dispatch({
       type: "agent_state",
@@ -2005,7 +2005,7 @@ export class AgentManager {
     } else {
       this.discardRetainedAgentState(agentId);
       if (!nextRecord.internal) {
-        this.dispatchArchivedStoredAgent(nextRecord);
+        this.dispatchStoredAgentState(nextRecord);
       }
     }
 
@@ -2027,16 +2027,24 @@ export class AgentManager {
 
     await this.syncNativeArchiveState(record.provider, record.persistence, "restore");
 
-    await registry.upsert({
+    const restoredRecord: StoredAgentRecord = {
       ...record,
       ...(updates?.workspaceId ? { workspaceId: updates.workspaceId } : {}),
       ...(updates?.labels ? { labels: applyLabelPatch(record.labels, updates.labels) } : {}),
       archivedAt: null,
+      // Once an agent is back, it is no longer owed to any workspace-archive
+      // gesture — a later workspace restore must not touch it again.
+      archivedWithWorkspaceId: null,
       updatedAt: new Date().toISOString(),
-    });
+    };
+    await registry.upsert(restoredRecord);
 
     if (this.getAgent(agentId)) {
       this.notifyAgentState(agentId);
+    } else if (!restoredRecord.internal) {
+      // Archived agents were closed, so there is no live agent to notify.
+      // Dispatch the stored record so every connected client sees it return.
+      this.dispatchStoredAgentState(restoredRecord);
     }
     return true;
   }

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -299,6 +299,78 @@ describe("AgentStorage", () => {
     expect(recordAfterSnapshot?.archivedAt).toBe(archivedAt);
   });
 
+  test("applySnapshot preserves the workspace-archive cascade stamp", async () => {
+    const agentId = "agent-workspace-archived";
+    await storage.applySnapshot(
+      createManagedAgent({
+        id: agentId,
+        lifecycle: "idle",
+      }),
+    );
+
+    const recordBeforeArchive = await storage.get(agentId);
+    expect(recordBeforeArchive).not.toBeNull();
+    await storage.upsert({
+      ...recordBeforeArchive!,
+      archivedAt: "2025-01-03T00:00:00.000Z",
+      archivedWithWorkspaceId: "ws-stamp",
+    });
+
+    await storage.applySnapshot(
+      createManagedAgent({
+        id: agentId,
+        lifecycle: "running",
+        updatedAt: new Date("2025-01-04T00:00:00.000Z"),
+      }),
+    );
+
+    const recordAfterSnapshot = await storage.get(agentId);
+    expect(recordAfterSnapshot?.archivedWithWorkspaceId).toBe("ws-stamp");
+  });
+
+  test("updateRecord mutates the record written by a concurrent in-flight write", async () => {
+    const agentId = "agent-concurrent-write";
+    await storage.applySnapshot(createManagedAgent({ id: agentId, lifecycle: "idle" }));
+    const initial = await storage.get(agentId);
+    expect(initial).not.toBeNull();
+
+    // Queue a write and, without awaiting it, stamp the same agent. The cache is
+    // only updated once the write's file I/O resolves, so a read-modify-write from
+    // outside the queue would read the pre-write record and clobber `title`.
+    const pendingWrite = storage.upsert({
+      ...initial!,
+      title: "written concurrently",
+      archivedAt: "2025-01-05T00:00:00.000Z",
+    });
+    const stamped = await storage.updateRecord(agentId, (record) => ({
+      ...record,
+      archivedWithWorkspaceId: "ws-race",
+    }));
+    await pendingWrite;
+
+    expect(stamped?.title).toBe("written concurrently");
+    const final = await storage.get(agentId);
+    expect(final?.title).toBe("written concurrently");
+    expect(final?.archivedAt).toBe("2025-01-05T00:00:00.000Z");
+    expect(final?.archivedWithWorkspaceId).toBe("ws-race");
+  });
+
+  test("updateRecord skips the write when the mutator declines", async () => {
+    const agentId = "agent-decline-update";
+    await storage.applySnapshot(createManagedAgent({ id: agentId, lifecycle: "idle" }));
+
+    const result = await storage.updateRecord(agentId, () => null);
+
+    expect(result).toBeNull();
+    const record = await storage.get(agentId);
+    expect(record?.archivedWithWorkspaceId ?? null).toBeNull();
+  });
+
+  test("updateRecord returns null for an unknown agent", async () => {
+    const result = await storage.updateRecord("agent-does-not-exist", (record) => record);
+    expect(result).toBeNull();
+  });
+
   test("stores titles independently of snapshots", async () => {
     await storage.applySnapshot(
       createManagedAgent({

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -74,6 +74,11 @@ const STORED_AGENT_SCHEMA = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   internal: z.boolean().optional(),
   archivedAt: z.string().nullable().optional(),
+  // Set when this agent was archived as part of archiving its workspace (the
+  // workspace-archive cascade), so restoring that workspace can bring back
+  // exactly those agents and leave individually-archived ones alone.
+  // Storage-only; never crosses the wire.
+  archivedWithWorkspaceId: z.string().nullable().optional(),
   owner: AgentOwnerSchema.optional(),
 });
 
@@ -159,9 +164,29 @@ export class AgentStorage {
     return this.queueRecordMutation(record.id, () => record);
   }
 
+  /**
+   * Read-modify-write inside the per-agent queue so the mutator sees the record
+   * after any in-flight write has landed.
+   */
+  async updateRecord(
+    agentId: string,
+    mutate: (record: StoredAgentRecord) => StoredAgentRecord | null,
+  ): Promise<StoredAgentRecord | null> {
+    await this.load();
+    let written: StoredAgentRecord | null = null;
+    await this.queueRecordMutation(agentId, (existing) => {
+      if (!existing) {
+        return null;
+      }
+      written = mutate(existing);
+      return written;
+    });
+    return written;
+  }
+
   private queueRecordMutation(
     agentId: string,
-    mutate: (existing: StoredAgentRecord | null) => StoredAgentRecord,
+    mutate: (existing: StoredAgentRecord | null) => StoredAgentRecord | null,
   ): Promise<void> {
     const prev = this.pendingWrites.get(agentId) ?? Promise.resolve();
     const next = prev.then(async () => {
@@ -170,6 +195,9 @@ export class AgentStorage {
       }
 
       const record = mutate(this.cache.get(agentId) ?? null);
+      if (!record) {
+        return undefined;
+      }
       await this.writeRecord(record);
       return undefined;
     });
@@ -258,6 +286,9 @@ export class AgentStorage {
       // stale pre-archive record after the archive mutation.
       if (existing && existing.archivedAt !== undefined) {
         record.archivedAt = existing.archivedAt;
+      }
+      if (existing && existing.archivedWithWorkspaceId !== undefined) {
+        record.archivedWithWorkspaceId = existing.archivedWithWorkspaceId;
       }
       return record;
     });

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -2,6 +2,7 @@ import { promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 import type { Logger } from "pino";
+import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 
 import { writeJsonFileAtomic } from "../atomic-file.js";
 import { AgentFeatureSchema, AgentStatusSchema } from "../messages.js";
@@ -147,6 +148,40 @@ export class AgentStorage {
   async listByWorkspace(workspaceId: string): Promise<StoredAgentRecord[]> {
     await this.load();
     return Array.from(this.cache.values()).filter((record) => record.workspaceId === workspaceId);
+  }
+
+  async listDescendants(rootAgentIds: readonly string[]): Promise<StoredAgentRecord[]> {
+    await this.load();
+    const childrenByParent = new Map<string, StoredAgentRecord[]>();
+    for (const record of this.cache.values()) {
+      const parentId = record.labels?.[PARENT_AGENT_ID_LABEL];
+      if (!parentId) continue;
+      const children = childrenByParent.get(parentId) ?? [];
+      children.push(record);
+      childrenByParent.set(parentId, children);
+    }
+
+    const descendants: StoredAgentRecord[] = [];
+    const visited = new Set(rootAgentIds);
+    const pending = [...rootAgentIds];
+    while (pending.length > 0) {
+      const parentId = pending.pop();
+      if (!parentId) continue;
+      for (const child of childrenByParent.get(parentId) ?? []) {
+        if (visited.has(child.id)) continue;
+        visited.add(child.id);
+        descendants.push(child);
+        pending.push(child.id);
+      }
+    }
+    return descendants;
+  }
+
+  async listByArchivedWorkspace(workspaceId: string): Promise<StoredAgentRecord[]> {
+    await this.load();
+    return Array.from(this.cache.values()).filter(
+      (record) => record.archivedWithWorkspaceId === workspaceId,
+    );
   }
 
   async findByDaemonExecution(owner: DaemonAgentOwner): Promise<StoredAgentRecord | null> {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -187,6 +187,8 @@ import type { PushNotifications } from "./push/index.js";
 import {
   archivePersistedWorkspaceRecord,
   archiveWorkspaceContents,
+  requireActiveWorkspaceForArchive,
+  unarchiveWorkspaceContents,
 } from "./workspace-archive-service.js";
 import type { ServiceProxySubsystem } from "./service-proxy.js";
 import { renameCurrentBranch as renameCurrentBranchDefault } from "../utils/checkout-git.js";
@@ -868,6 +870,16 @@ export class Session {
       isDirectory: (path) => this.filesystem.isDirectory(path),
       unarchiveWorkspace: async (workspace) => {
         await this.workspaceProvisioning.ensureWorkspaceRecordUnarchived(workspace);
+        // Bring back the agents this workspace's archive gesture took down.
+        // Agents archived individually beforehand carry no stamp and stay put.
+        await unarchiveWorkspaceContents(
+          {
+            agentManager: this.agentManager,
+            agentStorage: this.agentStorage,
+            sessionLogger: this.sessionLogger,
+          },
+          workspace.workspaceId,
+        );
       },
     });
     this.checkoutSession = new CheckoutSession({

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -187,7 +187,6 @@ import type { PushNotifications } from "./push/index.js";
 import {
   archivePersistedWorkspaceRecord,
   archiveWorkspaceContents,
-  requireActiveWorkspaceForArchive,
   unarchiveWorkspaceContents,
 } from "./workspace-archive-service.js";
 import type { ServiceProxySubsystem } from "./service-proxy.js";

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -187,7 +187,7 @@ import type { PushNotifications } from "./push/index.js";
 import {
   archivePersistedWorkspaceRecord,
   archiveWorkspaceContents,
-  unarchiveWorkspaceContents,
+  unarchiveWorkspaceContentsAndActivate,
 } from "./workspace-archive-service.js";
 import type { ServiceProxySubsystem } from "./service-proxy.js";
 import { renameCurrentBranch as renameCurrentBranchDefault } from "../utils/checkout-git.js";
@@ -870,18 +870,17 @@ export class Session {
       unarchiveWorkspace: async (workspace) => {
         // Bring back the agents this workspace's archive gesture took down.
         // Agents archived individually beforehand carry no stamp and stay put.
-        await unarchiveWorkspaceContents(
+        await unarchiveWorkspaceContentsAndActivate(
           {
             agentManager: this.agentManager,
             agentStorage: this.agentStorage,
             sessionLogger: this.sessionLogger,
           },
           workspace.workspaceId,
+          async () => {
+            await this.workspaceProvisioning.ensureWorkspaceRecordUnarchived(workspace);
+          },
         );
-        // Keep the workspace archived until every stamped agent has restored
-        // successfully. A failed provider hook must leave the recovery action
-        // available so the user can retry the remaining agents.
-        await this.workspaceProvisioning.ensureWorkspaceRecordUnarchived(workspace);
       },
     });
     this.checkoutSession = new CheckoutSession({

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -869,7 +869,6 @@ export class Session {
       getProject: (projectId) => this.projectRegistry.get(projectId),
       isDirectory: (path) => this.filesystem.isDirectory(path),
       unarchiveWorkspace: async (workspace) => {
-        await this.workspaceProvisioning.ensureWorkspaceRecordUnarchived(workspace);
         // Bring back the agents this workspace's archive gesture took down.
         // Agents archived individually beforehand carry no stamp and stay put.
         await unarchiveWorkspaceContents(
@@ -880,6 +879,10 @@ export class Session {
           },
           workspace.workspaceId,
         );
+        // Keep the workspace archived until every stamped agent has restored
+        // successfully. A failed provider hook must leave the recovery action
+        // available so the user can retry the remaining agents.
+        await this.workspaceProvisioning.ensureWorkspaceRecordUnarchived(workspace);
       },
     });
     this.checkoutSession = new CheckoutSession({

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -446,6 +446,44 @@ test("does not unarchive either record when checkout refresh fails", async () =>
   expect(await workspaceRegistry.get(created.workspaceId)).toEqual(archivedWorkspace);
 });
 
+test("rolls back the project and workspace when workspace activation fails", async () => {
+  const repo = path.join(tmpDir, "repo");
+  gitRoots.add(repo);
+  const created = await provisioning.findOrCreateWorkspaceForDirectory(repo);
+  await projectRegistry.archive(created.projectId, ARCHIVED_AT);
+  await workspaceRegistry.archive(created.workspaceId, ARCHIVED_AT);
+  const archivedProject = await projectRegistry.get(created.projectId);
+  const archivedWorkspace = await workspaceRegistry.get(created.workspaceId);
+  const failingWorkspaceRegistry: WorkspaceRegistry = {
+    initialize: () => workspaceRegistry.initialize(),
+    existsOnDisk: () => workspaceRegistry.existsOnDisk(),
+    list: () => workspaceRegistry.list(),
+    get: (workspaceId) => workspaceRegistry.get(workspaceId),
+    update: (workspaceId, updater) => workspaceRegistry.update(workspaceId, updater),
+    upsert: async (workspace, context) => {
+      if (!workspace.archivedAt) throw new Error("workspace activation failed");
+      await workspaceRegistry.upsert(workspace, context);
+    },
+    archive: (workspaceId, archivedAt, context) =>
+      workspaceRegistry.archive(workspaceId, archivedAt, context),
+    remove: (workspaceId) => workspaceRegistry.remove(workspaceId),
+    subscribeToMutations: (listener) => workspaceRegistry.subscribeToMutations(listener),
+  };
+  const failingProvisioning = createWorkspaceProvisioningService({
+    workspaceRegistry: failingWorkspaceRegistry,
+    projectRegistry,
+    workspaceGitService: gitService(),
+    logger,
+  });
+
+  await expect(
+    failingProvisioning.ensureWorkspaceRecordUnarchived(archivedWorkspace!),
+  ).rejects.toThrow("workspace activation failed");
+
+  expect(await projectRegistry.get(created.projectId)).toEqual(archivedProject);
+  expect(await workspaceRegistry.get(created.workspaceId)).toEqual(archivedWorkspace);
+});
+
 test("resolveOrCreateWorkspaceIdForCreateAgent returns a created worktree's id without touching the registry", async () => {
   // The branch only reads workspace.workspaceId off the worktree result.
   const createdWorktree = {

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -86,6 +86,28 @@ export class WorkspaceProvisioningError extends Error {
   }
 }
 
+async function rollbackWorkspaceActivation(
+  steps: ReadonlyArray<() => Promise<void>>,
+  cause: unknown,
+  workspaceId: string,
+): Promise<void> {
+  const rollbackErrors: unknown[] = [];
+  for (const step of steps.toReversed()) {
+    try {
+      await step();
+    } catch (error) {
+      rollbackErrors.push(error);
+    }
+  }
+  if (rollbackErrors.length > 0) {
+    throw new AggregateError(
+      [cause, ...rollbackErrors],
+      `Failed to unarchive workspace ${workspaceId}; rollback also failed`,
+      { cause },
+    );
+  }
+}
+
 export function createWorkspaceProvisioningService(deps: {
   serverId?: string;
   workspaceRegistry: WorkspaceRegistry;
@@ -365,6 +387,7 @@ export function createWorkspaceProvisioningService(deps: {
     const autoArchivedChangeRequestUrl =
       await resolveRestoredAutoArchiveChangeRequestUrl(workspace);
     let next: PersistedWorkspaceRecord | null = null;
+    let nextProject: PersistedProjectRecord | null = null;
     if (workspace.archivedAt && checkout) {
       const placementUpdate = reconcileWorkspacePlacement({
         workspace,
@@ -391,18 +414,31 @@ export function createWorkspaceProvisioningService(deps: {
         serverId,
       });
       if (project.archivedAt || project.kind !== kind || project.projectKey !== projectKey) {
-        await projectRegistry.upsert({
+        nextProject = {
           ...project,
           kind,
           projectKey,
           archivedAt: null,
           updatedAt: timestamp,
-        });
+        };
       }
     }
-    if (!next) return workspace;
-    await workspaceRegistry.upsert(next);
-    return next;
+
+    const rollbackSteps: Array<() => Promise<void>> = [];
+    try {
+      if (nextProject) {
+        rollbackSteps.push(() => projectRegistry.upsert(project));
+        await projectRegistry.upsert(nextProject);
+      }
+      if (next) {
+        rollbackSteps.push(() => workspaceRegistry.upsert(workspace));
+        await workspaceRegistry.upsert(next);
+      }
+      return next ?? workspace;
+    } catch (cause) {
+      await rollbackWorkspaceActivation(rollbackSteps, cause, workspace.workspaceId);
+      throw cause;
+    }
   }
 
   async function refreshWorkspaceRecord(

--- a/packages/server/src/server/workspace-archive-service.test.ts
+++ b/packages/server/src/server/workspace-archive-service.test.ts
@@ -17,6 +17,7 @@ import {
   type ArchiveDependencies,
   type ArchiveResult,
   resolveWorkspaceIdAtPath,
+  unarchiveWorkspaceContentsAndActivate,
 } from "./workspace-archive-service.js";
 import { WorkspaceAutomationBlockedError } from "./workspace-automation-gate.js";
 
@@ -880,5 +881,129 @@ describe("resolveWorkspaceIdAtPath", () => {
     );
 
     expect(result).toBe("ws-nested");
+  });
+});
+
+describe("workspace unarchive consistency", () => {
+  function createRestoreHarness(options?: { failUnarchiveId?: string; failArchiveId?: string }) {
+    const workspaceId = "ws-restore";
+    const records = new Map<string, StoredAgentRecord>(
+      ["agent-a", "agent-b"].map((id) => [
+        id,
+        {
+          id,
+          workspaceId,
+          archivedAt: "2026-08-01T00:00:00.000Z",
+          archivedWithWorkspaceId: workspaceId,
+        } as StoredAgentRecord,
+      ]),
+    );
+    const unarchived: string[] = [];
+    const archived: string[] = [];
+    const dependencies = {
+      agentManager: {
+        unarchiveSnapshot: async (agentId: string) => {
+          if (agentId === options?.failUnarchiveId) throw new Error("provider restore failed");
+          const record = records.get(agentId)!;
+          records.set(agentId, {
+            ...record,
+            archivedAt: null,
+            archivedWithWorkspaceId: null,
+          });
+          unarchived.push(agentId);
+          return true;
+        },
+        archiveSnapshot: async (agentId: string, archivedAt: string) => {
+          if (agentId === options?.failArchiveId) throw new Error("rollback write failed");
+          const record = records.get(agentId)!;
+          const archivedRecord = { ...record, archivedAt };
+          records.set(agentId, archivedRecord);
+          archived.push(agentId);
+          return archivedRecord;
+        },
+      },
+      agentStorage: {
+        list: async () => [...records.values()],
+        get: async (agentId: string) => records.get(agentId) ?? null,
+        updateRecord: async (
+          agentId: string,
+          update: (record: StoredAgentRecord) => StoredAgentRecord | null,
+        ) => {
+          const current = records.get(agentId)!;
+          const next = update(current);
+          if (next) records.set(agentId, next);
+          return next;
+        },
+      },
+      sessionLogger: createLogger(),
+    };
+    return { workspaceId, records, unarchived, archived, dependencies };
+  }
+
+  test("rolls back agents restored before a provider restore failure", async () => {
+    const harness = createRestoreHarness({ failUnarchiveId: "agent-b" });
+
+    await expect(
+      unarchiveWorkspaceContentsAndActivate(
+        harness.dependencies,
+        harness.workspaceId,
+        async () => {},
+      ),
+    ).rejects.toThrow("provider restore failed");
+
+    expect(harness.unarchived).toEqual(["agent-a"]);
+    expect(harness.archived).toEqual(["agent-a"]);
+    expect(harness.records.get("agent-a")).toMatchObject({
+      archivedAt: expect.any(String),
+      archivedWithWorkspaceId: harness.workspaceId,
+    });
+    expect(harness.records.get("agent-b")).toMatchObject({
+      archivedAt: expect.any(String),
+      archivedWithWorkspaceId: harness.workspaceId,
+    });
+  });
+
+  test("reports rollback failure and preserves its retry stamp", async () => {
+    const harness = createRestoreHarness({
+      failUnarchiveId: "agent-b",
+      failArchiveId: "agent-a",
+    });
+
+    await expect(
+      unarchiveWorkspaceContentsAndActivate(
+        harness.dependencies,
+        harness.workspaceId,
+        async () => {},
+      ),
+    ).rejects.toThrow("rollback also failed: Failed to roll back 1 agent(s)");
+
+    expect(harness.records.get("agent-a")).toMatchObject({
+      archivedAt: null,
+      archivedWithWorkspaceId: harness.workspaceId,
+    });
+  });
+
+  test("rolls restored agents back when workspace activation fails", async () => {
+    const harness = createRestoreHarness();
+
+    await expect(
+      unarchiveWorkspaceContentsAndActivate(harness.dependencies, harness.workspaceId, async () => {
+        throw new Error("workspace activation failed");
+      }),
+    ).rejects.toThrow("workspace activation failed");
+
+    expect(harness.archived).toEqual(["agent-a", "agent-b"]);
+    expect([...harness.records.values()]).toEqual([
+      expect.objectContaining({
+        id: "agent-a",
+        archivedAt: expect.any(String),
+        archivedWithWorkspaceId: harness.workspaceId,
+      }),
+      expect.objectContaining({
+        id: "agent-b",
+        archivedAt: expect.any(String),
+        archivedWithWorkspaceId: harness.workspaceId,
+      }),
+    ]);
   });
 });

--- a/packages/server/src/server/workspace-archive-service.test.ts
+++ b/packages/server/src/server/workspace-archive-service.test.ts
@@ -155,7 +155,9 @@ function createArchiveDeps(input: ArchiveDepsInput): ArchiveTestDependencies {
     },
     agentStorage: {
       listByWorkspace: async (): Promise<StoredAgentRecord[]> => [],
-    } as Pick<AgentStorage, "listByWorkspace">,
+      get: async () => null,
+      updateRecord: async () => null,
+    } as Pick<AgentStorage, "listByWorkspace" | "get" | "updateRecord">,
     findWorkspaceIdForCwd: input.findWorkspaceIdForCwd ?? vi.fn(async () => null),
     listActiveWorkspaces: async () =>
       active.filter((workspace) => !archivedWorkspaceIds.has(workspace.workspaceId)),
@@ -762,7 +764,9 @@ describe("archiveByScope", () => {
           : ([
               { id: otherStoredAgentId, workspaceId: otherWorkspaceId, archivedAt: null },
             ] as StoredAgentRecord[]),
-    } as Pick<AgentStorage, "listByWorkspace">;
+      get: async () => null,
+      updateRecord: async () => null,
+    } as Pick<AgentStorage, "listByWorkspace" | "get" | "updateRecord">;
 
     const result = await archiveByScope(deps, {
       scope: { kind: "workspace", workspaceId: targetWorkspaceId },

--- a/packages/server/src/server/workspace-archive-service.test.ts
+++ b/packages/server/src/server/workspace-archive-service.test.ts
@@ -156,9 +156,10 @@ function createArchiveDeps(input: ArchiveDepsInput): ArchiveTestDependencies {
     },
     agentStorage: {
       listByWorkspace: async (): Promise<StoredAgentRecord[]> => [],
+      listDescendants: async (): Promise<StoredAgentRecord[]> => [],
       get: async () => null,
       updateRecord: async () => null,
-    } as Pick<AgentStorage, "listByWorkspace" | "get" | "updateRecord">,
+    } as Pick<AgentStorage, "listByWorkspace" | "listDescendants" | "get" | "updateRecord">,
     findWorkspaceIdForCwd: input.findWorkspaceIdForCwd ?? vi.fn(async () => null),
     listActiveWorkspaces: async () =>
       active.filter((workspace) => !archivedWorkspaceIds.has(workspace.workspaceId)),
@@ -765,9 +766,10 @@ describe("archiveByScope", () => {
           : ([
               { id: otherStoredAgentId, workspaceId: otherWorkspaceId, archivedAt: null },
             ] as StoredAgentRecord[]),
+      listDescendants: async () => [],
       get: async () => null,
       updateRecord: async () => null,
-    } as Pick<AgentStorage, "listByWorkspace" | "get" | "updateRecord">;
+    } as Pick<AgentStorage, "listByWorkspace" | "listDescendants" | "get" | "updateRecord">;
 
     const result = await archiveByScope(deps, {
       scope: { kind: "workspace", workspaceId: targetWorkspaceId },
@@ -804,8 +806,12 @@ describe("archiveByScope", () => {
       }),
     };
     deps.agentStorage = {
-      list: async () => [{ id: agentId, workspaceId, archivedAt: null }] as StoredAgentRecord[],
-    } as Pick<AgentStorage, "list">;
+      listByWorkspace: async () =>
+        [{ id: agentId, workspaceId, archivedAt: null }] as StoredAgentRecord[],
+      listDescendants: async () => [],
+      get: async () => null,
+      updateRecord: async () => null,
+    } as Pick<AgentStorage, "listByWorkspace" | "listDescendants" | "get" | "updateRecord">;
 
     const result = await archiveByScope(deps, {
       scope: { kind: "workspace", workspaceId },
@@ -923,7 +929,10 @@ describe("workspace unarchive consistency", () => {
         },
       },
       agentStorage: {
-        list: async () => [...records.values()],
+        listByArchivedWorkspace: async (archivedWorkspaceId: string) =>
+          [...records.values()].filter(
+            (record) => record.archivedWithWorkspaceId === archivedWorkspaceId,
+          ),
         get: async (agentId: string) => records.get(agentId) ?? null,
         updateRecord: async (
           agentId: string,

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -34,7 +34,7 @@ export interface ArchiveDependencies {
   github: ForgeService;
   workspaceGitService: Pick<WorkspaceGitService, "getSnapshot">;
   agentManager: Pick<AgentManager, "listAgents" | "getAgent" | "archiveAgent" | "archiveSnapshot">;
-  agentStorage: Pick<AgentStorage, "listByWorkspace">;
+  agentStorage: Pick<AgentStorage, "listByWorkspace" | "get" | "updateRecord">;
   // Resolves the worktree at a path to its workspaceId for archive-by-path. The
   // path uniquely identifies a worktree workspace; this is a directory lookup for
   // the archive target, not status/ownership.
@@ -481,10 +481,25 @@ export async function archiveWorkspaceContents(
       "Failed to list stored agents during workspace archive; continuing",
     );
   }
+  const liveAgentIds = new Set(liveAgents.map((agent) => agent.id));
+  const storedRecordsById = new Map(storedRecords.map((record) => [record.id, record]));
   const matchingStoredRecords = storedRecords;
   for (const record of matchingStoredRecords) {
     archivedAgents.add(record.id);
   }
+
+  const snapshotsToArchive = matchingStoredRecords.filter(
+    (record) => !liveAgentIds.has(record.id) && !record.archivedAt,
+  );
+  // Exactly the agents this gesture takes from unarchived to archived. Agents the
+  // user archived individually beforehand are excluded so workspace restore leaves
+  // them where the user put them.
+  const cascadedAgentIds = [
+    ...liveAgents
+      .filter((agent) => !storedRecordsById.get(agent.id)?.archivedAt)
+      .map((agent) => agent.id),
+    ...snapshotsToArchive.map((record) => record.id),
+  ];
 
   const archivedAt = new Date().toISOString();
   const agentIdsToArchive = new Set([
@@ -509,7 +524,103 @@ export async function archiveWorkspaceContents(
     }
   }
 
+  await stampCascadeArchivedAgents(dependencies, cascadedAgentIds, workspaceId);
+
   return archivedAgents;
+}
+
+// Marks the records this gesture archived so `unarchiveWorkspaceContents` can find
+// them again. Runs AFTER the archive fan-out on purpose: `archiveAgent` rebuilds the
+// record (and cascade-archives children concurrently), so a stamp written inline
+// would be overwritten by the archive projection.
+async function stampCascadeArchivedAgents(
+  dependencies: ArchiveWorkspaceContentsDependencies,
+  agentIds: readonly string[],
+  workspaceId: string,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    agentIds.map(async (agentId) =>
+      // Read-modify-write inside the storage write queue: `archiveAgent` closes the
+      // agent, which fires an un-awaited background persist, so reading the record
+      // out here could hand us a stale copy and clobber that persist on write-back.
+      dependencies.agentStorage.updateRecord(agentId, (record) => {
+        // Only stamp what actually ended up archived; a failed archive step must not
+        // leave a stamp that a later restore would act on.
+        if (!record.archivedAt || record.archivedWithWorkspaceId === workspaceId) {
+          return null;
+        }
+        return { ...record, archivedWithWorkspaceId: workspaceId };
+      }),
+    ),
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      dependencies.sessionLogger?.warn(
+        { err: result.reason, workspaceId },
+        "Failed to stamp workspace-archived agent; workspace restore will skip it",
+      );
+    }
+  }
+}
+
+export interface UnarchiveWorkspaceContentsDependencies {
+  agentManager: Pick<AgentManager, "unarchiveSnapshot">;
+  agentStorage: Pick<AgentStorage, "list" | "get">;
+  sessionLogger?: Logger;
+}
+
+// Inverse of `archiveWorkspaceContents`: restores exactly the agents that were
+// archived as part of archiving this workspace (stamped with
+// `archivedWithWorkspaceId`). Agents archived individually before the workspace was
+// archived carry no stamp and stay archived. Goes through
+// `AgentManager.unarchiveSnapshot` so the provider's native unarchive hook (e.g.
+// Codex `thread/unarchive`) runs, and so the stamp is cleared.
+// Returns the restored records so the caller can publish them to clients.
+export async function unarchiveWorkspaceContents(
+  dependencies: UnarchiveWorkspaceContentsDependencies,
+  workspaceId: string,
+): Promise<StoredAgentRecord[]> {
+  let storedRecords: StoredAgentRecord[] = [];
+  try {
+    storedRecords = await dependencies.agentStorage.list();
+  } catch (error) {
+    dependencies.sessionLogger?.warn(
+      { err: error, workspaceId },
+      "Failed to list stored agents during workspace unarchive; skipping agent restore",
+    );
+    return [];
+  }
+
+  const candidates = storedRecords.filter(
+    (record) => record.archivedAt && record.archivedWithWorkspaceId === workspaceId,
+  );
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const results = await Promise.allSettled(
+    candidates.map(async (candidate) => {
+      const unarchived = await dependencies.agentManager.unarchiveSnapshot(candidate.id);
+      return unarchived ? await dependencies.agentStorage.get(candidate.id) : null;
+    }),
+  );
+
+  const restored: StoredAgentRecord[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      if (result.value) {
+        restored.push(result.value);
+      }
+    } else {
+      dependencies.sessionLogger?.warn(
+        { err: result.reason, workspaceId },
+        "Failed to unarchive agent during workspace restore; continuing",
+      );
+    }
+  }
+
+  return restored;
 }
 
 // True when, after archiving

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -644,7 +644,11 @@ async function rollbackWorkspaceContents(
         archivedWithWorkspaceId: workspaceId,
       })),
     );
-    await runRollbackStep(() => dependencies.agentManager.archiveSnapshot(record.id, archivedAt));
+    await runRollbackStep(() =>
+      dependencies.agentManager.archiveSnapshot(record.id, archivedAt, {
+        nativeArchiveMode: "required",
+      }),
+    );
     await runRollbackStep(() =>
       dependencies.agentStorage.updateRecord(record.id, (current) => ({
         ...current,

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -515,6 +515,7 @@ export async function archiveWorkspaceContents(
   const agentIdsToArchive = new Set([
     ...liveAgents.map((agent) => agent.id),
     ...matchingStoredRecords.filter((record) => !record.archivedAt).map((record) => record.id),
+    ...cascadedAgentIds,
   ]);
   const archiveResults = await Promise.allSettled([
     ...[...agentIdsToArchive].map((agentId) =>

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -605,8 +605,8 @@ async function stampCascadeArchivedAgents(
 }
 
 export interface UnarchiveWorkspaceContentsDependencies {
-  agentManager: Pick<AgentManager, "unarchiveSnapshot">;
-  agentStorage: Pick<AgentStorage, "list" | "get">;
+  agentManager: Pick<AgentManager, "archiveSnapshot" | "unarchiveSnapshot">;
+  agentStorage: Pick<AgentStorage, "list" | "get" | "updateRecord">;
   sessionLogger?: Logger;
 }
 
@@ -639,36 +639,31 @@ export async function unarchiveWorkspaceContents(
     return [];
   }
 
-  const results = await Promise.allSettled(
-    candidates.map(async (candidate) => {
-      const unarchived = await dependencies.agentManager.unarchiveSnapshot(candidate.id);
-      return unarchived ? await dependencies.agentStorage.get(candidate.id) : null;
-    }),
-  );
-
   const restored: StoredAgentRecord[] = [];
-  const failures: unknown[] = [];
-  for (const result of results) {
-    if (result.status === "fulfilled") {
-      if (result.value) {
-        restored.push(result.value);
-      }
-    } else {
-      failures.push(result.reason);
-      dependencies.sessionLogger?.warn(
-        { err: result.reason, workspaceId },
-        "Failed to unarchive agent during workspace restore",
-      );
+  try {
+    for (const candidate of candidates) {
+      const unarchived = await dependencies.agentManager.unarchiveSnapshot(candidate.id);
+      if (!unarchived) continue;
+      const record = await dependencies.agentStorage.get(candidate.id);
+      if (record) restored.push(record);
     }
-  }
-
-  if (failures.length > 0) {
-    const cause = failures[0];
-    const detail = cause instanceof Error ? `: ${cause.message}` : "";
-    throw new Error(
-      `Failed to restore ${failures.length} agent(s) for workspace ${workspaceId}${detail}`,
-      { cause },
+  } catch (cause) {
+    dependencies.sessionLogger?.warn(
+      { err: cause, workspaceId },
+      "Failed to unarchive agent during workspace restore; rolling back restored agents",
     );
+    const archivedAt = new Date().toISOString();
+    await Promise.allSettled(
+      restored.map(async (record) => {
+        await dependencies.agentManager.archiveSnapshot(record.id, archivedAt);
+        await dependencies.agentStorage.updateRecord(record.id, (current) => ({
+          ...current,
+          archivedWithWorkspaceId: workspaceId,
+        }));
+      }),
+    );
+    const detail = cause instanceof Error ? `: ${cause.message}` : "";
+    throw new Error(`Failed to restore workspace ${workspaceId}${detail}`, { cause });
   }
 
   return restored;

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 
 import type { Logger } from "pino";
+import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 
 import type { AgentManager } from "./agent/agent-manager.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
@@ -494,12 +495,16 @@ export async function archiveWorkspaceContents(
   // Exactly the agents this gesture takes from unarchived to archived. Agents the
   // user archived individually beforehand are excluded so workspace restore leaves
   // them where the user put them.
-  const cascadedAgentIds = [
-    ...liveAgents
+  const cascadedAgentIds = findWorkspaceCascadeAgentIds(
+    storedRecords,
+    liveAgents
       .filter((agent) => !storedRecordsById.get(agent.id)?.archivedAt)
       .map((agent) => agent.id),
-    ...snapshotsToArchive.map((record) => record.id),
-  ];
+    snapshotsToArchive.map((record) => record.id),
+  );
+  for (const agentId of cascadedAgentIds) {
+    archivedAgents.add(agentId);
+  }
 
   const archivedAt = new Date().toISOString();
   const agentIdsToArchive = new Set([
@@ -527,6 +532,41 @@ export async function archiveWorkspaceContents(
   await stampCascadeArchivedAgents(dependencies, cascadedAgentIds, workspaceId);
 
   return archivedAgents;
+}
+
+function findWorkspaceCascadeAgentIds(
+  storedRecords: readonly StoredAgentRecord[],
+  ...rootIdGroups: ReadonlyArray<readonly string[]>
+): string[] {
+  const initiallyUnarchivedIds = new Set(
+    storedRecords.filter((record) => !record.archivedAt).map((record) => record.id),
+  );
+  const childrenByParent = new Map<string, string[]>();
+  for (const record of storedRecords) {
+    const parentId = record.labels?.[PARENT_AGENT_ID_LABEL];
+    if (!parentId) continue;
+    const children = childrenByParent.get(parentId) ?? [];
+    children.push(record.id);
+    childrenByParent.set(parentId, children);
+  }
+
+  const archivedByWorkspace = new Set(rootIdGroups.flat());
+  const pending = [...archivedByWorkspace];
+  while (pending.length > 0) {
+    const parentId = pending.pop();
+    if (!parentId) continue;
+    for (const childId of childrenByParent.get(parentId) ?? []) {
+      // AgentManager's cascade skips an already-archived child and therefore does
+      // not reach descendants beneath that child either.
+      if (!initiallyUnarchivedIds.has(childId) || archivedByWorkspace.has(childId)) {
+        continue;
+      }
+      archivedByWorkspace.add(childId);
+      pending.push(childId);
+    }
+  }
+
+  return [...archivedByWorkspace];
 }
 
 // Marks the records this gesture archived so `unarchiveWorkspaceContents` can find
@@ -587,9 +627,9 @@ export async function unarchiveWorkspaceContents(
   } catch (error) {
     dependencies.sessionLogger?.warn(
       { err: error, workspaceId },
-      "Failed to list stored agents during workspace unarchive; skipping agent restore",
+      "Failed to list stored agents during workspace unarchive",
     );
-    return [];
+    throw error;
   }
 
   const candidates = storedRecords.filter(
@@ -607,17 +647,28 @@ export async function unarchiveWorkspaceContents(
   );
 
   const restored: StoredAgentRecord[] = [];
+  const failures: unknown[] = [];
   for (const result of results) {
     if (result.status === "fulfilled") {
       if (result.value) {
         restored.push(result.value);
       }
     } else {
+      failures.push(result.reason);
       dependencies.sessionLogger?.warn(
         { err: result.reason, workspaceId },
-        "Failed to unarchive agent during workspace restore; continuing",
+        "Failed to unarchive agent during workspace restore",
       );
     }
+  }
+
+  if (failures.length > 0) {
+    const cause = failures[0];
+    const detail = cause instanceof Error ? `: ${cause.message}` : "";
+    throw new Error(
+      `Failed to restore ${failures.length} agent(s) for workspace ${workspaceId}${detail}`,
+      { cause },
+    );
   }
 
   return restored;

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -610,6 +610,68 @@ export interface UnarchiveWorkspaceContentsDependencies {
   sessionLogger?: Logger;
 }
 
+async function rollbackWorkspaceContents(
+  dependencies: UnarchiveWorkspaceContentsDependencies,
+  workspaceId: string,
+  records: readonly StoredAgentRecord[],
+): Promise<void> {
+  const archivedAt = new Date().toISOString();
+  const failures: unknown[] = [];
+
+  for (const record of records) {
+    const runRollbackStep = async (step: () => Promise<unknown>): Promise<void> => {
+      try {
+        await step();
+      } catch (error) {
+        failures.push(error);
+        dependencies.sessionLogger?.error(
+          { err: error, workspaceId, agentId: record.id },
+          "Failed to roll back agent during workspace restore",
+        );
+      }
+    };
+
+    // Stamp both before and after archiving. Either successful write preserves
+    // the retry marker, including when the archive step itself fails.
+    await runRollbackStep(() =>
+      dependencies.agentStorage.updateRecord(record.id, (current) => ({
+        ...current,
+        archivedWithWorkspaceId: workspaceId,
+      })),
+    );
+    await runRollbackStep(() => dependencies.agentManager.archiveSnapshot(record.id, archivedAt));
+    await runRollbackStep(() =>
+      dependencies.agentStorage.updateRecord(record.id, (current) => ({
+        ...current,
+        archivedWithWorkspaceId: workspaceId,
+      })),
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Failed to roll back ${failures.length} agent(s) for workspace ${workspaceId}`,
+    );
+  }
+}
+
+function workspaceRestoreError(
+  workspaceId: string,
+  cause: unknown,
+  rollbackError?: unknown,
+): Error {
+  const detail = cause instanceof Error ? `: ${cause.message}` : "";
+  if (!rollbackError) {
+    return new Error(`Failed to restore workspace ${workspaceId}${detail}`, { cause });
+  }
+  const rollbackDetail = rollbackError instanceof Error ? `: ${rollbackError.message}` : "";
+  return new AggregateError(
+    [cause, rollbackError],
+    `Failed to restore workspace ${workspaceId}${detail}; rollback also failed${rollbackDetail}`,
+  );
+}
+
 // Inverse of `archiveWorkspaceContents`: restores exactly the agents that were
 // archived as part of archiving this workspace (stamped with
 // `archivedWithWorkspaceId`). Agents archived individually before the workspace was
@@ -632,8 +694,11 @@ export async function unarchiveWorkspaceContents(
     throw error;
   }
 
+  // A stamped active record means a previous rollback failed after preserving
+  // its retry marker. Treat it as already restored so this attempt can converge
+  // by activating the workspace or rolling the record back again.
   const candidates = storedRecords.filter(
-    (record) => record.archivedAt && record.archivedWithWorkspaceId === workspaceId,
+    (record) => record.archivedWithWorkspaceId === workspaceId,
   );
   if (candidates.length === 0) {
     return [];
@@ -642,31 +707,62 @@ export async function unarchiveWorkspaceContents(
   const restored: StoredAgentRecord[] = [];
   try {
     for (const candidate of candidates) {
-      const unarchived = await dependencies.agentManager.unarchiveSnapshot(candidate.id);
-      if (!unarchived) continue;
+      if (candidate.archivedAt) {
+        const unarchived = await dependencies.agentManager.unarchiveSnapshot(candidate.id);
+        if (!unarchived) {
+          throw new Error(`Stamped agent was not archived: ${candidate.id}`);
+        }
+        restored.push(candidate);
+      } else {
+        restored.push(candidate);
+        await dependencies.agentStorage.updateRecord(candidate.id, (current) => ({
+          ...current,
+          archivedWithWorkspaceId: null,
+        }));
+      }
       const record = await dependencies.agentStorage.get(candidate.id);
-      if (record) restored.push(record);
+      if (!record) {
+        throw new Error(`Restored agent disappeared from storage: ${candidate.id}`);
+      }
+      restored[restored.length - 1] = record;
     }
   } catch (cause) {
     dependencies.sessionLogger?.warn(
       { err: cause, workspaceId },
       "Failed to unarchive agent during workspace restore; rolling back restored agents",
     );
-    const archivedAt = new Date().toISOString();
-    await Promise.allSettled(
-      restored.map(async (record) => {
-        await dependencies.agentManager.archiveSnapshot(record.id, archivedAt);
-        await dependencies.agentStorage.updateRecord(record.id, (current) => ({
-          ...current,
-          archivedWithWorkspaceId: workspaceId,
-        }));
-      }),
-    );
-    const detail = cause instanceof Error ? `: ${cause.message}` : "";
-    throw new Error(`Failed to restore workspace ${workspaceId}${detail}`, { cause });
+    try {
+      await rollbackWorkspaceContents(dependencies, workspaceId, restored);
+    } catch (rollbackError) {
+      throw workspaceRestoreError(workspaceId, cause, rollbackError);
+    }
+    throw workspaceRestoreError(workspaceId, cause);
   }
 
   return restored;
+}
+
+export async function unarchiveWorkspaceContentsAndActivate(
+  dependencies: UnarchiveWorkspaceContentsDependencies,
+  workspaceId: string,
+  activateWorkspace: () => Promise<void>,
+): Promise<StoredAgentRecord[]> {
+  const restored = await unarchiveWorkspaceContents(dependencies, workspaceId);
+  try {
+    await activateWorkspace();
+    return restored;
+  } catch (cause) {
+    dependencies.sessionLogger?.warn(
+      { err: cause, workspaceId },
+      "Failed to activate workspace after restoring agents; rolling back restored agents",
+    );
+    try {
+      await rollbackWorkspaceContents(dependencies, workspaceId, restored);
+    } catch (rollbackError) {
+      throw workspaceRestoreError(workspaceId, cause, rollbackError);
+    }
+    throw workspaceRestoreError(workspaceId, cause);
+  }
 }
 
 // True when, after archiving

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -35,7 +35,7 @@ export interface ArchiveDependencies {
   github: ForgeService;
   workspaceGitService: Pick<WorkspaceGitService, "getSnapshot">;
   agentManager: Pick<AgentManager, "listAgents" | "getAgent" | "archiveAgent" | "archiveSnapshot">;
-  agentStorage: Pick<AgentStorage, "listByWorkspace" | "get" | "updateRecord">;
+  agentStorage: Pick<AgentStorage, "listByWorkspace" | "listDescendants" | "get" | "updateRecord">;
   // Resolves the worktree at a path to its workspaceId for archive-by-path. The
   // path uniquely identifies a worktree workspace; this is a directory lookup for
   // the archive target, not status/ownership.
@@ -473,9 +473,15 @@ export async function archiveWorkspaceContents(
     archivedAgents.add(agent.id);
   }
 
+  let matchingStoredRecords: StoredAgentRecord[] = [];
   let storedRecords: StoredAgentRecord[] = [];
   try {
-    storedRecords = await dependencies.agentStorage.listByWorkspace(workspaceId);
+    matchingStoredRecords = await dependencies.agentStorage.listByWorkspace(workspaceId);
+    const descendants = await dependencies.agentStorage.listDescendants([
+      ...liveAgents.map((agent) => agent.id),
+      ...matchingStoredRecords.map((record) => record.id),
+    ]);
+    storedRecords = [...matchingStoredRecords, ...descendants];
   } catch (error) {
     dependencies.sessionLogger?.warn(
       { err: error, workspaceId },
@@ -484,7 +490,6 @@ export async function archiveWorkspaceContents(
   }
   const liveAgentIds = new Set(liveAgents.map((agent) => agent.id));
   const storedRecordsById = new Map(storedRecords.map((record) => [record.id, record]));
-  const matchingStoredRecords = storedRecords;
   for (const record of matchingStoredRecords) {
     archivedAgents.add(record.id);
   }
@@ -606,7 +611,7 @@ async function stampCascadeArchivedAgents(
 
 export interface UnarchiveWorkspaceContentsDependencies {
   agentManager: Pick<AgentManager, "archiveSnapshot" | "unarchiveSnapshot">;
-  agentStorage: Pick<AgentStorage, "list" | "get" | "updateRecord">;
+  agentStorage: Pick<AgentStorage, "listByArchivedWorkspace" | "get" | "updateRecord">;
   sessionLogger?: Logger;
 }
 
@@ -685,7 +690,7 @@ export async function unarchiveWorkspaceContents(
 ): Promise<StoredAgentRecord[]> {
   let storedRecords: StoredAgentRecord[] = [];
   try {
-    storedRecords = await dependencies.agentStorage.list();
+    storedRecords = await dependencies.agentStorage.listByArchivedWorkspace(workspaceId);
   } catch (error) {
     dependencies.sessionLogger?.warn(
       { err: error, workspaceId },
@@ -697,9 +702,7 @@ export async function unarchiveWorkspaceContents(
   // A stamped active record means a previous rollback failed after preserving
   // its retry marker. Treat it as already restored so this attempt can converge
   // by activating the workspace or rolling the record back again.
-  const candidates = storedRecords.filter(
-    (record) => record.archivedWithWorkspaceId === workspaceId,
-  );
+  const candidates = storedRecords;
   if (candidates.length === 0) {
     return [];
   }


### PR DESCRIPTION
Closes #2651

## The problem

Archiving a workspace archives every agent in it (`archiveWorkspaceContents`), but unarchiving the workspace restored only the workspace record — `ensureWorkspaceRecordUnarchived` cleared `archivedAt` on the workspace/project records and touched no agents. The workspace came back empty, and every thread that was live when it was archived stayed archived.

## The change

Archive stamps each agent it takes from unarchived to archived with `archivedWithWorkspaceId`. Workspace unarchive (`unarchiveWorkspaceContents`) then restores exactly that set: provider-native unarchive hooks run (e.g. Codex `thread/unarchive`), the stamp clears, and stored agent state is dispatched so connected clients see the threads return without a manual refetch.

Agents archived individually beforehand carry no stamp and stay archived — restore never resurrects something the user put away on purpose. Unarchiving an agent individually also clears its stamp, so a later workspace restore leaves it alone.

The stamp is storage-only and never crosses the wire; no protocol change.

Wired into the session's `unarchiveWorkspace` callback, so both recovery actions (plain "unarchive" and worktree "restore") get it. The implicit reuse-an-archived-workspace-for-a-directory path in `workspace-provisioning-service.ts` is deliberately untouched.

## The race this had to avoid

Stamping needs a read-modify-write, and `archiveAgent` closes the agent — which fires an un-awaited background persist. `writeRecord` only updates the cache *after* its atomic file write resolves, so reading the record from outside the write queue could return a stale copy and clobber that persist on write-back.

`AgentStorage.updateRecord` runs the mutator *inside* the per-agent write queue instead, so it always sees the current record. A regression test covers this and fails under the naive `get()` + `upsert()` pattern.

## Behavior change to a documented rule

`docs/agent-lifecycle.md` previously documented the old behavior as intended ("Other archived agents in the restored workspace remain recoverable from History"). This PR deliberately changes that; the doc is updated to match. Flagging it explicitly since it's a design call, not a regression fix.

## Tests

- Workspace archive → unarchive round trip on a real `AgentManager` + `AgentStorage`: two workspace agents restored with native hooks and state dispatch, a pre-archived agent left archived, an other-workspace agent untouched.
- Stamp survives the `applySnapshot` projection (which would otherwise silently drop it).
- `updateRecord` sees a concurrent in-flight write; declines cleanly; returns null for unknown agents.

278 passed / 4 skipped across the four touched test files. Typecheck, lint, and format clean.

## Not covered here

App-side tab restore isn't verified end-to-end in the running UI. The daemon-side dispatch should repopulate sidebar and agent lists, but I haven't confirmed tab behavior in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)