### PR TITLE
Add UI and CLI for creating multiple provider accounts

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -261,6 +261,12 @@ You can create multiple entries that extend the same built-in provider. Each get
 
 "Profile" here means a provider alias, and it is not an **Agent profile** — that is a named bundle of provider, model, mode, thinking option and features, stored under `daemon.agentProfiles`. See [glossary.md](glossary.md) for all four senses of the word.
 
+Three ways to create one, all writing the same `config.json` entry:
+
+- **App** — Settings > Providers, the actions menu on a built-in provider row > Add account.
+- **CLI** — `paseo provider add claude-work --extends claude --label "Claude (Work)" --env ANTHROPIC_API_KEY=sk-ant-...`, and `paseo provider rm claude-work` to delete it.
+- **By hand** — edit `config.json` as below.
+
 Example: two different Anthropic accounts as separate profiles:
 
 ```json

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -263,7 +263,7 @@ You can create multiple entries that extend the same built-in provider. Each get
 
 Three ways to create one, all writing the same `config.json` entry:
 
-- **App** — Settings > Providers, the actions menu on a built-in provider row > Add account.
+- **App** — Settings > Providers, then use **Add account** on a built-in row. Use **Edit account** on the new row to change its name, ID, description, or environment.
 - **CLI** — `paseo provider add claude-work --extends claude --label "Claude (Work)" --env ANTHROPIC_API_KEY=sk-ant-...`, and `paseo provider rm claude-work` to delete it.
 - **By hand** — edit `config.json` as below.
 
@@ -294,7 +294,17 @@ Example: two different Anthropic accounts as separate profiles:
 }
 ```
 
-Each profile appears as a separate provider in the Paseo app. You can select which one to use when launching an agent.
+Each account appears immediately after its built-in provider in provider lists and usage. You can select it when launching an agent.
+
+Usage reads credentials from the account's environment without falling back to the built-in provider's credentials:
+
+| Provider | Account-specific usage credentials                                   |
+| -------- | -------------------------------------------------------------------- |
+| Claude   | `CLAUDE_CONFIG_DIR` or `CLAUDE_HOME`, containing `.credentials.json` |
+| Codex    | `CODEX_HOME`, containing `auth.json`                                 |
+| Copilot  | `COPILOT_TOKEN`, `GITHUB_TOKEN`, or `GITHUB_PAT`                     |
+
+An account without supported OAuth credentials still appears in usage as unavailable. API-key and custom-endpoint accounts often have no subscription quota API to report.
 
 You can also combine profiles with model overrides to pin specific models per profile:
 

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -294,7 +294,7 @@ Example: two different Anthropic accounts as separate profiles:
 }
 ```
 
-Each account appears immediately after its built-in provider in provider lists and usage. You can select it when launching an agent.
+Each account appears immediately after its built-in provider in provider lists and usage. You can select it when launching an agent. The shared agent tools return the account as its own provider ID and include `baseProviderId` in `list_providers` and `inspect_provider` so agents can recognize the relationship.
 
 Usage reads credentials from the account's environment without falling back to the built-in provider's credentials:
 

--- a/packages/app/e2e/browser/provider-account-create.spec.ts
+++ b/packages/app/e2e/browser/provider-account-create.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "../support/fixtures";
+import { gotoAppShell, openSettings } from "../support/helpers/app";
+import { connectDaemonClient } from "../support/helpers/daemon-client-loader";
+import { getServerId } from "../support/helpers/server-id";
+import {
+  expectProviderInstalledInSettings,
+  fillProviderAccountForm,
+  openProviderAccountForm,
+  openSettingsHost,
+  openSettingsHostSection,
+  submitProviderAccountForm,
+} from "../support/helpers/settings";
+
+const BASE_PROVIDER_ID = "claude";
+const ACCOUNT = {
+  id: "claude-work",
+  label: "Claude (Work)",
+} as const;
+
+interface ProviderAccountDaemonClient {
+  connect(): Promise<void>;
+  close(): Promise<void>;
+  patchDaemonConfig(config: { removeProviders?: string[] }): Promise<unknown>;
+  getDaemonConfig(): Promise<{
+    config: {
+      providers?: Record<
+        string,
+        { extends?: string; label?: string; description?: string; env?: Record<string, string> }
+      >;
+    };
+  }>;
+}
+
+test.describe("provider accounts", () => {
+  test("creates a second account for a builtin provider", async ({ page }) => {
+    test.setTimeout(120_000);
+    const client = await connectDaemonClient<ProviderAccountDaemonClient>({
+      clientIdPrefix: "provider-account-e2e",
+    });
+
+    try {
+      await client.patchDaemonConfig({ removeProviders: [ACCOUNT.id] }).catch(() => undefined);
+
+      await gotoAppShell(page);
+      await openSettings(page);
+      await openSettingsHost(page, getServerId());
+      await openSettingsHostSection(page, getServerId(), "providers");
+
+      await openProviderAccountForm(page, BASE_PROVIDER_ID);
+
+      // The id is derived from the label until it is edited by hand.
+      await page.getByTestId("provider-account-label-input").fill(ACCOUNT.label);
+      await expect(page.getByTestId("provider-account-id-input")).toHaveValue(ACCOUNT.id);
+
+      // A reserved id is rejected inline.
+      await page.getByTestId("provider-account-id-input").fill(BASE_PROVIDER_ID);
+      await expect(page.getByTestId("provider-account-id-error")).toBeVisible();
+      await page.getByTestId("provider-account-id-input").fill(ACCOUNT.id);
+      await expect(page.getByTestId("provider-account-id-error")).toHaveCount(0);
+
+      await fillProviderAccountForm(page, {
+        label: ACCOUNT.label,
+        providerId: ACCOUNT.id,
+        description: "Work account",
+        env: [{ key: "ANTHROPIC_API_KEY", value: "sk-e2e-test" }],
+      });
+      await submitProviderAccountForm(page);
+
+      await expect(page.getByTestId("provider-account-sheet")).toHaveCount(0);
+      await expectProviderInstalledInSettings(page, ACCOUNT.label);
+
+      await expect
+        .poll(async () => {
+          const { config } = await client.getDaemonConfig();
+          const entry = config.providers?.[ACCOUNT.id];
+          if (!entry) return null;
+          return {
+            extends: entry.extends,
+            label: entry.label,
+            description: entry.description,
+            env: entry.env,
+          };
+        })
+        .toEqual({
+          extends: BASE_PROVIDER_ID,
+          label: ACCOUNT.label,
+          description: "Work account",
+          env: { ANTHROPIC_API_KEY: "sk-e2e-test" },
+        });
+    } finally {
+      await client.patchDaemonConfig({ removeProviders: [ACCOUNT.id] }).catch(() => undefined);
+      await client.close().catch(() => undefined);
+    }
+  });
+});

--- a/packages/app/e2e/browser/provider-account-create.spec.ts
+++ b/packages/app/e2e/browser/provider-account-create.spec.ts
@@ -5,6 +5,7 @@ import { getServerId } from "../support/helpers/server-id";
 import {
   expectProviderInstalledInSettings,
   fillProviderAccountForm,
+  openProviderAccountEditForm,
   openProviderAccountForm,
   openSettingsHost,
   openSettingsHostSection,
@@ -16,11 +17,18 @@ const ACCOUNT = {
   id: "claude-work",
   label: "Claude (Work)",
 } as const;
+const EDITED_ACCOUNT = {
+  id: "claude-company",
+  label: "Claude (Company)",
+} as const;
 
 interface ProviderAccountDaemonClient {
   connect(): Promise<void>;
   close(): Promise<void>;
-  patchDaemonConfig(config: { removeProviders?: string[] }): Promise<unknown>;
+  patchDaemonConfig(config: {
+    removeProviders?: string[];
+    replaceProviders?: Record<string, unknown>;
+  }): Promise<unknown>;
   getDaemonConfig(): Promise<{
     config: {
       providers?: Record<
@@ -32,7 +40,7 @@ interface ProviderAccountDaemonClient {
 }
 
 test.describe("provider accounts", () => {
-  test("creates a second account for a builtin provider", async ({ page }) => {
+  test("creates and edits a second account for a builtin provider", async ({ page }) => {
     test.setTimeout(120_000);
     const client = await connectDaemonClient<ProviderAccountDaemonClient>({
       clientIdPrefix: "provider-account-e2e",
@@ -40,6 +48,9 @@ test.describe("provider accounts", () => {
 
     try {
       await client.patchDaemonConfig({ removeProviders: [ACCOUNT.id] }).catch(() => undefined);
+      await client
+        .patchDaemonConfig({ removeProviders: [EDITED_ACCOUNT.id] })
+        .catch(() => undefined);
 
       await gotoAppShell(page);
       await openSettings(page);
@@ -87,8 +98,45 @@ test.describe("provider accounts", () => {
           description: "Work account",
           env: { ANTHROPIC_API_KEY: "sk-e2e-test" },
         });
+
+      await openProviderAccountEditForm(page, ACCOUNT.id);
+      await expect(page.getByTestId("provider-account-label-input")).toHaveValue(ACCOUNT.label);
+      await expect(page.getByTestId("provider-account-id-input")).toHaveValue(ACCOUNT.id);
+      await expect(page.getByTestId("provider-account-description-input")).toHaveValue(
+        "Work account",
+      );
+      await expect(page.getByTestId("provider-account-env-key-0")).toHaveValue("ANTHROPIC_API_KEY");
+
+      await fillProviderAccountForm(page, {
+        label: EDITED_ACCOUNT.label,
+        providerId: EDITED_ACCOUNT.id,
+        description: "",
+        env: [{ key: "CLAUDE_CONFIG_DIR", value: "/tmp/claude-company" }],
+      });
+      await submitProviderAccountForm(page);
+
+      await expect(page.getByTestId("provider-account-sheet")).toHaveCount(0);
+      await expectProviderInstalledInSettings(page, EDITED_ACCOUNT.label);
+      await expect
+        .poll(async () => {
+          const { config } = await client.getDaemonConfig();
+          return {
+            old: config.providers?.[ACCOUNT.id] ?? null,
+            edited: config.providers?.[EDITED_ACCOUNT.id] ?? null,
+          };
+        })
+        .toEqual({
+          old: null,
+          edited: {
+            extends: BASE_PROVIDER_ID,
+            label: EDITED_ACCOUNT.label,
+            env: { CLAUDE_CONFIG_DIR: "/tmp/claude-company" },
+          },
+        });
     } finally {
-      await client.patchDaemonConfig({ removeProviders: [ACCOUNT.id] }).catch(() => undefined);
+      await client
+        .patchDaemonConfig({ removeProviders: [ACCOUNT.id, EDITED_ACCOUNT.id] })
+        .catch(() => undefined);
       await client.close().catch(() => undefined);
     }
   });

--- a/packages/app/e2e/browser/provider-removal.spec.ts
+++ b/packages/app/e2e/browser/provider-removal.spec.ts
@@ -71,7 +71,14 @@ test.describe("provider removal", () => {
       await openSettingsHost(page, getServerId());
       await openSettingsHostSection(page, getServerId(), "providers");
 
-      await expect(page.getByTestId("provider-actions-claude")).toHaveCount(0);
+      // Builtin providers get an actions menu for adding accounts, but they can
+      // never be removed.
+      await page.getByTestId("provider-actions-claude").click();
+      await expect(page.getByTestId("provider-add-account-claude")).toBeVisible();
+      await expect(page.getByTestId("provider-remove-claude")).toHaveCount(0);
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("provider-add-account-claude")).toHaveCount(0);
+
       await openAddProviderArea(page);
       await installAcpCatalogProvider(page, CUSTOM_PROVIDER.name);
       await expectProviderInstalledInSettings(page, CUSTOM_PROVIDER.name);

--- a/packages/app/e2e/support/helpers/settings.ts
+++ b/packages/app/e2e/support/helpers/settings.ts
@@ -366,6 +366,44 @@ export async function installAcpCatalogProvider(page: Page, providerName: string
   await page.getByRole("button", { name: "Add", exact: true }).click();
 }
 
+export interface ProviderAccountFormInput {
+  label: string;
+  providerId?: string;
+  description?: string;
+  env?: { key: string; value: string }[];
+}
+
+export async function openProviderAccountForm(page: Page, providerId: string): Promise<void> {
+  await page.getByTestId(`provider-actions-${providerId}`).click();
+  await page.getByTestId(`provider-add-account-${providerId}`).click();
+  await expect(page.getByTestId("provider-account-sheet")).toBeVisible();
+}
+
+export async function fillProviderAccountForm(
+  page: Page,
+  input: ProviderAccountFormInput,
+): Promise<void> {
+  await page.getByTestId("provider-account-label-input").fill(input.label);
+  if (input.providerId !== undefined) {
+    await page.getByTestId("provider-account-id-input").fill(input.providerId);
+  }
+  if (input.description !== undefined) {
+    await page.getByTestId("provider-account-description-input").fill(input.description);
+  }
+  const env = input.env ?? [];
+  for (const [index, variable] of env.entries()) {
+    if (index > 0) {
+      await page.getByTestId("provider-account-env-add").click();
+    }
+    await page.getByTestId(`provider-account-env-key-${index}`).fill(variable.key);
+    await page.getByTestId(`provider-account-env-value-${index}`).fill(variable.value);
+  }
+}
+
+export async function submitProviderAccountForm(page: Page): Promise<void> {
+  await page.getByTestId("provider-account-submit").click();
+}
+
 export async function expectProviderInstalledInSettings(
   page: Page,
   providerName: string,

--- a/packages/app/e2e/support/helpers/settings.ts
+++ b/packages/app/e2e/support/helpers/settings.ts
@@ -379,6 +379,12 @@ export async function openProviderAccountForm(page: Page, providerId: string): P
   await expect(page.getByTestId("provider-account-sheet")).toBeVisible();
 }
 
+export async function openProviderAccountEditForm(page: Page, providerId: string): Promise<void> {
+  await page.getByTestId(`provider-actions-${providerId}`).click();
+  await page.getByTestId(`provider-edit-account-${providerId}`).click();
+  await expect(page.getByTestId("provider-account-sheet")).toBeVisible();
+}
+
 export async function fillProviderAccountForm(
   page: Page,
   input: ProviderAccountFormInput,

--- a/packages/app/src/command-center/agent-control-contributions.ts
+++ b/packages/app/src/command-center/agent-control-contributions.ts
@@ -145,7 +145,7 @@ function buildModelGroup(source: AgentControlContributionSource): CommandCenterC
   for (const provider of source.models.providers) {
     if (provider.modelSelection.kind !== "models") continue;
     const agentProvider = provider.id;
-    const icon = source.icons.provider(agentProvider);
+    const icon = source.icons.provider(provider.baseProviderId ?? agentProvider);
     for (const model of provider.modelSelection.rows) {
       if (!model.modelId) continue;
       const modelId = model.modelId;

--- a/packages/app/src/components/combined-model-selector.tsx
+++ b/packages/app/src/components/combined-model-selector.tsx
@@ -11,7 +11,10 @@ import { ModelBrowser, ModelProviderGlyph, useModelBrowser } from "@/components/
 import { resolveModelBrowserScrolling } from "@/components/model-browser-view";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { isNative, isWeb } from "@/constants/platform";
-import type { ProviderSelectorProvider } from "@/provider-selection/provider-selection";
+import {
+  resolveProviderIconId,
+  type ProviderSelectorProvider,
+} from "@/provider-selection/provider-selection";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 
 const EMPTY_COMBOBOX_OPTIONS: ComboboxOption[] = [];
@@ -254,7 +257,7 @@ export function CombinedModelSelector({
           {selectedProvider.trim().length > 0 ? (
             <View style={toolbar?.glyphSize === 20 ? styles.toolbarGlyph20 : styles.toolbarGlyph16}>
               <ModelProviderGlyph
-                provider={selectedProvider}
+                provider={resolveProviderIconId(providers, selectedProvider)}
                 size={toolbar?.glyphSize ?? ICON_SIZE.md}
               />
             </View>

--- a/packages/app/src/components/model-browser.tsx
+++ b/packages/app/src/components/model-browser.tsx
@@ -48,6 +48,7 @@ import {
   filterAndRankModelRows,
   getAllProviderModelRows,
   getProviderModelRows,
+  resolveProviderIconId,
   resolveSelectedModelLabel,
   type ProviderSelectionModelRow,
   type ProviderSelectorProvider,
@@ -338,7 +339,7 @@ export function useModelBrowser({
       title: view.providerLabel,
       leading: (
         <ModelProviderGlyph
-          provider={view.providerId}
+          provider={resolveProviderIconId(providers, view.providerId)}
           serverId={serverId}
           size={ICON_SIZE.md}
           tone="foreground"
@@ -369,6 +370,7 @@ export function useModelBrowser({
   }, [
     autoFocusSearch,
     handleSearchQueryChange,
+    providers,
     searchResetKey,
     serverId,
     singleProviderView,
@@ -687,8 +689,14 @@ function ModelRow({
   const { t } = useTranslation();
   const [isHovered, setIsHovered] = useState(false);
   const leadingSlot = useMemo(
-    () => <ModelProviderGlyph provider={row.provider} serverId={serverId} size={ICON_SIZE.sm} />,
-    [row.provider, serverId],
+    () => (
+      <ModelProviderGlyph
+        provider={row.iconProviderId ?? row.provider}
+        serverId={serverId}
+        size={ICON_SIZE.sm}
+      />
+    ),
+    [row.iconProviderId, row.provider, serverId],
   );
 
   const description = showProviderLabel ? buildProviderQualifiedDescription(row) : row.description;
@@ -1008,8 +1016,14 @@ function GroupProviderButton({
     );
   }, [selection, t]);
   const leadingSlot = useMemo(
-    () => <ModelProviderGlyph provider={provider.id} serverId={serverId} size={ICON_SIZE.sm} />,
-    [provider.id, serverId],
+    () => (
+      <ModelProviderGlyph
+        provider={provider.baseProviderId ?? provider.id}
+        serverId={serverId}
+        size={ICON_SIZE.sm}
+      />
+    ),
+    [provider.baseProviderId, provider.id, serverId],
   );
   const trailingSlot = useMemo(
     () => (

--- a/packages/app/src/components/provider-account-sheet.tsx
+++ b/packages/app/src/components/provider-account-sheet.tsx
@@ -1,0 +1,369 @@
+import { useCallback, useMemo, useSyncExternalStore, type ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable, Text, View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { Plus, X } from "lucide-react-native";
+import type { MutableDaemonConfigPatch } from "@getpaseo/protocol/messages";
+import { AdaptiveModalSheet, type SheetHeader } from "@/components/adaptive-modal-sheet";
+import { Button } from "@/components/ui/button";
+import type { FieldControlSize } from "@/components/ui/control-geometry";
+import { Field, FormTextInput } from "@/components/ui/form-field";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import { useProviderAccountFormModel } from "@/provider-accounts/use-provider-account-form-model";
+import type {
+  ProviderAccountEnvRow,
+  ProviderAccountFormModel,
+  ProviderAccountFormState,
+} from "@/provider-accounts/provider-account-form-model";
+import type { Theme } from "@/styles/theme";
+
+const foregroundMutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const ThemedX = withUnistyles(X, foregroundMutedColorMapping);
+const ThemedPlus = withUnistyles(Plus, foregroundMutedColorMapping);
+const ADD_VARIABLE_ICON = <ThemedPlus size={14} />;
+
+export interface ProviderAccountCreateInput {
+  providerId: string;
+  patch: MutableDaemonConfigPatch;
+}
+
+export interface ProviderAccountSheetProps {
+  visible: boolean;
+  baseProviderId: string;
+  baseProviderLabel: string;
+  existingProviderIds: readonly string[];
+  onClose: () => void;
+  /** Resolves true when the account was written; the sheet then closes. */
+  onCreate: (input: ProviderAccountCreateInput) => Promise<boolean>;
+}
+
+export function ProviderAccountSheet(props: ProviderAccountSheetProps): ReactElement | null {
+  if (!props.visible) return null;
+  return <OpenProviderAccountSheet {...props} />;
+}
+
+function OpenProviderAccountSheet({
+  visible,
+  baseProviderId,
+  baseProviderLabel,
+  existingProviderIds,
+  onClose,
+  onCreate,
+}: ProviderAccountSheetProps): ReactElement {
+  const { t } = useTranslation();
+  const controlSize: FieldControlSize = useIsCompactFormFactor() ? "md" : "sm";
+  const snapshot = useMemo(
+    () => ({ baseProviderId, baseProviderLabel, existingProviderIds }),
+    [baseProviderId, baseProviderLabel, existingProviderIds],
+  );
+  const model = useProviderAccountFormModel(snapshot);
+  const state = useSyncExternalStore(model.subscribe, model.getState, model.getState);
+
+  const handleSubmit = useCallback(async () => {
+    if (state.isSubmitting) return;
+    model.markSubmitAttempted();
+    const patch = model.buildPatch();
+    if (!patch) return;
+
+    model.setSubmitting(true);
+    try {
+      const created = await onCreate({ providerId: state.providerId.trim(), patch });
+      if (created) {
+        onClose();
+        return;
+      }
+    } finally {
+      model.setSubmitting(false);
+    }
+  }, [model, onClose, onCreate, state.isSubmitting, state.providerId]);
+
+  const handleSubmitPress = useCallback(() => {
+    void handleSubmit();
+  }, [handleSubmit]);
+
+  const header = useMemo<SheetHeader>(
+    () => ({ title: t("settings.providers.account.title", { provider: baseProviderLabel }) }),
+    [baseProviderLabel, t],
+  );
+
+  const footer = useMemo(
+    () => (
+      <View style={styles.footer}>
+        <Button
+          style={styles.footerButton}
+          variant="secondary"
+          onPress={onClose}
+          disabled={state.isSubmitting}
+          testID="provider-account-cancel"
+        >
+          {t("common.actions.cancel")}
+        </Button>
+        <Button
+          style={styles.footerButton}
+          variant="default"
+          onPress={handleSubmitPress}
+          disabled={state.isSubmitting}
+          loading={state.isSubmitting}
+          testID="provider-account-submit"
+        >
+          {t("settings.providers.account.submit")}
+        </Button>
+      </View>
+    ),
+    [handleSubmitPress, onClose, state.isSubmitting, t],
+  );
+
+  return (
+    <AdaptiveModalSheet
+      header={header}
+      visible={visible}
+      onClose={onClose}
+      footer={footer}
+      testID="provider-account-sheet"
+    >
+      <Field
+        label={t("settings.providers.account.fields.label")}
+        error={state.labelError ? t("settings.providers.account.errors.labelRequired") : null}
+        testID="provider-account-label"
+      >
+        <FormTextInput
+          size={controlSize}
+          testID="provider-account-label-input"
+          accessibilityLabel={t("settings.providers.account.fields.label")}
+          initialValue={state.label}
+          value={state.label}
+          onChangeText={model.setLabel}
+          placeholder={t("settings.providers.account.placeholders.label", {
+            provider: baseProviderLabel,
+          })}
+          autoCapitalize="words"
+          autoCorrect={false}
+          editable={!state.isSubmitting}
+        />
+      </Field>
+
+      <Field
+        label={t("settings.providers.account.fields.providerId")}
+        error={resolveProviderIdError(state, t)}
+        testID="provider-account-id"
+      >
+        <FormTextInput
+          size={controlSize}
+          testID="provider-account-id-input"
+          accessibilityLabel={t("settings.providers.account.fields.providerId")}
+          // The id mirrors the label until it is edited, so the uncontrolled
+          // input has to remount whenever the derived value changes.
+          initialValue={state.providerId}
+          resetKey={state.providerIdEdited ? "manual" : `derived:${state.providerId}`}
+          value={state.providerId}
+          onChangeText={model.setProviderId}
+          placeholder={t("settings.providers.account.placeholders.providerId")}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!state.isSubmitting}
+        />
+      </Field>
+
+      <Field
+        label={t("settings.providers.account.fields.description")}
+        testID="provider-account-description"
+      >
+        <FormTextInput
+          size={controlSize}
+          testID="provider-account-description-input"
+          accessibilityLabel={t("settings.providers.account.fields.description")}
+          initialValue={state.description}
+          value={state.description}
+          onChangeText={model.setDescription}
+          placeholder={t("settings.providers.account.placeholders.description")}
+          autoCorrect={false}
+          editable={!state.isSubmitting}
+        />
+      </Field>
+
+      <Field label={t("settings.providers.account.fields.env")} testID="provider-account-env">
+        <View style={styles.envRows}>
+          {state.envRows.map((row, index) => (
+            <EnvVarRow
+              key={row.id}
+              row={row}
+              index={index}
+              model={model}
+              controlSize={controlSize}
+              disabled={state.isSubmitting}
+              error={resolveEnvError(state, row, t)}
+            />
+          ))}
+          <Button
+            variant="ghost"
+            size={controlSize === "md" ? "md" : "sm"}
+            style={styles.addEnvButton}
+            onPress={model.addEnvRow}
+            disabled={state.isSubmitting}
+            leftIcon={ADD_VARIABLE_ICON}
+            testID="provider-account-env-add"
+          >
+            {t("settings.providers.account.actions.addVariable")}
+          </Button>
+        </View>
+      </Field>
+    </AdaptiveModalSheet>
+  );
+}
+
+type Translate = ReturnType<typeof useTranslation>["t"];
+
+function resolveProviderIdError(state: ProviderAccountFormState, t: Translate): string | null {
+  switch (state.providerIdError) {
+    case "required":
+      return t("settings.providers.account.errors.idRequired");
+    case "invalid":
+      return t("settings.providers.account.errors.idInvalid");
+    case "taken":
+      return t("settings.providers.account.errors.idTaken");
+    default:
+      return null;
+  }
+}
+
+function resolveEnvError(
+  state: ProviderAccountFormState,
+  row: ProviderAccountEnvRow,
+  t: Translate,
+): string | null {
+  switch (state.envErrors[row.id]) {
+    case "keyRequired":
+      return t("settings.providers.account.errors.envKeyRequired");
+    case "duplicate":
+      return t("settings.providers.account.errors.envDuplicate");
+    default:
+      return null;
+  }
+}
+
+interface EnvVarRowProps {
+  row: ProviderAccountEnvRow;
+  index: number;
+  model: ProviderAccountFormModel;
+  controlSize: FieldControlSize;
+  disabled: boolean;
+  error: string | null;
+}
+
+function EnvVarRow({
+  row,
+  index,
+  model,
+  controlSize,
+  disabled,
+  error,
+}: EnvVarRowProps): ReactElement {
+  const { t } = useTranslation();
+  const handleKeyChange = useCallback(
+    (value: string) => {
+      model.setEnvKey(row.id, value);
+    },
+    [model, row.id],
+  );
+  const handleValueChange = useCallback(
+    (value: string) => {
+      model.setEnvValue(row.id, value);
+    },
+    [model, row.id],
+  );
+  const handleRemove = useCallback(() => {
+    model.removeEnvRow(row.id);
+  }, [model, row.id]);
+
+  return (
+    <View style={styles.envRowGroup}>
+      <View style={styles.envRow}>
+        <View style={styles.envKeyField}>
+          <FormTextInput
+            size={controlSize}
+            testID={`provider-account-env-key-${index}`}
+            accessibilityLabel={t("settings.providers.account.fields.envKey")}
+            initialValue={row.key}
+            value={row.key}
+            onChangeText={handleKeyChange}
+            placeholder={t("settings.providers.account.placeholders.envKey")}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            editable={!disabled}
+          />
+        </View>
+        <View style={styles.envValueField}>
+          <FormTextInput
+            size={controlSize}
+            testID={`provider-account-env-value-${index}`}
+            accessibilityLabel={t("settings.providers.account.fields.envValue")}
+            initialValue={row.value}
+            value={row.value}
+            onChangeText={handleValueChange}
+            placeholder={t("settings.providers.account.placeholders.envValue")}
+            autoCapitalize="none"
+            autoCorrect={false}
+            editable={!disabled}
+          />
+        </View>
+        <Pressable
+          style={styles.envRemoveButton}
+          onPress={handleRemove}
+          disabled={disabled}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t("settings.providers.account.actions.removeVariable")}
+          testID={`provider-account-env-remove-${index}`}
+        >
+          <ThemedX size={14} />
+        </Pressable>
+      </View>
+      {error ? <Text style={styles.envRowError}>{error}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  footer: {
+    flex: 1,
+    flexDirection: "row",
+    gap: theme.spacing[3],
+  },
+  footerButton: {
+    flex: 1,
+  },
+  envRows: {
+    gap: theme.spacing[2],
+  },
+  envRowGroup: {
+    gap: theme.spacing[1],
+  },
+  envRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  envKeyField: {
+    flex: 1,
+    minWidth: 0,
+  },
+  envValueField: {
+    flex: 1,
+    minWidth: 0,
+  },
+  envRemoveButton: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.lg,
+  },
+  envRowError: {
+    color: theme.colors.palette.red[300],
+    fontSize: theme.fontSize.xs,
+    lineHeight: Math.round(theme.fontSize.xs * 1.4),
+  },
+  addEnvButton: {
+    alignSelf: "flex-start",
+  },
+}));

--- a/packages/app/src/components/provider-account-sheet.tsx
+++ b/packages/app/src/components/provider-account-sheet.tsx
@@ -37,6 +37,8 @@ export interface ProviderAccountSheetProps {
     providerId: string;
     config: MutableDaemonConfig["providers"][string];
   };
+  /** Daemons without this migrate nothing on rename, so the sheet warns before you save. */
+  supportsProviderConfigRename?: boolean;
   onClose: () => void;
   /** Resolves true when the account was written; the sheet then closes. */
   onSave: (input: ProviderAccountSaveInput) => Promise<boolean>;
@@ -53,6 +55,7 @@ function OpenProviderAccountSheet({
   baseProviderLabel,
   existingProviderIds,
   account,
+  supportsProviderConfigRename = false,
   onClose,
   onSave,
 }: ProviderAccountSheetProps): ReactElement {
@@ -90,6 +93,13 @@ function OpenProviderAccountSheet({
   const handleSubmitPress = useCallback(() => {
     void handleSubmit();
   }, [handleSubmit]);
+
+  // Renaming an account on a daemon that can't migrate agents leaves those chats orphaned.
+  const showRenameWarning =
+    !supportsProviderConfigRename &&
+    account !== undefined &&
+    state.providerId.trim().length > 0 &&
+    state.providerId.trim() !== account.providerId;
 
   const header = useMemo<SheetHeader>(
     () => ({
@@ -184,6 +194,11 @@ function OpenProviderAccountSheet({
           editable={!state.isSubmitting}
         />
       </Field>
+      {showRenameWarning ? (
+        <Text style={styles.renameWarning} testID="provider-account-id-rename-warning">
+          {t("settings.providers.account.warnings.renameUnsupported")}
+        </Text>
+      ) : null}
 
       <Field
         label={t("settings.providers.account.fields.description")}
@@ -378,6 +393,12 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
     borderRadius: theme.borderRadius.lg,
+  },
+  renameWarning: {
+    color: theme.colors.palette.amber[500],
+    fontSize: theme.fontSize.xs,
+    lineHeight: Math.round(theme.fontSize.xs * 1.4),
+    marginTop: -theme.spacing[1],
   },
   envRowError: {
     color: theme.colors.palette.red[300],

--- a/packages/app/src/components/provider-account-sheet.tsx
+++ b/packages/app/src/components/provider-account-sheet.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Pressable, Text, View } from "react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { Plus, X } from "lucide-react-native";
-import type { MutableDaemonConfigPatch } from "@getpaseo/protocol/messages";
+import type { MutableDaemonConfig, MutableDaemonConfigPatch } from "@getpaseo/protocol/messages";
 import { AdaptiveModalSheet, type SheetHeader } from "@/components/adaptive-modal-sheet";
 import { Button } from "@/components/ui/button";
 import type { FieldControlSize } from "@/components/ui/control-geometry";
@@ -22,8 +22,9 @@ const ThemedX = withUnistyles(X, foregroundMutedColorMapping);
 const ThemedPlus = withUnistyles(Plus, foregroundMutedColorMapping);
 const ADD_VARIABLE_ICON = <ThemedPlus size={14} />;
 
-export interface ProviderAccountCreateInput {
+export interface ProviderAccountSaveInput {
   providerId: string;
+  originalProviderId?: string;
   patch: MutableDaemonConfigPatch;
 }
 
@@ -32,9 +33,13 @@ export interface ProviderAccountSheetProps {
   baseProviderId: string;
   baseProviderLabel: string;
   existingProviderIds: readonly string[];
+  account?: {
+    providerId: string;
+    config: MutableDaemonConfig["providers"][string];
+  };
   onClose: () => void;
   /** Resolves true when the account was written; the sheet then closes. */
-  onCreate: (input: ProviderAccountCreateInput) => Promise<boolean>;
+  onSave: (input: ProviderAccountSaveInput) => Promise<boolean>;
 }
 
 export function ProviderAccountSheet(props: ProviderAccountSheetProps): ReactElement | null {
@@ -47,14 +52,15 @@ function OpenProviderAccountSheet({
   baseProviderId,
   baseProviderLabel,
   existingProviderIds,
+  account,
   onClose,
-  onCreate,
+  onSave,
 }: ProviderAccountSheetProps): ReactElement {
   const { t } = useTranslation();
   const controlSize: FieldControlSize = useIsCompactFormFactor() ? "md" : "sm";
   const snapshot = useMemo(
-    () => ({ baseProviderId, baseProviderLabel, existingProviderIds }),
-    [baseProviderId, baseProviderLabel, existingProviderIds],
+    () => ({ baseProviderId, baseProviderLabel, existingProviderIds, account }),
+    [account, baseProviderId, baseProviderLabel, existingProviderIds],
   );
   const model = useProviderAccountFormModel(snapshot);
   const state = useSyncExternalStore(model.subscribe, model.getState, model.getState);
@@ -67,23 +73,34 @@ function OpenProviderAccountSheet({
 
     model.setSubmitting(true);
     try {
-      const created = await onCreate({ providerId: state.providerId.trim(), patch });
-      if (created) {
+      const saved = await onSave({
+        providerId: state.providerId.trim(),
+        originalProviderId: account?.providerId,
+        patch,
+      });
+      if (saved) {
         onClose();
         return;
       }
     } finally {
       model.setSubmitting(false);
     }
-  }, [model, onClose, onCreate, state.isSubmitting, state.providerId]);
+  }, [account?.providerId, model, onClose, onSave, state.isSubmitting, state.providerId]);
 
   const handleSubmitPress = useCallback(() => {
     void handleSubmit();
   }, [handleSubmit]);
 
   const header = useMemo<SheetHeader>(
-    () => ({ title: t("settings.providers.account.title", { provider: baseProviderLabel }) }),
-    [baseProviderLabel, t],
+    () => ({
+      title: t(
+        state.isEditing
+          ? "settings.providers.account.editTitle"
+          : "settings.providers.account.title",
+        { provider: baseProviderLabel },
+      ),
+    }),
+    [baseProviderLabel, state.isEditing, t],
   );
 
   const footer = useMemo(
@@ -106,11 +123,15 @@ function OpenProviderAccountSheet({
           loading={state.isSubmitting}
           testID="provider-account-submit"
         >
-          {t("settings.providers.account.submit")}
+          {t(
+            state.isEditing
+              ? "settings.providers.account.save"
+              : "settings.providers.account.submit",
+          )}
         </Button>
       </View>
     ),
-    [handleSubmitPress, onClose, state.isSubmitting, t],
+    [handleSubmitPress, onClose, state.isEditing, state.isSubmitting, t],
   );
 
   return (

--- a/packages/app/src/components/provider-account-sheet.tsx
+++ b/packages/app/src/components/provider-account-sheet.tsx
@@ -162,7 +162,6 @@ function OpenProviderAccountSheet({
           testID="provider-account-label-input"
           accessibilityLabel={t("settings.providers.account.fields.label")}
           initialValue={state.label}
-          value={state.label}
           onChangeText={model.setLabel}
           placeholder={t("settings.providers.account.placeholders.label", {
             provider: baseProviderLabel,
@@ -186,7 +185,6 @@ function OpenProviderAccountSheet({
           // input has to remount whenever the derived value changes.
           initialValue={state.providerId}
           resetKey={state.providerIdEdited ? "manual" : `derived:${state.providerId}`}
-          value={state.providerId}
           onChangeText={model.setProviderId}
           placeholder={t("settings.providers.account.placeholders.providerId")}
           autoCapitalize="none"
@@ -209,7 +207,6 @@ function OpenProviderAccountSheet({
           testID="provider-account-description-input"
           accessibilityLabel={t("settings.providers.account.fields.description")}
           initialValue={state.description}
-          value={state.description}
           onChangeText={model.setDescription}
           placeholder={t("settings.providers.account.placeholders.description")}
           autoCorrect={false}
@@ -320,7 +317,6 @@ function EnvVarRow({
             testID={`provider-account-env-key-${index}`}
             accessibilityLabel={t("settings.providers.account.fields.envKey")}
             initialValue={row.key}
-            value={row.key}
             onChangeText={handleKeyChange}
             placeholder={t("settings.providers.account.placeholders.envKey")}
             autoCapitalize="characters"
@@ -334,7 +330,6 @@ function EnvVarRow({
             testID={`provider-account-env-value-${index}`}
             accessibilityLabel={t("settings.providers.account.fields.envValue")}
             initialValue={row.value}
-            value={row.value}
             onChangeText={handleValueChange}
             placeholder={t("settings.providers.account.placeholders.envValue")}
             autoCapitalize="none"

--- a/packages/app/src/components/provider-account-sheet.tsx
+++ b/packages/app/src/components/provider-account-sheet.tsx
@@ -396,14 +396,14 @@ const styles = StyleSheet.create((theme) => ({
   },
   renameWarning: {
     color: theme.colors.palette.amber[500],
-    fontSize: theme.fontSize.xs,
-    lineHeight: Math.round(theme.fontSize.xs * 1.4),
+    fontSize: theme.fontSize.sm,
+    lineHeight: Math.round(theme.fontSize.sm * 1.4),
     marginTop: -theme.spacing[1],
   },
   envRowError: {
     color: theme.colors.palette.red[300],
-    fontSize: theme.fontSize.xs,
-    lineHeight: Math.round(theme.fontSize.xs * 1.4),
+    fontSize: theme.fontSize.sm,
+    lineHeight: Math.round(theme.fontSize.sm * 1.4),
   },
   addEnvButton: {
     alignSelf: "flex-start",

--- a/packages/app/src/components/provider-icon-name.test.ts
+++ b/packages/app/src/components/provider-icon-name.test.ts
@@ -5,7 +5,11 @@ import {
   TERMINAL_PROFILE_ICON_NAMES,
 } from "@getpaseo/protocol/provider-icon-names";
 import { ACP_PROVIDER_CATALOG } from "@/data/acp-provider-catalog";
-import { replaceProviderSnapshotIcons, resolveProviderIconName } from "./provider-icon-name";
+import {
+  registerProviderIconAliases,
+  replaceProviderSnapshotIcons,
+  resolveProviderIconName,
+} from "./provider-icon-name";
 
 describe("resolveProviderIconName", () => {
   it("returns the built-in identifier for known provider ids", () => {
@@ -66,6 +70,26 @@ describe("resolveProviderIconName", () => {
       kind: "svg",
       svg: secondSvg,
     });
+  });
+
+  it("resolves registered provider accounts to their base provider's icon", () => {
+    registerProviderIconAliases([
+      { provider: "claude-work", baseProviderId: "claude" },
+      { provider: "gemini-personal", baseProviderId: "gemini" },
+      { provider: "claude" },
+    ]);
+    expect(resolveProviderIconName("claude-work")).toEqual({ kind: "builtin", id: "claude" });
+    expect(resolveProviderIconName("gemini-personal")).toEqual({ kind: "catalog", id: "gemini" });
+  });
+
+  it("keeps the bot fallback when an alias points at an unknown base provider", () => {
+    registerProviderIconAliases([{ provider: "mystery-account", baseProviderId: "mystery" }]);
+    expect(resolveProviderIconName("mystery-account")).toEqual({ kind: "bot" });
+  });
+
+  it("never lets an alias shadow a real provider id", () => {
+    registerProviderIconAliases([{ provider: "codex", baseProviderId: "claude" }]);
+    expect(resolveProviderIconName("codex")).toEqual({ kind: "builtin", id: "codex" });
   });
 });
 

--- a/packages/app/src/components/provider-icon-name.ts
+++ b/packages/app/src/components/provider-icon-name.ts
@@ -27,6 +27,21 @@ export function replaceProviderSnapshotIcons(
   providerSnapshotIconSvgsByServer.set(serverId, icons);
 }
 
+/* Provider accounts get user-chosen ids ("claude-work") that no static icon
+ * list can anticipate; the snapshot layer registers each account's base
+ * provider here so every icon call site resolves the real logo. */
+const PROVIDER_ICON_ALIASES = new Map<string, string>();
+
+export function registerProviderIconAliases(
+  entries: ReadonlyArray<{ provider: string; baseProviderId?: string }>,
+): void {
+  for (const entry of entries) {
+    if (entry.baseProviderId && entry.baseProviderId !== entry.provider) {
+      PROVIDER_ICON_ALIASES.set(entry.provider, entry.baseProviderId);
+    }
+  }
+}
+
 export function resolveProviderIconName(
   provider: string,
   serverId?: string | null,
@@ -42,6 +57,15 @@ export function resolveProviderIconName(
   }
   if (KNOWN_PROVIDER_IDS.has(provider)) {
     return { kind: "catalog", id: provider };
+  }
+  const base = PROVIDER_ICON_ALIASES.get(provider);
+  if (base !== undefined) {
+    if (BUILTIN_PROVIDER_IDS.has(base)) {
+      return { kind: "builtin", id: base };
+    }
+    if (KNOWN_PROVIDER_IDS.has(base)) {
+      return { kind: "catalog", id: base };
+    }
   }
   return { kind: "bot" };
 }

--- a/packages/app/src/composer/agent-controls/model-sheet.tsx
+++ b/packages/app/src/composer/agent-controls/model-sheet.tsx
@@ -13,7 +13,10 @@ import { resolveModelBrowserScrolling } from "@/components/model-browser-view";
 import { AgentControlTrigger } from "@/composer/agent-controls/control";
 import { ComposerToolbarGlyph } from "@/composer/agent-controls/glyph";
 import { resolveModelSheetOpening } from "@/composer/agent-controls/model-sheet-flow";
-import type { ProviderSelectorProvider } from "@/provider-selection/provider-selection";
+import {
+  resolveProviderIconId,
+  type ProviderSelectorProvider,
+} from "@/provider-selection/provider-selection";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { isNative, isWeb } from "@/constants/platform";
 
@@ -131,7 +134,9 @@ export function CompactModelSheet({
     serverId,
   });
   const ProviderIcon =
-    selectedProvider.trim().length > 0 ? getProviderIcon(selectedProvider, serverId) : null;
+    selectedProvider.trim().length > 0
+      ? getProviderIcon(resolveProviderIconId(providers, selectedProvider), serverId)
+      : null;
   const ModelIcon = ProviderIcon ?? Bot;
   const rootHeader = useMemo(
     () => ({

--- a/packages/app/src/data/providers-snapshot.ts
+++ b/packages/app/src/data/providers-snapshot.ts
@@ -7,7 +7,10 @@ import {
   type ProviderSnapshotCache,
 } from "./provider-snapshot-cache";
 import { queryClient as singletonQueryClient } from "./query-client";
-import { replaceProviderSnapshotIcons } from "@/components/provider-icon-name";
+import {
+  registerProviderIconAliases,
+  replaceProviderSnapshotIcons,
+} from "@/components/provider-icon-name";
 import { agentCommandsQueryRoot } from "@/hooks/agent-commands-query";
 import type { AgentProvider } from "@getpaseo/protocol/agent-types";
 import { normalizeWorkspacePath } from "@/utils/workspace-identity";
@@ -115,6 +118,7 @@ export async function fetchProvidersSnapshot(input: {
   }
   if (input.signal?.aborted) throw new CancelledError();
   replaceProviderSnapshotIcons(input.serverId, snapshot.entries);
+  registerProviderIconAliases(snapshot.entries);
   return snapshot;
 }
 

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -2513,8 +2513,41 @@ export const ar: TranslationResources = {
       updateErrorTitle: "غير قادر على تحديث الموفر",
       actions: {
         menu: "{{name}} actions",
+        addAccount: "إضافة حساب",
         remove: "Remove provider",
         removing: "Removing...",
+      },
+      account: {
+        title: "إضافة حساب {{provider}}",
+        errorTitle: "تعذر إضافة الحساب",
+        submit: "إضافة حساب",
+        fields: {
+          label: "الاسم",
+          providerId: "معرّف المزود",
+          description: "الوصف",
+          env: "متغيرات البيئة",
+          envKey: "اسم المتغير",
+          envValue: "قيمة المتغير",
+        },
+        placeholders: {
+          label: "{{provider}} (العمل)",
+          providerId: "claude-work",
+          description: "اختياري",
+          envKey: "الاسم",
+          envValue: "القيمة",
+        },
+        actions: {
+          addVariable: "إضافة متغير",
+          removeVariable: "إزالة المتغير",
+        },
+        errors: {
+          labelRequired: "أدخل اسمًا.",
+          idRequired: "أدخل معرّف المزود.",
+          idInvalid: "استخدم أحرفًا صغيرة وأرقامًا وشرطات، بدءًا بحرف.",
+          idTaken: "معرّف المزود هذا مستخدم بالفعل.",
+          envKeyRequired: "أدخل اسم المتغير.",
+          envDuplicate: "هذا المتغير معيّن بالفعل.",
+        },
       },
       remove: {
         confirmTitle: "Remove {{name}}?",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -2543,6 +2543,10 @@ export const ar: TranslationResources = {
           addVariable: "إضافة متغير",
           removeVariable: "إزالة المتغير",
         },
+        warnings: {
+          renameUnsupported:
+            "لا يستطيع هذا المضيف نقل المحادثات الحالية إلى المعرّف الجديد. ستصبح المحادثات التي تستخدم هذا الحساب غير متاحة حتى تحدّث المضيف أو تستعيد المعرّف السابق.",
+        },
         errors: {
           labelRequired: "أدخل اسمًا.",
           idRequired: "أدخل معرّف المزود.",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -2514,13 +2514,16 @@ export const ar: TranslationResources = {
       actions: {
         menu: "{{name}} actions",
         addAccount: "إضافة حساب",
+        editAccount: "تعديل الحساب",
         remove: "Remove provider",
         removing: "Removing...",
       },
       account: {
         title: "إضافة حساب {{provider}}",
-        errorTitle: "تعذر إضافة الحساب",
+        editTitle: "تعديل حساب {{provider}}",
+        errorTitle: "تعذر حفظ الحساب",
         submit: "إضافة حساب",
+        save: "حفظ التغييرات",
         fields: {
           label: "الاسم",
           providerId: "معرّف المزود",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2652,6 +2652,10 @@ export const en = {
           addVariable: "Add variable",
           removeVariable: "Remove variable",
         },
+        warnings: {
+          renameUnsupported:
+            "This host can't move existing chats to the new ID. Chats using this account will be unavailable until you update the host or restore the old ID.",
+        },
         errors: {
           labelRequired: "Enter a name.",
           idRequired: "Enter a provider ID.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2623,13 +2623,16 @@ export const en = {
       actions: {
         menu: "{{name}} actions",
         addAccount: "Add account",
+        editAccount: "Edit account",
         remove: "Remove provider",
         removing: "Removing...",
       },
       account: {
         title: "Add {{provider}} account",
-        errorTitle: "Unable to add account",
+        editTitle: "Edit {{provider}} account",
+        errorTitle: "Unable to save account",
         submit: "Add account",
+        save: "Save changes",
         fields: {
           label: "Name",
           providerId: "Provider ID",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2622,8 +2622,41 @@ export const en = {
       updateErrorTitle: "Unable to update provider",
       actions: {
         menu: "{{name}} actions",
+        addAccount: "Add account",
         remove: "Remove provider",
         removing: "Removing...",
+      },
+      account: {
+        title: "Add {{provider}} account",
+        errorTitle: "Unable to add account",
+        submit: "Add account",
+        fields: {
+          label: "Name",
+          providerId: "Provider ID",
+          description: "Description",
+          env: "Environment variables",
+          envKey: "Variable name",
+          envValue: "Variable value",
+        },
+        placeholders: {
+          label: "{{provider}} (Work)",
+          providerId: "claude-work",
+          description: "Optional",
+          envKey: "NAME",
+          envValue: "Value",
+        },
+        actions: {
+          addVariable: "Add variable",
+          removeVariable: "Remove variable",
+        },
+        errors: {
+          labelRequired: "Enter a name.",
+          idRequired: "Enter a provider ID.",
+          idInvalid: "Use lowercase letters, numbers, and dashes, starting with a letter.",
+          idTaken: "This provider ID is already taken.",
+          envKeyRequired: "Enter a variable name.",
+          envDuplicate: "This variable is already set.",
+        },
       },
       remove: {
         confirmTitle: "Remove {{name}}?",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2571,13 +2571,16 @@ export const es: TranslationResources = {
       actions: {
         menu: "{{name}} actions",
         addAccount: "Añadir cuenta",
+        editAccount: "Editar cuenta",
         remove: "Remove provider",
         removing: "Removing...",
       },
       account: {
         title: "Añadir cuenta de {{provider}}",
-        errorTitle: "No se pudo añadir la cuenta",
+        editTitle: "Editar cuenta de {{provider}}",
+        errorTitle: "No se pudo guardar la cuenta",
         submit: "Añadir cuenta",
+        save: "Guardar cambios",
         fields: {
           label: "Nombre",
           providerId: "ID del proveedor",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2570,8 +2570,41 @@ export const es: TranslationResources = {
       updateErrorTitle: "No se puede actualizar el proveedor",
       actions: {
         menu: "{{name}} actions",
+        addAccount: "Añadir cuenta",
         remove: "Remove provider",
         removing: "Removing...",
+      },
+      account: {
+        title: "Añadir cuenta de {{provider}}",
+        errorTitle: "No se pudo añadir la cuenta",
+        submit: "Añadir cuenta",
+        fields: {
+          label: "Nombre",
+          providerId: "ID del proveedor",
+          description: "Descripción",
+          env: "Variables de entorno",
+          envKey: "Nombre de la variable",
+          envValue: "Valor de la variable",
+        },
+        placeholders: {
+          label: "{{provider}} (Trabajo)",
+          providerId: "claude-work",
+          description: "Opcional",
+          envKey: "NOMBRE",
+          envValue: "Valor",
+        },
+        actions: {
+          addVariable: "Añadir variable",
+          removeVariable: "Quitar variable",
+        },
+        errors: {
+          labelRequired: "Escribe un nombre.",
+          idRequired: "Escribe un ID de proveedor.",
+          idInvalid: "Usa minúsculas, números y guiones, empezando por una letra.",
+          idTaken: "Este ID de proveedor ya está en uso.",
+          envKeyRequired: "Escribe el nombre de la variable.",
+          envDuplicate: "Esta variable ya está definida.",
+        },
       },
       remove: {
         confirmTitle: "Remove {{name}}?",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2600,6 +2600,10 @@ export const es: TranslationResources = {
           addVariable: "Añadir variable",
           removeVariable: "Quitar variable",
         },
+        warnings: {
+          renameUnsupported:
+            "Este host no puede mover los chats existentes al nuevo ID. Los chats que usan esta cuenta no estarán disponibles hasta que actualices el host o restaures el ID anterior.",
+        },
         errors: {
           labelRequired: "Escribe un nombre.",
           idRequired: "Escribe un ID de proveedor.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2578,13 +2578,16 @@ export const fr: TranslationResources = {
       actions: {
         menu: "{{name}} actions",
         addAccount: "Ajouter un compte",
+        editAccount: "Modifier le compte",
         remove: "Remove provider",
         removing: "Removing...",
       },
       account: {
         title: "Ajouter un compte {{provider}}",
-        errorTitle: "Impossible d'ajouter le compte",
+        editTitle: "Modifier le compte {{provider}}",
+        errorTitle: "Impossible d'enregistrer le compte",
         submit: "Ajouter un compte",
+        save: "Enregistrer",
         fields: {
           label: "Nom",
           providerId: "ID du fournisseur",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2577,8 +2577,42 @@ export const fr: TranslationResources = {
       updateErrorTitle: "Impossible de mettre à jour le fournisseur",
       actions: {
         menu: "{{name}} actions",
+        addAccount: "Ajouter un compte",
         remove: "Remove provider",
         removing: "Removing...",
+      },
+      account: {
+        title: "Ajouter un compte {{provider}}",
+        errorTitle: "Impossible d'ajouter le compte",
+        submit: "Ajouter un compte",
+        fields: {
+          label: "Nom",
+          providerId: "ID du fournisseur",
+          description: "Description",
+          env: "Variables d'environnement",
+          envKey: "Nom de la variable",
+          envValue: "Valeur de la variable",
+        },
+        placeholders: {
+          label: "{{provider}} (Travail)",
+          providerId: "claude-work",
+          description: "Facultatif",
+          envKey: "NOM",
+          envValue: "Valeur",
+        },
+        actions: {
+          addVariable: "Ajouter une variable",
+          removeVariable: "Supprimer la variable",
+        },
+        errors: {
+          labelRequired: "Saisissez un nom.",
+          idRequired: "Saisissez un ID de fournisseur.",
+          idInvalid:
+            "Utilisez des minuscules, des chiffres et des tirets, en commençant par une lettre.",
+          idTaken: "Cet ID de fournisseur est déjà utilisé.",
+          envKeyRequired: "Saisissez le nom de la variable.",
+          envDuplicate: "Cette variable est déjà définie.",
+        },
       },
       remove: {
         confirmTitle: "Remove {{name}}?",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2607,6 +2607,10 @@ export const fr: TranslationResources = {
           addVariable: "Ajouter une variable",
           removeVariable: "Supprimer la variable",
         },
+        warnings: {
+          renameUnsupported:
+            "Cet hôte ne peut pas déplacer les conversations existantes vers le nouvel ID. Les conversations utilisant ce compte seront indisponibles tant que vous n'aurez pas mis à jour l'hôte ou restauré l'ancien ID.",
+        },
         errors: {
           labelRequired: "Saisissez un nom.",
           idRequired: "Saisissez un ID de fournisseur.",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -2568,6 +2568,10 @@ export const ja: TranslationResources = {
           addVariable: "変数を追加",
           removeVariable: "変数を削除",
         },
+        warnings: {
+          renameUnsupported:
+            "このホストは既存のチャットを新しい ID に移行できません。ホストを更新するか元の ID に戻すまで、このアカウントを使うチャットは利用できません。",
+        },
         errors: {
           labelRequired: "名前を入力してください。",
           idRequired: "プロバイダー ID を入力してください。",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -2539,13 +2539,16 @@ export const ja: TranslationResources = {
       actions: {
         menu: "{{name}} actions",
         addAccount: "アカウントを追加",
+        editAccount: "アカウントを編集",
         remove: "Remove provider",
         removing: "Removing...",
       },
       account: {
         title: "{{provider}} アカウントを追加",
-        errorTitle: "アカウントを追加できません",
+        editTitle: "{{provider}} アカウントを編集",
+        errorTitle: "アカウントを保存できません",
         submit: "アカウントを追加",
+        save: "変更を保存",
         fields: {
           label: "名前",
           providerId: "プロバイダー ID",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -2538,8 +2538,41 @@ export const ja: TranslationResources = {
       updateErrorTitle: "プロバイダーを更新できません",
       actions: {
         menu: "{{name}} actions",
+        addAccount: "アカウントを追加",
         remove: "Remove provider",
         removing: "Removing...",
+      },
+      account: {
+        title: "{{provider}} アカウントを追加",
+        errorTitle: "アカウントを追加できません",
+        submit: "アカウントを追加",
+        fields: {
+          label: "名前",
+          providerId: "プロバイダー ID",
+          description: "説明",
+          env: "環境変数",
+          envKey: "変数名",
+          envValue: "変数の値",
+        },
+        placeholders: {
+          label: "{{provider}}（仕事）",
+          providerId: "claude-work",
+          description: "省略可",
+          envKey: "名前",
+          envValue: "値",
+        },
+        actions: {
+          addVariable: "変数を追加",
+          removeVariable: "変数を削除",
+        },
+        errors: {
+          labelRequired: "名前を入力してください。",
+          idRequired: "プロバイダー ID を入力してください。",
+          idInvalid: "英小文字・数字・ハイフンを使い、先頭は英字にしてください。",
+          idTaken: "このプロバイダー ID は既に使われています。",
+          envKeyRequired: "変数名を入力してください。",
+          envDuplicate: "この変数は既に設定されています。",
+        },
       },
       remove: {
         confirmTitle: "Remove {{name}}?",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -2527,8 +2527,48 @@ export const ko: TranslationResources = {
       updateErrorTitle: "프로바이더를 업데이트할 수 없습니다",
       actions: {
         menu: "{{name}} 작업",
+        addAccount: "계정 추가",
+        editAccount: "계정 편집",
         remove: "프로바이더 제거",
         removing: "제거 중...",
+      },
+      account: {
+        title: "{{provider}} 계정 추가",
+        editTitle: "{{provider}} 계정 편집",
+        errorTitle: "계정을 저장할 수 없습니다",
+        submit: "계정 추가",
+        save: "변경 사항 저장",
+        fields: {
+          label: "이름",
+          providerId: "프로바이더 ID",
+          description: "설명",
+          env: "환경 변수",
+          envKey: "변수 이름",
+          envValue: "변수 값",
+        },
+        placeholders: {
+          label: "{{provider}} (업무)",
+          providerId: "claude-work",
+          description: "선택 사항",
+          envKey: "NAME",
+          envValue: "값",
+        },
+        actions: {
+          addVariable: "변수 추가",
+          removeVariable: "변수 제거",
+        },
+        warnings: {
+          renameUnsupported:
+            "이 호스트는 기존 대화를 새 ID로 옮길 수 없습니다. 호스트를 업데이트하거나 이전 ID를 복원할 때까지 이 계정을 사용하는 대화를 사용할 수 없습니다.",
+        },
+        errors: {
+          labelRequired: "이름을 입력하세요.",
+          idRequired: "프로바이더 ID를 입력하세요.",
+          idInvalid: "영문 소문자로 시작하고 소문자, 숫자, 하이픈만 사용하세요.",
+          idTaken: "이미 사용 중인 프로바이더 ID입니다.",
+          envKeyRequired: "변수 이름을 입력하세요.",
+          envDuplicate: "이미 설정된 변수입니다.",
+        },
       },
       remove: {
         confirmTitle: "{{name}}를 제거하시겠습니까?",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -2555,13 +2555,16 @@ export const ptBR: TranslationResources = {
       actions: {
         menu: "{{name}} actions",
         addAccount: "Adicionar conta",
+        editAccount: "Editar conta",
         remove: "Remove provider",
         removing: "Removing...",
       },
       account: {
         title: "Adicionar conta do {{provider}}",
-        errorTitle: "Não foi possível adicionar a conta",
+        editTitle: "Editar conta do {{provider}}",
+        errorTitle: "Não foi possível salvar a conta",
         submit: "Adicionar conta",
+        save: "Salvar alterações",
         fields: {
           label: "Nome",
           providerId: "ID do provedor",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -2554,8 +2554,41 @@ export const ptBR: TranslationResources = {
       updateErrorTitle: "Não foi possível atualizar provedor",
       actions: {
         menu: "{{name}} actions",
+        addAccount: "Adicionar conta",
         remove: "Remove provider",
         removing: "Removing...",
+      },
+      account: {
+        title: "Adicionar conta do {{provider}}",
+        errorTitle: "Não foi possível adicionar a conta",
+        submit: "Adicionar conta",
+        fields: {
+          label: "Nome",
+          providerId: "ID do provedor",
+          description: "Descrição",
+          env: "Variáveis de ambiente",
+          envKey: "Nome da variável",
+          envValue: "Valor da variável",
+        },
+        placeholders: {
+          label: "{{provider}} (Trabalho)",
+          providerId: "claude-work",
+          description: "Opcional",
+          envKey: "NOME",
+          envValue: "Valor",
+        },
+        actions: {
+          addVariable: "Adicionar variável",
+          removeVariable: "Remover variável",
+        },
+        errors: {
+          labelRequired: "Digite um nome.",
+          idRequired: "Digite um ID de provedor.",
+          idInvalid: "Use letras minúsculas, números e hifens, começando por uma letra.",
+          idTaken: "Este ID de provedor já está em uso.",
+          envKeyRequired: "Digite o nome da variável.",
+          envDuplicate: "Esta variável já está definida.",
+        },
       },
       remove: {
         confirmTitle: "Remove {{name}}?",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -2584,6 +2584,10 @@ export const ptBR: TranslationResources = {
           addVariable: "Adicionar variável",
           removeVariable: "Remover variável",
         },
+        warnings: {
+          renameUnsupported:
+            "Este host não consegue mover as conversas existentes para o novo ID. As conversas que usam esta conta ficarão indisponíveis até você atualizar o host ou restaurar o ID anterior.",
+        },
         errors: {
           labelRequired: "Digite um nome.",
           idRequired: "Digite um ID de provedor.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2590,6 +2590,10 @@ export const ru: TranslationResources = {
           addVariable: "Добавить переменную",
           removeVariable: "Удалить переменную",
         },
+        warnings: {
+          renameUnsupported:
+            "Этот хост не может перенести существующие чаты на новый ID. Чаты, использующие эту учётную запись, будут недоступны, пока вы не обновите хост или не вернёте прежний ID.",
+        },
         errors: {
           labelRequired: "Введите название.",
           idRequired: "Введите ID провайдера.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2560,8 +2560,41 @@ export const ru: TranslationResources = {
       updateErrorTitle: "Не удалось обновить провайдера",
       actions: {
         menu: "Действия с {{name}}",
+        addAccount: "Добавить аккаунт",
         remove: "Удалить провайдера",
         removing: "Удаление...",
+      },
+      account: {
+        title: "Добавить аккаунт {{provider}}",
+        errorTitle: "Не удалось добавить аккаунт",
+        submit: "Добавить аккаунт",
+        fields: {
+          label: "Название",
+          providerId: "ID провайдера",
+          description: "Описание",
+          env: "Переменные окружения",
+          envKey: "Имя переменной",
+          envValue: "Значение переменной",
+        },
+        placeholders: {
+          label: "{{provider}} (Работа)",
+          providerId: "claude-work",
+          description: "Необязательно",
+          envKey: "ИМЯ",
+          envValue: "Значение",
+        },
+        actions: {
+          addVariable: "Добавить переменную",
+          removeVariable: "Удалить переменную",
+        },
+        errors: {
+          labelRequired: "Введите название.",
+          idRequired: "Введите ID провайдера.",
+          idInvalid: "Используйте строчные буквы, цифры и дефисы, начиная с буквы.",
+          idTaken: "Этот ID провайдера уже занят.",
+          envKeyRequired: "Введите имя переменной.",
+          envDuplicate: "Эта переменная уже задана.",
+        },
       },
       remove: {
         confirmTitle: "Удалить {{name}}?",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2561,13 +2561,16 @@ export const ru: TranslationResources = {
       actions: {
         menu: "Действия с {{name}}",
         addAccount: "Добавить аккаунт",
+        editAccount: "Изменить аккаунт",
         remove: "Удалить провайдера",
         removing: "Удаление...",
       },
       account: {
         title: "Добавить аккаунт {{provider}}",
-        errorTitle: "Не удалось добавить аккаунт",
+        editTitle: "Изменить аккаунт {{provider}}",
+        errorTitle: "Не удалось сохранить аккаунт",
         submit: "Добавить аккаунт",
+        save: "Сохранить изменения",
         fields: {
           label: "Название",
           providerId: "ID провайдера",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -2483,13 +2483,16 @@ export const zhCN: TranslationResources = {
       actions: {
         menu: "{{name}} actions",
         addAccount: "添加账户",
+        editAccount: "编辑账户",
         remove: "Remove provider",
         removing: "Removing...",
       },
       account: {
         title: "添加 {{provider}} 账户",
-        errorTitle: "无法添加账户",
+        editTitle: "编辑 {{provider}} 账户",
+        errorTitle: "无法保存账户",
         submit: "添加账户",
+        save: "保存更改",
         fields: {
           label: "名称",
           providerId: "Provider ID",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -2512,6 +2512,10 @@ export const zhCN: TranslationResources = {
           addVariable: "添加变量",
           removeVariable: "移除变量",
         },
+        warnings: {
+          renameUnsupported:
+            "此主机无法将现有对话迁移到新 ID。在你更新主机或恢复原 ID 之前，使用该账户的对话将不可用。",
+        },
         errors: {
           labelRequired: "请输入名称。",
           idRequired: "请输入 Provider ID。",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -2482,8 +2482,41 @@ export const zhCN: TranslationResources = {
       updateErrorTitle: "无法更新 Provider",
       actions: {
         menu: "{{name}} actions",
+        addAccount: "添加账户",
         remove: "Remove provider",
         removing: "Removing...",
+      },
+      account: {
+        title: "添加 {{provider}} 账户",
+        errorTitle: "无法添加账户",
+        submit: "添加账户",
+        fields: {
+          label: "名称",
+          providerId: "Provider ID",
+          description: "描述",
+          env: "环境变量",
+          envKey: "变量名",
+          envValue: "变量值",
+        },
+        placeholders: {
+          label: "{{provider}}（工作）",
+          providerId: "claude-work",
+          description: "可选",
+          envKey: "名称",
+          envValue: "值",
+        },
+        actions: {
+          addVariable: "添加变量",
+          removeVariable: "移除变量",
+        },
+        errors: {
+          labelRequired: "请输入名称。",
+          idRequired: "请输入 Provider ID。",
+          idInvalid: "只能使用小写字母、数字和连字符，且以字母开头。",
+          idTaken: "该 Provider ID 已被占用。",
+          envKeyRequired: "请输入变量名。",
+          envDuplicate: "该变量已设置。",
+        },
       },
       remove: {
         confirmTitle: "Remove {{name}}?",

--- a/packages/app/src/provider-accounts/provider-account-form-model.test.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.test.ts
@@ -198,4 +198,87 @@ describe("provider account form model", () => {
     model.setSubmitting(false);
     expect(model.getState().canSubmit).toBe(true);
   });
+
+  it("opens an existing account with its editable fields and environment", () => {
+    const model = openForm({
+      existingProviderIds: ["claude", "claude-work", "claude-personal"],
+      account: {
+        providerId: "claude-work",
+        config: {
+          extends: "claude",
+          label: "Claude (Work)",
+          description: "Company account",
+          env: { CLAUDE_CONFIG_DIR: "/work/claude", TOKEN: " keep spaces " },
+        },
+      },
+    });
+
+    expect(model.getState()).toMatchObject({
+      isEditing: true,
+      label: "Claude (Work)",
+      providerId: "claude-work",
+      providerIdError: null,
+      description: "Company account",
+      canSubmit: true,
+    });
+    expect(model.getState().envRows.map(({ key, value }) => ({ key, value }))).toEqual([
+      { key: "CLAUDE_CONFIG_DIR", value: "/work/claude" },
+      { key: "TOKEN", value: " keep spaces " },
+    ]);
+  });
+
+  it("replaces an edited account exactly while preserving fields outside the form", () => {
+    const model = openForm({
+      existingProviderIds: ["claude", "claude-work"],
+      account: {
+        providerId: "claude-work",
+        config: {
+          extends: "claude",
+          label: "Old label",
+          description: "Delete me",
+          env: { OLD_TOKEN: "old", KEEP: "old" },
+          command: ["claude", "--work"],
+          additionalModels: [{ id: "work-model", label: "Work model" }],
+        },
+      },
+    });
+    model.setLabel("Work");
+    model.setDescription("   ");
+    const [oldToken, keep] = model.getState().envRows;
+    if (!oldToken || !keep) throw new Error("expected seeded environment rows");
+    model.removeEnvRow(oldToken.id);
+    model.setEnvValue(keep.id, "new");
+
+    expect(model.buildPatch()).toEqual({
+      replaceProviders: {
+        "claude-work": {
+          extends: "claude",
+          label: "Work",
+          env: { KEEP: "new" },
+          command: ["claude", "--work"],
+          additionalModels: [{ id: "work-model", label: "Work model" }],
+        },
+      },
+    });
+  });
+
+  it("renames an account atomically and still rejects another account id", () => {
+    const model = openForm({
+      existingProviderIds: ["claude", "claude-work", "claude-personal"],
+      account: {
+        providerId: "claude-work",
+        config: { extends: "claude", label: "Work", env: {} },
+      },
+    });
+
+    model.setProviderId("claude-personal");
+    expect(model.getState().providerIdError).toBe("taken");
+    model.setProviderId("claude-company");
+    expect(model.buildPatch()).toEqual({
+      replaceProviders: {
+        "claude-company": { extends: "claude", label: "Work", env: {} },
+      },
+      removeProviders: ["claude-work"],
+    });
+  });
 });

--- a/packages/app/src/provider-accounts/provider-account-form-model.test.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.test.ts
@@ -3,6 +3,7 @@ import {
   canAddProviderAccount,
   deriveProviderAccountId,
   groupProviderAccounts,
+  groupProviderAccountsBy,
   openProviderAccountForm,
   resolveProviderAccountBaseId,
   type ProviderAccountFormSnapshot,
@@ -69,6 +70,20 @@ describe("provider account presentation", () => {
       "copilot",
       "catalog",
     ]);
+  });
+
+  it("groups by an explicit base accessor", () => {
+    const items = [
+      { id: "claude" },
+      { id: "codex" },
+      { id: "claude-work", baseProviderId: "claude" },
+      { id: "orphan", baseProviderId: "missing" },
+    ];
+    expect(
+      groupProviderAccountsBy(items, (item) =>
+        "baseProviderId" in item ? item.baseProviderId : null,
+      ).map((item) => item.id),
+    ).toEqual(["claude", "claude-work", "codex", "orphan"]);
   });
 });
 
@@ -279,6 +294,7 @@ describe("provider account form model", () => {
         "claude-company": { extends: "claude", label: "Work", env: {} },
       },
       removeProviders: ["claude-work"],
+      renameProviders: { "claude-work": "claude-company" },
     });
   });
 });

--- a/packages/app/src/provider-accounts/provider-account-form-model.test.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.test.ts
@@ -22,10 +22,14 @@ describe("canAddProviderAccount", () => {
     expect(canAddProviderAccount({ providerId: "omp", source: "builtin" })).toBe(true);
   });
 
-  it("rejects acp, custom rows, and unknown sources", () => {
+  it("rejects acp and custom rows", () => {
     expect(canAddProviderAccount({ providerId: "acp", source: "builtin" })).toBe(false);
     expect(canAddProviderAccount({ providerId: "junie", source: "custom" })).toBe(false);
-    expect(canAddProviderAccount({ providerId: "claude", source: undefined })).toBe(false);
+    expect(canAddProviderAccount({ providerId: "junie", source: undefined })).toBe(false);
+  });
+
+  it("still offers builtins when the daemon omits source", () => {
+    expect(canAddProviderAccount({ providerId: "claude", source: undefined })).toBe(true);
   });
 });
 

--- a/packages/app/src/provider-accounts/provider-account-form-model.test.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  canAddProviderAccount,
+  deriveProviderAccountId,
+  openProviderAccountForm,
+  type ProviderAccountFormSnapshot,
+} from "./provider-account-form-model";
+
+const SNAPSHOT: ProviderAccountFormSnapshot = {
+  baseProviderId: "claude",
+  baseProviderLabel: "Claude Code",
+  existingProviderIds: ["claude", "codex", "junie"],
+};
+
+function openForm(overrides: Partial<ProviderAccountFormSnapshot> = {}) {
+  return openProviderAccountForm({ ...SNAPSHOT, ...overrides });
+}
+
+describe("canAddProviderAccount", () => {
+  it("accepts builtin providers that can be extended", () => {
+    expect(canAddProviderAccount({ providerId: "claude", source: "builtin" })).toBe(true);
+    expect(canAddProviderAccount({ providerId: "omp", source: "builtin" })).toBe(true);
+  });
+
+  it("rejects acp, custom rows, and unknown sources", () => {
+    expect(canAddProviderAccount({ providerId: "acp", source: "builtin" })).toBe(false);
+    expect(canAddProviderAccount({ providerId: "junie", source: "custom" })).toBe(false);
+    expect(canAddProviderAccount({ providerId: "claude", source: undefined })).toBe(false);
+  });
+});
+
+describe("deriveProviderAccountId", () => {
+  it("slugs a label into a legal provider id", () => {
+    expect(deriveProviderAccountId("Claude (Work)")).toBe("claude-work");
+    expect(deriveProviderAccountId("  Z.AI  ")).toBe("z-ai");
+    expect(deriveProviderAccountId("2nd Account")).toBe("nd-account");
+    expect(deriveProviderAccountId("!!!")).toBe("");
+  });
+});
+
+describe("provider account form model", () => {
+  it("tracks the label until the id is edited by hand", () => {
+    const model = openForm();
+    model.setLabel("Claude Work");
+    expect(model.getState().providerId).toBe("claude-work");
+    expect(model.getState().providerIdEdited).toBe(false);
+
+    model.setProviderId("work");
+    model.setLabel("Claude Personal");
+    expect(model.getState().providerId).toBe("work");
+    expect(model.getState().providerIdEdited).toBe(true);
+  });
+
+  it("hides required errors until submit is attempted", () => {
+    const model = openForm();
+    expect(model.getState().labelError).toBeNull();
+    expect(model.getState().providerIdError).toBeNull();
+    expect(model.getState().canSubmit).toBe(false);
+
+    model.markSubmitAttempted();
+    expect(model.getState().labelError).toBe("required");
+    expect(model.getState().providerIdError).toBe("required");
+  });
+
+  it("reports format and collision errors as soon as the id is touched", () => {
+    const model = openForm();
+    model.setProviderId("Claude Work");
+    expect(model.getState().providerIdError).toBe("invalid");
+
+    model.setProviderId("junie");
+    expect(model.getState().providerIdError).toBe("taken");
+
+    model.setProviderId("acp");
+    expect(model.getState().providerIdError).toBe("taken");
+
+    model.setProviderId("claude-work");
+    expect(model.getState().providerIdError).toBeNull();
+  });
+
+  it("rejects env rows with a value but no key, and duplicate keys", () => {
+    const model = openForm();
+    model.setLabel("Claude Work");
+    const [firstRow] = model.getState().envRows;
+    if (!firstRow) throw new Error("expected a seeded env row");
+
+    model.setEnvValue(firstRow.id, "sk-test");
+    expect(model.getState().envErrors[firstRow.id]).toBe("keyRequired");
+    expect(model.getState().canSubmit).toBe(false);
+
+    model.setEnvKey(firstRow.id, "ANTHROPIC_API_KEY");
+    expect(model.getState().envErrors).toEqual({});
+    expect(model.getState().canSubmit).toBe(true);
+
+    model.addEnvRow();
+    const secondRow = model.getState().envRows[1];
+    if (!secondRow) throw new Error("expected a second env row");
+    model.setEnvKey(secondRow.id, "ANTHROPIC_API_KEY");
+    expect(model.getState().envErrors[secondRow.id]).toBe("duplicate");
+    expect(model.getState().canSubmit).toBe(false);
+
+    model.removeEnvRow(secondRow.id);
+    expect(model.getState().canSubmit).toBe(true);
+  });
+
+  it("keeps one env row after removing the last one", () => {
+    const model = openForm();
+    const [firstRow] = model.getState().envRows;
+    if (!firstRow) throw new Error("expected a seeded env row");
+    model.removeEnvRow(firstRow.id);
+    expect(model.getState().envRows).toHaveLength(1);
+  });
+
+  it("builds the config patch and drops empty rows", () => {
+    const model = openForm();
+    model.setLabel("Claude (Work)");
+    model.setDescription("  Work account  ");
+    const [firstRow] = model.getState().envRows;
+    if (!firstRow) throw new Error("expected a seeded env row");
+    model.setEnvKey(firstRow.id, " ANTHROPIC_API_KEY ");
+    model.setEnvValue(firstRow.id, " sk-test ");
+    model.addEnvRow();
+
+    expect(model.buildPatch()).toEqual({
+      providers: {
+        "claude-work": {
+          extends: "claude",
+          label: "Claude (Work)",
+          description: "Work account",
+          env: { ANTHROPIC_API_KEY: "sk-test" },
+        },
+      },
+    });
+  });
+
+  it("omits description when blank and returns no patch while invalid", () => {
+    const model = openForm();
+    model.setLabel("Claude Work");
+    expect(model.buildPatch()).toEqual({
+      providers: {
+        "claude-work": { extends: "claude", label: "Claude Work", env: {} },
+      },
+    });
+
+    model.setProviderId("claude");
+    expect(model.buildPatch()).toBeNull();
+  });
+
+  it("revalidates when the provider snapshot gains the id", () => {
+    const model = openForm({ existingProviderIds: [] });
+    model.setLabel("Claude Work");
+    expect(model.getState().canSubmit).toBe(true);
+
+    model.applyExistingProviderIds(["claude-work"]);
+    model.markSubmitAttempted();
+    expect(model.getState().providerIdError).toBe("taken");
+    expect(model.getState().canSubmit).toBe(false);
+  });
+
+  it("blocks submission while submitting", () => {
+    const model = openForm();
+    model.setLabel("Claude Work");
+    model.setSubmitting(true);
+    expect(model.getState().canSubmit).toBe(false);
+    model.setSubmitting(false);
+    expect(model.getState().canSubmit).toBe(true);
+  });
+});

--- a/packages/app/src/provider-accounts/provider-account-form-model.test.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   canAddProviderAccount,
   deriveProviderAccountId,
+  groupProviderAccounts,
   openProviderAccountForm,
+  resolveProviderAccountBaseId,
   type ProviderAccountFormSnapshot,
 } from "./provider-account-form-model";
 
@@ -39,6 +41,34 @@ describe("deriveProviderAccountId", () => {
     expect(deriveProviderAccountId("  Z.AI  ")).toBe("z-ai");
     expect(deriveProviderAccountId("2nd Account")).toBe("nd-account");
     expect(deriveProviderAccountId("!!!")).toBe("");
+  });
+});
+
+describe("provider account presentation", () => {
+  const providers = {
+    "claude-work": { extends: "claude" },
+    "codex-work": { extends: "codex" },
+    catalog: { extends: "acp" },
+  };
+
+  it("resolves the built-in base used for an account icon", () => {
+    expect(resolveProviderAccountBaseId("claude-work", providers)).toBe("claude");
+    expect(resolveProviderAccountBaseId("catalog", providers)).toBeNull();
+    expect(resolveProviderAccountBaseId("claude", providers)).toBeNull();
+  });
+
+  it("groups accounts immediately after their built-in base", () => {
+    const items = ["claude", "codex", "copilot", "catalog", "claude-work", "codex-work"].map(
+      (id) => ({ id }),
+    );
+    expect(groupProviderAccounts(items, providers).map((item) => item.id)).toEqual([
+      "claude",
+      "claude-work",
+      "codex",
+      "codex-work",
+      "copilot",
+      "catalog",
+    ]);
   });
 });
 
@@ -130,7 +160,7 @@ describe("provider account form model", () => {
           extends: "claude",
           label: "Claude (Work)",
           description: "Work account",
-          env: { ANTHROPIC_API_KEY: "sk-test" },
+          env: { ANTHROPIC_API_KEY: " sk-test " },
         },
       },
     });

--- a/packages/app/src/provider-accounts/provider-account-form-model.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.ts
@@ -53,11 +53,22 @@ export function groupProviderAccounts<T extends { id: string }>(
   items: readonly T[],
   providers: Record<string, Record<string, unknown>> | undefined,
 ): T[] {
+  return groupProviderAccountsBy(items, (item) => resolveProviderAccountBaseId(item.id, providers));
+}
+
+/**
+ * Orders each provider account immediately after the base provider it extends.
+ * Accounts whose base is missing from the list keep their original order at the end.
+ */
+export function groupProviderAccountsBy<T extends { id: string }>(
+  items: readonly T[],
+  getBaseId: (item: T) => string | null | undefined,
+): T[] {
   const accountsByBase = new Map<string, T[]>();
   const accountIds = new Set<string>();
 
   for (const item of items) {
-    const baseProviderId = resolveProviderAccountBaseId(item.id, providers);
+    const baseProviderId = getBaseId(item);
     if (!baseProviderId) continue;
     accountIds.add(item.id);
     const accounts = accountsByBase.get(baseProviderId) ?? [];
@@ -266,7 +277,10 @@ export function buildProviderAccountConfigPatch(input: {
     return {
       replaceProviders: { [providerId]: providerConfig },
       ...(providerId !== input.originalProviderId
-        ? { removeProviders: [input.originalProviderId] }
+        ? {
+            removeProviders: [input.originalProviderId],
+            renameProviders: { [input.originalProviderId]: providerId },
+          }
         : {}),
     };
   }

--- a/packages/app/src/provider-accounts/provider-account-form-model.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.ts
@@ -1,4 +1,4 @@
-import type { MutableDaemonConfigPatch } from "@getpaseo/protocol/messages";
+import type { MutableDaemonConfig, MutableDaemonConfigPatch } from "@getpaseo/protocol/messages";
 
 /** Provider ids the daemon reserves; a new account can never claim one. */
 export const RESERVED_PROVIDER_IDS = [
@@ -98,6 +98,7 @@ export interface ProviderAccountEnvRow {
 }
 
 export interface ProviderAccountFormState {
+  isEditing: boolean;
   baseProviderId: string;
   baseProviderLabel: string;
   label: string;
@@ -118,6 +119,10 @@ export interface ProviderAccountFormSnapshot {
   baseProviderId: string;
   baseProviderLabel: string;
   existingProviderIds: readonly string[];
+  account?: {
+    providerId: string;
+    config: MutableDaemonConfig["providers"][string];
+  };
 }
 
 export interface ProviderAccountFormModel {
@@ -138,6 +143,7 @@ export interface ProviderAccountFormModel {
 }
 
 interface InternalState {
+  originalProviderId: string | null;
   label: string;
   providerId: string;
   providerIdEdited: boolean;
@@ -161,7 +167,9 @@ function validate(internal: InternalState): Validation {
   const providerId = internal.providerId.trim();
   const taken = new Set<string>([
     ...RESERVED_PROVIDER_IDS,
-    ...internal.existingProviderIds.map((value) => value.trim()),
+    ...internal.existingProviderIds
+      .map((value) => value.trim())
+      .filter((value) => value !== internal.originalProviderId),
   ]);
   let providerIdError: ProviderAccountIdError | null = null;
   if (providerId.length === 0) {
@@ -207,6 +215,7 @@ function project(internal: InternalState, snapshot: ProviderAccountFormSnapshot)
     (internal.providerIdEdited && validation.providerIdError !== "required");
 
   const state: ProviderAccountFormState = {
+    isEditing: internal.originalProviderId !== null,
     baseProviderId: snapshot.baseProviderId,
     baseProviderLabel: snapshot.baseProviderLabel,
     label: internal.label,
@@ -229,6 +238,8 @@ export function buildProviderAccountConfigPatch(input: {
   label: string;
   description: string;
   envRows: readonly ProviderAccountEnvRow[];
+  originalProviderId?: string;
+  originalConfig?: MutableDaemonConfig["providers"][string];
 }): MutableDaemonConfigPatch {
   const env: Record<string, string> = {};
   for (const row of input.envRows) {
@@ -238,16 +249,28 @@ export function buildProviderAccountConfigPatch(input: {
   }
   const description = input.description.trim();
 
-  return {
-    providers: {
-      [input.providerId.trim()]: {
-        extends: input.baseProviderId,
-        label: input.label.trim(),
-        ...(description ? { description } : {}),
-        env,
-      },
-    },
+  const providerId = input.providerId.trim();
+  const providerConfig: MutableDaemonConfig["providers"][string] = {
+    ...input.originalConfig,
+    extends: input.baseProviderId,
+    label: input.label.trim(),
+    env,
   };
+  if (description) {
+    providerConfig.description = description;
+  } else {
+    delete providerConfig.description;
+  }
+
+  if (input.originalProviderId) {
+    return {
+      replaceProviders: { [providerId]: providerConfig },
+      ...(providerId !== input.originalProviderId
+        ? { removeProviders: [input.originalProviderId] }
+        : {}),
+    };
+  }
+  return { providers: { [providerId]: providerConfig } };
 }
 
 export function openProviderAccountForm(
@@ -259,12 +282,22 @@ export function openProviderAccountForm(
     return { id: `env-${rowCounter}`, key: "", value: "" };
   };
 
+  const accountConfig = snapshot.account?.config;
+  const accountEnv = accountConfig?.env;
+  const initialEnvRows =
+    accountEnv && typeof accountEnv === "object" && !Array.isArray(accountEnv)
+      ? Object.entries(accountEnv).flatMap(([key, value]) =>
+          typeof value === "string" ? [{ ...createRow(), key, value }] : [],
+        )
+      : [];
+
   let internal: InternalState = {
-    label: "",
-    providerId: "",
-    providerIdEdited: false,
-    description: "",
-    envRows: [createRow()],
+    originalProviderId: snapshot.account?.providerId ?? null,
+    label: typeof accountConfig?.label === "string" ? accountConfig.label : "",
+    providerId: snapshot.account?.providerId ?? "",
+    providerIdEdited: snapshot.account !== undefined,
+    description: typeof accountConfig?.description === "string" ? accountConfig.description : "",
+    envRows: initialEnvRows.length > 0 ? initialEnvRows : [createRow()],
     existingProviderIds: [...snapshot.existingProviderIds],
     submitAttempted: false,
     isSubmitting: false,
@@ -343,6 +376,8 @@ export function openProviderAccountForm(
         label: internal.label,
         description: internal.description,
         envRows: internal.envRows,
+        originalProviderId: internal.originalProviderId ?? undefined,
+        originalConfig: snapshot.account?.config,
       });
     },
   };

--- a/packages/app/src/provider-accounts/provider-account-form-model.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.ts
@@ -1,0 +1,305 @@
+import type { MutableDaemonConfigPatch } from "@getpaseo/protocol/messages";
+
+/** Provider ids the daemon reserves; a new account can never claim one. */
+export const RESERVED_PROVIDER_IDS = [
+  "claude",
+  "codex",
+  "copilot",
+  "opencode",
+  "pi",
+  "omp",
+  "acp",
+] as const;
+
+/**
+ * Builtin providers an account can extend. `acp` is excluded: ACP entries are
+ * installed from the catalog with their own command, not cloned per account.
+ */
+export const ACCOUNT_BASE_PROVIDER_IDS = [
+  "claude",
+  "codex",
+  "copilot",
+  "opencode",
+  "pi",
+  "omp",
+] as const;
+
+// Mirrors ProviderOverridesSchema in packages/protocol/src/provider-config.ts.
+export const PROVIDER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+export function canAddProviderAccount(input: {
+  providerId: string;
+  source: "builtin" | "custom" | undefined;
+}): boolean {
+  if (input.source !== "builtin") return false;
+  return (ACCOUNT_BASE_PROVIDER_IDS as readonly string[]).includes(input.providerId);
+}
+
+export function deriveProviderAccountId(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^[^a-z]+/, "")
+    .replace(/-+$/, "");
+}
+
+export type ProviderAccountLabelError = "required";
+export type ProviderAccountIdError = "required" | "invalid" | "taken";
+export type ProviderAccountEnvError = "keyRequired" | "duplicate";
+
+export interface ProviderAccountEnvRow {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface ProviderAccountFormState {
+  baseProviderId: string;
+  baseProviderLabel: string;
+  label: string;
+  providerId: string;
+  /** False while the id still tracks the label; the id input remounts on change. */
+  providerIdEdited: boolean;
+  description: string;
+  envRows: ProviderAccountEnvRow[];
+  /** Errors are only populated once the user can act on them. */
+  labelError: ProviderAccountLabelError | null;
+  providerIdError: ProviderAccountIdError | null;
+  envErrors: Record<string, ProviderAccountEnvError>;
+  canSubmit: boolean;
+  isSubmitting: boolean;
+}
+
+export interface ProviderAccountFormSnapshot {
+  baseProviderId: string;
+  baseProviderLabel: string;
+  existingProviderIds: readonly string[];
+}
+
+export interface ProviderAccountFormModel {
+  getState: () => ProviderAccountFormState;
+  subscribe: (listener: () => void) => () => void;
+  close: () => void;
+  applyExistingProviderIds: (providerIds: readonly string[]) => void;
+  setLabel: (value: string) => void;
+  setProviderId: (value: string) => void;
+  setDescription: (value: string) => void;
+  addEnvRow: () => void;
+  removeEnvRow: (rowId: string) => void;
+  setEnvKey: (rowId: string, value: string) => void;
+  setEnvValue: (rowId: string, value: string) => void;
+  setSubmitting: (value: boolean) => void;
+  markSubmitAttempted: () => void;
+  buildPatch: () => MutableDaemonConfigPatch | null;
+}
+
+interface InternalState {
+  label: string;
+  providerId: string;
+  providerIdEdited: boolean;
+  description: string;
+  envRows: ProviderAccountEnvRow[];
+  existingProviderIds: readonly string[];
+  submitAttempted: boolean;
+  isSubmitting: boolean;
+}
+
+interface Validation {
+  labelError: ProviderAccountLabelError | null;
+  providerIdError: ProviderAccountIdError | null;
+  envErrors: Record<string, ProviderAccountEnvError>;
+}
+
+function validate(internal: InternalState): Validation {
+  const labelError: ProviderAccountLabelError | null =
+    internal.label.trim().length === 0 ? "required" : null;
+
+  const providerId = internal.providerId.trim();
+  const taken = new Set<string>([
+    ...RESERVED_PROVIDER_IDS,
+    ...internal.existingProviderIds.map((value) => value.trim()),
+  ]);
+  let providerIdError: ProviderAccountIdError | null = null;
+  if (providerId.length === 0) {
+    providerIdError = "required";
+  } else if (!PROVIDER_ID_PATTERN.test(providerId)) {
+    providerIdError = "invalid";
+  } else if (taken.has(providerId)) {
+    providerIdError = "taken";
+  }
+
+  const envErrors: Record<string, ProviderAccountEnvError> = {};
+  const seenKeys = new Set<string>();
+  for (const row of internal.envRows) {
+    const key = row.key.trim();
+    if (key.length === 0) {
+      if (row.value.trim().length > 0) {
+        envErrors[row.id] = "keyRequired";
+      }
+      continue;
+    }
+    if (seenKeys.has(key)) {
+      envErrors[row.id] = "duplicate";
+      continue;
+    }
+    seenKeys.add(key);
+  }
+
+  return { labelError, providerIdError, envErrors };
+}
+
+function project(internal: InternalState, snapshot: ProviderAccountFormSnapshot) {
+  const validation = validate(internal);
+  const isValid =
+    validation.labelError === null &&
+    validation.providerIdError === null &&
+    Object.keys(validation.envErrors).length === 0;
+
+  // "required" is noise until the user tries to submit; format and collision
+  // errors are actionable the moment the id field has been touched.
+  const showLabelError = internal.submitAttempted;
+  const showProviderIdError =
+    internal.submitAttempted ||
+    (internal.providerIdEdited && validation.providerIdError !== "required");
+
+  const state: ProviderAccountFormState = {
+    baseProviderId: snapshot.baseProviderId,
+    baseProviderLabel: snapshot.baseProviderLabel,
+    label: internal.label,
+    providerId: internal.providerId,
+    providerIdEdited: internal.providerIdEdited,
+    description: internal.description,
+    envRows: internal.envRows,
+    labelError: showLabelError ? validation.labelError : null,
+    providerIdError: showProviderIdError ? validation.providerIdError : null,
+    envErrors: validation.envErrors,
+    canSubmit: isValid && !internal.isSubmitting,
+    isSubmitting: internal.isSubmitting,
+  };
+  return state;
+}
+
+export function buildProviderAccountConfigPatch(input: {
+  providerId: string;
+  baseProviderId: string;
+  label: string;
+  description: string;
+  envRows: readonly ProviderAccountEnvRow[];
+}): MutableDaemonConfigPatch {
+  const env: Record<string, string> = {};
+  for (const row of input.envRows) {
+    const key = row.key.trim();
+    if (key.length === 0) continue;
+    env[key] = row.value.trim();
+  }
+  const description = input.description.trim();
+
+  return {
+    providers: {
+      [input.providerId.trim()]: {
+        extends: input.baseProviderId,
+        label: input.label.trim(),
+        ...(description ? { description } : {}),
+        env,
+      },
+    },
+  };
+}
+
+export function openProviderAccountForm(
+  snapshot: ProviderAccountFormSnapshot,
+): ProviderAccountFormModel {
+  let rowCounter = 0;
+  const createRow = (): ProviderAccountEnvRow => {
+    rowCounter += 1;
+    return { id: `env-${rowCounter}`, key: "", value: "" };
+  };
+
+  let internal: InternalState = {
+    label: "",
+    providerId: "",
+    providerIdEdited: false,
+    description: "",
+    envRows: [createRow()],
+    existingProviderIds: [...snapshot.existingProviderIds],
+    submitAttempted: false,
+    isSubmitting: false,
+  };
+
+  let listeners = new Set<() => void>();
+  let state = project(internal, snapshot);
+
+  const publish = (next: InternalState) => {
+    internal = next;
+    state = project(internal, snapshot);
+    for (const listener of listeners) listener();
+  };
+
+  const mapRows = (rowId: string, update: (row: ProviderAccountEnvRow) => ProviderAccountEnvRow) =>
+    internal.envRows.map((row) => (row.id === rowId ? update(row) : row));
+
+  return {
+    getState: () => state,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    close: () => {
+      listeners = new Set();
+    },
+    applyExistingProviderIds: (providerIds) => {
+      const next = [...providerIds];
+      const unchanged =
+        next.length === internal.existingProviderIds.length &&
+        next.every((value, index) => value === internal.existingProviderIds[index]);
+      if (unchanged) return;
+      publish({ ...internal, existingProviderIds: next });
+    },
+    setLabel: (value) => {
+      publish({
+        ...internal,
+        label: value,
+        providerId: internal.providerIdEdited
+          ? internal.providerId
+          : deriveProviderAccountId(value),
+      });
+    },
+    setProviderId: (value) => {
+      publish({ ...internal, providerId: value, providerIdEdited: true });
+    },
+    setDescription: (value) => {
+      publish({ ...internal, description: value });
+    },
+    addEnvRow: () => {
+      publish({ ...internal, envRows: [...internal.envRows, createRow()] });
+    },
+    removeEnvRow: (rowId) => {
+      const remaining = internal.envRows.filter((row) => row.id !== rowId);
+      publish({ ...internal, envRows: remaining.length > 0 ? remaining : [createRow()] });
+    },
+    setEnvKey: (rowId, value) => {
+      publish({ ...internal, envRows: mapRows(rowId, (row) => ({ ...row, key: value })) });
+    },
+    setEnvValue: (rowId, value) => {
+      publish({ ...internal, envRows: mapRows(rowId, (row) => ({ ...row, value })) });
+    },
+    setSubmitting: (value) => {
+      publish({ ...internal, isSubmitting: value });
+    },
+    markSubmitAttempted: () => {
+      publish({ ...internal, submitAttempted: true });
+    },
+    buildPatch: () => {
+      if (!state.canSubmit) return null;
+      return buildProviderAccountConfigPatch({
+        providerId: internal.providerId,
+        baseProviderId: snapshot.baseProviderId,
+        label: internal.label,
+        description: internal.description,
+        envRows: internal.envRows,
+      });
+    },
+  };
+}

--- a/packages/app/src/provider-accounts/provider-account-form-model.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.ts
@@ -38,6 +38,47 @@ export function canAddProviderAccount(input: {
   return (ACCOUNT_BASE_PROVIDER_IDS as readonly string[]).includes(input.providerId);
 }
 
+export function resolveProviderAccountBaseId(
+  providerId: string,
+  providers: Record<string, Record<string, unknown>> | undefined,
+): string | null {
+  const extendsProvider = providers?.[providerId]?.extends;
+  return typeof extendsProvider === "string" &&
+    (ACCOUNT_BASE_PROVIDER_IDS as readonly string[]).includes(extendsProvider)
+    ? extendsProvider
+    : null;
+}
+
+export function groupProviderAccounts<T extends { id: string }>(
+  items: readonly T[],
+  providers: Record<string, Record<string, unknown>> | undefined,
+): T[] {
+  const accountsByBase = new Map<string, T[]>();
+  const accountIds = new Set<string>();
+
+  for (const item of items) {
+    const baseProviderId = resolveProviderAccountBaseId(item.id, providers);
+    if (!baseProviderId) continue;
+    accountIds.add(item.id);
+    const accounts = accountsByBase.get(baseProviderId) ?? [];
+    accounts.push(item);
+    accountsByBase.set(baseProviderId, accounts);
+  }
+
+  const grouped: T[] = [];
+  for (const item of items) {
+    if (accountIds.has(item.id)) continue;
+    grouped.push(item, ...(accountsByBase.get(item.id) ?? []));
+  }
+
+  for (const item of items) {
+    if (accountIds.has(item.id) && !grouped.includes(item)) {
+      grouped.push(item);
+    }
+  }
+  return grouped;
+}
+
 export function deriveProviderAccountId(label: string): string {
   return label
     .toLowerCase()
@@ -193,7 +234,7 @@ export function buildProviderAccountConfigPatch(input: {
   for (const row of input.envRows) {
     const key = row.key.trim();
     if (key.length === 0) continue;
-    env[key] = row.value.trim();
+    env[key] = row.value;
   }
   const description = input.description.trim();
 

--- a/packages/app/src/provider-accounts/provider-account-form-model.ts
+++ b/packages/app/src/provider-accounts/provider-account-form-model.ts
@@ -31,7 +31,10 @@ export function canAddProviderAccount(input: {
   providerId: string;
   source: "builtin" | "custom" | undefined;
 }): boolean {
-  if (input.source !== "builtin") return false;
+  // `source` is optional on the wire, so daemons that predate it report
+  // undefined. Reject only an explicit "custom": the daemon reports a builtin
+  // id as "builtin" regardless of overrides, so no custom row can reach here.
+  if (input.source === "custom") return false;
   return (ACCOUNT_BASE_PROVIDER_IDS as readonly string[]).includes(input.providerId);
 }
 

--- a/packages/app/src/provider-accounts/use-provider-account-form-model.ts
+++ b/packages/app/src/provider-accounts/use-provider-account-form-model.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import {
+  openProviderAccountForm,
+  type ProviderAccountFormSnapshot,
+} from "./provider-account-form-model";
+
+export function useProviderAccountFormModel(snapshot: ProviderAccountFormSnapshot) {
+  const [model] = useState(() => openProviderAccountForm(snapshot));
+
+  useEffect(() => {
+    return () => {
+      model.close();
+    };
+  }, [model]);
+
+  useEffect(() => {
+    model.applyExistingProviderIds(snapshot.existingProviderIds);
+  }, [model, snapshot.existingProviderIds]);
+
+  return model;
+}

--- a/packages/app/src/provider-selection/provider-selection.test.ts
+++ b/packages/app/src/provider-selection/provider-selection.test.ts
@@ -9,6 +9,7 @@ import {
   buildSelectedTriggerLabel,
   filterAndRankModelRows,
   matchesModelSearch,
+  resolveProviderIconId,
   resolveSelectedModelLabel,
   resolveSubmissionReadiness,
 } from "./provider-selection";
@@ -35,6 +36,26 @@ describe("combined model selector data", () => {
       models: overrides.models ?? [codexModel],
     };
   }
+
+  it("orders provider accounts after their base provider and borrows its icon", () => {
+    const providers = buildSelectableProviderSelectorProviders([
+      snapshotEntry({ provider: "claude", label: "Claude" }),
+      snapshotEntry({ provider: "codex", label: "Codex" }),
+      snapshotEntry({
+        provider: "claude-work",
+        label: "Claude (Work)",
+        source: "custom",
+        baseProviderId: "claude",
+      }),
+    ]);
+
+    expect(providers.map((provider) => provider.id)).toEqual(["claude", "claude-work", "codex"]);
+    expect(resolveProviderIconId(providers, "claude-work")).toBe("claude");
+    expect(resolveProviderIconId(providers, "codex")).toBe("codex");
+    const accountRows =
+      providers[1].modelSelection.kind === "models" ? providers[1].modelSelection.rows : [];
+    expect(accountRows[0]?.iconProviderId).toBe("claude");
+  });
 
   it("builds selector providers from ready enabled snapshot entries", () => {
     expect(

--- a/packages/app/src/provider-selection/provider-selection.ts
+++ b/packages/app/src/provider-selection/provider-selection.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgentProviderDefinition } from "@getpaseo/protocol/provider-manifest";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
 import { i18n } from "@/i18n/i18next";
+import { groupProviderAccountsBy } from "@/provider-accounts/provider-account-form-model";
 import { compareMatchScores, scoreTextFields } from "@getpaseo/protocol/search/text-match";
 import { filterSelectableModels } from "./model-catalog";
 
@@ -23,6 +24,8 @@ export interface ProviderSelectionModelRow {
   modelLabel: string;
   description?: string;
   isDefault?: boolean;
+  /** Provider whose icon this row shows; differs from `provider` for provider accounts. */
+  iconProviderId?: string;
 }
 
 function buildModelRowKey(provider: string, modelId: string): string {
@@ -37,7 +40,17 @@ export type ProviderModelSelection =
 export interface ProviderSelectorProvider {
   id: string;
   label: string;
+  /** Builtin provider this account extends; drives grouping and the row icon. */
+  baseProviderId?: string;
   modelSelection: ProviderModelSelection;
+}
+
+/** The provider whose icon represents `providerId` — an account borrows its base provider's icon. */
+export function resolveProviderIconId(
+  providers: readonly ProviderSelectorProvider[],
+  providerId: string,
+): string {
+  return providers.find((entry) => entry.id === providerId)?.baseProviderId ?? providerId;
 }
 
 export interface ProviderSelectionState {
@@ -58,11 +71,13 @@ function buildModelRows(
   provider: string,
   providerLabel: string,
   models: AgentModelDefinition[],
+  iconProviderId?: string,
 ): ProviderSelectionModelRow[] {
   return models.map((model) => ({
     favoriteKey: buildModelRowKey(provider, model.id),
     provider,
     providerLabel,
+    iconProviderId,
     modelId: model.id,
     modelLabel: model.label,
     description: model.description ?? model.id,
@@ -73,11 +88,13 @@ function buildModelRows(
 function buildSyntheticDefaultRow(
   provider: string,
   providerLabel: string,
+  iconProviderId?: string,
 ): ProviderSelectionModelRow {
   return {
     favoriteKey: buildModelRowKey(provider, ""),
     provider,
     providerLabel,
+    iconProviderId,
     modelId: "",
     modelLabel: i18n.t("providerSelection.defaultModel"),
     description: undefined,
@@ -89,26 +106,34 @@ function buildModelSelection(
   provider: string,
   providerLabel: string,
   models: AgentModelDefinition[] | null,
+  iconProviderId?: string,
 ): ProviderModelSelection {
   if (models === null) {
     return { kind: "loading" };
   }
   const selectableModels = filterSelectableModels(models) ?? [];
   if (selectableModels.length === 0) {
-    return { kind: "models", rows: [buildSyntheticDefaultRow(provider, providerLabel)] };
+    return {
+      kind: "models",
+      rows: [buildSyntheticDefaultRow(provider, providerLabel, iconProviderId)],
+    };
   }
-  return { kind: "models", rows: buildModelRows(provider, providerLabel, selectableModels) };
+  return {
+    kind: "models",
+    rows: buildModelRows(provider, providerLabel, selectableModels, iconProviderId),
+  };
 }
 
 function buildEntryModelSelection(
   entry: ProviderSnapshotEntry,
   label: string,
+  iconProviderId?: string,
 ): ProviderModelSelection {
   if ((entry.models?.length ?? 0) > 0) {
-    return buildModelSelection(entry.provider, label, entry.models ?? null);
+    return buildModelSelection(entry.provider, label, entry.models ?? null, iconProviderId);
   }
   if (entry.status === "ready") {
-    return buildModelSelection(entry.provider, label, entry.models ?? null);
+    return buildModelSelection(entry.provider, label, entry.models ?? null, iconProviderId);
   }
   if (entry.status === "loading") {
     return { kind: "loading" };
@@ -127,32 +152,41 @@ export function buildProviderSelectorProviders(input: {
   providerDefinitions: AgentProviderDefinition[];
   modelsByProvider: Map<string, AgentModelDefinition[]>;
 }): ProviderSelectorProvider[] {
-  return input.providerDefinitions.map((definition) => ({
-    id: definition.id,
-    label: definition.label,
-    modelSelection: buildModelSelection(
-      definition.id,
-      definition.label,
-      input.modelsByProvider.has(definition.id)
-        ? (input.modelsByProvider.get(definition.id) ?? [])
-        : null,
-    ),
-  }));
+  return groupProviderAccountsBy(
+    input.providerDefinitions.map((definition) => ({
+      id: definition.id,
+      label: definition.label,
+      baseProviderId: definition.baseProviderId,
+      modelSelection: buildModelSelection(
+        definition.id,
+        definition.label,
+        input.modelsByProvider.has(definition.id)
+          ? (input.modelsByProvider.get(definition.id) ?? [])
+          : null,
+        definition.baseProviderId,
+      ),
+    })),
+    (provider) => provider.baseProviderId,
+  );
 }
 
 export function buildSelectableProviderSelectorProviders(
   entries: ProviderSnapshotEntry[] | undefined,
 ): ProviderSelectorProvider[] {
-  return (entries ?? [])
-    .filter((entry) => entry.enabled)
-    .map((entry) => {
-      const label = entry.label ?? entry.provider;
-      return {
-        id: entry.provider,
-        label,
-        modelSelection: buildEntryModelSelection(entry, label),
-      };
-    });
+  return groupProviderAccountsBy(
+    (entries ?? [])
+      .filter((entry) => entry.enabled)
+      .map((entry) => {
+        const label = entry.label ?? entry.provider;
+        return {
+          id: entry.provider,
+          label,
+          baseProviderId: entry.baseProviderId,
+          modelSelection: buildEntryModelSelection(entry, label, entry.baseProviderId),
+        };
+      }),
+    (provider) => provider.baseProviderId,
+  );
 }
 
 export function getProviderModelRows(

--- a/packages/app/src/provider-usage/card.tsx
+++ b/packages/app/src/provider-usage/card.tsx
@@ -65,7 +65,11 @@ export function ProviderUsageCard({
   return (
     <View style={containerStyle}>
       <View style={styles.header}>
-        <ThemedProviderUsageIcon iconKey={usage.providerId} size={14} uniProps={mutedIconColor} />
+        <ThemedProviderUsageIcon
+          iconKey={usage.baseProviderId ?? usage.providerId}
+          size={14}
+          uniProps={mutedIconColor}
+        />
         <Text style={styles.name} numberOfLines={1}>
           {usage.displayName}
         </Text>

--- a/packages/app/src/screens/settings/providers-section.test.tsx
+++ b/packages/app/src/screens/settings/providers-section.test.tsx
@@ -100,6 +100,7 @@ vi.mock("lucide-react-native", () => {
     ChevronRight: icon("ChevronRight"),
     MoreHorizontal: icon("MoreHorizontal"),
     Trash2: icon("Trash2"),
+    UserPlus: icon("UserPlus"),
   };
 });
 
@@ -244,6 +245,20 @@ vi.mock("@/stores/provider-settings-store", () => ({
 
 vi.mock("@/components/provider-catalog-list", () => ({
   ProviderCatalogList: () => null,
+}));
+
+// The real sheet pulls in react-native-reanimated, which is untransformed here.
+vi.mock("@/components/provider-account-sheet", () => ({
+  ProviderAccountSheet: ({
+    visible,
+    baseProviderId,
+  }: {
+    visible?: boolean;
+    baseProviderId?: string;
+  }) =>
+    visible
+      ? React.createElement("div", { "data-testid": `provider-account-sheet-${baseProviderId}` })
+      : null,
 }));
 
 vi.mock("@/hooks/use-providers-snapshot", () => ({
@@ -441,6 +456,29 @@ describe("ProvidersSection", () => {
       serverId: "server-1",
       provider: "codex",
     });
+  });
+
+  it("opens the account sheet from the actions menu of a builtin provider", () => {
+    snapshotState.entries = [claudeEntry];
+    configState.config = makeConfig();
+
+    render();
+
+    const sheetSelector = '[data-testid="provider-account-sheet-claude"]';
+    expect(container?.querySelector(sheetSelector)).toBeNull();
+    expect(container?.querySelector('[data-testid="provider-remove-claude"]')).toBeNull();
+
+    const addAccount = container?.querySelector<HTMLElement>(
+      '[data-testid="provider-add-account-claude"]',
+    );
+    expect(addAccount).not.toBeNull();
+
+    act(() => {
+      addAccount?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container?.querySelector(sheetSelector)).not.toBeNull();
+    expect(openProviderSettingsMock).not.toHaveBeenCalled();
   });
 
   it("toggles the provider enabled flag through patchConfig when the switch is pressed", async () => {

--- a/packages/app/src/screens/settings/providers-section.test.tsx
+++ b/packages/app/src/screens/settings/providers-section.test.tsx
@@ -7,41 +7,47 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderSnapshotEntry } from "@getpaseo/protocol/agent-types";
 import type { MutableDaemonConfig } from "@getpaseo/protocol/messages";
 
-const { theme, snapshotState, configState, patchConfigMock, openProviderSettingsMock } = vi.hoisted(
-  () => ({
-    theme: {
-      spacing: { 1: 4, "1.5": 6, 2: 8, 3: 12, 4: 16, 6: 24 },
-      iconSize: { sm: 14, md: 20 },
-      fontSize: { xs: 11, sm: 13, base: 15 },
-      fontWeight: { normal: "400" },
-      borderRadius: { lg: 8 },
-      opacity: { 50: 0.5 },
-      colors: {
-        surface1: "#111",
-        surface2: "#222",
-        surface3: "#333",
-        foreground: "#fff",
-        foregroundMuted: "#aaa",
-        border: "#555",
-        accent: "#0a84ff",
-        statusSuccess: "#00ff00",
-        statusWarning: "#ff9500",
-        statusDanger: "#ff0000",
-        palette: { red: { 300: "#ff6b6b" }, white: "#fff" },
-      },
+const {
+  theme,
+  snapshotState,
+  configState,
+  featureState,
+  patchConfigMock,
+  openProviderSettingsMock,
+} = vi.hoisted(() => ({
+  theme: {
+    spacing: { 1: 4, "1.5": 6, 2: 8, 3: 12, 4: 16, 6: 24 },
+    iconSize: { sm: 14, md: 20 },
+    fontSize: { xs: 11, sm: 13, base: 15 },
+    fontWeight: { normal: "400" },
+    borderRadius: { lg: 8 },
+    opacity: { 50: 0.5 },
+    colors: {
+      surface1: "#111",
+      surface2: "#222",
+      surface3: "#333",
+      foreground: "#fff",
+      foregroundMuted: "#aaa",
+      border: "#555",
+      accent: "#0a84ff",
+      statusSuccess: "#00ff00",
+      statusWarning: "#ff9500",
+      statusDanger: "#ff0000",
+      palette: { red: { 300: "#ff6b6b" }, white: "#fff" },
     },
-    snapshotState: {
-      entries: undefined as ProviderSnapshotEntry[] | undefined,
-      isLoading: false,
-      isRefreshing: false,
-    },
-    configState: {
-      config: null as MutableDaemonConfig | null,
-    },
-    patchConfigMock: vi.fn(async () => undefined),
-    openProviderSettingsMock: vi.fn(),
-  }),
-);
+  },
+  snapshotState: {
+    entries: undefined as ProviderSnapshotEntry[] | undefined,
+    isLoading: false,
+    isRefreshing: false,
+  },
+  configState: {
+    config: null as MutableDaemonConfig | null,
+  },
+  featureState: {} as Record<string, boolean>,
+  patchConfigMock: vi.fn(async () => undefined),
+  openProviderSettingsMock: vi.fn(),
+}));
 
 vi.mock("react-native", () => ({
   Platform: { OS: "web" },
@@ -101,6 +107,7 @@ vi.mock("lucide-react-native", () => {
     MoreHorizontal: icon("MoreHorizontal"),
     Trash2: icon("Trash2"),
     UserPlus: icon("UserPlus"),
+    Pencil: icon("Pencil"),
   };
 });
 
@@ -121,6 +128,8 @@ vi.mock("react-i18next", () => ({
           "settings.providers.addErrorTitle": "Unable to add provider",
           "settings.providers.updateErrorTitle": "Unable to update provider",
           "settings.providers.actions.menu": "{{name}} actions",
+          "settings.providers.actions.addAccount": "Add account",
+          "settings.providers.actions.editAccount": "Edit account",
           "settings.providers.actions.remove": "Remove provider",
           "settings.providers.actions.removing": "Removing...",
           "settings.providers.remove.confirmTitle": "Remove {{name}}?",
@@ -252,12 +261,16 @@ vi.mock("@/components/provider-account-sheet", () => ({
   ProviderAccountSheet: ({
     visible,
     baseProviderId,
+    account,
   }: {
     visible?: boolean;
     baseProviderId?: string;
+    account?: { providerId: string };
   }) =>
     visible
-      ? React.createElement("div", { "data-testid": `provider-account-sheet-${baseProviderId}` })
+      ? React.createElement("div", {
+          "data-testid": `provider-account-sheet-${account?.providerId ?? baseProviderId}`,
+        })
       : null,
 }));
 
@@ -287,7 +300,7 @@ vi.mock("@/runtime/host-runtime", () => ({
 }));
 
 vi.mock("@/runtime/host-features", () => ({
-  useHostFeature: () => false,
+  useHostFeature: (_serverId: string, feature: string) => featureState[feature] ?? false,
 }));
 
 vi.mock("@/utils/confirm-dialog", () => ({
@@ -374,6 +387,7 @@ describe("ProvidersSection", () => {
     snapshotState.isLoading = false;
     snapshotState.isRefreshing = false;
     configState.config = null;
+    for (const feature of Object.keys(featureState)) delete featureState[feature];
     patchConfigMock.mockReset();
     patchConfigMock.mockResolvedValue(undefined);
     openProviderSettingsMock.mockReset();
@@ -471,6 +485,9 @@ describe("ProvidersSection", () => {
     expect(
       findRow("Claude · Work provider details").querySelector('[data-icon="provider-claude"]'),
     ).not.toBeNull();
+    expect(
+      container?.querySelector('[data-testid="provider-edit-account-claude-work"]'),
+    ).toBeNull();
   });
 
   it("opens the diagnostic sheet when the outer row is pressed for a disabled provider", () => {
@@ -513,6 +530,33 @@ describe("ProvidersSection", () => {
     });
 
     expect(container?.querySelector(sheetSelector)).not.toBeNull();
+    expect(openProviderSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("opens an existing account for editing when the daemon supports exact replacement", () => {
+    snapshotState.entries = [claudeEntry, claudeWorkEntry];
+    configState.config = makeConfig({
+      "claude-work": {
+        extends: "claude",
+        label: "Claude · Work",
+        env: { CLAUDE_CONFIG_DIR: "/work/claude" },
+      },
+    });
+    featureState.providerConfigReplace = true;
+
+    render();
+
+    const editAccount = container?.querySelector<HTMLElement>(
+      '[data-testid="provider-edit-account-claude-work"]',
+    );
+    expect(editAccount).not.toBeNull();
+    act(() => {
+      editAccount?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(
+      container?.querySelector('[data-testid="provider-account-sheet-claude-work"]'),
+    ).not.toBeNull();
     expect(openProviderSettingsMock).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/screens/settings/providers-section.test.tsx
+++ b/packages/app/src/screens/settings/providers-section.test.tsx
@@ -321,6 +321,18 @@ const disabledCodexEntry: ProviderSnapshotEntry = {
   modes: [],
 };
 
+const claudeWorkEntry: ProviderSnapshotEntry = {
+  provider: "claude-work",
+  source: "custom",
+  status: "ready",
+  enabled: true,
+  label: "Claude · Work",
+  description: "Claude Code work account",
+  defaultModeId: null,
+  modes: [],
+  models: [],
+};
+
 function makeConfig(providers: MutableDaemonConfig["providers"] = {}): MutableDaemonConfig {
   return {
     relay: { enabled: false },
@@ -436,6 +448,29 @@ describe("ProvidersSection", () => {
     expect(status).toBeGreaterThan(label);
     expect(modelCount).toBeGreaterThan(status);
     expect(switchEl).toBeGreaterThan(modelCount);
+  });
+
+  it("groups an account with its base provider and reuses the base icon", () => {
+    snapshotState.entries = [claudeEntry, disabledCodexEntry, claudeWorkEntry];
+    configState.config = makeConfig({
+      codex: { enabled: false },
+      "claude-work": { extends: "claude", label: "Claude · Work" },
+    });
+
+    render();
+
+    const rows = Array.from(
+      container?.querySelectorAll<HTMLElement>('[role="button"][aria-label$="provider details"]') ??
+        [],
+    );
+    expect(rows.map((row) => row.getAttribute("aria-label"))).toEqual([
+      "Claude provider details",
+      "Claude · Work provider details",
+      "Codex provider details",
+    ]);
+    expect(
+      findRow("Claude · Work provider details").querySelector('[data-icon="provider-claude"]'),
+    ).not.toBeNull();
   });
 
   it("opens the diagnostic sheet when the outer row is pressed for a disabled provider", () => {

--- a/packages/app/src/screens/settings/providers-section.tsx
+++ b/packages/app/src/screens/settings/providers-section.tsx
@@ -24,7 +24,7 @@ import {
 import { ProviderCatalogList } from "@/components/provider-catalog-list";
 import {
   ProviderAccountSheet,
-  type ProviderAccountCreateInput,
+  type ProviderAccountSaveInput,
 } from "@/components/provider-account-sheet";
 import {
   canAddProviderAccount,
@@ -44,7 +44,7 @@ import { SettingsSection } from "@/components/settings/headings/settings-section
 import { useProviderSettingsStore } from "@/stores/provider-settings-store";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { filterSelectableModels } from "@/provider-selection/model-catalog";
-import { ChevronRight, MoreHorizontal, Trash2, UserPlus } from "lucide-react-native";
+import { ChevronRight, MoreHorizontal, Pencil, Trash2, UserPlus } from "lucide-react-native";
 
 type ProviderDefinition = ReturnType<typeof buildProviderDefinitions>[number];
 type ProviderEntry = NonNullable<ReturnType<typeof useProvidersSnapshot>["entries"]>[number];
@@ -94,12 +94,14 @@ interface ProviderRowProps {
   isRemoving: boolean;
   canRemove: boolean;
   canAddAccount: boolean;
+  canEditAccount: boolean;
   iconProviderId: string;
   isFirst: boolean;
   onPress: (providerId: string) => void;
   onToggleEnabled: (providerId: string, enabled: boolean) => void;
   onRemove: (providerId: string, providerLabel: string) => void;
   onAddAccount: (providerId: string, providerLabel: string) => void;
+  onEditAccount: (providerId: string) => void;
 }
 
 function stopPressInPropagation(event: GestureResponderEvent) {
@@ -112,12 +114,14 @@ interface ProviderActionsMenuProps {
   isRemoving: boolean;
   canRemove: boolean;
   canAddAccount: boolean;
+  canEditAccount: boolean;
   iconSize: number;
   foregroundColor: string;
   foregroundMutedColor: string;
   dangerColor: string;
   onRemove: (providerId: string, providerLabel: string) => void;
   onAddAccount: (providerId: string, providerLabel: string) => void;
+  onEditAccount: (providerId: string) => void;
 }
 
 function ProviderActionsMenu({
@@ -126,12 +130,14 @@ function ProviderActionsMenu({
   isRemoving,
   canRemove,
   canAddAccount,
+  canEditAccount,
   iconSize,
   foregroundColor,
   foregroundMutedColor,
   dangerColor,
   onRemove,
   onAddAccount,
+  onEditAccount,
 }: ProviderActionsMenuProps) {
   const { t } = useTranslation();
   const handleRemove = useCallback(() => {
@@ -140,6 +146,9 @@ function ProviderActionsMenu({
   const handleAddAccount = useCallback(() => {
     onAddAccount(providerId, providerLabel);
   }, [onAddAccount, providerId, providerLabel]);
+  const handleEditAccount = useCallback(() => {
+    onEditAccount(providerId);
+  }, [onEditAccount, providerId]);
   const triggerStyle = useCallback(
     ({
       pressed,
@@ -155,6 +164,10 @@ function ProviderActionsMenu({
   const trashLeading = useMemo(() => <Trash2 size={16} color={dangerColor} />, [dangerColor]);
   const addAccountLeading = useMemo(
     () => <UserPlus size={16} color={foregroundMutedColor} />,
+    [foregroundMutedColor],
+  );
+  const editAccountLeading = useMemo(
+    () => <Pencil size={16} color={foregroundMutedColor} />,
     [foregroundMutedColor],
   );
 
@@ -186,6 +199,15 @@ function ProviderActionsMenu({
             {t("settings.providers.actions.addAccount")}
           </DropdownMenuItem>
         ) : null}
+        {canEditAccount ? (
+          <DropdownMenuItem
+            leading={editAccountLeading}
+            onSelect={handleEditAccount}
+            testID={`provider-edit-account-${providerId}`}
+          >
+            {t("settings.providers.actions.editAccount")}
+          </DropdownMenuItem>
+        ) : null}
         {canRemove ? (
           <DropdownMenuItem
             destructive
@@ -212,12 +234,14 @@ function ProviderRow({
   isRemoving,
   canRemove,
   canAddAccount,
+  canEditAccount,
   iconProviderId,
   isFirst,
   onPress,
   onToggleEnabled,
   onRemove,
   onAddAccount,
+  onEditAccount,
 }: ProviderRowProps) {
   const { t } = useTranslation();
   const { theme } = useUnistyles();
@@ -291,19 +315,21 @@ function ProviderRow({
               accessibilityLabel={t("settings.providers.enableProvider", { name: def.label })}
             />
             <View style={styles.menuSlot}>
-              {canRemove || canAddAccount ? (
+              {canRemove || canAddAccount || canEditAccount ? (
                 <ProviderActionsMenu
                   providerId={def.id}
                   providerLabel={def.label}
                   isRemoving={isRemoving}
                   canRemove={canRemove}
                   canAddAccount={canAddAccount}
+                  canEditAccount={canEditAccount}
                   iconSize={theme.iconSize.sm}
                   foregroundColor={theme.colors.foreground}
                   foregroundMutedColor={theme.colors.foregroundMuted}
                   dangerColor={theme.colors.statusDanger}
                   onRemove={onRemove}
                   onAddAccount={onAddAccount}
+                  onEditAccount={onEditAccount}
                 />
               ) : null}
             </View>
@@ -362,8 +388,12 @@ function StatusIndicator({ status, compact }: { status: ProviderStatus; compact:
 }
 
 interface ProviderAccountTarget {
-  id: string;
-  label: string;
+  baseProviderId: string;
+  baseProviderLabel: string;
+  account?: {
+    providerId: string;
+    config: NonNullable<ReturnType<typeof useDaemonConfig>["config"]>["providers"][string];
+  };
 }
 
 export interface ProvidersSectionProps {
@@ -374,6 +404,7 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
   const { t } = useTranslation();
   const isConnected = useHostRuntimeIsConnected(serverId);
   const supportsProviderRemoval = useHostFeature(serverId, "providerRemoval");
+  const supportsProviderConfigReplace = useHostFeature(serverId, "providerConfigReplace");
   const { entries, isLoading, refresh } = useProvidersSnapshot(serverId);
   const { config, patchConfig } = useDaemonConfig(serverId);
   const openProviderSettings = useProviderSettingsStore((state) => state.open);
@@ -381,9 +412,7 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
   const [removingProviderId, setRemovingProviderId] = useState<string | null>(null);
   const removingProviderIdRef = useRef<string | null>(null);
   const [installingProviderId, setInstallingProviderId] = useState<string | null>(null);
-  const [accountBaseProvider, setAccountBaseProvider] = useState<ProviderAccountTarget | null>(
-    null,
-  );
+  const [accountTarget, setAccountTarget] = useState<ProviderAccountTarget | null>(null);
 
   const providerDefinitions = useMemo(
     () => groupProviderAccounts(buildProviderDefinitions(entries), config?.providers),
@@ -471,18 +500,38 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
   );
 
   const handleOpenAddAccount = useCallback((providerId: string, providerLabel: string) => {
-    setAccountBaseProvider({ id: providerId, label: providerLabel });
+    setAccountTarget({ baseProviderId: providerId, baseProviderLabel: providerLabel });
   }, []);
 
-  const handleCloseAddAccount = useCallback(() => {
-    setAccountBaseProvider(null);
+  const handleOpenEditAccount = useCallback(
+    (providerId: string) => {
+      const providerConfig = config?.providers[providerId];
+      const baseProviderId = resolveProviderAccountBaseId(providerId, config?.providers);
+      if (!providerConfig || !baseProviderId) return;
+      const baseProviderLabel =
+        entries?.find((entry) => entry.provider === baseProviderId)?.label ?? baseProviderId;
+      setAccountTarget({
+        baseProviderId,
+        baseProviderLabel,
+        account: { providerId, config: providerConfig },
+      });
+    },
+    [config?.providers, entries],
+  );
+
+  const handleCloseAccount = useCallback(() => {
+    setAccountTarget(null);
   }, []);
 
-  const handleCreateAccount = useCallback(
-    async ({ providerId, patch }: ProviderAccountCreateInput) => {
+  const handleSaveAccount = useCallback(
+    async ({ providerId, originalProviderId, patch }: ProviderAccountSaveInput) => {
       try {
         await patchConfig(patch);
-        await refresh([providerId]);
+        await refresh(
+          originalProviderId && originalProviderId !== providerId
+            ? [originalProviderId, providerId]
+            : [providerId],
+        );
         return true;
       } catch (error) {
         Alert.alert(
@@ -531,12 +580,18 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
                     providerId: def.id,
                     source: entry.source,
                   })}
+                  canEditAccount={
+                    supportsProviderConfigReplace &&
+                    entry.source === "custom" &&
+                    resolveProviderAccountBaseId(def.id, config?.providers) !== null
+                  }
                   iconProviderId={resolveProviderAccountBaseId(def.id, config?.providers) ?? def.id}
                   isFirst={index === 0}
                   onPress={handleOpenProviderSettings}
                   onToggleEnabled={handleToggleEnabled}
                   onRemove={handleRemoveProvider}
                   onAddAccount={handleOpenAddAccount}
+                  onEditAccount={handleOpenEditAccount}
                 />
               );
             })}
@@ -558,15 +613,16 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
         </SettingsSection>
       ) : null}
 
-      {accountBaseProvider ? (
+      {accountTarget ? (
         <ProviderAccountSheet
-          key={accountBaseProvider.id}
+          key={`${accountTarget.account ? "edit" : "add"}:${accountTarget.account?.providerId ?? accountTarget.baseProviderId}`}
           visible
-          baseProviderId={accountBaseProvider.id}
-          baseProviderLabel={accountBaseProvider.label}
+          baseProviderId={accountTarget.baseProviderId}
+          baseProviderLabel={accountTarget.baseProviderLabel}
           existingProviderIds={existingProviderIds}
-          onClose={handleCloseAddAccount}
-          onCreate={handleCreateAccount}
+          account={accountTarget.account}
+          onClose={handleCloseAccount}
+          onSave={handleSaveAccount}
         />
       ) : null}
     </>

--- a/packages/app/src/screens/settings/providers-section.tsx
+++ b/packages/app/src/screens/settings/providers-section.tsx
@@ -405,6 +405,7 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
   const isConnected = useHostRuntimeIsConnected(serverId);
   const supportsProviderRemoval = useHostFeature(serverId, "providerRemoval");
   const supportsProviderConfigReplace = useHostFeature(serverId, "providerConfigReplace");
+  const supportsProviderConfigRename = useHostFeature(serverId, "providerConfigRename");
   const { entries, isLoading, refresh } = useProvidersSnapshot(serverId);
   const { config, patchConfig } = useDaemonConfig(serverId);
   const openProviderSettings = useProviderSettingsStore((state) => state.open);
@@ -621,6 +622,7 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
           baseProviderLabel={accountTarget.baseProviderLabel}
           existingProviderIds={existingProviderIds}
           account={accountTarget.account}
+          supportsProviderConfigRename={supportsProviderConfigRename}
           onClose={handleCloseAccount}
           onSave={handleSaveAccount}
         />

--- a/packages/app/src/screens/settings/providers-section.tsx
+++ b/packages/app/src/screens/settings/providers-section.tsx
@@ -22,6 +22,11 @@ import {
   type AcpProviderCatalogItem,
 } from "@/hooks/use-acp-provider-catalog";
 import { ProviderCatalogList } from "@/components/provider-catalog-list";
+import {
+  ProviderAccountSheet,
+  type ProviderAccountCreateInput,
+} from "@/components/provider-account-sheet";
+import { canAddProviderAccount } from "@/provider-accounts/provider-account-form-model";
 import { getProviderIcon } from "@/components/provider-icons";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Switch } from "@/components/ui/switch";
@@ -35,7 +40,7 @@ import { SettingsSection } from "@/components/settings/headings/settings-section
 import { useProviderSettingsStore } from "@/stores/provider-settings-store";
 import { confirmDialog } from "@/utils/confirm-dialog";
 import { filterSelectableModels } from "@/provider-selection/model-catalog";
-import { ChevronRight, MoreHorizontal, Trash2 } from "lucide-react-native";
+import { ChevronRight, MoreHorizontal, Trash2, UserPlus } from "lucide-react-native";
 
 type ProviderDefinition = ReturnType<typeof buildProviderDefinitions>[number];
 type ProviderEntry = NonNullable<ReturnType<typeof useProvidersSnapshot>["entries"]>[number];
@@ -84,10 +89,12 @@ interface ProviderRowProps {
   isToggling: boolean;
   isRemoving: boolean;
   canRemove: boolean;
+  canAddAccount: boolean;
   isFirst: boolean;
   onPress: (providerId: string) => void;
   onToggleEnabled: (providerId: string, enabled: boolean) => void;
   onRemove: (providerId: string, providerLabel: string) => void;
+  onAddAccount: (providerId: string, providerLabel: string) => void;
 }
 
 function stopPressInPropagation(event: GestureResponderEvent) {
@@ -98,27 +105,36 @@ interface ProviderActionsMenuProps {
   providerId: string;
   providerLabel: string;
   isRemoving: boolean;
+  canRemove: boolean;
+  canAddAccount: boolean;
   iconSize: number;
   foregroundColor: string;
   foregroundMutedColor: string;
   dangerColor: string;
   onRemove: (providerId: string, providerLabel: string) => void;
+  onAddAccount: (providerId: string, providerLabel: string) => void;
 }
 
 function ProviderActionsMenu({
   providerId,
   providerLabel,
   isRemoving,
+  canRemove,
+  canAddAccount,
   iconSize,
   foregroundColor,
   foregroundMutedColor,
   dangerColor,
   onRemove,
+  onAddAccount,
 }: ProviderActionsMenuProps) {
   const { t } = useTranslation();
   const handleRemove = useCallback(() => {
     onRemove(providerId, providerLabel);
   }, [onRemove, providerId, providerLabel]);
+  const handleAddAccount = useCallback(() => {
+    onAddAccount(providerId, providerLabel);
+  }, [onAddAccount, providerId, providerLabel]);
   const triggerStyle = useCallback(
     ({
       pressed,
@@ -132,6 +148,10 @@ function ProviderActionsMenu({
     [],
   );
   const trashLeading = useMemo(() => <Trash2 size={16} color={dangerColor} />, [dangerColor]);
+  const addAccountLeading = useMemo(
+    () => <UserPlus size={16} color={foregroundMutedColor} />,
+    [foregroundMutedColor],
+  );
 
   return (
     <DropdownMenu>
@@ -152,16 +172,27 @@ function ProviderActionsMenu({
         )}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" width={220}>
-        <DropdownMenuItem
-          destructive
-          leading={trashLeading}
-          onSelect={handleRemove}
-          status={isRemoving ? "pending" : "idle"}
-          pendingLabel={t("settings.providers.actions.removing")}
-          testID={`provider-remove-${providerId}`}
-        >
-          {t("settings.providers.actions.remove")}
-        </DropdownMenuItem>
+        {canAddAccount ? (
+          <DropdownMenuItem
+            leading={addAccountLeading}
+            onSelect={handleAddAccount}
+            testID={`provider-add-account-${providerId}`}
+          >
+            {t("settings.providers.actions.addAccount")}
+          </DropdownMenuItem>
+        ) : null}
+        {canRemove ? (
+          <DropdownMenuItem
+            destructive
+            leading={trashLeading}
+            onSelect={handleRemove}
+            status={isRemoving ? "pending" : "idle"}
+            pendingLabel={t("settings.providers.actions.removing")}
+            testID={`provider-remove-${providerId}`}
+          >
+            {t("settings.providers.actions.remove")}
+          </DropdownMenuItem>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -175,10 +206,12 @@ function ProviderRow({
   isToggling,
   isRemoving,
   canRemove,
+  canAddAccount,
   isFirst,
   onPress,
   onToggleEnabled,
   onRemove,
+  onAddAccount,
 }: ProviderRowProps) {
   const { t } = useTranslation();
   const { theme } = useUnistyles();
@@ -252,16 +285,19 @@ function ProviderRow({
               accessibilityLabel={t("settings.providers.enableProvider", { name: def.label })}
             />
             <View style={styles.menuSlot}>
-              {canRemove ? (
+              {canRemove || canAddAccount ? (
                 <ProviderActionsMenu
                   providerId={def.id}
                   providerLabel={def.label}
                   isRemoving={isRemoving}
+                  canRemove={canRemove}
+                  canAddAccount={canAddAccount}
                   iconSize={theme.iconSize.sm}
                   foregroundColor={theme.colors.foreground}
                   foregroundMutedColor={theme.colors.foregroundMuted}
                   dangerColor={theme.colors.statusDanger}
                   onRemove={onRemove}
+                  onAddAccount={onAddAccount}
                 />
               ) : null}
             </View>
@@ -319,6 +355,11 @@ function StatusIndicator({ status, compact }: { status: ProviderStatus; compact:
   );
 }
 
+interface ProviderAccountTarget {
+  id: string;
+  label: string;
+}
+
 export interface ProvidersSectionProps {
   serverId: string;
 }
@@ -334,8 +375,15 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
   const [removingProviderId, setRemovingProviderId] = useState<string | null>(null);
   const removingProviderIdRef = useRef<string | null>(null);
   const [installingProviderId, setInstallingProviderId] = useState<string | null>(null);
+  const [accountBaseProvider, setAccountBaseProvider] = useState<ProviderAccountTarget | null>(
+    null,
+  );
 
   const providerDefinitions = useMemo(() => buildProviderDefinitions(entries), [entries]);
+  const existingProviderIds = useMemo(
+    () => (entries ?? []).map((entry) => entry.provider),
+    [entries],
+  );
   const hasServer = serverId.length > 0;
 
   const handleOpenProviderSettings = useCallback(
@@ -413,6 +461,31 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
     [installingProviderId, patchConfig, refresh, t],
   );
 
+  const handleOpenAddAccount = useCallback((providerId: string, providerLabel: string) => {
+    setAccountBaseProvider({ id: providerId, label: providerLabel });
+  }, []);
+
+  const handleCloseAddAccount = useCallback(() => {
+    setAccountBaseProvider(null);
+  }, []);
+
+  const handleCreateAccount = useCallback(
+    async ({ providerId, patch }: ProviderAccountCreateInput) => {
+      try {
+        await patchConfig(patch);
+        await refresh([providerId]);
+        return true;
+      } catch (error) {
+        Alert.alert(
+          t("settings.providers.account.errorTitle"),
+          error instanceof Error ? error.message : String(error),
+        );
+        return false;
+      }
+    },
+    [patchConfig, refresh, t],
+  );
+
   return (
     <>
       <SettingsSection
@@ -445,10 +518,15 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
                   isToggling={pendingProviderId === def.id}
                   isRemoving={removingProviderId === def.id}
                   canRemove={supportsProviderRemoval && entry.source === "custom"}
+                  canAddAccount={canAddProviderAccount({
+                    providerId: def.id,
+                    source: entry.source,
+                  })}
                   isFirst={index === 0}
                   onPress={handleOpenProviderSettings}
                   onToggleEnabled={handleToggleEnabled}
                   onRemove={handleRemoveProvider}
+                  onAddAccount={handleOpenAddAccount}
                 />
               );
             })}
@@ -468,6 +546,18 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
             onInstall={handleInstall}
           />
         </SettingsSection>
+      ) : null}
+
+      {accountBaseProvider ? (
+        <ProviderAccountSheet
+          key={accountBaseProvider.id}
+          visible
+          baseProviderId={accountBaseProvider.id}
+          baseProviderLabel={accountBaseProvider.label}
+          existingProviderIds={existingProviderIds}
+          onClose={handleCloseAddAccount}
+          onCreate={handleCreateAccount}
+        />
       ) : null}
     </>
   );

--- a/packages/app/src/screens/settings/providers-section.tsx
+++ b/packages/app/src/screens/settings/providers-section.tsx
@@ -26,7 +26,11 @@ import {
   ProviderAccountSheet,
   type ProviderAccountCreateInput,
 } from "@/components/provider-account-sheet";
-import { canAddProviderAccount } from "@/provider-accounts/provider-account-form-model";
+import {
+  canAddProviderAccount,
+  groupProviderAccounts,
+  resolveProviderAccountBaseId,
+} from "@/provider-accounts/provider-account-form-model";
 import { getProviderIcon } from "@/components/provider-icons";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Switch } from "@/components/ui/switch";
@@ -90,6 +94,7 @@ interface ProviderRowProps {
   isRemoving: boolean;
   canRemove: boolean;
   canAddAccount: boolean;
+  iconProviderId: string;
   isFirst: boolean;
   onPress: (providerId: string) => void;
   onToggleEnabled: (providerId: string, enabled: boolean) => void;
@@ -207,6 +212,7 @@ function ProviderRow({
   isRemoving,
   canRemove,
   canAddAccount,
+  iconProviderId,
   isFirst,
   onPress,
   onToggleEnabled,
@@ -216,7 +222,7 @@ function ProviderRow({
   const { t } = useTranslation();
   const { theme } = useUnistyles();
   const isCompact = useIsCompactFormFactor();
-  const ProviderIcon = getProviderIcon(def.id, serverId);
+  const ProviderIcon = getProviderIcon(iconProviderId, serverId);
   const providerError =
     enabled &&
     entry.status === "error" &&
@@ -369,7 +375,7 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
   const isConnected = useHostRuntimeIsConnected(serverId);
   const supportsProviderRemoval = useHostFeature(serverId, "providerRemoval");
   const { entries, isLoading, refresh } = useProvidersSnapshot(serverId);
-  const { patchConfig } = useDaemonConfig(serverId);
+  const { config, patchConfig } = useDaemonConfig(serverId);
   const openProviderSettings = useProviderSettingsStore((state) => state.open);
   const [pendingProviderId, setPendingProviderId] = useState<string | null>(null);
   const [removingProviderId, setRemovingProviderId] = useState<string | null>(null);
@@ -379,7 +385,10 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
     null,
   );
 
-  const providerDefinitions = useMemo(() => buildProviderDefinitions(entries), [entries]);
+  const providerDefinitions = useMemo(
+    () => groupProviderAccounts(buildProviderDefinitions(entries), config?.providers),
+    [config?.providers, entries],
+  );
   const existingProviderIds = useMemo(
     () => (entries ?? []).map((entry) => entry.provider),
     [entries],
@@ -522,6 +531,7 @@ export function ProvidersSection({ serverId }: ProvidersSectionProps) {
                     providerId: def.id,
                     source: entry.source,
                   })}
+                  iconProviderId={resolveProviderAccountBaseId(def.id, config?.providers) ?? def.id}
                   isFirst={index === 0}
                   onPress={handleOpenProviderSettings}
                   onToggleEnabled={handleToggleEnabled}

--- a/packages/app/src/utils/provider-definitions.ts
+++ b/packages/app/src/utils/provider-definitions.ts
@@ -28,6 +28,7 @@ export function buildProviderDefinitions(
     id: entry.provider,
     label: entry.label ?? entry.provider,
     description: entry.description ?? "",
+    baseProviderId: entry.baseProviderId,
     defaultModeId: entry.defaultModeId ?? null,
     modes: buildProviderModes(entry),
   }));

--- a/packages/cli/src/commands/provider/add.test.ts
+++ b/packages/cli/src/commands/provider/add.test.ts
@@ -78,4 +78,13 @@ describe("provider add override", () => {
       /expected KEY=VALUE/,
     );
   });
+
+  it("rejects whitespace-only model ids and labels", () => {
+    expect(() => buildProviderOverride("mine", { extends: "claude", model: ["   "] })).toThrow(
+      /expected id or id=label/,
+    );
+    expect(() =>
+      buildProviderOverride("mine", { extends: "claude", model: ["model-id=   "] }),
+    ).toThrow(/label must not be empty/);
+  });
 });

--- a/packages/cli/src/commands/provider/add.test.ts
+++ b/packages/cli/src/commands/provider/add.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { buildProviderOverride } from "./add.js";
+
+describe("provider add override", () => {
+  it("builds a profile that extends a built-in provider", () => {
+    expect(
+      buildProviderOverride("claude-work", {
+        extends: "claude",
+        label: "Claude (Work)",
+        description: "Work account",
+        env: ["ANTHROPIC_API_KEY=sk-ant-123", "ANTHROPIC_BASE_URL=https://proxy/v1"],
+      }),
+    ).toEqual({
+      id: "claude-work",
+      override: {
+        extends: "claude",
+        label: "Claude (Work)",
+        description: "Work account",
+        env: {
+          ANTHROPIC_API_KEY: "sk-ant-123",
+          ANTHROPIC_BASE_URL: "https://proxy/v1",
+        },
+      },
+    });
+  });
+
+  it("defaults the label to the id and marks the first model as default", () => {
+    expect(
+      buildProviderOverride("zai", {
+        extends: "claude",
+        model: ["glm-5-turbo=GLM 5 Turbo", "glm-4.5-air"],
+      }),
+    ).toEqual({
+      id: "zai",
+      override: {
+        extends: "claude",
+        label: "zai",
+        models: [
+          { id: "glm-5-turbo", label: "GLM 5 Turbo", isDefault: true },
+          { id: "glm-4.5-air", label: "glm-4.5-air" },
+        ],
+      },
+    });
+  });
+
+  it("keeps the command argv for acp providers", () => {
+    expect(
+      buildProviderOverride("gemini", {
+        extends: "acp",
+        label: "Gemini",
+        command: ["npx", "-y", "@google/gemini-cli", "--experimental-acp"],
+      }).override.command,
+    ).toEqual(["npx", "-y", "@google/gemini-cli", "--experimental-acp"]);
+  });
+
+  it("rejects ids that do not match the provider id pattern", () => {
+    expect(() => buildProviderOverride("Claude_Work", { extends: "claude" })).toThrow(
+      /Invalid provider id/,
+    );
+  });
+
+  it("refuses to shadow a built-in provider id", () => {
+    expect(() => buildProviderOverride("claude", { extends: "claude" })).toThrow(/built-in/);
+  });
+
+  it("rejects an unknown extends target", () => {
+    expect(() => buildProviderOverride("mine", { extends: "gpt" })).toThrow(/Invalid --extends/);
+  });
+
+  it("requires a command when extending acp", () => {
+    expect(() => buildProviderOverride("mine", { extends: "acp" })).toThrow(
+      /--command is required/,
+    );
+  });
+
+  it("rejects env entries that are not KEY=VALUE", () => {
+    expect(() => buildProviderOverride("mine", { extends: "claude", env: ["NOPE"] })).toThrow(
+      /expected KEY=VALUE/,
+    );
+  });
+});

--- a/packages/cli/src/commands/provider/add.test.ts
+++ b/packages/cli/src/commands/provider/add.test.ts
@@ -87,4 +87,14 @@ describe("provider add override", () => {
       buildProviderOverride("mine", { extends: "claude", model: ["model-id=   "] }),
     ).toThrow(/label must not be empty/);
   });
+
+  it("trims model ids and labels before saving them", () => {
+    expect(
+      buildProviderOverride("mine", { extends: "claude", model: [" model-id = Model label "] }),
+    ).toMatchObject({
+      override: {
+        models: [{ id: "model-id", label: "Model label", isDefault: true }],
+      },
+    });
+  });
 });

--- a/packages/cli/src/commands/provider/add.ts
+++ b/packages/cli/src/commands/provider/add.ts
@@ -62,10 +62,10 @@ function parseModelEntries(entries: string[]): ProviderProfileModel[] {
     const separator = entry.indexOf("=");
     const id = separator === -1 ? entry : entry.slice(0, separator);
     const label = separator === -1 ? entry : entry.slice(separator + 1);
-    if (!id) {
+    if (id.trim().length === 0) {
       throw new Error(`Invalid --model "${entry}": expected id or id=label`);
     }
-    if (!label) {
+    if (label.trim().length === 0) {
       throw new Error(`Invalid --model "${entry}": label must not be empty`);
     }
     return { id, label, ...(index === 0 ? { isDefault: true } : {}) };

--- a/packages/cli/src/commands/provider/add.ts
+++ b/packages/cli/src/commands/provider/add.ts
@@ -1,0 +1,175 @@
+import type { Command } from "commander";
+import type { ProviderOverride, ProviderProfileModel } from "@getpaseo/protocol/provider-config";
+import type {
+  CommandError,
+  CommandOptions,
+  OutputSchema,
+  SingleResult,
+} from "../../output/index.js";
+import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
+import { PROVIDER_ID_PATTERN, VALID_EXTENDS_VALUES, isBuiltinProviderId } from "./shared.js";
+
+export interface ProviderAddOptions extends CommandOptions {
+  extends?: string;
+  label?: string;
+  description?: string;
+  env?: string[];
+  model?: string[];
+  command?: string[];
+}
+
+export interface ProviderAddRow {
+  provider: string;
+  label: string;
+  extends: string;
+  models: string;
+  env: string;
+  command: string;
+}
+
+export const providerAddSchema: OutputSchema<ProviderAddRow> = {
+  idField: "provider",
+  columns: [
+    { header: "PROVIDER", field: "provider", width: 16 },
+    { header: "LABEL", field: "label", width: 20 },
+    { header: "EXTENDS", field: "extends", width: 10 },
+    { header: "MODELS", field: "models", width: 30 },
+    { header: "ENV", field: "env", width: 24 },
+    { header: "COMMAND", field: "command", width: 30 },
+  ],
+};
+
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function parseEnvEntries(entries: string[]): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const entry of entries) {
+    const separator = entry.indexOf("=");
+    if (separator <= 0) {
+      throw new Error(`Invalid --env "${entry}": expected KEY=VALUE`);
+    }
+    const key = entry.slice(0, separator);
+    if (!ENV_KEY_PATTERN.test(key)) {
+      throw new Error(`Invalid --env key "${key}": must match ${ENV_KEY_PATTERN}`);
+    }
+    env[key] = entry.slice(separator + 1);
+  }
+  return env;
+}
+
+function parseModelEntries(entries: string[]): ProviderProfileModel[] {
+  return entries.map((entry, index) => {
+    const separator = entry.indexOf("=");
+    const id = separator === -1 ? entry : entry.slice(0, separator);
+    const label = separator === -1 ? entry : entry.slice(separator + 1);
+    if (!id) {
+      throw new Error(`Invalid --model "${entry}": expected id or id=label`);
+    }
+    if (!label) {
+      throw new Error(`Invalid --model "${entry}": label must not be empty`);
+    }
+    return { id, label, ...(index === 0 ? { isDefault: true } : {}) };
+  });
+}
+
+/**
+ * Build the provider override for `provider add`. The daemon validates too; this
+ * catches the common mistakes before a round trip so the message names the flag.
+ */
+export function buildProviderOverride(
+  id: string,
+  options: ProviderAddOptions,
+): { id: string; override: ProviderOverride } {
+  if (!PROVIDER_ID_PATTERN.test(id)) {
+    throw new Error(
+      `Invalid provider id "${id}": must start with a lowercase letter and contain only lowercase letters, digits, and hyphens`,
+    );
+  }
+  if (isBuiltinProviderId(id)) {
+    throw new Error(
+      `"${id}" is a built-in provider. Pick a different id and use --extends ${id} to base a profile on it.`,
+    );
+  }
+
+  const extendsProvider = options.extends;
+  if (!extendsProvider) {
+    throw new Error(`--extends is required (one of: ${VALID_EXTENDS_VALUES.join(", ")})`);
+  }
+  if (!VALID_EXTENDS_VALUES.includes(extendsProvider)) {
+    throw new Error(
+      `Invalid --extends "${extendsProvider}": expected one of ${VALID_EXTENDS_VALUES.join(", ")}`,
+    );
+  }
+
+  const commandArgv = options.command ?? [];
+  if (extendsProvider === "acp" && commandArgv.length === 0) {
+    throw new Error("--command is required when extending acp");
+  }
+
+  const env = parseEnvEntries(options.env ?? []);
+  const models = parseModelEntries(options.model ?? []);
+
+  const override: ProviderOverride = {
+    extends: extendsProvider,
+    label: options.label ?? id,
+    ...(options.description ? { description: options.description } : {}),
+    ...(commandArgv.length > 0 ? { command: commandArgv } : {}),
+    ...(Object.keys(env).length > 0 ? { env } : {}),
+    ...(models.length > 0 ? { models } : {}),
+  };
+
+  return { id, override };
+}
+
+function toRow(id: string, override: ProviderOverride): ProviderAddRow {
+  return {
+    provider: id,
+    label: override.label ?? id,
+    extends: override.extends ?? "-",
+    models: (override.models ?? []).map((model) => model.id).join(", ") || "-",
+    env: Object.keys(override.env ?? {}).join(", ") || "-",
+    command: (override.command ?? []).join(" ") || "-",
+  };
+}
+
+export async function runAddCommand(
+  id: string,
+  options: ProviderAddOptions,
+  _command: Command,
+): Promise<SingleResult<ProviderAddRow>> {
+  let built: { id: string; override: ProviderOverride };
+  try {
+    built = buildProviderOverride(id, options);
+  } catch (error) {
+    throw {
+      code: "INVALID_PROVIDER_CONFIG",
+      message: error instanceof Error ? error.message : String(error),
+    } satisfies CommandError;
+  }
+
+  const host = getDaemonHost({ host: options.host });
+  const client = await connectToDaemon({ host: options.host }).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    throw {
+      code: "DAEMON_NOT_RUNNING",
+      message: `Cannot connect to daemon at ${host}: ${message}`,
+    } satisfies CommandError;
+  });
+
+  try {
+    const { config } = await client.getDaemonConfig();
+    if (built.id in (config.providers ?? {})) {
+      throw new Error(
+        `Provider "${built.id}" already exists. Remove it with "paseo provider rm ${built.id}" first.`,
+      );
+    }
+
+    await client.patchDaemonConfig({ providers: { [built.id]: built.override } });
+    return { type: "single", data: toRow(built.id, built.override), schema: providerAddSchema };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw { code: "PROVIDER_ADD_FAILED", message } satisfies CommandError;
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}

--- a/packages/cli/src/commands/provider/add.ts
+++ b/packages/cli/src/commands/provider/add.ts
@@ -68,7 +68,7 @@ function parseModelEntries(entries: string[]): ProviderProfileModel[] {
     if (label.trim().length === 0) {
       throw new Error(`Invalid --model "${entry}": label must not be empty`);
     }
-    return { id, label, ...(index === 0 ? { isDefault: true } : {}) };
+    return { id: id.trim(), label: label.trim(), ...(index === 0 ? { isDefault: true } : {}) };
   });
 }
 

--- a/packages/cli/src/commands/provider/index.ts
+++ b/packages/cli/src/commands/provider/index.ts
@@ -1,9 +1,12 @@
 import { Command } from "commander";
+import { runAddCommand } from "./add.js";
+import { runDiagnosticCommand } from "./diagnostic.js";
 import { runLsCommand } from "./ls.js";
 import { runModelsCommand } from "./models.js";
-import { runDiagnosticCommand } from "./diagnostic.js";
+import { runRmCommand } from "./rm.js";
+import { VALID_EXTENDS_VALUES } from "./shared.js";
 import { withOutput } from "../../output/index.js";
-import { addJsonAndDaemonHostOptions } from "../../utils/command-options.js";
+import { addJsonAndDaemonHostOptions, collectMultiple } from "../../utils/command-options.js";
 
 export function createProviderCommand(): Command {
   const provider = new Command("provider").description("Manage agent providers");
@@ -26,6 +29,39 @@ export function createProviderCommand(): Command {
       .description("Show provider installation, environment, and availability diagnostics")
       .argument("<provider>", "Provider name"),
   ).action(withOutput(runDiagnosticCommand));
+
+  addJsonAndDaemonHostOptions(
+    provider
+      .command("add")
+      .description("Add a custom provider profile")
+      .argument("<id>", "New provider id (lowercase letters, digits, hyphens)")
+      .requiredOption(
+        "--extends <provider>",
+        `Provider to inherit from (${VALID_EXTENDS_VALUES.join(", ")})`,
+      )
+      .option("--label <label>", "Display label (default: the provider id)")
+      .option("--description <text>", "Description shown next to the label")
+      .option("--env <KEY=VALUE>", "Environment variable, repeatable", collectMultiple, [])
+      .option(
+        "--model <id[=label]>",
+        "Model offered by this profile, repeatable; the first is the default",
+        collectMultiple,
+        [],
+      )
+      .option(
+        "--command <arg>",
+        "Launch argv entry, repeatable; required with --extends acp",
+        collectMultiple,
+        [],
+      ),
+  ).action(withOutput(runAddCommand));
+
+  addJsonAndDaemonHostOptions(
+    provider
+      .command("rm")
+      .description("Remove a custom provider profile")
+      .argument("<id>", "Custom provider id"),
+  ).action(withOutput(runRmCommand));
 
   return provider;
 }

--- a/packages/cli/src/commands/provider/ls.ts
+++ b/packages/cli/src/commands/provider/ls.ts
@@ -7,6 +7,7 @@ import { tryConnectToDaemon } from "../../utils/client.js";
 export interface ProviderListItem {
   provider: ProviderSnapshotEntry["provider"];
   label: string;
+  source: "builtin" | "custom";
   status: string;
   enabled: "Enabled" | "Disabled";
   defaultMode: string;
@@ -17,6 +18,7 @@ export interface ProviderListItem {
 const PROVIDERS: ProviderListItem[] = AGENT_PROVIDER_DEFINITIONS.map((def) => ({
   provider: def.id,
   label: def.label,
+  source: "builtin",
   status: "available",
   enabled: def.enabledByDefault === false ? "Disabled" : "Enabled",
   defaultMode: def.defaultModeId ?? "-",
@@ -33,6 +35,7 @@ export const providerLsSchema: OutputSchema<ProviderListItem> = {
   columns: [
     { header: "PROVIDER", field: "provider", width: 12 },
     { header: "LABEL", field: "label", width: 16 },
+    { header: "SOURCE", field: "source", width: 8 },
     {
       header: "STATUS",
       field: "status",
@@ -76,6 +79,7 @@ export async function runLsCommand(
       data: snapshot.entries.map((entry) => ({
         provider: entry.provider,
         label: entry.label ?? entry.provider,
+        source: entry.source ?? "builtin",
         status: entry.status === "ready" ? "available" : entry.status,
         enabled: !entry.enabled ? "Disabled" : "Enabled",
         defaultMode: entry.defaultModeId ?? "default",

--- a/packages/cli/src/commands/provider/rm.ts
+++ b/packages/cli/src/commands/provider/rm.ts
@@ -1,0 +1,65 @@
+import type { Command } from "commander";
+import type {
+  CommandError,
+  CommandOptions,
+  OutputSchema,
+  SingleResult,
+} from "../../output/index.js";
+import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
+import { isBuiltinProviderId } from "./shared.js";
+
+export type ProviderRmOptions = CommandOptions;
+
+export interface ProviderRmRow {
+  provider: string;
+  removed: string;
+}
+
+export const providerRmSchema: OutputSchema<ProviderRmRow> = {
+  idField: "provider",
+  columns: [
+    { header: "PROVIDER", field: "provider", width: 16 },
+    { header: "REMOVED", field: "removed", width: 10 },
+  ],
+};
+
+export async function runRmCommand(
+  id: string,
+  options: ProviderRmOptions,
+  _command: Command,
+): Promise<SingleResult<ProviderRmRow>> {
+  if (isBuiltinProviderId(id)) {
+    throw {
+      code: "INVALID_PROVIDER_CONFIG",
+      message: `"${id}" is a built-in provider and cannot be removed.`,
+    } satisfies CommandError;
+  }
+
+  const host = getDaemonHost({ host: options.host });
+  const client = await connectToDaemon({ host: options.host }).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    throw {
+      code: "DAEMON_NOT_RUNNING",
+      message: `Cannot connect to daemon at ${host}: ${message}`,
+    } satisfies CommandError;
+  });
+
+  try {
+    const { config } = await client.getDaemonConfig();
+    if (!(id in (config.providers ?? {}))) {
+      throw new Error(`No custom provider "${id}" is configured.`);
+    }
+
+    await client.patchDaemonConfig({ removeProviders: [id] });
+    return {
+      type: "single",
+      data: { provider: id, removed: "yes" },
+      schema: providerRmSchema,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw { code: "PROVIDER_RM_FAILED", message } satisfies CommandError;
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}

--- a/packages/cli/src/commands/provider/shared.ts
+++ b/packages/cli/src/commands/provider/shared.ts
@@ -1,0 +1,13 @@
+import { BUILTIN_PROVIDER_IDS } from "@getpaseo/protocol/provider-manifest";
+
+/** Mirrors the id pattern enforced by ProviderOverridesSchema in the protocol. */
+export const PROVIDER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+export const BUILTIN_PROVIDER_ID_SET = new Set<string>(BUILTIN_PROVIDER_IDS);
+
+/** Built-in providers plus the generic ACP base. */
+export const VALID_EXTENDS_VALUES: string[] = [...BUILTIN_PROVIDER_IDS, "acp"];
+
+export function isBuiltinProviderId(id: string): boolean {
+  return BUILTIN_PROVIDER_ID_SET.has(id);
+}

--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -19,6 +19,8 @@
  * - provider models --json outputs valid JSON
  * - provider diagnostic shows the daemon's provider diagnostic
  * - provider diagnostic --json returns structured output
+ * - provider add creates a custom profile that provider rm removes
+ * - provider add and rm refuse built-in provider ids
  */
 
 import assert from "node:assert";
@@ -430,7 +432,6 @@ try {
     );
     console.log("✓ provider models --quiet outputs model IDs only\n");
   }
-
   // Test 12: provider diagnostic shows the daemon's provider diagnostic
   {
     console.log("Test 12: provider diagnostic shows the daemon's provider diagnostic");
@@ -462,6 +463,85 @@ try {
     assert(data.diagnostic.includes("Version:"), "JSON should include the provider version");
     assert(data.diagnostic.includes("Status:"), "JSON should include provider status");
     console.log("✓ provider diagnostic --json returns structured output\n");
+  }
+
+  // Test 14: provider add creates a custom profile that provider rm removes
+  {
+    console.log("Test 14: provider add creates a custom profile that provider rm removes");
+    const added = await ctx.paseo([
+      "provider",
+      "add",
+      "claude-work",
+      "--extends",
+      "claude",
+      "--label",
+      "Claude (Work)",
+      "--env",
+      "ANTHROPIC_API_KEY=sk-ant-test",
+      "--model",
+      "claude-sonnet-5=Sonnet 5",
+      "--json",
+    ]);
+    assert.strictEqual(
+      added.exitCode,
+      0,
+      `provider add should exit 0\n${added.stdout}\n${added.stderr}`,
+    );
+    const addedRow = JSON.parse(added.stdout.trim()) as {
+      provider: string;
+      label: string;
+      extends: string;
+    };
+    assert.strictEqual(addedRow.provider, "claude-work", "add should echo the new provider id");
+    assert.strictEqual(addedRow.extends, "claude", "add should echo the extends target");
+
+    const afterAdd = await ctx.paseo(["provider", "ls", "--json"]);
+    assert.strictEqual(afterAdd.exitCode, 0, "provider ls should exit 0 after add");
+    const listedRows = JSON.parse(afterAdd.stdout.trim()) as Array<
+      ProviderListRow & { source?: string }
+    >;
+    const custom = listedRows.find((row) => row.provider === "claude-work");
+    assert(custom, "provider ls should include the new profile");
+    assert.strictEqual(custom.source, "custom", "the new profile should be listed as custom");
+    const builtin = listedRows.find((row) => row.provider === "codex");
+    assert.strictEqual(
+      builtin?.source,
+      "builtin",
+      "built-in providers should be listed as builtin",
+    );
+
+    const removed = await ctx.paseo(["provider", "rm", "claude-work", "--json"]);
+    assert.strictEqual(
+      removed.exitCode,
+      0,
+      `provider rm should exit 0\n${removed.stdout}\n${removed.stderr}`,
+    );
+
+    const afterRm = await ctx.paseo(["provider", "ls", "--json"]);
+    const remainingRows = JSON.parse(afterRm.stdout.trim()) as ProviderListRow[];
+    assert(
+      !remainingRows.some((row) => row.provider === "claude-work"),
+      "provider ls should drop the removed profile",
+    );
+    console.log("✓ provider add creates a custom profile that provider rm removes\n");
+  }
+
+  // Test 15: provider add and rm refuse built-in provider ids
+  {
+    console.log("Test 15: provider add and rm refuse built-in provider ids");
+    const addBuiltin = await ctx.paseo(["provider", "add", "claude", "--extends", "claude"]);
+    assert.notStrictEqual(addBuiltin.exitCode, 0, "adding a built-in id should fail");
+    assert(
+      (addBuiltin.stdout + addBuiltin.stderr).includes("built-in"),
+      "error should explain that the id is built-in",
+    );
+
+    const rmBuiltin = await ctx.paseo(["provider", "rm", "claude"]);
+    assert.notStrictEqual(rmBuiltin.exitCode, 0, "removing a built-in provider should fail");
+
+    const rmMissing = await ctx.paseo(["provider", "rm", "not-configured"]);
+    assert.notStrictEqual(rmMissing.exitCode, 0, "removing an unknown provider should fail");
+    console.log("✓ provider add and rm refuse built-in provider ids\n");
   }
 } finally {
   await ctx.stop();

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -107,6 +107,8 @@ export interface ProviderSnapshotEntry {
   status: ProviderStatus;
   enabled: boolean;
   source?: "builtin" | "custom";
+  /** Builtin provider this entry extends, when it is a custom provider account. */
+  baseProviderId?: string;
   error?: string;
   models?: AgentModelDefinition[];
   modes?: AgentMode[];

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -267,6 +267,10 @@ export const MutableDaemonConfigPatchSchema = z
       .record(z.string(), MutableDaemonProviderConfigSchema.partial().passthrough())
       .optional(),
     removeProviders: z.array(z.string().min(1)).optional(),
+    // Maps an old provider id to the new one it was renamed to. The new definition still
+    // arrives in `replaceProviders` and the old id still arrives in `removeProviders`; this
+    // only tells the daemon the two are the same account so persisted agents can be migrated.
+    renameProviders: z.record(z.string().min(1), z.string().min(1)).optional(),
     metadataGeneration: MutableMetadataGenerationConfigSchema.partial().optional(),
     autoArchiveAfterMerge: z.boolean().optional(),
     enableTerminalAgentHooks: z.boolean().optional(),
@@ -378,6 +382,8 @@ export const ProviderSnapshotEntrySchema = z.object({
   status: ProviderStatusSchema,
   enabled: z.boolean().optional().default(true),
   source: z.enum(["builtin", "custom"]).optional(),
+  /** Builtin provider this entry extends, when it is a custom provider account. */
+  baseProviderId: z.string().optional(),
   error: z.string().optional(),
   models: z.array(AgentModelDefinitionSchema).optional(),
   modes: z.array(AgentModeSchema).optional(),
@@ -3531,6 +3537,9 @@ export const ServerInfoStatusPayloadSchema = z
         providerRemoval: z.boolean().optional(),
         // COMPAT(providerConfigReplace): added in v0.2.X, remove after 2027-02-02 when old daemons are unsupported.
         providerConfigReplace: z.boolean().optional(),
+        // COMPAT(providerConfigRename): added in v0.2.X, remove after 2027-02-02 when old daemons are unsupported.
+        // Daemon migrates persisted agents when a provider account is renamed.
+        providerConfigRename: z.boolean().optional(),
         // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
         importSessionWorkspaceTarget: z.boolean().optional(),
         // COMPAT(importSessionSearch): added in v0.7.3, remove gate after 2027-03-02.

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -262,6 +262,10 @@ export const MutableDaemonConfigPatchSchema = z
     providers: z
       .record(z.string(), MutableDaemonProviderConfigSchema.partial().passthrough())
       .optional(),
+    // COMPAT(providerConfigReplace): added in v0.2.X, remove after 2027-02-02 when old daemons are unsupported.
+    replaceProviders: z
+      .record(z.string(), MutableDaemonProviderConfigSchema.partial().passthrough())
+      .optional(),
     removeProviders: z.array(z.string().min(1)).optional(),
     metadataGeneration: MutableMetadataGenerationConfigSchema.partial().optional(),
     autoArchiveAfterMerge: z.boolean().optional(),
@@ -3525,6 +3529,8 @@ export const ServerInfoStatusPayloadSchema = z
         commitBaseClassification: z.boolean().optional(),
         // COMPAT(providerRemoval): added in v0.1.105, drop the gate when floor >= v0.1.105.
         providerRemoval: z.boolean().optional(),
+        // COMPAT(providerConfigReplace): added in v0.2.X, remove after 2027-02-02 when old daemons are unsupported.
+        providerConfigReplace: z.boolean().optional(),
         // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
         importSessionWorkspaceTarget: z.boolean().optional(),
         // COMPAT(importSessionSearch): added in v0.7.3, remove gate after 2027-03-02.
@@ -5950,6 +5956,8 @@ export const ProviderUsageDetailSchema = z.object({
 
 export const ProviderUsageSchema = z.object({
   providerId: z.string(),
+  // COMPAT(providerUsageBaseProvider): added in v0.2.X, remove after 2027-02-02 when old clients are unsupported.
+  baseProviderId: z.string().optional(),
   displayName: z.string(),
   status: ProviderUsageStatusSchema,
   planLabel: z.string().nullable(),

--- a/packages/protocol/src/provider-manifest.ts
+++ b/packages/protocol/src/provider-manifest.ts
@@ -25,6 +25,8 @@ export interface AgentProviderDefinition {
   id: string;
   label: string;
   description: string;
+  /** Builtin provider this definition extends, when it comes from a custom provider account. */
+  baseProviderId?: string;
   enabledByDefault?: boolean;
   defaultModeId: string | null;
   modes: AgentProviderModeDefinition[];

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -793,6 +793,25 @@ export class AgentManager {
     }
   }
 
+  /**
+   * Repoints live agents at a renamed provider id. Must run after the registry rebuild so the
+   * new id already has a client, and before storage migration so the next persistence flush
+   * doesn't write the old id back over the migrated record.
+   */
+  renameProviderOnLiveAgents(fromProviderId: string, toProviderId: string): void {
+    for (const agent of this.agents.values()) {
+      if (agent.provider === fromProviderId) {
+        agent.provider = toProviderId;
+      }
+      if (agent.runtimeInfo?.provider === fromProviderId) {
+        agent.runtimeInfo = { ...agent.runtimeInfo, provider: toProviderId };
+      }
+      if (agent.persistence?.provider === fromProviderId) {
+        agent.persistence = { ...agent.persistence, provider: toProviderId };
+      }
+    }
+  }
+
   getRegisteredProviderIds(): AgentProvider[] {
     return Array.from(this.clients.keys());
   }

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -119,6 +119,8 @@ export interface ProviderSnapshotEntry {
   status: ProviderStatus;
   enabled: boolean;
   source?: "builtin" | "custom";
+  /** Builtin provider this entry extends, when it is a custom provider account. */
+  baseProviderId?: string;
   error?: string;
   models?: AgentModelDefinition[];
   modes?: AgentMode[];

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -323,6 +323,39 @@ describe("AgentStorage", () => {
     );
   });
 
+  test("renameProvider migrates every provider reference and survives reload", async () => {
+    await storage.applySnapshot(
+      createManagedAgent({
+        id: "agent-renamed",
+        provider: "claude-work",
+        persistence: { provider: "claude-work", sessionId: "session-abc" },
+      }),
+    );
+    await storage.applySnapshot(
+      createManagedAgent({ id: "agent-untouched", provider: "claude-personal" }),
+    );
+
+    const migrated = await storage.renameProvider("claude-work", "claude-job");
+    expect(migrated).toEqual(["agent-renamed"]);
+
+    const reloaded = new AgentStorage(storagePath, logger);
+    const record = await reloaded.get("agent-renamed");
+    expect(record?.provider).toBe("claude-job");
+    expect(record?.runtimeInfo?.provider).toBe("claude-job");
+    expect(record?.persistence?.provider).toBe("claude-job");
+
+    const untouched = await reloaded.get("agent-untouched");
+    expect(untouched?.provider).toBe("claude-personal");
+    expect(untouched?.runtimeInfo?.provider).toBe("claude-personal");
+  });
+
+  test("renameProvider is a no-op when no record references the old provider", async () => {
+    await storage.applySnapshot(createManagedAgent({ id: "agent-1", provider: "claude" }));
+
+    expect(await storage.renameProvider("claude-work", "claude-job")).toEqual([]);
+    expect((await storage.get("agent-1"))?.provider).toBe("claude");
+  });
+
   test("applySnapshot accepts explicit title overrides", async () => {
     const agentId = "agent-override";
     await storage.applySnapshot(createManagedAgent({ id: agentId }), { title: "Provided Title" });

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -273,6 +273,38 @@ export class AgentStorage {
     await this.upsert({ ...record, title });
   }
 
+  /**
+   * Rewrites every stored record that points at `fromProviderId` so it points at
+   * `toProviderId`. Used when a provider account is renamed: without it the records keep
+   * referencing an id that no longer exists and the agents drop out of listings.
+   * Returns the ids of the migrated agents.
+   */
+  async renameProvider(fromProviderId: string, toProviderId: string): Promise<string[]> {
+    await this.load();
+    const candidates = Array.from(this.cache.values())
+      .filter((record) => recordReferencesProvider(record, fromProviderId))
+      .map((record) => record.id);
+
+    const migrated: string[] = [];
+    for (const agentId of candidates) {
+      await this.waitForPendingWrite(agentId);
+      const record = this.cache.get(agentId);
+      if (!record || !recordReferencesProvider(record, fromProviderId)) {
+        continue;
+      }
+      await this.upsert(withRenamedProvider(record, fromProviderId, toProviderId));
+      migrated.push(agentId);
+    }
+
+    if (migrated.length > 0) {
+      this.logger.info(
+        { fromProviderId, toProviderId, agentCount: migrated.length },
+        "Migrated agent records to renamed provider",
+      );
+    }
+    return migrated;
+  }
+
   async flush(): Promise<void> {
     await this.load().catch(() => undefined);
     const writes = Array.from(this.pendingWrites.values());
@@ -425,6 +457,32 @@ export class AgentStorage {
   private async waitForPendingWrite(agentId: string): Promise<void> {
     await (this.pendingWrites.get(agentId) ?? Promise.resolve()).catch(() => undefined);
   }
+}
+
+function recordReferencesProvider(record: StoredAgentRecord, providerId: string): boolean {
+  return (
+    record.provider === providerId ||
+    record.runtimeInfo?.provider === providerId ||
+    record.persistence?.provider === providerId
+  );
+}
+
+// The provider id is stored in three places on a record; a rename has to move all of them.
+function withRenamedProvider(
+  record: StoredAgentRecord,
+  fromProviderId: string,
+  toProviderId: string,
+): StoredAgentRecord {
+  return {
+    ...record,
+    ...(record.provider === fromProviderId ? { provider: toProviderId } : {}),
+    ...(record.runtimeInfo?.provider === fromProviderId
+      ? { runtimeInfo: { ...record.runtimeInfo, provider: toProviderId } }
+      : {}),
+    ...(record.persistence?.provider === fromProviderId
+      ? { persistence: { ...record.persistence, provider: toProviderId } }
+      : {}),
+  };
 }
 
 function projectDirNameFromCwd(cwd: string): string {

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -281,6 +281,8 @@ interface ConfigureProviderEntry {
   label?: string;
   description?: string;
   enabled?: boolean;
+  source?: "builtin" | "custom";
+  baseProviderId?: string;
   defaultModeId?: string;
   modes?: AgentMode[];
 }
@@ -297,6 +299,8 @@ function buildSnapshotEntry(entry: ConfigureProviderEntry): ProviderSnapshotEntr
       enabled: false,
       ...(entry.label !== undefined ? { label: entry.label } : {}),
       ...(entry.description !== undefined ? { description: entry.description } : {}),
+      ...(entry.source !== undefined ? { source: entry.source } : {}),
+      ...(entry.baseProviderId !== undefined ? { baseProviderId: entry.baseProviderId } : {}),
       ...(entry.defaultModeId !== undefined ? { defaultModeId: entry.defaultModeId } : {}),
       modes: [],
     };
@@ -307,6 +311,8 @@ function buildSnapshotEntry(entry: ConfigureProviderEntry): ProviderSnapshotEntr
     enabled: true,
     ...(entry.label !== undefined ? { label: entry.label } : {}),
     ...(entry.description !== undefined ? { description: entry.description } : {}),
+    ...(entry.source !== undefined ? { source: entry.source } : {}),
+    ...(entry.baseProviderId !== undefined ? { baseProviderId: entry.baseProviderId } : {}),
     ...(entry.defaultModeId !== undefined ? { defaultModeId: entry.defaultModeId } : {}),
     modes: entry.modes ?? [],
   };
@@ -4874,6 +4880,8 @@ describe("provider listing MCP tool", () => {
         provider: "zai" as AgentProvider,
         label: "ZAI",
         description: "Custom Claude profile",
+        source: "custom",
+        baseProviderId: "claude",
         defaultModeId: "default",
         modes: [{ id: "default", label: "Default", description: "Custom mode" }],
       }),
@@ -4905,6 +4913,8 @@ describe("provider listing MCP tool", () => {
           status: "available",
           description: "Custom Claude profile",
           enabled: true,
+          source: "custom",
+          baseProviderId: "claude",
           modes: [{ id: "default", label: "Default", description: "Custom mode" }],
         },
       ],
@@ -5134,6 +5144,37 @@ describe("provider MCP tools", () => {
         },
       ],
     });
+  });
+
+  it("identifies a provider account and its base provider", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const provStub = createProviderSnapshotManagerStub();
+    const accountEntry = buildSnapshotEntry({
+      provider: "claude-work",
+      label: "Claude Work",
+      description: "Work account",
+      source: "custom",
+      baseProviderId: "claude",
+    });
+    provStub.getProvider.mockResolvedValue(accountEntry);
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: provStub.manager,
+      logger,
+    });
+    const tool = registeredTool(server, "inspect_provider");
+
+    const response = await tool.handler({ provider: "claude-work", cwd: "~/repo" });
+
+    expect(response.structuredContent).toEqual(
+      expect.objectContaining({
+        provider: "claude-work",
+        label: "Claude Work",
+        source: "custom",
+        baseProviderId: "claude",
+      }),
+    );
   });
 
   it("rejects disabled providers without fetching models", async () => {

--- a/packages/server/src/server/agent/mcp-shared.ts
+++ b/packages/server/src/server/agent/mcp-shared.ts
@@ -30,6 +30,8 @@ export const ProviderSummarySchema = z
     label: z.string().nullish(),
     description: z.string().nullish(),
     enabled: z.boolean().optional().default(true),
+    source: z.enum(["builtin", "custom"]).optional(),
+    baseProviderId: z.string().optional(),
     modes: z.array(ProviderModeSchema).nullish(),
   })
   .passthrough();

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -1452,6 +1452,38 @@ describe("ProviderSnapshotManager applyMutableProviderConfig", () => {
     }
   });
 
+  test("replaces startup provider overrides instead of merging stale fields", () => {
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        "claude-work": {
+          extends: "claude",
+          label: "Old label",
+          description: "Remove me",
+          env: { OLD_TOKEN: "secret" },
+        },
+      },
+    });
+    try {
+      const state = manager.applyMutableProviderConfig(
+        {
+          "claude-work": { extends: "claude", label: "Work" },
+        },
+        { replaceProviders: ["claude-work"] },
+      );
+
+      expect(state.providerDefinitions["claude-work"]).toBeDefined();
+      const snapshot = manager
+        .getSnapshot()
+        .records.map(({ entry }) => entry)
+        .find((entry) => entry.provider === "claude-work");
+      expect(snapshot?.label).toBe("Work");
+      expect(snapshot?.description).not.toBe("Remove me");
+    } finally {
+      manager.destroy();
+    }
+  });
+
   test("drops disabled built-in providers from clients while preserving providerDefinitions", () => {
     const manager = new ProviderSnapshotManager({
       logger: createTestLogger(),

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -1413,12 +1413,12 @@ describe("ProviderSnapshotManager applyMutableProviderConfig", () => {
       expect(manager.hasProvider("zai-claude")).toBe(true);
       expect(state.providerDefinitions["zai-claude"]).toMatchObject({ enabled: true });
       expect(manager.listRegisteredProviderIds()).toContain("zai-claude");
-      expect(
-        manager
-          .getSnapshot()
-          .records.map(({ entry }) => entry)
-          .find((entry) => entry.provider === "zai-claude")?.source,
-      ).toBe("custom");
+      const entries = manager.getSnapshot().records.map(({ entry }) => entry);
+      expect(entries.find((entry) => entry.provider === "zai-claude")?.source).toBe("custom");
+      expect(entries.find((entry) => entry.provider === "zai-claude")?.baseProviderId).toBe(
+        "claude",
+      );
+      expect(entries.find((entry) => entry.provider === "claude")?.baseProviderId).toBeUndefined();
     } finally {
       manager.destroy();
     }

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -836,6 +836,7 @@ export class ProviderSnapshotManager {
           status: definition.enabled ? "loading" : "unavailable",
           enabled: definition.enabled,
           source: custom ? "custom" : "builtin",
+          baseProviderId: resolveBaseProviderId(provider, overrides),
           label: definition.label,
           description: definition.description,
           iconSvg: definition.iconSvg,
@@ -1161,6 +1162,22 @@ function createFetchCatalogOptions(
 
 export function isGlobalProviderSnapshotKey(cwd: string): boolean {
   return cwd === GLOBAL_PROVIDER_SNAPSHOT_KEY;
+}
+
+/**
+ * The builtin provider a custom account extends. Builtin ids never report a
+ * base even when they derive from another builtin (omp extends pi), because
+ * the base only exists to group and icon provider accounts.
+ */
+function resolveBaseProviderId(
+  provider: AgentProvider,
+  overrides: Record<string, ProviderOverride> | undefined,
+): string | undefined {
+  if (BUILTIN_PROVIDER_IDS.includes(provider)) {
+    return undefined;
+  }
+  const base = overrides?.[provider]?.extends;
+  return typeof base === "string" && BUILTIN_PROVIDER_IDS.includes(base) ? base : undefined;
 }
 
 function identifyEntry(entry: ProviderSnapshotEntry): ProviderSnapshotRecord {

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -142,6 +142,7 @@ interface ProviderSnapshotReadOptions {
 interface ApplyMutableProviderConfigOptions {
   removeProviders?: readonly string[];
   replace?: boolean;
+  replaceProviders?: readonly string[];
 }
 
 export interface PreparedMutableProviderConfig {
@@ -583,7 +584,10 @@ export class ProviderSnapshotManager {
   ): PreparedMutableProviderConfig {
     const baseProviderOverrides = options.replace
       ? undefined
-      : omitProviderOverrides(this.baseProviderOverrides, options.removeProviders ?? []);
+      : omitProviderOverrides(this.baseProviderOverrides, [
+          ...(options.removeProviders ?? []),
+          ...(options.replaceProviders ?? []),
+        ]);
     const runtimeSettings = options.replace ? undefined : this.runtimeSettings;
     const providerOverrides = applyMutableProviderConfigToOverrides(
       baseProviderOverrides,

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -172,6 +172,8 @@ interface ProviderSummary {
   label: string;
   description: string;
   enabled: boolean;
+  source?: "builtin" | "custom";
+  baseProviderId?: string;
   modes: AgentMode[];
   status: string;
   error?: string;
@@ -281,6 +283,8 @@ function toProviderSummary(entry: {
   label?: string;
   description?: string;
   enabled: boolean;
+  source?: "builtin" | "custom";
+  baseProviderId?: string;
   modes?: AgentMode[];
   status: string;
   error?: string;
@@ -290,6 +294,8 @@ function toProviderSummary(entry: {
     label: entry.label ?? entry.provider,
     description: entry.description ?? "",
     enabled: entry.enabled,
+    ...(entry.source ? { source: entry.source } : {}),
+    ...(entry.baseProviderId ? { baseProviderId: entry.baseProviderId } : {}),
     modes: entry.modes ?? [],
     status: entry.status === "ready" ? "available" : entry.status,
     ...(entry.error ? { error: entry.error } : {}),
@@ -2884,7 +2890,8 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
     "list_providers",
     {
       title: "List providers",
-      description: "List configured agent providers, availability, and their modes.",
+      description:
+        "List configured agent providers and accounts, including availability, modes, and each account's base provider.",
       inputSchema: {},
       outputSchema: {
         providers: z.array(ProviderSummarySchema),
@@ -2965,6 +2972,8 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         label: z.string().nullable().optional(),
         description: z.string().nullable().optional(),
         enabled: z.boolean(),
+        source: z.enum(["builtin", "custom"]).optional(),
+        baseProviderId: z.string().optional(),
         status: z.string(),
         modes: z.array(ProviderModeSchema).nullish(),
         selectedModel: z.string().nullable(),
@@ -3006,6 +3015,8 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           label: summary.label,
           description: summary.description,
           enabled: summary.enabled,
+          ...(summary.source ? { source: summary.source } : {}),
+          ...(summary.baseProviderId ? { baseProviderId: summary.baseProviderId } : {}),
           status: summary.status,
           modes: summary.modes,
           selectedModel: selectedModel ?? null,

--- a/packages/server/src/server/bootstrap.test.ts
+++ b/packages/server/src/server/bootstrap.test.ts
@@ -1,6 +1,35 @@
 import { expect, test } from "vitest";
 
-import { fanOutReconciledWorkspaceUpdates } from "./bootstrap.js";
+import {
+  createInitialMutableDaemonConfig,
+  fanOutReconciledWorkspaceUpdates,
+  type PaseoDaemonConfig,
+} from "./bootstrap.js";
+
+test("initial mutable config includes complete custom provider definitions", () => {
+  const config = {
+    listen: "127.0.0.1:0",
+    paseoHome: "/tmp/paseo-test",
+    corsAllowedOrigins: [],
+    staticDir: "/tmp/static",
+    mcpDebug: false,
+    agentClients: {},
+    agentStoragePath: "/tmp/agents.json",
+    providerOverrides: {
+      "claude-work": {
+        extends: "claude",
+        label: "Claude (Work)",
+        description: "Company account",
+        env: { CLAUDE_CONFIG_DIR: "/work/claude" },
+        command: ["claude", "--work"],
+      },
+    },
+  } satisfies PaseoDaemonConfig;
+
+  expect(createInitialMutableDaemonConfig(config).providers["claude-work"]).toEqual(
+    config.providerOverrides["claude-work"],
+  );
+});
 
 test("reconciliation emits workspace updates when observer sync fails", async () => {
   const emittedWorkspaceIds: string[][] = [];

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -524,7 +524,7 @@ function resolveExpressTrustProxySetting(config: PaseoDaemonConfig): true | stri
   return config.trustedProxies ?? ["loopback"];
 }
 
-function createInitialMutableDaemonConfig(config: PaseoDaemonConfig): MutableDaemonConfig {
+export function createInitialMutableDaemonConfig(config: PaseoDaemonConfig): MutableDaemonConfig {
   const providers = config.providerOverrides ?? {};
 
   const initialConfig: MutableDaemonConfig = {

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -121,6 +121,7 @@ import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
 import { WorkspaceSetupRuntime } from "./workspace-setup-runtime.js";
 import { createWorkspaceLabelService } from "./workspace-labels/index.js";
 import { createGitHubService } from "../services/github-service.js";
+import { ProviderUsageService } from "../services/quota-fetcher/service.js";
 import { createPaseoWorktree as createRegisteredPaseoWorktree } from "./paseo-worktree-service.js";
 import { createWorkspaceProvisioningService } from "./session/workspace-provisioning/workspace-provisioning-service.js";
 import { createPaseoWorktreeWorkflow } from "./worktree-session.js";
@@ -1717,6 +1718,10 @@ export async function createPaseoDaemon(
               pluginRuntime,
               orchestrationSkills,
               workspaceLabelService,
+              new ProviderUsageService({
+                logger,
+                providerConfigs: daemonConfigStore.get().providers,
+              }),
             );
             pluginRuntime.bindPaseoSessionHost(wsServer);
             await pluginRuntime.start();

--- a/packages/server/src/server/daemon-config-store.test.ts
+++ b/packages/server/src/server/daemon-config-store.test.ts
@@ -442,6 +442,90 @@ describe("DaemonConfigStore", () => {
     });
   });
 
+  test("replaceProviders removes stale provider fields in memory and config.json", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+
+    writeFileSync(
+      path.join(paseoHome, "config.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          agents: {
+            providers: {
+              "claude-work": {
+                extends: "claude",
+                label: "Old label",
+                description: "Remove me",
+                env: { OLD_TOKEN: "secret", KEEP: "old" },
+                additionalModels: [{ id: "old-model", label: "Old model" }],
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const store = new DaemonConfigStore(paseoHome, {
+      mcp: { injectIntoAgents: false },
+      browserTools: { enabled: false },
+      providers: {
+        "claude-work": {
+          extends: "claude",
+          label: "Old label",
+          description: "Remove me",
+          env: { OLD_TOKEN: "secret", KEEP: "old" },
+          additionalModels: [{ id: "old-model", label: "Old model" }],
+        },
+      },
+      metadataGeneration: { providers: [] },
+      autoArchiveAfterMerge: false,
+      enableTerminalAgentHooks: false,
+      appendSystemPrompt: "",
+    });
+
+    const next = store.patch({
+      replaceProviders: {
+        "claude-work": {
+          extends: "claude",
+          label: "Work",
+          env: { KEEP: "new" },
+        },
+      },
+    });
+
+    const expected = {
+      extends: "claude",
+      label: "Work",
+      env: { KEEP: "new" },
+    };
+    expect(next.providers["claude-work"]).toEqual(expected);
+    expect(loadPersistedConfig(paseoHome).agents?.providers?.["claude-work"]).toEqual(expected);
+  });
+
+  test("rejects removing and replacing the same provider", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+    const store = new DaemonConfigStore(paseoHome, {
+      mcp: { injectIntoAgents: false },
+      browserTools: { enabled: false },
+      providers: {},
+      metadataGeneration: { providers: [] },
+      autoArchiveAfterMerge: false,
+      enableTerminalAgentHooks: false,
+      appendSystemPrompt: "",
+    });
+
+    expect(() =>
+      store.patch({
+        removeProviders: ["claude-work"],
+        replaceProviders: { "claude-work": { extends: "claude" } },
+      }),
+    ).toThrow("cannot be removed and replaced together");
+  });
+
   test("patch removes provider entries from config.json", () => {
     const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
     tempDirs.push(paseoHome);

--- a/packages/server/src/server/daemon-config-store.test.ts
+++ b/packages/server/src/server/daemon-config-store.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
-import { DaemonConfigStore, applyMutableProviderConfigToOverrides } from "./daemon-config-store.js";
+import {
+  DaemonConfigStore,
+  applyMutableProviderConfigToOverrides,
+  type DaemonConfigChangeDetails,
+} from "./daemon-config-store.js";
 import { loadPersistedConfig } from "./persisted-config.js";
 import type { PersistedConfig } from "./persisted-config.js";
 import type { MutableDaemonConfig } from "@getpaseo/protocol/messages";
@@ -503,6 +507,95 @@ describe("DaemonConfigStore", () => {
     };
     expect(next.providers["claude-work"]).toEqual(expected);
     expect(loadPersistedConfig(paseoHome).agents?.providers?.["claude-work"]).toEqual(expected);
+  });
+
+  test("renameProviders reports the rename and persists the move", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+    const store = new DaemonConfigStore(paseoHome, {
+      mcp: { injectIntoAgents: false },
+      browserTools: { enabled: false },
+      providers: {
+        "claude-work": { extends: "claude", label: "Work", env: { TOKEN: "secret" } },
+      },
+      metadataGeneration: { providers: [] },
+      autoArchiveAfterMerge: false,
+      enableTerminalAgentHooks: false,
+      appendSystemPrompt: "",
+    });
+
+    const changes: DaemonConfigChangeDetails[] = [];
+    store.onChange((_config, details) => {
+      changes.push(details);
+    });
+
+    const next = store.patch({
+      replaceProviders: {
+        "claude-job": { extends: "claude", label: "Job", env: { TOKEN: "secret" } },
+      },
+      removeProviders: ["claude-work"],
+      renameProviders: { "claude-work": "claude-job" },
+    });
+
+    expect(next.providers["claude-work"]).toBeUndefined();
+    expect(next.providers["claude-job"]).toEqual({
+      extends: "claude",
+      label: "Job",
+      env: { TOKEN: "secret" },
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.renamedProviders).toEqual([{ from: "claude-work", to: "claude-job" }]);
+    expect(changes[0]?.removedProviders).toEqual(["claude-work"]);
+
+    const persistedProviders = loadPersistedConfig(paseoHome).agents?.providers;
+    expect(persistedProviders?.["claude-work"]).toBeUndefined();
+    expect(persistedProviders?.["claude-job"]).toEqual({
+      extends: "claude",
+      label: "Job",
+      env: { TOKEN: "secret" },
+    });
+  });
+
+  test("rejects a rename that does not remove the old provider", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+    const store = new DaemonConfigStore(paseoHome, {
+      mcp: { injectIntoAgents: false },
+      browserTools: { enabled: false },
+      providers: {},
+      metadataGeneration: { providers: [] },
+      autoArchiveAfterMerge: false,
+      enableTerminalAgentHooks: false,
+      appendSystemPrompt: "",
+    });
+
+    expect(() =>
+      store.patch({
+        replaceProviders: { "claude-job": { extends: "claude" } },
+        renameProviders: { "claude-work": "claude-job" },
+      }),
+    ).toThrow("must also remove claude-work");
+  });
+
+  test("rejects a rename whose target is never defined", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+    const store = new DaemonConfigStore(paseoHome, {
+      mcp: { injectIntoAgents: false },
+      browserTools: { enabled: false },
+      providers: {},
+      metadataGeneration: { providers: [] },
+      autoArchiveAfterMerge: false,
+      enableTerminalAgentHooks: false,
+      appendSystemPrompt: "",
+    });
+
+    expect(() =>
+      store.patch({
+        removeProviders: ["claude-work"],
+        renameProviders: { "claude-work": "claude-job" },
+      }),
+    ).toThrow("must also define claude-job");
   });
 
   test("rejects removing and replacing the same provider", () => {

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -23,6 +23,7 @@ interface SupportedMutableConfigPatch {
   providers?: MutableDaemonConfig["providers"];
   removeProviders?: string[];
   replaceProviders?: MutableDaemonConfigPatch["replaceProviders"];
+  renameProviders?: MutableDaemonConfigPatch["renameProviders"];
   metadataGeneration?: MutableDaemonConfig["metadataGeneration"];
   autoArchiveAfterMerge?: boolean;
   enableTerminalAgentHooks?: boolean;
@@ -39,9 +40,15 @@ interface LoggerLike {
   info(...args: unknown[]): void;
 }
 
+export interface ProviderRename {
+  from: string;
+  to: string;
+}
+
 export interface DaemonConfigChangeDetails {
   removedProviders: readonly string[];
   replacedProviders: readonly string[];
+  renamedProviders: readonly ProviderRename[];
 }
 
 export interface DaemonConfigReloadResult {
@@ -263,6 +270,7 @@ function pickSupportedPatchFields(patch: MutableDaemonConfigPatch): SupportedMut
     ...(patch.providers !== undefined ? { providers: patch.providers } : {}),
     ...(patch.removeProviders !== undefined ? { removeProviders: patch.removeProviders } : {}),
     ...(patch.replaceProviders !== undefined ? { replaceProviders: patch.replaceProviders } : {}),
+    ...(patch.renameProviders !== undefined ? { renameProviders: patch.renameProviders } : {}),
     ...(patch.metadataGeneration?.providers !== undefined
       ? { metadataGeneration: { providers: patch.metadataGeneration.providers } }
       : {}),
@@ -309,6 +317,37 @@ export function applyMutableProviderConfigToOverrides(
   }
 
   return nextOverrides;
+}
+
+/**
+ * A rename carries no mutation of its own: the caller already sends the new definition in
+ * `replaceProviders` (or `providers`) and the old id in `removeProviders`. Reject renames that
+ * don't match that shape rather than half-applying one.
+ */
+function assertProviderMutationsAreConsistent(params: {
+  replacedProviders: readonly string[];
+  removedProviderSet: ReadonlySet<string>;
+  renameProviders: Record<string, string>;
+  definedProviders: ReadonlySet<string>;
+}): void {
+  const { replacedProviders, removedProviderSet, renameProviders, definedProviders } = params;
+  const conflictingProvider = replacedProviders.find((providerId) =>
+    removedProviderSet.has(providerId),
+  );
+  if (conflictingProvider) {
+    throw new Error(`Provider ${conflictingProvider} cannot be removed and replaced together`);
+  }
+  for (const [from, to] of Object.entries(renameProviders)) {
+    if (from === to) {
+      throw new Error(`Provider rename for ${from} must change the provider id`);
+    }
+    if (!removedProviderSet.has(from)) {
+      throw new Error(`Provider rename from ${from} must also remove ${from}`);
+    }
+    if (!definedProviders.has(to)) {
+      throw new Error(`Provider rename to ${to} must also define ${to}`);
+    }
+  }
 }
 
 export class DaemonConfigStore {
@@ -364,16 +403,30 @@ export class DaemonConfigStore {
         "Relay is controlled by a daemon launch override. Remove PASEO_RELAY_ENABLED or the relay CLI flag before changing it here.",
       );
     }
-    const { removeProviders = [], replaceProviders = {}, ...configPatch } = parsedPatch;
+    const {
+      removeProviders = [],
+      replaceProviders = {},
+      renameProviders = {},
+      ...configPatch
+    } = parsedPatch;
     const removedProviders = Array.from(new Set(removeProviders));
     const replacedProviders = Object.keys(replaceProviders);
     const removedProviderSet = new Set(removedProviders);
-    const conflictingProvider = replacedProviders.find((providerId) =>
-      removedProviderSet.has(providerId),
+    assertProviderMutationsAreConsistent({
+      replacedProviders,
+      removedProviderSet,
+      renameProviders,
+      definedProviders: new Set([
+        ...replacedProviders,
+        ...Object.keys(configPatch.providers ?? {}),
+      ]),
+    });
+    const renamedProviders: ProviderRename[] = Object.entries(renameProviders).map(
+      ([from, to]) => ({
+        from,
+        to,
+      }),
     );
-    if (conflictingProvider) {
-      throw new Error(`Provider ${conflictingProvider} cannot be removed and replaced together`);
-    }
     const mergePatch =
       replacedProviders.length > 0
         ? {
@@ -405,7 +458,7 @@ export class DaemonConfigStore {
       replacedProviders,
     );
     try {
-      this.applyReplacement(next, { removedProviders, replacedProviders });
+      this.applyReplacement(next, { removedProviders, replacedProviders, renamedProviders });
       this.lastKnownPersisted = knownNext;
     } catch (error) {
       savePersistedConfig(this.paseoHome, persistedBeforePatch, this.logger);
@@ -460,7 +513,11 @@ export class DaemonConfigStore {
     const removedProviders = Object.keys(this.current.providers).filter(
       (provider) => !(provider in desired.providers),
     );
-    this.applyReplacement(desired, { removedProviders, replacedProviders: [] });
+    this.applyReplacement(desired, {
+      removedProviders,
+      replacedProviders: [],
+      renamedProviders: [],
+    });
     this.lastKnownPersisted = persisted;
 
     return {
@@ -480,7 +537,8 @@ export class DaemonConfigStore {
     if (
       isEqualValue(this.current, next) &&
       changeDetails.removedProviders.length === 0 &&
-      changeDetails.replacedProviders.length === 0
+      changeDetails.replacedProviders.length === 0 &&
+      changeDetails.renamedProviders.length === 0
     ) {
       return;
     }

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -22,6 +22,7 @@ interface SupportedMutableConfigPatch {
   browserTools?: { enabled?: boolean };
   providers?: MutableDaemonConfig["providers"];
   removeProviders?: string[];
+  replaceProviders?: MutableDaemonConfigPatch["replaceProviders"];
   metadataGeneration?: MutableDaemonConfig["metadataGeneration"];
   autoArchiveAfterMerge?: boolean;
   enableTerminalAgentHooks?: boolean;
@@ -40,6 +41,7 @@ interface LoggerLike {
 
 export interface DaemonConfigChangeDetails {
   removedProviders: readonly string[];
+  replacedProviders: readonly string[];
 }
 
 export interface DaemonConfigReloadResult {
@@ -260,6 +262,7 @@ function pickSupportedPatchFields(patch: MutableDaemonConfigPatch): SupportedMut
       : {}),
     ...(patch.providers !== undefined ? { providers: patch.providers } : {}),
     ...(patch.removeProviders !== undefined ? { removeProviders: patch.removeProviders } : {}),
+    ...(patch.replaceProviders !== undefined ? { replaceProviders: patch.replaceProviders } : {}),
     ...(patch.metadataGeneration?.providers !== undefined
       ? { metadataGeneration: { providers: patch.metadataGeneration.providers } }
       : {}),
@@ -361,9 +364,24 @@ export class DaemonConfigStore {
         "Relay is controlled by a daemon launch override. Remove PASEO_RELAY_ENABLED or the relay CLI flag before changing it here.",
       );
     }
-    const { removeProviders = [], ...configPatch } = parsedPatch;
+    const { removeProviders = [], replaceProviders = {}, ...configPatch } = parsedPatch;
     const removedProviders = Array.from(new Set(removeProviders));
-    const merged = deepMerge(this.current, configPatch);
+    const replacedProviders = Object.keys(replaceProviders);
+    const removedProviderSet = new Set(removedProviders);
+    const conflictingProvider = replacedProviders.find((providerId) =>
+      removedProviderSet.has(providerId),
+    );
+    if (conflictingProvider) {
+      throw new Error(`Provider ${conflictingProvider} cannot be removed and replaced together`);
+    }
+    const mergePatch =
+      replacedProviders.length > 0
+        ? {
+            ...configPatch,
+            providers: { ...configPatch.providers, ...replaceProviders },
+          }
+        : configPatch;
+    const merged = deepMerge(omitProvidersFromConfig(this.current, replacedProviders), mergePatch);
     if (parsedPatch.skills?.selection !== undefined) {
       merged.skills = { selection: parsedPatch.skills.selection };
     }
@@ -377,21 +395,17 @@ export class DaemonConfigStore {
 
     const configChanged = !isEqualValue(this.current, next);
 
-    if (!configChanged && removedProviders.length === 0) {
+    if (!configChanged && removedProviders.length === 0 && replacedProviders.length === 0) {
       return this.current;
     }
 
     const { previous: persistedBeforePatch, knownNext } = this.persistConfig(
-      configPatch,
+      mergePatch,
       removedProviders,
+      replacedProviders,
     );
-    if (!configChanged) {
-      this.lastKnownPersisted = knownNext;
-      return this.current;
-    }
-
     try {
-      this.applyReplacement(next, { removedProviders });
+      this.applyReplacement(next, { removedProviders, replacedProviders });
       this.lastKnownPersisted = knownNext;
     } catch (error) {
       savePersistedConfig(this.paseoHome, persistedBeforePatch, this.logger);
@@ -446,7 +460,7 @@ export class DaemonConfigStore {
     const removedProviders = Object.keys(this.current.providers).filter(
       (provider) => !(provider in desired.providers),
     );
-    this.applyReplacement(desired, { removedProviders });
+    this.applyReplacement(desired, { removedProviders, replacedProviders: [] });
     this.lastKnownPersisted = persisted;
 
     return {
@@ -463,7 +477,13 @@ export class DaemonConfigStore {
     const changedFieldPaths = Array.from(this.fieldChangeHandlers.keys()).filter((path) => {
       return !isEqualValue(getValueAtPath(this.current, path), getValueAtPath(next, path));
     });
-    if (isEqualValue(this.current, next) && changeDetails.removedProviders.length === 0) return;
+    if (
+      isEqualValue(this.current, next) &&
+      changeDetails.removedProviders.length === 0 &&
+      changeDetails.replacedProviders.length === 0
+    ) {
+      return;
+    }
 
     const previous = this.current;
     const appliedFieldChanges: AppliedFieldChange[] = [];
@@ -557,8 +577,9 @@ export class DaemonConfigStore {
   }
 
   private persistConfig(
-    patch: Omit<SupportedMutableConfigPatch, "removeProviders">,
+    patch: Omit<SupportedMutableConfigPatch, "removeProviders" | "replaceProviders">,
     removeProviders: readonly string[],
+    replaceProviders: readonly string[],
   ): { previous: PersistedConfig; knownNext: PersistedConfig } {
     const persisted = loadPersistedConfig(this.paseoHome, this.logger);
     const merge = (source: PersistedConfig) =>
@@ -566,6 +587,7 @@ export class DaemonConfigStore {
         persisted: source,
         patch,
         removeProviders,
+        replaceProviders,
         persistRelayEnabled: this.relayEnabledMutable,
       });
     const nextPersisted = merge(persisted);
@@ -577,13 +599,14 @@ export class DaemonConfigStore {
 
 function mergeMutablePatchIntoPersistedConfig(params: {
   persisted: PersistedConfig;
-  patch: Omit<SupportedMutableConfigPatch, "removeProviders">;
+  patch: Omit<SupportedMutableConfigPatch, "removeProviders" | "replaceProviders">;
   removeProviders: readonly string[];
+  replaceProviders: readonly string[];
   persistRelayEnabled: boolean;
 }): PersistedConfig {
-  const { persisted, patch, removeProviders, persistRelayEnabled } = params;
+  const { persisted, patch, removeProviders, replaceProviders, persistRelayEnabled } = params;
   const daemon = mergeMutableDaemonPatch(persisted.daemon, patch, persistRelayEnabled);
-  const agents = mergeMutableAgentPatch(persisted.agents, patch, removeProviders);
+  const agents = mergeMutableAgentPatch(persisted.agents, patch, removeProviders, replaceProviders);
   return {
     ...persisted,
     ...(patch.pluginsEnabled !== undefined ? { pluginsEnabled: patch.pluginsEnabled } : {}),
@@ -595,14 +618,16 @@ function mergeMutablePatchIntoPersistedConfig(params: {
 
 function mergeMutableAgentPatch(
   persistedAgents: PersistedConfig["agents"],
-  patch: Omit<SupportedMutableConfigPatch, "removeProviders">,
+  patch: Omit<SupportedMutableConfigPatch, "removeProviders" | "replaceProviders">,
   removeProviders: readonly string[],
+  replaceProviders: readonly string[],
 ): PersistedConfig["agents"] {
   if (
     patch.providers === undefined &&
     patch.metadataGeneration === undefined &&
     patch.skills === undefined &&
-    removeProviders.length === 0
+    removeProviders.length === 0 &&
+    replaceProviders.length === 0
   ) {
     return persistedAgents;
   }
@@ -610,7 +635,7 @@ function mergeMutableAgentPatch(
   const next = { ...persistedAgents } as Record<string, unknown>;
   const persistedProviderOverrides = omitProvidersFromOverrides(
     persistedAgents?.providers as Record<string, ProviderOverride> | undefined,
-    removeProviders,
+    [...removeProviders, ...replaceProviders],
   );
   const providerOverrides = applyMutableProviderConfigToOverrides(
     persistedProviderOverrides,
@@ -639,7 +664,7 @@ function mergeMutableAgentPatch(
 
 function mergeMutableDaemonPatch(
   persistedDaemon: PersistedConfig["daemon"],
-  patch: Omit<SupportedMutableConfigPatch, "removeProviders">,
+  patch: Omit<SupportedMutableConfigPatch, "removeProviders" | "replaceProviders">,
   persistRelayEnabled: boolean,
 ): PersistedConfig["daemon"] {
   const next = { ...persistedDaemon } as NonNullable<PersistedConfig["daemon"]>;

--- a/packages/server/src/server/test-utils/session-stubs.ts
+++ b/packages/server/src/server/test-utils/session-stubs.ts
@@ -167,6 +167,9 @@ export interface ProviderSnapshotManagerSpies {
   applyMutableProviderConfig: ReturnType<
     typeof vi.fn<ProviderSnapshotManager["applyMutableProviderConfig"]>
   >;
+  prepareMutableProviderConfig: ReturnType<
+    typeof vi.fn<ProviderSnapshotManager["prepareMutableProviderConfig"]>
+  >;
   destroy: ReturnType<typeof vi.fn<ProviderSnapshotManager["destroy"]>>;
 }
 
@@ -227,6 +230,12 @@ export function createProviderSnapshotManagerStub(): {
       clients: {},
     }),
   );
+  const prepareMutableProviderConfig = vi.fn<
+    ProviderSnapshotManager["prepareMutableProviderConfig"]
+  >(() => ({
+    agentManagerState: { providerDefinitions: {}, clients: {} },
+    commit: vi.fn(),
+  }));
   const on = vi.fn();
   const off = vi.fn();
   const destroy = vi.fn<ProviderSnapshotManager["destroy"]>();
@@ -248,6 +257,7 @@ export function createProviderSnapshotManagerStub(): {
     resolveDefaultModel,
     getProviderDiagnostic,
     applyMutableProviderConfig,
+    prepareMutableProviderConfig,
     on,
     off,
     destroy,
@@ -274,6 +284,7 @@ export function createProviderSnapshotManagerStub(): {
     resolveDefaultModel,
     getProviderDiagnostic,
     applyMutableProviderConfig,
+    prepareMutableProviderConfig,
     destroy,
   };
 }

--- a/packages/server/src/server/websocket-server.provider-rename.test.ts
+++ b/packages/server/src/server/websocket-server.provider-rename.test.ts
@@ -1,0 +1,197 @@
+import { createServer, type Server as HTTPServer } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentManager } from "./agent/agent-manager.js";
+import { AgentStorage, type StoredAgentRecord } from "./agent/agent-storage.js";
+import type { CheckoutDiffManager } from "./checkout-diff-manager.js";
+import type { FileBackedChatService } from "./chat/chat-service.js";
+import { DaemonConfigStore } from "./daemon-config-store.js";
+import type { DownloadTokenStore } from "./file-download/token-store.js";
+import type { LoopService } from "./loop-service.js";
+import type { ScheduleService } from "./schedule/service.js";
+import { createStub } from "./test-utils/class-mocks.js";
+import { createProviderSnapshotManagerStub } from "./test-utils/session-stubs.js";
+import { createTestLogger } from "../test-utils/test-logger.js";
+import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
+import type { WorkspaceAutoName } from "./workspace-auto-name.js";
+
+interface ProviderRenameHarness {
+  configStore: DaemonConfigStore;
+  agentStorage: AgentStorage;
+  renameProviderOnLiveAgents: ReturnType<typeof vi.fn>;
+  stop(): Promise<void>;
+}
+
+const harnesses: ProviderRenameHarness[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(harnesses.splice(0).map((harness) => harness.stop()));
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function storedRecord(overrides: Partial<StoredAgentRecord>): StoredAgentRecord {
+  return {
+    id: "agent-1",
+    provider: "claude-work",
+    cwd: "/tmp/project",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    labels: {},
+    lastStatus: "closed",
+    config: null,
+    runtimeInfo: { provider: "claude-work", sessionId: "session-1" },
+    persistence: { provider: "claude-work", sessionId: "session-1" },
+    ...overrides,
+  };
+}
+
+function createWebSocketServer(params: {
+  httpServer: HTTPServer;
+  paseoHome: string;
+  agentStorage: AgentStorage;
+  configStore: DaemonConfigStore;
+  renameProviderOnLiveAgents: ReturnType<typeof vi.fn>;
+}): VoiceAssistantWebSocketServer {
+  const agentManager = {
+    setAgentAttentionCallback() {},
+    subscribe: () => () => {},
+    updateProviderRegistry() {},
+    renameProviderOnLiveAgents: params.renameProviderOnLiveAgents,
+    getMetricsSnapshot: () => ({
+      total: 0,
+      byLifecycle: {},
+      withActiveForegroundTurn: 0,
+      timelineStats: { totalItems: 0, maxItemsPerAgent: 0 },
+    }),
+  };
+
+  return new VoiceAssistantWebSocketServer(
+    params.httpServer,
+    createStub<pino.Logger>(createTestLogger()),
+    "srv-test",
+    createStub<AgentManager>(agentManager),
+    params.agentStorage,
+    createStub<DownloadTokenStore>({}),
+    params.paseoHome,
+    params.configStore,
+    null,
+    { allowedOrigins: new Set(["*"]) },
+    createStub<WorkspaceAutoName>({
+      scheduleForWorktree: () => {},
+      scheduleForDirectory: () => {},
+    }),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    "1.2.3-test",
+    undefined,
+    undefined,
+    undefined,
+    createStub<FileBackedChatService>({}),
+    createStub<LoopService>({}),
+    createStub<ScheduleService>({}),
+    createStub<CheckoutDiffManager>({
+      subscribe: () => {},
+      scheduleRefreshForCwd: () => {},
+      getMetrics: () => ({
+        checkoutDiffTargetCount: 0,
+        checkoutDiffSubscriptionCount: 0,
+        checkoutDiffWatcherCount: 0,
+        checkoutDiffFallbackRefreshTargetCount: 0,
+      }),
+      dispose: () => {},
+    }),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    createProviderSnapshotManagerStub().manager,
+  );
+}
+
+async function startHarness(): Promise<ProviderRenameHarness> {
+  const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-provider-rename-"));
+  tempDirs.push(paseoHome);
+
+  const agentStorage = new AgentStorage(path.join(paseoHome, "agents"), createTestLogger());
+  const configStore = new DaemonConfigStore(paseoHome, {
+    mcp: { injectIntoAgents: false },
+    browserTools: { enabled: false },
+    providers: { "claude-work": { extends: "claude", label: "Work" } },
+    metadataGeneration: { providers: [] },
+    autoArchiveAfterMerge: false,
+    enableTerminalAgentHooks: false,
+    appendSystemPrompt: "",
+  });
+  const renameProviderOnLiveAgents = vi.fn();
+
+  const httpServer = createServer();
+  const wsServer = createWebSocketServer({
+    httpServer,
+    paseoHome,
+    agentStorage,
+    configStore,
+    renameProviderOnLiveAgents,
+  });
+
+  const harness: ProviderRenameHarness = {
+    configStore,
+    agentStorage,
+    renameProviderOnLiveAgents,
+    async stop() {
+      await wsServer.close();
+      httpServer.close();
+    },
+  };
+  harnesses.push(harness);
+  return harness;
+}
+
+describe("provider rename migration wiring", () => {
+  it("migrates persisted agents and repoints live agents when a provider is renamed", async () => {
+    const harness = await startHarness();
+    await harness.agentStorage.upsert(storedRecord({ id: "agent-renamed" }));
+    await harness.agentStorage.upsert(
+      storedRecord({
+        id: "agent-other",
+        provider: "claude",
+        runtimeInfo: { provider: "claude", sessionId: "session-2" },
+        persistence: { provider: "claude", sessionId: "session-2" },
+      }),
+    );
+
+    harness.configStore.patch({
+      replaceProviders: { "claude-job": { extends: "claude", label: "Job" } },
+      removeProviders: ["claude-work"],
+      renameProviders: { "claude-work": "claude-job" },
+    });
+
+    expect(harness.renameProviderOnLiveAgents).toHaveBeenCalledWith("claude-work", "claude-job");
+
+    await vi.waitFor(async () => {
+      const record = await harness.agentStorage.get("agent-renamed");
+      expect(record?.provider).toBe("claude-job");
+    });
+
+    const record = await harness.agentStorage.get("agent-renamed");
+    expect(record?.runtimeInfo?.provider).toBe("claude-job");
+    expect(record?.persistence?.provider).toBe("claude-job");
+
+    const other = await harness.agentStorage.get("agent-other");
+    expect(other?.provider).toBe("claude");
+  });
+});

--- a/packages/server/src/server/websocket-server.provider-rename.test.ts
+++ b/packages/server/src/server/websocket-server.provider-rename.test.ts
@@ -17,6 +17,7 @@ import type { ScheduleService } from "./schedule/service.js";
 import { createStub } from "./test-utils/class-mocks.js";
 import { createProviderSnapshotManagerStub } from "./test-utils/session-stubs.js";
 import { createTestLogger } from "../test-utils/test-logger.js";
+import { ProviderUsageService } from "../services/quota-fetcher/service.js";
 import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
 import type { WorkspaceAutoName } from "./workspace-auto-name.js";
 
@@ -59,6 +60,7 @@ function createWebSocketServer(params: {
   agentStorage: AgentStorage;
   configStore: DaemonConfigStore;
   renameProviderOnLiveAgents: ReturnType<typeof vi.fn>;
+  providerUsageService?: ProviderUsageService;
 }): VoiceAssistantWebSocketServer {
   const agentManager = {
     setAgentAttentionCallback() {},
@@ -120,6 +122,11 @@ function createWebSocketServer(params: {
     undefined,
     undefined,
     createProviderSnapshotManagerStub().manager,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    params.providerUsageService,
   );
 }
 
@@ -193,5 +200,51 @@ describe("provider rename migration wiring", () => {
 
     const other = await harness.agentStorage.get("agent-other");
     expect(other?.provider).toBe("claude");
+  });
+});
+
+describe("provider usage service wiring", () => {
+  // Bootstrap builds the usage service with the daemon's provider-account
+  // configs; the server must use that instance. A merge once reintroduced a
+  // bare `new ProviderUsageService(...)` after the injected assignment, which
+  // silently dropped every account fetcher.
+  it("uses the injected provider usage service", async () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-provider-usage-"));
+    tempDirs.push(paseoHome);
+
+    const agentStorage = new AgentStorage(path.join(paseoHome, "agents"), createTestLogger());
+    const configStore = new DaemonConfigStore(paseoHome, {
+      mcp: { injectIntoAgents: false },
+      browserTools: { enabled: false },
+      providers: { "claude-work": { extends: "claude", label: "Work" } },
+      metadataGeneration: { providers: [] },
+      autoArchiveAfterMerge: false,
+      enableTerminalAgentHooks: false,
+      appendSystemPrompt: "",
+    });
+    const providerUsageService = new ProviderUsageService({
+      logger: createTestLogger(),
+      providerConfigs: configStore.get().providers,
+    });
+
+    const httpServer = createServer();
+    const wsServer = createWebSocketServer({
+      httpServer,
+      paseoHome,
+      agentStorage,
+      configStore,
+      renameProviderOnLiveAgents: vi.fn(),
+      providerUsageService,
+    });
+
+    try {
+      expect(
+        (wsServer as unknown as { providerUsageService: ProviderUsageService })
+          .providerUsageService,
+      ).toBe(providerUsageService);
+    } finally {
+      await wsServer.close();
+      httpServer.close();
+    }
   });
 });

--- a/packages/server/src/server/websocket-server.provider-rename.test.ts
+++ b/packages/server/src/server/websocket-server.provider-rename.test.ts
@@ -123,6 +123,9 @@ function createWebSocketServer(params: {
     undefined,
     undefined,
     undefined,
+    undefined,
+    undefined,
+    undefined,
     params.providerUsageService,
   );
 }

--- a/packages/server/src/server/websocket-server.provider-rename.test.ts
+++ b/packages/server/src/server/websocket-server.provider-rename.test.ts
@@ -126,6 +126,7 @@ function createWebSocketServer(params: {
     undefined,
     undefined,
     undefined,
+    undefined,
     params.providerUsageService,
   );
 }

--- a/packages/server/src/server/websocket-server.provider-rename.test.ts
+++ b/packages/server/src/server/websocket-server.provider-rename.test.ts
@@ -9,10 +9,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentManager } from "./agent/agent-manager.js";
 import { AgentStorage, type StoredAgentRecord } from "./agent/agent-storage.js";
 import type { CheckoutDiffManager } from "./checkout-diff-manager.js";
-import type { FileBackedChatService } from "./chat/chat-service.js";
 import { DaemonConfigStore } from "./daemon-config-store.js";
 import type { DownloadTokenStore } from "./file-download/token-store.js";
-import type { LoopService } from "./loop-service.js";
 import type { ScheduleService } from "./schedule/service.js";
 import { createStub } from "./test-utils/class-mocks.js";
 import { createProviderSnapshotManagerStub } from "./test-utils/session-stubs.js";
@@ -98,8 +96,6 @@ function createWebSocketServer(params: {
     undefined,
     undefined,
     undefined,
-    createStub<FileBackedChatService>({}),
-    createStub<LoopService>({}),
     createStub<ScheduleService>({}),
     createStub<CheckoutDiffManager>({
       subscribe: () => {},

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -650,6 +650,7 @@ export class VoiceAssistantWebSocketServer {
     pluginRuntime?: SessionOptions["pluginRuntime"],
     orchestrationSkills?: SessionOptions["orchestrationSkills"],
     workspaceLabelService?: WorkspaceLabelService,
+    providerUsageService?: ProviderUsageService,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.workspaceSetupRuntime = workspaceSetupRuntime;
@@ -710,6 +711,8 @@ export class VoiceAssistantWebSocketServer {
       this.speech?.onReadinessChange((snapshot) => {
         this.publishSpeechReadiness(snapshot);
       }) ?? null;
+    this.providerUsageService =
+      providerUsageService ?? new ProviderUsageService({ logger: this.logger });
     const unsubscribeProviderConfig = attachMutableProviderConfigOwner({
       store: this.daemonConfigStore,
       providerSnapshotManager: this.providerSnapshotManager,
@@ -735,11 +738,6 @@ export class VoiceAssistantWebSocketServer {
       void this.broadcastAgentAttention(params).catch((err) => {
         this.logger.warn({ err, agentId: params.agentId }, "Failed to broadcast agent attention");
       });
-    });
-
-    this.providerUsageService = new ProviderUsageService({
-      logger: this.logger,
-      providerConfigs: this.daemonConfigStore.get().providers,
     });
 
     this.wss = this.createWebSocketServer(server, wsConfig, auth);

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -14,7 +14,11 @@ import type { ProjectRegistry, WorkspaceRegistry } from "./workspace-registry.js
 import type { ProjectUpdate } from "./workspace-reconciliation-service.js";
 import type { ScheduleService } from "./schedule/service.js";
 import type { CheckoutDiffManager, CheckoutDiffMetrics } from "./checkout-diff-manager.js";
-import type { DaemonConfigStore, MutableDaemonConfig } from "./daemon-config-store.js";
+import type {
+  DaemonConfigStore,
+  MutableDaemonConfig,
+  ProviderRename,
+} from "./daemon-config-store.js";
 import {
   type ServerInfoStatusPayload,
   type SessionOutboundMessage,
@@ -718,9 +722,15 @@ export class VoiceAssistantWebSocketServer {
       providerSnapshotManager: this.providerSnapshotManager,
       updateProviderRegistry: (state) => this.agentManager.updateProviderRegistry(state),
     });
-    const unsubscribeChange = this.daemonConfigStore.onChange((config) => {
+    const unsubscribeChange = this.daemonConfigStore.onChange((config, details) => {
+      // Live agents move first: the registry already knows the new id, and repointing them
+      // before storage means a persistence flush can't write the old id back.
+      for (const rename of details.renamedProviders) {
+        this.agentManager.renameProviderOnLiveAgents(rename.from, rename.to);
+      }
       this.providerUsageService.updateProviderConfigs(config.providers);
       this.broadcastDaemonConfigChanged(config);
+      void this.migrateRenamedProviders(details.renamedProviders, config);
     });
     this.unsubscribeDaemonConfigChange = () => {
       unsubscribeProviderConfig();
@@ -1748,6 +1758,8 @@ export class VoiceAssistantWebSocketServer {
         providerRemoval: true,
         // COMPAT(providerConfigReplace): added in v0.2.X, remove after 2027-02-02 when old daemons are unsupported.
         providerConfigReplace: true,
+        // COMPAT(providerConfigRename): added in v0.2.X, remove after 2027-02-02 when old daemons are unsupported.
+        providerConfigRename: true,
         // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
         importSessionWorkspaceTarget: true,
         // COMPAT(importSessionSearch): added in v0.7.3, remove gate after 2027-03-02.
@@ -1802,6 +1814,35 @@ export class VoiceAssistantWebSocketServer {
   private broadcastCapabilitiesUpdate(): void {
     for (const connection of new Set(this.sessions.values())) {
       this.sendToConnection(connection, this.createServerInfoMessage(connection.session));
+    }
+  }
+
+  /**
+   * Storage migration is async, so it runs after the config broadcast. Clients get a second
+   * `daemon_config_changed` once records have moved, which is what makes them refetch the
+   * agent list and see the migrated agents under the new provider id.
+   */
+  private async migrateRenamedProviders(
+    renames: readonly ProviderRename[],
+    config: MutableDaemonConfig,
+  ): Promise<void> {
+    if (renames.length === 0) {
+      return;
+    }
+    let migratedAny = false;
+    for (const rename of renames) {
+      try {
+        const migrated = await this.agentStorage.renameProvider(rename.from, rename.to);
+        migratedAny ||= migrated.length > 0;
+      } catch (err) {
+        this.logger.error(
+          { err, fromProviderId: rename.from, toProviderId: rename.to },
+          "Failed to migrate agent records for renamed provider",
+        );
+      }
+    }
+    if (migratedAny) {
+      this.broadcastDaemonConfigChanged(config);
     }
   }
 

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -716,6 +716,7 @@ export class VoiceAssistantWebSocketServer {
       updateProviderRegistry: (state) => this.agentManager.updateProviderRegistry(state),
     });
     const unsubscribeChange = this.daemonConfigStore.onChange((config) => {
+      this.providerUsageService.updateProviderConfigs(config.providers);
       this.broadcastDaemonConfigChanged(config);
     });
     this.unsubscribeDaemonConfigChange = () => {
@@ -738,6 +739,7 @@ export class VoiceAssistantWebSocketServer {
 
     this.providerUsageService = new ProviderUsageService({
       logger: this.logger,
+      providerConfigs: this.daemonConfigStore.get().providers,
     });
 
     this.wss = this.createWebSocketServer(server, wsConfig, auth);
@@ -1746,6 +1748,8 @@ export class VoiceAssistantWebSocketServer {
         commitBaseClassification: true,
         // COMPAT(providerRemoval): added in v0.1.105, drop the gate when floor >= v0.1.105.
         providerRemoval: true,
+        // COMPAT(providerConfigReplace): added in v0.2.X, remove after 2027-02-02 when old daemons are unsupported.
+        providerConfigReplace: true,
         // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
         importSessionWorkspaceTarget: true,
         // COMPAT(importSessionSearch): added in v0.7.3, remove gate after 2027-03-02.

--- a/packages/server/src/services/quota-fetcher/manifest.ts
+++ b/packages/server/src/services/quota-fetcher/manifest.ts
@@ -1,3 +1,4 @@
+import type { MutableDaemonConfig } from "@getpaseo/protocol/messages";
 import type {
   ProviderUsageFetcher,
   ProviderUsageFetcherFactoryOptions,
@@ -11,6 +12,7 @@ import { GrokQuotaProvider } from "./providers/grok.js";
 import { KimiQuotaProvider } from "./providers/kimi.js";
 import { MiniMaxQuotaProvider } from "./providers/minimax.js";
 import { ZaiQuotaProvider } from "./providers/zai.js";
+import { unavailableUsage } from "./usage.js";
 
 export const PROVIDER_USAGE_FETCHERS: readonly ProviderUsageFetcherManifestEntry[] = [
   {
@@ -57,6 +59,80 @@ export const PROVIDER_USAGE_FETCHERS: readonly ProviderUsageFetcherManifestEntry
 
 export function createProviderUsageFetchers(
   options: ProviderUsageFetcherFactoryOptions,
+  providers: MutableDaemonConfig["providers"] = {},
 ): ProviderUsageFetcher[] {
-  return PROVIDER_USAGE_FETCHERS.map((entry) => entry.create(options));
+  const fetchers: ProviderUsageFetcher[] = [];
+  for (const entry of PROVIDER_USAGE_FETCHERS) {
+    fetchers.push(entry.create(options));
+    for (const [providerId, providerConfig] of Object.entries(providers)) {
+      if (providerConfig.extends === entry.providerId) {
+        fetchers.push(createProviderAccountUsageFetcher(options, providerId, providerConfig));
+      }
+    }
+  }
+  return fetchers;
+}
+
+function providerEnvironment(providerConfig: Record<string, unknown>): NodeJS.ProcessEnv {
+  const env = providerConfig.env;
+  if (!env || typeof env !== "object" || Array.isArray(env)) return {};
+  return Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+function createProviderAccountUsageFetcher(
+  options: ProviderUsageFetcherFactoryOptions,
+  providerId: string,
+  providerConfig: MutableDaemonConfig["providers"][string],
+): ProviderUsageFetcher {
+  const baseProviderId = String(providerConfig.extends);
+  const displayName =
+    typeof providerConfig.label === "string" && providerConfig.label.trim()
+      ? providerConfig.label.trim()
+      : providerId;
+  const env = providerEnvironment(providerConfig);
+  let baseFetcher: ProviderUsageFetcher | null = null;
+
+  if (baseProviderId === "claude") {
+    const claudeHome = env["CLAUDE_CONFIG_DIR"] || env["CLAUDE_HOME"];
+    if (claudeHome) {
+      baseFetcher = new ClaudeQuotaProvider({
+        logger: options.logger,
+        fetch: options.fetch,
+        claudeHome,
+        claudeKeychainReader: async () => null,
+      });
+    }
+  } else if (baseProviderId === "codex") {
+    const codexHome = env["CODEX_HOME"];
+    if (codexHome) {
+      baseFetcher = new CodexQuotaProvider({
+        logger: options.logger,
+        fetch: options.fetch,
+        codexHome,
+        includeDefaultAuthPaths: false,
+      });
+    }
+  } else if (baseProviderId === "copilot") {
+    baseFetcher = new CopilotQuotaProvider({
+      logger: options.logger,
+      fetch: options.fetch,
+      env,
+      readCliToken: async () => null,
+    });
+  }
+
+  return {
+    providerId,
+    baseProviderId,
+    displayName,
+    fetchUsage: async () => {
+      if (!baseFetcher) {
+        return unavailableUsage({ providerId, baseProviderId, displayName });
+      }
+      const usage = await baseFetcher.fetchUsage();
+      return { ...usage, providerId, baseProviderId, displayName };
+    },
+  };
 }

--- a/packages/server/src/services/quota-fetcher/provider.ts
+++ b/packages/server/src/services/quota-fetcher/provider.ts
@@ -5,6 +5,7 @@ export type ProviderApiFetch = typeof fetch;
 
 export interface ProviderUsageFetcher {
   readonly providerId: string;
+  readonly baseProviderId?: string;
   readonly displayName: string;
   fetchUsage(): Promise<ProviderUsage>;
 }

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -350,7 +350,10 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   constructor(options: ClaudeQuotaProviderOptions) {
     this.logger = options.logger.child({ module: "claude-quota-provider" });
     this.claudeHome =
-      options.claudeHome || process.env["CLAUDE_HOME"] || join(homedir(), ".claude");
+      options.claudeHome ||
+      process.env["CLAUDE_CONFIG_DIR"] ||
+      process.env["CLAUDE_HOME"] ||
+      join(homedir(), ".claude");
     this.readKeychainCredentials = options.claudeKeychainReader ?? readClaudeKeychainCredentials;
     this.platform = options.platform ?? process.platform;
     this.fetchApi = options.fetch ?? fetch;

--- a/packages/server/src/services/quota-fetcher/providers/codex.ts
+++ b/packages/server/src/services/quota-fetcher/providers/codex.ts
@@ -63,6 +63,7 @@ type CodexUsageResponse = z.infer<typeof CodexUsageResponseSchema>;
 interface CodexQuotaProviderOptions {
   logger: Logger;
   codexHome?: string;
+  includeDefaultAuthPaths?: boolean;
   fetch?: ProviderApiFetch;
 }
 
@@ -81,10 +82,12 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
   readonly displayName = "Codex";
 
   private readonly codexHome: string;
+  private readonly includeDefaultAuthPaths: boolean;
   private readonly fetchApi: ProviderApiFetch;
 
   constructor(options: CodexQuotaProviderOptions) {
     this.codexHome = options.codexHome || process.env["CODEX_HOME"] || join(homedir(), ".codex");
+    this.includeDefaultAuthPaths = options.includeDefaultAuthPaths ?? true;
     this.fetchApi = options.fetch ?? fetch;
   }
 
@@ -171,8 +174,10 @@ export class CodexQuotaProvider implements ProviderUsageFetcher {
 
   private async readCodexAuth(): Promise<CodexAuth | null> {
     const candidates = [
-      ...(process.env["CODEX_HOME"] ? [join(process.env["CODEX_HOME"], "auth.json")] : []),
-      join(homedir(), ".config", "codex", "auth.json"),
+      ...(this.includeDefaultAuthPaths && process.env["CODEX_HOME"]
+        ? [join(process.env["CODEX_HOME"], "auth.json")]
+        : []),
+      ...(this.includeDefaultAuthPaths ? [join(homedir(), ".config", "codex", "auth.json")] : []),
       join(this.codexHome, "auth.json"),
     ];
     for (const path of candidates) {

--- a/packages/server/src/services/quota-fetcher/providers/copilot.ts
+++ b/packages/server/src/services/quota-fetcher/providers/copilot.ts
@@ -15,6 +15,8 @@ const CopilotUsageResponseSchema = z.object({
 interface CopilotQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+  env?: NodeJS.ProcessEnv;
+  readCliToken?: () => Promise<string | null>;
 }
 
 async function readGithubCliToken(): Promise<string | null> {
@@ -43,18 +45,22 @@ export class CopilotQuotaProvider implements ProviderUsageFetcher {
 
   private readonly logger: Logger;
   private readonly fetchApi: ProviderApiFetch;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly readCliToken: () => Promise<string | null>;
 
   constructor(options: CopilotQuotaProviderOptions) {
     this.logger = options.logger;
     this.fetchApi = options.fetch ?? fetch;
+    this.env = options.env ?? process.env;
+    this.readCliToken = options.readCliToken ?? readGithubCliToken;
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
     const token =
-      process.env["COPILOT_TOKEN"] ||
-      process.env["GITHUB_TOKEN"] ||
-      process.env["GITHUB_PAT"] ||
-      (await readGithubCliToken());
+      this.env["COPILOT_TOKEN"] ||
+      this.env["GITHUB_TOKEN"] ||
+      this.env["GITHUB_PAT"] ||
+      (await this.readCliToken());
 
     if (!token) return unavailableUsage(this);
 

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -14,6 +14,7 @@ import { GrokQuotaProvider } from "./providers/grok.js";
 import { KimiQuotaProvider } from "./providers/kimi.js";
 import { MiniMaxQuotaProvider } from "./providers/minimax.js";
 import { ZaiQuotaProvider } from "./providers/zai.js";
+import { createProviderUsageFetchers } from "./manifest.js";
 import { ProviderUsageService } from "./service.js";
 
 function writeClaudeCredentials(
@@ -343,6 +344,58 @@ describe("ProviderUsageService", () => {
           windows: [{ id: "weekly", label: "Weekly", usedPct: 29 }],
         },
       ],
+    });
+  });
+
+  it("rebuilds account fetchers and invalidates cached usage when provider config changes", async () => {
+    const service = new ProviderUsageService({
+      logger: createLogger(),
+      now: () => Date.parse("2026-06-19T00:00:00.000Z"),
+      fetcherFactory: (providers) =>
+        Object.keys(providers).map((providerId) =>
+          usageFetcher({
+            providerId,
+            displayName: providerId,
+            status: "available",
+            planLabel: null,
+            windows: [],
+          }),
+        ),
+      providerConfigs: { claude: {} },
+    });
+
+    expect((await service.listUsage()).providers.map((provider) => provider.providerId)).toEqual([
+      "claude",
+    ]);
+    service.updateProviderConfigs({ "claude-work": { extends: "claude" } });
+    expect((await service.listUsage()).providers.map((provider) => provider.providerId)).toEqual([
+      "claude-work",
+    ]);
+  });
+
+  it("groups configured accounts after their base usage provider", async () => {
+    const fetchers = createProviderUsageFetchers(
+      { logger: createLogger() },
+      {
+        "codex-work": { extends: "codex", label: "Codex (Work)", env: {} },
+        "claude-work": { extends: "claude", label: "Claude (Work)", env: {} },
+        "opencode-work": { extends: "opencode", label: "OpenCode (Work)", env: {} },
+      },
+    );
+
+    expect(fetchers.map((fetcher) => fetcher.providerId).slice(0, 6)).toEqual([
+      "claude",
+      "claude-work",
+      "codex",
+      "codex-work",
+      "copilot",
+      "cursor",
+    ]);
+    await expect(fetchers[1]?.fetchUsage()).resolves.toMatchObject({
+      providerId: "claude-work",
+      baseProviderId: "claude",
+      displayName: "Claude (Work)",
+      status: "unavailable",
     });
   });
 });

--- a/packages/server/src/services/quota-fetcher/service.ts
+++ b/packages/server/src/services/quota-fetcher/service.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "pino";
+import type { MutableDaemonConfig } from "@getpaseo/protocol/messages";
 import type { ProviderUsage } from "../../server/messages.js";
 import { createProviderUsageFetchers } from "./manifest.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "./provider.js";
@@ -8,6 +9,8 @@ export interface ProviderUsageServiceOptions {
   logger: Logger;
   fetchers?: ProviderUsageFetcher[];
   fetch?: ProviderApiFetch;
+  providerConfigs?: MutableDaemonConfig["providers"];
+  fetcherFactory?: (providers: MutableDaemonConfig["providers"]) => ProviderUsageFetcher[];
   cacheTtlMs?: number;
   now?: () => number;
 }
@@ -21,22 +24,37 @@ const DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export class ProviderUsageService {
   private readonly logger: Logger;
-  private readonly fetchers: ProviderUsageFetcher[];
+  private fetchers: ProviderUsageFetcher[];
+  private readonly rebuildFetchers:
+    | ((providers: MutableDaemonConfig["providers"]) => ProviderUsageFetcher[])
+    | null;
   private readonly cacheTtlMs: number;
   private readonly now: () => number;
   private cached: { fetchedAtMs: number; result: ProviderUsageListResult } | null = null;
   private inFlight: Promise<ProviderUsageListResult> | null = null;
+  private revision = 0;
 
   constructor(options: ProviderUsageServiceOptions) {
     this.logger = options.logger.child({ module: "provider-usage-service" });
-    this.fetchers =
-      options.fetchers ??
-      createProviderUsageFetchers({
-        logger: this.logger,
-        fetch: options.fetch,
-      });
+    const factoryOptions = {
+      logger: this.logger,
+      fetch: options.fetch,
+    };
+    this.rebuildFetchers = options.fetchers
+      ? null
+      : (options.fetcherFactory ??
+        ((providers) => createProviderUsageFetchers(factoryOptions, providers)));
+    this.fetchers = options.fetchers ?? this.rebuildFetchers?.(options.providerConfigs ?? {}) ?? [];
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS;
     this.now = options.now ?? Date.now;
+  }
+
+  updateProviderConfigs(providers: MutableDaemonConfig["providers"]): void {
+    if (!this.rebuildFetchers) return;
+    this.fetchers = this.rebuildFetchers(providers);
+    this.revision += 1;
+    this.cached = null;
+    this.inFlight = null;
   }
 
   async listUsage(options?: { forceRefresh?: boolean }): Promise<ProviderUsageListResult> {
@@ -53,7 +71,7 @@ export class ProviderUsageService {
       return this.inFlight;
     }
 
-    const request = this.fetchFreshUsage(nowMs);
+    const request = this.fetchFreshUsage(nowMs, this.revision);
     this.inFlight = request;
     try {
       return await request;
@@ -64,10 +82,11 @@ export class ProviderUsageService {
     }
   }
 
-  private async fetchFreshUsage(nowMs: number): Promise<ProviderUsageListResult> {
-    const settled = await Promise.allSettled(this.fetchers.map((fetcher) => fetcher.fetchUsage()));
+  private async fetchFreshUsage(nowMs: number, revision: number): Promise<ProviderUsageListResult> {
+    const fetchers = this.fetchers;
+    const settled = await Promise.allSettled(fetchers.map((fetcher) => fetcher.fetchUsage()));
     const providers = settled.map((result, index) => {
-      const fetcher = this.fetchers[index];
+      const fetcher = fetchers[index];
       if (result.status === "fulfilled") {
         return result.value;
       }
@@ -77,13 +96,16 @@ export class ProviderUsageService {
       );
       return unavailableUsage({
         providerId: fetcher.providerId,
+        baseProviderId: fetcher.baseProviderId,
         displayName: fetcher.displayName,
         error: result.reason instanceof Error ? result.reason.message : String(result.reason),
       });
     });
 
     const result = { fetchedAt: new Date(nowMs).toISOString(), providers };
-    this.cached = { fetchedAtMs: nowMs, result };
+    if (revision === this.revision) {
+      this.cached = { fetchedAtMs: nowMs, result };
+    }
     return result;
   }
 }

--- a/packages/server/src/services/quota-fetcher/usage.ts
+++ b/packages/server/src/services/quota-fetcher/usage.ts
@@ -32,11 +32,13 @@ export function fetchProviderApi(
 
 export function unavailableUsage(provider: {
   providerId: string;
+  baseProviderId?: string;
   displayName: string;
   error?: string | null;
 }): ProviderUsage {
   return {
     providerId: provider.providerId,
+    ...(provider.baseProviderId ? { baseProviderId: provider.baseProviderId } : {}),
     displayName: provider.displayName,
     status: provider.error ? "error" : "unavailable",
     planLabel: null,


### PR DESCRIPTION
## Problem

`docs/custom-providers.md` documents running multiple accounts of the same provider as separate entries extending one built-in provider. The daemon already accepted these entries, and they appeared in provider pickers, but creating or editing one required hand-editing `config.json`.

## App

The actions menu on a built-in provider row gains **Add account**, opening a form for name, provider ID, description, and environment variables. A custom account row gains **Edit account** when the connected daemon advertises exact provider replacement.

- Provider IDs auto-derive from the name until edited, remain editable in edit mode, and validate format plus collisions against existing and reserved IDs.
- Environment variables use dynamic key/value rows with duplicate and empty-key validation. Values preserve whitespace.
- Editing starts from the complete persisted provider definition, preserves fields the form does not own (commands, models, enabled state), and removes deleted descriptions or environment keys exactly.
- Account rows inherit the built-in provider icon and appear immediately after their base provider.
- Account usage cards also inherit the base icon and use the same grouping.
- The form uses the non-React model from `docs/forms.md`; validation and patch construction are unit-tested independently of the sheet.
- Accounts are offered for `claude`, `codex`, `copilot`, `opencode`, `pi`, and `omp`. `acp` remains catalog-managed.

`docs/glossary.md` reserves "profile" for `HostProfile`, so the UI calls these **accounts**. The config concept is unchanged.

## Daemon and compatibility

Editing adds optional `replaceProviders` semantics to the existing daemon config patch. Replacement clears the old provider override before applying the new definition, so deleted environment keys cannot survive the existing deep merge. Renaming writes the new ID and removes the old ID in one patch. The app gates Edit on the optional `providerConfigReplace` server feature; older daemons continue to support account creation and removal unchanged.

The daemon now retains complete custom provider definitions in its mutable startup config, updates the live provider registry after exact replacement, and rebuilds provider usage fetchers when provider config changes.

Usage entries are created for custom Claude, Codex, and Copilot accounts and grouped after their base entry. Each account uses only its configured credential source (`CLAUDE_CONFIG_DIR` / `CLAUDE_HOME`, `CODEX_HOME`, or a Copilot token) and never falls back to the built-in account's credentials. Accounts without a supported quota credential still appear as unavailable. The optional `baseProviderId` usage field lets new clients reuse icons while old clients ignore it safely.

## CLI

```sh
paseo provider add claude-work --extends claude --label "Claude (Work)" \
  --env ANTHROPIC_API_KEY=sk-ant-... --model claude-sonnet-5="Sonnet 5"
paseo provider rm claude-work
```

`--env`, `--model`, and `--command` are repeatable; the first model becomes the default. Validation mirrors `ProviderOverridesSchema` client-side, including whitespace-only model IDs and labels, and both commands refuse built-in IDs. `provider ls` gains a `SOURCE` column distinguishing built-in from custom.

## Tests

- `provider-account-form-model.test.ts` covers creation and editing, including exact environment deletion, preserved out-of-form fields, collisions, and provider-ID rename patches.
- `providers-section.test.tsx` covers grouping, inherited icons, the compatibility gate, and opening an existing account for editing.
- `daemon-config-store.test.ts`, `provider-snapshot-manager.test.ts`, and `bootstrap.test.ts` cover exact persisted/live replacement and full custom config after restart.
- `quota-fetcher/service.test.ts` covers dynamic cache invalidation, grouping, and account identity.
- `provider/add.test.ts` and `tests/15-provider.test.ts` cover CLI validation plus real-daemon add/list/remove.
- `provider-account-create.spec.ts` drives create, reopen, edit, environment replacement, and ID rename through the browser UI.

Repo-wide typecheck, lint, and format checks pass. All changed focused unit files pass locally.

## QA notes

The Playwright browser spec was not executed locally because the isolated worker daemon does not become connectable in this sandbox; the untouched baseline `acp-provider-catalog.spec.ts` fails with the same fixture timeout. Browser and CLI integration coverage are deferred to CI.

Environment values render as plain text. `config.json` stores them in plaintext; a secure-entry toggle can be a separate UI follow-up.
