### PR TITLE
Stop commit history tests timing out on Windows

### DIFF
--- a/packages/server/src/utils/checkout-git.commits.test.ts
+++ b/packages/server/src/utils/checkout-git.commits.test.ts
@@ -34,6 +34,45 @@ function commitFile(repoDir: string, name: string, content: string, message: str
   commit(repoDir, message);
 }
 
+function importLinearHistory({
+  repoDir,
+  branch,
+  file,
+  subject,
+  count,
+}: {
+  repoDir: string;
+  branch: string;
+  file: string;
+  subject: string;
+  count: number;
+}): void {
+  const startingSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  }).trim();
+  const commands: string[] = [];
+  let parent = startingSha;
+
+  for (let index = 1; index <= count; index += 1) {
+    const blobMark = index * 2 - 1;
+    const commitMark = index * 2;
+    const content = `${index}\n`;
+    const message = `${subject} ${index}`;
+    commands.push(
+      `blob\nmark :${blobMark}\ndata ${Buffer.byteLength(content)}\n${content}`,
+      `commit refs/heads/${branch}\nmark :${commitMark}\ncommitter Test User <test@test.com> ${1_700_000_000 + index} +0000\ndata ${Buffer.byteLength(message)}\n${message}\nfrom ${parent}\nM 100644 :${blobMark} ${file}\n\n`,
+    );
+    parent = `:${commitMark}`;
+  }
+
+  execFileSync("git", ["fast-import", "--quiet"], {
+    cwd: repoDir,
+    input: commands.join(""),
+  });
+  git(["reset", "--hard", branch], repoDir);
+}
+
 function initRepoOnMain(): { repoDir: string; tempDir: string } {
   const tempDir = makeTempDir();
   const repoDir = join(tempDir, "repo");
@@ -165,13 +204,21 @@ describe("listCheckoutCommits", () => {
 
   it("shows every workspace commit followed by at most 10 base commits", async () => {
     const { repoDir } = initRepoOnMain();
-    for (let index = 1; index <= 14; index += 1) {
-      commitFile(repoDir, "base-history.txt", `${index}\n`, `Base ${index}`);
-    }
+    importLinearHistory({
+      repoDir,
+      branch: "main",
+      file: "base-history.txt",
+      subject: "Base",
+      count: 14,
+    });
     git(["checkout", "-b", "feature"], repoDir);
-    for (let index = 1; index <= 24; index += 1) {
-      commitFile(repoDir, "workspace-history.txt", `${index}\n`, `Workspace ${index}`);
-    }
+    importLinearHistory({
+      repoDir,
+      branch: "feature",
+      file: "workspace-history.txt",
+      subject: "Workspace",
+      count: 24,
+    });
 
     const { commits } = await listCheckoutCommits({ cwd: repoDir });
 
@@ -207,9 +254,13 @@ describe("listCheckoutCommits", () => {
 
   it("limits base-branch history to 10 commits", async () => {
     const { repoDir } = initRepoOnMain();
-    for (let index = 1; index <= 14; index += 1) {
-      commitFile(repoDir, "history.txt", `${index}\n`, `Commit ${index}`);
-    }
+    importLinearHistory({
+      repoDir,
+      branch: "main",
+      file: "history.txt",
+      subject: "Commit",
+      count: 14,
+    });
 
     const { commits } = await listCheckoutCommits({ cwd: repoDir });
 


### PR DESCRIPTION
### Linked issue

None. This fixes the failure observed in [CI run 30650931797](https://github.com/getpaseo/paseo/actions/runs/30650931797/job/91223818415).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

The commit-history fixture created 38 commits by launching roughly 80 separate Git processes. That exceeded Vitest's 30-second timeout on a loaded Windows runner and left a Git process holding the temporary repository during cleanup.

Bulk histories now use one real `git fast-import` stream per branch. Coverage and production behavior are unchanged while the platform-sensitive process-launch overhead is removed.

### How did you verify it

- Confirmed the linked Windows job timed out in `shows every workspace commit followed by at most 10 base commits`, followed by the expected `EBUSY` cleanup error.
- `npx vitest run src/utils/checkout-git.commits.test.ts --bail=1` — 12 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format` and `git diff --check` — passed.
- The PR's Windows server-test job is the affected-platform verification surface.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense