### PR TITLE
feat: hide unused usage providers

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -199,6 +199,7 @@ snapshot so a mixed edit can apply its live subset and still name the paths that
     hostnames: true | string[],   // legacy alias `allowedHosts` is migrated on load
     trustedProxies: true | string[], // defaults to ["loopback"]; Express proxy names/CIDRs
     mcp: { enabled: boolean, injectIntoAgents: boolean },
+    providerUsage: { hiddenProviders: string[] }, // host-scoped provider cards hidden from Usage
     git: { maxProcessesPerSecond: number, maxProcessConcurrency: number },
     appendSystemPrompt: string,    // appended to supported provider system/developer prompts
     terminalProfiles: TerminalProfile[],  // named shell commands; omitted means DEFAULT_TERMINAL_PROFILES
@@ -313,6 +314,10 @@ session is created, resumed, imported, or reloaded, so configuration changes aff
 session rather than an already-running one.
 
 `agents.metadataGeneration.providers` controls the preferred structured-generation fallback order for daemon-side metadata tasks such as commit messages, PR text, branch names, and generated agent titles. Entries are tried first in the configured order, then Paseo falls through to dynamically discovered defaults and finally the current selection when available.
+
+`daemon.providerUsage.hiddenProviders` stores provider IDs hidden from that host's Usage page. An
+empty or missing list shows every provider. This preference does not hide the active provider from
+the context-window tooltip.
 
 ### Git process limits
 

--- a/packages/app/e2e/browser/provider-usage-settings.spec.ts
+++ b/packages/app/e2e/browser/provider-usage-settings.spec.ts
@@ -1,8 +1,18 @@
 import { expect, test } from "../support/fixtures";
 import { gotoAppShell, openSettings } from "../support/helpers/app";
 import { installProviderUsageFixture } from "../support/helpers/provider-usage";
+import { connectDaemonClient } from "../support/helpers/daemon-client-loader";
 import { getServerId } from "../support/helpers/server-id";
 import { openSettingsHostSection } from "../support/helpers/settings";
+
+interface ProviderUsageConfigClient {
+  connect(): Promise<void>;
+  close(): Promise<void>;
+  getDaemonConfig(): Promise<{
+    config: { providerUsage: { hiddenProviders: string[] } };
+  }>;
+  patchDaemonConfig(config: { providerUsage: { hiddenProviders: string[] } }): Promise<unknown>;
+}
 
 test.describe("provider usage settings", () => {
   test("renders every provider returned by the daemon usage RPC", async ({ page }) => {
@@ -110,6 +120,69 @@ test.describe("provider usage settings", () => {
 
     expect(usageFixture.requestCount()).toBe(2);
     await expect(page.getByText("64%")).toBeVisible();
+  });
+
+  test("hides and restores provider cards from the shown-provider switches", async ({ page }) => {
+    test.setTimeout(120_000);
+    const serverId = getServerId();
+    const client = await connectDaemonClient<ProviderUsageConfigClient>({
+      clientIdPrefix: "provider-usage-visibility-e2e",
+    });
+    const previousConfig = await client.getDaemonConfig();
+    await client.patchDaemonConfig({ providerUsage: { hiddenProviders: [] } });
+    await installProviderUsageFixture(page, [
+      {
+        fetchedAt: "2026-06-19T00:00:00.000Z",
+        providers: [
+          {
+            providerId: "claude",
+            displayName: "Claude",
+            status: "available",
+            planLabel: "Max 20x",
+            windows: [{ id: "session", label: "Session", usedPct: 7 }],
+          },
+          {
+            providerId: "copilot",
+            displayName: "GitHub Copilot",
+            status: "available",
+            planLabel: "Pro",
+            windows: [{ id: "monthly", label: "Monthly", usedPct: 20 }],
+          },
+        ],
+      },
+    ]);
+
+    try {
+      await gotoAppShell(page);
+      await openSettings(page);
+      await openSettingsHostSection(page, serverId, "usage");
+
+      const usageCard = page.getByTestId("provider-usage-card");
+      const visibilityCard = page.getByTestId("provider-usage-visibility-card");
+      await expect(usageCard.getByText("GitHub Copilot", { exact: true })).toBeVisible();
+      await expect(visibilityCard).toBeVisible();
+
+      const copilotSwitch = page.getByRole("switch", { name: "Show GitHub Copilot" });
+      await expect(copilotSwitch).toBeChecked();
+      await copilotSwitch.click();
+
+      await expect(usageCard.getByText("GitHub Copilot", { exact: true })).toHaveCount(0);
+      await expect(copilotSwitch).not.toBeChecked();
+      await expect
+        .poll(async () => (await client.getDaemonConfig()).config.providerUsage.hiddenProviders)
+        .toEqual(["copilot"]);
+
+      await copilotSwitch.click();
+      await expect(usageCard.getByText("GitHub Copilot", { exact: true })).toBeVisible();
+      await expect(copilotSwitch).toBeChecked();
+    } finally {
+      await client
+        .patchDaemonConfig({
+          providerUsage: previousConfig.config.providerUsage,
+        })
+        .catch(() => undefined);
+      await client.close().catch(() => undefined);
+    }
   });
 
   test("one provider error does not collapse the usage list", async ({ page }) => {

--- a/packages/app/e2e/support/helpers/provider-usage.ts
+++ b/packages/app/e2e/support/helpers/provider-usage.ts
@@ -69,6 +69,7 @@ function withProviderUsageFeature(message: WebSocketMessage): string | null {
             ? payload.features
             : {}),
           providerUsageList: true,
+          providerUsageVisibility: true,
         },
       },
     },

--- a/packages/app/src/provider-usage/copy.ts
+++ b/packages/app/src/provider-usage/copy.ts
@@ -1,8 +1,5 @@
-// User-facing copy for the provider-usage surfaces, centralized so localization
-// is a single-file change. INTEGRATION: move these into the i18n resources
-// (a `providerUsage` namespace across all locales) and swap to `t(...)` at the
-// call sites once the feature is wired to data. Kept inline for now because the
-// surfaces are not yet mounted and the locale files are being edited elsewhere.
+// User-facing copy for the provider-usage surfaces, centralized until this
+// feature area moves into the shared i18n resources.
 export const providerUsageCopy = {
   title: "Plan usage",
   refresh: "Refresh",
@@ -15,4 +12,8 @@ export const providerUsageCopy = {
   clientUnavailable: "Host connection is not ready",
   retry: "Try again",
   tooltipLoading: "Loading plan usage…",
+  shownProvidersTitle: "Shown providers",
+  allHidden: "All providers are hidden",
+  updateVisibilityError: "Unable to update shown providers",
+  showProvider: (provider: string) => `Show ${provider}`,
 } as const;

--- a/packages/app/src/provider-usage/settings-section.tsx
+++ b/packages/app/src/provider-usage/settings-section.tsx
@@ -9,13 +9,16 @@ import { SettingsSection } from "@/screens/settings/settings-section";
 import { providerUsageCopy } from "./copy";
 import { ProviderUsageList } from "./list";
 import type { ProviderUsageView } from "./types";
+import { filterVisibleProviders } from "./visibility";
 
 export function ProviderUsageSettingsSection({
   view,
   onRefresh,
+  hiddenProviderIds = [],
 }: {
   view: ProviderUsageView;
   onRefresh: () => void;
+  hiddenProviderIds?: readonly string[];
 }) {
   const busy = view.kind === "loading" || (view.kind === "ready" && view.isRefreshing);
 
@@ -41,7 +44,7 @@ export function ProviderUsageSettingsSection({
       testID="provider-usage-card"
       trailing={refreshButton}
     >
-      <ProviderUsageBody view={view} onRefresh={onRefresh} />
+      <ProviderUsageBody view={view} onRefresh={onRefresh} hiddenProviderIds={hiddenProviderIds} />
     </SettingsSection>
   );
 }
@@ -49,9 +52,11 @@ export function ProviderUsageSettingsSection({
 function ProviderUsageBody({
   view,
   onRefresh,
+  hiddenProviderIds,
 }: {
   view: ProviderUsageView;
   onRefresh: () => void;
+  hiddenProviderIds: readonly string[];
 }) {
   if (view.kind === "loading") {
     return (
@@ -71,15 +76,20 @@ function ProviderUsageBody({
     );
   }
 
-  if (view.payload.providers.length === 0) {
+  const visibleProviders = filterVisibleProviders(view.payload.providers, hiddenProviderIds);
+  if (visibleProviders.length === 0) {
     return (
       <View style={[settingsStyles.card, styles.emptyCard]}>
-        <Text style={styles.emptyText}>{providerUsageCopy.empty}</Text>
+        <Text style={styles.emptyText}>
+          {view.payload.providers.length > 0
+            ? providerUsageCopy.allHidden
+            : providerUsageCopy.empty}
+        </Text>
       </View>
     );
   }
 
-  return <ProviderUsageList providers={view.payload.providers} />;
+  return <ProviderUsageList providers={visibleProviders} />;
 }
 
 const styles = StyleSheet.create((theme) => ({

--- a/packages/app/src/provider-usage/visibility-section.tsx
+++ b/packages/app/src/provider-usage/visibility-section.tsx
@@ -1,0 +1,100 @@
+import { useMutation } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { Text, View } from "react-native";
+import { Alert } from "@/components/ui/alert";
+import { Switch } from "@/components/ui/switch";
+import { SettingsSection } from "@/screens/settings/settings-section";
+import { settingsStyles } from "@/styles/settings";
+import { providerUsageCopy } from "./copy";
+import type { ProviderUsage } from "./types";
+
+interface ProviderUsageVisibilitySectionProps {
+  providers: readonly ProviderUsage[];
+  hiddenProviderIds: readonly string[];
+  isConfigLoading: boolean;
+  onVisibilityChange: (providerId: string, visible: boolean) => Promise<void>;
+}
+
+interface ProviderUsageVisibilityRowProps {
+  provider: ProviderUsage;
+  bordered: boolean;
+  visible: boolean;
+  disabled: boolean;
+  onChange: (input: { providerId: string; visible: boolean }) => void;
+}
+
+function ProviderUsageVisibilityRow({
+  provider,
+  bordered,
+  visible,
+  disabled,
+  onChange,
+}: ProviderUsageVisibilityRowProps) {
+  const handleValueChange = useCallback(
+    (next: boolean) => onChange({ providerId: provider.providerId, visible: next }),
+    [onChange, provider.providerId],
+  );
+
+  return (
+    <View style={[settingsStyles.row, bordered ? settingsStyles.rowBorder : null]}>
+      <Text style={settingsStyles.rowTitle} numberOfLines={1}>
+        {provider.displayName}
+      </Text>
+      <Switch
+        value={visible}
+        onValueChange={handleValueChange}
+        disabled={disabled}
+        accessibilityLabel={providerUsageCopy.showProvider(provider.displayName)}
+        testID={`provider-usage-visibility-${provider.providerId}`}
+      />
+    </View>
+  );
+}
+
+export function ProviderUsageVisibilitySection({
+  providers,
+  hiddenProviderIds,
+  isConfigLoading,
+  onVisibilityChange,
+}: ProviderUsageVisibilitySectionProps) {
+  const mutation = useMutation({
+    mutationFn: async (input: { providerId: string; visible: boolean }) => {
+      await onVisibilityChange(input.providerId, input.visible);
+    },
+  });
+  const hiddenProviders = new Set(hiddenProviderIds);
+
+  if (providers.length === 0) return null;
+
+  return (
+    <SettingsSection
+      title={providerUsageCopy.shownProvidersTitle}
+      testID="provider-usage-visibility-card"
+    >
+      <View style={settingsStyles.card}>
+        {providers.map((provider, index) => {
+          const visible = !hiddenProviders.has(provider.providerId);
+          return (
+            <ProviderUsageVisibilityRow
+              key={provider.providerId}
+              provider={provider}
+              bordered={index > 0}
+              visible={visible}
+              disabled={isConfigLoading || mutation.isPending}
+              onChange={mutation.mutate}
+            />
+          );
+        })}
+      </View>
+      {mutation.error ? (
+        <Alert
+          variant="error"
+          title={providerUsageCopy.updateVisibilityError}
+          description={
+            mutation.error instanceof Error ? mutation.error.message : String(mutation.error)
+          }
+        />
+      ) : null}
+    </SettingsSection>
+  );
+}

--- a/packages/app/src/provider-usage/visibility.test.ts
+++ b/packages/app/src/provider-usage/visibility.test.ts
@@ -32,22 +32,14 @@ describe("provider usage visibility", () => {
     ).toEqual(["claude", "minimax"]);
   });
 
-  it("creates deterministic patches without dropping unknown provider ids", () => {
-    expect(
-      createProviderVisibilityPatch({
-        hiddenProviderIds: ["future-provider"],
-        providerId: "copilot",
-        visible: false,
-      }),
-    ).toEqual({ providerUsage: { hiddenProviders: ["copilot", "future-provider"] } });
+  it("emits single-provider deltas instead of full-array snapshots", () => {
+    expect(createProviderVisibilityPatch({ providerId: "copilot", visible: false })).toEqual({
+      providerUsage: { hideProviders: ["copilot"] },
+    });
 
-    expect(
-      createProviderVisibilityPatch({
-        hiddenProviderIds: ["future-provider", "copilot"],
-        providerId: "copilot",
-        visible: true,
-      }),
-    ).toEqual({ providerUsage: { hiddenProviders: ["future-provider"] } });
+    expect(createProviderVisibilityPatch({ providerId: "copilot", visible: true })).toEqual({
+      providerUsage: { showProviders: ["copilot"] },
+    });
   });
 
   it("deduplicates persisted ids defensively", () => {

--- a/packages/app/src/provider-usage/visibility.test.ts
+++ b/packages/app/src/provider-usage/visibility.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { MutableDaemonConfig } from "@getpaseo/protocol/messages";
+import type { ProviderUsage } from "./types";
+import {
+  createProviderVisibilityPatch,
+  filterVisibleProviders,
+  getHiddenProviderIds,
+} from "./visibility";
+
+function usage(providerId: string): ProviderUsage {
+  return {
+    providerId,
+    displayName: providerId,
+    status: "available",
+    planLabel: null,
+    windows: [],
+  };
+}
+
+describe("provider usage visibility", () => {
+  it("defaults to showing every provider", () => {
+    expect(getHiddenProviderIds(null)).toEqual([]);
+    expect(filterVisibleProviders([usage("claude"), usage("copilot")], [])).toHaveLength(2);
+  });
+
+  it("hides only configured provider ids", () => {
+    expect(
+      filterVisibleProviders(
+        [usage("claude"), usage("copilot"), usage("minimax")],
+        ["copilot", "future-provider"],
+      ).map((provider) => provider.providerId),
+    ).toEqual(["claude", "minimax"]);
+  });
+
+  it("creates deterministic patches without dropping unknown provider ids", () => {
+    expect(
+      createProviderVisibilityPatch({
+        hiddenProviderIds: ["future-provider"],
+        providerId: "copilot",
+        visible: false,
+      }),
+    ).toEqual({ providerUsage: { hiddenProviders: ["copilot", "future-provider"] } });
+
+    expect(
+      createProviderVisibilityPatch({
+        hiddenProviderIds: ["future-provider", "copilot"],
+        providerId: "copilot",
+        visible: true,
+      }),
+    ).toEqual({ providerUsage: { hiddenProviders: ["future-provider"] } });
+  });
+
+  it("deduplicates persisted ids defensively", () => {
+    const config = {
+      providerUsage: { hiddenProviders: ["copilot", "copilot"] },
+    } as MutableDaemonConfig;
+
+    expect(getHiddenProviderIds(config)).toEqual(["copilot"]);
+  });
+});

--- a/packages/app/src/provider-usage/visibility.ts
+++ b/packages/app/src/provider-usage/visibility.ts
@@ -1,0 +1,28 @@
+import type { MutableDaemonConfig, MutableDaemonConfigPatch } from "@getpaseo/protocol/messages";
+import type { ProviderUsage } from "./types";
+
+export function getHiddenProviderIds(config: MutableDaemonConfig | null): string[] {
+  return Array.from(new Set(config?.providerUsage?.hiddenProviders ?? []));
+}
+
+export function createProviderVisibilityPatch(input: {
+  hiddenProviderIds: readonly string[];
+  providerId: string;
+  visible: boolean;
+}): MutableDaemonConfigPatch {
+  const hiddenProviders = new Set(input.hiddenProviderIds);
+  if (input.visible) {
+    hiddenProviders.delete(input.providerId);
+  } else {
+    hiddenProviders.add(input.providerId);
+  }
+  return { providerUsage: { hiddenProviders: Array.from(hiddenProviders).sort() } };
+}
+
+export function filterVisibleProviders(
+  providers: readonly ProviderUsage[],
+  hiddenProviderIds: readonly string[],
+): ProviderUsage[] {
+  const hiddenProviders = new Set(hiddenProviderIds);
+  return providers.filter((provider) => !hiddenProviders.has(provider.providerId));
+}

--- a/packages/app/src/provider-usage/visibility.ts
+++ b/packages/app/src/provider-usage/visibility.ts
@@ -5,18 +5,19 @@ export function getHiddenProviderIds(config: MutableDaemonConfig | null): string
   return Array.from(new Set(config?.providerUsage?.hiddenProviders ?? []));
 }
 
+// Emit a single-provider visibility delta rather than a full-array snapshot. The server merges
+// this against its authoritative hidden-provider set, so a client never has to reason about a
+// stale local snapshot — concurrent clients toggling different providers can no longer silently
+// undo each other (lost update).
 export function createProviderVisibilityPatch(input: {
-  hiddenProviderIds: readonly string[];
   providerId: string;
   visible: boolean;
 }): MutableDaemonConfigPatch {
-  const hiddenProviders = new Set(input.hiddenProviderIds);
-  if (input.visible) {
-    hiddenProviders.delete(input.providerId);
-  } else {
-    hiddenProviders.add(input.providerId);
-  }
-  return { providerUsage: { hiddenProviders: Array.from(hiddenProviders).sort() } };
+  return {
+    providerUsage: input.visible
+      ? { showProviders: [input.providerId] }
+      : { hideProviders: [input.providerId] },
+  };
 }
 
 export function filterVisibleProviders(

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -350,14 +350,12 @@ export function HostUsagePage({ serverId }: { serverId: string }) {
   }, [refreshProviderUsage]);
   const handleVisibilityChange = useCallback(
     async (providerId: string, visible: boolean) => {
-      const result = await patchConfig(
-        createProviderVisibilityPatch({ hiddenProviderIds, providerId, visible }),
-      );
+      const result = await patchConfig(createProviderVisibilityPatch({ providerId, visible }));
       if (!result) {
         throw new Error(providerUsageCopy.clientUnavailable);
       }
     },
-    [hiddenProviderIds, patchConfig],
+    [patchConfig],
   );
 
   if (!host) {

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -58,6 +58,9 @@ import {
 import { ProvidersSection } from "@/screens/settings/providers-section";
 import { ProviderUsageSettingsSection } from "@/provider-usage/settings-section";
 import { useProviderUsage } from "@/provider-usage/use-provider-usage";
+import { providerUsageCopy } from "@/provider-usage/copy";
+import { createProviderVisibilityPatch, getHiddenProviderIds } from "@/provider-usage/visibility";
+import { ProviderUsageVisibilitySection } from "@/provider-usage/visibility-section";
 import { HostAppearanceSection } from "@/screens/settings/host-appearance-section";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { useSessionStore } from "@/stores/session-store";
@@ -331,9 +334,31 @@ export function HostProvidersPage({ serverId }: { serverId: string }) {
 export function HostUsagePage({ serverId }: { serverId: string }) {
   const host = useHostProfile(serverId);
   const { view: providerUsageView, refresh: refreshProviderUsage } = useProviderUsage(serverId);
+  const supportsProviderUsageVisibility = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.providerUsageVisibility === true,
+  );
+  const {
+    config,
+    isLoading: isConfigLoading,
+    patchConfig,
+  } = useDaemonConfig(supportsProviderUsageVisibility ? serverId : null);
+  const hiddenProviderIds = useMemo(() => getHiddenProviderIds(config), [config]);
+  const visibilityProviders =
+    providerUsageView.kind === "ready" ? providerUsageView.payload.providers : [];
   const handleRefresh = useCallback(() => {
     void refreshProviderUsage();
   }, [refreshProviderUsage]);
+  const handleVisibilityChange = useCallback(
+    async (providerId: string, visible: boolean) => {
+      const result = await patchConfig(
+        createProviderVisibilityPatch({ hiddenProviderIds, providerId, visible }),
+      );
+      if (!result) {
+        throw new Error(providerUsageCopy.clientUnavailable);
+      }
+    },
+    [hiddenProviderIds, patchConfig],
+  );
 
   if (!host) {
     return <HostNotFound />;
@@ -341,7 +366,19 @@ export function HostUsagePage({ serverId }: { serverId: string }) {
 
   return (
     <View>
-      <ProviderUsageSettingsSection view={providerUsageView} onRefresh={handleRefresh} />
+      <ProviderUsageSettingsSection
+        view={providerUsageView}
+        onRefresh={handleRefresh}
+        hiddenProviderIds={supportsProviderUsageVisibility ? hiddenProviderIds : []}
+      />
+      {supportsProviderUsageVisibility ? (
+        <ProviderUsageVisibilitySection
+          providers={visibilityProviders}
+          hiddenProviderIds={hiddenProviderIds}
+          isConfigLoading={isConfigLoading}
+          onVisibilityChange={handleVisibilityChange}
+        />
+      ) : null}
     </View>
   );
 }

--- a/packages/protocol/src/messages.browser-automation.test.ts
+++ b/packages/protocol/src/messages.browser-automation.test.ts
@@ -174,5 +174,19 @@ describe("browser automation protocol integration", () => {
         providerUsage: { hiddenProviders: ["copilot", "minimax"] },
       }).providerUsage,
     ).toEqual({ hiddenProviders: ["copilot", "minimax"] });
+
+    // Visibility deltas are merged server-side against the authoritative set so concurrent
+    // clients don't clobber each other; the wire schema keeps them permissive.
+    expect(
+      MutableDaemonConfigPatchSchema.parse({
+        providerUsage: { hideProviders: ["copilot"] },
+      }).providerUsage,
+    ).toEqual({ hideProviders: ["copilot"] });
+
+    expect(
+      MutableDaemonConfigPatchSchema.parse({
+        providerUsage: { showProviders: ["copilot"] },
+      }).providerUsage,
+    ).toEqual({ showProviders: ["copilot"] });
   });
 });

--- a/packages/protocol/src/messages.browser-automation.test.ts
+++ b/packages/protocol/src/messages.browser-automation.test.ts
@@ -157,16 +157,22 @@ describe("browser automation protocol integration", () => {
   });
 
   test("mutable daemon config defaults browser tools off and accepts opt-in patches", () => {
-    expect(
-      MutableDaemonConfigSchema.parse({
-        mcp: { injectIntoAgents: false },
-      }).browserTools,
-    ).toEqual({ enabled: false });
+    const config = MutableDaemonConfigSchema.parse({
+      mcp: { injectIntoAgents: false },
+    });
+    expect(config.browserTools).toEqual({ enabled: false });
+    expect(config.providerUsage).toBeUndefined();
 
     expect(
       MutableDaemonConfigPatchSchema.parse({
         browserTools: { enabled: true },
       }).browserTools,
     ).toEqual({ enabled: true });
+
+    expect(
+      MutableDaemonConfigPatchSchema.parse({
+        providerUsage: { hiddenProviders: ["copilot", "minimax"] },
+      }).providerUsage,
+    ).toEqual({ hiddenProviders: ["copilot", "minimax"] });
   });
 });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -211,6 +211,11 @@ export const AgentSkillSelectionSchema = z.discriminatedUnion("mode", [
 ]);
 export type AgentSkillSelection = z.infer<typeof AgentSkillSelectionSchema>;
 
+const MutableProviderUsageConfigSchema = z
+  .object({
+    hiddenProviders: z.array(z.string().min(1)).default([]),
+  })
+  .passthrough();
 export const MutableDaemonConfigSchema = z
   .object({
     // COMPAT(relayConfig): added in v0.2.6, remove after 2027-01-31 when old daemons are unsupported.
@@ -238,6 +243,8 @@ export const MutableDaemonConfigSchema = z
     app: z.object({ baseUrl: z.string() }).optional(),
     catalogRefreshTimeoutMs: z.number().int().positive().optional(),
     browserTools: MutableBrowserToolsConfigSchema.default({ enabled: false }),
+    // COMPAT(providerUsageVisibility): added in v0.2.5; old daemons omit this object.
+    providerUsage: MutableProviderUsageConfigSchema.optional(),
     providers: z.record(z.string(), MutableDaemonProviderConfigSchema).default({}),
     metadataGeneration: MutableMetadataGenerationConfigSchema.default({ providers: [] }),
     autoArchiveAfterMerge: z.boolean().default(false),
@@ -256,6 +263,7 @@ export const MutableDaemonConfigPatchSchema = z
     relay: MutableRelayConfigSchema.partial().optional(),
     mcp: z.object({ injectIntoAgents: z.boolean().optional() }).passthrough().optional(),
     browserTools: MutableBrowserToolsConfigSchema.partial().optional(),
+    providerUsage: MutableProviderUsageConfigSchema.partial().optional(),
     providers: z
       .record(z.string(), MutableDaemonProviderConfigSchema.partial().passthrough())
       .optional(),
@@ -3478,6 +3486,8 @@ export const ServerInfoStatusPayloadSchema = z
         workspaceFileEditing: z.boolean().optional(),
         // COMPAT(providerUsageList): added in v0.1.98, drop the gate when daemon floor >= v0.1.98.
         providerUsageList: z.boolean().optional(),
+        // COMPAT(providerUsageVisibility): added in v0.2.5, remove after 2027-02-04.
+        providerUsageVisibility: z.boolean().optional(),
         // COMPAT(agentDetach): added in v0.1.98, remove gate after 2026-12-19 once daemon floor >= v0.1.98.
         agentDetach: z.boolean().optional(),
         // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -216,6 +216,17 @@ const MutableProviderUsageConfigSchema = z
     hiddenProviders: z.array(z.string().min(1)).default([]),
   })
   .passthrough();
+// Patch form for provider-usage visibility. `hiddenProviders` is the authoritative
+// full-array replace (kept permissive for back-compat). `hideProviders` / `showProviders`
+// are single-pass deltas that the server merges against its current set, so two clients
+// toggling different providers concurrently can't clobber each other (lost-update fix).
+const MutableProviderUsageConfigPatchSchema = z
+  .object({
+    hiddenProviders: z.array(z.string().min(1)).optional(),
+    hideProviders: z.array(z.string().min(1)).optional(),
+    showProviders: z.array(z.string().min(1)).optional(),
+  })
+  .passthrough();
 export const MutableDaemonConfigSchema = z
   .object({
     // COMPAT(relayConfig): added in v0.2.6, remove after 2027-01-31 when old daemons are unsupported.
@@ -263,7 +274,7 @@ export const MutableDaemonConfigPatchSchema = z
     relay: MutableRelayConfigSchema.partial().optional(),
     mcp: z.object({ injectIntoAgents: z.boolean().optional() }).passthrough().optional(),
     browserTools: MutableBrowserToolsConfigSchema.partial().optional(),
-    providerUsage: MutableProviderUsageConfigSchema.partial().optional(),
+    providerUsage: MutableProviderUsageConfigPatchSchema.optional(),
     providers: z
       .record(z.string(), MutableDaemonProviderConfigSchema.partial().passthrough())
       .optional(),

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -395,6 +395,7 @@ export interface PaseoDaemonConfig {
   mcpEnabled?: boolean;
   mcpInjectIntoAgents?: boolean;
   browserToolsEnabled?: boolean;
+  providerUsageHiddenProviders?: string[];
   git?: {
     maxProcessesPerSecond: number;
     maxProcessConcurrency: number;
@@ -523,6 +524,10 @@ function resolveExpressTrustProxySetting(config: PaseoDaemonConfig): true | stri
   return config.trustedProxies ?? ["loopback"];
 }
 
+function providerUsageConfig(config: PaseoDaemonConfig): MutableDaemonConfig["providerUsage"] {
+  return { hiddenProviders: config.providerUsageHiddenProviders ?? [] };
+}
+
 function createInitialMutableDaemonConfig(config: PaseoDaemonConfig): MutableDaemonConfig {
   const providers = config.providerOverrides ?? {};
 
@@ -541,6 +546,7 @@ function createInitialMutableDaemonConfig(config: PaseoDaemonConfig): MutableDae
       ? { catalogRefreshTimeoutMs: config.providerCatalogRefreshTimeoutMs }
       : {}),
     browserTools: { enabled: config.browserToolsEnabled ?? false },
+    providerUsage: providerUsageConfig(config),
     providers,
     metadataGeneration: {
       providers: config.metadataGeneration?.providers ?? [],

--- a/packages/server/src/server/config-provider-usage.test.ts
+++ b/packages/server/src/server/config-provider-usage.test.ts
@@ -1,0 +1,41 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { loadConfig } from "./config.js";
+
+const roots: string[] = [];
+
+async function createPaseoHome(config: unknown): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "paseo-config-provider-usage-"));
+  roots.push(root);
+  const paseoHome = path.join(root, ".paseo");
+  await mkdir(paseoHome, { recursive: true });
+  await writeFile(path.join(paseoHome, "config.json"), JSON.stringify(config, null, 2));
+  return paseoHome;
+}
+
+describe("daemon provider usage config", () => {
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  test("defaults to showing every provider", async () => {
+    const home = await createPaseoHome({ version: 1 });
+
+    expect(loadConfig(home, { env: {} }).providerUsageHiddenProviders).toEqual([]);
+  });
+
+  test("loads hidden providers from persisted daemon config", async () => {
+    const home = await createPaseoHome({
+      version: 1,
+      daemon: { providerUsage: { hiddenProviders: ["copilot", "minimax"] } },
+    });
+
+    expect(loadConfig(home, { env: {} }).providerUsageHiddenProviders).toEqual([
+      "copilot",
+      "minimax",
+    ]);
+  });
+});

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -519,6 +519,12 @@ function resolveProfileLists(persisted: ReturnType<typeof loadPersistedConfig>) 
   };
 }
 
+function resolveProviderUsageHiddenProviders(
+  persisted: ReturnType<typeof loadPersistedConfig>,
+): string[] {
+  return persisted.daemon?.providerUsage?.hiddenProviders ?? [];
+}
+
 function resolveStaticLoadConfigSettings(
   env: NodeJS.ProcessEnv,
   cli: CliConfigOverrides | undefined,
@@ -529,6 +535,7 @@ function resolveStaticLoadConfigSettings(
     mcpInjectIntoAgents:
       cli?.mcpInjectIntoAgents ?? persisted.daemon?.mcp?.injectIntoAgents ?? false,
     browserToolsEnabled: resolveBrowserToolsEnabled(persisted),
+    providerUsageHiddenProviders: resolveProviderUsageHiddenProviders(persisted),
     autoArchiveAfterMerge: persisted.daemon?.autoArchiveAfterMerge ?? false,
     appendSystemPrompt: resolveAppendSystemPrompt(persisted),
     ...resolveProfileLists(persisted),
@@ -564,6 +571,7 @@ export function resolveConfigFromPersisted(
     mcpEnabled,
     mcpInjectIntoAgents,
     browserToolsEnabled,
+    providerUsageHiddenProviders,
     autoArchiveAfterMerge,
     appendSystemPrompt,
     terminalProfiles,
@@ -607,6 +615,7 @@ export function resolveConfigFromPersisted(
     mcpEnabled,
     mcpInjectIntoAgents,
     browserToolsEnabled,
+    providerUsageHiddenProviders,
     git: resolveGitProcessConfig(env, persisted),
     autoArchiveAfterMerge,
     enableTerminalAgentHooks: persisted.daemon?.enableTerminalAgentHooks ?? false,

--- a/packages/server/src/server/daemon-config-store.test.ts
+++ b/packages/server/src/server/daemon-config-store.test.ts
@@ -705,6 +705,33 @@ describe("DaemonConfigStore", () => {
     expect(persisted.daemon?.browserTools).toEqual({ enabled: true });
   });
 
+  test("patch persists hidden provider usage ids into config.json", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+
+    const store = new DaemonConfigStore(
+      paseoHome,
+      {
+        mcp: { injectIntoAgents: false },
+        browserTools: { enabled: false },
+        providers: {},
+        metadataGeneration: { providers: [] },
+        autoArchiveAfterMerge: false,
+        enableTerminalAgentHooks: false,
+        appendSystemPrompt: "",
+      },
+      undefined,
+    );
+
+    store.patch({ providerUsage: { hiddenProviders: ["copilot", "minimax"] } });
+
+    expect(store.get().providerUsage.hiddenProviders).toEqual(["copilot", "minimax"]);
+    expect(loadPersistedConfig(paseoHome).daemon?.providerUsage?.hiddenProviders).toEqual([
+      "copilot",
+      "minimax",
+    ]);
+  });
+
   test("patch persists provider additional models into config.json", () => {
     const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
     tempDirs.push(paseoHome);

--- a/packages/server/src/server/daemon-config-store.test.ts
+++ b/packages/server/src/server/daemon-config-store.test.ts
@@ -694,6 +694,7 @@ describe("DaemonConfigStore", () => {
         providers: {},
         metadataGeneration: { providers: [] },
         autoArchiveAfterMerge: false,
+        enableTerminalAgentHooks: false,
         appendSystemPrompt: "",
       },
       undefined,
@@ -725,7 +726,7 @@ describe("DaemonConfigStore", () => {
 
     store.patch({ providerUsage: { hiddenProviders: ["copilot", "minimax"] } });
 
-    expect(store.get().providerUsage.hiddenProviders).toEqual(["copilot", "minimax"]);
+    expect(store.get().providerUsage?.hiddenProviders).toEqual(["copilot", "minimax"]);
     expect(loadPersistedConfig(paseoHome).daemon?.providerUsage?.hiddenProviders).toEqual([
       "copilot",
       "minimax",
@@ -792,7 +793,7 @@ describe("DaemonConfigStore", () => {
 
     const next = store.patch({ providerUsage: { showProviders: ["copilot"] } });
 
-    expect(next.providerUsage.hiddenProviders).toEqual([]);
+    expect(next.providerUsage?.hiddenProviders).toEqual([]);
     // The persisted daemon held nothing but the stripped block, so the patch-based store drops
     // the now-empty `daemon` object entirely instead of writing `{}`.
     const rawDaemon = JSON.parse(readFileSync(configPath, "utf-8")).daemon;
@@ -825,11 +826,11 @@ describe("DaemonConfigStore", () => {
     store.patch({ providerUsage: { hideProviders: ["copilot"] } });
     const afterSecond = store.patch({ providerUsage: { hideProviders: ["minimax"] } });
 
-    expect(afterSecond.providerUsage.hiddenProviders).toEqual(["copilot", "minimax"]);
+    expect(afterSecond.providerUsage?.hiddenProviders).toEqual(["copilot", "minimax"]);
 
     // Unhiding one provider removes only that id; the other toggle persists.
     const afterShow = store.patch({ providerUsage: { showProviders: ["copilot"] } });
-    expect(afterShow.providerUsage.hiddenProviders).toEqual(["minimax"]);
+    expect(afterShow.providerUsage?.hiddenProviders).toEqual(["minimax"]);
   });
 
   test("patch persists provider additional models into config.json", () => {
@@ -908,6 +909,7 @@ describe("DaemonConfigStore", () => {
       paseoHome,
       {
         mcp: { injectIntoAgents: false },
+        browserTools: { enabled: false },
         providers: {},
         metadataGeneration: { providers: [] },
         autoArchiveAfterMerge: false,

--- a/packages/server/src/server/daemon-config-store.test.ts
+++ b/packages/server/src/server/daemon-config-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -730,6 +730,106 @@ describe("DaemonConfigStore", () => {
       "copilot",
       "minimax",
     ]);
+  });
+
+  test("does not persist providerUsage when no providers are hidden", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+
+    const store = new DaemonConfigStore(paseoHome, {
+      relay: { enabled: false },
+      mcp: { injectIntoAgents: false },
+      browserTools: { enabled: false },
+      providers: {},
+      metadataGeneration: { providers: [] },
+      autoArchiveAfterMerge: false,
+      enableTerminalAgentHooks: false,
+      appendSystemPrompt: "",
+    });
+
+    // An unrelated patch (no hidden providers) must not pollute config.json with a
+    // `providerUsage` key — otherwise an older daemon whose strict daemon schema does
+    // not know that key would reject the file on rollback.
+    store.patch({ browserTools: { enabled: true } });
+
+    const rawConfigPath = path.join(paseoHome, "config.json");
+    const rawDaemon = JSON.parse(readFileSync(rawConfigPath, "utf-8")).daemon;
+    expect(rawDaemon.providerUsage).toBeUndefined();
+    expect(loadPersistedConfig(paseoHome).daemon?.providerUsage).toBeUndefined();
+  });
+
+  test("drops providerUsage from config.json when every provider is unhidden", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+
+    const configPath = path.join(paseoHome, "config.json");
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          daemon: { providerUsage: { hiddenProviders: ["copilot"] } },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const store = new DaemonConfigStore(
+      paseoHome,
+      {
+        relay: { enabled: false },
+        mcp: { injectIntoAgents: false },
+        browserTools: { enabled: false },
+        providers: {},
+        metadataGeneration: { providers: [] },
+        autoArchiveAfterMerge: false,
+        enableTerminalAgentHooks: false,
+        appendSystemPrompt: "",
+      },
+      undefined,
+    );
+
+    const next = store.patch({ providerUsage: { showProviders: ["copilot"] } });
+
+    expect(next.providerUsage.hiddenProviders).toEqual([]);
+    // The persisted daemon held nothing but the stripped block, so the patch-based store drops
+    // the now-empty `daemon` object entirely instead of writing `{}`.
+    const rawDaemon = JSON.parse(readFileSync(configPath, "utf-8")).daemon;
+    expect(rawDaemon?.providerUsage).toBeUndefined();
+    expect(loadPersistedConfig(paseoHome).daemon?.providerUsage).toBeUndefined();
+  });
+
+  test("merges concurrent visibility deltas without losing providers", () => {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-daemon-config-store-"));
+    tempDirs.push(paseoHome);
+
+    const store = new DaemonConfigStore(
+      paseoHome,
+      {
+        relay: { enabled: false },
+        mcp: { injectIntoAgents: false },
+        browserTools: { enabled: false },
+        providers: {},
+        metadataGeneration: { providers: [] },
+        autoArchiveAfterMerge: false,
+        enableTerminalAgentHooks: false,
+        appendSystemPrompt: "",
+      },
+      undefined,
+    );
+
+    // Two clients toggling different providers from an empty snapshot: a full-array patch
+    // would let the second clobber the first. Deltas are merged server-side against the
+    // authoritative set, so both toggles survive.
+    store.patch({ providerUsage: { hideProviders: ["copilot"] } });
+    const afterSecond = store.patch({ providerUsage: { hideProviders: ["minimax"] } });
+
+    expect(afterSecond.providerUsage.hiddenProviders).toEqual(["copilot", "minimax"]);
+
+    // Unhiding one provider removes only that id; the other toggle persists.
+    const afterShow = store.patch({ providerUsage: { showProviders: ["copilot"] } });
+    expect(afterShow.providerUsage.hiddenProviders).toEqual(["minimax"]);
   });
 
   test("patch persists provider additional models into config.json", () => {

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -29,6 +29,7 @@ interface SupportedMutableConfigPatch {
   terminalProfiles?: MutableDaemonConfig["terminalProfiles"];
   agentProfiles?: MutableDaemonConfig["agentProfiles"];
   skills?: MutableDaemonConfig["skills"];
+  providerUsage?: { hiddenProviders: string[] };
   pluginsEnabled?: boolean;
   plugins?: MutableDaemonConfig["plugins"];
 }
@@ -274,6 +275,9 @@ function pickSupportedPatchFields(patch: MutableDaemonConfigPatch): SupportedMut
       : {}),
     ...(patch.terminalProfiles !== undefined ? { terminalProfiles: patch.terminalProfiles } : {}),
     ...(patch.agentProfiles !== undefined ? { agentProfiles: patch.agentProfiles } : {}),
+    ...(patch.providerUsage?.hiddenProviders !== undefined
+      ? { providerUsage: { hiddenProviders: patch.providerUsage.hiddenProviders } }
+      : {}),
     ...(patch.pluginsEnabled !== undefined ? { pluginsEnabled: patch.pluginsEnabled } : {}),
     ...(patch.plugins !== undefined ? { plugins: patch.plugins } : {}),
   };
@@ -661,5 +665,8 @@ function mergeMutableDaemonPatch(
   if (patch.appendSystemPrompt !== undefined) next.appendSystemPrompt = patch.appendSystemPrompt;
   if (patch.terminalProfiles !== undefined) next.terminalProfiles = patch.terminalProfiles;
   if (patch.agentProfiles !== undefined) next.agentProfiles = patch.agentProfiles;
+  if (patch.providerUsage !== undefined) {
+    next.providerUsage = { hiddenProviders: patch.providerUsage.hiddenProviders };
+  }
   return Object.keys(next).length > 0 ? next : undefined;
 }

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -29,7 +29,11 @@ interface SupportedMutableConfigPatch {
   terminalProfiles?: MutableDaemonConfig["terminalProfiles"];
   agentProfiles?: MutableDaemonConfig["agentProfiles"];
   skills?: MutableDaemonConfig["skills"];
-  providerUsage?: { hiddenProviders: string[] };
+  providerUsage?: {
+    hiddenProviders?: string[];
+    hideProviders?: string[];
+    showProviders?: string[];
+  };
   pluginsEnabled?: boolean;
   plugins?: MutableDaemonConfig["plugins"];
 }
@@ -97,6 +101,37 @@ function deepMerge<T extends Record<string, unknown>>(
   }
 
   return next as T;
+}
+
+// Resolve provider-usage visibility patches against the authoritative hidden-provider set.
+// `hiddenProviders` alone is a full-array replace kept for back-compat; `hideProviders` /
+// `showProviders` are deltas merged on top. Resolution runs inside the synchronous
+// DaemonConfigStore.patch read-modify-write (and again against the persisted daemon while
+// persisting), so sequential patches from concurrent clients each observe the prior patch's
+// result — two clients toggling different providers can no longer silently undo each other
+// (lost update). Returns the authoritative full array, or undefined when the patch carries
+// nothing to apply.
+function resolveHiddenProviders(
+  currentHiddenProviders: readonly string[],
+  providerUsage: SupportedMutableConfigPatch["providerUsage"],
+): string[] | undefined {
+  if (!providerUsage) {
+    return undefined;
+  }
+  const { hiddenProviders, hideProviders, showProviders } = providerUsage;
+  if (hiddenProviders === undefined && !hideProviders?.length && !showProviders?.length) {
+    return undefined;
+  }
+
+  const next = new Set(hiddenProviders ?? currentHiddenProviders);
+  for (const providerId of hideProviders ?? []) {
+    next.add(providerId);
+  }
+  for (const providerId of showProviders ?? []) {
+    next.delete(providerId);
+  }
+
+  return Array.from(next).sort();
 }
 
 function omitProvidersFromConfig<T extends { providers?: Record<string, unknown> }>(
@@ -184,6 +219,7 @@ const RELOADABLE_PATHS = [
   "daemon.appendSystemPrompt",
   "daemon.terminalProfiles",
   "daemon.agentProfiles",
+  "daemon.providerUsage.hiddenProviders",
   "app.baseUrl",
   "agents.providers",
   "agents.catalogRefreshTimeoutMs",
@@ -207,6 +243,7 @@ const PERSISTED_TO_MUTABLE_PATH = new Map<string, string>([
   ["daemon.appendSystemPrompt", "appendSystemPrompt"],
   ["daemon.terminalProfiles", "terminalProfiles"],
   ["daemon.agentProfiles", "agentProfiles"],
+  ["daemon.providerUsage.hiddenProviders", "providerUsage.hiddenProviders"],
   ["app.baseUrl", "app.baseUrl"],
   ["agents.providers", "providers"],
   ["agents.catalogRefreshTimeoutMs", "catalogRefreshTimeoutMs"],
@@ -250,6 +287,23 @@ function compactOwnedPaths(paths: readonly string[], owners: readonly string[]):
   return Array.from(compacted).sort();
 }
 
+// Whitelist the provider-usage visibility patch forms the store understands: the
+// authoritative `hiddenProviders` full-array replace plus the `hideProviders` / `showProviders`
+// deltas that the server resolves against its current set.
+function pickSupportedProviderUsagePatch(
+  providerUsage: MutableDaemonConfigPatch["providerUsage"],
+): SupportedMutableConfigPatch["providerUsage"] {
+  const { hiddenProviders, hideProviders, showProviders } = providerUsage ?? {};
+  if (hiddenProviders === undefined && hideProviders === undefined && showProviders === undefined) {
+    return undefined;
+  }
+  return {
+    ...(hiddenProviders !== undefined ? { hiddenProviders } : {}),
+    ...(hideProviders !== undefined ? { hideProviders } : {}),
+    ...(showProviders !== undefined ? { showProviders } : {}),
+  };
+}
+
 function pickSupportedPatchFields(patch: MutableDaemonConfigPatch): SupportedMutableConfigPatch {
   return {
     ...(patch.relay?.enabled !== undefined ? { relay: { enabled: patch.relay.enabled } } : {}),
@@ -275,8 +329,8 @@ function pickSupportedPatchFields(patch: MutableDaemonConfigPatch): SupportedMut
       : {}),
     ...(patch.terminalProfiles !== undefined ? { terminalProfiles: patch.terminalProfiles } : {}),
     ...(patch.agentProfiles !== undefined ? { agentProfiles: patch.agentProfiles } : {}),
-    ...(patch.providerUsage?.hiddenProviders !== undefined
-      ? { providerUsage: { hiddenProviders: patch.providerUsage.hiddenProviders } }
+    ...(patch.providerUsage !== undefined
+      ? { providerUsage: pickSupportedProviderUsagePatch(patch.providerUsage) }
       : {}),
     ...(patch.pluginsEnabled !== undefined ? { pluginsEnabled: patch.pluginsEnabled } : {}),
     ...(patch.plugins !== undefined ? { plugins: patch.plugins } : {}),
@@ -367,7 +421,16 @@ export class DaemonConfigStore {
     }
     const { removeProviders = [], ...configPatch } = parsedPatch;
     const removedProviders = Array.from(new Set(removeProviders));
-    const merged = deepMerge(this.current, configPatch);
+    const resolvedHiddenProviders = resolveHiddenProviders(
+      this.current.providerUsage?.hiddenProviders ?? [],
+      configPatch.providerUsage,
+    );
+    const merged = deepMerge(this.current, {
+      ...configPatch,
+      ...(resolvedHiddenProviders !== undefined
+        ? { providerUsage: { hiddenProviders: resolvedHiddenProviders } }
+        : {}),
+    });
     if (parsedPatch.skills?.selection !== undefined) {
       merged.skills = { selection: parsedPatch.skills.selection };
     }
@@ -666,7 +729,21 @@ function mergeMutableDaemonPatch(
   if (patch.terminalProfiles !== undefined) next.terminalProfiles = patch.terminalProfiles;
   if (patch.agentProfiles !== undefined) next.agentProfiles = patch.agentProfiles;
   if (patch.providerUsage !== undefined) {
-    next.providerUsage = { hiddenProviders: patch.providerUsage.hiddenProviders };
+    // COMPAT(providerUsageVisibility): write `daemon.providerUsage` only when at least one
+    // provider is hidden, and strip the block when the list becomes empty, so config.json stays
+    // readable by older daemons whose strict daemon schema does not yet know the key — a
+    // rollback after a no-op upgrade must not break config loading.
+    const resolved = resolveHiddenProviders(
+      next.providerUsage?.hiddenProviders ?? [],
+      patch.providerUsage,
+    );
+    if (resolved !== undefined) {
+      if (resolved.length > 0) {
+        next.providerUsage = { hiddenProviders: resolved };
+      } else {
+        delete next.providerUsage;
+      }
+    }
   }
   return Object.keys(next).length > 0 ? next : undefined;
 }

--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -58,6 +58,18 @@ describe("PersistedConfigSchema daemon browser tools config", () => {
   });
 });
 
+describe("PersistedConfigSchema provider usage config", () => {
+  test("accepts host-scoped hidden provider ids", () => {
+    const parsed = PersistedConfigSchema.parse({
+      daemon: {
+        providerUsage: { hiddenProviders: ["copilot", "minimax"] },
+      },
+    });
+
+    expect(parsed.daemon?.providerUsage?.hiddenProviders).toEqual(["copilot", "minimax"]);
+  });
+});
+
 describe("PersistedConfigSchema daemon relay config", () => {
   test("accepts optional relay TLS setting", () => {
     const parsed = PersistedConfigSchema.parse({

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -254,6 +254,12 @@ export const PersistedConfigSchema = z
           })
           .passthrough()
           .optional(),
+        providerUsage: z
+          .object({
+            hiddenProviders: z.array(z.string().min(1)).optional(),
+          })
+          .strict()
+          .optional(),
         git: z
           .object({
             maxProcessesPerSecond: z.number().int().positive().optional(),

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1706,6 +1706,8 @@ export class VoiceAssistantWebSocketServer {
         workspaceFileEditing: true,
         // COMPAT(providerUsageList): added in v0.1.98, drop the gate when daemon floor >= v0.1.98.
         providerUsageList: true,
+        // COMPAT(providerUsageVisibility): added in v0.2.5, remove after 2027-02-04.
+        providerUsageVisibility: true,
         // COMPAT(agentDetach): added in v0.1.98, remove gate after 2026-12-19 once daemon floor >= v0.1.98.
         agentDetach: true,
         // COMPAT(agentThinkingUpdate): added in v0.2.4, remove gate after 2027-01-28.

--- a/packages/website/public/schemas/paseo.config.v1.json
+++ b/packages/website/public/schemas/paseo.config.v1.json
@@ -72,6 +72,19 @@
               },
               "additionalProperties": true
             },
+            "providerUsage": {
+              "type": "object",
+              "properties": {
+                "hiddenProviders": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
             "git": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
Links https://github.com/getpaseo/paseo/discussions/2861

## Summary
- add host-scoped Shown providers switches to Settings > Usage
- persist hidden provider IDs in daemon.providerUsage.hiddenProviders
- capability-gate the UI for mixed client/daemon versions
- keep the active-provider context tooltip unchanged

Missing or empty configuration shows every provider, and unknown hidden IDs are preserved when settings change.

## Compatibility
- new protocol fields are optional
- older daemons retain the existing Usage UI
- no provider credential, quota-fetching, or relay behavior changes

## Validation
- 82 focused Vitest tests passed
- full workspace typecheck passed
- server build, targeted lint, and formatting passed
- Playwright provider-usage suite: 4/4 passed
- browser UI inspected at desktop and responsive widths; no platform-specific UI code added

## Screenshot
![Provider usage visibility settings](https://raw.githubusercontent.com/ele-yufo/paseo/pr-assets/provider-usage-visibility.png)