### PR TITLE
feat(desktop): confirm before quitting when it stops the daemon

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -29,6 +29,7 @@ import { AddProjectFlowHost } from "@/components/add-project-flow-host";
 import { WorktreeSetupCalloutSource } from "@/components/worktree-setup-callout-source";
 import { DownloadToast } from "@/components/download-toast";
 import { QuittingOverlay } from "@/components/quitting-overlay";
+import { QuitDialogSync } from "@/desktop/components/quit-dialog-sync";
 import { KeyboardShortcutsDialog } from "@/components/keyboard-shortcuts-dialog";
 import { AppDiagnosticHost } from "@/components/app-diagnostic-host";
 import { LeftSidebar } from "@/components/left-sidebar";
@@ -574,6 +575,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
       <KeyboardShortcutsDialog />
       <AppDiagnosticHost />
       <QuittingOverlay />
+      <QuitDialogSync />
     </View>
   );
 

--- a/packages/app/src/desktop/components/quit-dialog-sync.tsx
+++ b/packages/app/src/desktop/components/quit-dialog-sync.tsx
@@ -29,9 +29,12 @@ export function QuitDialogSync(): null {
       quitLabel: i18n.t("desktop.quitConfirm.quit"),
       cancelLabel: i18n.t("desktop.quitConfirm.cancel"),
       keepDaemonRunningLabel: i18n.t("desktop.quitConfirm.keepDaemonRunning"),
-    }).catch(() => {
+    }).catch((error: unknown) => {
       // Non-fatal: main keeps whatever copy it already has, falling back to
-      // its English constants. A failed push must never break the app.
+      // its English constants. A failed push must never break the app, but it
+      // must not be invisible either — an English dialog on a translated app is
+      // otherwise impossible to explain.
+      console.warn("[quit-dialog-sync] Failed to push quit dialog copy", error);
     });
   }, [i18n, language]);
 

--- a/packages/app/src/desktop/components/quit-dialog-sync.tsx
+++ b/packages/app/src/desktop/components/quit-dialog-sync.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+import { getIsElectron } from "@/constants/platform";
+import { invokeDesktopCommand } from "@/desktop/electron/invoke";
+
+/**
+ * Pushes the translated quit-dialog strings to the main process. Renders
+ * nothing; mounted once from the root layout.
+ *
+ * The quit dialog is a native message box shown from main, which has no i18n
+ * bundle. Main caches what it receives here, so the quit path never has to reach
+ * back into the renderer or touch disk at the moment the user is quitting.
+ */
+export function QuitDialogSync(): null {
+  const { i18n } = useTranslation();
+  // Depend on the resolved language, never on `t`: its identity changes on
+  // every render, which would re-push the copy over IPC continuously.
+  const language = i18n.resolvedLanguage ?? i18n.language;
+
+  useEffect(() => {
+    if (!getIsElectron()) {
+      return;
+    }
+
+    void invokeDesktopCommand("set_quit_dialog_copy", {
+      title: i18n.t("desktop.quitConfirm.title"),
+      message: i18n.t("desktop.quitConfirm.message"),
+      quitLabel: i18n.t("desktop.quitConfirm.quit"),
+      cancelLabel: i18n.t("desktop.quitConfirm.cancel"),
+      keepDaemonRunningLabel: i18n.t("desktop.quitConfirm.keepDaemonRunning"),
+    }).catch(() => {
+      // Non-fatal: main keeps whatever copy it already has, falling back to
+      // its English constants. A failed push must never break the app.
+    });
+  }, [i18n, language]);
+
+  return null;
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1085,6 +1085,13 @@ export const ar: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "إنهاء Paseo؟",
+      message: "الإنهاء يوقف الخادم المحلي وأي وكلاء يشغّلهم. سيتم مقاطعة عملهم.",
+      quit: "إنهاء",
+      cancel: "إلغاء",
+      keepDaemonRunning: "إبقاء الخادم قيد التشغيل",
+    },
     quitting: {
       title: "جارٍ إنهاء Paseo...",
       detail: "إيقاف البرنامج الخفي المحلي.",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1095,6 +1095,14 @@ export const en = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "Quit Paseo?",
+      message:
+        "Quitting stops the local daemon, along with any agents it is running. Their work will be interrupted.",
+      quit: "Quit",
+      cancel: "Cancel",
+      keepDaemonRunning: "Leave the daemon running",
+    },
     quitting: {
       title: "Quitting Paseo...",
       detail: "Stopping the local daemon.",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1116,6 +1116,14 @@ export const es: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "¿Salir de Paseo?",
+      message:
+        "Al salir se detiene el daemon local y los agentes que esté ejecutando. Su trabajo se interrumpirá.",
+      quit: "Salir",
+      cancel: "Cancelar",
+      keepDaemonRunning: "Mantener el daemon en ejecución",
+    },
     quitting: {
       title: "Saliendo dePaseo...",
       detail: "Deteniendo el demonio local.",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1115,6 +1115,14 @@ export const fr: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "Quitter Paseo ?",
+      message:
+        "Quitter arrête le daemon local ainsi que les agents qu'il exécute. Leur travail sera interrompu.",
+      quit: "Quitter",
+      cancel: "Annuler",
+      keepDaemonRunning: "Laisser le daemon en cours d'exécution",
+    },
     quitting: {
       title: "QuitterPaseo...",
       detail: "Arrêt du démon local.",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1096,6 +1096,14 @@ export const ja: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "Paseo を終了しますか?",
+      message:
+        "終了するとローカルデーモンと、実行中のエージェントが停止します。作業は中断されます。",
+      quit: "終了",
+      cancel: "キャンセル",
+      keepDaemonRunning: "デーモンを実行したままにする",
+    },
     quitting: {
       title: "Paseoを終了中...",
       detail: "ローカルデーモンを停止中。",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1092,6 +1092,13 @@ export const ko: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "Paseo를 종료할까요?",
+      message: "종료하면 로컬 데몬과 실행 중인 에이전트가 중지됩니다. 작업이 중단됩니다.",
+      quit: "종료",
+      cancel: "취소",
+      keepDaemonRunning: "데몬을 계속 실행",
+    },
     quitting: {
       title: "Paseo 종료 중...",
       detail: "로컬 데몬을 중지하는 중입니다.",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1107,6 +1107,14 @@ export const ptBR: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "Sair do Paseo?",
+      message:
+        "Sair interrompe o daemon local e os agentes que ele estiver executando. O trabalho deles será interrompido.",
+      quit: "Sair",
+      cancel: "Cancelar",
+      keepDaemonRunning: "Manter o daemon em execução",
+    },
     quitting: {
       title: "Saindo do Paseo...",
       detail: "Parando o daemon local.",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1107,6 +1107,14 @@ export const ru: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "Выйти из Paseo?",
+      message:
+        "При выходе останавливается локальный демон и запущенные им агенты. Их работа будет прервана.",
+      quit: "Выйти",
+      cancel: "Отмена",
+      keepDaemonRunning: "Оставить демон запущенным",
+    },
     quitting: {
       title: "Выход из Paseo...",
       detail: "Остановка локального демона.",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1074,6 +1074,13 @@ export const zhCN: TranslationResources = {
     },
   },
   desktop: {
+    quitConfirm: {
+      title: "退出 Paseo？",
+      message: "退出会停止本地守护进程及其正在运行的代理，它们的工作将被中断。",
+      quit: "退出",
+      cancel: "取消",
+      keepDaemonRunning: "保持守护进程运行",
+    },
     quitting: {
       title: "正在退出 Paseo...",
       detail: "正在停止本地 daemon。",

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -39,6 +39,7 @@ import {
 } from "../settings/desktop-settings-commands.js";
 import type { DesktopSettings } from "../settings/desktop-settings.js";
 import { getDesktopSettingsStore } from "../settings/desktop-settings-electron.js";
+import { getQuitDialogCopyStore } from "../settings/quit-dialog-copy-electron.js";
 import { isRunningUnderARM64Translation } from "../system/arm64-translation.js";
 import { getDesktopAppLogs } from "../diagnostics/app-logs.js";
 import { tailFile } from "../diagnostics/tail-file.js";
@@ -517,6 +518,9 @@ async function resolveRequestedReleaseChannel(
 export function createDaemonCommandHandlers(): Record<string, DesktopCommandHandler> {
   return {
     ...createDesktopSettingsCommandHandlers({ settingsStore: getDesktopSettingsStore() }),
+    // The renderer owns translation; main only caches the resolved strings so the
+    // quit dialog never has to reach into the renderer (or disk) at quit time.
+    set_quit_dialog_copy: (args) => getQuitDialogCopyStore().set(args),
     desktop_get_runtime_info: () => ({
       appVersion: resolveDesktopAppVersion(),
       runningUnderARM64Translation: isRunningUnderARM64Translation(),

--- a/packages/desktop/src/daemon/quit-lifecycle.test.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.test.ts
@@ -42,6 +42,24 @@ function committedGate(): QuitConfirmationGate {
   };
 }
 
+/**
+ * A gate for a quit that needs no dialog and has not been committed yet: no
+ * managed daemon is running, or keepRunningAfterQuit is on. Distinct from
+ * committedGate(), whose latch is hardwired true and so cannot observe whether
+ * the lifecycle sets it.
+ */
+function silentGate(): QuitConfirmationGate {
+  let committed = false;
+  return {
+    isQuitCommitted: () => committed,
+    shouldConfirm: () => false,
+    requestConfirmation: async () => true,
+    commit() {
+      committed = true;
+    },
+  };
+}
+
 /** A gate that will ask, backed by a dialog the test resolves by hand. */
 function askingGate(): QuitConfirmationGate & {
   answer(confirmed: boolean): void;
@@ -445,6 +463,24 @@ describe("quit-lifecycle", () => {
       quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
       await waitForQuitLifecycle();
 
+      expect(events).toEqual(["close-transports", "stop-daemon", "install-update", "exit:0"]);
+    });
+
+    // Regression: a quit that skips the dialog used to leave the latch false all
+    // the way to app.exit(0). Window geometry flushes from a before-quit listener
+    // gated on that latch, and app.exit(0) fires no window close event, so the
+    // last resize or move was silently dropped on every unprompted quit.
+    it("commits the latch for a quit that never needed a dialog", async () => {
+      const gate = silentGate();
+      const { quitLifecycle, events } = createGatedLifecycle(gate);
+
+      quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+
+      // Synchronously, while the before-quit listeners are still running: the
+      // geometry flush is one of them and reads the latch during this emit.
+      expect(gate.isQuitCommitted()).toBe(true);
+
+      await waitForQuitLifecycle();
       expect(events).toEqual(["close-transports", "stop-daemon", "install-update", "exit:0"]);
     });
 

--- a/packages/desktop/src/daemon/quit-lifecycle.test.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   createQuitLifecycle,
   shouldStopDesktopManagedDaemonOnQuit,
   stopDesktopManagedDaemonOnQuitIfNeeded,
+  type QuitConfirmationGate,
 } from "./quit-lifecycle";
 
 const SETTINGS_STOP_ON_QUIT = DEFAULT_DESKTOP_SETTINGS;
@@ -26,6 +27,55 @@ function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
 
 function waitForQuitLifecycle(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * A gate for a quit the user has already agreed to. Every test that predates the
+ * confirmation dialog uses this so it exercises the same path it always did.
+ */
+function committedGate(): QuitConfirmationGate {
+  return {
+    isQuitCommitted: () => true,
+    shouldConfirm: () => false,
+    requestConfirmation: async () => true,
+    commit: () => {},
+  };
+}
+
+/** A gate that will ask, backed by a dialog the test resolves by hand. */
+function askingGate(): QuitConfirmationGate & {
+  answer(confirmed: boolean): void;
+  askCount(): number;
+} {
+  let committed = false;
+  let asks = 0;
+  let resolveAsk: ((confirmed: boolean) => void) | null = null;
+
+  return {
+    isQuitCommitted: () => committed,
+    shouldConfirm: () => !committed,
+    requestConfirmation() {
+      asks++;
+      return new Promise<boolean>((resolve) => {
+        resolveAsk = resolve;
+      });
+    },
+    commit() {
+      committed = true;
+    },
+    answer(confirmed: boolean) {
+      if (confirmed) {
+        committed = true;
+      }
+      resolveAsk?.(confirmed);
+      resolveAsk = null;
+    },
+    askCount: () => asks,
+  };
+}
+
+function countQuits(events: readonly string[]): number {
+  return events.filter((event) => event === "quit").length;
 }
 
 describe("quit-lifecycle", () => {
@@ -53,6 +103,51 @@ describe("quit-lifecycle", () => {
 
     expect(stopped).toBe(false);
     expect(events).toEqual([]);
+  });
+
+  it("honours the one-shot override over a stop-on-quit setting", async () => {
+    const events: string[] = [];
+
+    const stopped = await stopDesktopManagedDaemonOnQuitIfNeeded({
+      // Settings say stop; the user just said otherwise in the dialog.
+      settingsStore: {
+        get: async () => {
+          events.push("read-settings");
+          return SETTINGS_STOP_ON_QUIT;
+        },
+      },
+      isDesktopManagedDaemonRunning: () => true,
+      stopDaemon: async () => {
+        events.push("stop");
+      },
+      showShutdownFeedback: () => {
+        events.push("feedback");
+      },
+      keepDaemonRunningThisQuit: () => true,
+    });
+
+    expect(stopped).toBe(false);
+    // No shutdown overlay either, since nothing is being shut down.
+    expect(events).toEqual([]);
+  });
+
+  it("stops the daemon when the override is present but false", async () => {
+    const events: string[] = [];
+
+    const stopped = await stopDesktopManagedDaemonOnQuitIfNeeded({
+      settingsStore: { get: async () => SETTINGS_STOP_ON_QUIT },
+      isDesktopManagedDaemonRunning: () => true,
+      stopDaemon: async () => {
+        events.push("stop");
+      },
+      showShutdownFeedback: () => {
+        events.push("feedback");
+      },
+      keepDaemonRunningThisQuit: () => false,
+    });
+
+    expect(stopped).toBe(true);
+    expect(events).toEqual(["feedback", "stop"]);
   });
 
   it("does not stop a manually started daemon on quit", async () => {
@@ -97,9 +192,13 @@ describe("quit-lifecycle", () => {
     const events: string[] = [];
 
     const quitLifecycle = createQuitLifecycle({
+      quitConfirmation: committedGate(),
       app: {
         exit: (code) => {
           events.push(`exit:${code}`);
+        },
+        quit: () => {
+          events.push("quit");
         },
       },
       closeTransportSessions: () => {
@@ -155,7 +254,8 @@ describe("quit-lifecycle", () => {
   it("lets the updater own process exit when a validated update is installing", async () => {
     const exits: number[] = [];
     const quitLifecycle = createQuitLifecycle({
-      app: { exit: (code) => exits.push(code) },
+      quitConfirmation: committedGate(),
+      app: { exit: (code) => exits.push(code), quit: () => {} },
       closeTransportSessions: () => {},
       stopDesktopManagedDaemonIfNeeded: async () => false,
       installAppUpdateOnQuit: async () => true,
@@ -176,7 +276,8 @@ describe("quit-lifecycle", () => {
     const exits: number[] = [];
     let preventedQuitCount = 0;
     const quitLifecycle = createQuitLifecycle({
-      app: { exit: (code) => exits.push(code) },
+      quitConfirmation: committedGate(),
+      app: { exit: (code) => exits.push(code), quit: () => {} },
       closeTransportSessions: () => {},
       stopDesktopManagedDaemonIfNeeded: async () => false,
       installAppUpdateOnQuit: async () => true,
@@ -200,7 +301,8 @@ describe("quit-lifecycle", () => {
     let deadlineCount = 0;
     const exits: number[] = [];
     const quitLifecycle = createQuitLifecycle({
-      app: { exit: (code) => exits.push(code) },
+      quitConfirmation: committedGate(),
+      app: { exit: (code) => exits.push(code), quit: () => {} },
       closeTransportSessions: () => {},
       stopDesktopManagedDaemonIfNeeded: async () => false,
       installAppUpdateOnQuit: async () => true,
@@ -221,7 +323,8 @@ describe("quit-lifecycle", () => {
   it("does not intercept a quit started by a manual update", () => {
     const events: string[] = [];
     const quitLifecycle = createQuitLifecycle({
-      app: { exit: (code) => events.push(`exit:${code}`) },
+      quitConfirmation: committedGate(),
+      app: { exit: (code) => events.push(`exit:${code}`), quit: () => {} },
       closeTransportSessions: () => events.push("close-transports"),
       stopDesktopManagedDaemonIfNeeded: async () => {
         events.push("stop-daemon");
@@ -249,7 +352,8 @@ describe("quit-lifecycle", () => {
     const updateDecision = deferred<boolean>();
     const exits: number[] = [];
     const quitLifecycle = createQuitLifecycle({
-      app: { exit: (code) => exits.push(code) },
+      quitConfirmation: committedGate(),
+      app: { exit: (code) => exits.push(code), quit: () => {} },
       closeTransportSessions: () => {},
       stopDesktopManagedDaemonIfNeeded: async () => false,
       installAppUpdateOnQuit: () => updateDecision.promise,
@@ -268,5 +372,161 @@ describe("quit-lifecycle", () => {
     updateDecision.resolve(true);
     await waitForQuitLifecycle();
     expect(exits).toEqual([0]);
+  });
+
+  describe("confirmation gate", () => {
+    function createGatedLifecycle(gate: QuitConfirmationGate) {
+      const events: string[] = [];
+      const quitLifecycle = createQuitLifecycle({
+        quitConfirmation: gate,
+        app: {
+          exit: (code) => events.push(`exit:${code}`),
+          quit: () => events.push("quit"),
+        },
+        closeTransportSessions: () => events.push("close-transports"),
+        stopDesktopManagedDaemonIfNeeded: async () => {
+          events.push("stop-daemon");
+          return false;
+        },
+        installAppUpdateOnQuit: async () => {
+          events.push("install-update");
+          return false;
+        },
+        createUpdateDeadlineSignal: () => new AbortController().signal,
+        onStopError: () => events.push("stop-error"),
+        onUpdateError: () => events.push("update-error"),
+      });
+      return { quitLifecycle, events };
+    }
+
+    // The whole point of the gate: a quit the user is still being asked about
+    // must not close transport sessions (which deletes them and drops the
+    // renderer into reconnect), stop the daemon, or exit.
+    it("runs no side effects while the user is being asked", async () => {
+      const gate = askingGate();
+      const { quitLifecycle, events } = createGatedLifecycle(gate);
+      let prevented = 0;
+
+      quitLifecycle.handleBeforeQuit({ preventDefault: () => prevented++ });
+      await waitForQuitLifecycle();
+
+      expect(prevented).toBe(1);
+      expect(events).toEqual([]);
+      expect(gate.askCount()).toBe(1);
+    });
+
+    it("leaves the app fully alive after the user cancels", async () => {
+      const gate = askingGate();
+      const { quitLifecycle, events } = createGatedLifecycle(gate);
+
+      quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+      gate.answer(false);
+      await waitForQuitLifecycle();
+
+      expect(events).toEqual([]);
+    });
+
+    it("re-fires the quit exactly once after the user confirms", async () => {
+      const gate = askingGate();
+      const { quitLifecycle, events } = createGatedLifecycle(gate);
+
+      // Two quit paths (the close veto and before-quit) can both veto one quit.
+      quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+      quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+      gate.answer(true);
+      await waitForQuitLifecycle();
+
+      expect(countQuits(events)).toBe(1);
+    });
+
+    it("proceeds without asking once the quit is committed", async () => {
+      const { quitLifecycle, events } = createGatedLifecycle(committedGate());
+
+      quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+      await waitForQuitLifecycle();
+
+      expect(events).toEqual(["close-transports", "stop-daemon", "install-update", "exit:0"]);
+    });
+
+    it("keeps the dialog out of the auto-update path", () => {
+      const gate = askingGate();
+      const { quitLifecycle, events } = createGatedLifecycle(gate);
+
+      quitLifecycle.handleBeforeQuitForUpdate();
+      quitLifecycle.handleBeforeQuit({ preventDefault: () => events.push("prevent-default") });
+
+      expect(gate.askCount()).toBe(0);
+      expect(gate.isQuitCommitted()).toBe(true);
+      expect(events).toEqual(["close-transports"]);
+    });
+  });
+
+  // Regression: any second app.quit() used to count as MacUpdater handoff
+  // evidence. A user pressing Cmd+Q again during the multi-second daemon stop
+  // therefore convinced the lifecycle that the updater owned process exit, and
+  // it returned without ever calling app.exit(0) — an app that never quits.
+  it("does not mistake an impatient second quit for updater handoff", async () => {
+    const stopDecision = deferred<boolean>();
+    const handoffDeadline = new AbortController();
+    let deadlineCount = 0;
+    const exits: number[] = [];
+    const quitLifecycle = createQuitLifecycle({
+      quitConfirmation: committedGate(),
+      app: { exit: (code) => exits.push(code), quit: () => {} },
+      closeTransportSessions: () => {},
+      stopDesktopManagedDaemonIfNeeded: () => stopDecision.promise,
+      installAppUpdateOnQuit: async () => true,
+      createUpdateDeadlineSignal: () =>
+        deadlineCount++ === 0 ? new AbortController().signal : handoffDeadline.signal,
+      onStopError: () => {},
+      onUpdateError: () => {},
+    });
+
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+    // Second Cmd+Q while the daemon is still stopping — before any install began.
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+    await waitForQuitLifecycle();
+
+    stopDecision.resolve(false);
+    await waitForQuitLifecycle();
+    await waitForQuitLifecycle();
+
+    // No real handoff ever arrives, so the deadline must be what ends the wait.
+    // Before the fix the premature quit had already resolved the handoff and the
+    // lifecycle returned early, leaving `exits` empty forever.
+    handoffDeadline.abort();
+    await waitForQuitLifecycle();
+
+    expect(exits).toEqual([0]);
+  });
+
+  it("still treats a quit after the install began as updater handoff", async () => {
+    const handoffDeadline = new AbortController();
+    let deadlineCount = 0;
+    const exits: number[] = [];
+    const quitLifecycle = createQuitLifecycle({
+      quitConfirmation: committedGate(),
+      app: { exit: (code) => exits.push(code), quit: () => {} },
+      closeTransportSessions: () => {},
+      stopDesktopManagedDaemonIfNeeded: async () => false,
+      installAppUpdateOnQuit: async () => true,
+      createUpdateDeadlineSignal: () =>
+        deadlineCount++ === 0 ? new AbortController().signal : handoffDeadline.signal,
+      onStopError: () => {},
+      onUpdateError: () => {},
+    });
+
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+    await waitForQuitLifecycle();
+    // MacUpdater's no-relaunch path: app.quit() with no before-quit-for-update.
+    quitLifecycle.handleBeforeQuit({ preventDefault: () => {} });
+    await waitForQuitLifecycle();
+
+    // The updater owns process exit from here; aborting the deadline must not
+    // make us exit out from under it.
+    handoffDeadline.abort();
+    await waitForQuitLifecycle();
+
+    expect(exits).toEqual([]);
   });
 });

--- a/packages/desktop/src/daemon/quit-lifecycle.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.ts
@@ -12,11 +12,21 @@ interface BeforeQuitEvent {
 
 interface BeforeQuitApp {
   exit(code: number): void;
+  /** Re-fires the quit after the user confirms it. */
+  quit(): void;
 }
 
 interface QuitLifecycle {
   handleBeforeQuit(event: BeforeQuitEvent): void;
   handleBeforeQuitForUpdate(): void;
+}
+
+/** The part of the confirmation gate the quit lifecycle depends on. */
+export interface QuitConfirmationGate {
+  isQuitCommitted(): boolean;
+  shouldConfirm(): boolean;
+  requestConfirmation(): Promise<boolean>;
+  commit(): void;
 }
 
 interface DeferredUpdateQuit {
@@ -29,6 +39,12 @@ export interface StopOnQuitDeps {
   isDesktopManagedDaemonRunning: () => boolean;
   stopDaemon: () => Promise<unknown>;
   showShutdownFeedback: () => void;
+  /**
+   * One-shot override from the quit dialog's checkbox. Optional so callers that
+   * never show a dialog (tests, and any future headless quit) keep the plain
+   * settings-driven behavior.
+   */
+  keepDaemonRunningThisQuit?: () => boolean;
 }
 
 export function shouldStopDesktopManagedDaemonOnQuit(settings: QuitLifecycleSettings): boolean {
@@ -38,6 +54,12 @@ export function shouldStopDesktopManagedDaemonOnQuit(settings: QuitLifecycleSett
 export async function stopDesktopManagedDaemonOnQuitIfNeeded(
   deps: StopOnQuitDeps,
 ): Promise<boolean> {
+  // Checked before the settings read: the override is the user answering this
+  // exact question a second ago, so it outranks the stored preference.
+  if (deps.keepDaemonRunningThisQuit?.()) {
+    return false;
+  }
+
   const settings = await deps.settingsStore.get();
   if (!shouldStopDesktopManagedDaemonOnQuit(settings)) {
     return false;
@@ -76,6 +98,7 @@ export function createQuitLifecycle({
   stopDesktopManagedDaemonIfNeeded,
   installAppUpdateOnQuit,
   createUpdateDeadlineSignal,
+  quitConfirmation,
   onStopError,
   onUpdateError,
 }: {
@@ -84,6 +107,7 @@ export function createQuitLifecycle({
   stopDesktopManagedDaemonIfNeeded: () => Promise<boolean>;
   installAppUpdateOnQuit: (signal: AbortSignal) => Promise<boolean>;
   createUpdateDeadlineSignal: () => AbortSignal;
+  quitConfirmation: QuitConfirmationGate;
   onStopError: (error: unknown) => void;
   onUpdateError: (error: unknown) => void;
 }): QuitLifecycle {
@@ -92,15 +116,46 @@ export function createQuitLifecycle({
   // window-all-closed handler, which would veto that second quit.
   let quitting = false;
   let quittingForUpdate = false;
+  // Only a quit that arrives after we have actually asked the updater to install
+  // can be MacUpdater handing off. Before that point a second quit is just the
+  // user pressing Cmd+Q again during the multi-second daemon stop, and treating
+  // that as handoff evidence would make the app never exit.
+  let updateHandoffPossible = false;
+  let requitted = false;
   const updateQuit = createDeferredUpdateQuit();
 
   function handleBeforeQuit(event: BeforeQuitEvent): void {
+    // The gate sits above every side effect below. A quit the user is still
+    // being asked about must leave transports, window geometry, the daemon and
+    // the updater completely untouched.
+    if (
+      !quitting &&
+      !quittingForUpdate &&
+      !quitConfirmation.isQuitCommitted() &&
+      quitConfirmation.shouldConfirm()
+    ) {
+      event.preventDefault();
+      void quitConfirmation.requestConfirmation().then((confirmed) => {
+        // requestConfirmation() dedups concurrent asks, so several vetoed quits
+        // can resolve together; only one of them may re-fire the quit.
+        if (confirmed && !requitted) {
+          requitted = true;
+          app.quit();
+        }
+        return undefined;
+      });
+      return;
+    }
+
     closeTransportSessions();
     if (quittingForUpdate) return;
     if (quitting) {
       // MacUpdater's no-relaunch path calls app.quit() without emitting
-      // before-quit-for-update. A second quit is equivalent handoff evidence.
-      updateQuit.resolve();
+      // before-quit-for-update. A second quit is equivalent handoff evidence,
+      // but only once an install is actually under way.
+      if (updateHandoffPossible) {
+        updateQuit.resolve();
+      }
       return;
     }
     quitting = true;
@@ -114,6 +169,9 @@ export function createQuitLifecycle({
       }
 
       const signal = createUpdateDeadlineSignal();
+      // Armed before the await: quitAndInstall() fires app.quit() from inside
+      // this call, so waiting for it to resolve would miss the real handoff.
+      updateHandoffPossible = true;
       const updateInstallation = installAppUpdateOnQuit(signal).catch((error) => {
         onUpdateError(error);
         return false;
@@ -140,6 +198,11 @@ export function createQuitLifecycle({
     handleBeforeQuit,
     handleBeforeQuitForUpdate() {
       quittingForUpdate = true;
+      updateHandoffPossible = true;
+      // An update quit is not the user's decision to make; committing here keeps
+      // the confirmation dialog out of the install path. One-way dependency:
+      // the lifecycle tells the gate, the gate never reads lifecycle state.
+      quitConfirmation.commit();
       updateQuit.resolve();
     },
   };

--- a/packages/desktop/src/daemon/quit-lifecycle.ts
+++ b/packages/desktop/src/daemon/quit-lifecycle.ts
@@ -147,6 +147,15 @@ export function createQuitLifecycle({
       return;
     }
 
+    // Past the gate this quit is happening, so latch it even though nobody was
+    // asked. Window geometry flushes from a before-quit listener that gates on
+    // this latch, and the quit ends in app.exit(0), which fires neither
+    // will-quit nor the window close event. Without this, any quit that skips
+    // the dialog (no managed daemon, or keepRunningAfterQuit on) would drop the
+    // last resize or move. The flush listener is registered in createWindow,
+    // after main.ts registers this handler, so it observes the latch we set here.
+    quitConfirmation.commit();
+
     closeTransportSessions();
     if (quittingForUpdate) return;
     if (quitting) {

--- a/packages/desktop/src/features/dialogs.test.ts
+++ b/packages/desktop/src/features/dialogs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConfirmMessageBoxOptions, CONFIRM_BUTTON_INDEX } from "./dialogs.js";
+
+describe("buildConfirmMessageBoxOptions", () => {
+  // Regression: `paseo:dialog:ask` and `paseo:dialog:askWithCheckbox` both used to
+  // inline `defaultId: 1` / `cancelId: 0`. Extracting the builder must not shift
+  // which button Enter and Escape activate for either of them.
+  it("keeps Enter on OK and Escape on Cancel by default", () => {
+    const options = buildConfirmMessageBoxOptions({ message: "Delete it?" });
+
+    expect(options.buttons).toEqual(["Cancel", "OK"]);
+    expect(options.defaultId).toBe(1);
+    expect(options.cancelId).toBe(0);
+    expect(options.title).toBe("Confirm");
+    expect(options.type).toBe("question");
+  });
+
+  it("moves Enter to Cancel for dialogs guarding a destructive action", () => {
+    const options = buildConfirmMessageBoxOptions({
+      message: "Quit Paseo?",
+      defaultButton: "cancel",
+    });
+
+    // Cancel is index 0 in both roles, so Enter and Escape agree.
+    expect(options.defaultId).toBe(0);
+    expect(options.cancelId).toBe(0);
+    // The confirming button is still present and still index 1.
+    expect(options.buttons?.[CONFIRM_BUTTON_INDEX]).toBe("OK");
+  });
+
+  it("keeps Cancel at the index the confirm check depends on", () => {
+    const options = buildConfirmMessageBoxOptions({
+      message: "Quit?",
+      okLabel: "Quit",
+      cancelLabel: "Keep working",
+    });
+
+    expect(options.buttons?.[CONFIRM_BUTTON_INDEX]).toBe("Quit");
+    expect(options.buttons?.[options.cancelId!]).toBe("Keep working");
+  });
+
+  it("maps the dialog kind onto Electron message box types", () => {
+    expect(buildConfirmMessageBoxOptions({ message: "m", kind: "warning" }).type).toBe("warning");
+    expect(buildConfirmMessageBoxOptions({ message: "m", kind: "error" }).type).toBe("error");
+    expect(buildConfirmMessageBoxOptions({ message: "m", kind: "info" }).type).toBe("question");
+  });
+
+  it("omits checkbox fields entirely when no checkbox was requested", () => {
+    const options = buildConfirmMessageBoxOptions({ message: "m" });
+
+    expect(options).not.toHaveProperty("checkboxLabel");
+    expect(options).not.toHaveProperty("checkboxChecked");
+  });
+
+  it("defaults the checkbox to unchecked when a label is given", () => {
+    const options = buildConfirmMessageBoxOptions({
+      message: "m",
+      checkboxLabel: "Don't ask again",
+    });
+
+    expect(options.checkboxLabel).toBe("Don't ask again");
+    expect(options.checkboxChecked).toBe(false);
+  });
+});

--- a/packages/desktop/src/features/dialogs.ts
+++ b/packages/desktop/src/features/dialogs.ts
@@ -27,36 +27,69 @@ function resolveDialogType(kind: AskOptions["kind"]): "warning" | "error" | "que
   return "question";
 }
 
+/**
+ * Index of the confirming button in the `buttons` array built below. Cancel is
+ * always index 0 so that Escape and a closed dialog both read as "not confirmed".
+ */
+export const CONFIRM_BUTTON_INDEX = 1;
+const CANCEL_BUTTON_INDEX = 0;
+
+export interface ConfirmMessageBoxOptions extends AskOptions {
+  message: string;
+  checkboxLabel?: string;
+  checkboxChecked?: boolean;
+  /**
+   * Which button Enter activates. Defaults to "ok" to match every dialog that
+   * predates this option. Dialogs guarding a destructive action must pass
+   * "cancel" — otherwise the reflex keypress after a mis-triggered action
+   * confirms the very thing the dialog exists to catch.
+   */
+  defaultButton?: "ok" | "cancel";
+}
+
+/**
+ * Single source of truth for the confirm-dialog button contract. The button
+ * order decides what Enter and Escape do, so it lives in one place rather than
+ * being restated at each call site.
+ */
+export function buildConfirmMessageBoxOptions(
+  options: ConfirmMessageBoxOptions,
+): Electron.MessageBoxOptions {
+  const built: Electron.MessageBoxOptions = {
+    type: resolveDialogType(options.kind),
+    title: options.title ?? "Confirm",
+    message: options.message,
+    buttons: [options.cancelLabel ?? "Cancel", options.okLabel ?? "OK"],
+    defaultId: options.defaultButton === "cancel" ? CANCEL_BUTTON_INDEX : CONFIRM_BUTTON_INDEX,
+    cancelId: CANCEL_BUTTON_INDEX,
+  };
+  if (options.checkboxLabel !== undefined) {
+    built.checkboxLabel = options.checkboxLabel;
+    built.checkboxChecked = options.checkboxChecked ?? false;
+  }
+  return built;
+}
+
 export function registerDialogHandlers(): void {
   ipcMain.handle("paseo:dialog:ask", async (event, message: string, options?: AskOptions) => {
     const win = BrowserWindow.fromWebContents(event.sender);
-    const result = await dialog.showMessageBox(win ?? BrowserWindow.getFocusedWindow()!, {
-      type: resolveDialogType(options?.kind),
-      title: options?.title ?? "Confirm",
-      message,
-      buttons: [options?.cancelLabel ?? "Cancel", options?.okLabel ?? "OK"],
-      defaultId: 1,
-      cancelId: 0,
-    });
-    return result.response === 1;
+    const result = await dialog.showMessageBox(
+      win ?? BrowserWindow.getFocusedWindow()!,
+      buildConfirmMessageBoxOptions({ ...options, message }),
+    );
+    return result.response === CONFIRM_BUTTON_INDEX;
   });
 
   ipcMain.handle(
     "paseo:dialog:askWithCheckbox",
     async (event, message: string, options: AskWithCheckboxOptions) => {
       const win = BrowserWindow.fromWebContents(event.sender);
-      const result = await dialog.showMessageBox(win ?? BrowserWindow.getFocusedWindow()!, {
-        type: resolveDialogType(options.kind),
-        title: options.title ?? "Confirm",
-        message,
-        buttons: [options.cancelLabel ?? "Cancel", options.okLabel ?? "OK"],
-        defaultId: 1,
-        cancelId: 0,
-        checkboxLabel: options.checkboxLabel,
-        checkboxChecked: options.checkboxChecked ?? false,
-      });
+      const result = await dialog.showMessageBox(
+        win ?? BrowserWindow.getFocusedWindow()!,
+        buildConfirmMessageBoxOptions({ ...options, message }),
+      );
       return {
-        confirmed: result.response === 1,
+        confirmed: result.response === CONFIRM_BUTTON_INDEX,
         dontAskAgain: result.checkboxChecked,
       };
     },

--- a/packages/desktop/src/features/quit-confirmation.test.ts
+++ b/packages/desktop/src/features/quit-confirmation.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createQuitConfirmation,
+  selectDialogParentWindow,
+  type QuitConfirmationCopy,
+  type QuitConfirmationDeps,
+  type QuitConfirmationDialogResult,
+} from "./quit-confirmation.js";
+
+const COPY: QuitConfirmationCopy = {
+  title: "Quit Paseo?",
+  message: "Quitting stops the local daemon and any running agents.",
+  quitLabel: "Quit",
+  cancelLabel: "Cancel",
+  keepDaemonRunningLabel: "Leave the daemon running",
+};
+
+function createDeps(overrides: Partial<QuitConfirmationDeps> = {}): {
+  deps: QuitConfirmationDeps;
+  showDialog: QuitConfirmationDeps["showDialog"];
+  onError: QuitConfirmationDeps["onError"];
+} {
+  const deps: QuitConfirmationDeps = {
+    readSettingsSync: () => ({
+      daemon: { keepRunningAfterQuit: false },
+    }),
+    isAppReady: () => true,
+    hasOpenWindows: () => true,
+    isDesktopManagedDaemonRunning: () => true,
+    loadCopy: () => COPY,
+    showDialog: vi.fn(
+      async (): Promise<QuitConfirmationDialogResult> => ({
+        confirmed: true,
+        keepDaemonRunning: false,
+      }),
+    ),
+    onError: vi.fn(),
+    ...overrides,
+  };
+
+  // Read the spies back off `deps` so an override is what the test asserts on.
+  return {
+    deps,
+    showDialog: deps.showDialog,
+    onError: deps.onError,
+  };
+}
+
+describe("selectDialogParentWindow", () => {
+  function fakeWindow(state: {
+    destroyed?: boolean;
+    visible?: boolean;
+    minimized?: boolean;
+    focused?: boolean;
+    id?: string;
+  }) {
+    return {
+      id: state.id ?? "win",
+      isDestroyed: () => state.destroyed ?? false,
+      isVisible: () => state.visible ?? true,
+      isMinimized: () => state.minimized ?? false,
+      isFocused: () => state.focused ?? false,
+    };
+  }
+
+  it("prefers the focused window", () => {
+    const focused = fakeWindow({ focused: true, id: "focused" });
+    const other = fakeWindow({ id: "other" });
+
+    expect(selectDialogParentWindow([other, focused])?.id).toBe("focused");
+  });
+
+  // A sheet on a Cmd+H-hidden or minimized window is invisible; the app looks hung.
+  it("skips hidden and minimized windows", () => {
+    const hidden = fakeWindow({ visible: false, id: "hidden" });
+    const minimized = fakeWindow({ minimized: true, id: "minimized" });
+    const usable = fakeWindow({ id: "usable" });
+
+    expect(selectDialogParentWindow([hidden, minimized, usable])?.id).toBe("usable");
+  });
+
+  it("skips destroyed windows", () => {
+    const destroyed = fakeWindow({ destroyed: true, id: "destroyed" });
+
+    expect(selectDialogParentWindow([destroyed])).toBeNull();
+  });
+
+  it("falls back to no parent when nothing is showable", () => {
+    expect(selectDialogParentWindow([])).toBeNull();
+    expect(selectDialogParentWindow([fakeWindow({ visible: false })])).toBeNull();
+  });
+});
+
+describe("quit-confirmation shouldConfirm", () => {
+  it("asks for the default configuration with a managed daemon running", () => {
+    const { deps } = createDeps();
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(true);
+  });
+
+  it("is synchronous", () => {
+    const { deps } = createDeps();
+
+    // The before-quit handler calls this ahead of the synchronous
+    // event.preventDefault(); a thenable here would break that ordering.
+    expect(createQuitConfirmation(deps).shouldConfirm()).not.toBeInstanceOf(Promise);
+  });
+
+  it("does not ask when the daemon is configured to outlive the app", () => {
+    const { deps } = createDeps({
+      readSettingsSync: () => ({
+        daemon: { keepRunningAfterQuit: true },
+      }),
+    });
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(false);
+  });
+
+  it("does not ask when no desktop-managed daemon is running", () => {
+    const { deps } = createDeps({ isDesktopManagedDaemonRunning: () => false });
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(false);
+  });
+
+  // The single-instance lock calls app.quit() during startup, before whenReady().
+  it("does not ask before the app is ready", () => {
+    const { deps } = createDeps({ isAppReady: () => false });
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(false);
+  });
+
+  it("does not ask when there is no window to parent a dialog to", () => {
+    const { deps } = createDeps({ hasOpenWindows: () => false });
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(false);
+  });
+
+  it("does not ask when settings have not loaded yet", () => {
+    const { deps } = createDeps({ readSettingsSync: () => null });
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(false);
+  });
+
+  it("fails open and reports when reading settings throws", () => {
+    const { deps, onError } = createDeps({
+      readSettingsSync: () => {
+        throw new Error("cache exploded");
+      },
+    });
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(false);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("fails open and reports when the daemon check throws", () => {
+    const { deps, onError } = createDeps({
+      isDesktopManagedDaemonRunning: () => {
+        throw new Error("no daemon handle");
+      },
+    });
+
+    expect(createQuitConfirmation(deps).shouldConfirm()).toBe(false);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("stops asking once the quit is committed", () => {
+    const { deps } = createDeps();
+    const confirmation = createQuitConfirmation(deps);
+
+    confirmation.commit();
+
+    expect(confirmation.shouldConfirm()).toBe(false);
+    expect(confirmation.isQuitCommitted()).toBe(true);
+  });
+});
+
+describe("quit-confirmation requestConfirmation", () => {
+  it("commits the quit when the user confirms", async () => {
+    const { deps } = createDeps();
+    const confirmation = createQuitConfirmation(deps);
+
+    await expect(confirmation.requestConfirmation()).resolves.toBe(true);
+    expect(confirmation.isQuitCommitted()).toBe(true);
+    expect(confirmation.shouldKeepDaemonRunningThisQuit()).toBe(false);
+  });
+
+  it("leaves the quit uncommitted and re-askable after Cancel", async () => {
+    const { deps, showDialog } = createDeps({
+      showDialog: vi.fn(async () => ({ confirmed: false, keepDaemonRunning: false })),
+    });
+    const confirmation = createQuitConfirmation(deps);
+
+    await expect(confirmation.requestConfirmation()).resolves.toBe(false);
+    expect(confirmation.isQuitCommitted()).toBe(false);
+
+    // The next Cmd+Q must show the dialog again, not silently quit or silently hang.
+    await expect(confirmation.requestConfirmation()).resolves.toBe(false);
+    expect(showDialog).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a single dialog when two quit paths race", async () => {
+    let releaseDialog!: (result: QuitConfirmationDialogResult) => void;
+    const showDialog = vi.fn(
+      () =>
+        new Promise<QuitConfirmationDialogResult>((resolve) => {
+          releaseDialog = resolve;
+        }),
+    );
+    const { deps } = createDeps({ showDialog });
+    const confirmation = createQuitConfirmation(deps);
+
+    const first = confirmation.requestConfirmation();
+    const second = confirmation.requestConfirmation();
+    releaseDialog({ confirmed: true, keepDaemonRunning: false });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(showDialog).toHaveBeenCalledOnce();
+  });
+
+  it("carries the ticked checkbox to the quit that follows", async () => {
+    const { deps } = createDeps({
+      showDialog: vi.fn(async () => ({ confirmed: true, keepDaemonRunning: true })),
+    });
+    const confirmation = createQuitConfirmation(deps);
+
+    await expect(confirmation.requestConfirmation()).resolves.toBe(true);
+
+    // The stop-on-quit step runs after the re-fired quit, long after the dialog
+    // has closed, so the answer has to outlive it.
+    expect(confirmation.shouldKeepDaemonRunningThisQuit()).toBe(true);
+  });
+
+  it("ignores the checkbox when the user cancels", async () => {
+    const { deps, showDialog } = createDeps({
+      showDialog: vi.fn(async () => ({ confirmed: false, keepDaemonRunning: true })),
+    });
+    const confirmation = createQuitConfirmation(deps);
+
+    await expect(confirmation.requestConfirmation()).resolves.toBe(false);
+    expect(confirmation.isQuitCommitted()).toBe(false);
+
+    // A checkbox ticked alongside Cancel decided nothing. Leaking it into the
+    // next quit would silently keep the daemon alive on a quit nobody asked
+    // that question about.
+    expect(confirmation.shouldKeepDaemonRunningThisQuit()).toBe(false);
+
+    await confirmation.requestConfirmation();
+    expect(showDialog).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails open when the dialog throws", async () => {
+    const { deps, onError } = createDeps({
+      showDialog: vi.fn(async () => {
+        throw new Error("no display");
+      }),
+    });
+    const confirmation = createQuitConfirmation(deps);
+
+    // Rejecting would strand a preventDefault()ed quit with nothing to re-fire it.
+    await expect(confirmation.requestConfirmation()).resolves.toBe(true);
+    expect(confirmation.isQuitCommitted()).toBe(true);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("stops the daemon when the dialog fails open", async () => {
+    const { deps, onError } = createDeps({
+      showDialog: vi.fn(async () => {
+        throw new Error("no display");
+      }),
+    });
+    const confirmation = createQuitConfirmation(deps);
+
+    await expect(confirmation.requestConfirmation()).resolves.toBe(true);
+    expect(onError).toHaveBeenCalledOnce();
+
+    // Failing open must not also invent a "leave it running" the user never
+    // chose; the stored preference decides, exactly as it did before.
+    expect(confirmation.shouldKeepDaemonRunningThisQuit()).toBe(false);
+  });
+
+  it("skips the dialog entirely once committed by the update path", async () => {
+    const { deps, showDialog } = createDeps();
+    const confirmation = createQuitConfirmation(deps);
+
+    confirmation.commit();
+
+    await expect(confirmation.requestConfirmation()).resolves.toBe(true);
+    expect(showDialog).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/features/quit-confirmation.ts
+++ b/packages/desktop/src/features/quit-confirmation.ts
@@ -1,0 +1,176 @@
+/**
+ * Confirmation gate for quitting the desktop app.
+ *
+ * Quitting is irreversible and, in the default configuration, stops the
+ * desktop-managed daemon and with it every running agent. This module decides
+ * whether a given quit needs a confirmation dialog and owns the "committed"
+ * latch that every other quit-path guard reads.
+ *
+ * Deliberately free of Electron imports so the whole decision table is
+ * unit-testable; `main.ts` supplies the Electron-shaped dependencies.
+ */
+
+export interface QuitConfirmationCopy {
+  title: string;
+  message: string;
+  quitLabel: string;
+  cancelLabel: string;
+  keepDaemonRunningLabel: string;
+}
+
+export interface QuitConfirmationDialogResult {
+  confirmed: boolean;
+  /**
+   * The checkbox. Applies to this quit only and is never written to settings —
+   * "keep it running just this once" and "keep it running from now on" are
+   * different intents, and the durable one lives in Settings.
+   */
+  keepDaemonRunning: boolean;
+}
+
+/** The slice of DesktopSettings this gate reads. */
+export interface QuitConfirmationSettings {
+  daemon: {
+    keepRunningAfterQuit: boolean;
+  };
+}
+
+export interface QuitConfirmationDeps {
+  /**
+   * Synchronous because the caller has to decide before `event.preventDefault()`.
+   * Returns null when settings have not loaded yet, which reads as "don't veto".
+   */
+  readSettingsSync: () => QuitConfirmationSettings | null;
+  isAppReady: () => boolean;
+  hasOpenWindows: () => boolean;
+  isDesktopManagedDaemonRunning: () => boolean;
+  loadCopy: () => QuitConfirmationCopy;
+  showDialog: (copy: QuitConfirmationCopy) => Promise<QuitConfirmationDialogResult>;
+  onError: (error: unknown) => void;
+}
+
+export interface QuitConfirmation {
+  /** True once the quit has been confirmed, or handed off to the updater. */
+  isQuitCommitted(): boolean;
+  /** Marks the quit as committed without asking. Used by the auto-update path. */
+  commit(): void;
+  /** Whether this quit needs a dialog. Synchronous by contract. */
+  shouldConfirm(): boolean;
+  /** Shows the dialog (at most one at a time) and resolves to the user's answer. */
+  requestConfirmation(): Promise<boolean>;
+  /**
+   * True when the user ticked "leave daemon running" for the quit now in
+   * progress. Read by the stop-on-quit step, which runs after the re-fired
+   * quit, so the answer has to outlive the dialog that produced it.
+   */
+  shouldKeepDaemonRunningThisQuit(): boolean;
+}
+
+interface DialogParentWindow {
+  isDestroyed(): boolean;
+  isVisible(): boolean;
+  isMinimized(): boolean;
+  isFocused(): boolean;
+}
+
+/**
+ * Picks the window to parent the dialog to.
+ *
+ * On macOS a message box parented to a hidden (Cmd+H) or minimized window renders
+ * as a sheet on a window nobody can see, so the app just appears to hang on quit.
+ * Returning null makes it an app-modal dialog instead, which is always visible.
+ */
+export function selectDialogParentWindow<T extends DialogParentWindow>(windows: T[]): T | null {
+  const candidates = windows.filter(
+    (win) => !win.isDestroyed() && win.isVisible() && !win.isMinimized(),
+  );
+  return candidates.find((win) => win.isFocused()) ?? candidates[0] ?? null;
+}
+
+export function createQuitConfirmation(deps: QuitConfirmationDeps): QuitConfirmation {
+  let committed = false;
+  let pending: Promise<boolean> | null = null;
+  let keepDaemonRunningThisQuit = false;
+
+  function shouldConfirm(): boolean {
+    if (committed) {
+      return false;
+    }
+
+    // A quit before the app is up (the second-instance lock calls app.quit()
+    // during startup) has no window to parent a dialog to and nothing at stake.
+    if (!deps.isAppReady() || !deps.hasOpenWindows()) {
+      return false;
+    }
+
+    try {
+      const settings = deps.readSettingsSync();
+      if (!settings) {
+        return false;
+      }
+      // Only prompt when quitting will actually stop a running daemon. Without
+      // this the dialog fires on quits with nothing at stake, which is how a
+      // confirmation prompt trains people to dismiss it reflexively.
+      //
+      // This is also the only way to switch the prompt off: "Keep daemon running
+      // after quit" silences it and removes the risk, which is strictly better
+      // than a separate toggle that silences it and leaves the risk.
+      if (settings.daemon.keepRunningAfterQuit) {
+        return false;
+      }
+      return deps.isDesktopManagedDaemonRunning();
+    } catch (error) {
+      deps.onError(error);
+      return false;
+    }
+  }
+
+  async function runConfirmation(): Promise<boolean> {
+    try {
+      const result = await deps.showDialog(deps.loadCopy());
+      if (!result.confirmed) {
+        // A ticked checkbox alongside Cancel decides nothing: there is no quit
+        // for it to apply to. Carrying it to a later quit would be the worst
+        // possible reading of "no, don't quit".
+        return false;
+      }
+      keepDaemonRunningThisQuit = result.keepDaemonRunning;
+      committed = true;
+      return true;
+    } catch (error) {
+      // Fail open. A rejection here leaves the quit already preventDefault()ed
+      // with nothing left to re-fire it, i.e. an app that can only be killed by
+      // Force Quit — exactly the ungraceful exit this feature exists to prevent.
+      deps.onError(error);
+      committed = true;
+      return true;
+    }
+  }
+
+  return {
+    isQuitCommitted: () => committed,
+
+    commit(): void {
+      committed = true;
+    },
+
+    shouldConfirm,
+
+    shouldKeepDaemonRunningThisQuit: () => keepDaemonRunningThisQuit,
+
+    async requestConfirmation(): Promise<boolean> {
+      if (committed) {
+        return true;
+      }
+      // Cmd+Q while the dialog is already open, and the close-veto and
+      // before-quit paths both firing for one quit, must share one dialog.
+      if (pending) {
+        return pending;
+      }
+      pending = runConfirmation().finally(() => {
+        pending = null;
+      });
+      return pending;
+    },
+  };
+}

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -15,6 +15,7 @@ import {
   autoUpdater as electronAutoUpdater,
   BrowserWindow,
   clipboard,
+  dialog,
   Menu,
   ipcMain,
   nativeImage,
@@ -40,7 +41,7 @@ import {
   buildStandardContextMenuItems,
 } from "./window/window-manager.js";
 import { setupDarwinCompositorWatchdog } from "./window/compositor-watchdog/index.js";
-import { registerDialogHandlers } from "./features/dialogs.js";
+import { buildConfirmMessageBoxOptions, registerDialogHandlers } from "./features/dialogs.js";
 import {
   registerNotificationHandlers,
   ensureNotificationCenterRegistration,
@@ -76,7 +77,10 @@ import {
 import { parseOpenProjectPathFromArgv } from "./open-project-routing.js";
 import { PendingOpenProjectStore } from "./pending-open-project-store.js";
 import { getDesktopSettingsStore } from "./settings/desktop-settings-electron.js";
+import { getQuitDialogCopyStore } from "./settings/quit-dialog-copy-electron.js";
 import { clampWindowStateToWorkAreas, createWindowStateStore } from "./settings/window-state.js";
+import { createQuitConfirmation, selectDialogParentWindow } from "./features/quit-confirmation.js";
+import { shouldVetoWindowClose } from "./window/window-close-policy.js";
 import {
   isDesktopManagedDaemonRunningSync,
   stopDesktopDaemonViaCli,
@@ -684,6 +688,68 @@ function getWorkAreasPrimaryFirst(): Electron.Rectangle[] {
   return [primary, ...others].map((display) => display.workArea);
 }
 
+const quitDialogCopyStore = getQuitDialogCopyStore();
+
+// True once the OS says it is logging out or shutting down. Vetoing a close then
+// either parks the shutdown behind a "this app is preventing you from logging
+// out" dialog or gets the process force-killed with our dialog still on screen.
+//
+// These are BrowserWindow events on win32, not app events, so every window arms
+// the same module-level flag (see markSessionEnding below).
+let sessionEnding = false;
+
+// Constructed above createWindow rather than beside the other quit wiring at the
+// bottom of this file: createWindow reads it, and relying on bootstrap() to
+// suspend at `await app.whenReady()` first would be a temporal-dead-zone trap.
+const quitConfirmation = createQuitConfirmation({
+  readSettingsSync: () => getDesktopSettingsStore().getSync(),
+  isAppReady: () => app.isReady(),
+  hasOpenWindows: () => BrowserWindow.getAllWindows().some((win) => !win.isDestroyed()),
+  isDesktopManagedDaemonRunning: isDesktopManagedDaemonRunningSync,
+  loadCopy: () => quitDialogCopyStore.get(),
+  showDialog: async (copy) => {
+    const parent = selectDialogParentWindow(BrowserWindow.getAllWindows());
+    const options = buildConfirmMessageBoxOptions({
+      message: copy.message,
+      title: copy.title,
+      okLabel: copy.quitLabel,
+      cancelLabel: copy.cancelLabel,
+      checkboxLabel: copy.keepDaemonRunningLabel,
+      kind: "warning",
+      // Enter must cancel. Someone who just hit Cmd+Q by accident will reflexively
+      // hit Enter next, and the default button is the whole point of this dialog.
+      defaultButton: "cancel",
+    });
+    const result = parent
+      ? await dialog.showMessageBox(parent, options)
+      : await dialog.showMessageBox(options);
+    return { confirmed: result.response === 1, keepDaemonRunning: result.checkboxChecked };
+  },
+  onError: (error) => {
+    log.error("[quit-confirmation] failed; allowing the quit to proceed", error);
+  },
+});
+
+/**
+ * Whether closing this window is about to be vetoed to ask the user first.
+ *
+ * macOS is excluded on purpose: closing the last window there does not quit, so
+ * there is nothing to confirm. Windows and Linux route quits through the last
+ * window close via `window-all-closed`.
+ */
+function willVetoWindowClose(): boolean {
+  if (process.platform === "darwin") {
+    return false;
+  }
+  return (
+    shouldVetoWindowClose({
+      windows: BrowserWindow.getAllWindows(),
+      quitCommitted: quitConfirmation.isQuitCommitted(),
+      sessionEnding,
+    }) && quitConfirmation.shouldConfirm()
+  );
+}
+
 async function createWindow(
   options: {
     initialRoute?: string | null;
@@ -751,8 +817,38 @@ async function createWindow(
   setupDarwinCompositorWatchdog(mainWindow);
   setupWindowResizeEvents(mainWindow);
   if (windowStateStore) {
-    setupWindowStatePersistence(mainWindow, windowStateStore);
+    setupWindowStatePersistence(mainWindow, windowStateStore, {
+      gates: {
+        willVetoClose: willVetoWindowClose,
+        isQuitCommitted: quitConfirmation.isQuitCommitted,
+      },
+    });
   }
+
+  // query-session-end is the earlier, still-cancellable signal; session-end
+  // means the shutdown is already unstoppable. Either way we must stop
+  // prompting. Windows-only events, harmless no-op registrations elsewhere.
+  mainWindow.on("query-session-end", () => {
+    sessionEnding = true;
+  });
+  mainWindow.on("session-end", () => {
+    sessionEnding = true;
+  });
+
+  // Windows/Linux: closing the last window is how people quit, so the guard has
+  // to sit here as well as on before-quit.
+  mainWindow.on("close", (event) => {
+    if (!willVetoWindowClose()) {
+      return;
+    }
+    event.preventDefault();
+    void quitConfirmation.requestConfirmation().then((confirmed) => {
+      if (confirmed && !mainWindow.isDestroyed()) {
+        mainWindow.close();
+      }
+      return undefined;
+    });
+  });
   setupDefaultContextMenu(mainWindow);
   setupDragDropPrevention(mainWindow);
   mainWindow.webContents.on("will-attach-webview", (event, webPreferences, params) => {
@@ -945,6 +1041,20 @@ async function bootstrap(): Promise<void> {
 
   await app.whenReady();
 
+  // The before-quit gate reads both of these synchronously, so they have to be
+  // in memory before the user can press Cmd+Q. Neither is worth failing startup
+  // over: settings fall back to "don't confirm" and copy falls back to English.
+  await Promise.all([
+    getDesktopSettingsStore()
+      .warm()
+      .catch((error) => {
+        log.error("[desktop settings] failed to warm the settings cache", error);
+      }),
+    quitDialogCopyStore.load().catch((error) => {
+      log.error("[quit-confirmation] failed to load localized dialog copy", error);
+    }),
+  ]);
+
   const appDistDir = getAppDistDir();
   protocol.handle(APP_SCHEME, (request) => {
     const { pathname, search, hash } = new URL(request.url);
@@ -1045,6 +1155,17 @@ void runDesktopStartup({
   process.exit(1);
 });
 
+/**
+ * Platform note: on Windows and Linux, quitting by closing the last window
+ * destroys that window before `window-all-closed` fires `app.quit()`, so by the
+ * time this runs there is nothing left to render the overlay in and the daemon
+ * stop happens with no visible feedback. That is pre-existing behavior, not
+ * something the quit confirmation introduced — the confirmation dialog actually
+ * runs *before* the window is destroyed, so the user is at least told what the
+ * quit will stop. Fixing it properly means keeping the last window alive until
+ * the daemon stop resolves, which changes close semantics for every non-macOS
+ * quit; deliberately out of scope here.
+ */
 function showDaemonShutdownDialog(): void {
   for (const win of BrowserWindow.getAllWindows()) {
     win.webContents.send("paseo:event:quitting", {});
@@ -1053,6 +1174,7 @@ function showDaemonShutdownDialog(): void {
 
 const quitLifecycle = createQuitLifecycle({
   app,
+  quitConfirmation,
   closeTransportSessions: closeAllTransportSessions,
   stopDesktopManagedDaemonIfNeeded: () =>
     stopDesktopManagedDaemonOnQuitIfNeeded({
@@ -1060,6 +1182,7 @@ const quitLifecycle = createQuitLifecycle({
       isDesktopManagedDaemonRunning: isDesktopManagedDaemonRunningSync,
       stopDaemon: () => stopDesktopDaemonViaCli("quit"),
       showShutdownFeedback: showDaemonShutdownDialog,
+      keepDaemonRunningThisQuit: quitConfirmation.shouldKeepDaemonRunningThisQuit,
     }),
   installAppUpdateOnQuit: async (signal) => {
     const settings = await getDesktopSettingsStore().get();

--- a/packages/desktop/src/settings/desktop-settings-commands.test.ts
+++ b/packages/desktop/src/settings/desktop-settings-commands.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_DESKTOP_SETTINGS, type DesktopSettingsStore } from "./desktop-settings";
 import { createDesktopSettingsCommandHandlers } from "./desktop-settings-commands";
 
-function createStoreMock(): DesktopSettingsStore {
+type SettingsCommandStore = Pick<
+  DesktopSettingsStore,
+  "get" | "patch" | "migrateLegacyRendererSettings"
+>;
+
+function createStoreMock(): SettingsCommandStore {
   return {
     get: vi.fn(async () => DEFAULT_DESKTOP_SETTINGS),
     patch: vi.fn(async () => ({

--- a/packages/desktop/src/settings/desktop-settings-commands.ts
+++ b/packages/desktop/src/settings/desktop-settings-commands.ts
@@ -5,7 +5,7 @@ export type DesktopCommandHandler = (args?: Record<string, unknown>) => unknown;
 export function createDesktopSettingsCommandHandlers({
   settingsStore,
 }: {
-  settingsStore: DesktopSettingsStore;
+  settingsStore: Pick<DesktopSettingsStore, "get" | "patch" | "migrateLegacyRendererSettings">;
 }): Record<string, DesktopCommandHandler> {
   return {
     get_desktop_settings: () => settingsStore.get(),

--- a/packages/desktop/src/settings/desktop-settings.test.ts
+++ b/packages/desktop/src/settings/desktop-settings.test.ts
@@ -236,4 +236,31 @@ describe("desktop-settings", () => {
     });
     expect(ignoredSecondMigration).toEqual(migrated);
   });
+
+  describe("getSync", () => {
+    // The before-quit handler must decide whether to veto BEFORE calling the
+    // synchronous event.preventDefault(), so it cannot await store.get().
+    it("returns null until the document has been loaded", async () => {
+      const userDataPath = await createTempUserDataDir();
+      directories.add(userDataPath);
+      const store = createDesktopSettingsStore({ userDataPath });
+
+      expect(store.getSync()).toBeNull();
+
+      await store.warm();
+
+      expect(store.getSync()).toEqual(DEFAULT_DESKTOP_SETTINGS);
+    });
+
+    it("agrees with get() after a patch", async () => {
+      const userDataPath = await createTempUserDataDir();
+      directories.add(userDataPath);
+      const store = createDesktopSettingsStore({ userDataPath });
+
+      await store.patch({ daemon: { keepRunningAfterQuit: true } });
+
+      expect(store.getSync()).toEqual(await store.get());
+      expect(store.getSync()?.daemon.keepRunningAfterQuit).toBe(true);
+    });
+  });
 });

--- a/packages/desktop/src/settings/desktop-settings.ts
+++ b/packages/desktop/src/settings/desktop-settings.ts
@@ -32,6 +32,18 @@ interface PersistedDesktopSettingsDocument {
 
 export interface DesktopSettingsStore {
   get(): Promise<DesktopSettings>;
+  /**
+   * The already-loaded settings, or null before the first load resolves.
+   *
+   * The `before-quit` handler has to decide whether to veto the quit *before*
+   * calling `event.preventDefault()`, and `preventDefault` is synchronous. An
+   * async read there would either preventDefault every quit and re-quit (even
+   * when the feature is off) or stall the quit on a cold-cache `readFile` with
+   * no dialog and no explanation. Callers treat null as "don't veto".
+   */
+  getSync(): DesktopSettings | null;
+  /** Loads the document so a later `getSync()` can answer. */
+  warm(): Promise<void>;
   patch(patch: unknown): Promise<DesktopSettings>;
   migrateLegacyRendererSettings(legacySettings: unknown): Promise<DesktopSettings>;
 }
@@ -268,6 +280,14 @@ export function createDesktopSettingsStore({
     async get(): Promise<DesktopSettings> {
       const document = await loadDocument();
       return document.settings;
+    },
+
+    getSync(): DesktopSettings | null {
+      return cachedDocument?.settings ?? null;
+    },
+
+    async warm(): Promise<void> {
+      await loadDocument();
     },
 
     async patch(patch: unknown): Promise<DesktopSettings> {

--- a/packages/desktop/src/settings/quit-dialog-copy-electron.ts
+++ b/packages/desktop/src/settings/quit-dialog-copy-electron.ts
@@ -1,0 +1,12 @@
+import { app } from "electron";
+
+import { createQuitDialogCopyStore, type QuitDialogCopyStore } from "./quit-dialog-copy.js";
+
+let quitDialogCopyStore: QuitDialogCopyStore | null = null;
+
+export function getQuitDialogCopyStore(): QuitDialogCopyStore {
+  quitDialogCopyStore ??= createQuitDialogCopyStore({
+    userDataPath: app.getPath("userData"),
+  });
+  return quitDialogCopyStore;
+}

--- a/packages/desktop/src/settings/quit-dialog-copy.test.ts
+++ b/packages/desktop/src/settings/quit-dialog-copy.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  coerceQuitDialogCopy,
+  createQuitDialogCopyStore,
+  DEFAULT_QUIT_DIALOG_COPY,
+  type QuitDialogCopy,
+} from "./quit-dialog-copy";
+
+const GERMAN: QuitDialogCopy = {
+  title: "Paseo beenden?",
+  message: "Beim Beenden wird der lokale Daemon gestoppt.",
+  quitLabel: "Beenden",
+  cancelLabel: "Abbrechen",
+  keepDaemonRunningLabel: "Nicht mehr fragen",
+};
+
+describe("coerceQuitDialogCopy", () => {
+  it("keeps fully translated copy", () => {
+    expect(coerceQuitDialogCopy(GERMAN)).toEqual(GERMAN);
+  });
+
+  // Per-key, so one missing string doesn't revert the whole dialog to English.
+  it("falls back per key", () => {
+    const partial = coerceQuitDialogCopy({ title: "Paseo beenden?", quitLabel: "Beenden" });
+
+    expect(partial.title).toBe("Paseo beenden?");
+    expect(partial.quitLabel).toBe("Beenden");
+    expect(partial.cancelLabel).toBe(DEFAULT_QUIT_DIALOG_COPY.cancelLabel);
+    expect(partial.message).toBe(DEFAULT_QUIT_DIALOG_COPY.message);
+  });
+
+  it("rejects blank and non-string values", () => {
+    expect(coerceQuitDialogCopy({ title: "   ", quitLabel: 7, cancelLabel: null })).toEqual(
+      DEFAULT_QUIT_DIALOG_COPY,
+    );
+  });
+
+  it("falls back entirely for a non-object", () => {
+    expect(coerceQuitDialogCopy(null)).toEqual(DEFAULT_QUIT_DIALOG_COPY);
+    expect(coerceQuitDialogCopy("nope")).toEqual(DEFAULT_QUIT_DIALOG_COPY);
+    expect(coerceQuitDialogCopy([])).toEqual(DEFAULT_QUIT_DIALOG_COPY);
+  });
+});
+
+describe("quit-dialog-copy store", () => {
+  const directories = new Set<string>();
+
+  afterEach(async () => {
+    await Promise.all(
+      [...directories].map((directory) => rm(directory, { recursive: true, force: true })),
+    );
+    directories.clear();
+  });
+
+  async function tempDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "paseo-quit-copy-"));
+    directories.add(dir);
+    return dir;
+  }
+
+  it("serves English before the renderer has sent anything", async () => {
+    const userDataPath = await tempDir();
+    const store = createQuitDialogCopyStore({ userDataPath });
+
+    await store.load();
+
+    expect(store.get()).toEqual(DEFAULT_QUIT_DIALOG_COPY);
+  });
+
+  it("round-trips translated copy across a restart", async () => {
+    const userDataPath = await tempDir();
+
+    await createQuitDialogCopyStore({ userDataPath }).set(GERMAN);
+
+    // The quit path reads this synchronously, so it has to be right at startup.
+    const nextLaunch = createQuitDialogCopyStore({ userDataPath });
+    await nextLaunch.load();
+
+    expect(nextLaunch.get()).toEqual(GERMAN);
+  });
+
+  it("serves the new copy synchronously right after a language change", async () => {
+    const userDataPath = await tempDir();
+    const store = createQuitDialogCopyStore({ userDataPath });
+
+    await store.set(GERMAN);
+
+    expect(store.get()).toEqual(GERMAN);
+  });
+
+  it("treats a corrupt mirror as a cache miss", async () => {
+    const userDataPath = await tempDir();
+    await writeFile(path.join(userDataPath, "quit-dialog-copy.json"), "{ not json");
+    const store = createQuitDialogCopyStore({ userDataPath });
+
+    await expect(store.load()).resolves.toBeUndefined();
+    expect(store.get()).toEqual(DEFAULT_QUIT_DIALOG_COPY);
+  });
+
+  it("survives a mirror written with a partial locale", async () => {
+    const userDataPath = await tempDir();
+    await writeFile(
+      path.join(userDataPath, "quit-dialog-copy.json"),
+      JSON.stringify({ version: 1, copy: { title: "Paseo beenden?" } }),
+    );
+    const store = createQuitDialogCopyStore({ userDataPath });
+
+    await store.load();
+
+    expect(store.get().title).toBe("Paseo beenden?");
+    expect(store.get().quitLabel).toBe(DEFAULT_QUIT_DIALOG_COPY.quitLabel);
+  });
+});

--- a/packages/desktop/src/settings/quit-dialog-copy.ts
+++ b/packages/desktop/src/settings/quit-dialog-copy.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Localized strings for the quit confirmation dialog.
+ *
+ * The main process has no i18n bundle, but the quit prompt is the most-seen new
+ * string in an app that ships every locale under `app/src/i18n/resources`, so an
+ * English-only dialog is not acceptable. The renderer owns translation and pushes
+ * the resolved strings here;
+ * main keeps them in memory and mirrors them to disk so the very first quit after
+ * a cold start is already localized.
+ *
+ * Kept out of DesktopSettings on purpose: five display strings would otherwise
+ * cost five hand-written coercion points in the desktop schema and five more in
+ * the renderer mirror, for data that is a cache rather than a preference.
+ */
+export interface QuitDialogCopy {
+  title: string;
+  message: string;
+  quitLabel: string;
+  cancelLabel: string;
+  keepDaemonRunningLabel: string;
+}
+
+export const DEFAULT_QUIT_DIALOG_COPY: QuitDialogCopy = {
+  title: "Quit Paseo?",
+  message:
+    "Quitting stops the local daemon, along with any agents it is running. Their work will be interrupted.",
+  quitLabel: "Quit",
+  cancelLabel: "Cancel",
+  keepDaemonRunningLabel: "Leave the daemon running",
+};
+
+const QUIT_DIALOG_COPY_FILENAME = "quit-dialog-copy.json";
+
+interface PersistedQuitDialogCopyDocument {
+  version: 1;
+  copy: QuitDialogCopy;
+}
+
+export interface QuitDialogCopyStore {
+  /** Synchronous: the quit path must never wait on disk. */
+  get(): QuitDialogCopy;
+  /** Reads the mirrored copy from disk. Safe to call once at startup. */
+  load(): Promise<void>;
+  /** Accepts freshly translated copy from the renderer and mirrors it to disk. */
+  set(input: unknown): Promise<QuitDialogCopy>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error;
+}
+
+function coerceString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Falls back per key, not wholesale: a locale file that is missing one string
+ * should still get the other four translated rather than reverting the whole
+ * dialog to English.
+ */
+export function coerceQuitDialogCopy(input: unknown): QuitDialogCopy {
+  const record = isRecord(input) ? input : {};
+  return {
+    title: coerceString(record.title) ?? DEFAULT_QUIT_DIALOG_COPY.title,
+    message: coerceString(record.message) ?? DEFAULT_QUIT_DIALOG_COPY.message,
+    quitLabel: coerceString(record.quitLabel) ?? DEFAULT_QUIT_DIALOG_COPY.quitLabel,
+    cancelLabel: coerceString(record.cancelLabel) ?? DEFAULT_QUIT_DIALOG_COPY.cancelLabel,
+    keepDaemonRunningLabel:
+      coerceString(record.keepDaemonRunningLabel) ??
+      DEFAULT_QUIT_DIALOG_COPY.keepDaemonRunningLabel,
+  };
+}
+
+export function createQuitDialogCopyStore({
+  userDataPath,
+}: {
+  userDataPath: string;
+}): QuitDialogCopyStore {
+  const filePath = path.join(userDataPath, QUIT_DIALOG_COPY_FILENAME);
+  let copy: QuitDialogCopy = DEFAULT_QUIT_DIALOG_COPY;
+  let persistQueue: Promise<void> = Promise.resolve();
+
+  async function persist(next: QuitDialogCopy): Promise<void> {
+    const document: PersistedQuitDialogCopyDocument = { version: 1, copy: next };
+    const write = async () => {
+      await mkdir(userDataPath, { recursive: true });
+      const tempFilePath = `${filePath}.tmp.${process.pid}.${randomUUID()}`;
+      await writeFile(tempFilePath, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+      await rename(tempFilePath, filePath);
+    };
+    const queued = persistQueue.then(write, write);
+    persistQueue = queued.catch(() => undefined);
+    await queued;
+  }
+
+  return {
+    get: () => copy,
+
+    async load(): Promise<void> {
+      let raw: string;
+      try {
+        raw = await readFile(filePath, "utf8");
+      } catch (error) {
+        // No mirror yet (first launch) is expected; anything else still must not
+        // block startup, so English stands in either way.
+        if (!isNodeError(error) || error.code !== "ENOENT") {
+          throw error;
+        }
+        return;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        // A corrupt mirror is a cache miss, not a failure.
+        return;
+      }
+
+      copy = coerceQuitDialogCopy(isRecord(parsed) ? parsed.copy : null);
+    },
+
+    async set(input: unknown): Promise<QuitDialogCopy> {
+      copy = coerceQuitDialogCopy(input);
+      await persist(copy);
+      return copy;
+    },
+  };
+}

--- a/packages/desktop/src/window/window-close-policy.test.ts
+++ b/packages/desktop/src/window/window-close-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { countLiveWindows, shouldVetoWindowClose } from "./window-close-policy.js";
+
+function win(destroyed = false) {
+  return { isDestroyed: () => destroyed };
+}
+
+const OPEN = { quitCommitted: false, sessionEnding: false };
+
+describe("countLiveWindows", () => {
+  it("ignores destroyed windows", () => {
+    expect(countLiveWindows([win(), win(true), win()])).toBe(2);
+    expect(countLiveWindows([win(true)])).toBe(0);
+    expect(countLiveWindows([])).toBe(0);
+  });
+});
+
+describe("shouldVetoWindowClose", () => {
+  it("asks before closing the last window, because that quits the app", () => {
+    expect(shouldVetoWindowClose({ ...OPEN, windows: [win()] })).toBe(true);
+  });
+
+  it("does not ask when other windows remain", () => {
+    expect(shouldVetoWindowClose({ ...OPEN, windows: [win(), win()] })).toBe(false);
+  });
+
+  // A window closed moments ago can still be in getAllWindows(); counting it
+  // would make the real last window look like one of two and skip the prompt.
+  it("treats a window whose only sibling is destroyed as the last one", () => {
+    expect(shouldVetoWindowClose({ ...OPEN, windows: [win(), win(true)] })).toBe(true);
+  });
+
+  // quitAndInstall() closes every window before calling app.quit(). A veto here
+  // strands the updater with a half-finished handoff.
+  it("never vetoes once the quit is committed", () => {
+    expect(
+      shouldVetoWindowClose({ windows: [win()], quitCommitted: true, sessionEnding: false }),
+    ).toBe(false);
+  });
+
+  it("never vetoes while the OS session is ending", () => {
+    expect(
+      shouldVetoWindowClose({ windows: [win()], quitCommitted: false, sessionEnding: true }),
+    ).toBe(false);
+  });
+
+  // Whether the closing window is still listed during its own `close` event is
+  // an Electron detail we do not depend on: both "it counts itself" (1) and "it
+  // is already gone" (0) mean no window survives, so both prompt.
+  it("prompts whether or not the closing window still counts itself", () => {
+    expect(shouldVetoWindowClose({ ...OPEN, windows: [] })).toBe(true);
+    expect(shouldVetoWindowClose({ ...OPEN, windows: [win(true)] })).toBe(true);
+  });
+});

--- a/packages/desktop/src/window/window-close-policy.ts
+++ b/packages/desktop/src/window/window-close-policy.ts
@@ -1,0 +1,59 @@
+/**
+ * Decides whether closing a window should be vetoed to ask the user first.
+ *
+ * On Windows and Linux there is no Cmd+Q — closing the last window is how people
+ * quit, and `window-all-closed` turns that into `app.quit()`. So the guard has to
+ * sit on the window close, not only on `before-quit`.
+ *
+ * Pure and Electron-free on purpose: the window enumeration is the subtle part
+ * (the closing window still counts itself, destroyed-but-uncollected windows
+ * linger, and detached DevTools windows are BrowserWindows too), so it lives
+ * inside the tested unit rather than at the call site in main.ts.
+ */
+
+interface CloseableWindow {
+  isDestroyed(): boolean;
+}
+
+export interface WindowCloseDecisionInput {
+  /** Every window the app currently owns, including the one being closed. */
+  windows: CloseableWindow[];
+  /** True once the quit has been confirmed or handed to the auto-updater. */
+  quitCommitted: boolean;
+  /** True while the OS is logging out or shutting down. */
+  sessionEnding: boolean;
+}
+
+/** Windows that still count toward "is this the last one". */
+export function countLiveWindows(windows: CloseableWindow[]): number {
+  return windows.filter((win) => !win.isDestroyed()).length;
+}
+
+export function shouldVetoWindowClose({
+  windows,
+  quitCommitted,
+  sessionEnding,
+}: WindowCloseDecisionInput): boolean {
+  // The user already answered, or `quitAndInstall()` is closing every window to
+  // install an update. Vetoing here would strand the updater mid-handoff.
+  if (quitCommitted) {
+    return false;
+  }
+
+  // Windows delivers WM_QUERYENDSESSION/WM_CLOSE during logout. Vetoing either
+  // parks the shutdown behind a "this app is preventing you from logging out"
+  // dialog or gets the process force-killed with the dialog still up.
+  if (sessionEnding) {
+    return false;
+  }
+
+  // Closing one of several windows doesn't quit the app, so there is nothing to
+  // confirm. Only the last one turns into a quit.
+  //
+  // `<= 1` rather than `=== 1` deliberately: whether the closing window is still
+  // in getAllWindows() during its own `close` event is an Electron implementation
+  // detail, and both readings (1 = it counts itself, 0 = already removed) mean no
+  // window survives. The dialog falls back to app-modal when no window is usable,
+  // so the 0 case still shows something.
+  return countLiveWindows(windows) <= 1;
+}

--- a/packages/desktop/src/window/window-manager.test.ts
+++ b/packages/desktop/src/window/window-manager.test.ts
@@ -13,7 +13,11 @@ import {
   readWindowTheme,
   resolveRuntimeTitleBarOverlayOptions,
   resolveWindowBounds,
+  setupWindowStatePersistence,
+  type PersistableWindow,
+  type QuitEventTarget,
 } from "./window-manager";
+import type { WindowState, WindowStateStore } from "../settings/window-state";
 
 describe("window-manager", () => {
   describe("readBadgeCount", () => {
@@ -237,6 +241,194 @@ describe("window-manager", () => {
         width: 1024,
         height: 720,
       });
+    });
+  });
+
+  describe("setupWindowStatePersistence", () => {
+    function createFakeWindow(): PersistableWindow & {
+      emit(event: string): void;
+      setBounds(bounds: { x: number; y: number; width: number; height: number }): void;
+    } {
+      const handlers = new Map<string, Array<() => void>>();
+      let bounds = { x: 0, y: 0, width: 800, height: 600 };
+
+      return {
+        isMinimized: () => false,
+        isFullScreen: () => false,
+        isMaximized: () => false,
+        getNormalBounds: () => bounds,
+        on(event, handler) {
+          const existing = handlers.get(event) ?? [];
+          existing.push(handler);
+          handlers.set(event, existing);
+          return this;
+        },
+        emit(event) {
+          for (const handler of handlers.get(event) ?? []) {
+            handler();
+          }
+        },
+        setBounds(next) {
+          bounds = next;
+        },
+      };
+    }
+
+    function createFakeQuitEvents(): QuitEventTarget & { emit(): void } {
+      let handlers: Array<() => void> = [];
+      return {
+        on(_event, handler) {
+          handlers.push(handler);
+          return this;
+        },
+        removeListener(_event, handler) {
+          handlers = handlers.filter((existing) => existing !== handler);
+          return this;
+        },
+        emit() {
+          // for-of holds the array it started on, so a listener removing itself
+          // mid-emit (removeListener reassigns `handlers`) can't skip a peer.
+          for (const handler of handlers) {
+            handler();
+          }
+        },
+      };
+    }
+
+    /**
+     * A store that reproduces the real one-way `finalized` latch: once saveSync
+     * lands, every later save() is dropped (see settings/window-state.ts).
+     */
+    function createLatchingStore(): WindowStateStore & { written: WindowState[] } {
+      const written: WindowState[] = [];
+      let finalized = false;
+      return {
+        written,
+        load: async () => null,
+        async save(state) {
+          if (finalized) {
+            return;
+          }
+          written.push(state);
+        },
+        saveSync(state) {
+          finalized = true;
+          written.push(state);
+        },
+      };
+    }
+
+    it("flushes geometry on an ordinary window close", () => {
+      const win = createFakeWindow();
+      const store = createLatchingStore();
+      setupWindowStatePersistence(win, store, { quitEvents: createFakeQuitEvents() });
+
+      win.setBounds({ x: 10, y: 20, width: 1000, height: 700 });
+      win.emit("close");
+
+      expect(store.written).toEqual([
+        { x: 10, y: 20, width: 1000, height: 700, isMaximized: false },
+      ]);
+    });
+
+    // Cmd+W, the red button, and closing one of several windows all happen with
+    // the quit uncommitted. Gating the close flush on quit-committed would drop
+    // every one of them, and `closed` then unregisters the before-quit listener,
+    // so the geometry would never be written again.
+    it("still flushes on close when the quit is not committed", () => {
+      const win = createFakeWindow();
+      const store = createLatchingStore();
+      setupWindowStatePersistence(win, store, {
+        quitEvents: createFakeQuitEvents(),
+        gates: { willVetoClose: () => false, isQuitCommitted: () => false },
+      });
+
+      win.emit("close");
+
+      expect(store.written).toHaveLength(1);
+    });
+
+    it("does not flush a close that is about to be vetoed", () => {
+      const win = createFakeWindow();
+      const store = createLatchingStore();
+      setupWindowStatePersistence(win, store, {
+        quitEvents: createFakeQuitEvents(),
+        gates: { willVetoClose: () => true, isQuitCommitted: () => false },
+      });
+
+      win.emit("close");
+
+      expect(store.written).toEqual([]);
+    });
+
+    it("does not flush a before-quit the user can still cancel", () => {
+      const win = createFakeWindow();
+      const store = createLatchingStore();
+      const quitEvents = createFakeQuitEvents();
+      setupWindowStatePersistence(win, store, {
+        quitEvents,
+        gates: { willVetoClose: () => true, isQuitCommitted: () => false },
+      });
+
+      quitEvents.emit();
+
+      expect(store.written).toEqual([]);
+    });
+
+    it("flushes on before-quit once the quit is committed", () => {
+      const win = createFakeWindow();
+      const store = createLatchingStore();
+      const quitEvents = createFakeQuitEvents();
+      let committed = false;
+      setupWindowStatePersistence(win, store, {
+        quitEvents,
+        gates: { willVetoClose: () => !committed, isQuitCommitted: () => committed },
+      });
+
+      quitEvents.emit();
+      committed = true;
+      quitEvents.emit();
+
+      expect(store.written).toHaveLength(1);
+    });
+
+    // The regression this gating exists for: a cancelled quit used to run the
+    // synchronous final write, latching the store, after which resizing the
+    // window and quitting for real persisted nothing.
+    it("still persists the final geometry after the user cancels a quit", async () => {
+      const win = createFakeWindow();
+      const store = createLatchingStore();
+      const quitEvents = createFakeQuitEvents();
+      let committed = false;
+      setupWindowStatePersistence(win, store, {
+        quitEvents,
+        gates: { willVetoClose: () => !committed, isQuitCommitted: () => committed },
+      });
+
+      // Cmd+Q, then Cancel.
+      quitEvents.emit();
+
+      // Resize, then quit for real.
+      win.setBounds({ x: 5, y: 5, width: 1280, height: 800 });
+      committed = true;
+      quitEvents.emit();
+
+      expect(store.written).toEqual([{ x: 5, y: 5, width: 1280, height: 800, isMaximized: false }]);
+    });
+
+    it("stops listening for quits once the window is gone", () => {
+      const win = createFakeWindow();
+      const store = createLatchingStore();
+      const quitEvents = createFakeQuitEvents();
+      setupWindowStatePersistence(win, store, {
+        quitEvents,
+        gates: { willVetoClose: () => false, isQuitCommitted: () => true },
+      });
+
+      win.emit("closed");
+      quitEvents.emit();
+
+      expect(store.written).toEqual([]);
     });
   });
 });

--- a/packages/desktop/src/window/window-manager.ts
+++ b/packages/desktop/src/window/window-manager.ts
@@ -294,13 +294,62 @@ export function setupWindowResizeEvents(win: BrowserWindow): void {
 }
 
 /**
+ * Gates that tell the persistence layer whether a close/quit is actually final.
+ *
+ * `store.saveSync` sets a one-way `finalized` latch (see settings/window-state.ts)
+ * that permanently short-circuits every later `save()`. That is correct for a real
+ * exit and catastrophic for one the user cancels: the window would keep working
+ * but silently stop remembering its geometry until the app restarts.
+ */
+export interface WindowStatePersistenceGates {
+  /** True when this close is about to be vetoed to ask the user, so it isn't final. */
+  willVetoClose: () => boolean;
+  /** True once the quit has been confirmed or handed to the updater. */
+  isQuitCommitted: () => boolean;
+}
+
+// Default gates preserve the pre-confirmation behavior: every close and every
+// before-quit is final.
+const ALWAYS_FINAL: WindowStatePersistenceGates = {
+  willVetoClose: () => false,
+  isQuitCommitted: () => true,
+};
+
+/** The window surface this function actually uses, so tests can supply a fake. */
+export interface PersistableWindow {
+  isMinimized(): boolean;
+  isFullScreen(): boolean;
+  isMaximized(): boolean;
+  getNormalBounds(): { x: number; y: number; width: number; height: number };
+  on(
+    event: "resize" | "move" | "maximize" | "unmaximize" | "close" | "closed",
+    handler: () => void,
+  ): unknown;
+}
+
+/** The `app` surface this function uses. Injectable for the same reason. */
+export interface QuitEventTarget {
+  on(event: "before-quit", handler: () => void): unknown;
+  removeListener(event: "before-quit", handler: () => void): unknown;
+}
+
+export interface WindowStatePersistenceOptions {
+  gates?: WindowStatePersistenceGates;
+  quitEvents?: QuitEventTarget;
+}
+
+/**
  * Persist the window's size/position/maximized state so it can be restored on
  * the next launch. Debounces disk writes on resize/move, writes immediately on
  * maximize/unmaximize, and flushes synchronously on close so the final state
  * survives quit/reboot. The latest geometry is captured into memory on every
  * event so a queued async write can never overwrite the close-time snapshot.
  */
-export function setupWindowStatePersistence(win: BrowserWindow, store: WindowStateStore): void {
+export function setupWindowStatePersistence(
+  win: PersistableWindow,
+  store: WindowStateStore,
+  { gates = ALWAYS_FINAL, quitEvents = app }: WindowStatePersistenceOptions = {},
+): void {
   let latestState: WindowState | null = null;
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   let flushed = false;
@@ -351,9 +400,11 @@ export function setupWindowStatePersistence(win: BrowserWindow, store: WindowSta
     persist();
   }
 
-  // Final synchronous flush. Runs on window close AND on app quit: the app's
-  // before-quit handler calls app.exit(0), which bypasses the window close
-  // event (see daemon/quit-lifecycle.ts), so close alone would miss Cmd+Q.
+  // Final synchronous flush. Reached from window close AND from app quit: the
+  // app's before-quit handler calls app.exit(0), which bypasses the window close
+  // event (see daemon/quit-lifecycle.ts), so close alone would miss Cmd+Q. Both
+  // entry points gate on whether the exit is actually going to happen — see
+  // WindowStatePersistenceGates.
   function flushFinal(): void {
     if (flushed) {
       return;
@@ -370,16 +421,35 @@ export function setupWindowStatePersistence(win: BrowserWindow, store: WindowSta
     }
   }
 
+  // A close that is about to be vetoed (the quit-confirmation prompt on
+  // Windows/Linux) is not final. Every other close is — including Cmd+W and the
+  // red button, which is why this is gated on the veto and not on the quit.
+  function flushOnClose(): void {
+    if (gates.willVetoClose()) {
+      return;
+    }
+    flushFinal();
+  }
+
+  // The quit equivalent: before-quit fires for quits the user can still cancel,
+  // so only a committed quit gets the final write.
+  function flushOnQuit(): void {
+    if (!gates.isQuitCommitted()) {
+      return;
+    }
+    flushFinal();
+  }
+
   win.on("resize", scheduleSave);
   win.on("move", scheduleSave);
   win.on("maximize", saveNow);
   win.on("unmaximize", saveNow);
-  win.on("close", flushFinal);
-  app.on("before-quit", flushFinal);
+  win.on("close", flushOnClose);
+  quitEvents.on("before-quit", flushOnQuit);
 
   win.on("closed", () => {
     clearTimer();
-    app.removeListener("before-quit", flushFinal);
+    quitEvents.removeListener("before-quit", flushOnQuit);
   });
 }
 


### PR DESCRIPTION
### Type of change

- [x] New feature

### Reasoning

Quitting Paseo Desktop is instant and irreversible. Cmd+Q on macOS, or closing the last window on Windows and Linux, tears the app down, and because `daemon.keepRunningAfterQuit` defaults to `false` it also stops the desktop-managed daemon and every agent it was running.

That is not only what a fresh install gets. The `daemonStopOnQuitDefaultApplied` migration reset installs that still had the old `keepRunningAfterQuit: true` value on disk, so stop-on-quit applies to everyone who has not explicitly turned it back on.

I hit Cmd+Q by accident and lost in-progress agent work. Q sits one key from W and one key from Tab, so Cmd+Q is a slip away from both Cmd+W and Cmd+Tab, which are the two things you press constantly while working.

In this app that shortcut destroys running processes doing real work, not an unsaved buffer you can recover. It deserves the same guard any other destructive action gets. This adds a confirmation, but only on the quits that actually stop something.

### Goals

- Confirm before a quit that would stop a running desktop-managed daemon, and only then. If the daemon is already stopped, was started outside the app, or "Keep daemon running after quit" is on, the quit stays immediate and silent.
- Cover every quit entry point rather than just the shortcut: Cmd+Q, Dock Quit, the app menu, and Alt+F4 on the last window.
- Default the dialog to Cancel so pressing Enter does not quit.
- Offer "Leave the daemon running" in the dialog, so quitting the desktop app without interrupting agents is one click at the moment you need it. It applies to that quit only and never writes settings, because "just this once" and "from now on" are different intents and the durable one already exists as "Keep daemon running after quit".

### Non-goals

- No new setting. "Keep daemon running after quit" already silences the prompt, and it does so by removing the risk rather than hiding it. A separate "confirm before quitting" toggle would be a second way to answer the same question, and a no-op whenever the first one is on. The trade-off: there is no way to keep stop-on-quit and never be asked. Happy to add one if you want it.
- No warning for a daemon Paseo did not start. The prompt is scoped to desktop-managed daemons, since Paseo cannot claim ownership of a daemon it did not launch. Quitting with agents on a manually started daemon stays silent.
- The Windows and Linux overlay gap is left as is. Quitting by closing the last window destroys that window before the daemon-stop overlay can render, so the app disappears and the process lingers briefly. This is pre-existing behaviour, documented rather than fixed. The confirmation itself runs before the window is destroyed, so it is unaffected.

### QA

**Tests:**

- `packages/desktop/src/features/quit-confirmation.test.ts` (new) - the whole decision table for whether a quit needs a dialog, the one-shot checkbox and its refusal to leak past Cancel, dialog deduplication when two quit paths race, fail-open on every throwing dependency, and parent-window selection excluding hidden, minimized and destroyed windows.
- `packages/desktop/src/window/window-close-policy.test.ts` (new) - when closing a window should veto on Windows and Linux, including the update-in-flight and session-end exemptions and the destroyed-window counting rule.
- `packages/desktop/src/settings/quit-dialog-copy.test.ts` (new) - round-trip of the localized copy store, plus per-key English fallback for a missing, corrupt or partial file.
- `packages/desktop/src/features/dialogs.test.ts` (new) - that the extracted message-box builder preserves `cancelId` and `defaultId` for the existing confirm paths, and that the quit dialog defaults to Cancel.
- `packages/desktop/src/daemon/quit-lifecycle.test.ts` (extended) - an unconfirmed quit runs none of the side effects below the gate, the one-shot keep-running override outranks the stored setting, and a spurious second quit is not misread as an update handoff.
- `packages/desktop/src/window/window-manager.test.ts` (extended) - a normal Cmd+W close still flushes geometry, and a cancelled quit does not trip the window-state store's one-way finalized latch.
- `packages/desktop/src/settings/desktop-settings.test.ts` (extended) - the synchronous settings accessor agrees with the async one, which is what lets the gate decide before `preventDefault()`.

**Behaviour verified by hand** on macOS, desktop build, against a checkout-local `PASEO_HOME` with a managed daemon running:

- Cmd+Q shows the confirmation. Cancel leaves the app fully usable with agents still streaming.
- Ticking "Leave the daemon running" and choosing Quit exits the app, and the daemon and its agents are still alive afterwards.

Not verified by hand: that Enter defaults to Cancel, the auto-update and Windows session-end exemptions, and anything on Windows or Linux.

<img width="297" height="286" alt="image" src="https://github.com/user-attachments/assets/674a5c65-a524-443f-8d50-f853d2ad43b3" />

Tested on desktop (Electron, macOS). Not tested: web, iOS, Android.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
