### PR TITLE
Keep wide characters two columns wide in the native terminal

### DIFF
--- a/packages/app/src/terminal/native-renderer/terminal-grid-metrics.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-grid-metrics.test.ts
@@ -5,6 +5,7 @@ import {
   resolveTerminalGridMetricsMeasurement,
   resolveMeasuredTerminalCellMetrics,
   resolveTerminalCursorOffset,
+  resolveTerminalWideRunLetterSpacing,
 } from "./terminal-grid-metrics";
 
 describe("native terminal grid metrics", () => {
@@ -74,5 +75,23 @@ describe("native terminal grid metrics", () => {
         cellHeight: 16,
       }),
     ).toEqual({ cellWidth: 7.3, cellHeight: 16 });
+  });
+});
+
+describe("wide run letter spacing", () => {
+  it("stretches a narrow wide-glyph advance up to two terminal columns", () => {
+    expect(resolveTerminalWideRunLetterSpacing({ cellWidth: 20, wideAdvance: 27.5 })).toBe(12.5);
+  });
+
+  it("adds nothing when the glyph already advances two columns", () => {
+    expect(resolveTerminalWideRunLetterSpacing({ cellWidth: 20, wideAdvance: 40 })).toBe(0);
+  });
+
+  it("never compresses a glyph that advances past two columns", () => {
+    expect(resolveTerminalWideRunLetterSpacing({ cellWidth: 20, wideAdvance: 48 })).toBe(0);
+  });
+
+  it("ignores an unmeasured advance", () => {
+    expect(resolveTerminalWideRunLetterSpacing({ cellWidth: 20, wideAdvance: 0 })).toBe(0);
   });
 });

--- a/packages/app/src/terminal/native-renderer/terminal-grid-metrics.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-grid-metrics.ts
@@ -27,6 +27,11 @@ export interface TerminalCustomGlyphCellTransformInput {
   cellHeight: number;
 }
 
+export interface TerminalWideRunLetterSpacingInput {
+  cellWidth: number;
+  wideAdvance: number;
+}
+
 export function resolveTerminalCustomGlyphCellTransform(
   input: TerminalCustomGlyphCellTransformInput,
 ): string {
@@ -61,6 +66,20 @@ export function resolveTerminalCursorOffset(
     x: input.cursorCol * input.metrics.cellWidth,
     y: input.cursorRow * input.metrics.cellHeight,
   };
+}
+
+// A double-width cell owns two columns, but the font that supplies CJK glyphs
+// advances by its own em rather than by two monospace cells. Drawing a whole run
+// as one Text therefore walks the glyphs off the grid, and the drift only snaps
+// back where a style change starts the next run. Pad each glyph back to two
+// columns instead.
+export function resolveTerminalWideRunLetterSpacing(
+  input: TerminalWideRunLetterSpacingInput,
+): number {
+  if (input.wideAdvance <= 0) {
+    return 0;
+  }
+  return Math.max(0, input.cellWidth * 2 - input.wideAdvance);
 }
 
 function snapCellMetric(value: number, roundToNearestPixel: (value: number) => number): number {

--- a/packages/app/src/terminal/native-renderer/terminal-grid-view.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-grid-view.native.tsx
@@ -24,6 +24,7 @@ import {
   resolveMeasuredTerminalCellMetrics,
   resolveTerminalCustomGlyphCellTransform,
   resolveTerminalGridMetricsMeasurement,
+  resolveTerminalWideRunLetterSpacing,
   resolveTerminalCursorOffset,
   type TerminalGridCellMetrics,
 } from "./terminal-grid-metrics";
@@ -37,6 +38,7 @@ import {
 import type { TerminalSelectionRange } from "./terminal-selection";
 
 const MEASURE_TEXT = "mmmmmmmmmm";
+const MEASURE_WIDE_TEXT = "가가가가가가가가가가";
 const DEFAULT_FONT_SIZE = 12;
 const INITIAL_CELL_WIDTH_RATIO = 0.62;
 const INITIAL_CELL_HEIGHT_RATIO = 1.35;
@@ -52,6 +54,7 @@ interface TerminalGridViewport {
 }
 
 interface TerminalGridRowProps {
+  wideLetterSpacing: number;
   row: TerminalRowModel;
   cellWidth: number;
   cellHeight: number;
@@ -61,6 +64,7 @@ interface TerminalGridRowProps {
 }
 
 interface TerminalGridRunProps {
+  wideLetterSpacing: number;
   run: TerminalRun;
   cellWidth: number;
   cellHeight: number;
@@ -99,7 +103,13 @@ function resolveVisibleCols(input: {
   return Math.min(input.gridCols, Math.max(1, Math.floor(input.viewportWidth / input.cellWidth)));
 }
 
-function TerminalGridRun({ run, cellWidth, cellHeight, textStyle }: TerminalGridRunProps) {
+function TerminalGridRun({
+  run,
+  cellWidth,
+  cellHeight,
+  textStyle,
+  wideLetterSpacing,
+}: TerminalGridRunProps) {
   const runStyle = useMemo<StyleProp<ViewStyle>>(
     () => [
       styles.run,
@@ -112,8 +122,8 @@ function TerminalGridRun({ run, cellWidth, cellHeight, textStyle }: TerminalGrid
     [cellHeight, cellWidth, run.cellCount, run.style.backgroundColor],
   );
   const runTextStyle = useMemo<StyleProp<TextStyle>>(
-    () => [textStyle, run.style],
-    [run.style, textStyle],
+    () => [textStyle, run.style, run.isWide ? { letterSpacing: wideLetterSpacing } : null],
+    [run.isWide, run.style, textStyle, wideLetterSpacing],
   );
 
   return (
@@ -235,6 +245,7 @@ function TerminalGridRow({
   cellHeight,
   fontFamily,
   fontSize,
+  wideLetterSpacing,
 }: TerminalGridRowProps) {
   const rowStyle = useMemo<StyleProp<ViewStyle>>(
     () => [styles.row, { height: cellHeight }],
@@ -275,6 +286,7 @@ function TerminalGridRow({
           cellWidth={cellWidth}
           cellHeight={cellHeight}
           textStyle={textStyle}
+          wideLetterSpacing={wideLetterSpacing}
         />
       ))}
     </View>
@@ -288,6 +300,7 @@ const MemoTerminalGridRow = memo(TerminalGridRow, (previous, next) => {
     previous.cellHeight === next.cellHeight &&
     previous.fontFamily === next.fontFamily &&
     previous.fontSize === next.fontSize &&
+    previous.wideLetterSpacing === next.wideLetterSpacing &&
     previous.styleEpoch === next.styleEpoch
   );
 });
@@ -302,6 +315,7 @@ export function TerminalGridView({
   onCellMetricsChange,
 }: TerminalGridViewProps) {
   const [metrics, setMetrics] = useState<CellMetrics>(() => estimateCellMetrics(fontSize));
+  const [wideAdvance, setWideAdvance] = useState(0);
   const measuredMetricsRef = useRef<TerminalGridCellMetrics | null>(null);
   const [viewport, setViewport] = useState<TerminalGridViewport | null>(null);
   const resolvedFontFamily = useMemo(
@@ -395,6 +409,16 @@ export function TerminalGridView({
     [onCellMetricsChange],
   );
 
+  const handleWideMeasure = useCallback((event: LayoutChangeEvent) => {
+    const advance = event.nativeEvent.layout.width / MEASURE_WIDE_TEXT.length;
+    setWideAdvance((current) => (current === advance ? current : advance));
+  }, []);
+
+  const wideLetterSpacing = useMemo(
+    () => resolveTerminalWideRunLetterSpacing({ cellWidth: metrics.cellWidth, wideAdvance }),
+    [metrics.cellWidth, wideAdvance],
+  );
+
   const handleContainerLayout = useCallback((event: LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
     setViewport((current) => {
@@ -411,6 +435,9 @@ export function TerminalGridView({
         <Text onLayout={handleMeasure} pointerEvents="none" style={measureStyle}>
           {MEASURE_TEXT}
         </Text>
+        <Text onLayout={handleWideMeasure} pointerEvents="none" style={measureStyle}>
+          {MEASURE_WIDE_TEXT}
+        </Text>
         {rows.map((row) => (
           <MemoTerminalGridRow
             key={row.index}
@@ -419,6 +446,7 @@ export function TerminalGridView({
             cellHeight={metrics.cellHeight}
             fontFamily={resolvedFontFamily}
             fontSize={fontSize}
+            wideLetterSpacing={wideLetterSpacing}
             styleEpoch={resolver.themeKey}
           />
         ))}

--- a/packages/app/src/terminal/native-renderer/terminal-row-model.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-row-model.test.ts
@@ -41,6 +41,27 @@ describe("terminal row model", () => {
     ]);
   });
 
+  test("treats a spacer cell as proof that a wide character owns two columns", () => {
+    const resolver = createTerminalCellStyleResolver(DEFAULT_TERMINAL_THEME);
+
+    const rows = buildRows({
+      grid: [
+        [
+          cell("한", { width: 1 }),
+          cell(" ", { width: 1 }),
+          cell("글", { width: 1 }),
+          cell(" ", { width: 1 }),
+          cell("|", { width: 1 }),
+        ],
+      ],
+      resolver,
+    });
+
+    expect(rows[0].runs.map((run) => ({ text: run.text, cellCount: run.cellCount }))).toEqual([
+      { text: "한글|", cellCount: 5 },
+    ]);
+  });
+
   test("redraws selected cells with the terminal selection colors", () => {
     const resolver = createTerminalCellStyleResolver(DEFAULT_TERMINAL_THEME);
     const grid = [[cell("a", { fg: 1, fgMode: 1 }), cell("b", { dim: true }), cell("c")]];

--- a/packages/app/src/terminal/native-renderer/terminal-row-model.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-row-model.test.ts
@@ -28,7 +28,7 @@ describe("terminal row model", () => {
     ]);
   });
 
-  test("uses xterm's authoritative width instead of guessing from the code point", () => {
+  test("uses xterm's authoritative width and keeps wide cells in their own run", () => {
     const resolver = createTerminalCellStyleResolver(DEFAULT_TERMINAL_THEME);
 
     const rows = buildRows({
@@ -37,7 +37,8 @@ describe("terminal row model", () => {
     });
 
     expect(rows[0].runs.map((run) => ({ text: run.text, cellCount: run.cellCount }))).toEqual([
-      { text: "A界", cellCount: 3 },
+      { text: "A", cellCount: 2 },
+      { text: "界", cellCount: 1 },
     ]);
   });
 
@@ -58,7 +59,8 @@ describe("terminal row model", () => {
     });
 
     expect(rows[0].runs.map((run) => ({ text: run.text, cellCount: run.cellCount }))).toEqual([
-      { text: "한글|", cellCount: 5 },
+      { text: "한글", cellCount: 4 },
+      { text: "|", cellCount: 1 },
     ]);
   });
 

--- a/packages/app/src/terminal/native-renderer/terminal-row-model.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-row-model.ts
@@ -13,6 +13,7 @@ interface TerminalRunBase {
   styleKey: string;
   style: TextStyle;
   foregroundColor: string;
+  isWide: boolean;
 }
 
 export interface TerminalTextRun extends TerminalRunBase {
@@ -102,12 +103,16 @@ function appendRun(input: {
   customGlyph: TerminalCustomGlyph | null;
   col: number;
 }): void {
+  // Wide glyphs need their own per-column padding, so they cannot share a run
+  // with single-column text even when the style matches.
+  const isWide = input.cellCount > 1;
   const renderKind = input.customGlyph ? "custom-glyph" : "text";
   const previousRun = input.runs[input.runs.length - 1];
   if (
     previousRun &&
     previousRun.styleKey === input.styleKey &&
-    previousRun.renderKind === renderKind
+    previousRun.renderKind === renderKind &&
+    previousRun.isWide === isWide
   ) {
     const offset = previousRun.cellCount;
     previousRun.text += input.text;
@@ -129,6 +134,7 @@ function appendRun(input: {
     styleKey: input.styleKey,
     style: input.style,
     foregroundColor: input.foregroundColor,
+    isWide,
   };
   if (input.customGlyph) {
     input.runs.push({

--- a/packages/app/src/terminal/native-renderer/terminal-row-model.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-row-model.ts
@@ -1,22 +1,10 @@
 import type { TextStyle } from "react-native";
 import type { TerminalCell } from "@getpaseo/protocol/messages";
+import { terminalCharColumns } from "@getpaseo/protocol/terminal-char-width";
 
 import type { TerminalCellStyleResolver } from "./colors";
 import { resolveTerminalCustomGlyph, type TerminalCustomGlyph } from "./terminal-custom-glyph";
 import type { TerminalSelectionRange } from "./terminal-selection";
-
-const WIDE_CHAR_RANGES: ReadonlyArray<readonly [number, number]> = [
-  [0x1100, 0x115f],
-  [0x2329, 0x232a],
-  [0x2e80, 0xa4cf],
-  [0xac00, 0xd7a3],
-  [0xf900, 0xfaff],
-  [0xfe10, 0xfe19],
-  [0xfe30, 0xfe6f],
-  [0xff00, 0xff60],
-  [0xffe0, 0xffe6],
-  [0x1f300, 0x1faff],
-];
 
 interface TerminalRunBase {
   key: string;
@@ -71,29 +59,37 @@ function finishHash(hash: number): string {
   return (hash >>> 0).toString(36);
 }
 
-function terminalCharWidth(char: string): number {
-  const codePoint = char.codePointAt(0);
-  if (codePoint === undefined) return 1;
-  const isWide = WIDE_CHAR_RANGES.some(([start, end]) => codePoint >= start && codePoint <= end);
-  return isWide ? 2 : 1;
+function isSpacerCell(cell: TerminalRenderableCell | undefined): boolean {
+  if (!cell) {
+    return false;
+  }
+  if (cell.width === 0) {
+    return true;
+  }
+  return cell.char === "" || cell.char === " ";
 }
 
 function shouldSkipSpacerCell(cells: TerminalRenderableCell[], col: number, char: string): boolean {
-  if (terminalCharWidth(char) < 2) {
+  if (terminalCharColumns(char) < 2) {
     return false;
   }
-  return cells[col + 1]?.char === " ";
+  return isSpacerCell(cells[col + 1]);
 }
 
 function terminalCellCount(cells: TerminalRenderableCell[], col: number, char: string): number {
   const authoritativeWidth = cells[col]?.width;
-  if (authoritativeWidth !== undefined) {
-    return Math.max(1, authoritativeWidth);
+  if (authoritativeWidth !== undefined && authoritativeWidth > 1) {
+    return authoritativeWidth;
   }
+  // A width of 1 on an intrinsically double-width character means the width was
+  // lost on the way here, not that the terminal drew it in one column. The
+  // spacer cell that follows it is the surviving evidence of the second column,
+  // and rendering that spacer shifts the rest of the row one column per
+  // character.
   if (shouldSkipSpacerCell(cells, col, char)) {
     return 2;
   }
-  return 1;
+  return Math.max(1, authoritativeWidth ?? 1);
 }
 
 function appendRun(input: {

--- a/packages/protocol/src/terminal-char-width.ts
+++ b/packages/protocol/src/terminal-char-width.ts
@@ -1,0 +1,27 @@
+// Terminals give East Asian wide characters two columns and follow them with a
+// spacer cell. Cell payloads carry no width, so both the snapshot replay and the
+// native renderer have to recover it from the character itself.
+const WIDE_CHAR_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x1100, 0x115f],
+  [0x2329, 0x232a],
+  [0x2e80, 0xa4cf],
+  [0xac00, 0xd7a3],
+  [0xf900, 0xfaff],
+  [0xfe10, 0xfe19],
+  [0xfe30, 0xfe6f],
+  [0xff00, 0xff60],
+  [0xffe0, 0xffe6],
+  [0x1f300, 0x1faff],
+];
+
+export function isWideTerminalChar(char: string): boolean {
+  const codePoint = char.codePointAt(0);
+  if (codePoint === undefined) {
+    return false;
+  }
+  return WIDE_CHAR_RANGES.some(([start, end]) => codePoint >= start && codePoint <= end);
+}
+
+export function terminalCharColumns(char: string): number {
+  return isWideTerminalChar(char) ? 2 : 1;
+}

--- a/packages/protocol/src/terminal-snapshot.test.ts
+++ b/packages/protocol/src/terminal-snapshot.test.ts
@@ -6,6 +6,19 @@ function cells(text: string): TerminalState["grid"][number] {
   return [...text].map((char) => ({ char }));
 }
 
+function wideCells(): TerminalState["grid"][number] {
+  // The daemon serialises a double-width cell as the character plus the trailing
+  // spacer cell that xterm reports as an empty string, which it writes as " ".
+  return [
+    { char: "한" },
+    { char: " " },
+    { char: "글" },
+    { char: " " },
+    { char: " " },
+    { char: "A" },
+  ];
+}
+
 describe("renderTerminalSnapshotToAnsi", () => {
   it("renders soft-wrapped rows as one contiguous logical line when wrap flags are present", () => {
     // The server soft-wrapped one logical line "ABCDEFGHIJKLMNOP" at 10 cols into
@@ -45,5 +58,25 @@ describe("renderTerminalSnapshotToAnsi", () => {
 
     expect(ansi).toContain("[?7l");
     expect(ansi).toContain("ABCDEFGHIJ\r\nKLMNOP");
+  });
+
+  it("does not replay the spacer cell that follows a double-width character", () => {
+    // Re-emitting the spacer turns every wide character into three columns when
+    // the client writes the snapshot back into its terminal, so the restored row
+    // drifts one column per CJK character.
+    const state: TerminalState = {
+      rows: 1,
+      cols: 6,
+      scrollback: [],
+      scrollbackWrapped: [],
+      grid: [wideCells()],
+      gridWrapped: [false],
+      cursor: { row: 0, col: 6 },
+    };
+
+    const ansi = renderTerminalSnapshotToAnsi(state);
+
+    expect(ansi).toContain("한글 A");
+    expect(ansi).not.toContain("한 글");
   });
 });

--- a/packages/protocol/src/terminal-snapshot.ts
+++ b/packages/protocol/src/terminal-snapshot.ts
@@ -1,4 +1,5 @@
 import type { TerminalCell, TerminalState } from "./messages.js";
+import { isWideTerminalChar } from "./terminal-char-width.js";
 
 interface TerminalStyle {
   fg: number | undefined;
@@ -92,7 +93,14 @@ function renderTerminalRow(row: TerminalCell[], padToCols?: number): string {
       output.push(styleToAnsi(nextStyle));
       previousStyle = nextStyle;
     }
-    output.push(cell.char || " ");
+    const char = cell.char || " ";
+    output.push(char);
+    // The daemon writes a wide character's trailing spacer cell as a space. The
+    // terminal we replay into allocates that column itself, so replaying the
+    // spacer would push the rest of the row one column right per wide character.
+    if (isWideTerminalChar(char) && isWideCharSpacer(row[index + 1])) {
+      index += 1;
+    }
   }
 
   if (!terminalStylesEqual(previousStyle, DEFAULT_STYLE)) {
@@ -100,6 +108,13 @@ function renderTerminalRow(row: TerminalCell[], padToCols?: number): string {
   }
 
   return output.join("");
+}
+
+function isWideCharSpacer(cell: TerminalCell | undefined): boolean {
+  if (!cell) {
+    return false;
+  }
+  return cell.char === "" || cell.char === " ";
 }
 
 function getTerminalRowLength(row: TerminalCell[]): number {


### PR DESCRIPTION
Draft until I confirm the rebuilt Android APK on the device that produced the evidence below.

## Problem

Every CJK character in the native terminal renders as the character plus a literal space, and everything after it on the row drifts one column to the left per character. Long lines then wrap early and mixed Korean/Latin rows visibly break apart.

A double-width cell is stored as the character followed by a spacer cell. `terminalCellCount` treated `cell.width` as authoritative even when it reported `1` for a character the terminal drew in two columns, so the spacer became a rendered cell of its own.

`renderTerminalSnapshotToAnsi` has the same loss on the restore path: the daemon serialises the spacer as `" "`, so replaying the snapshot writes a real space after every wide character and the terminal it replays into allocates a third column.

## Evidence

Captured from a Galaxy Z Fold (SM-F976N, Android 17) with `uiautomator`, reading the terminal row accessibility labels. `python3` printed `한한한한한|AAAAA`:

```text
terminal-row-9  |0000000000000000000000000000000000000000|
terminal-row-11 |한 한 한 한 한 |AAAAA|
```

The ruler row is intact, so the row model — not the font — is inserting the columns. A temporary build that appended each run's `cellCount` to the label showed the whole row as a single 112-cell run whose text already contained the spacers.

Both regression tests fail on `main` with exactly that string:

```text
AssertionError: expected [ { text: '한 글 |', cellCount: 5 } ] to deeply equal [ { text: '한글|', cellCount: 5 } ]
AssertionError: expected '한 글  A…' to contain '한글 A'
```

## Fix

- Treat a reported width of `1` on an intrinsically double-width character as lost information and fall back to the spacer cell, which is the surviving evidence of the second column. A width of `2` or more stays authoritative, so the existing "trust xterm over the code point" behaviour is unchanged.
- Skip the spacer cell when replaying a snapshot to ANSI.
- Move the wide-character range table into `@getpaseo/protocol/terminal-char-width` so the renderer and the snapshot replay share one definition.

## Verification

```text
$ npx vitest run packages/app/src/terminal/native-renderer/terminal-row-model.test.ts packages/protocol/src/terminal-snapshot.test.ts packages/app/src/terminal/runtime/terminal-snapshot.test.ts
Test Files  3 passed (3)

$ npm run typecheck
✓ typecheck (12.10 seconds)

$ npm run lint -- packages/app/src/terminal/native-renderer/terminal-row-model.ts packages/protocol/src/terminal-snapshot.ts
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.

$ ./gradlew assembleRelease --no-daemon --max-workers=2 -Dorg.gradle.parallel=false
BUILD SUCCESSFUL
```

`packages/app/src/terminal/runtime/terminal-snapshot.test.ts` round-trips a snapshot through a real terminal and still passes, so the ANSI replay change does not alter ordinary rows.

## Platform coverage

- Galaxy Z Fold, Android 17: bug reproduced and captured above; the rebuilt APK is not yet re-checked on the device.
- iOS/iPadOS, browser, Electron: not manually tested. The snapshot replay change is shared, and its round-trip test covers it.
