### PR TITLE
fix(pi): stream assistant deltas when pi omits the cumulative message

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -662,6 +662,63 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("streams assistant text and reasoning when Pi omits the cumulative message", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "response-1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "hel" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "lo" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "thinking_delta", delta: "thinking" },
+    });
+
+    expect(events.timelineItems()).toEqual([
+      { type: "assistant_message", text: "hel", messageId: "response-1" },
+      { type: "assistant_message", text: "lo", messageId: "response-1" },
+      { type: "reasoning", text: "thinking" },
+    ]);
+  });
+
+  test("generates one message id when Pi omits both message start and the cumulative message", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "hel" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "lo" },
+    });
+
+    const [firstChunk, secondChunk] = events.timelineItems();
+    expect(firstChunk).toMatchObject({
+      type: "assistant_message",
+      text: "hel",
+      messageId: expect.any(String),
+    });
+    const firstMessageId = (firstChunk as { messageId: string }).messageId;
+    expect(secondChunk).toEqual({
+      type: "assistant_message",
+      text: "lo",
+      messageId: firstMessageId,
+    });
+  });
+
   test("emits live user messages with submitted Pi tree entry ids", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2191,12 +2191,12 @@ export class PiRpcAgentSession implements AgentSession {
     event: Extract<PiAgentSessionEvent, { type: "message_update" }>,
     turnId: string | undefined,
   ): void {
-    if (event.message.role !== "assistant") {
+    if (event.message && event.message.role !== "assistant") {
       return;
     }
     if (event.assistantMessageEvent.type === "text_delta") {
       // Pi-compatible runtimes may emit updates without a preceding message_start.
-      this.activeAssistantMessageId ??= event.message.responseId || randomUUID();
+      this.activeAssistantMessageId ??= event.message?.responseId || randomUUID();
       this.emit({
         type: "timeline",
         provider: this.provider,

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -160,8 +160,8 @@ export type PiAgentSessionEvent =
   | { type: "message_end"; message: PiAgentMessage }
   | {
       type: "message_update";
-      // COMPAT(piCumulativeMessageUpdate): pi <=0.83 repeats the cumulative assistant message on
-      // every update; pi >=0.84 sends deltas only. Remove optional once the pi floor is >=0.84.
+      // COMPAT(piCumulativeMessageUpdate): added in v0.3.0, remove after 2027-02-07 once the pi
+      // floor is >=0.84. pi <=0.83 repeats the cumulative assistant message on every update.
       message?: PiAgentMessage;
       assistantMessageEvent: PiAssistantMessageEvent;
     }

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -160,7 +160,9 @@ export type PiAgentSessionEvent =
   | { type: "message_end"; message: PiAgentMessage }
   | {
       type: "message_update";
-      message: PiAgentMessage;
+      // COMPAT(piCumulativeMessageUpdate): pi <=0.83 repeats the cumulative assistant message on
+      // every update; pi >=0.84 sends deltas only. Remove optional once the pi floor is >=0.84.
+      message?: PiAgentMessage;
       assistantMessageEvent: PiAssistantMessageEvent;
     }
   | {


### PR DESCRIPTION
Fixes #2940
Fixes #2946
Fixes #2950

## Problem

With pi `0.84.x` installed, every prompt to a pi agent kills the daemon. The worker exits with code 1, the supervisor restarts it, and the next assistant delta crashes it again, so the chat looks stuck and the message is lost.

```
TypeError: Cannot read properties of undefined (reading 'role')
    at PiRpcAgentSession.handleMessageUpdate (.../providers/pi/agent.js:1752:27)
    at PiRpcAgentSession.handleSessionEvent (.../providers/pi/agent.js:1663:22)
    at PiRpcAgentSession.handleRuntimeEvent (.../providers/pi/agent.js:1614:18)
...
Uncaught exception — daemon crashing
```

## Root cause

pi `0.84.0` dropped the cumulative `message` snapshot from JSON/RPC `message_update` events. From its changelog, under Breaking Changes:

> Changed JSON and RPC `message_update` events to emit only `assistantMessageEvent` deltas, removing the cumulative `message` and `assistantMessageEvent.partial` fields that caused quadratic output growth. Clients that need partial messages must assemble deltas between `message_start` and `message_end`; the latter remains authoritative.

The RPC path runs every event through `toJsonEvent()`, which strips the field, so what reaches the daemon is:

```json
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Hello"}}
```

`handleMessageUpdate` read `event.message.role` unconditionally, and `PiAgentSessionEvent` declared `message` as required, so nothing flagged the drift at the boundary. pi `0.84.1` did not revert it, and pi has no flag to restore the old shape, so the daemon has to accept both wire shapes.

## Fix

`message` is now optional on `message_update`, carrying a `COMPAT` note for when the pi floor moves past 0.83.

The role guard only rejects when a snapshot is present and says the message is not from the assistant. That is safe because `message_update` always carries an `assistantMessageEvent`, which pi only emits for assistant messages — a missing snapshot is an assistant update by construction.

The response id keeps flowing as before: `message_start` still carries the message on 0.84, so `activeAssistantMessageId` is already set by the time deltas arrive, and the existing generated-id fallback still covers pi-compatible runtimes that skip `message_start`.

Behavior on pi `<=0.83` is unchanged — the existing tests that assert on `message_update.message.responseId` still pass untouched.

## QA evidence

Environment: macOS 26 (Darwin 27.0.0, arm64), node v24.14.0, pi `0.84.1` on `PATH`, real e2e model `openai-codex/gpt-5.4`.

### Real pi 0.84.1, before the fix

Reverted only the two source files, kept the new tests, ran the existing real-provider e2e:

```
$ pi --version
0.84.1
$ npx vitest run src/server/daemon-e2e/pi.real.e2e.test.ts \
    -t "thinking-enabled runs emit reasoning timeline chunks" --maxWorkers=1

 × thinking-enabled runs emit reasoning timeline chunks 6496ms
AssertionError: expected '' to contain '1591'
TypeError: Cannot read properties of undefined (reading 'role')
 ❯ PiRpcAgentSession.handleMessageUpdate src/server/agent/providers/pi/agent.ts:2194:23
   ... same frame repeated once per streamed delta (8x)
      Tests  1 failed | 15 skipped (16)
```

The timeline is empty because every delta throws before it is emitted.

### Real pi 0.84.1, after the fix

```
$ npx vitest run src/server/daemon-e2e/pi.real.e2e.test.ts \
    -t "thinking-enabled runs emit reasoning timeline chunks" --maxWorkers=1

 Test Files  1 passed (1)
      Tests  1 passed | 15 skipped (16)
   Duration  11.55s
```

That test covers both branches of `handleMessageUpdate`: it asserts the assistant text contains `1591` (`text_delta`) and that at least one reasoning item arrived (`thinking_delta`).

### New regression tests fail on the old code, for the reported reason

Two tests in `agent.test.ts` emit `message_update` without a snapshot, the way pi 0.84 does. Against the unmodified source:

```
 × streams assistant text and reasoning when Pi omits the cumulative message 6ms
 × generates one message id when Pi omits both message start and the cumulative message 1ms
TypeError: Cannot read properties of undefined (reading 'role')
 ❯ PiRpcAgentSession.handleMessageUpdate src/server/agent/providers/pi/agent.ts:2194:23
      Tests  2 failed | 54 passed (56)
```

The 54 pre-existing tests in the file still pass there, so the failure is the fix, not the tests.

### After the fix

```
$ npx vitest run src/server/agent/providers/pi/
 Test Files  5 passed (5)
      Tests  91 passed (91)
```

### Wider unit sweep

```
$ npx vitest run src/server/agent/ --exclude "**/*.e2e.test.ts"
 Test Files  1 failed | 116 passed | 3 skipped (120)
      Tests  1 failed | 1733 passed | 21 skipped (1755)
```

The one failure is pre-existing and unrelated — `providers/omp/agent.diagnostic.test.ts > reports an overridden command and OMP-only paths and caveats`, `expected 'Oh My Pi (OMP)...' not to contain '.pi/agent'`. It fails identically on unmodified `main` on this machine (which has a real `~/.pi/agent`), verified by stashing the change and re-running that file alone.

### Checks

```
$ npm run typecheck --workspace=@getpaseo/server      # clean
$ npx oxlint packages/server/src/server/agent/providers/pi/
Found 0 warnings and 0 errors.
$ npx oxfmt --check packages/server/src/server/agent/providers/pi/
All matched files use the correct format.
```

The pre-commit hook passed with all three jobs green, including the full-workspace typecheck:

```
✔️ lint (0.23 seconds)
✔️ format (0.26 seconds)
✔️ typecheck (6.22 seconds)
```

## Platforms

The change is daemon-only (`packages/server`) with no platform-specific code, but I only verified it on one host.

| Platform        | Tested | Notes                                                                    |
| --------------- | ------ | ------------------------------------------------------------------------ |
| iOS             |        | not affected — no app changes                                            |
| Android         |        | not affected — no app changes                                            |
| Web             |        | not affected — no app changes                                            |
| Desktop macOS   | ✅     | real pi 0.84.1 e2e + unit suites, on Darwin 27.0.0 arm64                 |
| Desktop Windows |        | not tested — #2950 reports the same crash there                          |
| Desktop Linux   |        | not tested — #2946 reports the same crash there                          |

## Out of scope

The crash also exposes a separate weakness: an unexpected provider event propagates out of `handleRuntimeEvent` as an uncaught exception and takes the whole daemon down with it, rather than failing that one turn. Guarding that dispatch is a different change with its own blast radius, so I left it out to keep this PR to one fix. Happy to open it separately if you want it.

The omp provider has the same `handleMessageUpdate` shape, but its runtime is in-tree and its events are zod-validated, so it is untouched here.
