### PR TITLE
feat(app): improve Paseo skills discovery in Integrations panel

### DIFF
--- a/packages/app/src/desktop/components/integrations-section.tsx
+++ b/packages/app/src/desktop/components/integrations-section.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { type ReactElement, useCallback, useMemo, useState } from "react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { Text, View } from "react-native";
@@ -131,34 +131,28 @@ export function IntegrationsSection() {
     [theme.iconSize.sm, theme.colors.foregroundMuted],
   );
 
-  const trailing = useMemo(
+  const cliDocsLink = useMemo(
     () => (
-      <View style={styles.headerLinks}>
-        <Button
-          variant="ghost"
-          size="sm"
-          leftIcon={arrowIcon}
-          textStyle={settingsStyles.sectionHeaderLinkText}
-          style={settingsStyles.sectionHeaderLink}
-          onPress={handleOpenCliDocs}
-          accessibilityLabel={t("settings.integrations.docs.openCli")}
-        >
-          {t("settings.integrations.docs.cli")}
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          leftIcon={arrowIcon}
-          textStyle={settingsStyles.sectionHeaderLinkText}
-          style={settingsStyles.sectionHeaderLink}
-          onPress={handleOpenSkillsDocs}
-          accessibilityLabel={t("settings.integrations.docs.openSkills")}
-        >
-          {t("settings.integrations.docs.skills")}
-        </Button>
-      </View>
+      <DocsLink
+        icon={arrowIcon}
+        label={t("settings.integrations.docs.cli")}
+        accessibilityLabel={t("settings.integrations.docs.openCli")}
+        onPress={handleOpenCliDocs}
+      />
     ),
-    [arrowIcon, handleOpenCliDocs, handleOpenSkillsDocs, t],
+    [arrowIcon, handleOpenCliDocs, t],
+  );
+
+  const skillsDocsLink = useMemo(
+    () => (
+      <DocsLink
+        icon={arrowIcon}
+        label={t("settings.integrations.docs.skills")}
+        accessibilityLabel={t("settings.integrations.docs.openSkills")}
+        onPress={handleOpenSkillsDocs}
+      />
+    ),
+    [arrowIcon, handleOpenSkillsDocs, t],
   );
 
   if (!showSection) {
@@ -175,7 +169,7 @@ export function IntegrationsSection() {
       skillsStatus.selection.skills.some((name) => skillsStatus.available.includes(name)));
 
   return (
-    <SettingsSection title={t("settings.integrations.title")} trailing={trailing}>
+    <SettingsSection title={t("settings.integrations.title")}>
       <View style={settingsStyles.card}>
         <View style={settingsStyles.row}>
           <View style={settingsStyles.rowContent}>
@@ -188,6 +182,7 @@ export function IntegrationsSection() {
             <Text style={settingsStyles.rowHint}>
               {t("settings.integrations.commandLine.description")}
             </Text>
+            <View style={styles.docsLinkRow}>{cliDocsLink}</View>
           </View>
           {cliStatus?.installed ? (
             <View style={styles.installedLabel}>
@@ -218,6 +213,7 @@ export function IntegrationsSection() {
                 ? t("settings.integrations.skills.updateAvailable")
                 : t("settings.integrations.skills.description")}
             </Text>
+            <View style={styles.docsLinkRow}>{skillsDocsLink}</View>
           </View>
           <View style={styles.actionsRow}>
             <Button
@@ -251,6 +247,29 @@ export function IntegrationsSection() {
         />
       ) : null}
     </SettingsSection>
+  );
+}
+
+interface DocsLinkProps {
+  icon: ReactElement;
+  label: string;
+  accessibilityLabel: string;
+  onPress: () => void;
+}
+
+function DocsLink({ icon, label, accessibilityLabel, onPress }: DocsLinkProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      leftIcon={icon}
+      textStyle={settingsStyles.sectionHeaderLinkText}
+      style={settingsStyles.sectionHeaderLink}
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {label}
+    </Button>
   );
 }
 
@@ -305,15 +324,17 @@ function SkillsActions({ state, isWorking, onInstall, onUpdate, onUninstall }: S
 }
 
 const styles = StyleSheet.create((theme) => ({
-  headerLinks: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[0],
-  },
   rowTitleRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: theme.spacing[2],
+  },
+  docsLinkRow: {
+    flexDirection: "row",
+    marginTop: theme.spacing[1],
+    // Offset the sm Button's paddingHorizontal so the link's glyph sits flush
+    // with the title/description left edge instead of inset by the tap padding.
+    marginLeft: -theme.spacing[3],
   },
   installedLabel: {
     flexDirection: "row",

--- a/packages/app/src/desktop/components/integrations-section.tsx
+++ b/packages/app/src/desktop/components/integrations-section.tsx
@@ -131,30 +131,6 @@ export function IntegrationsSection() {
     [theme.iconSize.sm, theme.colors.foregroundMuted],
   );
 
-  const cliDocsLink = useMemo(
-    () => (
-      <DocsLink
-        icon={arrowIcon}
-        label={t("settings.integrations.docs.cli")}
-        accessibilityLabel={t("settings.integrations.docs.openCli")}
-        onPress={handleOpenCliDocs}
-      />
-    ),
-    [arrowIcon, handleOpenCliDocs, t],
-  );
-
-  const skillsDocsLink = useMemo(
-    () => (
-      <DocsLink
-        icon={arrowIcon}
-        label={t("settings.integrations.docs.skills")}
-        accessibilityLabel={t("settings.integrations.docs.openSkills")}
-        onPress={handleOpenSkillsDocs}
-      />
-    ),
-    [arrowIcon, handleOpenSkillsDocs, t],
-  );
-
   if (!showSection) {
     return null;
   }
@@ -182,7 +158,14 @@ export function IntegrationsSection() {
             <Text style={settingsStyles.rowHint}>
               {t("settings.integrations.commandLine.description")}
             </Text>
-            <View style={styles.docsLinkRow}>{cliDocsLink}</View>
+            <View style={styles.docsLinkRow}>
+              <DocsLink
+                icon={arrowIcon}
+                label={t("settings.integrations.docs.cli")}
+                accessibilityLabel={t("settings.integrations.docs.openCli")}
+                onPress={handleOpenCliDocs}
+              />
+            </View>
           </View>
           {cliStatus?.installed ? (
             <View style={styles.installedLabel}>
@@ -213,7 +196,14 @@ export function IntegrationsSection() {
                 ? t("settings.integrations.skills.updateAvailable")
                 : t("settings.integrations.skills.description")}
             </Text>
-            <View style={styles.docsLinkRow}>{skillsDocsLink}</View>
+            <View style={styles.docsLinkRow}>
+              <DocsLink
+                icon={arrowIcon}
+                label={t("settings.integrations.docs.skills")}
+                accessibilityLabel={t("settings.integrations.docs.openSkills")}
+                onPress={handleOpenSkillsDocs}
+              />
+            </View>
           </View>
           <View style={styles.actionsRow}>
             <Button

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1919,8 +1919,8 @@ export const ar: TranslationResources = {
     integrations: {
       title: "التكامل",
       docs: {
-        cli: "مستندات CLI",
-        skills: "وثائق المهارات",
+        cli: "معرفة المزيد",
+        skills: "معرفة المزيد",
         openCli: "افتح وثائق CLI",
         openSkills: "فتح وثائق المهارات",
       },
@@ -1929,8 +1929,8 @@ export const ar: TranslationResources = {
         description: "وكلاء التحكم والبرنامج النصي من المحطة الطرفية الخاصة بك",
       },
       skills: {
-        title: "مهارات التنسيق",
-        description: "قم بتعليم عملائك كيفية التنسيق من خلال CLI",
+        title: "مهارات Paseo",
+        description: "قم بتعليم عملائك كيفية إنشاء عملاء آخرين وتنسيقهم",
         updateAvailable: "التحديث متاح",
         updateTitle: "تحديث مهارات Paseo ؟",
         updateFallback: "مزامنة المهارات المجمعة لجهازك.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1929,8 +1929,8 @@ export const en = {
     integrations: {
       title: "Integrations",
       docs: {
-        cli: "CLI docs",
-        skills: "Skills docs",
+        cli: "Learn more",
+        skills: "Learn more",
         openCli: "Open CLI documentation",
         openSkills: "Open skills documentation",
       },
@@ -1939,8 +1939,8 @@ export const en = {
         description: "Control and script agents from your terminal",
       },
       skills: {
-        title: "Orchestration skills",
-        description: "Teach your agents to orchestrate through the CLI",
+        title: "Paseo skills",
+        description: "Teach your agents to spawn and coordinate other agents",
         updateAvailable: "Update available",
         updateTitle: "Update Paseo skills?",
         updateFallback: "Sync bundled skills to your machine.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1967,8 +1967,8 @@ export const es: TranslationResources = {
     integrations: {
       title: "Integraciones",
       docs: {
-        cli: "DocumentosCLI",
-        skills: "Documentos de habilidades",
+        cli: "Más información",
+        skills: "Más información",
         openCli: "Abrir la documentación deCLI",
         openSkills: "Documentación de habilidades abiertas",
       },
@@ -1977,8 +1977,8 @@ export const es: TranslationResources = {
         description: "Agentes de control y script desde tu terminal",
       },
       skills: {
-        title: "Habilidades de orquestación",
-        description: "Enseñe a sus agentes a orquestar a través delCLI",
+        title: "Habilidades de Paseo",
+        description: "Enseñe a sus agentes a crear y coordinar otros agentes",
         updateAvailable: "Actualización disponible",
         updateTitle: "¿Actualizar las habilidades dePaseo?",
         updateFallback: "Sincronice las habilidades incluidas con su máquina.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1971,8 +1971,8 @@ export const fr: TranslationResources = {
     integrations: {
       title: "Intégrations",
       docs: {
-        cli: "DocumentsCLI",
-        skills: "Documents de compétences",
+        cli: "En savoir plus",
+        skills: "En savoir plus",
         openCli: "Ouvrir la documentationCLI",
         openSkills: "Documentation des compétences ouvertes",
       },
@@ -1981,8 +1981,8 @@ export const fr: TranslationResources = {
         description: "Agents de contrôle et de script depuis votre terminal",
       },
       skills: {
-        title: "Compétences en orchestration",
-        description: "Apprenez à vos agents à orchestrer via leCLI",
+        title: "Compétences Paseo",
+        description: "Apprenez à vos agents à lancer et coordonner d'autres agents",
         updateAvailable: "Mise à jour disponible",
         updateTitle: "Mettre à jour les compétencesPaseo?",
         updateFallback: "Synchronisez les compétences regroupées sur votre machine.",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1936,8 +1936,8 @@ export const ja: TranslationResources = {
     integrations: {
       title: "連携",
       docs: {
-        cli: "CLIドキュメント",
-        skills: "スキルドキュメント",
+        cli: "詳細を見る",
+        skills: "詳細を見る",
         openCli: "CLIドキュメントを開く",
         openSkills: "スキルドキュメントを開く",
       },
@@ -1946,8 +1946,8 @@ export const ja: TranslationResources = {
         description: "ターミナルからエージェントを制御し、スクリプトで操作",
       },
       skills: {
-        title: "オーケストレーションスキル",
-        description: "エージェントがCLI経由でオーケストレーションできるようにします。",
+        title: "Paseoスキル",
+        description: "エージェントが他のエージェントを起動・調整できるようにします。",
         updateAvailable: "更新が利用可能",
         updateTitle: "Paseoスキルを更新しますか？",
         updateFallback: "バンドルされたスキルをマシンに同期します。",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1951,8 +1951,8 @@ export const ptBR: TranslationResources = {
     integrations: {
       title: "Integrações",
       docs: {
-        cli: "Docs da CLI",
-        skills: "Docs das skills",
+        cli: "Saiba mais",
+        skills: "Saiba mais",
         openCli: "Abrir documentação da CLI",
         openSkills: "Abrir documentação das skills",
       },
@@ -1961,8 +1961,8 @@ export const ptBR: TranslationResources = {
         description: "Controle agentes e execute scripts pelo terminal",
       },
       skills: {
-        title: "Skills de orquestração",
-        description: "Ensine seus agentes a orquestrar pela CLI",
+        title: "Paseo skills",
+        description: "Ensine seus agentes a criar e coordenar outros agentes",
         updateAvailable: "Atualização disponível",
         updateTitle: "Atualizar Paseo skills?",
         updateFallback: "Sincronize as skills incluídas com sua máquina.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1957,8 +1957,8 @@ export const ru: TranslationResources = {
     integrations: {
       title: "Интеграции",
       docs: {
-        cli: "Документация CLI",
-        skills: "Документы по навыкам",
+        cli: "Подробнее",
+        skills: "Подробнее",
         openCli: "Открыть документацию CLI",
         openSkills: "Открытая документация по навыкам",
       },
@@ -1967,8 +1967,8 @@ export const ru: TranslationResources = {
         description: "Агенты управления и сценариев с вашего терминала",
       },
       skills: {
-        title: "Навыки оркестровки",
-        description: "Научите своих агентов организовывать работу через CLI",
+        title: "Навыки Paseo",
+        description: "Научите своих агентов запускать и координировать других агентов",
         updateAvailable: "Доступно обновление",
         updateTitle: "Обновить навыки Paseo?",
         updateFallback: "Синхронизируйте связанные навыки с вашим компьютером.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1897,8 +1897,8 @@ export const zhCN: TranslationResources = {
     integrations: {
       title: "集成",
       docs: {
-        cli: "CLI 文档",
-        skills: "Skills 文档",
+        cli: "了解更多",
+        skills: "了解更多",
         openCli: "打开 CLI 文档",
         openSkills: "打开 skills 文档",
       },
@@ -1907,8 +1907,8 @@ export const zhCN: TranslationResources = {
         description: "从终端控制 Agent 并运行脚本",
       },
       skills: {
-        title: "编排 skills",
-        description: "教会 Agent 通过 CLI 编排任务",
+        title: "Paseo skills",
+        description: "教会 Agent 启动并协调其他 Agent",
         updateAvailable: "有更新可用",
         updateTitle: "更新 Paseo skills？",
         updateFallback: "将内置 skills 同步到你的机器。",

--- a/packages/desktop/e2e/support/skills-selection.ts
+++ b/packages/desktop/e2e/support/skills-selection.ts
@@ -240,14 +240,14 @@ export async function startSkillsSandbox(
 export async function openSkillsIntegrations(page: Page): Promise<void> {
   await openSettings(page);
   await openSettingsSection(page, "integrations");
-  await expect(page.getByText("Orchestration skills", { exact: true })).toBeVisible();
+  await expect(page.getByText("Paseo skills", { exact: true })).toBeVisible();
 }
 
 /** Settings on a compact form factor stacks list and detail, so it needs the menu first. */
 export async function openCompactSkillsIntegrations(page: Page): Promise<void> {
   await openCompactSettings(page, buildOpenProjectRoute());
   await openSettingsSection(page, "integrations");
-  await expect(page.getByText("Orchestration skills", { exact: true })).toBeVisible();
+  await expect(page.getByText("Paseo skills", { exact: true })).toBeVisible();
 }
 
 export async function openSkillSelection(page: Page): Promise<void> {


### PR DESCRIPTION
### Linked issue

Closes #1689

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The Integrations panel is the only place skills surface in the app, and its copy and links undersold what they are. I use Paseo daily and went a long time without realising `/paseo-advisor` existed — the description talked about the CLI, which I don't drive myself, so I assumed the feature wasn't for me. The row label ("Orchestration skills") didn't match what you type (`/paseo-*`), and the docs links sat in the section header where they read as chrome and got skipped. The goal is that a user landing on this panel understands what the skills do and can reach the docs, so more people actually discover and adopt them.

### Goals

- Description leads with the outcome, not the mechanism: "Teach your agents to spawn and coordinate other agents" (matches the skills docs framing "spawn, coordinate, and manage").
- Docs links move into each row as a per-row "Learn more ↗" under the description — attached to the item they document, and it scales as integrations are added (the header is one fixed slot).
- Row label matches the namespace users type: "Orchestration skills" → "Paseo skills" (`/paseo-*`).
- Applied across all eight locales (en, ar, es, fr, ja, pt-BR, ru, zh-CN).

### Non-goals

- No change to skill behaviour, the install/uninstall flow, or the choose-skills sheet.
- Not adding new skills or new integration rows.
- Not reconciling the docs, whose primary heading is still "Orchestration skills" — this PR leaves a UI/docs naming split. Happy to drop the rename or align the docs instead, whichever you prefer.

### QA

This is a copy-and-layout change to one panel with no behavioural logic. The panel is gated behind `shouldUseDesktopDaemon()`, so desktop is the only surface it renders on — there are no iOS/Android/web shots because it doesn't appear there.

On desktop I opened Settings → Integrations and confirmed:

- Both rows show "Learn more ↗" directly under their description, left-aligned with the title.
- The skills row reads "Paseo skills" / "Teach your agents to spawn and coordinate other agents".
- The links open the CLI and skills docs pages.

<img width="803" height="361" alt="image" src="https://github.com/user-attachments/assets/0ba574dd-e231-48e0-a677-5d79529b9f51" />

Static checks, green on all nine changed files (the component + eight locale files):

```
npm run typecheck
npm run lint
npm run format
```

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense (did not make sense so I guess zero tests qualify to check the box)
