### PR TITLE
Show terminal virtual keys on wide native layouts

### DIFF
--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -31,6 +31,7 @@ import {
   getTerminalVirtualKeyboardControlId,
   shouldShowTerminalFloatingCopyAction,
   shouldShowTerminalPasteAction,
+  shouldShowTerminalVirtualKeyboard,
   TERMINAL_VIRTUAL_KEYBOARD_ROWS,
   type TerminalVirtualKeyboardControl,
 } from "@/terminal/runtime/terminal-virtual-keyboard";
@@ -980,6 +981,10 @@ export function TerminalPane({
     hasSelection,
     isNative,
   });
+  const showVirtualKeyboard = shouldShowTerminalVirtualKeyboard({
+    isCompactFormFactor: isMobile,
+    isNative,
+  });
   const keyboardToggleIconColor = theme.colors.foregroundMuted;
 
   const renderVirtualKeyboardControl = (control: TerminalVirtualKeyboardControl) => {
@@ -1096,7 +1101,7 @@ export function TerminalPane({
         </View>
       ) : null}
 
-      {isMobile ? (
+      {showVirtualKeyboard ? (
         <View style={styles.keyboardContainer} testID="terminal-virtual-keyboard">
           <View style={styles.keyboardRows}>
             {TERMINAL_VIRTUAL_KEYBOARD_ROWS.map((row) => (

--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -221,12 +221,16 @@ export function TerminalPane({
     return trimmed.length > 0 ? trimmed : undefined;
   }, [settings.monoFontFamily]);
   const isMobile = useIsCompactFormFactor();
+  const showVirtualKeyboard = shouldShowTerminalVirtualKeyboard({
+    isCompactFormFactor: isMobile,
+    isNative,
+  });
   const mobileView = usePanelStore((state) => state.mobilePanel.target);
   const showMobileAgentList = usePanelStore((state) => state.showMobileAgentList);
   const swipeGesturesEnabled = isMobile;
   const { shift: keyboardShift, style: keyboardPaddingStyle } = useKeyboardShiftStyle({
     mode: "padding",
-    enabled: isMobile,
+    enabled: showVirtualKeyboard,
   });
   const [keyboardInset, setKeyboardInset] = useState(0);
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
@@ -285,7 +289,7 @@ export function TerminalPane({
   }, [terminalId]);
 
   const refreshClipboardAvailability = useCallback(async () => {
-    if (!isMobile) {
+    if (!showVirtualKeyboard) {
       setHasClipboardText(false);
       return;
     }
@@ -295,7 +299,7 @@ export function TerminalPane({
     } catch {
       setHasClipboardText(false);
     }
-  }, [isMobile]);
+  }, [showVirtualKeyboard]);
 
   useEffect(() => {
     void refreshClipboardAvailability();
@@ -341,7 +345,7 @@ export function TerminalPane({
   );
 
   useEffect(() => {
-    if (isMobile || !isPaneFocused || !terminalId) {
+    if (showVirtualKeyboard || !isPaneFocused || !terminalId) {
       lastAutoFocusKeyRef.current = null;
       return;
     }
@@ -353,7 +357,14 @@ export function TerminalPane({
       lastAutoFocusKeyRef.current = focusKey;
       requestTerminalFocus();
     }
-  }, [isMobile, isPaneFocused, isWorkspaceFocused, requestTerminalFocus, scopeKey, terminalId]);
+  }, [
+    showVirtualKeyboard,
+    isPaneFocused,
+    isWorkspaceFocused,
+    requestTerminalFocus,
+    scopeKey,
+    terminalId,
+  ]);
 
   useEffect(() => {
     const canRequest = canRequestFocusClaim({
@@ -428,11 +439,11 @@ export function TerminalPane({
 
   const handleKeyboardChange = useCallback(
     (nextShift: number) => {
-      setKeyboardInset(isMobile ? nextShift : 0);
+      setKeyboardInset(showVirtualKeyboard ? nextShift : 0);
       setIsKeyboardVisible(nextShift > 0);
       pulseKeyboardRefits();
     },
-    [isMobile, pulseKeyboardRefits],
+    [showVirtualKeyboard, pulseKeyboardRefits],
   );
 
   useEffect(() => {
@@ -979,10 +990,6 @@ export function TerminalPane({
   const showPasteAction = shouldShowTerminalPasteAction({ isNative });
   const showFloatingCopyAction = shouldShowTerminalFloatingCopyAction({
     hasSelection,
-    isNative,
-  });
-  const showVirtualKeyboard = shouldShowTerminalVirtualKeyboard({
-    isCompactFormFactor: isMobile,
     isNative,
   });
   const keyboardToggleIconColor = theme.colors.foregroundMuted;

--- a/packages/app/src/terminal/runtime/terminal-virtual-keyboard.test.ts
+++ b/packages/app/src/terminal/runtime/terminal-virtual-keyboard.test.ts
@@ -4,6 +4,7 @@ import {
   getTerminalVirtualKeyboardControlId,
   shouldShowTerminalFloatingCopyAction,
   shouldShowTerminalPasteAction,
+  shouldShowTerminalVirtualKeyboard,
   TERMINAL_VIRTUAL_KEYBOARD_ROWS,
   type TerminalVirtualKeyboardControl,
 } from "./terminal-virtual-keyboard";
@@ -104,5 +105,26 @@ describe("terminal virtual keyboard policy", () => {
   it("keeps Paste native-gated", () => {
     expect(shouldShowTerminalPasteAction({ isNative: true })).toBe(true);
     expect(shouldShowTerminalPasteAction({ isNative: false })).toBe(false);
+  });
+
+  it("shows terminal controls on native devices at every layout width", () => {
+    expect(
+      shouldShowTerminalVirtualKeyboard({
+        isCompactFormFactor: false,
+        isNative: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowTerminalVirtualKeyboard({
+        isCompactFormFactor: true,
+        isNative: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowTerminalVirtualKeyboard({
+        isCompactFormFactor: false,
+        isNative: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/app/src/terminal/runtime/terminal-virtual-keyboard.ts
+++ b/packages/app/src/terminal/runtime/terminal-virtual-keyboard.ts
@@ -60,6 +60,13 @@ export function shouldShowTerminalPasteAction(input: { isNative: boolean }): boo
   return input.isNative;
 }
 
+export function shouldShowTerminalVirtualKeyboard(input: {
+  isCompactFormFactor: boolean;
+  isNative: boolean;
+}): boolean {
+  return input.isNative || input.isCompactFormFactor;
+}
+
 export function shouldShowTerminalFloatingCopyAction(input: {
   hasSelection: boolean;
   isNative: boolean;


### PR DESCRIPTION
## Summary

- keep the terminal virtual-key rows visible on native iOS and Android at every responsive breakpoint
- preserve the existing virtual-key rows for compact browser layouts
- cover native wide, compact web, and wide web policy cases

Closes #2967.

## Problem

`TerminalPane` tied Esc, modifiers, arrows, and Enter to `useIsCompactFormFactor()`. An unfolded Galaxy Fold uses a wider tablet layout, so the Android APK stopped rendering controls that its software keyboard does not provide.

The controls are an input capability on native devices, not a compact-layout-only element. The new policy renders them when the runtime is native or the layout is compact.

## Verification

```text
$ npx vitest run packages/app/src/terminal/runtime/terminal-virtual-keyboard.test.ts --bail=1
Test Files  1 passed (1)
Tests       6 passed (6)

$ npm run lint -- packages/app/src/components/terminal-pane.tsx packages/app/src/terminal/runtime/terminal-virtual-keyboard.ts packages/app/src/terminal/runtime/terminal-virtual-keyboard.test.ts
Found 0 warnings and 0 errors.

$ npm run typecheck
completed successfully after npm run build:server

$ npm run format:check
All matched files use the correct format.
```

## Platform coverage

- Galaxy Fold / Android v0.3.0-beta.2: original missing-row behavior reported on an unfolded layout
- Patched Android build: not device-tested
- iOS/iPadOS: not device-tested
- Browser/Electron: not manually tested; policy test verifies compact web remains enabled and wide web remains disabled
