### PR TITLE
fix(acp): settle unfinished tool calls when a turn ends

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2318,6 +2318,50 @@ describe("ACPAgentSession", () => {
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
   });
 
+  test("completes a running tool call when ACP ends the turn without a terminal update", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => events.push(event));
+
+    const { turnId } = await session.startTurn("stop the poller");
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "proc-d653724c39ce",
+        title: "process kill: proc_d653724c39ce",
+        kind: "execute",
+        status: "in_progress",
+      } as SessionUpdate,
+    });
+
+    resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const toolEvents = events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "timeline" }> =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.callId === "proc-d653724c39ce",
+    );
+
+    expect(toolEvents.map((event) => event.item.status)).toEqual(["running", "completed"]);
+    expect(events.indexOf(toolEvents[1]!)).toBeLessThan(
+      events.findIndex((event) => event.type === "turn_completed" && event.turnId === turnId),
+    );
+  });
+
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2349,6 +2349,11 @@ describe("ACPAgentSession", () => {
     await Promise.resolve();
     await Promise.resolve();
 
+    await session.startTurn("continue");
+    resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
     const toolEvents = events.filter(
       (event): event is Extract<AgentStreamEvent, { type: "timeline" }> =>
         event.type === "timeline" &&
@@ -2361,6 +2366,50 @@ describe("ACPAgentSession", () => {
       events.findIndex((event) => event.type === "turn_completed" && event.turnId === turnId),
     );
   });
+
+  test.each(["max_tokens", "max_turn_requests", "refusal"] as const)(
+    "cancels a running tool call when ACP stops with %s",
+    async (stopReason) => {
+      const session = createSession();
+      const events: AgentStreamEvent[] = [];
+      let resolvePrompt!: (value: PromptResponse) => void;
+      const prompt = vi.fn(
+        () =>
+          new Promise<PromptResponse>((resolve) => {
+            resolvePrompt = resolve;
+          }),
+      );
+
+      asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+      asInternals<ACPSessionInternals>(session).connection = { prompt };
+      session.subscribe((event) => events.push(event));
+
+      await session.startTurn("stop the poller");
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "proc-d653724c39ce",
+          title: "process kill: proc_d653724c39ce",
+          kind: "execute",
+          status: "in_progress",
+        } as SessionUpdate,
+      });
+
+      resolvePrompt({ stopReason });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const toolEvents = events.filter(
+        (event): event is Extract<AgentStreamEvent, { type: "timeline" }> =>
+          event.type === "timeline" &&
+          event.item.type === "tool_call" &&
+          event.item.callId === "proc-d653724c39ce",
+      );
+
+      expect(toolEvents.map((event) => event.item.status)).toEqual(["running", "canceled"]);
+    },
+  );
 
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {
     const session = createSession();

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1300,6 +1300,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private pendingUserMessage: PendingUserMessage | null = null;
   private submittedUserMessageTurnId: string | null = null;
   private readonly toolCalls = new Map<string, ACPToolSnapshot>();
+  private readonly settledToolCallIds = new Set<string>();
   private readonly terminalEntries = new Map<string, TerminalEntry>();
   private readonly persistedHistory: AgentTimelineItem[] = [];
   private readonly initialHandle?: AgentPersistenceHandle;
@@ -2592,6 +2593,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       snapshot = this.toolSnapshotTransformer(snapshot);
     }
     this.toolCalls.set(toolCallId, snapshot);
+    if (mapToolStatus(snapshot.status) !== "running") {
+      this.settledToolCallIds.add(toolCallId);
+    }
     return [this.wrapTimeline(mapToolSnapshotToTimeline(snapshot, this.terminalEntries))];
   }
 
@@ -2685,13 +2689,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
     this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
-    if (response.stopReason === "end_turn") {
-      this.settleRunningToolCalls("completed");
-    }
+    this.settleRunningToolCalls(response.stopReason === "end_turn" ? "completed" : "canceled");
 
     switch (response.stopReason) {
       case "cancelled":
-        this.settleRunningToolCalls("canceled");
         this.finishTurn({
           type: "turn_canceled",
           provider: this.provider,
@@ -2804,7 +2805,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private settleRunningToolCalls(status: "canceled" | "completed"): void {
     for (const snapshot of this.toolCalls.values()) {
       const mapped = mapToolSnapshotToTimeline(snapshot, this.terminalEntries);
-      if (mapped.status === "running") {
+      if (mapped.status === "running" && !this.settledToolCallIds.has(snapshot.toolCallId)) {
+        this.settledToolCallIds.add(snapshot.toolCallId);
         this.pushEvent(
           this.wrapTimeline({
             ...mapped,

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2339,7 +2339,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         return;
       }
       if (this.activeForegroundTurnId) {
-        this.synthesizeCanceledToolCalls();
+        this.settleRunningToolCalls("canceled");
         this.finishTurn({
           type: "turn_failed",
           provider: this.provider,
@@ -2685,10 +2685,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
     this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
+    if (response.stopReason === "end_turn") {
+      this.settleRunningToolCalls("completed");
+    }
 
     switch (response.stopReason) {
       case "cancelled":
-        this.synthesizeCanceledToolCalls();
+        this.settleRunningToolCalls("canceled");
         this.finishTurn({
           type: "turn_canceled",
           provider: this.provider,
@@ -2798,14 +2801,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     });
   }
 
-  private synthesizeCanceledToolCalls(): void {
+  private settleRunningToolCalls(status: "canceled" | "completed"): void {
     for (const snapshot of this.toolCalls.values()) {
       const mapped = mapToolSnapshotToTimeline(snapshot, this.terminalEntries);
       if (mapped.status === "running") {
         this.pushEvent(
           this.wrapTimeline({
             ...mapped,
-            status: "canceled",
+            status,
             error: null,
           }),
         );


### PR DESCRIPTION
## Problem

Some ACP providers emit a running `tool_call`, then return `end_turn` without a terminal `tool_call_update`. Paseo ends the turn but leaves the timeline item running, so the tool row continues to shimmer even after the agent has finished.

A concrete reproduction is an ACP `execute` call titled `process kill: proc_d653724c39ce` with `status: in_progress`, followed by `PromptResponse { stopReason: "end_turn" }` and no further tool update.

## Change

- Emit a terminal timeline update for any still-running ACP tool before ending the turn. `end_turn` marks it completed. Other terminal stop reasons mark it canceled.
- Remember synthesized terminal tool calls so later turns do not re-emit stale tool rows.
- Preserve provider-supplied completed and failed tool updates.

## Validation

- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1`
  - 88 tests passed.
- `npm run lint -- packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts`
  - 0 warnings, 0 errors.
- `npm run format:check:files -- packages/server/src/server/agent/providers/acp-agent.ts packages/server/src/server/agent/providers/acp-agent.test.ts`
  - matched files are formatted.
- `npm run typecheck`
  - all workspaces passed.

Untested: desktop and mobile visual checks. This patch changes the existing daemon timeline event stream only; it does not change client rendering.