### PR TITLE
Stop terminal environment tests failing intermittently on Windows

### DIFF
--- a/packages/server/src/terminal/terminal-manager.test.ts
+++ b/packages/server/src/terminal/terminal-manager.test.ts
@@ -202,7 +202,10 @@ it("inherits registered env for the worktree root cwd", async () => {
     ],
   });
 
-  await waitForCondition(() => existsSync(markerPath), 10000);
+  await waitForCondition(
+    () => existsSync(markerPath) && readFileSync(markerPath, "utf8") === "45678",
+    10000,
+  );
   expect(readFileSync(markerPath, "utf8")).toBe("45678");
 });
 
@@ -228,7 +231,10 @@ it("inherits registered env for subdirectories within the worktree", async () =>
     ],
   });
 
-  await waitForCondition(() => existsSync(markerPath), 10000);
+  await waitForCondition(
+    () => existsSync(markerPath) && readFileSync(markerPath, "utf8") === "45679",
+    10000,
+  );
   expect(readFileSync(markerPath, "utf8")).toBe("45679");
 });
 


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

The terminal environment tests now wait for the marker file to contain the expected port instead of treating file creation as completion. Windows could expose the newly created file before the child process finished writing it, causing an intermittent empty-string assertion failure.

This changes test synchronization only; production terminal behavior is unchanged. The CI Windows server job covers the affected surface.

### How did you verify it

- Reproduced the readiness race: the marker was observable as an empty string before finishing as `45679`.
- `npx vitest run src/terminal/terminal-manager.test.ts --bail=1` from `packages/server`: 38 tests passed.
- `npm run typecheck`: passed across all workspaces.
- `npm run lint -- packages/server/src/terminal/terminal-manager.test.ts`: 0 warnings and 0 errors.
- `npm run format`: passed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense