### PR TITLE
Stabilize async server lifecycle tests

### DIFF
--- a/packages/server/src/server/agent/create-agent/create.test.ts
+++ b/packages/server/src/server/agent/create-agent/create.test.ts
@@ -22,6 +22,18 @@ function createRealAgentManager(storage: AgentStorage): AgentManager {
   });
 }
 
+async function removeRealAgentManagerWorkdir(
+  agentManager: AgentManager,
+  storage: AgentStorage,
+  workdir: string,
+): Promise<void> {
+  agentManager.prepareForShutdown();
+  await Promise.all(agentManager.listAgents().map((agent) => agentManager.closeAgent(agent.id)));
+  await agentManager.flushForShutdown();
+  await storage.flush();
+  rmSync(workdir, { recursive: true, force: true });
+}
+
 // Creates a worktree directory under repoRoot and reports it back as a fresh
 // workspace so the command can stamp the agent with it (mirrors the production
 // worktree service).
@@ -238,7 +250,7 @@ test("session create stamps the requested workspaceId when no worktree setup run
     const stored = await storage.get(snapshot.id);
     expect(stored?.workspaceId).toBe("ws-source");
   } finally {
-    rmSync(workdir, { recursive: true, force: true });
+    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
   }
 });
 
@@ -273,7 +285,7 @@ test("session create stamps the new worktree's workspaceId when a setup continua
     const stored = await storage.get(snapshot.id);
     expect(stored?.workspaceId).toBe("ws-new-worktree");
   } finally {
-    rmSync(workdir, { recursive: true, force: true });
+    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
   }
 });
 
@@ -324,7 +336,7 @@ test("mcp create stamps the new worktree's workspaceId, not the parent's", async
     expect(storedChild?.workspaceId).toBe("ws-new-worktree");
     expect(child.cwd).toBe(join(workdir, "worktree", "packages", "app"));
   } finally {
-    rmSync(workdir, { recursive: true, force: true });
+    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
   }
 });
 
@@ -376,7 +388,7 @@ test("mcp create exposes the created worktree before dispatching the initial pro
 
     expect(observed).toEqual({ createdWorktree, lifecycle: "idle" });
   } finally {
-    rmSync(workdir, { recursive: true, force: true });
+    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
   }
 });
 
@@ -414,7 +426,7 @@ test("session create keeps the prompt title after the initial prompt settles", a
     const settled = await storage.get(snapshot.id);
     expect(settled?.title).toBe(title);
   } finally {
-    rmSync(workdir, { recursive: true, force: true });
+    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
   }
 });
 
@@ -452,6 +464,6 @@ test("session create keeps an explicit title after the initial prompt settles", 
     const settled = await storage.get(snapshot.id);
     expect(settled?.title).toBe(title);
   } finally {
-    rmSync(workdir, { recursive: true, force: true });
+    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
   }
 });

--- a/packages/server/src/server/agent/create-agent/create.test.ts
+++ b/packages/server/src/server/agent/create-agent/create.test.ts
@@ -22,11 +22,15 @@ function createRealAgentManager(storage: AgentStorage): AgentManager {
   });
 }
 
-async function removeRealAgentManagerWorkdir(
-  agentManager: AgentManager,
-  storage: AgentStorage,
-  workdir: string,
-): Promise<void> {
+async function removeRealAgentManagerWorkdir({
+  agentManager,
+  storage,
+  workdir,
+}: {
+  agentManager: AgentManager;
+  storage: AgentStorage;
+  workdir: string;
+}): Promise<void> {
   agentManager.prepareForShutdown();
   await Promise.all(agentManager.listAgents().map((agent) => agentManager.closeAgent(agent.id)));
   await agentManager.flushForShutdown();
@@ -250,7 +254,7 @@ test("session create stamps the requested workspaceId when no worktree setup run
     const stored = await storage.get(snapshot.id);
     expect(stored?.workspaceId).toBe("ws-source");
   } finally {
-    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
+    await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
   }
 });
 
@@ -285,7 +289,7 @@ test("session create stamps the new worktree's workspaceId when a setup continua
     const stored = await storage.get(snapshot.id);
     expect(stored?.workspaceId).toBe("ws-new-worktree");
   } finally {
-    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
+    await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
   }
 });
 
@@ -336,7 +340,7 @@ test("mcp create stamps the new worktree's workspaceId, not the parent's", async
     expect(storedChild?.workspaceId).toBe("ws-new-worktree");
     expect(child.cwd).toBe(join(workdir, "worktree", "packages", "app"));
   } finally {
-    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
+    await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
   }
 });
 
@@ -388,7 +392,7 @@ test("mcp create exposes the created worktree before dispatching the initial pro
 
     expect(observed).toEqual({ createdWorktree, lifecycle: "idle" });
   } finally {
-    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
+    await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
   }
 });
 
@@ -426,7 +430,7 @@ test("session create keeps the prompt title after the initial prompt settles", a
     const settled = await storage.get(snapshot.id);
     expect(settled?.title).toBe(title);
   } finally {
-    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
+    await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
   }
 });
 
@@ -464,6 +468,6 @@ test("session create keeps an explicit title after the initial prompt settles", 
     const settled = await storage.get(snapshot.id);
     expect(settled?.title).toBe(title);
   } finally {
-    await removeRealAgentManagerWorkdir(agentManager, storage, workdir);
+    await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
   }
 });

--- a/packages/server/src/server/hub/test-utils/relationship-harness.ts
+++ b/packages/server/src/server/hub/test-utils/relationship-harness.ts
@@ -203,7 +203,10 @@ class ControlledAgentClient implements AgentClient {
   resumes = 0;
   createdConfigs: AgentSessionConfig[] = [];
 
-  constructor(private readonly client: AgentClient) {
+  constructor(
+    private readonly client: AgentClient,
+    private readonly internalClient: AgentClient,
+  ) {
     this.provider = client.provider;
     this.capabilities = client.capabilities;
   }
@@ -230,6 +233,9 @@ class ControlledAgentClient implements AgentClient {
     launchContext?: AgentLaunchContext,
     options?: AgentCreateSessionOptions,
   ): Promise<AgentSession> {
+    if (config.internal) {
+      return this.internalClient.createSession(config, launchContext, options);
+    }
     this.creations++;
     this.createdConfigs.push({ ...config });
     this.creationObserved.resolve();
@@ -242,6 +248,9 @@ class ControlledAgentClient implements AgentClient {
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
+    if (overrides?.internal) {
+      return this.internalClient.resumeSession(handle, overrides, launchContext);
+    }
     this.resumes++;
     return this.client.resumeSession(handle, overrides, launchContext);
   }
@@ -438,6 +447,7 @@ export class HubRelationshipHarness {
           this.providerPrompts.push(prompt);
         },
       }).codex,
+      createTestAgentClients({ supportsMcpServers: mcpEnabled }).codex,
     );
   }
 


### PR DESCRIPTION
### Linked issue

N/A — CI regressions in [PR run 31285478136](https://github.com/getpaseo/paseo/actions/runs/31285478136) and [main run 31284176940](https://github.com/getpaseo/paseo/actions/runs/31284176940).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Two server tests were observing asynchronous work they did not own. The Hub relationship harness counted detached internal workspace-naming sessions as user execution sessions, while real-manager create tests deleted their temporary storage before background persistence had drained. Isolating internal provider activity and using the daemon's shutdown order in test cleanup removes both CI races without changing production behavior.

### Goals

- Keep Hub execution counters and prompt observations scoped to user execution sessions.
- Drain real AgentManager and AgentStorage work before deleting create-test workdirs.
- Preserve the production code paths exercised by both suites.

### Non-goals

- Change Hub restart, workspace naming, agent persistence, or title behavior.
- Rework unrelated historical flakes; the recent sidebar hover failure is already fixed on `main`.

### QA

- Reproduced the Hub contamination by forcing metadata-provider fallback: one user Codex session plus one `internal: true` branch-name generator session, with only one durable owned agent.
- Confirmed the main failure was teardown-only: title assertions passed before `rmSync` raced an atomic snapshot write and failed with `ENOTEMPTY`.
- `npx vitest run packages/server/src/server/hub/relationship-controller.test.ts --bail=1 -t "daemon restart closes an interrupted owned turn without replaying its prompt|re-enrollment gives the same daemon fresh execution authority"` — 2 passed.
- `npx vitest run packages/server/src/server/agent/create-agent/create.test.ts --bail=1 -t "session create keeps an explicit title after the initial prompt settles"` — 1 passed.
- `npx vitest run packages/server/src/server/agent/create-agent/create.test.ts packages/server/src/server/hub/relationship-controller.test.ts --bail=1` — create suite passed all 10 tests; Hub suite passed 42 tests before one unrelated 5-second test timeout under local full-file load. That timed-out test passed in the focused two-test run above.
- `npm run typecheck` — passed.
- `npm run lint` — 0 warnings, 0 errors.
- `npm run format` — passed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
