### PR TITLE
Stabilize Hub worktree archive coverage on Windows

### DIFF
--- a/packages/server/src/server/hub/execution-session.websocket.test.ts
+++ b/packages/server/src/server/hub/execution-session.websocket.test.ts
@@ -184,7 +184,7 @@ test("Hub archives a running execution's Paseo-created worktree", async () => {
     agentArchivedAt: expect.any(String),
     workspaceArchivedAt: expect.any(String),
   });
-}, 20_000);
+}, 30_000);
 
 test("a sibling workspace keeps an archived execution's worktree directory alive", async () => {
   const hub = await launchRelationship();


### PR DESCRIPTION
The Hub worktree archive regression now has enough test budget on loaded Windows runners for its operation-specific archive deadline to remain authoritative. This prevents infrastructure variance from masking the behavior the test is meant to verify.

### Linked issue

None. The failure was observed in [CI run 30699276446](https://github.com/getpaseo/paseo/actions/runs/30699276446/job/91367295913).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The test had a 20-second outer deadline, while its archive observer starts later and owns a 15-second deadline. On a loaded Windows runner, daemon startup, CLI connection, agent startup, and Git worktree creation consumed enough time for the outer deadline to fire first. Recent successful Windows runs took 10.2–16.1 seconds; the failing run reached 20.081 seconds.

The outer deadline is now 30 seconds. The 15-second archive observer still detects real archive failures with a specific error.

### Goals

- Keep the real daemon and Git worktree regression running on Windows CI.
- Prevent setup variance from preempting the archive observer.
- Preserve the existing product behavior and archive failure detection.

### Non-goals

- Change Hub execution or worktree archive behavior.
- Serialize the server test suite.
- Relax the archive observer deadline.

### QA

- Reproduced the exact generic 20-second timeout from the linked Windows Actions job.
- Confirmed recent Windows executions of the same test varied between 10.2 and 16.1 seconds.
- `npx vitest run packages/server/src/server/hub/execution-session.websocket.test.ts -t "Hub archives a running execution's Paseo-created worktree" --bail=1` — passed.
- `npm run typecheck` — passed.
- `npm run lint -- packages/server/src/server/hub/execution-session.websocket.test.ts` — passed.
- `npm run format` — passed.
- Windows verification is delegated to PR CI.

### Risk surface

Test-only. A real archive stall still fails after the observer's 15-second deadline; only the surrounding Vitest deadline changes.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
