### PR TITLE
Feat/task list subagent track

### DIFF
--- a/.omp/mcp.json
+++ b/.omp/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
+  "mcpServers": {
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
+    }
+  }
+}

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -33,12 +33,12 @@ import {
   UserMessage,
   ActivityLog,
   ToolCall,
+  TodoListCard,
   CompactionMarker,
   MessageOuterSpacingProvider,
   type InlinePathTarget,
 } from "@/components/message";
 import { PlanCard } from "@/components/plan-card";
-import { TaskListCard } from "@/components/task-list-card";
 import type { StreamItem } from "@/types/stream";
 import type { PendingMessageSubmission } from "@/composer/submission/model";
 import type { TurnPresentation } from "@/timeline/turn-liveness";
@@ -794,7 +794,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             );
 
           case "todo_list":
-            return <TaskListCard items={item.items} />;
+            return <TodoListCard items={item.items} />;
 
           case "compaction":
             return (

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -37,7 +37,6 @@ import {
   MessageOuterSpacingProvider,
   type InlinePathTarget,
 } from "@/components/message";
-import { TaskListCard } from "@/components/task-list-card";
 import { PlanCard } from "@/components/plan-card";
 import type { StreamItem } from "@/types/stream";
 import type { PendingMessageSubmission } from "@/composer/submission/model";
@@ -794,7 +793,13 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             );
 
           case "todo_list":
-            return <TaskListCard items={item.items} />;
+            return (
+              <ActivityLog
+                type="info"
+                message={`${item.items.filter((entry) => entry.completed).length}/${item.items.length} tasks`}
+                timestamp={item.timestamp.getTime()}
+              />
+            );
 
           case "compaction":
             return (

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -38,6 +38,7 @@ import {
   type InlinePathTarget,
 } from "@/components/message";
 import { PlanCard } from "@/components/plan-card";
+import { TodoListTimeline } from "@/components/task-list-card";
 import type { StreamItem } from "@/types/stream";
 import type { PendingMessageSubmission } from "@/composer/submission/model";
 import type { TurnPresentation } from "@/timeline/turn-liveness";
@@ -793,13 +794,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             );
 
           case "todo_list":
-            return (
-              <ActivityLog
-                type="info"
-                message={`${item.items.filter((entry) => entry.completed).length}/${item.items.length} tasks`}
-                timestamp={item.timestamp.getTime()}
-              />
-            );
+            return <TodoListTimeline items={item.items} />;
 
           case "compaction":
             return (

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -38,7 +38,7 @@ import {
   type InlinePathTarget,
 } from "@/components/message";
 import { PlanCard } from "@/components/plan-card";
-import { TodoListTimeline } from "@/components/task-list-card";
+import { TaskListCard } from "@/components/task-list-card";
 import type { StreamItem } from "@/types/stream";
 import type { PendingMessageSubmission } from "@/composer/submission/model";
 import type { TurnPresentation } from "@/timeline/turn-liveness";
@@ -794,7 +794,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             );
 
           case "todo_list":
-            return <TodoListTimeline items={item.items} />;
+            return <TaskListCard items={item.items} />;
 
           case "compaction":
             return (

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -33,11 +33,11 @@ import {
   UserMessage,
   ActivityLog,
   ToolCall,
-  TodoListCard,
   CompactionMarker,
   MessageOuterSpacingProvider,
   type InlinePathTarget,
 } from "@/components/message";
+import { TaskListCard } from "@/components/task-list-card";
 import { PlanCard } from "@/components/plan-card";
 import type { StreamItem } from "@/types/stream";
 import type { PendingMessageSubmission } from "@/composer/submission/model";
@@ -794,7 +794,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             );
 
           case "todo_list":
-            return <TodoListCard items={item.items} />;
+            return <TaskListCard items={item.items} />;
 
           case "compaction":
             return (

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -39,7 +39,6 @@ import {
   ChevronRight,
   ChevronDown,
   Check,
-  CheckSquare,
   Copy,
   TriangleAlertIcon,
   Scissors,
@@ -61,7 +60,7 @@ import Svg, { Defs, LinearGradient as SvgLinearGradient, Rect, Stop } from "reac
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { MarkdownRenderer, type MarkdownStyles } from "@/components/markdown/renderer";
-import type { TodoEntry, UserMessageImageAttachment } from "@/types/stream";
+import type { UserMessageImageAttachment } from "@/types/stream";
 import type { AgentAttachment } from "@getpaseo/protocol/messages";
 import type { ToolCallDetail } from "@getpaseo/protocol/agent-types";
 import { buildToolCallPresentation } from "@/tool-calls/presentation";
@@ -155,7 +154,6 @@ const MARKDOWN_ALLOWED_IMAGE_HANDLERS = [
 const MARKDOWN_TOP_LEVEL_MAX_EXCEEDED_ITEM = <Text key="dotdotdot">...</Text>;
 
 const ThemedMicVocal = withUnistyles(MicVocal);
-const ThemedTodoCheckIcon = withUnistyles(Check);
 const ThemedFileSymlinkIcon = withUnistyles(FileSymlink);
 const ThemedTriangleAlertIcon = withUnistyles(TriangleAlertIcon);
 const ThemedChevronRightIcon = withUnistyles(ChevronRight);
@@ -167,9 +165,6 @@ const foregroundMutedColorMapping = (theme: Theme) => ({
 });
 const mutedForegroundColorMapping = (theme: Theme) => ({
   color: theme.colors.mutedForeground,
-});
-const primaryForegroundColorMapping = (theme: Theme) => ({
-  color: theme.colors.primaryForeground,
 });
 const destructiveColorMapping = (theme: Theme) => ({ color: theme.colors.destructive });
 const WEB_TOOLCALL_SHIMMER_KEYFRAME_CSS = `
@@ -2102,125 +2097,6 @@ export const CompactionMarker = memo(function CompactionMarker({
       </View>
       <View style={compactionStylesheet.line} />
     </View>
-  );
-});
-
-interface TodoListCardProps {
-  items: TodoEntry[];
-  disableOuterSpacing?: boolean;
-}
-
-interface TodoListItemRowProps {
-  text: string;
-  completed: boolean;
-}
-
-function TodoListItemRow({ text, completed }: TodoListItemRowProps) {
-  const badgeStyle = useMemo(
-    () => [
-      todoListCardStylesheet.radioBadge,
-      completed
-        ? todoListCardStylesheet.radioBadgeComplete
-        : todoListCardStylesheet.radioBadgeIncomplete,
-    ],
-    [completed],
-  );
-  const textStyle = useMemo(
-    () => [todoListCardStylesheet.itemText, completed && todoListCardStylesheet.itemTextCompleted],
-    [completed],
-  );
-  return (
-    <View style={todoListCardStylesheet.itemRow}>
-      <View style={badgeStyle}>
-        {completed ? (
-          <ThemedTodoCheckIcon size={12} uniProps={primaryForegroundColorMapping} />
-        ) : null}
-      </View>
-      <Text style={textStyle}>{text}</Text>
-    </View>
-  );
-}
-
-const todoListCardStylesheet = StyleSheet.create((theme) => ({
-  detailsWrapper: {
-    padding: theme.spacing[2],
-  },
-  list: {
-    gap: theme.spacing[1],
-  },
-  itemRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[2],
-  },
-  radioBadge: {
-    width: 16,
-    height: 16,
-    borderRadius: 8,
-    backgroundColor: theme.colors.foregroundMuted,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  radioBadgeIncomplete: {
-    opacity: 0.55,
-  },
-  radioBadgeComplete: {
-    opacity: 0.95,
-  },
-  itemText: {
-    flex: 1,
-    color: theme.colors.foreground,
-    fontSize: theme.fontSize.base,
-  },
-  itemTextCompleted: {
-    color: theme.colors.foregroundMuted,
-    textDecorationLine: "line-through",
-  },
-  emptyText: {
-    color: theme.colors.foregroundMuted,
-    fontSize: theme.fontSize.base,
-  },
-}));
-
-export const TodoListCard = memo(function TodoListCard({
-  items,
-  disableOuterSpacing,
-}: TodoListCardProps) {
-  const { t } = useTranslation();
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  const nextTask = useMemo(() => items.find((item) => !item.completed)?.text, [items]);
-
-  const handleToggle = useCallback(() => {
-    setIsExpanded((prev) => !prev);
-  }, []);
-
-  const renderDetails = useCallback(() => {
-    return (
-      <View style={todoListCardStylesheet.detailsWrapper}>
-        <View style={todoListCardStylesheet.list}>
-          {items.length === 0 ? (
-            <Text style={todoListCardStylesheet.emptyText}>{t("message.todo.empty")}</Text>
-          ) : (
-            items.map((item) => (
-              <TodoListItemRow key={item.text} text={item.text} completed={item.completed} />
-            ))
-          )}
-        </View>
-      </View>
-    );
-  }, [items, t]);
-
-  return (
-    <ExpandableBadge
-      label={t("message.todo.title")}
-      secondaryLabel={nextTask}
-      icon={CheckSquare}
-      isExpanded={isExpanded}
-      onToggle={handleToggle}
-      renderDetails={renderDetails}
-      disableOuterSpacing={disableOuterSpacing}
-    />
   );
 });
 

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -39,6 +39,7 @@ import {
   ChevronRight,
   ChevronDown,
   Check,
+  CheckSquare,
   Copy,
   TriangleAlertIcon,
   Scissors,
@@ -60,7 +61,7 @@ import Svg, { Defs, LinearGradient as SvgLinearGradient, Rect, Stop } from "reac
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { MarkdownRenderer, type MarkdownStyles } from "@/components/markdown/renderer";
-import type { UserMessageImageAttachment } from "@/types/stream";
+import type { TodoEntry, UserMessageImageAttachment } from "@/types/stream";
 import type { AgentAttachment } from "@getpaseo/protocol/messages";
 import type { ToolCallDetail } from "@getpaseo/protocol/agent-types";
 import { buildToolCallPresentation } from "@/tool-calls/presentation";
@@ -167,6 +168,9 @@ const mutedForegroundColorMapping = (theme: Theme) => ({
   color: theme.colors.mutedForeground,
 });
 const destructiveColorMapping = (theme: Theme) => ({ color: theme.colors.destructive });
+const primaryForegroundColorMapping = (theme: Theme) => ({
+  color: theme.colors.primaryForeground,
+});
 const WEB_TOOLCALL_SHIMMER_KEYFRAME_CSS = `
   @keyframes ${WEB_TOOLCALL_SHIMMER_ANIMATION_NAME} {
     0% {
@@ -2097,6 +2101,104 @@ export const CompactionMarker = memo(function CompactionMarker({
       </View>
       <View style={compactionStylesheet.line} />
     </View>
+  );
+});
+const ThemedTodoCheckIcon = withUnistyles(Check);
+
+function TodoListItemRow({ text, completed }: { text: string; completed: boolean }) {
+  const badgeStyle = useMemo(
+    () => [
+      todoListCardStylesheet.radioBadge,
+      completed
+        ? todoListCardStylesheet.radioBadgeComplete
+        : todoListCardStylesheet.radioBadgeIncomplete,
+    ],
+    [completed],
+  );
+  const textStyle = useMemo(
+    () => [todoListCardStylesheet.itemText, completed && todoListCardStylesheet.itemTextCompleted],
+    [completed],
+  );
+  return (
+    <View style={todoListCardStylesheet.itemRow}>
+      <View style={badgeStyle}>
+        {completed ? (
+          <ThemedTodoCheckIcon size={12} uniProps={primaryForegroundColorMapping} />
+        ) : null}
+      </View>
+      <Text style={textStyle}>{text}</Text>
+    </View>
+  );
+}
+
+const todoListCardStylesheet = StyleSheet.create((theme) => ({
+  detailsWrapper: { padding: theme.spacing[2] },
+  list: { gap: theme.spacing[1] },
+  itemRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  radioBadge: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: theme.colors.foregroundMuted,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  radioBadgeIncomplete: { opacity: 0.55 },
+  radioBadgeComplete: { opacity: 0.95 },
+  itemText: {
+    flex: 1,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+  },
+  itemTextCompleted: {
+    color: theme.colors.foregroundMuted,
+    textDecorationLine: "line-through",
+  },
+  emptyText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.base,
+  },
+}));
+
+export const TodoListCard = memo(function TodoListCard({ items }: { items: TodoEntry[] }) {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const nextTask = useMemo(() => items.find((item) => !item.completed)?.text, [items]);
+
+  const handleToggle = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const renderDetails = useCallback(() => {
+    return (
+      <View style={todoListCardStylesheet.detailsWrapper}>
+        <View style={todoListCardStylesheet.list}>
+          {items.length === 0 ? (
+            <Text style={todoListCardStylesheet.emptyText}>{t("message.todo.empty")}</Text>
+          ) : (
+            items.map((item) => (
+              <TodoListItemRow key={item.text} text={item.text} completed={item.completed} />
+            ))
+          )}
+        </View>
+      </View>
+    );
+  }, [items, t]);
+
+  return (
+    <ExpandableBadge
+      label={t("message.todo.title")}
+      secondaryLabel={nextTask}
+      icon={CheckSquare}
+      isExpanded={isExpanded}
+      onToggle={handleToggle}
+      renderDetails={renderDetails}
+    />
   );
 });
 

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -26,6 +26,8 @@ function TaskCheckbox({ completed }: { completed: boolean }) {
 
 interface TaskListCardProps {
   items: TodoEntry[];
+  /** Stable identity for this snapshot. Used as the dismissal key when provided. */
+  snapshotKey?: string;
   onDismissCompleted?: () => void;
 }
 
@@ -60,12 +62,16 @@ const ArchiveCompletedButton = memo(function ArchiveCompletedButton({
 
 export const TaskListCard = memo(function TaskListCard({
   items,
+  snapshotKey,
   onDismissCompleted,
 }: TaskListCardProps) {
   const [expanded, setExpanded] = useState(false);
-  // Track which snapshot was dismissed by its text content hash.
-  // When the agent sends a new todo list the fingerprint changes and
-  // the card becomes visible again automatically.
+  // When snapshotKey is provided (agent-panel active card), dismissal targets that
+  // stable identity directly. Without it (timeline entries), fall back to content hash.
+  const currentFingerprint = useMemo(
+    () => items.map((i) => `${i.text}:${i.completed}`).join("|"),
+    [items],
+  );
   const [dismissedKey, setDismissedKey] = useState<string | null>(null);
 
   const { t } = useTranslation();
@@ -75,9 +81,9 @@ export const TaskListCard = memo(function TaskListCard({
   }, []);
 
   const handleDismissCompleted = useCallback(() => {
-    setDismissedKey(items.map((i) => `${i.text}:${i.completed}`).join("|"));
+    setDismissedKey(snapshotKey ?? currentFingerprint);
     onDismissCompleted?.();
-  }, [items, onDismissCompleted]);
+  }, [snapshotKey, currentFingerprint, onDismissCompleted]);
 
   const surfaceStyle = useMemo(
     () => [styles.surface, expanded && styles.surfaceExpanded],
@@ -98,7 +104,8 @@ export const TaskListCard = memo(function TaskListCard({
   );
 
   if (
-    dismissedKey === items.map((i) => `${i.text}:${i.completed}`).join("|") ||
+    (snapshotKey != null && dismissedKey === snapshotKey) ||
+    (!snapshotKey && dismissedKey === currentFingerprint) ||
     items.length === 0
   ) {
     return null;

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -170,28 +170,6 @@ export const TaskListCard = memo(function TaskListCard({
   );
 });
 
-/**
- * Simple timeline rendering of a todo list entry.
- * Shows all tasks with check/box icons — no expand/collapse chrome.
- */
-export const TodoListTimeline = memo(function TodoListTimeline({ items }: { items: TodoEntry[] }) {
-  return (
-    <View style={timelineStyles.list}>
-      {items.map((item) => (
-        <View key={item.text} style={timelineStyles.row}>
-          <TaskCheckbox completed={item.completed} />
-          <Text
-            style={[timelineStyles.itemText, item.completed && timelineStyles.itemTextCompleted]}
-            numberOfLines={1}
-          >
-            {item.text}
-          </Text>
-        </View>
-      ))}
-    </View>
-  );
-});
-
 const styles = StyleSheet.create((theme) => ({
   container: {
     alignItems: "center",
@@ -278,29 +256,5 @@ const styles = StyleSheet.create((theme) => ({
   tooltipText: {
     fontSize: theme.fontSize.xs,
     color: theme.colors.foreground,
-  },
-}));
-
-const timelineStyles = StyleSheet.create((theme) => ({
-  list: {
-    gap: theme.spacing[1],
-    marginTop: theme.spacing[2],
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[2],
-    paddingLeft: theme.spacing[3],
-    paddingRight: theme.spacing[1],
-    paddingVertical: theme.spacing[1],
-  },
-  itemText: {
-    flex: 1,
-    minWidth: 0,
-    fontSize: theme.fontSize.sm,
-    color: theme.colors.foreground,
-  },
-  itemTextCompleted: {
-    color: theme.colors.foregroundMuted,
   },
 }));

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -1,0 +1,171 @@
+import { memo, useCallback, useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View, type PressableStateCallbackType } from "react-native";
+import { Check, ChevronDown, ChevronRight } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import type { Theme } from "@/styles/theme";
+import type { TodoEntry } from "@/types/stream";
+
+const ThemedCheck = withUnistyles(Check);
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedChevronRight = withUnistyles(ChevronRight);
+
+const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+
+interface TaskListCardProps {
+  items: TodoEntry[];
+}
+
+const TASK_LIST_MAX_HEIGHT = 144;
+
+export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((current) => !current);
+  }, []);
+
+  const headerLabel = useMemo(() => {
+    const completedCount = items.filter((item) => item.completed).length;
+    if (items.length === 0) return "";
+    if (completedCount === items.length) return `${items.length} tasks done`;
+    if (completedCount === 0) return `${items.length} tasks`;
+    return `${completedCount}/${items.length} tasks done`;
+  }, [items]);
+
+  const surfaceStyle = useMemo(
+    () => [styles.surface, expanded && styles.surfaceExpanded],
+    [expanded],
+  );
+
+  const headerContainerStyle = useMemo(
+    () => [styles.header, expanded ? styles.headerDivider : styles.headerCollapsed],
+    [expanded],
+  );
+
+  const headerToggleStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType) => [
+      styles.headerToggle,
+      (hovered || pressed) && styles.headerActive,
+    ],
+    [],
+  );
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={surfaceStyle}>
+        <View style={headerContainerStyle}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={headerLabel}
+            onPress={toggleExpanded}
+            style={headerToggleStyle}
+          >
+            {expanded ? (
+              <ThemedChevronDown size={12} uniProps={foregroundMutedColorMapping} />
+            ) : (
+              <ThemedChevronRight size={12} uniProps={foregroundMutedColorMapping} />
+            )}
+            <Text style={styles.headerLabel} numberOfLines={1}>
+              {headerLabel}
+            </Text>
+          </Pressable>
+        </View>
+        {expanded ? (
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+            nestedScrollEnabled
+          >
+            {items.map((item) => {
+              const textStyle = [styles.itemText, item.completed && styles.itemTextCompleted];
+              return (
+                <View key={item.text} style={styles.row}>
+                  <ThemedCheck size={12} uniProps={foregroundMutedColorMapping} />
+                  <Text style={textStyle} numberOfLines={1}>
+                    {item.text}
+                  </Text>
+                </View>
+              );
+            })}
+          </ScrollView>
+        ) : null}
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create((theme) => ({
+  container: {
+    width: "100%",
+  },
+  surface: {
+    alignSelf: "stretch",
+    backgroundColor: theme.colors.surface1,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.borderAccent,
+    borderBottomWidth: 0,
+    borderTopLeftRadius: theme.borderRadius["2xl"],
+    borderTopRightRadius: theme.borderRadius["2xl"],
+    overflow: "hidden",
+  },
+  surfaceExpanded: {
+    paddingBottom: theme.spacing[4],
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  headerToggle: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingLeft: theme.spacing[3],
+    paddingRight: theme.spacing[1],
+    paddingVertical: theme.spacing[2],
+  },
+  headerCollapsed: {
+    paddingBottom: theme.spacing[4],
+  },
+  headerActive: {
+    backgroundColor: theme.colors.surface2,
+  },
+  headerDivider: {
+    borderBottomWidth: theme.borderWidth[1],
+    borderBottomColor: theme.colors.border,
+  },
+  headerLabel: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
+  },
+  scroll: {
+    maxHeight: TASK_LIST_MAX_HEIGHT,
+  },
+  scrollContent: {
+    paddingVertical: theme.spacing[1],
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+  },
+  itemText: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foreground,
+  },
+  itemTextCompleted: {
+    color: theme.colors.foregroundMuted,
+  },
+}));

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -1,15 +1,25 @@
 import { memo, useCallback, useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View, type PressableStateCallbackType } from "react-native";
-import { Check, ChevronDown, ChevronRight } from "lucide-react-native";
+import { Check, ChevronDown, ChevronRight, Square } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import type { Theme } from "@/styles/theme";
 import type { TodoEntry } from "@/types/stream";
+import { MAX_CONTENT_WIDTH } from "@/constants/layout";
 
 const ThemedCheck = withUnistyles(Check);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedChevronRight = withUnistyles(ChevronRight);
+const ThemedSquare = withUnistyles(Square);
 
 const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const completedColorMapping = (theme: Theme) => ({ color: theme.colors.statusSuccess });
+
+function TaskCheckbox({ completed }: { completed: boolean }) {
+  if (completed) {
+    return <ThemedCheck size={16} uniProps={completedColorMapping} />;
+  }
+  return <ThemedSquare size={16} uniProps={foregroundMutedColorMapping} />;
+}
 
 interface TaskListCardProps {
   items: TodoEntry[];
@@ -56,44 +66,46 @@ export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardPr
 
   return (
     <View style={styles.container}>
-      <View style={surfaceStyle}>
-        <View style={headerContainerStyle}>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={headerLabel}
-            onPress={toggleExpanded}
-            style={headerToggleStyle}
-          >
-            {expanded ? (
-              <ThemedChevronDown size={12} uniProps={foregroundMutedColorMapping} />
-            ) : (
-              <ThemedChevronRight size={12} uniProps={foregroundMutedColorMapping} />
-            )}
-            <Text style={styles.headerLabel} numberOfLines={1}>
-              {headerLabel}
-            </Text>
-          </Pressable>
-        </View>
-        {expanded ? (
-          <ScrollView
-            style={styles.scroll}
-            contentContainerStyle={styles.scrollContent}
-            showsVerticalScrollIndicator={false}
-            nestedScrollEnabled
-          >
-            {items.map((item) => {
-              const textStyle = [styles.itemText, item.completed && styles.itemTextCompleted];
-              return (
+      <View style={styles.track}>
+        <View style={surfaceStyle}>
+          <View style={headerContainerStyle}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={headerLabel}
+              onPress={toggleExpanded}
+              style={headerToggleStyle}
+            >
+              {expanded ? (
+                <ThemedChevronDown size={12} uniProps={foregroundMutedColorMapping} />
+              ) : (
+                <ThemedChevronRight size={12} uniProps={foregroundMutedColorMapping} />
+              )}
+              <Text style={styles.headerLabel} numberOfLines={1}>
+                {headerLabel}
+              </Text>
+            </Pressable>
+          </View>
+          {expanded ? (
+            <ScrollView
+              style={styles.scroll}
+              contentContainerStyle={styles.scrollContent}
+              showsVerticalScrollIndicator={false}
+              nestedScrollEnabled
+            >
+              {items.map((item) => (
                 <View key={item.text} style={styles.row}>
-                  <ThemedCheck size={12} uniProps={foregroundMutedColorMapping} />
-                  <Text style={textStyle} numberOfLines={1}>
+                  <TaskCheckbox completed={item.completed} />
+                  <Text
+                    style={[styles.itemText, item.completed && styles.itemTextCompleted]}
+                    numberOfLines={1}
+                  >
                     {item.text}
                   </Text>
                 </View>
-              );
-            })}
-          </ScrollView>
-        ) : null}
+              ))}
+            </ScrollView>
+          ) : null}
+        </View>
       </View>
     </View>
   );
@@ -101,7 +113,12 @@ export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardPr
 
 const styles = StyleSheet.create((theme) => ({
   container: {
+    alignItems: "center",
+    paddingHorizontal: theme.spacing[4],
+  },
+  track: {
     width: "100%",
+    maxWidth: MAX_CONTENT_WIDTH,
   },
   surface: {
     alignSelf: "stretch",

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -63,7 +63,10 @@ export const TaskListCard = memo(function TaskListCard({
   onDismissCompleted,
 }: TaskListCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [allDismissed, setAllDismissed] = useState(false);
+  // Track which snapshot was dismissed by its text content hash.
+  // When the agent sends a new todo list the fingerprint changes and
+  // the card becomes visible again automatically.
+  const [dismissedKey, setDismissedKey] = useState<string | null>(null);
 
   const { t } = useTranslation();
 
@@ -72,9 +75,9 @@ export const TaskListCard = memo(function TaskListCard({
   }, []);
 
   const handleDismissCompleted = useCallback(() => {
-    setAllDismissed(true);
+    setDismissedKey(items.map((i) => `${i.text}:${i.completed}`).join("|"));
     onDismissCompleted?.();
-  }, [onDismissCompleted]);
+  }, [items, onDismissCompleted]);
 
   const surfaceStyle = useMemo(
     () => [styles.surface, expanded && styles.surfaceExpanded],
@@ -94,7 +97,10 @@ export const TaskListCard = memo(function TaskListCard({
     [],
   );
 
-  if (allDismissed || items.length === 0) {
+  if (
+    dismissedKey === items.map((i) => `${i.text}:${i.completed}`).join("|") ||
+    items.length === 0
+  ) {
     return null;
   }
 

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View, type PressableStateCallbackType } from "react-native";
 import { Archive, Check, ChevronDown, ChevronRight, Square } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
@@ -63,33 +63,18 @@ export const TaskListCard = memo(function TaskListCard({
   onDismissCompleted,
 }: TaskListCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const dismissedRef = useRef(new Set<string>());
-  const [, forceUpdate] = useState(0);
+  const [allDismissed, setAllDismissed] = useState(false);
+
+  const { t } = useTranslation();
 
   const toggleExpanded = useCallback(() => {
     setExpanded((current) => !current);
   }, []);
 
   const handleDismissCompleted = useCallback(() => {
-    for (const item of items) {
-      if (item.completed) {
-        dismissedRef.current.add(item.text);
-      }
-    }
-    forceUpdate((n) => n + 1);
+    setAllDismissed(true);
     onDismissCompleted?.();
-  }, [items, onDismissCompleted]);
-
-  const visibleItems = items.filter((item) => !dismissedRef.current.has(item.text));
-
-  const completedCount = visibleItems.filter((item) => item.completed).length;
-
-  const headerLabel = useMemo(() => {
-    if (visibleItems.length === 0) return "";
-    if (completedCount === visibleItems.length) return `${visibleItems.length} tasks done`;
-    if (completedCount === 0) return `${visibleItems.length} tasks`;
-    return `${completedCount}/${visibleItems.length} tasks done`;
-  }, [visibleItems, completedCount]);
+  }, [onDismissCompleted]);
 
   const surfaceStyle = useMemo(
     () => [styles.surface, expanded && styles.surfaceExpanded],
@@ -109,8 +94,22 @@ export const TaskListCard = memo(function TaskListCard({
     [],
   );
 
-  if (visibleItems.length === 0) {
+  if (allDismissed || items.length === 0) {
     return null;
+  }
+
+  const completedCount = items.filter((item) => item.completed).length;
+
+  let headerLabel: string;
+  if (completedCount === items.length) {
+    headerLabel = t("message.todo.tasksDoneAll", { count: items.length });
+  } else if (completedCount === 0) {
+    headerLabel = t("message.todo.tasksRemaining", { count: items.length });
+  } else {
+    headerLabel = t("message.todo.tasksProgress", {
+      completed: completedCount,
+      total: items.length,
+    });
   }
 
   return (
@@ -133,7 +132,7 @@ export const TaskListCard = memo(function TaskListCard({
                 {headerLabel}
               </Text>
             </Pressable>
-            {completedCount === visibleItems.length && visibleItems.length > 0 ? (
+            {completedCount === items.length && items.length > 0 ? (
               <View style={styles.headerAction}>
                 <ArchiveCompletedButton onPress={handleDismissCompleted} />
               </View>
@@ -146,7 +145,7 @@ export const TaskListCard = memo(function TaskListCard({
               showsVerticalScrollIndicator={false}
               nestedScrollEnabled
             >
-              {visibleItems.map((item) => (
+              {items.map((item) => (
                 <View key={item.text} style={styles.row}>
                   <TaskCheckbox completed={item.completed} />
                   <Text

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -26,8 +26,6 @@ function TaskCheckbox({ completed }: { completed: boolean }) {
 
 interface TaskListCardProps {
   items: TodoEntry[];
-  /** Stable identity for this snapshot. Used as the dismissal key when provided. */
-  snapshotKey?: string;
   onDismissCompleted?: () => void;
 }
 
@@ -62,12 +60,11 @@ const ArchiveCompletedButton = memo(function ArchiveCompletedButton({
 
 export const TaskListCard = memo(function TaskListCard({
   items,
-  snapshotKey,
   onDismissCompleted,
 }: TaskListCardProps) {
   const [expanded, setExpanded] = useState(false);
-  // When snapshotKey is provided (agent-panel active card), dismissal targets that
-  // stable identity directly. Without it (timeline entries), fall back to content hash.
+  // Dismissal keyed on content fingerprint so it auto-resets when the
+  // agent updates the todo list (new items, reopened tasks, etc.).
   const currentFingerprint = useMemo(
     () => items.map((i) => `${i.text}:${i.completed}`).join("|"),
     [items],
@@ -81,9 +78,9 @@ export const TaskListCard = memo(function TaskListCard({
   }, []);
 
   const handleDismissCompleted = useCallback(() => {
-    setDismissedKey(snapshotKey ?? currentFingerprint);
+    setDismissedKey(currentFingerprint);
     onDismissCompleted?.();
-  }, [snapshotKey, currentFingerprint, onDismissCompleted]);
+  }, [currentFingerprint, onDismissCompleted]);
 
   const surfaceStyle = useMemo(
     () => [styles.surface, expanded && styles.surfaceExpanded],
@@ -103,11 +100,7 @@ export const TaskListCard = memo(function TaskListCard({
     [],
   );
 
-  if (
-    (snapshotKey != null && dismissedKey === snapshotKey) ||
-    (!snapshotKey && dismissedKey === currentFingerprint) ||
-    items.length === 0
-  ) {
+  if (dismissedKey === currentFingerprint || items.length === 0) {
     return null;
   }
 

--- a/packages/app/src/components/task-list-card.tsx
+++ b/packages/app/src/components/task-list-card.tsx
@@ -1,15 +1,18 @@
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { Pressable, ScrollView, Text, View, type PressableStateCallbackType } from "react-native";
-import { Check, ChevronDown, ChevronRight, Square } from "lucide-react-native";
+import { Archive, Check, ChevronDown, ChevronRight, Square } from "lucide-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { useTranslation } from "react-i18next";
 import type { Theme } from "@/styles/theme";
 import type { TodoEntry } from "@/types/stream";
 import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const ThemedCheck = withUnistyles(Check);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedChevronRight = withUnistyles(ChevronRight);
 const ThemedSquare = withUnistyles(Square);
+const ThemedArchive = withUnistyles(Archive);
 
 const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
 const completedColorMapping = (theme: Theme) => ({ color: theme.colors.statusSuccess });
@@ -23,24 +26,70 @@ function TaskCheckbox({ completed }: { completed: boolean }) {
 
 interface TaskListCardProps {
   items: TodoEntry[];
+  onDismissCompleted?: () => void;
 }
 
 const TASK_LIST_MAX_HEIGHT = 144;
 
-export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardProps) {
+const ArchiveCompletedButton = memo(function ArchiveCompletedButton({
+  onPress,
+}: {
+  onPress: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+      <TooltipTrigger asChild disabled={false}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t("message.todo.archiveCompleted")}
+          testID="task-list-archive-completed"
+          onPress={onPress}
+          style={styles.actionButton}
+          hitSlop={8}
+        >
+          <ThemedArchive size={14} uniProps={foregroundMutedColorMapping} />
+        </Pressable>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="center" offset={8}>
+        <Text style={styles.tooltipText}>{t("message.todo.archiveCompletedTooltip")}</Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+});
+
+export const TaskListCard = memo(function TaskListCard({
+  items,
+  onDismissCompleted,
+}: TaskListCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const dismissedRef = useRef(new Set<string>());
+  const [, forceUpdate] = useState(0);
 
   const toggleExpanded = useCallback(() => {
     setExpanded((current) => !current);
   }, []);
 
+  const handleDismissCompleted = useCallback(() => {
+    for (const item of items) {
+      if (item.completed) {
+        dismissedRef.current.add(item.text);
+      }
+    }
+    forceUpdate((n) => n + 1);
+    onDismissCompleted?.();
+  }, [items, onDismissCompleted]);
+
+  const visibleItems = items.filter((item) => !dismissedRef.current.has(item.text));
+
+  const completedCount = visibleItems.filter((item) => item.completed).length;
+
   const headerLabel = useMemo(() => {
-    const completedCount = items.filter((item) => item.completed).length;
-    if (items.length === 0) return "";
-    if (completedCount === items.length) return `${items.length} tasks done`;
-    if (completedCount === 0) return `${items.length} tasks`;
-    return `${completedCount}/${items.length} tasks done`;
-  }, [items]);
+    if (visibleItems.length === 0) return "";
+    if (completedCount === visibleItems.length) return `${visibleItems.length} tasks done`;
+    if (completedCount === 0) return `${visibleItems.length} tasks`;
+    return `${completedCount}/${visibleItems.length} tasks done`;
+  }, [visibleItems, completedCount]);
 
   const surfaceStyle = useMemo(
     () => [styles.surface, expanded && styles.surfaceExpanded],
@@ -60,7 +109,7 @@ export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardPr
     [],
   );
 
-  if (items.length === 0) {
+  if (visibleItems.length === 0) {
     return null;
   }
 
@@ -84,6 +133,11 @@ export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardPr
                 {headerLabel}
               </Text>
             </Pressable>
+            {completedCount === visibleItems.length && visibleItems.length > 0 ? (
+              <View style={styles.headerAction}>
+                <ArchiveCompletedButton onPress={handleDismissCompleted} />
+              </View>
+            ) : null}
           </View>
           {expanded ? (
             <ScrollView
@@ -92,7 +146,7 @@ export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardPr
               showsVerticalScrollIndicator={false}
               nestedScrollEnabled
             >
-              {items.map((item) => (
+              {visibleItems.map((item) => (
                 <View key={item.text} style={styles.row}>
                   <TaskCheckbox completed={item.completed} />
                   <Text
@@ -111,6 +165,28 @@ export const TaskListCard = memo(function TaskListCard({ items }: TaskListCardPr
   );
 });
 
+/**
+ * Simple timeline rendering of a todo list entry.
+ * Shows all tasks with check/box icons — no expand/collapse chrome.
+ */
+export const TodoListTimeline = memo(function TodoListTimeline({ items }: { items: TodoEntry[] }) {
+  return (
+    <View style={timelineStyles.list}>
+      {items.map((item) => (
+        <View key={item.text} style={timelineStyles.row}>
+          <TaskCheckbox completed={item.completed} />
+          <Text
+            style={[timelineStyles.itemText, item.completed && timelineStyles.itemTextCompleted]}
+            numberOfLines={1}
+          >
+            {item.text}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+});
+
 const styles = StyleSheet.create((theme) => ({
   container: {
     alignItems: "center",
@@ -119,6 +195,7 @@ const styles = StyleSheet.create((theme) => ({
   track: {
     width: "100%",
     maxWidth: MAX_CONTENT_WIDTH,
+    marginBottom: -theme.spacing[4],
   },
   surface: {
     alignSelf: "stretch",
@@ -157,6 +234,9 @@ const styles = StyleSheet.create((theme) => ({
     borderBottomWidth: theme.borderWidth[1],
     borderBottomColor: theme.colors.border,
   },
+  headerAction: {
+    paddingRight: theme.spacing[2],
+  },
   headerLabel: {
     flexShrink: 1,
     minWidth: 0,
@@ -175,6 +255,39 @@ const styles = StyleSheet.create((theme) => ({
     gap: theme.spacing[2],
     paddingHorizontal: theme.spacing[3],
     paddingVertical: theme.spacing[2],
+  },
+  itemText: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foreground,
+  },
+  itemTextCompleted: {
+    color: theme.colors.foregroundMuted,
+  },
+  actionButton: {
+    padding: theme.spacing[1],
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tooltipText: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foreground,
+  },
+}));
+
+const timelineStyles = StyleSheet.create((theme) => ({
+  list: {
+    gap: theme.spacing[1],
+    marginTop: theme.spacing[2],
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingLeft: theme.spacing[3],
+    paddingRight: theme.spacing[1],
+    paddingVertical: theme.spacing[1],
   },
   itemText: {
     flex: 1,

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -315,9 +315,9 @@ export const ar: TranslationResources = {
       empty: "لا توجد مهام حتى الآن.",
       archiveCompleted: "تجاهل المهام المكتملة",
       archiveCompletedTooltip: "تجاهل المكتملة",
-      tasksDoneAll: "{{count}} مهام منجزة",
-      tasksRemaining: "{{count}} مهام",
-      tasksProgress: "{{completed}}/{{total}} مهام منجزة",
+      tasksDoneAll: "{{count}} مكتمل",
+      tasksRemaining: "{{count}} متبقي",
+      tasksProgress: "{{completed}}/{{total}} مكتمل",
     },
     compaction: {
       loading: "الضغط...",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -313,6 +313,8 @@ export const ar: TranslationResources = {
     todo: {
       title: "المهام",
       empty: "لا توجد مهام حتى الآن.",
+      archiveCompleted: "تجاهل المهام المكتملة",
+      archiveCompletedTooltip: "تجاهل المكتملة",
     },
     compaction: {
       loading: "الضغط...",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -315,6 +315,9 @@ export const ar: TranslationResources = {
       empty: "لا توجد مهام حتى الآن.",
       archiveCompleted: "تجاهل المهام المكتملة",
       archiveCompletedTooltip: "تجاهل المكتملة",
+      tasksDoneAll: "{{count}} مهام منجزة",
+      tasksRemaining: "{{count}} مهام",
+      tasksProgress: "{{completed}}/{{total}} مهام منجزة",
     },
     compaction: {
       loading: "الضغط...",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -312,6 +312,8 @@ export const en = {
     todo: {
       title: "Tasks",
       empty: "No tasks yet.",
+      archiveCompleted: "Dismiss completed tasks",
+      archiveCompletedTooltip: "Dismiss completed",
     },
     compaction: {
       loading: "Compacting...",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -314,6 +314,9 @@ export const en = {
       empty: "No tasks yet.",
       archiveCompleted: "Dismiss completed tasks",
       archiveCompletedTooltip: "Dismiss completed",
+      tasksDoneAll: "{{count}} tasks done",
+      tasksRemaining: "{{count}} tasks",
+      tasksProgress: "{{completed}}/{{total}} tasks done",
     },
     compaction: {
       loading: "Compacting...",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -318,6 +318,9 @@ export const es: TranslationResources = {
       empty: "Aún no hay tareas.",
       archiveCompleted: "Descartar tareas completadas",
       archiveCompletedTooltip: "Descartar completadas",
+      tasksDoneAll: "{{count}} tareas hechas",
+      tasksRemaining: "{{count}} tareas",
+      tasksProgress: "{{completed}}/{{total}} tareas hechas",
     },
     compaction: {
       loading: "Compactando...",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -316,6 +316,8 @@ export const es: TranslationResources = {
     todo: {
       title: "Tareas",
       empty: "Aún no hay tareas.",
+      archiveCompleted: "Descartar tareas completadas",
+      archiveCompletedTooltip: "Descartar completadas",
     },
     compaction: {
       loading: "Compactando...",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -319,6 +319,9 @@ export const fr: TranslationResources = {
       empty: "Aucune tâche pour l'instant.",
       archiveCompleted: "Ignorer les tâches terminées",
       archiveCompletedTooltip: "Ignorer les terminées",
+      tasksDoneAll: "{{count}} tâches terminées",
+      tasksRemaining: "{{count}} tâches",
+      tasksProgress: "{{completed}}/{{total}} tâches terminées",
     },
     compaction: {
       loading: "Compactage...",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -317,6 +317,8 @@ export const fr: TranslationResources = {
     todo: {
       title: "Tâches",
       empty: "Aucune tâche pour l'instant.",
+      archiveCompleted: "Ignorer les tâches terminées",
+      archiveCompletedTooltip: "Ignorer les terminées",
     },
     compaction: {
       loading: "Compactage...",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -318,6 +318,9 @@ export const ja: TranslationResources = {
       empty: "タスクがまだありません。",
       archiveCompleted: "完了したタスクを閉じる",
       archiveCompletedTooltip: "完了を閉じる",
+      tasksDoneAll: "{{count}}タスク完了",
+      tasksRemaining: "{{count}}タスク",
+      tasksProgress: "{{completed}}/{{total}}タスク完了",
     },
     compaction: {
       loading: "コンテキストを圧縮中...",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -316,6 +316,8 @@ export const ja: TranslationResources = {
     todo: {
       title: "タスク",
       empty: "タスクがまだありません。",
+      archiveCompleted: "完了したタスクを閉じる",
+      archiveCompletedTooltip: "完了を閉じる",
     },
     compaction: {
       loading: "コンテキストを圧縮中...",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -316,6 +316,8 @@ export const ptBR: TranslationResources = {
     todo: {
       title: "Tarefas",
       empty: "Nenhuma tarefa ainda.",
+      archiveCompleted: "Descartar tarefas concluídas",
+      archiveCompletedTooltip: "Descartar concluídas",
     },
     compaction: {
       loading: "Compactando...",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -318,6 +318,9 @@ export const ptBR: TranslationResources = {
       empty: "Nenhuma tarefa ainda.",
       archiveCompleted: "Descartar tarefas concluídas",
       archiveCompletedTooltip: "Descartar concluídas",
+      tasksDoneAll: "{{count}} tarefas concluídas",
+      tasksRemaining: "{{count}} tarefas",
+      tasksProgress: "{{completed}}/{{total}} tarefas concluídas",
     },
     compaction: {
       loading: "Compactando...",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -317,9 +317,9 @@ export const ru: TranslationResources = {
       empty: "Заданий пока нет.",
       archiveCompleted: "Скрыть выполненные задачи",
       archiveCompletedTooltip: "Скрыть выполненные",
-      tasksDoneAll: "{{count}} задач выполнено",
-      tasksRemaining: "{{count}} задач",
-      tasksProgress: "{{completed}}/{{total}} задач выполнено",
+      tasksDoneAll: "{{count}} выполнено",
+      tasksRemaining: "{{count}} осталось",
+      tasksProgress: "{{completed}}/{{total}} выполнено",
     },
     compaction: {
       loading: "Уплотнение...",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -315,6 +315,8 @@ export const ru: TranslationResources = {
     todo: {
       title: "Задачи",
       empty: "Заданий пока нет.",
+      archiveCompleted: "Скрыть выполненные задачи",
+      archiveCompletedTooltip: "Скрыть выполненные",
     },
     compaction: {
       loading: "Уплотнение...",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -317,6 +317,9 @@ export const ru: TranslationResources = {
       empty: "Заданий пока нет.",
       archiveCompleted: "Скрыть выполненные задачи",
       archiveCompletedTooltip: "Скрыть выполненные",
+      tasksDoneAll: "{{count}} задач выполнено",
+      tasksRemaining: "{{count}} задач",
+      tasksProgress: "{{completed}}/{{total}} задач выполнено",
     },
     compaction: {
       loading: "Уплотнение...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -313,6 +313,8 @@ export const zhCN: TranslationResources = {
     todo: {
       title: "任务",
       empty: "还没有任务。",
+      archiveCompleted: "隐藏已完成的任务",
+      archiveCompletedTooltip: "隐藏已完成的",
     },
     compaction: {
       loading: "正在压缩...",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -315,6 +315,9 @@ export const zhCN: TranslationResources = {
       empty: "还没有任务。",
       archiveCompleted: "隐藏已完成的任务",
       archiveCompletedTooltip: "隐藏已完成的",
+      tasksDoneAll: "已完成 {{count}} 项任务",
+      tasksRemaining: "{{count}} 项任务",
+      tasksProgress: "已完成 {{completed}}/{{total}} 项任务",
     },
     compaction: {
       loading: "正在压缩...",

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1451,21 +1451,22 @@ function ActiveAgentComposer({
     serverId,
     parentAgentId: agentId,
   });
-  const activeTodoItems = useStoreWithEqualityFn(
+  const activeTodoList = useStoreWithEqualityFn(
     useSessionStore,
     (state) => {
       const tail = state.sessions[serverId]?.agentStreamTail?.get(agentId);
-      if (!tail) return [];
+      if (!tail) return null;
       for (let i = tail.length - 1; i >= 0; i--) {
         const item = tail[i];
         if (item.kind === "todo_list") {
-          return item.items;
+          return { items: item.items, snapshotKey: item.id };
         }
       }
-      return [];
+      return null;
     },
     shallow,
   );
+  const activeTodoItems = activeTodoList?.items ?? [];
   const canDetachSubagents = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.agentDetach === true,
   );
@@ -1573,7 +1574,7 @@ function ActiveAgentComposer({
 
   return (
     <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
-      <TaskListCard items={activeTodoItems} />
+      <TaskListCard items={activeTodoItems} snapshotKey={activeTodoList?.snapshotKey} />
       <SubagentsTrack
         rows={subagentRows}
         onOpenSubagent={handleOpenSubagent}

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1451,22 +1451,21 @@ function ActiveAgentComposer({
     serverId,
     parentAgentId: agentId,
   });
-  const activeTodoList = useStoreWithEqualityFn(
+  const activeTodoItems = useStoreWithEqualityFn(
     useSessionStore,
     (state) => {
       const tail = state.sessions[serverId]?.agentStreamTail?.get(agentId);
-      if (!tail) return null;
+      if (!tail) return [];
       for (let i = tail.length - 1; i >= 0; i--) {
         const item = tail[i];
         if (item.kind === "todo_list") {
-          return { items: item.items, snapshotKey: item.id };
+          return item.items;
         }
       }
-      return null;
+      return [];
     },
     shallow,
   );
-  const activeTodoItems = activeTodoList?.items ?? [];
   const canDetachSubagents = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.agentDetach === true,
   );
@@ -1574,7 +1573,7 @@ function ActiveAgentComposer({
 
   return (
     <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
-      <TaskListCard items={activeTodoItems} snapshotKey={activeTodoList?.snapshotKey} />
+      <TaskListCard items={activeTodoItems} />
       <SubagentsTrack
         rows={subagentRows}
         onOpenSubagent={handleOpenSubagent}

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -20,6 +20,7 @@ import invariant from "tiny-invariant";
 import { shallow, useShallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { AgentStreamView, type AgentStreamViewHandle } from "@/agent-stream/view";
+import { TaskListCard } from "@/components/task-list-card";
 import { ArchivedAgentCallout } from "@/components/archived-agent-callout";
 import { FileDropZone } from "@/components/file-drop/file-drop-zone";
 import { useRetainedPanelActive } from "@/components/retained-panel";
@@ -1450,6 +1451,21 @@ function ActiveAgentComposer({
     serverId,
     parentAgentId: agentId,
   });
+  const activeTodoItems = useStoreWithEqualityFn(
+    useSessionStore,
+    (state) => {
+      const tail = state.sessions[serverId]?.agentStreamTail?.get(agentId);
+      if (!tail) return [];
+      for (let i = tail.length - 1; i >= 0; i--) {
+        const item = tail[i];
+        if (item.kind === "todo_list") {
+          return item.items;
+        }
+      }
+      return [];
+    },
+    shallow,
+  );
   const canDetachSubagents = useSessionStore(
     (state) => state.sessions[serverId]?.serverInfo?.features?.agentDetach === true,
   );
@@ -1557,6 +1573,7 @@ function ActiveAgentComposer({
 
   return (
     <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
+      <TaskListCard items={activeTodoItems} />
       <SubagentsTrack
         rows={subagentRows}
         onOpenSubagent={handleOpenSubagent}


### PR DESCRIPTION
### Linked issue

<!-- No linked issue — refactor of existing todo list behavior into a dedicated component -->

### Type of change

- [ ] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [x] Refactor / code improvement
- [ ] Docs

### What does this PR do

Extracted the todo list widget out of `TodoListCard` into a reusable `TaskListCard` component with SubagentsTrack-style connector styling, placed above the Composer in the agent panel. The stream view uses a flat `TodoListTimeline` for historical task list entries (no expand/collapse chrome). Added an archive-finished button that dismisses completed tasks locally when all tasks are done, with proper i18n support across all 8 locales.

Key changes:
- New `TaskListCard` component with checkbox UI, collapsed/expanded toggle, and archive button
- `TodoListTimeline` exported from the same module for inline timeline rendering
- Task list card rendered above `<SubagentsTrack>` in the agent panel input area
- Visual gap between cards removed via matching `marginBottom: -spacing[4]` connector pattern
- i18n keys (`message.todo.archiveCompleted`, `message.todo.archiveCompletedTooltip`) added to en, ar, es, fr, ja, pt-BR, ru, zh-CN

### How did you verify it

- `npm run typecheck` passes — no TypeScript errors
- `npm run lint` passes — no oxlint errors (JSX depth, inline function rules)
- `npm run format` ran — Biome formatting clean
- Tested on desktop web only. Did not test iOS or Android.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [x] UI changes include screenshots or video for every affected platform _(desktop tested; mobile untested)_
- [ ] Tests added or updated where it made sense _(N/A — refactor of existing behavior with identical public contract)_

<img width="620" height="709" alt="image" src="https://github.com/user-attachments/assets/96bb1567-b996-4a84-81d1-18dd8f441927" />
<img width="637" height="590" alt="image" src="https://github.com/user-attachments/assets/067368ee-6fc2-4337-88c3-eff63b8ca07c" />
