### PR TITLE
fix(app): clarify Auto Accept toolbar tooltip with On/Off state

### DIFF
--- a/packages/app/src/agent-controls/policy.ts
+++ b/packages/app/src/agent-controls/policy.ts
@@ -2,6 +2,7 @@ import type { AgentMode } from "@getpaseo/protocol/agent-types";
 
 export const PLAN_MODE_FEATURE_ID = "plan_mode";
 export const FAST_MODE_FEATURE_ID = "fast_mode";
+export const AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 
 export function isPlanningAgentMode(mode: Pick<AgentMode, "id" | "colorTier">): boolean {
   return mode.colorTier === "planning" || mode.id === "plan" || mode.id.endsWith("#plan");

--- a/packages/app/src/composer/agent-controls/utils.test.ts
+++ b/packages/app/src/composer/agent-controls/utils.test.ts
@@ -19,6 +19,7 @@ describe("feature metadata helpers", () => {
   it("prefers explicit feature tooltip copy", () => {
     expect(
       getFeatureTooltip({
+        id: "plan_mode",
         label: "Plan",
         tooltip: "Toggle plan mode",
       }),
@@ -28,13 +29,37 @@ describe("feature metadata helpers", () => {
   it("falls back to the feature label when no tooltip is provided", () => {
     expect(
       getFeatureTooltip({
+        id: "custom",
         label: "Custom",
       }),
     ).toBe("Custom");
   });
 
+  it("builds a stateful Auto Accept tooltip when the toggle is off", () => {
+    expect(
+      getFeatureTooltip({
+        id: "auto_accept",
+        label: "Auto Accept",
+        tooltip: "Auto accept permission prompts",
+        value: false,
+      }),
+    ).toBe("Auto Accept: Off — click to auto-approve permission prompts");
+  });
+
+  it("builds a stateful Auto Accept tooltip when the toggle is on", () => {
+    expect(
+      getFeatureTooltip({
+        id: "auto_accept",
+        label: "Auto Accept",
+        tooltip: "Auto accept permission prompts",
+        value: true,
+      }),
+    ).toBe("Auto Accept: On — permission prompts are auto-approved");
+  });
+
   it("maps feature highlight colors by feature id", () => {
     expect(getFeatureHighlightColor("fast_mode")).toBe("yellow");
+    expect(getFeatureHighlightColor("auto_accept")).toBe("green");
     expect(getFeatureHighlightColor("plan_mode")).toBe("blue");
     expect(getFeatureHighlightColor("other")).toBe("default");
   });

--- a/packages/app/src/composer/agent-controls/utils.ts
+++ b/packages/app/src/composer/agent-controls/utils.ts
@@ -1,7 +1,11 @@
 import type { AgentFeature, AgentModelDefinition } from "@getpaseo/protocol/agent-types";
 import { i18n } from "@/i18n/i18next";
 import { formatThinkingOptionLabel } from "@/agent-controls/labels";
-import { FAST_MODE_FEATURE_ID, PLAN_MODE_FEATURE_ID } from "@/agent-controls/policy";
+import {
+  AUTO_ACCEPT_FEATURE_ID,
+  FAST_MODE_FEATURE_ID,
+  PLAN_MODE_FEATURE_ID,
+} from "@/agent-controls/policy";
 
 export type ExplainedAgentControl = "mode" | "model" | "thinking";
 export type FeatureHighlightColor = "blue" | "default" | "green" | "yellow";
@@ -31,7 +35,14 @@ export function normalizeModelId(modelId: string | null | undefined): string | n
   return normalized;
 }
 
-export function getFeatureTooltip(feature: Pick<AgentFeature, "label" | "tooltip">): string {
+export function getFeatureTooltip(
+  feature: Pick<AgentFeature, "id" | "label" | "tooltip"> & { value?: unknown },
+): string {
+  if (feature.id === AUTO_ACCEPT_FEATURE_ID && typeof feature.value === "boolean") {
+    return feature.value
+      ? i18n.t("agentControls.features.autoAccept.tooltipOn")
+      : i18n.t("agentControls.features.autoAccept.tooltipOff");
+  }
   return feature.tooltip ?? feature.label;
 }
 
@@ -39,7 +50,7 @@ export function getFeatureHighlightColor(featureId: string): FeatureHighlightCol
   switch (featureId) {
     case FAST_MODE_FEATURE_ID:
       return "yellow";
-    case "auto_accept":
+    case AUTO_ACCEPT_FEATURE_ID:
       return "green";
     case PLAN_MODE_FEATURE_ID:
       return "blue";

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -216,6 +216,12 @@ describe("translation resources", () => {
     expect(en.agentControls.hints.model).toBe("Change model");
     expect(en.agentControls.hints.mode).toBe("Change mode");
     expect(en.agentControls.features.title).toBe("Features");
+    expect(en.agentControls.features.autoAccept.tooltipOn).toBe(
+      "Auto Accept: On — permission prompts are auto-approved",
+    );
+    expect(en.agentControls.features.autoAccept.tooltipOff).toBe(
+      "Auto Accept: Off — click to auto-approve permission prompts",
+    );
     expect(en.agentControls.mode.title).toBe("Mode");
     expect(en.agentStream.permission.required).toBe("Permission Required");
     expect(en.agentStream.permission.proposedPlan).toBe("Proposed plan");

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -175,6 +175,10 @@ export const ar: TranslationResources = {
       open: "ميزات الوكيل المفتوح",
       on: "على",
       off: "عن",
+      autoAccept: {
+        tooltipOn: "Auto Accept: تشغيل — تتم الموافقة تلقائيًا على طلبات الأذونات",
+        tooltipOff: "Auto Accept: إيقاف — انقر للموافقة تلقائيًا على طلبات الأذونات",
+      },
     },
     mode: {
       title: "وضع",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -173,6 +173,10 @@ export const en = {
       open: "Open agent features",
       on: "On",
       off: "Off",
+      autoAccept: {
+        tooltipOn: "Auto Accept: On — permission prompts are auto-approved",
+        tooltipOff: "Auto Accept: Off — click to auto-approve permission prompts",
+      },
     },
     mode: {
       title: "Mode",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -175,6 +175,11 @@ export const es: TranslationResources = {
       open: "Funciones de agente abierto",
       on: "En",
       off: "Apagado",
+      autoAccept: {
+        tooltipOn: "Auto Accept: Activado — los avisos de permiso se aprueban automáticamente",
+        tooltipOff:
+          "Auto Accept: Desactivado — haz clic para aprobar automáticamente los avisos de permiso",
+      },
     },
     mode: {
       title: "Modo",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -177,6 +177,12 @@ export const fr: TranslationResources = {
       open: "Fonctionnalités de l'agent ouvert",
       on: "Sur",
       off: "Désactivé",
+      autoAccept: {
+        tooltipOn:
+          "Auto Accept : Activé — les demandes de permission sont approuvées automatiquement",
+        tooltipOff:
+          "Auto Accept : Désactivé — cliquez pour approuver automatiquement les demandes de permission",
+      },
     },
     mode: {
       title: "Mode",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -175,6 +175,10 @@ export const ja: TranslationResources = {
       open: "エージェント機能を開く",
       on: "オン",
       off: "オフ",
+      autoAccept: {
+        tooltipOn: "Auto Accept: オン — 権限プロンプトは自動承認されます",
+        tooltipOff: "Auto Accept: オフ — クリックすると権限プロンプトを自動承認します",
+      },
     },
     mode: {
       title: "モード",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -175,6 +175,11 @@ export const ptBR: TranslationResources = {
       open: "Abrir recursos do agente",
       on: "Ativado",
       off: "Desativado",
+      autoAccept: {
+        tooltipOn: "Auto Accept: Ativado — os prompts de permissão são aprovados automaticamente",
+        tooltipOff:
+          "Auto Accept: Desativado — clique para aprovar automaticamente os prompts de permissão",
+      },
     },
     mode: {
       title: "Modo",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -175,6 +175,10 @@ export const ru: TranslationResources = {
       open: "Открытые возможности агента",
       on: "На",
       off: "Выключенный",
+      autoAccept: {
+        tooltipOn: "Auto Accept: Вкл — запросы разрешений одобряются автоматически",
+        tooltipOff: "Auto Accept: Выкл — нажмите, чтобы автоматически одобрять запросы разрешений",
+      },
     },
     mode: {
       title: "Режим",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -175,6 +175,10 @@ export const zhCN: TranslationResources = {
       open: "打开 Agent features",
       on: "开启",
       off: "关闭",
+      autoAccept: {
+        tooltipOn: "Auto Accept：开启 — 权限提示会自动批准",
+        tooltipOff: "Auto Accept：关闭 — 点击以自动批准权限提示",
+      },
     },
     mode: {
       title: "Mode",


### PR DESCRIPTION
## Summary
- Auto Accept was only a green/gray icon with a static tooltip (`Auto accept permission prompts`), so users could not tell what it does or whether it was on — especially painful for Cursor ACP, which relies on this shared toggle.
- The desktop tooltip and accessibility label now include On/Off state via client-side i18n, e.g. `Auto Accept: Off — click to auto-approve permission prompts` / `Auto Accept: On — permission prompts are auto-approved`.
- Feature sheet On/Off wording stays as-is; no runtime permission-behavior changes.

## Before / after (tooltip)
- **Before:** `Auto accept permission prompts` (same whether on or off)
- **After (off):** `Auto Accept: Off — click to auto-approve permission prompts`
- **After (on):** `Auto Accept: On — permission prompts are auto-approved`

## Test plan
- [ ] Hover Auto Accept on desktop when off → tooltip shows Off + click-to-enable copy
- [ ] Enable Auto Accept → tooltip shows On + auto-approved copy; icon stays green
- [ ] Disable again → tooltip returns to Off copy; icon muted
- [ ] Confirm accessibility label includes On/Off (screen reader / a11y inspector)
- [ ] Confirm features sheet still shows On/Off next to the toggle
- [x] Unit tests: `packages/app/src/composer/agent-controls/utils.test.ts` and i18n resource keys
