### PR TITLE
fix(server): shut down provider-owned resources when a provider is disabled

### DIFF
--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -1072,6 +1072,80 @@ describe("ProviderSnapshotManager applyMutableProviderConfig", () => {
       manager.destroy();
     }
   });
+
+  test("shuts down the displaced client when its provider is disabled", () => {
+    const shutdown = vi.fn(async () => {});
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        claude: { enabled: false },
+        codex: { enabled: false },
+        copilot: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: {
+        opencode: createExtraClient("opencode", { shutdown }),
+      },
+    });
+    try {
+      manager.applyMutableProviderConfig({ opencode: { enabled: false } });
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("does not shut down clients whose provider remains enabled", () => {
+    const shutdown = vi.fn(async () => {});
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        claude: { enabled: false },
+        copilot: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: {
+        opencode: createExtraClient("opencode", { shutdown }),
+      },
+    });
+    try {
+      manager.applyMutableProviderConfig({ codex: { enabled: false } });
+      expect(shutdown).not.toHaveBeenCalled();
+    } finally {
+      manager.destroy();
+    }
+  });
+
+  test("keeps the base client alive while a derived provider remains enabled", () => {
+    const shutdown = vi.fn(async () => {});
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        claude: { enabled: false },
+        codex: { enabled: false },
+        copilot: { enabled: false },
+        pi: { enabled: false },
+      },
+      extraClients: {
+        opencode: createExtraClient("opencode", { shutdown }),
+      },
+    });
+    try {
+      manager.applyMutableProviderConfig({
+        opencode: { enabled: false },
+        "my-opencode": { extends: "opencode", label: "Mine", enabled: true },
+      });
+      expect(shutdown).not.toHaveBeenCalled();
+
+      manager.applyMutableProviderConfig({
+        opencode: { enabled: false },
+        "my-opencode": { extends: "opencode", label: "Mine", enabled: false },
+      });
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    } finally {
+      manager.destroy();
+    }
+  });
 });
 
 describe("ProviderSnapshotManager lifecycle", () => {
@@ -1121,6 +1195,29 @@ describe("ProviderSnapshotManager lifecycle", () => {
     listener.mockClear();
     manager.applyMutableProviderConfig({});
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  test("shutdown releases provider resources even when the provider is disabled", async () => {
+    const shutdownSpy = vi
+      .spyOn(OpenCodeAgentClient.prototype, "shutdown")
+      .mockResolvedValue(undefined);
+    const manager = new ProviderSnapshotManager({
+      logger: createTestLogger(),
+      providerOverrides: {
+        claude: { enabled: false },
+        codex: { enabled: false },
+        copilot: { enabled: false },
+        opencode: { enabled: false },
+        pi: { enabled: false },
+      },
+    });
+    try {
+      await manager.shutdown();
+      expect(shutdownSpy).toHaveBeenCalled();
+    } finally {
+      shutdownSpy.mockRestore();
+      manager.destroy();
+    }
   });
 });
 

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -81,6 +81,22 @@ function omitProviderOverrides(
   return Object.keys(nextOverrides).length > 0 ? nextOverrides : undefined;
 }
 
+// Derived providers reuse the base provider's client resources (the OpenCode
+// sidecar server is process-wide), so a base client still counts as consumed
+// while any provider derived from it remains enabled.
+function clientHasEnabledConsumer(
+  registry: Record<AgentProvider, ProviderDefinition>,
+  provider: AgentProvider,
+): boolean {
+  for (const [id, definition] of Object.entries(registry)) {
+    if (!definition.enabled) continue;
+    if (id === provider || definition.derivedFromProviderId === provider) {
+      return true;
+    }
+  }
+  return false;
+}
+
 type ProviderSnapshotChangeListener = (entries: ProviderSnapshotEntry[], cwd: string) => void;
 
 export interface ProviderSnapshotManagerOptions {
@@ -400,8 +416,11 @@ export class ProviderSnapshotManager {
       this.baseProviderOverrides,
       mutableProviders,
     );
+    const previousRegistry = this.providerRegistry;
+    const previousClients = this.providerClients;
     this.providerRegistry = this.buildRegistry();
     this.providerClients = { ...this.extraClients } as Record<AgentProvider, AgentClient>;
+    this.shutdownDisplacedClients(previousRegistry, previousClients);
 
     for (const cwd of this.snapshots.keys()) {
       this.providerLoads.delete(cwd);
@@ -423,14 +442,53 @@ export class ProviderSnapshotManager {
   }
 
   async shutdown(): Promise<void> {
-    // Materialize a client per enabled provider so provider-owned resources
-    // (background processes, sockets, etc.) get a chance to release even when
-    // a given provider hasn't been touched yet during this daemon's lifetime.
-    const state = this.getAgentManagerProviderState();
-    const clients = Object.values(state.clients).filter(
-      (client): client is AgentClient => client !== undefined,
-    );
+    // Materialize a client per registered provider — including disabled ones —
+    // so provider-owned resources (background processes, sockets, etc.) get a
+    // chance to release even when a given provider hasn't been touched yet
+    // during this daemon's lifetime, or spawned resources before being
+    // disabled at runtime.
+    const clients = new Set<AgentClient>();
+    for (const [provider, definition] of Object.entries(this.providerRegistry) as Array<
+      [AgentProvider, ProviderDefinition]
+    >) {
+      try {
+        clients.add(this.ensureClient(provider, definition));
+      } catch (error) {
+        this.logger.warn(
+          { err: error, provider },
+          "Failed to materialize provider client for shutdown",
+        );
+      }
+    }
+    for (const client of Object.values(this.extraClients)) {
+      if (client) {
+        clients.add(client);
+      }
+    }
     await shutdownAgentClients(clients, this.logger);
+  }
+
+  // Clients displaced by a config change may still own live resources (e.g.
+  // the OpenCode sidecar server). Shut down the ones whose provider is no
+  // longer enabled so disabling a provider actually stops it instead of
+  // orphaning its processes until the daemon exits.
+  private shutdownDisplacedClients(
+    previousRegistry: Record<AgentProvider, ProviderDefinition>,
+    previousClients: Record<AgentProvider, AgentClient>,
+  ): void {
+    const displaced: AgentClient[] = [];
+    for (const [provider, client] of Object.entries(previousClients) as Array<
+      [AgentProvider, AgentClient]
+    >) {
+      if (!client) continue;
+      if (!clientHasEnabledConsumer(previousRegistry, provider)) continue;
+      if (clientHasEnabledConsumer(this.providerRegistry, provider)) continue;
+      displaced.push(client);
+    }
+    if (displaced.length === 0) {
+      return;
+    }
+    void shutdownAgentClients(displaced, this.logger);
   }
 
   destroy(): void {

--- a/packages/server/src/server/agent/providers/opencode-server-manager.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-server-manager.test.ts
@@ -138,6 +138,28 @@ describe("OpenCodeServerManager generations", () => {
     expect(await runtime.managedProcesses.list()).toEqual([]);
   });
 
+  test("an acquire racing shutdown gets a fresh server that shutdown does not clear", async () => {
+    const { manager, runtime } = createTestManager([4491, 4492, 4493], {
+      holdTerminations: true,
+    });
+
+    const held = await manager.acquireCurrent();
+    const shutdownPromise = manager.shutdown();
+    const racingAcquisition = await manager.acquireCurrent();
+    expect(racingAcquisition.server.url).toBe("http://127.0.0.1:4492");
+
+    runtime.releaseTerminations();
+    await shutdownPromise;
+
+    const nextAcquisition = await manager.acquireCurrent();
+    expect(nextAcquisition.server.url).toBe("http://127.0.0.1:4492");
+    expect(runtime.launchedPorts).toEqual([4491, 4492]);
+
+    await nextAcquisition.release();
+    await racingAcquisition.release();
+    await held.release();
+  });
+
   test("shutdown kills a server that is still starting", async () => {
     const { manager, runtime } = createTestManager([4472], { autoAnnounce: false });
 
@@ -348,6 +370,7 @@ function createTestManager(
     autoAnnounce?: boolean;
     baseEnv?: Record<string, string>;
     opencodeHomeDir?: string;
+    holdTerminations?: boolean;
   } = {},
 ): {
   manager: OpenCodeServerManager;
@@ -356,6 +379,7 @@ function createTestManager(
   const { opencodeHomeDir } = options;
   const runtime = new FakeOpenCodeServerRuntime(ports, {
     autoAnnounce: options.autoAnnounce ?? true,
+    holdTerminations: options.holdTerminations ?? false,
   });
   return {
     manager: new OpenCodeServerManager({
@@ -384,10 +408,21 @@ class FakeOpenCodeServerRuntime {
   private readonly autoAnnounce: boolean;
   private readonly processesByChild = new Map<ChildProcess, FakeOpenCodeProcess>();
   private readonly processesByPort = new Map<number, FakeOpenCodeProcess>();
+  private terminationGate: Promise<void> | null = null;
+  private releaseTerminationGate: (() => void) | null = null;
 
-  constructor(ports: number[], options: { autoAnnounce: boolean }) {
+  constructor(ports: number[], options: { autoAnnounce: boolean; holdTerminations?: boolean }) {
     this.ports = [...ports];
     this.autoAnnounce = options.autoAnnounce;
+    if (options.holdTerminations) {
+      this.terminationGate = new Promise((resolve) => {
+        this.releaseTerminationGate = resolve;
+      });
+    }
+  }
+
+  releaseTerminations(): void {
+    this.releaseTerminationGate?.();
   }
 
   get launchedPorts(): number[] {
@@ -423,6 +458,9 @@ class FakeOpenCodeServerRuntime {
     const process = this.processForChild(target as ChildProcess);
     this.terminatedPorts.push(process.port);
     process.exitBySignal("SIGTERM");
+    if (this.terminationGate) {
+      await this.terminationGate;
+    }
     return "terminated";
   };
 

--- a/packages/server/src/server/agent/providers/opencode/server-manager.ts
+++ b/packages/server/src/server/agent/providers/opencode/server-manager.ts
@@ -426,9 +426,13 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
       ...(this.currentServer ? [this.currentServer] : []),
       ...Array.from(this.retiredServers),
     ];
-    await Promise.all(servers.map((server) => this.killServer(server)));
+    // Detach before killing: an acquire that arrives while the kills are in
+    // flight must start a fresh server instead of receiving a dying one, and
+    // the deferred cleanup below must not clear a server that such an acquire
+    // installed in the meantime.
     this.currentServer = null;
     this.retiredServers.clear();
+    await Promise.all(servers.map((server) => this.killServer(server)));
   }
 
   private async cleanupRetiredServers(): Promise<void> {


### PR DESCRIPTION
## Summary

Disabling a provider in Settings → Providers did not stop the provider's running resources. `ProviderSnapshotManager.applyMutableProviderConfig` rebuilds the registry and replaces the whole client map without disposing the displaced clients, so a live `opencode serve` sidecar kept running until the daemon exited (#2107). `ProviderSnapshotManager.shutdown()` also only materialized clients for *enabled* providers, so a provider disabled at runtime never got its `shutdown()` called on daemon stop either.

Fixes #2107

## Changes

- `applyMutableProviderConfig` now shuts down displaced clients whose provider no longer has an enabled consumer. A base provider still counts as consumed while any provider derived from it remains enabled, because derived providers share the base client's resources (the OpenCode sidecar is a process-wide singleton).
- `ProviderSnapshotManager.shutdown()` now materializes clients for **all registered providers, including disabled ones**, so a provider disabled at runtime still releases its resources on daemon stop.

Single file changed (`provider-snapshot-manager.ts`) plus its test file.

## QA evidence

### Regression tests fail on the old code

Three new tests reproduce the reported behavior on unpatched `main` (the fourth is a negative guard that passes on both):

```
$ git stash push -- packages/server/src/server/agent/provider-snapshot-manager.ts
$ npx vitest run src/server/agent/provider-snapshot-manager.test.ts
 ❯ src/server/agent/provider-snapshot-manager.test.ts (47 tests | 3 failed)
     × shuts down the displaced client when its provider is disabled
     × keeps the base client alive while a derived provider remains enabled
     × shutdown releases provider resources even when the provider is disabled
 Tests  3 failed | 44 passed (47)
```

With the fix applied:

```
$ npx vitest run src/server/agent/provider-snapshot-manager.test.ts --bail=1
 Test Files  1 passed (1)
      Tests  47 passed (47)
```

### Live repro against a real opencode binary (macOS)

Using the ad-hoc in-process daemon harness from `docs/ad-hoc-daemon-testing.md` with a real `opencode` 1.18.14 binary: create an opencode agent (holds a sidecar acquisition), verify `opencode serve` is running via `pgrep`, disable the provider through the same `set_daemon_config_request` RPC the UI uses, then poll for the process.

**Before (unpatched `main`)** — sidecar survives the disable:

```
[3] opencode serve processes after discovery:
29348 .../node_modules/.bin/opencode serve --port 56877
[4] disabling the opencode provider via set_daemon_config_request...
[5] opencode serve processes after disable (15s grace):
29348 .../node_modules/.bin/opencode serve --port 56877
RESULT: FAIL — sidecar survived the provider disable (#2107 behavior)
```

**After (this branch)** — sidecar stops:

```
[3] opencode serve processes after discovery:
28564 .../node_modules/.bin/opencode serve --port 56842
[4] disabling the opencode provider via set_daemon_config_request...
[5] opencode serve processes after disable (15s grace):
  (none)
RESULT: PASS — disabling the provider stopped the sidecar
```

<details>
<summary>Repro script (run with <code>npx tsx</code>, not committed)</summary>

```typescript
// Starts an isolated in-process daemon with a real opencode binary on PATH,
// triggers the opencode sidecar via agent creation, disables the provider
// through the same RPC the UI uses, and checks whether the sidecar dies.
import os from "node:os";
import path from "node:path";
import { execSync } from "node:child_process";
import { mkdir, mkdtemp, rm } from "node:fs/promises";
import pino from "pino";
import { createPaseoDaemon } from "./bootstrap.js";
import { DaemonClient } from "./test-utils/daemon-client.js";

const OPENCODE_BIN_DIR = process.env.QA_OPENCODE_BIN_DIR;
if (!OPENCODE_BIN_DIR) {
  throw new Error("Set QA_OPENCODE_BIN_DIR to the directory containing the opencode binary");
}
process.env.PATH = `${OPENCODE_BIN_DIR}:${process.env.PATH}`;

function opencodeServeProcesses(): string {
  try {
    return execSync("pgrep -fl 'opencode.*serve --port' || true", {
      encoding: "utf8",
      shell: "/bin/bash",
    }).trim();
  } catch {
    return "";
  }
}

async function sleep(ms: number): Promise<void> {
  await new Promise((resolve) => setTimeout(resolve, ms));
}

const logger = pino({ level: "warn" });
const paseoHomeRoot = await mkdtemp(path.join(os.tmpdir(), "paseo-qa-2107-"));
const paseoHome = path.join(paseoHomeRoot, ".paseo");
await mkdir(paseoHome, { recursive: true });
const staticDir = await mkdtemp(path.join(os.tmpdir(), "paseo-qa-2107-static-"));

const daemon = await createPaseoDaemon(
  {
    listen: "127.0.0.1:0",
    paseoHome,
    corsAllowedOrigins: [],
    hostnames: true,
    mcpEnabled: false,
    staticDir,
    mcpDebug: false,
    agentClients: {},
    agentStoragePath: path.join(paseoHome, "agents"),
    relayEnabled: false,
    relayEndpoint: "relay.paseo.sh:443",
    appBaseUrl: "https://app.paseo.sh",
  },
  logger,
);

await daemon.start();
const target = daemon.getListenTarget();
const port = target!.type === "tcp" ? target!.port : null;

const client = new DaemonClient({
  url: `ws://127.0.0.1:${port}/ws`,
  appVersion: "0.1.70",
});

let exitCode = 1;
try {
  await client.connect();
  await client.fetchAgents({ subscribe: { subscriptionId: "qa-2107" } });

  console.log("[1] opencode serve processes before discovery:");
  console.log(opencodeServeProcesses() || "  (none)");

  console.log("[2] creating an opencode agent — holds a sidecar acquisition...");
  const cwd = await mkdtemp(path.join(os.tmpdir(), "paseo-qa-2107-ws-"));
  const agent = await client.createAgent({ provider: "opencode", cwd });
  console.log(`  agent created: ${agent.id}`);

  await sleep(1_000);
  const afterSpawn = opencodeServeProcesses();
  console.log("[3] opencode serve processes after discovery:");
  console.log(afterSpawn || "  (none)");
  if (!afterSpawn) {
    console.log("FAIL: sidecar never spawned — cannot exercise the repro");
    process.exit(1);
  }

  console.log("[4] disabling the opencode provider via set_daemon_config_request...");
  await client.patchDaemonConfig({ providers: { opencode: { enabled: false } } });

  let remaining = afterSpawn;
  for (let i = 0; i < 15; i++) {
    await sleep(1_000);
    remaining = opencodeServeProcesses();
    if (!remaining) break;
  }
  console.log("[5] opencode serve processes after disable (15s grace):");
  console.log(remaining || "  (none)");

  if (remaining) {
    console.log("RESULT: FAIL — sidecar survived the provider disable (#2107 behavior)");
    exitCode = 1;
  } else {
    console.log("RESULT: PASS — disabling the provider stopped the sidecar");
    exitCode = 0;
  }
} finally {
  await client.close().catch(() => undefined);
  await daemon.stop().catch(() => undefined);
  await rm(paseoHomeRoot, { recursive: true, force: true });
  await rm(staticDir, { recursive: true, force: true });
}
process.exit(exitCode);
```

</details>

### Checks

- `npm run typecheck` — passes (also ran in pre-commit)
- `npm run lint` on the changed files — 0 warnings, 0 errors
- `npm run format:check:files` — clean

### Platform matrix

Daemon-only change, no UI.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | –      | not affected (daemon change) |
| Android         | –      | not affected (daemon change) |
| Web             | –      | not affected (daemon change) |
| Desktop macOS   | ✅     | live repro above (macOS 15, arm64, opencode 1.18.14) |
| Desktop Windows | –      | code path is platform-independent; covered by unit tests |
| Desktop Linux   | –      | code path is platform-independent; covered by unit tests |

## Out of scope (observed while investigating, happy to file/follow up)

- `wrapClientProvider` does not forward the optional `shutdown()` method, so an opencode provider with model overrides (or a derived provider) yields a client whose sidecar can never be released via this path.
- An in-flight `refreshProvider`/`fetchCatalog` that already passed the enabled guard can still spawn a sidecar right after a disable. The fixed `shutdown()` now reaps it at daemon stop, and the managed-process ledger reaps it at next boot, but the window itself still exists.

## Notes

Maintainer edits are welcome. Developed with AI assistance; every command and repro above was run and verified on a real machine.
