### PR TITLE
fix(server): stop requesting the Claude bypass capability as root

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -69,6 +69,9 @@ async function createSession() {
     logger: createTestLogger(),
     queryFactory: sdkQueryFactory,
     resolveBinary: async () => "/test/claude/bin",
+    // Bypass expectations below only hold for a non-root daemon, so pin the uid rather than
+    // inherit whatever user runs the suite. See agent.root-bypass.test.ts.
+    getUid: () => 1000,
   });
   return client.createSession({
     provider: "claude",
@@ -81,6 +84,7 @@ function createSessionWithLogger(logger: Logger) {
     logger,
     queryFactory: sdkQueryFactory,
     resolveBinary: async () => "/test/claude/bin",
+    getUid: () => 1000,
   });
   return client.createSession({
     provider: "claude",
@@ -953,6 +957,7 @@ test("captures Claude stderr in the turn failure diagnostic when stderr arrives 
     logger: loggerSpy.logger,
     queryFactory: sdkQueryFactory,
     resolveBinary: async () => "/test/claude/bin",
+    getUid: () => 1000,
   });
   const session = await client.createSession({
     provider: "claude",

--- a/packages/server/src/server/agent/providers/claude/agent.root-bypass.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.root-bypass.test.ts
@@ -1,0 +1,217 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Query } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../../test-utils/test-logger.js";
+import type { AgentSessionConfig } from "../../agent-sdk-types.js";
+import { ClaudeAgentClient } from "./agent.js";
+import type { ClaudeOptions, ClaudeQueryInput } from "./query.js";
+
+// Claude Code refuses to start when the bypass capability is requested by a root process
+// outside a deliberate sandbox, so requesting it unconditionally killed every session on a
+// root-run daemon — including Ask mode. See issue #1582.
+
+const ROOT_UID = 0;
+const USER_UID = 1000;
+
+function createQueryMock(): Query {
+  const events: unknown[] = [
+    {
+      type: "system",
+      subtype: "init",
+      session_id: "root-bypass-session",
+      permissionMode: "default",
+      model: "opus",
+    },
+    { type: "assistant", message: { content: "done" } },
+    {
+      type: "result",
+      subtype: "success",
+      usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+      total_cost_usd: 0,
+    },
+  ];
+  let index = 0;
+  return {
+    next: vi.fn(async () =>
+      index < events.length
+        ? { done: false, value: events[index++] }
+        : { done: true, value: undefined },
+    ),
+    return: vi.fn(async () => ({ done: true, value: undefined })),
+    interrupt: vi.fn(async () => undefined),
+    close: vi.fn(() => undefined),
+    setPermissionMode: vi.fn(async () => undefined),
+    setModel: vi.fn(async () => undefined),
+    supportedModels: vi.fn(async () => [{ value: "opus", displayName: "Opus" }]),
+    supportedCommands: vi.fn(async () => []),
+    rewindFiles: vi.fn(async () => ({ canRewind: true })),
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } as Query;
+}
+
+const sdkQueryFactory = vi.fn();
+let capturedOptions: ClaudeOptions | undefined;
+
+function createSession(uid: number, config: Partial<AgentSessionConfig> = {}) {
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory: sdkQueryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+    getUid: () => uid,
+  });
+  return client.createSession({
+    provider: "claude",
+    cwd: process.cwd(),
+    ...config,
+  });
+}
+
+beforeEach(() => {
+  capturedOptions = undefined;
+  sdkQueryFactory.mockReset();
+  sdkQueryFactory.mockImplementation(({ options }: ClaudeQueryInput) => {
+    capturedOptions = options;
+    return createQueryMock();
+  });
+  vi.stubEnv("IS_SANDBOX", undefined);
+  vi.stubEnv("CLAUDE_CODE_BUBBLEWRAP", undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  sdkQueryFactory.mockReset();
+});
+
+test("drops the bypass launch capability when the daemon runs as root", async () => {
+  const session = await createSession(ROOT_UID);
+
+  try {
+    await session.run("hello from root");
+    expect(capturedOptions?.allowDangerouslySkipPermissions).toBe(false);
+    expect(capturedOptions?.permissionMode).toBe("default");
+  } finally {
+    await session.close();
+  }
+});
+
+test("keeps the bypass launch capability when root runs inside a sandbox", async () => {
+  vi.stubEnv("IS_SANDBOX", "1");
+  const session = await createSession(ROOT_UID);
+
+  try {
+    await session.run("hello from a sandboxed root");
+    expect(capturedOptions?.allowDangerouslySkipPermissions).toBe(true);
+  } finally {
+    await session.close();
+  }
+});
+
+test("reads the sandbox marker from the agent's own launch env, not the daemon's", async () => {
+  const session = await createSession(ROOT_UID, {
+    extra: { claude: { env: { IS_SANDBOX: "1" } } },
+  });
+
+  try {
+    await session.run("hello from a per-agent sandbox");
+    expect(capturedOptions?.env?.IS_SANDBOX).toBe("1");
+    expect(capturedOptions?.allowDangerouslySkipPermissions).toBe(true);
+  } finally {
+    await session.close();
+  }
+});
+
+test("keeps the bypass launch capability for a non-root daemon", async () => {
+  const session = await createSession(USER_UID);
+
+  try {
+    await session.run("hello from a normal user");
+    expect(capturedOptions?.allowDangerouslySkipPermissions).toBe(true);
+  } finally {
+    await session.close();
+  }
+});
+
+test("ignores a bypass capability forced through extra.claude on a root daemon", async () => {
+  const session = await createSession(ROOT_UID, {
+    extra: {
+      claude: { allowDangerouslySkipPermissions: true, permissionMode: "bypassPermissions" },
+    },
+  });
+
+  try {
+    await session.run("hello from a crafted client");
+    expect(capturedOptions?.allowDangerouslySkipPermissions).toBe(false);
+    expect(capturedOptions?.permissionMode).toBe("default");
+  } finally {
+    await session.close();
+  }
+});
+
+test("rejects switching to bypass mode when the daemon runs as root", async () => {
+  const session = await createSession(ROOT_UID);
+
+  try {
+    await expect(session.setMode("bypassPermissions")).rejects.toThrow(
+      "Claude Bypass mode cannot be used while Paseo runs as root",
+    );
+    expect(sdkQueryFactory).not.toHaveBeenCalled();
+  } finally {
+    await session.close();
+  }
+});
+
+test("rejects launching a bypass-mode session when the daemon runs as root", async () => {
+  const session = await createSession(ROOT_UID, { modeId: "bypassPermissions" });
+
+  try {
+    await expect(session.run("hello from root")).rejects.toThrow(
+      "Claude Bypass mode cannot be used while Paseo runs as root",
+    );
+    expect(sdkQueryFactory).not.toHaveBeenCalled();
+  } finally {
+    await session.close();
+  }
+});
+
+test("stops offering Bypass mode to a root daemon", async () => {
+  const session = await createSession(ROOT_UID);
+
+  try {
+    const modeIds = (await session.getAvailableModes()).map((mode) => mode.id);
+    expect(modeIds).not.toContain("bypassPermissions");
+    expect(modeIds).toContain("default");
+  } finally {
+    await session.close();
+  }
+});
+
+test("offers Bypass mode to a non-root daemon", async () => {
+  const session = await createSession(USER_UID);
+
+  try {
+    const modeIds = (await session.getAvailableModes()).map((mode) => mode.id);
+    expect(modeIds).toContain("bypassPermissions");
+  } finally {
+    await session.close();
+  }
+});
+
+test("keeps Bypass out of the provider catalog for a root daemon", async () => {
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory: sdkQueryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+    getUid: () => ROOT_UID,
+    // Keep the catalog off the host: no `claude --version` spawn, no real config dir read.
+    resolveVersion: async () => "2.1.220",
+    configDir: join(tmpdir(), "paseo-root-bypass-test-config"),
+  });
+
+  const catalog = await client.fetchCatalog({ scope: "global", force: false });
+
+  expect(catalog.modes.map((mode) => mode.id)).not.toContain("bypassPermissions");
+});

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -378,6 +378,8 @@ interface ClaudeAgentClientOptions {
   resolveBinary?: () => Promise<string>;
   resolveVersion?: () => Promise<string>;
   configDir?: string;
+  /** Effective user id of this process. Injected so tests need no root runner. */
+  getUid?: () => number | undefined;
 }
 
 interface ClaudeAgentSessionOptions {
@@ -390,6 +392,7 @@ interface ClaudeAgentSessionOptions {
   logger: Logger;
   queryFactory?: ClaudeQueryFactory;
   resolveBinary: () => Promise<string>;
+  getUid: () => number | undefined;
 }
 
 type ClaudeThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";
@@ -902,6 +905,44 @@ function detectIneligibleAutoModeTransport(env: NodeJS.ProcessEnv): "Bedrock" | 
     return "Vertex";
   }
   return null;
+}
+
+// Claude Code exits immediately when a root process asks for the permission-skip
+// capability, unless it was told the machine is a deliberate sandbox. Mirror that gate
+// so a root-run daemon does not lose every session, including the ones that never
+// intended to bypass anything.
+//
+// This reads the daemon's uid, while Claude Code reads its own. They differ when a
+// `command` override wraps the CLI in something that changes user (gosu, su, sudo), so a
+// deprivileging wrapper loses Bypass it could have had, and a privilege-raising one still
+// hits the raw CLI error. Detecting the wrapper's effective uid is the upgrade path.
+function isRootOutsideSandbox(uid: number | undefined, env: NodeJS.ProcessEnv): boolean {
+  return uid === 0 && env.IS_SANDBOX !== "1" && !env.CLAUDE_CODE_BUBBLEWRAP;
+}
+
+function assertClaudeBypassEligible(
+  mode: PermissionMode,
+  uid: number | undefined,
+  env: NodeJS.ProcessEnv,
+): void {
+  if (mode !== "bypassPermissions" || !isRootOutsideSandbox(uid, env)) {
+    return;
+  }
+  throw new Error(
+    "Claude Bypass mode cannot be used while Paseo runs as root. Run the daemon as a non-root user.",
+  );
+}
+
+function claudeModesFor(uid: number | undefined, env: NodeJS.ProcessEnv): AgentMode[] {
+  return DEFAULT_MODES.filter((mode) => {
+    if (mode.id === "auto") {
+      return detectIneligibleAutoModeTransport(env) === null;
+    }
+    if (mode.id === "bypassPermissions") {
+      return !isRootOutsideSandbox(uid, env);
+    }
+    return true;
+  });
 }
 
 function assertClaudeAutoModeEligible(mode: PermissionMode, env: NodeJS.ProcessEnv): void {
@@ -1455,6 +1496,7 @@ export class ClaudeAgentClient implements AgentClient {
   private readonly resolveBinary: () => Promise<string>;
   private readonly resolveVersion: () => Promise<string>;
   private readonly configDir?: string;
+  private readonly getUid: () => number | undefined;
 
   constructor(options: ClaudeAgentClientOptions) {
     this.defaults = options.defaults;
@@ -1465,6 +1507,7 @@ export class ClaudeAgentClient implements AgentClient {
     this.resolveVersion =
       options.resolveVersion ?? (() => resolveClaudeCodeVersion(this.runtimeSettings));
     this.configDir = options.configDir;
+    this.getUid = options.getUid ?? (() => process.getuid?.());
   }
 
   async createSession(
@@ -1482,6 +1525,7 @@ export class ClaudeAgentClient implements AgentClient {
       logger: this.logger,
       queryFactory: this.queryFactory,
       resolveBinary: this.resolveBinary,
+      getUid: this.getUid,
     });
   }
 
@@ -1510,6 +1554,7 @@ export class ClaudeAgentClient implements AgentClient {
       logger: this.logger,
       queryFactory: this.queryFactory,
       resolveBinary: this.resolveBinary,
+      getUid: this.getUid,
     });
   }
 
@@ -1526,11 +1571,10 @@ export class ClaudeAgentClient implements AgentClient {
       this.configDir,
       claudeCodeVersion,
     );
-    const modes = detectIneligibleAutoModeTransport(
+    const modes = claudeModesFor(
+      this.getUid(),
       createProviderEnv({ baseEnv: process.env, runtimeSettings: this.runtimeSettings }),
-    )
-      ? DEFAULT_MODES.filter((mode) => mode.id !== "auto")
-      : DEFAULT_MODES;
+    );
     return {
       models,
       modes,
@@ -1979,6 +2023,7 @@ class ClaudeAgentSession implements AgentSession {
   private readonly logger: Logger;
   private readonly queryFactory?: ClaudeQueryFactory;
   private readonly resolveBinary: () => Promise<string>;
+  private readonly getUid: () => number | undefined;
   private query: Query | null = null;
   private childProcess: ChildProcess | null = null;
   private input: AsyncMessageInput<SDKUserMessage> | null = null;
@@ -1986,7 +2031,6 @@ class ClaudeAgentSession implements AgentSession {
   private persistence: AgentPersistenceHandle | null;
   private currentMode: PermissionMode;
   private planResumeMode: PermissionMode | null = null;
-  private availableModes: AgentMode[] = DEFAULT_MODES;
   private toolUseCache = new Map<string, ToolUseCacheEntry>();
   private toolUseIndexToId = new Map<number, string>();
   private toolUseInputBuffers = new Map<string, string>();
@@ -2042,6 +2086,7 @@ class ClaudeAgentSession implements AgentSession {
     this.logger = options.logger.child({ agentId: this.agentId });
     this.queryFactory = options.queryFactory;
     this.resolveBinary = options.resolveBinary;
+    this.getUid = options.getUid;
     this.contextUsage = new ClaudeContextUsageState(
       findClaudeModel(this.config.model)?.contextWindowMaxTokens,
     );
@@ -2254,7 +2299,7 @@ class ClaudeAgentSession implements AgentSession {
   }
 
   async getAvailableModes(): Promise<AgentMode[]> {
-    return this.availableModes;
+    return claudeModesFor(this.getUid(), this.buildSdkEnv(this.config.extra?.claude));
   }
 
   async getCurrentMode(): Promise<string | null> {
@@ -2271,7 +2316,9 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     const normalized = isPermissionMode(modeId) ? modeId : "default";
-    assertClaudeAutoModeEligible(normalized, this.buildSdkEnv(this.config.extra?.claude));
+    const modeEnv = this.buildSdkEnv(this.config.extra?.claude);
+    assertClaudeAutoModeEligible(normalized, modeEnv);
+    assertClaudeBypassEligible(normalized, this.getUid(), modeEnv);
     const previousMode = this.currentMode;
     const activeQuery = await this.ensureQuery();
     await activeQuery.setPermissionMode(normalized);
@@ -3052,6 +3099,7 @@ class ClaudeAgentSession implements AgentSession {
     const settingsOptions = this.buildSettingsOptions(extraClaudeOptions, { ultracode });
     const sdkEnv = this.buildSdkEnv(extraClaudeOptions);
     assertClaudeAutoModeEligible(this.currentMode, sdkEnv);
+    assertClaudeBypassEligible(this.currentMode, this.getUid(), sdkEnv);
 
     const claudeBinary = await this.resolveBinary();
     this.logger.debug(
@@ -3074,11 +3122,6 @@ class ClaudeAgentSession implements AgentSession {
     const base: ClaudeOptions = {
       cwd: this.config.cwd,
       includePartialMessages: true,
-      permissionMode: this.currentMode,
-      // Dynamic mode switching can recreate the underlying Claude query. Keep the
-      // bypass launch capability available so later setPermissionMode("bypassPermissions")
-      // calls do not fail after a model/thinking/rewind-driven restart.
-      allowDangerouslySkipPermissions: true,
       agents: this.defaults?.agents,
       canUseTool: this.handlePermissionRequest,
       pathToClaudeCodeExecutable: claudeBinary,
@@ -3105,6 +3148,13 @@ class ClaudeAgentSession implements AgentSession {
       ...settingsOptions,
       // Provider subagent panes render the child's nested transcript.
       forwardSubagentText: true,
+      // Pinned after the spreads: extra.claude is an arbitrary record off the wire, and
+      // both keys decide whether Claude Code will start at all. The session owns the mode
+      // through setMode, and the bypass launch capability stays available so a later
+      // setPermissionMode("bypassPermissions") survives a model/thinking/rewind restart —
+      // except as root, where Claude Code refuses to boot with it.
+      permissionMode: this.currentMode,
+      allowDangerouslySkipPermissions: !isRootOutsideSandbox(this.getUid(), sdkEnv),
       // Merged rather than assigned above: extraClaudeOptions is spread after the base, so any
       // user-configured hooks would otherwise replace these wholesale and silently stop effort
       // from being observed.
@@ -4200,7 +4250,6 @@ class ClaudeAgentSession implements AgentSession {
       threadStartedSessionId = newSessionId;
       notice = this.createClaudeSessionChangedNotice(existingSessionId, newSessionId);
     }
-    this.availableModes = DEFAULT_MODES;
     this.currentMode = message.permissionMode;
     if (this.currentMode !== "plan") {
       this.planResumeMode = this.currentMode;


### PR DESCRIPTION
### Linked issue

Closes #1582

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

On a daemon running as root, **every** Claude session failed at launch — including Ask mode, and including the internal structured-generation sessions that name branches and write PR metadata:

```
StructuredAgentFallbackError: Structured generation failed for all providers:
claude (claude-haiku-4-5): failed (Claude Code process exited with code 1
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons)
```

`ClaudeAgentSession.buildOptions` passed `allowDangerouslySkipPermissions: true` on every launch, so a later `setPermissionMode("bypassPermissions")` would survive a model/thinking/rewind-driven query restart. The SDK turns that into `--allow-dangerously-skip-permissions`, and Claude Code refuses to boot when it sees it as root:

```js
// claude 2.1.220
if (permissionMode === "bypassPermissions" || allowBypass) {
  if (process.getuid?.() === 0 && process.env.IS_SANDBOX !== "1" && !env.CLAUDE_CODE_BUBBLEWRAP) {
    console.error("--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons")
    process.exit(1)
  }
}
```

The capability was requested for a mode the user never selected, so the session died before it started.

The fix mirrors the CLI's own gate in one place, `isRootOutsideSandbox(uid, env)`:

- Drop the launch capability when the daemon is root outside a deliberate sandbox. Non-root daemons and `IS_SANDBOX=1` / `CLAUDE_CODE_BUBBLEWRAP` hosts are unchanged, so dynamic mode switching still works.
- Stop offering **Bypass** to a root daemon — filtered from both the provider catalog and the session's mode list, next to the existing Bedrock/Vertex filter for **Auto** mode. The app's picker reads the session's list, so filtering only the catalog would have changed nothing.
- Reject Bypass with an actionable error instead of a bare exit code, the same shape as the existing Auto-mode-on-Bedrock guard.
- Pin `permissionMode` and `allowDangerouslySkipPermissions` *after* the `extra.claude` spread. `extra.claude` is an arbitrary record off the wire and was spread over both keys, so a client could re-add the capability and reproduce the crash on a supported path. Pinning `permissionMode` is a second behavior change: `extra.claude.permissionMode` no longer overrides the mode the session owns through `setMode`, which is what let a crafted client route around the new guard.

The uid is read through a `getUid` port on `ClaudeAgentClientOptions`, defaulting to `() => process.getuid?.()`, so tests inject a uid rather than monkey-patch a global (`docs/testing.md:213`).

### How did you verify it

**Real Claude CLI, root simulated with `unshare --map-root-user`.** The reported error, reproduced against `claude 2.1.220`:

```console
$ unshare --map-root-user claude --allow-dangerously-skip-permissions -p "reply with the single word ok"
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
exit=1

$ unshare --map-root-user claude -p "reply with the single word ok"
ok
exit=0
```

**Real provider code path, before and after.** A script constructing `ClaudeAgentClient` against the real `claude` binary — no query mock, real spawn, real API call — run under `unshare --map-root-user`:

| Scenario | Before | After |
| --- | --- | --- |
| root daemon, Ask mode | `THREW: Claude Code process exited with code 1` | `RESULT finalText: "ok"` |
| root daemon, Bypass mode | `THREW: Claude Code process exited with code 1` | `THREW: Claude Bypass mode cannot be used while Paseo runs as root. Run the daemon as a non-root user.` |
| root + `IS_SANDBOX=1`, Bypass mode | `RESULT finalText: "ok"` | `RESULT finalText: "ok"` |
| non-root daemon (uid 1000), Bypass mode | `RESULT finalText: "ok"` | `RESULT finalText: "ok"` |

```console
$ unshare --map-root-user node_modules/.bin/tsx /tmp/root-e2e.mts    # before
daemon uid: 0
THREW: Claude Code process exited with code 1

$ unshare --map-root-user node_modules/.bin/tsx /tmp/root-e2e.mts    # after
daemon uid: 0
RESULT finalText: "ok"
```

**Automated coverage.** `packages/server/src/server/agent/providers/claude/agent.root-bypass.test.ts` — 10 tests, written first. Six fail against the pre-fix `agent.ts` for the reported reason; the other four are non-root and sandbox regression guards that must pass on both sides.

```console
$ npx vitest run src/server/agent/providers/claude/agent.root-bypass.test.ts   # pre-fix agent.ts
PASS (4) FAIL (6)
 × drops the bypass launch capability when the daemon runs as root
   → expected true to be false
 × ignores a bypass capability forced through extra.claude on a root daemon
   → expected true to be false
 × rejects switching to bypass mode when the daemon runs as root
   → promise resolved "undefined" instead of rejecting
 × rejects launching a bypass-mode session when the daemon runs as root
   → promise resolved "{ …(4) }" instead of rejecting
 × stops offering Bypass mode to a root daemon
   → expected [ 'plan', 'default', …(3) ] to not include 'bypassPermissions'
 × keeps Bypass out of the provider catalog for a root daemon
   → expected [ 'plan', 'default', …(3) ] to not include 'bypassPermissions'

$ npx vitest run src/server/agent/providers/claude/                            # with the fix
PASS (301) FAIL (0)

$ npm run typecheck        # exit 0
$ npm run lint             # Found 0 warnings and 0 errors.
$ npm run format:check     # All matched files use the correct format.
```

`agent.redesign.test.ts` pins `getUid: () => 1000` in its client constructions: its bypass expectations only hold for a non-root daemon, and they should not depend on which user runs the suite.

**Platforms.** Server-only change — no app, protocol, or UI code touched, so there is no UI to screenshot.

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS / Android / Web | — | No client code changed |
| Desktop macOS | — | Not run; the daemon logic is platform-independent apart from the uid read |
| Desktop Windows | ✅ by construction | `process.getuid` is undefined there, so the default port yields `undefined`, `isRootOutsideSandbox` is always false, and behavior is unchanged |
| Desktop Linux | ✅ | Everything above, root simulated with `unshare --map-root-user` |

The Docker image already runs the daemon as the non-root `paseo` user, so it is unaffected.

**Notes.**

- **Root daemons lose Bypass mode.** That is the upstream CLI's own policy; Paseo now surfaces it instead of dying at spawn. The workaround remains running the daemon as a non-root user.
- **Known ceiling:** the check reads the daemon's uid, while Claude Code reads its own. They differ when a `command` override wraps the CLI in something that changes user (`gosu`, `su`, `sudo`). A deprivileging wrapper loses a capability it could have had; a privilege-raising one gets the same raw CLI error as before this change. Named in a comment at the check; probing the wrapper's effective uid is the upgrade path.
- `this.currentMode = message.permissionMode` on the SDK `init` message still writes the mode without passing either guard. It reflects what the CLI reports, and the CLI will not report `bypassPermissions` on a root host now that the capability is gone, so it is unreachable rather than guarded.
- The session's mode list now also applies the existing Bedrock/Vertex `auto` filter, which previously only affected the provider catalog. Same helper, and it makes the two lists agree.
- No protocol change, so no COMPAT tag. No docs change: the constraint lives in the error message the user actually sees, and no doc in `docs/` owns "running the daemon as root".

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
