### PR TITLE
Keep the active project when switching workspace hosts

### DIFF
--- a/packages/app/e2e/browser/new-workspace-host-project-preservation.spec.ts
+++ b/packages/app/e2e/browser/new-workspace-host-project-preservation.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "../support/helpers/new-workspace";
 import { connectSeedClient, type SeedDaemonClient } from "../support/helpers/seed-client";
 import { getServerId } from "../support/helpers/server-id";
+import { addConnectedHostsAndReload } from "../support/helpers/hosts";
 import { switchWorkspaceViaSidebar } from "../support/helpers/workspace-ui";
 import { createTempGitRepo } from "../support/helpers/workspace";
 
@@ -29,6 +30,7 @@ interface CreatedProject {
 
 interface CrossHostProjectScenario {
   contextWorkspaceId: string;
+  primarySharedWorkspaceId: string;
   selectedProjectViewKey: string;
   sharedProjectKey: string;
   secondaryHost: {
@@ -149,6 +151,7 @@ const test = base.extend<{ crossHostProject: CrossHostProjectScenario }>({
 
       await provide({
         contextWorkspaceId: contextProject.workspaceId,
+        primarySharedWorkspaceId: primarySharedProject.workspaceId,
         selectedProjectViewKey: projectPlacementViewKey(
           getServerId(),
           primarySharedProject.projectId,
@@ -192,6 +195,35 @@ test.describe("New workspace host project preservation", () => {
       projectViewKey: crossHostProject.selectedProjectViewKey,
       projectDisplayName: SHARED_PROJECT_NAME,
     });
+    await selectNewWorkspaceHost(page, SECONDARY_HOST_LABEL);
+
+    await expectNewWorkspaceProjectSelected(page, SHARED_PROJECT_NAME);
+  });
+
+  test("keeps the active workspace project selected when switching hosts", async ({
+    page,
+    crossHostProject,
+  }) => {
+    await openProjectDirectoryWithHosts(page, {
+      hosts: [crossHostProject.secondaryHost],
+      primaryLabel: PRIMARY_HOST_LABEL,
+    });
+    await switchWorkspaceViaSidebar({
+      page,
+      serverId: getServerId(),
+      workspaceId: crossHostProject.primarySharedWorkspaceId,
+    });
+    await openGlobalNewWorkspaceComposer(page);
+    await expectNewWorkspaceProjectSelected(page, SHARED_PROJECT_NAME);
+
+    await selectNewWorkspaceHost(page, SECONDARY_HOST_LABEL);
+
+    await expectNewWorkspaceProjectSelected(page, SHARED_PROJECT_NAME);
+
+    await addConnectedHostsAndReload(page, [crossHostProject.secondaryHost], {
+      primaryLabel: PRIMARY_HOST_LABEL,
+    });
+    await expectNewWorkspaceProjectSelected(page, SHARED_PROJECT_NAME);
     await selectNewWorkspaceHost(page, SECONDARY_HOST_LABEL);
 
     await expectNewWorkspaceProjectSelected(page, SHARED_PROJECT_NAME);

--- a/packages/app/src/projects/host-project-model.ts
+++ b/packages/app/src/projects/host-project-model.ts
@@ -71,7 +71,7 @@ export function hostProjectFromWorkspace(input: {
       serverId: input.serverId,
       projectId,
     }),
-    projectKey: null,
+    projectKey: input.workspace.project?.projectKey ?? null,
     projectName: input.workspace.projectDisplayName || projectId,
     projectKind: input.workspace.projectKind,
     iconWorkingDir,

--- a/packages/app/src/projects/host-projects.test.ts
+++ b/packages/app/src/projects/host-projects.test.ts
@@ -6,7 +6,9 @@ import {
   getHostProjectSourceDirectory,
   getWorktreeSupportForHostProject,
   hostProjectFromRoute,
+  hostProjectFromWorkspace,
 } from "./host-project-model";
+import { normalizeWorkspaceDescriptor } from "@/stores/session-store";
 
 function project(): HostProjectListItem {
   return {
@@ -93,6 +95,44 @@ describe("host project lookups", () => {
     ).toMatchObject({
       projectKey: null,
       hosts: [{ serverId: "host-a", projectId: "prj_a" }],
+    });
+  });
+
+  test("keeps canonical equivalence identity separate from host placement identity", () => {
+    const workspace = normalizeWorkspaceDescriptor({
+      id: "workspace-a",
+      projectId: "project-a",
+      projectDisplayName: "App",
+      projectRootPath: "/repo/app",
+      workspaceDirectory: "/repo/app",
+      projectKind: "git",
+      workspaceKind: "local_checkout",
+      name: "main",
+      archivingAt: null,
+      status: "done",
+      statusEnteredAt: null,
+      activityAt: null,
+      diffStat: null,
+      scripts: [],
+      project: {
+        projectKey: "remote:github.com/acme/app",
+        projectName: "App",
+        checkout: {
+          cwd: "/repo/app",
+          isGit: true,
+          currentBranch: "main",
+          remoteUrl: "https://github.com/acme/app.git",
+          worktreeRoot: "/repo/app",
+          isPaseoOwnedWorktree: false,
+          mainRepoRoot: null,
+        },
+      },
+    });
+
+    expect(hostProjectFromWorkspace({ serverId: "host-a", workspace })).toMatchObject({
+      viewKey: JSON.stringify(["host-a", "project-a"]),
+      projectKey: "remote:github.com/acme/app",
+      hosts: [{ serverId: "host-a", projectId: "project-a" }],
     });
   });
 });

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -78,6 +78,7 @@ import {
   getWorktreeSupportForHostProject,
   hostProjectFromRoute,
   hostProjectFromWorkspace,
+  resolveHostProjectCandidate,
   useHostProjects,
   type HostProjectListItem,
 } from "@/projects/host-projects";
@@ -1214,16 +1215,22 @@ function useNewWorkspaceInitialContext({
   const allServerIds = useMemo(() => allHosts.map((h) => h.serverId), [allHosts]);
   const projects = useHostProjects(allServerIds);
   const routeDisplayName = displayNameProp?.trim() ?? "";
-  const routeProject = useMemo(
-    () =>
-      hostProjectFromRoute({
+  const routeProject = useMemo(() => {
+    const routePlacement = hostProjectFromRoute({
+      serverId,
+      projectId,
+      displayName: routeDisplayName,
+      sourceDirectory: sourceDirectoryProp,
+    });
+    if (!routePlacement) return null;
+    return (
+      resolveHostProjectCandidate({
+        candidate: routePlacement,
+        projects,
         serverId,
-        projectId,
-        displayName: routeDisplayName,
-        sourceDirectory: sourceDirectoryProp,
-      }),
-    [projectId, routeDisplayName, serverId, sourceDirectoryProp],
-  );
+      }) ?? routePlacement
+    );
+  }, [projectId, projects, routeDisplayName, serverId, sourceDirectoryProp]);
   const lastWorkspaceSelection = useLastWorkspaceSelection();
   const lastWorkspaceServerId = useMemo(
     () =>

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -1202,6 +1202,7 @@ interface NewWorkspaceInitialContextState {
   openHostPicker: () => void;
   projects: HostProjectListItem[];
   routeProject: HostProjectListItem | null;
+  routeProjectContextViewKey: string | null;
   lastActiveProject: HostProjectListItem | null;
 }
 
@@ -1215,13 +1216,17 @@ function useNewWorkspaceInitialContext({
   const allServerIds = useMemo(() => allHosts.map((h) => h.serverId), [allHosts]);
   const projects = useHostProjects(allServerIds);
   const routeDisplayName = displayNameProp?.trim() ?? "";
+  const routePlacement = useMemo(
+    () =>
+      hostProjectFromRoute({
+        serverId,
+        projectId,
+        displayName: routeDisplayName,
+        sourceDirectory: sourceDirectoryProp,
+      }),
+    [projectId, routeDisplayName, serverId, sourceDirectoryProp],
+  );
   const routeProject = useMemo(() => {
-    const routePlacement = hostProjectFromRoute({
-      serverId,
-      projectId,
-      displayName: routeDisplayName,
-      sourceDirectory: sourceDirectoryProp,
-    });
     if (!routePlacement) return null;
     return (
       resolveHostProjectCandidate({
@@ -1230,7 +1235,7 @@ function useNewWorkspaceInitialContext({
         serverId,
       }) ?? routePlacement
     );
-  }, [projectId, projects, routeDisplayName, serverId, sourceDirectoryProp]);
+  }, [projects, routePlacement, serverId]);
   const lastWorkspaceSelection = useLastWorkspaceSelection();
   const lastWorkspaceServerId = useMemo(
     () =>
@@ -1274,6 +1279,7 @@ function useNewWorkspaceInitialContext({
     openHostPicker,
     projects,
     routeProject,
+    routeProjectContextViewKey: routePlacement?.viewKey ?? null,
     lastActiveProject,
   };
 }
@@ -1553,6 +1559,7 @@ export function NewWorkspaceScreen({
     openHostPicker,
     projects,
     routeProject,
+    routeProjectContextViewKey,
     lastActiveProject,
   } = useNewWorkspaceInitialContext({
     serverId,
@@ -1633,6 +1640,7 @@ export function NewWorkspaceScreen({
     selectedServerId,
     projects,
     routeProject,
+    routeProjectContextViewKey,
     lastActiveProject,
     allowAllProjects: supportsWorkspaceMultiplicity,
   });

--- a/packages/app/src/screens/new-workspace/project-picker.test.tsx
+++ b/packages/app/src/screens/new-workspace/project-picker.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { HostProjectListItem } from "@/projects/host-projects";
+import { useNewWorkspaceProjectPicker } from "./project-picker";
+
+function project(input: {
+  viewKey: string;
+  projectKey: string | null;
+  projectId: string;
+  projectName: string;
+}): HostProjectListItem {
+  return {
+    ...input,
+    projectKind: "git",
+    iconWorkingDir: `/work/${input.projectId}`,
+    hosts: [
+      {
+        serverId: "host",
+        projectId: input.projectId,
+        iconWorkingDir: `/work/${input.projectId}`,
+        worktreeSupport: "supported",
+      },
+    ],
+    workspaceKeys: [],
+  };
+}
+
+describe("useNewWorkspaceProjectPicker", () => {
+  it("preserves a manual choice when the routed project hydrates", () => {
+    const routePlacement = project({
+      viewKey: '["host","route-local"]',
+      projectKey: null,
+      projectId: "route-local",
+      projectName: "Route project",
+    });
+    const hydratedRouteProject = project({
+      viewKey: "remote:github.com/acme/route",
+      projectKey: "remote:github.com/acme/route",
+      projectId: "route-local",
+      projectName: "Route project",
+    });
+    const manualProject = project({
+      viewKey: "remote:github.com/acme/manual",
+      projectKey: "remote:github.com/acme/manual",
+      projectId: "manual-local",
+      projectName: "Manual project",
+    });
+    const { result, rerender } = renderHook(
+      ({ routeProject, projects }) =>
+        useNewWorkspaceProjectPicker({
+          selectedServerId: "host",
+          projects,
+          routeProject,
+          routeProjectContextViewKey: routePlacement.viewKey,
+          lastActiveProject: null,
+          allowAllProjects: true,
+        }),
+      {
+        initialProps: {
+          routeProject: routePlacement,
+          projects: [routePlacement, manualProject],
+        },
+      },
+    );
+
+    const manualOption = result.current.projectPickerOptions.find(
+      (option) => option.label === manualProject.projectName,
+    );
+    expect(manualOption).toBeDefined();
+    act(() => result.current.handleSelectProjectOption(manualOption!.id));
+    expect(result.current.selectedProject).toEqual(manualProject);
+
+    rerender({
+      routeProject: hydratedRouteProject,
+      projects: [hydratedRouteProject, manualProject],
+    });
+
+    expect(result.current.selectedProject).toEqual(manualProject);
+  });
+});

--- a/packages/app/src/screens/new-workspace/project-picker.ts
+++ b/packages/app/src/screens/new-workspace/project-picker.ts
@@ -24,6 +24,7 @@ interface NewWorkspaceProjectPickerInput {
   selectedServerId: string;
   projects: HostProjectListItem[];
   routeProject: HostProjectListItem | null;
+  routeProjectContextViewKey: string | null;
   lastActiveProject: HostProjectListItem | null;
   allowAllProjects: boolean;
 }
@@ -84,6 +85,7 @@ export function useNewWorkspaceProjectPicker({
   selectedServerId,
   projects,
   routeProject,
+  routeProjectContextViewKey,
   lastActiveProject,
   allowAllProjects,
 }: NewWorkspaceProjectPickerInput): NewWorkspaceProjectPickerState {
@@ -104,14 +106,13 @@ export function useNewWorkspaceProjectPicker({
     [allowAllProjects, lastActiveProject, routeProject, selectableProjects, selectedServerId],
   );
 
-  const routeProjectViewKey = routeProject?.viewKey ?? null;
   const selectionContextKey = createProjectSelectionContextKey({
     selectedServerId,
-    routeProjectViewKey,
+    routeProjectViewKey: routeProjectContextViewKey,
     allowAllProjects,
   });
   const manualSelectionContextKey = createManualProjectSelectionContextKey({
-    routeProjectViewKey,
+    routeProjectViewKey: routeProjectContextViewKey,
   });
   const shouldPreserveMissingProject = useCallback(
     (project: HostProjectListItem) =>


### PR DESCRIPTION
### Linked issue

None found after searching open issues.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

New workspace could replace the active project with an unrelated project when the user switched hosts. The entry route carried a host-local placement, but that placement was not hydrated back to the canonical cross-host project identity before the host changed.

This keeps host-local placement identity for exact clone selection while restoring the canonical project key used to find the equivalent project on another host. The same identity survives a full app reload.

### Goals

- Keep the active project selected when switching hosts in New workspace.
- Preserve exact source-host clone placement when multiple clones share a project key.
- Restore equivalent project selection after app reload.
- Cover the flow against two real daemon hosts.

### Non-goals

- Change project grouping or duplicate-clone selection policy.
- Persist arbitrary New workspace form state.
- Change protocol or daemon project identity.

### QA

Before the fix, the focused two-host Playwright repro failed after switching hosts:

```text
Expected: Paseo
Received: Aardvark project
```

After the fix:

```text
2 passed - new-workspace-host-project-preservation.spec.ts
6 passed - host-projects.test.ts
```

The regression uses two real daemons, duplicate same-key clones on the primary host, an unrelated project on the secondary host, host switching, and a full app reload.

Also verified:

- `npm run typecheck`
- targeted `npm run lint`
- `npm run format:files`
- pre-commit format, lint, and typecheck hooks

Risk surface: shared New workspace project initialization in the app. No protocol, server, or visual layout changes.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
