### PR TITLE
fix(server): read Kimi rate-limit windows from limits[]

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/kimi.ts
+++ b/packages/server/src/services/quota-fetcher/providers/kimi.ts
@@ -12,24 +12,96 @@ import {
   unavailableUsage,
 } from "../usage.js";
 
-const KimiUsageResponseSchema = z.object({
-  usage: z
+const KimiQuotaDetailSchema = z.object({
+  limit: ApiOptionalStringSchema,
+  used: ApiOptionalStringSchema,
+  remaining: ApiOptionalStringSchema,
+  resetTime: ApiOptionalStringSchema,
+});
+
+// The rolling rate-limit windows (the 5-hour one today) live in a `limits[]` array
+// rather than the top-level `usage` key. Entries are validated one at a time in
+// fetchUsage so a single malformed or newly-shaped entry cannot take down the windows
+// that already parsed.
+const KimiRateLimitSchema = z.object({
+  window: z
     .object({
-      limit: ApiOptionalStringSchema,
-      remaining: ApiOptionalStringSchema,
-      resetTime: ApiOptionalStringSchema,
+      duration: z.number(),
+      timeUnit: z.string(),
     })
     .nullish(),
+  detail: KimiQuotaDetailSchema.nullish(),
+});
+
+const KimiUsageResponseSchema = z.object({
+  usage: KimiQuotaDetailSchema.nullish(),
+  // Deliberately permissive: an additive section must never regress the top-level
+  // window, so shape validation happens per entry rather than here.
+  limits: z.array(z.unknown()).nullish(),
 });
 
 const KimiAuthSchema = z.object({
   access_token: z.string().optional(),
 });
 
+type KimiQuotaDetail = z.infer<typeof KimiQuotaDetailSchema>;
+type KimiRateLimitWindow = NonNullable<z.infer<typeof KimiRateLimitSchema>["window"]>;
+
 interface KimiQuotaProviderOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
   homeDir?: string;
+}
+
+function toFiniteNumber(value: string | null | undefined): number | null {
+  if (value === undefined || value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Percentage consumed within one quota window. `remaining` is the value the API always
+ * sends; `used` is the fallback for windows that omit it.
+ */
+function usedPctFromDetail(detail: KimiQuotaDetail | null | undefined): number | null {
+  const limit = toFiniteNumber(detail?.limit);
+  if (limit === null || limit <= 0) return null;
+  let remaining = toFiniteNumber(detail?.remaining);
+  if (remaining === null) {
+    const used = toFiniteNumber(detail?.used);
+    remaining = used === null ? null : limit - used;
+  }
+  if (remaining === null) return null;
+  return Math.max(0, Math.min(100, ((limit - remaining) / limit) * 100));
+}
+
+/**
+ * Identity of one rate-limit window, derived from its proto-style duration. The API
+ * expresses the 5-hour window as 300 minutes; normalize to the largest whole unit so
+ * the label reads "5-hour limit" rather than "300-minute limit". Unknown units return
+ * null so the entry is skipped instead of mislabelled.
+ */
+function rateLimitIdentity(window: KimiRateLimitWindow): { id: string; label: string } | null {
+  let duration = window.duration;
+  let unit: "minute" | "hour" | "day";
+  switch (window.timeUnit) {
+    case "TIME_UNIT_MINUTE":
+      unit = "minute";
+      break;
+    case "TIME_UNIT_HOUR":
+      unit = "hour";
+      break;
+    case "TIME_UNIT_DAY":
+      unit = "day";
+      break;
+    default:
+      return null;
+  }
+  if (unit === "minute" && duration % 60 === 0) {
+    duration /= 60;
+    unit = "hour";
+  }
+  return { id: `rate_limit_${duration}_${unit}`, label: `${duration}-${unit} limit` };
 }
 
 export class KimiQuotaProvider implements ProviderUsageFetcher {
@@ -65,30 +137,41 @@ export class KimiQuotaProvider implements ProviderUsageFetcher {
     }
 
     const resp = KimiUsageResponseSchema.parse(await res.json());
-    const limit = resp.usage?.limit === undefined ? null : Number(resp.usage.limit);
-    const remaining = resp.usage?.remaining === undefined ? null : Number(resp.usage.remaining);
-    const hasFiniteLimit = typeof limit === "number" && Number.isFinite(limit) && limit > 0;
-    const hasFiniteRemaining = typeof remaining === "number" && Number.isFinite(remaining);
-    const usedPct =
-      hasFiniteLimit && hasFiniteRemaining
-        ? Math.max(0, Math.min(100, ((limit - remaining) / limit) * 100))
-        : null;
+    const usedPct = usedPctFromDetail(resp.usage);
+
+    const windows: ProviderUsage["windows"] = [
+      {
+        id: "coding_usage",
+        label: "Coding usage",
+        usedPct,
+        remainingPct: usedPct === null ? null : Math.max(0, 100 - usedPct),
+        resetsAt: resp.usage?.resetTime ?? null,
+        tone: toneFromUsedPct(usedPct),
+      },
+    ];
+
+    for (const entry of resp.limits ?? []) {
+      const parsed = KimiRateLimitSchema.safeParse(entry);
+      if (!parsed.success || !parsed.data.window || !parsed.data.detail) continue;
+      const identity = rateLimitIdentity(parsed.data.window);
+      if (identity === null) continue;
+      const entryUsedPct = usedPctFromDetail(parsed.data.detail);
+      windows.push({
+        id: identity.id,
+        label: identity.label,
+        usedPct: entryUsedPct,
+        remainingPct: entryUsedPct === null ? null : Math.max(0, 100 - entryUsedPct),
+        resetsAt: parsed.data.detail.resetTime ?? null,
+        tone: toneFromUsedPct(entryUsedPct),
+      });
+    }
 
     return {
       providerId: this.providerId,
       displayName: this.displayName,
       status: "available",
       planLabel: null,
-      windows: [
-        {
-          id: "coding_usage",
-          label: "Coding usage",
-          usedPct,
-          remainingPct: usedPct === null ? null : Math.max(0, 100 - usedPct),
-          resetsAt: resp.usage?.resetTime ?? null,
-          tone: toneFromUsedPct(usedPct),
-        },
-      ],
+      windows,
       balances: [],
       details: [],
       error: null,

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -921,6 +921,97 @@ describe("real provider usage fetchers", () => {
     });
   });
 
+  it("fetches Kimi rate-limit windows from limits[]", async () => {
+    process.env["KIMI_TOKEN"] = "kimi_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api.kimi.com/coding/v1/usages",
+          () =>
+            jsonResponse({
+              usage: {
+                limit: "100",
+                remaining: "74",
+                resetTime: "2026-08-11T15:53:05Z",
+              },
+              limits: [
+                {
+                  window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+                  detail: {
+                    limit: "100",
+                    used: "27",
+                    remaining: "73",
+                    resetTime: "2026-08-08T14:53:05Z",
+                  },
+                },
+                {
+                  window: { duration: "soon" },
+                  detail: null,
+                },
+              ],
+            }),
+        ],
+      ]),
+    );
+
+    const kimi = findProvider(await service().listUsage(), "kimi");
+
+    expect(kimi).toMatchObject({
+      status: "available",
+      windows: [
+        expect.objectContaining({
+          id: "coding_usage",
+          usedPct: 26,
+          remainingPct: 74,
+          resetsAt: "2026-08-11T15:53:05Z",
+        }),
+        expect.objectContaining({
+          id: "rate_limit_5_hour",
+          label: "5-hour limit",
+          usedPct: 27,
+          remainingPct: 73,
+          resetsAt: "2026-08-08T14:53:05Z",
+        }),
+      ],
+    });
+  });
+
+  it("derives the Kimi rate-window consumption from used when remaining is omitted", async () => {
+    process.env["KIMI_TOKEN"] = "kimi_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api.kimi.com/coding/v1/usages",
+          () =>
+            jsonResponse({
+              usage: { limit: "100", remaining: "74" },
+              limits: [
+                {
+                  window: { duration: 24, timeUnit: "TIME_UNIT_HOUR" },
+                  detail: { limit: "50", used: "25" },
+                },
+              ],
+            }),
+        ],
+      ]),
+    );
+
+    const kimi = findProvider(await service().listUsage(), "kimi");
+
+    expect(kimi).toMatchObject({
+      status: "available",
+      windows: expect.arrayContaining([
+        expect.objectContaining({
+          id: "rate_limit_24_hour",
+          label: "24-hour limit",
+          usedPct: 50,
+          remainingPct: 50,
+          resetsAt: null,
+        }),
+      ]),
+    });
+  });
+
   it("fetches MiniMax usage from MINIMAX_API_KEY against the global endpoint", async () => {
     process.env["MINIMAX_API_KEY"] = "minimax_test_token";
     let requestedUrl: string | null = null;


### PR DESCRIPTION
### Linked issue

Closes #3024

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The Kimi usage card showed only the weekly coding quota. Kimi's `/coding/v1/usages` also returns a `limits[]` array with the rolling rate-limit windows (today: the 5-hour window, sent as 300 `TIME_UNIT_MINUTE`), each with its own limit/remaining/resetTime. The fetcher ignored the array, so the card looked healthy while the account was actually approaching a throttle — nothing errored, the window was just dropped.

This validates each `limits[]` entry on its own and renders one window per entry, labelled from the normalized duration ("5-hour limit" rather than "300-minute limit"). Same per-entry-validation pattern as #2303 used for Claude's scoped limits.

### Goals

- One usage window per `limits[]` entry on the Kimi card, with its own percentage and reset time.
- Labels derived from the proto-style duration: 300 minutes → "5-hour limit"; unknown units are skipped, never mislabelled.
- A malformed or newly-shaped entry can never take down the top-level "Coding usage" window (per-entry `safeParse`).
- Fall back to `used` when an entry omits `remaining`.

### Non-goals

- The top-level "Coding usage" window is unchanged (same id, same label).
- `boosterWallet` (Extra Usage balance) is a separate section of the response — not touched here.
- Monthly membership quota is not exposed by this endpoint (`totalQuota` arrives empty), so it stays web-only.

### QA

Reproduced against my account: `limits[0]` comes back as the 300-minute window at 27% consumed while the card rendered only the weekly bar (raw response in the linked issue).

- `npx vitest run src/services/quota-fetcher/service.test.ts -t "Kimi"` — 4/4 pass, including the two new ones: `limits[]` parsing with a malformed entry present (weekly window survives, one "5-hour limit" window appears), and the `used` fallback when `remaining` is omitted. Full-file run: 57/57 except `returns unavailable Claude usage when credentials are missing`, which fails on a clean main checkout too when real Kimi CLI credentials exist under `~/.kimi-code` — environmental, unrelated to this diff.
- `npm run typecheck`, `npm run lint`, `npm run format` — clean.
- Also verified live on Windows against a locally patched 0.3.0 desktop build: the Kimi card renders both "Coding usage" and "5-hour limit" with the real percentages from the response quoted in the issue.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
