### PR TITLE
fix(server): resolve exact file paths that git ignores

### DIFF
--- a/packages/server/src/server/daemon-client.e2e.test.ts
+++ b/packages/server/src/server/daemon-client.e2e.test.ts
@@ -1188,6 +1188,42 @@ test("finds workspace files inside the OpenCode directory", async () => {
   }
 }, 30000);
 
+test("opens an exact gitignored workspace path without offering it as a suggestion", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "paseo-gitignored-suggestion-"));
+  const target = path.join(cwd, "generated", "notes.md");
+
+  try {
+    execSync("git init -q", { cwd });
+    writeFileSync(path.join(cwd, ".gitignore"), "generated/\n");
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, "generated notes\n");
+    writeFileSync(path.join(cwd, "notes.md"), "tracked notes\n");
+
+    const exactResult = await ctx.client.getDirectorySuggestions({
+      cwd,
+      query: "generated/notes.md",
+      includeFiles: true,
+      includeDirectories: false,
+      matchMode: "suffix",
+      limit: 1,
+    });
+    const discoveryResult = await ctx.client.getDirectorySuggestions({
+      cwd,
+      query: "notes",
+      includeFiles: true,
+      includeDirectories: false,
+      limit: 20,
+    });
+
+    expect(exactResult.error).toBeNull();
+    expect(exactResult.entries).toEqual([{ path: "generated/notes.md", kind: "file" }]);
+    expect(discoveryResult.error).toBeNull();
+    expect(discoveryResult.entries).toEqual([{ path: "notes.md", kind: "file" }]);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}, 30000);
+
 test("receives server_info on websocket connect", async () => {
   const client = new DaemonClient({
     url: `ws://127.0.0.1:${ctx.daemon.port}/ws`,

--- a/packages/server/src/utils/directory-suggestions.test.ts
+++ b/packages/server/src/utils/directory-suggestions.test.ts
@@ -53,6 +53,7 @@ async function searchRelativeDirectoryEntries(options: {
   matchMode?: "fuzzy" | "suffix";
   maxDepth?: number;
   maxEntriesScanned?: number;
+  respectGitIgnore?: boolean;
 }) {
   return searchDirectoryEntries({
     root: options.cwd,
@@ -67,7 +68,13 @@ async function searchRelativeDirectoryEntries(options: {
     limit: options.limit,
     maxDepth: options.maxDepth,
     maxEntriesScanned: options.maxEntriesScanned,
+    respectGitIgnore: options.respectGitIgnore,
   });
+}
+
+function initGitRepo(directory: string, ignorePatterns: string): void {
+  execFileSync("git", ["init", "-q"], { cwd: directory });
+  writeFileSync(path.join(directory, ".gitignore"), ignorePatterns);
 }
 
 describe("searchDirectoryEntries", () => {
@@ -790,6 +797,68 @@ describe("relative typed-entry configuration", () => {
 
     expect(results).toEqual([{ path: ".dev/paseo-home/daemon.log", kind: "file" }]);
   });
+
+  it("resolves an exact gitignored path while keeping it out of discovery results", async () => {
+    initGitRepo(workspaceDir, "generated/\n");
+    mkdirSync(path.join(workspaceDir, "generated"), { recursive: true });
+    writeFileSync(path.join(workspaceDir, "generated", "notes.md"), "generated notes\n");
+
+    const exactResults = await searchRelativeDirectoryEntries({
+      cwd: workspaceDir,
+      query: "generated/notes.md",
+      limit: 1,
+      includeFiles: true,
+      includeDirectories: false,
+      matchMode: "suffix",
+      respectGitIgnore: true,
+    });
+    const fuzzyResults = await searchRelativeDirectoryEntries({
+      cwd: workspaceDir,
+      query: "notes",
+      limit: 20,
+      includeFiles: true,
+      includeDirectories: false,
+      respectGitIgnore: true,
+    });
+
+    expect({ exactResults, fuzzyResults }).toEqual({
+      exactResults: [{ path: "generated/notes.md", kind: "file" }],
+      fuzzyResults: [{ path: "docs/notes.md", kind: "file" }],
+    });
+  });
+
+  it.skipIf(isWindows)(
+    "refuses an exact path that escapes the root through a symlink",
+    async () => {
+      const outsideDir = path.join(tempRoot, "outside-workspace");
+      mkdirSync(outsideDir, { recursive: true });
+      writeFileSync(path.join(outsideDir, "secret.md"), "outside\n");
+      symlinkSync(outsideDir, path.join(workspaceDir, "escape-link"));
+      symlinkSync(path.join(workspaceDir, "docs"), path.join(workspaceDir, "inside-link"));
+
+      const escaping = await searchRelativeDirectoryEntries({
+        cwd: workspaceDir,
+        query: "escape-link/secret.md",
+        limit: 1,
+        includeFiles: true,
+        includeDirectories: false,
+        matchMode: "suffix",
+      });
+      const staysInside = await searchRelativeDirectoryEntries({
+        cwd: workspaceDir,
+        query: "inside-link/notes.md",
+        limit: 1,
+        includeFiles: true,
+        includeDirectories: false,
+        matchMode: "suffix",
+      });
+
+      expect({ escaping, staysInside }).toEqual({
+        escaping: [],
+        staysInside: [{ path: "inside-link/notes.md", kind: "file" }],
+      });
+    },
+  );
 
   it("traverses only allowlisted hidden directories without suggesting the directories", async () => {
     mkdirSync(path.join(workspaceDir, ".claude"), { recursive: true });

--- a/packages/server/src/utils/directory-suggestions.ts
+++ b/packages/server/src/utils/directory-suggestions.ts
@@ -119,6 +119,11 @@ const IGNORED_DIRECTORY_NAMES = new Set([
 const directoryListCache = new Map<string, DirectoryListCacheEntry>();
 const gitIgnoredPathsCache = new Map<string, GitIgnoredPathsCacheEntry>();
 
+// Discovery and retrieval filter differently, on purpose. Discovery — anything that ranks or
+// browses candidates the caller has not named — drops gitignored and hidden entries, so pickers
+// do not offer build output. Retrieval of a path the caller named exactly applies no ignore or
+// hidden filtering; the only question is whether the path stays inside the root. Clicking a file
+// reference an agent wrote must open it whether or not Git tracks it.
 export async function searchDirectoryEntries(
   options: SearchDirectoryEntriesOptions,
 ): Promise<DirectorySuggestionEntry[]> {
@@ -188,7 +193,8 @@ async function findExactEntry(input: SearchInput): Promise<DirectorySuggestionEn
   const visiblePath = path.resolve(input.root, input.plan.normalizedQuery);
   const resolvedPath = await realpath(visiblePath).catch(() => null);
   if (!resolvedPath || !isPathInsideRoot(input.root, resolvedPath)) return null;
-  if (isGitIgnoredPath(resolvedPath, input)) return null;
+  // No ignore filtering here: the caller named this exact path, so containment above is the
+  // only question left to answer. Filtering belongs to discovery, not retrieval.
   const info = await stat(resolvedPath).catch(() => null);
   const kind = getEntryKind(info);
   if (


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Reasoning

When an agent writes a file and then mentions its path, clicking that path should open it. Today it fails with "No file found" whenever the file is gitignored, which covers anything an agent puts under a scratch directory like `.dev/`. The file is right there on disk and the link is dead. Backticked paths do not open directly, they go through the directory-suggestions RPC, and that search filters out gitignored entries before returning. The filter is correct for the composer's @-mention picker, which should not offer up `node_modules`. It is wrong for click-to-open, where the user is pointing at one specific file that was just named for them. This splits the two cases: a query that names an exact path skips the ignore filters, while anything that ranks or browses candidates keeps them.

### Goals

- Clicking a file reference that names an exact path opens the file, whether or not git ignores it.
- Ranked and browse results are unchanged: the @-mention picker and the directory chooser still hide gitignored entries.
- Containment inside the workspace root stays the only check on the exact-path branch, including through symlinks.
- No new option, RPC field, or protocol change.

### Non-goals

- Bare filenames. The exact-path branch only runs when the query looks like a path, so a backticked filename with no slash inside an ignored directory still fails. Dropping that condition would let a root-level file short-circuit the ranked search and outrank a nested file with the same name that resolves correctly today.
- A flag on the RPC. Letting the client ask for unfiltered results would need a protocol field and a way for the daemon to tell a link open from a picker query. The exact-path condition already carries that meaning.
- Any change to what is readable. The file-read path applies no ignore filtering at all, it checks only that the path stays inside the workspace root, before and after resolving symlinks. Every file this now surfaces was already readable through the file explorer.
- The redundant git lookup. `loadGitIgnoredPaths` is awaited before the search picks a strategy, so an exact hit still shells out to `git ls-files` and discards the result. Reordering it is about six lines and I left it out to keep this focused. Happy to fold it in if you want it here.

### QA

Reproduced on desktop first: an agent wrote a file under `.dev/` and mentioned its path, and clicking the link showed the "No file found" toast while the file sat on disk. After the change, clicking the same kind of link opens the file.

**Tests:**

- `packages/server/src/utils/directory-suggestions.test.ts` (extended) - in a real git repo with a real `.gitignore`, that an exact path resolves while the same file stays out of fuzzy results, and that an exact path escaping the root through a symlink is refused while one staying inside still resolves. Both asserted against a control so an empty result cannot pass by accident. The first was verified failing against the unfixed code.
- `packages/server/src/server/daemon-client.e2e.test.ts` (extended) - the same asymmetry driven through a real client against a real daemon, which covers the session wiring that turns gitignore filtering on and that a unit test cannot reach. Verified failing against the unfixed code.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
