### PR TITLE
fix(server): make workspace finish fencing leak-free

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6511,6 +6511,48 @@ test("archiveAgent persists archivedAt and updatedAt before emitting closed stat
   expect(lifecycles.slice(-2)).toEqual(["idle", "closed"]);
 });
 
+test("releases a workspace after an archived agent is loaded only for history", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-release-history-agent-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+  const workspaceId = "wks_archived_history";
+  const finished = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000149",
+    { workspaceId },
+  );
+  await manager.archiveAgent(finished.id);
+
+  await ensureAgentLoaded(finished.id, {
+    agentManager: manager,
+    agentStorage: storage,
+    logger,
+  });
+  expect(manager.getAgent(finished.id)?.workspaceId).toBe(workspaceId);
+  expect((await storage.get(finished.id))?.archivedAt).toEqual(expect.any(String));
+
+  let released = false;
+  await expect(
+    manager.releaseWorkspaceIfUnowned({
+      workspaceId,
+      finishedAgentId: finished.id,
+      release: async () => {
+        released = true;
+      },
+    }),
+  ).resolves.toBe(true);
+
+  expect({ released, loadedAgent: manager.getAgent(finished.id) }).toEqual({
+    released: true,
+    loadedAgent: null,
+  });
+  rmSync(workdir, { recursive: true, force: true });
+});
+
 test("waits for an earlier workspace registration before checking ownership", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-release-pending-registration-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6690,6 +6690,43 @@ test("rejects a workspace registration that starts during release", async () => 
   rmSync(workdir, { recursive: true, force: true });
 });
 
+test("allows a workspace registration after its release callback fails", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-registration-after-release-failure-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+  const workspaceId = "wks_registration_after_release_failure";
+  const finished = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000150",
+    { workspaceId },
+  );
+
+  await expect(
+    manager.releaseWorkspaceIfUnowned({
+      workspaceId,
+      finishedAgentId: finished.id,
+      release: async () => {
+        throw new Error("workspace release failed");
+      },
+    }),
+  ).rejects.toThrow("workspace release failed");
+
+  const replacement = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000151",
+    { workspaceId },
+  );
+  expect(replacement.workspaceId).toBe(workspaceId);
+
+  await manager.closeAgent(finished.id);
+  await manager.closeAgent(replacement.id);
+  rmSync(workdir, { recursive: true, force: true });
+});
+
 test("fires onAgentArchived for archived parent and cascaded children", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-archived-hook-cascade-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -182,6 +182,7 @@ class SessionRecordingAgentClient extends TestAgentClient {
 class HeldAgentCreationClient extends TestAgentClient {
   private readonly creationStarted = deferred<void>();
   private readonly creationAllowed = deferred<void>();
+  creationFailure: Error | null = null;
   createdSessionClosed = false;
 
   override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
@@ -195,6 +196,9 @@ class HeldAgentCreationClient extends TestAgentClient {
     })(config);
     this.creationStarted.resolve();
     await this.creationAllowed.promise;
+    if (this.creationFailure) {
+      throw this.creationFailure;
+    }
     return session;
   }
 
@@ -296,6 +300,8 @@ class NativeArchiveRecordingClient extends TestAgentClient {
   readArchivedAtDuringUnarchive: (() => Promise<string | null | undefined>) | null = null;
   archivedAtDuringUnarchive: string | null | undefined;
   unarchiveFailure: Error | null = null;
+  private unarchiveStarted: Deferred<void> | null = null;
+  private unarchiveAllowed: Deferred<void> | null = null;
 
   async archiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
     this.archivedHandles.push(handle);
@@ -303,12 +309,37 @@ class NativeArchiveRecordingClient extends TestAgentClient {
 
   async unarchiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
     this.unarchivedHandles.push(handle);
+    this.unarchiveStarted?.resolve();
+    if (this.unarchiveAllowed) {
+      await this.unarchiveAllowed.promise;
+    }
     if (this.readArchivedAtDuringUnarchive) {
       this.archivedAtDuringUnarchive = await this.readArchivedAtDuringUnarchive();
     }
     if (this.unarchiveFailure) {
       throw this.unarchiveFailure;
     }
+  }
+
+  holdNativeUnarchive(): void {
+    this.unarchiveStarted = deferred<void>();
+    this.unarchiveAllowed = deferred<void>();
+  }
+
+  waitForNativeUnarchive(): Promise<void> {
+    if (!this.unarchiveStarted) {
+      throw new Error("Native unarchive is not held");
+    }
+    return this.unarchiveStarted.promise;
+  }
+
+  finishNativeUnarchive(): void {
+    if (!this.unarchiveAllowed) {
+      throw new Error("Native unarchive is not held");
+    }
+    this.unarchiveAllowed.resolve();
+    this.unarchiveStarted = null;
+    this.unarchiveAllowed = null;
   }
 }
 
@@ -6480,7 +6511,7 @@ test("archiveAgent persists archivedAt and updatedAt before emitting closed stat
   expect(lifecycles.slice(-2)).toEqual(["idle", "closed"]);
 });
 
-test("does not release a workspace while another agent is registering", async () => {
+test("waits for an earlier workspace registration before checking ownership", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-release-pending-registration-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
   const manager = new AgentManager({
@@ -6506,26 +6537,73 @@ test("does not release a workspace while another agent is registering", async ()
   await heldClient.waitForCreationToStart();
 
   let released = false;
-  try {
-    await expect(
-      manager.releaseWorkspaceIfUnowned({
-        workspaceId,
-        finishedAgentId: finished.id,
-        release: async () => {
-          released = true;
-        },
-      }),
-    ).resolves.toBe(false);
-  } finally {
-    heldClient.finishCreating();
-  }
+  const release = manager.releaseWorkspaceIfUnowned({
+    workspaceId,
+    finishedAgentId: finished.id,
+    release: async () => {
+      released = true;
+    },
+  });
+  const laterCreation = manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000144",
+    { workspaceId },
+  );
+
+  heldClient.finishCreating();
 
   const rival = await rivalCreation;
+  await expect(laterCreation).rejects.toThrow(`Workspace ${workspaceId} is being released`);
+  await expect(release).resolves.toBe(false);
   expect({ released, rivalWorkspaceId: rival.workspaceId }).toEqual({
     released: false,
     rivalWorkspaceId: workspaceId,
   });
   await manager.closeAgent(rival.id);
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+test("releases a workspace after an earlier registration fails", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-release-failed-registration-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const heldClient = new HeldAgentCreationClient();
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+  const workspaceId = "wks_failed_registration";
+  const finished = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000145",
+    { workspaceId },
+  );
+  await manager.archiveAgent(finished.id);
+
+  manager.registerClient("codex", heldClient);
+  heldClient.creationFailure = new Error("provider creation failed");
+  const rivalCreation = manager
+    .createAgent({ provider: "codex", cwd: workdir }, "00000000-0000-4000-8000-000000000146", {
+      workspaceId,
+    })
+    .catch((error: unknown) => error);
+  await heldClient.waitForCreationToStart();
+
+  let released = false;
+  const release = manager.releaseWorkspaceIfUnowned({
+    workspaceId,
+    finishedAgentId: finished.id,
+    release: async () => {
+      released = true;
+    },
+  });
+  heldClient.finishCreating();
+
+  await expect(rivalCreation).resolves.toEqual(
+    expect.objectContaining({ message: "provider creation failed" }),
+  );
+  await expect(release).resolves.toBe(true);
+  expect({ released, agents: manager.listAgents() }).toEqual({ released: true, agents: [] });
   rmSync(workdir, { recursive: true, force: true });
 });
 
@@ -6761,6 +6839,79 @@ test("unarchiveSnapshot keeps the stored record archived when native unarchive f
   const stored = await storage.get(agent.id);
   expect(stored?.archivedAt).toEqual(expect.any(String));
   expect(client.unarchivedHandles).toHaveLength(1);
+});
+
+test("an earlier archived restore prevents workspace release", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-restore-before-release-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const client = new NativeArchiveRecordingClient();
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  const workspaceId = "wks_restore_before_release";
+  const agent = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000147",
+    { workspaceId },
+  );
+  await manager.archiveAgent(agent.id);
+  client.holdNativeUnarchive();
+
+  const restore = manager.unarchiveSnapshot(agent.id);
+  await client.waitForNativeUnarchive();
+  let released = false;
+  const release = manager.releaseWorkspaceIfUnowned({
+    workspaceId,
+    finishedAgentId: agent.id,
+    release: async () => {
+      released = true;
+    },
+  });
+  const laterRestore = manager.unarchiveSnapshot(agent.id);
+  client.finishNativeUnarchive();
+
+  await expect(laterRestore).rejects.toThrow(`Workspace ${workspaceId} is being released`);
+  await expect(restore).resolves.toBe(true);
+  await expect(release).resolves.toBe(false);
+  expect({ released, archivedAt: (await storage.get(agent.id))?.archivedAt }).toEqual({
+    released: false,
+    archivedAt: null,
+  });
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+test("a release-first archived restore cannot revive provider or persisted state", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-release-before-restore-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const client = new NativeArchiveRecordingClient();
+  const manager = new AgentManager({ clients: { codex: client }, registry: storage, logger });
+  const workspaceId = "wks_release_before_restore";
+  const agent = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000148",
+    { workspaceId },
+  );
+  await manager.archiveAgent(agent.id);
+  const releaseStarted = deferred<void>();
+  const releaseAllowed = deferred<void>();
+
+  const release = manager.releaseWorkspaceIfUnowned({
+    workspaceId,
+    finishedAgentId: agent.id,
+    release: async () => {
+      releaseStarted.resolve();
+      await releaseAllowed.promise;
+    },
+  });
+  await releaseStarted.promise;
+  const priorNativeUnarchives = client.unarchivedHandles.length;
+  const restore = manager.unarchiveSnapshot(agent.id);
+  releaseAllowed.resolve();
+
+  await expect(restore).rejects.toThrow(`Workspace ${workspaceId} is being released`);
+  await expect(release).resolves.toBe(true);
+  expect(client.unarchivedHandles).toHaveLength(priorNativeUnarchives);
+  expect((await storage.get(agent.id))?.archivedAt).toEqual(expect.any(String));
+  expect(manager.getAgent(agent.id)).toBeNull();
+  rmSync(workdir, { recursive: true, force: true });
 });
 
 test("archiveAgent cascade archives in-memory children with the full archive contract", async () => {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6480,6 +6480,96 @@ test("archiveAgent persists archivedAt and updatedAt before emitting closed stat
   expect(lifecycles.slice(-2)).toEqual(["idle", "closed"]);
 });
 
+test("does not release a workspace while another agent is registering", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-release-pending-registration-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+  const workspaceId = "wks_pending_registration";
+  const finished = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000140",
+    { workspaceId },
+  );
+  await manager.archiveAgent(finished.id);
+
+  const heldClient = new HeldAgentCreationClient();
+  manager.registerClient("codex", heldClient);
+  const rivalCreation = manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000141",
+    { workspaceId },
+  );
+  await heldClient.waitForCreationToStart();
+
+  let released = false;
+  try {
+    await expect(
+      manager.releaseWorkspaceIfUnowned({
+        workspaceId,
+        finishedAgentId: finished.id,
+        release: async () => {
+          released = true;
+        },
+      }),
+    ).resolves.toBe(false);
+  } finally {
+    heldClient.finishCreating();
+  }
+
+  const rival = await rivalCreation;
+  expect({ released, rivalWorkspaceId: rival.workspaceId }).toEqual({
+    released: false,
+    rivalWorkspaceId: workspaceId,
+  });
+  await manager.closeAgent(rival.id);
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+test("rejects a workspace registration that starts during release", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-registration-during-release-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+  const workspaceId = "wks_registration_during_release";
+  const finished = await manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000142",
+    { workspaceId },
+  );
+  await manager.archiveAgent(finished.id);
+
+  const releaseStarted = deferred<void>();
+  const releaseAllowed = deferred<void>();
+  const release = manager.releaseWorkspaceIfUnowned({
+    workspaceId,
+    finishedAgentId: finished.id,
+    release: async () => {
+      releaseStarted.resolve();
+      await releaseAllowed.promise;
+    },
+  });
+  await releaseStarted.promise;
+
+  const rivalCreation = manager.createAgent(
+    { provider: "codex", cwd: workdir },
+    "00000000-0000-4000-8000-000000000143",
+    { workspaceId },
+  );
+  releaseAllowed.resolve();
+
+  await expect(rivalCreation).rejects.toThrow(`Workspace ${workspaceId} is being released`);
+  await expect(release).resolves.toBe(true);
+  expect(manager.listAgents()).toEqual([]);
+  rmSync(workdir, { recursive: true, force: true });
+});
+
 test("fires onAgentArchived for archived parent and cascaded children", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-archived-hook-cascade-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1549,10 +1549,6 @@ export class AgentManager {
     try {
       await this.workspaceAgentRegistrations.get(workspaceId)?.settled;
 
-      if (this.hasOtherLiveAgentInWorkspace(workspaceId, finishedAgentId)) {
-        return false;
-      }
-
       const records = await this.requireRegistry().list();
       const finishedRecord = records.find((record) => record.id === finishedAgentId);
       if (
@@ -1567,6 +1563,21 @@ export class AgentManager {
       ) {
         return false;
       }
+
+      // Archived agents may be loaded back into memory solely to serve history
+      // requests. Durable archive state, not in-memory presence, determines
+      // workspace ownership. Close those history-only runtimes before removing
+      // the workspace so they do not retain a session whose cwd no longer
+      // exists.
+      const archivedRuntimeIds = records
+        .filter(
+          (record) =>
+            record.workspaceId === workspaceId &&
+            Boolean(record.archivedAt) &&
+            this.agents.has(record.id),
+        )
+        .map((record) => record.id);
+      await Promise.all(archivedRuntimeIds.map((agentId) => this.closeAgent(agentId)));
 
       await options.release();
       return true;
@@ -4376,15 +4387,6 @@ export class AgentManager {
       this.workspaceAgentRegistrations.delete(workspaceId);
       state.resolveSettled();
     }
-  }
-
-  private hasOtherLiveAgentInWorkspace(workspaceId: string, finishedAgentId: string): boolean {
-    for (const agent of this.agents.values()) {
-      if (agent.id !== finishedAgentId && agent.workspaceId === workspaceId) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolve } from "node:path";
 import { stat } from "node:fs/promises";
 import {
@@ -283,6 +284,12 @@ export interface ReleaseWorkspaceIfUnownedOptions {
   workspaceId: string;
   finishedAgentId: string;
   release: () => Promise<void>;
+}
+
+interface WorkspaceAgentRegistrationState {
+  count: number;
+  settled: Promise<void>;
+  resolveSettled: () => void;
 }
 
 export interface WaitForAgentOptions {
@@ -637,7 +644,8 @@ export class AgentManager {
   private readonly backgroundTasks = new Set<Promise<void>>();
   private readonly agentRegistrationTasks = new Set<Promise<void>>();
   private readonly inFlightAgentCloses = new Map<string, Promise<void>>();
-  private readonly workspaceAgentRegistrations = new Map<string, number>();
+  private readonly workspaceAgentRegistrations = new Map<string, WorkspaceAgentRegistrationState>();
+  private readonly workspaceAgentRegistrationContext = new AsyncLocalStorage<Set<string>>();
   private readonly releasingWorkspaces = new Set<string>();
   private readonly agentStreamCoalescer: AgentStreamCoalescer;
   private mcpBaseUrl: string | null;
@@ -1083,10 +1091,8 @@ export class AgentManager {
     agentId: string | undefined,
     options: CreateAgentOptions,
   ): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(
-      this.trackWorkspaceAgentRegistration(options.workspaceId, () =>
-        this.createAgentInternal(config, agentId, options),
-      ),
+    return this.runWorkspaceAgentRegistration(options.workspaceId, () =>
+      this.createAgentInternal(config, agentId, options),
     );
   }
 
@@ -1149,10 +1155,8 @@ export class AgentManager {
     },
     resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(
-      this.trackWorkspaceAgentRegistration(options?.workspaceId, () =>
-        this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
-      ),
+    return this.runWorkspaceAgentRegistration(options?.workspaceId, () =>
+      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
     );
   }
 
@@ -1215,10 +1219,8 @@ export class AgentManager {
     workspaceId: string;
     labels?: Record<string, string>;
   }): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(
-      this.trackWorkspaceAgentRegistration(input.workspaceId, () =>
-        this.importProviderSessionInternal(input),
-      ),
+    return this.runWorkspaceAgentRegistration(input.workspaceId, () =>
+      this.importProviderSessionInternal(input),
     );
   }
 
@@ -1296,7 +1298,7 @@ export class AgentManager {
     overrides?: Partial<AgentSessionConfig>,
     options?: { rehydrateFromDisk?: boolean },
   ): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(
+    return this.runWorkspaceAgentRegistration(this.agents.get(agentId)?.workspaceId, () =>
       this.reloadAgentSessionInternal(agentId, overrides, options),
     );
   }
@@ -1537,17 +1539,16 @@ export class AgentManager {
 
   async releaseWorkspaceIfUnowned(options: ReleaseWorkspaceIfUnownedOptions): Promise<boolean> {
     const { workspaceId, finishedAgentId } = options;
-    // Registration and release claim opposing state before their first await, so
-    // JavaScript run-to-completion makes this ownership handoff atomic.
-    if (
-      this.releasingWorkspaces.has(workspaceId) ||
-      (this.workspaceAgentRegistrations.get(workspaceId) ?? 0) > 0
-    ) {
+    if (this.releasingWorkspaces.has(workspaceId)) {
       return false;
     }
 
+    // Claim release before waiting so later registrations cannot barge ahead of
+    // it. Registrations that already hold the claim may finish nested work.
     this.releasingWorkspaces.add(workspaceId);
     try {
+      await this.workspaceAgentRegistrations.get(workspaceId)?.settled;
+
       if (this.hasOtherLiveAgentInWorkspace(workspaceId, finishedAgentId)) {
         return false;
       }
@@ -1910,15 +1911,37 @@ export class AgentManager {
       return false;
     }
 
+    return this.runWorkspaceAgentRegistration(record.workspaceId, () =>
+      this.runWorkspaceAgentRegistration(updates?.workspaceId, () =>
+        this.unarchiveSnapshotInternal(agentId, updates),
+      ),
+    );
+  }
+
+  private async unarchiveSnapshotInternal(
+    agentId: string,
+    updates?: { workspaceId?: string; labels?: AgentLabelPatch },
+  ): Promise<boolean> {
+    const registry = this.requireRegistry();
+    const record = await registry.get(agentId);
+    if (!record || !record.archivedAt) {
+      return false;
+    }
+
     await this.unarchiveNativeSession(record.provider, record.persistence);
 
-    await registry.upsert({
-      ...record,
-      ...(updates?.workspaceId ? { workspaceId: updates.workspaceId } : {}),
-      ...(updates?.labels ? { labels: applyLabelPatch(record.labels, updates.labels) } : {}),
-      archivedAt: null,
-      updatedAt: new Date().toISOString(),
-    });
+    try {
+      await registry.upsert({
+        ...record,
+        ...(updates?.workspaceId ? { workspaceId: updates.workspaceId } : {}),
+        ...(updates?.labels ? { labels: applyLabelPatch(record.labels, updates.labels) } : {}),
+        archivedAt: null,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      await this.archiveNativeSessionBestEffort(record.provider, record.persistence);
+      throw error;
+    }
 
     if (this.getAgent(agentId)) {
       this.notifyAgentState(agentId);
@@ -4291,6 +4314,19 @@ export class AgentManager {
     return result;
   }
 
+  runWorkspaceAgentRegistration<T>(
+    workspaceId: string | undefined,
+    register: () => Promise<T>,
+  ): Promise<T> {
+    let registration: Promise<T>;
+    try {
+      registration = this.trackWorkspaceAgentRegistration(workspaceId, register);
+    } catch (error) {
+      registration = Promise.reject(error);
+    }
+    return this.trackAgentRegistrationOperation(registration);
+  }
+
   private trackWorkspaceAgentRegistration<T>(
     workspaceId: string | undefined,
     register: () => Promise<T>,
@@ -4298,17 +4334,31 @@ export class AgentManager {
     if (!workspaceId) {
       return register();
     }
+    const activeWorkspaces = this.workspaceAgentRegistrationContext.getStore();
+    if (activeWorkspaces?.has(workspaceId)) {
+      return register();
+    }
     if (this.releasingWorkspaces.has(workspaceId)) {
       return Promise.reject(new Error(`Workspace ${workspaceId} is being released`));
     }
 
-    this.workspaceAgentRegistrations.set(
-      workspaceId,
-      (this.workspaceAgentRegistrations.get(workspaceId) ?? 0) + 1,
-    );
+    let state = this.workspaceAgentRegistrations.get(workspaceId);
+    if (!state) {
+      let resolveSettled!: () => void;
+      const settled = new Promise<void>((settle) => {
+        resolveSettled = settle;
+      });
+      state = { count: 0, settled, resolveSettled };
+      this.workspaceAgentRegistrations.set(workspaceId, state);
+    }
+    state.count += 1;
+
     let registration: Promise<T>;
     try {
-      registration = register();
+      registration = this.workspaceAgentRegistrationContext.run(
+        new Set([...(activeWorkspaces ?? []), workspaceId]),
+        register,
+      );
     } catch (error) {
       this.finishWorkspaceAgentRegistration(workspaceId);
       throw error;
@@ -4317,11 +4367,14 @@ export class AgentManager {
   }
 
   private finishWorkspaceAgentRegistration(workspaceId: string): void {
-    const remaining = (this.workspaceAgentRegistrations.get(workspaceId) ?? 1) - 1;
-    if (remaining === 0) {
+    const state = this.workspaceAgentRegistrations.get(workspaceId);
+    if (!state) {
+      return;
+    }
+    state.count -= 1;
+    if (state.count === 0) {
       this.workspaceAgentRegistrations.delete(workspaceId);
-    } else {
-      this.workspaceAgentRegistrations.set(workspaceId, remaining);
+      state.resolveSettled();
     }
   }
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -288,6 +288,7 @@ export interface ReleaseWorkspaceIfUnownedOptions {
 
 interface WorkspaceAgentRegistrationState {
   count: number;
+  succeeded: boolean;
   settled: Promise<void>;
   resolveSettled: () => void;
 }
@@ -1547,13 +1548,15 @@ export class AgentManager {
     // it. Registrations that already hold the claim may finish nested work.
     this.releasingWorkspaces.add(workspaceId);
     try {
-      await this.workspaceAgentRegistrations.get(workspaceId)?.settled;
+      const priorRegistrations = this.workspaceAgentRegistrations.get(workspaceId);
+      await priorRegistrations?.settled;
 
       const records = await this.requireRegistry().list();
       const finishedRecord = records.find((record) => record.id === finishedAgentId);
       if (
         !finishedRecord ||
         finishedRecord.workspaceId !== workspaceId ||
+        (!finishedRecord.archivedAt && priorRegistrations?.succeeded) ||
         records.some(
           (record) =>
             record.id !== finishedAgentId &&
@@ -4359,10 +4362,11 @@ export class AgentManager {
       const settled = new Promise<void>((settle) => {
         resolveSettled = settle;
       });
-      state = { count: 0, settled, resolveSettled };
+      state = { count: 0, succeeded: false, settled, resolveSettled };
       this.workspaceAgentRegistrations.set(workspaceId, state);
     }
     state.count += 1;
+    const registrationState = state;
 
     let registration: Promise<T>;
     try {
@@ -4374,7 +4378,12 @@ export class AgentManager {
       this.finishWorkspaceAgentRegistration(workspaceId);
       throw error;
     }
-    return registration.finally(() => this.finishWorkspaceAgentRegistration(workspaceId));
+    return registration
+      .then((value) => {
+        registrationState.succeeded = true;
+        return value;
+      })
+      .finally(() => this.finishWorkspaceAgentRegistration(workspaceId));
   }
 
   private finishWorkspaceAgentRegistration(workspaceId: string): void {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -279,6 +279,12 @@ export interface AgentManagerOptions {
   logger: Logger;
 }
 
+export interface ReleaseWorkspaceIfUnownedOptions {
+  workspaceId: string;
+  finishedAgentId: string;
+  release: () => Promise<void>;
+}
+
 export interface WaitForAgentOptions {
   signal?: AbortSignal;
   waitForActive?: boolean;
@@ -631,6 +637,8 @@ export class AgentManager {
   private readonly backgroundTasks = new Set<Promise<void>>();
   private readonly agentRegistrationTasks = new Set<Promise<void>>();
   private readonly inFlightAgentCloses = new Map<string, Promise<void>>();
+  private readonly workspaceAgentRegistrations = new Map<string, number>();
+  private readonly releasingWorkspaces = new Set<string>();
   private readonly agentStreamCoalescer: AgentStreamCoalescer;
   private mcpBaseUrl: string | null;
   private readonly mcpAuthToken: string | null;
@@ -1075,7 +1083,11 @@ export class AgentManager {
     agentId: string | undefined,
     options: CreateAgentOptions,
   ): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(this.createAgentInternal(config, agentId, options));
+    return this.trackAgentRegistrationOperation(
+      this.trackWorkspaceAgentRegistration(options.workspaceId, () =>
+        this.createAgentInternal(config, agentId, options),
+      ),
+    );
   }
 
   private async createAgentInternal(
@@ -1138,7 +1150,9 @@ export class AgentManager {
     resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      this.trackWorkspaceAgentRegistration(options?.workspaceId, () =>
+        this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      ),
     );
   }
 
@@ -1201,7 +1215,11 @@ export class AgentManager {
     workspaceId: string;
     labels?: Record<string, string>;
   }): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(this.importProviderSessionInternal(input));
+    return this.trackAgentRegistrationOperation(
+      this.trackWorkspaceAgentRegistration(input.workspaceId, () =>
+        this.importProviderSessionInternal(input),
+      ),
+    );
   }
 
   private async importProviderSessionInternal(input: {
@@ -1515,6 +1533,45 @@ export class AgentManager {
     await this.cascadeArchiveChildren(agentId);
 
     return { archivedAt };
+  }
+
+  async releaseWorkspaceIfUnowned(options: ReleaseWorkspaceIfUnownedOptions): Promise<boolean> {
+    const { workspaceId, finishedAgentId } = options;
+    // Registration and release claim opposing state before their first await, so
+    // JavaScript run-to-completion makes this ownership handoff atomic.
+    if (
+      this.releasingWorkspaces.has(workspaceId) ||
+      (this.workspaceAgentRegistrations.get(workspaceId) ?? 0) > 0
+    ) {
+      return false;
+    }
+
+    this.releasingWorkspaces.add(workspaceId);
+    try {
+      if (this.hasOtherLiveAgentInWorkspace(workspaceId, finishedAgentId)) {
+        return false;
+      }
+
+      const records = await this.requireRegistry().list();
+      const finishedRecord = records.find((record) => record.id === finishedAgentId);
+      if (
+        !finishedRecord ||
+        finishedRecord.workspaceId !== workspaceId ||
+        records.some(
+          (record) =>
+            record.id !== finishedAgentId &&
+            record.workspaceId === workspaceId &&
+            !record.archivedAt,
+        )
+      ) {
+        return false;
+      }
+
+      await options.release();
+      return true;
+    } finally {
+      this.releasingWorkspaces.delete(workspaceId);
+    }
   }
 
   // Children created via the MCP `create_agent` tool carry the parent-agent-id
@@ -4232,6 +4289,49 @@ export class AgentManager {
       return undefined;
     });
     return result;
+  }
+
+  private trackWorkspaceAgentRegistration<T>(
+    workspaceId: string | undefined,
+    register: () => Promise<T>,
+  ): Promise<T> {
+    if (!workspaceId) {
+      return register();
+    }
+    if (this.releasingWorkspaces.has(workspaceId)) {
+      return Promise.reject(new Error(`Workspace ${workspaceId} is being released`));
+    }
+
+    this.workspaceAgentRegistrations.set(
+      workspaceId,
+      (this.workspaceAgentRegistrations.get(workspaceId) ?? 0) + 1,
+    );
+    let registration: Promise<T>;
+    try {
+      registration = register();
+    } catch (error) {
+      this.finishWorkspaceAgentRegistration(workspaceId);
+      throw error;
+    }
+    return registration.finally(() => this.finishWorkspaceAgentRegistration(workspaceId));
+  }
+
+  private finishWorkspaceAgentRegistration(workspaceId: string): void {
+    const remaining = (this.workspaceAgentRegistrations.get(workspaceId) ?? 1) - 1;
+    if (remaining === 0) {
+      this.workspaceAgentRegistrations.delete(workspaceId);
+    } else {
+      this.workspaceAgentRegistrations.set(workspaceId, remaining);
+    }
+  }
+
+  private hasOtherLiveAgentInWorkspace(workspaceId: string, finishedAgentId: string): boolean {
+    for (const agent of this.agents.values()) {
+      if (agent.id !== finishedAgentId && agent.workspaceId === workspaceId) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -552,10 +552,13 @@ class ProviderImportHarness {
   readonly snapshot: ManagedAgent;
   readonly freshImports: unknown[] = [];
   readonly closedAgentIds: string[] = [];
+  readonly archiveRegistrationDepths: number[] = [];
+  readonly registrationWorkspaces: string[] = [];
   timeline: AgentTimelineItem[] = [];
   activeAgent: ManagedAgent | null = null;
   resumeError: Error | null = null;
   resumeAttempts = 0;
+  private registrationDepth = 0;
   private unarchiveWait: Promise<void> | null = null;
   private releaseUnarchive: (() => void) | null = null;
 
@@ -622,6 +625,7 @@ class ProviderImportHarness {
         this.activeAgent = null;
       },
       archiveSnapshot: async (agentId: string, archivedAt: string) => {
+        this.archiveRegistrationDepths.push(this.registrationDepth);
         const record = await this.storage.get(agentId);
         if (!record) {
           throw new Error("Agent not found: " + agentId);
@@ -629,6 +633,22 @@ class ProviderImportHarness {
         const archived = { ...record, archivedAt };
         await this.storage.upsert(archived);
         return archived;
+      },
+      runWorkspaceAgentRegistration: async <T>(
+        workspaceId: string | undefined,
+        register: () => Promise<T>,
+      ) => {
+        if (workspaceId) {
+          this.registrationWorkspaces.push(workspaceId);
+          this.registrationDepth += 1;
+        }
+        try {
+          return await register();
+        } finally {
+          if (workspaceId) {
+            this.registrationDepth -= 1;
+          }
+        }
       },
     } satisfies ImportSessionAgentManager;
   }
@@ -803,6 +823,8 @@ test("importProviderSession restores storage and closes a partial runtime when l
   expect(await harness.storage.get(harness.snapshot.id)).toEqual(archived);
   expect(harness.activeAgent).toBeNull();
   expect(harness.closedAgentIds).toEqual([harness.snapshot.id]);
+  expect(harness.registrationWorkspaces).toEqual(["ws-archived", "ws-restored"]);
+  expect(harness.archiveRegistrationDepths).toEqual([2]);
 });
 
 test("importProviderSession serializes legacy and native aliases for one archived session", async () => {

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -33,6 +33,7 @@ export type ImportSessionAgentManager = AgentLoaderManager &
     | "getTimeline"
     | "importProviderSession"
     | "notifyAgentState"
+    | "runWorkspaceAgentRegistration"
     | "unarchiveSnapshot"
   >;
 
@@ -200,6 +201,7 @@ async function importProviderSessionNow(
   }
   const archivedRecord = matchingRecords.find((record) => record.archivedAt);
   if (archivedRecord?.persistence && archivedRecord.archivedAt) {
+    const originalArchivedAt = archivedRecord.archivedAt;
     if (!createRealpathAwarePathMatcher(cwd)(archivedRecord.cwd)) {
       throw new Error(`Provider session cwd does not match import cwd: ${providerHandleId}`);
     }
@@ -211,24 +213,28 @@ async function importProviderSessionNow(
     ) {
       labelPatch[PARENT_AGENT_ID_LABEL] = requestedParentAgentId;
     }
-    await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
-      workspaceId,
-      labels: Object.keys(labelPatch).length > 0 ? labelPatch : undefined,
-    });
-    try {
-      const snapshot = await ensureAgentLoaded(archivedRecord.id, {
-        agentManager: input.agentManager,
-        agentStorage: input.agentStorage,
-        logger: input.logger,
-      });
-      return {
-        snapshot,
-        timelineSize: input.agentManager.getTimeline(snapshot.id).length,
-      };
-    } catch (error) {
-      await rollbackArchivedImport(input, archivedRecord, archivedRecord.archivedAt);
-      throw error;
-    }
+    return input.agentManager.runWorkspaceAgentRegistration(archivedRecord.workspaceId, () =>
+      input.agentManager.runWorkspaceAgentRegistration(workspaceId, async () => {
+        await unarchiveAgentState(input.agentStorage, input.agentManager, archivedRecord.id, {
+          workspaceId,
+          labels: Object.keys(labelPatch).length > 0 ? labelPatch : undefined,
+        });
+        try {
+          const snapshot = await ensureAgentLoaded(archivedRecord.id, {
+            agentManager: input.agentManager,
+            agentStorage: input.agentStorage,
+            logger: input.logger,
+          });
+          return {
+            snapshot,
+            timelineSize: input.agentManager.getTimeline(snapshot.id).length,
+          };
+        } catch (error) {
+          await rollbackArchivedImport(input, archivedRecord, originalArchivedAt);
+          throw error;
+        }
+      }),
+    );
   }
 
   const snapshot = await input.agentManager.importProviderSession({

--- a/packages/server/src/server/hub/daemon-executions.test.ts
+++ b/packages/server/src/server/hub/daemon-executions.test.ts
@@ -27,6 +27,38 @@ test("sequential replay after reconstruction keeps one durable owned agent", asy
   expect(reconstructed.durableAgentCount).toBe(1);
 });
 
+test("concurrent creation-count waiters observe three sequential provider creations", async () => {
+  const hub = await launchRelationship();
+  hub.beginOwnedCreate("creation-broadcast-1", "creation-broadcast-execution-1");
+  const first = await hub.ownedCreateResult("creation-broadcast-1");
+  expect(first).toMatchObject({
+    type: "hub.execution.agent.create.response",
+    payload: { success: true, executionId: "creation-broadcast-execution-1" },
+  });
+
+  // Subscribe the higher threshold first. With one shared resettable deferred,
+  // its continuation could install a new signal that the lower threshold then
+  // replaced, leaving the first waiter orphaned after the third creation.
+  const thirdCreation = hub.agentCreationAttempts(3);
+  const secondCreation = hub.agentCreationAttempts(2);
+
+  hub.beginOwnedCreate("creation-broadcast-2", "creation-broadcast-execution-2");
+  await secondCreation;
+  const second = await hub.ownedCreateResult("creation-broadcast-2");
+  expect(second).toMatchObject({
+    type: "hub.execution.agent.create.response",
+    payload: { success: true, executionId: "creation-broadcast-execution-2" },
+  });
+
+  hub.beginOwnedCreate("creation-broadcast-3", "creation-broadcast-execution-3");
+  await thirdCreation;
+  const third = await hub.ownedCreateResult("creation-broadcast-3");
+  expect(third).toMatchObject({
+    type: "hub.execution.agent.create.response",
+    payload: { success: true, executionId: "creation-broadcast-execution-3" },
+  });
+});
+
 test("Hub MCP configuration reaches the provider alongside Paseo MCP without entering snapshots", async () => {
   const hub = await HubRelationshipHarness.startWithAgentMcp();
   await hub.beginConnect().result;

--- a/packages/server/src/server/hub/daemon-executions.test.ts
+++ b/packages/server/src/server/hub/daemon-executions.test.ts
@@ -326,3 +326,34 @@ test("failed create never archives a reused worktree", async () => {
   });
   expect(await hub.worktreeState(worktreeCwd!)).toEqual({ exists: true, listed: true });
 });
+
+test("finishing an execution preserves a workspace being acquired by a rival", async () => {
+  const hub = await launchRelationship();
+  hub.beginOwnedCreate("first-create", "first-execution", {
+    worktree: { mode: "branch-off", newBranch: "shared-finish-worktree" },
+  });
+  const first = await hub.ownedCreateResult("first-create");
+  const worktreeCwd = first.payload.agent?.cwd;
+  const workspaceId = first.payload.agent?.workspaceId;
+  expect(worktreeCwd).toEqual(expect.any(String));
+  expect(workspaceId).toEqual(expect.any(String));
+
+  const priorProviderCreations = hub.providerCreations();
+  hub.holdAgentCreationAtCwd(worktreeCwd!);
+  const rivalCreation = hub.createAgentInWorkspace(workspaceId!, worktreeCwd!);
+
+  let archiveResult;
+  try {
+    await hub.agentCreationAtCwd(worktreeCwd!, priorProviderCreations);
+    archiveResult = await hub.archiveExecution("first-execution");
+  } finally {
+    hub.finishAgentCreation();
+  }
+  const rival = await rivalCreation;
+
+  expect(archiveResult).toMatchObject({ success: true, executionId: "first-execution" });
+  expect(rival.workspaceId).toBe(workspaceId);
+  expect(await hub.ownedAgentArchivedAt(first.payload.agentId!)).not.toBeNull();
+  expect(await hub.agentRemainsAvailable(rival.id)).toBe(true);
+  expect(await hub.worktreeState(worktreeCwd!)).toEqual({ exists: true, listed: true });
+});

--- a/packages/server/src/server/hub/daemon-executions.test.ts
+++ b/packages/server/src/server/hub/daemon-executions.test.ts
@@ -343,11 +343,17 @@ test("finishing an execution preserves a workspace being acquired by a rival", a
   const rivalCreation = hub.createAgentInWorkspace(workspaceId!, worktreeCwd!);
 
   let archiveResult;
+  let creationReleased = false;
   try {
     await hub.agentCreationAtCwd(worktreeCwd!, priorProviderCreations);
-    archiveResult = await hub.archiveExecution("first-execution");
-  } finally {
+    const archive = hub.archiveExecution("first-execution");
     hub.finishAgentCreation();
+    creationReleased = true;
+    archiveResult = await archive;
+  } finally {
+    if (!creationReleased) {
+      hub.finishAgentCreation();
+    }
   }
   const rival = await rivalCreation;
 
@@ -356,4 +362,41 @@ test("finishing an execution preserves a workspace being acquired by a rival", a
   expect(await hub.ownedAgentArchivedAt(first.payload.agentId!)).not.toBeNull();
   expect(await hub.agentRemainsAvailable(rival.id)).toBe(true);
   expect(await hub.worktreeState(worktreeCwd!)).toEqual({ exists: true, listed: true });
+});
+
+test("finishing an execution releases its workspace after a rival registration fails", async () => {
+  const hub = await launchRelationship();
+  hub.beginOwnedCreate("first-create", "first-execution", {
+    worktree: { mode: "branch-off", newBranch: "failed-rival-finish-worktree" },
+  });
+  const first = await hub.ownedCreateResult("first-create");
+  const worktreeCwd = first.payload.agent?.cwd;
+  const workspaceId = first.payload.agent?.workspaceId;
+  expect(worktreeCwd).toEqual(expect.any(String));
+  expect(workspaceId).toEqual(expect.any(String));
+
+  const priorProviderCreations = hub.providerCreations();
+  hub.holdAgentCreationAtCwd(worktreeCwd!);
+  hub.failNextProviderCreation();
+  const rivalCreation = hub.createAgentInWorkspace(workspaceId!, worktreeCwd!);
+  let archiveResult;
+  let creationReleased = false;
+  try {
+    await hub.agentCreationAtCwd(worktreeCwd!, priorProviderCreations);
+    const archive = hub.archiveExecution("first-execution");
+    hub.finishAgentCreation();
+    creationReleased = true;
+    [archiveResult] = await Promise.all([
+      archive,
+      expect(rivalCreation).rejects.toThrow("Requested provider creation failure"),
+    ]);
+  } finally {
+    if (!creationReleased) {
+      hub.finishAgentCreation();
+    }
+  }
+
+  expect(archiveResult).toMatchObject({ success: true, executionId: "first-execution" });
+  expect(await hub.ownedAgentArchivedAt(first.payload.agentId!)).not.toBeNull();
+  expect(await hub.worktreeState(worktreeCwd!)).toEqual({ exists: false, listed: false });
 });

--- a/packages/server/src/server/hub/daemon-executions.ts
+++ b/packages/server/src/server/hub/daemon-executions.ts
@@ -269,7 +269,18 @@ export class DaemonExecutions implements HubExecutionAgents {
 
     const workspaceId = requireExecutionWorkspaceId(record);
     this.requireAuthority(authorityGeneration, "execution control");
-    await this.options.archiveWorkspace(workspaceId, input.requestId);
+    const released = await this.agentManager.releaseWorkspaceIfUnowned({
+      workspaceId,
+      finishedAgentId: record.id,
+      release: async () => {
+        this.requireAuthority(authorityGeneration, "execution control");
+        await this.options.archiveWorkspace(workspaceId, input.requestId);
+      },
+    });
+    if (!released && this.agentManager.getAgent(record.id)) {
+      this.requireAuthority(authorityGeneration, "execution control");
+      await this.agentManager.archiveAgent(record.id);
+    }
   }
 
   private resolveRecord(record: StoredAgentRecord): OwnedAgentSnapshot {

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -771,11 +771,9 @@ export class HubRelationshipHarness {
   }
 
   createAgentInWorkspace(workspaceId: string, cwd: string) {
-    return this.daemon!.agentManager.createAgent(
-      { provider: "codex", cwd },
-      undefined,
-      { workspaceId },
-    );
+    return this.daemon!.agentManager.createAgent({ provider: "codex", cwd }, undefined, {
+      workspaceId,
+    });
   }
 
   async ownedCreateResult(requestId: string): Promise<SessionOutboundMessage> {

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -198,6 +198,7 @@ class ControlledAgentClient implements AgentClient {
   readonly provider;
   readonly capabilities;
   private gate: Deferred<void> | null = null;
+  private heldCreationCwd: string | null = null;
   private creationObserved = deferred<void>();
   creations = 0;
   resumes = 0;
@@ -211,8 +212,9 @@ class ControlledAgentClient implements AgentClient {
     this.capabilities = client.capabilities;
   }
 
-  holdCreation(): void {
+  holdCreation(cwd?: string): void {
     this.gate = deferred<void>();
+    this.heldCreationCwd = cwd ?? null;
   }
 
   async creationAt(count: number): Promise<void> {
@@ -222,10 +224,18 @@ class ControlledAgentClient implements AgentClient {
     }
   }
 
+  async creationAtCwd(cwd: string, after: number): Promise<void> {
+    while (!this.createdConfigs.slice(after).some((config) => config.cwd === cwd)) {
+      await this.creationObserved.promise;
+      this.creationObserved = deferred<void>();
+    }
+  }
+
   finishCreation(): void {
     if (!this.gate) throw new Error("Agent creation is not held");
     this.gate.resolve();
     this.gate = null;
+    this.heldCreationCwd = null;
   }
 
   async createSession(
@@ -239,7 +249,9 @@ class ControlledAgentClient implements AgentClient {
     this.creations++;
     this.createdConfigs.push({ ...config });
     this.creationObserved.resolve();
-    await this.gate?.promise;
+    if (this.gate && (!this.heldCreationCwd || this.heldCreationCwd === config.cwd)) {
+      await this.gate.promise;
+    }
     return this.client.createSession(config, launchContext, options);
   }
 
@@ -654,6 +666,10 @@ export class HubRelationshipHarness {
     this.codex.holdCreation();
   }
 
+  holdAgentCreationAtCwd(cwd: string): void {
+    this.codex.holdCreation(cwd);
+  }
+
   beginOwnedCreate(
     requestId: string,
     executionId = "execution-race",
@@ -667,6 +683,7 @@ export class HubRelationshipHarness {
       thinkingOptionId?: string;
       featureValues?: Record<string, unknown>;
       mcpServers?: AgentSessionConfig["mcpServers"];
+      cwd?: string;
       providerOptions?: AgentSessionConfig["providerOptions"];
       toolPolicy?: AgentSessionConfig["toolPolicy"];
     } = {},
@@ -687,8 +704,20 @@ export class HubRelationshipHarness {
     await this.codex.creationAt(count);
   }
 
+  async agentCreationAtCwd(cwd: string, after: number): Promise<void> {
+    await this.codex.creationAtCwd(cwd, after);
+  }
+
   finishAgentCreation(): void {
     this.codex.finishCreation();
+  }
+
+  createAgentInWorkspace(workspaceId: string, cwd: string) {
+    return this.daemon!.agentManager.createAgent(
+      { provider: "codex", cwd },
+      undefined,
+      { workspaceId },
+    );
   }
 
   async ownedCreateResult(requestId: string): Promise<SessionOutboundMessage> {

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -228,7 +228,7 @@ class ControlledAgentClient implements AgentClient {
   readonly capabilities;
   private gate: Deferred<void> | null = null;
   private heldCreationCwd: string | null = null;
-  private creationObserved = deferred<void>();
+  private creationChanged = deferred<void>();
   private creationFailure: Error | null = null;
   creations = 0;
   resumes = 0;
@@ -248,17 +248,17 @@ class ControlledAgentClient implements AgentClient {
   }
 
   async creationAt(count: number): Promise<void> {
-    while (this.creations < count) {
-      await waitForHarnessSignal(this.creationObserved.promise, `provider creation ${count}`);
-      this.creationObserved = deferred<void>();
-    }
+    await this.waitForCreationCondition(
+      () => this.creations >= count,
+      `provider creation ${count}`,
+    );
   }
 
   async creationAtCwd(cwd: string, after: number): Promise<void> {
-    while (!this.createdConfigs.slice(after).some((config) => config.cwd === cwd)) {
-      await waitForHarnessSignal(this.creationObserved.promise, `provider creation at ${cwd}`);
-      this.creationObserved = deferred<void>();
-    }
+    await this.waitForCreationCondition(
+      () => this.createdConfigs.slice(after).some((config) => config.cwd === cwd),
+      `provider creation at ${cwd}`,
+    );
   }
 
   finishCreation(): void {
@@ -282,7 +282,9 @@ class ControlledAgentClient implements AgentClient {
     }
     this.creations++;
     this.createdConfigs.push({ ...config });
-    this.creationObserved.resolve();
+    const creationChanged = this.creationChanged;
+    this.creationChanged = deferred<void>();
+    creationChanged.resolve();
     if (this.gate && (!this.heldCreationCwd || this.heldCreationCwd === config.cwd)) {
       await this.gate.promise;
     }
@@ -292,6 +294,19 @@ class ControlledAgentClient implements AgentClient {
       throw error;
     }
     return this.client.createSession(config, launchContext, options);
+  }
+
+  private async waitForCreationCondition(
+    condition: () => boolean,
+    description: string,
+  ): Promise<void> {
+    while (!condition()) {
+      const changed = this.creationChanged.promise;
+      if (condition()) {
+        continue;
+      }
+      await waitForHarnessSignal(changed, description);
+    }
   }
 
   resumeSession(

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -62,6 +62,24 @@ const execFileAsync = promisify(execFile);
 const HUB_ORIGIN = "https://hub.test";
 const SOCKET_URL = "wss://hub.test/daemon";
 const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "../../../../../..");
+const HARNESS_WAIT_TIMEOUT_MS = 10_000;
+
+async function waitForHarnessSignal(signal: Promise<void>, description: string): Promise<void> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      signal,
+      new Promise<void>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Timed out waiting for ${description}`)),
+          HARNESS_WAIT_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 interface PersistedRelationship {
   version: number;
@@ -140,13 +158,12 @@ class MemoryHubSocket extends EventEmitter implements WebSocketLike, HubSocketCo
   sent: SessionOutboundMessage[] = [];
   closed = false;
   closeCode: number | null = null;
-  private messageObserved = deferred<void>();
 
   send(data: string | Uint8Array | ArrayBuffer): void {
     if (typeof data !== "string") return;
     const frame = JSON.parse(data) as { type: "session"; message: SessionOutboundMessage };
     this.sent.push(frame.message);
-    this.messageObserved.resolve();
+    this.emit("sent");
   }
 
   close(code = 1000): void {
@@ -177,8 +194,7 @@ class MemoryHubSocket extends EventEmitter implements WebSocketLike, HubSocketCo
           candidate.payload.requestId === requestId,
       );
       if (message) return message;
-      await this.messageObserved.promise;
-      this.messageObserved = deferred<void>();
+      await this.waitForSentMessage(requestId);
     }
   }
 
@@ -188,9 +204,22 @@ class MemoryHubSocket extends EventEmitter implements WebSocketLike, HubSocketCo
     while (true) {
       const message = this.sent.find(predicate);
       if (message) return message;
-      await this.messageObserved.promise;
-      this.messageObserved = deferred<void>();
+      await this.waitForSentMessage("matching predicate");
     }
+  }
+
+  private waitForSentMessage(description: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const observed = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        this.off("sent", observed);
+        reject(new Error(`Timed out waiting for Hub message: ${description}`));
+      }, HARNESS_WAIT_TIMEOUT_MS);
+      this.once("sent", observed);
+    });
   }
 }
 
@@ -200,6 +229,7 @@ class ControlledAgentClient implements AgentClient {
   private gate: Deferred<void> | null = null;
   private heldCreationCwd: string | null = null;
   private creationObserved = deferred<void>();
+  private creationFailure: Error | null = null;
   creations = 0;
   resumes = 0;
   createdConfigs: AgentSessionConfig[] = [];
@@ -219,14 +249,14 @@ class ControlledAgentClient implements AgentClient {
 
   async creationAt(count: number): Promise<void> {
     while (this.creations < count) {
-      await this.creationObserved.promise;
+      await waitForHarnessSignal(this.creationObserved.promise, `provider creation ${count}`);
       this.creationObserved = deferred<void>();
     }
   }
 
   async creationAtCwd(cwd: string, after: number): Promise<void> {
     while (!this.createdConfigs.slice(after).some((config) => config.cwd === cwd)) {
-      await this.creationObserved.promise;
+      await waitForHarnessSignal(this.creationObserved.promise, `provider creation at ${cwd}`);
       this.creationObserved = deferred<void>();
     }
   }
@@ -236,6 +266,10 @@ class ControlledAgentClient implements AgentClient {
     this.gate.resolve();
     this.gate = null;
     this.heldCreationCwd = null;
+  }
+
+  failNextCreation(error: Error): void {
+    this.creationFailure = error;
   }
 
   async createSession(
@@ -251,6 +285,11 @@ class ControlledAgentClient implements AgentClient {
     this.creationObserved.resolve();
     if (this.gate && (!this.heldCreationCwd || this.heldCreationCwd === config.cwd)) {
       await this.gate.promise;
+    }
+    if (this.creationFailure) {
+      const error = this.creationFailure;
+      this.creationFailure = null;
+      throw error;
     }
     return this.client.createSession(config, launchContext, options);
   }
@@ -614,6 +653,10 @@ export class HubRelationshipHarness {
 
   failNextProviderSessionClose(): void {
     this.failNextSessionClose = true;
+  }
+
+  failNextProviderCreation(): void {
+    this.codex.failNextCreation(new Error("Requested provider creation failure"));
   }
 
   async socketDialed(): Promise<void> {
@@ -1347,8 +1390,13 @@ export class HubRelationshipHarness {
   }
 
   private async stopDaemon(): Promise<void> {
-    await this.daemon?.stop();
-    this.daemon = null;
+    const daemon = this.daemon;
+    if (!daemon) return;
+    try {
+      await waitForHarnessSignal(daemon.stop(), "Hub relationship harness daemon shutdown");
+    } finally {
+      this.daemon = null;
+    }
   }
 
   private runCli(args: string[]): Promise<Record<string, unknown>> {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2564,11 +2564,16 @@ export class Session {
     });
   }
 
-  private async unarchiveAgentByHandle(handle: AgentPersistenceHandle): Promise<{
-    record: StoredAgentRecord;
-    didUnarchive: boolean;
-    originalArchivedAt: string | null;
-  } | null> {
+  private async withUnarchivedAgentByHandle<T>(
+    handle: AgentPersistenceHandle,
+    operation: (
+      matched: {
+        record: StoredAgentRecord;
+        didUnarchive: boolean;
+        originalArchivedAt: string | null;
+      } | null,
+    ) => Promise<T>,
+  ): Promise<T> {
     const records = await this.agentStorage.list();
     const matched = records
       .filter(
@@ -2589,18 +2594,20 @@ export class Session {
         return Date.parse(candidate.createdAt) > Date.parse(latest.createdAt) ? candidate : latest;
       }, null);
     if (!matched) {
-      return null;
+      return operation(null);
     }
-    const didUnarchive = await unarchiveAgentState(
-      this.agentStorage,
-      this.agentManager,
-      matched.id,
-    );
-    return {
-      record: matched,
-      didUnarchive,
-      originalArchivedAt: matched.archivedAt ?? null,
-    };
+    return this.agentManager.runWorkspaceAgentRegistration(matched.workspaceId, async () => {
+      const didUnarchive = await unarchiveAgentState(
+        this.agentStorage,
+        this.agentManager,
+        matched.id,
+      );
+      return operation({
+        record: matched,
+        didUnarchive,
+        originalArchivedAt: matched.archivedAt ?? null,
+      });
+    });
   }
 
   private async handleUpdateAgentRequest(
@@ -3359,20 +3366,22 @@ export class Session {
       `Resuming agent ${handle.sessionId} (${handle.provider})`,
     );
     try {
-      const matched = await this.unarchiveAgentByHandle(handle);
-      const effectiveOverrides = matched
-        ? { ...buildConfigOverrides(matched.record), ...overrides }
-        : overrides;
-      let snapshot: ManagedAgent;
-      try {
-        snapshot = await this.agentManager.resumeAgentFromPersistence(handle, effectiveOverrides);
-      } catch (error) {
-        if (matched?.didUnarchive && matched.originalArchivedAt) {
-          await this.agentManager.archiveSnapshot(matched.record.id, matched.originalArchivedAt);
+      const snapshot = await this.withUnarchivedAgentByHandle(handle, async (matched) => {
+        const effectiveOverrides = matched
+          ? { ...buildConfigOverrides(matched.record), ...overrides }
+          : overrides;
+        let resumed: ManagedAgent;
+        try {
+          resumed = await this.agentManager.resumeAgentFromPersistence(handle, effectiveOverrides);
+        } catch (error) {
+          if (matched?.didUnarchive && matched.originalArchivedAt) {
+            await this.agentManager.archiveSnapshot(matched.record.id, matched.originalArchivedAt);
+          }
+          throw error;
         }
-        throw error;
-      }
-      await unarchiveAgentState(this.agentStorage, this.agentManager, snapshot.id);
+        await unarchiveAgentState(this.agentStorage, this.agentManager, resumed.id);
+        return resumed;
+      });
       await this.agentManager.hydrateTimelineFromProvider(snapshot.id);
       await this.agentUpdates.forwardLiveAgent(snapshot);
       const timelineSize = this.agentManager.getTimeline(snapshot.id).length;


### PR DESCRIPTION
## Summary

- fence workspace release against agent creation, persistence resume, import, reload, and archived-session restoration
- let registrations already in flight settle before deciding whether a finished owner may release its workspace
- reject registrations that begin after release owns the fence, while allowing nested work in an already-registered operation
- release a Paseo-owned worktree when a rival registration fails, while preserving it when that rival becomes a live owner
- replace the Hub test harness's shared resettable notification with per-waiter signals so concurrent response waiters cannot lose a wakeup

This is the current-`main`, true-linear replacement for #2834. The original PR correctly introduced the ownership fence, but a transient registration refusal could leak a worktree when the rival later failed. Its Hub regression harness could also hang before reaching the production assertions because multiple waiters shared and reset one deferred notification.

## Verification

- mechanically replayed onto `777fe968f5bab50f63f25a61188482f6a15789fc`; both commits are patch-identical by `git range-diff`
- `finishing an execution preserves a workspace being acquired by a rival` passed alone with a hard process bound
- `finishing an execution releases its workspace after a rival registration fails` passed alone with a hard process bound
- `packages/server/src/server/agent/agent-manager.test.ts`: 155 passed
- `packages/server/src/server/agent/import-sessions.test.ts`: 15 passed
- archived resume rollback E2E: 1 passed, 35 skipped
- `npm run typecheck --workspace=@getpaseo/server`
- `npm run build --workspace=@getpaseo/server`
- targeted lint and format checks for all seven changed files
- pre-replay commit hook: full monorepo typecheck, lint, and format checks passed

No daemon, Desktop app, or live agent was restarted or deployed for this change.
