### PR TITLE
Fix Darwin Nix desktop app icon

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,22 @@
         let
           pkgs = pkgsFor system;
           paseo = pkgs.callPackage ./nix/package.nix { };
+          versionParts = pkgs.lib.splitString "." paseo.version;
+          sourceRevision = if self ? revCount && self.revCount != null then self.revCount else 0;
+          buildRevision = sourceRevision - (sourceRevision / 10000) * 10000;
+          desktopBuildVersion = pkgs.lib.concatStringsSep "." [
+            (builtins.elemAt versionParts 0)
+            (builtins.elemAt versionParts 1)
+            (toString buildRevision)
+          ];
         in
         {
           default = paseo;
           paseo = paseo;
-          desktop = pkgs.callPackage ./nix/desktop-package.nix { inherit paseo; };
+          desktop = pkgs.callPackage ./nix/desktop-package.nix {
+            inherit paseo;
+            buildVersion = desktopBuildVersion;
+          };
         }
       );
 

--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -10,6 +10,7 @@
   makeDesktopItem,
   electron,
   libuv,
+  buildVersion,
   # Reuse the daemon's prebuilt npm-deps FOD. Same lockfile, same content —
   # without this, the desktop drv produces a separately-named store path
   # (`paseo-desktop-<v>-npm-deps`) and refetches the entire registry. Override
@@ -126,6 +127,7 @@ buildNpmPackage {
             --mac \
             --publish never \
             --config.electronDist="$electron_dist" \
+            --config.buildVersion=${lib.escapeShellArg buildVersion} \
             --config.mac.identity=null \
             --config.mac.hardenedRuntime=false \
             --config.mac.notarize=false

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -42,6 +42,8 @@ mac:
   extraResources:
     - from: bin/paseo
       to: bin/paseo
+    - from: assets/icon.png
+      to: icon.png
   target:
     - dmg
     - zip

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -651,8 +651,8 @@ function applyAppIcon(): void {
     return;
   }
 
-  const iconPath = path.resolve(__dirname, "../assets/icon.png");
-  if (!existsSync(iconPath)) {
+  const iconPath = getWindowIconPath();
+  if (!iconPath) {
     return;
   }
 


### PR DESCRIPTION
Fixes #2782.

## What changed

- Package `assets/icon.png` as a macOS Electron resource.
- Resolve the Dock icon through the packaged/development-aware icon path helper.
- Give committed Darwin Nix builds a deterministic per-commit `CFBundleVersion` so Finder and LaunchServices invalidate stale bundle metadata across immutable store paths.

## Why

The Darwin Nix bundle included the correct `icon.icns` and `CFBundleIconFile`, but the runtime Dock-icon code only checked the development source-tree path. Packaged apps therefore could not find the PNG used by `app.dock.setIcon()`.

Nix rebuilds also produced new immutable bundle paths with the same `CFBundleVersion`. Finder could retain stale LaunchServices metadata until the bundle was explicitly re-registered. The Nix flake now derives the build version from the Git revision count while leaving `CFBundleShortVersionString` unchanged.

## QA evidence

### Bundle inspection before the fix

```console
$ /usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' result/Applications/Paseo.app/Contents/Info.plist
icon.icns

$ shasum -a 256 packages/desktop/assets/icon.icns result/Applications/Paseo.app/Contents/Resources/icon.icns
1f251e08249cd3e3712892fcce093c6ed86bae51f0ebbf9d5049fe8e40d74eda  packages/desktop/assets/icon.icns
1f251e08249cd3e3712892fcce093c6ed86bae51f0ebbf9d5049fe8e40d74eda  result/Applications/Paseo.app/Contents/Resources/icon.icns
```

The generated bundle did not contain `Contents/Resources/icon.png`, despite the packaged runtime resolving that path.

### Static checks

```console
$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.

$ git diff --check
```

The committed flake resolves a distinct bundle version and passes it to electron-builder:

```console
$ nix flake metadata --json --no-write-lock-file | jq '{revCount,lastModified}'
{
  "revCount": 4675,
  "lastModified": 1785634167
}

$ nix derivation show .#desktop | rg -o -- '--config\.buildVersion=[^ ]+' | head -1
--config.buildVersion=0.2.4675
```

Finder was inspected directly on macOS. The installed Nix app and isolated bundles using both `icon.icns` and `Paseo.icns` rendered the Paseo logo correctly after LaunchServices registration, confirming the ICNS asset itself is valid.

`npm run typecheck` was attempted from the fresh worktree but could not produce a valid result because the worktree had no local `node_modules`; TypeScript fell through to a stale dependency tree in the parent checkout and reported missing dependencies across unrelated workspaces.

The final Darwin Nix rebuild was not completed because an unrelated system `nix-darwin` build held the Nix store/GC path while the machine had about 2.5 GiB free.

## Platform coverage

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop macOS | Partial | Existing Nix bundle and Finder rendering inspected; derivation metadata verified. Full rebuild blocked by the system Nix build described above. |
| Desktop Windows | No | macOS-only resource configuration and runtime branch. |
| Desktop Linux | No | macOS-only resource configuration and runtime branch. |
| iOS | No | Not affected. |
| Android | No | Not affected. |
| Web | No | Not affected. |
