### PR TITLE
Fix CLI attach exit on agent completion

### DIFF
--- a/packages/cli/src/commands/agent/attach.test.ts
+++ b/packages/cli/src/commands/agent/attach.test.ts
@@ -1,0 +1,301 @@
+import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
+import type { AgentStreamEventPayload } from "@getpaseo/protocol/messages";
+import { describe, expect, it, vi } from "vitest";
+import {
+  runAttachSession,
+  type AttachAgentState,
+  type AttachAgentUpdate,
+  type AttachSessionClient,
+  type AttachSignal,
+  type AttachSignalSource,
+} from "./attach.js";
+
+const TARGET_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_ID = "22222222-2222-4222-8222-222222222222";
+
+class FakeAttachClient implements AttachSessionClient {
+  readonly streamListeners = new Set<(agentId: string, event: AgentStreamEventPayload) => void>();
+  readonly updateListeners = new Set<(update: AttachAgentUpdate) => void>();
+  private readback: AttachAgentState | null | Promise<AttachAgentState | null>;
+  private startResult: Promise<void> = Promise.resolve();
+  readonly startAgentUpdates = vi.fn(() => this.startResult);
+  readonly close = vi.fn(async () => undefined);
+  readonly fetchAgent = vi.fn(async () => this.readback);
+
+  constructor(
+    readback: AttachAgentState | null | Promise<AttachAgentState | null> = runningAgent(TARGET_ID),
+  ) {
+    this.readback = readback;
+  }
+
+  setReadback(readback: AttachAgentState | null | Promise<AttachAgentState | null>): void {
+    this.readback = readback;
+  }
+
+  setStartResult(startResult: Promise<void>): void {
+    this.startResult = startResult;
+  }
+
+  onAgentStream(listener: (agentId: string, event: AgentStreamEventPayload) => void): () => void {
+    this.streamListeners.add(listener);
+    return () => {
+      this.streamListeners.delete(listener);
+    };
+  }
+
+  onAgentUpdate(listener: Parameters<AttachSessionClient["onAgentUpdate"]>[0]): () => void {
+    this.updateListeners.add(listener);
+    return () => {
+      this.updateListeners.delete(listener);
+    };
+  }
+
+  emitStream(agentId: string, event: AgentStreamEventPayload): void {
+    for (const listener of this.streamListeners) listener(agentId, event);
+  }
+
+  emitRemove(agentId: string): void {
+    for (const listener of this.updateListeners) listener({ kind: "remove", agentId });
+  }
+
+  emitUpsert(agent: AttachAgentState): void {
+    for (const listener of this.updateListeners) listener({ kind: "upsert", agent });
+  }
+}
+
+class FakeSignalSource implements AttachSignalSource {
+  private readonly listeners = new Map<AttachSignal, Set<() => void>>([
+    ["SIGINT", new Set()],
+    ["SIGTERM", new Set()],
+  ]);
+
+  on(signal: AttachSignal, listener: () => void): void {
+    this.listeners.get(signal)?.add(listener);
+  }
+
+  removeListener(signal: AttachSignal, listener: () => void): void {
+    this.listeners.get(signal)?.delete(listener);
+  }
+
+  emit(signal: AttachSignal): void {
+    for (const listener of this.listeners.get(signal) ?? []) listener();
+  }
+
+  listenerCount(signal: AttachSignal): number {
+    return this.listeners.get(signal)?.size ?? 0;
+  }
+}
+
+function runningAgent(id: string): AttachAgentState {
+  return { id, status: "running", archivedAt: null };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function createSession(
+  client: FakeAttachClient,
+  signalSource = new FakeSignalSource(),
+  fetchTimelineItems = vi.fn(async () => [] as AgentTimelineItem[]),
+) {
+  const effects = {
+    fetchTimelineItems,
+    printTimelineItem: vi.fn(),
+    printStreamEvent: vi.fn(),
+    warnTimeline: vi.fn(),
+    printDetach: vi.fn(),
+  };
+  const promise = runAttachSession({
+    agentId: TARGET_ID,
+    client,
+    signalSource,
+    ...effects,
+  });
+  return { promise, signalSource, ...effects };
+}
+
+describe("runAttachSession", () => {
+  it("exits when an exact-target terminal is confirmed by authoritative state", async () => {
+    const client = new FakeAttachClient();
+    const session = createSession(client);
+    await vi.waitFor(() => expect(client.fetchAgent).toHaveBeenCalledOnce());
+    client.setReadback({ id: TARGET_ID, status: "idle", archivedAt: null });
+
+    client.emitStream(TARGET_ID, { type: "turn_completed", provider: "mock" });
+
+    await session.promise;
+    expect(client.fetchAgent).toHaveBeenCalledTimes(2);
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["stale", { type: "turn_completed", provider: "mock", turnId: "stale-turn" }],
+    [
+      "autonomous",
+      { type: "turn_failed", provider: "mock", turnId: "autonomous-turn", error: "failed" },
+    ],
+    [
+      "replacement",
+      { type: "turn_canceled", provider: "mock", turnId: "replaced-turn", reason: "replace" },
+    ],
+  ] satisfies Array<[string, AgentStreamEventPayload]>)(
+    "stays attached after a %s terminal while authoritative state is running",
+    async (_, event) => {
+      const client = new FakeAttachClient();
+      const session = createSession(client);
+      await vi.waitFor(() => expect(client.fetchAgent).toHaveBeenCalledOnce());
+
+      client.emitStream(TARGET_ID, event);
+      await vi.waitFor(() => expect(client.fetchAgent).toHaveBeenCalledTimes(2));
+      await Promise.resolve();
+
+      expect(client.close).not.toHaveBeenCalled();
+      client.emitUpsert({ id: TARGET_ID, status: "idle", archivedAt: null });
+      await session.promise;
+    },
+  );
+
+  it("exits when the exact target is archived", async () => {
+    const client = new FakeAttachClient();
+    const session = createSession(client);
+
+    client.emitRemove(TARGET_ID);
+
+    await session.promise;
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("exits when the exact target reports a closed state", async () => {
+    const client = new FakeAttachClient();
+    const session = createSession(client);
+
+    client.emitUpsert({ id: TARGET_ID, status: "closed", archivedAt: null });
+
+    await session.promise;
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("ignores terminal and archive events for unrelated agents", async () => {
+    const client = new FakeAttachClient();
+    const session = createSession(client);
+    let settled = false;
+    void session.promise.then(() => {
+      settled = true;
+      return undefined;
+    });
+
+    client.emitStream(OTHER_ID, { type: "turn_completed", provider: "mock" });
+    client.emitRemove(OTHER_ID);
+    client.emitUpsert({ id: OTHER_ID, status: "closed", archivedAt: null });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(client.close).not.toHaveBeenCalled();
+
+    client.emitUpsert({ id: TARGET_ID, status: "idle", archivedAt: null });
+    await session.promise;
+  });
+
+  it.each(["SIGINT", "SIGTERM"] satisfies AttachSignal[])(
+    "detaches and cleans up on %s",
+    async (signal) => {
+      const client = new FakeAttachClient();
+      const session = createSession(client);
+
+      session.signalSource.emit(signal);
+
+      await session.promise;
+      expect(session.printDetach).toHaveBeenCalledOnce();
+      expect(client.close).toHaveBeenCalledOnce();
+      expect(session.signalSource.listenerCount("SIGINT")).toBe(0);
+      expect(session.signalSource.listenerCount("SIGTERM")).toBe(0);
+    },
+  );
+
+  it("cleans up stream and update listeners after exit", async () => {
+    const client = new FakeAttachClient();
+    const session = createSession(client);
+    await vi.waitFor(() => expect(client.fetchAgent).toHaveBeenCalledOnce());
+    client.setReadback({ id: TARGET_ID, status: "error", archivedAt: null });
+
+    client.emitStream(TARGET_ID, { type: "turn_failed", provider: "mock", error: "failed" });
+
+    await session.promise;
+    expect(client.streamListeners.size).toBe(0);
+    expect(client.updateListeners.size).toBe(0);
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not wait for a pending subscription bootstrap after exact-target completion", async () => {
+    const start = deferred<void>();
+    const client = new FakeAttachClient({ id: TARGET_ID, status: "idle", archivedAt: null });
+    client.setStartResult(start.promise);
+    const session = createSession(client);
+
+    client.emitStream(TARGET_ID, { type: "turn_completed", provider: "mock" });
+
+    await session.promise;
+    expect(client.close).toHaveBeenCalledOnce();
+    expect(client.streamListeners.size).toBe(0);
+    expect(client.updateListeners.size).toBe(0);
+  });
+
+  it("does not wait for a pending exact readback after exact-target removal", async () => {
+    const readback = deferred<AttachAgentState | null>();
+    const client = new FakeAttachClient(readback.promise);
+    const session = createSession(client);
+    await vi.waitFor(() => expect(client.fetchAgent).toHaveBeenCalledOnce());
+
+    client.emitRemove(TARGET_ID);
+
+    await session.promise;
+    expect(client.close).toHaveBeenCalledOnce();
+    expect(session.signalSource.listenerCount("SIGINT")).toBe(0);
+    expect(session.signalSource.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  it("does not wait for pending timeline catch-up after exact-target completion", async () => {
+    const timeline = deferred<AgentTimelineItem[]>();
+    const fetchTimelineItems = vi.fn(() => timeline.promise);
+    const client = new FakeAttachClient();
+    const session = createSession(client, new FakeSignalSource(), fetchTimelineItems);
+    await vi.waitFor(() => expect(fetchTimelineItems).toHaveBeenCalledOnce());
+    client.setReadback({ id: TARGET_ID, status: "idle", archivedAt: null });
+
+    client.emitStream(TARGET_ID, { type: "turn_completed", provider: "mock" });
+
+    await session.promise;
+    expect(session.warnTimeline).not.toHaveBeenCalled();
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not warn when SIGINT closes pending timeline catch-up", async () => {
+    const timeline = deferred<AgentTimelineItem[]>();
+    const fetchTimelineItems = vi.fn(() => timeline.promise);
+    const client = new FakeAttachClient();
+    const session = createSession(client, new FakeSignalSource(), fetchTimelineItems);
+    await vi.waitFor(() => expect(fetchTimelineItems).toHaveBeenCalledOnce());
+
+    session.signalSource.emit("SIGINT");
+
+    await session.promise;
+    expect(session.warnTimeline).not.toHaveBeenCalled();
+    expect(session.printDetach).toHaveBeenCalledOnce();
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("exits when the exact readback says the target is no longer attachable", async () => {
+    const client = new FakeAttachClient({ id: TARGET_ID, status: "closed", archivedAt: null });
+
+    await createSession(client).promise;
+
+    expect(client.startAgentUpdates).toHaveBeenCalledOnce();
+    expect(client.fetchAgent).toHaveBeenCalledWith(TARGET_ID);
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/commands/agent/attach.ts
+++ b/packages/cli/src/commands/agent/attach.ts
@@ -12,11 +12,46 @@ import {
 } from "../../utils/timeline.js";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
-import type { AgentStreamEventPayload, AgentStreamMessage } from "@getpaseo/protocol/messages";
+import type {
+  AgentSnapshotPayload,
+  AgentStreamEventPayload,
+  AgentStreamMessage,
+  AgentUpdateMessage,
+} from "@getpaseo/protocol/messages";
 
 export interface AgentAttachOptions {
   host?: string;
   [key: string]: unknown;
+}
+
+export type AttachSignal = "SIGINT" | "SIGTERM";
+export type AttachAgentState = Pick<AgentSnapshotPayload, "id" | "status" | "archivedAt">;
+export type AttachAgentUpdate =
+  | { kind: "upsert"; agent: AttachAgentState }
+  | { kind: "remove"; agentId: string };
+
+export interface AttachSessionClient {
+  onAgentStream(listener: (agentId: string, event: AgentStreamEventPayload) => void): () => void;
+  onAgentUpdate(listener: (update: AttachAgentUpdate) => void): () => void;
+  startAgentUpdates(): Promise<void>;
+  fetchAgent(agentId: string): Promise<AttachAgentState | null>;
+  close(): Promise<void>;
+}
+
+export interface AttachSignalSource {
+  on(signal: AttachSignal, listener: () => void): void;
+  removeListener(signal: AttachSignal, listener: () => void): void;
+}
+
+interface RunAttachSessionInput {
+  agentId: string;
+  client: AttachSessionClient;
+  signalSource: AttachSignalSource;
+  fetchTimelineItems(): Promise<AgentTimelineItem[]>;
+  printTimelineItem(item: AgentTimelineItem): void;
+  printStreamEvent(event: AgentStreamEventPayload): void;
+  warnTimeline(error: unknown): void;
+  printDetach(): void;
 }
 
 /**
@@ -97,6 +132,109 @@ function printStreamEvent(event: AgentStreamEventPayload): void {
   }
 }
 
+function isAttachable(agent: AttachAgentState): boolean {
+  if (agent.archivedAt) return false;
+  return agent.status === "initializing" || agent.status === "running";
+}
+
+function isTerminalTurn(event: AgentStreamEventPayload): boolean {
+  return (
+    event.type === "turn_completed" ||
+    event.type === "turn_failed" ||
+    event.type === "turn_canceled"
+  );
+}
+
+export async function runAttachSession(input: RunAttachSessionInput): Promise<void> {
+  let completed = false;
+  let closePromise: Promise<void> | null = null;
+  let resolveCompletion: () => void = () => {};
+  const completion = new Promise<void>((resolve) => {
+    resolveCompletion = resolve;
+  });
+
+  function complete(): void {
+    if (completed) return;
+    completed = true;
+    resolveCompletion();
+    void closeClient().catch(() => {});
+  }
+
+  function closeClient(): Promise<void> {
+    closePromise ??= input.client.close();
+    return closePromise;
+  }
+
+  function detach(): void {
+    if (completed) return;
+    input.printDetach();
+    complete();
+  }
+
+  async function verifyTerminalState(): Promise<void> {
+    try {
+      const agent = await Promise.race([input.client.fetchAgent(input.agentId), completion]);
+      if (!completed && (!agent || !isAttachable(agent))) complete();
+    } catch {
+      return;
+    }
+  }
+
+  async function catchUpTimeline(): Promise<void> {
+    try {
+      const timelineItems = await Promise.race([input.fetchTimelineItems(), completion]);
+      if (completed) return;
+      for (const item of timelineItems ?? []) input.printTimelineItem(item);
+    } catch (error) {
+      if (!completed) input.warnTimeline(error);
+    }
+  }
+
+  const unsubscribeLifecycle = input.client.onAgentStream((agentId, event) => {
+    if (agentId !== input.agentId || !isTerminalTurn(event)) return;
+    void verifyTerminalState();
+  });
+  const unsubscribeUpdates = input.client.onAgentUpdate((update) => {
+    if (update.kind === "remove") {
+      if (update.agentId === input.agentId) complete();
+      return;
+    }
+    if (update.agent.id === input.agentId && !isAttachable(update.agent)) complete();
+  });
+  input.signalSource.on("SIGINT", detach);
+  input.signalSource.on("SIGTERM", detach);
+  let unsubscribeOutput: (() => void) | null = null;
+
+  try {
+    try {
+      await Promise.race([input.client.startAgentUpdates(), completion]);
+      if (!completed) {
+        const readback = await Promise.race([input.client.fetchAgent(input.agentId), completion]);
+        if (!completed && (!readback || !isAttachable(readback))) complete();
+      }
+    } catch (error) {
+      if (!completed) throw error;
+    }
+
+    if (!completed) await catchUpTimeline();
+
+    if (!completed) {
+      unsubscribeOutput = input.client.onAgentStream((agentId, event) => {
+        if (agentId === input.agentId) input.printStreamEvent(event);
+      });
+    }
+
+    await completion;
+  } finally {
+    unsubscribeOutput?.();
+    unsubscribeLifecycle();
+    unsubscribeUpdates();
+    input.signalSource.removeListener("SIGINT", detach);
+    input.signalSource.removeListener("SIGTERM", detach);
+    await closeClient();
+  }
+}
+
 /**
  * Attach to a running agent's output stream
  */
@@ -123,12 +261,18 @@ export async function runAttachCommand(
     process.exit(1);
   }
 
+  let closePromise: Promise<void> | null = null;
+  function closeClient(): Promise<void> {
+    closePromise ??= client.close();
+    return closePromise;
+  }
+
   try {
     const fetchResult = await client.fetchAgent({ agentId: id });
     if (!fetchResult) {
       console.error(`Error: No agent found matching: ${id}`);
       console.error("Use `paseo ls` to list available agents");
-      await client.close();
+      await closeClient();
       process.exit(1);
     }
     const resolvedId = fetchResult.agent.id;
@@ -137,56 +281,48 @@ export async function runAttachCommand(
     console.log(`Attaching to agent ${resolvedId.substring(0, 7)}...`);
     console.log(`(Press Ctrl+C to detach)\n`);
 
-    // Print existing output from timeline fetch.
-    try {
-      const timelineItems = await fetchProjectedTimelineItems({
-        client,
-        agentId: resolvedId,
-        timeoutMs: LIVE_HISTORY_FETCH_TIMEOUT_MS,
-      });
-      for (const item of timelineItems) {
-        printTimelineItem(item);
-      }
-    } catch (error) {
-      console.warn("Warning: failed to fetch existing timeline", error);
-    }
-
-    // Subscribe to new events
-    const unsubscribe = client.on("agent_stream", (msg: unknown) => {
-      const message = msg as AgentStreamMessage;
-      if (message.type !== "agent_stream") return;
-      if (message.payload.agentId !== resolvedId) return;
-
-      printStreamEvent(message.payload.event);
-    });
-
-    // Handle Ctrl+C to detach gracefully
-    let detached = false;
-    const detach = () => {
-      if (detached) return;
-      detached = true;
-
-      console.log("\n\nDetaching from agent...");
-      unsubscribe();
-      client
-        .close()
-        .then(() => {
-          process.exit(0);
-        })
-        .catch(() => {
-          process.exit(1);
+    await runAttachSession({
+      agentId: resolvedId,
+      client: {
+        onAgentStream(listener) {
+          return client.on("agent_stream", (message: AgentStreamMessage) => {
+            listener(message.payload.agentId, message.payload.event);
+          });
+        },
+        onAgentUpdate(listener) {
+          return client.on("agent_update", (message: AgentUpdateMessage) => {
+            listener(message.payload);
+          });
+        },
+        async startAgentUpdates() {
+          await client.fetchAgents({ subscribe: {} });
+        },
+        async fetchAgent(agentId) {
+          return (await client.fetchAgent({ agentId }))?.agent ?? null;
+        },
+        close() {
+          return closeClient();
+        },
+      },
+      signalSource: process,
+      fetchTimelineItems() {
+        return fetchProjectedTimelineItems({
+          client,
+          agentId: resolvedId,
+          timeoutMs: LIVE_HISTORY_FETCH_TIMEOUT_MS,
         });
-    };
-
-    process.on("SIGINT", detach);
-    process.on("SIGTERM", detach);
-
-    // Keep the process alive
-    await new Promise(() => {
-      // Wait indefinitely until interrupted
+      },
+      printTimelineItem,
+      printStreamEvent,
+      warnTimeline(error) {
+        console.warn("Warning: failed to fetch existing timeline", error);
+      },
+      printDetach() {
+        console.log("\n\nDetaching from agent...");
+      },
     });
   } catch (err) {
-    await client.close().catch(() => {});
+    await closeClient().catch(() => {});
     const message = err instanceof Error ? err.message : String(err);
     console.error(`Error: Failed to attach to agent: ${message}`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- keep `paseo attach` connected when stale, autonomous, canceled-for-replacement, or other non-current terminal events arrive while authoritative exact-agent state is still running
- verify target terminal events with an exact-agent readback and exit only on authoritative non-attachable state or exact-target removal
- race subscription bootstrap, exact readback, and timeline catch-up against completion; close the daemon client once and always remove stream/update/signal listeners
- suppress expected timeline warnings when Ctrl-C closes an in-flight catch-up request
- use a shared bounded 60-second session-RPC-scale history timeout for both `paseo logs` and `paseo attach`, while retaining caller-specific timeout overrides

## Integration
- merged upstream `origin/main` `777fe968f5bab50f63f25a61188482f6a15789fc` normally in `b940898a`
- repaired head: `5902a93820dd79f76a9154c31875ba9f0eb2131b`
- repaired tree: `9d277a8abfb7873af495e0e17f549e7321aa414a`

## Tests
- `npx vitest run packages/cli/src/commands/agent/attach.test.ts packages/cli/src/commands/agent/logs.test.ts packages/cli/src/utils/timeline.test.ts --bail=1` - 3 files, 19 tests passed
- `npx vitest run packages/server/src/server/agent/agent-manager.test.ts --bail=1 -t "ignores stale autonomous terminals|autonomous events arriving during foreground run"` - 2 passed, 148 skipped
- `npm run build --workspace=@getpaseo/cli` - passed
- `npm run typecheck --workspace=@getpaseo/cli` - passed
- targeted `npm run lint -- ...` - 0 warnings, 0 errors
- `npm run format` and targeted format check - passed
- `git diff --check` - passed