### PR TITLE
fix(app): make selectors keyboard searchable

### DIFF
--- a/packages/app/e2e/browser/new-workspace-codex-mode-preferences.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-codex-mode-preferences.spec.ts
@@ -114,6 +114,12 @@ async function expectThinkingOptionsFit(page: Page): Promise<void> {
   await expect(popup).toBeVisible({ timeout: 10_000 });
   await expectNoTruncation(popup);
 
+  const searchInput = popup.getByPlaceholder("Search...");
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill("Extra high");
+  await expect(popup.getByText("Extra high", { exact: true })).toBeVisible();
+  await expect(popup.getByText("Low", { exact: true })).toHaveCount(0);
+
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("combobox-desktop-container")).toHaveCount(0, { timeout: 5_000 });
 }

--- a/packages/app/e2e/browser/new-workspace.spec.ts
+++ b/packages/app/e2e/browser/new-workspace.spec.ts
@@ -280,6 +280,10 @@ test.describe("New workspace flow", () => {
       await page.keyboard.press("Escape");
 
       await page.getByTestId("host-picker-trigger").click();
+      await page.getByPlaceholder("Search hosts").fill("Empty");
+      await expect(
+        page.getByTestId(`new-workspace-host-picker-option-${primaryServerId}`),
+      ).toHaveCount(0);
       await page.getByTestId(`new-workspace-host-picker-option-${emptyServerId}`).click();
       await expect(projectTrigger).toContainText("Choose project");
       await projectTrigger.click();

--- a/packages/app/e2e/support/helpers/isolated-host-daemon.ts
+++ b/packages/app/e2e/support/helpers/isolated-host-daemon.ts
@@ -161,6 +161,9 @@ export async function startIsolatedHostDaemon(
       cwd: serverDir,
       env: withDisabledE2ESpeechEnv({
         ...process.env,
+        // Test hosts must not inherit auth from the developer's daemon. A test
+        // can still opt into password auth through options.environment.
+        PASEO_PASSWORD: undefined,
         ...options.environment,
         PASEO_HOME: paseoHome,
         PASEO_SERVER_ID: serverId,

--- a/packages/app/src/components/hosts/host-filter.tsx
+++ b/packages/app/src/components/hosts/host-filter.tsx
@@ -69,7 +69,6 @@ export function HostFilter({
       onOpenChange={setIsFilterOpen}
       anchorRef={filterAnchorRef}
       includeAllHost={includeAllHost}
-      searchable={false}
       title="Filter by host"
       desktopPlacement="bottom-start"
       hostOptionTestID={hostOptionTestID}

--- a/packages/app/src/components/hosts/host-picker.tsx
+++ b/packages/app/src/components/hosts/host-picker.tsx
@@ -22,7 +22,6 @@ export {
   getHostPickerLabel,
 };
 
-const SEARCHABLE_THRESHOLD = 10;
 type RenderHostOption = NonNullable<ComboboxProps["renderOption"]>;
 interface HostPickerHost {
   serverId: string;
@@ -174,6 +173,7 @@ export interface HostPickerProps {
   onEnableBuiltInDaemon?: () => void;
   showActiveConnection?: boolean;
   onOpenHostSettings?: (serverId: string) => void;
+  /** Host pickers search by default; pass `false` for a picker that is always short. */
   searchable?: boolean;
   title?: string;
   desktopPlacement?: ComboboxProps["desktopPlacement"];
@@ -197,7 +197,7 @@ export function HostPicker({
   onEnableBuiltInDaemon,
   showActiveConnection,
   onOpenHostSettings,
-  searchable,
+  searchable = true,
   title,
   desktopPlacement = "bottom-start",
   desktopMinWidth,
@@ -212,18 +212,21 @@ export function HostPicker({
   );
 
   const options = useMemo(() => {
-    const hostOptions = orderedHosts.map((host) => ({ id: host.serverId, label: host.label }));
+    const hostOptions: ComboboxProps["options"] = orderedHosts.map((host) => ({
+      id: host.serverId,
+      label: host.label,
+    }));
     if (includeAllHost) hostOptions.unshift({ id: ALL_HOSTS_OPTION_ID, label: "All hosts" });
-    if (includeAddHost) hostOptions.push({ id: ADD_HOST_OPTION_ID, label: "Add host" });
+    if (includeAddHost)
+      hostOptions.push({ id: ADD_HOST_OPTION_ID, label: "Add host", alwaysVisible: true });
     if (includeEnableBuiltInDaemon)
       hostOptions.push({
         id: ENABLE_BUILT_IN_DAEMON_OPTION_ID,
         label: "Enable built-in daemon",
+        alwaysVisible: true,
       });
     return hostOptions;
   }, [orderedHosts, includeAllHost, includeAddHost, includeEnableBuiltInDaemon]);
-
-  const isSearchable = searchable === true && orderedHosts.length > SEARCHABLE_THRESHOLD;
 
   const handleSelect = useCallback(
     (id: string) => {
@@ -305,7 +308,7 @@ export function HostPicker({
         value={value}
         onSelect={handleSelect}
         renderOption={renderOption}
-        searchable={isSearchable}
+        searchable={searchable}
         searchPlaceholder="Search hosts"
         title={title ?? "Host"}
         open={open}

--- a/packages/app/src/components/hosts/host-picker.tsx
+++ b/packages/app/src/components/hosts/host-picker.tsx
@@ -173,8 +173,6 @@ export interface HostPickerProps {
   onEnableBuiltInDaemon?: () => void;
   showActiveConnection?: boolean;
   onOpenHostSettings?: (serverId: string) => void;
-  /** Host pickers search by default; pass `false` for a picker that is always short. */
-  searchable?: boolean;
   title?: string;
   desktopPlacement?: ComboboxProps["desktopPlacement"];
   desktopMinWidth?: number;
@@ -197,7 +195,6 @@ export function HostPicker({
   onEnableBuiltInDaemon,
   showActiveConnection,
   onOpenHostSettings,
-  searchable = true,
   title,
   desktopPlacement = "bottom-start",
   desktopMinWidth,
@@ -308,7 +305,6 @@ export function HostPicker({
         value={value}
         onSelect={handleSelect}
         renderOption={renderOption}
-        searchable={searchable}
         searchPlaceholder="Search hosts"
         title={title ?? "Host"}
         open={open}

--- a/packages/app/src/components/import-session-sheet.tsx
+++ b/packages/app/src/components/import-session-sheet.tsx
@@ -520,7 +520,6 @@ export function ImportSessionSheet({
             value={selectedProvider}
             onSelect={handleFilterSelect}
             renderOption={renderFilterOption}
-            searchable={false}
             title="Filter by provider"
             open={isFilterOpen}
             onOpenChange={setIsFilterOpen}

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -449,7 +449,6 @@ function SidebarHostPicker({
       onAddHost={onAddHost}
       showActiveConnection
       onOpenHostSettings={onOpenHostSettings}
-      searchable
       desktopPlacement="top-start"
       desktopMinWidth={240}
       addHostTestID="sidebar-host-add"

--- a/packages/app/src/components/schedules/cadence-editor.tsx
+++ b/packages/app/src/components/schedules/cadence-editor.tsx
@@ -97,7 +97,6 @@ export function CadenceEditor({ value, onChange, error, size = "md" }: CadenceEd
           onChange={handlePresetChange}
           placeholder="Select cadence"
           emptyText="No cadences found"
-          searchable={false}
           title="Cadence"
           size={size}
           triggerTestID="schedule-cadence-preset-trigger"

--- a/packages/app/src/components/schedules/schedule-form-sheet.tsx
+++ b/packages/app/src/components/schedules/schedule-form-sheet.tsx
@@ -17,7 +17,6 @@ import type { ScheduleCadence, ScheduleSummary } from "@getpaseo/protocol/schedu
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { AdaptiveModalSheet, type SheetHeader } from "@/components/adaptive-modal-sheet";
 import { ComboboxItem } from "@/components/ui/combobox";
-import { SEARCHABLE_OPTION_THRESHOLD } from "@/components/ui/combobox-options";
 import { Button } from "@/components/ui/button";
 import { CombinedModelSelector } from "@/components/combined-model-selector";
 import { useIsCompactFormFactor } from "@/constants/layout";
@@ -713,7 +712,6 @@ function ScheduleTargetFields({
           placeholder="Select host"
           emptyText="No hosts found"
           disabled={state.mode === "edit"}
-          searchable
           searchPlaceholder="Search hosts"
           title="Host"
           size={controlSize}
@@ -733,7 +731,6 @@ function ScheduleTargetFields({
           emptyText="No projects found"
           disabled={!state.selectedServerId}
           hint={!state.selectedServerId ? "Choose a host first." : undefined}
-          searchable
           searchPlaceholder="Search projects..."
           title="Select project"
           size={controlSize}
@@ -770,7 +767,6 @@ function ScheduleTargetFields({
           onChange={handleSelectThinking}
           placeholder="Select thinking"
           emptyText="No thinking options found"
-          searchable={thinkingOptions.length > SEARCHABLE_OPTION_THRESHOLD}
           title="Select thinking"
           size={controlSize}
           triggerTestID="schedule-thinking-trigger"
@@ -789,7 +785,6 @@ function ScheduleTargetFields({
           emptyText="No modes found"
           disabled={modeOptions.length === 0}
           hint={modeOptions.length === 0 ? "No modes are available for this model." : undefined}
-          searchable={modeOptions.length > SEARCHABLE_OPTION_THRESHOLD}
           title="Select mode"
           size={controlSize}
           triggerTestID="schedule-mode-trigger"
@@ -878,7 +873,6 @@ function ScheduleIsolationField({
       onChange={handleSelectIsolation}
       placeholder="Select isolation"
       emptyText="No isolation options found"
-      searchable={false}
       title="Isolation"
       size={size}
       testID="schedule-isolation"

--- a/packages/app/src/components/schedules/schedule-form-sheet.tsx
+++ b/packages/app/src/components/schedules/schedule-form-sheet.tsx
@@ -17,6 +17,7 @@ import type { ScheduleCadence, ScheduleSummary } from "@getpaseo/protocol/schedu
 import { useStoreWithEqualityFn } from "zustand/traditional";
 import { AdaptiveModalSheet, type SheetHeader } from "@/components/adaptive-modal-sheet";
 import { ComboboxItem } from "@/components/ui/combobox";
+import { SEARCHABLE_OPTION_THRESHOLD } from "@/components/ui/combobox-options";
 import { Button } from "@/components/ui/button";
 import { CombinedModelSelector } from "@/components/combined-model-selector";
 import { useIsCompactFormFactor } from "@/constants/layout";
@@ -712,7 +713,8 @@ function ScheduleTargetFields({
           placeholder="Select host"
           emptyText="No hosts found"
           disabled={state.mode === "edit"}
-          searchable={false}
+          searchable
+          searchPlaceholder="Search hosts"
           title="Host"
           size={controlSize}
           triggerTestID="schedule-host-trigger"
@@ -768,7 +770,7 @@ function ScheduleTargetFields({
           onChange={handleSelectThinking}
           placeholder="Select thinking"
           emptyText="No thinking options found"
-          searchable={thinkingOptions.length > 6}
+          searchable={thinkingOptions.length > SEARCHABLE_OPTION_THRESHOLD}
           title="Select thinking"
           size={controlSize}
           triggerTestID="schedule-thinking-trigger"
@@ -787,7 +789,7 @@ function ScheduleTargetFields({
           emptyText="No modes found"
           disabled={modeOptions.length === 0}
           hint={modeOptions.length === 0 ? "No modes are available for this model." : undefined}
-          searchable={modeOptions.length > 6}
+          searchable={modeOptions.length > SEARCHABLE_OPTION_THRESHOLD}
           title="Select mode"
           size={controlSize}
           triggerTestID="schedule-mode-trigger"

--- a/packages/app/src/components/ui/combobox-options.test.ts
+++ b/packages/app/src/components/ui/combobox-options.test.ts
@@ -89,6 +89,21 @@ describe("filterAndRankComboboxOptions", () => {
     expect(filterAndRankComboboxOptions(options, "zzz")).toEqual([]);
   });
 
+  it("keeps always-visible actions after filtered matches", () => {
+    const items = [
+      { id: "host-a", label: "Host A" },
+      { id: "host-b", label: "Host B" },
+      { id: "add-host", label: "Add host", alwaysVisible: true },
+      { id: "enable-daemon", label: "Enable built-in daemon", alwaysVisible: true },
+    ];
+
+    expect(filterAndRankComboboxOptions(items, "host b")).toEqual([
+      { id: "host-b", label: "Host B" },
+      { id: "add-host", label: "Add host", alwaysVisible: true },
+      { id: "enable-daemon", label: "Enable built-in daemon", alwaysVisible: true },
+    ]);
+  });
+
   it("ranks word-boundary matches above mid-word substring matches", () => {
     const items = [
       { id: "happy", label: "happy" },

--- a/packages/app/src/components/ui/combobox-options.ts
+++ b/packages/app/src/components/ui/combobox-options.ts
@@ -6,11 +6,16 @@ import {
 
 export type ComboboxOptionKind = "directory" | "file";
 
+// Pickers whose option count varies with the model or provider turn search on
+// past this length. Below it the search row costs more than it saves.
+export const SEARCHABLE_OPTION_THRESHOLD = 6;
+
 export interface ComboboxOptionModel {
   id: string;
   label: string;
   description?: string;
   kind?: ComboboxOptionKind;
+  alwaysVisible?: boolean;
 }
 
 const DESCRIPTION_FALLBACK_TIER = 99;
@@ -58,7 +63,12 @@ export function filterAndRankComboboxOptions(
 ): ComboboxOptionModel[] {
   if (!search) return options;
   const scored: { opt: ComboboxOptionModel; score: MatchScore }[] = [];
+  const alwaysVisible: ComboboxOptionModel[] = [];
   for (const opt of options) {
+    if (opt.alwaysVisible) {
+      alwaysVisible.push(opt);
+      continue;
+    }
     const score = scoreOption(opt, search);
     if (score) scored.push({ opt, score });
   }
@@ -67,7 +77,7 @@ export function filterAndRankComboboxOptions(
     if (cmp !== 0) return cmp;
     return a.opt.label.localeCompare(b.opt.label);
   });
-  return scored.map((entry) => entry.opt);
+  return [...scored.map((entry) => entry.opt), ...alwaysVisible];
 }
 
 export function buildVisibleComboboxOptions(

--- a/packages/app/src/components/ui/combobox-options.ts
+++ b/packages/app/src/components/ui/combobox-options.ts
@@ -6,10 +6,6 @@ import {
 
 export type ComboboxOptionKind = "directory" | "file";
 
-// Pickers whose option count varies with the model or provider turn search on
-// past this length. Below it the search row costs more than it saves.
-export const SEARCHABLE_OPTION_THRESHOLD = 6;
-
 export interface ComboboxOptionModel {
   id: string;
   label: string;

--- a/packages/app/src/components/ui/select-field.tsx
+++ b/packages/app/src/components/ui/select-field.tsx
@@ -182,7 +182,7 @@ export function SelectField<TValue>({
   disabled = false,
   hint,
   error,
-  searchable = false,
+  searchable = true,
   searchPlaceholder,
   title,
   size = "md",

--- a/packages/app/src/composer/agent-controls/index.tsx
+++ b/packages/app/src/composer/agent-controls/index.tsx
@@ -39,7 +39,6 @@ import { useProvidersSnapshot } from "@/hooks/use-providers-snapshot";
 import { resolveProviderDefinition } from "@/utils/provider-definitions";
 import { mergeProviderPreferences, useFormPreferences } from "@/hooks/use-form-preferences";
 import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
-import { SEARCHABLE_OPTION_THRESHOLD } from "@/components/ui/combobox-options";
 import {
   AgentModeControl,
   useLiveAgentModeControl,
@@ -970,7 +969,6 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
             options={comboboxProviderOptions}
             value={selectedProviderId ?? ""}
             onSelect={handleProviderSelect}
-            searchable={comboboxProviderOptions.length > SEARCHABLE_OPTION_THRESHOLD}
             open={openSelector === "provider"}
             onOpenChange={handleProviderOpenChange}
             anchorRef={providerAnchorRef}
@@ -1041,7 +1039,6 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
             options={comboboxThinkingOptions}
             value={selectedThinkingOptionId ?? ""}
             onSelect={handleThinkingSelect}
-            searchable={comboboxThinkingOptions.length > SEARCHABLE_OPTION_THRESHOLD}
             open={openSelector === "thinking"}
             onOpenChange={handleThinkingOpenChange}
             anchorRef={thinkingAnchorRef}
@@ -1222,7 +1219,6 @@ function SheetAgentControlsContent(props: SheetAgentControlsContentProps) {
             options={comboboxThinkingOptions}
             value={selectedThinkingOptionId ?? ""}
             onSelect={handleSelectThinkingAndClose}
-            searchable={false}
             title={t("agentControls.thinking.title")}
             open={activeSheet === "thinking"}
             onOpenChange={handleThinkingSheetOpenChange}

--- a/packages/app/src/composer/agent-controls/index.tsx
+++ b/packages/app/src/composer/agent-controls/index.tsx
@@ -39,6 +39,7 @@ import { useProvidersSnapshot } from "@/hooks/use-providers-snapshot";
 import { resolveProviderDefinition } from "@/utils/provider-definitions";
 import { mergeProviderPreferences, useFormPreferences } from "@/hooks/use-form-preferences";
 import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
+import { SEARCHABLE_OPTION_THRESHOLD } from "@/components/ui/combobox-options";
 import {
   AgentModeControl,
   useLiveAgentModeControl,
@@ -886,8 +887,6 @@ interface DesktopAgentControlsContentProps {
   modelSelectorServerId: string | null;
 }
 
-const DESKTOP_SEARCH_THRESHOLD = 6;
-
 function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -971,7 +970,7 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
             options={comboboxProviderOptions}
             value={selectedProviderId ?? ""}
             onSelect={handleProviderSelect}
-            searchable={comboboxProviderOptions.length > DESKTOP_SEARCH_THRESHOLD}
+            searchable={comboboxProviderOptions.length > SEARCHABLE_OPTION_THRESHOLD}
             open={openSelector === "provider"}
             onOpenChange={handleProviderOpenChange}
             anchorRef={providerAnchorRef}
@@ -1042,7 +1041,7 @@ function DesktopAgentControlsContent(props: DesktopAgentControlsContentProps) {
             options={comboboxThinkingOptions}
             value={selectedThinkingOptionId ?? ""}
             onSelect={handleThinkingSelect}
-            searchable={comboboxThinkingOptions.length > DESKTOP_SEARCH_THRESHOLD}
+            searchable={comboboxThinkingOptions.length > SEARCHABLE_OPTION_THRESHOLD}
             open={openSelector === "thinking"}
             onOpenChange={handleThinkingOpenChange}
             anchorRef={thinkingAnchorRef}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -1410,7 +1410,6 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
         open={host.openState}
         onOpenChange={host.onOpenChange}
         anchorRef={host.anchorRef}
-        searchable={false}
         title="Host"
         desktopPlacement="bottom-start"
         desktopMinWidth={200}

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -948,7 +948,6 @@ function HostPicker({
       includeEnableBuiltInDaemon={enableBuiltInDaemonOption.visible}
       onEnableBuiltInDaemon={enableBuiltInDaemonOption.onPress}
       showActiveConnection
-      searchable={false}
       title={t("settings.hostPicker.switchHost")}
       desktopMinWidth={240}
       addHostTestID="settings-add-host"

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -733,7 +733,6 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
         options={tabSwitcherOptions}
         value={activeTabKey}
         onSelect={onSelectSwitcherTab}
-        searchable={false}
         title={t("workspace.tabs.switcher.title")}
         searchPlaceholder={t("workspace.tabs.switcher.searchPlaceholder")}
         open={isOpen}


### PR DESCRIPTION
Fixes #2726

## Problem

Selector searchability was controlled independently by wrappers, call sites, and option-count thresholds. `Combobox` already defaults to searchable, but:

- `HostPicker` only enabled search when explicitly opted in and more than 10 hosts existed.
- `SelectField` defaulted search off.
- Provider, thinking effort, and schedule mode selectors only enabled search above six options.
- Compact thinking effort, workspace tabs, cadence, isolation, and import-provider selectors explicitly disabled search.

That made keyboard filtering depend on the surface and option count. In particular, normal thinking-effort lists were too short to cross the threshold.

## Change

- Make `SelectField` searchable by default, matching `Combobox`.
- Remove all product-level `searchable={false}` overrides and option-count search thresholds.
- Make host pickers unconditionally searchable and remove their opt-out prop.
- Keep host action rows such as **Add host** and **Enable built-in daemon** visible while filtering, after matched hosts.
- Match host search against both label and server ID through the shared combobox scorer.
- Prevent isolated E2E daemons from inheriting the developer daemon's `PASEO_PASSWORD`; tests can still opt into password auth explicitly.

Every option-list `Combobox` and `SelectField` in the app is now keyboard searchable regardless of list length. The low-level primitives still support `searchable={false}` if a non-product use needs it later.

## Tests

- Extended the existing two-host new-workspace browser case to type into host search, verify the non-match disappears, and select the match.
- Extended the Codex controls browser case to search a normal short thinking-effort list for **Extra high** and verify **Low** is filtered out.
- Added unit coverage proving always-visible host actions remain after filtered matches.

## QA

Local checks:

```text
npm run format
npm run typecheck
npm run lint -- <changed files>
npx vitest run packages/app/src/components/ui/combobox-options.test.ts --bail=1
npm run test:e2e --workspace=@getpaseo/app -- \
  e2e/browser/new-workspace-codex-mode-preferences.spec.ts \
  --grep "keeps Full Access"

Test Files  1 passed (1)
Tests      16 passed (16)
Playwright 1 passed (1)
```

The first local Playwright attempt exposed that Paseo-hosted shells pass `PASEO_PASSWORD` to child processes. The isolated E2E daemon inherited it while its seed client intentionally connected without credentials, so fixture setup timed out. The harness now removes inherited password auth, and the targeted effort-search case passes without unsetting the parent environment. The local run used the Nix-packaged browser and CI-pinned Codex 0.105. Mobile bottom-sheet behavior was not exercised locally.
