### PR TITLE
fix(server): pin ALPN http/1.1 for outbound relay WebSockets

### DIFF
--- a/packages/server/src/server/relay-transport.test.ts
+++ b/packages/server/src/server/relay-transport.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type pino from "pino";
 import { createClientChannel, type Transport } from "@getpaseo/relay/e2ee";
 import { exportPublicKey, generateKeyPair } from "@getpaseo/relay";
-import { startRelayTransport } from "./relay-transport";
+import { RELAY_WEBSOCKET_OPTIONS, startRelayTransport } from "./relay-transport";
 
 function createMockLogger() {
   const messages: { level: "debug" | "info" | "warn" | "error"; args: unknown[] }[] = [];
@@ -131,6 +131,16 @@ function createFakeWebSockets() {
     },
   };
 }
+
+describe("relay-transport websocket options", () => {
+  test("pins HTTP/1.1 ALPN for outbound relay sockets", () => {
+    expect(RELAY_WEBSOCKET_OPTIONS).toMatchObject({
+      handshakeTimeout: 10_000,
+      perMessageDeflate: false,
+      ALPNProtocols: ["http/1.1"],
+    });
+  });
+});
 
 describe("relay-transport control lifecycle", () => {
   const controllers: Array<{ stop: () => Promise<void> }> = [];

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -56,7 +56,13 @@ type ControlMessage =
 const CONTROL_PING_INTERVAL_MS = 10_000;
 const CONTROL_STALE_TIMEOUT_MS = 30_000;
 const CONTROL_READY_TIMEOUT_MS = 8_000;
-const RELAY_WEBSOCKET_OPTIONS = { handshakeTimeout: 10_000, perMessageDeflate: false } as const;
+// Pin HTTP/1.1 ALPN for outbound relay sockets so Node on Linux/WSL does not
+// negotiate h2 and hang the WebSocket handshake.
+export const RELAY_WEBSOCKET_OPTIONS = {
+  handshakeTimeout: 10_000,
+  perMessageDeflate: false,
+  ALPNProtocols: ["http/1.1"],
+} as const;
 
 function createDefaultRelayWebSocket(url: string): RelayWebSocketLike {
   return new WebSocket(url, RELAY_WEBSOCKET_OPTIONS);


### PR DESCRIPTION
### Linked issue

Closes #2362

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On Linux and WSL, Node.js's TLS stack may negotiate `h2` with `relay.paseo.sh` during the outbound relay WebSocket handshake. The `ws` library then tries to complete an HTTP/1.1 `Upgrade: websocket` request over a connection the server expects to speak HTTP/2, causing the handshake to hang and the control socket to close with code `1006` (`relay_control_disconnected`).

Users see the daemon running locally and reachable on `127.0.0.1:6767`, but remote clients never see it through relay. The same setup works on Windows and other clients because their TLS stacks do not advertise/negotiate `h2` in the same way.

This change pins `ALPNProtocols: ["http/1.1"]` on the shared `RELAY_WEBSOCKET_OPTIONS` used by both control and data sockets. It is a minimal, backward-compatible fix: `http/1.1` is the only protocol WebSocket upgrade works over, and relay already supports it. It does not affect E2E encryption, the relay protocol, or other platforms.

### Goals

- Force Node.js to announce only `http/1.1` for outbound relay WebSocket connections.
- Keep the existing `handshakeTimeout` and `perMessageDeflate` behavior unchanged.
- Add a focused regression test on `RELAY_WEBSOCKET_OPTIONS` so the ALPN setting is not accidentally removed.
- Follow the existing code style and PR template.

### Non-goals

- Refactoring the larger relay transport logic.
- Adding per-platform branching or configuration toggles.
- Changing client-side or mobile relay code. The WebSocket client already behaves correctly; the root cause is the daemon's outbound TLS negotiation on Linux/WSL.

### QA

- Reproduced the bug on Linux with Node 22/24: `paseo daemon start` logged `relay_control_disconnected code=1006` repeatedly.
- Confirmed that an isolated `ws` connection to `wss://relay.paseo.sh/ws` with `ALPNProtocols: ["http/1.1"]` receives the initial `sync` frame and stays open, while the same connection without it closes with `1006`.
- Confirmed that a daemon running with this patch logs `relay_control_connected` and stays reachable from a remote client.
- Local verification (after `npm ci`):
  - `npm run lint -- packages/server/src/server/relay-transport.ts packages/server/src/server/relay-transport.test.ts` ✅
  - `npm run format:check -- packages/server/src/server/relay-transport.ts packages/server/src/server/relay-transport.test.ts` ✅
  - `npm run typecheck` (root, all workspaces) ✅
  - `npm run build:server` ✅
  - `npx vitest run src/server/relay-transport.test.ts --bail=1` ✅ (7/7 tests pass)

### Relation to #2407

#2407 proposed the same core change and was closed rather than merged. This PR:

- Keeps the identical minimal code change (`ALPNProtocols: ["http/1.1"]` on `RELAY_WEBSOCKET_OPTIONS`), which is the only fix needed.
- Adds a slightly clearer comment that explicitly calls out Linux/WSL and the WebSocket handshake, rather than the more general `Node/WSL TLS` wording.
- Keeps the same regression test structure from #2407, but the `RELAY_WEBSOCKET_OPTIONS` constant is now exported so it can be asserted against directly.
- Uses the upstream PR template and a more complete QA / reasoning section.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
