### PR TITLE
Configure usage percentages as used or remaining

### DIFF
--- a/packages/app/e2e/browser/provider-usage-settings.spec.ts
+++ b/packages/app/e2e/browser/provider-usage-settings.spec.ts
@@ -60,6 +60,10 @@ test.describe("provider usage settings", () => {
     await expect(card.getByText("Biweekly", { exact: true })).toBeVisible();
     await expect(card.getByText("Daily", { exact: true })).toBeVisible();
     await expect(card.getByText("70%")).toBeVisible();
+
+    await page.getByTestId("provider-usage-percentage-display").getByText("Remaining").click();
+    await expect(card.getByText("30%")).toBeVisible();
+    await expect(card.getByText("70%")).not.toBeVisible();
     await expect(card.getByText("Credits", { exact: true })).toBeVisible();
     await expect(card.getByText("1,234 left", { exact: true })).toBeVisible();
     await expect(card.getByText("Extra usage", { exact: true })).toBeVisible();

--- a/packages/app/src/provider-usage/card.tsx
+++ b/packages/app/src/provider-usage/card.tsx
@@ -6,7 +6,7 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import type { Theme } from "@/styles/theme";
 import { ProviderUsageBalanceBar } from "./balance-bar";
 import { formatAgo } from "./format";
-import type { ProviderUsage } from "./types";
+import type { ProviderUsage, ProviderUsagePercentageDisplay } from "./types";
 import { ProviderUsageWindowBar } from "./window-bar";
 
 interface ProviderUsageIconProps {
@@ -39,9 +39,11 @@ function footerText(usage: ProviderUsage): string | null {
 
 export function ProviderUsageCard({
   usage,
+  percentageDisplay,
   compact = false,
 }: {
   usage: ProviderUsage;
+  percentageDisplay: ProviderUsagePercentageDisplay;
   compact?: boolean;
 }) {
   const status = statusText(usage);
@@ -88,7 +90,11 @@ export function ProviderUsageCard({
       {usage.windows.length > 0 || balances.length > 0 ? (
         <View style={styles.bars}>
           {usage.windows.map((window) => (
-            <ProviderUsageWindowBar key={window.id} window={window} />
+            <ProviderUsageWindowBar
+              key={window.id}
+              window={window}
+              percentageDisplay={percentageDisplay}
+            />
           ))}
           {balances.map((balance) => (
             <ProviderUsageBalanceBar key={balance.id} balance={balance} />

--- a/packages/app/src/provider-usage/copy.ts
+++ b/packages/app/src/provider-usage/copy.ts
@@ -5,6 +5,9 @@
 // surfaces are not yet mounted and the locale files are being edited elsewhere.
 export const providerUsageCopy = {
   title: "Plan usage",
+  percentageUsed: "Used",
+  percentageRemaining: "Remaining",
+  percentageDisplayLabel: "Percentages",
   refresh: "Refresh",
   refreshing: "Refreshing...",
   loading: "Loading usage...",

--- a/packages/app/src/provider-usage/format.test.ts
+++ b/packages/app/src/provider-usage/format.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolvePercentages } from "./format";
+
+describe("provider usage percentage display", () => {
+  it("derives remaining percentage from used percentage", () => {
+    const window = { id: "weekly", label: "Weekly", usedPct: 29 };
+
+    expect(resolvePercentages(window, "remaining")).toEqual({ displayed: 71, used: 29 });
+  });
+
+  it("derives used percentage from remaining percentage", () => {
+    const window = { id: "daily", label: "Daily", remainingPct: 30 };
+
+    expect(resolvePercentages(window, "used")).toEqual({ displayed: 70, used: 70 });
+  });
+
+  it("keeps the used percentage for bar fill and tone when showing remaining", () => {
+    const window = { id: "session", label: "Session", remainingPct: 8 };
+
+    expect(resolvePercentages(window, "remaining")).toEqual({ displayed: 8, used: 92 });
+  });
+
+  it("returns no percentage when the provider reports neither value", () => {
+    const window = { id: "session", label: "Session" };
+
+    expect(resolvePercentages(window, "remaining")).toEqual({ displayed: null, used: null });
+  });
+});

--- a/packages/app/src/provider-usage/format.test.ts
+++ b/packages/app/src/provider-usage/format.test.ts
@@ -5,24 +5,40 @@ describe("provider usage percentage display", () => {
   it("derives remaining percentage from used percentage", () => {
     const window = { id: "weekly", label: "Weekly", usedPct: 29 };
 
-    expect(resolvePercentages(window, "remaining")).toEqual({ displayed: 71, used: 29 });
+    expect(resolvePercentages(window, "remaining")).toEqual({
+      displayed: 71,
+      fillPct: 71,
+      used: 29,
+    });
   });
 
   it("derives used percentage from remaining percentage", () => {
     const window = { id: "daily", label: "Daily", remainingPct: 30 };
 
-    expect(resolvePercentages(window, "used")).toEqual({ displayed: 70, used: 70 });
+    expect(resolvePercentages(window, "used")).toEqual({
+      displayed: 70,
+      fillPct: 70,
+      used: 70,
+    });
   });
 
-  it("keeps the used percentage for bar fill and tone when showing remaining", () => {
+  it("uses the remaining complement for the bar fill when showing remaining", () => {
     const window = { id: "session", label: "Session", remainingPct: 8 };
 
-    expect(resolvePercentages(window, "remaining")).toEqual({ displayed: 8, used: 92 });
+    expect(resolvePercentages(window, "remaining")).toEqual({
+      displayed: 8,
+      fillPct: 8,
+      used: 92,
+    });
   });
 
   it("returns no percentage when the provider reports neither value", () => {
     const window = { id: "session", label: "Session" };
 
-    expect(resolvePercentages(window, "remaining")).toEqual({ displayed: null, used: null });
+    expect(resolvePercentages(window, "remaining")).toEqual({
+      displayed: null,
+      fillPct: null,
+      used: null,
+    });
   });
 });

--- a/packages/app/src/provider-usage/format.ts
+++ b/packages/app/src/provider-usage/format.ts
@@ -1,5 +1,23 @@
 import { formatTokenCount } from "@/components/context-window-meter.utils";
-import type { ProviderUsageBalanceUnit } from "./types";
+import type {
+  ProviderUsageBalanceUnit,
+  ProviderUsagePercentageDisplay,
+  ProviderUsageWindow,
+} from "./types";
+
+export interface ProviderUsagePercentages {
+  displayed: number | null;
+  used: number | null;
+}
+
+export function resolvePercentages(
+  window: ProviderUsageWindow,
+  display: ProviderUsagePercentageDisplay,
+): ProviderUsagePercentages {
+  const used = window.usedPct ?? (window.remainingPct != null ? 100 - window.remainingPct : null);
+  const remaining = window.remainingPct ?? (window.usedPct != null ? 100 - window.usedPct : null);
+  return { displayed: display === "used" ? used : remaining, used };
+}
 
 export function clampPct(value: number): number {
   return Math.max(0, Math.min(100, value));

--- a/packages/app/src/provider-usage/format.ts
+++ b/packages/app/src/provider-usage/format.ts
@@ -7,6 +7,7 @@ import type {
 
 export interface ProviderUsagePercentages {
   displayed: number | null;
+  fillPct: number | null;
   used: number | null;
 }
 
@@ -16,7 +17,8 @@ export function resolvePercentages(
 ): ProviderUsagePercentages {
   const used = window.usedPct ?? (window.remainingPct != null ? 100 - window.remainingPct : null);
   const remaining = window.remainingPct ?? (window.usedPct != null ? 100 - window.usedPct : null);
-  return { displayed: display === "used" ? used : remaining, used };
+  const displayed = display === "used" ? used : remaining;
+  return { displayed, fillPct: displayed, used };
 }
 
 export function clampPct(value: number): number {

--- a/packages/app/src/provider-usage/list.tsx
+++ b/packages/app/src/provider-usage/list.tsx
@@ -3,15 +3,21 @@ import { View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { settingsStyles } from "@/styles/settings";
 import { ProviderUsageCard } from "./card";
-import type { ProviderUsage } from "./types";
+import type { ProviderUsage, ProviderUsagePercentageDisplay } from "./types";
 
-export function ProviderUsageList({ providers }: { providers: ProviderUsage[] }) {
+export function ProviderUsageList({
+  providers,
+  percentageDisplay,
+}: {
+  providers: ProviderUsage[];
+  percentageDisplay: ProviderUsagePercentageDisplay;
+}) {
   return (
     <View style={settingsStyles.card}>
       {providers.map((usage, index) => (
         <Fragment key={usage.providerId}>
           {index > 0 ? <View style={styles.divider} /> : null}
-          <ProviderUsageCard usage={usage} />
+          <ProviderUsageCard usage={usage} percentageDisplay={percentageDisplay} />
         </Fragment>
       ))}
     </View>

--- a/packages/app/src/provider-usage/preferences.test.ts
+++ b/packages/app/src/provider-usage/preferences.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { asyncStorage } = vi.hoisted(() => ({
+  asyncStorage: new Map<string, string>(),
+}));
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: async (key: string) => asyncStorage.get(key) ?? null,
+    setItem: async (key: string, value: string) => {
+      asyncStorage.set(key, value);
+    },
+    removeItem: async (key: string) => {
+      asyncStorage.delete(key);
+    },
+  },
+}));
+
+describe("provider usage preferences", () => {
+  beforeEach(() => {
+    asyncStorage.clear();
+    vi.resetModules();
+  });
+
+  it("restores the selected percentage display after the store reloads", async () => {
+    const { useProviderUsagePreferences: firstStore } = await import("./preferences");
+    await firstStore.persist.rehydrate();
+
+    firstStore.getState().setPercentageDisplay("remaining");
+    await vi.waitFor(() =>
+      expect(asyncStorage.get("provider-usage-preferences")).toContain(
+        '"percentageDisplay":"remaining"',
+      ),
+    );
+
+    vi.resetModules();
+    const { useProviderUsagePreferences: reloadedStore } = await import("./preferences");
+    await reloadedStore.persist.rehydrate();
+
+    expect(reloadedStore.getState().percentageDisplay).toBe("remaining");
+  });
+});

--- a/packages/app/src/provider-usage/preferences.ts
+++ b/packages/app/src/provider-usage/preferences.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { ProviderUsagePercentageDisplay } from "./types";
+
+interface ProviderUsagePreferencesState {
+  percentageDisplay: ProviderUsagePercentageDisplay;
+  setPercentageDisplay: (display: ProviderUsagePercentageDisplay) => void;
+}
+
+export const useProviderUsagePreferences = create<ProviderUsagePreferencesState>()(
+  persist(
+    (set) => ({
+      percentageDisplay: "used",
+      setPercentageDisplay: (percentageDisplay) => set({ percentageDisplay }),
+    }),
+    {
+      name: "provider-usage-preferences",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ percentageDisplay: state.percentageDisplay }),
+    },
+  ),
+);

--- a/packages/app/src/provider-usage/settings-section.tsx
+++ b/packages/app/src/provider-usage/settings-section.tsx
@@ -4,11 +4,18 @@ import { Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { SegmentedControl, type SegmentedControlOption } from "@/components/ui/segmented-control";
 import { settingsStyles } from "@/styles/settings";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { providerUsageCopy } from "./copy";
 import { ProviderUsageList } from "./list";
-import type { ProviderUsageView } from "./types";
+import { useProviderUsagePreferences } from "./preferences";
+import type { ProviderUsagePercentageDisplay, ProviderUsageView } from "./types";
+
+const percentageDisplayOptions = [
+  { value: "used", label: providerUsageCopy.percentageUsed },
+  { value: "remaining", label: providerUsageCopy.percentageRemaining },
+] satisfies SegmentedControlOption<ProviderUsagePercentageDisplay>[];
 
 export function ProviderUsageSettingsSection({
   view,
@@ -18,6 +25,8 @@ export function ProviderUsageSettingsSection({
   onRefresh: () => void;
 }) {
   const busy = view.kind === "loading" || (view.kind === "ready" && view.isRefreshing);
+  const percentageDisplay = useProviderUsagePreferences((state) => state.percentageDisplay);
+  const setPercentageDisplay = useProviderUsagePreferences((state) => state.setPercentageDisplay);
 
   const refreshButton = useMemo(
     () => (
@@ -41,7 +50,21 @@ export function ProviderUsageSettingsSection({
       testID="provider-usage-card"
       trailing={refreshButton}
     >
-      <ProviderUsageBody view={view} onRefresh={onRefresh} />
+      <View style={settingsStyles.card}>
+        <View style={settingsStyles.row}>
+          <View style={settingsStyles.rowContent}>
+            <Text style={settingsStyles.rowTitle}>{providerUsageCopy.percentageDisplayLabel}</Text>
+          </View>
+          <SegmentedControl
+            options={percentageDisplayOptions}
+            value={percentageDisplay}
+            onValueChange={setPercentageDisplay}
+            size="sm"
+            testID="provider-usage-percentage-display"
+          />
+        </View>
+      </View>
+      <ProviderUsageBody view={view} onRefresh={onRefresh} percentageDisplay={percentageDisplay} />
     </SettingsSection>
   );
 }
@@ -49,9 +72,11 @@ export function ProviderUsageSettingsSection({
 function ProviderUsageBody({
   view,
   onRefresh,
+  percentageDisplay,
 }: {
   view: ProviderUsageView;
   onRefresh: () => void;
+  percentageDisplay: ProviderUsagePercentageDisplay;
 }) {
   if (view.kind === "loading") {
     return (
@@ -79,7 +104,9 @@ function ProviderUsageBody({
     );
   }
 
-  return <ProviderUsageList providers={view.payload.providers} />;
+  return (
+    <ProviderUsageList providers={view.payload.providers} percentageDisplay={percentageDisplay} />
+  );
 }
 
 const styles = StyleSheet.create((theme) => ({

--- a/packages/app/src/provider-usage/tone.test.ts
+++ b/packages/app/src/provider-usage/tone.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { resolveWindowBarTone } from "./tone";
+
+describe("provider usage window bar tone", () => {
+  it("uses green for remaining capacity even when usage is at risk", () => {
+    expect(resolveWindowBarTone("remaining", 95, "danger")).toBe("ok");
+  });
+
+  it("uses consumption risk tone when displaying used percentage", () => {
+    expect(resolveWindowBarTone("used", 95, undefined)).toBe("danger");
+  });
+});

--- a/packages/app/src/provider-usage/tone.ts
+++ b/packages/app/src/provider-usage/tone.ts
@@ -1,8 +1,16 @@
-import type { ProviderUsageTone } from "./types";
+import type { ProviderUsagePercentageDisplay, ProviderUsageTone } from "./types";
 
 export function deriveTone(usedPct: number | null | undefined): ProviderUsageTone {
   if (usedPct == null) return "default";
   if (usedPct > 90) return "danger";
   if (usedPct >= 70) return "warning";
   return "default";
+}
+
+export function resolveWindowBarTone(
+  percentageDisplay: ProviderUsagePercentageDisplay,
+  usedPct: number | null | undefined,
+  providerTone: ProviderUsageTone | undefined,
+): ProviderUsageTone {
+  return percentageDisplay === "remaining" ? "ok" : (providerTone ?? deriveTone(usedPct));
 }

--- a/packages/app/src/provider-usage/tooltip-section.tsx
+++ b/packages/app/src/provider-usage/tooltip-section.tsx
@@ -2,6 +2,7 @@ import { Text, View } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { ProviderUsageCard } from "./card";
 import { providerUsageCopy } from "./copy";
+import { useProviderUsagePreferences } from "./preferences";
 import type { ProviderUsage, ProviderUsageView } from "./types";
 
 function matchProvider(
@@ -23,6 +24,8 @@ export function ProviderUsageTooltipSection({
   view: ProviderUsageView;
   activeProviderId: string | null | undefined;
 }) {
+  const percentageDisplay = useProviderUsagePreferences((state) => state.percentageDisplay);
+
   if (view.kind === "loading") {
     return (
       <>
@@ -47,7 +50,7 @@ export function ProviderUsageTooltipSection({
   return (
     <>
       <View style={styles.divider} />
-      <ProviderUsageCard usage={usage} compact />
+      <ProviderUsageCard usage={usage} percentageDisplay={percentageDisplay} compact />
     </>
   );
 }

--- a/packages/app/src/provider-usage/types.ts
+++ b/packages/app/src/provider-usage/types.ts
@@ -19,6 +19,7 @@ export type {
 
 export type ProviderUsageBalanceUnit = ProviderUsageBalance["unit"];
 export type ProviderUsageListPayload = ProviderUsageListResponseMessage["payload"];
+export type ProviderUsagePercentageDisplay = "used" | "remaining";
 
 export type ProviderUsageView =
   | { kind: "loading" }

--- a/packages/app/src/provider-usage/window-bar.tsx
+++ b/packages/app/src/provider-usage/window-bar.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { Text, View, type StyleProp, type ViewStyle } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { clampPct, formatPct, formatResetLabel, resolvePercentages } from "./format";
-import { deriveTone } from "./tone";
+import { resolveWindowBarTone } from "./tone";
 import type {
   ProviderUsagePercentageDisplay,
   ProviderUsageTone,
@@ -31,9 +31,9 @@ export function ProviderUsageWindowBar({
 }) {
   const percentages = resolvePercentages(window, percentageDisplay);
   const usedPct = percentages.used;
-  const tone = window.tone ?? deriveTone(usedPct);
+  const tone = resolveWindowBarTone(percentageDisplay, usedPct, window.tone);
 
-  const fillWidth = clampPct(usedPct ?? 0);
+  const fillWidth = clampPct(percentages.fillPct ?? 0);
   const fillStyle = useMemo<StyleProp<ViewStyle>>(
     () => [styles.fill, fillToneStyle(tone), { width: `${fillWidth}%` }],
     [fillWidth, tone],

--- a/packages/app/src/provider-usage/window-bar.tsx
+++ b/packages/app/src/provider-usage/window-bar.tsx
@@ -1,15 +1,13 @@
 import { useMemo } from "react";
 import { Text, View, type StyleProp, type ViewStyle } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
-import { clampPct, formatPct, formatResetLabel } from "./format";
+import { clampPct, formatPct, formatResetLabel, resolvePercentages } from "./format";
 import { deriveTone } from "./tone";
-import type { ProviderUsageTone, ProviderUsageWindow } from "./types";
-
-function resolveUsedPct(window: ProviderUsageWindow): number | null {
-  if (window.usedPct != null) return window.usedPct;
-  if (window.remainingPct != null) return 100 - window.remainingPct;
-  return null;
-}
+import type {
+  ProviderUsagePercentageDisplay,
+  ProviderUsageTone,
+  ProviderUsageWindow,
+} from "./types";
 
 function fillToneStyle(tone: ProviderUsageTone) {
   switch (tone) {
@@ -24,8 +22,15 @@ function fillToneStyle(tone: ProviderUsageTone) {
   }
 }
 
-export function ProviderUsageWindowBar({ window }: { window: ProviderUsageWindow }) {
-  const usedPct = resolveUsedPct(window);
+export function ProviderUsageWindowBar({
+  window,
+  percentageDisplay,
+}: {
+  window: ProviderUsageWindow;
+  percentageDisplay: ProviderUsagePercentageDisplay;
+}) {
+  const percentages = resolvePercentages(window, percentageDisplay);
+  const usedPct = percentages.used;
   const tone = window.tone ?? deriveTone(usedPct);
 
   const fillWidth = clampPct(usedPct ?? 0);
@@ -46,7 +51,7 @@ export function ProviderUsageWindowBar({ window }: { window: ProviderUsageWindow
           {window.label}
         </Text>
         <Text style={styles.value}>
-          {usedPct != null ? formatPct(usedPct) : "—"}
+          {percentages.displayed != null ? formatPct(percentages.displayed) : "—"}
           {trailing ? (
             <Text style={isAtRisk ? styles.atRisk : styles.reset}>{` · ${trailing}`}</Text>
           ) : null}


### PR DESCRIPTION
## Summary

- add a persisted Used / Remaining selector to the host usage screen
- apply the preference to provider usage cards and context-meter tooltips
- preserve consumption-based bar fill and warning tones in both display modes

## Verification

- npm run typecheck
- targeted npm lint
- npx vitest run packages/app/src/provider-usage/format.test.ts --bail=1
- browser E2E attempted twice; the isolated e2eWorkerClient fixture timed out during setup before test execution