### PR TITLE
fix(cli): list worktrees from registered projects

### DIFF
--- a/packages/cli/src/commands/worktree/archive.test.ts
+++ b/packages/cli/src/commands/worktree/archive.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { runArchiveCommandWithDeps } from "./archive.js";
+import { createWorktreeCommand } from "./index.js";
+
+const testOptions = { host: "localhost:6767" };
 
 function createFakeDaemonClient(
   overrides: Partial<
@@ -29,7 +32,34 @@ function createFakeDaemonClient(
 // worktree-session.test.ts prove real filesystem removal end-to-end.
 
 describe("runArchiveCommand", () => {
-  it("sends scope worktree when archiving by worktree path", async () => {
+  it("registers cwd and repoRoot selectors", () => {
+    const archiveCommand = createWorktreeCommand().commands.find(
+      (command) => command.name() === "archive",
+    );
+
+    expect(archiveCommand?.options.map((option) => option.attributeName())).toEqual(
+      expect.arrayContaining(["cwd", "repoRoot"]),
+    );
+  });
+
+  it("rejects selector-free archive before connecting to the daemon", async () => {
+    let connectCalls = 0;
+
+    await expect(
+      runArchiveCommandWithDeps("feature", testOptions, {
+        connectToDaemon: async () => {
+          connectCalls += 1;
+          return createFakeDaemonClient();
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "MISSING_WORKTREE_SELECTOR",
+      details: expect.stringContaining("--repo-root"),
+    });
+    expect(connectCalls).toBe(0);
+  });
+
+  it("sends scope and expected identity without authorizing the cached path", async () => {
     const worktreePath = "/tmp/paseo-home/worktrees/repo/feature";
     const archiveCalls: Array<{
       input: Parameters<DaemonClient["archivePaseoWorktree"]>[0];
@@ -60,15 +90,20 @@ describe("runArchiveCommand", () => {
 
     const result = await runArchiveCommandWithDeps(
       "feature",
-      {},
+      { ...testOptions, cwd: "/repos/repo" },
       {
         connectToDaemon: async () => fakeClient,
       },
     );
 
     expect(archiveCalls).toHaveLength(1);
-    expect(archiveCalls[0]?.input.scope).toBe("worktree");
-    expect(archiveCalls[0]?.input.worktreePath).toBe(worktreePath);
+    expect(archiveCalls[0]?.input).toEqual({
+      repoRoot: "/repos/repo",
+      expectedWorktreeIdentity: "feature",
+      expectedWorktreePath: worktreePath,
+      scope: "worktree",
+    });
+    expect(archiveCalls[0]?.input).not.toHaveProperty("worktreePath");
     expect(result).toEqual({
       type: "single",
       data: {
@@ -111,15 +146,121 @@ describe("runArchiveCommand", () => {
 
     await runArchiveCommandWithDeps(
       "feature-x",
-      {},
+      { ...testOptions, cwd: "/repos/repo" },
       {
         connectToDaemon: async () => fakeClient,
       },
     );
 
     expect(archiveCalls).toHaveLength(1);
-    expect(archiveCalls[0]?.input.scope).toBe("worktree");
-    expect(archiveCalls[0]?.input.worktreePath).toBe(worktreePath);
+    expect(archiveCalls[0]?.input).toEqual({
+      repoRoot: "/repos/repo",
+      expectedWorktreeIdentity: "feature-x",
+      expectedWorktreePath: worktreePath,
+      scope: "worktree",
+    });
+  });
+
+  it("refuses to archive either of two same-named worktrees", async () => {
+    const firstPath = "/tmp/paseo-home/worktrees/repo-a/shared";
+    const secondPath = "/tmp/paseo-home/worktrees/repo-b/shared";
+    const archiveCalls: Array<Parameters<DaemonClient["archivePaseoWorktree"]>[0]> = [];
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async () => ({
+        worktrees: [
+          {
+            worktreePath: firstPath,
+            branchName: "feature-a",
+            head: "abc123",
+            createdAt: "2026-04-12T00:00:00.000Z",
+          },
+          {
+            worktreePath: secondPath,
+            branchName: "feature-b",
+            head: "def456",
+            createdAt: "2026-04-12T00:00:00.000Z",
+          },
+        ],
+        error: null,
+        requestId: "req-list",
+      }),
+      archivePaseoWorktree: async (input) => {
+        archiveCalls.push(input);
+        return {
+          success: true,
+          removedAgents: [],
+          error: null,
+          requestId: "req-archive",
+        };
+      },
+    });
+
+    await expect(
+      runArchiveCommandWithDeps(
+        "shared",
+        { ...testOptions, repoRoot: "/repos/repo" },
+        {
+          connectToDaemon: async () => fakeClient,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "WORKTREE_AMBIGUOUS",
+      details: expect.stringContaining(`${firstPath} (branch: feature-a)\n${secondPath}`),
+    });
+    expect(archiveCalls).toEqual([]);
+  });
+
+  it.each([
+    ["cwd", { cwd: "/repos/repo-a" }],
+    ["repoRoot", { repoRoot: "/repos/repo-a" }],
+  ] as const)("uses an explicit %s selector to archive one exact target", async (_, selector) => {
+    const selectedPath = "/tmp/paseo-home/worktrees/repo-a/shared";
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const archiveCalls: Array<Parameters<DaemonClient["archivePaseoWorktree"]>[0]> = [];
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [
+            {
+              worktreePath: selectedPath,
+              branchName: "shared",
+              head: "abc123",
+              createdAt: "2026-04-12T00:00:00.000Z",
+            },
+          ],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+      archivePaseoWorktree: async (input) => {
+        archiveCalls.push(input);
+        return {
+          success: true,
+          removedAgents: [],
+          error: null,
+          requestId: "req-archive",
+        };
+      },
+    });
+
+    await runArchiveCommandWithDeps(
+      "shared",
+      { ...testOptions, ...selector },
+      {
+        connectToDaemon: async () => fakeClient,
+      },
+    );
+
+    expect(listCalls).toEqual([{ cwd: undefined, repoRoot: undefined, ...selector }]);
+    expect(archiveCalls).toEqual([
+      {
+        repoRoot: "/repos/repo-a",
+        expectedWorktreeIdentity: "shared",
+        expectedWorktreePath: selectedPath,
+        scope: "worktree",
+      },
+    ]);
   });
 
   it("throws a CommandError when the worktree is not found", async () => {
@@ -134,7 +275,7 @@ describe("runArchiveCommand", () => {
     await expect(
       runArchiveCommandWithDeps(
         "missing",
-        {},
+        { ...testOptions, cwd: "/repos/repo" },
         {
           connectToDaemon: async () => fakeClient,
         },

--- a/packages/cli/src/commands/worktree/archive.ts
+++ b/packages/cli/src/commands/worktree/archive.ts
@@ -31,6 +31,8 @@ export const archiveSchema: OutputSchema<WorktreeArchiveResult> = {
 
 export interface WorktreeArchiveOptions extends CommandOptions {
   host?: string;
+  cwd?: string;
+  repoRoot?: string;
 }
 
 export type WorktreeArchiveCommandResult = SingleResult<WorktreeArchiveResult>;
@@ -60,6 +62,15 @@ export async function runArchiveCommandWithDeps(
     throw error;
   }
 
+  if (!options.cwd && !options.repoRoot) {
+    const error: CommandError = {
+      code: "MISSING_WORKTREE_SELECTOR",
+      message: "Archive requires --cwd or --repo-root",
+      details: "Use --repo-root <path> or --cwd <path> to select one repository.",
+    };
+    throw error;
+  }
+
   let client: DaemonClient;
   try {
     client = await deps.connectToDaemon({ host: options.host });
@@ -75,7 +86,10 @@ export async function runArchiveCommandWithDeps(
 
   try {
     // Get the list of worktrees first to resolve the name
-    const listResponse = await client.getPaseoWorktreeList({});
+    const listResponse = await client.getPaseoWorktreeList({
+      cwd: options.cwd,
+      repoRoot: options.repoRoot,
+    });
 
     if (listResponse.error) {
       const error: CommandError = {
@@ -86,10 +100,26 @@ export async function runArchiveCommandWithDeps(
     }
 
     // Find the worktree by name or branch
-    const worktree = listResponse.worktrees.find((wt) => {
+    const matches = listResponse.worktrees.filter((wt) => {
       const name = path.basename(wt.worktreePath);
       return name === nameArg || wt.branchName === nameArg;
     });
+    if (matches.length > 1) {
+      const identities = matches.map(
+        (worktree) => `${worktree.worktreePath} (branch: ${worktree.branchName ?? "-"})`,
+      );
+      const error: CommandError = {
+        code: "WORKTREE_AMBIGUOUS",
+        message: `Multiple worktrees match: ${nameArg}`,
+        details: [
+          ...identities,
+          "Use --repo-root <path> or --cwd <path> to select one repository.",
+        ].join("\n"),
+      };
+      throw error;
+    }
+
+    const worktree = matches[0];
 
     if (!worktree) {
       const error: CommandError = {
@@ -103,7 +133,9 @@ export async function runArchiveCommandWithDeps(
     // Archive the worktree. scope:"worktree" archives every active workspace on
     // the directory and then removes the directory (Paseo-owned gated).
     const response = await client.archivePaseoWorktree({
-      worktreePath: worktree.worktreePath,
+      repoRoot: options.repoRoot ?? options.cwd,
+      expectedWorktreeIdentity: nameArg,
+      expectedWorktreePath: worktree.worktreePath,
       scope: "worktree",
     });
 

--- a/packages/cli/src/commands/worktree/index.ts
+++ b/packages/cli/src/commands/worktree/index.ts
@@ -30,8 +30,10 @@ export function createWorktreeCommand(): Command {
   addJsonAndDaemonHostOptions(
     worktree
       .command("archive")
-      .description("Archive a worktree (removes worktree and associated branch)")
-      .argument("<name>", "Worktree name or branch name"),
+      .description("Archive a worktree in an explicitly selected repository")
+      .argument("<name>", "Worktree name or branch name")
+      .option("--cwd <path>", "Directory within the repository (required without --repo-root)")
+      .option("--repo-root <path>", "Repository root (required without --cwd; takes precedence)"),
   ).action(withOutput(runArchiveCommand));
 
   return worktree;

--- a/packages/cli/src/commands/worktree/ls.test.ts
+++ b/packages/cli/src/commands/worktree/ls.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import { render } from "../../output/index.js";
+import { runLsCommandWithDeps } from "./ls.js";
+
+function createFakeDaemonClient(
+  overrides: Partial<Pick<DaemonClient, "fetchAgents" | "getPaseoWorktreeList" | "close">> = {},
+): DaemonClient {
+  return {
+    fetchAgents: async () => ({ entries: [] }),
+    getPaseoWorktreeList: async () => ({
+      worktrees: [],
+      error: null,
+      requestId: "req-list",
+    }),
+    close: async () => {},
+    ...overrides,
+  } as unknown as DaemonClient;
+}
+
+describe("runLsCommand", () => {
+  it("requests worktrees from all registered projects explicitly", async () => {
+    const listCalls: Array<Parameters<DaemonClient["getPaseoWorktreeList"]>[0]> = [];
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async (input) => {
+        listCalls.push(input);
+        return {
+          worktrees: [],
+          error: null,
+          requestId: "req-list",
+        };
+      },
+    });
+
+    const result = await runLsCommandWithDeps(
+      { host: "localhost:6767" },
+      { connectToDaemon: async () => fakeClient },
+    );
+
+    expect(listCalls).toEqual([{ allRegisteredProjects: true }]);
+    expect(result).toMatchObject({
+      type: "single",
+      data: {
+        inventoryScope: "current_registered_non_archived_git_projects",
+        allManagedWorktreesIncluded: false,
+        excludedProjectStates: ["archived", "removed"],
+        worktrees: [],
+      },
+    });
+    expect(render(result, { noColor: true })).toContain(
+      "Scope: current registered, non-archived Git projects only; this is not a complete inventory of all managed worktrees because archived or removed projects are excluded.",
+    );
+  });
+
+  it("labels the limited inventory scope in structured output", async () => {
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async () => ({
+        worktrees: [
+          {
+            worktreePath: "/tmp/paseo-home/worktrees/repo/feature",
+            branchName: "feature",
+            head: "abc123",
+            createdAt: "2026-04-12T00:00:00.000Z",
+          },
+        ],
+        error: null,
+        requestId: "req-list",
+      }),
+    });
+
+    const result = await runLsCommandWithDeps(
+      { host: "localhost:6767", format: "json" },
+      { connectToDaemon: async () => fakeClient },
+    );
+
+    expect(JSON.parse(render(result, { format: "json" }))).toEqual({
+      inventoryScope: "current_registered_non_archived_git_projects",
+      allManagedWorktreesIncluded: false,
+      excludedProjectStates: ["archived", "removed"],
+      worktrees: [
+        {
+          name: "feature",
+          branch: "feature",
+          cwd: "/tmp/paseo-home/worktrees/repo/feature",
+          agent: "-",
+        },
+      ],
+    });
+  });
+
+  it("fails instead of returning a known-partial inventory", async () => {
+    const fakeClient = createFakeDaemonClient({
+      getPaseoWorktreeList: async () => ({
+        worktrees: [
+          {
+            worktreePath: "/tmp/paseo-home/worktrees/repo/feature",
+            branchName: "feature",
+            head: "abc123",
+            createdAt: "2026-04-12T00:00:00.000Z",
+          },
+        ],
+        repositoryErrors: 2,
+        error: null,
+        requestId: "req-list",
+      }),
+    });
+
+    await expect(
+      runLsCommandWithDeps(
+        { host: "localhost:6767", format: "json" },
+        { connectToDaemon: async () => fakeClient },
+      ),
+    ).rejects.toMatchObject({
+      code: "WORKTREE_LIST_PARTIAL",
+      message: "Failed to list worktrees from 2 registered repositories",
+    });
+  });
+});

--- a/packages/cli/src/commands/worktree/ls.ts
+++ b/packages/cli/src/commands/worktree/ls.ts
@@ -3,7 +3,13 @@ import { homedir } from "node:os";
 import { basename, join, sep } from "node:path";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
-import type { CommandOptions, ListResult, OutputSchema, CommandError } from "../../output/index.js";
+import {
+  renderTable,
+  type CommandOptions,
+  type SingleResult,
+  type OutputSchema,
+  type CommandError,
+} from "../../output/index.js";
 
 /** Worktree list item for display */
 export interface WorktreeListItem {
@@ -11,6 +17,13 @@ export interface WorktreeListItem {
   branch: string;
   cwd: string;
   agent: string;
+}
+
+export interface WorktreeListOutput {
+  inventoryScope: "current_registered_non_archived_git_projects";
+  allManagedWorktreesIncluded: false;
+  excludedProjectStates: ["archived", "removed"];
+  worktrees: WorktreeListItem[];
 }
 
 /** Shorten home directory in path */
@@ -40,8 +53,7 @@ function isAgentInManagedWorktree(agentCwd: string): boolean {
   return agentCwd === worktreesDir || agentCwd.startsWith(worktreesDir + sep);
 }
 
-/** Schema for worktree ls output */
-export const worktreeLsSchema: OutputSchema<WorktreeListItem> = {
+const worktreeLsTableSchema: OutputSchema<WorktreeListItem> = {
   idField: "name",
   columns: [
     { header: "NAME", field: "name", width: 20 },
@@ -51,7 +63,28 @@ export const worktreeLsSchema: OutputSchema<WorktreeListItem> = {
   ],
 };
 
-export type WorktreeLsResult = ListResult<WorktreeListItem>;
+const WORKTREE_INVENTORY_SCOPE_TEXT =
+  "Scope: current registered, non-archived Git projects only; this is not a complete inventory of all managed worktrees because archived or removed projects are excluded.";
+
+/** Schema for worktree ls output */
+export const worktreeLsSchema: OutputSchema<WorktreeListOutput> = {
+  idField: (output) => output.worktrees.map((worktree) => worktree.name).join("\n"),
+  columns: [],
+  renderHuman: (result, options) => {
+    const outputs = result.type === "single" ? [result.data] : result.data;
+    const table = renderTable<WorktreeListItem>(
+      {
+        type: "list",
+        data: outputs.flatMap((output) => output.worktrees),
+        schema: worktreeLsTableSchema,
+      },
+      options,
+    );
+    return table ? `${WORKTREE_INVENTORY_SCOPE_TEXT}\n${table}` : WORKTREE_INVENTORY_SCOPE_TEXT;
+  },
+};
+
+export type WorktreeLsResult = SingleResult<WorktreeListOutput>;
 
 export interface WorktreeLsOptions extends CommandOptions {
   host?: string;
@@ -61,11 +94,18 @@ export async function runLsCommand(
   options: WorktreeLsOptions,
   _command: Command,
 ): Promise<WorktreeLsResult> {
+  return runLsCommandWithDeps(options, { connectToDaemon });
+}
+
+export async function runLsCommandWithDeps(
+  options: WorktreeLsOptions,
+  deps: { connectToDaemon: typeof connectToDaemon },
+): Promise<WorktreeLsResult> {
   const host = getDaemonHost({ host: options.host });
 
   let client: DaemonClient;
   try {
-    client = await connectToDaemon({ host: options.host });
+    client = await deps.connectToDaemon({ host: options.host });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const error: CommandError = {
@@ -80,8 +120,7 @@ export async function runLsCommand(
     const agentsPayload = await client.fetchAgents({ filter: { includeArchived: true } });
     const agents = agentsPayload.entries.map((entry) => entry.agent);
 
-    // Get worktree list from daemon
-    const response = await client.getPaseoWorktreeList({});
+    const response = await client.getPaseoWorktreeList({ allRegisteredProjects: true });
 
     await client.close();
 
@@ -89,6 +128,15 @@ export async function runLsCommand(
       const error: CommandError = {
         code: "WORKTREE_LIST_FAILED",
         message: `Failed to list worktrees: ${response.error.message}`,
+      };
+      throw error;
+    }
+
+    if (response.repositoryErrors !== undefined) {
+      const error: CommandError = {
+        code: "WORKTREE_LIST_PARTIAL",
+        message: `Failed to list worktrees from ${response.repositoryErrors} registered ${response.repositoryErrors === 1 ? "repository" : "repositories"}`,
+        details: "Resolve the unavailable repositories and retry.",
       };
       throw error;
     }
@@ -109,8 +157,13 @@ export async function runLsCommand(
     }));
 
     return {
-      type: "list",
-      data: items,
+      type: "single",
+      data: {
+        inventoryScope: "current_registered_non_archived_git_projects",
+        allManagedWorktreesIncluded: false,
+        excludedProjectStates: ["archived", "removed"],
+        worktrees: items,
+      },
       schema: worktreeLsSchema,
     };
   } catch (err) {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -3430,6 +3430,108 @@ test("requests directory suggestions via RPC", async () => {
   });
 });
 
+test("requests registered-project worktree inventory via RPC", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const promise = client.getPaseoWorktreeList({ allRegisteredProjects: true }, "req-all-worktrees");
+
+  expect(mock.sent).toHaveLength(1);
+  expect(parseSentFrame(mock.sent[0])).toEqual({
+    type: "paseo_worktree_list_request",
+    allRegisteredProjects: true,
+    requestId: "req-all-worktrees",
+  });
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "paseo_worktree_list_response",
+      payload: {
+        worktrees: [],
+        error: null,
+        requestId: "req-all-worktrees",
+      },
+    }),
+  );
+
+  await expect(promise).resolves.toEqual({
+    worktrees: [],
+    error: null,
+    requestId: "req-all-worktrees",
+  });
+});
+
+test("archives a worktree by expected identity without sending a destructive path", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const promise = client.archivePaseoWorktree(
+    {
+      repoRoot: "/repo",
+      expectedWorktreeIdentity: "feature",
+      expectedWorktreePath: "/paseo/worktrees/repo/feature",
+      scope: "worktree",
+    },
+    "req-archive-worktree",
+  );
+
+  expect(mock.sent).toHaveLength(1);
+  expect(parseSentFrame(mock.sent[0])).toEqual({
+    type: "paseo_worktree_archive_request",
+    repoRoot: "/repo",
+    expectedWorktreeIdentity: "feature",
+    expectedWorktreePath: "/paseo/worktrees/repo/feature",
+    scope: "worktree",
+    deleteWorktreeFromDisk: false,
+    requestId: "req-archive-worktree",
+  });
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "paseo_worktree_archive_response",
+      payload: {
+        success: true,
+        removedAgents: [],
+        error: null,
+        requestId: "req-archive-worktree",
+      },
+    }),
+  );
+
+  await expect(promise).resolves.toEqual({
+    success: true,
+    removedAgents: [],
+    error: null,
+    requestId: "req-archive-worktree",
+  });
+});
+
 test("requests checkout merge from base via RPC", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -4044,7 +4044,7 @@ export class DaemonClient {
   }
 
   async getPaseoWorktreeList(
-    input: { cwd?: string; repoRoot?: string },
+    input: { cwd?: string; repoRoot?: string; allRegisteredProjects?: true },
     requestId?: string,
   ): Promise<PaseoWorktreeListPayload> {
     return this.sendCorrelatedSessionRequest({
@@ -4053,6 +4053,7 @@ export class DaemonClient {
         type: "paseo_worktree_list_request",
         cwd: input.cwd,
         repoRoot: input.repoRoot,
+        allRegisteredProjects: input.allRegisteredProjects,
       },
       responseType: "paseo_worktree_list_response",
     });
@@ -4063,6 +4064,8 @@ export class DaemonClient {
       worktreePath?: string;
       repoRoot?: string;
       branchName?: string;
+      expectedWorktreeIdentity?: string;
+      expectedWorktreePath?: string;
       workspaceId?: string;
       scope?: "workspace" | "worktree";
     },
@@ -4075,6 +4078,8 @@ export class DaemonClient {
         worktreePath: input.worktreePath,
         repoRoot: input.repoRoot,
         branchName: input.branchName,
+        expectedWorktreeIdentity: input.expectedWorktreeIdentity,
+        expectedWorktreePath: input.expectedWorktreePath,
         ...(input.workspaceId !== undefined ? { workspaceId: input.workspaceId } : {}),
         ...(input.scope !== undefined ? { scope: input.scope } : {}),
       },

--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   FileExplorerRequestSchema,
   PaseoWorktreeArchiveRequestSchema,
+  PaseoWorktreeListRequestSchema,
   parseServerInfoStatusPayload,
   SessionInboundMessageSchema,
   SessionOutboundMessageSchema,
@@ -400,6 +401,11 @@ describe("file explorer request compatibility", () => {
 });
 
 describe("paseo worktree archive request compatibility", () => {
+  const legacyRequestSchema = PaseoWorktreeArchiveRequestSchema.omit({
+    expectedWorktreeIdentity: true,
+    expectedWorktreePath: true,
+  });
+
   test("omitted scope defaults to workspace", () => {
     const parsed = PaseoWorktreeArchiveRequestSchema.parse({
       type: "paseo_worktree_archive_request",
@@ -428,6 +434,103 @@ describe("paseo worktree archive request compatibility", () => {
     });
     expect(parsed).not.toHaveProperty("extraField");
     expect(parsed.scope).toBe("workspace");
+  });
+
+  test("old daemons strip expected identity fields and cannot receive a destructive path", () => {
+    const parsed = legacyRequestSchema.parse({
+      type: "paseo_worktree_archive_request",
+      repoRoot: "/repo",
+      expectedWorktreeIdentity: "feature",
+      expectedWorktreePath: "/paseo/worktrees/repo/feature",
+      scope: "worktree",
+      requestId: "req-new-cli-old-daemon",
+    });
+
+    expect(parsed).toEqual({
+      type: "paseo_worktree_archive_request",
+      repoRoot: "/repo",
+      scope: "worktree",
+      deleteWorktreeFromDisk: false,
+      requestId: "req-new-cli-old-daemon",
+    });
+    expect(parsed).not.toHaveProperty("worktreePath");
+  });
+
+  test("new daemons preserve the expected identity and path", () => {
+    const parsed = PaseoWorktreeArchiveRequestSchema.parse({
+      type: "paseo_worktree_archive_request",
+      repoRoot: "/repo",
+      expectedWorktreeIdentity: "feature",
+      expectedWorktreePath: "/paseo/worktrees/repo/feature",
+      scope: "worktree",
+      requestId: "req-new-cli-new-daemon",
+    });
+
+    expect(parsed).toMatchObject({
+      expectedWorktreeIdentity: "feature",
+      expectedWorktreePath: "/paseo/worktrees/repo/feature",
+    });
+  });
+});
+
+describe("paseo worktree list request compatibility", () => {
+  const legacyRequestSchema = PaseoWorktreeListRequestSchema.omit({
+    allRegisteredProjects: true,
+  });
+
+  test("old CLI and old daemon retain the unscoped legacy request shape", () => {
+    const parsed = legacyRequestSchema.parse({
+      type: "paseo_worktree_list_request",
+      requestId: "req-old-cli-old-daemon",
+    });
+
+    expect(parsed).toEqual({
+      type: "paseo_worktree_list_request",
+      requestId: "req-old-cli-old-daemon",
+    });
+  });
+
+  test("old daemon strips the new global inventory flag and returns its explicit error", () => {
+    const request = legacyRequestSchema.parse({
+      type: "paseo_worktree_list_request",
+      allRegisteredProjects: true,
+      requestId: "req-new-cli-old-daemon",
+    });
+    const response = SessionOutboundMessageSchema.parse({
+      type: "paseo_worktree_list_response",
+      payload: {
+        worktrees: [],
+        error: { code: "UNKNOWN", message: "cwd or repoRoot is required" },
+        requestId: "req-new-cli-old-daemon",
+      },
+    });
+
+    expect(request).toEqual({
+      type: "paseo_worktree_list_request",
+      requestId: "req-new-cli-old-daemon",
+    });
+    expect(response).toEqual({
+      type: "paseo_worktree_list_response",
+      payload: {
+        worktrees: [],
+        error: { code: "UNKNOWN", message: "cwd or repoRoot is required" },
+        requestId: "req-new-cli-old-daemon",
+      },
+    });
+  });
+
+  test("new daemon preserves the explicit global inventory flag", () => {
+    const parsed = PaseoWorktreeListRequestSchema.parse({
+      type: "paseo_worktree_list_request",
+      allRegisteredProjects: true,
+      requestId: "req-new-cli-new-daemon",
+    });
+
+    expect(parsed).toEqual({
+      type: "paseo_worktree_list_request",
+      allRegisteredProjects: true,
+      requestId: "req-new-cli-new-daemon",
+    });
   });
 });
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -2012,6 +2012,7 @@ export const PaseoWorktreeListRequestSchema = z.object({
   type: z.literal("paseo_worktree_list_request"),
   cwd: z.string().optional(),
   repoRoot: z.string().optional(),
+  allRegisteredProjects: z.literal(true).optional(),
   requestId: z.string(),
 });
 
@@ -2020,6 +2021,11 @@ export const PaseoWorktreeArchiveRequestSchema = z.object({
   worktreePath: z.string().optional(),
   repoRoot: z.string().optional(),
   branchName: z.string().optional(),
+  // COMPAT(worktreeArchiveExpectedIdentity): added in v0.2.6, remove optional after 2027-02-03.
+  // New destructive clients send both fields instead of worktreePath so an old
+  // daemon strips them and fails safely rather than trusting a stale cached path.
+  expectedWorktreeIdentity: z.string().optional(),
+  expectedWorktreePath: z.string().optional(),
   // COMPAT(worktreeArchiveWorkspaceId): added in v0.1.97, drop the optional gate when floor >= v0.1.97.
   // Explicit workspace record to archive. A directory can back multiple workspaces
   // (Model B), so resolving the target by cwd alone picks the wrong record. When
@@ -4865,6 +4871,9 @@ export const PaseoWorktreeListResponseSchema = z.object({
   type: z.literal("paseo_worktree_list_response"),
   payload: z.object({
     worktrees: z.array(PaseoWorktreeSchema),
+    // Reports only failures observed while inspecting current registered projects.
+    // Absence does not assert that the inventory is complete.
+    repositoryErrors: z.number().int().positive().optional(),
     error: CheckoutErrorSchema.nullable(),
     requestId: z.string(),
   }),

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3957,6 +3957,8 @@ export class Session {
         emit: (message) => this.emit(message),
         paseoHome: this.paseoHome,
         workspaceGitService: this.workspaceGitService,
+        projectRegistry: this.projectRegistry,
+        sessionLogger: this.sessionLogger,
       },
       msg,
     );

--- a/packages/server/src/server/worktree-session.test.ts
+++ b/packages/server/src/server/worktree-session.test.ts
@@ -87,6 +87,23 @@ function createLogger(): Logger {
   return logger;
 }
 
+function createProjectForWorktreeList(options: {
+  projectId: string;
+  rootPath: string;
+  kind?: PersistedProjectRecord["kind"];
+  archivedAt?: string;
+}): PersistedProjectRecord {
+  return createPersistedProjectRecord({
+    projectId: options.projectId,
+    rootPath: options.rootPath,
+    kind: options.kind ?? "git",
+    displayName: path.basename(options.rootPath),
+    createdAt: "2026-04-12T00:00:00.000Z",
+    updatedAt: "2026-04-12T00:00:00.000Z",
+    archivedAt: options.archivedAt,
+  });
+}
+
 function createWorkflowForRequestTest(options: {
   paseoHome: string;
   createPaseoWorktree?: CreatePaseoWorktreeFn;
@@ -392,12 +409,15 @@ describe("handlePaseoWorktreeListRequest", () => {
         },
       ]),
     };
+    const projectRegistry = { list: vi.fn(async () => []) };
 
     await handlePaseoWorktreeListRequest(
       {
         emit: (message) => emitted.push(message),
         paseoHome: "/tmp/paseo-home",
         workspaceGitService: workspaceGitService as unknown as WorkspaceGitService,
+        projectRegistry,
+        sessionLogger: createLogger(),
       },
       {
         type: "paseo_worktree_list_request",
@@ -408,6 +428,7 @@ describe("handlePaseoWorktreeListRequest", () => {
 
     expect(workspaceGitService.listWorktrees).toHaveBeenCalledTimes(1);
     expect(workspaceGitService.listWorktrees).toHaveBeenCalledWith("/tmp/repo");
+    expect(projectRegistry.list).not.toHaveBeenCalled();
     expect(emitted).toContainEqual({
       type: "paseo_worktree_list_response",
       payload: {
@@ -421,6 +442,237 @@ describe("handlePaseoWorktreeListRequest", () => {
         ],
         error: null,
         requestId: "request-worktrees",
+      },
+    });
+  });
+
+  test("prefers repoRoot when both explicit selectors are supplied", async () => {
+    const emitted: SessionOutboundMessage[] = [];
+    const workspaceGitService = {
+      listWorktrees: vi.fn().mockResolvedValue([]),
+    };
+    const projectRegistry = { list: vi.fn(async () => []) };
+
+    await handlePaseoWorktreeListRequest(
+      {
+        emit: (message) => emitted.push(message),
+        workspaceGitService: workspaceGitService as unknown as WorkspaceGitService,
+        projectRegistry,
+        sessionLogger: createLogger(),
+      },
+      {
+        type: "paseo_worktree_list_request",
+        cwd: "/tmp/cwd-repository",
+        repoRoot: "/tmp/selected-repository",
+        allRegisteredProjects: true,
+        requestId: "request-selected-worktrees",
+      },
+    );
+
+    expect(workspaceGitService.listWorktrees).toHaveBeenCalledWith("/tmp/selected-repository");
+    expect(projectRegistry.list).not.toHaveBeenCalled();
+    expect(emitted).toContainEqual({
+      type: "paseo_worktree_list_response",
+      payload: {
+        worktrees: [],
+        error: null,
+        requestId: "request-selected-worktrees",
+      },
+    });
+  });
+
+  test("rejects an unscoped request that omits explicit global inventory", async () => {
+    const emitted: SessionOutboundMessage[] = [];
+    const workspaceGitService = {
+      listWorktrees: vi.fn(async () => []),
+      resolveRepoRoot: vi.fn(async () => "/tmp/repo"),
+    };
+    const projectRegistry = { list: vi.fn(async () => []) };
+
+    await handlePaseoWorktreeListRequest(
+      {
+        emit: (message) => emitted.push(message),
+        workspaceGitService: workspaceGitService as unknown as WorkspaceGitService,
+        projectRegistry,
+        sessionLogger: createLogger(),
+      },
+      {
+        type: "paseo_worktree_list_request",
+        requestId: "request-legacy-unscoped",
+      },
+    );
+
+    expect(projectRegistry.list).not.toHaveBeenCalled();
+    expect(workspaceGitService.resolveRepoRoot).not.toHaveBeenCalled();
+    expect(workspaceGitService.listWorktrees).not.toHaveBeenCalled();
+    expect(emitted).toEqual([
+      {
+        type: "paseo_worktree_list_response",
+        payload: {
+          worktrees: [],
+          error: { code: "UNKNOWN", message: "cwd or repoRoot is required" },
+          requestId: "request-legacy-unscoped",
+        },
+      },
+    ]);
+  });
+
+  test("lists registered project worktrees when the process cwd is outside Git", async () => {
+    const daemonCwd = realpathSync.native(
+      mkdtempSync(path.join(tmpdir(), "worktree-list-daemon-cwd-")),
+    );
+    const repoDir = path.join(daemonCwd, "registered-repo");
+    const managedWorktree = path.join(daemonCwd, "managed-worktree");
+    const originalCwd = process.cwd();
+    const emitted: SessionOutboundMessage[] = [];
+    const workspaceGitService = {
+      resolveRepoRoot: vi.fn(async () => repoDir),
+      listWorktrees: vi.fn(async () => [
+        {
+          path: managedWorktree,
+          createdAt: "2026-04-12T00:00:00.000Z",
+          branchName: "feature",
+          head: "abc123",
+        },
+      ]),
+    };
+    const project = createProjectForWorktreeList({
+      projectId: "prj-worktree-list",
+      rootPath: repoDir,
+    });
+
+    try {
+      process.chdir(daemonCwd);
+      await handlePaseoWorktreeListRequest(
+        {
+          emit: (message) => emitted.push(message),
+          paseoHome: path.join(daemonCwd, ".paseo"),
+          workspaceGitService: workspaceGitService as unknown as WorkspaceGitService,
+          projectRegistry: { list: async () => [project] },
+          sessionLogger: createLogger(),
+        },
+        {
+          type: "paseo_worktree_list_request",
+          allRegisteredProjects: true,
+          requestId: "request-all-worktrees",
+        },
+      );
+
+      expect(workspaceGitService.resolveRepoRoot).toHaveBeenCalledWith(repoDir);
+      expect(workspaceGitService.listWorktrees).toHaveBeenCalledWith(repoDir);
+      expect(emitted).toContainEqual({
+        type: "paseo_worktree_list_response",
+        payload: {
+          worktrees: [
+            {
+              worktreePath: managedWorktree,
+              createdAt: "2026-04-12T00:00:00.000Z",
+              branchName: "feature",
+              head: "abc123",
+            },
+          ],
+          error: null,
+          requestId: "request-all-worktrees",
+        },
+      });
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(daemonCwd, { recursive: true, force: true });
+    }
+  });
+
+  test("deduplicates repositories and isolates unavailable registered projects", async () => {
+    const emitted: SessionOutboundMessage[] = [];
+    const logger = createLogger();
+    const projects = [
+      createProjectForWorktreeList({
+        projectId: "prj-repo-a",
+        rootPath: "/tmp/repo-a",
+      }),
+      createProjectForWorktreeList({
+        projectId: "prj-repo-a-package",
+        rootPath: "/tmp/repo-a/packages/app",
+      }),
+      createProjectForWorktreeList({
+        projectId: "prj-repo-b",
+        rootPath: "/tmp/repo-b",
+      }),
+      createProjectForWorktreeList({
+        projectId: "prj-stale",
+        rootPath: "/tmp/stale-repo",
+      }),
+      createProjectForWorktreeList({
+        projectId: "prj-archived",
+        rootPath: "/tmp/archived-repo",
+        archivedAt: "2026-04-13T00:00:00.000Z",
+      }),
+      createProjectForWorktreeList({
+        projectId: "prj-directory",
+        rootPath: "/tmp/directory",
+        kind: "non_git",
+      }),
+    ];
+    const workspaceGitService = {
+      resolveRepoRoot: vi.fn(async (projectRoot: string) => {
+        if (projectRoot === "/tmp/stale-repo") {
+          throw new Error("repository is unavailable");
+        }
+        return projectRoot.startsWith("/tmp/repo-a") ? "/tmp/repo-a" : projectRoot;
+      }),
+      listWorktrees: vi.fn(async (repoRoot: string) => {
+        if (repoRoot === "/tmp/repo-b") {
+          throw new Error("worktree inventory failed");
+        }
+        return [
+          {
+            path: "/tmp/paseo-home/worktrees/repo-a/feature",
+            createdAt: "2026-04-12T00:00:00.000Z",
+            branchName: "feature",
+            head: "abc123",
+          },
+        ];
+      }),
+    };
+
+    await handlePaseoWorktreeListRequest(
+      {
+        emit: (message) => emitted.push(message),
+        workspaceGitService: workspaceGitService as unknown as WorkspaceGitService,
+        projectRegistry: { list: async () => projects },
+        sessionLogger: logger,
+      },
+      {
+        type: "paseo_worktree_list_request",
+        allRegisteredProjects: true,
+        requestId: "request-available-worktrees",
+      },
+    );
+
+    expect(workspaceGitService.resolveRepoRoot.mock.calls).toEqual([
+      ["/tmp/repo-a"],
+      ["/tmp/repo-a/packages/app"],
+      ["/tmp/repo-b"],
+      ["/tmp/stale-repo"],
+    ]);
+    expect(workspaceGitService.listWorktrees.mock.calls).toEqual([
+      ["/tmp/repo-a"],
+      ["/tmp/repo-b"],
+    ]);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(emitted).toContainEqual({
+      type: "paseo_worktree_list_response",
+      payload: {
+        worktrees: [
+          {
+            worktreePath: "/tmp/paseo-home/worktrees/repo-a/feature",
+            createdAt: "2026-04-12T00:00:00.000Z",
+            branchName: "feature",
+            head: "abc123",
+          },
+        ],
+        repositoryErrors: 2,
+        error: null,
+        requestId: "request-available-worktrees",
       },
     });
   });
@@ -1891,6 +2143,121 @@ describe("handlePaseoWorktreeArchiveRequest worktree scope", () => {
         error: null,
       },
     });
+  });
+
+  test("rejects an identity from a primed cache after its branch moves to another path", async () => {
+    const { tempDir, repoDir } = createGitRepo();
+    cleanupPaths.push(tempDir);
+
+    const paseoHome = path.join(tempDir, ".paseo");
+    const created = await createLegacyWorktreeForTest({
+      branchName: "cached-archive-name",
+      cwd: repoDir,
+      baseBranch: "main",
+      worktreeSlug: "stable-archive-path",
+      runSetup: false,
+      paseoHome,
+    });
+    const workspaceGitService = new WorkspaceGitServiceImpl({
+      logger: createLogger(),
+      paseoHome,
+      deps: { forgeOverrides: { github: createGitHubServiceStub() } },
+    });
+    const archiveWorkspaceRecord = vi.fn(async () => {});
+    const archiveAgent = vi.fn(async () => ({ archivedAt: new Date().toISOString() }));
+    const emitted: SessionOutboundMessage[] = [];
+
+    try {
+      await expect(workspaceGitService.listWorktrees(repoDir)).resolves.toEqual([
+        expect.objectContaining({
+          path: created.worktreePath,
+          branchName: "cached-archive-name",
+        }),
+      ]);
+      execFileSync("git", ["branch", "-m", "renamed-before-archive"], {
+        cwd: created.worktreePath,
+        stdio: "pipe",
+      });
+      const replacement = await createLegacyWorktreeForTest({
+        branchName: "cached-archive-name",
+        cwd: repoDir,
+        baseBranch: "main",
+        worktreeSlug: "replacement-archive-path",
+        runSetup: false,
+        paseoHome,
+      });
+      await expect(workspaceGitService.listWorktrees(repoDir)).resolves.toEqual([
+        expect.objectContaining({
+          path: created.worktreePath,
+          branchName: "cached-archive-name",
+        }),
+      ]);
+
+      await handlePaseoWorktreeArchiveRequest(
+        {
+          paseoHome,
+          github: createGitHubServiceStub(),
+          workspaceGitService,
+          agentManager: {
+            listAgents: () => [],
+            archiveAgent,
+            archiveSnapshot: vi.fn(async () => {
+              throw new Error("not expected for empty agent list");
+            }),
+          },
+          agentStorage: createAgentStorageStub(),
+          findWorkspaceIdForCwd: vi.fn(async () => "ws-cached-archive"),
+          listActiveWorkspaces: vi.fn(async () => [
+            {
+              workspaceId: "ws-cached-archive",
+              cwd: created.worktreePath,
+              kind: "worktree" as const,
+            },
+          ]),
+          archiveWorkspaceRecord,
+          emit: (message) => emitted.push(message),
+          emitWorkspaceUpdatesForWorkspaceIds: vi.fn(async () => {}),
+          markWorkspaceArchiving: vi.fn(),
+          clearWorkspaceArchiving: vi.fn(),
+          killTerminalsForWorkspace: vi.fn(async () => {}),
+          sessionLogger: createLogger(),
+        },
+        {
+          type: "paseo_worktree_archive_request",
+          requestId: "req-stale-cached-identity",
+          repoRoot: repoDir,
+          expectedWorktreeIdentity: "cached-archive-name",
+          expectedWorktreePath: created.worktreePath,
+          scope: "worktree",
+        },
+      );
+
+      expect(archiveWorkspaceRecord).not.toHaveBeenCalled();
+      expect(archiveAgent).not.toHaveBeenCalled();
+      expect(existsSync(created.worktreePath)).toBe(true);
+      expect(existsSync(replacement.worktreePath)).toBe(true);
+      expect(
+        execFileSync("git", ["branch", "--show-current"], {
+          cwd: created.worktreePath,
+          stdio: "pipe",
+        })
+          .toString()
+          .trim(),
+      ).toBe("renamed-before-archive");
+      expect(
+        emitted.find((message) => message.type === "paseo_worktree_archive_response"),
+      ).toMatchObject({
+        payload: {
+          success: false,
+          removedAgents: [],
+          error: {
+            message: "Paseo worktree identity cached-archive-name now matches a different path",
+          },
+        },
+      });
+    } finally {
+      workspaceGitService.dispose();
+    }
   });
 
   test("default scope archives a single workspace record and removes the directory on last reference", async () => {

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -11,8 +11,8 @@ import {
   type WorkspaceSetupSnapshot,
   type WorkspaceDescriptorPayload,
 } from "./messages.js";
-import type { PersistedWorkspaceRecord } from "./workspace-registry.js";
-import type { WorkspaceGitService } from "./workspace-git-service.js";
+import type { PersistedWorkspaceRecord, ProjectRegistry } from "./workspace-registry.js";
+import type { WorkspaceGitService, WorkspaceGitWorktreeInfo } from "./workspace-git-service.js";
 import {
   runAsyncWorktreeBootstrap,
   applyWorktreeSetupProgressEvent,
@@ -24,7 +24,7 @@ import type { TerminalManager } from "../terminal/terminal-manager.js";
 import type { ServiceProxySubsystem } from "./service-proxy.js";
 import type { WorkspaceScriptRuntimeStore } from "./workspace-script-runtime-store.js";
 import type { CheckoutExistingBranchResult } from "../utils/checkout-git.js";
-import { expandTilde } from "../utils/path.js";
+import { expandTilde, normalizePathForIdentity } from "../utils/path.js";
 import {
   getWorktreeSetupCommands,
   resolveWorktreeRuntimeEnv,
@@ -399,12 +399,14 @@ export async function handlePaseoWorktreeListRequest(
     emit: EmitSessionMessage;
     paseoHome?: string;
     workspaceGitService: WorkspaceGitService;
+    projectRegistry: Pick<ProjectRegistry, "list">;
+    sessionLogger: Logger;
   },
   msg: Extract<SessionInboundMessage, { type: "paseo_worktree_list_request" }>,
 ): Promise<void> {
   const { requestId } = msg;
   const cwd = msg.repoRoot ?? msg.cwd;
-  if (!cwd) {
+  if (!cwd && msg.allRegisteredProjects !== true) {
     dependencies.emit({
       type: "paseo_worktree_list_response",
       payload: {
@@ -417,10 +419,62 @@ export async function handlePaseoWorktreeListRequest(
   }
 
   try {
-    const worktrees = await listPaseoWorktreesCommand(
-      { workspaceGitService: dependencies.workspaceGitService },
-      { cwd },
-    );
+    let repositoryErrors = 0;
+    let worktrees: WorkspaceGitWorktreeInfo[];
+    if (cwd) {
+      worktrees = await listPaseoWorktreesCommand(
+        { workspaceGitService: dependencies.workspaceGitService },
+        { cwd },
+      );
+    } else {
+      const projects = (await dependencies.projectRegistry.list()).filter(
+        (project) => !project.archivedAt && project.kind === "git",
+      );
+      const resolvedRepositories = await Promise.all(
+        projects.map(async (project) => {
+          try {
+            return await dependencies.workspaceGitService.resolveRepoRoot(project.rootPath);
+          } catch (error) {
+            repositoryErrors += 1;
+            dependencies.sessionLogger.warn(
+              { err: error, projectId: project.projectId, projectRoot: project.rootPath },
+              "Skipping project while listing Paseo worktrees",
+            );
+            return null;
+          }
+        }),
+      );
+      const repositoryRoots = new Map<string, string>();
+      for (const repoRoot of resolvedRepositories) {
+        if (repoRoot) {
+          repositoryRoots.set(normalizePathForIdentity(repoRoot), repoRoot);
+        }
+      }
+
+      const worktreesByRepository = await Promise.all(
+        Array.from(repositoryRoots.values()).map(async (repoRoot) => {
+          try {
+            return await listPaseoWorktreesCommand(
+              { workspaceGitService: dependencies.workspaceGitService },
+              { cwd: repoRoot },
+            );
+          } catch (error) {
+            repositoryErrors += 1;
+            dependencies.sessionLogger.warn(
+              { err: error, repoRoot },
+              "Skipping repository while listing Paseo worktrees",
+            );
+            return [];
+          }
+        }),
+      );
+      const worktreesByPath = new Map(
+        worktreesByRepository
+          .flat()
+          .map((worktree) => [normalizePathForIdentity(worktree.path), worktree] as const),
+      );
+      worktrees = Array.from(worktreesByPath.values());
+    }
     dependencies.emit({
       type: "paseo_worktree_list_response",
       payload: {
@@ -430,6 +484,7 @@ export async function handlePaseoWorktreeListRequest(
           branchName: entry.branchName ?? null,
           head: entry.head ?? null,
         })),
+        ...(repositoryErrors > 0 ? { repositoryErrors } : {}),
         error: null,
         requestId,
       },
@@ -465,6 +520,8 @@ export async function handlePaseoWorktreeArchiveRequest(
       worktreePath: msg.worktreePath,
       repoRoot: msg.repoRoot,
       branchName: msg.branchName,
+      expectedWorktreeIdentity: msg.expectedWorktreeIdentity,
+      expectedWorktreePath: msg.expectedWorktreePath,
       workspaceId: msg.workspaceId,
       scope: msg.scope,
     });

--- a/packages/server/src/server/worktree/commands.ts
+++ b/packages/server/src/server/worktree/commands.ts
@@ -1,5 +1,6 @@
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
+import { areEquivalentPaths } from "../../utils/path.js";
 import { getPaseoWorktreesRoot, isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
 import {
   archiveByScope,
@@ -102,6 +103,8 @@ export interface ArchiveCommandInput {
   worktreePath?: string;
   worktreeSlug?: string;
   branchName?: string;
+  expectedWorktreeIdentity?: string;
+  expectedWorktreePath?: string;
   workspaceId?: string;
   scope?: ArchiveScope["kind"];
 }
@@ -180,6 +183,19 @@ async function resolveArchiveTarget(
   input: ArchiveCommandInput,
 ): Promise<string> {
   const repoRoot = input.repoRoot ?? null;
+  if (input.expectedWorktreeIdentity || input.expectedWorktreePath) {
+    if (!repoRoot || !input.expectedWorktreeIdentity || !input.expectedWorktreePath) {
+      throw new Error(
+        "repoRoot, expectedWorktreeIdentity, and expectedWorktreePath must be supplied together",
+      );
+    }
+    return resolveFreshArchiveIdentity(dependencies, {
+      repoRoot,
+      identity: input.expectedWorktreeIdentity,
+      expectedPath: input.expectedWorktreePath,
+    });
+  }
+
   if (input.worktreePath) {
     return input.worktreePath;
   }
@@ -192,15 +208,47 @@ async function resolveArchiveTarget(
   }
 
   if (repoRoot && input.branchName) {
-    const worktrees = await dependencies.workspaceGitService.listWorktrees(repoRoot);
-    const match = worktrees.find((entry) => entry.branchName === input.branchName);
-    if (!match) {
+    const worktrees = await dependencies.workspaceGitService.listWorktrees(repoRoot, {
+      force: true,
+      reason: "archive-worktree-branch",
+    });
+    const matches = worktrees.filter((entry) => entry.branchName === input.branchName);
+    if (matches.length === 0) {
       throw new Error(`Paseo worktree not found for branch ${input.branchName}`);
     }
-    return match.path;
+    if (matches.length > 1) {
+      throw new Error(`Multiple Paseo worktrees match branch ${input.branchName}`);
+    }
+    return matches[0]!.path;
   }
 
   throw new Error("worktreePath, worktreeSlug, or repoRoot+branchName is required");
+}
+
+async function resolveFreshArchiveIdentity(
+  dependencies: ArchiveCommandDependencies,
+  input: { repoRoot: string; identity: string; expectedPath: string },
+): Promise<string> {
+  const worktrees = await dependencies.workspaceGitService.listWorktrees(input.repoRoot, {
+    force: true,
+    reason: "archive-worktree-identity",
+  });
+  const matches = worktrees.filter(
+    (entry) => basename(entry.path) === input.identity || entry.branchName === input.identity,
+  );
+
+  if (matches.length === 0) {
+    throw new Error(`Paseo worktree no longer matches identity ${input.identity}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`Multiple Paseo worktrees match identity ${input.identity}`);
+  }
+
+  const match = matches[0]!;
+  if (!areEquivalentPaths(match.path, input.expectedPath)) {
+    throw new Error(`Paseo worktree identity ${input.identity} now matches a different path`);
+  }
+  return match.path;
 }
 
 async function resolveWorktreeSlugPath(


### PR DESCRIPTION
## Summary
- resolve global worktree inventory from registered Git projects only when the request explicitly sends `allRegisteredProjects: true`
- preserve the legacy error for unscoped requests that omit the global flag
- report only observed registered-project failures through the optional positive-only `repositoryErrors` field; absence does not claim complete inventory
- fail `paseo worktree ls` with `WORKTREE_LIST_PARTIAL` instead of returning known-partial output
- label text, JSON, and YAML output as current registered, non-archived Git projects only; archived or removed projects remain excluded, so the result does not claim to contain every managed worktree
- require `--cwd` or `--repo-root` before `paseo worktree archive <name>` connects to the daemon or resolves a destructive target
- keep the CLI's scoped preflight for useful not-found and ambiguity errors, but do not send its cached path as destructive authority
- make the daemon force a fresh scoped Git read, require exactly one identity match, verify that match still has the expected path, and retain Paseo-owned-path validation before mutation

## Regression
Repository A can expose a matching worktree while repository B cannot be inspected. The daemon returns the observed worktrees with `repositoryErrors`; `paseo worktree ls` rejects that known-partial result, and archive cannot use global inventory because it requires an explicit repository selector before any RPC.

The archive regression primes the real 15-second worktree cache, renames a branch in place, reuses the old branch name at another path, and confirms an ordinary read remains stale. Archive then forces a fresh read and rejects the rebound identity because its path no longer matches. Neither worktree, workspace records, nor agents are archived.

## Protocol compatibility
`allRegisteredProjects` is an optional literal request field, `repositoryErrors` is an optional response field, and the expected archive identity/path fields are optional.

- old CLI + old daemon: the unchanged unscoped list request retains the old `cwd or repoRoot is required` error
- old CLI + new daemon: omission of `allRegisteredProjects` retains that explicit error
- new CLI + old daemon: the old request schema strips the unknown global-list flag, then the old daemon returns the same explicit error
- new CLI + new daemon: `allRegisteredProjects: true` enables registered-project inventory
- new archive CLI + old daemon: the old schema strips the expected identity/path fields, receives no `worktreePath`, and fails instead of mutating
- new archive CLI + new daemon: the daemon resolves the identity from a forced fresh scoped list and verifies the expected path
- older scoped clients that send `worktreePath` retain their existing behavior

Older clients ignore additive response fields, and the daemon omits `repositoryErrors` unless it observed at least one repository failure.

## Verification
- `npm run build:client`
- `npx vitest run packages/protocol/src/messages.test.ts packages/client/src/daemon-client.test.ts packages/cli/src/commands/worktree/archive.test.ts packages/cli/src/commands/worktree/ls.test.ts packages/server/src/server/worktree-session.test.ts --bail=1` - 5 files, 175 passed
- `npm run typecheck`
- `npm run lint` - 0 warnings, 0 errors across 3148 files
- `npm run format`
- `npm run format:check` - 3349 files matched
- `git diff --check`
- pre-commit format, lint, and typecheck hooks

Reviewed repair commit: `6ce5d1286cfaffbb59411843cfb63d0b647d4760`.
