### PR TITLE
Document normalized daemon slugs in Hub

### DIFF
--- a/public-docs/hub/concepts.md
+++ b/public-docs/hub/concepts.md
@@ -52,7 +52,7 @@ The [Workflows guide](/docs/hub/workflows) starts with a one-step Slack example 
 When Hub syncs `.paseo/hub.yml`, it validates the configuration and resolves its references:
 
 - `filters.repo`, `filters.workspace`, and `filters.guild` must name resources available through the organization's connections.
-- `environment.daemon` must name a registered daemon.
+- `environment.daemon` must match a registered daemon's friendly slug.
 - Step ids, expressions, input filters, output schemas, and durations must be valid.
 
 If activation fails, Hub keeps the previous active revision. The Configuration tab shows the failed sync and its validation error; Activity continues to reflect the last active revision.

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -41,7 +41,7 @@ triggers:
 | ---------- | ----------- | --------------------------------------------------------------------------------------------------------- |
 | `name`     | yes         | Lowercase identifier referenced by a step.                                                                |
 | `kind`     | yes         | `daemon`, `fly`, or `docker` in the authored schema; workflow steps must resolve to a daemon environment. |
-| `daemon`   | daemon only | Daemon name, resolved when the revision activates.                                                        |
+| `daemon`   | daemon only | Friendly daemon slug, resolved to its immutable ID when the revision activates.                           |
 | `cwd`      | daemon only | Absolute path on the daemon.                                                                              |
 | `image`    | fly/docker  | Image name.                                                                                               |
 | `worktree` | no          | `branch-off`, `checkout-branch`, or `checkout-pr` target.                                                 |

--- a/public-docs/hub/daemons.md
+++ b/public-docs/hub/daemons.md
@@ -18,9 +18,11 @@ On the machine:
 paseo hub connect https://hub.example.com
 ```
 
-The CLI prints a URL and a verification code, and opens your browser if it can. In Hub, open **Daemons → Register a daemon**, enter the code, name the daemon, and approve it.
+The CLI prints a URL and a verification code, and opens your browser if it can. In Hub, open **Daemons → Register a daemon**, enter the code, choose a friendly slug, and approve it.
 
-The name you choose here is what configuration references. It can be renamed later, but renaming after a configuration is active means updating that configuration.
+Each daemon has two identifiers: an immutable generated ID and a friendly slug. Hub normalizes the slug you enter with lowercase words joined by hyphens, so `Build Studio` becomes `build-studio`. The slug is what the dashboard shows and what configuration references.
+
+You can rename the slug later without changing the daemon ID. Renaming after a configuration is active means updating that configuration.
 
 For unattended setup, skip the browser with an enrollment token:
 
@@ -48,7 +50,7 @@ environments:
     cwd: /Users/you/code/your-repo
 ```
 
-`daemon` is the display name. It resolves to a daemon id when the configuration activates, so a daemon that no longer exists fails activation instead of failing at dispatch.
+`daemon` is the friendly slug. It resolves to the immutable daemon ID when the configuration activates, so a daemon that no longer exists fails activation instead of failing at dispatch.
 
 `cwd` is a path on that machine. Hub does not clone anything for you; the directory must already exist.
 

--- a/public-docs/hub/quickstart.md
+++ b/public-docs/hub/quickstart.md
@@ -28,7 +28,7 @@ On the machine that will run agents:
 paseo hub connect https://your-hub.example.com
 ```
 
-The CLI prints a verification code. In Hub, open **Daemons → Register a daemon**, enter the code, and give it a name. See [Daemons](/docs/hub/daemons).
+The CLI prints a verification code. In Hub, open **Daemons → Register a daemon**, enter the code, and choose a friendly slug. Hub normalizes `Build Studio` to `build-studio`. See [Daemons](/docs/hub/daemons).
 
 ## 4. Create a project
 
@@ -67,7 +67,7 @@ triggers:
               ${{ paseo.prompt }}
 ```
 
-`daemon` is the name you gave it in step 3. `cwd` is a directory on that machine.
+`daemon` is the normalized slug from step 3. `cwd` is a directory on that machine.
 
 ## 6. Push
 


### PR DESCRIPTION
### Linked issue

No matching open issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Hub configuration resolves a daemon's friendly slug, but the public guides described the value as a daemon name or display name. That wording could send users to `hub.yml` with an identifier that does not match the normalized slug shown by Hub.

### Goals

- Define the daemon model as an immutable generated ID plus a friendly slug.
- Explain normalization with `Build Studio` → `build-studio`.
- Use slug terminology consistently in enrollment, quickstart, activation, and the `hub.yml` reference.

### Non-goals

- Change daemon enrollment or configuration behavior.
- Add aliases or additional daemon identifier concepts.

### QA

- `npm run format` — passed.
- `npm run typecheck` — passed across all workspaces.
- `npm run lint` — passed with 0 warnings and 0 errors.
- Searched the Hub docs for obsolete daemon name/display-name wording; no remaining daemon identifier references use it.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
