### PR TITLE
Bound structured metadata generation so it can't orphan provider processes

### DIFF
--- a/packages/server/src/server/agent/agent-response-loop.real.e2e.test.ts
+++ b/packages/server/src/server/agent/agent-response-loop.real.e2e.test.ts
@@ -186,17 +186,18 @@ async function startSinkhole(): Promise<SinkholeHandle> {
   };
 }
 
-// The provider CLI runs as a child of this process, so a leak is visible in the
-// process table and nowhere else.
+// A leaked provider CLI is visible in the process table and nowhere else.
+// Restricted to this process's own children: the developer running this may well
+// have their own daemon spawning claude CLIs, and those must not count.
 function providerCliPids(): Set<string> {
-  const out = execFileSync("ps", ["-eo", "pid,args"], { encoding: "utf8" });
+  const out = execFileSync("ps", ["-eo", "pid,ppid,args"], { encoding: "utf8" });
   const pids = new Set<string>();
   for (const line of out.split("\n")) {
     if (!line.includes("--output-format stream-json")) {
       continue;
     }
-    const pid = line.trim().split(/\s+/)[0];
-    if (pid) {
+    const [pid, ppid] = line.trim().split(/\s+/);
+    if (pid && ppid === String(process.pid)) {
       pids.add(pid);
     }
   }

--- a/packages/server/src/server/agent/agent-response-loop.real.e2e.test.ts
+++ b/packages/server/src/server/agent/agent-response-loop.real.e2e.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
 import { createServer } from "http";
+import { createServer as createSocketServer, type Socket } from "net";
+import { execFileSync } from "child_process";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
@@ -8,11 +10,16 @@ import { z } from "zod";
 import express from "express";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import { generateStructuredAgentResponse } from "./agent-response-loop.js";
+import {
+  generateStructuredAgentResponse,
+  StructuredAgentTimeoutError,
+} from "./agent-response-loop.js";
 import { AgentManager } from "./agent-manager.js";
 import { AgentStorage } from "./agent-storage.js";
 import { createAgentMcpServer } from "./mcp-server.js";
 import { shutdownProviders } from "./provider-registry.js";
+import { ClaudeAgentClient } from "./providers/claude/agent.js";
+import { isCommandAvailable } from "../../executable-resolution/executable-resolution.js";
 import {
   canRunRealProvider,
   createRealProviderClients,
@@ -148,6 +155,54 @@ async function startAgentMcpServer(logger: pino.Logger): Promise<AgentMcpServerH
   };
 }
 
+interface SinkholeHandle {
+  port: number;
+  close: () => Promise<void>;
+}
+
+// Accepts connections and never answers them, which is what a hung provider
+// looks like from here. Live connections are destroyed on close because
+// net.Server#close waits for them, and the killed child's socket can outlive
+// the child.
+async function startSinkhole(): Promise<SinkholeHandle> {
+  const sockets = new Set<Socket>();
+  const server = createSocketServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => undefined);
+  });
+  server.on("error", () => undefined);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  return {
+    port: typeof address === "object" && address ? address.port : 0,
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+// The provider CLI runs as a child of this process, so a leak is visible in the
+// process table and nowhere else.
+function providerCliPids(): Set<string> {
+  const out = execFileSync("ps", ["-eo", "pid,args"], { encoding: "utf8" });
+  const pids = new Set<string>();
+  for (const line of out.split("\n")) {
+    if (!line.includes("--output-format stream-json")) {
+      continue;
+    }
+    const pid = line.trim().split(/\s+/)[0];
+    if (pid) {
+      pids.add(pid);
+    }
+  }
+  return pids;
+}
+
 describe("getStructuredAgentResponse (e2e)", () => {
   let manager: AgentManager;
   let cwd: string;
@@ -250,4 +305,96 @@ describe("getStructuredAgentResponse (e2e)", () => {
 
     expect(result.message.trim().toLowerCase()).toBe("hello");
   }, 180000);
+});
+
+// Regression for #1937: a generation that never reaches a terminal event left
+// its provider CLI child (~250MB) alive for the lifetime of the daemon, because
+// the close that reaps it lives in a finally block the run never reached.
+//
+// Separate from the suite above because it needs no API key and must not use
+// one: the stall is a socket that accepts and never answers, which is what a
+// hung provider looks like from here. Only the real `claude` binary is required.
+describe("generateStructuredAgentResponse process cleanup (e2e)", () => {
+  const logger = pino({ level: "silent" });
+  let cwd: string;
+  let claudeInstalled = false;
+
+  beforeAll(async () => {
+    claudeInstalled = await isCommandAvailable("claude");
+  });
+
+  beforeEach(() => {
+    cwd = mkdtempSync(path.join(tmpdir(), "agent-response-loop-stall-"));
+  });
+
+  afterEach(async () => {
+    rmSync(cwd, { recursive: true, force: true });
+    await shutdownProviders(logger);
+  }, 60000);
+
+  test("reaps the provider CLI child when the run stalls", async (context) => {
+    if (!claudeInstalled || process.platform === "win32") {
+      context.skip();
+    }
+
+    const sinkhole = await startSinkhole();
+
+    const manager = new AgentManager({
+      clients: {
+        claude: new ClaudeAgentClient({
+          logger,
+          runtimeSettings: {
+            env: {
+              ANTHROPIC_BASE_URL: `http://127.0.0.1:${sinkhole.port}`,
+              ANTHROPIC_AUTH_TOKEN: "sinkhole",
+              ANTHROPIC_API_KEY: "",
+            },
+          },
+        }),
+      },
+      logger,
+    });
+
+    const before = providerCliPids();
+    // Poll rather than checking only at the end, so "no leak" cannot pass
+    // trivially by never spawning a child in the first place.
+    const spawned = new Set<string>();
+    const watcher = setInterval(() => {
+      for (const pid of providerCliPids()) {
+        if (!before.has(pid)) {
+          spawned.add(pid);
+        }
+      }
+    }, 100);
+
+    try {
+      await expect(
+        generateStructuredAgentResponse({
+          manager,
+          agentConfig: {
+            provider: "claude",
+            model: CLAUDE_TEST_MODEL,
+            cwd,
+            title: "Stalled Generation Test",
+            internal: true,
+          },
+          persistSession: false,
+          prompt: "Return JSON with a short message.",
+          schema: z.object({ message: z.string() }),
+          maxRetries: 0,
+          timeoutMs: 20000,
+        }),
+      ).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
+    } finally {
+      clearInterval(watcher);
+      await sinkhole.close();
+    }
+
+    // SIGTERM then SIGKILL, then the OS has to reap.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    const after = providerCliPids();
+
+    expect(spawned.size).toBeGreaterThan(0);
+    expect([...spawned].filter((pid) => after.has(pid))).toEqual([]);
+  }, 120000);
 });

--- a/packages/server/src/server/agent/agent-response-loop.test.ts
+++ b/packages/server/src/server/agent/agent-response-loop.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import {
   getStructuredAgentResponse,
+  generateStructuredAgentResponse,
   generateStructuredAgentResponseWithFallback,
   StructuredAgentFallbackError,
   StructuredAgentResponseError,
+  StructuredAgentTimeoutError,
   type AgentCaller,
 } from "./agent-response-loop.js";
 import type { AgentManager } from "./agent-manager.js";
@@ -127,6 +129,91 @@ describe("getStructuredAgentResponse", () => {
     });
 
     expect(result).toEqual({ value: 42 });
+  });
+});
+
+describe("generateStructuredAgentResponse", () => {
+  const schema = z.object({ summary: z.string() });
+
+  function createRunnerManager(runAgent: () => Promise<{ finalText: string }>) {
+    const created: string[] = [];
+    const closed: string[] = [];
+    const deleted: string[] = [];
+    const manager = {
+      createAgent: async () => {
+        created.push("generator");
+        return { id: "generator" };
+      },
+      runAgent,
+      closeAgent: async (id: string) => {
+        closed.push(id);
+      },
+      deleteAgentState: async (id: string) => {
+        deleted.push(id);
+      },
+    } as unknown as AgentManager;
+    return { manager, created, closed, deleted };
+  }
+
+  it("closes and deletes the ephemeral agent after a successful run", async () => {
+    const { manager, closed, deleted } = createRunnerManager(async () => ({
+      finalText: '{"summary":"ok"}',
+    }));
+
+    const result = await generateStructuredAgentResponse({
+      manager,
+      agentConfig: { provider: "claude", cwd: "/tmp/project" },
+      prompt: "Return JSON",
+      schema,
+      maxRetries: 0,
+    });
+
+    expect(result).toEqual({ summary: "ok" });
+    expect(closed).toEqual(["generator"]);
+    expect(deleted).toEqual(["generator"]);
+  });
+
+  // Regression: a metadata-generation run that never terminates (an internal
+  // agent's permission prompt has no UI to answer it) left the provider CLI
+  // child process alive forever. See issue #1937.
+  it("closes the ephemeral agent when the run never finishes", async () => {
+    const { manager, closed, deleted } = createRunnerManager(() => new Promise<never>(() => {}));
+
+    await expect(
+      generateStructuredAgentResponse({
+        manager,
+        agentConfig: { provider: "claude", cwd: "/tmp/project" },
+        prompt: "Return JSON",
+        schema,
+        timeoutMs: 25,
+      }),
+    ).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
+
+    expect(closed).toEqual(["generator"]);
+    expect(deleted).toEqual(["generator"]);
+  });
+
+  it("bounds the whole generation, not each retry", async () => {
+    let attempts = 0;
+    const { manager, closed } = createRunnerManager(async () => {
+      attempts += 1;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return { finalText: "not json" };
+    });
+
+    await expect(
+      generateStructuredAgentResponse({
+        manager,
+        agentConfig: { provider: "claude", cwd: "/tmp/project" },
+        prompt: "Return JSON",
+        schema,
+        maxRetries: 100,
+        timeoutMs: 60,
+      }),
+    ).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
+
+    expect(attempts).toBeLessThan(101);
+    expect(closed).toEqual(["generator"]);
   });
 });
 

--- a/packages/server/src/server/agent/agent-response-loop.test.ts
+++ b/packages/server/src/server/agent/agent-response-loop.test.ts
@@ -212,7 +212,9 @@ describe("generateStructuredAgentResponse", () => {
       }),
     ).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
 
-    expect(attempts).toBeLessThan(101);
+    // 60ms of budget at 20ms per attempt: three or four, nowhere near the 101
+    // that a per-retry bound would have allowed.
+    expect(attempts).toBeLessThanOrEqual(4);
     expect(closed).toEqual(["generator"]);
   });
 });
@@ -339,6 +341,41 @@ describe("generateStructuredAgentResponseWithFallback", () => {
       { provider: "codex", model: "gpt-5.4-mini" },
     ]);
     expect(manager.checkedProviders).toEqual(["claude", "codex"]);
+  });
+
+  it("spends one shared deadline across the waterfall", async () => {
+    const timeouts: Array<number | undefined> = [];
+    const manager = createManager([
+      { provider: "claude", available: true, error: null },
+      { provider: "codex", available: true, error: null },
+      { provider: "opencode", available: true, error: null },
+    ]);
+
+    await expect(
+      generateStructuredAgentResponseWithFallback({
+        manager,
+        cwd: "/tmp/project",
+        prompt: "Return JSON",
+        schema,
+        providers: [
+          { provider: "claude", model: "haiku" },
+          { provider: "codex", model: "gpt-5.4-mini" },
+          { provider: "opencode", model: "opencode/gpt-5-nano" },
+        ],
+        timeoutMs: 50,
+        runner: async (options) => {
+          timeouts.push(options.timeoutMs);
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          throw new Error("failed");
+        },
+      }),
+    ).rejects.toBeInstanceOf(StructuredAgentFallbackError);
+
+    // Each candidate gets what is left of the budget, not a fresh copy of it,
+    // and once it is spent the rest are skipped instead of run.
+    expect(timeouts).toHaveLength(2);
+    expect(timeouts[0]).toBeLessThanOrEqual(50);
+    expect(timeouts[1]).toBeLessThan(timeouts[0] as number);
   });
 
   it("throws a fallback error when all providers are unavailable or fail", async () => {

--- a/packages/server/src/server/agent/agent-response-loop.test.ts
+++ b/packages/server/src/server/agent/agent-response-loop.test.ts
@@ -221,9 +221,12 @@ describe("generateStructuredAgentResponse", () => {
       await vi.advanceTimersByTimeAsync(60);
       await settled;
 
-      // A per-retry bound would have let all 101 attempts through. One shared
-      // 60ms budget at 20ms an attempt starts four (t=0/20/40/60) before the
-      // deadline stops it.
+      // A per-retry bound would have let all 101 attempts through; one shared
+      // 60ms budget stops the loop after three. The fourth is the abandoned
+      // loop resuming once more after the deadline already rejected, which is
+      // possible only because this fake manager has no closed-agent guard —
+      // in production `streamAgent`'s `requireSessionAgent` throws once
+      // `prepareAgentForClosure` has removed the agent. Don't "fix" it to 3.
       expect(attempts).toBe(4);
       expect(closed).toEqual(["generator"]);
     } finally {
@@ -391,8 +394,8 @@ describe("generateStructuredAgentResponseWithFallback", () => {
       // and once it is spent the rest are skipped instead of run.
       expect(error).toBeInstanceOf(StructuredAgentFallbackError);
       expect(timeouts).toEqual([50, 20]);
-      // A skipped candidate was never probed, so the summary must not claim it
-      // is unavailable.
+      // A skipped candidate was probed and is usable — the budget ran out
+      // before it could run — so the summary must not call it unavailable.
       expect((error as Error).message).toContain(
         "opencode (opencode/gpt-5-nano): skipped (structured generation deadline exceeded)",
       );

--- a/packages/server/src/server/agent/agent-response-loop.test.ts
+++ b/packages/server/src/server/agent/agent-response-loop.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
 import {
   getStructuredAgentResponse,
@@ -177,45 +177,58 @@ describe("generateStructuredAgentResponse", () => {
   // agent's permission prompt has no UI to answer it) left the provider CLI
   // child process alive forever. See issue #1937.
   it("closes the ephemeral agent when the run never finishes", async () => {
-    const { manager, closed, deleted } = createRunnerManager(() => new Promise<never>(() => {}));
+    vi.useFakeTimers();
+    try {
+      const { manager, closed, deleted } = createRunnerManager(() => new Promise<never>(() => {}));
 
-    await expect(
-      generateStructuredAgentResponse({
+      const generation = generateStructuredAgentResponse({
         manager,
         agentConfig: { provider: "claude", cwd: "/tmp/project" },
         prompt: "Return JSON",
         schema,
         timeoutMs: 25,
-      }),
-    ).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
+      });
+      const settled = expect(generation).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
+      await vi.advanceTimersByTimeAsync(25);
+      await settled;
 
-    expect(closed).toEqual(["generator"]);
-    expect(deleted).toEqual(["generator"]);
+      expect(closed).toEqual(["generator"]);
+      expect(deleted).toEqual(["generator"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("bounds the whole generation, not each retry", async () => {
-    let attempts = 0;
-    const { manager, closed } = createRunnerManager(async () => {
-      attempts += 1;
-      await new Promise((resolve) => setTimeout(resolve, 20));
-      return { finalText: "not json" };
-    });
+    vi.useFakeTimers();
+    try {
+      let attempts = 0;
+      const { manager, closed } = createRunnerManager(async () => {
+        attempts += 1;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { finalText: "not json" };
+      });
 
-    await expect(
-      generateStructuredAgentResponse({
+      const generation = generateStructuredAgentResponse({
         manager,
         agentConfig: { provider: "claude", cwd: "/tmp/project" },
         prompt: "Return JSON",
         schema,
         maxRetries: 100,
         timeoutMs: 60,
-      }),
-    ).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
+      });
+      const settled = expect(generation).rejects.toBeInstanceOf(StructuredAgentTimeoutError);
+      await vi.advanceTimersByTimeAsync(60);
+      await settled;
 
-    // 60ms of budget at 20ms per attempt: three or four, nowhere near the 101
-    // that a per-retry bound would have allowed.
-    expect(attempts).toBeLessThanOrEqual(4);
-    expect(closed).toEqual(["generator"]);
+      // A per-retry bound would have let all 101 attempts through. One shared
+      // 60ms budget at 20ms an attempt starts four (t=0/20/40/60) before the
+      // deadline stops it.
+      expect(attempts).toBe(4);
+      expect(closed).toEqual(["generator"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -344,15 +357,16 @@ describe("generateStructuredAgentResponseWithFallback", () => {
   });
 
   it("spends one shared deadline across the waterfall", async () => {
-    const timeouts: Array<number | undefined> = [];
-    const manager = createManager([
-      { provider: "claude", available: true, error: null },
-      { provider: "codex", available: true, error: null },
-      { provider: "opencode", available: true, error: null },
-    ]);
+    vi.useFakeTimers();
+    try {
+      const timeouts: Array<number | undefined> = [];
+      const manager = createManager([
+        { provider: "claude", available: true, error: null },
+        { provider: "codex", available: true, error: null },
+        { provider: "opencode", available: true, error: null },
+      ]);
 
-    await expect(
-      generateStructuredAgentResponseWithFallback({
+      const generation = generateStructuredAgentResponseWithFallback({
         manager,
         cwd: "/tmp/project",
         prompt: "Return JSON",
@@ -368,14 +382,23 @@ describe("generateStructuredAgentResponseWithFallback", () => {
           await new Promise((resolve) => setTimeout(resolve, 30));
           throw new Error("failed");
         },
-      }),
-    ).rejects.toBeInstanceOf(StructuredAgentFallbackError);
+      });
+      const settled = generation.catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(100);
+      const error = await settled;
 
-    // Each candidate gets what is left of the budget, not a fresh copy of it,
-    // and once it is spent the rest are skipped instead of run.
-    expect(timeouts).toHaveLength(2);
-    expect(timeouts[0]).toBeLessThanOrEqual(50);
-    expect(timeouts[1]).toBeLessThan(timeouts[0] as number);
+      // Each candidate gets what is left of the budget, not a fresh copy of it,
+      // and once it is spent the rest are skipped instead of run.
+      expect(error).toBeInstanceOf(StructuredAgentFallbackError);
+      expect(timeouts).toEqual([50, 20]);
+      // A skipped candidate was never probed, so the summary must not claim it
+      // is unavailable.
+      expect((error as Error).message).toContain(
+        "opencode (opencode/gpt-5-nano): skipped (structured generation deadline exceeded)",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("throws a fallback error when all providers are unavailable or fail", async () => {

--- a/packages/server/src/server/agent/agent-response-loop.ts
+++ b/packages/server/src/server/agent/agent-response-loop.ts
@@ -42,7 +42,11 @@ export interface StructuredGenerationAttempt {
 // An unbounded wait pins the provider CLI child process (~250MB for `claude`)
 // for the lifetime of the daemon, because the close that reaps it lives in the
 // finally block this wait never reaches. Bound the run so cleanup always runs.
-export const DEFAULT_STRUCTURED_GENERATION_TIMEOUT_MS = 120_000;
+// Generous on purpose: the bound exists to stop a leak that otherwise lasts for
+// the daemon's lifetime, so it only has to be shorter than "forever". Cutting a
+// slow but legitimate generation short is the worse failure — the largest real
+// prompt is a 200k-char patch (MAX_PULL_REQUEST_PATCH_CHARS).
+export const DEFAULT_STRUCTURED_GENERATION_TIMEOUT_MS = 300_000;
 
 export class StructuredAgentTimeoutError extends Error {
   readonly timeoutMs: number;
@@ -446,12 +450,28 @@ export async function generateStructuredAgentResponseWithFallback<T>(
     throw new StructuredAgentFallbackError([]);
   }
 
+  // One deadline for the whole waterfall. A per-candidate bound would stack, so
+  // a total provider outage would keep the caller waiting timeoutMs once per
+  // candidate instead of once.
+  const deadline = Date.now() + (timeoutMs ?? DEFAULT_STRUCTURED_GENERATION_TIMEOUT_MS);
+
   const runStructured =
     runner ??
     ((input: StructuredAgentGenerationOptions<T>) => generateStructuredAgentResponse<T>(input));
   const attempts: StructuredGenerationAttempt[] = [];
 
   for (const candidate of providers) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      attempts.push({
+        provider: candidate.provider,
+        model: candidate.model ?? null,
+        available: false,
+        error: "structured generation deadline exceeded",
+      });
+      continue;
+    }
+
     const availabilityEntry = await manager.getProviderAvailability(candidate.provider);
     if (!availabilityEntry.available) {
       const reason = availabilityEntry.error ?? "unavailable";
@@ -476,7 +496,7 @@ export async function generateStructuredAgentResponseWithFallback<T>(
         maxRetries,
         schemaName,
         persistSession,
-        ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        timeoutMs: remainingMs,
         agentConfig: {
           ...agentConfigOverrides,
           provider: candidate.provider,

--- a/packages/server/src/server/agent/agent-response-loop.ts
+++ b/packages/server/src/server/agent/agent-response-loop.ts
@@ -35,6 +35,9 @@ export interface StructuredGenerationAttempt {
   model: string | null;
   available: boolean;
   error: string | null;
+  // Never run because an earlier candidate spent the shared deadline. Distinct
+  // from `available: false`, which means the provider itself is unusable.
+  skipped?: boolean;
 }
 
 // Metadata generation runs headless on an internal agent: it has no UI, so a
@@ -65,6 +68,9 @@ export class StructuredAgentFallbackError extends Error {
     const summary = attempts
       .map((attempt) => {
         const modelSuffix = attempt.model ? ` (${attempt.model})` : "";
+        if (attempt.skipped) {
+          return `${attempt.provider}${modelSuffix}: skipped${attempt.error ? ` (${attempt.error})` : ""}`;
+        }
         if (!attempt.available) {
           return `${attempt.provider}${modelSuffix}: unavailable${attempt.error ? ` (${attempt.error})` : ""}`;
         }
@@ -453,6 +459,11 @@ export async function generateStructuredAgentResponseWithFallback<T>(
   // One deadline for the whole waterfall. A per-candidate bound would stack, so
   // a total provider outage would keep the caller waiting timeoutMs once per
   // candidate instead of once.
+  //
+  // The trade-off is that a first candidate which hangs rather than fails eats
+  // the budget and the rest are skipped. Splitting the budget per candidate
+  // would fix that but re-introduce a bound too tight for a legitimately slow
+  // generation on a large patch, and no split can tell "hung" from "slow".
   const deadline = Date.now() + (timeoutMs ?? DEFAULT_STRUCTURED_GENERATION_TIMEOUT_MS);
 
   const runStructured =
@@ -461,17 +472,6 @@ export async function generateStructuredAgentResponseWithFallback<T>(
   const attempts: StructuredGenerationAttempt[] = [];
 
   for (const candidate of providers) {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model ?? null,
-        available: false,
-        error: "structured generation deadline exceeded",
-      });
-      continue;
-    }
-
     const availabilityEntry = await manager.getProviderAvailability(candidate.provider);
     if (!availabilityEntry.available) {
       const reason = availabilityEntry.error ?? "unavailable";
@@ -484,6 +484,24 @@ export async function generateStructuredAgentResponseWithFallback<T>(
       logger?.warn(
         { provider: candidate.provider, model: candidate.model, schemaName, reason },
         "Structured generation: skipping unavailable provider",
+      );
+      continue;
+    }
+
+    // Computed here rather than at the top of the loop so the availability
+    // check above can't eat into the budget this candidate is told it has.
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      attempts.push({
+        provider: candidate.provider,
+        model: candidate.model ?? null,
+        available: true,
+        error: "structured generation deadline exceeded",
+        skipped: true,
+      });
+      logger?.warn(
+        { provider: candidate.provider, model: candidate.model, schemaName },
+        "Structured generation: deadline spent, skipping remaining provider",
       );
       continue;
     }

--- a/packages/server/src/server/agent/agent-response-loop.ts
+++ b/packages/server/src/server/agent/agent-response-loop.ts
@@ -37,6 +37,23 @@ export interface StructuredGenerationAttempt {
   error: string | null;
 }
 
+// Metadata generation runs headless on an internal agent: it has no UI, so a
+// permission prompt it raises can never be answered and the turn waits forever.
+// An unbounded wait pins the provider CLI child process (~250MB for `claude`)
+// for the lifetime of the daemon, because the close that reaps it lives in the
+// finally block this wait never reaches. Bound the run so cleanup always runs.
+export const DEFAULT_STRUCTURED_GENERATION_TIMEOUT_MS = 120_000;
+
+export class StructuredAgentTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Structured generation timed out after ${timeoutMs}ms`);
+    this.name = "StructuredAgentTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export class StructuredAgentFallbackError extends Error {
   readonly attempts: StructuredGenerationAttempt[];
 
@@ -78,6 +95,7 @@ export interface StructuredAgentGenerationOptions<T> {
   schema: z.ZodType<T> | JsonSchema;
   maxRetries?: number;
   schemaName?: string;
+  timeoutMs?: number;
 }
 
 export interface StructuredAgentGenerationWithFallbackOptions<T> {
@@ -93,6 +111,7 @@ export interface StructuredAgentGenerationWithFallbackOptions<T> {
   persistSession?: boolean;
   maxRetries?: number;
   schemaName?: string;
+  timeoutMs?: number;
   logger?: StructuredGenerationLogger;
   runner?: <TResult>(options: StructuredAgentGenerationOptions<TResult>) => Promise<TResult>;
 }
@@ -356,10 +375,12 @@ export async function generateStructuredAgentResponse<T>(
 ): Promise<T> {
   const { manager, agentConfig, agentId, persistSession, prompt, schema, maxRetries, schemaName } =
     options;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_STRUCTURED_GENERATION_TIMEOUT_MS;
   const agent = await manager.createAgent(agentConfig, agentId, {
     persistSession,
     workspaceId: undefined,
   });
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const caller: AgentCaller = async (nextPrompt) => {
       const result = await manager.runAgent(agent.id, nextPrompt);
@@ -370,14 +391,22 @@ export async function generateStructuredAgentResponse<T>(
       const lastAssistant = result.timeline.findLast((item) => item.type === "assistant_message");
       return lastAssistant?.text ?? "";
     };
-    return await getStructuredAgentResponse({
-      caller,
-      prompt,
-      schema,
-      maxRetries,
-      schemaName,
-    });
+    // The deadline covers every retry, not each one, so a model that stalls on
+    // its second attempt can't extend the run past the bound.
+    return await Promise.race([
+      getStructuredAgentResponse({
+        caller,
+        prompt,
+        schema,
+        maxRetries,
+        schemaName,
+      }),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new StructuredAgentTimeoutError(timeoutMs)), timeoutMs);
+      }),
+    ]);
   } finally {
+    clearTimeout(timer);
     try {
       await manager.closeAgent(agent.id);
     } catch {
@@ -408,6 +437,7 @@ export async function generateStructuredAgentResponseWithFallback<T>(
     persistSession,
     maxRetries,
     schemaName,
+    timeoutMs,
     logger,
     runner,
   } = options;
@@ -446,6 +476,7 @@ export async function generateStructuredAgentResponseWithFallback<T>(
         maxRetries,
         schemaName,
         persistSession,
+        ...(timeoutMs === undefined ? {} : { timeoutMs }),
         agentConfig: {
           ...agentConfigOverrides,
           provider: candidate.provider,


### PR DESCRIPTION
Fixes #1937

## The problem

Structured metadata generation — branch names, commit messages, PR text — runs a one-shot turn on an `internal: true` agent via `generateStructuredAgentResponse`.

Internal agents have no UI. `agent-manager.ts` deliberately skips raising attention for their permission requests, and nothing in `runAgent` / `streamAgent` / the turn stream has a timeout. So when the model triggers a permission prompt — or the provider stalls for any other reason — the turn never reaches a terminal event:

- the `await` never returns,
- the `finally` block that calls `manager.closeAgent` is never reached,
- and the provider CLI child that turn spawned stays alive for the lifetime of the daemon.

That is the `claude ... --model claude-haiku-4-5 ... --no-session-persistence` half of the pairs in the issue: ~250MB of RSS per stalled generation, accumulating for days.

### Scope

`--no-session-persistence` reaches argv only when `persistSession === false`, and the ephemeral generators are the only callers that pass it (`packages/server/src/server/agent/providers/claude/agent.ts:2514`). So this fixes the processes in the report carrying that flag, not all ~25 of them.

The other half of each pair — the main-model session — is a live agent holding its provider runtime, which is the documented design (`docs/agent-lifecycle.md`: `closed` is the state for a record with no live provider runtime). Reclaiming those would be idle-session eviction, a product decision, and is not attempted here.

## The fix

Give the generation a deadline that covers all of its retries. On expiry it throws `StructuredAgentTimeoutError`, which propagates into the existing cleanup path — `closeAgent` → `session.close()` → `terminateWithTreeKill` — so the child is reaped instead of orphaned.

The fallback waterfall spends **one** deadline across all candidates rather than giving each a fresh copy: each candidate gets `remaining = deadline - Date.now()`, and once the budget is spent the rest are skipped. A total provider outage therefore costs one wait, not one per candidate.

The default is 300s. It is deliberately generous — the bound exists to stop a leak that otherwise lasts for the daemon's lifetime, so it only has to be shorter than "forever", and cutting a slow but legitimate generation short is the worse failure. The largest real prompt is a 200k-char patch (`MAX_PULL_REQUEST_PATCH_CHARS`).

A candidate that is skipped because the budget is gone is reported as `skipped`, not `unavailable` — it was never probed, and saying otherwise would send whoever reads the daemon log hunting for an auth or install problem that doesn't exist.

### The trade-off worth knowing about

Sharing one deadline means a first candidate that *hangs* — rather than failing — eats the budget, and the remaining candidates are skipped. For the users who hit this issue, whose focused provider is the one hanging, the waterfall therefore won't save them: they get the fallback commit message after 5 minutes instead of a working one from the second provider.

Splitting the budget per candidate fixes that but re-introduces a bound too tight for a legitimately slow generation, and no split can tell "hung" from "slow" — that needs stream-activity tracking, which is a larger change than this bug warrants. This is still strictly better than the current behaviour, which is an unbounded hang plus a permanent ~250MB leak.

## QA evidence

### Unit: the regression test fails on the old code, for the reported reason

`packages/server/src/server/agent/agent-response-loop.test.ts`, before the fix:

```
FAIL src/server/agent/agent-response-loop.test.ts > generateStructuredAgentResponse > closes the ephemeral agent when the run never finishes
Error: Test timed out in 30000ms.
```

It hangs — which is the bug: the run never returns, so cleanup never happens. After the fix, with the fallback and generator suites:

```
npx vitest run src/server/agent/agent-response-loop.test.ts \
  src/server/worktree-branch-name-generator.test.ts \
  src/server/session/checkout/git-metadata-generator.test.ts --root packages/server

 Test Files  3 passed (3)
      Tests  37 passed (37)
```

### Real provider, real process, real stall

Unit tests prove the control flow. To prove the OS process actually gets reaped, `agent-response-loop.real.e2e.test.ts` gains `"reaps the provider CLI child when the run stalls"`: it runs the real `claude` CLI with `ANTHROPIC_BASE_URL` pointed at a socket that accepts connections and never answers — reproducing the stall without depending on the model choosing to request a permission — then polls the process table.

It asserts both halves, so it cannot pass trivially: a child **was** spawned during the run, and none of the spawned pids survive it.

```
✓ generateStructuredAgentResponse process cleanup (e2e) > reaps the provider CLI child when the run stalls 22580ms
  Tests  1 passed | 2 skipped (3)
```

With the deadline removed, the same test hangs to its 120s limit and leaves behind exactly the issue's signature — reparented to systemd, away from the dead daemon:

```
× reaps the provider CLI child when the run stalls 120012ms
  → Test timed out in 120000ms.

/home/nick/.local/bin/claude --output-format stream-json --verbose --input-format stream-json
  --model haiku --permission-prompt-tool stdio ... --no-session-persistence
```

The test needs no API key (nothing ever answers), only the `claude` binary. It lives in a `*.real.e2e.test.ts` file, which `test:e2e` excludes and `npm run test:integration:real` runs — so it cannot hang CI.

**It skips on Windows**, because the leak detector reads the process table via `ps`. Windows process cleanup for this fix therefore has no automated coverage; a green CI run does not prove it. The cleanup path itself (`terminateWithTreeKill`) is the same one every other agent close already uses on Windows, so this is a gap in proof rather than a known defect.

### Checks

```
npm run typecheck    # all workspaces pass
npm run lint         # 0 warnings, 0 errors
npm run format:check # all matched files use the correct format
```

## Not in this change

- **The permission prompt is still unanswerable.** `agent-manager.ts:3677` skips raising attention for `internal: true` agents, so the request sits in `pendingPermissions` with no path to a response. This change is the backstop, not the cure; auto-resolving permissions for internal agents is the actual fix and is a behavioural decision worth its own PR.
- **Pi, ACP and OpenCode spawn inside `createSession`**, before the `try`/`finally` this bound lives in, so a stalled handshake still leaks.
- **`AgentManager.registerSession`** sets `registered = true` before its `assertAgentRegistrationActive` calls, so a shutdown race can leave a session in `this.agents` with nobody to close it.

## Platforms

The change is daemon-side and platform-independent — no UI, no native code, no protocol or wire-schema change.

| Platform        | Tested | Notes                                                    |
| --------------- | ------ | -------------------------------------------------------- |
| iOS             | ✗      | No app-side change                                       |
| Android         | ✗      | No app-side change                                       |
| Web             | ✗      | No app-side change                                       |
| Desktop macOS   | ✗      | Not available to me                                      |
| Desktop Windows | ✗      | Not available to me; the regression test skips on win32  |
| Desktop Linux   | ✓      | Ubuntu, daemon-side unit tests + the real-provider e2e   |
