### PR TITLE
fix(server): fence workspace release against agent creation

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6433,6 +6433,96 @@ test("archiveAgent persists archivedAt and updatedAt before emitting closed stat
   expect(lifecycles.slice(-2)).toEqual(["idle", "closed"]);
 });
 
+test("does not release a workspace while another agent is registering", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-release-pending-registration-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+  const workspaceId = "wks_pending_registration";
+  const finished = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000140",
+    { workspaceId },
+  );
+  await manager.archiveAgent(finished.id);
+
+  const heldClient = new HeldAgentCreationClient();
+  manager.registerClient("codex", heldClient);
+  const rivalCreation = manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000141",
+    { workspaceId },
+  );
+  await heldClient.waitForCreationToStart();
+
+  let released = false;
+  try {
+    await expect(
+      manager.releaseWorkspaceIfUnowned({
+        workspaceId,
+        finishedAgentId: finished.id,
+        release: async () => {
+          released = true;
+        },
+      }),
+    ).resolves.toBe(false);
+  } finally {
+    heldClient.finishCreating();
+  }
+
+  const rival = await rivalCreation;
+  expect({ released, rivalWorkspaceId: rival.workspaceId }).toEqual({
+    released: false,
+    rivalWorkspaceId: workspaceId,
+  });
+  await manager.closeAgent(rival.id);
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+test("rejects a workspace registration that starts during release", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-registration-during-release-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+  const workspaceId = "wks_registration_during_release";
+  const finished = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000142",
+    { workspaceId },
+  );
+  await manager.archiveAgent(finished.id);
+
+  const releaseStarted = deferred<void>();
+  const releaseAllowed = deferred<void>();
+  const release = manager.releaseWorkspaceIfUnowned({
+    workspaceId,
+    finishedAgentId: finished.id,
+    release: async () => {
+      releaseStarted.resolve();
+      await releaseAllowed.promise;
+    },
+  });
+  await releaseStarted.promise;
+
+  const rivalCreation = manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000143",
+    { workspaceId },
+  );
+  releaseAllowed.resolve();
+
+  await expect(rivalCreation).rejects.toThrow(`Workspace ${workspaceId} is being released`);
+  await expect(release).resolves.toBe(true);
+  expect(manager.listAgents()).toEqual([]);
+  rmSync(workdir, { recursive: true, force: true });
+});
+
 test("fires onAgentArchived for archived parent and cascaded children", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-archived-hook-cascade-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -267,6 +267,12 @@ export interface AgentManagerOptions {
   logger: Logger;
 }
 
+export interface ReleaseWorkspaceIfUnownedOptions {
+  workspaceId: string;
+  finishedAgentId: string;
+  release: () => Promise<void>;
+}
+
 export interface WaitForAgentOptions {
   signal?: AbortSignal;
   waitForActive?: boolean;
@@ -618,6 +624,8 @@ export class AgentManager {
   private readonly backgroundTasks = new Set<Promise<void>>();
   private readonly agentRegistrationTasks = new Set<Promise<void>>();
   private readonly inFlightAgentCloses = new Map<string, Promise<void>>();
+  private readonly workspaceAgentRegistrations = new Map<string, number>();
+  private readonly releasingWorkspaces = new Set<string>();
   private readonly agentStreamCoalescer: AgentStreamCoalescer;
   private mcpBaseUrl: string | null;
   private readonly mcpAuthToken: string | null;
@@ -1060,7 +1068,11 @@ export class AgentManager {
     agentId: string | undefined,
     options: CreateAgentOptions,
   ): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(this.createAgentInternal(config, agentId, options));
+    return this.trackAgentRegistrationOperation(
+      this.trackWorkspaceAgentRegistration(options.workspaceId, () =>
+        this.createAgentInternal(config, agentId, options),
+      ),
+    );
   }
 
   private async createAgentInternal(
@@ -1123,7 +1135,9 @@ export class AgentManager {
     resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      this.trackWorkspaceAgentRegistration(options?.workspaceId, () =>
+        this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      ),
     );
   }
 
@@ -1186,7 +1200,11 @@ export class AgentManager {
     workspaceId: string;
     labels?: Record<string, string>;
   }): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(this.importProviderSessionInternal(input));
+    return this.trackAgentRegistrationOperation(
+      this.trackWorkspaceAgentRegistration(input.workspaceId, () =>
+        this.importProviderSessionInternal(input),
+      ),
+    );
   }
 
   private async importProviderSessionInternal(input: {
@@ -1499,6 +1517,40 @@ export class AgentManager {
     await this.cascadeArchiveChildren(agentId);
 
     return { archivedAt };
+  }
+
+  async releaseWorkspaceIfUnowned(options: ReleaseWorkspaceIfUnownedOptions): Promise<boolean> {
+    const { workspaceId, finishedAgentId } = options;
+    // Registration and release claim opposing state before their first await, so
+    // JavaScript run-to-completion makes this ownership handoff atomic.
+    if (
+      this.releasingWorkspaces.has(workspaceId) ||
+      (this.workspaceAgentRegistrations.get(workspaceId) ?? 0) > 0
+    ) {
+      return false;
+    }
+
+    this.releasingWorkspaces.add(workspaceId);
+    try {
+      if (this.hasLiveAgentInWorkspace(workspaceId)) {
+        return false;
+      }
+
+      const records = await this.requireRegistry().list();
+      const finishedRecord = records.find((record) => record.id === finishedAgentId);
+      if (
+        !finishedRecord?.archivedAt ||
+        finishedRecord.workspaceId !== workspaceId ||
+        records.some((record) => record.workspaceId === workspaceId && !record.archivedAt)
+      ) {
+        return false;
+      }
+
+      await options.release();
+      return true;
+    } finally {
+      this.releasingWorkspaces.delete(workspaceId);
+    }
   }
 
   // Children created via the MCP `create_agent` tool carry the parent-agent-id
@@ -4216,6 +4268,49 @@ export class AgentManager {
       return undefined;
     });
     return result;
+  }
+
+  private trackWorkspaceAgentRegistration<T>(
+    workspaceId: string | undefined,
+    register: () => Promise<T>,
+  ): Promise<T> {
+    if (!workspaceId) {
+      return register();
+    }
+    if (this.releasingWorkspaces.has(workspaceId)) {
+      return Promise.reject(new Error(`Workspace ${workspaceId} is being released`));
+    }
+
+    this.workspaceAgentRegistrations.set(
+      workspaceId,
+      (this.workspaceAgentRegistrations.get(workspaceId) ?? 0) + 1,
+    );
+    let registration: Promise<T>;
+    try {
+      registration = register();
+    } catch (error) {
+      this.finishWorkspaceAgentRegistration(workspaceId);
+      throw error;
+    }
+    return registration.finally(() => this.finishWorkspaceAgentRegistration(workspaceId));
+  }
+
+  private finishWorkspaceAgentRegistration(workspaceId: string): void {
+    const remaining = (this.workspaceAgentRegistrations.get(workspaceId) ?? 1) - 1;
+    if (remaining === 0) {
+      this.workspaceAgentRegistrations.delete(workspaceId);
+    } else {
+      this.workspaceAgentRegistrations.set(workspaceId, remaining);
+    }
+  }
+
+  private hasLiveAgentInWorkspace(workspaceId: string): boolean {
+    for (const agent of this.agents.values()) {
+      if (agent.workspaceId === workspaceId) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/packages/server/src/server/hub/daemon-executions.test.ts
+++ b/packages/server/src/server/hub/daemon-executions.test.ts
@@ -255,3 +255,41 @@ test("failed create never archives a reused worktree", async () => {
   });
   expect(await hub.worktreeState(worktreeCwd!)).toEqual({ exists: true, listed: true });
 });
+
+test("finishing an execution preserves a workspace being acquired by a rival", async () => {
+  const hub = await launchRelationship();
+  hub.beginOwnedCreate("first-create", "first-execution", {
+    worktree: { mode: "branch-off", newBranch: "shared-finish-worktree" },
+  });
+  const first = await hub.ownedCreateResult("first-create");
+  const worktreeCwd = first.payload.agent?.cwd;
+  const workspaceId = first.payload.agent?.workspaceId;
+  expect(worktreeCwd).toEqual(expect.any(String));
+  expect(workspaceId).toEqual(expect.any(String));
+
+  const priorProviderCreations = hub.providerCreations();
+  hub.holdAgentCreationAtCwd(worktreeCwd!);
+  hub.beginOwnedCreate("rival-create", "rival-execution", {
+    cwd: worktreeCwd,
+    workspaceId,
+  });
+
+  let archiveResult;
+  try {
+    await hub.agentCreationAtCwd(worktreeCwd!, priorProviderCreations);
+    archiveResult = await hub.archiveExecution("first-execution");
+  } finally {
+    hub.finishAgentCreation();
+  }
+  const rival = await hub.ownedCreateResult("rival-create");
+
+  expect(archiveResult).toMatchObject({ success: true, executionId: "first-execution" });
+  expect(rival).toMatchObject({
+    type: "hub.execution.agent.create.response",
+    payload: { success: true, executionId: "rival-execution" },
+  });
+  expect(rival.payload.agent?.workspaceId).toBe(workspaceId);
+  expect(await hub.ownedAgentArchivedAt(first.payload.agentId!)).not.toBeNull();
+  expect(await hub.agentRemainsAvailable(rival.payload.agentId!)).toBe(true);
+  expect(await hub.worktreeState(worktreeCwd!)).toEqual({ exists: true, listed: true });
+});

--- a/packages/server/src/server/hub/daemon-executions.ts
+++ b/packages/server/src/server/hub/daemon-executions.ts
@@ -273,7 +273,14 @@ export class DaemonExecutions implements HubExecutionAgents {
     }
     if (workspace?.isPaseoOwnedWorktree) {
       this.requireAuthority(authorityGeneration, "execution control");
-      await this.options.archiveWorkspace(workspace.workspaceId, input.requestId);
+      await this.agentManager.releaseWorkspaceIfUnowned({
+        workspaceId: workspace.workspaceId,
+        finishedAgentId: record.id,
+        release: async () => {
+          this.requireAuthority(authorityGeneration, "execution control");
+          await this.options.archiveWorkspace(workspace.workspaceId, input.requestId);
+        },
+      });
     }
   }
 

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -245,6 +245,7 @@ class ControlledAgentClient implements AgentClient {
   readonly provider;
   readonly capabilities;
   private gate: Deferred<void> | null = null;
+  private heldCreationCwd: string | null = null;
   private creationObserved = deferred<void>();
   creations = 0;
   resumes = 0;
@@ -255,8 +256,9 @@ class ControlledAgentClient implements AgentClient {
     this.capabilities = client.capabilities;
   }
 
-  holdCreation(): void {
+  holdCreation(cwd?: string): void {
     this.gate = deferred<void>();
+    this.heldCreationCwd = cwd ?? null;
   }
 
   async creationAt(count: number): Promise<void> {
@@ -266,10 +268,18 @@ class ControlledAgentClient implements AgentClient {
     }
   }
 
+  async creationAtCwd(cwd: string, after: number): Promise<void> {
+    while (!this.createdConfigs.slice(after).some((config) => config.cwd === cwd)) {
+      await this.creationObserved.promise;
+      this.creationObserved = deferred<void>();
+    }
+  }
+
   finishCreation(): void {
     if (!this.gate) throw new Error("Agent creation is not held");
     this.gate.resolve();
     this.gate = null;
+    this.heldCreationCwd = null;
   }
 
   async createSession(
@@ -280,7 +290,9 @@ class ControlledAgentClient implements AgentClient {
     this.creations++;
     this.createdConfigs.push({ ...config });
     this.creationObserved.resolve();
-    await this.gate?.promise;
+    if (this.gate && (!this.heldCreationCwd || this.heldCreationCwd === config.cwd)) {
+      await this.gate.promise;
+    }
     return this.client.createSession(config, launchContext, options);
   }
 
@@ -687,6 +699,10 @@ export class HubRelationshipHarness {
     this.codex.holdCreation();
   }
 
+  holdAgentCreationAtCwd(cwd: string): void {
+    this.codex.holdCreation(cwd);
+  }
+
   beginOwnedCreate(
     requestId: string,
     executionId = "execution-race",
@@ -695,6 +711,8 @@ export class HubRelationshipHarness {
       prompt?: string;
       modeId?: string;
       mcpServers?: AgentSessionConfig["mcpServers"];
+      cwd?: string;
+      workspaceId?: string;
     } = {},
   ): void {
     const { prompt = "Create through the Hub", ...requestOptions } = options;
@@ -712,6 +730,10 @@ export class HubRelationshipHarness {
 
   async agentCreationAttempts(count: number): Promise<void> {
     await this.codex.creationAt(count);
+  }
+
+  async agentCreationAtCwd(cwd: string, after: number): Promise<void> {
+    await this.codex.creationAtCwd(cwd, after);
   }
 
   finishAgentCreation(): void {


### PR DESCRIPTION
## Summary
- reserve workspace ownership while agent creation, persistence resume, or session import is registering
- release an owned workspace only after the exact finished agent is archived and no live, stored, or pending rival owns it
- route Hub finish cleanup through the atomic `AgentManager` fence
- add deterministic coverage for both race orderings and the same-workspace Hub regression

## Verification
- `npx vitest run src/server/agent/agent-manager.test.ts --bail=1` (152 passed)
- `npx vitest run src/server/hub/daemon-executions.test.ts --bail=1` (11 passed)
- changed Hub regression passed again in isolation after the final assertion update
- pre-existing Hub cleanup test passed in isolation after one later full-file run hit its 30-second timeout
- `npm run build` in `packages/server`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`