### PR TITLE
Make Ready to review an orthogonal sidebar status

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -118,6 +118,12 @@ Workspace status is an aggregate activity signal computed **per `workspaceId`**.
 
 Running provider-native subagents contribute `running` to the workspace owned by their parent agent. Their completed, failed, and canceled states stay in the parent's subagents track.
 
+### Ready to review
+
+The daemon sets finished attention when an agent goes from running to idle. The sidebar treats that flag as an annotation rather than a workspace state: the workspace stays in its normal status group and carries a pulsing blue badge until you act on it. A workspace can be Working and ready to review at the same time. Collapsed project rows carry the badge when any hidden workspace is ready.
+
+Opening or reading the agent does not clear the flag. Sending a prompt clears it automatically. **Mark as read** clears it explicitly from the workspace header menu or the sidebar row menu.
+
 ## The subagents track
 
 The collapsible track above the composer in an agent's pane (`packages/app/src/subagents/track.tsx`) combines two kinds of children:

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -64,8 +64,9 @@ import {
 } from "@/utils/host-routes";
 import {
   shouldShowSidebarHostLabels,
-  useSidebarProjectStatusBucket,
+  useSidebarProjectStatus,
   type SidebarProjectEntry,
+  type SidebarStateBucket,
   type SidebarWorkspaceEntry,
   type SidebarWorkspacePlacement,
 } from "@/hooks/use-sidebar-workspaces-list";
@@ -91,7 +92,6 @@ import { getForgePresentation, normalizeForge } from "@/git/forge";
 import { toWorktreeArchiveRisk } from "@/git/worktree-archive-warning";
 import { hasVisibleOrderChanged, mergeWithRemainder } from "@/utils/sidebar-reorder";
 import { confirmDialog } from "@/utils/confirm-dialog";
-import type { SidebarStateBucket } from "@/utils/sidebar-agent-state";
 import { SidebarStatusWorkspaceList } from "@/components/sidebar/sidebar-status-list";
 import type { StatusGroup } from "@/hooks/sidebar-status-view-model";
 import {
@@ -258,6 +258,7 @@ interface ProjectHeaderRowProps {
   displayName: string;
   iconDataUri: string | null;
   statusBucket: SidebarStateBucket | null;
+  readyToReview?: boolean;
   selected?: boolean;
   chevron: "expand" | "collapse" | null;
   onPress: () => void;
@@ -853,6 +854,7 @@ function ProjectHeaderRow({
   displayName,
   iconDataUri,
   statusBucket,
+  readyToReview = false,
   selected = false,
   chevron,
   onPress,
@@ -936,6 +938,7 @@ function ProjectHeaderRow({
           displayName={displayName}
           iconDataUri={iconDataUri}
           statusBucket={statusBucket}
+          readyToReview={readyToReview}
           projectViewKey={project.viewKey}
           backdrop={getSidebarRowBackdrop({ isDragging, selected, isHovered })}
           chevron={chevron}
@@ -1305,9 +1308,11 @@ function WorkspaceRowWithMenu({
   });
   const handleMarkAsRead = useCallback(() => {
     void clearAttention().catch((error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to mark workspace as read");
+      toast.error(
+        error instanceof Error ? error.message : t("sidebar.workspace.actions.markAsReadError"),
+      );
     });
-  }, [clearAttention, toast]);
+  }, [clearAttention, t, toast]);
 
   useKeyboardActionHandler({
     handlerId: `workspace-archive-${workspace.workspaceKey}`,
@@ -1609,7 +1614,7 @@ function ProjectBlock({
 
   // Collapsed rows hide their workspace rows, so the project row carries the most urgent
   // status among them; expanded rows leave the signal to the child rows themselves.
-  const aggregateStatusBucket = useSidebarProjectStatusBucket({
+  const aggregateStatus = useSidebarProjectStatus({
     workspaces: project.workspaces,
     enabled: collapsed,
   });
@@ -1797,7 +1802,8 @@ function ProjectBlock({
         project={project}
         displayName={displayName}
         iconDataUri={iconDataUri}
-        statusBucket={aggregateStatusBucket}
+        statusBucket={aggregateStatus?.statusBucket ?? null}
+        readyToReview={aggregateStatus?.readyToReview ?? false}
         selected={false}
         chevron={rowModel.chevron}
         onPress={handleToggleCollapsed}

--- a/packages/app/src/components/sidebar/project-leading-visual.tsx
+++ b/packages/app/src/components/sidebar/project-leading-visual.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, ChevronRight, CircleAlert } from "lucide-react-native";
 import { ProjectIconView } from "@/components/project-icon-view";
 import { STATUS_BUCKET_LABELS } from "@/hooks/sidebar-status-view-model";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
-import type { SidebarStateBucket } from "@/utils/sidebar-agent-state";
+import type { SidebarWorkspaceEntry } from "@/hooks/sidebar-workspaces-view-model";
 import {
   getProjectStatusBadgeContent,
   type ProjectStatusBadgeContent,
@@ -14,6 +14,9 @@ import { projectIconPlaceholderLabelFromDisplayName } from "@/utils/project-disp
 import { getStatusDotColor } from "@/utils/status-dot-color";
 import { STATUS_INDICATOR_ALERT_SIZE } from "@/utils/status-indicator-geometry";
 import type { SurfaceBackdrop } from "@/styles/surface-backdrop";
+import { ReadyToReviewBadge } from "@/components/sidebar/ready-to-review-badge";
+
+type SidebarStatusBucket = SidebarWorkspaceEntry["statusBucket"];
 
 // Every surfaced status shares one badge shell, so the badge never changes size or position
 // between states. Only the thing inside it changes.
@@ -53,6 +56,7 @@ export function ProjectLeadingVisual({
   displayName,
   iconDataUri,
   statusBucket,
+  readyToReview = false,
   projectViewKey,
   backdrop,
   chevron = null,
@@ -62,7 +66,8 @@ export function ProjectLeadingVisual({
   displayName: string;
   iconDataUri: string | null;
   /** Aggregate status of the project's workspaces; null when it shouldn't be surfaced. */
-  statusBucket: SidebarStateBucket | null;
+  statusBucket: SidebarStatusBucket | null;
+  readyToReview?: boolean;
   projectViewKey: string;
   /** The row's current background, so the status badge can knock out of it. */
   backdrop: SurfaceBackdrop;
@@ -92,6 +97,7 @@ export function ProjectLeadingVisual({
       displayName={displayName}
       projectViewKey={projectViewKey}
       statusBucket={statusBucket}
+      readyToReview={readyToReview}
       backdrop={backdrop}
     />
   );
@@ -107,6 +113,7 @@ export function ProjectStatusIndicator({
   displayName,
   projectViewKey,
   statusBucket,
+  readyToReview = false,
   backdrop,
   loading = false,
   testID,
@@ -114,7 +121,8 @@ export function ProjectStatusIndicator({
   iconDataUri: string | null;
   displayName: string;
   projectViewKey: string;
-  statusBucket: SidebarStateBucket | null;
+  statusBucket: SidebarStatusBucket | null;
+  readyToReview?: boolean;
   /** The row's current background, so the status badge can knock out of it. */
   backdrop: SurfaceBackdrop;
   loading?: boolean;
@@ -152,6 +160,11 @@ export function ProjectStatusIndicator({
             backdrop={backdrop}
           />
         )}
+        {readyToReview ? (
+          <View style={styles.readyToReviewBadge}>
+            <ReadyToReviewBadge />
+          </View>
+        ) : null}
       </View>
     </View>
   );
@@ -163,7 +176,7 @@ function ProjectStatusBadge({
   backdrop,
 }: {
   content: ProjectStatusBadgeContent;
-  statusBucket: SidebarStateBucket;
+  statusBucket: SidebarStatusBucket;
   backdrop: SurfaceBackdrop;
 }) {
   return (
@@ -229,8 +242,7 @@ function ProjectInlineChevron({ chevron }: { chevron: "expand" | "collapse" | nu
 
 function getStatusDotColorStyle(bucket: ProjectStatusBadgeDotBucket): ViewStyle {
   if (bucket === "failed") return styles.statusDotFailed;
-  if (bucket === "running") return styles.statusDotRunning;
-  return styles.statusDotAttention;
+  return styles.statusDotRunning;
 }
 
 const styles = StyleSheet.create((theme) => {
@@ -285,8 +297,12 @@ const styles = StyleSheet.create((theme) => {
     statusBadgeOnSidebar: { backgroundColor: theme.colors.surfaceSidebar },
     statusBadgeOnSidebarHover: { backgroundColor: theme.colors.surfaceSidebarHover },
     statusBadgeOnSurface2: { backgroundColor: theme.colors.surface2 },
+    readyToReviewBadge: {
+      position: "absolute",
+      top: -4,
+      right: -4,
+    },
     statusDotRunning: statusDot("running"),
     statusDotFailed: statusDot("failed"),
-    statusDotAttention: statusDot("attention"),
   };
 });

--- a/packages/app/src/components/sidebar/ready-to-review-badge.tsx
+++ b/packages/app/src/components/sidebar/ready-to-review-badge.tsx
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+import { View } from "react-native";
+import Animated, {
+  cancelAnimation,
+  Easing,
+  interpolate,
+  makeMutable,
+  useAnimatedStyle,
+  useReducedMotion,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+import { StyleSheet } from "react-native-unistyles";
+import { useRetainedPanelActive } from "@/components/retained-panel";
+
+const PULSE_PERIOD_MS = 1_400;
+const pulseClock = makeMutable(0);
+let pulseClockSubscribers = 0;
+
+function acquirePulseClock(): void {
+  pulseClockSubscribers += 1;
+  if (pulseClockSubscribers > 1) return;
+  pulseClock.value = 0;
+  pulseClock.value = withRepeat(
+    withTiming(1, { duration: PULSE_PERIOD_MS, easing: Easing.out(Easing.quad) }),
+    -1,
+    false,
+  );
+}
+
+function releasePulseClock(): void {
+  pulseClockSubscribers -= 1;
+  if (pulseClockSubscribers > 0) return;
+  cancelAnimation(pulseClock);
+  pulseClock.value = 0;
+}
+
+export function ReadyToReviewBadge() {
+  const active = useRetainedPanelActive();
+  const reduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (!active || reduceMotion) return;
+    acquirePulseClock();
+    return releasePulseClock;
+  }, [active, reduceMotion]);
+
+  const pulseStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(pulseClock.value, [0, 1], [0.65, 0]),
+    transform: [{ scale: interpolate(pulseClock.value, [0, 1], [0.65, 1.4]) }],
+  }));
+
+  return (
+    <View
+      accessibilityLabel="Ready to review"
+      role="status"
+      style={styles.badge}
+      testID="ready-to-review-badge"
+    >
+      <Animated.View
+        style={[styles.pulse, reduceMotion ? styles.reducedMotionPulse : pulseStyle]}
+      />
+      <View style={styles.dot} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  badge: {
+    width: 12,
+    height: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pulse: {
+    position: "absolute",
+    width: 12,
+    height: 12,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.statusDotRunning,
+  },
+  reducedMotionPulse: {
+    opacity: 0.25,
+    transform: [{ scale: 1 }],
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.statusDotRunning,
+  },
+}));

--- a/packages/app/src/components/sidebar/sidebar-projection.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-projection.test.ts
@@ -32,6 +32,7 @@ function makeWorkspace(id: string, statusBucket: SidebarWorkspaceEntry["statusBu
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    readyToReview: false,
   };
   return { placement, entry };
 }

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -72,9 +72,6 @@ const needsInputColorMapping = (theme: Theme) => ({
 const failedColorMapping = (theme: Theme) => ({
   color: getStatusDotColor({ theme, bucket: "failed" }) ?? undefined,
 });
-const attentionColorMapping = (theme: Theme) => ({
-  color: getStatusDotColor({ theme, bucket: "attention" }) ?? undefined,
-});
 const runningColorMapping = (theme: Theme) => ({
   color: getStatusDotColor({ theme, bucket: "running" }) ?? undefined,
 });
@@ -402,8 +399,6 @@ function StatusGroupIcon({ bucket }: { bucket: StatusGroup["bucket"] }) {
       return <ThemedCircleAlert size={14} uniProps={needsInputColorMapping} />;
     case "failed":
       return <ThemedCircleX size={14} uniProps={failedColorMapping} />;
-    case "attention":
-      return <ThemedCircleCheck size={14} uniProps={attentionColorMapping} />;
     case "running":
       return <ThemedCircleDot size={14} uniProps={runningColorMapping} />;
     case "done":
@@ -580,9 +575,11 @@ function StatusWorkspaceRowWithMenu({
   });
   const handleMarkAsRead = useCallback(() => {
     void clearAttention().catch((error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to mark workspace as read");
+      toast.error(
+        error instanceof Error ? error.message : t("sidebar.workspace.actions.markAsReadError"),
+      );
     });
-  }, [clearAttention, toast]);
+  }, [clearAttention, t, toast]);
 
   useKeyboardActionHandler({
     handlerId: `workspace-archive-${workspace.workspaceKey}`,

--- a/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-menu.tsx
@@ -165,7 +165,7 @@ function SidebarWorkspaceMenuItems({
           leading={markAsReadLeadingIcon}
           onSelect={onMarkAsRead}
         >
-          Mark as read
+          {t("sidebar.workspace.actions.markAsRead")}
         </WorkspaceMenuItem>
       ) : null}
       {onTogglePin ? (

--- a/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/utils/status-indicator-geometry";
 import { shouldRenderSyncedStatusLoader } from "@/utils/status-loader";
 import { resolveSidebarWorkspacePrimaryLabel } from "@/components/sidebar/sidebar-workspace-title";
+import { ReadyToReviewBadge } from "@/components/sidebar/ready-to-review-badge";
 
 // The scrim spans more than the kebab so the fade starts left of the diff stat. Solid from
 // SCRIM_SOLID_OFFSET rightward, which keeps the kebab itself off the gradient entirely.
@@ -175,17 +176,29 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
             displayName={leadingProjectName}
             projectViewKey={workspace.projectViewKey}
             statusBucket={workspace.statusBucket}
+            readyToReview={workspace.readyToReview}
             backdrop={backdrop}
             loading={isLoading}
             testID={`sidebar-row-project-icon-${workspace.workspaceKey}`}
           />
         ) : (
-          <WorkspaceStatusIndicator
-            bucket={workspace.statusBucket}
-            workspaceKind={workspace.workspaceKind}
-            loading={isLoading}
-            reserveIdleSpace={reserveIdleStatusIndicatorSpace}
-          />
+          <View style={styles.workspaceStatusWithReviewIndicator}>
+            {workspace.readyToReview && workspace.statusBucket === "done" && !isLoading ? (
+              <ReadyToReviewBadge />
+            ) : (
+              <WorkspaceStatusIndicator
+                bucket={workspace.statusBucket}
+                workspaceKind={workspace.workspaceKind}
+                loading={isLoading}
+                reserveIdleSpace={reserveIdleStatusIndicatorSpace}
+              />
+            )}
+            {workspace.readyToReview && workspace.statusBucket !== "done" && !isLoading ? (
+              <View style={styles.readyToReviewBadge}>
+                <ReadyToReviewBadge />
+              </View>
+            ) : null}
+          </View>
         )}
         <View style={styles.workspaceContentColumn}>
           <View style={styles.workspaceTitleRow}>
@@ -245,14 +258,6 @@ function WorkspaceStatusIndicator({
     return (
       <View style={styles.workspaceStatusDot} testID="workspace-status-indicator-needs_input">
         <ThemedCircleAlert size={STATUS_INDICATOR_ALERT_SIZE} uniProps={needsInputColorMapping} />
-      </View>
-    );
-  }
-
-  if (bucket === "attention") {
-    return (
-      <View style={styles.workspaceStatusDot} testID="workspace-status-indicator-attention">
-        <View style={styles.standaloneStatusDot} />
       </View>
     );
   }
@@ -329,8 +334,6 @@ function getStatusDotColorStyle(bucket: SidebarStateBucket) {
       return styles.statusDotFailed;
     case "running":
       return styles.statusDotRunning;
-    case "attention":
-      return styles.statusDotAttention;
     case "done":
       return null;
   }
@@ -567,16 +570,23 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     justifyContent: "center",
   },
+  workspaceStatusWithReviewIndicator: {
+    position: "relative",
+    width: theme.iconSize.md,
+    height: 20,
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  readyToReviewBadge: {
+    position: "absolute",
+    right: -3,
+    bottom: -2,
+  },
   statusDotOverlay: {
     position: "absolute",
     borderRadius: theme.borderRadius.full,
     borderWidth: 1,
-  },
-  standaloneStatusDot: {
-    width: STATUS_INDICATOR_DOT_SIZE,
-    height: STATUS_INDICATOR_DOT_SIZE,
-    borderRadius: theme.borderRadius.full,
-    backgroundColor: getStatusDotColor({ theme, bucket: "attention" }) ?? undefined,
   },
   standaloneRunningDot: {
     width: STATUS_INDICATOR_DOT_SIZE,
@@ -618,10 +628,6 @@ const styles = StyleSheet.create((theme) => ({
   },
   statusDotRunning: {
     backgroundColor: getStatusDotColor({ theme, bucket: "running" }) ?? undefined,
-    borderColor: theme.colors.surface0,
-  },
-  statusDotAttention: {
-    backgroundColor: getStatusDotColor({ theme, bucket: "attention" }) ?? undefined,
     borderColor: theme.colors.surface0,
   },
 }));

--- a/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row.tsx
@@ -165,9 +165,11 @@ export function SidebarWorkspaceRow({
   });
   const handleMarkAsRead = useCallback(() => {
     void clearAttention().catch((error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to mark workspace as read");
+      toast.error(
+        error instanceof Error ? error.message : t("sidebar.workspace.actions.markAsReadError"),
+      );
     });
-  }, [clearAttention, toast]);
+  }, [clearAttention, t, toast]);
 
   useKeyboardActionHandler({
     handlerId: `workspace-archive-${workspace.workspaceKey}`,

--- a/packages/app/src/components/sidebar/sidebar-workspace-title.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-workspace-title.test.ts
@@ -36,7 +36,12 @@ describe("resolveSidebarWorkspacePrimaryLabel", () => {
 describe("resolveSidebarWorkspaceAccessibilityLabel", () => {
   it("includes the visible host badge with the workspace title", () => {
     const label = resolveSidebarWorkspaceAccessibilityLabel({
-      workspace: { name: "Investigate search", currentBranch: "fix/search", statusBucket: "done" },
+      workspace: {
+        name: "Investigate search",
+        currentBranch: "fix/search",
+        statusBucket: "done",
+        readyToReview: false,
+      },
       workspaceTitleSource: "title",
       hostBadgeLabel: "Build host",
     });
@@ -50,6 +55,7 @@ describe("resolveSidebarWorkspaceAccessibilityLabel", () => {
         name: "Investigate search",
         currentBranch: "fix/search",
         statusBucket: "running",
+        readyToReview: false,
       },
       workspaceTitleSource: "branch",
       leadingProjectName: "Search project",
@@ -65,12 +71,31 @@ describe("resolveSidebarWorkspaceAccessibilityLabel", () => {
 
   it("omits the idle status from the workspace label", () => {
     const label = resolveSidebarWorkspaceAccessibilityLabel({
-      workspace: { name: "Investigate search", currentBranch: "fix/search", statusBucket: "done" },
+      workspace: {
+        name: "Investigate search",
+        currentBranch: "fix/search",
+        statusBucket: "done",
+        readyToReview: false,
+      },
       workspaceTitleSource: "title",
       leadingProjectName: "Search project",
       hostBadgeLabel: "Build host",
     });
 
     expect(label).toBe("Search project, Investigate search, Build host");
+  });
+
+  it("announces ready to review independently from the workspace status", () => {
+    const label = resolveSidebarWorkspaceAccessibilityLabel({
+      workspace: {
+        name: "Investigate search",
+        currentBranch: "fix/search",
+        statusBucket: "running",
+        readyToReview: true,
+      },
+      workspaceTitleSource: "title",
+    });
+
+    expect(label).toBe("Investigate search, Working, Ready to review");
   });
 });

--- a/packages/app/src/components/sidebar/sidebar-workspace-title.ts
+++ b/packages/app/src/components/sidebar/sidebar-workspace-title.ts
@@ -13,7 +13,10 @@ export function resolveSidebarWorkspacePrimaryLabel(input: {
 }
 
 export function resolveSidebarWorkspaceAccessibilityLabel(input: {
-  workspace: Pick<SidebarWorkspaceEntry, "name" | "currentBranch" | "statusBucket">;
+  workspace: Pick<
+    SidebarWorkspaceEntry,
+    "name" | "currentBranch" | "statusBucket" | "readyToReview"
+  >;
   workspaceTitleSource: WorkspaceTitleSource;
   leadingProjectName?: string | null;
   hostBadgeLabel?: string | null;
@@ -29,6 +32,7 @@ export function resolveSidebarWorkspaceAccessibilityLabel(input: {
     input.workspace.statusBucket === "done"
       ? null
       : STATUS_BUCKET_LABELS[input.workspace.statusBucket],
+    input.workspace.readyToReview ? "Ready to review" : null,
   ]
     .filter((label): label is string => Boolean(label))
     .join(", ");

--- a/packages/app/src/hooks/sidebar-status-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-status-view-model.test.ts
@@ -26,6 +26,7 @@ function ws(
     currentBranch: input.currentBranch ?? null,
     statusBucket: input.statusBucket ?? "done",
     statusEnteredAt: input.statusEnteredAt ?? null,
+    readyToReview: input.readyToReview ?? false,
     archivingAt: null,
     diffStat: null,
     prHint: null,
@@ -169,7 +170,8 @@ describe("buildStatusGroups", () => {
       }),
       ws({
         workspaceKey: "srv:att",
-        statusBucket: "attention",
+        statusBucket: "done",
+        readyToReview: true,
         statusEnteredAt: d("2026-01-01T00:00:00Z"),
       }),
       ws({
@@ -177,7 +179,6 @@ describe("buildStatusGroups", () => {
         statusBucket: "running",
         statusEnteredAt: d("2026-01-01T00:00:00Z"),
       }),
-      ws({ workspaceKey: "srv:dn", statusBucket: "done", statusEnteredAt: null }),
     ];
 
     const groups = buildStatusGroups(workspaces, emptyProjectNames);
@@ -191,6 +192,7 @@ describe("buildStatusGroups", () => {
       expect(group.rows).toHaveLength(1);
       expect(group.rows[0]?.statusBucket).toBe(group.bucket);
     }
+    expect(groups.some((group) => group.label === "Ready to review")).toBe(false);
   });
 });
 

--- a/packages/app/src/hooks/sidebar-status-view-model.ts
+++ b/packages/app/src/hooks/sidebar-status-view-model.ts
@@ -5,7 +5,6 @@ export type StatusBucket = SidebarWorkspaceEntry["statusBucket"];
 export const STATUS_BUCKET_ORDER: readonly StatusBucket[] = [
   "needs_input",
   "failed",
-  "attention",
   "running",
   "done",
 ] as const;
@@ -13,7 +12,6 @@ export const STATUS_BUCKET_ORDER: readonly StatusBucket[] = [
 export const STATUS_BUCKET_LABELS: Record<StatusBucket, string> = {
   needs_input: "Needs input",
   failed: "Failed",
-  attention: "Ready to review",
   running: "Working",
   done: "Done",
 };

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -10,6 +10,7 @@ import {
   buildSidebarProjectsFromStructure,
   computeSidebarOrderUpdates,
   createSidebarWorkspaceEntry,
+  deriveProjectStatus,
   deriveProjectStatusBucket,
   deriveSidebarLoadingState,
   shouldShowSidebarHostLabels,
@@ -86,6 +87,18 @@ describe("createSidebarWorkspaceEntry workspace directory label", () => {
     const entry = createSidebarWorkspaceEntry({ serverId: "srv", workspace: descriptor });
 
     expect(entry.workspaceDirectoryLabel).toBe("~/external/feature");
+  });
+});
+
+describe("createSidebarWorkspaceEntry ready to review", () => {
+  it("keeps attention in Done and exposes it as an annotation", () => {
+    const descriptor = workspaceWithForge(undefined, "https://github.com/acme/repo/pull/42");
+    descriptor.status = "attention";
+
+    const entry = createSidebarWorkspaceEntry({ serverId: "srv", workspace: descriptor });
+
+    expect(entry.statusBucket).toBe("done");
+    expect(entry.readyToReview).toBe(true);
   });
 });
 
@@ -839,7 +852,7 @@ describe("deriveProjectStatusBucket", () => {
     ).toBe("failed");
   });
 
-  it("keeps a project on attention when only one workspace awaits review", () => {
+  it("keeps a project in done when only one workspace awaits review", () => {
     expect(
       deriveProjectStatusBucket({
         workspaces: [
@@ -852,7 +865,26 @@ describe("deriveProjectStatusBucket", () => {
           }),
         },
       }),
-    ).toBe("attention");
+    ).toBe("done");
+  });
+
+  it("carries ready to review independently from a running project status", () => {
+    expect(
+      deriveProjectStatus({
+        workspaces: [
+          workspacePlacement({ workspaceId: "ws-1" }),
+          workspacePlacement({ workspaceId: "ws-2" }),
+        ],
+        sessions: {
+          srv: sessionWith({
+            workspaces: [
+              projectWorkspace("ws-1", "running"),
+              projectWorkspace("ws-2", "attention"),
+            ],
+          }),
+        },
+      }),
+    ).toEqual({ statusBucket: "running", readyToReview: true });
   });
 
   it("aggregates across the hosts a project spans", () => {

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -15,7 +15,7 @@ import { resolveWorkspaceMapKeyByIdentity } from "@/utils/workspace-identity";
 
 const EMPTY_PROJECTS: SidebarProjectEntry[] = [];
 
-export type SidebarStateBucket = WorkspaceDescriptor["status"];
+export type SidebarStateBucket = Exclude<WorkspaceDescriptor["status"], "attention">;
 
 export interface SidebarWorkspacePlacement {
   workspaceKey: string;
@@ -33,6 +33,7 @@ export interface SidebarWorkspacePlacement {
 export interface SidebarStatusWorkspacePlacement extends SidebarWorkspacePlacement {
   statusBucket: SidebarStateBucket;
   statusEnteredAt: Date | null;
+  readyToReview: boolean;
 }
 
 export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
@@ -122,8 +123,13 @@ export function areSidebarWorkspaceSessionsEqual(
 }
 
 interface EffectiveWorkspaceStatus {
-  status: WorkspaceDescriptor["status"];
+  status: SidebarStateBucket;
   enteredAt: Date | null;
+  readyToReview: boolean;
+}
+
+function toSidebarStatusBucket(status: WorkspaceDescriptor["status"]): SidebarStateBucket {
+  return status === "attention" ? "done" : status;
 }
 
 function projectNameForWorkspace(workspace: WorkspaceDescriptor): string {
@@ -169,6 +175,7 @@ export function createSidebarWorkspaceEntry(input: {
     currentBranch: normalizeCurrentBranch(input.workspace.gitRuntime?.currentBranch),
     statusBucket: effectiveStatus.status,
     statusEnteredAt: effectiveStatus.enteredAt,
+    readyToReview: effectiveStatus.readyToReview,
     archivingAt: input.workspace.archivingAt,
     diffStat: input.workspace.diffStat,
     prHint: selectPrHintFromStatus(
@@ -188,8 +195,16 @@ function deriveEffectiveWorkspaceStatus(input: {
   pendingCreateAttempts?: Record<string, PendingCreateAttempt>;
   workspaceAgentActivity?: ReadonlyMap<string, WorkspaceAgentActivity>;
 }): EffectiveWorkspaceStatus {
+  const rootAgentActivity = input.workspaceAgentActivity?.get(input.workspace.id);
+  const readyToReview =
+    input.workspace.status === "attention" || rootAgentActivity?.readyToReview === true;
+
   if (input.workspace.status !== "done") {
-    return { status: input.workspace.status, enteredAt: input.workspace.statusEnteredAt };
+    return {
+      status: toSidebarStatusBucket(input.workspace.status),
+      enteredAt: input.workspace.statusEnteredAt,
+      readyToReview,
+    };
   }
 
   const pendingStartedAt = getPendingInitialAgentCreateStartedAt({
@@ -198,15 +213,22 @@ function deriveEffectiveWorkspaceStatus(input: {
     pendingCreateAttempts: input.pendingCreateAttempts,
   });
   if (pendingStartedAt) {
-    return { status: "running", enteredAt: pendingStartedAt };
+    return { status: "running", enteredAt: pendingStartedAt, readyToReview };
   }
 
-  const rootAgentActivity = input.workspaceAgentActivity?.get(input.workspace.id);
   if (rootAgentActivity && rootAgentActivity.status !== "done") {
-    return rootAgentActivity;
+    return {
+      status: toSidebarStatusBucket(rootAgentActivity.status),
+      enteredAt: rootAgentActivity.enteredAt,
+      readyToReview,
+    };
   }
 
-  return { status: input.workspace.status, enteredAt: input.workspace.statusEnteredAt };
+  return {
+    status: "done",
+    enteredAt: input.workspace.statusEnteredAt,
+    readyToReview,
+  };
 }
 
 function getPendingInitialAgentCreateStartedAt(input: {
@@ -232,6 +254,11 @@ export interface ProjectStatusSession {
   workspaceAgentActivity: Map<string, WorkspaceAgentActivity>;
 }
 
+export interface SidebarProjectStatus {
+  statusBucket: SidebarStateBucket;
+  readyToReview: boolean;
+}
+
 /**
  * Most urgent status among a project's workspaces. Backs the status dot on a collapsed
  * project row, which otherwise hides every workspace-level signal it contains.
@@ -241,11 +268,11 @@ export interface ProjectStatusSession {
  * activity-index + effective-status pipeline as per-workspace rows (one pass over the
  * session's agents per server, not per workspace) rather than re-deriving it.
  */
-export function deriveProjectStatusBucket(input: {
+export function deriveProjectStatus(input: {
   workspaces: readonly SidebarWorkspacePlacement[];
   sessions: Record<string, ProjectStatusSession | undefined>;
   pendingCreateAttempts?: Record<string, PendingCreateAttempt>;
-}): SidebarStateBucket {
+}): SidebarProjectStatus {
   const workspaceIdsByServer = new Map<string, string[]>();
   for (const placement of input.workspaces) {
     const existing = workspaceIdsByServer.get(placement.serverId);
@@ -257,6 +284,7 @@ export function deriveProjectStatusBucket(input: {
   }
 
   const buckets: SidebarStateBucket[] = [];
+  let readyToReview = false;
   for (const [serverId, workspaceIds] of workspaceIdsByServer) {
     const session = input.sessions[serverId];
     if (!session) continue;
@@ -267,18 +295,27 @@ export function deriveProjectStatusBucket(input: {
       });
       const workspace = workspaceKey ? session.workspaces.get(workspaceKey) : undefined;
       if (!workspace) continue;
-      buckets.push(
-        deriveEffectiveWorkspaceStatus({
-          serverId,
-          workspace,
-          pendingCreateAttempts: input.pendingCreateAttempts,
-          workspaceAgentActivity: session.workspaceAgentActivity,
-        }).status,
-      );
+      const status = deriveEffectiveWorkspaceStatus({
+        serverId,
+        workspace,
+        pendingCreateAttempts: input.pendingCreateAttempts,
+        workspaceAgentActivity: session.workspaceAgentActivity,
+      });
+      buckets.push(status.status);
+      readyToReview ||= status.readyToReview;
     }
   }
 
-  return aggregateSidebarStateBuckets(buckets);
+  return {
+    statusBucket: toSidebarStatusBucket(aggregateSidebarStateBuckets(buckets)),
+    readyToReview,
+  };
+}
+
+export function deriveProjectStatusBucket(
+  input: Parameters<typeof deriveProjectStatus>[0],
+): SidebarStateBucket {
+  return deriveProjectStatus(input).statusBucket;
 }
 
 export function buildSidebarWorkspacePlacementModel(input: {

--- a/packages/app/src/hooks/use-agent-attention-clear.ts
+++ b/packages/app/src/hooks/use-agent-attention-clear.ts
@@ -1,12 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { AppState } from "react-native";
+import { useCallback } from "react";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import {
   shouldClearAgentAttention,
   type AgentAttentionClearTrigger,
 } from "@/utils/agent-attention";
-import { getIsAppActivelyVisible } from "@/utils/app-visibility";
-import { isWeb } from "@/constants/platform";
 
 type AttentionReason = "finished" | "error" | "permission" | null | undefined;
 
@@ -16,7 +13,6 @@ interface UseAgentAttentionClearParams {
   isConnected: boolean;
   requiresAttention: boolean | null | undefined;
   attentionReason: AttentionReason;
-  isScreenFocused: boolean;
 }
 
 interface AgentAttentionClearController {
@@ -31,15 +27,7 @@ export function useAgentAttentionClear({
   isConnected,
   requiresAttention,
   attentionReason,
-  isScreenFocused,
 }: UseAgentAttentionClearParams): AgentAttentionClearController {
-  const [isAppVisible, setIsAppVisible] = useState<boolean>(() => getIsAppActivelyVisible());
-  const deferredFocusEntryClearRef = useRef(false);
-  const prevRequiresAttentionRef = useRef(Boolean(requiresAttention));
-  const prevActivelyViewedRef = useRef(isScreenFocused && getIsAppActivelyVisible());
-  const prevScreenFocusedRef = useRef(false);
-  const prevAppVisibleRef = useRef(getIsAppActivelyVisible());
-
   const clearAttention = useCallback(
     (trigger: AgentAttentionClearTrigger) => {
       const resolvedAgentId = agentId?.trim();
@@ -53,73 +41,14 @@ export function useAgentAttentionClear({
           requiresAttention,
           attentionReason,
           trigger,
-          hasDeferredFocusEntryClear: deferredFocusEntryClearRef.current,
         })
       ) {
         return;
       }
-      deferredFocusEntryClearRef.current = false;
       client.clearAgentAttention(resolvedAgentId).catch(() => {});
     },
     [agentId, attentionReason, client, isConnected, requiresAttention],
   );
-
-  useEffect(() => {
-    const updateVisibility = () => {
-      setIsAppVisible(getIsAppActivelyVisible());
-    };
-
-    const appStateSubscription = AppState.addEventListener("change", updateVisibility);
-
-    if (isWeb && typeof document !== "undefined") {
-      document.addEventListener("visibilitychange", updateVisibility);
-      window.addEventListener("focus", updateVisibility);
-      window.addEventListener("blur", updateVisibility);
-
-      return () => {
-        appStateSubscription.remove();
-        document.removeEventListener("visibilitychange", updateVisibility);
-        window.removeEventListener("focus", updateVisibility);
-        window.removeEventListener("blur", updateVisibility);
-      };
-    }
-
-    return () => {
-      appStateSubscription.remove();
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!requiresAttention) {
-      deferredFocusEntryClearRef.current = false;
-    }
-  }, [requiresAttention]);
-
-  useEffect(() => {
-    const isActivelyViewed = isScreenFocused && isAppVisible;
-    if (
-      !prevRequiresAttentionRef.current &&
-      Boolean(requiresAttention) &&
-      prevActivelyViewedRef.current &&
-      isActivelyViewed
-    ) {
-      deferredFocusEntryClearRef.current = true;
-    }
-    prevRequiresAttentionRef.current = Boolean(requiresAttention);
-    prevActivelyViewedRef.current = isActivelyViewed;
-  }, [isAppVisible, isScreenFocused, requiresAttention]);
-
-  useEffect(() => {
-    const enteredScreenFocus = !prevScreenFocusedRef.current && isScreenFocused && isAppVisible;
-    const resumedIntoFocusedAgent = !prevAppVisibleRef.current && isAppVisible && isScreenFocused;
-
-    if (enteredScreenFocus || resumedIntoFocusedAgent) {
-      clearAttention("focus-entry");
-    }
-
-    prevScreenFocusedRef.current = isScreenFocused;
-    prevAppVisibleRef.current = isAppVisible;
-  }, [clearAttention, isAppVisible, isScreenFocused]);
 
   return {
     clearOnInputFocus: useCallback(() => {

--- a/packages/app/src/hooks/use-clear-workspace-attention.ts
+++ b/packages/app/src/hooks/use-clear-workspace-attention.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { i18n } from "@/i18n/i18next";
 import { getHostRuntimeStore } from "@/runtime/host-runtime";
 import { useSessionStore } from "@/stores/session-store";
+import { hasClearableWorkspaceAttention } from "@/utils/clear-workspace-attention";
 
 export interface ClearWorkspaceAttentionController {
   hasClearableAttention: boolean;
@@ -16,8 +17,13 @@ export function useClearWorkspaceAttention({
   workspaceId: string;
 }): ClearWorkspaceAttentionController {
   const hasClearableAttention = useSessionStore((state) => {
-    const workspace = state.sessions[serverId]?.workspaces.get(workspaceId);
-    return workspace?.status === "attention" || workspace?.status === "failed";
+    const session = state.sessions[serverId];
+    const workspace = session?.workspaces.get(workspaceId);
+    const readyToReview = session?.workspaceAgentActivity.get(workspaceId)?.readyToReview === true;
+    return hasClearableWorkspaceAttention({
+      workspaceStatus: workspace?.status,
+      readyToReview,
+    });
   });
 
   const clearAttention = useCallback(async () => {

--- a/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
+++ b/packages/app/src/hooks/use-sidebar-shortcut-model.test.tsx
@@ -36,6 +36,7 @@ function workspace(projectKey: string, workspaceId: string): SidebarWorkspaceEnt
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    readyToReview: false,
   };
 }
 

--- a/packages/app/src/hooks/use-sidebar-workspaces-list.ts
+++ b/packages/app/src/hooks/use-sidebar-workspaces-list.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useStoreWithEqualityFn } from "zustand/traditional";
+import { shallow } from "zustand/shallow";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
 import { useSessionStore } from "@/stores/session-store";
 import { useHydratedWorkspaceServerIds } from "@/stores/session-store-hooks";
@@ -12,10 +13,12 @@ import {
   buildSidebarWorkspacePlacementModel,
   computeSidebarOrderUpdates,
   createSidebarWorkspaceEntry,
+  deriveProjectStatus,
   deriveProjectStatusBucket,
   deriveSidebarLoadingState,
   type ProjectStatusSession,
   type SidebarProjectEntry,
+  type SidebarProjectStatus,
   type SidebarWorkspaceEntry,
   type SidebarWorkspacePlacement,
 } from "./sidebar-workspaces-view-model";
@@ -30,6 +33,7 @@ export {
   buildSidebarWorkspacePlacementModel,
   computeSidebarOrderUpdates,
   deriveProjectStatusBucket,
+  deriveProjectStatus,
   deriveSidebarLoadingState,
   shouldShowSidebarHostLabels,
   type SidebarLoadingState,
@@ -38,6 +42,7 @@ export {
   type SidebarWorkspacePlacement,
   type SidebarWorkspacePlacementModel,
   type SidebarProjectEntry,
+  type SidebarProjectStatus,
   type SidebarStateBucket,
   type SidebarWorkspaceEntry,
 } from "./sidebar-workspaces-view-model";
@@ -53,10 +58,10 @@ export {
  * Pass `enabled: false` while the project is expanded: the child rows show their own dots
  * and the selector is pure cost.
  */
-export function useSidebarProjectStatusBucket(input: {
+export function useSidebarProjectStatus(input: {
   workspaces: readonly SidebarWorkspacePlacement[];
   enabled: boolean;
-}): SidebarStateBucket | null {
+}): SidebarProjectStatus | null {
   const { workspaces, enabled } = input;
   const pendingCreateAttempts = useStoreWithEqualityFn(
     useCreateFlowStore,
@@ -67,7 +72,7 @@ export function useSidebarProjectStatusBucket(input: {
   const selector = useCallback(
     (state: { sessions: Record<string, ProjectStatusSession | undefined> }) => {
       if (!enabled) return null;
-      return deriveProjectStatusBucket({
+      return deriveProjectStatus({
         workspaces,
         sessions: state.sessions,
         pendingCreateAttempts,
@@ -76,7 +81,7 @@ export function useSidebarProjectStatusBucket(input: {
     [enabled, pendingCreateAttempts, workspaces],
   );
 
-  return useStoreWithEqualityFn(useSessionStore, selector, Object.is);
+  return useStoreWithEqualityFn(useSessionStore, selector, shallow);
 }
 
 const EMPTY_ORDER: string[] = [];

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1001,6 +1001,8 @@ export const ar: TranslationResources = {
         showMore: "عرض المزيد",
         showLess: "عرض أقل",
         createWorkspaceFor: "قم بإنشاء مساحة عمل جديدة لـ{{projectName}}",
+        markAsRead: "تحديد كمقروء",
+        markAsReadError: "تعذّر تحديد مساحة العمل كمقروءة.",
         copyPath: "نسخ المسار",
         copyBranchName: "انسخ اسم الفرع",
         rename: "إعادة تسمية مساحة العمل",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1011,6 +1011,8 @@ export const en = {
         showMore: "Show more",
         showLess: "Show less",
         createWorkspaceFor: "Create a new workspace for {{projectName}}",
+        markAsRead: "Mark as read",
+        markAsReadError: "Couldn't mark the workspace as read.",
         copyPath: "Copy path",
         copyBranchName: "Copy branch name",
         rename: "Rename workspace",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1032,6 +1032,8 @@ export const es: TranslationResources = {
         showMore: "Mostrar más",
         showLess: "Mostrar menos",
         createWorkspaceFor: "Crea un nuevo espacio de trabajo para{{projectName}}",
+        markAsRead: "Marcar como leído",
+        markAsReadError: "No se pudo marcar el workspace como leído.",
         copyPath: "Copiar ruta",
         copyBranchName: "Copiar nombre de sucursal",
         rename: "Cambiar nombre del espacio de trabajo",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1031,6 +1031,8 @@ export const fr: TranslationResources = {
         showMore: "Afficher plus",
         showLess: "Afficher moins",
         createWorkspaceFor: "Créer un nouvel espace de travail pour{{projectName}}",
+        markAsRead: "Marquer comme lu",
+        markAsReadError: "Impossible de marquer l'espace de travail comme lu.",
         copyPath: "Copier le chemin",
         copyBranchName: "Copier le nom de la branche",
         rename: "Renommer l'espace de travail",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1012,6 +1012,8 @@ export const ja: TranslationResources = {
         showMore: "さらに表示",
         showLess: "表示を減らす",
         createWorkspaceFor: "{{projectName}}の新しいワークスペースを作成",
+        markAsRead: "既読にする",
+        markAsReadError: "ワークスペースを既読にできませんでした。",
         copyPath: "パスをコピー",
         copyBranchName: "ブランチ名をコピー",
         rename: "ワークスペースの名前を変更",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1008,6 +1008,8 @@ export const ko: TranslationResources = {
         showMore: "더 보기",
         showLess: "간략히 보기",
         createWorkspaceFor: "{{projectName}}을(를) 위한 새 워크스페이스 생성",
+        markAsRead: "읽음으로 표시",
+        markAsReadError: "워크스페이스를 읽음으로 표시하지 못했습니다.",
         copyPath: "경로 복사",
         copyBranchName: "브랜치 이름 복사",
         rename: "워크스페이스 이름 변경",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1023,6 +1023,8 @@ export const ptBR: TranslationResources = {
         showMore: "Mostrar mais",
         showLess: "Mostrar menos",
         createWorkspaceFor: "Criar um novo workspace para {{projectName}}",
+        markAsRead: "Marcar como lido",
+        markAsReadError: "Não foi possível marcar o workspace como lido.",
         copyPath: "Copiar caminho",
         copyBranchName: "Copiar nome da branch",
         rename: "Renomear workspace",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1023,6 +1023,8 @@ export const ru: TranslationResources = {
         showMore: "Показать ещё",
         showLess: "Показать меньше",
         createWorkspaceFor: "Создайте новое рабочее пространство для{{projectName}}.",
+        markAsRead: "Отметить как прочитанное",
+        markAsReadError: "Не удалось отметить рабочее пространство как прочитанное.",
         copyPath: "Копировать путь",
         copyBranchName: "Скопировать название ветки",
         rename: "Переименовать рабочую область",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -991,6 +991,8 @@ export const zhCN: TranslationResources = {
         showMore: "显示更多",
         showLess: "收起",
         createWorkspaceFor: "为 {{projectName}} 新建 workspace",
+        markAsRead: "标记为已读",
+        markAsReadError: "无法将工作区标记为已读。",
         copyPath: "复制路径",
         copyBranchName: "复制分支名称",
         rename: "重命名 workspace",

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -857,7 +857,6 @@ function ChatAgentContent({
     isConnected,
     requiresAttention: agentState.requiresAttention,
     attentionReason: agentState.attentionReason,
-    isScreenFocused: isPaneFocused,
   });
   useEffect(() => {
     clearOnAgentBlurRef.current = attentionController.clearOnAgentBlur;

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -20,6 +20,7 @@ import * as Clipboard from "expo-clipboard";
 import { useTranslation } from "react-i18next";
 import { DiffStat } from "@/components/diff-stat";
 import {
+  CircleCheck,
   CopyX,
   ArrowLeftToLine,
   ArrowRightToLine,
@@ -72,6 +73,7 @@ import { WorkspaceOpenInEditorButton } from "@/screens/workspace/workspace-open-
 import { WorkspaceScriptsButton } from "@/screens/workspace/workspace-scripts-button";
 import { ImportSessionSheet } from "@/components/import-session-sheet";
 import { useToast } from "@/contexts/toast-context";
+import { useClearWorkspaceAttention } from "@/hooks/use-clear-workspace-attention";
 import { selectIsFileExplorerOpen, usePanelStore } from "@/stores/panel-store";
 import { type ExplorerCheckoutContext } from "@/stores/explorer-checkout-context";
 import { traceInstant } from "@/performance/native-trace";
@@ -249,6 +251,7 @@ const ThemedLoadingSpinner = withUnistyles(LoadingSpinner);
 const ThemedEllipsis = withUnistyles(Ellipsis);
 const ThemedChevronDown = withUnistyles(ChevronDown);
 const ThemedCopy = withUnistyles(Copy);
+const ThemedCircleCheck = withUnistyles(CircleCheck);
 const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
@@ -289,6 +292,7 @@ const MENU_NEW_TERMINAL_ICON = <ThemedSquareTerminal size={16} uniProps={mutedCo
 const MENU_NEW_BROWSER_ICON = <ThemedGlobe size={16} uniProps={mutedColorMapping} />;
 const MENU_IMPORT_ICON = <ThemedImport size={16} uniProps={mutedColorMapping} />;
 const MENU_COPY_ICON = <ThemedCopy size={16} uniProps={mutedColorMapping} />;
+const MENU_MARK_AS_READ_ICON = <ThemedCircleCheck size={16} uniProps={mutedColorMapping} />;
 const MENU_SETTINGS_ICON = <ThemedSettings size={16} uniProps={mutedColorMapping} />;
 const GATED_WORKSPACE_HEADER_LEFT = <SidebarMenuToggle />;
 
@@ -986,6 +990,7 @@ function useCloseTabs(): UseCloseTabsResult {
 
 interface WorkspaceHeaderMenuProps {
   normalizedServerId: string;
+  normalizedWorkspaceId: string;
   currentBranchName: string | null;
   showWorkspaceSetup: boolean;
   showCreateBrowserTab: boolean;
@@ -1061,6 +1066,7 @@ function WorkspaceHeaderMenuTriggerIcon({ hovered, open }: { hovered: boolean; o
 
 function WorkspaceHeaderMenu({
   normalizedServerId,
+  normalizedWorkspaceId,
   currentBranchName,
   showWorkspaceSetup,
   showCreateBrowserTab,
@@ -1085,7 +1091,20 @@ function WorkspaceHeaderMenu({
 }: WorkspaceHeaderMenuProps) {
   const { t } = useTranslation();
   const router = useRouter();
+  const toast = useToast();
   const { config } = useDaemonConfig(normalizedServerId);
+  const { hasClearableAttention, clearAttention } = useClearWorkspaceAttention({
+    serverId: normalizedServerId,
+    workspaceId: normalizedWorkspaceId,
+  });
+
+  const handleMarkAsRead = useCallback(() => {
+    void clearAttention().catch((error) => {
+      toast.error(
+        error instanceof Error ? error.message : t("sidebar.workspace.actions.markAsReadError"),
+      );
+    });
+  }, [clearAttention, t, toast]);
   const profiles = useMemo(
     () => resolveTerminalProfiles(config?.terminalProfiles),
     [config?.terminalProfiles],
@@ -1158,6 +1177,15 @@ function WorkspaceHeaderMenu({
             onSelect={onCopyBranchName}
           >
             {t("workspace.header.actions.copyBranchName")}
+          </DropdownMenuItem>
+        ) : null}
+        {hasClearableAttention ? (
+          <DropdownMenuItem
+            testID="workspace-header-mark-as-read"
+            leading={MENU_MARK_AS_READ_ICON}
+            onSelect={handleMarkAsRead}
+          >
+            {t("sidebar.workspace.actions.markAsRead")}
           </DropdownMenuItem>
         ) : null}
         {showWorkspaceSetup ? (
@@ -1333,6 +1361,7 @@ function WorkspaceHeaderTitleBar({
       <View style={styles.compactHeaderMenuCluster}>
         <WorkspaceHeaderMenu
           normalizedServerId={normalizedServerId}
+          normalizedWorkspaceId={normalizedWorkspaceId}
           currentBranchName={currentBranchName}
           showWorkspaceSetup={showWorkspaceSetup}
           showCreateBrowserTab={showCreateBrowserTab}

--- a/packages/app/src/utils/agent-attention.test.ts
+++ b/packages/app/src/utils/agent-attention.test.ts
@@ -46,6 +46,7 @@ describe("shouldClearAgentAttention", () => {
         isConnected: true,
         requiresAttention: true,
         attentionReason: "finished",
+        trigger: "prompt-send",
       }),
     ).toBe(true);
   });
@@ -57,6 +58,7 @@ describe("shouldClearAgentAttention", () => {
         isConnected: false,
         requiresAttention: true,
         attentionReason: "finished",
+        trigger: "prompt-send",
       }),
     ).toBe(false);
   });
@@ -68,6 +70,7 @@ describe("shouldClearAgentAttention", () => {
         isConnected: true,
         requiresAttention: false,
         attentionReason: null,
+        trigger: "prompt-send",
       }),
     ).toBe(false);
   });
@@ -79,6 +82,7 @@ describe("shouldClearAgentAttention", () => {
         isConnected: true,
         requiresAttention: true,
         attentionReason: "finished",
+        trigger: "prompt-send",
       }),
     ).toBe(false);
   });
@@ -90,56 +94,23 @@ describe("shouldClearAgentAttention", () => {
         isConnected: true,
         requiresAttention: true,
         attentionReason: "permission",
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false for focus entry when clear was deferred while already focused", () => {
-    expect(
-      shouldClearAgentAttention({
-        agentId: "agent-1",
-        isConnected: true,
-        requiresAttention: true,
-        attentionReason: "finished",
-        trigger: "focus-entry",
-        hasDeferredFocusEntryClear: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true for explicit follow-up entrypoints after deferred focus clear", () => {
-    expect(
-      shouldClearAgentAttention({
-        agentId: "agent-1",
-        isConnected: true,
-        requiresAttention: true,
-        attentionReason: "finished",
-        trigger: "input-focus",
-        hasDeferredFocusEntryClear: true,
-      }),
-    ).toBe(true);
-
-    expect(
-      shouldClearAgentAttention({
-        agentId: "agent-1",
-        isConnected: true,
-        requiresAttention: true,
-        attentionReason: "finished",
         trigger: "prompt-send",
-        hasDeferredFocusEntryClear: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
+  });
 
-    expect(
-      shouldClearAgentAttention({
-        agentId: "agent-1",
-        isConnected: true,
-        requiresAttention: true,
-        attentionReason: "finished",
-        trigger: "agent-blur",
-        hasDeferredFocusEntryClear: true,
-      }),
-    ).toBe(true);
+  it("keeps attention while the agent is opened, focused, or blurred", () => {
+    for (const trigger of ["focus-entry", "input-focus", "agent-blur"] as const) {
+      expect(
+        shouldClearAgentAttention({
+          agentId: "agent-1",
+          isConnected: true,
+          requiresAttention: true,
+          attentionReason: "finished",
+          trigger,
+        }),
+      ).toBe(false);
+    }
   });
 });
 

--- a/packages/app/src/utils/agent-attention.ts
+++ b/packages/app/src/utils/agent-attention.ts
@@ -5,8 +5,7 @@ interface ShouldClearAgentAttentionInput {
   isConnected: boolean;
   requiresAttention: boolean | null | undefined;
   attentionReason?: "finished" | "error" | "permission" | null | undefined;
-  trigger?: AgentAttentionClearTrigger;
-  hasDeferredFocusEntryClear?: boolean;
+  trigger: AgentAttentionClearTrigger;
 }
 
 export type AgentAttentionClearTrigger =
@@ -74,8 +73,5 @@ export function shouldClearAgentAttention(input: ShouldClearAgentAttentionInput)
   if (input.attentionReason === "permission") {
     return false;
   }
-  if (input.trigger === "focus-entry" && input.hasDeferredFocusEntryClear === true) {
-    return false;
-  }
-  return true;
+  return input.trigger === "prompt-send";
 }

--- a/packages/app/src/utils/clear-workspace-attention.test.ts
+++ b/packages/app/src/utils/clear-workspace-attention.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { hasClearableWorkspaceAttention } from "./clear-workspace-attention";
+
+describe("hasClearableWorkspaceAttention", () => {
+  it("allows dismissal while another agent keeps the workspace running", () => {
+    expect(
+      hasClearableWorkspaceAttention({ workspaceStatus: "running", readyToReview: true }),
+    ).toBe(true);
+  });
+
+  it("does not offer dismissal for ordinary running or done workspaces", () => {
+    expect(
+      hasClearableWorkspaceAttention({ workspaceStatus: "running", readyToReview: false }),
+    ).toBe(false);
+    expect(hasClearableWorkspaceAttention({ workspaceStatus: "done", readyToReview: false })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/app/src/utils/clear-workspace-attention.ts
+++ b/packages/app/src/utils/clear-workspace-attention.ts
@@ -1,0 +1,10 @@
+export function hasClearableWorkspaceAttention(input: {
+  workspaceStatus: "needs_input" | "failed" | "running" | "attention" | "done" | undefined;
+  readyToReview: boolean;
+}): boolean {
+  return (
+    input.workspaceStatus === "attention" ||
+    input.workspaceStatus === "failed" ||
+    input.readyToReview
+  );
+}

--- a/packages/app/src/utils/project-status-badge-content.test.ts
+++ b/packages/app/src/utils/project-status-badge-content.test.ts
@@ -14,13 +14,6 @@ describe("getProjectStatusBadgeContent", () => {
     expect(getProjectStatusBadgeContent("failed")).toEqual({ kind: "dot", bucket: "failed" });
   });
 
-  it("shows an attention dot when a workspace awaits review", () => {
-    expect(getProjectStatusBadgeContent("attention")).toEqual({
-      kind: "dot",
-      bucket: "attention",
-    });
-  });
-
   it("shows nothing when the project is done", () => {
     expect(getProjectStatusBadgeContent("done")).toBeNull();
   });

--- a/packages/app/src/utils/project-status-badge-content.ts
+++ b/packages/app/src/utils/project-status-badge-content.ts
@@ -1,6 +1,7 @@
-import type { SidebarStateBucket } from "@/utils/sidebar-agent-state";
+import type { SidebarWorkspaceEntry } from "@/hooks/sidebar-workspaces-view-model";
 
-export type ProjectStatusBadgeDotBucket = "failed" | "attention" | "running";
+type SidebarStatusBucket = SidebarWorkspaceEntry["statusBucket"];
+export type ProjectStatusBadgeDotBucket = "failed" | "running";
 
 export type ProjectStatusBadgeContent =
   | { kind: "alert" }
@@ -11,18 +12,18 @@ export type ProjectStatusBadgeContent =
  * no badge should show at all. Kept as plain data (no React) so it's testable without JSDOM
  * or component mounting — see docs/testing.md's two test categories.
  *
- * Running is a dot like failed and attention rather than its own glyph. The badge is 14pt;
+ * Running is a dot like failed rather than its own glyph. The badge is 14pt;
  * anything with internal detail at that size loses to a solid disc, so the buckets separate
  * by color and — for running alone — by pulsing. Only needs_input earns a glyph, because
  * "someone must act" has to survive being the one amber state next to running.
  */
 export function getProjectStatusBadgeContent(
-  statusBucket: SidebarStateBucket | null,
+  statusBucket: SidebarStatusBucket | null,
 ): ProjectStatusBadgeContent | null {
   if (statusBucket === "needs_input") {
     return { kind: "alert" };
   }
-  if (statusBucket === "failed" || statusBucket === "attention" || statusBucket === "running") {
+  if (statusBucket === "failed" || statusBucket === "running") {
     return { kind: "dot", bucket: statusBucket };
   }
   return null;

--- a/packages/app/src/utils/sidebar-project-row-model.test.ts
+++ b/packages/app/src/utils/sidebar-project-row-model.test.ts
@@ -31,6 +31,7 @@ function workspace(overrides: Partial<SidebarWorkspaceEntry> = {}): SidebarWorks
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    readyToReview: false,
     statusEnteredAt: null,
     ...overrides,
     archivingAt: overrides.archivingAt ?? null,

--- a/packages/app/src/utils/sidebar-shortcuts.test.ts
+++ b/packages/app/src/utils/sidebar-shortcuts.test.ts
@@ -42,6 +42,7 @@ function workspace(input: {
     archiveUnpushedCommitCount: null,
     scripts: [],
     hasRunningScripts: false,
+    readyToReview: false,
   };
 }
 

--- a/packages/app/src/utils/workspace-agent-activity.test.ts
+++ b/packages/app/src/utils/workspace-agent-activity.test.ts
@@ -99,6 +99,7 @@ describe("workspace agent activity index", () => {
             agentId: "permission",
             status: "needs_input",
             enteredAt: new Date("2026-06-01T10:01:00.000Z"),
+            readyToReview: false,
           },
         ],
         [
@@ -107,6 +108,7 @@ describe("workspace agent activity index", () => {
             agentId: "attention",
             status: "attention",
             enteredAt: new Date("2026-06-01T10:02:00.000Z"),
+            readyToReview: true,
           },
         ],
       ]),
@@ -153,6 +155,7 @@ describe("workspace agent activity index", () => {
       agentId: "root",
       status: "running",
       enteredAt: new Date("2026-06-01T10:00:00.000Z"),
+      readyToReview: false,
     });
   });
 
@@ -188,6 +191,7 @@ describe("workspace agent activity index", () => {
             agentId: "parent",
             status: "done",
             enteredAt: new Date("2026-06-01T10:00:00.000Z"),
+            readyToReview: false,
           },
         ],
         [
@@ -196,6 +200,7 @@ describe("workspace agent activity index", () => {
             agentId: "child",
             status: "running",
             enteredAt: new Date("2026-06-01T10:03:00.000Z"),
+            readyToReview: false,
           },
         ],
       ]),
@@ -272,6 +277,40 @@ describe("workspace agent activity index", () => {
       agentId: "root",
       status: "needs_input",
       enteredAt: new Date("2026-06-01T10:05:00.000Z"),
+      readyToReview: false,
+    });
+  });
+
+  it("keeps finished attention alongside newer running activity", () => {
+    const index = buildWorkspaceAgentActivityIndex(
+      new Map([
+        [
+          "finished",
+          agent({
+            id: "finished",
+            workspaceId: "workspace-a",
+            updatedAt: "2026-06-01T10:00:00.000Z",
+            requiresAttention: true,
+            attentionReason: "finished",
+          }),
+        ],
+        [
+          "running",
+          agent({
+            id: "running",
+            workspaceId: "workspace-a",
+            status: "running",
+            updatedAt: "2026-06-01T10:01:00.000Z",
+          }),
+        ],
+      ]),
+    );
+
+    expect(index.get("workspace-a")).toEqual({
+      agentId: "running",
+      status: "running",
+      enteredAt: new Date("2026-06-01T10:01:00.000Z"),
+      readyToReview: true,
     });
   });
 });

--- a/packages/app/src/utils/workspace-agent-activity.ts
+++ b/packages/app/src/utils/workspace-agent-activity.ts
@@ -6,6 +6,20 @@ export interface WorkspaceAgentActivity {
   agentId: string;
   status: WorkspaceDescriptor["status"];
   enteredAt: Date | null;
+  readyToReview: boolean;
+}
+
+function collectReadyToReviewWorkspaceIds(agents: ReadonlyMap<string, Agent>): Set<string> {
+  const workspaceIds = new Set<string>();
+  for (const agent of agents.values()) {
+    const parentAgent = agent.parentAgentId ? agents.get(agent.parentAgentId) : undefined;
+    const isRoot = isWorkspaceRootAgent(agent, parentAgent);
+    const isReady = agent.requiresAttention === true && agent.attentionReason === "finished";
+    if (!agent.archivedAt && agent.workspaceId && isRoot && isReady) {
+      workspaceIds.add(agent.workspaceId);
+    }
+  }
+  return workspaceIds;
 }
 
 export function buildWorkspaceAgentActivityIndex(
@@ -14,6 +28,7 @@ export function buildWorkspaceAgentActivityIndex(
 ): Map<string, WorkspaceAgentActivity> {
   const activityByWorkspaceId = new Map<string, WorkspaceAgentActivity>();
   const latestActivityAtByWorkspaceId = new Map<string, Date>();
+  const readyToReviewWorkspaceIds = collectReadyToReviewWorkspaceIds(agents);
 
   for (const agent of agents.values()) {
     const parentAgent = agent.parentAgentId ? agents.get(agent.parentAgentId) : undefined;
@@ -38,6 +53,7 @@ export function buildWorkspaceAgentActivityIndex(
       agentId: agent.id,
       status,
       enteredAt,
+      readyToReview: readyToReviewWorkspaceIds.has(agent.workspaceId),
     });
   }
 
@@ -45,7 +61,8 @@ export function buildWorkspaceAgentActivityIndex(
     const previousActivity = previous?.get(workspaceId);
     if (
       previousActivity?.agentId === activity.agentId &&
-      previousActivity.status === activity.status
+      previousActivity.status === activity.status &&
+      previousActivity.readyToReview === activity.readyToReview
     ) {
       activityByWorkspaceId.set(workspaceId, previousActivity);
     }


### PR DESCRIPTION
## Problem

Opening an agent cleared Ready to review immediately, and treating it as a sidebar bucket made the row move when you opened it. Reading a thread is not reviewing it, and review readiness is independent from whether another agent is working.

## What changed

- Ready to review persists until the user sends a prompt or explicitly chooses **Mark as read**.
- It is no longer a status group. Finished-only workspaces remain in Done, while a workspace can be Working and ready to review at the same time.
- Sidebar rows show a synchronized pulsing blue review badge. For Done it replaces the idle dot; alongside an active, failed, or waiting status it overlays that indicator.
- Collapsed project icons carry the badge when any hidden workspace is ready.
- **Mark as read** remains in the sidebar row menu and is now also available in the workspace header menu. Its labels and errors are localized across all locales.
- The configurable behavior and client-side display preference are removed; this is the default behavior.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- 139 focused Vitest cases across attention policy, workspace activity and view models, status grouping, sidebar behavior, and i18n
- Rendered web QA against an isolated local daemon and mock agent, verifying normal grouping, the review badge, and its accessibility label
- Full suite deferred to CI per repository policy

Docs: `docs/agent-lifecycle.md` documents Ready to review as an annotation independent of lifecycle state, plus its dismissal rules.
