### PR TITLE
fix(pi): let prompt acceptance wait for compaction

### DIFF
--- a/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
@@ -293,6 +293,49 @@ describe("PiCliRuntime", () => {
     await rejection;
   });
 
+  test("prompt waits beyond the default timeout when Pi auto-compacts before accepting", async () => {
+    vi.useFakeTimers();
+    const child = createPiChild();
+    const pendingPrompt = capturePendingCommand(child, "prompt");
+    const session = await createRuntime(child).startSession({ cwd: "/workspace/project" });
+
+    try {
+      const promptPromise = session.prompt("continue after compaction");
+      const promptCommand = await pendingPrompt;
+      await vi.advanceTimersByTimeAsync(35_000);
+
+      expect(promptCommand).toMatchObject({
+        type: "prompt",
+        message: "continue after compaction",
+        id: expect.any(String),
+      });
+
+      writePiResponse(child, promptCommand, { agentInvoked: true });
+
+      await expect(promptPromise).resolves.toEqual({
+        requestId: promptCommand.id,
+        agentInvoked: true,
+      });
+    } finally {
+      vi.useRealTimers();
+      await session.close();
+    }
+  });
+
+  test("prompt without a wall-clock timeout rejects when the session closes", async () => {
+    const child = createPiChild();
+    const pendingPrompt = capturePendingCommand(child, "prompt");
+    const session = await createRuntime(child).startSession({ cwd: "/workspace/project" });
+
+    const promptPromise = session.prompt("continue after compaction");
+    await pendingPrompt;
+
+    const rejection = expect(promptPromise).rejects.toThrow("Pi RPC session is closed");
+    await session.close();
+
+    await rejection;
+  });
+
   test("compact waits beyond the default control-plane timeout for a late response", async () => {
     vi.useFakeTimers();
     const child = createPiChild();

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -32,10 +32,14 @@ const DEFAULT_COMMANDS_RPC_NAME = "get_commands";
 
 /**
  * Pi RPC timeout policy:
- * - Control-plane / accept-and-stream (`prompt`, `get_state`, `abort`, …): default 30s
- * - Long-running blocking LLM jobs (`compact`): no wall-clock timeout — complete on
- *   response, process death, or session close (`JsonlRpcProcess.failAll` / `close`).
+ * - Prompt acceptance and explicit compaction: no wall-clock timeout. Pi may run
+ *   automatic LLM-backed compaction before acknowledging a prompt.
+ * - Other control-plane calls (`get_state`, `abort`, …): default 30s.
+ *
+ * Requests without a wall-clock timeout still complete on response, process
+ * death, or session close (`JsonlRpcProcess.failAll` / `close`).
  */
+const PI_PROMPT_REQUEST_TIMEOUT_MS = JSONL_RPC_NO_TIMEOUT;
 const PI_COMPACT_REQUEST_TIMEOUT_MS = JSONL_RPC_NO_TIMEOUT;
 
 export interface PiCliRuntimeOptions {
@@ -108,11 +112,14 @@ class PiCliRuntimeSession implements PiRuntimeSession {
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
   ): Promise<PiPromptAck> {
-    const { id: requestId, promise } = this.process.startRequest({
-      type: "prompt",
-      message,
-      ...(images?.length ? { images } : {}),
-    });
+    const { id: requestId, promise } = this.process.startRequest(
+      {
+        type: "prompt",
+        message,
+        ...(images?.length ? { images } : {}),
+      },
+      PI_PROMPT_REQUEST_TIMEOUT_MS,
+    );
     const data = await promise;
     if (typeof data === "object" && data !== null && !Array.isArray(data)) {
       const { agentInvoked } = data as Record<string, unknown>;


### PR DESCRIPTION
## Problem

Pi does not always acknowledge `prompt` within 30 seconds. Its RPC preflight can wait for automatic LLM-backed compaction, and long-running extension commands can also delay acceptance. Paseo currently expires the request at 30 seconds even though Pi is still healthy and continues the operation, producing a false `Pi RPC request timed out for prompt` turn failure.

I reproduced this with Paseo 0.3.0 and Pi 0.84.1 on macOS. Four large sessions (207k–325k tokens before compaction) hit the 30-second Paseo timeout while Pi continued and later persisted the compaction/result.

Fixes #2046.

## Change

Use the existing `JSONL_RPC_NO_TIMEOUT` policy for Pi `prompt`, as Paseo already does for explicit `compact`. The request remains bounded by a Pi response, process death, or session close; `JsonlRpcProcess.failAll` still rejects every pending request in the latter two cases.

No protocol or UI behavior changes are required.

## Automated coverage

The focused regression test uses the Pi process adapter and proves both boundaries:

- a prompt can receive its acceptance response after 35 seconds;
- a pending prompt still rejects when the session closes.

The late-acceptance test fails on `main` with the reported `Pi RPC request timed out for prompt` error and passes with this change.

```text
npx vitest run packages/server/src/server/agent/providers/pi/cli-runtime.test.ts --bail=1
Test Files  1 passed (1)
Tests       18 passed (18)
```

Additional checks:

```text
npm run lint -- packages/server/src/server/agent/providers/pi/cli-runtime.ts packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
npm run build:server
npm run typecheck --workspace=@getpaseo/server
```

All passed. The whole-repo `npm run typecheck` reaches and passes the server package, then fails in the unchanged app file `packages/app/src/components/draggable-list.native.tsx` because `dragGestureHostPresented` is absent from the installed draggable-list type.

## Platform QA

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop macOS | Yes | Paseo 0.3.0, Pi 0.84.1; real long-session timeout evidence plus focused runtime A/B |
| Desktop Windows | No | Provider runtime policy is shared; no platform-specific code |
| Desktop Linux | No | Provider runtime policy is shared; no platform-specific code |
| iOS / Android / Web | N/A | No client or protocol change |
