### PR TITLE
Make sidebar shortcuts leave focus mode

### DIFF
--- a/packages/app/e2e/workspace-focus-mode.spec.ts
+++ b/packages/app/e2e/workspace-focus-mode.spec.ts
@@ -1,23 +1,48 @@
-import { expect, test } from "./fixtures";
+import { expect, test, type Page } from "./fixtures";
 
 const modifier = process.platform === "darwin" ? "Meta" : "Control";
 
-async function pressFocusModeShortcut(page: import("@playwright/test").Page) {
+async function pressFocusModeShortcut(page: Page) {
   await page.keyboard.press(`${modifier}+Shift+F`);
 }
 
-async function pressSettingsShortcut(page: import("@playwright/test").Page) {
+async function pressSettingsShortcut(page: Page) {
   await page.keyboard.press(`${modifier}+Comma`);
 }
 
-async function blurActiveElement(page: import("@playwright/test").Page) {
+async function pressRightSidebarShortcut(page: Page) {
+  await page.keyboard.press(`${modifier}+E`);
+}
+
+async function blurActiveElement(page: Page) {
   await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
 }
+
+function exitFocusModeButton(page: Page) {
+  return page.getByRole("button", { name: "Exit focus mode" });
+}
+
+async function enterFocusMode(page: Page) {
+  await blurActiveElement(page);
+  await pressFocusModeShortcut(page);
+  await expect(exitFocusModeButton(page)).toBeVisible();
+}
+
+test("sidebar shortcuts exit focus mode before executing", async ({ page, withWorkspace }) => {
+  const workspace = await withWorkspace({ prefix: "focus-mode-sidebar-shortcut-" });
+  await workspace.navigateTo();
+  await enterFocusMode(page);
+
+  await pressRightSidebarShortcut(page);
+
+  await expect(exitFocusModeButton(page)).toHaveCount(0);
+  await expect(page.getByText("Changes", { exact: true })).toBeVisible();
+});
 
 test("focus mode only applies to the active workspace screen", async ({ page, withWorkspace }) => {
   const workspace = await withWorkspace({ prefix: "focus-mode-boundary-" });
   await workspace.navigateTo();
-  const exitFocusMode = page.getByRole("button", { name: "Exit focus mode" });
+  const exitFocusMode = exitFocusModeButton(page);
   const settingsButton = page.getByRole("button", { name: "Settings", exact: true });
   const settingsSidebar = page.getByRole("navigation", { name: "Settings" });
 

--- a/packages/app/e2e/workspace-focus-mode.spec.ts
+++ b/packages/app/e2e/workspace-focus-mode.spec.ts
@@ -14,6 +14,10 @@ async function pressRightSidebarShortcut(page: Page) {
   await page.keyboard.press(`${modifier}+E`);
 }
 
+async function returnToWorkspace(page: Page, workspaceUrl: string) {
+  await page.goto(workspaceUrl);
+}
+
 async function blurActiveElement(page: Page) {
   await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
 }
@@ -28,7 +32,10 @@ async function enterFocusMode(page: Page) {
   await expect(exitFocusModeButton(page)).toBeVisible();
 }
 
-test("sidebar shortcuts exit focus mode before executing", async ({ page, withWorkspace }) => {
+test("sidebar shortcuts exit focus mode and execute their action", async ({
+  page,
+  withWorkspace,
+}) => {
   const workspace = await withWorkspace({ prefix: "focus-mode-sidebar-shortcut-" });
   await workspace.navigateTo();
   await enterFocusMode(page);
@@ -37,6 +44,24 @@ test("sidebar shortcuts exit focus mode before executing", async ({ page, withWo
 
   await expect(exitFocusModeButton(page)).toHaveCount(0);
   await expect(page.getByText("Changes", { exact: true })).toBeVisible();
+});
+
+test("sidebar shortcuts outside a workspace preserve its focus mode", async ({
+  page,
+  withWorkspace,
+}) => {
+  const workspace = await withWorkspace({ prefix: "focus-mode-sidebar-boundary-" });
+  await workspace.navigateTo();
+  await enterFocusMode(page);
+  const workspaceUrl = page.url();
+
+  await pressSettingsShortcut(page);
+  await expect(page.getByRole("navigation", { name: "Settings" })).toBeVisible();
+
+  await pressRightSidebarShortcut(page);
+  await returnToWorkspace(page, workspaceUrl);
+
+  await expect(exitFocusModeButton(page)).toBeVisible();
 });
 
 test("focus mode only applies to the active workspace screen", async ({ page, withWorkspace }) => {
@@ -66,7 +91,7 @@ test("focus mode only applies to the active workspace screen", async ({ page, wi
   await expect(exitFocusMode).toHaveCount(0);
 
   await pressFocusModeShortcut(page);
-  await page.goto(workspaceUrl);
+  await returnToWorkspace(page, workspaceUrl);
 
   await expect(exitFocusMode).toBeVisible();
   await exitFocusMode.click();

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -473,6 +473,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
   useKeyboardShortcuts({
     enabled: keyboardShortcutsEnabled,
     isMobile: isCompactLayout,
+    isWorkspaceFocusModeEnabled,
     toggleAgentList,
     toggleBothSidebars: toggleDesktopSidebars,
     exitFocusMode,

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -428,6 +428,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
   const openDesktopAgentList = usePanelStore((state) => state.openDesktopAgentList);
   const closeDesktopAgentList = usePanelStore((state) => state.closeDesktopAgentList);
   const closeDesktopFileExplorer = usePanelStore((state) => state.closeDesktopFileExplorer);
+  const exitFocusMode = usePanelStore((state) => state.exitFocusMode);
   const isFocusModeEnabled = usePanelStore((state) => state.desktop.focusModeEnabled);
   const isDesktopAgentListOpen = usePanelStore((state) => state.desktop.agentListOpen);
   const isDesktopFileExplorerOpen = usePanelStore((state) => state.desktop.fileExplorerOpen);
@@ -474,6 +475,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
     isMobile: isCompactLayout,
     toggleAgentList,
     toggleBothSidebars: toggleDesktopSidebars,
+    exitFocusMode,
     cycleTheme,
   });
 

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -42,12 +42,14 @@ export function useKeyboardShortcuts({
   isMobile,
   toggleAgentList,
   toggleBothSidebars,
+  exitFocusMode,
   cycleTheme,
 }: {
   enabled: boolean;
   isMobile: boolean;
   toggleAgentList: () => void;
   toggleBothSidebars?: () => void;
+  exitFocusMode: () => void;
   cycleTheme?: () => void;
 }) {
   const pathname = usePathname();
@@ -207,11 +209,15 @@ export function useKeyboardShortcuts({
           shortcutsDialogOpen: store.shortcutsDialogOpen,
         },
       );
-      return performShortcutAction(
+      const handled = performShortcutAction(
         shortcutAction,
         input.domEvent,
         input.browserFocusRestoreElement,
       );
+      if (handled && input.action.startsWith("sidebar.")) {
+        exitFocusMode();
+      }
+      return handled;
     };
 
     const resolveAndPerformShortcut = (input: {
@@ -371,6 +377,7 @@ export function useKeyboardShortcuts({
     bindings,
     cycleTheme,
     enabled,
+    exitFocusMode,
     activeWorkspaceSelection,
     isDesktopApp,
     isMac,

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -40,6 +40,7 @@ import {
 export function useKeyboardShortcuts({
   enabled,
   isMobile,
+  isWorkspaceFocusModeEnabled,
   toggleAgentList,
   toggleBothSidebars,
   exitFocusMode,
@@ -47,6 +48,7 @@ export function useKeyboardShortcuts({
 }: {
   enabled: boolean;
   isMobile: boolean;
+  isWorkspaceFocusModeEnabled: boolean;
   toggleAgentList: () => void;
   toggleBothSidebars?: () => void;
   exitFocusMode: () => void;
@@ -209,14 +211,15 @@ export function useKeyboardShortcuts({
           shortcutsDialogOpen: store.shortcutsDialogOpen,
         },
       );
-      if (shortcutAction.kind !== "none" && input.action.startsWith("sidebar.")) {
-        exitFocusMode();
-      }
-      return performShortcutAction(
+      const handled = performShortcutAction(
         shortcutAction,
         input.domEvent,
         input.browserFocusRestoreElement,
       );
+      if (handled && isWorkspaceFocusModeEnabled && input.action.startsWith("sidebar.")) {
+        exitFocusMode();
+      }
+      return handled;
     };
 
     const resolveAndPerformShortcut = (input: {
@@ -381,6 +384,7 @@ export function useKeyboardShortcuts({
     isDesktopApp,
     isMac,
     isMobile,
+    isWorkspaceFocusModeEnabled,
     openProjectPickerAction,
     pathname,
     publishBrowserShortcutPolicy,

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -209,15 +209,14 @@ export function useKeyboardShortcuts({
           shortcutsDialogOpen: store.shortcutsDialogOpen,
         },
       );
-      const handled = performShortcutAction(
+      if (shortcutAction.kind !== "none" && input.action.startsWith("sidebar.")) {
+        exitFocusMode();
+      }
+      return performShortcutAction(
         shortcutAction,
         input.domEvent,
         input.browserFocusRestoreElement,
       );
-      if (handled && input.action.startsWith("sidebar.")) {
-        exitFocusMode();
-      }
-      return handled;
     };
 
     const resolveAndPerformShortcut = (input: {

--- a/packages/app/src/stores/panel-store/index.ts
+++ b/packages/app/src/stores/panel-store/index.ts
@@ -90,6 +90,7 @@ export interface PanelState {
 
   // Actions
   toggleFocusMode: () => void;
+  exitFocusMode: () => void;
   showMobileAgent: () => void;
   showMobileAgentList: () => void;
   toggleMobileAgentList: () => void;
@@ -156,6 +157,13 @@ export const usePanelStore = create<PanelState>()(
         set((state) => ({
           desktop: { ...state.desktop, focusModeEnabled: !state.desktop.focusModeEnabled },
         })),
+
+      exitFocusMode: () =>
+        set((state) =>
+          state.desktop.focusModeEnabled
+            ? { desktop: { ...state.desktop, focusModeEnabled: false } }
+            : state,
+        ),
 
       showMobileAgent: () => set((state) => setMobilePanelTargetPatch(state, "agent")),
 


### PR DESCRIPTION
### Linked issue

Refs #2128

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

Sidebar toggle shortcuts now execute and leave active workspace focus mode. Previously Ctrl/Cmd+E updated explorer state while focus mode kept the sidebar hidden, so the keypress appeared to do nothing.

Focus exits only when workspace focus is active and the routed sidebar action reports handled. Sidebar shortcuts on Settings leave the retained workspace focus state unchanged.

### How did you verify it

- Reproduced the original bug first with `npm run test:e2e --workspace=@getpaseo/app -- e2e/workspace-focus-mode.spec.ts`: “Exit focus mode” remained present after Ctrl/Cmd+E.
- Added a failing-first route-boundary regression: enter focus mode, open Settings, press Ctrl/Cmd+E, return to the workspace, and verify focus mode remains enabled.
- Ran the complete focused Playwright spec after both fixes: 3 passed.
- `npm run typecheck`
- `npm run lint` — 0 warnings/errors.
- `npm run format`

Platform coverage:

- Web Chrome: tested via real Playwright browser, app, network, and isolated daemon.
- Electron macOS/Windows/Linux: not manually tested; they share shortcut execution but browser-forwarded Electron input remains a CI/manual risk.
- iOS/Android: not affected because global desktop shortcuts are disabled on native/compact layouts.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
