### PR TITLE
Keep terminal output live after returning to Paseo

### DIFF
--- a/packages/app/e2e/browser/terminal-stuck-size.spec.ts
+++ b/packages/app/e2e/browser/terminal-stuck-size.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from "../support/fixtures";
-import { TerminalE2EHarness } from "../support/helpers/terminal-dsl";
+import { TerminalE2EHarness, withTerminalInApp } from "../support/helpers/terminal-dsl";
+import { getTerminalBufferText } from "../support/helpers/terminal-perf";
 import { buildHostWorkspaceRoute } from "../../src/utils/host-routes";
 import { getServerId } from "../support/helpers/server-id";
 
@@ -97,6 +98,15 @@ async function captureTerminalText(
   return capture.lines.join("\n");
 }
 
+async function waitForTerminalMarker(page: Page, marker: string): Promise<void> {
+  await expect
+    .poll(() => getTerminalBufferText(page), {
+      message: "terminal stream should deliver PTY output after focus returns",
+      timeout: 10_000,
+    })
+    .toContain(marker);
+}
+
 test.describe("terminal PTY size claim under lost window focus", () => {
   let harness: TerminalE2EHarness;
 
@@ -173,5 +183,23 @@ test.describe("terminal PTY size claim under lost window focus", () => {
         { timeout: 15_000, intervals: [100, 250, 500] },
       )
       .toEqual({ rows: rendered.rows, cols: rendered.cols });
+  });
+
+  test("terminal output remains subscribed after window focus returns", async ({ page }) => {
+    await withTerminalInApp(page, harness, { name: "focus-return-output" }, async (terminal) => {
+      const marker = `OUTPUT_AFTER_FOCUS_${Date.now()}`;
+
+      await setWindowFocused(page, false);
+      await page.waitForTimeout(50);
+      await setWindowFocused(page, true);
+      await page.waitForTimeout(50);
+
+      harness.client.sendTerminalInput(terminal.id, {
+        type: "input",
+        data: `printf "\\n${marker}\\n"\n`,
+      });
+
+      await waitForTerminalMarker(page, marker);
+    });
   });
 });

--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -7,6 +7,7 @@ import Animated, { runOnJS, useAnimatedReaction } from "react-native-reanimated"
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { Keyboard as KeyboardIcon, KeyboardOff as KeyboardOffIcon } from "lucide-react-native";
 import type { TerminalKeyInput } from "@getpaseo/protocol/terminal-key-input";
+import type { TerminalState } from "@getpaseo/protocol/messages";
 import {
   DEFAULT_TERMINAL_INPUT_MODE_STATE,
   type TerminalInputModeState,
@@ -484,6 +485,66 @@ export function TerminalPane({
     setStreamError(status.error);
   }, []);
 
+  const getPreferredStreamSize = useStableEvent(() => {
+    if (
+      !canRequestFocusClaim({
+        isWorkspaceFocused: terminalActiveRef.current,
+        isPaneFocused,
+        isAppActivelyVisible,
+        isClientReady: client !== null,
+        isConnected,
+        isRendererReady: rendererReadyStreamKey === terminalStreamKey,
+      })
+    ) {
+      return null;
+    }
+    return measuredTerminalSizeRef.current;
+  });
+
+  const handleStreamOutput = useStableEvent(
+    ({ terminalId: outputTerminalId, data }: { terminalId: string; data: Uint8Array }) => {
+      if (!terminalActiveRef.current || terminalIdRef.current !== outputTerminalId) {
+        return;
+      }
+      emulatorRef.current?.writeOutput(data);
+    },
+  );
+
+  const handleStreamRestore = useStableEvent(
+    ({ terminalId: restoreTerminalId, data }: { terminalId: string; data: Uint8Array }) => {
+      workspaceTerminalSession.snapshots.clear({ terminalId: restoreTerminalId });
+      if (!terminalActiveRef.current || terminalIdRef.current !== restoreTerminalId) {
+        return;
+      }
+      emulatorRef.current?.restoreOutput(data);
+    },
+  );
+
+  const handleStreamSnapshot = useStableEvent(
+    ({ terminalId: snapshotTerminalId, state }: { terminalId: string; state: TerminalState }) => {
+      workspaceTerminalSession.snapshots.set({ terminalId: snapshotTerminalId, state });
+      if (!terminalActiveRef.current || terminalIdRef.current !== snapshotTerminalId) {
+        return;
+      }
+      emulatorRef.current?.renderSnapshot(state);
+    },
+  );
+
+  const getStreamRestoreOptions = useStableEvent(() =>
+    resolveTerminalRestoreOptions({
+      supportsTerminalRestoreModes,
+      canClaimSize: canRequestFocusClaim({
+        isWorkspaceFocused: terminalActiveRef.current,
+        isPaneFocused,
+        isAppActivelyVisible,
+        isClientReady: client !== null,
+        isConnected,
+        isRendererReady: rendererReadyStreamKey === terminalStreamKey,
+      }),
+      size: measuredTerminalSizeRef.current,
+    }),
+  );
+
   useEffect(() => {
     streamControllerRef.current?.dispose();
     streamControllerRef.current = null;
@@ -496,55 +557,11 @@ export function TerminalPane({
 
     const controller = new TerminalStreamController({
       client,
-      getPreferredSize: () => {
-        if (
-          !canRequestFocusClaim({
-            isWorkspaceFocused: terminalActiveRef.current,
-            isPaneFocused,
-            isAppActivelyVisible,
-            isClientReady: client !== null,
-            isConnected,
-            isRendererReady: rendererReadyStreamKey === terminalStreamKey,
-          })
-        ) {
-          return null;
-        }
-        return measuredTerminalSizeRef.current;
-      },
-      onOutput: ({ terminalId: outputTerminalId, data }) => {
-        if (!terminalActiveRef.current || terminalIdRef.current !== outputTerminalId) {
-          return;
-        }
-        emulatorRef.current?.writeOutput(data);
-      },
-      onRestore: ({ terminalId: restoreTerminalId, data }) => {
-        workspaceTerminalSession.snapshots.clear({ terminalId: restoreTerminalId });
-        if (!terminalActiveRef.current || terminalIdRef.current !== restoreTerminalId) {
-          return;
-        }
-        emulatorRef.current?.restoreOutput(data);
-      },
-      onSnapshot: ({ terminalId: snapshotTerminalId, state }) => {
-        workspaceTerminalSession.snapshots.set({ terminalId: snapshotTerminalId, state });
-        if (!terminalActiveRef.current || terminalIdRef.current !== snapshotTerminalId) {
-          return;
-        }
-        emulatorRef.current?.renderSnapshot(state);
-      },
-      getRestoreOptions: () => {
-        return resolveTerminalRestoreOptions({
-          supportsTerminalRestoreModes,
-          canClaimSize: canRequestFocusClaim({
-            isWorkspaceFocused: terminalActiveRef.current,
-            isPaneFocused,
-            isAppActivelyVisible,
-            isClientReady: client !== null,
-            isConnected,
-            isRendererReady: rendererReadyStreamKey === terminalStreamKey,
-          }),
-          size: measuredTerminalSizeRef.current,
-        });
-      },
+      getPreferredSize: getPreferredStreamSize,
+      onOutput: handleStreamOutput,
+      onRestore: handleStreamRestore,
+      onSnapshot: handleStreamSnapshot,
+      getRestoreOptions: getStreamRestoreOptions,
       onStatusChange: handleStreamControllerStatus,
     });
 
@@ -558,14 +575,13 @@ export function TerminalPane({
     };
   }, [
     client,
+    getPreferredStreamSize,
+    getStreamRestoreOptions,
     handleStreamControllerStatus,
+    handleStreamOutput,
+    handleStreamRestore,
+    handleStreamSnapshot,
     isConnected,
-    isAppActivelyVisible,
-    isPaneFocused,
-    rendererReadyStreamKey,
-    supportsTerminalRestoreModes,
-    terminalStreamKey,
-    workspaceTerminalSession.snapshots,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Docs

### Reasoning

Returning to Paseo after switching applications or browser tabs could leave an active terminal accepting input while no longer displaying PTY output. Renderer-readiness work had made live focus and renderer values dependencies of the stream-controller effect, so a focus transition disposed the subscribed controller and created an untargeted replacement.

Keep the stream controller scoped to the client connection. Stable event callbacks provide current focus, renderer, sizing, and snapshot state without rebuilding the controller; the dedicated target effect remains responsible for subscribing and unsubscribing terminals.

### Goals

- Keep active terminal output flowing after window or tab focus changes.
- Avoid controller teardown and stream subscription churn for live UI state changes.
- Preserve renderer-readiness stream isolation and terminal-size ownership behavior.
- Cover the focus-return output path with a real daemon, WebSocket, PTY, and xterm browser test.

### Non-goals

- Change terminal rendering, PTY backpressure, or size-ownership semantics.
- Change native terminal input or selection behavior.

### QA

- Reproduced in macOS Electron: after switching away and returning, input reached the PTY but terminal output stopped updating.
- Captured the frozen renderer through DevTools: input count advanced while output delivery and parsing counters remained unchanged.
- After the fix, repeated the Electron focus cycle and confirmed each input was followed by output delivery, xterm parsing, and rendering.
- Added and ran: npm --prefix packages/app run test:e2e -- terminal-stuck-size.spec.ts -g "terminal output remains subscribed" — 1 passed.
- Ran npm run typecheck — passed across all workspaces.
- Ran npm run lint — 0 warnings and 0 errors.
- Ran npm run format — passed.
- Tested: macOS Electron and automated Chromium web. Not manually tested on native iOS or Android; the changed controller lifecycle is shared, while the regression is web focus-specific.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [x] Tests added or updated where it made sense