### PR TITLE
fix(acp): probe per-model thinking options in the provider catalog

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2502,6 +2502,85 @@ describe("ACPAgentClient fetchCatalog", () => {
       vi.useRealTimers();
     }
   });
+
+  test("stalled probes run concurrently, so many stalled models stay within one per-model budget", async () => {
+    // Both model probes never answer; the whole catalog must still finish
+    // after a single PER_MODEL_THINKING_PROBE_TIMEOUT_MS, not N × that.
+    const setSessionConfigOption = vi.fn(() => new Promise(() => {}));
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              sessionId: "sess-1",
+              modes: null,
+              models: null,
+              configOptions: [
+                {
+                  id: "model",
+                  name: "Model",
+                  category: "model",
+                  type: "select",
+                  currentValue: "model-a",
+                  options: [
+                    { value: "model-a", name: "Model A" },
+                    { value: "model-b", name: "Model B" },
+                  ],
+                },
+                {
+                  id: "thinking",
+                  name: "Thinking",
+                  category: "thought_level",
+                  type: "select",
+                  currentValue: "high",
+                  options: [
+                    { value: "off", name: "Off" },
+                    { value: "low", name: "Low" },
+                    { value: "high", name: "High" },
+                    { value: "max", name: "Max" },
+                  ],
+                },
+              ],
+            }),
+            setSessionConfigOption,
+          },
+          initialize: { agentCapabilities: {} },
+        } as SpawnedACPProcess;
+      }
+
+      protected override async closeProbe(): Promise<void> {}
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "pi",
+      logger: createTestLogger(),
+      defaultCommand: ["test-acp"],
+      defaultModes: [],
+    });
+
+    vi.useFakeTimers();
+    try {
+      const catalogPromise = client.fetchCatalog({
+        scope: "workspace",
+        cwd: "/tmp/acp-per-model-concurrent",
+        force: false,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      // One per-model budget fires both stalled probes at once.
+      await vi.advanceTimersByTimeAsync(PER_MODEL_THINKING_PROBE_TIMEOUT_MS);
+      const catalog = await catalogPromise;
+
+      expect(setSessionConfigOption).toHaveBeenCalledTimes(2);
+      // Both models fell back to the shared options, and the catalog survived.
+      for (const model of catalog.models) {
+        expect(model.thinkingOptions?.map((o) => o.id)).toEqual(["off", "low", "high", "max"]);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("ACPAgentClient listImportableSessions", () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1732,6 +1732,104 @@ describe("deriveModelDefinitionsFromACP", () => {
       },
     ]);
   });
+
+  test("uses per-model thinking options when provided", () => {
+    const result = deriveModelDefinitionsFromACP(
+      "claude-acp",
+      {
+        availableModels: [
+          { modelId: "haiku", name: "Haiku" },
+          { modelId: "sonnet", name: "Sonnet" },
+        ],
+        currentModelId: "haiku",
+      },
+      [
+        {
+          id: "reasoning",
+          name: "Reasoning",
+          category: "thought_level",
+          type: "select",
+          currentValue: "high",
+          options: [
+            { value: "low", name: "Low" },
+            { value: "high", name: "High" },
+          ],
+        },
+      ],
+      new Map([
+        [
+          "haiku",
+          [
+            { id: "low", label: "Low", isDefault: false },
+            { id: "high", label: "High", isDefault: true },
+          ],
+        ],
+        [
+          "sonnet",
+          [
+            { id: "medium", label: "Medium", isDefault: false },
+            { id: "high", label: "High", isDefault: false },
+            { id: "max", label: "Max", isDefault: false },
+          ],
+        ],
+      ]),
+    );
+
+    expect(result).toEqual([
+      {
+        provider: "claude-acp",
+        id: "haiku",
+        label: "Haiku",
+        description: undefined,
+        isDefault: true,
+        thinkingOptions: [
+          { id: "low", label: "Low", isDefault: false },
+          { id: "high", label: "High", isDefault: true },
+        ],
+        defaultThinkingOptionId: "high",
+      },
+      {
+        provider: "claude-acp",
+        id: "sonnet",
+        label: "Sonnet",
+        description: undefined,
+        isDefault: false,
+        thinkingOptions: [
+          { id: "medium", label: "Medium", isDefault: false },
+          { id: "high", label: "High", isDefault: false },
+          { id: "max", label: "Max", isDefault: false },
+        ],
+        defaultThinkingOptionId: "high",
+      },
+    ]);
+  });
+
+  test("falls back to shared thinking options for models missing from the per-model map", () => {
+    const result = deriveModelDefinitionsFromACP(
+      "claude-acp",
+      {
+        availableModels: [{ modelId: "haiku", name: "Haiku" }],
+        currentModelId: "haiku",
+      },
+      [
+        {
+          id: "reasoning",
+          name: "Reasoning",
+          category: "thought_level",
+          type: "select",
+          currentValue: "medium",
+          options: [
+            { value: "low", name: "Low" },
+            { value: "medium", name: "Medium" },
+          ],
+        },
+      ],
+      new Map([["other-model", [{ id: "max", label: "Max", isDefault: true }]]]),
+    );
+
+    expect(result[0]?.thinkingOptions?.map((option) => option.id)).toEqual(["low", "medium"]);
+    expect(result[0]?.defaultThinkingOptionId).toBe("medium");
+  });
 });
 
 describe("ACPAgentClient modelTransformer", () => {
@@ -2075,6 +2173,219 @@ describe("ACPAgentClient fetchCatalog", () => {
       models: [],
       modes: [],
     });
+  });
+
+  test("probes per-model thinking options and returns them in the catalog", async () => {
+    const setSessionConfigOption = vi.fn().mockImplementation(({ value }: { value: string }) => ({
+      configOptions: [
+        {
+          id: "model",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: value,
+          options: [
+            { value: "model-a", name: "Model A" },
+            { value: "model-b", name: "Model B" },
+          ],
+        },
+        {
+          id: "thinking",
+          name: "Thinking",
+          category: "thought_level",
+          type: "select",
+          currentValue: "high",
+          options:
+            value === "model-a"
+              ? [
+                  { value: "off", name: "Off" },
+                  { value: "low", name: "Low" },
+                  { value: "high", name: "High" },
+                  { value: "max", name: "Max" },
+                ]
+              : [
+                  { value: "off", name: "Off" },
+                  { value: "medium", name: "Medium" },
+                  { value: "high", name: "High" },
+                  { value: "xhigh", name: "XHigh" },
+                  { value: "max", name: "Max" },
+                ],
+        },
+      ],
+    }));
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              sessionId: "sess-1",
+              modes: null,
+              models: null,
+              configOptions: [
+                {
+                  id: "model",
+                  name: "Model",
+                  category: "model",
+                  type: "select",
+                  currentValue: "model-a",
+                  options: [
+                    { value: "model-a", name: "Model A" },
+                    { value: "model-b", name: "Model B" },
+                  ],
+                },
+                {
+                  id: "thinking",
+                  name: "Thinking",
+                  category: "thought_level",
+                  type: "select",
+                  currentValue: "high",
+                  options: [
+                    { value: "off", name: "Off" },
+                    { value: "low", name: "Low" },
+                    { value: "high", name: "High" },
+                    { value: "max", name: "Max" },
+                  ],
+                },
+              ],
+            }),
+            setSessionConfigOption,
+          },
+          initialize: { agentCapabilities: {} },
+        } as SpawnedACPProcess;
+      }
+
+      protected override async closeProbe(): Promise<void> {}
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "pi",
+      logger: createTestLogger(),
+      defaultCommand: ["test-acp"],
+      defaultModes: [],
+    });
+
+    const catalog = await client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/tmp/acp-per-model",
+      force: false,
+    });
+
+    expect(setSessionConfigOption).toHaveBeenCalledTimes(2);
+    expect(setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "sess-1",
+      configId: "model",
+      value: "model-a",
+    });
+    expect(setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "sess-1",
+      configId: "model",
+      value: "model-b",
+    });
+    expect(
+      catalog.models.find((model) => model.id === "model-a")?.thinkingOptions?.map((o) => o.id),
+    ).toEqual(["off", "low", "high", "max"]);
+    expect(
+      catalog.models.find((model) => model.id === "model-b")?.thinkingOptions?.map((o) => o.id),
+    ).toEqual(["off", "medium", "high", "xhigh", "max"]);
+  });
+
+  test("skips failed per-model probes and falls back to shared thinking options", async () => {
+    const setSessionConfigOption = vi
+      .fn()
+      .mockResolvedValueOnce({
+        configOptions: [
+          {
+            id: "model",
+            name: "Model",
+            category: "model",
+            type: "select",
+            currentValue: "model-a",
+            options: [
+              { value: "model-a", name: "Model A" },
+              { value: "model-b", name: "Model B" },
+            ],
+          },
+          {
+            id: "thinking",
+            name: "Thinking",
+            category: "thought_level",
+            type: "select",
+            currentValue: "high",
+            options: [
+              { value: "off", name: "Off" },
+              { value: "low", name: "Low" },
+              { value: "high", name: "High" },
+              { value: "max", name: "Max" },
+            ],
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("probe failed"));
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              sessionId: "sess-1",
+              modes: null,
+              models: null,
+              configOptions: [
+                {
+                  id: "model",
+                  name: "Model",
+                  category: "model",
+                  type: "select",
+                  currentValue: "model-a",
+                  options: [
+                    { value: "model-a", name: "Model A" },
+                    { value: "model-b", name: "Model B" },
+                  ],
+                },
+                {
+                  id: "thinking",
+                  name: "Thinking",
+                  category: "thought_level",
+                  type: "select",
+                  currentValue: "high",
+                  options: [
+                    { value: "off", name: "Off" },
+                    { value: "low", name: "Low" },
+                    { value: "high", name: "High" },
+                    { value: "max", name: "Max" },
+                  ],
+                },
+              ],
+            }),
+            setSessionConfigOption,
+          },
+          initialize: { agentCapabilities: {} },
+        } as SpawnedACPProcess;
+      }
+
+      protected override async closeProbe(): Promise<void> {}
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "pi",
+      logger: createTestLogger(),
+      defaultCommand: ["test-acp"],
+      defaultModes: [],
+    });
+
+    const catalog = await client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/tmp/acp-per-model-fallback",
+      force: false,
+    });
+
+    // model-b probe failed: it falls back to the shared (session/new) options.
+    expect(
+      catalog.models.find((model) => model.id === "model-b")?.thinkingOptions?.map((o) => o.id),
+    ).toEqual(["off", "low", "high", "max"]);
   });
 });
 

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2503,9 +2503,11 @@ describe("ACPAgentClient fetchCatalog", () => {
     }
   });
 
-  test("stalled probes run concurrently, so many stalled models stay within one per-model budget", async () => {
-    // Both model probes never answer; the whole catalog must still finish
-    // after a single PER_MODEL_THINKING_PROBE_TIMEOUT_MS, not N × that.
+  test("multiple stalled probes each time out serially without failing the catalog", async () => {
+    // Both model probes never answer; each times out on its own
+    // PER_MODEL_THINKING_PROBE_TIMEOUT_MS budget and the catalog still
+    // completes — serial probing stays within the catalog budget for any
+    // realistic model count.
     const setSessionConfigOption = vi.fn(() => new Promise(() => {}));
 
     class TestACPAgentClient extends ACPAgentClient {
@@ -2564,11 +2566,13 @@ describe("ACPAgentClient fetchCatalog", () => {
     try {
       const catalogPromise = client.fetchCatalog({
         scope: "workspace",
-        cwd: "/tmp/acp-per-model-concurrent",
+        cwd: "/tmp/acp-per-model-serial-stall",
         force: false,
       });
       await vi.advanceTimersByTimeAsync(0);
-      // One per-model budget fires both stalled probes at once.
+      // First stalled probe times out, then the second one is attempted and
+      // times out too — each on its own per-model budget.
+      await vi.advanceTimersByTimeAsync(PER_MODEL_THINKING_PROBE_TIMEOUT_MS);
       await vi.advanceTimersByTimeAsync(PER_MODEL_THINKING_PROBE_TIMEOUT_MS);
       const catalog = await catalogPromise;
 

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   ACPAgentClient,
   ACPAgentSession,
+  PER_MODEL_THINKING_PROBE_TIMEOUT_MS,
   type SpawnedACPProcess,
   type SessionStateResponse,
   buildACPClientCapabilities,
@@ -2386,6 +2387,120 @@ describe("ACPAgentClient fetchCatalog", () => {
     expect(
       catalog.models.find((model) => model.id === "model-b")?.thinkingOptions?.map((o) => o.id),
     ).toEqual(["off", "low", "high", "max"]);
+  });
+
+  test("a stalled per-model probe times out and falls back without failing the catalog", async () => {
+    const setSessionConfigOption = vi
+      .fn()
+      .mockResolvedValueOnce({
+        configOptions: [
+          {
+            id: "model",
+            name: "Model",
+            category: "model",
+            type: "select",
+            currentValue: "model-a",
+            options: [
+              { value: "model-a", name: "Model A" },
+              { value: "model-b", name: "Model B" },
+            ],
+          },
+          {
+            id: "thinking",
+            name: "Thinking",
+            category: "thought_level",
+            type: "select",
+            currentValue: "high",
+            options: [
+              { value: "off", name: "Off" },
+              { value: "low", name: "Low" },
+              { value: "high", name: "High" },
+              { value: "max", name: "Max" },
+            ],
+          },
+        ],
+      })
+      // model-b never answers: neither a result nor an error.
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    class TestACPAgentClient extends ACPAgentClient {
+      protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+        return {
+          child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+          connection: {
+            newSession: vi.fn().mockResolvedValue({
+              sessionId: "sess-1",
+              modes: null,
+              models: null,
+              configOptions: [
+                {
+                  id: "model",
+                  name: "Model",
+                  category: "model",
+                  type: "select",
+                  currentValue: "model-a",
+                  options: [
+                    { value: "model-a", name: "Model A" },
+                    { value: "model-b", name: "Model B" },
+                  ],
+                },
+                {
+                  id: "thinking",
+                  name: "Thinking",
+                  category: "thought_level",
+                  type: "select",
+                  currentValue: "high",
+                  options: [
+                    { value: "off", name: "Off" },
+                    { value: "low", name: "Low" },
+                    { value: "high", name: "High" },
+                    { value: "max", name: "Max" },
+                  ],
+                },
+              ],
+            }),
+            setSessionConfigOption,
+          },
+          initialize: { agentCapabilities: {} },
+        } as SpawnedACPProcess;
+      }
+
+      protected override async closeProbe(): Promise<void> {}
+    }
+
+    const client = new TestACPAgentClient({
+      provider: "pi",
+      logger: createTestLogger(),
+      defaultCommand: ["test-acp"],
+      defaultModes: [],
+    });
+
+    vi.useFakeTimers();
+    try {
+      const catalogPromise = client.fetchCatalog({
+        scope: "workspace",
+        cwd: "/tmp/acp-per-model-stall",
+        force: false,
+      });
+      // Run the microtask chain up to the stalled model-b probe, which
+      // registers the per-model timeout.
+      await vi.advanceTimersByTimeAsync(0);
+      // The stalled probe times out; the catalog must still complete.
+      await vi.advanceTimersByTimeAsync(PER_MODEL_THINKING_PROBE_TIMEOUT_MS);
+      const catalog = await catalogPromise;
+
+      expect(setSessionConfigOption).toHaveBeenCalledTimes(2);
+      // model-a was probed successfully and keeps its own options.
+      expect(
+        catalog.models.find((model) => model.id === "model-a")?.thinkingOptions?.map((o) => o.id),
+      ).toEqual(["off", "low", "high", "max"]);
+      // model-b stalled: it falls back to the shared (session/new) options.
+      expect(
+        catalog.models.find((model) => model.id === "model-b")?.thinkingOptions?.map((o) => o.id),
+      ).toEqual(["off", "low", "high", "max"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -649,33 +649,49 @@ export function deriveModelDefinitionsFromACP(
   provider: string,
   models: SessionModelState | null | undefined,
   configOptions?: SessionConfigOption[] | null,
+  perModelThinkingOptions?: Map<string, ConfigOptionSelector[]> | null,
 ): AgentModelDefinition[] {
   const thinkingOptions = deriveSelectorOptions(configOptions, "thought_level");
   const defaultThinkingOptionId = thinkingOptions.find((option) => option.isDefault)?.id ?? null;
 
+  const resolveThinkingOptions = (modelId: string): ConfigOptionSelector[] =>
+    perModelThinkingOptions?.get(modelId) ?? thinkingOptions;
+
   if (models?.availableModels?.length) {
-    return models.availableModels.map((model) => ({
-      provider,
-      id: model.modelId,
-      label: model.name,
-      description: model.description ?? undefined,
-      isDefault: model.modelId === models.currentModelId,
-      thinkingOptions: thinkingOptions.length > 0 ? thinkingOptions : undefined,
-      defaultThinkingOptionId: defaultThinkingOptionId ?? undefined,
-    }));
+    return models.availableModels.map((model) => {
+      const modelThinkingOptions = resolveThinkingOptions(model.modelId);
+      return {
+        provider,
+        id: model.modelId,
+        label: model.name,
+        description: model.description ?? undefined,
+        isDefault: model.modelId === models.currentModelId,
+        thinkingOptions: modelThinkingOptions.length > 0 ? modelThinkingOptions : undefined,
+        defaultThinkingOptionId:
+          modelThinkingOptions.find((option) => option.isDefault)?.id ??
+          defaultThinkingOptionId ??
+          undefined,
+      };
+    });
   }
 
   const modelOptions = deriveSelectorOptions(configOptions, "model");
-  return modelOptions.map((option) => ({
-    provider,
-    id: option.id,
-    label: option.label,
-    description: option.description,
-    isDefault: option.isDefault,
-    thinkingOptions: thinkingOptions.length > 0 ? thinkingOptions : undefined,
-    defaultThinkingOptionId: defaultThinkingOptionId ?? undefined,
-    metadata: option.metadata,
-  }));
+  return modelOptions.map((option) => {
+    const modelThinkingOptions = resolveThinkingOptions(option.id);
+    return {
+      provider,
+      id: option.id,
+      label: option.label,
+      description: option.description,
+      isDefault: option.isDefault,
+      thinkingOptions: modelThinkingOptions.length > 0 ? modelThinkingOptions : undefined,
+      defaultThinkingOptionId:
+        modelThinkingOptions.find((entry) => entry.isDefault)?.id ??
+        defaultThinkingOptionId ??
+        undefined,
+      metadata: option.metadata,
+    };
+  });
 }
 
 export function deriveFeaturesFromACP(
@@ -924,10 +940,16 @@ export class ACPAgentClient implements AgentClient {
           }),
         );
         const transformed = this.transformSessionResponse(response);
+        const perModelThinkingOptions = await this.collectPerModelThinkingOptions({
+          connection: initializedProbe.connection,
+          sessionId: response.sessionId,
+          configOptions: transformed.configOptions,
+        });
         const models = deriveModelDefinitionsFromACP(
           this.provider,
           transformed.models,
           transformed.configOptions,
+          perModelThinkingOptions,
         );
         const modeInfo = deriveModesFromACP(
           this.defaultModes,
@@ -950,6 +972,64 @@ export class ACPAgentClient implements AgentClient {
         await this.closeProbe(probe);
       }
     }
+  }
+
+  /**
+   * Probe the `thought_level` options of every selectable model so the
+   * catalog can advertise per-model thinking levels instead of only the
+   * levels of the model that was current during `session/new`.
+   *
+   * ACP agents expose `thought_level` rows for the current session model
+   * only (e.g. Kimi Code CLI emits `off` plus the current model's
+   * `support_efforts`), so without this probe every catalog model shares
+   * one model's options and switching models shows stale levels. Each
+   * round-trip is a local stdio request on the already-spawned probe
+   * process and is closed right after, so this is cheap and
+   * side-effect free.
+   *
+   * Returns undefined when the agent exposes no `thought_level` category
+   * (the caller keeps the previous shared-options behavior), and skips
+   * individual models whose probe fails (they fall back to the shared
+   * options).
+   */
+  private async collectPerModelThinkingOptions({
+    connection,
+    sessionId,
+    configOptions,
+  }: {
+    connection: ClientSideConnection;
+    sessionId: string;
+    configOptions: SessionConfigOption[] | null | undefined;
+  }): Promise<Map<string, ConfigOptionSelector[]> | undefined> {
+    const thinkingOption = findSelectConfigOption({ configOptions, category: "thought_level" });
+    const modelOption = findSelectConfigOption({ configOptions, category: "model" });
+    if (!thinkingOption || !modelOption) {
+      return undefined;
+    }
+
+    const perModel = new Map<string, ConfigOptionSelector[]>();
+    for (const choice of flattenSelectOptions(modelOption.options)) {
+      try {
+        const response = await this.runACPRequest(() =>
+          connection.setSessionConfigOption({
+            sessionId,
+            configId: modelOption.id,
+            value: choice.value,
+          }),
+        );
+        const transformedConfigOptions = this.configOptionsTransformer
+          ? this.configOptionsTransformer(response.configOptions)
+          : response.configOptions;
+        const options = deriveSelectorOptions(transformedConfigOptions, "thought_level");
+        perModel.set(choice.value, options);
+      } catch (error) {
+        this.logger.warn(
+          { err: error, provider: this.provider, model: choice.value },
+          "Failed to probe ACP thinking options for model",
+        );
+      }
+    }
+    return perModel.size > 0 ? perModel : undefined;
   }
 
   async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -272,9 +272,10 @@ const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
 // Per-model thinking-option probe budget. Each probe is a local stdio
 // JSON-RPC round-trip that normally completes in milliseconds; the timeout
 // only guards against an agent that never answers a model-switch request.
-// Keeping it far below ACP_CATALOG_TIMEOUT_MS lets several stalled probes
-// fall back to shared options instead of failing the whole catalog.
-export const PER_MODEL_THINKING_PROBE_TIMEOUT_MS = 5_000;
+// Probes run serially so the agent's shared session state is always the
+// model the response was requested for; 2s × 30 models = the 60s catalog
+// budget, and realistic model counts are far below that.
+export const PER_MODEL_THINKING_PROBE_TIMEOUT_MS = 2_000;
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {
@@ -1000,11 +1001,12 @@ export class ACPAgentClient implements AgentClient {
    * PER_MODEL_THINKING_PROBE_TIMEOUT_MS so a stalled probe cannot hang the
    * whole catalog probe.
    *
-   * Probes run concurrently: ACP is JSON-RPC, so requests carry ids and
-   * responses are matched per request; local agents process the writes
-   * sequentially anyway. Parallel probes keep the worst case at one
-   * per-model timeout instead of models × timeout, so a provider that
-   * advertises many models cannot exhaust the catalog budget.
+   * Probes run serially: an ACP session has one shared model state, and
+   * serial order guarantees each response is built after exactly the
+   * requested model was applied — concurrent probes could associate a
+   * response with the wrong model. The serial worst case is
+   * models × PER_MODEL_THINKING_PROBE_TIMEOUT_MS, which stays inside the
+   * catalog budget for any realistic model count.
    */
   private async collectPerModelThinkingOptions({
     connection,
@@ -1021,41 +1023,32 @@ export class ACPAgentClient implements AgentClient {
       return undefined;
     }
 
-    const probed = await Promise.all(
-      flattenSelectOptions(modelOption.options).map(async (choice) => {
-        try {
-          const response = await withTimeout(
-            this.runACPRequest(() =>
-              connection.setSessionConfigOption({
-                sessionId,
-                configId: modelOption.id,
-                value: choice.value,
-              }),
-            ),
-            PER_MODEL_THINKING_PROBE_TIMEOUT_MS,
-            `ACP thinking-options probe for model "${choice.value}" timed out after ${PER_MODEL_THINKING_PROBE_TIMEOUT_MS}ms`,
-          );
-          const transformedConfigOptions = this.configOptionsTransformer
-            ? this.configOptionsTransformer(response.configOptions)
-            : response.configOptions;
-          return {
-            modelId: choice.value,
-            options: deriveSelectorOptions(transformedConfigOptions, "thought_level"),
-          };
-        } catch (error) {
-          this.logger.warn(
-            { err: error, provider: this.provider, model: choice.value },
-            "Failed to probe ACP thinking options for model",
-          );
-          return null;
-        }
-      }),
-    );
-
     const perModel = new Map<string, ConfigOptionSelector[]>();
-    for (const entry of probed) {
-      if (entry) {
-        perModel.set(entry.modelId, entry.options);
+    for (const choice of flattenSelectOptions(modelOption.options)) {
+      try {
+        const response = await withTimeout(
+          this.runACPRequest(() =>
+            connection.setSessionConfigOption({
+              sessionId,
+              configId: modelOption.id,
+              value: choice.value,
+            }),
+          ),
+          PER_MODEL_THINKING_PROBE_TIMEOUT_MS,
+          `ACP thinking-options probe for model "${choice.value}" timed out after ${PER_MODEL_THINKING_PROBE_TIMEOUT_MS}ms`,
+        );
+        const transformedConfigOptions = this.configOptionsTransformer
+          ? this.configOptionsTransformer(response.configOptions)
+          : response.configOptions;
+        perModel.set(
+          choice.value,
+          deriveSelectorOptions(transformedConfigOptions, "thought_level"),
+        );
+      } catch (error) {
+        this.logger.warn(
+          { err: error, provider: this.provider, model: choice.value },
+          "Failed to probe ACP thinking options for model",
+        );
       }
     }
     return perModel.size > 0 ? perModel : undefined;

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -269,6 +269,12 @@ export function buildACPClientCapabilities(
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
 const ACP_CATALOG_TIMEOUT_MS = 60_000;
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
+// Per-model thinking-option probe budget. Each probe is a local stdio
+// JSON-RPC round-trip that normally completes in milliseconds; the timeout
+// only guards against an agent that never answers a model-switch request.
+// Keeping it far below ACP_CATALOG_TIMEOUT_MS lets several stalled probes
+// fall back to shared options instead of failing the whole catalog.
+export const PER_MODEL_THINKING_PROBE_TIMEOUT_MS = 5_000;
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {
@@ -989,8 +995,10 @@ export class ACPAgentClient implements AgentClient {
    *
    * Returns undefined when the agent exposes no `thought_level` category
    * (the caller keeps the previous shared-options behavior), and skips
-   * individual models whose probe fails (they fall back to the shared
-   * options).
+   * individual models whose probe fails or stalls (they fall back to the
+   * shared options). Each probe is bounded by
+   * PER_MODEL_THINKING_PROBE_TIMEOUT_MS so a stalled probe cannot hang the
+   * whole catalog probe.
    */
   private async collectPerModelThinkingOptions({
     connection,
@@ -1010,12 +1018,16 @@ export class ACPAgentClient implements AgentClient {
     const perModel = new Map<string, ConfigOptionSelector[]>();
     for (const choice of flattenSelectOptions(modelOption.options)) {
       try {
-        const response = await this.runACPRequest(() =>
-          connection.setSessionConfigOption({
-            sessionId,
-            configId: modelOption.id,
-            value: choice.value,
-          }),
+        const response = await withTimeout(
+          this.runACPRequest(() =>
+            connection.setSessionConfigOption({
+              sessionId,
+              configId: modelOption.id,
+              value: choice.value,
+            }),
+          ),
+          PER_MODEL_THINKING_PROBE_TIMEOUT_MS,
+          `ACP thinking-options probe for model "${choice.value}" timed out after ${PER_MODEL_THINKING_PROBE_TIMEOUT_MS}ms`,
         );
         const transformedConfigOptions = this.configOptionsTransformer
           ? this.configOptionsTransformer(response.configOptions)

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -999,6 +999,12 @@ export class ACPAgentClient implements AgentClient {
    * shared options). Each probe is bounded by
    * PER_MODEL_THINKING_PROBE_TIMEOUT_MS so a stalled probe cannot hang the
    * whole catalog probe.
+   *
+   * Probes run concurrently: ACP is JSON-RPC, so requests carry ids and
+   * responses are matched per request; local agents process the writes
+   * sequentially anyway. Parallel probes keep the worst case at one
+   * per-model timeout instead of models × timeout, so a provider that
+   * advertises many models cannot exhaust the catalog budget.
    */
   private async collectPerModelThinkingOptions({
     connection,
@@ -1015,30 +1021,41 @@ export class ACPAgentClient implements AgentClient {
       return undefined;
     }
 
+    const probed = await Promise.all(
+      flattenSelectOptions(modelOption.options).map(async (choice) => {
+        try {
+          const response = await withTimeout(
+            this.runACPRequest(() =>
+              connection.setSessionConfigOption({
+                sessionId,
+                configId: modelOption.id,
+                value: choice.value,
+              }),
+            ),
+            PER_MODEL_THINKING_PROBE_TIMEOUT_MS,
+            `ACP thinking-options probe for model "${choice.value}" timed out after ${PER_MODEL_THINKING_PROBE_TIMEOUT_MS}ms`,
+          );
+          const transformedConfigOptions = this.configOptionsTransformer
+            ? this.configOptionsTransformer(response.configOptions)
+            : response.configOptions;
+          return {
+            modelId: choice.value,
+            options: deriveSelectorOptions(transformedConfigOptions, "thought_level"),
+          };
+        } catch (error) {
+          this.logger.warn(
+            { err: error, provider: this.provider, model: choice.value },
+            "Failed to probe ACP thinking options for model",
+          );
+          return null;
+        }
+      }),
+    );
+
     const perModel = new Map<string, ConfigOptionSelector[]>();
-    for (const choice of flattenSelectOptions(modelOption.options)) {
-      try {
-        const response = await withTimeout(
-          this.runACPRequest(() =>
-            connection.setSessionConfigOption({
-              sessionId,
-              configId: modelOption.id,
-              value: choice.value,
-            }),
-          ),
-          PER_MODEL_THINKING_PROBE_TIMEOUT_MS,
-          `ACP thinking-options probe for model "${choice.value}" timed out after ${PER_MODEL_THINKING_PROBE_TIMEOUT_MS}ms`,
-        );
-        const transformedConfigOptions = this.configOptionsTransformer
-          ? this.configOptionsTransformer(response.configOptions)
-          : response.configOptions;
-        const options = deriveSelectorOptions(transformedConfigOptions, "thought_level");
-        perModel.set(choice.value, options);
-      } catch (error) {
-        this.logger.warn(
-          { err: error, provider: this.provider, model: choice.value },
-          "Failed to probe ACP thinking options for model",
-        );
+    for (const entry of probed) {
+      if (entry) {
+        perModel.set(entry.modelId, entry.options);
       }
     }
     return perModel.size > 0 ? perModel : undefined;


### PR DESCRIPTION
Closes #2823

## What

ACP provider catalog probing only read the thinking options of the session's default model, so switching models in the composer kept showing the old model's effort levels. `fetchCatalog` now probes each selectable model and attaches per-model thinking options (and per-model defaults) to the catalog definitions.

## Testing

- 3 new unit tests: per-model option derivation, per-model probing during `fetchCatalog`, and fallback to shared options when a single model probe fails
- Full `acp-agent.test.ts` suite passes: 99/99
- lint + format clean on the changed files