### PR TITLE
Show New Workspace isolation controls immediately

### DIFF
--- a/packages/app/e2e/helpers/new-workspace.ts
+++ b/packages/app/e2e/helpers/new-workspace.ts
@@ -190,6 +190,29 @@ export async function openGlobalNewWorkspaceComposer(page: Page): Promise<void> 
   });
 }
 
+export async function openMissingProjectNewWorkspaceComposer(
+  page: Page,
+  input: { serverId: string; projectId: string; sourceDirectory: string },
+): Promise<void> {
+  const query = new URLSearchParams({
+    serverId: input.serverId,
+    projectId: input.projectId,
+    dir: input.sourceDirectory,
+    name: "Missing project",
+  });
+  await page.goto(`/new?${query.toString()}`);
+  await expect(page).toHaveURL(/\/new\?.*projectId=/u, { timeout: 30_000 });
+}
+
+export async function expectNewWorkspaceControlsEnabled(page: Page): Promise<void> {
+  await expect(page.getByRole("button", { name: "Workspace project" })).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(page.getByRole("textbox", { name: "Message agent..." })).toBeEditable({
+    timeout: 30_000,
+  });
+}
+
 export async function openNewWorkspaceProjectPickerWithShortcut(page: Page): Promise<void> {
   await page.keyboard.press("Control+P");
 
@@ -286,9 +309,8 @@ export async function selectWorkspaceIsolation(
   await expect(trigger).toBeVisible({ timeout: 30_000 });
   await trigger.click();
 
-  // "New worktree" is only listed once the checkout status query confirms the
-  // selected project is a git repo, so wait for the option to appear before
-  // clicking it.
+  // Isolation options are derived from project capability. Wait for the option
+  // so this helper also covers route-to-project reconciliation.
   const option = page.getByTestId(`workspace-create-isolation-${isolation}`);
   await expect(option).toBeVisible({ timeout: 30_000 });
   await option.click();

--- a/packages/app/e2e/new-workspace-entry.spec.ts
+++ b/packages/app/e2e/new-workspace-entry.spec.ts
@@ -2,8 +2,10 @@ import { expect, test } from "./fixtures";
 import { gotoAppShell } from "./helpers/app";
 import {
   connectNewWorkspaceDaemonClient,
+  expectNewWorkspaceControlsEnabled,
   expectNewWorkspaceProjectSelected,
   openGlobalNewWorkspaceComposer,
+  openMissingProjectNewWorkspaceComposer,
   openNewWorkspaceComposer,
   openNewWorkspaceProjectPickerWithShortcut,
 } from "./helpers/new-workspace";
@@ -13,7 +15,7 @@ import { seedSavedSettingsHosts } from "./helpers/settings";
 import { getServerId } from "./helpers/server-id";
 import { projectEquivalenceViewKey } from "./helpers/project-view-key";
 import { clickArchiveWorkspaceMenuItem, expectWorkspaceAbsentFromSidebar } from "./helpers/sidebar";
-import { waitForSidebarHydration } from "./helpers/workspace-ui";
+import { waitForNoProjectsInSidebar, waitForSidebarHydration } from "./helpers/workspace-ui";
 
 // Model B entry points into the New Workspace screen. The surviving entries are
 // the global button (universal) and each project's per-row New workspace icon
@@ -106,6 +108,18 @@ test.describe("New workspace entry points", () => {
     } finally {
       await seeded.cleanup();
     }
+  });
+
+  test("a stale project route keeps the New Workspace controls enabled", async ({ page }) => {
+    await gotoAppShell(page);
+    await waitForNoProjectsInSidebar(page);
+    await openMissingProjectNewWorkspaceComposer(page, {
+      serverId: getServerId(),
+      projectId: "missing-project",
+      sourceDirectory: "/tmp/missing-project",
+    });
+
+    await expectNewWorkspaceControlsEnabled(page);
   });
 
   test("Ctrl+P opens the project picker with search focused", async ({ page }) => {

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -45,7 +45,7 @@ function makeProject(workspaces: SidebarWorkspacePlacement[]): SidebarProjectEnt
         serverId: "srv",
         projectId: "project",
         iconWorkingDir: "/repo",
-        canCreateWorktree: true,
+        worktreeSupport: "supported" as const,
       },
     ],
     workspaces,

--- a/packages/app/src/git/checkout-status-cache.test.ts
+++ b/packages/app/src/git/checkout-status-cache.test.ts
@@ -136,6 +136,25 @@ describe("ensureCheckoutStatus", () => {
     expect(second).toEqual(fetched);
     expect(client.getCheckoutStatus).toHaveBeenCalledExactlyOnceWith(cwd);
   });
+
+  it("awaits a refetch when the canonical cached status was invalidated", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(
+      checkoutStatusQueryKey(serverId, cwd),
+      checkoutStatus({ currentBranch: "feature/stale" }),
+    );
+    await queryClient.invalidateQueries({
+      queryKey: checkoutStatusQueryKey(serverId, cwd),
+      refetchType: "none",
+    });
+    const fetched = checkoutStatus({ currentBranch: "feature/current" });
+    const client = { getCheckoutStatus: vi.fn(async () => fetched) };
+
+    const result = await ensureCheckoutStatus({ queryClient, client, serverId, cwd });
+
+    expect(result.currentBranch).toBe("feature/current");
+    expect(client.getCheckoutStatus).toHaveBeenCalledExactlyOnceWith(cwd);
+  });
 });
 
 describe("applyCheckoutStatusUpdateFromEvent", () => {

--- a/packages/app/src/git/checkout-status-cache.test.ts
+++ b/packages/app/src/git/checkout-status-cache.test.ts
@@ -14,6 +14,7 @@ import {
 import { resetReviewDraftStore, useReviewDraftStore } from "@/review/store";
 import {
   applyCheckoutStatusUpdateFromEvent,
+  ensureCheckoutStatus,
   type CheckoutPrStatusPayload,
   type CheckoutStatusPayload,
   fetchCheckoutStatus,
@@ -119,6 +120,21 @@ describe("fetchCheckoutStatus", () => {
     await fetchCheckoutStatus({ client, serverId, cwd });
 
     expect(useReviewDraftStore.getState().diffModeOverrides["review:scope"]).toBeUndefined();
+  });
+});
+
+describe("ensureCheckoutStatus", () => {
+  it("awaits the canonical checkout-status query and reuses its cached result", async () => {
+    const queryClient = createQueryClient();
+    const fetched = checkoutStatus({ currentBranch: "feature/current" });
+    const client = { getCheckoutStatus: vi.fn(async () => fetched) };
+
+    const first = await ensureCheckoutStatus({ queryClient, client, serverId, cwd });
+    const second = await ensureCheckoutStatus({ queryClient, client, serverId, cwd });
+
+    expect(first).toEqual(fetched);
+    expect(second).toEqual(fetched);
+    expect(client.getCheckoutStatus).toHaveBeenCalledExactlyOnceWith(cwd);
   });
 });
 

--- a/packages/app/src/git/checkout-status-cache.ts
+++ b/packages/app/src/git/checkout-status-cache.ts
@@ -46,7 +46,7 @@ export async function ensureCheckoutStatus({
   serverId: string;
   cwd: string;
 }): Promise<CheckoutStatusPayload> {
-  return await queryClient.ensureQueryData({
+  return await queryClient.fetchQuery({
     queryKey: checkoutStatusQueryKey(serverId, cwd),
     queryFn: () => fetchCheckoutStatus({ client, serverId, cwd }),
     staleTime: Infinity,

--- a/packages/app/src/git/checkout-status-cache.ts
+++ b/packages/app/src/git/checkout-status-cache.ts
@@ -35,6 +35,24 @@ export async function fetchCheckoutStatus({
   return payload;
 }
 
+export async function ensureCheckoutStatus({
+  queryClient,
+  client,
+  serverId,
+  cwd,
+}: {
+  queryClient: QueryClient;
+  client: CheckoutStatusClient;
+  serverId: string;
+  cwd: string;
+}): Promise<CheckoutStatusPayload> {
+  return await queryClient.ensureQueryData({
+    queryKey: checkoutStatusQueryKey(serverId, cwd),
+    queryFn: () => fetchCheckoutStatus({ client, serverId, cwd }),
+    staleTime: Infinity,
+  });
+}
+
 export function applyCheckoutStatusUpdateFromEvent({
   queryClient,
   serverId,

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -93,7 +93,7 @@ function project(input: {
         {
           serverId: "srv",
           iconWorkingDir: input.iconWorkingDir ?? input.projectKey,
-          canCreateWorktree: true,
+          worktreeSupport: "supported" as const,
         },
       ],
       (host) => Object.assign({}, host, { projectId: host.projectId ?? input.projectKey }),
@@ -251,7 +251,7 @@ describe("buildSidebarProjectsFromStructure", () => {
             {
               serverId: "relay:paseo-host",
               iconWorkingDir: "/repo/project-1",
-              canCreateWorktree: true,
+              worktreeSupport: "supported" as const,
             },
           ],
           workspaceKeys: ["relay:paseo-host:ws-main"],
@@ -276,8 +276,16 @@ describe("shared sidebar workspace model", () => {
           projectName: "getpaseo/paseo",
           iconWorkingDir: "/repo/getpaseo/paseo",
           hosts: [
-            { serverId: "host-a", iconWorkingDir: "/repo/getpaseo/paseo", canCreateWorktree: true },
-            { serverId: "host-b", iconWorkingDir: "/repo/getpaseo/paseo", canCreateWorktree: true },
+            {
+              serverId: "host-a",
+              iconWorkingDir: "/repo/getpaseo/paseo",
+              worktreeSupport: "supported" as const,
+            },
+            {
+              serverId: "host-b",
+              iconWorkingDir: "/repo/getpaseo/paseo",
+              worktreeSupport: "supported" as const,
+            },
           ],
           workspaceKeys: ["host-a:main", "host-b:feature"],
         }),
@@ -334,13 +342,13 @@ describe("shared sidebar workspace model", () => {
             serverId: "host-a",
             projectId: "getpaseo/paseo",
             iconWorkingDir: "/repo/getpaseo/paseo",
-            canCreateWorktree: true,
+            worktreeSupport: "supported" as const,
           },
           {
             serverId: "host-b",
             projectId: "getpaseo/paseo",
             iconWorkingDir: "/repo/getpaseo/paseo",
-            canCreateWorktree: true,
+            worktreeSupport: "supported" as const,
           },
         ],
         workspaces: [
@@ -470,14 +478,22 @@ describe("shouldShowSidebarHostLabels", () => {
         project({
           projectKey: "project-a",
           hosts: [
-            { serverId: "host-a", iconWorkingDir: "/repo/project-a", canCreateWorktree: true },
+            {
+              serverId: "host-a",
+              iconWorkingDir: "/repo/project-a",
+              worktreeSupport: "supported" as const,
+            },
           ],
           workspaceKeys: ["host-a:ws-1"],
         }),
         project({
           projectKey: "project-b",
           hosts: [
-            { serverId: "host-b", iconWorkingDir: "/repo/project-b", canCreateWorktree: true },
+            {
+              serverId: "host-b",
+              iconWorkingDir: "/repo/project-b",
+              worktreeSupport: "supported" as const,
+            },
           ],
           workspaceKeys: ["host-b:ws-2"],
         }),
@@ -493,8 +509,16 @@ describe("shouldShowSidebarHostLabels", () => {
         project({
           projectKey: "getpaseo/paseo",
           hosts: [
-            { serverId: "host-a", iconWorkingDir: "/repo/paseo", canCreateWorktree: true },
-            { serverId: "host-b", iconWorkingDir: "/repo/paseo", canCreateWorktree: true },
+            {
+              serverId: "host-a",
+              iconWorkingDir: "/repo/paseo",
+              worktreeSupport: "supported" as const,
+            },
+            {
+              serverId: "host-b",
+              iconWorkingDir: "/repo/paseo",
+              worktreeSupport: "supported" as const,
+            },
           ],
           workspaceKeys: ["host-a:main", "host-b:feature"],
         }),

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -23,7 +23,7 @@ export interface SidebarWorkspacePlacement {
   projectName: string;
   projectRootPath?: string;
   workspaceDirectory?: string;
-  projectKind: WorkspaceDescriptor["projectKind"];
+  projectKind: WorkspaceStructureProject["projectKind"];
   workspaceKind: WorkspaceDescriptor["workspaceKind"];
   name: string;
 }
@@ -52,7 +52,7 @@ export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
 export interface SidebarProjectEntry {
   viewKey: string;
   projectName: string;
-  projectKind: WorkspaceDescriptor["projectKind"];
+  projectKind: WorkspaceStructureProject["projectKind"];
   iconWorkingDir: string;
   hosts: WorkspaceStructureHostPlacement[];
   workspaces: SidebarWorkspacePlacement[];

--- a/packages/app/src/projects/host-project-model.ts
+++ b/packages/app/src/projects/host-project-model.ts
@@ -124,6 +124,20 @@ export function resolveHydratedHostProject(input: {
   );
 }
 
+export function getHostProjectWorktreeCapability(input: {
+  project: HostProjectListItem;
+  projects: readonly HostProjectListItem[];
+  serverId: string;
+}): "pending" | "available" | "unavailable" {
+  const hydratedProject = resolveHydratedHostProject(input);
+  if (!hydratedProject) {
+    return "pending";
+  }
+  return canCreateWorktreeForHostProject({ project: hydratedProject, serverId: input.serverId })
+    ? "available"
+    : "unavailable";
+}
+
 export function getHostProjectSourceDirectory(
   project: HostProjectListItem,
   serverId: string,

--- a/packages/app/src/projects/host-project-model.ts
+++ b/packages/app/src/projects/host-project-model.ts
@@ -108,6 +108,22 @@ export function canCreateWorktreeForHostProject(input: {
   return getHostProjectPlacement(input.project, input.serverId)?.canCreateWorktree === true;
 }
 
+export function resolveHydratedHostProject(input: {
+  project: HostProjectListItem;
+  projects: readonly HostProjectListItem[];
+  serverId: string;
+}): HostProjectListItem | null {
+  const projectId = getHostProjectPlacement(input.project, input.serverId)?.projectId;
+  if (!projectId) {
+    return null;
+  }
+  return (
+    input.projects.find(
+      (project) => getHostProjectPlacement(project, input.serverId)?.projectId === projectId,
+    ) ?? null
+  );
+}
+
 export function getHostProjectSourceDirectory(
   project: HostProjectListItem,
   serverId: string,

--- a/packages/app/src/projects/host-project-model.ts
+++ b/packages/app/src/projects/host-project-model.ts
@@ -101,6 +101,13 @@ function getHostProjectPlacement(
   return null;
 }
 
+export function canCreateWorktreeForHostProject(input: {
+  project: HostProjectListItem;
+  serverId: string;
+}): boolean {
+  return getHostProjectPlacement(input.project, input.serverId)?.canCreateWorktree === true;
+}
+
 export function getHostProjectSourceDirectory(
   project: HostProjectListItem,
   serverId: string,

--- a/packages/app/src/projects/host-project-model.ts
+++ b/packages/app/src/projects/host-project-model.ts
@@ -35,14 +35,14 @@ export function hostProjectFromRoute(route: HostProjectRouteContext): HostProjec
     viewKey: createProjectViewKey({ kind: "placement", serverId: route.serverId, projectId }),
     projectKey: null,
     projectName: trimOptional(route.displayName) || projectId,
-    projectKind: "git",
+    projectKind: "unknown",
     iconWorkingDir,
     hosts: [
       {
         serverId: route.serverId,
         projectId,
         iconWorkingDir,
-        canCreateWorktree: true,
+        worktreeSupport: "unknown",
       },
     ],
     workspaceKeys: [],
@@ -80,7 +80,7 @@ export function hostProjectFromWorkspace(input: {
         serverId: input.serverId,
         projectId: input.workspace.projectId,
         iconWorkingDir,
-        canCreateWorktree: canCreate,
+        worktreeSupport: canCreate ? "supported" : "unsupported",
       },
     ],
     workspaceKeys: [`${input.serverId}:${input.workspace.id}`],
@@ -88,7 +88,7 @@ export function hostProjectFromWorkspace(input: {
 }
 
 function projectCanCreateWorktree(project: HostProjectListItem): boolean {
-  return project.hosts.some((h) => h.canCreateWorktree);
+  return project.hosts.some((host) => host.worktreeSupport !== "unsupported");
 }
 
 function getHostProjectPlacement(
@@ -101,41 +101,11 @@ function getHostProjectPlacement(
   return null;
 }
 
-export function canCreateWorktreeForHostProject(input: {
+export function getWorktreeSupportForHostProject(input: {
   project: HostProjectListItem;
   serverId: string;
-}): boolean {
-  return getHostProjectPlacement(input.project, input.serverId)?.canCreateWorktree === true;
-}
-
-export function resolveHydratedHostProject(input: {
-  project: HostProjectListItem;
-  projects: readonly HostProjectListItem[];
-  serverId: string;
-}): HostProjectListItem | null {
-  const projectId = getHostProjectPlacement(input.project, input.serverId)?.projectId;
-  if (!projectId) {
-    return null;
-  }
-  return (
-    input.projects.find(
-      (project) => getHostProjectPlacement(project, input.serverId)?.projectId === projectId,
-    ) ?? null
-  );
-}
-
-export function getHostProjectWorktreeCapability(input: {
-  project: HostProjectListItem;
-  projects: readonly HostProjectListItem[];
-  serverId: string;
-}): "pending" | "available" | "unavailable" {
-  const hydratedProject = resolveHydratedHostProject(input);
-  if (!hydratedProject) {
-    return "pending";
-  }
-  return canCreateWorktreeForHostProject({ project: hydratedProject, serverId: input.serverId })
-    ? "available"
-    : "unavailable";
+}): WorkspaceStructureHostPlacement["worktreeSupport"] {
+  return getHostProjectPlacement(input.project, input.serverId)?.worktreeSupport ?? "unknown";
 }
 
 export function getHostProjectSourceDirectory(
@@ -158,7 +128,7 @@ export function canCreateWorkspaceForHostProject(input: {
   if (!host) {
     return false;
   }
-  return input.allowAllProjects || host.canCreateWorktree;
+  return input.allowAllProjects || host.worktreeSupport !== "unsupported";
 }
 
 export function filterWorkspaceProjectsForHost(input: {

--- a/packages/app/src/projects/host-projects.test.ts
+++ b/packages/app/src/projects/host-projects.test.ts
@@ -5,6 +5,7 @@ import {
   canCreateWorkspaceForHostProject,
   getHostProjectId,
   getHostProjectSourceDirectory,
+  getHostProjectWorktreeCapability,
   hostProjectFromRoute,
   resolveHydratedHostProject,
 } from "./host-project-model";
@@ -98,6 +99,20 @@ describe("host project lookups", () => {
         serverId: "host-a",
       }),
     ).toBe(hydratedProject);
+    expect(
+      getHostProjectWorktreeCapability({
+        project: routeProject!,
+        projects: [],
+        serverId: "host-a",
+      }),
+    ).toBe("pending");
+    expect(
+      getHostProjectWorktreeCapability({
+        project: routeProject!,
+        projects: [hydratedProject],
+        serverId: "host-a",
+      }),
+    ).toBe("unavailable");
   });
 
   test("builds an unhydrated route project around the routed project id", () => {

--- a/packages/app/src/projects/host-projects.test.ts
+++ b/packages/app/src/projects/host-projects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import type { HostProjectListItem } from "./host-project-model";
 import {
+  canCreateWorktreeForHostProject,
   canCreateWorkspaceForHostProject,
   getHostProjectId,
   getHostProjectSourceDirectory,
@@ -47,6 +48,24 @@ describe("host project lookups", () => {
         allowAllProjects: false,
       }),
     ).toBe(true);
+  });
+
+  test("checks worktree capability against the selected host placement", () => {
+    const groupedProject = project();
+    groupedProject.hosts[1] = {
+      ...groupedProject.hosts[1]!,
+      canCreateWorktree: false,
+    };
+
+    expect(canCreateWorktreeForHostProject({ project: groupedProject, serverId: "host-a" })).toBe(
+      true,
+    );
+    expect(canCreateWorktreeForHostProject({ project: groupedProject, serverId: "host-b" })).toBe(
+      false,
+    );
+    expect(canCreateWorktreeForHostProject({ project: groupedProject, serverId: "missing" })).toBe(
+      false,
+    );
   });
 
   test("builds an unhydrated route project around the routed project id", () => {

--- a/packages/app/src/projects/host-projects.test.ts
+++ b/packages/app/src/projects/host-projects.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, test } from "vitest";
 import type { HostProjectListItem } from "./host-project-model";
 import {
-  canCreateWorktreeForHostProject,
   canCreateWorkspaceForHostProject,
   getHostProjectId,
   getHostProjectSourceDirectory,
-  getHostProjectWorktreeCapability,
+  getWorktreeSupportForHostProject,
   hostProjectFromRoute,
-  resolveHydratedHostProject,
 } from "./host-project-model";
 
 function project(): HostProjectListItem {
@@ -22,13 +20,13 @@ function project(): HostProjectListItem {
         serverId: "host-a",
         projectId: "prj_a",
         iconWorkingDir: "/repo/a",
-        canCreateWorktree: true,
+        worktreeSupport: "supported" as const,
       },
       {
         serverId: "host-b",
         projectId: "prj_b",
         iconWorkingDir: "/repo/b",
-        canCreateWorktree: true,
+        worktreeSupport: "supported" as const,
       },
     ],
     workspaceKeys: [],
@@ -56,21 +54,21 @@ describe("host project lookups", () => {
     const groupedProject = project();
     groupedProject.hosts[1] = {
       ...groupedProject.hosts[1]!,
-      canCreateWorktree: false,
+      worktreeSupport: "unsupported" as const,
     };
 
-    expect(canCreateWorktreeForHostProject({ project: groupedProject, serverId: "host-a" })).toBe(
-      true,
+    expect(getWorktreeSupportForHostProject({ project: groupedProject, serverId: "host-a" })).toBe(
+      "supported",
     );
-    expect(canCreateWorktreeForHostProject({ project: groupedProject, serverId: "host-b" })).toBe(
-      false,
+    expect(getWorktreeSupportForHostProject({ project: groupedProject, serverId: "host-b" })).toBe(
+      "unsupported",
     );
-    expect(canCreateWorktreeForHostProject({ project: groupedProject, serverId: "missing" })).toBe(
-      false,
+    expect(getWorktreeSupportForHostProject({ project: groupedProject, serverId: "missing" })).toBe(
+      "unknown",
     );
   });
 
-  test("does not treat an unhydrated route placeholder as authoritative", () => {
+  test("marks route placeholder worktree support as unknown", () => {
     const routeProject = hostProjectFromRoute({
       serverId: "host-a",
       projectId: "prj_a",
@@ -78,41 +76,10 @@ describe("host project lookups", () => {
       sourceDirectory: "/repo/a",
     });
     expect(routeProject).not.toBeNull();
-
-    expect(
-      resolveHydratedHostProject({
-        project: routeProject!,
-        projects: [],
-        serverId: "host-a",
-      }),
-    ).toBeNull();
-
-    const hydratedProject = project();
-    hydratedProject.hosts[0] = {
-      ...hydratedProject.hosts[0]!,
-      canCreateWorktree: false,
-    };
-    expect(
-      resolveHydratedHostProject({
-        project: routeProject!,
-        projects: [hydratedProject],
-        serverId: "host-a",
-      }),
-    ).toBe(hydratedProject);
-    expect(
-      getHostProjectWorktreeCapability({
-        project: routeProject!,
-        projects: [],
-        serverId: "host-a",
-      }),
-    ).toBe("pending");
-    expect(
-      getHostProjectWorktreeCapability({
-        project: routeProject!,
-        projects: [hydratedProject],
-        serverId: "host-a",
-      }),
-    ).toBe("unavailable");
+    expect(routeProject!.projectKind).toBe("unknown");
+    expect(getWorktreeSupportForHostProject({ project: routeProject!, serverId: "host-a" })).toBe(
+      "unknown",
+    );
   });
 
   test("builds an unhydrated route project around the routed project id", () => {

--- a/packages/app/src/projects/host-projects.test.ts
+++ b/packages/app/src/projects/host-projects.test.ts
@@ -6,6 +6,7 @@ import {
   getHostProjectId,
   getHostProjectSourceDirectory,
   hostProjectFromRoute,
+  resolveHydratedHostProject,
 } from "./host-project-model";
 
 function project(): HostProjectListItem {
@@ -66,6 +67,37 @@ describe("host project lookups", () => {
     expect(canCreateWorktreeForHostProject({ project: groupedProject, serverId: "missing" })).toBe(
       false,
     );
+  });
+
+  test("does not treat an unhydrated route placeholder as authoritative", () => {
+    const routeProject = hostProjectFromRoute({
+      serverId: "host-a",
+      projectId: "prj_a",
+      displayName: "App",
+      sourceDirectory: "/repo/a",
+    });
+    expect(routeProject).not.toBeNull();
+
+    expect(
+      resolveHydratedHostProject({
+        project: routeProject!,
+        projects: [],
+        serverId: "host-a",
+      }),
+    ).toBeNull();
+
+    const hydratedProject = project();
+    hydratedProject.hosts[0] = {
+      ...hydratedProject.hosts[0]!,
+      canCreateWorktree: false,
+    };
+    expect(
+      resolveHydratedHostProject({
+        project: routeProject!,
+        projects: [hydratedProject],
+        serverId: "host-a",
+      }),
+    ).toBe(hydratedProject);
   });
 
   test("builds an unhydrated route project around the routed project id", () => {

--- a/packages/app/src/projects/host-projects.ts
+++ b/packages/app/src/projects/host-projects.ts
@@ -7,6 +7,7 @@ export {
   canCreateWorktreeForProjectKind,
   filterWorkspaceProjectsForHost,
   getHostProjectSourceDirectory,
+  getHostProjectWorktreeCapability,
   getHostProjectId,
   hostProjectFromRoute,
   hostProjectFromWorkspace,

--- a/packages/app/src/projects/host-projects.ts
+++ b/packages/app/src/projects/host-projects.ts
@@ -13,6 +13,7 @@ export {
   resolveHostProjectCandidate,
   resolveExactHostProjectCandidate,
   resolveEquivalentHostProjectCandidate,
+  resolveHydratedHostProject,
   resolveInitialWorkspaceProject,
   resolveInitialWorktreeProject,
   resolveSelectedHostProject,

--- a/packages/app/src/projects/host-projects.ts
+++ b/packages/app/src/projects/host-projects.ts
@@ -2,19 +2,17 @@ import { useWorkspaceStructure } from "@/stores/session-store-hooks";
 import { type HostProjectListItem } from "@/projects/host-project-model";
 
 export {
-  canCreateWorktreeForHostProject,
   canCreateWorkspaceForHostProject,
   canCreateWorktreeForProjectKind,
   filterWorkspaceProjectsForHost,
   getHostProjectSourceDirectory,
-  getHostProjectWorktreeCapability,
   getHostProjectId,
+  getWorktreeSupportForHostProject,
   hostProjectFromRoute,
   hostProjectFromWorkspace,
   resolveHostProjectCandidate,
   resolveExactHostProjectCandidate,
   resolveEquivalentHostProjectCandidate,
-  resolveHydratedHostProject,
   resolveInitialWorkspaceProject,
   resolveInitialWorktreeProject,
   resolveSelectedHostProject,

--- a/packages/app/src/projects/host-projects.ts
+++ b/packages/app/src/projects/host-projects.ts
@@ -2,6 +2,7 @@ import { useWorkspaceStructure } from "@/stores/session-store-hooks";
 import { type HostProjectListItem } from "@/projects/host-project-model";
 
 export {
+  canCreateWorktreeForHostProject,
   canCreateWorkspaceForHostProject,
   canCreateWorktreeForProjectKind,
   filterWorkspaceProjectsForHost,

--- a/packages/app/src/projects/workspace-structure.ts
+++ b/packages/app/src/projects/workspace-structure.ts
@@ -5,14 +5,14 @@ export interface WorkspaceStructureHostPlacement {
   serverId: string;
   projectId: string;
   iconWorkingDir: string;
-  canCreateWorktree: boolean;
+  worktreeSupport: "supported" | "unsupported" | "unknown";
 }
 
 export interface WorkspaceStructureProject {
   viewKey: string;
   projectKey: string | null;
   projectName: string;
-  projectKind: WorkspaceDescriptor["projectKind"];
+  projectKind: WorkspaceDescriptor["projectKind"] | "unknown";
   iconWorkingDir: string;
   hosts: WorkspaceStructureHostPlacement[];
   workspaceKeys: string[];
@@ -157,7 +157,7 @@ function addProjectToView(input: {
     serverId,
     projectId: project.projectId,
     iconWorkingDir: project.projectRootPath,
-    canCreateWorktree: project.projectKind === "git",
+    worktreeSupport: project.projectKind === "git" ? "supported" : "unsupported",
   };
   const draft = byProject.get(viewKey);
   if (!draft) {

--- a/packages/app/src/screens/new-workspace-initial-context.test.ts
+++ b/packages/app/src/screens/new-workspace-initial-context.test.ts
@@ -13,7 +13,14 @@ function projectFor(serverId: string, key = "project"): HostProjectListItem {
     projectName: key,
     projectKind: "git",
     iconWorkingDir: `/work/${key}`,
-    hosts: [{ serverId, projectId: key, iconWorkingDir: `/work/${key}`, canCreateWorktree: true }],
+    hosts: [
+      {
+        serverId,
+        projectId: key,
+        iconWorkingDir: `/work/${key}`,
+        worktreeSupport: "supported" as const,
+      },
+    ],
     workspaceKeys: [],
   };
 }

--- a/packages/app/src/screens/new-workspace-picker-item.test.ts
+++ b/packages/app/src/screens/new-workspace-picker-item.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { ForgeSearchItem } from "@getpaseo/protocol/messages";
-import { pickerItemToCheckoutRequest, type PickerItem } from "./new-workspace-picker-item";
+import type { CheckoutStatusPayload } from "@/git/checkout-status-cache";
+import {
+  pickerItemToCheckoutRequest,
+  resolveCheckoutRequest,
+  type PickerItem,
+} from "./new-workspace-picker-item";
 
 const prItem: ForgeSearchItem = {
   kind: "change_request",
@@ -80,5 +85,33 @@ describe("pickerItemToCheckoutRequest", () => {
         projectPath: "acme/repo",
       },
     });
+  });
+});
+
+describe("resolveCheckoutRequest", () => {
+  const checkoutStatus = {
+    currentBranch: "feature/current",
+  } as CheckoutStatusPayload;
+
+  it("branches from the loaded current branch when nothing was picked", () => {
+    expect(resolveCheckoutRequest(null, checkoutStatus)).toEqual({
+      action: "branch-off",
+      refName: "feature/current",
+    });
+  });
+
+  it("prefers an explicit picker selection", () => {
+    expect(
+      resolveCheckoutRequest({ kind: "branch", name: "feature/picked" }, checkoutStatus),
+    ).toEqual({
+      action: "branch-off",
+      refName: "feature/picked",
+    });
+  });
+
+  it("preserves the server-default intent for a detached checkout", () => {
+    expect(
+      resolveCheckoutRequest(null, { ...checkoutStatus, currentBranch: null }),
+    ).toBeUndefined();
   });
 });

--- a/packages/app/src/screens/new-workspace-picker-item.ts
+++ b/packages/app/src/screens/new-workspace-picker-item.ts
@@ -1,5 +1,6 @@
 import type { CreatePaseoWorktreeInput } from "@getpaseo/client/internal/daemon-client";
 import type { ForgeSearchItem } from "@getpaseo/protocol/messages";
+import type { CheckoutStatusPayload } from "@/git/checkout-status-cache";
 
 export type PickerItem =
   | { kind: "branch"; name: string }
@@ -42,4 +43,17 @@ export function pickerItemToCheckoutRequest(
       };
     }
   }
+}
+
+export function resolveCheckoutRequest(
+  selectedItem: PickerItem | null,
+  checkoutStatus: CheckoutStatusPayload,
+): PickerCheckoutRequest | undefined {
+  const selectedCheckoutRequest = pickerItemToCheckoutRequest(selectedItem);
+  if (selectedCheckoutRequest) return selectedCheckoutRequest;
+  if (!checkoutStatus.currentBranch) return undefined;
+  return {
+    action: "branch-off",
+    refName: checkoutStatus.currentBranch,
+  };
 }

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -67,12 +67,11 @@ import { generateMessageId } from "@/types/stream";
 import { toErrorMessage } from "@/utils/error-messages";
 import { projectIconPlaceholderLabelFromDisplayName } from "@/utils/project-display-name";
 import {
-  canCreateWorktreeForHostProject,
   getHostProjectSourceDirectory,
   getHostProjectId,
+  getHostProjectWorktreeCapability,
   hostProjectFromRoute,
   hostProjectFromWorkspace,
-  resolveHydratedHostProject,
   useHostProjects,
   type HostProjectListItem,
 } from "@/projects/host-projects";
@@ -1555,7 +1554,6 @@ export function NewWorkspaceScreen({
   }, [pickerSearchQuery]);
 
   const workspace = createdWorkspace;
-  const isPending = isNewWorkspacePending({ pendingAction, isDraftHandoffActive });
   const client = useHostRuntimeClient(selectedServerId);
   const isConnected = useHostRuntimeIsConnected(selectedServerId);
   const {
@@ -1640,15 +1638,17 @@ export function NewWorkspaceScreen({
   });
 
   const currentBranch = checkoutStatus?.currentBranch ?? null;
-  const hydratedSelectedProject = selectedProject
-    ? resolveHydratedHostProject({ project: selectedProject, projects, serverId: selectedServerId })
-    : null;
-  const projectCanCreateWorktree = hydratedSelectedProject
-    ? canCreateWorktreeForHostProject({
-        project: hydratedSelectedProject,
+  const projectWorktreeCapability = selectedProject
+    ? getHostProjectWorktreeCapability({
+        project: selectedProject,
+        projects,
         serverId: selectedServerId,
       })
-    : false;
+    : "unavailable";
+  const projectCanCreateWorktree = projectWorktreeCapability === "available";
+  const isPending =
+    isNewWorkspacePending({ pendingAction, isDraftHandoffActive }) ||
+    projectWorktreeCapability === "pending";
   const { effectiveIsolation, setIsolation, canCreateWorktree, showRefPicker } =
     useWorkspaceIsolation({
       supportsMultiplicity: supportsWorkspaceMultiplicity,

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -31,6 +31,7 @@ import { HEADER_INNER_HEIGHT, MAX_CONTENT_WIDTH, useIsCompactFormFactor } from "
 import { useToast } from "@/contexts/toast-context";
 import { useAgentInputDraft } from "@/composer/draft/input-draft";
 import { useForgeSearchQuery } from "@/git/use-forge-search-query";
+import { useCheckoutStatusQuery } from "@/git/use-status-query";
 import {
   useHostRuntimeClient,
   useHostRuntimeConnectionStatuses,
@@ -65,6 +66,7 @@ import { generateMessageId } from "@/types/stream";
 import { toErrorMessage } from "@/utils/error-messages";
 import { projectIconPlaceholderLabelFromDisplayName } from "@/utils/project-display-name";
 import {
+  canCreateWorktreeForHostProject,
   getHostProjectSourceDirectory,
   getHostProjectId,
   hostProjectFromRoute,
@@ -702,16 +704,16 @@ interface WorkspaceIsolationState {
 // never submits an impossible request.
 function useWorkspaceIsolation(input: {
   supportsMultiplicity: boolean;
-  selectedIsGit: boolean;
+  projectCanCreateWorktree: boolean;
 }): WorkspaceIsolationState {
-  const { supportsMultiplicity, selectedIsGit } = input;
+  const { supportsMultiplicity, projectCanCreateWorktree } = input;
   // The last isolation choice is remembered alongside the other New Workspace
   // form preferences (provider, model, mode). A manual in-screen pick overrides
   // the remembered default until the screen remounts.
   const { preferences, updatePreferences } = useFormPreferences();
   const [manualIsolation, setManualIsolation] = useState<"local" | "worktree" | null>(null);
   const isolation = manualIsolation ?? preferences.isolation ?? "local";
-  const canCreateWorktree = supportsMultiplicity && selectedIsGit;
+  const canCreateWorktree = supportsMultiplicity && projectCanCreateWorktree;
   const isWorktree = isolation === "worktree" && canCreateWorktree;
 
   const setIsolation = useCallback(
@@ -1646,27 +1648,19 @@ export function NewWorkspaceScreen({
   const hasSelectedSourceDirectory = selectedSourceDirectory !== null;
   const pickerQueryEnabled = pickerOpen && clientReady && hasSelectedSourceDirectory;
 
-  const checkoutStatusQuery = useQuery({
-    queryKey: ["checkout-status", selectedServerId, selectedSourceDirectory],
-    queryFn: async () => {
-      if (!selectedSourceDirectory) {
-        throw new Error("Choose a project");
-      }
-      const connectedClient = withConnectedClient();
-      return connectedClient.getCheckoutStatus(selectedSourceDirectory);
-    },
-    enabled: clientReady && hasSelectedSourceDirectory,
-    staleTime: Infinity,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
+  const { status: checkoutStatus } = useCheckoutStatusQuery({
+    serverId: selectedServerId,
+    cwd: selectedSourceDirectory ?? "",
   });
 
-  const currentBranch = checkoutStatusQuery.data?.currentBranch ?? null;
+  const currentBranch = checkoutStatus?.currentBranch ?? null;
+  const projectCanCreateWorktree = selectedProject
+    ? canCreateWorktreeForHostProject({ project: selectedProject, serverId: selectedServerId })
+    : false;
   const { effectiveIsolation, setIsolation, canCreateWorktree, showRefPicker } =
     useWorkspaceIsolation({
       supportsMultiplicity: supportsWorkspaceMultiplicity,
-      selectedIsGit: checkoutStatusQuery.data?.isGit === true,
+      projectCanCreateWorktree,
     });
 
   const branchSuggestionsQuery = useQuery({

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -8,7 +8,7 @@ import ReanimatedAnimated from "react-native-reanimated";
 import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createNameId } from "mnemonic-id";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, Folder, FolderPlus, GitBranch, GitPullRequest } from "lucide-react-native";
 import { Composer } from "@/composer";
 import { FileDropZone } from "@/components/file-drop/file-drop-zone";
@@ -32,6 +32,7 @@ import { useToast } from "@/contexts/toast-context";
 import { useAgentInputDraft } from "@/composer/draft/input-draft";
 import { useForgeSearchQuery } from "@/git/use-forge-search-query";
 import { useCheckoutStatusQuery } from "@/git/use-status-query";
+import { ensureCheckoutStatus } from "@/git/checkout-status-cache";
 import {
   useHostRuntimeClient,
   useHostRuntimeConnectionStatuses,
@@ -90,7 +91,7 @@ import {
   remapDraftCwdToWorkspace,
 } from "./new-workspace-fork-context";
 import {
-  pickerItemToCheckoutRequest,
+  resolveCheckoutRequest,
   type PickerCheckoutRequest,
   type PickerItem,
 } from "./new-workspace-picker-item";
@@ -111,19 +112,6 @@ const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.for
 const addProjectIcon = (
   <ThemedFolderPlus size={ICON_SIZE.sm} uniProps={foregroundMutedColorMapping} />
 );
-
-function resolveCheckoutRequest(
-  selectedItem: PickerItem | null,
-  currentBranch: string | null,
-): PickerCheckoutRequest | undefined {
-  const selectedCheckoutRequest = pickerItemToCheckoutRequest(selectedItem);
-  if (selectedCheckoutRequest) return selectedCheckoutRequest;
-  if (!currentBranch) return undefined;
-  return {
-    action: "branch-off",
-    refName: currentBranch,
-  };
-}
 
 function useIsNewWorkspaceDraftHandoffActive(input: {
   draftId: string | undefined;
@@ -815,8 +803,7 @@ async function createMultiplicityWorkspace(input: {
   isolation: "local" | "worktree";
   project: HostProjectListItem;
   sourceDirectory: string;
-  selectedItem: PickerItem | null;
-  currentBranch: string | null;
+  checkoutRequest: PickerCheckoutRequest | undefined;
   withInitialAgent: boolean;
   prompt: string;
   attachments: AgentAttachment[];
@@ -830,9 +817,6 @@ async function createMultiplicityWorkspace(input: {
   const projectId = getHostProjectId(input.project, input.serverId);
   if (!projectId) throw new Error("Project is not available on the selected host");
   const isWorktree = input.isolation === "worktree";
-  const checkoutRequest = isWorktree
-    ? resolveCheckoutRequest(input.selectedItem, input.currentBranch)
-    : undefined;
   const firstAgentContext = buildFirstAgentContext({
     prompt: input.prompt,
     attachments: input.attachments,
@@ -844,7 +828,7 @@ async function createMultiplicityWorkspace(input: {
           cwd: input.sourceDirectory,
           projectId,
           worktreeSlug: createNameId(),
-          ...checkoutRequest,
+          ...input.checkoutRequest,
         }
       : {
           kind: "directory",
@@ -1521,6 +1505,7 @@ export function NewWorkspaceScreen({
   displayName: displayNameProp,
   draftId,
 }: NewWorkspaceScreenProps) {
+  const queryClient = useQueryClient();
   const { theme } = useUnistyles();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -1886,6 +1871,7 @@ export function NewWorkspaceScreen({
       cwd: string;
       prompt: string;
       attachments: AgentAttachment[];
+      checkoutRequest: PickerCheckoutRequest | undefined;
     }): CreatePaseoWorktreeInput => {
       if (!selectedProject) {
         throw new Error("Choose a project");
@@ -1893,7 +1879,6 @@ export function NewWorkspaceScreen({
       if (!selectedSourceDirectory) {
         throw new Error("Choose a host for this project");
       }
-      const checkoutRequest = resolveCheckoutRequest(selectedItem, currentBranch);
       const firstAgentContext = buildFirstAgentContext(input);
       const hostProjectId = getHostProjectId(selectedProject, selectedServerId);
       if (!hostProjectId) {
@@ -1905,10 +1890,10 @@ export function NewWorkspaceScreen({
         projectId: hostProjectId,
         worktreeSlug: createNameId(),
         ...(firstAgentContext ? { firstAgentContext } : {}),
-        ...checkoutRequest,
+        ...input.checkoutRequest,
       };
     },
-    [currentBranch, selectedItem, selectedProject, selectedServerId, selectedSourceDirectory],
+    [selectedProject, selectedServerId, selectedSourceDirectory],
   );
 
   const ensureWorkspace = useCallback(
@@ -1927,14 +1912,26 @@ export function NewWorkspaceScreen({
       if (!selectedSourceDirectory) {
         throw new Error("Choose a host for this project");
       }
+      const connectedClient = withConnectedClient();
+      const createsWorktree = !supportsWorkspaceMultiplicity || effectiveIsolation === "worktree";
+      const checkoutRequest = createsWorktree
+        ? resolveCheckoutRequest(
+            selectedItem,
+            await ensureCheckoutStatus({
+              queryClient,
+              client: connectedClient,
+              serverId: selectedServerId,
+              cwd: selectedSourceDirectory,
+            }),
+          )
+        : undefined;
       const normalizedWorkspace = supportsWorkspaceMultiplicity
         ? await createMultiplicityWorkspace({
-            client: withConnectedClient(),
+            client: connectedClient,
             isolation: effectiveIsolation,
             project: selectedProject,
             sourceDirectory: selectedSourceDirectory,
-            selectedItem,
-            currentBranch,
+            checkoutRequest,
             withInitialAgent: input.withInitialAgent,
             prompt: input.prompt,
             attachments: input.attachments,
@@ -1943,8 +1940,8 @@ export function NewWorkspaceScreen({
             createFailedMessage: t("newWorkspace.errors.createWorktreeFailed"),
           })
         : await createAndMergeWorkspace({
-            client: withConnectedClient(),
-            createInput: buildCreateWorktreeInput(input),
+            client: connectedClient,
+            createInput: buildCreateWorktreeInput({ ...input, checkoutRequest }),
             mergeWorkspaces,
             serverId: selectedServerId,
             createFailedMessage: t("newWorkspace.errors.createWorktreeFailed"),
@@ -1955,9 +1952,9 @@ export function NewWorkspaceScreen({
     [
       buildCreateWorktreeInput,
       createdWorkspace,
-      currentBranch,
       effectiveIsolation,
       mergeWorkspaces,
+      queryClient,
       selectedItem,
       selectedProject,
       selectedServerId,

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -71,6 +71,7 @@ import {
   getHostProjectId,
   hostProjectFromRoute,
   hostProjectFromWorkspace,
+  resolveHydratedHostProject,
   useHostProjects,
   type HostProjectListItem,
 } from "@/projects/host-projects";
@@ -1654,8 +1655,14 @@ export function NewWorkspaceScreen({
   });
 
   const currentBranch = checkoutStatus?.currentBranch ?? null;
-  const projectCanCreateWorktree = selectedProject
-    ? canCreateWorktreeForHostProject({ project: selectedProject, serverId: selectedServerId })
+  const hydratedSelectedProject = selectedProject
+    ? resolveHydratedHostProject({ project: selectedProject, projects, serverId: selectedServerId })
+    : null;
+  const projectCanCreateWorktree = hydratedSelectedProject
+    ? canCreateWorktreeForHostProject({
+        project: hydratedSelectedProject,
+        serverId: selectedServerId,
+      })
     : false;
   const { effectiveIsolation, setIsolation, canCreateWorktree, showRefPicker } =
     useWorkspaceIsolation({

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -69,7 +69,7 @@ import { projectIconPlaceholderLabelFromDisplayName } from "@/utils/project-disp
 import {
   getHostProjectSourceDirectory,
   getHostProjectId,
-  getHostProjectWorktreeCapability,
+  getWorktreeSupportForHostProject,
   hostProjectFromRoute,
   hostProjectFromWorkspace,
   useHostProjects,
@@ -554,7 +554,8 @@ function NewWorkspaceProjectPickerOption({
       active={active}
       disabled={
         isPending ||
-        (!supportsWorkspaceMultiplicity && !project.hosts.some((host) => host.canCreateWorktree))
+        (!supportsWorkspaceMultiplicity &&
+          !project.hosts.some((host) => host.worktreeSupport !== "unsupported"))
       }
       onPress={onPress}
     />
@@ -687,21 +688,20 @@ interface WorkspaceIsolationState {
   showRefPicker: boolean;
 }
 
-// Worktree isolation only makes sense for a git checkout. The effective isolation
-// falls back to local whenever the selected directory isn't git so the flow
-// never submits an impossible request.
+// Preserve the user's worktree choice while route metadata is provisional. Once
+// the authoritative placement arrives, unsupported projects fall back to local.
 function useWorkspaceIsolation(input: {
   supportsMultiplicity: boolean;
-  projectCanCreateWorktree: boolean;
+  worktreeSupport: "supported" | "unsupported" | "unknown";
 }): WorkspaceIsolationState {
-  const { supportsMultiplicity, projectCanCreateWorktree } = input;
+  const { supportsMultiplicity, worktreeSupport } = input;
   // The last isolation choice is remembered alongside the other New Workspace
   // form preferences (provider, model, mode). A manual in-screen pick overrides
   // the remembered default until the screen remounts.
   const { preferences, updatePreferences } = useFormPreferences();
   const [manualIsolation, setManualIsolation] = useState<"local" | "worktree" | null>(null);
   const isolation = manualIsolation ?? preferences.isolation ?? "local";
-  const canCreateWorktree = supportsMultiplicity && projectCanCreateWorktree;
+  const canCreateWorktree = supportsMultiplicity && worktreeSupport !== "unsupported";
   const isWorktree = isolation === "worktree" && canCreateWorktree;
 
   const setIsolation = useCallback(
@@ -1638,21 +1638,14 @@ export function NewWorkspaceScreen({
   });
 
   const currentBranch = checkoutStatus?.currentBranch ?? null;
-  const projectWorktreeCapability = selectedProject
-    ? getHostProjectWorktreeCapability({
-        project: selectedProject,
-        projects,
-        serverId: selectedServerId,
-      })
-    : "unavailable";
-  const projectCanCreateWorktree = projectWorktreeCapability === "available";
-  const isPending =
-    isNewWorkspacePending({ pendingAction, isDraftHandoffActive }) ||
-    projectWorktreeCapability === "pending";
+  const worktreeSupport = selectedProject
+    ? getWorktreeSupportForHostProject({ project: selectedProject, serverId: selectedServerId })
+    : "unsupported";
+  const isPending = isNewWorkspacePending({ pendingAction, isDraftHandoffActive });
   const { effectiveIsolation, setIsolation, canCreateWorktree, showRefPicker } =
     useWorkspaceIsolation({
       supportsMultiplicity: supportsWorkspaceMultiplicity,
-      projectCanCreateWorktree,
+      worktreeSupport,
     });
 
   const branchSuggestionsQuery = useQuery({

--- a/packages/app/src/screens/new-workspace/project-picker.ts
+++ b/packages/app/src/screens/new-workspace/project-picker.ts
@@ -166,7 +166,11 @@ export function useNewWorkspaceProjectPicker({
     (id: string) => {
       const project = projectByOptionId.get(id);
       if (!project) return;
-      if (!allowAllProjects && !project.hosts.some((host) => host.canCreateWorktree)) return;
+      if (
+        !allowAllProjects &&
+        !project.hosts.some((host) => host.worktreeSupport !== "unsupported")
+      )
+        return;
       setProjectSelection({
         contextKey: manualSelectionContextKey,
         project,

--- a/packages/app/src/screens/new-workspace/project-selection.test.ts
+++ b/packages/app/src/screens/new-workspace/project-selection.test.ts
@@ -23,7 +23,7 @@ function project(projectKey: string, serverId = "host"): HostProjectListItem {
         serverId,
         projectId: projectKey,
         iconWorkingDir: `/work/${projectKey}`,
-        canCreateWorktree: true,
+        worktreeSupport: "supported" as const,
       },
     ],
     workspaceKeys: [],
@@ -127,7 +127,7 @@ describe("reconcileProjectSelection", () => {
           serverId: "host",
           projectId: "local-project-id",
           iconWorkingDir: "/work/project",
-          canCreateWorktree: true,
+          worktreeSupport: "supported" as const,
         },
       ],
     };
@@ -138,7 +138,7 @@ describe("reconcileProjectSelection", () => {
           serverId: "host",
           projectId: "local-project-id",
           iconWorkingDir: "/work/project",
-          canCreateWorktree: false,
+          worktreeSupport: "unsupported" as const,
         },
       ],
     };
@@ -301,7 +301,7 @@ describe("reconcileProjectSelection", () => {
           serverId: "host-b",
           projectId: "prj_a",
           iconWorkingDir: "/work/a",
-          canCreateWorktree: true,
+          worktreeSupport: "supported" as const,
         },
       ],
     };
@@ -338,7 +338,7 @@ describe("reconcileProjectSelection", () => {
           serverId: "host-a",
           projectId: "prj_b",
           iconWorkingDir: "/work/selected",
-          canCreateWorktree: true,
+          worktreeSupport: "supported" as const,
         },
       ],
     };
@@ -421,7 +421,7 @@ describe("reconcileProjectSelection", () => {
           serverId: "host-a",
           projectId: "prj_b",
           iconWorkingDir: "/work/selected",
-          canCreateWorktree: true,
+          worktreeSupport: "supported" as const,
         },
       ],
     };
@@ -466,7 +466,7 @@ describe("reconcileProjectSelection", () => {
           serverId: "host-b",
           projectId: "shared",
           iconWorkingDir: "/work/shared",
-          canCreateWorktree: false,
+          worktreeSupport: "unsupported" as const,
         },
       ],
     };
@@ -619,7 +619,7 @@ describe("reconcileProjectSelection", () => {
           serverId: "host",
           projectId: "sibling",
           iconWorkingDir: "/work/sibling",
-          canCreateWorktree: true,
+          worktreeSupport: "supported" as const,
         },
       ],
     };

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -44,7 +44,11 @@ function project(overrides: ProjectOverrides = {}): SidebarProjectEntry {
   const projectKind = overrides.projectKind ?? "git";
   const hosts = Array.from(
     overrides.hosts ?? [
-      { serverId: "srv", iconWorkingDir: "/repo", canCreateWorktree: projectKind === "git" },
+      {
+        serverId: "srv",
+        iconWorkingDir: "/repo",
+        worktreeSupport: projectKind === "git" ? "supported" : "unsupported",
+      },
     ],
     (host) => Object.assign({}, host, { projectId: host.projectId ?? `project-${host.serverId}` }),
   );
@@ -135,8 +139,12 @@ describe("buildSidebarProjectRowModel", () => {
     const result = buildSidebarProjectRowModel({
       project: project({
         hosts: [
-          { serverId: "host-a", iconWorkingDir: "/repo/a", canCreateWorktree: false },
-          { serverId: "host-b", iconWorkingDir: "/repo/b", canCreateWorktree: true },
+          {
+            serverId: "host-a",
+            iconWorkingDir: "/repo/a",
+            worktreeSupport: "unsupported" as const,
+          },
+          { serverId: "host-b", iconWorkingDir: "/repo/b", worktreeSupport: "supported" as const },
         ],
       }),
       collapsed: false,
@@ -155,8 +163,16 @@ describe("buildSidebarProjectRowModel", () => {
       project: project({
         projectKind: "directory",
         hosts: [
-          { serverId: "host-a", iconWorkingDir: "/repo/a", canCreateWorktree: false },
-          { serverId: "host-b", iconWorkingDir: "/repo/b", canCreateWorktree: false },
+          {
+            serverId: "host-a",
+            iconWorkingDir: "/repo/a",
+            worktreeSupport: "unsupported" as const,
+          },
+          {
+            serverId: "host-b",
+            iconWorkingDir: "/repo/b",
+            worktreeSupport: "unsupported" as const,
+          },
         ],
       }),
       collapsed: false,
@@ -197,8 +213,8 @@ describe("buildSidebarProjectRowModel", () => {
     const iconTarget = resolveSidebarProjectIconTarget(
       project({
         hosts: [
-          { serverId: "host-b", iconWorkingDir: "/repo/b", canCreateWorktree: true },
-          { serverId: "host-a", iconWorkingDir: "/repo/a", canCreateWorktree: true },
+          { serverId: "host-b", iconWorkingDir: "/repo/b", worktreeSupport: "supported" as const },
+          { serverId: "host-a", iconWorkingDir: "/repo/a", worktreeSupport: "supported" as const },
         ],
       }),
     );
@@ -214,7 +230,9 @@ describe("buildSidebarProjectRowModel", () => {
     const [iconTarget] = resolveSidebarProjectIconTargets([
       project({
         viewKey: '["placement","host-b","project-b"]',
-        hosts: [{ serverId: "host-b", iconWorkingDir: "/repo/b", canCreateWorktree: true }],
+        hosts: [
+          { serverId: "host-b", iconWorkingDir: "/repo/b", worktreeSupport: "supported" as const },
+        ],
       }),
     ]);
 
@@ -230,8 +248,12 @@ describe("buildSidebarProjectRowModel", () => {
     const groupedProject = project({
       iconWorkingDir: "/remote/repo",
       hosts: [
-        { serverId: "remote", iconWorkingDir: "/remote/repo", canCreateWorktree: true },
-        { serverId: "local", iconWorkingDir: "/local/repo", canCreateWorktree: true },
+        {
+          serverId: "remote",
+          iconWorkingDir: "/remote/repo",
+          worktreeSupport: "supported" as const,
+        },
+        { serverId: "local", iconWorkingDir: "/local/repo", worktreeSupport: "supported" as const },
       ],
     });
 

--- a/packages/app/src/utils/sidebar-project-row-model.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.ts
@@ -75,7 +75,10 @@ function resolveNewWorkspaceTarget(
   supportsMultiplicityByServerId: ReadonlyMap<string, boolean>,
 ): SidebarProjectHostTarget | null {
   for (const host of project.hosts) {
-    if (!host.canCreateWorktree && !supportsMultiplicityByServerId.get(host.serverId)) {
+    if (
+      host.worktreeSupport === "unsupported" &&
+      !supportsMultiplicityByServerId.get(host.serverId)
+    ) {
       continue;
     }
     const target = hostTarget(host);

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -55,7 +55,7 @@ function project(projectKey: string, workspaces: SidebarWorkspaceEntry[]): Sideb
         serverId: workspaces[0]?.serverId ?? "s1",
         projectId: projectKey,
         iconWorkingDir: workspaces[0]?.workspaceDirectory ?? "",
-        canCreateWorktree: true,
+        worktreeSupport: "supported" as const,
       },
     ],
     workspaces,
@@ -150,7 +150,7 @@ describe("buildSidebarShortcutModel", () => {
     directoryProject.projectKind = "directory";
     directoryProject.hosts = directoryProject.hosts.map((host) => ({
       ...host,
-      canCreateWorktree: false,
+      worktreeSupport: "unsupported" as const,
     }));
 
     const model = buildSidebarShortcutModel({


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

New Workspace shows worktree isolation from the selected project's reconciled Git capability instead of waiting for a checkout-status round trip. Route-derived projects carry an explicit provisional capability, preserving the user's isolation choice without disabling stale or legacy project routes.

Checkout status now uses one shared query definition. Worktree submission awaits that canonical cached or in-flight status before creation, so a fast submit still branches from the currently checked-out branch and reconnect invalidation cannot reuse a stale branch.

Host-specific placement remains authoritative when projects are grouped across hosts, so a Git checkout on one host does not enable worktrees on another.

### How did you verify it

- Added a Playwright regression proving a stale project route keeps the project picker and Composer enabled against an authoritatively empty project list.
- Added focused regressions for host-specific worktree support, provisional project selection, checkout cache reuse, invalidation, and checkout intent.
- Focused Vitest run: 10 files, 116 tests passed.
- Focused Playwright run: stale-project route regression passed on Desktop Chrome with the isolated E2E daemon.
- Existing reconciliation tests cover daemon project-kind reconciliation and app-side `project.update` application.
- `npm run typecheck` — passed.
- `npm run lint` — 0 warnings and 0 errors.
- `npm run format` — passed.

### Risk surface

The affected form path is shared across iOS, Android, browser, and Electron. Platform rendering is unchanged; the browser behavior is covered by Playwright, and capability/creation ordering is covered by focused model and cache tests.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
