### PR TITLE
feat(app): keep a Claude plan readable after you answer it

### DIFF
--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -3078,6 +3078,38 @@ interface ToolCallProps {
   maxDetailHeight?: number;
 }
 
+interface PlanCardPresentation {
+  outcome?: "approved" | "rejected" | "superseded";
+  collapsible: boolean;
+}
+
+// `plan_approval` is Claude's plan, anchored at the ExitPlanMode position. While it's running
+// the plan is pending and shown by the permission card, so nothing renders here (no duplicate);
+// once it resolves, the same item flips in place to the decided card. The decision maps from the
+// terminal status (completed -> approved, failed -> rejected, canceled -> superseded). Other plan
+// cards (e.g. Codex's inline plan) stay as-is. Returns null when the card must not render.
+function resolvePlanCardPresentation(
+  toolName: string,
+  status: ToolCallProps["status"],
+): PlanCardPresentation | null {
+  if (toolName !== "plan_approval") {
+    return { collapsible: false };
+  }
+  if (status === "failed") {
+    return { outcome: "rejected", collapsible: true };
+  }
+  if (status === "canceled") {
+    return { outcome: "superseded", collapsible: true };
+  }
+  if (status === "completed") {
+    return { outcome: "approved", collapsible: true };
+  }
+  // Still running. Rendering it here would double up with the permission card for the whole
+  // time the plan is pending, which is every plan. The cost is that a plan whose daemon was
+  // killed before any tool_result stays running forever and never gets a card.
+  return null;
+}
+
 export const ToolCall = memo(function ToolCall({
   toolName,
   args,
@@ -3208,9 +3240,15 @@ export const ToolCall = memo(function ToolCall({
   ]);
 
   if (presentation.isPlan && effectiveDetail?.type === "plan") {
+    const plan = resolvePlanCardPresentation(toolName, status);
+    if (!plan) {
+      return null;
+    }
     return (
       <PlanCard
         text={effectiveDetail.text}
+        outcome={plan.outcome}
+        collapsible={plan.collapsible}
         testID="timeline-plan-card"
         disableOuterSpacing={disableOuterSpacing}
       />

--- a/packages/app/src/components/plan-card.tsx
+++ b/packages/app/src/components/plan-card.tsx
@@ -1,10 +1,29 @@
-import { useMemo, type ReactNode } from "react";
-import { Text, View, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+  Pressable,
+  Text,
+  View,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from "react-native";
 import Markdown, { type ASTNode } from "react-native-markdown-display";
-import { StyleSheet, useUnistyles } from "react-native-unistyles";
+import { ChevronRight, ClipboardList } from "lucide-react-native";
+import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles";
 import { useTranslation } from "react-i18next";
+import { isNative } from "@/constants/platform";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import type { Theme } from "@/styles/theme";
 import { createMarkdownStyles } from "@/styles/markdown-styles";
 import { getMarkdownListMarker } from "@/utils/markdown-list";
+import { splitPlanHeading } from "@/utils/plan-heading";
+
+type PlanOutcome = "approved" | "rejected" | "superseded";
+
+const ThemedChevronRight = withUnistyles(ChevronRight);
+const ThemedClipboardList = withUnistyles(ClipboardList);
+const mutedIconColor = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const foregroundIconColor = (theme: Theme) => ({ color: theme.colors.foreground });
 
 type MarkdownRuleStyles = Record<string, TextStyle & ViewStyle & { [key: string]: unknown }>;
 
@@ -179,6 +198,8 @@ export function PlanCard({
   description,
   text,
   footer,
+  outcome,
+  collapsible = false,
   disableOuterSpacing = false,
   testID,
 }: {
@@ -186,6 +207,8 @@ export function PlanCard({
   description?: string;
   text: string;
   footer?: ReactNode;
+  outcome?: PlanOutcome;
+  collapsible?: boolean;
   disableOuterSpacing?: boolean;
   testID?: string;
 }) {
@@ -193,7 +216,69 @@ export function PlanCard({
   const { t } = useTranslation();
   const markdownStyles = createMarkdownStyles(theme);
   const markdownRules = createPlanMarkdownRules();
-  const resolvedTitle = title ?? t("agentStream.permission.plan");
+  const { planHeading, bodyText } = useMemo(
+    () => (collapsible ? splitPlanHeading(text) : { planHeading: undefined, bodyText: text }),
+    [collapsible, text],
+  );
+  const resolvedTitle = title ?? planHeading ?? t("agentStream.permission.plan");
+  // Collapsible cards (resolved plans in the timeline) start collapsed so the timeline
+  // stays scannable; the live permission card is never collapsible.
+  const [expanded, setExpanded] = useState(false);
+  // Mirror the tool-call badge: a left icon slot that swaps to the expand chevron on
+  // hover (web only — native always shows the icon and taps to expand).
+  const [isHovered, setIsHovered] = useState(false);
+  const showBody = !collapsible || expanded;
+  const outcomeMeta = useMemo(() => {
+    if (!outcome) {
+      return null;
+    }
+    if (outcome === "approved") {
+      return {
+        backgroundColor: theme.colors.statusSuccess,
+        color: "#ffffff",
+        label: t("agentStream.permission.planApproved"),
+      };
+    }
+    if (outcome === "rejected") {
+      return {
+        backgroundColor: theme.colors.statusDanger,
+        color: "#ffffff",
+        label: t("agentStream.permission.planRejected"),
+      };
+    }
+    return {
+      backgroundColor: theme.colors.surface3,
+      color: theme.colors.foregroundMuted,
+      label: t("agentStream.permission.planDismissed"),
+    };
+  }, [
+    outcome,
+    theme.colors.statusSuccess,
+    theme.colors.statusDanger,
+    theme.colors.surface3,
+    theme.colors.foregroundMuted,
+    t,
+  ]);
+  const outcomePillStyle = useMemo(
+    () =>
+      outcomeMeta ? [styles.outcomePill, { backgroundColor: outcomeMeta.backgroundColor }] : null,
+    [outcomeMeta],
+  );
+  const outcomeTextStyle = useMemo(
+    () => (outcomeMeta ? [styles.outcomeText, { color: outcomeMeta.color }] : null),
+    [outcomeMeta],
+  );
+  const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
+  const handleHoverIn = useCallback(() => setIsHovered(true), []);
+  const handleHoverOut = useCallback(() => setIsHovered(false), []);
+  const isCompact = useIsCompactFormFactor();
+  // Hover never fires on native, so the chevron is the only expand affordance there and has to
+  // be permanent. Same on a compact web viewport, which is touch-driven.
+  const showChevron = isHovered || isNative || isCompact;
+  const chevronStyle = useMemo(
+    () => [styles.chevron, expanded && styles.chevronExpanded],
+    [expanded],
+  );
 
   const containerStyle = useMemo(
     () => [
@@ -207,21 +292,60 @@ export function PlanCard({
     [disableOuterSpacing, theme.colors.surface1, theme.colors.border],
   );
   const titleStyle = useMemo(
-    () => [styles.title, { color: theme.colors.foreground }],
-    [theme.colors.foreground],
+    () => [styles.title, collapsible && styles.titleBold, { color: theme.colors.foreground }],
+    [collapsible, theme.colors.foreground],
   );
   const descriptionStyle = useMemo(
     () => [styles.description, { color: theme.colors.foregroundMuted }],
     [theme.colors.foregroundMuted],
   );
 
+  const headerContent = (
+    <>
+      {collapsible ? (
+        <View style={styles.iconBadge}>
+          {showChevron ? (
+            <ThemedChevronRight size={12} style={chevronStyle} uniProps={foregroundIconColor} />
+          ) : (
+            <ThemedClipboardList size={12} uniProps={mutedIconColor} />
+          )}
+        </View>
+      ) : null}
+      <Text style={titleStyle} numberOfLines={collapsible ? 2 : undefined}>
+        {resolvedTitle}
+      </Text>
+      {outcomeMeta ? (
+        <View style={outcomePillStyle} testID={`${testID ?? "plan-card"}-outcome`}>
+          <Text style={outcomeTextStyle}>{outcomeMeta.label}</Text>
+        </View>
+      ) : null}
+    </>
+  );
+
   return (
     <View testID={testID} style={containerStyle}>
-      <Text style={titleStyle}>{resolvedTitle}</Text>
-      {description ? <Text style={descriptionStyle}>{description}</Text> : null}
-      <Markdown style={markdownStyles} rules={markdownRules}>
-        {text}
-      </Markdown>
+      {collapsible ? (
+        <Pressable
+          style={styles.titleRow}
+          onPress={toggleExpanded}
+          onHoverIn={handleHoverIn}
+          onHoverOut={handleHoverOut}
+          accessibilityRole="button"
+          testID={`${testID ?? "plan-card"}-toggle`}
+        >
+          {headerContent}
+        </Pressable>
+      ) : (
+        <View style={styles.titleRow}>{headerContent}</View>
+      )}
+      {showBody ? (
+        <>
+          {description ? <Text style={descriptionStyle}>{description}</Text> : null}
+          <Markdown style={markdownStyles} rules={markdownRules}>
+            {bodyText}
+          </Markdown>
+        </>
+      ) : null}
       {footer ? <View style={styles.footer}>{footer}</View> : null}
     </View>
   );
@@ -238,13 +362,46 @@ const styles = StyleSheet.create((theme) => ({
   containerCompact: {
     marginVertical: 0,
   },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
   title: {
     fontSize: theme.fontSize.base,
     lineHeight: 22,
+    flexShrink: 1,
+  },
+  titleBold: {
+    fontWeight: "600",
   },
   description: {
     fontSize: theme.fontSize.sm,
     lineHeight: 20,
+  },
+  outcomePill: {
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: 2,
+    borderRadius: theme.spacing[2],
+  },
+  outcomeText: {
+    fontSize: theme.fontSize.xs,
+    lineHeight: 16,
+    fontWeight: "600",
+  },
+  iconBadge: {
+    width: 20,
+    height: 20,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  chevron: {
+    flexShrink: 0,
+    transform: [{ scale: 1.3 }],
+  },
+  chevronExpanded: {
+    transform: [{ scale: 1.3 }, { rotate: "90deg" }],
   },
   footer: {
     gap: theme.spacing[2],

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -201,6 +201,9 @@ export const ar: TranslationResources = {
       implement: "ينفذ",
       question: "كيف تريد المتابعة؟",
       proposedPlan: "الخطة المقترحة",
+      planApproved: "تمت الموافقة",
+      planRejected: "مرفوض",
+      planDismissed: "تم التجاهل",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -199,6 +199,9 @@ export const en = {
       implement: "Implement",
       question: "How would you like to proceed?",
       proposedPlan: "Proposed plan",
+      planApproved: "Approved",
+      planRejected: "Rejected",
+      planDismissed: "Dismissed",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -201,6 +201,9 @@ export const es: TranslationResources = {
       implement: "Implementar",
       question: "¿Cómo le gustaría proceder?",
       proposedPlan: "Plan propuesto",
+      planApproved: "Aprobado",
+      planRejected: "Rechazado",
+      planDismissed: "Descartado",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -203,6 +203,9 @@ export const fr: TranslationResources = {
       implement: "Mettre en œuvre",
       question: "Comment souhaitez-vous procéder?",
       proposedPlan: "Plan proposé",
+      planApproved: "Approuvé",
+      planRejected: "Rejeté",
+      planDismissed: "Ignoré",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -201,6 +201,9 @@ export const ja: TranslationResources = {
       implement: "実装",
       question: "どのように続けますか？",
       proposedPlan: "提案されたプラン",
+      planApproved: "承認済み",
+      planRejected: "却下済み",
+      planDismissed: "破棄済み",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -201,6 +201,9 @@ export const ko: TranslationResources = {
       implement: "구현",
       question: "어떻게 진행할까요?",
       proposedPlan: "제안된 계획",
+      planApproved: "승인됨",
+      planRejected: "거부됨",
+      planDismissed: "취소됨",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -201,6 +201,9 @@ export const ptBR: TranslationResources = {
       implement: "Implementar",
       question: "Como você quer prosseguir?",
       proposedPlan: "Plano proposto",
+      planApproved: "Aprovado",
+      planRejected: "Rejeitado",
+      planDismissed: "Descartado",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -201,6 +201,9 @@ export const ru: TranslationResources = {
       implement: "Осуществлять",
       question: "Как бы вы хотели продолжить?",
       proposedPlan: "Предлагаемый план",
+      planApproved: "Одобрено",
+      planRejected: "Отклонено",
+      planDismissed: "Отменено",
     },
   },
   agentPanel: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -201,6 +201,9 @@ export const zhCN: TranslationResources = {
       implement: "实施",
       question: "你想如何继续？",
       proposedPlan: "建议计划",
+      planApproved: "已批准",
+      planRejected: "已拒绝",
+      planDismissed: "已忽略",
     },
   },
   agentPanel: {

--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -261,6 +261,69 @@ describe("stream reducer tool call idempotency", () => {
     assert.deepStrictEqual(merged, incoming);
   });
 
+  it("lets a plan card's later status win over a dismissal", () => {
+    const callId = "toolu_plan";
+    const detail: ToolCallDetail = { type: "plan", text: "# Plan\n\n- step one" };
+    // A turn cancel dismisses the plan, then Claude's real tool_result decides it. The generic
+    // merge treats canceled as sticky, which would disagree with the server's projection and
+    // leave the live card reading Dismissed where a reload reads Approved.
+    const dismissed = reduceStreamUpdate(
+      [],
+      canonicalToolTimeline({
+        provider: "claude",
+        callId,
+        name: "plan_approval",
+        status: "canceled",
+        detail,
+      }),
+      new Date("2025-01-01T12:00:00Z"),
+    );
+    expect(findToolByCallId(dismissed, callId)?.payload.data.status).toBe("canceled");
+
+    const decided = reduceStreamUpdate(
+      dismissed,
+      canonicalToolTimeline({
+        provider: "claude",
+        callId,
+        name: "plan_approval",
+        status: "completed",
+        detail,
+      }),
+      new Date("2025-01-01T12:00:01Z"),
+    );
+
+    expect(findToolByCallId(decided, callId)?.payload.data.status).toBe("completed");
+  });
+
+  it("keeps a canceled non-plan tool call canceled when a completion follows", () => {
+    const callId = "shell-canceled";
+    const canceled = reduceStreamUpdate(
+      [],
+      canonicalToolTimeline({
+        provider: "codex",
+        callId,
+        name: "shell",
+        status: "canceled",
+        detail: { type: "shell", command: "npm test", cwd: "/tmp/repo" },
+      }),
+      new Date("2025-01-01T12:00:00Z"),
+    );
+
+    const completed = reduceStreamUpdate(
+      canceled,
+      canonicalToolTimeline({
+        provider: "codex",
+        callId,
+        name: "shell",
+        status: "completed",
+        detail: { type: "shell", command: "npm test", cwd: "/tmp/repo" },
+      }),
+      new Date("2025-01-01T12:00:01Z"),
+    );
+
+    expect(findToolByCallId(completed, callId)?.payload.data.status).toBe("canceled");
+  });
+
   it("returns the same state array when status, error, detail, and metadata are identical", () => {
     const callId = "idempotent-tool-call";
     const initialState = reduceStreamUpdate(

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -1082,13 +1082,20 @@ export function mergeAgentToolCallItem(
   timestamp: Date,
   timelineCursor?: TimelinePosition,
 ): AgentToolCallItem {
-  const mergedStatus = mergeAgentToolCallStatus(existing.payload.data.status, data.status);
+  const mergedDetail = mergeToolCallDetail(existing.payload.data.detail, data.detail);
+  // A plan card is emitted twice on purpose: a turn cancel dismisses it, then Claude's real
+  // tool_result flips it to its actual outcome. The generic merge treats canceled as sticky,
+  // which would leave the live card reading Dismissed where a reload reads Approved. The
+  // server's projection is last-status-wins (timeline-projection.ts), so match it here.
+  const mergedStatus =
+    mergedDetail.type === "plan"
+      ? data.status
+      : mergeAgentToolCallStatus(existing.payload.data.status, data.status);
   const mergedError =
     mergedStatus === "failed"
       ? (data.error ?? existing.payload.data.error ?? { message: "Tool call failed" })
       : null;
   const mergedMetadata = mergeToolCallMetadata(existing.payload.data.metadata, data.metadata);
-  const mergedDetail = mergeToolCallDetail(existing.payload.data.detail, data.detail);
 
   return {
     ...existing,

--- a/packages/app/src/utils/plan-heading.test.ts
+++ b/packages/app/src/utils/plan-heading.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { splitPlanHeading } from "./plan-heading";
+
+describe("splitPlanHeading", () => {
+  it("lifts a leading ATX heading out of the body", () => {
+    const result = splitPlanHeading("# Plan: Calculate 2 + 2\n\n## Context\nDo the thing.");
+    expect(result.planHeading).toBe("Plan: Calculate 2 + 2");
+    expect(result.bodyText).toBe("## Context\nDo the thing.");
+  });
+
+  it("skips blank lines before the heading", () => {
+    const result = splitPlanHeading("\n\n## Refactor auth\nbody");
+    expect(result.planHeading).toBe("Refactor auth");
+    expect(result.bodyText).toBe("body");
+  });
+
+  it("strips trailing closing hashes but keeps inner hashes", () => {
+    const result = splitPlanHeading("# Title with # inside ##\nbody");
+    expect(result.planHeading).toBe("Title with # inside");
+    expect(result.bodyText).toBe("body");
+  });
+
+  it("returns the text unchanged when there is no heading", () => {
+    const text = "- Step one\n- Step two";
+    const result = splitPlanHeading(text);
+    expect(result.planHeading).toBeUndefined();
+    expect(result.bodyText).toBe(text);
+  });
+
+  it("does not treat a bare hash with no text as a heading", () => {
+    const text = "#\nbody";
+    const result = splitPlanHeading(text);
+    expect(result.planHeading).toBeUndefined();
+    expect(result.bodyText).toBe(text);
+  });
+
+  it("ignores headings that are not on the first content line", () => {
+    const text = "Intro paragraph\n# Later heading";
+    const result = splitPlanHeading(text);
+    expect(result.planHeading).toBeUndefined();
+    expect(result.bodyText).toBe(text);
+  });
+
+  it("returns an empty body when the plan is only a heading", () => {
+    const result = splitPlanHeading("# Just a title");
+    expect(result.planHeading).toBe("Just a title");
+    expect(result.bodyText).toBe("");
+  });
+});

--- a/packages/app/src/utils/plan-heading.ts
+++ b/packages/app/src/utils/plan-heading.ts
@@ -1,0 +1,29 @@
+export interface SplitPlanHeading {
+  /** The first markdown heading, lifted out for use as a concise title. */
+  planHeading?: string;
+  /** The plan markdown with the leading heading removed (so it isn't shown twice). */
+  bodyText: string;
+}
+
+// Plans usually open with a markdown heading (e.g. "# Plan: Calculate 2 + 2"). Lift it
+// out as a concise title for the collapsed plan card, and drop it from the body so it
+// isn't repeated when the card is expanded. When there's no leading heading, the heading
+// is left undefined and the body is returned unchanged.
+export function splitPlanHeading(text: string): SplitPlanHeading {
+  const lines = text.split("\n");
+  let index = 0;
+  while (index < lines.length && (lines[index] ?? "").trim() === "") {
+    index += 1;
+  }
+  const headingMatch = lines[index]?.match(/^#{1,6}\s+(.+?)\s*#*\s*$/);
+  if (!headingMatch) {
+    return { bodyText: text };
+  }
+  return {
+    planHeading: headingMatch[1].trim(),
+    bodyText: lines
+      .slice(index + 1)
+      .join("\n")
+      .trimStart(),
+  };
+}

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -1405,6 +1406,13 @@ test("refuses a planFilePath outside the Claude plans directory", async () => {
     const link = path.join(plansDir, "link.md");
     fs.symlinkSync(secret, link);
     expect(internal.resolvePlanTextFromToolInput({ planFilePath: link })).toBeNull();
+    // A FIFO inside the plans directory is rejected without blocking. Without O_NONBLOCK the
+    // open would park the event loop until a writer showed up, which is never.
+    if (process.platform !== "win32") {
+      const fifo = path.join(plansDir, "fifo.md");
+      childProcess.execFileSync("mkfifo", [fifo]);
+      expect(internal.resolvePlanTextFromToolInput({ planFilePath: fifo })).toBeNull();
+    }
   } finally {
     if (previousConfigDir === undefined) {
       delete process.env.CLAUDE_CONFIG_DIR;

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -1338,9 +1338,13 @@ test("resolves the plan text from planFilePath when input.plan is empty (CC 2.0.
   const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
   sdkQueryFactory.mockImplementation(() => queryMock);
   const session = await createSession();
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-plan-"));
-  const planFile = path.join(dir, "plan.md");
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-claude-"));
+  const plansDir = path.join(configDir, "plans");
+  fs.mkdirSync(plansDir);
+  const planFile = path.join(plansDir, "plan.md");
   fs.writeFileSync(planFile, "# Plan from file\n\n- step one");
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
   try {
     const internal = asInternals<{
       resolvePlanTextFromToolInput: (input: Record<string, unknown> | null) => string | null;
@@ -1350,20 +1354,64 @@ test("resolves the plan text from planFilePath when input.plan is empty (CC 2.0.
     );
     // Missing file: the read throws and is swallowed -> no recoverable text.
     expect(
-      internal.resolvePlanTextFromToolInput({ planFilePath: path.join(dir, "gone.md") }),
+      internal.resolvePlanTextFromToolInput({ planFilePath: path.join(plansDir, "gone.md") }),
     ).toBeNull();
     // input.plan wins over the file when present.
     expect(internal.resolvePlanTextFromToolInput({ plan: "inline", planFilePath: planFile })).toBe(
       "inline",
     );
     // A non-regular path (directory) is rejected, not read — guards against FIFO/device paths.
-    expect(internal.resolvePlanTextFromToolInput({ planFilePath: dir })).toBeNull();
+    expect(internal.resolvePlanTextFromToolInput({ planFilePath: plansDir })).toBeNull();
     // An oversized file is not read, so a hostile path can't exhaust memory / stall the loop.
-    const hugeFile = path.join(dir, "huge.md");
+    const hugeFile = path.join(plansDir, "huge.md");
     fs.writeFileSync(hugeFile, "#".repeat(1024 * 1024 + 1));
     expect(internal.resolvePlanTextFromToolInput({ planFilePath: hugeFile })).toBeNull();
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+    }
+    fs.rmSync(configDir, { recursive: true, force: true });
+    await session.close();
+  }
+});
+
+test("refuses a planFilePath outside the Claude plans directory", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-claude-"));
+  const plansDir = path.join(configDir, "plans");
+  fs.mkdirSync(plansDir);
+  const secret = path.join(configDir, "secret.env");
+  fs.writeFileSync(secret, "API_KEY=super-secret");
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  try {
+    const internal = asInternals<{
+      resolvePlanTextFromToolInput: (input: Record<string, unknown> | null) => string | null;
+    }>(session);
+    // A model-named path outside the plans directory is never read, so a plan card can't be
+    // used to surface a file the agent's own Read rules would have denied.
+    expect(internal.resolvePlanTextFromToolInput({ planFilePath: secret })).toBeNull();
+    // Traversal out of the plans directory is rejected too.
+    expect(
+      internal.resolvePlanTextFromToolInput({
+        planFilePath: path.join(plansDir, "..", "secret.env"),
+      }),
+    ).toBeNull();
+    // And a symlink planted inside the plans directory can't redirect the read.
+    const link = path.join(plansDir, "link.md");
+    fs.symlinkSync(secret, link);
+    expect(internal.resolvePlanTextFromToolInput({ planFilePath: link })).toBeNull();
+  } finally {
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+    }
+    fs.rmSync(configDir, { recursive: true, force: true });
     await session.close();
   }
 });

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { Logger } from "pino";
 
 import { createTestLogger } from "../../../../test-utils/test-logger.js";
@@ -1106,6 +1109,492 @@ test("plan approval exposes a resume-bypass action and can return to bypassPermi
     });
     expect(queryMock.setPermissionMode).toHaveBeenLastCalledWith("bypassPermissions");
     expect(await session.getCurrentMode()).toBe("bypassPermissions");
+  } finally {
+    await session.close();
+  }
+});
+
+type RedesignTestSession = Awaited<ReturnType<typeof createSession>>;
+
+function exitPlanModeTranscript(
+  toolUseId: string,
+  planText: string,
+  result: { content: string; isError?: boolean },
+): Record<string, unknown>[] {
+  return [
+    {
+      type: "assistant",
+      uuid: `assistant-${toolUseId}`,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: toolUseId, name: "ExitPlanMode", input: { plan: planText } },
+        ],
+      },
+    },
+    {
+      type: "user",
+      uuid: `user-${toolUseId}`,
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: toolUseId,
+            content: result.content,
+            ...(result.isError ? { is_error: true } : {}),
+          },
+        ],
+      },
+    },
+  ];
+}
+
+interface ExitPlanModeCallEntry {
+  planText: string | null;
+  supersededEmitted: boolean;
+}
+
+// Registers a plan the way the live path does: the permission callback fires from canUseTool
+// before the complete assistant message reaches handleToolUseStart, so this is routinely the
+// only write that lands before the turn is canceled.
+function rememberPlan(session: RedesignTestSession, toolUseId: string, planText: string | null) {
+  asInternals<{
+    rememberExitPlanModeCall: (id: string, text: string | null) => void;
+  }>(session).rememberExitPlanModeCall(toolUseId, planText);
+}
+
+function exitPlanModeCalls(session: RedesignTestSession): Map<string, ExitPlanModeCallEntry> {
+  return asInternals<{ exitPlanModeCalls: Map<string, ExitPlanModeCallEntry> }>(session)
+    .exitPlanModeCalls;
+}
+
+// Swaps pushToolCall for a collector so flush behaviour can be read without standing up the
+// full event pipeline.
+function capturePushedToolCalls(session: RedesignTestSession): AgentTimelineItem[] {
+  const pushed: AgentTimelineItem[] = [];
+  (
+    session as unknown as {
+      pushToolCall: (item: AgentTimelineItem | null, items?: AgentTimelineItem[]) => void;
+    }
+  ).pushToolCall = (item, items) => {
+    if (!item) return;
+    // Mirror the real signature: with a target array the item is collected there instead of
+    // being emitted, which is how handleToolResult returns its items to the caller.
+    if (items) {
+      items.push(item);
+      return;
+    }
+    pushed.push(item);
+  };
+  return pushed;
+}
+
+async function replayHistoryPlanCard(
+  session: RedesignTestSession,
+  entries: Record<string, unknown>[],
+): Promise<Extract<AgentTimelineItem, { type: "tool_call" }> | undefined> {
+  asInternals<{ ingestPersistedHistory: (content: string) => void }>(
+    session,
+  ).ingestPersistedHistory(entries.map((entry) => JSON.stringify(entry)).join("\n"));
+  // The plan replays as a running plan_approval (the tool_use) that flips to a resolved one
+  // (the tool_result); return the resolved (terminal) card.
+  let resolved: Extract<AgentTimelineItem, { type: "tool_call" }> | undefined;
+  for await (const event of session.streamHistory()) {
+    if (
+      event.type === "timeline" &&
+      event.item.type === "tool_call" &&
+      event.item.name === "plan_approval" &&
+      event.item.status !== "running"
+    ) {
+      resolved = event.item;
+    }
+  }
+  return resolved;
+}
+
+test("replays an approved ExitPlanMode from the transcript as a completed plan card", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const planText = "# Ship it\n\n- step one\n- step two";
+    const card = await replayHistoryPlanCard(
+      session,
+      exitPlanModeTranscript("toolu_approved", planText, {
+        content: "User has approved your plan. You can now start coding.",
+      }),
+    );
+    expect(card).toBeDefined();
+    expect(card).toMatchObject({ status: "completed", detail: { type: "plan", text: planText } });
+  } finally {
+    await session.close();
+  }
+});
+
+test("replays a rejected ExitPlanMode from the transcript as a failed plan card", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const planText = "# Maybe later\n\n- do the thing";
+    const card = await replayHistoryPlanCard(
+      session,
+      exitPlanModeTranscript("toolu_rejected", planText, {
+        content: "Denied by user",
+        isError: true,
+      }),
+    );
+    expect(card).toBeDefined();
+    expect(card).toMatchObject({ status: "failed", detail: { type: "plan", text: planText } });
+  } finally {
+    await session.close();
+  }
+});
+
+test("replays an interrupted ExitPlanMode from the transcript as a canceled plan card", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const planText = "# On second thought\n\n- never mind";
+    const card = await replayHistoryPlanCard(
+      session,
+      exitPlanModeTranscript("toolu_interrupted", planText, {
+        content: "[Request interrupted by user for tool use]",
+        isError: true,
+      }),
+    );
+    expect(card).toBeDefined();
+    expect(card).toMatchObject({ status: "canceled", detail: { type: "plan", text: planText } });
+  } finally {
+    await session.close();
+  }
+});
+
+test("resolves an interrupted live plan to a plan card (not a failed Tool)", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{
+      handleToolResult: (block: Record<string, unknown>, items: AgentTimelineItem[]) => void;
+    }>(session);
+    // The running plan_approval (pushed by handleToolUseStart) registered the plan text.
+    rememberPlan(session, "toolu_interrupted_plan", "# Do the thing");
+    const items: AgentTimelineItem[] = [];
+    // Interrupted plan: the tool_result arrives orphaned (cache cleared by the turn restart).
+    internal.handleToolResult(
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_interrupted_plan",
+        is_error: true,
+        content: "The user doesn't want to proceed with this tool use. The tool use was rejected.",
+      },
+      items,
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      type: "tool_call",
+      name: "plan_approval",
+      detail: { type: "plan", text: "# Do the thing" },
+    });
+  } finally {
+    await session.close();
+  }
+});
+
+test("still renders a normal orphaned failed tool_result as a tool call", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{
+      flushPendingToolCalls: () => void;
+      handleToolResult: (block: Record<string, unknown>, items: AgentTimelineItem[]) => void;
+    }>(session);
+    // A plan in the registry must not make every later orphaned result look like a plan.
+    rememberPlan(session, "toolu_unrelated_plan", "# Unrelated plan");
+    internal.flushPendingToolCalls();
+    const items: AgentTimelineItem[] = [];
+    internal.handleToolResult(
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_some_other_tool",
+        is_error: true,
+        content: "boom",
+      },
+      items,
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ type: "tool_call", status: "failed" });
+    expect(items[0]).not.toMatchObject({ name: "plan_approval" });
+  } finally {
+    await session.close();
+  }
+});
+
+test("resolves the plan text from planFilePath when input.plan is empty (CC 2.0.51+)", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paseo-plan-"));
+  const planFile = path.join(dir, "plan.md");
+  fs.writeFileSync(planFile, "# Plan from file\n\n- step one");
+  try {
+    const internal = asInternals<{
+      resolvePlanTextFromToolInput: (input: Record<string, unknown> | null) => string | null;
+    }>(session);
+    expect(internal.resolvePlanTextFromToolInput({ plan: "", planFilePath: planFile })).toBe(
+      "# Plan from file\n\n- step one",
+    );
+    // Missing file: the read throws and is swallowed -> no recoverable text.
+    expect(
+      internal.resolvePlanTextFromToolInput({ planFilePath: path.join(dir, "gone.md") }),
+    ).toBeNull();
+    // input.plan wins over the file when present.
+    expect(internal.resolvePlanTextFromToolInput({ plan: "inline", planFilePath: planFile })).toBe(
+      "inline",
+    );
+    // A non-regular path (directory) is rejected, not read — guards against FIFO/device paths.
+    expect(internal.resolvePlanTextFromToolInput({ planFilePath: dir })).toBeNull();
+    // An oversized file is not read, so a hostile path can't exhaust memory / stall the loop.
+    const hugeFile = path.join(dir, "huge.md");
+    fs.writeFileSync(hugeFile, "#".repeat(1024 * 1024 + 1));
+    expect(internal.resolvePlanTextFromToolInput({ planFilePath: hugeFile })).toBeNull();
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+    await session.close();
+  }
+});
+
+test("flushPendingToolCalls resolves an abandoned plan to a dismissed card", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{
+      toolUseCache: Map<string, { id: string; name: string; started: boolean; input: unknown }>;
+      flushPendingToolCalls: () => void;
+    }>(session);
+    const pushed = capturePushedToolCalls(session);
+    internal.toolUseCache.set("toolu_abandoned", {
+      id: "toolu_abandoned",
+      name: "ExitPlanMode",
+      started: true,
+      input: { plan: "# Abandoned plan" },
+    });
+    rememberPlan(session, "toolu_abandoned", "# Abandoned plan");
+
+    internal.flushPendingToolCalls();
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({
+      type: "tool_call",
+      name: "plan_approval",
+      status: "canceled",
+      detail: { type: "plan", text: "# Abandoned plan" },
+    });
+    // The registry deliberately survives the flush: Claude's tool_result arrives after the
+    // turn is canceled and the id is the only thing that still identifies it as a plan.
+    expect(exitPlanModeCalls(session).get("toolu_abandoned")).toMatchObject({
+      planText: "# Abandoned plan",
+      supersededEmitted: true,
+    });
+  } finally {
+    await session.close();
+  }
+});
+
+test("flushPendingToolCalls dismisses a plan that never reached the tool_use cache", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{ flushPendingToolCalls: () => void }>(session);
+    const pushed = capturePushedToolCalls(session);
+    // The live shape: the permission fired from canUseTool, so nothing ever populated
+    // toolUseCache. The old code emitted nothing at all here.
+    rememberPlan(session, "toolu_no_cache_entry", "# Uncached plan");
+
+    internal.flushPendingToolCalls();
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({
+      type: "tool_call",
+      name: "plan_approval",
+      status: "canceled",
+      detail: { type: "plan", text: "# Uncached plan" },
+    });
+  } finally {
+    await session.close();
+  }
+});
+
+test("two flushes emit exactly one dismissed card for the same plan", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{ flushPendingToolCalls: () => void }>(session);
+    const pushed = capturePushedToolCalls(session);
+    rememberPlan(session, "toolu_double_flush", "# Plan");
+
+    internal.flushPendingToolCalls();
+    internal.flushPendingToolCalls();
+
+    expect(pushed).toHaveLength(1);
+  } finally {
+    await session.close();
+  }
+});
+
+test("flushPendingToolCalls emits nothing for a plan whose text never resolved", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{ flushPendingToolCalls: () => void }>(session);
+    const pushed = capturePushedToolCalls(session);
+    rememberPlan(session, "toolu_textless", null);
+
+    internal.flushPendingToolCalls();
+
+    expect(pushed).toEqual([]);
+  } finally {
+    await session.close();
+  }
+});
+
+test("the ExitPlanMode registry is bounded and keeps the newest entries", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const max = 32;
+    const overflow = 5;
+    for (let i = 0; i < max + overflow; i += 1) {
+      rememberPlan(session, `toolu_${i}`, `# Plan ${i}`);
+    }
+    const calls = exitPlanModeCalls(session);
+    expect(calls.size).toBe(max);
+    expect(calls.has("toolu_0")).toBe(false);
+    expect(calls.has(`toolu_${overflow - 1}`)).toBe(false);
+    expect(calls.has(`toolu_${overflow}`)).toBe(true);
+    expect(calls.has(`toolu_${max + overflow - 1}`)).toBe(true);
+  } finally {
+    await session.close();
+  }
+});
+
+test("a later empty registration cannot erase resolved plan text", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    // handlePermissionRequest resolves the text from planFilePath; handleToolUseStart then
+    // arrives with an empty input.plan and must not clobber it.
+    rememberPlan(session, "toolu_upgrade_only", "# Resolved from file");
+    rememberPlan(session, "toolu_upgrade_only", null);
+    expect(exitPlanModeCalls(session).get("toolu_upgrade_only")?.planText).toBe(
+      "# Resolved from file",
+    );
+  } finally {
+    await session.close();
+  }
+});
+
+test("a plan rejected by typing a follow-up settles on the same card as a reload", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{
+      flushPendingToolCalls: () => void;
+      handleToolResult: (block: Record<string, unknown>, items: AgentTimelineItem[]) => void;
+    }>(session);
+    const planText = "# Dummy Implementation Plan\n\n- step one";
+    const pushed = capturePushedToolCalls(session);
+    // Typing a follow-up cancels the turn before Claude's tool_result arrives.
+    rememberPlan(session, "toolu_typed_reject", planText);
+    internal.flushPendingToolCalls();
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({
+      name: "plan_approval",
+      status: "canceled",
+      callId: "toolu_typed_reject",
+    });
+
+    // The real tool_result lands after the flush and must flip the card in place.
+    const items: AgentTimelineItem[] = [];
+    internal.handleToolResult(
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_typed_reject",
+        is_error: true,
+        content: "The user doesn't want to proceed with this tool use. The tool use was rejected.",
+      },
+      items,
+    );
+    expect(items).toHaveLength(1);
+    const live = items[0];
+    expect(live).toMatchObject({
+      type: "tool_call",
+      name: "plan_approval",
+      status: "failed",
+      callId: "toolu_typed_reject",
+      detail: { type: "plan", text: planText },
+    });
+    // The regression this guards: the result used to fall through to a generic tool row.
+    expect(live).not.toMatchObject({ name: "tool" });
+    expect(live).not.toMatchObject({ detail: { type: "unknown" } });
+
+    // Live and reload must agree.
+    const replayed = await replayHistoryPlanCard(
+      session,
+      exitPlanModeTranscript("toolu_replayed_reject", planText, {
+        content: "The user doesn't want to proceed with this tool use. The tool use was rejected.",
+        isError: true,
+      }),
+    );
+    expect(replayed).toBeDefined();
+    expect(replayed?.status).toBe(
+      (live as Extract<AgentTimelineItem, { type: "tool_call" }>).status,
+    );
+    expect(replayed?.detail).toEqual(
+      (live as Extract<AgentTimelineItem, { type: "tool_call" }>).detail,
+    );
+  } finally {
+    await session.close();
+  }
+});
+
+test("classifies an array-shaped interrupted result as superseded (canceled)", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+  const session = await createSession();
+  try {
+    const internal = asInternals<{
+      handleToolResult: (block: Record<string, unknown>, items: AgentTimelineItem[]) => void;
+    }>(session);
+    rememberPlan(session, "toolu_array_interrupt", "# Plan");
+    const items: AgentTimelineItem[] = [];
+    // Claude commonly sends tool_result content as an array of text blocks.
+    internal.handleToolResult(
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_array_interrupt",
+        is_error: true,
+        content: [{ type: "text", text: "[Request interrupted by user for tool use]" }],
+      },
+      items,
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      type: "tool_call",
+      name: "plan_approval",
+      status: "canceled",
+    });
   } finally {
     await session.close();
   }

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -375,6 +375,28 @@ function isInsideDir(candidate: string, dir: string): boolean {
   return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
+// Reads a plan file whose path has already passed the containment check. The descriptor is
+// opened once and stat'd and read through that same descriptor, so the file cannot be swapped
+// between the check and the read. O_NOFOLLOW rejects a path that became a symlink after it was
+// resolved; O_NONBLOCK stops a FIFO from parking the event loop before fstat can reject it.
+// Both are absent on Windows, where the containment check and the fstat still apply.
+function readContainedPlanFile(resolved: string): string | null {
+  const flags =
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0) | (fs.constants.O_NONBLOCK ?? 0);
+  const fd = fs.openSync(resolved, flags);
+  try {
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.size === 0 || stat.size > MAX_PLAN_FILE_BYTES) {
+      return null;
+    }
+    const buffer = Buffer.alloc(stat.size);
+    const read = fs.readSync(fd, buffer, 0, stat.size, 0);
+    return buffer.subarray(0, read).toString("utf8");
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 // The ExitPlanMode registry outlives the turn (see exitPlanModeCalls), so it needs its own
 // bound. A session realistically holds a handful of plans; 32 is far above that and keeps a
 // pathological agent from growing the map without limit.
@@ -5176,14 +5198,9 @@ class ClaudeAgentSession implements AgentSession {
           );
           return null;
         }
-        // Only read a regular file within a sane size, so a FIFO/device path can't block the
-        // event loop and a huge file can't exhaust memory.
-        const stat = fs.statSync(resolved);
-        if (stat.isFile() && stat.size > 0 && stat.size <= MAX_PLAN_FILE_BYTES) {
-          const text = fs.readFileSync(resolved, "utf8");
-          if (text.trim().length > 0) {
-            return text;
-          }
+        const text = readContainedPlanFile(resolved);
+        if (text && text.trim().length > 0) {
+          return text;
         }
       } catch (error) {
         // A deleted or unreadable plan file is expected (plans outlive their files), so this

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -356,6 +356,80 @@ const CLAUDE_ROOT_ONLY_COMMANDS = new Set([
 const INTERRUPT_TOOL_USE_PLACEHOLDER = "[Request interrupted by user for tool use]";
 const INTERRUPT_PLACEHOLDER_PATTERN = /^\[Request interrupted by user(?:[^\]]*)\]$/;
 const NO_RESPONSE_REQUESTED_PLACEHOLDER = "No response requested.";
+
+// Cap for reading a model-supplied planFilePath. A plan is markdown text; 1 MiB is generous
+// and bounds a hostile/corrupt path from exhausting memory or stalling the event loop.
+const MAX_PLAN_FILE_BYTES = 1024 * 1024;
+
+// The ExitPlanMode registry outlives the turn (see exitPlanModeCalls), so it needs its own
+// bound. A session realistically holds a handful of plans; 32 is far above that and keeps a
+// pathological agent from growing the map without limit.
+const MAX_TRACKED_EXIT_PLAN_MODE_CALLS = 32;
+
+type PlanCardOutcome = "approved" | "rejected" | "superseded";
+
+interface ExitPlanModeCall {
+  /** Null until a write site resolves the plan text; a textless plan emits no card. */
+  planText: string | null;
+  /** Latched once a flush emitted the superseded card, so a second flush can't duplicate it. */
+  supersededEmitted: boolean;
+}
+
+// The running plan card anchored at the ExitPlanMode position. Hidden by the client while
+// running (the pending plan is shown by the permission card); its tool_result flips it in
+// place to the resolved card. Same callId (the ExitPlanMode tool_use id) is the anchor.
+function buildRunningPlanCardItem(
+  callId: string,
+  planText: string,
+): Extract<AgentTimelineItem, { type: "tool_call" }> {
+  return {
+    type: "tool_call",
+    callId,
+    name: "plan_approval",
+    detail: { type: "plan", text: planText },
+    status: "running",
+    error: null,
+  };
+}
+
+// Builds the resolved-plan card timeline item (used by handleExitPlanModeResult for both the
+// live stream and a transcript replay). The decision rides the tool-call status:
+// approved -> completed, rejected -> failed, superseded (interrupt) -> canceled.
+function buildPlanCardItem(
+  callId: string,
+  planText: string,
+  outcome: PlanCardOutcome,
+): Extract<AgentTimelineItem, { type: "tool_call" }> {
+  const detail = { type: "plan" as const, text: planText };
+  if (outcome === "approved") {
+    return {
+      type: "tool_call",
+      callId,
+      name: "plan_approval",
+      detail,
+      status: "completed",
+      error: null,
+    };
+  }
+  if (outcome === "rejected") {
+    return {
+      type: "tool_call",
+      callId,
+      name: "plan_approval",
+      detail,
+      status: "failed",
+      error: { message: "Plan rejected" },
+    };
+  }
+  return {
+    type: "tool_call",
+    callId,
+    name: "plan_approval",
+    detail,
+    status: "canceled",
+    error: null,
+  };
+}
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface SlashCommandInvocation {
@@ -688,6 +762,19 @@ function splitClaudeToolResultImages(content: unknown): {
     return block;
   });
   return { images, text };
+}
+
+// Renders the images pulled out of a tool_result as assistant markdown, appended after the
+// tool_call they came from (matching how Codex emits them).
+function pushToolResultImages(images: ProviderImageOutput[], items: AgentTimelineItem[]): void {
+  for (const image of images) {
+    const imageItem = renderProviderImageOutputAsAssistantMarkdown(image, {
+      materialize: materializeProviderImage,
+    });
+    if (imageItem) {
+      items.push(imageItem);
+    }
+  }
 }
 
 function normalizeClaudeTranscriptText(value: unknown): string | null {
@@ -2005,6 +2092,15 @@ class ClaudeAgentSession implements AgentSession {
   private planResumeMode: PermissionMode | null = null;
   private availableModes: AgentMode[] = DEFAULT_MODES;
   private toolUseCache = new Map<string, ToolUseCacheEntry>();
+  // Every ExitPlanMode tool_use this session has seen, keyed by tool_use id.
+  //
+  // Deliberately session-scoped: unlike toolUseCache this survives flushPendingToolCalls,
+  // because the turn is what ends, not the session. Typing a follow-up cancels the turn
+  // *before* Claude's tool_result arrives, so if this were cleared on flush the result would
+  // land unidentifiable — tool_result blocks carry no tool_name — and degrade into a generic
+  // "tool" row instead of the resolved plan card. Bounded by
+  // MAX_TRACKED_EXIT_PLAN_MODE_CALLS; pruned per id on resolution and cleared on close().
+  private exitPlanModeCalls = new Map<string, ExitPlanModeCall>();
   private toolUseIndexToId = new Map<number, string>();
   private toolUseInputBuffers = new Map<string, string>();
   private pendingPermissions = new Map<string, PendingPermission>();
@@ -2413,17 +2509,8 @@ class ClaudeAgentSession implements AgentSession {
           ? "bypassPermissions"
           : "acceptEdits";
         await this.setMode(targetMode);
-        this.pushToolCall(
-          mapClaudeCompletedToolCall({
-            name: "plan_approval",
-            callId: pending.request.id,
-            input: pending.request.input ?? null,
-            output: {
-              approved: true,
-              actionId: selectedActionId ?? "implement",
-            },
-          }),
-        );
+        // The resolved plan card comes from ExitPlanMode's tool_result (handleToolResult),
+        // which flips the running plan_approval card in place — no separate push needed.
       }
       const updatedInput =
         pending.request.kind === "question"
@@ -2508,6 +2595,7 @@ class ClaudeAgentSession implements AgentSession {
     this.cancelCurrentTurn = null;
     this.turnState = "idle";
     this.sidechainTracker.clear();
+    this.exitPlanModeCalls.clear();
     this.taskProtocolSource.reset();
     this.input?.end();
     this.query?.close?.();
@@ -4352,8 +4440,27 @@ class ClaudeAgentSession implements AgentSession {
     if (options.toolUseID) {
       metadata.toolUseId = options.toolUseID;
     }
-    if (toolName === "ExitPlanMode" && typeof input.plan === "string") {
-      metadata.planText = input.plan;
+    if (toolName === "ExitPlanMode") {
+      // Resolve the plan text, falling back to the saved plan file — Claude Code 2.0.51+
+      // leaves input.plan empty and writes a planFilePath. Without the fallback the
+      // permission card and the anchored running card would be blank on that path.
+      const planText = this.resolvePlanTextFromToolInput(input);
+      if (planText) {
+        metadata.planText = planText;
+      }
+      if (options.toolUseID) {
+        // Register unconditionally. Live, the permission fires from canUseTool before the
+        // complete assistant message reaches handleToolUseStart, so this is routinely the
+        // only write that happens before a turn cancel — and the id is what keeps the later
+        // tool_result identifiable as a plan.
+        this.rememberExitPlanModeCall(options.toolUseID, planText);
+        if (planText) {
+          // Anchor (or refresh) the running plan card at this position with the complete plan
+          // text. callId = the ExitPlanMode tool_use id, so its tool_result flips it in place
+          // (and updates any partial card handleToolUseStart pushed from streamed input).
+          this.pushToolCall(buildRunningPlanCardItem(options.toolUseID, planText));
+        }
+      }
     }
     const toolDetail =
       kind === "tool"
@@ -4428,16 +4535,33 @@ class ClaudeAgentSession implements AgentSession {
 
   private flushPendingToolCalls() {
     for (const [id, entry] of this.toolUseCache) {
-      if (entry.started) {
-        this.pushToolCall(
-          mapClaudeCanceledToolCall({
-            name: entry.name,
-            callId: id,
-            input: entry.input ?? null,
-            output: null,
-          }),
-        );
+      // Plans are resolved from exitPlanModeCalls below, never from this loop: the cache entry
+      // is often missing entirely (the permission fires before the assistant message lands) and
+      // a plan must never fall through to a raw canceled ExitPlanMode row.
+      if (entry.name === "ExitPlanMode") {
+        continue;
       }
+      if (!entry.started) {
+        continue;
+      }
+      this.pushToolCall(
+        mapClaudeCanceledToolCall({
+          name: entry.name,
+          callId: id,
+          input: entry.input ?? null,
+          output: null,
+        }),
+      );
+    }
+    // An abandoned plan resolves as a dismissed card rather than vanishing. If Claude's
+    // tool_result still arrives it shares this callId and flips the card in place to its real
+    // outcome, so the registry deliberately survives the flush.
+    for (const [id, call] of this.exitPlanModeCalls) {
+      if (call.planText === null || call.supersededEmitted) {
+        continue;
+      }
+      call.supersededEmitted = true;
+      this.pushToolCall(buildPlanCardItem(id, call.planText, "superseded"));
     }
     this.toolUseCache.clear();
     this.sidechainTracker.clear();
@@ -4541,6 +4665,15 @@ class ClaudeAgentSession implements AgentSession {
       pending.cleanup?.();
       pending.reject(error);
       this.pendingPermissions.delete(id);
+      // Clients drop a permission card only on permission_resolved (respondToPermission emits
+      // it on the answered path). Without this, dropping the request server-side leaves the
+      // card on screen forever — visible when a typed follow-up cancels a pending plan.
+      this.pushEvent({
+        type: "permission_resolved",
+        provider: "claude",
+        requestId: id,
+        resolution: { behavior: "deny", message: error.message, interrupt: true },
+      });
     }
   }
 
@@ -4864,6 +4997,23 @@ class ClaudeAgentSession implements AgentSession {
     }
     entry.started = true;
     this.toolUseCache.set(entry.id, entry);
+    // Render the plan as a single `plan_approval` card anchored at this position. It stays
+    // hidden (running) while the permission is pending, then its tool_result flips it to the
+    // resolved card (approved/rejected) in place — identically for the live stream and a
+    // transcript replay, so the card is always correctly ordered. The plan text is cached by
+    // tool_use id so an interrupted plan (whose entry the turn restart clears) can still
+    // resolve.
+    if (entry.name === "ExitPlanMode") {
+      // Live, the tool_use input streams in after this fires, so the plan text may not be
+      // ready yet — handlePermissionRequest anchors the card with the full input. On a
+      // transcript replay the input is already complete, so anchor it here.
+      const planText = this.resolvePlanTextFromToolInput(entry.input);
+      this.rememberExitPlanModeCall(entry.id, planText);
+      if (planText) {
+        this.pushToolCall(buildRunningPlanCardItem(entry.id, planText), items);
+      }
+      return;
+    }
     this.pushToolCall(
       mapClaudeRunningToolCall({
         name: entry.name,
@@ -4878,6 +5028,11 @@ class ClaudeAgentSession implements AgentSession {
   private handleToolResult(block: ClaudeContentChunk, items: AgentTimelineItem[]): void {
     const entry =
       typeof block.tool_use_id === "string" ? this.toolUseCache.get(block.tool_use_id) : undefined;
+    // ExitPlanMode flips its running plan_approval card to the resolved card in place
+    // (approved/rejected/superseded) — same path live and on transcript replay. See the method.
+    if (this.handleExitPlanModeResult(entry, block, items)) {
+      return;
+    }
     const blockToolName = typeof block.tool_name === "string" ? block.tool_name : undefined;
     const toolName = entry?.name ?? blockToolName ?? "tool";
     const callId =
@@ -4913,18 +5068,114 @@ class ClaudeAgentSession implements AgentSession {
       );
     }
 
-    for (const image of images) {
-      const imageItem = renderProviderImageOutputAsAssistantMarkdown(image, {
-        materialize: materializeProviderImage,
-      });
-      if (imageItem) {
-        items.push(imageItem);
-      }
-    }
+    pushToolResultImages(images, items);
 
     if (typeof block.tool_use_id === "string") {
       this.toolUseCache.delete(block.tool_use_id);
     }
+  }
+
+  // Flips the running `plan_approval` card (pushed by handleToolUseStart) to its resolved
+  // state when ExitPlanMode's tool_result arrives — same callId, so it updates in place at
+  // the plan's position. Outcome comes from the result: success -> approved, interrupt ->
+  // superseded, else rejected. This is the single source of the resolved card for both the
+  // live stream and a transcript replay. Returns true when handled.
+  private handleExitPlanModeResult(
+    entry: ToolUseCacheEntry | undefined,
+    block: ClaudeContentChunk,
+    items: AgentTimelineItem[],
+  ): boolean {
+    const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : null;
+    const isExitPlanMode =
+      entry?.name === "ExitPlanMode" ||
+      (toolUseId !== null && this.exitPlanModeCalls.has(toolUseId));
+    if (!isExitPlanMode) {
+      return false;
+    }
+    const callId = toolUseId ?? entry?.id ?? null;
+    const planText =
+      (entry ? this.resolvePlanTextFromToolInput(entry.input) : null) ??
+      (toolUseId !== null ? (this.exitPlanModeCalls.get(toolUseId)?.planText ?? null) : null);
+    if (callId && planText) {
+      this.pushToolCall(
+        buildPlanCardItem(callId, planText, this.resolveExitPlanModeHistoryOutcome(block)),
+        items,
+      );
+    } else {
+      // Identified as a plan but the text never resolved. Emit nothing and still return true:
+      // a blank plan card reads worse than none, and claiming the result suppresses the
+      // generic "tool" row it would otherwise fall through to.
+      this.logger.debug(
+        { toolUseId },
+        "ExitPlanMode result without resolvable plan text; emitting no plan card",
+      );
+    }
+    if (toolUseId !== null) {
+      this.toolUseCache.delete(toolUseId);
+      this.sidechainTracker.delete(toolUseId);
+      this.exitPlanModeCalls.delete(toolUseId);
+    }
+    return true;
+  }
+
+  // Records an ExitPlanMode tool_use id so its tool_result stays identifiable, and upgrades the
+  // plan text when a later write site resolves it. Registration is unconditional: the id alone
+  // is what keeps the result out of the generic tool-call branch, even before any text exists.
+  private rememberExitPlanModeCall(toolUseId: string, planText: string | null): void {
+    const existing = this.exitPlanModeCalls.get(toolUseId);
+    if (existing) {
+      // Only ever upgrade. A late handleToolUseStart carrying an empty input.plan must not
+      // erase text handlePermissionRequest already resolved from planFilePath.
+      if (planText) {
+        existing.planText = planText;
+      }
+      return;
+    }
+    this.exitPlanModeCalls.set(toolUseId, { planText, supersededEmitted: false });
+    // Map iterates in insertion order, so the oldest entry is the front one.
+    while (this.exitPlanModeCalls.size > MAX_TRACKED_EXIT_PLAN_MODE_CALLS) {
+      const oldest = this.exitPlanModeCalls.keys().next();
+      if (oldest.done) {
+        break;
+      }
+      this.exitPlanModeCalls.delete(oldest.value);
+    }
+  }
+
+  private resolvePlanTextFromToolInput(input: AgentMetadata | null | undefined): string | null {
+    const plan = input?.plan;
+    if (typeof plan === "string" && plan.trim().length > 0) {
+      return plan;
+    }
+    // Claude Code 2.0.51+ may write the plan to a file and leave input.plan empty.
+    const filePath = input?.planFilePath;
+    if (typeof filePath === "string" && filePath.length > 0) {
+      try {
+        // The path is model-supplied; only read a regular file within a sane size so a
+        // FIFO/device path can't block the event loop and a huge file can't exhaust memory.
+        const stat = fs.statSync(filePath);
+        if (stat.isFile() && stat.size > 0 && stat.size <= MAX_PLAN_FILE_BYTES) {
+          const text = fs.readFileSync(filePath, "utf8");
+          if (text.trim().length > 0) {
+            return text;
+          }
+        }
+      } catch {
+        // Plan file may be gone / unreadable; treat as no recoverable text.
+      }
+    }
+    return null;
+  }
+
+  private resolveExitPlanModeHistoryOutcome(block: ClaudeContentChunk): PlanCardOutcome {
+    if (!block.is_error) {
+      return "approved";
+    }
+    const resultText = coerceToolResultContentToString(block.content);
+    if (/\[Request interrupted by user/i.test(resultText)) {
+      return "superseded";
+    }
+    return "rejected";
   }
 
   private buildToolOutput(
@@ -5204,6 +5455,18 @@ class ClaudeAgentSession implements AgentSession {
     }
     this.applyToolInput(entry, normalized);
     this.toolUseCache.set(toolId, entry);
+    if (entry.name === "ExitPlanMode") {
+      // Keep ExitPlanMode as a single plan_approval card (see handleToolUseStart); never emit
+      // the raw ExitPlanMode running row. Anchor from the streamed input.plan once present;
+      // the planFilePath fallback runs later in handlePermissionRequest (one bounded read).
+      const plan = entry.input?.plan;
+      const planText = typeof plan === "string" && plan.trim().length > 0 ? plan : null;
+      this.rememberExitPlanModeCall(toolId, planText);
+      if (planText) {
+        this.pushToolCall(buildRunningPlanCardItem(toolId, planText));
+      }
+      return;
+    }
     this.pushToolCall(
       mapClaudeRunningToolCall({
         name: entry.name,

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -361,6 +361,20 @@ const NO_RESPONSE_REQUESTED_PLACEHOLDER = "No response requested.";
 // and bounds a hostile/corrupt path from exhausting memory or stalling the event loop.
 const MAX_PLAN_FILE_BYTES = 1024 * 1024;
 
+// planFilePath is model-supplied, so the read is contained to the directory Claude Code writes
+// plans into. Without this the daemon would read any path the model names and publish it as
+// plan text, which sidesteps the agent's own Read permission rules (a user who denies
+// Read(./.env) would still see it surfaced through a plan card).
+function claudePlansDir(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+  return path.join(configDir, "plans");
+}
+
+function isInsideDir(candidate: string, dir: string): boolean {
+  const relative = path.relative(dir, candidate);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
 // The ExitPlanMode registry outlives the turn (see exitPlanModeCalls), so it needs its own
 // bound. A session realistically holds a handful of plans; 32 is far above that and keeps a
 // pathological agent from growing the map without limit.
@@ -5151,17 +5165,31 @@ class ClaudeAgentSession implements AgentSession {
     const filePath = input?.planFilePath;
     if (typeof filePath === "string" && filePath.length > 0) {
       try {
-        // The path is model-supplied; only read a regular file within a sane size so a
-        // FIFO/device path can't block the event loop and a huge file can't exhaust memory.
-        const stat = fs.statSync(filePath);
+        // realpath first: containment has to hold for the file actually opened, or a symlink
+        // inside the plans directory would point the read anywhere.
+        const resolved = fs.realpathSync(path.resolve(filePath));
+        const plansDir = fs.realpathSync(claudePlansDir());
+        if (!isInsideDir(resolved, plansDir)) {
+          this.logger.warn(
+            { filePath },
+            "ExitPlanMode planFilePath outside the Claude plans directory; refusing to read",
+          );
+          return null;
+        }
+        // Only read a regular file within a sane size, so a FIFO/device path can't block the
+        // event loop and a huge file can't exhaust memory.
+        const stat = fs.statSync(resolved);
         if (stat.isFile() && stat.size > 0 && stat.size <= MAX_PLAN_FILE_BYTES) {
-          const text = fs.readFileSync(filePath, "utf8");
+          const text = fs.readFileSync(resolved, "utf8");
           if (text.trim().length > 0) {
             return text;
           }
         }
-      } catch {
-        // Plan file may be gone / unreadable; treat as no recoverable text.
+      } catch (error) {
+        // A deleted or unreadable plan file is expected (plans outlive their files), so this
+        // degrades to no card rather than failing the turn. Logged so a genuine I/O fault is
+        // still diagnosable.
+        this.logger.debug({ err: error, filePath }, "Could not read ExitPlanMode planFilePath");
       }
     }
     return null;

--- a/packages/server/src/server/agent/timeline-projection.test.ts
+++ b/packages/server/src/server/agent/timeline-projection.test.ts
@@ -176,6 +176,60 @@ describe("projectTimelineRows", () => {
     expect(tool?.collapsed).toContain("tool_lifecycle");
   });
 
+  test("a dismissed plan card flips in place when the real result lands after it", () => {
+    // Typing a follow-up dismisses the plan mid-turn; Claude's tool_result arrives afterwards
+    // carrying the same tool_use id. Both rows must collapse to one card, not two.
+    const planDetail = { type: "plan" as const, text: "# Plan\n\n- step one" };
+    const rows: AgentTimelineRow[] = [
+      {
+        seq: 1,
+        timestamp: "2026-02-13T00:00:00.000Z",
+        item: {
+          type: "tool_call",
+          name: "plan_approval",
+          callId: "toolu_plan",
+          status: "running",
+          detail: planDetail,
+        },
+      },
+      {
+        seq: 2,
+        timestamp: "2026-02-13T00:00:00.100Z",
+        item: {
+          type: "tool_call",
+          name: "plan_approval",
+          callId: "toolu_plan",
+          status: "canceled",
+          detail: planDetail,
+        },
+      },
+      {
+        seq: 3,
+        timestamp: "2026-02-13T00:00:00.200Z",
+        item: {
+          type: "tool_call",
+          name: "plan_approval",
+          callId: "toolu_plan",
+          status: "failed",
+          detail: planDetail,
+          error: { message: "Plan rejected" },
+        },
+      },
+    ];
+
+    const projected = projectTimelineRows({ rows, mode: "projected" });
+
+    expect(projected).toHaveLength(1);
+    expect(projected[0]?.item).toMatchObject({
+      type: "tool_call",
+      name: "plan_approval",
+      callId: "toolu_plan",
+      status: "failed",
+      detail: planDetail,
+      error: { message: "Plan rejected" },
+    });
+  });
+
   test("returns canonical rows unchanged in canonical mode", () => {
     const rows: AgentTimelineRow[] = [
       {


### PR DESCRIPTION
### Linked issue

Closes #1688

### Type of change

- [x] New feature

### Reasoning

When a Claude Code agent proposes a plan and you answer it, the plan disappears from the stream. The plan is often the most considered thing the agent produced in the turn, and it is the thing you want to check the work against while the agent implements it. Right now the only way back to it is scrolling the raw transcript, or asking the agent to repeat it. This keeps the plan in the timeline at the position it was proposed, collapsed to its heading with an Approved, Rejected, or Dismissed badge, and expandable to the full text. It is derived from the `ExitPlanMode` tool_use and tool_result already in the session transcript, so it reads the same live and after a daemon restart.

### Goals

- An answered plan stays in the timeline at the position it was proposed, instead of disappearing.
- The card collapses to the plan's own markdown heading and expands to the full plan on tap or click.
- The outcome is visible on the card: Approved or Rejected. A plan whose turn was canceled before Claude answered reads Dismissed until the answer lands.
- The card is derived from the `ExitPlanMode` tool_use and tool_result already in the session transcript, so no new persistence or data model is introduced.
- The plan reads identically in the live stream and after a daemon restart or reload.
- A plan interrupted mid-turn resolves to a Dismissed card rather than a raw canceled `ExitPlanMode` row.
- Rejecting a plan by typing a follow-up or pressing Escape leaves the same card as clicking Reject, and the same card a reload produces.
- Canceling a turn drops the pending permission card from the stream instead of leaving it on screen.
- Plan text is read from `planFilePath` when Claude Code 2.0.51+ leaves `input.plan` empty, with a bounded read so a corrupt path cannot exhaust memory.

### Non-goals

- Claude only. Other providers that surface plans, including Codex's inline plan card, are left exactly as they are.
- No change to how plans are approved or rejected; only how an already-answered plan is displayed.
- No new persistence, no protocol change, no migration.
- Typing a follow-up, pressing Escape, and clicking Reject are not distinguished. Claude writes the same tool_result for all three, so the distinction cannot be recovered from the transcript. All settle on Rejected, live and after a reload, rather than adding a second source of truth to carry it.
- A plan whose daemon was killed before any tool_result stays running and gets no card. Rendering the running state would double up with the permission card for the whole time every plan is pending, which is the worse trade.
- A plan written to `planFilePath` loses its card if the file is deleted before the transcript is replayed. Plan text is not copied into a second store to survive that.
- The card is not searchable or linkable, and there is no jump-to-plan affordance from later in the timeline.
- Collapsed state is per-render and not remembered across reloads.

### QA

Tested on desktop (Electron, macOS). Not tested: web, iOS, Android.

Clicking Approve:

<img width="825" height="90" alt="image" src="https://github.com/user-attachments/assets/d6738dd0-0ed6-490d-b19d-6f5183f612fd" />

Clicking Reject or pressing Escape:

<img width="839" height="78" alt="image" src="https://github.com/user-attachments/assets/3dc58652-bbaf-4cf9-b40d-0ee2fb1a2a32" />

Type in composer instead:

<img width="852" height="212" alt="image" src="https://github.com/user-attachments/assets/39c6650c-02b2-45b2-b6fb-9e414a5e7aea" />

Hover state:

<img width="847" height="73" alt="image" src="https://github.com/user-attachments/assets/c2914649-afdc-45cb-b58a-d70047e7678d" />

Clicking it opens the plan again:

<img width="834" height="235" alt="image" src="https://github.com/user-attachments/assets/4ba4a19c-23a9-4a6a-bbd1-282cae66f674" />



**Tests:**

- `packages/server/src/server/agent/providers/claude/agent.redesign.test.ts` (extended) - the resolved plan card end to end: transcript replay of an approved, rejected, and interrupted `ExitPlanMode`; the typed-follow-up path from turn cancellation through the late `tool_result`, asserted against what a reload produces; the bounded `ExitPlanMode` registry and its lifecycle across one and two flushes; the `planFilePath` fallback when `input.plan` is empty; and that an unrelated orphaned failed tool_result still renders as a normal tool call. The typed-follow-up cases were verified failing against the unfixed code.
- `packages/server/src/server/agent/timeline-projection.test.ts` (extended) - a running, then dismissed, then rejected plan row on one `callId` collapsing to a single Rejected card.
- `packages/app/src/types/stream.test.ts` (extended) - a plan card's later status winning over an earlier dismissal so the live card agrees with the server projection, and that an ordinary canceled tool call still stays canceled. The plan case was verified failing against the unfixed code.
- `packages/app/src/utils/plan-heading.test.ts` (new) - lifting the leading markdown heading out of a plan for use as the collapsed title, across heading levels, leading blank lines, and closing hashes, and leaving the body unchanged when there is no heading.

Ran all four ways of answering a plan by hand against a Claude agent on desktop. Clicking Implement leaves an Approved card at the plan's position that expands to the full text. Clicking Reject, typing a follow-up, and pressing Escape all leave a Rejected card. Restarting the session re-renders each one unchanged.

Typing a follow-up and pressing Escape used to leave no card at all plus a stray generic tool row, and the pending permission card stayed on screen.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
