### PR TITLE
feat: add close editor tabs action

### DIFF
--- a/packages/app/e2e/browser/launcher-tab.spec.ts
+++ b/packages/app/e2e/browser/launcher-tab.spec.ts
@@ -281,16 +281,6 @@ test.describe("Tab creation", () => {
     expect(newTabButtonInScroll === 0 || scrollShades === 0).toBe(true);
     await expect(tabRow.getByTestId("workspace-new-tab-button")).toBeVisible();
   });
-
-  test("right-clicking the empty tab strip opens tab creation actions", async ({ page }) => {
-    await page.setViewportSize({ width: 1600, height: 900 });
-    await gotoWorkspace(page, workspace.workspaceId);
-
-    await page.getByTestId("workspace-empty-tab-strip").click({ button: "right" });
-
-    await expect(page.getByTestId("workspace-empty-tab-menu-agent")).toBeVisible();
-    await expect(page.getByTestId("workspace-empty-tab-menu-terminal")).toBeVisible();
-  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/app/e2e/browser/launcher-tab.spec.ts
+++ b/packages/app/e2e/browser/launcher-tab.spec.ts
@@ -281,6 +281,16 @@ test.describe("Tab creation", () => {
     expect(newTabButtonInScroll === 0 || scrollShades === 0).toBe(true);
     await expect(tabRow.getByTestId("workspace-new-tab-button")).toBeVisible();
   });
+
+  test("right-clicking the empty tab strip opens tab creation actions", async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await gotoWorkspace(page, workspace.workspaceId);
+
+    await page.getByTestId("workspace-empty-tab-strip").click({ button: "right" });
+
+    await expect(page.getByTestId("workspace-empty-tab-menu-agent")).toBeVisible();
+    await expect(page.getByTestId("workspace-empty-tab-menu-terminal")).toBeVisible();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/app/src/components/split-container.tsx
+++ b/packages/app/src/components/split-container.tsx
@@ -115,6 +115,8 @@ interface SplitContainerProps {
   onCloseTabsToLeft: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string, paneTabs: WorkspaceTabDescriptor[]) => Promise<void> | void;
+  onCloseEditorTabs: () => Promise<void> | void;
+  canCloseEditorTabs: boolean;
   onCreateNewTab: (input: { paneId?: string }) => void;
   buildPaneContentModel: (input: {
     paneId: string;
@@ -328,6 +330,8 @@ export function SplitContainer({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onCloseEditorTabs,
+  canCloseEditorTabs,
   onCreateNewTab,
   buildPaneContentModel,
   onFocusPane,
@@ -681,6 +685,8 @@ export function SplitContainer({
                   onCloseTabsToLeft={onCloseTabsToLeft}
                   onCloseTabsToRight={onCloseTabsToRight}
                   onCloseOtherTabs={onCloseOtherTabs}
+                  onCloseEditorTabs={onCloseEditorTabs}
+                  canCloseEditorTabs={canCloseEditorTabs}
                   onCreateNewTab={onCreateNewTab}
                   buildPaneContentModel={buildPaneContentModel}
                   onFocusPane={onFocusPane}
@@ -943,6 +949,8 @@ function SplitNodeView({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onCloseEditorTabs,
+  canCloseEditorTabs,
   onCreateNewTab,
   buildPaneContentModel,
   onFocusPane,
@@ -1031,6 +1039,8 @@ function SplitNodeView({
             onCloseTabsToLeft={onCloseTabsToLeft}
             onCloseTabsToRight={onCloseTabsToRight}
             onCloseOtherTabs={onCloseOtherTabs}
+            onCloseEditorTabs={onCloseEditorTabs}
+            canCloseEditorTabs={canCloseEditorTabs}
             onCreateNewTab={onCreateNewTab}
             buildPaneContentModel={buildPaneContentModel}
             onFocusPane={onFocusPane}
@@ -1083,6 +1093,8 @@ function SplitNodeView({
               onCloseTabsToLeft={onCloseTabsToLeft}
               onCloseTabsToRight={onCloseTabsToRight}
               onCloseOtherTabs={onCloseOtherTabs}
+              onCloseEditorTabs={onCloseEditorTabs}
+              canCloseEditorTabs={canCloseEditorTabs}
               onCreateNewTab={onCreateNewTab}
               buildPaneContentModel={buildPaneContentModel}
               onFocusPane={onFocusPane}
@@ -1143,6 +1155,8 @@ function SplitPaneView({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onCloseEditorTabs,
+  canCloseEditorTabs,
   onCreateNewTab,
   buildPaneContentModel,
   onFocusPane,
@@ -1278,6 +1292,8 @@ function SplitPaneView({
             onCloseTabsToLeft={handleCloseTabsToLeft}
             onCloseTabsToRight={handleCloseTabsToRight}
             onCloseOtherTabs={handleCloseOtherTabs}
+            onCloseEditorTabs={onCloseEditorTabs}
+            canCloseEditorTabs={canCloseEditorTabs}
             onCreateNewTab={onCreateNewTab}
             onReorderTabs={handleReorderTabs}
             externalDndContext

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -605,6 +605,7 @@ export const ar: TranslationResources = {
         closeLeft: "بالقرب من اليسار",
         closeRight: "قريب من اليمين",
         closeOthers: "أغلق علامات التبويب الأخرى",
+        closeEditorTabs: "إغلاق علامات تبويب المحرر",
         moveToMain: "Move to main panel",
         reloadAgent: "إعادة تحميل الوكيل",
         reloadAgentTooltip: "قم بإعادة تحميل الوكيل لتحديث المهارات أو MCPs أو حالة تسجيل الدخول.",
@@ -670,6 +671,7 @@ export const ar: TranslationResources = {
         closeTabsLeftTitle: "هل تريد إغلاق علامات التبويب على اليسار؟",
         closeTabsRightTitle: "هل تريد إغلاق علامات التبويب على اليمين؟",
         closeOtherTabsTitle: "هل تريد إغلاق علامات التبويب الأخرى؟",
+        closeEditorTabsTitle: "هل تريد إغلاق علامات تبويب المحرر؟",
         bulk: {
           all: "سيؤدي هذا إلى أرشفة وكيل (وكلاء){{agents}}، وإغلاق محطة (محطات){{terminals}}، وإغلاق علامة (علامات) تبويب{{tabs}}. سيتم إيقاف أي عملية جارية في محطة مغلقة على الفور.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -603,6 +603,7 @@ export const en = {
         closeLeft: "Close to the left",
         closeRight: "Close to the right",
         closeOthers: "Close other tabs",
+        closeEditorTabs: "Close editor tabs",
         moveToMain: "Move to main panel",
         reloadAgent: "Reload agent",
         reloadAgentTooltip: "Reload agent to update skills, MCPs or login status.",
@@ -667,6 +668,7 @@ export const en = {
         closeTabsLeftTitle: "Close tabs to the left?",
         closeTabsRightTitle: "Close tabs to the right?",
         closeOtherTabsTitle: "Close other tabs?",
+        closeEditorTabsTitle: "Close editor tabs?",
         bulk: {
           all: "This will archive {{agents}} agent(s), close {{terminals}} terminal(s), and close {{tabs}} tab(s). Any running process in a closed terminal will be stopped immediately.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -609,6 +609,7 @@ export const es: TranslationResources = {
         closeLeft: "Cerrar pestañas a la izquierda",
         closeRight: "Cerrar pestañas a la derecha",
         closeOthers: "Cerrar otras pestañas",
+        closeEditorTabs: "Cerrar pestañas del editor",
         moveToMain: "Mover al panel principal",
         reloadAgent: "Recargar agente",
         reloadAgentTooltip:
@@ -676,6 +677,7 @@ export const es: TranslationResources = {
         closeTabsLeftTitle: "¿Cerrar pestañas a la izquierda?",
         closeTabsRightTitle: "¿Cerrar pestañas a la derecha?",
         closeOtherTabsTitle: "¿Cerrar otras pestañas?",
+        closeEditorTabsTitle: "¿Cerrar pestañas del editor?",
         bulk: {
           all: "Esto archivará los agentes{{agents}}, cerrará los terminales{{terminals}}y cerrará las pestañas{{tabs}}. Cualquier proceso en ejecución en una terminal cerrada se detendrá inmediatamente.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -609,6 +609,7 @@ export const fr: TranslationResources = {
         closeLeft: "Près de la gauche",
         closeRight: "Près de la droite",
         closeOthers: "Fermer les autres onglets",
+        closeEditorTabs: "Fermer les onglets de l’éditeur",
         moveToMain: "Déplacer vers le panneau principal",
         reloadAgent: "Agent de rechargement",
         reloadAgentTooltip:
@@ -676,6 +677,7 @@ export const fr: TranslationResources = {
         closeTabsLeftTitle: "Fermer les onglets à gauche?",
         closeTabsRightTitle: "Fermer les onglets à droite?",
         closeOtherTabsTitle: "Fermer les autres onglets?",
+        closeEditorTabsTitle: "Fermer les onglets de l’éditeur?",
         bulk: {
           all: "Cela archivera les agents{{agents}}, fermera les terminaux{{terminals}}et fermera les onglets{{tabs}}. Tout processus en cours d’exécution dans un terminal fermé sera immédiatement arrêté.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -609,6 +609,7 @@ export const ja: TranslationResources = {
         closeLeft: "左のタブを閉じる",
         closeRight: "右のタブを閉じる",
         closeOthers: "他のタブを閉じる",
+        closeEditorTabs: "エディタータブを閉じる",
         moveToMain: "メインパネルへ移動",
         reloadAgent: "エージェントを再読み込み",
         reloadAgentTooltip:
@@ -673,6 +674,7 @@ export const ja: TranslationResources = {
         closeTabsLeftTitle: "左のタブを閉じますか？",
         closeTabsRightTitle: "右のタブを閉じますか？",
         closeOtherTabsTitle: "他のタブを閉じますか？",
+        closeEditorTabsTitle: "エディタータブを閉じますか？",
         bulk: {
           all: "{{agents}}件のエージェントをアーカイブし、{{terminals}}件のターミナルを閉じ、{{tabs}}件のタブを閉じます。閉じたターミナルで実行中のプロセスはすぐに停止されます。",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -606,7 +606,7 @@ export const ko: TranslationResources = {
         closeLeft: "왼쪽 탭 닫기",
         closeRight: "오른쪽 탭 닫기",
         closeOthers: "다른 탭 닫기",
-        closeEditorTabs: "에디터 탭 닫기",
+        closeEditorTabs: "편집기 탭 닫기",
         moveToMain: "기본 패널로 이동",
         reloadAgent: "에이전트 다시 로드",
         reloadAgentTooltip:
@@ -672,7 +672,7 @@ export const ko: TranslationResources = {
         closeTabsLeftTitle: "왼쪽 탭을 닫을까요?",
         closeTabsRightTitle: "오른쪽 탭을 닫을까요?",
         closeOtherTabsTitle: "다른 탭을 닫을까요?",
-        closeEditorTabsTitle: "에디터 탭을 닫을까요?",
+        closeEditorTabsTitle: "편집기 탭을 닫을까요?",
         bulk: {
           all: "에이전트 {{agents}}개를 보관하고, 터미널 {{terminals}}개를 닫고, 탭 {{tabs}}개를 닫습니다. 닫히는 터미널에서 실행 중인 프로세스는 즉시 중지됩니다.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -606,6 +606,7 @@ export const ko: TranslationResources = {
         closeLeft: "왼쪽 탭 닫기",
         closeRight: "오른쪽 탭 닫기",
         closeOthers: "다른 탭 닫기",
+        closeEditorTabs: "에디터 탭 닫기",
         moveToMain: "기본 패널로 이동",
         reloadAgent: "에이전트 다시 로드",
         reloadAgentTooltip:
@@ -671,6 +672,7 @@ export const ko: TranslationResources = {
         closeTabsLeftTitle: "왼쪽 탭을 닫을까요?",
         closeTabsRightTitle: "오른쪽 탭을 닫을까요?",
         closeOtherTabsTitle: "다른 탭을 닫을까요?",
+        closeEditorTabsTitle: "에디터 탭을 닫을까요?",
         bulk: {
           all: "에이전트 {{agents}}개를 보관하고, 터미널 {{terminals}}개를 닫고, 탭 {{tabs}}개를 닫습니다. 닫히는 터미널에서 실행 중인 프로세스는 즉시 중지됩니다.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -609,6 +609,7 @@ export const ptBR: TranslationResources = {
         closeLeft: "Fechar à esquerda",
         closeRight: "Fechar à direita",
         closeOthers: "Fechar outras abas",
+        closeEditorTabs: "Fechar abas do editor",
         moveToMain: "Mover para o painel principal",
         reloadAgent: "Recarregar agente",
         reloadAgentTooltip: "Recarregue o agente para atualizar skills, MCPs ou status de login.",
@@ -674,6 +675,7 @@ export const ptBR: TranslationResources = {
         closeTabsLeftTitle: "Fechar abas à esquerda?",
         closeTabsRightTitle: "Fechar abas à direita?",
         closeOtherTabsTitle: "Fechar outras abas?",
+        closeEditorTabsTitle: "Fechar abas do editor?",
         bulk: {
           all: "Isso vai arquivar {{agents}} agente(s), fechar {{terminals}} terminal(ais) e fechar {{tabs}} aba(s). Qualquer processo em execução em um terminal fechado será interrompido imediatamente.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -610,6 +610,7 @@ export const ru: TranslationResources = {
         closeLeft: "Закрыть вкладки слева",
         closeRight: "Закрыть вкладки справа",
         closeOthers: "Закрыть другие вкладки",
+        closeEditorTabs: "Закрыть вкладки редактора",
         moveToMain: "Переместить на основную панель",
         reloadAgent: "Перезагрузить агента",
         reloadAgentTooltip: "Перезагрузите агента, чтобы обновить навыки, MCP или статус входа.",
@@ -676,6 +677,7 @@ export const ru: TranslationResources = {
         closeTabsLeftTitle: "Закрыть вкладки слева?",
         closeTabsRightTitle: "Закрыть вкладки справа?",
         closeOtherTabsTitle: "Закрыть другие вкладки?",
+        closeEditorTabsTitle: "Закрыть вкладки редактора?",
         bulk: {
           all: "Будут архивированы агенты ({{agents}}), закрыты терминалы ({{terminals}}) и вкладки ({{tabs}}). Все запущенные процессы в закрытых терминалах будут немедленно остановлены.",
           agentsAndTerminals:

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -605,6 +605,7 @@ export const zhCN: TranslationResources = {
         closeLeft: "关闭左侧标签",
         closeRight: "关闭右侧标签",
         closeOthers: "关闭其他标签",
+        closeEditorTabs: "关闭编辑器标签",
         moveToMain: "移至主面板",
         reloadAgent: "重新加载 Agent",
         reloadAgentTooltip: "重新加载 Agent 以更新 skills、MCPs 或登录状态。",
@@ -667,6 +668,7 @@ export const zhCN: TranslationResources = {
         closeTabsLeftTitle: "关闭左侧标签？",
         closeTabsRightTitle: "关闭右侧标签？",
         closeOtherTabsTitle: "关闭其他标签？",
+        closeEditorTabsTitle: "关闭编辑器标签？",
         bulk: {
           all: "这会归档 {{agents}} 个 Agent，关闭 {{terminals}} 个 Terminal，并关闭 {{tabs}} 个标签。已关闭 Terminal 中任何正在运行的进程都会立即停止。",
           agentsAndTerminals:

--- a/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
@@ -3,6 +3,7 @@ import {
   buildBulkCloseConfirmationMessage,
   classifyBulkClosableTabs,
   closeBulkWorkspaceTabs,
+  selectWorkspaceEditorTabs,
 } from "@/screens/workspace/workspace-bulk-close";
 import type { WorkspaceTabDescriptor } from "@/screens/workspace/workspace-tabs-types";
 
@@ -34,6 +35,62 @@ function makeFileTab(path: string): WorkspaceTabDescriptor {
 }
 
 describe("workspace bulk close helpers", () => {
+  it("selects every non-agent, non-terminal tab as an editor tab", () => {
+    const tabs: WorkspaceTabDescriptor[] = [
+      makeAgentTab("a1"),
+      makeTerminalTab("t1"),
+      {
+        key: "draft",
+        tabId: "draft",
+        kind: "draft",
+        target: { kind: "draft", draftId: "draft-1" },
+      },
+      {
+        key: "provider_subagent",
+        tabId: "provider_subagent",
+        kind: "provider_subagent",
+        target: {
+          kind: "provider_subagent",
+          parentAgentId: "agent-1",
+          subagentId: "subagent-1",
+        },
+      },
+      makeFileTab("/repo/README.md"),
+      {
+        key: "working_diff",
+        tabId: "working_diff",
+        kind: "working_diff",
+        target: { kind: "working_diff" },
+      },
+      {
+        key: "commit_diff",
+        tabId: "commit_diff",
+        kind: "commit_diff",
+        target: { kind: "commit_diff", sha: "abc123" },
+      },
+      {
+        key: "browser",
+        tabId: "browser",
+        kind: "browser",
+        target: { kind: "browser", browserId: "browser-1" },
+      },
+      {
+        key: "setup",
+        tabId: "setup",
+        kind: "setup",
+        target: { kind: "setup", workspaceId: "workspace-1" },
+      },
+    ];
+
+    expect(selectWorkspaceEditorTabs(tabs).map((tab) => tab.target.kind)).toEqual([
+      "file",
+      "working_diff",
+      "commit_diff",
+      "browser",
+      "setup",
+    ]);
+  });
+
   it("classifies agent, terminal, and passive tabs for shared bulk close handling", () => {
     const groups = classifyBulkClosableTabs([
       makeAgentTab("a1"),

--- a/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.test.ts
@@ -35,7 +35,7 @@ function makeFileTab(path: string): WorkspaceTabDescriptor {
 }
 
 describe("workspace bulk close helpers", () => {
-  it("selects every non-agent, non-terminal tab as an editor tab", () => {
+  it("selects file, diff, browser, and setup tabs as editor tabs", () => {
     const tabs: WorkspaceTabDescriptor[] = [
       makeAgentTab("a1"),
       makeTerminalTab("t1"),

--- a/packages/app/src/screens/workspace/workspace-bulk-close.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.ts
@@ -49,6 +49,20 @@ interface CloseBulkWorkspaceTabsInput {
   warn?: (message: string, payload: object) => void;
 }
 
+function isWorkspaceAgentTab(tab: WorkspaceTabDescriptor): boolean {
+  return (
+    tab.target.kind === "agent" ||
+    tab.target.kind === "draft" ||
+    tab.target.kind === "provider_subagent"
+  );
+}
+
+export function selectWorkspaceEditorTabs(
+  tabs: WorkspaceTabDescriptor[],
+): WorkspaceTabDescriptor[] {
+  return tabs.filter((tab) => !isWorkspaceAgentTab(tab) && tab.target.kind !== "terminal");
+}
+
 export function classifyBulkClosableTabs(
   tabs: WorkspaceTabDescriptor[],
   resolveAgentCloseKind: (agentId: string) => "archive" | "layout-only" = () => "archive",

--- a/packages/app/src/screens/workspace/workspace-bulk-close.ts
+++ b/packages/app/src/screens/workspace/workspace-bulk-close.ts
@@ -49,18 +49,22 @@ interface CloseBulkWorkspaceTabsInput {
   warn?: (message: string, payload: object) => void;
 }
 
-function isWorkspaceAgentTab(tab: WorkspaceTabDescriptor): boolean {
-  return (
-    tab.target.kind === "agent" ||
-    tab.target.kind === "draft" ||
-    tab.target.kind === "provider_subagent"
-  );
+function isWorkspaceEditorTab(tab: WorkspaceTabDescriptor): boolean {
+  switch (tab.target.kind) {
+    case "agent":
+    case "draft":
+    case "provider_subagent":
+    case "terminal":
+      return false;
+    default:
+      return true;
+  }
 }
 
 export function selectWorkspaceEditorTabs(
   tabs: WorkspaceTabDescriptor[],
 ): WorkspaceTabDescriptor[] {
-  return tabs.filter((tab) => !isWorkspaceAgentTab(tab) && tab.target.kind !== "terminal");
+  return tabs.filter(isWorkspaceEditorTab);
 }
 
 export function classifyBulkClosableTabs(

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -16,6 +16,7 @@ import {
   ArrowRightToLine,
   Copy,
   Pencil,
+  PanelTopClose,
   RotateCw,
   Columns2,
   Rows2,
@@ -120,6 +121,7 @@ const ThemedRotateCw = withUnistyles(RotateCw);
 const ThemedArrowLeftToLine = withUnistyles(ArrowLeftToLine);
 const ThemedArrowRightToLine = withUnistyles(ArrowRightToLine);
 const ThemedCopyX = withUnistyles(CopyX);
+const ThemedPanelTopClose = withUnistyles(PanelTopClose);
 const ThemedPencil = withUnistyles(Pencil);
 const ThemedPlus = withUnistyles(Plus);
 const ThemedColumns2 = withUnistyles(Columns2);
@@ -411,6 +413,8 @@ function TabContextMenuItem({
         return <ThemedArrowRightToLine size={16} uniProps={mutedColorMapping} />;
       case "copy-x":
         return <ThemedCopyX size={16} uniProps={mutedColorMapping} />;
+      case "panel-top-close":
+        return <ThemedPanelTopClose size={16} uniProps={mutedColorMapping} />;
       case "pencil":
         return <ThemedPencil size={16} uniProps={mutedColorMapping} />;
       case "x":
@@ -515,6 +519,8 @@ interface WorkspaceDesktopTabsRowProps {
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  onCloseEditorTabs: () => Promise<void> | void;
+  canCloseEditorTabs: boolean;
   onCreateNewTab: (input: { paneId?: string }) => void;
   onReorderTabs: (nextTabs: WorkspaceTabDescriptor[]) => void;
   externalDndContext?: boolean;
@@ -1008,6 +1014,8 @@ function ResolvedWorkspaceDesktopTabsRow({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onCloseEditorTabs,
+  canCloseEditorTabs,
   onCreateNewTab,
   onReorderTabs,
   externalDndContext = false,
@@ -1087,6 +1095,7 @@ function ResolvedWorkspaceDesktopTabsRow({
       closeLeft: t("workspace.tabs.menu.closeLeft"),
       closeRight: t("workspace.tabs.menu.closeRight"),
       closeOthers: t("workspace.tabs.menu.closeOthers"),
+      closeEditorTabs: t("workspace.tabs.menu.closeEditorTabs"),
       reloadAgent: t("workspace.tabs.menu.reloadAgent"),
       reloadAgentTooltip: t("workspace.tabs.menu.reloadAgentTooltip"),
       close: t("workspace.tabs.menu.close"),
@@ -1264,6 +1273,8 @@ function ResolvedWorkspaceDesktopTabsRow({
           onCloseTabsToLeft={onCloseTabsToLeft}
           onCloseTabsToRight={onCloseTabsToRight}
           onCloseOtherTabs={onCloseOtherTabs}
+          onCloseEditorTabs={onCloseEditorTabs}
+          canCloseEditorTabs={canCloseEditorTabs}
           resolvedTabWidth={resolvedTabWidth}
           showLabel={showLabel}
           showCloseButton={shouldShowCloseButton}
@@ -1284,6 +1295,8 @@ function ResolvedWorkspaceDesktopTabsRow({
       layout.items,
       normalizedServerId,
       onCloseOtherTabs,
+      onCloseEditorTabs,
+      canCloseEditorTabs,
       onCloseTab,
       onCloseTabsToLeft,
       onCloseTabsToRight,
@@ -1411,6 +1424,8 @@ function ResolvedDesktopTabChip({
   onCloseTabsToLeft,
   onCloseTabsToRight,
   onCloseOtherTabs,
+  onCloseEditorTabs,
+  canCloseEditorTabs,
   resolvedTabWidth,
   showLabel,
   showCloseButton,
@@ -1437,6 +1452,8 @@ function ResolvedDesktopTabChip({
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  onCloseEditorTabs: () => Promise<void> | void;
+  canCloseEditorTabs: boolean;
   resolvedTabWidth: number;
   showLabel: boolean;
   showCloseButton: boolean;
@@ -1466,12 +1483,16 @@ function ResolvedDesktopTabChip({
         onCloseTabsToLeft,
         onCloseTabsToRight,
         onCloseOtherTabs,
+        onCloseEditorTabs,
+        canCloseEditorTabs,
         labels,
       }),
     [
       index,
       item.tab,
       onCloseOtherTabs,
+      onCloseEditorTabs,
+      canCloseEditorTabs,
       onCloseTab,
       onCloseTabsToLeft,
       onCloseTabsToRight,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -2306,24 +2306,19 @@ function WorkspaceScreenContent({
     return map;
   }, [tabs]);
 
-  const allTabDescriptors = useMemo<WorkspaceTabDescriptor[]>(
-    () =>
-      uiTabs.map((tab) => ({
-        key: tab.tabId,
-        tabId: tab.tabId,
-        kind: tab.target.kind,
-        target: tab.target,
-      })),
-    [uiTabs],
-  );
-  const allTabDescriptorsById = useMemo(
-    () => new Map(allTabDescriptors.map((tab) => [tab.tabId, tab])),
-    [allTabDescriptors],
-  );
-  const editorTabs = useMemo(
-    () => selectWorkspaceEditorTabs(allTabDescriptors),
-    [allTabDescriptors],
-  );
+  const { allTabDescriptorsById, editorTabs } = useMemo(() => {
+    const tabDescriptors: WorkspaceTabDescriptor[] = uiTabs.map((tab) => ({
+      key: tab.tabId,
+      tabId: tab.tabId,
+      kind: tab.target.kind,
+      target: tab.target,
+    }));
+
+    return {
+      allTabDescriptorsById: new Map(tabDescriptors.map((tab) => [tab.tabId, tab])),
+      editorTabs: selectWorkspaceEditorTabs(tabDescriptors),
+    };
+  }, [uiTabs]);
   const canCloseEditorTabs = editorTabs.length > 0;
   const bulkCloseConfirmationLabels = useMemo<BulkCloseConfirmationLabels>(
     () => ({

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -180,6 +180,7 @@ import {
   type BulkCloseConfirmationLabels,
   classifyBulkClosableTabs,
   closeBulkWorkspaceTabs,
+  selectWorkspaceEditorTabs,
 } from "@/screens/workspace/workspace-bulk-close";
 import { resolveCloseAgentTabPolicy } from "@/subagents";
 import {
@@ -421,6 +422,8 @@ interface MobileWorkspaceTabSwitcherProps {
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  onCloseEditorTabs: () => Promise<void> | void;
+  canCloseEditorTabs: boolean;
 }
 
 function MobileActiveTabTrigger({
@@ -528,6 +531,8 @@ function MobileWorkspaceTabOption({
   onCloseTabsAbove,
   onCloseTabsBelow,
   onCloseOtherTabs,
+  onCloseEditorTabs,
+  canCloseEditorTabs,
 }: {
   tab: WorkspaceTabDescriptor;
   tabIndex: number;
@@ -547,6 +552,8 @@ function MobileWorkspaceTabOption({
   onCloseTabsAbove: (tabId: string) => Promise<void> | void;
   onCloseTabsBelow: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  onCloseEditorTabs: () => Promise<void> | void;
+  canCloseEditorTabs: boolean;
 }) {
   const { t } = useTranslation();
   const tabMenuLabels = useMemo<WorkspaceTabMenuLabels>(
@@ -561,6 +568,7 @@ function MobileWorkspaceTabOption({
       closeLeft: t("workspace.tabs.menu.closeLeft"),
       closeRight: t("workspace.tabs.menu.closeRight"),
       closeOthers: t("workspace.tabs.menu.closeOthers"),
+      closeEditorTabs: t("workspace.tabs.menu.closeEditorTabs"),
       reloadAgent: t("workspace.tabs.menu.reloadAgent"),
       reloadAgentTooltip: t("workspace.tabs.menu.reloadAgentTooltip"),
       close: t("workspace.tabs.menu.close"),
@@ -584,6 +592,8 @@ function MobileWorkspaceTabOption({
     onCloseTabsBefore: onCloseTabsAbove,
     onCloseTabsAfter: onCloseTabsBelow,
     onCloseOtherTabs,
+    onCloseEditorTabs,
+    canCloseEditorTabs,
     labels: tabMenuLabels,
   });
 
@@ -656,6 +666,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   onCloseTabsAbove,
   onCloseTabsBelow,
   onCloseOtherTabs,
+  onCloseEditorTabs,
+  canCloseEditorTabs,
 }: MobileWorkspaceTabSwitcherProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -713,6 +725,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
           onCloseTabsAbove={onCloseTabsAbove}
           onCloseTabsBelow={onCloseTabsBelow}
           onCloseOtherTabs={onCloseOtherTabs}
+          onCloseEditorTabs={onCloseEditorTabs}
+          canCloseEditorTabs={canCloseEditorTabs}
         />
       );
     },
@@ -732,6 +746,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       onCloseTabsAbove,
       onCloseTabsBelow,
       onCloseOtherTabs,
+      onCloseEditorTabs,
+      canCloseEditorTabs,
     ],
   );
 
@@ -2290,18 +2306,25 @@ function WorkspaceScreenContent({
     return map;
   }, [tabs]);
 
-  const allTabDescriptorsById = useMemo(() => {
-    const map = new Map<string, WorkspaceTabDescriptor>();
-    for (const tab of uiTabs) {
-      map.set(tab.tabId, {
+  const allTabDescriptors = useMemo<WorkspaceTabDescriptor[]>(
+    () =>
+      uiTabs.map((tab) => ({
         key: tab.tabId,
         tabId: tab.tabId,
         kind: tab.target.kind,
         target: tab.target,
-      });
-    }
-    return map;
-  }, [uiTabs]);
+      })),
+    [uiTabs],
+  );
+  const allTabDescriptorsById = useMemo(
+    () => new Map(allTabDescriptors.map((tab) => [tab.tabId, tab])),
+    [allTabDescriptors],
+  );
+  const editorTabs = useMemo(
+    () => selectWorkspaceEditorTabs(allTabDescriptors),
+    [allTabDescriptors],
+  );
+  const canCloseEditorTabs = editorTabs.length > 0;
   const bulkCloseConfirmationLabels = useMemo<BulkCloseConfirmationLabels>(
     () => ({
       newTab: t("workspace.tabs.actions.newTab"),
@@ -2949,6 +2972,13 @@ function WorkspaceScreenContent({
     },
     [handleCloseOtherTabsInPane, tabs],
   );
+  const handleCloseEditorTabs = useCallback(async () => {
+    await handleBulkCloseTabs({
+      tabsToClose: editorTabs,
+      title: t("workspace.tabs.confirmations.closeEditorTabsTitle"),
+      logLabel: "from close editor tabs",
+    });
+  }, [editorTabs, handleBulkCloseTabs, t]);
 
   const handleClosePane = useCallback(
     async (paneId: string) => {
@@ -3959,6 +3989,8 @@ function WorkspaceScreenContent({
         onCloseTabsToLeft={handleCloseTabsToLeftInPane}
         onCloseTabsToRight={handleCloseTabsToRightInPane}
         onCloseOtherTabs={handleCloseOtherTabsInPane}
+        onCloseEditorTabs={handleCloseEditorTabs}
+        canCloseEditorTabs={canCloseEditorTabs}
         onCreateNewTab={handleCreateNewTab}
         buildPaneContentModel={buildDesktopPaneContentModel}
         onFocusPane={handleFocusPane}
@@ -3995,6 +4027,8 @@ function WorkspaceScreenContent({
     handleCloseTabsToLeftInPane,
     handleCloseTabsToRightInPane,
     handleCloseOtherTabsInPane,
+    handleCloseEditorTabs,
+    canCloseEditorTabs,
     handleCreateNewTab,
     buildDesktopPaneContentModel,
     handleFocusPane,
@@ -4039,6 +4073,8 @@ function WorkspaceScreenContent({
           onCloseTabsAbove={handleCloseTabsToLeft}
           onCloseTabsBelow={handleCloseTabsToRight}
           onCloseOtherTabs={handleCloseOtherTabs}
+          onCloseEditorTabs={handleCloseEditorTabs}
+          canCloseEditorTabs={canCloseEditorTabs}
         />
       ) : null}
 
@@ -4062,6 +4098,8 @@ function WorkspaceScreenContent({
             onCloseTabsToLeft={handleCloseTabsToLeft}
             onCloseTabsToRight={handleCloseTabsToRight}
             onCloseOtherTabs={handleCloseOtherTabs}
+            onCloseEditorTabs={handleCloseEditorTabs}
+            canCloseEditorTabs={canCloseEditorTabs}
             onCreateNewTab={handleCreateNewTab}
             onReorderTabs={handleReorderTabsInFocusedPane}
             focusModeEnabled={desktopFocusModeEnabled}

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildWorkspaceDesktopTabActions,
@@ -62,9 +63,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     const closeEditorTabsEntry = entries.find(
       (entry) => entry.kind === "item" && entry.key === "close-editor-tabs",
     );
-    if (!closeEditorTabsEntry || closeEditorTabsEntry.kind !== "item") {
-      throw new Error("Close editor tabs entry missing");
-    }
+    assert(closeEditorTabsEntry?.kind === "item", "Close editor tabs entry missing");
     expect(closeEditorTabsEntry.disabled).toBe(false);
     closeEditorTabsEntry.onSelect();
     expect(onCloseEditorTabs).toHaveBeenCalledTimes(1);

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -25,6 +25,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
     const onCloseTabsBefore = vi.fn();
     const onCloseTabsAfter = vi.fn();
     const onCloseOtherTabs = vi.fn();
+    const onCloseEditorTabs = vi.fn();
 
     const entries = buildWorkspaceTabMenuEntries({
       surface: "desktop",
@@ -42,6 +43,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore,
       onCloseTabsAfter,
       onCloseOtherTabs,
+      onCloseEditorTabs,
+      canCloseEditorTabs: true,
     });
 
     expect(entries.filter((entry) => entry.kind === "item").map((entry) => entry.label)).toEqual([
@@ -51,9 +54,50 @@ describe("buildWorkspaceTabMenuEntries", () => {
       "Close to the left",
       "Close to the right",
       "Close other tabs",
+      "Close editor tabs",
       "Reload agent",
       "Close",
     ]);
+
+    const closeEditorTabsEntry = entries.find(
+      (entry) => entry.kind === "item" && entry.key === "close-editor-tabs",
+    );
+    if (!closeEditorTabsEntry || closeEditorTabsEntry.kind !== "item") {
+      throw new Error("Close editor tabs entry missing");
+    }
+    expect(closeEditorTabsEntry.disabled).toBe(false);
+    closeEditorTabsEntry.onSelect();
+    expect(onCloseEditorTabs).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables close editor tabs when the workspace has no editor tabs", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "desktop",
+      tab: createAgentTab(),
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-context-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      onCopyTerminalId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: false,
+    });
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        kind: "item",
+        key: "close-editor-tabs",
+        disabled: true,
+      }),
+    );
   });
 
   it("uses stacked ordering labels for mobile menus", () => {
@@ -73,6 +117,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     });
 
     expect(entries.filter((entry) => entry.kind === "item").map((entry) => entry.label)).toEqual([
@@ -82,6 +128,7 @@ describe("buildWorkspaceTabMenuEntries", () => {
       "Close tabs above",
       "Close tabs below",
       "Close other tabs",
+      "Close editor tabs",
       "Reload agent",
       "Close",
     ]);
@@ -109,6 +156,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     });
 
     expect(entries.some((entry) => entry.kind === "item" && entry.label === "Copy agent id")).toBe(
@@ -138,6 +187,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     });
 
     expect(entries).toContainEqual(
@@ -168,6 +219,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     });
 
     const renameEntry = entries.find((entry) => entry.kind === "item" && entry.label === "Rename");
@@ -204,6 +257,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     });
 
     const labels = entries.filter((entry) => entry.kind === "item").map((entry) => entry.label);
@@ -255,6 +310,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     });
 
     const labels = entries.filter((entry) => entry.kind === "item").map((entry) => entry.label);
@@ -298,6 +355,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsToLeft: vi.fn(),
       onCloseTabsToRight: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     });
 
     expect(actions.closeButtonTestId).toMatch(/^workspace-working-diff-close-/);
@@ -329,6 +388,8 @@ describe("buildWorkspaceTabMenuEntries", () => {
       onCloseTabsBefore: vi.fn(),
       onCloseTabsAfter: vi.fn(),
       onCloseOtherTabs: vi.fn(),
+      onCloseEditorTabs: vi.fn(),
+      canCloseEditorTabs: true,
     };
 
     const agentEntries = buildWorkspaceTabMenuEntries({ ...sharedInput, tab: createAgentTab() });

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -16,6 +16,7 @@ export interface WorkspaceTabMenuLabels {
   closeLeft: string;
   closeRight: string;
   closeOthers: string;
+  closeEditorTabs: string;
   reloadAgent: string;
   reloadAgentTooltip: string;
   close: string;
@@ -32,6 +33,7 @@ export const DEFAULT_WORKSPACE_TAB_MENU_LABELS: WorkspaceTabMenuLabels = {
   closeLeft: i18n.t("workspace.tabs.menu.closeLeft"),
   closeRight: i18n.t("workspace.tabs.menu.closeRight"),
   closeOthers: i18n.t("workspace.tabs.menu.closeOthers"),
+  closeEditorTabs: i18n.t("workspace.tabs.menu.closeEditorTabs"),
   reloadAgent: i18n.t("workspace.tabs.menu.reloadAgent"),
   reloadAgentTooltip: i18n.t("workspace.tabs.menu.reloadAgentTooltip"),
   close: i18n.t("workspace.tabs.menu.close"),
@@ -48,6 +50,7 @@ export type WorkspaceTabMenuEntry =
         | "arrow-left-to-line"
         | "arrow-right-to-line"
         | "copy-x"
+        | "panel-top-close"
         | "pencil"
         | "x";
       hint?: string;
@@ -78,6 +81,8 @@ interface BuildWorkspaceTabMenuEntriesInput {
   onCloseTabsBefore: (tabId: string) => Promise<void> | void;
   onCloseTabsAfter: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  onCloseEditorTabs: () => Promise<void> | void;
+  canCloseEditorTabs: boolean;
   labels?: WorkspaceTabMenuLabels;
 }
 
@@ -95,6 +100,8 @@ interface BuildWorkspaceDesktopTabActionsInput {
   onCloseTabsToLeft: (tabId: string) => Promise<void> | void;
   onCloseTabsToRight: (tabId: string) => Promise<void> | void;
   onCloseOtherTabs: (tabId: string) => Promise<void> | void;
+  onCloseEditorTabs: () => Promise<void> | void;
+  canCloseEditorTabs: boolean;
   labels?: WorkspaceTabMenuLabels;
 }
 
@@ -182,6 +189,8 @@ export function buildWorkspaceTabMenuEntries(
     onCloseTabsBefore,
     onCloseTabsAfter,
     onCloseOtherTabs,
+    onCloseEditorTabs,
+    canCloseEditorTabs,
   } = input;
   const labels = input.labels ?? DEFAULT_WORKSPACE_TAB_MENU_LABELS;
   const isFirstTab = index === 0;
@@ -293,6 +302,17 @@ export function buildWorkspaceTabMenuEntries(
       void onCloseOtherTabs(tab.tabId);
     },
   });
+  entries.push({
+    kind: "item",
+    key: "close-editor-tabs",
+    label: labels.closeEditorTabs,
+    icon: "panel-top-close",
+    disabled: !canCloseEditorTabs,
+    testID: `${menuTestIDBase}-close-editor-tabs`,
+    onSelect: () => {
+      void onCloseEditorTabs();
+    },
+  });
   if (tab.target.kind === "agent") {
     const { agentId } = tab.target;
     entries.push({
@@ -343,6 +363,8 @@ export function buildWorkspaceDesktopTabActions(
       onCloseTabsBefore: input.onCloseTabsToLeft,
       onCloseTabsAfter: input.onCloseTabsToRight,
       onCloseOtherTabs: input.onCloseOtherTabs,
+      onCloseEditorTabs: input.onCloseEditorTabs,
+      canCloseEditorTabs: input.canCloseEditorTabs,
       labels: input.labels,
     }),
     closeButtonTestId: getCloseButtonTestId(input.tab),

--- a/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.test.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.test.tsx
@@ -150,6 +150,8 @@ function renderAccessory(
     onCloseTabsBefore: vi.fn(),
     onCloseTabsAfter: vi.fn(),
     onCloseOtherTabs: vi.fn(),
+    onCloseEditorTabs: vi.fn(),
+    canCloseEditorTabs: true,
   });
 
   const container = document.createElement("div");


### PR DESCRIPTION
### Linked issue

No matching open issue found.

### Type of change

- [ ] Bug fix
- [x] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

- Adds **Close editor tabs** to workspace tab menus. It closes file, diff, browser, preview, setup, and other editor tabs while leaving agent, draft, subagent, and terminal tabs open.
- Reuses the existing bulk and single-tab cleanup path for unsaved changes, browser teardown, persisted layout state, and active-tab reselection.
- Disables the action when there are no editor tabs to close.
- Opens the existing new agent, terminal, browser, and terminal-profile actions when right-clicking empty space in the desktop tab strip.

### How did you verify it

- Tab menu and bulk-close coverage: 16 unit tests passed.
- Empty tab-strip Playwright regression: 1 test passed.
- Full launcher-tab Playwright spec: 9 passed, 2 existing skips.
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `git diff --check`

### Risk surface

Client only. The close action uses the existing cleanup and confirmation path, and the empty-strip menu reuses the existing creation actions. There is no protocol or persisted-data shape change.

### Screenshots

<img width="1480" height="622" alt="CleanShot 2026-08-11 at 10 02 50@2x" src="https://github.com/user-attachments/assets/2c18649e-da90-4d81-a224-9407f361e814" />


### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
