### PR TITLE
Fix context usage for Anthropic-compatible providers

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -2182,6 +2182,84 @@ describe("ClaudeAgentSession context window usage", () => {
     }
   });
 
+  test("assistant usage corrects incomplete Anthropic-compatible stream usage", async () => {
+    const session = await createSessionForTurns(
+      [
+        [
+          createInitMessage(),
+          createMessageStartEvent({
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          }),
+          createMessageDeltaEvent(799),
+          {
+            type: "assistant",
+            parent_tool_use_id: null,
+            message: {
+              id: "assistant-compatible-provider-1",
+              role: "assistant",
+              content: [{ type: "text", text: "Continuing with a tool call." }],
+              usage: {
+                input_tokens: 1_514,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 178_752,
+                output_tokens: 799,
+              },
+            },
+            uuid: "assistant-compatible-provider-event-1",
+            session_id: "session-1",
+          },
+          createSuccessResult({
+            usage: {
+              input_tokens: 1_514,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 178_752,
+              output_tokens: 799,
+              iterations: [],
+            },
+            modelUsage: {
+              "glm-5.2": { contextWindow: 1_000_000 },
+            },
+          }),
+        ],
+      ],
+      { model: "claude-sonnet-5[1m]" },
+    );
+
+    try {
+      const events = await collectStreamEvents(session);
+
+      expect(
+        events.some(
+          (event) => event.type === "usage_updated" && event.usage.contextWindowUsedTokens === 799,
+        ),
+      ).toBe(false);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "usage_updated",
+          provider: "claude",
+          usage: {
+            contextWindowMaxTokens: 1_000_000,
+            contextWindowUsedTokens: 181_065,
+          },
+        }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "turn_completed",
+          provider: "claude",
+          usage: expect.objectContaining({
+            contextWindowMaxTokens: 1_000_000,
+            contextWindowUsedTokens: 181_065,
+          }),
+        }),
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
   test("per-request stream usage is not cumulative across API calls in a turn", async () => {
     const session = await createSessionForTurns([
       [

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -1733,38 +1733,46 @@ function extractContextWindowSize(modelUsage: unknown): number | undefined {
   return maxContextWindow;
 }
 
-function readStreamRequestInputTokens(event: Record<string, unknown>): number | undefined {
-  const messageUsage = toObjectRecord(toObjectRecord(event.message)?.usage);
-  if (!messageUsage) {
+function readRequestInputTokens(usage: unknown): number | undefined {
+  const usageRecord = toObjectRecord(usage);
+  if (!usageRecord) {
     return undefined;
   }
-  const usage = messageUsage;
   const inputTokens =
-    typeof usage.input_tokens === "number" && Number.isFinite(usage.input_tokens)
-      ? usage.input_tokens
+    typeof usageRecord.input_tokens === "number" && Number.isFinite(usageRecord.input_tokens)
+      ? usageRecord.input_tokens
       : undefined;
   const cacheCreationInputTokens =
-    typeof usage.cache_creation_input_tokens === "number" &&
-    Number.isFinite(usage.cache_creation_input_tokens)
-      ? usage.cache_creation_input_tokens
+    typeof usageRecord.cache_creation_input_tokens === "number" &&
+    Number.isFinite(usageRecord.cache_creation_input_tokens)
+      ? usageRecord.cache_creation_input_tokens
       : 0;
   const cacheReadInputTokens =
-    typeof usage.cache_read_input_tokens === "number" &&
-    Number.isFinite(usage.cache_read_input_tokens)
-      ? usage.cache_read_input_tokens
+    typeof usageRecord.cache_read_input_tokens === "number" &&
+    Number.isFinite(usageRecord.cache_read_input_tokens)
+      ? usageRecord.cache_read_input_tokens
       : 0;
   if (typeof inputTokens !== "number" || inputTokens < 0) {
     return undefined;
   }
-  return inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
+  const total = inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
+  return total > 0 ? total : undefined;
 }
 
-function readStreamRequestOutputTokens(event: Record<string, unknown>): number | undefined {
-  const outputTokens = toObjectRecord(event.usage)?.output_tokens;
+function readStreamRequestInputTokens(event: Record<string, unknown>): number | undefined {
+  return readRequestInputTokens(toObjectRecord(event.message)?.usage);
+}
+
+function readRequestOutputTokens(usage: unknown): number | undefined {
+  const outputTokens = toObjectRecord(usage)?.output_tokens;
   if (typeof outputTokens !== "number" || !Number.isFinite(outputTokens) || outputTokens < 0) {
     return undefined;
   }
   return outputTokens;
+}
+
+function readStreamRequestOutputTokens(event: Record<string, unknown>): number | undefined {
+  return readRequestOutputTokens(event.usage);
 }
 
 function readLastUsageIteration(usage: unknown): Record<string, unknown> | undefined {
@@ -1866,11 +1874,11 @@ class ClaudeContextUsageState {
     const eventType = readTrimmedString(streamEvent.type);
     if (eventType === "message_start") {
       const inputTokens = readStreamRequestInputTokens(streamEvent);
+      this.streamRequestInputTokens = inputTokens;
+      this.streamRequestOutputTokens = inputTokens === undefined ? undefined : 0;
       if (typeof inputTokens !== "number") {
         return null;
       }
-      this.streamRequestInputTokens = inputTokens;
-      this.streamRequestOutputTokens = 0;
     } else if (eventType === "message_delta") {
       const outputTokens = readStreamRequestOutputTokens(streamEvent);
       if (typeof outputTokens !== "number") {
@@ -1883,6 +1891,25 @@ class ClaudeContextUsageState {
 
     const usedTokens = this.streamUsedTokens();
     if (usedTokens === undefined) {
+      return null;
+    }
+    return this.createUsageUpdatedEvent(usedTokens);
+  }
+
+  buildAssistantUsageEvent(usage: unknown): AgentStreamEvent | null {
+    // Anthropic-compatible gateways can zero the message_start usage while keeping the completed
+    // assistant frame accurate. Reconcile from that per-request frame before the result aggregate.
+    const inputTokens = readRequestInputTokens(usage);
+    const outputTokens = readRequestOutputTokens(usage);
+    if (inputTokens === undefined || outputTokens === undefined) {
+      return null;
+    }
+
+    const previousUsedTokens = this.streamUsedTokens();
+    this.streamRequestInputTokens = inputTokens;
+    this.streamRequestOutputTokens = outputTokens;
+    const usedTokens = this.streamUsedTokens();
+    if (usedTokens === undefined || usedTokens === previousUsedTokens) {
       return null;
     }
     return this.createUsageUpdatedEvent(usedTokens);
@@ -3782,6 +3809,10 @@ class ClaudeAgentSession implements AgentSession {
         this.appendSidechainResultEvents(message, events);
         break;
       case "assistant": {
+        const usageUpdatedEvent = this.contextUsage.buildAssistantUsageEvent(message.message.usage);
+        if (usageUpdatedEvent) {
+          events.push(usageUpdatedEvent);
+        }
         const timelineItems = this.mapBlocksToTimeline(message.message.content, {
           suppressAssistantText: options?.suppressAssistantText ?? false,
           suppressReasoning: options?.suppressReasoning ?? false,


### PR DESCRIPTION
## Summary

- Treat zero-token `message_start` usage as incomplete so output deltas cannot replace the context meter with an output-only value.
- Reconcile each parent assistant frame’s per-request input, cache-read, cache-creation, and output usage into live and completed context usage.
- Keep subagent usage excluded through the existing parent-frame routing.

## Root cause

Some Anthropic-compatible gateways emit a zeroed `message_start` usage object, then publish accurate usage on the completed assistant frame. Paseo accepted the zero input as authoritative, added the later output delta, and displayed only that output count (for example, `799 / 1m`). It did not read the accurate assistant-frame usage, even though that frame contained the full cached context.

## Validation

- `npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts --bail=1` (62 passed)
- `npm run typecheck`
- `npm run lint`
