### PR TITLE
fix(agent): keep Pi provider trailing reasoning in one block

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -553,6 +553,57 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("coalesces trailing reasoning so the answer text does not split the reasoning run", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "r1" },
+    });
+    // Long thinking block.
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "think1" },
+    });
+    // Answer begins... but text is held so trailing reasoning stays in the same run.
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "text_delta", delta: "There are " },
+    });
+    // Trailing reasoning tail after the answer has started.
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "thinking_delta", delta: " reasoning" },
+    });
+    // More answer text (still held until the reasoning run closes).
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "text_delta", delta: "3 r's" },
+    });
+    fakeSession.emit({
+      type: "message_end",
+      message: { role: "assistant", content: [], responseId: "r1" },
+    });
+    fakeSession.finishTurn();
+
+    await events.nextTurnCompletion();
+
+    // Both reasoning deltas are adjacent (no assistant_message between them), so
+    // the trailing " reasoning" merges into the same reasoning block instead of
+    // forming a second one. The held answer text is flushed after it.
+    expect(events.timelineItems()).toEqual([
+      { type: "reasoning", text: "think1" },
+      { type: "reasoning", text: " reasoning" },
+      { type: "assistant_message", text: "There are 3 r's", messageId: "r1" },
+    ]);
+  });
+
   test("keeps one generated message id when Pi omits message start and response id", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -746,7 +746,7 @@ describe("PiRpcAgentSession", () => {
 
   test("discards held text on close (no late emit)", async () => {
     const prev = process.env.PI_REASONING_HOLD_MS;
-    process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: only close can cancel it
+    process.env.PI_REASONING_HOLD_MS = "30"; // short hold: an uncancelled timer fires within the wait, so only a real cancel passes
     onTestFinished(() => {
       if (prev === undefined) delete process.env.PI_REASONING_HOLD_MS;
       else process.env.PI_REASONING_HOLD_MS = prev;
@@ -771,7 +771,7 @@ describe("PiRpcAgentSession", () => {
       assistantMessageEvent: { type: "text_delta", delta: "There are " },
     });
     await session.close();
-    await new Promise((r) => setTimeout(r, 30)); // a leaked timer would have fired by now
+    await new Promise((r) => setTimeout(r, 100)); // a leaked 30ms timer fires here and would emit the held text
 
     // Thinking was streamed, but the held text is dropped on close (no late emit).
     expect(events.timelineItems()).toEqual([{ type: "reasoning", text: "think" }]);
@@ -779,7 +779,7 @@ describe("PiRpcAgentSession", () => {
 
   test("discards held text on interrupt (no late emit)", async () => {
     const prev = process.env.PI_REASONING_HOLD_MS;
-    process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: only interrupt can cancel it
+    process.env.PI_REASONING_HOLD_MS = "30"; // short hold: an uncancelled timer fires within the wait, so only a real cancel passes
     onTestFinished(() => {
       if (prev === undefined) delete process.env.PI_REASONING_HOLD_MS;
       else process.env.PI_REASONING_HOLD_MS = prev;
@@ -804,7 +804,7 @@ describe("PiRpcAgentSession", () => {
       assistantMessageEvent: { type: "text_delta", delta: "There are " },
     });
     await session.interrupt();
-    await new Promise((r) => setTimeout(r, 30));
+    await new Promise((r) => setTimeout(r, 100)); // a leaked 30ms timer fires here and would emit the held text
 
     expect(events.timelineItems()).toEqual([{ type: "reasoning", text: "think" }]);
   });

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -682,7 +682,69 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
-  test("discards held text on close (no late emit)", async t => {
+  test("resets coalescing flags so the next turn coalesces without a message_start", async () => {
+    const prev = process.env.PI_REASONING_HOLD_MS;
+    process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: flush must come from turn completion, not the timer
+    onTestFinished(() => {
+      if (prev === undefined) delete process.env.PI_REASONING_HOLD_MS;
+      else process.env.PI_REASONING_HOLD_MS = prev;
+    });
+
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    // Turn 1 ends without an assistant message_end, leaking textStreamDirect=true.
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "r1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "think" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "text_delta", delta: "There are " },
+    });
+    fakeSession.finishTurn();
+    await events.nextTurnCompletion();
+
+    // Turn 2 starts WITHOUT message_start (the shim path), so only a flag reset in
+    // completeTurn keeps coalescing armed. If textStreamDirect leaked, the text
+    // would stream before the trailing reasoning and split the reasoning run.
+    await session.startTurn("hello2");
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r2" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "think2" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r2" },
+      assistantMessageEvent: { type: "text_delta", delta: "There are 4 " },
+    });
+    // Trailing reasoning must stay in the reasoning run, not after the text.
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r2" },
+      assistantMessageEvent: { type: "thinking_delta", delta: " more" },
+    });
+    fakeSession.finishTurn();
+    await events.nextTurnCompletion();
+
+    expect(events.timelineItems()).toEqual([
+      { type: "reasoning", text: "think" },
+      { type: "assistant_message", text: "There are ", messageId: "r1" },
+      { type: "reasoning", text: "think2" },
+      { type: "reasoning", text: " more" },
+      { type: "assistant_message", text: "There are 4 ", messageId: "r2" },
+    ]);
+  });
+
+  test("discards held text on close (no late emit)", async () => {
     const prev = process.env.PI_REASONING_HOLD_MS;
     process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: only close can cancel it
     onTestFinished(() => {
@@ -709,13 +771,13 @@ describe("PiRpcAgentSession", () => {
       assistantMessageEvent: { type: "text_delta", delta: "There are " },
     });
     await session.close();
-    await new Promise(r => setTimeout(r, 30)); // a leaked timer would have fired by now
+    await new Promise((r) => setTimeout(r, 30)); // a leaked timer would have fired by now
 
     // Thinking was streamed, but the held text is dropped on close (no late emit).
     expect(events.timelineItems()).toEqual([{ type: "reasoning", text: "think" }]);
   });
 
-  test("discards held text on interrupt (no late emit)", async t => {
+  test("discards held text on interrupt (no late emit)", async () => {
     const prev = process.env.PI_REASONING_HOLD_MS;
     process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: only interrupt can cancel it
     onTestFinished(() => {
@@ -742,7 +804,7 @@ describe("PiRpcAgentSession", () => {
       assistantMessageEvent: { type: "text_delta", delta: "There are " },
     });
     await session.interrupt();
-    await new Promise(r => setTimeout(r, 30));
+    await new Promise((r) => setTimeout(r, 30));
 
     expect(events.timelineItems()).toEqual([{ type: "reasoning", text: "think" }]);
   });

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -682,6 +682,71 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("discards held text on close (no late emit)", async t => {
+    const prev = process.env.PI_REASONING_HOLD_MS;
+    process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: only close can cancel it
+    onTestFinished(() => {
+      if (prev === undefined) delete process.env.PI_REASONING_HOLD_MS;
+      else process.env.PI_REASONING_HOLD_MS = prev;
+    });
+
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "r1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "think" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "text_delta", delta: "There are " },
+    });
+    await session.close();
+    await new Promise(r => setTimeout(r, 30)); // a leaked timer would have fired by now
+
+    // Thinking was streamed, but the held text is dropped on close (no late emit).
+    expect(events.timelineItems()).toEqual([{ type: "reasoning", text: "think" }]);
+  });
+
+  test("discards held text on interrupt (no late emit)", async t => {
+    const prev = process.env.PI_REASONING_HOLD_MS;
+    process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: only interrupt can cancel it
+    onTestFinished(() => {
+      if (prev === undefined) delete process.env.PI_REASONING_HOLD_MS;
+      else process.env.PI_REASONING_HOLD_MS = prev;
+    });
+
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "r1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "think" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "text_delta", delta: "There are " },
+    });
+    await session.interrupt();
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(events.timelineItems()).toEqual([{ type: "reasoning", text: "think" }]);
+  });
+
   test("keeps one generated message id when Pi omits message start and response id", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -604,6 +604,84 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("keeps held text under the previous message id when a new message starts", async () => {
+    const prev = process.env.PI_REASONING_HOLD_MS;
+    process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: flush must come from message_start, not the timer
+    onTestFinished(() => {
+      if (prev === undefined) delete process.env.PI_REASONING_HOLD_MS;
+      else process.env.PI_REASONING_HOLD_MS = prev;
+    });
+
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "r1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "think" },
+    });
+    // Buffered (prior message never got a message_end).
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "text_delta", delta: "There are " },
+    });
+    // Next assistant message starts without a message_end for r1.
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "r2" },
+    });
+    fakeSession.finishTurn();
+    await events.nextTurnCompletion();
+
+    expect(events.timelineItems()).toEqual([
+      { type: "reasoning", text: "think" },
+      // Flushed under the OLD message id, not the new one.
+      { type: "assistant_message", text: "There are ", messageId: "r1" },
+    ]);
+  });
+
+  test("flushes held text when a turn ends without an assistant message_end", async () => {
+    const prev = process.env.PI_REASONING_HOLD_MS;
+    process.env.PI_REASONING_HOLD_MS = "10000"; // long hold: flush must come from turn completion, not the timer
+    onTestFinished(() => {
+      if (prev === undefined) delete process.env.PI_REASONING_HOLD_MS;
+      else process.env.PI_REASONING_HOLD_MS = prev;
+    });
+
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "r1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "think" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      message: { role: "assistant", content: [], responseId: "r1" },
+      assistantMessageEvent: { type: "text_delta", delta: "There are " },
+    });
+    // No assistant message_end — turn terminates directly.
+    fakeSession.finishTurn();
+    await events.nextTurnCompletion();
+
+    expect(events.timelineItems()).toEqual([
+      { type: "reasoning", text: "think" },
+      { type: "assistant_message", text: "There are ", messageId: "r1" },
+    ]);
+  });
+
   test("keeps one generated message id when Pi omits message start and response id", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2290,10 +2290,11 @@ export class PiRpcAgentSession implements AgentSession {
 
   private handleMessageStart(event: Extract<PiAgentSessionEvent, { type: "message_start" }>): void {
     if (event.message.role === "assistant") {
-      this.activeAssistantMessageId = event.message.responseId || null;
-    }
-    if (event.message.role === "assistant") {
+      // Flush any stale held text under the PREVIOUS message id before adopting the
+      // new responseId, so buffered text from an un-terminated prior message isn't
+      // emitted under the wrong message id.
       this.resetReasoningCoalescing();
+      this.activeAssistantMessageId = event.message.responseId || null;
     }
   }
 
@@ -2375,6 +2376,10 @@ export class PiRpcAgentSession implements AgentSession {
       this.lastInterruptedTurnId = null;
       return;
     }
+    // Flush any buffered text from this turn before its ids are cleared, so the
+    // fragment is emitted under the correct turn/message and doesn't outlive the
+    // turn (or attach to the next one) when a turn ends without assistant message_end.
+    this.flushHeldText();
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1230,6 +1230,24 @@ export class PiRpcAgentSession implements AgentSession {
   private activeClientMessageId: string | null = null;
   private activeAssistantMessageId: string | null = null;
   private activeTurnStarted = false;
+
+  // ---- Reasoning coalescing ----
+  // pi can stream a trailing reasoning delta AFTER the final answer has begun
+  // (inherited from the provider). The TUI renders one merged thinking block;
+  // this provider was relaying raw reasoning/text deltas in arrival order, so
+  // clients saw [reasoning][text][reasoning][text]. We hold the first text chunk
+  // briefly after thinking so a trailing reasoning delta stays in the same
+  // reasoning run (clients merge adjacent reasoning items into one block),
+  // mirroring the replay path (history-mapper) which emits one reasoning item
+  // per thinking block. Tune via PI_REASONING_HOLD_MS.
+  private readonly reasoningHoldMs = (() => {
+    const n = Number(process.env.PI_REASONING_HOLD_MS);
+    return Number.isFinite(n) && n > 0 ? n : 150;
+  })();
+  private reasoningPresent = false;
+  private textStreamDirect = false;
+  private heldTextBuf = "";
+  private reasonHoldTimer: ReturnType<typeof setTimeout> | null = null;
   private activeNoTurnPromptText: string | null = null;
   private readonly pendingNoTurnOutputs: Array<{ turnId: string; message: string }> = [];
   private activePromptRequestId: string | null = null;
@@ -1603,6 +1621,35 @@ export class PiRpcAgentSession implements AgentSession {
     for (const subscriber of this.subscribers) {
       subscriber(event);
     }
+  }
+
+  private flushHeldText(): void {
+    if (this.reasonHoldTimer) {
+      clearTimeout(this.reasonHoldTimer);
+      this.reasonHoldTimer = null;
+    }
+    const text = this.heldTextBuf;
+    this.heldTextBuf = "";
+    this.textStreamDirect = true;
+    if (text) {
+      this.emit({
+        type: "timeline",
+        provider: this.provider,
+        turnId: this.activeTurnId ?? undefined,
+        item: {
+          type: "assistant_message",
+          text,
+          messageId: this.activeAssistantMessageId ?? "",
+        },
+      });
+    }
+  }
+
+  private resetReasoningCoalescing(): void {
+    this.flushHeldText();
+    this.reasoningPresent = false;
+    this.heldTextBuf = "";
+    this.textStreamDirect = false;
   }
 
   private currentTurnIdForEvent(): string | undefined {
@@ -2197,19 +2244,32 @@ export class PiRpcAgentSession implements AgentSession {
     if (event.assistantMessageEvent.type === "text_delta") {
       // Pi-compatible runtimes may emit updates without a preceding message_start.
       this.activeAssistantMessageId ??= event.message.responseId || randomUUID();
-      this.emit({
-        type: "timeline",
-        provider: this.provider,
-        turnId,
-        item: {
-          type: "assistant_message",
-          text: event.assistantMessageEvent.delta ?? "",
-          messageId: this.activeAssistantMessageId,
-        },
-      });
+      const delta = event.assistantMessageEvent.delta ?? "";
+      if (this.textStreamDirect || !this.reasoningPresent) {
+        if (!this.reasoningPresent) this.textStreamDirect = true;
+        this.emit({
+          type: "timeline",
+          provider: this.provider,
+          turnId,
+          item: {
+            type: "assistant_message",
+            text: delta,
+            messageId: this.activeAssistantMessageId,
+          },
+        });
+      } else {
+        // Reasoning is in flight: hold the text briefly so a trailing reasoning
+        // delta stays in the same reasoning run instead of splitting into a
+        // second reasoning block.
+        this.heldTextBuf += delta;
+        if (!this.reasonHoldTimer) {
+          this.reasonHoldTimer = setTimeout(() => this.flushHeldText(), this.reasoningHoldMs);
+        }
+      }
       return;
     }
     if (event.assistantMessageEvent.type === "thinking_delta") {
+      this.reasoningPresent = true;
       this.emit({
         type: "timeline",
         provider: this.provider,
@@ -2219,12 +2279,21 @@ export class PiRpcAgentSession implements AgentSession {
           text: event.assistantMessageEvent.delta ?? "",
         },
       });
+      if (this.reasonHoldTimer) {
+        // Trailing reasoning while we hold text: keep it in the same reasoning
+        // run and postpone the text flush.
+        clearTimeout(this.reasonHoldTimer);
+        this.reasonHoldTimer = setTimeout(() => this.flushHeldText(), this.reasoningHoldMs);
+      }
     }
   }
 
   private handleMessageStart(event: Extract<PiAgentSessionEvent, { type: "message_start" }>): void {
     if (event.message.role === "assistant") {
       this.activeAssistantMessageId = event.message.responseId || null;
+    }
+    if (event.message.role === "assistant") {
+      this.resetReasoningCoalescing();
     }
   }
 
@@ -2233,6 +2302,7 @@ export class PiRpcAgentSession implements AgentSession {
     turnId: string | undefined,
   ): void {
     if (event.message.role === "assistant") {
+      this.resetReasoningCoalescing();
       this.activeAssistantMessageId = null;
       return;
     }
@@ -2258,6 +2328,8 @@ export class PiRpcAgentSession implements AgentSession {
     result: PiToolResult,
     error: unknown,
   ): boolean {
+    // Don't let held text fall after a tool call that closes the reasoning run.
+    this.flushHeldText();
     const turnId = this.currentTurnIdForEvent();
     const detail = this.mapToolDetail(toolCallId, toolCall, result);
     if (!detail) {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1630,6 +1630,11 @@ export class PiRpcAgentSession implements AgentSession {
     }
     const text = this.heldTextBuf;
     this.heldTextBuf = "";
+    // Once the hold flushes we assume thinking is done and stream the rest of this
+    // message directly (no perpetual buffering). This re-arms on the next assistant
+    // message_start/end. ponytail: a trailing reasoning delta arriving well after a
+    // flush (e.g. after a mid-message tool call) still re-splits the reasoning run;
+    // only contentIndex-based grouping fully fixes that, add it if it shows up.
     this.textStreamDirect = true;
     if (text) {
       this.emit({
@@ -2362,6 +2367,10 @@ export class PiRpcAgentSession implements AgentSession {
   }
 
   private completeTurn(turnId: string | undefined, messages: PiAgentMessage[]): void {
+    // Flush any buffered text before ids are cleared (and before ANY early return),
+    // so the fragment is emitted under the correct turn/message and no held text
+    // survives the turn with a dangling timer that could emit under later/empty ids.
+    this.flushHeldText();
     if (turnId && this.interruptingTurnId === turnId && isPiAbortedTerminalResponse(messages)) {
       this.interruptedTerminalError = {
         turnId,
@@ -2379,7 +2388,6 @@ export class PiRpcAgentSession implements AgentSession {
     // Flush any buffered text from this turn before its ids are cleared, so the
     // fragment is emitted under the correct turn/message and doesn't outlive the
     // turn (or attach to the next one) when a turn ends without assistant message_end.
-    this.flushHeldText();
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2402,14 +2402,17 @@ export class PiRpcAgentSession implements AgentSession {
       this.lastInterruptedTurnId = null;
       return;
     }
-    // Flush any buffered text from this turn before its ids are cleared, so the
-    // fragment is emitted under the correct turn/message and doesn't outlive the
-    // turn (or attach to the next one) when a turn ends without assistant message_end.
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;
     this.activeTurnStarted = false;
     this.clearNoTurnBuffers();
+    // Reset per-message coalescing flags too: flushHeldText() above leaves
+    // textStreamDirect=true, which would otherwise leak into the next turn and
+    // silently disable coalescing for an assistant message that starts without
+    // message_start (the very case this PR targets).
+    this.reasoningPresent = false;
+    this.textStreamDirect = false;
     const errorMessage = latestPiErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {
       this.emit({

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1481,6 +1481,7 @@ export class PiRpcAgentSession implements AgentSession {
         this.activeTurnStarted = false;
         this.activeAssistantMessageId = null;
         this.clearNoTurnBuffers();
+        this.discardReasoningHold();
         this.emit({
           type: "turn_failed",
           provider: this.provider,
@@ -1496,6 +1497,7 @@ export class PiRpcAgentSession implements AgentSession {
       this.activeTurnStarted = false;
       this.activeAssistantMessageId = null;
       this.clearNoTurnBuffers();
+      this.discardReasoningHold();
       this.emit({
         type: "turn_canceled",
         provider: this.provider,
@@ -1544,6 +1546,8 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
     this.closed = true;
+    // Don't let a pending hold timer emit after the session is closed.
+    this.discardReasoningHold();
     try {
       await this.runtimeSession.close();
     } finally {
@@ -1654,6 +1658,19 @@ export class PiRpcAgentSession implements AgentSession {
     this.flushHeldText();
     this.reasoningPresent = false;
     this.heldTextBuf = "";
+    this.textStreamDirect = false;
+  }
+
+  // Cancel a pending hold WITHOUT emitting: used on interrupt/close where the
+  // turn is being abandoned and the buffered partial text should be dropped, not
+  // emitted later under nulled/empty message ids.
+  private discardReasoningHold(): void {
+    if (this.reasonHoldTimer) {
+      clearTimeout(this.reasonHoldTimer);
+      this.reasonHoldTimer = null;
+    }
+    this.heldTextBuf = "";
+    this.reasoningPresent = false;
     this.textStreamDirect = false;
   }
 


### PR DESCRIPTION
### Linked issue

Closes #2803

### Type of change

- [x] Bug fix

### Reasoning

The Pi provider (`src/server/agent/providers/pi/agent.ts`) relays the Pi RPC delta stream in arrival order. With a provider like local vLLM, Pi can emit a trailing `thinking_delta` after the final answer text has begun, so the Paseo client rendered a long thinking block, a few answer words, then a second short thinking tail, then the rest of the answer — while the replay path (`history-mapper`) collapses thinking into a single block per message. The live stream and the replayed view of the same conversation diverge.

### Goals

- Emit `reasoning` timeline items as one contiguous run when a trailing `thinking_delta` arrives after text has started, matching the replay path.
- Stream answer text with no added latency for runs that have no reasoning.
- Preserve reasoning → text ordering around tool calls.

### Non-goals

- No change to how Pi core orders or tags deltas (Pi already attaches `contentIndex` and renders by block index).
- No change to the agent-stream coalescer; the fix lives in the provider's emission.

### QA

Repro (from a real Pi RPC delta stream; see #2803): `THINKING_START idx=0` → `THINK idx=0` → `TEXT_START idx=1` → `TEXT "There are **"` → `THINK idx=0 " reasoning."` (trailing, after text) → `TEXT` (rest). Before the fix this emitted `[reasoning][text][reasoning][text]`.

- `npm -w @getpaseo/server run test:unit` — pi provider suite: **130 passed, 0 failed**, including the new regression test `coalesces trailing reasoning so the answer text does not split the reasoning run`.
- `tsgo -p tsconfig.server.typecheck.json --noEmit` — clean.
- Behavior is gated by `PI_REASONING_HOLD_MS` (default 150ms): only the first text chunk of a reasoning run is held; a lower value trades a small first-text delay for earlier streaming.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes (server package)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added