### PR TITLE
feat(app): recall sent messages with Up and Down in the composer

### DIFF
--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -49,6 +49,13 @@ import { useFileDrop } from "@/components/file-drop/use-file-drop";
 import type { DroppedItem } from "@/components/file-drop/types";
 import { MessageInput, type MessageInputRef, type AttachmentMenuItem } from "./input/input";
 import type { ImageAttachment, MessagePayload } from "./types";
+import type { StreamItem } from "@/types/stream";
+import {
+  DRAFT_HISTORY_INDEX,
+  collectUserMessageHistory,
+  shouldEnterMessageHistory,
+  stepMessageHistory,
+} from "./message-history";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import type { DraftCommandConfig } from "@/hooks/use-agent-commands-query";
 import { encodeImages } from "@/utils/encode-images";
@@ -892,6 +899,7 @@ interface ComposerProps {
 const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 
 const EMPTY_ARRAY: readonly QueuedMessage[] = [];
+const EMPTY_STREAM_ITEMS: readonly StreamItem[] = [];
 const StableMessageInput = memo(MessageInput);
 
 function resolveContextWindowValues(
@@ -1115,6 +1123,34 @@ export function Composer({
   const messagePlaceholder = resolveMessagePlaceholder(inputMode, isDesktopLayout, t, placeholder);
   const userInput = value;
   const setUserInput = onChangeText;
+
+  // Up/Down recall previously sent messages. Everything the handler needs is mirrored into
+  // refs so the callback stays stable, matching the autocomplete handler beside it.
+  const streamTail = useSessionStore((state) =>
+    state.sessions[serverId]?.agentStreamTail.get(agentId),
+  );
+  const messageHistory = useMemo(
+    () => collectUserMessageHistory(streamTail ?? EMPTY_STREAM_ITEMS),
+    [streamTail],
+  );
+  const messageHistoryRef = useRef(messageHistory);
+  messageHistoryRef.current = messageHistory;
+  const userInputRef = useRef(userInput);
+  userInputRef.current = userInput;
+  const setUserInputRef = useRef(setUserInput);
+  setUserInputRef.current = setUserInput;
+  const historyIndexRef = useRef(DRAFT_HISTORY_INDEX);
+  const heldDraftRef = useRef("");
+
+  // Editing recalled text leaves history, so the next Up starts from the newest message
+  // again rather than continuing from wherever the user stopped.
+  useEffect(() => {
+    const index = historyIndexRef.current;
+    if (index === DRAFT_HISTORY_INDEX) return;
+    if (userInput !== messageHistoryRef.current[index]) {
+      historyIndexRef.current = DRAFT_HISTORY_INDEX;
+    }
+  }, [userInput]);
   const workspaceAttachments = useWorkspaceAttachmentsForScopes(attachmentScopeKeys);
   const {
     selectedAttachments,
@@ -1728,10 +1764,29 @@ export function Composer({
 
   const hasSendableContent = userInput.trim().length > 0 || selectedAttachments.length > 0;
 
-  // Handle keyboard navigation for command autocomplete.
+  // Handle keyboard navigation for command autocomplete, then message recall. Autocomplete
+  // owns the arrow keys while its menu is open, so recall only sees what it declined.
   const handleCommandKeyPress = useCallback(
-    (event: { key: string; preventDefault: () => void }) =>
-      autocompleteOnKeyPressRef.current(event),
+    (event: { key: string; preventDefault: () => void }) => {
+      if (autocompleteOnKeyPressRef.current(event)) return true;
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return false;
+      const index = historyIndexRef.current;
+      if (!shouldEnterMessageHistory({ value: userInputRef.current, index })) return false;
+      if (index === DRAFT_HISTORY_INDEX) {
+        heldDraftRef.current = userInputRef.current;
+      }
+      const step = stepMessageHistory({
+        history: messageHistoryRef.current,
+        index,
+        direction: event.key === "ArrowUp" ? "older" : "newer",
+        draft: heldDraftRef.current,
+      });
+      if (!step) return false;
+      historyIndexRef.current = step.index;
+      setUserInputRef.current(step.text);
+      event.preventDefault();
+      return true;
+    },
     [],
   );
 

--- a/packages/app/src/composer/message-history.test.ts
+++ b/packages/app/src/composer/message-history.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import type { StreamItem } from "@/types/stream";
+import {
+  DRAFT_HISTORY_INDEX,
+  collectUserMessageHistory,
+  shouldEnterMessageHistory,
+  stepMessageHistory,
+} from "./message-history";
+
+function userMessage(id: string, text: string): StreamItem {
+  return { kind: "user_message", id, text, timestamp: new Date(0) };
+}
+
+function assistantMessage(id: string, text: string): StreamItem {
+  return { kind: "assistant_message", id, text, timestamp: new Date(0) };
+}
+
+describe("collectUserMessageHistory", () => {
+  it("returns the user's own messages newest first", () => {
+    const history = collectUserMessageHistory([
+      userMessage("1", "first"),
+      assistantMessage("2", "a reply"),
+      userMessage("3", "second"),
+      assistantMessage("4", "another reply"),
+      userMessage("5", "third"),
+    ]);
+    expect(history).toEqual(["third", "second", "first"]);
+  });
+
+  it("skips assistant output, blank messages, and adjacent repeats", () => {
+    const history = collectUserMessageHistory([
+      userMessage("1", "keep"),
+      userMessage("2", "   "),
+      userMessage("3", "repeat"),
+      userMessage("4", "repeat"),
+      assistantMessage("5", "noise"),
+    ]);
+    expect(history).toEqual(["repeat", "keep"]);
+  });
+
+  it("is empty for a conversation the user has not spoken in", () => {
+    expect(collectUserMessageHistory([assistantMessage("1", "hello")])).toEqual([]);
+    expect(collectUserMessageHistory([])).toEqual([]);
+  });
+});
+
+describe("stepMessageHistory", () => {
+  const history = ["newest", "middle", "oldest"];
+
+  it("walks backwards from the draft through every entry", () => {
+    expect(
+      stepMessageHistory({ history, index: DRAFT_HISTORY_INDEX, direction: "older", draft: "" }),
+    ).toEqual({ index: 0, text: "newest" });
+    expect(stepMessageHistory({ history, index: 0, direction: "older", draft: "" })).toEqual({
+      index: 1,
+      text: "middle",
+    });
+    expect(stepMessageHistory({ history, index: 1, direction: "older", draft: "" })).toEqual({
+      index: 2,
+      text: "oldest",
+    });
+  });
+
+  it("stops at the oldest entry instead of wrapping", () => {
+    expect(stepMessageHistory({ history, index: 2, direction: "older", draft: "" })).toBeNull();
+  });
+
+  it("restores the held draft when walking forward past the newest entry", () => {
+    expect(
+      stepMessageHistory({ history, index: 0, direction: "newer", draft: "half typed" }),
+    ).toEqual({ index: DRAFT_HISTORY_INDEX, text: "half typed" });
+  });
+
+  it("does nothing when already on the draft", () => {
+    expect(
+      stepMessageHistory({ history, index: DRAFT_HISTORY_INDEX, direction: "newer", draft: "" }),
+    ).toBeNull();
+  });
+
+  it("does nothing when there is no history", () => {
+    expect(
+      stepMessageHistory({
+        history: [],
+        index: DRAFT_HISTORY_INDEX,
+        direction: "older",
+        draft: "",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("shouldEnterMessageHistory", () => {
+  it("enters from an empty composer", () => {
+    expect(shouldEnterMessageHistory({ value: "", index: DRAFT_HISTORY_INDEX })).toBe(true);
+    expect(shouldEnterMessageHistory({ value: "   ", index: DRAFT_HISTORY_INDEX })).toBe(true);
+  });
+
+  it("leaves a composer the user is typing in alone", () => {
+    expect(shouldEnterMessageHistory({ value: "half typed", index: DRAFT_HISTORY_INDEX })).toBe(
+      false,
+    );
+  });
+
+  it("keeps walking once history is already open, even though the input is not empty", () => {
+    expect(shouldEnterMessageHistory({ value: "newest", index: 0 })).toBe(true);
+  });
+});

--- a/packages/app/src/composer/message-history.ts
+++ b/packages/app/src/composer/message-history.ts
@@ -1,0 +1,70 @@
+import type { StreamItem } from "@/types/stream";
+
+/**
+ * Recall of previously sent messages, the way a shell recalls commands.
+ *
+ * The composer holds no history of its own — what the user sent is already in the agent
+ * timeline, so history is derived from it rather than stored twice and kept in sync.
+ */
+
+/** Newest first. Adjacent repeats collapse, so holding Up walks distinct messages. */
+export function collectUserMessageHistory(items: readonly StreamItem[]): string[] {
+  const history: string[] = [];
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item?.kind !== "user_message") continue;
+    const text = item.text.trim();
+    if (!text) continue;
+    if (history[history.length - 1] === text) continue;
+    history.push(text);
+  }
+  return history;
+}
+
+/** `-1` is the live draft, `0` the most recent sent message, and so on backwards. */
+export const DRAFT_HISTORY_INDEX = -1;
+
+export interface MessageHistoryStep {
+  index: number;
+  text: string;
+}
+
+/**
+ * Walk the recall list.
+ *
+ * Returns `null` when the step is not available — no history, already at the oldest entry —
+ * so the caller can leave the key to whatever would normally handle it. Walking forward past
+ * the newest entry lands back on the draft the user was holding when they entered history.
+ */
+export function stepMessageHistory(input: {
+  history: readonly string[];
+  index: number;
+  direction: "older" | "newer";
+  draft: string;
+}): MessageHistoryStep | null {
+  const { history, index, direction, draft } = input;
+  if (history.length === 0) return null;
+
+  if (direction === "older") {
+    const next = index + 1;
+    if (next >= history.length) return null;
+    return { index: next, text: history[next] ?? "" };
+  }
+
+  if (index <= DRAFT_HISTORY_INDEX) return null;
+  const next = index - 1;
+  if (next === DRAFT_HISTORY_INDEX) {
+    return { index: DRAFT_HISTORY_INDEX, text: draft };
+  }
+  return { index: next, text: history[next] ?? "" };
+}
+
+/**
+ * Whether Up should start a recall rather than move the caret.
+ *
+ * Only an empty composer enters history, so recall can never discard something the user is
+ * partway through writing. Once in history, the keys keep walking.
+ */
+export function shouldEnterMessageHistory(input: { value: string; index: number }): boolean {
+  return input.index > DRAFT_HISTORY_INDEX || input.value.trim().length === 0;
+}


### PR DESCRIPTION
### Linked issue

Discussion #2926

> [!IMPORTANT]
> Draft on purpose, and not ready for review. This is a feature with no maintainer buy-in yet, and CONTRIBUTING is explicit that unsolicited feature PRs get closed and that UI changes need visual proof on every affected platform. I have not produced that proof — see **Not covered**. Posting it as a draft so there is something concrete attached to the discussion; happy to close it if the direction is wrong.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Every message you send is already in the timeline, but the only way to send a variation of one is to retype it. That is most of the friction in the loop this addresses: re-running a prompt with one word changed, or recovering something you sent to the wrong agent.

Up from an empty composer fills it with the last message sent to this agent and keeps walking back on each press. Down walks forward and restores whatever draft was held when history opened.

Two decisions worth flagging, because they are the design and not just the code:

- **History is derived from the timeline, not stored.** The composer keeps no history of its own. A separate list would be a second copy of the user's messages to keep in sync across rewind, reload, and agent switching, and it would drift.
- **Only an empty composer enters history.** Recall can never discard something you were partway through writing. Once you are in history the keys keep walking, and editing recalled text drops you back out.

Autocomplete keeps first claim on the arrow keys — `useAutocomplete` returns `false` when its menu is closed, so recall only ever acts on keys it declined.

### Goals

- Up from an empty composer recalls the last message sent to this agent, repeatably.
- Down walks forward and restores the held draft at the end.
- Autocomplete arrow navigation is unaffected while its menu is open.
- No new persisted state.

### Non-goals

- No cross-agent history. Recall is scoped to the agent whose composer you are in.
- No search through history (`Ctrl-R`), and no history for attachments — text only.
- Native is untouched: composer key handling is already `isWeb`-gated, so this is web and Electron desktop only. If recall is wanted with an external keyboard on iPad, that is a separate change.

### QA

```
$ npx vitest run src/composer/
 Test Files  20 passed (20)
      Tests  157 passed (157)
```

157 = the 146 that existed plus the 11 added here, covering `collectUserMessageHistory` (newest-first ordering, skipping assistant output and blank messages, collapsing adjacent repeats), `stepMessageHistory` (walking back, stopping at the oldest entry rather than wrapping, restoring the held draft, no-op with no history), and `shouldEnterMessageHistory` (enters from empty, refuses to clobber a draft in progress, keeps walking once open).

```
$ npm run lint -- packages/app/src/composer/index.tsx packages/app/src/composer/message-history.ts packages/app/src/composer/message-history.test.ts
Found 0 warnings and 0 errors.
```

`npm run typecheck --workspace packages/app` reports one error, in `src/components/draggable-list.native.tsx(122,7)` — a `react-native-draggable-flatlist` prop typing issue that reproduces identically on a clean `main` with these changes stashed. Pre-existing and unrelated; no new type errors.

**Not covered — the reason this is a draft:**

- **No video or screenshots on any platform.** CONTRIBUTING requires visual proof on every affected platform for UI changes and lists its absence as an automatic rejection. I have not run this in the desktop or web app. Everything above is unit-level.
- **The wiring is untested.** The recall state machine is pure and fully covered, but the `handleCommandKeyPress` integration in `composer/index.tsx` — the ref mirroring, the reset effect, the ordering against autocomplete — is verified by reading and by typecheck, not by a component test.
- **The interaction with a multi-line composer is unverified.** In a shell, Up moves the caret between lines before it recalls. Here an empty composer has one line so the question does not arise, but I have not checked how it feels once you are walking history through a multi-line message.
