### PR TITLE
fix: show Z.ai quota usage

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -111,6 +111,8 @@ See [Codex with a custom OpenAI-compatible endpoint](#codex-with-a-custom-openai
 
 - `ANTHROPIC_AUTH_TOKEN` is used instead of `ANTHROPIC_API_KEY` — this is the z.ai API key
 - The `API_TIMEOUT_MS` env var extends the request timeout (z.ai can be slower than direct Anthropic)
+- Plan usage automatically reads this provider credential and supports both `api.z.ai` and the
+  China-region `open.bigmodel.cn` endpoint
 - If you get auth errors, run `/logout` inside Claude Code before switching to the z.ai provider
 - Web search (`WebSearch` tool) is an Anthropic-only server-side feature — third-party endpoints don't support it. Add `"disallowedTools": ["WebSearch"]` to avoid errors.
 - Automated setup is also available: `npx @z_ai/coding-helper`

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -76,6 +76,8 @@ import {
   type WebSocketRuntimeDiagnosticSnapshot,
 } from "./websocket/runtime-metrics.js";
 import { ProviderUsageService } from "../services/quota-fetcher/service.js";
+import type { ProviderUsageAgentProviderConfigs } from "../services/quota-fetcher/provider.js";
+import { loadPersistedConfig } from "./persisted-config.js";
 import { getProcessMemoryDiagnostics, getProcessUptimeSeconds } from "./process-diagnostics.js";
 import {
   CLIENT_SHUTDOWN_RPC_REASON,
@@ -148,6 +150,30 @@ type WebSocketRuntimeDiagnosticPayload = WebSocketRuntimeDiagnosticSnapshot<
 type WebSocketRuntimeMetricsLogPayload = Omit<WebSocketRuntimeDiagnosticPayload, "collectedAt">;
 
 type TerminalAttentionReason = "finished" | "needs_input";
+
+/**
+ * Projects the persisted agent-provider overrides into the shape the provider-usage
+ * fetchers consume. `loadPersistedConfig` types `agents.providers` as launch-only runtime
+ * settings (`{ command, env, disallowedTools }`), but the parsed entries also retain the
+ * `enabled` and `order` fields from `ProviderOverridesSchema`. Reading those faithfully lets
+ * the Z.ai quota fetcher bind credential selection to a profile's enabled state and
+ * configured order instead of first-match across every persisted profile.
+ */
+function agentProviderConfigsForUsage(paseoHome: string): ProviderUsageAgentProviderConfigs {
+  const providers = loadPersistedConfig(paseoHome).agents?.providers;
+  if (!providers) return {};
+  type PersistedProviderEntry = NonNullable<(typeof providers)[string]> & {
+    enabled?: boolean;
+    order?: number;
+  };
+  const result: ProviderUsageAgentProviderConfigs = {};
+  for (const [id, provider] of Object.entries(providers)) {
+    if (!provider) continue;
+    const entry = provider as PersistedProviderEntry;
+    result[id] = { env: entry.env, enabled: entry.enabled, order: entry.order };
+  }
+  return result;
+}
 
 function resolveTerminalAttentionReason(input: {
   attentionReason?: TerminalActivity["attentionReason"];
@@ -684,6 +710,7 @@ export class VoiceAssistantWebSocketServer {
 
     this.providerUsageService = new ProviderUsageService({
       logger: this.logger,
+      getAgentProviderConfigs: () => agentProviderConfigsForUsage(this.paseoHome),
     });
 
     this.wss = this.createWebSocketServer(server, wsConfig, auth);

--- a/packages/server/src/services/quota-fetcher/manifest.ts
+++ b/packages/server/src/services/quota-fetcher/manifest.ts
@@ -39,7 +39,12 @@ export const PROVIDER_USAGE_FETCHERS: readonly ProviderUsageFetcherManifestEntry
   },
   {
     providerId: "zai",
-    create: (options) => new ZaiQuotaProvider({ logger: options.logger, fetch: options.fetch }),
+    create: (options) =>
+      new ZaiQuotaProvider({
+        logger: options.logger,
+        fetch: options.fetch,
+        getAgentProviderConfigs: options.getAgentProviderConfigs,
+      }),
   },
   {
     providerId: "grok",

--- a/packages/server/src/services/quota-fetcher/provider.ts
+++ b/packages/server/src/services/quota-fetcher/provider.ts
@@ -3,6 +3,26 @@ import type { ProviderUsage } from "../../server/messages.js";
 
 export type ProviderApiFetch = typeof fetch;
 
+export interface ProviderUsageAgentProviderConfig {
+  env?: Record<string, string>;
+  /**
+   * Whether the persisted profile is enabled. Profiles default to enabled; a profile
+   * with `enabled === false` is skipped when selecting credentials so quota is never
+   * reported for an account the user has turned off.
+   */
+  enabled?: boolean;
+  /**
+   * Configured display order for the profile. When several enabled profiles target the
+   * same provider, the lowest order wins (undefined sorts last), so selection reflects
+   * the user's configured priority rather than incidental map iteration order.
+   */
+  order?: number;
+}
+
+export type ProviderUsageAgentProviderConfigs = Partial<
+  Record<string, ProviderUsageAgentProviderConfig>
+>;
+
 export interface ProviderUsageFetcher {
   readonly providerId: string;
   readonly displayName: string;
@@ -12,6 +32,7 @@ export interface ProviderUsageFetcher {
 export interface ProviderUsageFetcherFactoryOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+  getAgentProviderConfigs?: () => ProviderUsageAgentProviderConfigs;
 }
 
 export interface ProviderUsageFetcherManifestEntry {

--- a/packages/server/src/services/quota-fetcher/providers/zai.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/zai.test.ts
@@ -1,0 +1,447 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProviderUsageAgentProviderConfigs } from "../provider.js";
+import { ZaiQuotaProvider } from "./zai.js";
+
+const SESSION_RESET = 1_782_960_937_355;
+const WEEKLY_RESET = 1_783_303_263_991;
+
+function createLogger() {
+  const logger = {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger as never;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function monitorResponse(
+  limits: Array<{
+    type: string;
+    unit?: number | string;
+    number?: number | string;
+    percentage?: number | string | null;
+    nextResetTime?: number | string | null;
+  }> = [
+    { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 7, nextResetTime: SESSION_RESET },
+    { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 84, nextResetTime: WEEKLY_RESET },
+    { type: "TIME_LIMIT", unit: 5, number: 1, percentage: 6, nextResetTime: WEEKLY_RESET + 1 },
+  ],
+  level = "max",
+) {
+  return { code: 200, success: true, data: { limits, level } };
+}
+
+function createProvider(
+  options: {
+    env?: NodeJS.ProcessEnv;
+    fetch?: typeof fetch;
+    providerConfigs?: ProviderUsageAgentProviderConfigs;
+  } = {},
+) {
+  return new ZaiQuotaProvider({
+    logger: createLogger(),
+    env: options.env ?? {},
+    fetch: options.fetch,
+    getAgentProviderConfigs: () => options.providerConfigs ?? {},
+  });
+}
+
+describe("ZaiQuotaProvider", () => {
+  it("returns unavailable without a supported credential", async () => {
+    const fetchApi = vi.fn();
+
+    await expect(
+      createProvider({ fetch: fetchApi as unknown as typeof fetch }).fetchUsage(),
+    ).resolves.toMatchObject({ status: "unavailable", windows: [] });
+    expect(fetchApi).not.toHaveBeenCalled();
+  });
+
+  it("maps Z.ai monitor windows by declared duration and preserves subscription metadata", async () => {
+    const fetchApi = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.endsWith("/api/monitor/usage/quota/limit")) {
+        expect(init?.headers).toMatchObject({ Authorization: "zai-token" });
+        return jsonResponse(
+          monitorResponse([
+            {
+              type: "TOKENS_LIMIT",
+              unit: 6,
+              number: 1,
+              percentage: 84,
+              nextResetTime: SESSION_RESET,
+            },
+            {
+              type: "TIME_LIMIT",
+              unit: 5,
+              number: 1,
+              percentage: 6,
+              nextResetTime: WEEKLY_RESET + 1,
+            },
+            {
+              type: "TOKENS_LIMIT",
+              unit: 3,
+              number: 5,
+              percentage: 7,
+              nextResetTime: WEEKLY_RESET,
+            },
+          ]),
+        );
+      }
+      if (url.endsWith("/api/biz/subscription/list")) {
+        expect(init?.headers).toMatchObject({ Authorization: "Bearer zai-token" });
+        return jsonResponse({
+          data: [
+            {
+              productName: "GLM Coding Max",
+              status: "VALID",
+              purchaseTime: "2026-01-12 16:55:13",
+              valid: "2026-02-12 16:55:13-2026-03-12 16:55:13",
+            },
+          ],
+        });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createProvider({ env: { ZAI_API_KEY: "zai-token" }, fetch: fetchApi }).fetchUsage(),
+    ).resolves.toMatchObject({
+      status: "available",
+      planLabel: "GLM Coding Max",
+      windows: [
+        {
+          id: "session",
+          label: "Session (5h)",
+          usedPct: 7,
+          remainingPct: 93,
+          resetsAt: new Date(WEEKLY_RESET).toISOString(),
+          tone: "ok",
+        },
+        {
+          id: "weekly",
+          label: "Weekly (7d)",
+          usedPct: 84,
+          remainingPct: 16,
+          resetsAt: new Date(SESSION_RESET).toISOString(),
+          tone: "warning",
+        },
+        {
+          id: "monthly-tools",
+          label: "MCP tools (monthly)",
+          usedPct: 6,
+          remainingPct: 94,
+          resetsAt: new Date(WEEKLY_RESET + 1).toISOString(),
+          tone: "ok",
+        },
+      ],
+      details: expect.arrayContaining([{ id: "status", label: "Status", value: "VALID" }]),
+    });
+  });
+
+  it("uses the GLM China endpoint with a bare GLM_API_KEY", async () => {
+    const fetchApi = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://open.bigmodel.cn/api/monitor/usage/quota/limit");
+      expect(init?.headers).toMatchObject({ Authorization: "glm-token" });
+      return jsonResponse(
+        monitorResponse([
+          {
+            type: "TOKENS_LIMIT",
+            unit: "3",
+            number: "5",
+            percentage: "0",
+            nextResetTime: String(SESSION_RESET),
+          },
+        ]),
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createProvider({ env: { GLM_API_KEY: "glm-token" }, fetch: fetchApi }).fetchUsage(),
+    ).resolves.toMatchObject({
+      status: "available",
+      planLabel: "max",
+      windows: [{ id: "session", usedPct: 0, remainingPct: 100, tone: "ok" }],
+    });
+    expect(fetchApi).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["https://api.z.ai/api/anthropic", "https://api.z.ai"],
+    ["https://open.bigmodel.cn/api/anthropic", "https://open.bigmodel.cn"],
+  ])("reads the credential from a custom provider configured for %s", async (baseUrl, origin) => {
+    const fetchApi = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe(`${origin}/api/monitor/usage/quota/limit`);
+      expect(init?.headers).toMatchObject({ Authorization: "custom-token" });
+      return jsonResponse(monitorResponse([], "Coding Plan"));
+    }) as unknown as typeof fetch;
+
+    const result = await createProvider({
+      fetch: fetchApi,
+      providerConfigs: {
+        "my-glm": {
+          env: {
+            ANTHROPIC_AUTH_TOKEN: "custom-token",
+            ANTHROPIC_BASE_URL: baseUrl,
+          },
+        },
+      },
+    }).fetchUsage();
+
+    expect(result).toMatchObject({ status: "available", planLabel: "Coding Plan" });
+  });
+
+  it("ignores unrelated custom-provider credentials", async () => {
+    const fetchApi = vi.fn();
+    const result = await createProvider({
+      fetch: fetchApi as unknown as typeof fetch,
+      providerConfigs: {
+        proxy: {
+          env: {
+            ANTHROPIC_AUTH_TOKEN: "secret",
+            ANTHROPIC_BASE_URL: "https://proxy.example.com/v1",
+          },
+        },
+      },
+    }).fetchUsage();
+
+    expect(result.status).toBe("unavailable");
+    expect(fetchApi).not.toHaveBeenCalled();
+  });
+
+  it("returns unavailable when the monitor endpoint rejects the credential", async () => {
+    const fetchApi = vi.fn(async () => jsonResponse({ error: "unauthorized" }, 401));
+
+    await expect(
+      createProvider({ env: { GLM_API_KEY: "bad-token" }, fetch: fetchApi }).fetchUsage(),
+    ).resolves.toMatchObject({ status: "unavailable", windows: [] });
+  });
+
+  it("returns unavailable when the monitor API rejects the credential in a 200 response", async () => {
+    const fetchApi = vi.fn(async () =>
+      jsonResponse({ code: 401, success: false, message: "unauthorized" }),
+    );
+
+    await expect(
+      createProvider({ env: { GLM_API_KEY: "bad-token" }, fetch: fetchApi }).fetchUsage(),
+    ).resolves.toMatchObject({ status: "unavailable", windows: [] });
+  });
+
+  it("preserves null percentages and reset timestamps", async () => {
+    const fetchApi = vi.fn(async () =>
+      jsonResponse(
+        monitorResponse([
+          {
+            type: "TOKENS_LIMIT",
+            unit: 3,
+            number: 5,
+            percentage: null,
+            nextResetTime: null,
+          },
+        ]),
+      ),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      createProvider({ env: { GLM_API_KEY: "glm-token" }, fetch: fetchApi }).fetchUsage(),
+    ).resolves.toMatchObject({
+      status: "available",
+      windows: [{ id: "session", usedPct: null, remainingPct: null, resetsAt: null }],
+    });
+  });
+
+  it("keeps quota available when optional subscription metadata fails", async () => {
+    const fetchApi = vi.fn(async (input: RequestInfo | URL) => {
+      if (input.toString().endsWith("/api/monitor/usage/quota/limit")) {
+        return jsonResponse(
+          monitorResponse(
+            [
+              {
+                type: "TOKENS_LIMIT",
+                unit: 3,
+                number: 5,
+                percentage: 100,
+                nextResetTime: SESSION_RESET,
+              },
+            ],
+            "pro",
+          ),
+        );
+      }
+      throw new TypeError("subscription endpoint unavailable");
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createProvider({ env: { ZAI_API_KEY: "zai-token" }, fetch: fetchApi }).fetchUsage(),
+    ).resolves.toMatchObject({
+      status: "available",
+      planLabel: "pro",
+      windows: [{ usedPct: 100, remainingPct: 0, tone: "danger" }],
+    });
+  });
+
+  it("selects the enabled Z.ai profile with the lowest configured order, not first-match", async () => {
+    let usedToken: string | null = null;
+    const fetchApi = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (input.toString().endsWith("/api/monitor/usage/quota/limit")) {
+        usedToken = (init?.headers as Record<string, string> | undefined)?.Authorization ?? null;
+        return jsonResponse(
+          monitorResponse(
+            [
+              {
+                type: "TOKENS_LIMIT",
+                unit: 3,
+                number: 5,
+                percentage: 7,
+                nextResetTime: SESSION_RESET,
+              },
+            ],
+            "max",
+          ),
+        );
+      }
+      return jsonResponse({ data: [] });
+    }) as unknown as typeof fetch;
+
+    // "work" is listed first but has the higher order; "personal" must win on order.
+    await createProvider({
+      fetch: fetchApi,
+      providerConfigs: {
+        work: {
+          enabled: true,
+          order: 2,
+          env: {
+            ANTHROPIC_AUTH_TOKEN: "work-token",
+            ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+          },
+        },
+        personal: {
+          enabled: true,
+          order: 1,
+          env: {
+            ANTHROPIC_AUTH_TOKEN: "personal-token",
+            ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+          },
+        },
+      },
+    }).fetchUsage();
+
+    expect(usedToken).toBe("personal-token");
+  });
+
+  it("skips a disabled Z.ai profile even when it has the lowest order", async () => {
+    let usedToken: string | null = null;
+    const fetchApi = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (input.toString().endsWith("/api/monitor/usage/quota/limit")) {
+        usedToken = (init?.headers as Record<string, string> | undefined)?.Authorization ?? null;
+        return jsonResponse(
+          monitorResponse(
+            [
+              {
+                type: "TOKENS_LIMIT",
+                unit: 3,
+                number: 5,
+                percentage: 7,
+                nextResetTime: SESSION_RESET,
+              },
+            ],
+            "max",
+          ),
+        );
+      }
+      return jsonResponse({ data: [] });
+    }) as unknown as typeof fetch;
+
+    await createProvider({
+      fetch: fetchApi,
+      providerConfigs: {
+        disabled: {
+          enabled: false,
+          order: 0,
+          env: {
+            ANTHROPIC_AUTH_TOKEN: "disabled-token",
+            ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+          },
+        },
+        enabled: {
+          enabled: true,
+          order: 5,
+          env: {
+            ANTHROPIC_AUTH_TOKEN: "enabled-token",
+            ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+          },
+        },
+      },
+    }).fetchUsage();
+
+    expect(usedToken).toBe("enabled-token");
+  });
+
+  it("falls back to the monitor plan label when subscription metadata lacks a product name", async () => {
+    const fetchApi = vi.fn(async (input: RequestInfo | URL) => {
+      if (input.toString().endsWith("/api/monitor/usage/quota/limit")) {
+        return jsonResponse(
+          monitorResponse(
+            [
+              {
+                type: "TOKENS_LIMIT",
+                unit: 3,
+                number: 5,
+                percentage: 7,
+                nextResetTime: SESSION_RESET,
+              },
+            ],
+            "max",
+          ),
+        );
+      }
+      return jsonResponse({ data: [{ status: "VALID" }] });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createProvider({ env: { ZAI_API_KEY: "zai-token" }, fetch: fetchApi }).fetchUsage(),
+    ).resolves.toMatchObject({ status: "available", planLabel: "max" });
+  });
+
+  it("does not block when the optional subscription endpoint hangs beyond its timeout", async () => {
+    const fetchApi = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.endsWith("/api/monitor/usage/quota/limit")) {
+        return jsonResponse(
+          monitorResponse(
+            [
+              {
+                type: "TOKENS_LIMIT",
+                unit: 3,
+                number: 5,
+                percentage: 7,
+                nextResetTime: SESSION_RESET,
+              },
+            ],
+            "max",
+          ),
+        );
+      }
+      // Never resolves on its own; only the subscription AbortSignal timeout can end it.
+      return new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("subscription hung")));
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await createProvider({
+      env: { ZAI_API_KEY: "zai-token" },
+      fetch: fetchApi,
+    }).fetchUsage();
+
+    // Monitor-derived quota is returned even though the subscription never completed.
+    expect(result).toMatchObject({ status: "available", planLabel: "max" });
+  }, 15_000);
+});

--- a/packages/server/src/services/quota-fetcher/providers/zai.ts
+++ b/packages/server/src/services/quota-fetcher/providers/zai.ts
@@ -1,8 +1,58 @@
 import type { Logger } from "pino";
 import { z } from "zod";
-import type { ProviderUsage, ProviderUsageDetail } from "../../../server/messages.js";
-import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
-import { ApiOptionalStringSchema, fetchProviderApi, unavailableUsage } from "../usage.js";
+import type {
+  ProviderUsage,
+  ProviderUsageDetail,
+  ProviderUsageWindow,
+} from "../../../server/messages.js";
+import type {
+  ProviderApiFetch,
+  ProviderUsageAgentProviderConfigs,
+  ProviderUsageFetcher,
+} from "../provider.js";
+import {
+  ApiNullableNumberSchema,
+  ApiNumberSchema,
+  ApiOptionalStringSchema,
+  fetchProviderApi,
+  toneFromUsedPct,
+  toIsoStringOrNull,
+  unavailableUsage,
+  windowFromUsedPct,
+} from "../usage.js";
+
+const ZAI_ORIGIN = "https://api.z.ai";
+const GLM_CN_ORIGIN = "https://open.bigmodel.cn";
+const MONITOR_PATH = "/api/monitor/usage/quota/limit";
+const SUBSCRIPTION_PATH = "/api/biz/subscription/list";
+/**
+ * Optional subscription metadata (plan name / validity) is fetched in parallel with the
+ * authoritative monitor call and is given a tighter timeout than the monitor request so
+ * a slow or failing metadata endpoint can never delay the otherwise-complete quota
+ * result. When it times out or fails we degrade to monitor-only data.
+ */
+const ZAI_SUBSCRIPTION_TIMEOUT_MS = 4_000;
+
+const ZaiMonitorResponseSchema = z.object({
+  code: ApiNullableNumberSchema.optional(),
+  success: z.boolean().optional(),
+  data: z
+    .object({
+      level: ApiOptionalStringSchema,
+      limits: z
+        .array(
+          z.object({
+            type: z.string(),
+            unit: ApiNumberSchema.optional(),
+            number: ApiNumberSchema.optional(),
+            percentage: ApiNullableNumberSchema.optional(),
+            nextResetTime: ApiNullableNumberSchema.optional(),
+          }),
+        )
+        .default([]),
+    })
+    .optional(),
+});
 
 const ZaiUsageResponseSchema = z.object({
   data: z
@@ -17,9 +67,118 @@ const ZaiUsageResponseSchema = z.object({
     .optional(),
 });
 
+type ZaiSubscription = NonNullable<z.infer<typeof ZaiUsageResponseSchema>["data"]>[number];
+type ZaiQuotaLimit = NonNullable<
+  z.infer<typeof ZaiMonitorResponseSchema>["data"]
+>["limits"][number];
+
 interface ZaiQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+  env?: NodeJS.ProcessEnv;
+  getAgentProviderConfigs?: () => ProviderUsageAgentProviderConfigs;
+}
+
+interface ZaiCredential {
+  token: string;
+  origin: string;
+}
+
+function resolveZaiOrigin(baseUrl: string | undefined): string | null {
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    if (url.hostname === "api.z.ai") return ZAI_ORIGIN;
+    if (url.hostname === "open.bigmodel.cn") return GLM_CN_ORIGIN;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function resolveZaiCredential(
+  env: NodeJS.ProcessEnv,
+  providerConfigs: ProviderUsageAgentProviderConfigs,
+): ZaiCredential | null {
+  const zaiToken = env["ZAI_API_KEY"]?.trim();
+  if (zaiToken) return { token: zaiToken, origin: ZAI_ORIGIN };
+
+  const glmToken = env["GLM_API_KEY"]?.trim();
+  if (glmToken) return { token: glmToken, origin: GLM_CN_ORIGIN };
+
+  // Persisted agent-provider profiles are only consulted after env vars. Selection is
+  // bound to provider identity (a Z.ai / GLM China base URL) and the profile's enabled
+  // state: a disabled profile (enabled === false) is skipped, and when several enabled
+  // profiles target Z.ai the lowest configured `order` wins so we surface the user's
+  // primary account rather than whichever entry happens to iterate first.
+  const ranked = Object.entries(providerConfigs)
+    .filter(([, provider]) => provider?.enabled !== false)
+    .flatMap(([id, provider]) => {
+      const providerEnv = provider?.env;
+      const origin = resolveZaiOrigin(providerEnv?.["ANTHROPIC_BASE_URL"]);
+      const token =
+        providerEnv?.["ANTHROPIC_AUTH_TOKEN"]?.trim() ||
+        providerEnv?.["ANTHROPIC_API_KEY"]?.trim();
+      // Only profiles that resolve to a Z.ai/GLM identity and carry a token are candidates.
+      if (!origin || !token) return [];
+      return [{ id, origin, token, order: provider?.order }];
+    })
+    .sort((a, b) => compareByOrderThenId(a.order, b.order, a.id, b.id));
+
+  const selected = ranked[0];
+  return selected ? { token: selected.token, origin: selected.origin } : null;
+}
+
+/** Lowest order wins (undefined sorts last), then profile id for a stable tiebreak. */
+function compareByOrderThenId(
+  orderA: number | undefined,
+  orderB: number | undefined,
+  idA: string,
+  idB: string,
+): number {
+  const left = orderA ?? Number.POSITIVE_INFINITY;
+  const right = orderB ?? Number.POSITIVE_INFINITY;
+  if (left !== right) return left < right ? -1 : 1;
+  return idA < idB ? -1 : idA > idB ? 1 : 0;
+}
+
+function toUsageWindows(limits: ZaiQuotaLimit[]): ProviderUsageWindow[] {
+  const windowDefinitions = [
+    {
+      id: "session",
+      label: "Session (5h)",
+      find: (limit: ZaiQuotaLimit) =>
+        limit.type === "TOKENS_LIMIT" && limit.unit === 3 && limit.number === 5,
+    },
+    {
+      id: "weekly",
+      label: "Weekly (7d)",
+      find: (limit: ZaiQuotaLimit) =>
+        limit.type === "TOKENS_LIMIT" && limit.unit === 6 && limit.number === 1,
+    },
+    {
+      id: "monthly-tools",
+      label: "MCP tools (monthly)",
+      find: (limit: ZaiQuotaLimit) =>
+        limit.type === "TIME_LIMIT" && limit.unit === 5 && limit.number === 1,
+    },
+  ] as const;
+
+  return windowDefinitions.flatMap((definition) => {
+    const limit = limits.find(definition.find);
+    if (!limit) return [];
+
+    const usedPct = limit.percentage;
+    return [
+      windowFromUsedPct({
+        id: definition.id,
+        label: definition.label,
+        utilizationPct: usedPct,
+        resetsAt: limit.nextResetTime == null ? null : toIsoStringOrNull(limit.nextResetTime),
+        tone: toneFromUsedPct(usedPct),
+      }),
+    ];
+  });
 }
 
 export class ZaiQuotaProvider implements ProviderUsageFetcher {
@@ -28,40 +187,90 @@ export class ZaiQuotaProvider implements ProviderUsageFetcher {
 
   private readonly logger: Logger;
   private readonly fetchApi: ProviderApiFetch;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly getAgentProviderConfigs: () => ProviderUsageAgentProviderConfigs;
 
   constructor(options: ZaiQuotaProviderOptions) {
     this.logger = options.logger;
     this.fetchApi = options.fetch ?? fetch;
+    this.env = options.env ?? process.env;
+    this.getAgentProviderConfigs = options.getAgentProviderConfigs ?? (() => ({}));
+  }
+
+  private async fetchSubscription(credential: ZaiCredential): Promise<ZaiSubscription | undefined> {
+    if (credential.origin !== ZAI_ORIGIN) return undefined;
+
+    try {
+      const response = await fetchProviderApi(
+        this.fetchApi,
+        `${credential.origin}${SUBSCRIPTION_PATH}`,
+        {
+          // Tighter than the monitor timeout: this is optional metadata, and a slow/hung
+          // endpoint must not hold back the quota result that the monitor already gave us.
+          signal: AbortSignal.timeout(ZAI_SUBSCRIPTION_TIMEOUT_MS),
+          headers: {
+            Authorization: `Bearer ${credential.token}`,
+            Accept: "application/json",
+          },
+        },
+      );
+      if (response.ok) {
+        return ZaiUsageResponseSchema.parse(await response.json()).data?.[0];
+      }
+      this.logger.debug({ status: response.status }, "Z.ai subscription metadata fetch failed");
+    } catch (error) {
+      this.logger.debug({ err: error }, "Z.ai subscription metadata fetch failed");
+    }
+    return undefined;
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
-    const token = process.env["ZAI_API_KEY"] || process.env["GLM_API_KEY"];
-    if (!token) return unavailableUsage(this);
+    const credential = resolveZaiCredential(this.env, this.getAgentProviderConfigs());
+    if (!credential) return unavailableUsage(this);
 
-    const res = await fetchProviderApi(
+    // The monitor call is authoritative for availability; the subscription call only adds
+    // optional metadata. Run them concurrently so the optional metadata cannot delay the
+    // monitor-derived quota. fetchSubscription never rejects and is timeout-bounded, so a
+    // metadata failure or hang degrades to monitor-only data instead of blocking the result.
+    const subscriptionPromise = this.fetchSubscription(credential);
+
+    const monitorRes = await fetchProviderApi(
       this.fetchApi,
-      "https://api.z.ai/api/biz/subscription/list",
+      `${credential.origin}${MONITOR_PATH}`,
       {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: credential.token,
           Accept: "application/json",
+          "Content-Type": "application/json",
         },
       },
     );
 
-    if (!res.ok) {
-      this.logger.debug({ status: res.status }, "Z.ai usage fetch failed");
+    if (!monitorRes.ok) {
+      this.logger.debug({ status: monitorRes.status }, "Z.ai quota fetch failed");
+      // The monitor already failed; the optional metadata is useless, so do not wait on it.
+      void subscriptionPromise;
       return unavailableUsage(this);
     }
 
-    const resp = ZaiUsageResponseSchema.parse(await res.json());
-    const sub = resp.data?.[0];
-    if (!sub) return unavailableUsage(this);
+    const monitor = ZaiMonitorResponseSchema.parse(await monitorRes.json());
+    if (
+      monitor.success === false ||
+      (monitor.code != null && monitor.code !== 200) ||
+      !monitor.data
+    ) {
+      this.logger.debug({ code: monitor.code }, "Z.ai quota API rejected request");
+      void subscriptionPromise;
+      return unavailableUsage(this);
+    }
+    const windows = toUsageWindows(monitor.data?.limits ?? []);
+
+    const sub = await subscriptionPromise;
 
     const details: ProviderUsageDetail[] = [];
-    if (sub.status) details.push({ id: "status", label: "Status", value: sub.status });
-    if (sub.valid) details.push({ id: "valid", label: "Valid", value: sub.valid });
-    if (sub.purchaseTime) {
+    if (sub?.status) details.push({ id: "status", label: "Status", value: sub.status });
+    if (sub?.valid) details.push({ id: "valid", label: "Valid", value: sub.valid });
+    if (sub?.purchaseTime) {
       details.push({ id: "purchase_time", label: "Purchased", value: sub.purchaseTime });
     }
 
@@ -69,8 +278,8 @@ export class ZaiQuotaProvider implements ProviderUsageFetcher {
       providerId: this.providerId,
       displayName: this.displayName,
       status: "available",
-      planLabel: sub.productName || null,
-      windows: [],
+      planLabel: sub?.productName || monitor.data?.level || "Coding Plan",
+      windows,
       balances: [],
       details,
       error: null,

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -698,6 +698,33 @@ describe("real provider usage fetchers", () => {
     fetchApi = mockFetch(
       new Map([
         [
+          "https://api.z.ai/api/monitor/usage/quota/limit",
+          () =>
+            jsonResponse({
+              code: 200,
+              success: true,
+              data: {
+                level: "max",
+                limits: [
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 3,
+                    number: 5,
+                    percentage: 7,
+                    nextResetTime: 1_782_960_937_355,
+                  },
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 6,
+                    number: 1,
+                    percentage: 84,
+                    nextResetTime: 1_783_303_263_991,
+                  },
+                ],
+              },
+            }),
+        ],
+        [
           "https://api.z.ai/api/biz/subscription/list",
           () =>
             jsonResponse({
@@ -719,6 +746,10 @@ describe("real provider usage fetchers", () => {
     expect(zai).toMatchObject({
       status: "available",
       planLabel: "GLM Coding Max",
+      windows: [
+        expect.objectContaining({ id: "session", usedPct: 7, remainingPct: 93 }),
+        expect.objectContaining({ id: "weekly", usedPct: 84, remainingPct: 16 }),
+      ],
       details: expect.arrayContaining([{ id: "status", label: "Status", value: "VALID" }]),
     });
   });

--- a/packages/server/src/services/quota-fetcher/service.ts
+++ b/packages/server/src/services/quota-fetcher/service.ts
@@ -1,13 +1,18 @@
 import type { Logger } from "pino";
 import type { ProviderUsage } from "../../server/messages.js";
 import { createProviderUsageFetchers } from "./manifest.js";
-import type { ProviderApiFetch, ProviderUsageFetcher } from "./provider.js";
+import type {
+  ProviderApiFetch,
+  ProviderUsageAgentProviderConfigs,
+  ProviderUsageFetcher,
+} from "./provider.js";
 import { unavailableUsage } from "./usage.js";
 
 export interface ProviderUsageServiceOptions {
   logger: Logger;
   fetchers?: ProviderUsageFetcher[];
   fetch?: ProviderApiFetch;
+  getAgentProviderConfigs?: () => ProviderUsageAgentProviderConfigs;
   cacheTtlMs?: number;
   now?: () => number;
 }
@@ -34,6 +39,7 @@ export class ProviderUsageService {
       createProviderUsageFetchers({
         logger: this.logger,
         fetch: options.fetch,
+        getAgentProviderConfigs: options.getAgentProviderConfigs,
       });
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_PROVIDER_USAGE_CACHE_TTL_MS;
     this.now = options.now ?? Date.now;


### PR DESCRIPTION
Closes #2440.

## Summary

- Resolve Z.ai / GLM credentials from documented custom-provider configuration when daemon-level `ZAI_API_KEY` or `GLM_API_KEY` is absent.
- Read 5-hour, weekly, and monthly MCP quota windows from `/api/monitor/usage/quota/limit` for both `api.z.ai` and `open.bigmodel.cn`.
- Keep the existing Z.ai subscription metadata when available, while treating it as optional so quota remains visible if that endpoint fails.

## Safety and compatibility

- Custom-provider credentials are only used when `ANTHROPIC_BASE_URL` has an exact supported hostname; unrelated provider tokens are ignored.
- Monitor requests use the API's raw-token authorization format, tokens are never logged, and no protocol schema changes are required.
- API-level error envelopes and nullable quota fields are handled explicitly.

## Validation

- `npx vitest run --bail=1 packages/server/src/services/quota-fetcher/providers/zai.test.ts packages/server/src/services/quota-fetcher/service.test.ts` — 65 tests passed.
- `npm run build --workspace=@getpaseo/server` — passed.
- `npm run typecheck` — all workspaces passed.
- Pre-commit lint and format checks — passed.
- Live check against a GLM China Coding Plan returned the expected 5-hour, weekly, and monthly MCP windows. Credential and raw response data were not printed.

Tested on Linux. The app UI and wire protocol are unchanged, so there is no platform-specific client behavior in this patch.
