### PR TITLE
Make Hub worktree archive coverage deterministic

### DIFF
--- a/packages/server/src/server/hub/execution-session.websocket.test.ts
+++ b/packages/server/src/server/hub/execution-session.websocket.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, expect, test } from "vitest";
-import {
-  HubRelationshipHarness,
-  SetupFailingArchiveWatchFiles,
-} from "./test-utils/relationship-harness.js";
+import { HubRelationshipHarness } from "./test-utils/relationship-harness.js";
 
 let relationship: HubRelationshipHarness | null = null;
 
@@ -167,9 +164,7 @@ test("Hub archives a running execution's Paseo-created worktree", async () => {
   const worktreeCwd = hub.latestCreatedCwd();
   await hub.ownedRunningUpdate(worktreeCreated.payload.agentId!);
   const duringRun = await hub.worktreeState(worktreeCwd!);
-  const archiveCompletion = hub.waitForOwnedArchiveCompletion(worktreeCreated.payload.agentId!);
   const response = await hub.archiveExecution("execution-worktree", "archive-worktree");
-  const archive = await archiveCompletion;
   const afterArchive = await hub.worktreeState(worktreeCwd!);
 
   expect(worktreeCreated).toMatchObject({
@@ -180,11 +175,13 @@ test("Hub archives a running execution's Paseo-created worktree", async () => {
   expect(duringRun).toEqual({ exists: true, listed: true });
   expect(response).toMatchObject({ success: true, error: null, action: "archive" });
   expect(afterArchive).toEqual({ exists: false, listed: false });
-  expect(archive).toEqual({
-    agentArchivedAt: expect.any(String),
-    workspaceArchivedAt: expect.any(String),
-  });
-}, 30_000);
+  expect(await hub.ownedAgentArchivedAt(worktreeCreated.payload.agentId!)).toEqual(
+    expect.any(String),
+  );
+  expect(await hub.ownedWorkspaceArchivedAt(worktreeCreated.payload.agentId!)).toEqual(
+    expect.any(String),
+  );
+}, 20_000);
 
 test("a sibling workspace keeps an archived execution's worktree directory alive", async () => {
   const hub = await launchRelationship();
@@ -274,20 +271,4 @@ test("Hub treats missing and foreign executions as already controlled without ex
     expect.objectContaining({ success: true, error: null }),
   ]);
   expect(await hub.agentRemainsAvailable(foreignAgentId)).toBe(true);
-});
-
-test("archive observation closes its first watcher when the second watcher cannot start", async () => {
-  const watchFiles = new SetupFailingArchiveWatchFiles(2);
-  const hub = await HubRelationshipHarness.start(watchFiles);
-  relationship = hub;
-  await hub.beginConnect().result;
-  hub.connectLatestSocket();
-  hub.beginOwnedCreate("watch-setup-create", "watch-setup-execution");
-  const created = await hub.ownedCreateResult("watch-setup-create");
-
-  await expect(hub.waitForOwnedArchiveCompletion(created.payload.agentId!)).rejects.toThrow(
-    "Cannot watch",
-  );
-
-  expect(watchFiles.activeDirectories()).toEqual([]);
 });

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -63,53 +63,6 @@ const HUB_ORIGIN = "https://hub.test";
 const SOCKET_URL = "wss://hub.test/daemon";
 const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "../../../../../..");
 
-export interface ArchiveWatcher {
-  close(): void;
-  onError(listener: (error: Error) => void): void;
-}
-
-export interface ArchiveWatchFiles {
-  watchDirectory(path: string, onChange: () => void): ArchiveWatcher;
-}
-
-const nodeArchiveWatchFiles: ArchiveWatchFiles = {
-  watchDirectory(directory, onChange) {
-    const watcher = watch(directory, onChange);
-    return {
-      close: () => watcher.close(),
-      onError: (listener) => watcher.on("error", listener),
-    };
-  },
-};
-
-export class SetupFailingArchiveWatchFiles implements ArchiveWatchFiles {
-  private attempts = 0;
-  private readonly openDirectories = new Set<string>();
-
-  constructor(private readonly failOnAttempt: number) {}
-
-  watchDirectory(directory: string): ArchiveWatcher {
-    this.attempts++;
-    if (this.attempts === this.failOnAttempt) {
-      throw new Error(`Cannot watch ${directory}`);
-    }
-    this.openDirectories.add(directory);
-    let open = true;
-    return {
-      close: () => {
-        if (!open) return;
-        open = false;
-        this.openDirectories.delete(directory);
-      },
-      onError: () => {},
-    };
-  }
-
-  activeDirectories(): string[] {
-    return [...this.openDirectories];
-  }
-}
-
 interface PersistedRelationship {
   version: number;
   state: string;
@@ -465,10 +418,7 @@ export class HubRelationshipHarness {
   private observedSockets = 0;
   private readonly codex: ControlledAgentClient;
 
-  private constructor(
-    private readonly archiveWatchFiles: ArchiveWatchFiles,
-    private readonly mcpEnabled: boolean,
-  ) {
+  private constructor(private readonly mcpEnabled: boolean) {
     this.codex = new ControlledAgentClient(
       createTestAgentClients({
         supportsMcpServers: mcpEnabled,
@@ -488,23 +438,16 @@ export class HubRelationshipHarness {
     );
   }
 
-  static async start(
-    archiveWatchFiles: ArchiveWatchFiles = nodeArchiveWatchFiles,
-  ): Promise<HubRelationshipHarness> {
-    return this.launch(archiveWatchFiles, false);
+  static async start(): Promise<HubRelationshipHarness> {
+    return this.launch(false);
   }
 
-  static async startWithAgentMcp(
-    archiveWatchFiles: ArchiveWatchFiles = nodeArchiveWatchFiles,
-  ): Promise<HubRelationshipHarness> {
-    return this.launch(archiveWatchFiles, true);
+  static async startWithAgentMcp(): Promise<HubRelationshipHarness> {
+    return this.launch(true);
   }
 
-  private static async launch(
-    archiveWatchFiles: ArchiveWatchFiles,
-    mcpEnabled: boolean,
-  ): Promise<HubRelationshipHarness> {
-    const harness = new HubRelationshipHarness(archiveWatchFiles, mcpEnabled);
+  private static async launch(mcpEnabled: boolean): Promise<HubRelationshipHarness> {
+    const harness = new HubRelationshipHarness(mcpEnabled);
     await harness.createHome();
     await harness.startDaemon();
     return harness;
@@ -795,6 +738,13 @@ export class HubRelationshipHarness {
     return (await this.daemon!.agentStorage.get(agentId))?.archivedAt ?? null;
   }
 
+  async ownedWorkspaceArchivedAt(agentId: string): Promise<string | null> {
+    const agent = await this.daemon!.agentStorage.get(agentId);
+    if (!agent) throw new Error(`Owned agent ${agentId} does not exist`);
+    if (!agent.workspaceId) throw new Error(`Owned agent ${agentId} has no workspace`);
+    return this.workspaceArchivedAt(agent.workspaceId);
+  }
+
   async createForeignExecution(executionId: string): Promise<string> {
     const agent = await this.daemon!.agentManager.createAgent(
       { provider: "codex", cwd: this.root },
@@ -864,65 +814,6 @@ export class HubRelationshipHarness {
 
   repoExists(): boolean {
     return existsSync(this.root);
-  }
-
-  async waitForOwnedArchiveCompletion(
-    agentId: string,
-  ): Promise<{ agentArchivedAt: string; workspaceArchivedAt: string }> {
-    const created = await this.daemon!.agentStorage.get(agentId);
-    if (!created) throw new Error(`Owned agent ${agentId} does not exist`);
-    if (!created.workspaceId) throw new Error(`Owned agent ${agentId} has no workspace`);
-    return new Promise<{ agentArchivedAt: string; workspaceArchivedAt: string }>(
-      (resolve, reject) => {
-        const watchers: ArchiveWatcher[] = [];
-        let settled = false;
-        const timeout = setTimeout(
-          () => finish(new Error(`Timed out waiting for owned agent ${agentId} to archive`)),
-          15_000,
-        );
-        timeout.unref?.();
-        const closeWatchers = () => {
-          clearTimeout(timeout);
-          for (const watcher of watchers) watcher.close();
-        };
-        const finish = (
-          result: Error | { agentArchivedAt: string; workspaceArchivedAt: string },
-        ) => {
-          if (settled) return;
-          settled = true;
-          closeWatchers();
-          if (result instanceof Error) reject(result);
-          else resolve(result);
-        };
-        const observeCompletion = async () => {
-          try {
-            const archived = await this.daemon!.agentStorage.get(agentId);
-            const workspaceArchivedAt = this.workspaceArchivedAt(created.workspaceId!);
-            if (!archived?.archivedAt || !workspaceArchivedAt || existsSync(created.cwd)) return;
-            finish({ agentArchivedAt: archived.archivedAt, workspaceArchivedAt });
-          } catch (error) {
-            finish(error instanceof Error ? error : new Error(String(error)));
-          }
-        };
-        try {
-          const projectsWatcher = this.archiveWatchFiles.watchDirectory(
-            path.join(this.paseoHome, "projects"),
-            observeCompletion,
-          );
-          watchers.push(projectsWatcher);
-          projectsWatcher.onError(finish);
-          const worktreeWatcher = this.archiveWatchFiles.watchDirectory(
-            path.dirname(created.cwd),
-            observeCompletion,
-          );
-          watchers.push(worktreeWatcher);
-          worktreeWatcher.onError(finish);
-          void observeCompletion();
-        } catch (error) {
-          finish(error instanceof Error ? error : new Error(String(error)));
-        }
-      },
-    );
   }
 
   private workspaceArchivedAt(workspaceId: string): string | null {


### PR DESCRIPTION
### Linked issue

None. This fixes a Windows CI failure observed while delivering the preceding change.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The Hub worktree archive test raced the archive RPC against a separate filesystem-watcher observer with its own fixed 15-second timeout. The RPC already resolves after the agent and workspace are archived and the owned worktree is removed, so the extra observer duplicated synchronization and could time out on Windows after the operation had completed.

Assert the real persisted agent/workspace records and Git/filesystem worktree state directly after the successful archive response. This removes the timing race while retaining the behavioral contract.

### Goals

- Keep coverage for agent archival, workspace archival, worktree directory removal, and Git worktree removal.
- Remove the independent watcher timeout that flakes on slow Windows runners.
- Keep the test focused on externally observable archive completion.

### Non-goals

- Change Hub archive production behavior.
- Increase test timeouts or add retries.
- Alter unrelated server tests.

### QA

- Reproduced in GitHub Actions: `server-tests (windows-latest)` timed out in `waitForOwnedArchiveCompletion` while the Ubuntu server job passed.
- `npx vitest run packages/server/src/server/hub/execution-session.websocket.test.ts --bail=1` — 14/14 passed in 28.36s.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format` — passed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense