### PR TITLE
feat(quota): gemini fetcher, grok token refresh, claude cred merge fix

### DIFF
--- a/packages/server/src/services/quota-fetcher/manifest.ts
+++ b/packages/server/src/services/quota-fetcher/manifest.ts
@@ -7,6 +7,7 @@ import { ClaudeQuotaProvider } from "./providers/claude.js";
 import { CodexQuotaProvider } from "./providers/codex.js";
 import { CopilotQuotaProvider } from "./providers/copilot.js";
 import { CursorQuotaProvider } from "./providers/cursor.js";
+import { GeminiQuotaProvider } from "./providers/gemini.js";
 import { GrokQuotaProvider } from "./providers/grok.js";
 import { KimiQuotaProvider } from "./providers/kimi.js";
 import { MiniMaxQuotaProvider } from "./providers/minimax.js";
@@ -44,6 +45,10 @@ export const PROVIDER_USAGE_FETCHERS: readonly ProviderUsageFetcherManifestEntry
   {
     providerId: "grok",
     create: (options) => new GrokQuotaProvider({ logger: options.logger, fetch: options.fetch }),
+  },
+  {
+    providerId: "gemini",
+    create: (options) => new GeminiQuotaProvider({ logger: options.logger, fetch: options.fetch }),
   },
   {
     providerId: "kimi",

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -491,11 +491,15 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
     oauth: ClaudeCredentials["claudeAiOauth"],
   ): Promise<void> {
     try {
-      const existing = ClaudeCredentialsSchema.parse(
-        JSON.parse(await fs.readFile(credPath, "utf8")),
-      );
-      existing.claudeAiOauth = oauth;
-      await fs.writeFile(credPath, JSON.stringify(existing, null, 2), { mode: 0o600 });
+      // Merge into the raw document: parsing through ClaudeCredentialsSchema
+      // would strip sibling keys (mcpOAuth, expiresAt, scopes, ...) on write.
+      const existing: unknown = JSON.parse(await fs.readFile(credPath, "utf8"));
+      const record =
+        existing && typeof existing === "object" && !Array.isArray(existing)
+          ? (existing as Record<string, unknown>)
+          : {};
+      record["claudeAiOauth"] = oauth;
+      await fs.writeFile(credPath, JSON.stringify(record, null, 2), { mode: 0o600 });
     } catch {
       // Non-fatal; Claude Code can refresh again on its own next time.
     }

--- a/packages/server/src/services/quota-fetcher/providers/gemini.ts
+++ b/packages/server/src/services/quota-fetcher/providers/gemini.ts
@@ -1,0 +1,279 @@
+import { existsSync, readdirSync, promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Logger } from "pino";
+import { z } from "zod";
+import type {
+  ProviderUsage,
+  ProviderUsageDetail,
+  ProviderUsageWindow,
+} from "../../../server/messages.js";
+import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
+import {
+  ApiNumberSchema,
+  fetchProviderApi,
+  toneFromUsedPct,
+  unavailableUsage,
+  windowFromUsedPct,
+} from "../usage.js";
+
+const GEMINI_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GEMINI_QUOTA_URL = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
+const GEMINI_TOKEN_EXPIRY_SKEW_MS = 60_000;
+const GOOGLE_CLIENT_ID_RE = /\d+-[a-z0-9]+\.apps\.googleusercontent\.com/;
+const GOOGLE_CLIENT_SECRET_RE = /GOCSPX-[A-Za-z0-9_-]+/;
+
+const GeminiCredsSchema = z.object({
+  access_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  expiry_date: ApiNumberSchema.optional(),
+});
+
+const GeminiTokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  expires_in: ApiNumberSchema.optional(),
+});
+
+const GeminiQuotaResponseSchema = z.object({
+  buckets: z
+    .array(
+      z.object({
+        modelId: z.string().nullish(),
+        remainingFraction: ApiNumberSchema.nullish(),
+        remainingAmount: z.coerce.string().nullish(),
+        resetTime: z.string().nullish(),
+      }),
+    )
+    .nullish(),
+});
+
+type GeminiCreds = z.infer<typeof GeminiCredsSchema>;
+
+interface GoogleOAuthClient {
+  id: string;
+  secret: string;
+}
+
+let cachedOAuthClient: GoogleOAuthClient | null | undefined;
+
+/**
+ * The Gemini CLI's installed-app OAuth client is needed to refresh expired
+ * ~/.gemini/oauth_creds.json tokens. It is resolved at runtime (never
+ * committed): env override first, then extracted from the local gemini-cli
+ * bundle (the auth chunk references oauth_creds; the secret sits next to the id).
+ */
+async function resolveGeminiOAuthClient(): Promise<GoogleOAuthClient | null> {
+  if (cachedOAuthClient !== undefined) return cachedOAuthClient;
+  cachedOAuthClient = null;
+  const envId = process.env["GEMINI_OAUTH_CLIENT_ID"];
+  const envSecret = process.env["GEMINI_OAUTH_CLIENT_SECRET"];
+  if (envId && envSecret) {
+    cachedOAuthClient = { id: envId, secret: envSecret };
+    return cachedOAuthClient;
+  }
+  for (const dir of geminiCliBundleDirs()) {
+    try {
+      if (!existsSync(dir)) continue;
+      const files = (await fs.readdir(dir)).filter((f) => f.endsWith(".js"));
+      let fallback: GoogleOAuthClient | null = null;
+      for (const file of files) {
+        const text = await fs.readFile(join(dir, file), "utf8");
+        const secretMatch = text.match(GOOGLE_CLIENT_SECRET_RE);
+        if (!secretMatch || secretMatch.index === undefined) continue;
+        const window = text.slice(
+          Math.max(0, secretMatch.index - 500),
+          secretMatch.index + 500,
+        );
+        const id = window.match(GOOGLE_CLIENT_ID_RE)?.[0];
+        if (!id) continue;
+        const client = { id, secret: secretMatch[0] };
+        if (text.includes("oauth_creds")) {
+          cachedOAuthClient = client;
+          return cachedOAuthClient;
+        }
+        fallback ??= client;
+      }
+      if (fallback) {
+        cachedOAuthClient = fallback;
+        return cachedOAuthClient;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return cachedOAuthClient;
+}
+
+function geminiCliBundleDirs(): string[] {
+  const dirs: string[] = [];
+  if (process.env["GEMINI_CLI_BUNDLE_DIR"]) dirs.push(process.env["GEMINI_CLI_BUNDLE_DIR"]);
+  if (process.platform === "win32") {
+    const appData = process.env["APPDATA"];
+    if (appData) {
+      dirs.push(join(appData, "npm", "node_modules", "@google", "gemini-cli", "bundle"));
+    }
+  }
+  const nvmRoot = join(homedir(), ".nvm", "versions", "node");
+  try {
+    if (existsSync(nvmRoot)) {
+      for (const ver of readdirSync(nvmRoot)) {
+        dirs.push(join(nvmRoot, ver, "lib", "node_modules", "@google", "gemini-cli", "bundle"));
+      }
+    }
+  } catch {
+    // No nvm layout; nothing more to try.
+  }
+  return dirs;
+}
+
+interface GeminiQuotaProviderOptions {
+  logger: Logger;
+  fetch?: ProviderApiFetch;
+  /** Code Assist project; defaults to GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_QUOTA_PROJECT. */
+  projectId?: string;
+}
+
+export class GeminiQuotaProvider implements ProviderUsageFetcher {
+  readonly providerId = "gemini";
+  readonly displayName = "Gemini";
+
+  private readonly logger: Logger;
+  private readonly fetchApi: ProviderApiFetch;
+  private readonly projectId: string | undefined;
+
+  constructor(options: GeminiQuotaProviderOptions) {
+    this.logger = options.logger;
+    this.fetchApi = options.fetch ?? fetch;
+    this.projectId =
+      options.projectId ??
+      process.env["GOOGLE_CLOUD_PROJECT"] ??
+      process.env["GOOGLE_CLOUD_QUOTA_PROJECT"];
+  }
+
+  async fetchUsage(): Promise<ProviderUsage> {
+    if (!this.projectId) {
+      return unavailableUsage({
+        providerId: this.providerId,
+        displayName: this.displayName,
+        error: "no Code Assist project (set GOOGLE_CLOUD_PROJECT)",
+      });
+    }
+    const token = await this.readAccessToken();
+    if (!token) return unavailableUsage(this);
+
+    const res = await fetchProviderApi(this.fetchApi, GEMINI_QUOTA_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ project: this.projectId }),
+    });
+
+    if (!res.ok) {
+      this.logger.debug({ status: res.status }, "Gemini quota fetch failed");
+      return unavailableUsage(this);
+    }
+
+    const resp = GeminiQuotaResponseSchema.parse(await res.json());
+    const windows: ProviderUsageWindow[] = [];
+    for (const bucket of resp.buckets ?? []) {
+      if (!bucket.modelId || bucket.remainingFraction == null) continue;
+      const usedPct = Math.max(0, Math.min(100, (1 - bucket.remainingFraction) * 100));
+      windows.push(
+        windowFromUsedPct({
+          id: `model_${bucket.modelId}`,
+          label: bucket.modelId,
+          utilizationPct: usedPct,
+          resetsAt: bucket.resetTime ?? null,
+          tone: toneFromUsedPct(usedPct),
+        }),
+      );
+    }
+    windows.sort((a, b) => (b.usedPct ?? -1) - (a.usedPct ?? -1));
+
+    const details: ProviderUsageDetail[] = [
+      { id: "project", label: "Project", value: this.projectId },
+    ];
+
+    return {
+      providerId: this.providerId,
+      displayName: this.displayName,
+      status: "available",
+      planLabel: null,
+      windows,
+      balances: [],
+      details,
+      error: null,
+    };
+  }
+
+  private async readAccessToken(): Promise<string | null> {
+    for (const path of this.candidateCredPaths()) {
+      const token = await this.readTokenFromFile(path);
+      if (token) return token;
+    }
+    return null;
+  }
+
+  private candidateCredPaths(): string[] {
+    const paths: string[] = [];
+    if (process.env["GEMINI_OAUTH_CREDS"]) paths.push(process.env["GEMINI_OAUTH_CREDS"]);
+    paths.push(join(homedir(), ".gemini", "oauth_creds.json"));
+    return paths;
+  }
+
+  private async readTokenFromFile(path: string): Promise<string | null> {
+    if (!existsSync(path)) return null;
+    let raw: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(await fs.readFile(path, "utf8"));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+      raw = parsed as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+    const creds = GeminiCredsSchema.safeParse(raw);
+    if (!creds.success || !creds.data.access_token) return null;
+    const expiry = creds.data.expiry_date;
+    const fresh =
+      typeof expiry !== "number" || expiry > Date.now() + GEMINI_TOKEN_EXPIRY_SKEW_MS;
+    if (fresh) return creds.data.access_token;
+    if (!creds.data.refresh_token) return null;
+    return this.refreshCreds(path, raw, creds.data);
+  }
+
+  private async refreshCreds(
+    path: string,
+    raw: Record<string, unknown>,
+    creds: GeminiCreds,
+  ): Promise<string | null> {
+    const client = await resolveGeminiOAuthClient();
+    if (!client) return null;
+    try {
+      const res = await fetchProviderApi(this.fetchApi, GEMINI_TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: client.id,
+          client_secret: client.secret,
+          refresh_token: creds.refresh_token as string,
+          grant_type: "refresh_token",
+        }).toString(),
+      });
+      if (!res.ok) return null;
+      const tok = GeminiTokenResponseSchema.parse(await res.json());
+      if (!tok.access_token) return null;
+
+      raw["access_token"] = tok.access_token;
+      if (tok.refresh_token) raw["refresh_token"] = tok.refresh_token;
+      raw["expiry_date"] = Date.now() + Number(tok.expires_in ?? 3600) * 1000;
+      await fs.writeFile(path, JSON.stringify(raw, null, 2));
+      return tok.access_token;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -3,7 +3,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Logger } from "pino";
 import { z } from "zod";
-import type { ProviderUsage, ProviderUsageBalance } from "../../../server/messages.js";
+import type {
+  ProviderUsage,
+  ProviderUsageBalance,
+  ProviderUsageDetail,
+} from "../../../server/messages.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNumberSchema,
@@ -26,6 +30,7 @@ const GrokUsageResponseSchema = z.object({
           val: ApiNumberSchema.optional(),
         })
         .nullish(),
+      billingPeriodEnd: z.string().nullish(),
     })
     .nullish(),
   usage: z
@@ -35,6 +40,24 @@ const GrokUsageResponseSchema = z.object({
     .nullish(),
 });
 
+const GrokTokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  expires_in: ApiNumberSchema.optional(),
+});
+
+const GROK_TOKEN_EXPIRY_SKEW_MS = 60_000;
+const GROK_DEFAULT_ISSUER = "https://auth.x.ai";
+
+interface GrokAuthEntry {
+  topKey: string | null;
+  token: string;
+  expiresAt: string | null;
+  refreshToken: string | null;
+  issuer: string | null;
+  clientId: string | null;
+}
+
 interface GrokQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
@@ -42,28 +65,55 @@ interface GrokQuotaProviderOptions {
   homeDir?: string;
 }
 
-/** Resolve a Grok CLI token from ~/.grok/auth.json (legacy or current nested shape). */
-export function extractGrokTokenFromAuth(auth: unknown): string | null {
-  if (auth == null || typeof auth !== "object" || Array.isArray(auth)) return null;
+function isExpired(expiresAt: string | null): boolean {
+  if (!expiresAt) return false;
+  const parsed = Date.parse(expiresAt);
+  return !Number.isNaN(parsed) && parsed <= Date.now() + GROK_TOKEN_EXPIRY_SKEW_MS;
+}
+
+function entryFromValue(topKey: string | null, value: unknown): GrokAuthEntry | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const token = record["access_token"] ?? record["key"];
+  if (typeof token !== "string" || token.length === 0) return null;
+  const scopedIssuer = topKey?.includes("::") ? topKey.split("::")[0] : null;
+  const scopedClient = topKey?.includes("::") ? topKey.split("::")[1] : null;
+  return {
+    topKey,
+    token,
+    expiresAt: typeof record["expires_at"] === "string" ? record["expires_at"] : null,
+    refreshToken: typeof record["refresh_token"] === "string" ? record["refresh_token"] : null,
+    issuer: typeof record["oidc_issuer"] === "string" ? record["oidc_issuer"] : scopedIssuer,
+    clientId:
+      typeof record["oidc_client_id"] === "string" ? record["oidc_client_id"] : scopedClient,
+  };
+}
+
+/** All usable auth entries from ~/.grok/auth.json (legacy flat or current nested shape). */
+function extractGrokAuthEntries(auth: unknown): GrokAuthEntry[] {
+  if (auth == null || typeof auth !== "object" || Array.isArray(auth)) return [];
   const record = auth as Record<string, unknown>;
 
-  const topLevel = record["access_token"];
-  if (typeof topLevel === "string" && topLevel.length > 0) {
-    return topLevel;
+  const entries: GrokAuthEntry[] = [];
+  const flat = entryFromValue(null, record);
+  if (flat) entries.push(flat);
+
+  const scoped = Object.entries(record).filter(([key]) =>
+    key.startsWith("https://auth.x.ai::"),
+  );
+  const candidates = scoped.length > 0 ? scoped : Object.entries(record);
+  for (const [key, value] of candidates) {
+    const entry = entryFromValue(key, value);
+    if (entry) entries.push(entry);
   }
+  return entries;
+}
 
-  const entries = Object.entries(record);
-  const preferred = entries.filter(([key]) => key.startsWith("https://auth.x.ai::"));
-  const candidates = preferred.length > 0 ? preferred : entries;
-
-  for (const [, value] of candidates) {
-    if (value == null || typeof value !== "object" || Array.isArray(value)) continue;
-    const nestedKey = (value as Record<string, unknown>)["key"];
-    if (typeof nestedKey === "string" && nestedKey.length > 0) {
-      return nestedKey;
-    }
+/** Resolve a Grok CLI token from ~/.grok/auth.json (legacy or current nested shape). */
+export function extractGrokTokenFromAuth(auth: unknown): string | null {
+  for (const entry of extractGrokAuthEntries(auth)) {
+    if (!isExpired(entry.expiresAt)) return entry.token;
   }
-
   return null;
 }
 
@@ -125,6 +175,15 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
       });
     }
 
+    const details: ProviderUsageDetail[] = [];
+    if (resp.config?.billingPeriodEnd) {
+      details.push({
+        id: "billing_period_end",
+        label: "Billing period ends",
+        value: resp.config.billingPeriodEnd.slice(0, 10),
+      });
+    }
+
     return {
       providerId: this.providerId,
       displayName: this.displayName,
@@ -132,17 +191,92 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
       planLabel: null,
       windows: [],
       balances,
-      details: [],
+      details,
       error: null,
     };
   }
 
   private async readGrokToken(): Promise<string | null> {
+    for (const path of this.candidateAuthPaths()) {
+      const token = await this.readTokenFromFile(path);
+      if (token) return token;
+    }
+    return null;
+  }
+
+  private candidateAuthPaths(): string[] {
+    const paths: string[] = [];
+    if (process.env["GROK_AUTH_FILE"]) paths.push(process.env["GROK_AUTH_FILE"]);
     // homeDir override is for tests: Windows os.homedir() ignores $HOME (uses USERPROFILE).
-    const path = join(this.homeDir ?? homedir(), ".grok", "auth.json");
+    paths.push(join(this.homeDir ?? homedir(), ".grok", "auth.json"));
+    return paths;
+  }
+
+  private async readTokenFromFile(path: string): Promise<string | null> {
     if (!existsSync(path)) return null;
+    let raw: Record<string, unknown>;
     try {
-      return extractGrokTokenFromAuth(JSON.parse(await fs.readFile(path, "utf8")));
+      const parsed: unknown = JSON.parse(await fs.readFile(path, "utf8"));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+      raw = parsed as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+
+    const entries = extractGrokAuthEntries(raw);
+    for (const entry of entries) {
+      if (!isExpired(entry.expiresAt)) return entry.token;
+    }
+    // Every stored token is expired: refresh via OIDC and persist the rotated
+    // tokens back to the same file, exactly like the Grok CLI does.
+    for (const entry of entries) {
+      if (!entry.refreshToken) continue;
+      const token = await this.refreshEntry(path, raw, entry);
+      if (token) return token;
+    }
+    return null;
+  }
+
+  private async refreshEntry(
+    path: string,
+    raw: Record<string, unknown>,
+    entry: GrokAuthEntry,
+  ): Promise<string | null> {
+    const issuer = entry.issuer ?? GROK_DEFAULT_ISSUER;
+    try {
+      const discoRes = await fetchProviderApi(
+        this.fetchApi,
+        `${issuer}/.well-known/openid-configuration`,
+        { headers: { Accept: "application/json" } },
+      );
+      if (!discoRes.ok) return null;
+      const tokenEndpoint = z
+        .object({ token_endpoint: z.string() })
+        .parse(await discoRes.json()).token_endpoint;
+
+      const res = await fetchProviderApi(this.fetchApi, tokenEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: entry.refreshToken as string,
+          ...(entry.clientId ? { client_id: entry.clientId } : {}),
+        }).toString(),
+      });
+      if (!res.ok) return null;
+      const tok = GrokTokenResponseSchema.parse(await res.json());
+      if (!tok.access_token) return null;
+
+      const target = entry.topKey ? raw[entry.topKey] : raw;
+      if (!target || typeof target !== "object" || Array.isArray(target)) return null;
+      const record = target as Record<string, unknown>;
+      record["key"] = tok.access_token;
+      if (tok.refresh_token) record["refresh_token"] = tok.refresh_token;
+      record["expires_at"] = new Date(
+        Date.now() + Number(tok.expires_in ?? 3600) * 1000,
+      ).toISOString();
+      await fs.writeFile(path, JSON.stringify(raw, null, 2));
+      return tok.access_token;
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary

Three independent quota-fetcher fixes, found while running the fetchers against real CLI credential files on Windows + WSL:

- **claude**: \saveClaudeCredentials\ wrote back the zod-parsed document, which strips unknown keys — refreshing a token deleted \mcpOAuth\, \expiresAt\, \scopes\, etc. from \.credentials.json\, degrading the user's Claude Code login. Now merges into the raw document.
- **grok**: tokens in \~/.grok/auth.json\ expire every ~6h; an expired token silently made usage unavailable. Now: expired entries are skipped, and if every token is expired the fetcher runs the CLI's own OIDC flow (discovery → \efresh_token\ grant) and persists the rotated tokens back to the same file (write-back is required — xAI rotates refresh tokens). Also adds \GROK_AUTH_FILE\ env override and a billing-period-end detail.
- **gemini**: new fetcher for Code Assist subscriptions — \etrieveUserQuota\ per-model buckets (remainingFraction/resetTime) as usage windows. Refreshes expired \oauth_creds.json\ via the gemini-cli's installed-app OAuth client, which is resolved at runtime from the local gemini-cli bundle (or \GEMINI_OAUTH_CLIENT_ID\/\GEMINI_OAUTH_CLIENT_SECRET\ env) so no client credentials are committed. Project from \GOOGLE_CLOUD_PROJECT\/\GOOGLE_CLOUD_QUOTA_PROJECT\ or constructor option; reports a descriptive error when unset.

## Testing

- \	sc -p packages/server/tsconfig.server.json\ — the four changed files compile clean (full-project build on this machine has unrelated pre-existing drift in \cp-agent.ts\/\session.ts\ from a stale local \
ode_modules\, untouched by this PR).
- Verified live against real credential files: claude (Max) usage windows, grok monthly credits after a real token expiry + refresh round-trip, gemini per-model buckets on a Code Assist project.
- vitest not run locally (environment limitation); existing grok fixtures (tokens without \expires_at\) are unaffected — they're treated as non-expiring, same as before.