### PR TITLE
fix(app): emit transform-origin as x-then-y for native menu popovers

### DIFF
--- a/packages/app/src/components/ui/menu/menu-anchor.test.ts
+++ b/packages/app/src/components/ui/menu/menu-anchor.test.ts
@@ -68,8 +68,8 @@ describe("computePosition", () => {
 
 describe("getTransformOrigin", () => {
   it.each([
-    ["bottom", "start", "top left"],
-    ["top", "end", "bottom right"],
+    ["bottom", "start", "left top"],
+    ["top", "end", "right bottom"],
     ["right", "center", "center center"],
   ] as const)("maps %s/%s to %s", (placement, alignment, expected) => {
     expect(getTransformOrigin(placement, alignment)).toBe(expected);

--- a/packages/app/src/components/ui/menu/menu-anchor.ts
+++ b/packages/app/src/components/ui/menu/menu-anchor.ts
@@ -155,5 +155,7 @@ export function getTransformOrigin(placement: Placement, alignment: Alignment): 
   else if (alignment === "end") horizontal = "right";
   else horizontal = "center";
 
-  return `${vertical} ${horizontal}`;
+  // React Native parses transform-origin positionally (x then y), unlike CSS
+  // which accepts keyword pairs in either order.
+  return `${horizontal} ${vertical}`;
 }


### PR DESCRIPTION
## Summary

Opening any **submenu** from a popover menu crashes the whole app on native with:

> Invariant Violation: Transform-origin left can only be used for x-position

Repro: on a native device wide enough to get popover presentation (tablet, unfolded foldable), open the menu next to the Workspaces heading in the sidebar and open the Grouping submenu to switch from by-project to by-status.

## Root cause

React Native's `processTransformOrigin` does accept CSS's vertical-first keyword pairs — when it sees `top`/`bottom` in the x slot it looks ahead and consumes the following horizontal keyword. What it cannot do is recover once `center` has already consumed the x slot: `center` is axis-agnostic, so it fills x and advances to y, and the following `left`/`right` hits `invariant(index === INDEX_X)` and throws.

That makes exactly the side placements fail. `getTransformOrigin` maps placement `left`/`right` to a `center` vertical, so side placement + `start`/`end` alignment produced `"center left"` / `"center right"`:

| placement/align | old | new |
|---|---|---|
| bottom, top × start/center/end | `"top left"` … | parses fine, unchanged |
| left/right × center | `"center center"` | parses fine, unchanged |
| **left/right × start** | `"center left"` → **throws** | `"left center"` → `[0, "50%", 0]` |
| **left/right × end** | `"center right"` → **throws** | `"right center"` → `["100%", "50%", 0]` |

Submenu flyouts are the only side-placed menus: `menu-surface.tsx:285` renders every `MenuFlyout` with `side="right" align="start"`, so every submenu on native popover presentation hit the throwing combination. Compact form factors present menus as sheets, where submenus are pages rather than flyouts, which is why narrow phones were unaffected. Web was unaffected because the browser accepts keyword pairs in either order.

## Changes

- Emit `horizontal vertical` order from `getTransformOrigin`. Horizontal-first never trips the invariant: a leading `left`/`right` is in the x slot by definition, and the trailing vertical keyword is valid in the y slot.
- Comment recording the constraint.
- Updated test expectations.

## Testing

- Simulated RN's parser over all 12 placement × alignment combinations: the 4 previously-throwing combinations now parse, and the other 8 produce byte-identical output to before, so there is no visual change to any menu that already worked.
- `npx vitest run packages/app/src/components/ui/menu/menu-anchor.test.ts` — 18 passed.
- Lint, format, and typecheck green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)