### PR TITLE
fix(codex): keep default approvals user-reviewed

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -379,6 +379,34 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("Default Permissions sends the user reviewer to thread/start", async () => {
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const session = createSession({ modeId: "auto", thinkingOptionId: "medium" });
+    session.currentThreadId = null;
+    session.activeForegroundTurnId = null;
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        if (method === "thread/start") {
+          return { thread: { id: "default-permissions-thread" } };
+        }
+        if (method === "turn/start") {
+          return {};
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      }),
+    };
+
+    await session.startTurn("trigger thread creation");
+
+    const startCall = requests.find((request) => request.method === "thread/start");
+    expect(startCall?.params).toMatchObject({
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      approvalsReviewer: "user",
+    });
+  });
+
   test("setMode and setThinkingOption return a next-turn notice while a turn is active", async () => {
     const session = createSession({ modeId: "auto", thinkingOptionId: "medium" });
 
@@ -429,8 +457,11 @@ describe("Codex app-server provider", () => {
     },
   );
 
-  test("turn/start forwards approvalsReviewer while in auto-review mode", async () => {
-    const session = createSession({ modeId: "auto-review" }, { autoReviewEnabled: true });
+  test.each([
+    ["Default Permissions", "auto", "user"],
+    ["Auto-review", "auto-review", "auto_review"],
+  ])("turn/start forwards the %s reviewer", async (_label, modeId, approvalsReviewer) => {
+    const session = createSession({ modeId }, { autoReviewEnabled: true });
     const request = vi.fn(async (method: string) => {
       if (method === "thread/loaded/list") {
         return { data: ["test-thread"] };
@@ -449,7 +480,7 @@ describe("Codex app-server provider", () => {
     expect(turnStartCall?.[1]).toEqual(
       expect.objectContaining({
         approvalPolicy: "on-request",
-        approvalsReviewer: "auto_review",
+        approvalsReviewer,
       }),
     );
   });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -259,7 +259,7 @@ interface CodexModePreset {
   approvalPolicy: string;
   sandbox: string;
   networkAccess?: boolean;
-  approvalsReviewer?: "auto_review";
+  approvalsReviewer?: "user" | "auto_review";
 }
 
 const MODE_PRESETS: Record<string, CodexModePreset> = {
@@ -270,6 +270,7 @@ const MODE_PRESETS: Record<string, CodexModePreset> = {
   auto: {
     approvalPolicy: "on-request",
     sandbox: "workspace-write",
+    approvalsReviewer: "user",
   },
   "auto-review": {
     approvalPolicy: "on-request",


### PR DESCRIPTION
**Continued in #4550 with passing native Codex approval evidence.** GitHub rejected reopening this PR with HTTP 422; the follow-up uses the same branch and includes all current changes.

### Linked issue

Closes #2770

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Default Permissions omitted `approvalsReviewer`, so Codex could inherit `auto_review` from its global configuration or a previous turn on the same thread. Explicit Default now sends `approvalsReviewer: "user"` through the existing `thread/start` and `turn/start` path. Auto-review remains `auto_review`; an omitted Paseo mode still inherits Codex configuration.

### Goals

- Route explicit Default approval requests to the user in both reported inheritance cases.
- Verify native Codex requests remain pending until the client sends an approval response.
- Keep regression coverage reproducible without account credentials.

### Non-goals

- Change sandbox policy, approval policy, or UI behavior.
- Validate model judgment or claim a manual UI/live-model test.

### QA

**Both requested scenarios now pass with native Codex approval requests.** Evidence requested in [the closing comment](https://github.com/getpaseo/paseo/pull/2805#issuecomment-5577459757).

[Successful CI run](https://github.com/HMWCS/paseo/actions/runs/34325995731) · [Job logs](https://github.com/HMWCS/paseo/actions/runs/34325995731/job/102383270148) · [Raw evidence ZIP](https://github.com/HMWCS/paseo/actions/runs/34325995731/artifacts/10093870802)

Tested commit: `d1ee912d0b132b9387c0b5a2c3bf98e8b93ed319`. Runtime: Codex CLI 0.153.4, Node 22.23.2, Ubuntu 22.04.

**Test boundary:** the real Codex app-server, its sandbox/tool execution, Paseo daemon, and WebSocket client run together. A localhost Responses API fixture supplies deterministic tool calls and the guardian's allow output, using `requires_openai_auth=false`. The native approval requests and routing are not mocked. The test client supplies the explicit user-side allow response. There is no live model inference, account credential, or manual UI click in this evidence.

#### Observed native approval behavior

| Scenario | Before the client responds | After explicit allow |
| --- | --- | --- |
| Process-wide `approvals_reviewer="auto_review"` with Default selected | Native `item/commandExecution/requestApproval`; one pending permission; marker absent | Turn idle; marker contains `approved`; no pending permissions |
| Auto-review turn, then Default on the same thread | First turn emits native auto-review completion; Default turn emits a native user approval request; marker absent | Turn idle; marker contains `approved`; no pending permissions |

Both tests receive the WebSocket `agent_permission_request`. A second RPC observes the same unresolved pending permission before the test responds. Neither Default turn starts auto-review.

Selected values from `patched.json` (full native events are in each assertion's `meta`):

```text
Global auto-review + Default:
  threadId: 01a08529-1fbf-7cc2-924f-aedc461a5cf8
  turnId:   01a08529-203c-7233-8a8a-c7eba86582e9

Auto-review -> Default:
  threadId for BOTH turns: 01a08529-2699-7170-b457-edb8021b94f4
  auto-review turnId: 01a08529-26af-79b0-bc22-e6f3288ce518
  Default turnId:     01a08529-2879-7f53-8529-8b402be2a173

Both Default turns:
  native method: item/commandExecution/requestApproval
  command: /bin/bash -lc 'node write-marker.cjs ../user-approved.txt'
  beforeUserResponse: { status: "permission", fileExists: false }
  requestId: permission-write-user-approved
  afterUserResponse:
    { decision: "allow", status: "idle",
      fileContent: "approved", pendingPermissions: [] }
```

#### Negative control

The same CI job removes only the Default preset's `approvalsReviewer: "user"` line and reruns both tests.

```text
Patched:   2 passed, 0 failed, 0 skipped
Unpatched: 0 passed, 2 failed, 0 skipped
Both failures: expected 'idle' to be 'permission'
```

In `unpatched.json`, both Default turns emit native auto-review completion, create the marker before any client response, and finish idle. CI checks the exact failure reason, so an unrelated crash or timeout cannot pass the negative control.

#### Reproduce

```sh
ONNXRUNTIME_NODE_INSTALL=skip npm ci --no-audit --no-fund
npm install --global @openai/codex@0.153.4
npm run build:server
cd packages/server
npx vitest run src/server/daemon-e2e/codex-default-approvals.local.e2e.test.ts \
  --reporter=verbose --reporter=json --outputFile=approval-evidence.json
```

The included workflow also runs the negative control and uploads `runtime.txt`, `patched.json`, and `unpatched.json`. The JSON metadata includes native events, pending permissions, WebSocket messages, before/after state, and the scripted model requests. GitHub's evidence artifact expires December 8, 2026.

CI build, full workspace typecheck, lint, and format check all passed. The existing targeted provider suite previously passed all 153 tests; this revision also passed a separate typecheck explicitly including the new E2E file. Native approval execution ran on the GitHub runner because this Work VM's nested sandbox startup prevents local native sessions. macOS, Windows, and manual UI/live-model QA remain unverified.

### Checklist

- [x] One focused production change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] Native approval request/pending/response evidence for both requested scenarios
- [x] Tests added or updated, including a negative control
