### PR TITLE
fix(cli): bound WebSocket close handshake

### DIFF
--- a/packages/cli/src/utils/client.test.ts
+++ b/packages/cli/src/utils/client.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { installBoundedWebSocketClose } from "./client";
+
+class FakeCliWebSocket {
+  readyState = 1;
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+  terminateCalls = 0;
+  private closeListeners: Array<() => void> = [];
+
+  send(): void {}
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+  }
+
+  terminate(): void {
+    this.terminateCalls++;
+  }
+
+  once(event: "close", listener: () => void): void {
+    if (event === "close") {
+      this.closeListeners.push(listener);
+    }
+  }
+
+  emitClose(): void {
+    this.readyState = 3;
+    for (const listener of this.closeListeners.splice(0)) {
+      listener();
+    }
+  }
+}
+
+function createFakeTimers() {
+  class FakeTimer {
+    cleared = false;
+    unrefCalls = 0;
+
+    constructor(
+      readonly callback: () => void,
+      readonly delayMs: number,
+    ) {}
+
+    unref(): void {
+      this.unrefCalls++;
+    }
+  }
+
+  const scheduled: FakeTimer[] = [];
+
+  const timers = {
+    setTimeout(callback, delayMs) {
+      const timer = new FakeTimer(callback, delayMs);
+      scheduled.push(timer);
+      return timer;
+    },
+    clearTimeout(timerHandle) {
+      const timer = scheduled.find((entry) => entry === timerHandle);
+      if (timer) {
+        timer.cleared = true;
+      }
+    },
+  } satisfies NonNullable<Parameters<typeof installBoundedWebSocketClose>[1]>;
+
+  return { scheduled, timers };
+}
+
+describe("installBoundedWebSocketClose", () => {
+  it("unrefs and terminates a socket whose close handshake does not complete", () => {
+    const socket = new FakeCliWebSocket();
+    const { scheduled, timers } = createFakeTimers();
+    installBoundedWebSocketClose(socket, timers, 25);
+
+    socket.close(1000, "command complete");
+
+    expect(socket.closeCalls).toEqual([{ code: 1000, reason: "command complete" }]);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toMatchObject({ delayMs: 25, cleared: false, unrefCalls: 1 });
+
+    scheduled[0]?.callback();
+
+    expect(socket.terminateCalls).toBe(1);
+  });
+
+  it("cancels termination when graceful close completes first", () => {
+    const socket = new FakeCliWebSocket();
+    const { scheduled, timers } = createFakeTimers();
+    installBoundedWebSocketClose(socket, timers, 25);
+
+    socket.close();
+    socket.emitClose();
+    scheduled[0]?.callback();
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]).toMatchObject({ cleared: true, unrefCalls: 1 });
+    expect(socket.terminateCalls).toBe(0);
+  });
+});

--- a/packages/cli/src/utils/client.ts
+++ b/packages/cli/src/utils/client.ts
@@ -30,7 +30,27 @@ export interface DaemonConnectionCommandError {
 
 const DEFAULT_HOST = "localhost:6767";
 const DEFAULT_TIMEOUT = 15000;
+const WEBSOCKET_CLOSE_TIMEOUT_MS = 1000;
 const PID_FILENAME = "paseo.pid";
+
+interface TerminableWebSocket extends WebSocketLike {
+  terminate(): void;
+  once(event: "close", listener: () => void): void;
+}
+
+interface WebSocketCloseTimer {
+  unref(): void;
+}
+
+interface WebSocketCloseTimers {
+  setTimeout(callback: () => void, delayMs: number): WebSocketCloseTimer;
+  clearTimeout(timer: WebSocketCloseTimer): void;
+}
+
+const nodeWebSocketCloseTimers: WebSocketCloseTimers = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+};
 
 type DaemonTarget =
   | {
@@ -256,11 +276,47 @@ function createNodeWebSocketFactory() {
     url: string,
     options?: { headers?: Record<string, string>; protocols?: string[]; socketPath?: string },
   ): WebSocketLike => {
-    return new WebSocket(url, options?.protocols, {
+    const socket = new WebSocket(url, options?.protocols, {
       headers: options?.headers,
       ...(options?.socketPath ? { socketPath: options.socketPath } : {}),
-    }) as unknown as WebSocketLike;
+    }) as unknown as TerminableWebSocket;
+    return installBoundedWebSocketClose(socket);
   };
+}
+
+export function installBoundedWebSocketClose(
+  socket: TerminableWebSocket,
+  timers: WebSocketCloseTimers = nodeWebSocketCloseTimers,
+  timeoutMs = WEBSOCKET_CLOSE_TIMEOUT_MS,
+): WebSocketLike {
+  // Node's `ws.close()` has no handshake timeout. Bound only the CLI socket's graceful close.
+  const gracefulClose = socket.close.bind(socket);
+  let terminateTimer: WebSocketCloseTimer | null = null;
+
+  socket.once("close", () => {
+    if (terminateTimer) {
+      timers.clearTimeout(terminateTimer);
+      terminateTimer = null;
+    }
+  });
+
+  socket.close = (code?: number, reason?: string) => {
+    try {
+      gracefulClose(code, reason);
+    } finally {
+      if (socket.readyState !== WebSocket.CLOSED && !terminateTimer) {
+        terminateTimer = timers.setTimeout(() => {
+          terminateTimer = null;
+          if (socket.readyState !== WebSocket.CLOSED) {
+            socket.terminate();
+          }
+        }, timeoutMs);
+        terminateTimer.unref();
+      }
+    }
+  };
+
+  return socket;
 }
 
 /**


### PR DESCRIPTION
## Summary

- keep the Node CLI WebSocket graceful close path, then terminate it after a one-second bound if the peer does not complete the handshake
- cancel the fallback on normal close and unref its timer so it cannot retain the CLI process
- apply the behavior at the CLI-only WebSocket factory, covering direct, IPC, and relay command cleanup without changing shared desktop or mobile transports

## Live reproduction

Before this patch, a live `paseo agent finish <id> --json` run against official main `048b82f2a7b3ecc9b62bc5b817729f4ca2741863` committed agent archival and workspace removal, emitted no terminal receipt, and retained only the CLI process for more than 90 seconds until it was interrupted.

## Tests

- `npx vitest run packages/cli/src/utils/client.test.ts --bail=1`
- `npx tsx packages/cli/tests/28-client-ipc-targets.test.ts`
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`