### PR TITLE
fix(app): defensive guards for command-center empty rows (needs verification)

### DIFF
--- a/packages/app/src/command-center/command-center.tsx
+++ b/packages/app/src/command-center/command-center.tsx
@@ -477,6 +477,7 @@ export function CommandCenter() {
 
   const revealActiveResult = useCallback(() => {
     if (!state.open || !state.activeId) return;
+    if (state.rows.length === 0) return;
     const index = state.rowIndexByResultId.get(state.activeId);
     if (index === undefined) return;
     const { offset, visibleLength } = scrollMetricsRef.current;
@@ -536,11 +537,17 @@ export function CommandCenter() {
     [state.activeId, state.select],
   );
   const getItemLayout = useCallback(
-    (_data: ArrayLike<CommandCenterListRow> | null | undefined, index: number) => ({
-      index,
-      length: state.rows[index].height,
-      offset: state.offsets[index],
-    }),
+    (_data: ArrayLike<CommandCenterListRow> | null | undefined, index: number) => {
+      const row = state.rows[index];
+      if (!row) {
+        return { length: 0, offset: 0, index };
+      }
+      return {
+        index,
+        length: row.height,
+        offset: state.offsets[index],
+      };
+    },
     [state.offsets, state.rows],
   );
   const keyExtractor = useCallback((row: CommandCenterListRow) => row.key, []);


### PR DESCRIPTION
## Summary

Defensive guards around the command-center's empty `state.rows` case. The Android crash from #2936 (`scrollToIndex out of range: item length 0 but minimum is 1`) happens when the search query filters all results and the underlying list ends up empty.

## Honest status

I could not definitively identify the call site for the throwing `scrollToIndex` in the user's stack trace. The two guards below cover the two paths I could verify from source, but neither is confirmed to match the exact code path the user is hitting. **This PR needs Matteo to run the patched build on Android before it can be closed.**

The stack trace from #2936 shows:

```
scrollToIndex (caller)
scrollToIndex (throws)
anonymous useEffect callback
commitHookEffectListMount
```

In `react-native@0.81.5` (installed), the only call sites of `scrollToIndex` inside the VirtualizedList are:
- `scrollToItem` (we don't call it)
- `_maybeScrollToInitialScrollIndex`, gated by `initialScrollIndex != null && initialScrollIndex > 0` (we don't set it)

Our app source contains exactly one `scrollToIndex` call (`agent-stream/use-scroll-to-message.web.ts:114`) and it uses `@tanstack/react-virtual`, not the React Native FlatList. So our code does not call `scrollToIndex` directly on the native list.

The `useEffect` callback in our command-center tree (the one in `CommandCenter` that calls `revealActiveResult`) calls `scrollToOffset`, not `scrollToIndex` — and in 0.81.5's source, `scrollToOffset` does not call `scrollToIndex` internally. So the stack trace and the source don't line up under my analysis. Possibilities: the bundle was built against an older RN where `scrollToOffset` *did* call `scrollToIndex`; the user is on Paseo 0.2.4 with a different RN than this branch's lockfile; or there's a code path I cannot see without an unminified bundle / source map.

## What this PR changes anyway

Even without certainty about the exact call site, two real bugs in the file are fixed:

1. **`getItemLayout` crashed on empty rows** (`state.rows[index].height` → `TypeError: Cannot read properties of undefined (reading 'height')`). This was an actual TypeError waiting to fire on any empty-data render of the command center.
2. **`revealActiveResult` called `scrollToOffset` on empty rows**. Even if this isn't the path the user hits, calling scroll APIs with no content is a bug — fixing it costs nothing.

## Diff

```diff
   const revealActiveResult = useCallback(() => {
     if (!state.open || !state.activeId) return;
+    if (state.rows.length === 0) return;
     const index = state.rowIndexByResultId.get(state.activeId);
     ...

   const getItemLayout = useCallback(
-    (_data, index) => ({
-      index,
-      length: state.rows[index].height,
-      offset: state.offsets[index],
-    }),
+    (_data, index) => {
+      const row = state.rows[index];
+      if (!row) {
+        return { length: 0, offset: 0, index };
+      }
+      return {
+        index,
+        length: row.height,
+        offset: state.offsets[index],
+      };
+    },
     [state.offsets, state.rows],
   );
```

## Verification done here

- `npm run lint -- packages/app/src/command-center/command-center.tsx` — pass
- `npm run format:files -- src/command-center/command-center.tsx` — pass
- `npx vitest run src/command-center --bail=1` — 29/29 pass

## Verification needed from Matteo

Please build the patched APK and reproduce #2936 on Android:
1. Open the mobile app.
2. Open the command center.
3. Type a search query that matches no project/workspace/agent.

If the crash is gone: merge. If it still crashes, paste the new stack trace (preferably with the unminified source) and I'll find the actual call site.

Refs #2936