### PR TITLE
Prevent workspace file watching from stalling the daemon

### DIFF
--- a/packages/server/scripts/measure-git-observation.ts
+++ b/packages/server/scripts/measure-git-observation.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/utils/run-git-command.js";
 import { CheckoutDiffManager } from "../src/server/checkout-diff-manager.js";
 import {
+  subscribeToWorkspaceFileChanges,
   WorkspaceGitServiceImpl,
   type WorkspaceGitRuntimeSnapshot,
 } from "../src/server/workspace-git-service.js";
@@ -94,7 +95,7 @@ function createTrackedSubscriber(failWorktreeRoot: string | null) {
     if (failWorktreeRoot && path.resolve(args[0]) === failWorktreeRoot) {
       throw new Error("measurement watcher setup failure");
     }
-    const subscription = await parcelWatcher.subscribe(...args);
+    const subscription = await subscribeToWorkspaceFileChanges(...args);
     subscriptions.add(subscription);
     return {
       unsubscribe: async () => {

--- a/packages/server/src/server/workspace-git-service.observation.integration.test.ts
+++ b/packages/server/src/server/workspace-git-service.observation.integration.test.ts
@@ -6,7 +6,10 @@ import type pino from "pino";
 import { afterEach, expect, test, vi } from "vitest";
 import type { CheckoutSnapshotFacts, CheckoutStatusGit } from "../utils/checkout-git.js";
 import { CheckoutDiffManager } from "./checkout-diff-manager.js";
-import { WorkspaceGitServiceImpl } from "./workspace-git-service.js";
+import {
+  subscribeToWorkspaceFileChanges,
+  WorkspaceGitServiceImpl,
+} from "./workspace-git-service.js";
 
 function createLogger(): pino.Logger {
   const logger = {
@@ -83,7 +86,7 @@ test("native recursive observation updates tracked state and prunes ignored stor
     events: parcelWatcher.Event[];
   }> = [];
   const subscribe: typeof parcelWatcher.subscribe = async (directory, callback, options) => {
-    const subscription = await parcelWatcher.subscribe(
+    const subscription = await subscribeToWorkspaceFileChanges(
       directory,
       (error, events) => {
         deliveredEvents.push({ directory, events });

--- a/packages/server/src/server/workspace-git-service.observation.integration.test.ts
+++ b/packages/server/src/server/workspace-git-service.observation.integration.test.ts
@@ -197,9 +197,19 @@ test("native recursive observation updates tracked state and prunes ignored stor
     { timeout: 5_000 },
   );
 
-  // Parcel may deliver a startup batch before subscribe resolves. Let its
-  // already-scheduled consumer debounce finish inside the bootstrap phase.
-  await new Promise((resolve) => setTimeout(resolve, 250));
+  writeFileSync(trackedPath, "base\n");
+  await vi.waitFor(
+    () => {
+      const events = deliveredEvents.flatMap((batch) => batch.events);
+      expect(events.map((event) => event.path)).toContain(trackedPath);
+      expect(getCheckoutWorktreeState).toHaveBeenCalled();
+      expect(service.getMetrics()).toMatchObject({
+        workspaceRefreshInFlightCount: 0,
+        workspaceRefreshQueuedCount: 0,
+      });
+    },
+    { timeout: 5_000 },
+  );
 
   getCheckoutSnapshotFacts.mockClear();
   getCheckoutStatus.mockClear();
@@ -209,7 +219,6 @@ test("native recursive observation updates tracked state and prunes ignored stor
   runGitCommand.mockClear();
   deliveredEvents.length = 0;
 
-  await new Promise((resolve) => setTimeout(resolve, 250));
   expect(runGitCommand).not.toHaveBeenCalled();
   expect(getCheckoutWorktreeState).not.toHaveBeenCalled();
   expect(getCheckoutDiff, JSON.stringify(deliveredEvents)).not.toHaveBeenCalled();

--- a/packages/server/src/server/workspace-git-service.primitive.test.ts
+++ b/packages/server/src/server/workspace-git-service.primitive.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../utils/checkout-git.js";
 import { runGitCommand as runGitCommandReal } from "../utils/run-git-command.js";
 import {
+  getWorkspaceFileWatcherBackend,
   getWorkspaceGitSelfHealPhaseMs,
   WorkspaceGitServiceImpl,
   type WorkspaceGitRuntimeSnapshot,
@@ -889,6 +890,20 @@ describe("WorkspaceGitServiceImpl primitive refresh entrypoint", () => {
   test("self-heal phase is stable across process restarts", () => {
     expect(getWorkspaceGitSelfHealPhaseMs("/tmp/repo")).toBe(54_185);
     expect(getWorkspaceGitSelfHealPhaseMs("/tmp/staggered-repo")).toBe(9_817);
+  });
+
+  test.each([
+    ["darwin", "fs-events"],
+    ["linux", "inotify"],
+    ["win32", "windows"],
+  ] as const)("uses the native %s file watcher backend", (platform, backend) => {
+    expect(getWorkspaceFileWatcherBackend(platform)).toBe(backend);
+  });
+
+  test("rejects unsupported watcher platforms instead of using backend auto-detection", () => {
+    expect(() => getWorkspaceFileWatcherBackend("freebsd")).toThrow(
+      "No native workspace file watcher configured for freebsd",
+    );
   });
 
   test("self-heal staggers workspaces and settles into a 120 second cadence", async () => {

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -321,6 +321,17 @@ export function getWorkspaceFileWatcherBackend(
   }
 }
 
+export function subscribeToWorkspaceFileChanges(
+  directory: string,
+  callback: parcelWatcher.SubscribeCallback,
+  options?: parcelWatcher.Options,
+): Promise<parcelWatcher.AsyncSubscription> {
+  return parcelWatcher.subscribe(directory, callback, {
+    ...options,
+    backend: getWorkspaceFileWatcherBackend(process.platform),
+  });
+}
+
 interface WorkspaceGitTarget {
   cwd: string;
   listeners: Set<WorkspaceGitListener>;
@@ -390,11 +401,7 @@ interface WorkspaceForgePrStatusPollTarget {
 
 function buildDefaultWorkspaceGitServiceDeps(): WorkspaceGitServiceDependencies {
   return {
-    subscribe: (directory, callback, options) =>
-      parcelWatcher.subscribe(directory, callback, {
-        ...options,
-        backend: getWorkspaceFileWatcherBackend(process.platform),
-      }),
+    subscribe: subscribeToWorkspaceFileChanges,
     getCheckoutSnapshotFacts,
     getCheckoutStatus,
     getCheckoutShortstat,

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -306,6 +306,21 @@ interface WorkspaceGitServiceOptions {
   deps?: Partial<WorkspaceGitServiceDependencies>;
 }
 
+export function getWorkspaceFileWatcherBackend(
+  platform: NodeJS.Platform,
+): parcelWatcher.BackendType {
+  switch (platform) {
+    case "darwin":
+      return "fs-events";
+    case "linux":
+      return "inotify";
+    case "win32":
+      return "windows";
+    default:
+      throw new Error(`No native workspace file watcher configured for ${platform}`);
+  }
+}
+
 interface WorkspaceGitTarget {
   cwd: string;
   listeners: Set<WorkspaceGitListener>;
@@ -375,7 +390,11 @@ interface WorkspaceForgePrStatusPollTarget {
 
 function buildDefaultWorkspaceGitServiceDeps(): WorkspaceGitServiceDependencies {
   return {
-    subscribe: parcelWatcher.subscribe,
+    subscribe: (directory, callback, options) =>
+      parcelWatcher.subscribe(directory, callback, {
+        ...options,
+        backend: getWorkspaceFileWatcherBackend(process.platform),
+      }),
     getCheckoutSnapshotFacts,
     getCheckoutStatus,
     getCheckoutShortstat,


### PR DESCRIPTION
### Linked issue

None — the open issue search found no report matching this worker-pool deadlock.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Workspace watcher backend auto-detection can select an IPC-backed implementation whose subscription locking deadlocks the Node worker pool during watcher reconfiguration. Once all workers are occupied, relay DNS, asynchronous logging, and filesystem operations stop making progress while the daemon still appears locally reachable.

The daemon now selects the host-native watcher backend explicitly on macOS, Linux, and Windows. Unsupported platforms fail into the existing bounded polling fallback instead of using backend auto-detection.

### Goals

- Prevent workspace watcher reconfiguration from starving the daemon worker pool.
- Use the native file-watching backend on every supported daemon platform.
- Preserve the existing polling fallback when a native watcher cannot start.

### Non-goals

- Change workspace Git observation semantics or polling cadence.
- Patch or fork the native watcher dependency.
- Change relay reconnect behavior.

### QA

Initial red evidence:

```text
npx vitest run packages/server/src/server/workspace-git-service.primitive.test.ts
Test Files  1 failed (1)
Tests  3 failed | 56 passed (59)
TypeError: getWorkspaceFileWatcherBackend is not a function
```

Production-boundary red evidence:

```text
npx vitest run packages/server/src/server/workspace-git-service.observation.integration.test.ts --bail=1
Test Files  1 failed (1)
Tests  1 failed (1)
AssertionError: expected +0 to be 2
```

Green evidence:

```text
npx vitest run packages/server/src/server/workspace-git-service.observation.integration.test.ts --bail=1
Test Files  1 passed (1)
Tests  1 passed (1)
```

```text
npx vitest run packages/server/src/server/workspace-git-service.primitive.test.ts --bail=1
Test Files  1 passed (1)
Tests  60 passed (60)
```

The integration test uses the production subscription function with the real native watcher and real filesystem events, including watcher replacement when ignored directories change.

A separate macOS smoke subscribed with the explicit native backend and observed the expected `probe.txt` create event.

```text
npm run typecheck
All workspace typechecks passed.
```

```text
npm run lint -- packages/server/src/server/workspace-git-service.ts packages/server/src/server/workspace-git-service.primitive.test.ts packages/server/src/server/workspace-git-service.observation.integration.test.ts
Found 0 warnings and 0 errors.
```

Platform coverage: the backend policy is covered for macOS, Linux, and Windows. The production-boundary integration test and manual smoke passed locally on macOS; CI provides Linux and Windows server validation.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
