### PR TITLE
fix(app): make the context meter tooltip openable on touch

### DIFF
--- a/packages/app/src/components/context-window-meter.tsx
+++ b/packages/app/src/components/context-window-meter.tsx
@@ -178,7 +178,10 @@ export function ContextWindowMeter({
         <Pressable
           style={containerStyle}
           testID="context-window-meter"
-          accessibilityRole="image"
+          // The visible ring is ~14px inside a 28px box; widen the tap target so
+          // the reveal is reachable by thumb on touch, where hover doesn't exist.
+          hitSlop={8}
+          accessibilityRole="button"
           accessibilityLabel={t("contextWindow.accessibility", {
             percentage: roundedPercentage,
           })}

--- a/packages/app/src/components/ui/tooltip.test.tsx
+++ b/packages/app/src/components/ui/tooltip.test.tsx
@@ -6,13 +6,19 @@ import { Pressable, Text } from "react-native";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Tooltip, TooltipTrigger } from "./tooltip";
 
+const platform = vi.hoisted(() => ({ isWeb: true, isNative: false, isCompact: false }));
+
 vi.mock("@/constants/platform", () => ({
-  isWeb: true,
-  isNative: false,
+  get isWeb() {
+    return platform.isWeb;
+  },
+  get isNative() {
+    return platform.isNative;
+  },
 }));
 
 vi.mock("@/constants/layout", () => ({
-  useIsCompactFormFactor: () => false,
+  useIsCompactFormFactor: () => platform.isCompact,
 }));
 
 vi.mock("@gorhom/portal", () => ({
@@ -41,6 +47,10 @@ let root: Root | null = null;
 let container: HTMLElement | null = null;
 
 beforeEach(() => {
+  platform.isWeb = true;
+  platform.isNative = false;
+  platform.isCompact = false;
+
   const dom = new JSDOM("<!doctype html><html><body></body></html>");
   vi.stubGlobal("React", React);
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
@@ -112,5 +122,76 @@ describe("TooltipTrigger", () => {
     pressTrigger();
 
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  function renderToggleTrigger(onOpenChange: (open: boolean) => void): void {
+    act(() => {
+      root?.render(
+        <Tooltip enabledOnMobile onOpenChange={onOpenChange}>
+          <TooltipTrigger asChild>
+            <Pressable testID="trigger">
+              <Text>Send</Text>
+            </Pressable>
+          </TooltipTrigger>
+        </Tooltip>,
+      );
+    });
+  }
+
+  it("toggles open on press in a compact (touch) context", () => {
+    platform.isCompact = true;
+    const onOpenChange = vi.fn();
+
+    renderToggleTrigger(onOpenChange);
+
+    pressTrigger();
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    pressTrigger();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("opens on press on native, where hover never fires", () => {
+    platform.isWeb = false;
+    platform.isNative = true;
+    const onOpenChange = vi.fn();
+
+    renderToggleTrigger(onOpenChange);
+
+    pressTrigger();
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    pressTrigger();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("toggles as a controlled tooltip (the context meter's shape)", () => {
+    platform.isCompact = true;
+    const renders: boolean[] = [];
+
+    function Controlled(): React.ReactElement {
+      const [open, setOpen] = React.useState(false);
+      renders.push(open);
+      return (
+        <Tooltip open={open} enabledOnMobile onOpenChange={setOpen}>
+          <TooltipTrigger asChild>
+            <Pressable testID="trigger">
+              <Text>Send</Text>
+            </Pressable>
+          </TooltipTrigger>
+        </Tooltip>
+      );
+    }
+
+    act(() => {
+      root?.render(<Controlled />);
+    });
+
+    pressTrigger();
+    pressTrigger();
+
+    // Routed the toggle through the parent's controlled state: opened, then closed.
+    expect(renders).toContain(true);
+    expect(renders[renders.length - 1]).toBe(false);
   });
 });

--- a/packages/app/src/components/ui/tooltip.tsx
+++ b/packages/app/src/components/ui/tooltip.tsx
@@ -28,7 +28,7 @@ import { FadeIn, FadeOut } from "react-native-reanimated";
 import { StyleSheet } from "react-native-unistyles";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { FloatingSurface } from "@/components/ui/floating";
-import { isWeb } from "@/constants/platform";
+import { isNative, isWeb } from "@/constants/platform";
 import { getOverlayRoot, OVERLAY_Z } from "@/lib/overlay-root";
 
 type Side = "top" | "bottom" | "left" | "right";
@@ -248,7 +248,12 @@ export function Tooltip({
   });
 
   const isCompact = useIsCompactFormFactor();
-  const enabled = isCompact ? enabledOnMobile : enabledOnDesktop;
+  // Native never fires hover, and a narrow web window is treated as touch. In both
+  // a press has to be able to open the tooltip, and the mobile enablement flag is
+  // the one that governs. Bucketing native with desktop is what left the tooltip
+  // unreachable on touch — no hover to open it, and press wired to close only.
+  const isTouchContext = isNative || isCompact;
+  const enabled = isTouchContext ? enabledOnMobile : enabledOnDesktop;
 
   const value = useMemo<TooltipContextValue>(
     () => ({
@@ -256,10 +261,10 @@ export function Tooltip({
       setOpen: setIsOpen,
       triggerRef,
       enabled,
-      openOnPress: isCompact,
+      openOnPress: isTouchContext,
       delayDuration,
     }),
-    [isOpen, setIsOpen, enabled, isCompact, delayDuration],
+    [isOpen, setIsOpen, enabled, isTouchContext, delayDuration],
   );
 
   return <TooltipContext.Provider value={value}>{children}</TooltipContext.Provider>;
@@ -357,7 +362,8 @@ export function TooltipTrigger({
       }
       if (ctx.openOnPress) {
         clearOpenTimer();
-        ctx.setOpen(true);
+        // Toggle: on touch the trigger is the only affordance to close again.
+        ctx.setOpen(!ctx.open);
         return;
       }
       close();


### PR DESCRIPTION
## Problem

On mobile, the context-window meter (the small usage ring in the composer) could not be triggered. It revealed its usage tooltip on **hover only**, and hover doesn't exist on touch.

## Root cause

The meter already opted into mobile (`enabledOnMobile`) via the shared `Tooltip` primitive, but the primitive **bucketed native with desktop**: both `enabled` and `openOnPress` keyed off `isCompact` alone.

- `useIsCompactFormFactor()` is derived from the window breakpoint (`xs`/`sm`), i.e. screen width.
- On a **native tablet**, the breakpoint isn't compact → `openOnPress` was `false`, and native never fires hover → the tooltip was **genuinely unreachable**.
- On a **native phone** (which *is* compact) it already opened on tap, but the visible ring is ~14px inside a 28px box — an easy-to-miss target — and there was no tap-to-close affordance.

## Fix

Treat native as a touch context in the `Tooltip` primitive.

1. **`components/ui/tooltip.tsx`** — `isTouchContext = isNative || isCompact` now governs `enabled` and `openOnPress`, so a press opens the tooltip on native (phone *and* tablet). `handlePress` now **toggles** (`setOpen(!ctx.open)`), so a second tap on the ring closes it — in addition to the existing native `Modal` backdrop that already dismisses on outside-tap.
2. **`components/context-window-meter.tsx`** — `hitSlop={8}` widens the thumb target; `accessibilityRole` `image → button` since the element is interactive on touch now.

The **web-compact hover path is deliberately untouched** — an e2e spec drives the meter at a 390px viewport with `.hover()`, and a web dismiss backdrop or hover-gating would break it and reintroduce a known hover flicker failure mode.

### Why tap, not long-press
Long-press is undiscoverable on a bare ring, the `Tooltip` primitive has no long-press model, and the original dismissal worry was a *dismiss* bug (now fixed by the toggle), not a trigger bug.

## Evidence

**Unit tests** (`components/ui/tooltip.test.tsx`) — 5/5 pass, including three new cases that fail against the old code:
- `toggles open on press in a compact (touch) context`
- `opens on press on native, where hover never fires` (mocks `isNative: true`)
- `toggles as a controlled tooltip (the context meter's shape)` — matches the meter's real controlled usage

**Checks:** `npm run typecheck` (all workspaces) ✅ · `npm run lint` ✅ · Biome format ✅ · pre-commit hook green.

## Verification status

⚠️ **No native device run.** This environment can't drive the iOS/Android app. The unit tests cover the shared `isTouchContext`/toggle logic (including the `isNative` branch); the native surface (`Modal`) itself was verified by reading. A reviewer should confirm on a device — particularly a **tablet**, which is the decisive case this fixes.

## Known limitations (pre-existing, out of scope)
- **Touch web** (browser on a phone) still has no outside-tap dismiss; the toggle doesn't help there because `pointerenter` re-opens before the tap's `click`.
- On a **native tablet with a hardware keyboard**, default tooltips (`enabledOnMobile: false`) no longer open on focus — a quieter side effect of the enablement change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
