### PR TITLE
Add terminal and browser tabs to the New Workspace screen

### DIFF
--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -527,6 +527,7 @@ export const ar: TranslationResources = {
         preparingTerminal: "إعداد علامة التبويب المحطة الطرفية",
         preparingTerminalTooltip: "جارٍ تحضير المحطة...",
         newBrowser: "متصفح جديد",
+        moreActions: "المزيد من الإجراءات",
         exitFocusMode: "إنهاء وضع التركيز",
         splitRight: "تقسيم الجزء الأيمن",
         splitDown: "تقسيم الجزء لأسفل",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -526,6 +526,7 @@ export const en = {
         preparingTerminal: "Preparing terminal tab",
         preparingTerminalTooltip: "Preparing terminal...",
         newBrowser: "New browser",
+        moreActions: "More actions",
         exitFocusMode: "Exit focus mode",
         splitRight: "Split pane right",
         splitDown: "Split pane down",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -532,6 +532,7 @@ export const es: TranslationResources = {
         preparingTerminal: "Preparando la pestaña del terminal",
         preparingTerminalTooltip: "Preparando terminal...",
         newBrowser: "Nuevo navegador",
+        moreActions: "Más acciones",
         exitFocusMode: "Salir del modo de concentración",
         splitRight: "Panel dividido a la derecha",
         splitDown: "Dividir panel hacia abajo",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -532,6 +532,7 @@ export const fr: TranslationResources = {
         preparingTerminal: "Préparation de l'onglet du terminal",
         preparingTerminalTooltip: "Préparation du terminal...",
         newBrowser: "Nouveau navigateur",
+        moreActions: "Plus de propositions",
         exitFocusMode: "Quitter le mode concentration",
         splitRight: "Volet divisé à droite",
         splitDown: "Diviser le volet vers le bas",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -532,6 +532,7 @@ export const ja: TranslationResources = {
         preparingTerminal: "ターミナルタブを準備中",
         preparingTerminalTooltip: "ターミナルを準備中...",
         newBrowser: "新しいブラウザ",
+        moreActions: "その他のアクション",
         exitFocusMode: "フォーカスモードを終了",
         splitRight: "右にペインを分割",
         splitDown: "下にペインを分割",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -529,6 +529,7 @@ export const ko: TranslationResources = {
         preparingTerminal: "터미널 탭 준비 중",
         preparingTerminalTooltip: "터미널 준비 중...",
         newBrowser: "새 브라우저",
+        moreActions: "작업 더 보기",
         exitFocusMode: "집중 모드 종료",
         splitRight: "창을 오른쪽으로 분할",
         splitDown: "창을 아래로 분할",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -531,6 +531,7 @@ export const ptBR: TranslationResources = {
         preparingTerminal: "Preparando aba de terminal",
         preparingTerminalTooltip: "Preparando terminal...",
         newBrowser: "Novo navegador",
+        moreActions: "Mais ações",
         exitFocusMode: "Sair do modo de foco",
         splitRight: "Dividir painel à direita",
         splitDown: "Dividir painel abaixo",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -531,6 +531,7 @@ export const ru: TranslationResources = {
         preparingTerminal: "Подготовка вкладки терминала",
         preparingTerminalTooltip: "Подготовка терминала...",
         newBrowser: "Новый браузер",
+        moreActions: "Дополнительные действия",
         exitFocusMode: "Выйти из режима фокусировки",
         splitRight: "Разделить панель справа",
         splitDown: "Разделить панель вниз",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -527,6 +527,7 @@ export const zhCN: TranslationResources = {
         preparingTerminal: "正在准备 Terminal 标签",
         preparingTerminalTooltip: "正在准备 Terminal...",
         newBrowser: "新建浏览器",
+        moreActions: "更多操作",
         exitFocusMode: "退出专注模式",
         splitRight: "向右拆分窗格",
         splitDown: "向下拆分窗格",

--- a/packages/app/src/panels/pane-context.tsx
+++ b/packages/app/src/panels/pane-context.tsx
@@ -8,6 +8,13 @@ export interface PaneContextValue {
   workspaceId: string;
   tabId: string;
   target: WorkspaceTabTarget;
+  /**
+   * Optional working directory override for panels that resolve their cwd
+   * from the workspace (e.g. the terminal panel). Used by surfaces that render
+   * panels before a workspace exists (the New Workspace screen). When unset,
+   * panels fall back to the workspace directory as before.
+   */
+  cwdOverride?: string;
   fileNavigationRevision?: number;
   openTab: (target: WorkspaceTabTarget) => void;
   closeCurrentTab: () => void;

--- a/packages/app/src/panels/terminal-panel.tsx
+++ b/packages/app/src/panels/terminal-panel.tsx
@@ -76,13 +76,13 @@ function useTerminalPanelDescriptor(
 }
 
 function TerminalPanel() {
-  const { serverId, workspaceId, target, openFileInWorkspace } = usePaneContext();
+  const { serverId, workspaceId, target, cwdOverride, openFileInWorkspace } = usePaneContext();
   const { isWorkspaceFocused, isPaneFocused } = usePaneFocus();
   const workspaceFields = useWorkspaceFields(serverId, workspaceId, (w) => ({
     workspaceDirectory: w.workspaceDirectory,
     isGitCheckout: w.projectKind === "git",
   }));
-  const workspaceDirectory = workspaceFields?.workspaceDirectory || null;
+  const workspaceDirectory = workspaceFields?.workspaceDirectory || cwdOverride || null;
   const isGitCheckout = workspaceFields?.isGitCheckout ?? false;
   const openFileExplorerForCheckout = usePanelStore((state) => state.openFileExplorerForCheckout);
   const handleOpenFileExplorer = useCallback(() => {

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -83,6 +83,20 @@ import type { AgentAttachment, ForgeSearchItem } from "@getpaseo/protocol/messag
 import type { CreatePaseoWorktreeInput } from "@getpaseo/client/internal/daemon-client";
 import type { AgentProvider } from "@getpaseo/protocol/agent-types";
 import type { WorkspaceDraftTabSetup, WorkspaceTabTarget } from "@/workspace-tabs/model";
+import { getIsElectron } from "@/constants/platform";
+import { createWorkspaceBrowser, useBrowserStore } from "@/desktop/browser/store";
+import { removeResidentBrowserWebview } from "@/desktop/browser/resident-webviews";
+import { NewWorkspaceTabsRow } from "@/screens/new-workspace/new-workspace-tabs-row";
+import {
+  initialPanelsState,
+  panelsReducer,
+  selectActivePanel,
+  type NewWorkspacePanel,
+} from "@/screens/new-workspace/panels-state";
+import {
+  buildWorkspacePaneContentModel,
+  WorkspacePaneContent,
+} from "@/screens/workspace/workspace-pane-content";
 import { isEmptyWorkspaceSubmission, runCreateEmptyWorkspace } from "./new-workspace-empty";
 import {
   getWorkspaceNamingAttachments,
@@ -168,6 +182,24 @@ interface NewWorkspaceScreenProps {
   projectId?: string;
   displayName?: string;
   draftId?: string;
+}
+
+function buildActivePanelTarget(panel: NewWorkspacePanel): WorkspaceTabTarget | null {
+  if (panel.kind === "terminal" && panel.terminalId) {
+    return { kind: "terminal", terminalId: panel.terminalId };
+  }
+  if (panel.kind === "browser" && panel.browserId) {
+    return { kind: "browser", browserId: panel.browserId };
+  }
+  return null;
+}
+
+function isTerminalCreationDisabled(input: {
+  isConnected: boolean;
+  hasClient: boolean;
+  hasSourceDirectory: boolean;
+}): boolean {
+  return !input.isConnected || !input.hasClient || !input.hasSourceDirectory;
 }
 
 const PROJECT_ICON_FALLBACK_FONT_SIZE = 10;
@@ -1500,6 +1532,8 @@ export function NewWorkspaceScreen({
   const isolationPickerAnchorRef = useRef<View>(null);
   const hostPickerAnchorRef = useRef<View | null>(null);
   const isDraftHandoffActive = useIsNewWorkspaceDraftHandoffActive({ draftId, selectedServerId });
+  const [panelsState, dispatchPanels] = useReducer(panelsReducer, initialPanelsState);
+  const activePanel = selectActivePanel(panelsState);
 
   useEffect(() => {
     const trimmed = pickerSearchQuery.trim();
@@ -1977,6 +2011,131 @@ export function NewWorkspaceScreen({
     ],
   );
 
+  const isElectron = getIsElectron();
+  const terminalDisabled = isTerminalCreationDisabled({
+    isConnected,
+    hasClient: Boolean(client),
+    hasSourceDirectory: selectedSourceDirectory !== null,
+  });
+
+  const handleCreateTerminal = useCallback(async () => {
+    if (!client || !isConnected || !selectedSourceDirectory) {
+      return;
+    }
+    try {
+      const ensuredWorkspace = await ensureWorkspace({
+        cwd: selectedSourceDirectory,
+        prompt: "",
+        attachments: [],
+        withInitialAgent: false,
+      });
+      const terminalCwd = ensuredWorkspace.workspaceDirectory || selectedSourceDirectory;
+      const payload = await client.createTerminal(terminalCwd, undefined, undefined, {
+        workspaceId: ensuredWorkspace.id,
+      });
+      if (!payload.terminal && payload.error) {
+        toast.error(payload.error);
+        return;
+      }
+      if (!payload.terminal) {
+        return;
+      }
+      dispatchPanels({
+        type: "add-terminal",
+        terminalId: payload.terminal.id,
+        createdAt: Date.now(),
+      });
+    } catch (error) {
+      toast.error(toErrorMessage(error));
+    }
+  }, [client, ensureWorkspace, isConnected, selectedSourceDirectory, toast]);
+
+  const handleCreateBrowser = useCallback(() => {
+    const { browserId } = createWorkspaceBrowser();
+    dispatchPanels({ type: "add-browser", browserId, createdAt: Date.now() });
+  }, []);
+
+  const handleClosePanel = useCallback(
+    (panel: NewWorkspacePanel) => {
+      if (panel.kind === "terminal" && panel.terminalId && client) {
+        void client.killTerminal(panel.terminalId).catch(() => {
+          toast.error(t("workspace.terminal.hostDisconnected"));
+        });
+      } else if (panel.kind === "browser" && panel.browserId) {
+        useBrowserStore.getState().removeBrowser(panel.browserId);
+        removeResidentBrowserWebview(panel.browserId);
+      }
+      dispatchPanels({ type: "close", panelId: panel.panelId });
+    },
+    [client, t, toast],
+  );
+
+  const handleCreateAgentTab = useCallback(() => {
+    dispatchPanels({ type: "activate-composer" });
+  }, []);
+
+  const handleActivatePanel = useCallback((panelId: string) => {
+    dispatchPanels({ type: "activate", panelId });
+  }, []);
+
+  const handleClosePanelById = useCallback(
+    (panelId: string) => {
+      const panel = panelsState.panels.find((candidate) => candidate.panelId === panelId);
+      if (panel) {
+        handleClosePanel(panel);
+      }
+    },
+    [handleClosePanel, panelsState.panels],
+  );
+
+  const handleCloseComposer = useCallback(() => {
+    const lastPanel = panelsState.panels[panelsState.panels.length - 1];
+    if (lastPanel) {
+      dispatchPanels({ type: "activate", panelId: lastPanel.panelId });
+    }
+  }, [panelsState.panels]);
+
+  const handleOpenTabTarget = useCallback((target: WorkspaceTabTarget) => {
+    if (target.kind === "terminal") {
+      dispatchPanels({ type: "activate", panelId: target.terminalId });
+    } else if (target.kind === "browser") {
+      dispatchPanels({ type: "activate", panelId: target.browserId });
+    }
+  }, []);
+
+  const activePanelModel = useMemo(() => {
+    if (!activePanel) {
+      return null;
+    }
+    const target = buildActivePanelTarget(activePanel);
+    if (!target) {
+      return null;
+    }
+    return buildWorkspacePaneContentModel({
+      tab: {
+        key: activePanel.panelId,
+        tabId: activePanel.panelId,
+        kind: activePanel.kind,
+        target,
+      },
+      normalizedServerId: selectedServerId,
+      normalizedWorkspaceId: "",
+      cwdOverride: workspace?.workspaceDirectory ?? selectedSourceDirectory ?? undefined,
+      onOpenTab: handleOpenTabTarget,
+      onCloseCurrentTab: () => handleClosePanel(activePanel),
+      onRetargetCurrentTab: handleOpenTabTarget,
+      onOpenWorkspaceFile: () => {},
+      onOpenImportSheet: () => {},
+    });
+  }, [
+    activePanel,
+    handleClosePanel,
+    handleOpenTabTarget,
+    selectedServerId,
+    selectedSourceDirectory,
+    workspace,
+  ]);
+
   const renderPickerOption = useCallback(
     (props: {
       option: ComboboxOptionType;
@@ -2102,42 +2261,62 @@ export function NewWorkspaceScreen({
   return (
     <FileDropZone style={styles.container}>
       <ScreenHeader left={screenHeaderLeft} borderless />
+      {!isCompact ? (
+        <NewWorkspaceTabsRow
+          panels={panelsState.panels}
+          activePanelId={panelsState.activePanelId}
+          onCreateAgentTab={handleCreateAgentTab}
+          onCreateTerminal={handleCreateTerminal}
+          onCreateBrowser={handleCreateBrowser}
+          onActivatePanel={handleActivatePanel}
+          onClosePanel={handleClosePanelById}
+          onCloseComposer={handleCloseComposer}
+          terminalDisabled={terminalDisabled}
+          showCreateBrowser={isElectron}
+        />
+      ) : null}
       <View style={contentStyle}>
         <TitlebarDragRegion />
-        <ReanimatedAnimated.View style={centeredStyle}>
-          <View style={styles.composerTitleContainer}>
-            <Text style={styles.composerTitle}>{t("newWorkspace.title")}</Text>
+        {activePanelModel ? (
+          <View style={styles.paneContainer}>
+            <WorkspacePaneContent content={activePanelModel} isWorkspaceFocused isPaneFocused />
           </View>
-          {formStack}
-          <Composer
-            externalKeyboardShift
-            agentId={draftKey}
-            serverId={selectedServerId}
-            isPaneFocused={true}
-            onSubmitMessage={handleSubmitNewWorkspace}
-            allowEmptySubmit={true}
-            submitButtonAccessibilityLabel={t("newWorkspace.create")}
-            submitButtonTestID="workspace-create-submit"
-            submitIcon="return"
-            isSubmitLoading={isPending}
-            waitForGithubAutoAttachOnSubmit
-            submitBehavior="preserve-and-lock"
-            blurOnSubmit={true}
-            value={chatDraft.text}
-            onChangeText={chatDraft.setText}
-            attachments={chatDraft.attachments}
-            attachmentScopeKeys={visibleDraftContextScopeKeys}
-            onChangeAttachments={chatDraft.setAttachments}
-            onGithubPrDetected={handleGithubPrDetected}
-            onGithubPrAutoAttach={handleGithubPrAutoAttach}
-            cwd={selectedSourceDirectory ?? ""}
-            clearDraft={handleClearDraft}
-            autoFocus
-            commandDraftConfig={composerState?.commandDraftConfig}
-            agentControls={agentControlsWithDisabled}
-          />
-          {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
-        </ReanimatedAnimated.View>
+        ) : (
+          <ReanimatedAnimated.View style={centeredStyle}>
+            <View style={styles.composerTitleContainer}>
+              <Text style={styles.composerTitle}>{t("newWorkspace.title")}</Text>
+            </View>
+            {formStack}
+            <Composer
+              externalKeyboardShift
+              agentId={draftKey}
+              serverId={selectedServerId}
+              isPaneFocused={true}
+              onSubmitMessage={handleSubmitNewWorkspace}
+              allowEmptySubmit={true}
+              submitButtonAccessibilityLabel={t("newWorkspace.create")}
+              submitButtonTestID="workspace-create-submit"
+              submitIcon="return"
+              isSubmitLoading={isPending}
+              waitForGithubAutoAttachOnSubmit
+              submitBehavior="preserve-and-lock"
+              blurOnSubmit={true}
+              value={chatDraft.text}
+              onChangeText={chatDraft.setText}
+              attachments={chatDraft.attachments}
+              attachmentScopeKeys={visibleDraftContextScopeKeys}
+              onChangeAttachments={chatDraft.setAttachments}
+              onGithubPrDetected={handleGithubPrDetected}
+              onGithubPrAutoAttach={handleGithubPrAutoAttach}
+              cwd={selectedSourceDirectory ?? ""}
+              clearDraft={handleClearDraft}
+              autoFocus
+              commandDraftConfig={composerState?.commandDraftConfig}
+              agentControls={agentControlsWithDisabled}
+            />
+            {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+          </ReanimatedAnimated.View>
+        )}
       </View>
     </FileDropZone>
   );
@@ -2167,6 +2346,11 @@ const styles = StyleSheet.create((theme) => ({
   },
   contentCompact: {
     justifyContent: "flex-end",
+  },
+  paneContainer: {
+    flex: 1,
+    width: "100%",
+    alignSelf: "stretch",
   },
   composerTitleContainer: {
     marginBottom: theme.spacing[8],

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -1973,6 +1973,7 @@ export function NewWorkspaceScreen({
             navigate: (targetServerId, workspaceId) =>
               navigateToWorkspace({ serverId: targetServerId, workspaceId }),
           });
+          committedRef.current = true;
           return;
         }
 
@@ -1991,6 +1992,7 @@ export function NewWorkspaceScreen({
             selectModel: t("newWorkspace.errors.selectModel"),
           },
         });
+        committedRef.current = true;
       } catch (error) {
         const message = toErrorMessage(error);
         setPendingAction(null);
@@ -2017,6 +2019,34 @@ export function NewWorkspaceScreen({
     hasClient: Boolean(client),
     hasSourceDirectory: selectedSourceDirectory !== null,
   });
+
+  // Route-driven unmount must not orphan the daemon terminals and persisted
+  // browser records this screen creates. A submit hands terminals off to the
+  // created workspace (the workspace screen lists them), so only browsers are
+  // cleaned up then; abandoning the screen without submitting releases both.
+  const committedRef = useRef(false);
+  const panelsRef = useRef<NewWorkspacePanel[]>([]);
+  const clientRef = useRef(client);
+  useEffect(() => {
+    panelsRef.current = panelsState.panels;
+  }, [panelsState.panels]);
+  useEffect(() => {
+    clientRef.current = client;
+  }, [client]);
+  useEffect(() => {
+    return () => {
+      const committed = committedRef.current;
+      const liveClient = clientRef.current;
+      for (const panel of panelsRef.current) {
+        if (panel.kind === "browser" && panel.browserId) {
+          useBrowserStore.getState().removeBrowser(panel.browserId);
+          removeResidentBrowserWebview(panel.browserId);
+        } else if (panel.kind === "terminal" && panel.terminalId && !committed && liveClient) {
+          liveClient.killTerminal(panel.terminalId).catch(() => {});
+        }
+      }
+    };
+  }, []);
 
   const handleCreateTerminal = useCallback(async () => {
     if (!client || !isConnected || !selectedSourceDirectory) {

--- a/packages/app/src/screens/new-workspace/new-workspace-tabs-row.test.tsx
+++ b/packages/app/src/screens/new-workspace/new-workspace-tabs-row.test.tsx
@@ -1,0 +1,397 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { i18n as testI18n } from "@/i18n/i18next";
+import React, { type ReactElement } from "react";
+import { act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  NewWorkspaceTabsRow,
+  type NewWorkspaceTabsRowPanel,
+} from "@/screens/new-workspace/new-workspace-tabs-row";
+
+void testI18n;
+
+const {
+  mockTheme,
+}: {
+  mockTheme: {
+    spacing: Record<number, number>;
+    borderWidth: Record<number, number>;
+    borderRadius: Record<string, number>;
+    fontSize: Record<string, number>;
+    fontWeight: Record<string, string>;
+    colors: Record<string, unknown>;
+  };
+} = vi.hoisted(() => {
+  const themeData = {
+    spacing: { 1: 4, 2: 8, 3: 12 },
+    borderWidth: { 1: 1 },
+    borderRadius: { sm: 4, md: 6 },
+    fontSize: { sm: 13 },
+    fontWeight: { normal: "400" },
+    colors: {
+      foreground: "#fff",
+      foregroundMuted: "#aaa",
+      surface0: "#000",
+      surface1: "#111",
+      surface2: "#222",
+      surface3: "#333",
+      border: "#444",
+      accent: "#0a84ff",
+    },
+  };
+  return { mockTheme: themeData };
+});
+
+vi.mock("react-native-unistyles", () => ({
+  StyleSheet: {
+    create: (factory: unknown) => (typeof factory === "function" ? factory(mockTheme) : factory),
+  },
+  withUnistyles:
+    (Component: React.ComponentType<Record<string, unknown>>) =>
+    ({
+      uniProps,
+      ...rest
+    }: {
+      uniProps?: (theme: unknown) => Record<string, unknown>;
+    } & Record<string, unknown>) => {
+      const themed = uniProps ? uniProps(mockTheme) : {};
+      return React.createElement(Component, { ...rest, ...themed });
+    },
+}));
+
+vi.mock("@/constants/layout", () => ({
+  WORKSPACE_SECONDARY_HEADER_HEIGHT: 36,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    testID,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    onSelect?: () => void;
+    testID?: string;
+  }) => (
+    <button type="button" data-testid={testID} disabled={disabled} onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    testID,
+  }: {
+    children:
+      | React.ReactNode
+      | ((state: { hovered: boolean; pressed: boolean; open: boolean }) => React.ReactNode);
+    testID?: string;
+  }) => (
+    <button type="button" data-testid={testID}>
+      {typeof children === "function"
+        ? children({ hovered: false, pressed: false, open: true })
+        : children}
+    </button>
+  ),
+  useDropdownMenuClose: () => () => {},
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children as ReactElement,
+  TooltipTrigger: ({
+    children,
+    testID,
+    onPress,
+  }: {
+    children: React.ReactNode;
+    testID?: string;
+    onPress?: () => void;
+  }) => (
+    <span data-testid={testID} onClick={onPress}>
+      {children}
+    </span>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("lucide-react-native", () => {
+  const createIcon = (name: string) => (props: Record<string, unknown>) =>
+    React.createElement("span", { "data-icon": name, "data-size": props.size });
+  return {
+    ChevronDown: createIcon("chevron-down"),
+    Globe: createIcon("globe"),
+    Plus: createIcon("plus"),
+    SquarePen: createIcon("square-pen"),
+    SquareTerminal: createIcon("square-terminal"),
+    X: createIcon("x"),
+  };
+});
+
+vi.mock("react-native", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-native");
+  return actual;
+});
+
+function panel(
+  input: Partial<NewWorkspaceTabsRowPanel> & Pick<NewWorkspaceTabsRowPanel, "panelId">,
+): NewWorkspaceTabsRowPanel {
+  return {
+    kind: "terminal",
+    ...input,
+  };
+}
+
+interface RenderTabsRowOptions {
+  panels?: NewWorkspaceTabsRowPanel[];
+  activePanelId?: string | null;
+  terminalDisabled?: boolean;
+  showCreateBrowser?: boolean;
+  onCreateAgentTab?: () => void;
+  onCreateTerminal?: () => void;
+  onCreateBrowser?: () => void;
+  onActivatePanel?: (panelId: string) => void;
+  onClosePanel?: (panelId: string) => void;
+  onCloseComposer?: () => void;
+}
+
+function renderTabsRow(options: RenderTabsRowOptions = {}): {
+  container: HTMLElement;
+  unmount: () => void;
+} {
+  const {
+    panels = [],
+    activePanelId = null,
+    terminalDisabled = false,
+    showCreateBrowser = false,
+    onCreateAgentTab = vi.fn(),
+    onCreateTerminal = vi.fn(),
+    onCreateBrowser = vi.fn(),
+    onActivatePanel = vi.fn(),
+    onClosePanel = vi.fn(),
+    onCloseComposer,
+  } = options;
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  function element(): ReactElement {
+    return (
+      <NewWorkspaceTabsRow
+        panels={panels}
+        activePanelId={activePanelId}
+        onCreateAgentTab={onCreateAgentTab}
+        onCreateTerminal={onCreateTerminal}
+        onCreateBrowser={onCreateBrowser}
+        onActivatePanel={onActivatePanel}
+        onClosePanel={onClosePanel}
+        onCloseComposer={onCloseComposer}
+        terminalDisabled={terminalDisabled}
+        showCreateBrowser={showCreateBrowser}
+      />
+    );
+  }
+
+  act(() => {
+    root.render(element());
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("NewWorkspaceTabsRow", () => {
+  let root: Root | null = null;
+  let container: HTMLElement | null = null;
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+  });
+
+  it("renders the composer tab active when no panel is active", () => {
+    const rendered = renderTabsRow();
+    const composerTab = rendered.container.querySelector(
+      '[data-testid="new-workspace-composer-tab"]',
+    );
+    expect(composerTab).not.toBeNull();
+    rendered.unmount();
+  });
+
+  it("renders the menu trigger with New Agent and New Terminal items", () => {
+    const rendered = renderTabsRow();
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-new-tab-menu-trigger"]'),
+    ).not.toBeNull();
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-new-tab-menu-agent"]'),
+    ).not.toBeNull();
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-new-tab-menu-terminal"]'),
+    ).not.toBeNull();
+    rendered.unmount();
+  });
+
+  it("does not render the New Browser item when showCreateBrowser is false", () => {
+    const rendered = renderTabsRow({ showCreateBrowser: false });
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-new-tab-menu-browser"]'),
+    ).toBeNull();
+    rendered.unmount();
+  });
+
+  it("renders the New Browser item when showCreateBrowser is true", () => {
+    const rendered = renderTabsRow({ showCreateBrowser: true });
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-new-tab-menu-browser"]'),
+    ).not.toBeNull();
+    rendered.unmount();
+  });
+
+  it("disables the New Terminal item when terminalDisabled is true", () => {
+    const rendered = renderTabsRow({ terminalDisabled: true });
+    const terminalItem = rendered.container.querySelector(
+      '[data-testid="new-workspace-new-tab-menu-terminal"]',
+    ) as HTMLButtonElement | null;
+    expect(terminalItem?.disabled).toBe(true);
+    rendered.unmount();
+  });
+
+  it("invokes onCreateTerminal when the New Terminal item is selected", () => {
+    const onCreateTerminal = vi.fn();
+    const rendered = renderTabsRow({ onCreateTerminal });
+    const terminalItem = rendered.container.querySelector(
+      '[data-testid="new-workspace-new-tab-menu-terminal"]',
+    ) as HTMLButtonElement | null;
+    act(() => {
+      terminalItem?.click();
+    });
+    expect(onCreateTerminal).toHaveBeenCalledTimes(1);
+    rendered.unmount();
+  });
+
+  it("invokes onCreateAgentTab when the composer tab is pressed", () => {
+    const onCreateAgentTab = vi.fn();
+    const rendered = renderTabsRow({ onCreateAgentTab });
+    const composerTab = rendered.container.querySelector(
+      '[data-testid="new-workspace-composer-tab"]',
+    ) as HTMLButtonElement | null;
+    act(() => {
+      composerTab?.click();
+    });
+    expect(onCreateAgentTab).toHaveBeenCalledTimes(1);
+    rendered.unmount();
+  });
+
+  it("invokes onCreateAgentTab when the add tab button is pressed", () => {
+    const onCreateAgentTab = vi.fn();
+    const rendered = renderTabsRow({ onCreateAgentTab });
+    const addButton = rendered.container.querySelector(
+      '[data-testid="new-workspace-add-tab-button"]',
+    ) as HTMLButtonElement | null;
+    act(() => {
+      addButton?.click();
+    });
+    expect(onCreateAgentTab).toHaveBeenCalledTimes(1);
+    rendered.unmount();
+  });
+
+  it("invokes onCloseComposer when the composer close button is pressed", () => {
+    const onCloseComposer = vi.fn();
+    const rendered = renderTabsRow({ onCloseComposer });
+    const closeButton = rendered.container.querySelector(
+      '[data-testid="new-workspace-composer-close"]',
+    ) as HTMLButtonElement | null;
+    expect(closeButton).not.toBeNull();
+    act(() => {
+      closeButton?.click();
+    });
+    expect(onCloseComposer).toHaveBeenCalledTimes(1);
+    rendered.unmount();
+  });
+
+  it("does not render a composer close button when onCloseComposer is omitted", () => {
+    const rendered = renderTabsRow({
+      onCloseComposer: undefined,
+    });
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-composer-close"]'),
+    ).toBeNull();
+    rendered.unmount();
+  });
+
+  it("renders one chip per panel with a kind label", () => {
+    const rendered = renderTabsRow({
+      panels: [panel({ panelId: "t1" }), panel({ panelId: "b1", kind: "browser" })],
+    });
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-panel-tab-t1"]'),
+    ).not.toBeNull();
+    expect(
+      rendered.container.querySelector('[data-testid="new-workspace-panel-tab-b1"]'),
+    ).not.toBeNull();
+    rendered.unmount();
+  });
+
+  it("invokes onActivatePanel when a panel chip is pressed", () => {
+    const onActivatePanel = vi.fn();
+    const rendered = renderTabsRow({
+      panels: [panel({ panelId: "t1" })],
+      activePanelId: null,
+      onActivatePanel,
+    });
+    const panelTab = rendered.container.querySelector(
+      '[data-testid="new-workspace-panel-tab-t1"]',
+    ) as HTMLButtonElement | null;
+    act(() => {
+      panelTab?.click();
+    });
+    expect(onActivatePanel).toHaveBeenCalledWith("t1");
+    rendered.unmount();
+  });
+
+  it("invokes onClosePanel when the panel close button is pressed", () => {
+    const onClosePanel = vi.fn();
+    const rendered = renderTabsRow({
+      panels: [panel({ panelId: "t1" })],
+      onClosePanel,
+    });
+    const closeButton = rendered.container.querySelector(
+      '[data-testid="new-workspace-panel-close-t1"]',
+    ) as HTMLButtonElement | null;
+    act(() => {
+      closeButton?.click();
+    });
+    expect(onClosePanel).toHaveBeenCalledWith("t1");
+    rendered.unmount();
+  });
+
+  it("suffixes labels with an ordinal when more than one of the same kind is open", () => {
+    const rendered = renderTabsRow({
+      panels: [panel({ panelId: "t1" }), panel({ panelId: "t2" })],
+    });
+    const chipOne = rendered.container.querySelector('[data-testid="new-workspace-panel-tab-t1"]');
+    const chipTwo = rendered.container.querySelector('[data-testid="new-workspace-panel-tab-t2"]');
+    expect(chipOne?.textContent).toContain("Terminal");
+    expect(chipTwo?.textContent).toContain("Terminal 2");
+    rendered.unmount();
+  });
+});

--- a/packages/app/src/screens/new-workspace/new-workspace-tabs-row.tsx
+++ b/packages/app/src/screens/new-workspace/new-workspace-tabs-row.tsx
@@ -1,0 +1,407 @@
+import React, { useCallback, useMemo, type ReactElement } from "react";
+import {
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+  type GestureResponderEvent,
+  type PressableStateCallbackType,
+} from "react-native";
+import { ChevronDown, Globe, Plus, SquarePen, SquareTerminal, X } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { useTranslation } from "react-i18next";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { WORKSPACE_SECONDARY_HEADER_HEIGHT } from "@/constants/layout";
+import type { Theme } from "@/styles/theme";
+
+export interface NewWorkspaceTabsRowPanel {
+  panelId: string;
+  kind: "terminal" | "browser";
+}
+
+export interface NewWorkspaceTabsRowProps {
+  panels: NewWorkspaceTabsRowPanel[];
+  /** null means the composer (chat) view is active. */
+  activePanelId: string | null;
+  onCreateAgentTab: () => void;
+  onCreateTerminal: () => void;
+  onCreateBrowser: () => void;
+  onActivatePanel: (panelId: string) => void;
+  onClosePanel: (panelId: string) => void;
+  onCloseComposer?: () => void;
+  terminalDisabled: boolean;
+  showCreateBrowser: boolean;
+}
+
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedGlobe = withUnistyles(Globe);
+const ThemedPlus = withUnistyles(Plus);
+const ThemedSquarePen = withUnistyles(SquarePen);
+const ThemedSquareTerminal = withUnistyles(SquareTerminal);
+const ThemedX = withUnistyles(X);
+const mutedColorMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+
+const COMPOSER_ICON = <ThemedSquarePen size={14} uniProps={mutedColorMapping} />;
+const TERMINAL_ICON = <ThemedSquareTerminal size={14} uniProps={mutedColorMapping} />;
+const BROWSER_ICON = <ThemedGlobe size={14} uniProps={mutedColorMapping} />;
+
+function newTabActionButtonStyle({ hovered, pressed }: PressableStateCallbackType) {
+  return [styles.newTabActionButton, (hovered || pressed) && styles.newTabActionButtonHovered];
+}
+
+function inlineAddActionButtonStyle({ hovered, pressed }: PressableStateCallbackType) {
+  return [styles.inlineAddActionButton, (hovered || pressed) && styles.newTabActionButtonHovered];
+}
+
+function resolvePanelLabel(
+  panel: NewWorkspaceTabsRowPanel,
+  sameKindIndex: number,
+  sameKindCount: number,
+  terminalLabel: string,
+  browserLabel: string,
+): string {
+  const base = panel.kind === "terminal" ? terminalLabel : browserLabel;
+  if (sameKindCount <= 1) {
+    return base;
+  }
+  return `${base} ${sameKindIndex + 1}`;
+}
+
+function stopEvent(event: GestureResponderEvent): void {
+  event.stopPropagation();
+}
+
+interface TabChipProps {
+  label: string;
+  icon: ReactElement;
+  active: boolean;
+  onPress: () => void;
+  onClose?: () => void;
+  tabTestID: string;
+  closeTestID?: string;
+}
+
+function TabChip({
+  label,
+  icon,
+  active,
+  onPress,
+  onClose,
+  tabTestID,
+  closeTestID,
+}: TabChipProps): ReactElement {
+  const accessibilityState = useMemo(() => ({ selected: active }), [active]);
+  const chipStyle = useCallback(
+    ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.tab,
+      (Boolean(hovered) || pressed || active) && styles.tabActive,
+    ],
+    [active],
+  );
+  const closeButtonStyle = useCallback(
+    ({ hovered: isHovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
+      styles.tabCloseButton,
+      (Boolean(isHovered) || pressed) && styles.tabCloseButtonActive,
+    ],
+    [],
+  );
+  const handleClosePress = useCallback(
+    (event: GestureResponderEvent) => {
+      stopEvent(event);
+      onClose?.();
+    },
+    [onClose],
+  );
+  const handleClosePressIn = useCallback((event: GestureResponderEvent) => {
+    stopEvent(event);
+  }, []);
+
+  return (
+    <Pressable
+      testID={tabTestID}
+      onPress={onPress}
+      style={chipStyle}
+      accessibilityRole="button"
+      accessibilityState={accessibilityState}
+    >
+      {active ? <View style={styles.tabFocusIndicator} /> : null}
+      <View style={styles.tabIcon}>{icon}</View>
+      <Text
+        style={[styles.tabLabel, active && styles.tabLabelActive]}
+        numberOfLines={1}
+        selectable={false}
+      >
+        {label}
+      </Text>
+      {onClose && closeTestID ? (
+        <Pressable
+          testID={closeTestID}
+          onPressIn={handleClosePressIn}
+          onPress={handleClosePress}
+          style={closeButtonStyle}
+          accessibilityRole="button"
+          accessibilityLabel={label}
+        >
+          <ThemedX size={12} uniProps={mutedColorMapping} />
+        </Pressable>
+      ) : null}
+    </Pressable>
+  );
+}
+
+function WorkspacePanelChip({
+  panel,
+  label,
+  active,
+  onActivatePanel,
+  onClosePanel,
+}: {
+  panel: NewWorkspaceTabsRowPanel;
+  label: string;
+  active: boolean;
+  onActivatePanel: (panelId: string) => void;
+  onClosePanel: (panelId: string) => void;
+}): ReactElement {
+  const handlePress = useCallback(
+    () => onActivatePanel(panel.panelId),
+    [onActivatePanel, panel.panelId],
+  );
+  const handleClose = useCallback(() => onClosePanel(panel.panelId), [onClosePanel, panel.panelId]);
+
+  return (
+    <TabChip
+      label={label}
+      icon={panel.kind === "terminal" ? TERMINAL_ICON : BROWSER_ICON}
+      active={active}
+      onPress={handlePress}
+      onClose={handleClose}
+      tabTestID={`new-workspace-panel-tab-${panel.panelId}`}
+      closeTestID={`new-workspace-panel-close-${panel.panelId}`}
+    />
+  );
+}
+
+export function NewWorkspaceTabsRow({
+  panels,
+  activePanelId,
+  onCreateAgentTab,
+  onCreateTerminal,
+  onCreateBrowser,
+  onActivatePanel,
+  onClosePanel,
+  onCloseComposer,
+  terminalDisabled,
+  showCreateBrowser,
+}: NewWorkspaceTabsRowProps): ReactElement {
+  const { t } = useTranslation();
+  const terminalLabel = t("workspace.tabs.fallback.terminal");
+  const browserLabel = t("workspace.tabs.fallback.browser");
+
+  const panelLabels = useMemo(() => {
+    const counts = { terminal: 0, browser: 0 };
+    for (const panel of panels) {
+      counts[panel.kind] += 1;
+    }
+    const seen = { terminal: 0, browser: 0 };
+    const labels = new Map<string, string>();
+    for (const panel of panels) {
+      const index = seen[panel.kind];
+      seen[panel.kind] += 1;
+      labels.set(
+        panel.panelId,
+        resolvePanelLabel(panel, index, counts[panel.kind], terminalLabel, browserLabel),
+      );
+    }
+    return labels;
+  }, [browserLabel, panels, terminalLabel]);
+
+  return (
+    <View style={styles.tabsContainer} testID="new-workspace-tabs-row">
+      <ScrollView
+        horizontal
+        style={styles.tabsScroll}
+        contentContainerStyle={styles.tabsContent}
+        showsHorizontalScrollIndicator={false}
+      >
+        <TabChip
+          label={t("workspace.tabs.actions.newAgent")}
+          icon={COMPOSER_ICON}
+          active={activePanelId === null}
+          onPress={onCreateAgentTab}
+          onClose={onCloseComposer}
+          tabTestID="new-workspace-composer-tab"
+          closeTestID="new-workspace-composer-close"
+        />
+        {panels.map((panel) => (
+          <WorkspacePanelChip
+            key={panel.panelId}
+            panel={panel}
+            label={
+              panelLabels.get(panel.panelId) ??
+              (panel.kind === "terminal" ? terminalLabel : browserLabel)
+            }
+            active={activePanelId === panel.panelId}
+            onActivatePanel={onActivatePanel}
+            onClosePanel={onClosePanel}
+          />
+        ))}
+        <View style={styles.inlineAddButton}>
+          <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+            <TooltipTrigger
+              testID="new-workspace-add-tab-button"
+              onPress={onCreateAgentTab}
+              accessibilityRole="button"
+              accessibilityLabel={t("workspace.tabs.actions.newAgent")}
+              style={inlineAddActionButtonStyle}
+            >
+              <ThemedPlus size={14} uniProps={mutedColorMapping} />
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="center" offset={8}>
+              <Text style={styles.tooltipText}>{t("workspace.tabs.actions.newAgent")}</Text>
+            </TooltipContent>
+          </Tooltip>
+        </View>
+      </ScrollView>
+      <View style={styles.tabsActions}>
+        <DropdownMenu>
+          <Tooltip delayDuration={0} enabledOnDesktop enabledOnMobile={false}>
+            <TooltipTrigger asChild triggerRefProp="triggerRef">
+              <DropdownMenuTrigger
+                testID="new-workspace-new-tab-menu-trigger"
+                accessibilityRole="button"
+                accessibilityLabel={t("workspace.tabs.actions.moreActions")}
+                style={newTabActionButtonStyle}
+              >
+                <ThemedChevronDown size={14} uniProps={mutedColorMapping} />
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="center" offset={8}>
+              <Text style={styles.tooltipText}>{t("workspace.tabs.actions.moreActions")}</Text>
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent side="bottom" align="end" offset={4} minWidth={200}>
+            <DropdownMenuItem testID="new-workspace-new-tab-menu-agent" onSelect={onCreateAgentTab}>
+              {t("workspace.tabs.actions.newAgent")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              testID="new-workspace-new-tab-menu-terminal"
+              disabled={terminalDisabled}
+              onSelect={terminalDisabled ? undefined : onCreateTerminal}
+            >
+              {t("workspace.tabs.actions.newTerminal")}
+            </DropdownMenuItem>
+            {showCreateBrowser ? (
+              <DropdownMenuItem
+                testID="new-workspace-new-tab-menu-browser"
+                onSelect={onCreateBrowser}
+              >
+                {t("workspace.tabs.actions.newBrowser")}
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  tabsContainer: {
+    height: WORKSPACE_SECONDARY_HEADER_HEIGHT,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    backgroundColor: theme.colors.surface0,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  tabsScroll: {
+    minWidth: 0,
+    flex: 1,
+  },
+  tabsContent: {
+    flexDirection: "row",
+    alignItems: "stretch",
+  },
+  tabsActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: theme.spacing[2],
+  },
+  tab: {
+    paddingHorizontal: theme.spacing[3],
+    paddingVertical: theme.spacing[2],
+    borderRightWidth: 1,
+    borderRightColor: theme.colors.border,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    userSelect: "none",
+  },
+  tabActive: {
+    backgroundColor: theme.colors.surface1,
+  },
+  tabFocusIndicator: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 2,
+    backgroundColor: theme.colors.accent,
+  },
+  tabIcon: {
+    flexShrink: 0,
+  },
+  tabLabel: {
+    flexShrink: 1,
+    minWidth: 0,
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.normal,
+    userSelect: "none",
+  },
+  tabLabelActive: {
+    color: theme.colors.foreground,
+  },
+  tabCloseButton: {
+    width: 18,
+    height: 18,
+    borderRadius: theme.borderRadius.sm,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tabCloseButtonActive: {
+    backgroundColor: theme.colors.surface3,
+  },
+  newTabActionButton: {
+    width: 22,
+    height: 22,
+    borderRadius: theme.borderRadius.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  inlineAddActionButton: {
+    width: 28,
+    height: 28,
+    borderRadius: theme.borderRadius.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  inlineAddButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: theme.spacing[1],
+  },
+  newTabActionButtonHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  tooltipText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+}));

--- a/packages/app/src/screens/new-workspace/panel-render-spike.test.tsx
+++ b/packages/app/src/screens/new-workspace/panel-render-spike.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * SPIKE REGRESSION TEST: the New Workspace screen renders the shared
+ * terminal/browser panels before a workspace exists (workspaceId === "").
+ * The terminal panel must fall back to the pane context's cwdOverride so it
+ * shows a real terminal instead of the "Workspace directory not found."
+ * placeholder; the browser panel must tolerate a null cwd.
+ */
+import { reactGlobalInstalled } from "../../../test-stubs/react-global";
+void reactGlobalInstalled;
+import { i18n as testI18n } from "@/i18n/i18next";
+import React from "react";
+import { act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  buildWorkspacePaneContentModel,
+  WorkspacePaneContent,
+} from "@/screens/workspace/workspace-pane-content";
+import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
+
+void testI18n;
+
+const {
+  mockTheme,
+  terminalPaneProps,
+  browserPaneProps,
+}: {
+  mockTheme: Record<string, unknown>;
+  terminalPaneProps: Array<{ cwd: string; terminalId: string; serverId: string }>;
+  browserPaneProps: Array<{ cwd: string | null; browserId: string; serverId: string }>;
+} = vi.hoisted(() => {
+  const themeData = {
+    spacing: { 1: 4, 2: 8, 3: 12 },
+    borderWidth: { 1: 1 },
+    borderRadius: { sm: 4, md: 6 },
+    fontSize: { sm: 13 },
+    fontWeight: { normal: "400" },
+    colors: {
+      foreground: "#fff",
+      foregroundMuted: "#aaa",
+      surface0: "#000",
+      surface1: "#111",
+      surface2: "#222",
+      surface3: "#333",
+      border: "#444",
+    },
+  };
+  return {
+    mockTheme: themeData,
+    terminalPaneProps: [],
+    browserPaneProps: [],
+  };
+});
+
+vi.mock("@/panels/register-panels", () => ({
+  ensurePanelsRegistered: vi.fn(),
+}));
+
+vi.mock("@/panels/panel-registry", async () => {
+  const terminalModule =
+    await vi.importActual<typeof import("@/panels/terminal-panel")>("@/panels/terminal-panel");
+  const browserModule =
+    await vi.importActual<typeof import("@/desktop/browser/panel")>("@/desktop/browser/panel");
+  return {
+    getPanelRegistration: (kind: string) => {
+      if (kind === "terminal") {
+        return terminalModule.terminalPanelRegistration;
+      }
+      if (kind === "browser") {
+        return browserModule.browserPanelRegistration;
+      }
+      throw new Error(`panel-render-spike: unexpected kind ${kind}`);
+    },
+  };
+});
+
+vi.mock("react-native-unistyles", () => ({
+  StyleSheet: {
+    create: (factory: unknown) => (typeof factory === "function" ? factory(mockTheme) : factory),
+  },
+  withUnistyles:
+    (Component: React.ComponentType<Record<string, unknown>>) =>
+    ({
+      uniProps,
+      ...rest
+    }: {
+      uniProps?: (theme: unknown) => Record<string, unknown>;
+    } & Record<string, unknown>) => {
+      const themed = uniProps ? uniProps(mockTheme) : {};
+      return React.createElement(Component, { ...rest, ...themed });
+    },
+}));
+
+vi.mock("lucide-react-native", () => {
+  const createIcon = (name: string) => (props: Record<string, unknown>) =>
+    React.createElement("span", { "data-icon": name, "data-size": props.size });
+  return {
+    Globe: createIcon("globe"),
+    Terminal: createIcon("terminal"),
+  };
+});
+
+vi.mock("@/components/terminal-pane", () => ({
+  TerminalPane: (props: { serverId: string; cwd: string; terminalId: string }) => {
+    terminalPaneProps.push({
+      serverId: props.serverId,
+      cwd: props.cwd,
+      terminalId: props.terminalId,
+    });
+    return <div data-testid="terminal-pane" />;
+  },
+}));
+
+vi.mock("@/desktop/browser/pane", () => ({
+  BrowserPane: (props: { serverId: string; cwd: string | null; browserId: string }) => {
+    browserPaneProps.push({
+      serverId: props.serverId,
+      cwd: props.cwd,
+      browserId: props.browserId,
+    });
+    return <div data-testid="browser-pane" />;
+  },
+}));
+
+vi.mock("@/stores/session-store-hooks", () => ({
+  useWorkspaceDirectory: () => null,
+  useWorkspaceFields: () => null,
+}));
+
+vi.mock("@/stores/panel-store", () => ({
+  usePanelStore: (selector: (state: { openFileExplorerForCheckout: unknown }) => unknown) =>
+    selector({ openFileExplorerForCheckout: vi.fn() }),
+}));
+
+vi.mock("@/data/query-client", () => ({
+  queryClient: {},
+}));
+
+vi.mock("react-native", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-native");
+  return actual;
+});
+
+function terminalTab(terminalId = "t1"): WorkspaceTabDescriptor {
+  return {
+    key: `terminal_${terminalId}`,
+    tabId: `terminal_${terminalId}`,
+    kind: "terminal",
+    target: { kind: "terminal", terminalId },
+  };
+}
+
+function browserTab(browserId = "b1"): WorkspaceTabDescriptor {
+  return {
+    key: `browser_${browserId}`,
+    tabId: `browser_${browserId}`,
+    kind: "browser",
+    target: { kind: "browser", browserId },
+  };
+}
+
+function buildModel(input: { tab: WorkspaceTabDescriptor; cwdOverride?: string }) {
+  return buildWorkspacePaneContentModel({
+    tab: input.tab,
+    normalizedServerId: "test-server",
+    normalizedWorkspaceId: "",
+    cwdOverride: input.cwdOverride,
+    onOpenTab: vi.fn(),
+    onCloseCurrentTab: vi.fn(),
+    onRetargetCurrentTab: vi.fn(),
+    onOpenWorkspaceFile: vi.fn(),
+    onOpenImportSheet: vi.fn(),
+  });
+}
+
+describe("panel render spike: empty workspaceId", () => {
+  let root: Root | null = null;
+  let container: HTMLElement | null = null;
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    terminalPaneProps.length = 0;
+    browserPaneProps.length = 0;
+  });
+
+  function mount(content: ReturnType<typeof buildModel>): HTMLElement {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root?.render(<WorkspacePaneContent content={content} isWorkspaceFocused isPaneFocused />);
+    });
+    return container;
+  }
+
+  it("terminal panel without cwdOverride renders the missing-directory placeholder (no throw)", () => {
+    const content = buildModel({ tab: terminalTab() });
+    const rendered = mount(content);
+    expect(rendered.textContent).toContain("Workspace directory not found.");
+    expect(terminalPaneProps).toHaveLength(0);
+  });
+
+  it("terminal panel with cwdOverride renders the terminal pane with the override cwd", () => {
+    const content = buildModel({ tab: terminalTab("t2"), cwdOverride: "/tmp/project" });
+    const rendered = mount(content);
+    expect(rendered.querySelector('[data-testid="terminal-pane"]')).not.toBeNull();
+    expect(terminalPaneProps).toEqual([
+      { serverId: "test-server", cwd: "/tmp/project", terminalId: "t2" },
+    ]);
+  });
+
+  it("browser panel with empty workspaceId renders the browser pane with a null cwd (no throw)", () => {
+    const content = buildModel({ tab: browserTab() });
+    const rendered = mount(content);
+    expect(rendered.querySelector('[data-testid="browser-pane"]')).not.toBeNull();
+    expect(browserPaneProps).toEqual([{ serverId: "test-server", cwd: null, browserId: "b1" }]);
+  });
+});

--- a/packages/app/src/screens/new-workspace/panels-state.test.ts
+++ b/packages/app/src/screens/new-workspace/panels-state.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialPanelsState,
+  panelsReducer,
+  selectActivePanel,
+  type NewWorkspacePanelsState,
+} from "./panels-state";
+
+describe("panels-state reducer", () => {
+  it("initializes with an empty panel array and composer active (null)", () => {
+    expect(initialPanelsState).toEqual({
+      panels: [],
+      activePanelId: null,
+    });
+    expect(selectActivePanel(initialPanelsState)).toBeNull();
+  });
+
+  it("adds a terminal panel and activates it", () => {
+    const action = { type: "add-terminal" as const, terminalId: "term-1", createdAt: 1000 };
+    const nextState = panelsReducer(initialPanelsState, action);
+
+    expect(nextState).toEqual({
+      panels: [
+        {
+          panelId: "term-1",
+          kind: "terminal",
+          terminalId: "term-1",
+          createdAt: 1000,
+        },
+      ],
+      activePanelId: "term-1",
+    });
+    expect(selectActivePanel(nextState)).toEqual({
+      panelId: "term-1",
+      kind: "terminal",
+      terminalId: "term-1",
+      createdAt: 1000,
+    });
+  });
+
+  it("adds a browser panel and activates it", () => {
+    const action = { type: "add-browser" as const, browserId: "browser-1", createdAt: 2000 };
+    const nextState = panelsReducer(initialPanelsState, action);
+
+    expect(nextState).toEqual({
+      panels: [
+        {
+          panelId: "browser-1",
+          kind: "browser",
+          browserId: "browser-1",
+          createdAt: 2000,
+        },
+      ],
+      activePanelId: "browser-1",
+    });
+    expect(selectActivePanel(nextState)).toEqual({
+      panelId: "browser-1",
+      kind: "browser",
+      browserId: "browser-1",
+      createdAt: 2000,
+    });
+  });
+
+  it("dedupes add-terminal if terminalId already exists (no-op)", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [{ panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 }],
+      activePanelId: "term-1",
+    };
+
+    const nextState = panelsReducer(state, {
+      type: "add-terminal",
+      terminalId: "term-1",
+      createdAt: 3000,
+    });
+
+    expect(nextState).toBe(state);
+  });
+
+  it("dedupes add-browser if browserId already exists (no-op)", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [{ panelId: "browser-1", kind: "browser", browserId: "browser-1", createdAt: 2000 }],
+      activePanelId: "browser-1",
+    };
+
+    const nextState = panelsReducer(state, {
+      type: "add-browser",
+      browserId: "browser-1",
+      createdAt: 3000,
+    });
+
+    expect(nextState).toBe(state);
+  });
+
+  it("activates an existing panel", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [
+        { panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 },
+        { panelId: "browser-1", kind: "browser", browserId: "browser-1", createdAt: 2000 },
+      ],
+      activePanelId: "browser-1",
+    };
+
+    const nextState = panelsReducer(state, { type: "activate", panelId: "term-1" });
+
+    expect(nextState.activePanelId).toBe("term-1");
+    expect(selectActivePanel(nextState)?.panelId).toBe("term-1");
+  });
+
+  it("no-ops when activating an unknown panel id", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [{ panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 }],
+      activePanelId: "term-1",
+    };
+
+    const nextState = panelsReducer(state, { type: "activate", panelId: "unknown-id" });
+
+    expect(nextState).toBe(state);
+  });
+
+  it("activates composer (null activePanelId)", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [{ panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 }],
+      activePanelId: "term-1",
+    };
+
+    const nextState = panelsReducer(state, { type: "activate-composer" });
+
+    expect(nextState.activePanelId).toBeNull();
+    expect(selectActivePanel(nextState)).toBeNull();
+  });
+
+  it("keeps active panel unchanged when closing a non-active panel", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [
+        { panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 },
+        { panelId: "browser-1", kind: "browser", browserId: "browser-1", createdAt: 2000 },
+      ],
+      activePanelId: "browser-1",
+    };
+
+    const nextState = panelsReducer(state, { type: "close", panelId: "term-1" });
+
+    expect(nextState).toEqual({
+      panels: [{ panelId: "browser-1", kind: "browser", browserId: "browser-1", createdAt: 2000 }],
+      activePanelId: "browser-1",
+    });
+  });
+
+  it("falls back to last remaining panel in array order when closing active panel", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [
+        { panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 },
+        { panelId: "term-2", kind: "terminal", terminalId: "term-2", createdAt: 1500 },
+        { panelId: "browser-1", kind: "browser", browserId: "browser-1", createdAt: 2000 },
+      ],
+      activePanelId: "term-2",
+    };
+
+    const nextState = panelsReducer(state, { type: "close", panelId: "term-2" });
+
+    expect(nextState).toEqual({
+      panels: [
+        { panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 },
+        { panelId: "browser-1", kind: "browser", browserId: "browser-1", createdAt: 2000 },
+      ],
+      activePanelId: "browser-1",
+    });
+  });
+
+  it("falls back to activePanelId = null when closing the last remaining panel", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [{ panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 }],
+      activePanelId: "term-1",
+    };
+
+    const nextState = panelsReducer(state, { type: "close", panelId: "term-1" });
+
+    expect(nextState).toEqual({
+      panels: [],
+      activePanelId: null,
+    });
+    expect(selectActivePanel(nextState)).toBeNull();
+  });
+
+  it("no-ops when closing an unknown panel id", () => {
+    const state: NewWorkspacePanelsState = {
+      panels: [{ panelId: "term-1", kind: "terminal", terminalId: "term-1", createdAt: 1000 }],
+      activePanelId: "term-1",
+    };
+
+    const nextState = panelsReducer(state, { type: "close", panelId: "unknown-id" });
+
+    expect(nextState).toBe(state);
+  });
+});

--- a/packages/app/src/screens/new-workspace/panels-state.ts
+++ b/packages/app/src/screens/new-workspace/panels-state.ts
@@ -1,0 +1,82 @@
+export type NewWorkspacePanelKind = "terminal" | "browser";
+
+export interface NewWorkspacePanel {
+  panelId: string;
+  kind: NewWorkspacePanelKind;
+  terminalId?: string;
+  browserId?: string;
+  createdAt: number;
+}
+
+export interface NewWorkspacePanelsState {
+  panels: NewWorkspacePanel[];
+  // null active means the composer (chat) view is active.
+  activePanelId: string | null;
+}
+
+export const initialPanelsState: NewWorkspacePanelsState = {
+  panels: [],
+  activePanelId: null,
+};
+
+export type NewWorkspacePanelsAction =
+  | { type: "add-terminal"; terminalId: string; createdAt: number }
+  | { type: "add-browser"; browserId: string; createdAt: number }
+  | { type: "activate"; panelId: string }
+  | { type: "activate-composer" }
+  | { type: "close"; panelId: string };
+
+export function panelsReducer(
+  state: NewWorkspacePanelsState,
+  action: NewWorkspacePanelsAction,
+): NewWorkspacePanelsState {
+  switch (action.type) {
+    case "add-terminal": {
+      if (state.panels.some((panel) => panel.terminalId === action.terminalId)) {
+        return state;
+      }
+      const panel: NewWorkspacePanel = {
+        panelId: action.terminalId,
+        kind: "terminal",
+        terminalId: action.terminalId,
+        createdAt: action.createdAt,
+      };
+      return { panels: [...state.panels, panel], activePanelId: panel.panelId };
+    }
+    case "add-browser": {
+      if (state.panels.some((panel) => panel.browserId === action.browserId)) {
+        return state;
+      }
+      const panel: NewWorkspacePanel = {
+        panelId: action.browserId,
+        kind: "browser",
+        browserId: action.browserId,
+        createdAt: action.createdAt,
+      };
+      return { panels: [...state.panels, panel], activePanelId: panel.panelId };
+    }
+    case "activate": {
+      if (!state.panels.some((panel) => panel.panelId === action.panelId)) {
+        return state;
+      }
+      return { ...state, activePanelId: action.panelId };
+    }
+    case "activate-composer":
+      return { ...state, activePanelId: null };
+    case "close": {
+      if (!state.panels.some((panel) => panel.panelId === action.panelId)) {
+        return state;
+      }
+      const panels = state.panels.filter((panel) => panel.panelId !== action.panelId);
+      let activePanelId = state.activePanelId;
+      if (state.activePanelId === action.panelId) {
+        activePanelId = panels.length > 0 ? panels[panels.length - 1].panelId : null;
+      }
+      return { panels, activePanelId };
+    }
+  }
+}
+
+export function selectActivePanel(state: NewWorkspacePanelsState): NewWorkspacePanel | null {
+  return state.panels.find((panel) => panel.panelId === state.activePanelId) ?? null;
+}

--- a/packages/app/src/screens/workspace/workspace-pane-content.tsx
+++ b/packages/app/src/screens/workspace/workspace-pane-content.tsx
@@ -23,6 +23,7 @@ export interface BuildWorkspacePaneContentModelInput {
   tab: WorkspaceTabDescriptor;
   normalizedServerId: string;
   normalizedWorkspaceId: string;
+  cwdOverride?: string;
   fileNavigationRevision?: number;
   onOpenTab: (target: WorkspaceTabDescriptor["target"]) => void;
   onCloseCurrentTab: () => void;
@@ -35,6 +36,7 @@ export function buildWorkspacePaneContentModel({
   tab,
   normalizedServerId,
   normalizedWorkspaceId,
+  cwdOverride,
   fileNavigationRevision,
   onOpenTab,
   onCloseCurrentTab,
@@ -53,6 +55,7 @@ export function buildWorkspacePaneContentModel({
       workspaceId: normalizedWorkspaceId,
       tabId: tab.tabId,
       target: tab.target,
+      cwdOverride,
       fileNavigationRevision,
       openTab: onOpenTab,
       closeCurrentTab: onCloseCurrentTab,
@@ -88,6 +91,7 @@ export function WorkspacePaneContent({
       workspaceId: paneContextValue.workspaceId,
       tabId: paneContextValue.tabId,
       target: paneContextValue.target,
+      cwdOverride: paneContextValue.cwdOverride,
       fileNavigationRevision: paneContextValue.fileNavigationRevision,
       openTab,
       closeCurrentTab,
@@ -101,6 +105,7 @@ export function WorkspacePaneContent({
       openImportSheet,
       openTab,
       paneContextValue.serverId,
+      paneContextValue.cwdOverride,
       paneContextValue.fileNavigationRevision,
       paneContextValue.tabId,
       paneContextValue.target,

--- a/packages/app/test-stubs/react-global.ts
+++ b/packages/app/test-stubs/react-global.ts
@@ -1,0 +1,11 @@
+import React from "react";
+
+// The vitest transform emits classic-runtime JSX (React.createElement) while the
+// app's babel config uses the automatic runtime. Components that omit the React
+// import (e.g. the shared terminal panel) must see a React global when they
+// evaluate in tests.
+(globalThis as { React?: typeof React }).React = React;
+
+// Re-exported so importers satisfy no-unassigned-import while the side effect
+// above runs first (this module is imported before any panel module).
+export const reactGlobalInstalled = true;


### PR DESCRIPTION
## What this does

**Before:** the New Workspace screen only had a chat box. To run a command in the folder you were about to work in, you had to create the workspace first, land in the chat tab, and only then open a terminal.

**After:** the New Workspace screen now has a tabs row, like the workspace screen. You can open a terminal in the selected folder right there and start typing CLI commands before the workspace even exists, or open a browser (desktop app only), and switch freely between chat, terminal, and browser tabs. Leaving the screen cleans everything up — terminals you started are handed off to the workspace when you create it, or stopped if you abandon the screen.

## Summary

- add a workspace-style tabs row to the New Workspace screen (desktop/web): a New Agent composer chip with an active-tab accent line, an inline `+` button right after the last tab, and a menu to add a Terminal or a Browser
- **New Terminal** opens an inline daemon terminal in the selected folder right in the screen, before the workspace is created — an empty workspace is ensured first because the daemon requires a workspace id for terminal creation
- **New Browser** (Electron only) opens an inline browser panel; the menu item stays hidden in ordinary browser web
- chips switch between the composer and open panels; closing a terminal kills it, closing a browser removes its record and resident webview
- panels render through the shared panel registry (`WorkspacePaneContent`) with a new optional `cwdOverride` in the pane context, so the terminal panel can show a real terminal before a workspace exists
- panels created by the screen are released on route-driven unmount: browsers are always removed, and daemon terminals are killed unless the composer was submitted (submitting hands them off to the created workspace)
- add the missing `workspace.tabs.actions.moreActions` i18n key to all locales (the workspace tabs row already referenced it)

## Why

The New Workspace screen only offered the chat composer, so there was no way to run CLI commands in the folder you were about to work in without first creating a workspace and landing in the chat tab. This brings the workspace screen's tab affordances to the New Workspace screen so you can drop into a terminal immediately.

## Tests

```
$ vitest run src/screens/new-workspace/panels-state.test.ts src/screens/new-workspace/new-workspace-tabs-row.test.tsx src/screens/new-workspace/panel-render-spike.test.tsx src/screens/workspace/workspace-pane-content.test.tsx --bail=1
 Test Files  4 passed (4)
      Tests  31 passed (31)

$ oxlint packages/app/src/screens/new-workspace/ ...
Found 0 warnings and 0 errors.

$ tsgo --noEmit (packages/app)
0 errors in new-workspace files
```

- `panels-state.test.ts` — panel add/activate/close/dedupe reducer
- `new-workspace-tabs-row.test.tsx` — tabs row rendering, menu items, disabled/browser-gated states, chip interactions
- `panel-render-spike.test.tsx` — proves the terminal panel renders with a `cwdOverride` and the browser panel tolerates a null cwd before a workspace exists

## QA evidence (web)

Ran the dev daemon (`npm run dev`, port 6768) + Expo web (`npm run dev:app`, port 8081) and drove the real app with Playwright:

- New Workspace screen renders the tabs row: composer chip + inline `+` button + menu trigger (asserted via `data-testid`, e.g. `new-workspace-composer-tab`, `new-workspace-add-tab-button`, `new-workspace-new-tab-menu-trigger`)
- Menu items: **New Terminal is disabled until a folder is selected**; **New Browser is absent on web** (Electron-only gate, `getIsElectron()`)
- Full terminal flow: added `/Users/dny/IdeaProjects/paseo` as a project via directory search → clicked New Terminal → daemon received `create_terminal_request` → terminal chip "터미널" appeared → **xterm.js terminal rendered inline** (`.xterm` present) → workspace git status visible
- Tab interactions: switch composer ↔ terminal chip, close button per chip (kill terminal on close)
- Active-tab accent line renders on the focused chip (`rgb(32,116,74)` 2px top bar); `+` button sits immediately right of the last tab (`x=458` vs tab right edge `454`)
- i18n: `workspace.tabs.actions.moreActions` now resolves (verified `aria-label="작업 더 보기"` after the locale additions)
- Console: no new errors from the feature

**Electron desktop (added 2026-08-06):** launched `npm run dev:desktop` (Electron + Metro) against the dev daemon and drove the app over its CDP endpoint with Playwright:
- tabs row renders (composer chip, inline `+`, menu trigger)
- **New Browser item is visible on Electron** (it is hidden in browser web — the `getIsElectron()` gate works) and clicking it opens a browser panel (webview element present)
- New Terminal opens an inline terminal — "터미널" chip + xterm.js terminal render
- caveat: the pre-workspace browser webview logs `Invalid attached browser registration` (browser created before a workspace has no workspace context for the resident-webview registration); the webview still renders. Noted for follow-up.

**iOS simulator (added 2026-08-06):** built the dev client (`APP_VARIANT=development npx expo run:ios`, 0 errors) on iPhone 17 Pro and verified with Maestro:
- New Workspace screen renders the compact layout: composer (`에이전트에게 메시지...`), project picker, isolation, submit button all present
- **the tabs row is correctly not rendered on compact** (Maestro `assertNotVisible: "작업 더 보기"` passed) — mobile keeps the original single-composer layout by design

**Platforms tested:** web (Chrome via Playwright), Electron desktop (macOS, via CDP), iOS (simulator via Maestro), daemon on macOS.
**Platforms not tested:** Android. The tabs row is desktop/web-only by design; compact form factors (iOS/Android) keep the original layout.