### PR TITLE
fix(nix): keep runtime mode out of agent environment

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -230,7 +230,6 @@ in
       '';
 
       environment = {
-        NODE_ENV = "production";
         PASEO_HOME = cfg.dataDir;
         PASEO_LISTEN = "${cfg.listenAddress}:${toString cfg.port}";
       } // lib.optionalAttrs cfg.inheritUserEnvironment (

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -114,9 +114,10 @@ buildNpmPackage rec {
 
     # Create wrapper for the server entry point (for systemd / direct use)
     mkdir -p $out/bin
+    # Keep Paseo's runtime mode separate from NODE_ENV, which belongs to spawned agents.
     makeWrapper ${nodejs}/bin/node $out/bin/paseo-server \
       --add-flags "$out/lib/paseo/packages/server/dist/scripts/supervisor-entrypoint.js" \
-      --set NODE_ENV production
+      --set PASEO_NODE_ENV production
 
     # Create wrapper for the CLI
     makeWrapper ${nodejs}/bin/node $out/bin/paseo \

--- a/packages/cli/tests/26-daemon-launch-supervision.test.ts
+++ b/packages/cli/tests/26-daemon-launch-supervision.test.ts
@@ -18,6 +18,7 @@ const serverConnectionOfferE2ePath = join(
 );
 const desktopRuntimePathsPath = join(repoRoot, "packages/desktop/src/daemon/runtime-paths.ts");
 const nixPackagePath = join(repoRoot, "nix/package.nix");
+const nixModulePath = join(repoRoot, "nix/module.nix");
 
 function assertNoDirectWorkerLaunch(label: string, command: string): void {
   assert(
@@ -100,6 +101,24 @@ assert(
   "Nix paseo-server wrapper should use dist/scripts/supervisor-entrypoint.js",
 );
 assertNoDirectWorkerLaunch("Nix package wrapper", nixPackage);
-console.log("✓ desktop runtime and Nix wrapper enter supervisor\n");
+assert(
+  nixPackage.includes("--set PASEO_NODE_ENV production"),
+  "Nix paseo-server wrapper should keep the daemon runtime mode Paseo-scoped",
+);
+assert(
+  !/--set(-default)?\s+NODE_ENV\b/.test(nixPackage),
+  "Nix paseo-server wrapper must not leak NODE_ENV to external agent processes",
+);
+
+const nixModule = await readFile(nixModulePath, "utf-8");
+assert(
+  !/\bNODE_ENV\b\s*=/.test(nixModule),
+  "NixOS module must not leak NODE_ENV to external agent processes",
+);
+assert(
+  !/\bPASEO_NODE_ENV\b/.test(nixModule),
+  "NixOS module must not duplicate the packaged daemon runtime mode",
+);
+console.log("✓ desktop runtime and Nix wrapper enter supervisor without leaking runtime env\n");
 
 console.log("=== Daemon launch supervision regression test passed ===");


### PR DESCRIPTION
## Summary

- set the packaged daemon runtime mode with `PASEO_NODE_ENV` instead of `NODE_ENV`
- remove the duplicate runtime-mode assignment from the NixOS module
- extend the daemon launch regression test to prevent either Nix path from reintroducing the leak

## Why

The server already treats `PASEO_NODE_ENV` as Paseo-owned runtime control and scrubs it from external agent processes. The Nix wrapper and module still set `NODE_ENV=production`, so every agent and command launched by a NixOS Paseo service inherits production mode. This changes npm install behavior and can make test runners select production builds.

The package wrapper is the single owner of the packaged daemon's production mode. User-provided `NODE_ENV` remains pass-through as designed.

## Validation

- `node packages/cli/tests/26-daemon-launch-supervision.test.ts`
- `npm run build:server`
- `npm run build:app-deps`
- `npm run typecheck`
- `npm run lint`
- `nix build .#packages.x86_64-linux.default --no-link`
- built wrapper contains `export PASEO_NODE_ENV='production'` and no Paseo-owned `NODE_ENV`

Refs #2560