### PR TITLE
fix(server): stop a rejected prompt from stranding the agent at error

### DIFF
--- a/packages/server/src/server/agent/agent-manager-busy-rejection.test.ts
+++ b/packages/server/src/server/agent/agent-manager-busy-rejection.test.ts
@@ -1,0 +1,219 @@
+import { expect, test, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { AgentManager } from "./agent-manager.js";
+import { AgentStorage } from "./agent-storage.js";
+import type {
+  AgentClient,
+  AgentPersistenceHandle,
+  AgentSession,
+  AgentSessionConfig,
+  AgentStreamEvent,
+} from "./agent-sdk-types.js";
+
+const logger = createTestLogger();
+
+const CAPABILITIES = {
+  supportsStreaming: false,
+  supportsSessionPersistence: false,
+  supportsSessionListing: true,
+  supportsDynamicModes: false,
+  supportsMcpServers: false,
+  supportsReasoningStream: false,
+  supportsToolInvocations: false,
+} as const;
+
+/**
+ * A session that is already busy with an autonomous provider turn Paseo never started,
+ * and rejects any foreground prompt the way an ACP provider does: the turn is announced,
+ * then the provider refuses it because its own turn is still in flight.
+ */
+class BusyRejectingSession implements AgentSession {
+  readonly provider = "codex" as const;
+  readonly capabilities = CAPABILITIES;
+  readonly id = randomUUID();
+  private subscribers = new Set<(event: AgentStreamEvent) => void>();
+  private turnCounter = 0;
+
+  constructor(private readonly config: AgentSessionConfig) {}
+
+  async run() {
+    return { sessionId: this.id, finalText: "", timeline: [] };
+  }
+
+  /** Mirrors acp-agent.startTurn: announce the turn, then reject it asynchronously. */
+  async startTurn(): Promise<{ turnId: string }> {
+    const turnId = `rejected-turn-${++this.turnCounter}`;
+    setTimeout(() => {
+      this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+      this.pushEvent({
+        type: "turn_failed",
+        provider: this.provider,
+        turnId,
+        error: "Invalid request: Cannot launch a new turn while another turn (ID 8) is active",
+        rejected: true,
+      });
+    }, 0);
+    return { turnId };
+  }
+
+  subscribe(callback: (event: AgentStreamEvent) => void): () => void {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  pushEvent(event: AgentStreamEvent): void {
+    for (const cb of this.subscribers) {
+      cb(event);
+    }
+  }
+
+  async *streamHistory(): AsyncGenerator<AgentStreamEvent> {}
+
+  async getRuntimeInfo() {
+    return {
+      provider: this.provider,
+      sessionId: this.id,
+      model: this.config.model ?? null,
+      modeId: null,
+    };
+  }
+
+  async getAvailableModes() {
+    return [];
+  }
+  async getCurrentMode() {
+    return null;
+  }
+  async setMode(): Promise<void> {}
+  getPendingPermissions() {
+    return [];
+  }
+  async respondToPermission(): Promise<void> {}
+  describePersistence() {
+    return { provider: this.provider, sessionId: this.id };
+  }
+  async interrupt(): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+class BusyRejectingClient implements AgentClient {
+  readonly provider = "codex" as const;
+  readonly capabilities = CAPABILITIES;
+  session: BusyRejectingSession | null = null;
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async fetchCatalog() {
+    return { models: [], modes: [] };
+  }
+
+  async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+    this.session = new BusyRejectingSession(config);
+    return this.session;
+  }
+
+  async resumeSession(
+    _handle: AgentPersistenceHandle,
+    config?: Partial<AgentSessionConfig>,
+  ): Promise<AgentSession> {
+    this.session = new BusyRejectingSession({
+      ...config,
+      provider: this.provider,
+      cwd: config?.cwd ?? process.cwd(),
+    });
+    return this.session;
+  }
+}
+
+async function drain(stream: AsyncGenerator<AgentStreamEvent>): Promise<void> {
+  try {
+    for await (const _event of stream) {
+      // consume
+    }
+  } catch {
+    // streamAgent rethrows the rejection; the agent state is what we assert on.
+  }
+}
+
+/**
+ * Repro for #2889.
+ *
+ * An ACP provider can be mid-turn on a turn Paseo never started, so the daemon sees no
+ * `turn_started` for it and no terminal when it ends. A prompt sent during that window is
+ * rejected by the provider with a busy error. The rejected turn is the only turn the daemon
+ * tracks, so its failure is the last word on agent health: the agent sits at `error` until
+ * some later prompt happens to succeed.
+ */
+test("a prompt the provider rejected as busy does not leave the agent stuck at error", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-busy-rejection-"));
+  const client = new BusyRejectingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000002889",
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  // The provider is busy with a turn the daemon never observed, so it rejects this prompt.
+  await drain(manager.streamAgent(snapshot.id, "status?"));
+
+  const afterRejection = manager.getAgent(snapshot.id);
+  // The rejection belongs in the timeline, not in agent health.
+  expect(afterRejection?.lifecycle).not.toBe("error");
+  expect(afterRejection?.lastError).toBeUndefined();
+  expect(manager.getTimeline(snapshot.id)).toContainEqual(
+    expect.objectContaining({
+      type: "assistant_message",
+      text: expect.stringContaining("Cannot launch a new turn"),
+    }),
+  );
+
+  await manager.closeAgent(snapshot.id);
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+test("a turn that ran and failed still reports agent health as error", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-real-failure-"));
+  const client = new BusyRejectingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000002890",
+  });
+
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+
+  // A turn the provider accepted and then failed is a genuine agent failure.
+  client.session!.pushEvent({ type: "turn_started", provider: "codex", turnId: "turn-live" });
+  client.session!.pushEvent({
+    type: "turn_failed",
+    provider: "codex",
+    turnId: "turn-live",
+    error: "provider crashed mid-turn",
+  });
+
+  await vi.waitFor(() => {
+    const failed = manager.getAgent(snapshot.id);
+    expect(failed?.lifecycle).toBe("error");
+    expect(failed?.lastError).toBe("provider crashed mid-turn");
+  });
+
+  await manager.closeAgent(snapshot.id);
+  rmSync(workdir, { recursive: true, force: true });
+});

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3800,10 +3800,15 @@ export class AgentManager {
       "handleStreamEvent: turn_failed",
     );
     if (terminalDisposition === "stale") return;
-    if (!isForegroundEvent && !agent.activeForegroundTurnId) {
-      agent.lifecycle = "error";
+    // A rejected turn never ran. It is reported in the timeline, but recording it as agent
+    // health strands the agent at `error`: the turn that is actually running settles under a
+    // different identity, so nothing that follows ever clears it.
+    if (!event.rejected) {
+      if (!isForegroundEvent && !agent.activeForegroundTurnId) {
+        agent.lifecycle = "error";
+      }
+      agent.lastError = event.error;
     }
-    agent.lastError = event.error;
     await this.appendSystemErrorTimelineMessage(
       agent,
       event.provider,

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -408,6 +408,15 @@ export type AgentStreamEvent =
       code?: string;
       diagnostic?: string;
       turnId?: string;
+      /**
+       * The provider refused to start this turn, so no turn ran. A rejection describes the
+       * request, not the agent: it is reported in the timeline but never recorded as agent
+       * health. Providers that reject a prompt while another turn is still in flight would
+       * otherwise strand the agent at `error`, because the turn that is actually running
+       * emits its terminal under a different identity — or, for turns the daemon never
+       * started, emits none at all.
+       */
+      rejected?: boolean;
     }
   | { type: "turn_canceled"; provider: AgentProvider; reason: string; turnId?: string }
   | {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1582,6 +1582,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           code: summary.code,
           diagnostic: this.collectDiagnostic(summary.diagnostic ?? summary.message),
           turnId,
+          // The prompt request itself failed, so this turn never ran.
+          rejected: true,
         });
       });
 


### PR DESCRIPTION
### Linked issue

Closes #2889

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

An ACP provider can be mid-turn on a turn the daemon never started — an autonomous/goal turn, or one whose foreground tracking was already torn down. The daemon sees no `turn_started` for it and no terminal when it ends.

Send a prompt during that window and the provider rejects it (`Cannot launch a new turn while another turn (ID 8) is active`). That rejected turn is the *only* turn the daemon is tracking, so `onStreamTurnFailed` records its error as `lastError` and `finalizeForegroundTurn` promotes that into `lifecycle: "error"`. Nothing that follows ever clears it: the turn actually running settles under a different identity, or emits no terminal at all. The agent card shows a red error state while the provider session is healthy and idle, and only recovers because the next `streamAgent` call clears `lastError` on its way in.

The distinction the code is missing is between *a turn that ran and failed* and *a turn the provider refused to start*. The first is agent health. The second is a fact about one request.

This marks the failure at the point where that is actually known — `connection.prompt()` rejecting means the turn never ran — and has the manager report a rejection in the timeline without writing it to agent health.

### Goals

- A prompt rejected by the provider does not leave the agent at `error` after the real turn finishes.
- The rejection is still visible to the user as a timeline row.
- A turn that started and then failed still sets `lastError` and `lifecycle: "error"`, unchanged.

### Non-goals

- Not retrying rejected prompts — that is #2398, and this is deliberately independent of it. #2398 removes the common way to *hit* this path; the status-lifecycle defect survives it, because any transient rejection can still trip it.
- Not fixing the underlying split-brain (provider-driven turns being invisible to `AgentManager` for ACP providers). That is the deeper issue and wants its own change.
- Only the ACP adapter sets `rejected` today. The synchronous `startTurn` throw path in `agent-manager` is provider-generic and mixes genuine failures ("session is closed") with rejections, so it is left alone rather than broadened on a guess.

### QA

Reproduced as an automated test against a real `AgentManager` with a session that mirrors `acp-agent.startTurn`: announce the turn, then reject it asynchronously.

**Before the fix** — `packages/server/src/server/agent/agent-manager-busy-rejection.test.ts`:

```
FAIL  > a prompt the provider rejected as busy does not leave the agent stuck at error
AssertionError: expected 'error' not to be 'error' // Object.is equality
 ❯ src/server/agent/agent-manager-busy-rejection.test.ts:174:41
    173|   // The rejection belongs in the timeline, not in agent health.
    174|   expect(afterRejection?.lifecycle).not.toBe("error");
```

**After the fix:**

```
$ npx vitest run src/server/agent/agent-manager-busy-rejection.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

The second test is the guard in the other direction: a turn that started and then failed still lands at `error` with its `lastError` intact, so the fix cannot silently swallow real failures.

**No regressions:**

```
$ npx vitest run src/server/agent/agent-manager.test.ts
 Test Files  1 passed (1)
      Tests  151 passed (151)

$ npx vitest run src/server/agent/providers/acp-agent.test.ts src/server/agent/providers/generic-acp-agent.test.ts
 Test Files  2 passed (2)
      Tests  97 passed (97)

$ npm run typecheck --workspace packages/server
exit 0

$ npm run lint -- <the four changed files>
Found 0 warnings and 0 errors.
```

**Platforms:** daemon-only change, no UI. Tested on Linux (Ubuntu 24.04, Node 20.20.2 — the repo pins 22.20.0; the affected suites are pure daemon logic and pass here). Not separately exercised on macOS or Windows.

**Not covered:** the original live repro was Kimi (`kimi-code` 0.29.0 via ACP) on Paseo 0.1.110, captured in #2889 with daemon and provider logs. This PR is verified against the automated repro above, not by re-running that live Kimi session.
