### PR TITLE
Preview CSV and TSV files as a sortable table

### DIFF
--- a/packages/app/e2e/browser/file-editing.spec.ts
+++ b/packages/app/e2e/browser/file-editing.spec.ts
@@ -1,11 +1,14 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { Locator } from "@playwright/test";
 import { expect, test, type Page } from "../support/fixtures";
 import {
   openFileExplorer,
   openFileFromExplorer,
   expectFileTabOpen,
 } from "../support/helpers/file-explorer";
+import { openSettings } from "../support/helpers/app";
+import { openSettingsSection, clickSettingsBackToWorkspace } from "../support/helpers/settings";
 import { installDaemonWebSocketGate } from "../support/helpers/daemon-websocket-gate";
 import { openAgentRoute, seedMockAgentWorkspace } from "../support/helpers/mock-agent";
 
@@ -49,6 +52,11 @@ async function openWorkspaceFile(page: Page, filename: string): Promise<void> {
   if (!(await tree.isVisible())) await openFileExplorer(page);
   await openFileFromExplorer(page, filename);
   await expectFileTabOpen(page, filename);
+}
+
+async function columnWidth(header: Locator): Promise<number> {
+  const box = await header.boundingBox();
+  return box ? box.width : 0;
 }
 
 function tableRows(page: Page): Promise<string[][]> {
@@ -577,6 +585,34 @@ test.describe("CodeMirror workspace file editing", () => {
     await expect(editor(page)).toContainText("katherine,42");
     await selectFileView(page, "Preview");
     await expect(page.getByTestId("file-table-preview")).toBeVisible();
+  });
+
+  test("resizes table columns when the code font size changes", async ({ page, withWorkspace }) => {
+    test.setTimeout(120_000);
+    const workspace = await withWorkspace({ prefix: "file-editing-table-appearance-" });
+    await writeFile(
+      path.join(workspace.repoPath, "sizes.csv"),
+      "region,owner\nus-east,ada\n",
+      "utf8",
+    );
+    await workspace.navigateTo();
+    await openWorkspaceFile(page, "sizes.csv");
+
+    const header = page.getByTestId("file-table-sort-0");
+    await expect(header).toBeVisible();
+    const initialWidth = await columnWidth(header);
+
+    await openSettings(page);
+    await openSettingsSection(page, "appearance");
+    const codeSize = page.getByLabel("Code font size");
+    await codeSize.fill("22");
+    await codeSize.press("Enter");
+    await clickSettingsBackToWorkspace(page);
+
+    // Column widths and row height are derived from the code font size, and that
+    // token is patched at runtime rather than through a React render.
+    await expect(header).toBeVisible();
+    await expect.poll(() => columnWidth(header)).toBeGreaterThan(initialWidth);
   });
 
   test("names a header-only CSV empty rather than filtered", async ({ page, withWorkspace }) => {

--- a/packages/app/e2e/browser/file-editing.spec.ts
+++ b/packages/app/e2e/browser/file-editing.spec.ts
@@ -573,8 +573,23 @@ test.describe("CodeMirror workspace file editing", () => {
     await selectFileView(page, "Source");
     await expect(page.getByTestId("file-source-editor")).toBeVisible();
     await expect(page.getByTestId("file-table-preview")).toHaveCount(0);
+    await expect(editor(page)).toContainText("name,runs");
+    await expect(editor(page)).toContainText("katherine,42");
     await selectFileView(page, "Preview");
     await expect(page.getByTestId("file-table-preview")).toBeVisible();
+  });
+
+  test("names a header-only CSV empty rather than filtered", async ({ page, withWorkspace }) => {
+    test.setTimeout(90_000);
+    const workspace = await withWorkspace({ prefix: "file-editing-table-empty-" });
+    await writeFile(path.join(workspace.repoPath, "headers.csv"), "region,owner\n", "utf8");
+    await workspace.navigateTo();
+    await openWorkspaceFile(page, "headers.csv");
+
+    await expect(page.getByTestId("file-table-preview")).toBeVisible();
+    await expect(page.getByTestId("file-table-sort-0")).toHaveText("region");
+    await expect(page.getByText("No rows", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("file-table-row-count")).toHaveText("0 rows");
   });
 
   test("runs inline scripts without allowing fetch egress", async ({ page, withWorkspace }) => {

--- a/packages/app/e2e/browser/file-editing.spec.ts
+++ b/packages/app/e2e/browser/file-editing.spec.ts
@@ -587,6 +587,29 @@ test.describe("CodeMirror workspace file editing", () => {
     await expect(page.getByTestId("file-table-preview")).toBeVisible();
   });
 
+  test("survives a CSV that loses the column it was sorted and filtered by", async ({
+    page,
+    withWorkspace,
+  }) => {
+    test.setTimeout(90_000);
+    const workspace = await withWorkspace({ prefix: "file-editing-table-shrink-" });
+    const csvPath = path.join(workspace.repoPath, "shrinking.csv");
+    await writeFile(csvPath, "name,runs\ngrace,10\nada,9\n", "utf8");
+    await workspace.navigateTo();
+    await openWorkspaceFile(page, "shrinking.csv");
+
+    await page.getByTestId("file-table-sort-1").click();
+    await page.getByTestId("file-table-filter-1").fill("9");
+    await expect.poll(() => tableRows(page)).toEqual([["ada", "9"]]);
+
+    // The runs column disappears under an active sort and filter on it.
+    await writeFile(csvPath, "name\ngrace\nada\n", "utf8");
+
+    await expect(page.getByTestId("file-table-sort-1")).toHaveCount(0);
+    await expect(page.getByTestId("file-table-row-count")).toHaveText("2 rows");
+    await expect.poll(() => tableRows(page)).toEqual([["grace"], ["ada"]]);
+  });
+
   test("resizes table columns when the code font size changes", async ({ page, withWorkspace }) => {
     test.setTimeout(120_000);
     const workspace = await withWorkspace({ prefix: "file-editing-table-appearance-" });

--- a/packages/app/e2e/browser/file-editing.spec.ts
+++ b/packages/app/e2e/browser/file-editing.spec.ts
@@ -51,6 +51,15 @@ async function openWorkspaceFile(page: Page, filename: string): Promise<void> {
   await expectFileTabOpen(page, filename);
 }
 
+function tableRows(page: Page): Promise<string[][]> {
+  return page
+    .getByTestId("file-table-preview")
+    .locator('[data-testid^="file-table-body-row-"]')
+    .evaluateAll((rows) =>
+      rows.map((row) => [...row.children].map((cell) => cell.textContent ?? "")),
+    );
+}
+
 function htmlPreview(page: Page) {
   return {
     host: page.getByTestId("file-html-preview"),
@@ -494,6 +503,78 @@ test.describe("CodeMirror workspace file editing", () => {
     await expect(preview.host).toHaveCount(0);
     await selectFileView(page, "Preview");
     await expect(preview.host).toBeVisible();
+  });
+
+  test("previews a CSV as a table that sorts, filters, and follows the file", async ({
+    page,
+    withWorkspace,
+  }) => {
+    test.setTimeout(90_000);
+    const workspace = await withWorkspace({ prefix: "file-editing-table-preview-" });
+    const csvPath = path.join(workspace.repoPath, "metrics.csv");
+    await writeFile(csvPath, "name,runs\ngrace,10\nalan,\nada,9\n", "utf8");
+    await workspace.navigateTo();
+    await openWorkspaceFile(page, "metrics.csv");
+
+    const runsHeader = page.getByTestId("file-table-sort-1");
+    const rowCount = page.getByTestId("file-table-row-count");
+    await expect(page.getByTestId("file-table-preview")).toBeVisible();
+    await expect(page.getByTestId("file-table-sort-0")).toHaveText("name");
+    await expect(rowCount).toHaveText("3 rows");
+    await expect
+      .poll(() => tableRows(page))
+      .toEqual([
+        ["grace", "10"],
+        ["alan", ""],
+        ["ada", "9"],
+      ]);
+
+    // Numeric, not lexicographic: 9 sorts before 10, and the blank stays last
+    // whichever way the column points.
+    await runsHeader.click();
+    await expect(runsHeader).toHaveAttribute("aria-label", "runs, sorted ascending");
+    await expect
+      .poll(() => tableRows(page))
+      .toEqual([
+        ["ada", "9"],
+        ["grace", "10"],
+        ["alan", ""],
+      ]);
+    await runsHeader.click();
+    await expect(runsHeader).toHaveAttribute("aria-label", "runs, sorted descending");
+    await expect
+      .poll(() => tableRows(page))
+      .toEqual([
+        ["grace", "10"],
+        ["ada", "9"],
+        ["alan", ""],
+      ]);
+    await runsHeader.click();
+    await expect(runsHeader).toHaveAttribute("aria-label", "Sort by runs");
+    await expect
+      .poll(() => tableRows(page))
+      .toEqual([
+        ["grace", "10"],
+        ["alan", ""],
+        ["ada", "9"],
+      ]);
+
+    await page.getByTestId("file-table-filter-0").fill("ada");
+    await expect.poll(() => tableRows(page)).toEqual([["ada", "9"]]);
+    await expect(rowCount).toHaveText("1 of 3 rows");
+    await page.getByTestId("file-table-filter-0").fill("nothing here");
+    await expect(page.getByText("No matching rows", { exact: true })).toBeVisible();
+    await page.getByTestId("file-table-filter-0").fill("");
+    await expect(rowCount).toHaveText("3 rows");
+
+    await writeFile(csvPath, "name,runs\ngrace,10\nalan,\nada,9\nkatherine,42\n", "utf8");
+    await expect(rowCount).toHaveText("4 rows");
+
+    await selectFileView(page, "Source");
+    await expect(page.getByTestId("file-source-editor")).toBeVisible();
+    await expect(page.getByTestId("file-table-preview")).toHaveCount(0);
+    await selectFileView(page, "Preview");
+    await expect(page.getByTestId("file-table-preview")).toBeVisible();
   });
 
   test("runs inline scripts without allowing fetch egress", async ({ page, withWorkspace }) => {

--- a/packages/app/src/components/file-pane-render-mode.test.ts
+++ b/packages/app/src/components/file-pane-render-mode.test.ts
@@ -32,9 +32,16 @@ describe("filePreviewRenderKind", () => {
     expect(filePreviewRenderKind("plan.htm")).toBe("html");
   });
 
+  it("maps delimited data files to the table kind", () => {
+    expect(filePreviewRenderKind("metrics.csv")).toBe("table");
+    expect(filePreviewRenderKind("data/EXPORT.CSV")).toBe("table");
+    expect(filePreviewRenderKind("rows.tsv")).toBe("table");
+  });
+
   it("returns null for files without a rendered preview", () => {
     expect(filePreviewRenderKind("src/index.ts")).toBe(null);
     expect(filePreviewRenderKind("page.mdx")).toBe(null);
     expect(filePreviewRenderKind("index.html.erb")).toBe(null);
+    expect(filePreviewRenderKind("archive.csv.gz")).toBe(null);
   });
 });

--- a/packages/app/src/components/file-pane-render-mode.ts
+++ b/packages/app/src/components/file-pane-render-mode.ts
@@ -1,4 +1,4 @@
-export type FilePreviewRenderKind = "markdown" | "html";
+export type FilePreviewRenderKind = "markdown" | "html" | "table";
 
 export function isRenderedMarkdownFile(filePath: string): boolean {
   const normalizedPath = filePath.trim().toLowerCase();
@@ -10,8 +10,14 @@ function isRenderedHtmlFile(filePath: string): boolean {
   return normalizedPath.endsWith(".html") || normalizedPath.endsWith(".htm");
 }
 
+function isDelimitedTableFile(filePath: string): boolean {
+  const normalizedPath = filePath.trim().toLowerCase();
+  return normalizedPath.endsWith(".csv") || normalizedPath.endsWith(".tsv");
+}
+
 export function filePreviewRenderKind(filePath: string): FilePreviewRenderKind | null {
   if (isRenderedMarkdownFile(filePath)) return "markdown";
   if (isRenderedHtmlFile(filePath)) return "html";
+  if (isDelimitedTableFile(filePath)) return "table";
   return null;
 }

--- a/packages/app/src/file-pane/pane.tsx
+++ b/packages/app/src/file-pane/pane.tsx
@@ -234,7 +234,12 @@ function RenderedTextPreview({ renderKind, content, filePath }: RenderedTextPrev
     // to whichever file the pane opened first.
     return (
       <View style={styles.previewScrollContainer}>
-        <FileTablePreview key={filePath} content={content} testID="file-table-preview" />
+        <FileTablePreview
+          key={filePath}
+          content={content}
+          filePath={filePath}
+          testID="file-table-preview"
+        />
       </View>
     );
   }

--- a/packages/app/src/file-pane/pane.tsx
+++ b/packages/app/src/file-pane/pane.tsx
@@ -20,7 +20,10 @@ import { syntaxTokenStyleFor } from "@/styles/syntax-token-styles";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { lineNumberGutterWidth } from "@/components/code-insets";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
-import { filePreviewRenderKind } from "@/components/file-pane-render-mode";
+import {
+  filePreviewRenderKind,
+  type FilePreviewRenderKind,
+} from "@/components/file-pane-render-mode";
 import type { AttachmentMetadata } from "@/attachments/types";
 import { useAttachmentPreviewUrl } from "@/attachments/use-attachment-preview-url";
 import { persistAttachmentFromBytes } from "@/attachments/service";
@@ -36,6 +39,7 @@ import { useAppSettings } from "@/hooks/use-settings";
 import { useLiveFile } from "./live-file/hook";
 import { FilePanelBar } from "./bar";
 import { FileHtmlPreview } from "./html-preview";
+import { FileTablePreview } from "./table/view";
 import { FileEditorModel, getFileConflictCallout, type FileConflictCallout } from "./editor/model";
 import { createFileObservationSource } from "./editor/observation-source";
 import { FileEditorView } from "./editor/view";
@@ -209,6 +213,45 @@ const codeLineStyles = StyleSheet.create((theme) => ({
   },
 }));
 
+interface RenderedTextPreviewProps {
+  renderKind: FilePreviewRenderKind;
+  content: string;
+  filePath: string;
+}
+
+function RenderedTextPreview({ renderKind, content, filePath }: RenderedTextPreviewProps) {
+  if (renderKind === "html") {
+    // The HTML document owns its own scrolling, so no ScrollView wrapper here.
+    return (
+      <View style={styles.previewScrollContainer}>
+        <FileHtmlPreview html={content} testID="file-html-preview" />
+      </View>
+    );
+  }
+
+  if (renderKind === "table") {
+    // Keyed by path so sort and filter state belongs to the file being read, not
+    // to whichever file the pane opened first.
+    return (
+      <View style={styles.previewScrollContainer}>
+        <FileTablePreview key={filePath} content={content} testID="file-table-preview" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.previewScrollContainer}>
+      <RNScrollView
+        style={styles.previewContent}
+        contentContainerStyle={styles.previewMarkdownScrollContent}
+        showsVerticalScrollIndicator
+      >
+        <MarkdownRenderer text={content} />
+      </RNScrollView>
+    </View>
+  );
+}
+
 function FilePreviewBody({
   preview,
   mode,
@@ -290,27 +333,13 @@ function FilePreviewBody({
   }
 
   if (preview.kind === "text") {
-    if (renderKind === "html") {
-      // The HTML document owns its own scrolling, so no ScrollView wrapper here.
+    if (renderKind) {
       return (
-        <View style={styles.previewScrollContainer}>
-          <FileHtmlPreview html={preview.content ?? ""} testID="file-html-preview" />
-        </View>
-      );
-    }
-
-    if (renderKind === "markdown") {
-      return (
-        <View style={styles.previewScrollContainer}>
-          <RNScrollView
-            ref={previewScrollRef}
-            style={styles.previewContent}
-            contentContainerStyle={styles.previewMarkdownScrollContent}
-            showsVerticalScrollIndicator
-          >
-            <MarkdownRenderer text={preview.content ?? ""} />
-          </RNScrollView>
-        </View>
+        <RenderedTextPreview
+          renderKind={renderKind}
+          content={preview.content ?? ""}
+          filePath={filePath}
+        />
       );
     }
 

--- a/packages/app/src/file-pane/table/model.test.ts
+++ b/packages/app/src/file-pane/table/model.test.ts
@@ -57,6 +57,46 @@ describe("parseDelimitedTable", () => {
     ]);
   });
 
+  it("splits a .tsv file on tabs even when the header also holds a comma", () => {
+    const table = parseDelimitedTable("last, first\tage\nlovelace, ada\t36", "people.tsv");
+
+    expect(table.columns.map((column) => column.label)).toEqual(["last, first", "age"]);
+    expect(table.rows).toEqual([{ index: 0, cells: ["lovelace, ada", "36"] }]);
+  });
+
+  it("still sniffs the delimiter when the extension does not name one", () => {
+    const table = parseDelimitedTable("a;b\n1;2", "data.csv");
+
+    expect(table.columns.map((column) => column.label)).toEqual(["a", "b"]);
+  });
+
+  it("keeps a row whose cells are all empty", () => {
+    const table = parseDelimitedTable("a,b\n,\n1,2");
+
+    expect(table.rows).toEqual([
+      { index: 0, cells: ["", ""] },
+      { index: 1, cells: ["1", "2"] },
+    ]);
+  });
+
+  it("keeps a row holding a single quoted empty cell", () => {
+    const table = parseDelimitedTable('value\n""\nkept');
+
+    expect(table.rows).toEqual([
+      { index: 0, cells: [""] },
+      { index: 1, cells: ["kept"] },
+    ]);
+  });
+
+  it("drops blank lines between records", () => {
+    const table = parseDelimitedTable("a,b\n1,2\n\n3,4\n");
+
+    expect(table.rows).toEqual([
+      { index: 0, cells: ["1", "2"] },
+      { index: 1, cells: ["3", "4"] },
+    ]);
+  });
+
   it("accepts CRLF line endings and a trailing newline", () => {
     const table = parseDelimitedTable("a,b\r\n1,2\r\n");
 

--- a/packages/app/src/file-pane/table/model.test.ts
+++ b/packages/app/src/file-pane/table/model.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { nextTableSort, parseDelimitedTable, tableRowsInView, type TableRow } from "./model";
+import {
+  nextTableSort,
+  parseDelimitedTable,
+  tableRowsInView,
+  tableViewWithinColumns,
+  type TableRow,
+  type TableSort,
+} from "./model";
 
 describe("parseDelimitedTable", () => {
   it("reads the first row as column labels and the rest as rows", () => {
@@ -62,6 +69,13 @@ describe("parseDelimitedTable", () => {
 
     expect(table.columns.map((column) => column.label)).toEqual(["last, first", "age"]);
     expect(table.rows).toEqual([{ index: 0, cells: ["lovelace, ada", "36"] }]);
+  });
+
+  it("keeps a .tsv single column whose text contains commas", () => {
+    const table = parseDelimitedTable("description, notes\nhello, world\n", "notes.tsv");
+
+    expect(table.columns.map((column) => column.label)).toEqual(["description, notes"]);
+    expect(table.rows).toEqual([{ index: 0, cells: ["hello, world"] }]);
   });
 
   it("still sniffs the delimiter when the extension does not name one", () => {
@@ -218,6 +232,52 @@ describe("tableRowsInView", () => {
     tableRowsInView({ rows, filters: new Map(), sort: { column: 1, direction: "desc" } });
 
     expect(rows).toEqual(original);
+  });
+});
+
+describe("tableViewWithinColumns", () => {
+  it("keeps a sort and filters that still have columns", () => {
+    const sort: TableSort = { column: 1, direction: "asc" };
+    const filters = new Map([[0, "ada"]]);
+
+    const view = tableViewWithinColumns({ sort, filters }, 2);
+
+    expect(view.sort).toBe(sort);
+    expect(view.filters).toBe(filters);
+  });
+
+  it("drops a sort whose column the file no longer has", () => {
+    const view = tableViewWithinColumns(
+      { sort: { column: 2, direction: "desc" }, filters: new Map() },
+      2,
+    );
+
+    expect(view.sort).toBe(null);
+  });
+
+  it("drops filters past the last column and keeps the rest", () => {
+    const view = tableViewWithinColumns(
+      {
+        sort: null,
+        filters: new Map([
+          [0, "ada"],
+          [3, "gone"],
+        ]),
+      },
+      2,
+    );
+
+    expect([...view.filters]).toEqual([[0, "ada"]]);
+  });
+
+  it("drops everything when the file has no columns", () => {
+    const view = tableViewWithinColumns(
+      { sort: { column: 0, direction: "asc" }, filters: new Map([[0, "ada"]]) },
+      0,
+    );
+
+    expect(view.sort).toBe(null);
+    expect([...view.filters]).toEqual([]);
   });
 });
 

--- a/packages/app/src/file-pane/table/model.test.ts
+++ b/packages/app/src/file-pane/table/model.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { nextTableSort, parseDelimitedTable, tableRowsInView, type TableRow } from "./model";
+
+describe("parseDelimitedTable", () => {
+  it("reads the first row as column labels and the rest as rows", () => {
+    const table = parseDelimitedTable("name,age\nada,36\ngrace,45\n");
+
+    expect(table.columns).toEqual([
+      { index: 0, label: "name" },
+      { index: 1, label: "age" },
+    ]);
+    expect(table.rows).toEqual([
+      { index: 0, cells: ["ada", "36"] },
+      { index: 1, cells: ["grace", "45"] },
+    ]);
+  });
+
+  it("keeps delimiters, newlines, and doubled quotes inside a quoted field", () => {
+    const table = parseDelimitedTable('note,owner\n"a, b\nc","say ""hi"""\n');
+
+    expect(table.rows).toEqual([{ index: 0, cells: ["a, b\nc", 'say "hi"'] }]);
+  });
+
+  it("detects the delimiter from the header row", () => {
+    expect(parseDelimitedTable("a\tb\n1\t2").columns.map((column) => column.label)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(parseDelimitedTable("a;b\n1;2").columns.map((column) => column.label)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(parseDelimitedTable("a|b\n1|2").columns.map((column) => column.label)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("ignores delimiters that only appear inside a quoted header cell", () => {
+    const table = parseDelimitedTable('"last, first";age\n"lovelace, ada";36');
+
+    expect(table.columns.map((column) => column.label)).toEqual(["last, first", "age"]);
+    expect(table.rows).toEqual([{ index: 0, cells: ["lovelace, ada", "36"] }]);
+  });
+
+  it("pads ragged rows to the widest row and labels the extra columns", () => {
+    const table = parseDelimitedTable("a,b\n1\n2,3,4");
+
+    expect(table.columns).toEqual([
+      { index: 0, label: "a" },
+      { index: 1, label: "b" },
+      { index: 2, label: "" },
+    ]);
+    expect(table.rows).toEqual([
+      { index: 0, cells: ["1", "", ""] },
+      { index: 1, cells: ["2", "3", "4"] },
+    ]);
+  });
+
+  it("accepts CRLF line endings and a trailing newline", () => {
+    const table = parseDelimitedTable("a,b\r\n1,2\r\n");
+
+    expect(table.rows).toEqual([{ index: 0, cells: ["1", "2"] }]);
+  });
+
+  it("returns an empty table for blank content", () => {
+    expect(parseDelimitedTable("")).toEqual({ columns: [], rows: [] });
+    expect(parseDelimitedTable("\n")).toEqual({ columns: [], rows: [] });
+  });
+
+  it("keeps a header-only file as columns with no rows", () => {
+    const table = parseDelimitedTable("a,b\n");
+
+    expect(table.columns.map((column) => column.label)).toEqual(["a", "b"]);
+    expect(table.rows).toEqual([]);
+  });
+});
+
+function rowsOf(...cells: string[][]): TableRow[] {
+  return cells.map((values, index) => ({ index, cells: values }));
+}
+
+function labelsOf(rows: TableRow[]): string[] {
+  return rows.map((row) => row.cells[0]);
+}
+
+describe("tableRowsInView", () => {
+  const rows = rowsOf(
+    ["Ada", "36", "London"],
+    ["Grace", "45", "New York"],
+    ["alan", "41", "london"],
+  );
+
+  it("returns every row when nothing is filtered or sorted", () => {
+    expect(tableRowsInView({ rows, filters: new Map(), sort: null })).toEqual(rows);
+  });
+
+  it("filters case-insensitively on a substring", () => {
+    const view = tableRowsInView({ rows, filters: new Map([[2, "LON"]]), sort: null });
+
+    expect(labelsOf(view)).toEqual(["Ada", "alan"]);
+  });
+
+  it("requires every column filter to match", () => {
+    const view = tableRowsInView({
+      rows,
+      filters: new Map([
+        [2, "london"],
+        [0, "ada"],
+      ]),
+      sort: null,
+    });
+
+    expect(labelsOf(view)).toEqual(["Ada"]);
+  });
+
+  it("ignores a filter that is only whitespace", () => {
+    expect(tableRowsInView({ rows, filters: new Map([[0, "  "]]), sort: null })).toEqual(rows);
+  });
+
+  it("sorts numeric columns by value, not by digits", () => {
+    const numbers = rowsOf(["9"], ["10"], ["-2.5"]);
+    const view = tableRowsInView({
+      rows: numbers,
+      filters: new Map(),
+      sort: { column: 0, direction: "asc" },
+    });
+
+    expect(labelsOf(view)).toEqual(["-2.5", "9", "10"]);
+  });
+
+  it("sorts text case-insensitively and reverses on descending", () => {
+    const ascending = tableRowsInView({
+      rows,
+      filters: new Map(),
+      sort: { column: 0, direction: "asc" },
+    });
+    const descending = tableRowsInView({
+      rows,
+      filters: new Map(),
+      sort: { column: 0, direction: "desc" },
+    });
+
+    expect(labelsOf(ascending)).toEqual(["Ada", "alan", "Grace"]);
+    expect(labelsOf(descending)).toEqual(["Grace", "alan", "Ada"]);
+  });
+
+  it("keeps blank cells last in both directions", () => {
+    const sparse = rowsOf(["b"], [""], ["a"]);
+    const ascending = tableRowsInView({
+      rows: sparse,
+      filters: new Map(),
+      sort: { column: 0, direction: "asc" },
+    });
+    const descending = tableRowsInView({
+      rows: sparse,
+      filters: new Map(),
+      sort: { column: 0, direction: "desc" },
+    });
+
+    expect(labelsOf(ascending)).toEqual(["a", "b", ""]);
+    expect(labelsOf(descending)).toEqual(["b", "a", ""]);
+  });
+
+  it("keeps equal cells in file order", () => {
+    const duplicates = rowsOf(["same", "second"], ["same", "first"]);
+    const view = tableRowsInView({
+      rows: duplicates,
+      filters: new Map(),
+      sort: { column: 0, direction: "desc" },
+    });
+
+    expect(view.map((row) => row.cells[1])).toEqual(["second", "first"]);
+  });
+
+  it("leaves the source rows untouched", () => {
+    const original = [...rows];
+    tableRowsInView({ rows, filters: new Map(), sort: { column: 1, direction: "desc" } });
+
+    expect(rows).toEqual(original);
+  });
+});
+
+describe("nextTableSort", () => {
+  it("cycles a column through ascending, descending, and unsorted", () => {
+    const ascending = nextTableSort(null, 2);
+    expect(ascending).toEqual({ column: 2, direction: "asc" });
+
+    const descending = nextTableSort(ascending, 2);
+    expect(descending).toEqual({ column: 2, direction: "desc" });
+
+    expect(nextTableSort(descending, 2)).toBe(null);
+  });
+
+  it("starts a different column ascending", () => {
+    expect(nextTableSort({ column: 0, direction: "desc" }, 1)).toEqual({
+      column: 1,
+      direction: "asc",
+    });
+  });
+});

--- a/packages/app/src/file-pane/table/model.ts
+++ b/packages/app/src/file-pane/table/model.ts
@@ -1,0 +1,234 @@
+export interface TableColumn {
+  index: number;
+  label: string;
+}
+
+export interface TableRow {
+  index: number;
+  cells: string[];
+}
+
+export interface TableGrid {
+  columns: TableColumn[];
+  rows: TableRow[];
+}
+
+export type TableSortDirection = "asc" | "desc";
+
+export interface TableSort {
+  column: number;
+  direction: TableSortDirection;
+}
+
+/** Filter text per column index. A column with no entry is unfiltered. */
+export type TableFilters = ReadonlyMap<number, string>;
+
+interface TableViewInput {
+  rows: TableRow[];
+  filters: TableFilters;
+  sort: TableSort | null;
+}
+
+interface TableFilterTerm {
+  column: number;
+  term: string;
+}
+
+// Ordered by how often a file in the wild uses them, which is also the tie-break
+// order when the header row has the same count of two candidates.
+const DELIMITERS = [",", "\t", ";", "|"];
+const QUOTE = '"';
+
+export function parseDelimitedTable(text: string): TableGrid {
+  const delimiter = detectDelimiter(text);
+  const records = splitRecords(text, delimiter);
+  if (records.length === 0) {
+    return { columns: [], rows: [] };
+  }
+
+  const [header, ...body] = records;
+  const width = Math.max(header.length, ...body.map((cells) => cells.length));
+  const columns = Array.from({ length: width }, (_, index) => ({
+    index,
+    label: header[index] ?? "",
+  }));
+  const rows = body.map((cells, index) => ({
+    index,
+    cells: padCells(cells, width),
+  }));
+
+  return { columns, rows };
+}
+
+export function tableRowsInView({ rows, filters, sort }: TableViewInput): TableRow[] {
+  const terms = filterTerms(filters);
+  const matching = terms.length === 0 ? rows : rows.filter((row) => matchesTerms(row, terms));
+  if (!sort) return matching;
+
+  const direction = sort.direction === "asc" ? 1 : -1;
+  return [...matching].sort((left, right) => {
+    const leftCell = left.cells[sort.column];
+    const rightCell = right.cells[sort.column];
+    // Blank cells stay at the bottom in both directions, so flipping the
+    // direction reorders values without pulling the gaps to the top.
+    const blankOrder = Number(isBlank(leftCell)) - Number(isBlank(rightCell));
+    if (blankOrder !== 0) return blankOrder;
+    const order = compareCells(leftCell, rightCell) * direction;
+    return order === 0 ? left.index - right.index : order;
+  });
+}
+
+export function nextTableSort(current: TableSort | null, column: number): TableSort | null {
+  if (current?.column !== column) return { column, direction: "asc" };
+  if (current.direction === "asc") return { column, direction: "desc" };
+  return null;
+}
+
+function filterTerms(filters: TableFilters): TableFilterTerm[] {
+  const terms: TableFilterTerm[] = [];
+  for (const [column, value] of filters) {
+    const term = value.trim().toLowerCase();
+    if (term.length > 0) terms.push({ column, term });
+  }
+  return terms;
+}
+
+function matchesTerms(row: TableRow, terms: TableFilterTerm[]): boolean {
+  return terms.every(({ column, term }) => row.cells[column].toLowerCase().includes(term));
+}
+
+function isBlank(cell: string): boolean {
+  return cell.trim().length === 0;
+}
+
+// A spreadsheet sorts 10 after 9 and "Ada" next to "ada"; the engine's default
+// string compare does neither. Locale-aware compare is avoided on purpose:
+// Hermes, JSC, and V8 disagree, and the same file must sort the same on every
+// platform.
+const NUMERIC_CELL = /^[+-]?(\d+\.?\d*|\.\d+)(e[+-]?\d+)?$/i;
+
+function compareCells(left: string, right: string): number {
+  const leftNumber = numericCell(left);
+  const rightNumber = numericCell(right);
+  if (leftNumber !== null && rightNumber !== null) {
+    return leftNumber - rightNumber;
+  }
+  const folded = compareStrings(left.toLowerCase(), right.toLowerCase());
+  return folded === 0 ? compareStrings(left, right) : folded;
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  return left > right ? 1 : 0;
+}
+
+function numericCell(cell: string): number | null {
+  const trimmed = cell.trim();
+  if (!NUMERIC_CELL.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : null;
+}
+
+function padCells(cells: string[], width: number): string[] {
+  if (cells.length === width) return cells;
+  return Array.from({ length: width }, (_, index) => cells[index] ?? "");
+}
+
+function detectDelimiter(text: string): string {
+  const header = headerRecord(text);
+  let best = DELIMITERS[0];
+  let bestCount = 0;
+  for (const candidate of DELIMITERS) {
+    const count = countUnquoted(header, candidate);
+    if (count > bestCount) {
+      best = candidate;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+// The header row alone decides the delimiter: a data cell holding prose can
+// out-count the real delimiter, a header cell almost never does.
+function headerRecord(text: string): string {
+  let quoted = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === QUOTE) {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && (char === "\n" || char === "\r")) {
+      return text.slice(0, index);
+    }
+  }
+  return text;
+}
+
+function countUnquoted(record: string, delimiter: string): number {
+  let count = 0;
+  let quoted = false;
+  for (const char of record) {
+    if (char === QUOTE) {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && char === delimiter) count += 1;
+  }
+  return count;
+}
+
+function splitRecords(text: string, delimiter: string): string[][] {
+  const records: string[][] = [];
+  let cells: string[] = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (quoted) {
+      if (char !== QUOTE) {
+        cell += char;
+        continue;
+      }
+      if (text[index + 1] === QUOTE) {
+        cell += QUOTE;
+        index += 1;
+        continue;
+      }
+      quoted = false;
+      continue;
+    }
+    // A quote only opens a quoted cell at the start of that cell, so a stray
+    // quote inside an unquoted value stays literal instead of swallowing the
+    // rest of the file.
+    if (char === QUOTE && cell.length === 0) {
+      quoted = true;
+      continue;
+    }
+    if (char === delimiter) {
+      cells.push(cell);
+      cell = "";
+      continue;
+    }
+    if (char === "\n" || char === "\r") {
+      if (char === "\r" && text[index + 1] === "\n") index += 1;
+      cells.push(cell);
+      records.push(cells);
+      cells = [];
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+
+  if (cell.length > 0 || cells.length > 0) {
+    cells.push(cell);
+    records.push(cells);
+  }
+
+  // Blank records are separators, not data: a trailing newline, a Windows file
+  // ending in CRLF CRLF, or a stray gap between blocks. Row indexes are view
+  // positions rather than file line numbers, so dropping them costs nothing.
+  return records.filter((record) => record.some((value) => value.length > 0));
+}

--- a/packages/app/src/file-pane/table/model.ts
+++ b/packages/app/src/file-pane/table/model.ts
@@ -37,10 +37,11 @@ interface TableFilterTerm {
 // Ordered by how often a file in the wild uses them, which is also the tie-break
 // order when the header row has the same count of two candidates.
 const DELIMITERS = [",", "\t", ";", "|"];
+const EXTENSION_DELIMITERS = [{ extension: ".tsv", delimiter: "\t" }];
 const QUOTE = '"';
 
-export function parseDelimitedTable(text: string): TableGrid {
-  const delimiter = detectDelimiter(text);
+export function parseDelimitedTable(text: string, filePath = ""): TableGrid {
+  const delimiter = detectDelimiter(text, namedDelimiter(filePath));
   const records = splitRecords(text, delimiter);
   if (records.length === 0) {
     return { columns: [], rows: [] };
@@ -134,8 +135,21 @@ function padCells(cells: string[], width: number): string[] {
   return Array.from({ length: width }, (_, index) => cells[index] ?? "");
 }
 
-function detectDelimiter(text: string): string {
+// An extension that names its delimiter wins whenever that delimiter is present:
+// a .tsv header holding "last, first" has as many commas as tabs, and counting
+// alone would split the name in half.
+function namedDelimiter(filePath: string): string | null {
+  const normalizedPath = filePath.trim().toLowerCase();
+  const named = EXTENSION_DELIMITERS.find((entry) => normalizedPath.endsWith(entry.extension));
+  return named ? named.delimiter : null;
+}
+
+function detectDelimiter(text: string, named: string | null): string {
   const header = headerRecord(text);
+  if (named && countUnquoted(header, named) > 0) {
+    return named;
+  }
+
   let best = DELIMITERS[0];
   let bestCount = 0;
   for (const candidate of DELIMITERS) {
@@ -183,6 +197,10 @@ function splitRecords(text: string, delimiter: string): string[][] {
   let cells: string[] = [];
   let cell = "";
   let quoted = false;
+  // A blank line is a separator; a line of empty cells is data. They both parse
+  // to empty strings, so the difference has to be caught while reading: a
+  // delimiter, a quote, or any character means the line said something.
+  let written = false;
 
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
@@ -204,31 +222,34 @@ function splitRecords(text: string, delimiter: string): string[][] {
     // rest of the file.
     if (char === QUOTE && cell.length === 0) {
       quoted = true;
+      written = true;
       continue;
     }
     if (char === delimiter) {
       cells.push(cell);
       cell = "";
+      written = true;
       continue;
     }
     if (char === "\n" || char === "\r") {
       if (char === "\r" && text[index + 1] === "\n") index += 1;
-      cells.push(cell);
-      records.push(cells);
+      if (written) {
+        cells.push(cell);
+        records.push(cells);
+      }
       cells = [];
       cell = "";
+      written = false;
       continue;
     }
     cell += char;
+    written = true;
   }
 
-  if (cell.length > 0 || cells.length > 0) {
+  if (written) {
     cells.push(cell);
     records.push(cells);
   }
 
-  // Blank records are separators, not data: a trailing newline, a Windows file
-  // ending in CRLF CRLF, or a stray gap between blocks. Row indexes are view
-  // positions rather than file line numbers, so dropping them costs nothing.
-  return records.filter((record) => record.some((value) => value.length > 0));
+  return records;
 }

--- a/packages/app/src/file-pane/table/model.ts
+++ b/packages/app/src/file-pane/table/model.ts
@@ -23,6 +23,11 @@ export interface TableSort {
 /** Filter text per column index. A column with no entry is unfiltered. */
 export type TableFilters = ReadonlyMap<number, string>;
 
+export interface TableViewState {
+  sort: TableSort | null;
+  filters: TableFilters;
+}
+
 interface TableViewInput {
   rows: TableRow[];
   filters: TableFilters;
@@ -77,6 +82,24 @@ export function tableRowsInView({ rows, filters, sort }: TableViewInput): TableR
     const order = compareCells(leftCell, rightCell) * direction;
     return order === 0 ? left.index - right.index : order;
   });
+}
+
+// Sort and filter state outlives the parse, and a file can lose columns while it
+// is open. Resolving the state against the current column count keeps a stale
+// index from reaching a row, and drops a filter the user could no longer see to
+// clear.
+export function tableViewWithinColumns(state: TableViewState, columnCount: number): TableViewState {
+  const sort = state.sort && state.sort.column < columnCount ? state.sort : null;
+  const stale = [...state.filters.keys()].filter((column) => column >= columnCount);
+  if (sort === state.sort && stale.length === 0) {
+    return state;
+  }
+
+  const filters = new Map(state.filters);
+  for (const column of stale) {
+    filters.delete(column);
+  }
+  return { sort, filters };
 }
 
 export function nextTableSort(current: TableSort | null, column: number): TableSort | null {
@@ -135,9 +158,9 @@ function padCells(cells: string[], width: number): string[] {
   return Array.from({ length: width }, (_, index) => cells[index] ?? "");
 }
 
-// An extension that names its delimiter wins whenever that delimiter is present:
-// a .tsv header holding "last, first" has as many commas as tabs, and counting
-// alone would split the name in half.
+// An extension that names its delimiter is taken at its word: a .tsv header
+// holding "last, first" has as many commas as tabs, and a single-column .tsv
+// holding prose has more commas than tabs. Counting loses both.
 function namedDelimiter(filePath: string): string | null {
   const normalizedPath = filePath.trim().toLowerCase();
   const named = EXTENSION_DELIMITERS.find((entry) => normalizedPath.endsWith(entry.extension));
@@ -145,11 +168,9 @@ function namedDelimiter(filePath: string): string | null {
 }
 
 function detectDelimiter(text: string, named: string | null): string {
-  const header = headerRecord(text);
-  if (named && countUnquoted(header, named) > 0) {
-    return named;
-  }
+  if (named) return named;
 
+  const header = headerRecord(text);
   let best = DELIMITERS[0];
   let bestCount = 0;
   for (const candidate of DELIMITERS) {

--- a/packages/app/src/file-pane/table/view.tsx
+++ b/packages/app/src/file-pane/table/view.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, UnistylesRuntime, withUnistyles } from "react-native-unisty
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react-native";
+import { AppearanceStyleBoundary } from "@/components/appearance-style-boundary";
 import { Button } from "@/components/ui/button";
 import { createControlGeometry } from "@/components/ui/control-geometry";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
@@ -14,6 +15,7 @@ import {
   tableRowsInView,
   type TableColumn,
   type TableFilters,
+  type TableGrid,
   type TableRow,
   type TableSort,
   type TableSortDirection,
@@ -41,6 +43,9 @@ const CELL_PADDING = 24;
 // the header row stops lining up with the data.
 const HEADER_CHROME = 52;
 const MONO_CHARACTER_RATIO = 0.62;
+// Shared by the rendered cell and by getItemLayout, so a row's reported height
+// is the height it actually draws at.
+const CELL_LINE_HEIGHT_RATIO = 1.45;
 
 interface TableCellStyle {
   width: number;
@@ -48,29 +53,21 @@ interface TableCellStyle {
 
 const EMPTY_FILTERS: TableFilters = new Map();
 
-export function FileTablePreview({ content, testID }: { content: string; testID?: string }) {
+interface FileTablePreviewProps {
+  content: string;
+  filePath: string;
+  testID?: string;
+}
+
+export function FileTablePreview({ content, filePath, testID }: FileTablePreviewProps) {
   const { t } = useTranslation();
-  const table = useMemo(() => parseDelimitedTable(content), [content]);
+  const table = useMemo(() => parseDelimitedTable(content, filePath), [content, filePath]);
   const [sort, setSort] = useState<TableSort | null>(null);
   const [filters, setFilters] = useState<TableFilters>(EMPTY_FILTERS);
   const rows = useMemo(
     () => tableRowsInView({ rows: table.rows, filters, sort }),
     [table.rows, filters, sort],
   );
-  const theme = UnistylesRuntime.getTheme();
-  const cellWidths = useMemo(
-    () => columnWidths({ table, fontSize: theme.fontSize.code }),
-    [table, theme.fontSize.code],
-  );
-  const cellStyles = useMemo(
-    () => cellWidths.map((width) => inlineUnistylesStyle({ width })),
-    [cellWidths],
-  );
-  const rowHeight = Math.round(theme.fontSize.code * 1.45) + theme.spacing[2] * 2;
-  const gridStyle = useMemo(() => {
-    const totalWidth = cellWidths.reduce((sum, width) => sum + width, 0);
-    return inlineUnistylesStyle({ width: totalWidth });
-  }, [cellWidths]);
 
   const toggleSort = useCallback((column: number) => {
     setSort((current) => nextTableSort(current, column));
@@ -83,6 +80,74 @@ export function FileTablePreview({ content, testID }: { content: string; testID?
       return next;
     });
   }, []);
+
+  if (table.columns.length === 0) {
+    return (
+      <View style={styles.centerState} testID={testID}>
+        <Text style={styles.emptyText}>{t("panels.file.table.empty")}</Text>
+      </View>
+    );
+  }
+
+  const hasRows = rows.length > 0;
+  const emptyMessage = table.rows.length === 0 ? "empty" : "noMatches";
+
+  return (
+    <View style={styles.container} testID={testID}>
+      {/* The grid sizes itself from the code font, which appearance settings
+          patch at runtime without re-rendering React. Remounting it there keeps
+          the column widths and row height honest. Sort and filter state lives
+          out here so it survives that remount. */}
+      <AppearanceStyleBoundary>
+        <TableSurface
+          table={table}
+          rows={rows}
+          filters={filters}
+          sort={sort}
+          onSort={toggleSort}
+          onFilter={setColumnFilter}
+        />
+      </AppearanceStyleBoundary>
+      {hasRows ? null : (
+        // Outside the scroller so a wide table cannot push the message off screen
+        // while the filter that emptied it stays reachable.
+        <View style={styles.centerState}>
+          <Text style={styles.emptyText}>{t(`panels.file.table.${emptyMessage}`)}</Text>
+        </View>
+      )}
+      <View style={styles.footer}>
+        <Text style={styles.footerText} testID="file-table-row-count">
+          {rowCountLabel({ visible: rows.length, total: table.rows.length, t })}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+interface TableSurfaceProps {
+  table: TableGrid;
+  rows: TableRow[];
+  filters: TableFilters;
+  sort: TableSort | null;
+  onSort(column: number): void;
+  onFilter(column: number, term: string): void;
+}
+
+function TableSurface({ table, rows, filters, sort, onSort, onFilter }: TableSurfaceProps) {
+  const theme = UnistylesRuntime.getTheme();
+  const cellWidths = useMemo(
+    () => columnWidths({ table, fontSize: theme.fontSize.code }),
+    [table, theme.fontSize.code],
+  );
+  const cellStyles = useMemo(
+    () => cellWidths.map((width) => inlineUnistylesStyle({ width })),
+    [cellWidths],
+  );
+  const rowHeight = Math.round(theme.fontSize.code * CELL_LINE_HEIGHT_RATIO) + theme.spacing[2] * 2;
+  const gridStyle = useMemo(() => {
+    const totalWidth = cellWidths.reduce((sum, width) => sum + width, 0);
+    return inlineUnistylesStyle({ width: totalWidth });
+  }, [cellWidths]);
   const renderRow = useCallback(
     ({ item }: ListRenderItemInfo<TableRow>) => (
       <TableBodyRow row={item} columns={table.columns} cellStyles={cellStyles} />
@@ -97,74 +162,52 @@ export function FileTablePreview({ content, testID }: { content: string; testID?
     }),
     [rowHeight],
   );
-
-  if (table.columns.length === 0) {
-    return (
-      <View style={styles.centerState} testID={testID}>
-        <Text style={styles.emptyText}>{t("panels.file.table.empty")}</Text>
-      </View>
-    );
-  }
-
   const hasRows = rows.length > 0;
 
+  // The header, the filters, and the rows share one horizontal scroller so a
+  // cell never drifts out from under its column.
   return (
-    <View style={styles.container} testID={testID}>
-      {/* The header, the filters, and the rows share one horizontal scroller so
-          a cell never drifts out from under its column. */}
-      <ScrollView
-        horizontal
-        style={hasRows ? styles.gridFill : styles.gridChrome}
-        contentContainerStyle={styles.gridScrollContent}
-      >
-        <View style={gridStyle}>
-          <View style={styles.headerRow}>
-            {table.columns.map((column) => (
-              <TableHeaderCell
-                key={column.index}
-                column={column}
-                cellStyle={cellStyles[column.index]}
-                sort={sort}
-                onPress={toggleSort}
-              />
-            ))}
-          </View>
-          <View style={styles.filterRow}>
-            {table.columns.map((column) => (
-              <TableFilterCell
-                key={column.index}
-                column={column}
-                cellStyle={cellStyles[column.index]}
-                onChange={setColumnFilter}
-              />
-            ))}
-          </View>
-          {hasRows ? (
-            <FlatList
-              data={rows}
-              renderItem={renderRow}
-              keyExtractor={rowKey}
-              getItemLayout={rowLayout}
-              style={styles.body}
-              nestedScrollEnabled
-              showsVerticalScrollIndicator
+    <ScrollView
+      horizontal
+      style={hasRows ? styles.gridFill : styles.gridChrome}
+      contentContainerStyle={styles.gridScrollContent}
+    >
+      <View style={gridStyle}>
+        <View style={styles.headerRow}>
+          {table.columns.map((column) => (
+            <TableHeaderCell
+              key={column.index}
+              column={column}
+              cellStyle={cellStyles[column.index]}
+              sort={sort}
+              onPress={onSort}
             />
-          ) : null}
+          ))}
         </View>
-      </ScrollView>
-      {hasRows ? null : (
-        // Outside the scroller so a wide table cannot push the message off screen
-        // while the filter that emptied it stays reachable.
-        <View style={styles.centerState}>
-          <Text style={styles.emptyText}>{t("panels.file.table.noMatches")}</Text>
+        <View style={styles.filterRow}>
+          {table.columns.map((column) => (
+            <TableFilterCell
+              key={column.index}
+              column={column}
+              cellStyle={cellStyles[column.index]}
+              term={filters.get(column.index) ?? ""}
+              onChange={onFilter}
+            />
+          ))}
         </View>
-      )}
-      <View style={styles.footer}>
-        <Text style={styles.footerText} testID="file-table-row-count">
-          {rowCountLabel({ visible: rows.length, total: table.rows.length, t })}
-        </Text>
+        {hasRows ? (
+          <FlatList
+            data={rows}
+            renderItem={renderRow}
+            keyExtractor={rowKey}
+            getItemLayout={rowLayout}
+            style={styles.body}
+            nestedScrollEnabled
+            showsVerticalScrollIndicator
+          />
+        ) : null}
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -258,18 +301,20 @@ function TableSortIndicator({ direction }: { direction: TableSortDirection | nul
 interface TableFilterCellProps {
   column: TableColumn;
   cellStyle: TableCellStyle;
+  term: string;
   onChange(column: number, term: string): void;
 }
 
 const TableFilterCell = memo(function TableFilterCell({
   column,
   cellStyle,
+  term,
   onChange,
 }: TableFilterCellProps) {
   const { t } = useTranslation();
   const [focused, setFocused] = useState(false);
   const change = useCallback(
-    (term: string) => onChange(column.index, term),
+    (nextTerm: string) => onChange(column.index, nextTerm),
     [column.index, onChange],
   );
   const focus = useCallback(() => setFocused(true), []);
@@ -283,6 +328,10 @@ const TableFilterCell = memo(function TableFilterCell({
     <View style={[styles.filterCell, cellStyle]}>
       <ThemedFilterInput
         style={[styles.filterInput, focused ? styles.filterInputFocused : null]}
+        // Uncontrolled on purpose: a controlled TextInput replays stale values
+        // during fast typing. The seed only matters when the grid remounts under
+        // an active filter, which is what an appearance change does.
+        defaultValue={term}
         placeholder={t("panels.file.table.filter")}
         accessibilityLabel={t("panels.file.table.filterColumn", { column: label })}
         autoCapitalize="none"
@@ -421,7 +470,7 @@ const styles = StyleSheet.create((theme) => {
       color: theme.colors.foreground,
       fontFamily: theme.fontFamily.mono,
       fontSize: theme.fontSize.code,
-      lineHeight: Math.round(theme.fontSize.code * 1.45),
+      lineHeight: Math.round(theme.fontSize.code * CELL_LINE_HEIGHT_RATIO),
       paddingHorizontal: theme.spacing[3],
       paddingVertical: theme.spacing[2],
     },

--- a/packages/app/src/file-pane/table/view.tsx
+++ b/packages/app/src/file-pane/table/view.tsx
@@ -1,0 +1,457 @@
+import { memo, useCallback, useMemo, useState } from "react";
+import { FlatList, ScrollView, Text, TextInput, View, type ListRenderItemInfo } from "react-native";
+import { StyleSheet, UnistylesRuntime, withUnistyles } from "react-native-unistyles";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react-native";
+import { Button } from "@/components/ui/button";
+import { createControlGeometry } from "@/components/ui/control-geometry";
+import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
+import type { Theme } from "@/styles/theme";
+import {
+  nextTableSort,
+  parseDelimitedTable,
+  tableRowsInView,
+  type TableColumn,
+  type TableFilters,
+  type TableRow,
+  type TableSort,
+  type TableSortDirection,
+} from "./model";
+
+const ThemedFilterInput = withUnistyles(TextInput, (theme) => ({
+  placeholderTextColor: theme.colors.foregroundMuted,
+}));
+const ThemedArrowUp = withUnistyles(ArrowUp);
+const ThemedArrowDown = withUnistyles(ArrowDown);
+const ThemedArrowUpDown = withUnistyles(ArrowUpDown);
+const sortedIconMapping = (theme: Theme) => ({ color: theme.colors.foreground });
+const unsortedIconMapping = (theme: Theme) => ({ color: theme.colors.foregroundExtraMuted });
+
+const SORT_ICON_SIZE = 12;
+const MIN_COLUMN_WIDTH = 96;
+const MAX_COLUMN_WIDTH = 320;
+// Widths come from the content instead of a measure pass, so the sample bounds
+// the cost on a file with a million rows. A later row wider than the sample
+// truncates rather than widening its column.
+const WIDTH_SAMPLE_ROWS = 200;
+const CELL_PADDING = 24;
+// The header label shares its cell with the sort arrows and the button's own
+// padding, so a column has to be wide enough for both or the label wraps and
+// the header row stops lining up with the data.
+const HEADER_CHROME = 52;
+const MONO_CHARACTER_RATIO = 0.62;
+
+interface TableCellStyle {
+  width: number;
+}
+
+const EMPTY_FILTERS: TableFilters = new Map();
+
+export function FileTablePreview({ content, testID }: { content: string; testID?: string }) {
+  const { t } = useTranslation();
+  const table = useMemo(() => parseDelimitedTable(content), [content]);
+  const [sort, setSort] = useState<TableSort | null>(null);
+  const [filters, setFilters] = useState<TableFilters>(EMPTY_FILTERS);
+  const rows = useMemo(
+    () => tableRowsInView({ rows: table.rows, filters, sort }),
+    [table.rows, filters, sort],
+  );
+  const theme = UnistylesRuntime.getTheme();
+  const cellWidths = useMemo(
+    () => columnWidths({ table, fontSize: theme.fontSize.code }),
+    [table, theme.fontSize.code],
+  );
+  const cellStyles = useMemo(
+    () => cellWidths.map((width) => inlineUnistylesStyle({ width })),
+    [cellWidths],
+  );
+  const rowHeight = Math.round(theme.fontSize.code * 1.45) + theme.spacing[2] * 2;
+  const gridStyle = useMemo(() => {
+    const totalWidth = cellWidths.reduce((sum, width) => sum + width, 0);
+    return inlineUnistylesStyle({ width: totalWidth });
+  }, [cellWidths]);
+
+  const toggleSort = useCallback((column: number) => {
+    setSort((current) => nextTableSort(current, column));
+  }, []);
+  const setColumnFilter = useCallback((column: number, term: string) => {
+    setFilters((current) => {
+      const next = new Map(current);
+      if (term.length === 0) next.delete(column);
+      else next.set(column, term);
+      return next;
+    });
+  }, []);
+  const renderRow = useCallback(
+    ({ item }: ListRenderItemInfo<TableRow>) => (
+      <TableBodyRow row={item} columns={table.columns} cellStyles={cellStyles} />
+    ),
+    [table.columns, cellStyles],
+  );
+  const rowLayout = useCallback(
+    (_data: ArrayLike<TableRow> | null | undefined, index: number) => ({
+      length: rowHeight,
+      offset: rowHeight * index,
+      index,
+    }),
+    [rowHeight],
+  );
+
+  if (table.columns.length === 0) {
+    return (
+      <View style={styles.centerState} testID={testID}>
+        <Text style={styles.emptyText}>{t("panels.file.table.empty")}</Text>
+      </View>
+    );
+  }
+
+  const hasRows = rows.length > 0;
+
+  return (
+    <View style={styles.container} testID={testID}>
+      {/* The header, the filters, and the rows share one horizontal scroller so
+          a cell never drifts out from under its column. */}
+      <ScrollView
+        horizontal
+        style={hasRows ? styles.gridFill : styles.gridChrome}
+        contentContainerStyle={styles.gridScrollContent}
+      >
+        <View style={gridStyle}>
+          <View style={styles.headerRow}>
+            {table.columns.map((column) => (
+              <TableHeaderCell
+                key={column.index}
+                column={column}
+                cellStyle={cellStyles[column.index]}
+                sort={sort}
+                onPress={toggleSort}
+              />
+            ))}
+          </View>
+          <View style={styles.filterRow}>
+            {table.columns.map((column) => (
+              <TableFilterCell
+                key={column.index}
+                column={column}
+                cellStyle={cellStyles[column.index]}
+                onChange={setColumnFilter}
+              />
+            ))}
+          </View>
+          {hasRows ? (
+            <FlatList
+              data={rows}
+              renderItem={renderRow}
+              keyExtractor={rowKey}
+              getItemLayout={rowLayout}
+              style={styles.body}
+              nestedScrollEnabled
+              showsVerticalScrollIndicator
+            />
+          ) : null}
+        </View>
+      </ScrollView>
+      {hasRows ? null : (
+        // Outside the scroller so a wide table cannot push the message off screen
+        // while the filter that emptied it stays reachable.
+        <View style={styles.centerState}>
+          <Text style={styles.emptyText}>{t("panels.file.table.noMatches")}</Text>
+        </View>
+      )}
+      <View style={styles.footer}>
+        <Text style={styles.footerText} testID="file-table-row-count">
+          {rowCountLabel({ visible: rows.length, total: table.rows.length, t })}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function rowKey(row: TableRow): string {
+  return String(row.index);
+}
+
+interface RowCountLabelInput {
+  visible: number;
+  total: number;
+  t: TFunction;
+}
+
+// The count that carries the plural is the total, so a filtered label reads
+// "1 of 12 rows" rather than "1 of 12 row".
+function rowCountLabel({ visible, total, t }: RowCountLabelInput): string {
+  const plural = total === 1 ? "one" : "other";
+  if (visible === total) {
+    return t(`panels.file.table.rowCount.${plural}`, { count: total });
+  }
+  return t(`panels.file.table.filteredRowCount.${plural}`, { count: total, visible });
+}
+
+function columnLabel(column: TableColumn, t: TFunction): string {
+  return column.label.length > 0 ? column.label : t("panels.file.table.unnamedColumn");
+}
+
+interface SortLabelInput {
+  column: string;
+  direction: TableSortDirection | null;
+  t: TFunction;
+}
+
+// The arrow says which way the column points; the label has to say it too for
+// anyone who is not looking at it.
+function sortLabel({ column, direction, t }: SortLabelInput): string {
+  if (direction === "asc") return t("panels.file.table.sortedAscending", { column });
+  if (direction === "desc") return t("panels.file.table.sortedDescending", { column });
+  return t("panels.file.table.sortColumn", { column });
+}
+
+interface TableHeaderCellProps {
+  column: TableColumn;
+  cellStyle: TableCellStyle;
+  sort: TableSort | null;
+  onPress(column: number): void;
+}
+
+const TableHeaderCell = memo(function TableHeaderCell({
+  column,
+  cellStyle,
+  sort,
+  onPress,
+}: TableHeaderCellProps) {
+  const { t } = useTranslation();
+  const sorted = sort?.column === column.index ? sort.direction : null;
+  const press = useCallback(() => onPress(column.index), [column.index, onPress]);
+  const label = columnLabel(column, t);
+  const indicator = useMemo(() => <TableSortIndicator direction={sorted} />, [sorted]);
+
+  return (
+    <View style={[styles.headerCell, cellStyle]}>
+      <Button
+        variant="ghost"
+        size="xs"
+        onPress={press}
+        style={styles.headerButton}
+        textStyle={styles.headerLabel}
+        trailing={indicator}
+        accessibilityLabel={sortLabel({ column: label, direction: sorted, t })}
+        testID={`file-table-sort-${column.index}`}
+      >
+        {label}
+      </Button>
+    </View>
+  );
+});
+
+function TableSortIndicator({ direction }: { direction: TableSortDirection | null }) {
+  if (direction === "asc") {
+    return <ThemedArrowUp size={SORT_ICON_SIZE} uniProps={sortedIconMapping} />;
+  }
+  if (direction === "desc") {
+    return <ThemedArrowDown size={SORT_ICON_SIZE} uniProps={sortedIconMapping} />;
+  }
+  // The unsorted arrows stay visible so the column reads as sortable and the
+  // label does not reflow the first time it is sorted.
+  return <ThemedArrowUpDown size={SORT_ICON_SIZE} uniProps={unsortedIconMapping} />;
+}
+
+interface TableFilterCellProps {
+  column: TableColumn;
+  cellStyle: TableCellStyle;
+  onChange(column: number, term: string): void;
+}
+
+const TableFilterCell = memo(function TableFilterCell({
+  column,
+  cellStyle,
+  onChange,
+}: TableFilterCellProps) {
+  const { t } = useTranslation();
+  const [focused, setFocused] = useState(false);
+  const change = useCallback(
+    (term: string) => onChange(column.index, term),
+    [column.index, onChange],
+  );
+  const focus = useCallback(() => setFocused(true), []);
+  const blur = useCallback(() => setFocused(false), []);
+  const label = columnLabel(column, t);
+
+  // Deliberately not `FormTextInput`: on a compact native layout that primitive
+  // renders `@gorhom/bottom-sheet`'s input, which only works inside a sheet.
+  // This row lives in a pane, so it owns the same field chrome directly.
+  return (
+    <View style={[styles.filterCell, cellStyle]}>
+      <ThemedFilterInput
+        style={[styles.filterInput, focused ? styles.filterInputFocused : null]}
+        placeholder={t("panels.file.table.filter")}
+        accessibilityLabel={t("panels.file.table.filterColumn", { column: label })}
+        autoCapitalize="none"
+        autoCorrect={false}
+        onChangeText={change}
+        onFocus={focus}
+        onBlur={blur}
+        testID={`file-table-filter-${column.index}`}
+      />
+    </View>
+  );
+});
+
+interface TableBodyRowProps {
+  row: TableRow;
+  columns: TableColumn[];
+  cellStyles: TableCellStyle[];
+}
+
+const TableBodyRow = memo(function TableBodyRow({ row, columns, cellStyles }: TableBodyRowProps) {
+  return (
+    <View style={styles.bodyRow} testID={`file-table-body-row-${row.index}`}>
+      {columns.map((column) => (
+        <Text
+          key={column.index}
+          selectable
+          numberOfLines={1}
+          style={[styles.bodyCell, cellStyles[column.index]]}
+        >
+          {row.cells[column.index]}
+        </Text>
+      ))}
+    </View>
+  );
+});
+
+interface ColumnWidthInput {
+  table: { columns: TableColumn[]; rows: TableRow[] };
+  fontSize: number;
+}
+
+function columnWidths({ table, fontSize }: ColumnWidthInput): number[] {
+  // One character of slack absorbs the difference between this estimate and
+  // whichever mono stack the user configured.
+  const characterWidth = fontSize * MONO_CHARACTER_RATIO;
+  const sample = table.rows.slice(0, WIDTH_SAMPLE_ROWS);
+  return table.columns.map((column) => {
+    let longestCell = 0;
+    for (const row of sample) {
+      longestCell = Math.max(longestCell, row.cells[column.index].length);
+    }
+    const cellWidth = Math.ceil((longestCell + 1) * characterWidth) + CELL_PADDING;
+    const labelWidth = Math.ceil((column.label.length + 1) * characterWidth) + HEADER_CHROME;
+    const contentWidth = Math.max(cellWidth, labelWidth);
+    return Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, contentWidth));
+  });
+}
+
+const styles = StyleSheet.create((theme) => {
+  const geometry = createControlGeometry(theme);
+
+  return {
+    container: {
+      flex: 1,
+      minHeight: 0,
+    },
+    gridFill: {
+      flex: 1,
+      minHeight: 0,
+    },
+    gridChrome: {
+      flexGrow: 0,
+      flexShrink: 0,
+    },
+    gridScrollContent: {
+      flexGrow: 1,
+    },
+    body: {
+      flex: 1,
+      minHeight: 0,
+    },
+    headerRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: theme.colors.surface1,
+      borderBottomWidth: theme.borderWidth[1],
+      borderBottomColor: theme.colors.border,
+    },
+    headerCell: {
+      paddingHorizontal: theme.spacing[1],
+      paddingVertical: theme.spacing[1],
+    },
+    headerButton: {
+      justifyContent: "space-between",
+      paddingHorizontal: theme.spacing[2],
+    },
+    headerLabel: {
+      color: theme.colors.foreground,
+      fontWeight: theme.fontWeight.medium,
+      flexShrink: 1,
+    },
+    sortIcon: {
+      color: theme.colors.foregroundExtraMuted,
+    },
+    sortIconActive: {
+      color: theme.colors.foreground,
+    },
+    filterRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      borderBottomWidth: theme.borderWidth[1],
+      borderBottomColor: theme.colors.border,
+      backgroundColor: theme.colors.surface1,
+    },
+    filterCell: {
+      flexDirection: "row",
+      paddingHorizontal: theme.spacing[1],
+      paddingBottom: theme.spacing[1],
+    },
+    filterInput: {
+      ...geometry.formTextInputSm,
+      ...geometry.controlRest,
+      flex: 1,
+      minWidth: 0,
+      backgroundColor: theme.colors.surface2,
+      color: theme.colors.foreground,
+    },
+    filterInputFocused: {
+      ...geometry.controlActive,
+    },
+    bodyRow: {
+      flexDirection: "row",
+      alignItems: "center",
+    },
+    bodyCell: {
+      color: theme.colors.foreground,
+      fontFamily: theme.fontFamily.mono,
+      fontSize: theme.fontSize.code,
+      lineHeight: Math.round(theme.fontSize.code * 1.45),
+      paddingHorizontal: theme.spacing[3],
+      paddingVertical: theme.spacing[2],
+    },
+    footer: {
+      flexShrink: 0,
+      flexDirection: "row",
+      alignItems: "center",
+      // Right-aligned because a compact layout floats its own control over the
+      // bottom-left corner of the pane.
+      justifyContent: "flex-end",
+      minHeight: 28,
+      paddingHorizontal: theme.spacing[3],
+      borderTopWidth: theme.borderWidth[1],
+      borderTopColor: theme.colors.border,
+      backgroundColor: theme.colors.surface1,
+    },
+    footerText: {
+      color: theme.colors.foregroundExtraMuted,
+      fontSize: theme.fontSize.xs,
+    },
+    centerState: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      padding: theme.spacing[4],
+    },
+    emptyText: {
+      color: theme.colors.foregroundMuted,
+      fontSize: theme.fontSize.sm,
+      textAlign: "center",
+    },
+  };
+});

--- a/packages/app/src/file-pane/table/view.tsx
+++ b/packages/app/src/file-pane/table/view.tsx
@@ -13,6 +13,7 @@ import {
   nextTableSort,
   parseDelimitedTable,
   tableRowsInView,
+  tableViewWithinColumns,
   type TableColumn,
   type TableFilters,
   type TableGrid,
@@ -64,9 +65,15 @@ export function FileTablePreview({ content, filePath, testID }: FileTablePreview
   const table = useMemo(() => parseDelimitedTable(content, filePath), [content, filePath]);
   const [sort, setSort] = useState<TableSort | null>(null);
   const [filters, setFilters] = useState<TableFilters>(EMPTY_FILTERS);
+  // The live file can lose columns while it is open, so what the user asked for
+  // is resolved against what the file currently has.
+  const view = useMemo(
+    () => tableViewWithinColumns({ sort, filters }, table.columns.length),
+    [sort, filters, table.columns.length],
+  );
   const rows = useMemo(
-    () => tableRowsInView({ rows: table.rows, filters, sort }),
-    [table.rows, filters, sort],
+    () => tableRowsInView({ rows: table.rows, filters: view.filters, sort: view.sort }),
+    [table.rows, view],
   );
 
   const toggleSort = useCallback((column: number) => {
@@ -102,8 +109,8 @@ export function FileTablePreview({ content, filePath, testID }: FileTablePreview
         <TableSurface
           table={table}
           rows={rows}
-          filters={filters}
-          sort={sort}
+          filters={view.filters}
+          sort={view.sort}
           onSort={toggleSort}
           onFilter={setColumnFilter}
         />

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1542,6 +1542,24 @@ export const ar: TranslationResources = {
       binaryPreviewUnavailable: "المعاينة الثنائية غير متاحة",
       failedToLoad: "فشل تحميل الملف",
       failedToLoadPreview: "فشل تحميل معاينة الملف",
+      table: {
+        empty: "لا توجد صفوف",
+        noMatches: "لا توجد صفوف مطابقة",
+        filter: "تصفية",
+        filterColumn: "تصفية {{column}}",
+        sortColumn: "ترتيب حسب {{column}}",
+        sortedAscending: "{{column}}، مرتبة تصاعديًا",
+        sortedDescending: "{{column}}، مرتبة تنازليًا",
+        unnamedColumn: "عمود بدون اسم",
+        rowCount: {
+          one: "{{count}} صف",
+          other: "{{count}} صفوف",
+        },
+        filteredRowCount: {
+          one: "{{visible}} من {{count}} صف",
+          other: "{{visible}} من {{count}} صفوف",
+        },
+      },
       editor: {
         fileSize: "حجم الملف {{size}}",
         lines: "{{count}} سطر",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1553,6 +1553,24 @@ export const en = {
       binaryPreviewUnavailable: "Binary preview unavailable",
       failedToLoad: "Failed to load file",
       failedToLoadPreview: "Failed to load file preview",
+      table: {
+        empty: "No rows",
+        noMatches: "No matching rows",
+        filter: "Filter",
+        filterColumn: "Filter {{column}}",
+        sortColumn: "Sort by {{column}}",
+        sortedAscending: "{{column}}, sorted ascending",
+        sortedDescending: "{{column}}, sorted descending",
+        unnamedColumn: "Unnamed column",
+        rowCount: {
+          one: "{{count}} row",
+          other: "{{count}} rows",
+        },
+        filteredRowCount: {
+          one: "{{visible}} of {{count}} row",
+          other: "{{visible}} of {{count}} rows",
+        },
+      },
       editor: {
         fileSize: "File size {{size}}",
         lines: "{{count}} lines",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1585,6 +1585,24 @@ export const es: TranslationResources = {
       binaryPreviewUnavailable: "Vista previa binaria no disponible",
       failedToLoad: "No se pudo cargar el archivo",
       failedToLoadPreview: "No se pudo cargar la vista previa del archivo",
+      table: {
+        empty: "Sin filas",
+        noMatches: "Ninguna fila coincide",
+        filter: "Filtrar",
+        filterColumn: "Filtrar {{column}}",
+        sortColumn: "Ordenar por {{column}}",
+        sortedAscending: "{{column}}, orden ascendente",
+        sortedDescending: "{{column}}, orden descendente",
+        unnamedColumn: "Columna sin nombre",
+        rowCount: {
+          one: "{{count}} fila",
+          other: "{{count}} filas",
+        },
+        filteredRowCount: {
+          one: "{{visible}} de {{count}} fila",
+          other: "{{visible}} de {{count}} filas",
+        },
+      },
       editor: {
         fileSize: "Tamaño {{size}}",
         lines: "{{count}} líneas",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1589,6 +1589,24 @@ export const fr: TranslationResources = {
       binaryPreviewUnavailable: "Aperçu binaire indisponible",
       failedToLoad: "Échec du chargement du fichier",
       failedToLoadPreview: "Échec du chargement de l'aperçu du fichier",
+      table: {
+        empty: "Aucune ligne",
+        noMatches: "Aucune ligne correspondante",
+        filter: "Filtrer",
+        filterColumn: "Filtrer {{column}}",
+        sortColumn: "Trier par {{column}}",
+        sortedAscending: "{{column}}, tri croissant",
+        sortedDescending: "{{column}}, tri décroissant",
+        unnamedColumn: "Colonne sans nom",
+        rowCount: {
+          one: "{{count}} ligne",
+          other: "{{count}} lignes",
+        },
+        filteredRowCount: {
+          one: "{{visible}} sur {{count}} ligne",
+          other: "{{visible}} sur {{count}} lignes",
+        },
+      },
       editor: {
         fileSize: "Taille {{size}}",
         lines: "{{count}} lignes",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1558,6 +1558,24 @@ export const ja: TranslationResources = {
       binaryPreviewUnavailable: "バイナリプレビューが利用できません",
       failedToLoad: "ファイルの読み込みに失敗しました",
       failedToLoadPreview: "ファイルプレビューの読み込みに失敗しました",
+      table: {
+        empty: "行がありません",
+        noMatches: "一致する行がありません",
+        filter: "絞り込み",
+        filterColumn: "{{column}}を絞り込み",
+        sortColumn: "{{column}}で並べ替え",
+        sortedAscending: "{{column}}、昇順",
+        sortedDescending: "{{column}}、降順",
+        unnamedColumn: "名称のない列",
+        rowCount: {
+          one: "{{count}}行",
+          other: "{{count}}行",
+        },
+        filteredRowCount: {
+          one: "{{count}}行中{{visible}}行",
+          other: "{{count}}行中{{visible}}行",
+        },
+      },
       editor: {
         fileSize: "ファイルサイズ {{size}}",
         lines: "{{count}} 行",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1571,6 +1571,24 @@ export const ptBR: TranslationResources = {
       binaryPreviewUnavailable: "Prévia binária indisponível",
       failedToLoad: "Falha ao carregar arquivo",
       failedToLoadPreview: "Falha ao carregar prévia do arquivo",
+      table: {
+        empty: "Nenhuma linha",
+        noMatches: "Nenhuma linha corresponde",
+        filter: "Filtrar",
+        filterColumn: "Filtrar {{column}}",
+        sortColumn: "Ordenar por {{column}}",
+        sortedAscending: "{{column}}, ordem crescente",
+        sortedDescending: "{{column}}, ordem decrescente",
+        unnamedColumn: "Coluna sem nome",
+        rowCount: {
+          one: "{{count}} linha",
+          other: "{{count}} linhas",
+        },
+        filteredRowCount: {
+          one: "{{visible}} de {{count}} linha",
+          other: "{{visible}} de {{count}} linhas",
+        },
+      },
       editor: {
         fileSize: "Tamanho {{size}}",
         lines: "{{count}} linhas",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1576,6 +1576,24 @@ export const ru: TranslationResources = {
       binaryPreviewUnavailable: "Предварительный просмотр двоичного файла недоступен.",
       failedToLoad: "Не удалось загрузить файл",
       failedToLoadPreview: "Не удалось загрузить предварительный просмотр файла.",
+      table: {
+        empty: "Нет строк",
+        noMatches: "Нет подходящих строк",
+        filter: "Фильтр",
+        filterColumn: "Фильтровать {{column}}",
+        sortColumn: "Сортировать по {{column}}",
+        sortedAscending: "{{column}}, по возрастанию",
+        sortedDescending: "{{column}}, по убыванию",
+        unnamedColumn: "Столбец без названия",
+        rowCount: {
+          one: "{{count}} строка",
+          other: "{{count}} строк",
+        },
+        filteredRowCount: {
+          one: "{{visible}} из {{count}} строки",
+          other: "{{visible}} из {{count}} строк",
+        },
+      },
       editor: {
         fileSize: "Размер файла {{size}}",
         lines: "Строк: {{count}}",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1522,6 +1522,24 @@ export const zhCN: TranslationResources = {
       binaryPreviewUnavailable: "二进制预览不可用",
       failedToLoad: "加载文件失败",
       failedToLoadPreview: "加载文件预览失败",
+      table: {
+        empty: "没有数据行",
+        noMatches: "没有匹配的行",
+        filter: "筛选",
+        filterColumn: "筛选{{column}}",
+        sortColumn: "按{{column}}排序",
+        sortedAscending: "{{column}}，升序",
+        sortedDescending: "{{column}}，降序",
+        unnamedColumn: "未命名列",
+        rowCount: {
+          one: "{{count}} 行",
+          other: "{{count}} 行",
+        },
+        filteredRowCount: {
+          one: "{{count}} 行中的 {{visible}} 行",
+          other: "{{count}} 行中的 {{visible}} 行",
+        },
+      },
       editor: {
         fileSize: "文件大小 {{size}}",
         lines: "{{count}} 行",


### PR DESCRIPTION
### Linked issue

None. There's no issue or discussion for this one — I hit it in my own workflow and it's a small, contained addition to the file pane. Closing it as "not the direction" is a fine outcome; I'd rather you see the shape first.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Agents produce CSVs constantly — benchmark runs, exported query results, generated fixtures, `usage.csv` from a script in the workspace. Opening one in the file pane today gives highlighted plain text, so past three or four columns you're counting commas to work out which value belongs to which column, and you can't answer "which row has the worst pass rate" without leaving Paseo for a spreadsheet.

This renders `.csv` and `.tsv` as a table in Preview, with `Source` still one toggle away, using the same Preview/Source chrome Markdown and HTML previews already use. Each column header sorts and carries a filter box, so the two things you actually do with a data file — order it and narrow it — happen in the pane.

### Goals

- Render `.csv` and `.tsv` through the existing `Preview`/`Source` toggle; `Source` keeps the raw text and the editor.
- Parse per RFC 4180: quoted cells keep their delimiters and newlines, `""` unescapes, CRLF and a trailing newline are handled, ragged rows pad to the widest row.
- Detect the delimiter from the header row, so semicolon- and pipe-separated exports work without another extension.
- Sort per column: ascending, descending, off. Numeric when both cells are numbers, case-insensitive for text, blanks last in both directions, ties keep file order.
- Filter per column, ANDed across columns, with the surviving row count visible.
- Keep a large export scrollable — virtualized rows, no layout pass over a file's worth of cells.
- Follow live file updates, the same way the Markdown and HTML previews do.

### Non-goals

- No editing through the table. `Source` is the editor; the table is a viewer.
- No `.xlsx`/`.docx`/spreadsheet-binary support, and no new dependency — the parser is ~60 lines.
- No column resize, column hide, multi-column sort, or aggregate row.
- No change to Markdown, HTML, image, or code previews beyond moving the three renderable branches of `FilePreviewBody` into one `RenderedTextPreview` component (the `complexity` lint rule caps that function, and a fourth branch went over it).

### QA

Ran on macOS 15 (Darwin 25.4), against a real daemon and a real Chromium through the app's Playwright harness.

**New Playwright cases — real browser, real daemon, real file on disk**

```
$ npm run test:e2e --workspace=@getpaseo/app -- file-editing.spec.ts \
    -g "previews a CSV as a table|header-only CSV|resizes table columns|loses the column"

Running 4 tests using 1 worker
  ✓  1 [browser] › file-editing.spec.ts:516:7 › previews a CSV as a table that sorts, filters, and follows the file (4.1s)
  ✓  2 [browser] › file-editing.spec.ts:590:7 › survives a CSV that loses the column it was sorted and filtered by (3.4s)
  ✓  3 [browser] › file-editing.spec.ts:613:7 › resizes table columns when the code font size changes (3.4s)
  ✓  4 [browser] › file-editing.spec.ts:641:7 › names a header-only CSV empty rather than filtered (3.0s)
  4 passed (21.9s)
```

The first writes `metrics.csv` in the workspace, opens it from the explorer, and asserts: the parsed row order, that `runs` sorts `9` before `10` (numeric, not lexicographic) with the blank cell last in both directions, that a third click clears the sort and returns file order, that the accessible header label reads `runs, sorted ascending` / `runs, sorted descending`, that a column filter narrows the rows and the footer reads `1 of 3 rows`, that a filter matching nothing shows `No matching rows`, that a row appended on disk appears without reopening the file, and that `Source` shows the raw CSV text in the editor and Preview brings the table back.

The second sorts and filters a column, then rewrites the file without it. That used to crash the pane — `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` — because sort and filter state outlives the parse; the test reproduces that on the pre-fix commit.

The third raises Code font size in Appearance settings and asserts the header cell gets wider, because column widths and row height are derived from a token that gets patched at runtime rather than through a React render. It fails on the commit before the fix — `Expected: > 97, Received: 97` — and passes after it, 97px to 140px.

The fourth opens a header-only file and asserts it reads `No rows` with a `0 rows` count — an empty file and a filtered-to-nothing file say different things.

**Unit tests**

```
$ npx vitest run packages/app/src/file-pane/table/model.test.ts \
    packages/app/src/components/file-pane-render-mode.test.ts \
    packages/app/src/i18n/resources.test.ts

 Test Files  3 passed (3)
      Tests  69 passed (69)
```

`model.test.ts` covers the parser (quoted delimiters and newlines, doubled quotes, tab/semicolon/pipe detection, a quoted header cell containing the delimiter, `.tsv` forcing tabs over a comma in the header, rows of only empty cells surviving while blank lines are dropped, ragged rows, CRLF, blank content, header-only) and the view model (case-insensitive substring filters, ANDed columns, whitespace-only filter ignored, numeric ordering, case-insensitive text ordering, blanks last both ways, stable ties, no mutation of the source rows, and the sort cycle).

**Checks**

```
$ npm run typecheck        # 0 errors
$ npm run lint             # Found 0 warnings and 0 errors (3213 files)
$ npm run format:check     # all matched files use the correct format
```

**Regression pass over the rest of the file pane**

`npm run test:e2e --workspace=@getpaseo/app -- file-editing.spec.ts` → 10 passed, 5 failed. The same 5 fail on a clean `origin/main` checkout on this machine (`git stash` + rerun, same 5), and they all fail on CodeMirror keybindings that differ on macOS — `Control+A` and `Control+Home` don't select-all / jump-to-start here, so the helper types instead of replacing. Not touched by this PR; the HTML preview, image preview, Vim-mode, and unsaved-draft cases all pass.

**Screenshots** — desktop web at 1280px, then compact at 430px, light and dark:

| Default | Sorted `runs` descending |
| --- | --- |
| <img src="https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/01-desktop-default.png" width="420"> | <img src="https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/02-desktop-sorted-desc.png" width="420"> |

| Two column filters | Filter matches nothing |
| --- | --- |
| <img src="https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/03-desktop-filtered.png" width="420"> | <img src="https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/04-desktop-no-matches.png" width="420"> |

| Compact, light | Compact, dark |
| --- | --- |
| <img src="https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/05-compact-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/06-compact-dark.png" width="300"> |

Descending `runs` reads `1042, 512, 256, 128, 77, 64, 15, 9, 3` with the empty cell last, which is the point of sorting numerically. Note the blank `pass rate` and `runs` cells stay at the bottom either way.

**Video of the whole interaction** (open → sort → filter → empty → clear → compact):

![CSV table preview interaction](https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/csv-table-preview.gif)

Source `.webm` if the GIF is too lossy: [csv-table-preview.webm](https://raw.githubusercontent.com/nickmaglowsch/paseo/qa/csv-table-preview/csv-table-preview.webm). Both live on a `qa/csv-table-preview` branch in my fork, not in this diff.

**Platform matrix**

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | ❌ | No simulator on this machine. See the native note below. |
| Android | ❌ | No emulator on this machine. See the native note below. |
| Web | ✅ | Chromium via the app Playwright harness, real daemon, light and dark, 1280px and 430px. |
| Desktop macOS | ⚠️ | Not launched separately. Same renderer and same code path as browser web; this change has no Electron-specific branch. |
| Desktop Windows | ❌ | No machine. |
| Desktop Linux | ❌ | No machine. |

**What I did about native without a device**

Two things in this feature could only break on native, so I kept them off the risky path rather than guess:

- The filter box does **not** use `FormTextInput`. On a compact native layout that primitive renders `@gorhom/bottom-sheet`'s `BottomSheetTextInput`, which is only valid inside a sheet — this row lives in a pane. The cell takes its chrome from `createControlGeometry` directly, so it stays on the same field geometry tokens without the sheet coupling. Comment at `packages/app/src/file-pane/table/view.tsx`.
- Vertical rows go through a `FlatList` nested in a **horizontal** `ScrollView`, so the orientations differ and `nestedScrollEnabled` is set. Row height is fixed and fed to `getItemLayout`.

If you'd rather someone with a device confirm the compact filter row and nested scroll before this lands, that's a reasonable gate and I'd expect it.


### Review notes

Two independent reviewers went over this before I opened it, and six findings turned into the three commits after the first:

- A `.tsv` whose header holds `last, first` has as many commas as tabs, and counting alone split the name in half. An extension that names its delimiter now wins whenever that delimiter appears in the header.
- Rows of only empty cells (`,` and `""`) were dropped along with blank lines, because both parse to empty strings. The reader now tracks whether a line said anything, so those rows survive and a blank line still does not.
- Column widths and the row height came from a `UnistylesRuntime` read, which does not re-render when appearance settings patch the code font size. The grid sits behind `AppearanceStyleBoundary` now; sort and filter state stays outside it, and the filter box seeds from that state so a remount under an active filter keeps its term. There's a Playwright case for this that fails on the pre-fix commit.
- A header-only file said `No matching rows` when nothing had been filtered.

- Sort and filter state outlived the parse, so a live file that lost the column being sorted or filtered on crashed the pane on the next render. `tableViewWithinColumns` resolves the requested view against the columns the file currently has, which also drops a filter whose box is no longer on screen to clear.
- A `.tsv` whose header held no tab still fell through to comma sniffing, so a single-column TSV of prose split on its commas. An extension that names its delimiter is now taken at its word.

One finding I argued instead of fixing: the parse walks the whole file on the UI thread. The daemon read already decodes the entire file into one string before any preview runs, and the code view this replaces then calls `highlightCode()` over all of it and renders one non-virtualized `View` per line. For the same large CSV the table does strictly less work than what ships today. Chunked or worker parsing belongs to the file-read path for every preview kind, not to this feature.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

### Notes for review

- Column widths are estimated from the header plus the first 200 rows rather than measured, so a wider row later truncates instead of widening its column. That bounds the cost on a large file; the ceiling is a comment at the constant.
- Sorting deliberately avoids `localeCompare`: Hermes, JSC, and V8 disagree, and the same file has to sort the same on every platform.
- The row-count footer is right-aligned because the compact layout floats a control over the pane's bottom-left corner.
- Blank records are dropped while parsing (a trailing newline, a CRLF CRLF ending, a stray gap). Row indexes are view positions, not file line numbers, and nothing claims otherwise.
- Maintainer edits are enabled.
