### PR TITLE
Show workspace tab shortcut hints

### DIFF
--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -4,6 +4,7 @@ import {
   buildEffectiveBindings,
   getBindingIdForAction,
   getWorkspaceIndexJumpModifierKey,
+  getWorkspaceTabIndexBadgeKeys,
   resolveKeyboardShortcut,
   type ChordState,
   type KeyboardShortcutContext,
@@ -713,5 +714,54 @@ describe("getWorkspaceIndexJumpModifierKey", () => {
 
   it("uses Ctrl on desktop non-Mac, not Meta or Alt", () => {
     expect(getWorkspaceIndexJumpModifierKey({ isMac: false, isDesktop: true })).toBe("Control");
+  });
+});
+
+describe("getWorkspaceTabIndexBadgeKeys", () => {
+  it("shows the remaining Option+number chord while Cmd is held on desktop Mac", () => {
+    expect(
+      getWorkspaceTabIndexBadgeKeys({
+        shortcutKeys: [["mod", "alt", "1-9"]],
+        index: 2,
+        isDesktop: true,
+      }),
+    ).toEqual(["alt", "3"]);
+  });
+
+  it("keeps Alt in the hint when the held desktop workspace modifier is Ctrl", () => {
+    expect(
+      getWorkspaceTabIndexBadgeKeys({
+        shortcutKeys: [["alt", "1-9"]],
+        index: 0,
+        isDesktop: true,
+      }),
+    ).toEqual(["alt", "1"]);
+  });
+
+  it("shows the remaining Shift+number chord while Alt is held on web", () => {
+    expect(
+      getWorkspaceTabIndexBadgeKeys({
+        shortcutKeys: [["alt", "shift", "1-9"]],
+        index: 8,
+        isDesktop: false,
+      }),
+    ).toEqual(["shift", "9"]);
+  });
+
+  it("does not show hints beyond the nine reachable tabs or for a non-index binding", () => {
+    expect(
+      getWorkspaceTabIndexBadgeKeys({
+        shortcutKeys: [["mod", "alt", "1-9"]],
+        index: 9,
+        isDesktop: true,
+      }),
+    ).toBeNull();
+    expect(
+      getWorkspaceTabIndexBadgeKeys({
+        shortcutKeys: [["mod", "alt", "K"]],
+        index: 0,
+        isDesktop: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -1435,6 +1435,31 @@ export function getWorkspaceIndexJumpModifierKey(platform: {
   return platform.isMac ? "Meta" : "Control";
 }
 
+/**
+ * Builds the per-tab hint shown while the workspace-index modifier is held.
+ * The held modifier is omitted, so Cmd+Alt+Digit on macOS is presented as
+ * Option+Digit while Cmd is already down.
+ */
+export function getWorkspaceTabIndexBadgeKeys(input: {
+  shortcutKeys: ShortcutKey[][] | null;
+  index: number;
+  isDesktop: boolean;
+}): ShortcutKey[] | null {
+  if (input.index < 0 || input.index >= 9 || input.shortcutKeys?.length !== 1) {
+    return null;
+  }
+
+  const combo = input.shortcutKeys[0];
+  if (!combo?.includes("1-9")) {
+    return null;
+  }
+
+  const heldWorkspaceModifier = input.isDesktop ? "mod" : "alt";
+  return combo
+    .filter((key) => key !== heldWorkspaceModifier)
+    .map((key) => (key === "1-9" ? String(input.index + 1) : key));
+}
+
 export function buildKeyboardShortcutHelpSections(
   input: KeyboardShortcutPlatformContext,
   bindings: readonly ParsedShortcutBinding[] = DEFAULT_BINDINGS,

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -59,8 +59,10 @@ import {
 import { Shortcut } from "@/components/ui/shortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
-import { WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
+import { useShowShortcutBadges } from "@/hooks/use-show-shortcut-badges";
+import { getIsElectronRuntime, WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
 import type { ShortcutKey } from "@/utils/format-shortcut";
+import { getWorkspaceTabIndexBadgeKeys } from "@/keyboard/keyboard-shortcuts";
 import { useWorkspaceTabLayout } from "@/screens/workspace/use-workspace-tab-layout";
 import {
   WorkspaceTabPresentationResolver,
@@ -539,6 +541,7 @@ function TabChip({
   onNavigateTab,
   onCloseTab,
   dragHandleProps,
+  shortcutBadgeKeys,
 }: {
   tab: WorkspaceTabDescriptor;
   isActive: boolean;
@@ -556,6 +559,7 @@ function TabChip({
   onNavigateTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => Promise<void> | void;
   dragHandleProps: DraggableListDragHandleProps | undefined;
+  shortcutBadgeKeys: ShortcutKey[] | null;
 }) {
   const { t } = useTranslation();
   const { closeButtonTestId, contextMenuTestId, menuEntries } = resolvedTab;
@@ -564,7 +568,8 @@ function TabChip({
   );
   const [hovered, setHovered] = useState(false);
   const isHighlighted = isActive || hovered || isCloseHovered;
-  const showTrailingAffordance = showCloseButton || presentation.modified;
+  const showTrailingAffordance =
+    shortcutBadgeKeys !== null || showCloseButton || presentation.modified;
   const closeButtonDragBlockers = isWeb
     ? ({
         onPointerDown: (event: { stopPropagation?: () => void }) => {
@@ -681,7 +686,19 @@ function TabChip({
                 tabLabelStyle={tabLabelStyle}
               />
 
-              {showTrailingAffordance ? (
+              {shortcutBadgeKeys ? (
+                <View
+                  pointerEvents="none"
+                  testID={`workspace-tab-shortcut-${buildDeterministicWorkspaceTabId(tab.target)}`}
+                >
+                  <Shortcut
+                    keys={shortcutBadgeKeys}
+                    style={styles.tabShortcutBadge}
+                    textStyle={styles.tabShortcutBadgeText}
+                  />
+                </View>
+              ) : null}
+              {!shortcutBadgeKeys && showTrailingAffordance ? (
                 <Pressable
                   {...(closeButtonDragBlockers as object | undefined)}
                   testID={closeButtonTestId}
@@ -794,6 +811,9 @@ export function WorkspaceDesktopTabsRow({
   const focusModeKeys = useShortcutKeys("toggle-focus");
   const splitRightKeys = useShortcutKeys("workspace-pane-split-right");
   const splitDownKeys = useShortcutKeys("workspace-pane-split-down");
+  const tabJumpKeys = useShortcutKeys("workspace-tab-jump-index");
+  const showShortcutBadges = useShowShortcutBadges();
+  const isDesktopApp = getIsElectronRuntime();
   const [tabsContainerWidth, setTabsContainerWidth] = useState<number>(0);
   const [tabsActionsWidth, setTabsActionsWidth] = useState<number>(0);
   const [inlineAddButtonWidth, setInlineAddButtonWidth] = useState<number>(0);
@@ -935,6 +955,14 @@ export function WorkspaceDesktopTabsRow({
         activeDragTabId !== null &&
         tabDropPreviewIndex === tabs.length &&
         index === tabs.length - 1;
+      const shortcutBadgeKeys =
+        showShortcutBadges && isFocused
+          ? getWorkspaceTabIndexBadgeKeys({
+              shortcutKeys: tabJumpKeys,
+              index,
+              isDesktop: isDesktopApp,
+            })
+          : null;
 
       return (
         <ResolvedDesktopTabChip
@@ -965,12 +993,14 @@ export function WorkspaceDesktopTabsRow({
           dragHandleProps={dragHandleProps}
           showDropIndicatorBefore={showDropIndicatorBefore}
           showDropIndicatorAfter={showDropIndicatorAfter}
+          shortcutBadgeKeys={shortcutBadgeKeys}
         />
       );
     },
     [
       activeDragTabId,
       isFocused,
+      isDesktopApp,
       layout.closeButtonPolicy,
       layout.items,
       normalizedServerId,
@@ -987,8 +1017,10 @@ export function WorkspaceDesktopTabsRow({
       onReloadAgent,
       onRenameTab,
       setHoveredCloseTabKey,
+      showShortcutBadges,
       tabMenuLabels,
       tabDropPreviewIndex,
+      tabJumpKeys,
       tabs.length,
     ],
   );
@@ -1119,6 +1151,7 @@ function ResolvedDesktopTabChip({
   dragHandleProps,
   showDropIndicatorBefore,
   showDropIndicatorAfter,
+  shortcutBadgeKeys,
 }: {
   item: WorkspaceDesktopTabRowItem;
   isFocused: boolean;
@@ -1146,6 +1179,7 @@ function ResolvedDesktopTabChip({
   dragHandleProps: DraggableListDragHandleProps | undefined;
   showDropIndicatorBefore: boolean;
   showDropIndicatorAfter: boolean;
+  shortcutBadgeKeys: ShortcutKey[] | null;
 }) {
   const { t } = useTranslation();
   const resolvedTab = useMemo(
@@ -1218,6 +1252,7 @@ function ResolvedDesktopTabChip({
               onNavigateTab={onNavigateTab}
               onCloseTab={onCloseTab}
               dragHandleProps={dragHandleProps}
+              shortcutBadgeKeys={shortcutBadgeKeys}
             />
             {showDropIndicatorAfter ? (
               <View style={[styles.tabDropIndicator, styles.tabDropIndicatorAfter]} />
@@ -1349,6 +1384,24 @@ const styles = StyleSheet.create((theme) => ({
   },
   tabLabelActive: {
     color: theme.colors.foreground,
+  },
+  tabShortcutBadge: {
+    minWidth: 18,
+    height: 18,
+    paddingHorizontal: theme.spacing[1],
+    paddingVertical: 0,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.sm,
+    borderWidth: 1,
+    borderColor: theme.colors.surface2,
+    backgroundColor: theme.colors.surface0,
+    flexShrink: 0,
+  },
+  tabShortcutBadgeText: {
+    color: theme.colors.foregroundMuted,
+    fontWeight: theme.fontWeight.medium,
+    lineHeight: 14,
   },
   tabCloseButton: {
     width: 18,


### PR DESCRIPTION
### Linked issue

None

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Holding the workspace navigation modifier reveals numbered hints in the vertical workspace list, but the horizontal workspace tabs did not communicate their related index shortcuts. This left the tab shortcut difficult to discover even though it was already available.

This change reuses the existing delayed shortcut-hint state to show the remaining tab chord beside each focused horizontal tab. On macOS, holding Command reveals `⌥1` through `⌥9`; Windows/Linux and browser web derive their labels from their active shortcut definitions. The temporary hint replaces the close affordance so the tab row does not resize.

### Goals

- Reveal shortcut hints for the first nine focused horizontal workspace tabs
- Derive platform-specific labels from the active tab-jump shortcut
- Match the compact white shortcut-badge styling used in the vertical workspace list
- Avoid layout shifts while hints appear and disappear
- Cover macOS, Windows/Linux, browser web, and unreachable-tab behavior with automated tests

### Non-goals

- Change the existing keyboard bindings
- Add shortcut hints to the compact mobile tab switcher
- Show hints for tabs beyond the nine index shortcuts

### QA

#### Platform coverage

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | Not affected | Compact mobile tab switcher does not render this row |
| Android | Not affected | Compact mobile tab switcher does not render this row |
| Web | Yes | Rendered three hints in the live Expo app and verified badge styling and stable tab-row sizing |
| Desktop macOS | Yes, author | Local interaction verified; screenshot below |
| Desktop Windows | Logic only | Unit coverage verifies `Alt+number` labels; not visually exercised on Windows |
| Desktop Linux | Logic only | Shares the non-macOS desktop mapping; not visually exercised on Linux |

#### Automated checks

```text
$ npx vitest run packages/app/src/keyboard/keyboard-shortcuts.test.ts --bail=1
Test Files  1 passed (1)
Tests       80 passed (80)

$ npm run lint -- packages/app/src/keyboard/keyboard-shortcuts.ts packages/app/src/keyboard/keyboard-shortcuts.test.ts packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
Found 0 warnings and 0 errors.

$ npm run typecheck
All workspace typechecks passed.

$ npm run format
Finished successfully; no unrelated files changed.
```

#### Screenshot

<img width="1499" height="1113" alt="Screenshot 2026-08-02 at 18 04 43" src="https://github.com/user-attachments/assets/99b1777c-fbe2-4e2b-81c5-e61b46d72090" />


### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence — add the macOS screenshot above
- [x] Tests added or updated where it made sense
