### PR TITLE
Preserve interactive ACP permission choices

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,6 +12,8 @@ The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `Gen
 
 Copilot custom agents are exposed through ACP session config, not the slash-command list. When custom agents are available, Copilot returns a select config option with `id: "agent"` and `category: "_agent"`; Paseo maps that to the `agent` provider feature. Copilot uses the agent display name as the option value, and the blank value means the default Copilot agent.
 
+ACP permission options are rendered as ordered actions and Paseo returns the selected option's exact `optionId`. Agents can therefore encode a single-choice question as multiple options of the same allow kind. Auto-accept does not resolve those chooser requests; they always wait for the user.
+
 ### Direct
 
 Implement the `AgentClient` and `AgentSession` interfaces from `agent-sdk-types.ts` yourself. This gives full control but requires you to handle process management, streaming, permissions, and session persistence from scratch.

--- a/packages/app/e2e/browser/acp-permission-choices.real.spec.ts
+++ b/packages/app/e2e/browser/acp-permission-choices.real.spec.ts
@@ -39,6 +39,8 @@ async function capturePermissionChoices(page: Page, outputPath: string) {
   await expect(page.getByRole("button", { name: "Beta" })).toBeVisible();
 }
 
+test.use({ e2eForkProviders: ["kimi"] });
+
 test.describe("real ACP permission choices", () => {
   test.setTimeout(600_000);
 

--- a/packages/app/e2e/browser/acp-permission-choices.real.spec.ts
+++ b/packages/app/e2e/browser/acp-permission-choices.real.spec.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test, type Page } from "../support/fixtures";
+import { submitMessage } from "../support/helpers/composer";
+import { choosePermissionAction, expectPermissionActions } from "../support/helpers/permissions";
+import {
+  cleanupRewindFlow,
+  launchAgent,
+  type AgentHandle,
+  type RewindFlowProvider,
+} from "../support/helpers/rewind-flow";
+
+const QUESTION = "Which option should I choose?";
+const OPTIONS = ["Alpha", "Beta", "Gamma"];
+
+async function askAgentToOfferChoices(handle: AgentHandle): Promise<void> {
+  await submitMessage(
+    handle.page,
+    `Use your built-in question tool now. Ask exactly "${QUESTION}" with exactly three choices named Alpha, Beta, and Gamma. Do not answer the question yourself. After I choose, reply exactly SELECTED_<CHOICE>, replacing <CHOICE> with my selection.`,
+  );
+}
+
+async function expectAgentToResumeWithSelection(handle: AgentHandle, selection: string) {
+  const finish = await handle.client.waitForFinish(handle.agentId, 240_000);
+  expect(finish.status).toBe("idle");
+  expect(finish.final?.lastError).toBeFalsy();
+  await expect(
+    handle.page
+      .getByTestId("assistant-message")
+      .filter({ hasText: `SELECTED_${selection}` })
+      .last(),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+async function capturePermissionChoices(page: Page, outputPath: string) {
+  await page.screenshot({ path: outputPath });
+  await expect(page.getByText(QUESTION, { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Beta" })).toBeVisible();
+}
+
+test.describe("real ACP permission choices", () => {
+  test.setTimeout(600_000);
+
+  test("Kimi renders its question choices and resumes with the selected option", async ({
+    page,
+  }, testInfo) => {
+    const provider = "kimi" satisfies RewindFlowProvider;
+    const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "paseo-acp-question-kimi-")));
+    let handle: AgentHandle | undefined;
+
+    try {
+      handle = await launchAgent({ page, provider, cwd, mode: "full-access" });
+      await askAgentToOfferChoices(handle);
+      await expectPermissionActions(page, OPTIONS);
+      const screenshotPath = testInfo.outputPath("kimi-permission-choices.png");
+      await capturePermissionChoices(page, screenshotPath);
+      await testInfo.attach("Kimi permission choices", {
+        path: screenshotPath,
+        contentType: "image/png",
+      });
+      await choosePermissionAction(page, "Beta");
+      await expectAgentToResumeWithSelection(handle, "BETA");
+    } finally {
+      await cleanupRewindFlow({ handle, cwd });
+    }
+  });
+});

--- a/packages/app/e2e/browser/project-status-badge.spec.ts
+++ b/packages/app/e2e/browser/project-status-badge.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./support/fixtures";
+import { test } from "../support/fixtures";
 import {
   expandStatusProject,
   expectCollapsedProjectStatus,
@@ -8,7 +8,7 @@ import {
   seedStatusProject,
   startNeedsInputWorkspace,
   startWorkingWorkspace,
-} from "./helpers/project-status-badge";
+} from "../helpers/project-status-badge";
 
 test("a collapsed project surfaces its most urgent hidden workspace status", async ({ page }) => {
   test.setTimeout(120_000);

--- a/packages/app/e2e/support/fixtures.ts
+++ b/packages/app/e2e/support/fixtures.ts
@@ -42,11 +42,14 @@ const test = metroTest.extend<
     projectPickerFixture: TrackedProjectPickerFixture;
     withWorkspace: WithWorkspace;
   },
-  { e2eWorker: void; e2eWorkerClient: SeedDaemonClient }
+  { e2eForkProviders: string[]; e2eWorker: void; e2eWorkerClient: SeedDaemonClient }
 >({
+  e2eForkProviders: [[], { scope: "worker", option: true }],
   e2eWorker: [
-    async ({}, provide, workerInfo) => {
-      const worker = await startE2EWorker(workerInfo.workerIndex);
+    async ({ e2eForkProviders }, provide, workerInfo) => {
+      const worker = await startE2EWorker(workerInfo.workerIndex, {
+        forkProviders: e2eForkProviders,
+      });
       try {
         await provide();
       } finally {

--- a/packages/app/e2e/support/helpers/e2e-worker.ts
+++ b/packages/app/e2e/support/helpers/e2e-worker.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { forkPaseoHomeMetadata, resolvePaseoHomePath } from "./paseo-home-fork";
@@ -117,6 +117,30 @@ async function applyMetadataFork(targetHome: string): Promise<void> {
   process.env.E2E_FORK_TARGET_PASEO_HOME = result.targetHome;
   process.env.E2E_FORK_COPIED_FILES = String(result.copiedFiles);
   process.env.E2E_FORK_COPIED_BYTES = String(result.copiedBytes);
+
+  const providerIds = (process.env.E2E_FORK_PROVIDERS ?? "")
+    .split(",")
+    .map((providerId) => providerId.trim())
+    .filter(Boolean);
+  if (providerIds.length === 0) return;
+
+  const sourceConfig = JSON.parse(
+    await readFile(path.join(result.sourceHome, "config.json"), "utf8"),
+  );
+  const sourceProviders = sourceConfig.agents?.providers ?? {};
+  const providers = Object.fromEntries(
+    providerIds.map((providerId) => {
+      const provider = sourceProviders[providerId];
+      if (!provider) {
+        throw new Error(`E2E provider '${providerId}' is not configured in ${result.sourceHome}`);
+      }
+      return [providerId, provider];
+    }),
+  );
+  await writeFile(
+    path.join(targetHome, "config.json"),
+    `${JSON.stringify({ version: 1, agents: { providers } }, null, 2)}\n`,
+  );
 }
 
 export async function startE2EWorker(workerIndex: number): Promise<E2EWorker> {

--- a/packages/app/e2e/support/helpers/e2e-worker.ts
+++ b/packages/app/e2e/support/helpers/e2e-worker.ts
@@ -118,9 +118,9 @@ async function applyMetadataFork(targetHome: string): Promise<void> {
   process.env.E2E_FORK_COPIED_FILES = String(result.copiedFiles);
   process.env.E2E_FORK_COPIED_BYTES = String(result.copiedBytes);
 
-  const providerIds = (process.env.E2E_FORK_PROVIDERS ?? "")
+  const providerIds: string[] = (process.env.E2E_FORK_PROVIDERS ?? "")
     .split(",")
-    .map((providerId) => providerId.trim())
+    .map((providerId: string) => providerId.trim())
     .filter(Boolean);
   if (providerIds.length === 0) return;
 
@@ -129,7 +129,7 @@ async function applyMetadataFork(targetHome: string): Promise<void> {
   );
   const sourceProviders = sourceConfig.agents?.providers ?? {};
   const providers = Object.fromEntries(
-    providerIds.map((providerId) => {
+    providerIds.map((providerId: string) => {
       const provider = sourceProviders[providerId];
       if (!provider) {
         throw new Error(`E2E provider '${providerId}' is not configured in ${result.sourceHome}`);

--- a/packages/app/e2e/support/helpers/e2e-worker.ts
+++ b/packages/app/e2e/support/helpers/e2e-worker.ts
@@ -109,7 +109,7 @@ process.exit(result.status ?? 1);
   return binDir;
 }
 
-async function applyMetadataFork(targetHome: string): Promise<void> {
+async function applyMetadataFork(targetHome: string, providerIds: string[]): Promise<void> {
   const sourceHome = resolveOptionalHome(process.env.E2E_FORK_PASEO_HOME_FROM);
   if (!sourceHome) return;
   const result = await forkPaseoHomeMetadata({ sourceHome, targetHome });
@@ -118,10 +118,6 @@ async function applyMetadataFork(targetHome: string): Promise<void> {
   process.env.E2E_FORK_COPIED_FILES = String(result.copiedFiles);
   process.env.E2E_FORK_COPIED_BYTES = String(result.copiedBytes);
 
-  const providerIds: string[] = (process.env.E2E_FORK_PROVIDERS ?? "")
-    .split(",")
-    .map((providerId: string) => providerId.trim())
-    .filter(Boolean);
   if (providerIds.length === 0) return;
 
   const sourceConfig = JSON.parse(
@@ -143,7 +139,10 @@ async function applyMetadataFork(targetHome: string): Promise<void> {
   );
 }
 
-export async function startE2EWorker(workerIndex: number): Promise<E2EWorker> {
+export async function startE2EWorker(
+  workerIndex: number,
+  options: { forkProviders?: string[] } = {},
+): Promise<E2EWorker> {
   const requestedRoot = resolveOptionalHome(process.env.E2E_PASEO_HOME);
   const paseoHome = requestedRoot
     ? path.join(requestedRoot, `worker-${workerIndex}`)
@@ -154,7 +153,7 @@ export async function startE2EWorker(workerIndex: number): Promise<E2EWorker> {
   const serverId = `srv_e2e_worker_${workerIndex}`;
 
   try {
-    await applyMetadataFork(paseoHome);
+    await applyMetadataFork(paseoHome, options.forkProviders ?? []);
     const daemon = await startIsolatedHostDaemon(serverId, {
       paseoHome,
       preserveHome,

--- a/packages/app/e2e/support/helpers/permissions.ts
+++ b/packages/app/e2e/support/helpers/permissions.ts
@@ -15,3 +15,16 @@ export async function denyPermission(page: Page): Promise<void> {
   await expect(denyButton).toBeVisible({ timeout: 5_000 });
   await denyButton.click();
 }
+
+export async function expectPermissionActions(page: Page, labels: string[]): Promise<void> {
+  await waitForPermissionPrompt(page, 120_000);
+  const card = page.getByTestId("permission-request-question").first().locator("..");
+  for (const label of labels) {
+    await expect(card.getByRole("button", { name: label })).toBeVisible();
+  }
+}
+
+export async function choosePermissionAction(page: Page, label: string): Promise<void> {
+  const card = page.getByTestId("permission-request-question").first().locator("..");
+  await card.getByRole("button", { name: label }).click();
+}

--- a/packages/app/e2e/support/helpers/rewind-flow.ts
+++ b/packages/app/e2e/support/helpers/rewind-flow.ts
@@ -7,7 +7,7 @@ import { expectComposerEditable, submitMessage } from "./composer";
 import { connectSeedClient, type SeedDaemonClient } from "./seed-client";
 import { getServerId } from "./server-id";
 
-export type RewindFlowProvider = "claude" | "codex" | "opencode" | "pi";
+export type RewindFlowProvider = "claude" | "codex" | "kimi" | "opencode" | "pi";
 export type RewindFlowMode = "conversation" | "files" | "both";
 
 export interface AgentHandle {
@@ -54,6 +54,8 @@ function fullAccessConfig(provider: RewindFlowProvider): ProviderLaunchConfig {
         modeId: "build",
         featureValues: { auto_accept: true },
       };
+    case "kimi":
+      return { provider, modeId: "default", featureValues: { auto_accept: true } };
     case "pi":
       return {
         provider,
@@ -156,6 +158,8 @@ export async function launchAgent(input: {
   mode: "full-access";
   providerConfig?: {
     model?: string;
+    modeId?: string;
+    featureValues?: Record<string, unknown>;
     extra?: { codex?: { features?: { multi_agent_v2?: boolean } } };
   };
 }): Promise<AgentHandle> {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run",
     "test:browser": "vitest run --project browser",
     "test:e2e": "playwright test --project=browser",
-    "test:e2e:real": "cross-env E2E_FORK_PASEO_HOME_FROM=../../.dev/paseo-home E2E_FORK_PROVIDERS=kimi playwright test --project=real-provider",
+    "test:e2e:real": "cross-env E2E_FORK_PASEO_HOME_FROM=../../.dev/paseo-home playwright test --project=real-provider",
     "test:e2e:ui": "playwright test --ui",
     "build": "npm run build:web",
     "build:web": "npm --prefix ../.. run build:app-deps && expo export --platform web",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run",
     "test:browser": "vitest run --project browser",
     "test:e2e": "playwright test --project=browser",
-    "test:e2e:real": "cross-env E2E_FORK_PASEO_HOME_FROM=../../.dev/paseo-home playwright test --project=real-provider",
+    "test:e2e:real": "cross-env E2E_FORK_PASEO_HOME_FROM=../../.dev/paseo-home E2E_FORK_PROVIDERS=kimi playwright test --project=real-provider",
     "test:e2e:ui": "playwright test --ui",
     "build": "npm run build:web",
     "build:web": "npm --prefix ../.. run build:app-deps && expo export --platform web",

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -1517,6 +1517,7 @@ const permissionStyles = StyleSheet.create((theme) => ({
   },
   optionsContainerDesktop: {
     flexDirection: "row",
+    flexWrap: "wrap",
     justifyContent: "flex-start",
     alignItems: "center",
     width: "100%",

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -1166,7 +1166,13 @@ function PermissionActionButton({
     : permissionStyles.optionText;
   const colorMapping = isPrimary ? primaryColorMapping : mutedColorMapping;
   return (
-    <Pressable testID={testID} style={pressableStyle} onPress={handlePress} disabled={isResponding}>
+    <Pressable
+      accessibilityRole="button"
+      testID={testID}
+      style={pressableStyle}
+      onPress={handlePress}
+      disabled={isResponding}
+    >
       {isRespondingAction ? (
         <ThemedLoadingSpinner size="small" uniProps={colorMapping} />
       ) : (

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1234,7 +1234,7 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
-  test("preserves ACP permission requests when the selected action conflicts with its behavior", async () => {
+  test("preserves ACP permission requests after invalid selected actions", async () => {
     const session = createSessionWithConfig({ provider: "generic-acp" });
     const events: AgentStreamEvent[] = [];
 
@@ -1261,6 +1261,14 @@ describe("ACPAgentSession Zed parity", () => {
     if (requested?.type !== "permission_requested") {
       throw new Error("Expected permission request");
     }
+
+    await expect(
+      session.respondToPermission(requested.request.id, {
+        behavior: "allow",
+        selectedActionId: "",
+      }),
+    ).rejects.toThrow("does not exist");
+    expect(session.getPendingPermissions()).toHaveLength(1);
 
     await expect(
       session.respondToPermission(requested.request.id, {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1229,7 +1229,7 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
-  test("cancels ACP responses whose selected action conflicts with their behavior", async () => {
+  test("preserves ACP permission requests when the selected action conflicts with its behavior", async () => {
     const session = createSessionWithConfig({ provider: "generic-acp" });
     const events: AgentStreamEvent[] = [];
 
@@ -1257,12 +1257,21 @@ describe("ACPAgentSession Zed parity", () => {
       throw new Error("Expected permission request");
     }
 
+    await expect(
+      session.respondToPermission(requested.request.id, {
+        behavior: "deny",
+        selectedActionId: "allow-once",
+      }),
+    ).rejects.toThrow("does not match 'deny' behavior");
+    expect(session.getPendingPermissions()).toHaveLength(1);
+
     await session.respondToPermission(requested.request.id, {
       behavior: "deny",
-      selectedActionId: "allow-once",
+      selectedActionId: "reject-once",
     });
-
-    await expect(permission).resolves.toEqual({ outcome: { outcome: "cancelled" } });
+    await expect(permission).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "reject-once" },
+    });
   });
 
   test("auto-accepts ACP permission requests when the shared feature is enabled", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1125,7 +1125,7 @@ describe("ACPAgentSession Zed parity", () => {
       provider: "cursor-acp",
       modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
     });
-    const events: Array<{ type: string; request?: { id: string } }> = [];
+    const events: AgentStreamEvent[] = [];
     const permissionOptions: PermissionOption[] = [
       { optionId: "allow-once", name: "Allow", kind: "allow_once" },
       { optionId: "reject-once", name: "Reject", kind: "reject_once" },
@@ -1133,7 +1133,7 @@ describe("ACPAgentSession Zed parity", () => {
 
     asInternals<ACPSessionInternals>(session).sessionId = "session-1";
     session.subscribe((event) => {
-      events.push(event as { type: string; request?: { id: string } });
+      events.push(event);
     });
 
     const permission = session.requestPermission({
@@ -1150,11 +1150,82 @@ describe("ACPAgentSession Zed parity", () => {
     await Promise.resolve();
 
     const requested = events.find((event) => event.type === "permission_requested");
-    expect(requested?.request?.id).toEqual(expect.any(String));
+    expect(requested).toMatchObject({
+      type: "permission_requested",
+      request: {
+        actions: [
+          { id: "allow-once", label: "Allow", behavior: "allow" },
+          { id: "reject-once", label: "Reject", behavior: "deny" },
+        ],
+      },
+    });
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
 
-    await session.respondToPermission(requested!.request!.id, { behavior: "allow" });
+    await session.respondToPermission(requested.request.id, { behavior: "allow" });
     await expect(permission).resolves.toEqual({
       outcome: { outcome: "selected", optionId: "allow-once" },
+    });
+  });
+
+  test("preserves ACP chooser actions and returns the selected option", async () => {
+    const session = createSessionWithConfig({
+      provider: "kimi-acp",
+      modeId: "https://agentclientprotocol.com/protocol/session-modes#agent",
+    });
+    const events: AgentStreamEvent[] = [];
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "question-1",
+        title: "AskUserQuestion",
+        status: "pending",
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "Which path should Paseo take?",
+            },
+          },
+        ],
+      },
+      options: [
+        { optionId: "q0_opt_0", name: "Narrow fix", kind: "allow_once" },
+        { optionId: "q0_opt_1", name: "Protocol fix", kind: "allow_once" },
+        { optionId: "q0_skip", name: "Skip", kind: "reject_once" },
+      ],
+    } satisfies RequestPermissionRequest);
+
+    await Promise.resolve();
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested).toMatchObject({
+      type: "permission_requested",
+      request: {
+        actions: [
+          { id: "q0_opt_0", label: "Narrow fix", behavior: "allow" },
+          { id: "q0_opt_1", label: "Protocol fix", behavior: "allow" },
+          { id: "q0_skip", label: "Skip", behavior: "deny" },
+        ],
+      },
+    });
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
+
+    await session.respondToPermission(requested.request.id, {
+      behavior: "allow",
+      selectedActionId: "q0_opt_1",
+    });
+
+    await expect(permission).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "q0_opt_1" },
     });
   });
 
@@ -1179,6 +1250,7 @@ describe("ACPAgentSession Zed parity", () => {
         },
         options: [
           { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+          { optionId: "allow-always", name: "Always allow", kind: "allow_always" },
           { optionId: "reject-once", name: "Reject", kind: "reject_once" },
         ],
       } satisfies RequestPermissionRequest),
@@ -1187,6 +1259,56 @@ describe("ACPAgentSession Zed parity", () => {
     });
     expect(events).not.toContainEqual(expect.objectContaining({ type: "permission_requested" }));
     expect(session.getPendingPermissions()).toEqual([]);
+  });
+
+  test("does not auto-accept ACP chooser requests", async () => {
+    const session = createSessionWithConfig({
+      provider: "kimi-acp",
+      featureValues: { auto_accept: true },
+    });
+    const events: AgentStreamEvent[] = [];
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "question-1",
+        title: "AskUserQuestion",
+        status: "pending",
+      },
+      options: [
+        { optionId: "q0_opt_0", name: "Narrow fix", kind: "allow_once" },
+        { optionId: "q0_opt_1", name: "Protocol fix", kind: "allow_once" },
+        { optionId: "q0_skip", name: "Skip", kind: "reject_once" },
+      ],
+    } satisfies RequestPermissionRequest);
+
+    await Promise.resolve();
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested).toMatchObject({
+      type: "permission_requested",
+      request: {
+        actions: [
+          { id: "q0_opt_0", label: "Narrow fix", behavior: "allow" },
+          { id: "q0_opt_1", label: "Protocol fix", behavior: "allow" },
+          { id: "q0_skip", label: "Skip", behavior: "deny" },
+        ],
+      },
+    });
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
+
+    await session.respondToPermission(requested.request.id, {
+      behavior: "allow",
+      selectedActionId: "q0_opt_0",
+    });
+    await expect(permission).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "q0_opt_0" },
+    });
   });
 
   test("starts auto-accepting permissions when the shared feature is toggled on", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1208,6 +1208,11 @@ describe("ACPAgentSession Zed parity", () => {
     expect(requested).toMatchObject({
       type: "permission_requested",
       request: {
+        detail: {
+          type: "plain_text",
+          label: "AskUserQuestion",
+          text: "Which path should Paseo take?",
+        },
         actions: [
           { id: "q0_opt_0", label: "Narrow fix", behavior: "allow" },
           { id: "q0_opt_1", label: "Protocol fix", behavior: "allow" },

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1229,6 +1229,42 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
+  test("cancels ACP responses whose selected action conflicts with their behavior", async () => {
+    const session = createSessionWithConfig({ provider: "generic-acp" });
+    const events: AgentStreamEvent[] = [];
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "tool-1",
+        title: "Edit file",
+        kind: "edit",
+        status: "pending",
+      },
+      options: [
+        { optionId: "allow-once", name: "Allow", kind: "allow_once" },
+        { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+      ],
+    } satisfies RequestPermissionRequest);
+
+    await Promise.resolve();
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
+
+    await session.respondToPermission(requested.request.id, {
+      behavior: "deny",
+      selectedActionId: "allow-once",
+    });
+
+    await expect(permission).resolves.toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
   test("auto-accepts ACP permission requests when the shared feature is enabled", async () => {
     const session = createSessionWithConfig({
       provider: "cursor-acp",

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2053,8 +2053,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       throw new Error(`No pending permission request with id '${requestId}'`);
     }
 
-    this.pendingPermissions.delete(requestId);
     const selectedOption = selectPermissionOption(pending.options, response);
+    if (response.selectedActionId && !selectedOption) {
+      throw new Error(
+        `ACP permission action '${response.selectedActionId}' does not exist or does not match '${response.behavior}' behavior`,
+      );
+    }
+
+    this.pendingPermissions.delete(requestId);
     pending.resolve(
       selectedOption
         ? {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3449,13 +3449,23 @@ function mapPermissionRequest(
   snapshot: ACPToolSnapshot,
 ): AgentPermissionRequest {
   const kind: AgentPermissionRequestKind = snapshot.kind === "switch_mode" ? "mode" : "tool";
+  const chooserText = isACPChooserRequest(params.options)
+    ? extractToolText(params.toolCall.content)
+    : undefined;
   return {
     id: requestId,
     provider,
     name: snapshot.kind ?? snapshot.title,
     kind,
     title: params.toolCall.title ?? snapshot.title,
-    detail: mapToolDetail(snapshot, new Map()),
+    detail: chooserText
+      ? {
+          type: "plain_text",
+          label: params.toolCall.title ?? snapshot.title,
+          text: chooserText,
+          icon: "wrench",
+        }
+      : mapToolDetail(snapshot, new Map()),
     actions: params.options.map((option) => ({
       id: option.optionId,
       label: option.name,

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2159,7 +2159,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
-    if (isACPAutoAcceptEnabled(this.config)) {
+    const canAutoAccept =
+      isACPAutoAcceptEnabled(this.config) && !isACPChooserRequest(params.options);
+    if (canAutoAccept) {
       const allowOption = selectPermissionOption(params.options, { behavior: "allow" });
       if (allowOption) {
         this.logger.info(
@@ -3448,6 +3450,11 @@ function mapPermissionRequest(
     kind,
     title: params.toolCall.title ?? snapshot.title,
     detail: mapToolDetail(snapshot, new Map()),
+    actions: params.options.map((option) => ({
+      id: option.optionId,
+      label: option.name,
+      behavior: option.kind.startsWith("allow") ? "allow" : "deny",
+    })),
     metadata: {
       toolCallId: params.toolCall.toolCallId,
       rawRequest: params,
@@ -3460,6 +3467,13 @@ function selectPermissionOption(
   options: PermissionOption[],
   response: AgentPermissionResponse,
 ): PermissionOption | null {
+  if (response.selectedActionId) {
+    const selectedOption = options.find((option) => option.optionId === response.selectedActionId);
+    if (selectedOption) {
+      return selectedOption;
+    }
+  }
+
   const order =
     response.behavior === "allow"
       ? ["allow_once", "allow_always"]
@@ -3471,6 +3485,20 @@ function selectPermissionOption(
     }
   }
   return null;
+}
+
+function isACPChooserRequest(options: PermissionOption[]): boolean {
+  const allowKinds = new Set<PermissionOption["kind"]>();
+  for (const option of options) {
+    if (!option.kind.startsWith("allow")) {
+      continue;
+    }
+    if (allowKinds.has(option.kind)) {
+      return true;
+    }
+    allowKinds.add(option.kind);
+  }
+  return false;
 }
 
 function appendTerminalOutput(entry: TerminalEntry, chunk: string): void {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -3469,9 +3469,9 @@ function selectPermissionOption(
 ): PermissionOption | null {
   if (response.selectedActionId) {
     const selectedOption = options.find((option) => option.optionId === response.selectedActionId);
-    if (selectedOption) {
-      return selectedOption;
-    }
+    if (!selectedOption) return null;
+    const selectedBehavior = selectedOption.kind.startsWith("allow") ? "allow" : "deny";
+    return selectedBehavior === response.behavior ? selectedOption : null;
   }
 
   const order =

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2054,7 +2054,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     const selectedOption = selectPermissionOption(pending.options, response);
-    if (response.selectedActionId && !selectedOption) {
+    if (response.selectedActionId !== undefined && !selectedOption) {
       throw new Error(
         `ACP permission action '${response.selectedActionId}' does not exist or does not match '${response.behavior}' behavior`,
       );
@@ -3483,7 +3483,7 @@ function selectPermissionOption(
   options: PermissionOption[],
   response: AgentPermissionResponse,
 ): PermissionOption | null {
-  if (response.selectedActionId) {
+  if (response.selectedActionId !== undefined) {
     const selectedOption = options.find((option) => option.optionId === response.selectedActionId);
     if (!selectedOption) return null;
     const selectedBehavior = selectedOption.kind.startsWith("allow") ? "allow" : "deny";


### PR DESCRIPTION
### Linked issue

Closes #1854
Supersedes #1879

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

ACP already sends every available choice as an ordered `PermissionOption`, but Paseo collapsed that list into binary Accept/Deny behavior and returned the first matching allow option. Passing the options through the existing permission-action model lets users see the upstream labels and sends the exact selected `optionId` back to the agent without parsing provider-private tool input.

The same wire shape is also used for normal approvals. Auto-accept remains enabled for standard approval sets, but repeated options of the same allow kind identify a chooser and always wait for the user instead of silently selecting the first answer.

### Goals

- Render every ACP permission option as an ordered action with its upstream label.
- Return the exact selected option ID to ACP.
- Keep behavior-based fallback responses working for clients that do not send an action ID.
- Prevent auto-accept from answering chooser requests.
- Allow long action rows to wrap on desktop.

### Non-goals

- Parse provider-specific `rawInput` payloads.
- Add ACP elicitation forms, multi-select, or free-text answers.
- Upgrade the ACP SDK.
- Include the unrelated OMP skill-rendering work from #1879.

### QA

- Added regression coverage for option order and behavior, exact selection, behavior fallback, standard auto-accept, and chooser auto-accept suppression.
- `npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1` — 95 passed.
- `node --test scripts/ci-workflow.test.mjs scripts/daemon-launch-contract.test.mjs` — 9 passed. This branch also moves the misplaced project-status browser spec into the browser-owned directory to repair the current base invariant failure.
- Isolated real ACP smoke: received three labeled choices with auto-accept enabled, selected the second choice, observed the exact second `optionId` returned, and the agent resumed without error.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format` — passed.
- Desktop action wrapping was not visually captured. No native-specific behavior changed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
