### PR TITLE
feat: resume the agent directory incrementally after reconnect

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -991,6 +991,11 @@ export default function RootLayout() {
       if (nextState !== "active") {
         void flushDraftPersistStorage();
       }
+      if (isNative) {
+        // Pause keep-alive work (heartbeat, reconnect, probes) in the background and
+        // force an immediate connection check on foreground resume.
+        getHostRuntimeStore().setBackgrounded(nextState !== "active");
+      }
     });
     return () => subscription.remove();
   }, []);

--- a/packages/app/src/hooks/use-client-activity.ts
+++ b/packages/app/src/hooks/use-client-activity.ts
@@ -129,7 +129,12 @@ export function useClientActivity({
     const start = () => {
       if (intervalId) clearInterval(intervalId);
       tracker.sendHeartbeat();
-      intervalId = setInterval(() => tracker.sendHeartbeat(), HEARTBEAT_INTERVAL_MS);
+      intervalId = setInterval(() => {
+        // Skip sending while backgrounded — the socket may be gone and the radio
+        // wake-up would be wasted; foreground resume triggers an immediate probe.
+        if (AppState.currentState !== "active") return;
+        tracker.sendHeartbeat();
+      }, HEARTBEAT_INTERVAL_MS);
     };
 
     const stop = () => {

--- a/packages/app/src/runtime/directory-sync/index.test.ts
+++ b/packages/app/src/runtime/directory-sync/index.test.ts
@@ -1,21 +1,32 @@
 import { afterEach, describe, expect, it } from "vitest";
-import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type {
+  DaemonClient,
+  FetchAgentsEntry,
+  FetchAgentsOptions,
+} from "@getpaseo/client/internal/daemon-client";
 import type { SessionOutboundMessage } from "@getpaseo/protocol/messages";
 import { useSessionStore } from "@/stores/session-store";
 import { DirectoryRefreshSupersededError, DirectorySync } from "./index";
 
 type WorkspaceFetchResult = Awaited<ReturnType<DaemonClient["fetchWorkspaces"]>>;
 type ProjectListResult = Awaited<ReturnType<DaemonClient["listProjects"]>>;
+type AgentFetchResult = Awaited<ReturnType<DaemonClient["fetchAgents"]>>;
 
 class FakeDirectoryClient {
   fetchAgentsCalls = 0;
   fetchWorkspacesCalls = 0;
   listProjectsCalls = 0;
+  fetchAgentsOptions: FetchAgentsOptions[] = [];
+  private queuedAgentFetch: AgentFetchResult[] = [];
   private pendingWorkspaceFetch: Promise<WorkspaceFetchResult> | null = null;
   private readonly handlers = new Map<
     SessionOutboundMessage["type"],
     Set<(message: SessionOutboundMessage) => void>
   >();
+
+  queueFetchAgents(result: AgentFetchResult): void {
+    this.queuedAgentFetch.push(result);
+  }
 
   on<TType extends SessionOutboundMessage["type"]>(
     type: TType,
@@ -42,8 +53,11 @@ class FakeDirectoryClient {
     return complete;
   }
 
-  async fetchAgents(): Promise<Awaited<ReturnType<DaemonClient["fetchAgents"]>>> {
+  async fetchAgents(options?: FetchAgentsOptions): Promise<AgentFetchResult> {
     this.fetchAgentsCalls += 1;
+    this.fetchAgentsOptions.push(options ?? {});
+    const queued = this.queuedAgentFetch.shift();
+    if (queued) return queued;
     return {
       requestId: "agents",
       entries: [],
@@ -84,6 +98,66 @@ class FakeDirectoryClient {
 }
 
 const serverIds = new Set<string>();
+
+function makeFetchAgentsEntry(input: {
+  id: string;
+  cwd: string;
+  updatedAt: string;
+  title?: string | null;
+  requiresAttention?: boolean;
+  attentionReason?: "permission" | "error" | null;
+  archivedAt?: string | null;
+}): FetchAgentsEntry {
+  return {
+    agent: {
+      id: input.id,
+      provider: "codex",
+      status: "idle",
+      createdAt: input.updatedAt,
+      updatedAt: input.updatedAt,
+      lastUserMessageAt: null,
+      lastError: undefined,
+      runtimeInfo: {
+        provider: "codex",
+        sessionId: null,
+      },
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      currentModeId: null,
+      availableModes: [],
+      pendingPermissions: [],
+      persistence: null,
+      title: input.title ?? null,
+      cwd: input.cwd,
+      model: null,
+      thinkingOptionId: null,
+      requiresAttention: input.requiresAttention ?? false,
+      attentionReason: input.attentionReason ?? null,
+      attentionTimestamp: input.requiresAttention && input.attentionReason ? input.updatedAt : null,
+      archivedAt: input.archivedAt ?? null,
+      labels: {},
+    },
+    project: {
+      projectKey: input.cwd,
+      projectName: "workspace",
+      checkout: {
+        cwd: input.cwd,
+        isGit: false,
+        currentBranch: null,
+        remoteUrl: null,
+        worktreeRoot: null,
+        isPaseoOwnedWorktree: false,
+        mainRepoRoot: null,
+      },
+    },
+  };
+}
 
 function createDirectory(serverId: string): {
   client: FakeDirectoryClient;
@@ -288,6 +362,149 @@ describe("DirectorySync session readiness", () => {
     ).toMatchObject({
       projectDisplayName: "Early project",
       projectRootPath: "/repo/early-project",
+    });
+    directory.dispose();
+  });
+
+  it("resyncs incrementally after a reconnect using the sequence cursor", async () => {
+    const serverId = "incremental-resync";
+    const { client, directory } = createDirectory(serverId);
+    const store = useSessionStore.getState();
+    store.initializeSession(serverId, client as unknown as DaemonClient, 1);
+    store.updateSessionServerInfo(serverId, {
+      serverId,
+      hostname: null,
+      version: "test",
+      features: { workspaceMultiplicity: true },
+    });
+
+    const agentA = makeFetchAgentsEntry({
+      id: "agent-a",
+      cwd: "/repo",
+      updatedAt: "2026-07-12T10:00:00.000Z",
+      title: "a",
+    });
+    client.queueFetchAgents({
+      requestId: "full",
+      entries: [agentA],
+      pageInfo: { hasMore: false, nextCursor: null, prevCursor: null },
+      sequence: 5,
+      directoryGeneration: "gen-1",
+    });
+    await directory.refreshAgents();
+    expect(useSessionStore.getState().sessions[serverId]?.agents.has("agent-a")).toBe(true);
+
+    // 模拟重连：新的 connection epoch，客户端带着旧 cursor 增量续拉
+    directory.connectionChanged({
+      client: client as unknown as DaemonClient,
+      status: "online",
+      source: { clientGeneration: 1, connectionEpoch: 2 },
+    });
+
+    const agentAUpdated = makeFetchAgentsEntry({
+      id: "agent-a",
+      cwd: "/repo",
+      updatedAt: "2026-07-12T10:00:05.000Z",
+      title: "a-v2",
+    });
+    const agentB = makeFetchAgentsEntry({
+      id: "agent-b",
+      cwd: "/repo",
+      updatedAt: "2026-07-12T10:00:06.000Z",
+      title: "b",
+    });
+    client.queueFetchAgents({
+      requestId: "incr",
+      entries: [agentAUpdated, agentB],
+      deletedIds: ["agent-c"],
+      pageInfo: { hasMore: false, nextCursor: null, prevCursor: null },
+      sequence: 8,
+      directoryGeneration: "gen-1",
+      incremental: true,
+    });
+    await directory.refreshAgents();
+
+    expect(client.fetchAgentsCalls).toBe(2);
+    expect(client.fetchAgentsOptions[1]).toMatchObject({
+      scope: "active",
+      afterSequence: 5,
+      directoryGeneration: "gen-1",
+    });
+    const agents = useSessionStore.getState().sessions[serverId]?.agents;
+    expect(agents?.get("agent-a")).toMatchObject({ title: "a-v2" });
+    expect(agents?.has("agent-b")).toBe(true);
+    expect(agents?.has("agent-c")).toBe(false);
+    directory.dispose();
+  });
+
+  it("falls back to a full snapshot when the daemon generation changes", async () => {
+    const serverId = "generation-change";
+    const { client, directory } = createDirectory(serverId);
+    const store = useSessionStore.getState();
+    store.initializeSession(serverId, client as unknown as DaemonClient, 1);
+    store.updateSessionServerInfo(serverId, {
+      serverId,
+      hostname: null,
+      version: "test",
+      features: { workspaceMultiplicity: true },
+    });
+
+    const agentA = makeFetchAgentsEntry({
+      id: "agent-a",
+      cwd: "/repo",
+      updatedAt: "2026-07-12T10:00:00.000Z",
+      title: "a",
+    });
+    client.queueFetchAgents({
+      requestId: "full",
+      entries: [agentA],
+      pageInfo: { hasMore: false, nextCursor: null, prevCursor: null },
+      sequence: 5,
+      directoryGeneration: "gen-1",
+    });
+    await directory.refreshAgents();
+
+    // daemon 重启：generation 变了，增量请求被拒绝
+    directory.connectionChanged({
+      client: client as unknown as DaemonClient,
+      status: "online",
+      source: { clientGeneration: 1, connectionEpoch: 3 },
+    });
+    client.queueFetchAgents({
+      requestId: "reject",
+      entries: [],
+      deletedIds: [],
+      pageInfo: { hasMore: false, nextCursor: null, prevCursor: null },
+      sequence: 0,
+      directoryGeneration: "gen-2",
+      incremental: false,
+    });
+    // 全量兜底：gen-2 下当前 active 快照
+    const agentA2 = makeFetchAgentsEntry({
+      id: "agent-a",
+      cwd: "/repo",
+      updatedAt: "2026-07-12T10:00:10.000Z",
+      title: "a-v2",
+    });
+    client.queueFetchAgents({
+      requestId: "full2",
+      entries: [agentA2],
+      pageInfo: { hasMore: false, nextCursor: null, prevCursor: null },
+      sequence: 0,
+      directoryGeneration: "gen-2",
+    });
+
+    await directory.refreshAgents();
+
+    // 第 2 次调用是带 cursor 的增量尝试，被拒后第 3 次退化为无 cursor 的全量
+    expect(client.fetchAgentsCalls).toBe(3);
+    expect(client.fetchAgentsOptions[1]).toMatchObject({
+      afterSequence: 5,
+      directoryGeneration: "gen-1",
+    });
+    expect(client.fetchAgentsOptions[2].afterSequence).toBeUndefined();
+    expect(useSessionStore.getState().sessions[serverId]?.agents.get("agent-a")).toMatchObject({
+      title: "a-v2",
     });
     directory.dispose();
   });

--- a/packages/app/src/runtime/directory-sync/index.ts
+++ b/packages/app/src/runtime/directory-sync/index.ts
@@ -40,6 +40,7 @@ interface AgentSnapshot {
   entries: FetchAgentsEntry[];
   subscriptionId: string | null;
   legacy: boolean;
+  directoryCursor: { generation: string; sequence: number } | null;
 }
 
 export interface DirectoryConnection {
@@ -187,6 +188,7 @@ export class DirectorySync {
       entries: [],
       subscriptionId: null,
       legacy: false,
+      directoryCursor: null,
     }));
     this.callbacks.markAgentLoading();
     try {
@@ -236,6 +238,13 @@ export class DirectorySync {
           )
         : completion.deltas;
       const agents = this.agents.commitSnapshot(completion.snapshot.entries, deltas);
+      // Advance the cursor only after the whole paginated snapshot committed. A
+      // mid-pagination failure leaves the cursor at its previous value, so the
+      // next sync resumes incrementally from a state the client actually
+      // applied — not from a sequence whose entries were discarded.
+      if (completion.snapshot.directoryCursor) {
+        this.agentDirectoryCursor = completion.snapshot.directoryCursor;
+      }
       this.callbacks.markAgentReady();
       return { agents, subscriptionId: completion.snapshot.subscriptionId };
     } catch (error) {
@@ -350,7 +359,7 @@ export class DirectorySync {
       transaction.snapshot.entries.push(...payload.entries);
       transaction.snapshot.subscriptionId ??= payload.subscriptionId ?? null;
       if (payload.sequence !== undefined && payload.directoryGeneration !== undefined) {
-        this.agentDirectoryCursor = {
+        transaction.snapshot.directoryCursor = {
           generation: payload.directoryGeneration,
           sequence: payload.sequence,
         };

--- a/packages/app/src/runtime/directory-sync/index.ts
+++ b/packages/app/src/runtime/directory-sync/index.ts
@@ -77,6 +77,11 @@ export class DirectorySync {
   };
   private unsubscribe: (() => void) | null = null;
   private readonly abortSessionWaits = new Set<() => void>();
+  // Last agent-directory sequence this client applied, keyed by the daemon's
+  // generation. On reconnect we ask the daemon for only the mutations after it,
+  // avoiding the full paginated snapshot. A null cursor or a generation change
+  // (daemon restart) forces the full path.
+  private agentDirectoryCursor: { generation: string; sequence: number } | null = null;
 
   constructor(
     private readonly serverId: string,
@@ -170,6 +175,14 @@ export class DirectorySync {
     input: RefreshAgentDirectoryInput = {},
   ): Promise<RefreshAgentDirectoryResult> {
     const { client, source } = this.requireOnline();
+
+    // Incremental fast path: with a live sequence cursor we ask the daemon for
+    // only the mutations since the last sync instead of the full snapshot. The
+    // daemon decides whether a delta is still reconstructible; anything else
+    // falls through to the full paginated path below.
+    const incremental = await this.tryRefreshIncrementally(client, source, input);
+    if (incremental) return incremental;
+
     const transaction = this.agentTransactions.begin(source, () => ({
       entries: [],
       subscriptionId: null,
@@ -336,6 +349,12 @@ export class DirectorySync {
       this.assertAgentTransactionCurrent(client, source, transaction);
       transaction.snapshot.entries.push(...payload.entries);
       transaction.snapshot.subscriptionId ??= payload.subscriptionId ?? null;
+      if (payload.sequence !== undefined && payload.directoryGeneration !== undefined) {
+        this.agentDirectoryCursor = {
+          generation: payload.directoryGeneration,
+          sequence: payload.sequence,
+        };
+      }
       const pageInfo = payload.pageInfo as {
         hasMore?: boolean;
         hasMoreAfter?: boolean;
@@ -348,6 +367,69 @@ export class DirectorySync {
       cursor = nextCursor;
       subscribe = undefined;
     }
+  }
+
+  /**
+   * Runs the incremental fast path only when a live sequence cursor is present
+   * and no filter is active; returns null otherwise so the caller falls through
+   * to the full paginated snapshot.
+   */
+  private async tryRefreshIncrementally(
+    client: DaemonClient,
+    source: DirectorySourceToken,
+    input: RefreshAgentDirectoryInput,
+  ): Promise<RefreshAgentDirectoryResult | null> {
+    if (input.filter || !this.agentDirectoryCursor) return null;
+    return this.tryIncrementalAgentDirectory(client, source, input);
+  }
+
+  /**
+   * Incremental agent-directory sync. Requests only the mutations since the
+   * last applied sequence; applies them through the same delta path as live
+   * `agent_update` events. Returns `null` when the daemon could not produce a
+   * delta (generation changed, cursor aged out, too many changes) or the
+   * connection moved underneath us — the caller then runs the full snapshot.
+   */
+  private async tryIncrementalAgentDirectory(
+    client: DaemonClient,
+    source: DirectorySourceToken,
+    input: RefreshAgentDirectoryInput,
+  ): Promise<RefreshAgentDirectoryResult | null> {
+    const cursor = this.agentDirectoryCursor;
+    if (!cursor) return null;
+    let payload: Awaited<ReturnType<DaemonClient["fetchAgents"]>>;
+    try {
+      payload = await client.fetchAgents({
+        scope: "active",
+        afterSequence: cursor.sequence,
+        directoryGeneration: cursor.generation,
+        ...(input.subscribe ? { subscribe: input.subscribe } : {}),
+      });
+    } catch {
+      return null;
+    }
+    if (!this.isCurrent(client, source) || payload.incremental !== true) return null;
+
+    for (const entry of payload.entries ?? []) {
+      this.agents.applyDelta({
+        kind: "upsert",
+        agent: entry.agent,
+        project: entry.project ?? null,
+      });
+    }
+    for (const agentId of payload.deletedIds ?? []) {
+      this.agents.applyDelta({ kind: "remove", agentId });
+    }
+
+    if (payload.sequence !== undefined && payload.directoryGeneration !== undefined) {
+      this.agentDirectoryCursor = {
+        generation: payload.directoryGeneration,
+        sequence: payload.sequence,
+      };
+    }
+    const agents = useSessionStore.getState().sessions[this.serverId]?.agents ?? new Map();
+    this.callbacks.markAgentReady();
+    return { agents, subscriptionId: payload.subscriptionId ?? null };
   }
 
   private assertAgentTransactionCurrent(

--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -168,6 +168,19 @@ class FakeDaemonClient {
 
   setReconnectEnabled(_enabled: boolean): void {}
 
+  public backgroundedValues: boolean[] = [];
+
+  setBackgrounded(backgrounded: boolean): void {
+    this.backgroundedValues.push(backgrounded);
+  }
+
+  public forceLivenessCheckCalls = 0;
+
+  forceLivenessCheck(): Promise<boolean> {
+    this.forceLivenessCheckCalls += 1;
+    return Promise.resolve(true);
+  }
+
   getLastLivenessRttMs(): number | null {
     return this.heartbeatRttMs;
   }
@@ -1380,6 +1393,44 @@ describe("HostRuntimeController", () => {
     expect(controller.getSnapshot().client).toBe(activeClientBeforeProbes);
     expect(controller.getSnapshot().clientGeneration).toBe(generationBeforeProbes);
     expect(createdClients).toHaveLength(0);
+  });
+
+  it("delegates background pause/resume and forced liveness checks to the active client", async () => {
+    useHostRuntimeClock();
+    const host = makeHost({
+      connections: [
+        {
+          id: "direct:lan:6767",
+          type: "directTcp",
+          endpoint: "lan:6767",
+        },
+      ],
+    });
+    const activeClient = new FakeDaemonClient();
+    const controller = new HostRuntimeController({
+      host,
+      deps: {
+        createClient: () => activeClient as unknown as DaemonClient,
+        connectToDaemon: async () => {
+          throw new Error("probe unavailable");
+        },
+        getClientId: async () => "cid_test_runtime",
+      },
+    });
+
+    await controller.start();
+    await controller.activateConnection({ connectionId: "direct:lan:6767" });
+    expect(controller.getSnapshot().client).toBe(activeClient);
+
+    controller.setBackgrounded(true);
+    expect(activeClient.backgroundedValues).toEqual([true]);
+
+    controller.setBackgrounded(false);
+    expect(activeClient.backgroundedValues).toEqual([true, false]);
+
+    controller.forceLivenessCheck();
+    await Promise.resolve();
+    expect(activeClient.forceLivenessCheckCalls).toBe(1);
   });
 });
 

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -558,6 +558,8 @@ export class HostRuntimeController {
   private unsubscribeClientStatus: (() => void) | null = null;
   private unsubscribeClientHandlers: (() => void) | null = null;
   private probeIntervalHandle: ReturnType<typeof setInterval> | null = null;
+  private autoProbe = true;
+  private backgrounded = false;
   private started = false;
   private connectionFirstSeenAt = new Map<string, number>();
   private connectionLastProbedAt = new Map<string, number>();
@@ -612,6 +614,7 @@ export class HostRuntimeController {
       return;
     }
     this.started = true;
+    this.autoProbe = options?.autoProbe !== false;
     this.trackConnectionFirstSeen();
     if (options?.initialConnection) {
       await this.switchToConnection({
@@ -653,6 +656,37 @@ export class HostRuntimeController {
       ...toSnapshotConnectionPatch(this.connectionMachineState, this.connectionEpoch),
       client: null,
     });
+  }
+
+  /**
+   * Pause probe work and delegate keep-alive pause to the active client while the app
+   * is backgrounded. On resume, restore the probe interval and let the caller trigger a
+   * forced liveness check so a silently-dead socket reconnects immediately instead of
+   * after the next heartbeat timeout.
+   */
+  setBackgrounded(backgrounded: boolean): void {
+    if (this.backgrounded === backgrounded) {
+      return;
+    }
+    this.backgrounded = backgrounded;
+    if (backgrounded) {
+      this.activeClient?.setBackgrounded(true);
+      if (this.probeIntervalHandle) {
+        clearInterval(this.probeIntervalHandle);
+        this.probeIntervalHandle = null;
+      }
+      return;
+    }
+    this.activeClient?.setBackgrounded(false);
+    if (this.started && this.autoProbe && !this.probeIntervalHandle) {
+      this.probeIntervalHandle = setInterval(() => {
+        void this.runProbeCycleNow();
+      }, PROBE_TICK_MS);
+    }
+  }
+
+  forceLivenessCheck(): void {
+    void this.activeClient?.forceLivenessCheck().catch(() => undefined);
   }
 
   async updateHost(host: HostProfile): Promise<void> {
@@ -2200,6 +2234,19 @@ export class HostRuntimeStore {
   ensureConnectedAll(): void {
     for (const controller of this.controllers.values()) {
       controller.ensureConnected();
+    }
+  }
+
+  setBackgrounded(backgrounded: boolean): void {
+    for (const controller of this.controllers.values()) {
+      controller.setBackgrounded(backgrounded);
+    }
+    if (!backgrounded) {
+      // Foreground resume: probe every active connection immediately so a socket the
+      // OS killed while backgrounded reconnects without waiting for a heartbeat timeout.
+      for (const controller of this.controllers.values()) {
+        controller.forceLivenessCheck();
+      }
     }
   }
 

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -1234,6 +1234,10 @@ export class HostRuntimeController {
     }
 
     this.activeClient = client;
+    // A client established while the app is backgrounded (e.g. a host that
+    // comes online mid-background) must inherit the background state — the
+    // store only fans setBackgrounded out to controllers that already exist.
+    if (this.backgrounded) client.setBackgrounded(true);
     this.unsubscribeClientHandlers =
       this.deps.mountClientHandlers?.({ client, host: this.host, connection }) ?? null;
     this.applyConnectionEvent({
@@ -1395,6 +1399,7 @@ export class HostRuntimeStore {
   private bootPromise: Promise<void> | null = null;
   private storage: HostRuntimeStorage;
   private replicaCache: ReplicaCache;
+  private backgrounded = false;
 
   constructor(input?: { deps?: HostRuntimeControllerDeps; storage?: HostRuntimeStorage }) {
     this.deps = input?.deps ?? createDefaultDeps();
@@ -2008,6 +2013,10 @@ export class HostRuntimeStore {
         onReconcileServerId: (oldId, newId) => this.reconcileServerId(oldId, newId),
       });
       this.controllers.set(host.serverId, controller);
+      // A controller created after the app went to the background must inherit
+      // the current background state — setBackgrounded only fans out to
+      // controllers that already exist.
+      if (this.backgrounded) controller.setBackgrounded(true);
       this.directorySyncByServer.set(
         host.serverId,
         new DirectorySync(host.serverId, {
@@ -2238,6 +2247,7 @@ export class HostRuntimeStore {
   }
 
   setBackgrounded(backgrounded: boolean): void {
+    this.backgrounded = backgrounded;
     for (const controller of this.controllers.values()) {
       controller.setBackgrounded(backgrounded);
     }

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -587,6 +587,14 @@ class DaemonClientSession {
     return this.client.getLastLivenessRttMs();
   }
 
+  setBackgrounded(backgrounded: boolean): void {
+    this.client.setBackgrounded(backgrounded);
+  }
+
+  forceLivenessCheck(): Promise<boolean> {
+    return this.client.forceLivenessCheck();
+  }
+
   measureLatency(input: { timeoutMs: number }): Promise<number> {
     return this.client.measureLatency(input);
   }
@@ -1604,6 +1612,52 @@ test("stops pinging once the connection is gone", async () => {
   await session.advance(30_000);
 
   expect(session.pingTimestamps()).toEqual(["10s"]);
+});
+
+test("stops the liveness heartbeat while backgrounded and resumes it on foreground", async () => {
+  useHeartbeatClock();
+  const session = new DaemonClientSession();
+  session.daemonAnswersPingsAfter("fast");
+
+  await session.connect();
+  await session.advance(10_000);
+  expect(session.pingTimestamps()).toEqual(["10s"]);
+
+  session.setBackgrounded(true);
+  await session.advance(60_000);
+  expect(session.pingTimestamps()).toEqual(["10s"]);
+
+  session.setBackgrounded(false);
+  await session.advance(10_000);
+  expect(session.pingTimestamps()).toEqual(["10s", "80s"]);
+});
+
+test("forceLivenessCheck returns true when the socket is live", async () => {
+  useHeartbeatClock();
+  const session = new DaemonClientSession();
+  session.daemonAnswersPingsAfter("fast");
+
+  await session.connect();
+  expect(await session.forceLivenessCheck()).toBe(true);
+  expect(session.state()).toEqual({ status: "connected" });
+});
+
+test("forceLivenessCheck tears down a silently-dead socket and reports it disconnected", async () => {
+  useHeartbeatClock();
+  const session = new DaemonClientSession();
+  session.daemonGoesSilent();
+
+  await session.connect();
+  const check = session.forceLivenessCheck();
+  await session.advance(5_000);
+  expect(await check).toBe(false);
+  expect(session.state()).toEqual({
+    status: "disconnected",
+    reason: "Liveness check timed out (5000ms)",
+  });
+  expect(session.closesFromClient()).toEqual([
+    { code: 1001, reason: "Liveness check timed out (5000ms)" },
+  ]);
 });
 
 test("sends only one ping while a slow pong is still outstanding", async () => {
@@ -3055,6 +3109,49 @@ test("requires non-empty clientId", () => {
     });
     void _client;
   }).toThrow("Daemon client requires a non-empty clientId");
+});
+
+test("backgrounding defers reconnects and foreground resume reconnects immediately", async () => {
+  useHeartbeatClock();
+  try {
+    const logger = createMockLogger();
+    const mock = createMockTransport();
+    let factoryCalls = 0;
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_bg_reconnect_test",
+      logger,
+      reconnect: { enabled: true, baseDelayMs: 1000, maxDelayMs: 1000 },
+      transportFactory: () => {
+        factoryCalls += 1;
+        return mock.transport;
+      },
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    mock.triggerOpen();
+    await connectPromise;
+    expect(client.getConnectionState().status).toBe("connected");
+    expect(factoryCalls).toBe(1);
+
+    // Backgrounded: the transport dies but the reconnect timer must not fire.
+    client.setBackgrounded(true);
+    mock.triggerClose({ code: 1006, reason: "backgrounded socket kill" });
+    expect(client.getConnectionState().status).toBe("disconnected");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(factoryCalls).toBe(1);
+
+    // Foreground resume reconnects immediately.
+    client.setBackgrounded(false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(client.getConnectionState().status).toBe("connecting");
+    expect(factoryCalls).toBe(2);
+    mock.triggerOpen();
+    expect(client.getConnectionState().status).toBe("connected");
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("requires non-empty clientId for direct connections", () => {

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -1163,6 +1163,7 @@ export class DaemonClient {
   private livenessHeartbeatTimer: ReturnType<typeof setTimeout> | null = null;
   private lastLivenessRttMs: number | null = null;
   private consecutiveLivenessFailures = 0;
+  private backgrounded = false;
 
   constructor(private config: DaemonClientConfig) {
     this.logger = config.logger ?? consoleLogger;
@@ -1454,6 +1455,66 @@ export class DaemonClient {
       return;
     }
     void this.connect();
+  }
+
+  /**
+   * Pause connection keep-alive work while the app is backgrounded. Stops the liveness
+   * heartbeat and any pending reconnect timer. Native OSes freeze or throttle the JS
+   * thread in the background, and letting heartbeat pings and reconnect attempts keep
+   * firing just wakes the radio for nothing — background delivery goes through push
+   * notifications, not this socket. Resuming clears the reconnect backoff so the first
+   * foreground reconnect uses the shortest delay.
+   */
+  setBackgrounded(backgrounded: boolean): void {
+    if (this.backgrounded === backgrounded) {
+      return;
+    }
+    this.backgrounded = backgrounded;
+    if (backgrounded) {
+      this.stopLivenessHeartbeat();
+      if (this.reconnectTimeout) {
+        clearTimeout(this.reconnectTimeout);
+        this.reconnectTimeout = null;
+      }
+      return;
+    }
+    this.reconnectAttempt = 0;
+    if (
+      this.connectionState.status === "connected" ||
+      this.connectionState.status === "connecting"
+    ) {
+      this.startLivenessHeartbeat();
+    }
+    if (this.connectionState.status === "disconnected" || this.connectionState.status === "idle") {
+      void this.connect();
+    }
+  }
+
+  /**
+   * Force an immediate liveness probe of the current connection. Used when the app
+   * returns to the foreground to detect a silently-dead socket (backgrounded iOS/Android
+   * often tears the WebSocket down without the client noticing) instead of waiting for
+   * the next liveness heartbeat timeout. Returns true when the connection answered. A
+   * failed probe tears the transport down and schedules a reconnect immediately.
+   */
+  async forceLivenessCheck(params?: { timeoutMs?: number }): Promise<boolean> {
+    if (this.backgrounded || this.connectionState.status !== "connected" || !this.transport) {
+      return false;
+    }
+    try {
+      await this.livenessPing({ timeoutMs: params?.timeoutMs ?? DEFAULT_LIVENESS_TIMEOUT_MS });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Forced liveness check failed";
+      this.lastErrorValue = message;
+      this.disposeTransport(1001, message);
+      this.scheduleReconnect({
+        reason: message,
+        event: "FORCED_LIVENESS_FAILED",
+        reasonCode: "liveness_timeout",
+      });
+      return false;
+    }
   }
 
   getConnectionState(): ConnectionState {
@@ -2081,6 +2142,8 @@ export class DaemonClient {
       ...(options?.sort ? { sort: options.sort } : {}),
       ...(options?.page ? { page: options.page } : {}),
       ...(options?.subscribe ? { subscribe: options.subscribe } : {}),
+      ...(options?.afterSequence !== undefined ? { afterSequence: options.afterSequence } : {}),
+      ...(options?.directoryGeneration ? { directoryGeneration: options.directoryGeneration } : {}),
     });
     return this.sendRequest({
       requestId: resolvedRequestId,
@@ -5753,6 +5816,11 @@ export class DaemonClient {
   }
 
   private armReconnectTimer(): void {
+    if (this.backgrounded) {
+      // Do not wake the radio to reconnect while backgrounded; the app reconnects
+      // explicitly on foreground resume (see setBackgrounded).
+      return;
+    }
     const attempt = this.reconnectAttempt;
     const baseDelay = this.config.reconnect?.baseDelayMs ?? DEFAULT_RECONNECT_BASE_DELAY_MS;
     const maxDelay = this.config.reconnect?.maxDelayMs ?? DEFAULT_RECONNECT_MAX_DELAY_MS;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1085,6 +1085,13 @@ export const FetchAgentsRequestMessageSchema = z.object({
       subscriptionId: z.string().optional(),
     })
     .optional(),
+  // COMPAT(agentDirectoryIncremental): added in v0.3.0-beta.2, remove after 2027-01-06.
+  // Optional incremental directory sync. When present with a matching `directoryGeneration`,
+  // the daemon returns only agents whose records changed after `afterSequence`, plus the
+  // `deletedIds` removed from the active directory since then. Older daemons strip the
+  // unknown field and return a full page, which clients detect via `incremental: true`.
+  afterSequence: z.number().int().nonnegative().optional(),
+  directoryGeneration: z.string().optional(),
 });
 
 const WorkspaceStateBucketSchema = z.enum([
@@ -3323,6 +3330,16 @@ export const FetchAgentsResponseMessageSchema = z.object({
     subscriptionId: z.string().nullable().optional(),
     entries: z.array(AgentDirectoryResponseEntrySchema),
     pageInfo: AgentDirectoryPageInfoSchema,
+    // COMPAT(agentDirectoryIncremental): added in v0.3.0-beta.2, remove after 2027-01-06.
+    // Present on every fetch_agents_response. When `incremental: true` the response is a
+    // partial diff: `entries` are agents that changed after `afterSequence`, `deletedIds`
+    // are agents removed from the active directory since then, and the page is complete
+    // (no cursor). Older clients ignore these unknown fields and treat the response as a
+    // full page.
+    sequence: z.number().int().nonnegative().optional(),
+    directoryGeneration: z.string().optional(),
+    deletedIds: z.array(z.string()).optional(),
+    incremental: z.boolean().optional(),
   }),
 });
 

--- a/packages/server/src/server/agent/agent-directory-sequence.test.ts
+++ b/packages/server/src/server/agent/agent-directory-sequence.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { AgentDirectorySequenceTracker } from "./agent-directory-sequence.js";
+
+describe("AgentDirectorySequenceTracker", () => {
+  it("starts at sequence zero with an empty change log", () => {
+    const tracker = new AgentDirectorySequenceTracker("gen");
+    expect(tracker.getCurrentSequence()).toBe(0);
+    expect(tracker.getGeneration()).toBe("gen");
+    expect(tracker.changesAfter(0)).toEqual({ changes: [], incremental: false });
+  });
+
+  it("assigns monotonically increasing sequences to changes", () => {
+    const tracker = new AgentDirectorySequenceTracker("gen");
+    tracker.recordChange("a", "upsert");
+    tracker.recordChange("b", "delete");
+    tracker.recordChange("a", "upsert");
+    expect(tracker.getCurrentSequence()).toBe(3);
+  });
+
+  it("returns every change after a cursor", () => {
+    const tracker = new AgentDirectorySequenceTracker("gen");
+    tracker.recordChange("a", "upsert");
+    tracker.recordChange("b", "delete");
+    tracker.recordChange("c", "upsert");
+
+    const result = tracker.changesAfter(0);
+    expect(result.incremental).toBe(true);
+    expect(result.changes).toEqual([
+      { seq: 1, type: "upsert", agentId: "a" },
+      { seq: 2, type: "delete", agentId: "b" },
+      { seq: 3, type: "upsert", agentId: "c" },
+    ]);
+  });
+
+  it("returns only changes after the cursor", () => {
+    const tracker = new AgentDirectorySequenceTracker("gen");
+    tracker.recordChange("a", "upsert");
+    tracker.recordChange("b", "upsert");
+    tracker.recordChange("c", "upsert");
+
+    const result = tracker.changesAfter(1);
+    expect(result.incremental).toBe(true);
+    expect(result.changes).toEqual([
+      { seq: 2, type: "upsert", agentId: "b" },
+      { seq: 3, type: "upsert", agentId: "c" },
+    ]);
+  });
+
+  it("reports an up-to-date cursor as incremental with no changes", () => {
+    const tracker = new AgentDirectorySequenceTracker("gen");
+    tracker.recordChange("a", "upsert");
+    expect(tracker.changesAfter(1)).toEqual({ changes: [], incremental: true });
+  });
+
+  it("declines a delta when the cursor is older than the retained window", () => {
+    const tracker = new AgentDirectorySequenceTracker("gen");
+    for (let i = 0; i < 5005; i += 1) {
+      tracker.recordChange(`agent-${i}`, "upsert");
+    }
+    // The first five changes were evicted; seq 1..5 are no longer reconstructible.
+    expect(tracker.changesAfter(0)).toEqual({ changes: [], incremental: false });
+    expect(tracker.changesAfter(6)).toMatchObject({ incremental: true });
+  });
+
+  it("keeps each instance on its own generation", () => {
+    expect(new AgentDirectorySequenceTracker().getGeneration()).not.toBe(
+      new AgentDirectorySequenceTracker().getGeneration(),
+    );
+  });
+});

--- a/packages/server/src/server/agent/agent-directory-sequence.ts
+++ b/packages/server/src/server/agent/agent-directory-sequence.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from "node:crypto";
+
+export interface AgentDirectoryChange {
+  seq: number;
+  type: "upsert" | "delete";
+  agentId: string;
+}
+
+const MAX_TRACKED_CHANGES = 5000;
+
+/**
+ * Tracks agent record mutations so clients can resync the agent directory
+ * incrementally instead of re-fetching the full paginated snapshot on every
+ * reconnect.
+ *
+ * Every persisted agent upsert/delete records a change with a monotonically
+ * increasing `seq`. A client that remembers the last `seq` it applied can ask
+ * for `changesAfter(seq)` and receive only the mutations it missed. Deletions
+ * are reported explicitly so the client can drop agents that no longer exist.
+ *
+ * The sequence is in-memory and process-local: a daemon restart resets it to
+ * zero with a fresh `generation`. Clients pin the generation they synced under
+ * and fall back to a full resync when it changes.
+ *
+ * Only recent changes are retained (`MAX_TRACKED_CHANGES`); a client whose
+ * cursor has aged past the retained window is told the delta is unavailable
+ * and must full-resync.
+ */
+export class AgentDirectorySequenceTracker {
+  private seq = 0;
+  private readonly generation: string;
+  private readonly changes: AgentDirectoryChange[] = [];
+  private minTrackedSeq = 1;
+
+  constructor(generation?: string) {
+    this.generation = generation ?? randomUUID();
+  }
+
+  getGeneration(): string {
+    return this.generation;
+  }
+
+  getCurrentSequence(): number {
+    return this.seq;
+  }
+
+  recordChange(agentId: string, type: "upsert" | "delete"): void {
+    this.seq += 1;
+    this.changes.push({ seq: this.seq, type, agentId });
+    if (this.changes.length > MAX_TRACKED_CHANGES) {
+      this.changes.shift();
+    }
+    this.minTrackedSeq = this.changes[0]?.seq ?? this.seq + 1;
+  }
+
+  /**
+   * Returns the mutations after `afterSequence`, or `{ incremental: false }`
+   * when the delta cannot be reconstructed (no changes recorded yet, cursor
+   * already current, or cursor too old for the retained window). The caller
+   * must also verify the client's `directoryGeneration` matches before trusting
+   * a delta.
+   */
+  changesAfter(afterSequence: number): { changes: AgentDirectoryChange[]; incremental: boolean } {
+    if (this.seq === 0) {
+      return { changes: [], incremental: false };
+    }
+    if (afterSequence >= this.seq) {
+      return { changes: [], incremental: true };
+    }
+    // The window starts at `minTrackedSeq`; a cursor that needs anything before
+    // it can't be reconstructed, so the caller must full-resync.
+    if (afterSequence + 1 < this.minTrackedSeq) {
+      return { changes: [], incremental: false };
+    }
+    return {
+      changes: this.changes.filter((change) => change.seq > afterSequence),
+      incremental: true,
+    };
+  }
+}

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -6,6 +6,7 @@ import type { Logger } from "pino";
 import { writeJsonFileAtomic } from "../atomic-file.js";
 import { AgentFeatureSchema, AgentStatusSchema } from "../messages.js";
 import { toStoredAgentRecord } from "./agent-projections.js";
+import { AgentDirectorySequenceTracker } from "./agent-directory-sequence.js";
 import type { ManagedAgent } from "./agent-manager.js";
 import type { AgentSessionConfig } from "./agent-sdk-types.js";
 import { AgentOwnerSchema, daemonExecutionKey, type DaemonAgentOwner } from "./agent-owner.js";
@@ -96,6 +97,7 @@ export class AgentStorage {
   private baseDir: string;
   private loadPromise: Promise<StoredAgentRecord[]> | null = null;
   private logger: Logger;
+  private readonly sequenceTracker = new AgentDirectorySequenceTracker();
 
   constructor(baseDir: string, logger: Logger) {
     this.baseDir = baseDir;
@@ -169,6 +171,7 @@ export class AgentStorage {
     this.cache.set(agentId, record);
     this.indexOwner(record);
     this.pathById.set(agentId, nextPath);
+    this.sequenceTracker.recordChange(agentId, record.archivedAt != null ? "delete" : "upsert");
   }
 
   beginDelete(agentId: string): void {
@@ -200,6 +203,11 @@ export class AgentStorage {
     this.removeOwnerIndex(agentId);
     this.pathById.delete(agentId);
     this.pathsById.delete(agentId);
+    this.sequenceTracker.recordChange(agentId, "delete");
+  }
+
+  getDirectorySequenceTracker(): AgentDirectorySequenceTracker {
+    return this.sequenceTracker;
   }
 
   async applySnapshot(

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -21,10 +21,14 @@ import {
 import { isSessionRpcAllowed, Session } from "./session.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
 import { StructuredAgentFallbackError } from "./agent/agent-response-loop.js";
-import type { StoredAgentRecord } from "./agent/agent-storage.js";
+import { AgentDirectorySequenceTracker } from "./agent/agent-directory-sequence.js";
+import { AgentStorage, type StoredAgentRecord } from "./agent/agent-storage.js";
 import type { AgentManagerEvent } from "./agent/agent-manager.js";
 import type { ProviderSnapshotManager } from "./agent/provider-snapshot-manager.js";
-import { createPersistedProjectRecord } from "./workspace-registry.js";
+import {
+  createPersistedProjectRecord,
+  createPersistedWorkspaceRecord,
+} from "./workspace-registry.js";
 import { deriveProjectKey } from "./project-key.js";
 import type { SessionOptions } from "./session.js";
 import type { SessionInboundMessage, SessionOutboundMessage } from "./messages.js";
@@ -377,6 +381,7 @@ function createSessionForTest(options: SessionForTestOptions = {}): Session {
     agentStorage: asAgentStorage({
       get: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue([]),
+      getDirectorySequenceTracker: () => new AgentDirectorySequenceTracker(),
       ...options.agentStorage,
     }),
     projectRegistry: {
@@ -1161,6 +1166,263 @@ describe("agent detach RPC", () => {
         error: null,
       },
     });
+  });
+});
+
+describe("agent directory incremental sync", () => {
+  async function setupIncrementalSession(
+    messages: SessionOutboundMessage[],
+  ): Promise<{ session: Session; storage: AgentStorage }> {
+    const home = mkdtempSync(join(tmpdir(), "paseo-incr-"));
+    const storage = new AgentStorage(home, pino({ level: "silent" }));
+    await storage.initialize();
+    const project = createPersistedProjectRecord({
+      projectId: "project-1",
+      rootPath: "/tmp/ws1",
+      kind: "git",
+      displayName: "Project",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const workspace = createPersistedWorkspaceRecord({
+      workspaceId: "ws-1",
+      projectId: project.projectId,
+      cwd: "/tmp/ws1",
+      kind: "worktree",
+      displayName: "WS1",
+      branch: "main",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const providerSnapshotManagerStub = createProviderSnapshotManagerStub();
+    providerSnapshotManagerStub.listRegisteredProviderIds.mockReturnValue(["codex"]);
+    const session = createSessionForTest({
+      messages,
+      agentManager: { getAgent: vi.fn(() => null) },
+      agentStorage: {
+        get: storage.get.bind(storage),
+        list: storage.list.bind(storage),
+        upsert: storage.upsert.bind(storage),
+        remove: storage.remove.bind(storage),
+        getDirectorySequenceTracker: storage.getDirectorySequenceTracker.bind(storage),
+      } as unknown as SessionOptions["agentStorage"],
+      workspaceRegistry: {
+        get: vi.fn().mockResolvedValue(workspace),
+        list: vi.fn().mockResolvedValue([workspace]),
+      },
+      projectRegistry: {
+        get: vi.fn().mockResolvedValue(project),
+        list: vi.fn().mockResolvedValue([project]),
+      },
+      providerSnapshotManager: providerSnapshotManagerStub.manager,
+    });
+    afterEach(() => {
+      rmSync(home, { recursive: true, force: true });
+    });
+    return { session, storage };
+  }
+
+  function fetchAgentsResponse(messages: SessionOutboundMessage[]): {
+    type: "fetch_agents_response";
+    payload: Record<string, unknown>;
+  } {
+    const message = messages.find((m): m is { type: string } => m.type === "fetch_agents_response");
+    if (!message) {
+      throw new Error("no fetch_agents_response emitted");
+    }
+    return message as unknown as {
+      type: "fetch_agents_response";
+      payload: Record<string, unknown>;
+    };
+  }
+
+  test("returns only the mutations after the sequence cursor", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const { session, storage } = await setupIncrementalSession(messages);
+    const agentA = createStoredAgentRecord({ id: "agent-a", cwd: "/tmp/ws1", workspaceId: "ws-1" });
+    await storage.upsert(agentA);
+    const generation = storage.getDirectorySequenceTracker().getGeneration();
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "full-1",
+      scope: "active",
+    });
+    const full = fetchAgentsResponse(messages);
+    expect(full.payload.sequence).toBe(1);
+    expect(full.payload.directoryGeneration).toBe(generation);
+    expect((full.payload.entries as { agent: { id: string } }[]).map((e) => e.agent.id)).toEqual([
+      "agent-a",
+    ]);
+    messages.splice(0);
+
+    const agentB = createStoredAgentRecord({ id: "agent-b", cwd: "/tmp/ws1", workspaceId: "ws-1" });
+    await storage.upsert(agentB);
+    await storage.remove(agentA.id);
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "incr-1",
+      scope: "active",
+      afterSequence: 1,
+      directoryGeneration: generation,
+    });
+    const incr = fetchAgentsResponse(messages);
+    expect(incr.payload.incremental).toBe(true);
+    expect((incr.payload.entries as { agent: { id: string } }[]).map((e) => e.agent.id)).toEqual([
+      "agent-b",
+    ]);
+    expect(incr.payload.deletedIds).toEqual(["agent-a"]);
+    expect(incr.payload.sequence).toBe(3);
+    expect(incr.payload.directoryGeneration).toBe(generation);
+  });
+
+  test("falls back to a full snapshot when the daemon generation does not match", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const { session, storage } = await setupIncrementalSession(messages);
+    const agentA = createStoredAgentRecord({ id: "agent-a", cwd: "/tmp/ws1", workspaceId: "ws-1" });
+    await storage.upsert(agentA);
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "incr-stale",
+      scope: "active",
+      afterSequence: 1,
+      directoryGeneration: "a-different-generation",
+    });
+    const response = fetchAgentsResponse(messages);
+    expect(response.payload.incremental).toBeUndefined();
+    expect(
+      (response.payload.entries as { agent: { id: string } }[]).map((e) => e.agent.id),
+    ).toEqual(["agent-a"]);
+  });
+
+  test("reports archived agents through deletedIds", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const { session, storage } = await setupIncrementalSession(messages);
+    const agentA = createStoredAgentRecord({ id: "agent-a", cwd: "/tmp/ws1", workspaceId: "ws-1" });
+    await storage.upsert(agentA);
+    const generation = storage.getDirectorySequenceTracker().getGeneration();
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "full-1",
+      scope: "active",
+    });
+    messages.splice(0);
+
+    const archivedAgent = createStoredAgentRecord({
+      id: "agent-a",
+      cwd: "/tmp/ws1",
+      workspaceId: "ws-1",
+      archivedAt: "2026-01-02T00:00:00.000Z",
+    });
+    await storage.upsert(archivedAgent);
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "incr-archived",
+      scope: "active",
+      afterSequence: 1,
+      directoryGeneration: generation,
+    });
+    const response = fetchAgentsResponse(messages);
+    expect(response.payload.incremental).toBe(true);
+    expect(response.payload.deletedIds).toEqual(["agent-a"]);
+    expect(response.payload.entries).toEqual([]);
+  });
+
+  test("snapshots the sequence before async work so concurrent changes stay catchable", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const { session, storage } = await setupIncrementalSession(messages);
+    const agentA = createStoredAgentRecord({ id: "agent-a", cwd: "/tmp/ws1", workspaceId: "ws-1" });
+    await storage.upsert(agentA);
+    const tracker = storage.getDirectorySequenceTracker();
+    const generation = tracker.getGeneration();
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "full-1",
+      scope: "active",
+    });
+    messages.splice(0);
+
+    // Fire an incremental request without awaiting: handleMessage synchronously
+    // reaches the sequence snapshot, then suspends on async I/O. A change
+    // recorded during that window must not advance the cursor the client gets —
+    // the snapshot keeps the cursor conservative so the follow-up request below
+    // re-catches anything added in between.
+    const requestPromise = session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "incr-1",
+      scope: "active",
+      afterSequence: 1,
+      directoryGeneration: generation,
+    });
+    tracker.recordChange("agent-b", "upsert");
+    await requestPromise;
+
+    const incr = fetchAgentsResponse(messages);
+    expect(incr.payload.incremental).toBe(true);
+    expect(incr.payload.sequence).toBe(1);
+    expect(incr.payload.directoryGeneration).toBe(generation);
+    expect((incr.payload.entries as { agent: { id: string } }[]).map((e) => e.agent.id)).toEqual(
+      [],
+    );
+
+    // A follow-up request from the snapshot cursor catches the in-flight change.
+    messages.splice(0);
+    const agentB = createStoredAgentRecord({ id: "agent-b", cwd: "/tmp/ws1", workspaceId: "ws-1" });
+    await storage.upsert(agentB);
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "incr-2",
+      scope: "active",
+      afterSequence: 1,
+      directoryGeneration: generation,
+    });
+    const followUp = fetchAgentsResponse(messages);
+    expect(
+      (followUp.payload.entries as { agent: { id: string } }[]).map((e) => e.agent.id),
+    ).toEqual(["agent-b"]);
+    expect(followUp.payload.deletedIds).toEqual([]);
+  });
+
+  test("does not report a restored agent in both entries and deletedIds", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const { session, storage } = await setupIncrementalSession(messages);
+    const agentA = createStoredAgentRecord({ id: "agent-a", cwd: "/tmp/ws1", workspaceId: "ws-1" });
+    await storage.upsert(agentA);
+    const generation = storage.getDirectorySequenceTracker().getGeneration();
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "full-1",
+      scope: "active",
+    });
+    messages.splice(0);
+
+    // Archiving writes a "delete" change for the id; unarchiving writes an
+    // "upsert". Together they form an interleaved [delete, upsert] window where
+    // the agent's final state is active. It must be delivered as an entry and
+    // must NOT also appear in deletedIds — the client applies entries then
+    // deletes, and the overlap would make the agent vanish client-side.
+    await storage.upsert({ ...agentA, archivedAt: "2026-01-02T00:00:00.000Z" });
+    await storage.upsert(agentA);
+
+    await session.handleMessage({
+      type: "fetch_agents_request",
+      requestId: "incr-1",
+      scope: "active",
+      afterSequence: 1,
+      directoryGeneration: generation,
+    });
+    const incr = fetchAgentsResponse(messages);
+    expect(incr.payload.incremental).toBe(true);
+    expect((incr.payload.entries as { agent: { id: string } }[]).map((e) => e.agent.id)).toEqual([
+      "agent-a",
+    ]);
+    expect(incr.payload.deletedIds).toEqual([]);
   });
 });
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -39,6 +39,7 @@ import {
   toAgentPersistenceHandle,
 } from "./persistence-hooks.js";
 import { ensureAgentLoaded, ensureUnarchivedAgentLoaded } from "./agent/agent-loading.js";
+import type { AgentDirectoryChange } from "./agent/agent-directory-sequence.js";
 import {
   formatSystemNotificationPrompt,
   sendPromptToAgent,
@@ -4215,10 +4216,57 @@ export class Session {
     return matchedEntries;
   }
 
+  private async tryListIncrementalAgentDirectory(request: AgentDirectoryRequestMessage): Promise<{
+    entries: FetchAgentsResponseEntry[];
+    pageInfo: FetchAgentsResponsePageInfo;
+    deletedIds: string[];
+    incremental: true;
+    sequence: number;
+    directoryGeneration: string;
+  } | null> {
+    if (request.type !== "fetch_agents_request" || request.afterSequence === undefined) {
+      return null;
+    }
+    const sequenceTracker = this.agentStorage.getDirectorySequenceTracker();
+    if (request.directoryGeneration !== sequenceTracker.getGeneration()) {
+      return null;
+    }
+    const { changes, incremental } = sequenceTracker.changesAfter(request.afterSequence);
+    if (!incremental) {
+      return null;
+    }
+    // Snapshot the sequence before awaiting: `buildIncrementalAgentDirectory`
+    // does async I/O during which new recordChange calls can advance the
+    // sequence. Returning a sequence captured afterward would make the client
+    // believe it has applied changes it never saw. The snapshot is conservative
+    // — the next incremental sync re-requests anything added in between.
+    const snapshotSequence = sequenceTracker.getCurrentSequence();
+    const delta = await this.buildIncrementalAgentDirectory(changes);
+    if (!delta) {
+      return null;
+    }
+    return {
+      ...delta,
+      sequence: snapshotSequence,
+      directoryGeneration: sequenceTracker.getGeneration(),
+    };
+  }
+
   private async listFetchAgentsEntries(request: AgentDirectoryRequestMessage): Promise<{
     entries: FetchAgentsResponseEntry[];
     pageInfo: FetchAgentsResponsePageInfo;
+    deletedIds?: string[];
+    sequence?: number;
+    directoryGeneration?: string;
+    incremental?: boolean;
   }> {
+    // Incremental path: a client that remembers its last applied sequence asks
+    // for only the mutations it missed since then. Falls back to the full path
+    // when the generation changed (daemon restart), the delta window aged out,
+    // or the change set is too large to return in one page.
+    const incrementalDelta = await this.tryListIncrementalAgentDirectory(request);
+    if (incrementalDelta) return incrementalDelta;
+
     const filter =
       request.type === "fetch_agent_history_request" &&
       request.filter?.includeArchived === undefined
@@ -4288,6 +4336,7 @@ export class Session {
         ? this.agentsPager.encode(pagedEntries[pagedEntries.length - 1].agent, sort)
         : null;
 
+    const sequenceTracker = this.agentStorage.getDirectorySequenceTracker();
     return {
       entries: pagedEntries,
       pageInfo: {
@@ -4295,6 +4344,65 @@ export class Session {
         prevCursor: request.page?.cursor ?? null,
         hasMore,
       },
+      sequence: sequenceTracker.getCurrentSequence(),
+      directoryGeneration: sequenceTracker.getGeneration(),
+    };
+  }
+
+  /**
+   * Reconstructs an incremental agent directory delta from the sequence
+   * tracker's change log. For each `upsert` it resolves the agent's current
+   * snapshot and keeps it only when it still belongs to the active directory;
+   * agents that were archived, deleted, or whose workspace lost its placement
+   * are reported through `deletedIds` so the client drops them. Returns `null`
+   * when the change set is too large for one page — the caller falls back to a
+   * full snapshot.
+   */
+  private async buildIncrementalAgentDirectory(changes: readonly AgentDirectoryChange[]): Promise<{
+    entries: FetchAgentsResponseEntry[];
+    deletedIds: string[];
+    incremental: true;
+    pageInfo: FetchAgentsResponsePageInfo;
+  } | null> {
+    const upsertIds = Array.from(
+      new Set(changes.filter((c) => c.type === "upsert").map((c) => c.agentId)),
+    );
+    const deletedIds = new Set(changes.filter((c) => c.type === "delete").map((c) => c.agentId));
+    if (upsertIds.length + deletedIds.size > 200) {
+      return null;
+    }
+
+    const activePlacements = await this.buildActiveProjectPlacementsByWorkspaceId();
+    const entries: FetchAgentsResponseEntry[] = [];
+    for (const agentId of upsertIds) {
+      const agent = await this.getAgentPayloadById(agentId);
+      if (!agent || agent.archivedAt || agent.workspaceId == null) {
+        deletedIds.add(agentId);
+        continue;
+      }
+      if (!activePlacements.has(agent.workspaceId)) {
+        deletedIds.add(agentId);
+        continue;
+      }
+      const placement = activePlacements.get(agent.workspaceId);
+      if (!placement) {
+        deletedIds.add(agentId);
+        continue;
+      }
+      entries.push({ agent, project: placement });
+      // The same agent may appear in both upsert and delete change records when
+      // the window contains interleaved mutations (e.g. upsert, delete, upsert).
+      // An entry that survives still belongs in the directory, so it must not
+      // also be reported through deletedIds — the client applies entries then
+      // deletes, and an overlap would make the agent vanish client-side.
+      deletedIds.delete(agentId);
+    }
+
+    return {
+      entries,
+      deletedIds: Array.from(deletedIds),
+      incremental: true,
+      pageInfo: { nextCursor: null, prevCursor: null, hasMore: false },
     };
   }
 

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -24,6 +24,7 @@ import type { TerminalManager } from "../terminal/terminal-manager.js";
 import { createTerminalManager } from "../terminal/terminal-manager.js";
 import { AgentManager, type AgentManagerEvent, type ManagedAgent } from "./agent/agent-manager.js";
 import type { ProviderSubagentDescriptor } from "./agent/provider-subagents/store.js";
+import { AgentDirectorySequenceTracker } from "./agent/agent-directory-sequence.js";
 import { AgentStorage, type StoredAgentRecord } from "./agent/agent-storage.js";
 import type {
   AgentClient,
@@ -670,6 +671,7 @@ function createSessionForWorkspaceTests(
               })
             : null,
         upsert: async () => {},
+        getDirectorySequenceTracker: () => new AgentDirectorySequenceTracker(),
         ...options.agentStorage,
       }),
       projectRegistry: options.projectRegistry ?? {


### PR DESCRIPTION
### Linked issue

No issue — this came out of daily use (see Reasoning).

### Type of change

- [x] Enhancement

### Reasoning

Locking the phone and unlocking after a long background pause makes the app re-fetch the entire agent directory and rebuild its local replica. On a slow link (and over the E2E relay) that resume feels sluggish, and every lock/unlock churns the directory UI even though almost nothing changed.

This adopts the resume pattern messaging apps already use (Zulip `last_event_id`, Telegram `pts`, Discord `RESUME` + seq): the daemon assigns a monotonic sequence and generation to every agent directory mutation, and `fetch_agents` answers with only the delta since the client's cursor. Resume stops being "refetch everything" and becomes "fetch what changed since I last saw it."

### Goals

- Daemon: track every agent directory mutation with a monotonic sequence plus a generation string and a retained 5000-change ring buffer, fed by `AgentStorage.writeRecord`/`remove` (archived records count as deletes).
- `fetch_agents` accepts `afterSequence` + `directoryGeneration` and returns the delta (`entries` + `deletedIds` + `sequence`); falls back to a full snapshot when the generation changed (daemon restart), the cursor is older than the retained window, or the change set exceeds one page.
- Protocol stays backward compatible: new request/response fields are optional, wire schemas stay pure, tagged `// COMPAT(agentDirectoryIncremental)`.
- App: while backgrounded, heartbeat and probe work pause; foreground resume triggers an immediate liveness check so a silently-dead socket reconnects at once instead of after the next heartbeat timeout.

### Non-goals

- No persistent sequence storage — a daemon restart bumps the generation and the client does one full resync. That is intentional.
- No change to the full-resync path's semantics; it stays as the safe fallback.
- No multi-device directory consistency beyond what the generation gating already provides.

### QA

- Server unit tests (all passed):
  - `npx vitest run packages/server/src/server/agent/agent-directory-sequence.test.ts --bail=1` — 7 passed (delta window, generation fallback, cursor retention, ring buffer).
  - `npx vitest run packages/server/src/server/session.test.ts --bail=1` — 157 passed, including two new discriminating tests: one proving the sequence is snapshotted before async I/O (a change landing during the build must be returned by the *next* incremental sync, not silently skipped), and one proving archive→unarchive keeps `entries` and `deletedIds` mutually exclusive (an overlapping entry would make the agent vanish client-side).
  - `npx vitest run packages/server/src/server/session.workspaces.test.ts --bail=1` — passed (no regressions on the workspaces flows that share the directory path).
- Client: `npx vitest run packages/client/src/daemon-client.test.ts --bail=1` — passed (cursor pass-through, backgrounded behavior).
- App: `npm run test --workspace=@getpaseo/app -- packages/app/src/runtime/directory-sync` — 7 passed (fast path, fallback on generation change, cursor recorded on full-sync pages); `host-runtime.test.ts` — passed (background pause + immediate resume liveness check).
- `npm run typecheck` passes. `npm run lint` passes. `npm run format:check` passes.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense