### PR TITLE
Stop shipping a hardened runtime on unsigned mac builds

### DIFF
--- a/nix/desktop-package.nix
+++ b/nix/desktop-package.nix
@@ -118,11 +118,13 @@ buildNpmPackage {
       chmod -R u+w "$electron_dist/Electron.app"
       (
         cd packages/desktop
-        # The Nix output is not a distributable DMG, so leave it unsigned and
-        # disable the hardened runtime that requires a matching signature.
+        # The Nix output is not a distributable DMG, so leave it unsigned.
+        # CSC_IDENTITY_AUTO_DISCOVERY=false also tells the shared config to drop
+        # the hardened runtime, which an unsigned build cannot satisfy; the
+        # flags below restate that so this stays readable on its own.
         CSC_IDENTITY_AUTO_DISCOVERY=false \
           ../../node_modules/.bin/electron-builder \
-            --config electron-builder.yml \
+            --config electron-builder.config.cjs \
             --dir \
             --mac \
             --publish never \

--- a/package-lock.json
+++ b/package-lock.json
@@ -37473,6 +37473,7 @@
         "@types/ws": "^8.5.14",
         "electron": "41.2.0",
         "electron-builder": "26.8.1",
+        "js-yaml": "^4.1.0",
         "typescript": "5.9.3",
         "unzip-crx-3": "^0.2.0",
         "vitest": "^4.1.6",

--- a/packages/desktop/electron-builder-signing.cjs
+++ b/packages/desktop/electron-builder-signing.cjs
@@ -1,0 +1,30 @@
+const { execFileSync } = require("node:child_process");
+
+function hasConfiguredSigningIdentity(env) {
+  return ["CSC_LINK", "CSC_NAME", "CSC_IDENTITY"].some((name) => (env[name] ?? "").trim() !== "");
+}
+
+function hasKeychainIdentity(env, options = {}) {
+  if (env.CSC_IDENTITY_AUTO_DISCOVERY === "false") return false;
+  if ((options.platform ?? process.platform) !== "darwin") return false;
+
+  const run = options.run ?? execFileSync;
+  try {
+    const output = run("security", ["find-identity", "-v", "-p", "codesigning"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return /\b[1-9]\d* valid identities found\b/.test(output);
+  } catch {
+    return false;
+  }
+}
+
+function isMacSigningAvailable(env, options) {
+  return hasConfiguredSigningIdentity(env) || hasKeychainIdentity(env, options);
+}
+
+module.exports = {
+  hasKeychainIdentity,
+  isMacSigningAvailable,
+};

--- a/packages/desktop/electron-builder.config.cjs
+++ b/packages/desktop/electron-builder.config.cjs
@@ -1,0 +1,59 @@
+/**
+ * electron-builder config: `electron-builder.yml` plus the one thing YAML
+ * cannot express — what to do when there is no Apple signing identity.
+ *
+ * A build without credentials still gets an ad-hoc signature, because arm64
+ * macOS refuses to run an unsigned binary at all. But ad-hoc signing and the
+ * hardened runtime together are a combination macOS rejects: the hardened
+ * runtime turns on dyld library validation, which requires every loaded library
+ * to share the main executable's Team ID, and an ad-hoc signature has no Team
+ * ID. The app dies the instant it launches, on Electron Framework, with a
+ * "different Team IDs" error. Only a `codesign --force --deep --sign -` over
+ * the installed .app recovers it, which no downloader should have to do.
+ *
+ * So the hardened runtime — and notarization, which requires it — is switched
+ * off for unsigned builds and left alone for signed ones. The alternative, a
+ * `com.apple.security.cs.disable-library-validation` entitlement, would fix the
+ * same crash by weakening the signed release for everyone; this only changes
+ * the builds that are already unsigned.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const yaml = require("js-yaml");
+
+const CONFIG_PATH = path.join(__dirname, "electron-builder.yml");
+
+/** An identity handed to us explicitly, the way CI passes a certificate. */
+function hasConfiguredSigningIdentity(env) {
+  return ["CSC_LINK", "CSC_NAME", "CSC_IDENTITY"].some((name) => (env[name] ?? "").trim() !== "");
+}
+
+/**
+ * electron-builder also searches the local keychain. A CI runner has none of
+ * the developer's certificates, so a bare `CI` with no credentials in the
+ * environment is the fork-build case this exists for.
+ */
+function canDiscoverKeychainIdentity(env) {
+  return !env.CI && env.CSC_IDENTITY_AUTO_DISCOVERY !== "false";
+}
+
+function isMacSigningAvailable(env) {
+  return hasConfiguredSigningIdentity(env) || canDiscoverKeychainIdentity(env);
+}
+
+const config = yaml.load(fs.readFileSync(CONFIG_PATH, "utf8"));
+
+if (!isMacSigningAvailable(process.env)) {
+  config.mac = {
+    ...config.mac,
+    hardenedRuntime: false,
+    // Notarization needs the hardened runtime and a Developer ID, so it could
+    // only fail here. electron-builder would skip it anyway; saying so is
+    // clearer than letting it warn.
+    notarize: false,
+  };
+}
+
+module.exports = config;

--- a/packages/desktop/electron-builder.config.cjs
+++ b/packages/desktop/electron-builder.config.cjs
@@ -22,26 +22,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const yaml = require("js-yaml");
+const { isMacSigningAvailable } = require("./electron-builder-signing.cjs");
 
 const CONFIG_PATH = path.join(__dirname, "electron-builder.yml");
-
-/** An identity handed to us explicitly, the way CI passes a certificate. */
-function hasConfiguredSigningIdentity(env) {
-  return ["CSC_LINK", "CSC_NAME", "CSC_IDENTITY"].some((name) => (env[name] ?? "").trim() !== "");
-}
-
-/**
- * electron-builder also searches the local keychain. A CI runner has none of
- * the developer's certificates, so a bare `CI` with no credentials in the
- * environment is the fork-build case this exists for.
- */
-function canDiscoverKeychainIdentity(env) {
-  return !env.CI && env.CSC_IDENTITY_AUTO_DISCOVERY !== "false";
-}
-
-function isMacSigningAvailable(env) {
-  return hasConfiguredSigningIdentity(env) || canDiscoverKeychainIdentity(env);
-}
 
 const config = yaml.load(fs.readFileSync(CONFIG_PATH, "utf8"));
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -15,7 +15,7 @@
   },
   "main": "dist/main.js",
   "scripts": {
-    "build": "npm --prefix ../.. run build:server:clean && npm run build:main && electron-builder --config electron-builder.yml",
+    "build": "npm --prefix ../.. run build:server:clean && npm run build:main && electron-builder --config electron-builder.config.cjs",
     "build:main": "tsc -p tsconfig.json",
     "capture-harness": "./capture-harness/run.sh",
     "dev": "./scripts/dev.sh",
@@ -39,6 +39,7 @@
     "@types/ws": "^8.5.14",
     "electron": "41.2.0",
     "electron-builder": "26.8.1",
+    "js-yaml": "^4.1.0",
     "typescript": "5.9.3",
     "unzip-crx-3": "^0.2.0",
     "vitest": "^4.1.6",

--- a/packages/desktop/src/daemon/desktop-packaging.test.ts
+++ b/packages/desktop/src/daemon/desktop-packaging.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { hasKeychainIdentity } from "../../electron-builder-signing.cjs";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -152,6 +153,13 @@ describe("desktop packaging", () => {
     });
 
     expect(optedOut.mac.hardenedRuntime).toBe(false);
+  });
+
+  it("does not mistake an empty keychain for a signing identity", () => {
+    const env = { CSC_IDENTITY_AUTO_DISCOVERY: undefined };
+    const run = () => "     0 valid identities found";
+
+    expect(hasKeychainIdentity(env, { platform: "darwin", run })).toBe(false);
   });
 
   it("keeps the hardened runtime for a signed release build", () => {

--- a/packages/desktop/src/daemon/desktop-packaging.test.ts
+++ b/packages/desktop/src/daemon/desktop-packaging.test.ts
@@ -8,12 +8,38 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const requireFromHere = createRequire(import.meta.url);
+const BUILDER_CONFIG_PATH = join(packageRoot, "electron-builder.config.cjs");
+
+interface BuilderConfig {
+  mac: { hardenedRuntime?: boolean; notarize?: boolean; entitlements?: string };
+  appId: string;
+}
+
+/** The config decides at load time, so each environment needs a fresh load. */
+function loadBuilderConfig(env: Record<string, string | undefined>): BuilderConfig {
+  const previous = process.env;
+  process.env = { ...previous, ...env } as NodeJS.ProcessEnv;
+  for (const key of Object.keys(env)) {
+    if (env[key] === undefined) {
+      delete process.env[key];
+    }
+  }
+  try {
+    delete requireFromHere.cache[requireFromHere.resolve(BUILDER_CONFIG_PATH)];
+    return requireFromHere(BUILDER_CONFIG_PATH) as BuilderConfig;
+  } finally {
+    process.env = previous;
+  }
+}
 
 function writeExecutable(filePath: string, contents: string): void {
   writeFileSync(filePath, contents, "utf8");
@@ -101,6 +127,41 @@ describe("desktop packaging", () => {
     expect(serverPackage).toContain("fs.rmSync('dist/server/skills',{recursive:true,force:true})");
     expect(serverPackage).toContain("fs.cpSync('../../skills','dist/server/skills'");
     expect(runtimeTrace).toContain('"packages/server/dist/server/skills/**"');
+  });
+
+  it("drops the hardened runtime when a build has no signing identity", () => {
+    // An ad-hoc signature has no Team ID, and the hardened runtime's library
+    // validation requires every loaded library to match one. Shipping both
+    // makes the .app die on launch against Electron Framework.
+    const forkCi = loadBuilderConfig({
+      CI: "1",
+      CSC_LINK: undefined,
+      CSC_NAME: undefined,
+      CSC_IDENTITY: undefined,
+    });
+
+    expect(forkCi.mac.hardenedRuntime).toBe(false);
+    expect(forkCi.mac.notarize).toBe(false);
+
+    const optedOut = loadBuilderConfig({
+      CI: undefined,
+      CSC_IDENTITY_AUTO_DISCOVERY: "false",
+      CSC_LINK: undefined,
+      CSC_NAME: undefined,
+      CSC_IDENTITY: undefined,
+    });
+
+    expect(optedOut.mac.hardenedRuntime).toBe(false);
+  });
+
+  it("keeps the hardened runtime for a signed release build", () => {
+    const releaseCi = loadBuilderConfig({ CI: "1", CSC_LINK: "base64-certificate" });
+
+    expect(releaseCi.mac.hardenedRuntime).toBe(true);
+    expect(releaseCi.mac.notarize).toBe(true);
+    // The signing switch must not disturb the rest of the mac config.
+    expect(releaseCi.mac.entitlements).toBe("build/entitlements.mac.plist");
+    expect(releaseCi.appId).toBe("sh.paseo.desktop");
   });
 
   it("registers Paseo agent links with the operating system", () => {


### PR DESCRIPTION
Reported by a user: the arm64 DMG is ad-hoc signed but carries the hardened runtime flag, so dyld library validation refuses to load Electron Framework with a "different Team IDs" error and the app dies instantly on launch. The only recovery is `codesign --force --deep --sign - /Applications/Paseo.app` after install, which no downloader should have to run.

## Cause

An ad-hoc signature has no Team ID. The hardened runtime turns on dyld library validation, which requires every loaded library to share the main executable's Team ID. Together they cannot work.

`electron-builder.yml` set `hardenedRuntime: true` unconditionally. Official CI passes a real certificate via `secrets.APPLE_CERTIFICATE`, so it is correct there — but any build without credentials still gets an ad-hoc signature (arm64 macOS refuses to run a fully unsigned binary), and ships the broken combination. That covers fork CI, where the Apple secrets are empty, and a local `npm run build:desktop` on a Mac without certificates.

This is already known in the repo, incidentally: `nix/desktop-package.nix` works around it by hand with `--config.mac.hardenedRuntime=false --config.mac.notarize=false` and a comment explaining that an unsigned build cannot satisfy a hardened runtime. It was fixed there instead of at the source.

## The change

YAML cannot express the condition, so `electron-builder.yml` stays the source of truth and a thin `electron-builder.config.cjs` reads it and applies one override when no signing identity is available.

| Environment | `hardenedRuntime` |
| --- | --- |
| Official CI (`CSC_LINK` set) | `true` — unchanged |
| Fork CI (`CI=1`, no certs) | `false` |
| Local Mac, keychain identity | `true` — unchanged |
| `CSC_IDENTITY_AUTO_DISCOVERY=false` | `false` |

Notarization goes off with it, since it requires the hardened runtime and a Developer ID and could only fail.

Fixing this in the build config rather than in the workflow means every invocation path benefits — fork CI, the Nix build, and local builds — instead of only the one workflow.

### Why not the entitlement

The other fix is a `com.apple.security.cs.disable-library-validation` entitlement. It clears the same crash, but by weakening the *signed* release for every user: it permits loading third-party libraries into the app. Dropping the hardened runtime only changes builds that are already unsigned and un-notarizable.

## Notes

- `js-yaml@4.1.1` was already in the tree via `electron-builder`; this declares it in `packages/desktop` instead of relying on a transitive hoist. `npm install --package-lock-only` wanted to churn 419 unrelated lines of peer/optional drift, so the lockfile edit is the single added line.
- `nix/desktop-package.nix` points at the shared config and keeps its explicit flags, which now restate the shared rule rather than owning it.

## Test plan

- Two tests cover the switch, including that it leaves the rest of the mac config (entitlements, appId) untouched for a signed build.
- `desktop-packaging.test.ts`: 9 tests pass. `npm run typecheck` and `npm run lint` clean.

**Needs verification on a Mac** — I could not test this from Linux. Specifically: that the resulting DMG launches on Apple Silicon without the `codesign` workaround, and that a signed release build still notarizes. The table above confirms the config values are unchanged with a certificate present, but that is not the same as a green notarization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)