### PR TITLE
Expand ~ in every configured filesystem path

### DIFF
--- a/packages/server/src/server/config-web-ui.test.ts
+++ b/packages/server/src/server/config-web-ui.test.ts
@@ -114,6 +114,29 @@ describe("daemon web UI config", () => {
     expect(config.webUi.distDir).toBe(path.join(home, "web-ui-dist"));
   });
 
+  test("expands ~ in persisted distDir", async () => {
+    const home = await createPaseoHome({
+      version: 1,
+      features: { webUi: { distDir: "~/web-ui-dist" } },
+    });
+
+    const config = loadConfig(home, { env: {} });
+
+    expect(config.webUi.distDir).toBe(
+      path.resolve(process.env.HOME || os.homedir(), "web-ui-dist"),
+    );
+  });
+
+  test("expands ~ in PASEO_WEB_UI_DIST_DIR", async () => {
+    const home = await createPaseoHome({ version: 1 });
+
+    const config = loadConfig(home, { env: { PASEO_WEB_UI_DIST_DIR: "~/env-web-ui-dist" } });
+
+    expect(config.webUi.distDir).toBe(
+      path.resolve(process.env.HOME || os.homedir(), "env-web-ui-dist"),
+    );
+  });
+
   test("PASEO_WEB_UI_DIST_DIR overrides persisted distDir", async () => {
     const home = await createPaseoHome({
       version: 1,

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolvePaseoNodeEnv } from "./paseo-env.js";
 import { z } from "zod";
-import { expandTilde } from "../utils/path.js";
+import { resolveConfiguredPath } from "../utils/path.js";
 
 import type { PaseoDaemonConfig } from "./bootstrap.js";
 import {
@@ -317,7 +317,7 @@ function resolveWebUiConfig(
   const rawDistDir = env.PASEO_WEB_UI_DIST_DIR ?? persisted.features?.webUi?.distDir;
   const trimmedDistDir = rawDistDir?.trim();
   const distDir = trimmedDistDir
-    ? path.resolve(path.isAbsolute(trimmedDistDir) ? trimmedDistDir : paseoHome, trimmedDistDir)
+    ? resolveConfiguredPath(paseoHome, trimmedDistDir)
     : BUNDLED_WEB_UI_DIST_DIR;
   return {
     enabled,
@@ -424,10 +424,7 @@ function resolveWorktreesRoot(
     return undefined;
   }
 
-  const expandedRoot = expandTilde(configuredRoot);
-  return path.isAbsolute(expandedRoot)
-    ? path.resolve(expandedRoot)
-    : path.resolve(paseoHome, expandedRoot);
+  return resolveConfiguredPath(paseoHome, configuredRoot);
 }
 
 function resolveAppendSystemPrompt(persisted: ReturnType<typeof loadPersistedConfig>): string {

--- a/packages/server/src/server/logger.test.ts
+++ b/packages/server/src/server/logger.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -106,6 +106,16 @@ describe("resolveLogConfig", () => {
         path: path.resolve(paseoHome, "logs", "programmatic.log"),
       },
     });
+  });
+
+  it("expands ~ in log.file.path", () => {
+    const config: PersistedConfig = {
+      log: { file: { path: "~/paseo-logs/daemon.log" } },
+    };
+
+    expect(resolveLogConfig(config, { paseoHome }).file?.path).toBe(
+      path.resolve(process.env.HOME || homedir(), "paseo-logs", "daemon.log"),
+    );
   });
 
   it("defaults file output to info when log.file is present without a level", () => {

--- a/packages/server/src/server/logger.ts
+++ b/packages/server/src/server/logger.ts
@@ -5,6 +5,7 @@ import pretty from "pino-pretty";
 import { resolveDaemonVersion } from "./daemon-version.js";
 import type { PersistedConfig } from "./persisted-config.js";
 import { resolvePaseoHome } from "./paseo-home.js";
+import { resolveConfiguredPath } from "../utils/path.js";
 
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 export type LogFormat = "pretty" | "json";
@@ -67,11 +68,7 @@ function resolveFilePath(paseoHome: string, configuredPath: string | undefined):
     return fallback;
   }
 
-  if (path.isAbsolute(configuredPath)) {
-    return configuredPath;
-  }
-
-  return path.resolve(paseoHome, configuredPath);
+  return resolveConfiguredPath(paseoHome, configuredPath);
 }
 
 function minLogLevel(levels: LogLevel[]): LogLevel {

--- a/packages/server/src/server/speech/providers/local/config.test.ts
+++ b/packages/server/src/server/speech/providers/local/config.test.ts
@@ -1,0 +1,68 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { resolveLocalSpeechConfig } from "./config.js";
+import type { PersistedConfig } from "../../../persisted-config.js";
+import type { RequestedSpeechProviders } from "../../speech-types.js";
+
+const PASEO_HOME = "/tmp/paseo-home";
+// Matches expandTilde in utils/path.ts, which prefers $HOME over os.homedir().
+const HOME_DIR = process.env.HOME || os.homedir();
+
+const LOCAL_PROVIDERS: RequestedSpeechProviders = {
+  dictationStt: { provider: "local", explicit: true },
+  voiceTurnDetection: { provider: "local", explicit: true },
+  voiceStt: { provider: "local", explicit: true },
+  voiceTts: { provider: "local", explicit: true },
+};
+
+function resolveModelsDir(params: {
+  env?: NodeJS.ProcessEnv;
+  persisted?: PersistedConfig;
+}): string | undefined {
+  return resolveLocalSpeechConfig({
+    paseoHome: PASEO_HOME,
+    env: params.env ?? {},
+    persisted: params.persisted ?? {},
+    providers: LOCAL_PROVIDERS,
+  }).local?.modelsDir;
+}
+
+describe("resolveLocalSpeechConfig modelsDir", () => {
+  it("expands ~ from persisted providers.local.modelsDir", () => {
+    expect(
+      resolveModelsDir({
+        persisted: { providers: { local: { modelsDir: "~/speech-models" } } },
+      }),
+    ).toBe(path.resolve(HOME_DIR, "speech-models"));
+  });
+
+  it("expands ~ from PASEO_LOCAL_MODELS_DIR", () => {
+    expect(resolveModelsDir({ env: { PASEO_LOCAL_MODELS_DIR: "~/env-speech-models" } })).toBe(
+      path.resolve(HOME_DIR, "env-speech-models"),
+    );
+  });
+
+  it("expands a bare ~", () => {
+    expect(resolveModelsDir({ persisted: { providers: { local: { modelsDir: "~" } } } })).toBe(
+      path.resolve(HOME_DIR),
+    );
+  });
+
+  it("anchors a relative configured path to paseoHome", () => {
+    expect(
+      resolveModelsDir({ persisted: { providers: { local: { modelsDir: "models/speech" } } } }),
+    ).toBe(path.join(PASEO_HOME, "models", "speech"));
+  });
+
+  it("leaves an absolute configured path alone", () => {
+    expect(
+      resolveModelsDir({ persisted: { providers: { local: { modelsDir: "/opt/speech" } } } }),
+    ).toBe(path.resolve("/opt/speech"));
+  });
+
+  it("defaults under paseoHome", () => {
+    expect(resolveModelsDir({})).toBe(path.join(PASEO_HOME, "models", "local-speech"));
+  });
+});

--- a/packages/server/src/server/speech/providers/local/config.ts
+++ b/packages/server/src/server/speech/providers/local/config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { z } from "zod";
 
 import type { PersistedConfig } from "../../../persisted-config.js";
+import { resolveConfiguredPath } from "../../../../utils/path.js";
 import type { RequestedSpeechProviders } from "../../speech-types.js";
 import {
   DEFAULT_LOCAL_STT_MODEL,
@@ -211,7 +212,11 @@ export function resolveLocalSpeechConfig(params: {
     },
     local: parsed.includeProviderConfig
       ? {
-          modelsDir: parsed.modelsDir,
+          // `modelsDir` is whatever the user typed in config.json or
+          // PASEO_LOCAL_MODELS_DIR. Everything downstream (downloader, worker,
+          // native sherpa bindings) treats it as a real directory, so expand it
+          // here rather than at each use.
+          modelsDir: resolveConfiguredPath(params.paseoHome, parsed.modelsDir),
           models: {
             dictationStt: parsed.dictationLocalSttModel,
             voiceStt: parsed.voiceLocalSttModel,

--- a/packages/server/src/server/speech/providers/local/sherpa/model-downloader.test.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/model-downloader.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
 
-import { ensureSherpaOnnxModel, getSherpaOnnxModelDir } from "./model-downloader.js";
+import {
+  ensureSherpaOnnxModel,
+  getSherpaOnnxModelDir,
+  SherpaOnnxModelPreparationError,
+} from "./model-downloader.js";
 
 function makeTmpDir(): string {
   return mkdtempSync(path.join(tmpdir(), "paseo-speech-models-"));
@@ -37,5 +41,21 @@ describe("sherpa model downloader", () => {
     });
 
     expect(out).toBe(modelDir);
+  });
+
+  test("keeps model preparation context available as structured error fields", () => {
+    const cause = new Error("directory is read-only");
+    const error = new SherpaOnnxModelPreparationError({
+      modelId: "kokoro-en-v0_19",
+      modelsDir: "/models/local-speech",
+      cause,
+    });
+
+    expect(error).toMatchObject({
+      name: "SherpaOnnxModelPreparationError",
+      modelId: "kokoro-en-v0_19",
+      modelsDir: "/models/local-speech",
+      cause,
+    });
   });
 });

--- a/packages/server/src/server/speech/providers/local/sherpa/model-downloader.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/model-downloader.ts
@@ -161,8 +161,15 @@ export async function ensureSherpaOnnxModel(
     logger.info({ modelDir }, "Model download completed");
     return modelDir;
   } catch (error) {
-    logger.error({ err: error }, "Model download failed");
-    throw error;
+    logger.error({ err: error, modelsDir: options.modelsDir }, "Model download failed");
+    // The readiness banner only surfaces this message, so name the directory we
+    // actually used — a misconfigured models dir otherwise looks like a network
+    // failure.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to prepare model ${options.modelId} in ${options.modelsDir}: ${message}`,
+      { cause: error },
+    );
   }
 }
 

--- a/packages/server/src/server/speech/providers/local/sherpa/model-downloader.ts
+++ b/packages/server/src/server/speech/providers/local/sherpa/model-downloader.ts
@@ -14,6 +14,21 @@ export interface EnsureSherpaOnnxModelOptions {
   logger: pino.Logger;
 }
 
+export class SherpaOnnxModelPreparationError extends Error {
+  readonly modelId: SherpaOnnxModelId;
+  readonly modelsDir: string;
+
+  constructor(input: { modelId: SherpaOnnxModelId; modelsDir: string; cause: unknown }) {
+    const message = input.cause instanceof Error ? input.cause.message : String(input.cause);
+    super(`Failed to prepare model ${input.modelId} in ${input.modelsDir}: ${message}`, {
+      cause: input.cause,
+    });
+    this.name = "SherpaOnnxModelPreparationError";
+    this.modelId = input.modelId;
+    this.modelsDir = input.modelsDir;
+  }
+}
+
 export function getSherpaOnnxModelDir(modelsDir: string, modelId: SherpaOnnxModelId): string {
   const spec = getSherpaOnnxModelSpec(modelId);
   return path.join(modelsDir, spec.extractedDir);
@@ -162,14 +177,11 @@ export async function ensureSherpaOnnxModel(
     return modelDir;
   } catch (error) {
     logger.error({ err: error, modelsDir: options.modelsDir }, "Model download failed");
-    // The readiness banner only surfaces this message, so name the directory we
-    // actually used — a misconfigured models dir otherwise looks like a network
-    // failure.
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Failed to prepare model ${options.modelId} in ${options.modelsDir}: ${message}`,
-      { cause: error },
-    );
+    throw new SherpaOnnxModelPreparationError({
+      modelId: options.modelId,
+      modelsDir: options.modelsDir,
+      cause: error,
+    });
   }
 }
 

--- a/packages/server/src/utils/path.ts
+++ b/packages/server/src/utils/path.ts
@@ -17,6 +17,20 @@ export function expandTilde(path: string): string {
 }
 
 /**
+ * Resolve a filesystem path the user wrote in config.json or a PASEO_* env var.
+ *
+ * `~` and `~/...` expand to the home directory; anything still relative is
+ * anchored to `baseDir` (normally $PASEO_HOME) so it never depends on the
+ * daemon's cwd.
+ */
+export function resolveConfiguredPath(baseDir: string, configured: string): string {
+  const expanded = expandTilde(configured.trim());
+  return nodePath.isAbsolute(expanded)
+    ? nodePath.resolve(expanded)
+    : nodePath.resolve(baseDir, expanded);
+}
+
+/**
  * Compare two path strings as filesystem-equivalent for cwd filtering.
  *
  * This is a string-only comparison: it normalizes separators and dot segments,

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -20,6 +20,10 @@ By default, Paseo uses `~/.paseo` as its home directory. The configuration file 
 
 You can change the home directory by setting `PASEO_HOME` or passing `--home` to `paseo daemon start`.
 
+## Paths
+
+Every filesystem path you write in `config.json` or in a `PASEO_*` variable — `worktrees.root`, `providers.local.modelsDir`, `features.webUi.distDir`, `log.file.path` — takes `~` for your home directory. Relative paths are resolved against `PASEO_HOME`, not the daemon's working directory.
+
 ## Precedence
 
 Paseo merges configuration in this order:
@@ -67,7 +71,7 @@ New worktrees are created under `$PASEO_HOME/worktrees` by default. To place new
 }
 ```
 
-Relative paths are resolved against `PASEO_HOME`. Existing worktrees remain where they are; changing this setting only changes where Paseo creates and discovers Paseo-managed worktrees going forward.
+Existing worktrees remain where they are; changing this setting only changes where Paseo creates and discovers Paseo-managed worktrees going forward.
 
 ## Voice
 


### PR DESCRIPTION
A configured `~/.paseo/models/local-speech` reached the downloader as a literal string, so the daemon tried to `mkdir` a directory named `~` and voice features died with `model_download_failed`. An absolute path works. 0.2.5 expanded it; `public-docs/voice.md` still advertises the tilde form, so the docs were promising something the code had stopped doing.

Reported by a user running the desktop and iOS builds.

## The gap was wider than the report

Auditing every path-valued field in `persisted-config.ts` and the `PASEO_*` env vars turned up two more with the same bug:

| Field | Env var | Status |
| --- | --- | --- |
| `providers.local.modelsDir` | `PASEO_LOCAL_MODELS_DIR` | fixed (reported) |
| `features.webUi.distDir` | `PASEO_WEB_UI_DIST_DIR` | fixed |
| `log.file.path` | — | fixed |
| `worktrees.root` | — | already correct, had its own copy of the logic |

`worktrees.root` was the only field doing this right, via an inline expression in `config.ts`. That logic is now a shared `resolveConfiguredPath(baseDir, configured)` in `utils/path.ts`: expand `~`, then anchor anything still relative to `$PASEO_HOME` so it never depends on the daemon's cwd. Three call sites share it instead of copying it.

Expansion runs *after* the Zod parse, so no `.transform()` lands in a schema.

## Also

`model_download_failed` read as a network problem. `ensureSherpaOnnxModel` now rethrows `Failed to prepare model <id> in <modelsDir>: <cause>` and logs `modelsDir`, so a bad path names itself.

`public-docs/configuration.md` had the path-resolution rule buried in the Worktrees section and covering only relative paths. It moves up into a `## Paths` section covering `~` and relative-to-`PASEO_HOME` for all four fields.

## Deliberately not fixed

- **`agents.providers.*.env` values** — a real gap (`docs/custom-providers.md` shows `"XDG_CONFIG_HOME": "~/.config/omp-work"`, which does not expand), but env values are arbitrary strings rather than declared paths. Blanket-expanding every value starting with `~` changes what gets handed to every child process. Separate decision.
- Command argv and terminal profile commands — `~` there is shell syntax, and argv[0] resolves via PATH.
- Network addresses, URLs, credentials, model/language fields — not filesystem paths.

## Test plan

- New `packages/server/src/server/speech/providers/local/config.test.ts`: `~/foo` from persisted config and from the env var, bare `~`, relative-anchored-to-`paseoHome`, absolute-left-alone, and the default.
- `~` cases added to `config-web-ui.test.ts` and `logger.test.ts`.
- 28 tests pass across the three files; `npm run typecheck` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)