### PR TITLE
fix(acp): recover stale foreground turn on replace

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -879,7 +879,7 @@ test("reload leaves a closed durable snapshot when shutdown starts during the sw
   }
 });
 
-test("reload closes both sessions when the closed snapshot cannot be persisted", async () => {
+test("reload retains the existing session when the closed snapshot cannot be persisted", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-persist-failure-test-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
@@ -906,8 +906,6 @@ test("reload closes both sessions when the closed snapshot cannot be persisted",
     writeFileSync(storagePath, "blocks the storage directory");
 
     const reload = manager.reloadAgentSession(agentId).catch((error: unknown) => error);
-    await client.waitForCloseToStart();
-    client.finishClosing();
 
     expect(await reload).toBeInstanceOf(Error);
     await manager.flushForShutdown();
@@ -915,9 +913,9 @@ test("reload closes both sessions when the closed snapshot cannot be persisted",
       agents: manager.listAgents(),
       originalSessionClosed: client.originalSessionClosed,
       replacementSessionClosed: client.replacementSessionClosed,
-    }).toEqual({
-      agents: [],
-      originalSessionClosed: true,
+    }).toMatchObject({
+      agents: [{ id: agentId, lifecycle: "idle" }],
+      originalSessionClosed: false,
       replacementSessionClosed: true,
     });
   } finally {
@@ -8145,6 +8143,127 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
   expect(collectedEvents.some((e) => e.type === "turn_completed")).toBe(true);
   expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
   expect(manager.getAgent(snapshot.id)?.activeForegroundTurnId).toBeNull();
+}, 10_000);
+
+test("replaceAgentRun retains the existing agent when stale-session recovery registration fails", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-stale-fg-recovery-failure-"));
+  const storagePath = join(workdir, "agents");
+  let originalSessionId: string | null = null;
+  let failRecoveredRegistration = false;
+  let staleSessionClosed = false;
+  let resumedSessionCreated = false;
+
+  class FailingRecoveredRegistrationStorage extends AgentStorage {
+    override async applySnapshot(
+      ...args: Parameters<AgentStorage["applySnapshot"]>
+    ): Promise<void> {
+      const [agent] = args;
+      if (
+        failRecoveredRegistration &&
+        originalSessionId !== null &&
+        agent.persistence?.sessionId !== originalSessionId
+      ) {
+        throw new Error("Injected recovery registration failure");
+      }
+      await super.applySnapshot(...args);
+    }
+  }
+
+  class StaleForegroundSession extends TestAgentSession {
+    private providerTurnIsStillActive = false;
+    private localTurnCounter = 0;
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      if (this.providerTurnIsStillActive) {
+        throw new Error("A foreground turn is already active");
+      }
+      this.providerTurnIsStillActive = true;
+      const turnId = `turn-${++this.localTurnCounter}`;
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
+
+    override async interrupt(): Promise<void> {}
+
+    override async close(): Promise<void> {
+      staleSessionClosed = true;
+    }
+  }
+
+  class RecoveredForegroundSession extends TestAgentSession {
+    override async startTurn(): Promise<{ turnId: string }> {
+      const turnId = "turn-recovered";
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+        this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
+  }
+
+  class StaleForegroundClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new StaleForegroundSession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      resumedSessionCreated = true;
+      return new RecoveredForegroundSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const storage = new FailingRecoveredRegistrationStorage(storagePath, logger);
+  const manager = new AgentManager({
+    clients: { codex: new StaleForegroundClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000501",
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  originalSessionId = manager.getAgent(snapshot.id)?.persistence?.sessionId ?? null;
+  expect(originalSessionId).not.toBeNull();
+
+  const firstRun = manager.streamAgent(snapshot.id, "hanging prompt");
+  const firstRunDrain = (async () => {
+    for await (const _event of firstRun) {
+      // Draining the intentionally unterminated foreground turn.
+    }
+  })();
+  await manager.waitForAgentRunStart(snapshot.id);
+
+  failRecoveredRegistration = true;
+  await expect(manager.replaceAgentRun(snapshot.id, "replacement prompt")).rejects.toThrow(
+    "Injected recovery registration failure",
+  );
+
+  expect(manager.getAgent(snapshot.id)).toMatchObject({
+    id: snapshot.id,
+    lifecycle: "running",
+    activeForegroundTurnId: null,
+  });
+  expect(staleSessionClosed).toBe(false);
+
+  failRecoveredRegistration = false;
+  const retryRun = await manager.replaceAgentRun(snapshot.id, "retry replacement prompt");
+  for await (const _event of retryRun) {
+    // Drain the recovered retry.
+  }
+  await firstRunDrain;
+
+  expect(resumedSessionCreated).toBe(true);
+  expect(staleSessionClosed).toBe(true);
+  expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
 }, 10_000);
 
 class RecordingPersistedAgentsClient implements AgentClient {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -8035,26 +8035,26 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
   const allowSecondRunToEnd = deferred<void>();
+  let staleSessionClosed = false;
+  let resumedSessionCreated = false;
 
-  // Session where the first foreground turn never emits a terminal event
-  // (simulates the claude-agent pendingInterruptAbort suppression bug),
-  // and interrupt() does not produce events either.
+  // Session where the first foreground turn never emits a terminal event and
+  // interrupt() does not produce events either.
   class StaleForegroundSession extends TestAgentSession {
+    private providerTurnIsStillActive = false;
+
     override async startTurn(): Promise<{ turnId: string }> {
+      if (this.providerTurnIsStillActive) {
+        throw new Error("A foreground turn is already active");
+      }
       this.interrupted = false;
+      this.providerTurnIsStillActive = true;
       const turnId = `turn-${++this.turnIdCounter}`;
-      const turnNum = this.turnIdCounter;
 
       setTimeout(async () => {
         this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
-        if (turnNum === 1) {
-          // First turn: emit turn_started but NEVER emit a terminal event.
-          // This simulates the provider suppressing the result.
-        } else {
-          // Subsequent turns: complete normally
-          await allowSecondRunToEnd.promise;
-          this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
-        }
+        // The provider accepts cancel but never settles this turn, so a new
+        // prompt on the same session is rejected as still active.
       }, 0);
       return { turnId };
     }
@@ -8063,11 +8063,38 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
       this.interrupted = true;
       // No events produced — the terminal event was suppressed
     }
+
+    override async close(): Promise<void> {
+      staleSessionClosed = true;
+    }
+  }
+
+  class RecoveredForegroundSession extends TestAgentSession {
+    override async startTurn(): Promise<{ turnId: string }> {
+      const turnId = "turn-recovered";
+      setTimeout(async () => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+        await allowSecondRunToEnd.promise;
+        this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
   }
 
   class StaleForegroundClient extends TestAgentClient {
     override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
       return new StaleForegroundSession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      resumedSessionCreated = true;
+      return new RecoveredForegroundSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
     }
   }
 
@@ -8096,9 +8123,9 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
   expect(beforeReplace?.lifecycle).toBe("running");
   expect(beforeReplace?.activeForegroundTurnId).toBe("turn-1");
 
-  // Replace the hung run. cancelAgentRun will time out after 2s because
-  // no terminal event arrives. After the fix, it should force-clear the
-  // stale foreground state so streamAgent can proceed.
+  // Replace the hung run. Cancellation times out because no terminal event
+  // arrives. Paseo must recreate the provider session before starting the
+  // replacement because the original session still rejects new foreground turns.
   const secondRun = await manager.replaceAgentRun(snapshot.id, "replacement prompt");
   const collectedEvents: AgentStreamEvent[] = [];
   const secondRunDrain = (async () => {
@@ -8113,6 +8140,8 @@ test("replaceAgentRun succeeds when foreground turn terminal event is never deli
   await secondRunDrain;
   await firstRunDrain;
 
+  expect(staleSessionClosed).toBe(true);
+  expect(resumedSessionCreated).toBe(true);
   expect(collectedEvents.some((e) => e.type === "turn_completed")).toBe(true);
   expect(manager.getAgent(snapshot.id)?.lifecycle).toBe("idle");
   expect(manager.getAgent(snapshot.id)?.activeForegroundTurnId).toBeNull();

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -8252,6 +8252,12 @@ test("replaceAgentRun retains the existing agent when stale-session recovery reg
     lifecycle: "running",
     activeForegroundTurnId: null,
   });
+  const restartedStorage = new AgentStorage(storagePath, logger);
+  expect(await restartedStorage.get(snapshot.id)).toMatchObject({
+    id: snapshot.id,
+    lastStatus: "running",
+    persistence: { sessionId: originalSessionId },
+  });
   expect(staleSessionClosed).toBe(false);
 
   failRecoveredRegistration = false;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1242,15 +1242,13 @@ export class AgentManager {
       : await client.createSession(providerLaunchConfig, launchContext);
 
     let handedToRegistration = false;
+    let existingPreparedForClosure = false;
     try {
       this.assertAcceptingAgentRegistrations();
 
       const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
-      try {
-        await this.persistSnapshot(closedExisting);
-      } finally {
-        await this.closeReloadedSession(existing.session, agentId);
-      }
+      existingPreparedForClosure = true;
+      await this.persistSnapshot(closedExisting);
 
       if (rehydrateFromDisk) {
         // Wipe both durable and in-memory timeline so registerSession mints a
@@ -1264,8 +1262,7 @@ export class AgentManager {
       }
 
       // Preserve existing labels and timeline during reload.
-      handedToRegistration = true;
-      return this.registerSession(session, storedConfig, agentId, {
+      const reloaded = await this.registerSession(session, storedConfig, agentId, {
         labels: existing.labels,
         workspaceId: existing.workspaceId,
         owner: existing.owner,
@@ -1277,6 +1274,31 @@ export class AgentManager {
         lastError: preservedLastError,
         attention: preservedAttention,
       });
+      handedToRegistration = true;
+      await this.closeReloadedSession(existing.session, agentId);
+      this.assertAcceptingAgentRegistrations();
+      this.assertAgentRegistrationActive(this.requireSessionAgent(agentId));
+      return reloaded;
+    } catch (error) {
+      if (existingPreparedForClosure && this.acceptingAgentRegistrations) {
+        const partiallyRegistered = this.agents.get(agentId);
+        if (partiallyRegistered && partiallyRegistered !== existing) {
+          this.prepareAgentForClosure(partiallyRegistered, "agent reload rolled back");
+        }
+        this.agents.set(agentId, existing);
+        this.previousStatuses.set(agentId, existing.lifecycle);
+        this.subscribeToSession(existing);
+        try {
+          await this.persistSnapshot(existing);
+        } catch (persistError) {
+          this.logger.warn(
+            { err: persistError, agentId },
+            "Failed to restore previous agent snapshot after reload failure",
+          );
+        }
+        this.emitState(existing, { persist: false });
+      }
+      throw error;
     } finally {
       if (!handedToRegistration) {
         await this.closeUnregisteredSession(session);

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -108,7 +108,7 @@ export class AgentRunCancellationError extends Error {
 
 export type AgentRunCancellationResult =
   | { status: "not_running" }
-  | { status: "settled" }
+  | { status: "settled"; forced?: boolean }
   | { status: "refused" };
 
 interface PreparedSessionConfig {
@@ -2106,7 +2106,10 @@ export class AgentManager {
     this.emitState(agent);
 
     try {
-      await this.cancelAgentRunBefore(agentId, "replace");
+      const cancellation = await this.cancelAgentRunBefore(agentId, "replace");
+      if (cancellation.status === "settled" && cancellation.forced) {
+        await this.reloadAgentSessionInternal(agentId);
+      }
       return this.streamAgent(agentId, prompt, options);
     } catch (error) {
       const latest = this.agents.get(agentId);
@@ -2279,6 +2282,7 @@ export class AgentManager {
       return { status: settlement === "completed" ? "settled" : "refused" };
     }
 
+    let forced = false;
     if (settlement === "timed_out" && run.turnId) {
       this.logger.warn(
         { agentId, turnId: run.turnId, kind: run.kind },
@@ -2291,6 +2295,7 @@ export class AgentManager {
         turnId: run.turnId,
       });
       await run.settledPromise;
+      forced = true;
     } else if (settlement === "timed_out" && run.kind === "autonomous") {
       this.logger.warn(
         { agentId, kind: run.kind },
@@ -2301,6 +2306,7 @@ export class AgentManager {
         provider: agent.provider,
         reason: "interrupted",
       });
+      forced = true;
     }
 
     if (agent.pendingPermissions.size > 0) {
@@ -2308,17 +2314,18 @@ export class AgentManager {
       this.touchUpdatedAt(agent);
       this.emitState(agent);
     }
-    return { status: "settled" };
+    return forced ? { status: "settled", forced: true } : { status: "settled" };
   }
 
   private async cancelAgentRunBefore(
     agentId: string,
     action: "reload" | "replace" | "rewind",
-  ): Promise<void> {
+  ): Promise<AgentRunCancellationResult> {
     const result = await this.cancelAgentRun(agentId);
     if (result.status === "refused") {
       throw new AgentRunCancellationError(agentId, action);
     }
+    return result;
   }
 
   private async interruptSession(session: AgentSession, agentId: string): Promise<boolean> {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1246,9 +1246,8 @@ export class AgentManager {
     try {
       this.assertAcceptingAgentRegistrations();
 
-      const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
+      this.prepareAgentForClosure(existing, "agent reloaded");
       existingPreparedForClosure = true;
-      await this.persistSnapshot(closedExisting);
 
       if (rehydrateFromDisk) {
         // Wipe both durable and in-memory timeline so registerSession mints a
@@ -1288,14 +1287,6 @@ export class AgentManager {
         this.agents.set(agentId, existing);
         this.previousStatuses.set(agentId, existing.lifecycle);
         this.subscribeToSession(existing);
-        try {
-          await this.persistSnapshot(existing);
-        } catch (persistError) {
-          this.logger.warn(
-            { err: persistError, agentId },
-            "Failed to restore previous agent snapshot after reload failure",
-          );
-        }
         this.emitState(existing, { persist: false });
       }
       throw error;


### PR DESCRIPTION
## Problem

If a provider acknowledges cancellation but never emits a terminal turn event, Paseo force-cancels its manager-side run after the timeout. The provider session can still retain its foreground turn. The next replacement prompt then fails with `A foreground turn is already active`.

## Fix

After that forced cancellation path, reload the agent session before starting the replacement prompt. Reloading resumes the persisted provider session while retaining the Paseo agent, timeline, labels, and workspace. Normal cancellations keep their existing result shape and do not reload.

## Regression coverage

The test models a provider that accepts cancellation, omits the terminal event, and rejects another foreground turn. It verifies that Paseo closes the stale session, resumes a replacement session, and completes the queued replacement prompt.

## Validation

- `npx vitest run src/server/agent/agent-manager.test.ts`
- `npm run typecheck --workspace=@getpaseo/server`
- `npm run lint -- packages/server/src/server/agent/agent-manager.ts packages/server/src/server/agent/agent-manager.test.ts`
- `npm run format:check:files -- packages/server/src/server/agent/agent-manager.ts packages/server/src/server/agent/agent-manager.test.ts`

Fixes #1936