### PR TITLE
Fix Android draft composer handoff race

### DIFF
--- a/packages/app/src/composer/draft/workspace-tab-core.ts
+++ b/packages/app/src/composer/draft/workspace-tab-core.ts
@@ -19,6 +19,21 @@ export async function waitForDraftComposerMountsToSettle(
   await new Promise<void>((resolve) => requestFrame(resolve));
 }
 
+export async function completeWorkspaceDraftCreation<T>(input: {
+  platform: string;
+  result: T;
+  clearDraftState: () => void;
+  onCreated: (result: T) => void;
+  requestFrame?: (callback: () => void) => void;
+}): Promise<void> {
+  input.clearDraftState();
+  if (input.platform === "android") {
+    // Let Fabric apply the composer's final native updates before replacing its tab.
+    await waitForDraftComposerMountsToSettle(input.requestFrame);
+  }
+  input.onCreated(input.result);
+}
+
 export function validateDraftSubmission(input: {
   text: string;
   allowsEmptyAutoSubmit: boolean;

--- a/packages/app/src/composer/draft/workspace-tab-core.ts
+++ b/packages/app/src/composer/draft/workspace-tab-core.ts
@@ -12,6 +12,13 @@ export function shouldAllowEmptyDraftText(input: {
   return input.allowsEmptyAutoSubmit || input.attachments.length > 0;
 }
 
+export async function waitForDraftComposerMountsToSettle(
+  requestFrame: (callback: () => void) => void = (callback) => requestAnimationFrame(callback),
+): Promise<void> {
+  await new Promise<void>((resolve) => requestFrame(resolve));
+  await new Promise<void>((resolve) => requestFrame(resolve));
+}
+
 export function validateDraftSubmission(input: {
   text: string;
   allowsEmptyAutoSubmit: boolean;

--- a/packages/app/src/composer/draft/workspace-tab.test.ts
+++ b/packages/app/src/composer/draft/workspace-tab.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  completeWorkspaceDraftCreation,
   shouldAllowEmptyDraftText,
   validateDraftSubmission,
-  waitForDraftComposerMountsToSettle,
 } from "./workspace-tab-core";
 
 const baseComposerState = {
@@ -75,18 +75,44 @@ describe("workspace draft empty text readiness", () => {
 });
 
 describe("workspace draft creation handoff", () => {
-  test("waits for two rendered frames before replacing the draft composer", async () => {
+  test("clears the Android composer and waits two rendered frames before replacing the tab", async () => {
+    const events: string[] = [];
     const pendingFrames: Array<() => void> = [];
-    const settled = waitForDraftComposerMountsToSettle((callback) => {
-      pendingFrames.push(callback);
+    const handoff = completeWorkspaceDraftCreation({
+      platform: "android",
+      result: "created-agent",
+      clearDraftState: () => events.push("clear"),
+      onCreated: (result) => events.push(`created:${result}`),
+      requestFrame: (callback) => pendingFrames.push(callback),
     });
 
+    expect(events).toEqual(["clear"]);
     expect(pendingFrames).toHaveLength(1);
     pendingFrames.shift()?.();
     await Promise.resolve();
+    expect(events).toEqual(["clear"]);
     expect(pendingFrames).toHaveLength(1);
 
     pendingFrames.shift()?.();
-    await expect(settled).resolves.toBeUndefined();
+    await handoff;
+    expect(events).toEqual(["clear", "created:created-agent"]);
+  });
+
+  test.each(["ios", "web"])("hands off immediately on %s", async (platform) => {
+    const events: string[] = [];
+    let requestedFrames = 0;
+
+    await completeWorkspaceDraftCreation({
+      platform,
+      result: "created-agent",
+      clearDraftState: () => events.push("clear"),
+      onCreated: (result) => events.push(`created:${result}`),
+      requestFrame: () => {
+        requestedFrames += 1;
+      },
+    });
+
+    expect(events).toEqual(["clear", "created:created-agent"]);
+    expect(requestedFrames).toBe(0);
   });
 });

--- a/packages/app/src/composer/draft/workspace-tab.test.ts
+++ b/packages/app/src/composer/draft/workspace-tab.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { shouldAllowEmptyDraftText, validateDraftSubmission } from "./workspace-tab-core";
+import {
+  shouldAllowEmptyDraftText,
+  validateDraftSubmission,
+  waitForDraftComposerMountsToSettle,
+} from "./workspace-tab-core";
 
 const baseComposerState = {
   providerDefinitions: [{ id: "codewhale" }],
@@ -67,5 +71,22 @@ describe("workspace draft empty text readiness", () => {
         attachments: [],
       }),
     ).toBe(false);
+  });
+});
+
+describe("workspace draft creation handoff", () => {
+  test("waits for two rendered frames before replacing the draft composer", async () => {
+    const pendingFrames: Array<() => void> = [];
+    const settled = waitForDraftComposerMountsToSettle((callback) => {
+      pendingFrames.push(callback);
+    });
+
+    expect(pendingFrames).toHaveLength(1);
+    pendingFrames.shift()?.();
+    await Promise.resolve();
+    expect(pendingFrames).toHaveLength(1);
+
+    pendingFrames.shift()?.();
+    await expect(settled).resolves.toBeUndefined();
   });
 });

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -36,9 +36,9 @@ import { encodeImages } from "@/utils/encode-images";
 import type { WorkspaceFileOpenRequest } from "@/workspace/file-open";
 import { shouldAutoFocusWorkspaceDraftComposer } from "@/screens/workspace/workspace-draft-pane-focus";
 import {
+  completeWorkspaceDraftCreation,
   shouldAllowEmptyDraftText,
   validateDraftSubmission,
-  waitForDraftComposerMountsToSettle,
 } from "@/composer/draft/workspace-tab-core";
 import type { AgentCapabilityFlags } from "@getpaseo/protocol/agent-types";
 import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
@@ -534,14 +534,16 @@ export function WorkspaceDraftAgentTab({
         selectModelMessage: t("workspaceSetup.errors.selectModel"),
       }),
     onCreateSuccess: async ({ result }) => {
-      clearDraftInput("sent");
-      clearWorkspaceAttachments({ scopeKey: draftAttachmentScopeKey });
-      useWorkspaceDraftSubmissionStore.getState().clearDraftSetup({ draftId });
-      if (Platform.OS === "android") {
-        // Let Fabric apply the composer's final native updates before replacing its tab.
-        await waitForDraftComposerMountsToSettle();
-      }
-      onCreated(result);
+      await completeWorkspaceDraftCreation({
+        platform: Platform.OS,
+        result,
+        clearDraftState: () => {
+          clearDraftInput("sent");
+          clearWorkspaceAttachments({ scopeKey: draftAttachmentScopeKey });
+          useWorkspaceDraftSubmissionStore.getState().clearDraftSetup({ draftId });
+        },
+        onCreated,
+      });
     },
   });
   const turnPresentation = useMemo(

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { Keyboard, ScrollView, StyleSheet as RNStyleSheet, Text, View } from "react-native";
+import {
+  Keyboard,
+  Platform,
+  ScrollView,
+  StyleSheet as RNStyleSheet,
+  Text,
+  View,
+} from "react-native";
 import { useTranslation } from "react-i18next";
 import ReanimatedAnimated from "react-native-reanimated";
 import { StyleSheet } from "react-native-unistyles";
@@ -31,6 +38,7 @@ import { shouldAutoFocusWorkspaceDraftComposer } from "@/screens/workspace/works
 import {
   shouldAllowEmptyDraftText,
   validateDraftSubmission,
+  waitForDraftComposerMountsToSettle,
 } from "@/composer/draft/workspace-tab-core";
 import type { AgentCapabilityFlags } from "@getpaseo/protocol/agent-types";
 import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
@@ -525,10 +533,14 @@ export function WorkspaceDraftAgentTab({
         hostDisconnectedMessage: t("workspace.terminal.hostDisconnected"),
         selectModelMessage: t("workspaceSetup.errors.selectModel"),
       }),
-    onCreateSuccess: ({ result }) => {
+    onCreateSuccess: async ({ result }) => {
       clearDraftInput("sent");
       clearWorkspaceAttachments({ scopeKey: draftAttachmentScopeKey });
       useWorkspaceDraftSubmissionStore.getState().clearDraftSetup({ draftId });
+      if (Platform.OS === "android") {
+        // Let Fabric apply the composer's final native updates before replacing its tab.
+        await waitForDraftComposerMountsToSettle();
+      }
       onCreated(result);
     },
   });


### PR DESCRIPTION
## Summary

- wait for Android Fabric to apply the draft composer final native updates before replacing the tab
- keep the existing immediate handoff behavior on iOS and web
- cover the two-frame handoff boundary with a focused regression test

## Why

After a successful image-backed draft submission, the app cleared the controlled composer and immediately replaced its tab. Android could then dispatch a stale `setTextAndSelection` command after the TextInput had unmounted, producing an `Unable to find viewState` soft exception even though the image upload and agent creation succeeded.

## Verification

- `npx vitest run packages/app/src/composer/draft/workspace-tab.test.ts --bail=1`
- `npm run format:check`
- `npm run typecheck`
- `npm run lint`