### PR TITLE
Cache repository-common Git facts

### DIFF
--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -105,6 +105,35 @@ function createDeferredRunner(): TestRunner {
   };
 }
 
+function createQueuedDeferredRunner(): TestRunner & {
+  resolveCall: (index: number, stdout: string) => void;
+} {
+  const calls: RunnerCall[] = [];
+  const pending = new Map<number, (stdout: string) => void>();
+
+  return {
+    calls,
+    runner: (args: string[], options: GitHubCommandRunnerOptions) => {
+      const index = calls.length;
+      calls.push({ args, cwd: options.cwd, envOverlay: options.envOverlay });
+      return new Promise((resolve) => {
+        pending.set(index, (stdout: string) => {
+          pending.delete(index);
+          resolve({ stdout, stderr: "" });
+        });
+      });
+    },
+    resolveNext: () => {},
+    resolveCall: (index: number, stdout: string) => {
+      const resolve = pending.get(index);
+      if (!resolve) {
+        throw new Error(`Runner call ${index} is not waiting for resolution.`);
+      }
+      resolve(stdout);
+    },
+  };
+}
+
 interface FakeGitHubCliFixture {
   cwd: string;
   logPath: string;
@@ -824,6 +853,59 @@ describe("ForgeService", () => {
     expect(currentPullRequestStatusCalls(runner.calls)).toHaveLength(1);
 
     subscription?.unsubscribe();
+    service.dispose?.();
+  });
+
+  it("does not deliver an old same-key poll into a newly retained target", async () => {
+    const runner = createQueuedDeferredRunner();
+    const service = createGitHubService({
+      ttlMs: 30_000,
+      runner: runner.runner,
+      resolveGhPath: async () => "/usr/bin/gh",
+      resolveRepoHost: async () => null,
+    });
+    const oldStatus = vi.fn();
+    const freshStatus = vi.fn();
+
+    const oldSubscription = service.retainCurrentPullRequestStatusPoll?.({
+      cwd: "/repo",
+      headRef: "feature/fork",
+      onStatus: oldStatus,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runner.calls).toHaveLength(1);
+
+    oldSubscription?.unsubscribe();
+    const freshSubscription = service.retainCurrentPullRequestStatusPoll?.({
+      cwd: "/repo",
+      headRef: "feature/fork",
+      onStatus: freshStatus,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A new retained lifecycle must not join the old lifecycle's same-key read.
+    expect(runner.calls).toHaveLength(2);
+
+    runner.resolveCall(1, currentPullRequestJson({ title: "Fresh generation PR" }));
+    await vi.waitFor(() => expect(runner.calls).toHaveLength(3));
+    runner.resolveCall(2, currentPullRequestGithubFactsJson());
+    await vi.waitFor(() => expect(freshStatus).toHaveBeenCalledTimes(1));
+    expect(freshStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: "Fresh generation PR" }),
+    );
+
+    runner.resolveCall(0, currentPullRequestJson({ title: "Stale generation PR" }));
+    await vi.waitFor(() => expect(runner.calls).toHaveLength(4));
+    runner.resolveCall(3, currentPullRequestGithubFactsJson());
+    await flushMicrotasks();
+
+    expect(oldStatus).not.toHaveBeenCalled();
+    expect(freshStatus).toHaveBeenCalledTimes(1);
+    expect(freshStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: "Fresh generation PR" }),
+    );
+
+    freshSubscription?.unsubscribe();
     service.dispose?.();
   });
 

--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -105,31 +105,50 @@ function createDeferredRunner(): TestRunner {
   };
 }
 
+interface QueuedDeferredRunnerCall {
+  resolve: (stdout: string) => void;
+  reject: (error: Error) => void;
+}
+
 function createQueuedDeferredRunner(): TestRunner & {
   resolveCall: (index: number, stdout: string) => void;
+  rejectCall: (index: number, error: Error) => void;
 } {
   const calls: RunnerCall[] = [];
-  const pending = new Map<number, (stdout: string) => void>();
+  const pending = new Map<number, QueuedDeferredRunnerCall>();
 
   return {
     calls,
     runner: (args: string[], options: GitHubCommandRunnerOptions) => {
       const index = calls.length;
       calls.push({ args, cwd: options.cwd, envOverlay: options.envOverlay });
-      return new Promise((resolve) => {
-        pending.set(index, (stdout: string) => {
-          pending.delete(index);
-          resolve({ stdout, stderr: "" });
+      return new Promise((resolve, reject) => {
+        pending.set(index, {
+          resolve: (stdout: string) => {
+            pending.delete(index);
+            resolve({ stdout, stderr: "" });
+          },
+          reject: (error: Error) => {
+            pending.delete(index);
+            reject(error);
+          },
         });
       });
     },
     resolveNext: () => {},
     resolveCall: (index: number, stdout: string) => {
-      const resolve = pending.get(index);
-      if (!resolve) {
+      const call = pending.get(index);
+      if (!call) {
         throw new Error(`Runner call ${index} is not waiting for resolution.`);
       }
-      resolve(stdout);
+      call.resolve(stdout);
+    },
+    rejectCall: (index: number, error: Error) => {
+      const call = pending.get(index);
+      if (!call) {
+        throw new Error(`Runner call ${index} is not waiting for rejection.`);
+      }
+      call.reject(error);
     },
   };
 }
@@ -904,6 +923,51 @@ describe("ForgeService", () => {
     expect(freshStatus).toHaveBeenLastCalledWith(
       expect.objectContaining({ title: "Fresh generation PR" }),
     );
+
+    freshSubscription?.unsubscribe();
+    service.dispose?.();
+  });
+
+  it("does not deliver an old same-key poll error into a newly retained target", async () => {
+    const runner = createQueuedDeferredRunner();
+    const service = createGitHubService({
+      ttlMs: 30_000,
+      runner: runner.runner,
+      resolveGhPath: async () => "/usr/bin/gh",
+      resolveRepoHost: async () => null,
+    });
+    const oldError = vi.fn();
+    const freshError = vi.fn();
+    const freshStatus = vi.fn();
+
+    const oldSubscription = service.retainCurrentPullRequestStatusPoll?.({
+      cwd: "/repo",
+      headRef: "feature/fork",
+      onError: oldError,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runner.calls).toHaveLength(1);
+
+    oldSubscription?.unsubscribe();
+    const freshSubscription = service.retainCurrentPullRequestStatusPoll?.({
+      cwd: "/repo",
+      headRef: "feature/fork",
+      onStatus: freshStatus,
+      onError: freshError,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runner.calls).toHaveLength(2);
+
+    runner.rejectCall(0, new Error("stale poll failed"));
+    await flushMicrotasks();
+
+    runner.resolveCall(1, currentPullRequestJson({ title: "Fresh generation PR" }));
+    await vi.waitFor(() => expect(runner.calls).toHaveLength(3));
+    runner.resolveCall(2, currentPullRequestGithubFactsJson());
+    await vi.waitFor(() => expect(freshStatus).toHaveBeenCalledTimes(1));
+
+    expect(oldError).not.toHaveBeenCalled();
+    expect(freshError).not.toHaveBeenCalled();
 
     freshSubscription?.unsubscribe();
     service.dispose?.();

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -892,9 +892,10 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
     headRepositoryOwner?: string;
     status: CurrentPullRequestStatus | null;
     notify: boolean;
+    expectedTarget: GitHubPollTarget | null;
   }): void {
     const target = pollTargets.get(getPollTargetKey(update));
-    if (!target) {
+    if (!target || target !== update.expectedTarget) {
       return;
     }
 
@@ -959,6 +960,12 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
     target.retainCount = 0;
     target.callbacks.clear();
     target.errorCallbacks.clear();
+  }
+
+  function expireGitHubPollTargetRead(target: GitHubPollTarget): void {
+    const key = getPollTargetKey(target);
+    cache.delete(key);
+    inFlight.delete(key);
   }
 
   api = {
@@ -1097,6 +1104,7 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
     },
 
     getCurrentPullRequestStatus(input) {
+      const expectedPollTarget = pollTargets.get(getPollTargetKey(input)) ?? null;
       return cached({
         cwd: input.cwd,
         method: "getCurrentPullRequestStatus",
@@ -1124,6 +1132,7 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
           headRepositoryOwner: input.headRepositoryOwner,
           status,
           notify: input.reason === "self-heal-github",
+          expectedTarget: expectedPollTarget,
         });
         return status;
       });
@@ -1555,6 +1564,10 @@ export function createGitHubService(options: CreateGitHubServiceOptions = {}): G
           if (target.retainCount > 0) {
             return;
           }
+          // A replacement retained lifecycle with the same textual target must
+          // start its own read. The old request may still resolve, but its
+          // captured target identity prevents it from notifying the replacement.
+          expireGitHubPollTargetRead(target);
           closeGitHubPollTarget(target);
           pollTargets.delete(key);
         },


### PR DESCRIPTION
## Summary
- cache repository-common default-branch, ref-existence, and main-repository-root reads by normalized physical `gitCommonDir`
- keep effective Git config, current branch, status, dirty state, and other worktree-specific reads local to each checkout
- bound ready values to 128 repositories, 64 facts per repository, and a 60-second freshness window while keeping in-flight single-flight state separate
- invalidate repository facts at existing mutation/refresh boundaries and when the final repository observer closes
- fail closed when an external-state event arrives before its cwd can be mapped: invalidate all repository facts, fence older loads, and detach that cwd's base and uncommitted diff reads
- preserve repository-scoped invalidation for mapped cwds
- pass repository identity and cache context through base-mode checkout-diff default-branch and ref-existence reads so sibling worktrees share one load

## Safety
- concurrent sibling reads share one repository-common load
- invalidated in-flight loads cannot repopulate the ready cache or replace a newer value
- a newly observed sibling cannot join an older repository-fact or checkout-diff load after its external-state event
- direct checkout reads expire even when no workspace observation target exists
- removing the final listener prevents repository facts from surviving observer shutdown
- cache keys use physical repository identity and fall back to resolved absolute paths when realpath lookup is unavailable
- mapped invalidation retains the repository-local fast path; only unknown ownership uses the global fail-closed fallback

## Verification
- `workspace-git-service.primitive.test.ts`: 65 passed
- `workspace-git-service.observation.test.ts`: 16 passed
- `workspace-git-service.test.ts`: 20 passed
- `checkout-diff-manager.test.ts`: 12 passed
- `checkout-git.test.ts`: passed
- exact unmapped-sibling regression: failed before the repair and passed after it
- `npm run build:server`: passed
- server and root workspace typechecks: passed
- root `npm run lint`: 0 warnings and 0 errors
- root `npm run format:check`: passed
- `git diff --check`: passed
- pre-commit hook: formatting, lint, and full workspace typecheck passed

## Base
Merged upstream `main` commit `777fe968f5bab50f63f25a61188482f6a15789fc` (tree `4c06280b94ecab9e2d98c4c5326ce8bdc3095928`) without conflicts.

Replaces #2747 with a smaller implementation based on the current upstream observation and refresh architecture.
