### PR TITLE
Require a real directory to create a local workspace

### DIFF
--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -2531,6 +2531,34 @@ describe("create_agent MCP tool", () => {
     }
   });
 
+  it("rejects a local path that is not an existing directory", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      logger,
+    });
+    const tool = registeredTool(server, "create_workspace");
+    const tempDir = await mkdtemp(join(tmpdir(), "paseo-mcp-local-workspace-"));
+    try {
+      const filePath = join(tempDir, "not-a-directory.txt");
+      await writeFile(filePath, "");
+
+      // A caller that cannot see the filesystem — a Live Voice call routing to
+      // another machine — used to get a workspace record pointing at nothing.
+      await expect(
+        tool.handler({ isolation: "local", path: join(tempDir, "no-such-directory") }),
+      ).rejects.toThrow("No such directory");
+
+      await expect(tool.handler({ isolation: "local", path: filePath })).rejects.toThrow(
+        "Not a directory",
+      );
+    } finally {
+      await removeTempDir(tempDir);
+    }
+  });
+
   it("creates a worktree workspace from a project root without a path", async () => {
     const { agentManager, agentStorage } = createTestDeps();
     const project = createPersistedProjectRecord({

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -1,3 +1,5 @@
+import { stat } from "node:fs/promises";
+
 import { z } from "zod";
 import { ensureValidJson } from "../../json-utils.js";
 import type { Logger } from "pino";
@@ -214,6 +216,33 @@ function assertOptionsAbsent(
 ): void {
   if (options.some(([, value]) => value !== undefined)) {
     throw new Error(message);
+  }
+}
+
+/**
+ * Local workspace creation adopts a directory that already exists; it never
+ * provisions one. Nothing downstream checked that, so a caller that guessed a
+ * path got a successful-looking workspace record pointing at nothing, and the
+ * failure only surfaced later as an agent that could not start.
+ *
+ * The cost of the guess is highest for callers that cannot see the filesystem —
+ * a Live Voice call routes `create_workspace` to a machine it has no other view
+ * of — so the message says what to do next rather than only what went wrong.
+ */
+async function assertExistingWorkspaceDirectory(cwd: string): Promise<void> {
+  const stats = await stat(cwd).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+      return null;
+    }
+    throw error;
+  });
+  if (!stats) {
+    throw new Error(
+      `No such directory: ${cwd}. Local workspace creation adopts an existing directory and never creates one. Pass a path that exists on this machine — list_workspaces shows directories already in use — or ask the user which directory to use.`,
+    );
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`Not a directory: ${cwd}. Local workspace creation requires a directory path.`);
   }
 }
 
@@ -1215,7 +1244,9 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         path: z
           .string()
           .optional()
-          .describe("Local directory or source checkout. Defaults to your current workspace."),
+          .describe(
+            "Local directory or source checkout. Defaults to your current workspace. Must already exist; this tool never creates the directory.",
+          ),
         projectId: z.string().optional().describe("Existing project id to own the workspace."),
         title: z.string().trim().min(1).optional(),
         mode: z
@@ -1267,6 +1298,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       let workspace: PersistedWorkspaceRecord;
       if (isolation === "local") {
         const cwd = resolveScopedCwd(path, { required: true });
+        await assertExistingWorkspaceDirectory(cwd);
         assertOptionsAbsent(
           [
             ["mode", mode],


### PR DESCRIPTION
`create_workspace` with `isolation: local` adopts a directory — it never provisions one. Nothing checked that the directory existed.

So a caller that guessed a path got a **successful-looking workspace record pointing at nothing**: `createWorkspaceForDirectory` resolves the path, asks git for a checkout, writes the record, and returns a `workspaceId`. The failure only surfaced later, as an agent that could not start in a cwd that was never there.

## Why it matters more now

The guess costs most for a caller that cannot see the filesystem. A Live Voice call routes `create_workspace` to a machine it has no other view of, and when asked for work with no obvious home it would compose a plausible path out of the workspace's name. That is what surfaced this, but the hole is in the tool, not in the caller.

## The change

The guard is on the MCP tool rather than in `createWorkspaceForDirectory`, so agent-supplied paths get validated while the UI and schedule paths keep their own semantics.

The error says what to do next rather than only what went wrong:

> `No such directory: /Users/dana/Projects/thing. Local workspace creation adopts an existing directory and never creates one. Pass a path that exists on this machine — list_workspaces shows directories already in use — or ask the user which directory to use.`

A path that exists but is a file gets `Not a directory`. The `path` schema description now says the directory must already exist, so a model reading the schema learns it before making the call rather than from the rejection.

## Test plan

- New test covers both rejections against a real temp directory.
- `mcp-server.test.ts`: 114 tests pass, including the existing worktree and placement cases.
- `npm run typecheck` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)