### PR TITLE
Stop terminal activity after interrupted turns

### DIFF
--- a/docs/terminal-activity.md
+++ b/docs/terminal-activity.md
@@ -53,6 +53,11 @@ Claude hook mapping:
 - `Stop`, `StopFailure`, `SessionEnd` → `idle`
 - `Notification` with `reason` or `matcher` equal to `idle_prompt` → `needs-input`
 
+Claude does not run `Stop` when the user interrupts a turn. A standalone Ctrl-C or Escape input
+while terminal activity is working clears the activity without finished attention. The same
+fallback applies to every hooked terminal agent; exact input matching excludes escape sequences and
+pasted content, while later provider idle events remain authoritative.
+
 Codex hook mapping:
 
 - `UserPromptSubmit` → `running`

--- a/packages/server/src/terminal/activity/terminal-activity-tracker.ts
+++ b/packages/server/src/terminal/activity/terminal-activity-tracker.ts
@@ -47,6 +47,13 @@ export class TerminalActivityTracker {
     return true;
   }
 
+  interrupt(): void {
+    if (this.resolvedState !== "working") {
+      return;
+    }
+    this.setState(null, null);
+  }
+
   private setState(
     state: TerminalActivityState | null,
     attentionReason: TerminalActivityAttentionReason | null,

--- a/packages/server/src/terminal/agent-hooks/claude/claude.real.e2e.test.ts
+++ b/packages/server/src/terminal/agent-hooks/claude/claude.real.e2e.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import * as pty from "node-pty";
 import { afterEach, describe, expect, it } from "vitest";
-import { resolvePaseoCliBinDir } from "../../terminal.js";
+import { createTerminal, resolvePaseoCliBinDir, type TerminalSession } from "../../terminal.js";
 import { installRegisteredAgentHooks } from "../provider-registry.js";
 
 interface ActivityPost {
@@ -70,7 +70,7 @@ function readBody(request: IncomingMessage): Promise<string> {
   });
 }
 
-async function createActivityRecorder() {
+async function createActivityRecorder(onPost?: (post: ActivityPost) => void) {
   const posts: ActivityPost[] = [];
   const server = createServer(async (request: IncomingMessage, response: ServerResponse) => {
     if (request.method !== "POST" || request.url !== "/api/terminal-activity") {
@@ -80,7 +80,9 @@ async function createActivityRecorder() {
     }
 
     const body = await readBody(request);
-    posts.push(JSON.parse(body) as ActivityPost);
+    const post = JSON.parse(body) as ActivityPost;
+    posts.push(post);
+    onPost?.(post);
     response.statusCode = 200;
     response.end("ok");
   });
@@ -116,6 +118,23 @@ function statesFor(posts: ActivityPost[], terminalId: string, token: string): st
   return posts
     .filter((post) => post.terminalId === terminalId && post.token === token)
     .map((post) => post.state);
+}
+
+async function waitForRecordedState(
+  posts: ActivityPost[],
+  terminalId: string,
+  token: string,
+  state: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (statesFor(posts, terminalId, token).includes(state)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Timed out waiting for ${state}; observed ${statesFor(posts, terminalId, token).join(", ")}`,
+  );
 }
 
 describe.skipIf(!claudeAvailability.available)(
@@ -166,6 +185,57 @@ describe.skipIf(!claudeAvailability.available)(
         await recorder.close();
       }
     }, 100_000);
+
+    it("clears activity for an interrupted interactive Claude turn through TerminalSession", async () => {
+      const terminalId = "real-claude-interrupt-terminal";
+      const token = "real-claude-interrupt-token";
+      let session: TerminalSession | null = null;
+      const recorder = await createActivityRecorder((post) => {
+        if (post.terminalId !== terminalId || post.token !== token) return;
+        if (post.state === "running") session?.setActivity("working");
+        if (post.state === "idle") session?.setActivity("idle");
+        if (post.state === "needs-input") session?.setActivity("attention");
+      });
+      const configDir = createTempDir("paseo-real-claude-interrupt-config-");
+      const paseoCliBinDir = resolvePaseoCliBinDir();
+      if (!paseoCliBinDir) {
+        throw new Error("Could not resolve paseo CLI bin directory");
+      }
+
+      installRegisteredAgentHooks({ configDir });
+
+      try {
+        session = await createTerminal({
+          id: terminalId,
+          workspaceId: "real-claude-interrupt-workspace",
+          cwd: process.cwd(),
+          command: "claude",
+          args: ["--settings", join(configDir, "settings.json")],
+          env: {
+            ...process.env,
+            PASEO_TERMINAL_ID: terminalId,
+            PASEO_ACTIVITY_TOKEN: token,
+            PASEO_TERMINAL_ACTIVITY_URL: recorder.url,
+            PATH: [paseoCliBinDir, process.env.PATH].filter(isString).join(delimiter),
+          },
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+        session.send({
+          type: "input",
+          data: "Write a very long essay about the history of computing.\r",
+        });
+        await waitForRecordedState(recorder.posts, terminalId, token, "running", 20_000);
+        expect(session.getActivity()).toMatchObject({ state: "working" });
+
+        session.send({ type: "input", data: "\x03" });
+
+        expect(session.getActivity()).toBeNull();
+      } finally {
+        session?.kill();
+        await recorder.close();
+      }
+    }, 45_000);
   },
 );
 

--- a/packages/server/src/terminal/terminal.test.ts
+++ b/packages/server/src/terminal/terminal.test.ts
@@ -1059,3 +1059,42 @@ describe("mouse events", () => {
     session.send({ type: "mouse", row: 0, col: 0, button: 0, action: "up" });
   });
 });
+
+describe("terminal activity interruption", () => {
+  it.each([
+    ["Ctrl-C", "\x03"],
+    ["Escape", "\x1b"],
+  ])("clears working activity when %s is sent", async (_name, data) => {
+    const session = trackSession(
+      await createTerminal({
+        workspaceId: "ws-test",
+        cwd: realpathSync(tmpdir()),
+        shell: "/bin/sh",
+      }),
+    );
+    session.setActivity("working");
+
+    session.send({ type: "input", data });
+
+    expect(session.getActivity()).toBeNull();
+  });
+
+  it.each([
+    ["an arrow sequence", "\x1b[A"],
+    ["pasted text containing Ctrl-C", "before\x03after"],
+    ["ordinary input", "hello"],
+  ])("keeps a working terminal active for %s", async (_name, data) => {
+    const session = trackSession(
+      await createTerminal({
+        workspaceId: "ws-test",
+        cwd: realpathSync(tmpdir()),
+        shell: "/bin/sh",
+      }),
+    );
+    session.setActivity("working");
+
+    session.send({ type: "input", data });
+
+    expect(session.getActivity()).toMatchObject({ state: "working" });
+  });
+});

--- a/packages/server/src/terminal/terminal.test.ts
+++ b/packages/server/src/terminal/terminal.test.ts
@@ -1069,7 +1069,6 @@ describe("terminal activity interruption", () => {
       await createTerminal({
         workspaceId: "ws-test",
         cwd: realpathSync(tmpdir()),
-        shell: "/bin/sh",
       }),
     );
     session.setActivity("working");
@@ -1088,7 +1087,6 @@ describe("terminal activity interruption", () => {
       await createTerminal({
         workspaceId: "ws-test",
         cwd: realpathSync(tmpdir()),
-        shell: "/bin/sh",
       }),
     );
     session.setActivity("working");

--- a/packages/server/src/terminal/terminal.ts
+++ b/packages/server/src/terminal/terminal.ts
@@ -149,6 +149,10 @@ function resolveInitialTitleMode(presetTitle: string | undefined): "auto" | "man
   return presetTitle?.trim() ? "manual" : "auto";
 }
 
+function isTerminalActivityInterruptInput(data: string): boolean {
+  return data === "\x03" || data === "\x1b";
+}
+
 interface BuildTerminalEnvironmentInput {
   shell: string;
   env: Record<string, string>;
@@ -1222,6 +1226,9 @@ export async function createTerminal(options: CreateTerminalOptions): Promise<Te
 
     switch (msg.type) {
       case "input": {
+        if (isTerminalActivityInterruptInput(msg.data)) {
+          activityTracker.interrupt();
+        }
         pendingInput += msg.data;
         scheduleInputFlush();
         break;


### PR DESCRIPTION
### Linked issue

None found.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Terminal activity starts when an agent accepts a prompt, but some terminal runtimes omit their stop event when the user interrupts a turn with Ctrl-C or Escape. The terminal then remains visibly running until a later normally completed turn.

Exact standalone interrupt input now clears working activity at the terminal-session boundary. Clearing activity avoids presenting a canceled turn as finished or sending completion attention, while normal provider lifecycle events remain authoritative.

### Goals

- Clear a terminal's running indicator when its active turn is interrupted.
- Handle both Ctrl-C and Escape across hooked terminal agents.
- Avoid completion attention for user-canceled work.
- Preserve escape sequences, pasted control characters, and ordinary terminal input.

### Non-goals

- Parse terminal output to infer provider state.
- Replace normal provider lifecycle hooks.
- Add terminal activity support for providers that do not currently report activity.

### QA

Red phase:

- Added terminal-session cases for Ctrl-C and Escape.
- Both failed with `expected idle activity to clear; received working`.

Green phase:

- `npx vitest run packages/server/src/terminal/terminal.test.ts --bail=1` — 44 passed.
- `npx vitest run packages/server/src/terminal/activity/terminal-activity-tracker.test.ts --bail=1` — 12 passed.
- Real authenticated terminal-agent PTY E2E — 2 passed, covering normal completion and interruption through `TerminalSession`.
- `npm run format` — passed.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run typecheck` — passed across all workspaces.

Tested on macOS. No UI rendering changed. Linux and Windows were not manually tested; exact input-frame behavior is covered by platform-independent tests.

Risk surface: terminal input handling while activity is working. Tests verify that arrow escape sequences, embedded control characters, and ordinary input do not clear activity.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
