### PR TITLE
fix(app): derive markdown line heights from the font-size ramp

### DIFF
--- a/packages/app/src/styles/markdown-styles.test.ts
+++ b/packages/app/src/styles/markdown-styles.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it } from "vitest";
 import { createCompactMarkdownStyles, createMarkdownStyles } from "./markdown-styles";
-import { darkTheme } from "./theme";
+import { darkTheme, type Theme } from "./theme";
+
+// Stated here as a literal on purpose. Importing the implementation's own constant
+// would make these assertions circular: lowering it would keep the tests green while
+// reintroducing the clipping they exist to catch. ~1.45em is Noto Sans CJK's
+// ascent + descent, so this is the behaviour the styles owe callers, not a knob.
+const REQUIRED_MIN_RATIO = 1.45;
+
+const HEADING_KEYS = [
+  "heading1",
+  "heading2",
+  "heading3",
+  "heading4",
+  "heading5",
+  "heading6",
+] as const;
+
+// Mirrors what `applyAppearance` does when the user raises the UI font size:
+// the whole ramp scales, so anything that hardcodes a companion line height
+// silently tightens until glyphs collide. `code` is left alone to match
+// `scaleFontSize`, which sets it absolutely from the separate code-size control.
+function withScaledFontRamp(theme: Theme, ratio: number): Theme {
+  const fontSize = Object.fromEntries(
+    Object.entries(theme.fontSize).map(([key, size]) => [
+      key,
+      key === "code" ? size : Math.round(size * ratio),
+    ]),
+  ) as Theme["fontSize"];
+  return { ...theme, fontSize };
+}
 
 describe("createMarkdownStyles", () => {
   it("applies shrink-and-wrap constraints to long markdown text and links", () => {
@@ -70,6 +99,32 @@ describe("createMarkdownStyles", () => {
     });
   });
 
+  it("keeps heading line heights above the CJK glyph box at every UI font size", () => {
+    // 24 / 16 is the top of the appearance UI font-size range.
+    for (const theme of [darkTheme, withScaledFontRamp(darkTheme, 24 / 16)]) {
+      for (const create of [createMarkdownStyles, createCompactMarkdownStyles]) {
+        const styles = create(theme);
+        for (const key of HEADING_KEYS) {
+          const { fontSize, lineHeight } = styles[key];
+          expect(lineHeight / fontSize, `${create.name} ${key}`).toBeGreaterThanOrEqual(
+            REQUIRED_MIN_RATIO,
+          );
+        }
+      }
+    }
+  });
+
+  it("scales list markers with the font-size ramp so they stay on the text baseline", () => {
+    const styles = createMarkdownStyles(withScaledFontRamp(darkTheme, 24 / 16));
+
+    expect(
+      styles.bullet_list_icon.lineHeight / styles.bullet_list_icon.fontSize,
+    ).toBeGreaterThanOrEqual(REQUIRED_MIN_RATIO);
+    expect(
+      styles.ordered_list_icon.lineHeight / styles.ordered_list_icon.fontSize,
+    ).toBeGreaterThanOrEqual(REQUIRED_MIN_RATIO);
+  });
+
   it("uses the mono font-size token directly for inline and block code", () => {
     const styles = createMarkdownStyles(darkTheme);
     const compactStyles = createCompactMarkdownStyles(darkTheme);
@@ -77,7 +132,7 @@ describe("createMarkdownStyles", () => {
     expect(styles.code_inline).toMatchObject({
       fontFamily: darkTheme.fontFamily.mono,
       fontSize: darkTheme.fontSize.code,
-      lineHeight: Math.round(darkTheme.fontSize.code * 1.45),
+      lineHeight: Math.ceil(darkTheme.fontSize.code * REQUIRED_MIN_RATIO),
     });
     expect(styles.code_block).toMatchObject({
       fontFamily: darkTheme.fontFamily.mono,
@@ -90,7 +145,7 @@ describe("createMarkdownStyles", () => {
     expect(compactStyles.code_inline).toMatchObject({
       fontFamily: darkTheme.fontFamily.mono,
       fontSize: darkTheme.fontSize.code,
-      lineHeight: Math.round(darkTheme.fontSize.code * 1.45),
+      lineHeight: Math.ceil(darkTheme.fontSize.code * REQUIRED_MIN_RATIO),
     });
   });
 });

--- a/packages/app/src/styles/markdown-styles.ts
+++ b/packages/app/src/styles/markdown-styles.ts
@@ -4,6 +4,30 @@ import { isWeb } from "@/constants/platform";
 const webSelectableTextStyle = isWeb ? { userSelect: "text" as const } : {};
 
 /**
+ * Smallest `lineHeight / fontSize` any markdown text may use.
+ *
+ * Noto Sans CJK's ascent + descent is ~1.45em, so a Korean, Japanese, or Chinese
+ * line needs that much room. Android does not overflow when it is short: RN's
+ * `CustomLineHeightSpan` clamps the ascent instead, which slices the top off every
+ * wrapped line. Latin fonts hide the problem because their glyph box is ~1.2em.
+ */
+const MIN_LINE_HEIGHT_RATIO = 1.45;
+
+/**
+ * Derive a line height from the font size instead of hardcoding one.
+ *
+ * `applyAppearance` rescales the whole `theme.fontSize` ramp when the user changes
+ * the UI font size, so a constant `lineHeight` tightens as the ramp grows — at UI
+ * size 24 the old heading constants dropped to ~0.8, and headings collided.
+ *
+ * Ceil, not round: rounding down lands back under the ratio this exists to
+ * guarantee (18 * 1.45 rounds to 26, a ratio of 1.44).
+ */
+function lineHeightFor(fontSize: number): number {
+  return Math.ceil(fontSize * MIN_LINE_HEIGHT_RATIO);
+}
+
+/**
  * Creates comprehensive markdown styles for react-native-markdown-display.
  *
  * Usage:
@@ -20,9 +44,9 @@ export function createMarkdownStyles(theme: Theme) {
       ...webSelectableTextStyle,
       color: theme.colors.foreground,
       fontSize: theme.fontSize.base,
-      // Prose line-height scales with the UI ramp (≈22 at base 16), NOT the
+      // Prose line-height scales with the UI ramp (24 at base 16), NOT the
       // code-size-coupled lineHeight.diff token used by code/diff surfaces.
-      lineHeight: Math.round(theme.fontSize.base * 1.4),
+      lineHeight: lineHeightFor(theme.fontSize.base),
       flexShrink: 1,
       minWidth: 0,
       width: "100%" as const,
@@ -59,7 +83,7 @@ export function createMarkdownStyles(theme: Theme) {
       color: theme.colors.foreground,
       marginTop: theme.spacing[6],
       marginBottom: theme.spacing[3],
-      lineHeight: 32,
+      lineHeight: lineHeightFor(theme.fontSize["3xl"]),
       borderBottomWidth: 1,
       borderBottomColor: theme.colors.border,
       paddingBottom: theme.spacing[2],
@@ -72,7 +96,7 @@ export function createMarkdownStyles(theme: Theme) {
       color: theme.colors.foreground,
       marginTop: theme.spacing[6],
       marginBottom: theme.spacing[3],
-      lineHeight: 28,
+      lineHeight: lineHeightFor(theme.fontSize["2xl"]),
       borderBottomWidth: 1,
       borderBottomColor: theme.colors.border,
       paddingBottom: theme.spacing[2],
@@ -85,7 +109,7 @@ export function createMarkdownStyles(theme: Theme) {
       color: theme.colors.foreground,
       marginTop: theme.spacing[4],
       marginBottom: theme.spacing[2],
-      lineHeight: 26,
+      lineHeight: lineHeightFor(theme.fontSize.xl),
     },
 
     heading4: {
@@ -95,7 +119,7 @@ export function createMarkdownStyles(theme: Theme) {
       color: theme.colors.foreground,
       marginTop: theme.spacing[4],
       marginBottom: theme.spacing[2],
-      lineHeight: 24,
+      lineHeight: lineHeightFor(theme.fontSize.lg),
     },
 
     heading5: {
@@ -105,7 +129,7 @@ export function createMarkdownStyles(theme: Theme) {
       color: theme.colors.foreground,
       marginTop: theme.spacing[3],
       marginBottom: theme.spacing[1],
-      lineHeight: 22,
+      lineHeight: lineHeightFor(theme.fontSize.base),
     },
 
     heading6: {
@@ -115,7 +139,7 @@ export function createMarkdownStyles(theme: Theme) {
       color: theme.colors.foregroundMuted,
       marginTop: theme.spacing[3],
       marginBottom: theme.spacing[1],
-      lineHeight: 20,
+      lineHeight: lineHeightFor(theme.fontSize.base),
       textTransform: "uppercase" as const,
       letterSpacing: 0.5,
     },
@@ -172,7 +196,7 @@ export function createMarkdownStyles(theme: Theme) {
       borderWidth: 0,
       fontFamily: theme.fontFamily.mono,
       fontSize: theme.fontSize.code,
-      lineHeight: Math.round(theme.fontSize.code * 1.45),
+      lineHeight: lineHeightFor(theme.fontSize.code),
     },
 
     code_block: {
@@ -285,7 +309,7 @@ export function createMarkdownStyles(theme: Theme) {
       color: theme.colors.foregroundMuted,
       marginRight: 4,
       fontSize: theme.fontSize.base,
-      lineHeight: 22,
+      lineHeight: lineHeightFor(theme.fontSize.base),
     },
 
     ordered_list_icon: {
@@ -294,7 +318,7 @@ export function createMarkdownStyles(theme: Theme) {
       marginRight: 4,
       fontSize: theme.fontSize.base,
       fontWeight: theme.fontWeight.normal,
-      lineHeight: 22,
+      lineHeight: lineHeightFor(theme.fontSize.base),
       minWidth: 12,
     },
 
@@ -356,7 +380,7 @@ export function createCompactMarkdownStyles(theme: Theme) {
     body: {
       ...baseStyles.body,
       fontSize: theme.fontSize.sm,
-      lineHeight: 20,
+      lineHeight: lineHeightFor(theme.fontSize.sm),
     },
 
     heading1: {
@@ -364,7 +388,7 @@ export function createCompactMarkdownStyles(theme: Theme) {
       fontSize: theme.fontSize.xl,
       marginTop: theme.spacing[4],
       marginBottom: theme.spacing[2],
-      lineHeight: 26,
+      lineHeight: lineHeightFor(theme.fontSize.xl),
     },
 
     heading2: {
@@ -372,7 +396,7 @@ export function createCompactMarkdownStyles(theme: Theme) {
       fontSize: theme.fontSize.lg,
       marginTop: theme.spacing[3],
       marginBottom: theme.spacing[2],
-      lineHeight: 24,
+      lineHeight: lineHeightFor(theme.fontSize.lg),
     },
 
     heading3: {
@@ -380,7 +404,7 @@ export function createCompactMarkdownStyles(theme: Theme) {
       fontSize: theme.fontSize.base,
       marginTop: theme.spacing[3],
       marginBottom: theme.spacing[1],
-      lineHeight: 22,
+      lineHeight: lineHeightFor(theme.fontSize.base),
     },
 
     paragraph: {


### PR DESCRIPTION
### Linked issue

Closes #2959

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On Android, a markdown heading that wraps to a second line gets sliced. Someone reading an agent's answer on their phone loses the title of the section they're reading — and since it only bites when the heading is long enough to wrap, it hits exactly the headings that carry the most information. It shows up first in Korean and other CJK text, whose glyph box is taller than Latin's.

The cause is that `markdown-styles.ts` pinned `lineHeight` to constants while `fontSize` comes from the theme ramp. `applyAppearance` rescales that ramp by `uiFontSize / 16`, so the ratio collapses as a user raises their font size: at UI size 24, `heading1` is `fontSize 39` against `lineHeight 32`, a ratio of 0.82, and the wrapped lines overlap outright. Body prose never broke because its line height was already derived from `fontSize`.

Android doesn't overflow when `lineHeight` is too small — RN's `CustomLineHeightSpan` clamps the ascent instead, which cuts the glyphs. So the floor has to clear the font's actual glyph box, not just look reasonable.

This replaces every hardcoded value with one derived helper at a 1.45 floor: Noto Sans CJK's ascent + descent, and the ratio `code_inline` in this same file already used.

### Goals

- Heading line heights track the font-size ramp, so raising the UI font size can never crowd them.
- Every markdown line height clears the CJK glyph box, so wrapped Korean/Japanese/Chinese headings are not sliced.
- Same treatment for the list markers and the compact variant, which had the identical defect.
- A regression test that fails if a hardcoded line height comes back.

### Non-goals

- No change to the type scale itself — font sizes, weights, margins, and the heading borders are untouched.
- No change to `theme.lineHeight.diff` or any code/diff surface; those are coupled to the code font size on purpose.
- Not a fix for other markdown layout issues on this screen.
- Trade-off: body prose moves from a 1.4 ratio to 1.45, which is 22px → 24px at the default size. One shared floor beats two near-identical constants, and the extra pixel is what keeps CJK body text off the clamp too.

### QA

**Environment:** Android emulator, freshly created AVD (API 36.1, x86_64, 1080x2400, stock Roboto + Noto Sans CJK), debug build off this branch. Not tested on iOS, web, or desktop — this is a shared style module, but the clipping mechanism (`CustomLineHeightSpan`) is Android-only and the change is a pure numeric widening elsewhere.

**Repro before the fix.** Rendered a fixture through `MarkdownRenderer` with headings long enough to wrap, then called `applyAppearance` with `uiFontSize: 24`:

```
# 실제 pi로 검증한 결과와 앞으로의 계획 정리
## 실제 pi로 검증한 결과
### 실제 pi로 검증한 결과를 조금 더 길게 적어본 제목
본문입니다. 제목이 두 줄로 접힐 때 아래쪽이 잘리는지 확인합니다.
```

At UI 24: `heading1` and `heading3` wrapped lines overlap and the lower line is cut; `heading2` clips the descender of `pi` even on one line; the body paragraph directly beneath is correct. At UI 16 the stock emulator font does not clip — the original report is from a Samsung One UI device, whose taller system font metrics push the same too-tight ratio over the edge. I could not test that font.

**After the fix.** Same fixture, same emulator, checked at UI 16 and UI 24: headings wrap cleanly at both, no overlap, no cut glyphs, `pi` descender intact.

| | Before | After |
|---|---|---|
| **UI font size 24** | <img width="360" alt="before, UI 24 - headings collide and are sliced" src="https://github.com/user-attachments/assets/224c9d43-54b0-43d7-ac8e-e688233cd173" /> | <img width="360" alt="after, UI 24 - headings wrap cleanly" src="https://github.com/user-attachments/assets/45c94ba1-7bc2-4071-9735-8237b11179dc" /> |
| **UI font size 16** (default) | <img width="360" alt="before, UI 16" src="https://github.com/user-attachments/assets/55092ba6-33de-4aeb-86eb-e8eed59c5cd2" /> | <img width="360" alt="after, UI 16" src="https://github.com/user-attachments/assets/9ae54f7a-acc4-4e59-8ec9-458fe120f522" /> |

The UI 24 row is the one that carries it: on the left `heading1` and `heading3` overlap their own wrapped line and `heading2` loses the descender of `pi`; on the right all three wrap cleanly. The UI 16 row shows the default size is unharmed — headings gain a little air and nothing else moves.

**Tests.**

```
$ npx vitest run packages/app/src/styles/markdown-styles.test.ts --bail=1

 RUN  v4.1.7

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  1.70s
```

Two new tests. The first walks headings 1–6 across both `createMarkdownStyles` and `createCompactMarkdownStyles`, on the default theme and on a theme whose font ramp is scaled by 24/16 the way `applyAppearance` scales it, and asserts `lineHeight / fontSize` never drops below the floor. It fails on `main`. The second does the same for the list markers.

The floor is a `Math.ceil`, not a `Math.round`, because rounding lands back under it — `18 * 1.45` rounds to 26, a ratio of 1.44. The first test caught exactly that during development.

**Checks.**

```
$ npm run typecheck                          # all 12 workspaces pass
$ npm run lint                               # Found 0 warnings and 0 errors (3221 files)
$ npm run format:check:files -- <both files> # All matched files use the correct format
```

Scoped to the changed files: repo-wide `npm run format:check` reports every file dirty in my Windows worktree because of CRLF checkout, and does so identically with my changes stashed, so it is not a signal here. The pre-commit hook runs lint, `format:check:files`, and a full `typecheck` and passes.

**Review follow-up.** Addressed all three bot comments; force-pushed as one commit rather than a fixup.

- The tests now state the 1.45 floor as their own literal instead of importing the implementation's constant, which was circular. Verified by temporarily setting the implementation constant to 1.2: `AssertionError: createMarkdownStyles heading1: expected 1.2307692307692308 to be greater than or equal to 1.45`.
- Fixed the prose comment: `lineHeightFor(16)` is 24, not 23. Left over from when the helper still used `Math.round`.
- `withScaledFontRamp` no longer scales `code`, matching `scaleFontSize`, which sets it absolutely from the separate code-size control.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
