### PR TITLE
fix: show imported Codex session titles in workspaces

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3428,7 +3428,7 @@ export class Session {
         logger: this.sessionLogger,
       });
       if (createdWorkspace) {
-        await this.registerWorkspaceForImportedAgent(createdWorkspace);
+        await this.registerWorkspaceForImportedAgent(createdWorkspace, snapshot.id);
       }
       const agentPayload = await this.buildAgentPayload(snapshot);
       this.emit({
@@ -5207,14 +5207,38 @@ export class Session {
 
   private async registerWorkspaceForImportedAgent(
     workspace: PersistedWorkspaceRecord,
+    importedAgentId: string,
   ): Promise<void> {
+    let workspaceToRegister = workspace;
     try {
-      await this.syncWorkspaceGitObserverForWorkspace(workspace);
-      await this.describeWorkspaceRecord(workspace);
-      await this.emitWorkspaceUpdateForWorkspaceId(workspace.workspaceId);
+      const importedTitle = (await this.agentStorage.get(importedAgentId))?.title?.trim();
+      if (importedTitle) {
+        workspaceToRegister =
+          (await this.workspaceRegistry.update(workspace.workspaceId, (existing) => {
+            if (existing.title?.trim()) {
+              return existing;
+            }
+            return {
+              ...existing,
+              title: importedTitle,
+              updatedAt: new Date().toISOString(),
+            };
+          })) ?? workspace;
+      }
     } catch (error) {
       this.sessionLogger.warn(
-        { err: error, workspaceId: workspace.workspaceId, cwd: workspace.cwd },
+        { err: error, workspaceId: workspace.workspaceId, agentId: importedAgentId },
+        "Failed to sync imported agent title to workspace",
+      );
+    }
+
+    try {
+      await this.syncWorkspaceGitObserverForWorkspace(workspaceToRegister);
+      await this.describeWorkspaceRecord(workspaceToRegister);
+      await this.emitWorkspaceUpdateForWorkspaceId(workspaceToRegister.workspaceId);
+    } catch (error) {
+      this.sessionLogger.warn(
+        { err: error, workspaceId: workspaceToRegister.workspaceId, cwd: workspaceToRegister.cwd },
         "Failed to register workspace for imported agent",
       );
     }

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -278,6 +278,7 @@ function makeStoredAgent(input: {
   id: string;
   cwd: string;
   updatedAt: string;
+  title?: string | null;
   requiresAttention?: boolean;
   attentionReason?: StoredAgentRecord["attentionReason"];
 }): StoredAgentRecord {
@@ -289,7 +290,7 @@ function makeStoredAgent(input: {
     updatedAt: input.updatedAt,
     lastActivityAt: input.updatedAt,
     lastUserMessageAt: null,
-    title: null,
+    title: input.title ?? null,
     labels: {},
     lastStatus: "closed",
     lastModeId: null,
@@ -4024,6 +4025,15 @@ test("import_agent_request registers a workspace for a never-seen cwd", async ()
   ) => {
     workspaces.set(record.workspaceId, record);
   };
+  session.workspaceRegistry.update = async (workspaceId, updater) => {
+    const existing = workspaces.get(workspaceId);
+    if (!existing) {
+      return null;
+    }
+    const updated = updater(existing);
+    workspaces.set(workspaceId, updated);
+    return updated;
+  };
   session.projectRegistry.list = async () => Array.from(projects.values());
   session.workspaceRegistry.list = async () => Array.from(workspaces.values());
   session.buildProjectPlacement = async (cwd: string) => ({
@@ -4051,7 +4061,15 @@ test("import_agent_request registers a workspace for a never-seen cwd", async ()
   session.agentManager.getTimeline = () => [];
   session.agentManager.setTitle = async () => undefined;
   session.agentStorage.list = async () => [];
-  session.agentStorage.get = async () => null;
+  session.agentStorage.get = async (agentId: string) =>
+    agentId === managed.id
+      ? makeStoredAgent({
+          id: managed.id,
+          cwd: importedCwd,
+          updatedAt: managed.updatedAt.toISOString(),
+          title: "Imported session title",
+        })
+      : null;
   session.agentUpdates.forwardLiveAgent = async () => undefined;
 
   session.workspaceUpdatesSubscription = {
@@ -4099,6 +4117,7 @@ test("import_agent_request registers a workspace for a never-seen cwd", async ()
     (workspace) => workspace.cwd === importedCwd,
   );
   expect(importedWorkspace).toBeTruthy();
+  expect(importedWorkspace?.title).toBe("Imported session title");
   const workspaceUpdates = filterByType(emitted, "workspace_update");
   expect(workspaceUpdates.length).toBeGreaterThan(0);
   expect(


### PR DESCRIPTION
## Summary
- sync an imported provider session title onto a newly created workspace
- preserve an existing workspace title when it was set manually
- add a regression test for imported workspace titles

## Root cause
Codex import persisted the session title on the agent record, but the newly provisioned workspace kept `title: null`. Workspace display then correctly fell back to the branch name, making the imported session appear untitled in the workspace list.

## Validation
- `npx vitest run packages/server/src/server/session.workspaces.test.ts --bail=1 -t "import_agent_request registers a workspace for a never-seen cwd"`
- `npm run typecheck:server`
- `npm run lint`
- `npm run format`
- pre-commit hook: full workspace typecheck, lint, and format check

The full workspace test file also ran; the changed test passed, while an unrelated existing worktree archive test exceeded its 5-second timeout.