### PR TITLE
feat(app): close settings with Escape

### DIFF
--- a/packages/app/e2e/browser/settings-navigation.spec.ts
+++ b/packages/app/e2e/browser/settings-navigation.spec.ts
@@ -121,6 +121,13 @@ test.describe("Settings sidebar navigation", () => {
     await clickSettingsBackToWorkspace(page);
     await expect(page).not.toHaveURL(/\/settings(\/|$)/);
   });
+
+  test("pressing Escape closes settings", async ({ page }) => {
+    await gotoAppShell(page);
+    await openSettings(page);
+    await page.keyboard.press("Escape");
+    await expect(page).not.toHaveURL(/\/settings(\/|$)/);
+  });
 });
 
 test.describe("Settings — compact master-detail", () => {

--- a/packages/app/e2e/browser/settings-navigation.spec.ts
+++ b/packages/app/e2e/browser/settings-navigation.spec.ts
@@ -128,6 +128,34 @@ test.describe("Settings sidebar navigation", () => {
     await page.keyboard.press("Escape");
     await expect(page).not.toHaveURL(/\/settings(\/|$)/);
   });
+
+  test("Escape lets settings dropdowns and modals close before leaving settings", async ({
+    page,
+  }) => {
+    await gotoAppShell(page);
+    await openSettings(page);
+
+    await test.step("a dropdown owns Escape", async () => {
+      await openSettingsSection(page, "appearance");
+      await page.getByLabel(/Theme:/).click();
+      await expect(page.getByRole("menuitem", { name: "System", exact: true })).toBeVisible();
+
+      await page.keyboard.press("Escape");
+
+      await expect(page.getByRole("menuitem", { name: "System", exact: true })).toHaveCount(0);
+      await expect(page).toHaveURL(/\/settings(\/|$)/);
+    });
+
+    await test.step("a modal owns Escape", async () => {
+      await openAddHostFlow(page);
+      await expect(page.getByText("Add connection", { exact: true })).toBeVisible();
+
+      await page.keyboard.press("Escape");
+
+      await expect(page.getByText("Add connection", { exact: true })).toHaveCount(0);
+      await expect(page).toHaveURL(/\/settings(\/|$)/);
+    });
+  });
 });
 
 test.describe("Settings — compact master-detail", () => {

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -32,6 +32,8 @@ import { isNative } from "@/constants/platform";
 import { keyboardShortcutsAvailable } from "@/keyboard/availability";
 import { getDesktopHost, isElectronRuntime } from "@/desktop/host";
 import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
+import { buildOpenProjectRoute } from "@/utils/host-routes";
+import { hasActiveWebOverlay } from "@/lib/overlay-root";
 import {
   type ActiveWorkspaceSelection,
   navigateToLastWorkspace,
@@ -179,7 +181,11 @@ export function useKeyboardShortcuts({
           navigateToWorkspace({ serverId: action.serverId, workspaceId: action.workspaceId });
           return true;
         case "navigate-last-workspace":
-          return navigateToLastWorkspace();
+          if (navigateToLastWorkspace()) {
+            return true;
+          }
+          router.replace(buildOpenProjectRoute());
+          return true;
         case "router-replace":
           router.replace(action.route as Parameters<typeof router.replace>[0]);
           return true;
@@ -330,6 +336,14 @@ export function useKeyboardShortcuts({
       }
 
       const key = event.key ?? "";
+      if (
+        key === "Escape" &&
+        pathname.startsWith("/settings") &&
+        !isMobile &&
+        hasActiveWebOverlay()
+      ) {
+        return;
+      }
       if (key === badgeModifierKey && !event.shiftKey) {
         setBadgeModifierDown(true);
       }

--- a/packages/app/src/keyboard/route-shortcut.test.ts
+++ b/packages/app/src/keyboard/route-shortcut.test.ts
@@ -59,6 +59,27 @@ describe("routeKeyboardShortcut — dispatch passthroughs", () => {
       action: expected,
     });
   });
+
+  it("closes desktop settings when Escape routes through agent interrupt", () => {
+    expect(
+      routeKeyboardShortcut(
+        { action: "agent.interrupt", payload: null },
+        makeCtx({ pathname: "/settings/general" }),
+      ),
+    ).toEqual<ShortcutAction>({ kind: "navigate-last-workspace" });
+  });
+
+  it("keeps agent interrupt behavior on compact settings layouts", () => {
+    expect(
+      routeKeyboardShortcut(
+        { action: "agent.interrupt", payload: null },
+        makeCtx({ pathname: "/settings/general", isMobile: true }),
+      ),
+    ).toEqual<ShortcutAction>({
+      kind: "dispatch",
+      action: { id: "agent.interrupt", scope: "global" },
+    });
+  });
 });
 
 describe("routeKeyboardShortcut — workspace.tab.navigate", () => {

--- a/packages/app/src/keyboard/route-shortcut.ts
+++ b/packages/app/src/keyboard/route-shortcut.ts
@@ -177,6 +177,13 @@ export function routeKeyboardShortcut(
 ): ShortcutAction {
   const passthrough = PASSTHROUGH_DISPATCH[input.action];
   if (passthrough) {
+    if (
+      input.action === "agent.interrupt" &&
+      ctx.pathname.startsWith("/settings") &&
+      !ctx.isMobile
+    ) {
+      return { kind: "navigate-last-workspace" };
+    }
     return dispatch(passthrough);
   }
 

--- a/packages/app/src/lib/overlay-root.ts
+++ b/packages/app/src/lib/overlay-root.ts
@@ -107,6 +107,10 @@ function getTopWebOverlay(): WebOverlayEntry | undefined {
   }, undefined);
 }
 
+export function hasActiveWebOverlay(): boolean {
+  return getTopWebOverlay() !== undefined;
+}
+
 function getFocusableElements(scope: HTMLElement): HTMLElement[] {
   const selector = [
     "a[href]",


### PR DESCRIPTION
### Linked issue

No issue number was provided.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On desktop and web, pressing Escape in Settings was routed as an agent-interrupt shortcut and left the Settings screen open. Route Escape to the existing Settings exit path instead.

### Goals

- Close non-compact Settings with Escape and return to the last workspace.
- Fall back to Open Project when no remembered workspace exists.
- Let active web overlays keep ownership of Escape.
- Preserve compact/mobile Settings behavior.

### Non-goals

- Change Escape behavior for other routes or compact layouts.
- Change existing Settings or agent-interrupt shortcut bindings.

### QA

- `npx vitest run packages/app/src/keyboard/route-shortcut.test.ts packages/app/src/keyboard/keyboard-shortcuts.test.ts --bail=1` — 137 tests passed.
- `npm run test:e2e --workspace=@getpaseo/app -- settings-navigation.spec.ts --grep "pressing Escape closes settings"` — 1 test passed in the real browser/Metro/daemon harness.
- `npm run typecheck --workspace=@getpaseo/app` — passed.
- `npm run lint` and targeted format checks — passed.
- Web browser tested; Electron was not separately exercised.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
