### PR TITLE
fix(claude): don't drop the prompt when a query restart is pending

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -436,14 +436,17 @@ test("delivers the prompt when a query restart is pending and no query exists", 
 
   const session = await createSession();
   const internal: { query: unknown; queryRestartNeeded: boolean } = asInternals(session);
-  // A restart can be requested while the session has no live query (idle runtime
-  // released, rewind, model/thinking change before the first prompt). The flag must
-  // not survive query creation, or startQueryPump() tears down the input stream that
-  // sendPrompt() is about to write to.
-  expect(internal.query).toBeNull();
-  internal.queryRestartNeeded = true;
 
   try {
+    // Request a restart through the public API while the session has no live query,
+    // the way the UI does when the thinking option is changed before the first prompt.
+    // The request must not survive query creation, or startQueryPump() tears down the
+    // input stream that sendPrompt() is about to write to.
+    expect(internal.query).toBeNull();
+    await session.setThinkingOption("high");
+    expect(internal.queryRestartNeeded).toBe(true);
+    expect(sdkQueryFactory).not.toHaveBeenCalled();
+
     const events = await collectUntilTerminal(streamSession(session, "hello"));
     const failure = events.find(
       (event): event is Extract<AgentStreamEvent, { type: "turn_failed" }> =>

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -409,6 +409,56 @@ test("logs redacted query summary and never leaks sentinel secrets", async () =>
   }
 });
 
+test("delivers the prompt when a query restart is pending and no query exists", async () => {
+  sdkQueryFactory.mockImplementation(({ prompt }: { prompt: AsyncIterable<unknown> }) => {
+    const readPromptUuid = createPromptUuidReader(prompt);
+    let emittedResult = false;
+    return createBaseQueryMock(
+      vi.fn(async () => {
+        if (emittedResult) {
+          return { done: true, value: undefined };
+        }
+        emittedResult = true;
+        const uuid = await readPromptUuid();
+        return {
+          done: false,
+          value: {
+            type: "result",
+            subtype: "success",
+            session_id: "session-restart-pending",
+            usage: buildUsage(),
+            result: uuid ? "received prompt" : "missing prompt",
+          },
+        };
+      }),
+    );
+  });
+
+  const session = await createSession();
+  const internal: { query: unknown; queryRestartNeeded: boolean } = asInternals(session);
+  // A restart can be requested while the session has no live query (idle runtime
+  // released, rewind, model/thinking change before the first prompt). The flag must
+  // not survive query creation, or startQueryPump() tears down the input stream that
+  // sendPrompt() is about to write to.
+  expect(internal.query).toBeNull();
+  internal.queryRestartNeeded = true;
+
+  try {
+    const events = await collectUntilTerminal(streamSession(session, "hello"));
+    const failure = events.find(
+      (event): event is Extract<AgentStreamEvent, { type: "turn_failed" }> =>
+        event.type === "turn_failed",
+    );
+
+    expect(failure).toBeUndefined();
+    expect(events.some((event) => event.type === "turn_completed")).toBe(true);
+    expect(sdkQueryFactory).toHaveBeenCalledTimes(1);
+    expect(internal.queryRestartNeeded).toBe(false);
+  } finally {
+    await session.close();
+  }
+});
+
 test("interruptActiveTurn only interrupts the active query without info logs", async () => {
   const spy = createSpyLogger();
   const session = await createSessionWithLogger(spy.logger);

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2190,11 +2190,14 @@ class ClaudeAgentSession implements AgentSession {
 
     try {
       await this.ensureQuery();
-      if (!this.input) {
+      const input = this.input;
+      if (!input) {
         throw new Error("Claude session input stream not initialized");
       }
+      // Push before starting the pump: startQueryPump() re-enters ensureQuery(), which can
+      // synchronously swap out this.input when a query restart is pending.
+      input.push(sdkMessage);
       this.startQueryPump();
-      this.input.push(sdkMessage);
       setTimeout(() => {
         if (this.activeForegroundTurnId === turnId) {
           this.emitSubmittedUserMessage(sdkMessage, turnId, options?.clientMessageId);
@@ -2924,6 +2927,13 @@ class ClaudeAgentSession implements AgentSession {
         this.childProcess = null;
       }
     }
+
+    // The query is about to be (re)created, so any pending restart request is satisfied.
+    // Clearing this unconditionally matters when a restart was requested while no query
+    // existed (idle runtime released, rewind, model/thinking change before the first
+    // prompt): otherwise the flag stays set and the next ensureQuery() call — reached
+    // synchronously from startQueryPump() — tears down the query/input we just handed out.
+    this.queryRestartNeeded = false;
 
     // Preserve claudeSessionId across query recreation so buildOptions() passes
     // resume: sessionId and the new query continues the existing conversation.


### PR DESCRIPTION
## Problem
<img width="909" height="217" alt="bug" src="https://github.com/user-attachments/assets/652d9064-6c35-42cb-859b-68391006009f" />

A foreground turn dies ~3s after sending with `[System Error] Cannot read properties of null (reading 'push')`, and the user's message is gone — it is never persisted and never reaches the Claude CLI.

Raw daemon log for one occurrence (0.2.3, provider `claude`; ids/paths redacted):

```
21:09:57 WARN  Claude query operation did not settle cleanly
              op=return err="ProcessTransport is not ready for writing"
21:09:57 INFO  Collected idle agent runtime  agentId=<redacted> idleMs=1800xxx
21:38:35 INFO  Agent resumed from persistence agentId=<redacted>
21:43:04 INFO  handleStreamEvent: turn_failed provider=claude turnId=foreground-turn-1
              error="Cannot read properties of null (reading 'push')"
21:43:04 WARN  [CLAUDE_SDK_CAN_USE_TOOL_SHADOWED] ...   <- one per created query
21:43:04 WARN  [CLAUDE_SDK_CAN_USE_TOOL_SHADOWED] ...   <- two queries for one prompt
```

The event carries no `stack`/`code`/`diagnostic`, and there is never a `Claude Agent SDK stderr` line, so the CLI subprocess is not involved. Grepping the published `@getpaseo/server` bundle for `.push(` sites whose receiver can be `null` leaves exactly one candidate: `this.input.push(sdkMessage)` in `ClaudeAgentClient.sendPrompt`. The duplicated `CAN_USE_TOOL_SHADOWED` warning confirms two queries were created while serving a single prompt.

## Root cause

```ts
await this.ensureQuery();
if (!this.input) { throw ... }
this.startQueryPump();       // re-enters ensureQuery()
this.input.push(sdkMessage); // 💥
```

An `async` function body runs synchronously up to its first `await`, so the `ensureQuery()` call inside `startQueryPump()` executes its restart branch — `this.query = null; this.input = null;` — *before* returning to `sendPrompt`, which then pushes into `null`.

It gets there because `queryRestartNeeded` could survive query creation: it was cleared only inside the `if (this.queryRestartNeeded && this.query)` branch. A restart requested while no query existed left the flag dirty, so on the next prompt `ensureQuery()` created query #1 with the flag still set, and `startQueryPump()`'s `ensureQuery()` immediately tore it down and created query #2. Paths that can set the flag with `this.query === null`: idle agent runtime release, `rewindFilesOnce`, `rebindConversationSession` / `startFreshConversationSession`, and thinking/model reconciliation before the first prompt.

Related: #2568. That issue was closed by #2590, which removed the idle-runtime GC — i.e. the most common *trigger* is gone in 0.2.5, but `ensureQuery`/`sendPrompt` are byte-identical in 0.2.5 and the remaining triggers (rewind, session rebind, thinking/model change before the first prompt) still lose the user's message.

## Fix

- `ensureQuery()`: clear `queryRestartNeeded` unconditionally before the query is (re)created, since creating it satisfies any pending restart request.
- `sendPrompt()`: capture `this.input` in a local and push the message **before** `startQueryPump()`, so a concurrent restart can't swap the stream out from under the write. Deliberately not `this.input?.push(...)` — that would silently drop the prompt instead of surfacing it.

## QA

- New regression test in `agent.redesign.test.ts` ("delivers the prompt when a query restart is pending and no query exists"): sets `queryRestartNeeded` while `query === null`, then sends a prompt. Without the fix it fails with the exact production message `Cannot read properties of null (reading 'push')` and `sdkQueryFactory` is called twice; with the fix the turn completes, the SDK receives the prompt message, and the factory is called once.
- `npx vitest run packages/server/src/server/agent/providers/claude/` → 291 passed, 3 skipped. The 3 failing *files* are the `*.real.e2e` suites, which fail at import because no `ANTHROPIC_API_KEY` is set here — unrelated to this change.
- `oxfmt --check` and `oxlint` clean on both changed files.
- `npm run typecheck --workspace=@getpaseo/server` reports only a pre-existing unrelated error (`Cannot find module '@getpaseo/highlight'`, package not built in my checkout).
- Platform tested: Linux x64, Node 20. Not tested on macOS/Windows; the change is platform-independent JS ordering.

Maintainer edits are enabled.
