### PR TITLE
fix(desktop): package target Windows native dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,11 +244,28 @@ jobs:
           PASEO_DESKTOP_SMOKE: "1"
           PASEO_DESKTOP_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/desktop-smoke
 
+      - name: Build and smoke unpacked Windows desktop app
+        if: ${{ runner.os == 'Windows' }}
+        run: npm run build:desktop -- --publish never --win --x64 --dir
+        env:
+          EP_GH_IGNORE_TIME: true
+          PASEO_DESKTOP_SMOKE: "1"
+          PASEO_DESKTOP_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/desktop-smoke
+
       - name: Upload packaged smoke diagnostics
         uses: actions/upload-artifact@v4
         if: ${{ failure() && runner.os == 'Linux' }}
         with:
           name: desktop-packaged-smoke-linux-x64
+          path: ${{ runner.temp }}/desktop-smoke
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Windows packaged smoke diagnostics
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() && runner.os == 'Windows' }}
+        with:
+          name: desktop-packaged-smoke-windows-x64
           path: ${{ runner.temp }}/desktop-smoke
           if-no-files-found: ignore
           retention-days: 7

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -6,6 +6,7 @@ protocols:
   - name: Paseo agent link
     schemes:
       - paseo
+beforePack: ./scripts/before-pack.js
 afterPack: ./scripts/after-pack.js
 afterSign: ./scripts/after-sign.js
 directories:

--- a/packages/desktop/scripts/after-pack.js
+++ b/packages/desktop/scripts/after-pack.js
@@ -14,6 +14,21 @@ const RIPGREP_PLATFORM_DIR = {
   win32: { arm64: "arm64-win32", x64: "x64-win32" },
 };
 
+const PARCEL_WATCHER_PLATFORM_DIRS = {
+  darwin: { arm64: ["watcher-darwin-arm64"], x64: ["watcher-darwin-x64"] },
+  linux: {
+    arm64: ["watcher-linux-arm64-glibc", "watcher-linux-arm64-musl"],
+    x64: ["watcher-linux-x64-glibc", "watcher-linux-x64-musl"],
+  },
+  win32: { arm64: ["watcher-win32-arm64"], x64: ["watcher-win32-x64"] },
+};
+
+const SHERPA_PLATFORM_DIR = {
+  darwin: { arm64: "sherpa-onnx-darwin-arm64", x64: "sherpa-onnx-darwin-x64" },
+  linux: { arm64: "sherpa-onnx-linux-arm64", x64: "sherpa-onnx-linux-x64" },
+  win32: { ia32: "sherpa-onnx-win-ia32", x64: "sherpa-onnx-win-x64" },
+};
+
 function rmSafe(target) {
   fs.rmSync(target, { recursive: true, force: true });
 }
@@ -22,6 +37,15 @@ function pruneChildrenExcept(parent, keep) {
   if (!fs.existsSync(parent)) return;
   for (const entry of fs.readdirSync(parent)) {
     if (!keep.has(entry)) {
+      rmSafe(path.join(parent, entry));
+    }
+  }
+}
+
+function pruneMatchingChildrenExcept(parent, prefix, keep) {
+  if (!fs.existsSync(parent)) return;
+  for (const entry of fs.readdirSync(parent)) {
+    if (entry.startsWith(prefix) && !keep.has(entry)) {
       rmSafe(path.join(parent, entry));
     }
   }
@@ -73,6 +97,45 @@ function pruneSharpLibvips(nodeModules, platform, arch) {
   }
 }
 
+function pruneParcelWatcher(nodeModules, platform, arch) {
+  const keep = new Set(PARCEL_WATCHER_PLATFORM_DIRS[platform]?.[arch] || []);
+  pruneMatchingChildrenExcept(path.join(nodeModules, "@parcel"), "watcher-", keep);
+}
+
+function pruneSherpaOnnx(nodeModules, platform, arch) {
+  const keep = new Set(["sherpa-onnx-node"]);
+  const platformPackage = SHERPA_PLATFORM_DIR[platform]?.[arch];
+  if (platformPackage) keep.add(platformPackage);
+  pruneMatchingChildrenExcept(nodeModules, "sherpa-onnx-", keep);
+}
+
+function assertFile(filePath, label) {
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    throw new Error(`${label} is missing from the packaged app: ${filePath}`);
+  }
+}
+
+function validateWindowsNativeModules(nodeModules, arch) {
+  const watcherDir = PARCEL_WATCHER_PLATFORM_DIRS.win32[arch]?.[0];
+  if (!watcherDir) {
+    throw new Error(`Unsupported Windows architecture for @parcel/watcher: ${arch}`);
+  }
+
+  assertFile(
+    path.join(nodeModules, "@parcel", watcherDir, "watcher.node"),
+    "Parcel watcher binding",
+  );
+  assertFile(
+    path.join(nodeModules, "node-pty", "prebuilds", `win32-${arch}`, "conpty.node"),
+    "node-pty binding",
+  );
+
+  const sherpaDir = SHERPA_PLATFORM_DIR.win32[arch];
+  if (sherpaDir) {
+    assertFile(path.join(nodeModules, sherpaDir, "sherpa-onnx.node"), "sherpa-onnx binding");
+  }
+}
+
 function pruneNativeModules(appOutDir, platform, arch) {
   const resourcesDir =
     platform === "darwin"
@@ -80,13 +143,24 @@ function pruneNativeModules(appOutDir, platform, arch) {
       : path.join(appOutDir, "resources");
 
   const nodeModules = path.join(resourcesDir, "app.asar.unpacked", "node_modules");
-  if (!fs.existsSync(nodeModules)) return;
+  if (!fs.existsSync(nodeModules)) {
+    if (platform === "win32") {
+      throw new Error(`Packaged native modules directory is missing: ${nodeModules}`);
+    }
+    return;
+  }
 
   const before = dirSizeSync(nodeModules);
 
   pruneClaudeAgentSdk(nodeModules, platform, arch);
   pruneNodePty(nodeModules, platform, arch);
   pruneSharpLibvips(nodeModules, platform, arch);
+  pruneParcelWatcher(nodeModules, platform, arch);
+  pruneSherpaOnnx(nodeModules, platform, arch);
+
+  if (platform === "win32") {
+    validateWindowsNativeModules(nodeModules, arch);
+  }
 
   const after = dirSizeSync(nodeModules);
   const savedMB = ((before - after) / 1024 / 1024).toFixed(1);
@@ -135,3 +209,5 @@ async function smokeUnpackedAppIfRequested(appOutDir) {
     appPath: appOutDir,
   });
 }
+
+exports.pruneNativeModules = pruneNativeModules;

--- a/packages/desktop/scripts/before-pack.js
+++ b/packages/desktop/scripts/before-pack.js
@@ -1,0 +1,45 @@
+const childProcess = require("node:child_process");
+const path = require("node:path");
+
+const ARCH_MAP = { 0: "ia32", 1: "x64", 2: "armv7l", 3: "arm64", 4: "universal" };
+const WORKSPACE_ROOT = path.resolve(__dirname, "../../..");
+
+function getTargetNpmInstallArgs(platform, arch) {
+  return [
+    "install",
+    "--workspaces",
+    "--include-workspace-root",
+    "--include=optional",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+    "--no-save",
+    "--force",
+    `--os=${platform}`,
+    `--cpu=${arch}`,
+  ];
+}
+
+exports.default = function beforePack(context) {
+  const platform = context.electronPlatformName;
+  if (platform !== "win32") return;
+
+  const arch = ARCH_MAP[context.arch] || process.arch;
+  const npmExecPath = process.env.npm_execpath;
+  if (!npmExecPath) {
+    throw new Error("Cannot install Windows optional dependencies: npm_execpath is unset.");
+  }
+
+  console.log(`Installing optional dependencies for ${platform}-${arch}.`);
+  childProcess.execFileSync(
+    process.execPath,
+    [npmExecPath, ...getTargetNpmInstallArgs(platform, arch)],
+    {
+      cwd: WORKSPACE_ROOT,
+      env: process.env,
+      stdio: "inherit",
+    },
+  );
+};
+
+exports.getTargetNpmInstallArgs = getTargetNpmInstallArgs;

--- a/packages/desktop/scripts/before-pack.js
+++ b/packages/desktop/scripts/before-pack.js
@@ -14,7 +14,6 @@ function getTargetNpmInstallArgs(platform, arch) {
     "--no-audit",
     "--no-fund",
     "--no-save",
-    "--force",
     `--os=${platform}`,
     `--cpu=${arch}`,
   ];

--- a/packages/desktop/scripts/native-packaging.test.mjs
+++ b/packages/desktop/scripts/native-packaging.test.mjs
@@ -1,0 +1,118 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import afterPack from "./after-pack.js";
+import beforePack from "./before-pack.js";
+
+const temporaryDirs = [];
+
+afterEach(() => {
+  for (const dir of temporaryDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createPackagedNodeModules() {
+  const appOutDir = mkdtempSync(path.join(tmpdir(), "paseo-native-packaging-"));
+  temporaryDirs.push(appOutDir);
+  const nodeModules = path.join(appOutDir, "resources", "app.asar.unpacked", "node_modules");
+  mkdirSync(nodeModules, { recursive: true });
+  return { appOutDir, nodeModules };
+}
+
+function touch(root, relativePath) {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, "native");
+}
+
+function addWindowsBindings(nodeModules, arch) {
+  touch(nodeModules, `@parcel/watcher-win32-${arch}/watcher.node`);
+  touch(nodeModules, `node-pty/prebuilds/win32-${arch}/conpty.node`);
+  if (arch === "x64") {
+    touch(nodeModules, "sherpa-onnx-win-x64/sherpa-onnx.node");
+  }
+}
+
+describe("Windows native dependency preparation", () => {
+  it.each(["x64", "arm64"])("builds target npm install arguments for %s", (arch) => {
+    expect(beforePack.getTargetNpmInstallArgs("win32", arch)).toEqual([
+      "install",
+      "--workspaces",
+      "--include-workspace-root",
+      "--include=optional",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--no-save",
+      "--force",
+      "--os=win32",
+      `--cpu=${arch}`,
+    ]);
+  });
+});
+
+describe("Windows packaged native dependencies", () => {
+  it("keeps only Windows x64 watcher, node-pty, and sherpa bindings", () => {
+    const { appOutDir, nodeModules } = createPackagedNodeModules();
+    addWindowsBindings(nodeModules, "x64");
+    touch(nodeModules, "@parcel/watcher-linux-x64-glibc/watcher.node");
+    touch(nodeModules, "@parcel/watcher-win32-arm64/watcher.node");
+    touch(nodeModules, "node-pty/prebuilds/win32-arm64/conpty.node");
+    touch(nodeModules, "sherpa-onnx-linux-x64/sherpa-onnx.node");
+
+    afterPack.pruneNativeModules(appOutDir, "win32", "x64");
+
+    expect(existsSync(path.join(nodeModules, "@parcel/watcher-win32-x64/watcher.node"))).toBe(true);
+    expect(existsSync(path.join(nodeModules, "node-pty/prebuilds/win32-x64/conpty.node"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(nodeModules, "sherpa-onnx-win-x64/sherpa-onnx.node"))).toBe(true);
+    expect(existsSync(path.join(nodeModules, "@parcel/watcher-linux-x64-glibc"))).toBe(false);
+    expect(existsSync(path.join(nodeModules, "@parcel/watcher-win32-arm64"))).toBe(false);
+    expect(existsSync(path.join(nodeModules, "node-pty/prebuilds/win32-arm64"))).toBe(false);
+    expect(existsSync(path.join(nodeModules, "sherpa-onnx-linux-x64"))).toBe(false);
+  });
+
+  it("keeps Windows ARM64 bindings and removes unsupported sherpa packages", () => {
+    const { appOutDir, nodeModules } = createPackagedNodeModules();
+    addWindowsBindings(nodeModules, "arm64");
+    touch(nodeModules, "@parcel/watcher-win32-x64/watcher.node");
+    touch(nodeModules, "node-pty/prebuilds/win32-x64/conpty.node");
+    touch(nodeModules, "sherpa-onnx-win-x64/sherpa-onnx.node");
+
+    afterPack.pruneNativeModules(appOutDir, "win32", "arm64");
+
+    expect(existsSync(path.join(nodeModules, "@parcel/watcher-win32-arm64/watcher.node"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(nodeModules, "node-pty/prebuilds/win32-arm64/conpty.node"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(nodeModules, "@parcel/watcher-win32-x64"))).toBe(false);
+    expect(existsSync(path.join(nodeModules, "node-pty/prebuilds/win32-x64"))).toBe(false);
+    expect(existsSync(path.join(nodeModules, "sherpa-onnx-win-x64"))).toBe(false);
+  });
+
+  it("fails when the target watcher binding is missing", () => {
+    const { appOutDir, nodeModules } = createPackagedNodeModules();
+    touch(nodeModules, "node-pty/prebuilds/win32-x64/conpty.node");
+    touch(nodeModules, "sherpa-onnx-win-x64/sherpa-onnx.node");
+
+    expect(() => afterPack.pruneNativeModules(appOutDir, "win32", "x64")).toThrow(
+      "Parcel watcher binding is missing",
+    );
+  });
+
+  it("fails when another required target binding is missing", () => {
+    const { appOutDir, nodeModules } = createPackagedNodeModules();
+    touch(nodeModules, "@parcel/watcher-win32-x64/watcher.node");
+    touch(nodeModules, "node-pty/prebuilds/win32-x64/conpty.node");
+
+    expect(() => afterPack.pruneNativeModules(appOutDir, "win32", "x64")).toThrow(
+      "sherpa-onnx binding is missing",
+    );
+  });
+});

--- a/packages/desktop/scripts/native-packaging.test.mjs
+++ b/packages/desktop/scripts/native-packaging.test.mjs
@@ -47,7 +47,6 @@ describe("Windows native dependency preparation", () => {
       "--no-audit",
       "--no-fund",
       "--no-save",
-      "--force",
       "--os=win32",
       `--cpu=${arch}`,
     ]);


### PR DESCRIPTION
### Linked issue

Closes #2816

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Windows desktop builds can be produced on a different host OS. npm installs native optional dependencies for the host by default, so the Windows package could contain Linux Parcel watcher binaries while omitting the Windows binding. Once the daemon imported the watcher during startup, the packaged app exited before opening its renderer.

This change installs optional dependencies for each Windows target architecture before electron-builder copies the app, then prunes wrong-platform packages and fails the build if required Windows bindings are missing. Pull-request CI now builds and smokes an unpacked Windows x64 app so this packaging path runs before release.

### Goals

- Package the target Windows Parcel watcher, node-pty, and supported sherpa-onnx bindings.
- Keep only native packages that match the packaged OS and architecture.
- Fail packaging before artifact creation when a required binding is missing.
- Exercise Windows x64 packaging and packaged-app startup in pull-request CI.

### Non-goals

- Change Git observation, watcher behavior, runtime APIs, or protocol data.
- Add or upgrade dependencies.
- Add sherpa-onnx support for Windows ARM64; upstream does not publish that package, so incompatible sherpa packages are removed from ARM64 artifacts.

### QA

Original Windows x64 startup failure:

    Error: No prebuild or local build of @parcel/watcher found. Tried @parcel/watcher-win32-x64. Please ensure it is installed (don't use --no-optional when installing with npm).

The broken artifact contained Linux watcher packages and no @parcel/watcher-win32-x64/watcher.node. The corrected x64 package was confirmed to start on Windows.

Targeted regression tests:

    $ npx vitest run packages/desktop/scripts/native-packaging.test.mjs --bail=1
    Test Files  1 passed (1)
         Tests  6 passed (6)

Repository checks:

    $ npm run format:check
    All matched files use the correct format.

    $ npm run typecheck
    @getpaseo/expo-two-way-audio, highlight, protocol, client, server, app,
    relay, website, desktop, and cli typechecks completed with exit code 0.

    $ npm run lint
    Found 0 warnings and 0 errors.

Linux to Windows multi-architecture packaging, without npm --force:

    $ npm exec electron-builder -- --config electron-builder.yml --publish never --win --x64 --arm64 --dir
    Installing optional dependencies for win32-x64.
    Pruned native modules: 1053.3 MB removed (1077.2 MB → 23.9 MB)
    Installing optional dependencies for win32-arm64.
    Pruned native modules: 1072.5 MB removed (1077.2 MB → 4.7 MB)
    exit code 0

Post-build artifact assertions checked:

- x64 contains watcher-win32-x64, node-pty win32-x64, and sherpa-onnx-win-x64 bindings.
- ARM64 contains watcher-win32-arm64 and node-pty win32-arm64 bindings.
- ARM64 contains no unsupported sherpa package.
- Neither artifact contains Linux watcher or sherpa packages.

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop Windows x64 | Yes | Corrected package startup confirmed; native binding contents validated. |
| Desktop Windows ARM64 | Partial | Cross-packaged and inspected; not launched on ARM64 hardware. |
| Desktop Linux | No runtime retest | beforePack is Windows-only; existing Linux packaging path remains in PR CI. |
| Desktop macOS | No | Native release runners already build on matching architecture; no macOS hook behavior changed. |
| Mobile / browser web | Not affected | Desktop packaging scripts only. |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
