### PR TITLE
Limit daemon-wide Git process pressure

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -237,13 +237,14 @@ All fields are optional with sensible defaults.
 
 ### Git process limits
 
-Git process limits are global to one daemon. Both values default to `8`:
+Git process limits are global to one daemon. The start-rate limit defaults to `64` processes per
+second, and the concurrency limit defaults to `8`:
 
 ```json
 {
   "daemon": {
     "git": {
-      "maxProcessesPerSecond": 8,
+      "maxProcessesPerSecond": 64,
       "maxProcessConcurrency": 8
     }
   }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -187,6 +187,7 @@ Single file, validated with `PersistedConfigSchema`.
     hostnames: true | string[],   // legacy alias `allowedHosts` is migrated on load
     trustedProxies: true | string[], // defaults to ["loopback"]; Express proxy names/CIDRs
     mcp: { enabled: boolean, injectIntoAgents: boolean },
+    git: { maxProcessesPerSecond: number, maxProcessConcurrency: number },
     appendSystemPrompt: string,    // appended to supported provider system/developer prompts
     cors: { allowedOrigins: string[] },
     relay: { enabled: boolean, endpoint: string, publicEndpoint: string, useTls: boolean, publicUseTls: boolean }, // new homes materialize enabled: false
@@ -233,6 +234,39 @@ Single file, validated with `PersistedConfigSchema`.
 ```
 
 All fields are optional with sensible defaults.
+
+### Git process limits
+
+Git process limits are global to one daemon. Both values default to `8`:
+
+```json
+{
+  "daemon": {
+    "git": {
+      "maxProcessesPerSecond": 8,
+      "maxProcessConcurrency": 8
+    }
+  }
+}
+```
+
+`maxProcessesPerSecond` limits Git process starts in any one-second interval. The allowance can
+start as a burst; it does not wait for earlier processes to exit. `maxProcessConcurrency` limits
+the number of Git processes that have started but not exited. Every Git command uses both limits,
+including initial workspace reads, filesystem-triggered refreshes, background checks, and explicit
+requests.
+
+Environment variables override `config.json`:
+
+| Environment variable                 | Setting                  |
+| ------------------------------------ | ------------------------ |
+| `PASEO_GIT_MAX_PROCESSES_PER_SECOND` | `maxProcessesPerSecond`  |
+| `PASEO_GIT_MAX_PROCESS_CONCURRENCY`  | `maxProcessConcurrency`  |
+| `PASEO_GIT_CONCURRENCY`              | Legacy concurrency alias |
+
+`PASEO_GIT_MAX_PROCESS_CONCURRENCY` wins when it and the legacy alias are both set. Restart the
+daemon after changing the file or environment. Run `paseo daemon restart` for a standalone daemon.
+For a desktop-managed daemon, fully quit and reopen Paseo Desktop.
 
 `agents.metadataGeneration.providers` controls the preferred structured-generation fallback order for daemon-side metadata tasks such as commit messages, PR text, branch names, and generated agent titles. Entries are tried first in the configured order, then Paseo falls through to dynamically discovered defaults and finally the current selection when available.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -244,6 +244,27 @@ The supervisor rotates `daemon.log`. Persisted `log.file.rotate` settings in
 `PASEO_LOG_ROTATE_SIZE` and `PASEO_LOG_ROTATE_COUNT` env vars override the
 defaults. The default rotation is `10m` x `3` files everywhere.
 
+### Git process pressure
+
+If Git refreshes consume too much CPU, disk, or antivirus capacity, especially on Windows, reduce
+the daemon-global Git process limits in `$PASEO_HOME/config.json`:
+
+```json
+{
+  "daemon": {
+    "git": {
+      "maxProcessesPerSecond": 5,
+      "maxProcessConcurrency": 4
+    }
+  }
+}
+```
+
+Restart the daemon with `paseo daemon restart`. If Paseo Desktop manages the daemon, fully quit and
+reopen the desktop app. Lower values reduce machine pressure but make Git-backed workspace state and
+Git RPCs wait longer. See [Git process limits](data-model.md#git-process-limits) for defaults,
+semantics, and environment-variable overrides.
+
 ### Agent Tool Catalog Measurement
 
 Measure the MCP `tools/list` payload that Paseo injects into agents with:

--- a/nix/npm-deps.hash
+++ b/nix/npm-deps.hash
@@ -1,1 +1,1 @@
-sha256-UunIQIS/Y2LhJWqhZMcU1CM9aVOwQUoKKR5z/kj+JDE=
+sha256-Mg6cn08RoEFmAYKDjowYd7DZSeeJezix0rzQeDadRAs=

--- a/package-lock.json
+++ b/package-lock.json
@@ -28414,6 +28414,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-throttle": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-8.1.0.tgz",
+      "integrity": "sha512-c1wmXavsHZIC4g1OLhOsafK6jZSAeMo0Ap3yivj59PUcCkpacy5YgWdgIp/dB4vp1JZrfBSsPCR0YuADB+ENLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -38210,6 +38222,7 @@
         "openai": "^6.44.0",
         "p-limit": "^7.3.0",
         "p-memoize": "^8.0.0",
+        "p-throttle": "^8.1.0",
         "pino": "^10.2.0",
         "pino-pretty": "^13.1.3",
         "qrcode": "^1.5.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -90,6 +90,7 @@
     "openai": "^6.44.0",
     "p-limit": "^7.3.0",
     "p-memoize": "^8.0.0",
+    "p-throttle": "^8.1.0",
     "pino": "^10.2.0",
     "pino-pretty": "^13.1.3",
     "qrcode": "^1.5.4",

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -198,6 +198,8 @@ import { createWebUiMiddleware } from "./web-ui.js";
 import { WorkspaceAutoName } from "./workspace-auto-name.js";
 import { createGitMutationService } from "./session/git-mutation/git-mutation-service.js";
 import { workspaceIdsOnCheckout } from "./workspace-directory.js";
+import { configureGitProcessPolicy } from "../utils/run-git-command.js";
+import { resolveGitProcessPolicy } from "../utils/git-process-scheduler.js";
 import { resolveFirstAgentPromptTitle } from "./agent/create-agent-title.js";
 import {
   createAgentCommand,
@@ -388,6 +390,10 @@ export interface PaseoDaemonConfig {
   mcpEnabled?: boolean;
   mcpInjectIntoAgents?: boolean;
   browserToolsEnabled?: boolean;
+  git?: {
+    maxProcessesPerSecond: number;
+    maxProcessConcurrency: number;
+  };
   autoArchiveAfterMerge?: boolean;
   enableTerminalAgentHooks?: boolean;
   appendSystemPrompt?: string;
@@ -539,6 +545,7 @@ export async function createPaseoDaemon(
   rootLogger: Logger,
   dependencies: PaseoDaemonDependencies = {},
 ): Promise<PaseoDaemon> {
+  configureGitProcessPolicy(config.git ?? resolveGitProcessPolicy({ env: process.env }));
   const logger = rootLogger.child({ module: "bootstrap" });
   const bootstrapStart = performance.now();
   const elapsed = () => `${(performance.now() - bootstrapStart).toFixed(0)}ms`;

--- a/packages/server/src/server/config-git.test.ts
+++ b/packages/server/src/server/config-git.test.ts
@@ -19,11 +19,11 @@ describe("daemon Git process config", () => {
     await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
-  test("defaults both global process limits to eight", async () => {
+  test("defaults the global process limits", async () => {
     const home = await createHome();
 
     expect(loadConfig(home, { env: {} }).git).toEqual({
-      maxProcessesPerSecond: 8,
+      maxProcessesPerSecond: 64,
       maxProcessConcurrency: 8,
     });
   });

--- a/packages/server/src/server/config-git.test.ts
+++ b/packages/server/src/server/config-git.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { loadConfig } from "./config.js";
+
+const roots: string[] = [];
+
+async function createHome(config: object = {}): Promise<string> {
+  const home = await mkdtemp(path.join(os.tmpdir(), "paseo-config-git-"));
+  roots.push(home);
+  await writeFile(path.join(home, "config.json"), JSON.stringify(config));
+  return home;
+}
+
+describe("daemon Git process config", () => {
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  test("defaults both global process limits to eight", async () => {
+    const home = await createHome();
+
+    expect(loadConfig(home, { env: {} }).git).toEqual({
+      maxProcessesPerSecond: 8,
+      maxProcessConcurrency: 8,
+    });
+  });
+
+  test("loads both limits from daemon.git", async () => {
+    const home = await createHome({
+      daemon: {
+        git: {
+          maxProcessesPerSecond: 5,
+          maxProcessConcurrency: 4,
+        },
+      },
+    });
+
+    expect(loadConfig(home, { env: {} }).git).toEqual({
+      maxProcessesPerSecond: 5,
+      maxProcessConcurrency: 4,
+    });
+  });
+
+  test("new environment variables override config.json", async () => {
+    const home = await createHome({
+      daemon: {
+        git: {
+          maxProcessesPerSecond: 5,
+          maxProcessConcurrency: 4,
+        },
+      },
+    });
+
+    expect(
+      loadConfig(home, {
+        env: {
+          PASEO_GIT_MAX_PROCESSES_PER_SECOND: "12",
+          PASEO_GIT_MAX_PROCESS_CONCURRENCY: "6",
+        },
+      }).git,
+    ).toEqual({
+      maxProcessesPerSecond: 12,
+      maxProcessConcurrency: 6,
+    });
+  });
+
+  test("accepts legacy PASEO_GIT_CONCURRENCY below the renamed variable", async () => {
+    const home = await createHome();
+
+    expect(
+      loadConfig(home, {
+        env: {
+          PASEO_GIT_CONCURRENCY: "3",
+        },
+      }).git?.maxProcessConcurrency,
+    ).toBe(3);
+    expect(
+      loadConfig(home, {
+        env: {
+          PASEO_GIT_CONCURRENCY: "3",
+          PASEO_GIT_MAX_PROCESS_CONCURRENCY: "7",
+        },
+      }).git?.maxProcessConcurrency,
+    ).toBe(7);
+  });
+});

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -22,6 +22,7 @@ import { AgentProviderSchema } from "@getpaseo/protocol/provider-manifest";
 import { hashDaemonPassword } from "./auth.js";
 import { resolveSpeechConfig } from "./speech/speech-config-resolver.js";
 import { mergeHostnames, parseHostnamesEnv, type HostnamesConfig } from "./hostnames.js";
+import { resolveGitProcessPolicy } from "../utils/git-process-scheduler.js";
 
 const DEFAULT_PORT = 6767;
 const DEFAULT_RELAY_ENDPOINT = "relay.paseo.sh:443";
@@ -85,6 +86,16 @@ function normalizeLogEnv(value: string | undefined): string | undefined {
   }
 
   return value.trim().toLowerCase();
+}
+
+function resolveGitProcessConfig(
+  env: NodeJS.ProcessEnv,
+  persisted: ReturnType<typeof loadPersistedConfig>,
+): NonNullable<PaseoDaemonConfig["git"]> {
+  return resolveGitProcessPolicy({
+    env,
+    persisted: persisted.daemon?.git,
+  });
 }
 
 export type CliConfigOverrides = Partial<{
@@ -504,6 +515,7 @@ export function loadConfig(
     mcpEnabled,
     mcpInjectIntoAgents,
     browserToolsEnabled,
+    git: resolveGitProcessConfig(env, persisted),
     autoArchiveAfterMerge,
     enableTerminalAgentHooks: persisted.daemon?.enableTerminalAgentHooks ?? false,
     appendSystemPrompt,

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -248,6 +248,13 @@ export const PersistedConfigSchema = z
           })
           .passthrough()
           .optional(),
+        git: z
+          .object({
+            maxProcessesPerSecond: z.number().int().positive().optional(),
+            maxProcessConcurrency: z.number().int().positive().optional(),
+          })
+          .strict()
+          .optional(),
         autoArchiveAfterMerge: z.boolean().optional(),
         enableTerminalAgentHooks: z.boolean().optional(),
         appendSystemPrompt: z.string().optional(),

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -201,8 +201,11 @@ const agentResponseMocks = vi.hoisted(() => ({
 }));
 
 const spawnMocks = vi.hoisted(() => ({
-  execCommand: vi.fn(),
   spawnWorkspaceScript: vi.fn(),
+}));
+
+const gitCommandMocks = vi.hoisted(() => ({
+  runGitCommand: vi.fn(),
 }));
 
 const paseoWorktreeServiceMocks = vi.hoisted(() => ({
@@ -253,11 +256,11 @@ vi.mock("./paseo-worktree-service.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../utils/spawn.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../utils/spawn.js")>();
+vi.mock("../utils/run-git-command.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils/run-git-command.js")>();
   return {
     ...actual,
-    execCommand: spawnMocks.execCommand,
+    runGitCommand: gitCommandMocks.runGitCommand,
   };
 });
 
@@ -4045,7 +4048,7 @@ describe("session stash mutation handling", () => {
     const messages: unknown[] = [];
     const workspaceGitService = { getSnapshot: vi.fn().mockResolvedValue({}) };
     const session = createSessionForTest({ workspaceGitService, messages });
-    spawnMocks.execCommand.mockResolvedValue({
+    gitCommandMocks.runGitCommand.mockResolvedValue({
       stdout: "",
       stderr: "",
       exitCode: 0,
@@ -4060,6 +4063,10 @@ describe("session stash mutation handling", () => {
       requestId: "request-stash-push",
     });
 
+    expect(gitCommandMocks.runGitCommand).toHaveBeenCalledWith(
+      ["stash", "push", "--include-untracked", "-m", "paseo-auto-stash: feature"],
+      { cwd: "/tmp/repo" },
+    );
     expect(workspaceGitService.getSnapshot).toHaveBeenCalledWith("/tmp/repo", {
       force: true,
       reason: "stash-push",
@@ -4079,7 +4086,7 @@ describe("session stash mutation handling", () => {
     const messages: unknown[] = [];
     const workspaceGitService = { getSnapshot: vi.fn().mockResolvedValue({}) };
     const session = createSessionForTest({ workspaceGitService, messages });
-    spawnMocks.execCommand.mockResolvedValue({
+    gitCommandMocks.runGitCommand.mockResolvedValue({
       stdout: "",
       stderr: "",
       exitCode: 0,
@@ -4094,6 +4101,9 @@ describe("session stash mutation handling", () => {
       requestId: "request-stash-pop",
     });
 
+    expect(gitCommandMocks.runGitCommand).toHaveBeenCalledWith(["stash", "pop", "stash@{0}"], {
+      cwd: "/tmp/repo",
+    });
     expect(workspaceGitService.getSnapshot).toHaveBeenCalledWith("/tmp/repo", {
       force: true,
       reason: "stash-pop",

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -4065,7 +4065,7 @@ describe("session stash mutation handling", () => {
 
     expect(gitCommandMocks.runGitCommand).toHaveBeenCalledWith(
       ["stash", "push", "--include-untracked", "-m", "paseo-auto-stash: feature"],
-      { cwd: "/tmp/repo" },
+      { cwd: "/tmp/repo", timeout: 120_000 },
     );
     expect(workspaceGitService.getSnapshot).toHaveBeenCalledWith("/tmp/repo", {
       force: true,
@@ -4103,6 +4103,7 @@ describe("session stash mutation handling", () => {
 
     expect(gitCommandMocks.runGitCommand).toHaveBeenCalledWith(["stash", "pop", "stash@{0}"], {
       cwd: "/tmp/repo",
+      timeout: 120_000,
     });
     expect(workspaceGitService.getSnapshot).toHaveBeenCalledWith("/tmp/repo", {
       force: true,

--- a/packages/server/src/server/session/checkout/checkout-session.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.ts
@@ -51,7 +51,7 @@ import {
   listCheckoutCommits,
   getCommitFileDiff,
 } from "../../../utils/checkout-git.js";
-import { execCommand } from "../../../utils/spawn.js";
+import { runGitCommand } from "../../../utils/run-git-command.js";
 import { expandTilde } from "../../../utils/path.js";
 import type { GitMetadataGenerator } from "./git-metadata-generator.js";
 
@@ -614,7 +614,7 @@ export class CheckoutSession {
       const message = branchLabel
         ? `${CheckoutSession.PASEO_STASH_PREFIX} ${branchLabel}`
         : `${CheckoutSession.PASEO_STASH_PREFIX} unnamed`;
-      await execCommand("git", ["stash", "push", "--include-untracked", "-m", message], {
+      await runGitCommand(["stash", "push", "--include-untracked", "-m", message], {
         cwd,
       });
       await this.gitMutation.notifyGitMutation(cwd, "stash-push");
@@ -636,7 +636,7 @@ export class CheckoutSession {
   ): Promise<void> {
     const { cwd, stashIndex, requestId } = msg;
     try {
-      await execCommand("git", ["stash", "pop", `stash@{${stashIndex}}`], {
+      await runGitCommand(["stash", "pop", `stash@{${stashIndex}}`], {
         cwd,
       });
       await this.gitMutation.notifyGitMutation(cwd, "stash-pop");

--- a/packages/server/src/server/session/checkout/checkout-session.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.ts
@@ -616,6 +616,7 @@ export class CheckoutSession {
         : `${CheckoutSession.PASEO_STASH_PREFIX} unnamed`;
       await runGitCommand(["stash", "push", "--include-untracked", "-m", message], {
         cwd,
+        timeout: 120_000,
       });
       await this.gitMutation.notifyGitMutation(cwd, "stash-push");
       this.scheduleDiffRefresh(cwd);
@@ -638,6 +639,7 @@ export class CheckoutSession {
     try {
       await runGitCommand(["stash", "pop", `stash@{${stashIndex}}`], {
         cwd,
+        timeout: 120_000,
       });
       await this.gitMutation.notifyGitMutation(cwd, "stash-pop");
       this.scheduleDiffRefresh(cwd);

--- a/packages/server/src/server/session/git-mutation/git-mutation-service.ts
+++ b/packages/server/src/server/session/git-mutation/git-mutation-service.ts
@@ -118,7 +118,10 @@ export function createGitMutationService(deps: {
       }
 
       await ensureCleanWorkingTree(cwd);
-      await runGitCommand(["checkout", "-b", newBranchName, baseBranch], { cwd });
+      await runGitCommand(["checkout", "-b", newBranchName, baseBranch], {
+        cwd,
+        timeout: 120_000,
+      });
       await notifyGitMutation(cwd, "create-branch");
     },
 

--- a/packages/server/src/server/session/git-mutation/git-mutation-service.ts
+++ b/packages/server/src/server/session/git-mutation/git-mutation-service.ts
@@ -5,7 +5,7 @@ import {
   type CheckoutExistingBranchResult,
   type GitMutationRefreshReason,
 } from "../../../utils/checkout-git.js";
-import { execCommand } from "../../../utils/spawn.js";
+import { runGitCommand } from "../../../utils/run-git-command.js";
 import type { WorkspaceGitService } from "../../workspace-git-service.js";
 import { assertSafeGitRef as assertWorktreeSafeGitRef } from "../../worktree-session.js";
 
@@ -118,7 +118,7 @@ export function createGitMutationService(deps: {
       }
 
       await ensureCleanWorkingTree(cwd);
-      await execCommand("git", ["checkout", "-b", newBranchName, baseBranch], { cwd });
+      await runGitCommand(["checkout", "-b", newBranchName, baseBranch], { cwd });
       await notifyGitMutation(cwd, "create-branch");
     },
 

--- a/packages/server/src/server/workspace-git-service.primitive.test.ts
+++ b/packages/server/src/server/workspace-git-service.primitive.test.ts
@@ -1153,12 +1153,13 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
   test("settled GitHub self-heal reads stay on the slow poll window without refreshing git", async () => {
     let nowMs = 0;
     const githubReadCalls: Array<{ reason: string | undefined; tickMs: number }> = [];
+    const runner = vi.fn(async () => ({
+      stdout: currentPullRequestJson(),
+      stderr: "",
+    }));
     const github = createGitHubService({
       ttlMs: 0,
-      runner: vi.fn(async () => ({
-        stdout: currentPullRequestJson(),
-        stderr: "",
-      })),
+      runner,
       resolveGhPath: async () => "/usr/bin/gh",
       now: () => nowMs,
     });
@@ -1180,6 +1181,9 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
     const subscription = service.registerWorkspace({ cwd: REPO_CWD }, vi.fn());
     await flushPromises();
     await vi.advanceTimersByTimeAsync(0);
+    await vi.waitFor(() => {
+      expect(runner).toHaveBeenCalledTimes(1);
+    });
     await flushPromises();
     const gitReadsAfterInitialSnapshot = getCheckoutStatus.mock.calls.length;
 

--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -820,6 +820,7 @@ describe("ForgeService", () => {
         reason: "self-heal-github",
       }),
     ]);
+    await vi.advanceTimersByTimeAsync(0);
     expect(currentPullRequestStatusCalls(runner.calls)).toHaveLength(1);
 
     subscription?.unsubscribe();
@@ -856,6 +857,7 @@ describe("ForgeService", () => {
 
     now = EXPECTED_GITHUB_SLOW_POLL_MS;
     await vi.advanceTimersByTimeAsync(EXPECTED_GITHUB_SLOW_POLL_MS - EXPECTED_GITHUB_FAST_POLL_MS);
+    await vi.advanceTimersByTimeAsync(0);
     expect(currentPullRequestStatusCalls(runner.calls)).toHaveLength(2);
     expect(reads.map((read) => read.reason)).toEqual([undefined, "self-heal-github"]);
 

--- a/packages/server/src/utils/git-command-runtime-metrics.test.ts
+++ b/packages/server/src/utils/git-command-runtime-metrics.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "vitest";
 import { GitCommandRuntimeMetricsWindow } from "./git-command-runtime-metrics.js";
 
-function createMetricsWindow(concurrencyLimit = 2) {
+function createMetricsWindow(concurrencyLimit = 2, maxProcessesPerSecond = 8) {
   let now = 1_000;
   return {
-    metrics: new GitCommandRuntimeMetricsWindow(concurrencyLimit, () => now),
+    metrics: new GitCommandRuntimeMetricsWindow(
+      { concurrencyLimit, maxProcessesPerSecond },
+      () => now,
+    ),
     advance(ms: number) {
       now += ms;
     },
@@ -42,6 +45,7 @@ describe("GitCommandRuntimeMetricsWindow", () => {
 
     expect(metrics.snapshotAndReset()).toMatchObject({
       concurrencyLimit: 1,
+      maxProcessesPerSecond: 8,
       active: 1,
       pending: 1,
       peakActive: 1,

--- a/packages/server/src/utils/git-command-runtime-metrics.ts
+++ b/packages/server/src/utils/git-command-runtime-metrics.ts
@@ -7,6 +7,7 @@ export interface GitCommandDurationStats {
 
 export interface GitCommandRuntimeMetricsSnapshot {
   concurrencyLimit: number;
+  maxProcessesPerSecond: number;
   active: number;
   pending: number;
   peakActive: number;
@@ -44,7 +45,10 @@ export class GitCommandRuntimeMetricsWindow {
   private readonly operationCounts = new Map<string, number>();
 
   constructor(
-    private readonly concurrencyLimit: number,
+    private readonly limits: {
+      concurrencyLimit: number;
+      maxProcessesPerSecond: number;
+    },
     private readonly clock: Clock = Date.now,
   ) {}
 
@@ -98,7 +102,8 @@ export class GitCommandRuntimeMetricsWindow {
       ...Array.from(this.pendingCommands, (metric) => metric.queuedAtMs),
     );
     const snapshot: GitCommandRuntimeMetricsSnapshot = {
-      concurrencyLimit: this.concurrencyLimit,
+      concurrencyLimit: this.limits.concurrencyLimit,
+      maxProcessesPerSecond: this.limits.maxProcessesPerSecond,
       active: limiter.active,
       pending: limiter.pending,
       peakActive: this.peakActive,

--- a/packages/server/src/utils/git-process-scheduler.test.ts
+++ b/packages/server/src/utils/git-process-scheduler.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { GitProcessScheduler, resolveGitProcessPolicy } from "./git-process-scheduler.js";
+
+function createConcurrencyTask(
+  index: number,
+  started: number[],
+  releases: Array<() => void>,
+): () => Promise<void> {
+  return () => {
+    started.push(index);
+    if (index >= 2) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      releases.push(resolve);
+    });
+  };
+}
+
+describe("GitProcessScheduler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("limits unresolved processes independently of their start rate", async () => {
+    const scheduler = new GitProcessScheduler({
+      maxProcessesPerSecond: 100,
+      maxProcessConcurrency: 2,
+    });
+    const releases: Array<() => void> = [];
+    const started: number[] = [];
+    const tasks = Array.from({ length: 4 }, (_, index) =>
+      scheduler.run(createConcurrencyTask(index, started, releases)),
+    );
+
+    await vi.waitFor(() => expect(started).toEqual([0, 1]));
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toContain(2));
+    releases.shift()?.();
+    await Promise.all(tasks);
+
+    expect(scheduler.activeCount).toBe(0);
+    expect(scheduler.pendingCount).toBe(0);
+  });
+
+  test("limits process starts in each strict one-second interval", async () => {
+    vi.useFakeTimers();
+    const scheduler = new GitProcessScheduler({
+      maxProcessesPerSecond: 2,
+      maxProcessConcurrency: 4,
+    });
+    const startedAt: number[] = [];
+    const recordStart = async () => {
+      startedAt.push(Date.now());
+    };
+    const tasks = Array.from({ length: 4 }, () => scheduler.run(recordStart));
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(startedAt).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(startedAt).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(startedAt).toHaveLength(3);
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.all(tasks);
+
+    expect(startedAt).toHaveLength(4);
+    expect(startedAt[2]! - startedAt[0]!).toBeGreaterThanOrEqual(1_000);
+  });
+});
+
+describe("resolveGitProcessPolicy", () => {
+  test("prefers renamed environment variables over legacy and persisted values", () => {
+    expect(
+      resolveGitProcessPolicy({
+        env: {
+          PASEO_GIT_MAX_PROCESSES_PER_SECOND: "12",
+          PASEO_GIT_MAX_PROCESS_CONCURRENCY: "7",
+          PASEO_GIT_CONCURRENCY: "3",
+        },
+        persisted: { maxProcessesPerSecond: 5, maxProcessConcurrency: 4 },
+      }),
+    ).toEqual({ maxProcessesPerSecond: 12, maxProcessConcurrency: 7 });
+  });
+});

--- a/packages/server/src/utils/git-process-scheduler.test.ts
+++ b/packages/server/src/utils/git-process-scheduler.test.ts
@@ -6,15 +6,17 @@ function createConcurrencyTask(
   index: number,
   started: number[],
   releases: Array<() => void>,
-): () => Promise<void> {
+): () => { result: Promise<void>; exited: Promise<void> } {
   return () => {
     started.push(index);
     if (index >= 2) {
-      return Promise.resolve();
+      const completed = Promise.resolve();
+      return { result: completed, exited: completed };
     }
-    return new Promise<void>((resolve) => {
+    const completed = new Promise<void>((resolve) => {
       releases.push(resolve);
     });
+    return { result: completed, exited: completed };
   };
 }
 
@@ -51,8 +53,10 @@ describe("GitProcessScheduler", () => {
       maxProcessConcurrency: 4,
     });
     const startedAt: number[] = [];
-    const recordStart = async () => {
+    const recordStart = () => {
       startedAt.push(Date.now());
+      const completed = Promise.resolve();
+      return { result: completed, exited: completed };
     };
     const tasks = Array.from({ length: 4 }, () => scheduler.run(recordStart));
 

--- a/packages/server/src/utils/git-process-scheduler.ts
+++ b/packages/server/src/utils/git-process-scheduler.ts
@@ -7,7 +7,7 @@ export interface GitProcessPolicy {
 }
 
 export const DEFAULT_GIT_PROCESS_POLICY: GitProcessPolicy = {
-  maxProcessesPerSecond: 8,
+  maxProcessesPerSecond: 64,
   maxProcessConcurrency: 8,
 };
 

--- a/packages/server/src/utils/git-process-scheduler.ts
+++ b/packages/server/src/utils/git-process-scheduler.ts
@@ -1,0 +1,77 @@
+import pLimit from "p-limit";
+import pThrottle from "p-throttle";
+
+export interface GitProcessPolicy {
+  maxProcessesPerSecond: number;
+  maxProcessConcurrency: number;
+}
+
+export const DEFAULT_GIT_PROCESS_POLICY: GitProcessPolicy = {
+  maxProcessesPerSecond: 8,
+  maxProcessConcurrency: 8,
+};
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function resolveGitProcessPolicy(input: {
+  env: NodeJS.ProcessEnv;
+  persisted?: Partial<GitProcessPolicy>;
+}): GitProcessPolicy {
+  return {
+    maxProcessesPerSecond:
+      parsePositiveInteger(input.env.PASEO_GIT_MAX_PROCESSES_PER_SECOND) ??
+      input.persisted?.maxProcessesPerSecond ??
+      DEFAULT_GIT_PROCESS_POLICY.maxProcessesPerSecond,
+    maxProcessConcurrency:
+      parsePositiveInteger(input.env.PASEO_GIT_MAX_PROCESS_CONCURRENCY) ??
+      // COMPAT(gitConcurrencyEnv): renamed in v0.2.6; remove after 2027-02-02.
+      parsePositiveInteger(input.env.PASEO_GIT_CONCURRENCY) ??
+      input.persisted?.maxProcessConcurrency ??
+      DEFAULT_GIT_PROCESS_POLICY.maxProcessConcurrency,
+  };
+}
+
+export class GitProcessScheduler {
+  private readonly limit;
+  private readonly throttle;
+  private running = 0;
+  private waiting = 0;
+
+  constructor(readonly policy: GitProcessPolicy) {
+    this.limit = pLimit(policy.maxProcessConcurrency);
+    this.throttle = pThrottle({
+      limit: policy.maxProcessesPerSecond,
+      interval: 1_000,
+      strict: true,
+    });
+  }
+
+  get activeCount(): number {
+    return this.running;
+  }
+
+  get pendingCount(): number {
+    return this.waiting;
+  }
+
+  run<T>(task: () => Promise<T>): Promise<T> {
+    this.waiting += 1;
+    return this.limit(
+      this.throttle(async () => {
+        this.waiting = Math.max(0, this.waiting - 1);
+        this.running += 1;
+        try {
+          return await task();
+        } finally {
+          this.running = Math.max(0, this.running - 1);
+        }
+      }),
+    );
+  }
+}

--- a/packages/server/src/utils/git-process-scheduler.ts
+++ b/packages/server/src/utils/git-process-scheduler.ts
@@ -11,6 +11,11 @@ export const DEFAULT_GIT_PROCESS_POLICY: GitProcessPolicy = {
   maxProcessConcurrency: 8,
 };
 
+export interface ScheduledGitProcess<T> {
+  result: Promise<T>;
+  exited: Promise<void>;
+}
+
 function parsePositiveInteger(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -60,18 +65,24 @@ export class GitProcessScheduler {
     return this.waiting;
   }
 
-  run<T>(task: () => Promise<T>): Promise<T> {
+  run<T>(start: () => ScheduledGitProcess<T>): Promise<T> {
     this.waiting += 1;
-    return this.limit(
-      this.throttle(async () => {
-        this.waiting = Math.max(0, this.waiting - 1);
-        this.running += 1;
-        try {
-          return await task();
-        } finally {
-          this.running = Math.max(0, this.running - 1);
-        }
-      }),
-    );
+    return new Promise<T>((resolve, reject) => {
+      void this.limit(
+        this.throttle(async () => {
+          this.waiting = Math.max(0, this.waiting - 1);
+          this.running += 1;
+          try {
+            const process = start();
+            void process.result.then(resolve, reject);
+            await process.exited;
+          } catch (error) {
+            reject(error);
+          } finally {
+            this.running = Math.max(0, this.running - 1);
+          }
+        }),
+      ).catch(reject);
+    });
   }
 }

--- a/packages/server/src/utils/run-git-command.test.ts
+++ b/packages/server/src/utils/run-git-command.test.ts
@@ -2,8 +2,10 @@ import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface FakeSpawnBehavior {
+  closeDelayMs?: number;
   delayMs?: number;
   emitError?: Error;
+  exitDelayMs?: number;
   exitCode?: number | null;
   killCloseDelayMs?: number;
   killExitDelayMs?: number;
@@ -125,12 +127,22 @@ class FakeChildProcess extends EventEmitter {
       return;
     }
 
+    const exitDelayMs = this.behavior.exitDelayMs ?? this.behavior.delayMs ?? 0;
     this.schedule(() => {
-      this.finishClose({
+      this.finishExit({
         exitCode: this.behavior.exitCode ?? 0,
         signal: null,
       });
-    }, this.behavior.delayMs ?? 0);
+    }, exitDelayMs);
+    this.schedule(
+      () => {
+        this.finishClose({
+          exitCode: this.behavior.exitCode ?? 0,
+          signal: null,
+        });
+      },
+      Math.max(exitDelayMs, this.behavior.closeDelayMs ?? this.behavior.delayMs ?? exitDelayMs),
+    );
   }
 
   private finishClose({
@@ -300,6 +312,30 @@ describe("runGitCommand", () => {
       stdout: "next",
     });
     expect(fakeSpawnController.peakActiveCount).toBe(1);
+  });
+
+  it("finishes process metrics at exit without waiting for close", async () => {
+    const { runGitCommand, startGitCommandMetrics, stopGitCommandMetrics } =
+      await loadRunGitCommand(1);
+
+    enqueueSpawnBehaviors(
+      { exitDelayMs: 0, closeDelayMs: 500 },
+      { delayMs: 0, stdoutData: "next" },
+    );
+    startGitCommandMetrics();
+
+    void runGitCommand(["status"], { cwd: process.cwd() });
+    await expect(
+      runGitCommand(["rev-parse", "--show-toplevel"], { cwd: process.cwd() }),
+    ).resolves.toMatchObject({ stdout: "next" });
+
+    expect(fakeSpawnController.processes[0]?.exited).toBe(true);
+    expect(fakeSpawnController.processes[0]?.closed).toBe(false);
+    expect(stopGitCommandMetrics()).toMatchObject({
+      total: 2,
+      failed: 0,
+      maxConcurrent: 1,
+    });
   });
 
   it("resolves truncated stdout, caps output, and kills the child process", async () => {

--- a/packages/server/src/utils/run-git-command.test.ts
+++ b/packages/server/src/utils/run-git-command.test.ts
@@ -9,6 +9,7 @@ interface FakeSpawnBehavior {
   exitCode?: number | null;
   killCloseDelayMs?: number;
   killExitDelayMs?: number;
+  spawnError?: Error;
   stderrData?: Buffer | string;
   stdoutData?: Buffer | string;
 }
@@ -202,6 +203,9 @@ vi.mock("node:child_process", async () => {
     ...actual,
     spawn: vi.fn(() => {
       const behavior = fakeSpawnController.queue.shift() ?? {};
+      if (behavior.spawnError) {
+        throw behavior.spawnError;
+      }
       const child = new FakeChildProcess(behavior);
       fakeSpawnController.processes.push(child);
       return child as unknown as ReturnType<typeof actual.spawn>;
@@ -382,6 +386,21 @@ describe("runGitCommand", () => {
       truncated: false,
     });
   });
+
+  it("releases the limiter after a synchronous spawn failure", async () => {
+    const { runGitCommand } = await loadRunGitCommand(1);
+
+    enqueueSpawnBehaviors(
+      { spawnError: new Error("spawn threw") },
+      { delayMs: 0, stdoutData: "ok" },
+    );
+
+    await expect(runGitCommand(["status"], { cwd: process.cwd() })).rejects.toThrow("spawn threw");
+    await expect(runGitCommand(["status"], { cwd: process.cwd() })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "ok",
+    });
+  }, 1_000);
 
   it("traces git command spawn and close metadata when a logger is provided", async () => {
     const { runGitCommand } = await loadRunGitCommand(1);

--- a/packages/server/src/utils/run-git-command.test.ts
+++ b/packages/server/src/utils/run-git-command.test.ts
@@ -5,6 +5,7 @@ interface FakeSpawnBehavior {
   delayMs?: number;
   emitError?: Error;
   exitCode?: number | null;
+  killCloseDelayMs?: number;
   stderrData?: Buffer | string;
   stdoutData?: Buffer | string;
 }
@@ -74,7 +75,7 @@ class FakeChildProcess extends EventEmitter {
         exitCode: null,
         signal,
       });
-    }, 0);
+    }, this.behavior.killCloseDelayMs ?? 0);
     return true;
   }
 
@@ -134,10 +135,9 @@ class FakeChildProcess extends EventEmitter {
   private finishError(error: Error): void {
     if (this.closed) return;
 
-    this.closed = true;
     this.clearTimers();
-    fakeSpawnController.activeCount -= 1;
     this.emit("error", error);
+    this.finishClose({ exitCode: null, signal: null });
   }
 
   private schedule(callback: () => void, delayMs: number): void {
@@ -228,6 +228,43 @@ describe("runGitCommand", () => {
       exitCode: 0,
       truncated: false,
     });
+  });
+
+  it("holds the limiter slot until a timed out process closes", async () => {
+    const { runGitCommand } = await loadRunGitCommand(1);
+
+    enqueueSpawnBehaviors(
+      { delayMs: 5_000, killCloseDelayMs: 100 },
+      { delayMs: 0, stdoutData: "next" },
+    );
+
+    const timedOut = runGitCommand(["status"], {
+      cwd: process.cwd(),
+      timeout: 20,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    const next = runGitCommand(["rev-parse", "--show-toplevel"], {
+      cwd: process.cwd(),
+    });
+
+    await vi.waitFor(() => {
+      expect(fakeSpawnController.processes[0]?.killed).toBe(true);
+    });
+    expect(fakeSpawnController.processes).toHaveLength(1);
+    expect(fakeSpawnController.activeCount).toBe(1);
+
+    await expect(timedOut).resolves.toEqual(
+      expect.objectContaining({
+        message: "Git command timed out after 20ms: git status",
+      }),
+    );
+    await expect(next).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "next",
+    });
+    expect(fakeSpawnController.peakActiveCount).toBe(1);
   });
 
   it("resolves truncated stdout, caps output, and kills the child process", async () => {

--- a/packages/server/src/utils/run-git-command.test.ts
+++ b/packages/server/src/utils/run-git-command.test.ts
@@ -6,6 +6,7 @@ interface FakeSpawnBehavior {
   emitError?: Error;
   exitCode?: number | null;
   killCloseDelayMs?: number;
+  killExitDelayMs?: number;
   stderrData?: Buffer | string;
   stdoutData?: Buffer | string;
 }
@@ -44,10 +45,11 @@ class FakeChildProcess extends EventEmitter {
   public readonly stdout = new EventEmitter();
   public killed = false;
   public killSignals: NodeJS.Signals[] = [];
+  public closed = false;
+  public exited = false;
 
   private readonly behavior: FakeSpawnBehavior;
   private readonly timers: NodeJS.Timeout[] = [];
-  private closed = false;
 
   public constructor(behavior: FakeSpawnBehavior) {
     super();
@@ -70,17 +72,31 @@ class FakeChildProcess extends EventEmitter {
     this.killed = true;
     this.killSignals.push(signal);
     this.clearTimers();
+    const exitDelayMs = this.behavior.killExitDelayMs ?? 0;
     this.schedule(() => {
-      this.finishClose({
+      this.finishExit({
         exitCode: null,
         signal,
       });
-    }, this.behavior.killCloseDelayMs ?? 0);
+    }, exitDelayMs);
+    this.schedule(
+      () => {
+        this.finishClose({
+          exitCode: null,
+          signal,
+        });
+      },
+      Math.max(exitDelayMs, this.behavior.killCloseDelayMs ?? exitDelayMs),
+    );
     return true;
   }
 
   public dispose(): void {
     this.clearTimers();
+    if (!this.exited) {
+      fakeSpawnController.activeCount -= 1;
+      this.exited = true;
+    }
     this.closed = true;
   }
 
@@ -126,10 +142,24 @@ class FakeChildProcess extends EventEmitter {
   }): void {
     if (this.closed) return;
 
+    this.finishExit({ exitCode, signal });
     this.closed = true;
     this.clearTimers();
-    fakeSpawnController.activeCount -= 1;
     this.emit("close", exitCode, signal);
+  }
+
+  private finishExit({
+    exitCode,
+    signal,
+  }: {
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+  }): void {
+    if (this.exited) return;
+
+    this.exited = true;
+    fakeSpawnController.activeCount -= 1;
+    this.emit("exit", exitCode, signal);
   }
 
   private finishError(error: Error): void {
@@ -230,11 +260,11 @@ describe("runGitCommand", () => {
     });
   });
 
-  it("holds the limiter slot until a timed out process closes", async () => {
+  it("holds the limiter slot until a timed out process exits without waiting for close", async () => {
     const { runGitCommand } = await loadRunGitCommand(1);
 
     enqueueSpawnBehaviors(
-      { delayMs: 5_000, killCloseDelayMs: 100 },
+      { delayMs: 5_000, killExitDelayMs: 100, killCloseDelayMs: 500 },
       { delayMs: 0, stdoutData: "next" },
     );
 
@@ -260,6 +290,11 @@ describe("runGitCommand", () => {
         message: "Git command timed out after 20ms: git status",
       }),
     );
+    await vi.waitFor(() => {
+      expect(fakeSpawnController.processes).toHaveLength(2);
+    });
+    expect(fakeSpawnController.processes[0]?.exited).toBe(true);
+    expect(fakeSpawnController.processes[0]?.closed).toBe(false);
     await expect(next).resolves.toMatchObject({
       exitCode: 0,
       stdout: "next",

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -197,16 +197,6 @@ export function runGitCommand(
         logger.trace(traceContext, "Spawning git command");
       }
 
-      // `core.quotepath=false` makes git emit raw UTF-8 paths instead of
-      // octal-escaping non-ASCII bytes (e.g. `测试文件.txt` vs `"\346\265\213..."`).
-      const child = spawnProcess("git", ["-c", "core.quotepath=false", ...args], {
-        cwd: options.cwd,
-        envOverlay,
-        shell: false,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      spawnGitCommandTrace(commandTrace, child.pid);
-
       let settled = false;
       let metricFinished = false;
       let processError: Error | null = null;
@@ -217,11 +207,12 @@ export function runGitCommand(
       let stderrBytes = 0;
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
+      let timer: NodeJS.Timeout | undefined;
 
       const settle = (callback: () => void) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
         callback();
       };
 
@@ -263,7 +254,42 @@ export function runGitCommand(
         }
       };
 
-      const timer = setTimeout(() => {
+      const rejectSpawnFailure = (error: unknown) => {
+        processError = error instanceof Error ? error : new Error(String(error));
+        markProcessExited(null, null);
+        settleGitCommandTrace(commandTrace, {
+          outcome: "spawn_error",
+          exitCode: null,
+          signal: null,
+        });
+        settle(() => reject(processError));
+      };
+
+      let child: ReturnType<typeof spawnProcess>;
+      try {
+        // `core.quotepath=false` makes git emit raw UTF-8 paths instead of
+        // octal-escaping non-ASCII bytes (e.g. `测试文件.txt` vs `"\346\265\213..."`).
+        child = spawnProcess("git", ["-c", "core.quotepath=false", ...args], {
+          cwd: options.cwd,
+          envOverlay,
+          shell: false,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        spawnGitCommandTrace(commandTrace, child.pid);
+      } catch (error) {
+        rejectSpawnFailure(error);
+        return;
+      }
+
+      const stdout = child.stdout;
+      const stderr = child.stderr;
+      if (!stdout || !stderr) {
+        child.kill("SIGKILL");
+        rejectSpawnFailure(new Error("Git process did not expose piped stdout and stderr"));
+        return;
+      }
+
+      timer = setTimeout(() => {
         timeoutError = new Error(`Git command timed out after ${timeout}ms: ${command}`);
         child.kill("SIGKILL");
         settle(() => reject(timeoutError));
@@ -272,7 +298,7 @@ export function runGitCommand(
         }
       }, timeout);
 
-      child.stdout!.on("data", (chunk: Buffer | string) => {
+      stdout.on("data", (chunk: Buffer | string) => {
         if (settled || truncated) return;
 
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
@@ -296,7 +322,7 @@ export function runGitCommand(
         stdoutBytes += buffer.length;
       });
 
-      child.stderr!.on("data", (chunk: Buffer | string) => {
+      stderr.on("data", (chunk: Buffer | string) => {
         if (settled || stderrBytes >= DEFAULT_STDERR_LIMIT) return;
 
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs";
-import pLimit from "p-limit";
 import type { Logger } from "pino";
 import type { ProcessEnvRecord } from "../server/paseo-env.js";
 import {
@@ -13,14 +12,30 @@ import {
   submitGitCommandTrace,
 } from "./git-command-trace.js";
 import { spawnProcess } from "./spawn.js";
+import {
+  GitProcessScheduler,
+  resolveGitProcessPolicy,
+  type GitProcessPolicy,
+} from "./git-process-scheduler.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 20 * 1024 * 1024; // 20MB
 const DEFAULT_STDERR_LIMIT = 2048;
 
-const gitConcurrency = parseInt(process.env.PASEO_GIT_CONCURRENCY ?? "8", 10) || 8;
-const gitLimit = pLimit(gitConcurrency);
-const gitRuntimeMetrics = new GitCommandRuntimeMetricsWindow(gitConcurrency);
+let gitProcessScheduler = new GitProcessScheduler(resolveGitProcessPolicy({ env: process.env }));
+let gitRuntimeMetrics = createGitCommandRuntimeMetricsWindow(gitProcessScheduler.policy);
+
+function createGitCommandRuntimeMetricsWindow(policy: GitProcessPolicy) {
+  return new GitCommandRuntimeMetricsWindow({
+    concurrencyLimit: policy.maxProcessConcurrency,
+    maxProcessesPerSecond: policy.maxProcessesPerSecond,
+  });
+}
+
+export function configureGitProcessPolicy(policy: GitProcessPolicy): void {
+  gitProcessScheduler = new GitProcessScheduler(policy);
+  gitRuntimeMetrics = createGitCommandRuntimeMetricsWindow(policy);
+}
 
 export interface GitCommandOptions {
   cwd: string;
@@ -94,8 +109,8 @@ export function stopGitCommandMetrics(): GitCommandMetricsSnapshot {
 
 export function snapshotGitCommandRuntimeMetrics(): GitCommandRuntimeMetricsSnapshot {
   return gitRuntimeMetrics.snapshotAndReset({
-    active: gitLimit.activeCount,
-    pending: gitLimit.pendingCount,
+    active: gitProcessScheduler.activeCount,
+    pending: gitProcessScheduler.pendingCount,
   });
 }
 
@@ -142,16 +157,16 @@ export function runGitCommand(
   options: GitCommandOptions,
 ): Promise<GitCommandResult> {
   const commandTrace = submitGitCommandTrace(args, options.cwd, {
-    active: gitLimit.activeCount,
-    pending: gitLimit.pendingCount,
+    active: gitProcessScheduler.activeCount,
+    pending: gitProcessScheduler.pendingCount,
   });
   const runtimeMetric = gitRuntimeMetrics.submit(getGitOperation(args));
-  const promise = gitLimit(
+  const promise = gitProcessScheduler.run(
     () =>
       new Promise<GitCommandResult>((resolve, reject) => {
         startGitCommandTrace(commandTrace, {
-          active: gitLimit.activeCount,
-          pending: gitLimit.pendingCount,
+          active: gitProcessScheduler.activeCount,
+          pending: gitProcessScheduler.pendingCount,
         });
         gitRuntimeMetrics.start(runtimeMetric);
         const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
@@ -367,7 +382,10 @@ export function runGitCommand(
         });
       }),
   );
-  gitRuntimeMetrics.observeLimiter(gitLimit.activeCount, gitLimit.pendingCount);
+  gitRuntimeMetrics.observeLimiter(
+    gitProcessScheduler.activeCount,
+    gitProcessScheduler.pendingCount,
+  );
   return promise;
 }
 

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -232,12 +232,18 @@ export function runGitCommand(
         gitRuntimeMetrics.finish(runtimeMetric, { success: metric.success, timedOut });
       };
 
-      const finishTimeoutOnce = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+      const settleTimeoutTrace = (exitCode: number | null, signal: NodeJS.Signals | null) => {
         settleGitCommandTrace(commandTrace, {
           outcome: "timed_out",
           exitCode,
           signal,
         });
+      };
+
+      const markProcessExited = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+        if (processExit) return;
+        processExit = { exitCode, signal };
+        const timedOut = timeoutError !== null;
         finishMetricOnce(
           {
             args,
@@ -246,18 +252,14 @@ export function runGitCommand(
             durationMs: Date.now() - startedAt,
             exitCode,
             signal,
-            success: false,
+            success:
+              !timedOut && !processError && (truncated || acceptExitCodes.includes(exitCode ?? -1)),
           },
-          true,
+          timedOut,
         );
-      };
-
-      const markProcessExited = (exitCode: number | null, signal: NodeJS.Signals | null) => {
-        if (processExit) return;
-        processExit = { exitCode, signal };
         releaseProcessSlot();
-        if (timeoutError) {
-          finishTimeoutOnce(exitCode, signal);
+        if (timedOut) {
+          settleTimeoutTrace(exitCode, signal);
         }
       };
 
@@ -266,7 +268,7 @@ export function runGitCommand(
         child.kill("SIGKILL");
         settle(() => reject(timeoutError));
         if (processExit) {
-          finishTimeoutOnce(processExit.exitCode, processExit.signal);
+          settleTimeoutTrace(processExit.exitCode, processExit.signal);
         }
       }, timeout);
 
@@ -360,15 +362,6 @@ export function runGitCommand(
             exitCode,
             signal,
           });
-          finishMetricOnce({
-            args,
-            cwd: options.cwd,
-            startedAtMs: startedAt,
-            durationMs: Date.now() - startedAt,
-            exitCode,
-            signal,
-            success: false,
-          });
           settle(() => reject(processError));
           return;
         }
@@ -381,15 +374,6 @@ export function runGitCommand(
         });
 
         if (!truncated && !acceptExitCodes.includes(exitCode ?? -1)) {
-          finishMetricOnce({
-            args,
-            cwd: options.cwd,
-            startedAtMs: startedAt,
-            durationMs: Date.now() - startedAt,
-            exitCode,
-            signal,
-            success: false,
-          });
           const stderrPreview = result.stderr.trim() || "(no stderr)";
           const truncationNote = result.truncated ? " (stdout truncated)" : "";
 
@@ -403,15 +387,6 @@ export function runGitCommand(
           return;
         }
 
-        finishMetricOnce({
-          args,
-          cwd: options.cwd,
-          startedAtMs: startedAt,
-          durationMs: Date.now() - startedAt,
-          exitCode,
-          signal,
-          success: true,
-        });
         settle(() => resolve(result));
       });
     });

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -206,6 +206,8 @@ export function runGitCommand(
 
         let settled = false;
         let metricFinished = false;
+        let processError: Error | null = null;
+        let timeoutError: Error | null = null;
         let truncated = false;
         let stdoutBytes = 0;
         let stderrBytes = 0;
@@ -227,26 +229,8 @@ export function runGitCommand(
         };
 
         const timer = setTimeout(() => {
-          const error = new Error(`Git command timed out after ${timeout}ms: ${command}`);
+          timeoutError = new Error(`Git command timed out after ${timeout}ms: ${command}`);
           child.kill("SIGKILL");
-          settleGitCommandTrace(commandTrace, {
-            outcome: "timed_out",
-            exitCode: null,
-            signal: "SIGKILL",
-          });
-          finishMetricOnce(
-            {
-              args,
-              cwd: options.cwd,
-              startedAtMs: startedAt,
-              durationMs: Date.now() - startedAt,
-              exitCode: null,
-              signal: "SIGKILL",
-              success: false,
-            },
-            true,
-          );
-          settle(() => reject(error));
         }, timeout);
 
         child.stdout!.on("data", (chunk: Buffer | string) => {
@@ -290,20 +274,7 @@ export function runGitCommand(
         });
 
         child.on("error", (error) => {
-          settleGitCommandTrace(commandTrace, {
-            outcome: "spawn_error",
-            exitCode: null,
-            signal: null,
-          });
-          finishMetricOnce({
-            args,
-            cwd: options.cwd,
-            startedAtMs: startedAt,
-            durationMs: Date.now() - startedAt,
-            exitCode: null,
-            signal: null,
-            success: false,
-          });
+          processError = error;
           if (logger && traceContext) {
             logger.trace(
               {
@@ -314,16 +285,9 @@ export function runGitCommand(
               "Git command process error",
             );
           }
-          settle(() => reject(error));
         });
 
         child.on("close", (exitCode, signal) => {
-          settleGitCommandTrace(commandTrace, {
-            outcome: "closed",
-            exitCode,
-            signal,
-            truncated,
-          });
           const result: GitCommandResult = {
             stdout: Buffer.concat(stdoutChunks).toString("utf8"),
             stderr: Buffer.concat(stderrChunks).toString("utf8"),
@@ -345,6 +309,54 @@ export function runGitCommand(
               "Git command closed",
             );
           }
+
+          if (timeoutError) {
+            settleGitCommandTrace(commandTrace, {
+              outcome: "timed_out",
+              exitCode,
+              signal,
+            });
+            finishMetricOnce(
+              {
+                args,
+                cwd: options.cwd,
+                startedAtMs: startedAt,
+                durationMs: Date.now() - startedAt,
+                exitCode,
+                signal,
+                success: false,
+              },
+              true,
+            );
+            settle(() => reject(timeoutError));
+            return;
+          }
+
+          if (processError) {
+            settleGitCommandTrace(commandTrace, {
+              outcome: "spawn_error",
+              exitCode,
+              signal,
+            });
+            finishMetricOnce({
+              args,
+              cwd: options.cwd,
+              startedAtMs: startedAt,
+              durationMs: Date.now() - startedAt,
+              exitCode,
+              signal,
+              success: false,
+            });
+            settle(() => reject(processError));
+            return;
+          }
+
+          settleGitCommandTrace(commandTrace, {
+            outcome: "closed",
+            exitCode,
+            signal,
+            truncated,
+          });
 
           if (!truncated && !acceptExitCodes.includes(exitCode ?? -1)) {
             finishMetricOnce({

--- a/packages/server/src/utils/run-git-command.ts
+++ b/packages/server/src/utils/run-git-command.ts
@@ -161,226 +161,205 @@ export function runGitCommand(
     pending: gitProcessScheduler.pendingCount,
   });
   const runtimeMetric = gitRuntimeMetrics.submit(getGitOperation(args));
-  const promise = gitProcessScheduler.run(
-    () =>
-      new Promise<GitCommandResult>((resolve, reject) => {
-        startGitCommandTrace(commandTrace, {
-          active: gitProcessScheduler.activeCount,
-          pending: gitProcessScheduler.pendingCount,
-        });
-        gitRuntimeMetrics.start(runtimeMetric);
-        const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
-        const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
-        const acceptExitCodes = options.acceptExitCodes ?? [0];
-        const command = formatGitCommand(args);
-        const envOverlay = mergeEnvOverlays(options.env, options.envOverlay);
-        const startedAt = Date.now();
-        const metricsState = beginGitCommandMetric();
-        const logger = typeof options.logger?.trace === "function" ? options.logger : undefined;
-        const traceContext = logger
-          ? {
-              command: "git",
-              args,
-              cwd: options.cwd,
-              cwdExists: existsSync(options.cwd),
-              timeout,
-              maxOutputBytes,
-              acceptExitCodes,
-              envOverlayKeys: getEnvOverlayKeys(envOverlay),
-            }
-          : null;
+  const promise = gitProcessScheduler.run(() => {
+    let releaseProcessSlot!: () => void;
+    const exited = new Promise<void>((resolve) => {
+      releaseProcessSlot = resolve;
+    });
+    const resultPromise = new Promise<GitCommandResult>((resolve, reject) => {
+      startGitCommandTrace(commandTrace, {
+        active: gitProcessScheduler.activeCount,
+        pending: gitProcessScheduler.pendingCount,
+      });
+      gitRuntimeMetrics.start(runtimeMetric);
+      const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+      const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+      const acceptExitCodes = options.acceptExitCodes ?? [0];
+      const command = formatGitCommand(args);
+      const envOverlay = mergeEnvOverlays(options.env, options.envOverlay);
+      const startedAt = Date.now();
+      const metricsState = beginGitCommandMetric();
+      const logger = typeof options.logger?.trace === "function" ? options.logger : undefined;
+      const traceContext = logger
+        ? {
+            command: "git",
+            args,
+            cwd: options.cwd,
+            cwdExists: existsSync(options.cwd),
+            timeout,
+            maxOutputBytes,
+            acceptExitCodes,
+            envOverlayKeys: getEnvOverlayKeys(envOverlay),
+          }
+        : null;
 
-        if (logger && traceContext) {
-          logger.trace(traceContext, "Spawning git command");
+      if (logger && traceContext) {
+        logger.trace(traceContext, "Spawning git command");
+      }
+
+      // `core.quotepath=false` makes git emit raw UTF-8 paths instead of
+      // octal-escaping non-ASCII bytes (e.g. `测试文件.txt` vs `"\346\265\213..."`).
+      const child = spawnProcess("git", ["-c", "core.quotepath=false", ...args], {
+        cwd: options.cwd,
+        envOverlay,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      spawnGitCommandTrace(commandTrace, child.pid);
+
+      let settled = false;
+      let metricFinished = false;
+      let processError: Error | null = null;
+      let processExit: { exitCode: number | null; signal: NodeJS.Signals | null } | null = null;
+      let timeoutError: Error | null = null;
+      let truncated = false;
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+
+      const settle = (callback: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        callback();
+      };
+
+      const finishMetricOnce = (metric: GitCommandMetric, timedOut = false) => {
+        if (metricFinished) return;
+        metricFinished = true;
+        finishGitCommandMetric(metricsState, metric);
+        gitRuntimeMetrics.finish(runtimeMetric, { success: metric.success, timedOut });
+      };
+
+      const finishTimeoutOnce = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+        settleGitCommandTrace(commandTrace, {
+          outcome: "timed_out",
+          exitCode,
+          signal,
+        });
+        finishMetricOnce(
+          {
+            args,
+            cwd: options.cwd,
+            startedAtMs: startedAt,
+            durationMs: Date.now() - startedAt,
+            exitCode,
+            signal,
+            success: false,
+          },
+          true,
+        );
+      };
+
+      const markProcessExited = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+        if (processExit) return;
+        processExit = { exitCode, signal };
+        releaseProcessSlot();
+        if (timeoutError) {
+          finishTimeoutOnce(exitCode, signal);
+        }
+      };
+
+      const timer = setTimeout(() => {
+        timeoutError = new Error(`Git command timed out after ${timeout}ms: ${command}`);
+        child.kill("SIGKILL");
+        settle(() => reject(timeoutError));
+        if (processExit) {
+          finishTimeoutOnce(processExit.exitCode, processExit.signal);
+        }
+      }, timeout);
+
+      child.stdout!.on("data", (chunk: Buffer | string) => {
+        if (settled || truncated) return;
+
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        const remainingBytes = maxOutputBytes - stdoutBytes;
+
+        if (remainingBytes <= 0) {
+          truncated = true;
+          child.kill("SIGKILL");
+          return;
         }
 
-        // `core.quotepath=false` makes git emit raw UTF-8 paths instead of
-        // octal-escaping non-ASCII bytes (e.g. `测试文件.txt` vs `"\346\265\213..."`).
-        const child = spawnProcess("git", ["-c", "core.quotepath=false", ...args], {
-          cwd: options.cwd,
-          envOverlay,
-          shell: false,
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        spawnGitCommandTrace(commandTrace, child.pid);
-
-        let settled = false;
-        let metricFinished = false;
-        let processError: Error | null = null;
-        let timeoutError: Error | null = null;
-        let truncated = false;
-        let stdoutBytes = 0;
-        let stderrBytes = 0;
-        const stdoutChunks: Buffer[] = [];
-        const stderrChunks: Buffer[] = [];
-
-        const settle = (callback: () => void) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timer);
-          callback();
-        };
-
-        const finishMetricOnce = (metric: GitCommandMetric, timedOut = false) => {
-          if (metricFinished) return;
-          metricFinished = true;
-          finishGitCommandMetric(metricsState, metric);
-          gitRuntimeMetrics.finish(runtimeMetric, { success: metric.success, timedOut });
-        };
-
-        const timer = setTimeout(() => {
-          timeoutError = new Error(`Git command timed out after ${timeout}ms: ${command}`);
+        if (buffer.length > remainingBytes) {
+          stdoutChunks.push(buffer.subarray(0, remainingBytes));
+          stdoutBytes += remainingBytes;
+          truncated = true;
           child.kill("SIGKILL");
-        }, timeout);
+          return;
+        }
 
-        child.stdout!.on("data", (chunk: Buffer | string) => {
-          if (settled || truncated) return;
+        stdoutChunks.push(buffer);
+        stdoutBytes += buffer.length;
+      });
 
-          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-          const remainingBytes = maxOutputBytes - stdoutBytes;
+      child.stderr!.on("data", (chunk: Buffer | string) => {
+        if (settled || stderrBytes >= DEFAULT_STDERR_LIMIT) return;
 
-          if (remainingBytes <= 0) {
-            truncated = true;
-            child.kill("SIGKILL");
-            return;
-          }
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        const remainingBytes = DEFAULT_STDERR_LIMIT - stderrBytes;
 
-          if (buffer.length > remainingBytes) {
-            stdoutChunks.push(buffer.subarray(0, remainingBytes));
-            stdoutBytes += remainingBytes;
-            truncated = true;
-            child.kill("SIGKILL");
-            return;
-          }
+        if (buffer.length > remainingBytes) {
+          stderrChunks.push(buffer.subarray(0, remainingBytes));
+          stderrBytes += remainingBytes;
+          return;
+        }
 
-          stdoutChunks.push(buffer);
-          stdoutBytes += buffer.length;
-        });
+        stderrChunks.push(buffer);
+        stderrBytes += buffer.length;
+      });
 
-        child.stderr!.on("data", (chunk: Buffer | string) => {
-          if (settled || stderrBytes >= DEFAULT_STDERR_LIMIT) return;
+      child.on("error", (error) => {
+        processError = error;
+        if (logger && traceContext) {
+          logger.trace(
+            {
+              ...traceContext,
+              err: error,
+              durationMs: Date.now() - startedAt,
+            },
+            "Git command process error",
+          );
+        }
+      });
 
-          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-          const remainingBytes = DEFAULT_STDERR_LIMIT - stderrBytes;
+      child.on("exit", markProcessExited);
 
-          if (buffer.length > remainingBytes) {
-            stderrChunks.push(buffer.subarray(0, remainingBytes));
-            stderrBytes += remainingBytes;
-            return;
-          }
-
-          stderrChunks.push(buffer);
-          stderrBytes += buffer.length;
-        });
-
-        child.on("error", (error) => {
-          processError = error;
-          if (logger && traceContext) {
-            logger.trace(
-              {
-                ...traceContext,
-                err: error,
-                durationMs: Date.now() - startedAt,
-              },
-              "Git command process error",
-            );
-          }
-        });
-
-        child.on("close", (exitCode, signal) => {
-          const result: GitCommandResult = {
-            stdout: Buffer.concat(stdoutChunks).toString("utf8"),
-            stderr: Buffer.concat(stderrChunks).toString("utf8"),
-            truncated,
-            exitCode,
-            signal,
-          };
-          if (logger && traceContext) {
-            logger.trace(
-              {
-                ...traceContext,
-                durationMs: Date.now() - startedAt,
-                exitCode,
-                signal,
-                truncated,
-                stdoutBytes,
-                stderrBytes,
-              },
-              "Git command closed",
-            );
-          }
-
-          if (timeoutError) {
-            settleGitCommandTrace(commandTrace, {
-              outcome: "timed_out",
-              exitCode,
-              signal,
-            });
-            finishMetricOnce(
-              {
-                args,
-                cwd: options.cwd,
-                startedAtMs: startedAt,
-                durationMs: Date.now() - startedAt,
-                exitCode,
-                signal,
-                success: false,
-              },
-              true,
-            );
-            settle(() => reject(timeoutError));
-            return;
-          }
-
-          if (processError) {
-            settleGitCommandTrace(commandTrace, {
-              outcome: "spawn_error",
-              exitCode,
-              signal,
-            });
-            finishMetricOnce({
-              args,
-              cwd: options.cwd,
-              startedAtMs: startedAt,
+      child.on("close", (exitCode, signal) => {
+        markProcessExited(exitCode, signal);
+        const result: GitCommandResult = {
+          stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+          stderr: Buffer.concat(stderrChunks).toString("utf8"),
+          truncated,
+          exitCode,
+          signal,
+        };
+        if (logger && traceContext) {
+          logger.trace(
+            {
+              ...traceContext,
               durationMs: Date.now() - startedAt,
               exitCode,
               signal,
-              success: false,
-            });
-            settle(() => reject(processError));
-            return;
-          }
+              truncated,
+              stdoutBytes,
+              stderrBytes,
+            },
+            "Git command closed",
+          );
+        }
 
+        if (timeoutError) {
+          return;
+        }
+
+        if (processError) {
           settleGitCommandTrace(commandTrace, {
-            outcome: "closed",
+            outcome: "spawn_error",
             exitCode,
             signal,
-            truncated,
           });
-
-          if (!truncated && !acceptExitCodes.includes(exitCode ?? -1)) {
-            finishMetricOnce({
-              args,
-              cwd: options.cwd,
-              startedAtMs: startedAt,
-              durationMs: Date.now() - startedAt,
-              exitCode,
-              signal,
-              success: false,
-            });
-            const stderrPreview = result.stderr.trim() || "(no stderr)";
-            const truncationNote = result.truncated ? " (stdout truncated)" : "";
-
-            settle(() =>
-              reject(
-                new Error(
-                  `Git command failed: ${command}${truncationNote} (exit code: ${String(exitCode)}, signal: ${signal ?? "none"})\n${stderrPreview}`,
-                ),
-              ),
-            );
-            return;
-          }
-
           finishMetricOnce({
             args,
             cwd: options.cwd,
@@ -388,12 +367,56 @@ export function runGitCommand(
             durationMs: Date.now() - startedAt,
             exitCode,
             signal,
-            success: true,
+            success: false,
           });
-          settle(() => resolve(result));
+          settle(() => reject(processError));
+          return;
+        }
+
+        settleGitCommandTrace(commandTrace, {
+          outcome: "closed",
+          exitCode,
+          signal,
+          truncated,
         });
-      }),
-  );
+
+        if (!truncated && !acceptExitCodes.includes(exitCode ?? -1)) {
+          finishMetricOnce({
+            args,
+            cwd: options.cwd,
+            startedAtMs: startedAt,
+            durationMs: Date.now() - startedAt,
+            exitCode,
+            signal,
+            success: false,
+          });
+          const stderrPreview = result.stderr.trim() || "(no stderr)";
+          const truncationNote = result.truncated ? " (stdout truncated)" : "";
+
+          settle(() =>
+            reject(
+              new Error(
+                `Git command failed: ${command}${truncationNote} (exit code: ${String(exitCode)}, signal: ${signal ?? "none"})\n${stderrPreview}`,
+              ),
+            ),
+          );
+          return;
+        }
+
+        finishMetricOnce({
+          args,
+          cwd: options.cwd,
+          startedAtMs: startedAt,
+          durationMs: Date.now() - startedAt,
+          exitCode,
+          signal,
+          success: true,
+        });
+        settle(() => resolve(result));
+      });
+    });
+    return { result: resultPromise, exited };
+  });
   gitRuntimeMetrics.observeLimiter(
     gitProcessScheduler.activeCount,
     gitProcessScheduler.pendingCount,

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
     },
   },
   test: {
+    // Fake-timer suites freeze p-throttle's clock, so a real per-second cap deadlocks them.
+    env: {
+      PASEO_GIT_MAX_PROCESSES_PER_SECOND: "10000",
+    },
     testTimeout: 30000,
     hookTimeout: 60000,
     globals: true,

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -72,6 +72,20 @@
               },
               "additionalProperties": true
             },
+            "git": {
+              "type": "object",
+              "properties": {
+                "maxProcessesPerSecond": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "maxProcessConcurrency": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                }
+              },
+              "additionalProperties": false
+            },
             "autoArchiveAfterMerge": {
               "type": "boolean"
             },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,6 +57,10 @@ export default defineConfig({
     ],
   },
   test: {
+    // Fake-timer suites freeze p-throttle's clock, so a real per-second cap deadlocks them.
+    env: {
+      PASEO_GIT_MAX_PROCESSES_PER_SECOND: "10000",
+    },
     exclude: [...configDefaults.exclude, "**/.claude/**", "**/.dev/**"],
   },
 });


### PR DESCRIPTION
Git-heavy workspace refreshes now share daemon-global limits for both process starts and unresolved processes. Users can tune both limits in config.json or with environment variables when Git activity strains their machine.

### Linked issue

Refs #2753
Refs #1114
Refs #2391

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

The existing concurrency ceiling limited live Git processes but still allowed fast commands to churn through new process launches continuously. That can monopolize CPU, disk, process creation, and antivirus scanning during a large workspace refresh or any later watcher burst.

Every Git command now crosses one daemon-global scheduler. The scheduler limits starts in a strict one-second interval and retains the existing unresolved-process ceiling. The limits default to 64 starts per second and 8 concurrent processes, apply uniformly to bootstrap, watcher refreshes, background work, and RPCs, and are exposed through daemon runtime metrics.

Persisted configuration lives under daemon.git. Environment variables override the JSON settings, and the legacy PASEO_GIT_CONCURRENCY variable remains supported below the renamed concurrency variable.

### Goals

- Bound Git process starts and unresolved Git processes across the whole daemon.
- Use the same policy for every source of Git work without separate bootstrap or foreground paths.
- Let users tune constrained hosts through config.json and environment variables.
- Preserve the legacy concurrency environment variable.
- Document defaults, trade-offs, troubleshooting, and restart behavior.

### Non-goals

- Prioritize individual Git callers or RPCs.
- Change workspace refresh, watcher, or per-workspace coalescing semantics.
- Eliminate the initial Git snapshot required for accurate workspace state.
- Dynamically reload these process limits without a daemon restart.

### QA

Automated verification:

- 18 focused tests passed across the process scheduler, configuration precedence, command execution, and runtime metrics.
- npm run typecheck passed across every workspace.
- npm run lint passed with zero warnings and errors.
- npm run format passed.

Seeded daemon/browser verification on macOS with 8 starts/second and 8 concurrent processes:

- The workspace and agent timeline rendered while Git work remained queued; 25 commands were still pending at capture time.
- Timeline request to provider-process spawn measured 325 ms, compared with a 2.05 s pre-throttle median.
- Event-loop delay measured 40.4 ms p99 and 131.6 ms max, compared with pre-throttle runs of 177.5–222 ms p99 and 190–286 ms max.
- The loading overlay remained governed by agent history hydration and was visible for 4.39 s.

Windows was not manually tested. Windows-specific behavior is covered by the shared process boundary, but constrained Windows and antivirus environments are the primary risk surface for maintainer QA.

### Risk surface

Lower limits deliberately increase Git queue latency, including for Git-backed RPCs. The default permits an initial burst of up to 64 starts while preventing more than 8 live processes; custom values require a daemon restart. Configuration precedence and both independent constraints have focused tests.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [x] Tests added or updated where it made sense


