### PR TITLE
feat(app): open the New workspace pickers from the keyboard

### DIFF
--- a/packages/app/e2e/browser/new-workspace-picker-shortcuts.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-picker-shortcuts.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import {
+  openNewWorkspaceComposer,
+  selectWorkspaceIsolation,
+} from "../support/helpers/new-workspace";
+import { seedWorkspace, type SeededWorkspace } from "../support/helpers/seed-client";
+import { waitForSidebarHydration } from "../support/helpers/workspace-ui";
+
+// The three New workspace selects each open from the keyboard: Mod+. picks the
+// project, Mod+Shift+. the isolation, Mod+Alt+. the starting ref. Mod+. is also
+// bound to "toggle both sidebars", so the last case proves the resolver falls
+// through to the sidebar when this screen isn't the one claiming the key.
+test.describe("New workspace picker shortcuts", () => {
+  test.describe.configure({ timeout: 240_000 });
+
+  // The app resolves Mod from the runtime's own platform, so the chord has to
+  // follow the browser the test happens to run in.
+  async function modifier(page: import("@playwright/test").Page): Promise<"Meta" | "Control"> {
+    const isMac = await page.evaluate(() => /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent));
+    return isMac ? "Meta" : "Control";
+  }
+
+  test("Mod+. / Mod+Shift+. / Mod+Alt+. open the three pickers", async ({ page }) => {
+    const seeded: SeededWorkspace = await seedWorkspace({ repoPrefix: "picker-shortcuts-" });
+
+    try {
+      await gotoAppShell(page);
+      await waitForSidebarHydration(page);
+      await openNewWorkspaceComposer(page, {
+        projectKey: seeded.projectKey,
+        projectDisplayName: seeded.projectDisplayName,
+      });
+      const mod = await modifier(page);
+
+      await page.keyboard.press(`${mod}+Period`);
+      const projectSearch = page.getByPlaceholder("Search projects");
+      await expect(projectSearch).toBeVisible({ timeout: 30_000 });
+      await page.keyboard.press("Escape");
+      await expect(projectSearch).toBeHidden({ timeout: 30_000 });
+
+      await page.keyboard.press(`${mod}+Shift+Period`);
+      await expect(page.getByTestId("workspace-create-isolation-worktree")).toBeVisible({
+        timeout: 30_000,
+      });
+      await page.keyboard.press("Escape");
+
+      // The starting-ref row only exists under worktree isolation, which is also
+      // what gates the shortcut.
+      await selectWorkspaceIsolation(page, "worktree");
+      await page.keyboard.press(`${mod}+Alt+Period`);
+      await expect(page.getByPlaceholder("Search branches and PRs")).toBeVisible({
+        timeout: 30_000,
+      });
+    } finally {
+      await seeded.cleanup();
+    }
+  });
+});

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -271,12 +271,19 @@ export function useKeyboardShortcuts({
         return;
       }
 
-      const handled = routeAndPerformShortcut({
-        action: result.match.action,
-        payload: result.match.payload,
-        domEvent: input.domEvent,
-        browserFocusRestoreElement: input.browserFocusRestoreElement,
-      });
+      // Several bindings can share a combo (e.g. Cmd+. opens the New workspace
+      // project picker, and otherwise toggles both sidebars). Walk them in
+      // binding order until one claims the key.
+      let handled = false;
+      for (const candidate of [result.match, ...(result.fallbackMatches ?? [])]) {
+        handled = routeAndPerformShortcut({
+          action: candidate.action,
+          payload: candidate.payload,
+          domEvent: input.domEvent,
+          browserFocusRestoreElement: input.browserFocusRestoreElement,
+        });
+        if (handled) break;
+      }
       if (!handled || !input.domEvent) {
         return;
       }

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1931,6 +1931,8 @@ export const ar: TranslationResources = {
         queueMessage: "رسالة قائمة الانتظار",
         muteUnmuteVoiceMode: "كتم وضع الصوت /unmute",
         switchProject: "تبديل المشروع",
+        chooseWorkspaceIsolation: "اختيار بيئة مساحة العمل",
+        chooseBaseBranch: "اختيار الفرع الأولي",
       },
       helpNotes: {
         showKeyboardShortcuts: "متاح عندما لا يكون التركيز في حقل نص أو محطة طرفية.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1941,6 +1941,8 @@ export const en = {
         queueMessage: "Queue message",
         muteUnmuteVoiceMode: "Mute/unmute voice mode",
         switchProject: "Switch project",
+        chooseWorkspaceIsolation: "Choose workspace environment",
+        chooseBaseBranch: "Choose starting branch",
       },
       helpNotes: {
         showKeyboardShortcuts: "Available when focus is not in a text field or terminal.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1979,6 +1979,8 @@ export const es: TranslationResources = {
         queueMessage: "mensaje de cola",
         muteUnmuteVoiceMode: "Silenciar el modo de voz/unmute",
         switchProject: "Cambiar proyecto",
+        chooseWorkspaceIsolation: "Elegir entorno del espacio de trabajo",
+        chooseBaseBranch: "Elegir rama inicial",
       },
       helpNotes: {
         showKeyboardShortcuts: "Disponible cuando el foco no está en un campo de texto o terminal.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1982,6 +1982,8 @@ export const fr: TranslationResources = {
         queueMessage: "Message de file d'attente",
         muteUnmuteVoiceMode: "Mode vocal/unmutemuet",
         switchProject: "Changer de projet",
+        chooseWorkspaceIsolation: "Choisir l'environnement de l'espace de travail",
+        chooseBaseBranch: "Choisir la branche de départ",
       },
       helpNotes: {
         showKeyboardShortcuts:

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1947,6 +1947,8 @@ export const ja: TranslationResources = {
         queueMessage: "メッセージをキューに追加",
         muteUnmuteVoiceMode: "音声モードのミュートを切り替え",
         switchProject: "プロジェクトを切り替え",
+        chooseWorkspaceIsolation: "ワークスペース環境を選択",
+        chooseBaseBranch: "開始ブランチを選択",
       },
       helpNotes: {
         showKeyboardShortcuts:

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1942,6 +1942,8 @@ export const ko: TranslationResources = {
         queueMessage: "메시지 대기열에 추가",
         muteUnmuteVoiceMode: "음성 모드 음소거/해제",
         switchProject: "프로젝트 전환",
+        chooseWorkspaceIsolation: "워크스페이스 환경 선택",
+        chooseBaseBranch: "시작 브랜치 선택",
       },
       helpNotes: {
         showKeyboardShortcuts: "포커스가 텍스트 필드나 터미널에 있지 않을 때 사용할 수 있습니다.",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1962,6 +1962,8 @@ export const ptBR: TranslationResources = {
         queueMessage: "Enfileirar mensagem",
         muteUnmuteVoiceMode: "Silenciar/ativar modo de voz",
         switchProject: "Trocar projeto",
+        chooseWorkspaceIsolation: "Escolher ambiente do workspace",
+        chooseBaseBranch: "Escolher branch inicial",
       },
       helpNotes: {
         showKeyboardShortcuts:

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1969,6 +1969,8 @@ export const ru: TranslationResources = {
         queueMessage: "Сообщение в очереди",
         muteUnmuteVoiceMode: "Отключить голосовой режим /unmute",
         switchProject: "Сменить проект",
+        chooseWorkspaceIsolation: "Выбрать среду рабочего пространства",
+        chooseBaseBranch: "Выбрать начальную ветку",
       },
       helpNotes: {
         showKeyboardShortcuts: "Доступно, когда фокус находится не в текстовом поле или терминале.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1909,6 +1909,8 @@ export const zhCN: TranslationResources = {
         queueMessage: "消息排队",
         muteUnmuteVoiceMode: "静音/取消静音语音模式",
         switchProject: "切换项目",
+        chooseWorkspaceIsolation: "选择工作区环境",
+        chooseBaseBranch: "选择起始分支",
       },
       helpNotes: {
         showKeyboardShortcuts: "焦点不在文本输入框或终端内时可用。",

--- a/packages/app/src/keyboard/actions.ts
+++ b/packages/app/src/keyboard/actions.ts
@@ -45,6 +45,8 @@ export type KeyboardActionId =
   | "workspace.terminal.new"
   | "workspace.new"
   | "workspace.project.pick"
+  | "workspace.isolation.pick"
+  | "workspace.base-ref.pick"
   | "worktree.new"
   | "workspace.archive"
   | "workspace.pin"

--- a/packages/app/src/keyboard/keyboard-action-dispatcher.ts
+++ b/packages/app/src/keyboard/keyboard-action-dispatcher.ts
@@ -31,6 +31,8 @@ export type KeyboardActionId =
   | "sidebar.toggle.right"
   | "workspace.new"
   | "workspace.project.pick"
+  | "workspace.isolation.pick"
+  | "workspace.base-ref.pick"
   | "worktree.new"
   | "workspace.archive"
   | "workspace.pin";
@@ -66,6 +68,8 @@ export type KeyboardActionDefinition =
   | { id: "sidebar.toggle.right"; scope: KeyboardActionScope }
   | { id: "workspace.new"; scope: KeyboardActionScope }
   | { id: "workspace.project.pick"; scope: KeyboardActionScope }
+  | { id: "workspace.isolation.pick"; scope: KeyboardActionScope }
+  | { id: "workspace.base-ref.pick"; scope: KeyboardActionScope }
   | { id: "worktree.new"; scope: KeyboardActionScope }
   | { id: "workspace.archive"; scope: KeyboardActionScope }
   | { id: "workspace.pin"; scope: KeyboardActionScope };

--- a/packages/app/src/keyboard/keyboard-shortcuts.test.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.test.ts
@@ -294,16 +294,16 @@ describe("keyboard-shortcuts", () => {
       action: "sidebar.toggle.left",
     },
     {
-      name: "routes Mod+. to toggle both sidebars on non-mac",
+      name: "routes Mod+. to the project picker first on non-mac",
       event: { key: ".", code: "Period", ctrlKey: true },
       context: { isMac: false },
-      action: "sidebar.toggle.both",
+      action: "workspace.project.pick",
     },
     {
-      name: "matches Dvorak logical Cmd+. to toggle both sidebars on macOS",
+      name: "matches Dvorak logical Cmd+. on macOS",
       event: { key: ".", code: "KeyE", metaKey: true },
       context: { isMac: true },
-      action: "sidebar.toggle.both",
+      action: "workspace.project.pick",
     },
     {
       name: "routes Mod+D to message-input action outside terminal",
@@ -602,6 +602,18 @@ describe("keyboard-shortcuts", () => {
 
     expect(onChordReset).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
+  });
+});
+
+describe("Mod+. fallback chain", () => {
+  it("offers the sidebar toggle as a fallback behind the project picker", () => {
+    const result = resolveShortcut({
+      event: { key: ".", code: "Period", metaKey: true },
+      context: { isMac: true },
+    });
+
+    expect(result.match?.action).toBe("workspace.project.pick");
+    expect(result.fallbackMatches?.map((m) => m.action)).toContain("sidebar.toggle.both");
   });
 });
 

--- a/packages/app/src/keyboard/keyboard-shortcuts.ts
+++ b/packages/app/src/keyboard/keyboard-shortcuts.ts
@@ -105,6 +105,14 @@ export interface ParsedShortcutBinding extends ShortcutBinding {
   parsedChord: KeyCombo[];
 }
 
+export interface ShortcutResolution {
+  match: KeyboardShortcutMatch | null;
+  /** Lower-priority bindings for the same combo, tried when `match` goes unhandled. */
+  fallbackMatches?: KeyboardShortcutMatch[];
+  nextChordState: ChordState;
+  preventDefault: boolean;
+}
+
 export interface ChordState {
   candidateIndices: number[];
   step: number;
@@ -133,6 +141,8 @@ const SHORTCUT_HELP_LABEL_KEYS: Record<string, string> = {
   "new-agent": "settings.shortcuts.help.openProject",
   "new-workspace": "settings.shortcuts.help.newWorkspace",
   "switch-project": "settings.shortcuts.help.switchProject",
+  "choose-workspace-isolation": "settings.shortcuts.help.chooseWorkspaceIsolation",
+  "choose-base-branch": "settings.shortcuts.help.chooseBaseBranch",
   "archive-workspace": "settings.shortcuts.help.archiveWorkspace",
   "workspace-tab-new": "settings.shortcuts.help.newTab",
   "workspace-tab-close-current": "settings.shortcuts.help.closeCurrentTab",
@@ -256,6 +266,71 @@ const SHORTCUT_BINDINGS: readonly ShortcutBinding[] = [
       section: "projects",
       label: "Switch project",
       keys: ["mod", "P"],
+    },
+  },
+
+  // --- New workspace pickers (Cursor-style Mod+. family) ---
+  // These must stay ahead of `sidebar.toggle.both` (Mod+.): both bindings match
+  // the same combo, and the resolver falls through to the sidebar toggle when
+  // the New workspace screen isn't mounted to claim the picker action.
+  {
+    id: "workspace-project-pick-cmd-period-mac",
+    action: "workspace.project.pick",
+    combo: "Cmd+.",
+    when: { mac: true, commandCenter: false },
+  },
+  {
+    id: "workspace-project-pick-ctrl-period-non-mac",
+    action: "workspace.project.pick",
+    combo: "Ctrl+.",
+    when: { mac: false, commandCenter: false, terminal: false },
+  },
+  {
+    id: "workspace-isolation-pick-cmd-shift-period-mac",
+    action: "workspace.isolation.pick",
+    combo: "Cmd+Shift+.",
+    when: { mac: true, commandCenter: false },
+    help: {
+      id: "choose-workspace-isolation",
+      section: "projects",
+      label: "Choose workspace environment",
+      keys: ["mod", "shift", "."],
+    },
+  },
+  {
+    id: "workspace-isolation-pick-ctrl-shift-period-non-mac",
+    action: "workspace.isolation.pick",
+    combo: "Ctrl+Shift+.",
+    when: { mac: false, commandCenter: false, terminal: false },
+    help: {
+      id: "choose-workspace-isolation",
+      section: "projects",
+      label: "Choose workspace environment",
+      keys: ["mod", "shift", "."],
+    },
+  },
+  {
+    id: "workspace-base-ref-pick-cmd-alt-period-mac",
+    action: "workspace.base-ref.pick",
+    combo: "Cmd+Alt+.",
+    when: { mac: true, commandCenter: false },
+    help: {
+      id: "choose-base-branch",
+      section: "projects",
+      label: "Choose starting branch",
+      keys: ["mod", "alt", "."],
+    },
+  },
+  {
+    id: "workspace-base-ref-pick-ctrl-alt-period-non-mac",
+    action: "workspace.base-ref.pick",
+    combo: "Ctrl+Alt+.",
+    when: { mac: false, commandCenter: false, terminal: false },
+    help: {
+      id: "choose-base-branch",
+      section: "projects",
+      label: "Choose starting branch",
+      keys: ["mod", "alt", "."],
     },
   },
 
@@ -1244,14 +1319,10 @@ function resolveInitialChordStep(input: {
   chordState: ChordState;
   onChordReset: () => void;
   bindings: readonly ParsedShortcutBinding[];
-}): {
-  match: KeyboardShortcutMatch | null;
-  nextChordState: ChordState;
-  preventDefault: boolean;
-} {
+}): ShortcutResolution {
   const { event, context, chordState, onChordReset, bindings } = input;
   const advancingCandidateIndices: number[] = [];
-  let singleComboMatch: KeyboardShortcutMatch | null = null;
+  const singleComboMatches: KeyboardShortcutMatch[] = [];
 
   for (const [index, binding] of bindings.entries()) {
     const firstCombo = binding.parsedChord[0];
@@ -1268,9 +1339,7 @@ function resolveInitialChordStep(input: {
       advancingCandidateIndices.push(index);
       continue;
     }
-    if (!singleComboMatch) {
-      singleComboMatch = buildMatchFromBinding(binding, event);
-    }
+    singleComboMatches.push(buildMatchFromBinding(binding, event));
   }
 
   if (advancingCandidateIndices.length > 0) {
@@ -1286,7 +1355,8 @@ function resolveInitialChordStep(input: {
   }
 
   return {
-    match: singleComboMatch,
+    match: singleComboMatches[0] ?? null,
+    fallbackMatches: singleComboMatches.slice(1),
     nextChordState: resetChordState(chordState),
     preventDefault: false,
   };
@@ -1298,11 +1368,7 @@ function resolveAdvancingChordStep(input: {
   chordState: ChordState;
   onChordReset: () => void;
   bindings: readonly ParsedShortcutBinding[];
-}): {
-  match: KeyboardShortcutMatch | null;
-  nextChordState: ChordState;
-  preventDefault: boolean;
-} {
+}): ShortcutResolution {
   const { event, context, chordState, onChordReset, bindings } = input;
   const matchingCandidateIndices: number[] = [];
   let completedMatch: KeyboardShortcutMatch | null = null;
@@ -1363,11 +1429,7 @@ export function resolveKeyboardShortcut(input: {
   chordState: ChordState;
   onChordReset: () => void;
   bindings?: readonly ParsedShortcutBinding[];
-}): {
-  match: KeyboardShortcutMatch | null;
-  nextChordState: ChordState;
-  preventDefault: boolean;
-} {
+}): ShortcutResolution {
   const { event, context, chordState, onChordReset, bindings = DEFAULT_BINDINGS } = input;
   if (chordState.step === 0) {
     return resolveInitialChordStep({ event, context, chordState, onChordReset, bindings });

--- a/packages/app/src/keyboard/route-shortcut.ts
+++ b/packages/app/src/keyboard/route-shortcut.ts
@@ -43,6 +43,8 @@ const PASSTHROUGH_DISPATCH: Record<string, KeyboardActionDefinition> = {
   "workspace.tab.new": { id: "workspace.tab.new", scope: "workspace" },
   "workspace.new": { id: "workspace.new", scope: "sidebar" },
   "workspace.project.pick": { id: "workspace.project.pick", scope: "workspace" },
+  "workspace.isolation.pick": { id: "workspace.isolation.pick", scope: "workspace" },
+  "workspace.base-ref.pick": { id: "workspace.base-ref.pick", scope: "workspace" },
   "workspace.archive": { id: "workspace.archive", scope: "sidebar" },
   "workspace.pin": { id: "workspace.pin", scope: "sidebar" },
   "worktree.new": { id: "worktree.new", scope: "sidebar" },

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -204,6 +204,34 @@ function RefPickerBadgeContent({
   );
 }
 
+// Trigger tooltip for the three New workspace pickers: what it picks, plus the
+// shortcut that opens the same picker. `shortcutHelpId` is a binding help id,
+// so a user's rebind shows through instead of a hardcoded chord.
+function PickerTooltip({
+  label,
+  shortcutHelpId,
+  children,
+}: {
+  label: string;
+  shortcutHelpId: string;
+  children: React.ReactElement;
+}) {
+  const keys = useShortcutKeys(shortcutHelpId);
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild triggerRefProp="ref">
+        {children}
+      </TooltipTrigger>
+      <TooltipContent side="top" align="center" offset={8}>
+        <View style={styles.tooltipRow}>
+          <Text style={styles.tooltipText}>{label}</Text>
+          {keys ? <Shortcut chord={keys} /> : null}
+        </View>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function RefPickerTrigger({
   pickerAnchorRef,
   onPress,
@@ -228,29 +256,24 @@ function RefPickerTrigger({
   iconSize: number;
 }) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild triggerRefProp="ref">
-        <ComboboxTrigger
-          ref={pickerAnchorRef}
-          testID="new-workspace-ref-picker-trigger"
-          onPress={onPress}
-          disabled={disabled}
-          style={badgePressableStyle}
-          accessibilityRole="button"
-          accessibilityLabel={accessibilityLabel}
-        >
-          <RefPickerBadgeContent
-            selectedItem={selectedItem}
-            triggerLabel={triggerLabel}
-            iconColor={iconColor}
-            iconSize={iconSize}
-          />
-        </ComboboxTrigger>
-      </TooltipTrigger>
-      <TooltipContent side="top" align="center" offset={8}>
-        <Text style={styles.tooltipText}>{tooltipLabel}</Text>
-      </TooltipContent>
-    </Tooltip>
+    <PickerTooltip label={tooltipLabel} shortcutHelpId="choose-base-branch">
+      <ComboboxTrigger
+        ref={pickerAnchorRef}
+        testID="new-workspace-ref-picker-trigger"
+        onPress={onPress}
+        disabled={disabled}
+        style={badgePressableStyle}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+      >
+        <RefPickerBadgeContent
+          selectedItem={selectedItem}
+          triggerLabel={triggerLabel}
+          iconColor={iconColor}
+          iconSize={iconSize}
+        />
+      </ComboboxTrigger>
+    </PickerTooltip>
   );
 }
 
@@ -278,39 +301,34 @@ function ProjectPickerTrigger({
   const placeholderLabel = projectIconPlaceholderLabelFromDisplayName(label);
   const placeholderInitial = placeholderLabel.charAt(0).toUpperCase() || "?";
   return (
-    <Tooltip>
-      <TooltipTrigger asChild triggerRefProp="ref">
-        <ComboboxTrigger
-          ref={pickerAnchorRef}
-          testID="new-workspace-project-picker-trigger"
-          onPress={onPress}
-          disabled={disabled}
-          style={badgePressableStyle}
-          accessibilityRole="button"
-          accessibilityLabel="Workspace project"
-        >
-          <View style={styles.badgeIconBox}>
-            {projectViewKey ? (
-              <ProjectIconView
-                iconDataUri={iconDataUri}
-                initial={placeholderInitial}
-                projectViewKey={projectViewKey}
-                size={ICON_SIZE.md}
-                textStyle={styles.projectIconFallbackText}
-              />
-            ) : (
-              <Folder size={iconSize} color={iconColor} />
-            )}
-          </View>
-          <Text style={styles.badgeText} numberOfLines={1}>
-            {label}
-          </Text>
-        </ComboboxTrigger>
-      </TooltipTrigger>
-      <TooltipContent side="top" align="center" offset={8}>
-        <Text style={styles.tooltipText}>Choose project</Text>
-      </TooltipContent>
-    </Tooltip>
+    <PickerTooltip label="Choose project" shortcutHelpId="switch-project">
+      <ComboboxTrigger
+        ref={pickerAnchorRef}
+        testID="new-workspace-project-picker-trigger"
+        onPress={onPress}
+        disabled={disabled}
+        style={badgePressableStyle}
+        accessibilityRole="button"
+        accessibilityLabel="Workspace project"
+      >
+        <View style={styles.badgeIconBox}>
+          {projectViewKey ? (
+            <ProjectIconView
+              iconDataUri={iconDataUri}
+              initial={placeholderInitial}
+              projectViewKey={projectViewKey}
+              size={ICON_SIZE.md}
+              textStyle={styles.projectIconFallbackText}
+            />
+          ) : (
+            <Folder size={iconSize} color={iconColor} />
+          )}
+        </View>
+        <Text style={styles.badgeText} numberOfLines={1}>
+          {label}
+        </Text>
+      </ComboboxTrigger>
+    </PickerTooltip>
   );
 }
 
@@ -592,6 +610,7 @@ function IsolationPickerTrigger({
   badgePressableStyle,
   isolation,
   label,
+  tooltipLabel,
   iconColor,
   iconSize,
 }: {
@@ -601,30 +620,33 @@ function IsolationPickerTrigger({
   badgePressableStyle: React.ComponentProps<typeof Pressable>["style"];
   isolation: "local" | "worktree";
   label: string;
+  tooltipLabel: string;
   iconColor: string;
   iconSize: number;
 }) {
   return (
-    <ComboboxTrigger
-      ref={pickerAnchorRef}
-      testID="workspace-create-isolation-trigger"
-      onPress={onPress}
-      disabled={disabled}
-      style={badgePressableStyle}
-      accessibilityRole="button"
-      accessibilityLabel="Workspace isolation"
-    >
-      <View style={styles.badgeIconBox}>
-        {isolation === "worktree" ? (
-          <GitBranch size={iconSize} color={iconColor} />
-        ) : (
-          <Folder size={iconSize} color={iconColor} />
-        )}
-      </View>
-      <Text style={styles.badgeText} numberOfLines={1}>
-        {label}
-      </Text>
-    </ComboboxTrigger>
+    <PickerTooltip label={tooltipLabel} shortcutHelpId="choose-workspace-isolation">
+      <ComboboxTrigger
+        ref={pickerAnchorRef}
+        testID="workspace-create-isolation-trigger"
+        onPress={onPress}
+        disabled={disabled}
+        style={badgePressableStyle}
+        accessibilityRole="button"
+        accessibilityLabel="Workspace isolation"
+      >
+        <View style={styles.badgeIconBox}>
+          {isolation === "worktree" ? (
+            <GitBranch size={iconSize} color={iconColor} />
+          ) : (
+            <Folder size={iconSize} color={iconColor} />
+          )}
+        </View>
+        <Text style={styles.badgeText} numberOfLines={1}>
+          {label}
+        </Text>
+      </ComboboxTrigger>
+    </PickerTooltip>
   );
 }
 
@@ -1380,6 +1402,9 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
         badgePressableStyle={badgePressableStyle}
         isolation={isolation.effectiveIsolation}
         label={isolationTriggerLabel}
+        // Same phrase as the shortcut help row, so the tooltip and the settings
+        // list name this picker identically.
+        tooltipLabel={t("settings.shortcuts.help.chooseWorkspaceIsolation")}
         iconColor={theme.colors.foregroundMuted}
         iconSize={theme.iconSize.sm}
       />
@@ -1772,6 +1797,32 @@ export function NewWorkspaceScreen({
     if (!canCreateWorktree) return [localOption];
     return [localOption, { id: "worktree", label: isolationLabel(t, "worktree") }];
   }, [canCreateWorktree, t]);
+
+  // Mod+Shift+. / Mod+Alt+. mirror Mod+. on the project picker: the two other
+  // New workspace selects, opened from the keyboard. Each is gated on the
+  // picker actually being reachable, so the shortcut stays unhandled (and the
+  // key falls through) when the row is hidden.
+  useKeyboardActionHandler({
+    handlerId: "new-workspace-isolation-pick",
+    actions: ["workspace.isolation.pick"],
+    enabled: canCreateWorktree,
+    priority: 0,
+    handle: () => {
+      openIsolationPicker();
+      return true;
+    },
+  });
+
+  useKeyboardActionHandler({
+    handlerId: "new-workspace-base-ref-pick",
+    actions: ["workspace.base-ref.pick"],
+    enabled: showRefPicker,
+    priority: 0,
+    handle: () => {
+      openPicker();
+      return true;
+    },
+  });
 
   const handleSelectIsolationOption = useCallback(
     (id: string) => {
@@ -2232,6 +2283,11 @@ const styles = StyleSheet.create((theme) => ({
     fontSize: theme.fontSize.sm,
     color: theme.colors.foregroundMuted,
     flexShrink: 1,
+  },
+  tooltipRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
   },
   tooltipText: {
     fontSize: theme.fontSize.sm,


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The New workspace screen asks three questions before you can start — project, isolation, starting ref — and only the first one was reachable from the keyboard (Mod+P). Everything else meant going back to the mouse in the middle of a keyboard-driven flow.

Cursor users already have this muscle memory: `Cmd+.` picks the project, `Cmd+Shift+.` the environment, `Cmd+Alt+.` the branch. This PR gives Paseo the same family, so setting up a workspace never leaves the keyboard.

### Goals

- `Mod+.` opens the project picker, `Mod+Shift+.` the isolation picker, `Mod+Alt+.` the starting-ref picker, on mac and non-mac.
- `Mod+.` keeps toggling both sidebars everywhere the New workspace screen isn't mounted.
- Each shortcut is gated on its picker actually being reachable — no isolation picker on a non-git project, no ref picker under local isolation.
- The two new bindings show up in Settings › Keyboard shortcuts and are rebindable.
- Each picker trigger's tooltip shows the shortcut that opens it, resolved through the binding help id so a rebind shows through.

### Non-goals

- **Mod+P stays the documented project-pick binding.** Shortcut overrides are keyed by binding id, so moving the `switch-project` help entry onto the new `Mod+.` binding would silently drop an existing user's customized chord. `Mod+.` is an undocumented alias until that's worth a migration — which is why the project tooltip badge reads `⌘P` while both keys work.
- No new chord for the host picker; it only appears with more than one host.

### QA

Ran the dev daemon + Expo web build in a worktree and drove the real screen.

**Real keystrokes (macOS, browser):**
- `⌘.` on New workspace → project picker opens with search focused. ✅
- `⌘⇧.` → intercepted by a Chrome extension command before the page sees the keydown. Not fixable from app code (extension commands outrank the page); works in the desktop app, and the binding is rebindable in Settings. ⚠️
- `⌘⌥.` → not yet exercised with a physical key.

**Synthetic `KeyboardEvent` dispatched into the running app** (same handler path, minus the OS layer) — all four passed:
- `⌘.` → project picker
- `⌘⇧.` → isolation picker (Local / New worktree)
- switch to New worktree, `⌘⌥.` → branch and PR picker
- navigate to a workspace screen, `⌘.` → both sidebars toggle (fallback intact)

Tooltips, hovered on the real screen:

| Trigger | Tooltip |
| --- | --- |
| Project | `Choose project  ⌘P` |
| Isolation | `워크스페이스 환경 선택  Shift+⌘+.` |
| Starting ref | `시작 위치를 선택하세요  ⌥⌘.` |

**Unit:** `packages/app/src/keyboard` + `packages/app/src/screens/new-workspace*` — 160 passed, including a new case asserting `sidebar.toggle.both` sits in `fallbackMatches` behind `workspace.project.pick` for `⌘.`.

**E2E:** added `packages/app/e2e/browser/new-workspace-picker-shortcuts.spec.ts`, which presses all three chords through CDP (real key events). **It has not run locally** — the Playwright Chromium download stalled in this environment. Relying on CI for this one; please flag if it goes red.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)
