### PR TITLE
feat(app): unify Add Project search across local and GitHub sources

### DIFF
--- a/packages/app/src/add-project-flow/filter-store.test.ts
+++ b/packages/app/src/add-project-flow/filter-store.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readAddProjectSourceFilter, useAddProjectFilterStore } from "./filter-store";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn().mockResolvedValue(null),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe("add-project source filter store", () => {
+  beforeEach(() => {
+    useAddProjectFilterStore.setState({ filterByHost: {} });
+  });
+
+  it("defaults to All when nothing is stored", () => {
+    expect(readAddProjectSourceFilter({}, "host-1")).toBe("all");
+    expect(readAddProjectSourceFilter({}, null)).toBe("all");
+  });
+
+  it("persists an explicit per-host selection without touching other hosts", () => {
+    useAddProjectFilterStore.getState().setHostFilter("host-1", "local");
+    useAddProjectFilterStore.getState().setHostFilter("host-2", "github");
+
+    const { filterByHost } = useAddProjectFilterStore.getState();
+    expect(readAddProjectSourceFilter(filterByHost, "host-1")).toBe("local");
+    expect(readAddProjectSourceFilter(filterByHost, "host-2")).toBe("github");
+    expect(readAddProjectSourceFilter(filterByHost, "host-3")).toBe("all");
+  });
+
+  it("drops the stored preference when the user returns to All", () => {
+    const { setHostFilter } = useAddProjectFilterStore.getState();
+    setHostFilter("host-1", "github");
+    setHostFilter("host-1", "all");
+
+    expect(useAddProjectFilterStore.getState().filterByHost).toEqual({});
+    expect(readAddProjectSourceFilter({}, "host-1")).toBe("all");
+  });
+});

--- a/packages/app/src/add-project-flow/filter-store.ts
+++ b/packages/app/src/add-project-flow/filter-store.ts
@@ -1,0 +1,48 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+import type { AddProjectSourceFilter } from "./options";
+
+interface AddProjectFilterStoreState {
+  /** Explicit per-host selections only. Absent key = "all" (the default). */
+  filterByHost: Record<string, AddProjectSourceFilter>;
+  setHostFilter: (hostId: string, filter: AddProjectSourceFilter) => void;
+}
+
+/**
+ * Per-host sticky source filter for the unified Add Project search. Only
+ * explicit non-default selections are persisted — choosing "all" removes the
+ * stored preference so the default can never stomp a host that was never
+ * customized, and a stored filter always reflects a deliberate user choice.
+ */
+export const useAddProjectFilterStore = create<AddProjectFilterStoreState>()(
+  persist(
+    (set) => ({
+      filterByHost: {},
+      setHostFilter: (hostId, filter) =>
+        set((state) => {
+          const filterByHost = { ...state.filterByHost };
+          if (filter === "all") {
+            delete filterByHost[hostId];
+          } else {
+            filterByHost[hostId] = filter;
+          }
+          return { filterByHost };
+        }),
+    }),
+    {
+      name: "add-project-source-filter",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ filterByHost: state.filterByHost }),
+    },
+  ),
+);
+
+export function readAddProjectSourceFilter(
+  filterByHost: Record<string, AddProjectSourceFilter>,
+  hostId: string | null,
+): AddProjectSourceFilter {
+  if (!hostId) return "all";
+  return filterByHost[hostId] ?? "all";
+}

--- a/packages/app/src/add-project-flow/model.test.ts
+++ b/packages/app/src/add-project-flow/model.test.ts
@@ -6,7 +6,6 @@ import {
   moveAddProjectActiveIndex,
   moveAddProjectSelection,
   openAddProjectFlow,
-  openDirectorySearchPage,
   openGithubLocationPage,
   openNewDirectoryNamePage,
   openNewDirectoryParentPage,
@@ -16,10 +15,11 @@ import {
   type AddProjectHost,
 } from "./model";
 import {
-  addProjectMethodEmptyText,
-  buildAddProjectMethods,
+  buildAddProjectSourceOptions,
   buildCloneLocationOptions,
   buildManualGithubRepositoryChoices,
+  canUseGithubSource,
+  resolveAddProjectSourceFilter,
 } from "./options";
 
 const HOST: AddProjectHost = {
@@ -37,11 +37,12 @@ describe("Add Project navigation", () => {
     const state = openAddProjectFlow({ hosts: [HOST] });
 
     expect(currentAddProjectPage(state)).toEqual({
-      kind: "method",
+      kind: "search",
       hostId: "host-1",
       query: "",
       activeIndex: 0,
       error: null,
+      isSubmitting: false,
     });
     expect(backAddProjectPage(state)).toBeNull();
   });
@@ -52,7 +53,7 @@ describe("Add Project navigation", () => {
     state = setAddProjectPageInput(state, "rem");
     state = setAddProjectActiveIndex(state, 1);
     state = chooseAddProjectHost(state, secondHost.serverId);
-    state = openDirectorySearchPage(state, secondHost.serverId);
+    state = openNewDirectoryParentPage(state, secondHost.serverId);
 
     state = backAddProjectPage(state) ?? state;
     state = backAddProjectPage(state) ?? state;
@@ -110,42 +111,36 @@ describe("Add Project navigation", () => {
   });
 });
 
-describe("Add Project options", () => {
-  it("hides every mutating method when the host lacks stable project identity", () => {
+describe("Add Project source filters", () => {
+  it("hides the GitHub source when the host cannot clone repositories", () => {
     const outdatedHost = { ...HOST, canAddProject: false };
 
-    expect(buildAddProjectMethods(outdatedHost)).toEqual([]);
-    expect(addProjectMethodEmptyText(outdatedHost)).toBe("Update the host to use Add Project.");
+    expect(canUseGithubSource(outdatedHost)).toBe(false);
+    expect(buildAddProjectSourceOptions(outdatedHost)).toEqual([
+      { id: "all", label: "All" },
+      { id: "local", label: "Local" },
+    ]);
   });
 
-  it("keeps host-upgrade methods discoverable while hiding local-only Browse", () => {
+  it("offers the GitHub source whenever cloning works, even without account search", () => {
     expect(
-      buildAddProjectMethods({
+      buildAddProjectSourceOptions({
         ...HOST,
-        canBrowse: false,
-        canCloneGithubRepositories: false,
         canSearchGithubRepositories: false,
-        canCreateDirectory: false,
       }),
     ).toEqual([
-      {
-        id: "directory-search",
-        label: "Search for directory",
-        description: "Find a directory on Local",
-      },
-      {
-        id: "github",
-        label: "Clone from GitHub",
-        description: "Update this host to clone GitHub repositories",
-        disabled: true,
-      },
-      {
-        id: "new-directory",
-        label: "New directory",
-        description: "Update this host to create directories",
-        disabled: true,
-      },
+      { id: "all", label: "All" },
+      { id: "local", label: "Local" },
+      { id: "github", label: "GitHub" },
     ]);
+  });
+
+  it("falls back to All when a stored filter outlives its capability", () => {
+    expect(
+      resolveAddProjectSourceFilter({ ...HOST, canCloneGithubRepositories: false }, "github"),
+    ).toBe("all");
+    expect(resolveAddProjectSourceFilter(HOST, "github")).toBe("github");
+    expect(resolveAddProjectSourceFilter(HOST, "local")).toBe("local");
   });
 
   it("offers manual URL and protocol-specific owner/repo clone choices", () => {

--- a/packages/app/src/add-project-flow/model.ts
+++ b/packages/app/src/add-project-flow/model.ts
@@ -25,9 +25,7 @@ interface SearchPageState {
 
 export type AddProjectPage =
   | ({ kind: "host" } & SearchPageState)
-  | ({ kind: "method"; hostId: string } & SearchPageState)
-  | ({ kind: "directory-search"; hostId: string; isSubmitting: boolean } & SearchPageState)
-  | ({ kind: "github-search"; hostId: string } & SearchPageState)
+  | ({ kind: "search"; hostId: string; isSubmitting: boolean } & SearchPageState)
   | ({
       kind: "github-location";
       hostId: string;
@@ -61,8 +59,8 @@ function searchPage<TKind extends AddProjectPage["kind"]>(kind: TKind) {
   return { kind, query: "", activeIndex: 0, error: null } as const;
 }
 
-function methodPage(hostId: string): AddProjectPage {
-  return { ...searchPage("method"), hostId };
+function unifiedSearchPage(hostId: string): AddProjectPage {
+  return { ...searchPage("search"), hostId, isSubmitting: false };
 }
 
 export function openAddProjectFlow(input: OpenAddProjectFlowInput): AddProjectFlowState {
@@ -74,7 +72,7 @@ export function openAddProjectFlow(input: OpenAddProjectFlowInput): AddProjectFl
 
   return {
     hosts: input.hosts,
-    pages: initialHost ? [methodPage(initialHost.serverId)] : [searchPage("host")],
+    pages: initialHost ? [unifiedSearchPage(initialHost.serverId)] : [searchPage("host")],
     newDirectoryNameDrafts: {},
     githubLocationDrafts: {},
   };
@@ -97,7 +95,7 @@ export function applyAvailableAddProjectHosts(
   return {
     ...state,
     hosts,
-    pages: initialHost ? [methodPage(initialHost.serverId)] : state.pages,
+    pages: initialHost ? [unifiedSearchPage(initialHost.serverId)] : state.pages,
   };
 }
 
@@ -138,25 +136,7 @@ export function chooseAddProjectHost(
   state: AddProjectFlowState,
   hostId: string,
 ): AddProjectFlowState {
-  return pushAddProjectPage(state, methodPage(hostId));
-}
-
-export function openDirectorySearchPage(
-  state: AddProjectFlowState,
-  hostId: string,
-): AddProjectFlowState {
-  return pushAddProjectPage(state, {
-    ...searchPage("directory-search"),
-    hostId,
-    isSubmitting: false,
-  });
-}
-
-export function openGithubSearchPage(
-  state: AddProjectFlowState,
-  hostId: string,
-): AddProjectFlowState {
-  return pushAddProjectPage(state, { ...searchPage("github-search"), hostId });
+  return pushAddProjectPage(state, unifiedSearchPage(hostId));
 }
 
 export function openGithubLocationPage(

--- a/packages/app/src/add-project-flow/options.ts
+++ b/packages/app/src/add-project-flow/options.ts
@@ -6,13 +6,11 @@ import {
 import { shortenPath } from "@/utils/shorten-path";
 import type { AddProjectHost, GithubRepositoryChoice } from "./model";
 
-export type AddProjectMethodId = "directory-search" | "browse" | "github" | "new-directory";
+export type AddProjectSourceFilter = "all" | "local" | "github";
 
-export interface AddProjectMethodOption {
-  id: AddProjectMethodId;
+export interface AddProjectSourceOption {
+  id: AddProjectSourceFilter;
   label: string;
-  description: string;
-  disabled?: boolean;
 }
 
 export interface AddProjectPathOption {
@@ -23,6 +21,39 @@ export interface AddProjectPathOption {
   disabled: boolean;
 }
 
+/**
+ * The GitHub source needs cloning support; searching your account is a
+ * separate capability — without it, manual URL/owner-repo entry still works.
+ */
+export function canUseGithubSource(host: AddProjectHost): boolean {
+  return host.canAddProject && host.canCloneGithubRepositories;
+}
+
+/** Pill order is fixed: All first, then the specific sources. */
+export function buildAddProjectSourceOptions(host: AddProjectHost): AddProjectSourceOption[] {
+  const options: AddProjectSourceOption[] = [
+    { id: "all", label: "All" },
+    { id: "local", label: "Local" },
+  ];
+  if (canUseGithubSource(host)) {
+    options.push({ id: "github", label: "GitHub" });
+  }
+  return options;
+}
+
+/**
+ * A stored filter can outlive the capability it names (host downgrade,
+ * feature flag flip). Fall back to the default instead of rendering an
+ * empty source the user can't act on.
+ */
+export function resolveAddProjectSourceFilter(
+  host: AddProjectHost,
+  stored: AddProjectSourceFilter,
+): AddProjectSourceFilter {
+  if (stored === "github" && !canUseGithubSource(host)) return "all";
+  return stored;
+}
+
 export function filterAddProjectHosts(hosts: AddProjectHost[], query: string): AddProjectHost[] {
   const normalized = query.trim().toLowerCase();
   if (!normalized) return hosts;
@@ -31,54 +62,6 @@ export function filterAddProjectHosts(hosts: AddProjectHost[], query: string): A
       host.label.toLowerCase().includes(normalized) ||
       host.serverId.toLowerCase().includes(normalized),
   );
-}
-
-export function buildAddProjectMethods(host: AddProjectHost): AddProjectMethodOption[] {
-  if (!host.canAddProject) return [];
-  const options: AddProjectMethodOption[] = [];
-  options.push({
-    id: "directory-search",
-    label: "Search for directory",
-    description: `Find a directory on ${host.label}`,
-  });
-  if (host.canBrowse) {
-    options.push({
-      id: "browse",
-      label: "Browse",
-      description: "Choose or create a directory in Finder",
-    });
-  }
-  options.push({
-    id: "github",
-    label: "Clone from GitHub",
-    description: githubMethodDescription(host),
-    disabled: !host.canCloneGithubRepositories,
-  });
-  options.push({
-    id: "new-directory",
-    label: "New directory",
-    description: host.canCreateDirectory
-      ? `Create an empty directory on ${host.label}`
-      : "Update this host to create directories",
-    disabled: !host.canCreateDirectory,
-  });
-  return options;
-}
-
-export function addProjectMethodEmptyText(host: AddProjectHost | null): string {
-  return host?.canAddProject === false
-    ? "Update the host to use Add Project."
-    : "No matching options";
-}
-
-function githubMethodDescription(host: AddProjectHost): string {
-  if (!host.canCloneGithubRepositories) {
-    return "Update this host to clone GitHub repositories";
-  }
-  if (host.canSearchGithubRepositories) {
-    return "Search projects available to your GitHub account";
-  }
-  return "Enter a GitHub URL or owner/repo";
 }
 
 export function pathBaseName(path: string): string {

--- a/packages/app/src/components/add-project-flow.tsx
+++ b/packages/app/src/components/add-project-flow.tsx
@@ -8,7 +8,6 @@ import {
   Github,
   HardDrive,
   Plus,
-  Search,
   Server,
 } from "lucide-react-native";
 import {
@@ -37,9 +36,7 @@ import {
   currentAddProjectPage,
   moveAddProjectSelection,
   openAddProjectFlow,
-  openDirectorySearchPage,
   openGithubLocationPage,
-  openGithubSearchPage,
   openNewDirectoryNamePage,
   openNewDirectoryParentPage,
   setAddProjectActiveIndex,
@@ -52,16 +49,21 @@ import {
   type GithubRepositoryChoice,
 } from "@/add-project-flow/model";
 import {
-  buildAddProjectMethods,
-  addProjectMethodEmptyText,
+  buildAddProjectSourceOptions,
   buildCloneLocationOptions,
   buildManualGithubRepositoryChoices,
   buildSuggestedParentDirectories,
+  canUseGithubSource,
   filterAddProjectHosts,
   joinDirectoryPath,
   pathBaseName,
-  type AddProjectMethodId,
+  resolveAddProjectSourceFilter,
+  type AddProjectSourceFilter,
 } from "@/add-project-flow/options";
+import {
+  readAddProjectSourceFilter,
+  useAddProjectFilterStore,
+} from "@/add-project-flow/filter-store";
 import {
   buildProjectPickerOptions,
   type ProjectPickerOption,
@@ -103,6 +105,8 @@ interface FlowRowOption {
   subtitle: string | null;
   icon: ComponentType<{ size?: number; color?: string }>;
   disabled?: boolean;
+  /** Group headers render as plain labels and are never selectable. */
+  header?: boolean;
   testID: string;
   select: () => void;
 }
@@ -156,13 +160,6 @@ function FlowBackButton({ onPress }: { onPress: () => void }) {
   );
 }
 
-function methodIcon(method: AddProjectMethodId): FlowRowOption["icon"] {
-  if (method === "github") return Github;
-  if (method === "browse") return FolderOpen;
-  if (method === "new-directory") return FolderPlus;
-  return Search;
-}
-
 function directoryOptionSubtitle(option: ProjectPickerOption, shortPath: string): string | null {
   if (option.kind === "path") return "Open this path";
   if (shortPath === option.path) return null;
@@ -177,8 +174,11 @@ function progressText(page: AddProjectPage): string {
 
 function emptyText(page: AddProjectPage, host: AddProjectHost | null): string {
   if (page.kind === "host") return "No connected hosts";
-  if (page.kind === "github-search") return "Enter a GitHub URL or owner/repo";
-  if (page.kind === "method") return addProjectMethodEmptyText(host);
+  if (page.kind === "search") {
+    return host?.canAddProject === false
+      ? "Update the host to use Add Project."
+      : "No matching options";
+  }
   return "No matching options";
 }
 
@@ -206,12 +206,8 @@ function pageTitle(page: AddProjectPage): string {
   switch (page.kind) {
     case "host":
       return "Choose host";
-    case "method":
+    case "search":
       return "Add project";
-    case "directory-search":
-      return "Search for directory";
-    case "github-search":
-      return "Clone from GitHub";
     case "github-location":
       return "Choose destination";
     case "new-directory-parent":
@@ -225,12 +221,8 @@ function pagePlaceholder(page: AddProjectPage): string {
   switch (page.kind) {
     case "host":
       return "Search hosts...";
-    case "method":
-      return "Search methods...";
-    case "directory-search":
-      return "Search directories or enter a path...";
-    case "github-search":
-      return "Search or enter a GitHub repository...";
+    case "search":
+      return "Search directories and GitHub, or enter a path...";
     case "github-location":
     case "new-directory-parent":
       return "Search parent directories or enter a path...";
@@ -260,6 +252,13 @@ function FlowRow({ option, active }: { option: FlowRowOption; active: boolean })
     ],
     [active, option.disabled],
   );
+  if (option.header) {
+    return (
+      <Text style={styles.groupHeader} testID={option.testID}>
+        {option.title}
+      </Text>
+    );
+  }
   return (
     <Pressable
       accessibilityRole="button"
@@ -293,6 +292,175 @@ function FlowHint({ keys, action }: { keys: string[]; action: string }) {
       <Text style={styles.footerAction}>{action}</Text>
     </View>
   );
+}
+
+function SourcePill({
+  id,
+  label,
+  active,
+  testID,
+  onSelect,
+}: {
+  id: AddProjectSourceFilter;
+  label: string;
+  active: boolean;
+  testID: string;
+  onSelect: (filter: AddProjectSourceFilter) => void;
+}) {
+  const accessibilityState = useMemo(() => ({ selected: active }), [active]);
+  const handlePress = useCallback(() => onSelect(id), [id, onSelect]);
+  const pillStyle = useCallback(
+    ({ hovered = false, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.pill,
+      (active || hovered || pressed) && styles.pillActive,
+    ],
+    [active],
+  );
+  return (
+    <Pressable
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityState={accessibilityState}
+      testID={testID}
+      style={pillStyle}
+    >
+      <Text style={[styles.pillText, active && styles.pillTextActive]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+type SearchPage = Extract<AddProjectPage, { kind: "search" }>;
+
+function buildSearchRows(input: {
+  page: SearchPage;
+  host: AddProjectHost;
+  sourceFilter: AddProjectSourceFilter;
+  pathOptions: ProjectPickerOption[];
+  githubPayload: { repositories?: GithubRepositoryChoice[] } | null;
+  query: string;
+  openAddedProject: (path: string) => void;
+  browse: () => void;
+  setState: (update: (current: AddProjectFlowState) => AddProjectFlowState) => void;
+}): FlowRowOption[] {
+  const { page, host, sourceFilter, pathOptions, query } = input;
+  if (!host.canAddProject) {
+    return [
+      {
+        id: "host-update-required",
+        title: "Update the host to use Add Project.",
+        subtitle: null,
+        icon: Server,
+        disabled: true,
+        testID: "add-project-flow-host-update-required",
+        select: () => undefined,
+      },
+    ];
+  }
+  const rows: FlowRowOption[] = [];
+  if (sourceFilter !== "github") {
+    rows.push({
+      id: "header:local",
+      title: "Local",
+      subtitle: null,
+      icon: Folder,
+      header: true,
+      disabled: true,
+      testID: "add-project-flow-group-local",
+      select: () => undefined,
+    });
+    for (const option of pathOptions) {
+      const shortPath = shortenPath(option.path);
+      rows.push({
+        id: option.path,
+        title: shortPath,
+        subtitle: directoryOptionSubtitle(option, shortPath),
+        icon: Folder,
+        testID: pathTestId(option.path),
+        select: () => input.openAddedProject(option.path),
+      });
+    }
+    if (pathOptions.length === 0) {
+      rows.push({
+        id: "empty:local",
+        title: "No matching directories",
+        subtitle: null,
+        icon: Folder,
+        disabled: true,
+        testID: "add-project-flow-empty-local",
+        select: () => undefined,
+      });
+    }
+    if (host.canCreateDirectory) {
+      rows.push({
+        id: "action:new-directory",
+        title: "New directory",
+        subtitle: `Create an empty directory on ${host.label}`,
+        icon: FolderPlus,
+        testID: "add-project-flow-action-new-directory",
+        select: () => input.setState((current) => openNewDirectoryParentPage(current, page.hostId)),
+      });
+    }
+    if (host.canBrowse) {
+      rows.push({
+        id: "action:browse",
+        title: "Browse",
+        subtitle: "Choose or create a directory in Finder",
+        icon: FolderOpen,
+        testID: "add-project-flow-action-browse",
+        select: () => input.browse(),
+      });
+    }
+  }
+  if (sourceFilter !== "local" && canUseGithubSource(host)) {
+    rows.push({
+      id: "header:github",
+      title: "GitHub",
+      subtitle: null,
+      icon: Github,
+      header: true,
+      disabled: true,
+      testID: "add-project-flow-group-github",
+      select: () => undefined,
+    });
+    const repositories = input.githubPayload?.repositories ?? [];
+    const normalizedQuery = query.trim().toLowerCase();
+    const hasExactSearchResult = repositories.some(
+      (repository) =>
+        repository.nameWithOwner.toLowerCase() === normalizedQuery ||
+        repository.cloneUrl.toLowerCase() === normalizedQuery,
+    );
+    const manualRepositories = hasExactSearchResult
+      ? []
+      : buildManualGithubRepositoryChoices(query);
+    const repositoryChoices: GithubRepositoryChoice[] = [...manualRepositories, ...repositories];
+    for (const repository of repositoryChoices) {
+      rows.push({
+        id: repository.id,
+        title: repository.cloneProtocol
+          ? `${repository.nameWithOwner} via ${repository.cloneProtocol.toUpperCase()}`
+          : repository.nameWithOwner,
+        subtitle: repository.description,
+        icon: Github,
+        testID: `add-project-flow-repository-${repository.id}`,
+        select: () =>
+          input.setState((current) => openGithubLocationPage(current, page.hostId, repository)),
+      });
+    }
+    if (repositoryChoices.length === 0) {
+      rows.push({
+        id: "empty:github",
+        title: host.canSearchGithubRepositories
+          ? "No matching repositories"
+          : "Enter a GitHub URL or owner/repo",
+        subtitle: null,
+        icon: Github,
+        disabled: true,
+        testID: "add-project-flow-empty-github",
+        select: () => undefined,
+      });
+    }
+  }
+  return rows;
 }
 
 function setPageStatus(
@@ -372,6 +540,14 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
   const browseInFlightRef = useRef(false);
   const query = page.kind === "new-directory-name" ? "" : page.query;
   const [debouncedQuery, setDebouncedQuery] = useState(query);
+  const [debouncedGithubQuery, setDebouncedGithubQuery] = useState(query);
+  const storedSourceFilter = useAddProjectFilterStore((store) =>
+    readAddProjectSourceFilter(store.filterByHost, hostId),
+  );
+  const setHostFilter = useAddProjectFilterStore((store) => store.setHostFilter);
+  const sourceFilter = host
+    ? resolveAddProjectSourceFilter(host, storedSourceFilter)
+    : ("all" as AddProjectSourceFilter);
 
   useEffect(() => {
     setState((current) =>
@@ -384,13 +560,20 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
     return () => clearTimeout(timer);
   }, [query]);
 
+  // GitHub search rides a slower, rate-limited API: pace it well behind the
+  // local debounce instead of firing on every keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedGithubQuery(query), 600);
+    return () => clearTimeout(timer);
+  }, [query]);
+
   useEffect(() => {
     const timer = setTimeout(() => inputRef.current?.focus(), 0);
     return () => clearTimeout(timer);
   }, [page.kind]);
 
   const searchesDirectories =
-    page.kind === "directory-search" ||
+    (page.kind === "search" && sourceFilter !== "github") ||
     page.kind === "github-location" ||
     page.kind === "new-directory-parent";
   const directoryQuery = useFetchQuery({
@@ -416,13 +599,21 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
     staleTimeMs: 15_000,
   });
   const githubQuery = useFetchQuery({
-    queryKey: ["add-project-flow-github", hostId, debouncedQuery],
+    queryKey: ["add-project-flow-github", hostId, debouncedGithubQuery],
     queryFn: async () => {
       if (!client) throw new Error("Host is unavailable");
-      const payload = await client.searchGithubRepositories({ query: debouncedQuery, limit: 30 });
-      return { query: debouncedQuery, payload };
+      const payload = await client.searchGithubRepositories({
+        query: debouncedGithubQuery,
+        limit: 30,
+      });
+      return { query: debouncedGithubQuery, payload };
     },
-    enabled: Boolean(client && page.kind === "github-search" && host?.canSearchGithubRepositories),
+    enabled: Boolean(
+      client &&
+      page.kind === "search" &&
+      sourceFilter !== "local" &&
+      host?.canSearchGithubRepositories,
+    ),
     dataShape: "value",
     retry: false,
     staleTimeMs: 15_000,
@@ -453,12 +644,10 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
   );
 
   const openAddedProject = useCallback(
-    async (path: string, sourceKind: "directory-search" | "method") => {
+    async (path: string) => {
       if (!hostId || submissionInFlightRef.current) return;
       submissionInFlightRef.current = true;
-      setState((current) =>
-        setPageStatus(current, sourceKind, { isSubmitting: true, error: null }),
-      );
+      setState((current) => setPageStatus(current, "search", { isSubmitting: true, error: null }));
       try {
         const result = await openProject(path);
         if (result.ok) {
@@ -469,11 +658,11 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
         const message =
           reason === "directory_not_found" ? "Directory not found" : "Unable to add project";
         setState((current) =>
-          setPageStatus(current, sourceKind, { isSubmitting: false, error: message }),
+          setPageStatus(current, "search", { isSubmitting: false, error: message }),
         );
       } catch {
         setState((current) =>
-          setPageStatus(current, sourceKind, {
+          setPageStatus(current, "search", {
             isSubmitting: false,
             error: "Unable to add project",
           }),
@@ -490,30 +679,34 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
     browseInFlightRef.current = true;
     try {
       const path = await pickDirectory();
-      if (path) await openAddedProject(path, "method");
+      if (path) await openAddedProject(path);
     } catch {
       setState((current) =>
-        setPageStatus(current, "method", { error: "Unable to browse for a directory" }),
+        setPageStatus(current, "search", { error: "Unable to browse for a directory" }),
       );
     } finally {
       browseInFlightRef.current = false;
     }
   }, [hostId, isLocalDaemon, openAddedProject]);
 
-  const selectMethod = useCallback(
-    (method: AddProjectMethodId) => {
+  const selectSourceFilter = useCallback(
+    (filter: AddProjectSourceFilter) => {
       if (!hostId) return;
-      if (method === "directory-search") {
-        setState((current) => openDirectorySearchPage(current, hostId));
-      } else if (method === "browse") {
-        void browse();
-      } else if (method === "github") {
-        setState((current) => openGithubSearchPage(current, hostId));
-      } else {
-        setState((current) => openNewDirectoryParentPage(current, hostId));
-      }
+      setHostFilter(hostId, filter);
+      setState((current) => setAddProjectActiveIndex(current, 0));
     },
-    [browse, hostId],
+    [hostId, setHostFilter],
+  );
+
+  const cycleSourceFilter = useCallback(
+    (direction: 1 | -1) => {
+      if (!host) return;
+      const options = buildAddProjectSourceOptions(host);
+      const index = options.findIndex((option) => option.id === sourceFilter);
+      const next = options[(index + direction + options.length) % options.length];
+      if (next) selectSourceFilter(next.id);
+    },
+    [host, selectSourceFilter, sourceFilter],
   );
 
   const directoryPaths = useMemo(
@@ -593,63 +786,19 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
       }
       return choices;
     }
-    if (page.kind === "method") {
+    if (page.kind === "search") {
       if (!host) return [];
-      const normalized = page.query.trim().toLowerCase();
-      return buildAddProjectMethods(host)
-        .filter(
-          (method) =>
-            !normalized ||
-            method.label.toLowerCase().includes(normalized) ||
-            method.description.toLowerCase().includes(normalized),
-        )
-        .map((method) => ({
-          id: method.id,
-          title: method.label,
-          subtitle: method.description,
-          icon: methodIcon(method.id),
-          disabled: method.disabled,
-          testID: `add-project-flow-method-${method.id}`,
-          select: () => selectMethod(method.id),
-        }));
-    }
-    if (page.kind === "directory-search") {
-      return pathOptions.map((option) => {
-        const shortPath = shortenPath(option.path);
-        return {
-          id: option.path,
-          title: shortPath,
-          subtitle: directoryOptionSubtitle(option, shortPath),
-          icon: Folder,
-          testID: pathTestId(option.path),
-          select: () => void openAddedProject(option.path, "directory-search"),
-        };
+      return buildSearchRows({
+        page,
+        host,
+        sourceFilter,
+        pathOptions,
+        githubPayload: githubQuery.data?.query === query ? githubQuery.data.payload : null,
+        query,
+        openAddedProject,
+        browse,
+        setState,
       });
-    }
-    if (page.kind === "github-search") {
-      const search = githubQuery.data?.query === page.query ? githubQuery.data.payload : null;
-      const repositories = search?.repositories ?? [];
-      const normalizedQuery = page.query.trim().toLowerCase();
-      const hasExactSearchResult = repositories.some(
-        (repository) =>
-          repository.nameWithOwner.toLowerCase() === normalizedQuery ||
-          repository.cloneUrl.toLowerCase() === normalizedQuery,
-      );
-      const manualRepositories = hasExactSearchResult
-        ? []
-        : buildManualGithubRepositoryChoices(page.query);
-      const repositoryChoices: GithubRepositoryChoice[] = [...manualRepositories, ...repositories];
-      return repositoryChoices.map((repository) => ({
-        id: repository.id,
-        title: repository.cloneProtocol
-          ? `${repository.nameWithOwner} via ${repository.cloneProtocol.toUpperCase()}`
-          : repository.nameWithOwner,
-        subtitle: repository.description,
-        icon: Github,
-        testID: `add-project-flow-repository-${repository.id}`,
-        select: () =>
-          setState((current) => openGithubLocationPage(current, page.hostId, repository)),
-      }));
     }
     if (page.kind === "github-location") {
       const repositoryName = pathBaseName(page.repository.nameWithOwner);
@@ -690,6 +839,7 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
     }
     return [];
   }, [
+    browse,
     cloneRepository,
     directoryPaths,
     githubQuery.data,
@@ -698,8 +848,9 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
     openAddedProject,
     page,
     pathOptions,
+    query,
     recommendedPaths,
-    selectMethod,
+    sourceFilter,
     state.hosts,
   ]);
 
@@ -770,6 +921,11 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
         submitActive();
         return true;
       }
+      if (key === "ArrowLeft" || key === "ArrowRight") {
+        if (page.kind !== "search") return false;
+        cycleSourceFilter(key === "ArrowRight" ? 1 : -1);
+        return true;
+      }
       if (key !== "ArrowDown" && key !== "ArrowUp") return false;
       const next = moveAddProjectSelection(
         activeIndex,
@@ -779,7 +935,7 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
       setState((current) => setAddProjectActiveIndex(current, next));
       return true;
     },
-    [activeIndex, handleBack, rows, submitActive],
+    [activeIndex, cycleSourceFilter, handleBack, page.kind, rows, submitActive],
   );
 
   const modalLayer = useGlobalWebOverlayLayer("modal", isWeb);
@@ -799,7 +955,13 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
 
   const handleNativeKeyPress = useCallback(
     ({ nativeEvent: { key } }: { nativeEvent: { key: string } }) => {
-      if (key === "ArrowDown" || key === "ArrowUp" || key === "Escape") {
+      if (
+        key === "ArrowDown" ||
+        key === "ArrowUp" ||
+        key === "ArrowLeft" ||
+        key === "ArrowRight" ||
+        key === "Escape"
+      ) {
         handleKey(key);
       }
     },
@@ -815,21 +977,23 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
   }, []);
   const isSubmitting = "isSubmitting" in page && page.isSubmitting;
   const currentGithubSearch =
-    page.kind === "github-search" && githubQuery.data?.query === page.query
+    page.kind === "search" && githubQuery.data?.query === page.query
       ? githubQuery.data.payload
       : null;
   const loading =
     (searchesDirectories && (query !== debouncedQuery || directoryQuery.isFetching)) ||
-    (page.kind === "github-search" &&
+    (page.kind === "search" &&
       host?.canSearchGithubRepositories === true &&
-      (query !== debouncedQuery || githubQuery.isFetching));
+      sourceFilter !== "local" &&
+      (query !== debouncedGithubQuery || githubQuery.isFetching));
   const queryError = queryErrorText({
     searchesDirectories,
     directoryFailed: directoryQuery.isError,
-    githubFailed: page.kind === "github-search" && githubQuery.isError,
+    githubFailed: page.kind === "search" && githubQuery.isError,
     githubAvailable: currentGithubSearch?.available ?? null,
     githubError: currentGithubSearch?.error ?? null,
   });
+  const sourceOptions = host ? buildAddProjectSourceOptions(host) : [];
   const preview =
     page.kind === "new-directory-name" && page.name.trim()
       ? joinDirectoryPath(page.parentPath, page.name.trim())
@@ -874,6 +1038,27 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
               returnKeyType="go"
               testID="add-project-flow-input"
             />
+            {page.kind === "search" && sourceOptions.length > 0 ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                style={styles.pillRow}
+                contentContainerStyle={styles.pillRowContent}
+                keyboardShouldPersistTaps="always"
+                testID="add-project-flow-sources"
+              >
+                {sourceOptions.map((option) => (
+                  <SourcePill
+                    key={option.id}
+                    id={option.id}
+                    label={option.label}
+                    active={sourceFilter === option.id}
+                    testID={`add-project-flow-source-${option.id}`}
+                    onSelect={selectSourceFilter}
+                  />
+                ))}
+              </ScrollView>
+            ) : null}
           </View>
           <ScrollView
             style={styles.results}
@@ -907,9 +1092,7 @@ export function AddProjectFlow({ request, onClose }: AddProjectFlowProps) {
                 Loading...
               </Text>
             ) : null}
-            {!isSubmitting &&
-            (!loading || page.kind === "github-search") &&
-            (!queryError || page.kind === "github-search")
+            {!isSubmitting && !loading && !queryError
               ? rows.map((option, index) => (
                   <FlowRow key={option.id} option={option} active={index === activeIndex} />
                 ))
@@ -1008,6 +1191,25 @@ const styles = StyleSheet.create((theme) => ({
     paddingVertical: theme.spacing[1],
     outlineStyle: "none",
   } as object,
+  pillRow: { flexGrow: 0, flexShrink: 0 },
+  pillRowContent: { gap: theme.spacing[2], paddingVertical: theme.spacing[1] },
+  pill: {
+    borderRadius: theme.borderRadius.full,
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[1],
+    backgroundColor: theme.colors.surface1,
+  },
+  pillActive: { backgroundColor: theme.colors.surface2 },
+  pillText: { color: theme.colors.foregroundMuted, fontSize: theme.fontSize.xs },
+  pillTextActive: { color: theme.colors.foreground },
+  groupHeader: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+    paddingHorizontal: theme.spacing[4],
+    paddingTop: theme.spacing[2],
+    paddingBottom: theme.spacing[1],
+  },
   results: { flexGrow: 0, flexShrink: 1, minHeight: 0 },
   resultsContent: { paddingVertical: theme.spacing[2] },
   row: {


### PR DESCRIPTION
## Problem

The Add Project flow opened on a method page that forced an eager choice: pick a search domain (directory / GitHub / new directory) before seeing any data. The method page's search box only filtered methods — typing a directory name there showed "No matching options," which reads as a broken autocomplete.

## Change

The method page becomes a unified search:

- **One input, concurrent fan-out.** Local directory suggestions and GitHub repository search run in parallel. Results group under fixed-order Local/GitHub headers with per-group empty states; groups never reorder on arrival.
- **Source-filter pills** under the input (All / Local / GitHub, horizontally scrollable, gated on the host's clone capability). Default is All; explicit selections are sticky **per host** — only non-default choices are persisted, so the default never stomps an untouched host, and a stored filter that outlives its capability falls back to All. Arrow keys cycle the filter with the same keyboard parity as row navigation.
- **Continuations ride on result selection.** Directories open the project; repositories continue to the clone-destination page; New directory and Browse remain as action rows in the Local group. Manual GitHub URL / owner-repo entry works without the account-search capability, as before.
- **Lawful fan-out.** Results are generation-tagged by query string, so stale completions are never rendered regardless of finish order; each domain keeps its own error state; the rate-limited GitHub search debounces at 600ms behind the 250ms local scan.

## Tests

- Model: unified page replaces method in the state machine; back-stack behavior preserved.
- Options: source availability, capability-fallback of stored filters.
- Filter store: default-All, per-host persistence, All removes the stored pref.
- Smoke-tested in the web app: grouped fan-out with live data, pill filtering, stickiness across close/reopen, ArrowLeft/Right cycling.

Draft while I decide whether the group headers want a visual pass.

