### PR TITLE
fix(server): strip GUI credential helpers from agent environments

### DIFF
--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -265,6 +265,39 @@ describe("createProviderEnv", () => {
     expect(env.CLAUDE_AGENT_SDK_VERSION).toBeUndefined();
     expect(env.CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING).toBe("true");
   });
+
+  test("strips inherited askpass helpers so credential prompts fail fast", () => {
+    const base = {
+      PATH: "/usr/bin",
+      SUDO_ASKPASS: "/usr/bin/zenity-askpass",
+      SSH_ASKPASS: "/usr/bin/ssh-askpass",
+      GIT_ASKPASS: "/usr/bin/git-askpass",
+      DISPLAY: ":1",
+    };
+
+    const env = createProviderEnv({ baseEnv: base });
+
+    expect(env.SUDO_ASKPASS).toBeUndefined();
+    expect(env.SSH_ASKPASS).toBeUndefined();
+    expect(env.GIT_ASKPASS).toBeUndefined();
+    // DISPLAY stays: it is not itself a credential prompt, and GUI-aware
+    // tools legitimately use it.
+    expect(env.DISPLAY).toBe(":1");
+  });
+
+  test("keeps an explicitly configured askpass helper", () => {
+    const base = {
+      PATH: "/usr/bin",
+      SUDO_ASKPASS: "/usr/bin/zenity-askpass",
+    };
+
+    const env = createProviderEnv({
+      baseEnv: base,
+      runtimeSettings: { env: { SUDO_ASKPASS: "/opt/paseo/bin/paseo-askpass" } },
+    });
+
+    expect(env.SUDO_ASKPASS).toBe("/opt/paseo/bin/paseo-askpass");
+  });
 });
 
 describe("ProviderOverrideSchema", () => {

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -210,6 +210,14 @@ const PARENT_SESSION_ENV_VARS = [
   "CLAUDE_AGENT_SDK_VERSION",
 ];
 
+// GUI credential helpers. Agent tool calls run without a TTY, so sudo/ssh
+// fall back to the askpass helper — typically a desktop dialog the remote
+// user can never see, parking the agent's turn indefinitely. Strip them so
+// credential prompts fail fast with a legible error instead. An explicit
+// value in provider runtimeSettings.env is kept: that is a deliberate
+// configuration, not an inherited leak.
+const ASKPASS_ENV_VARS = ["SUDO_ASKPASS", "SSH_ASKPASS", "GIT_ASKPASS"];
+
 export interface ProviderEnvOptions {
   baseEnv?: ProcessEnvRecord;
   runtimeSettings?: ProviderRuntimeSettings;
@@ -235,6 +243,11 @@ export function createProviderEnvSpec(options: ProviderEnvOptions = {}): Provide
   const envOverlay: ProcessEnvRecord = Object.assign({}, ...overlays);
   for (const key of PARENT_SESSION_ENV_VARS) {
     envOverlay[key] = undefined;
+  }
+  for (const key of ASKPASS_ENV_VARS) {
+    if (!(key in envOverlay)) {
+      envOverlay[key] = undefined;
+    }
   }
   return {
     ...(options.baseEnv ? { baseEnv: options.baseEnv } : {}),

--- a/packages/server/src/server/agent/providers/jsonl-rpc-process.ts
+++ b/packages/server/src/server/agent/providers/jsonl-rpc-process.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
 import type { Logger } from "pino";
 
+import type { ProcessEnvRecord } from "../../paseo-env.js";
 import { spawnProcess } from "../../../utils/spawn.js";
 import { terminateWithTreeKill } from "../../../utils/tree-kill.js";
 
@@ -20,7 +21,7 @@ export interface JsonlRpcLaunch {
   command: string;
   args: string[];
   cwd: string;
-  env?: Record<string, string>;
+  env?: ProcessEnvRecord;
 }
 
 interface JsonlRpcResponse {

--- a/packages/server/src/server/agent/providers/omp/runtime.test.ts
+++ b/packages/server/src/server/agent/providers/omp/runtime.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
+import { buildOmpLaunch } from "./runtime.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
 
 test("falls back to progress when the event subscription is unavailable", async () => {
@@ -8,4 +9,31 @@ test("falls back to progress when the event subscription is unavailable", async 
   await omp.start();
 
   await expect(omp.waitForSubscriptionFallback()).resolves.toEqual(["events", "progress"]);
+});
+
+describe("buildOmpLaunch env", () => {
+  test("marks inherited askpass helpers and parent-session markers for deletion", () => {
+    const launch = buildOmpLaunch({
+      command: ["omp"],
+      session: { cwd: "/workspace/project" },
+    });
+
+    expect(launch.env?.SUDO_ASKPASS).toBeUndefined();
+    expect(launch.env?.SSH_ASKPASS).toBeUndefined();
+    expect(launch.env?.GIT_ASKPASS).toBeUndefined();
+    expect(launch.env?.CLAUDECODE).toBeUndefined();
+    expect(Object.keys(launch.env ?? {})).toEqual(
+      expect.arrayContaining(["SUDO_ASKPASS", "SSH_ASKPASS", "GIT_ASKPASS", "CLAUDECODE"]),
+    );
+  });
+
+  test("keeps an explicitly configured askpass helper", () => {
+    const launch = buildOmpLaunch({
+      command: ["omp"],
+      runtimeSettings: { env: { SUDO_ASKPASS: "/opt/paseo/bin/paseo-askpass" } },
+      session: { cwd: "/workspace/project" },
+    });
+
+    expect(launch.env?.SUDO_ASKPASS).toBe("/opt/paseo/bin/paseo-askpass");
+  });
 });

--- a/packages/server/src/server/agent/providers/omp/runtime.ts
+++ b/packages/server/src/server/agent/providers/omp/runtime.ts
@@ -12,12 +12,16 @@ import type {
   OmpSubagentSubscriptionLevel,
   OmpThinkingLevel,
 } from "./rpc-types.js";
-import type { ProviderRuntimeSettings } from "../../provider-launch-config.js";
+import type { ProcessEnvRecord } from "../../../paseo-env.js";
+import {
+  createProviderEnvSpec,
+  type ProviderRuntimeSettings,
+} from "../../provider-launch-config.js";
 
 export interface OmpRuntimeLaunch {
   cwd: string;
   argv: string[];
-  env?: Record<string, string>;
+  env?: ProcessEnvRecord;
   protocolMode?: "rpc" | "rpc-ui";
   model?: string;
   thinkingOptionId?: string;
@@ -100,13 +104,11 @@ export function buildOmpLaunch(input: {
   return {
     cwd: input.session.cwd,
     argv,
-    env:
-      input.runtimeSettings?.env || input.session.env
-        ? {
-            ...input.runtimeSettings?.env,
-            ...input.session.env,
-          }
-        : undefined,
+    // Same shared provider env spec as every other provider: strips
+    // inherited GUI credential helpers and parent-session markers.
+    env: createProviderEnvSpec({
+      overlays: [input.runtimeSettings?.env, input.session.env],
+    }).envOverlay,
     model: input.session.model,
     thinkingOptionId: input.session.thinkingOptionId,
     protocolMode,

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
@@ -5,7 +5,7 @@ import pino from "pino";
 import { describe, expect, test, vi } from "vitest";
 
 import { PiCliRuntime } from "./cli-runtime.js";
-import type { PiRuntimeLaunch } from "./runtime.js";
+import { buildPiLaunch, type PiRuntimeLaunch } from "./runtime.js";
 
 type PiChild = ChildProcessWithoutNullStreams & {
   stdin: PassThrough;
@@ -443,5 +443,32 @@ describe("PiCliRuntime", () => {
 
     // Neither RPC returned usable data — should resolve with empty object
     expect(stats).toEqual({});
+  });
+});
+
+describe("buildPiLaunch env", () => {
+  test("marks inherited askpass helpers and parent-session markers for deletion", () => {
+    const launch = buildPiLaunch({
+      command: ["pi"],
+      session: { cwd: "/workspace/project" },
+    });
+
+    expect(launch.env?.SUDO_ASKPASS).toBeUndefined();
+    expect(launch.env?.SSH_ASKPASS).toBeUndefined();
+    expect(launch.env?.GIT_ASKPASS).toBeUndefined();
+    expect(launch.env?.CLAUDECODE).toBeUndefined();
+    expect(Object.keys(launch.env ?? {})).toEqual(
+      expect.arrayContaining(["SUDO_ASKPASS", "SSH_ASKPASS", "GIT_ASKPASS", "CLAUDECODE"]),
+    );
+  });
+
+  test("keeps an explicitly configured askpass helper", () => {
+    const launch = buildPiLaunch({
+      command: ["pi"],
+      runtimeSettings: { env: { SUDO_ASKPASS: "/opt/paseo/bin/paseo-askpass" } },
+      session: { cwd: "/workspace/project" },
+    });
+
+    expect(launch.env?.SUDO_ASKPASS).toBe("/opt/paseo/bin/paseo-askpass");
   });
 });

--- a/packages/server/src/server/agent/providers/pi/runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/runtime.ts
@@ -7,12 +7,16 @@ import type {
   PiSessionState,
   PiSessionStats,
 } from "./rpc-types.js";
-import type { ProviderRuntimeSettings } from "../../provider-launch-config.js";
+import type { ProcessEnvRecord } from "../../../paseo-env.js";
+import {
+  createProviderEnvSpec,
+  type ProviderRuntimeSettings,
+} from "../../provider-launch-config.js";
 
 export interface PiRuntimeLaunch {
   cwd: string;
   argv: string[];
-  env?: Record<string, string>;
+  env?: ProcessEnvRecord;
   protocolMode?: "rpc" | "rpc-ui";
   model?: string;
   thinkingOptionId?: string;
@@ -88,13 +92,12 @@ export function buildPiLaunch(input: {
   return {
     cwd: input.session.cwd,
     argv,
-    env:
-      input.runtimeSettings?.env || input.session.env
-        ? {
-            ...input.runtimeSettings?.env,
-            ...input.session.env,
-          }
-        : undefined,
+    // Route through the shared provider env spec so inherited GUI credential
+    // helpers (askpass class) and parent-session markers are stripped here
+    // too, not just for providers that spawn via createProviderEnv directly.
+    env: createProviderEnvSpec({
+      overlays: [input.runtimeSettings?.env, input.session.env],
+    }).envOverlay,
     model: input.session.model,
     thinkingOptionId: input.session.thinkingOptionId,
     protocolMode,


### PR DESCRIPTION
## Problem

On a desktop host, the daemon inherits the login session's environment (`inheritLoginShellEnv`) — including GUI credential helpers like `SUDO_ASKPASS`. Agent tool calls run without a TTY, so an ordinary `sudo apt install` falls back to the askpass helper: an invisible desktop dialog the remote user can never see or answer. The agent's turn parks until the tool timeout (5 minutes of silence under omp's default), with nothing in the chat explaining why.

Notable: the failure only exists when running the agent *through paseo* — the same agent in a real terminal prompts visibly. It's an environment-leak bug, not an agent bug.

The codebase already treats this class as a bug elsewhere: `GIT_TERMINAL_PROMPT=0` in all forge/git services, `NO_BROWSER` on ACP probes, `SSH_ASKPASS=/usr/bin/false` + BatchMode in the test harness, and the `PARENT_SESSION_ENV_VARS` strip for `CLAUDECODE`. Agent spawn env was the gap.

## Fix

- `createProviderEnvSpec` now strips `SUDO_ASKPASS`, `SSH_ASKPASS`, and `GIT_ASKPASS` (in addition to the existing parent-session vars), so credential prompts **fail fast with a legible error** the agent can react to. Values set explicitly via `runtimeSettings.env` are kept — deliberate configuration, not a leak.
- The pi and omp providers built launch env by hand and **bypassed the spec entirely**; they now route through it, gaining both strips. This was the exposed path for omp agents (which additionally harden `SSH_ASKPASS`/`GIT_TERMINAL_PROMPT` at their tool layer but not `SUDO_ASKPASS`).

Deliberately kept:
- `DISPLAY` — GUI-aware tools (browser automation) legitimately need it.
- `DBUS_SESSION_BUS_ADDRESS` — secret-service reads work silently when the keyring is unlocked; stripping would break working flows to fix locked-keyring edge cases.
- Paseo terminals — they have a real PTY, so credential prompts are visible to the remote user. That path is a feature.

Residual, documented non-goals: gpg GUI pinentry and locked-keyring D-Bus prompts (conditional, unfixable without breaking working cases).

## Tests

- Spec: strips inherited askpass vars (incl. `GIT_ASKPASS`), keeps `DISPLAY`, keeps explicit overrides.
- pi/omp launch builders: askpass + parent-session markers marked for deletion; explicit override preserved.
- Full pi + omp provider suites: 198 green. Typecheck/lint/format clean.
