### PR TITLE
Use OpenCode busy status for background activity

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -1996,7 +1996,7 @@ describe("OpenCode adapter startTurn error handling", () => {
     }
   });
 
-  test("streams an autonomous wake as soon as the canceled run reaches its terminal", async () => {
+  test("streams an autonomous wake after the canceled run reaches its terminal", async () => {
     const { parent: session, openCode } = await createParentSession("ses_wake_after_terminal");
     const settleAbort = createTestDeferred<void>();
     const events: AgentStreamEvent[] = [];
@@ -2022,6 +2022,13 @@ describe("OpenCode adapter startTurn error handling", () => {
       openCode.emitEvent({
         type: "session.idle",
         properties: { sessionID: "ses_wake_after_terminal" },
+      });
+      openCode.emitEvent({
+        type: "session.status",
+        properties: {
+          sessionID: "ses_wake_after_terminal",
+          status: { type: "busy" },
+        },
       });
       for (const event of userMessageEvents({
         sessionId: "ses_wake_after_terminal",
@@ -2375,6 +2382,13 @@ describe("OpenCode adapter startTurn error handling", () => {
       openCode.emitEvent({
         type: "session.idle",
         properties: { sessionID: "ses_carried_abort" },
+      });
+      openCode.emitEvent({
+        type: "session.status",
+        properties: {
+          sessionID: "ses_carried_abort",
+          status: { type: "busy" },
+        },
       });
       for (const event of userMessageEvents({
         sessionId: "ses_carried_abort",

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -4446,3 +4446,53 @@ function waitForAbort(signal: AbortSignal): Promise<void> {
     signal.addEventListener("abort", () => resolve(), { once: true });
   });
 }
+
+describe("OpenCode snapshot summary false-idle regression", () => {
+  test("user message.updated carrying snapshot diffs does not start a turn", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCodeClient = new TestOpenCodeClient();
+    openCodeClient.sessionCreateResponse = { data: { id: "ses_snapshot" } };
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession(
+      { provider: "opencode", cwd: "/workspace/repo" },
+      { env: { PASEO_AGENT_ID: "snapshot-agent" } },
+    );
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    // Captured live shape: after the turn goes idle OpenCode writes the filesystem
+    // snapshot diff onto the user message, with no time.end on the message.
+    openCodeClient.emitEvent({
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_snapshot_user",
+          sessionID: "ses_snapshot",
+          role: "user",
+          time: { created: 1000 },
+          summary: {
+            diffs: [{ file: "packages/server/src/thing.ts", additions: 3, deletions: 1 }],
+          },
+        },
+      },
+    });
+    // Drain marker: events are processed in order, so observing this one proves
+    // the snapshot update above was already handled.
+    openCodeClient.emitEvent({
+      type: "session.created",
+      properties: {
+        info: { id: "ses_snapshot_child", parentID: "ses_snapshot", title: "Drain marker" },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(events).toContainEqual(expect.objectContaining({ type: "provider_subagent" }));
+    });
+
+    expect(events.some((event) => event.type === "turn_started")).toBe(false);
+    await session.close();
+  });
+});

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -3100,7 +3100,9 @@ describe("OpenCode persisted sessions", () => {
 });
 
 describe("OpenCode provider subagent contract", () => {
-  async function createAdoptedChildSession(): Promise<{
+  async function createAdoptedChildSession(
+    configureChild?: (client: TestOpenCodeClient) => void,
+  ): Promise<{
     readonly runtime: TestOpenCodeHarness;
     readonly provider: OpenCodeAgentClient;
     readonly parent: Awaited<ReturnType<OpenCodeAgentClient["createSession"]>>;
@@ -3110,6 +3112,7 @@ describe("OpenCode provider subagent contract", () => {
     const runtime = new TestOpenCodeHarness();
     const parentClient = new TestOpenCodeClient();
     const childClient = new TestOpenCodeClient();
+    configureChild?.(childClient);
     parentClient.sessionCreateResponse = { data: { id: "ses_parent_external" } };
     runtime.enqueueClient(parentClient);
     runtime.enqueueClient(childClient);
@@ -3251,14 +3254,14 @@ describe("OpenCode provider subagent contract", () => {
     });
 
     for (const event of [
-      ...assistantTurnEvents({ sessionId: "ses_child_external", text: "child says hi" }).slice(
-        0,
-        2,
-      ),
       {
         type: "session.status",
         properties: { sessionID: "ses_child_external", status: { type: "busy" } },
       },
+      ...assistantTurnEvents({ sessionId: "ses_child_external", text: "child says hi" }).slice(
+        0,
+        2,
+      ),
       { type: "session.idle", properties: { sessionID: "ses_child_external" } },
     ]) {
       childClient.emitEvent(event);
@@ -3290,7 +3293,55 @@ describe("OpenCode provider subagent contract", () => {
     );
   });
 
-  test("surfaces an autonomous OpenCode wake as a new parent turn", async () => {
+  test("reconciles an adopted child that was already busy before attachment", async () => {
+    const { child, childClient, parent } = await createAdoptedChildSession((client) => {
+      client.sessionStatusResponse = {
+        data: { ses_child_external: { type: "busy" } },
+      };
+    });
+    const completed = createTestDeferred<void>();
+    const started = createTestDeferred<void>();
+    const events: AgentStreamEvent[] = [];
+    try {
+      child.subscribe((event) => {
+        events.push(event);
+        if (event.type === "turn_started") {
+          started.resolve();
+        }
+        if (event.type === "turn_completed") {
+          completed.resolve();
+        }
+      });
+
+      await started.promise;
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_child_external",
+        text: "already-running child says hi",
+      })) {
+        childClient.emitEvent(event);
+      }
+
+      await completed.promise;
+
+      expect(childClient.calls.sessionStatus).toEqual([{ directory: "/workspace/repo" }]);
+      expect(turnEventSignatures(events)).toEqual([
+        ["turn_started", "opencode-turn-0"],
+        ["timeline", "opencode-turn-0"],
+        ["turn_completed", "opencode-turn-0"],
+      ]);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "timeline",
+          item: expect.objectContaining({ text: "already-running child says hi" }),
+        }),
+      );
+    } finally {
+      await child.close();
+      await parent.close();
+    }
+  });
+
+  test("uses busy as the autonomous boundary without replaying earlier idle content", async () => {
     const { parent, openCode } = await createParentSession("ses_parent_plugin_wake");
     const events: AgentStreamEvent[] = [];
     parent.subscribe((event) => events.push(event));
@@ -3334,7 +3385,6 @@ describe("OpenCode provider subagent contract", () => {
         expect(turnEventSignatures(events)).toEqual([
           ["turn_started", "opencode-turn-0"],
           ["timeline", "opencode-turn-0"],
-          ["timeline", "opencode-turn-0"],
           ["turn_completed", "opencode-turn-0"],
         ]);
       });
@@ -3344,6 +3394,14 @@ describe("OpenCode provider subagent contract", () => {
           item: expect.objectContaining({
             type: "assistant_message",
             text: "Parent consumed the background result.",
+          }),
+        }),
+      );
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: "timeline",
+          item: expect.objectContaining({
+            text: "<system-reminder>All background tasks are complete.</system-reminder>",
           }),
         }),
       );

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -3286,6 +3286,22 @@ describe("OpenCode provider subagent contract", () => {
         openCode.emitEvent(event);
       }
       openCode.emitEvent({
+        type: "session.created",
+        properties: {
+          info: {
+            id: "ses_plugin_wake_drain_marker",
+            parentID: "ses_parent_plugin_wake",
+            title: "Pre-busy drain marker",
+          },
+        },
+      });
+      await vi.waitFor(() => {
+        expect(events).toContainEqual(expect.objectContaining({ type: "provider_subagent" }));
+      });
+      expect(events.filter((event) => event.type !== "provider_subagent")).toEqual([]);
+      events.length = 0;
+
+      openCode.emitEvent({
         type: "session.status",
         properties: { sessionID: "ses_parent_plugin_wake", status: { type: "busy" } },
       });
@@ -3313,6 +3329,35 @@ describe("OpenCode provider subagent contract", () => {
           }),
         }),
       );
+    } finally {
+      await parent.close();
+    }
+  });
+
+  test("starts autonomous activity from busy without requiring an initiating message", async () => {
+    const { parent, openCode } = await createParentSession("ses_parent_busy_only");
+    const events: AgentStreamEvent[] = [];
+    parent.subscribe((event) => events.push(event));
+
+    try {
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_busy_only", status: { type: "busy" } },
+      });
+      for (const event of assistantTurnEvents({
+        sessionId: "ses_parent_busy_only",
+        text: "Autonomous response after busy.",
+      })) {
+        openCode.emitEvent(event);
+      }
+
+      await vi.waitFor(() => {
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+          ["turn_completed", "opencode-turn-0"],
+        ]);
+      });
     } finally {
       await parent.close();
     }
@@ -3378,6 +3423,10 @@ describe("OpenCode provider subagent contract", () => {
           text: "Autonomous wake",
         })[0],
       );
+      openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_parent_active_wake", status: { type: "busy" } },
+      });
       await vi.waitFor(() => {
         expect(events).toEqual([
           { type: "turn_started", provider: "opencode", turnId: "opencode-turn-0" },
@@ -3519,6 +3568,10 @@ describe("OpenCode provider subagent contract", () => {
       }
     });
 
+    childClient.emitEvent({
+      type: "session.status",
+      properties: { sessionID: "ses_child_external", status: { type: "busy" } },
+    });
     childClient.emitEvent({
       type: "permission.asked",
       properties: {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -2138,6 +2138,10 @@ describe("OpenCode adapter startTurn error handling", () => {
         },
       });
       openCode.emitEvent({
+        type: "session.status",
+        properties: { sessionID: "ses_deferred_autonomous", status: { type: "busy" } },
+      });
+      openCode.emitEvent({
         type: "message.part.updated",
         properties: {
           part: {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -3293,49 +3293,102 @@ describe("OpenCode provider subagent contract", () => {
     );
   });
 
-  test("reconciles an adopted child that was already busy before attachment", async () => {
+  test.each(["busy", "retry"] as const)(
+    "reconciles an adopted child that was already %s before attachment",
+    async (runnerStatus) => {
+      const { child, childClient, parent } = await createAdoptedChildSession((client) => {
+        client.sessionStatusResponse = {
+          data: { ses_child_external: { type: runnerStatus } },
+        };
+      });
+      const completed = createTestDeferred<void>();
+      const events: AgentStreamEvent[] = [];
+      try {
+        child.subscribe((event) => {
+          events.push(event);
+          if (event.type === "turn_completed") {
+            completed.resolve();
+          }
+        });
+
+        await vi.waitFor(() => {
+          expect(events).toContainEqual({
+            type: "turn_started",
+            provider: "opencode",
+            turnId: "opencode-turn-0",
+          });
+        });
+        for (const event of assistantTurnEvents({
+          sessionId: "ses_child_external",
+          text: "already-running child says hi",
+        })) {
+          childClient.emitEvent(event);
+        }
+
+        await completed.promise;
+
+        expect(childClient.calls.sessionStatus).toEqual([{ directory: "/workspace/repo" }]);
+        expect(turnEventSignatures(events)).toEqual([
+          ["turn_started", "opencode-turn-0"],
+          ["timeline", "opencode-turn-0"],
+          ["turn_completed", "opencode-turn-0"],
+        ]);
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            type: "timeline",
+            item: expect.objectContaining({ text: "already-running child says hi" }),
+          }),
+        );
+      } finally {
+        await child.close();
+        await parent.close();
+      }
+    },
+  );
+
+  test("ignores a stale busy snapshot after the live stream reaches idle", async () => {
+    const statusStarted = createTestDeferred<void>();
+    const releaseStatus = createTestDeferred<void>();
     const { child, childClient, parent } = await createAdoptedChildSession((client) => {
-      client.sessionStatusResponse = {
-        data: { ses_child_external: { type: "busy" } },
+      client.sessionStatusImplementation = async () => {
+        statusStarted.resolve();
+        await releaseStatus.promise;
+        return { data: { ses_child_external: { type: "busy" } } };
       };
     });
-    const completed = createTestDeferred<void>();
-    const started = createTestDeferred<void>();
+    const idleConsumed = createTestDeferred<void>();
     const events: AgentStreamEvent[] = [];
     try {
       child.subscribe((event) => {
         events.push(event);
-        if (event.type === "turn_started") {
-          started.resolve();
-        }
-        if (event.type === "turn_completed") {
-          completed.resolve();
+        if (event.type === "provider_subagent") {
+          idleConsumed.resolve();
         }
       });
 
-      await started.promise;
-      for (const event of assistantTurnEvents({
-        sessionId: "ses_child_external",
-        text: "already-running child says hi",
-      })) {
-        childClient.emitEvent(event);
-      }
+      await statusStarted.promise;
+      childClient.emitEvent({
+        type: "session.idle",
+        properties: { sessionID: "ses_child_external" },
+      });
+      childClient.emitEvent({
+        type: "session.created",
+        properties: {
+          info: {
+            id: "ses_child_idle_drain_marker",
+            parentID: "ses_child_external",
+            title: "Idle drain marker",
+          },
+        },
+      });
+      await idleConsumed.promise;
 
-      await completed.promise;
+      releaseStatus.resolve();
+      await new Promise<void>((resolve) => setImmediate(resolve));
 
-      expect(childClient.calls.sessionStatus).toEqual([{ directory: "/workspace/repo" }]);
-      expect(turnEventSignatures(events)).toEqual([
-        ["turn_started", "opencode-turn-0"],
-        ["timeline", "opencode-turn-0"],
-        ["turn_completed", "opencode-turn-0"],
-      ]);
-      expect(events).toContainEqual(
-        expect.objectContaining({
-          type: "timeline",
-          item: expect.objectContaining({ text: "already-running child says hi" }),
-        }),
-      );
+      expect(events.some((event) => event.type === "turn_started")).toBe(false);
     } finally {
+      releaseStatus.resolve();
       await child.close();
       await parent.close();
     }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3745,7 +3745,11 @@ class OpenCodeAgentSession implements AgentSession {
     // OpenCode publishes the persisted user message before it marks the runner
     // busy. That message is the earliest unambiguous boundary for a plugin-
     // initiated parent turn; session metadata and assistant echoes are not.
-    if (event.type === "message.updated" && event.properties.info.role === "user") {
+    if (
+      event.type === "message.updated" &&
+      event.properties.info.role === "user" &&
+      !event.properties.info.summary?.diffs
+    ) {
       if (this.emittedUserMessageIds.has(event.properties.info.id)) {
         return false;
       }

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -103,6 +103,7 @@ const OPENCODE_LEGACY_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
+const OPENCODE_PENDING_AUTONOMOUS_EVENT_LIMIT = 64;
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
@@ -1379,7 +1380,6 @@ export class OpenCodeAgentClient implements AgentClient {
         undefined,
         launchContext?.agentId,
         url,
-        registeredAcquisition !== null,
       );
     } catch (error) {
       await acquisition.release();
@@ -2937,6 +2937,8 @@ class OpenCodeAgentSession implements AgentSession {
    * run, and a rejection means we never proved the runner stopped.
    */
   private abortSettlement: Promise<void> = Promise.resolve();
+  /** Exact-session content OpenCode persists immediately before its runner reports busy. */
+  private readonly pendingAutonomousEvents: AgentStreamEvent[] = [];
   private readonly runningToolCalls = new Map<string, ToolCallTimelineItem>();
   private subAgentsByCallId = new Map<string, OpenCodeSubAgentActivityState>();
   private subAgentCallIdByChildSessionId = new Map<string, string>();
@@ -2965,7 +2967,6 @@ class OpenCodeAgentSession implements AgentSession {
     persistSession = true,
     private readonly agentId?: string,
     private readonly serverUrl?: string,
-    private readonly externallyDriven = false,
   ) {
     this.config = config;
     this.client = client;
@@ -3199,6 +3200,7 @@ class OpenCodeAgentSession implements AgentSession {
       throw new Error("OpenCode is still stopping the previous turn");
     }
 
+    this.clearPendingAutonomousEvents();
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
     this.subAgentCallIdByChildSessionId.clear();
@@ -3683,10 +3685,16 @@ class OpenCodeAgentSession implements AgentSession {
         foregroundEvents.push(translatedEvent);
       }
     }
-    if (!turnId && this.shouldStartAutonomousTurn(event, foregroundEvents)) {
+    if (!turnId && this.shouldStartAutonomousTurn(event)) {
       turnId = this.startAutonomousTurn();
+      foregroundEvents.unshift(...this.takePendingAutonomousEvents());
     }
     if (!turnId) {
+      if (isOpenCodeTerminalEvent(event, this.sessionId)) {
+        this.clearPendingAutonomousEvents();
+      } else if (getOpenCodeEventSessionId(event) === this.sessionId) {
+        this.stagePendingAutonomousEvents(foregroundEvents);
+      }
       this.emitBackgroundPermissionRequests(foregroundEvents);
       this.traceOpenCode("provider.opencode.event.skip", {
         n: eventCount,
@@ -3732,41 +3740,44 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
-  private shouldStartAutonomousTurn(
-    event: OpenCodeEvent,
-    foregroundEvents: readonly AgentStreamEvent[],
-  ): boolean {
+  private shouldStartAutonomousTurn(event: OpenCodeEvent): boolean {
     if (this.turnState.status !== "idle") {
       return false;
     }
     if (getOpenCodeEventSessionId(event) !== this.sessionId) {
       return false;
     }
-    // OpenCode publishes the persisted user message before it marks the runner
-    // busy. That message is the earliest unambiguous boundary for a plugin-
-    // initiated parent turn; session metadata and assistant echoes are not.
-    if (
-      event.type === "message.updated" &&
-      event.properties.info.role === "user" &&
-      !event.properties.info.summary?.diffs
-    ) {
-      if (this.emittedUserMessageIds.has(event.properties.info.id)) {
-        return false;
-      }
-      return true;
-    }
-    if (!this.externallyDriven) {
-      return false;
-    }
-    if (
-      foregroundEvents.some(
-        (foregroundEvent) =>
-          foregroundEvent.type !== "thread_started" && !toTerminalTurnEvent(foregroundEvent),
-      )
-    ) {
-      return true;
-    }
+    return this.isAutonomousWakeBoundary(event);
+  }
+
+  private isAutonomousWakeBoundary(event: OpenCodeEvent): boolean {
+    // Message records are mutable and can be patched after the runner stops.
+    // Only OpenCode's execution status is authoritative for autonomous activity.
     return event.type === "session.status" && event.properties.status.type === "busy";
+  }
+
+  private stagePendingAutonomousEvents(events: readonly AgentStreamEvent[]): void {
+    for (const event of events) {
+      if (
+        event.type === "thread_started" ||
+        event.type === "permission_requested" ||
+        toTerminalTurnEvent(event)
+      ) {
+        continue;
+      }
+      if (this.pendingAutonomousEvents.length === OPENCODE_PENDING_AUTONOMOUS_EVENT_LIMIT) {
+        this.pendingAutonomousEvents.shift();
+      }
+      this.pendingAutonomousEvents.push(event);
+    }
+  }
+
+  private takePendingAutonomousEvents(): AgentStreamEvent[] {
+    return this.pendingAutonomousEvents.splice(0);
+  }
+
+  private clearPendingAutonomousEvents(): void {
+    this.pendingAutonomousEvents.length = 0;
   }
 
   private startAutonomousTurn(): string {
@@ -3803,6 +3814,7 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
+    this.clearPendingAutonomousEvents();
     this.turnState = { status: "idle" };
     this.abortController = null;
     this.notifySubscribers(event, turnId);
@@ -3834,6 +3846,7 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
+    this.clearPendingAutonomousEvents();
     this.abortController = null;
     return abort;
   }
@@ -3896,6 +3909,7 @@ class OpenCodeAgentSession implements AgentSession {
     resetOpenCodeTurnTrackingState(this.createTranslationState());
     const contextWindowMaxTokens = this.resolveSelectedModelContextWindowMaxTokens();
     this.accumulatedUsage = contextWindowMaxTokens !== undefined ? { contextWindowMaxTokens } : {};
+    this.clearPendingAutonomousEvents();
     this.turnState = { status: "idle" };
     stop.terminal.resolve();
   }
@@ -4146,6 +4160,7 @@ class OpenCodeAgentSession implements AgentSession {
         logger: this.logger,
       });
       await this.deleteProviderSessionIfEphemeral();
+      this.clearPendingAutonomousEvents();
       this.turnState = { status: "idle" };
     } finally {
       await this.releaseServer?.();

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -3659,21 +3659,7 @@ class OpenCodeAgentSession implements AgentSession {
     if (!event) {
       return;
     }
-    if (
-      this.turnState.status === "stopping" &&
-      getOpenCodeEventSessionId(event) === this.sessionId
-    ) {
-      // Residue of the canceled run must not surface as a new turn. Its terminal
-      // is the authoritative end of the stop, so anything OpenCode publishes
-      // afterwards belongs to a new run by construction and takes the live path.
-      if (isOpenCodeTerminalEvent(event, this.sessionId)) {
-        this.finishStoppingTurn(this.turnState.stop);
-      }
-      this.traceOpenCode("provider.opencode.event.skip", {
-        n: eventCount,
-        reason: "turn_stopping",
-        type: event.type,
-      });
+    if (this.discardEventWhileStopping(event, eventCount)) {
       return;
     }
     const translated = await this.translateEvent(event);
@@ -3730,6 +3716,27 @@ class OpenCodeAgentSession implements AgentSession {
       }
       this.notifySubscribers(e, turnId);
     }
+  }
+
+  private discardEventWhileStopping(event: OpenCodeEvent, eventCount: number): boolean {
+    if (
+      this.turnState.status !== "stopping" ||
+      getOpenCodeEventSessionId(event) !== this.sessionId
+    ) {
+      return false;
+    }
+    // Residue of the canceled run must not surface as a new turn. Its terminal
+    // is the authoritative end of the stop, so anything OpenCode publishes
+    // afterwards belongs to a new run by construction and takes the live path.
+    if (isOpenCodeTerminalEvent(event, this.sessionId)) {
+      this.finishStoppingTurn(this.turnState.stop);
+    }
+    this.traceOpenCode("provider.opencode.event.skip", {
+      n: eventCount,
+      reason: "turn_stopping",
+      type: event.type,
+    });
+    return true;
   }
 
   private emitBackgroundPermissionRequests(events: readonly AgentStreamEvent[]): void {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -103,7 +103,6 @@ const OPENCODE_LEGACY_FULL_ACCESS_MODE_ID = "full-access";
 const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
-const OPENCODE_PENDING_AUTONOMOUS_EVENT_LIMIT = 64;
 const OPENCODE_CHILD_SESSION_HYDRATION_LIMIT = 100;
 const OPENCODE_CHILD_SESSION_SERVER_REGISTRY_LIMIT = 500;
 const OPENCODE_PERMISSION_ACTION_ALLOW_ONCE = "allow_once";
@@ -1380,6 +1379,7 @@ export class OpenCodeAgentClient implements AgentClient {
         undefined,
         launchContext?.agentId,
         url,
+        registeredAcquisition !== null,
       );
     } catch (error) {
       await acquisition.release();
@@ -2937,8 +2937,7 @@ class OpenCodeAgentSession implements AgentSession {
    * run, and a rejection means we never proved the runner stopped.
    */
   private abortSettlement: Promise<void> = Promise.resolve();
-  /** Exact-session content OpenCode persists immediately before its runner reports busy. */
-  private readonly pendingAutonomousEvents: AgentStreamEvent[] = [];
+  private externalStatusReconciliationStarted = false;
   private readonly runningToolCalls = new Map<string, ToolCallTimelineItem>();
   private subAgentsByCallId = new Map<string, OpenCodeSubAgentActivityState>();
   private subAgentCallIdByChildSessionId = new Map<string, string>();
@@ -2967,6 +2966,7 @@ class OpenCodeAgentSession implements AgentSession {
     persistSession = true,
     private readonly agentId?: string,
     private readonly serverUrl?: string,
+    private readonly externallyDriven = false,
   ) {
     this.config = config;
     this.client = client;
@@ -3200,7 +3200,6 @@ class OpenCodeAgentSession implements AgentSession {
       throw new Error("OpenCode is still stopping the previous turn");
     }
 
-    this.clearPendingAutonomousEvents();
     this.runningToolCalls.clear();
     this.subAgentsByCallId.clear();
     this.subAgentCallIdByChildSessionId.clear();
@@ -3395,10 +3394,32 @@ class OpenCodeAgentSession implements AgentSession {
   }
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
     this.subscribers.add(callback);
+    this.startExternalStatusReconciliation();
     this.startChildSessionHydration();
     return () => {
       this.subscribers.delete(callback);
     };
+  }
+
+  private startExternalStatusReconciliation(): void {
+    if (!this.externallyDriven || this.externalStatusReconciliationStarted || this.closed) {
+      return;
+    }
+    this.externalStatusReconciliationStarted = true;
+    void this.reconcileExternalRunnerStatus().catch((error) => {
+      this.logger.warn(
+        { err: error, sessionId: this.sessionId },
+        "Failed to reconcile externally driven OpenCode session status",
+      );
+    });
+  }
+
+  private async reconcileExternalRunnerStatus(): Promise<void> {
+    await this.ensureEventStreamReady();
+    if ((await this.readProviderRunnerStatus()) !== "busy" || this.turnState.status !== "idle") {
+      return;
+    }
+    this.startAutonomousTurn();
   }
 
   private startChildSessionHydration(): void {
@@ -3673,14 +3694,8 @@ class OpenCodeAgentSession implements AgentSession {
     }
     if (!turnId && this.shouldStartAutonomousTurn(event)) {
       turnId = this.startAutonomousTurn();
-      foregroundEvents.unshift(...this.takePendingAutonomousEvents());
     }
     if (!turnId) {
-      if (isOpenCodeTerminalEvent(event, this.sessionId)) {
-        this.clearPendingAutonomousEvents();
-      } else if (getOpenCodeEventSessionId(event) === this.sessionId) {
-        this.stagePendingAutonomousEvents(foregroundEvents);
-      }
       this.emitBackgroundPermissionRequests(foregroundEvents);
       this.traceOpenCode("provider.opencode.event.skip", {
         n: eventCount,
@@ -3763,30 +3778,6 @@ class OpenCodeAgentSession implements AgentSession {
     return event.type === "session.status" && event.properties.status.type === "busy";
   }
 
-  private stagePendingAutonomousEvents(events: readonly AgentStreamEvent[]): void {
-    for (const event of events) {
-      if (
-        event.type === "thread_started" ||
-        event.type === "permission_requested" ||
-        toTerminalTurnEvent(event)
-      ) {
-        continue;
-      }
-      if (this.pendingAutonomousEvents.length === OPENCODE_PENDING_AUTONOMOUS_EVENT_LIMIT) {
-        this.pendingAutonomousEvents.shift();
-      }
-      this.pendingAutonomousEvents.push(event);
-    }
-  }
-
-  private takePendingAutonomousEvents(): AgentStreamEvent[] {
-    return this.pendingAutonomousEvents.splice(0);
-  }
-
-  private clearPendingAutonomousEvents(): void {
-    this.pendingAutonomousEvents.length = 0;
-  }
-
   private startAutonomousTurn(): string {
     const turnId = this.createTurnId();
     this.turnState = { status: "running", turnId };
@@ -3821,7 +3812,6 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
-    this.clearPendingAutonomousEvents();
     this.turnState = { status: "idle" };
     this.abortController = null;
     this.notifySubscribers(event, turnId);
@@ -3853,7 +3843,6 @@ class OpenCodeAgentSession implements AgentSession {
     }
     this.pendingUserMessageText = null;
     this.pendingClientMessageId = null;
-    this.clearPendingAutonomousEvents();
     this.abortController = null;
     return abort;
   }
@@ -3916,7 +3905,6 @@ class OpenCodeAgentSession implements AgentSession {
     resetOpenCodeTurnTrackingState(this.createTranslationState());
     const contextWindowMaxTokens = this.resolveSelectedModelContextWindowMaxTokens();
     this.accumulatedUsage = contextWindowMaxTokens !== undefined ? { contextWindowMaxTokens } : {};
-    this.clearPendingAutonomousEvents();
     this.turnState = { status: "idle" };
     stop.terminal.resolve();
   }
@@ -4167,7 +4155,6 @@ class OpenCodeAgentSession implements AgentSession {
         logger: this.logger,
       });
       await this.deleteProviderSessionIfEphemeral();
-      this.clearPendingAutonomousEvents();
       this.turnState = { status: "idle" };
     } finally {
       await this.releaseServer?.();

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -2815,15 +2815,28 @@ function getOpenCodeEventSessionId(event: OpenCodeEvent): string | null {
   );
 }
 
-function isOpenCodeTerminalEvent(event: OpenCodeEvent, sessionId: string): boolean {
-  if (event.type === "session.idle" || event.type === "session.error") {
-    return event.properties.sessionID === sessionId;
+function getOpenCodeRunnerStatusFromEvent(
+  event: OpenCodeEvent,
+  sessionId: string,
+): OpenCodeRunnerStatus | null {
+  if (getOpenCodeEventSessionId(event) !== sessionId) {
+    return null;
   }
-  return (
-    event.type === "session.status" &&
-    event.properties.sessionID === sessionId &&
-    event.properties.status.type === "idle"
-  );
+  if (event.type === "session.status") {
+    return event.properties.status.type;
+  }
+  if (event.type === "session.idle" || event.type === "session.error") {
+    return "idle";
+  }
+  return null;
+}
+
+function isOpenCodeRunnerActive(status: OpenCodeRunnerStatus): boolean {
+  return status === "busy" || status === "retry";
+}
+
+function isOpenCodeTerminalEvent(event: OpenCodeEvent, sessionId: string): boolean {
+  return getOpenCodeRunnerStatusFromEvent(event, sessionId) === "idle";
 }
 
 function isOpenCodeProviderInternalEvent(event: AgentStreamEvent): boolean {
@@ -2938,6 +2951,7 @@ class OpenCodeAgentSession implements AgentSession {
    */
   private abortSettlement: Promise<void> = Promise.resolve();
   private externalStatusReconciliationStarted = false;
+  private runnerStatusRevision = 0;
   private readonly runningToolCalls = new Map<string, ToolCallTimelineItem>();
   private subAgentsByCallId = new Map<string, OpenCodeSubAgentActivityState>();
   private subAgentCallIdByChildSessionId = new Map<string, string>();
@@ -3416,7 +3430,13 @@ class OpenCodeAgentSession implements AgentSession {
 
   private async reconcileExternalRunnerStatus(): Promise<void> {
     await this.ensureEventStreamReady();
-    if ((await this.readProviderRunnerStatus()) !== "busy" || this.turnState.status !== "idle") {
+    const observedRevision = this.runnerStatusRevision;
+    const runnerStatus = await this.readProviderRunnerStatus();
+    if (
+      this.runnerStatusRevision !== observedRevision ||
+      this.turnState.status !== "idle" ||
+      !isOpenCodeRunnerActive(runnerStatus)
+    ) {
       return;
     }
     this.startAutonomousTurn();
@@ -3680,6 +3700,7 @@ class OpenCodeAgentSession implements AgentSession {
     if (!event) {
       return;
     }
+    this.observeRunnerStatusEvent(event);
     if (this.discardEventWhileStopping(event, eventCount)) {
       return;
     }
@@ -3762,20 +3783,20 @@ class OpenCodeAgentSession implements AgentSession {
     }
   }
 
+  private observeRunnerStatusEvent(event: OpenCodeEvent): void {
+    if (getOpenCodeRunnerStatusFromEvent(event, this.sessionId) !== null) {
+      this.runnerStatusRevision += 1;
+    }
+  }
+
   private shouldStartAutonomousTurn(event: OpenCodeEvent): boolean {
     if (this.turnState.status !== "idle") {
       return false;
     }
-    if (getOpenCodeEventSessionId(event) !== this.sessionId) {
-      return false;
-    }
-    return this.isAutonomousWakeBoundary(event);
-  }
-
-  private isAutonomousWakeBoundary(event: OpenCodeEvent): boolean {
     // Message records are mutable and can be patched after the runner stops.
     // Only OpenCode's execution status is authoritative for autonomous activity.
-    return event.type === "session.status" && event.properties.status.type === "busy";
+    const runnerStatus = getOpenCodeRunnerStatusFromEvent(event, this.sessionId);
+    return runnerStatus !== null && isOpenCodeRunnerActive(runnerStatus);
   }
 
   private startAutonomousTurn(): string {

--- a/packages/server/src/server/daemon-e2e/opencode-omo-autonomous.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/opencode-omo-autonomous.real.e2e.test.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { expect, test } from "vitest";
@@ -11,7 +11,6 @@ const CHILD_TOKEN = "PASEO_OMO_CHILD_READY";
 const ROOT_IDLE_TOKEN = "PASEO_OMO_ROOT_WAITING";
 const FINAL_TOKEN = "PASEO_OMO_AUTONOMOUS_FINAL";
 const ROOT_IDLE_BARRIER = ".paseo-omo-root-idle";
-const ROOT_SNAPSHOT_FILE = ".paseo-omo-snapshot-source";
 
 test("OpenCode remains idle while an OMO child works and completes the autonomous wake", async () => {
   const runtime = await createOpenCodeOmoRealRuntime();
@@ -31,7 +30,6 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     await runtime.client.sendMessage(
       agent.id,
       [
-        `First use bash to write PASEO_OMO_SNAPSHOT_EDIT to ${ROOT_SNAPSHOT_FILE}.`,
         "Use the OMO task tool exactly once with category quick and run_in_background=true.",
         `Tell the child: use bash to wait until ${ROOT_IDLE_BARRIER} exists in the workspace, sleep 5, then return exactly ${CHILD_TOKEN}.`,
         `After the background task starts, reply exactly ${ROOT_IDLE_TOKEN} and stop.`,
@@ -44,13 +42,6 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     expect(firstFinish.status).toBe("idle");
     const firstTimeline = await runtime.client.fetchAgentTimeline(agent.id, { limit: 240 });
     expect(assistantTexts(firstTimeline.entries).join("\n")).toContain(ROOT_IDLE_TOKEN);
-    const firstTerminal = firstTerminalIndex(collector.messages, agent.id);
-    await waitForSnapshotDiff(runtime.artifacts, ROOT_SNAPSHOT_FILE);
-    expect(
-      collector.messages
-        .slice(firstTerminal + 1)
-        .some((message) => isAgentStreamEvent(message, agent.id, "turn_started")),
-    ).toBe(false);
     await writeFile(join(runtime.workspace, ROOT_IDLE_BARRIER), "root idle\n", "utf8");
 
     const completedChild = await waitForCompletedChildWithToken(
@@ -59,6 +50,7 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
       CHILD_TOKEN,
     );
 
+    const firstTerminal = firstTerminalIndex(collector.messages, agent.id);
     await waitForMessage(
       collector.messages,
       (message, index) =>
@@ -133,19 +125,6 @@ function assistantTexts(
   return entries.flatMap((entry) =>
     entry.item.type === "assistant_message" ? [entry.item.text] : [],
   );
-}
-
-async function waitForSnapshotDiff(artifacts: string, filename: string): Promise<void> {
-  const daemonLog = join(artifacts, "daemon.log");
-  const deadline = Date.now() + 240_000;
-  while (Date.now() < deadline) {
-    const contents = await readFile(daemonLog, "utf8").catch(() => "");
-    if (contents.includes('"diffs"') && contents.includes(filename)) {
-      return;
-    }
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
-  }
-  throw new Error(`Timed out waiting for an OpenCode snapshot diff for ${filename}`);
 }
 
 function isAgentStreamEvent(

--- a/packages/server/src/server/daemon-e2e/opencode-omo-autonomous.real.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/opencode-omo-autonomous.real.e2e.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { expect, test } from "vitest";
@@ -11,6 +11,7 @@ const CHILD_TOKEN = "PASEO_OMO_CHILD_READY";
 const ROOT_IDLE_TOKEN = "PASEO_OMO_ROOT_WAITING";
 const FINAL_TOKEN = "PASEO_OMO_AUTONOMOUS_FINAL";
 const ROOT_IDLE_BARRIER = ".paseo-omo-root-idle";
+const ROOT_SNAPSHOT_FILE = ".paseo-omo-snapshot-source";
 
 test("OpenCode remains idle while an OMO child works and completes the autonomous wake", async () => {
   const runtime = await createOpenCodeOmoRealRuntime();
@@ -30,6 +31,7 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     await runtime.client.sendMessage(
       agent.id,
       [
+        `First use bash to write PASEO_OMO_SNAPSHOT_EDIT to ${ROOT_SNAPSHOT_FILE}.`,
         "Use the OMO task tool exactly once with category quick and run_in_background=true.",
         `Tell the child: use bash to wait until ${ROOT_IDLE_BARRIER} exists in the workspace, sleep 5, then return exactly ${CHILD_TOKEN}.`,
         `After the background task starts, reply exactly ${ROOT_IDLE_TOKEN} and stop.`,
@@ -42,6 +44,13 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     expect(firstFinish.status).toBe("idle");
     const firstTimeline = await runtime.client.fetchAgentTimeline(agent.id, { limit: 240 });
     expect(assistantTexts(firstTimeline.entries).join("\n")).toContain(ROOT_IDLE_TOKEN);
+    const firstTerminal = firstTerminalIndex(collector.messages, agent.id);
+    await waitForSnapshotDiff(runtime.artifacts, ROOT_SNAPSHOT_FILE);
+    expect(
+      collector.messages
+        .slice(firstTerminal + 1)
+        .some((message) => isAgentStreamEvent(message, agent.id, "turn_started")),
+    ).toBe(false);
     await writeFile(join(runtime.workspace, ROOT_IDLE_BARRIER), "root idle\n", "utf8");
 
     const completedChild = await waitForCompletedChildWithToken(
@@ -50,7 +59,6 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
       CHILD_TOKEN,
     );
 
-    const firstTerminal = firstTerminalIndex(collector.messages, agent.id);
     await waitForMessage(
       collector.messages,
       (message, index) =>
@@ -99,6 +107,7 @@ test("OpenCode remains idle while an OMO child works and completes the autonomou
     expect(childRunningIndex).toBeGreaterThan(rootRunningIndex);
     expect(rootIdleIndex).toBeGreaterThan(childRunningIndex);
     expect(childCompletedIndex).toBeGreaterThan(rootIdleIndex);
+    expect(wakeStartIndex).toBeGreaterThan(childCompletedIndex);
     expect(wakeStartIndex).toBeGreaterThan(-1);
     expect(autonomousTerminalIndex).toBeGreaterThan(wakeStartIndex);
     expect(cancellationAfterWake).toBe(false);
@@ -124,6 +133,19 @@ function assistantTexts(
   return entries.flatMap((entry) =>
     entry.item.type === "assistant_message" ? [entry.item.text] : [],
   );
+}
+
+async function waitForSnapshotDiff(artifacts: string, filename: string): Promise<void> {
+  const daemonLog = join(artifacts, "daemon.log");
+  const deadline = Date.now() + 240_000;
+  while (Date.now() < deadline) {
+    const contents = await readFile(daemonLog, "utf8").catch(() => "");
+    if (contents.includes('"diffs"') && contents.includes(filename)) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for an OpenCode snapshot diff for ${filename}`);
 }
 
 function isAgentStreamEvent(


### PR DESCRIPTION
### Linked issue

Closes #2330

Supersedes #2489, which GitHub closed when its stacked base was merged and deleted.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

Keeps OpenCode agents idle when late message metadata arrives, while still showing running status and streamed output when background work legitimately wakes the parent session.

Instead of classifying individual `message.updated` shapes, Paseo now uses exact-session provider runner status as the sole boundary for visible background activity. Events received while idle are not retained for a future run. Adopted child sessions reconcile current status when subscribed; `busy` and `retry` both mean active. Live runner boundaries carry a revision so a status response is ignored when a newer live event superseded it while the request was in flight. During cancellation, the existing stop boundary continues to discard canceled residue through the terminal event.

### How did you verify it

- Focused OpenCode adapter suite: 85/85 tests passed, including the captured late `message.updated` snapshot shape, stale idle content followed by a later active run, attachment during busy and retry, and an idle event superseding an in-flight stale busy snapshot.
- Pinned real OpenCode/background-agent integration test: observed the root become idle while a child continued running, then observed child completion wake the root, stream output, and return to idle.
- Browser QA against an isolated daemon: submitted `launch an agent in the background to run sleep 5`, observed the root idle while one child ran, then observed the parent self-start with a visible Stop control and streamed background output before returning to idle.
- `npm run typecheck`
- `npm run lint`
- `npm run format`

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
