### PR TITLE
fix(claude): show the Fast toggle on Opus 5

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -683,7 +683,23 @@ describe("ClaudeAgentSession features", () => {
       client.listFeatures({
         provider: "claude",
         cwd: process.cwd(),
+        model: "claude-opus-5",
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: "fast_mode", value: false })]);
+
+    await expect(
+      client.listFeatures({
+        provider: "claude",
+        cwd: process.cwd(),
         model: "openrouter/anthropic/claude-opus-4-8",
+      }),
+    ).resolves.toEqual([]);
+
+    await expect(
+      client.listFeatures({
+        provider: "claude",
+        cwd: process.cwd(),
+        model: "claude-sonnet-5",
       }),
     ).resolves.toEqual([]);
 

--- a/packages/server/src/server/agent/providers/claude/model-manifest.ts
+++ b/packages/server/src/server/agent/providers/claude/model-manifest.ts
@@ -43,6 +43,7 @@ export const CLAUDE_MODEL_MANIFEST = [
     contextWindowMaxTokens: 1_000_000,
     effortLevels: CLAUDE_EFFORT_LEVELS.xhigh,
     supportsThinkingDisabled: true,
+    supportsFastMode: true,
   },
   {
     id: "claude-fable-5",

--- a/packages/server/src/server/agent/providers/claude/models.test.ts
+++ b/packages/server/src/server/agent/providers/claude/models.test.ts
@@ -497,4 +497,10 @@ describe("claudeManifestModelSupportsFastMode", () => {
     expect(claudeManifestModelSupportsFastMode("openrouter/anthropic/claude-opus-4-8")).toBe(false);
     expect(claudeManifestModelSupportsFastMode("claude-opus-4-8-20260101")).toBe(true);
   });
+
+  it("supports fast mode on Opus 5 but not on other Claude 5 models", () => {
+    expect(claudeManifestModelSupportsFastMode("claude-opus-5")).toBe(true);
+    expect(claudeManifestModelSupportsFastMode("claude-sonnet-5")).toBe(false);
+    expect(claudeManifestModelSupportsFastMode("claude-fable-5")).toBe(false);
+  });
 });


### PR DESCRIPTION
### Linked issue

None — one-flag fix, opening the PR directly.

### Type of change

- [x] Bug fix

### Reasoning

Opus 5 hides the **Fast** toggle, so fast mode can't be turned on for the newest Opus
model. Claude Code supports it — Opus 5 "is also offered in Fast mode … through usage
credits in Claude Code" ([announcement](https://www.anthropic.com/news/claude-opus-5)).

`CLAUDE_MODEL_MANIFEST` declares fast-mode support per model, and the `claude-opus-5`
entry was added without `supportsFastMode`. Setting it is the whole fix — `listFeatures`,
`setFeature` and the `setModel` auto-clear all key off that flag already.

### Goals

- The Fast toggle shows for Opus 5 and passes `fastMode` through, like Opus 4.8.

### Non-goals

- No change for Fable 5, Sonnet 5 or Haiku 4.5 — Claude Code's fast-mode gate is Opus-only.

### QA

- Desktop app on this branch: selected Opus 5, the Fast (zap) toggle now shows in the
  composer. Absent before the change.

<img width="503" height="126" alt="image" src="https://github.com/user-attachments/assets/64fcaa0a-bc9a-47c8-9387-2f7c8380fa0f" />

- `vitest run .../claude/{models,agent}.test.ts` — 99 passed, incl. two new cases.
- `npm run typecheck`, `lint`, `format` — clean.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
