### PR TITLE
fix(claude): support root daemon permissions

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -57,6 +57,8 @@ Existing direct providers: `claude` (in `providers/claude/agent.ts`), `codex` (`
 
 Claude first-party model metadata lives in `packages/server/src/server/agent/providers/claude/model-manifest.ts`. When adding or updating a Claude model, update that manifest only; the model picker thinking options and Claude-specific feature gates are derived from the manifest. Do not add model-specific Claude capability lists in feature code.
 
+Claude Code refuses both `--dangerously-skip-permissions` and the SDK's `--allow-dangerously-skip-permissions` capability when the daemon runs with UID 0. The Claude provider detects that runtime constraint, omits the SDK capability, and reports `bypassPermissions` as a disabled mode with an explanation. Keep the server-side mode rejection and client disabled state driven by that catalog fact; do not infer root status in the app.
+
 Paseo tools are not implemented as MCP tools internally. They live in a shared tool catalog under `packages/server/src/server/agent/tools/`; MCP is only the fallback adapter. A provider that can register runtime tools directly should set `supportsNativePaseoTools: true` and consume `launchContext.paseoTools` in `createSession`/`resumeSession`. When native tools are present, `AgentManager` strips the internal Paseo MCP server from the provider launch config so the provider does not receive the same tools twice. Providers that only know MCP should keep `supportsMcpServers: true` and let the daemon inject `/mcp/agents`.
 
 Pi is a process-backed provider. Paseo requires the user to have the `pi` binary installed and talks to it through `pi --mode rpc`; the server package does not embed Pi's SDK/runtime packages.

--- a/packages/app/src/components/schedules/schedule-form-sheet.tsx
+++ b/packages/app/src/components/schedules/schedule-form-sheet.tsx
@@ -596,6 +596,7 @@ function ScheduleTargetFields({
         id: option.id,
         value: option.id,
         label: option.label,
+        disabledReason: option.disabledReason,
       })),
     [state.modeOptions],
   );

--- a/packages/app/src/components/ui/combobox-keyboard.test.ts
+++ b/packages/app/src/components/ui/combobox-keyboard.test.ts
@@ -19,4 +19,37 @@ describe("getNextActiveIndex", () => {
     expect(getNextActiveIndex({ currentIndex: 2, itemCount: 3, key: "ArrowDown" })).toBe(0);
     expect(getNextActiveIndex({ currentIndex: 0, itemCount: 3, key: "ArrowUp" })).toBe(2);
   });
+
+  it("skips disabled items in both directions", () => {
+    const isDisabled = (index: number) => index === 1;
+
+    expect(
+      getNextActiveIndex({ currentIndex: 0, itemCount: 3, key: "ArrowDown", isDisabled }),
+    ).toBe(2);
+    expect(getNextActiveIndex({ currentIndex: 2, itemCount: 3, key: "ArrowUp", isDisabled })).toBe(
+      0,
+    );
+  });
+
+  it("skips disabled boundary items when choosing the initial item", () => {
+    const isDisabled = (index: number) => index === 0 || index === 2;
+
+    expect(
+      getNextActiveIndex({ currentIndex: -1, itemCount: 3, key: "ArrowDown", isDisabled }),
+    ).toBe(1);
+    expect(getNextActiveIndex({ currentIndex: -1, itemCount: 3, key: "ArrowUp", isDisabled })).toBe(
+      1,
+    );
+  });
+
+  it("returns -1 when every item is disabled", () => {
+    expect(
+      getNextActiveIndex({
+        currentIndex: -1,
+        itemCount: 3,
+        key: "ArrowDown",
+        isDisabled: () => true,
+      }),
+    ).toBe(-1);
+  });
 });

--- a/packages/app/src/components/ui/combobox-keyboard.ts
+++ b/packages/app/src/components/ui/combobox-keyboard.ts
@@ -2,17 +2,26 @@ export function getNextActiveIndex(args: {
   currentIndex: number;
   itemCount: number;
   key: "ArrowDown" | "ArrowUp";
+  isDisabled?: (index: number) => boolean;
 }): number {
-  const { currentIndex, itemCount, key } = args;
+  const { currentIndex, itemCount, key, isDisabled } = args;
 
   if (itemCount <= 0) return -1;
 
+  const step = key === "ArrowDown" ? 1 : -1;
+  let candidate: number;
   if (currentIndex < 0) {
-    return key === "ArrowDown" ? 0 : itemCount - 1;
+    candidate = key === "ArrowDown" ? 0 : itemCount - 1;
+  } else {
+    candidate = (currentIndex + step + itemCount) % itemCount;
   }
 
-  const normalizedCurrent = currentIndex % itemCount;
-  return key === "ArrowDown"
-    ? (normalizedCurrent + 1) % itemCount
-    : (normalizedCurrent - 1 + itemCount) % itemCount;
+  for (let visited = 0; visited < itemCount; visited += 1) {
+    if (!isDisabled?.(candidate)) {
+      return candidate;
+    }
+    candidate = (candidate + step + itemCount) % itemCount;
+  }
+
+  return -1;
 }

--- a/packages/app/src/components/ui/combobox-options.ts
+++ b/packages/app/src/components/ui/combobox-options.ts
@@ -10,6 +10,7 @@ export interface ComboboxOptionModel {
   id: string;
   label: string;
   description?: string;
+  disabledReason?: string;
   kind?: ComboboxOptionKind;
 }
 

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -45,7 +45,6 @@ import {
 import { getNextActiveIndex } from "./combobox-keyboard";
 import {
   buildVisibleComboboxOptions,
-  getComboboxFallbackIndex,
   orderVisibleComboboxOptions,
   shouldShowCustomComboboxOption,
 } from "./combobox-options";
@@ -519,8 +518,14 @@ function computeDesktopPosition(input: DesktopPositionInput): DesktopPositionRes
   };
 }
 
-function advanceActiveIndex(itemCount: number, key: "ArrowDown" | "ArrowUp") {
-  return (currentIndex: number) => getNextActiveIndex({ currentIndex, itemCount, key });
+function advanceActiveIndex(options: ComboboxOption[], key: "ArrowDown" | "ArrowUp") {
+  return (currentIndex: number) =>
+    getNextActiveIndex({
+      currentIndex,
+      itemCount: options.length,
+      key,
+      isDisabled: (index) => Boolean(options[index]?.disabledReason),
+    });
 }
 
 type DesktopKey = "ArrowDown" | "ArrowUp" | "Enter" | "Escape";
@@ -536,13 +541,24 @@ interface DesktopKeyHandlerInput {
 }
 
 function handleDesktopArrowKey(input: DesktopKeyHandlerInput, key: "ArrowDown" | "ArrowUp") {
-  input.setActiveIndex(advanceActiveIndex(input.orderedVisibleOptions.length, key));
+  input.setActiveIndex(advanceActiveIndex(input.orderedVisibleOptions, key));
 }
 
 function handleDesktopEnterKey(input: DesktopKeyHandlerInput) {
   if (input.orderedVisibleOptions.length === 0) return;
   const { activeIndex, orderedVisibleOptions } = input;
-  const index = activeIndex >= 0 && activeIndex < orderedVisibleOptions.length ? activeIndex : 0;
+  const index =
+    activeIndex >= 0 &&
+    activeIndex < orderedVisibleOptions.length &&
+    !orderedVisibleOptions[activeIndex]?.disabledReason
+      ? activeIndex
+      : getNextActiveIndex({
+          currentIndex: -1,
+          itemCount: orderedVisibleOptions.length,
+          key: "ArrowDown",
+          isDisabled: (candidate) => Boolean(orderedVisibleOptions[candidate]?.disabledReason),
+        });
+  if (index < 0) return;
   input.handleSelect(orderedVisibleOptions[index].id);
 }
 
@@ -903,13 +919,17 @@ function resolveInitialActiveIndex(
   value: string,
 ): number {
   if (orderedVisibleOptions.length === 0) return -1;
-  const fallbackIndex = getComboboxFallbackIndex(
-    orderedVisibleOptions.length,
-    effectiveOptionsPosition,
-  );
+  const fallbackIndex = getNextActiveIndex({
+    currentIndex: -1,
+    itemCount: orderedVisibleOptions.length,
+    key: effectiveOptionsPosition === "above-search" ? "ArrowUp" : "ArrowDown",
+    isDisabled: (index) => Boolean(orderedVisibleOptions[index]?.disabledReason),
+  });
   if (normalizedSearch) return fallbackIndex;
   const selectedIndex = orderedVisibleOptions.findIndex((opt) => opt.id === value);
-  return selectedIndex >= 0 ? selectedIndex : fallbackIndex;
+  return selectedIndex >= 0 && !orderedVisibleOptions[selectedIndex]?.disabledReason
+    ? selectedIndex
+    : fallbackIndex;
 }
 
 type BottomSheetVisibility = ReturnType<typeof useIsolatedBottomSheetVisibility>;
@@ -1504,10 +1524,11 @@ export function Combobox({
 
   const handleSelect = useCallback(
     (id: string) => {
+      if (orderedVisibleOptions.find((option) => option.id === id)?.disabledReason) return;
       onSelect(id);
       runIfSelected(keepOpenOnSelect, handleClose);
     },
-    [handleClose, keepOpenOnSelect, onSelect],
+    [handleClose, keepOpenOnSelect, onSelect, orderedVisibleOptions],
   );
 
   const handleSubmitSearch = useCallback(

--- a/packages/app/src/components/ui/select-field.tsx
+++ b/packages/app/src/components/ui/select-field.tsx
@@ -29,6 +29,7 @@ export interface SelectFieldOption<TValue> {
   value: TValue;
   label: string;
   description?: string;
+  disabledReason?: string;
   kind?: ComboboxOption["kind"];
   testID?: string;
 }
@@ -206,7 +207,8 @@ export function SelectField<TValue>({
       visibleOptions.map((option) => ({
         id: option.id,
         label: option.label,
-        description: option.description,
+        description: option.disabledReason ?? option.description,
+        disabledReason: option.disabledReason,
         kind: option.kind,
       })),
     [visibleOptions],
@@ -220,6 +222,9 @@ export function SelectField<TValue>({
     (id: string) => {
       const option = optionById.get(id);
       if (!option) {
+        return;
+      }
+      if (option.disabledReason) {
         return;
       }
       onChange(option.value, { label: option.label, description: option.description });
@@ -277,6 +282,7 @@ export function SelectField<TValue>({
           kind={selectOption.kind}
           selected={selected}
           active={active}
+          disabled={Boolean(selectOption.disabledReason)}
           onPress={onPress}
         />
       );

--- a/packages/app/src/components/workspace-setup-dialog.tsx
+++ b/packages/app/src/components/workspace-setup-dialog.tsx
@@ -123,7 +123,7 @@ function buildCreateAgentOptions({
   provider,
 }: {
   composerState: {
-    modeOptions: { id: string }[];
+    modeOptions: { id: string; disabledReason?: string }[];
     selectedMode: string;
     effectiveModelId: string | null;
     effectiveThinkingOptionId: string | null;
@@ -140,7 +140,9 @@ function buildCreateAgentOptions({
   // globally-remembered mode this workspace's provider config no longer
   // defines), so the submitted mode must match that display rather than send a
   // stale mode the provider would reject.
-  const modeOptionIds = composerState.modeOptions.map((mode) => mode.id);
+  const modeOptionIds = composerState.modeOptions
+    .filter((mode) => mode.disabledReason === undefined)
+    .map((mode) => mode.id);
   const reconciledMode = modeOptionIds.includes(composerState.selectedMode)
     ? composerState.selectedMode
     : (modeOptionIds[0] ?? "");

--- a/packages/app/src/composer/agent-controls/mode-control.tsx
+++ b/packages/app/src/composer/agent-controls/mode-control.tsx
@@ -54,8 +54,10 @@ function ModeComboboxOption({
   return (
     <ComboboxItem
       label={option.label}
+      description={option.description}
       selected={selected}
       active={active}
+      disabled={Boolean(option.disabledReason)}
       onPress={onPress}
       leadingSlot={leadingSlot}
     />
@@ -98,7 +100,10 @@ export function AgentModeControl({
 
   const selectedMode = useMemo(() => {
     if (modeOptions.length === 0) return null;
-    return modeOptions.find((m) => m.id === selectedModeId) ?? modeOptions[0];
+    const selected = modeOptions.find((mode) => mode.id === selectedModeId);
+    return (
+      selected ?? modeOptions.find((mode) => mode.disabledReason === undefined) ?? modeOptions[0]
+    );
   }, [modeOptions, selectedModeId]);
 
   const Icon = getAgentModeIcon(provider, selectedMode?.id ?? "", providerDefinitions);
@@ -106,7 +111,13 @@ export function AgentModeControl({
   const selectedModeLabel = selectedMode ? formatAgentModeLabel(selectedMode) : "";
 
   const allOptions = useMemo<ComboboxOption[]>(
-    () => modeOptions.map((m) => ({ id: m.id, label: formatAgentModeLabel(m) })),
+    () =>
+      modeOptions.map((mode) => ({
+        id: mode.id,
+        label: formatAgentModeLabel(mode),
+        description: mode.disabledReason ?? mode.description,
+        disabledReason: mode.disabledReason,
+      })),
     [modeOptions],
   );
   const options = useMemo<ComboboxOption[]>(() => {
@@ -131,10 +142,11 @@ export function AgentModeControl({
   const handlePress = useCallback(() => handleOpenChange(!open), [handleOpenChange, open]);
   const handleSelect = useCallback(
     (id: string) => {
+      if (modeOptions.find((mode) => mode.id === id)?.disabledReason) return;
       onSelectMode(id);
       handleOpenChange(false);
     },
-    [onSelectMode, handleOpenChange],
+    [handleOpenChange, modeOptions, onSelectMode],
   );
 
   const handleKeyboardAction = useCallback(

--- a/packages/app/src/composer/agent-controls/mode.test.ts
+++ b/packages/app/src/composer/agent-controls/mode.test.ts
@@ -66,4 +66,15 @@ describe("resolveNextAgentModeId", () => {
     expect(resolveNextAgentModeId({ modeOptions: [], selectedMode: "" })).toBeNull();
     expect(resolveNextAgentModeId({ modeOptions: [PLAN_MODE], selectedMode: "plan" })).toBeNull();
   });
+
+  it("skips disabled modes", () => {
+    const modes = [
+      PLAN_MODE,
+      { id: "bypassPermissions", label: "Bypass", disabledReason: "Unavailable as root" },
+      { id: "default", label: "Always Ask" },
+    ] satisfies AgentMode[];
+
+    expect(resolveNextAgentModeId({ modeOptions: modes, selectedMode: "plan" })).toBe("default");
+    expect(resolveNextAgentModeId({ modeOptions: modes, selectedMode: "default" })).toBe("plan");
+  });
 });

--- a/packages/app/src/composer/agent-controls/mode.ts
+++ b/packages/app/src/composer/agent-controls/mode.ts
@@ -8,12 +8,13 @@ export function resolveNextAgentModeId({
   modeOptions: readonly AgentMode[];
   selectedMode: string | null | undefined;
 }): string | null {
-  if (modeOptions.length < 2) return null;
+  const enabledModes = modeOptions.filter((mode) => mode.disabledReason === undefined);
+  if (enabledModes.length < 2) return null;
 
-  const selectedIndex = modeOptions.findIndex((mode) => mode.id === selectedMode);
+  const selectedIndex = enabledModes.findIndex((mode) => mode.id === selectedMode);
   const currentIndex = selectedIndex >= 0 ? selectedIndex : 0;
-  const nextIndex = (currentIndex + 1) % modeOptions.length;
-  return modeOptions[nextIndex]?.id ?? null;
+  const nextIndex = (currentIndex + 1) % enabledModes.length;
+  return enabledModes[nextIndex]?.id ?? null;
 }
 
 export function resolveAgentControlsMode(agentControls?: DraftAgentControlsProps) {

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -110,7 +110,7 @@ function resolveDraftModeIdOverride(input: {
   selectedMode: string;
 }): { modeId: string } | Record<string, never> {
   const { autoSubmitConfig, modeOptionIds, selectedMode } = input;
-  if (autoSubmitConfig?.modeId) {
+  if (autoSubmitConfig?.modeId && modeOptionIds.includes(autoSubmitConfig.modeId)) {
     return { modeId: autoSubmitConfig.modeId };
   }
   const reconciled = reconcileSelectedMode(modeOptionIds, selectedMode);
@@ -126,7 +126,10 @@ function resolveDraftModeId(input: {
   selectedMode: string;
 }): string | null {
   const { autoSubmitConfig, modeOptionIds, selectedMode } = input;
-  if (autoSubmitConfig?.modeId !== undefined) {
+  if (
+    autoSubmitConfig?.modeId !== undefined &&
+    (autoSubmitConfig.modeId === null || modeOptionIds.includes(autoSubmitConfig.modeId))
+  ) {
     return autoSubmitConfig.modeId;
   }
   const reconciled = reconcileSelectedMode(modeOptionIds, selectedMode);
@@ -149,7 +152,7 @@ async function submitDraftCreateRequest(input: {
   composerState: {
     selectedProvider: string | null;
     selectedMode: string;
-    modeOptions: readonly { id: string }[];
+    modeOptions: readonly { id: string; disabledReason?: string }[];
     effectiveModelId: string | null;
     effectiveThinkingOptionId: string | null;
     featureValues: Record<string, unknown> | undefined;
@@ -182,7 +185,9 @@ async function submitDraftCreateRequest(input: {
   }
   const modeIdOverride = resolveDraftModeIdOverride({
     autoSubmitConfig,
-    modeOptionIds: composerState.modeOptions.map((mode) => mode.id),
+    modeOptionIds: composerState.modeOptions
+      .filter((mode) => mode.disabledReason === undefined)
+      .map((mode) => mode.id),
     selectedMode: composerState.selectedMode,
   });
   const config = buildWorkspaceDraftAgentConfig({
@@ -221,7 +226,7 @@ function buildDraftAgentSnapshot(input: {
   composerState: {
     effectiveModelId: string | null;
     effectiveThinkingOptionId: string | null;
-    modeOptions: readonly { id: string }[];
+    modeOptions: readonly { id: string; disabledReason?: string }[];
     selectedMode: string;
     selectedProvider: string | null;
     agentControls: { features?: Agent["features"] };
@@ -236,7 +241,9 @@ function buildDraftAgentSnapshot(input: {
     autoSubmitConfig?.thinkingOptionId ?? (composerState.effectiveThinkingOptionId || null);
   const modeId = resolveDraftModeId({
     autoSubmitConfig,
-    modeOptionIds: composerState.modeOptions.map((mode) => mode.id),
+    modeOptionIds: composerState.modeOptions
+      .filter((mode) => mode.disabledReason === undefined)
+      .map((mode) => mode.id),
     selectedMode: composerState.selectedMode,
   });
   const provider = autoSubmitConfig?.provider ?? composerState.selectedProvider;

--- a/packages/app/src/provider-selection/resolve-agent-form.test.ts
+++ b/packages/app/src/provider-selection/resolve-agent-form.test.ts
@@ -448,6 +448,30 @@ describe("resolveFormState", () => {
     expect(resolved.thinkingOptionId).toBe("");
   });
 
+  it("falls back from a preferred mode disabled by the host", () => {
+    const rootClaudeDefinition: AgentProviderDefinition = {
+      ...TEST_CLAUDE_DEFINITION,
+      modes: TEST_CLAUDE_DEFINITION.modes.map((mode) =>
+        mode.id === "bypassPermissions"
+          ? { ...mode, disabledReason: "Unavailable while Paseo runs as root" }
+          : mode,
+      ),
+    };
+    const resolved = resolveFormState(
+      undefined,
+      {
+        provider: "claude",
+        providerPreferences: { claude: { mode: "bypassPermissions" } },
+      },
+      null,
+      INITIAL_USER_MODIFIED,
+      makeState({ provider: "claude" }).form,
+      makeProviderMap(rootClaudeDefinition),
+    );
+
+    expect(resolved.modeId).toBe("default");
+  });
+
   it("auto-selects the model's default thinking option when model is preferred but thinking is not", () => {
     const resolved = resolveFormState(
       undefined,

--- a/packages/app/src/provider-selection/resolve-agent-form.ts
+++ b/packages/app/src/provider-selection/resolve-agent-form.ts
@@ -191,17 +191,23 @@ function resolvePreferredModeId(input: {
   // Saved modes are user intent. Provider create config validates unknown modes
   // at submission time, so background form resolution should not erase them.
   const initialModeId = normalizeSelectedModeId(input.initialModeId);
-  if (initialModeId) return initialModeId;
+  const modes = input.providerDef?.modes ?? [];
+  const isDisabledMode = (modeId: string) =>
+    modes.some((mode) => mode.id === modeId && mode.disabledReason !== undefined);
+  if (initialModeId && !isDisabledMode(initialModeId)) return initialModeId;
 
   const preferredModeId = normalizeSelectedModeId(input.preferredModeId);
-  if (preferredModeId) return preferredModeId;
+  if (preferredModeId && !isDisabledMode(preferredModeId)) return preferredModeId;
 
   const defaultModeId = input.providerDef?.defaultModeId;
-  const modes = input.providerDef?.modes ?? [];
-  if (defaultModeId && (modes.length === 0 || modes.some((mode) => mode.id === defaultModeId))) {
+  const enabledModes = modes.filter((mode) => mode.disabledReason === undefined);
+  if (
+    defaultModeId &&
+    (modes.length === 0 || enabledModes.some((mode) => mode.id === defaultModeId))
+  ) {
     return defaultModeId;
   }
-  return modes[0]?.id ?? "";
+  return enabledModes[0]?.id ?? "";
 }
 
 export function mergeSelectedComposerPreferences(args: {

--- a/packages/app/src/schedules/schedule-form-model.ts
+++ b/packages/app/src/schedules/schedule-form-model.ts
@@ -775,7 +775,11 @@ function pickModeForProvider(input: {
     return currentMode;
   }
   const entry = resolveSelectedEntry(input.entries, input.provider);
-  return entry?.defaultModeId ?? entry?.modes?.[0]?.id ?? "";
+  const enabledModes = entry?.modes?.filter((mode) => mode.disabledReason === undefined) ?? [];
+  if (entry?.defaultModeId && enabledModes.some((mode) => mode.id === entry.defaultModeId)) {
+    return entry.defaultModeId;
+  }
+  return enabledModes[0]?.id ?? "";
 }
 
 function pickModelForProvider(input: {

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -65,6 +65,7 @@ export interface AgentMode {
   id: string;
   label: string;
   description?: string;
+  disabledReason?: string;
   icon?: string;
   colorTier?: string;
 }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -280,6 +280,7 @@ const AgentModeSchema: z.ZodType<AgentMode> = z.object({
   id: z.string(),
   label: z.string(),
   description: z.string().optional(),
+  disabledReason: z.string().optional(),
   icon: z.string().optional(),
   colorTier: z.string().optional(),
 });

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -69,6 +69,7 @@ export interface AgentMode {
   id: string;
   label: string;
   description?: string;
+  disabledReason?: string;
   icon?: string;
   colorTier?: string;
   isUnattended?: boolean;

--- a/packages/server/src/server/agent/create-agent-mode.test.ts
+++ b/packages/server/src/server/agent/create-agent-mode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveAndValidateCreateAgentMode } from "./create-agent-mode.js";
+import {
+  resolveAndValidateCreateAgentMode,
+  resolveDefaultAgentCreateConfig,
+} from "./create-agent-mode.js";
 
 const CLAUDE_MODES = ["default", "acceptEdits", "plan", "bypassPermissions"];
 const OPENCODE_MODES = ["build", "plan"];
@@ -209,5 +212,45 @@ describe("resolveAndValidateCreateAgentMode", () => {
       targetUnattendedMode: "full-access",
     });
     expect(resolved).toBe("auto");
+  });
+});
+
+describe("resolveDefaultAgentCreateConfig", () => {
+  it("rejects a mode disabled by the provider with its explanation", () => {
+    expect(() =>
+      resolveDefaultAgentCreateConfig({
+        provider: "claude",
+        requestedMode: "bypassPermissions",
+        parent: null,
+        unattended: false,
+        availableModes: [
+          { id: "default", label: "Always Ask" },
+          {
+            id: "bypassPermissions",
+            label: "Bypass",
+            disabledReason: "Claude Code does not allow permission bypass as root.",
+          },
+        ],
+      }),
+    ).toThrow("Claude Code does not allow permission bypass as root.");
+  });
+
+  it("rejects a disabled mode inherited from a same-provider parent", () => {
+    expect(() =>
+      resolveDefaultAgentCreateConfig({
+        provider: "claude",
+        requestedMode: undefined,
+        parent: agentParent("claude", "bypassPermissions", true),
+        unattended: false,
+        availableModes: [
+          { id: "default", label: "Always Ask" },
+          {
+            id: "bypassPermissions",
+            label: "Bypass",
+            disabledReason: "Claude Code does not allow permission bypass as root.",
+          },
+        ],
+      }),
+    ).toThrow("Claude Code does not allow permission bypass as root.");
   });
 });

--- a/packages/server/src/server/agent/create-agent-mode.ts
+++ b/packages/server/src/server/agent/create-agent-mode.ts
@@ -84,15 +84,24 @@ export function resolveAndValidateCreateAgentMode(
 export function resolveDefaultAgentCreateConfig(
   input: ResolveAgentCreateConfigInput,
 ): ResolveAgentCreateConfigResult {
-  const availableModeIds = input.availableModes?.map((mode) => mode.id);
+  const availableModes = input.availableModes?.filter((mode) => mode.disabledReason === undefined);
+  const inheritedModeId =
+    input.requestedMode === undefined && input.parent?.provider === input.provider
+      ? input.parent.modeId
+      : null;
+  const selectedModeId = input.requestedMode ?? inheritedModeId;
+  const selectedMode = input.availableModes?.find((mode) => mode.id === selectedModeId);
+  if (selectedMode?.disabledReason) {
+    throw new Error(selectedMode.disabledReason);
+  }
   return {
     modeId: resolveAndValidateCreateAgentMode({
       requestedMode: input.requestedMode,
       targetProvider: input.provider,
       parent: input.parent,
       unattended: input.unattended,
-      availableModes: availableModeIds,
-      targetUnattendedMode: input.availableModes?.find(isUnattendedMode)?.id,
+      availableModes: availableModes?.map((mode) => mode.id),
+      targetUnattendedMode: availableModes?.find(isUnattendedMode)?.id,
     }),
     featureValues: input.featureValues,
   };
@@ -104,7 +113,10 @@ export function isDefaultAgentCreateConfigUnattended(
   if (input.modeId === null) {
     return false;
   }
-  return input.availableModes.some((mode) => mode.id === input.modeId && isUnattendedMode(mode));
+  return input.availableModes.some(
+    (mode) =>
+      mode.id === input.modeId && mode.disabledReason === undefined && isUnattendedMode(mode),
+  );
 }
 
 function isUnattendedMode(mode: AgentMode): boolean {

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -34,7 +34,7 @@ import type {
   ProviderProfileModel,
   ProviderRuntimeSettings,
 } from "./provider-launch-config.js";
-import { ClaudeAgentClient } from "./providers/claude/agent.js";
+import { applyClaudeRuntimeModeAvailability, ClaudeAgentClient } from "./providers/claude/agent.js";
 import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js";
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
@@ -601,6 +601,11 @@ function createRegistryEntry(
       });
     });
 
+  const applyRuntimeModeAvailability = (modes: AgentMode[]): AgentMode[] => {
+    const baseProvider = resolved.derivedFromProviderId ?? provider;
+    return baseProvider === "claude" ? applyClaudeRuntimeModeAvailability(modes) : modes;
+  };
+
   const hasStaticModes = resolved.definition.modes.length > 0;
 
   return {
@@ -654,7 +659,7 @@ function createRegistryEntry(
           );
           return {
             models,
-            modes: decorateModes(resolved.definition.modes),
+            modes: decorateModes(applyRuntimeModeAvailability(resolved.definition.modes)),
             defaultModeId,
           };
         }

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -76,6 +76,20 @@ async function createSession() {
   });
 }
 
+async function createRootSession(modeId?: string) {
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory: sdkQueryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+    runningAsRoot: true,
+  });
+  return client.createSession({
+    provider: "claude",
+    cwd: process.cwd(),
+    modeId,
+  });
+}
+
 function createSessionWithLogger(logger: Logger) {
   const client = new ClaudeAgentClient({
     logger,
@@ -199,6 +213,70 @@ test("exposes and applies auto permission mode", async () => {
   } finally {
     await session.close();
   }
+});
+
+test("disables permission bypass and omits its launch capability when running as root", async () => {
+  let capturedOptions:
+    | {
+        permissionMode?: string;
+        allowDangerouslySkipPermissions?: boolean;
+      }
+    | undefined;
+  sdkQueryFactory.mockImplementation(
+    ({
+      options,
+    }: {
+      options: {
+        permissionMode?: string;
+        allowDangerouslySkipPermissions?: boolean;
+      };
+    }) => {
+      capturedOptions = options;
+      return createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+    },
+  );
+  const session = await createRootSession("bypassPermissions");
+
+  try {
+    await expect(session.getCurrentMode()).resolves.toBe("default");
+    await expect(session.getAvailableModes()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "bypassPermissions",
+          disabledReason:
+            "Claude Code does not allow bypassing permissions when Paseo runs as root.",
+        }),
+      ]),
+    );
+    await expect(session.setMode("bypassPermissions")).rejects.toThrow(
+      "Claude Code does not allow bypassing permissions when Paseo runs as root.",
+    );
+
+    await collectUntilTerminal(streamSession(session, "run safely"));
+    expect(capturedOptions).toMatchObject({ permissionMode: "default" });
+    expect(capturedOptions?.allowDangerouslySkipPermissions).toBeUndefined();
+  } finally {
+    await session.close();
+  }
+});
+
+test("marks permission bypass disabled in the root provider catalog", async () => {
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    resolveVersion: async () => "2.1.220",
+    runningAsRoot: true,
+  });
+
+  const catalog = await client.fetchCatalog({ scope: "global", force: false });
+
+  expect(catalog.modes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: "bypassPermissions",
+        disabledReason: "Claude Code does not allow bypassing permissions when Paseo runs as root.",
+      }),
+    ]),
+  );
 });
 
 test("rejects auto mode when Claude Code uses Bedrock", async () => {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -343,6 +343,39 @@ const DEFAULT_MODES: AgentMode[] = [
 ];
 
 const VALID_CLAUDE_MODES = new Set(DEFAULT_MODES.map((mode) => mode.id));
+const CLAUDE_ROOT_BYPASS_DISABLED_REASON =
+  "Claude Code does not allow bypassing permissions when Paseo runs as root.";
+
+function isRunningAsRoot(): boolean {
+  return process.getuid?.() === 0;
+}
+
+export function applyClaudeRuntimeModeAvailability(
+  modes: AgentMode[],
+  runningAsRoot = isRunningAsRoot(),
+): AgentMode[] {
+  if (!runningAsRoot) {
+    return modes;
+  }
+  return modes.map((mode) =>
+    mode.id === "bypassPermissions"
+      ? { ...mode, disabledReason: CLAUDE_ROOT_BYPASS_DISABLED_REASON }
+      : mode,
+  );
+}
+
+function modesForRuntime(runningAsRoot: boolean): AgentMode[] {
+  return applyClaudeRuntimeModeAvailability(DEFAULT_MODES, runningAsRoot);
+}
+
+function permissionBypassOptions(
+  runningAsRoot: boolean,
+): Partial<Pick<ClaudeOptions, "allowDangerouslySkipPermissions">> {
+  if (runningAsRoot) {
+    return {};
+  }
+  return { allowDangerouslySkipPermissions: true };
+}
 
 const REWIND_COMMAND_NAME = "rewind";
 const REWIND_COMMAND: AgentSlashCommand = {
@@ -400,6 +433,7 @@ interface ClaudeAgentClientOptions {
   resolveBinary?: () => Promise<string>;
   resolveVersion?: (signal?: AbortSignal) => Promise<string>;
   configDir?: string;
+  runningAsRoot?: boolean;
 }
 
 interface ClaudeAgentSessionOptions {
@@ -412,6 +446,7 @@ interface ClaudeAgentSessionOptions {
   logger: Logger;
   queryFactory?: ClaudeQueryFactory;
   resolveBinary: () => Promise<string>;
+  runningAsRoot: boolean;
 }
 
 type ClaudeThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";
@@ -1484,6 +1519,7 @@ export class ClaudeAgentClient implements AgentClient {
   private readonly resolveBinary: () => Promise<string>;
   private readonly resolveVersion: (signal?: AbortSignal) => Promise<string>;
   private readonly configDir?: string;
+  private readonly runningAsRoot: boolean;
 
   constructor(options: ClaudeAgentClientOptions) {
     this.defaults = options.defaults;
@@ -1495,6 +1531,7 @@ export class ClaudeAgentClient implements AgentClient {
       options.resolveVersion ??
       ((signal) => resolveClaudeCodeVersion(this.runtimeSettings, signal));
     this.configDir = options.configDir;
+    this.runningAsRoot = options.runningAsRoot ?? isRunningAsRoot();
   }
 
   resolveConfiguredModel(model: AgentModelDefinition): AgentModelDefinition {
@@ -1516,6 +1553,7 @@ export class ClaudeAgentClient implements AgentClient {
       logger: this.logger,
       queryFactory: this.queryFactory,
       resolveBinary: this.resolveBinary,
+      runningAsRoot: this.runningAsRoot,
     });
   }
 
@@ -1544,6 +1582,7 @@ export class ClaudeAgentClient implements AgentClient {
       logger: this.logger,
       queryFactory: this.queryFactory,
       resolveBinary: this.resolveBinary,
+      runningAsRoot: this.runningAsRoot,
     });
   }
 
@@ -1563,11 +1602,12 @@ export class ClaudeAgentClient implements AgentClient {
     const models = await runProviderRefreshActivity(context, "settings", () =>
       getClaudeModelsWithSettings(this.logger, this.configDir, claudeCodeVersion),
     );
+    const runtimeModes = modesForRuntime(this.runningAsRoot);
     const modes = detectIneligibleAutoModeTransport(
       createProviderEnv({ baseEnv: process.env, runtimeSettings: this.runtimeSettings }),
     )
-      ? DEFAULT_MODES.filter((mode) => mode.id !== "auto")
-      : DEFAULT_MODES;
+      ? runtimeModes.filter((mode) => mode.id !== "auto")
+      : runtimeModes;
     return {
       models,
       modes,
@@ -2022,6 +2062,7 @@ class ClaudeAgentSession implements AgentSession {
   private readonly logger: Logger;
   private readonly queryFactory?: ClaudeQueryFactory;
   private readonly resolveBinary: () => Promise<string>;
+  private readonly runningAsRoot: boolean;
   private query: Query | null = null;
   private childProcess: ChildProcess | null = null;
   private input: AsyncMessageInput<SDKUserMessage> | null = null;
@@ -2040,7 +2081,7 @@ class ClaudeAgentSession implements AgentSession {
   private persistence: AgentPersistenceHandle | null;
   private currentMode: PermissionMode;
   private planResumeMode: PermissionMode | null = null;
-  private availableModes: AgentMode[] = DEFAULT_MODES;
+  private availableModes: AgentMode[];
   private toolUseCache = new Map<string, ToolUseCacheEntry>();
   private toolUseIndexToId = new Map<number, string>();
   private toolUseInputBuffers = new Map<string, string>();
@@ -2100,6 +2141,8 @@ class ClaudeAgentSession implements AgentSession {
     this.logger = options.logger.child({ agentId: this.agentId });
     this.queryFactory = options.queryFactory;
     this.resolveBinary = options.resolveBinary;
+    this.runningAsRoot = options.runningAsRoot;
+    this.availableModes = modesForRuntime(this.runningAsRoot);
     this.contextUsage = new ClaudeContextUsageState(
       findClaudeModel(this.config.model)?.contextWindowMaxTokens,
     );
@@ -2125,7 +2168,9 @@ class ClaudeAgentSession implements AgentSession {
       );
     }
 
-    this.currentMode = isPermissionMode(config.modeId) ? config.modeId : "default";
+    const configuredMode = isPermissionMode(config.modeId) ? config.modeId : "default";
+    this.currentMode =
+      this.runningAsRoot && configuredMode === "bypassPermissions" ? "default" : configuredMode;
     if (this.currentMode !== "plan") {
       this.planResumeMode = this.currentMode;
     }
@@ -2386,6 +2431,10 @@ class ClaudeAgentSession implements AgentSession {
       throw new Error(
         `Invalid mode '${modeId}' for Claude provider. Valid modes: ${validModesList}`,
       );
+    }
+
+    if (this.runningAsRoot && modeId === "bypassPermissions") {
+      throw new Error(CLAUDE_ROOT_BYPASS_DISABLED_REASON);
     }
 
     const normalized = isPermissionMode(modeId) ? modeId : "default";
@@ -3260,9 +3309,8 @@ class ClaudeAgentSession implements AgentSession {
       includePartialMessages: true,
       permissionMode: this.currentMode,
       // Dynamic mode switching can recreate the underlying Claude query. Keep the
-      // bypass launch capability available so later setPermissionMode("bypassPermissions")
-      // calls do not fail after a model/thinking/rewind-driven restart.
-      allowDangerouslySkipPermissions: true,
+      // bypass launch capability available unless Claude Code forbids the flag for root.
+      ...permissionBypassOptions(this.runningAsRoot),
       agents: this.defaults?.agents,
       canUseTool: this.handlePermissionRequest,
       pathToClaudeCodeExecutable: claudeBinary,
@@ -4516,8 +4564,11 @@ class ClaudeAgentSession implements AgentSession {
       threadStartedSessionId = newSessionId;
       notice = this.createClaudeSessionChangedNotice(existingSessionId, newSessionId);
     }
-    this.availableModes = DEFAULT_MODES;
-    this.currentMode = message.permissionMode;
+    this.availableModes = modesForRuntime(this.runningAsRoot);
+    this.currentMode =
+      this.runningAsRoot && message.permissionMode === "bypassPermissions"
+        ? "default"
+        : message.permissionMode;
     if (this.currentMode !== "plan") {
       this.planResumeMode = this.currentMode;
     }


### PR DESCRIPTION
---
Fixed this in my Paseo fork, offering as PR if there is interest.

The issue: claude didn't work at all in my server setup, where paseo runs as root. This now detects if we're running as root and disables this behavior.

<img width="1062" height="424" alt="image" src="https://github.com/user-attachments/assets/4d96890a-b9ca-4d52-8e02-80d6fba31448" />

The rest of the text is AI generated.

---

## Summary

- detect when the Paseo daemon is running as UID 0 and omit Claude Agent SDK's `allowDangerouslySkipPermissions` launch capability
- expose Claude's Bypass mode as disabled, with an explanation, through the provider catalog
- prevent disabled modes from being selected by composer controls, drafts, workspace setup, schedules, inherited agents, or live mode changes
- skip disabled options during initial focus and directional combobox navigation, and reject keyboard or pointer selection centrally
- preserve protocol compatibility with an optional `disabledReason` mode field

## Why

Claude Code rejects both `--dangerously-skip-permissions` and `--allow-dangerously-skip-permissions` under root. Paseo currently always enables the latter SDK capability so that a session can switch into Bypass mode later, which prevents Claude from launching at all when the daemon runs as root.

This keeps Claude available in normal permission modes while making the unsupported Bypass choice visible but inactive. Server-side validation remains authoritative, so stale clients and persisted configurations cannot reintroduce the rejected flag.

## Verification

- `npx vitest run packages/server/src/server/agent/providers/claude/agent.redesign.test.ts packages/server/src/server/agent/create-agent-mode.test.ts packages/app/src/components/ui/combobox-keyboard.test.ts packages/app/src/composer/agent-controls/mode.test.ts packages/app/src/provider-selection/resolve-agent-form.test.ts --bail=1` (125 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

All verification ran on the isolated one-commit PR branch rebased onto current `upstream/main`.
