### PR TITLE
fix: honor log.file.path everywhere and create daemon logs owner-only

### DIFF
--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -1,8 +1,8 @@
 import { addLocalDaemonOptions } from "../utils/command-options.js";
 import { cancel, confirm, intro, isCancel, log, note, outro } from "@clack/prompts";
 import { Command, Option } from "commander";
-import path from "node:path";
 import {
+  daemonLogPath,
   readPersistedConfig as loadPersistedConfig,
   savePersistedConfig,
   readDaemonInstance,
@@ -113,7 +113,7 @@ async function resolveVoiceSelection(mode: OnboardOptions["voice"]): Promise<boo
 }
 
 function printNextSteps(pairingUrl: string | null, paseoHome: string, richUi: boolean): void {
-  const daemonLogPath = path.join(paseoHome, "daemon.log");
+  const configuredDaemonLogPath = daemonLogPath(paseoHome);
   const nextStepsLines = [
     pairingUrl
       ? "1. Open Paseo and scan the QR code above, or paste the pairing link."
@@ -128,7 +128,7 @@ function printNextSteps(pairingUrl: string | null, paseoHome: string, richUi: bo
     `2. paseo ls --home ${JSON.stringify(paseoHome)}`,
     `3. paseo run --home ${JSON.stringify(paseoHome)} "your prompt"`,
     `4. paseo status --home ${JSON.stringify(paseoHome)}`,
-    `5. Daemon logs: ${daemonLogPath}`,
+    `5. Daemon logs: ${configuredDaemonLogPath}`,
   ];
 
   if (!richUi) {

--- a/packages/desktop/src/daemon/daemon-manager.test.ts
+++ b/packages/desktop/src/daemon/daemon-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,7 +23,9 @@ const mocks = vi.hoisted(() => ({
     env: {},
   })),
   spawnProcess: vi.fn(),
+  loadPersistedConfig: vi.fn(),
   logInfo: vi.fn(),
+  logWarn: vi.fn(),
   logError: vi.fn(),
   appLogPath: "",
   getElectronLogFile: vi.fn(),
@@ -42,6 +44,7 @@ vi.mock("electron", () => ({
 vi.mock("electron-log/main", () => ({
   default: {
     info: mocks.logInfo,
+    warn: mocks.logWarn,
     error: mocks.logError,
     transports: {
       file: {
@@ -51,10 +54,17 @@ vi.mock("electron-log/main", () => ({
   },
 }));
 
-vi.mock("@getpaseo/server", () => ({
-  resolvePaseoHome: vi.fn(() => mocks.paseoHome),
-  spawnProcess: mocks.spawnProcess,
-}));
+vi.mock("@getpaseo/server", async () => {
+  const { DEFAULT_DAEMON_LOG_FILENAME, resolveDaemonLogPath } =
+    await import("@server/server/daemon-log-path.js");
+  return {
+    DEFAULT_DAEMON_LOG_FILENAME,
+    resolveDaemonLogPath,
+    loadPersistedConfig: mocks.loadPersistedConfig,
+    resolvePaseoHome: vi.fn(() => mocks.paseoHome),
+    spawnProcess: mocks.spawnProcess,
+  };
+});
 
 vi.mock("../settings/desktop-settings-electron.js", () => ({
   getDesktopSettingsStore: () => ({
@@ -90,7 +100,10 @@ describe("daemon-manager commands", () => {
     mocks.createNodeEntrypointInvocation.mockReset();
     mocks.createNodeEntrypointInvocation.mockReturnValue({ command: "node", args: [], env: {} });
     mocks.spawnProcess.mockReset();
+    mocks.loadPersistedConfig.mockReset();
+    mocks.loadPersistedConfig.mockReturnValue({});
     mocks.logInfo.mockReset();
+    mocks.logWarn.mockReset();
     mocks.logError.mockReset();
     mocks.getElectronLogFile.mockReset();
     mocks.getElectronLogFile.mockReturnValue({ path: mocks.appLogPath });
@@ -98,6 +111,33 @@ describe("daemon-manager commands", () => {
 
   afterEach(() => {
     rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("reads the daemon log from the configured log.file.path", () => {
+    mocks.loadPersistedConfig.mockReturnValue({ log: { file: { path: "logs/custom.log" } } });
+    const configuredLogPath = path.resolve(mocks.paseoHome, "logs", "custom.log");
+    mkdirSync(path.dirname(configuredLogPath), { recursive: true });
+    writeFileSync(configuredLogPath, "configured log line\n");
+    writeFileSync(path.join(mocks.paseoHome, "daemon.log"), "default log line\n");
+
+    expect(createDaemonCommandHandlers().desktop_daemon_logs()).toEqual({
+      logPath: configuredLogPath,
+      contents: "configured log line",
+    });
+  });
+
+  it("falls back to the default daemon log when the config cannot be read", () => {
+    mocks.loadPersistedConfig.mockImplementation(() => {
+      throw new Error("invalid config");
+    });
+    mkdirSync(mocks.paseoHome, { recursive: true });
+    writeFileSync(path.join(mocks.paseoHome, "daemon.log"), "default log line\n");
+
+    expect(createDaemonCommandHandlers().desktop_daemon_logs()).toEqual({
+      logPath: path.join(mocks.paseoHome, "daemon.log"),
+      contents: "default log line",
+    });
+    expect(mocks.logWarn).toHaveBeenCalled();
   });
 
   it("returns the Electron main-process log tail from electron-log", () => {

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import { app, ipcMain, powerMonitor } from "electron";
 import log from "electron-log/main";
 import {
+  DEFAULT_DAEMON_LOG_FILENAME,
+  loadPersistedConfig,
+  resolveDaemonLogPath,
   resolvePaseoHome,
   startDaemonInstance,
   DaemonInstanceError,
@@ -53,7 +56,6 @@ import {
 } from "../integrations/legacy-skill-selection.js";
 import { tailFile } from "../diagnostics/tail-file.js";
 
-const DAEMON_LOG_FILENAME = "daemon.log";
 let ownedLaunch: { home: string; instance: DaemonInstance } | null = null;
 
 type DesktopDaemonState = "starting" | "running" | "stopped" | "errored";
@@ -127,7 +129,13 @@ function getPaseoHome(): string {
 }
 
 function logFilePath(): string {
-  return path.join(getPaseoHome(), DAEMON_LOG_FILENAME);
+  const paseoHome = getPaseoHome();
+  try {
+    return resolveDaemonLogPath(paseoHome, loadPersistedConfig(paseoHome));
+  } catch (err) {
+    log.warn("[desktop daemon]", "Failed to read config for log path; using default", { err });
+    return path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
+  }
 }
 
 export function isDesktopManagedDaemonRunningSync(): boolean {

--- a/packages/server/scripts/supervisor-log-config.ts
+++ b/packages/server/scripts/supervisor-log-config.ts
@@ -1,8 +1,6 @@
-import path from "node:path";
-
+import { resolveDaemonLogPath } from "../src/server/daemon-log-path.js";
 import type { loadPersistedConfig } from "../src/server/persisted-config.js";
 
-const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
 const DEFAULT_LOG_ROTATE_SIZE = "10m";
 const DEFAULT_LOG_ROTATE_MAX_FILES = 3;
 
@@ -12,18 +10,11 @@ export function resolveSupervisorLogFile(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const configuredFile = persistedConfig.log?.file;
-  const configuredPath = configuredFile?.path;
   const envRotateSize = env.PASEO_LOG_ROTATE_SIZE?.trim();
   const envRotateMaxFiles = parseOptionalPositiveInteger(env.PASEO_LOG_ROTATE_COUNT);
-  let logPath = path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
-  if (configuredPath) {
-    logPath = path.isAbsolute(configuredPath)
-      ? configuredPath
-      : path.resolve(paseoHome, configuredPath);
-  }
 
   return {
-    path: logPath,
+    path: resolveDaemonLogPath(paseoHome, persistedConfig),
     rotate: {
       maxSize: configuredFile?.rotate?.maxSize ?? envRotateSize ?? DEFAULT_LOG_ROTATE_SIZE,
       maxFiles:

--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -28,6 +28,7 @@ async function runSupervisorFixture(options: {
   signal: NodeJS.Signals | null;
   elapsedMs: number;
   log: string;
+  logPath: string;
   stdout: string;
   stderr: string;
 }> {
@@ -99,7 +100,7 @@ async function runSupervisorFixture(options: {
   });
 
   const log = await readFile(logPath, "utf8");
-  return { code, signal, elapsedMs: Date.now() - startedAt, log, stdout, stderr };
+  return { code, signal, elapsedMs: Date.now() - startedAt, log, logPath, stdout, stderr };
 }
 
 describe("supervisor durable logging", () => {
@@ -169,6 +170,18 @@ describe("supervisor durable logging", () => {
     expect(result.log).toContain('"worker-json-stderr"');
     expect(result.stdout).toContain('"worker-json-stdout"');
     expect(result.stderr).toContain('"worker-json-stderr"');
+  });
+
+  // POSIX-only: Windows does not honour POSIX file modes.
+  test.skipIf(isPlatform("win32"))("creates the log file owner-only", async () => {
+    const result = await runSupervisorFixture({
+      workerSource: `
+        process.stdout.write('mode check\\n');
+        process.exit(0);
+      `,
+    });
+
+    expect((await stat(result.logPath)).mode & 0o777).toBe(0o600);
   });
 
   test("preserves raw non-JSON stdout and stderr lines", async () => {

--- a/packages/server/scripts/supervisor.ts
+++ b/packages/server/scripts/supervisor.ts
@@ -2,6 +2,7 @@ import { fork, spawn, type ChildProcess } from "child_process";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { createStream as createRotatingFileStream } from "rotating-file-stream";
+import { ensurePrivateFile, PRIVATE_FILE_MODE } from "../src/server/private-files.js";
 import { signalProcessTree } from "../src/utils/tree-kill.js";
 
 const WORKER_HEARTBEAT_INTERVAL_MS = 1_000;
@@ -112,10 +113,15 @@ function createSupervisorLogStream(options: SupervisorLogFileOptions | undefined
   }
 
   mkdirSync(path.dirname(options.path), { recursive: true });
+  // The log carries verbatim agent stdout/stderr, so it stays owner-only. `mode`
+  // covers the current file and every rotated file, but only at creation time —
+  // chmod the existing log so upgrades tighten one an older release left behind.
+  ensurePrivateFile(options.path);
   return createRotatingFileStream(path.basename(options.path), {
     path: path.dirname(options.path),
     size: toRotatingFileStreamSize(options.rotate.maxSize),
     maxFiles: options.rotate.maxFiles,
+    mode: PRIVATE_FILE_MODE,
   });
 }
 

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -168,6 +168,7 @@ import type { TerminalManager } from "../terminal/terminal-manager.js";
 import { createConfiguredTerminalManager } from "../terminal/terminal-manager-factory.js";
 import { applyTerminalAgentHookSetting } from "../terminal/agent-hooks/terminal-agent-hook-setting.js";
 import { loadOrCreateDaemonKeyPair } from "./daemon-keypair.js";
+import { resolveDaemonLogPath } from "./daemon-log-path.js";
 import { createRelayRuntime, type RelayRuntime } from "./relay-runtime.js";
 import type { PushNotificationSender } from "./push/index.js";
 import { getOrCreateServerId } from "./server-id.js";
@@ -1701,6 +1702,7 @@ export async function createPaseoDaemon(
                   return appBaseUrl;
                 },
                 desktopManaged: config.desktopManaged === true,
+                logPath: resolveDaemonLogPath(config.paseoHome, { log: config.log }),
                 getRelayConfig: () =>
                   relayRuntime?.getConfig() ?? {
                     enabled: daemonConfigStore.get().relay?.enabled ?? relayEnabled,

--- a/packages/server/src/server/daemon-log-path.test.ts
+++ b/packages/server/src/server/daemon-log-path.test.ts
@@ -1,0 +1,31 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_DAEMON_LOG_FILENAME, resolveDaemonLogPath } from "./daemon-log-path.js";
+
+const paseoHome = path.join(path.sep, "tmp", "paseo-log-path-tests");
+
+describe("resolveDaemonLogPath", () => {
+  it("defaults to daemon.log in PASEO_HOME", () => {
+    const expected = path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
+
+    expect(resolveDaemonLogPath(paseoHome)).toBe(expected);
+    expect(resolveDaemonLogPath(paseoHome, {})).toBe(expected);
+    expect(resolveDaemonLogPath(paseoHome, { log: {} })).toBe(expected);
+    expect(resolveDaemonLogPath(paseoHome, { log: { file: {} } })).toBe(expected);
+  });
+
+  it("uses an absolute configured path as-is", () => {
+    const absolute = path.join(path.sep, "var", "log", "paseo", "daemon.log");
+
+    expect(resolveDaemonLogPath(paseoHome, { log: { file: { path: absolute } } })).toBe(absolute);
+  });
+
+  it("resolves a relative configured path against PASEO_HOME", () => {
+    expect(resolveDaemonLogPath(paseoHome, { log: { file: { path: "logs/daemon.log" } } })).toBe(
+      path.resolve(paseoHome, "logs", "daemon.log"),
+    );
+    expect(
+      resolveDaemonLogPath(paseoHome, { log: { file: { path: "../shared/daemon.log" } } }),
+    ).toBe(path.resolve(paseoHome, "..", "shared", "daemon.log"));
+  });
+});

--- a/packages/server/src/server/daemon-log-path.ts
+++ b/packages/server/src/server/daemon-log-path.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+
+export const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
+
+/**
+ * Minimal slice of the persisted config needed to locate the daemon log file.
+ * Kept structural so callers can pass a full `PersistedConfig` without importing it.
+ */
+export interface DaemonLogPathConfig {
+  log?: {
+    file?: {
+      path?: string;
+    };
+  };
+}
+
+/**
+ * Supervisor, worker, and desktop all read and write the same daemon log, so they
+ * have to agree on where it lives. Absolute `log.file.path` values are used as-is,
+ * relative ones resolve against PASEO_HOME.
+ */
+export function resolveDaemonLogPath(paseoHome: string, config?: DaemonLogPathConfig): string {
+  const configuredPath = config?.log?.file?.path;
+  if (!configuredPath) {
+    return path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
+  }
+
+  if (path.isAbsolute(configuredPath)) {
+    return configuredPath;
+  }
+
+  return path.resolve(paseoHome, configuredPath);
+}

--- a/packages/server/src/server/daemon-worker.ts
+++ b/packages/server/src/server/daemon-worker.ts
@@ -2,6 +2,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { createPaseoDaemon, formatListenTarget } from "./bootstrap.js";
 import { loadConfig } from "./config.js";
+import { resolveDaemonLogPath } from "./daemon-log-path.js";
 import { resolvePaseoHome } from "./paseo-home.js";
 import { createRootLogger } from "./logger.js";
 import type { DaemonLifecycleIntent } from "./bootstrap.js";
@@ -42,12 +43,11 @@ function isPidAlive(pid: number): boolean {
 }
 
 function writeWorkerLifecycleLog(
-  paseoHome: string,
+  logPath: string,
   message: string,
   fields: Record<string, unknown> = {},
 ): void {
   try {
-    const logPath = path.join(paseoHome, "daemon.log");
     mkdirSync(path.dirname(logPath), { recursive: true });
     appendFileSync(
       logPath,
@@ -129,6 +129,7 @@ function applyCliFlagOverrides(config: ReturnType<typeof loadConfig>): void {
 
 async function main() {
   const { paseoHome, logger, config } = bootstrapFromEnvironment();
+  const workerLogPath = resolveDaemonLogPath(paseoHome, { log: config.log });
   let daemon: Awaited<ReturnType<typeof createPaseoDaemon>> | null = null;
   let shutdownPromise: Promise<number> | null = null;
   let exitHookInstalled = false;
@@ -252,7 +253,7 @@ async function main() {
       }
       supervisorExitRequested = true;
 
-      writeWorkerLifecycleLog(paseoHome, "Supervisor liveness lost; worker exiting", {
+      writeWorkerLifecycleLog(workerLogPath, "Supervisor liveness lost; worker exiting", {
         reason,
         ...getProcessDiagnostics(),
         supervisorPid,

--- a/packages/server/src/server/daemon-worker.ts
+++ b/packages/server/src/server/daemon-worker.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "./config.js";
 import { resolveDaemonLogPath } from "./daemon-log-path.js";
 import { resolvePaseoHome } from "./paseo-home.js";
 import { createRootLogger } from "./logger.js";
+import { PRIVATE_FILE_MODE } from "./private-files.js";
 import type { DaemonLifecycleIntent } from "./bootstrap.js";
 import { getProcessDiagnostics } from "./process-diagnostics.js";
 
@@ -59,7 +60,7 @@ function writeWorkerLifecycleLog(
         msg: message,
         ...fields,
       })}\n`,
-      "utf8",
+      { encoding: "utf8", mode: PRIVATE_FILE_MODE },
     );
   } catch {
     // Exit-reason logging must never prevent the worker from exiting.

--- a/packages/server/src/server/exports.ts
+++ b/packages/server/src/server/exports.ts
@@ -5,6 +5,11 @@ export { resolvePaseoHome } from "./paseo-home.js";
 export { getOrCreateServerId } from "./server-id.js";
 export { createRootLogger, type LogLevel, type LogFormat } from "./logger.js";
 export {
+  DEFAULT_DAEMON_LOG_FILENAME,
+  resolveDaemonLogPath,
+  type DaemonLogPathConfig,
+} from "./daemon-log-path.js";
+export {
   loadPersistedConfig,
   savePersistedConfig,
   type PersistedConfig,

--- a/packages/server/src/server/logger.test.ts
+++ b/packages/server/src/server/logger.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -207,6 +207,30 @@ describe("createRootLogger", () => {
     expect(logText).toContain('"proof":"file-explicit"');
     expect(logText).toContain('"msg":"explicit file logger"');
     expect(files).toEqual(["programmatic.log"]);
+    if (process.platform !== "win32") {
+      // The log carries verbatim agent stdout/stderr and must not be world-readable.
+      expect((await stat(logPath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("tightens permissions on a log file left world-readable by an older release", async () => {
+    const paseoHome = await mkdtemp(path.join(tmpdir(), "paseo-logger-chmod-"));
+    const logPath = path.join(paseoHome, "daemon.log");
+    await writeFile(logPath, "", { mode: 0o644 });
+    await chmod(logPath, 0o644);
+
+    await runLoggerFixture(`
+      const logger = createRootLogger(
+        { log: { file: { path: ${JSON.stringify(logPath)} } } },
+        { paseoHome: ${JSON.stringify(paseoHome)} },
+      );
+      logger.info("permission fixup");
+      logger.flush();
+    `);
+
+    if (process.platform !== "win32") {
+      expect((await stat(logPath)).mode & 0o777).toBe(0o600);
+    }
   });
 
   it("can disable file output for supervised workers", async () => {

--- a/packages/server/src/server/logger.ts
+++ b/packages/server/src/server/logger.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 import pino from "pino";
 import pretty from "pino-pretty";
+import { resolveDaemonLogPath } from "./daemon-log-path.js";
 import { resolveDaemonVersion } from "./daemon-version.js";
 import type { PersistedConfig } from "./persisted-config.js";
 import { resolvePaseoHome } from "./paseo-home.js";
@@ -45,7 +46,6 @@ const LOG_LEVEL_PRIORITIES: Record<LogLevel, number> = {
 const DEFAULT_CONSOLE_LEVEL: LogLevel = "info";
 const DEFAULT_CONSOLE_FORMAT: LogFormat = "json";
 const DEFAULT_FILE_LEVEL: LogLevel = "info";
-const DEFAULT_DAEMON_LOG_FILENAME = "daemon.log";
 const REDACT_PATHS = [
   "authorization",
   "Authorization",
@@ -60,19 +60,6 @@ const REDACT_PATHS = [
   'req.headers["sec-websocket-protocol"]',
   "req.headers.Sec-WebSocket-Protocol",
 ];
-
-function resolveFilePath(paseoHome: string, configuredPath: string | undefined): string {
-  const fallback = path.join(paseoHome, DEFAULT_DAEMON_LOG_FILENAME);
-  if (!configuredPath) {
-    return fallback;
-  }
-
-  if (path.isAbsolute(configuredPath)) {
-    return configuredPath;
-  }
-
-  return path.resolve(paseoHome, configuredPath);
-}
 
 function minLogLevel(levels: LogLevel[]): LogLevel {
   let minLevel = levels[0];
@@ -148,7 +135,7 @@ export function resolveLogConfig(
     options?.file !== false && persistedLog?.file
       ? {
           level: fileLevel ?? DEFAULT_FILE_LEVEL,
-          path: resolveFilePath(paseoHome, persistedLog.file.path),
+          path: resolveDaemonLogPath(paseoHome, persistedConfig),
         }
       : undefined;
 

--- a/packages/server/src/server/logger.ts
+++ b/packages/server/src/server/logger.ts
@@ -6,6 +6,7 @@ import { resolveDaemonLogPath } from "./daemon-log-path.js";
 import { resolveDaemonVersion } from "./daemon-version.js";
 import type { PersistedConfig } from "./persisted-config.js";
 import { resolvePaseoHome } from "./paseo-home.js";
+import { ensurePrivateFile, PRIVATE_FILE_MODE } from "./private-files.js";
 
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 export type LogFormat = "pretty" | "json";
@@ -154,9 +155,19 @@ export function createRootLogger(
   options?: ResolveLogConfigOptions,
 ): pino.Logger {
   const config = resolveLogConfig(configInput, options);
-  if (config.file) {
-    mkdirSync(path.dirname(config.file.path), { recursive: true });
+  const filePath = config.file?.path;
+  if (filePath) {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    // The log carries verbatim agent stdout/stderr. `mode` below only applies when
+    // the file is created, so tighten a log left world-readable by an older release.
+    ensurePrivateFile(filePath);
   }
+
+  // Open the file destination here rather than handing pino-pretty a path: it does
+  // not forward a mode when it opens the file itself.
+  const fileDestination = filePath
+    ? pino.destination({ dest: filePath, sync: false, mode: PRIVATE_FILE_MODE })
+    : null;
 
   const stream =
     config.console.format === "pretty"
@@ -164,9 +175,9 @@ export function createRootLogger(
           colorize: true,
           singleLine: true,
           ignore: "pid,hostname",
-          destination: config.file?.path ?? 1,
+          destination: fileDestination ?? 1,
         })
-      : pino.destination({ dest: config.file?.path ?? 1, sync: false });
+      : (fileDestination ?? pino.destination({ dest: 1, sync: false }));
 
   const logger = pino(
     {

--- a/packages/server/src/server/session/daemon/daemon-session.test.ts
+++ b/packages/server/src/server/session/daemon/daemon-session.test.ts
@@ -376,6 +376,28 @@ describe("DaemonSession", () => {
     expect(message.payload.diagnostic).not.toContain("pairing-secret");
   });
 
+  test("diagnostics tails the resolved daemon log path", async () => {
+    const configuredLogPath = join(makeHome(), "custom.log");
+    const { subsystem, emitted, paseoHome } = makeSubsystem({
+      daemonRuntimeConfig: {
+        listen: "127.0.0.1:6767",
+        logPath: configuredLogPath,
+        getRelayConfig: () => null,
+      },
+    });
+    writeFileSync(configuredLogPath, "configured log line\n");
+    writeFileSync(join(paseoHome, "daemon.log"), "default log line\n");
+
+    await subsystem.handleDiagnosticsRequest({ type: "diagnostics.request", requestId: "d-log" });
+
+    const message = emitted[0];
+    if (message?.type !== "diagnostics.response") {
+      throw new Error("expected diagnostics response");
+    }
+    expect(message.payload.diagnostic).toContain("configured log line");
+    expect(message.payload.diagnostic).not.toContain("default log line");
+  });
+
   test("diagnostics includes the PATH and shell visible to the daemon", async () => {
     const originalPath = process.env.PATH;
     const originalShell = process.env.SHELL;

--- a/packages/server/src/server/session/daemon/daemon-session.ts
+++ b/packages/server/src/server/session/daemon/daemon-session.ts
@@ -18,6 +18,9 @@ export interface DaemonRuntimeConfig {
   worktreesRoot?: string;
   appBaseUrl?: string;
   desktopManaged?: boolean;
+  // Resolved from `log.file.path` at bootstrap. Diagnostics tails the default when
+  // it is absent, which is what a caller that never configured logging would get.
+  logPath?: string;
   getRelayConfig(): {
     enabled: boolean;
     endpoint: string;

--- a/packages/server/src/server/session/daemon/diagnostics.ts
+++ b/packages/server/src/server/session/daemon/diagnostics.ts
@@ -1,6 +1,5 @@
 import { open, statfs } from "node:fs/promises";
 import { cpus, freemem, loadavg, platform, release, totalmem, type } from "node:os";
-import path from "node:path";
 
 import type pino from "pino";
 
@@ -8,6 +7,7 @@ import type { ManagedAgent, ProviderAvailability } from "../../agent/agent-manag
 import type { WebSocketRuntimeDiagnosticSnapshot } from "../../websocket/runtime-metrics.js";
 import type { PersistedProjectRecord, PersistedWorkspaceRecord } from "../../workspace-registry.js";
 import { execCommand } from "../../../utils/spawn.js";
+import { resolveDaemonLogPath } from "../../daemon-log-path.js";
 import type { DaemonRuntimeConfig } from "./daemon-session.js";
 
 interface DiagnosticEntry {
@@ -424,7 +424,7 @@ async function checkTool(command: string, args: string[]): Promise<string> {
 }
 
 async function safeLogTailSection(options: DaemonDiagnosticsOptions): Promise<string> {
-  const logPath = path.join(options.paseoHome, "daemon.log");
+  const logPath = options.daemonRuntimeConfig?.logPath ?? resolveDaemonLogPath(options.paseoHome);
   try {
     const tail = await tailFile(logPath, LOG_TAIL_LINES, LOG_TAIL_MAX_BYTES);
     return ["Daemon log tail", `  Path: ${logPath}`, tail ? tail : "  No log lines found"].join(


### PR DESCRIPTION
## Problem

Two independent bugs around the daemon log file.

**1. `log.file.path` was honored in one place and ignored in four.** The config field exists and `logger.ts` respected it, but every other reader hardcoded `$PASEO_HOME/daemon.log`. With `log.file.path` set, the daemon wrote to one file while the desktop log viewer, `paseo daemon status`, the log tail after a failed start, the onboarding hint, and the diagnostics tail all pointed at a file that was never written.

**2. Daemon logs were world-readable.** They were created 0644 inside the 0700 `$PASEO_HOME`, so confidentiality depended entirely on the parent directory. The supervisor pipes agent stdout/stderr into the log verbatim (`scripts/supervisor.ts`), so these files can contain whatever an agent printed — including secrets an agent echoed. Pino redacts `authorization` headers, but that only covers the daemon's own structured logs, not piped child output.

## Change

**One resolver.** New `packages/server/src/server/daemon-log-path.ts` exports `resolveDaemonLogPath(paseoHome, config)` (absolute path used as-is, relative resolved against `PASEO_HOME`, default `daemon.log`). Now used by `logger.ts`, `supervisor-log-config.ts`, `daemon-worker.ts`, diagnostics, the desktop daemon manager, and the CLI. Where a caller already had the loaded config it is reused rather than re-read.

**0600 everywhere**, via the existing `PRIVATE_FILE_MODE`: the rotating stream (covers rotated files too), the pino destination, and the emergency append path. Plus a best-effort `chmod` of the current log at startup, so existing 0644 logs get tightened on upgrade.

Two implementation notes worth review attention:

- `logger.ts` now builds the file destination with `pino.destination({ dest, mode })` and hands pino-pretty a **stream** rather than a path, because pino-pretty opens the path itself and does not forward a mode.
- `DaemonLaunchRuntime` gained a `resolveLogPath` seam. Calling `loadPersistedConfig` inline in `startLocalDaemonDetached` would have made the existing detached-start unit test write a `config.json` into the hardcoded `/tmp/paseo-test` it passes as its home; the seam keeps that test off the filesystem.

## Evidence

```
$ NODE_ENV=test npx vitest run packages/server/src/server/daemon-log-path.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ NODE_ENV=test npx vitest run packages/server/src/server/logger.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  11 passed (11)

$ NODE_ENV=test npx vitest run packages/server/scripts/supervisor.logging.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ NODE_ENV=test npx vitest run packages/desktop/src/daemon/daemon-manager.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  13 passed (13)

$ NODE_ENV=test npx vitest run packages/cli/src/commands/daemon/local-daemon.supervision.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ NODE_ENV=test npx vitest run packages/server/src/server/session/daemon/daemon-session.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

New coverage, each asserting the real behavior rather than the plumbing:

- `daemon-log-path.test.ts` — default, absolute, relative (incl. `../`).
- `logger.test.ts` +2 — the created log is 0600; an existing 0644 log is tightened at startup.
- `supervisor.logging.test.ts` +1 — the rotating stream creates 0600.
- `daemon-manager.test.ts` +2 — the configured `log.file.path` is honored, and an unreadable config falls back to the default and warns.
- `local-daemon.supervision.test.ts` +2 — `resolveLocalDaemonState().logPath` and `resolveLocalDaemonLogPath()` agree, both when configured and by default.
- `daemon-session.test.ts` +1 — diagnostics tails the configured path and **not** a default `daemon.log` sitting in the same home.

`npm run typecheck`, `npm run lint`, `npm run format` all clean.

## Platforms

Daemon/CLI/desktop-main change; no renderer or UI surface.

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop Linux | ✅ | All suites above |
| Desktop macOS | — | POSIX modes behave the same; no platform-specific code |
| Desktop Windows | ⚠️ | Path resolution is `path`-based and covered. File modes are largely a no-op on Windows — the permissions half of this PR is a POSIX hardening, not a Windows one |
| Docker | — | Inherits the 0600 behavior; log path config unchanged |
| iOS / Android / Web | n/a | Not reachable |

## Remaining `daemon.log` mentions

All intentional: the constant in `daemon-log-path.ts`, a comment in `daemon-worker.ts`, a user-facing hint in the local speech worker client, and `daemon-e2e/opencode-omo-real-runtime.ts` (writes to a test-artifacts dir, not `PASEO_HOME`).

Context: part of a small series toward a dotfile-friendly config/state layout (the `PASEO_HOME`-holds-everything thread in Discord). Independent of the others — merges on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
