### PR TITLE
fix(app): preserve IME composition in web overlays

### DIFF
--- a/packages/app/src/lib/overlay-root.browser.test.tsx
+++ b/packages/app/src/lib/overlay-root.browser.test.tsx
@@ -1,0 +1,70 @@
+import React, { type RefCallback } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useWebOverlayRegistration } from "./overlay-root";
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function OverlayHarness({ active, showScope }: { active: boolean; showScope: boolean }) {
+  const setScope = useWebOverlayRegistration({ active, layer: 20, onKeyDown: () => false });
+  return showScope ? (
+    <div data-testid="scope" ref={setScope as RefCallback<HTMLDivElement>} tabIndex={-1}>
+      <input data-testid="overlay-input" />
+    </div>
+  ) : null;
+}
+
+describe("useWebOverlayRegistration in the browser", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let opener: HTMLButtonElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    opener = document.createElement("button");
+    opener.textContent = "Open";
+    document.body.append(opener, container);
+    root = createRoot(container);
+    opener.focus();
+  });
+
+  afterEach(() => {
+    root.unmount();
+    document.body.replaceChildren();
+  });
+
+  async function renderHarness(active: boolean, showScope: boolean): Promise<void> {
+    flushSync(() => {
+      root.render(<OverlayHarness active={active} showScope={showScope} />);
+    });
+    await nextFrame();
+  }
+
+  it("skips focus restoration for active scope detach but restores focus when closing", async () => {
+    await renderHarness(true, true);
+
+    const input = document.querySelector<HTMLInputElement>('[data-testid="overlay-input"]');
+    expect(input).toBeTruthy();
+    input?.focus();
+    await nextFrame();
+    expect(document.activeElement).not.toBe(opener);
+
+    const originalFocus = opener.focus.bind(opener);
+    let openerFocusCalls = 0;
+    opener.focus = () => {
+      openerFocusCalls += 1;
+      originalFocus();
+    };
+
+    await renderHarness(true, false);
+
+    expect(openerFocusCalls).toBe(0);
+
+    await renderHarness(false, false);
+
+    expect(openerFocusCalls).toBe(1);
+  });
+});

--- a/packages/app/src/lib/overlay-root.test.tsx
+++ b/packages/app/src/lib/overlay-root.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWebOverlayRegistration } from "./overlay-root";
+
+describe("useWebOverlayRegistration", () => {
+  let opener: HTMLButtonElement;
+  let input: HTMLInputElement;
+  let scope: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 0;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    opener = document.createElement("button");
+    input = document.createElement("input");
+    scope = document.createElement("div");
+    scope.tabIndex = -1;
+    scope.append(input);
+    document.body.append(opener, scope);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.replaceChildren();
+  });
+
+  it("does not restore opener focus when an active overlay scope detaches", () => {
+    const { result, unmount } = renderHook(() =>
+      useWebOverlayRegistration({ active: true, layer: 20, onKeyDown: () => false }),
+    );
+
+    act(() => result.current(scope));
+    const openerFocus = vi.spyOn(opener, "focus");
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    act(() => result.current(null));
+
+    expect(openerFocus).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input);
+    unmount();
+  });
+
+  it("restores opener focus when an overlay closes", () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ active }: { active: boolean }) =>
+        useWebOverlayRegistration({ active, layer: 20, onKeyDown: () => false }),
+      { initialProps: { active: true } },
+    );
+
+    act(() => result.current(scope));
+    const openerFocus = vi.spyOn(opener, "focus");
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    act(() => rerender({ active: false }));
+
+    expect(openerFocus).toHaveBeenCalled();
+    unmount();
+  });
+
+  it("restores opener focus when an active overlay unmounts after its scope detaches", () => {
+    const { result, unmount } = renderHook(() =>
+      useWebOverlayRegistration({ active: true, layer: 20, onKeyDown: () => false }),
+    );
+
+    act(() => result.current(scope));
+    const openerFocus = vi.spyOn(opener, "focus");
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    act(() => result.current(null));
+    expect(openerFocus).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(openerFocus).toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/lib/overlay-root.ts
+++ b/packages/app/src/lib/overlay-root.ts
@@ -249,6 +249,7 @@ export function useWebOverlayRegistration({
   const keyHandlerRef = useRef(onKeyDown);
   const capturedRestoreFocusRef = useRef<HTMLElement | null>(null);
   const removeEntryRef = useRef<((options?: RemoveWebOverlayOptions) => void) | null>(null);
+  const detachedRemoveEntryRef = useRef<((options?: RemoveWebOverlayOptions) => void) | null>(null);
   const registeredRef = useRef(false);
   const activeRef = useRef(active);
   const wasActiveRef = useRef(false);
@@ -279,11 +280,15 @@ export function useWebOverlayRegistration({
         removeEntryRef.current?.({ restoreFocus: shouldRestoreFocus });
       }
       registeredRef.current = false;
-      if (shouldRestoreFocus) removeEntryRef.current = null;
+      if (shouldRestoreFocus) {
+        removeEntryRef.current = null;
+        detachedRemoveEntryRef.current = null;
+      }
       return;
     }
     if (registeredRef.current) return;
 
+    detachedRemoveEntryRef.current = null;
     const entry: WebOverlayEntry = {
       id: idRef.current,
       order: ++webOverlayOrder,
@@ -301,7 +306,10 @@ export function useWebOverlayRegistration({
       scopeRef.current =
         typeof HTMLElement !== "undefined" && node instanceof HTMLElement ? node : null;
       if (!scopeRef.current && activeRef.current) {
-        removeEntryRef.current?.({ restoreFocus: false });
+        const removeEntry = removeEntryRef.current;
+        removeEntry?.({ restoreFocus: false });
+        detachedRemoveEntryRef.current = removeEntry;
+        removeEntryRef.current = null;
         registeredRef.current = false;
       }
       // Host refs attach before descendant layout effects and autofocus. Register
@@ -314,8 +322,10 @@ export function useWebOverlayRegistration({
   useLayoutEffect(() => {
     syncRegistration();
     return () => {
-      removeEntryRef.current?.();
+      const removeEntry = removeEntryRef.current ?? detachedRemoveEntryRef.current;
+      removeEntry?.();
       removeEntryRef.current = null;
+      detachedRemoveEntryRef.current = null;
       registeredRef.current = false;
     };
   }, [active, syncRegistration]);

--- a/packages/app/src/lib/overlay-root.ts
+++ b/packages/app/src/lib/overlay-root.ts
@@ -95,6 +95,10 @@ let webOverlayOrder = 0;
 let webOverlayListenersAttached = false;
 let webOverlayFocusCheckQueued = false;
 
+interface RemoveWebOverlayOptions {
+  restoreFocus?: boolean;
+}
+
 function getTopWebOverlay(): WebOverlayEntry | undefined {
   return webOverlayEntries.reduce<WebOverlayEntry | undefined>((top, entry) => {
     if (!top) return entry;
@@ -195,7 +199,7 @@ function detachWebOverlayListeners(): void {
   webOverlayListenersAttached = false;
 }
 
-function addWebOverlay(entry: WebOverlayEntry): () => void {
+function addWebOverlay(entry: WebOverlayEntry): (options?: RemoveWebOverlayOptions) => void {
   webOverlayEntries.push(entry);
   attachWebOverlayListeners();
 
@@ -206,12 +210,16 @@ function addWebOverlay(entry: WebOverlayEntry): () => void {
     }
   });
 
-  return () => {
+  return (options) => {
     window.cancelAnimationFrame(focusFrame);
     const index = webOverlayEntries.findIndex((candidate) => candidate.id === entry.id);
     if (index !== -1) webOverlayEntries.splice(index, 1);
     detachWebOverlayListeners();
-    if (entry.restoreFocus && document.contains(entry.restoreFocus)) {
+    if (
+      options?.restoreFocus !== false &&
+      entry.restoreFocus &&
+      document.contains(entry.restoreFocus)
+    ) {
       entry.restoreFocus.focus();
     }
   };
@@ -240,7 +248,8 @@ export function useWebOverlayRegistration({
   const layerRef = useRef(layer);
   const keyHandlerRef = useRef(onKeyDown);
   const capturedRestoreFocusRef = useRef<HTMLElement | null>(null);
-  const removeEntryRef = useRef<(() => void) | null>(null);
+  const removeEntryRef = useRef<((options?: RemoveWebOverlayOptions) => void) | null>(null);
+  const registeredRef = useRef(false);
   const activeRef = useRef(active);
   const wasActiveRef = useRef(false);
 
@@ -265,11 +274,15 @@ export function useWebOverlayRegistration({
       typeof window !== "undefined" &&
       typeof document !== "undefined";
     if (!shouldRegister) {
-      removeEntryRef.current?.();
-      removeEntryRef.current = null;
+      const shouldRestoreFocus = !activeRef.current;
+      if (registeredRef.current || shouldRestoreFocus) {
+        removeEntryRef.current?.({ restoreFocus: shouldRestoreFocus });
+      }
+      registeredRef.current = false;
+      if (shouldRestoreFocus) removeEntryRef.current = null;
       return;
     }
-    if (removeEntryRef.current) return;
+    if (registeredRef.current) return;
 
     const entry: WebOverlayEntry = {
       id: idRef.current,
@@ -280,12 +293,17 @@ export function useWebOverlayRegistration({
       restoreFocus: capturedRestoreFocusRef.current,
     };
     removeEntryRef.current = addWebOverlay(entry);
+    registeredRef.current = true;
   }, []);
 
   const setScope = useCallback(
     (node: unknown) => {
       scopeRef.current =
         typeof HTMLElement !== "undefined" && node instanceof HTMLElement ? node : null;
+      if (!scopeRef.current && activeRef.current) {
+        removeEntryRef.current?.({ restoreFocus: false });
+        registeredRef.current = false;
+      }
       // Host refs attach before descendant layout effects and autofocus. Register
       // here so the previous overlay cannot redirect that pending focus.
       syncRegistration();
@@ -298,6 +316,7 @@ export function useWebOverlayRegistration({
     return () => {
       removeEntryRef.current?.();
       removeEntryRef.current = null;
+      registeredRef.current = false;
     };
   }, [active, syncRegistration]);
 


### PR DESCRIPTION
### Linked issue

N/A — no issue filed. Bug reproduced directly in web/Electron overlay inputs.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Chinese IME composition was interrupted in overlay inputs on web and Electron. While composing text, the overlay scope could temporarily detach during render; Paseo treated that transient detach like the overlay had closed and restored focus to the opener. That blur canceled the active IME composition, so the candidate window flashed and the raw pinyin letters were inserted instead of the composed Chinese text.

This keeps focus restoration for real overlay close/inactive transitions, but skips restoring focus when an active overlay scope temporarily detaches.

### Goals

- Preserve Chinese/Japanese/Korean IME composition inside web/Electron overlay inputs.
- Avoid restoring focus to the opener when an active overlay scope temporarily detaches.
- Preserve existing focus restoration when the overlay actually closes.
- Add regression coverage for transient scope detach vs real overlay close.

### Non-goals

- No changes to native mobile keyboard behavior.
- No redesign of modal, sheet, or input components.
- No changes to global shortcut routing or Escape handling.

### QA

Repro evidence before the fix:

Desktop macOS / Electron production app:

https://github.com/user-attachments/assets/f86cd0f2-5f66-4a75-886e-ec476c9d794a

Observed: while using Chinese IME in an overlay input, the candidate window flashes and composition is canceled, leaving raw pinyin letters in the input.

After fix:

https://github.com/user-attachments/assets/0e8342c2-37e8-4b85-941a-3bb0eeaa965d


- Desktop macOS/Electron dev app: Chinese IME composition completes normally in the same overlay input.

Manual behavior verification:

- Reproduced before the fix in web/Electron overlay inputs: while using a Chinese input method, the IME candidate window flashed and composition was canceled, leaving pinyin letters in the input.
- Confirmed after the fix in local browser and desktop dev app: Chinese IME composition completes normally in overlay inputs.

Automated checks:

```text
$ npx vitest run packages/app/src/lib/overlay-root.test.tsx --bail=1

Test Files  1 passed (1)
Tests       2 passed (2)