### PR TITLE
Show complete native subagent conversations

### DIFF
--- a/packages/app/e2e/browser/provider-subagents.real.spec.ts
+++ b/packages/app/e2e/browser/provider-subagents.real.spec.ts
@@ -76,6 +76,9 @@ test.describe("real provider subagent timelines", () => {
         const panel = page.getByTestId("provider-subagent-panel");
         await expect(panel).toBeVisible({ timeout: 30_000 });
         await expect(
+          panel.getByTestId("user-message").filter({ hasText: scenario.sentinel }),
+        ).toBeVisible({ timeout: 30_000 });
+        await expect(
           panel.getByTestId("assistant-message").filter({ hasText: scenario.sentinel }),
         ).toBeVisible({ timeout: 30_000 });
         await expect(

--- a/packages/app/e2e/helpers/project-status-badge.ts
+++ b/packages/app/e2e/helpers/project-status-badge.ts
@@ -1,7 +1,7 @@
 import { expect, type Page } from "@playwright/test";
-import { gotoAppShell } from "./app";
-import { seedWorkspace, type SeededWorkspace } from "./seed-client";
-import { waitForSidebarHydration } from "./workspace-ui";
+import { gotoAppShell } from "../support/helpers/app";
+import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
+import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
 
 export interface StatusProject {
   seed: SeededWorkspace;

--- a/packages/app/e2e/project-status-badge.spec.ts
+++ b/packages/app/e2e/project-status-badge.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./fixtures";
+import { test } from "./support/fixtures";
 import {
   expandStatusProject,
   expectCollapsedProjectStatus,

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -3103,6 +3103,8 @@ class ClaudeAgentSession implements AgentSession {
       ...(effort ? { effort } : {}),
       ...extraClaudeOptions,
       ...settingsOptions,
+      // Provider subagent panes render the child's nested transcript.
+      forwardSubagentText: true,
       // Merged rather than assigned above: extraClaudeOptions is spread after the base, so any
       // user-configured hooks would otherwise replace these wholesale and silently stop effort
       // from being observed.


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Native subagent panes showed the delegated prompt and tool activity but could omit the child response because the provider SDK now defaults to forwarding only tool blocks. Requesting the full nested transcript preserves both sides of the conversation in the existing provider-subagent timeline.

### Goals

- Show the prompt delegated by the parent in the native subagent pane.
- Show the native subagent response in the same pane.
- Preserve existing tool-call and tool-result rendering.
- Cover the flow through a real provider, daemon, network, and browser.

### Non-goals

- Change subagent lifecycle or task discovery.
- Change provider-subagent UI layout.
- Alter other provider adapters.

### QA

- Reproduced red with: npm run test:e2e:real --workspace=@getpaseo/app -- e2e/provider-subagents.real.spec.ts --grep "claude exposes native child output". The delegated user message rendered, while the child assistant response was absent.
- Ran the same real-provider browser test after the fix: 1 passed. The pane rendered both the delegated prompt and child response.
- npm run typecheck: passed.
- npm run lint -- packages/server/src/server/agent/providers/claude/agent.ts packages/app/e2e/provider-subagents.real.spec.ts: passed with 0 warnings and 0 errors.
- npm run format: passed.
- Tested in the browser E2E project. Native mobile and Electron were not manually exercised; timeline rendering is shared.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [x] Tests added or updated where it made sense