### PR TITLE
Fix the two CI failures on main

### DIFF
--- a/packages/app/e2e/support/helpers/chat-outline.ts
+++ b/packages/app/e2e/support/helpers/chat-outline.ts
@@ -91,19 +91,19 @@ export async function expectNoChatOutlinePreviewWhileCrossingToSidebar(page: Pag
     Object.assign(window, { __chatOutlinePreviewObserver: observer });
   });
 
-  for (let step = 0; step <= 10; step += 1) {
-    await page.mouse.move(
-      railBox.x + railBox.width - 1 - (step * railBox.width) / 10,
-      railBox.y + railBox.height / 2,
-    );
-    await page.evaluate(
-      () =>
-        new Promise<void>((resolve) => {
-          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-        }),
-    );
-  }
-  await page.mouse.move(railBox.x - 2, railBox.y + railBox.height / 2);
+  // One uninterrupted sweep. The rail suppresses the preview by restarting its
+  // dwell timer on every horizontal move, so the crossing only means what the
+  // test says it means while the moves stay closer together than that timer.
+  // Waiting for a frame between steps handed that spacing to the main thread —
+  // a busy renderer stretched a step past the dwell window and the rail opened a
+  // preview the reader never asked for.
+  await page.mouse.move(railBox.x - 2, railBox.y + railBox.height / 2, { steps: 12 });
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
 
   const previewAppeared = await page.evaluate(() => {
     const observer = Reflect.get(window, "__chatOutlinePreviewObserver") as

--- a/packages/app/e2e/support/helpers/chat-outline.ts
+++ b/packages/app/e2e/support/helpers/chat-outline.ts
@@ -91,12 +91,8 @@ export async function expectNoChatOutlinePreviewWhileCrossingToSidebar(page: Pag
     Object.assign(window, { __chatOutlinePreviewObserver: observer });
   });
 
-  // One uninterrupted sweep. The rail suppresses the preview by restarting its
-  // dwell timer on every horizontal move, so the crossing only means what the
-  // test says it means while the moves stay closer together than that timer.
-  // Waiting for a frame between steps handed that spacing to the main thread —
-  // a busy renderer stretched a step past the dwell window and the rail opened a
-  // preview the reader never asked for.
+  // One uninterrupted sweep: waiting for a frame between steps lets a busy
+  // renderer stretch the crossing past the rail's dwell timer, which activates.
   await page.mouse.move(railBox.x - 2, railBox.y + railBox.height / 2, { steps: 12 });
   await page.evaluate(
     () =>

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -853,10 +853,7 @@ export class HubRelationshipHarness {
           15_000,
         );
         timeout.unref?.();
-        // fs.watch is an optimization here, not the contract: Windows drops
-        // directory events under load, and a dropped one used to mean this
-        // waiter slept through a completed archive until the timeout. Re-read
-        // the state on a timer so the wait ends when the archive ends.
+        // Windows drops fs.watch directory events under load; re-read anyway.
         const poll = setInterval(() => void observeCompletion(), 250);
         poll.unref?.();
         const closeWatchers = () => {

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -853,8 +853,15 @@ export class HubRelationshipHarness {
           15_000,
         );
         timeout.unref?.();
+        // fs.watch is an optimization here, not the contract: Windows drops
+        // directory events under load, and a dropped one used to mean this
+        // waiter slept through a completed archive until the timeout. Re-read
+        // the state on a timer so the wait ends when the archive ends.
+        const poll = setInterval(() => void observeCompletion(), 250);
+        poll.unref?.();
         const closeWatchers = () => {
           clearTimeout(timeout);
+          clearInterval(poll);
           for (const watcher of watchers) watcher.close();
         };
         const finish = (

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1200,7 +1200,12 @@ async function removeDirectoryWithRetries(path: string): Promise<void> {
     return;
   }
 
-  const delaysMs = [0, 100, 300, 700, 1500];
+  // Windows refuses to unlink a directory any live process still holds open,
+  // and an archived agent's process is only just being torn down when we get
+  // here. The tail of this backoff exists for that window: give the OS long
+  // enough to release the handles rather than reporting a removal failure for a
+  // worktree that goes away a second later.
+  const delaysMs = [0, 100, 300, 700, 1500, 2500, 2500, 2500];
   let lastError: unknown = null;
   for (const delay of delaysMs) {
     if (delay > 0) {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1200,11 +1200,8 @@ async function removeDirectoryWithRetries(path: string): Promise<void> {
     return;
   }
 
-  // Windows refuses to unlink a directory any live process still holds open,
-  // and an archived agent's process is only just being torn down when we get
-  // here. The tail of this backoff exists for that window: give the OS long
-  // enough to release the handles rather than reporting a removal failure for a
-  // worktree that goes away a second later.
+  // The tail covers Windows, which won't unlink a directory a live process
+  // still holds — an archived agent's process is only just being torn down.
   const delaysMs = [0, 100, 300, 700, 1500, 2500, 2500, 2500];
   let lastError: unknown = null;
   for (const delay of delaysMs) {


### PR DESCRIPTION
`main` is red at 553ac53 on two tests. Both fail on timing rather than on behavior.

## Chat outline: crossing the rail toward the sidebar

`chat-outline.spec.ts › does not preview while crossing the rail toward the sidebar` failed on the initial run and the retry in shard 1/4. The test is new in #2792, and CI passed twice on that PR — so it flakes, it does not reproduce deterministically.

The rail suppresses its preview by restarting a 150ms dwell timer on every horizontal move (`hover-intent.ts`). The helper drove the crossing one step at a time and awaited a double `requestAnimationFrame` between steps. That handed the spacing between moves to the main thread: under a loaded runner rendering a 16-turn timeline across four shards, one frame wait outran the dwell timer, the rail activated, and the assertion caught real behavior at a crossing speed no reader can produce.

The crossing is now a single continuous `mouse.move(..., { steps: 12 })`, which dispatches the intermediate moves back to back. One frame wait stays at the end so a genuinely missing guard still commits and still fails the test.

## Windows: archiving a running execution's worktree

`execution-session.websocket.test.ts › Hub archives a running execution's Paseo-created worktree` timed out waiting for the worktree to disappear. This one is not from #2792 — the same test failed the same way on run 30711564703 yesterday. It is a recurring Windows flake.

The test archives an execution whose agent is still running (`sleep 30`) with its cwd inside the worktree. Two things could strand it, and this fixes both:

- **Removal budget.** Windows will not unlink a directory a live process still holds open, and the agent process is only just being torn down when removal starts. `removeDirectoryWithRetries` gave up after ~2.6s, which can report a failure for a worktree that goes away a moment later. The backoff now carries a longer tail. On POSIX removal succeeds on the first attempt, so nothing changes there.
- **Completion observation.** The harness learned about completion only from `fs.watch`, which drops directory events on Windows under load; a dropped event meant the waiter slept through a completed archive until its 15s timeout. It now re-reads the state on a 250ms timer as well — the same watch-plus-poll shape `FileObserver` already uses in production.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format` — clean.
- `packages/server/src/utils/worktree.test.ts` + `worktree.posix.test.ts` — 63 passed.
- `packages/app/src/agent-stream/chat-outline/hover-intent.test.ts` — 4 passed. No product hover logic changed.

Neither failing test runs on my machine, so both fixes rest on the CI evidence and the code rather than on a local reproduction: the app e2e daemon client cannot connect here, and every test in `execution-session.websocket.test.ts` fails identically on unmodified `main` with "An invalid or duplicated subprotocol was specified". The Windows path in particular is only exercisable on the Windows runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)