### PR TITLE
Keep dictation prompts visible during submission

### DIFF
--- a/packages/app/e2e/new-workspace-dictation-submit.spec.ts
+++ b/packages/app/e2e/new-workspace-dictation-submit.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test, type Page } from "./fixtures";
+import { gotoAppShell } from "./helpers/app";
+import { daemonWsRoutePattern } from "./helpers/daemon-port";
+import { openNewWorkspaceComposer, selectWorkspaceIsolation } from "./helpers/new-workspace";
+import { seedWorkspace } from "./helpers/seed-client";
+import { waitForSidebarHydration } from "./helpers/workspace-ui";
+
+type WebSocketMessage = string | Buffer;
+
+const TRANSCRIPT = "Keep this spoken prompt visible while creating the workspace";
+const CREATE_FAILURE = "Synthetic workspace creation failure";
+
+function parseEnvelope(message: WebSocketMessage): {
+  type?: unknown;
+  message?: Record<string, unknown>;
+} | null {
+  const raw = typeof message === "string" ? message : message.toString("utf8");
+  try {
+    return JSON.parse(raw) as { type?: unknown; message?: Record<string, unknown> };
+  } catch {
+    return null;
+  }
+}
+
+function sessionMessage(message: WebSocketMessage): Record<string, unknown> | null {
+  const envelope = parseEnvelope(message);
+  return envelope?.type === "session" && envelope.message ? envelope.message : null;
+}
+
+function sendSessionMessage(
+  ws: { send(message: string): void },
+  message: Record<string, unknown>,
+): void {
+  ws.send(JSON.stringify({ type: "session", message }));
+}
+
+function enableDictationCapability(message: WebSocketMessage): WebSocketMessage {
+  const envelope = parseEnvelope(message);
+  const payload = envelope?.message?.payload;
+  if (
+    envelope?.message?.type !== "status" ||
+    !payload ||
+    typeof payload !== "object" ||
+    (payload as { status?: unknown }).status !== "server_info"
+  ) {
+    return message;
+  }
+
+  (payload as Record<string, unknown>).capabilities = {
+    voice: {
+      dictation: { enabled: true, reason: "" },
+      voice: { enabled: false, reason: "Realtime voice is disabled in this test." },
+    },
+  };
+  return JSON.stringify(envelope);
+}
+
+async function installSyntheticMicrophone(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const mediaDevices = navigator.mediaDevices;
+    Object.defineProperty(mediaDevices, "getUserMedia", {
+      configurable: true,
+      value: async () => {
+        const context = new AudioContext();
+        const oscillator = context.createOscillator();
+        const destination = context.createMediaStreamDestination();
+        oscillator.connect(destination);
+        oscillator.start();
+        return destination.stream;
+      },
+    });
+  });
+}
+
+async function installDictationFailureHarness(page: Page) {
+  let resolveAudioChunk!: () => void;
+  let resolveCreateRequest!: () => void;
+  const audioChunk = new Promise<void>((resolve) => {
+    resolveAudioChunk = resolve;
+  });
+  const createRequest = new Promise<void>((resolve) => {
+    resolveCreateRequest = resolve;
+  });
+  let failCreate: (() => void) | null = null;
+
+  await page.routeWebSocket(daemonWsRoutePattern(), (ws) => {
+    const server = ws.connectToServer();
+
+    ws.onMessage((message) => {
+      const request = sessionMessage(message);
+      const type = request?.type;
+      const dictationId = typeof request?.dictationId === "string" ? request.dictationId : null;
+
+      if (type === "dictation_stream_start" && dictationId) {
+        sendSessionMessage(ws, {
+          type: "dictation_stream_ack",
+          payload: { dictationId, ackSeq: -1 },
+        });
+        return;
+      }
+      if (type === "dictation_stream_chunk" && dictationId) {
+        const seq = typeof request?.seq === "number" ? request.seq : 0;
+        sendSessionMessage(ws, {
+          type: "dictation_stream_ack",
+          payload: { dictationId, ackSeq: seq },
+        });
+        resolveAudioChunk();
+        return;
+      }
+      if (type === "dictation_stream_finish" && dictationId) {
+        sendSessionMessage(ws, {
+          type: "dictation_stream_finish_accepted",
+          payload: { dictationId, timeoutMs: 5_000 },
+        });
+        sendSessionMessage(ws, {
+          type: "dictation_stream_final",
+          payload: { dictationId, text: TRANSCRIPT },
+        });
+        return;
+      }
+      if (request && type === "workspace.create.request" && typeof request.requestId === "string") {
+        const requestId = request.requestId;
+        failCreate = () => {
+          sendSessionMessage(ws, {
+            type: "workspace.create.response",
+            payload: {
+              requestId,
+              workspace: null,
+              setupTerminalId: null,
+              error: CREATE_FAILURE,
+            },
+          });
+        };
+        resolveCreateRequest();
+        return;
+      }
+
+      server.send(message);
+    });
+
+    server.onMessage((message) => ws.send(enableDictationCapability(message)));
+  });
+
+  return {
+    waitForAudio: () => audioChunk,
+    waitForCreateRequest: () => createRequest,
+    failWorkspaceCreation: () => {
+      if (!failCreate) {
+        throw new Error("Workspace creation request has not been received");
+      }
+      failCreate();
+    },
+  };
+}
+
+async function dictateAndSend(page: Page, waitForAudio: () => Promise<void>): Promise<void> {
+  await page.getByRole("button", { name: "Start dictation" }).click();
+  await waitForAudio();
+  await page.getByRole("button", { name: "Insert transcription and send" }).click();
+}
+
+test.describe("New Workspace dictation submit", () => {
+  test.describe.configure({ timeout: 240_000 });
+
+  test("keeps the spoken prompt visible while pending and after failure", async ({ page }) => {
+    const seeded = await seedWorkspace({ repoPrefix: "dictation-submit-" });
+    await installSyntheticMicrophone(page);
+    const harness = await installDictationFailureHarness(page);
+
+    try {
+      await gotoAppShell(page);
+      await waitForSidebarHydration(page);
+      await openNewWorkspaceComposer(page, {
+        projectKey: seeded.projectKey,
+        projectDisplayName: seeded.projectDisplayName,
+      });
+      await selectWorkspaceIsolation(page, "local");
+
+      await dictateAndSend(page, harness.waitForAudio);
+      await harness.waitForCreateRequest();
+
+      const composer = page.getByRole("textbox", { name: "Message agent..." });
+      await expect(composer).toHaveValue(TRANSCRIPT);
+      await expect(composer).not.toBeEditable();
+
+      harness.failWorkspaceCreation();
+
+      await expect(composer).toBeEditable();
+      await expect(composer).toHaveValue(TRANSCRIPT);
+      await expect(page.getByText(CREATE_FAILURE).first()).toBeVisible();
+    } finally {
+      await seeded.cleanup();
+    }
+  });
+});

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -66,6 +66,7 @@ import {
   resolveVoiceTooltipText,
 } from "./labels";
 import {
+  applyDictationTranscript,
   computeCanStartDictation,
   resolveComposerSurfacePresentation,
   runAlternateSendAction,
@@ -776,42 +777,6 @@ function SendButtonTooltip({
       </TooltipContent>
     </Tooltip>
   );
-}
-
-interface DictationTranscriptContext {
-  value: string;
-  defaultSendBehavior: "interrupt" | "queue";
-  isAgentRunning: boolean;
-  onQueue: ((payload: MessagePayload) => void) | undefined;
-  onSubmit: (payload: MessagePayload) => void;
-  onChangeText: (text: string) => void;
-  attachments: ComposerAttachment[];
-  cwd: string;
-  autoSend: boolean;
-}
-
-function applyDictationTranscript(text: string, ctx: DictationTranscriptContext): void {
-  if (!text) return;
-  const shouldPad = ctx.value.length > 0 && !/\s$/.test(ctx.value);
-  const nextValue = `${ctx.value}${shouldPad ? " " : ""}${text}`;
-
-  if (!ctx.autoSend) {
-    ctx.onChangeText(nextValue);
-    return;
-  }
-
-  if (ctx.defaultSendBehavior === "queue" && ctx.isAgentRunning && ctx.onQueue) {
-    ctx.onQueue({ text: nextValue, attachments: ctx.attachments, cwd: ctx.cwd });
-    ctx.onChangeText("");
-    return;
-  }
-
-  ctx.onSubmit({
-    text: nextValue,
-    attachments: ctx.attachments,
-    cwd: ctx.cwd,
-    forceSend: ctx.isAgentRunning || undefined,
-  });
 }
 
 interface ToggleRealtimeVoiceContext {

--- a/packages/app/src/composer/input/state.test.ts
+++ b/packages/app/src/composer/input/state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyDictationTranscript,
   computeCanStartDictation,
   resolveComposerSurfacePresentation,
   runAlternateSendAction,
@@ -160,6 +161,29 @@ describe("dictation keyboard behavior", () => {
     keyboard.pressDictationShortcut();
 
     expect(keyboard.actions).toEqual(["start", "start"]);
+  });
+});
+
+describe("dictation transcript behavior", () => {
+  it("publishes an auto-sent transcript to the composer before submitting it", () => {
+    const actions: string[] = [];
+
+    applyDictationTranscript("spoken prompt", {
+      value: "typed context",
+      defaultSendBehavior: "interrupt",
+      isAgentRunning: false,
+      onQueue: undefined,
+      onChangeText: (text) => actions.push(`change:${text}`),
+      onSubmit: (payload) => actions.push(`submit:${payload.text}`),
+      attachments: [],
+      cwd: "/repo",
+      autoSend: true,
+    });
+
+    expect(actions).toEqual([
+      "change:typed context spoken prompt",
+      "submit:typed context spoken prompt",
+    ]);
   });
 });
 

--- a/packages/app/src/composer/input/state.ts
+++ b/packages/app/src/composer/input/state.ts
@@ -46,6 +46,44 @@ interface SendActionContext {
   handleQueueMessage: () => void;
 }
 
+interface DictationTranscriptContext {
+  value: string;
+  defaultSendBehavior: SendBehavior;
+  isAgentRunning: boolean;
+  onQueue: ((payload: MessagePayload) => void) | undefined;
+  onSubmit: (payload: MessagePayload) => void;
+  onChangeText: (text: string) => void;
+  attachments: MessagePayload["attachments"];
+  cwd: string;
+  autoSend: boolean;
+}
+
+export function applyDictationTranscript(text: string, ctx: DictationTranscriptContext): void {
+  if (!text) return;
+  const shouldPad = ctx.value.length > 0 && !/\s$/.test(ctx.value);
+  const nextValue = `${ctx.value}${shouldPad ? " " : ""}${text}`;
+
+  if (!ctx.autoSend) {
+    ctx.onChangeText(nextValue);
+    return;
+  }
+
+  ctx.onChangeText(nextValue);
+
+  if (ctx.defaultSendBehavior === "queue" && ctx.isAgentRunning && ctx.onQueue) {
+    ctx.onQueue({ text: nextValue, attachments: ctx.attachments, cwd: ctx.cwd });
+    ctx.onChangeText("");
+    return;
+  }
+
+  ctx.onSubmit({
+    text: nextValue,
+    attachments: ctx.attachments,
+    cwd: ctx.cwd,
+    forceSend: ctx.isAgentRunning || undefined,
+  });
+}
+
 interface MessageInputKeyboardActions {
   focusInput: () => void;
   isDictationRecording: () => boolean;


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### What does this PR do

Dictation auto-send now publishes the completed transcript into the controlled composer before invoking its normal submit path. New Workspace and draft-agent composers therefore show the spoken prompt while submission is pending and retain it when submission fails, matching typed prompt behavior.

The dictation handler previously submitted a constructed payload without updating composer state. Preserved draft surfaces locked with their previous value, which was often empty, even though the correct text was already being submitted.

### How did you verify it

- Verified the Playwright regression red against the old behavior: the pending New Workspace composer expected `Keep this spoken prompt visible while creating the workspace` but received `""`.
- Restored the fix and ran `npm run test:e2e --workspace=@getpaseo/app -- new-workspace-dictation-submit.spec.ts`: 1 passed.
- Ran `npx vitest run packages/app/src/composer/input/state.test.ts --bail=1`: 16 passed.
- Ran `npm run typecheck`: passed.
- Ran `npm run lint`: passed with 0 warnings and 0 errors.
- Ran `npm run format`: passed; the commit hook also passed targeted format, lint, and full workspace typecheck.
- Captured and inspected the locked-pending and restored-after-failure states in Desktop Chrome.

Platform coverage:

- Web / Desktop Chrome: tested through Playwright.
- iOS, Android, and Electron desktop: not manually tested. The production change is in the shared cross-platform composer state transition.

Risk surface: dictation transcript insertion and auto-send ordering in the shared composer. Queue/interrupt selection and the existing submission lifecycle are unchanged.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
