### PR TITLE
fix(pi): adapt message_update to delta-only events from Pi >=0.84

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -500,18 +500,15 @@ describe("PiRpcAgentSession", () => {
     });
     fakeSession.emit({
       type: "message_update",
-      message: { role: "assistant", content: [], responseId: "response-1" },
-      assistantMessageEvent: { type: "text_delta", delta: "hel" },
+      assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: "hel" },
     });
     fakeSession.emit({
       type: "message_update",
-      message: { role: "assistant", content: [], responseId: "response-1" },
-      assistantMessageEvent: { type: "text_delta", delta: "lo" },
+      assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: "lo" },
     });
     fakeSession.emit({
       type: "message_update",
-      message: { role: "assistant", content: [] },
-      assistantMessageEvent: { type: "thinking_delta", delta: "thinking" },
+      assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "thinking" },
     });
     fakeSession.emit({
       type: "tool_execution_start",
@@ -615,13 +612,11 @@ describe("PiRpcAgentSession", () => {
     await session.startTurn("hello");
     fakeSession.emit({
       type: "message_update",
-      message: { role: "assistant", content: [] },
-      assistantMessageEvent: { type: "text_delta", delta: "hel" },
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "hel" },
     });
     fakeSession.emit({
       type: "message_update",
-      message: { role: "assistant", content: [] },
-      assistantMessageEvent: { type: "text_delta", delta: "lo" },
+      assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "lo" },
     });
 
     const [firstChunk, secondChunk] = events.timelineItems();
@@ -638,7 +633,7 @@ describe("PiRpcAgentSession", () => {
     });
   });
 
-  test("uses a response id that first appears on the assistant update", async () => {
+  test("uses a legacy response id carried on the assistant update", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
 
@@ -650,7 +645,7 @@ describe("PiRpcAgentSession", () => {
     fakeSession.emit({
       type: "message_update",
       message: { role: "assistant", content: [], responseId: "late-response-id" },
-      assistantMessageEvent: { type: "text_delta", delta: "hello" },
+      assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: "hello" },
     });
 
     expect(events.timelineItems()).toEqual([

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -550,6 +550,81 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("streams Pi 0.84+ delta-only message updates without a cumulative message", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "response-1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "thinking_start", contentIndex: 0 },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "thinking_delta", contentIndex: 0, delta: "think" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "thinking_end", contentIndex: 0, content: "think" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_start", contentIndex: 1 },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", contentIndex: 1, delta: "hello" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_end", contentIndex: 1, content: "hello" },
+    });
+    fakeSession.finishTurn();
+
+    await events.nextTurnCompletion();
+
+    expect(events.timelineItems()).toEqual([
+      { type: "reasoning", text: "think" },
+      { type: "assistant_message", text: "hello", messageId: "response-1" },
+    ]);
+  });
+
+  test("ignores Pi 0.84+ toolcall deltas and content markers without emitting timeline items", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("hello");
+    fakeSession.emit({
+      type: "message_start",
+      message: { role: "assistant", content: [], responseId: "response-1" },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "toolcall_start", contentIndex: 0 },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "toolcall_delta", contentIndex: 0, delta: '{"command":' },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "toolcall_end", contentIndex: 0, toolCall: { id: "tool-1" } },
+    });
+    fakeSession.emit({
+      type: "message_update",
+      assistantMessageEvent: { type: "done" },
+    });
+    fakeSession.finishTurn();
+
+    await events.nextTurnCompletion();
+
+    expect(events.timelineItems()).toEqual([]);
+  });
+
   test("streams Pi task calls as sub-agent cards with lifecycle status", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2191,32 +2191,38 @@ export class PiRpcAgentSession implements AgentSession {
     event: Extract<PiAgentSessionEvent, { type: "message_update" }>,
     turnId: string | undefined,
   ): void {
-    if (event.message.role !== "assistant") {
+    // COMPAT(piMessageUpdateDeltas): Pi >=0.84 emits only `assistantMessageEvent`
+    // deltas — the cumulative `message` field was removed (pi #7290).
+    // `message_start` still carries the full assistant message, so only the
+    // legacy binary path needs the optional `message` field.
+    const legacyMessage = event.message;
+    if (legacyMessage && legacyMessage.role !== "assistant") {
       return;
     }
-    if (event.assistantMessageEvent.type === "text_delta") {
+    const { assistantMessageEvent } = event;
+    if (assistantMessageEvent.type === "text_delta") {
       // Pi-compatible runtimes may emit updates without a preceding message_start.
-      this.activeAssistantMessageId ??= event.message.responseId || randomUUID();
+      this.activeAssistantMessageId ??= legacyMessage?.responseId || randomUUID();
       this.emit({
         type: "timeline",
         provider: this.provider,
         turnId,
         item: {
           type: "assistant_message",
-          text: event.assistantMessageEvent.delta ?? "",
+          text: assistantMessageEvent.delta ?? "",
           messageId: this.activeAssistantMessageId,
         },
       });
       return;
     }
-    if (event.assistantMessageEvent.type === "thinking_delta") {
+    if (assistantMessageEvent.type === "thinking_delta") {
       this.emit({
         type: "timeline",
         provider: this.provider,
         turnId,
         item: {
           type: "reasoning",
-          text: event.assistantMessageEvent.delta ?? "",
+          text: assistantMessageEvent.delta ?? "",
         },
       });
     }

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -149,9 +149,17 @@ export interface PiRpcResponse {
 }
 
 export type PiAssistantMessageEvent =
-  | { type: "text_delta"; delta?: string }
-  | { type: "thinking_delta"; delta?: string }
-  | { type: "start" | "text_start" | "text_end" | "thinking_start" | "thinking_end" | "done" };
+  | { type: "start"; contentIndex?: number }
+  | { type: "text_start"; contentIndex: number }
+  | { type: "text_delta"; contentIndex: number; delta?: string }
+  | { type: "text_end"; contentIndex: number; content?: string }
+  | { type: "thinking_start"; contentIndex: number }
+  | { type: "thinking_delta"; contentIndex: number; delta?: string }
+  | { type: "thinking_end"; contentIndex: number; content?: string }
+  | { type: "toolcall_start"; contentIndex: number }
+  | { type: "toolcall_delta"; contentIndex: number; delta?: string }
+  | { type: "toolcall_end"; contentIndex: number; toolCall?: unknown }
+  | { type: "done"; contentIndex?: number };
 
 export type PiAgentSessionEvent =
   | { type: "agent_start" }
@@ -160,7 +168,11 @@ export type PiAgentSessionEvent =
   | { type: "message_end"; message: PiAgentMessage }
   | {
       type: "message_update";
-      message: PiAgentMessage;
+      // COMPAT(piMessageUpdateDeltas): Pi >=0.84 emits only `assistantMessageEvent`
+      // deltas — the cumulative `message` field was removed (pi #7290). Older
+      // binaries still include it. Remove the optional field after the supported
+      // pi floor includes 0.84.
+      message?: PiAgentMessage;
       assistantMessageEvent: PiAssistantMessageEvent;
     }
   | {


### PR DESCRIPTION
## Problem

Pi 0.84.0 removed the cumulative `message` field from RPC `message_update` events ([pi #7290](https://github.com/earendil-works/pi/issues/7290)) — they now carry only `assistantMessageEvent` deltas with a `contentIndex`. Paseo's `handleMessageUpdate` read `event.message.role` on every streamed delta, so the first `message_update` threw `TypeError: Cannot read properties of undefined (reading 'role')` inside the JSONL subscriber loop, which has no error boundary. The daemon died mid-turn (`Uncaught exception — daemon crashing` in `daemon.log`), making Pi agents unusable from the desktop app after upgrading pi.

## Fix

- `agent.ts`: `handleMessageUpdate` consumes only `assistantMessageEvent` deltas. The legacy `message` field is used as an optional fallback when the binary predates 0.84 (role filter + `responseId`), tagged `// COMPAT(piMessageUpdateDeltas)`.
- `rpc-types.ts`: `PiAssistantMessageEvent` matches the 0.84 protocol (`contentIndex` plus `text_*` / `thinking_*` / `toolcall_*` deltas); `message_update.message` is now optional.
- `agent.test.ts`: stream tests use the 0.84 delta-only shape; added a regression test that replays a real 0.84 event sequence (thinking + text blocks across `contentIndex`) and a test asserting toolcall deltas/content markers produce no timeline items.

## QA

**Regression test fails on the pre-fix code with the exact production error** (`event.message` is `undefined`):

```
❯ packages/server/src/server/agent/providers/pi/agent.test.ts (56 tests | 1 failed)
    × streams assistant text, reasoning, and tool calls from Pi events
TypeError: Cannot read properties of undefined (reading 'role')
```

**Unit tests** (pi provider, 91 tests):

```
 Test Files  5 passed (5)
      Tests  91 passed (91)
```

**Live probe against pi 0.84.1** (`pi --mode rpc`, raw JSONL): `message_update` events contain only `assistantMessageEvent`; `message_start` / `message_end` / `agent_end` still carry the full message; `tool_execution_start` still fires for bash tool calls.

```
EVENT: {"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"The"}}
  -> has message field: false | keys: type,assistantMessageEvent
```

**Static checks**: `oxlint` 0 warnings/errors, `oxfmt` clean, `tsgo --noEmit` passes.

## Platform coverage

Server-only change (Pi provider event handling). No UI/platform surface touched. Tested on daemon headless path; not tested on iOS/Android/Web (unaffected — server code).
