### PR TITLE
Fix updater errors while release artifacts are still building

### DIFF
--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -52,6 +52,7 @@ jobs:
             --repo "${{ github.repository }}"
             --title "Paseo $RELEASE_TAG"
             --notes ""
+            --draft
           )
 
           if [[ "$IS_PRERELEASE" == "true" ]]; then

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -86,6 +86,7 @@ jobs:
               --repo "${{ github.repository }}" \
               --title "Paseo $RELEASE_TAG" \
               --notes "" \
+              --draft \
               $prerelease_flag || {
                 echo "Release creation raced with another workflow; continuing."
               }
@@ -480,7 +481,7 @@ jobs:
           name: windows-manifest
           path: release-manifests/windows-manifest
 
-      - name: Assemble and upload stamped manifests
+      - name: Assemble manifests and publish release
         if: env.IS_SMOKE_TAG != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -537,3 +538,5 @@ jobs:
             }
           ' "${files[@]}"
           gh release upload "$RELEASE_TAG" "${files[@]}" --clobber --repo "${{ github.repository }}"
+          release_id="$(gh api "repos/${{ github.repository }}/releases/tags/$RELEASE_TAG" --jq .id)"
+          gh api --method PATCH "repos/${{ github.repository }}/releases/$release_id" -F draft=false

--- a/.github/workflows/release-notes-sync.yml
+++ b/.github/workflows/release-notes-sync.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       create_if_missing:
-        description: "Create release if missing (normally only needed for tag events)."
+        description: "Create a draft release if missing (normally only needed for tag events)."
         required: false
         default: false
         type: boolean

--- a/docs/release.md
+++ b/docs/release.md
@@ -150,10 +150,10 @@ The rollout is driven by a `rolloutHours` field stamped into the GitHub Release 
 
 Desktop release builds now publish in two phases:
 
-- Platform build jobs upload the installers/packages (`.dmg`, `.zip`, `.exe`, `.AppImage`, etc.) to the GitHub release.
-- The final job merges/stamps the manifests and uploads all `.yml` files only after they already contain the final `releaseDate` and `rolloutHours`.
+- The GitHub release stays a draft while platform build jobs upload the installers/packages (`.dmg`, `.zip`, `.exe`, `.AppImage`, etc.).
+- The final job merges/stamps the manifests, uploads all `.yml` files with their final `releaseDate` and `rolloutHours`, and then publishes the GitHub release.
 
-Updater clients only discover a release through those `.yml` manifests, so there is no silent 100% admission window before rollout metadata is present.
+Keeping the release as a draft prevents Electron's GitHub feed from advertising it before its update manifests exist. Updater clients cannot discover the release until every desktop artifact is ready.
 
 ### Default behavior
 

--- a/scripts/sync-release-notes-from-changelog.mjs
+++ b/scripts/sync-release-notes-from-changelog.mjs
@@ -17,7 +17,7 @@ Usage: node scripts/sync-release-notes-from-changelog.mjs [options]
 Options:
   --repo <owner/repo>       Repository slug. Defaults to $GITHUB_REPOSITORY.
   --tag <tag>               Release tag (e.g. v0.1.14). Defaults to latest changelog entry.
-  --create-if-missing       Create release if it does not already exist.
+  --create-if-missing       Create a draft release if it does not already exist.
 `;
   process.stderr.write(usage.trimStart());
   process.stderr.write("\n");
@@ -186,6 +186,7 @@ export function syncReleaseNotes(argv = process.argv.slice(2), deps = {}) {
     "--notes-file",
     notesPath,
     "--verify-tag",
+    "--draft",
     ...(parseReleaseVersion(releaseInfo.version).isPrerelease ? ["--prerelease"] : []),
   ];
 

--- a/scripts/sync-release-notes-from-changelog.test.mjs
+++ b/scripts/sync-release-notes-from-changelog.test.mjs
@@ -64,6 +64,38 @@ test("updates an existing release body through the release id API", () => {
   });
 });
 
+test("creates missing releases as drafts", () => {
+  withTempChangelog(() => {
+    const calls = [];
+
+    const execFileSync = (command, args, options) => {
+      calls.push({ args, command, options });
+
+      if (args[0] === "api" && args[1] === "repos/getpaseo/paseo/releases/tags/v0.1.60-beta.1") {
+        throw new Error("release not found");
+      }
+
+      if (args[0] === "release" && args[1] === "create") {
+        return "";
+      }
+
+      throw new Error(`Unexpected gh call: ${command} ${args.join(" ")}`);
+    };
+
+    syncReleaseNotes(
+      ["--repo", "getpaseo/paseo", "--tag", "v0.1.60-beta.1", "--create-if-missing"],
+      { execFileSync },
+    );
+
+    const createCall = calls.find(
+      (call) => call.args[0] === "release" && call.args[1] === "create",
+    );
+    assert.ok(createCall, "the missing release should be created");
+    assert.equal(createCall.args.includes("--draft"), true);
+    assert.equal(createCall.args.includes("--prerelease"), true);
+  });
+});
+
 test("converts contributor profile links to mentions in synced release notes", () => {
   const changelogText = [
     "## 0.1.60-beta.1 - 2026-04-20",


### PR DESCRIPTION
## Summary

- create GitHub releases as drafts from every tag-triggered release creator
- publish the draft only after the desktop manifests have been merged, stamped, and uploaded
- document and test the draft-release behavior

## Why

GitHub advertised `v0.3.0-beta.1` in its releases feed as soon as the release was created, while the desktop jobs were still building. Electron Updater selected that prerelease, failed to find `beta-mac.yml`, then reported its fallback failure for `latest-mac.yml`.

Keeping the release in draft state makes release visibility atomic with the update manifests, so clients continue seeing the previous complete release until the new one is installable.

## Verification

- `node --test scripts/sync-release-notes-from-changelog.test.mjs`
- `npm run typecheck`
- `npm run lint`
- workflow YAML parsed with `js-yaml`
- `npm run format:check`
