### PR TITLE
feat(app): show agent controls in the New workspace Command Center

### DIFF
--- a/packages/app/e2e/browser/command-center-agent-controls.spec.ts
+++ b/packages/app/e2e/browser/command-center-agent-controls.spec.ts
@@ -3,6 +3,7 @@ import { closeCommandCenter, openCommandCenter } from "../support/helpers/comman
 import {
   applyCommandCenterAgentControls,
   chooseCommandCenterAgentControl,
+  expectCommandCenterAgentControlRowCount,
   expectCommandCenterAgentControlSelected,
   expectFocusedAgentControls,
   expectWorkspaceAgentConfiguration,
@@ -11,14 +12,26 @@ import {
 } from "../support/helpers/command-center-agent-controls";
 import { clickNewChat, gotoWorkspace } from "../support/helpers/launcher";
 import { openAgentRoute, seedMockAgentWorkspace } from "../support/helpers/mock-agent";
+import {
+  assertNewWorkspaceSidebarAndHeader,
+  connectNewWorkspaceDaemonClient,
+  expectNewWorkspaceProjectSelected,
+  openGlobalNewWorkspaceComposer,
+  selectWorkspaceIsolation,
+  submitNewWorkspacePrompt,
+} from "../support/helpers/new-workspace";
 import { seedWorkspace } from "../support/helpers/seed-client";
 import { getServerId } from "../support/helpers/server-id";
+import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
 
 const CREATE_AGENT_PREFERENCES_KEY = "@paseo:create-agent-preferences";
 
-async function seedMockDraftPreferences(page: import("@playwright/test").Page): Promise<void> {
+async function seedMockDraftPreferences(
+  page: import("@playwright/test").Page,
+  options?: { mode?: string },
+): Promise<void> {
   await page.addInitScript(
-    ({ preferencesKey, serverId }) => {
+    ({ preferencesKey, serverId, mode }) => {
       localStorage.setItem(
         preferencesKey,
         JSON.stringify({
@@ -27,13 +40,17 @@ async function seedMockDraftPreferences(page: import("@playwright/test").Page): 
           providerPreferences: {
             mock: {
               model: "five-minute-stream",
-              mode: "load-test",
+              mode,
             },
           },
         }),
       );
     },
-    { preferencesKey: CREATE_AGENT_PREFERENCES_KEY, serverId: getServerId() },
+    {
+      preferencesKey: CREATE_AGENT_PREFERENCES_KEY,
+      serverId: getServerId(),
+      mode: options?.mode ?? "load-test",
+    },
   );
 }
 
@@ -94,6 +111,52 @@ test.describe("Command Center agent controls", () => {
       });
     } finally {
       await workspace.cleanup();
+    }
+  });
+
+  test("applies New workspace choices to the created agent", async ({ page }) => {
+    const serverId = getServerId();
+    const seeded = await seedWorkspace({ repoPrefix: "command-center-new-workspace-controls-" });
+    // A non-default seeded mode makes the Mode row a real change rather than a selected-row no-op.
+    await seedMockDraftPreferences(page, { mode: "approval-test" });
+    const client = await connectNewWorkspaceDaemonClient();
+
+    try {
+      await gotoWorkspace(page, seeded.workspaceId);
+      await waitForSidebarHydration(page);
+      await openGlobalNewWorkspaceComposer(page);
+      await expectNewWorkspaceProjectSelected(page, seeded.projectDisplayName);
+      await selectWorkspaceIsolation(page, "local");
+
+      await applyCommandCenterAgentControls(page, DRAFT_AGENT_CONTROL_CHOICES);
+
+      // The seeded workspace is still mounted behind /new. Exactly one owner may publish the row.
+      await openCommandCenter(page);
+      await expectCommandCenterAgentControlRowCount({
+        page,
+        query: "load test",
+        choice: "Mode › Load test",
+        count: 1,
+      });
+      await closeCommandCenter(page);
+
+      await submitNewWorkspacePrompt(page, "Create with Command Center choices");
+      const created = await assertNewWorkspaceSidebarAndHeader(page, {
+        serverId,
+        client,
+        previousWorkspaceId: seeded.workspaceId,
+        projectDisplayName: seeded.projectDisplayName,
+      });
+
+      // Must be the CREATED workspace: expectWorkspaceAgentConfiguration filters by the id it is
+      // handed, so passing the seeded one would assert against the wrong agent.
+      await expectWorkspaceAgentConfiguration(
+        { client: seeded.client, workspaceId: created.workspaceId },
+        { provider: "mock", model: "ten-second-stream", modeId: "load-test" },
+      );
+    } finally {
+      await client.close().catch(() => undefined);
+      await seeded.cleanup();
     }
   });
 });

--- a/packages/app/e2e/browser/new-workspace-mode-cycle-safety.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-mode-cycle-safety.spec.ts
@@ -1,4 +1,9 @@
 import { expect, test, type Page } from "../support/fixtures";
+import { openCommandCenter } from "../support/helpers/command-center";
+import {
+  chooseCommandCenterAgentControl,
+  expectCommandCenterAgentControlRowCount,
+} from "../support/helpers/command-center-agent-controls";
 import { daemonWsRoutePattern } from "../support/helpers/daemon-port";
 import { openAgentRoute } from "../support/helpers/mock-agent";
 import {
@@ -138,6 +143,64 @@ test.describe("New Workspace mode cycle safety", () => {
       // fetchAgents is a real daemon round-trip; once it resolves, any mode change the
       // presses would have triggered has already landed. Assert the running agent is
       // untouched — both its committed mode and on the wire — with no fixed sleep.
+      const agents = await seeded.client.fetchAgents();
+      const backgroundAgent = agents.entries.find((entry) => entry.agent.id === agent.id)?.agent;
+      expect(backgroundAgent?.currentModeId).toBe("auto");
+      expect(modeRequests.requestsForAgent(agent.id)).toEqual([]);
+    } finally {
+      await seeded.cleanup();
+    }
+  });
+
+  // Same hazard, different trigger: the New Workspace composer now registers Command Center
+  // agent-control rows. Picking a mode there must stay in the draft's form state and never reach
+  // the backgrounded agent that shares the provider — and therefore shares the mode's label.
+  test("Command Center mode in New Workspace never changes a backgrounded agent's mode", async ({
+    page,
+  }) => {
+    const serverId = getServerId();
+    const seeded = await seedWorkspace({ repoPrefix: "mode-command-center-safety-" });
+    await seedCodexDefaultPreferences(page, serverId);
+    // Routing must be installed before the page opens its daemon socket.
+    const modeRequests = await recordSetAgentModeRequests(page);
+
+    try {
+      const agent = await seeded.client.createAgent({
+        provider: "codex",
+        cwd: seeded.repoPath,
+        workspaceId: seeded.workspaceId,
+        title: "mode command center safety e2e",
+        modeId: "auto",
+        model: "gpt-5.4-mini",
+      });
+
+      await openAgentRoute(page, { workspaceId: seeded.workspaceId, agentId: agent.id });
+      await expect(
+        page.getByRole("button", { name: "Select agent mode (Default permissions)" }),
+      ).toBeVisible({ timeout: 30_000 });
+
+      await openGlobalNewWorkspaceComposer(page);
+      await selectNewWorkspaceProject(page, {
+        projectKey: seeded.projectKey,
+        projectDisplayName: seeded.projectDisplayName,
+      });
+
+      // Both composers are codex, so an extra registrant would duplicate this exact row. Checking
+      // the count is what separates "the live agent ignored the pick" from "the live agent was
+      // never registered" — the assertion below cannot tell those apart on its own.
+      await openCommandCenter(page);
+      await expectCommandCenterAgentControlRowCount({
+        page,
+        query: "auto-review",
+        choice: "Mode › Auto-review",
+        count: 1,
+      });
+      await chooseCommandCenterAgentControl({
+        page,
+        query: "auto-review",
+        choice: "Mode › Auto-review",
+      });
+
       const agents = await seeded.client.fetchAgents();
       const backgroundAgent = agents.entries.find((entry) => entry.agent.id === agent.id)?.agent;
       expect(backgroundAgent?.currentModeId).toBe("auto");

--- a/packages/app/e2e/browser/new-workspace-mode-cycle-safety.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-mode-cycle-safety.spec.ts
@@ -188,17 +188,21 @@ test.describe("New Workspace mode cycle safety", () => {
       // Both composers are codex, so an extra registrant would duplicate this exact row. Checking
       // the count is what separates "the live agent ignored the pick" from "the live agent was
       // never registered" — the assertion below cannot tell those apart on its own.
+      //
+      // Full access, not auto-review: auto-review is gated on the installed codex version
+      // (codex-app-server-agent.ts:6567), so it is absent on hosts with an older binary. Every
+      // codex install has full-access.
       await openCommandCenter(page);
       await expectCommandCenterAgentControlRowCount({
         page,
-        query: "auto-review",
-        choice: "Mode › Auto-review",
+        query: "full access",
+        choice: "Mode › Full access",
         count: 1,
       });
       await chooseCommandCenterAgentControl({
         page,
-        query: "auto-review",
-        choice: "Mode › Auto-review",
+        query: "full access",
+        choice: "Mode › Full access",
       });
 
       const agents = await seeded.client.fetchAgents();

--- a/packages/app/e2e/support/helpers/command-center-agent-controls.ts
+++ b/packages/app/e2e/support/helpers/command-center-agent-controls.ts
@@ -31,6 +31,23 @@ export async function expectCommandCenterAgentControlSelected(input: {
   await expect(choice).toHaveAttribute("aria-pressed", "true");
 }
 
+/**
+ * Agent-control rows are registered by whichever composer owns focus. Two enabled owners publish
+ * the same row twice under different source ids, so the count is how you catch a second registrant.
+ */
+export async function expectCommandCenterAgentControlRowCount(input: {
+  page: Page;
+  query: string;
+  choice: string;
+  count: number;
+}): Promise<void> {
+  const panel = input.page.getByTestId("command-center-panel");
+  await panel.getByRole("textbox").fill(input.query);
+  await expect(panel.getByRole("button", { name: input.choice })).toHaveCount(input.count, {
+    timeout: 30_000,
+  });
+}
+
 export async function applyCommandCenterAgentControls(
   page: Page,
   choices: readonly CommandCenterAgentControlChoice[],

--- a/packages/app/src/composer/agent-controls/index.tsx
+++ b/packages/app/src/composer/agent-controls/index.tsx
@@ -66,6 +66,7 @@ import { toErrorMessage } from "@/utils/error-messages";
 import { showProviderNoticeToast } from "@/utils/provider-notice-toast";
 import { useAgentControlCommandCenterActions } from "@/command-center/agent-control-registration";
 import { isNative } from "@/constants/platform";
+import { resolveEffectiveComposerModelId } from "@/provider-selection/provider-selection";
 import {
   resolveComposerControlDensity,
   resolveComposerControlPresentation,
@@ -149,6 +150,17 @@ export interface DraftAgentControlsProps {
   modelSelectorServerId?: string | null;
   isCompactLayout?: boolean;
 }
+
+/**
+ * `DraftAgentControlsProps` is the control *data* built by `buildDraftAgentControls` and passed
+ * through `Composer`'s `agentControls` prop. These three come from `Composer` itself instead, so
+ * they stay off that type.
+ */
+type DraftAgentControlsComponentProps = DraftAgentControlsProps & {
+  agentId: string;
+  serverId: string;
+  isPaneFocused: boolean;
+};
 
 interface AgentControlsProps {
   agentId: string;
@@ -1715,7 +1727,10 @@ export function DraftAgentControls({
   disabled = false,
   modelSelectorServerId = null,
   isCompactLayout,
-}: DraftAgentControlsProps) {
+  agentId,
+  serverId,
+  isPaneFocused,
+}: DraftAgentControlsComponentProps) {
   const mappedThinkingOptions = useMemo<AgentControlOption[]>(() => {
     return toThinkingControlOptions(thinkingOptions);
   }, [thinkingOptions]);
@@ -1781,6 +1796,55 @@ export function DraftAgentControls({
         : null,
     [selectedProvider, providerDefinitions, modeOptions, selectedMode, onSelectMode, disabled],
   );
+
+  const effectiveModelId = useMemo(
+    () =>
+      resolveEffectiveComposerModelId({
+        provider: selectedProvider,
+        modelId: selectedModel,
+        modeId: selectedMode,
+        thinkingOptionId: selectedThinkingOptionId,
+        availableModels: models,
+        modeOptions,
+      }),
+    [selectedProvider, selectedModel, selectedMode, selectedThinkingOptionId, models, modeOptions],
+  );
+
+  // Registration lives here rather than at each host screen so any draft surface gets the Cmd-K
+  // rows by rendering this component. Exactly one owner may be enabled at a time: `isPaneFocused`
+  // means route focus on every host, and workspace panes additionally go inactive off a workspace
+  // pathname (see parseActiveWorkspaceSelection, navigation.ts:75-77 — retained panes stay mounted,
+  // so that parser is what keeps a backgrounded workspace from registering).
+  useAgentControlCommandCenterActions({
+    sourceId: `draft:${serverId}:${agentId}`,
+    enabled: isPaneFocused && !disabled,
+    controls: {
+      serverId,
+      ownerKey: agentId,
+      provider: selectedProvider,
+      providerDefinitions,
+      models: {
+        providers: modelSelectorProviders,
+        selectedProvider,
+        selectedModelId: effectiveModelId,
+        select: onSelectProviderAndModel,
+      },
+      thinking: {
+        options: thinkingOptions,
+        selectedId: selectedThinkingOptionId,
+        select: onSelectThinkingOption,
+      },
+      modes: {
+        options: modeOptions,
+        selectedId: selectedMode,
+        select: onSelectMode,
+      },
+      features: {
+        list: features,
+        set: onSetFeature,
+      },
+    },
+  });
 
   return (
     <ControlledAgentControls

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -24,7 +24,6 @@ import { useCreateFlowStore } from "@/stores/create-flow-store";
 import type { Agent } from "@/stores/session-store";
 import { useWorkspaceFields } from "@/stores/session-store-hooks";
 import { useWorkspaceDraftSubmissionStore } from "@/stores/workspace-draft-submission-store";
-import { useAgentControlCommandCenterActions } from "@/command-center/agent-control-registration";
 import { encodeImages } from "@/utils/encode-images";
 import type { WorkspaceFileOpenRequest } from "@/workspace/file-open";
 import { shouldAutoFocusWorkspaceDraftComposer } from "@/screens/workspace/workspace-draft-pane-focus";
@@ -378,17 +377,6 @@ export function WorkspaceDraftAgentTab({
     throw new Error("Workspace draft composer state is required");
   }
 
-  const draftProvider = composerState.selectedProvider;
-  const draftProviderDefinitions = composerState.providerDefinitions;
-  const draftThinkingOptions = composerState.availableThinkingOptions;
-  const draftSelectedThinkingId = composerState.selectedThinkingOptionId;
-  const draftSetThinkingOption = composerState.setThinkingOptionFromUser;
-  const draftModeOptions = composerState.modeOptions;
-  const draftSelectedMode = composerState.selectedMode;
-  const draftSetMode = composerState.setModeFromUser;
-  const draftFeatures = composerState.agentControls.features;
-  const draftOnSetFeature = composerState.agentControls.onSetFeature;
-
   const clearDraftInput = draftInput.clear;
   const setDraftText = draftInput.setText;
   const setDraftAttachments = draftInput.setAttachments;
@@ -536,36 +524,6 @@ export function WorkspaceDraftAgentTab({
     () => resolveTurnPresentation(TURN_LIVENESS_IDLE, pendingMessageSubmissions.length > 0),
     [pendingMessageSubmissions],
   );
-  useAgentControlCommandCenterActions({
-    sourceId: `draft:${serverId}:${tabId}`,
-    enabled: isPaneFocused && !isSubmitting,
-    controls: {
-      serverId,
-      ownerKey: tabId,
-      provider: draftProvider,
-      providerDefinitions: draftProviderDefinitions,
-      models: {
-        providers: composerState.modelSelectorProviders,
-        selectedProvider: draftProvider,
-        selectedModelId: composerState.effectiveModelId,
-        select: composerState.setProviderAndModelFromUser,
-      },
-      thinking: {
-        options: draftThinkingOptions,
-        selectedId: draftSelectedThinkingId,
-        select: draftSetThinkingOption,
-      },
-      modes: {
-        options: draftModeOptions,
-        selectedId: draftSelectedMode,
-        select: draftSetMode,
-      },
-      features: {
-        list: draftFeatures,
-        set: draftOnSetFeature,
-      },
-    },
-  });
   const isReadyForPendingAutoSubmit = Boolean(
     pendingAutoSubmit &&
     draftInput.isHydrated &&

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -302,7 +302,15 @@ function renderLeftContent(args: RenderLeftContentArgs): ReactElement | null {
   const { agentControls, agentId, serverId, focusInput, isCompactLayout, isPaneFocused } = args;
   if (!args.showAgentControls) return null;
   if (resolveAgentControlsMode(agentControls) === "draft" && agentControls) {
-    return <DraftAgentControls {...agentControls} isCompactLayout={isCompactLayout} />;
+    return (
+      <DraftAgentControls
+        {...agentControls}
+        isCompactLayout={isCompactLayout}
+        agentId={agentId}
+        serverId={serverId}
+        isPaneFocused={isPaneFocused}
+      />
+    );
   }
   return (
     <AgentControls

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -9,6 +9,7 @@ import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles"
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createNameId } from "mnemonic-id";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIsFocused } from "@react-navigation/native";
 import { ChevronDown, Folder, FolderPlus, GitBranch, GitPullRequest } from "lucide-react-native";
 import { Composer } from "@/composer";
 import { FileDropZone } from "@/components/file-drop/file-drop-zone";
@@ -1550,6 +1551,10 @@ export function NewWorkspaceScreen({
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const isCompact = useIsCompactFormFactor();
+  // `/new` is a root-stack screen, so pushing a sibling route on top of it leaves this screen
+  // mounted. The composer's controls register Command Center rows while focused, so this has to
+  // be real route focus rather than a hardcoded `true`.
+  const isRouteFocused = useIsFocused();
   const toast = useToast();
   const mergeWorkspaces = useSessionStore((state) => state.mergeWorkspaces);
   const {
@@ -2299,7 +2304,7 @@ export function NewWorkspaceScreen({
               submitLabel={terminalSubmitLabel}
               agentId={draftKey}
               serverId={selectedServerId}
-              isPaneFocused={true}
+              isPaneFocused={isRouteFocused}
               onSubmitMessage={handleSubmitTerminalLaunch}
               allowEmptySubmit={true}
               submitButtonAccessibilityLabel={t("newWorkspace.launch.submit")}
@@ -2321,7 +2326,7 @@ export function NewWorkspaceScreen({
               externalKeyboardShift
               agentId={draftKey}
               serverId={selectedServerId}
-              isPaneFocused={true}
+              isPaneFocused={isRouteFocused}
               onSubmitMessage={handleSubmitNewWorkspace}
               allowEmptySubmit={true}
               submitButtonAccessibilityLabel={t("newWorkspace.create")}


### PR DESCRIPTION
### Type of change

- [x] Enhancement

### Reasoning

Cmd/Ctrl-K lets you switch Model, Thinking, Mode, Plan mode, and Fast mode by typing. It works
from a live agent pane and from a draft tab inside an existing workspace, but not from the New
workspace screen — which is the one place you're choosing all of that *before* the first turn.

The cause is an asymmetry rather than a decision. These rows are Command Center contributions
registered by whichever composer owns focus. `AgentControls` registers inside the component, so a
live pane can't forget it. `DraftAgentControls` registered nothing, leaving each host screen to
call `useAgentControlCommandCenterActions` itself — `workspace-tab.tsx` remembered, the New
workspace screen never did, and forgetting it fails silently. The commit that added the feature
covered "a running agent and a new draft tab"; the standalone screen was missed.

So this moves the registration into `DraftAgentControls`, which fixes the screen and removes the
way to forget it again.

### Goals

- Cmd-K Model / Thinking / Mode / Plan mode / Fast mode rows work on the New workspace screen,
  and the choices reach the created agent.
- One registration path for draft composers, so a future draft surface can't silently miss it.
- No behavior change for the live agent pane or the in-workspace draft tab.

### Non-goals

- **`components/workspace-setup-dialog.tsx`** has the same gap and is deliberately left alone: it
  renders a composer with `agentControls`, but `beginWorkspaceSetup` has no production caller, so
  `pendingWorkspaceSetup` is always null and the dialog short-circuits before mounting it. It's
  unreachable. Deleting it (with its two unused e2e helpers) is a separate cleanup — happy to do
  it in a follow-up if you want it gone.
- No duplicate-owner warning in `command-center/registry.ts`. It would catch a regression of the
  single-registrant invariant at the moment it appears, but that hardens shared Command Center
  code on a PR about one missing registration.
- No protocol change. `create_agent` already carries `modeId` / `model` / `thinkingOptionId` /
  `featureValues`, and selecting a row only mutates draft form state.
- No new strings — `shell.commandCenter.*` already exist.

### Implementation notes

Two things worth calling out in review:

**The component takes its own props type.** `agentId` / `serverId` / `isPaneFocused` come from
`Composer`, not from `buildDraftAgentControls`, so they go on a
`DraftAgentControlsProps & {…}` intersection and the exported control-data type is unchanged.
`effectiveModelId` is derived from props via `resolveEffectiveComposerModelId` rather than added
as a prop — it reads only `modelId` and `availableModels`, which are already there as
`selectedModel` and `models`.

**New workspace passed `isPaneFocused={true}`.** Harmless while the screen registered nothing,
but `/new` is a root-stack screen: pushing a sibling route on top of it (Settings, Sessions,
open-project) leaves it mounted, so a hardcoded `true` would keep publishing rows into the palette
on those screens. It now passes real route focus via `useIsFocused()`, matching
`workspace-screen.tsx:941`. The `/new` → workspace hop was already safe — `navigateToHostWorkspaceRoute`
dispatches `POP_TO` rather than a push.

### QA

**Platforms tested:** web (browser, Playwright + the dev app). **Not tested:** iOS, Android,
Electron desktop. This is client-side Command Center wiring with no platform-specific code, but
I haven't run it on those.

I didn't attach a video. The change is "a palette row exists and its choice lands on the created
agent", which the tests below assert directly against the daemon.

**Tests added** — `packages/app/e2e/browser/`:

1. `command-center-agent-controls.spec.ts` — "applies New workspace choices to the created agent".
   Opens the global New workspace composer over a seeded workspace, picks
   `Model › Mock Load Test › Ten second stream` and `Mode › Load test` from Cmd-K, submits, and
   asserts the **created** workspace's agent has that provider/model/mode. The seeded mode is
   `approval-test` so the Mode pick is a real change, not a selected-row no-op. It also asserts
   the Mode row renders exactly once — the seeded workspace is still mounted behind `/new`, so
   this is a behavioral check that only one owner registers.
2. `new-workspace-mode-cycle-safety.spec.ts` — "Command Center mode in New Workspace never changes
   a backgrounded agent's mode". Same hazard as the existing Shift+Tab test in that file, new
   trigger. A live codex agent on `auto` is backgrounded, then `Mode › Full access` is chosen from
   Cmd-K on `/new`. Asserts no `set_agent_mode_request` for that agent and that its
   `currentModeId` is untouched. Both composers are codex, so they'd contribute the same row —
   the count assertion is what separates "the live agent ignored the pick" from "the live agent
   was never registered", which the wire assertion alone can't tell apart.

   The first push used `Mode › Auto-review` here and shard 2/4 failed with 0 matching rows.
   `auto-review` is gated on the installed codex version — the provider drops it from the mode
   list unless `resolveAutoReviewEnabled()` passes (`codex-app-server-agent.ts:6567`) — so it
   exists on a dev machine with a current binary and not on CI. `full-access` survives that same
   filter, and `new-workspace-codex-mode-preferences.spec.ts` already selects it on CI. Fixed in
   `a022bf38e`.

**Results** (from `packages/app`):

```
$ npm run test:e2e -- e2e/browser/command-center-agent-controls.spec.ts \
                     e2e/browser/new-workspace-mode-cycle-safety.spec.ts

  ✓  1 command-center-agent-controls.spec.ts:60 › changes a running agent setting and preserves its selected row (3.6s)
  ✓  2 command-center-agent-controls.spec.ts:97 › applies draft model and setting choices to the created agent (3.6s)
  ✓  3 command-center-agent-controls.spec.ts:117 › applies New workspace choices to the created agent (4.0s)
  ✓  4 new-workspace-mode-cycle-safety.spec.ts:111 › Shift+Tab in New Workspace never changes a backgrounded agent's mode (4.0s)
  ✓  5 new-workspace-mode-cycle-safety.spec.ts:158 › Command Center mode in New Workspace never changes a backgrounded agent's mode (3.8s)

  5 passed (28.0s)
```

**Negative control** — same two specs with only the `src/` changes stashed, tests untouched:

```
  ✓  2 › applies draft model and setting choices to the created agent (4.9s)
  ✘  3 › applies New workspace choices to the created agent (34.6s)
        Error: expect(locator).toBeVisible() failed
  ✓  4 › Shift+Tab in New Workspace never changes a backgrounded agent's mode (4.3s)
  ✘  5 › Command Center mode in New Workspace never changes a backgrounded agent's mode (33.9s)
        Error: expect(locator).toHaveCount(expected) failed

  2 failed
  3 passed (1.6m)
```

Both new tests fail without the fix — the row never appears on `/new`, and its count is 0 rather
than 1 — while the two pre-existing tests still pass. The tests exercise the fix, not the mock.

That run predates the `auto-review` → `full-access` change in `a022bf38e`; the assertion is
otherwise identical, only the mode it names differs.

**Unit tests** on the touched files:

```
$ npx vitest run src/composer/draft/workspace-tab.test.ts src/composer/draft/input-draft.test.ts
  Test Files  2 passed (2)
       Tests  14 passed (14)
```

**Manual, dev daemon** (`npm run dev` + `npm run dev:app`, web):

- New workspace → Cmd-K → `auto` → `Mode › Auto mode` appears, checked on the current value;
  selecting it updates the composer mode pill.
- `opus` → Model rows; a cross-provider pick switches the provider too.
- `think` / `effort` → Thinking rows (only when the model has more than one option).
  `plan` / `fast` → On/Off toggles.
- Empty query → default palette unchanged; the rows are `visibility: "query"`.
- From `/new`, opening Settings drops the agent-control rows from the palette (the focus fix).
- Regression: the in-workspace draft tab and a live agent pane still show their rows.

**Checks:** `npm run typecheck`, `npm run lint`, `npm run format:check` all clean across the
monorepo.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

