### PR TITLE
fix(cli): bound the WebSocket close handshake

### DIFF
--- a/packages/cli/src/utils/client.ts
+++ b/packages/cli/src/utils/client.ts
@@ -15,6 +15,7 @@ import { DaemonClient, type WebSocketLike } from "@getpaseo/client/internal/daem
 import path from "node:path";
 import { WebSocket } from "ws";
 import { getOrCreateCliClientId } from "./client-id.js";
+import { boundCloseHandshake } from "./websocket-close.js";
 import { resolveCliVersion } from "../version.js";
 
 export interface ConnectOptions {
@@ -256,10 +257,11 @@ function createNodeWebSocketFactory() {
     url: string,
     options?: { headers?: Record<string, string>; protocols?: string[]; socketPath?: string },
   ): WebSocketLike => {
-    return new WebSocket(url, options?.protocols, {
+    const socket = new WebSocket(url, options?.protocols, {
       headers: options?.headers,
       ...(options?.socketPath ? { socketPath: options.socketPath } : {}),
-    }) as unknown as WebSocketLike;
+    });
+    return boundCloseHandshake(socket) as unknown as WebSocketLike;
   };
 }
 

--- a/packages/cli/src/utils/websocket-close.test.ts
+++ b/packages/cli/src/utils/websocket-close.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import type { AddressInfo, Socket } from "node:net";
 import { WebSocket, WebSocketServer } from "ws";
 
-import { boundCloseHandshake } from "./websocket-close.js";
+import { boundCloseHandshake, CLOSE_HANDSHAKE_TIMEOUT_MS } from "./websocket-close.js";
 
 /**
  * `ws` waits 30s for a close frame to be answered before it drops the socket, so a peer
@@ -46,8 +46,8 @@ async function startServer(options: { answersClose: boolean }): Promise<string> 
   return `ws://127.0.0.1:${(server.address() as AddressInfo).port}`;
 }
 
-async function connect(url: string): Promise<WebSocket> {
-  const socket = boundCloseHandshake(new WebSocket(url), BOUND_MS);
+async function connect(url: string, timeoutMs: number): Promise<WebSocket> {
+  const socket = boundCloseHandshake(new WebSocket(url), timeoutMs);
   sockets.push(socket);
   await new Promise<void>((resolve) => socket.once("open", resolve));
   return socket;
@@ -59,7 +59,7 @@ function whenClosed(socket: WebSocket): Promise<{ code: number }> {
 
 describe("boundCloseHandshake", () => {
   test("drops the socket when the peer never answers the close frame", async () => {
-    const socket = await connect(await startServer({ answersClose: false }));
+    const socket = await connect(await startServer({ answersClose: false }), BOUND_MS);
     const closed = whenClosed(socket);
 
     socket.close(1000, "Client closed");
@@ -70,7 +70,12 @@ describe("boundCloseHandshake", () => {
   }, 5000);
 
   test("completes the normal close handshake untouched", async () => {
-    const socket = await connect(await startServer({ answersClose: true }));
+    // Exercise the production deadline here. Reusing the deliberately tiny failure-test
+    // bound makes a healthy loopback handshake compete with routine CI scheduling jitter.
+    const socket = await connect(
+      await startServer({ answersClose: true }),
+      CLOSE_HANDSHAKE_TIMEOUT_MS,
+    );
     const closed = whenClosed(socket);
 
     socket.close(1000, "Client closed");

--- a/packages/cli/src/utils/websocket-close.test.ts
+++ b/packages/cli/src/utils/websocket-close.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { AddressInfo, Socket } from "node:net";
+import { WebSocket, WebSocketServer } from "ws";
+
+import { boundCloseHandshake } from "./websocket-close.js";
+
+/**
+ * `ws` waits 30s for a close frame to be answered before it drops the socket, so a peer
+ * that never answers has to be bounded well inside the test timeout to prove anything.
+ */
+const BOUND_MS = 50;
+
+const servers: WebSocketServer[] = [];
+const sockets: WebSocket[] = [];
+const accepted: Socket[] = [];
+
+afterEach(async () => {
+  for (const socket of sockets.splice(0)) {
+    socket.terminate();
+  }
+  // A paused server-side socket never finishes closing on its own, so drop it by hand
+  // before waiting on the server.
+  for (const socket of accepted.splice(0)) {
+    socket.destroy();
+  }
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+});
+
+/** Start a daemon-shaped WebSocket server. `answersClose` false = a wedged peer. */
+async function startServer(options: { answersClose: boolean }): Promise<string> {
+  const server = new WebSocketServer({ port: 0 });
+  servers.push(server);
+  server.on("connection", (_socket, request) => {
+    accepted.push(request.socket);
+    if (!options.answersClose) {
+      // Stop reading from the socket: the close frame is never received, so the server
+      // never answers it, and the client is left in CLOSING.
+      request.socket.pause();
+    }
+  });
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  return `ws://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+async function connect(url: string): Promise<WebSocket> {
+  const socket = boundCloseHandshake(new WebSocket(url), BOUND_MS);
+  sockets.push(socket);
+  await new Promise<void>((resolve) => socket.once("open", resolve));
+  return socket;
+}
+
+function whenClosed(socket: WebSocket): Promise<{ code: number }> {
+  return new Promise((resolve) => socket.once("close", (code) => resolve({ code })));
+}
+
+describe("boundCloseHandshake", () => {
+  test("drops the socket when the peer never answers the close frame", async () => {
+    const socket = await connect(await startServer({ answersClose: false }));
+    const closed = whenClosed(socket);
+
+    socket.close(1000, "Client closed");
+
+    // 1006 (abnormal): the handshake was bounded and the socket dropped, rather than the
+    // connection lingering until `ws` gives up 30s later and holding the CLI process open.
+    expect(await closed).toEqual({ code: 1006 });
+  }, 5000);
+
+  test("completes the normal close handshake untouched", async () => {
+    const socket = await connect(await startServer({ answersClose: true }));
+    const closed = whenClosed(socket);
+
+    socket.close(1000, "Client closed");
+
+    expect(await closed).toEqual({ code: 1000 });
+  }, 5000);
+});

--- a/packages/cli/src/utils/websocket-close.ts
+++ b/packages/cli/src/utils/websocket-close.ts
@@ -1,0 +1,50 @@
+import { WebSocket } from "ws";
+
+/**
+ * How long the CLI waits for the daemon to answer a close frame before it drops the
+ * socket. Long enough for a healthy daemon to finish the handshake, short enough that a
+ * wedged one is never what keeps the CLI from exiting.
+ */
+export const CLOSE_HANDSHAKE_TIMEOUT_MS = 2000;
+
+/**
+ * Bound the WebSocket closing handshake.
+ *
+ * A daemon can receive a close frame and never answer it — a paused process, a half-open
+ * socket, a relay that went away mid-flight. Node's `ws` keeps the underlying socket
+ * handle alive until its own 30s close timeout expires, and a live handle keeps the CLI
+ * process alive with it, so a command that has already printed its output sits there
+ * doing nothing. Send the polite close, then terminate if the peer does not answer.
+ *
+ * The timer is unref'd: the bound must never itself be the reason the process stays up.
+ */
+export function boundCloseHandshake(
+  socket: WebSocket,
+  timeoutMs: number = CLOSE_HANDSHAKE_TIMEOUT_MS,
+): WebSocket {
+  let timer: NodeJS.Timeout | null = null;
+
+  const clearCloseTimer = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  socket.once("close", clearCloseTimer);
+
+  const close = socket.close.bind(socket);
+  socket.close = (code?: number, reason?: string) => {
+    close(code, reason);
+    if (timer || socket.readyState === WebSocket.CLOSED) {
+      return;
+    }
+    timer = setTimeout(() => {
+      timer = null;
+      socket.terminate();
+    }, timeoutMs);
+    timer.unref();
+  };
+
+  return socket;
+}


### PR DESCRIPTION
Replaces #2771 with a clean, independently reviewable change based on the latest stable v0.2.5 line and verified to merge cleanly with current upstream main.\n\nThis keeps the production behavior but removes the export-only test seam: the bounded close logic now lives in `websocket-close.ts` and is covered with a real `ws` server regression.\n\nScope: 3 files, one commit, no unrelated fleet/runtime changes.\n\nVerification previously run on the exact commit: focused WebSocket-close tests, CLI typecheck, lint, formatting, and diff check.\n\nSupersedes: #2771.