### PR TITLE
Fix archived timeline loading after cwd removal

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -85,10 +85,11 @@ History navigation preserves the selected agent as an explicit recovery target. 
 and its workspace are archived, the workspace recovery action restores the workspace and unarchives
 the selected agent as one user action. Other archived agents in the restored workspace remain
 recoverable from History. Opening one pins its tab and renders the archived-agent callout. Authoritative
-timeline catch-up may load provider history with a runtime-only `history` resume purpose, which must
-leave both Paseo's `archivedAt` and the provider's native archive state unchanged. **Unarchive** remains
-the only transition back to an interactive runtime: it runs the provider's native unarchive hook
-(including Codex `thread/unarchive`) before the normal agent resume and timeline hydration flow.
+timeline catch-up uses a provider's explicit read-only history loader. The loader must not start or
+resume an interactive provider runtime. Providers without this loader fail closed. The load leaves
+both Paseo's `archivedAt` and the provider's native archive state unchanged. **Unarchive** remains the
+only transition back to an interactive runtime. It closes the history loader, runs the provider's
+native unarchive hook, and then uses the normal agent resume and timeline hydration flow.
 
 Provider session connection owns every process it spawns until the session is registered with
 `AgentManager`. If initialization, persisted-session resume, or initial history hydration fails,

--- a/packages/server/src/server/agent/agent-load-coordinator.ts
+++ b/packages/server/src/server/agent/agent-load-coordinator.ts
@@ -1,0 +1,75 @@
+import type { ManagedAgent } from "./agent-manager.js";
+
+export interface PendingAgentInitialization {
+  promise: Promise<ManagedAgent>;
+  options: { broadcastTimeline: boolean };
+}
+
+const pendingAgentInitializations = new Map<string, PendingAgentInitialization>();
+const interactiveTransitions = new Map<string, Promise<unknown>>();
+
+export function getPendingAgentInitialization(
+  agentId: string,
+): PendingAgentInitialization | undefined {
+  return pendingAgentInitializations.get(agentId);
+}
+
+export function hasAgentInteractiveTransition(agentId: string): boolean {
+  return interactiveTransitions.has(agentId);
+}
+
+export function claimPendingAgentInitialization(
+  agentId: string,
+  pending: PendingAgentInitialization,
+): boolean {
+  if (pendingAgentInitializations.has(agentId) || interactiveTransitions.has(agentId)) {
+    return false;
+  }
+  pendingAgentInitializations.set(agentId, pending);
+  return true;
+}
+
+export function clearPendingAgentInitialization(
+  agentId: string,
+  pending: PendingAgentInitialization,
+): void {
+  if (pendingAgentInitializations.get(agentId) === pending) {
+    pendingAgentInitializations.delete(agentId);
+  }
+}
+
+/**
+ * Serialize an archived-to-interactive transition with provider-backed loading.
+ * A transition waits for an already-claimed history initialization to settle so
+ * its reader can be closed before any native unarchive action runs.
+ */
+export function runAgentInteractiveTransition<T>(
+  agentId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = interactiveTransitions.get(agentId);
+  const run = (async () => {
+    await previous?.catch(() => undefined);
+    await pendingAgentInitializations.get(agentId)?.promise.catch(() => undefined);
+    return await operation();
+  })();
+  interactiveTransitions.set(agentId, run);
+  const clear = () => {
+    if (interactiveTransitions.get(agentId) === run) {
+      interactiveTransitions.delete(agentId);
+    }
+  };
+  void run.then(clear, clear);
+  return run;
+}
+
+/** Wait until every interactive transition visible at the call boundary settles. */
+export async function waitForAgentInteractiveTransition(agentId: string): Promise<void> {
+  while (true) {
+    const transition = interactiveTransitions.get(agentId);
+    if (!transition) {
+      return;
+    }
+    await transition.catch(() => undefined);
+  }
+}

--- a/packages/server/src/server/agent/agent-loading.test.ts
+++ b/packages/server/src/server/agent/agent-loading.test.ts
@@ -1,24 +1,43 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import { AgentManager } from "./agent-manager.js";
 import { ensureAgentLoaded } from "./agent-loading.js";
 import { AgentStorage } from "./agent-storage.js";
+import type { StoredAgentRecord } from "./agent-storage.js";
+import { sendPromptToAgent } from "./agent-prompt.js";
 import type {
   AgentClient,
+  AgentHistoryLoader,
   AgentLaunchContext,
   AgentPersistenceHandle,
-  AgentResumeSessionOptions,
   AgentSession,
   AgentSessionConfig,
+  AgentStreamEvent,
 } from "./agent-sdk-types.js";
 import { createTestAgentClients } from "../test-utils/fake-agent-client.js";
+import { OmpAgentClient } from "./providers/omp/agent.js";
+import { FakeOmp } from "./providers/omp/test-utils/fake-omp.js";
 
-test("loads archived records for history and active records with the interactive default", async () => {
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+test("loads archived history after its cwd is removed and active records interactively", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "agent-loading-purpose-"));
+  const archivedCwd = path.join(root, "archived-workspace");
+  const activeCwd = path.join(root, "active-workspace");
+  await Promise.all([mkdir(archivedCwd), mkdir(activeCwd)]);
   const logger = createTestLogger();
   const storage = new AgentStorage(path.join(root, "agents"), logger);
   const baseClient = createTestAgentClients().codex;
@@ -26,7 +45,8 @@ test("loads archived records for history and active records with the interactive
     throw new Error("expected Codex test client");
   }
 
-  const resumeOptions: Array<AgentResumeSessionOptions | undefined> = [];
+  const historyLoads: AgentPersistenceHandle[] = [];
+  const interactiveResumes: AgentPersistenceHandle[] = [];
   const client: AgentClient = {
     provider: baseClient.provider,
     capabilities: baseClient.capabilities,
@@ -38,10 +58,24 @@ test("loads archived records for history and active records with the interactive
       handle: AgentPersistenceHandle,
       overrides?: Partial<AgentSessionConfig>,
       launchContext?: AgentLaunchContext,
-      options?: AgentResumeSessionOptions,
     ): Promise<AgentSession> => {
-      resumeOptions.push(options);
+      interactiveResumes.push(handle);
       return await baseClient.resumeSession(handle, overrides, launchContext);
+    },
+    loadHistorySession: async (
+      handle: AgentPersistenceHandle,
+      overrides?: Partial<AgentSessionConfig>,
+    ): Promise<AgentHistoryLoader> => {
+      historyLoads.push(handle);
+      const session = await baseClient.resumeSession(handle, overrides);
+      session.streamHistory = async function* () {
+        yield {
+          type: "timeline",
+          provider: "codex",
+          item: { type: "assistant_message", text: "persisted response" },
+        } satisfies AgentStreamEvent;
+      };
+      return session;
     },
     fetchCatalog: async (options) => await baseClient.fetchCatalog(options),
     isAvailable: async () => await baseClient.isAvailable(),
@@ -56,12 +90,31 @@ test("loads archived records for history and active records with the interactive
   const activeId = "00000000-0000-4000-8000-000000000302";
 
   try {
-    const archived = await manager.createAgent({ provider: "codex", cwd: root }, archivedId, {
-      workspaceId: "workspace-archived",
-    });
+    const archived = await manager.createAgent(
+      { provider: "codex", cwd: archivedCwd },
+      archivedId,
+      {
+        workspaceId: "workspace-archived",
+      },
+    );
     await manager.archiveAgent(archived.id);
+    await rm(archivedCwd, { recursive: true, force: true });
+    await manager.flush();
+    await storage.flush();
+    const archivedRecordBeforeHistoryLoad = await storage.get(archived.id);
+    if (!archivedRecordBeforeHistoryLoad) {
+      throw new Error("expected archived record before history load");
+    }
+    const attentionTimestamp = new Date("2025-01-15T00:00:00.000Z").toISOString();
+    const archivedRecordWithAttention: StoredAgentRecord = {
+      ...archivedRecordBeforeHistoryLoad,
+      requiresAttention: true,
+      attentionReason: "permission",
+      attentionTimestamp,
+    };
+    await storage.upsert(archivedRecordWithAttention);
 
-    const active = await manager.createAgent({ provider: "codex", cwd: root }, activeId, {
+    const active = await manager.createAgent({ provider: "codex", cwd: activeCwd }, activeId, {
       workspaceId: "workspace-active",
     });
     await manager.closeAgent(active.id);
@@ -69,12 +122,517 @@ test("loads archived records for history and active records with the interactive
     await ensureAgentLoaded(archived.id, { agentManager: manager, agentStorage: storage, logger });
     await ensureAgentLoaded(active.id, { agentManager: manager, agentStorage: storage, logger });
 
-    expect(resumeOptions).toEqual([{ purpose: "history" }, undefined]);
+    expect(historyLoads.map((handle) => handle.sessionId)).toEqual([
+      archived.persistence?.sessionId,
+    ]);
+    expect(interactiveResumes.map((handle) => handle.sessionId)).toEqual([
+      active.persistence?.sessionId,
+    ]);
+    expect(manager.getAgent(archived.id)?.sessionExecutionMode).toBe("history-only");
+    expect(manager.getAgent(active.id)?.sessionExecutionMode).toBe("interactive");
+    expect(manager.getAgent(archived.id)?.attention).toEqual({
+      requiresAttention: true,
+      attentionReason: "permission",
+      attentionTimestamp: new Date(attentionTimestamp),
+    });
+    expect(() => manager.streamAgent(archived.id, "must not run")).toThrow(
+      `Agent '${archived.id}' is loaded for history only`,
+    );
+    expect(manager.fetchTimeline(archived.id, { limit: 0 }).rows).toEqual([
+      expect.objectContaining({
+        item: { type: "assistant_message", text: "persisted response" },
+      }),
+    ]);
+    await manager.flush();
+    await storage.flush();
+    expect(await storage.get(archived.id)).toEqual(archivedRecordWithAttention);
+
+    await manager.clearAgentAttention(archived.id);
+    expect(manager.getAgent(archived.id)?.attention).toEqual({ requiresAttention: false });
+    expect(await storage.get(archived.id)).toMatchObject({
+      requiresAttention: false,
+      attentionReason: null,
+      attentionTimestamp: null,
+    });
   } finally {
     await Promise.all([
       manager.closeAgent(archivedId).catch(() => undefined),
       manager.closeAgent(activeId).catch(() => undefined),
     ]);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects interactive resume after its cwd is removed", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-missing-cwd-"));
+  const cwd = path.join(root, "workspace");
+  await mkdir(cwd);
+  const logger = createTestLogger();
+  const storage = new AgentStorage(path.join(root, "agents"), logger);
+  const baseClient = createTestAgentClients().codex;
+  if (!baseClient) {
+    throw new Error("expected Codex test client");
+  }
+  const manager = new AgentManager({
+    clients: { codex: baseClient },
+    registry: storage,
+    logger,
+  });
+  const agentId = "00000000-0000-4000-8000-000000000303";
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd }, agentId, {
+      workspaceId: "workspace-active",
+    });
+    await manager.closeAgent(agent.id);
+    await rm(cwd, { recursive: true, force: true });
+
+    await expect(
+      ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger }),
+    ).rejects.toThrow(`Working directory does not exist: ${cwd}`);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fails closed for archived records without persisted history", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-no-history-"));
+  const cwd = path.join(root, "removed-workspace");
+  await mkdir(cwd);
+  const logger = createTestLogger();
+  const storage = new AgentStorage(path.join(root, "agents"), logger);
+  const client = createTestAgentClients().codex;
+  if (!client) {
+    throw new Error("expected Codex test client");
+  }
+  const createSession = vi.spyOn(client, "createSession");
+  const fetchCatalog = vi.spyOn(client, "fetchCatalog");
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  const agentId = "00000000-0000-4000-8000-000000000307";
+  const now = new Date().toISOString();
+
+  try {
+    await storage.upsert({
+      id: agentId,
+      provider: "codex",
+      cwd,
+      createdAt: now,
+      updatedAt: now,
+      labels: {},
+      lastStatus: "closed",
+      config: null,
+      persistence: null,
+      archivedAt: now,
+    });
+    await rm(cwd, { recursive: true, force: true });
+
+    await expect(
+      ensureAgentLoaded(agentId, { agentManager: manager, agentStorage: storage, logger }),
+    ).rejects.toThrow(`Archived agent ${agentId} has no persisted session history`);
+
+    expect(createSession).not.toHaveBeenCalled();
+    expect(fetchCatalog).not.toHaveBeenCalled();
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fails closed before provider resume when history loading is unsupported", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-unsupported-history-"));
+  const cwd = path.join(root, "removed-workspace");
+  await mkdir(cwd);
+  const logger = createTestLogger();
+  const baseClient = createTestAgentClients().codex;
+  if (!baseClient) {
+    throw new Error("expected Codex test client");
+  }
+  const resumeSession = vi.fn(baseClient.resumeSession.bind(baseClient));
+  const fetchCatalog = vi.fn(baseClient.fetchCatalog.bind(baseClient));
+  const client: AgentClient = {
+    provider: baseClient.provider,
+    capabilities: baseClient.capabilities,
+    createSession: baseClient.createSession.bind(baseClient),
+    resumeSession,
+    fetchCatalog,
+    isAvailable: baseClient.isAvailable.bind(baseClient),
+  };
+  const manager = new AgentManager({ clients: { codex: client }, logger });
+  const agentId = "00000000-0000-4000-8000-000000000308";
+  await rm(cwd, { recursive: true, force: true });
+
+  try {
+    await expect(
+      manager.loadAgentHistoryFromPersistence(
+        {
+          provider: "codex",
+          sessionId: "unsupported-history-session",
+          metadata: { cwd },
+        },
+        undefined,
+        agentId,
+      ),
+    ).rejects.toThrow("Provider 'codex' does not support non-runnable history loading");
+
+    expect(resumeSession).not.toHaveBeenCalled();
+    expect(fetchCatalog).not.toHaveBeenCalled();
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("loads archived OMP history without catalog discovery or a runtime launch", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-omp-history-"));
+  const cwd = path.join(root, "removed-workspace");
+  const sessionFile = path.join(root, "omp-session.jsonl");
+  await mkdir(cwd);
+  await writeFile(
+    sessionFile,
+    [
+      { type: "session", id: "session-root", parentId: null },
+      {
+        type: "message",
+        id: "user-1",
+        parentId: "session-root",
+        message: { role: "user", content: "persisted question" },
+      },
+      {
+        type: "message",
+        id: "assistant-1",
+        parentId: "user-1",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "persisted answer" }],
+          responseId: "assistant-1",
+        },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n"),
+    "utf8",
+  );
+
+  const logger = createTestLogger();
+  const storage = new AgentStorage(path.join(root, "agents"), logger);
+  const runtime = new FakeOmp();
+  const client = new OmpAgentClient({ logger, runtime });
+  const fetchCatalog = vi.spyOn(client, "fetchCatalog");
+  const manager = new AgentManager({ clients: { omp: client }, registry: storage, logger });
+  const agentId = "00000000-0000-4000-8000-000000000304";
+  const now = new Date().toISOString();
+  const record = {
+    id: agentId,
+    provider: "omp",
+    cwd,
+    createdAt: now,
+    updatedAt: now,
+    labels: {},
+    lastStatus: "closed",
+    config: null,
+    persistence: {
+      provider: "omp",
+      sessionId: "omp-session-1",
+      nativeHandle: sessionFile,
+      metadata: { cwd },
+    },
+    archivedAt: now,
+  } satisfies StoredAgentRecord;
+
+  try {
+    await storage.upsert(record);
+    await rm(cwd, { recursive: true, force: true });
+
+    const loaded = await ensureAgentLoaded(agentId, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+
+    expect(loaded.sessionExecutionMode).toBe("history-only");
+    expect(loaded.config.model).toBeUndefined();
+    expect(loaded.config.modeId).toBeUndefined();
+    expect(fetchCatalog).not.toHaveBeenCalled();
+    expect(runtime.recordedLaunches).toHaveLength(0);
+    expect(manager.fetchTimeline(agentId, { limit: 0 }).rows.map((row) => row.item)).toEqual([
+      { type: "user_message", text: "persisted question", messageId: "user-1" },
+      {
+        type: "assistant_message",
+        text: "persisted answer",
+        messageId: "assistant-1",
+      },
+    ]);
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("unarchive send closes and replaces a history-only loader before starting a turn", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-unarchive-replace-"));
+  const cwd = path.join(root, "workspace");
+  await mkdir(cwd);
+  const logger = createTestLogger();
+  const storage = new AgentStorage(path.join(root, "agents"), logger);
+  const baseClient = createTestAgentClients().codex;
+  if (!baseClient) {
+    throw new Error("expected Codex test client");
+  }
+
+  const actions: string[] = [];
+  const client: AgentClient = {
+    provider: baseClient.provider,
+    capabilities: baseClient.capabilities,
+    createSession: async (config, launchContext) =>
+      await baseClient.createSession(config, launchContext),
+    resumeSession: async (handle, overrides, launchContext) => {
+      actions.push("interactive-resume");
+      const session = await baseClient.resumeSession(handle, overrides, launchContext);
+      const startTurn = session.startTurn.bind(session);
+      session.startTurn = async (prompt, options) => {
+        actions.push("interactive-start");
+        return await startTurn(prompt, options);
+      };
+      return session;
+    },
+    loadHistorySession: async (handle) => ({
+      provider: "codex",
+      id: handle.sessionId,
+      capabilities: baseClient.capabilities,
+      streamHistory: async function* () {},
+      describePersistence: () => handle,
+      close: async () => {
+        actions.push("history-close");
+      },
+    }),
+    fetchCatalog: async (options) => await baseClient.fetchCatalog(options),
+    isAvailable: async () => await baseClient.isAvailable(),
+    unarchiveNativeSession: async () => {
+      actions.push("native-unarchive");
+    },
+  };
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  const agentId = "00000000-0000-4000-8000-000000000305";
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd }, agentId, {
+      workspaceId: "workspace-unarchive",
+    });
+    await manager.archiveAgent(agent.id);
+    await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
+
+    await sendPromptToAgent({
+      agentManager: manager,
+      agentStorage: storage,
+      agentId: agent.id,
+      prompt: "continue",
+      logger,
+    });
+    await vi.waitFor(() => expect(actions).toContain("interactive-start"));
+
+    expect(actions.slice(0, 4)).toEqual([
+      "history-close",
+      "native-unarchive",
+      "interactive-resume",
+      "interactive-start",
+    ]);
+    expect(manager.getAgent(agent.id)?.sessionExecutionMode).toBe("interactive");
+    expect((await storage.get(agent.id))?.archivedAt).toBeNull();
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("three concurrent loaders converge on one interactive session across unarchive", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-unarchive-single-flight-"));
+  const cwd = path.join(root, "workspace");
+  await mkdir(cwd);
+  const logger = createTestLogger();
+  const storage = new AgentStorage(path.join(root, "agents"), logger);
+  const baseClient = createTestAgentClients().codex;
+  if (!baseClient) {
+    throw new Error("expected Codex test client");
+  }
+
+  const historyStarted = deferred<void>();
+  const historyAllowed = deferred<void>();
+  const actions: string[] = [];
+  let historyLoadCount = 0;
+  let interactiveResumeCount = 0;
+  const client: AgentClient = {
+    provider: baseClient.provider,
+    capabilities: baseClient.capabilities,
+    createSession: baseClient.createSession.bind(baseClient),
+    resumeSession: async (handle, overrides, launchContext) => {
+      interactiveResumeCount += 1;
+      actions.push("interactive-resume");
+      return await baseClient.resumeSession(handle, overrides, launchContext);
+    },
+    loadHistorySession: async (handle) => {
+      historyLoadCount += 1;
+      actions.push("history-load");
+      return {
+        provider: "codex",
+        id: handle.sessionId,
+        capabilities: baseClient.capabilities,
+        streamHistory: async function* () {
+          historyStarted.resolve();
+          await historyAllowed.promise;
+          yield {
+            type: "timeline",
+            provider: "codex",
+            item: { type: "assistant_message", text: "persisted response" },
+          } satisfies AgentStreamEvent;
+        },
+        describePersistence: () => handle,
+        close: async () => {
+          actions.push("history-close");
+        },
+      };
+    },
+    fetchCatalog: baseClient.fetchCatalog.bind(baseClient),
+    isAvailable: baseClient.isAvailable.bind(baseClient),
+    unarchiveNativeSession: async () => {
+      actions.push("native-unarchive");
+    },
+  };
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  const agentId = "00000000-0000-4000-8000-000000000310";
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd }, agentId, {
+      workspaceId: "workspace-unarchive-single-flight",
+    });
+    await manager.archiveAgent(agent.id);
+
+    const firstLoad = ensureAgentLoaded(agent.id, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    await historyStarted.promise;
+    const secondLoad = ensureAgentLoaded(agent.id, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    const thirdLoad = ensureAgentLoaded(agent.id, {
+      agentManager: manager,
+      agentStorage: storage,
+      logger,
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const unarchive = manager.unarchiveSnapshot(agent.id);
+    historyAllowed.resolve();
+    const [first, second, third, didUnarchive] = await Promise.all([
+      firstLoad,
+      secondLoad,
+      thirdLoad,
+      unarchive,
+    ]);
+
+    expect(didUnarchive).toBe(true);
+    expect([first, second, third].map((snapshot) => snapshot.sessionExecutionMode)).toEqual([
+      "interactive",
+      "interactive",
+      "interactive",
+    ]);
+    const sessions = [first, second, third].map((snapshot) =>
+      snapshot.lifecycle === "closed" ? null : snapshot.session,
+    );
+    expect(new Set(sessions).size).toBe(1);
+    const current = manager.getAgent(agent.id);
+    expect(current?.sessionExecutionMode).toBe("interactive");
+    expect(sessions[0]).toBe(current?.lifecycle === "closed" ? null : current?.session);
+    expect(historyLoadCount).toBe(1);
+    expect(interactiveResumeCount).toBe(1);
+    expect(actions).toEqual([
+      "history-load",
+      "history-close",
+      "native-unarchive",
+      "interactive-resume",
+    ]);
+  } finally {
+    historyAllowed.resolve();
+    await manager.closeAgent(agentId).catch(() => undefined);
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("unarchive send validates cwd before native unarchive or interactive resume", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "agent-loading-unarchive-cwd-"));
+  const cwd = path.join(root, "workspace");
+  await mkdir(cwd);
+  const logger = createTestLogger();
+  const storage = new AgentStorage(path.join(root, "agents"), logger);
+  const baseClient = createTestAgentClients().codex;
+  if (!baseClient) {
+    throw new Error("expected Codex test client");
+  }
+
+  const interactiveResume = vi.fn(baseClient.resumeSession.bind(baseClient));
+  const nativeUnarchive = vi.fn(async () => {});
+  const historyClose = vi.fn(async () => {});
+  const client: AgentClient = {
+    provider: baseClient.provider,
+    capabilities: baseClient.capabilities,
+    createSession: async (config, launchContext) =>
+      await baseClient.createSession(config, launchContext),
+    resumeSession: interactiveResume,
+    loadHistorySession: async (handle) => ({
+      provider: "codex",
+      id: handle.sessionId,
+      capabilities: baseClient.capabilities,
+      streamHistory: async function* () {},
+      describePersistence: () => handle,
+      close: historyClose,
+    }),
+    fetchCatalog: async (options) => await baseClient.fetchCatalog(options),
+    isAvailable: async () => await baseClient.isAvailable(),
+    unarchiveNativeSession: nativeUnarchive,
+  };
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  const agentId = "00000000-0000-4000-8000-000000000306";
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd }, agentId, {
+      workspaceId: "workspace-unarchive",
+    });
+    await manager.archiveAgent(agent.id);
+    await ensureAgentLoaded(agent.id, { agentManager: manager, agentStorage: storage, logger });
+    await rm(cwd, { recursive: true, force: true });
+
+    await expect(
+      sendPromptToAgent({
+        agentManager: manager,
+        agentStorage: storage,
+        agentId: agent.id,
+        prompt: "continue",
+        logger,
+      }),
+    ).rejects.toThrow(`Working directory does not exist: ${cwd}`);
+
+    expect(nativeUnarchive).not.toHaveBeenCalled();
+    expect(interactiveResume).not.toHaveBeenCalled();
+    expect(historyClose).not.toHaveBeenCalled();
+    expect(manager.getAgent(agent.id)?.sessionExecutionMode).toBe("history-only");
+    expect((await storage.get(agent.id))?.archivedAt).not.toBeNull();
+  } finally {
+    await manager.closeAgent(agentId).catch(() => undefined);
     await manager.flush().catch(() => undefined);
     await storage.flush().catch(() => undefined);
     await rm(root, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -10,20 +10,23 @@ import {
   isStoredAgentProviderAvailable,
   toAgentPersistenceHandle,
 } from "../persistence-hooks.js";
-
-interface PendingAgentInitialization {
-  promise: Promise<ManagedAgent>;
-  options: { broadcastTimeline: boolean };
-}
-
-const pendingAgentInitializations = new Map<string, PendingAgentInitialization>();
+import {
+  claimPendingAgentInitialization,
+  clearPendingAgentInitialization,
+  getPendingAgentInitialization,
+  hasAgentInteractiveTransition,
+  type PendingAgentInitialization,
+  waitForAgentInteractiveTransition,
+} from "./agent-load-coordinator.js";
 
 export type AgentLoaderManager = Pick<
   AgentManager,
   | "createAgent"
+  | "closeAgent"
   | "getAgent"
   | "getRegisteredProviderIds"
   | "hydrateTimelineFromProvider"
+  | "loadAgentHistoryFromPersistence"
   | "resumeAgentFromPersistence"
 > &
   Partial<Pick<AgentManager, "waitForAgentClose">>;
@@ -38,9 +41,7 @@ export interface EnsureAgentLoadedDeps {
 
 export async function ensureUnarchivedAgentLoaded(
   agentId: string,
-  deps: EnsureAgentLoadedDeps & {
-    agentManager: AgentLoaderManager & Pick<AgentManager, "closeAgent">;
-  },
+  deps: EnsureAgentLoadedDeps,
 ): Promise<ManagedAgent> {
   const record = await deps.agentStorage.get(agentId);
   if (record?.archivedAt) {
@@ -63,86 +64,142 @@ export async function ensureAgentLoaded(
   agentId: string,
   deps: EnsureAgentLoadedDeps,
 ): Promise<ManagedAgent> {
-  await deps.agentManager.waitForAgentClose?.(agentId);
+  while (true) {
+    await waitForAgentInteractiveTransition(agentId);
+    await deps.agentManager.waitForAgentClose?.(agentId);
 
-  const inflight = pendingAgentInitializations.get(agentId);
-  if (inflight) {
-    inflight.options.broadcastTimeline ||= deps.broadcastTimeline === true;
-    return inflight.promise;
-  }
-
-  const existing = deps.agentManager.getAgent(agentId);
-  if (existing) {
-    return existing;
-  }
-
-  // A close may have started after the first barrier observed no in-flight
-  // work. Once the live lookup is empty, this second barrier closes that gap
-  // before storage-backed resume begins.
-  await deps.agentManager.waitForAgentClose?.(agentId);
-
-  const laterInflight = pendingAgentInitializations.get(agentId);
-  if (laterInflight) {
-    laterInflight.options.broadcastTimeline ||= deps.broadcastTimeline === true;
-    return laterInflight.promise;
-  }
-
-  const pendingOptions = {
-    broadcastTimeline: deps.broadcastTimeline === true,
-  };
-  const initPromise = (async () => {
-    const record = await deps.agentStorage.get(agentId);
-    if (!record) {
-      throw new Error(`Agent not found: ${agentId}`);
+    const inflight = getPendingAgentInitialization(agentId);
+    if (inflight) {
+      inflight.options.broadcastTimeline ||= deps.broadcastTimeline === true;
+      await inflight.promise;
+      continue;
     }
 
-    const validProviders = deps.validProviders ?? deps.agentManager.getRegisteredProviderIds();
-    if (!isStoredAgentProviderAvailable(record, validProviders)) {
+    const existing = deps.agentManager.getAgent(agentId);
+    if (existing) {
+      const reusable = await reuseLoadedAgent(existing, agentId, deps);
+      if (reusable) {
+        await waitForAgentInteractiveTransition(agentId);
+        if (hasAgentInteractiveTransition(agentId)) {
+          continue;
+        }
+        const current = deps.agentManager.getAgent(agentId);
+        if (current) {
+          return current;
+        }
+      }
+      continue;
+    }
+
+    // A close or transition may have started after the first barriers. Claim
+    // initialization only after checking both again, then let every caller
+    // converge through the claimed promise and the current manager snapshot.
+    await deps.agentManager.waitForAgentClose?.(agentId);
+    await waitForAgentInteractiveTransition(agentId);
+    if (getPendingAgentInitialization(agentId) || deps.agentManager.getAgent(agentId)) {
+      continue;
+    }
+
+    let resolveInitialization!: (agent: ManagedAgent) => void;
+    let rejectInitialization!: (error: unknown) => void;
+    const promise = new Promise<ManagedAgent>((resolve, reject) => {
+      resolveInitialization = resolve;
+      rejectInitialization = reject;
+    });
+    const pending: PendingAgentInitialization = {
+      promise,
+      options: { broadcastTimeline: deps.broadcastTimeline === true },
+    };
+    if (!claimPendingAgentInitialization(agentId, pending)) {
+      continue;
+    }
+
+    try {
+      resolveInitialization(await initializeAgent(agentId, deps, pending));
+      await promise;
+    } catch (error) {
+      rejectInitialization(error);
+      await promise.catch(() => undefined);
+      throw error;
+    } finally {
+      clearPendingAgentInitialization(agentId, pending);
+    }
+  }
+}
+
+async function initializeAgent(
+  agentId: string,
+  deps: EnsureAgentLoadedDeps,
+  pending: PendingAgentInitialization,
+): Promise<ManagedAgent> {
+  const record = await deps.agentStorage.get(agentId);
+  if (!record) {
+    throw new Error(`Agent not found: ${agentId}`);
+  }
+
+  const validProviders = deps.validProviders ?? deps.agentManager.getRegisteredProviderIds();
+  if (!isStoredAgentProviderAvailable(record, validProviders)) {
+    throw new Error(`Agent ${agentId} references unavailable provider '${record.provider}'`);
+  }
+
+  const handle = toAgentPersistenceHandle(validProviders, record.persistence);
+  let snapshot: ManagedAgent;
+  if (record.archivedAt) {
+    if (!handle) {
+      throw new Error(`Archived agent ${agentId} has no persisted session history`);
+    }
+    snapshot = await deps.agentManager.loadAgentHistoryFromPersistence(
+      handle,
+      buildConfigOverrides(record),
+      agentId,
+      extractTimestamps(record),
+    );
+    deps.logger.info(
+      { agentId, provider: record.provider },
+      "Agent history loaded from persistence",
+    );
+  } else if (handle) {
+    snapshot = await deps.agentManager.resumeAgentFromPersistence(
+      handle,
+      buildConfigOverrides(record),
+      agentId,
+      extractTimestamps(record),
+    );
+    deps.logger.info({ agentId, provider: record.provider }, "Agent resumed from persistence");
+  } else {
+    const config = buildSessionConfig(record, { validProviders });
+    if (!config) {
       throw new Error(`Agent ${agentId} references unavailable provider '${record.provider}'`);
     }
-
-    const handle = toAgentPersistenceHandle(validProviders, record.persistence);
-
-    let snapshot: ManagedAgent;
-    if (handle) {
-      snapshot = await deps.agentManager.resumeAgentFromPersistence(
-        handle,
-        buildConfigOverrides(record),
-        agentId,
-        extractTimestamps(record),
-        record.archivedAt ? { purpose: "history" } : undefined,
-      );
-      deps.logger.info({ agentId, provider: record.provider }, "Agent resumed from persistence");
-    } else {
-      const config = buildSessionConfig(record, {
-        validProviders,
-      });
-      if (!config) {
-        throw new Error(`Agent ${agentId} references unavailable provider '${record.provider}'`);
-      }
-      snapshot = await deps.agentManager.createAgent(config, agentId, {
-        labels: record.labels,
-        workspaceId: record.workspaceId,
-        owner: record.owner,
-      });
-      deps.logger.info({ agentId, provider: record.provider }, "Agent created from stored config");
-    }
-
-    await deps.agentManager.hydrateTimelineFromProvider(agentId, {
-      broadcast: () => pendingOptions.broadcastTimeline,
+    snapshot = await deps.agentManager.createAgent(config, agentId, {
+      labels: record.labels,
+      workspaceId: record.workspaceId,
+      owner: record.owner,
     });
-    return deps.agentManager.getAgent(agentId) ?? snapshot;
-  })();
-
-  const pending: PendingAgentInitialization = { promise: initPromise, options: pendingOptions };
-  pendingAgentInitializations.set(agentId, pending);
-
-  try {
-    return await initPromise;
-  } finally {
-    const current = pendingAgentInitializations.get(agentId);
-    if (current === pending) {
-      pendingAgentInitializations.delete(agentId);
-    }
+    deps.logger.info({ agentId, provider: record.provider }, "Agent created from stored config");
   }
+
+  await deps.agentManager.hydrateTimelineFromProvider(agentId, {
+    broadcast: () => pending.options.broadcastTimeline,
+  });
+  return deps.agentManager.getAgent(agentId) ?? snapshot;
+}
+
+async function reuseLoadedAgent(
+  agent: ManagedAgent,
+  agentId: string,
+  deps: EnsureAgentLoadedDeps,
+): Promise<ManagedAgent | null> {
+  if (agent.sessionExecutionMode !== "history-only") {
+    return agent;
+  }
+
+  const record = await deps.agentStorage.get(agentId);
+  if (record?.archivedAt) {
+    return agent;
+  }
+
+  await deps.agentManager.closeAgent(agentId);
+  await deps.agentManager.waitForAgentClose?.(agentId);
+  return null;
 }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -20,7 +20,7 @@ import {
   type AgentCapabilityFlags,
   type AgentClient,
   type AgentCreateSessionOptions,
-  type AgentResumeSessionOptions,
+  type AgentHistoryLoader,
   type AgentFeature,
   type AgentLaunchContext,
   type AgentSlashCommand,
@@ -73,6 +73,7 @@ import {
   type ProviderSubagentDescriptor,
   type ProviderSubagentStoreEvent,
 } from "./provider-subagents/store.js";
+import { runAgentInteractiveTransition } from "./agent-load-coordinator.js";
 
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
@@ -126,8 +127,19 @@ interface PreparedSessionConfig {
   launchConfig: AgentSessionConfig;
 }
 
+interface PersistenceRegistrationOptions {
+  createdAt?: Date;
+  updatedAt?: Date;
+  lastUserMessageAt?: Date | null;
+  labels?: Record<string, string>;
+  workspaceId?: string;
+  owner?: AgentOwner;
+  attention?: AttentionState;
+}
+
 interface NormalizeConfigOptions {
   resolveDefaultModel?: boolean;
+  validateCwd?: boolean;
   env?: Record<string, string>;
 }
 
@@ -139,6 +151,60 @@ interface TimeoutOptions {
 
 function formatProviderList(providers: readonly string[]): string {
   return providers.length > 0 ? providers.join(", ") : "none";
+}
+
+async function validateWorkingDirectory(cwd: string): Promise<void> {
+  try {
+    const cwdStats = await stat(cwd);
+    if (!cwdStats.isDirectory()) {
+      throw new Error(`Working directory is not a directory: ${cwd}`);
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      throw new Error(`Working directory does not exist: ${cwd}`, { cause: error });
+    }
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Failed to access working directory: ${cwd}`, { cause: error });
+  }
+}
+
+function historyOnlySession(agentId: string, loader: AgentHistoryLoader): AgentSession {
+  const rejectInteractiveAction = (): never => {
+    throw new Error(`Agent '${agentId}' is loaded for history only`);
+  };
+
+  return {
+    provider: loader.provider,
+    id: loader.id,
+    capabilities: STORED_AGENT_CAPABILITIES,
+    get features() {
+      return loader.features;
+    },
+    run: async () => rejectInteractiveAction(),
+    startTurn: async () => rejectInteractiveAction(),
+    subscribe: () => () => {},
+    streamHistory: () => loader.streamHistory(),
+    getRuntimeInfo: async () => ({
+      provider: loader.provider,
+      sessionId: loader.id,
+      model: null,
+      modeId: null,
+    }),
+    getAvailableModes: async () => [],
+    getCurrentMode: async () => null,
+    setMode: async () => rejectInteractiveAction(),
+    getPendingPermissions: () => [],
+    respondToPermission: async () => rejectInteractiveAction(),
+    describePersistence: () => loader.describePersistence(),
+    interrupt: async () => rejectInteractiveAction(),
+    close: () => loader.close(),
+  };
 }
 
 function buildStoredAgentConfig(record: StoredAgentRecord): AgentSessionConfig {
@@ -336,6 +402,8 @@ interface ManagedAgentBase {
   workspaceId?: string;
   owner?: AgentOwner;
   capabilities: AgentCapabilityFlags;
+  /** History-only loaders are deliberately non-runnable and must be replaced before interaction. */
+  sessionExecutionMode?: "interactive" | "history-only";
   config: AgentSessionConfig;
   runtimeInfo?: AgentRuntimeInfo;
   createdAt: Date;
@@ -469,6 +537,7 @@ interface WriteLabelsResult {
 interface AgentMetadataPatch {
   title?: string;
   labels?: AgentLabelPatch;
+  attention?: AttentionState;
 }
 
 const SYSTEM_ERROR_PREFIX = "[System Error]";
@@ -1127,18 +1196,10 @@ export class AgentManager {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     agentId?: string,
-    options?: {
-      createdAt?: Date;
-      updatedAt?: Date;
-      lastUserMessageAt?: Date | null;
-      labels?: Record<string, string>;
-      workspaceId?: string;
-      owner?: AgentOwner;
-    },
-    resumeOptions?: AgentResumeSessionOptions,
+    options?: PersistenceRegistrationOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options),
     );
   }
 
@@ -1146,15 +1207,7 @@ export class AgentManager {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     agentId?: string,
-    options?: {
-      createdAt?: Date;
-      updatedAt?: Date;
-      lastUserMessageAt?: Date | null;
-      labels?: Record<string, string>;
-      workspaceId?: string;
-      owner?: AgentOwner;
-    },
-    resumeOptions?: AgentResumeSessionOptions,
+    options?: PersistenceRegistrationOptions,
   ): Promise<ManagedAgent> {
     this.assertAcceptingAgentRegistrations();
     const resolvedAgentId = validateAgentId(
@@ -1181,17 +1234,67 @@ export class AgentManager {
     }
     const launchContext = await this.buildLaunchContext(resolvedAgentId, client, storedConfig.cwd);
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
-    const session = await client.resumeSession(
-      handle,
-      providerLaunchConfig,
-      launchContext,
-      resumeOptions,
-    );
+    const session = await client.resumeSession(handle, providerLaunchConfig, launchContext);
     await this.requireExternalMcpSupport(session, storedConfig);
     return this.registerSession(session, storedConfig, resolvedAgentId, {
       ...options,
       persistence: handle,
     });
+  }
+
+  loadAgentHistoryFromPersistence(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+    agentId?: string,
+    options?: PersistenceRegistrationOptions,
+  ): Promise<ManagedAgent> {
+    return this.trackAgentRegistrationOperation(
+      this.loadAgentHistoryFromPersistenceInternal(handle, overrides, agentId, options),
+    );
+  }
+
+  private async loadAgentHistoryFromPersistenceInternal(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+    agentId?: string,
+    options?: PersistenceRegistrationOptions,
+  ): Promise<ManagedAgent> {
+    this.assertAcceptingAgentRegistrations();
+    const resolvedAgentId = validateAgentId(
+      agentId ?? this.idFactory(),
+      "loadAgentHistoryFromPersistence",
+    );
+    const metadata = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
+    const storedConfig = await this.normalizeConfig(
+      stripInternalPaseoMcpServer({
+        ...metadata,
+        ...overrides,
+        provider: handle.provider,
+      } as AgentSessionConfig),
+      {
+        validateCwd: false,
+        resolveDefaultModel: false,
+      },
+    );
+
+    const client = this.requireClient(handle.provider);
+    if (!client.loadHistorySession) {
+      throw new Error(
+        `Provider '${handle.provider}' does not support non-runnable history loading`,
+      );
+    }
+
+    const loader = await client.loadHistorySession(handle, storedConfig);
+    return this.registerSession(
+      historyOnlySession(resolvedAgentId, loader),
+      storedConfig,
+      resolvedAgentId,
+      {
+        ...options,
+        persistence: handle,
+        sessionExecutionMode: "history-only",
+      },
+    );
   }
 
   importProviderSession(input: {
@@ -1499,12 +1602,27 @@ export class AgentManager {
       throw new Error("Agent storage is not configured");
     }
 
-    await this.registry.applySnapshot(agent, {
-      internal: agent.internal,
-    });
+    if (agent.sessionExecutionMode !== "history-only") {
+      await this.registry.applySnapshot(agent, {
+        internal: agent.internal,
+      });
+    }
     const stored = await this.registry.get(agentId);
     if (!stored) {
       throw new Error(`Agent ${agentId} not found in storage after snapshot`);
+    }
+    if (agent.sessionExecutionMode === "history-only") {
+      if (stored.archivedAt) {
+        await this.closeAgent(agentId);
+        this.discardRetainedAgentState(agentId);
+        return { archivedAt: stored.archivedAt };
+      }
+      await validateWorkingDirectory(resolve(stored.cwd));
+      await this.closeAgent(agentId);
+      const { archivedAt } = await this.markRecordArchived(stored);
+      this.discardRetainedAgentState(agentId);
+      await this.cascadeArchiveChildren(agentId);
+      return { archivedAt };
     }
 
     const { archivedAt } = await this.markRecordArchived(stored);
@@ -1679,7 +1797,7 @@ export class AgentManager {
   }
 
   async setAgentFeature(agentId: string, featureId: string, value: unknown): Promise<void> {
-    const agent = this.requireAgent(agentId);
+    const agent = this.requireSessionAgent(agentId);
 
     if (!agent.session.setFeature) {
       throw new Error("Agent session does not support setting features");
@@ -1696,6 +1814,12 @@ export class AgentManager {
     const agent = this.requireAgent(agentId);
     const normalizedTitle = title.trim();
     if (!normalizedTitle) {
+      return;
+    }
+    if (agent.sessionExecutionMode === "history-only") {
+      const record = await this.writeStoredMetadata(agent.id, { title: normalizedTitle });
+      agent.updatedAt = new Date(record.updatedAt);
+      this.emitState(agent, { persist: false });
       return;
     }
     if (
@@ -1719,6 +1843,12 @@ export class AgentManager {
     const liveAgent = this.agents.get(agentId);
     if (liveAgent) {
       liveAgent.labels = applyLabelPatch(liveAgent.labels, patch);
+      if (liveAgent.sessionExecutionMode === "history-only") {
+        const record = await this.writeStoredMetadata(agentId, { labels: patch });
+        liveAgent.updatedAt = new Date(record.updatedAt);
+        this.emitState(liveAgent, { persist: false });
+        return { record, live: true };
+      }
       this.touchUpdatedAt(liveAgent);
       await this.persistSnapshot(liveAgent);
       this.emitState(liveAgent, { persist: false });
@@ -1740,10 +1870,24 @@ export class AgentManager {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
+    const attentionPatch: Partial<
+      Pick<StoredAgentRecord, "requiresAttention" | "attentionReason" | "attentionTimestamp">
+    > = {};
+    if (patch.attention) {
+      attentionPatch.requiresAttention = patch.attention.requiresAttention;
+      attentionPatch.attentionReason = patch.attention.requiresAttention
+        ? patch.attention.attentionReason
+        : null;
+      attentionPatch.attentionTimestamp = patch.attention.requiresAttention
+        ? patch.attention.attentionTimestamp.toISOString()
+        : null;
+    }
+
     const nextRecord = {
       ...record,
       ...(patch.title ? { title: patch.title } : {}),
       ...(patch.labels ? { labels: applyLabelPatch(record.labels, patch.labels) } : {}),
+      ...attentionPatch,
       updatedAt: this.nextStoredUpdatedAt(record),
     };
     await registry.upsert(nextRecord);
@@ -1804,6 +1948,14 @@ export class AgentManager {
     const agent = this.requireAgent(agentId);
     if (agent.attention.requiresAttention) {
       agent.attention = { requiresAttention: false };
+      if (agent.sessionExecutionMode === "history-only") {
+        const record = await this.writeStoredMetadata(agent.id, {
+          attention: agent.attention,
+        });
+        agent.updatedAt = new Date(record.updatedAt);
+        this.emitState(agent, { persist: false });
+        return;
+      }
       await this.persistSnapshot(agent);
       this.emitState(agent, { persist: false });
     }
@@ -1821,6 +1973,15 @@ export class AgentManager {
     const record = await registry.get(agentId);
     if (!record) {
       throw new Error(`Agent not found: ${agentId}`);
+    }
+    if (liveAgent?.sessionExecutionMode === "history-only") {
+      if (record.archivedAt) {
+        await this.closeAgent(agentId);
+        this.discardRetainedAgentState(agentId);
+        return record;
+      }
+      await validateWorkingDirectory(resolve(record.cwd));
+      await this.closeAgent(agentId);
     }
 
     const nextRecord = buildArchivedAgentRecord(record, { archivedAt });
@@ -1843,7 +2004,16 @@ export class AgentManager {
     return nextRecord;
   }
 
-  async unarchiveSnapshot(
+  unarchiveSnapshot(
+    agentId: string,
+    updates?: { workspaceId?: string; labels?: AgentLabelPatch },
+  ): Promise<boolean> {
+    return runAgentInteractiveTransition(agentId, () =>
+      this.unarchiveSnapshotInternal(agentId, updates),
+    );
+  }
+
+  private async unarchiveSnapshotInternal(
     agentId: string,
     updates?: { workspaceId?: string; labels?: AgentLabelPatch },
   ): Promise<boolean> {
@@ -1851,6 +2021,13 @@ export class AgentManager {
     const record = await registry.get(agentId);
     if (!record || !record.archivedAt) {
       return false;
+    }
+
+    await validateWorkingDirectory(resolve(record.cwd));
+
+    const loaded = this.agents.get(agentId);
+    if (loaded?.sessionExecutionMode === "history-only") {
+      await this.closeAgent(agentId);
     }
 
     await this.unarchiveNativeSession(record.provider, record.persistence);
@@ -2370,7 +2547,7 @@ export class AgentManager {
     requestId: string,
     response: AgentPermissionResponse,
   ): Promise<AgentPermissionResult | void> {
-    const agent = this.requireAgent(agentId);
+    const agent = this.requireSessionAgent(agentId);
     agent.inFlightPermissionResponses.add(requestId);
 
     try {
@@ -2509,7 +2686,7 @@ export class AgentManager {
     agentId: string,
     options?: HydrateTimelineOptions,
   ): Promise<void> {
-    const agent = this.requireSessionAgent(agentId);
+    const agent = this.requireAgent(agentId);
     await this.hydrateTimelineFromLegacyProviderHistory(agent, options);
   }
 
@@ -2831,6 +3008,7 @@ export class AgentManager {
       publishWhenReady?: boolean;
       workspaceId?: string;
       owner?: AgentOwner;
+      sessionExecutionMode?: "interactive" | "history-only";
     },
   ): Promise<ManagedAgent> {
     let registered = false;
@@ -2859,6 +3037,7 @@ export class AgentManager {
         config,
         now,
         durableTimelineHasRows,
+        sessionExecutionMode: options?.sessionExecutionMode ?? "interactive",
         options,
       });
 
@@ -2867,7 +3046,9 @@ export class AgentManager {
       registered = true;
       // Initialize previousStatus to track transitions
       this.previousStatuses.set(resolvedAgentId, managed.lifecycle);
-      await this.refreshRuntimeInfo(managed, { emit: false });
+      if (managed.sessionExecutionMode !== "history-only") {
+        await this.refreshRuntimeInfo(managed, { emit: false });
+      }
       this.assertAgentRegistrationActive(managed);
       await this.persistSnapshot(managed, {
         title: initialPersistedTitle,
@@ -2877,14 +3058,20 @@ export class AgentManager {
         this.emitState(managed, { persist: false });
       }
 
-      await this.refreshSessionState(managed, { emit: false });
+      if (managed.sessionExecutionMode !== "history-only") {
+        await this.refreshSessionState(managed, { emit: false });
+      }
       this.assertAgentRegistrationActive(managed);
       managed.lifecycle = "idle";
-      this.touchUpdatedAt(managed);
+      if (managed.sessionExecutionMode !== "history-only") {
+        this.touchUpdatedAt(managed);
+      }
       await this.persistSnapshot(managed);
       this.assertAgentRegistrationActive(managed);
       this.emitState(managed, { persist: false });
-      this.subscribeToSession(managed);
+      if (managed.sessionExecutionMode !== "history-only") {
+        this.subscribeToSession(managed);
+      }
       return { ...managed };
     } catch (error) {
       if (!registered) {
@@ -2971,6 +3158,7 @@ export class AgentManager {
     config: AgentSessionConfig;
     now: Date;
     durableTimelineHasRows: boolean;
+    sessionExecutionMode: "interactive" | "history-only";
     options:
       | {
           createdAt?: Date;
@@ -2987,7 +3175,15 @@ export class AgentManager {
         }
       | undefined;
   }): ActiveManagedAgent {
-    const { resolvedAgentId, session, config, now, durableTimelineHasRows, options } = params;
+    const {
+      resolvedAgentId,
+      session,
+      config,
+      now,
+      durableTimelineHasRows,
+      sessionExecutionMode,
+      options,
+    } = params;
     return {
       id: resolvedAgentId,
       provider: config.provider,
@@ -2996,6 +3192,7 @@ export class AgentManager {
       owner: options?.owner,
       session,
       capabilities: session.capabilities,
+      sessionExecutionMode,
       config,
       runtimeInfo: undefined,
       lifecycle: "initializing",
@@ -3240,6 +3437,12 @@ export class AgentManager {
     if (!this.registry) {
       return;
     }
+    // Archived history readers are a read-only view over an existing record.
+    // Persisting their intentionally minimal runtime state would erase the
+    // interactive session's runtime metadata and feature configuration.
+    if (agent.sessionExecutionMode === "history-only") {
+      return;
+    }
     // Don't persist internal agents - they're ephemeral system tasks
     if (agent.internal) {
       return;
@@ -3378,7 +3581,9 @@ export class AgentManager {
         });
       }
     }
-    this.touchUpdatedAt(agent);
+    if (agent.sessionExecutionMode !== "history-only") {
+      this.touchUpdatedAt(agent);
+    }
     this.emitState(agent);
   }
 
@@ -4363,24 +4568,9 @@ export class AgentManager {
     // Always resolve cwd to absolute path for consistent history file lookup
     if (normalized.cwd) {
       normalized.cwd = resolve(normalized.cwd);
-      try {
-        const cwdStats = await stat(normalized.cwd);
-        if (!cwdStats.isDirectory()) {
-          throw new Error(`Working directory is not a directory: ${normalized.cwd}`);
-        }
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          (error as NodeJS.ErrnoException).code === "ENOENT"
-        ) {
-          throw new Error(`Working directory does not exist: ${normalized.cwd}`, { cause: error });
-        }
-        if (error instanceof Error) {
-          throw error;
-        }
-        throw new Error(`Failed to access working directory: ${normalized.cwd}`, { cause: error });
-      }
+    }
+    if (normalized.cwd && options.validateCwd !== false) {
+      await validateWorkingDirectory(normalized.cwd);
     }
 
     if (typeof normalized.model === "string") {
@@ -4599,6 +4789,9 @@ export class AgentManager {
     const agent = this.requireAgent(id);
     if (agent.session === null) {
       throw new Error(`Agent '${agent.id}' has no managed session`);
+    }
+    if (agent.sessionExecutionMode === "history-only") {
+      throw new Error(`Agent '${agent.id}' is loaded for history only`);
     }
     return agent;
   }

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -607,10 +607,21 @@ export interface AgentCreateSessionOptions {
   persistSession?: boolean;
 }
 
-/** Runtime-only intent for a persisted-session resume. Never persist this option. */
-export interface AgentResumeSessionOptions {
-  /** Defaults to interactive. History loading may be read-only for archived native sessions. */
-  purpose?: "interactive" | "history";
+/**
+ * Read-only access to persisted provider history.
+ *
+ * Implementations must not create or resume an interactive provider runtime.
+ * The deliberately narrow surface prevents history hydration from being
+ * mistaken for a runnable session.
+ */
+export interface AgentHistoryLoader {
+  readonly provider: AgentProvider;
+  readonly id: string | null;
+  readonly capabilities: AgentCapabilityFlags;
+  readonly features?: AgentFeature[];
+  streamHistory(): AsyncGenerator<AgentStreamEvent>;
+  describePersistence(): AgentPersistenceHandle | null;
+  close(): Promise<void>;
 }
 
 /**
@@ -699,8 +710,16 @@ export interface AgentClient {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
-    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession>;
+  /**
+   * Load persisted history without creating or resuming a runnable provider
+   * runtime. Providers without this explicit capability fail closed when an
+   * archived timeline needs provider-backed hydration.
+   */
+  loadHistorySession?(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+  ): Promise<AgentHistoryLoader>;
   /**
    * Discover models and modes together. Implementations may use one upstream
    * process, separate upstream calls, static modes, or private helpers; callers

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -212,6 +212,8 @@ function buildAgentManagerSpies() {
     getAgent: vi.fn(),
     listAgents: vi.fn().mockReturnValue([]),
     getTimeline: vi.fn().mockReturnValue([]),
+    closeAgent: vi.fn().mockResolvedValue(undefined),
+    loadAgentHistoryFromPersistence: vi.fn(),
     resumeAgentFromPersistence: vi.fn(),
     hydrateTimelineFromProvider: vi.fn().mockResolvedValue(undefined),
     appendTimelineItem: vi.fn().mockResolvedValue(undefined),
@@ -5661,12 +5663,11 @@ describe("agent snapshot MCP serialization", () => {
       id: "archived-activity-agent",
       currentModeId: "default",
     } as ManagedAgent;
-    spies.agentManager.getAgent
-      .mockReturnValueOnce(null)
-      .mockReturnValue(snapshot)
-      .mockReturnValue(snapshot);
     spies.agentStorage.get.mockResolvedValue(record);
-    spies.agentManager.resumeAgentFromPersistence.mockResolvedValue(snapshot);
+    spies.agentManager.loadAgentHistoryFromPersistence.mockResolvedValue(snapshot);
+    spies.agentManager.getAgent.mockImplementation(() =>
+      spies.agentManager.loadAgentHistoryFromPersistence.mock.calls.length > 0 ? snapshot : null,
+    );
     spies.agentManager.getTimeline.mockReturnValue([
       {
         kind: "status",
@@ -5691,7 +5692,7 @@ describe("agent snapshot MCP serialization", () => {
         currentModeId: "default",
       }),
     );
-    expect(spies.agentManager.resumeAgentFromPersistence).toHaveBeenCalled();
+    expect(spies.agentManager.loadAgentHistoryFromPersistence).toHaveBeenCalled();
     expect(spies.agentManager.hydrateTimelineFromProvider).toHaveBeenCalledWith(
       "archived-activity-agent",
       { broadcast: expect.any(Function) },

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type {
   AgentClient,
   AgentCreateConfigUnattendedInput,
+  AgentHistoryLoader,
   AgentMode,
   AgentModelDefinition,
   AgentPersistenceHandle,
@@ -464,6 +465,27 @@ export function wrapSessionProvider(provider: AgentProvider, inner: AgentSession
   };
 }
 
+function wrapHistoryLoaderProvider(
+  provider: AgentProvider,
+  inner: AgentHistoryLoader,
+): AgentHistoryLoader {
+  return {
+    provider,
+    id: inner.id,
+    capabilities: inner.capabilities,
+    get features() {
+      return inner.features;
+    },
+    async *streamHistory() {
+      for await (const event of inner.streamHistory()) {
+        yield mapStreamEvent(provider, event);
+      }
+    },
+    describePersistence: () => mapPersistenceHandle(provider, inner.describePersistence()),
+    close: () => inner.close(),
+  };
+}
+
 function wrapClientProvider(
   provider: AgentProvider,
   inner: AgentClient,
@@ -474,6 +496,7 @@ function wrapClientProvider(
   const listImportableSessions = inner.listImportableSessions?.bind(inner);
   const importSession = inner.importSession?.bind(inner);
   const listFeatures = inner.listFeatures?.bind(inner);
+  const loadHistorySession = inner.loadHistorySession?.bind(inner);
 
   return {
     provider,
@@ -489,7 +512,7 @@ function wrapClientProvider(
           launchContext,
         ),
       ),
-    resumeSession: async (handle, overrides, launchContext, options) =>
+    resumeSession: async (handle, overrides, launchContext) =>
       wrapSessionProvider(
         provider,
         await inner.resumeSession(
@@ -504,9 +527,26 @@ function wrapClientProvider(
               }
             : undefined,
           launchContext,
-          options,
         ),
       ),
+    loadHistorySession: loadHistorySession
+      ? async (handle, overrides) =>
+          wrapHistoryLoaderProvider(
+            provider,
+            await loadHistorySession(
+              {
+                ...handle,
+                provider: inner.provider,
+              },
+              overrides
+                ? {
+                    ...overrides,
+                    provider: inner.provider,
+                  }
+                : undefined,
+            ),
+          )
+      : undefined,
     fetchCatalog: async (options) => {
       const catalog = await inner.fetchCatalog(options);
       return {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -93,6 +93,7 @@ import {
   type AgentClient,
   type AgentCreateSessionOptions,
   type AgentFeature,
+  type AgentHistoryLoader,
   type AgentLaunchContext,
   type AgentMetadata,
   type AgentMode,
@@ -1537,6 +1538,24 @@ export class ClaudeAgentClient implements AgentClient {
       queryFactory: this.queryFactory,
       resolveBinary: this.resolveBinary,
     });
+  }
+
+  async loadHistorySession(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+  ): Promise<AgentHistoryLoader> {
+    const session = await this.resumeSession(handle, overrides);
+    return {
+      provider: session.provider,
+      id: session.id,
+      capabilities: session.capabilities,
+      get features() {
+        return session.features;
+      },
+      streamHistory: () => session.streamHistory(),
+      describePersistence: () => session.describePersistence(),
+      close: () => session.close(),
+    };
   }
 
   async fetchCatalog(_options: FetchCatalogOptions): Promise<ProviderCatalog> {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -15,6 +15,7 @@ import type {
   AgentSlashCommand,
   AgentStreamEvent,
 } from "../agent-sdk-types.js";
+import { AgentManager } from "../agent-manager.js";
 import {
   buildCodexAppServerEnv,
   CodexAppServerAgentClient,
@@ -1055,31 +1056,24 @@ describe("Codex app-server provider", () => {
     await session.close();
   });
 
-  test("loads archived Codex history without resuming the native thread", async () => {
-    const threadRequests: string[] = [];
-    const appServer = createFakeCodexAppServer({
-      "thread/loaded/list": () => {
-        threadRequests.push("thread/loaded/list");
-        return { data: [] };
-      },
-      "thread/resume": () => {
-        threadRequests.push("thread/resume");
-        return Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id")));
-      },
-      "thread/read": () => {
-        threadRequests.push("thread/read");
-        return { thread: { turns: [] } };
-      },
+  test("fails archived Codex history closed without spawning app-server", async () => {
+    const provider = new CodexAppServerAgentClient(createTestLogger());
+    const spawnAppServer = vi.fn(async () => {
+      throw new Error("Codex app-server must not spawn for history loading");
     });
-    const provider = createProviderWithFakeAppServer(appServer);
+    castInternals<{ spawnAppServer: typeof spawnAppServer }>(provider).spawnAppServer =
+      spawnAppServer;
+    const manager = new AgentManager({ clients: { codex: provider }, logger: createTestLogger() });
 
-    const session = await provider.resumeSession(archivedThreadHandle(), undefined, undefined, {
-      purpose: "history",
-    });
+    await expect(
+      manager.loadAgentHistoryFromPersistence(
+        { ...archivedThreadHandle(), provider: "codex" },
+        { cwd: "/removed/codex-workspace", modeId: "auto" },
+        "00000000-0000-4000-8000-000000000309",
+      ),
+    ).rejects.toThrow("Provider 'codex' does not support non-runnable history loading");
 
-    expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume", "thread/read"]);
-    await session.close();
-    appServer.assertNoErrors();
+    expect(spawnAppServer).not.toHaveBeenCalled();
   });
 
   test("closes Codex app-server when an interactive resume fails", async () => {
@@ -1093,23 +1087,6 @@ describe("Codex app-server provider", () => {
     await expect(provider.resumeSession(archivedThreadHandle())).rejects.toThrow(
       archivedThreadErrorMessage("archived-thread-id"),
     );
-
-    expect(killSpy).toHaveBeenCalledWith("SIGTERM");
-    appServer.assertNoErrors();
-  });
-
-  test("closes Codex app-server when archived history hydration fails", async () => {
-    const appServer = createFakeCodexAppServer({
-      "thread/resume": () =>
-        Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id"))),
-      "thread/read": () => Promise.reject(new Error("thread history is unavailable")),
-    });
-    const killSpy = vi.spyOn(appServer.child, "kill");
-    const provider = createProviderWithFakeAppServer(appServer);
-
-    await expect(
-      provider.resumeSession(archivedThreadHandle(), undefined, undefined, { purpose: "history" }),
-    ).rejects.toThrow("thread history is unavailable");
 
     expect(killSpy).toHaveBeenCalledWith("SIGTERM");
     appServer.assertNoErrors();

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -6,7 +6,6 @@ import {
   type AgentCreateSessionOptions,
   type AgentFeature,
   type AgentLaunchContext,
-  type AgentResumeSessionOptions,
   type AgentMode,
   type AgentModelDefinition,
   type McpServerConfig,
@@ -114,14 +113,6 @@ function assertChildWithPipes(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
-}
-
-function isArchivedCodexThreadResumeError(error: unknown, threadId: string): boolean {
-  if (!(error instanceof Error)) return false;
-  const expectedMessage =
-    `session ${threadId} is archived. ` +
-    `Run \`codex unarchive ${threadId}\` to unarchive it first.`;
-  return error.message === expectedMessage;
 }
 
 function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolean {
@@ -3242,7 +3233,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     private readonly goalsEnabled: boolean = false,
     private readonly autoReviewEnabled: boolean = false,
     private readonly agentId?: string,
-    private readonly initialResumePurpose: "interactive" | "history" = "interactive",
   ) {
     this.logger = logger.child({
       module: "agent",
@@ -3333,9 +3323,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       await this.loadSkills();
 
       if (this.currentThreadId) {
-        await this.ensureThreadLoaded({
-          allowArchivedHistory: this.initialResumePurpose === "history",
-        });
+        await this.ensureThreadLoaded();
         await this.loadPersistedHistory();
       }
 
@@ -3711,9 +3699,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
   }
 
-  private async ensureThreadLoaded(
-    options: { allowArchivedHistory?: boolean } = {},
-  ): Promise<void> {
+  private async ensureThreadLoaded(): Promise<void> {
     if (!this.client || !this.currentThreadId) return;
     try {
       const loaded = toObjectRecord(await this.client.request("thread/loaded/list", {}));
@@ -3738,16 +3724,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     } catch (error) {
       const threadId = this.currentThreadId;
       const message = error instanceof Error ? error.message : String(error);
-      if (
-        options.allowArchivedHistory === true &&
-        isArchivedCodexThreadResumeError(error, threadId)
-      ) {
-        this.logger.info(
-          { threadId },
-          "Loading archived Codex thread history without resuming the native session",
-        );
-        return;
-      }
       this.logger.warn({ error, threadId }, "Failed to resume persisted Codex thread");
       throw new Error(`Failed to resume Codex thread ${threadId}: ${message}`, { cause: error });
     }
@@ -6584,7 +6560,6 @@ export class CodexAppServerAgentClient implements AgentClient {
     handle: { sessionId: string; metadata?: Record<string, unknown> },
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
-    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession> {
     const storedConfig = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
     const merged: AgentSessionConfig = {
@@ -6606,7 +6581,6 @@ export class CodexAppServerAgentClient implements AgentClient {
       goalsEnabled,
       autoReviewEnabled,
       launchContext?.agentId,
-      options?.purpose ?? "interactive",
     );
     await session.connect();
     return session;

--- a/packages/server/src/server/agent/providers/mock-load-test-agent.ts
+++ b/packages/server/src/server/agent/providers/mock-load-test-agent.ts
@@ -4,6 +4,7 @@ import type {
   AgentCapabilityFlags,
   AgentClient,
   AgentFeature,
+  AgentHistoryLoader,
   AgentLaunchContext,
   AgentMode,
   AgentModelDefinition,
@@ -598,6 +599,13 @@ export class MockLoadTestAgentClient implements AgentClient {
       sessionId: handle.sessionId,
       logger: this.logger,
     });
+  }
+
+  async loadHistorySession(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+  ): Promise<AgentHistoryLoader> {
+    return await this.resumeSession(handle, overrides);
   }
 
   async fetchCatalog(_options: FetchCatalogOptions): Promise<ProviderCatalog> {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -9,6 +9,7 @@ import {
   type AgentCapabilityFlags,
   type AgentClient,
   type AgentFeature,
+  type AgentHistoryLoader,
   type AgentLaunchContext,
   type AgentMetadata,
   type AgentMode,
@@ -2302,6 +2303,30 @@ export class OmpAgentClient implements AgentClient {
       await runtimeSession.close().catch(() => undefined);
       throw error;
     }
+  }
+
+  async loadHistorySession(handle: AgentPersistenceHandle): Promise<AgentHistoryLoader> {
+    const sessionFile = handle.nativeHandle;
+    if (typeof sessionFile !== "string" || sessionFile.length === 0) {
+      throw new Error("OMP history loading requires a native session file handle");
+    }
+    if (!existsSync(sessionFile)) {
+      throw new Error(`OMP history session file does not exist: ${sessionFile}`);
+    }
+
+    return {
+      provider: this.provider,
+      id: handle.sessionId,
+      capabilities: this.capabilities,
+      features: [],
+      streamHistory: () =>
+        streamOmpHistory({
+          sessionFile,
+          provider: this.provider,
+        }),
+      describePersistence: () => handle,
+      close: async () => {},
+    };
   }
 
   async fetchCatalog(options: FetchCatalogOptions): Promise<ProviderCatalog> {

--- a/packages/server/src/server/persistence-hooks.ts
+++ b/packages/server/src/server/persistence-hooks.ts
@@ -1,4 +1,4 @@
-import type { AgentManager } from "./agent/agent-manager.js";
+import type { AgentManager, ManagedAgent } from "./agent/agent-manager.js";
 import { stripInternalPaseoMcpServer } from "./agent/runtime-mcp-config.js";
 import type {
   AgentPersistenceHandle,
@@ -113,7 +113,17 @@ export function extractTimestamps(record: StoredAgentRecord): {
   labels?: Record<string, string>;
   workspaceId?: string;
   owner?: StoredAgentRecord["owner"];
+  attention: ManagedAgent["attention"];
 } {
+  let attention: ManagedAgent["attention"] = { requiresAttention: false };
+  if (record.requiresAttention && record.attentionReason && record.attentionTimestamp) {
+    attention = {
+      requiresAttention: true,
+      attentionReason: record.attentionReason,
+      attentionTimestamp: new Date(record.attentionTimestamp),
+    };
+  }
+
   return {
     createdAt: new Date(record.createdAt),
     updatedAt: new Date(record.lastActivityAt ?? record.updatedAt),
@@ -121,6 +131,7 @@ export function extractTimestamps(record: StoredAgentRecord): {
     labels: record.labels,
     workspaceId: record.workspaceId,
     owner: record.owner,
+    attention,
   };
 }
 

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -197,11 +197,13 @@ function buildRunOutput(params: {
 
 type ScheduleAgentManager = Pick<
   AgentManager,
+  | "closeAgent"
   | "createAgent"
   | "getAgent"
   | "getRegisteredProviderIds"
   | "hasInFlightRun"
   | "hydrateTimelineFromProvider"
+  | "loadAgentHistoryFromPersistence"
   | "resumeAgentFromPersistence"
   | "runAgent"
   | "waitForAgentEvent"


### PR DESCRIPTION
### Linked issue

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Archived agents can outlive the managed worktree that supplied their cwd. Loading an archived timeline normalized the persisted session configuration and rejected the deleted cwd before the provider could read persisted history, so the timeline became unreadable.

This change skips cwd existence validation only for archived history loading. The cwd is still resolved for history lookup, while interactive resume, reload, create, and execution retain the existing fail-closed validation.

### Goals

- Keep archived timelines readable after their former cwd is deleted.
- Preserve missing-cwd rejection for interactive resume and reload.
- Cover both paths with focused regression tests.

### Non-goals

- Change provider history persistence or hydration behavior.
- Recreate deleted worktrees.
- Relax cwd validation for active or executable sessions.

### QA

Tested on macOS. No UI behavior changed.

Before the implementation, the archived-history regression failed with `Working directory does not exist: .../archived-workspace` after the test removed the archived cwd.

After the implementation:

- `npx vitest run src/server/agent/agent-loading.test.ts --bail=1`: 2 passed.
- `npx vitest run src/server/agent/agent-manager.test.ts -t "reloadAgentSession fails when the agent cwd no longer exists" --bail=1`: 1 passed, 150 skipped.
- `npm run typecheck`: passed for all workspaces.
- `npm run lint`: 0 warnings and 0 errors.
- `npm run format`: completed successfully.
- `npm run format:check`: all matched files use the correct format.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense