### PR TITLE
Show the current pull request after switching branches

### DIFF
--- a/packages/server/src/server/session/checkout/checkout-session.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.ts
@@ -576,7 +576,6 @@ export class CheckoutSession {
       // Branch is a git fact derived per-descriptor from each workspace's own
       // live git snapshot (id → cwd); the reconciliation pass re-persists the
       // `branch` field per workspace from its own cwd. No cwd → ids fan-out here.
-      // TODO(K10): PR-binding on branch rename is deferred — see plan K10.
 
       // Push a workspace_update immediately so the sidebar/header reflect
       // the new branch name without waiting for the background git watcher.

--- a/packages/server/src/server/worktree-core.posix.test.ts
+++ b/packages/server/src/server/worktree-core.posix.test.ts
@@ -879,6 +879,7 @@ describe.skipIf(isPlatform("win32"))("worktree-core POSIX-only", () => {
       expect(metadata?.changeRequestLookupTarget).toEqual({
         headRef: "feature/gitlab-mr",
         changeRequestNumber: 14,
+        localBranchName: "feature/gitlab-mr-1",
       });
       expect(facts).toMatchObject({
         isGit: true,

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2587,6 +2587,50 @@ const x = 1;
     expect(lookupTarget).not.toHaveProperty("headRepositoryOwner");
   });
 
+  it("does not apply a legacy fork hint to an ownerless branch with the same head", async () => {
+    execFileSync("git", ["branch", "contributor/old-change"], { cwd: repoDir });
+    execFileSync("git", ["branch", "old-change"], { cwd: repoDir });
+    const workspaceDir = join(paseoHome, "worktrees", "repo", "legacy-fork-worktree");
+    mkdirSync(join(paseoHome, "worktrees", "repo"), { recursive: true });
+    execFileSync("git", ["worktree", "add", workspaceDir, "contributor/old-change"], {
+      cwd: repoDir,
+    });
+    writePaseoWorktreeMetadata(workspaceDir, {
+      baseRefName: "main",
+      changeRequestLookupTarget: {
+        headRef: "old-change",
+        headRepositoryOwner: "contributor",
+        changeRequestNumber: 41,
+      },
+    });
+    const requestedTargets: RequestedPullRequestTarget[] = [];
+    const forge = createGitHubServiceRecordingPullRequestTargets({ requestedTargets });
+
+    const forkFacts = await getCheckoutSnapshotFacts(workspaceDir, { paseoHome });
+    await getPullRequestStatus(
+      workspaceDir,
+      forge,
+      { force: true, reason: "legacy-fork-branch" },
+      { paseoHome, facts: forkFacts },
+    );
+    expect(requestedTargets.at(-1)).toMatchObject({
+      headRef: "old-change",
+      headRepositoryOwner: "contributor",
+    });
+
+    execFileSync("git", ["checkout", "old-change"], { cwd: workspaceDir });
+    const ownerlessFacts = await getCheckoutSnapshotFacts(workspaceDir, { paseoHome });
+    await getPullRequestStatus(
+      workspaceDir,
+      forge,
+      { force: true, reason: "ownerless-same-head" },
+      { paseoHome, facts: ownerlessFacts },
+    );
+
+    expect(requestedTargets.at(-1)).toMatchObject({ headRef: "old-change" });
+    expect(requestedTargets.at(-1)).not.toHaveProperty("headRepositoryOwner");
+  });
+
   it("recognizes a normalized GitHub owner branch from legacy Enterprise metadata", async () => {
     execFileSync("git", ["remote", "add", "origin", "git@github.acme.internal:base/repo.git"], {
       cwd: repoDir,

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2550,6 +2550,15 @@ const x = 1;
       headRef: "old-change",
       headRepositoryOwner: "contributor",
     });
+
+    execFileSync("git", ["branch", "local-upstream"], { cwd: repoDir });
+    execFileSync("git", ["config", "branch.new-change.remote", "."], { cwd: repoDir });
+    execFileSync("git", ["config", "branch.new-change.merge", "refs/heads/local-upstream"], {
+      cwd: repoDir,
+    });
+    expect(await readPullRequestLookupTargetFromFacts(workspaceDir, paseoHome)).toMatchObject({
+      headRef: "local-upstream",
+    });
   });
 
   it("does not apply ambiguous legacy PR metadata to a suffixed branch", async () => {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2812,6 +2812,29 @@ const x = 1;
     expect(lookupTarget?.headSha).toMatch(/^[0-9a-f]{40}$/);
   });
 
+  it("treats differently cased Enterprise remotes as the same repository", async () => {
+    execFileSync("git", ["checkout", "-b", "local-feature"], { cwd: repoDir });
+    execFileSync("git", ["remote", "add", "origin", "git@github.acme.internal:Acme/Repo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync(
+      "git",
+      ["remote", "add", "enterprise-alias", "git@github.acme.internal:acme/repo.git"],
+      { cwd: repoDir },
+    );
+    execFileSync("git", ["config", "branch.local-feature.remote", "enterprise-alias"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["config", "branch.local-feature.merge", "refs/heads/main"], {
+      cwd: repoDir,
+    });
+
+    const lookupTarget = await readPullRequestLookupTargetFromFacts(repoDir, paseoHome);
+
+    expect(lookupTarget).toMatchObject({ headRef: "local-feature" });
+    expect(lookupTarget).not.toHaveProperty("headRepositoryOwner");
+  });
+
   it("derives the same origin tracked head for on-demand PR status reads", async () => {
     execFileSync("git", ["checkout", "-b", "tender-parrot"], { cwd: repoDir });
     execFileSync("git", ["remote", "add", "origin", "https://github.com/getpaseo/paseo.git"], {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2532,6 +2532,24 @@ const x = 1;
     expect(await readPullRequestLookupTargetFromFacts(workspaceDir, paseoHome)).toMatchObject({
       headRef: "new-change",
     });
+
+    execFileSync(
+      "git",
+      ["remote", "add", "enterprise-fork", "git@github.acme.internal:contributor/repo.git"],
+      {
+        cwd: repoDir,
+      },
+    );
+    execFileSync("git", ["config", "branch.new-change.remote", "enterprise-fork"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["config", "branch.new-change.merge", "refs/heads/old-change"], {
+      cwd: repoDir,
+    });
+    expect(await readPullRequestLookupTargetFromFacts(workspaceDir, paseoHome)).toMatchObject({
+      headRef: "old-change",
+      headRepositoryOwner: "contributor",
+    });
   });
 
   it("does not apply ambiguous legacy PR metadata to a suffixed branch", async () => {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -89,7 +89,7 @@ function createLegacyWorktreeForTest(
     paseoHome: options.paseoHome,
   });
 }
-import { getPaseoWorktreeMetadataPath } from "./worktree-metadata.js";
+import { getPaseoWorktreeMetadataPath, writePaseoWorktreeMetadata } from "./worktree-metadata.js";
 
 function initRepo(): { tempDir: string; repoDir: string } {
   const tempDir = realpathSync.native(mkdtempSync(join(tmpdir(), "checkout-git-test-")));
@@ -2478,6 +2478,82 @@ const x = 1;
 
     expect(lookupTarget).toMatchObject({ headRef: "feature" });
     expect(lookupTarget?.headSha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("reconciles a PR worktree lookup from current branch tracking", async () => {
+    execFileSync("git", ["remote", "add", "origin", "https://github.com/acme/repo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["branch", "contributor/old-change"], { cwd: repoDir });
+    execFileSync("git", ["branch", "new-change"], { cwd: repoDir });
+    execFileSync("git", ["config", "branch.new-change.remote", "origin"], { cwd: repoDir });
+    execFileSync("git", ["config", "branch.new-change.merge", "refs/heads/new-change"], {
+      cwd: repoDir,
+    });
+    const workspaceDir = join(paseoHome, "worktrees", "repo", "pr-worktree");
+    mkdirSync(join(paseoHome, "worktrees", "repo"), { recursive: true });
+    execFileSync("git", ["worktree", "add", workspaceDir, "contributor/old-change"], {
+      cwd: repoDir,
+    });
+    const staleLookupTarget = {
+      headRef: "old-change",
+      headRepositoryOwner: "contributor",
+      changeRequestNumber: 41,
+    };
+    writePaseoWorktreeMetadata(workspaceDir, {
+      baseRefName: "main",
+      changeRequestLookupTarget: {
+        ...staleLookupTarget,
+        localBranchName: "contributor/old-change",
+      },
+    });
+
+    expect(await readPullRequestLookupTargetFromFacts(workspaceDir, paseoHome)).toMatchObject({
+      headRef: "old-change",
+      headRepositoryOwner: "contributor",
+    });
+
+    execFileSync("git", ["checkout", "new-change"], { cwd: workspaceDir });
+    startGitCommandMetrics();
+    const switchedTarget = await readPullRequestLookupTargetFromFacts(workspaceDir, paseoHome);
+    const commands = stopGitCommandMetrics().commands.map((command) => command.args[0]);
+
+    expect(switchedTarget).toMatchObject({ headRef: "new-change" });
+    expect(switchedTarget).not.toHaveProperty("headRepositoryOwner");
+    expect(commands).not.toContain("fetch");
+
+    writePaseoWorktreeMetadata(workspaceDir, {
+      baseRefName: "main",
+      changeRequestLookupTarget: {
+        ...staleLookupTarget,
+        localBranchName: "new-change",
+      },
+    });
+    expect(await readPullRequestLookupTargetFromFacts(workspaceDir, paseoHome)).toMatchObject({
+      headRef: "new-change",
+    });
+  });
+
+  it("does not apply ambiguous legacy PR metadata to a suffixed branch", async () => {
+    execFileSync("git", ["branch", "contributor/old-change-1"], { cwd: repoDir });
+    const workspaceDir = join(paseoHome, "worktrees", "repo", "legacy-pr-worktree");
+    mkdirSync(join(paseoHome, "worktrees", "repo"), { recursive: true });
+    execFileSync("git", ["worktree", "add", workspaceDir, "contributor/old-change-1"], {
+      cwd: repoDir,
+    });
+    writePaseoWorktreeMetadata(workspaceDir, {
+      baseRefName: "main",
+      changeRequestLookupTarget: {
+        headRef: "old-change",
+        headRepositoryOwner: "contributor",
+        changeRequestNumber: 41,
+      },
+    });
+
+    const lookupTarget = await readPullRequestLookupTargetFromFacts(workspaceDir, paseoHome);
+
+    expect(lookupTarget).toMatchObject({ headRef: "contributor/old-change-1" });
+    expect(lookupTarget).not.toHaveProperty("headRepositoryOwner");
   });
 
   it("does not attach an owner when the tracked remote is the same GitHub repository", async () => {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2632,6 +2632,27 @@ const x = 1;
     expect(requestedTargets).toEqual([
       expect.objectContaining({ headRef: "old-change", headRepositoryOwner: "MixedOwner" }),
     ]);
+
+    execFileSync(
+      "git",
+      ["remote", "add", "replacement-fork", "git@github.acme.internal:OtherOwner/repo.git"],
+      { cwd: repoDir },
+    );
+    execFileSync("git", ["config", "branch.mixedowner/old-change.remote", "replacement-fork"], {
+      cwd: repoDir,
+    });
+    const repointedFacts = await getCheckoutSnapshotFacts(workspaceDir, { paseoHome });
+    await getPullRequestStatus(
+      workspaceDir,
+      forge,
+      { force: true, reason: "repointed-enterprise-owner" },
+      { paseoHome, facts: repointedFacts },
+    );
+
+    expect(requestedTargets.at(-1)).toMatchObject({
+      headRef: "old-change",
+      headRepositoryOwner: "OtherOwner",
+    });
   });
 
   it("keeps a ref-only change request bound across rename but not branch switch", async () => {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -89,7 +89,11 @@ function createLegacyWorktreeForTest(
     paseoHome: options.paseoHome,
   });
 }
-import { getPaseoWorktreeMetadataPath, writePaseoWorktreeMetadata } from "./worktree-metadata.js";
+import {
+  getPaseoWorktreeMetadataPath,
+  readPaseoWorktreeMetadata,
+  writePaseoWorktreeMetadata,
+} from "./worktree-metadata.js";
 
 function initRepo(): { tempDir: string; repoDir: string } {
   const tempDir = realpathSync.native(mkdtempSync(join(tmpdir(), "checkout-git-test-")));
@@ -2581,6 +2585,98 @@ const x = 1;
 
     expect(lookupTarget).toMatchObject({ headRef: "contributor/old-change-1" });
     expect(lookupTarget).not.toHaveProperty("headRepositoryOwner");
+  });
+
+  it("recognizes a normalized GitHub owner branch from legacy Enterprise metadata", async () => {
+    execFileSync("git", ["remote", "add", "origin", "git@github.acme.internal:base/repo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync(
+      "git",
+      ["remote", "add", "enterprise-fork", "git@github.acme.internal:MixedOwner/repo.git"],
+      {
+        cwd: repoDir,
+      },
+    );
+    execFileSync("git", ["branch", "mixedowner/old-change"], { cwd: repoDir });
+    execFileSync("git", ["config", "branch.mixedowner/old-change.remote", "enterprise-fork"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["config", "branch.mixedowner/old-change.merge", "refs/heads/old-change"], {
+      cwd: repoDir,
+    });
+    const workspaceDir = join(paseoHome, "worktrees", "repo", "legacy-enterprise-worktree");
+    mkdirSync(join(paseoHome, "worktrees", "repo"), { recursive: true });
+    execFileSync("git", ["worktree", "add", workspaceDir, "mixedowner/old-change"], {
+      cwd: repoDir,
+    });
+    writePaseoWorktreeMetadata(workspaceDir, {
+      baseRefName: "main",
+      changeRequestLookupTarget: {
+        headRef: "old-change",
+        headRepositoryOwner: "MixedOwner",
+        changeRequestNumber: 41,
+      },
+    });
+    const requestedTargets: RequestedPullRequestTarget[] = [];
+    const forge = createGitHubServiceRecordingPullRequestTargets({ requestedTargets });
+
+    const facts = await getCheckoutSnapshotFacts(workspaceDir, { paseoHome });
+    await getPullRequestStatus(
+      workspaceDir,
+      forge,
+      { force: true, reason: "legacy-enterprise-owner" },
+      { paseoHome, facts },
+    );
+
+    expect(requestedTargets).toEqual([
+      expect.objectContaining({ headRef: "old-change", headRepositoryOwner: "MixedOwner" }),
+    ]);
+  });
+
+  it("keeps a ref-only change request bound across rename but not branch switch", async () => {
+    execFileSync("git", ["branch", "feature/gitlab-mr"], { cwd: repoDir });
+    const workspaceDir = join(paseoHome, "worktrees", "repo", "gitlab-mr-worktree");
+    mkdirSync(join(paseoHome, "worktrees", "repo"), { recursive: true });
+    execFileSync("git", ["worktree", "add", workspaceDir, "feature/gitlab-mr"], {
+      cwd: repoDir,
+    });
+    writePaseoWorktreeMetadata(workspaceDir, {
+      baseRefName: "main",
+      changeRequestLookupTarget: {
+        headRef: "feature/gitlab-mr",
+        changeRequestNumber: 14,
+        localBranchName: "feature/gitlab-mr",
+      },
+    });
+    const requestedTargets: RequestedPullRequestTarget[] = [];
+    const forge = createGitHubServiceRecordingPullRequestTargets({ requestedTargets });
+
+    await renameCurrentBranch(workspaceDir, "feature/renamed");
+    expect(readPaseoWorktreeMetadata(workspaceDir)?.changeRequestLookupTarget).toMatchObject({
+      localBranchName: "feature/renamed",
+    });
+    const renamedFacts = await getCheckoutSnapshotFacts(workspaceDir, { paseoHome });
+    const renamedStatus = await getPullRequestStatus(
+      workspaceDir,
+      forge,
+      { force: true, reason: "renamed-change-request" },
+      { paseoHome, facts: renamedFacts },
+    );
+
+    expect(requestedTargets).toEqual([expect.objectContaining({ headRef: "feature/gitlab-mr" })]);
+    expect(renamedStatus.status?.headRefName).toBe("feature/gitlab-mr");
+
+    execFileSync("git", ["checkout", "-b", "other-branch"], { cwd: workspaceDir });
+    const switchedFacts = await getCheckoutSnapshotFacts(workspaceDir, { paseoHome });
+    await getPullRequestStatus(
+      workspaceDir,
+      forge,
+      { force: true, reason: "switched-after-rename" },
+      { paseoHome, facts: switchedFacts },
+    );
+
+    expect(requestedTargets.at(-1)).toMatchObject({ headRef: "other-branch" });
   });
 
   it("does not attach an owner when the tracked remote is the same GitHub repository", async () => {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2856,6 +2856,27 @@ const x = 1;
     expect(lookupTarget?.headSha).toMatch(/^[0-9a-f]{40}$/);
   });
 
+  it("keeps the local branch lookup when a fork tracks the upstream base branch", async () => {
+    execFileSync("git", ["checkout", "-b", "local-feature"], { cwd: repoDir });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:contributor/paseo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["remote", "add", "upstream", "https://github.com/getpaseo/paseo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["config", "branch.local-feature.remote", "upstream"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["config", "branch.local-feature.merge", "refs/heads/main"], {
+      cwd: repoDir,
+    });
+
+    const lookupTarget = await readPullRequestLookupTargetFromFacts(repoDir, paseoHome);
+
+    expect(lookupTarget).toMatchObject({ headRef: "local-feature" });
+    expect(lookupTarget).not.toHaveProperty("headRepositoryOwner");
+  });
+
   it("treats differently cased Enterprise remotes as the same repository", async () => {
     execFileSync("git", ["checkout", "-b", "local-feature"], { cwd: repoDir });
     execFileSync("git", ["remote", "add", "origin", "git@github.acme.internal:Acme/Repo.git"], {

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -2649,10 +2649,12 @@ const x = 1;
         localBranchName: "feature/gitlab-mr",
       },
     });
+    const workspaceCwd = join(workspaceDir, "packages", "service");
+    mkdirSync(workspaceCwd, { recursive: true });
     const requestedTargets: RequestedPullRequestTarget[] = [];
     const forge = createGitHubServiceRecordingPullRequestTargets({ requestedTargets });
 
-    await renameCurrentBranch(workspaceDir, "feature/renamed");
+    await renameCurrentBranch(workspaceCwd, "feature/renamed");
     expect(readPaseoWorktreeMetadata(workspaceDir)?.changeRequestLookupTarget).toMatchObject({
       localBranchName: "feature/renamed",
     });
@@ -2677,6 +2679,25 @@ const x = 1;
     );
 
     expect(requestedTargets.at(-1)).toMatchObject({ headRef: "other-branch" });
+  });
+
+  it("keeps fork identity when the local and tracked branch names match", async () => {
+    execFileSync("git", ["remote", "add", "origin", "https://github.com/getpaseo/paseo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["remote", "add", "contributor", "git@github.com:contributor/paseo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["checkout", "-b", "topic"], { cwd: repoDir });
+    execFileSync("git", ["config", "branch.topic.remote", "contributor"], { cwd: repoDir });
+    execFileSync("git", ["config", "branch.topic.merge", "refs/heads/topic"], { cwd: repoDir });
+
+    const lookupTarget = await readPullRequestLookupTargetFromFacts(repoDir, paseoHome);
+
+    expect(lookupTarget).toMatchObject({
+      headRef: "topic",
+      headRepositoryOwner: "contributor",
+    });
   });
 
   it("does not attach an owner when the tracked remote is the same GitHub repository", async () => {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -28,7 +28,12 @@ import {
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
 import { runGitCommand } from "./run-git-command.js";
 import { isPaseoOwnedWorktreeCwd, resolvePaseoWorktreesBaseRoot } from "./worktree.js";
-import { type PaseoWorktreeMetadata, readPaseoWorktreeMetadata } from "./worktree-metadata.js";
+import {
+  getPaseoWorktreeChangeRequestHintForBranch,
+  type PaseoWorktreeMetadata,
+  readPaseoWorktreeMetadata,
+  rebindPaseoWorktreeChangeRequestHint,
+} from "./worktree-metadata.js";
 const READ_ONLY_GIT_ENV = {
   GIT_OPTIONAL_LOCKS: "0",
   LC_ALL: "C",
@@ -1050,6 +1055,9 @@ export async function renameCurrentBranch(
   });
 
   const currentBranch = await getCurrentBranch(cwd);
+  if (currentBranch) {
+    rebindPaseoWorktreeChangeRequestHint(cwd, previousBranch, currentBranch);
+  }
   return { previousBranch, currentBranch };
 }
 
@@ -1660,30 +1668,14 @@ function buildPullRequestLookupTargetFromMetadata(
   metadata: PaseoWorktreeMetadata | null,
   currentBranch: string,
 ): PullRequestStatusLookupTarget | null {
-  const target = metadata?.changeRequestLookupTarget;
-  if (!target || !isChangeRequestLookupTargetForBranch(target, currentBranch)) {
+  const target = getPaseoWorktreeChangeRequestHintForBranch(metadata, currentBranch);
+  if (!target) {
     return null;
   }
   return {
     headRef: target.headRef,
     ...(target.headRepositoryOwner ? { headRepositoryOwner: target.headRepositoryOwner } : {}),
   };
-}
-
-function isChangeRequestLookupTargetForBranch(
-  target: NonNullable<PaseoWorktreeMetadata["changeRequestLookupTarget"]>,
-  currentBranch: string,
-): boolean {
-  if (target.localBranchName) {
-    return target.localBranchName === currentBranch;
-  }
-
-  // Legacy metadata did not record the local branch. Only accept canonical names;
-  // a collision suffix cannot be distinguished from an unrelated later branch.
-  const legacyLocalBranch = target.headRepositoryOwner
-    ? `${target.headRepositoryOwner}/${target.headRef}`
-    : target.headRef;
-  return currentBranch === legacyLocalBranch;
 }
 
 function buildInitialPullRequestLookupTarget(input: {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1658,15 +1658,32 @@ function buildPullRequestLookupTargetFromPushConfig(
 
 function buildPullRequestLookupTargetFromMetadata(
   metadata: PaseoWorktreeMetadata | null,
+  currentBranch: string,
 ): PullRequestStatusLookupTarget | null {
   const target = metadata?.changeRequestLookupTarget;
-  if (!target) {
+  if (!target || !isChangeRequestLookupTargetForBranch(target, currentBranch)) {
     return null;
   }
   return {
     headRef: target.headRef,
     ...(target.headRepositoryOwner ? { headRepositoryOwner: target.headRepositoryOwner } : {}),
   };
+}
+
+function isChangeRequestLookupTargetForBranch(
+  target: NonNullable<PaseoWorktreeMetadata["changeRequestLookupTarget"]>,
+  currentBranch: string,
+): boolean {
+  if (target.localBranchName) {
+    return target.localBranchName === currentBranch;
+  }
+
+  // Legacy metadata did not record the local branch. Only accept canonical names;
+  // a collision suffix cannot be distinguished from an unrelated later branch.
+  const legacyLocalBranch = target.headRepositoryOwner
+    ? `${target.headRepositoryOwner}/${target.headRef}`
+    : target.headRef;
+  return currentBranch === legacyLocalBranch;
 }
 
 function buildInitialPullRequestLookupTarget(input: {
@@ -1682,8 +1699,24 @@ function buildInitialPullRequestLookupTarget(input: {
     return null;
   }
 
+  const hasConfiguredBranchTarget = Boolean(
+    input.branchRemoteName &&
+    input.branchRemoteUrl &&
+    parseBranchMergeHeadRef(input.branchMergeRef),
+  );
+  if (hasConfiguredBranchTarget) {
+    return buildPullRequestLookupTargetFromBranchConfig({
+      currentBranch: input.currentBranch,
+      branchRemoteName: input.branchRemoteName,
+      branchMergeRef: input.branchMergeRef,
+      branchRemoteUrl: input.branchRemoteUrl,
+      originRemoteUrl: input.originRemoteUrl,
+      resolvedBaseRef: input.resolvedBaseRef,
+    });
+  }
+
   return (
-    buildPullRequestLookupTargetFromMetadata(input.metadata) ??
+    buildPullRequestLookupTargetFromMetadata(input.metadata, input.currentBranch) ??
     buildPullRequestLookupTargetFromBranchConfig({
       currentBranch: input.currentBranch,
       branchRemoteName: input.branchRemoteName,

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1631,7 +1631,7 @@ function buildPullRequestLookupTargetFromBranchConfig(
 
   const remoteRepo = parseRepositoryIdentityFromRemote(input.branchRemoteUrl);
   const originRepo = parseRepositoryIdentityFromRemote(input.originRemoteUrl);
-  const isSameRepo = Boolean(remoteRepo && originRepo && remoteRepo === originRepo);
+  const isSameRepo = areSameGitHubRepository(remoteRepo, originRepo);
   const headRepositoryOwner = remoteRepo && !isSameRepo ? remoteRepo.split("/")[0] : null;
   const normalizedBaseRef = input.resolvedBaseRef
     ? normalizeLocalBranchRefName(input.resolvedBaseRef)
@@ -1658,6 +1658,10 @@ function parseRepositoryIdentityFromRemote(remoteUrl: string | null): string | n
   return location ? (parseGitHubRemoteIdentity(location.path)?.repo ?? null) : null;
 }
 
+function areSameGitHubRepository(left: string | null, right: string | null): boolean {
+  return Boolean(left && right && left.toLowerCase() === right.toLowerCase());
+}
+
 function buildPullRequestLookupTargetFromPushConfig(
   input: PullRequestLookupTargetPushConfig,
 ): PullRequestStatusLookupTarget | null {
@@ -1670,7 +1674,7 @@ function buildPullRequestLookupTargetFromPushConfig(
   const originRepo = input.originRemoteUrl
     ? parseGitHubRepoFromRemote(input.originRemoteUrl)
     : null;
-  const isSameRepo = Boolean(remoteRepo && originRepo && remoteRepo === originRepo);
+  const isSameRepo = areSameGitHubRepository(remoteRepo, originRepo);
   const headRepositoryOwner = remoteRepo && !isSameRepo ? remoteRepo.split("/")[0] : null;
   const normalizedBaseRef = input.resolvedBaseRef
     ? normalizeLocalBranchRefName(input.resolvedBaseRef)

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1700,9 +1700,7 @@ function buildInitialPullRequestLookupTarget(input: {
   }
 
   const hasConfiguredBranchTarget = Boolean(
-    input.branchRemoteName &&
-    input.branchRemoteUrl &&
-    parseBranchMergeHeadRef(input.branchMergeRef),
+    input.branchRemoteName && parseBranchMergeHeadRef(input.branchMergeRef),
   );
   if (hasConfiguredBranchTarget) {
     const configuredTarget = buildPullRequestLookupTargetFromBranchConfig({
@@ -1723,7 +1721,8 @@ function buildInitialPullRequestLookupTarget(input: {
     // agrees with the explicit tracking configuration.
     if (
       trackedHeadRef &&
-      !parseGitHubRepoFromRemote(input.branchRemoteUrl ?? "") &&
+      input.branchRemoteUrl &&
+      !parseGitHubRepoFromRemote(input.branchRemoteUrl) &&
       !configuredTarget.headRepositoryOwner &&
       metadataTarget?.headRef === trackedHeadRef &&
       metadataTarget.headRepositoryOwner

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1636,7 +1636,14 @@ function buildPullRequestLookupTargetFromBranchConfig(
   const normalizedBaseRef = input.resolvedBaseRef
     ? normalizeLocalBranchRefName(input.resolvedBaseRef)
     : null;
-  if (trackedHeadRef === normalizedBaseRef && !headRepositoryOwner) {
+  if (
+    trackedHeadRef === normalizedBaseRef &&
+    !doesLocalBranchNameIdentifyTrackedHead(
+      input.currentBranch,
+      trackedHeadRef,
+      headRepositoryOwner,
+    )
+  ) {
     return { headRef: input.currentBranch };
   }
 
@@ -1660,6 +1667,22 @@ function parseRepositoryIdentityFromRemote(remoteUrl: string | null): string | n
 
 function areSameGitHubRepository(left: string | null, right: string | null): boolean {
   return Boolean(left && right && left.toLowerCase() === right.toLowerCase());
+}
+
+function doesLocalBranchNameIdentifyTrackedHead(
+  currentBranch: string,
+  trackedHeadRef: string,
+  headRepositoryOwner: string | null,
+): boolean {
+  if (currentBranch === trackedHeadRef) {
+    return true;
+  }
+  if (!headRepositoryOwner) {
+    return false;
+  }
+  return [headRepositoryOwner, headRepositoryOwner.toLowerCase()].some(
+    (owner) => currentBranch === `${owner}/${trackedHeadRef}`,
+  );
 }
 
 function buildPullRequestLookupTargetFromPushConfig(

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -3,6 +3,7 @@ import { existsSync, realpathSync } from "fs";
 import { open as openFile, readFile, stat as statFile } from "fs/promises";
 import { TTLCache } from "@isaacs/ttlcache";
 import type { CheckoutCommit, CheckoutCommitFile } from "@getpaseo/protocol/messages";
+import { parseGitHubRemoteIdentity, parseGitRemoteLocation } from "@getpaseo/protocol/git-remote";
 import { maxBase64EncryptedPlaintextByteLength } from "@getpaseo/relay";
 import type { Logger } from "pino";
 import type { ParsedDiffFile } from "../server/utils/diff-highlighter.js";
@@ -1628,12 +1629,8 @@ function buildPullRequestLookupTargetFromBranchConfig(
     return { headRef: input.currentBranch };
   }
 
-  const remoteRepo = input.branchRemoteUrl
-    ? parseGitHubRepoFromRemote(input.branchRemoteUrl)
-    : null;
-  const originRepo = input.originRemoteUrl
-    ? parseGitHubRepoFromRemote(input.originRemoteUrl)
-    : null;
+  const remoteRepo = parseRepositoryIdentityFromRemote(input.branchRemoteUrl);
+  const originRepo = parseRepositoryIdentityFromRemote(input.originRemoteUrl);
   const isSameRepo = Boolean(remoteRepo && originRepo && remoteRepo === originRepo);
   const headRepositoryOwner = remoteRepo && !isSameRepo ? remoteRepo.split("/")[0] : null;
   const normalizedBaseRef = input.resolvedBaseRef
@@ -1651,6 +1648,14 @@ function buildPullRequestLookupTargetFromBranchConfig(
     headRef: trackedHeadRef,
     ...(headRepositoryOwner ? { headRepositoryOwner } : {}),
   };
+}
+
+function parseRepositoryIdentityFromRemote(remoteUrl: string | null): string | null {
+  if (!remoteUrl) {
+    return null;
+  }
+  const location = parseGitRemoteLocation(remoteUrl);
+  return location ? (parseGitHubRemoteIdentity(location.path)?.repo ?? null) : null;
 }
 
 function buildPullRequestLookupTargetFromPushConfig(
@@ -1711,7 +1716,7 @@ function buildInitialPullRequestLookupTarget(input: {
     input.branchRemoteName && parseBranchMergeHeadRef(input.branchMergeRef),
   );
   if (hasConfiguredBranchTarget) {
-    const configuredTarget = buildPullRequestLookupTargetFromBranchConfig({
+    return buildPullRequestLookupTargetFromBranchConfig({
       currentBranch: input.currentBranch,
       branchRemoteName: input.branchRemoteName,
       branchMergeRef: input.branchMergeRef,
@@ -1719,28 +1724,6 @@ function buildInitialPullRequestLookupTarget(input: {
       originRemoteUrl: input.originRemoteUrl,
       resolvedBaseRef: input.resolvedBaseRef,
     });
-    const trackedHeadRef = parseBranchMergeHeadRef(input.branchMergeRef);
-    const metadataTarget = buildPullRequestLookupTargetFromMetadata(
-      input.metadata,
-      input.currentBranch,
-    );
-    // The cloud-host parser cannot derive an owner for Enterprise remotes. A
-    // branch-bound hint may supplement that owner only when its head still
-    // agrees with the explicit tracking configuration.
-    if (
-      trackedHeadRef &&
-      input.branchRemoteUrl &&
-      !parseGitHubRepoFromRemote(input.branchRemoteUrl) &&
-      !configuredTarget.headRepositoryOwner &&
-      metadataTarget?.headRef === trackedHeadRef &&
-      metadataTarget.headRepositoryOwner
-    ) {
-      return {
-        headRef: trackedHeadRef,
-        headRepositoryOwner: metadataTarget.headRepositoryOwner,
-      };
-    }
-    return configuredTarget;
   }
 
   return (

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -832,6 +832,22 @@ async function requireGitRepo(cwd: string): Promise<void> {
   }
 }
 
+async function requireGitWorktreeRoot(cwd: string): Promise<string> {
+  try {
+    const { stdout } = await runGitCommand(["rev-parse", "--show-toplevel"], {
+      cwd,
+      envOverlay: READ_ONLY_GIT_ENV,
+    });
+    const worktreeRoot = parseGitRevParsePath(stdout);
+    if (!worktreeRoot) {
+      throw new Error("Git returned no worktree root");
+    }
+    return worktreeRoot;
+  } catch {
+    throw new NotGitRepoError(cwd);
+  }
+}
+
 export async function getCurrentBranch(cwd: string): Promise<string | null> {
   try {
     const { stdout } = await runGitCommand(["rev-parse", "--abbrev-ref", "HEAD"], {
@@ -1042,7 +1058,7 @@ export async function renameCurrentBranch(
   cwd: string,
   newName: string,
 ): Promise<{ previousBranch: string | null; currentBranch: string | null }> {
-  await requireGitRepo(cwd);
+  const worktreeRoot = await requireGitWorktreeRoot(cwd);
 
   const previousBranch = await getCurrentBranch(cwd);
   if (!previousBranch || previousBranch === "HEAD") {
@@ -1056,7 +1072,7 @@ export async function renameCurrentBranch(
 
   const currentBranch = await getCurrentBranch(cwd);
   if (currentBranch) {
-    rebindPaseoWorktreeChangeRequestHint(cwd, previousBranch, currentBranch);
+    rebindPaseoWorktreeChangeRequestHint(worktreeRoot, previousBranch, currentBranch);
   }
   return { previousBranch, currentBranch };
 }
@@ -1608,7 +1624,7 @@ function buildPullRequestLookupTargetFromBranchConfig(
   input: PullRequestLookupTargetBranchConfig,
 ): PullRequestStatusLookupTarget {
   const trackedHeadRef = parseBranchMergeHeadRef(input.branchMergeRef);
-  if (!input.branchRemoteName || !trackedHeadRef || trackedHeadRef === input.currentBranch) {
+  if (!input.branchRemoteName || !trackedHeadRef) {
     return { headRef: input.currentBranch };
   }
 

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1705,7 +1705,7 @@ function buildInitialPullRequestLookupTarget(input: {
     parseBranchMergeHeadRef(input.branchMergeRef),
   );
   if (hasConfiguredBranchTarget) {
-    return buildPullRequestLookupTargetFromBranchConfig({
+    const configuredTarget = buildPullRequestLookupTargetFromBranchConfig({
       currentBranch: input.currentBranch,
       branchRemoteName: input.branchRemoteName,
       branchMergeRef: input.branchMergeRef,
@@ -1713,6 +1713,27 @@ function buildInitialPullRequestLookupTarget(input: {
       originRemoteUrl: input.originRemoteUrl,
       resolvedBaseRef: input.resolvedBaseRef,
     });
+    const trackedHeadRef = parseBranchMergeHeadRef(input.branchMergeRef);
+    const metadataTarget = buildPullRequestLookupTargetFromMetadata(
+      input.metadata,
+      input.currentBranch,
+    );
+    // The cloud-host parser cannot derive an owner for Enterprise remotes. A
+    // branch-bound hint may supplement that owner only when its head still
+    // agrees with the explicit tracking configuration.
+    if (
+      trackedHeadRef &&
+      !parseGitHubRepoFromRemote(input.branchRemoteUrl ?? "") &&
+      !configuredTarget.headRepositoryOwner &&
+      metadataTarget?.headRef === trackedHeadRef &&
+      metadataTarget.headRepositoryOwner
+    ) {
+      return {
+        headRef: trackedHeadRef,
+        headRepositoryOwner: metadataTarget.headRepositoryOwner,
+      };
+    }
+    return configuredTarget;
   }
 
   return (

--- a/packages/server/src/utils/worktree-metadata.ts
+++ b/packages/server/src/utils/worktree-metadata.ts
@@ -6,6 +6,7 @@ const ChangeRequestLookupTargetSchema = z.object({
   headRef: z.string().min(1),
   headRepositoryOwner: z.string().min(1).optional(),
   changeRequestNumber: z.number().int().positive().optional(),
+  localBranchName: z.string().min(1).optional(),
 });
 
 const PaseoWorktreeMetadataV1Schema = z.object({

--- a/packages/server/src/utils/worktree-metadata.ts
+++ b/packages/server/src/utils/worktree-metadata.ts
@@ -67,13 +67,15 @@ export function getPaseoWorktreeChangeRequestHintForBranch(
 
   // COMPAT(change-request-local-branch): metadata before v0.2.5 omitted the
   // local binding; remove after 2027-07-31.
-  const canonicalBranches = new Set([target.headRef]);
+  const canonicalBranches = new Set<string>();
   if (target.headRepositoryOwner) {
     canonicalBranches.add(`${target.headRepositoryOwner}/${target.headRef}`);
     const normalizedOwner = normalizeLegacyGitHubOwnerForBranch(target.headRepositoryOwner);
     if (normalizedOwner) {
       canonicalBranches.add(`${normalizedOwner}/${target.headRef}`);
     }
+  } else {
+    canonicalBranches.add(target.headRef);
   }
   return canonicalBranches.has(currentBranch) ? target : null;
 }

--- a/packages/server/src/utils/worktree-metadata.ts
+++ b/packages/server/src/utils/worktree-metadata.ts
@@ -45,9 +45,64 @@ const PaseoWorktreeMetadataSchema = z.union([
 ]);
 
 export type PaseoWorktreeMetadata = z.infer<typeof PaseoWorktreeMetadataSchema>;
-export type PaseoWorktreeChangeRequestLookupTarget = z.infer<
-  typeof ChangeRequestLookupTargetSchema
->;
+export type PaseoWorktreeChangeRequestHint = z.infer<typeof ChangeRequestLookupTargetSchema>;
+
+export function createPaseoWorktreeChangeRequestHint(
+  input: PaseoWorktreeChangeRequestHint,
+): PaseoWorktreeChangeRequestHint {
+  return ChangeRequestLookupTargetSchema.parse(input);
+}
+
+export function getPaseoWorktreeChangeRequestHintForBranch(
+  metadata: PaseoWorktreeMetadata | null,
+  currentBranch: string,
+): PaseoWorktreeChangeRequestHint | null {
+  const target = metadata?.changeRequestLookupTarget;
+  if (!target) {
+    return null;
+  }
+  if (target.localBranchName) {
+    return target.localBranchName === currentBranch ? target : null;
+  }
+
+  // COMPAT(change-request-local-branch): metadata before v0.2.5 omitted the
+  // local binding; remove after 2027-07-31.
+  const canonicalBranches = new Set([target.headRef]);
+  if (target.headRepositoryOwner) {
+    canonicalBranches.add(`${target.headRepositoryOwner}/${target.headRef}`);
+    const normalizedOwner = normalizeLegacyGitHubOwnerForBranch(target.headRepositoryOwner);
+    if (normalizedOwner) {
+      canonicalBranches.add(`${normalizedOwner}/${target.headRef}`);
+    }
+  }
+  return canonicalBranches.has(currentBranch) ? target : null;
+}
+
+function normalizeLegacyGitHubOwnerForBranch(owner: string): string | null {
+  const normalized = owner.trim().toLowerCase();
+  return /^[a-z0-9-]+$/.test(normalized) ? normalized : null;
+}
+
+export function rebindPaseoWorktreeChangeRequestHint(
+  worktreeRoot: string,
+  previousBranch: string,
+  currentBranch: string,
+): boolean {
+  const metadata = readPaseoWorktreeMetadata(worktreeRoot);
+  const target = getPaseoWorktreeChangeRequestHintForBranch(metadata, previousBranch);
+  if (!metadata || !target) {
+    return false;
+  }
+
+  writePaseoWorktreeMetadataFile(worktreeRoot, {
+    ...metadata,
+    changeRequestLookupTarget: {
+      ...target,
+      localBranchName: currentBranch,
+    },
+  });
+  return true;
+}
 
 function getGitDirForWorktreeRoot(worktreeRoot: string): string {
   const gitPath = join(worktreeRoot, ".git");
@@ -91,7 +146,7 @@ export function writePaseoWorktreeMetadata(
   worktreeRoot: string,
   options: {
     baseRefName: string;
-    changeRequestLookupTarget?: PaseoWorktreeChangeRequestLookupTarget;
+    changeRequestLookupTarget?: PaseoWorktreeChangeRequestHint;
   },
 ): void {
   const baseRefName = normalizeBaseRefName(options.baseRefName);

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1414,6 +1414,7 @@ async function resolveWorktreeSourcePlan({
             ? { headRepositoryOwner: source.headRepositoryOwner }
             : {}),
           changeRequestNumber,
+          localBranchName,
         },
         addArguments: [localBranchName],
         ...remotePlan,

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -22,8 +22,9 @@ export {
 } from "@getpaseo/protocol/paseo-config-schema";
 import { PaseoConfigSchema, type PaseoConfig } from "@getpaseo/protocol/paseo-config-schema";
 import {
+  createPaseoWorktreeChangeRequestHint,
   normalizeBaseRefName,
-  type PaseoWorktreeChangeRequestLookupTarget,
+  type PaseoWorktreeChangeRequestHint,
   readPaseoWorktreeMetadata,
   readPaseoWorktreeRuntimePort,
   writePaseoWorktreeMetadata,
@@ -1300,7 +1301,7 @@ interface ResolveWorktreeSourcePlanOptions {
 interface WorktreeSourcePlan {
   branchName: string;
   metadataBaseRefName: string;
-  changeRequestLookupTarget?: PaseoWorktreeChangeRequestLookupTarget;
+  changeRequestLookupTarget?: PaseoWorktreeChangeRequestHint;
   addArguments: string[];
   pushRemote?: {
     name: string;
@@ -1408,14 +1409,14 @@ async function resolveWorktreeSourcePlan({
       return {
         branchName: localBranchName,
         metadataBaseRefName: normalizedBaseRefName,
-        changeRequestLookupTarget: {
+        changeRequestLookupTarget: createPaseoWorktreeChangeRequestHint({
           headRef: source.headRef,
           ...(source.headRepositoryOwner
             ? { headRepositoryOwner: source.headRepositoryOwner }
             : {}),
           changeRequestNumber,
           localBranchName,
-        },
+        }),
         addArguments: [localBranchName],
         ...remotePlan,
       };


### PR DESCRIPTION
### Linked issue

None — reproduced from a workspace whose persisted pull-request metadata no longer matched its checked-out branch.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

Treats persisted change-request metadata as a branch-bound lookup hint rather than current authority. Explicit tracking configuration already collected for the checked-out branch wins, so switching, renaming, or repointing a workspace reconciles to the current pull request.

New worktrees persist the final deduplicated local branch name. Managed renames rebind that hint, branch switches reject it, and ambiguous legacy suffixes are not inferred. Current remote identity owns fork selection for GitHub and GitHub Enterprise, including same-name branches and differently cased aliases.

No fetch, polling, forge fallback, or additional Git command path was added.

### How did you verify it

The real-Git regressions failed first by retaining the old pull-request target after a branch switch, losing fork identity, accepting stale Enterprise ownership after a remote repoint, failing rename from a nested workspace directory, and treating differently cased aliases as different repositories, and misidentifying an upstream base as the PR head.

After the fix:

- npx vitest run packages/server/src/utils/checkout-git.test.ts --bail=1 — 138 passed
- npx vitest run packages/server/src/server/worktree-core.posix.test.ts --bail=1 — 26 passed
- npx vitest run packages/server/src/server/session/git-mutation/git-mutation-service.test.ts --bail=1 — 13 passed
- npm run typecheck — passed
- npm run lint -- changed files — 0 warnings, 0 errors
- npm run format — passed

The tests use real repositories and linked worktrees. They verify branch switching, branch rename, same-branch tracking changes, GitHub Enterprise fork ownership, case-insensitive repository aliases, fork-origin upstream-base tracking, legacy metadata rejection, and that reconciliation does not fetch.

Platforms tested: Linux locally. Linux and Windows are covered by the PR CI matrix. No UI code changed.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

