### PR TITLE
feat(app): tooltip with full skill description on autocomplete row hover

### DIFF
--- a/packages/app/e2e/browser/composer-command-tooltip.spec.ts
+++ b/packages/app/e2e/browser/composer-command-tooltip.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test, type Page } from "../support/fixtures";
+import { composerLocator, expectComposerVisible } from "../support/helpers/composer";
+import { openAgentRoute, seedMockAgentWorkspace } from "../support/helpers/mock-agent";
+import { expectWorkspaceTabVisible } from "../support/helpers/archive-tab";
+
+// The `/exit` client command is always present in an open (non-draft) agent and
+// carries a stable description, so it is the deterministic target for the hover
+// tooltip. The row renders the description with numberOfLines={1}; the tooltip
+// surfaces the same text in full on hover.
+const EXIT_COMMAND_ID = "exit";
+const EXIT_DESCRIPTION = "Archive the current agent";
+
+async function openReadyMockAgent(page: Page) {
+  const session = await seedMockAgentWorkspace({
+    repoPrefix: "composer-command-tooltip-",
+    title: "Command tooltip e2e",
+    initialPrompt: "Prepare a command tooltip test agent.",
+  });
+  await openAgentRoute(page, session);
+  await expectWorkspaceTabVisible(page, session.agentId);
+  await expectComposerVisible(page);
+  return session;
+}
+
+test.describe("Composer command autocomplete tooltip", () => {
+  test("hovering a command row reveals the full description and dismisses on leave", async ({
+    page,
+  }) => {
+    const session = await openReadyMockAgent(page);
+    try {
+      const input = composerLocator(page);
+      await expect(input).toBeEditable({ timeout: 30_000 });
+      await input.fill("/ex");
+
+      const row = page.getByTestId(`composer-autocomplete-option-${EXIT_COMMAND_ID}`);
+      await expect(row).toBeVisible({ timeout: 30_000 });
+
+      const tooltip = page.getByTestId(`composer-autocomplete-tooltip-${EXIT_COMMAND_ID}`);
+      // No tooltip until the row is hovered.
+      await expect(tooltip).toHaveCount(0);
+
+      await row.hover();
+
+      await expect(tooltip).toBeVisible({ timeout: 10_000 });
+      await expect(tooltip).toContainText(EXIT_DESCRIPTION);
+
+      // Leaving the row dismisses the tooltip.
+      await page.mouse.move(0, 0);
+      await expect(tooltip).toHaveCount(0);
+    } finally {
+      await session.cleanup();
+    }
+  });
+});

--- a/packages/app/src/components/ui/autocomplete.tsx
+++ b/packages/app/src/components/ui/autocomplete.tsx
@@ -13,6 +13,7 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
 import { File, Folder } from "lucide-react-native";
 import type { Theme } from "@/styles/theme";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getAutocompleteScrollOffset } from "./autocomplete-utils";
 
 export interface AutocompleteOption {
@@ -78,7 +79,7 @@ function AutocompleteRow({
     [isSelected],
   );
 
-  return (
+  const row = (
     <Pressable onLayout={handleLayout} onPress={handlePress} style={pressableStyle}>
       {isFileOrDir ? (
         <>
@@ -115,6 +116,19 @@ function AutocompleteRow({
       )}
     </Pressable>
   );
+
+  if (option.kind === "command" && optionDescription) {
+    return (
+      <Tooltip delayDuration={300} enabledOnDesktop enabledOnMobile={false}>
+        <TooltipTrigger asChild>{row}</TooltipTrigger>
+        <TooltipContent side="top" align="start" maxWidth={360}>
+          <Text style={styles.tooltipText}>{optionDescription}</Text>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return row;
 }
 
 export function Autocomplete({
@@ -387,5 +401,9 @@ const styles = StyleSheet.create((theme: Theme) => ({
   emptyText: {
     color: theme.colors.foregroundMuted,
     fontSize: theme.fontSize.sm,
+  },
+  tooltipText: {
+    color: theme.colors.popoverForeground,
+    fontSize: theme.fontSize.xs,
   },
 })) as unknown as Record<string, object>;

--- a/packages/app/src/components/ui/autocomplete.tsx
+++ b/packages/app/src/components/ui/autocomplete.tsx
@@ -80,7 +80,12 @@ function AutocompleteRow({
   );
 
   const row = (
-    <Pressable onLayout={handleLayout} onPress={handlePress} style={pressableStyle}>
+    <Pressable
+      testID={`composer-autocomplete-option-${option.id}`}
+      onLayout={handleLayout}
+      onPress={handlePress}
+      style={pressableStyle}
+    >
       {isFileOrDir ? (
         <>
           <View style={styles.itemLeading}>
@@ -121,7 +126,12 @@ function AutocompleteRow({
     return (
       <Tooltip delayDuration={300} enabledOnDesktop enabledOnMobile={false}>
         <TooltipTrigger asChild>{row}</TooltipTrigger>
-        <TooltipContent side="top" align="start" maxWidth={360}>
+        <TooltipContent
+          side="top"
+          align="start"
+          maxWidth={360}
+          testID={`composer-autocomplete-tooltip-${option.id}`}
+        >
           <Text style={styles.tooltipText}>{optionDescription}</Text>
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
## What

Command/skill rows in the composer autocomplete truncate their description to a single line (`numberOfLines={1}`), so long skill descriptions are cut with an ellipsis. This wraps each command row in the existing `Tooltip` so hovering surfaces the **full, untruncated** description.

- Scoped to `kind === "command"` rows that have a description; file/directory rows are unchanged.
- Desktop hover only (`enabledOnDesktop`, `enabledOnMobile={false}`) with a 300ms delay — no behavior change on native/mobile.
- Reuses `Tooltip`/`TooltipTrigger`/`TooltipContent` from `@/components/ui/tooltip`; the full text is already on `option.description`, only visually clipped at render time.
- Adds `testID`s to the autocomplete row and tooltip content so the flow is testable.

## QA

### Does it work well

Ran the dev app, opened the composer autocomplete, and hovered a command row with a long description (`/doctor`). The row stays truncated with an ellipsis; the tooltip shows the whole description. Screenshot in the comment below.

### Automated coverage

New Playwright browser flow: `packages/app/e2e/browser/composer-command-tooltip.spec.ts`. It opens a mock agent, filters the composer autocomplete to `/exit`, asserts no tooltip is present, hovers the row, asserts the tooltip appears with the full description, then moves the pointer away and asserts it dismisses. Modeled on the existing `provider-usage-tooltip.spec.ts` and `client-slash-commands.spec.ts` peers.

```
$ cd packages/app && npx playwright test --project=browser composer-command-tooltip.spec.ts
  ✓  Composer command autocomplete tooltip › hovering a command row reveals the full description and dismisses on leave (11.9s)
  1 passed (45.4s)
```

The assertion fails on the old code: without the tooltip the `composer-autocomplete-tooltip-exit` node never exists, so `toBeVisible()` times out.

`npm run typecheck`, `npm run lint`, `npm run format` all clean (pre-commit hooks green).

### Platforms

Web-only feature (hover). The tooltip is gated `enabledOnMobile={false}`; native/compact code paths are unchanged.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| Web (browser)   | ✅     | Manual hover + Playwright E2E (Desktop Chrome) |
| Desktop macOS   | ✅     | Same web renderer; verified in dev app |
| Desktop Windows | —      | Same web renderer, no platform-gated code |
| Desktop Linux   | —      | Same web renderer, no platform-gated code |
| iOS             | n/a    | Hover-only; `enabledOnMobile={false}`, no change |
| Android         | n/a    | Hover-only; `enabledOnMobile={false}`, no change |

## Does it regress anything else

The change only wraps command rows; file/directory autocomplete rows and the existing selected-command detail card are untouched. No protocol or daemon changes.
