### PR TITLE
fix: apply paseo.json title overrides in non-git workspaces

### DIFF
--- a/packages/server/src/utils/build-metadata-prompt.test.ts
+++ b/packages/server/src/utils/build-metadata-prompt.test.ts
@@ -1,0 +1,100 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildMetadataPrompt, type RepoRootResolver } from "./build-metadata-prompt.js";
+
+describe("buildMetadataPrompt", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), "build-metadata-prompt-test-")));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const CONTRACT = "Produce the artifact.";
+  const DEFAULT_STYLE = "Default style guidance.";
+  const OVERRIDE_STYLE = "Custom override style from paseo.json.";
+  const REPO_ROOT_OVERRIDE = "Repo-root override style from paseo.json.";
+
+  function buildOptions(cwd: string, workspaceGitService?: RepoRootResolver) {
+    return {
+      cwd,
+      contract: CONTRACT,
+      styles: [{ configKey: "title" as const, default: DEFAULT_STYLE }],
+      after: "Seed prompt.",
+      workspaceGitService,
+    };
+  }
+
+  function writeTitleOverride(dir: string, instructions: string) {
+    writeFileSync(
+      join(dir, "paseo.json"),
+      JSON.stringify({ metadataGeneration: { title: { instructions } } }),
+    );
+  }
+
+  it("reads paseo.json overrides from the resolved git repo root", async () => {
+    // cwd has no paseo.json; the override lives only at the resolved repo root.
+    const repoRoot = join(tempDir, "repo");
+    mkdirSync(repoRoot);
+    writeTitleOverride(repoRoot, REPO_ROOT_OVERRIDE);
+    const resolver: RepoRootResolver = { resolveRepoRoot: async () => repoRoot };
+
+    const prompt = await buildMetadataPrompt(buildOptions(tempDir, resolver));
+
+    expect(prompt).toContain(REPO_ROOT_OVERRIDE);
+    expect(prompt).not.toContain(DEFAULT_STYLE);
+  });
+
+  it("falls back to cwd when resolveRepoRoot throws in a non-git directory", async () => {
+    writeTitleOverride(tempDir, OVERRIDE_STYLE);
+    const resolver: RepoRootResolver = {
+      resolveRepoRoot: async () => {
+        throw new Error("Create worktree requires a git repository");
+      },
+    };
+
+    const prompt = await buildMetadataPrompt(buildOptions(tempDir, resolver));
+
+    expect(prompt).toContain(OVERRIDE_STYLE);
+    expect(prompt).not.toContain(DEFAULT_STYLE);
+  });
+
+  it("reads overrides from cwd when no workspace git service is provided", async () => {
+    writeTitleOverride(tempDir, OVERRIDE_STYLE);
+
+    const prompt = await buildMetadataPrompt(buildOptions(tempDir));
+
+    expect(prompt).toContain(OVERRIDE_STYLE);
+    expect(prompt).not.toContain(DEFAULT_STYLE);
+  });
+
+  it("uses the default style when no paseo.json exists in the fallback dir", async () => {
+    const resolver: RepoRootResolver = {
+      resolveRepoRoot: async () => {
+        throw new Error("Create worktree requires a git repository");
+      },
+    };
+
+    const prompt = await buildMetadataPrompt(buildOptions(tempDir, resolver));
+
+    expect(prompt).toContain(DEFAULT_STYLE);
+  });
+
+  it("uses the default style when paseo.json is invalid JSON", async () => {
+    writeFileSync(join(tempDir, "paseo.json"), "{ invalid json\n");
+    const resolver: RepoRootResolver = {
+      resolveRepoRoot: async () => {
+        throw new Error("Create worktree requires a git repository");
+      },
+    };
+
+    const prompt = await buildMetadataPrompt(buildOptions(tempDir, resolver));
+
+    expect(prompt).toContain(DEFAULT_STYLE);
+  });
+});

--- a/packages/server/src/utils/build-metadata-prompt.ts
+++ b/packages/server/src/utils/build-metadata-prompt.ts
@@ -47,16 +47,31 @@ function renderStyleSection(section: MetadataStyleSection, override: string | un
 async function readProjectMetadataOverrides(
   options: Pick<BuildMetadataPromptOptions, "cwd" | "workspaceGitService">,
 ): Promise<PaseoMetadataGeneration | undefined> {
-  if (!options.workspaceGitService) {
-    return undefined;
-  }
+  const configDir = await resolveMetadataConfigDir(options);
   try {
-    const repoRoot = await options.workspaceGitService.resolveRepoRoot(options.cwd);
-    const json = readPaseoConfigJson(repoRoot);
+    const json = readPaseoConfigJson(configDir);
     return PaseoConfigSchema.parse(json).metadataGeneration;
   } catch {
     return undefined;
   }
+}
+
+// The directory to read paseo.json overrides from. In a git repo resolveRepoRoot
+// returns the repo root. Non-git directories make it throw ("Create worktree
+// requires a git repository"); since a non-git workspace keeps its paseo.json at
+// its own root, fall back to options.cwd. We deliberately do not walk parent
+// directories — for a non-git workspace the cwd is the project root by definition.
+async function resolveMetadataConfigDir(
+  options: Pick<BuildMetadataPromptOptions, "cwd" | "workspaceGitService">,
+): Promise<string> {
+  if (options.workspaceGitService) {
+    try {
+      return await options.workspaceGitService.resolveRepoRoot(options.cwd);
+    } catch {
+      // Non-git directory — fall back to the workspace cwd below.
+    }
+  }
+  return options.cwd;
 }
 
 function isNonEmptyString(value: unknown): value is string {


### PR DESCRIPTION
## Problem

In a non-git workspace, the auto-generated session title ignores `metadataGeneration.title.instructions` from `paseo.json` and always uses the default English title style.

## Root cause

`buildMetadataPrompt` reads project overrides via `resolveRepoRoot(cwd)` → `readPaseoConfigJson(repoRoot)`. `resolveRepoRoot` throws `"Create worktree requires a git repository"` for non-git directories (`workspace-git-service.ts:680`), and the surrounding `try/catch` swallowed that as "no override" — so non-git workspaces never read their `paseo.json`.

This affects every consumer of `buildMetadataPrompt`: the title/branch generator (`worktree-branch-name-generator.ts`) and the commit-message / PR-text generators (`git-metadata-generator.ts`).

## Fix

Add `resolveMetadataConfigDir`: when `resolveRepoRoot` throws (non-git) or no git resolver is injected, fall back to `options.cwd`. For a non-git workspace the cwd is the project root by definition, so the override is read from `<cwd>/paseo.json`.

- Only the metadata-config lookup changes; `resolveRepoRoot` itself is untouched (its "throw on non-git" semantics are relied on by `worktree-core`, `codex-app-server-agent`, etc.).
- Parent-directory walking is intentionally not added (precedent: `codex-app-server-agent.ts` does `resolveRepoRoot(cwd).catch(() => null)`).
- Missing or invalid `paseo.json` still yields the default style — unchanged.

## Tests

New `build-metadata-prompt.test.ts` (5 cases):
1. reads overrides from the resolved git repo root
2. falls back to cwd when `resolveRepoRoot` throws (non-git) — the core fix
3. reads overrides from cwd when no git resolver is injected
4. uses default style when no `paseo.json` exists
5. uses default style when `paseo.json` is invalid JSON

## Verification

- `oxlint` / `oxfmt` on changed files — clean
- server `tsgo -p tsconfig.server.typecheck.json --noEmit` — clean
- `vitest run src/utils/build-metadata-prompt.test.ts` — 5/5 passed
- existing `git-metadata-generator.test.ts` unaffected (its resolver mock returns a path instead of throwing)