### PR TITLE
Preserve chat scroll position across workspace switches

### DIFF
--- a/packages/app/e2e/browser/agent-scroll-return.spec.ts
+++ b/packages/app/e2e/browser/agent-scroll-return.spec.ts
@@ -1,0 +1,167 @@
+import { expect, type Page } from "@playwright/test";
+import { test } from "../support/fixtures";
+import {
+  readScrollMetrics,
+  scrollChatAwayFromBottom,
+} from "../support/helpers/agent-bottom-anchor";
+import { getServerId } from "../support/helpers/server-id";
+import { seedMockAgentWorkspace, type MockAgentWorkspace } from "../support/helpers/mock-agent";
+import { openMobileAgentSidebar } from "../support/helpers/sidebar";
+import {
+  expectTimelinePromptVisible,
+  openAgentTimeline,
+  seedLongMockAgentTimeline,
+} from "../support/helpers/timeline-pagination";
+import { switchWorkspaceViaSidebar } from "../support/helpers/workspace-ui";
+
+async function expectChatAtBottom(page: Page): Promise<void> {
+  await expect
+    .poll(async () => (await readScrollMetrics(page)).distanceFromBottom, {
+      timeout: 10_000,
+    })
+    .toBeLessThanOrEqual(72);
+}
+
+async function openCompactWorkspace(
+  page: Page,
+  workspace: Pick<MockAgentWorkspace, "workspaceId">,
+): Promise<void> {
+  await openMobileAgentSidebar(page);
+  await switchWorkspaceViaSidebar({
+    page,
+    serverId: getServerId(),
+    workspaceId: workspace.workspaceId,
+  });
+}
+
+function armDelayedScrollForHiddenChat(page: Page): Promise<void> {
+  return page
+    .locator('[data-testid="agent-chat-scroll"]:visible')
+    .first()
+    .evaluate((root) => {
+      const scroll = root as HTMLElement;
+      return new Promise<void>((resolve) => {
+        const observer = new ResizeObserver(() => {
+          if (scroll.getClientRects().length > 0) return;
+          observer.disconnect();
+          scroll.dispatchEvent(new Event("scroll"));
+          resolve();
+        });
+        observer.observe(scroll);
+      });
+    });
+}
+
+test("a long chat remains at the bottom through viewport geometry changes", async ({ page }) => {
+  test.setTimeout(240_000);
+  const longChat = await seedLongMockAgentTimeline({ turns: 30 });
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openAgentTimeline(page, longChat);
+    await expectTimelinePromptVisible(page, longChat.newestPrompt);
+    await expectChatAtBottom(page);
+
+    await page.setViewportSize({ width: 390, height: 1124 });
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await expectChatAtBottom(page);
+  } finally {
+    await longChat.cleanup();
+  }
+});
+
+test("a retained chat ignores delayed scroll delivery while hidden", async ({ page }) => {
+  test.setTimeout(240_000);
+  const longChat = await seedLongMockAgentTimeline({ turns: 30 });
+  const otherWorkspace = await seedMockAgentWorkspace({
+    repoPrefix: "scroll-return-hidden-other-",
+    title: "Other workspace",
+    initialPrompt: "Open the other workspace",
+  });
+  const backgroundPrompt = "emit 500 coalesced agent stream updates";
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openAgentTimeline(page, longChat);
+    await expectTimelinePromptVisible(page, longChat.newestPrompt);
+    await expectChatAtBottom(page);
+
+    const delayedScrollDelivered = armDelayedScrollForHiddenChat(page);
+    await openCompactWorkspace(page, otherWorkspace);
+    await delayedScrollDelivered;
+    await longChat.client.sendAgentMessage(longChat.agentId, backgroundPrompt);
+    await longChat.client.waitForFinish(longChat.agentId, 20_000);
+
+    await openCompactWorkspace(page, longChat);
+    await expectTimelinePromptVisible(page, backgroundPrompt);
+    await expectChatAtBottom(page);
+  } finally {
+    await Promise.allSettled([longChat.cleanup(), otherWorkspace.cleanup()]);
+  }
+});
+
+test("a retained streaming chat returns to the bottom and continues following", async ({
+  page,
+}) => {
+  test.setTimeout(240_000);
+  const longChat = await seedLongMockAgentTimeline({ turns: 30 });
+  const otherWorkspace = await seedMockAgentWorkspace({
+    repoPrefix: "scroll-return-streaming-other-",
+    title: "Other workspace",
+    initialPrompt: "Open the other workspace",
+  });
+  const streamingPrompt = "Continue streaming while this workspace is hidden";
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openAgentTimeline(page, longChat);
+    await expectTimelinePromptVisible(page, longChat.newestPrompt);
+    await expectChatAtBottom(page);
+
+    await longChat.client.sendAgentMessage(longChat.agentId, streamingPrompt);
+    await longChat.client.waitForAgentUpsert(
+      longChat.agentId,
+      (snapshot) => snapshot.status === "running",
+      15_000,
+    );
+    await openCompactWorkspace(page, otherWorkspace);
+    await openCompactWorkspace(page, longChat);
+
+    await expectTimelinePromptVisible(page, streamingPrompt);
+    await expectChatAtBottom(page);
+    await longChat.client.waitForFinish(longChat.agentId, 20_000);
+    await expectChatAtBottom(page);
+  } finally {
+    await Promise.allSettled([longChat.cleanup(), otherWorkspace.cleanup()]);
+  }
+});
+
+test("a retained chat preserves an intentional reading position", async ({ page }) => {
+  test.setTimeout(240_000);
+  const longChat = await seedLongMockAgentTimeline({ turns: 30 });
+  const otherWorkspace = await seedMockAgentWorkspace({
+    repoPrefix: "scroll-return-reading-position-other-",
+    title: "Other workspace",
+    initialPrompt: "Open the other workspace",
+  });
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openAgentTimeline(page, longChat);
+    await expectTimelinePromptVisible(page, longChat.newestPrompt);
+    const readingPosition = await scrollChatAwayFromBottom(page, {
+      deltaY: -900,
+      minDistanceFromBottom: 300,
+    });
+
+    await openCompactWorkspace(page, otherWorkspace);
+    await openCompactWorkspace(page, longChat);
+
+    await expect
+      .poll(async () => Math.abs((await readScrollMetrics(page)).offsetY - readingPosition.offsetY))
+      .toBeLessThanOrEqual(24);
+  } finally {
+    await Promise.allSettled([longChat.cleanup(), otherWorkspace.cleanup()]);
+  }
+});

--- a/packages/app/e2e/browser/agent-scroll-return.spec.ts
+++ b/packages/app/e2e/browser/agent-scroll-return.spec.ts
@@ -6,6 +6,12 @@ import {
 } from "../support/helpers/agent-bottom-anchor";
 import { getServerId } from "../support/helpers/server-id";
 import { seedMockAgentWorkspace, type MockAgentWorkspace } from "../support/helpers/mock-agent";
+import {
+  continueToNextQuestion,
+  fillQuestionAnswer,
+  submitQuestionAnswers,
+  waitForQuestionPrompt,
+} from "../support/helpers/questions";
 import { openMobileAgentSidebar } from "../support/helpers/sidebar";
 import {
   expectTimelinePromptVisible,
@@ -174,5 +180,44 @@ test("a retained chat preserves an intentional reading position", async ({ page 
       .toBeLessThanOrEqual(24);
   } finally {
     await Promise.allSettled([longChat.cleanup(), otherWorkspace.cleanup()]);
+  }
+});
+
+test("editing keys in an embedded question keep output following", async ({ page }) => {
+  test.setTimeout(240_000);
+  const longChat = await seedLongMockAgentTimeline({ turns: 30 });
+  const questionPrompt = "Emit synthetic questions: two free-write questions.";
+  const firstQuestion = "What is the GitHub private repo URL to push to?";
+  const secondQuestion = "What should the first commit message be?";
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await openAgentTimeline(page, longChat);
+    await expectTimelinePromptVisible(page, longChat.newestPrompt);
+    await expectChatAtBottom(page);
+
+    await longChat.client.sendAgentMessage(longChat.agentId, questionPrompt);
+    await waitForQuestionPrompt(page, 30_000);
+    await fillQuestionAnswer(page, {
+      question: firstQuestion,
+      answer: "git@github.com:user/private-repo.git",
+    });
+    const firstInput = page
+      .getByTestId("question-form-card")
+      .first()
+      .getByRole("textbox", { name: firstQuestion });
+    await firstInput.press("Home");
+    await firstInput.press("ArrowUp");
+    await continueToNextQuestion(page);
+    await fillQuestionAnswer(page, {
+      question: secondQuestion,
+      answer: "Initialize private repo",
+    });
+    await submitQuestionAnswers(page);
+    await longChat.client.waitForFinish(longChat.agentId, 20_000);
+
+    await expectChatAtBottom(page);
+  } finally {
+    await longChat.cleanup();
   }
 });

--- a/packages/app/e2e/browser/agent-scroll-return.spec.ts
+++ b/packages/app/e2e/browser/agent-scroll-return.spec.ts
@@ -52,9 +52,10 @@ function armDelayedScrollForHiddenChat(page: Page): Promise<void> {
     });
 }
 
-test("a long chat remains at the bottom through viewport geometry changes", async ({ page }) => {
+test("a stationary pointer cannot turn geometry changes into scroll intent", async ({ page }) => {
   test.setTimeout(240_000);
   const longChat = await seedLongMockAgentTimeline({ turns: 30 });
+  const backgroundPrompt = "Continue after a pointer is released outside the chat";
 
   try {
     await page.setViewportSize({ width: 390, height: 844 });
@@ -62,9 +63,19 @@ test("a long chat remains at the bottom through viewport geometry changes", asyn
     await expectTimelinePromptVisible(page, longChat.newestPrompt);
     await expectChatAtBottom(page);
 
+    const scroll = page.locator('[data-testid="agent-chat-scroll"]:visible').first();
+    const bounds = await scroll.boundingBox();
+    expect(bounds, "Expected visible chat scroll bounds").not.toBeNull();
+    await page.mouse.move(bounds!.x + bounds!.width / 2, bounds!.y + bounds!.height / 2);
+    await page.mouse.down();
     await page.setViewportSize({ width: 390, height: 1124 });
     await page.setViewportSize({ width: 390, height: 844 });
+    await page.mouse.move(410, bounds!.y + bounds!.height / 2);
+    await page.mouse.up();
 
+    await longChat.client.sendAgentMessage(longChat.agentId, backgroundPrompt);
+    await longChat.client.waitForFinish(longChat.agentId, 20_000);
+    await expectTimelinePromptVisible(page, backgroundPrompt);
     await expectChatAtBottom(page);
   } finally {
     await longChat.cleanup();

--- a/packages/app/e2e/browser/agent-scroll-return.spec.ts
+++ b/packages/app/e2e/browser/agent-scroll-return.spec.ts
@@ -58,7 +58,7 @@ function armDelayedScrollForHiddenChat(page: Page): Promise<void> {
     });
 }
 
-test("a stationary pointer cannot turn geometry changes into scroll intent", async ({ page }) => {
+test("pointer jitter cannot turn geometry changes into scroll intent", async ({ page }) => {
   test.setTimeout(240_000);
   const longChat = await seedLongMockAgentTimeline({ turns: 30 });
   const backgroundPrompt = "Continue after a pointer is released outside the chat";
@@ -74,9 +74,10 @@ test("a stationary pointer cannot turn geometry changes into scroll intent", asy
     expect(bounds, "Expected visible chat scroll bounds").not.toBeNull();
     await page.mouse.move(bounds!.x + bounds!.width / 2, bounds!.y + bounds!.height / 2);
     await page.mouse.down();
+    await page.mouse.move(bounds!.x + bounds!.width / 2, bounds!.y + bounds!.height / 2 - 3);
     await page.setViewportSize({ width: 390, height: 1124 });
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.mouse.move(410, bounds!.y + bounds!.height / 2);
+    await page.mouse.move(410, bounds!.y + bounds!.height / 2 - 3);
     await page.mouse.up();
 
     await longChat.client.sendAgentMessage(longChat.agentId, backgroundPrompt);
@@ -206,6 +207,18 @@ test("editing keys in an embedded question keep output following", async ({ page
       .getByTestId("question-form-card")
       .first()
       .getByRole("textbox", { name: firstQuestion });
+    const inputBounds = await firstInput.boundingBox();
+    expect(inputBounds, "Expected embedded question input bounds").not.toBeNull();
+    await page.mouse.move(
+      inputBounds!.x + inputBounds!.width / 2,
+      inputBounds!.y + inputBounds!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      inputBounds!.x + inputBounds!.width / 2 + 20,
+      inputBounds!.y + inputBounds!.height / 2 - 3,
+    );
+    await page.mouse.up();
     await firstInput.press("Home");
     await firstInput.press("ArrowUp");
     await continueToNextQuestion(page);

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -891,6 +891,97 @@ describe("createWebStreamStrategy", () => {
     expect(scrollTo).toHaveBeenCalledWith({ top: 1800, behavior: "auto" });
   });
 
+  it("stops following output after an upward primary-pointer drag", () => {
+    const scrollTo = vi.fn(function (this: HTMLElement, options?: ScrollToOptions | number) {
+      const top = typeof options === "object" ? (options.top ?? 0) : 0;
+      Object.defineProperty(this, "scrollTop", { configurable: true, value: top });
+    });
+    HTMLElement.prototype.scrollTo = scrollTo;
+    const strategy = createWebStreamStrategy({ isMobileBreakpoint: true });
+    const renderInput: StreamRenderInput = {
+      agentId: "agent",
+      segments: {
+        historyVirtualized: [],
+        historyMounted: [userMessage(1), userMessage(2)],
+        liveHead: [],
+      },
+      boundary: {
+        hasVirtualizedHistory: false,
+        hasMountedHistory: true,
+        hasLiveHead: false,
+      },
+      renderers: createRenderers(vi.fn()),
+      listEmptyComponent: null,
+      viewportRef: React.createRef<StreamViewportHandle>(),
+      routeBottomAnchorRequest: null,
+      isAuthoritativeHistoryReady: true,
+      onNearBottomChange: vi.fn(),
+      onNearHistoryStart: vi.fn().mockReturnValue(true),
+      isLoadingOlderHistory: false,
+      hasOlderHistory: false,
+      olderHistoryProgressKey: null,
+      scrollEnabled: true,
+      listStyle: null,
+      baseListContentContainerStyle: null,
+      forwardListContentContainerStyle: null,
+    };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => root?.render(strategy.render(renderInput)));
+    const scrollContainer = container.querySelector('[data-testid="agent-chat-scroll"]');
+    if (!(scrollContainer instanceof HTMLElement)) {
+      throw new Error("Expected agent chat scroll container");
+    }
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1500 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+
+    const pointerDown = new MouseEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      clientY: 400,
+    });
+    Object.defineProperties(pointerDown, {
+      isPrimary: { value: true },
+      pointerId: { value: 1 },
+      pointerType: { value: "mouse" },
+    });
+    const pointerMove = new MouseEvent("pointermove", {
+      bubbles: true,
+      buttons: 1,
+      clientY: 300,
+    });
+    Object.defineProperties(pointerMove, {
+      isPrimary: { value: true },
+      pointerId: { value: 1 },
+      pointerType: { value: "mouse" },
+    });
+    act(() => {
+      scrollContainer.dispatchEvent(pointerDown);
+      window.dispatchEvent(pointerMove);
+    });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 700 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    scrollTo.mockClear();
+
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1800 });
+    act(() => {
+      root?.render(
+        strategy.render({
+          ...renderInput,
+          segments: { ...renderInput.segments, liveHead: [userMessage(3)] },
+          boundary: { ...renderInput.boundary, hasLiveHead: true },
+        }),
+      );
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
   it("keeps the retained viewport mounted while inactive and reconciles it once on return", () => {
     const observed = new Map<Element, ReturnType<typeof vi.fn>>();
     Object.defineProperty(globalThis, "ResizeObserver", {

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -877,6 +877,11 @@ describe("createWebStreamStrategy", () => {
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
     scrollTo.mockClear();
 
+    act(() => {
+      scrollContainer.dispatchEvent(
+        new WheelEvent("wheel", { bubbles: true, ctrlKey: true, deltaY: -100 }),
+      );
+    });
     Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1800 });
     act(() => {
       root?.render(

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RetainedPanelActivity } from "@/components/retained-panel";
 import type { StreamItem } from "@/types/stream";
 import type { StreamRenderInput, StreamSegmentRenderers, StreamViewportHandle } from "./strategy";
 import { createWebStreamStrategy } from "./strategy-web";
@@ -820,5 +821,170 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(scrollTo).toHaveBeenCalled();
+  });
+
+  it("keeps following output after an upward geometry displacement without user intent", () => {
+    const scrollTo = vi.fn(function (this: HTMLElement, options?: ScrollToOptions | number) {
+      const top = typeof options === "object" ? (options.top ?? 0) : 0;
+      Object.defineProperty(this, "scrollTop", { configurable: true, value: top });
+    });
+    HTMLElement.prototype.scrollTo = scrollTo;
+    const strategy = createWebStreamStrategy({ isMobileBreakpoint: true });
+    const viewportRef = React.createRef<StreamViewportHandle>();
+    const renderInput: StreamRenderInput = {
+      agentId: "agent",
+      segments: {
+        historyVirtualized: [],
+        historyMounted: [userMessage(1), userMessage(2)],
+        liveHead: [],
+      },
+      boundary: {
+        hasVirtualizedHistory: false,
+        hasMountedHistory: true,
+        hasLiveHead: false,
+      },
+      renderers: createRenderers(vi.fn()),
+      listEmptyComponent: null,
+      viewportRef,
+      routeBottomAnchorRequest: null,
+      isAuthoritativeHistoryReady: true,
+      onNearBottomChange: vi.fn(),
+      onNearHistoryStart: vi.fn().mockReturnValue(true),
+      isLoadingOlderHistory: false,
+      hasOlderHistory: false,
+      olderHistoryProgressKey: null,
+      scrollEnabled: true,
+      listStyle: null,
+      baseListContentContainerStyle: null,
+      forwardListContentContainerStyle: null,
+    };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => root?.render(strategy.render(renderInput)));
+    const scrollContainer = container.querySelector('[data-testid="agent-chat-scroll"]');
+    if (!(scrollContainer instanceof HTMLElement)) {
+      throw new Error("Expected agent chat scroll container");
+    }
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1500 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 700 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 800 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    scrollTo.mockClear();
+
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1800 });
+    act(() => {
+      root?.render(
+        strategy.render({
+          ...renderInput,
+          segments: { ...renderInput.segments, liveHead: [userMessage(3)] },
+          boundary: { ...renderInput.boundary, hasLiveHead: true },
+        }),
+      );
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 1800, behavior: "auto" });
+  });
+
+  it("keeps the retained viewport mounted while inactive and reconciles it once on return", () => {
+    const observed = new Map<Element, ReturnType<typeof vi.fn>>();
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: class ResizeObserver {
+        readonly disconnect = vi.fn();
+
+        observe(target: Element) {
+          observed.set(target, this.disconnect);
+        }
+      },
+    });
+    const scrollTo = vi.fn(function (this: HTMLElement, options?: ScrollToOptions | number) {
+      const top = typeof options === "object" ? (options.top ?? 0) : 0;
+      Object.defineProperty(this, "scrollTop", { configurable: true, value: top });
+    });
+    HTMLElement.prototype.scrollTo = scrollTo;
+    const strategy = createWebStreamStrategy({ isMobileBreakpoint: true });
+    const viewportRef = React.createRef<StreamViewportHandle>();
+    const renderInput: StreamRenderInput = {
+      agentId: "agent",
+      segments: {
+        historyVirtualized: [],
+        historyMounted: [userMessage(1), userMessage(2)],
+        liveHead: [],
+      },
+      boundary: {
+        hasVirtualizedHistory: false,
+        hasMountedHistory: true,
+        hasLiveHead: false,
+      },
+      renderers: createRenderers(vi.fn()),
+      listEmptyComponent: null,
+      viewportRef,
+      routeBottomAnchorRequest: null,
+      isAuthoritativeHistoryReady: true,
+      onNearBottomChange: vi.fn(),
+      onNearHistoryStart: vi.fn().mockReturnValue(true),
+      isLoadingOlderHistory: false,
+      hasOlderHistory: false,
+      olderHistoryProgressKey: null,
+      scrollEnabled: true,
+      listStyle: null,
+      baseListContentContainerStyle: null,
+      forwardListContentContainerStyle: null,
+    };
+    const renderWithActivity = (active: boolean, input: StreamRenderInput = renderInput) => (
+      <RetainedPanelActivity active={active}>{strategy.render(input)}</RetainedPanelActivity>
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => root?.render(renderWithActivity(true)));
+    const scrollContainer = container.querySelector('[data-testid="agent-chat-scroll"]');
+    if (!(scrollContainer instanceof HTMLElement)) {
+      throw new Error("Expected agent chat scroll container");
+    }
+    Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1500 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    const viewportObserverDisconnect = observed.get(scrollContainer);
+    expect(viewportObserverDisconnect).toBeDefined();
+
+    act(() => root?.render(renderWithActivity(false)));
+    expect(container.querySelector('[data-testid="agent-chat-scroll"]')).toBe(scrollContainer);
+    expect(viewportObserverDisconnect).toHaveBeenCalledOnce();
+    scrollTo.mockClear();
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 2200 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 0 });
+    act(() => {
+      scrollContainer.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      scrollContainer.dispatchEvent(new Event("scroll"));
+      root?.render(
+        renderWithActivity(false, {
+          ...renderInput,
+          segments: { ...renderInput.segments, liveHead: [userMessage(3)] },
+          boundary: { ...renderInput.boundary, hasLiveHead: true },
+        }),
+      );
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    act(() => {
+      root?.render(
+        renderWithActivity(true, {
+          ...renderInput,
+          segments: { ...renderInput.segments, liveHead: [userMessage(3)] },
+          boundary: { ...renderInput.boundary, hasLiveHead: true },
+        }),
+      );
+    });
+    expect(container.querySelector('[data-testid="agent-chat-scroll"]')).toBe(scrollContainer);
+    expect(scrollTo).toHaveBeenCalledWith({ top: 2200, behavior: "auto" });
   });
 });

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -1058,6 +1058,59 @@ describe("createWebStreamStrategy", () => {
 
     Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1400 });
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    const autoscrollPointerDown = new MouseEvent("pointerdown", {
+      bubbles: true,
+      button: 1,
+      buttons: 4,
+      clientX: 100,
+      clientY: 400,
+    });
+    const autoscrollPointerUp = new MouseEvent("pointerup", {
+      bubbles: true,
+      button: 1,
+      buttons: 0,
+      clientX: 100,
+      clientY: 400,
+    });
+    const autoscrollPointerMove = new MouseEvent("pointermove", {
+      bubbles: true,
+      buttons: 0,
+      clientX: 100,
+      clientY: 300,
+    });
+    for (const event of [autoscrollPointerDown, autoscrollPointerUp, autoscrollPointerMove]) {
+      Object.defineProperties(event, {
+        isPrimary: { value: true },
+        pointerId: { value: 3 },
+        pointerType: { value: "mouse" },
+      });
+    }
+    act(() => {
+      scrollContainer.dispatchEvent(autoscrollPointerDown);
+      window.dispatchEvent(autoscrollPointerUp);
+      window.dispatchEvent(autoscrollPointerMove);
+    });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    scrollTo.mockClear();
+
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 2000 });
+    act(() => {
+      root?.render(
+        strategy.render({
+          ...renderInput,
+          segments: {
+            ...renderInput.segments,
+            liveHead: [userMessage(3), userMessage(4), userMessage(5)],
+          },
+          boundary: { ...renderInput.boundary, hasLiveHead: true },
+        }),
+      );
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1500 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
     const pointerDown = new MouseEvent("pointerdown", {
       bubbles: true,
       button: 0,
@@ -1067,7 +1120,7 @@ describe("createWebStreamStrategy", () => {
     });
     Object.defineProperties(pointerDown, {
       isPrimary: { value: true },
-      pointerId: { value: 3 },
+      pointerId: { value: 4 },
       pointerType: { value: "mouse" },
     });
     const pointerMove = new MouseEvent("pointermove", {
@@ -1078,25 +1131,25 @@ describe("createWebStreamStrategy", () => {
     });
     Object.defineProperties(pointerMove, {
       isPrimary: { value: true },
-      pointerId: { value: 3 },
+      pointerId: { value: 4 },
       pointerType: { value: "mouse" },
     });
     act(() => {
       scrollContainer.dispatchEvent(pointerDown);
       window.dispatchEvent(pointerMove);
     });
-    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1100 });
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
     scrollTo.mockClear();
 
-    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 2100 });
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 2200 });
     act(() => {
       root?.render(
         strategy.render({
           ...renderInput,
           segments: {
             ...renderInput.segments,
-            liveHead: [userMessage(3), userMessage(4)],
+            liveHead: [userMessage(3), userMessage(4), userMessage(5), userMessage(6)],
           },
           boundary: { ...renderInput.boundary, hasLiveHead: true },
         }),

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -881,10 +881,48 @@ describe("createWebStreamStrategy", () => {
       throw new Error("Expected agent chat scroll container");
     }
     Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "clientWidth", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "offsetWidth", { configurable: true, value: 500 });
     Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1500 });
     Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    scrollContainer.getBoundingClientRect = () =>
+      ({
+        bottom: 500,
+        height: 500,
+        left: 0,
+        right: 500,
+        top: 0,
+        width: 500,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as DOMRect;
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
 
+    const jitterPointerDown = new MouseEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      clientX: 100,
+      clientY: 400,
+    });
+    const jitterPointerMove = new MouseEvent("pointermove", {
+      bubbles: true,
+      buttons: 1,
+      clientX: 100,
+      clientY: 397,
+    });
+    for (const event of [jitterPointerDown, jitterPointerMove]) {
+      Object.defineProperties(event, {
+        isPrimary: { value: true },
+        pointerId: { value: 1 },
+        pointerType: { value: "mouse" },
+      });
+    }
+    act(() => {
+      scrollContainer.dispatchEvent(jitterPointerDown);
+      window.dispatchEvent(jitterPointerMove);
+    });
     Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 700 });
     Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 800 });
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
@@ -918,7 +956,7 @@ describe("createWebStreamStrategy", () => {
     expect(scrollTo).toHaveBeenCalledWith({ top: 1800, behavior: "auto" });
   });
 
-  it("stops following output after pointer-driven upward scrolling", () => {
+  it("stops following output after scrollbar and middle-button upward scrolling", () => {
     const scrollTo = vi.fn(function (this: HTMLElement, options?: ScrollToOptions | number) {
       const top = typeof options === "object" ? (options.top ?? 0) : 0;
       Object.defineProperty(this, "scrollTop", { configurable: true, value: top });
@@ -1107,55 +1145,6 @@ describe("createWebStreamStrategy", () => {
         }),
       );
     });
-    expect(scrollTo).not.toHaveBeenCalled();
-
-    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1500 });
-    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
-    const pointerDown = new MouseEvent("pointerdown", {
-      bubbles: true,
-      button: 0,
-      buttons: 1,
-      clientX: 100,
-      clientY: 400,
-    });
-    Object.defineProperties(pointerDown, {
-      isPrimary: { value: true },
-      pointerId: { value: 4 },
-      pointerType: { value: "mouse" },
-    });
-    const pointerMove = new MouseEvent("pointermove", {
-      bubbles: true,
-      buttons: 1,
-      clientX: 100,
-      clientY: 300,
-    });
-    Object.defineProperties(pointerMove, {
-      isPrimary: { value: true },
-      pointerId: { value: 4 },
-      pointerType: { value: "mouse" },
-    });
-    act(() => {
-      scrollContainer.dispatchEvent(pointerDown);
-      window.dispatchEvent(pointerMove);
-    });
-    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1100 });
-    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
-    scrollTo.mockClear();
-
-    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 2200 });
-    act(() => {
-      root?.render(
-        strategy.render({
-          ...renderInput,
-          segments: {
-            ...renderInput.segments,
-            liveHead: [userMessage(3), userMessage(4), userMessage(5), userMessage(6)],
-          },
-          boundary: { ...renderInput.boundary, hasLiveHead: true },
-        }),
-      );
-    });
-
     expect(scrollTo).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -26,6 +26,10 @@ vi.hoisted(() => {
   });
 });
 
+vi.mock("react-native-unistyles", () => ({
+  withUnistyles: (Component: React.ComponentType) => Component,
+}));
+
 function userMessage(index: number): StreamItem {
   return {
     kind: "user_message",
@@ -534,6 +538,7 @@ describe("createWebStreamStrategy", () => {
     const strategy = createWebStreamStrategy({ isMobileBreakpoint: true });
     const viewportRef = React.createRef<StreamViewportHandle>();
     const historyMounted = Array.from({ length: 20 }, (_, index) => userMessage(index));
+    const onNearHistoryStart = vi.fn().mockReturnValue(false);
     const routeBottomAnchorRequest = {
       agentId: "agent",
       reason: "initial-entry" as const,
@@ -556,10 +561,10 @@ describe("createWebStreamStrategy", () => {
       viewportRef,
       routeBottomAnchorRequest,
       onNearBottomChange: vi.fn(),
-      onNearHistoryStart: vi.fn().mockReturnValue(true),
+      onNearHistoryStart,
       isLoadingOlderHistory: false,
-      hasOlderHistory: false,
-      olderHistoryProgressKey: null,
+      hasOlderHistory: true,
+      olderHistoryProgressKey: "epoch-1:20",
       scrollEnabled: true,
       listStyle: null,
       baseListContentContainerStyle: null,
@@ -596,7 +601,7 @@ describe("createWebStreamStrategy", () => {
     act(() => {
       scrollContainer.dispatchEvent(new WheelEvent("wheel", { deltaY: -240 }));
     });
-    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 520 });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 0 });
     act(() => {
       scrollContainer.dispatchEvent(new Event("scroll"));
     });
@@ -612,6 +617,14 @@ describe("createWebStreamStrategy", () => {
     });
 
     expect(scrollTo).not.toHaveBeenCalled();
+    await act(async () => Promise.resolve());
+    expect(onNearHistoryStart).toHaveBeenCalledOnce();
+
+    act(() => {
+      scrollContainer.dispatchEvent(new WheelEvent("wheel", { deltaY: -240 }));
+    });
+    await act(async () => Promise.resolve());
+    expect(onNearHistoryStart).toHaveBeenCalledTimes(2);
   });
 
   it("does not force bottom after upward wheel when cached scroll top is stale", async () => {

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -823,7 +823,7 @@ describe("createWebStreamStrategy", () => {
     expect(scrollTo).toHaveBeenCalled();
   });
 
-  it("keeps following output after an upward geometry displacement without user intent", () => {
+  it("keeps following output after geometry, nested-scroll, and zoom wheel events", () => {
     const scrollTo = vi.fn(function (this: HTMLElement, options?: ScrollToOptions | number) {
       const top = typeof options === "object" ? (options.top ?? 0) : 0;
       Object.defineProperty(this, "scrollTop", { configurable: true, value: top });
@@ -877,7 +877,16 @@ describe("createWebStreamStrategy", () => {
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
     scrollTo.mockClear();
 
+    const nestedScroller = document.createElement("div");
+    nestedScroller.style.overflowY = "auto";
+    Object.defineProperty(nestedScroller, "clientHeight", { configurable: true, value: 100 });
+    Object.defineProperty(nestedScroller, "scrollHeight", { configurable: true, value: 300 });
+    Object.defineProperty(nestedScroller, "scrollTop", { configurable: true, value: 100 });
+    scrollContainer.append(nestedScroller);
     act(() => {
+      nestedScroller.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: -100 }));
+      Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 700 });
+      scrollContainer.dispatchEvent(new Event("scroll"));
       scrollContainer.dispatchEvent(
         new WheelEvent("wheel", { bubbles: true, ctrlKey: true, deltaY: -100 }),
       );

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -896,7 +896,7 @@ describe("createWebStreamStrategy", () => {
     expect(scrollTo).toHaveBeenCalledWith({ top: 1800, behavior: "auto" });
   });
 
-  it("stops following output after an upward primary-pointer drag", () => {
+  it("stops following output after pointer-driven upward scrolling", () => {
     const scrollTo = vi.fn(function (this: HTMLElement, options?: ScrollToOptions | number) {
       const top = typeof options === "object" ? (options.top ?? 0) : 0;
       Object.defineProperty(this, "scrollTop", { configurable: true, value: top });
@@ -940,35 +940,37 @@ describe("createWebStreamStrategy", () => {
       throw new Error("Expected agent chat scroll container");
     }
     Object.defineProperty(scrollContainer, "clientHeight", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "clientWidth", { configurable: true, value: 500 });
+    Object.defineProperty(scrollContainer, "offsetWidth", { configurable: true, value: 520 });
     Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1500 });
     Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    scrollContainer.getBoundingClientRect = () =>
+      ({
+        bottom: 500,
+        height: 500,
+        left: 0,
+        right: 520,
+        top: 0,
+        width: 520,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as DOMRect;
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
 
-    const pointerDown = new MouseEvent("pointerdown", {
+    const scrollbarPointerDown = new MouseEvent("pointerdown", {
       bubbles: true,
       button: 0,
       buttons: 1,
+      clientX: 515,
       clientY: 400,
     });
-    Object.defineProperties(pointerDown, {
+    Object.defineProperties(scrollbarPointerDown, {
       isPrimary: { value: true },
       pointerId: { value: 1 },
       pointerType: { value: "mouse" },
     });
-    const pointerMove = new MouseEvent("pointermove", {
-      bubbles: true,
-      buttons: 1,
-      clientY: 300,
-    });
-    Object.defineProperties(pointerMove, {
-      isPrimary: { value: true },
-      pointerId: { value: 1 },
-      pointerType: { value: "mouse" },
-    });
-    act(() => {
-      scrollContainer.dispatchEvent(pointerDown);
-      window.dispatchEvent(pointerMove);
-    });
+    act(() => scrollContainer.dispatchEvent(scrollbarPointerDown));
     Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 700 });
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
     scrollTo.mockClear();
@@ -979,6 +981,54 @@ describe("createWebStreamStrategy", () => {
         strategy.render({
           ...renderInput,
           segments: { ...renderInput.segments, liveHead: [userMessage(3)] },
+          boundary: { ...renderInput.boundary, hasLiveHead: true },
+        }),
+      );
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1300 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    const pointerDown = new MouseEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      clientX: 100,
+      clientY: 400,
+    });
+    Object.defineProperties(pointerDown, {
+      isPrimary: { value: true },
+      pointerId: { value: 2 },
+      pointerType: { value: "mouse" },
+    });
+    const pointerMove = new MouseEvent("pointermove", {
+      bubbles: true,
+      buttons: 1,
+      clientX: 100,
+      clientY: 300,
+    });
+    Object.defineProperties(pointerMove, {
+      isPrimary: { value: true },
+      pointerId: { value: 2 },
+      pointerType: { value: "mouse" },
+    });
+    act(() => {
+      scrollContainer.dispatchEvent(pointerDown);
+      window.dispatchEvent(pointerMove);
+    });
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1000 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    scrollTo.mockClear();
+
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 2100 });
+    act(() => {
+      root?.render(
+        strategy.render({
+          ...renderInput,
+          segments: {
+            ...renderInput.segments,
+            liveHead: [userMessage(3), userMessage(4)],
+          },
           boundary: { ...renderInput.boundary, hasLiveHead: true },
         }),
       );

--- a/packages/app/src/agent-stream/strategy-web.test.tsx
+++ b/packages/app/src/agent-stream/strategy-web.test.tsx
@@ -989,6 +989,53 @@ describe("createWebStreamStrategy", () => {
 
     Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1300 });
     act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    Object.defineProperty(scrollContainer, "offsetWidth", { configurable: true, value: 500 });
+    scrollContainer.getBoundingClientRect = () =>
+      ({
+        bottom: 500,
+        height: 500,
+        left: 0,
+        right: 500,
+        top: 0,
+        width: 500,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as DOMRect;
+    const overlayScrollbarPointerDown = new MouseEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      clientX: 495,
+      clientY: 400,
+    });
+    Object.defineProperties(overlayScrollbarPointerDown, {
+      isPrimary: { value: true },
+      pointerId: { value: 2 },
+      pointerType: { value: "mouse" },
+    });
+    act(() => scrollContainer.dispatchEvent(overlayScrollbarPointerDown));
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 900 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
+    scrollTo.mockClear();
+
+    Object.defineProperty(scrollContainer, "scrollHeight", { configurable: true, value: 1900 });
+    act(() => {
+      root?.render(
+        strategy.render({
+          ...renderInput,
+          segments: {
+            ...renderInput.segments,
+            liveHead: [userMessage(3), userMessage(4)],
+          },
+          boundary: { ...renderInput.boundary, hasLiveHead: true },
+        }),
+      );
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    Object.defineProperty(scrollContainer, "scrollTop", { configurable: true, value: 1400 });
+    act(() => scrollContainer.dispatchEvent(new Event("scroll")));
     const pointerDown = new MouseEvent("pointerdown", {
       bubbles: true,
       button: 0,
@@ -998,7 +1045,7 @@ describe("createWebStreamStrategy", () => {
     });
     Object.defineProperties(pointerDown, {
       isPrimary: { value: true },
-      pointerId: { value: 2 },
+      pointerId: { value: 3 },
       pointerType: { value: "mouse" },
     });
     const pointerMove = new MouseEvent("pointermove", {
@@ -1009,7 +1056,7 @@ describe("createWebStreamStrategy", () => {
     });
     Object.defineProperties(pointerMove, {
       isPrimary: { value: true },
-      pointerId: { value: 2 },
+      pointerId: { value: 3 },
       pointerType: { value: "mouse" },
     });
     act(() => {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { measureElement as measureVirtualElement, useVirtualizer } from "@tanstack/react-virtual";
 import { withUnistyles } from "react-native-unistyles";
+import { useRetainedPanelActive } from "@/components/retained-panel";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import type { Theme } from "@/styles/theme";
@@ -105,6 +106,21 @@ function isScrollContainerAtBottom(
   return isScrollContainerNearBottom(scrollContainer, AUTO_SCROLL_RESUME_THRESHOLD_PX);
 }
 
+function isScrollContainerMeasurable(
+  scrollContainer: Pick<HTMLElement, "clientHeight" | "scrollHeight">,
+): boolean {
+  return scrollContainer.clientHeight > 0 && scrollContainer.scrollHeight > 0;
+}
+
+function isUpwardScrollKey(event: KeyboardEvent): boolean {
+  return (
+    event.key === "ArrowUp" ||
+    event.key === "PageUp" ||
+    event.key === "Home" ||
+    (event.key === " " && event.shiftKey)
+  );
+}
+
 function scrollElementToBottom(
   scrollContainer: HTMLElement,
   behavior: ScrollBehaviorLike = "auto",
@@ -159,6 +175,8 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     scrollEnabled,
     isMobileBreakpoint,
   } = props;
+  const isActive = useRetainedPanelActive();
+  const isActiveRef = useRef(isActive);
   const scrollContainerRef = useRef<HTMLElement | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
   const handleScrollContainerRef = useCallback((node: HTMLElement | null) => {
@@ -176,6 +194,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   };
   const lastKnownScrollTopRef = useRef(0);
   const pendingUserScrollUpIntentRef = useRef(false);
+  const isPointerScrollActiveRef = useRef(false);
   const lastTouchClientYRef = useRef<number | null>(null);
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const pendingAutoScrollTimeoutRef = useRef<number | null>(null);
@@ -196,6 +215,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     renderLiveAuxiliary,
   } = renderers;
 
+  isActiveRef.current = isActive;
   followOutputRef.current = followOutput;
 
   const hasRouteBottomAnchorRequest = routeBottomAnchorRequest !== null;
@@ -234,7 +254,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const virtualTotalSize = rowVirtualizer.getTotalSize();
   const getHistoryStartPaginationInput = useStableEvent((): HistoryStartPaginationInput | null => {
     const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer) {
+    if (!isActiveRef.current || !scrollContainer || !isScrollContainerMeasurable(scrollContainer)) {
       return null;
     }
     const bottomAnchorSettled =
@@ -371,6 +391,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   });
 
   useLayoutEffect(() => {
+    if (!isActiveRef.current) {
+      return;
+    }
     const anchor = historyStartPrependAnchorRef.current;
     if (!anchor || anchor.progressKey === olderHistoryProgressKey) {
       return;
@@ -402,7 +425,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       }
       const frame = window.requestAnimationFrame(() => {
         pendingFrames.delete(node);
-        if (node.isConnected) {
+        if (isActiveRef.current && node.isConnected) {
           rowVirtualizer.measureElement(node);
         }
       });
@@ -434,10 +457,29 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
   }, []);
 
+  useLayoutEffect(() => {
+    if (isActive) {
+      return;
+    }
+    cancelPendingStickToBottom();
+    historyStartSettleSchedulerRef.current?.cancel();
+    for (const frame of pendingVirtualRowMeasureFramesRef.current.values()) {
+      window.cancelAnimationFrame(frame);
+    }
+    pendingVirtualRowMeasureFramesRef.current.clear();
+    pendingUserScrollUpIntentRef.current = false;
+    isPointerScrollActiveRef.current = false;
+    lastTouchClientYRef.current = null;
+  }, [cancelPendingStickToBottom, isActive]);
+
   const scrollMessagesToBottom = useCallback(
     (behavior: ScrollBehaviorLike = "auto") => {
       const scrollContainer = scrollContainerRef.current;
-      if (!scrollContainer) {
+      if (
+        !isActiveRef.current ||
+        !scrollContainer ||
+        !isScrollContainerMeasurable(scrollContainer)
+      ) {
         return;
       }
       if (isScrollContainerOverscrolledPastBottom(scrollContainer)) {
@@ -452,6 +494,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   );
 
   const scheduleStickToBottom = useCallback(() => {
+    if (!isActiveRef.current) {
+      return;
+    }
     const scrollContainer = scrollContainerRef.current;
     if (scrollContainer && isScrollContainerOverscrolledPastBottom(scrollContainer)) {
       return;
@@ -461,7 +506,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
     pendingAutoScrollFrameRef.current = window.requestAnimationFrame(() => {
       pendingAutoScrollFrameRef.current = null;
-      if (!followOutputRef.current) {
+      if (!isActiveRef.current || !followOutputRef.current) {
         return;
       }
       scrollMessagesToBottom("auto");
@@ -477,6 +522,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   // Rows are laid out in DOM order, virtualized block first, so the first row whose bottom
   // clears the reading line is the one the reader is looking at.
   const reportReadingPosition = useStableEvent(() => {
+    if (!isActiveRef.current) {
+      return;
+    }
     if (!onReadingPositionChange) {
       return;
     }
@@ -502,6 +550,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   });
 
   const updateScrollMetrics = useCallback(() => {
+    if (!isActiveRef.current) {
+      return;
+    }
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) {
       onNearBottomChange(true);
@@ -512,6 +563,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, [onNearBottomChange, reportReadingPosition]);
 
   const { isJumpSettling, scrollToMessage } = useScrollToMessage({
+    active: isActive,
     scrollContainerRef,
     rowVirtualizer,
     historyVirtualized: segments.historyVirtualized,
@@ -522,7 +574,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
   const handleDomScroll = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer) {
+    if (!isActiveRef.current || !scrollContainer || !isScrollContainerMeasurable(scrollContainer)) {
       return;
     }
 
@@ -532,21 +584,18 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     const scrolledDown =
       currentScrollTop > lastKnownScrollTopRef.current + USER_SCROLL_DELTA_EPSILON;
 
-    if (scrolledUp) {
-      cancelPendingStickToBottom();
-      if (followOutputRef.current) {
-        setFollowOutput(false);
-      }
-      pendingUserScrollUpIntentRef.current = false;
-      rearmHistoryStartFromUserIntent();
-    } else if (!followOutputRef.current && isAtBottom && scrolledDown && !isJumpSettling()) {
+    const hasUserScrollUpIntent =
+      pendingUserScrollUpIntentRef.current || isPointerScrollActiveRef.current;
+
+    if (!followOutputRef.current && isAtBottom && scrolledDown && !isJumpSettling()) {
       setFollowOutput(true);
       pendingUserScrollUpIntentRef.current = false;
-    } else if (followOutputRef.current && pendingUserScrollUpIntentRef.current) {
-      if (!isAtBottom) {
-        cancelPendingStickToBottom();
-        setFollowOutput(false);
-      }
+    } else if (followOutputRef.current && hasUserScrollUpIntent && (scrolledUp || !isAtBottom)) {
+      cancelPendingStickToBottom();
+      setFollowOutput(false);
+      pendingUserScrollUpIntentRef.current = false;
+      rearmHistoryStartFromUserIntent();
+    } else if (pendingUserScrollUpIntentRef.current) {
       pendingUserScrollUpIntentRef.current = false;
     }
 
@@ -580,7 +629,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, [evaluateHistoryStart, props.agentId]);
 
   useLayoutEffect(() => {
-    if (!isActivationReady) {
+    if (!isActiveRef.current || !isActivationReady) {
       return;
     }
     if (hasRouteBottomAnchorRequest && !followOutputRef.current) {
@@ -615,13 +664,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   // Following output is a layout invariant: rows, footer, and bottom offset must
   // reach the browser in the same paint.
   useLayoutEffect(() => {
-    if (!followOutputRef.current) {
+    if (!isActive || !followOutputRef.current) {
       return;
     }
     cancelPendingStickToBottom();
     scrollMessagesToBottom("auto");
   }, [
     cancelPendingStickToBottom,
+    isActive,
     renderLiveAuxiliary,
     scrollMessagesToBottom,
     segments.historyMounted,
@@ -631,6 +681,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   ]);
 
   useEffect(() => {
+    if (!isActive) {
+      return;
+    }
     updateScrollMetrics();
     evaluateHistoryStart();
     if (historyStartPaginationStateRef.current.status === "settling") {
@@ -639,6 +692,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, [
     evaluateHistoryStart,
     hasOlderHistory,
+    isActive,
     isLoadingOlderHistory,
     olderHistoryProgressKey,
     scheduleHistoryStartPrependSettle,
@@ -649,7 +703,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     virtualTotalSize,
   ]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (!isActive) {
+      return;
+    }
     const scrollContainer = scrollContainerRef.current;
     const contentNode = contentRef.current;
     if (!scrollContainer || typeof ResizeObserver === "undefined") {
@@ -682,12 +739,16 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, [
     applyHistoryStartPrependAnchor,
     evaluateHistoryStart,
+    isActive,
     scheduleHistoryStartPrependSettle,
     scheduleStickToBottom,
     updateScrollMetrics,
   ]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (!isActive) {
+      return;
+    }
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) {
       return;
@@ -699,6 +760,20 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         cancelPendingStickToBottom();
         rearmHistoryStartFromUserIntent();
       }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isUpwardScrollKey(event)) {
+        return;
+      }
+      pendingUserScrollUpIntentRef.current = true;
+      cancelPendingStickToBottom();
+      rearmHistoryStartFromUserIntent();
+    };
+    const handlePointerDown = () => {
+      isPointerScrollActiveRef.current = true;
+    };
+    const handlePointerUp = () => {
+      isPointerScrollActiveRef.current = false;
     };
     const handleTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
@@ -726,6 +801,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
     scrollContainer.addEventListener("scroll", handleDomScroll, { passive: true });
     scrollContainer.addEventListener("wheel", handleWheel, { passive: true });
+    scrollContainer.addEventListener("keydown", handleKeyDown, { passive: true });
+    scrollContainer.addEventListener("pointerdown", handlePointerDown, { passive: true });
+    scrollContainer.addEventListener("pointerup", handlePointerUp, { passive: true });
+    scrollContainer.addEventListener("pointercancel", handlePointerUp, { passive: true });
     scrollContainer.addEventListener("touchstart", handleTouchStart, { passive: true });
     scrollContainer.addEventListener("touchmove", handleTouchMove, { passive: true });
     scrollContainer.addEventListener("touchend", handleTouchEnd, { passive: true });
@@ -734,12 +813,16 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     return () => {
       scrollContainer.removeEventListener("scroll", handleDomScroll);
       scrollContainer.removeEventListener("wheel", handleWheel);
+      scrollContainer.removeEventListener("keydown", handleKeyDown);
+      scrollContainer.removeEventListener("pointerdown", handlePointerDown);
+      scrollContainer.removeEventListener("pointerup", handlePointerUp);
+      scrollContainer.removeEventListener("pointercancel", handlePointerUp);
       scrollContainer.removeEventListener("touchstart", handleTouchStart);
       scrollContainer.removeEventListener("touchmove", handleTouchMove);
       scrollContainer.removeEventListener("touchend", handleTouchEnd);
       scrollContainer.removeEventListener("touchcancel", handleTouchEnd);
     };
-  }, [cancelPendingStickToBottom, handleDomScroll, rearmHistoryStartFromUserIntent]);
+  }, [cancelPendingStickToBottom, handleDomScroll, isActive, rearmHistoryStartFromUserIntent]);
 
   useEffect(() => {
     const handle: StreamViewportHandle = {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -253,6 +253,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   const lastKnownScrollTopRef = useRef(0);
   const mouseScrollGestureRef = useRef<{
     pointerId: number;
+    button: 0 | 1;
     lastClientY: number;
     startedInScrollbarGutter: boolean;
     hasUpwardContentDragEvidence: boolean;
@@ -867,13 +868,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       if (
         event.pointerType !== "mouse" ||
         !event.isPrimary ||
-        event.button !== 0 ||
+        (event.button !== 0 && event.button !== 1) ||
         isEditableEventTarget(event.target)
       ) {
         return;
       }
       mouseScrollGestureRef.current = {
         pointerId: event.pointerId,
+        button: event.button,
         lastClientY: event.clientY,
         startedInScrollbarGutter: isVerticalScrollbarGutterPress(event, scrollContainer),
         hasUpwardContentDragEvidence: false,
@@ -885,7 +887,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       if (!gesture || gesture.pointerId !== event.pointerId) {
         return;
       }
-      if ((event.buttons & 1) === 0) {
+      if (gesture.button === 0 && (event.buttons & 1) === 0) {
         clearMouseScrollGesture();
         return;
       }
@@ -899,14 +901,24 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         }
         gesture.evidenceExpiryFrame = window.requestAnimationFrame(() => {
           if (mouseScrollGestureRef.current === gesture) {
-            gesture.hasUpwardContentDragEvidence = false;
-            gesture.evidenceExpiryFrame = null;
+            if (gesture.button === 1) {
+              mouseScrollGestureRef.current = null;
+            } else {
+              gesture.hasUpwardContentDragEvidence = false;
+              gesture.evidenceExpiryFrame = null;
+            }
           }
         });
       }
       gesture.lastClientY = event.clientY;
     };
     const handlePointerEnd = (event: PointerEvent) => {
+      const gesture = mouseScrollGestureRef.current;
+      if (gesture?.pointerId === event.pointerId && gesture.button === 0) {
+        clearMouseScrollGesture();
+      }
+    };
+    const handlePointerCancel = (event: PointerEvent) => {
       if (mouseScrollGestureRef.current?.pointerId === event.pointerId) {
         clearMouseScrollGesture();
       }
@@ -943,7 +955,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     scrollContainer.addEventListener("pointerdown", handlePointerDown, { passive: true });
     window.addEventListener("pointermove", handlePointerMove, { passive: true });
     window.addEventListener("pointerup", handlePointerEnd, { passive: true });
-    window.addEventListener("pointercancel", handlePointerEnd, { passive: true });
+    window.addEventListener("pointercancel", handlePointerCancel, { passive: true });
     window.addEventListener("blur", clearMouseScrollGesture);
     scrollContainer.addEventListener("touchstart", handleTouchStart, { passive: true });
     scrollContainer.addEventListener("touchmove", handleTouchMove, { passive: true });
@@ -957,7 +969,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       scrollContainer.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener("pointerup", handlePointerEnd);
-      window.removeEventListener("pointercancel", handlePointerEnd);
+      window.removeEventListener("pointercancel", handlePointerCancel);
       window.removeEventListener("blur", clearMouseScrollGesture);
       scrollContainer.removeEventListener("touchstart", handleTouchStart);
       scrollContainer.removeEventListener("touchmove", handleTouchMove);

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -838,13 +838,19 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       return;
     }
 
+    const markUpwardViewportInput = () => {
+      markUpwardInputEvidence();
+      if (scrollContainer.scrollTop <= USER_SCROLL_DELTA_EPSILON) {
+        rearmHistoryStartFromUserIntent();
+      }
+    };
     const handleWheel = (event: WheelEvent) => {
       if (
         !event.ctrlKey &&
         event.deltaY < 0 &&
         !canNestedScrollerConsumeUpwardInput(event.target, scrollContainer)
       ) {
-        markUpwardInputEvidence();
+        markUpwardViewportInput();
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -854,7 +860,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       if (canNestedScrollerConsumeUpwardInput(event.target, scrollContainer)) {
         return;
       }
-      markUpwardInputEvidence();
+      markUpwardViewportInput();
     };
     const handlePointerDown = (event: PointerEvent) => {
       clearMouseScrollGesture();
@@ -923,7 +929,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         touch.clientY > previousTouchY + 1 &&
         !canNestedScrollerConsumeUpwardInput(event.target, scrollContainer)
       ) {
-        markUpwardInputEvidence();
+        markUpwardViewportInput();
       }
       lastTouchClientYRef.current = touch.clientY;
     };
@@ -965,6 +971,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     handleDomScroll,
     isActive,
     markUpwardInputEvidence,
+    rearmHistoryStartFromUserIntent,
   ]);
 
   useEffect(() => {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -112,7 +112,25 @@ function isScrollContainerMeasurable(
   return scrollContainer.clientHeight > 0 && scrollContainer.scrollHeight > 0;
 }
 
-function isUpwardScrollKey(event: KeyboardEvent): boolean {
+function isEditableEventTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  const editableRoot = target.closest("input, textarea, [contenteditable]");
+  if (!editableRoot) {
+    return false;
+  }
+  const tagName = editableRoot.tagName.toLowerCase();
+  if (tagName === "input" || tagName === "textarea") {
+    return true;
+  }
+  return editableRoot.getAttribute("contenteditable")?.toLowerCase() !== "false";
+}
+
+function isUpwardViewportScrollKey(event: KeyboardEvent): boolean {
+  if (isEditableEventTarget(event.target)) {
+    return false;
+  }
   return (
     event.key === "ArrowUp" ||
     event.key === "PageUp" ||
@@ -748,7 +766,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!isUpwardScrollKey(event)) {
+      if (!isUpwardViewportScrollKey(event)) {
         return;
       }
       stopFollowingOutputFromUserIntent();

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -53,6 +53,7 @@ const AUTO_SCROLL_RESUME_THRESHOLD_PX = 1;
 const HISTORY_START_SETTLE_FRAMES = 2;
 const HISTORY_START_SLOT_HEIGHT_PX = 32;
 const CONTENT_PADDING_TOP_PX = 16;
+const UPWARD_INPUT_EVIDENCE_TIMEOUT_MS = 100;
 const VIRTUALIZER_SCROLL_MARGIN_PX = HISTORY_START_SLOT_HEIGHT_PX + CONTENT_PADDING_TOP_PX;
 // A row has to clear this much of the viewport top before the next one takes over as the
 // reading position, so a row resting exactly on the edge does not flip back and forth.
@@ -138,6 +139,24 @@ function isUpwardViewportScrollKey(event: KeyboardEvent): boolean {
     event.key === "Home" ||
     (event.key === " " && event.shiftKey)
   );
+}
+
+function canNestedScrollerConsumeUpwardInput(
+  target: EventTarget | null,
+  scrollContainer: HTMLElement,
+): boolean {
+  let element = target instanceof Element ? target : null;
+  while (element && element !== scrollContainer) {
+    if (element instanceof HTMLElement) {
+      const overflowY = window.getComputedStyle(element).overflowY;
+      const canScroll = overflowY === "auto" || overflowY === "scroll";
+      if (canScroll && element.scrollHeight > element.clientHeight && element.scrollTop > 0) {
+        return true;
+      }
+    }
+    element = element.parentElement;
+  }
+  return false;
 }
 
 function isVerticalScrollbarGutterPress(
@@ -239,6 +258,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     hasUpwardContentDragEvidence: boolean;
     evidenceExpiryFrame: number | null;
   } | null>(null);
+  const upwardInputEvidenceUntilRef = useRef(0);
   const lastTouchClientYRef = useRef<number | null>(null);
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const pendingAutoScrollTimeoutRef = useRef<number | null>(null);
@@ -509,6 +529,15 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     mouseScrollGestureRef.current = null;
   }, []);
 
+  const clearUpwardInputEvidence = useCallback(() => {
+    upwardInputEvidenceUntilRef.current = 0;
+  }, []);
+
+  const markUpwardInputEvidence = useCallback(() => {
+    upwardInputEvidenceUntilRef.current =
+      window.performance.now() + UPWARD_INPUT_EVIDENCE_TIMEOUT_MS;
+  }, []);
+
   useLayoutEffect(() => {
     if (isActive) {
       return;
@@ -520,8 +549,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
     pendingVirtualRowMeasureFramesRef.current.clear();
     clearMouseScrollGesture();
+    clearUpwardInputEvidence();
     lastTouchClientYRef.current = null;
-  }, [cancelPendingStickToBottom, clearMouseScrollGesture, isActive]);
+  }, [cancelPendingStickToBottom, clearMouseScrollGesture, clearUpwardInputEvidence, isActive]);
 
   const scrollMessagesToBottom = useCallback(
     (behavior: ScrollBehaviorLike = "auto") => {
@@ -643,13 +673,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     const scrolledDown =
       currentScrollTop > lastKnownScrollTopRef.current + USER_SCROLL_DELTA_EPSILON;
     const mouseGesture = mouseScrollGestureRef.current;
-    const hasPointerScrollIntent =
+    const hasUpwardInputEvidence =
       mouseGesture?.startedInScrollbarGutter === true ||
-      mouseGesture?.hasUpwardContentDragEvidence === true;
+      mouseGesture?.hasUpwardContentDragEvidence === true ||
+      window.performance.now() < upwardInputEvidenceUntilRef.current;
 
     if (!followOutputRef.current && isAtBottom && scrolledDown && !isJumpSettling()) {
       setFollowOutput(true);
-    } else if (followOutputRef.current && scrolledUp && hasPointerScrollIntent) {
+    } else if (followOutputRef.current && scrolledUp && hasUpwardInputEvidence) {
       stopFollowingOutputFromUserIntent();
     }
 
@@ -808,15 +839,22 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
 
     const handleWheel = (event: WheelEvent) => {
-      if (!event.ctrlKey && event.deltaY < 0) {
-        stopFollowingOutputFromUserIntent();
+      if (
+        !event.ctrlKey &&
+        event.deltaY < 0 &&
+        !canNestedScrollerConsumeUpwardInput(event.target, scrollContainer)
+      ) {
+        markUpwardInputEvidence();
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!isUpwardViewportScrollKey(event)) {
         return;
       }
-      stopFollowingOutputFromUserIntent();
+      if (canNestedScrollerConsumeUpwardInput(event.target, scrollContainer)) {
+        return;
+      }
+      markUpwardInputEvidence();
     };
     const handlePointerDown = (event: PointerEvent) => {
       clearMouseScrollGesture();
@@ -880,8 +918,12 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
         return;
       }
       const previousTouchY = lastTouchClientYRef.current;
-      if (previousTouchY !== null && touch.clientY > previousTouchY + 1) {
-        stopFollowingOutputFromUserIntent();
+      if (
+        previousTouchY !== null &&
+        touch.clientY > previousTouchY + 1 &&
+        !canNestedScrollerConsumeUpwardInput(event.target, scrollContainer)
+      ) {
+        markUpwardInputEvidence();
       }
       lastTouchClientYRef.current = touch.clientY;
     };
@@ -915,8 +957,15 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       scrollContainer.removeEventListener("touchmove", handleTouchMove);
       scrollContainer.removeEventListener("touchend", handleTouchEnd);
       scrollContainer.removeEventListener("touchcancel", handleTouchEnd);
+      clearUpwardInputEvidence();
     };
-  }, [clearMouseScrollGesture, handleDomScroll, isActive, stopFollowingOutputFromUserIntent]);
+  }, [
+    clearMouseScrollGesture,
+    clearUpwardInputEvidence,
+    handleDomScroll,
+    isActive,
+    markUpwardInputEvidence,
+  ]);
 
   useEffect(() => {
     const handle: StreamViewportHandle = {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -139,6 +139,23 @@ function isUpwardViewportScrollKey(event: KeyboardEvent): boolean {
   );
 }
 
+function isVerticalScrollbarGutterPress(
+  event: PointerEvent,
+  scrollContainer: HTMLElement,
+): boolean {
+  if (event.target !== scrollContainer) {
+    return false;
+  }
+  const scrollbarWidth = scrollContainer.offsetWidth - scrollContainer.clientWidth;
+  if (scrollbarWidth <= 0) {
+    return false;
+  }
+  const bounds = scrollContainer.getBoundingClientRect();
+  return window.getComputedStyle(scrollContainer).direction === "rtl"
+    ? event.clientX <= bounds.left + scrollbarWidth
+    : event.clientX >= bounds.right - scrollbarWidth;
+}
+
 function scrollElementToBottom(
   scrollContainer: HTMLElement,
   behavior: ScrollBehaviorLike = "auto",
@@ -211,7 +228,13 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     return value;
   };
   const lastKnownScrollTopRef = useRef(0);
-  const mouseDragRef = useRef<{ pointerId: number; lastClientY: number } | null>(null);
+  const mouseScrollGestureRef = useRef<{
+    pointerId: number;
+    lastClientY: number;
+    startedInScrollbarGutter: boolean;
+    hasUpwardContentDragEvidence: boolean;
+    evidenceExpiryFrame: number | null;
+  } | null>(null);
   const lastTouchClientYRef = useRef<number | null>(null);
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const pendingAutoScrollTimeoutRef = useRef<number | null>(null);
@@ -474,6 +497,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
   }, []);
 
+  const clearMouseScrollGesture = useCallback(() => {
+    const evidenceExpiryFrame = mouseScrollGestureRef.current?.evidenceExpiryFrame;
+    if (evidenceExpiryFrame !== null && evidenceExpiryFrame !== undefined) {
+      window.cancelAnimationFrame(evidenceExpiryFrame);
+    }
+    mouseScrollGestureRef.current = null;
+  }, []);
+
   useLayoutEffect(() => {
     if (isActive) {
       return;
@@ -484,9 +515,9 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       window.cancelAnimationFrame(frame);
     }
     pendingVirtualRowMeasureFramesRef.current.clear();
-    mouseDragRef.current = null;
+    clearMouseScrollGesture();
     lastTouchClientYRef.current = null;
-  }, [cancelPendingStickToBottom, isActive]);
+  }, [cancelPendingStickToBottom, clearMouseScrollGesture, isActive]);
 
   const scrollMessagesToBottom = useCallback(
     (behavior: ScrollBehaviorLike = "auto") => {
@@ -604,17 +635,29 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
     const currentScrollTop = scrollContainer.scrollTop;
     const isAtBottom = isScrollContainerAtBottom(scrollContainer);
+    const scrolledUp = currentScrollTop < lastKnownScrollTopRef.current - USER_SCROLL_DELTA_EPSILON;
     const scrolledDown =
       currentScrollTop > lastKnownScrollTopRef.current + USER_SCROLL_DELTA_EPSILON;
+    const mouseGesture = mouseScrollGestureRef.current;
+    const hasPointerScrollIntent =
+      mouseGesture?.startedInScrollbarGutter === true ||
+      mouseGesture?.hasUpwardContentDragEvidence === true;
 
     if (!followOutputRef.current && isAtBottom && scrolledDown && !isJumpSettling()) {
       setFollowOutput(true);
+    } else if (followOutputRef.current && scrolledUp && hasPointerScrollIntent) {
+      stopFollowingOutputFromUserIntent();
     }
 
     lastKnownScrollTopRef.current = currentScrollTop;
     updateScrollMetrics();
     evaluateHistoryStart();
-  }, [evaluateHistoryStart, isJumpSettling, updateScrollMetrics]);
+  }, [
+    evaluateHistoryStart,
+    isJumpSettling,
+    stopFollowingOutputFromUserIntent,
+    updateScrollMetrics,
+  ]);
 
   useEffect(() => {
     const initialHistoryStartState = createHistoryStartPaginationState();
@@ -772,32 +815,53 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       stopFollowingOutputFromUserIntent();
     };
     const handlePointerDown = (event: PointerEvent) => {
-      if (event.pointerType !== "mouse" || !event.isPrimary || event.button !== 0) {
+      clearMouseScrollGesture();
+      if (
+        event.pointerType !== "mouse" ||
+        !event.isPrimary ||
+        event.button !== 0 ||
+        isEditableEventTarget(event.target)
+      ) {
         return;
       }
-      mouseDragRef.current = { pointerId: event.pointerId, lastClientY: event.clientY };
+      mouseScrollGestureRef.current = {
+        pointerId: event.pointerId,
+        lastClientY: event.clientY,
+        startedInScrollbarGutter: isVerticalScrollbarGutterPress(event, scrollContainer),
+        hasUpwardContentDragEvidence: false,
+        evidenceExpiryFrame: null,
+      };
     };
     const handlePointerMove = (event: PointerEvent) => {
-      const drag = mouseDragRef.current;
-      if (!drag || drag.pointerId !== event.pointerId) {
+      const gesture = mouseScrollGestureRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) {
         return;
       }
       if ((event.buttons & 1) === 0) {
-        mouseDragRef.current = null;
+        clearMouseScrollGesture();
         return;
       }
-      if (event.clientY < drag.lastClientY - 1) {
-        stopFollowingOutputFromUserIntent();
+      if (
+        !gesture.startedInScrollbarGutter &&
+        event.clientY < gesture.lastClientY - USER_SCROLL_DELTA_EPSILON
+      ) {
+        gesture.hasUpwardContentDragEvidence = true;
+        if (gesture.evidenceExpiryFrame !== null) {
+          window.cancelAnimationFrame(gesture.evidenceExpiryFrame);
+        }
+        gesture.evidenceExpiryFrame = window.requestAnimationFrame(() => {
+          if (mouseScrollGestureRef.current === gesture) {
+            gesture.hasUpwardContentDragEvidence = false;
+            gesture.evidenceExpiryFrame = null;
+          }
+        });
       }
-      drag.lastClientY = event.clientY;
+      gesture.lastClientY = event.clientY;
     };
     const handlePointerEnd = (event: PointerEvent) => {
-      if (mouseDragRef.current?.pointerId === event.pointerId) {
-        mouseDragRef.current = null;
+      if (mouseScrollGestureRef.current?.pointerId === event.pointerId) {
+        clearMouseScrollGesture();
       }
-    };
-    const handlePointerInactivity = () => {
-      mouseDragRef.current = null;
     };
     const handleTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
@@ -828,7 +892,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     window.addEventListener("pointermove", handlePointerMove, { passive: true });
     window.addEventListener("pointerup", handlePointerEnd, { passive: true });
     window.addEventListener("pointercancel", handlePointerEnd, { passive: true });
-    window.addEventListener("blur", handlePointerInactivity);
+    window.addEventListener("blur", clearMouseScrollGesture);
     scrollContainer.addEventListener("touchstart", handleTouchStart, { passive: true });
     scrollContainer.addEventListener("touchmove", handleTouchMove, { passive: true });
     scrollContainer.addEventListener("touchend", handleTouchEnd, { passive: true });
@@ -842,13 +906,13 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener("pointerup", handlePointerEnd);
       window.removeEventListener("pointercancel", handlePointerEnd);
-      window.removeEventListener("blur", handlePointerInactivity);
+      window.removeEventListener("blur", clearMouseScrollGesture);
       scrollContainer.removeEventListener("touchstart", handleTouchStart);
       scrollContainer.removeEventListener("touchmove", handleTouchMove);
       scrollContainer.removeEventListener("touchend", handleTouchEnd);
       scrollContainer.removeEventListener("touchcancel", handleTouchEnd);
     };
-  }, [handleDomScroll, isActive, stopFollowingOutputFromUserIntent]);
+  }, [clearMouseScrollGesture, handleDomScroll, isActive, stopFollowingOutputFromUserIntent]);
 
   useEffect(() => {
     const handle: StreamViewportHandle = {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -193,8 +193,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     return value;
   };
   const lastKnownScrollTopRef = useRef(0);
-  const pendingUserScrollUpIntentRef = useRef(false);
-  const isPointerScrollActiveRef = useRef(false);
+  const mouseDragRef = useRef<{ pointerId: number; lastClientY: number } | null>(null);
   const lastTouchClientYRef = useRef<number | null>(null);
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const pendingAutoScrollTimeoutRef = useRef<number | null>(null);
@@ -467,8 +466,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       window.cancelAnimationFrame(frame);
     }
     pendingVirtualRowMeasureFramesRef.current.clear();
-    pendingUserScrollUpIntentRef.current = false;
-    isPointerScrollActiveRef.current = false;
+    mouseDragRef.current = null;
     lastTouchClientYRef.current = null;
   }, [cancelPendingStickToBottom, isActive]);
 
@@ -572,6 +570,14 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     onNearBottomChange,
   });
 
+  const stopFollowingOutputFromUserIntent = useStableEvent(() => {
+    cancelPendingStickToBottom();
+    if (followOutputRef.current) {
+      setFollowOutput(false);
+    }
+    rearmHistoryStartFromUserIntent();
+  });
+
   const handleDomScroll = useCallback(() => {
     const scrollContainer = scrollContainerRef.current;
     if (!isActiveRef.current || !scrollContainer || !isScrollContainerMeasurable(scrollContainer)) {
@@ -580,35 +586,17 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
     const currentScrollTop = scrollContainer.scrollTop;
     const isAtBottom = isScrollContainerAtBottom(scrollContainer);
-    const scrolledUp = currentScrollTop < lastKnownScrollTopRef.current - USER_SCROLL_DELTA_EPSILON;
     const scrolledDown =
       currentScrollTop > lastKnownScrollTopRef.current + USER_SCROLL_DELTA_EPSILON;
 
-    const hasUserScrollUpIntent =
-      pendingUserScrollUpIntentRef.current || isPointerScrollActiveRef.current;
-
     if (!followOutputRef.current && isAtBottom && scrolledDown && !isJumpSettling()) {
       setFollowOutput(true);
-      pendingUserScrollUpIntentRef.current = false;
-    } else if (followOutputRef.current && hasUserScrollUpIntent && (scrolledUp || !isAtBottom)) {
-      cancelPendingStickToBottom();
-      setFollowOutput(false);
-      pendingUserScrollUpIntentRef.current = false;
-      rearmHistoryStartFromUserIntent();
-    } else if (pendingUserScrollUpIntentRef.current) {
-      pendingUserScrollUpIntentRef.current = false;
     }
 
     lastKnownScrollTopRef.current = currentScrollTop;
     updateScrollMetrics();
     evaluateHistoryStart();
-  }, [
-    cancelPendingStickToBottom,
-    evaluateHistoryStart,
-    isJumpSettling,
-    rearmHistoryStartFromUserIntent,
-    updateScrollMetrics,
-  ]);
+  }, [evaluateHistoryStart, isJumpSettling, updateScrollMetrics]);
 
   useEffect(() => {
     const initialHistoryStartState = createHistoryStartPaginationState();
@@ -756,24 +744,42 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
 
     const handleWheel = (event: WheelEvent) => {
       if (event.deltaY < 0) {
-        pendingUserScrollUpIntentRef.current = true;
-        cancelPendingStickToBottom();
-        rearmHistoryStartFromUserIntent();
+        stopFollowingOutputFromUserIntent();
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!isUpwardScrollKey(event)) {
         return;
       }
-      pendingUserScrollUpIntentRef.current = true;
-      cancelPendingStickToBottom();
-      rearmHistoryStartFromUserIntent();
+      stopFollowingOutputFromUserIntent();
     };
-    const handlePointerDown = () => {
-      isPointerScrollActiveRef.current = true;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.pointerType !== "mouse" || !event.isPrimary || event.button !== 0) {
+        return;
+      }
+      mouseDragRef.current = { pointerId: event.pointerId, lastClientY: event.clientY };
     };
-    const handlePointerUp = () => {
-      isPointerScrollActiveRef.current = false;
+    const handlePointerMove = (event: PointerEvent) => {
+      const drag = mouseDragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) {
+        return;
+      }
+      if ((event.buttons & 1) === 0) {
+        mouseDragRef.current = null;
+        return;
+      }
+      if (event.clientY < drag.lastClientY - 1) {
+        stopFollowingOutputFromUserIntent();
+      }
+      drag.lastClientY = event.clientY;
+    };
+    const handlePointerEnd = (event: PointerEvent) => {
+      if (mouseDragRef.current?.pointerId === event.pointerId) {
+        mouseDragRef.current = null;
+      }
+    };
+    const handlePointerInactivity = () => {
+      mouseDragRef.current = null;
     };
     const handleTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
@@ -789,9 +795,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       }
       const previousTouchY = lastTouchClientYRef.current;
       if (previousTouchY !== null && touch.clientY > previousTouchY + 1) {
-        pendingUserScrollUpIntentRef.current = true;
-        cancelPendingStickToBottom();
-        rearmHistoryStartFromUserIntent();
+        stopFollowingOutputFromUserIntent();
       }
       lastTouchClientYRef.current = touch.clientY;
     };
@@ -803,8 +807,10 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     scrollContainer.addEventListener("wheel", handleWheel, { passive: true });
     scrollContainer.addEventListener("keydown", handleKeyDown, { passive: true });
     scrollContainer.addEventListener("pointerdown", handlePointerDown, { passive: true });
-    scrollContainer.addEventListener("pointerup", handlePointerUp, { passive: true });
-    scrollContainer.addEventListener("pointercancel", handlePointerUp, { passive: true });
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    window.addEventListener("pointerup", handlePointerEnd, { passive: true });
+    window.addEventListener("pointercancel", handlePointerEnd, { passive: true });
+    window.addEventListener("blur", handlePointerInactivity);
     scrollContainer.addEventListener("touchstart", handleTouchStart, { passive: true });
     scrollContainer.addEventListener("touchmove", handleTouchMove, { passive: true });
     scrollContainer.addEventListener("touchend", handleTouchEnd, { passive: true });
@@ -815,14 +821,16 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       scrollContainer.removeEventListener("wheel", handleWheel);
       scrollContainer.removeEventListener("keydown", handleKeyDown);
       scrollContainer.removeEventListener("pointerdown", handlePointerDown);
-      scrollContainer.removeEventListener("pointerup", handlePointerUp);
-      scrollContainer.removeEventListener("pointercancel", handlePointerUp);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerEnd);
+      window.removeEventListener("pointercancel", handlePointerEnd);
+      window.removeEventListener("blur", handlePointerInactivity);
       scrollContainer.removeEventListener("touchstart", handleTouchStart);
       scrollContainer.removeEventListener("touchmove", handleTouchMove);
       scrollContainer.removeEventListener("touchend", handleTouchEnd);
       scrollContainer.removeEventListener("touchcancel", handleTouchEnd);
     };
-  }, [cancelPendingStickToBottom, handleDomScroll, isActive, rearmHistoryStartFromUserIntent]);
+  }, [handleDomScroll, isActive, stopFollowingOutputFromUserIntent]);
 
   useEffect(() => {
     const handle: StreamViewportHandle = {

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -761,7 +761,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     }
 
     const handleWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0) {
+      if (!event.ctrlKey && event.deltaY < 0) {
         stopFollowingOutputFromUserIntent();
       }
     };

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -251,14 +251,17 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     return value;
   };
   const lastKnownScrollTopRef = useRef(0);
-  const mouseScrollGestureRef = useRef<{
-    pointerId: number;
-    button: 0 | 1;
-    lastClientY: number;
-    startedInScrollbarGutter: boolean;
-    hasUpwardContentDragEvidence: boolean;
-    evidenceExpiryFrame: number | null;
-  } | null>(null);
+  const mouseScrollGestureRef = useRef<
+    | { kind: "scrollbar"; pointerId: number }
+    | {
+        kind: "autoscroll";
+        pointerId: number;
+        lastClientY: number;
+        hasUpwardEvidence: boolean;
+        evidenceExpiryFrame: number | null;
+      }
+    | null
+  >(null);
   const upwardInputEvidenceUntilRef = useRef(0);
   const lastTouchClientYRef = useRef<number | null>(null);
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
@@ -523,7 +526,8 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
   }, []);
 
   const clearMouseScrollGesture = useCallback(() => {
-    const evidenceExpiryFrame = mouseScrollGestureRef.current?.evidenceExpiryFrame;
+    const gesture = mouseScrollGestureRef.current;
+    const evidenceExpiryFrame = gesture?.kind === "autoscroll" ? gesture.evidenceExpiryFrame : null;
     if (evidenceExpiryFrame !== null && evidenceExpiryFrame !== undefined) {
       window.cancelAnimationFrame(evidenceExpiryFrame);
     }
@@ -675,8 +679,8 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       currentScrollTop > lastKnownScrollTopRef.current + USER_SCROLL_DELTA_EPSILON;
     const mouseGesture = mouseScrollGestureRef.current;
     const hasUpwardInputEvidence =
-      mouseGesture?.startedInScrollbarGutter === true ||
-      mouseGesture?.hasUpwardContentDragEvidence === true ||
+      mouseGesture?.kind === "scrollbar" ||
+      (mouseGesture?.kind === "autoscroll" && mouseGesture.hasUpwardEvidence) ||
       window.performance.now() < upwardInputEvidenceUntilRef.current;
 
     if (!followOutputRef.current && isAtBottom && scrolledDown && !isJumpSettling()) {
@@ -873,40 +877,33 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
       ) {
         return;
       }
+      if (event.button === 0) {
+        if (isVerticalScrollbarGutterPress(event, scrollContainer)) {
+          mouseScrollGestureRef.current = { kind: "scrollbar", pointerId: event.pointerId };
+        }
+        return;
+      }
       mouseScrollGestureRef.current = {
+        kind: "autoscroll",
         pointerId: event.pointerId,
-        button: event.button,
         lastClientY: event.clientY,
-        startedInScrollbarGutter: isVerticalScrollbarGutterPress(event, scrollContainer),
-        hasUpwardContentDragEvidence: false,
+        hasUpwardEvidence: false,
         evidenceExpiryFrame: null,
       };
     };
     const handlePointerMove = (event: PointerEvent) => {
       const gesture = mouseScrollGestureRef.current;
-      if (!gesture || gesture.pointerId !== event.pointerId) {
+      if (!gesture || gesture.kind !== "autoscroll" || gesture.pointerId !== event.pointerId) {
         return;
       }
-      if (gesture.button === 0 && (event.buttons & 1) === 0) {
-        clearMouseScrollGesture();
-        return;
-      }
-      if (
-        !gesture.startedInScrollbarGutter &&
-        event.clientY < gesture.lastClientY - USER_SCROLL_DELTA_EPSILON
-      ) {
-        gesture.hasUpwardContentDragEvidence = true;
+      if (event.clientY < gesture.lastClientY - USER_SCROLL_DELTA_EPSILON) {
+        gesture.hasUpwardEvidence = true;
         if (gesture.evidenceExpiryFrame !== null) {
           window.cancelAnimationFrame(gesture.evidenceExpiryFrame);
         }
         gesture.evidenceExpiryFrame = window.requestAnimationFrame(() => {
           if (mouseScrollGestureRef.current === gesture) {
-            if (gesture.button === 1) {
-              mouseScrollGestureRef.current = null;
-            } else {
-              gesture.hasUpwardContentDragEvidence = false;
-              gesture.evidenceExpiryFrame = null;
-            }
+            mouseScrollGestureRef.current = null;
           }
         });
       }
@@ -914,7 +911,7 @@ function WebStreamViewport(props: StreamRenderInput & { isMobileBreakpoint: bool
     };
     const handlePointerEnd = (event: PointerEvent) => {
       const gesture = mouseScrollGestureRef.current;
-      if (gesture?.pointerId === event.pointerId && gesture.button === 0) {
+      if (gesture?.pointerId === event.pointerId && gesture.kind === "scrollbar") {
         clearMouseScrollGesture();
       }
     };

--- a/packages/app/src/agent-stream/strategy-web.tsx
+++ b/packages/app/src/agent-stream/strategy-web.tsx
@@ -13,6 +13,7 @@ import { useRetainedPanelActive } from "@/components/retained-panel";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import type { Theme } from "@/styles/theme";
+import { WEB_SCROLLBAR_SIZE_PX } from "@/styles/web-scrollbar";
 import { estimateStreamItemHeight } from "./web-virtualization";
 import type { StreamRenderInput, StreamStrategy, StreamViewportHandle } from "./strategy";
 import { createStreamStrategy } from "./strategy";
@@ -146,10 +147,13 @@ function isVerticalScrollbarGutterPress(
   if (event.target !== scrollContainer) {
     return false;
   }
-  const scrollbarWidth = scrollContainer.offsetWidth - scrollContainer.clientWidth;
-  if (scrollbarWidth <= 0) {
+  if (scrollContainer.scrollHeight <= scrollContainer.clientHeight) {
     return false;
   }
+  const scrollbarWidth = Math.max(
+    scrollContainer.offsetWidth - scrollContainer.clientWidth,
+    WEB_SCROLLBAR_SIZE_PX,
+  );
   const bounds = scrollContainer.getBoundingClientRect();
   return window.getComputedStyle(scrollContainer).direction === "rtl"
     ? event.clientX <= bounds.left + scrollbarWidth

--- a/packages/app/src/agent-stream/use-scroll-to-message.web.ts
+++ b/packages/app/src/agent-stream/use-scroll-to-message.web.ts
@@ -1,9 +1,10 @@
 import type React from "react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo } from "react";
 import type { Virtualizer } from "@tanstack/react-virtual";
 import { createPromptJumpSettleController, PROMPT_JUMP_TOP_INSET_PX } from "./prompt-jump-settle";
 
 interface UseScrollToMessageInput {
+  active: boolean;
   scrollContainerRef: React.RefObject<HTMLElement | null>;
   rowVirtualizer: Virtualizer<HTMLElement, Element>;
   historyVirtualized: readonly { id: string }[];
@@ -23,6 +24,7 @@ const SCROLL_AFFECTING_KEYS = new Set([
 ]);
 
 export function useScrollToMessage({
+  active,
   scrollContainerRef,
   rowVirtualizer,
   historyVirtualized,
@@ -79,9 +81,15 @@ export function useScrollToMessage({
   );
 
   useEffect(() => () => settleController.cancel(), [settleController]);
+  useLayoutEffect(() => {
+    if (!active) {
+      settleController.cancel();
+    }
+  }, [active, settleController]);
 
   const scrollToMessage = useCallback(
     (itemId: string) => {
+      if (!active) return;
       const container = scrollContainerRef.current;
       if (!container) return;
       cancelPendingStickToBottom();
@@ -109,6 +117,7 @@ export function useScrollToMessage({
       }
     },
     [
+      active,
       cancelPendingStickToBottom,
       historyVirtualized,
       onNearBottomChange,

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -269,6 +269,14 @@ const AGENT_CAPABILITY_FLAG_KEYS: (keyof AgentCapabilityFlags)[] = [
 ];
 
 const EMPTY_STREAM_HEAD: StreamItem[] = [];
+
+function useRetainedValue<T>(value: T, active: boolean): T {
+  const retainedRef = useRef(value);
+  if (active) {
+    retainedRef.current = value;
+  }
+  return active ? value : retainedRef.current;
+}
 const EMPTY_PENDING_MESSAGE_SUBMISSIONS: readonly PendingMessageSubmission[] = [];
 const GROUPED_TOOL_CALL_DETAIL_MAX_HEIGHT = 200;
 
@@ -465,20 +473,15 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       });
     });
 
-    // Freeze stream data while this tab slot is hidden to prevent offscreen FlatList
-    // cell-window renders on every 48ms flush from background agents.
+    // Freeze stream presentation while this tab slot is hidden to prevent offscreen
+    // cell-window and turn-lifecycle renders from background agents.
     // When isActive flips back to true, the context change triggers a re-render and
     // the component reads the current (fresh) streamItems/streamHead from props.
     const isActive = useRetainedPanelActive();
-    const frozenStreamItemsRef = useRef(streamItems);
-    const frozenStreamHeadRef = useRef(streamHead);
-    if (isActive) {
-      frozenStreamItemsRef.current = streamItems;
-      frozenStreamHeadRef.current = streamHead;
-    }
-    const effectiveStreamItems = isActive ? streamItems : frozenStreamItemsRef.current;
-    const effectiveStreamHead = isActive ? streamHead : frozenStreamHeadRef.current;
-    const isTurnActive = turnPresentation.isActive;
+    const effectiveStreamItems = useRetainedValue(streamItems, isActive);
+    const effectiveStreamHead = useRetainedValue(streamHead, isActive);
+    const effectiveTurnPresentation = useRetainedValue(turnPresentation, isActive);
+    const isTurnActive = effectiveTurnPresentation.isActive;
     // Keep retained history outside the 48ms live-head flush path.
     const preparedToolCallHistory = useMemo(
       () => prepareToolCallHistory(toolCallDetailLevel, effectiveStreamItems),
@@ -505,7 +508,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const baseRenderModel = useMemo(() => {
       return buildAgentStreamRenderModel({
         isTurnActive,
-        activeTurnStartedAt: turnPresentation.startedAt,
+        activeTurnStartedAt: effectiveTurnPresentation.startedAt,
         tail: projectedToolCalls.tail,
         head: projectedToolCalls.head,
         platform: isWeb ? "web" : "native",
@@ -516,7 +519,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       isTurnActive,
       projectedToolCalls.head,
       projectedToolCalls.tail,
-      turnPresentation.startedAt,
+      effectiveTurnPresentation.startedAt,
     ]);
     const streamLayout = useMemo(
       () =>

--- a/packages/app/src/components/retained-panel.tsx
+++ b/packages/app/src/components/retained-panel.tsx
@@ -1,4 +1,4 @@
-import { createContext, memo, type ReactNode, useContext } from "react";
+import React, { createContext, memo, type ReactNode, useContext } from "react";
 import { StyleSheet, View, type StyleProp, type ViewStyle } from "react-native";
 
 const RetainedPanelActiveContext = createContext(true);


### PR DESCRIPTION
Chats now return to the same reading state after switching workspaces: chats following output remain at the bottom, while chats intentionally scrolled up preserve their position.

### Linked issue

Closes #1196

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Retained chat panels stay mounted but collapse to zero geometry while hidden. A delayed browser scroll event during that collapse was classified as upward user intent, disabling output following before background stream updates changed the hidden content height.

The scroll strategy now requires explicit wheel, touch, pointer, or keyboard intent before leaving bottom-follow mode. Hidden retained panels keep their DOM and virtualized rows mounted, but disconnect observers and input listeners, cancel queued measurement/scroll work, and freeze presentation inputs. Reactivation reconnects that lightweight work and performs one bottom reconciliation only when the chat was already following output.

### Goals

- Keep a bottom-following long chat at the bottom across workspace switches, including while the agent streams or finishes in the background.
- Preserve an intentional scrolled-up reading position across workspace switches.
- Keep retained chat DOM mounted and avoid expensive background scroll, measurement, and presentation work.
- Cover hidden geometry races and visible geometry changes with deterministic regression tests.

### Non-goals

- Changing chat virtualization or pagination behavior.
- Unmounting inactive workspace panels.
- Changing the visual design of the chat timeline.

### Risk surface

The change is limited to the web chat viewport's scroll-intent classification and inactive retained-panel lifecycle. Keyboard, pointer, wheel, and touch paths are affected; the regression suite covers bottom following, hidden streaming, geometry changes, and intentional reading positions. Native chat rendering is unchanged.

### QA

- Reproduced the hidden-panel failure deterministically by delivering a queued scroll event after the retained chat collapsed, then applying 500 background stream updates.
- `npx vitest run packages/app/src/agent-stream/strategy-web.test.tsx --bail=1` — 11 tests passed.
- `npm run test:e2e --workspace=@getpaseo/app -- agent-scroll-return.spec.ts --workers=1` — 4 tests passed: geometry changes, delayed hidden scroll delivery, background streaming/finish, and preserved reading position.
- `npm run test:e2e --workspace=@getpaseo/app -- agent-timeline-pagination.spec.ts --workers=1 --grep='keyboard'` — 1 keyboard pagination test passed.
- `npm run typecheck` — passed.
- `npm run lint` on all changed files — passed with 0 warnings and 0 errors.
- `npm run format` and the pre-commit format check — passed.
- Tested in browser web through Playwright. Electron and native devices were not manually tested; native rendering is outside the changed implementation.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
