### PR TITLE
feat: expose provider-neutral material progress snapshots

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -97,6 +97,7 @@ Each agent is stored as a separate JSON file, grouped by project directory.
 | `features`           | `AgentFeature[]?`                        | Provider-reported features (toggles/selects)                                                                                                                                                                                                                                                                                                                                        |
 | `persistence`        | `PersistenceHandle?`                     | Handle for resuming sessions                                                                                                                                                                                                                                                                                                                                                        |
 | `lastError`          | `string?` (nullable)                     | Last error message, if any                                                                                                                                                                                                                                                                                                                                                          |
+| `materialProgress`   | `MaterialProgressCheckpoint?`            | Incremental material-progress accumulator for the current accepted continuation. It is bound to a timeline epoch and sequence boundary so timeline replacement cannot reuse a stale result. Legacy records may omit it.                                                                                                                                                             |
 | `requiresAttention`  | `boolean?`                               | Whether the agent needs user attention                                                                                                                                                                                                                                                                                                                                              |
 | `attentionReason`    | `"finished" \| "error" \| "permission"?` | Why attention is needed                                                                                                                                                                                                                                                                                                                                                             |
 | `attentionTimestamp` | `string?` (ISO 8601)                     | When attention was flagged                                                                                                                                                                                                                                                                                                                                                          |
@@ -135,6 +136,30 @@ Each agent is stored as a separate JSON file, grouped by project directory.
 | `sessionId`    | `string`               | Session ID for resumption                                             |
 | `nativeHandle` | `any?`                 | Provider-specific handle (Codex thread ID, Claude resume token, etc.) |
 | `metadata`     | `Record<string, any>?` | Extra metadata                                                        |
+
+### Nested: MaterialProgressCheckpoint
+
+This checkpoint is an observational read model; it does not change lifecycle or control whether an
+agent continues. An accepted provider turn opens a new continuation boundary. Rejected starts that
+never return a turn id leave the preceding accepted outcome intact. Timeline replacement creates a
+new epoch and an empty checkpoint; ordinary reload can rebind a valid persisted cursor and catch up
+all later rows incrementally.
+
+| Field                                       | Type                                                                                     | Description                                                                                        |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `timelineEpoch`                             | `string`                                                                                 | Epoch of the authoritative timeline the checkpoint describes                                       |
+| `continuationBoundarySeq`                   | `number?`                                                                                | First sequence in the current accepted continuation; `null` when no accepted continuation is known |
+| `acceptedTurnId`                            | `string?`                                                                                | Provider turn identity that opened the boundary                                                    |
+| `turnOutcome`                               | `"completed" \| "failed" \| "canceled"?`                                                 | Terminal outcome for the accepted turn, when known                                                 |
+| `observedThroughSeq`                        | `number`                                                                                 | Highest contiguous authoritative row incorporated                                                  |
+| `completedCompactionsSinceMaterialProgress` | `number`                                                                                 | Completed compactions since the last distinct material event                                       |
+| `lastMaterialProgressAt`                    | `string?` (ISO 8601)                                                                     | Timestamp of the last distinct material event                                                      |
+| `lastMaterialProgressKind`                  | `"edit" \| "write" \| "evidence" \| "verification" \| "decision" \| "assistant_result"?` | Class of the last distinct material event                                                          |
+| `seenMaterialProgressFingerprints`          | `string[]`                                                                               | Digests used to prevent repeated identical evidence from resetting the counter                     |
+| `trailingAssistantFingerprint`              | `string?`                                                                                | Digest of the trailing assistant output pending terminal settlement                                |
+| `trailingAssistantHasConcreteText`          | `boolean`                                                                                | Whether the pending assistant output contains concrete text                                        |
+| `trailingAssistantAt`                       | `string?` (ISO 8601)                                                                     | Timestamp of the pending assistant output                                                          |
+| `unavailableReason`                         | `string?`                                                                                | Why the checkpoint was cleared instead of reusing an unprovable cursor                             |
 
 ### Nested: AgentFeature (discriminated union on `type`)
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -52,6 +52,8 @@ $PASEO_HOME/
 ├── agents/
 │   └── {sanitized-cwd}/
 │       └── {agentId}.json               # One file per agent
+├── timelines/
+│   └── agent-{base64url-agentId}.json    # Canonical rows plus durable incarnation epoch
 ├── schedules/
 │   └── {scheduleId}.json                # One file per schedule
 ├── chat/
@@ -68,7 +70,7 @@ $PASEO_HOME/
 └── push-tokens.json                     # Expo push notification tokens
 ```
 
-The `agents/{sanitized-cwd}/` directory name is derived from the agent's `cwd` by stripping the filesystem root and replacing path separators with `-` (Windows drive letters become a `C-` style prefix). Persistent server stores write atomically by writing a temp file in the target directory and then renaming it into place.
+The `agents/{sanitized-cwd}/` directory name is derived from the agent's `cwd` by stripping the filesystem root and replacing path separators with `-` (Windows drive letters become a `C-` style prefix). Each timeline file stores the canonical rows and the exact incarnation epoch used by material-progress checkpoints. Reopening unchanged durable rows restores that epoch; deleting or replacing the timeline retires it and mints a new one. Persistent server stores write atomically by writing a temp file in the target directory and then renaming it into place.
 
 ---
 
@@ -142,10 +144,12 @@ Each agent is stored as a separate JSON file, grouped by project directory.
 This checkpoint is an observational read model; it does not change lifecycle or control whether an
 agent continues. An accepted provider turn opens a new continuation boundary. Rejected starts that
 never return a turn id leave the preceding accepted outcome intact. A checkpoint is restored only
-when its timeline epoch is unchanged; sequence bounds alone cannot prove continuity across a process
-restart or timeline replacement. A changed epoch starts an empty checkpoint, even when the new
-timeline is equally long or longer. After a successful provider rewind, the empty checkpoint is
-persisted before any fallible history refresh; a rejected provider rewind preserves the checkpoint.
+when its timeline epoch is unchanged; sequence bounds alone cannot prove continuity. The epoch is
+persisted with the canonical timeline so a daemon restart of that exact durable incarnation preserves
+the checkpoint. Timeline replacement, rewind, or explicit rehydration retires the epoch and starts an
+empty checkpoint, even when the replacement is equally long or longer. After a successful provider
+rewind, the empty checkpoint is persisted before any fallible history refresh; a rejected provider
+rewind preserves the checkpoint.
 
 | Field                                       | Type                                                                                     | Description                                                                                        |
 | ------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -141,9 +141,11 @@ Each agent is stored as a separate JSON file, grouped by project directory.
 
 This checkpoint is an observational read model; it does not change lifecycle or control whether an
 agent continues. An accepted provider turn opens a new continuation boundary. Rejected starts that
-never return a turn id leave the preceding accepted outcome intact. Timeline replacement creates a
-new epoch and an empty checkpoint; ordinary reload can rebind a valid persisted cursor and catch up
-all later rows incrementally.
+never return a turn id leave the preceding accepted outcome intact. A checkpoint is restored only
+when its timeline epoch is unchanged; sequence bounds alone cannot prove continuity across a process
+restart or timeline replacement. A changed epoch starts an empty checkpoint, even when the new
+timeline is equally long or longer. After a successful provider rewind, the empty checkpoint is
+persisted before any fallible history refresh; a rejected provider rewind preserves the checkpoint.
 
 | Field                                       | Type                                                                                     | Description                                                                                        |
 | ------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -146,10 +146,11 @@ agent continues. An accepted provider turn opens a new continuation boundary. Re
 never return a turn id leave the preceding accepted outcome intact. A checkpoint is restored only
 when its timeline epoch is unchanged; sequence bounds alone cannot prove continuity. The epoch is
 persisted with the canonical timeline so a daemon restart of that exact durable incarnation preserves
-the checkpoint. Timeline replacement, rewind, or explicit rehydration retires the epoch and starts an
-empty checkpoint, even when the replacement is equally long or longer. After a successful provider
-rewind, the empty checkpoint is persisted before any fallible history refresh; a rejected provider
-rewind preserves the checkpoint.
+the checkpoint. Successful timeline replacement, rewind, or explicit rehydration retires the epoch
+and starts an empty checkpoint, even when the replacement is equally long or longer. Explicit
+rehydration stages provider history before committing, so a failed history read preserves the prior
+epoch and checkpoint. After a successful provider rewind, the empty checkpoint is persisted before
+any fallible history refresh; a rejected provider rewind preserves the checkpoint.
 
 | Field                                       | Type                                                                                     | Description                                                                                        |
 | ------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |

--- a/packages/cli/src/commands/agent/inspect.test.ts
+++ b/packages/cli/src/commands/agent/inspect.test.ts
@@ -1,0 +1,49 @@
+import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
+import { describe, expect, it } from "vitest";
+import { toInspectData, toInspectRows } from "./inspect.js";
+
+describe("agent inspect material progress", () => {
+  it("preserves the structured checkpoint and renders its state and reason", () => {
+    const snapshot = {
+      id: "agent-1",
+      provider: "opencode",
+      cwd: "/tmp/work",
+      model: "test-model",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:01:00.000Z",
+      lastUserMessageAt: "2026-08-01T00:00:30.000Z",
+      status: "running",
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: false,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      currentModeId: null,
+      availableModes: [],
+      pendingPermissions: [],
+      persistence: null,
+      title: "Stalled worker",
+      labels: {},
+      materialProgress: {
+        state: "stalled",
+        timelineEpoch: "epoch-1",
+        continuationBoundarySeq: 10,
+        observedThroughSeq: 15,
+        completedCompactionsSinceMaterialProgress: 2,
+        lastMaterialProgressAt: null,
+        lastMaterialProgressKind: null,
+        reason: "Two compactions completed without later distinct material progress.",
+      },
+    } as AgentSnapshotPayload;
+
+    const inspect = toInspectData(snapshot);
+    expect(inspect.MaterialProgress).toEqual(snapshot.materialProgress);
+    expect(toInspectRows(inspect)).toContainEqual({
+      key: "MaterialProgress",
+      value: "stalled: Two compactions completed without later distinct material progress.",
+    });
+  });
+});

--- a/packages/cli/src/commands/agent/inspect.ts
+++ b/packages/cli/src/commands/agent/inspect.ts
@@ -11,7 +11,7 @@ export function addInspectOptions(cmd: Command): Command {
 }
 
 /** Agent inspect data for display (matches CLI spec format) */
-interface AgentInspect {
+export interface AgentInspect {
   Id: string;
   Name: string;
   Provider: string;
@@ -46,10 +46,11 @@ interface AgentInspect {
   }>;
   Worktree: string | null;
   ParentAgentId: string | null;
+  MaterialProgress: AgentSnapshotPayload["materialProgress"] | null;
 }
 
 /** Key-value row for table display */
-interface InspectRow {
+export interface InspectRow {
   key: string;
   value: string;
 }
@@ -126,7 +127,7 @@ function buildCapabilities(snapshot: AgentSnapshotPayload): AgentInspect["Capabi
 }
 
 /** Convert agent snapshot to inspection data */
-function toInspectData(snapshot: AgentSnapshotPayload): AgentInspect {
+export function toInspectData(snapshot: AgentSnapshotPayload): AgentInspect {
   return {
     Id: snapshot.id,
     Name: snapshot.title ?? "-",
@@ -151,11 +152,12 @@ function toInspectData(snapshot: AgentSnapshotPayload): AgentInspect {
     })),
     Worktree: snapshot.labels?.["paseo.worktree"] ?? null,
     ParentAgentId: snapshot.labels?.[PARENT_AGENT_ID_LABEL] ?? null,
+    MaterialProgress: snapshot.materialProgress ?? null,
   };
 }
 
 /** Convert agent to key-value rows for table display */
-function toInspectRows(agent: AgentInspect): InspectRow[] {
+export function toInspectRows(agent: AgentInspect): InspectRow[] {
   const rows: InspectRow[] = [
     { key: "Id", value: agent.Id },
     { key: "Name", value: agent.Name },
@@ -202,6 +204,12 @@ function toInspectRows(agent: AgentInspect): InspectRow[] {
 
   rows.push({ key: "Worktree", value: agent.Worktree ?? "null" });
   rows.push({ key: "ParentAgentId", value: agent.ParentAgentId ?? "null" });
+  rows.push({
+    key: "MaterialProgress",
+    value: agent.MaterialProgress
+      ? `${agent.MaterialProgress.state}: ${agent.MaterialProgress.reason}`
+      : "unavailable",
+  });
 
   return rows;
 }

--- a/packages/protocol/src/material-progress-schema.test.ts
+++ b/packages/protocol/src/material-progress-schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { AgentSnapshotPayloadSchema, ServerInfoStatusPayloadSchema } from "./messages.js";
+
+const baseSnapshot = {
+  id: "agent-1",
+  provider: "opencode",
+  cwd: "/tmp/work",
+  model: null,
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  lastUserMessageAt: null,
+  status: "running" as const,
+  capabilities: {
+    supportsStreaming: true,
+    supportsSessionPersistence: true,
+    supportsDynamicModes: false,
+    supportsMcpServers: true,
+    supportsReasoningStream: true,
+    supportsToolInvocations: true,
+  },
+  currentModeId: null,
+  availableModes: [],
+  pendingPermissions: [],
+  persistence: null,
+  title: null,
+  labels: {},
+};
+
+describe("material progress wire compatibility", () => {
+  it("accepts legacy snapshots without the optional signal", () => {
+    expect(AgentSnapshotPayloadSchema.parse(baseSnapshot).materialProgress).toBeUndefined();
+  });
+
+  it("accepts an epoch-bound material progress snapshot", () => {
+    const parsed = AgentSnapshotPayloadSchema.parse({
+      ...baseSnapshot,
+      materialProgress: {
+        state: "warning",
+        timelineEpoch: "epoch-2",
+        continuationBoundarySeq: 42,
+        observedThroughSeq: 57,
+        completedCompactionsSinceMaterialProgress: 1,
+        lastMaterialProgressAt: "2026-08-01T00:00:01.000Z",
+        lastMaterialProgressKind: "evidence",
+        reason: "One compaction completed without later material progress.",
+      },
+    });
+
+    expect(parsed.materialProgress).toMatchObject({
+      state: "warning",
+      timelineEpoch: "epoch-2",
+      continuationBoundarySeq: 42,
+      observedThroughSeq: 57,
+      lastMaterialProgressKind: "evidence",
+    });
+  });
+
+  it("advertises the material-progress feature independently of legacy snapshots", () => {
+    expect(
+      ServerInfoStatusPayloadSchema.parse({
+        status: "server_info",
+        serverId: "server-1",
+        features: { materialProgress: true },
+      }).features?.materialProgress,
+    ).toBe(true);
+  });
+});

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -702,6 +702,37 @@ const AgentActiveTurnPayloadSchema = z.object({
   startedAt: z.string().nullable(),
 });
 
+export interface MaterialProgressPayload {
+  state: "none" | "progressing" | "warning" | "stalled";
+  timelineEpoch: string | null;
+  continuationBoundarySeq: number | null;
+  observedThroughSeq: number | null;
+  completedCompactionsSinceMaterialProgress: number;
+  lastMaterialProgressAt: string | null;
+  lastMaterialProgressKind:
+    | "edit"
+    | "write"
+    | "evidence"
+    | "verification"
+    | "decision"
+    | "assistant_result"
+    | null;
+  reason: string;
+}
+
+export const MaterialProgressPayloadSchema: z.ZodType<MaterialProgressPayload> = z.object({
+  state: z.enum(["none", "progressing", "warning", "stalled"]),
+  timelineEpoch: z.string().nullable(),
+  continuationBoundarySeq: z.number().int().positive().nullable(),
+  observedThroughSeq: z.number().int().nonnegative().nullable(),
+  completedCompactionsSinceMaterialProgress: z.number().int().nonnegative(),
+  lastMaterialProgressAt: z.string().nullable(),
+  lastMaterialProgressKind: z
+    .enum(["edit", "write", "evidence", "verification", "decision", "assistant_result"])
+    .nullable(),
+  reason: z.string(),
+});
+
 export const AgentSnapshotPayloadSchema = z.object({
   id: z.string(),
   provider: AgentProviderSchema,
@@ -731,6 +762,8 @@ export const AgentSnapshotPayloadSchema = z.object({
   attentionTimestamp: z.string().nullable().optional(),
   archivedAt: z.string().nullable().optional(),
   providerUnavailable: z.boolean().optional(),
+  // COMPAT(materialProgress): added in v0.2.5, remove optional after 2027-02-01.
+  materialProgress: MaterialProgressPayloadSchema.optional(),
 });
 
 export type AgentSnapshotPayload = z.infer<typeof AgentSnapshotPayloadSchema>;
@@ -2852,6 +2885,8 @@ export const ServerInfoStatusPayloadSchema = z
         agentDetach: z.boolean().optional(),
         // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.
         agentThinkingUpdate: z.boolean().optional(),
+        // COMPAT(materialProgress): added in v0.2.5, remove gate after 2027-02-01.
+        materialProgress: z.boolean().optional(),
         // COMPAT(daemonDiagnostics): added in v0.1.100, remove gate after 2026-12-25 once daemon floor >= v0.1.100.
         daemonDiagnostics: z.boolean().optional(),
         // COMPAT(daemonSelfUpdate): added in v0.1.93, remove gate after 2026-12-13.

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -3056,6 +3056,348 @@ test("material progress restores only with the exact durable timeline incarnatio
   }
 });
 
+test("provider history hydration retries after a one-row-then-throw restart without persisting a prefix", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-history-atomic-retry-"));
+  const agentStoragePath = join(workdir, "agents");
+  const timelineStoragePath = join(workdir, "timelines");
+  const agentId = "00000000-0000-4000-8000-000000000154";
+  let historyReads = 0;
+
+  class RetryHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyReads += 1;
+      yield {
+        type: "timeline",
+        provider: this.provider,
+        timestamp: "2026-08-01T00:00:00.000Z",
+        item: { type: "user_message", text: "history row one" },
+        turnId: "history-turn",
+      };
+      if (historyReads === 1) {
+        throw new Error("history interrupted after one row");
+      }
+      yield {
+        type: "timeline",
+        provider: this.provider,
+        timestamp: "2026-08-01T00:00:01.000Z",
+        item: { type: "assistant_message", text: "history row two" },
+        turnId: "history-turn",
+      };
+    }
+  }
+
+  class RetryHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new RetryHistorySession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new RetryHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const client = new RetryHistoryClient();
+  const createManager = (storage: AgentStorage) =>
+    new AgentManager({
+      clients: { codex: client },
+      registry: storage,
+      durableTimelineStore: new FileAgentTimelineStore(timelineStoragePath, logger),
+      logger,
+      idFactory: () => agentId,
+    });
+
+  try {
+    const firstStorage = new AgentStorage(agentStoragePath, logger);
+    const firstManager = createManager(firstStorage);
+    const created = await firstManager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const beforeFailureEpoch = firstManager.fetchTimeline(created.id, { limit: 0 }).epoch;
+
+    await firstManager.hydrateTimelineFromProvider(created.id);
+    await firstManager.flush();
+    expect(historyReads).toBe(1);
+    expect(firstManager.getTimeline(created.id)).toEqual([]);
+    const durableAfterFailure = await new FileAgentTimelineStore(
+      timelineStoragePath,
+      logger,
+    ).fetchCommitted(created.id, { limit: 0 });
+    expect(durableAfterFailure).toMatchObject({ epoch: beforeFailureEpoch, rows: [] });
+    expect((await firstStorage.get(created.id))?.historyPrimed).toBe(false);
+
+    await firstManager.closeAgent(created.id);
+    await firstManager.flush();
+
+    const restartedStorage = new AgentStorage(agentStoragePath, logger);
+    const restartedManager = createManager(restartedStorage);
+    try {
+      await ensureAgentLoaded(created.id, {
+        agentManager: restartedManager,
+        agentStorage: restartedStorage,
+        logger,
+      });
+      await restartedManager.flush();
+
+      expect(historyReads).toBe(2);
+      expect(restartedManager.fetchTimeline(created.id, { limit: 0 }).epoch).not.toBe(
+        beforeFailureEpoch,
+      );
+      expect(restartedManager.getTimeline(created.id)).toEqual([
+        { type: "user_message", text: "history row one" },
+        { type: "assistant_message", text: "history row two" },
+      ]);
+      await expect(
+        new FileAgentTimelineStore(timelineStoragePath, logger).getCommittedRows(created.id),
+      ).resolves.toMatchObject([
+        { seq: 1, turnId: "history-turn", item: { text: "history row one" } },
+        { seq: 2, turnId: "history-turn", item: { text: "history row two" } },
+      ]);
+      expect((await restartedStorage.get(created.id))?.historyPrimed).toBe(true);
+      await restartedManager.closeAgent(created.id);
+      await restartedManager.flush();
+    } finally {
+      await restartedManager.closeAgent(created.id).catch(() => undefined);
+    }
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("atomic provider hydration replays a live row after the complete replacement", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-history-live-replay-"));
+  const timelineStoragePath = join(workdir, "timelines");
+  const agentId = "00000000-0000-4000-8000-000000000156";
+  const historyEntered = deferred<void>();
+  const releaseHistory = deferred<void>();
+  let activeSession: LiveDuringHistorySession | null = null;
+
+  class LiveDuringHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyEntered.resolve();
+      await releaseHistory.promise;
+      yield {
+        type: "timeline",
+        provider: this.provider,
+        item: { type: "user_message", text: "complete provider history" },
+        turnId: "history-turn",
+      };
+    }
+  }
+
+  class LiveDuringHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new LiveDuringHistorySession(config);
+      return activeSession;
+    }
+  }
+
+  const epochs = ["initial-live-epoch", "replacement-live-epoch"];
+  const durableStore = new FileAgentTimelineStore(timelineStoragePath, logger, {
+    epochFactory: () => epochs.shift() ?? "unexpected-live-epoch",
+  });
+  const manager = new AgentManager({
+    clients: { codex: new LiveDuringHistoryClient() },
+    durableTimelineStore: durableStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const hydration = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    await historyEntered.promise;
+    activeSession!.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      item: { type: "assistant_message", text: "live after gate admission" },
+      turnId: "live-turn",
+    });
+    releaseHistory.resolve();
+    await hydration;
+    await manager.flush();
+
+    const inMemory = manager.fetchTimeline(created.id, { direction: "tail", limit: 0 });
+    const durable = await durableStore.fetchCommitted(created.id, { limit: 0 });
+    expect(inMemory.epoch).toBe("replacement-live-epoch");
+    expect(durable.epoch).toBe(inMemory.epoch);
+    expect(inMemory.rows).toEqual(durable.rows);
+    expect(inMemory.rows).toMatchObject([
+      {
+        seq: 1,
+        turnId: "history-turn",
+        item: { type: "user_message", text: "complete provider history" },
+      },
+      {
+        seq: 2,
+        turnId: "live-turn",
+        item: { type: "assistant_message", text: "live after gate admission" },
+      },
+    ]);
+  } finally {
+    releaseHistory.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("late material progress from a replaced turn stays excluded across restart", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-material-progress-turn-restart-"));
+  const agentStoragePath = join(workdir, "agents");
+  const timelineStoragePath = join(workdir, "timelines");
+  const agentId = "00000000-0000-4000-8000-000000000155";
+  let activeSession: ReplacementProgressSession | null = null;
+
+  class ReplacementProgressSession extends TestAgentSession {
+    private turnCounter = 0;
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      const turnId = `replacement-turn-${++this.turnCounter}`;
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
+
+    override async interrupt(): Promise<void> {
+      this.pushEvent({
+        type: "turn_canceled",
+        provider: this.provider,
+        reason: "Replaced",
+        turnId: "replacement-turn-1",
+      });
+    }
+  }
+
+  class ReplacementProgressClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new ReplacementProgressSession(config);
+      return activeSession;
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      activeSession = new ReplacementProgressSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+      return activeSession;
+    }
+  }
+
+  const client = new ReplacementProgressClient();
+  const createManager = (storage: AgentStorage) =>
+    new AgentManager({
+      clients: { codex: client },
+      registry: storage,
+      durableTimelineStore: new FileAgentTimelineStore(timelineStoragePath, logger),
+      logger,
+      idFactory: () => agentId,
+    });
+
+  try {
+    const firstStorage = new AgentStorage(agentStoragePath, logger);
+    const firstManager = createManager(firstStorage);
+    const created = await firstManager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const firstRun = firstManager.streamAgent(created.id, "turn one", {
+      clientMessageId: "replacement-client-one",
+    });
+    const firstDrain = (async () => {
+      for await (const _event of firstRun) {
+        // Drain the replaced turn.
+      }
+    })();
+    await firstManager.waitForAgentRunStart(created.id);
+
+    const secondRun = await firstManager.replaceAgentRun(created.id, "turn two", {
+      clientMessageId: "replacement-client-two",
+    });
+    const secondDrain = (async () => {
+      for await (const _event of secondRun) {
+        // Drained by closeAgent below.
+      }
+    })();
+    await firstManager.waitForAgentRunStart(created.id);
+
+    activeSession!.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      turnId: "replacement-turn-1",
+      item: {
+        type: "tool_call",
+        callId: "late-replaced-write",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "stale.txt", content: "late result" },
+      },
+    });
+    await vi.waitFor(() =>
+      expect(
+        firstManager
+          .fetchTimeline(created.id, { direction: "tail", limit: 0 })
+          .rows.some(
+            (row) => row.item.type === "tool_call" && row.item.callId === "late-replaced-write",
+          ),
+      ).toBe(true),
+    );
+    await firstManager.flush();
+    const beforeRestart = firstManager.getMaterialProgress(created.id);
+    expect(beforeRestart).toMatchObject({
+      state: "none",
+      lastMaterialProgressKind: null,
+      completedCompactionsSinceMaterialProgress: 0,
+    });
+    expect(
+      firstManager
+        .fetchTimeline(created.id, { direction: "tail", limit: 0 })
+        .rows.find(
+          (row) => row.item.type === "tool_call" && row.item.callId === "late-replaced-write",
+        )?.turnId,
+    ).toBe("replacement-turn-1");
+
+    await firstManager.closeAgent(created.id);
+    await firstManager.flush();
+    await Promise.all([firstDrain, secondDrain]);
+
+    const restartedStorage = new AgentStorage(agentStoragePath, logger);
+    const restartedManager = createManager(restartedStorage);
+    try {
+      await ensureAgentLoaded(created.id, {
+        agentManager: restartedManager,
+        agentStorage: restartedStorage,
+        logger,
+      });
+      await restartedManager.flush();
+
+      expect(restartedManager.getMaterialProgress(created.id)).toEqual(beforeRestart);
+      expect(
+        restartedManager
+          .fetchTimeline(created.id, { direction: "tail", limit: 0 })
+          .rows.find(
+            (row) => row.item.type === "tool_call" && row.item.callId === "late-replaced-write",
+          )?.turnId,
+      ).toBe("replacement-turn-1");
+      await restartedManager.closeAgent(created.id);
+    } finally {
+      await restartedManager.closeAgent(created.id).catch(() => undefined);
+    }
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("reloadAgentSession clears provider children before rehydrating from disk", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-reload-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
@@ -8609,6 +8951,7 @@ test("canonical submitted prompt keeps wire identity while rewind resolves provi
         seq: 1,
         timestamp: expect.any(String),
         providerMessageId: "provider-message-1",
+        turnId: "turn-submitted-user-message",
         item: {
           type: "user_message",
           text: "hello from composer",
@@ -8619,6 +8962,7 @@ test("canonical submitted prompt keeps wire identity while rewind resolves provi
       {
         seq: 2,
         timestamp: expect.any(String),
+        turnId: "turn-submitted-user-message",
         item: { type: "assistant_message", text: "output before provider echo" },
       },
     ]);

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2880,6 +2880,77 @@ test("reloadAgentSession preserves timeline and does not force history replay", 
   expect(afterHydrate).toEqual(beforeReload);
 });
 
+test("ordinary reload preserves material progress while disk rehydration mints a clean epoch", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-material-progress-reload-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  class ReloadProgressSession extends TestAgentSession {
+    async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield {
+        type: "timeline",
+        provider: this.provider,
+        item: { type: "assistant_message", text: "provider history after rewind" },
+      };
+    }
+  }
+
+  class ReloadProgressClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new ReloadProgressSession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new ReloadProgressSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new ReloadProgressClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000133",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.runAgent(snapshot.id, "accepted continuation");
+    await manager.appendTimelineItem(snapshot.id, {
+      type: "tool_call",
+      callId: "write-before-reload",
+      name: "write",
+      status: "completed",
+      error: null,
+      detail: { type: "write", filePath: "proof.txt", content: "durable proof" },
+    });
+    const beforeReload = manager.getMaterialProgress(snapshot.id);
+    expect(beforeReload).toMatchObject({ state: "progressing", lastMaterialProgressKind: "write" });
+
+    await manager.reloadAgentSession(snapshot.id);
+    expect(manager.getMaterialProgress(snapshot.id)).toEqual(beforeReload);
+
+    await manager.reloadAgentSession(snapshot.id, undefined, { rehydrateFromDisk: true });
+    const afterRehydrate = manager.getMaterialProgress(snapshot.id);
+    expect(afterRehydrate).toMatchObject({
+      state: "none",
+      continuationBoundarySeq: null,
+      lastMaterialProgressKind: null,
+    });
+    expect(afterRehydrate.timelineEpoch).not.toBe(beforeReload.timelineEpoch);
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("reloadAgentSession clears provider children before rehydrating from disk", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-reload-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
@@ -6174,6 +6245,108 @@ test("streamAgent clears pending run when startTurn fails before a turn id exist
       canceled: false,
     }),
   );
+});
+
+test("a pre-accept start failure preserves the prior accepted continuation progress", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-material-progress-rejection-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  class MaterialThenRejectSession extends TestAgentSession {
+    private attempt = 0;
+
+    override async startTurn(): Promise<{ turnId: string }> {
+      this.attempt += 1;
+      if (this.attempt === 2) {
+        throw new Error("rejected before provider turn acceptance");
+      }
+      const turnId = "accepted-material-turn";
+      setTimeout(() => {
+        this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+        this.pushEvent({
+          type: "timeline",
+          provider: this.provider,
+          turnId,
+          item: {
+            type: "tool_call",
+            callId: "write-proof",
+            name: "write",
+            status: "completed",
+            error: null,
+            detail: { type: "write", filePath: "proof.txt", content: "material result" },
+          },
+        });
+        this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
+      }, 0);
+      return { turnId };
+    }
+  }
+
+  class MaterialThenRejectClient implements AgentClient {
+    readonly provider = "codex" as const;
+    readonly capabilities = TEST_CAPABILITIES;
+    readonly session = new MaterialThenRejectSession({ provider: "codex", cwd: workdir });
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+
+    async createSession(): Promise<AgentSession> {
+      return this.session;
+    }
+
+    async resumeSession(): Promise<AgentSession> {
+      return this.session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new MaterialThenRejectClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000132",
+  });
+
+  try {
+    const agent = await manager.createAgent(
+      { provider: "codex", cwd: workdir, title: "Material progress rejection" },
+      undefined,
+      { workspaceId: undefined },
+    );
+    await manager.runAgent(agent.id, "accepted turn");
+    const accepted = manager.getMaterialProgress(agent.id);
+    expect(accepted).toMatchObject({
+      state: "progressing",
+      continuationBoundarySeq: 1,
+      observedThroughSeq: 1,
+      lastMaterialProgressKind: "write",
+    });
+
+    await expect(manager.runAgent(agent.id, "rejected turn")).rejects.toThrow(
+      "rejected before provider turn acceptance",
+    );
+    const afterRejection = manager.getMaterialProgress(agent.id);
+    expect(afterRejection).toMatchObject({
+      state: accepted.state,
+      timelineEpoch: accepted.timelineEpoch,
+      continuationBoundarySeq: accepted.continuationBoundarySeq,
+      completedCompactionsSinceMaterialProgress: accepted.completedCompactionsSinceMaterialProgress,
+      lastMaterialProgressAt: accepted.lastMaterialProgressAt,
+      lastMaterialProgressKind: accepted.lastMaterialProgressKind,
+    });
+    expect(afterRejection.observedThroughSeq).toBe(accepted.observedThroughSeq! + 1);
+
+    await manager.flush();
+    expect((await storage.get(agent.id))?.materialProgress).toMatchObject({
+      timelineEpoch: afterRejection.timelineEpoch,
+      continuationBoundarySeq: afterRejection.continuationBoundarySeq,
+      observedThroughSeq: afterRejection.observedThroughSeq,
+      lastMaterialProgressKind: "write",
+    });
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("archiveAgent persists archivedAt and updatedAt before emitting closed state", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -2938,6 +2938,9 @@ test("ordinary reload preserves material progress while disk rehydration mints a
     expect(manager.getMaterialProgress(snapshot.id)).toEqual(beforeReload);
 
     await manager.reloadAgentSession(snapshot.id, undefined, { rehydrateFromDisk: true });
+    expect(manager.getMaterialProgress(snapshot.id)).toEqual(beforeReload);
+
+    await manager.hydrateTimelineFromProvider(snapshot.id, { force: true });
     const afterRehydrate = manager.getMaterialProgress(snapshot.id);
     expect(afterRehydrate).toMatchObject({
       state: "none",
@@ -3248,6 +3251,96 @@ test("atomic provider hydration replays a live row after the complete replacemen
   }
 });
 
+test("file-backed assistant-only history returns one last message across force hydration and restart", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-assistant-only-history-"));
+  const agentId = "00000000-0000-4000-8000-000000000160";
+  const expectedMessage = "one durable assistant response";
+  const timelineStoragePath = join(workdir, "timelines");
+  let historyCalls = 0;
+
+  class AssistantOnlyHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyCalls += 1;
+      yield {
+        type: "timeline",
+        provider: "codex",
+        timestamp: "2026-02-01T00:00:00.000Z",
+        item: { type: "assistant_message", text: expectedMessage },
+      };
+    }
+  }
+
+  class AssistantOnlyHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new AssistantOnlyHistorySession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new AssistantOnlyHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const client = new AssistantOnlyHistoryClient();
+  const firstManager = new AgentManager({
+    clients: { codex: client },
+    durableTimelineStore: new FileAgentTimelineStore(timelineStoragePath, logger),
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await firstManager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await firstManager.hydrateTimelineFromProvider(created.id, { force: true });
+    await expect(firstManager.getLastAssistantMessage(created.id)).resolves.toBe(expectedMessage);
+    await expect(firstManager.waitForAgentEvent(created.id)).resolves.toMatchObject({
+      lastMessage: expectedMessage,
+    });
+    await firstManager.closeAgent(agentId);
+
+    const restartedManager = new AgentManager({
+      clients: { codex: client },
+      durableTimelineStore: new FileAgentTimelineStore(timelineStoragePath, logger),
+      logger,
+      idFactory: () => agentId,
+    });
+    try {
+      const restarted = await restartedManager.resumeAgentFromPersistence(
+        { provider: "codex", sessionId: "assistant-only-session", metadata: { cwd: workdir } },
+        undefined,
+        agentId,
+        { workspaceId: undefined },
+      );
+      await restartedManager.hydrateTimelineFromProvider(restarted.id);
+      expect(historyCalls).toBe(1);
+      await expect(restartedManager.getLastAssistantMessage(restarted.id)).resolves.toBe(
+        expectedMessage,
+      );
+      await expect(restartedManager.waitForAgentEvent(restarted.id)).resolves.toMatchObject({
+        lastMessage: expectedMessage,
+      });
+
+      await restartedManager.hydrateTimelineFromProvider(restarted.id, { force: true });
+      expect(historyCalls).toBe(2);
+      await expect(restartedManager.getLastAssistantMessage(restarted.id)).resolves.toBe(
+        expectedMessage,
+      );
+    } finally {
+      await restartedManager.closeAgent(agentId).catch(() => undefined);
+    }
+  } finally {
+    await firstManager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("late material progress from a replaced turn stays excluded across restart", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-material-progress-turn-restart-"));
   const agentStoragePath = join(workdir, "agents");
@@ -3398,7 +3491,7 @@ test("late material progress from a replaced turn stays excluded across restart"
   }
 });
 
-test("reloadAgentSession clears provider children before rehydrating from disk", async () => {
+test("reloadAgentSession keeps provider children until disk rehydration commits", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-reload-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
   let activeSession: TestAgentSession | null = null;
@@ -3436,7 +3529,102 @@ test("reloadAgentSession clears provider children before rehydrating from disk",
 
   await manager.reloadAgentSession(snapshot.id, undefined, { rehydrateFromDisk: true });
 
+  expect(manager.listProviderSubagents(snapshot.id)).toHaveLength(1);
+  await manager.hydrateTimelineFromProvider(snapshot.id, { force: true, broadcast: true });
   expect(manager.listProviderSubagents(snapshot.id)).toEqual([]);
+});
+
+test("failed refresh history preserves prior file-backed state", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-refresh-history-rollback-"));
+  const agentId = "00000000-0000-4000-8000-000000000159";
+  const agentStorage = new AgentStorage(join(workdir, "agents"), logger);
+  const timelineStoragePath = join(workdir, "timelines");
+  const durableTimelineStore = new FileAgentTimelineStore(timelineStoragePath, logger);
+  let activeSession: TestAgentSession | null = null;
+
+  class FailingRefreshHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield* [];
+      throw new Error("provider refresh history failed");
+    }
+  }
+
+  class FailingRefreshHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      activeSession = new TestAgentSession(config);
+      return activeSession;
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new FailingRefreshHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new FailingRefreshHistoryClient() },
+    registry: agentStorage,
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await manager.runAgent(created.id, "accepted continuation");
+    await manager.appendTimelineItem(created.id, {
+      type: "tool_call",
+      callId: "write-before-failed-refresh",
+      name: "write",
+      status: "completed",
+      error: null,
+      detail: { type: "write", filePath: "proof.txt", content: "durable proof" },
+    });
+    activeSession?.pushEvent({
+      type: "provider_subagent",
+      provider: "codex",
+      event: {
+        type: "upsert",
+        id: "prior-child",
+        title: "Prior child",
+        status: "running",
+      },
+    });
+    await vi.waitFor(() => expect(manager.listProviderSubagents(agentId)).toHaveLength(1));
+    await manager.flush();
+
+    const timelineBefore = manager.fetchTimeline(agentId, { direction: "tail", limit: 0 });
+    const materialProgressBefore = manager.getMaterialProgress(agentId);
+    const childrenBefore = manager.listProviderSubagents(agentId);
+    const durableBefore = await durableTimelineStore.fetchCommitted(agentId, { limit: 0 });
+
+    await manager.reloadAgentSession(agentId, undefined, { rehydrateFromDisk: true });
+    expect(manager.fetchTimeline(agentId, { direction: "tail", limit: 0 })).toEqual(timelineBefore);
+    expect(manager.getMaterialProgress(agentId)).toEqual(materialProgressBefore);
+    expect(manager.listProviderSubagents(agentId)).toEqual(childrenBefore);
+
+    await expect(
+      manager.hydrateTimelineFromProvider(agentId, { force: true, broadcast: true }),
+    ).rejects.toThrow("provider refresh history failed");
+    await manager.flush();
+
+    expect(manager.fetchTimeline(agentId, { direction: "tail", limit: 0 })).toEqual(timelineBefore);
+    expect(manager.getMaterialProgress(agentId)).toEqual(materialProgressBefore);
+    expect(manager.listProviderSubagents(agentId)).toEqual(childrenBefore);
+    await expect(
+      new FileAgentTimelineStore(timelineStoragePath, logger).fetchCommitted(agentId, { limit: 0 }),
+    ).resolves.toEqual(durableBefore);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("hydrateTimelineFromProvider restores and broadcasts provider children from session history", async () => {
@@ -3540,6 +3728,277 @@ test("force provider hydration removes children absent from current history", as
       subagentId: "removed-by-rewind",
     },
   });
+});
+
+test("provider hydration preserves a queued terminal child update across a successor", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-provider-child-order-"));
+  const agentId = "00000000-0000-4000-8000-000000000161";
+  let session: TestAgentSession | null = null;
+  let historyGeneration = 0;
+
+  class ProviderChildOrderingSession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyGeneration += 1;
+      yield {
+        type: "provider_subagent",
+        provider: "codex",
+        event: {
+          type: "upsert",
+          id: "child-1",
+          title: "Child",
+          status: "running",
+          timestamp: "2026-01-01T00:00:00.000Z",
+        },
+      };
+      if (historyGeneration > 1) {
+        yield {
+          type: "provider_subagent",
+          provider: "codex",
+          event: {
+            type: "upsert",
+            id: "child-1",
+            title: "Child",
+            status: "completed",
+            timestamp: "2026-01-02T00:00:00.000Z",
+          },
+        };
+      }
+    }
+  }
+
+  class ProviderChildOrderingClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new ProviderChildOrderingSession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new ProviderChildOrderingClient() },
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    let successorHydration: Promise<void> | null = null;
+    let completedUpserts = 0;
+    manager.subscribe(
+      (event) => {
+        if (
+          event.type !== "provider_subagent" ||
+          event.event.type !== "upsert" ||
+          event.event.subagent.status !== "completed"
+        ) {
+          return;
+        }
+        completedUpserts += 1;
+        successorHydration ??= manager.hydrateTimelineFromProvider(created.id, {
+          force: true,
+          broadcast: true,
+        });
+      },
+      { agentId: created.id, replayState: false },
+    );
+    session?.pushEvent({
+      type: "provider_subagent",
+      provider: "codex",
+      event: {
+        type: "upsert",
+        id: "child-1",
+        title: "Child",
+        status: "completed",
+        timestamp: "2026-01-02T00:00:00.000Z",
+      },
+    });
+
+    await manager.hydrateTimelineFromProvider(created.id, { force: true, broadcast: true });
+    await successorHydration;
+
+    expect(manager.getProviderSubagent(created.id, "child-1")).toMatchObject({
+      status: "completed",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    expect(historyGeneration).toBe(2);
+    expect(completedUpserts).toBe(2);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("force hydration preserves durable provider identity for canonical submitted prompts", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-provider-identity-"));
+  const agentId = "00000000-0000-4000-8000-000000000163";
+  const durableTimelineStore = new FileAgentTimelineStore(join(workdir, "timelines"), logger);
+  const canonicalItem = {
+    type: "user_message",
+    text: "canonical submitted prompt",
+    messageId: "client-message-1",
+    clientMessageId: "client-message-1",
+  } satisfies AgentTimelineItem;
+  await durableTimelineStore.replaceCommitted(agentId, [
+    {
+      seq: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      providerMessageId: "provider-message-1",
+      turnId: "submitted-turn",
+      item: canonicalItem,
+    },
+  ]);
+
+  class IdentityHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      yield { type: "timeline", provider: "codex", item: canonicalItem };
+    }
+  }
+
+  class IdentityHistoryClient extends TestAgentClient {
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new IdentityHistorySession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new IdentityHistoryClient() },
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const resumed = await manager.resumeAgentFromPersistence(
+      { provider: "codex", sessionId: "identity-session", metadata: { cwd: workdir } },
+      undefined,
+      agentId,
+      { workspaceId: undefined },
+    );
+    await manager.hydrateTimelineFromProvider(resumed.id, { force: true });
+
+    await expect(durableTimelineStore.getCommittedRows(agentId)).resolves.toEqual([
+      expect.objectContaining({
+        seq: 1,
+        providerMessageId: "provider-message-1",
+        turnId: "submitted-turn",
+        item: canonicalItem,
+      }),
+    ]);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("a successor generation preserves a writer replaying behind the prior generation", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-writer-successor-"));
+  const agentId = "00000000-0000-4000-8000-000000000162";
+  const writerPersistStarted = deferred<void>();
+  const releaseWriterPersist = deferred<void>();
+  const durableTimelineStore = new FileAgentTimelineStore(join(workdir, "timelines"), logger);
+  let session: TestAgentSession | null = null;
+  let historyGeneration = 0;
+
+  class GatedWriterStorage extends AgentStorage {
+    armed = false;
+    private armedPersistCount = 0;
+
+    override async applySnapshot(
+      agent: ManagedAgent,
+      options?: { title?: string | null; internal?: boolean },
+    ): Promise<void> {
+      if (this.armed) {
+        this.armedPersistCount += 1;
+        if (this.armedPersistCount === 2) {
+          writerPersistStarted.resolve();
+          await releaseWriterPersist.promise;
+        }
+      }
+      await super.applySnapshot(agent, options);
+    }
+  }
+
+  class GeneratedWriterHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyGeneration += 1;
+      yield {
+        type: "timeline",
+        provider: "codex",
+        item: { type: "user_message", text: `history generation ${historyGeneration}` },
+      };
+      if (historyGeneration > 1) {
+        yield {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "user_message", text: "writer admitted behind generation 1" },
+        };
+      }
+    }
+  }
+
+  class GeneratedWriterHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new GeneratedWriterHistorySession(config);
+      return session;
+    }
+  }
+
+  const storage = new GatedWriterStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new GeneratedWriterHistoryClient() },
+    registry: storage,
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    storage.armed = true;
+    const first = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      turnId: "writer-turn-behind-generation-1",
+      item: { type: "user_message", text: "writer admitted behind generation 1" },
+    });
+
+    await writerPersistStarted.promise;
+    const second = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    session?.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      turnId: "live-turn-behind-generation-2",
+      item: { type: "user_message", text: "live row admitted behind generation 2" },
+    });
+    releaseWriterPersist.resolve();
+
+    await Promise.all([first, second]);
+    await manager.flush();
+    const expectedItems: AgentTimelineItem[] = [
+      { type: "user_message", text: "history generation 2" },
+      { type: "user_message", text: "writer admitted behind generation 1" },
+      { type: "user_message", text: "live row admitted behind generation 2" },
+    ];
+    expect(manager.getTimeline(created.id)).toEqual(expectedItems);
+    const durableRows = await durableTimelineStore.getCommittedRows(agentId);
+    expect(durableRows.map((row) => row.item)).toEqual(expectedItems);
+    expect(durableRows[1]?.turnId).toBe("writer-turn-behind-generation-1");
+    expect(durableRows[2]?.turnId).toBe("live-turn-behind-generation-2");
+  } finally {
+    releaseWriterPersist.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("reloadAgentSession preserves current title when config title is unset", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4001,6 +4001,112 @@ test("a successor generation preserves a writer replaying behind the prior gener
   }
 });
 
+test("a successor hydration preserves material progress opened by a replayed running state", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-hydration-progress-successor-"));
+  const agentId = "00000000-0000-4000-8000-000000000164";
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const epochs = ["initial-progress-epoch", "first-progress-epoch", "successor-progress-epoch"];
+  const durableTimelineStore = new FileAgentTimelineStore(join(workdir, "timelines"), logger, {
+    epochFactory: () => epochs.shift() ?? "unexpected-progress-epoch",
+  });
+  let session: TestAgentSession | null = null;
+  let historyGeneration = 0;
+
+  class SuccessorProgressHistorySession extends TestAgentSession {
+    override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+      historyGeneration += 1;
+      yield* [];
+    }
+  }
+
+  class SuccessorProgressHistoryClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new SuccessorProgressHistorySession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new SuccessorProgressHistoryClient() },
+    registry: storage,
+    durableTimelineStore,
+    logger,
+    idFactory: () => agentId,
+  });
+
+  try {
+    const created = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const turnId = "accepted-live-turn";
+    let successorHydration: Promise<void> | null = null;
+    manager.subscribe(
+      (event) => {
+        if (
+          successorHydration === null &&
+          event.type === "agent_state" &&
+          event.agent.lifecycle === "running"
+        ) {
+          successorHydration = manager.hydrateTimelineFromProvider(created.id, { force: true });
+        }
+      },
+      { agentId: created.id, replayState: false },
+    );
+
+    const firstHydration = manager.hydrateTimelineFromProvider(created.id, { force: true });
+    session!.pushEvent({ type: "turn_started", provider: "codex", turnId });
+    session!.pushEvent({
+      type: "timeline",
+      provider: "codex",
+      turnId,
+      item: {
+        type: "tool_call",
+        callId: "write-replayed-behind-successor",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "proof.txt", content: "durable successor proof" },
+      },
+    });
+    session!.pushEvent({
+      type: "usage_updated",
+      provider: "codex",
+      turnId,
+      usage: { inputTokens: 1 },
+    });
+
+    await firstHydration;
+    await successorHydration;
+    await manager.flush();
+
+    expect(historyGeneration).toBe(2);
+    expect(manager.getMaterialProgress(created.id)).toMatchObject({
+      state: "progressing",
+      timelineEpoch: "successor-progress-epoch",
+      continuationBoundarySeq: 1,
+      observedThroughSeq: 1,
+      lastMaterialProgressKind: "write",
+    });
+    await expect(durableTimelineStore.getCommittedRows(agentId)).resolves.toMatchObject([
+      {
+        seq: 1,
+        turnId,
+        item: { type: "tool_call", callId: "write-replayed-behind-successor" },
+      },
+    ]);
+    expect((await storage.get(agentId))?.materialProgress).toMatchObject({
+      timelineEpoch: "successor-progress-epoch",
+      continuationBoundarySeq: 1,
+      acceptedTurnId: turnId,
+      observedThroughSeq: 1,
+      lastMaterialProgressKind: "write",
+    });
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("reloadAgentSession preserves current title when config title is unset", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-title-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -18,6 +18,7 @@ import { toAgentPayload } from "./agent-projections.js";
 import { PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 import { formatSystemNotificationPrompt, startAgentRun } from "./agent-prompt.js";
 import { ensureAgentLoaded, ensureUnarchivedAgentLoaded } from "./agent-loading.js";
+import { FileAgentTimelineStore } from "./file-agent-timeline-store.js";
 import type { StoredAgentRecord } from "./agent-storage.js";
 import type {
   AgentClient,
@@ -2947,6 +2948,110 @@ test("ordinary reload preserves material progress while disk rehydration mints a
   } finally {
     await manager.flush().catch(() => undefined);
     await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("material progress restores only with the exact durable timeline incarnation across restart", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-material-progress-restart-"));
+  const agentStoragePath = join(workdir, "agents");
+  const timelineStoragePath = join(workdir, "timelines");
+  const agentId = "00000000-0000-4000-8000-000000000134";
+
+  class ReplacementHistoryClient extends TestAgentClient {
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      return new (class extends TestAgentSession {
+        override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+          yield {
+            type: "timeline",
+            provider: this.provider,
+            item: { type: "user_message", text: "longer replacement history" },
+          };
+          yield {
+            type: "timeline",
+            provider: this.provider,
+            item: { type: "assistant_message", text: "replacement result" },
+          };
+        }
+      })({ provider: "codex", cwd: config?.cwd ?? workdir });
+    }
+  }
+
+  const createManager = (storage: AgentStorage) =>
+    new AgentManager({
+      clients: { codex: new ReplacementHistoryClient() },
+      registry: storage,
+      durableTimelineStore: new FileAgentTimelineStore(timelineStoragePath, logger),
+      logger,
+      idFactory: () => agentId,
+    });
+
+  try {
+    const firstStorage = new AgentStorage(agentStoragePath, logger);
+    const firstManager = createManager(firstStorage);
+    const created = await firstManager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    await firstManager.runAgent(created.id, "accepted durable continuation");
+    await firstManager.appendTimelineItem(created.id, {
+      type: "tool_call",
+      callId: "write-before-restart",
+      name: "write",
+      status: "completed",
+      error: null,
+      detail: { type: "write", filePath: "proof.txt", content: "durable proof" },
+    });
+    await firstManager.flush();
+    const beforeRestart = firstManager.getMaterialProgress(created.id);
+    expect(beforeRestart).toMatchObject({
+      state: "progressing",
+      continuationBoundarySeq: 1,
+      observedThroughSeq: 1,
+      lastMaterialProgressKind: "write",
+    });
+    await firstManager.closeAgent(created.id);
+    await firstManager.flush();
+
+    const restartedStorage = new AgentStorage(agentStoragePath, logger);
+    const restartedManager = createManager(restartedStorage);
+    await ensureAgentLoaded(created.id, {
+      agentManager: restartedManager,
+      agentStorage: restartedStorage,
+      logger,
+    });
+    expect(restartedManager.getMaterialProgress(created.id)).toEqual(beforeRestart);
+
+    await restartedManager.reloadAgentSession(created.id, undefined, {
+      rehydrateFromDisk: true,
+    });
+    await restartedManager.hydrateTimelineFromProvider(created.id);
+    await restartedManager.flush();
+    const afterReplacement = restartedManager.getMaterialProgress(created.id);
+    expect(afterReplacement).toMatchObject({
+      state: "none",
+      continuationBoundarySeq: null,
+      observedThroughSeq: 2,
+      lastMaterialProgressKind: null,
+    });
+    expect(afterReplacement.timelineEpoch).not.toBe(beforeRestart.timelineEpoch);
+    expect(restartedManager.getTimeline(created.id)).toHaveLength(2);
+    await restartedManager.closeAgent(created.id);
+    await restartedManager.flush();
+
+    const replacementRestartStorage = new AgentStorage(agentStoragePath, logger);
+    const replacementRestartManager = createManager(replacementRestartStorage);
+    await ensureAgentLoaded(created.id, {
+      agentManager: replacementRestartManager,
+      agentStorage: replacementRestartStorage,
+      logger,
+    });
+    expect(replacementRestartManager.getMaterialProgress(created.id)).toEqual(afterReplacement);
+    await replacementRestartManager.closeAgent(created.id);
+    await replacementRestartManager.flush();
+  } finally {
     rmSync(workdir, { recursive: true, force: true });
   }
 });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -76,9 +76,10 @@ import {
 import {
   advanceMaterialProgressCheckpoint,
   createMaterialProgressCheckpoint,
+  invalidateMaterialProgressCheckpoint,
   materialProgressPayload,
   openMaterialProgressContinuation,
-  rebindMaterialProgressCheckpoint,
+  restoreMaterialProgressCheckpoint,
   settleMaterialProgressContinuation,
   type MaterialProgressCheckpoint,
   type MaterialProgressTurnOutcome,
@@ -110,12 +111,12 @@ function submittedPromptText(prompt: AgentPromptInput): string {
     .trim();
 }
 
-function restoreMaterialProgressCheckpoint(
+function restoreAgentMaterialProgressCheckpoint(
   checkpoint: MaterialProgressCheckpoint | undefined,
   timeline: { epoch: string; nextSeq: number },
 ): MaterialProgressCheckpoint {
   if (checkpoint) {
-    return rebindMaterialProgressCheckpoint(checkpoint, {
+    return restoreMaterialProgressCheckpoint(checkpoint, {
       timelineEpoch: timeline.epoch,
       nextSeq: timeline.nextSeq,
     });
@@ -2243,12 +2244,18 @@ export class AgentManager {
     });
   }
 
-  private resetMaterialProgress(agent: ActiveManagedAgent): void {
+  private resetMaterialProgress(agent: ActiveManagedAgent, unavailableReason?: string): void {
     const timeline = this.timelineStore.fetch(agent.id, { direction: "tail", limit: 1 });
-    agent.materialProgress = createMaterialProgressCheckpoint({
-      timelineEpoch: timeline.epoch,
-      nextSeq: timeline.window.nextSeq,
-    });
+    agent.materialProgress = unavailableReason
+      ? invalidateMaterialProgressCheckpoint({
+          timelineEpoch: timeline.epoch,
+          nextSeq: timeline.window.nextSeq,
+          reason: unavailableReason,
+        })
+      : createMaterialProgressCheckpoint({
+          timelineEpoch: timeline.epoch,
+          nextSeq: timeline.window.nextSeq,
+        });
   }
 
   private applyActiveTurnTerminal(
@@ -2576,6 +2583,12 @@ export class AgentManager {
         "agent.rewind.start",
       );
       await invokeRewindCapability(agent.session, { messageId: providerMessageId, mode });
+      this.resetMaterialProgress(
+        agent,
+        "Material progress is unavailable because the provider session was rewound.",
+      );
+      await this.persistSnapshot(agent);
+      this.emitState(agent, { persist: false });
       if (mode !== "files") {
         await this.hydrateTimelineFromProvider(agentId, { force: true, broadcast: true });
       }
@@ -3015,7 +3028,7 @@ export class AgentManager {
   }): ActiveManagedAgent {
     const { resolvedAgentId, session, config, now, durableTimelineHasRows, options } = params;
     const timeline = this.timelineStore.fetch(resolvedAgentId, { direction: "tail", limit: 1 });
-    const materialProgress = restoreMaterialProgressCheckpoint(options?.materialProgress, {
+    const materialProgress = restoreAgentMaterialProgressCheckpoint(options?.materialProgress, {
       epoch: timeline.epoch,
       nextSeq: timeline.window.nextSeq,
     });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2318,6 +2318,41 @@ export class AgentManager {
         });
   }
 
+  private materialProgressAfterTimelineReplacement(
+    agent: ActiveManagedAgent,
+    replacementRows: readonly AgentTimelineRow[],
+    timelineEpoch: string,
+  ): MaterialProgressCheckpoint {
+    // A replacement normally invalidates the prior checkpoint. The exception is a still-active
+    // accepted turn whose rows can be re-evaluated against the replacement before buffered writes
+    // resume; rewinds and settled/unavailable checkpoints deliberately take the reset path.
+    const checkpoint = agent.materialProgress;
+    const currentTimelineEpoch = this.timelineStore.getEpoch(agent.id);
+    const nextSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
+    const acceptedTurnId = checkpoint.acceptedTurnId;
+    if (
+      acceptedTurnId === null ||
+      checkpoint.continuationBoundarySeq === null ||
+      checkpoint.turnOutcome !== null ||
+      checkpoint.unavailableReason !== undefined ||
+      checkpoint.timelineEpoch !== currentTimelineEpoch ||
+      agent.activeTurnId !== acceptedTurnId
+    ) {
+      return createMaterialProgressCheckpoint({ timelineEpoch, nextSeq });
+    }
+
+    const firstAcceptedTurnRow = replacementRows.find((row) => row.turnId === acceptedTurnId);
+    let rebound = openMaterialProgressContinuation({
+      timelineEpoch,
+      boundarySeq: firstAcceptedTurnRow?.seq ?? nextSeq,
+      turnId: acceptedTurnId,
+    });
+    for (const row of replacementRows) {
+      rebound = advanceMaterialProgressCheckpoint(rebound, row, timelineEpoch);
+    }
+    return rebound;
+  }
+
   private applyActiveTurnTerminal(
     agent: ActiveManagedAgent,
     turnId?: string,
@@ -3584,6 +3619,11 @@ export class AgentManager {
       await this.markHistoryHydrationUnprimed(agent);
       throw error;
     }
+    const materialProgress = this.materialProgressAfterTimelineReplacement(
+      agent,
+      replacementRows,
+      epoch,
+    );
     this.timelineStore.initialize(agent.id, {
       epoch,
       rows: replacementRows,
@@ -3593,7 +3633,7 @@ export class AgentManager {
     activeHydration.carriedLiveTimelineRows = carriedRows;
     activeHydration.nextUncapturedTimelineSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
     activeHydration.lastProviderHistoryItems = historyRows.map((row) => structuredClone(row.item));
-    this.resetMaterialProgress(agent);
+    agent.materialProgress = materialProgress;
     agent.historyPrimed = true;
 
     this.replaceProviderSubagentHistory(
@@ -3725,6 +3765,12 @@ export class AgentManager {
       throw error;
     }
 
+    const materialProgress = this.materialProgressAfterTimelineReplacement(
+      agent,
+      replacementRows,
+      epoch,
+    );
+
     this.timelineStore.initialize(agent.id, {
       epoch,
       rows: replacementRows,
@@ -3732,7 +3778,7 @@ export class AgentManager {
       timestamp: new Date().toISOString(),
     });
     activeHydration.nextUncapturedTimelineSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
-    this.resetMaterialProgress(agent);
+    agent.materialProgress = materialProgress;
     agent.historyPrimed = true;
     await this.persistSnapshot(agent);
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2983,17 +2983,19 @@ export class AgentManager {
     const { agentId, now, options } = params;
     const timelineAlreadyPrimed = this.timelineStore.has(agentId);
     const explicitTimelineSeed = buildExplicitTimelineSeedForRegister(now, options);
-    const shouldSeedFromDurable =
-      !explicitTimelineSeed &&
-      !this.timelineStore.has(agentId) &&
-      this.durableTimelineStore !== undefined;
+    const shouldSeedFromDurable = !timelineAlreadyPrimed && this.durableTimelineStore !== undefined;
     const durableTimelineSeed = shouldSeedFromDurable
       ? await this.loadCommittedTimelineSeed(agentId, now)
       : null;
     const durableTimelineHasRows =
       timelineAlreadyPrimed ||
       (durableTimelineSeed != null && (durableTimelineSeed.nextSeq ?? 1) > 1);
-    const timelineSeed = explicitTimelineSeed ?? durableTimelineSeed;
+    const timelineSeed = explicitTimelineSeed
+      ? {
+          ...explicitTimelineSeed,
+          ...(durableTimelineSeed ? { epoch: durableTimelineSeed.epoch } : {}),
+        }
+      : durableTimelineSeed;
     if (timelineSeed || !this.timelineStore.has(agentId)) {
       this.timelineStore.initialize(agentId, timelineSeed ?? { timestamp: now.toISOString() });
     }
@@ -3092,8 +3094,11 @@ export class AgentManager {
       return { timestamp: now.toISOString() };
     }
 
+    const committed = await this.durableTimelineStore.fetchCommitted(agentId, { limit: 0 });
     return {
-      nextSeq: (await this.durableTimelineStore.getLatestCommittedSeq(agentId)) + 1,
+      epoch: committed.epoch,
+      rows: committed.rows,
+      nextSeq: committed.window.nextSeq,
       timestamp: now.toISOString(),
     };
   }
@@ -3407,7 +3412,10 @@ export class AgentManager {
     this.agentStreamCoalescer.flushAndDiscard(agent.id);
     await this.deleteCommittedTimeline(agent.id);
     this.timelineStore.delete(agent.id);
-    this.timelineStore.initialize(agent.id, { timestamp: new Date().toISOString() });
+    this.timelineStore.initialize(
+      agent.id,
+      await this.loadCommittedTimelineSeed(agent.id, new Date()),
+    );
     this.resetMaterialProgress(agent);
     agent.historyPrimed = true;
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -73,6 +73,16 @@ import {
   type ProviderSubagentDescriptor,
   type ProviderSubagentStoreEvent,
 } from "./provider-subagents/store.js";
+import {
+  advanceMaterialProgressCheckpoint,
+  createMaterialProgressCheckpoint,
+  materialProgressPayload,
+  openMaterialProgressContinuation,
+  rebindMaterialProgressCheckpoint,
+  settleMaterialProgressContinuation,
+  type MaterialProgressCheckpoint,
+  type MaterialProgressTurnOutcome,
+} from "./material-progress.js";
 
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
@@ -98,6 +108,22 @@ function submittedPromptText(prompt: AgentPromptInput): string {
     .flatMap((block) => (block.type === "text" && !("mimeType" in block) ? [block.text] : []))
     .join("\n")
     .trim();
+}
+
+function restoreMaterialProgressCheckpoint(
+  checkpoint: MaterialProgressCheckpoint | undefined,
+  timeline: { epoch: string; nextSeq: number },
+): MaterialProgressCheckpoint {
+  if (checkpoint) {
+    return rebindMaterialProgressCheckpoint(checkpoint, {
+      timelineEpoch: timeline.epoch,
+      nextSeq: timeline.nextSeq,
+    });
+  }
+  return createMaterialProgressCheckpoint({
+    timelineEpoch: timeline.epoch,
+    nextSeq: timeline.nextSeq,
+  });
 }
 
 export class AgentManagerShuttingDownError extends Error {
@@ -343,6 +369,7 @@ interface ManagedAgentBase {
   lastUserMessageAt: Date | null;
   activeTurnId: string | null;
   activeTurnStartedAt: Date | null;
+  materialProgress: MaterialProgressCheckpoint;
   lastUsage?: AgentUsage;
   lastError?: string;
   attention: AttentionState;
@@ -1017,6 +1044,10 @@ export class AgentManager {
     return this.timelineStore.getRows(id);
   }
 
+  getMaterialProgress(id: string) {
+    return materialProgressPayload(this.requireAgent(id).materialProgress);
+  }
+
   fetchTimeline(id: string, options?: AgentTimelineFetchOptions): AgentTimelineFetchResult {
     this.requireAgent(id);
     return this.timelineStore.fetch(id, options);
@@ -1107,6 +1138,7 @@ export class AgentManager {
       labels?: Record<string, string>;
       workspaceId?: string;
       owner?: AgentOwner;
+      materialProgress?: MaterialProgressCheckpoint;
     },
     resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
@@ -1126,6 +1158,7 @@ export class AgentManager {
       labels?: Record<string, string>;
       workspaceId?: string;
       owner?: AgentOwner;
+      materialProgress?: MaterialProgressCheckpoint;
     },
     resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
@@ -1270,6 +1303,7 @@ export class AgentManager {
     const preservedHistoryPrimed = existing.historyPrimed;
     const preservedLastUsage = existing.lastUsage;
     const preservedLastError = existing.lastError;
+    const preservedMaterialProgress = existing.materialProgress;
     const preservedAttention = existing.attention;
     const handle = existing.persistence;
     const provider = handle?.provider ?? existing.provider;
@@ -1321,6 +1355,7 @@ export class AgentManager {
         historyPrimed: rehydrateFromDisk ? false : preservedHistoryPrimed,
         lastUsage: preservedLastUsage,
         lastError: preservedLastError,
+        materialProgress: rehydrateFromDisk ? undefined : preservedMaterialProgress,
         attention: preservedAttention,
       });
     } finally {
@@ -1579,6 +1614,9 @@ export class AgentManager {
         lastUserMessageAt: record.lastUserMessageAt ? new Date(record.lastUserMessageAt) : null,
         lastUsage: undefined,
         lastError: record.lastError ?? undefined,
+        materialProgress:
+          record.materialProgress ??
+          createMaterialProgressCheckpoint({ timelineEpoch: "stored", nextSeq: 1 }),
         attention: { requiresAttention: false },
         internal: record.internal,
         labels: record.labels,
@@ -2060,6 +2098,7 @@ export class AgentManager {
       pendingRun.turnId = turnId;
       agent.activeForegroundTurnId = turnId;
       this.openActiveTurn(agent, turnId, turnStartedAt);
+      this.openMaterialProgressContinuation(agent, turnId);
       agent.lifecycle = "running";
       this.touchUpdatedAt(agent);
       // AgentManager owns the accepted-turn boundary. Publish liveness before the canonical
@@ -2182,6 +2221,34 @@ export class AgentManager {
   private openActiveTurn(agent: ActiveManagedAgent, turnId: string, startedAt: Date): void {
     agent.activeTurnId = turnId;
     agent.activeTurnStartedAt = startedAt;
+  }
+
+  private openMaterialProgressContinuation(agent: ActiveManagedAgent, turnId: string): void {
+    const timeline = this.timelineStore.fetch(agent.id, { direction: "tail", limit: 1 });
+    agent.materialProgress = openMaterialProgressContinuation({
+      timelineEpoch: timeline.epoch,
+      boundarySeq: timeline.window.nextSeq,
+      turnId,
+    });
+  }
+
+  private settleMaterialProgress(
+    agent: ActiveManagedAgent,
+    turnId: string,
+    outcome: MaterialProgressTurnOutcome,
+  ): void {
+    agent.materialProgress = settleMaterialProgressContinuation(agent.materialProgress, {
+      turnId,
+      outcome,
+    });
+  }
+
+  private resetMaterialProgress(agent: ActiveManagedAgent): void {
+    const timeline = this.timelineStore.fetch(agent.id, { direction: "tail", limit: 1 });
+    agent.materialProgress = createMaterialProgressCheckpoint({
+      timelineEpoch: timeline.epoch,
+      nextSeq: timeline.window.nextSeq,
+    });
   }
 
   private applyActiveTurnTerminal(
@@ -2796,6 +2863,7 @@ export class AgentManager {
       historyPrimed?: boolean;
       lastUsage?: AgentUsage;
       lastError?: string;
+      materialProgress?: MaterialProgressCheckpoint;
       attention?: AttentionState;
       initialTitle?: string | null;
       publishWhenReady?: boolean;
@@ -2835,6 +2903,7 @@ export class AgentManager {
       this.assertAcceptingAgentRegistrations();
       this.agents.set(resolvedAgentId, managed);
       registered = true;
+      await this.catchUpMaterialProgress(managed);
       // Initialize previousStatus to track transitions
       this.previousStatuses.set(resolvedAgentId, managed.lifecycle);
       await this.refreshRuntimeInfo(managed, { emit: false });
@@ -2936,6 +3005,7 @@ export class AgentManager {
           historyPrimed?: boolean;
           lastUsage?: AgentUsage;
           lastError?: string;
+          materialProgress?: MaterialProgressCheckpoint;
           attention?: AttentionState;
           persistence?: AgentPersistenceHandle;
           workspaceId?: string;
@@ -2944,6 +3014,11 @@ export class AgentManager {
       | undefined;
   }): ActiveManagedAgent {
     const { resolvedAgentId, session, config, now, durableTimelineHasRows, options } = params;
+    const timeline = this.timelineStore.fetch(resolvedAgentId, { direction: "tail", limit: 1 });
+    const materialProgress = restoreMaterialProgressCheckpoint(options?.materialProgress, {
+      epoch: timeline.epoch,
+      nextSeq: timeline.window.nextSeq,
+    });
     return {
       id: resolvedAgentId,
       provider: config.provider,
@@ -2966,6 +3041,7 @@ export class AgentManager {
       activeForegroundTurnId: null,
       activeTurnId: null,
       activeTurnStartedAt: null,
+      materialProgress,
       foregroundTurnWaiters: new Set<ForegroundTurnWaiter>(),
       finalizedForegroundTurnIds: new Set<string>(),
       unsubscribeSession: null,
@@ -2981,6 +3057,18 @@ export class AgentManager {
       internal: config.internal ?? false,
       labels: options?.labels ?? {},
     } as ActiveManagedAgent;
+  }
+
+  private async catchUpMaterialProgress(agent: ActiveManagedAgent): Promise<void> {
+    const rows = await this.getTimelineRows(agent.id);
+    const timelineEpoch = this.timelineStore.getEpoch(agent.id);
+    for (const row of rows.toSorted((left, right) => left.seq - right.seq)) {
+      agent.materialProgress = advanceMaterialProgressCheckpoint(
+        agent.materialProgress,
+        row,
+        timelineEpoch,
+      );
+    }
   }
 
   private async loadCommittedTimelineSeed(
@@ -3307,6 +3395,7 @@ export class AgentManager {
     await this.deleteCommittedTimeline(agent.id);
     this.timelineStore.delete(agent.id);
     this.timelineStore.initialize(agent.id, { timestamp: new Date().toISOString() });
+    this.resetMaterialProgress(agent);
     agent.historyPrimed = true;
 
     for (const event of this.providerSubagents.deleteParent(agent.id)) {
@@ -3727,6 +3816,9 @@ export class AgentManager {
       "agent.manager.turn.completed",
     );
     if (terminalDisposition === "stale") return;
+    if (terminalDisposition === "closed_current" && eventTurnId) {
+      this.settleMaterialProgress(agent, eventTurnId, "completed");
+    }
     if (event.usage) {
       agent.lastUsage = { ...agent.lastUsage, ...event.usage };
     }
@@ -3771,6 +3863,9 @@ export class AgentManager {
       "handleStreamEvent: turn_failed",
     );
     if (terminalDisposition === "stale") return;
+    if (terminalDisposition === "closed_current" && eventTurnId) {
+      this.settleMaterialProgress(agent, eventTurnId, "failed");
+    }
     if (!isForegroundEvent && !agent.activeForegroundTurnId) {
       agent.lifecycle = "error";
     }
@@ -3813,6 +3908,9 @@ export class AgentManager {
       "agent.manager.turn.canceled",
     );
     if (terminalDisposition === "stale") return;
+    if (terminalDisposition === "closed_current" && eventTurnId) {
+      this.settleMaterialProgress(agent, eventTurnId, "canceled");
+    }
     if (!isForegroundEvent && !agent.activeForegroundTurnId && !agent.pendingReplacement) {
       agent.lifecycle = "idle";
     }
@@ -3854,6 +3952,7 @@ export class AgentManager {
     this.runs.trackAutonomousRun(agent.id, eventTurnId ?? null);
     if (eventTurnId) {
       this.openActiveTurn(agent, eventTurnId, new Date());
+      this.openMaterialProgressContinuation(agent, eventTurnId);
     }
     agent.lifecycle = "running";
     this.emitState(agent);
@@ -4041,6 +4140,14 @@ export class AgentManager {
   ): AgentTimelineRow {
     item = limitAgentTimelineItemContent(item);
     const row = this.timelineStore.append(agentId, item, options);
+    const agent = this.agents.get(agentId);
+    if (agent) {
+      agent.materialProgress = advanceMaterialProgressCheckpoint(
+        agent.materialProgress,
+        row,
+        this.timelineStore.getEpoch(agentId),
+      );
+    }
     this.enqueueDurableTimelineAppend(agentId, row);
     return row;
   }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { stat } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 import {
   AGENT_LIFECYCLE_STATUSES,
   type AgentLifecycleStatus,
@@ -71,6 +72,7 @@ import type { PaseoToolCatalogFactory } from "./tools/types.js";
 import {
   ProviderSubagentStore,
   type ProviderSubagentDescriptor,
+  type ProviderSubagentInputEvent,
   type ProviderSubagentStoreEvent,
 } from "./provider-subagents/store.js";
 import {
@@ -347,11 +349,23 @@ interface ActiveHistoryHydration {
   preGateSessionEventTokens: Set<symbol>;
   preGateBufferedOperations: BufferedHistoryHydrationOperation[];
   bufferedOperations: BufferedHistoryHydrationOperation[];
+  nextUncapturedTimelineSeq: number;
+  carriedLiveTimelineRows: AgentTimelineRow[];
+  lastProviderHistoryItems: AgentTimelineItem[];
+  carriedProviderSubagentEvents: Array<{
+    provider: AgentProvider;
+    event: ProviderSubagentInputEvent;
+  }>;
+  lastProviderSubagentHistory: Array<{
+    provider: AgentProvider;
+    event: ProviderSubagentInputEvent;
+  }>;
 }
 
 interface BufferedHistoryHydrationOperation {
-  kind: "session_event" | "timeline_writer";
+  kind: "session_event" | "timeline_writer" | "provider_subagent";
   run: () => Promise<void>;
+  providerSubagentEvent?: { provider: AgentProvider; event: ProviderSubagentInputEvent };
   resolve?: () => void;
   reject?: (error: unknown) => void;
 }
@@ -1316,10 +1330,9 @@ export class AgentManager {
 
   // Hot-reload an active agent session with config overrides. By default the
   // in-memory timeline is preserved (used for voice-mode toggles and similar
-  // config swaps). When `rehydrateFromDisk` is set, the timeline is wiped so a
-  // new epoch is minted and provider history is re-streamed — this is what the
-  // user-facing "Reload agent" action wants when the on-disk session was
-  // mutated outside Paseo.
+  // config swaps). When `rehydrateFromDisk` is set, provider history is marked
+  // unprimed so the caller can stage and atomically replace the timeline. The
+  // last complete timeline remains readable until that replacement commits.
   reloadAgentSession(
     agentId: string,
     overrides?: Partial<AgentSessionConfig>,
@@ -1374,18 +1387,9 @@ export class AgentManager {
         await this.closeReloadedSession(existing.session, agentId);
       }
 
-      if (rehydrateFromDisk) {
-        // Wipe both durable and in-memory timeline so registerSession mints a
-        // new epoch and hydrateTimelineFromProvider re-streams the freshly read
-        // provider history into an empty timeline.
-        await this.deleteCommittedTimeline(agentId);
-        this.timelineStore.delete(agentId);
-        for (const event of this.providerSubagents.deleteParent(agentId)) {
-          this.dispatch({ type: "provider_subagent", event });
-        }
-      }
-
       // Preserve existing labels and timeline during reload.
+      // A disk refresh keeps the last complete timeline, material checkpoint,
+      // and child projection until its caller atomically installs provider history.
       handedToRegistration = true;
       return this.registerSession(session, storedConfig, agentId, {
         labels: existing.labels,
@@ -1397,7 +1401,7 @@ export class AgentManager {
         historyPrimed: rehydrateFromDisk ? false : preservedHistoryPrimed,
         lastUsage: preservedLastUsage,
         lastError: preservedLastError,
-        materialProgress: rehydrateFromDisk ? undefined : preservedMaterialProgress,
+        materialProgress: preservedMaterialProgress,
         attention: preservedAttention,
       });
     } finally {
@@ -2662,7 +2666,11 @@ export class AgentManager {
       await this.drainSessionEvents(agentId);
       this.flushPreGateCoalescedTimelineItems(agentId, hydrationToken);
       const agent = this.requireSessionAgent(agentId);
-      await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
+      const activeHydration = this.activeHistoryHydrations.get(agentId);
+      if (!activeHydration || activeHydration.token !== hydrationToken) {
+        throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+      }
+      await this.hydrateTimelineFromLegacyProviderHistory(agent, options, activeHydration);
     } finally {
       if (ownsLatestTail()) {
         await this.releaseHistoryHydration(agentId, hydrationToken, ownsLatestTail);
@@ -2779,26 +2787,12 @@ export class AgentManager {
 
   private async getLastAssistantMessageFromStores(agentId: string): Promise<string | null> {
     const liveTimeline = this.timelineStore.getItems(agentId);
-    const liveSegment = this.getLastAssistantMessageSegmentFromTimeline(liveTimeline);
-    if (!this.durableTimelineStore) {
-      return liveSegment?.text ?? null;
+    const liveMessage = this.getLastAssistantMessageFromTimeline(liveTimeline);
+    if (liveMessage !== null || !this.durableTimelineStore) {
+      return liveMessage;
     }
 
-    if (!liveSegment) {
-      return await this.durableTimelineStore.getLastAssistantMessage(agentId);
-    }
-
-    if (!liveSegment.startsAtBeginning) {
-      return liveSegment.text;
-    }
-
-    const lastDurableItem = await this.durableTimelineStore.getLastItem(agentId);
-    if (lastDurableItem?.type !== "assistant_message") {
-      return liveSegment.text;
-    }
-
-    const durableMessage = await this.durableTimelineStore.getLastAssistantMessage(agentId);
-    return durableMessage ? `${durableMessage}${liveSegment.text}` : liveSegment.text;
+    return await this.durableTimelineStore.getLastAssistantMessage(agentId);
   }
 
   private async getLastItemFromStores(agentId: string): Promise<AgentTimelineItem | null> {
@@ -3374,8 +3368,18 @@ export class AgentManager {
     historyHydrationToken?: symbol,
   ): Promise<void> {
     if (event.type === "provider_subagent") {
-      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-      this.dispatch({ type: "provider_subagent", event: update });
+      await this.runOrBufferHistoryHydrationOperation(
+        agent.id,
+        {
+          kind: "provider_subagent",
+          providerSubagentEvent: { provider: event.provider, event: event.event },
+          run: async () => {
+            const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
+            this.dispatch({ type: "provider_subagent", event: update });
+          },
+        },
+        historyHydrationToken,
+      );
       return;
     }
     const turnId = getAgentStreamEventTurnId(event);
@@ -3513,7 +3517,8 @@ export class AgentManager {
 
   private async hydrateTimelineFromLegacyProviderHistory(
     agent: ActiveManagedAgent,
-    options?: HydrateTimelineOptions,
+    options: HydrateTimelineOptions | undefined,
+    activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
     if (agent.historyPrimed && !options?.force) {
       return;
@@ -3521,20 +3526,25 @@ export class AgentManager {
 
     const broadcast = options?.broadcast ?? false;
 
-    if (options?.force) {
+    // An unprimed agent with existing rows is a staged refresh or retry. It
+    // must replace provider history atomically rather than append it to the
+    // last complete incarnation.
+    if (options?.force || this.timelineStore.getRows(agent.id).length > 0) {
       await this.forceHydrateTimelineFromLegacyProviderHistory(
         agent,
         typeof broadcast === "function" ? broadcast() : broadcast,
+        activeHydration,
       );
       return;
     }
 
-    await this.primeTimelineFromLegacyProviderHistory(agent, broadcast);
+    await this.primeTimelineFromLegacyProviderHistory(agent, broadcast, activeHydration);
   }
 
   private async forceHydrateTimelineFromLegacyProviderHistory(
     agent: ActiveManagedAgent,
     broadcast: boolean,
+    activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
     const historyEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
     const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
@@ -3554,53 +3564,131 @@ export class AgentManager {
       throw error;
     }
 
-    const historyRows = this.buildProviderHistoryRows(historyEvents, 1);
+    let historyRows = this.buildProviderHistoryRows(historyEvents, 1);
+    const merged = this.mergeCarriedLiveTimelineRows(agent.id, activeHydration, historyRows);
+    historyRows = merged.historyRows;
+    const carriedRows = merged.carriedRows;
+    const replacementRows = [...historyRows, ...carriedRows];
+    const incomingProviderSubagentHistory = providerSubagentEvents.map((event) => ({
+      provider: event.provider,
+      event: event.event,
+    }));
+    const carriedProviderSubagentEvents = this.mergeCarriedProviderSubagentEvents(
+      activeHydration,
+      incomingProviderSubagentHistory,
+    );
     let epoch: string;
     try {
-      epoch = await this.replaceCommittedTimeline(agent.id, historyRows);
+      epoch = await this.replaceCommittedTimeline(agent.id, replacementRows);
     } catch (error) {
       await this.markHistoryHydrationUnprimed(agent);
       throw error;
     }
     this.timelineStore.initialize(agent.id, {
       epoch,
-      rows: historyRows,
-      nextSeq: (historyRows.at(-1)?.seq ?? 0) + 1,
+      rows: replacementRows,
+      nextSeq: (replacementRows.at(-1)?.seq ?? 0) + 1,
       timestamp: new Date().toISOString(),
     });
+    activeHydration.carriedLiveTimelineRows = carriedRows;
+    activeHydration.nextUncapturedTimelineSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
+    activeHydration.lastProviderHistoryItems = historyRows.map((row) => structuredClone(row.item));
     this.resetMaterialProgress(agent);
     agent.historyPrimed = true;
 
-    for (const event of this.providerSubagents.deleteParent(agent.id)) {
-      if (broadcast) {
-        this.dispatch({ type: "provider_subagent", event });
-      }
-    }
-    for (const event of providerSubagentEvents) {
-      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-      if (broadcast) {
-        this.dispatch({ type: "provider_subagent", event: update });
-      }
-    }
-    for (let index = 0; index < historyEvents.length; index += 1) {
-      const event = historyEvents[index];
-      const row = historyRows[index];
-      if (broadcast) {
-        this.dispatchStream(agent.id, event, {
-          seq: row.seq,
-          epoch,
-          timestamp: row.timestamp,
-        });
-      }
-    }
+    this.replaceProviderSubagentHistory(
+      agent.id,
+      providerSubagentEvents,
+      carriedProviderSubagentEvents,
+      broadcast,
+    );
+    activeHydration.carriedProviderSubagentEvents = carriedProviderSubagentEvents;
+    activeHydration.lastProviderSubagentHistory = incomingProviderSubagentHistory.map((event) =>
+      structuredClone(event),
+    );
+    this.broadcastHydratedTimeline(
+      agent,
+      historyEvents,
+      historyRows,
+      carriedRows,
+      epoch,
+      broadcast,
+    );
     this.touchUpdatedAt(agent);
     await this.persistSnapshot(agent);
     this.emitState(agent, { persist: false });
   }
 
+  private replaceProviderSubagentHistory(
+    agentId: string,
+    providerSubagentEvents: readonly Extract<AgentStreamEvent, { type: "provider_subagent" }>[],
+    carriedProviderSubagentEvents: readonly {
+      provider: AgentProvider;
+      event: ProviderSubagentInputEvent;
+    }[],
+    broadcast: boolean,
+  ): void {
+    for (const event of this.providerSubagents.deleteParent(agentId)) {
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event });
+      }
+    }
+    for (const event of providerSubagentEvents) {
+      const update = this.providerSubagents.apply(agentId, event.provider, event.event);
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
+    for (const carried of carriedProviderSubagentEvents) {
+      const update = this.providerSubagents.apply(agentId, carried.provider, carried.event);
+      if (broadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
+  }
+
+  private broadcastHydratedTimeline(
+    agent: ActiveManagedAgent,
+    historyEvents: readonly Extract<AgentStreamEvent, { type: "timeline" }>[],
+    historyRows: readonly AgentTimelineRow[],
+    carriedRows: readonly AgentTimelineRow[],
+    epoch: string,
+    broadcast: boolean,
+  ): void {
+    if (!broadcast) {
+      return;
+    }
+    for (let index = 0; index < historyEvents.length; index += 1) {
+      const event = historyEvents[index];
+      const row = historyRows[index];
+      this.dispatchStream(agent.id, event, {
+        seq: row.seq,
+        epoch,
+        timestamp: row.timestamp,
+      });
+    }
+    for (const row of carriedRows) {
+      this.dispatchStream(
+        agent.id,
+        {
+          type: "timeline",
+          provider: agent.provider,
+          item: row.item,
+          ...(row.turnId ? { turnId: row.turnId } : {}),
+        },
+        {
+          seq: row.seq,
+          epoch,
+          timestamp: row.timestamp,
+        },
+      );
+    }
+  }
+
   private async primeTimelineFromLegacyProviderHistory(
     agent: ActiveManagedAgent,
     broadcast: boolean | (() => boolean),
+    activeHydration: ActiveHistoryHydration,
   ): Promise<void> {
     const timelineEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
     const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
@@ -3623,10 +3711,15 @@ export class AgentManager {
       return;
     }
 
-    const historyRows = this.buildProviderHistoryRows(timelineEvents, 1);
+    const existingRows = this.timelineStore.getRows(agent.id);
+    const historyRows = this.buildProviderHistoryRows(
+      timelineEvents,
+      (existingRows.at(-1)?.seq ?? 0) + 1,
+    );
+    const replacementRows = [...existingRows, ...historyRows];
     let epoch: string;
     try {
-      epoch = await this.replaceCommittedTimeline(agent.id, historyRows);
+      epoch = await this.replaceCommittedTimeline(agent.id, replacementRows);
     } catch (error) {
       await this.markHistoryHydrationUnprimed(agent);
       throw error;
@@ -3634,10 +3727,11 @@ export class AgentManager {
 
     this.timelineStore.initialize(agent.id, {
       epoch,
-      rows: historyRows,
-      nextSeq: (historyRows.at(-1)?.seq ?? 0) + 1,
+      rows: replacementRows,
+      nextSeq: (replacementRows.at(-1)?.seq ?? 0) + 1,
       timestamp: new Date().toISOString(),
     });
+    activeHydration.nextUncapturedTimelineSeq = (replacementRows.at(-1)?.seq ?? 0) + 1;
     this.resetMaterialProgress(agent);
     agent.historyPrimed = true;
     await this.persistSnapshot(agent);
@@ -3684,11 +3778,117 @@ export class AgentManager {
     });
   }
 
+  private mergeCarriedLiveTimelineRows(
+    agentId: string,
+    activeHydration: ActiveHistoryHydration,
+    incomingHistoryRows: AgentTimelineRow[],
+  ): { historyRows: AgentTimelineRow[]; carriedRows: AgentTimelineRow[] } {
+    const currentRows = this.timelineStore.getRows(agentId);
+    const newlyAppliedRows = currentRows.filter(
+      (row) => row.seq >= activeHydration.nextUncapturedTimelineSeq,
+    );
+    const candidateCarriedRows = [
+      ...activeHydration.carriedLiveTimelineRows,
+      ...newlyAppliedRows.map((row) => structuredClone(row)),
+    ];
+
+    const acknowledgedProviderMessages = new Map<
+      string,
+      { providerMessageId: string; turnId?: string }
+    >();
+    for (const row of currentRows) {
+      if (row.item.type === "user_message" && row.item.clientMessageId && row.providerMessageId) {
+        acknowledgedProviderMessages.set(row.item.clientMessageId, {
+          providerMessageId: row.providerMessageId,
+          ...(row.turnId ? { turnId: row.turnId } : {}),
+        });
+      }
+    }
+    const historyRows = incomingHistoryRows.map((row) => {
+      if (row.item.type !== "user_message" || !row.item.clientMessageId) {
+        return row;
+      }
+      const acknowledged = acknowledgedProviderMessages.get(row.item.clientMessageId);
+      if (!acknowledged) {
+        return row;
+      }
+      return {
+        ...row,
+        providerMessageId: acknowledged.providerMessageId,
+        ...(!row.turnId && acknowledged.turnId ? { turnId: acknowledged.turnId } : {}),
+      };
+    });
+
+    const priorHistoryItems = activeHydration.lastProviderHistoryItems;
+    const hasPriorHistoryPrefix =
+      priorHistoryItems.length <= historyRows.length &&
+      priorHistoryItems.every((item, index) => isDeepStrictEqual(item, historyRows[index]?.item));
+    let historySearchIndex = hasPriorHistoryPrefix ? priorHistoryItems.length : 0;
+    const unmatchedCarriedRows: AgentTimelineRow[] = [];
+    for (const carriedRow of candidateCarriedRows) {
+      const matchingHistoryIndex = historyRows.findIndex(
+        (row, index) => index >= historySearchIndex && isDeepStrictEqual(row.item, carriedRow.item),
+      );
+      if (matchingHistoryIndex < 0) {
+        unmatchedCarriedRows.push(carriedRow);
+        continue;
+      }
+      historySearchIndex = matchingHistoryIndex + 1;
+      if (carriedRow.providerMessageId || carriedRow.turnId) {
+        historyRows[matchingHistoryIndex] = {
+          ...historyRows[matchingHistoryIndex],
+          ...(carriedRow.providerMessageId
+            ? { providerMessageId: carriedRow.providerMessageId }
+            : {}),
+          ...(carriedRow.turnId ? { turnId: carriedRow.turnId } : {}),
+        };
+      }
+    }
+    let nextSeq = historyRows.length + 1;
+    const carriedRows: AgentTimelineRow[] = [];
+    for (const row of unmatchedCarriedRows) {
+      const carriedRow = structuredClone(row);
+      carriedRow.seq = nextSeq++;
+      carriedRows.push(carriedRow);
+    }
+    return { historyRows, carriedRows };
+  }
+
+  private mergeCarriedProviderSubagentEvents(
+    activeHydration: ActiveHistoryHydration,
+    incomingHistory: Array<{
+      provider: AgentProvider;
+      event: ProviderSubagentInputEvent;
+    }>,
+  ): Array<{ provider: AgentProvider; event: ProviderSubagentInputEvent }> {
+    const priorHistory = activeHydration.lastProviderSubagentHistory;
+    const hasPriorHistoryPrefix =
+      priorHistory.length <= incomingHistory.length &&
+      priorHistory.every((event, index) => isDeepStrictEqual(event, incomingHistory[index]));
+    let historySearchIndex = hasPriorHistoryPrefix ? priorHistory.length : 0;
+    const unmatchedCarriedEvents: Array<{
+      provider: AgentProvider;
+      event: ProviderSubagentInputEvent;
+    }> = [];
+    for (const carriedEvent of activeHydration.carriedProviderSubagentEvents) {
+      const matchingHistoryIndex = incomingHistory.findIndex(
+        (event, index) => index >= historySearchIndex && isDeepStrictEqual(event, carriedEvent),
+      );
+      if (matchingHistoryIndex < 0) {
+        unmatchedCarriedEvents.push(structuredClone(carriedEvent));
+        continue;
+      }
+      historySearchIndex = matchingHistoryIndex + 1;
+    }
+    return unmatchedCarriedEvents;
+  }
+
   private beginOrContinueHistoryHydration(agentId: string): symbol {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (activeHydration) {
       return activeHydration.token;
     }
+    const currentRows = this.timelineStore.getRows(agentId);
     const token = Symbol(agentId);
     this.activeHistoryHydrations.set(agentId, {
       token,
@@ -3697,6 +3897,11 @@ export class AgentManager {
       preGateSessionEventTokens: new Set(this.sessionEventAdmissionTokens.get(agentId) ?? []),
       preGateBufferedOperations: [],
       bufferedOperations: [],
+      nextUncapturedTimelineSeq: (currentRows.at(-1)?.seq ?? 0) + 1,
+      carriedLiveTimelineRows: [],
+      lastProviderHistoryItems: [],
+      carriedProviderSubagentEvents: [],
+      lastProviderSubagentHistory: [],
     });
     return token;
   }
@@ -3706,6 +3911,9 @@ export class AgentManager {
     token: symbol,
     stillOwnsTail: () => boolean,
   ): Promise<void> {
+    if (!stillOwnsTail()) {
+      return;
+    }
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (!activeHydration || activeHydration.token !== token) {
       throw new Error(`Agent ${agentId} history hydration ownership was lost`);
@@ -3713,6 +3921,11 @@ export class AgentManager {
 
     await this.drainSessionEvents(agentId);
     while (true) {
+      // A successor owns every operation that remains queued. The operation
+      // already in flight is captured from the installed timeline on its pass.
+      if (!stillOwnsTail()) {
+        return;
+      }
       const operation =
         activeHydration.preGateBufferedOperations.shift() ??
         activeHydration.bufferedOperations.shift();
@@ -3722,6 +3935,11 @@ export class AgentManager {
             this.flushCoalescedTimelineItems(agentId, token);
           }
           await operation.run();
+          if (operation.providerSubagentEvent) {
+            activeHydration.carriedProviderSubagentEvents.push(
+              structuredClone(operation.providerSubagentEvent),
+            );
+          }
           operation.resolve?.();
         } catch (err) {
           operation.reject?.(err);
@@ -3740,9 +3958,6 @@ export class AgentManager {
       ) {
         continue;
       }
-      if (!stillOwnsTail()) {
-        return;
-      }
       if (this.activeHistoryHydrations.get(agentId) !== activeHydration) {
         throw new Error(`Agent ${agentId} history hydration ownership was lost`);
       }
@@ -3756,13 +3971,36 @@ export class AgentManager {
     run: () => Promise<void> | void,
     historyHydrationToken?: symbol,
   ): Promise<void> {
+    return this.runOrBufferHistoryHydrationOperation(
+      agentId,
+      { kind: "timeline_writer", run: async () => run() },
+      historyHydrationToken,
+    );
+  }
+
+  private runOrBufferHistoryHydrationOperation(
+    agentId: string,
+    operation: BufferedHistoryHydrationOperation,
+    historyHydrationToken?: symbol,
+  ): Promise<void> {
     const activeHydration = this.activeHistoryHydrations.get(agentId);
     if (!activeHydration || activeHydration.token === historyHydrationToken) {
+      let result: Promise<void>;
       try {
-        return Promise.resolve(run());
+        result = Promise.resolve(operation.run());
       } catch (error) {
         return Promise.reject(error);
       }
+      const providerSubagentEvent = operation.providerSubagentEvent;
+      if (activeHydration && providerSubagentEvent) {
+        return result.then(() => {
+          activeHydration.carriedProviderSubagentEvents.push(
+            structuredClone(providerSubagentEvent),
+          );
+          return undefined;
+        });
+      }
+      return result;
     }
 
     if (
@@ -3770,17 +4008,13 @@ export class AgentManager {
       (historyHydrationToken !== undefined &&
         activeHydration.preGateSessionEventTokens.has(historyHydrationToken))
     ) {
-      activeHydration.preGateBufferedOperations.push({
-        kind: "timeline_writer",
-        run: async () => run(),
-      });
+      activeHydration.preGateBufferedOperations.push(operation);
       return Promise.resolve();
     }
 
     return new Promise<void>((promiseResolve, promiseReject) => {
       activeHydration.bufferedOperations.push({
-        kind: "timeline_writer",
-        run: async () => run(),
+        ...operation,
         resolve: promiseResolve,
         reject: promiseReject,
       });
@@ -4107,11 +4341,19 @@ export class AgentManager {
       return;
     }
 
-    if (
+    const isSubmittedPromptEcho =
       event.item.type === "user_message" &&
       event.item.clientMessageId &&
-      this.reconcileSubmittedPromptEcho(agent, event.item)
-    ) {
+      this.timelineStore.getSubmittedUserMessage(agent.id, event.item.clientMessageId) !== null;
+    if (isSubmittedPromptEcho && event.item.type === "user_message") {
+      const submittedPromptEcho = event.item;
+      await this.runOrBufferTimelineWriter(
+        agent.id,
+        async () => {
+          this.reconcileSubmittedPromptEcho(agent, submittedPromptEcho);
+        },
+        options?.historyHydrationToken,
+      );
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -337,6 +337,23 @@ type ActiveTurnTerminalDisposition = "closed_current" | "stale" | "untracked";
 
 interface HandleStreamEventOptions {
   fromHistory?: boolean;
+  historyHydrationToken?: symbol;
+}
+
+interface ActiveHistoryHydration {
+  token: symbol;
+  preGateCoalescerToken: symbol;
+  preGateCoalescerOpen: boolean;
+  preGateSessionEventTokens: Set<symbol>;
+  preGateBufferedOperations: BufferedHistoryHydrationOperation[];
+  bufferedOperations: BufferedHistoryHydrationOperation[];
+}
+
+interface BufferedHistoryHydrationOperation {
+  kind: "session_event" | "timeline_writer";
+  run: () => Promise<void>;
+  resolve?: () => void;
+  reject?: (error: unknown) => void;
 }
 
 interface ManagedAgentBase {
@@ -637,6 +654,11 @@ export class AgentManager {
   private readonly providerSubagents = new ProviderSubagentStore();
   private readonly agentsAwaitingInitialSnapshotPersist = new Set<string>();
   private readonly sessionEventTails = new Map<string, Promise<void>>();
+  private readonly sessionEventAdmissionTokens = new Map<string, Set<symbol>>();
+  private readonly historyHydrationTails = new Map<string, Promise<void>>();
+  private readonly activeHistoryHydrations = new Map<string, ActiveHistoryHydration>();
+  private readonly coalescerHistoryHydrationTokens = new Map<string, symbol>();
+  private readonly durableTimelineWriteTails = new Map<string, Promise<void>>();
   private readonly runs = new AgentRunState();
   private readonly subscribers = new Set<SubscriptionRecord>();
   private readonly idFactory: () => string;
@@ -680,8 +702,25 @@ export class AgentManager {
       windowMs: options.agentStreamCoalesceWindowMs ?? AGENT_STREAM_COALESCE_DEFAULT_WINDOW_MS,
       timers: { setTimeout, clearTimeout },
       onFlush: ({ agentId, item, provider, turnId }) => {
-        const event = this.recordAndDispatchTimelineItem(agentId, item, provider, turnId);
-        this.notifyForegroundTurnWaiters(agentId, event);
+        const activeHydration = this.activeHistoryHydrations.get(agentId);
+        const historyHydrationToken =
+          this.coalescerHistoryHydrationTokens.get(agentId) ??
+          (activeHydration?.preGateCoalescerOpen
+            ? activeHydration.preGateCoalescerToken
+            : undefined);
+        void this.runOrBufferTimelineWriter(
+          agentId,
+          async () => {
+            const event = this.recordAndDispatchTimelineItem(agentId, item, provider, turnId);
+            this.notifyForegroundTurnWaiters(agentId, event);
+          },
+          historyHydrationToken,
+        ).catch((err) => {
+          this.logger.error(
+            { err, agentId, itemType: item.type },
+            "Failed to persist coalesced timeline item",
+          );
+        });
       },
     });
     this.updateProviderRegistry({
@@ -1139,6 +1178,7 @@ export class AgentManager {
       labels?: Record<string, string>;
       workspaceId?: string;
       owner?: AgentOwner;
+      historyPrimed?: boolean;
       materialProgress?: MaterialProgressCheckpoint;
     },
     resumeOptions?: AgentResumeSessionOptions,
@@ -1159,6 +1199,7 @@ export class AgentManager {
       labels?: Record<string, string>;
       workspaceId?: string;
       owner?: AgentOwner;
+      historyPrimed?: boolean;
       materialProgress?: MaterialProgressCheckpoint;
     },
     resumeOptions?: AgentResumeSessionOptions,
@@ -1967,7 +2008,12 @@ export class AgentManager {
       return false;
     }
     if (options?.clientMessageId) {
-      this.recordSubmittedPrompt(agent, prompt, options.clientMessageId);
+      void this.recordSubmittedPrompt(agent, prompt, options.clientMessageId).catch((err) => {
+        this.logger.error(
+          { err, agentId, clientMessageId: options.clientMessageId },
+          "Failed to record out-of-band submitted prompt",
+        );
+      });
       this.emitState(agent);
     }
     const dispatch = (event: AgentStreamEvent): void => {
@@ -1975,11 +2021,17 @@ export class AgentManager {
       // for live subscribers. Other event types are broadcast only.
       if (event.type === "timeline") {
         this.touchUpdatedAt(agent);
-        const row = this.recordTimeline(agent.id, event.item);
-        this.dispatchStream(agent.id, event, {
-          seq: row.seq,
-          epoch: this.timelineStore.getEpoch(agent.id),
-          timestamp: row.timestamp,
+        void this.runOrBufferTimelineWriter(agent.id, async () => {
+          const row = this.recordTimeline(
+            agent.id,
+            event.item,
+            event.turnId ? { turnId: event.turnId } : undefined,
+          );
+          this.dispatchStream(agent.id, event, {
+            seq: row.seq,
+            epoch: this.timelineStore.getEpoch(agent.id),
+            timestamp: row.timestamp,
+          });
         });
         return;
       }
@@ -2004,20 +2056,24 @@ export class AgentManager {
     const agent = this.requireAgent(agentId);
     item = limitAgentTimelineItemContent(item);
     this.touchUpdatedAt(agent);
-    const row = this.recordTimeline(agentId, item);
-    this.dispatchStream(
-      agentId,
-      {
-        type: "timeline",
-        item,
-        provider: agent.provider,
-      },
-      {
-        seq: row.seq,
-        epoch: this.timelineStore.getEpoch(agentId),
-        timestamp: row.timestamp,
-      },
-    );
+    await this.runOrBufferTimelineWriter(agentId, async () => {
+      const turnId = agent.materialProgress.acceptedTurnId ?? undefined;
+      const row = this.recordTimeline(agentId, item, { turnId });
+      this.dispatchStream(
+        agentId,
+        {
+          type: "timeline",
+          item,
+          provider: agent.provider,
+          ...(turnId ? { turnId } : {}),
+        },
+        {
+          seq: row.seq,
+          epoch: this.timelineStore.getEpoch(agentId),
+          timestamp: row.timestamp,
+        },
+      );
+    });
     await this.persistSnapshot(agent);
   }
 
@@ -2119,7 +2175,7 @@ export class AgentManager {
           )
         : undefined;
       if (options?.clientMessageId) {
-        this.recordSubmittedPrompt(agent, prompt, options.clientMessageId, {
+        await this.recordSubmittedPrompt(agent, prompt, options.clientMessageId, {
           messageId: options.clientMessageId,
           providerMessageId:
             stagedSubmittedPromptEcho?.item.type === "user_message"
@@ -2553,8 +2609,65 @@ export class AgentManager {
     agentId: string,
     options?: HydrateTimelineOptions,
   ): Promise<void> {
-    const agent = this.requireSessionAgent(agentId);
-    await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
+    this.requireSessionAgent(agentId);
+
+    // Install the gate synchronously with admission. A live event queued in the microtask between
+    // this call and the serialized history read must not commit into the timeline being replaced.
+    const hydrationToken = this.beginOrContinueHistoryHydration(agentId);
+    const previous = (this.historyHydrationTails.get(agentId) ?? Promise.resolve()).catch(
+      () => undefined,
+    );
+    let hydration!: Promise<void>;
+    const ownsLatestTail = () => this.historyHydrationTails.get(agentId) === hydration;
+    hydration = previous.then(() =>
+      this.runSerializedHistoryHydration(agentId, options, hydrationToken, ownsLatestTail),
+    );
+    this.historyHydrationTails.set(agentId, hydration);
+
+    let hydrationError: unknown;
+    let hydrationFailed = false;
+    try {
+      await hydration;
+    } catch (error) {
+      hydrationFailed = true;
+      hydrationError = error;
+    } finally {
+      while (true) {
+        const latestHydration = this.historyHydrationTails.get(agentId);
+        if (!latestHydration || latestHydration === hydration) {
+          break;
+        }
+        await latestHydration.catch(() => undefined);
+        if (this.historyHydrationTails.get(agentId) === latestHydration) {
+          break;
+        }
+      }
+      if (this.historyHydrationTails.get(agentId) === hydration) {
+        this.historyHydrationTails.delete(agentId);
+      }
+    }
+
+    if (hydrationFailed) {
+      throw hydrationError;
+    }
+  }
+
+  private async runSerializedHistoryHydration(
+    agentId: string,
+    options: HydrateTimelineOptions | undefined,
+    hydrationToken: symbol,
+    ownsLatestTail: () => boolean,
+  ): Promise<void> {
+    try {
+      await this.drainSessionEvents(agentId);
+      this.flushPreGateCoalescedTimelineItems(agentId, hydrationToken);
+      const agent = this.requireSessionAgent(agentId);
+      await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
+    } finally {
+      if (ownsLatestTail()) {
+        await this.releaseHistoryHydration(agentId, hydrationToken, ownsLatestTail);
+      }
+    }
   }
 
   async rewind(agentId: string, messageId: string, mode: RewindMode): Promise<void> {
@@ -3160,6 +3273,14 @@ export class AgentManager {
   }
 
   private enqueueSessionEvent(agentId: string, event: AgentStreamEvent): void {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (activeHydration) {
+      activeHydration.bufferedOperations.push({
+        kind: "session_event",
+        run: async () => this.processSessionEvent(agentId, event, activeHydration.token),
+      });
+      return;
+    }
     this.logger.trace(
       {
         agentId,
@@ -3175,30 +3296,17 @@ export class AgentManager {
       pendingRun.stagedEvents.push(event);
       return;
     }
+    const admissionToken = Symbol(agentId);
+    let admissionTokens = this.sessionEventAdmissionTokens.get(agentId);
+    if (!admissionTokens) {
+      admissionTokens = new Set();
+      this.sessionEventAdmissionTokens.set(agentId, admissionTokens);
+    }
+    admissionTokens.add(admissionToken);
     const previous = this.sessionEventTails.get(agentId) ?? Promise.resolve();
     const next = previous
       .catch(() => undefined)
-      .then(async () => {
-        const current = this.agents.get(agentId);
-        if (!current) {
-          return;
-        }
-        if (current.session == null) {
-          return;
-        }
-        this.logger.trace(
-          {
-            agentId,
-            provider: event.provider,
-            sessionId: current.persistence?.sessionId ?? undefined,
-            turnId: getAgentStreamEventTurnId(event),
-            event,
-          },
-          "agent.manager.dequeue",
-        );
-        await this.dispatchSessionEvent(current, event);
-        return;
-      })
+      .then(async () => this.processSessionEvent(agentId, event, admissionToken))
       .catch((err) => {
         this.logger.error(
           { err, agentId, eventType: event.type },
@@ -3209,10 +3317,37 @@ export class AgentManager {
     this.sessionEventTails.set(agentId, next);
     this.trackBackgroundTask(next);
     void next.finally(() => {
+      const tokens = this.sessionEventAdmissionTokens.get(agentId);
+      tokens?.delete(admissionToken);
+      if (tokens?.size === 0) {
+        this.sessionEventAdmissionTokens.delete(agentId);
+      }
       if (this.sessionEventTails.get(agentId) === next) {
         this.sessionEventTails.delete(agentId);
       }
     });
+  }
+
+  private async processSessionEvent(
+    agentId: string,
+    event: AgentStreamEvent,
+    historyHydrationToken?: symbol,
+  ): Promise<void> {
+    const current = this.agents.get(agentId);
+    if (!current || current.session == null) {
+      return;
+    }
+    this.logger.trace(
+      {
+        agentId,
+        provider: event.provider,
+        sessionId: current.persistence?.sessionId ?? undefined,
+        turnId: getAgentStreamEventTurnId(event),
+        event,
+      },
+      "agent.manager.dequeue",
+    );
+    await this.dispatchSessionEvent(current, event, historyHydrationToken);
   }
 
   /**
@@ -3236,6 +3371,7 @@ export class AgentManager {
   private async dispatchSessionEvent(
     agent: ActiveManagedAgent,
     event: AgentStreamEvent,
+    historyHydrationToken?: symbol,
   ): Promise<void> {
     if (event.type === "provider_subagent") {
       const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
@@ -3256,7 +3392,11 @@ export class AgentManager {
       "agent.manager.dispatch_session_event",
     );
 
-    const shouldNotifyWaiters = await this.handleStreamEvent(agent, event);
+    const shouldNotifyWaiters = await this.handleStreamEvent(
+      agent,
+      event,
+      historyHydrationToken ? { historyHydrationToken } : undefined,
+    );
 
     if (!shouldNotifyWaiters) {
       return;
@@ -3398,24 +3538,36 @@ export class AgentManager {
   ): Promise<void> {
     const historyEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
     const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
-    for await (const event of agent.session.streamHistory()) {
-      if (event.type === "timeline") {
-        if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
-          continue;
+    try {
+      for await (const event of agent.session.streamHistory()) {
+        if (event.type === "timeline") {
+          if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
+            continue;
+          }
+          historyEvents.push(event);
+        } else if (event.type === "provider_subagent") {
+          providerSubagentEvents.push(event);
         }
-        historyEvents.push(event);
-      } else if (event.type === "provider_subagent") {
-        providerSubagentEvents.push(event);
       }
+    } catch (error) {
+      await this.markHistoryHydrationUnprimed(agent);
+      throw error;
     }
 
-    this.agentStreamCoalescer.flushAndDiscard(agent.id);
-    await this.deleteCommittedTimeline(agent.id);
-    this.timelineStore.delete(agent.id);
-    this.timelineStore.initialize(
-      agent.id,
-      await this.loadCommittedTimelineSeed(agent.id, new Date()),
-    );
+    const historyRows = this.buildProviderHistoryRows(historyEvents, 1);
+    let epoch: string;
+    try {
+      epoch = await this.replaceCommittedTimeline(agent.id, historyRows);
+    } catch (error) {
+      await this.markHistoryHydrationUnprimed(agent);
+      throw error;
+    }
+    this.timelineStore.initialize(agent.id, {
+      epoch,
+      rows: historyRows,
+      nextSeq: (historyRows.at(-1)?.seq ?? 0) + 1,
+      timestamp: new Date().toISOString(),
+    });
     this.resetMaterialProgress(agent);
     agent.historyPrimed = true;
 
@@ -3430,45 +3582,32 @@ export class AgentManager {
         this.dispatch({ type: "provider_subagent", event: update });
       }
     }
-    for (const event of historyEvents) {
-      const row = this.recordTimeline(
-        agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
-      );
+    for (let index = 0; index < historyEvents.length; index += 1) {
+      const event = historyEvents[index];
+      const row = historyRows[index];
       if (broadcast) {
         this.dispatchStream(agent.id, event, {
           seq: row.seq,
-          epoch: this.timelineStore.getEpoch(agent.id),
+          epoch,
           timestamp: row.timestamp,
         });
       }
     }
     this.touchUpdatedAt(agent);
-    this.emitState(agent);
+    await this.persistSnapshot(agent);
+    this.emitState(agent, { persist: false });
   }
 
   private async primeTimelineFromLegacyProviderHistory(
     agent: ActiveManagedAgent,
     broadcast: boolean | (() => boolean),
   ): Promise<void> {
-    const deferredBroadcast = typeof broadcast === "function";
-    const timelineEvents: Array<{
-      event: Extract<AgentStreamEvent, { type: "timeline" }>;
-      row: AgentTimelineRow;
-    }> = [];
-    const providerSubagentEvents: AgentManagerEvent[] = [];
-    agent.historyPrimed = true;
+    const timelineEvents: Extract<AgentStreamEvent, { type: "timeline" }>[] = [];
+    const providerSubagentEvents: Extract<AgentStreamEvent, { type: "provider_subagent" }>[] = [];
     try {
       for await (const event of agent.session.streamHistory()) {
         if (event.type === "provider_subagent") {
-          const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
-          const managerEvent: AgentManagerEvent = { type: "provider_subagent", event: update };
-          if (deferredBroadcast) {
-            providerSubagentEvents.push(managerEvent);
-          } else if (broadcast) {
-            this.dispatch(managerEvent);
-          }
+          providerSubagentEvents.push(event);
           continue;
         }
         if (event.type !== "timeline") {
@@ -3477,37 +3616,213 @@ export class AgentManager {
         if (event.item.type === "user_message" && isSystemInjectedEnvelope(event.item.text)) {
           continue;
         }
-        const row = this.recordTimeline(
-          agent.id,
-          event.item,
-          event.timestamp ? { timestamp: event.timestamp } : undefined,
-        );
-        if (deferredBroadcast) {
-          timelineEvents.push({ event, row });
-        } else if (broadcast) {
-          this.dispatchStream(agent.id, event, {
-            seq: row.seq,
-            epoch: this.timelineStore.getEpoch(agent.id),
-            timestamp: row.timestamp,
-          });
-        }
+        timelineEvents.push(event);
       }
     } catch {
-      // ignore history failures
-    }
-
-    if (typeof broadcast !== "function" || !broadcast()) {
+      await this.markHistoryHydrationUnprimed(agent);
       return;
     }
-    for (const event of providerSubagentEvents) {
-      this.dispatch(event);
+
+    const historyRows = this.buildProviderHistoryRows(timelineEvents, 1);
+    let epoch: string;
+    try {
+      epoch = await this.replaceCommittedTimeline(agent.id, historyRows);
+    } catch (error) {
+      await this.markHistoryHydrationUnprimed(agent);
+      throw error;
     }
-    for (const { event, row } of timelineEvents) {
-      this.dispatchStream(agent.id, event, {
-        seq: row.seq,
-        epoch: this.timelineStore.getEpoch(agent.id),
-        timestamp: row.timestamp,
+
+    this.timelineStore.initialize(agent.id, {
+      epoch,
+      rows: historyRows,
+      nextSeq: (historyRows.at(-1)?.seq ?? 0) + 1,
+      timestamp: new Date().toISOString(),
+    });
+    this.resetMaterialProgress(agent);
+    agent.historyPrimed = true;
+    await this.persistSnapshot(agent);
+
+    const shouldBroadcast = typeof broadcast === "function" ? broadcast() : broadcast;
+    for (const event of providerSubagentEvents) {
+      const update = this.providerSubagents.apply(agent.id, event.provider, event.event);
+      if (shouldBroadcast) {
+        this.dispatch({ type: "provider_subagent", event: update });
+      }
+    }
+    for (let index = 0; index < timelineEvents.length; index += 1) {
+      const event = timelineEvents[index];
+      const row = historyRows[index];
+      if (shouldBroadcast) {
+        this.dispatchStream(agent.id, event, {
+          seq: row.seq,
+          epoch,
+          timestamp: row.timestamp,
+        });
+      }
+    }
+  }
+
+  private async markHistoryHydrationUnprimed(agent: ActiveManagedAgent): Promise<void> {
+    agent.historyPrimed = false;
+    await this.persistSnapshot(agent);
+  }
+
+  private buildProviderHistoryRows(
+    events: readonly Extract<AgentStreamEvent, { type: "timeline" }>[],
+    startSeq: number,
+  ): AgentTimelineRow[] {
+    let nextSeq = startSeq;
+    return events.map((event) => {
+      const row: AgentTimelineRow = {
+        seq: nextSeq,
+        timestamp: event.timestamp ?? new Date().toISOString(),
+        item: limitAgentTimelineItemContent(event.item),
+        ...(event.turnId ? { turnId: event.turnId } : {}),
+      };
+      nextSeq += 1;
+      return row;
+    });
+  }
+
+  private beginOrContinueHistoryHydration(agentId: string): symbol {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (activeHydration) {
+      return activeHydration.token;
+    }
+    const token = Symbol(agentId);
+    this.activeHistoryHydrations.set(agentId, {
+      token,
+      preGateCoalescerToken: Symbol(`${agentId}:pre-gate-coalescer`),
+      preGateCoalescerOpen: true,
+      preGateSessionEventTokens: new Set(this.sessionEventAdmissionTokens.get(agentId) ?? []),
+      preGateBufferedOperations: [],
+      bufferedOperations: [],
+    });
+    return token;
+  }
+
+  private async releaseHistoryHydration(
+    agentId: string,
+    token: symbol,
+    stillOwnsTail: () => boolean,
+  ): Promise<void> {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (!activeHydration || activeHydration.token !== token) {
+      throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+    }
+
+    await this.drainSessionEvents(agentId);
+    while (true) {
+      const operation =
+        activeHydration.preGateBufferedOperations.shift() ??
+        activeHydration.bufferedOperations.shift();
+      if (operation) {
+        try {
+          if (operation.kind === "timeline_writer") {
+            this.flushCoalescedTimelineItems(agentId, token);
+          }
+          await operation.run();
+          operation.resolve?.();
+        } catch (err) {
+          operation.reject?.(err);
+          this.logger.error(
+            { err, agentId, operationKind: operation.kind },
+            "Failed to replay operation buffered during history hydration",
+          );
+        }
+        continue;
+      }
+
+      this.flushCoalescedTimelineItems(agentId, token);
+      if (
+        activeHydration.preGateBufferedOperations.length > 0 ||
+        activeHydration.bufferedOperations.length > 0
+      ) {
+        continue;
+      }
+      if (!stillOwnsTail()) {
+        return;
+      }
+      if (this.activeHistoryHydrations.get(agentId) !== activeHydration) {
+        throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+      }
+      this.activeHistoryHydrations.delete(agentId);
+      return;
+    }
+  }
+
+  private runOrBufferTimelineWriter(
+    agentId: string,
+    run: () => Promise<void> | void,
+    historyHydrationToken?: symbol,
+  ): Promise<void> {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (!activeHydration || activeHydration.token === historyHydrationToken) {
+      try {
+        return Promise.resolve(run());
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+
+    if (
+      historyHydrationToken === activeHydration.preGateCoalescerToken ||
+      (historyHydrationToken !== undefined &&
+        activeHydration.preGateSessionEventTokens.has(historyHydrationToken))
+    ) {
+      activeHydration.preGateBufferedOperations.push({
+        kind: "timeline_writer",
+        run: async () => run(),
       });
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((promiseResolve, promiseReject) => {
+      activeHydration.bufferedOperations.push({
+        kind: "timeline_writer",
+        run: async () => run(),
+        resolve: promiseResolve,
+        reject: promiseReject,
+      });
+    });
+  }
+
+  private flushCoalescedTimelineItems(agentId: string, historyHydrationToken?: symbol): void {
+    this.withCoalescerHistoryHydrationToken(agentId, historyHydrationToken, () => {
+      this.agentStreamCoalescer.flushFor(agentId);
+    });
+  }
+
+  private flushPreGateCoalescedTimelineItems(agentId: string, hydrationToken: symbol): void {
+    const activeHydration = this.activeHistoryHydrations.get(agentId);
+    if (!activeHydration || activeHydration.token !== hydrationToken) {
+      throw new Error(`Agent ${agentId} history hydration ownership was lost`);
+    }
+    try {
+      this.agentStreamCoalescer.flushAndDiscard(agentId);
+    } finally {
+      activeHydration.preGateCoalescerOpen = false;
+    }
+  }
+
+  private withCoalescerHistoryHydrationToken<T>(
+    agentId: string,
+    historyHydrationToken: symbol | undefined,
+    run: () => T,
+  ): T {
+    if (!historyHydrationToken) {
+      return run();
+    }
+    const previousToken = this.coalescerHistoryHydrationTokens.get(agentId);
+    this.coalescerHistoryHydrationTokens.set(agentId, historyHydrationToken);
+    try {
+      return run();
+    } finally {
+      if (previousToken) {
+        this.coalescerHistoryHydrationTokens.set(agentId, previousToken);
+      } else {
+        this.coalescerHistoryHydrationTokens.delete(agentId);
+      }
     }
   }
 
@@ -3557,11 +3872,16 @@ export class AgentManager {
     // Only update timestamp for live events, not history replay
     if (!options?.fromHistory) {
       this.touchUpdatedAt(agent);
-      if (this.agentStreamCoalescer.handle(agent.id, event)) {
+      const eventWasCoalesced = this.withCoalescerHistoryHydrationToken(
+        agent.id,
+        options?.historyHydrationToken,
+        () => this.agentStreamCoalescer.handle(agent.id, event),
+      );
+      if (eventWasCoalesced) {
         this.traceCoalescerBuffered(agent, event, eventTurnId);
         return false;
       }
-      this.agentStreamCoalescer.flushFor(agent.id);
+      this.flushCoalescedTimelineItems(agent.id, options?.historyHydrationToken);
     }
 
     let terminalDisposition: ActiveTurnTerminalDisposition = "untracked";
@@ -3776,7 +4096,7 @@ export class AgentManager {
   private async onStreamTimelineEvent(params: {
     agent: ActiveManagedAgent;
     event: Extract<AgentStreamEvent, { type: "timeline" }>;
-    options: { fromHistory?: boolean } | undefined;
+    options: HandleStreamEventOptions | undefined;
     flags: StreamEventFlags;
   }): Promise<void> {
     const { agent, event, options, flags } = params;
@@ -3798,17 +4118,28 @@ export class AgentManager {
     }
 
     if (options?.fromHistory) {
-      this.recordTimeline(
+      await this.runOrBufferTimelineWriter(
         agent.id,
-        event.item,
-        event.timestamp ? { timestamp: event.timestamp } : undefined,
+        async () => {
+          this.recordTimeline(agent.id, event.item, {
+            ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+            ...(event.turnId ? { turnId: event.turnId } : {}),
+          });
+        },
+        options.historyHydrationToken,
       );
       flags.shouldDispatchEvent = false;
       flags.shouldNotifyWaiters = false;
       return;
     }
 
-    this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
+    await this.runOrBufferTimelineWriter(
+      agent.id,
+      async () => {
+        this.recordAndDispatchTimelineItem(agent.id, event.item, event.provider, event.turnId);
+      },
+      options?.historyHydrationToken,
+    );
     if (event.item.type === "user_message") {
       agent.lastUserMessageAt = new Date();
       this.emitState(agent);
@@ -3896,6 +4227,7 @@ export class AgentManager {
       event.provider,
       this.formatTurnFailedMessage(event),
       options,
+      eventTurnId,
     );
     this.resolvePendingPermissionsForAgent(agent, event.provider, options, "Turn failed");
     if (!isForegroundEvent && !agent.activeForegroundTurnId) {
@@ -4033,7 +4365,10 @@ export class AgentManager {
     turnId?: string,
     options?: { providerMessageId?: string },
   ): AgentStreamEvent {
-    const row = this.recordTimeline(agentId, item, options);
+    const row = this.recordTimeline(agentId, item, {
+      ...options,
+      ...(turnId ? { turnId } : {}),
+    });
     const event: AgentStreamEvent = {
       type: "timeline",
       item,
@@ -4061,24 +4396,27 @@ export class AgentManager {
     return event;
   }
 
-  private recordSubmittedPrompt(
+  private async recordSubmittedPrompt(
     agent: ActiveManagedAgent,
     prompt: AgentPromptInput,
     clientMessageId: string,
     options?: { messageId?: string; providerMessageId?: string },
-  ): void {
-    if (this.timelineStore.getSubmittedUserMessage(agent.id, clientMessageId)) {
-      return;
-    }
-    this.touchUpdatedAt(agent);
-    agent.lastUserMessageAt = new Date();
-    const item: AgentTimelineItem = {
-      type: "user_message",
-      text: submittedPromptText(prompt),
-      clientMessageId,
-      ...(options?.messageId ? { messageId: options.messageId } : {}),
-    };
-    this.recordAndDispatchTimelineItem(agent.id, item, agent.provider, undefined, options);
+  ): Promise<void> {
+    await this.runOrBufferTimelineWriter(agent.id, async () => {
+      if (this.timelineStore.getSubmittedUserMessage(agent.id, clientMessageId)) {
+        return;
+      }
+      this.touchUpdatedAt(agent);
+      agent.lastUserMessageAt = new Date();
+      const item: AgentTimelineItem = {
+        type: "user_message",
+        text: submittedPromptText(prompt),
+        clientMessageId,
+        ...(options?.messageId ? { messageId: options.messageId } : {}),
+      };
+      const turnId = agent.activeTurnId ?? agent.materialProgress.acceptedTurnId ?? undefined;
+      this.recordAndDispatchTimelineItem(agent.id, item, agent.provider, turnId, options);
+    });
   }
 
   private reconcileSubmittedPromptEcho(
@@ -4104,7 +4442,8 @@ export class AgentManager {
     agent: ActiveManagedAgent,
     provider: AgentProvider,
     message: string,
-    options?: { fromHistory?: boolean },
+    options?: HandleStreamEventOptions,
+    turnId?: string,
   ): Promise<void> {
     if (options?.fromHistory) {
       return;
@@ -4115,26 +4454,33 @@ export class AgentManager {
       return;
     }
 
-    const text = `${SYSTEM_ERROR_PREFIX} ${normalized}`;
-    const lastItem = await this.getLastItemFromStores(agent.id);
-    if (lastItem?.type === "assistant_message" && lastItem.text === text) {
-      return;
-    }
-
-    const item: AgentTimelineItem = { type: "assistant_message", text };
-    const row = this.recordTimeline(agent.id, item);
-    this.dispatchStream(
+    await this.runOrBufferTimelineWriter(
       agent.id,
-      {
-        type: "timeline",
-        item,
-        provider,
+      async () => {
+        const text = `${SYSTEM_ERROR_PREFIX} ${normalized}`;
+        const lastItem = await this.getLastItemFromStores(agent.id);
+        if (lastItem?.type === "assistant_message" && lastItem.text === text) {
+          return;
+        }
+
+        const item: AgentTimelineItem = { type: "assistant_message", text };
+        const row = this.recordTimeline(agent.id, item, { turnId });
+        this.dispatchStream(
+          agent.id,
+          {
+            type: "timeline",
+            item,
+            provider,
+            ...(turnId ? { turnId } : {}),
+          },
+          {
+            seq: row.seq,
+            epoch: this.timelineStore.getEpoch(agent.id),
+            timestamp: row.timestamp,
+          },
+        );
       },
-      {
-        seq: row.seq,
-        epoch: this.timelineStore.getEpoch(agent.id),
-        timestamp: row.timestamp,
-      },
+      options?.historyHydrationToken,
     );
   }
 
@@ -4157,12 +4503,17 @@ export class AgentManager {
   private recordTimeline(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string; providerMessageId?: string },
+    options?: { timestamp?: string; providerMessageId?: string; turnId?: string },
   ): AgentTimelineRow {
     item = limitAgentTimelineItemContent(item);
     const row = this.timelineStore.append(agentId, item, options);
     const agent = this.agents.get(agentId);
     if (agent) {
+      // A normal live canonical row makes the durable timeline authoritative on restart.
+      // Rows replayed behind a failed hydration gate must not cancel that hydration's retry.
+      if (!this.activeHistoryHydrations.has(agentId)) {
+        agent.historyPrimed = true;
+      }
       agent.materialProgress = advanceMaterialProgressCheckpoint(
         agent.materialProgress,
         row,
@@ -4256,11 +4607,13 @@ export class AgentManager {
   }
 
   private enqueueDurableTimelineAppend(agentId: string, row: AgentTimelineRow): void {
-    if (!this.durableTimelineStore) {
+    const store = this.durableTimelineStore;
+    if (!store) {
       return;
     }
-    const task = this.durableTimelineStore
-      .bulkInsert(agentId, [row])
+    const task = this.queueDurableTimelineWrite(agentId, async () => {
+      await store.bulkInsert(agentId, [row]);
+    })
       .then(() => undefined)
       .catch((err) => {
         this.logger.error(
@@ -4275,10 +4628,13 @@ export class AgentManager {
     agentId: string,
     rows: readonly AgentTimelineRow[],
   ): void {
-    if (!this.durableTimelineStore || rows.length === 0) {
+    const store = this.durableTimelineStore;
+    if (!store || rows.length === 0) {
       return;
     }
-    const task = this.durableTimelineStore.bulkInsert(agentId, rows).catch((err) => {
+    const task = this.queueDurableTimelineWrite(agentId, async () => {
+      await store.bulkInsert(agentId, rows);
+    }).catch((err) => {
       this.logger.error(
         { err, agentId, rowCount: rows.length },
         "Failed to seed durable timeline store",
@@ -4288,14 +4644,48 @@ export class AgentManager {
   }
 
   private enqueueDurableTimelineUpdate(agentId: string, row: AgentTimelineRow): void {
-    if (!this.durableTimelineStore) return;
-    const task = this.durableTimelineStore.updateCommittedRow(agentId, row).catch((err) => {
+    const store = this.durableTimelineStore;
+    if (!store) return;
+    const task = this.queueDurableTimelineWrite(agentId, async () => {
+      await store.updateCommittedRow(agentId, row);
+    }).catch((err) => {
       this.logger.error(
         { err, agentId, seq: row.seq, itemType: row.item.type },
         "Failed to enrich durable timeline row",
       );
     });
     this.trackBackgroundTask(task);
+  }
+
+  private async replaceCommittedTimeline(
+    agentId: string,
+    rows: readonly AgentTimelineRow[],
+  ): Promise<string> {
+    const store = this.durableTimelineStore;
+    if (!store) {
+      return randomUUID();
+    }
+    const result = await this.queueDurableTimelineWrite(agentId, async () =>
+      store.replaceCommitted(agentId, rows),
+    );
+    return result.epoch;
+  }
+
+  private queueDurableTimelineWrite<T>(agentId: string, write: () => Promise<T>): Promise<T> {
+    const previous = this.durableTimelineWriteTails.get(agentId) ?? Promise.resolve();
+    const operation = previous.catch(() => undefined).then(write);
+    const settled = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.durableTimelineWriteTails.set(agentId, settled);
+    void settled.then(() => {
+      if (this.durableTimelineWriteTails.get(agentId) === settled) {
+        this.durableTimelineWriteTails.delete(agentId);
+      }
+      return undefined;
+    });
+    return operation;
   }
 
   private trackBackgroundTask(task: Promise<void>): void {

--- a/packages/server/src/server/agent/agent-projections.test.ts
+++ b/packages/server/src/server/agent/agent-projections.test.ts
@@ -168,6 +168,7 @@ describe("toStoredAgentRecord", () => {
     expect(record.updatedAt).toBe(agent.updatedAt.toISOString());
     expect(record.lastActivityAt).toBe(agent.updatedAt.toISOString());
     expect(record.lastUserMessageAt).toBe(agent.lastUserMessageAt?.toISOString());
+    expect(record.historyPrimed).toBe(true);
     expect(record.persistence).toEqual({
       provider: "claude",
       sessionId: "persist-2",

--- a/packages/server/src/server/agent/agent-projections.test.ts
+++ b/packages/server/src/server/agent/agent-projections.test.ts
@@ -15,6 +15,7 @@ import type {
   AgentPersistenceHandle,
   AgentSessionConfig,
 } from "./agent-sdk-types.js";
+import { createMaterialProgressCheckpoint } from "./material-progress.js";
 
 type ManagedAgentOverrides = Omit<Partial<ManagedAgent>, "config" | "pendingPermissions"> & {
   config?: Partial<AgentSessionConfig>;
@@ -84,6 +85,9 @@ function createManagedAgent(overrides: ManagedAgentOverrides = {}): ManagedAgent
     foregroundTurnWaiters: new Set(),
     unsubscribeSession: null,
     timeline: [],
+    materialProgress:
+      restOverrides.materialProgress ??
+      createMaterialProgressCheckpoint({ timelineEpoch: "epoch-1", nextSeq: 1 }),
     runtimeInfo: {
       provider: "claude",
       sessionId: "session-123",

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -88,6 +88,7 @@ export function toStoredAgentRecord(
     features: normalizeFeatures(agent.features),
     persistence,
     lastError: agent.lastError ?? undefined,
+    historyPrimed: agent.historyPrimed,
     materialProgress: {
       ...agent.materialProgress,
       seenMaterialProgressFingerprints: [

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -20,6 +20,7 @@ import type {
 import type { ManagedAgent } from "./agent-manager.js";
 import type { JsonValue } from "../json-utils.js";
 import { isStoredAgentProviderAvailable, toAgentPersistenceHandle } from "../persistence-hooks.js";
+import { materialProgressPayload } from "./material-progress.js";
 export type { ManagedAgent };
 
 interface ProjectionOptions {
@@ -87,6 +88,12 @@ export function toStoredAgentRecord(
     features: normalizeFeatures(agent.features),
     persistence,
     lastError: agent.lastError ?? undefined,
+    materialProgress: {
+      ...agent.materialProgress,
+      seenMaterialProgressFingerprints: [
+        ...agent.materialProgress.seenMaterialProgressFingerprints,
+      ],
+    },
     requiresAttention: agent.attention.requiresAttention,
     attentionReason: agent.attention.requiresAttention ? agent.attention.attentionReason : null,
     attentionTimestamp: agent.attention.requiresAttention
@@ -135,6 +142,7 @@ export function toAgentPayload(
     persistence: sanitizePersistenceHandle(agent.persistence),
     title: options?.title ?? null,
     labels: agent.labels,
+    materialProgress: materialProgressPayload(agent.materialProgress),
   };
 
   const usage = sanitizeUsage(agent.lastUsage);
@@ -242,6 +250,7 @@ export function buildStoredAgentPayload(
     attentionTimestamp: record.attentionTimestamp ?? null,
     archivedAt: record.archivedAt ?? null,
     labels: normalizeLabels(record.labels),
+    materialProgress: materialProgressPayload(record.materialProgress),
     ...(providerAvailable ? {} : { providerUnavailable: true }),
   };
 }

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -14,6 +14,7 @@ import type {
   AgentSession,
   AgentSessionConfig,
 } from "./agent-sdk-types.js";
+import { createMaterialProgressCheckpoint } from "./material-progress.js";
 
 type ManagedAgentOverrides = Omit<
   Partial<ManagedAgent>,
@@ -113,6 +114,9 @@ function createManagedAgent(overrides: ManagedAgentOverrides = {}): ManagedAgent
     foregroundTurnWaiters: new Set(),
     unsubscribeSession: null,
     timeline: overrides.timeline ?? [],
+    materialProgress:
+      overrides.materialProgress ??
+      createMaterialProgressCheckpoint({ timelineEpoch: "epoch-1", nextSeq: 1 }),
     attention: overrides.attention ?? { requiresAttention: false },
     runtimeInfo:
       overrides.runtimeInfo ??
@@ -211,6 +215,26 @@ describe("AgentStorage", () => {
     const persisted = await reloaded.get("agent-feature-values");
     expect(persisted?.config?.featureValues).toEqual({ fast_mode: true });
     expect(buildSessionConfig(persisted!).featureValues).toEqual({ fast_mode: true });
+  });
+
+  test("applySnapshot stores and reloads the epoch-bound material progress checkpoint", async () => {
+    const checkpoint = {
+      ...createMaterialProgressCheckpoint({ timelineEpoch: "epoch-persisted", nextSeq: 1 }),
+      continuationBoundarySeq: 1,
+      acceptedTurnId: "turn-persisted",
+      observedThroughSeq: 3,
+      completedCompactionsSinceMaterialProgress: 1,
+      lastMaterialProgressAt: "2026-08-01T00:00:03.000Z",
+      lastMaterialProgressKind: "write" as const,
+      seenMaterialProgressFingerprints: ["write:proof"],
+    };
+
+    await storage.applySnapshot(
+      createManagedAgent({ id: "agent-material-progress", materialProgress: checkpoint }),
+    );
+
+    const reloaded = new AgentStorage(storagePath, logger);
+    expect((await reloaded.get("agent-material-progress"))?.materialProgress).toEqual(checkpoint);
   });
 
   test("applySnapshot keeps featureValues absent when they were never set", async () => {
@@ -388,6 +412,47 @@ describe("AgentStorage", () => {
     await applySnapshotPromise;
     const record = await storage.get(agentId);
     expect(record?.title).toBe("Generated title");
+  });
+
+  test("a concurrent title mutation cannot overwrite a newer material progress checkpoint", async () => {
+    const agentId = "agent-material-progress-race";
+    const initialCheckpoint = createMaterialProgressCheckpoint({
+      timelineEpoch: "epoch-race",
+      nextSeq: 1,
+    });
+    await storage.applySnapshot(
+      createManagedAgent({ id: agentId, materialProgress: initialCheckpoint }),
+    );
+
+    let releasePendingWrite: (() => void) | null = null;
+    const pendingWrite = new Promise<void>((resolve) => {
+      releasePendingWrite = resolve;
+    });
+    const storageInternals = storage as unknown as {
+      pendingWrites: Map<string, Promise<void>>;
+    };
+    storageInternals.pendingWrites.set(agentId, pendingWrite);
+
+    const newerCheckpoint = {
+      ...initialCheckpoint,
+      continuationBoundarySeq: 1,
+      acceptedTurnId: "turn-race",
+      observedThroughSeq: 4,
+      lastMaterialProgressAt: "2026-08-01T00:00:04.000Z",
+      lastMaterialProgressKind: "verification" as const,
+      seenMaterialProgressFingerprints: ["verification:race"],
+    };
+    const snapshotWrite = storage.applySnapshot(
+      createManagedAgent({ id: agentId, materialProgress: newerCheckpoint }),
+    );
+    const titleWrite = storage.setTitle(agentId, "Generated during snapshot");
+    releasePendingWrite?.();
+
+    await Promise.all([snapshotWrite, titleWrite]);
+    const reloaded = new AgentStorage(storagePath, logger);
+    const record = await reloaded.get(agentId);
+    expect(record?.title).toBe("Generated during snapshot");
+    expect(record?.materialProgress).toEqual(newerCheckpoint);
   });
 
   test("list returns all agents including internal ones", async () => {

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -9,6 +9,7 @@ import { toStoredAgentRecord } from "./agent-projections.js";
 import type { ManagedAgent } from "./agent-manager.js";
 import type { AgentSessionConfig } from "./agent-sdk-types.js";
 import { AgentOwnerSchema, daemonExecutionKey, type DaemonAgentOwner } from "./agent-owner.js";
+import { MaterialProgressCheckpointSchema } from "./material-progress.js";
 
 const SERIALIZABLE_CONFIG_SCHEMA = z
   .object({
@@ -60,6 +61,7 @@ const STORED_AGENT_SCHEMA = z.object({
   features: z.array(AgentFeatureSchema).optional(),
   persistence: PERSISTENCE_HANDLE_SCHEMA,
   lastError: z.string().nullable().optional(),
+  materialProgress: MaterialProgressCheckpointSchema.optional(),
   requiresAttention: z.boolean().optional(),
   attentionReason: z.enum(["finished", "error", "permission"]).nullable().optional(),
   attentionTimestamp: z.string().nullable().optional(),
@@ -128,13 +130,20 @@ export class AgentStorage {
   }
 
   private queueRecordWrite(record: StoredAgentRecord): Promise<void> {
-    const agentId = record.id;
-    const prev = this.pendingWrites.get(agentId) ?? Promise.resolve();
+    return this.queueRecordMutation(record.id, () => record);
+  }
+
+  private queueRecordMutation(
+    agentId: string,
+    buildRecord: (existing: StoredAgentRecord | null) => StoredAgentRecord,
+  ): Promise<void> {
+    const prev = (this.pendingWrites.get(agentId) ?? Promise.resolve()).catch(() => undefined);
     const next = prev.then(async () => {
       if (this.deleting.has(agentId)) {
         return undefined;
       }
 
+      const record = buildRecord(this.cache.get(agentId) ?? null);
       await this.writeRecord(record);
       return undefined;
     });
@@ -207,35 +216,35 @@ export class AgentStorage {
     options?: { title?: string | null; internal?: boolean },
   ): Promise<void> {
     await this.load();
-    await this.waitForPendingWrite(agent.id);
-    const existing = (await this.get(agent.id)) ?? null;
     const hasTitleOverride =
       options !== undefined && Object.prototype.hasOwnProperty.call(options, "title");
     const hasInternalOverride =
       options !== undefined && Object.prototype.hasOwnProperty.call(options, "internal");
-    const record = toStoredAgentRecord(agent, {
-      title: hasTitleOverride ? (options?.title ?? null) : (existing?.title ?? null),
-      createdAt: existing?.createdAt,
-      internal: hasInternalOverride ? options?.internal : (agent.internal ?? existing?.internal),
-    });
+    await this.queueRecordMutation(agent.id, (existing) => {
+      const record = toStoredAgentRecord(agent, {
+        title: hasTitleOverride ? (options?.title ?? null) : (existing?.title ?? null),
+        createdAt: existing?.createdAt,
+        internal: hasInternalOverride ? options?.internal : (agent.internal ?? existing?.internal),
+      });
 
-    // Preserve soft-delete/archive status across snapshot flushes.
-    // `archivedAt` is not part of the ManagedAgent snapshot, so a naive projection
-    // would wipe it during normal persistence (including on daemon restart).
-    if (existing && existing.archivedAt !== undefined) {
-      record.archivedAt = existing.archivedAt;
-    }
-    await this.upsert(record);
+      // Preserve soft-delete/archive status across snapshot flushes.
+      // `archivedAt` is not part of the ManagedAgent snapshot, so a naive projection
+      // would wipe it during normal persistence (including on daemon restart).
+      if (existing && existing.archivedAt !== undefined) {
+        record.archivedAt = existing.archivedAt;
+      }
+      return record;
+    });
   }
 
   async setTitle(agentId: string, title: string): Promise<void> {
     await this.load();
-    await this.waitForPendingWrite(agentId);
-    const record = await this.get(agentId);
-    if (!record) {
-      throw new Error(`Agent ${agentId} not found`);
-    }
-    await this.upsert({ ...record, title });
+    await this.queueRecordMutation(agentId, (existing) => {
+      if (!existing) {
+        throw new Error(`Agent ${agentId} not found`);
+      }
+      return { ...existing, title };
+    });
   }
 
   async flush(): Promise<void> {
@@ -385,10 +394,6 @@ export class AgentStorage {
       this.daemonAgentIdsByExecution.delete(key);
     }
     this.daemonExecutionKeysByAgentId.delete(agentId);
-  }
-
-  private async waitForPendingWrite(agentId: string): Promise<void> {
-    await (this.pendingWrites.get(agentId) ?? Promise.resolve()).catch(() => undefined);
   }
 }
 

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -61,6 +61,7 @@ const STORED_AGENT_SCHEMA = z.object({
   features: z.array(AgentFeatureSchema).optional(),
   persistence: PERSISTENCE_HANDLE_SCHEMA,
   lastError: z.string().nullable().optional(),
+  historyPrimed: z.boolean().optional(),
   materialProgress: MaterialProgressCheckpointSchema.optional(),
   requiresAttention: z.boolean().optional(),
   attentionReason: z.enum(["finished", "error", "permission"]).nullable().optional(),

--- a/packages/server/src/server/agent/agent-timeline-store-types.ts
+++ b/packages/server/src/server/agent/agent-timeline-store-types.ts
@@ -5,6 +5,12 @@ export interface AgentTimelineRow {
   timestamp: string;
   item: AgentTimelineItem;
   readonly providerMessageId?: string;
+  /** Provider turn that produced this row, when known. */
+  readonly turnId?: string;
+}
+
+export interface AgentTimelineReplacementResult {
+  epoch: string;
 }
 
 export interface AgentTimelineCursor {
@@ -47,7 +53,7 @@ export interface AgentTimelineStore {
   appendCommitted(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): Promise<AgentTimelineRow>;
   fetchCommitted(
     agentId: string,
@@ -58,6 +64,11 @@ export interface AgentTimelineStore {
   getLastItem(agentId: string): Promise<AgentTimelineItem | null>;
   getLastAssistantMessage(agentId: string): Promise<string | null>;
   deleteAgent(agentId: string): Promise<void>;
+  /** Atomically replaces the complete committed timeline for one agent. */
+  replaceCommitted(
+    agentId: string,
+    rows: readonly AgentTimelineRow[],
+  ): Promise<AgentTimelineReplacementResult>;
   bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void>;
   updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void>;
 }

--- a/packages/server/src/server/agent/agent-timeline-store.ts
+++ b/packages/server/src/server/agent/agent-timeline-store.ts
@@ -264,7 +264,7 @@ export class InMemoryAgentTimelineStore {
   append(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string; providerMessageId?: string },
+    options?: { timestamp?: string; providerMessageId?: string; turnId?: string },
   ): AgentTimelineRow {
     const state = this.requireState(agentId);
     const row: AgentTimelineRow = {
@@ -272,6 +272,7 @@ export class InMemoryAgentTimelineStore {
       timestamp: options?.timestamp ?? new Date().toISOString(),
       item,
       ...(options?.providerMessageId ? { providerMessageId: options.providerMessageId } : {}),
+      ...(options?.turnId ? { turnId: options.turnId } : {}),
     };
     state.nextSeq += 1;
     state.rows.push(row);

--- a/packages/server/src/server/agent/file-agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.test.ts
@@ -5,7 +5,9 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
+import { writeJsonFileAtomic } from "../atomic-file.js";
 import { FileAgentTimelineStore } from "./file-agent-timeline-store.js";
+import type { AgentTimelineRow } from "./agent-timeline-store-types.js";
 
 const logger = createTestLogger();
 const temporaryDirectories: string[] = [];
@@ -62,6 +64,71 @@ describe("FileAgentTimelineStore", () => {
       epoch: "epoch-two",
       rows: [],
       window: { nextSeq: 1 },
+    });
+  });
+
+  it("atomically keeps prior truth after a failed complete replacement", async () => {
+    const directory = await createStoreDirectory();
+    const agentId = "agent-with-atomic-history";
+    let rejectWrites = false;
+    const epochs = ["prior-epoch", "failed-replacement-epoch", "replacement-epoch"];
+    const store = new FileAgentTimelineStore(directory, logger, {
+      epochFactory: () => epochs.shift() ?? "unexpected-epoch",
+      writeJson: async (filePath, value) => {
+        if (rejectWrites) {
+          throw new Error("injected pre-rename failure");
+        }
+        await writeJsonFileAtomic(filePath, value);
+      },
+    });
+    const priorRows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        item: { type: "user_message", text: "prior complete timeline" },
+        turnId: "turn-prior",
+      },
+    ];
+    const replacementRows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-02-01T00:00:00.000Z",
+        item: { type: "user_message", text: "replacement row one" },
+        turnId: "turn-replacement",
+      },
+      {
+        seq: 2,
+        timestamp: "2026-02-01T00:00:01.000Z",
+        item: { type: "assistant_message", text: "replacement row two" },
+        turnId: "turn-replacement",
+      },
+    ];
+
+    await store.bulkInsert(agentId, priorRows);
+    const prior = await store.fetchCommitted(agentId, { limit: 0 });
+    expect(prior.epoch).toBe("prior-epoch");
+    rejectWrites = true;
+    await expect(store.replaceCommitted(agentId, replacementRows)).rejects.toThrow(
+      "injected pre-rename failure",
+    );
+
+    const restartedAfterFailure = new FileAgentTimelineStore(directory, logger);
+    await expect(restartedAfterFailure.getCommittedRows(agentId)).resolves.toEqual(priorRows);
+    await expect(
+      restartedAfterFailure.fetchCommitted(agentId, { limit: 0 }),
+    ).resolves.toMatchObject({ epoch: "prior-epoch" });
+
+    rejectWrites = false;
+    await expect(store.replaceCommitted(agentId, replacementRows)).resolves.toEqual({
+      epoch: "replacement-epoch",
+    });
+    const restartedAfterSuccess = new FileAgentTimelineStore(directory, logger);
+    await expect(
+      restartedAfterSuccess.fetchCommitted(agentId, { limit: 0 }),
+    ).resolves.toMatchObject({
+      epoch: "replacement-epoch",
+      window: { minSeq: 1, maxSeq: 2, nextSeq: 3 },
+      rows: replacementRows,
     });
   });
 });

--- a/packages/server/src/server/agent/file-agent-timeline-store.test.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { FileAgentTimelineStore } from "./file-agent-timeline-store.js";
+
+const logger = createTestLogger();
+const temporaryDirectories: string[] = [];
+
+async function createStoreDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "file-agent-timeline-store-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("FileAgentTimelineStore", () => {
+  it("persists an empty incarnation and its rows, then mints a new epoch after deletion", async () => {
+    const directory = await createStoreDirectory();
+    const agentId = "agent-with-durable-incarnation";
+    const epochs = ["epoch-one", "epoch-two"];
+    const store = new FileAgentTimelineStore(directory, logger, {
+      epochFactory: () => epochs.shift() ?? "unexpected-epoch",
+    });
+
+    const empty = await store.fetchCommitted(agentId, { limit: 0 });
+    expect(empty).toMatchObject({ epoch: "epoch-one", rows: [], window: { nextSeq: 1 } });
+
+    const restartedEmpty = new FileAgentTimelineStore(directory, logger);
+    await expect(restartedEmpty.fetchCommitted(agentId, { limit: 0 })).resolves.toMatchObject({
+      epoch: "epoch-one",
+      rows: [],
+      window: { nextSeq: 1 },
+    });
+
+    await store.bulkInsert(agentId, [
+      {
+        seq: 1,
+        timestamp: "2026-08-01T00:00:00.000Z",
+        item: { type: "assistant_message", text: "durable row" },
+      },
+    ]);
+    const restartedWithRows = new FileAgentTimelineStore(directory, logger);
+    await expect(restartedWithRows.fetchCommitted(agentId, { limit: 0 })).resolves.toMatchObject({
+      epoch: "epoch-one",
+      rows: [{ seq: 1, item: { type: "assistant_message", text: "durable row" } }],
+      window: { nextSeq: 2 },
+    });
+
+    await store.deleteAgent(agentId);
+    await expect(store.fetchCommitted(agentId, { limit: 0 })).resolves.toMatchObject({
+      epoch: "epoch-two",
+      rows: [],
+      window: { nextSeq: 1 },
+    });
+  });
+});

--- a/packages/server/src/server/agent/file-agent-timeline-store.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.ts
@@ -1,0 +1,274 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import type { Logger } from "pino";
+
+import { writeJsonFileAtomic } from "../atomic-file.js";
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
+import type {
+  AgentTimelineFetchOptions,
+  AgentTimelineFetchResult,
+  AgentTimelineRow,
+  AgentTimelineStore,
+} from "./agent-timeline-store-types.js";
+
+interface PersistedAgentTimeline {
+  version: 1;
+  epoch: string;
+  rows: AgentTimelineRow[];
+}
+
+export interface FileAgentTimelineStoreOptions {
+  epochFactory?: () => string;
+}
+
+function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
+  return structuredClone(row);
+}
+
+function normalizeRows(rows: readonly AgentTimelineRow[]): AgentTimelineRow[] {
+  const normalized = rows.map(cloneRow).sort((left, right) => left.seq - right.seq);
+  let previousSeq = 0;
+  for (const row of normalized) {
+    if (!Number.isSafeInteger(row.seq) || row.seq <= 0 || row.seq === previousSeq) {
+      throw new Error(`Invalid or duplicate timeline sequence ${row.seq}`);
+    }
+    if (typeof row.timestamp !== "string" || row.timestamp.length === 0) {
+      throw new Error(`Timeline row ${row.seq} has no timestamp`);
+    }
+    if (
+      typeof row.item !== "object" ||
+      row.item === null ||
+      typeof (row.item as { type?: unknown }).type !== "string"
+    ) {
+      throw new Error(`Timeline row ${row.seq} has an invalid item`);
+    }
+    previousSeq = row.seq;
+  }
+  return normalized;
+}
+
+function parsePersistedTimeline(value: unknown): PersistedAgentTimeline {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Timeline file must contain an object");
+  }
+  const candidate = value as { version?: unknown; epoch?: unknown; rows?: unknown };
+  if (candidate.version !== 1) {
+    throw new Error("Unsupported timeline file version");
+  }
+  if (typeof candidate.epoch !== "string" || candidate.epoch.length === 0) {
+    throw new Error("Timeline file has no epoch");
+  }
+  if (!Array.isArray(candidate.rows)) {
+    throw new Error("Timeline file has no rows array");
+  }
+  return {
+    version: 1,
+    epoch: candidate.epoch,
+    rows: normalizeRows(candidate.rows as AgentTimelineRow[]),
+  };
+}
+
+/**
+ * Persists each canonical agent timeline together with its incarnation epoch.
+ * Deleting one timeline retires both its rows and epoch, so the next history
+ * incarnation cannot inherit a checkpoint from the previous one.
+ */
+export class FileAgentTimelineStore implements AgentTimelineStore {
+  private readonly states = new Map<string, PersistedAgentTimeline>();
+  private readonly loadPromises = new Map<string, Promise<PersistedAgentTimeline>>();
+  private readonly operationTails = new Map<string, Promise<void>>();
+  private readonly logger: Logger;
+  private readonly epochFactory: () => string;
+
+  constructor(
+    private readonly baseDir: string,
+    logger: Logger,
+    options?: FileAgentTimelineStoreOptions,
+  ) {
+    this.logger = logger.child({ module: "agent", component: "file-agent-timeline-store" });
+    this.epochFactory = options?.epochFactory ?? randomUUID;
+  }
+
+  async appendCommitted(
+    agentId: string,
+    item: AgentTimelineItem,
+    options?: { timestamp?: string },
+  ): Promise<AgentTimelineRow> {
+    return await this.queueMutation(agentId, (current) => {
+      const row: AgentTimelineRow = {
+        seq: (current.rows.at(-1)?.seq ?? 0) + 1,
+        timestamp: options?.timestamp ?? new Date().toISOString(),
+        item: structuredClone(item),
+      };
+      return {
+        next: { ...current, rows: [...current.rows, row] },
+        result: cloneRow(row),
+      };
+    });
+  }
+
+  async fetchCommitted(
+    agentId: string,
+    options?: AgentTimelineFetchOptions,
+  ): Promise<AgentTimelineFetchResult> {
+    const state = await this.readState(agentId);
+    const store = new InMemoryAgentTimelineStore();
+    store.initialize(agentId, {
+      epoch: state.epoch,
+      rows: state.rows,
+      nextSeq: (state.rows.at(-1)?.seq ?? 0) + 1,
+    });
+    return store.fetch(agentId, options);
+  }
+
+  async getLatestCommittedSeq(agentId: string): Promise<number> {
+    const state = await this.readState(agentId);
+    return state.rows.at(-1)?.seq ?? 0;
+  }
+
+  async getCommittedRows(agentId: string): Promise<AgentTimelineRow[]> {
+    const state = await this.readState(agentId);
+    return state.rows.map(cloneRow);
+  }
+
+  async getLastItem(agentId: string): Promise<AgentTimelineItem | null> {
+    const state = await this.readState(agentId);
+    const item = state.rows.at(-1)?.item;
+    return item ? structuredClone(item) : null;
+  }
+
+  async getLastAssistantMessage(agentId: string): Promise<string | null> {
+    const state = await this.readState(agentId);
+    const chunks: string[] = [];
+    for (let index = state.rows.length - 1; index >= 0; index -= 1) {
+      const item = state.rows[index]?.item;
+      if (!item || item.type !== "assistant_message") {
+        if (chunks.length > 0) {
+          break;
+        }
+        continue;
+      }
+      chunks.push(item.text);
+    }
+    return chunks.length > 0 ? chunks.toReversed().join("") : null;
+  }
+
+  async deleteAgent(agentId: string): Promise<void> {
+    await this.queueOperation(agentId, async () => {
+      try {
+        await fs.unlink(this.filePath(agentId));
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+      this.states.delete(agentId);
+      this.loadPromises.delete(agentId);
+    });
+  }
+
+  async bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
+    if (rows.length === 0) {
+      return;
+    }
+    const incoming = normalizeRows(rows);
+    await this.queueMutation(agentId, (current) => {
+      const merged = new Map(current.rows.map((row) => [row.seq, row]));
+      for (const row of incoming) {
+        merged.set(row.seq, row);
+      }
+      return {
+        next: { ...current, rows: normalizeRows(Array.from(merged.values())) },
+        result: undefined,
+      };
+    });
+  }
+
+  async updateCommittedRow(agentId: string, row: AgentTimelineRow): Promise<void> {
+    await this.bulkInsert(agentId, [row]);
+  }
+
+  private async readState(agentId: string): Promise<PersistedAgentTimeline> {
+    await (this.operationTails.get(agentId) ?? Promise.resolve());
+    return await this.loadState(agentId);
+  }
+
+  private async loadState(agentId: string): Promise<PersistedAgentTimeline> {
+    const cached = this.states.get(agentId);
+    if (cached) {
+      return cached;
+    }
+    const existingLoad = this.loadPromises.get(agentId);
+    if (existingLoad) {
+      return await existingLoad;
+    }
+    const load = this.loadStateFromDisk(agentId).finally(() => {
+      if (this.loadPromises.get(agentId) === load) {
+        this.loadPromises.delete(agentId);
+      }
+    });
+    this.loadPromises.set(agentId, load);
+    return await load;
+  }
+
+  private async loadStateFromDisk(agentId: string): Promise<PersistedAgentTimeline> {
+    const filePath = this.filePath(agentId);
+    let state: PersistedAgentTimeline;
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      state = parsePersistedTimeline(JSON.parse(raw));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        this.logger.error({ err: error, agentId, filePath }, "Failed to load agent timeline");
+        throw error;
+      }
+      state = { version: 1, epoch: this.epochFactory(), rows: [] };
+      // The empty incarnation is authoritative too. Persist it before exposing
+      // its epoch so a restart before the first row cannot silently mint another.
+      await writeJsonFileAtomic(filePath, state);
+    }
+    this.states.set(agentId, state);
+    return state;
+  }
+
+  private async queueMutation<T>(
+    agentId: string,
+    mutate: (
+      current: PersistedAgentTimeline,
+    ) =>
+      | { next: PersistedAgentTimeline; result: T }
+      | Promise<{ next: PersistedAgentTimeline; result: T }>,
+  ): Promise<T> {
+    return await this.queueOperation(agentId, async () => {
+      const current = await this.loadState(agentId);
+      const { next, result } = await mutate(current);
+      await writeJsonFileAtomic(this.filePath(agentId), next);
+      this.states.set(agentId, next);
+      return result;
+    });
+  }
+
+  private queueOperation<T>(agentId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.operationTails.get(agentId) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    const settled = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.operationTails.set(agentId, settled);
+    void settled.then(() => {
+      if (this.operationTails.get(agentId) === settled) {
+        this.operationTails.delete(agentId);
+      }
+      return undefined;
+    });
+    return current;
+  }
+
+  private filePath(agentId: string): string {
+    return path.join(this.baseDir, `agent-${Buffer.from(agentId).toString("base64url")}.json`);
+  }
+}

--- a/packages/server/src/server/agent/file-agent-timeline-store.ts
+++ b/packages/server/src/server/agent/file-agent-timeline-store.ts
@@ -10,6 +10,7 @@ import { InMemoryAgentTimelineStore } from "./agent-timeline-store.js";
 import type {
   AgentTimelineFetchOptions,
   AgentTimelineFetchResult,
+  AgentTimelineReplacementResult,
   AgentTimelineRow,
   AgentTimelineStore,
 } from "./agent-timeline-store-types.js";
@@ -22,6 +23,7 @@ interface PersistedAgentTimeline {
 
 export interface FileAgentTimelineStoreOptions {
   epochFactory?: () => string;
+  writeJson?: (filePath: string, value: unknown) => Promise<void>;
 }
 
 function cloneRow(row: AgentTimelineRow): AgentTimelineRow {
@@ -82,6 +84,7 @@ export class FileAgentTimelineStore implements AgentTimelineStore {
   private readonly operationTails = new Map<string, Promise<void>>();
   private readonly logger: Logger;
   private readonly epochFactory: () => string;
+  private readonly writeJson: (filePath: string, value: unknown) => Promise<void>;
 
   constructor(
     private readonly baseDir: string,
@@ -90,18 +93,20 @@ export class FileAgentTimelineStore implements AgentTimelineStore {
   ) {
     this.logger = logger.child({ module: "agent", component: "file-agent-timeline-store" });
     this.epochFactory = options?.epochFactory ?? randomUUID;
+    this.writeJson = options?.writeJson ?? writeJsonFileAtomic;
   }
 
   async appendCommitted(
     agentId: string,
     item: AgentTimelineItem,
-    options?: { timestamp?: string },
+    options?: { timestamp?: string; turnId?: string },
   ): Promise<AgentTimelineRow> {
     return await this.queueMutation(agentId, (current) => {
       const row: AgentTimelineRow = {
         seq: (current.rows.at(-1)?.seq ?? 0) + 1,
         timestamp: options?.timestamp ?? new Date().toISOString(),
         item: structuredClone(item),
+        ...(options?.turnId ? { turnId: options.turnId } : {}),
       };
       return {
         next: { ...current, rows: [...current.rows, row] },
@@ -170,6 +175,20 @@ export class FileAgentTimelineStore implements AgentTimelineStore {
     });
   }
 
+  async replaceCommitted(
+    agentId: string,
+    rows: readonly AgentTimelineRow[],
+  ): Promise<AgentTimelineReplacementResult> {
+    const replacement = normalizeRows(rows);
+    return await this.queueMutation(agentId, () => {
+      const epoch = this.epochFactory();
+      return {
+        next: { version: 1, epoch, rows: replacement },
+        result: { epoch },
+      };
+    });
+  }
+
   async bulkInsert(agentId: string, rows: readonly AgentTimelineRow[]): Promise<void> {
     if (rows.length === 0) {
       return;
@@ -228,7 +247,7 @@ export class FileAgentTimelineStore implements AgentTimelineStore {
       state = { version: 1, epoch: this.epochFactory(), rows: [] };
       // The empty incarnation is authoritative too. Persist it before exposing
       // its epoch so a restart before the first row cannot silently mint another.
-      await writeJsonFileAtomic(filePath, state);
+      await this.writeJson(filePath, state);
     }
     this.states.set(agentId, state);
     return state;
@@ -245,7 +264,7 @@ export class FileAgentTimelineStore implements AgentTimelineStore {
     return await this.queueOperation(agentId, async () => {
       const current = await this.loadState(agentId);
       const { next, result } = await mutate(current);
-      await writeJsonFileAtomic(this.filePath(agentId), next);
+      await this.writeJson(this.filePath(agentId), next);
       this.states.set(agentId, next);
       return result;
     });

--- a/packages/server/src/server/agent/material-progress.test.ts
+++ b/packages/server/src/server/agent/material-progress.test.ts
@@ -5,7 +5,7 @@ import {
   advanceMaterialProgressCheckpoint,
   materialProgressPayload,
   openMaterialProgressContinuation,
-  rebindMaterialProgressCheckpoint,
+  restoreMaterialProgressCheckpoint,
   settleMaterialProgressContinuation,
 } from "./material-progress.js";
 
@@ -153,26 +153,80 @@ describe("material progress checkpoint", () => {
     ).toMatchObject({ state: "progressing", lastMaterialProgressKind: "assistant_result" });
   });
 
-  it("binds restored state to the current epoch and rejects impossible cursors", () => {
+  it("restores state only when the exact timeline epoch and cursor remain valid", () => {
     const checkpoint = applyRows([row(1, { type: "compaction", status: "completed" })]);
-    const rebound = rebindMaterialProgressCheckpoint(checkpoint, {
-      timelineEpoch: "epoch-2",
+    const restored = restoreMaterialProgressCheckpoint(checkpoint, {
+      timelineEpoch: "epoch-1",
       nextSeq: 2,
     });
-    expect(materialProgressPayload(rebound)).toMatchObject({
+    expect(materialProgressPayload(restored)).toMatchObject({
       state: "warning",
-      timelineEpoch: "epoch-2",
+      timelineEpoch: "epoch-1",
       continuationBoundarySeq: 1,
     });
 
-    const invalid = rebindMaterialProgressCheckpoint(checkpoint, {
-      timelineEpoch: "epoch-reset",
+    const invalid = restoreMaterialProgressCheckpoint(checkpoint, {
+      timelineEpoch: "epoch-1",
       nextSeq: 1,
     });
     expect(materialProgressPayload(invalid)).toMatchObject({
       state: "none",
-      timelineEpoch: "epoch-reset",
+      timelineEpoch: "epoch-1",
       continuationBoundarySeq: null,
+    });
+  });
+
+  it("invalidates old evidence and compactions after an equal-length epoch replacement", () => {
+    const checkpoint = applyRows([
+      row(1, {
+        type: "tool_call",
+        callId: "read-before-equal-replacement",
+        name: "read",
+        status: "completed",
+        error: null,
+        detail: { type: "read", filePath: "old.txt", content: "old evidence" },
+      }),
+      row(2, { type: "compaction", status: "completed" }),
+    ]);
+
+    const replacement = restoreMaterialProgressCheckpoint(checkpoint, {
+      timelineEpoch: "epoch-equal-replacement",
+      nextSeq: 3,
+    });
+    expect(materialProgressPayload(replacement)).toMatchObject({
+      state: "none",
+      timelineEpoch: "epoch-equal-replacement",
+      continuationBoundarySeq: null,
+      observedThroughSeq: 2,
+      completedCompactionsSinceMaterialProgress: 0,
+      lastMaterialProgressKind: null,
+    });
+  });
+
+  it("invalidates old evidence and compactions after a longer epoch replacement", () => {
+    const checkpoint = applyRows([
+      row(1, {
+        type: "tool_call",
+        callId: "write-before-longer-replacement",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "old.txt", content: "old result" },
+      }),
+      row(2, { type: "compaction", status: "completed" }),
+    ]);
+
+    const replacement = restoreMaterialProgressCheckpoint(checkpoint, {
+      timelineEpoch: "epoch-longer-replacement",
+      nextSeq: 10_002,
+    });
+    expect(materialProgressPayload(replacement)).toMatchObject({
+      state: "none",
+      timelineEpoch: "epoch-longer-replacement",
+      continuationBoundarySeq: null,
+      observedThroughSeq: 10_001,
+      completedCompactionsSinceMaterialProgress: 0,
+      lastMaterialProgressKind: null,
     });
   });
 

--- a/packages/server/src/server/agent/material-progress.test.ts
+++ b/packages/server/src/server/agent/material-progress.test.ts
@@ -10,7 +10,12 @@ import {
 } from "./material-progress.js";
 
 function row(seq: number, item: AgentTimelineItem): AgentTimelineRow {
-  return { seq, timestamp: `2026-08-01T00:00:${String(seq).padStart(2, "0")}.000Z`, item };
+  return {
+    seq,
+    timestamp: `2026-08-01T00:00:${String(seq).padStart(2, "0")}.000Z`,
+    item,
+    turnId: "turn-1",
+  };
 }
 
 function acceptedCheckpoint() {
@@ -151,6 +156,32 @@ describe("material progress checkpoint", () => {
         }),
       ),
     ).toMatchObject({ state: "progressing", lastMaterialProgressKind: "assistant_result" });
+  });
+
+  it("observes but does not count rows from a replaced turn", () => {
+    const staleWrite = {
+      ...row(1, {
+        type: "tool_call",
+        callId: "late-write",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "stale.txt", content: "late" },
+      }),
+      turnId: "turn-replaced",
+    } satisfies AgentTimelineRow;
+    const afterStaleWrite = advanceMaterialProgressCheckpoint(
+      acceptedCheckpoint(),
+      staleWrite,
+      "epoch-1",
+    );
+
+    expect(materialProgressPayload(afterStaleWrite)).toMatchObject({
+      state: "none",
+      observedThroughSeq: 1,
+      lastMaterialProgressKind: null,
+      completedCompactionsSinceMaterialProgress: 0,
+    });
   });
 
   it("restores state only when the exact timeline epoch and cursor remain valid", () => {

--- a/packages/server/src/server/agent/material-progress.test.ts
+++ b/packages/server/src/server/agent/material-progress.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTimelineItem } from "./agent-sdk-types.js";
+import type { AgentTimelineRow } from "./agent-timeline-store-types.js";
+import {
+  advanceMaterialProgressCheckpoint,
+  materialProgressPayload,
+  openMaterialProgressContinuation,
+  rebindMaterialProgressCheckpoint,
+  settleMaterialProgressContinuation,
+} from "./material-progress.js";
+
+function row(seq: number, item: AgentTimelineItem): AgentTimelineRow {
+  return { seq, timestamp: `2026-08-01T00:00:${String(seq).padStart(2, "0")}.000Z`, item };
+}
+
+function acceptedCheckpoint() {
+  return openMaterialProgressContinuation({
+    timelineEpoch: "epoch-1",
+    boundarySeq: 1,
+    turnId: "turn-1",
+  });
+}
+
+function applyRows(rows: AgentTimelineRow[]) {
+  return rows.reduce(
+    (checkpoint, current) => advanceMaterialProgressCheckpoint(checkpoint, current, "epoch-1"),
+    acceptedCheckpoint(),
+  );
+}
+
+describe("material progress checkpoint", () => {
+  it("warns after one compaction and stalls after two", () => {
+    const warning = applyRows([row(1, { type: "compaction", status: "completed" })]);
+    expect(materialProgressPayload(warning)).toMatchObject({
+      state: "warning",
+      completedCompactionsSinceMaterialProgress: 1,
+    });
+
+    const stalled = advanceMaterialProgressCheckpoint(
+      warning,
+      row(2, { type: "compaction", status: "completed" }),
+      "epoch-1",
+    );
+    expect(materialProgressPayload(stalled)).toMatchObject({
+      state: "stalled",
+      completedCompactionsSinceMaterialProgress: 2,
+    });
+  });
+
+  it("counts concrete read, verification, decision, edit, and write results", () => {
+    const checkpoint = applyRows([
+      row(1, {
+        type: "tool_call",
+        callId: "read-1",
+        name: "read",
+        status: "completed",
+        error: null,
+        detail: { type: "read", filePath: "src/auth.ts", content: "export const auth = true;" },
+      }),
+      row(2, { type: "compaction", status: "completed" }),
+      row(3, {
+        type: "tool_call",
+        callId: "test-1",
+        name: "shell",
+        status: "completed",
+        error: null,
+        detail: { type: "shell", command: "npm test", output: "12 passed", exitCode: 0 },
+      }),
+      row(4, { type: "compaction", status: "completed" }),
+      row(5, {
+        type: "tool_call",
+        callId: "plan-1",
+        name: "plan",
+        status: "completed",
+        error: null,
+        detail: { type: "plan", text: "Use the accepted boundary." },
+      }),
+      row(6, {
+        type: "tool_call",
+        callId: "edit-1",
+        name: "edit",
+        status: "completed",
+        error: null,
+        detail: { type: "edit", filePath: "src/a.ts", unifiedDiff: "+change" },
+      }),
+      row(7, {
+        type: "tool_call",
+        callId: "write-1",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "proof.txt", content: "done" },
+      }),
+    ]);
+
+    expect(materialProgressPayload(checkpoint)).toMatchObject({
+      state: "progressing",
+      completedCompactionsSinceMaterialProgress: 0,
+      lastMaterialProgressKind: "write",
+    });
+  });
+
+  it("does not let repeated identical evidence reset compactions", () => {
+    const read = row(1, {
+      type: "tool_call",
+      callId: "read-1",
+      name: "read",
+      status: "completed",
+      error: null,
+      detail: { type: "read", filePath: "notes.txt", content: "unchanged" },
+    });
+    let checkpoint = applyRows([read, row(2, { type: "compaction", status: "completed" })]);
+    checkpoint = advanceMaterialProgressCheckpoint(
+      checkpoint,
+      { ...read, seq: 3, timestamp: "2026-08-01T00:00:03.000Z" },
+      "epoch-1",
+    );
+    checkpoint = advanceMaterialProgressCheckpoint(
+      checkpoint,
+      row(4, { type: "compaction", status: "completed" }),
+      "epoch-1",
+    );
+
+    expect(materialProgressPayload(checkpoint)).toMatchObject({
+      state: "stalled",
+      completedCompactionsSinceMaterialProgress: 2,
+      lastMaterialProgressKind: "evidence",
+    });
+  });
+
+  it("counts only a successfully completed turn's trailing assistant result", () => {
+    const withAssistant = applyRows([
+      row(1, { type: "compaction", status: "completed" }),
+      row(2, { type: "assistant_message", text: "Delivered " }),
+      row(3, { type: "assistant_message", text: "result." }),
+    ]);
+
+    expect(
+      materialProgressPayload(
+        settleMaterialProgressContinuation(withAssistant, {
+          turnId: "turn-1",
+          outcome: "failed",
+        }),
+      ).state,
+    ).toBe("warning");
+    expect(
+      materialProgressPayload(
+        settleMaterialProgressContinuation(withAssistant, {
+          turnId: "turn-1",
+          outcome: "completed",
+        }),
+      ),
+    ).toMatchObject({ state: "progressing", lastMaterialProgressKind: "assistant_result" });
+  });
+
+  it("binds restored state to the current epoch and rejects impossible cursors", () => {
+    const checkpoint = applyRows([row(1, { type: "compaction", status: "completed" })]);
+    const rebound = rebindMaterialProgressCheckpoint(checkpoint, {
+      timelineEpoch: "epoch-2",
+      nextSeq: 2,
+    });
+    expect(materialProgressPayload(rebound)).toMatchObject({
+      state: "warning",
+      timelineEpoch: "epoch-2",
+      continuationBoundarySeq: 1,
+    });
+
+    const invalid = rebindMaterialProgressCheckpoint(checkpoint, {
+      timelineEpoch: "epoch-reset",
+      nextSeq: 1,
+    });
+    expect(materialProgressPayload(invalid)).toMatchObject({
+      state: "none",
+      timelineEpoch: "epoch-reset",
+      continuationBoundarySeq: null,
+    });
+  });
+
+  it("marks a sequence gap unavailable instead of reusing a stale signal", () => {
+    const checkpoint = advanceMaterialProgressCheckpoint(
+      acceptedCheckpoint(),
+      row(10_001, {
+        type: "tool_call",
+        callId: "write-after-gap",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "proof.txt", content: "new" },
+      }),
+      "epoch-1",
+    );
+
+    expect(materialProgressPayload(checkpoint)).toMatchObject({
+      state: "none",
+      observedThroughSeq: 10_001,
+      continuationBoundarySeq: null,
+    });
+  });
+
+  it("clears a stale signal when a row belongs to a different timeline epoch", () => {
+    const checkpoint = applyRows([
+      row(1, {
+        type: "tool_call",
+        callId: "write-before-reset",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "proof.txt", content: "old" },
+      }),
+    ]);
+
+    const reset = advanceMaterialProgressCheckpoint(
+      checkpoint,
+      row(1, { type: "reasoning", text: "replacement history" }),
+      "epoch-reset",
+    );
+    expect(materialProgressPayload(reset)).toMatchObject({
+      state: "none",
+      timelineEpoch: "epoch-reset",
+      continuationBoundarySeq: null,
+      observedThroughSeq: 1,
+      lastMaterialProgressKind: null,
+    });
+  });
+
+  it("accumulates beyond ten thousand contiguous rows without a capped-history fallback", () => {
+    let checkpoint = acceptedCheckpoint();
+    for (let seq = 1; seq <= 10_000; seq += 1) {
+      checkpoint = advanceMaterialProgressCheckpoint(
+        checkpoint,
+        row(seq, { type: "reasoning", text: `step ${seq}` }),
+        "epoch-1",
+      );
+    }
+    checkpoint = advanceMaterialProgressCheckpoint(
+      checkpoint,
+      row(10_001, {
+        type: "tool_call",
+        callId: "write-after-history",
+        name: "write",
+        status: "completed",
+        error: null,
+        detail: { type: "write", filePath: "proof.txt", content: "new" },
+      }),
+      "epoch-1",
+    );
+
+    expect(materialProgressPayload(checkpoint)).toMatchObject({
+      state: "progressing",
+      observedThroughSeq: 10_001,
+      continuationBoundarySeq: 1,
+      lastMaterialProgressKind: "write",
+    });
+  });
+});

--- a/packages/server/src/server/agent/material-progress.ts
+++ b/packages/server/src/server/agent/material-progress.ts
@@ -325,6 +325,10 @@ export function advanceMaterialProgressCheckpoint(
     });
   }
 
+  if (checkpoint.acceptedTurnId !== null && row.turnId !== checkpoint.acceptedTurnId) {
+    return { ...checkpoint, observedThroughSeq: row.seq };
+  }
+
   let next = withTrailingAssistant({ ...checkpoint, observedThroughSeq: row.seq }, row);
   if (checkpoint.continuationBoundarySeq === null || row.seq < checkpoint.continuationBoundarySeq) {
     return next;

--- a/packages/server/src/server/agent/material-progress.ts
+++ b/packages/server/src/server/agent/material-progress.ts
@@ -208,7 +208,7 @@ export function createMaterialProgressCheckpoint(input: {
   });
 }
 
-export function rebindMaterialProgressCheckpoint(
+export function restoreMaterialProgressCheckpoint(
   checkpoint: MaterialProgressCheckpoint,
   input: { timelineEpoch: string; nextSeq: number },
 ): MaterialProgressCheckpoint {
@@ -216,14 +216,31 @@ export function rebindMaterialProgressCheckpoint(
   const boundaryIsValid =
     checkpoint.continuationBoundarySeq === null ||
     checkpoint.continuationBoundarySeq <= input.nextSeq;
-  if (!boundaryIsValid || checkpoint.observedThroughSeq > lastSeq) {
+  // Sequence bounds are not a continuity identity: replacement timelines can
+  // have the same length or be longer. Only an unchanged epoch proves that the
+  // checkpoint still describes these rows.
+  const continuityIsProven = checkpoint.timelineEpoch === input.timelineEpoch;
+  if (!continuityIsProven || !boundaryIsValid || checkpoint.observedThroughSeq > lastSeq) {
     return emptyCheckpoint({
       timelineEpoch: input.timelineEpoch,
       observedThroughSeq: lastSeq,
-      unavailableReason: "Persisted material progress did not match the restored timeline.",
+      unavailableReason:
+        "Persisted material progress could not be proven to match the restored timeline.",
     });
   }
-  return { ...checkpoint, timelineEpoch: input.timelineEpoch };
+  return checkpoint;
+}
+
+export function invalidateMaterialProgressCheckpoint(input: {
+  timelineEpoch: string;
+  nextSeq: number;
+  reason: string;
+}): MaterialProgressCheckpoint {
+  return emptyCheckpoint({
+    timelineEpoch: input.timelineEpoch,
+    observedThroughSeq: Math.max(0, input.nextSeq - 1),
+    unavailableReason: input.reason,
+  });
 }
 
 export function openMaterialProgressContinuation(input: {

--- a/packages/server/src/server/agent/material-progress.ts
+++ b/packages/server/src/server/agent/material-progress.ts
@@ -1,0 +1,414 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { MaterialProgressPayload } from "../messages.js";
+import type { ToolCallDetail, ToolCallTimelineItem } from "./agent-sdk-types.js";
+import type { AgentTimelineRow } from "./agent-timeline-store-types.js";
+
+export type MaterialProgressKind = NonNullable<MaterialProgressPayload["lastMaterialProgressKind"]>;
+export type MaterialProgressTurnOutcome = "completed" | "failed" | "canceled";
+
+export interface MaterialProgressCheckpoint {
+  timelineEpoch: string;
+  continuationBoundarySeq: number | null;
+  acceptedTurnId: string | null;
+  turnOutcome: MaterialProgressTurnOutcome | null;
+  observedThroughSeq: number;
+  completedCompactionsSinceMaterialProgress: number;
+  lastMaterialProgressAt: string | null;
+  lastMaterialProgressKind: MaterialProgressKind | null;
+  seenMaterialProgressFingerprints: string[];
+  trailingAssistantFingerprint: string | null;
+  trailingAssistantHasConcreteText: boolean;
+  trailingAssistantAt: string | null;
+  unavailableReason?: string;
+}
+
+const MaterialProgressKindSchema = z.enum([
+  "edit",
+  "write",
+  "evidence",
+  "verification",
+  "decision",
+  "assistant_result",
+]);
+
+export const MaterialProgressCheckpointSchema: z.ZodType<MaterialProgressCheckpoint> = z.object({
+  timelineEpoch: z.string(),
+  continuationBoundarySeq: z.number().int().positive().nullable(),
+  acceptedTurnId: z.string().nullable(),
+  turnOutcome: z.enum(["completed", "failed", "canceled"]).nullable(),
+  observedThroughSeq: z.number().int().nonnegative(),
+  completedCompactionsSinceMaterialProgress: z.number().int().nonnegative(),
+  lastMaterialProgressAt: z.string().nullable(),
+  lastMaterialProgressKind: MaterialProgressKindSchema.nullable(),
+  seenMaterialProgressFingerprints: z.array(z.string()),
+  trailingAssistantFingerprint: z.string().nullable(),
+  trailingAssistantHasConcreteText: z.boolean(),
+  trailingAssistantAt: z.string().nullable(),
+  unavailableReason: z.string().optional(),
+});
+
+interface MaterialProgressEvent {
+  kind: MaterialProgressKind;
+  fingerprint: string;
+}
+
+type EditDetail = Extract<ToolCallDetail, { type: "edit" }>;
+type WriteDetail = Extract<ToolCallDetail, { type: "write" }>;
+type EvidenceDetail = Extract<ToolCallDetail, { type: "read" | "search" | "fetch" }>;
+type SearchDetail = Extract<EvidenceDetail, { type: "search" }>;
+type ShellDetail = Extract<ToolCallDetail, { type: "shell" }>;
+type PlanDetail = Extract<ToolCallDetail, { type: "plan" }>;
+
+function hasConcreteText(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function progressFingerprint(kind: MaterialProgressKind, result: unknown): string {
+  return `${kind}:${digest(result)}`;
+}
+
+function progressEvent(kind: MaterialProgressKind, result: unknown): MaterialProgressEvent {
+  return { kind, fingerprint: progressFingerprint(kind, result) };
+}
+
+function editEvent(detail: EditDetail): MaterialProgressEvent | null {
+  const { filePath, oldString, newString, unifiedDiff } = detail;
+  if (!hasConcreteText(unifiedDiff) && oldString !== undefined && oldString === newString) {
+    return null;
+  }
+  if (!hasConcreteText(unifiedDiff) && oldString === undefined && newString === undefined) {
+    return null;
+  }
+  return progressEvent("edit", { filePath, oldString, newString, unifiedDiff });
+}
+
+function writeEvent(detail: WriteDetail): MaterialProgressEvent | null {
+  const { filePath, content } = detail;
+  return content === undefined ? null : progressEvent("write", { filePath, content });
+}
+
+function hasSearchResult(detail: SearchDetail): boolean {
+  return (
+    hasConcreteText(detail.content) ||
+    detail.numFiles !== undefined ||
+    detail.numMatches !== undefined ||
+    (detail.filePaths?.length ?? 0) > 0 ||
+    (detail.webResults?.length ?? 0) > 0 ||
+    (detail.annotations?.length ?? 0) > 0
+  );
+}
+
+function evidenceEvent(detail: EvidenceDetail): MaterialProgressEvent | null {
+  switch (detail.type) {
+    case "read": {
+      const { filePath, content } = detail;
+      return hasConcreteText(content)
+        ? progressEvent("evidence", { type: "read", filePath, content })
+        : null;
+    }
+    case "search": {
+      const { query, content, filePaths, webResults, annotations, numFiles, numMatches } = detail;
+      return hasSearchResult(detail)
+        ? progressEvent("evidence", {
+            type: "search",
+            query,
+            content,
+            filePaths,
+            webResults,
+            annotations,
+            numFiles,
+            numMatches,
+          })
+        : null;
+    }
+    case "fetch": {
+      const { url, result, code, bytes } = detail;
+      const succeeded =
+        hasConcreteText(result) && (code === undefined || (code >= 200 && code < 400));
+      return succeeded
+        ? progressEvent("evidence", { type: "fetch", url, result, code, bytes })
+        : null;
+    }
+  }
+}
+
+function verificationEvent(detail: ShellDetail): MaterialProgressEvent | null {
+  const { command, cwd, output, exitCode } = detail;
+  return exitCode === 0 && hasConcreteText(output)
+    ? progressEvent("verification", { command, cwd, output, exitCode })
+    : null;
+}
+
+function decisionEvent(detail: PlanDetail): MaterialProgressEvent | null {
+  const text = detail.text.trim();
+  return text ? progressEvent("decision", text) : null;
+}
+
+function materialToolEvent(item: ToolCallTimelineItem): MaterialProgressEvent | null {
+  if (item.status !== "completed") return null;
+  switch (item.detail.type) {
+    case "edit":
+      return editEvent(item.detail);
+    case "write":
+      return writeEvent(item.detail);
+    case "read":
+    case "search":
+    case "fetch":
+      return evidenceEvent(item.detail);
+    case "shell":
+      return verificationEvent(item.detail);
+    case "plan":
+      return decisionEvent(item.detail);
+    case "worktree_setup":
+    case "sub_agent":
+    case "unknown":
+    case "plain_text":
+      return null;
+  }
+}
+
+function validTimestamp(value: string): string | null {
+  return Number.isNaN(Date.parse(value)) ? null : value;
+}
+
+function emptyCheckpoint(input: {
+  timelineEpoch: string;
+  observedThroughSeq: number;
+  unavailableReason?: string;
+}): MaterialProgressCheckpoint {
+  return {
+    timelineEpoch: input.timelineEpoch,
+    continuationBoundarySeq: null,
+    acceptedTurnId: null,
+    turnOutcome: null,
+    observedThroughSeq: input.observedThroughSeq,
+    completedCompactionsSinceMaterialProgress: 0,
+    lastMaterialProgressAt: null,
+    lastMaterialProgressKind: null,
+    seenMaterialProgressFingerprints: [],
+    trailingAssistantFingerprint: null,
+    trailingAssistantHasConcreteText: false,
+    trailingAssistantAt: null,
+    ...(input.unavailableReason ? { unavailableReason: input.unavailableReason } : {}),
+  };
+}
+
+export function createMaterialProgressCheckpoint(input: {
+  timelineEpoch: string;
+  nextSeq: number;
+}): MaterialProgressCheckpoint {
+  return emptyCheckpoint({
+    timelineEpoch: input.timelineEpoch,
+    observedThroughSeq: Math.max(0, input.nextSeq - 1),
+  });
+}
+
+export function rebindMaterialProgressCheckpoint(
+  checkpoint: MaterialProgressCheckpoint,
+  input: { timelineEpoch: string; nextSeq: number },
+): MaterialProgressCheckpoint {
+  const lastSeq = Math.max(0, input.nextSeq - 1);
+  const boundaryIsValid =
+    checkpoint.continuationBoundarySeq === null ||
+    checkpoint.continuationBoundarySeq <= input.nextSeq;
+  if (!boundaryIsValid || checkpoint.observedThroughSeq > lastSeq) {
+    return emptyCheckpoint({
+      timelineEpoch: input.timelineEpoch,
+      observedThroughSeq: lastSeq,
+      unavailableReason: "Persisted material progress did not match the restored timeline.",
+    });
+  }
+  return { ...checkpoint, timelineEpoch: input.timelineEpoch };
+}
+
+export function openMaterialProgressContinuation(input: {
+  timelineEpoch: string;
+  boundarySeq: number;
+  turnId: string;
+}): MaterialProgressCheckpoint {
+  return {
+    ...emptyCheckpoint({
+      timelineEpoch: input.timelineEpoch,
+      observedThroughSeq: Math.max(0, input.boundarySeq - 1),
+    }),
+    continuationBoundarySeq: input.boundarySeq,
+    acceptedTurnId: input.turnId,
+  };
+}
+
+function withTrailingAssistant(
+  checkpoint: MaterialProgressCheckpoint,
+  row: AgentTimelineRow,
+): MaterialProgressCheckpoint {
+  if (row.item.type !== "assistant_message") {
+    return {
+      ...checkpoint,
+      trailingAssistantFingerprint: null,
+      trailingAssistantHasConcreteText: false,
+      trailingAssistantAt: null,
+    };
+  }
+  const previous = checkpoint.trailingAssistantFingerprint;
+  return {
+    ...checkpoint,
+    trailingAssistantFingerprint: digest(
+      previous === null ? { text: row.item.text } : { previous, text: row.item.text },
+    ),
+    trailingAssistantHasConcreteText:
+      checkpoint.trailingAssistantHasConcreteText || hasConcreteText(row.item.text),
+    trailingAssistantAt: validTimestamp(row.timestamp),
+  };
+}
+
+function recordMaterialEvent(
+  checkpoint: MaterialProgressCheckpoint,
+  event: MaterialProgressEvent | null,
+  timestamp: string,
+): MaterialProgressCheckpoint {
+  if (!event || checkpoint.seenMaterialProgressFingerprints.includes(event.fingerprint)) {
+    return checkpoint;
+  }
+  return {
+    ...checkpoint,
+    completedCompactionsSinceMaterialProgress: 0,
+    lastMaterialProgressAt: validTimestamp(timestamp),
+    lastMaterialProgressKind: event.kind,
+    seenMaterialProgressFingerprints: [
+      ...checkpoint.seenMaterialProgressFingerprints,
+      event.fingerprint,
+    ],
+  };
+}
+
+export function advanceMaterialProgressCheckpoint(
+  checkpoint: MaterialProgressCheckpoint,
+  row: AgentTimelineRow,
+  timelineEpoch: string,
+): MaterialProgressCheckpoint {
+  if (checkpoint.timelineEpoch !== timelineEpoch) {
+    return emptyCheckpoint({
+      timelineEpoch,
+      observedThroughSeq: row.seq,
+      unavailableReason: "Material progress is unavailable because the timeline epoch changed.",
+    });
+  }
+  if (row.seq <= checkpoint.observedThroughSeq) {
+    return checkpoint;
+  }
+  if (row.seq !== checkpoint.observedThroughSeq + 1) {
+    return emptyCheckpoint({
+      timelineEpoch,
+      observedThroughSeq: row.seq,
+      unavailableReason: "Material progress is unavailable because timeline history is incomplete.",
+    });
+  }
+
+  let next = withTrailingAssistant({ ...checkpoint, observedThroughSeq: row.seq }, row);
+  if (checkpoint.continuationBoundarySeq === null || row.seq < checkpoint.continuationBoundarySeq) {
+    return next;
+  }
+
+  const event = row.item.type === "tool_call" ? materialToolEvent(row.item) : null;
+  next = recordMaterialEvent(next, event, row.timestamp);
+  if (row.item.type === "compaction" && row.item.status === "completed") {
+    next = {
+      ...next,
+      completedCompactionsSinceMaterialProgress: next.completedCompactionsSinceMaterialProgress + 1,
+    };
+  }
+  return next;
+}
+
+export function settleMaterialProgressContinuation(
+  checkpoint: MaterialProgressCheckpoint,
+  input: { turnId: string; outcome: MaterialProgressTurnOutcome },
+): MaterialProgressCheckpoint {
+  if (checkpoint.acceptedTurnId !== input.turnId) return checkpoint;
+  let next: MaterialProgressCheckpoint = { ...checkpoint, turnOutcome: input.outcome };
+  if (
+    input.outcome === "completed" &&
+    checkpoint.trailingAssistantFingerprint !== null &&
+    checkpoint.trailingAssistantHasConcreteText
+  ) {
+    next = recordMaterialEvent(
+      next,
+      {
+        kind: "assistant_result",
+        fingerprint: `assistant_result:${checkpoint.trailingAssistantFingerprint}`,
+      },
+      checkpoint.trailingAssistantAt ?? "",
+    );
+  }
+  return next;
+}
+
+export function materialProgressPayload(
+  checkpoint: MaterialProgressCheckpoint | null | undefined,
+): MaterialProgressPayload {
+  if (!checkpoint) {
+    return {
+      state: "none",
+      timelineEpoch: null,
+      continuationBoundarySeq: null,
+      observedThroughSeq: null,
+      completedCompactionsSinceMaterialProgress: 0,
+      lastMaterialProgressAt: null,
+      lastMaterialProgressKind: null,
+      reason: "Material progress is unavailable from this stored agent snapshot.",
+    };
+  }
+
+  const base = {
+    timelineEpoch: checkpoint.timelineEpoch,
+    continuationBoundarySeq: checkpoint.continuationBoundarySeq,
+    observedThroughSeq: checkpoint.observedThroughSeq,
+    completedCompactionsSinceMaterialProgress: checkpoint.completedCompactionsSinceMaterialProgress,
+    lastMaterialProgressAt: checkpoint.lastMaterialProgressAt,
+    lastMaterialProgressKind: checkpoint.lastMaterialProgressKind,
+  };
+  if (checkpoint.unavailableReason) {
+    return { ...base, state: "none", reason: checkpoint.unavailableReason };
+  }
+  if (checkpoint.continuationBoundarySeq === null) {
+    return {
+      ...base,
+      state: "none",
+      reason: "No accepted continuation is available for the current timeline epoch.",
+    };
+  }
+  if (checkpoint.completedCompactionsSinceMaterialProgress >= 2) {
+    const count = checkpoint.completedCompactionsSinceMaterialProgress;
+    return {
+      ...base,
+      state: "stalled",
+      reason:
+        count === 2
+          ? "Two compactions completed without later distinct material progress."
+          : `${count} compactions completed without later distinct material progress.`,
+    };
+  }
+  if (checkpoint.completedCompactionsSinceMaterialProgress === 1) {
+    return {
+      ...base,
+      state: "warning",
+      reason: "One compaction completed without later distinct material progress.",
+    };
+  }
+  if (checkpoint.lastMaterialProgressKind) {
+    return {
+      ...base,
+      state: "progressing",
+      reason: "Distinct material progress was recorded in the current accepted continuation.",
+    };
+  }
+  return {
+    ...base,
+    state: "none",
+    reason: "No material progress has been recorded for the current accepted continuation.",
+  };
+}

--- a/packages/server/src/server/agent/rewind/rewind.test.ts
+++ b/packages/server/src/server/agent/rewind/rewind.test.ts
@@ -1,8 +1,18 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { AgentManager } from "../agent-manager.js";
-import type { AgentClient, AgentSession, AgentSessionConfig } from "../agent-sdk-types.js";
+import type {
+  AgentClient,
+  AgentSession,
+  AgentSessionConfig,
+  AgentStreamEvent,
+  FetchCatalogOptions,
+} from "../agent-sdk-types.js";
+import { AgentStorage } from "../agent-storage.js";
 import { FakeRewindSession, REWIND_TEST_CAPABILITIES } from "./test-rewind-session.js";
 
 class FakeRewindClient implements AgentClient {
@@ -49,10 +59,18 @@ class RewindHistoryGate {
   }
 }
 
-async function createRewindHarness(options: { historyGate?: RewindHistoryGate } = {}) {
-  const session = new FakeRewindSession(options.historyGate?.wait.bind(options.historyGate));
+async function createRewindHarness(
+  options: {
+    historyGate?: RewindHistoryGate;
+    session?: FakeRewindSession;
+    storage?: AgentStorage;
+  } = {},
+) {
+  const session =
+    options.session ?? new FakeRewindSession(options.historyGate?.wait.bind(options.historyGate));
   const manager = new AgentManager({
     clients: { claude: new FakeRewindClient(session) },
+    registry: options.storage,
     logger: createTestLogger(),
     idFactory: () => "00000000-0000-4000-8000-000000000901",
   });
@@ -65,6 +83,47 @@ async function createRewindHarness(options: { historyGate?: RewindHistoryGate } 
     { workspaceId: undefined },
   );
   return { manager, session, agentId: agent.id };
+}
+
+async function createPersistedRewindHarness(session = new FakeRewindSession()) {
+  const root = mkdtempSync(join(tmpdir(), "material-progress-rewind-"));
+  const storage = new AgentStorage(join(root, "agents"), createTestLogger());
+  const harness = await createRewindHarness({ session, storage });
+  return {
+    ...harness,
+    storage,
+    async cleanup() {
+      await harness.manager.flush().catch(() => undefined);
+      await storage.flush().catch(() => undefined);
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+async function seedMaterialProgress(
+  manager: AgentManager,
+  session: FakeRewindSession,
+  agentId: string,
+): Promise<void> {
+  const run = manager.streamAgent(agentId, "produce durable progress");
+  await run.next();
+  await manager.appendTimelineItem(agentId, {
+    type: "tool_call",
+    callId: "write-before-rewind",
+    name: "write",
+    status: "completed",
+    error: null,
+    detail: { type: "write", filePath: "proof.txt", content: "durable proof" },
+  });
+  await session.interrupt();
+  for await (const _event of run) {
+    // Drain the canceled turn so its terminal state is persisted.
+  }
+  await manager.flush();
+  expect(manager.getMaterialProgress(agentId)).toMatchObject({
+    state: "progressing",
+    lastMaterialProgressKind: "write",
+  });
 }
 
 describe("AgentManager rewind", () => {
@@ -87,6 +146,97 @@ describe("AgentManager rewind", () => {
 
     expect(session.recordedRewinds).toEqual([{ mode: "files", messageId: "message-1" }]);
     expect(session.historyReadCount).toBe(0);
+  });
+
+  test("invalidates and persists material progress after a successful files rewind", async () => {
+    const { manager, session, storage, agentId, cleanup } = await createPersistedRewindHarness();
+
+    try {
+      await seedMaterialProgress(manager, session, agentId);
+
+      await manager.rewind(agentId, "message-1", "files");
+
+      expect(session.recordedRewinds).toEqual([{ mode: "files", messageId: "message-1" }]);
+      expect(session.historyReadCount).toBe(0);
+      expect(manager.getMaterialProgress(agentId)).toMatchObject({
+        state: "none",
+        continuationBoundarySeq: null,
+        lastMaterialProgressKind: null,
+        reason: "Material progress is unavailable because the provider session was rewound.",
+      });
+      expect((await storage.get(agentId))?.materialProgress).toMatchObject({
+        continuationBoundarySeq: null,
+        lastMaterialProgressKind: null,
+        unavailableReason:
+          "Material progress is unavailable because the provider session was rewound.",
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("persists invalidation before conversation history rehydration can fail", async () => {
+    class FailingHistorySession extends FakeRewindSession {
+      override async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+        yield* super.streamHistory();
+        throw new Error("history unavailable after successful rewind");
+      }
+    }
+
+    const session = new FailingHistorySession();
+    const { manager, storage, agentId, cleanup } = await createPersistedRewindHarness(session);
+
+    try {
+      await seedMaterialProgress(manager, session, agentId);
+
+      await expect(manager.rewind(agentId, "message-1", "conversation")).rejects.toThrow(
+        "history unavailable after successful rewind",
+      );
+
+      expect(session.recordedRewinds).toEqual([{ mode: "conversation", messageId: "message-1" }]);
+      expect(session.historyReadCount).toBe(1);
+      expect(manager.getMaterialProgress(agentId)).toMatchObject({
+        state: "none",
+        continuationBoundarySeq: null,
+        lastMaterialProgressKind: null,
+        reason: "Material progress is unavailable because the provider session was rewound.",
+      });
+      expect((await storage.get(agentId))?.materialProgress).toMatchObject({
+        continuationBoundarySeq: null,
+        lastMaterialProgressKind: null,
+        unavailableReason:
+          "Material progress is unavailable because the provider session was rewound.",
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("preserves material progress when the provider rewind fails", async () => {
+    class RejectingProviderRewindSession extends FakeRewindSession {
+      override async revertFiles(): Promise<void> {
+        throw new Error("provider rewind rejected");
+      }
+    }
+
+    const session = new RejectingProviderRewindSession();
+    const { manager, storage, agentId, cleanup } = await createPersistedRewindHarness(session);
+
+    try {
+      await seedMaterialProgress(manager, session, agentId);
+      const beforePayload = manager.getMaterialProgress(agentId);
+      const beforeStored = structuredClone((await storage.get(agentId))?.materialProgress);
+
+      await expect(manager.rewind(agentId, "message-1", "files")).rejects.toThrow(
+        "provider rewind rejected",
+      );
+
+      expect(session.recordedRewinds).toEqual([]);
+      expect(manager.getMaterialProgress(agentId)).toEqual(beforePayload);
+      expect((await storage.get(agentId))?.materialProgress).toEqual(beforeStored);
+    } finally {
+      await cleanup();
+    }
   });
 
   test("aborts an in-flight turn before rewinding", async () => {

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -128,6 +128,7 @@ import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
 import { AgentStorage } from "./agent/agent-storage.js";
+import { FileAgentTimelineStore } from "./agent/file-agent-timeline-store.js";
 import { attachAgentStoragePersistence } from "./persistence-hooks.js";
 import { createAgentMcpServer } from "./agent/mcp-server.js";
 import {
@@ -781,6 +782,10 @@ export async function createPaseoDaemon(
   }
 
   const agentStorage = new AgentStorage(config.agentStoragePath, logger);
+  const durableTimelineStore = new FileAgentTimelineStore(
+    path.join(config.paseoHome, "timelines"),
+    logger,
+  );
   const projectRegistry = new FileBackedProjectRegistry(
     path.join(config.paseoHome, "projects", "projects.json"),
     logger,
@@ -824,6 +829,7 @@ export async function createPaseoDaemon(
     clients: initialAgentManagerState.clients,
     providerDefinitions: initialAgentManagerState.providerDefinitions,
     registry: agentStorage,
+    durableTimelineStore,
     appendSystemPrompt: config.appendSystemPrompt,
     onWorkspaceStateMayHaveChanged: ({ cwd }) => {
       workspaceGitService.onWorkspaceStateMayHaveChanged(cwd);

--- a/packages/server/src/server/material-progress.e2e.test.ts
+++ b/packages/server/src/server/material-progress.e2e.test.ts
@@ -1,0 +1,78 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { createDaemonTestContext, type DaemonTestContext } from "./test-utils/index.js";
+
+describe("daemon E2E - material progress snapshot", () => {
+  let ctx: DaemonTestContext;
+
+  beforeEach(async () => {
+    ctx = await createDaemonTestContext();
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  }, 60_000);
+
+  test("agent fetch reports progress, compaction stall, recovery, and archived readback", async () => {
+    const cwd = mkdtempSync(path.join(tmpdir(), "material-progress-e2e-"));
+    try {
+      const agent = await ctx.client.createAgent({
+        provider: "codex",
+        cwd,
+        title: "Material Progress E2E",
+        modeId: "full-access",
+      });
+
+      await ctx.client.sendMessage(agent.id, "Respond with exactly: READY");
+      expect((await ctx.client.waitForFinish(agent.id, 5_000)).status).toBe("idle");
+
+      const afterAcceptedTurn = await ctx.client.fetchAgent({ agentId: agent.id });
+      expect(afterAcceptedTurn?.agent.materialProgress).toMatchObject({
+        state: "progressing",
+        continuationBoundarySeq: 1,
+        lastMaterialProgressKind: "assistant_result",
+      });
+
+      await ctx.daemon.daemon.agentManager.appendTimelineItem(agent.id, {
+        type: "compaction",
+        status: "completed",
+      });
+      await ctx.daemon.daemon.agentManager.appendTimelineItem(agent.id, {
+        type: "compaction",
+        status: "completed",
+      });
+
+      const stalled = await ctx.client.fetchAgent({ agentId: agent.id });
+      expect(stalled?.agent.materialProgress).toMatchObject({
+        state: "stalled",
+        completedCompactionsSinceMaterialProgress: 2,
+        lastMaterialProgressKind: "assistant_result",
+      });
+
+      await ctx.daemon.daemon.agentManager.appendTimelineItem(agent.id, {
+        type: "tool_call",
+        callId: "read-after-compactions",
+        name: "read",
+        status: "completed",
+        error: null,
+        detail: { type: "read", filePath: "proof.txt", content: "fresh evidence" },
+      });
+      const recovered = await ctx.client.fetchAgent({ agentId: agent.id });
+      expect(recovered?.agent.materialProgress).toMatchObject({
+        state: "progressing",
+        completedCompactionsSinceMaterialProgress: 0,
+        lastMaterialProgressKind: "evidence",
+      });
+
+      await ctx.daemon.daemon.agentManager.archiveAgent(agent.id);
+      const archived = await ctx.client.fetchAgent({ agentId: agent.id });
+      expect(archived?.agent.status).toBe("closed");
+      expect(archived?.agent.materialProgress).toEqual(recovered?.agent.materialProgress);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/server/src/server/persistence-hooks.ts
+++ b/packages/server/src/server/persistence-hooks.ts
@@ -111,6 +111,7 @@ export function extractTimestamps(record: StoredAgentRecord): {
   labels?: Record<string, string>;
   workspaceId?: string;
   owner?: StoredAgentRecord["owner"];
+  materialProgress?: StoredAgentRecord["materialProgress"];
 } {
   return {
     createdAt: new Date(record.createdAt),
@@ -119,6 +120,7 @@ export function extractTimestamps(record: StoredAgentRecord): {
     labels: record.labels,
     workspaceId: record.workspaceId,
     owner: record.owner,
+    materialProgress: record.materialProgress,
   };
 }
 

--- a/packages/server/src/server/persistence-hooks.ts
+++ b/packages/server/src/server/persistence-hooks.ts
@@ -111,6 +111,7 @@ export function extractTimestamps(record: StoredAgentRecord): {
   labels?: Record<string, string>;
   workspaceId?: string;
   owner?: StoredAgentRecord["owner"];
+  historyPrimed?: boolean;
   materialProgress?: StoredAgentRecord["materialProgress"];
 } {
   return {
@@ -120,6 +121,7 @@ export function extractTimestamps(record: StoredAgentRecord): {
     labels: record.labels,
     workspaceId: record.workspaceId,
     owner: record.owner,
+    historyPrimed: record.historyPrimed,
     materialProgress: record.materialProgress,
   };
 }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3421,7 +3421,10 @@ export class Session {
           logger: this.sessionLogger,
         });
       }
-      await this.agentManager.hydrateTimelineFromProvider(agentId, { broadcast: true });
+      await this.agentManager.hydrateTimelineFromProvider(agentId, {
+        broadcast: true,
+        force: true,
+      });
       await this.agentUpdates.forwardLiveAgent(snapshot);
       const timelineSize = this.agentManager.getTimeline(agentId).length;
       if (requestId) {

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -5066,7 +5066,12 @@ test("refresh_agent_request leaves workspace archival independent when its direc
   session.agentManager.getAgent = () => managed;
   session.interruptAgentIfRunning = async () => undefined;
   session.agentManager.reloadAgentSession = async () => managed;
-  session.agentManager.hydrateTimelineFromProvider = async () => undefined;
+  let hydrationRequest:
+    | { agentId: string; options: { broadcast?: boolean; force?: boolean } | undefined }
+    | undefined;
+  session.agentManager.hydrateTimelineFromProvider = async (requestedAgentId, options) => {
+    hydrationRequest = { agentId: requestedAgentId, options };
+  };
   session.agentManager.getTimeline = () => [];
   session.agentUpdates.forwardLiveAgent = async () => undefined;
 
@@ -5087,6 +5092,39 @@ test("refresh_agent_request leaves workspace archival independent when its direc
   expect(projects.get(cwd)?.archivedAt).toBe("2026-03-10T00:00:00.000Z");
   expect(unarchivedWorkspaceIds).toEqual([]);
   expect(findByType(emitted, "rpc_error")).toBeUndefined();
+  expect(hydrationRequest).toEqual({
+    agentId,
+    options: { broadcast: true, force: true },
+  });
+
+  session.agentManager.hydrateTimelineFromProvider = async () => {
+    throw new Error("provider refresh history failed");
+  };
+  await session.handleMessage({
+    type: "refresh_agent_request",
+    agentId,
+    requestId: "req-refresh-history-failure",
+  });
+
+  expect(
+    emitted.find(
+      (message) =>
+        message.type === "rpc_error" && message.payload.requestId === "req-refresh-history-failure",
+    )?.payload,
+  ).toMatchObject({
+    requestId: "req-refresh-history-failure",
+    requestType: "refresh_agent_request",
+    code: "agent_refresh_failed",
+    error: "provider refresh history failed",
+  });
+  expect(
+    emitted.find(
+      (message) =>
+        message.type === "status" &&
+        message.payload.status === "agent_refreshed" &&
+        message.payload.requestId === "req-refresh-history-failure",
+    ),
+  ).toBeUndefined();
 });
 
 test("refresh_agent_request leaves workspace archival independent when its directory is missing", async () => {

--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -933,6 +933,7 @@ describe("relay external socket reconnect behavior", () => {
 
     expect(serverInfo.features?.stableProjectIdentity).toBe(true);
     expect(serverInfo.features?.canonicalSubmittedPrompts).toBe(true);
+    expect(serverInfo.features?.materialProgress).toBe(true);
     expect(serverInfo.features?.agentTurnIdentity).toBeUndefined();
     await server.close();
   });

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1555,6 +1555,8 @@ export class VoiceAssistantWebSocketServer {
         agentDetach: true,
         // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.
         agentThinkingUpdate: true,
+        // COMPAT(materialProgress): added in v0.2.5, remove gate after 2027-02-01.
+        materialProgress: true,
         // COMPAT(daemonDiagnostics): added in v0.1.100, remove gate after 2026-12-25 once daemon floor >= v0.1.100.
         daemonDiagnostics: true,
         // COMPAT(daemonSelfUpdate): added in v0.1.93, remove gate after 2026-12-13.


### PR DESCRIPTION
## Summary

- add an additive, provider-neutral materialProgress snapshot to agent inspection
- persist an epoch- and sequence-bound incremental checkpoint so restart, replacement, and histories beyond 10,000 rows cannot silently reuse stale evidence
- distinguish no progress, progressing, warning, and stalled from concrete material events and completed compactions
- expose the snapshot through agent fetches, agent inspect table/JSON output, archived records, and an explicit server capability

## Successor context

This is the narrow current-main successor to #2721. It intentionally leaves #2721 open and excludes its lifecycle manifests, receipts, provider adapters, and lifecycle-control changes. The snapshot is observational only and does not change whether an agent runs, stops, or continues.

## Compatibility

Older clients ignore the optional snapshot field. New clients accept legacy snapshots without it and can gate on server_info.features.materialProgress.

## Verification

- 225 focused tests across protocol, classifier, manager, storage, projection, CLI, websocket capability, and daemon E2E
- protocol, server, and CLI package builds
- repository-wide typecheck
- repository-wide lint
- repository-wide format check
- normal pre-commit hook across all files
- clean diff and worktree on merge tree e024eb1811434f437e5ff6f9e3e29d2773877840, based on main 9ddc3e0c4253b4cf3a1a7b864b7a92294cf2e8d4