### PR TITLE
fix(app): copy code without Markdown fences or a trailing newline

### DIFF
--- a/packages/app/e2e/browser/assistant-selection-copy.spec.ts
+++ b/packages/app/e2e/browser/assistant-selection-copy.spec.ts
@@ -309,6 +309,28 @@ test("copying an assistant selection preserves Markdown structure and links", as
     expect(columnSliceClipboard.html).not.toContain("<table>");
     expect(columnSliceClipboard.html).toContain("ready");
     expect(columnSliceClipboard.html).toContain("<s>obsolete</s>");
+
+    await selectAssistantText(page, "answer");
+    await copySelection(page);
+
+    const wordInFenceClipboard = await readRichClipboard(page);
+    expect(wordInFenceClipboard.plainText).toBe("answer");
+    expect(wordInFenceClipboard.html).toContain("<code>answer</code>");
+    expect(wordInFenceClipboard.html).not.toContain("<pre>");
+
+    await selectAssistantTextRange(page, "before", "after");
+    await copySelection(page);
+
+    const fenceLinesClipboard = await readRichClipboard(page);
+    expect(fenceLinesClipboard.plainText).toBe("before\n```\nafter");
+    expect(fenceLinesClipboard.html).toContain('<pre><code class="language-text">');
+
+    await selectAssistantText(page, "apply");
+    await copySelection(page);
+
+    const inlineCodeClipboard = await readRichClipboard(page);
+    expect(inlineCodeClipboard.plainText).toBe("apply");
+    expect(inlineCodeClipboard.html).toContain("<code>apply</code>");
   } finally {
     await agent.cleanup();
   }

--- a/packages/app/e2e/browser/assistant-selection-copy.spec.ts
+++ b/packages/app/e2e/browser/assistant-selection-copy.spec.ts
@@ -36,6 +36,7 @@ const ASSISTANT_MARKDOWN = [
   "",
   "```typescript",
   'const answer = "yes";',
+  "  return answer;",
   "```",
   "",
   "````text",
@@ -132,6 +133,44 @@ async function selectAssistantTextRange(
     },
     { startText, endText },
   );
+}
+
+/**
+ * Select from `startText` through the line break that ends its rendered code line.
+ *
+ * Highlighted code splits a line across one text node per syntax token and puts the
+ * newline in a node of its own, so this is what a drag or double click that runs off
+ * the end of a line produces.
+ */
+async function selectAssistantThroughLineBreak(page: Page, startText: string): Promise<void> {
+  const assistantMessage = page.getByTestId("assistant-message").filter({
+    hasText: "Direct matches:",
+  });
+  await assistantMessage.evaluate((element, text) => {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    let startNode: Node | null = null;
+    let startOffset = -1;
+    let textNode = walker.nextNode();
+    while (textNode) {
+      if (!startNode) {
+        const offset = textNode.textContent?.indexOf(text) ?? -1;
+        if (offset >= 0) {
+          startNode = textNode;
+          startOffset = offset;
+        }
+      } else if (textNode.textContent?.startsWith("\n")) {
+        const range = document.createRange();
+        range.setStart(startNode, startOffset);
+        range.setEnd(textNode, 1);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        return;
+      }
+      textNode = walker.nextNode();
+    }
+    throw new Error(`Could not find a line break after: ${text}`);
+  }, startText);
 }
 
 async function copySelection(page: Page): Promise<void> {
@@ -324,6 +363,14 @@ test("copying an assistant selection preserves Markdown structure and links", as
     const fenceLinesClipboard = await readRichClipboard(page);
     expect(fenceLinesClipboard.plainText).toBe("before\n```\nafter");
     expect(fenceLinesClipboard.html).toContain('<pre><code class="language-text">');
+
+    // Selecting a whole line runs off its end into the newline node. A trailing
+    // newline auto-executes the line when it is pasted into a terminal.
+    await selectAssistantThroughLineBreak(page, "const");
+    await copySelection(page);
+
+    const wholeLineClipboard = await readRichClipboard(page);
+    expect(wholeLineClipboard.plainText).toBe('const answer = "yes";');
 
     await selectAssistantText(page, "apply");
     await copySelection(page);

--- a/packages/app/e2e/browser/assistant-selection-copy.spec.ts
+++ b/packages/app/e2e/browser/assistant-selection-copy.spec.ts
@@ -177,6 +177,11 @@ async function copySelection(page: Page): Promise<void> {
   await page.keyboard.press("ControlOrMeta+c");
 }
 
+/** The Copy button writes text/plain only, so the rich reader would throw on it. */
+async function readPlainClipboard(page: Page): Promise<string> {
+  return page.evaluate(() => navigator.clipboard.readText());
+}
+
 async function readRichClipboard(page: Page): Promise<ClipboardContent> {
   return page.evaluate(async () => {
     const items = await navigator.clipboard.read();
@@ -371,6 +376,15 @@ test("copying an assistant selection preserves Markdown structure and links", as
 
     const wholeLineClipboard = await readRichClipboard(page);
     expect(wholeLineClipboard.plainText).toBe('const answer = "yes";');
+
+    // Same hazard from the block's own Copy button: a Markdown fence body ends in a
+    // newline, and the button used to copy it raw.
+    const typescriptFence = assistantMessage.locator('[data-paseo-markdown-language="typescript"]');
+    // The button is opacity 0 / pointerEvents none until the fence is hovered.
+    await typescriptFence.hover();
+    await typescriptFence.locator("[data-paseo-markdown-ignore]").click();
+
+    expect(await readPlainClipboard(page)).toBe('const answer = "yes";\n  return answer;');
 
     await selectAssistantText(page, "apply");
     await copySelection(page);

--- a/packages/app/src/assistant-selection-copy/content.browser.test.ts
+++ b/packages/app/src/assistant-selection-copy/content.browser.test.ts
@@ -70,6 +70,14 @@ function el(
 
 /** The single text node whose content is exactly `text`. */
 function textNode(root: Node, text: string): Text {
+  const matches = textNodes(root, text);
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one text node "${text}", found ${matches.length}`);
+  }
+  return matches[0];
+}
+
+function textNodes(root: Node, text: string): Text[] {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
   const matches: Text[] = [];
   while (walker.nextNode()) {
@@ -77,10 +85,17 @@ function textNode(root: Node, text: string): Text {
       matches.push(walker.currentNode as Text);
     }
   }
-  if (matches.length !== 1) {
-    throw new Error(`Expected exactly one text node "${text}", found ${matches.length}`);
+  return matches;
+}
+
+/** The standalone `\n` node that separates rendered code line `index` from the next. */
+function lineBreakNode(root: Node, index: number): Text {
+  const breaks = textNodes(root, "\n");
+  const node = breaks[index];
+  if (!node) {
+    throw new Error(`Expected a line break node at index ${index}, found ${breaks.length}`);
   }
-  return matches[0];
+  return node;
 }
 
 function copy(start: [Text, number], end: [Text, number]) {
@@ -146,6 +161,34 @@ describe("createAssistantSelectionClipboardContent inside code", () => {
 
     expect(content?.plainText).toBe("const answer = 1;\n  if (answer) {\n    doThing();");
     expect(content?.plainText).not.toContain("Copy");
+  });
+
+  it("drops a trailing line break swept in by a double click", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    // Chrome extends a double click through the whitespace after the word, which
+    // here is the standalone newline node ending the line.
+    const content = copy([textNode(message, " = 1;"), 1], [lineBreakNode(message, 0), 1]);
+
+    expect(content?.plainText).toBe("= 1;");
+  });
+
+  it("drops a trailing line break and the indentation that followed it", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copy([textNode(message, "const"), 0], [textNode(message, "  if"), 2]);
+
+    expect(content?.plainText).toBe("const answer = 1;");
+    // One line once the break is gone, so it lands as inline code, not a block.
+    expect(content?.html).toBe('<meta charset="utf-8"><code>const answer = 1;</code>');
+  });
+
+  it("keeps line breaks that are not at the end of the selection", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copy([textNode(message, "const"), 0], [textNode(message, "  if"), 4]);
+
+    expect(content?.plainText).toBe("const answer = 1;\n  if");
   });
 
   it("returns null when the selection contains only ignored content", () => {

--- a/packages/app/src/assistant-selection-copy/content.browser.test.ts
+++ b/packages/app/src/assistant-selection-copy/content.browser.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createCodeClipboardContent } from "@/utils/rich-clipboard";
+// Explicit `.web` suffix, matching `surface.web.tsx` — tsc does not apply Metro's
+// platform extension resolution.
+import { createAssistantSelectionClipboardContent } from "./content.web";
+
+/**
+ * The fixture mirrors what `highlighted-code-block.tsx` and the Markdown render
+ * rules emit: `data-paseo-markdown-tag` wrappers, syntax tokens split across
+ * sibling spans, newlines as their own text nodes, and the hover Copy button
+ * living *inside* the `pre`. Keep it in sync with the renderer — the e2e spec
+ * covers the same cases against the real thing.
+ */
+function renderFixture(options: { language?: string } = {}): HTMLElement {
+  const message = el("div", { "data-testid": "assistant-message" });
+
+  message.append(
+    el(
+      "div",
+      { "data-paseo-markdown-tag": "p" },
+      el("span", {}, "Run "),
+      el("span", { "data-paseo-markdown-tag": "code" }, "apply_patch"),
+      el("span", {}, " first."),
+    ),
+  );
+
+  const fenceAttributes: Record<string, string> = { "data-paseo-markdown-tag": "pre" };
+  if (options.language !== undefined) {
+    fenceAttributes["data-paseo-markdown-language"] = options.language;
+  }
+  message.append(
+    el(
+      "div",
+      fenceAttributes,
+      el(
+        "span",
+        { "data-paseo-markdown-tag": "code" },
+        el("span", {}, "const"),
+        el("span", {}, " answer"),
+        el("span", {}, " = 1;"),
+        "\n",
+        el("span", {}, "  if"),
+        el("span", {}, " (answer)"),
+        el("span", {}, " {"),
+        "\n",
+        el("span", {}, "    doThing();"),
+      ),
+      el("div", { "data-paseo-markdown-ignore": "true" }, el("span", {}, "Copy")),
+    ),
+  );
+
+  message.append(el("div", { "data-paseo-markdown-tag": "p" }, el("span", {}, "After the block.")));
+
+  document.body.append(message);
+  return message;
+}
+
+function el(
+  tag: string,
+  attributes: Record<string, string>,
+  ...children: Array<Node | string>
+): HTMLElement {
+  const element = document.createElement(tag);
+  for (const [name, value] of Object.entries(attributes)) {
+    element.setAttribute(name, value);
+  }
+  element.append(...children);
+  return element;
+}
+
+/** The single text node whose content is exactly `text`. */
+function textNode(root: Node, text: string): Text {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const matches: Text[] = [];
+  while (walker.nextNode()) {
+    if (walker.currentNode.textContent === text) {
+      matches.push(walker.currentNode as Text);
+    }
+  }
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one text node "${text}", found ${matches.length}`);
+  }
+  return matches[0];
+}
+
+function copy(start: [Text, number], end: [Text, number]) {
+  const range = document.createRange();
+  range.setStart(start[0], start[1]);
+  range.setEnd(end[0], end[1]);
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("Expected a window selection");
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return createAssistantSelectionClipboardContent(selection);
+}
+
+/** Select from the start of one text node to the end of another. */
+function copyWhole(root: Node, startText: string, endText: string) {
+  const start = textNode(root, startText);
+  const end = textNode(root, endText);
+  return copy([start, 0], [end, endText.length]);
+}
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges();
+  document.body.replaceChildren();
+});
+
+describe("createAssistantSelectionClipboardContent inside code", () => {
+  it("copies a partial word in a fence verbatim, with no fence syntax", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copy([textNode(message, " answer"), 1], [textNode(message, " answer"), 4]);
+
+    expect(content?.plainText).toBe("ans");
+    expect(content?.html).toBe('<meta charset="utf-8"><code>ans</code>');
+  });
+
+  it("keeps newlines and indentation across two fence lines", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copyWhole(message, "const", " {");
+
+    expect(content?.plainText).toBe("const answer = 1;\n  if (answer) {");
+    expect(content?.html).toBe(
+      '<meta charset="utf-8"><pre><code class="language-typescript">const answer = 1;\n  if (answer) {</code></pre>',
+    );
+  });
+
+  it("fires when the common ancestor is an element rather than a text node", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    // Spanning two token spans makes `commonAncestorContainer` the `code` element.
+    const content = copy([textNode(message, "const"), 1], [textNode(message, " answer"), 4]);
+
+    expect(content?.plainText).toBe("onst ans");
+    expect(content?.html).toBe('<meta charset="utf-8"><code>onst ans</code>');
+  });
+
+  it("drops the hover copy button from a whole-block selection", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copyWhole(message, "const", "Copy");
+
+    expect(content?.plainText).toBe("const answer = 1;\n  if (answer) {\n    doThing();");
+    expect(content?.plainText).not.toContain("Copy");
+  });
+
+  it("returns null when the selection contains only ignored content", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    expect(copyWhole(message, "Copy", "Copy")).toBeNull();
+  });
+
+  it("copies whitespace-only code selections as the whitespace itself", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copy([textNode(message, "  if"), 0], [textNode(message, "  if"), 2]);
+
+    expect(content?.plainText).toBe("  ");
+  });
+
+  it("omits the language class when the fence has no info string", () => {
+    const message = renderFixture();
+
+    const content = copyWhole(message, "const", " {");
+
+    expect(content?.html).toBe(
+      '<meta charset="utf-8"><pre><code>const answer = 1;\n  if (answer) {</code></pre>',
+    );
+  });
+
+  it("escapes a fence info string that would otherwise break out of the attribute", () => {
+    const message = renderFixture({ language: 'ts" onload="x' });
+
+    const content = copyWhole(message, "const", " {");
+
+    expect(content?.html).toContain('class="language-ts&quot; onload=&quot;x"');
+    expect(content?.html).not.toContain('onload="x"');
+  });
+
+  it("copies partial and whole inline code without backticks", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const partial = copy(
+      [textNode(message, "apply_patch"), 0],
+      [textNode(message, "apply_patch"), 5],
+    );
+    expect(partial?.plainText).toBe("apply");
+    expect(partial?.html).toBe('<meta charset="utf-8"><code>apply</code>');
+
+    const whole = copyWhole(message, "apply_patch", "apply_patch");
+    expect(whole?.plainText).toBe("apply_patch");
+    expect(whole?.html).toBe('<meta charset="utf-8"><code>apply_patch</code>');
+  });
+
+  it("keeps the fence when the selection reaches out of the code block into prose", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copyWhole(message, "  if", "After the block.");
+
+    expect(content?.plainText).toContain("```typescript");
+    expect(content?.plainText).toContain("After the block.");
+  });
+
+  it("leaves prose-only selections on the Markdown path", () => {
+    const message = renderFixture({ language: "typescript" });
+
+    const content = copyWhole(message, "After the block.", "After the block.");
+
+    expect(content?.plainText).toBe("After the block.");
+  });
+});
+
+describe("createCodeClipboardContent", () => {
+  it("escapes html-significant characters in the code body", () => {
+    const content = createCodeClipboardContent('if (a < b && c > "d") {', { block: false });
+
+    expect(content.plainText).toBe('if (a < b && c > "d") {');
+    expect(content.html).toContain("if (a &lt; b &amp;&amp; c &gt;");
+    expect(content.html).not.toContain("<b");
+  });
+
+  it("omits the language class for blank and missing info strings", () => {
+    expect(createCodeClipboardContent("x\ny", { block: true }).html).toContain("<pre><code>");
+    expect(createCodeClipboardContent("x\ny", { block: true, language: "  " }).html).toContain(
+      "<pre><code>",
+    );
+    expect(createCodeClipboardContent("x\ny", { block: true, language: "ts" }).html).toContain(
+      '<pre><code class="language-ts">',
+    );
+  });
+});

--- a/packages/app/src/assistant-selection-copy/content.web.ts
+++ b/packages/app/src/assistant-selection-copy/content.web.ts
@@ -143,8 +143,11 @@ function selectedCodeText(range: Range): string {
   for (const ignored of fragment.querySelectorAll(`[${MARKDOWN_COPY_IGNORE_ATTRIBUTE}]`)) {
     ignored.remove();
   }
-  // Deliberately untrimmed — leading indentation is part of the code.
-  return fragment.textContent ?? "";
+  // Deliberately untrimmed — leading indentation is part of the code. A trailing
+  // line break is the exception: newlines are their own text nodes between lines
+  // (`highlighted-code-block.tsx:113`), and double-clicking the last word on a line
+  // sweeps one in. Pasting that into a terminal runs the line.
+  return (fragment.textContent ?? "").replace(/\r?\n[ \t]*$/, "");
 }
 
 function wrapSelectionWithAncestors(range: Range, message: Element): Node {

--- a/packages/app/src/assistant-selection-copy/content.web.ts
+++ b/packages/app/src/assistant-selection-copy/content.web.ts
@@ -1,6 +1,7 @@
 import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 import {
+  createCodeClipboardContent,
   createMarkdownClipboardContent,
   type MarkdownClipboardContent,
 } from "@/utils/rich-clipboard";
@@ -14,6 +15,8 @@ import {
 } from "./markup";
 
 const ASSISTANT_MESSAGE_SELECTOR = '[data-testid="assistant-message"]';
+const CODE_BLOCK_SELECTOR = `[${MARKDOWN_COPY_TAG_ATTRIBUTE}="pre"]`;
+const CODE_REGION_SELECTOR = `${CODE_BLOCK_SELECTOR}, [${MARKDOWN_COPY_TAG_ATTRIBUTE}="code"]`;
 
 const turndown = new TurndownService({
   bulletListMarker: "-",
@@ -65,6 +68,11 @@ export function createAssistantSelectionClipboardContent(
     return null;
   }
 
+  const codeSelection = createCodeSelectionContent(range, startMessage);
+  if (codeSelection) {
+    return codeSelection;
+  }
+
   const container = document.createElement("div");
   const selected = wrapSelectionWithAncestors(range, startMessage);
   normalizeOrderedListStarts(selected, range, startMessage);
@@ -73,6 +81,70 @@ export function createAssistantSelectionClipboardContent(
 
   const markdown = turndown.turndown(container.innerHTML).trim();
   return markdown ? createMarkdownClipboardContent(markdown) : null;
+}
+
+/**
+ * Selections that sit entirely inside rendered code copy as the code itself.
+ *
+ * The Markdown path below would fence them: a partial selection carries no
+ * ancestors of its own, so `wrapSelectionWithAncestors` rebuilds the `pre`/`code`
+ * chain and Turndown emits a whole fence around whatever was highlighted. Nobody
+ * highlights part of a code block wanting fence syntax — they want what the
+ * block's own Copy button gives.
+ *
+ * Returns null when the selection is not code, or is empty, so the caller falls
+ * through to the Markdown path.
+ */
+function createCodeSelectionContent(
+  range: Range,
+  message: Element,
+): MarkdownClipboardContent | null {
+  const region = closestCodeRegion(range.commonAncestorContainer, message);
+  if (!region) {
+    return null;
+  }
+
+  const code = selectedCodeText(range);
+  if (!code) {
+    return null;
+  }
+
+  // `closest` stops at the inner `code` span, but the fence language lives on the
+  // outer `pre` wrapper.
+  const fence = region.closest(CODE_BLOCK_SELECTOR);
+
+  // Block vs inline is an affordance call, not a semantic one. A multi-line
+  // snippet earns a code block; a double-clicked identifier should land in a rich
+  // editor as inline code rather than as a paragraph-breaking block. A selection
+  // without a newline may still have come from a fence — that is the trade.
+  const block = Boolean(fence) && code.includes("\n");
+  return createCodeClipboardContent(code, {
+    language: fence?.getAttribute(MARKDOWN_COPY_LANGUAGE_ATTRIBUTE),
+    block,
+  });
+}
+
+function closestCodeRegion(node: Node, message: Element): Element | null {
+  const element = node instanceof Element ? node : node.parentElement;
+  const region = element?.closest(CODE_REGION_SELECTOR) ?? null;
+  if (!region || !message.contains(region)) {
+    return null;
+  }
+  // A selection sitting entirely inside the block's own hover Copy button is not
+  // code. `cloneContents` of a single text node drops the ignore marker with the
+  // element that carried it, so this has to be asked of the live DOM.
+  return element?.closest(`[${MARKDOWN_COPY_IGNORE_ATTRIBUTE}]`) ? null : region;
+}
+
+function selectedCodeText(range: Range): string {
+  const fragment = range.cloneContents();
+  // The hover Copy button lives inside the `pre`, so selecting the whole block
+  // sweeps it up too.
+  for (const ignored of fragment.querySelectorAll(`[${MARKDOWN_COPY_IGNORE_ATTRIBUTE}]`)) {
+    ignored.remove();
+  }
+  // Deliberately untrimmed — leading indentation is part of the code.
+  return fragment.textContent ?? "";
 }
 
 function wrapSelectionWithAncestors(range: Range, message: Element): Node {

--- a/packages/app/src/components/highlighted-code-block.tsx
+++ b/packages/app/src/components/highlighted-code-block.tsx
@@ -82,7 +82,9 @@ export const HighlightedCodeBlock = React.memo(function HighlightedCodeBlock({
   const handlePointerEnter = useCallback(() => setIsHovered(true), []);
   const handlePointerLeave = useCallback(() => setIsHovered(false), []);
   const controlsVisible = isHovered || isNative || isCompact;
-  const getCode = useCallback(() => code, [code]);
+  // Copy what is rendered, not the raw fence body: a Markdown fence ends in a
+  // newline, and pasting that into a terminal executes the last line.
+  const getCode = useCallback(() => renderedCode, [renderedCode]);
 
   return (
     <View

--- a/packages/app/src/utils/rich-clipboard.ts
+++ b/packages/app/src/utils/rich-clipboard.ts
@@ -26,6 +26,41 @@ export function createMarkdownClipboardContent(markdown: string): MarkdownClipbo
   };
 }
 
+export interface CodeClipboardOptions {
+  language?: string | null;
+  /** Fenced block markup when true, inline `<code>` when false. */
+  block: boolean;
+}
+
+/**
+ * Clipboard payload for a selection that lies entirely inside rendered code.
+ *
+ * `plainText` is the code exactly as it was selected — no fences, no backticks —
+ * so it pastes straight into a shell or editor. The html half keeps the code
+ * marked up for rich targets.
+ *
+ * The fence info string is agent-authored, so the language is escaped as an
+ * attribute value rather than interpolated raw.
+ */
+export function createCodeClipboardContent(
+  code: string,
+  options: CodeClipboardOptions,
+): MarkdownClipboardContent {
+  const escapedCode = markdownRenderer.utils.escapeHtml(code);
+  if (!options.block) {
+    return { plainText: code, html: `<meta charset="utf-8"><code>${escapedCode}</code>` };
+  }
+
+  const language = options.language?.trim();
+  const className = language
+    ? ` class="language-${markdownRenderer.utils.escapeHtml(language)}"`
+    : "";
+  return {
+    plainText: code,
+    html: `<meta charset="utf-8"><pre><code${className}>${escapedCode}</code></pre>`,
+  };
+}
+
 export async function writeMarkdownToRichClipboard(
   markdown: string,
   environment: MarkdownClipboardEnvironment,


### PR DESCRIPTION
### Linked issue

No issue — reported on Discord by ramblurr, confirmed by nikus and reproduced by me.

Follow-up to #2808 (which closed #2667).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Copying a snippet out of an assistant message dragged Markdown syntax along with it, so
it had to go through a scratch editor before it could be pasted into a shell or a file.
Selecting a single word inside a code block came back wrapped in a fence. The only way to
get clean code out of a block was its Copy button, which takes every line at once.

#2808 re-serializes the selected DOM back to Markdown, which is right for prose and lists
— a partial list selection keeps its bullets. It reaches code too.
`wrapSelectionWithAncestors` rebuilds the `pre`/`code` ancestor chain around the cloned
fragment, so Turndown emits a whole fence around whatever was highlighted. Inline
`` `code` `` picks up backticks the same way.

This adds one guard before the Markdown path: a selection that sits entirely inside
rendered code copies as the code itself. `text/plain` is what was highlighted, indentation
intact; `text/html` keeps it marked up so a rich target still sees code. That matches what
the block's own Copy button puts on the clipboard.

A Turndown rule could not have done this. By the time Turndown runs, a one-word selection
and a whole-block selection are byte-identical DOM, because the `pre`/`code` wrapper is
manufactured *after* `cloneContents()`. Only a check against the live `Range` has the
information.

Two newline fixes ride along, because both make a paste run code you did not ask to run:

- Newlines between rendered code lines are their own text nodes, so a selection that runs
  off the end of a line carries the break with it. Pasting that into a terminal executes
  the line. One trailing break, plus any indentation after it, is now stripped.
- The block's Copy button was handed the raw fence body, which ends in a newline. It now
  gets the same text that is rendered.

### Goals

- Selecting part of a code block and copying yields the code, with no fence or backticks.
- Multi-line selections keep their newlines and leading indentation.
- Neither selection copy nor the Copy button leaves a trailing newline on the clipboard.
- The block's hover Copy button never leaks its label into the copied text.
- A rich paste target still receives a code block (or inline code), with the language class.
- Prose, list, link, table, and whole-message selections behave exactly as before — the
  existing byte-exact whole-message assertion passes unchanged.

### Non-goals

Three deliberate calls, listed so they are not read as oversights:

- **Selecting a *whole* fence, or a whole inline code span, now also yields bare code**
  rather than the Markdown construct. That is the behavior the reports asked for and it
  matches the Copy button. **Copy turn** still produces fenced Markdown for anyone who
  wants the source form.
- **Mixed code-and-prose selections still fence the code fragment.** A selection that
  starts inside a block and ends in the sentence after it is unchanged. Deferred on
  purpose: a correct fix needs a "is this fence fully selected?" test, and the block's
  hover Copy button lives *inside* the `pre`, so a node-based containment check reports
  *partial* for a fence the user completely highlighted — it would strip the fence off
  exactly the case that must keep it. Containment would have to be defined on text content
  excluding `[data-paseo-markdown-ignore]` nodes. Worth doing, not here.
- **@ramblurr's original ask is broader than this PR.** It covers prose too — "always
  includes the markdown formatting" — which points at a copy-as-plain-text preference, or
  flipping `text/plain` to rendered text globally. That reverses what #2667 explicitly
  asked for, so it is a product call and belongs in its own issue. This PR fixes the code
  case, which is the part that regressed.

Also out of scope: native selection copy (`assistant-selection-copy/surface.tsx` is a
passthrough on native — there is no handler to change), and tool-call / file-preview code
blocks, which carry the same attributes but render outside `[data-testid="assistant-message"]`
where the copy handler never sees them.

### QA

**Manual** — verified on Electron desktop. Before/after videos below. Native is
untouched: `surface.tsx` has no copy handler at all, so this is not a claimed native pass.

**Before**

https://github.com/user-attachments/assets/a65216f4-454d-42ba-803d-6d668dcf3cc5

**After**

https://github.com/user-attachments/assets/9d8bbd6f-bdde-47da-a40d-f53e80b25789


Steps run:

1. Double-click a word inside a fence, Cmd+C, paste into a terminal → the word alone, no
   trailing newline, nothing executes.
2. Drag-select two indented lines, paste into a plain editor → indentation intact, no fences.
3. Paste the same two lines into a rich target → still a code block.
4. Select part of `` `inline` `` → no backticks.
5. Select the whole fence plus the sentence after it → fence still there.
6. Select the whole message, paste → fenced Markdown, unchanged.
7. Click the block's Copy button, paste into a terminal → no trailing newline.

**Automated**

- `packages/app/e2e/browser/assistant-selection-copy.spec.ts` — five new cases against the
  real renderer, each doing a real Cmd+C (or a real button click) and reading the system
  clipboard back: a word inside the ```` ```typescript ```` fence, a two-line range inside
  the ````` ````text ````` fence, `apply` inside `` `apply_patch` ``, a whole fence line
  selected through its trailing line break, and the Copy button. The last two were each
  verified to **fail with their fix reverted**, so they reproduce the bug rather than only
  asserting the outcome. The `typescript` fence in the fixture is two lines now; at one
  line it had no line break node to select through.
- The pre-existing whole-message assertion in that spec is byte-identical and still passes
  — that is the regression guard for #2808.
- `packages/app/src/assistant-selection-copy/content.browser.test.ts` — new, 16 cases in
  the real-Chromium vitest project. First direct test of `content.web.ts`. Covers the
  element-vs-text common ancestor, indentation and newline preservation, trailing-break
  stripping, the ignored Copy button, whitespace-only and ignored-only selections, a fence
  with no info string, a fence info string containing `"`, inline code partial and whole,
  and the two paths that must stay on Markdown.
- `npm run typecheck`, `npm run lint`, `npm run format` pass at the repo root, after
  rebasing onto current `main`.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
