### PR TITLE
Fix missing slash commands in the pre-chat composer

### DIFF
--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -422,7 +422,10 @@ export function useAgentAutocomplete(input: UseAgentAutocompleteInput): AgentAut
     draftConfig: queryDraftConfig,
   });
 
-  const isVisible = canShowAutocomplete && !(mode === "command" && isCommandsLoading);
+  // Listing commands spawns a provider runtime, which takes a second or two on a
+  // cold config. Stay visible so the menu shows its loading and error rows instead
+  // of making "/" look like it did nothing.
+  const isVisible = canShowAutocomplete;
 
   const fileSuggestionsQuery = useQuery({
     queryKey: [

--- a/packages/app/src/hooks/use-agent-commands-query.test.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.test.ts
@@ -3,6 +3,7 @@ import {
   type AgentCommandsClient,
   type DraftCommandConfig,
   fetchAgentCommands,
+  resolveCommandsStaleTime,
 } from "./use-agent-commands-query";
 
 type ListCommands = AgentCommandsClient["listCommands"];
@@ -63,5 +64,53 @@ describe("fetchAgentCommands", () => {
     await fetchAgentCommands({ client, agentId: "agent-1" });
 
     expect(client.calls).toEqual([{ agentId: "agent-1", draftConfig: undefined }]);
+  });
+});
+
+describe("draft command failures", () => {
+  it("surfaces a daemon error for a draft composer instead of an empty command list", async () => {
+    const client = createClient({
+      requestId: "req_commands",
+      agentId: "",
+      error: "Provider 'codex' has no models available, so its commands cannot be listed.",
+      commands: [],
+    });
+
+    await expect(
+      fetchAgentCommands({
+        client,
+        agentId: "",
+        draftConfig: { provider: "codex", cwd: "/repo" },
+      }),
+    ).rejects.toThrow("has no models available");
+  });
+
+  it("keeps a running agent usable when the provider cannot list commands", async () => {
+    const client = createClient({
+      requestId: "req_commands",
+      agentId: "agent-1",
+      error: "Agent does not support listing commands",
+      commands: [],
+    });
+
+    await expect(fetchAgentCommands({ client, agentId: "agent-1" })).resolves.toEqual([]);
+  });
+});
+
+describe("resolveCommandsStaleTime", () => {
+  it("keeps a loaded draft command list indefinitely", () => {
+    expect(
+      resolveCommandsStaleTime({
+        isDraft: true,
+        commands: [{ name: "review", description: "", argumentHint: "" }],
+      }),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("lets an empty draft command list go stale so it is retried", () => {
+    const staleTime = resolveCommandsStaleTime({ isDraft: true, commands: [] });
+
+    expect(staleTime).toBeLessThan(Number.POSITIVE_INFINITY);
+    expect(staleTime).toBeGreaterThan(0);
   });
 });

--- a/packages/app/src/hooks/use-agent-commands-query.ts
+++ b/packages/app/src/hooks/use-agent-commands-query.ts
@@ -7,6 +7,13 @@ import { agentCommandsQueryKey, type AgentCommandsDraftConfig } from "@/hooks/ag
 
 const DRAFT_COMMANDS_STALE_TIME = Number.POSITIVE_INFINITY;
 const SESSION_COMMANDS_STALE_TIME = 60_000;
+/**
+ * A draft config the daemon could not service — no model resolved yet, provider
+ * snapshot still loading — comes back as an empty list. Caching that forever
+ * leaves the composer with no commands for the rest of the session, so let an
+ * empty result go stale and be retried.
+ */
+const EMPTY_DRAFT_COMMANDS_STALE_TIME = 5_000;
 
 export interface AgentSlashCommand {
   name: string;
@@ -35,7 +42,25 @@ export async function fetchAgentCommands(input: {
     agentId: input.agentId,
     draftConfig: input.draftConfig,
   });
+  // A draft composer has nothing to show but provider commands, so a failure has
+  // to surface. A running agent still has client commands to fall back on, and
+  // some providers legitimately report that they cannot list commands at all.
+  if (input.draftConfig && response.error) {
+    throw new Error(response.error);
+  }
   return response.commands as AgentSlashCommand[];
+}
+
+export function resolveCommandsStaleTime(input: {
+  isDraft: boolean;
+  commands: readonly AgentSlashCommand[] | undefined;
+}): number {
+  if (!input.isDraft) {
+    return SESSION_COMMANDS_STALE_TIME;
+  }
+  return (input.commands?.length ?? 0) > 0
+    ? DRAFT_COMMANDS_STALE_TIME
+    : EMPTY_DRAFT_COMMANDS_STALE_TIME;
 }
 
 interface UseAgentCommandsQueryOptions {
@@ -66,7 +91,11 @@ export function useAgentCommandsQuery({
       return fetchAgentCommands({ client, agentId, draftConfig });
     },
     enabled: queryEnabled && !!client && isConnected && (!!agentId || !!draftConfig),
-    staleTime: draftConfig ? DRAFT_COMMANDS_STALE_TIME : SESSION_COMMANDS_STALE_TIME,
+    staleTime: (commandsQuery) =>
+      resolveCommandsStaleTime({
+        isDraft: Boolean(draftConfig),
+        commands: commandsQuery.state.data,
+      }),
     retry: 3,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 5000),
   });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1809,28 +1809,27 @@ test("normalizeConfig strips legacy 'default' model id", async () => {
   expect(snapshot.config.modeId).toBeUndefined();
 });
 
-test("listDraftCommands returns no commands without guessing a missing model", async () => {
+test("listDraftCommands falls back to the provider default model", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-draft-commands-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
+  const draftCommand: AgentSlashCommand = {
+    name: "review",
+    description: "Review changes",
+    argumentHint: "",
+    kind: "command",
+  };
+  class DraftCommandSession extends TestAgentSession {
+    override async listCommands(): Promise<AgentSlashCommand[]> {
+      return [draftCommand];
+    }
+  }
   class DraftCommandClient extends TestAgentClient {
-    fetchCatalogCalls = 0;
-    createSessionCalls = 0;
-    availabilityCalls = 0;
-
-    override async isAvailable(): Promise<boolean> {
-      this.availabilityCalls += 1;
-      return true;
-    }
-
-    override async fetchCatalog() {
-      this.fetchCatalogCalls += 1;
-      return await super.fetchCatalog();
-    }
+    readonly commandConfigs: AgentSessionConfig[] = [];
 
     override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
-      this.createSessionCalls += 1;
-      return await super.createSession(config);
+      this.commandConfigs.push(config);
+      return new DraftCommandSession(config);
     }
   }
   const client = new DraftCommandClient();
@@ -1842,11 +1841,43 @@ test("listDraftCommands returns no commands without guessing a missing model", a
     logger,
   });
 
-  await expect(manager.listDraftCommands({ provider: "codex", cwd: workdir })).resolves.toEqual([]);
+  // A pre-chat composer sends no model until its provider snapshot resolves one.
+  await expect(manager.listDraftCommands({ provider: "codex", cwd: workdir })).resolves.toEqual([
+    draftCommand,
+  ]);
 
-  expect(client.fetchCatalogCalls).toBe(0);
+  expect(client.commandConfigs.map((config) => config.model)).toEqual(["gpt-5.4"]);
+});
+
+test("listDraftCommands reports an error when the provider has no models", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-draft-commands-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  class EmptyCatalogClient extends TestAgentClient {
+    createSessionCalls = 0;
+
+    override async fetchCatalog() {
+      return { models: [], modes: [] };
+    }
+
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      this.createSessionCalls += 1;
+      return await super.createSession(config);
+    }
+  }
+  const client = new EmptyCatalogClient();
+  const manager = new AgentManager({
+    clients: {
+      codex: client,
+    },
+    registry: storage,
+    logger,
+  });
+
+  await expect(manager.listDraftCommands({ provider: "codex", cwd: workdir })).rejects.toThrow(
+    "has no models available",
+  );
   expect(client.createSessionCalls).toBe(0);
-  expect(client.availabilityCalls).toBe(0);
 });
 
 test("listDraftCommands uses explicit model config without default model fetching", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -87,6 +87,7 @@ import {
   type ProviderSubagentStoreEvent,
 } from "./provider-subagents/store.js";
 import { withTimeout } from "../../utils/promise-timeout.js";
+import { ProviderIntrospectionQueue } from "./provider-introspection-queue.js";
 
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
@@ -292,6 +293,7 @@ export interface AgentManagerOptions {
   pluginLifecycle?: PluginLifecycle;
   clients?: ProviderClientMap;
   providerDefinitions?: ProviderEnabledMap;
+  providerIntrospectionQueue?: ProviderIntrospectionQueue;
   idFactory?: () => string;
   registry?: AgentStorage;
   onAgentAttention?: AgentAttentionCallback;
@@ -691,6 +693,9 @@ function detachedAgentLabelPatch(labels: Record<string, string>): AgentLabelPatc
 export class AgentManager {
   private readonly pluginLifecycle: PluginLifecycle | undefined;
   private readonly clients = new Map<AgentProvider, AgentClient>();
+  private readonly providerIntrospectionQueue: ProviderIntrospectionQueue;
+  private readonly inFlightDraftCommands = new Map<string, Promise<AgentSlashCommand[]>>();
+  private readonly inFlightDraftFeatures = new Map<string, Promise<AgentFeature[]>>();
   private readonly providerEnabled = new Map<AgentProvider, boolean>();
   private readonly providerDefinitions = new Map<AgentProvider, ProviderEnabledFlag>();
   private readonly agents = new Map<string, LiveManagedAgent>();
@@ -731,6 +736,8 @@ export class AgentManager {
 
   constructor(options: AgentManagerOptions) {
     this.pluginLifecycle = options.pluginLifecycle;
+    this.providerIntrospectionQueue =
+      options.providerIntrospectionQueue ?? new ProviderIntrospectionQueue();
     this.idFactory = options?.idFactory ?? (() => randomUUID());
     this.registry = options?.registry;
     this.durableTimelineStore = options?.durableTimelineStore;
@@ -1058,35 +1065,40 @@ export class AgentManager {
     if (!normalizedConfig.model) {
       return [];
     }
-    const available = await client.isAvailable();
-    if (!available) {
-      throw new Error(
-        `Provider '${normalizedConfig.provider}' is not available. Please ensure the CLI is installed.`,
-      );
-    }
-
-    if (client.listCommands) {
-      return await client.listCommands(normalizedConfig);
-    }
-
-    const session = await client.createSession(normalizedConfig);
-    try {
-      if (!session.listCommands) {
+    const requestKey = this.buildDraftRequestKey(normalizedConfig);
+    return await this.runDraftRequest(this.inFlightDraftCommands, requestKey, async () => {
+      const available = await client.isAvailable();
+      if (!available) {
         throw new Error(
-          `Provider '${normalizedConfig.provider}' does not support listing commands`,
+          `Provider '${normalizedConfig.provider}' is not available. Please ensure the CLI is installed.`,
         );
       }
-      return await session.listCommands();
-    } finally {
-      try {
-        await session.close();
-      } catch (error) {
-        this.logger.warn(
-          { err: error, provider: normalizedConfig.provider },
-          "Failed to close draft command listing session",
-        );
-      }
-    }
+
+      return await this.providerIntrospectionQueue.run(normalizedConfig.provider, async () => {
+        if (client.listCommands) {
+          return await client.listCommands(normalizedConfig);
+        }
+
+        const session = await client.createSession(normalizedConfig);
+        try {
+          if (!session.listCommands) {
+            throw new Error(
+              `Provider '${normalizedConfig.provider}' does not support listing commands`,
+            );
+          }
+          return await session.listCommands();
+        } finally {
+          try {
+            await session.close();
+          } catch (error) {
+            this.logger.warn(
+              { err: error, provider: normalizedConfig.provider },
+              "Failed to close draft command listing session",
+            );
+          }
+        }
+      });
+    });
   }
 
   async listDraftFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
@@ -1095,30 +1107,68 @@ export class AgentManager {
     if (!normalizedConfig.model && !client.listFeatures) {
       return [];
     }
-    const available = await client.isAvailable();
-    if (!available) {
-      throw new Error(
-        `Provider '${normalizedConfig.provider}' is not available. Please ensure the CLI is installed.`,
-      );
-    }
-
-    if (client.listFeatures) {
-      return await client.listFeatures(normalizedConfig);
-    }
-
-    const session = await client.createSession(normalizedConfig);
-    try {
-      return session.features ?? [];
-    } finally {
-      try {
-        await session.close();
-      } catch (error) {
-        this.logger.warn(
-          { err: error, provider: normalizedConfig.provider },
-          "Failed to close draft feature listing session",
+    const requestKey = this.buildDraftRequestKey(normalizedConfig);
+    return await this.runDraftRequest(this.inFlightDraftFeatures, requestKey, async () => {
+      const available = await client.isAvailable();
+      if (!available) {
+        throw new Error(
+          `Provider '${normalizedConfig.provider}' is not available. Please ensure the CLI is installed.`,
         );
       }
+
+      return await this.providerIntrospectionQueue.run(normalizedConfig.provider, async () => {
+        if (client.listFeatures) {
+          return await client.listFeatures(normalizedConfig);
+        }
+
+        const session = await client.createSession(normalizedConfig);
+        try {
+          return session.features ?? [];
+        } finally {
+          try {
+            await session.close();
+          } catch (error) {
+            this.logger.warn(
+              { err: error, provider: normalizedConfig.provider },
+              "Failed to close draft feature listing session",
+            );
+          }
+        }
+      });
+    });
+  }
+
+  private buildDraftRequestKey(config: AgentSessionConfig): string {
+    return JSON.stringify(config);
+  }
+
+  private runDraftRequest<T>(
+    requests: Map<string, Promise<T>>,
+    key: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const existing = requests.get(key);
+    if (existing) {
+      return existing;
     }
+
+    const request = operation();
+    requests.set(key, request);
+    void request.then(
+      () => {
+        if (requests.get(key) === request) {
+          requests.delete(key);
+        }
+        return undefined;
+      },
+      () => {
+        if (requests.get(key) === request) {
+          requests.delete(key);
+        }
+        return undefined;
+      },
+    );
+    return request;
   }
 
   getAgent(id: string): ManagedAgent | null {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -703,6 +703,12 @@ function detachedAgentLabelPatch(labels: Record<string, string>): AgentLabelPatc
   return patch;
 }
 
+function resolveProviderIntrospectionQueue(
+  queue: ProviderIntrospectionQueue | undefined,
+): ProviderIntrospectionQueue {
+  return queue ?? new ProviderIntrospectionQueue();
+}
+
 export class AgentManager {
   private readonly pluginLifecycle: PluginLifecycle | undefined;
   private readonly clients = new Map<AgentProvider, AgentClient>();
@@ -750,8 +756,9 @@ export class AgentManager {
 
   constructor(options: AgentManagerOptions) {
     this.pluginLifecycle = options.pluginLifecycle;
-    this.providerIntrospectionQueue =
-      options.providerIntrospectionQueue ?? new ProviderIntrospectionQueue();
+    this.providerIntrospectionQueue = resolveProviderIntrospectionQueue(
+      options.providerIntrospectionQueue,
+    );
     this.idFactory = options?.idFactory ?? (() => randomUUID());
     this.registry = options?.registry;
     this.durableTimelineStore = options?.durableTimelineStore;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -89,6 +89,19 @@ import {
 import { withTimeout } from "../../utils/promise-timeout.js";
 import { ProviderIntrospectionQueue } from "./provider-introspection-queue.js";
 
+/**
+ * Listing draft commands spawns a short-lived provider runtime, which costs a
+ * second or two. Composers re-ask on every model, mode, and thinking-option
+ * change, so a short cache keeps those switches from feeling broken.
+ */
+const DRAFT_COMMAND_CACHE_TTL_MS = 60_000;
+const DRAFT_COMMAND_CACHE_MAX_ENTRIES = 64;
+
+interface DraftCommandCacheEntry {
+  commands: AgentSlashCommand[];
+  storedAt: number;
+}
+
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
 const IMPORTABLE_SESSION_LIST_TIMEOUT_MS = 90_000;
@@ -696,6 +709,7 @@ export class AgentManager {
   private readonly providerIntrospectionQueue: ProviderIntrospectionQueue;
   private readonly inFlightDraftCommands = new Map<string, Promise<AgentSlashCommand[]>>();
   private readonly inFlightDraftFeatures = new Map<string, Promise<AgentFeature[]>>();
+  private readonly draftCommandCache = new Map<string, DraftCommandCacheEntry>();
   private readonly providerEnabled = new Map<AgentProvider, boolean>();
   private readonly providerDefinitions = new Map<AgentProvider, ProviderEnabledFlag>();
   private readonly agents = new Map<string, LiveManagedAgent>();
@@ -1060,12 +1074,28 @@ export class AgentManager {
   }
 
   async listDraftCommands(config: AgentSessionConfig): Promise<AgentSlashCommand[]> {
-    const normalizedConfig = await this.normalizeConfig(config, { resolveDefaultModel: false });
-    const client = this.requireClient(normalizedConfig.provider);
+    const requestedConfig = await this.normalizeConfig(config, { resolveDefaultModel: false });
+    const client = this.requireClient(requestedConfig.provider);
+    // Cached under the requested config as well as the resolved one: filling in a
+    // default model costs a catalog fetch, which for some providers is its own
+    // process spawn.
+    const requestedKey = this.buildDraftRequestKey(requestedConfig);
+    const cachedForRequest = this.readCachedDraftCommands(requestedKey);
+    if (cachedForRequest) {
+      return cachedForRequest;
+    }
+    const normalizedConfig = await this.resolveDraftModel(requestedConfig);
     if (!normalizedConfig.model) {
-      return [];
+      throw new Error(
+        `Provider '${normalizedConfig.provider}' has no models available, so its commands cannot be listed.`,
+      );
     }
     const requestKey = this.buildDraftRequestKey(normalizedConfig);
+    const cached = this.readCachedDraftCommands(requestKey);
+    if (cached) {
+      this.writeCachedDraftCommands(requestedKey, cached);
+      return cached;
+    }
     return await this.runDraftRequest(this.inFlightDraftCommands, requestKey, async () => {
       const available = await client.isAvailable();
       if (!available) {
@@ -1074,30 +1104,36 @@ export class AgentManager {
         );
       }
 
-      return await this.providerIntrospectionQueue.run(normalizedConfig.provider, async () => {
-        if (client.listCommands) {
-          return await client.listCommands(normalizedConfig);
-        }
+      const commands = await this.providerIntrospectionQueue.run(
+        normalizedConfig.provider,
+        async () => {
+          if (client.listCommands) {
+            return await client.listCommands(normalizedConfig);
+          }
 
-        const session = await client.createSession(normalizedConfig);
-        try {
-          if (!session.listCommands) {
-            throw new Error(
-              `Provider '${normalizedConfig.provider}' does not support listing commands`,
-            );
-          }
-          return await session.listCommands();
-        } finally {
+          const session = await client.createSession(normalizedConfig);
           try {
-            await session.close();
-          } catch (error) {
-            this.logger.warn(
-              { err: error, provider: normalizedConfig.provider },
-              "Failed to close draft command listing session",
-            );
+            if (!session.listCommands) {
+              throw new Error(
+                `Provider '${normalizedConfig.provider}' does not support listing commands`,
+              );
+            }
+            return await session.listCommands();
+          } finally {
+            try {
+              await session.close();
+            } catch (error) {
+              this.logger.warn(
+                { err: error, provider: normalizedConfig.provider },
+                "Failed to close draft command listing session",
+              );
+            }
           }
-        }
-      });
+        },
+      );
+      this.writeCachedDraftCommands(requestKey, commands);
+      this.writeCachedDraftCommands(requestedKey, commands);
+      return commands;
     });
   }
 
@@ -1140,6 +1176,45 @@ export class AgentManager {
 
   private buildDraftRequestKey(config: AgentSessionConfig): string {
     return JSON.stringify(config);
+  }
+
+  /**
+   * Draft surfaces send whatever model the composer has resolved, which is empty
+   * while the provider snapshot is still loading or has failed. Falling back to
+   * the provider default keeps a pre-chat composer from silently listing nothing.
+   * The catalog fetch goes through the introspection queue because it can spawn
+   * a provider runtime.
+   */
+  private async resolveDraftModel(config: AgentSessionConfig): Promise<AgentSessionConfig> {
+    if (config.model) {
+      return config;
+    }
+    const model = await this.providerIntrospectionQueue.run(config.provider, () =>
+      this.resolveDefaultModelId(config),
+    );
+    return model ? { ...config, model } : config;
+  }
+
+  private readCachedDraftCommands(key: string): AgentSlashCommand[] | null {
+    const entry = this.draftCommandCache.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (Date.now() - entry.storedAt > DRAFT_COMMAND_CACHE_TTL_MS) {
+      this.draftCommandCache.delete(key);
+      return null;
+    }
+    return entry.commands;
+  }
+
+  private writeCachedDraftCommands(key: string, commands: AgentSlashCommand[]): void {
+    if (this.draftCommandCache.size >= DRAFT_COMMAND_CACHE_MAX_ENTRIES) {
+      const oldest = this.draftCommandCache.keys().next();
+      if (!oldest.done) {
+        this.draftCommandCache.delete(oldest.value);
+      }
+    }
+    this.draftCommandCache.set(key, { commands, storedAt: Date.now() });
   }
 
   private runDraftRequest<T>(

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -720,6 +720,8 @@ export interface ProviderRefreshContext {
   readonly signal: AbortSignal;
   /** Track an upstream operation so timeout errors identify the work still pending. */
   runActivity<T>(name: string, operation: () => Promise<T>): Promise<T>;
+  /** Keep the provider lane occupied until abort-triggered resource cleanup finishes. */
+  registerAbortCleanup(cleanup: () => Promise<void>): () => void;
 }
 
 export interface ProviderCatalog {

--- a/packages/server/src/server/agent/provider-introspection-queue.test.ts
+++ b/packages/server/src/server/agent/provider-introspection-queue.test.ts
@@ -314,3 +314,79 @@ test("does not serialize real agent creation behind draft introspection", async 
   const created = await agent;
   await manager.closeAgent(created.id);
 });
+
+test("falls back to the provider default model when the draft config has none", async () => {
+  const sessionModels: Array<string | undefined> = [];
+  const client = createClient({
+    async fetchCatalog() {
+      return {
+        models: [
+          { provider: "codex", id: "gpt-5.4", label: "GPT-5.4" },
+          { provider: "codex", id: "gpt-5.6-codex", label: "GPT-5.6 Codex", isDefault: true },
+        ] as AgentModelDefinition[],
+        modes: [] as AgentMode[],
+      };
+    },
+    async createSession(config) {
+      sessionModels.push(config.model);
+      return {
+        ...createSession(config),
+        async listCommands() {
+          return [{ name: "review", description: "Review changes", argumentHint: "" }];
+        },
+      };
+    },
+  });
+  const manager = new AgentManager({ clients: { codex: client }, logger: createTestLogger() });
+
+  const commands = await manager.listDraftCommands({
+    provider: "codex",
+    cwd: process.cwd(),
+    modeId: "default",
+  });
+
+  expect(commands.map((command) => command.name)).toEqual(["review"]);
+  expect(sessionModels).toEqual(["gpt-5.6-codex"]);
+});
+
+test("reports an error instead of an empty list when no model can be resolved", async () => {
+  const client = createClient({
+    async createSession(config) {
+      return createSession(config);
+    },
+  });
+  const manager = new AgentManager({ clients: { codex: client }, logger: createTestLogger() });
+
+  await expect(
+    manager.listDraftCommands({ provider: "codex", cwd: process.cwd(), modeId: "default" }),
+  ).rejects.toThrow("has no models available");
+});
+
+test("serves repeat draft command requests from cache without respawning the provider", async () => {
+  let createCalls = 0;
+  const client = createClient({
+    async createSession(config) {
+      createCalls += 1;
+      return {
+        ...createSession(config),
+        async listCommands() {
+          return [{ name: "review", description: "Review changes", argumentHint: "" }];
+        },
+      };
+    },
+  });
+  const manager = new AgentManager({ clients: { codex: client }, logger: createTestLogger() });
+  const config = {
+    provider: "codex",
+    cwd: process.cwd(),
+    model: "gpt-5.4",
+    modeId: "default",
+  } as const;
+
+  const first = await manager.listDraftCommands(config);
+  const second = await manager.listDraftCommands(config);
+
+  expect(first.map((command) => command.name)).toEqual(["review"]);
+  expect(second.map((command) => command.name)).toEqual(["review"]);
+  expect(createCalls).toBe(1);
+});

--- a/packages/server/src/server/agent/provider-introspection-queue.test.ts
+++ b/packages/server/src/server/agent/provider-introspection-queue.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import type {
@@ -198,6 +198,89 @@ test("a failed draft session does not wedge or poison later identical requests",
   await expect(manager.listDraftFeatures(config)).rejects.toThrow("provider startup failed");
   await expect(manager.listDraftFeatures(config)).resolves.toEqual([]);
   expect(createCalls).toBe(2);
+});
+
+test("waits for timed-out snapshot cleanup before starting draft introspection", async () => {
+  vi.useFakeTimers();
+  const catalogStarted = deferred<void>();
+  const catalogAborted = deferred<void>();
+  const cleanupAllowed = deferred<void>();
+  const draftStarted = deferred<void>();
+  let catalogActive = false;
+  let createSessionCalls = 0;
+  const client = createClient({
+    async fetchCatalog(_options, context) {
+      if (!context) throw new Error("missing refresh context");
+      catalogActive = true;
+      catalogStarted.resolve();
+      return await new Promise<never>((_resolve, reject) => {
+        context.signal.addEventListener(
+          "abort",
+          () => {
+            catalogAborted.resolve();
+            void cleanupAllowed.promise.then(() => {
+              catalogActive = false;
+              reject(context.signal.reason);
+              return undefined;
+            });
+          },
+          { once: true },
+        );
+      });
+    },
+    async createSession(config) {
+      createSessionCalls += 1;
+      expect(catalogActive).toBe(false);
+      draftStarted.resolve();
+      return createSession(config);
+    },
+  });
+  const queue = new ProviderIntrospectionQueue();
+  const snapshotManager = new ProviderSnapshotManager({
+    logger: createTestLogger(),
+    refreshTimeoutMs: 100,
+    extraClients: { codex: client },
+    providerIntrospectionQueue: queue,
+  });
+  const agentManager = new AgentManager({
+    clients: { codex: client },
+    providerIntrospectionQueue: queue,
+    logger: createTestLogger(),
+  });
+  const config = {
+    provider: "codex",
+    cwd: process.cwd(),
+    model: "gpt-5.4",
+    modeId: "default",
+  } as const;
+
+  try {
+    const snapshot = snapshotManager.getProvider({
+      cwd: process.cwd(),
+      provider: "codex",
+      wait: true,
+    });
+    await catalogStarted.promise;
+    const features = agentManager.listDraftFeatures(config);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await catalogAborted.promise;
+    expect(createSessionCalls).toBe(0);
+
+    cleanupAllowed.resolve();
+    await draftStarted.promise;
+
+    await expect(snapshot).resolves.toMatchObject({
+      provider: "codex",
+      status: "error",
+      error: "Timed out refreshing Codex after 100ms",
+    });
+    await expect(features).resolves.toEqual([]);
+    expect(createSessionCalls).toBe(1);
+  } finally {
+    snapshotManager.destroy();
+    vi.useRealTimers();
+  }
 });
 
 test("serializes snapshot warmup with draft session creation for the same provider", async () => {

--- a/packages/server/src/server/agent/provider-introspection-queue.test.ts
+++ b/packages/server/src/server/agent/provider-introspection-queue.test.ts
@@ -200,28 +200,31 @@ test("a failed draft session does not wedge or poison later identical requests",
   expect(createCalls).toBe(2);
 });
 
-test("releases the provider queue when a timed-out snapshot never settles", async () => {
+test("waits for registered timeout cleanup before releasing the provider queue", async () => {
   vi.useFakeTimers();
   const catalogStarted = deferred<void>();
   const catalogAborted = deferred<void>();
+  const cleanupAllowed = deferred<void>();
   const draftStarted = deferred<void>();
+  let catalogActive = false;
   let createSessionCalls = 0;
   const client = createClient({
     async fetchCatalog(_options, context) {
       if (!context) throw new Error("missing refresh context");
+      catalogActive = true;
       catalogStarted.resolve();
+      context.registerAbortCleanup(async () => {
+        catalogAborted.resolve();
+        await cleanupAllowed.promise;
+        catalogActive = false;
+      });
       return await new Promise<never>(() => {
-        context.signal.addEventListener(
-          "abort",
-          () => {
-            catalogAborted.resolve();
-          },
-          { once: true },
-        );
+        context.signal.addEventListener("abort", () => undefined, { once: true });
       });
     },
     async createSession(config) {
       createSessionCalls += 1;
+      expect(catalogActive).toBe(false);
       draftStarted.resolve();
       return createSession(config);
     },
@@ -256,6 +259,9 @@ test("releases the provider queue when a timed-out snapshot never settles", asyn
 
     await vi.advanceTimersByTimeAsync(100);
     await catalogAborted.promise;
+    expect(createSessionCalls).toBe(0);
+
+    cleanupAllowed.resolve();
     await draftStarted.promise;
 
     await expect(snapshot).resolves.toMatchObject({

--- a/packages/server/src/server/agent/provider-introspection-queue.test.ts
+++ b/packages/server/src/server/agent/provider-introspection-queue.test.ts
@@ -200,29 +200,21 @@ test("a failed draft session does not wedge or poison later identical requests",
   expect(createCalls).toBe(2);
 });
 
-test("waits for timed-out snapshot cleanup before starting draft introspection", async () => {
+test("releases the provider queue when a timed-out snapshot never settles", async () => {
   vi.useFakeTimers();
   const catalogStarted = deferred<void>();
   const catalogAborted = deferred<void>();
-  const cleanupAllowed = deferred<void>();
   const draftStarted = deferred<void>();
-  let catalogActive = false;
   let createSessionCalls = 0;
   const client = createClient({
     async fetchCatalog(_options, context) {
       if (!context) throw new Error("missing refresh context");
-      catalogActive = true;
       catalogStarted.resolve();
-      return await new Promise<never>((_resolve, reject) => {
+      return await new Promise<never>(() => {
         context.signal.addEventListener(
           "abort",
           () => {
             catalogAborted.resolve();
-            void cleanupAllowed.promise.then(() => {
-              catalogActive = false;
-              reject(context.signal.reason);
-              return undefined;
-            });
           },
           { once: true },
         );
@@ -230,7 +222,6 @@ test("waits for timed-out snapshot cleanup before starting draft introspection",
     },
     async createSession(config) {
       createSessionCalls += 1;
-      expect(catalogActive).toBe(false);
       draftStarted.resolve();
       return createSession(config);
     },
@@ -265,9 +256,6 @@ test("waits for timed-out snapshot cleanup before starting draft introspection",
 
     await vi.advanceTimersByTimeAsync(100);
     await catalogAborted.promise;
-    expect(createSessionCalls).toBe(0);
-
-    cleanupAllowed.resolve();
     await draftStarted.promise;
 
     await expect(snapshot).resolves.toMatchObject({

--- a/packages/server/src/server/agent/provider-introspection-queue.test.ts
+++ b/packages/server/src/server/agent/provider-introspection-queue.test.ts
@@ -1,0 +1,316 @@
+import { expect, test } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import type {
+  AgentClient,
+  AgentFeature,
+  AgentMode,
+  AgentModelDefinition,
+  AgentRunResult,
+  AgentSession,
+  AgentSessionConfig,
+  AgentStreamEvent,
+  FetchCatalogOptions,
+} from "./agent-sdk-types.js";
+import { AgentManager } from "./agent-manager.js";
+import { ProviderIntrospectionQueue } from "./provider-introspection-queue.js";
+import { ProviderSnapshotManager } from "./provider-snapshot-manager.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve = (_value: T): void => {};
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+const TEST_CAPABILITIES = {
+  supportsStreaming: false,
+  supportsSessionPersistence: false,
+  supportsSessionListing: false,
+  supportsDynamicModes: false,
+  supportsMcpServers: false,
+  supportsReasoningStream: false,
+  supportsToolInvocations: false,
+} as const;
+
+function createSession(
+  config: AgentSessionConfig,
+  options: { features?: AgentFeature[]; close?: () => Promise<void> } = {},
+): AgentSession {
+  return {
+    provider: config.provider,
+    id: null,
+    capabilities: TEST_CAPABILITIES,
+    features: options.features,
+    async run(): Promise<AgentRunResult> {
+      return { sessionId: config.provider, finalText: "", timeline: [] };
+    },
+    async startTurn() {
+      return { turnId: "turn-test" };
+    },
+    subscribe(_callback: (event: AgentStreamEvent) => void) {
+      return () => {};
+    },
+    async *streamHistory(): AsyncGenerator<AgentStreamEvent> {},
+    async getRuntimeInfo() {
+      return {
+        provider: config.provider,
+        sessionId: null,
+        model: config.model ?? null,
+        modeId: config.modeId ?? null,
+      };
+    },
+    async getAvailableModes() {
+      return [];
+    },
+    async getCurrentMode() {
+      return config.modeId ?? null;
+    },
+    async setMode() {},
+    getPendingPermissions() {
+      return [];
+    },
+    async respondToPermission() {},
+    describePersistence() {
+      return null;
+    },
+    async interrupt() {},
+    async close() {
+      await options.close?.();
+    },
+    async listCommands() {
+      return [];
+    },
+  };
+}
+
+function createClient(overrides: Partial<AgentClient> = {}): AgentClient {
+  return {
+    provider: "codex",
+    capabilities: TEST_CAPABILITIES,
+    async createSession(config) {
+      return createSession(config);
+    },
+    async resumeSession() {
+      throw new Error("not implemented");
+    },
+    async fetchCatalog(_options: FetchCatalogOptions) {
+      return { models: [] as AgentModelDefinition[], modes: [] as AgentMode[] };
+    },
+    async isAvailable() {
+      return true;
+    },
+    ...overrides,
+  } satisfies AgentClient;
+}
+
+class ObservedProviderIntrospectionQueue extends ProviderIntrospectionQueue {
+  private runCalls = 0;
+  private readonly secondRunStarted = deferred<void>();
+
+  override run<T>(
+    provider: AgentSessionConfig["provider"],
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    this.runCalls += 1;
+    if (this.runCalls === 2) {
+      this.secondRunStarted.resolve();
+    }
+    return super.run(provider, operation);
+  }
+
+  waitForSecondRun(): Promise<void> {
+    return this.secondRunStarted.promise;
+  }
+}
+
+test("serializes draft command and feature session creation per provider", async () => {
+  const firstStarted = deferred<void>();
+  const secondStarted = deferred<void>();
+  const firstAllowed = deferred<void>();
+  const secondAllowed = deferred<void>();
+  let createCalls = 0;
+  let activeCreations = 0;
+  let maxActiveCreations = 0;
+  const client = createClient({
+    async createSession(config) {
+      const call = createCalls;
+      createCalls += 1;
+      activeCreations += 1;
+      maxActiveCreations = Math.max(maxActiveCreations, activeCreations);
+      if (call === 0) {
+        firstStarted.resolve();
+        await firstAllowed.promise;
+      } else {
+        secondStarted.resolve();
+        await secondAllowed.promise;
+      }
+      activeCreations -= 1;
+      return createSession(config);
+    },
+  });
+  const manager = new AgentManager({ clients: { codex: client }, logger: createTestLogger() });
+  const config = {
+    provider: "codex",
+    cwd: process.cwd(),
+    model: "gpt-5.4",
+    modeId: "default",
+  } as const;
+
+  const commands = manager.listDraftCommands(config);
+  await firstStarted.promise;
+  const features = manager.listDraftFeatures(config);
+
+  expect({ createCalls, maxActiveCreations }).toEqual({ createCalls: 1, maxActiveCreations: 1 });
+  firstAllowed.resolve();
+  await secondStarted.promise;
+  expect({ createCalls, maxActiveCreations }).toEqual({ createCalls: 2, maxActiveCreations: 1 });
+  secondAllowed.resolve();
+
+  await expect(Promise.all([commands, features])).resolves.toEqual([[], []]);
+});
+
+test("a failed draft session does not wedge or poison later identical requests", async () => {
+  let createCalls = 0;
+  const client = createClient({
+    async createSession(config) {
+      createCalls += 1;
+      if (createCalls === 1) {
+        throw new Error("provider startup failed");
+      }
+      return createSession(config);
+    },
+  });
+  const manager = new AgentManager({ clients: { codex: client }, logger: createTestLogger() });
+  const config = {
+    provider: "codex",
+    cwd: process.cwd(),
+    model: "gpt-5.4",
+    modeId: "default",
+  } as const;
+
+  await expect(manager.listDraftFeatures(config)).rejects.toThrow("provider startup failed");
+  await expect(manager.listDraftFeatures(config)).resolves.toEqual([]);
+  expect(createCalls).toBe(2);
+});
+
+test("serializes snapshot warmup with draft session creation for the same provider", async () => {
+  const catalogStarted = deferred<void>();
+  const catalogAllowed = deferred<void>();
+  const draftSessionStarted = deferred<void>();
+  let activeProcesses = 0;
+  let maxActiveProcesses = 0;
+  let createSessionCalls = 0;
+  const client = createClient({
+    async fetchCatalog() {
+      activeProcesses += 1;
+      maxActiveProcesses = Math.max(maxActiveProcesses, activeProcesses);
+      catalogStarted.resolve();
+      await catalogAllowed.promise;
+      activeProcesses -= 1;
+      return { models: [], modes: [] };
+    },
+    async createSession(config) {
+      createSessionCalls += 1;
+      activeProcesses += 1;
+      maxActiveProcesses = Math.max(maxActiveProcesses, activeProcesses);
+      draftSessionStarted.resolve();
+      activeProcesses -= 1;
+      return createSession(config);
+    },
+  });
+  const queue = new ObservedProviderIntrospectionQueue();
+  const snapshotManager = new ProviderSnapshotManager({
+    logger: createTestLogger(),
+    extraClients: { codex: client },
+    providerIntrospectionQueue: queue,
+  });
+  const agentManager = new AgentManager({
+    clients: { codex: client },
+    providerIntrospectionQueue: queue,
+    logger: createTestLogger(),
+  });
+  const config = {
+    provider: "codex",
+    cwd: process.cwd(),
+    model: "gpt-5.4",
+    modeId: "default",
+  } as const;
+
+  try {
+    const warmup = snapshotManager.warmUpSnapshotForCwd({
+      cwd: process.cwd(),
+      providers: ["codex"],
+    });
+    await catalogStarted.promise;
+    const features = agentManager.listDraftFeatures(config);
+    await queue.waitForSecondRun();
+
+    expect({ createSessionCalls, maxActiveProcesses }).toEqual({
+      createSessionCalls: 0,
+      maxActiveProcesses: 1,
+    });
+    catalogAllowed.resolve();
+    await draftSessionStarted.promise;
+    await expect(Promise.all([warmup, features])).resolves.toEqual([undefined, []]);
+    expect(maxActiveProcesses).toBe(1);
+  } finally {
+    snapshotManager.destroy();
+  }
+});
+
+test("does not serialize real agent creation behind draft introspection", async () => {
+  const draftStarted = deferred<void>();
+  const draftAllowed = deferred<void>();
+  const agentStarted = deferred<void>();
+  let createCalls = 0;
+  let activeCreations = 0;
+  let maxActiveCreations = 0;
+  const client = createClient({
+    async createSession(config) {
+      const call = createCalls;
+      createCalls += 1;
+      activeCreations += 1;
+      maxActiveCreations = Math.max(maxActiveCreations, activeCreations);
+      if (call === 0) {
+        draftStarted.resolve();
+        await draftAllowed.promise;
+      } else {
+        agentStarted.resolve();
+      }
+      activeCreations -= 1;
+      return createSession(config);
+    },
+  });
+  const queue = new ProviderIntrospectionQueue();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    providerIntrospectionQueue: queue,
+    logger: createTestLogger(),
+  });
+  const config = {
+    provider: "codex",
+    cwd: process.cwd(),
+    model: "gpt-5.4",
+    modeId: "default",
+  } as const;
+
+  const draft = manager.listDraftCommands(config);
+  await draftStarted.promise;
+  const agent = manager.createAgent(config, "00000000-0000-4000-8000-000000000001", {
+    workspaceId: undefined,
+  });
+  await agentStarted.promise;
+
+  expect({ createCalls, maxActiveCreations }).toEqual({ createCalls: 2, maxActiveCreations: 2 });
+  draftAllowed.resolve();
+  await draft;
+  const created = await agent;
+  await manager.closeAgent(created.id);
+});

--- a/packages/server/src/server/agent/provider-introspection-queue.ts
+++ b/packages/server/src/server/agent/provider-introspection-queue.ts
@@ -1,0 +1,22 @@
+import type { AgentProvider } from "./agent-sdk-types.js";
+
+export class ProviderIntrospectionQueue {
+  private readonly tails = new Map<AgentProvider, Promise<void>>();
+
+  run<T>(provider: AgentProvider, operation: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(provider) ?? Promise.resolve();
+    const result = previous.then(operation);
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(provider, tail);
+    void tail.then(() => {
+      if (this.tails.get(provider) === tail) {
+        this.tails.delete(provider);
+      }
+      return undefined;
+    });
+    return result;
+  }
+}

--- a/packages/server/src/server/agent/provider-refresh-deadline.test.ts
+++ b/packages/server/src/server/agent/provider-refresh-deadline.test.ts
@@ -1,0 +1,41 @@
+import { expect, test, vi } from "vitest";
+
+import {
+  PROVIDER_REFRESH_ABORT_CLEANUP_TIMEOUT_MS,
+  runProviderRefreshWithDeadline,
+} from "./provider-refresh-deadline.js";
+
+test("bounds abort cleanup before settling a timed-out refresh", async () => {
+  vi.useFakeTimers();
+  let settled = false;
+
+  try {
+    const refresh = runProviderRefreshWithDeadline({
+      label: "Codex",
+      timeoutMs: 100,
+      operation: async (context) => {
+        context.registerAbortCleanup(async () => await new Promise<void>(() => {}));
+        return await new Promise<never>(() => {});
+      },
+    });
+    void refresh.then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      () => {
+        settled = true;
+        return undefined;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(PROVIDER_REFRESH_ABORT_CLEANUP_TIMEOUT_MS);
+    await expect(refresh).rejects.toThrow("Timed out refreshing Codex after 100ms");
+    expect(settled).toBe(true);
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/server/src/server/agent/provider-refresh-deadline.ts
+++ b/packages/server/src/server/agent/provider-refresh-deadline.ts
@@ -6,6 +6,25 @@ interface RunProviderRefreshOptions<T> {
   operation: (context: ProviderRefreshContext) => Promise<T>;
 }
 
+export const PROVIDER_REFRESH_ABORT_CLEANUP_TIMEOUT_MS = 5_000;
+
+async function waitForAbortCleanups(cleanups: Array<() => Promise<void>>): Promise<void> {
+  if (cleanups.length === 0) return;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, PROVIDER_REFRESH_ABORT_CLEANUP_TIMEOUT_MS);
+  });
+  try {
+    await Promise.race([
+      Promise.allSettled(cleanups.map((cleanup) => Promise.resolve().then(cleanup))),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export function runProviderRefreshActivity<T>(
   context: ProviderRefreshContext | undefined,
   name: string,
@@ -37,6 +56,8 @@ export async function runProviderRefreshWithDeadline<T>(
 ): Promise<T> {
   const controller = new AbortController();
   const activityCounts = new Map<string, number>();
+  const abortCleanups = new Set<() => Promise<void>>();
+  let abortCleanup: Promise<void> | undefined;
   let timeoutError: Error | undefined;
 
   const context: ProviderRefreshContext = {
@@ -57,6 +78,10 @@ export async function runProviderRefreshWithDeadline<T>(
         }
       }
     },
+    registerAbortCleanup(cleanup) {
+      abortCleanups.add(cleanup);
+      return () => abortCleanups.delete(cleanup);
+    },
   };
 
   const timer = setTimeout(() => {
@@ -66,6 +91,7 @@ export async function runProviderRefreshWithDeadline<T>(
       `Timed out refreshing ${options.label} after ${options.timeoutMs}ms${suffix}`,
     );
     controller.abort(timeoutError);
+    abortCleanup = waitForAbortCleanups(Array.from(abortCleanups));
   }, options.timeoutMs);
 
   try {
@@ -73,6 +99,7 @@ export async function runProviderRefreshWithDeadline<T>(
     if (timeoutError) throw timeoutError;
     return result;
   } catch (error) {
+    await abortCleanup;
     throw timeoutError ?? error;
   } finally {
     clearTimeout(timer);

--- a/packages/server/src/server/agent/provider-refresh-deadline.ts
+++ b/packages/server/src/server/agent/provider-refresh-deadline.ts
@@ -69,7 +69,7 @@ export async function runProviderRefreshWithDeadline<T>(
   }, options.timeoutMs);
 
   try {
-    const result = await options.operation(context);
+    const result = await raceProviderRefreshAbort(controller.signal, options.operation(context));
     if (timeoutError) throw timeoutError;
     return result;
   } catch (error) {

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -50,6 +50,7 @@ import {
 } from "./agent-configuration-validator.js";
 import type { ProviderRegistration } from "@getpaseo/plugin/provider";
 import { PluginAgentClientRegistry } from "./plugin-provider.js";
+import { ProviderIntrospectionQueue } from "./provider-introspection-queue.js";
 
 const DEFAULT_REFRESH_TIMEOUT_MS = 120_000;
 const MAX_REFRESH_TIMEOUT_MS = 2_147_483_647;
@@ -112,6 +113,7 @@ type ProviderSnapshotChangeListener = (transition: ProviderSnapshotTransition) =
 
 export interface ProviderSnapshotManagerOptions {
   logger: Logger;
+  providerIntrospectionQueue?: ProviderIntrospectionQueue;
   runtimeSettings?: AgentProviderRuntimeSettingsMap;
   providerOverrides?: Record<string, ProviderOverride>;
   workspaceGitService?: Pick<WorkspaceGitService, "resolveRepoRoot">;
@@ -242,6 +244,7 @@ export class ProviderSnapshotManager {
   private refreshTimeoutMs: number;
   private diagnosticTimeoutMs: number;
   private readonly logger: Logger;
+  private readonly providerIntrospectionQueue: ProviderIntrospectionQueue;
   private readonly workspaceGitService?: Pick<WorkspaceGitService, "resolveRepoRoot">;
   private readonly managedProcesses?: ManagedProcessRegistry;
   private readonly openCodeBridge?: OpenCodeBridge;
@@ -260,6 +263,8 @@ export class ProviderSnapshotManager {
     this.pluginProviders = new PluginAgentClientRegistry(
       options.logger.child({ module: "plugin-providers" }),
     );
+    this.providerIntrospectionQueue =
+      options.providerIntrospectionQueue ?? new ProviderIntrospectionQueue();
     this.workspaceGitService = options.workspaceGitService;
     this.managedProcesses = options.managedProcesses;
     this.openCodeBridge = options.openCodeBridge;
@@ -995,23 +1000,25 @@ export class ProviderSnapshotManager {
     } = options;
 
     try {
-      const catalog = await runProviderRefreshWithDeadline({
-        label: definition.label,
-        timeoutMs: this.refreshTimeoutMs,
-        operation: async (context) => {
-          const available = await context.runActivity("availability", () =>
-            raceProviderRefreshAbort(
-              context.signal,
-              client.isAvailable(context.signal, catalogOptions),
-            ),
-          );
-          if (!available) {
-            return null;
-          }
+      const catalog = await this.providerIntrospectionQueue.run(provider, () =>
+        runProviderRefreshWithDeadline({
+          label: definition.label,
+          timeoutMs: this.refreshTimeoutMs,
+          operation: async (context) => {
+            const available = await context.runActivity("availability", () =>
+              raceProviderRefreshAbort(
+                context.signal,
+                client.isAvailable(context.signal, catalogOptions),
+              ),
+            );
+            if (!available) {
+              return null;
+            }
 
-          return await definition.fetchCatalog(catalogOptions, client, context);
-        },
-      });
+            return await definition.fetchCatalog(catalogOptions, client, context);
+          },
+        }),
+      );
       if (!catalog) {
         setEntry({ ...base, status: "unavailable", enabled: true });
         return;

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -3604,6 +3604,7 @@ describe("ACPAgentClient probe cleanup", () => {
     const context: ProviderRefreshContext = {
       signal: abort.signal,
       runActivity: async (_name, operation) => await operation(),
+      registerAbortCleanup: () => () => undefined,
     };
     const catalog = client.fetchCatalog(
       { scope: "workspace", cwd: "/tmp/acp-models", force: false },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -7124,8 +7124,7 @@ export class CodexAppServerAgentClient implements AgentClient {
       disposePromise ??= client.dispose();
       return disposePromise;
     };
-    const handleAbort = () => void dispose().catch(() => undefined);
-    context?.signal.addEventListener("abort", handleAbort, { once: true });
+    const unregisterAbortCleanup = context?.registerAbortCleanup(dispose);
 
     try {
       await runProviderRefreshActivity(context, "app-server.start", async () => {
@@ -7161,7 +7160,7 @@ export class CodexAppServerAgentClient implements AgentClient {
         }),
       );
     } finally {
-      context?.signal.removeEventListener("abort", handleAbort);
+      unregisterAbortCleanup?.();
       await dispose();
     }
   }

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -139,6 +139,7 @@ import {
 } from "./agent/tools/paseo-tools.js";
 import type { PaseoToolRuntimeContext } from "./agent/tools/types.js";
 import { createAgentProviderRuntime } from "./agent/provider-runtime.js";
+import { ProviderIntrospectionQueue } from "./agent/provider-introspection-queue.js";
 import { bootstrapWorkspaceRegistries } from "./workspace-registry-bootstrap.js";
 import { WorkspaceReconciliationService } from "./workspace-reconciliation-service.js";
 import {
@@ -893,11 +894,13 @@ export async function createPaseoDaemon(
     workspaceGitService,
     logger,
   });
+  const providerIntrospectionQueue = new ProviderIntrospectionQueue();
   const agentProviderRuntime = await createAgentProviderRuntime({
     paseoHome: config.paseoHome,
     logger,
     snapshotManager: {
       refreshTimeoutMs: config.providerCatalogRefreshTimeoutMs,
+      providerIntrospectionQueue,
       runtimeSettings: config.agentProviderSettings,
       providerOverrides: config.providerOverrides,
       workspaceGitService,
@@ -923,6 +926,7 @@ export async function createPaseoDaemon(
     pluginLifecycle: pluginRuntime,
     clients: initialAgentManagerState.clients,
     providerDefinitions: initialAgentManagerState.providerDefinitions,
+    providerIntrospectionQueue,
     registry: agentStorage,
     appendSystemPrompt: config.appendSystemPrompt,
     onWorkspaceStateMayHaveChanged: ({ cwd }) => {


### PR DESCRIPTION
## Summary

- fix the pre-chat composer showing no slash commands or skills: the daemon answered a draft config with no model with an empty list and a null error
- cache draft command results so switching model, mode, or thinking option does not pay a provider spawn every time
- serialize short-lived provider introspection per provider, working around an upstream Codex crash under concurrent startup
- keep real agent creation outside the queue so users can still start and run multiple agents concurrently

## Root cause 1: a model-less draft config listed nothing

A pre-chat composer sends whatever model it has resolved. That is nothing until the provider snapshot loads — or forever, if the snapshot errored. `AgentManager.listDraftCommands` answered that config with `commands: [], error: null`, and the client cached it at `staleTime: Infinity`. The composer showed no commands at all, for the rest of the session, with nothing in the logs.

Measured against a real in-process daemon:

| draft config | before | after |
| --- | ---: | ---: |
| claude, no model | 0 commands, 1ms | 77 commands, 1737ms |
| claude, no model (repeat) | 0 commands | 77 commands, **1ms** |
| codex, no model | 0 commands, 28ms | 51 commands, 5510ms |
| codex, no model (repeat) | 0 commands | 51 commands, **3ms** |

This is provider-agnostic — Claude and Codex fail the same way — and it explains the intermittency. Pick a model explicitly and commands load; leave the composer on whatever it resolved before the snapshot arrived and they never do.

The daemon now resolves the provider default model for draft listing, and throws when no model can be resolved so the client sees a failure instead of a plausible empty list. Results are cached for 60s under both the requested and the resolved config; the second key matters because filling in a default model is itself a process spawn for some providers.

`listDraftFeatures` keeps its no-model early return. It deliberately avoids a spawn before a model exists and re-asks once one resolves.

On the client, an empty draft result no longer caches forever, a daemon-reported error is surfaced for draft configs rather than dropped, and the menu stays visible while loading so `/` shows its loading and error rows instead of looking dead. Those three work against any daemon version, including hosts that have not picked up the daemon fix.

## Root cause 2: concurrent Codex startup

Codex 0.146.0 has an upstream race in its sqlite state runtime. When several `codex app-server` processes initialize concurrently under the same `CODEX_HOME`, one or more can exit with code 1 while initializing the state runtime. This reproduces with a virgin `CODEX_HOME`, so it is not state corruption.

| Concurrent startups | Failures |
| ---: | ---: |
| 1 | 0 |
| 2 | 0 |
| 3 | 0 |
| 4 | 1/4 |
| 6 | 1/6 |
| 8 | 1/8; 3/8 on repeat |

A single startup takes about two seconds. Paseo can reach the failing concurrency from pre-chat draft surfaces: snapshot warmup, `listDraftCommands`, and `listDraftFeatures` all spawn short-lived provider runtimes, and multiple mounted draft surfaces can issue the same requests concurrently.

The daemon creates one shared per-provider introspection queue and passes it to `AgentManager` and `ProviderSnapshotManager`. It covers draft slash-command listing, draft feature listing, default-model resolution, and snapshot catalog warmup. Session close stays inside the queued operation, and resolve/reject paths both advance and clean up the queue. Identical command or feature requests share their in-flight promise, and the entry is removed after either success or failure.

Real agent creation, resume, reload, and other long-lived session paths are deliberately not serialized. Users legitimately run multiple agents at once.

This is a robustness fix around an upstream bug, not the fix for the missing commands. Serializing introspection does cost latency on a cold draft listing — it puts command listing behind catalog warmup for the same provider — which is what the cache pays for.

## Follow-up

Draft commands need a model only because we get them by spawning a session, and sessions need a model. `AgentClient` already has an optional `listCommands(config)` that skips the session; neither the Claude nor the Codex client implements it. If they did, the spawn, the queue pressure on this path, and most of the need for the cache would go away together.

## Verification

- `npx vitest run packages/server/src/server/agent/provider-introspection-queue.test.ts packages/server/src/server/agent/agent-manager.test.ts` — 155 passed
- `npx vitest run packages/server/src/server/session.list-commands.test.ts packages/client/src/daemon-client.test.ts` — 106 passed
- `npx vitest run src/hooks/use-agent-commands-query.test.ts src/utils/agent-command-autocomplete.test.ts` in `packages/app` — 16 passed
- before/after latency table above measured through the `docs/ad-hoc-daemon-testing.md` harness against real Claude and Codex clients
- `npm run typecheck`, `npm run lint`, `npm run format:check`

An existing test asserted the old contract (`listDraftCommands returns no commands without guessing a missing model`). It is rewritten as the default-model fallback, plus a new case for the no-models-available rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
