### PR TITLE
Add turn minimap navigation

### DIFF
--- a/packages/app/e2e/browser/agent-stream-ui.spec.ts
+++ b/packages/app/e2e/browser/agent-stream-ui.spec.ts
@@ -1,3 +1,4 @@
+import type { Locator } from "@playwright/test";
 import { test, expect } from "../support/fixtures";
 import {
   awaitAssistantMessage,
@@ -27,6 +28,10 @@ import {
 
 const SCROLL_AWAY_MIN_SCROLLABLE_DISTANCE = 360;
 
+async function readScrollTop(locator: Locator): Promise<number> {
+  return locator.evaluate((element) => element.scrollTop);
+}
+
 test.describe("Agent stream UI", () => {
   test("keeps running agent chrome after page refresh", async ({ page }) => {
     const title = "Running agent refresh";
@@ -43,6 +48,44 @@ test.describe("Agent stream UI", () => {
       await page.reload();
 
       await expectRunningAgentChrome(page, title);
+    } finally {
+      await agent.cleanup();
+    }
+  });
+
+  test("previews and navigates turns from the wide-layout minimap", async ({ page }) => {
+    const agent = await seedMockAgentWorkspace({
+      repoPrefix: "turn-minimap-",
+      title: "Turn minimap",
+    });
+    const prompts = [
+      "First minimap turn: emit 80 coalesced agent stream updates.",
+      "Second minimap turn: emit 80 coalesced agent stream updates.",
+      "Third minimap turn: emit 80 coalesced agent stream updates.",
+    ];
+
+    try {
+      for (const prompt of prompts) {
+        await agent.client.sendAgentMessage(agent.agentId, prompt);
+        await agent.client.waitForFinish(agent.agentId, 15_000);
+      }
+
+      await page.setViewportSize({ width: 1_400, height: 720 });
+      await openAgentRoute(page, agent);
+      await expectComposerVisible(page);
+
+      const minimap = page.getByTestId("turn-minimap");
+      const rail = page.getByTestId("turn-minimap-rail");
+      await expect(minimap).toBeVisible();
+      await rail.hover({ position: { x: 4, y: 1 } });
+      await expect(page.getByTestId("turn-minimap-preview")).toContainText(prompts[0]!);
+
+      const scroll = page.locator('[data-testid="agent-chat-scroll"]:visible').first();
+      await rail.click({ position: { x: 4, y: 1 } });
+      await expect.poll(() => readScrollTop(scroll)).toBeLessThan(100);
+
+      await page.setViewportSize({ width: 900, height: 720 });
+      await expect(minimap).toHaveCount(0);
     } finally {
       await agent.cleanup();
     }

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -30,6 +30,8 @@ import {
   createHistoryStartSettleScheduler,
   type HistoryStartSettleScheduler,
 } from "./history-start-settle-scheduler";
+import { TurnMinimap } from "./turn-minimap-view.web";
+import { deriveTurnMinimapItems, type TurnMinimapItem } from "./turn-minimap";
 
 interface CreateWebStreamStrategyInput {
   isMobileBreakpoint: boolean;
@@ -77,6 +79,24 @@ const mountedHistoryRowStyle: CSSProperties = {
   flexDirection: "column",
   width: "100%",
 };
+
+const viewportFrameStyle: CSSProperties = {
+  position: "relative",
+  display: "flex",
+  flex: 1,
+  minHeight: 0,
+  width: "100%",
+};
+
+function setTurnMarkerInView(marker: HTMLSpanElement | undefined, inView: boolean): void {
+  if (!marker) {
+    return;
+  }
+  marker.style.backgroundColor = inView
+    ? "var(--colors-foreground)"
+    : "var(--colors-foreground-extra-muted)";
+  marker.style.opacity = inView ? "0.9" : "0.5";
+}
 
 function isScrollContainerNearBottom(
   scrollContainer: Pick<HTMLElement, "scrollTop" | "clientHeight" | "scrollHeight">,
@@ -155,8 +175,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   } = props;
   const scrollContainerRef = useRef<HTMLElement | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
+  const [scrollContainerElement, setScrollContainerElement] = useState<HTMLElement | null>(null);
   const handleScrollContainerRef = useCallback((node: HTMLElement | null) => {
     scrollContainerRef.current = node;
+    setScrollContainerElement(node);
   }, []);
   const handleContentRef = useCallback((node: HTMLElement | null) => {
     contentRef.current = node;
@@ -174,6 +196,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const pendingAutoScrollTimeoutRef = useRef<number | null>(null);
   const pendingVirtualRowMeasureFramesRef = useRef(new Map<Element, number>());
+  const visibleTurnIdsRef = useRef<ReadonlySet<string>>(new Set());
   const historyStartReadyRef = useRef(false);
   const [historyStartPaginationState, setHistoryStartPaginationState] = useState(
     createHistoryStartPaginationState,
@@ -182,6 +205,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const historyStartPrependAnchorRef = useRef<HistoryStartPrependAnchor | null>(null);
   const historyStartPrependAnchorActiveRef = useRef(false);
   const historyStartSettleSchedulerRef = useRef<HistoryStartSettleScheduler | null>(null);
+  const [turnMarkerMap] = useState(() => new Map<string, HTMLSpanElement>());
   const shouldUseVirtualizer = segments.historyVirtualized.length > 0;
   const {
     renderHistoryVirtualizedRow,
@@ -189,6 +213,11 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     renderLiveHeadRow,
     renderLiveAuxiliary,
   } = renderers;
+  const orderedItems = useMemo(
+    () => [...segments.historyVirtualized, ...segments.historyMounted, ...segments.liveHead],
+    [segments.historyMounted, segments.historyVirtualized, segments.liveHead],
+  );
+  const turnMinimapItems = useMemo(() => deriveTurnMinimapItems(orderedItems), [orderedItems]);
 
   followOutputRef.current = followOutput;
 
@@ -476,6 +505,37 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     syncNearBottom(scrollContainer, onNearBottomChange);
   }, [onNearBottomChange]);
 
+  const updateTurnMarkers = useCallback(() => {
+    const scrollContainer = scrollContainerRef.current;
+    const content = contentRef.current;
+    if (!scrollContainer || !content) {
+      return;
+    }
+
+    const viewportRect = scrollContainer.getBoundingClientRect();
+    const nextVisibleIds = new Set<string>();
+    const turnRows = content.querySelectorAll<HTMLElement>("[data-turn-minimap-row]");
+    for (const row of turnRows) {
+      const turnId = row.dataset.turnMinimapRow;
+      if (!turnId) {
+        continue;
+      }
+      const rowRect = row.getBoundingClientRect();
+      const inView = rowRect.top < viewportRect.bottom && rowRect.bottom > viewportRect.top;
+      if (inView) {
+        nextVisibleIds.add(turnId);
+      }
+      setTurnMarkerInView(turnMarkerMap.get(turnId), inView);
+    }
+
+    for (const turnId of visibleTurnIdsRef.current) {
+      if (!nextVisibleIds.has(turnId)) {
+        setTurnMarkerInView(turnMarkerMap.get(turnId), false);
+      }
+    }
+    visibleTurnIdsRef.current = nextVisibleIds;
+  }, [turnMarkerMap]);
+
   const handleDomScroll = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) {
@@ -508,13 +568,20 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
     lastKnownScrollTopRef.current = currentScrollTop;
     updateScrollMetrics();
+    updateTurnMarkers();
     evaluateHistoryStart();
   }, [
     cancelPendingStickToBottom,
     evaluateHistoryStart,
     rearmHistoryStartFromUserIntent,
     updateScrollMetrics,
+    updateTurnMarkers,
   ]);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(updateTurnMarkers);
+    return () => window.cancelAnimationFrame(frame);
+  }, [turnMinimapItems, updateTurnMarkers, virtualRows]);
 
   useEffect(() => {
     const initialHistoryStartState = createHistoryStartPaginationState();
@@ -719,6 +786,36 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     };
   }, [cancelPendingStickToBottom, forceStickToBottom, scheduleStickToBottom, viewportRef]);
 
+  const selectTurn = useCallback(
+    (item: TurnMinimapItem) => {
+      const scrollContainer = scrollContainerRef.current;
+      const content = contentRef.current;
+      if (!scrollContainer || !content) {
+        return;
+      }
+
+      cancelPendingStickToBottom();
+      setFollowOutput(false);
+      if (item.rowIndex < segments.historyVirtualized.length) {
+        rowVirtualizer.scrollToIndex(item.rowIndex, { align: "start", behavior: "smooth" });
+        return;
+      }
+
+      const rows = content.querySelectorAll<HTMLElement>("[data-turn-minimap-row]");
+      const target = Array.from(rows).find((row) => row.dataset.turnMinimapRow === item.id);
+      if (!target) {
+        return;
+      }
+      const viewportRect = scrollContainer.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      scrollContainer.scrollTo({
+        top: scrollContainer.scrollTop + targetRect.top - viewportRect.top - 24,
+        behavior: "smooth",
+      });
+    },
+    [cancelPendingStickToBottom, rowVirtualizer, segments.historyVirtualized.length],
+  );
+
   const contentContainerStyle = useMemo((): CSSProperties => {
     return {
       display: "flex",
@@ -761,16 +858,28 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
   const mountedHistoryRows = useMemo(() => {
     return segments.historyMounted.map((item, index) => (
-      <div key={item.id} data-history-row-id={item.id} style={mountedHistoryRowStyle}>
+      <div
+        key={item.id}
+        data-history-row-id={item.id}
+        data-turn-minimap-row={item.kind === "user_message" ? item.id : undefined}
+        style={mountedHistoryRowStyle}
+      >
         {renderHistoryMountedRow(item, index, segments.historyMounted)}
       </div>
     ));
   }, [renderHistoryMountedRow, segments.historyMounted]);
   const liveHeadRows = useMemo(() => {
     void liveHeadRowRevision;
-    return segments.liveHead.map((item, index) => (
-      <Fragment key={item.id}>{renderLiveHeadRow(item, index, segments.liveHead)}</Fragment>
-    ));
+    return segments.liveHead.map((item, index) => {
+      const row = renderLiveHeadRow(item, index, segments.liveHead);
+      return item.kind === "user_message" ? (
+        <div data-turn-minimap-row={item.id} key={item.id}>
+          {row}
+        </div>
+      ) : (
+        <Fragment key={item.id}>{row}</Fragment>
+      );
+    });
   }, [liveHeadRowRevision, renderLiveHeadRow, segments.liveHead]);
   const liveAuxiliary = useMemo(() => {
     return renderLiveAuxiliary();
@@ -794,40 +903,54 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     !liveAuxiliary;
 
   return (
-    <div
-      ref={handleScrollContainerRef}
-      data-testid="agent-chat-scroll"
-      id={`agent-chat-scroll-${shouldUseVirtualizer ? "web-dom-virtualized" : "web-dom-scroll"}`}
-      style={scrollContainerStyle}
-    >
-      <div ref={handleContentRef} style={contentContainerStyle}>
-        {historyStartSlot}
-        {shouldUseVirtualizer ? (
-          <div style={virtualRowsContainerStyle}>
-            {virtualRows.map((virtualRow) => {
-              const item = segments.historyVirtualized[virtualRow.index];
-              if (!item) {
-                return null;
-              }
-              return (
-                <div
-                  key={virtualRow.key}
-                  data-index={virtualRow.index}
-                  data-history-row-id={item.id}
-                  ref={measureVirtualizedRowElement}
-                  style={renderVirtualRowStyle(virtualRow.start)}
-                >
-                  {renderHistoryVirtualizedRow(item, virtualRow.index, segments.historyVirtualized)}
-                </div>
-              );
-            })}
-          </div>
-        ) : null}
-        {mountedHistoryRows}
-        {liveHeadRows}
-        {liveAuxiliary}
-        {shouldRenderEmpty ? listEmptyComponent : null}
+    <div style={viewportFrameStyle}>
+      <div
+        ref={handleScrollContainerRef}
+        data-testid="agent-chat-scroll"
+        id={`agent-chat-scroll-${shouldUseVirtualizer ? "web-dom-virtualized" : "web-dom-scroll"}`}
+        style={scrollContainerStyle}
+      >
+        <div ref={handleContentRef} style={contentContainerStyle}>
+          {historyStartSlot}
+          {shouldUseVirtualizer ? (
+            <div style={virtualRowsContainerStyle}>
+              {virtualRows.map((virtualRow) => {
+                const item = segments.historyVirtualized[virtualRow.index];
+                if (!item) {
+                  return null;
+                }
+                return (
+                  <div
+                    data-index={virtualRow.index}
+                    data-history-row-id={item.id}
+                    data-turn-minimap-row={item.kind === "user_message" ? item.id : undefined}
+                    key={virtualRow.key}
+                    ref={measureVirtualizedRowElement}
+                    style={renderVirtualRowStyle(virtualRow.start)}
+                  >
+                    {renderHistoryVirtualizedRow(
+                      item,
+                      virtualRow.index,
+                      segments.historyVirtualized,
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+          {mountedHistoryRows}
+          {liveHeadRows}
+          {liveAuxiliary}
+          {shouldRenderEmpty ? listEmptyComponent : null}
+        </div>
       </div>
+      <TurnMinimap
+        items={turnMinimapItems}
+        markerMap={turnMarkerMap}
+        viewportElement={scrollContainerElement}
+        onMarkersReady={updateTurnMarkers}
+        onSelect={selectTurn}
+      />
     </div>
   );
 }

--- a/packages/app/src/agent-stream/turn-minimap-view.web.tsx
+++ b/packages/app/src/agent-stream/turn-minimap-view.web.tsx
@@ -1,0 +1,392 @@
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import {
+  resolveTurnMinimapHeight,
+  resolveTurnMinimapIndexFromPointer,
+  resolveTurnMinimapTopPercent,
+  turnMinimapHasEnoughSpace,
+  TURN_MINIMAP_MIN_ITEMS,
+  type TurnMinimapItem,
+} from "./turn-minimap";
+
+const MINIMAP_WIDTH = 72;
+const RAIL_LEFT = 12;
+const HIT_STRIP_WIDTH = 40;
+const EXPANDED_HIT_STRIP_WIDTH = 352;
+const PREVIEW_LEFT = 32;
+const PREVIEW_WIDTH = 320;
+
+interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+interface TurnMinimapProps {
+  items: readonly TurnMinimapItem[];
+  markerMap: Map<string, HTMLSpanElement>;
+  viewportElement: HTMLElement | null;
+  onMarkersReady: () => void;
+  onSelect: (item: TurnMinimapItem) => void;
+}
+
+export function TurnMinimap({
+  items,
+  markerMap,
+  viewportElement,
+  onMarkersReady,
+  onSelect,
+}: TurnMinimapProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [hasFinePointer, setHasFinePointer] = useState(false);
+  const [viewportSize, setViewportSize] = useState<ViewportSize>({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const query = window.matchMedia("(hover: hover) and (pointer: fine)");
+    const update = () => setHasFinePointer(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    if (!viewportElement) {
+      setViewportSize({ width: 0, height: 0 });
+      return;
+    }
+
+    const measure = () => {
+      const rect = viewportElement.getBoundingClientRect();
+      setViewportSize((current) => {
+        if (current.width === rect.width && current.height === rect.height) {
+          return current;
+        }
+        return { width: rect.width, height: rect.height };
+      });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(viewportElement);
+    return () => observer.disconnect();
+  }, [viewportElement]);
+
+  const resolvedActiveIndex =
+    activeIndex !== null && activeIndex < items.length ? activeIndex : null;
+  const activeItem = resolvedActiveIndex === null ? null : (items[resolvedActiveIndex] ?? null);
+
+  const resolveIndexFromPointer = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      return resolveTurnMinimapIndexFromPointer({
+        itemCount: items.length,
+        railTop: rect.top,
+        railHeight: rect.height,
+        pointerY: event.clientY,
+      });
+    },
+    [items.length],
+  );
+
+  const moveActiveIndex = useCallback(
+    (delta: number) => {
+      setActiveIndex((current) => {
+        const base = current ?? 0;
+        return Math.max(0, Math.min(items.length - 1, base + delta));
+      });
+    },
+    [items.length],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        moveActiveIndex(1);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        moveActiveIndex(-1);
+        return;
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        setActiveIndex(0);
+        return;
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        setActiveIndex(items.length - 1);
+        return;
+      }
+      if ((event.key === "Enter" || event.key === " ") && activeItem) {
+        event.preventDefault();
+        onSelect(activeItem);
+      }
+    },
+    [activeItem, items.length, moveActiveIndex, onSelect],
+  );
+
+  const handleBlur = useCallback(() => setActiveIndex(null), []);
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (eventTargetIsPreview(event.target)) {
+        return;
+      }
+      const nextIndex = resolveIndexFromPointer(event);
+      const nextItem = nextIndex === null ? null : (items[nextIndex] ?? null);
+      if (nextItem) {
+        onSelect(nextItem);
+      }
+      event.currentTarget.blur();
+    },
+    [items, onSelect, resolveIndexFromPointer],
+  );
+  const handleFocus = useCallback(() => setActiveIndex((current) => current ?? 0), []);
+  const handleMouseDown = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    if (!eventTargetIsPreview(event.target)) {
+      event.preventDefault();
+    }
+  }, []);
+  const handleMouseLeave = useCallback(() => setActiveIndex(null), []);
+  const handleMouseMove = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => setActiveIndex(resolveIndexFromPointer(event)),
+    [resolveIndexFromPointer],
+  );
+  const handlePreviewMouseMove = useCallback((event: MouseEvent<HTMLSpanElement>) => {
+    event.stopPropagation();
+  }, []);
+
+  const hasEnoughSpace = turnMinimapHasEnoughSpace(viewportSize.width);
+  const railHeight = resolveTurnMinimapHeight(items.length, viewportSize.height);
+  const activeTopPercent =
+    resolvedActiveIndex === null
+      ? 0
+      : resolveTurnMinimapTopPercent(resolvedActiveIndex, items.length);
+  const activeTooltipTranslate = resolvePreviewTranslate(resolvedActiveIndex, items.length);
+  const railStyle = useMemo<CSSProperties>(
+    () => ({
+      ...railButtonStyle,
+      height: railHeight,
+      width: activeItem ? EXPANDED_HIT_STRIP_WIDTH : HIT_STRIP_WIDTH,
+    }),
+    [activeItem, railHeight],
+  );
+  const activePreviewStyle = useMemo<CSSProperties>(
+    () => ({
+      ...previewPositionStyle,
+      top: `${activeTopPercent}%`,
+      transform: `translateY(${activeTooltipTranslate})`,
+    }),
+    [activeTooltipTranslate, activeTopPercent],
+  );
+
+  useEffect(() => {
+    if (!hasFinePointer || !hasEnoughSpace || items.length < TURN_MINIMAP_MIN_ITEMS) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(onMarkersReady);
+    return () => window.cancelAnimationFrame(frame);
+  }, [hasEnoughSpace, hasFinePointer, items.length, onMarkersReady, viewportSize.height]);
+
+  if (!hasFinePointer || !hasEnoughSpace || items.length < TURN_MINIMAP_MIN_ITEMS) {
+    return null;
+  }
+
+  return (
+    <div data-testid="turn-minimap" style={minimapStyle}>
+      <button
+        aria-label={`Jump to turn: ${activeItem?.userText ?? "User message"}`}
+        data-testid="turn-minimap-rail"
+        onBlur={handleBlur}
+        onClick={handleClick}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
+        onMouseDown={handleMouseDown}
+        onMouseLeave={handleMouseLeave}
+        onMouseMove={handleMouseMove}
+        style={railStyle}
+        type="button"
+      >
+        <span aria-hidden="true" style={railLineStyle} />
+        {items.map((item, index) => {
+          const activeDistance =
+            resolvedActiveIndex === null ? null : Math.abs(index - resolvedActiveIndex);
+          return (
+            <TurnMinimapMarker
+              activeDistance={activeDistance}
+              item={item}
+              key={item.id}
+              markerMap={markerMap}
+              topPercent={resolveTurnMinimapTopPercent(index, items.length)}
+            />
+          );
+        })}
+        {activeItem ? (
+          <span
+            data-testid="turn-minimap-preview"
+            data-turn-minimap-preview
+            onMouseMove={handlePreviewMouseMove}
+            style={activePreviewStyle}
+          >
+            <span style={previewCardStyle}>
+              <span style={previewUserStyle}>{activeItem.userText ?? "User message"}</span>
+              {activeItem.assistantText ? (
+                <span style={previewAssistantStyle}>{activeItem.assistantText}</span>
+              ) : null}
+            </span>
+          </span>
+        ) : null}
+      </button>
+    </div>
+  );
+}
+
+const TurnMinimapMarker = memo(function TurnMinimapMarker({
+  activeDistance,
+  item,
+  markerMap,
+  topPercent,
+}: {
+  activeDistance: number | null;
+  item: TurnMinimapItem;
+  markerMap: Map<string, HTMLSpanElement>;
+  topPercent: number;
+}) {
+  const setMarkerRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (node) {
+        node.style.backgroundColor = "var(--colors-foreground-extra-muted)";
+        node.style.opacity = "0.5";
+        markerMap.set(item.id, node);
+      } else {
+        markerMap.delete(item.id);
+      }
+    },
+    [item.id, markerMap],
+  );
+  const style = useMemo<CSSProperties>(
+    () => ({
+      ...markerStyle,
+      top: `${topPercent}%`,
+      width: resolveMarkerWidth(activeDistance),
+    }),
+    [activeDistance, topPercent],
+  );
+
+  return <span aria-hidden="true" data-turn-minimap-marker ref={setMarkerRef} style={style} />;
+});
+
+function eventTargetIsPreview(target: EventTarget): boolean {
+  return target instanceof Element && target.closest("[data-turn-minimap-preview]") !== null;
+}
+
+function resolveMarkerWidth(activeDistance: number | null): number {
+  if (activeDistance === 0) return 24;
+  if (activeDistance === 1) return 16;
+  if (activeDistance === 2) return 10;
+  return 8;
+}
+
+function resolvePreviewTranslate(activeIndex: number | null, itemCount: number): string {
+  if (activeIndex === 0) return "0%";
+  if (activeIndex === itemCount - 1) return "-100%";
+  return "-50%";
+}
+
+const minimapStyle: CSSProperties = {
+  position: "absolute",
+  zIndex: 40,
+  top: 0,
+  bottom: 0,
+  left: 0,
+  width: MINIMAP_WIDTH,
+  pointerEvents: "none",
+};
+
+const railButtonStyle: CSSProperties = {
+  position: "absolute",
+  top: "50%",
+  left: RAIL_LEFT,
+  padding: 0,
+  border: 0,
+  transform: "translateY(-50%)",
+  overflow: "visible",
+  background: "transparent",
+  cursor: "pointer",
+  pointerEvents: "auto",
+  userSelect: "none",
+};
+
+const railLineStyle: CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: RAIL_LEFT,
+  width: 1,
+  height: "100%",
+  backgroundColor: "var(--colors-border)",
+  opacity: 0.2,
+};
+
+const markerStyle: CSSProperties = {
+  position: "absolute",
+  left: 0,
+  height: 2,
+  borderRadius: "var(--border-radius-full, 9999px)",
+  transform: "translateY(-50%)",
+  transition: "width 150ms ease, background-color 150ms ease, opacity 150ms ease",
+  pointerEvents: "none",
+};
+
+const previewPositionStyle: CSSProperties = {
+  position: "absolute",
+  left: PREVIEW_LEFT,
+  width: PREVIEW_WIDTH,
+  cursor: "text",
+  userSelect: "text",
+  pointerEvents: "auto",
+};
+
+const previewCardStyle: CSSProperties = {
+  display: "block",
+  padding: "var(--spacing-3, 12px)",
+  border: "1px solid var(--colors-border)",
+  borderRadius: "var(--border-radius-xl, 12px)",
+  backgroundColor: "var(--colors-popover)",
+  color: "var(--colors-popover-foreground)",
+  boxShadow: "0 10px 30px rgba(0, 0, 0, 0.2)",
+  textAlign: "left",
+};
+
+const previewUserStyle: CSSProperties = {
+  display: "block",
+  maxWidth: "100%",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  fontFamily: "var(--font-family-ui)",
+  fontSize: "var(--font-size-sm, 14px)",
+  fontWeight: 500,
+  lineHeight: "20px",
+};
+
+const previewAssistantStyle: CSSProperties = {
+  display: "-webkit-box",
+  marginTop: "var(--spacing-1, 4px)",
+  maxHeight: 60,
+  overflow: "hidden",
+  WebkitBoxOrient: "vertical",
+  WebkitLineClamp: 3,
+  color: "var(--colors-foreground-muted)",
+  fontFamily: "var(--font-family-ui)",
+  fontSize: "var(--font-size-sm, 14px)",
+  fontWeight: 400,
+  lineHeight: "20px",
+};

--- a/packages/app/src/agent-stream/turn-minimap.test.ts
+++ b/packages/app/src/agent-stream/turn-minimap.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { StreamItem } from "@/types/stream";
+import {
+  deriveTurnMinimapItems,
+  resolveTurnMinimapHeight,
+  resolveTurnMinimapIndexFromPointer,
+  resolveTurnMinimapTopPercent,
+  turnMinimapHasEnoughSpace,
+} from "./turn-minimap";
+
+function message(input: {
+  id: string;
+  kind: "user_message" | "assistant_message";
+  text: string;
+}): StreamItem {
+  return {
+    ...input,
+    timestamp: new Date("2026-08-01T00:00:00.000Z"),
+  };
+}
+
+describe("turn minimap", () => {
+  it("builds one preview per user turn with the final assistant response", () => {
+    const items = [
+      message({ id: "user-1", kind: "user_message", text: "  First\n prompt  " }),
+      message({ id: "assistant-1a", kind: "assistant_message", text: "Working" }),
+      message({ id: "assistant-1b", kind: "assistant_message", text: "Final first response" }),
+      message({ id: "user-2", kind: "user_message", text: "Second prompt" }),
+      message({ id: "assistant-2", kind: "assistant_message", text: "Second response" }),
+    ];
+
+    expect(deriveTurnMinimapItems(items)).toEqual([
+      {
+        id: "user-1",
+        rowIndex: 0,
+        userText: "First prompt",
+        assistantText: "Final first response",
+      },
+      {
+        id: "user-2",
+        rowIndex: 3,
+        userText: "Second prompt",
+        assistantText: "Second response",
+      },
+    ]);
+  });
+
+  it("maps pointer position and marker position across the full rail", () => {
+    expect(resolveTurnMinimapTopPercent(2, 5)).toBe(50);
+    expect(
+      resolveTurnMinimapIndexFromPointer({
+        itemCount: 101,
+        railTop: 100,
+        railHeight: 500,
+        pointerY: 350,
+      }),
+    ).toBe(50);
+    expect(
+      resolveTurnMinimapIndexFromPointer({
+        itemCount: 101,
+        railTop: 100,
+        railHeight: 500,
+        pointerY: 999,
+      }),
+    ).toBe(100);
+  });
+
+  it("caps the rail within the viewport", () => {
+    expect(resolveTurnMinimapHeight(5, 600)).toBe(32);
+    expect(resolveTurnMinimapHeight(101, 320)).toBe(256);
+  });
+
+  it("requires a full side gutter beside the content column", () => {
+    expect(turnMinimapHasEnoughSpace(915)).toBe(false);
+    expect(turnMinimapHasEnoughSpace(916)).toBe(true);
+    expect(turnMinimapHasEnoughSpace(1400)).toBe(true);
+    expect(turnMinimapHasEnoughSpace(Number.NaN)).toBe(false);
+  });
+});

--- a/packages/app/src/agent-stream/turn-minimap.ts
+++ b/packages/app/src/agent-stream/turn-minimap.ts
@@ -1,0 +1,95 @@
+import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+import type { StreamItem } from "@/types/stream";
+
+export const TURN_MINIMAP_ITEM_SPACING = 8;
+export const TURN_MINIMAP_MIN_ITEMS = 2;
+export const TURN_MINIMAP_REQUIRED_GUTTER = 48;
+export const TURN_MINIMAP_VERTICAL_INSET = 32;
+
+export interface TurnMinimapItem {
+  id: string;
+  rowIndex: number;
+  userText: string | null;
+  assistantText: string | null;
+}
+
+export function deriveTurnMinimapItems(items: readonly StreamItem[]): TurnMinimapItem[] {
+  const turns: TurnMinimapItem[] = [];
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    if (item?.kind !== "user_message") {
+      continue;
+    }
+
+    turns.push({
+      id: item.id,
+      rowIndex: index,
+      userText: compactPreview(item.text),
+      assistantText: compactPreview(resolveFinalAssistantText(items, index)),
+    });
+  }
+  return turns;
+}
+
+export function resolveTurnMinimapHeight(itemCount: number, viewportHeight: number): number {
+  const naturalHeight = Math.max(1, (itemCount - 1) * TURN_MINIMAP_ITEM_SPACING);
+  const availableHeight = Math.max(1, viewportHeight - TURN_MINIMAP_VERTICAL_INSET * 2);
+  return Math.min(naturalHeight, availableHeight);
+}
+
+export function resolveTurnMinimapTopPercent(index: number, itemCount: number): number {
+  if (itemCount <= 1) {
+    return 0;
+  }
+  const boundedIndex = Math.max(0, Math.min(index, itemCount - 1));
+  return (boundedIndex / (itemCount - 1)) * 100;
+}
+
+export function resolveTurnMinimapIndexFromPointer(input: {
+  itemCount: number;
+  railTop: number;
+  railHeight: number;
+  pointerY: number;
+}): number | null {
+  if (input.itemCount <= 0 || input.railHeight <= 0) {
+    return null;
+  }
+  if (input.itemCount === 1) {
+    return 0;
+  }
+
+  const progress = Math.max(0, Math.min(1, (input.pointerY - input.railTop) / input.railHeight));
+  return Math.round(progress * (input.itemCount - 1));
+}
+
+export function turnMinimapHasEnoughSpace(viewportWidth: number): boolean {
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
+    return false;
+  }
+
+  const contentWidth = Math.min(viewportWidth, MAX_CONTENT_WIDTH);
+  const sideGutter = Math.max(0, (viewportWidth - contentWidth) / 2);
+  return sideGutter >= TURN_MINIMAP_REQUIRED_GUTTER;
+}
+
+function resolveFinalAssistantText(
+  items: readonly StreamItem[],
+  userRowIndex: number,
+): string | null {
+  let finalAssistantText: string | null = null;
+  for (let index = userRowIndex + 1; index < items.length; index += 1) {
+    const item = items[index];
+    if (item?.kind === "user_message") {
+      break;
+    }
+    if (item?.kind === "assistant_message") {
+      finalAssistantText = item.text;
+    }
+  }
+  return finalAssistantText;
+}
+
+function compactPreview(text: string | null | undefined): string | null {
+  const compact = text?.replace(/\s+/g, " ").trim() ?? "";
+  return compact.length > 0 ? compact : null;
+}


### PR DESCRIPTION
### Linked issue

None — requested directly as a focused UI enhancement.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Long agent conversations are difficult to scan because the scrollbar exposes document position, not conversational turns. This adds a compact turn minimap in the unused side gutter on wide web and desktop layouts, giving each user turn a stable navigation target without crowding compact layouts.

### Goals

- Show one marker per user turn when the conversation has at least two turns.
- Highlight markers for turns currently in view.
- Preview the user prompt and final assistant response on hover.
- Jump to turns with pointer or keyboard interaction.
- Hide the minimap when the content column has less than 48px of side gutter or the device lacks a fine pointer.
- Preserve virtualized history navigation and existing history-start anchoring.

### Non-goals

- No compact/mobile minimap.
- No protocol or persisted-data changes.
- No replacement for ordinary free scrolling.

### Screenshots

**Resting turn rail** — one marker per user turn, with the visible turn emphasized.

<img width="1400" height="820" alt="Turn minimap at rest" src="https://github.com/user-attachments/assets/dc64be27-b7e7-46b5-b96a-3f728fef5a53" />

**Hover preview** — nearby markers expand and the selected prompt plus final response appear in the gutter.

<img width="1400" height="820" alt="Turn minimap hover preview" src="https://github.com/user-attachments/assets/c6bdca94-f9a2-4327-a00d-59271ef28f47" />

### QA

Tested browser web at 1400×820 and responsive hiding at 900×720.

- Resting rail: one marker per seeded user turn.
- Hover: nearby markers expand and the selected turn preview appears.
- Endpoint hover: approaching the lowest marker from below activates its preview.
- Click: selecting the first marker scrolls the conversation back to the first turn.
- Responsive: the minimap is removed below the available-gutter threshold.

Commands:

- `npm run typecheck`
- `npm run lint -- packages/app/e2e/browser/agent-stream-ui.spec.ts packages/app/src/agent-stream/strategy-web.tsx packages/app/src/agent-stream/turn-minimap-view.web.tsx packages/app/src/agent-stream/turn-minimap.test.ts packages/app/src/agent-stream/turn-minimap.ts`
- `npm run format:check:files -- packages/app/e2e/browser/agent-stream-ui.spec.ts packages/app/src/agent-stream/strategy-web.tsx packages/app/src/agent-stream/turn-minimap-view.web.tsx packages/app/src/agent-stream/turn-minimap.test.ts packages/app/src/agent-stream/turn-minimap.ts`
- `npx vitest run packages/app/src/agent-stream/turn-minimap.test.ts --bail=1` — 4 tests passed
- `npm --workspace packages/app run test:e2e -- e2e/browser/agent-stream-ui.spec.ts --grep 'wide-layout minimap'` — 1 browser test passed

Platforms:

- Browser web: tested
- Electron desktop: not separately tested; shares the web stream strategy
- iOS/Android: unaffected because the minimap is web-only

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
