### PR TITLE
fix(server): stop Claude replay from accumulating running subagents

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts
@@ -57,14 +57,18 @@ function taskToolResult(options: { isError?: boolean; mentionAgentId?: boolean }
   });
 }
 
-function sidechainEntry(): string {
+function sidechainEntry(options: { stopReason?: string | null } = {}): string {
   return JSON.stringify({
     type: "assistant",
     isSidechain: true,
     agentId: AGENT_ID,
     sessionId: "replay-session",
     timestamp: "2026-07-26T06:27:50.000Z",
-    message: { role: "assistant", content: [{ type: "text", text: "summary of the docs" }] },
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "summary of the docs" }],
+      stop_reason: options.stopReason ?? null,
+    },
   });
 }
 
@@ -198,32 +202,42 @@ describe("ClaudeAgentSession persisted subagent replay", () => {
     expect(statuses).toContain("running");
   });
 
-  test("finishes a skill-spawned subagent the parent never named", async () => {
-    // The reported bug. A /code-review subagent has no Task tool_use, so its sidecar carries only
-    // agentType and its id appears nowhere in the parent — it used to replay as running forever,
-    // and every reopen resurrected it.
+  test("finishes a Task subagent from its own end_turn when the parent outcome is missing", async () => {
     writeSession({
-      parentLines: [parentEntry([{ type: "text", text: "running /code-review" }])],
-      meta: JSON.stringify({ agentType: "general-purpose" }),
-    });
-
-    const events = upserts(await replayDescriptors());
-    expect(events[0]).toMatchObject({ id: AGENT_ID });
-    expect(events.at(-1)).toMatchObject({ id: AGENT_ID, status: "completed" });
-  });
-
-  test("finishes a subagent whose toolUseId names no Task call in this transcript", async () => {
-    // A grandchild recorded before spawnDepth existed: the Task call it names was made inside a
-    // sibling's session, so no tool_result for it can ever reach this parent.
-    writeSession({
-      parentLines: [parentEntry([{ type: "text", text: "no task calls here" }])],
-      meta: JSON.stringify({ toolUseId: TOOL_USE_ID, agentType: "Explore" }),
+      parentLines: [taskToolUse()],
+      meta: JSON.stringify({ toolUseId: TOOL_USE_ID }),
+      sidechainLines: [sidechainEntry({ stopReason: "end_turn" })],
     });
 
     expect(upserts(await replayDescriptors()).at(-1)).toMatchObject({
       id: TOOL_USE_ID,
       status: "completed",
     });
+  });
+
+  test("does not replay a skill-spawned subagent the parent never named", async () => {
+    // The reported bug. A /code-review subagent has no Task tool_use, so its sidecar carries only
+    // agentType and its id appears nowhere in the parent — it used to replay as running forever,
+    // and every reopen resurrected it.
+    writeSession({
+      parentLines: [parentEntry([{ type: "text", text: "running /code-review" }])],
+      meta: JSON.stringify({ agentType: "general-purpose" }),
+      sidechainLines: [sidechainEntry({ stopReason: "end_turn" })],
+    });
+
+    expect(upserts(await replayDescriptors())).toEqual([]);
+  });
+
+  test("does not replay a subagent whose toolUseId names no Task call in this transcript", async () => {
+    // A grandchild recorded before spawnDepth existed: the Task call it names was made inside a
+    // sibling's session, so no tool_result for it can ever reach this parent.
+    writeSession({
+      parentLines: [parentEntry([{ type: "text", text: "no task calls here" }])],
+      meta: JSON.stringify({ toolUseId: TOOL_USE_ID, agentType: "Explore" }),
+      sidechainLines: [sidechainEntry({ stopReason: "end_turn" })],
+    });
+
+    expect(upserts(await replayDescriptors())).toEqual([]);
   });
 
   test.each([

--- a/packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts
@@ -57,11 +57,11 @@ function taskToolResult(options: { isError?: boolean; mentionAgentId?: boolean }
   });
 }
 
-function sidechainEntry(options: { stopReason?: string | null } = {}): string {
+function sidechainEntry(options: { agentId?: string; stopReason?: string | null } = {}): string {
   return JSON.stringify({
     type: "assistant",
     isSidechain: true,
-    agentId: AGENT_ID,
+    agentId: options.agentId ?? AGENT_ID,
     sessionId: "replay-session",
     timestamp: "2026-07-26T06:27:50.000Z",
     message: {
@@ -81,24 +81,40 @@ describe("ClaudeAgentSession persisted subagent replay", () => {
   let cwd: string;
   let configDir: string;
 
+  function writeParentSession(parentLines: string[]): string {
+    const historyDir = claudeProjectDirSync(cwd, { configDir });
+    mkdirSync(historyDir, { recursive: true });
+    writeFileSync(path.join(historyDir, "replay-session.jsonl"), parentLines.join("\n"));
+    return path.join(historyDir, "replay-session", "subagents");
+  }
+
+  function writeSubagent(options: {
+    subagentDir: string;
+    agentId?: string;
+    meta?: string | null;
+    sidechainLines?: string[];
+  }): void {
+    const agentId = options.agentId ?? AGENT_ID;
+    mkdirSync(options.subagentDir, { recursive: true });
+    writeFileSync(
+      path.join(options.subagentDir, `agent-${agentId}.jsonl`),
+      (options.sidechainLines ?? [sidechainEntry({ agentId })]).join("\n"),
+    );
+    if (options.meta !== null && options.meta !== undefined) {
+      writeFileSync(path.join(options.subagentDir, `agent-${agentId}.meta.json`), options.meta);
+    }
+  }
+
   function writeSession(options: {
     parentLines: string[];
     meta?: string | null;
     sidechainLines?: string[];
   }): void {
-    const historyDir = claudeProjectDirSync(cwd, { configDir });
-    mkdirSync(historyDir, { recursive: true });
-    writeFileSync(path.join(historyDir, "replay-session.jsonl"), options.parentLines.join("\n"));
-
-    const subagentDir = path.join(historyDir, "replay-session", "subagents");
-    mkdirSync(subagentDir, { recursive: true });
-    writeFileSync(
-      path.join(subagentDir, `agent-${AGENT_ID}.jsonl`),
-      (options.sidechainLines ?? [sidechainEntry()]).join("\n"),
-    );
-    if (options.meta !== null && options.meta !== undefined) {
-      writeFileSync(path.join(subagentDir, `agent-${AGENT_ID}.meta.json`), options.meta);
-    }
+    writeSubagent({
+      subagentDir: writeParentSession(options.parentLines),
+      meta: options.meta,
+      sidechainLines: options.sidechainLines,
+    });
   }
 
   async function replayDescriptors(): Promise<
@@ -224,6 +240,31 @@ describe("ClaudeAgentSession persisted subagent replay", () => {
       meta: JSON.stringify({ agentType: "general-purpose" }),
       sidechainLines: [sidechainEntry({ stopReason: "end_turn" })],
     });
+
+    expect(upserts(await replayDescriptors())).toEqual([]);
+  });
+
+  test("does not accumulate internal workflow agents as replay-only running rows", async () => {
+    const subagentRoot = writeParentSession([
+      parentEntry([
+        {
+          type: "tool_use",
+          id: "toolu_workflow",
+          name: "Workflow",
+          input: { script: "await Promise.all([agent('one'), agent('two'), agent('three')])" },
+        },
+      ]),
+    ]);
+    const workflowDir = path.join(subagentRoot, "workflows", "wf_c240e728-6ea");
+
+    for (const agentId of ["a17a341a0902f5799", "ae2d01ba2dfa46032", "abc9f20546c326c53"]) {
+      writeSubagent({
+        subagentDir: workflowDir,
+        agentId,
+        meta: JSON.stringify({ agentType: "workflow-subagent", spawnDepth: 1 }),
+        sidechainLines: [sidechainEntry({ agentId, stopReason: "end_turn" })],
+      });
+    }
 
     expect(upserts(await replayDescriptors())).toEqual([]);
   });

--- a/packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts
@@ -198,6 +198,34 @@ describe("ClaudeAgentSession persisted subagent replay", () => {
     expect(statuses).toContain("running");
   });
 
+  test("finishes a skill-spawned subagent the parent never named", async () => {
+    // The reported bug. A /code-review subagent has no Task tool_use, so its sidecar carries only
+    // agentType and its id appears nowhere in the parent — it used to replay as running forever,
+    // and every reopen resurrected it.
+    writeSession({
+      parentLines: [parentEntry([{ type: "text", text: "running /code-review" }])],
+      meta: JSON.stringify({ agentType: "general-purpose" }),
+    });
+
+    const events = upserts(await replayDescriptors());
+    expect(events[0]).toMatchObject({ id: AGENT_ID });
+    expect(events.at(-1)).toMatchObject({ id: AGENT_ID, status: "completed" });
+  });
+
+  test("finishes a subagent whose toolUseId names no Task call in this transcript", async () => {
+    // A grandchild recorded before spawnDepth existed: the Task call it names was made inside a
+    // sibling's session, so no tool_result for it can ever reach this parent.
+    writeSession({
+      parentLines: [parentEntry([{ type: "text", text: "no task calls here" }])],
+      meta: JSON.stringify({ toolUseId: TOOL_USE_ID, agentType: "Explore" }),
+    });
+
+    expect(upserts(await replayDescriptors()).at(-1)).toMatchObject({
+      id: TOOL_USE_ID,
+      status: "completed",
+    });
+  });
+
   test.each([
     ["truncated json", '{"toolUseId":"toolu_01DgLoPMW9"'],
     ["not json", "toolUseId: toolu"],

--- a/packages/server/src/server/agent/providers/claude/subagents/replay-source.test.ts
+++ b/packages/server/src/server/agent/providers/claude/subagents/replay-source.test.ts
@@ -126,8 +126,7 @@ describe("observeReplaySubagents", () => {
     expect(observations[0]).toMatchObject({ kind: "declared", id: TOOL_USE_ID });
   });
 
-  it("recovers identity from meta when the parent's Task call is missing", () => {
-    // The case the legacy scrape cannot handle: no tool_result, so no link and no identity.
+  it("drops a meta-linked subagent when the parent never declared its Task", () => {
     const observations = observeReplaySubagents({
       subagents: [
         {
@@ -140,12 +139,7 @@ describe("observeReplaySubagents", () => {
       convertEntry: () => [],
     });
 
-    expect(observations[0]).toMatchObject({
-      id: TOOL_USE_ID,
-      toolCallId: TOOL_USE_ID,
-      title: "Explore",
-      description: "Find the code",
-    });
+    expect(observations).toEqual([]);
   });
 
   it("falls back to the scraped link when there is no meta file", () => {
@@ -165,17 +159,16 @@ describe("observeReplaySubagents", () => {
     expect(rest.at(-1)).toMatchObject({ kind: "status", status: "completed" });
   });
 
-  it("keeps an unlinkable subagent visible under its own id", () => {
-    const [declared] = observeReplaySubagents({
+  it("drops an unlinkable subagent", () => {
+    const observations = observeReplaySubagents({
       subagents: [{ agentId: AGENT_ID, meta: null, entries: [] }],
       parent: emptyParent(),
       convertEntry: () => [],
     });
-    expect(declared).toMatchObject({ id: AGENT_ID });
-    expect(declared).not.toHaveProperty("toolCallId");
+    expect(observations).toEqual([]);
   });
 
-  it("finishes a subagent the parent has no Task call for", () => {
+  it("drops a terminal subagent the parent has no Task call for", () => {
     // A legacy grandchild: its toolUseId names a Task call made inside a sibling's transcript, so
     // no tool_result for it can ever reach the parent. Left running, it never stops.
     const descriptor = applyToStore(
@@ -184,7 +177,13 @@ describe("observeReplaySubagents", () => {
           {
             agentId: AGENT_ID,
             meta: { toolUseId: TOOL_USE_ID },
-            entries: [{ type: "assistant", timestamp: "2026-07-31T03:41:00.000Z" }],
+            entries: [
+              {
+                type: "assistant",
+                timestamp: "2026-07-31T03:41:00.000Z",
+                message: { stop_reason: "end_turn" },
+              },
+            ],
           },
         ],
         parent: emptyParent(),
@@ -192,14 +191,10 @@ describe("observeReplaySubagents", () => {
       }),
     );
 
-    expect(descriptor).toMatchObject({
-      id: TOOL_USE_ID,
-      status: "completed",
-      updatedAt: "2026-07-31T03:41:00.000Z",
-    });
+    expect(descriptor).toBeNull();
   });
 
-  it("finishes a skill-spawned subagent that has no link at all", () => {
+  it("drops a terminal skill-spawned subagent that has no link at all", () => {
     // A /code-review run: no Task tool_use exists to name it, so its sidecar carries only
     // agentType and its id appears nowhere in the parent transcript.
     const descriptor = applyToStore(
@@ -208,7 +203,13 @@ describe("observeReplaySubagents", () => {
           {
             agentId: AGENT_ID,
             meta: { agentType: "general-purpose" },
-            entries: [{ type: "assistant", timestamp: "2026-07-31T03:41:00.000Z" }],
+            entries: [
+              {
+                type: "assistant",
+                timestamp: "2026-07-31T03:41:00.000Z",
+                message: { stop_reason: "end_turn" },
+              },
+            ],
           },
         ],
         parent: emptyParent(),
@@ -216,12 +217,7 @@ describe("observeReplaySubagents", () => {
       }),
     );
 
-    expect(descriptor).toMatchObject({
-      id: AGENT_ID,
-      status: "completed",
-      toolCallId: null,
-      updatedAt: "2026-07-31T03:41:00.000Z",
-    });
+    expect(descriptor).toBeNull();
   });
 
   it("reports a scraped link's failure as failed", () => {
@@ -238,6 +234,52 @@ describe("observeReplaySubagents", () => {
     );
 
     expect(descriptor).toMatchObject({ id: TOOL_USE_ID, status: "failed" });
+  });
+
+  it("drops a non-terminal linkless subagent", () => {
+    const observations = observeReplaySubagents({
+      subagents: [
+        {
+          agentId: AGENT_ID,
+          meta: { agentType: "general-purpose" },
+          entries: [
+            {
+              type: "assistant",
+              timestamp: "2026-07-31T03:41:00.000Z",
+              message: { stop_reason: null },
+            },
+          ],
+        },
+      ],
+      parent: emptyParent(),
+      convertEntry: () => [],
+    });
+
+    expect(observations).toEqual([]);
+  });
+
+  it("finishes a terminal Task child when the parent has not recorded its outcome", () => {
+    const descriptor = applyToStore(
+      observeReplaySubagents({
+        subagents: [
+          {
+            agentId: AGENT_ID,
+            meta: { toolUseId: TOOL_USE_ID },
+            entries: [
+              {
+                type: "assistant",
+                timestamp: "2026-07-31T03:41:00.000Z",
+                message: { stop_reason: "end_turn" },
+              },
+            ],
+          },
+        ],
+        parent: { ...parentWithTaskCall(), outcomesByToolCallId: new Map() },
+        convertEntry: () => [],
+      }),
+    );
+
+    expect(descriptor).toMatchObject({ status: "completed" });
   });
 
   it("leaves a subagent with no recorded outcome running", () => {

--- a/packages/server/src/server/agent/providers/claude/subagents/replay-source.test.ts
+++ b/packages/server/src/server/agent/providers/claude/subagents/replay-source.test.ts
@@ -99,7 +99,7 @@ describe("observeReplaySubagents", () => {
     // Claude Code writes every descendant into the same subagents/ directory. A grandchild's
     // toolUseId names a Task call made inside its parent's session, so nothing here can resolve
     // it: it would replay as an extra row the live stream never showed, with no Task card and no
-    // outcome, running forever. One recorded session showed 10 subagents live and 22 on reopen.
+    // outcome. One recorded session showed 10 subagents live and 22 on reopen.
     const observations = observeReplaySubagents({
       subagents: [
         { agentId: AGENT_ID, meta: { toolUseId: TOOL_USE_ID, spawnDepth: 1 }, entries: [] },
@@ -173,6 +173,71 @@ describe("observeReplaySubagents", () => {
     });
     expect(declared).toMatchObject({ id: AGENT_ID });
     expect(declared).not.toHaveProperty("toolCallId");
+  });
+
+  it("finishes a subagent the parent has no Task call for", () => {
+    // A legacy grandchild: its toolUseId names a Task call made inside a sibling's transcript, so
+    // no tool_result for it can ever reach the parent. Left running, it never stops.
+    const descriptor = applyToStore(
+      observeReplaySubagents({
+        subagents: [
+          {
+            agentId: AGENT_ID,
+            meta: { toolUseId: TOOL_USE_ID },
+            entries: [{ type: "assistant", timestamp: "2026-07-31T03:41:00.000Z" }],
+          },
+        ],
+        parent: emptyParent(),
+        convertEntry: () => [],
+      }),
+    );
+
+    expect(descriptor).toMatchObject({
+      id: TOOL_USE_ID,
+      status: "completed",
+      updatedAt: "2026-07-31T03:41:00.000Z",
+    });
+  });
+
+  it("finishes a skill-spawned subagent that has no link at all", () => {
+    // A /code-review run: no Task tool_use exists to name it, so its sidecar carries only
+    // agentType and its id appears nowhere in the parent transcript.
+    const descriptor = applyToStore(
+      observeReplaySubagents({
+        subagents: [
+          {
+            agentId: AGENT_ID,
+            meta: { agentType: "general-purpose" },
+            entries: [{ type: "assistant", timestamp: "2026-07-31T03:41:00.000Z" }],
+          },
+        ],
+        parent: emptyParent(),
+        convertEntry: () => [],
+      }),
+    );
+
+    expect(descriptor).toMatchObject({
+      id: AGENT_ID,
+      status: "completed",
+      toolCallId: null,
+      updatedAt: "2026-07-31T03:41:00.000Z",
+    });
+  });
+
+  it("reports a scraped link's failure as failed", () => {
+    const descriptor = applyToStore(
+      observeReplaySubagents({
+        subagents: [{ agentId: AGENT_ID, meta: null, entries: [] }],
+        parent: {
+          toolCalls: new Map([[TOOL_USE_ID, { title: "Explore" }]]),
+          linksByAgentId: new Map([[AGENT_ID, { toolCallId: TOOL_USE_ID, failed: true }]]),
+          outcomesByToolCallId: new Map(),
+        },
+        convertEntry: () => [],
+      }),
+    );
+
+    expect(descriptor).toMatchObject({ id: TOOL_USE_ID, status: "failed" });
   });
 
   it("leaves a subagent with no recorded outcome running", () => {

--- a/packages/server/src/server/agent/providers/claude/subagents/replay-source.ts
+++ b/packages/server/src/server/agent/providers/claude/subagents/replay-source.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import type { AgentTimelineItem } from "../../../agent-sdk-types.js";
 import { normalizeProviderReplayTimestamp } from "../../../provider-history-timestamps.js";
+import type { ProviderSubagentStatus } from "../../../provider-subagents/store.js";
 import { resolveObservedClaudeModelId } from "../models.js";
 import type { SubagentObservation } from "./observation.js";
 import { buildClaudeSubagentSubtitle, type ClaudeSubagentUsage } from "./presentation.js";
@@ -152,42 +153,89 @@ export interface ClaudeReplayParentFacts {
   outcomesByToolCallId: ReadonlyMap<string, { failed: boolean }>;
 }
 
-interface ResolvedLink {
+interface ParentLink {
   id: string;
   toolCallId: string | null;
-  failed: boolean | null;
+  /** Terminal status the parent implies, or null when the child may still be running. */
+  status: ProviderSubagentStatus | null;
 }
 
 /**
- * Resolve the canonical subagent id.
+ * Everything the parent transcript can say about one child: its canonical id and, when the parent
+ * settles the question, its terminal status.
  *
- * `meta.toolUseId` is authoritative: it is the same id the live stream keys on. The legacy path
- * scrapes `agentId:` out of stringified tool-result content, which both misses the link when the
- * parent's tool_result is absent and matches unrelated text — on a real five-subagent session it
- * produced eight ids, inventing `z`, `string`, and `update`. It stays only as a fallback for
- * sessions recorded before the meta file existed.
+ * `meta.toolUseId` is authoritative for identity — it is the same id the live stream keys on. The
+ * legacy path scrapes `agentId:` out of stringified tool-result content, which both misses the link
+ * when the parent's tool_result is absent and matches unrelated text — on a real five-subagent
+ * session it produced eight ids, inventing `z`, `string`, and `update`. It stays only as a fallback
+ * for sessions recorded before the meta file existed.
+ *
+ * ```
+ * meta.toolUseId present?
+ * ├─ yes → outcomesByToolCallId has it?
+ * │         ├─ hit, is_error   → "failed"       id = toolCallId = toolUseId
+ * │         ├─ hit, ok         → "completed"    id = toolCallId = toolUseId
+ * │         └─ miss → parent.toolCalls has it?
+ * │                   ├─ yes   → null           interrupted mid-Task; a resume
+ * │                   │                         may still finish it — keep running
+ * │                   └─ no    → "completed"    no Task call ⇒ nothing in the parent
+ * │                                             can ever name it
+ * └─ no  → linksByAgentId (legacy scrape) hit?
+ *           ├─ hit, failed     → "failed"       id = toolCallId = scraped id
+ *           ├─ hit, ok         → "completed"
+ *           └─ miss            → "completed"    id = agentId, toolCallId = null
+ * ```
+ *
+ * Outcomes are only ever recorded for a child whose Task call was parsed out of the parent
+ * (`agent.ts` skips any tool_result whose id is not in `toolCalls`). So a child with no Task call
+ * is one no reader can finish: across every such transcript recorded on a real machine, no
+ * `tool_result` for it exists in the parent at all. Calling it completed is the only status that
+ * does not strand it as running forever. A child that *does* have a Task call but no result yet is
+ * the opposite case — the parent was interrupted mid-Task — and keeps running.
  */
-function resolveLink(
+function resolveParentLink(
   subagent: ClaudeReplaySubagentInput,
   parent: ClaudeReplayParentFacts,
-): ResolvedLink {
+): ParentLink {
   const metaToolUseId = subagent.meta?.toolUseId?.trim();
   if (metaToolUseId) {
     const outcome = parent.outcomesByToolCallId.get(metaToolUseId);
+    if (outcome) {
+      return {
+        id: metaToolUseId,
+        toolCallId: metaToolUseId,
+        status: outcome.failed ? "failed" : "completed",
+      };
+    }
     return {
       id: metaToolUseId,
       toolCallId: metaToolUseId,
-      failed: outcome ? outcome.failed : null,
+      status: parent.toolCalls.has(metaToolUseId) ? null : "completed",
     };
   }
 
   const scraped = parent.linksByAgentId.get(subagent.agentId);
   if (scraped) {
-    return { id: scraped.toolCallId, toolCallId: scraped.toolCallId, failed: scraped.failed };
+    return {
+      id: scraped.toolCallId,
+      toolCallId: scraped.toolCallId,
+      status: scraped.failed ? "failed" : "completed",
+    };
   }
 
-  // No link at all: keep the subagent visible under its own agent id rather than dropping it.
-  return { id: subagent.agentId, toolCallId: null, failed: null };
+  // No link at all. `parseClaudeSubagentMeta` collapses absent, malformed, and pre-sidecar metadata
+  // into the same null, so all of those land here beside a genuine skill-spawned child: a
+  // `/code-review` subagent has no Task tool_use to name, so its sidecar carries only `agentType`
+  // and its id appears nowhere in the parent. Keep it visible under its own agent id rather than
+  // dropping it — the transcript is real and readable.
+  //
+  // Known asymmetry: `live-source.ts` drops any announced task with no `tool_use_id`, so the live
+  // path cannot declare a skill-spawned child and only replay produces this row. That is in tension
+  // with the live/replay parity claim in `agent.ts`. Keeping the row is the reversible direction;
+  // hiding a real transcript is not. If Claude Code ever does send a `tool_use_id` on the live
+  // frame, this becomes an identity split — live would key the row by that id while replay keys it
+  // by the raw agent id — and archive state would stop sticking across a reopen.
+  return { id: subagent.agentId, toolCallId: null, status: "completed" };
 }
 
 /**
@@ -196,7 +244,7 @@ function resolveLink(
  */
 function declareSubagent(
   subagent: ClaudeReplaySubagentInput,
-  link: ResolvedLink,
+  link: ParentLink,
   toolCall: { title?: string; description?: string } | undefined,
 ): SubagentObservation {
   const title = toolCall?.title ?? subagent.meta?.agentType;
@@ -214,7 +262,7 @@ function declareSubagent(
 
 function observeSubtitle(
   subagent: ClaudeReplaySubagentInput,
-  link: ResolvedLink,
+  link: ParentLink,
   title: string | undefined,
 ): SubagentObservation | null {
   const runtime = readRuntime(subagent.entries);
@@ -244,7 +292,7 @@ function observeSubagent(
   parent: ClaudeReplayParentFacts,
   convertEntry: (entry: ClaudeReplayEntry) => AgentTimelineItem[],
 ): SubagentObservation[] {
-  const link = resolveLink(subagent, parent);
+  const link = resolveParentLink(subagent, parent);
   const toolCall = link.toolCallId ? parent.toolCalls.get(link.toolCallId) : undefined;
 
   const observations: SubagentObservation[] = [declareSubagent(subagent, link, toolCall)];
@@ -263,14 +311,15 @@ function observeSubagent(
     }
   }
 
-  // A transcript with no recorded outcome is a subagent that never finished — leave it running
-  // rather than inventing a completion.
-  if (link.failed !== null) {
+  // No terminal status means the parent was interrupted mid-Task, so leave the child running rather
+  // than inventing a completion. The timestamp is the child's last entry, so a finished row sorts
+  // at the time it actually stopped rather than at reopen.
+  if (link.status) {
     const lastTimestamp = normalizeProviderReplayTimestamp(subagent.entries.at(-1)?.timestamp);
     observations.push({
       kind: "status",
       id: link.id,
-      status: link.failed ? "failed" : "completed",
+      status: link.status,
       ...(lastTimestamp ? { timestamp: lastTimestamp } : {}),
     });
   }
@@ -286,9 +335,8 @@ function observeSubagent(
  * another subagent. A grandchild's `toolUseId` names a Task call made inside its parent's session,
  * so nothing in this transcript can resolve it — surveyed across recorded sessions, every depth-1
  * id matched a Task tool_use block in the parent transcript and no deeper id did. Replaying them
- * anyway adds rows the live stream never showed, each with no Task card and no recoverable
- * outcome, which leaves them running forever. One session recorded 10 subagents live and would
- * replay 22.
+ * anyway adds rows the live stream never showed, each with no Task card and no recoverable outcome.
+ * One session recorded 10 subagents live and would replay 22.
  *
  * Absent depth means a session recorded before the field existed: keep the subagent rather than
  * lose it, matching how every other missing field here is treated.

--- a/packages/server/src/server/agent/providers/claude/subagents/replay-source.ts
+++ b/packages/server/src/server/agent/providers/claude/subagents/replay-source.ts
@@ -155,14 +155,13 @@ export interface ClaudeReplayParentFacts {
 
 interface ParentLink {
   id: string;
-  toolCallId: string | null;
-  /** Terminal status the parent implies, or null when the child may still be running. */
+  toolCallId: string;
+  /** Terminal status recorded by the parent, or null when its Task has no outcome yet. */
   status: ProviderSubagentStatus | null;
 }
 
 /**
- * Everything the parent transcript can say about one child: its canonical id and, when the parent
- * settles the question, its terminal status.
+ * Resolve a child only when the parent transcript declares the corresponding Task.
  *
  * `meta.toolUseId` is authoritative for identity — it is the same id the live stream keys on. The
  * legacy path scrapes `agentId:` out of stringified tool-result content, which both misses the link
@@ -171,51 +170,35 @@ interface ParentLink {
  * for sessions recorded before the meta file existed.
  *
  * ```
- * meta.toolUseId present?
- * ├─ yes → outcomesByToolCallId has it?
- * │         ├─ hit, is_error   → "failed"       id = toolCallId = toolUseId
- * │         ├─ hit, ok         → "completed"    id = toolCallId = toolUseId
- * │         └─ miss → parent.toolCalls has it?
- * │                   ├─ yes   → null           interrupted mid-Task; a resume
- * │                   │                         may still finish it — keep running
- * │                   └─ no    → "completed"    no Task call ⇒ nothing in the parent
- * │                                             can ever name it
- * └─ no  → linksByAgentId (legacy scrape) hit?
- *           ├─ hit, failed     → "failed"       id = toolCallId = scraped id
- *           ├─ hit, ok         → "completed"
- *           └─ miss            → "completed"    id = agentId, toolCallId = null
+ * meta.toolUseId matches a parent Task?
+ * ├─ yes → use it and the parent's outcome, when present
+ * └─ no  → a legacy scraped agentId link matches a parent Task?
+ *           ├─ yes → use it and its recorded outcome
+ *           └─ no  → drop it; live never declared this child either
  * ```
  *
- * Outcomes are only ever recorded for a child whose Task call was parsed out of the parent
- * (`agent.ts` skips any tool_result whose id is not in `toolCalls`). So a child with no Task call
- * is one no reader can finish: across every such transcript recorded on a real machine, no
- * `tool_result` for it exists in the parent at all. Calling it completed is the only status that
- * does not strand it as running forever. A child that *does* have a Task call but no result yet is
- * the opposite case — the parent was interrupted mid-Task — and keeps running.
+ * Claude writes grandchildren and skill-owned sidechains beside direct children. Admitting those
+ * without a parent Task creates replay-only rows with no identity or lifecycle source. Filtering
+ * here keeps live and replay on the same declaration boundary.
  */
 function resolveParentLink(
   subagent: ClaudeReplaySubagentInput,
   parent: ClaudeReplayParentFacts,
-): ParentLink {
+): ParentLink | null {
   const metaToolUseId = subagent.meta?.toolUseId?.trim();
-  if (metaToolUseId) {
+  if (metaToolUseId && parent.toolCalls.has(metaToolUseId)) {
     const outcome = parent.outcomesByToolCallId.get(metaToolUseId);
-    if (outcome) {
-      return {
-        id: metaToolUseId,
-        toolCallId: metaToolUseId,
-        status: outcome.failed ? "failed" : "completed",
-      };
-    }
+    let status: ProviderSubagentStatus | null = null;
+    if (outcome) status = outcome.failed ? "failed" : "completed";
     return {
       id: metaToolUseId,
       toolCallId: metaToolUseId,
-      status: parent.toolCalls.has(metaToolUseId) ? null : "completed",
+      status,
     };
   }
 
   const scraped = parent.linksByAgentId.get(subagent.agentId);
-  if (scraped) {
+  if (scraped && parent.toolCalls.has(scraped.toolCallId)) {
     return {
       id: scraped.toolCallId,
       toolCallId: scraped.toolCallId,
@@ -223,19 +206,19 @@ function resolveParentLink(
     };
   }
 
-  // No link at all. `parseClaudeSubagentMeta` collapses absent, malformed, and pre-sidecar metadata
-  // into the same null, so all of those land here beside a genuine skill-spawned child: a
-  // `/code-review` subagent has no Task tool_use to name, so its sidecar carries only `agentType`
-  // and its id appears nowhere in the parent. Keep it visible under its own agent id rather than
-  // dropping it — the transcript is real and readable.
-  //
-  // Known asymmetry: `live-source.ts` drops any announced task with no `tool_use_id`, so the live
-  // path cannot declare a skill-spawned child and only replay produces this row. That is in tension
-  // with the live/replay parity claim in `agent.ts`. Keeping the row is the reversible direction;
-  // hiding a real transcript is not. If Claude Code ever does send a `tool_use_id` on the live
-  // frame, this becomes an identity split — live would key the row by that id while replay keys it
-  // by the raw agent id — and archive state would stop sticking across a reopen.
-  return { id: subagent.agentId, toolCallId: null, status: "completed" };
+  return null;
+}
+
+/** A final `end_turn` is the child's own completion signal when the parent result is absent. */
+function readChildTerminalStatus(
+  entries: readonly ClaudeReplayEntry[],
+): ProviderSubagentStatus | null {
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index];
+    if (entry?.type !== "assistant") continue;
+    return entry.message?.stop_reason === "end_turn" ? "completed" : null;
+  }
+  return null;
 }
 
 /**
@@ -293,7 +276,8 @@ function observeSubagent(
   convertEntry: (entry: ClaudeReplayEntry) => AgentTimelineItem[],
 ): SubagentObservation[] {
   const link = resolveParentLink(subagent, parent);
-  const toolCall = link.toolCallId ? parent.toolCalls.get(link.toolCallId) : undefined;
+  if (!link) return [];
+  const toolCall = parent.toolCalls.get(link.toolCallId);
 
   const observations: SubagentObservation[] = [declareSubagent(subagent, link, toolCall)];
   const subtitle = observeSubtitle(subagent, link, toolCall?.title ?? subagent.meta?.agentType);
@@ -311,15 +295,15 @@ function observeSubagent(
     }
   }
 
-  // No terminal status means the parent was interrupted mid-Task, so leave the child running rather
-  // than inventing a completion. The timestamp is the child's last entry, so a finished row sorts
-  // at the time it actually stopped rather than at reopen.
-  if (link.status) {
+  // Prefer the parent's result because it carries failure. If that result is missing, the child's
+  // final end_turn still proves completion. Any other shape remains running.
+  const terminalStatus = link.status ?? readChildTerminalStatus(subagent.entries);
+  if (terminalStatus) {
     const lastTimestamp = normalizeProviderReplayTimestamp(subagent.entries.at(-1)?.timestamp);
     observations.push({
       kind: "status",
       id: link.id,
-      status: link.status,
+      status: terminalStatus,
       ...(lastTimestamp ? { timestamp: lastTimestamp } : {}),
     });
   }

--- a/packages/server/src/server/agent/providers/claude/subagents/replay-source.ts
+++ b/packages/server/src/server/agent/providers/claude/subagents/replay-source.ts
@@ -222,8 +222,8 @@ function readChildTerminalStatus(
 }
 
 /**
- * The parent's tool input is the same source the live path reads, so it wins; meta.json fills the
- * gap when the parent's Task call is missing from the transcript.
+ * The parent's tool input is the same identity source the live path reads; meta.json contributes
+ * provider details only after that declaration has admitted the child.
  */
 function declareSubagent(
   subagent: ClaudeReplaySubagentInput,


### PR DESCRIPTION
### Linked evidence

Closes [#2874](https://github.com/getpaseo/paseo/issues/2874).
Closes [#2445](https://github.com/getpaseo/paseo/issues/2445).

Also covers the current replay form of [#2860](https://github.com/getpaseo/paseo/issues/2860): declared Task children already finish from the parent result, and this change accepts the child final `end_turn` when that parent outcome is absent.

The same replay bug produced the Discord report showing `22 subagents · 22 running`: [report and screenshot](https://discord.com/channels/1481169421832814616/1481169422990184542/1534611062681239765).

### What changed

Claude replay now uses the same admission boundary as the live task-protocol path: a provider-subagent descriptor exists only when the parent transcript declares the matching `Task`/`Agent` call.

This removes replay-only rows from:

- skill-owned sidechains such as `/code-review`, which have no parent Task;
- internal Workflow agents stored under `subagents/workflows/<run>/`, whose parent announcement is `local_workflow` and is deliberately excluded live; and
- legacy grandchildren whose Task belongs to another transcript.

For declared Task children, terminal status comes from the parent result when present. A final child `stop_reason: "end_turn"` supplies completion when the parent result is missing. A declared child with neither signal remains running.

No protocol or UI change.

### Real Claude verification

Claude Code `2.1.220`, captured from real CLI runs and replayed through rebuilt Paseo server code:

| Runtime case | Current `main` replay | This PR |
| --- | --- | --- |
| `/code-review`: one finished child, meta contains only `agentType` | 1 `running` row | no row |
| Workflow with 3 concurrent agents: 3 distinct transcript IDs under `subagents/workflows/...`, each meta is `workflow-subagent` | 3 `running` rows | no rows |
| 3 declared foreground Tasks with matching completion results | 3 `completed` rows | 3 `completed` rows |
| Declared Task interrupted after `task_started` and `task_progress`; Claude emitted `stopped`, `killed`, and rejected result | `failed` | `failed` |

The Workflow run reproduces the Discord screenshot shape: Claude creates one real transcript per internal workflow agent. The rows are not duplicate progress events for one child. Replay recursively admitted children that live mode had rejected, so a workflow with 22 agents accumulated 22 stale rows with the same model and effort and differing token totals.

### Automated verification

The persisted-layout regression now includes the real nested Workflow directory shape with three distinct child IDs.

```text
npx vitest run packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts packages/server/src/server/agent/providers/claude/subagents/replay-source.test.ts --bail=1

Test Files  2 passed (2)
Tests      48 passed (48)

npm run build:server  # passed
npm run typecheck     # passed
npm run lint          # 0 warnings, 0 errors
npm run format:files -- packages/server/src/server/agent/providers/claude/agent.sub-agent-replay.test.ts packages/server/src/server/agent/providers/claude/subagents/replay-source.ts packages/server/src/server/agent/providers/claude/subagents/replay-source.test.ts
```

This is daemon-side replay shared by desktop, browser, iOS, and Android. Runtime capture was performed on Linux; the original report and contributor QA were Electron on macOS.
