### PR TITLE
Add direct model and thinking effort shortcuts

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -426,7 +426,18 @@ interface AppContainerProps {
 const THEME_CYCLE_ORDER: ThemeName[] = ["dark", "zinc", "midnight", "claude", "ghostty", "light"];
 const WINDOW_SIDEBAR_TOGGLE_HORIZONTAL_PADDING = 12;
 
-function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppContainerProps) {
+function AppContainer(props: AppContainerProps) {
+  return (
+    <CommandCenterProvider>
+      <AppContainerContent {...props} />
+    </CommandCenterProvider>
+  );
+}
+
+function AppContainerContent({
+  children,
+  chromeEnabled: chromeEnabledOverride,
+}: AppContainerProps) {
   const daemons = useHosts();
   const { settings, updateSettings } = useAppSettings();
   const toggleMobileAgentList = usePanelStore((state) => state.toggleMobileAgentList);
@@ -583,7 +594,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
     surface
   );
 
-  return <CommandCenterProvider>{content}</CommandCenterProvider>;
+  return content;
 }
 
 function SidebarChrome({

--- a/packages/app/src/command-center/agent-control-contributions.test.ts
+++ b/packages/app/src/command-center/agent-control-contributions.test.ts
@@ -184,11 +184,20 @@ describe("Command Center agent-control contributions", () => {
     expect(
       contributions.map((contribution) => ({
         id: contribution.id,
+        shortcutId: contribution.shortcutId,
         selected: selected(contribution),
       })),
     ).toEqual([
-      { id: "models:claude:shared", selected: false },
-      { id: "models:codex:shared", selected: true },
+      {
+        id: "models:claude:shared",
+        shortcutId: "models:claude:shared",
+        selected: false,
+      },
+      {
+        id: "models:codex:shared",
+        shortcutId: "models:codex:shared",
+        selected: true,
+      },
     ]);
     expect(contributions[0].presentation).toMatchObject({
       path: ["Model", "Claude", "Claude model"],
@@ -219,6 +228,11 @@ describe("Command Center agent-control contributions", () => {
       "thinking:high",
       "thinking:xhigh",
     ]);
+    expect(contributions.map((contribution) => contribution.shortcutId)).toEqual([
+      "thinking:low",
+      "thinking:high",
+      "thinking:xhigh",
+    ]);
     expect(contributions.map(selected)).toEqual([false, true, false]);
     for (const contribution of contributions) contribution.run();
     expect(selections).toEqual(["low", "xhigh"]);
@@ -232,6 +246,32 @@ describe("Command Center agent-control contributions", () => {
       }),
     );
     expect(singleOption.filter((contribution) => contribution.group === "thinking")).toEqual([]);
+  });
+
+  it("uses one semantic top-effort identity for ultra and ultracode", () => {
+    const selections: string[] = [];
+
+    for (const optionId of ["ultra", "ultracode"]) {
+      const contribution = buildAgentControlContributions(
+        makeSource({
+          thinking: {
+            options: [
+              { id: "high", label: "High" },
+              { id: optionId, label: "Top" },
+            ],
+            selectedId: "high",
+            select: (id) => {
+              selections.push(id);
+            },
+          },
+        }),
+      ).find((candidate) => candidate.id === `thinking:${optionId}`);
+
+      expect(contribution?.shortcutId).toBe("thinking:top");
+      contribution?.run();
+    }
+
+    expect(selections).toEqual(["ultra", "ultracode"]);
   });
 
   it("formats access modes, excludes planning modes, and marks the current mode", () => {

--- a/packages/app/src/command-center/agent-control-contributions.ts
+++ b/packages/app/src/command-center/agent-control-contributions.ts
@@ -66,6 +66,7 @@ export interface AgentControlContributionIcons {
 
 interface CommandCenterChoice {
   id: string;
+  shortcutId?: string;
   path: readonly string[];
   keywords?: readonly string[];
   icon?: CommandCenterIcon;
@@ -119,6 +120,7 @@ function buildContributions(
     for (const [rank, choice] of group.choices.entries()) {
       contributions.push({
         id: `${group.id}:${choice.id}`,
+        ...(choice.shortcutId ? { shortcutId: choice.shortcutId } : {}),
         group: group.id,
         groupRank: group.rank,
         rank,
@@ -151,6 +153,7 @@ function buildModelGroup(source: AgentControlContributionSource): CommandCenterC
       const modelId = model.modelId;
       choices.push({
         id: `${provider.id}:${modelId}`,
+        shortcutId: `models:${provider.id}:${modelId}`,
         path: [provider.label, model.modelLabel],
         keywords: [modelId],
         icon,
@@ -177,6 +180,7 @@ function buildThinkingGroup(source: AgentControlContributionSource): CommandCent
       ? source.thinking.options.map(
           (option): CommandCenterChoice => ({
             id: option.id,
+            shortcutId: `thinking:${normalizeThinkingShortcutTargetId(option.id)}`,
             path: [formatThinkingOptionLabel(option)],
             icon: source.icons.thinking,
             selected: option.id === source.thinking.selectedId,
@@ -192,6 +196,10 @@ function buildThinkingGroup(source: AgentControlContributionSource): CommandCent
     keywords: [source.labels.thinkingKeywords],
     choices,
   };
+}
+
+export function normalizeThinkingShortcutTargetId(optionId: string): string {
+  return optionId === "ultra" || optionId === "ultracode" ? "top" : optionId;
 }
 
 function buildModeGroup(source: AgentControlContributionSource): CommandCenterChoiceGroup {

--- a/packages/app/src/command-center/contributions.ts
+++ b/packages/app/src/command-center/contributions.ts
@@ -9,6 +9,7 @@ export type CommandCenterIcon = ComponentType<CommandCenterIconProps>;
 
 interface CommandCenterContributionBase {
   id: string;
+  shortcutId?: string;
   group: string;
   groupRank: number;
   rank: number;
@@ -40,6 +41,7 @@ export type CommandCenterContribution =
 
 export interface CommandCenterContributionSnapshot {
   contributions: readonly CommandCenterContribution[];
+  shortcutCatalog: readonly CommandCenterContribution[];
 }
 
 export interface CommandCenterRegistrationOwner {
@@ -50,4 +52,5 @@ export interface CommandCenterRegistrationOwner {
 export interface CommandCenterRegistration {
   owner: CommandCenterRegistrationOwner;
   contributions: readonly CommandCenterContribution[];
+  enabled?: boolean;
 }

--- a/packages/app/src/command-center/provider.tsx
+++ b/packages/app/src/command-center/provider.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   createContext,
   useContext,
   useEffect,
@@ -28,6 +29,11 @@ function useCommandCenterRegistry(): CommandCenterRegistry {
   return registry;
 }
 
+export function useCommandCenterShortcutRunner(): (shortcutId: string) => boolean {
+  const registry = useCommandCenterRegistry();
+  return useCallback((shortcutId: string) => registry.runShortcut(shortcutId), [registry]);
+}
+
 export function useCommandCenterContributions() {
   const registry = useCommandCenterRegistry();
   return useSyncExternalStore(registry.subscribe, registry.getSnapshot, registry.getSnapshot);
@@ -46,11 +52,10 @@ export function useCommandCenterActions(input: {
   const owner = ownerRef.current;
 
   useEffect(() => {
-    if (!input.enabled) {
-      registry.remove(owner);
-      return;
-    }
-    registry.replace({ owner, contributions: input.actions });
-    return () => registry.remove(owner);
+    registry.replace({ owner, contributions: input.actions, enabled: input.enabled });
   }, [input.actions, input.enabled, owner, registry]);
+
+  useEffect(() => {
+    return () => registry.remove(owner);
+  }, [owner, registry]);
 }

--- a/packages/app/src/command-center/registry.test.ts
+++ b/packages/app/src/command-center/registry.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from "vitest";
 import type { CommandCenterContribution, CommandCenterRegistrationOwner } from "./contributions";
-import { createCommandCenterRegistry } from "./registry";
+import { createCommandCenterRegistry, getResolvableShortcutIds } from "./registry";
 
-function action(id: string, rank: number): CommandCenterContribution {
+function action(
+  id: string,
+  rank: number,
+  shortcutId?: string,
+  run: () => void = () => undefined,
+): CommandCenterContribution {
   return {
     id,
+    ...(shortcutId ? { shortcutId } : {}),
     group: "actions",
     groupRank: 0,
     rank,
     keywords: [],
     visibility: "always",
-    run: () => undefined,
+    run,
     presentation: { kind: "action", title: id },
   };
 }
@@ -69,5 +75,67 @@ describe("Command Center registry", () => {
         contributions: [action("same", 0), action("same", 1)],
       }),
     ).toThrow("Duplicate Command Center contribution id: duplicate:same");
+  });
+
+  it("runs one active contribution by stable identity", () => {
+    const registry = createCommandCenterRegistry();
+    const calls: string[] = [];
+    registry.replace({
+      owner: owner("agent:host:first"),
+      contributions: [action("dynamic-model", 0, "models:codex:gpt", () => calls.push("gpt"))],
+    });
+
+    expect(registry.getSnapshot().contributions[0].id).toBe("agent:host:first:dynamic-model");
+    expect(registry.runShortcut("models:codex:gpt")).toBe(true);
+    expect(calls).toEqual(["gpt"]);
+  });
+
+  it("does not run unavailable or ambiguous targets", () => {
+    const registry = createCommandCenterRegistry();
+    const calls: string[] = [];
+    registry.replace({
+      owner: owner("agent:first"),
+      contributions: [action("high", 0, "thinking:high", () => calls.push("first"))],
+    });
+    registry.replace({
+      owner: owner("agent:second"),
+      contributions: [action("high", 0, "thinking:high", () => calls.push("second"))],
+    });
+
+    expect(getResolvableShortcutIds(registry.getSnapshot().contributions)).toEqual([]);
+    expect(registry.runShortcut("thinking:high")).toBe(false);
+    expect(registry.runShortcut("thinking:low")).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  it("catalogs inactive mounted sources without making them executable", () => {
+    const registry = createCommandCenterRegistry();
+    const source = owner("agent:first");
+    registry.replace({
+      owner: source,
+      contributions: [action("high", 0, "thinking:high")],
+      enabled: false,
+    });
+
+    expect(registry.getSnapshot().contributions).toEqual([]);
+    expect(registry.getSnapshot().shortcutCatalog.map((item) => item.shortcutId)).toEqual([
+      "thinking:high",
+    ]);
+    expect(registry.runShortcut("thinking:high")).toBe(false);
+
+    registry.remove(source);
+    expect(registry.getSnapshot().shortcutCatalog).toEqual([]);
+  });
+
+  it("updates active resolution when a mounted source changes focus", () => {
+    const registry = createCommandCenterRegistry();
+    const source = owner("agent:first");
+    const contributions = [action("high", 0, "thinking:high")];
+    registry.replace({ owner: source, contributions, enabled: false });
+    registry.replace({ owner: source, contributions, enabled: true });
+
+    expect(getResolvableShortcutIds(registry.getSnapshot().contributions)).toEqual([
+      "thinking:high",
+    ]);
   });
 });

--- a/packages/app/src/command-center/registry.ts
+++ b/packages/app/src/command-center/registry.ts
@@ -10,14 +10,19 @@ export interface CommandCenterRegistry {
   subscribe(listener: () => void): () => void;
   replace(registration: CommandCenterRegistration): void;
   remove(owner: CommandCenterRegistrationOwner): void;
+  runShortcut(shortcutId: string): boolean;
 }
 
 interface ActiveRegistration {
   owner: CommandCenterRegistrationOwner;
   contributions: readonly CommandCenterContribution[];
+  enabled?: boolean;
 }
 
-const EMPTY_SNAPSHOT: CommandCenterContributionSnapshot = { contributions: [] };
+const EMPTY_SNAPSHOT: CommandCenterContributionSnapshot = {
+  contributions: [],
+  shortcutCatalog: [],
+};
 
 function contributionId(sourceId: string, id: string): string {
   return `${sourceId}:${id}`;
@@ -41,6 +46,17 @@ function sameContributions(
   return left.length === right.length && left.every((item, index) => item === right[index]);
 }
 
+export function getResolvableShortcutIds(
+  contributions: readonly CommandCenterContribution[],
+): string[] {
+  const counts = new Map<string, number>();
+  for (const contribution of contributions) {
+    if (!contribution.shortcutId) continue;
+    counts.set(contribution.shortcutId, (counts.get(contribution.shortcutId) ?? 0) + 1);
+  }
+  return [...counts].flatMap(([shortcutId, count]) => (count === 1 ? [shortcutId] : []));
+}
+
 export function createCommandCenterRegistry(): CommandCenterRegistry {
   const registrations = new Map<string, ActiveRegistration>();
   const listeners = new Set<() => void>();
@@ -48,6 +64,7 @@ export function createCommandCenterRegistry(): CommandCenterRegistry {
 
   function publish(): void {
     const contributions: CommandCenterContribution[] = [];
+    const shortcutCatalog: CommandCenterContribution[] = [];
     const ids = new Set<string>();
 
     for (const registration of registrations.values()) {
@@ -57,13 +74,28 @@ export function createCommandCenterRegistry(): CommandCenterRegistry {
           throw new Error(`Duplicate Command Center contribution id: ${id}`);
         }
         ids.add(id);
-        contributions.push({ ...contribution, id });
+        const registeredContribution = { ...contribution, id };
+        if (registration.enabled !== false) {
+          contributions.push(registeredContribution);
+        }
+        if (registeredContribution.shortcutId) {
+          shortcutCatalog.push(registeredContribution);
+        }
       }
     }
     contributions.sort(compareContributions);
+    shortcutCatalog.sort(compareContributions);
 
-    if (sameContributions(snapshot.contributions, contributions)) return;
-    snapshot = contributions.length === 0 ? EMPTY_SNAPSHOT : { contributions };
+    if (
+      sameContributions(snapshot.contributions, contributions) &&
+      sameContributions(snapshot.shortcutCatalog, shortcutCatalog)
+    ) {
+      return;
+    }
+    snapshot =
+      contributions.length === 0 && shortcutCatalog.length === 0
+        ? EMPTY_SNAPSHOT
+        : { contributions, shortcutCatalog };
     for (const listener of listeners) listener();
   }
 
@@ -77,6 +109,7 @@ export function createCommandCenterRegistry(): CommandCenterRegistry {
       const current = registrations.get(registration.owner.sourceId);
       if (
         current?.owner.token === registration.owner.token &&
+        current.enabled === registration.enabled &&
         sameContributions(current.contributions, registration.contributions)
       ) {
         return;
@@ -95,6 +128,14 @@ export function createCommandCenterRegistry(): CommandCenterRegistry {
       if (current?.owner.token !== owner.token) return;
       registrations.delete(owner.sourceId);
       publish();
+    },
+    runShortcut(shortcutId) {
+      const matches = snapshot.contributions.filter(
+        (contribution) => contribution.shortcutId === shortcutId,
+      );
+      if (matches.length !== 1) return false;
+      void matches[0].run();
+      return true;
     },
   };
 }

--- a/packages/app/src/command-center/shortcut-settings.test.ts
+++ b/packages/app/src/command-center/shortcut-settings.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { CommandCenterContribution } from "./contributions";
+import { buildCommandShortcutSettingsRows } from "./shortcut-settings";
+
+function choice(input: {
+  id: string;
+  shortcutId: string;
+  path: readonly [string, ...string[]];
+}): CommandCenterContribution {
+  return {
+    id: input.id,
+    shortcutId: input.shortcutId,
+    group: input.path[0],
+    groupRank: 1,
+    rank: 0,
+    keywords: [],
+    visibility: "query",
+    run: () => undefined,
+    presentation: { kind: "choice", path: input.path, selected: false },
+  };
+}
+
+describe("command shortcut settings", () => {
+  it("lists discovered exact choices with stable persisted override keys", () => {
+    const rows = buildCommandShortcutSettingsRows(
+      [
+        choice({
+          id: "dynamic:models:codex:gpt-5.6-sol",
+          shortcutId: "models:codex:gpt-5.6-sol",
+          path: ["Model", "Codex", "GPT-5.6 Sol"],
+        }),
+        choice({
+          id: "dynamic:thinking:high",
+          shortcutId: "thinking:high",
+          path: ["Thinking", "High"],
+        }),
+      ],
+      { "command-center.shortcut:models:codex:gpt-5.6-sol": "F13" },
+    );
+
+    expect(rows).toEqual([
+      {
+        shortcutId: "models:codex:gpt-5.6-sol",
+        bindingId: "command-center.shortcut:models:codex:gpt-5.6-sol",
+        group: "models",
+        label: "Codex · GPT-5.6 Sol",
+        combo: "F13",
+        available: true,
+      },
+      {
+        shortcutId: "thinking:high",
+        bindingId: "command-center.shortcut:thinking:high",
+        group: "thinking",
+        label: "High",
+        combo: undefined,
+        available: true,
+      },
+    ]);
+  });
+
+  it("collapses duplicate discoveries and gives top effort one semantic label", () => {
+    const rows = buildCommandShortcutSettingsRows(
+      [
+        choice({
+          id: "codex:ultra",
+          shortcutId: "thinking:top",
+          path: ["Thinking", "Ultra"],
+        }),
+        choice({
+          id: "claude:ultracode",
+          shortcutId: "thinking:top",
+          path: ["Thinking", "Ultracode"],
+        }),
+      ],
+      {},
+    );
+
+    expect(rows).toEqual([
+      {
+        shortcutId: "thinking:top",
+        bindingId: "command-center.shortcut:thinking:top",
+        group: "thinking",
+        label: "Top",
+        combo: undefined,
+        available: true,
+      },
+    ]);
+  });
+
+  it("keeps stored unavailable targets visible for reset", () => {
+    const rows = buildCommandShortcutSettingsRows([], {
+      "command-center.shortcut:models:claude:claude-opus-5": "F14",
+      "command-center.shortcut:thinking:top": "F24",
+      "command-center.shortcut:": "F15",
+      "unrelated-binding": "F16",
+    });
+
+    expect(rows).toEqual([
+      {
+        shortcutId: "models:claude:claude-opus-5",
+        bindingId: "command-center.shortcut:models:claude:claude-opus-5",
+        group: "models",
+        label: "claude · claude-opus-5",
+        combo: "F14",
+        available: false,
+      },
+      {
+        shortcutId: "thinking:top",
+        bindingId: "command-center.shortcut:thinking:top",
+        group: "thinking",
+        label: "Top",
+        combo: "F24",
+        available: false,
+      },
+    ]);
+  });
+});

--- a/packages/app/src/command-center/shortcut-settings.ts
+++ b/packages/app/src/command-center/shortcut-settings.ts
@@ -1,0 +1,91 @@
+import {
+  getCommandShortcutBindingId,
+  getCommandShortcutIdFromBindingId,
+} from "@/keyboard/keyboard-shortcuts";
+import type { CommandCenterContribution } from "./contributions";
+
+export type CommandShortcutSettingsGroup = "models" | "thinking";
+
+export interface CommandShortcutSettingsRow {
+  shortcutId: string;
+  bindingId: string;
+  group: CommandShortcutSettingsGroup;
+  label: string;
+  combo: string | undefined;
+  available: boolean;
+}
+
+function getGroup(shortcutId: string): CommandShortcutSettingsGroup | null {
+  if (shortcutId.startsWith("models:") && shortcutId.slice("models:".length).includes(":")) {
+    return "models";
+  }
+  if (shortcutId.startsWith("thinking:") && shortcutId.length > "thinking:".length) {
+    return "thinking";
+  }
+  return null;
+}
+
+function fallbackLabel(shortcutId: string, group: CommandShortcutSettingsGroup): string {
+  const target = shortcutId.slice(group.length + 1);
+  if (group === "thinking") return target === "top" ? "Top" : target;
+  const separator = target.indexOf(":");
+  return `${target.slice(0, separator)} · ${target.slice(separator + 1)}`;
+}
+
+function contributionLabel(contribution: CommandCenterContribution): string | null {
+  if (contribution.presentation.kind !== "choice") return null;
+  return contribution.presentation.path.slice(1).join(" · ");
+}
+
+function resolveLabel(
+  shortcutId: string,
+  group: CommandShortcutSettingsGroup,
+  matches: readonly CommandCenterContribution[],
+): string {
+  if (shortcutId === "thinking:top") return "Top";
+  const labels = new Set(matches.flatMap((match) => contributionLabel(match) ?? []));
+  if (labels.size === 1) return [...labels][0];
+  return fallbackLabel(shortcutId, group);
+}
+
+export function buildCommandShortcutSettingsRows(
+  contributions: readonly CommandCenterContribution[],
+  overrides: Readonly<Record<string, string>>,
+): CommandShortcutSettingsRow[] {
+  const contributionsByShortcutId = new Map<string, CommandCenterContribution[]>();
+  for (const contribution of contributions) {
+    if (!contribution.shortcutId || !getGroup(contribution.shortcutId)) continue;
+    const matches = contributionsByShortcutId.get(contribution.shortcutId) ?? [];
+    matches.push(contribution);
+    contributionsByShortcutId.set(contribution.shortcutId, matches);
+  }
+
+  const shortcutIds = new Set(contributionsByShortcutId.keys());
+  for (const bindingId of Object.keys(overrides)) {
+    const shortcutId = getCommandShortcutIdFromBindingId(bindingId);
+    if (shortcutId && getGroup(shortcutId)) shortcutIds.add(shortcutId);
+  }
+
+  const rows = [...shortcutIds].flatMap((shortcutId): CommandShortcutSettingsRow[] => {
+    const group = getGroup(shortcutId);
+    if (!group) return [];
+    const matches = contributionsByShortcutId.get(shortcutId) ?? [];
+    const bindingId = getCommandShortcutBindingId(shortcutId);
+    return [
+      {
+        shortcutId,
+        bindingId,
+        group,
+        label: resolveLabel(shortcutId, group, matches),
+        combo: overrides[bindingId],
+        available: matches.length > 0,
+      },
+    ];
+  });
+
+  return rows.sort((left, right) => {
+    if (left.group !== right.group) return left.group === "models" ? -1 : 1;
+    const labelDelta = left.label.localeCompare(right.label);
+    return labelDelta !== 0 ? labelDelta : left.shortcutId.localeCompare(right.shortcutId);
+  });
+}

--- a/packages/app/src/desktop/browser/shortcuts.test.ts
+++ b/packages/app/src/desktop/browser/shortcuts.test.ts
@@ -4,9 +4,46 @@ import {
   parseBrowserShortcutInput,
   shouldPublishBrowserShortcutPolicy,
 } from "./shortcuts";
-import { buildEffectiveBindings, resolveKeyboardShortcut } from "../../keyboard/keyboard-shortcuts";
+import {
+  buildCommandShortcutBindings,
+  buildEffectiveBindings,
+  resolveKeyboardShortcut,
+} from "../../keyboard/keyboard-shortcuts";
 
 describe("buildBrowserKeyboardPolicy", () => {
+  it("forwards unmodified F13-F24 direct shortcuts while preserving F1-F12 behavior", () => {
+    const bindings = buildCommandShortcutBindings(["thinking:high", "thinking:top"], {
+      "command-center.shortcut:thinking:high": "F13",
+      "command-center.shortcut:thinking:top": "F24",
+    });
+
+    const prefixes = buildBrowserKeyboardPolicy({
+      bindings,
+      isMac: true,
+      isDesktop: true,
+    }).prefixes;
+
+    expect(prefixes).toEqual([
+      {
+        alt: false,
+        code: "F13",
+        control: false,
+        meta: false,
+        repeat: false,
+        shift: false,
+      },
+      {
+        alt: false,
+        code: "F24",
+        control: false,
+        meta: false,
+        repeat: false,
+        shift: false,
+      },
+    ]);
+    expect(prefixes.some((prefix) => prefix.code === "F12")).toBe(false);
+  });
+
   it("publishes only chord starts while no browser chord is pending", () => {
     const bindings = buildEffectiveBindings({
       "workspace-tab-new-ctrl-t-non-mac": "Ctrl+Y",

--- a/packages/app/src/desktop/browser/shortcuts.ts
+++ b/packages/app/src/desktop/browser/shortcuts.ts
@@ -109,7 +109,8 @@ function prefixFromCombo(
   if (combo.shiftedKey) {
     prefix.shiftedKey = combo.shiftedKey;
   }
-  return prefix.meta || prefix.control || prefix.alt ? prefix : null;
+  const isExtendedFunctionKey = /^F(?:1[3-9]|2[0-4])$/.test(combo.code);
+  return prefix.meta || prefix.control || prefix.alt || isExtendedFunctionKey ? prefix : null;
 }
 
 function isBrowserNativeNavigationPrefix(prefix: BrowserShortcutPrefix, isMac: boolean): boolean {

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -9,6 +9,7 @@ import { keyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher"
 import {
   type ChordState,
   type KeyboardShortcutInput,
+  buildCommandShortcutBindings,
   resolveKeyboardShortcut,
   buildEffectiveBindings,
   getWorkspaceIndexJumpModifierKey,
@@ -37,6 +38,11 @@ import {
   navigateToLastWorkspace,
   useActiveWorkspaceSelection,
 } from "@/stores/navigation-active-workspace-store";
+import {
+  useCommandCenterContributions,
+  useCommandCenterShortcutRunner,
+} from "@/command-center/provider";
+import { getResolvableShortcutIds } from "@/command-center/registry";
 
 export function useKeyboardShortcuts({
   enabled,
@@ -59,7 +65,15 @@ export function useKeyboardShortcuts({
   const router = useRouter();
   const resetModifiers = useKeyboardShortcutsStore((s) => s.resetModifiers);
   const { overrides } = useKeyboardShortcutOverrides();
-  const bindings = useMemo(() => buildEffectiveBindings(overrides), [overrides]);
+  const commandCenterSnapshot = useCommandCenterContributions();
+  const runCommandCenterShortcut = useCommandCenterShortcutRunner();
+  const bindings = useMemo(() => {
+    const shortcutIds = getResolvableShortcutIds(commandCenterSnapshot.contributions);
+    return [
+      ...buildCommandShortcutBindings(shortcutIds, overrides),
+      ...buildEffectiveBindings(overrides),
+    ];
+  }, [commandCenterSnapshot.contributions, overrides]);
   const shortcutsAvailable = keyboardShortcutsAvailable({ isNative, isCompact: isMobile });
   const isDesktopApp = getIsElectronRuntime();
   const isMac = getShortcutOs() === "mac";
@@ -271,12 +285,14 @@ export function useKeyboardShortcuts({
         return;
       }
 
-      const handled = routeAndPerformShortcut({
-        action: result.match.action,
-        payload: result.match.payload,
-        domEvent: input.domEvent,
-        browserFocusRestoreElement: input.browserFocusRestoreElement,
-      });
+      const handled = result.match.commandShortcutId
+        ? runCommandCenterShortcut(result.match.commandShortcutId)
+        : routeAndPerformShortcut({
+            action: result.match.action,
+            payload: result.match.payload,
+            domEvent: input.domEvent,
+            browserFocusRestoreElement: input.browserFocusRestoreElement,
+          });
       if (!handled || !input.domEvent) {
         return;
       }
@@ -390,6 +406,7 @@ export function useKeyboardShortcuts({
     pathname,
     publishBrowserShortcutPolicy,
     resetModifiers,
+    runCommandCenterShortcut,
     router,
     shortcutsAvailable,
     toggleAgentList,

--- a/packages/app/src/keyboard/actions.ts
+++ b/packages/app/src/keyboard/actions.ts
@@ -41,6 +41,7 @@ export type KeyboardActionId =
   | "sidebar.toggle.both"
   | "settings.toggle"
   | "command-center.toggle"
+  | "command-center.contribution.run"
   | "shortcuts.dialog.toggle"
   | "workspace.terminal.new"
   | "workspace.new"

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildCommandShortcutBindings,
   buildKeyboardShortcutHelpSections,
   buildEffectiveBindings,
+  getCommandShortcutBindingId,
+  getCommandShortcutIdFromBindingId,
   getBindingIdForAction,
   getWorkspaceIndexJumpModifierKey,
   resolveKeyboardShortcut,
@@ -602,6 +605,68 @@ describe("keyboard-shortcuts", () => {
 
     expect(onChordReset).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
+  });
+});
+
+describe("direct command shortcut overrides", () => {
+  const shortcutId = "models:codex:gpt-5.6-sol";
+  const bindingId = "command-center.shortcut:models:codex:gpt-5.6-sol";
+
+  it("resolves a configured exact target through its stable persisted identity", () => {
+    const bindings = buildCommandShortcutBindings([shortcutId], { [bindingId]: "F13" });
+    const result = resolveShortcut({
+      event: { key: "F13", code: "F13" },
+      context: { focusScope: "message-input" },
+      bindings,
+    });
+
+    expect(result.match).toMatchObject({
+      action: "command-center.contribution.run",
+      commandShortcutId: shortcutId,
+      payload: null,
+      preventDefault: true,
+      stopPropagation: true,
+    });
+  });
+
+  it("has no default mapping and ignores unavailable or invalid stored targets", () => {
+    expect(getCommandShortcutBindingId(shortcutId)).toBe(bindingId);
+    expect(getCommandShortcutIdFromBindingId(bindingId)).toBe(shortcutId);
+    expect(getCommandShortcutIdFromBindingId("command-center.shortcut:")).toBeNull();
+    expect(getCommandShortcutIdFromBindingId("settings-toggle-cmd-comma-mac")).toBeNull();
+    expect(buildCommandShortcutBindings([shortcutId], {})).toEqual([]);
+    expect(
+      buildCommandShortcutBindings(["models:claude:claude-opus-5"], {
+        [bindingId]: "F13",
+      }),
+    ).toEqual([]);
+    expect(buildCommandShortcutBindings([shortcutId], { [bindingId]: "F25" })).toEqual([]);
+  });
+
+  it("matches editable composer focus but not terminals or the open command center", () => {
+    const bindings = buildCommandShortcutBindings([shortcutId], { [bindingId]: "F13" });
+
+    expect(
+      resolveShortcut({
+        event: { key: "F13", code: "F13" },
+        context: { focusScope: "terminal" },
+        bindings,
+      }).match,
+    ).toBeNull();
+    expect(
+      resolveShortcut({
+        event: { key: "F13", code: "F13" },
+        context: { commandCenterOpen: true },
+        bindings,
+      }).match,
+    ).toBeNull();
+    expect(
+      resolveShortcut({
+        event: { key: "F13", code: "F13" },
+        context: { focusScope: "editable" },
+        bindings,
+      }).match?.commandShortcutId,
+    ).toBe(shortcutId);
   });
 });
 

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -31,6 +31,7 @@ export interface KeyboardShortcutInput {
 
 export interface KeyboardShortcutMatch {
   action: KeyboardActionId;
+  commandShortcutId?: string;
   payload: KeyboardShortcutPayload;
   preventDefault: boolean;
   stopPropagation: boolean;
@@ -103,6 +104,7 @@ interface ShortcutBinding {
 
 export interface ParsedShortcutBinding extends ShortcutBinding {
   parsedChord: KeyCombo[];
+  commandShortcutId?: string;
 }
 
 export interface ChordState {
@@ -1076,6 +1078,48 @@ function parseBinding(binding: ShortcutBinding): ParsedShortcutBinding {
 export const DEFAULT_BINDINGS: readonly ParsedShortcutBinding[] =
   SHORTCUT_BINDINGS.map(parseBinding);
 
+const COMMAND_SHORTCUT_BINDING_PREFIX = "command-center.shortcut:";
+
+export function getCommandShortcutBindingId(shortcutId: string): string {
+  return `${COMMAND_SHORTCUT_BINDING_PREFIX}${shortcutId}`;
+}
+
+export function getCommandShortcutIdFromBindingId(bindingId: string): string | null {
+  if (!bindingId.startsWith(COMMAND_SHORTCUT_BINDING_PREFIX)) return null;
+  const shortcutId = bindingId.slice(COMMAND_SHORTCUT_BINDING_PREFIX.length);
+  return shortcutId.length > 0 ? shortcutId : null;
+}
+
+export function buildCommandShortcutBindings(
+  shortcutIds: readonly string[],
+  overrides: Readonly<Record<string, string>>,
+): ParsedShortcutBinding[] {
+  const bindings: ParsedShortcutBinding[] = [];
+  for (const shortcutId of new Set(shortcutIds)) {
+    const id = getCommandShortcutBindingId(shortcutId);
+    const combo = overrides[id];
+    if (!combo) continue;
+    let parsedChord: KeyCombo[];
+    try {
+      parsedChord = parseChordString(combo);
+    } catch {
+      continue;
+    }
+    const lastCombo = parsedChord.at(-1);
+    if (lastCombo) lastCombo.repeat = false;
+    bindings.push({
+      id,
+      action: "command-center.contribution.run",
+      commandShortcutId: shortcutId,
+      combo,
+      parsedChord,
+      repeat: false,
+      when: { commandCenter: false, terminal: false },
+    });
+  }
+  return bindings;
+}
+
 export function buildEffectiveBindings(overrides: Record<string, string>): ParsedShortcutBinding[] {
   return DEFAULT_BINDINGS.map(function (binding) {
     const override = overrides[binding.id];
@@ -1232,6 +1276,7 @@ function buildMatchFromBinding(
 ): KeyboardShortcutMatch {
   return {
     action: binding.action,
+    ...(binding.commandShortcutId ? { commandShortcutId: binding.commandShortcutId } : {}),
     payload: resolvePayload(binding.payload, event),
     preventDefault: binding.preventDefault ?? true,
     stopPropagation: binding.stopPropagation ?? true,

--- a/packages/app/src/keyboard/shortcut-string.test.ts
+++ b/packages/app/src/keyboard/shortcut-string.test.ts
@@ -68,3 +68,20 @@ describe("parseShortcutString round-trips punctuation keys", () => {
     expect(keyComboToString(combo)).toBe("Cmd+-");
   });
 });
+
+describe("function-key shortcuts", () => {
+  for (let index = 1; index <= 24; index += 1) {
+    const key = `F${index}`;
+
+    it(`parses, displays, and captures ${key}`, () => {
+      const combo = parseShortcutString(key);
+      expect(combo).toEqual({ code: key });
+      expect(keyComboToString(combo)).toBe(key);
+      expect(keyboardEventToComboString(keyboardEvent({ key, code: key }))).toBe(key);
+    });
+  }
+
+  it("rejects function keys outside F1-F24", () => {
+    expect(() => parseShortcutString("F25")).toThrow('Unknown key: "F25"');
+  });
+});

--- a/packages/app/src/keyboard/shortcut-string.ts
+++ b/packages/app/src/keyboard/shortcut-string.ts
@@ -70,7 +70,7 @@ KEY_MAP["PageUp"] = { code: "PageUp" };
 KEY_MAP["PageDown"] = { code: "PageDown" };
 KEY_MAP["Insert"] = { code: "Insert" };
 
-for (let i = 1; i <= 12; i++) {
+for (let i = 1; i <= 24; i++) {
   KEY_MAP[`F${i}`] = { code: `F${i}` };
 }
 

--- a/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
+++ b/packages/app/src/screens/settings/keyboard-shortcuts-section.tsx
@@ -24,6 +24,12 @@ import { getShortcutOs } from "@/utils/shortcut-platform";
 import { getIsElectronRuntime } from "@/constants/layout";
 import { isNative } from "@/constants/platform";
 import { getDesktopHost } from "@/desktop/host";
+import { useCommandCenterContributions } from "@/command-center/provider";
+import {
+  buildCommandShortcutSettingsRows,
+  type CommandShortcutSettingsRow,
+} from "@/command-center/shortcut-settings";
+import type { ShortcutKey } from "@/utils/format-shortcut";
 
 const EMPTY_CAPTURED_COMBOS: string[] = [];
 
@@ -75,6 +81,7 @@ function ShortcutRowContainer({
   onCancelCapture,
   onRemoveOverride,
 }: ShortcutRowContainerProps) {
+  const { t } = useTranslation();
   const handleRebind = useCallback(() => {
     if (bindingId) onStartCapture(bindingId);
   }, [bindingId, onStartCapture]);
@@ -85,8 +92,10 @@ function ShortcutRowContainer({
 
   return (
     <ShortcutRow
-      row={row}
+      label={t(row.labelKey)}
+      defaultChord={[row.keys]}
       bindingId={bindingId}
+      canRebind={bindingId !== null}
       overrideCombo={overrideCombo}
       isCapturing={isCapturing}
       capturedCombos={capturedCombos}
@@ -99,9 +108,53 @@ function ShortcutRowContainer({
   );
 }
 
-function ShortcutRow({
+function DirectShortcutRowContainer({
   row,
+  isCapturing,
+  capturedCombos,
+  heldModifiers,
+  onStartCapture,
+  onSaveCapture,
+  onCancelCapture,
+  onRemoveOverride,
+}: {
+  row: CommandShortcutSettingsRow;
+  isCapturing: boolean;
+  capturedCombos: string[];
+  heldModifiers: string | null;
+  onStartCapture: (bindingId: string) => void;
+  onSaveCapture: () => void;
+  onCancelCapture: () => void;
+  onRemoveOverride: (bindingId: string) => void;
+}) {
+  const { t } = useTranslation();
+  const handleRebind = useCallback(() => onStartCapture(row.bindingId), [onStartCapture, row]);
+  const handleReset = useCallback(() => onRemoveOverride(row.bindingId), [onRemoveOverride, row]);
+  const label = row.available ? row.label : `${row.label} · ${t("settings.providers.unavailable")}`;
+
+  return (
+    <ShortcutRow
+      label={label}
+      defaultChord={null}
+      bindingId={row.bindingId}
+      canRebind={row.available}
+      overrideCombo={row.combo}
+      isCapturing={isCapturing}
+      capturedCombos={capturedCombos}
+      heldModifiers={heldModifiers}
+      onRebind={handleRebind}
+      onDone={onSaveCapture}
+      onCancel={onCancelCapture}
+      onReset={handleReset}
+    />
+  );
+}
+
+function ShortcutRow({
+  label,
+  defaultChord,
   bindingId,
+  canRebind,
   overrideCombo,
   isCapturing,
   capturedCombos,
@@ -111,8 +164,10 @@ function ShortcutRow({
   onCancel,
   onReset,
 }: {
-  row: KeyboardShortcutHelpRow;
+  label: string;
+  defaultChord: ShortcutKey[][] | null;
   bindingId: string | null;
+  canRebind: boolean;
   overrideCombo: string | undefined;
   isCapturing: boolean;
   capturedCombos: string[];
@@ -124,21 +179,25 @@ function ShortcutRow({
 }) {
   const { t } = useTranslation();
   const displayChord = useMemo(
-    () => (overrideCombo ? chordStringToShortcutKeys(overrideCombo) : [row.keys]),
-    [overrideCombo, row.keys],
+    () => (overrideCombo ? chordStringToShortcutKeys(overrideCombo) : defaultChord),
+    [defaultChord, overrideCombo],
   );
   const rowStyle = useMemo(() => [styles.row, isCapturing && styles.rowCapturing], [isCapturing]);
+  let shortcut = displayChord ? (
+    <Shortcut chord={displayChord} />
+  ) : (
+    <Text style={styles.unassigned}>—</Text>
+  );
+  if (isCapturing) {
+    shortcut = <ShortcutSequence chord={capturedCombos} heldModifiers={heldModifiers} />;
+  }
 
   return (
     <View style={rowStyle}>
-      <Text style={styles.rowLabel}>{t(row.labelKey)}</Text>
+      <Text style={styles.rowLabel}>{label}</Text>
       <View style={styles.rowActions}>
-        {isCapturing ? (
-          <ShortcutSequence chord={capturedCombos} heldModifiers={heldModifiers} />
-        ) : (
-          <Shortcut chord={displayChord} />
-        )}
-        {bindingId !== null && (
+        {shortcut}
+        {bindingId !== null && canRebind && (
           <>
             {isCapturing && capturedCombos.length > 0 ? (
               <Button variant="ghost" size="sm" onPress={onDone}>
@@ -169,6 +228,7 @@ export function KeyboardShortcutsSection() {
   const [heldModifiers, setHeldModifiers] = useState<string | null>(null);
   const { overrides, hasOverrides, setOverride, removeOverride, resetAll } =
     useKeyboardShortcutOverrides();
+  const commandCenterSnapshot = useCommandCenterContributions();
   const setCapturingShortcut = useKeyboardShortcutsStore((s) => s.setCapturingShortcut);
   const capturing = useKeyboardShortcutsStore((s) => s.capturingShortcut);
 
@@ -176,6 +236,25 @@ export function KeyboardShortcutsSection() {
   const isMac = getShortcutOs() === "mac";
   const isDesktopApp = getIsElectronRuntime();
   const sections = buildKeyboardShortcutHelpSections({ isMac, isDesktop: isDesktopApp });
+  const directShortcutRows = useMemo(
+    () => buildCommandShortcutSettingsRows(commandCenterSnapshot.shortcutCatalog, overrides),
+    [commandCenterSnapshot.shortcutCatalog, overrides],
+  );
+  const directShortcutGroups = useMemo(
+    () => [
+      {
+        id: "models" as const,
+        title: t("shell.commandCenter.modelGroupLabel"),
+        rows: directShortcutRows.filter((row) => row.group === "models"),
+      },
+      {
+        id: "thinking" as const,
+        title: t("shell.commandCenter.thinkingGroupLabel"),
+        rows: directShortcutRows.filter((row) => row.group === "thinking"),
+      },
+    ],
+    [directShortcutRows, t],
+  );
 
   const cancelCapture = useCallback(() => {
     setCapturedCombos([]);
@@ -318,6 +397,36 @@ export function KeyboardShortcutsSection() {
           </SettingsSection>
         );
       })}
+      {directShortcutGroups.map(function (group) {
+        if (group.rows.length === 0) return null;
+        return (
+          <SettingsSection key={group.id} title={group.title}>
+            <View style={settingsStyles.card}>
+              {group.rows.map(function (row, index) {
+                return (
+                  <View key={row.shortcutId}>
+                    <DirectShortcutRowContainer
+                      row={row}
+                      isCapturing={capturingBindingId === row.bindingId}
+                      capturedCombos={
+                        capturingBindingId === row.bindingId
+                          ? capturedCombos
+                          : EMPTY_CAPTURED_COMBOS
+                      }
+                      heldModifiers={capturingBindingId === row.bindingId ? heldModifiers : null}
+                      onStartCapture={startCapture}
+                      onSaveCapture={saveCapture}
+                      onCancelCapture={cancelCapture}
+                      onRemoveOverride={handleRemoveOverride}
+                    />
+                    {index < group.rows.length - 1 && <View style={styles.separator} />}
+                  </View>
+                );
+              })}
+            </View>
+          </SettingsSection>
+        );
+      })}
     </>
   );
 }
@@ -348,6 +457,10 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foregroundMuted,
   },
   resetText: {
+    color: theme.colors.foregroundMuted,
+  },
+  unassigned: {
+    fontSize: theme.fontSize.sm,
     color: theme.colors.foregroundMuted,
   },
   separator: {

--- a/packages/desktop/src/features/browser-keyboard/policy.test.ts
+++ b/packages/desktop/src/features/browser-keyboard/policy.test.ts
@@ -228,4 +228,33 @@ describe("browser keyboard policy", () => {
       }),
     ).toBe(false);
   });
+
+  test.each(["F13", "F24"])("matches an unmodified %s browser-pane shortcut", (code) => {
+    const policy = parseBrowserKeyboardPolicy({
+      menuPrefixes: [],
+      prefixes: [
+        {
+          alt: false,
+          code,
+          control: false,
+          meta: false,
+          repeat: false,
+          shift: false,
+        },
+      ],
+    });
+    expect(policy).not.toBeNull();
+
+    const input = {
+      alt: false,
+      code,
+      control: false,
+      key: code,
+      meta: false,
+      repeat: false,
+      shift: false,
+    };
+    expect(matchesBrowserShortcutPolicy(policy!, input)).toBe(true);
+    expect(matchesBrowserShortcutPolicy(policy!, { ...input, repeat: true })).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- add configurable direct shortcuts for selecting exact models and thinking-effort levels without opening pickers
- expose discovered model and thinking commands in keyboard shortcut settings with stable semantic identities and persisted overrides
- resolve shortcuts only against unique commands offered by the focused composer, preserving draft provider changes and same-provider running-agent behavior
- support F13-F24 parsing, capture, display, matching, and Electron browser-pane forwarding

This intentionally does not add the separate Alt+M/Alt+E picker actions.

## Validation

- `npx vitest run packages/app/src/command-center/agent-control-contributions.test.ts packages/app/src/command-center/registry.test.ts packages/app/src/command-center/shortcut-settings.test.ts packages/app/src/desktop/browser/shortcuts.test.ts packages/app/src/keyboard/keyboard-shortcuts.test.ts packages/app/src/keyboard/shortcut-string.test.ts packages/desktop/src/features/browser-keyboard/policy.test.ts --bail=1` (158 tests passed)
- targeted lint for all 19 changed files (0 warnings, 0 errors)
- `npm run format:check`
- `git diff --check`

Repository-wide typecheck remains blocked by pre-existing missing dependencies and stale generated declarations, including `expo-module-scripts`, `expo-clipboard`, xterm packages, and client protocol types.