### PR TITLE
Restore browser test routing

### DIFF
--- a/packages/app/e2e/browser/project-status-badge.spec.ts
+++ b/packages/app/e2e/browser/project-status-badge.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./support/fixtures";
+import { test } from "../support/fixtures";
 import {
   expandStatusProject,
   expectCollapsedProjectStatus,
@@ -8,7 +8,7 @@ import {
   seedStatusProject,
   startNeedsInputWorkspace,
   startWorkingWorkspace,
-} from "./helpers/project-status-badge";
+} from "../helpers/project-status-badge";
 
 test("a collapsed project surfaces its most urgent hidden workspace status", async ({ page }) => {
   test.setTimeout(120_000);


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The project status badge Playwright spec was added at the app E2E root after browser tests became owned by `packages/app/e2e/browser`. The always-running CI contract therefore rejected every pull-request checkout, while the Playwright browser project did not collect the misplaced spec.

Move the spec into the browser-owned directory and keep the ownership assertion intact. This restores PR routing and makes the regression test executable again.

### Goals

- Restore the always-running `changes` check.
- Keep browser and desktop test ownership explicit.
- Ensure Playwright discovers the project status badge spec.

### Non-goals

- Change CI routing rules or required checks.
- Change project status badge behavior.

### QA

Red reproduction before the fix:

```text
node --test scripts/ci-workflow.test.mjs
# browser and desktop tests have exclusive, directory-owned suites: failed
# assert.ok(browserSpecs.every((path) => path.startsWith("packages/app/e2e/browser/")))
```

Green verification:

```text
node --test scripts/ci-workflow.test.mjs scripts/daemon-launch-contract.test.mjs
# 9 passed, 0 failed

npm run test:e2e --workspace=@getpaseo/app -- --list packages/app/e2e/browser/project-status-badge.spec.ts
# Total: 1 test in 1 file

npm run typecheck
# passed

npm run lint
# Found 0 warnings and 0 errors

npm run format
# passed
```

No runtime or UI behavior changed. Verification ran on Linux.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense