### PR TITLE
feat(server): add omp provider model and config-overlay guardrails

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -389,6 +389,27 @@ Custom OMP profiles should extend `omp`. They inherit the OMP adapter's `rpc-ui`
 
 `params.sessionDir` is used only for importing sessions that were started outside Paseo. If `command` or XDG env vars move OMP's state directory, set `params.sessionDir` to the resulting OMP JSONL session directory; launching and resuming still go through the configured command.
 
+Two optional params guard against unwanted model spend on unattended (loop, schedule, voice, subagent) OMP agents:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "omp": {
+        "enabled": true,
+        "params": {
+          "model": "kimi-code/k3-256k",
+          "configOverlay": "/home/brian/.paseo/omp-guardrails.yml"
+        }
+      }
+    }
+  }
+}
+```
+
+- `params.model` is the default model for agent requests that don't pick one. An explicit model choice (app picker, `--model`, `provider/model`) always wins. Resumed sessions ignore it and restore the model the session itself used.
+- `params.configOverlay` is an absolute path to an OMP settings overlay passed to every spawn as `--config` (create and resume). Use it to pin `modelRoles` or strip paid providers from `retry.fallbackChains` for Paseo-driven sessions without touching your interactive `~/.omp/agent/config.yml`. Note the overlay steers defaults and fallback chains; OMP still resolves an explicitly requested `--model` outside `enabledModels`.
+
 For other providers that keep Pi's `--mode rpc` API but write sessions somewhere else, extend `pi`, replace the command, and provide the JSONL session directory:
 
 ```json

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -60,6 +60,7 @@ import {
   resolveOmpLaunchMode,
   resolveOmpProviderParams,
   OMP_MODES,
+  type OmpGuardrailParams,
   type OmpModelRoleParams,
   type OmpRuntimeProviderParams,
 } from "./provider-config.js";
@@ -2185,6 +2186,7 @@ export class OmpAgentClient implements AgentClient {
   private readonly runtimeSettings?: ProviderRuntimeSettings;
   private readonly providerParams: OmpRuntimeProviderParams;
   private readonly modelRoleParams: OmpModelRoleParams;
+  private readonly guardrailParams: OmpGuardrailParams;
   private readonly subagentCardScheduler?: OmpSubagentCardScheduler;
   private readonly providerIdleScheduler?: OmpProviderIdleScheduler;
   private readonly noTurnScheduler?: OmpNoTurnScheduler;
@@ -2192,7 +2194,7 @@ export class OmpAgentClient implements AgentClient {
   private readonly runtime: OmpRuntime;
 
   constructor(options: OmpAgentClientOptions) {
-    const { runtimeProviderParams, modelRoleParams } = resolveOmpProviderParams(
+    const { runtimeProviderParams, modelRoleParams, guardrailParams } = resolveOmpProviderParams(
       options.providerParams,
     );
     const runtimeSettings = mergeOmpRuntimeSettings(
@@ -2208,6 +2210,7 @@ export class OmpAgentClient implements AgentClient {
     this.runtimeSettings = runtimeSettings;
     this.providerParams = runtimeProviderParams;
     this.modelRoleParams = modelRoleParams;
+    this.guardrailParams = guardrailParams;
     this.subagentCardScheduler = options.subagentCardScheduler;
     this.providerIdleScheduler = options.providerIdleScheduler;
     this.noTurnScheduler = options.noTurnScheduler;
@@ -2233,11 +2236,18 @@ export class OmpAgentClient implements AgentClient {
     const runtimeSession = await this.runtime.startSession({
       cwd: config.cwd,
       protocolMode: "rpc-ui",
-      model: config.model,
+      // params.model only backstops requests that didn't pick a model; an
+      // explicit caller choice always wins. Resumes deliberately skip this —
+      // they restore the model the session itself persisted.
+      model: config.model ?? this.guardrailParams.defaultModel,
       thinkingOptionId: normalizeOmpThinkingOption(config.thinkingOptionId) ?? undefined,
       noSession: config.internal === true,
       modeId: launchMode.modeId,
-      extraArgs: launchMode.extraArgs,
+      // The params.configOverlay settings overlay rides every launch —
+      // its fallback-chain/model-role constraints must hold for the process.
+      extraArgs: this.guardrailParams.configOverlay
+        ? [...launchMode.extraArgs, "--config", this.guardrailParams.configOverlay]
+        : launchMode.extraArgs,
       systemPrompt: composeSystemPromptParts(config.systemPrompt, config.daemonAppendSystemPrompt),
       env: launchContext?.env,
     });
@@ -2280,7 +2290,12 @@ export class OmpAgentClient implements AgentClient {
         resumeConfig,
         sessionFile,
         launchContext,
-        launchMode,
+        launchMode: this.guardrailParams.configOverlay
+          ? {
+              ...launchMode,
+              extraArgs: [...launchMode.extraArgs, "--config", this.guardrailParams.configOverlay],
+            }
+          : launchMode,
       }),
     );
     try {

--- a/packages/server/src/server/agent/providers/omp/provider-config.test.ts
+++ b/packages/server/src/server/agent/providers/omp/provider-config.test.ts
@@ -1,0 +1,95 @@
+import pino from "pino";
+import { describe, expect, test } from "vitest";
+
+import { OmpAgentClient } from "./agent.js";
+import { resolveOmpProviderParams } from "./provider-config.js";
+import { FakeOmp } from "./test-utils/fake-omp.js";
+
+function createClient(providerParams: unknown, omp: FakeOmp): OmpAgentClient {
+  return new OmpAgentClient({
+    logger: pino({ level: "silent" }),
+    runtime: omp,
+    providerParams,
+  });
+}
+
+describe("resolveOmpProviderParams guardrails", () => {
+  test("maps model and configOverlay into guardrail params", () => {
+    const { guardrailParams } = resolveOmpProviderParams({
+      model: "kimi-code/k3-256k",
+      configOverlay: "/etc/paseo/omp-guardrails.yml",
+    });
+    expect(guardrailParams).toEqual({
+      defaultModel: "kimi-code/k3-256k",
+      configOverlay: "/etc/paseo/omp-guardrails.yml",
+    });
+  });
+
+  test("omits guardrails when params are absent", () => {
+    expect(resolveOmpProviderParams(undefined).guardrailParams).toEqual({});
+    expect(resolveOmpProviderParams({}).guardrailParams).toEqual({});
+  });
+});
+
+describe("omp launch guardrails", () => {
+  test("applies params.model when the request picks no model", async () => {
+    const omp = new FakeOmp();
+    const client = createClient({ model: "kimi-code/k3-256k" }, omp);
+    await client.createSession({ provider: "omp", cwd: "/tmp/work" });
+
+    const argv = omp.recordedLaunches[0]!.argv;
+    expect(argv[argv.indexOf("--model") + 1]).toBe("kimi-code/k3-256k");
+  });
+
+  test("an explicit request model beats params.model", async () => {
+    const omp = new FakeOmp();
+    const client = createClient({ model: "kimi-code/k3-256k" }, omp);
+    await client.createSession({
+      provider: "omp",
+      cwd: "/tmp/work",
+      model: "openai/gpt-5.6-luna",
+    });
+
+    const argv = omp.recordedLaunches[0]!.argv;
+    expect(argv[argv.indexOf("--model") + 1]).toBe("openai/gpt-5.6-luna");
+  });
+
+  test("passes params.configOverlay as --config on create", async () => {
+    const omp = new FakeOmp();
+    const client = createClient({ configOverlay: "/etc/paseo/omp-guardrails.yml" }, omp);
+    await client.createSession({ provider: "omp", cwd: "/tmp/work" });
+
+    const argv = omp.recordedLaunches[0]!.argv;
+    expect(argv[argv.indexOf("--config") + 1]).toBe("/etc/paseo/omp-guardrails.yml");
+  });
+
+  test("resume carries the overlay but not the default model", async () => {
+    const omp = new FakeOmp();
+    const client = createClient(
+      { model: "kimi-code/k3-256k", configOverlay: "/etc/paseo/omp-guardrails.yml" },
+      omp,
+    );
+    await client.resumeSession({
+      provider: "omp",
+      sessionId: "session-1",
+      nativeHandle: "/tmp/session.jsonl",
+      metadata: { cwd: "/tmp/work" },
+    });
+
+    const argv = omp.recordedLaunches[0]!.argv;
+    expect(argv[argv.indexOf("--config") + 1]).toBe("/etc/paseo/omp-guardrails.yml");
+    // A resume restores the model the session itself persisted; the provider
+    // default would silently override it, so it must not appear.
+    expect(argv).not.toContain("--model");
+  });
+
+  test("launch is unchanged when no guardrails are configured", async () => {
+    const omp = new FakeOmp();
+    const client = createClient(undefined, omp);
+    await client.createSession({ provider: "omp", cwd: "/tmp/work" });
+
+    const argv = omp.recordedLaunches[0]!.argv;
+    expect(argv).not.toContain("--model");
+    expect(argv).not.toContain("--config");
+  });
+});

--- a/packages/server/src/server/agent/providers/omp/provider-config.ts
+++ b/packages/server/src/server/agent/providers/omp/provider-config.ts
@@ -15,6 +15,8 @@ export { OMP_MODES };
 export const OmpProviderParamsSchema = z
   .object({
     sessionDir: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+    configOverlay: z.string().min(1).optional(),
     smolModel: z.string().min(1).optional(),
     slowModel: z.string().min(1).optional(),
     planModel: z.string().min(1).optional(),
@@ -29,6 +31,18 @@ export interface OmpModelRoleParams {
   smolModel?: string;
   slowModel?: string;
   planModel?: string;
+}
+
+/**
+ * Provider-level launch guardrails for unattended agents: a default model for
+ * agent requests that don't pick one, and an OMP settings overlay (passed as
+ * `--config`) whose `modelRoles`/`retry.fallbackChains` constrain every
+ * spawned session, so headless agents can't silently escalate to models the
+ * deployment didn't budget for.
+ */
+export interface OmpGuardrailParams {
+  defaultModel?: string;
+  configOverlay?: string;
 }
 
 export function resolveOmpLaunchMode(
@@ -127,6 +141,7 @@ export function formatOmpVersionSupport(versionOutput: string): string {
 export function resolveOmpProviderParams(providerParams: unknown): {
   runtimeProviderParams: OmpRuntimeProviderParams;
   modelRoleParams: OmpModelRoleParams;
+  guardrailParams: OmpGuardrailParams;
 } {
   const params = OmpProviderParamsSchema.parse(providerParams ?? {});
   return {
@@ -135,6 +150,10 @@ export function resolveOmpProviderParams(providerParams: unknown): {
       ...(params.smolModel ? { smolModel: params.smolModel } : {}),
       ...(params.slowModel ? { slowModel: params.slowModel } : {}),
       ...(params.planModel ? { planModel: params.planModel } : {}),
+    },
+    guardrailParams: {
+      ...(params.model ? { defaultModel: params.model } : {}),
+      ...(params.configOverlay ? { configOverlay: params.configOverlay } : {}),
     },
   };
 }


### PR DESCRIPTION
## What

Two new optional `agents.providers.omp.params` keys, mirroring the existing `smolModel`/`slowModel`/`planModel` pattern:

- **`model`** — default model for agent requests that don't pick one. Applied at `createSession` only: an explicit caller choice (app picker, CLI `--model`, `provider/model`) always wins, and `resumeSession` deliberately skips it so resumes restore the model the session itself persisted.
- **`configOverlay`** — absolute path to an OMP settings overlay passed as `--config` on **every** spawn (create and resume), letting a deployment pin `modelRoles` and constrain `retry.fallbackChains` for Paseo-driven sessions without touching the user's interactive `~/.omp/agent/config.yml`.

## Why

Unattended Paseo agents (loops, schedules, voice reloads, `create_agent` subagents) spawn OMP **without** `--model`, so every process resolves the user's global interactive config: `modelRoles.default` plus `retry.fallbackChains`. OMP's fallback is built for interactive use — it emits `retry_fallback_applied` for a human to act on, and persists the switch into the session JSONL. Under Paseo there is no human watching: a rate-limit blip on the primary silently escalates to any provider with a key in OMP's `.env`, at agentic-loop volume, per agent process.

Concretely: my deployment fell back to `openai/gpt-5.6-*` across two unattended sessions and burned ~$20 / ~79M tokens in ~3 days ($5.77 in one 36-minute stretch), which also drained the OpenAI org my embeddings backend shares. Paseo has no config surface to prevent this today — `ProviderRuntimeSettingsSchema` exposes only `command`/`env`/`disallowedTools`, and the OMP params cover only role models.

With this PR a deployment can write one overlay (e.g. `retry.fallbackChains` limited to flat-plan/free models) and have it enforced for every OMP process Paseo spawns, while interactive OMP use outside Paseo keeps the user's original chains.

## Testing

- New `provider-config.test.ts` (7 tests) covering: params→guardrail mapping, default model applied/omitted, explicit model wins over `params.model`, `--config` appended on create, resume carries the overlay but **not** the default model, and no-guardrails launches staying byte-identical.
- Full OMP provider suite: 20 files / 119 tests pass.
- Pre-commit hooks green: oxlint, oxfmt, workspace tsgo typecheck.
- Docs updated in `docs/custom-providers.md` (params example + semantics).