### PR TITLE
Use native macOS application and Window menus

### DIFF
--- a/packages/desktop/src/features/menu.test.ts
+++ b/packages/desktop/src/features/menu.test.ts
@@ -1,5 +1,51 @@
-import { describe, expect, it } from "vitest";
-import { reloadActiveBrowserOrWindow } from "./menu.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { reloadActiveBrowserOrWindow, setupApplicationMenu } from "./menu.js";
+
+const electronMocks = vi.hoisted(() => {
+  const appMenuInsert = vi.fn();
+  return {
+    appMenuInsert,
+    buildFromTemplate: vi.fn((template: unknown) => ({
+      getMenuItemById: vi.fn((id: string) =>
+        id === "application-menu"
+          ? {
+              submenu: {
+                insert: appMenuInsert,
+                items: [{ role: "about" }, { type: "separator" }, { role: "services" }],
+              },
+            }
+          : null,
+      ),
+      template,
+    })),
+    setApplicationMenu: vi.fn(),
+  };
+});
+
+vi.mock("electron", () => ({
+  app: { on: vi.fn() },
+  BrowserWindow: class BrowserWindow {
+    public readonly webContents = {};
+
+    public static getFocusedWindow(): null {
+      return null;
+    }
+
+    public static fromWebContents(): null {
+      return null;
+    }
+  },
+  ipcMain: { handle: vi.fn() },
+  Menu: electronMocks,
+  MenuItem: class MenuItem {
+    public constructor(public readonly options: unknown) {}
+  },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
 
 class FakeWebContents {
   public readonly reloads: string[] = [];
@@ -66,5 +112,39 @@ describe("reloadActiveBrowserOrWindow", () => {
     expect(browserReloads.firstBrowser.reloads).toEqual([]);
     expect(browserReloads.secondBrowser.reloads).toEqual(["force-reload"]);
     expect(browserReloads.secondWindow.webContents.reloads).toEqual([]);
+  });
+});
+
+describe("setupApplicationMenu", () => {
+  it("adds Preferences to Electron's native macOS application and Window menus", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+
+    setupApplicationMenu({ onNewWindow: vi.fn() });
+
+    const template = electronMocks.buildFromTemplate.mock.calls[0]?.[0];
+    expect(template).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "application-menu", role: "appMenu" }),
+        expect.objectContaining({ role: "windowMenu" }),
+      ]),
+    );
+    expect(electronMocks.appMenuInsert).toHaveBeenNthCalledWith(
+      1,
+      2,
+      expect.objectContaining({
+        options: expect.objectContaining({
+          label: "Preferences…",
+          accelerator: "Command+,",
+          click: expect.any(Function),
+        }),
+      }),
+    );
+    expect(electronMocks.appMenuInsert).toHaveBeenNthCalledWith(
+      2,
+      3,
+      expect.objectContaining({
+        options: expect.objectContaining({ type: "separator" }),
+      }),
+    );
   });
 });

--- a/packages/desktop/src/features/menu.ts
+++ b/packages/desktop/src/features/menu.ts
@@ -1,4 +1,4 @@
-import { app, Menu, BrowserWindow, ipcMain } from "electron";
+import { app, Menu, BrowserWindow, ipcMain, MenuItem } from "electron";
 import { getActivePaseoBrowserWebContentsForHostWindow } from "./browser-webviews/index.js";
 
 interface ShowContextMenuInput {
@@ -8,6 +8,11 @@ interface ShowContextMenuInput {
 
 interface ApplicationMenuOptions {
   onNewWindow: () => void;
+}
+
+function openPreferences(win: BrowserWindow): void {
+  win.webContents.sendInputEvent({ type: "keyDown", keyCode: ",", modifiers: ["meta"] });
+  win.webContents.sendInputEvent({ type: "keyUp", keyCode: ",", modifiers: ["meta"] });
 }
 
 function withBrowserWindow(
@@ -75,18 +80,8 @@ function buildApplicationMenuTemplate(
     ...(isMac
       ? [
           {
-            label: app.name,
-            submenu: [
-              { role: "about" as const },
-              { type: "separator" as const },
-              { role: "services" as const },
-              { type: "separator" as const },
-              { role: "hide" as const },
-              { role: "hideOthers" as const },
-              { role: "unhide" as const },
-              { type: "separator" as const },
-              { role: "quit" as const },
-            ],
+            id: "application-menu",
+            role: "appMenu" as const,
           },
         ]
       : []),
@@ -168,27 +163,55 @@ function buildApplicationMenuTemplate(
         { role: "togglefullscreen" },
       ],
     },
-    {
-      label: "Window",
-      submenu: [
-        { role: "minimize" },
-        { role: "zoom" },
-        ...(isMac
-          ? [{ type: "separator" as const }, { role: "front" as const }]
-          : [{ role: "close" as const }]),
-      ],
-    },
+    ...(isMac
+      ? [{ role: "windowMenu" as const }]
+      : [
+          {
+            label: "Window",
+            submenu: [
+              { role: "minimize" as const },
+              { role: "zoom" as const },
+              { role: "close" as const },
+            ],
+          },
+        ]),
   ];
 }
 
 let applicationMenuOptions: ApplicationMenuOptions | null = null;
 let capturingShortcut = false;
 
+function addMacPreferencesMenuItem(menu: Menu): void {
+  const appMenu = menu.getMenuItemById("application-menu")?.submenu;
+  if (!appMenu) {
+    return;
+  }
+
+  const firstSeparatorIndex = appMenu.items.findIndex((item) => item.type === "separator");
+  if (firstSeparatorIndex === -1) {
+    return;
+  }
+
+  const preferencesIndex = firstSeparatorIndex + 1;
+  appMenu.insert(
+    preferencesIndex,
+    new MenuItem({
+      label: "Preferences…",
+      accelerator: "Command+,",
+      click: withBrowserWindow(openPreferences),
+    }),
+  );
+  appMenu.insert(preferencesIndex + 1, new MenuItem({ type: "separator" }));
+}
+
 function rebuildApplicationMenu(): void {
   if (!applicationMenuOptions) return;
   const menu = Menu.buildFromTemplate(
     buildApplicationMenuTemplate(applicationMenuOptions, capturingShortcut),
   );
+  if (process.platform === "darwin") {
+    addMacPreferencesMenuItem(menu);
+  }
   Menu.setApplicationMenu(menu);
 }
 


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo's hand-built macOS Window menu exposed only a small subset of the controls macOS users expect. Delegating the application and Window menus to Electron's native roles restores the complete platform-standard menus while preserving Paseo's existing Preferences action and its `⌘,` shortcut.

### Goals

- Use Electron's native `appMenu` role for the macOS application menu.
- Use Electron's native `windowMenu` role for the macOS Window menu.
- Keep Paseo's Preferences action in the native application menu with `⌘,`.
- Preserve the current Window menu behavior on Windows and Linux.
- Add regression coverage for the macOS menu roles and Preferences item.

### Non-goals

- Change the Windows or Linux Window-menu implementation.
- Change Preferences behavior outside the Electron application menu.
- Change menus on iOS, Android, or browser web.

### QA

Automated validation:

- `npx vitest run packages/desktop/src/features/menu.test.ts --bail=1` — passed.
- `npm run lint` — passed.
- `npm run typecheck` — passed.

Manual validation:

- Launched the Electron client on macOS.
- Confirmed the native application and Window menus are present.
- Confirmed Preferences opens through `⌘,`.

Visual evidence:

**Window menu comparison**

<img width="2000" height="1000" alt="Window menu comparison" src="https://github.com/user-attachments/assets/9f29108d-2378-4700-b75b-fcf744660e7d" />

**Application menu comparison**

<img width="1600" height="1000" alt="Application menu Preferences comparison" src="https://github.com/user-attachments/assets/ca2fde2e-4d24-4af3-b1b0-ef9d4f790860" />

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Not affected by the Electron menu implementation. |
| Android | No | Not affected by the Electron menu implementation. |
| Web | No | Not affected by the Electron menu implementation. |
| Desktop macOS | Yes | Verified the native menu roles and Preferences action in the running Electron client. |
| Desktop Windows | No | Not affected; the existing manual Window-menu template remains in place. |
| Desktop Linux | No | Not affected; the existing manual Window-menu template remains in place. |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
