### PR TITLE
Prevent ignored workspace data from stalling suggestions

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -3898,6 +3898,7 @@ export class Session {
           ? WORKSPACE_SEARCH_HIDDEN_DIRECTORIES
           : [],
         confidentResultScanThreshold: searchesWorkspace ? undefined : 5_000,
+        respectGitIgnore: searchesWorkspace,
         includeFiles,
         includeDirectories,
         matchMode,

--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
   mkdtempSync,
   mkdirSync,
@@ -11,6 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isPlatform } from "../test-utils/platform.js";
+import { startGitCommandMetrics, stopGitCommandMetrics } from "./run-git-command.js";
 import {
   searchDirectoryEntries,
   WORKSPACE_SEARCH_HIDDEN_DIRECTORIES,
@@ -115,6 +117,49 @@ describe("searchDirectoryEntries", () => {
         },
       ],
     });
+  });
+
+  it("prunes directories ignored by Git and caches concurrent lookups", async () => {
+    execFileSync("git", ["init", "-q"], { cwd: searchRoot });
+    writeFileSync(path.join(searchRoot, ".gitignore"), "data/\n");
+    mkdirSync(path.join(searchRoot, "data", "matching-ignored-directory"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(searchRoot, "visible", "matching-visible-directory"), {
+      recursive: true,
+    });
+
+    startGitCommandMetrics();
+    const results = await Promise.all([
+      searchDirectoryEntries({
+        root: searchRoot,
+        query: "matching",
+        pathFormat: "relative",
+        includeFiles: false,
+        includeDirectories: true,
+        respectGitIgnore: true,
+      }),
+      searchDirectoryEntries({
+        root: searchRoot,
+        query: "visible",
+        pathFormat: "relative",
+        includeFiles: false,
+        includeDirectories: true,
+        respectGitIgnore: true,
+      }),
+    ]);
+    const gitMetrics = stopGitCommandMetrics();
+
+    expect(results).toEqual([
+      [{ path: "visible/matching-visible-directory", kind: "directory" }],
+      [
+        { path: "visible", kind: "directory" },
+        { path: "visible/matching-visible-directory", kind: "directory" },
+      ],
+    ]);
+    expect(gitMetrics.commands.filter((command) => command.args.includes("ls-files"))).toHaveLength(
+      1,
+    );
   });
 
   it("configures raw blank queries independently from explicit root aliases", async () => {

--- a/packages/server/src/utils/directory-suggestions.ts
+++ b/packages/server/src/utils/directory-suggestions.ts
@@ -2,6 +2,7 @@ import type { Dirent, Stats } from "node:fs";
 import { readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { isPathInsideRoot } from "./path.js";
+import { runGitCommand } from "./run-git-command.js";
 
 export type DirectorySuggestionKind = "file" | "directory";
 export type DirectorySuggestionPathFormat = "absolute" | "relative";
@@ -29,6 +30,7 @@ export interface SearchDirectoryEntriesOptions {
   maxDepth?: number;
   maxEntriesScanned?: number;
   confidentResultScanThreshold?: number;
+  respectGitIgnore?: boolean;
 }
 
 interface QueryPlan {
@@ -70,12 +72,19 @@ interface DirectoryListCacheEntry {
   entries: RawChildEntry[];
 }
 
+interface GitIgnoredPathsCacheEntry {
+  expiresAt: number;
+  paths: Promise<Set<string>>;
+}
+
 const DEFAULT_LIMIT = 30;
 const MAX_LIMIT = 100;
 const DEFAULT_MAX_DEPTH = 12;
 const DEFAULT_MAX_ENTRIES_SCANNED = 20_000;
 const DIRECTORY_LIST_CACHE_TTL_MS = 8_000;
 const DIRECTORY_LIST_CACHE_MAX_ENTRIES = 4_000;
+const GIT_IGNORED_PATHS_CACHE_TTL_MS = 8_000;
+const GIT_IGNORED_PATHS_CACHE_MAX_ENTRIES = 256;
 // Windows does not reliably update directory mtime/ctime when children change,
 // so metadata cannot safely validate a cross-request listing cache there.
 const CAN_VALIDATE_DIRECTORY_CACHE_FROM_METADATA = process.platform !== "win32";
@@ -108,6 +117,7 @@ const IGNORED_DIRECTORY_NAMES = new Set([
   ".git",
 ]);
 const directoryListCache = new Map<string, DirectoryListCacheEntry>();
+const gitIgnoredPathsCache = new Map<string, GitIgnoredPathsCacheEntry>();
 
 export async function searchDirectoryEntries(
   options: SearchDirectoryEntriesOptions,
@@ -115,7 +125,10 @@ export async function searchDirectoryEntries(
   const root = await resolveDirectory(options.root);
   if (!root) return [];
 
-  const input = buildSearchInput(options, root);
+  const gitIgnoredPaths = options.respectGitIgnore
+    ? await loadGitIgnoredPaths(root)
+    : new Set<string>();
+  const input = buildSearchInput(options, root, gitIgnoredPaths);
   if (!input) return [];
 
   const exact =
@@ -138,6 +151,7 @@ export async function searchDirectoryEntries(
 function buildSearchInput(
   options: SearchDirectoryEntriesOptions,
   root: string,
+  gitIgnoredPaths: Set<string>,
 ): SearchInput | null {
   const includeDirectories = options.includeDirectories ?? true;
   const includeFiles = options.includeFiles ?? false;
@@ -165,6 +179,7 @@ function buildSearchInput(
     maxDepth: options.maxDepth ?? DEFAULT_MAX_DEPTH,
     maxEntriesScanned: options.maxEntriesScanned ?? DEFAULT_MAX_ENTRIES_SCANNED,
     confidentResultScanThreshold: options.confidentResultScanThreshold,
+    gitIgnoredPaths,
   };
 }
 
@@ -173,6 +188,7 @@ async function findExactEntry(input: SearchInput): Promise<DirectorySuggestionEn
   const visiblePath = path.resolve(input.root, input.plan.normalizedQuery);
   const resolvedPath = await realpath(visiblePath).catch(() => null);
   if (!resolvedPath || !isPathInsideRoot(input.root, resolvedPath)) return null;
+  if (isGitIgnoredPath(resolvedPath, input)) return null;
   const info = await stat(resolvedPath).catch(() => null);
   const kind = getEntryKind(info);
   if (
@@ -196,12 +212,14 @@ interface SearchInput {
   maxDepth: number;
   maxEntriesScanned: number;
   confidentResultScanThreshold: number | undefined;
+  gitIgnoredPaths: Set<string>;
 }
 
 async function searchChildren(input: SearchInput): Promise<RankedEntry[]> {
   const visibleParent = path.resolve(input.root, input.plan.parentPart || ".");
   const parent = await realpath(visibleParent).catch(() => null);
   if (!parent || !isPathInsideRoot(input.root, parent)) return [];
+  if (isGitIgnoredPath(parent, input)) return [];
   const entries = await readChildren(parent);
   return entries.flatMap((entry) => {
     if (!isPathInsideRoot(input.root, entry.resolvedPath) || !shouldDiscover(entry, input))
@@ -297,12 +315,22 @@ async function* roundRobin<T>(branches: Array<AsyncGenerator<T>>): AsyncGenerato
 }
 
 function shouldDiscover(entry: ChildEntry, input: SearchInput): boolean {
+  if (isGitIgnoredPath(entry.resolvedPath, input)) return false;
   if (entry.kind === "file") {
     return input.includeFiles && !entry.name.startsWith(".");
   }
   if (IGNORED_DIRECTORY_NAMES.has(entry.name)) return false;
   if (!entry.name.startsWith(".")) return true;
   return input.hiddenDirectoryNames.has(entry.name);
+}
+
+function isGitIgnoredPath(absolutePath: string, input: SearchInput): boolean {
+  let candidate = absolutePath;
+  while (candidate !== input.root && isPathInsideRoot(input.root, candidate)) {
+    if (input.gitIgnoredPaths.has(candidate)) return true;
+    candidate = path.dirname(candidate);
+  }
+  return false;
 }
 
 function shouldSuggest(entry: TraversedEntry, input: SearchInput): boolean {
@@ -538,6 +566,47 @@ async function readChildren(directory: string): Promise<ChildEntry[]> {
   return (await Promise.all(rawEntries.map((entry) => resolveChild(directory, entry))))
     .filter((entry): entry is ChildEntry => entry !== null)
     .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function loadGitIgnoredPaths(root: string): Promise<Set<string>> {
+  const now = Date.now();
+  const cached = gitIgnoredPathsCache.get(root);
+  if (cached && cached.expiresAt > now) return cached.paths;
+
+  const paths = runGitCommand(["ls-files", "-o", "-i", "--directory", "--exclude-standard", "-z"], {
+    cwd: root,
+    envOverlay: { GIT_OPTIONAL_LOCKS: "0" },
+    timeout: 10_000,
+  })
+    .then(
+      (result) =>
+        new Set(
+          result.stdout
+            .split("\0")
+            .filter(Boolean)
+            .map((relativePath) => path.resolve(root, relativePath.replace(/\/$/, ""))),
+        ),
+    )
+    .catch(() => new Set<string>());
+
+  gitIgnoredPathsCache.set(root, {
+    expiresAt: now + GIT_IGNORED_PATHS_CACHE_TTL_MS,
+    paths,
+  });
+  pruneGitIgnoredPathsCache(now);
+  return paths;
+}
+
+function pruneGitIgnoredPathsCache(now: number): void {
+  if (gitIgnoredPathsCache.size <= GIT_IGNORED_PATHS_CACHE_MAX_ENTRIES) return;
+  for (const [key, entry] of gitIgnoredPathsCache) {
+    if (entry.expiresAt <= now) gitIgnoredPathsCache.delete(key);
+  }
+  while (gitIgnoredPathsCache.size > GIT_IGNORED_PATHS_CACHE_MAX_ENTRIES) {
+    const key = gitIgnoredPathsCache.keys().next().value;
+    if (!key) return;
+    gitIgnoredPathsCache.delete(key);
+  }
 }
 
 function toRawChildEntry(dirent: Dirent): RawChildEntry | null {


### PR DESCRIPTION
### Linked issue

No linked issue; reproduced from a user report.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Workspace file suggestions traversed Git-ignored directories because the search used only a fixed list of skipped directory names. Large generated-data trees could therefore consume enough CPU and memory to make the daemon unresponsive when a client requested suggestions.

Workspace searches now ask Git for ignored paths with `git ls-files -o -i --directory --exclude-standard`, cache the result per workspace, and prune ignored paths before traversal expands them. Concurrent suggestion requests share the same in-flight Git lookup.

### Goals

- Exclude Git-ignored files and directories from workspace suggestions.
- Prune ignored directories before creating traversal branches.
- Avoid repeated Git processes while autocomplete requests overlap.
- Cover pruning and in-flight cache reuse with an automated test.

### Non-goals

- Redesign the directory traversal or its breadth-first frontier.
- Change home-directory browsing outside a workspace.
- Add a separate gitignore parser.

### QA

- Ran `npx vitest run packages/server/src/utils/directory-suggestions.test.ts --bail=1`: 29 tests passed.
- Ran `npm run typecheck` through the commit hook: every workspace passed.
- Ran `npm run lint` through the commit hook: zero warnings and errors.
- Ran `npm run format`; the commit hook confirmed all changed files are formatted.
- The new test initializes a real Git repository, ignores a generated-data directory, confirms it is absent from suggestions, confirms a visible directory remains searchable, and confirms concurrent searches issue one Git lookup.
- Tested on macOS. The original Linux large-tree environment was not available locally; CI should cover Linux path handling.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense