### PR TITLE
fix(server): hydrate provider history atomically

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import {
+  AgentHistoryHydrationError,
   AgentManager,
   AgentManagerShuttingDownError,
   commandMayHaveChangedExternalState,
@@ -442,6 +443,44 @@ class TestAgentSession implements AgentSession {
   }
 
   async close(): Promise<void> {}
+}
+
+class NonSettlingHistorySession extends TestAgentSession {
+  readonly historyStarted = deferred<void>();
+  readonly returnRequested = deferred<void>();
+  returnCallCount = 0;
+  private readonly nextResult = deferred<IteratorResult<AgentStreamEvent>>();
+
+  override streamHistory(): AsyncGenerator<AgentStreamEvent> {
+    const iterator = {
+      next: async () => {
+        this.historyStarted.resolve();
+        return await this.nextResult.promise;
+      },
+      return: async () => {
+        this.returnCallCount += 1;
+        this.returnRequested.resolve();
+        return { done: true, value: undefined };
+      },
+      throw: async (error: unknown) => {
+        throw error;
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    return iterator as AsyncGenerator<AgentStreamEvent>;
+  }
+}
+
+class SingleSessionAgentClient extends TestAgentClient {
+  constructor(private readonly session: AgentSession) {
+    super();
+  }
+
+  override async createSession(): Promise<AgentSession> {
+    return this.session;
+  }
 }
 
 class AtomicTestTimelineStore implements AgentTimelineStore {
@@ -4187,6 +4226,334 @@ test("force hydration preserves provider and turn identity for a canonical promp
       }),
     ]);
   } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("provider hydration bounds sustained live events and releases the gate", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-buffer-bound-"));
+  const agentId = "00000000-0000-4000-8000-000000000167";
+  const session = new NonSettlingHistorySession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: { codex: new SingleSessionAgentClient(session) },
+    historyHydrationMaxBufferedOperations: 3,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydration = manager.hydrateTimelineFromProvider(created.id);
+    await session.historyStarted.promise;
+
+    for (let index = 1; index <= 20; index += 1) {
+      session.pushEvent({
+        type: "timeline",
+        provider: "codex",
+        item: { type: "user_message", text: `live event ${index}` },
+      });
+    }
+
+    const hydrationState = manager as unknown as {
+      activeHistoryHydrations: Map<
+        string,
+        { preGateBufferedOperations: unknown[]; bufferedOperations: unknown[] }
+      >;
+    };
+    const activeHydration = hydrationState.activeHistoryHydrations.get(agentId);
+    expect(
+      (activeHydration?.preGateBufferedOperations.length ?? 0) +
+        (activeHydration?.bufferedOperations.length ?? 0),
+    ).toBeLessThanOrEqual(3);
+    await session.returnRequested.promise;
+    await hydration;
+    expect(session.returnCallCount).toBe(1);
+    expect(manager.getTimeline(agentId)).toEqual(
+      Array.from({ length: 20 }, (_, index) => ({
+        type: "user_message",
+        text: `live event ${index + 1}`,
+      })),
+    );
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("buffer cancellation preserves pre-gate event order without deadlock", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-pre-gate-cancel-"));
+  const agentId = "00000000-0000-4000-8000-000000000173";
+  const session = new NonSettlingHistorySession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: { codex: new SingleSessionAgentClient(session) },
+    historyHydrationMaxBufferedOperations: 2,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const releasePreGateEvent = deferred<void>();
+    const hydrationState = manager as unknown as {
+      sessionEventTails: Map<string, Promise<void>>;
+    };
+    hydrationState.sessionEventTails.set(agentId, releasePreGateEvent.promise);
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "event admitted before hydration" },
+    });
+
+    const hydration = manager.hydrateTimelineFromProvider(created.id);
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "first event admitted during hydration" },
+    });
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "second event admitted during hydration" },
+    });
+    releasePreGateEvent.resolve();
+
+    await hydration;
+    expect(manager.getTimeline(agentId)).toEqual([
+      { type: "user_message", text: "event admitted before hydration" },
+      { type: "user_message", text: "first event admitted during hydration" },
+      { type: "user_message", text: "second event admitted during hydration" },
+    ]);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("provider hydration timeout releases admitted live events once in order", async () => {
+  vi.useFakeTimers();
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-timeout-order-"));
+  const agentId = "00000000-0000-4000-8000-000000000168";
+  const session = new NonSettlingHistorySession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: { codex: new SingleSessionAgentClient(session) },
+    rescueTimeouts: { historyHydrationMs: 25 },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydration = manager.hydrateTimelineFromProvider(created.id);
+    await session.historyStarted.promise;
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "first admitted event" },
+    });
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "second admitted event" },
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    await hydration;
+    expect(manager.getTimeline(agentId)).toEqual([
+      { type: "user_message", text: "first admitted event" },
+      { type: "user_message", text: "second admitted event" },
+    ]);
+  } finally {
+    vi.useRealTimers();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("forced provider hydration reports a typed timeout failure", async () => {
+  vi.useFakeTimers();
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-forced-timeout-"));
+  const agentId = "00000000-0000-4000-8000-000000000169";
+  const session = new NonSettlingHistorySession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: { codex: new SingleSessionAgentClient(session) },
+    rescueTimeouts: { historyHydrationMs: 25 },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const failure = manager
+      .hydrateTimelineFromProvider(created.id, { force: true })
+      .catch((error: unknown) => error);
+    await session.historyStarted.promise;
+
+    await vi.advanceTimersByTimeAsync(25);
+    const error = await failure;
+    expect(error).toBeInstanceOf(AgentHistoryHydrationError);
+    expect(error).toMatchObject({ agentId, reason: "timed_out" });
+  } finally {
+    vi.useRealTimers();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("closing an agent cancels hydration, clears its gate, and does not replay", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-close-"));
+  const agentId = "00000000-0000-4000-8000-000000000170";
+  const session = new NonSettlingHistorySession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: { codex: new SingleSessionAgentClient(session) },
+    logger,
+    idFactory: () => agentId,
+  });
+  const events: AgentManagerEvent[] = [];
+  manager.subscribe((event) => events.push(event), { agentId, replayState: false });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydrationFailure = manager
+      .hydrateTimelineFromProvider(created.id, { force: true })
+      .catch((error: unknown) => error);
+    await session.historyStarted.promise;
+    session.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "must not replay after close" },
+    });
+
+    await manager.closeAgent(agentId);
+    const error = await hydrationFailure;
+    expect(error).toBeInstanceOf(AgentHistoryHydrationError);
+    expect(error).toMatchObject({ agentId, reason: "cancelled" });
+    expect(session.returnCallCount).toBe(1);
+    expect(
+      events.some(
+        (event) =>
+          event.type === "agent_stream" &&
+          event.event.type === "timeline" &&
+          event.event.item.type === "user_message" &&
+          event.event.item.text === "must not replay after close",
+      ),
+    ).toBe(false);
+    const hydrationState = manager as unknown as {
+      activeHistoryHydrations: Map<string, unknown>;
+      historyHydrationTails: Map<string, Promise<void>>;
+      coalescerHistoryHydrationTokens: Map<string, symbol>;
+    };
+    expect(hydrationState.activeHistoryHydrations.has(agentId)).toBe(false);
+    expect(hydrationState.historyHydrationTails.has(agentId)).toBe(false);
+    expect(hydrationState.coalescerHistoryHydrationTokens.has(agentId)).toBe(false);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("provider hydration requests iterator cleanup exactly once", async () => {
+  vi.useFakeTimers();
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-return-"));
+  const agentId = "00000000-0000-4000-8000-000000000171";
+  const session = new NonSettlingHistorySession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: { codex: new SingleSessionAgentClient(session) },
+    rescueTimeouts: { historyHydrationMs: 25 },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydration = manager.hydrateTimelineFromProvider(created.id);
+    await session.historyStarted.promise;
+
+    await vi.advanceTimersByTimeAsync(25);
+    await hydration;
+    await manager.closeAgent(agentId);
+    expect(session.returnCallCount).toBe(1);
+  } finally {
+    vi.useRealTimers();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("normal provider hydration keeps atomic history and live event ordering", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-normal-"));
+  const agentId = "00000000-0000-4000-8000-000000000172";
+  const historyStarted = deferred<void>();
+  const releaseHistory = deferred<void>();
+  let returnCallCount = 0;
+  let session: TestAgentSession | null = null;
+
+  class NormalHistorySession extends TestAgentSession {
+    override streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      const iterator = (async function* () {
+        historyStarted.resolve();
+        await releaseHistory.promise;
+        yield {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "user_message", text: "complete provider history" },
+        } satisfies AgentStreamEvent;
+      })();
+      const closeIterator = iterator.return.bind(iterator);
+      iterator.return = async (value) => {
+        returnCallCount += 1;
+        return await closeIterator(value);
+      };
+      return iterator;
+    }
+  }
+
+  class NormalHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new NormalHistorySession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new NormalHistoryClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydration = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    await historyStarted.promise;
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "live event during normal hydration" },
+    });
+    releaseHistory.resolve();
+
+    await hydration;
+    expect(manager.getTimeline(agentId)).toEqual([
+      { type: "user_message", text: "complete provider history" },
+      { type: "user_message", text: "live event during normal hydration" },
+    ]);
+    expect(returnCallCount).toBe(0);
+  } finally {
+    releaseHistory.resolve();
     await manager.closeAgent(agentId).catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });
   }

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2979,7 +2979,7 @@ test("reloadAgentSession preserves timeline and does not force history replay", 
   expect(afterHydrate).toEqual(beforeReload);
 });
 
-test("reloadAgentSession clears provider children before rehydrating from disk", async () => {
+test("reloadAgentSession keeps provider children until disk rehydration commits", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-reload-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
   let activeSession: TestAgentSession | null = null;
@@ -3017,7 +3017,65 @@ test("reloadAgentSession clears provider children before rehydrating from disk",
 
   await manager.reloadAgentSession(snapshot.id, undefined, { rehydrateFromDisk: true });
 
+  expect(manager.listProviderSubagents(snapshot.id)).toHaveLength(1);
+  await manager.hydrateTimelineFromProvider(snapshot.id, { force: true, broadcast: true });
   expect(manager.listProviderSubagents(snapshot.id)).toEqual([]);
+});
+
+test("failed refresh history preserves the prior file-backed timeline and reports failure", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-refresh-history-rollback-"));
+  const agentId = "00000000-0000-4000-8000-000000000156";
+  const durableTimelineStore = new FileAgentTimelineStore(join(workdir, "timelines"), logger);
+
+  class FailingRefreshHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield* [];
+      throw new Error("provider refresh history failed");
+    }
+  }
+
+  class FailingRefreshHistoryClient extends TestAgentClient {
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new FailingRefreshHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new FailingRefreshHistoryClient() },
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.appendTimelineItem(created.id, {
+      type: "assistant_message",
+      text: "prior durable answer",
+    });
+    await manager.flush();
+    const durableBefore = await durableTimelineStore.getCommittedRows(agentId);
+
+    await manager.reloadAgentSession(created.id, undefined, { rehydrateFromDisk: true });
+    expect(manager.getTimeline(created.id)).toEqual(durableBefore.map((row) => row.item));
+    await expect(
+      manager.hydrateTimelineFromProvider(created.id, { force: true, broadcast: true }),
+    ).rejects.toThrow("provider refresh history failed");
+
+    expect(manager.getTimeline(created.id)).toEqual(durableBefore.map((row) => row.item));
+    await expect(durableTimelineStore.getCommittedRows(agentId)).resolves.toEqual(durableBefore);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("hydrateTimelineFromProvider restores and broadcasts provider children from session history", async () => {
@@ -3121,6 +3179,68 @@ test("force provider hydration removes children absent from current history", as
       subagentId: "removed-by-rewind",
     },
   });
+});
+
+test("provider hydration replays a queued terminal child update after older history", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-order-"));
+  const agentId = "00000000-0000-4000-8000-000000000157";
+  let session: TestAgentSession | null = null;
+
+  class ProviderChildOrderingSession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield {
+        type: "provider_subagent",
+        provider: "codex",
+        event: {
+          type: "upsert",
+          id: "child-1",
+          title: "Child",
+          status: "running",
+          timestamp: "2026-01-01T00:00:00.000Z",
+        },
+      };
+    }
+  }
+
+  class ProviderChildOrderingClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new ProviderChildOrderingSession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new ProviderChildOrderingClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    session?.pushEvent({
+      type: "provider_subagent",
+      provider: "codex",
+      event: {
+        type: "upsert",
+        id: "child-1",
+        title: "Child",
+        status: "completed",
+        timestamp: "2026-01-02T00:00:00.000Z",
+      },
+    });
+
+    await manager.hydrateTimelineFromProvider(created.id, { force: true, broadcast: true });
+
+    expect(manager.getProviderSubagent(created.id, "child-1")).toMatchObject({
+      status: "completed",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("provider hydration gates a microtask live event before draining the session queue", async () => {
@@ -3661,6 +3781,109 @@ test("concurrent force generations share one gate and release live events after 
   } finally {
     releaseFirst.resolve();
     releaseSecond.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("a successor generation preserves a writer already replaying behind the prior generation", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-writer-successor-"));
+  const agentId = "00000000-0000-4000-8000-000000000158";
+  const writerPersistStarted = deferred<void>();
+  const releaseWriterPersist = deferred<void>();
+  const durableTimelineStore = new FileAgentTimelineStore(join(workdir, "timelines"), logger);
+  let session: TestAgentSession | null = null;
+  let historyGeneration = 0;
+
+  class GatedWriterStorage extends AgentStorage {
+    armed = false;
+    private armedPersistCount = 0;
+
+    override async applySnapshot(
+      agent: ManagedAgent,
+      options?: { title?: string | null; internal?: boolean },
+    ): Promise<void> {
+      if (this.armed) {
+        this.armedPersistCount += 1;
+        if (this.armedPersistCount === 2) {
+          writerPersistStarted.resolve();
+          await releaseWriterPersist.promise;
+        }
+      }
+      await super.applySnapshot(agent, options);
+    }
+  }
+
+  class GeneratedWriterHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyGeneration += 1;
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "user_message", text: `history generation ${historyGeneration}` },
+      };
+      if (historyGeneration > 1) {
+        yield {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "user_message", text: "writer admitted behind generation 1" },
+        };
+      }
+    }
+  }
+
+  class GeneratedWriterHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new GeneratedWriterHistorySession(config);
+      return session;
+    }
+  }
+
+  const storage = new GatedWriterStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new GeneratedWriterHistoryClient() },
+    registry: storage,
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    storage.armed = true;
+    const first = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    const bufferedWriter = manager.appendTimelineItem(created.id, {
+      type: "user_message",
+      text: "writer admitted behind generation 1",
+    });
+
+    await writerPersistStarted.promise;
+    const second = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "live row admitted behind generation 2" },
+    });
+    releaseWriterPersist.resolve();
+
+    await Promise.all([first, second, bufferedWriter]);
+    await manager.flush();
+    const expectedItems: AgentTimelineItem[] = [
+      { type: "user_message", text: "history generation 2" },
+      { type: "user_message", text: "writer admitted behind generation 1" },
+      { type: "user_message", text: "live row admitted behind generation 2" },
+    ];
+    expect(manager.getTimeline(created.id)).toEqual(expectedItems);
+    await expect(durableTimelineStore.getCommittedRows(agentId)).resolves.toEqual(
+      expect.arrayContaining(expectedItems.map((item) => expect.objectContaining({ item }))),
+    );
+    expect((await durableTimelineStore.getCommittedRows(agentId)).map((row) => row.item)).toEqual(
+      expectedItems,
+    );
+  } finally {
+    releaseWriterPersist.resolve();
     await manager.closeAgent(agentId).catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });
   }

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -3181,13 +3181,15 @@ test("force provider hydration removes children absent from current history", as
   });
 });
 
-test("provider hydration replays a queued terminal child update after older history", async () => {
+test("provider hydration preserves a queued terminal child update across a successor", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-order-"));
   const agentId = "00000000-0000-4000-8000-000000000157";
   let session: TestAgentSession | null = null;
+  let historyGeneration = 0;
 
   class ProviderChildOrderingSession extends TestAgentSession {
     override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyGeneration += 1;
       yield {
         type: "provider_subagent",
         provider: "codex",
@@ -3199,6 +3201,19 @@ test("provider hydration replays a queued terminal child update after older hist
           timestamp: "2026-01-01T00:00:00.000Z",
         },
       };
+      if (historyGeneration > 1) {
+        yield {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "upsert",
+            id: "child-1",
+            title: "Child",
+            status: "completed",
+            timestamp: "2026-01-02T00:00:00.000Z",
+          },
+        };
+      }
     }
   }
 
@@ -3219,6 +3234,25 @@ test("provider hydration replays a queued terminal child update after older hist
     const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
       workspaceId: undefined,
     });
+    let successorHydration: Promise<void> | null = null;
+    let completedUpserts = 0;
+    manager.subscribe(
+      (event) => {
+        if (
+          event.type !== "provider_subagent" ||
+          event.event.type !== "upsert" ||
+          event.event.subagent.status !== "completed"
+        ) {
+          return;
+        }
+        completedUpserts += 1;
+        successorHydration ??= manager.hydrateTimelineFromProvider(created.id, {
+          force: true,
+          broadcast: true,
+        });
+      },
+      { agentId: created.id, replayState: false },
+    );
     session?.pushEvent({
       type: "provider_subagent",
       provider: "codex",
@@ -3232,11 +3266,14 @@ test("provider hydration replays a queued terminal child update after older hist
     });
 
     await manager.hydrateTimelineFromProvider(created.id, { force: true, broadcast: true });
+    await successorHydration;
 
     expect(manager.getProviderSubagent(created.id, "child-1")).toMatchObject({
       status: "completed",
       updatedAt: "2026-01-02T00:00:00.000Z",
     });
+    expect(historyGeneration).toBe(2);
+    expect(completedUpserts).toBe(2);
   } finally {
     await manager.closeAgent(agentId).catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -460,12 +460,13 @@ class AtomicTestTimelineStore implements AgentTimelineStore {
   async appendCommitted(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): Promise<AgentTimelineRow> {
     const row: AgentTimelineRow = {
       seq: (await this.getLatestCommittedSeq(agentId)) + 1,
       timestamp: options?.timestamp ?? new Date().toISOString(),
       item,
+      ...(options?.turnId ? { turnId: options.turnId } : {}),
     };
     await this.bulkInsert(agentId, [row]);
     return structuredClone(row);
@@ -512,7 +513,10 @@ class AtomicTestTimelineStore implements AgentTimelineStore {
     this.rowsByAgent.delete(agentId);
   }
 
-  async replaceCommitted(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
+  async replaceCommitted(
+    agentId: string,
+    rows: readonly AgentTimelineRow[],
+  ): Promise<{ epoch: string }> {
     const replacement = rows.map((row) => structuredClone(row));
     this.replacementStarted?.resolve();
     await this.replacementGate?.promise;
@@ -520,6 +524,7 @@ class AtomicTestTimelineStore implements AgentTimelineStore {
       throw this.replacementError;
     }
     this.rowsByAgent.set(agentId, replacement);
+    return { epoch: `test-epoch-${agentId}` };
   }
 
   async bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
@@ -3181,6 +3186,81 @@ test("force provider hydration removes children absent from current history", as
   });
 });
 
+test("force provider hydration preserves a newer terminal child present in stale history", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-terminal-"));
+  const agentId = "00000000-0000-4000-8000-000000000164";
+  let session: TestAgentSession | null = null;
+
+  class StaleProviderChildHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield {
+        type: "provider_subagent",
+        provider: "codex",
+        event: {
+          type: "upsert",
+          id: "child-in-stale-history",
+          title: "Child in stale history",
+          status: "running",
+          timestamp: "2026-01-01T00:00:00.000Z",
+        },
+      };
+    }
+  }
+
+  class StaleProviderChildHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new StaleProviderChildHistorySession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new StaleProviderChildHistoryClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    session?.pushEvent({
+      type: "provider_subagent",
+      provider: "codex",
+      event: {
+        type: "upsert",
+        id: "child-in-stale-history",
+        title: "Child in stale history",
+        status: "completed",
+        timestamp: "2026-01-02T00:00:00.000Z",
+      },
+    });
+    session?.pushEvent({
+      type: "provider_subagent",
+      provider: "codex",
+      event: {
+        type: "upsert",
+        id: "child-absent-from-history",
+        title: "Child absent from history",
+        status: "completed",
+        timestamp: "2026-01-02T00:00:00.000Z",
+      },
+    });
+    await vi.waitFor(() => expect(manager.listProviderSubagents(agentId)).toHaveLength(2));
+
+    await manager.hydrateTimelineFromProvider(created.id, { force: true });
+
+    expect(manager.getProviderSubagent(agentId, "child-in-stale-history")).toMatchObject({
+      status: "completed",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    expect(manager.getProviderSubagent(agentId, "child-absent-from-history")).toBeNull();
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("provider hydration preserves a queued terminal child update across a successor", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-order-"));
   const agentId = "00000000-0000-4000-8000-000000000157";
@@ -3529,6 +3609,8 @@ test("file-backed assistant-only history returns one last message across force h
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-assistant-only-history-"));
   const agentId = "00000000-0000-4000-8000-000000000155";
   const expectedMessage = "one durable assistant response";
+  const timelineStoragePath = join(workdir, "timelines");
+  const firstTimelineStore = new FileAgentTimelineStore(timelineStoragePath, logger);
   let historyCalls = 0;
 
   class AssistantOnlyHistorySession extends TestAgentSession {
@@ -3562,7 +3644,7 @@ test("file-backed assistant-only history returns one last message across force h
   const client = new AssistantOnlyHistoryClient();
   const firstManager = new AgentManager({
     clients: { codex: client },
-    durableTimelineStore: new FileAgentTimelineStore(join(workdir, "timelines"), logger),
+    durableTimelineStore: firstTimelineStore,
     logger,
     idFactory: () => agentId,
   });
@@ -3572,6 +3654,13 @@ test("file-backed assistant-only history returns one last message across force h
       workspaceId: undefined,
     });
     await firstManager.hydrateTimelineFromProvider(created.id, { force: true });
+    const beforeRestart = firstManager.fetchTimeline(created.id, {
+      direction: "tail",
+      limit: 0,
+    });
+    expect((await firstTimelineStore.fetchCommitted(agentId, { limit: 0 })).epoch).toBe(
+      beforeRestart.epoch,
+    );
     await expect(firstManager.getLastAssistantMessage(created.id)).resolves.toBe(expectedMessage);
     await expect(firstManager.waitForAgentEvent(created.id)).resolves.toMatchObject({
       lastMessage: expectedMessage,
@@ -3580,7 +3669,7 @@ test("file-backed assistant-only history returns one last message across force h
 
     const restartedManager = new AgentManager({
       clients: { codex: client },
-      durableTimelineStore: new FileAgentTimelineStore(join(workdir, "timelines"), logger),
+      durableTimelineStore: new FileAgentTimelineStore(timelineStoragePath, logger),
       logger,
       idFactory: () => agentId,
     });
@@ -3593,6 +3682,13 @@ test("file-backed assistant-only history returns one last message across force h
       );
       await restartedManager.hydrateTimelineFromProvider(restarted.id);
       expect(historyCalls).toBe(1);
+      expect(
+        restartedManager.fetchTimeline(restarted.id, {
+          direction: "after",
+          cursor: { epoch: beforeRestart.epoch, seq: beforeRestart.window.maxSeq },
+          limit: 0,
+        }),
+      ).toMatchObject({ reset: false, staleCursor: false, rows: [] });
       await expect(restartedManager.getLastAssistantMessage(restarted.id)).resolves.toBe(
         expectedMessage,
       );
@@ -3921,6 +4017,176 @@ test("a successor generation preserves a writer already replaying behind the pri
     );
   } finally {
     releaseWriterPersist.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("a rewritten successor preserves a live occurrence equal to prior history", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-duplicate-successor-"));
+  const agentId = "00000000-0000-4000-8000-000000000165";
+  const writerPersistStarted = deferred<void>();
+  const releaseWriterPersist = deferred<void>();
+  const durableTimelineStore = new FileAgentTimelineStore(join(workdir, "timelines"), logger);
+  const repeatedItem = {
+    type: "assistant_message",
+    text: "equal historical and live payload",
+  } satisfies AgentTimelineItem;
+  let session: TestAgentSession | null = null;
+  let historyGeneration = 0;
+
+  class GatedWriterStorage extends AgentStorage {
+    armed = false;
+    private armedPersistCount = 0;
+
+    override async applySnapshot(
+      agent: ManagedAgent,
+      options?: { title?: string | null; internal?: boolean },
+    ): Promise<void> {
+      if (this.armed) {
+        this.armedPersistCount += 1;
+        if (this.armedPersistCount === 2) {
+          writerPersistStarted.resolve();
+          await releaseWriterPersist.promise;
+        }
+      }
+      await super.applySnapshot(agent, options);
+    }
+  }
+
+  class RewrittenDuplicateHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyGeneration += 1;
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "user_message", text: `rewritten history ${historyGeneration}` },
+      };
+      yield { type: "timeline", provider: "codex", item: repeatedItem };
+    }
+  }
+
+  class RewrittenDuplicateHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new RewrittenDuplicateHistorySession(config);
+      return session;
+    }
+  }
+
+  const storage = new GatedWriterStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new RewrittenDuplicateHistoryClient() },
+    registry: storage,
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    storage.armed = true;
+    const first = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    const bufferedWriter = manager.appendTimelineItem(created.id, repeatedItem);
+
+    await writerPersistStarted.promise;
+    const second = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "live row admitted behind generation 2" },
+    });
+    releaseWriterPersist.resolve();
+
+    await Promise.all([first, second, bufferedWriter]);
+    await manager.flush();
+    const expectedItems: AgentTimelineItem[] = [
+      { type: "user_message", text: "rewritten history 2" },
+      repeatedItem,
+      repeatedItem,
+      { type: "user_message", text: "live row admitted behind generation 2" },
+    ];
+    expect(manager.getTimeline(created.id)).toEqual(expectedItems);
+    expect((await durableTimelineStore.getCommittedRows(agentId)).map((row) => row.item)).toEqual(
+      expectedItems,
+    );
+  } finally {
+    releaseWriterPersist.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("force hydration preserves provider and turn identity for a canonical prompt", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-provider-identity-"));
+  const agentId = "00000000-0000-4000-8000-000000000166";
+  const durableTimelineStore = new FileAgentTimelineStore(join(workdir, "timelines"), logger);
+  const canonicalItem = {
+    type: "user_message",
+    text: "canonical submitted prompt",
+    messageId: "client-message-1",
+    clientMessageId: "client-message-1",
+  } satisfies AgentTimelineItem;
+  await durableTimelineStore.replaceCommitted(agentId, [
+    {
+      seq: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      providerMessageId: "provider-message-1",
+      turnId: "submitted-turn",
+      item: canonicalItem,
+    },
+  ]);
+
+  class IdentityHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield { type: "timeline", provider: "codex", item: canonicalItem };
+    }
+  }
+
+  class IdentityHistoryClient extends TestAgentClient {
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new IdentityHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new IdentityHistoryClient() },
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const resumed = await manager.resumeAgentFromPersistence(
+      { provider: "codex", sessionId: "identity-session", metadata: { cwd: workdir } },
+      undefined,
+      agentId,
+      { workspaceId: undefined },
+    );
+    await manager.hydrateTimelineFromProvider(resumed.id, { force: true });
+
+    expect(manager.fetchTimeline(agentId, { direction: "tail", limit: 0 }).rows).toEqual([
+      expect.objectContaining({
+        providerMessageId: "provider-message-1",
+        turnId: "submitted-turn",
+        item: canonicalItem,
+      }),
+    ]);
+    await expect(durableTimelineStore.getCommittedRows(agentId)).resolves.toEqual([
+      expect.objectContaining({
+        providerMessageId: "provider-message-1",
+        turnId: "submitted-turn",
+        item: canonicalItem,
+      }),
+    ]);
+  } finally {
     await manager.closeAgent(agentId).catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });
   }
@@ -9233,6 +9499,7 @@ test("canonical submitted prompt keeps wire identity while rewind resolves provi
         seq: 1,
         timestamp: expect.any(String),
         providerMessageId: "provider-message-1",
+        turnId: "turn-submitted-user-message",
         item: {
           type: "user_message",
           text: "hello from composer",
@@ -9243,6 +9510,7 @@ test("canonical submitted prompt keeps wire identity while rewind resolves provi
       {
         seq: 2,
         timestamp: expect.any(String),
+        turnId: "turn-submitted-user-message",
         item: { type: "assistant_message", text: "output before provider echo" },
       },
     ]);

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -24,6 +24,7 @@ import type {
   AgentClient,
   AgentCreateSessionOptions,
   AgentFeature,
+  AgentHistoryStreamOptions,
   AgentLaunchContext,
   AgentPromptInput,
   AgentProvider,
@@ -4456,6 +4457,68 @@ test("closing an agent cancels hydration, clears its gate, and does not replay",
     expect(hydrationState.activeHistoryHydrations.has(agentId)).toBe(false);
     expect(hydrationState.historyHydrationTails.has(agentId)).toBe(false);
     expect(hydrationState.coalescerHistoryHydrationTokens.has(agentId)).toBe(false);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("closing an agent releases native provider history work through cancellation", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-native-history-cancel-"));
+  const agentId = "00000000-0000-4000-8000-000000000174";
+  const historyStarted = deferred<void>();
+  const historyReleased = deferred<void>();
+
+  class NativeStallingHistorySession extends TestAgentSession {
+    override async *streamHistory(
+      options?: AgentHistoryStreamOptions,
+    ): AsyncGenerator<AgentStreamEvent> {
+      const signal = options?.signal;
+      if (!signal) {
+        throw new Error("History cancellation signal was not provided");
+      }
+      historyStarted.resolve();
+      try {
+        await new Promise<void>((_resolve, reject) => {
+          const onAbort = () => reject(signal.reason);
+          if (signal.aborted) {
+            onAbort();
+          } else {
+            signal.addEventListener("abort", onAbort, { once: true });
+          }
+        });
+      } finally {
+        historyReleased.resolve();
+      }
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "assistant_message", text: "unreachable stalled history" },
+      };
+    }
+  }
+
+  const session = new NativeStallingHistorySession({ provider: "codex", cwd: workdir });
+  const manager = new AgentManager({
+    clients: { codex: new SingleSessionAgentClient(session) },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydrationFailure = manager
+      .hydrateTimelineFromProvider(created.id, { force: true })
+      .catch((error: unknown) => error);
+    await historyStarted.promise;
+
+    await manager.closeAgent(agentId);
+    await historyReleased.promise;
+    const error = await hydrationFailure;
+    expect(error).toBeInstanceOf(AgentHistoryHydrationError);
+    expect(error).toMatchObject({ agentId, reason: "cancelled" });
   } finally {
     await manager.closeAgent(agentId).catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -41,6 +41,7 @@ import type {
 import type { PaseoToolCatalog } from "./tools/types.js";
 import type { ProviderDefinition } from "./provider-registry.js";
 import type { AgentTimelineRow, AgentTimelineStore } from "./agent-timeline-store-types.js";
+import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -469,8 +470,15 @@ class AtomicTestTimelineStore implements AgentTimelineStore {
     return structuredClone(row);
   }
 
-  async fetchCommitted(): Promise<never> {
-    throw new Error("fetchCommitted is not used by this test store");
+  async fetchCommitted(agentId: string) {
+    const store = new InMemoryAgentTimelineStore();
+    const rows = await this.getCommittedRows(agentId);
+    store.initialize(agentId, {
+      epoch: `test-epoch-${agentId}`,
+      rows,
+      nextSeq: (rows.at(-1)?.seq ?? 0) + 1,
+    });
+    return store.fetch(agentId, { limit: 0 });
   }
 
   async getLatestCommittedSeq(agentId: string): Promise<number> {
@@ -3174,6 +3182,69 @@ test("provider hydration gates a microtask live event before draining the sessio
   }
 });
 
+test("provider hydration drains a queued pre-gate event and replays it before post-gate events", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-hydration-admission-"));
+  const agentId = "00000000-0000-4000-8000-000000000153";
+  let session: TestAgentSession | null = null;
+
+  class ReplacementHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "user_message", text: "replacement history" },
+      };
+    }
+  }
+
+  class ReplacementHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new ReplacementHistorySession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new ReplacementHistoryClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "queued before hydration admission" },
+    });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "assistant_message", text: "coalesced before hydration admission" },
+    });
+    const hydration = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "admitted after hydration gate" },
+    });
+
+    await hydration;
+
+    expect(manager.getTimeline(created.id)).toEqual([
+      { type: "user_message", text: "replacement history" },
+      { type: "user_message", text: "queued before hydration admission" },
+      { type: "assistant_message", text: "coalesced before hydration admission" },
+      { type: "user_message", text: "admitted after hydration gate" },
+    ]);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("provider hydration awaits one atomic durable replacement before a restart can prime", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-hydration-durable-"));
   const agentId = "00000000-0000-4000-8000-000000000151";
@@ -3282,6 +3353,7 @@ test("provider hydration awaits one atomic durable replacement before a restart 
       );
       await restartedManager.hydrateTimelineFromProvider(restarted.id);
       expect(historyCalls).toBe(1);
+      expect(restartedManager.getTimeline(restarted.id)).toEqual(committed.map((row) => row.item));
       expect((await restartedManager.getTimelineRows(restarted.id)).map((row) => row.item)).toEqual(
         committed.map((row) => row.item),
       );

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -40,6 +40,7 @@ import type {
 } from "./agent-sdk-types.js";
 import type { PaseoToolCatalog } from "./tools/types.js";
 import type { ProviderDefinition } from "./provider-registry.js";
+import type { AgentTimelineRow, AgentTimelineStore } from "./agent-timeline-store-types.js";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -439,6 +440,95 @@ class TestAgentSession implements AgentSession {
   }
 
   async close(): Promise<void> {}
+}
+
+class AtomicTestTimelineStore implements AgentTimelineStore {
+  private readonly rowsByAgent = new Map<string, AgentTimelineRow[]>();
+  replacementGate: Deferred<void> | null = null;
+  replacementStarted: Deferred<void> | null = null;
+  replacementError: Error | null = null;
+
+  seed(agentId: string, rows: readonly AgentTimelineRow[]): void {
+    this.rowsByAgent.set(
+      agentId,
+      rows.map((row) => structuredClone(row)),
+    );
+  }
+
+  async appendCommitted(
+    agentId: string,
+    item: AgentTimelineItem,
+    options?: { timestamp?: string },
+  ): Promise<AgentTimelineRow> {
+    const row: AgentTimelineRow = {
+      seq: (await this.getLatestCommittedSeq(agentId)) + 1,
+      timestamp: options?.timestamp ?? new Date().toISOString(),
+      item,
+    };
+    await this.bulkInsert(agentId, [row]);
+    return structuredClone(row);
+  }
+
+  async fetchCommitted(): Promise<never> {
+    throw new Error("fetchCommitted is not used by this test store");
+  }
+
+  async getLatestCommittedSeq(agentId: string): Promise<number> {
+    return this.rowsByAgent.get(agentId)?.at(-1)?.seq ?? 0;
+  }
+
+  async getCommittedRows(agentId: string): Promise<AgentTimelineRow[]> {
+    return (this.rowsByAgent.get(agentId) ?? []).map((row) => structuredClone(row));
+  }
+
+  async getLastItem(agentId: string): Promise<AgentTimelineItem | null> {
+    return structuredClone(this.rowsByAgent.get(agentId)?.at(-1)?.item ?? null);
+  }
+
+  async getLastAssistantMessage(agentId: string): Promise<string | null> {
+    const rows = this.rowsByAgent.get(agentId) ?? [];
+    const chunks: string[] = [];
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      const item = rows[index].item;
+      if (item.type !== "assistant_message") {
+        if (chunks.length > 0) break;
+        continue;
+      }
+      chunks.push(item.text);
+    }
+    return chunks.length > 0 ? chunks.toReversed().join("") : null;
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    this.rowsByAgent.delete(agentId);
+  }
+
+  async replaceCommitted(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
+    const replacement = rows.map((row) => structuredClone(row));
+    this.replacementStarted?.resolve();
+    await this.replacementGate?.promise;
+    if (this.replacementError) {
+      throw this.replacementError;
+    }
+    this.rowsByAgent.set(agentId, replacement);
+  }
+
+  async bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
+    const merged = new Map(
+      (this.rowsByAgent.get(agentId) ?? []).map((row) => [row.seq, structuredClone(row)]),
+    );
+    for (const row of rows) {
+      merged.set(row.seq, structuredClone(row));
+    }
+    this.rowsByAgent.set(
+      agentId,
+      Array.from(merged.values()).sort((left, right) => left.seq - right.seq),
+    );
+  }
+
+  async updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void> {
+    await this.bulkInsert(agentId, [row]);
+  }
 }
 
 class ControlledInterruptSession extends TestAgentSession {
@@ -3022,6 +3112,396 @@ test("force provider hydration removes children absent from current history", as
       subagentId: "removed-by-rewind",
     },
   });
+});
+
+test("provider hydration gates a microtask live event before draining the session queue", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-hydration-gate-"));
+  const agentId = "00000000-0000-4000-8000-000000000150";
+  const historyEntered = deferred<void>();
+  const releaseHistory = deferred<void>();
+  let session: TestAgentSession | null = null;
+
+  class GatedHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyEntered.resolve();
+      await releaseHistory.promise;
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "user_message", text: "replacement history" },
+      };
+    }
+  }
+
+  class GatedHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new GatedHistorySession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new GatedHistoryClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydration = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    queueMicrotask(() => {
+      session?.pushEvent({
+        type: "timeline",
+        provider: "codex",
+        item: { type: "user_message", text: "live event from the drain-to-gate gap" },
+      });
+    });
+
+    await historyEntered.promise;
+    releaseHistory.resolve();
+    await hydration;
+
+    expect(manager.getTimeline(created.id)).toEqual([
+      { type: "user_message", text: "replacement history" },
+      { type: "user_message", text: "live event from the drain-to-gate gap" },
+    ]);
+  } finally {
+    releaseHistory.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("provider hydration awaits one atomic durable replacement before a restart can prime", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-hydration-durable-"));
+  const agentId = "00000000-0000-4000-8000-000000000151";
+  const durableStore = new AtomicTestTimelineStore();
+  durableStore.replacementStarted = deferred<void>();
+  durableStore.replacementGate = deferred<void>();
+  let historyCalls = 0;
+
+  class DurableHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyCalls += 1;
+      yield {
+        type: "timeline",
+        provider: "codex",
+        timestamp: "2026-02-01T00:00:00.000Z",
+        item: { type: "user_message", text: "history row one" },
+      };
+      yield {
+        type: "timeline",
+        provider: "codex",
+        timestamp: "2026-02-01T00:00:01.000Z",
+        item: { type: "assistant_message", text: "history row two" },
+      };
+      yield {
+        type: "timeline",
+        provider: "codex",
+        timestamp: "2026-02-01T00:00:02.000Z",
+        item: { type: "reasoning", text: "history row three" },
+      };
+    }
+  }
+
+  class DurableHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new DurableHistorySession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new DurableHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const client = new DurableHistoryClient();
+  const firstManager = new AgentManager({
+    clients: { codex: client },
+    durableTimelineStore: durableStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await firstManager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    durableStore.seed(agentId, [
+      {
+        seq: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        item: { type: "user_message", text: "stale durable row" },
+      },
+    ]);
+    let hydrationSettled = false;
+    const hydration = firstManager
+      .hydrateTimelineFromProvider(created.id, { force: true })
+      .finally(() => {
+        hydrationSettled = true;
+      });
+
+    await durableStore.replacementStarted.promise;
+    expect(await durableStore.getCommittedRows(agentId)).toEqual([
+      expect.objectContaining({ item: { type: "user_message", text: "stale durable row" } }),
+    ]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(hydrationSettled).toBe(false);
+
+    durableStore.replacementGate.resolve();
+    await hydration;
+    const committed = await durableStore.getCommittedRows(agentId);
+    expect(committed.map((row) => row.item)).toEqual([
+      { type: "user_message", text: "history row one" },
+      { type: "assistant_message", text: "history row two" },
+      { type: "reasoning", text: "history row three" },
+    ]);
+
+    await firstManager.closeAgent(agentId);
+    durableStore.replacementGate = null;
+    durableStore.replacementStarted = null;
+    const restartedManager = new AgentManager({
+      clients: { codex: client },
+      durableTimelineStore: durableStore,
+      logger,
+      idFactory: () => agentId,
+    });
+    try {
+      const restarted = await restartedManager.resumeAgentFromPersistence(
+        { provider: "codex", sessionId: "durable-history-session", metadata: { cwd: workdir } },
+        undefined,
+        agentId,
+        { workspaceId: undefined },
+      );
+      await restartedManager.hydrateTimelineFromProvider(restarted.id);
+      expect(historyCalls).toBe(1);
+      expect((await restartedManager.getTimelineRows(restarted.id)).map((row) => row.item)).toEqual(
+        committed.map((row) => row.item),
+      );
+    } finally {
+      await restartedManager.closeAgent(agentId).catch(() => undefined);
+    }
+  } finally {
+    durableStore.replacementGate?.resolve();
+    await firstManager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("failed durable history replacement rolls back and a later force retries cleanly", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-hydration-rollback-"));
+  const agentId = "00000000-0000-4000-8000-000000000152";
+  const durableStore = new AtomicTestTimelineStore();
+
+  class RetryHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "assistant_message", text: "replacement after retry" },
+      };
+    }
+  }
+
+  class RetryHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new RetryHistorySession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new RetryHistoryClient() },
+    durableTimelineStore: durableStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.appendTimelineItem(created.id, {
+      type: "user_message",
+      text: "live row before failed replacement",
+    });
+    await manager.flush();
+    const durableBefore = await durableStore.getCommittedRows(agentId);
+    durableStore.replacementError = new Error("atomic durable replacement failed");
+
+    await expect(manager.hydrateTimelineFromProvider(created.id, { force: true })).rejects.toThrow(
+      "atomic durable replacement failed",
+    );
+    expect(manager.getTimeline(created.id)).toEqual([
+      { type: "user_message", text: "live row before failed replacement" },
+    ]);
+    expect(await durableStore.getCommittedRows(agentId)).toEqual(durableBefore);
+
+    durableStore.replacementError = null;
+    await manager.hydrateTimelineFromProvider(created.id, { force: true });
+    expect(manager.getTimeline(created.id)).toEqual([
+      { type: "assistant_message", text: "replacement after retry" },
+    ]);
+    expect((await durableStore.getCommittedRows(agentId)).map((row) => row.item)).toEqual([
+      { type: "assistant_message", text: "replacement after retry" },
+    ]);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("failed provider history discards staged rows, releases live events, and remains retryable", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-hydration-stream-failure-"));
+  const agentId = "00000000-0000-4000-8000-000000000153";
+  let historyCalls = 0;
+
+  class RetryableHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyCalls += 1;
+      if (historyCalls === 1) {
+        yield {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "assistant_message", text: "partial row that must roll back" },
+        };
+        this.pushEvent({
+          type: "timeline",
+          provider: "codex",
+          item: { type: "user_message", text: "live row during failed hydration" },
+        });
+        throw new Error("provider history stream failed");
+      }
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "assistant_message", text: "complete history on retry" },
+      };
+    }
+  }
+
+  class RetryableHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new RetryableHistorySession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new RetryableHistoryClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.hydrateTimelineFromProvider(created.id);
+    expect(manager.getTimeline(created.id)).toEqual([
+      { type: "user_message", text: "live row during failed hydration" },
+    ]);
+
+    await manager.hydrateTimelineFromProvider(created.id);
+    expect(historyCalls).toBe(2);
+    expect(manager.getTimeline(created.id)).toEqual([
+      { type: "user_message", text: "live row during failed hydration" },
+      { type: "assistant_message", text: "complete history on retry" },
+    ]);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("concurrent force generations share one gate and release live events after the newest history", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-hydration-generation-"));
+  const agentId = "00000000-0000-4000-8000-000000000154";
+  const firstEntered = deferred<void>();
+  const releaseFirst = deferred<void>();
+  const secondEntered = deferred<void>();
+  const releaseSecond = deferred<void>();
+  let historyCalls = 0;
+  let activeHistoryReads = 0;
+  let maxActiveHistoryReads = 0;
+  let session: TestAgentSession | null = null;
+
+  class GeneratedHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyCalls += 1;
+      const generation = historyCalls;
+      activeHistoryReads += 1;
+      maxActiveHistoryReads = Math.max(maxActiveHistoryReads, activeHistoryReads);
+      try {
+        if (generation === 1) {
+          firstEntered.resolve();
+          await releaseFirst.promise;
+        } else {
+          secondEntered.resolve();
+          await releaseSecond.promise;
+        }
+        yield {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "user_message", text: `history generation ${generation}` },
+        };
+      } finally {
+        activeHistoryReads -= 1;
+      }
+    }
+  }
+
+  class GeneratedHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new GeneratedHistorySession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new GeneratedHistoryClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    let firstSettled = false;
+    const first = manager.hydrateTimelineFromProvider(created.id, { force: true }).finally(() => {
+      firstSettled = true;
+    });
+    await firstEntered.promise;
+    const second = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "user_message", text: "live row behind both generations" },
+    });
+
+    releaseFirst.resolve();
+    await secondEntered.promise;
+    expect(firstSettled).toBe(false);
+    expect(maxActiveHistoryReads).toBe(1);
+
+    releaseSecond.resolve();
+    await Promise.all([first, second]);
+    expect(manager.getTimeline(created.id)).toEqual([
+      { type: "user_message", text: "history generation 2" },
+      { type: "user_message", text: "live row behind both generations" },
+    ]);
+  } finally {
+    releaseFirst.resolve();
+    releaseSecond.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("reloadAgentSession preserves current title when config title is unset", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -42,6 +42,7 @@ import type { PaseoToolCatalog } from "./tools/types.js";
 import type { ProviderDefinition } from "./provider-registry.js";
 import type { AgentTimelineRow, AgentTimelineStore } from "./agent-timeline-store-types.js";
 import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
+import { FileAgentTimelineStore } from "./file-agent-timeline-store.js";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -3362,6 +3363,95 @@ test("provider hydration awaits one atomic durable replacement before a restart 
     }
   } finally {
     durableStore.replacementGate?.resolve();
+    await firstManager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("file-backed assistant-only history returns one last message across force hydration and restart", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-assistant-only-history-"));
+  const agentId = "00000000-0000-4000-8000-000000000155";
+  const expectedMessage = "one durable assistant response";
+  let historyCalls = 0;
+
+  class AssistantOnlyHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyCalls += 1;
+      yield {
+        type: "timeline",
+        provider: "codex",
+        timestamp: "2026-02-01T00:00:00.000Z",
+        item: { type: "assistant_message", text: expectedMessage },
+      };
+    }
+  }
+
+  class AssistantOnlyHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new AssistantOnlyHistorySession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new AssistantOnlyHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const client = new AssistantOnlyHistoryClient();
+  const firstManager = new AgentManager({
+    clients: { codex: client },
+    durableTimelineStore: new FileAgentTimelineStore(join(workdir, "timelines"), logger),
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await firstManager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await firstManager.hydrateTimelineFromProvider(created.id, { force: true });
+    await expect(firstManager.getLastAssistantMessage(created.id)).resolves.toBe(expectedMessage);
+    await expect(firstManager.waitForAgentEvent(created.id)).resolves.toMatchObject({
+      lastMessage: expectedMessage,
+    });
+    await firstManager.closeAgent(agentId);
+
+    const restartedManager = new AgentManager({
+      clients: { codex: client },
+      durableTimelineStore: new FileAgentTimelineStore(join(workdir, "timelines"), logger),
+      logger,
+      idFactory: () => agentId,
+    });
+    try {
+      const restarted = await restartedManager.resumeAgentFromPersistence(
+        { provider: "codex", sessionId: "assistant-only-session", metadata: { cwd: workdir } },
+        undefined,
+        agentId,
+        { workspaceId: undefined },
+      );
+      await restartedManager.hydrateTimelineFromProvider(restarted.id);
+      expect(historyCalls).toBe(1);
+      await expect(restartedManager.getLastAssistantMessage(restarted.id)).resolves.toBe(
+        expectedMessage,
+      );
+      await expect(restartedManager.waitForAgentEvent(restarted.id)).resolves.toMatchObject({
+        lastMessage: expectedMessage,
+      });
+
+      await restartedManager.hydrateTimelineFromProvider(restarted.id, { force: true });
+      expect(historyCalls).toBe(2);
+      await expect(restartedManager.getLastAssistantMessage(restarted.id)).resolves.toBe(
+        expectedMessage,
+      );
+    } finally {
+      await restartedManager.closeAgent(agentId).catch(() => undefined);
+    }
+  } finally {
     await firstManager.closeAgent(agentId).catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });
   }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2668,15 +2668,8 @@ export class AgentManager {
   private getLastAssistantMessageFromTimeline(
     timeline: readonly AgentTimelineItem[],
   ): string | null {
-    return this.getLastAssistantMessageSegmentFromTimeline(timeline)?.text ?? null;
-  }
-
-  private getLastAssistantMessageSegmentFromTimeline(
-    timeline: readonly AgentTimelineItem[],
-  ): { text: string; startsAtBeginning: boolean } | null {
     // Collect the last contiguous assistant messages (Claude streams chunks)
     const chunks: string[] = [];
-    let startsAtBeginning = false;
     for (let i = timeline.length - 1; i >= 0; i--) {
       const item = timeline[i];
       if (item.type !== "assistant_message") {
@@ -2686,41 +2679,23 @@ export class AgentManager {
         continue;
       }
       chunks.push(item.text);
-      startsAtBeginning = i === 0;
     }
 
     if (!chunks.length) {
       return null;
     }
 
-    return {
-      text: chunks.toReversed().join(""),
-      startsAtBeginning,
-    };
+    return chunks.toReversed().join("");
   }
 
   private async getLastAssistantMessageFromStores(agentId: string): Promise<string | null> {
     const liveTimeline = this.timelineStore.getItems(agentId);
-    const liveSegment = this.getLastAssistantMessageSegmentFromTimeline(liveTimeline);
-    if (!this.durableTimelineStore) {
-      return liveSegment?.text ?? null;
+    const liveMessage = this.getLastAssistantMessageFromTimeline(liveTimeline);
+    if (liveMessage !== null || !this.durableTimelineStore) {
+      return liveMessage;
     }
 
-    if (!liveSegment) {
-      return await this.durableTimelineStore.getLastAssistantMessage(agentId);
-    }
-
-    if (!liveSegment.startsAtBeginning) {
-      return liveSegment.text;
-    }
-
-    const lastDurableItem = await this.durableTimelineStore.getLastItem(agentId);
-    if (lastDurableItem?.type !== "assistant_message") {
-      return liveSegment.text;
-    }
-
-    const durableMessage = await this.durableTimelineStore.getLastAssistantMessage(agentId);
-    return durableMessage ? `${durableMessage}${liveSegment.text}` : liveSegment.text;
+    return await this.durableTimelineStore.getLastAssistantMessage(agentId);
   }
 
   private async getLastItemFromStores(agentId: string): Promise<AgentTimelineItem | null> {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -310,6 +310,19 @@ type ActiveTurnTerminalDisposition = "closed_current" | "stale" | "untracked";
 
 interface HandleStreamEventOptions {
   fromHistory?: boolean;
+  historyHydrationToken?: symbol;
+}
+
+interface ActiveHistoryHydration {
+  token: symbol;
+  bufferedOperations: BufferedHistoryHydrationOperation[];
+}
+
+interface BufferedHistoryHydrationOperation {
+  kind: "session_event" | "timeline_writer";
+  run: () => Promise<void>;
+  resolve?: () => void;
+  reject?: (error: unknown) => void;
 }
 
 interface ManagedAgentBase {
@@ -609,6 +622,10 @@ export class AgentManager {
   private readonly providerSubagents = new ProviderSubagentStore();
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
   private readonly sessionEventTails = new Map<string, Promise<void>>();
+  private readonly historyHydrationTails = new Map<string, Promise<void>>();
+  private readonly activeHistoryHydrations = new Map<string, ActiveHistoryHydration>();
+  private readonly coalescerHistoryHydrationTokens = new Map<string, symbol>();
+  private readonly durableTimelineWriteTails = new Map<string, Promise<void>>();
   private readonly runs = new AgentRunState();
   private readonly subscribers = new Set<SubscriptionRecord>();
   private readonly idFactory: () => string;
@@ -652,8 +669,19 @@ export class AgentManager {
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
       onFlush: ({ agentId, item, provider, turnId }) => {
-        const event = this.recordAndDispatchTimelineItem(agentId, item, provider, turnId);
-        this.notifyForegroundTurnWaiters(agentId, event);
+        void this.runOrBufferTimelineWriter(
+          agentId,
+          async () => {
+            const event = this.recordAndDispatchTimelineItem(agentId, item, provider, turnId);
+            this.notifyForegroundTurnWaiters(agentId, event);
+          },
+          this.coalescerHistoryHydrationTokens.get(agentId),
+        ).catch((err) => {
+          this.logger.error(
+            { err, agentId, itemType: item.type },
+            "Failed to persist coalesced timeline item",
+          );
+        });
       },
     });
     this.updateProviderRegistry({
@@ -1928,19 +1956,31 @@ export class AgentManager {
       return false;
     }
     if (options?.clientMessageId) {
-      this.recordSubmittedPrompt(agent, prompt, options.clientMessageId);
+      void this.recordSubmittedPrompt(agent, prompt, options.clientMessageId).catch((err) => {
+        this.logger.error(
+          { err, agentId: agent.id, clientMessageId: options.clientMessageId },
+          "Failed to persist out-of-band submitted prompt",
+        );
+      });
       this.emitState(agent);
     }
     const dispatch = (event: AgentStreamEvent): void => {
       // Persist timeline items so they show up in fetchAgentTimeline; broadcast
       // for live subscribers. Other event types are broadcast only.
       if (event.type === "timeline") {
-        this.touchUpdatedAt(agent);
-        const row = this.recordTimeline(agent.id, event.item);
-        this.dispatchStream(agent.id, event, {
-          seq: row.seq,
-          epoch: this.timelineStore.getEpoch(agent.id),
-          timestamp: row.timestamp,
+        void this.runOrBufferTimelineWriter(agent.id, async () => {
+          this.touchUpdatedAt(agent);
+          const row = this.recordTimeline(agent.id, event.item);
+          this.dispatchStream(agent.id, event, {
+            seq: row.seq,
+            epoch: this.timelineStore.getEpoch(agent.id),
+            timestamp: row.timestamp,
+          });
+        }).catch((err) => {
+          this.logger.error(
+            { err, agentId: agent.id, itemType: event.item.type },
+            "Failed to persist out-of-band timeline item",
+          );
         });
         return;
       }
@@ -1964,22 +2004,24 @@ export class AgentManager {
   async appendTimelineItem(agentId: string, item: AgentTimelineItem): Promise<void> {
     const agent = this.requireAgent(agentId);
     item = limitAgentTimelineItemContent(item);
-    this.touchUpdatedAt(agent);
-    const row = this.recordTimeline(agentId, item);
-    this.dispatchStream(
-      agentId,
-      {
-        type: "timeline",
-        item,
-        provider: agent.provider,
-      },
-      {
-        seq: row.seq,
-        epoch: this.timelineStore.getEpoch(agentId),
-        timestamp: row.timestamp,
-      },
-    );
-    await this.persistSnapshot(agent);
+    await this.runOrBufferTimelineWriter(agentId, async () => {
+      this.touchUpdatedAt(agent);
+      const row = this.recordTimeline(agentId, item);
+      this.dispatchStream(
+        agentId,
+        {
+          type: "timeline",
+          item,
+          provider: agent.provider,
+        },
+        {
+          seq: row.seq,
+          epoch: this.timelineStore.getEpoch(agentId),
+          timestamp: row.timestamp,
+        },
+      );
+      await this.persistSnapshot(agent);
+    });
   }
 
   async emitLiveTimelineItem(agentId: string, item: AgentTimelineItem): Promise<void> {
@@ -2079,7 +2121,7 @@ export class AgentManager {
           )
         : undefined;
       if (options?.clientMessageId) {
-        this.recordSubmittedPrompt(agent, prompt, options.clientMessageId, {
+        await this.recordSubmittedPrompt(agent, prompt, options.clientMessageId, {
           messageId: options.clientMessageId,
           providerMessageId:
             stagedSubmittedPromptEcho?.item.type === "user_message"
@@ -2479,8 +2521,70 @@ export class AgentManager {
     agentId: string,
     options?: HydrateTimelineOptions,
   ): Promise<void> {
-    const agent = this.requireSessionAgent(agentId);
-    await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
+    this.requireSessionAgent(agentId);
+
+    // Install the gate synchronously with admission. A live event queued in the microtask between
+    // this call and the serialized history read must observe the gate, not commit into the
+    // timeline that the history replacement is about to supersede.
+    const hydrationToken = this.beginOrContinueHistoryHydration(agentId);
+    const previous = (this.historyHydrationTails.get(agentId) ?? Promise.resolve()).catch(
+      () => undefined,
+    );
+    let hydration!: Promise<void>;
+    const ownsLatestTail = () => this.historyHydrationTails.get(agentId) === hydration;
+    hydration = previous.then(() =>
+      this.runSerializedHistoryHydration(agentId, options, hydrationToken, ownsLatestTail),
+    );
+    this.historyHydrationTails.set(agentId, hydration);
+
+    let hydrationError: unknown;
+    let hydrationFailed = false;
+    try {
+      await hydration;
+    } catch (error) {
+      hydrationFailed = true;
+      hydrationError = error;
+    } finally {
+      // A caller that handed the shared gate to a queued successor must not return while live
+      // operations accepted during its call still wait behind that gate.
+      while (true) {
+        const latestHydration = this.historyHydrationTails.get(agentId);
+        if (!latestHydration || latestHydration === hydration) {
+          break;
+        }
+        await latestHydration.catch(() => undefined);
+        if (this.historyHydrationTails.get(agentId) === latestHydration) {
+          break;
+        }
+      }
+      if (this.historyHydrationTails.get(agentId) === hydration) {
+        this.historyHydrationTails.delete(agentId);
+      }
+    }
+
+    if (hydrationFailed) {
+      throw hydrationError;
+    }
+  }
+
+  private async runSerializedHistoryHydration(
+    agentId: string,
+    options: HydrateTimelineOptions | undefined,
+    hydrationToken: symbol,
+    ownsLatestTail: () => boolean,
+  ): Promise<void> {
+    try {
+      await this.drainSessionEvents(agentId);
+      // Preserve coalesced output admitted before or during the drain. The already-installed gate
+      // turns this flush into an ordered buffered writer that will replay after history commits.
+      this.agentStreamCoalescer.flushAndDiscard(agentId);
+      const agent = this.requireSessionAgent(agentId);
+      await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
+    } finally {
+      if (ownsLatestTail()) {
+        await this.releaseHistoryHydration(agentId, hydrationToken, ownsLatestTail);
+      }
+    }
   }
 
   async rewind(agentId: string, messageId: string, mode: RewindMode): Promise<void> {
@@ -3054,6 +3158,14 @@ export class AgentManager {
   }
 
   private enqueueSessionEvent(agentId: string, event: AgentStreamEvent): void {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (activeHydration) {
+      activeHydration.bufferedOperations.push({
+        kind: "session_event",
+        run: async () => this.processSessionEvent(agentId, event, activeHydration.token),
+      });
+      return;
+    }
     this.logger.trace(
       {
         agentId,
@@ -3072,27 +3184,7 @@ export class AgentManager {
     const previous = this.sessionEventTails.get(agentId) ?? Promise.resolve();
     const next = previous
       .catch(() => undefined)
-      .then(async () => {
-        const current = this.agents.get(agentId);
-        if (!current) {
-          return;
-        }
-        if (current.session == null) {
-          return;
-        }
-        this.logger.trace(
-          {
-            agentId,
-            provider: event.provider,
-            sessionId: current.persistence?.sessionId ?? undefined,
-            turnId: getAgentStreamEventTurnId(event),
-            event,
-          },
-          "agent.manager.dequeue",
-        );
-        await this.dispatchSessionEvent(current, event);
-        return;
-      })
+      .then(async () => this.processSessionEvent(agentId, event))
       .catch((err) => {
         this.logger.error(
           { err, agentId, eventType: event.type },
@@ -3107,6 +3199,28 @@ export class AgentManager {
         this.sessionEventTails.delete(agentId);
       }
     });
+  }
+
+  private async processSessionEvent(
+    agentId: string,
+    event: AgentStreamEvent,
+    historyHydrationToken?: symbol,
+  ): Promise<void> {
+    const current = this.agents.get(agentId);
+    if (!current || current.session == null) {
+      return;
+    }
+    this.logger.trace(
+      {
+        agentId,
+        provider: event.provider,
+        sessionId: current.persistence?.sessionId ?? undefined,
+        turnId: getAgentStreamEventTurnId(event),
+        event,
+      },
+      "agent.manager.dequeue",
+    );
+    await this.dispatchSessionEvent(current, event, historyHydrationToken);
   }
 
   /**
@@ -3130,6 +3244,7 @@ export class AgentManager {
   private async dispatchSessionEvent(
     agent: ActiveManagedAgent,
     event: AgentStreamEvent,
+    historyHydrationToken?: symbol,
   ): Promise<void> {
     if (event.type === "provider_subagent") {
       const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
@@ -3150,7 +3265,11 @@ export class AgentManager {
       "agent.manager.dispatch_session_event",
     );
 
-    const shouldNotifyWaiters = await this.handleStreamEvent(agent, event);
+    const shouldNotifyWaiters = await this.handleStreamEvent(
+      agent,
+      event,
+      historyHydrationToken ? { historyHydrationToken } : undefined,
+    );
 
     if (!shouldNotifyWaiters) {
       return;
@@ -3303,10 +3422,13 @@ export class AgentManager {
       }
     }
 
-    this.agentStreamCoalescer.flushAndDiscard(agent.id);
-    await this.deleteCommittedTimeline(agent.id);
-    this.timelineStore.delete(agent.id);
-    this.timelineStore.initialize(agent.id, { timestamp: new Date().toISOString() });
+    const historyRows = this.buildProviderHistoryRows(historyEvents, 1);
+    await this.replaceCommittedTimeline(agent.id, historyRows);
+    this.timelineStore.initialize(agent.id, {
+      rows: historyRows,
+      nextSeq: historyRows.length + 1,
+      timestamp: new Date().toISOString(),
+    });
     agent.historyPrimed = true;
 
     for (const event of this.providerSubagents.deleteParent(agent.id)) {
@@ -3320,12 +3442,9 @@ export class AgentManager {
         this.dispatch({ type: "provider_subagent", event: update });
       }
     }
-    for (const event of historyEvents) {
-      const row = this.recordTimeline(
-        agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
-      );
+    for (let index = 0; index < historyEvents.length; index += 1) {
+      const event = historyEvents[index];
+      const row = historyRows[index];
       if (broadcast) {
         this.dispatchStream(agent.id, event, {
           seq: row.seq,
@@ -3342,23 +3461,13 @@ export class AgentManager {
     agent: ActiveManagedAgent,
     broadcast: boolean | (() => boolean),
   ): Promise<void> {
-    const deferredBroadcast = typeof broadcast === "function";
-    const timelineEvents: Array<{
-      event: Extract<AgentStreamEvent, { type: "timeline" }>;
-      row: AgentTimelineRow;
-    }> = [];
-    const providerSubagentEvents: AgentManagerEvent[] = [];
+    const timelineEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
+    const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
     agent.historyPrimed = true;
     try {
       for await (const event of agent.session.streamHistory()) {
         if (event.type === "provider_subagent") {
-          const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-          const managerEvent: AgentManagerEvent = { type: "provider_subagent", event: update };
-          if (deferredBroadcast) {
-            providerSubagentEvents.push(managerEvent);
-          } else if (broadcast) {
-            this.dispatch(managerEvent);
-          }
+          providerSubagentEvents.push(event);
           continue;
         }
         if (event.type !== "timeline") {
@@ -3367,37 +3476,174 @@ export class AgentManager {
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
           continue;
         }
-        const row = this.recordTimeline(
-          agent.id,
-          event.item,
-          event.timestamp ? { timestamp: event.timestamp } : undefined,
-        );
-        if (deferredBroadcast) {
-          timelineEvents.push({ event, row });
-        } else if (broadcast) {
-          this.dispatchStream(agent.id, event, {
-            seq: row.seq,
-            epoch: this.timelineStore.getEpoch(agent.id),
-            timestamp: row.timestamp,
-          });
-        }
+        timelineEvents.push(event);
       }
     } catch {
+      agent.historyPrimed = false;
       // ignore history failures
-    }
-
-    if (typeof broadcast !== "function" || !broadcast()) {
       return;
     }
-    for (const event of providerSubagentEvents) {
-      this.dispatch(event);
+
+    const existingRows = this.timelineStore.getRows(agent.id);
+    const historyRows = this.buildProviderHistoryRows(
+      timelineEvents,
+      (existingRows.at(-1)?.seq ?? 0) + 1,
+    );
+    const replacementRows = [...existingRows, ...historyRows];
+    try {
+      await this.replaceCommittedTimeline(agent.id, replacementRows);
+    } catch (error) {
+      agent.historyPrimed = false;
+      throw error;
     }
-    for (const { event, row } of timelineEvents) {
-      this.dispatchStream(agent.id, event, {
-        seq: row.seq,
-        epoch: this.timelineStore.getEpoch(agent.id),
-        timestamp: row.timestamp,
+
+    const epoch = this.timelineStore.getEpoch(agent.id);
+    this.timelineStore.initialize(agent.id, {
+      epoch,
+      rows: replacementRows,
+      nextSeq: (replacementRows.at(-1)?.seq ?? 0) + 1,
+      timestamp: new Date().toISOString(),
+    });
+
+    const shouldBroadcast = typeof broadcast === "function" ? broadcast() : broadcast;
+    for (const event of providerSubagentEvents) {
+      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
+      if (shouldBroadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
+    for (let index = 0; index < timelineEvents.length; index += 1) {
+      const event = timelineEvents[index];
+      const row = historyRows[index];
+      if (shouldBroadcast) {
+        this.dispatchStream(agent.id, event, {
+          seq: row.seq,
+          epoch,
+          timestamp: row.timestamp,
+        });
+      }
+    }
+  }
+
+  private buildProviderHistoryRows(
+    events: readonly Extract<AgentStreamEvent, { type: "timeline" }>[],
+    startSeq: number,
+  ): AgentTimelineRow[] {
+    let nextSeq = startSeq;
+    return events.map((event) => {
+      const row: AgentTimelineRow = {
+        seq: nextSeq,
+        timestamp: event.timestamp ?? new Date().toISOString(),
+        item: limitAgentTimelineItemContent(event.item),
+      };
+      nextSeq += 1;
+      return row;
+    });
+  }
+
+  private beginOrContinueHistoryHydration(agentId: string): symbol {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (activeHydration) {
+      return activeHydration.token;
+    }
+    const token = Symbol(agentId);
+    this.activeHistoryHydrations.set(agentId, { token, bufferedOperations: [] });
+    return token;
+  }
+
+  private async releaseHistoryHydration(
+    agentId: string,
+    token: symbol,
+    stillOwnsTail: () => boolean,
+  ): Promise<void> {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (!activeHydration || activeHydration.token !== token) {
+      throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+    }
+
+    await this.drainSessionEvents(agentId);
+    while (true) {
+      const operation = activeHydration.bufferedOperations.shift();
+      if (operation) {
+        try {
+          if (operation.kind === "timeline_writer") {
+            this.flushCoalescedTimelineItems(agentId, token);
+          }
+          await operation.run();
+          operation.resolve?.();
+        } catch (err) {
+          operation.reject?.(err);
+          this.logger.error(
+            { err, agentId, operationKind: operation.kind },
+            "Failed to replay operation buffered during history hydration",
+          );
+        }
+        continue;
+      }
+
+      this.flushCoalescedTimelineItems(agentId, token);
+      if (activeHydration.bufferedOperations.length > 0) {
+        continue;
+      }
+      if (!stillOwnsTail()) {
+        return;
+      }
+      if (this.activeHistoryHydrations.get(agentId) !== activeHydration) {
+        throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+      }
+      this.activeHistoryHydrations.delete(agentId);
+      return;
+    }
+  }
+
+  private runOrBufferTimelineWriter(
+    agentId: string,
+    run: () => Promise<void> | void,
+    historyHydrationToken?: symbol,
+  ): Promise<void> {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (!activeHydration || activeHydration.token === historyHydrationToken) {
+      try {
+        return Promise.resolve(run());
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+
+    return new Promise<void>((promiseResolve, promiseReject) => {
+      activeHydration.bufferedOperations.push({
+        kind: "timeline_writer",
+        run: async () => run(),
+        resolve: promiseResolve,
+        reject: promiseReject,
       });
+    });
+  }
+
+  private flushCoalescedTimelineItems(agentId: string, historyHydrationToken?: symbol): void {
+    this.withCoalescerHistoryHydrationToken(agentId, historyHydrationToken, () => {
+      this.agentStreamCoalescer.flushFor(agentId);
+    });
+  }
+
+  private withCoalescerHistoryHydrationToken<T>(
+    agentId: string,
+    historyHydrationToken: symbol | undefined,
+    run: () => T,
+  ): T {
+    if (!historyHydrationToken) {
+      return run();
+    }
+    const previousToken = this.coalescerHistoryHydrationTokens.get(agentId);
+    this.coalescerHistoryHydrationTokens.set(agentId, historyHydrationToken);
+    try {
+      return run();
+    } finally {
+      if (previousToken) {
+        this.coalescerHistoryHydrationTokens.set(agentId, previousToken);
+      } else {
+        this.coalescerHistoryHydrationTokens.delete(agentId);
+      }
     }
   }
 
@@ -3447,11 +3693,16 @@ export class AgentManager {
     // Only update timestamp for live events, not history replay
     if (!options?.fromHistory) {
       this.touchUpdatedAt(agent);
-      if (this.agentStreamCoalescer.handle(agent.id, event)) {
+      const eventWasCoalesced = this.withCoalescerHistoryHydrationToken(
+        agent.id,
+        options?.historyHydrationToken,
+        () => this.agentStreamCoalescer.handle(agent.id, event),
+      );
+      if (eventWasCoalesced) {
         this.traceCoalescerBuffered(agent, event, eventTurnId);
         return false;
       }
-      this.agentStreamCoalescer.flushFor(agent.id);
+      this.flushCoalescedTimelineItems(agent.id, options?.historyHydrationToken);
     }
 
     let terminalDisposition: ActiveTurnTerminalDisposition = "untracked";
@@ -3666,7 +3917,7 @@ export class AgentManager {
   private async onStreamTimelineEvent(params: {
     agent: ActiveManagedAgent;
     event: Extract<AgentStreamEvent, { type: "timeline" }>;
-    options: { fromHistory?: boolean } | undefined;
+    options: HandleStreamEventOptions | undefined;
     flags: StreamEventFlags;
   }): Promise<void> {
     const { agent, event, options, flags } = params;
@@ -3688,17 +3939,29 @@ export class AgentManager {
     }
 
     if (options?.fromHistory) {
-      this.recordTimeline(
+      await this.runOrBufferTimelineWriter(
         agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
+        async () => {
+          this.recordTimeline(
+            agent.id,
+            event.item,
+            event.timestamp ? { timestamp: event.timestamp } : undefined,
+          );
+        },
+        options.historyHydrationToken,
       );
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;
     }
 
-    this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
+    await this.runOrBufferTimelineWriter(
+      agent.id,
+      async () => {
+        this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
+      },
+      options?.historyHydrationToken,
+    );
     if (event.item.type === "user_message") {
       agent.lastUserMessageAt = new Date();
       this.emitState(agent);
@@ -3752,7 +4015,7 @@ export class AgentManager {
     eventTurnId: string | undefined;
     isForegroundEvent: boolean;
     terminalDisposition: ActiveTurnTerminalDisposition;
-    options: { fromHistory?: boolean } | undefined;
+    options: HandleStreamEventOptions | undefined;
   }): Promise<void> {
     const { agent, event, eventTurnId, isForegroundEvent, terminalDisposition, options } = params;
     this.logger.warn(
@@ -3793,11 +4056,7 @@ export class AgentManager {
     eventTurnId: string | undefined;
     isForegroundEvent: boolean;
     terminalDisposition: ActiveTurnTerminalDisposition;
-    options:
-      | {
-          fromHistory?: boolean;
-        }
-      | undefined;
+    options: HandleStreamEventOptions | undefined;
   }): void {
     const { agent, event, eventTurnId, isForegroundEvent, terminalDisposition, options } = params;
     this.logger.trace(
@@ -3941,24 +4200,26 @@ export class AgentManager {
     return event;
   }
 
-  private recordSubmittedPrompt(
+  private async recordSubmittedPrompt(
     agent: ActiveManagedAgent,
     prompt: AgentPromptInput,
     clientMessageId: string,
     options?: { messageId?: string; providerMessageId?: string },
-  ): void {
-    if (this.timelineStore.getSubmittedUserMessage(agent.id, clientMessageId)) {
-      return;
-    }
-    this.touchUpdatedAt(agent);
-    agent.lastUserMessageAt = new Date();
-    const item: AgentTimelineItem = {
-      type: "user_message",
-      text: submittedPromptText(prompt),
-      clientMessageId,
-      ...(options?.messageId ? { messageId: options.messageId } : {}),
-    };
-    this.recordAndDispatchTimelineItem(agent.id, item, agent.provider, undefined, options);
+  ): Promise<void> {
+    await this.runOrBufferTimelineWriter(agent.id, async () => {
+      if (this.timelineStore.getSubmittedUserMessage(agent.id, clientMessageId)) {
+        return;
+      }
+      this.touchUpdatedAt(agent);
+      agent.lastUserMessageAt = new Date();
+      const item: AgentTimelineItem = {
+        type: "user_message",
+        text: submittedPromptText(prompt),
+        clientMessageId,
+        ...(options?.messageId ? { messageId: options.messageId } : {}),
+      };
+      this.recordAndDispatchTimelineItem(agent.id, item, agent.provider, undefined, options);
+    });
   }
 
   private reconcileSubmittedPromptEcho(
@@ -3984,7 +4245,7 @@ export class AgentManager {
     agent: ActiveManagedAgent,
     provider: AgentProvider,
     message: string,
-    options?: { fromHistory?: boolean },
+    options?: HandleStreamEventOptions,
   ): Promise<void> {
     if (options?.fromHistory) {
       return;
@@ -3995,26 +4256,32 @@ export class AgentManager {
       return;
     }
 
-    const text = `${SYSTEM_ERROR_PREFIX} ${normalized}`;
-    const lastItem = await this.getLastItemFromStores(agent.id);
-    if (lastItem?.type === "assistant_message" && lastItem.text === text) {
-      return;
-    }
-
-    const item: AgentTimelineItem = { type: "assistant_message", text };
-    const row = this.recordTimeline(agent.id, item);
-    this.dispatchStream(
+    await this.runOrBufferTimelineWriter(
       agent.id,
-      {
-        type: "timeline",
-        item,
-        provider,
+      async () => {
+        const text = `${SYSTEM_ERROR_PREFIX} ${normalized}`;
+        const lastItem = await this.getLastItemFromStores(agent.id);
+        if (lastItem?.type === "assistant_message" && lastItem.text === text) {
+          return;
+        }
+
+        const item: AgentTimelineItem = { type: "assistant_message", text };
+        const row = this.recordTimeline(agent.id, item);
+        this.dispatchStream(
+          agent.id,
+          {
+            type: "timeline",
+            item,
+            provider,
+          },
+          {
+            seq: row.seq,
+            epoch: this.timelineStore.getEpoch(agent.id),
+            timestamp: row.timestamp,
+          },
+        );
       },
-      {
-        seq: row.seq,
-        epoch: this.timelineStore.getEpoch(agent.id),
-        timestamp: row.timestamp,
-      },
+      options?.historyHydrationToken,
     );
   }
 
@@ -4128,11 +4395,13 @@ export class AgentManager {
   }
 
   private enqueueDurableTimelineAppend(agentId: string, row: AgentTimelineRow): void {
-    if (!this.durableTimelineStore) {
+    const store = this.durableTimelineStore;
+    if (!store) {
       return;
     }
-    const task = this.durableTimelineStore
-      .bulkInsert(agentId, [row])
+    const task = this.queueDurableTimelineWrite(agentId, async () => {
+      await store.bulkInsert(agentId, [row]);
+    })
       .then(() => undefined)
       .catch((err) => {
         this.logger.error(
@@ -4147,10 +4416,13 @@ export class AgentManager {
     agentId: string,
     rows: readonly AgentTimelineRow[],
   ): void {
-    if (!this.durableTimelineStore || rows.length === 0) {
+    const store = this.durableTimelineStore;
+    if (!store || rows.length === 0) {
       return;
     }
-    const task = this.durableTimelineStore.bulkInsert(agentId, rows).catch((err) => {
+    const task = this.queueDurableTimelineWrite(agentId, async () => {
+      await store.bulkInsert(agentId, rows);
+    }).catch((err) => {
       this.logger.error(
         { err, agentId, rowCount: rows.length },
         "Failed to seed durable timeline store",
@@ -4160,14 +4432,47 @@ export class AgentManager {
   }
 
   private enqueueDurableTimelineUpdate(agentId: string, row: AgentTimelineRow): void {
-    if (!this.durableTimelineStore) return;
-    const task = this.durableTimelineStore.updateCommittedRow(agentId, row).catch((err) => {
+    const store = this.durableTimelineStore;
+    if (!store) return;
+    const task = this.queueDurableTimelineWrite(agentId, async () => {
+      await store.updateCommittedRow(agentId, row);
+    }).catch((err) => {
       this.logger.error(
         { err, agentId, seq: row.seq, itemType: row.item.type },
         "Failed to enrich durable timeline row",
       );
     });
     this.trackBackgroundTask(task);
+  }
+
+  private async replaceCommittedTimeline(
+    agentId: string,
+    rows: readonly AgentTimelineRow[],
+  ): Promise<void> {
+    const store = this.durableTimelineStore;
+    if (!store) {
+      return;
+    }
+    await this.queueDurableTimelineWrite(agentId, async () => {
+      await store.replaceCommitted(agentId, rows);
+    });
+  }
+
+  private queueDurableTimelineWrite(agentId: string, write: () => Promise<void>): Promise<void> {
+    const previous = this.durableTimelineWriteTails.get(agentId) ?? Promise.resolve();
+    const operation = previous.catch(() => undefined).then(write);
+    const settled = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.durableTimelineWriteTails.set(agentId, settled);
+    void settled.then(() => {
+      if (this.durableTimelineWriteTails.get(agentId) === settled) {
+        this.durableTimelineWriteTails.delete(agentId);
+      }
+      return undefined;
+    });
+    return operation;
   }
 
   private trackBackgroundTask(task: Promise<void>): void {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -333,6 +333,7 @@ interface ActiveHistoryHydration {
     provider: AgentProvider;
     event: ProviderSubagentInputEvent;
   }>;
+  admissionTerminalProviderSubagents: ProviderSubagentDescriptor[];
 }
 
 interface BufferedHistoryHydrationOperation {
@@ -1986,7 +1987,11 @@ export class AgentManager {
       if (event.type === "timeline") {
         void this.runOrBufferTimelineWriter(agent.id, async () => {
           this.touchUpdatedAt(agent);
-          const row = this.recordTimeline(agent.id, event.item);
+          const row = this.recordTimeline(
+            agent.id,
+            event.item,
+            event.turnId ? { turnId: event.turnId } : undefined,
+          );
           this.dispatchStream(agent.id, event, {
             seq: row.seq,
             epoch: this.timelineStore.getEpoch(agent.id),
@@ -2022,13 +2027,15 @@ export class AgentManager {
     item = limitAgentTimelineItemContent(item);
     await this.runOrBufferTimelineWriter(agentId, async () => {
       this.touchUpdatedAt(agent);
-      const row = this.recordTimeline(agentId, item);
+      const turnId = agent.activeTurnId ?? undefined;
+      const row = this.recordTimeline(agentId, item, { turnId });
       this.dispatchStream(
         agentId,
         {
           type: "timeline",
           item,
           provider: agent.provider,
+          ...(turnId ? { turnId } : {}),
         },
         {
           seq: row.seq,
@@ -2143,6 +2150,7 @@ export class AgentManager {
             stagedSubmittedPromptEcho?.item.type === "user_message"
               ? stagedSubmittedPromptEcho.item.messageId
               : undefined,
+          turnId,
         });
       }
       for (const stagedEvent of pendingRun.stagedEvents.splice(0)) {
@@ -3459,34 +3467,30 @@ export class AgentManager {
       activeHydration,
       incomingProviderSubagentHistory,
     );
-    await this.replaceCommittedTimeline(agent.id, replacementRows);
+    const retainedTerminalProviderSubagentEvents =
+      this.getRetainedAdmissionTerminalProviderSubagentEvents(
+        activeHydration.admissionTerminalProviderSubagents,
+        incomingProviderSubagentHistory,
+      );
+    const epoch = await this.replaceCommittedTimeline(agent.id, replacementRows);
     this.timelineStore.initialize(agent.id, {
+      epoch,
       rows: replacementRows,
-      nextSeq: replacementRows.length + 1,
+      nextSeq: (replacementRows.at(-1)?.seq ?? 0) + 1,
       timestamp: new Date().toISOString(),
     });
     activeHydration.carriedLiveTimelineRows = carriedRows;
-    activeHydration.nextUncapturedTimelineSeq = replacementRows.length + 1;
+    activeHydration.nextUncapturedTimelineSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
     activeHydration.lastProviderHistoryItems = historyRows.map((row) => structuredClone(row.item));
     agent.historyPrimed = true;
 
-    for (const event of this.providerSubagents.deleteParent(agent.id)) {
-      if (broadcast) {
-        this.dispatch({ type: "provider_subagent", event });
-      }
-    }
-    for (const event of providerSubagentEvents) {
-      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-      if (broadcast) {
-        this.dispatch({ type: "provider_subagent", event: update });
-      }
-    }
-    for (const carried of carriedProviderSubagentEvents) {
-      const update = this.providerSubagents.apply(agent.id, carried.provider, carried.event);
-      if (broadcast) {
-        this.dispatch({ type: "provider_subagent", event: update });
-      }
-    }
+    this.replaceProviderSubagentHistory(
+      agent.id,
+      providerSubagentEvents,
+      retainedTerminalProviderSubagentEvents,
+      carriedProviderSubagentEvents,
+      broadcast,
+    );
     activeHydration.carriedProviderSubagentEvents = carriedProviderSubagentEvents;
     activeHydration.lastProviderSubagentHistory = incomingProviderSubagentHistory.map((event) =>
       structuredClone(event),
@@ -3506,7 +3510,12 @@ export class AgentManager {
       if (broadcast) {
         this.dispatchStream(
           agent.id,
-          { type: "timeline", provider: agent.provider, item: row.item },
+          {
+            type: "timeline",
+            provider: agent.provider,
+            item: row.item,
+            ...(row.turnId ? { turnId: row.turnId } : {}),
+          },
           {
             seq: row.seq,
             epoch: this.timelineStore.getEpoch(agent.id),
@@ -3517,6 +3526,38 @@ export class AgentManager {
     }
     this.touchUpdatedAt(agent);
     this.emitState(agent);
+  }
+
+  private replaceProviderSubagentHistory(
+    agentId: string,
+    historyEvents: readonly Extract<AgentStreamEvent, { type: "provider_subagent" }>[],
+    retainedEvents: readonly { provider: AgentProvider; event: ProviderSubagentInputEvent }[],
+    carriedEvents: readonly { provider: AgentProvider; event: ProviderSubagentInputEvent }[],
+    broadcast: boolean,
+  ): void {
+    for (const event of this.providerSubagents.deleteParent(agentId)) {
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event });
+      }
+    }
+    for (const event of historyEvents) {
+      const update = this.providerSubagents.apply(agentId, event.provider, event.event);
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
+    for (const retained of retainedEvents) {
+      const update = this.providerSubagents.apply(agentId, retained.provider, retained.event);
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
+    for (const carried of carriedEvents) {
+      const update = this.providerSubagents.apply(agentId, carried.provider, carried.event);
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
   }
 
   private async primeTimelineFromLegacyProviderHistory(
@@ -3554,19 +3595,18 @@ export class AgentManager {
     );
     const replacementRows = [...existingRows, ...historyRows];
     try {
-      await this.replaceCommittedTimeline(agent.id, replacementRows);
+      const replacementEpoch = await this.replaceCommittedTimeline(agent.id, replacementRows);
+      this.timelineStore.initialize(agent.id, {
+        epoch: replacementEpoch,
+        rows: replacementRows,
+        nextSeq: (replacementRows.at(-1)?.seq ?? 0) + 1,
+        timestamp: new Date().toISOString(),
+      });
     } catch (error) {
       agent.historyPrimed = false;
       throw error;
     }
-
     const epoch = this.timelineStore.getEpoch(agent.id);
-    this.timelineStore.initialize(agent.id, {
-      epoch,
-      rows: replacementRows,
-      nextSeq: (replacementRows.at(-1)?.seq ?? 0) + 1,
-      timestamp: new Date().toISOString(),
-    });
     activeHydration.nextUncapturedTimelineSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
 
     const shouldBroadcast = typeof broadcast === "function" ? broadcast() : broadcast;
@@ -3599,6 +3639,7 @@ export class AgentManager {
         seq: nextSeq,
         timestamp: event.timestamp ?? new Date().toISOString(),
         item: limitAgentTimelineItemContent(event.item),
+        ...(event.turnId ? { turnId: event.turnId } : {}),
       };
       nextSeq += 1;
       return row;
@@ -3619,39 +3660,65 @@ export class AgentManager {
       ...newlyAppliedRows.map((row) => structuredClone(row)),
     ];
 
-    const acknowledgedProviderMessages = new Map<string, string>();
+    const acknowledgedProviderMessages = new Map<
+      string,
+      { providerMessageId: string; turnId?: string }
+    >();
     for (const row of currentRows) {
       if (row.item.type === "user_message" && row.item.clientMessageId && row.providerMessageId) {
-        acknowledgedProviderMessages.set(row.item.clientMessageId, row.providerMessageId);
+        acknowledgedProviderMessages.set(row.item.clientMessageId, {
+          providerMessageId: row.providerMessageId,
+          ...(row.turnId ? { turnId: row.turnId } : {}),
+        });
       }
     }
     const historyRows = incomingHistoryRows.map((row) => {
       if (row.item.type !== "user_message" || !row.item.clientMessageId) {
         return row;
       }
-      const providerMessageId = acknowledgedProviderMessages.get(row.item.clientMessageId);
-      return providerMessageId ? { ...row, providerMessageId } : row;
+      const acknowledged = acknowledgedProviderMessages.get(row.item.clientMessageId);
+      if (!acknowledged) {
+        return row;
+      }
+      return {
+        ...row,
+        providerMessageId: acknowledged.providerMessageId,
+        ...(!row.turnId && acknowledged.turnId ? { turnId: acknowledged.turnId } : {}),
+      };
     });
 
     const priorHistoryItems = activeHydration.lastProviderHistoryItems;
-    const hasPriorHistoryPrefix =
-      priorHistoryItems.length <= historyRows.length &&
-      priorHistoryItems.every((item, index) => isDeepStrictEqual(item, historyRows[index]?.item));
-    let historySearchIndex = hasPriorHistoryPrefix ? priorHistoryItems.length : 0;
+    const reservedHistoryIndexes = new Set<number>();
+    for (const priorItem of priorHistoryItems) {
+      const matchingHistoryIndex = historyRows.findIndex(
+        (row, index) =>
+          !reservedHistoryIndexes.has(index) && isDeepStrictEqual(row.item, priorItem),
+      );
+      if (matchingHistoryIndex >= 0) {
+        reservedHistoryIndexes.add(matchingHistoryIndex);
+      }
+    }
+    let historySearchIndex = 0;
     const unmatchedCarriedRows: AgentTimelineRow[] = [];
     for (const carriedRow of candidateCarriedRows) {
       const matchingHistoryIndex = historyRows.findIndex(
-        (row, index) => index >= historySearchIndex && isDeepStrictEqual(row.item, carriedRow.item),
+        (row, index) =>
+          index >= historySearchIndex &&
+          !reservedHistoryIndexes.has(index) &&
+          isDeepStrictEqual(row.item, carriedRow.item),
       );
       if (matchingHistoryIndex < 0) {
         unmatchedCarriedRows.push(carriedRow);
         continue;
       }
       historySearchIndex = matchingHistoryIndex + 1;
-      if (carriedRow.providerMessageId) {
+      if (carriedRow.providerMessageId || carriedRow.turnId) {
         historyRows[matchingHistoryIndex] = {
           ...historyRows[matchingHistoryIndex],
-          providerMessageId: carriedRow.providerMessageId,
+          ...(carriedRow.providerMessageId
+            ? { providerMessageId: carriedRow.providerMessageId }
+            : {}),
+          ...(carriedRow.turnId ? { turnId: carriedRow.turnId } : {}),
         };
       }
     }
@@ -3691,6 +3758,45 @@ export class AgentManager {
     return unmatchedCarriedEvents;
   }
 
+  private getRetainedAdmissionTerminalProviderSubagentEvents(
+    admissionTerminalSubagents: readonly ProviderSubagentDescriptor[],
+    incomingHistory: readonly {
+      provider: AgentProvider;
+      event: ProviderSubagentInputEvent;
+    }[],
+  ): Array<{ provider: AgentProvider; event: ProviderSubagentInputEvent }> {
+    const projectedHistory = new ProviderSubagentStore();
+    for (const incoming of incomingHistory) {
+      projectedHistory.apply("history", incoming.provider, incoming.event);
+    }
+
+    const retainedEvents: Array<{
+      provider: AgentProvider;
+      event: ProviderSubagentInputEvent;
+    }> = [];
+    for (const retained of admissionTerminalSubagents) {
+      const incoming = projectedHistory.get("history", retained.id);
+      if (!incoming || retained.updatedAt <= incoming.updatedAt) {
+        continue;
+      }
+      retainedEvents.push({
+        provider: retained.provider,
+        event: {
+          type: "upsert",
+          id: retained.id,
+          title: retained.title,
+          description: retained.description,
+          status: retained.status,
+          toolCallId: retained.toolCallId,
+          cwd: retained.cwd,
+          subtitle: retained.subtitle,
+          timestamp: retained.updatedAt,
+        },
+      });
+    }
+    return retainedEvents;
+  }
+
   private beginOrContinueHistoryHydration(agentId: string): symbol {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (activeHydration) {
@@ -3710,6 +3816,10 @@ export class AgentManager {
       lastProviderHistoryItems: [],
       carriedProviderSubagentEvents: [],
       lastProviderSubagentHistory: [],
+      admissionTerminalProviderSubagents: this.providerSubagents
+        .list(agentId)
+        .filter((subagent) => subagent.status !== "running")
+        .map((subagent) => structuredClone(subagent)),
     });
     return token;
   }
@@ -4172,7 +4282,12 @@ export class AgentManager {
           this.recordTimeline(
             agent.id,
             event.item,
-            event.timestamp ? { timestamp: event.timestamp } : undefined,
+            event.timestamp || event.turnId
+              ? {
+                  ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+                  ...(event.turnId ? { turnId: event.turnId } : {}),
+                }
+              : undefined,
           );
         },
         options.historyHydrationToken,
@@ -4399,7 +4514,10 @@ export class AgentManager {
     turnId?: string,
     options?: { providerMessageId?: string },
   ): AgentStreamEvent {
-    const row = this.recordTimeline(agentId, item, options);
+    const row = this.recordTimeline(agentId, item, {
+      ...options,
+      ...(turnId ? { turnId } : {}),
+    });
     const event: AgentStreamEvent = {
       type: "timeline",
       item,
@@ -4431,7 +4549,7 @@ export class AgentManager {
     agent: ActiveManagedAgent,
     prompt: AgentPromptInput,
     clientMessageId: string,
-    options?: { messageId?: string; providerMessageId?: string },
+    options?: { messageId?: string; providerMessageId?: string; turnId?: string },
   ): Promise<void> {
     await this.runOrBufferTimelineWriter(agent.id, async () => {
       if (this.timelineStore.getSubmittedUserMessage(agent.id, clientMessageId)) {
@@ -4445,7 +4563,7 @@ export class AgentManager {
         clientMessageId,
         ...(options?.messageId ? { messageId: options.messageId } : {}),
       };
-      this.recordAndDispatchTimelineItem(agent.id, item, agent.provider, undefined, options);
+      this.recordAndDispatchTimelineItem(agent.id, item, agent.provider, options?.turnId, options);
     });
   }
 
@@ -4531,7 +4649,7 @@ export class AgentManager {
   private recordTimeline(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string; providerMessageId?: string },
+    options?: { timestamp?: string; providerMessageId?: string; turnId?: string },
   ): AgentTimelineRow {
     item = limitAgentTimelineItemContent(item);
     const row = this.timelineStore.append(agentId, item, options);
@@ -4675,17 +4793,18 @@ export class AgentManager {
   private async replaceCommittedTimeline(
     agentId: string,
     rows: readonly AgentTimelineRow[],
-  ): Promise<void> {
+  ): Promise<string> {
     const store = this.durableTimelineStore;
     if (!store) {
-      return;
+      return randomUUID();
     }
-    await this.queueDurableTimelineWrite(agentId, async () => {
-      await store.replaceCommitted(agentId, rows);
-    });
+    const result = await this.queueDurableTimelineWrite(agentId, async () =>
+      store.replaceCommitted(agentId, rows),
+    );
+    return result.epoch;
   }
 
-  private queueDurableTimelineWrite(agentId: string, write: () => Promise<void>): Promise<void> {
+  private queueDurableTimelineWrite<T>(agentId: string, write: () => Promise<T>): Promise<T> {
     const previous = this.durableTimelineWriteTails.get(agentId) ?? Promise.resolve();
     const operation = previous.catch(() => undefined).then(write);
     const settled = operation.then(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { stat } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 import {
   AGENT_LIFECYCLE_STATUSES,
   type AgentLifecycleStatus,
@@ -71,6 +72,7 @@ import type { PaseoToolCatalogFactory } from "./tools/types.js";
 import {
   ProviderSubagentStore,
   type ProviderSubagentDescriptor,
+  type ProviderSubagentInputEvent,
   type ProviderSubagentStoreEvent,
 } from "./provider-subagents/store.js";
 
@@ -320,11 +322,19 @@ interface ActiveHistoryHydration {
   preGateSessionEventTokens: Set<symbol>;
   preGateBufferedOperations: BufferedHistoryHydrationOperation[];
   bufferedOperations: BufferedHistoryHydrationOperation[];
+  nextUncapturedTimelineSeq: number;
+  carriedLiveTimelineRows: AgentTimelineRow[];
+  lastProviderHistoryItems: AgentTimelineItem[];
+  carriedProviderSubagentEvents: Array<{
+    provider: AgentProvider;
+    event: ProviderSubagentInputEvent;
+  }>;
 }
 
 interface BufferedHistoryHydrationOperation {
-  kind: "session_event" | "timeline_writer";
+  kind: "session_event" | "timeline_writer" | "provider_subagent";
   run: () => Promise<void>;
+  providerSubagentEvent?: { provider: AgentProvider; event: ProviderSubagentInputEvent };
   resolve?: () => void;
   reject?: (error: unknown) => void;
 }
@@ -1337,18 +1347,9 @@ export class AgentManager {
         await this.closeReloadedSession(existing.session, agentId);
       }
 
-      if (rehydrateFromDisk) {
-        // Wipe both durable and in-memory timeline so registerSession mints a
-        // new epoch and hydrateTimelineFromProvider re-streams the freshly read
-        // provider history into an empty timeline.
-        await this.deleteCommittedTimeline(agentId);
-        this.timelineStore.delete(agentId);
-        for (const event of this.providerSubagents.deleteParent(agentId)) {
-          this.dispatch({ type: "provider_subagent", event });
-        }
-      }
-
       // Preserve existing labels and timeline during reload.
+      // A disk refresh keeps the last complete timeline and child projection too;
+      // its caller force-hydrates after registration and swaps them only on success.
       handedToRegistration = true;
       return this.registerSession(session, storedConfig, agentId, {
         labels: existing.labels,
@@ -2590,7 +2591,11 @@ export class AgentManager {
       // turns this flush into an ordered buffered writer that will replay after history commits.
       this.flushPreGateCoalescedTimelineItems(agentId, hydrationToken);
       const agent = this.requireSessionAgent(agentId);
-      await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
+      const activeHydration = this.activeHistoryHydrations.get(agentId);
+      if (!activeHydration || activeHydration.token !== hydrationToken) {
+        throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+      }
+      await this.hydrateTimelineFromLegacyProviderHistory(agent, options, activeHydration);
     } finally {
       if (ownsLatestTail()) {
         await this.releaseHistoryHydration(agentId, hydrationToken, ownsLatestTail);
@@ -3249,8 +3254,18 @@ export class AgentManager {
     historyHydrationToken?: symbol,
   ): Promise<void> {
     if (event.type === "provider_subagent") {
-      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-      this.dispatch({ type: "provider_subagent", event: update });
+      await this.runOrBufferHistoryHydrationOperation(
+        agent.id,
+        {
+          kind: "provider_subagent",
+          providerSubagentEvent: { provider: event.provider, event: event.event },
+          run: async () => {
+            const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
+            this.dispatch({ type: "provider_subagent", event: update });
+          },
+        },
+        historyHydrationToken,
+      );
       return;
     }
     const turnId = getAgentStreamEventTurnId(event);
@@ -3388,7 +3403,8 @@ export class AgentManager {
 
   private async hydrateTimelineFromLegacyProviderHistory(
     agent: ActiveManagedAgent,
-    options?: HydrateTimelineOptions,
+    options: HydrateTimelineOptions | undefined,
+    activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
     if (agent.historyPrimed && !options?.force) {
       return;
@@ -3400,16 +3416,18 @@ export class AgentManager {
       await this.forceHydrateTimelineFromLegacyProviderHistory(
         agent,
         typeof broadcast === "function" ? broadcast() : broadcast,
+        activeHydration,
       );
       return;
     }
 
-    await this.primeTimelineFromLegacyProviderHistory(agent, broadcast);
+    await this.primeTimelineFromLegacyProviderHistory(agent, broadcast, activeHydration);
   }
 
   private async forceHydrateTimelineFromLegacyProviderHistory(
     agent: ActiveManagedAgent,
     broadcast: boolean,
+    activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
     const historyEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
     const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
@@ -3424,13 +3442,20 @@ export class AgentManager {
       }
     }
 
-    const historyRows = this.buildProviderHistoryRows(historyEvents, 1);
-    await this.replaceCommittedTimeline(agent.id, historyRows);
+    let historyRows = this.buildProviderHistoryRows(historyEvents, 1);
+    const merged = this.mergeCarriedLiveTimelineRows(agent.id, activeHydration, historyRows);
+    historyRows = merged.historyRows;
+    const carriedRows = merged.carriedRows;
+    const replacementRows = [...historyRows, ...carriedRows];
+    await this.replaceCommittedTimeline(agent.id, replacementRows);
     this.timelineStore.initialize(agent.id, {
-      rows: historyRows,
-      nextSeq: historyRows.length + 1,
+      rows: replacementRows,
+      nextSeq: replacementRows.length + 1,
       timestamp: new Date().toISOString(),
     });
+    activeHydration.carriedLiveTimelineRows = carriedRows;
+    activeHydration.nextUncapturedTimelineSeq = replacementRows.length + 1;
+    activeHydration.lastProviderHistoryItems = historyRows.map((row) => structuredClone(row.item));
     agent.historyPrimed = true;
 
     for (const event of this.providerSubagents.deleteParent(agent.id)) {
@@ -3440,6 +3465,12 @@ export class AgentManager {
     }
     for (const event of providerSubagentEvents) {
       const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
+    for (const carried of activeHydration.carriedProviderSubagentEvents) {
+      const update = this.providerSubagents.apply(agent.id, carried.provider, carried.event);
       if (broadcast) {
         this.dispatch({ type: "provider_subagent", event: update });
       }
@@ -3455,6 +3486,19 @@ export class AgentManager {
         });
       }
     }
+    for (const row of carriedRows) {
+      if (broadcast) {
+        this.dispatchStream(
+          agent.id,
+          { type: "timeline", provider: agent.provider, item: row.item },
+          {
+            seq: row.seq,
+            epoch: this.timelineStore.getEpoch(agent.id),
+            timestamp: row.timestamp,
+          },
+        );
+      }
+    }
     this.touchUpdatedAt(agent);
     this.emitState(agent);
   }
@@ -3462,6 +3506,7 @@ export class AgentManager {
   private async primeTimelineFromLegacyProviderHistory(
     agent: ActiveManagedAgent,
     broadcast: boolean | (() => boolean),
+    activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
     const timelineEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
     const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
@@ -3506,6 +3551,7 @@ export class AgentManager {
       nextSeq: (replacementRows.at(-1)?.seq ?? 0) + 1,
       timestamp: new Date().toISOString(),
     });
+    activeHydration.nextUncapturedTimelineSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
 
     const shouldBroadcast = typeof broadcast === "function" ? broadcast() : broadcast;
     for (const event of providerSubagentEvents) {
@@ -3543,11 +3589,72 @@ export class AgentManager {
     });
   }
 
+  private mergeCarriedLiveTimelineRows(
+    agentId: string,
+    activeHydration: ActiveHistoryHydration,
+    incomingHistoryRows: AgentTimelineRow[],
+  ): { historyRows: AgentTimelineRow[]; carriedRows: AgentTimelineRow[] } {
+    const currentRows = this.timelineStore.getRows(agentId);
+    const newlyAppliedRows = currentRows.filter(
+      (row) => row.seq >= activeHydration.nextUncapturedTimelineSeq,
+    );
+    const candidateCarriedRows = [
+      ...activeHydration.carriedLiveTimelineRows,
+      ...newlyAppliedRows.map((row) => structuredClone(row)),
+    ];
+
+    const acknowledgedProviderMessages = new Map<string, string>();
+    for (const row of currentRows) {
+      if (row.item.type === "user_message" && row.item.clientMessageId && row.providerMessageId) {
+        acknowledgedProviderMessages.set(row.item.clientMessageId, row.providerMessageId);
+      }
+    }
+    const historyRows = incomingHistoryRows.map((row) => {
+      if (row.item.type !== "user_message" || !row.item.clientMessageId) {
+        return row;
+      }
+      const providerMessageId = acknowledgedProviderMessages.get(row.item.clientMessageId);
+      return providerMessageId ? { ...row, providerMessageId } : row;
+    });
+
+    const priorHistoryItems = activeHydration.lastProviderHistoryItems;
+    const hasPriorHistoryPrefix =
+      priorHistoryItems.length <= historyRows.length &&
+      priorHistoryItems.every((item, index) => isDeepStrictEqual(item, historyRows[index]?.item));
+    let historySearchIndex = hasPriorHistoryPrefix ? priorHistoryItems.length : 0;
+    const unmatchedCarriedRows: AgentTimelineRow[] = [];
+    for (const carriedRow of candidateCarriedRows) {
+      const matchingHistoryIndex = historyRows.findIndex(
+        (row, index) => index >= historySearchIndex && isDeepStrictEqual(row.item, carriedRow.item),
+      );
+      if (matchingHistoryIndex < 0) {
+        unmatchedCarriedRows.push(carriedRow);
+        continue;
+      }
+      historySearchIndex = matchingHistoryIndex + 1;
+      if (carriedRow.providerMessageId) {
+        historyRows[matchingHistoryIndex] = {
+          ...historyRows[matchingHistoryIndex],
+          providerMessageId: carriedRow.providerMessageId,
+        };
+      }
+    }
+    let nextSeq = historyRows.length + 1;
+    const carriedRows: AgentTimelineRow[] = [];
+    for (const row of unmatchedCarriedRows) {
+      const carriedRow = structuredClone(row);
+      carriedRow.seq = nextSeq++;
+      carriedRows.push(carriedRow);
+    }
+    return { historyRows, carriedRows };
+  }
+
   private beginOrContinueHistoryHydration(agentId: string): symbol {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (activeHydration) {
       return activeHydration.token;
     }
+    const currentRows = this.timelineStore.getRows(agentId);
     const token = Symbol(agentId);
     this.activeHistoryHydrations.set(agentId, {
       token,
@@ -3556,6 +3663,10 @@ export class AgentManager {
       preGateSessionEventTokens: new Set(this.sessionEventAdmissionTokens.get(agentId) ?? []),
       preGateBufferedOperations: [],
       bufferedOperations: [],
+      nextUncapturedTimelineSeq: (currentRows.at(-1)?.seq ?? 0) + 1,
+      carriedLiveTimelineRows: [],
+      lastProviderHistoryItems: [],
+      carriedProviderSubagentEvents: [],
     });
     return token;
   }
@@ -3572,6 +3683,12 @@ export class AgentManager {
 
     await this.drainSessionEvents(agentId);
     while (true) {
+      // A successor owns every operation that remains queued. Do not consume
+      // even one of its writes; it will release the shared gate after its
+      // provider-history replacement has committed.
+      if (!stillOwnsTail()) {
+        return;
+      }
       const operation =
         activeHydration.preGateBufferedOperations.shift() ??
         activeHydration.bufferedOperations.shift();
@@ -3581,6 +3698,11 @@ export class AgentManager {
             this.flushCoalescedTimelineItems(agentId, token);
           }
           await operation.run();
+          if (operation.providerSubagentEvent) {
+            activeHydration.carriedProviderSubagentEvents.push(
+              structuredClone(operation.providerSubagentEvent),
+            );
+          }
           operation.resolve?.();
         } catch (err) {
           operation.reject?.(err);
@@ -3599,9 +3721,6 @@ export class AgentManager {
       ) {
         continue;
       }
-      if (!stillOwnsTail()) {
-        return;
-      }
       if (this.activeHistoryHydrations.get(agentId) !== activeHydration) {
         throw new Error(`Agent ${agentId} history hydration ownership was lost`);
       }
@@ -3615,13 +3734,36 @@ export class AgentManager {
     run: () => Promise<void> | void,
     historyHydrationToken?: symbol,
   ): Promise<void> {
+    return this.runOrBufferHistoryHydrationOperation(
+      agentId,
+      { kind: "timeline_writer", run: async () => run() },
+      historyHydrationToken,
+    );
+  }
+
+  private runOrBufferHistoryHydrationOperation(
+    agentId: string,
+    operation: BufferedHistoryHydrationOperation,
+    historyHydrationToken?: symbol,
+  ): Promise<void> {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (!activeHydration || activeHydration.token === historyHydrationToken) {
+      let result: Promise<void>;
       try {
-        return Promise.resolve(run());
+        result = Promise.resolve(operation.run());
       } catch (error) {
         return Promise.reject(error);
       }
+      const providerSubagentEvent = operation.providerSubagentEvent;
+      if (activeHydration && providerSubagentEvent) {
+        return result.then(() => {
+          activeHydration.carriedProviderSubagentEvents.push(
+            structuredClone(providerSubagentEvent),
+          );
+          return undefined;
+        });
+      }
+      return result;
     }
 
     if (
@@ -3629,17 +3771,13 @@ export class AgentManager {
       (historyHydrationToken !== undefined &&
         activeHydration.preGateSessionEventTokens.has(historyHydrationToken))
     ) {
-      activeHydration.preGateBufferedOperations.push({
-        kind: "timeline_writer",
-        run: async () => run(),
-      });
+      activeHydration.preGateBufferedOperations.push(operation);
       return Promise.resolve();
     }
 
     return new Promise<void>((promiseResolve, promiseReject) => {
       activeHydration.bufferedOperations.push({
-        kind: "timeline_writer",
-        run: async () => run(),
+        ...operation,
         resolve: promiseResolve,
         reject: promiseReject,
       });
@@ -3966,11 +4104,19 @@ export class AgentManager {
       return;
     }
 
-    if (
+    const isSubmittedPromptEcho =
       event.item.type === "user_message" &&
       event.item.clientMessageId &&
-      this.reconcileSubmittedPromptEcho(agent, event.item)
-    ) {
+      this.timelineStore.getSubmittedUserMessage(agent.id, event.item.clientMessageId) !== null;
+    if (isSubmittedPromptEcho && event.item.type === "user_message") {
+      const submittedPromptEcho = event.item;
+      await this.runOrBufferTimelineWriter(
+        agent.id,
+        async () => {
+          this.reconcileSubmittedPromptEcho(agent, submittedPromptEcho);
+        },
+        options?.historyHydrationToken,
+      );
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -78,6 +78,8 @@ import {
 
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
+const HISTORY_HYDRATION_TIMEOUT_MS = 3_000;
+const HISTORY_HYDRATION_MAX_BUFFERED_OPERATIONS = 1_000;
 const STORED_AGENT_CAPABILITIES: AgentCapabilityFlags = {
   supportsStreaming: false,
   supportsSessionPersistence: true,
@@ -115,6 +117,34 @@ export class AgentRunCancellationError extends Error {
       `Cannot ${action} agent ${agentId} because its active run cancellation was not acknowledged`,
     );
     this.name = "AgentRunCancellationError";
+  }
+}
+
+export type AgentHistoryHydrationFailureReason =
+  | "timed_out"
+  | "buffer_limit_exceeded"
+  | "cancelled";
+
+function getHistoryHydrationErrorMessage(
+  agentId: string,
+  reason: AgentHistoryHydrationFailureReason,
+): string {
+  if (reason === "timed_out") {
+    return `Provider history hydration timed out for agent ${agentId}`;
+  }
+  if (reason === "buffer_limit_exceeded") {
+    return `Provider history hydration buffered operation limit was exceeded for agent ${agentId}`;
+  }
+  return `Provider history hydration was cancelled for agent ${agentId}`;
+}
+
+export class AgentHistoryHydrationError extends Error {
+  constructor(
+    public readonly agentId: string,
+    public readonly reason: AgentHistoryHydrationFailureReason,
+  ) {
+    super(getHistoryHydrationErrorMessage(agentId, reason));
+    this.name = "AgentHistoryHydrationError";
   }
 }
 
@@ -230,6 +260,25 @@ export interface ProviderAvailability {
 interface AgentManagerRescueTimeouts {
   reloadSessionCloseMs?: number;
   interruptSessionMs?: number;
+  historyHydrationMs?: number;
+}
+
+function resolveAgentManagerRescueTimeouts(
+  options: AgentManagerOptions,
+): Required<AgentManagerRescueTimeouts> {
+  return {
+    reloadSessionCloseMs:
+      options.rescueTimeouts?.reloadSessionCloseMs ?? RELOAD_SESSION_CLOSE_TIMEOUT_MS,
+    interruptSessionMs: options.rescueTimeouts?.interruptSessionMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
+    historyHydrationMs: options.rescueTimeouts?.historyHydrationMs ?? HISTORY_HYDRATION_TIMEOUT_MS,
+  };
+}
+
+function resolveHistoryHydrationMaxBufferedOperations(options: AgentManagerOptions): number {
+  return Math.max(
+    1,
+    options.historyHydrationMaxBufferedOperations ?? HISTORY_HYDRATION_MAX_BUFFERED_OPERATIONS,
+  );
 }
 
 interface ProviderEnabledFlag {
@@ -265,6 +314,7 @@ export interface AgentManagerOptions {
   paseoToolCatalogFactory?: PaseoToolCatalogFactory;
   appendSystemPrompt?: string;
   agentStreamCoalesceWindowMs?: number;
+  historyHydrationMaxBufferedOperations?: number;
   rescueTimeouts?: AgentManagerRescueTimeouts;
   logger: Logger;
 }
@@ -317,6 +367,13 @@ interface HandleStreamEventOptions {
 
 interface ActiveHistoryHydration {
   token: symbol;
+  abortController: AbortController;
+  cancellationError: AgentHistoryHydrationError | null;
+  discardBufferedOperations: boolean;
+  historyIterator: AsyncGenerator<AgentStreamEvent> | null;
+  historyIteratorReturnRequested: boolean;
+  releasePromise: Promise<void>;
+  resolveRelease: () => void;
   preGateCoalescerToken: symbol;
   preGateCoalescerOpen: boolean;
   preGateSessionEventTokens: Set<symbol>;
@@ -342,6 +399,11 @@ interface BufferedHistoryHydrationOperation {
   providerSubagentEvent?: { provider: AgentProvider; event: ProviderSubagentInputEvent };
   resolve?: () => void;
   reject?: (error: unknown) => void;
+}
+
+interface ProviderHistoryEvents {
+  timeline: Extract<AgentStreamEvent, { type: "timeline" }>[];
+  providerSubagents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[];
 }
 
 interface ManagedAgentBase {
@@ -666,6 +728,7 @@ export class AgentManager {
   private onWorkspaceStateMayHaveChanged?: (params: { cwd: string }) => void;
   private logger: Logger;
   private readonly rescueTimeouts: Required<AgentManagerRescueTimeouts>;
+  private readonly historyHydrationMaxBufferedOperations: number;
   private acceptingAgentRegistrations = true;
 
   constructor(options: AgentManagerOptions) {
@@ -679,12 +742,9 @@ export class AgentManager {
     this.configurePaseoTools(options);
     this.appendSystemPrompt = options.appendSystemPrompt ?? "";
     this.logger = options.logger.child({ module: "agent", component: "agent-manager" });
-    this.rescueTimeouts = {
-      reloadSessionCloseMs:
-        options.rescueTimeouts?.reloadSessionCloseMs ?? RELOAD_SESSION_CLOSE_TIMEOUT_MS,
-      interruptSessionMs:
-        options.rescueTimeouts?.interruptSessionMs ?? INTERRUPT_SESSION_TIMEOUT_MS,
-    };
+    this.rescueTimeouts = resolveAgentManagerRescueTimeouts(options);
+    this.historyHydrationMaxBufferedOperations =
+      resolveHistoryHydrationMaxBufferedOperations(options);
     this.agentStreamCoalescer = new AgentStreamCoalescer({
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
@@ -762,6 +822,11 @@ export class AgentManager {
 
   prepareForShutdown(): void {
     this.acceptingAgentRegistrations = false;
+    for (const agentId of this.activeHistoryHydrations.keys()) {
+      this.cancelHistoryHydration(agentId, new AgentHistoryHydrationError(agentId, "cancelled"), {
+        discardBufferedOperations: true,
+      });
+    }
   }
 
   setPaseoToolsEnabled(enabled: boolean): void {
@@ -1345,6 +1410,7 @@ export class AgentManager {
     try {
       this.assertAcceptingAgentRegistrations();
 
+      await this.cancelAndWaitForHistoryHydration(agentId);
       const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
       try {
         await this.persistSnapshot(closedExisting);
@@ -1460,6 +1526,7 @@ export class AgentManager {
       },
       "agent.manager.close.start",
     );
+    await this.cancelAndWaitForHistoryHydration(agentId);
     await this.drainSessionEvents(agentId);
     this.cancelRunningProviderSubagents(agentId);
     const closedAgent = this.prepareAgentForClosure(agent, "agent closed");
@@ -2597,6 +2664,7 @@ export class AgentManager {
     hydrationToken: symbol,
     ownsLatestTail: () => boolean,
   ): Promise<void> {
+    let timeout: NodeJS.Timeout | null = null;
     try {
       await this.drainSessionEvents(agentId);
       // Preserve coalesced output admitted before or during the drain. The already-installed gate
@@ -2605,10 +2673,22 @@ export class AgentManager {
       const agent = this.requireSessionAgent(agentId);
       const activeHydration = this.activeHistoryHydrations.get(agentId);
       if (!activeHydration || activeHydration.token !== hydrationToken) {
-        throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+        throw new AgentHistoryHydrationError(agentId, "cancelled");
       }
+      timeout = setTimeout(() => {
+        this.cancelHistoryHydration(agentId, new AgentHistoryHydrationError(agentId, "timed_out"));
+      }, this.rescueTimeouts.historyHydrationMs);
       await this.hydrateTimelineFromLegacyProviderHistory(agent, options, activeHydration);
+      if (activeHydration.cancellationError) {
+        agent.historyPrimed = false;
+        if (options?.force) {
+          throw activeHydration.cancellationError;
+        }
+      }
     } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       if (ownsLatestTail()) {
         await this.releaseHistoryHydration(agentId, hydrationToken, ownsLatestTail);
       }
@@ -2669,6 +2749,7 @@ export class AgentManager {
   }
 
   async deleteAgentState(agentId: string): Promise<void> {
+    await this.cancelAndWaitForHistoryHydration(agentId);
     this.discardRetainedAgentState(agentId);
     await this.deleteCommittedTimeline(agentId);
   }
@@ -3166,9 +3247,17 @@ export class AgentManager {
   private enqueueSessionEvent(agentId: string, event: AgentStreamEvent): void {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (activeHydration) {
-      activeHydration.bufferedOperations.push({
+      void this.runOrBufferHistoryHydrationOperation(agentId, {
         kind: "session_event",
         run: async () => this.processSessionEvent(agentId, event, activeHydration.token),
+      }).catch((err) => {
+        if (err instanceof AgentHistoryHydrationError && err.reason === "cancelled") {
+          return;
+        }
+        this.logger.error(
+          { err, agentId, eventType: event.type },
+          "Failed to process session event",
+        );
       });
       return;
     }
@@ -3441,18 +3530,9 @@ export class AgentManager {
     broadcast: boolean,
     activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
-    const historyEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
-    const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
-    for await (const event of agent.session.streamHistory()) {
-      if (event.type === "timeline") {
-        if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
-          continue;
-        }
-        historyEvents.push(event);
-      } else if (event.type === "provider_subagent") {
-        providerSubagentEvents.push(event);
-      }
-    }
+    const history = await this.collectProviderHistoryEvents(agent, activeHydration);
+    const historyEvents = history.timeline;
+    const providerSubagentEvents = history.providerSubagents;
 
     let historyRows = this.buildProviderHistoryRows(historyEvents, 1);
     const merged = this.mergeCarriedLiveTimelineRows(agent.id, activeHydration, historyRows);
@@ -3565,28 +3645,17 @@ export class AgentManager {
     broadcast: boolean | (() => boolean),
     activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
-    const timelineEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
-    const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
     agent.historyPrimed = true;
+    let history: ProviderHistoryEvents;
     try {
-      for await (const event of agent.session.streamHistory()) {
-        if (event.type === "provider_subagent") {
-          providerSubagentEvents.push(event);
-          continue;
-        }
-        if (event.type !== "timeline") {
-          continue;
-        }
-        if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
-          continue;
-        }
-        timelineEvents.push(event);
-      }
+      history = await this.collectProviderHistoryEvents(agent, activeHydration);
     } catch {
       agent.historyPrimed = false;
       // ignore history failures
       return;
     }
+    const timelineEvents = history.timeline;
+    const providerSubagentEvents = history.providerSubagents;
 
     const existingRows = this.timelineStore.getRows(agent.id);
     const historyRows = this.buildProviderHistoryRows(
@@ -3626,6 +3695,81 @@ export class AgentManager {
           timestamp: row.timestamp,
         });
       }
+    }
+  }
+
+  private async collectProviderHistoryEvents(
+    agent: ActiveManagedAgent,
+    activeHydration: ActiveHistoryHydration,
+  ): Promise<ProviderHistoryEvents> {
+    this.throwIfHistoryHydrationCancelled(activeHydration);
+    const iterator = agent.session.streamHistory();
+    activeHydration.historyIterator = iterator;
+    activeHydration.historyIteratorReturnRequested = false;
+    const timeline: ProviderHistoryEvents["timeline"] = [];
+    const providerSubagents: ProviderHistoryEvents["providerSubagents"] = [];
+
+    try {
+      while (true) {
+        const result = await this.nextProviderHistoryEvent(agent.id, activeHydration, iterator);
+        if (result.done) {
+          return { timeline, providerSubagents };
+        }
+        const event = result.value;
+        if (event.type === "provider_subagent") {
+          providerSubagents.push(event);
+          continue;
+        }
+        if (event.type !== "timeline") {
+          continue;
+        }
+        if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+          continue;
+        }
+        timeline.push(event);
+      }
+    } catch (error) {
+      this.requestHistoryIteratorReturn(agent.id, activeHydration, iterator);
+      throw error;
+    } finally {
+      if (activeHydration.historyIterator === iterator) {
+        activeHydration.historyIterator = null;
+      }
+    }
+  }
+
+  private async nextProviderHistoryEvent(
+    agentId: string,
+    activeHydration: ActiveHistoryHydration,
+    iterator: AsyncGenerator<AgentStreamEvent>,
+  ): Promise<IteratorResult<AgentStreamEvent>> {
+    this.throwIfHistoryHydrationCancelled(activeHydration);
+    const signal = activeHydration.abortController.signal;
+    let onAbort: (() => void) | null = null;
+    const cancelled = new Promise<never>((_resolve, reject) => {
+      onAbort = () => {
+        reject(
+          activeHydration.cancellationError ?? new AgentHistoryHydrationError(agentId, "cancelled"),
+        );
+      };
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    });
+    try {
+      return await Promise.race([iterator.next(), cancelled]);
+    } finally {
+      if (onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    }
+  }
+
+  private throwIfHistoryHydrationCancelled(activeHydration: ActiveHistoryHydration): void {
+    if (activeHydration.cancellationError) {
+      throw activeHydration.cancellationError;
     }
   }
 
@@ -3804,8 +3948,19 @@ export class AgentManager {
     }
     const currentRows = this.timelineStore.getRows(agentId);
     const token = Symbol(agentId);
+    let resolveRelease!: () => void;
+    const releasePromise = new Promise<void>((resolvePromise) => {
+      resolveRelease = resolvePromise;
+    });
     this.activeHistoryHydrations.set(agentId, {
       token,
+      abortController: new AbortController(),
+      cancellationError: null,
+      discardBufferedOperations: false,
+      historyIterator: null,
+      historyIteratorReturnRequested: false,
+      releasePromise,
+      resolveRelease,
       preGateCoalescerToken: Symbol(`${agentId}:pre-gate-coalescer`),
       preGateCoalescerOpen: true,
       preGateSessionEventTokens: new Set(this.sessionEventAdmissionTokens.get(agentId) ?? []),
@@ -3831,15 +3986,23 @@ export class AgentManager {
   ): Promise<void> {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (!activeHydration || activeHydration.token !== token) {
-      throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+      return;
     }
 
-    await this.drainSessionEvents(agentId);
+    if (!activeHydration.cancellationError) {
+      await this.drainSessionEvents(agentId);
+    }
     while (true) {
+      if (activeHydration.discardBufferedOperations) {
+        this.rejectBufferedHistoryHydrationOperations(agentId, activeHydration);
+        this.finishHistoryHydration(agentId, activeHydration);
+        await this.drainSessionEvents(agentId);
+        return;
+      }
       // A successor owns every operation that remains queued. Do not consume
       // even one of its writes; it will release the shared gate after its
       // provider-history replacement has committed.
-      if (!stillOwnsTail()) {
+      if (!activeHydration.cancellationError && !stillOwnsTail()) {
         return;
       }
       const operation =
@@ -3875,10 +4038,98 @@ export class AgentManager {
         continue;
       }
       if (this.activeHistoryHydrations.get(agentId) !== activeHydration) {
-        throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+        return;
       }
-      this.activeHistoryHydrations.delete(agentId);
+      this.finishHistoryHydration(agentId, activeHydration);
+      await this.drainSessionEvents(agentId);
       return;
+    }
+  }
+
+  private finishHistoryHydration(agentId: string, activeHydration: ActiveHistoryHydration): void {
+    if (this.activeHistoryHydrations.get(agentId) === activeHydration) {
+      this.activeHistoryHydrations.delete(agentId);
+    }
+    this.coalescerHistoryHydrationTokens.delete(agentId);
+    activeHydration.resolveRelease();
+  }
+
+  private cancelHistoryHydration(
+    agentId: string,
+    error: AgentHistoryHydrationError,
+    options?: { discardBufferedOperations?: boolean },
+  ): ActiveHistoryHydration | null {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (!activeHydration) {
+      return null;
+    }
+    if (!activeHydration.cancellationError) {
+      activeHydration.cancellationError = error;
+      activeHydration.abortController.abort(error);
+    }
+    if (options?.discardBufferedOperations) {
+      activeHydration.discardBufferedOperations = true;
+      this.rejectBufferedHistoryHydrationOperations(agentId, activeHydration);
+    }
+    const iterator = activeHydration.historyIterator;
+    if (iterator) {
+      this.requestHistoryIteratorReturn(agentId, activeHydration, iterator);
+    }
+    return activeHydration;
+  }
+
+  private async cancelAndWaitForHistoryHydration(agentId: string): Promise<void> {
+    const tail = this.historyHydrationTails.get(agentId);
+    const activeHydration = this.cancelHistoryHydration(
+      agentId,
+      new AgentHistoryHydrationError(agentId, "cancelled"),
+      { discardBufferedOperations: true },
+    );
+    if (tail) {
+      await tail.catch(() => undefined);
+    }
+    if (activeHydration && this.activeHistoryHydrations.get(agentId) === activeHydration) {
+      this.finishHistoryHydration(agentId, activeHydration);
+    }
+    if (tail && this.historyHydrationTails.get(agentId) === tail) {
+      this.historyHydrationTails.delete(agentId);
+    }
+  }
+
+  private rejectBufferedHistoryHydrationOperations(
+    agentId: string,
+    activeHydration: ActiveHistoryHydration,
+  ): void {
+    const error =
+      activeHydration.cancellationError ?? new AgentHistoryHydrationError(agentId, "cancelled");
+    for (const operation of [
+      ...activeHydration.preGateBufferedOperations,
+      ...activeHydration.bufferedOperations,
+    ]) {
+      operation.reject?.(error);
+    }
+    activeHydration.preGateBufferedOperations.length = 0;
+    activeHydration.bufferedOperations.length = 0;
+  }
+
+  private requestHistoryIteratorReturn(
+    agentId: string,
+    activeHydration: ActiveHistoryHydration,
+    iterator: AsyncGenerator<AgentStreamEvent>,
+  ): void {
+    if (
+      activeHydration.historyIterator !== iterator ||
+      activeHydration.historyIteratorReturnRequested
+    ) {
+      return;
+    }
+    activeHydration.historyIteratorReturnRequested = true;
+    try {
+      void iterator.return(undefined).catch((error) => {
+        this.logger.warn({ err: error, agentId }, "Provider history iterator cleanup failed");
+      });
+    } catch (error) {
+      this.logger.warn({ err: error, agentId }, "Provider history iterator cleanup failed");
     }
   }
 
@@ -3900,32 +4151,35 @@ export class AgentManager {
     historyHydrationToken?: symbol,
   ): Promise<void> {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
-    if (!activeHydration || activeHydration.token === historyHydrationToken) {
-      let result: Promise<void>;
-      try {
-        result = Promise.resolve(operation.run());
-      } catch (error) {
-        return Promise.reject(error);
-      }
-      const providerSubagentEvent = operation.providerSubagentEvent;
-      if (activeHydration && providerSubagentEvent) {
-        return result.then(() => {
-          activeHydration.carriedProviderSubagentEvents.push(
-            structuredClone(providerSubagentEvent),
-          );
-          return undefined;
-        });
-      }
-      return result;
+    if (!activeHydration) {
+      return this.runHistoryHydrationOperation(operation);
     }
 
-    if (
+    if (activeHydration.discardBufferedOperations) {
+      return Promise.reject(
+        activeHydration.cancellationError ?? new AgentHistoryHydrationError(agentId, "cancelled"),
+      );
+    }
+
+    if (activeHydration.token === historyHydrationToken) {
+      return this.runHistoryHydrationOperation(operation, activeHydration);
+    }
+
+    const isPreGateOperation =
       historyHydrationToken === activeHydration.preGateCoalescerToken ||
       (historyHydrationToken !== undefined &&
-        activeHydration.preGateSessionEventTokens.has(historyHydrationToken))
-    ) {
+        activeHydration.preGateSessionEventTokens.has(historyHydrationToken));
+    if (isPreGateOperation) {
+      if (activeHydration.cancellationError) {
+        return this.runHistoryHydrationOperation(operation);
+      }
       activeHydration.preGateBufferedOperations.push(operation);
+      this.cancelHistoryHydrationAtBufferLimit(agentId, activeHydration);
       return Promise.resolve();
+    }
+
+    if (activeHydration.cancellationError) {
+      return this.queueOperationAfterHistoryHydrationRelease(agentId, activeHydration, operation);
     }
 
     return new Promise<void>((promiseResolve, promiseReject) => {
@@ -3934,7 +4188,76 @@ export class AgentManager {
         resolve: promiseResolve,
         reject: promiseReject,
       });
+      this.cancelHistoryHydrationAtBufferLimit(agentId, activeHydration);
     });
+  }
+
+  private runHistoryHydrationOperation(
+    operation: BufferedHistoryHydrationOperation,
+    activeHydration?: ActiveHistoryHydration,
+  ): Promise<void> {
+    let result: Promise<void>;
+    try {
+      result = Promise.resolve(operation.run());
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    const providerSubagentEvent = operation.providerSubagentEvent;
+    if (!activeHydration || !providerSubagentEvent) {
+      return result;
+    }
+    return result.then(() => {
+      activeHydration.carriedProviderSubagentEvents.push(structuredClone(providerSubagentEvent));
+      return undefined;
+    });
+  }
+
+  private cancelHistoryHydrationAtBufferLimit(
+    agentId: string,
+    activeHydration: ActiveHistoryHydration,
+  ): void {
+    const bufferedOperationCount =
+      activeHydration.preGateBufferedOperations.length + activeHydration.bufferedOperations.length;
+    if (bufferedOperationCount < this.historyHydrationMaxBufferedOperations) {
+      return;
+    }
+    this.cancelHistoryHydration(
+      agentId,
+      new AgentHistoryHydrationError(agentId, "buffer_limit_exceeded"),
+    );
+  }
+
+  private queueOperationAfterHistoryHydrationRelease(
+    agentId: string,
+    activeHydration: ActiveHistoryHydration,
+    operation: BufferedHistoryHydrationOperation,
+  ): Promise<void> {
+    const previous = this.sessionEventTails.get(agentId) ?? Promise.resolve();
+    const result = previous
+      .catch(() => undefined)
+      .then(async () => {
+        await activeHydration.releasePromise;
+        if (activeHydration.discardBufferedOperations) {
+          throw (
+            activeHydration.cancellationError ??
+            new AgentHistoryHydrationError(agentId, "cancelled")
+          );
+        }
+        return await operation.run();
+      });
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.sessionEventTails.set(agentId, settled);
+    this.trackBackgroundTask(settled);
+    void settled.then(() => {
+      if (this.sessionEventTails.get(agentId) === settled) {
+        this.sessionEventTails.delete(agentId);
+      }
+      return undefined;
+    });
+    return result;
   }
 
   private flushCoalescedTimelineItems(agentId: string, historyHydrationToken?: symbol): void {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3703,7 +3703,9 @@ export class AgentManager {
     activeHydration: ActiveHistoryHydration,
   ): Promise<ProviderHistoryEvents> {
     this.throwIfHistoryHydrationCancelled(activeHydration);
-    const iterator = agent.session.streamHistory();
+    const iterator = agent.session.streamHistory({
+      signal: activeHydration.abortController.signal,
+    });
     activeHydration.historyIterator = iterator;
     activeHydration.historyIteratorReturnRequested = false;
     const timeline: ProviderHistoryEvents["timeline"] = [];

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -315,6 +315,10 @@ interface HandleStreamEventOptions {
 
 interface ActiveHistoryHydration {
   token: symbol;
+  preGateCoalescerToken: symbol;
+  preGateCoalescerOpen: boolean;
+  preGateSessionEventTokens: Set<symbol>;
+  preGateBufferedOperations: BufferedHistoryHydrationOperation[];
   bufferedOperations: BufferedHistoryHydrationOperation[];
 }
 
@@ -622,6 +626,7 @@ export class AgentManager {
   private readonly providerSubagents = new ProviderSubagentStore();
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
   private readonly sessionEventTails = new Map<string, Promise<void>>();
+  private readonly sessionEventAdmissionTokens = new Map<string, Set<symbol>>();
   private readonly historyHydrationTails = new Map<string, Promise<void>>();
   private readonly activeHistoryHydrations = new Map<string, ActiveHistoryHydration>();
   private readonly coalescerHistoryHydrationTokens = new Map<string, symbol>();
@@ -669,13 +674,19 @@ export class AgentManager {
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
       onFlush: ({ agentId, item, provider, turnId }) => {
+        const activeHydration = this.activeHistoryHydrations.get(agentId);
+        const historyHydrationToken =
+          this.coalescerHistoryHydrationTokens.get(agentId) ??
+          (activeHydration?.preGateCoalescerOpen
+            ? activeHydration.preGateCoalescerToken
+            : undefined);
         void this.runOrBufferTimelineWriter(
           agentId,
           async () => {
             const event = this.recordAndDispatchTimelineItem(agentId, item, provider, turnId);
             this.notifyForegroundTurnWaiters(agentId, event);
           },
-          this.coalescerHistoryHydrationTokens.get(agentId),
+          historyHydrationToken,
         ).catch((err) => {
           this.logger.error(
             { err, agentId, itemType: item.type },
@@ -2577,7 +2588,7 @@ export class AgentManager {
       await this.drainSessionEvents(agentId);
       // Preserve coalesced output admitted before or during the drain. The already-installed gate
       // turns this flush into an ordered buffered writer that will replay after history commits.
-      this.agentStreamCoalescer.flushAndDiscard(agentId);
+      this.flushPreGateCoalescedTimelineItems(agentId, hydrationToken);
       const agent = this.requireSessionAgent(agentId);
       await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
     } finally {
@@ -3095,8 +3106,11 @@ export class AgentManager {
       return { timestamp: now.toISOString() };
     }
 
+    const committed = await this.durableTimelineStore.fetchCommitted(agentId, { limit: 0 });
     return {
-      nextSeq: (await this.durableTimelineStore.getLatestCommittedSeq(agentId)) + 1,
+      epoch: committed.epoch,
+      rows: committed.rows,
+      nextSeq: committed.window.nextSeq,
       timestamp: now.toISOString(),
     };
   }
@@ -3181,15 +3195,28 @@ export class AgentManager {
       pendingRun.stagedEvents.push(event);
       return;
     }
+    const admissionToken = Symbol(agentId);
+    let admissionTokens = this.sessionEventAdmissionTokens.get(agentId);
+    if (!admissionTokens) {
+      admissionTokens = new Set();
+      this.sessionEventAdmissionTokens.set(agentId, admissionTokens);
+    }
+    admissionTokens.add(admissionToken);
     const previous = this.sessionEventTails.get(agentId) ?? Promise.resolve();
     const next = previous
       .catch(() => undefined)
-      .then(async () => this.processSessionEvent(agentId, event))
+      .then(async () => this.processSessionEvent(agentId, event, admissionToken))
       .catch((err) => {
         this.logger.error(
           { err, agentId, eventType: event.type },
           "Failed to process session event",
         );
+      })
+      .finally(() => {
+        admissionTokens.delete(admissionToken);
+        if (admissionTokens.size === 0) {
+          this.sessionEventAdmissionTokens.delete(agentId);
+        }
       });
 
     this.sessionEventTails.set(agentId, next);
@@ -3547,7 +3574,14 @@ export class AgentManager {
       return activeHydration.token;
     }
     const token = Symbol(agentId);
-    this.activeHistoryHydrations.set(agentId, { token, bufferedOperations: [] });
+    this.activeHistoryHydrations.set(agentId, {
+      token,
+      preGateCoalescerToken: Symbol(`${agentId}:pre-gate-coalescer`),
+      preGateCoalescerOpen: true,
+      preGateSessionEventTokens: new Set(this.sessionEventAdmissionTokens.get(agentId) ?? []),
+      preGateBufferedOperations: [],
+      bufferedOperations: [],
+    });
     return token;
   }
 
@@ -3563,7 +3597,9 @@ export class AgentManager {
 
     await this.drainSessionEvents(agentId);
     while (true) {
-      const operation = activeHydration.bufferedOperations.shift();
+      const operation =
+        activeHydration.preGateBufferedOperations.shift() ??
+        activeHydration.bufferedOperations.shift();
       if (operation) {
         try {
           if (operation.kind === "timeline_writer") {
@@ -3582,7 +3618,10 @@ export class AgentManager {
       }
 
       this.flushCoalescedTimelineItems(agentId, token);
-      if (activeHydration.bufferedOperations.length > 0) {
+      if (
+        activeHydration.preGateBufferedOperations.length > 0 ||
+        activeHydration.bufferedOperations.length > 0
+      ) {
         continue;
       }
       if (!stillOwnsTail()) {
@@ -3610,6 +3649,18 @@ export class AgentManager {
       }
     }
 
+    if (
+      historyHydrationToken === activeHydration.preGateCoalescerToken ||
+      (historyHydrationToken !== undefined &&
+        activeHydration.preGateSessionEventTokens.has(historyHydrationToken))
+    ) {
+      activeHydration.preGateBufferedOperations.push({
+        kind: "timeline_writer",
+        run: async () => run(),
+      });
+      return Promise.resolve();
+    }
+
     return new Promise<void>((promiseResolve, promiseReject) => {
       activeHydration.bufferedOperations.push({
         kind: "timeline_writer",
@@ -3624,6 +3675,18 @@ export class AgentManager {
     this.withCoalescerHistoryHydrationToken(agentId, historyHydrationToken, () => {
       this.agentStreamCoalescer.flushFor(agentId);
     });
+  }
+
+  private flushPreGateCoalescedTimelineItems(agentId: string, hydrationToken: symbol): void {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (!activeHydration || activeHydration.token !== hydrationToken) {
+      throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+    }
+    try {
+      this.agentStreamCoalescer.flushAndDiscard(agentId);
+    } finally {
+      activeHydration.preGateCoalescerOpen = false;
+    }
   }
 
   private withCoalescerHistoryHydrationToken<T>(

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -329,6 +329,10 @@ interface ActiveHistoryHydration {
     provider: AgentProvider;
     event: ProviderSubagentInputEvent;
   }>;
+  lastProviderSubagentHistory: Array<{
+    provider: AgentProvider;
+    event: ProviderSubagentInputEvent;
+  }>;
 }
 
 interface BufferedHistoryHydrationOperation {
@@ -3447,6 +3451,14 @@ export class AgentManager {
     historyRows = merged.historyRows;
     const carriedRows = merged.carriedRows;
     const replacementRows = [...historyRows, ...carriedRows];
+    const incomingProviderSubagentHistory = providerSubagentEvents.map((event) => ({
+      provider: event.provider,
+      event: event.event,
+    }));
+    const carriedProviderSubagentEvents = this.mergeCarriedProviderSubagentEvents(
+      activeHydration,
+      incomingProviderSubagentHistory,
+    );
     await this.replaceCommittedTimeline(agent.id, replacementRows);
     this.timelineStore.initialize(agent.id, {
       rows: replacementRows,
@@ -3469,12 +3481,16 @@ export class AgentManager {
         this.dispatch({ type: "provider_subagent", event: update });
       }
     }
-    for (const carried of activeHydration.carriedProviderSubagentEvents) {
+    for (const carried of carriedProviderSubagentEvents) {
       const update = this.providerSubagents.apply(agent.id, carried.provider, carried.event);
       if (broadcast) {
         this.dispatch({ type: "provider_subagent", event: update });
       }
     }
+    activeHydration.carriedProviderSubagentEvents = carriedProviderSubagentEvents;
+    activeHydration.lastProviderSubagentHistory = incomingProviderSubagentHistory.map((event) =>
+      structuredClone(event),
+    );
     for (let index = 0; index < historyEvents.length; index += 1) {
       const event = historyEvents[index];
       const row = historyRows[index];
@@ -3649,6 +3665,32 @@ export class AgentManager {
     return { historyRows, carriedRows };
   }
 
+  private mergeCarriedProviderSubagentEvents(
+    activeHydration: ActiveHistoryHydration,
+    incomingHistory: Array<{
+      provider: AgentProvider;
+      event: ProviderSubagentInputEvent;
+    }>,
+  ): Array<{ provider: AgentProvider; event: ProviderSubagentInputEvent }> {
+    const priorHistory = activeHydration.lastProviderSubagentHistory;
+    const hasPriorHistoryPrefix =
+      priorHistory.length <= incomingHistory.length &&
+      priorHistory.every((event, index) => isDeepStrictEqual(event, incomingHistory[index]));
+    let historySearchIndex = hasPriorHistoryPrefix ? priorHistory.length : 0;
+    const unmatchedCarriedEvents = [];
+    for (const carriedEvent of activeHydration.carriedProviderSubagentEvents) {
+      const matchingHistoryIndex = incomingHistory.findIndex(
+        (event, index) => index >= historySearchIndex && isDeepStrictEqual(event, carriedEvent),
+      );
+      if (matchingHistoryIndex < 0) {
+        unmatchedCarriedEvents.push(structuredClone(carriedEvent));
+        continue;
+      }
+      historySearchIndex = matchingHistoryIndex + 1;
+    }
+    return unmatchedCarriedEvents;
+  }
+
   private beginOrContinueHistoryHydration(agentId: string): symbol {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (activeHydration) {
@@ -3667,6 +3709,7 @@ export class AgentManager {
       carriedLiveTimelineRows: [],
       lastProviderHistoryItems: [],
       carriedProviderSubagentEvents: [],
+      lastProviderSubagentHistory: [],
     });
     return token;
   }

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -616,6 +616,10 @@ export interface AgentPermissionResult {
   followUpPrompt?: AgentPromptInput;
 }
 
+export interface AgentHistoryStreamOptions {
+  signal?: AbortSignal;
+}
+
 export interface AgentSession {
   readonly provider: AgentProvider;
   readonly id: string | null;
@@ -624,7 +628,7 @@ export interface AgentSession {
   run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult>;
   startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<{ turnId: string }>;
   subscribe(callback: (event: AgentStreamEvent) => void): () => void;
-  streamHistory(): AsyncGenerator<AgentStreamEvent>;
+  streamHistory(options?: AgentHistoryStreamOptions): AsyncGenerator<AgentStreamEvent>;
   getRuntimeInfo(): Promise<AgentRuntimeInfo>;
   getAvailableModes(): Promise<AgentMode[]>;
   getCurrentMode(): Promise<string | null>;

--- a/packages/server/src/server/agent/agent-timeline-store-types.ts
+++ b/packages/server/src/server/agent/agent-timeline-store-types.ts
@@ -58,6 +58,8 @@ export interface AgentTimelineStore {
   getLastItem(agentId: string): Promise<AgentTimelineItem | null>;
   getLastAssistantMessage(agentId: string): Promise<string | null>;
   deleteAgent(agentId: string): Promise<void>;
+  /** Atomically replaces the complete committed timeline for one agent. */
+  replaceCommitted(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void>;
   bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void>;
   updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void>;
 }

--- a/packages/server/src/server/agent/agent-timeline-store-types.ts
+++ b/packages/server/src/server/agent/agent-timeline-store-types.ts
@@ -5,6 +5,12 @@ export interface AgentTimelineRow {
   timestamp: string;
   item: AgentTimelineItem;
   readonly providerMessageId?: string;
+  /** Provider turn that produced this row, when known. */
+  readonly turnId?: string;
+}
+
+export interface AgentTimelineReplacementResult {
+  epoch: string;
 }
 
 export interface AgentTimelineCursor {
@@ -47,7 +53,7 @@ export interface AgentTimelineStore {
   appendCommitted(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): Promise<AgentTimelineRow>;
   fetchCommitted(
     agentId: string,
@@ -59,7 +65,10 @@ export interface AgentTimelineStore {
   getLastAssistantMessage(agentId: string): Promise<string | null>;
   deleteAgent(agentId: string): Promise<void>;
   /** Atomically replaces the complete committed timeline for one agent. */
-  replaceCommitted(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void>;
+  replaceCommitted(
+    agentId: string,
+    rows: readonly AgentTimelineRow[],
+  ): Promise<AgentTimelineReplacementResult>;
   bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void>;
   updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void>;
 }

--- a/packages/server/src/server/agent/agent-timeline-store.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.ts
@@ -264,7 +264,7 @@ export class InMemoryAgentTimelineStore {
   append(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string; providerMessageId?: string },
+    options?: { timestamp?: string; providerMessageId?: string; turnId?: string },
   ): AgentTimelineRow {
     const state = this.requireState(agentId);
     const row: AgentTimelineRow = {
@@ -272,6 +272,7 @@ export class InMemoryAgentTimelineStore {
       timestamp: options?.timestamp ?? new Date().toISOString(),
       item,
       ...(options?.providerMessageId ? { providerMessageId: options.providerMessageId } : {}),
+      ...(options?.turnId ? { turnId: options.turnId } : {}),
     };
     state.nextSeq += 1;
     state.rows.push(row);

--- a/packages/server/src/server/agent/file-agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { writeJsonFileAtomic } from "../atomic-file.js";
+import { FileAgentTimelineStore } from "./file-agent-timeline-store.js";
+import type { AgentTimelineRow } from "./agent-timeline-store-types.js";
+
+const logger = createTestLogger();
+const temporaryDirectories: string[] = [];
+
+async function createStoreDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "file-agent-timeline-store-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("FileAgentTimelineStore", () => {
+  it("keeps the prior complete timeline after a failed replacement and exposes one replacement after restart", async () => {
+    const directory = await createStoreDirectory();
+    const agentId = "agent-with-atomic-history";
+    let rejectWrites = false;
+    const store = new FileAgentTimelineStore(directory, logger, {
+      epochFactory: () => "replacement-epoch",
+      writeJson: async (filePath, value) => {
+        if (rejectWrites) {
+          throw new Error("injected pre-rename failure");
+        }
+        await writeJsonFileAtomic(filePath, value);
+      },
+    });
+    const priorRows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        item: { type: "user_message", text: "prior complete timeline" },
+      },
+    ];
+    const replacementRows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-02-01T00:00:00.000Z",
+        item: { type: "user_message", text: "replacement row one" },
+      },
+      {
+        seq: 2,
+        timestamp: "2026-02-01T00:00:01.000Z",
+        item: { type: "assistant_message", text: "replacement row two" },
+      },
+    ];
+
+    await store.bulkInsert(agentId, priorRows);
+    rejectWrites = true;
+    await expect(store.replaceCommitted(agentId, replacementRows)).rejects.toThrow(
+      "injected pre-rename failure",
+    );
+
+    const restartedAfterFailure = new FileAgentTimelineStore(directory, logger);
+    await expect(restartedAfterFailure.getCommittedRows(agentId)).resolves.toEqual(priorRows);
+
+    rejectWrites = false;
+    await store.replaceCommitted(agentId, replacementRows);
+
+    const restartedAfterSuccess = new FileAgentTimelineStore(directory, logger);
+    await expect(restartedAfterSuccess.getCommittedRows(agentId)).resolves.toEqual(replacementRows);
+    await expect(
+      restartedAfterSuccess.fetchCommitted(agentId, { limit: 0 }),
+    ).resolves.toMatchObject({
+      epoch: "replacement-epoch",
+      reset: false,
+      staleCursor: false,
+      gap: false,
+      window: { minSeq: 1, maxSeq: 2, nextSeq: 3 },
+      rows: replacementRows,
+    });
+  });
+});

--- a/packages/server/src/server/agent/file-agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.test.ts
@@ -70,7 +70,9 @@ describe("FileAgentTimelineStore", () => {
     await expect(restartedAfterFailure.getCommittedRows(agentId)).resolves.toEqual(priorRows);
 
     rejectWrites = false;
-    await store.replaceCommitted(agentId, replacementRows);
+    await expect(store.replaceCommitted(agentId, replacementRows)).resolves.toEqual({
+      epoch: "replacement-epoch",
+    });
 
     const restartedAfterSuccess = new FileAgentTimelineStore(directory, logger);
     await expect(restartedAfterSuccess.getCommittedRows(agentId)).resolves.toEqual(replacementRows);

--- a/packages/server/src/server/agent/file-agent-timeline-store.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.ts
@@ -10,6 +10,7 @@ import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
 import type {
   AgentTimelineFetchOptions,
   AgentTimelineFetchResult,
+  AgentTimelineReplacementResult,
   AgentTimelineRow,
   AgentTimelineStore,
 } from "./agent-timeline-store-types.js";
@@ -97,13 +98,14 @@ export class FileAgentTimelineStore implements AgentTimelineStore {
   async appendCommitted(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): Promise<AgentTimelineRow> {
     return await this.queueMutation(agentId, (current) => {
       const row: AgentTimelineRow = {
         seq: (current.rows.at(-1)?.seq ?? 0) + 1,
         timestamp: options?.timestamp ?? new Date().toISOString(),
         item: structuredClone(item),
+        ...(options?.turnId ? { turnId: options.turnId } : {}),
       };
       return {
         next: { ...current, rows: [...current.rows, row] },
@@ -172,12 +174,18 @@ export class FileAgentTimelineStore implements AgentTimelineStore {
     });
   }
 
-  async replaceCommitted(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
+  async replaceCommitted(
+    agentId: string,
+    rows: readonly AgentTimelineRow[],
+  ): Promise<AgentTimelineReplacementResult> {
     const replacement = normalizeRows(rows);
-    await this.queueMutation(agentId, () => ({
-      next: { version: 1, epoch: this.epochFactory(), rows: replacement },
-      result: undefined,
-    }));
+    return await this.queueMutation(agentId, () => {
+      const epoch = this.epochFactory();
+      return {
+        next: { version: 1, epoch, rows: replacement },
+        result: { epoch },
+      };
+    });
   }
 
   async bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {

--- a/packages/server/src/server/agent/file-agent-timeline-store.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.ts
@@ -1,0 +1,284 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import type { Logger } from "pino";
+
+import { writeJsonFileAtomic } from "../atomic-file.js";
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
+import type {
+  AgentTimelineFetchOptions,
+  AgentTimelineFetchResult,
+  AgentTimelineRow,
+  AgentTimelineStore,
+} from "./agent-timeline-store-types.js";
+
+interface PersistedAgentTimeline {
+  version: 1;
+  epoch: string;
+  rows: AgentTimelineRow[];
+}
+
+export interface FileAgentTimelineStoreOptions {
+  epochFactory?: () => string;
+  writeJson?: (filePath: string, value: unknown) => Promise<void>;
+}
+
+function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
+  return structuredClone(row);
+}
+
+function normalizeRows(rows: readonly AgentTimelineRow[]): AgentTimelineRow[] {
+  const normalized = rows.map(cloneRow).sort((left, right) => left.seq - right.seq);
+  let previousSeq = 0;
+  for (const row of normalized) {
+    if (!Number.isSafeInteger(row.seq) || row.seq <= 0 || row.seq === previousSeq) {
+      throw new Error(`Invalid or duplicate timeline sequence ${row.seq}`);
+    }
+    if (typeof row.timestamp !== "string" || row.timestamp.length === 0) {
+      throw new Error(`Timeline row ${row.seq} has no timestamp`);
+    }
+    if (
+      typeof row.item !== "object" ||
+      row.item === null ||
+      typeof (row.item as { type?: unknown }).type !== "string"
+    ) {
+      throw new Error(`Timeline row ${row.seq} has an invalid item`);
+    }
+    previousSeq = row.seq;
+  }
+  return normalized;
+}
+
+function parsePersistedTimeline(value: unknown): PersistedAgentTimeline {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Timeline file must contain an object");
+  }
+  const candidate = value as { version?: unknown; epoch?: unknown; rows?: unknown };
+  if (candidate.version !== 1) {
+    throw new Error("Unsupported timeline file version");
+  }
+  if (typeof candidate.epoch !== "string" || candidate.epoch.length === 0) {
+    throw new Error("Timeline file has no epoch");
+  }
+  if (!Array.isArray(candidate.rows)) {
+    throw new Error("Timeline file has no rows array");
+  }
+  return {
+    version: 1,
+    epoch: candidate.epoch,
+    rows: normalizeRows(candidate.rows as AgentTimelineRow[]),
+  };
+}
+
+/**
+ * Production timeline persistence. Each agent has one JSON document so a complete history
+ * replacement becomes visible with one atomic rename rather than a delete-then-insert window.
+ */
+export class FileAgentTimelineStore implements AgentTimelineStore {
+  private readonly states = new Map<string, PersistedAgentTimeline>();
+  private readonly loadPromises = new Map<string, Promise<PersistedAgentTimeline>>();
+  private readonly operationTails = new Map<string, Promise<void>>();
+  private readonly logger: Logger;
+  private readonly epochFactory: () => string;
+  private readonly writeJson: (filePath: string, value: unknown) => Promise<void>;
+
+  constructor(
+    private readonly baseDir: string,
+    logger: Logger,
+    options?: FileAgentTimelineStoreOptions,
+  ) {
+    this.logger = logger.child({ module: "agent", component: "file-agent-timeline-store" });
+    this.epochFactory = options?.epochFactory ?? randomUUID;
+    this.writeJson = options?.writeJson ?? writeJsonFileAtomic;
+  }
+
+  async appendCommitted(
+    agentId: string,
+    item: AgentTimelineItem,
+    options?: { timestamp?: string },
+  ): Promise<AgentTimelineRow> {
+    return await this.queueMutation(agentId, (current) => {
+      const row: AgentTimelineRow = {
+        seq: (current.rows.at(-1)?.seq ?? 0) + 1,
+        timestamp: options?.timestamp ?? new Date().toISOString(),
+        item: structuredClone(item),
+      };
+      return {
+        next: { ...current, rows: [...current.rows, row] },
+        result: cloneRow(row),
+      };
+    });
+  }
+
+  async fetchCommitted(
+    agentId: string,
+    options?: AgentTimelineFetchOptions,
+  ): Promise<AgentTimelineFetchResult> {
+    const state = await this.readState(agentId);
+    const store = new InMemoryAgentTimelineStore();
+    store.initialize(agentId, {
+      epoch: state.epoch,
+      rows: state.rows,
+      nextSeq: (state.rows.at(-1)?.seq ?? 0) + 1,
+    });
+    return store.fetch(agentId, options);
+  }
+
+  async getLatestCommittedSeq(agentId: string): Promise<number> {
+    const state = await this.readState(agentId);
+    return state.rows.at(-1)?.seq ?? 0;
+  }
+
+  async getCommittedRows(agentId: string): Promise<AgentTimelineRow[]> {
+    const state = await this.readState(agentId);
+    return state.rows.map(cloneRow);
+  }
+
+  async getLastItem(agentId: string): Promise<AgentTimelineItem | null> {
+    const state = await this.readState(agentId);
+    const item = state.rows.at(-1)?.item;
+    return item ? structuredClone(item) : null;
+  }
+
+  async getLastAssistantMessage(agentId: string): Promise<string | null> {
+    const state = await this.readState(agentId);
+    const chunks: string[] = [];
+    for (let index = state.rows.length - 1; index >= 0; index -= 1) {
+      const item = state.rows[index].item;
+      if (item.type !== "assistant_message") {
+        if (chunks.length > 0) {
+          break;
+        }
+        continue;
+      }
+      chunks.push(item.text);
+    }
+    return chunks.length > 0 ? chunks.toReversed().join("") : null;
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    await this.queueOperation(agentId, async () => {
+      try {
+        await fs.unlink(this.filePath(agentId));
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+      this.states.delete(agentId);
+      this.loadPromises.delete(agentId);
+    });
+  }
+
+  async replaceCommitted(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
+    const replacement = normalizeRows(rows);
+    await this.queueMutation(agentId, () => ({
+      next: { version: 1, epoch: this.epochFactory(), rows: replacement },
+      result: undefined,
+    }));
+  }
+
+  async bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
+    if (rows.length === 0) {
+      return;
+    }
+    const incoming = normalizeRows(rows);
+    await this.queueMutation(agentId, (current) => {
+      const merged = new Map(current.rows.map((row) => [row.seq, row]));
+      for (const row of incoming) {
+        merged.set(row.seq, row);
+      }
+      return {
+        next: {
+          ...current,
+          rows: normalizeRows(Array.from(merged.values())),
+        },
+        result: undefined,
+      };
+    });
+  }
+
+  async updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void> {
+    await this.bulkInsert(agentId, [row]);
+  }
+
+  private async readState(agentId: string): Promise<PersistedAgentTimeline> {
+    await (this.operationTails.get(agentId) ?? Promise.resolve());
+    return await this.loadState(agentId);
+  }
+
+  private async loadState(agentId: string): Promise<PersistedAgentTimeline> {
+    const cached = this.states.get(agentId);
+    if (cached) {
+      return cached;
+    }
+    const existingLoad = this.loadPromises.get(agentId);
+    if (existingLoad) {
+      return await existingLoad;
+    }
+    const load = this.loadStateFromDisk(agentId).finally(() => {
+      if (this.loadPromises.get(agentId) === load) {
+        this.loadPromises.delete(agentId);
+      }
+    });
+    this.loadPromises.set(agentId, load);
+    return await load;
+  }
+
+  private async loadStateFromDisk(agentId: string): Promise<PersistedAgentTimeline> {
+    const filePath = this.filePath(agentId);
+    let state: PersistedAgentTimeline;
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      state = parsePersistedTimeline(JSON.parse(raw));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        this.logger.error({ err: error, agentId, filePath }, "Failed to load agent timeline");
+        throw error;
+      }
+      state = { version: 1, epoch: this.epochFactory(), rows: [] };
+    }
+    this.states.set(agentId, state);
+    return state;
+  }
+
+  private async queueMutation<T>(
+    agentId: string,
+    mutate: (
+      current: PersistedAgentTimeline,
+    ) =>
+      | { next: PersistedAgentTimeline; result: T }
+      | Promise<{ next: PersistedAgentTimeline; result: T }>,
+  ): Promise<T> {
+    return await this.queueOperation(agentId, async () => {
+      const current = await this.loadState(agentId);
+      const { next, result } = await mutate(current);
+      await this.writeJson(this.filePath(agentId), next);
+      this.states.set(agentId, next);
+      return result;
+    });
+  }
+
+  private queueOperation<T>(agentId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.operationTails.get(agentId) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    const settled = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.operationTails.set(agentId, settled);
+    void settled.then(() => {
+      if (this.operationTails.get(agentId) === settled) {
+        this.operationTails.delete(agentId);
+      }
+      return undefined;
+    });
+    return current;
+  }
+
+  private filePath(agentId: string): string {
+    return path.join(this.baseDir, `agent-${Buffer.from(agentId).toString("base64url")}.json`);
+  }
+}

--- a/packages/server/src/server/agent/provider-registry-wrap.test.ts
+++ b/packages/server/src/server/agent/provider-registry-wrap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type {
   AgentCapabilityFlags,
+  AgentHistoryStreamOptions,
   AgentPromptInput,
   AgentSession,
   AgentStreamEvent,
@@ -60,6 +61,7 @@ class FakeSession implements AgentSession {
   readonly capabilities = CAPABILITIES;
   readonly features = [];
   readonly recordedCalls: string[] = [];
+  readonly historySignals: Array<AbortSignal | undefined> = [];
 
   async run() {
     this.recordedCalls.push("run");
@@ -76,8 +78,9 @@ class FakeSession implements AgentSession {
     return () => {};
   }
 
-  async *streamHistory() {
+  async *streamHistory(options?: AgentHistoryStreamOptions) {
     this.recordedCalls.push("streamHistory");
+    this.historySignals.push(options?.signal);
     yield* emptyHistory();
   }
 
@@ -168,6 +171,19 @@ async function* emptyHistory(): AsyncGenerator<AgentStreamEvent> {
 }
 
 describe("wrapSessionProvider", () => {
+  test("forwards stream history cancellation", async () => {
+    const session = new FakeSession();
+    const wrapped = wrapSessionProvider("custom-claude", session);
+    const signal = new AbortController().signal;
+
+    await expect(wrapped.streamHistory({ signal }).next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    expect(session.historySignals).toEqual([signal]);
+  });
+
   test("forwards every optional AgentSession method", async () => {
     const session = new FakeSession();
     const wrapped = wrapSessionProvider("custom-claude", session);

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -358,8 +358,8 @@ export function wrapSessionProvider(provider: AgentProvider, inner: AgentSession
     run: (prompt, options) => inner.run(prompt, options),
     startTurn: (prompt, options) => inner.startTurn(prompt, options),
     subscribe: (callback) => inner.subscribe((event) => callback(mapStreamEvent(provider, event))),
-    async *streamHistory() {
-      for await (const event of inner.streamHistory()) {
+    async *streamHistory(options) {
+      for await (const event of inner.streamHistory(options)) {
         yield mapStreamEvent(provider, event);
       }
     },

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -1663,6 +1663,32 @@ describe("OpenCode adapter startTurn error handling", () => {
     ]);
   });
 
+  test("streamHistory forwards one cancellation signal to every history request", async () => {
+    const get = vi.fn().mockResolvedValue({ data: { revert: undefined }, error: undefined });
+    const messages = vi.fn().mockResolvedValue({ data: [], error: undefined });
+    const fakeClient = { session: { get, messages } } as never;
+    const session = new __openCodeInternals.OpenCodeAgentSession(
+      { provider: "opencode", cwd: "/tmp/test" },
+      fakeClient,
+      "ses_unit_test",
+      createTestLogger(),
+    );
+    const signal = new AbortController().signal;
+
+    await expect(session.streamHistory({ signal }).next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(get).toHaveBeenCalledWith(
+      { sessionID: "ses_unit_test", directory: "/tmp/test" },
+      { signal },
+    );
+    expect(messages).toHaveBeenCalledWith(
+      { sessionID: "ses_unit_test", directory: "/tmp/test" },
+      { signal },
+    );
+  });
+
   test("streamHistory omits replay timestamps when OpenCode omits times", async () => {
     const fakeClient = {
       session: {

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -23,6 +23,7 @@ import {
   type AgentClient,
   type AgentCreateSessionOptions,
   type AgentFeature,
+  type AgentHistoryStreamOptions,
   type AgentLaunchContext,
   type AgentMode,
   type AgentModelDefinition,
@@ -4002,15 +4003,22 @@ class OpenCodeAgentSession implements AgentSession {
     );
   }
 
-  async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
-    const sessionResponse = await this.client.session.get({
-      sessionID: this.sessionId,
-      directory: this.config.cwd,
-    });
-    const response = await this.client.session.messages({
-      sessionID: this.sessionId,
-      directory: this.config.cwd,
-    });
+  async *streamHistory(options?: AgentHistoryStreamOptions): AsyncGenerator<AgentStreamEvent> {
+    const requestOptions = options?.signal ? { signal: options.signal } : undefined;
+    const sessionResponse = await this.client.session.get(
+      {
+        sessionID: this.sessionId,
+        directory: this.config.cwd,
+      },
+      requestOptions,
+    );
+    const response = await this.client.session.messages(
+      {
+        sessionID: this.sessionId,
+        directory: this.config.cwd,
+      },
+      requestOptions,
+    );
 
     if (response.error || !response.data) {
       return;

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -128,6 +128,7 @@ import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
 import { AgentStorage } from "./agent/agent-storage.js";
+import { FileAgentTimelineStore } from "./agent/file-agent-timeline-store.js";
 import { attachAgentStoragePersistence } from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
 import {
@@ -781,6 +782,10 @@ export async function createPaseoDaemon(
   }
 
   const agentStorage = new AgentStorage(config.agentStoragePath, logger);
+  const durableTimelineStore = new FileAgentTimelineStore(
+    path.join(config.paseoHome, "timelines"),
+    logger,
+  );
   const projectRegistry = new FileBackedProjectRegistry(
     path.join(config.paseoHome, "projects", "projects.json"),
     logger,
@@ -824,6 +829,7 @@ export async function createPaseoDaemon(
     clients: initialAgentManagerState.clients,
     providerDefinitions: initialAgentManagerState.providerDefinitions,
     registry: agentStorage,
+    durableTimelineStore,
     appendSystemPrompt: config.appendSystemPrompt,
     onWorkspaceStateMayHaveChanged: ({ cwd }) => {
       workspaceGitService.onWorkspaceStateMayHaveChanged(cwd);

--- a/packages/server/src/server/daemon-e2e/agent-refresh-rehydrates-timeline.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/agent-refresh-rehydrates-timeline.e2e.test.ts
@@ -5,12 +5,9 @@ import path from "node:path";
 import pino from "pino";
 
 import { ClaudeAgentClient } from "../agent/providers/claude/agent.js";
+import { claudeProjectDirSync } from "../agent/providers/claude/project-dir.js";
 import { DaemonClient } from "../test-utils/daemon-client.js";
 import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
-
-function sanitizeClaudeProjectPath(cwd: string): string {
-  return cwd.replace(/[\\/._:]/g, "-");
-}
 
 interface ClaudeJsonlEntry {
   type: "user" | "assistant";
@@ -70,7 +67,7 @@ describe("daemon E2E - refresh rehydrates timeline from on-disk session", () => 
     process.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
 
     cwd = mkdtempSync(path.join(tmpdir(), "claude-cwd-refresh-"));
-    const projectsDir = path.join(claudeConfigDir, "projects", sanitizeClaudeProjectPath(cwd));
+    const projectsDir = claudeProjectDirSync(cwd, { configDir: claudeConfigDir });
     mkdirSync(projectsDir, { recursive: true });
     sessionFile = path.join(projectsDir, `${sessionId}.jsonl`);
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3421,7 +3421,12 @@ export class Session {
           logger: this.sessionLogger,
         });
       }
-      await this.agentManager.hydrateTimelineFromProvider(agentId, { broadcast: true });
+      await this.agentManager.hydrateTimelineFromProvider(agentId, {
+        broadcast: true,
+        // An explicit refresh must surface provider-history failures even when
+        // ensureAgentLoaded already attempted the best-effort initial hydration.
+        force: true,
+      });
       await this.agentUpdates.forwardLiveAgent(snapshot);
       const timelineSize = this.agentManager.getTimeline(agentId).length;
       if (requestId) {

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -5066,7 +5066,12 @@ test("refresh_agent_request leaves workspace archival independent when its direc
   session.agentManager.getAgent = () => managed;
   session.interruptAgentIfRunning = async () => undefined;
   session.agentManager.reloadAgentSession = async () => managed;
-  session.agentManager.hydrateTimelineFromProvider = async () => undefined;
+  let hydrationRequest:
+    | { agentId: string; options: { broadcast?: boolean; force?: boolean } | undefined }
+    | undefined;
+  session.agentManager.hydrateTimelineFromProvider = async (requestedAgentId, options) => {
+    hydrationRequest = { agentId: requestedAgentId, options };
+  };
   session.agentManager.getTimeline = () => [];
   session.agentUpdates.forwardLiveAgent = async () => undefined;
 
@@ -5087,6 +5092,39 @@ test("refresh_agent_request leaves workspace archival independent when its direc
   expect(projects.get(cwd)?.archivedAt).toBe("2026-03-10T00:00:00.000Z");
   expect(unarchivedWorkspaceIds).toEqual([]);
   expect(findByType(emitted, "rpc_error")).toBeUndefined();
+  expect(hydrationRequest).toEqual({
+    agentId,
+    options: { broadcast: true, force: true },
+  });
+
+  session.agentManager.hydrateTimelineFromProvider = async () => {
+    throw new Error("provider refresh history failed");
+  };
+  await session.handleMessage({
+    type: "refresh_agent_request",
+    agentId,
+    requestId: "req-refresh-history-failure",
+  });
+
+  expect(
+    emitted.find(
+      (message) =>
+        message.type === "rpc_error" && message.payload.requestId === "req-refresh-history-failure",
+    )?.payload,
+  ).toMatchObject({
+    requestId: "req-refresh-history-failure",
+    requestType: "refresh_agent_request",
+    code: "agent_refresh_failed",
+    error: "provider refresh history failed",
+  });
+  expect(
+    emitted.find(
+      (message) =>
+        message.type === "status" &&
+        message.payload.status === "agent_refreshed" &&
+        message.payload.requestId === "req-refresh-history-failure",
+    ),
+  ).toBeUndefined();
 });
 
 test("refresh_agent_request leaves workspace archival independent when its directory is missing", async () => {


### PR DESCRIPTION
Successor to #2723. This keeps the replacement narrowly focused on provider-history hydration atomicity; it does not close or modify the earlier pull request.

## What changes

- installs the per-agent hydration gate synchronously when hydration is admitted, before the session queue drain can yield
- stages provider history and commits it through one awaited atomic durable replacement
- releases queued live session events and direct timeline writers only after history is installed
- serializes concurrent hydration generations without opening a between-generation writer gap
- preserves the prior timeline on provider-stream or durable-replacement failure and leaves hydration retryable

## Non-goals

- stored-resume or initialization-close lifecycle changes
- terminal ownership changes
- documentation/proof artifacts from #2723

## Verification

- focused manager, stream-coalescing, session, agent-storage, and timeline-store tests: 348 passed
- timeline-window daemon E2E: 11 passed
- persistence/restart daemon E2E: 2 passed
- server and CLI build: passed
- all-workspace typecheck: passed
- repository lint and formatting checks: passed
- diff checks: passed

## Upstream baseline observations

Two additional daemon E2Es were attempted and fail identically on the detached upstream base (`9ddc3e0c4253b4cf3a1a7b864b7a92294cf2e8d4`):

- `agent-refresh-rehydrates-timeline.e2e.test.ts` sees an empty initial Claude import before reaching refresh
- `timeline-reconnect-contract.e2e.test.ts` times out waiting for an existing provisional live event

Those unrelated baseline behaviors are intentionally not changed here.