### PR TITLE
feat(app): switch sidebar Group by from the command center

### DIFF
--- a/packages/app/e2e/browser/command-center-grouping.spec.ts
+++ b/packages/app/e2e/browser/command-center-grouping.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test, type Page } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { openCommandCenter } from "../support/helpers/command-center";
+import { seedWorkspace } from "../support/helpers/seed-client";
+
+const GROUP_BY_STATUS = "Group by status";
+const GROUP_BY_PROJECT = "Group by project";
+
+// Result rows carry no testID of their own, so the entries are addressed by their visible label.
+async function runGroupingEntry(page: Page, label: string, absent: string): Promise<void> {
+  const panel = await openCommandCenter(page);
+  await panel.getByTestId("command-center-input").fill("group");
+
+  const entry = panel.getByText(label, { exact: true });
+  await expect(entry).toBeVisible({ timeout: 30_000 });
+  // The entry always names the mode you are not in, so its opposite must never be listed.
+  await expect(panel.getByText(absent, { exact: true })).toHaveCount(0);
+
+  await entry.click();
+  await expect(page.getByTestId("command-center-panel")).not.toBeVisible({ timeout: 30_000 });
+}
+
+test.describe("Command center sidebar grouping", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test("flips sidebar grouping and persists the choice across a reload", async ({ page }) => {
+    const seeded = await seedWorkspace({ repoPrefix: "command-center-grouping-" });
+
+    try {
+      await gotoAppShell(page);
+      const projectList = page.getByTestId("sidebar-project-workspace-list-scroll");
+      const statusList = page.getByTestId("sidebar-status-list-scroll");
+      await expect(projectList).toBeVisible({ timeout: 30_000 });
+
+      // Query-only: the grouping entry stays out of the default empty-query list.
+      const panel = await openCommandCenter(page);
+      await expect(panel.getByText(GROUP_BY_STATUS, { exact: true })).toHaveCount(0);
+      await expect(panel.getByText(GROUP_BY_PROJECT, { exact: true })).toHaveCount(0);
+      await page.keyboard.press("Escape");
+      await expect(panel).not.toBeVisible({ timeout: 30_000 });
+
+      await runGroupingEntry(page, GROUP_BY_STATUS, GROUP_BY_PROJECT);
+      await expect(statusList).toBeVisible({ timeout: 30_000 });
+      await expect(projectList).toHaveCount(0);
+
+      // The only assertion that catches a flip which never reached persisted storage.
+      await page.reload();
+      await expect(statusList).toBeVisible({ timeout: 30_000 });
+
+      // Grouping persists, so the run must leave the sidebar back in project mode.
+      await runGroupingEntry(page, GROUP_BY_PROJECT, GROUP_BY_STATUS);
+      await expect(projectList).toBeVisible({ timeout: 30_000 });
+      await expect(statusList).toHaveCount(0);
+    } finally {
+      await seeded.cleanup().catch(() => undefined);
+    }
+  });
+});

--- a/packages/app/src/command-center/root-contributions.test.ts
+++ b/packages/app/src/command-center/root-contributions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { SidebarGroupMode } from "@/stores/sidebar-view-store";
+import type { CommandCenterIconProps } from "./contributions";
+import { buildGroupingContribution, type GroupingCommandCenterSource } from "./root-contributions";
+
+function ProjectIcon(_props: CommandCenterIconProps) {
+  return null;
+}
+
+function StatusIcon(_props: CommandCenterIconProps) {
+  return null;
+}
+
+function source(groupMode: SidebarGroupMode): {
+  value: GroupingCommandCenterSource;
+  applied: SidebarGroupMode[];
+} {
+  const applied: SidebarGroupMode[] = [];
+  return {
+    value: {
+      groupMode,
+      labels: {
+        section: "Actions",
+        groupByProject: "Group by project",
+        groupByStatus: "Group by status",
+      },
+      icons: { project: ProjectIcon, status: StatusIcon },
+      setGroupMode: (mode) => applied.push(mode),
+    },
+    applied,
+  };
+}
+
+describe("grouping command center contribution", () => {
+  it("offers status while grouped by project", () => {
+    const fixture = source("project");
+    const contribution = buildGroupingContribution(fixture.value);
+
+    expect(contribution.presentation).toMatchObject({
+      title: "Group by status",
+      icon: StatusIcon,
+    });
+
+    contribution.run();
+    expect(fixture.applied).toEqual(["status"]);
+  });
+
+  it("offers project while grouped by status", () => {
+    const fixture = source("status");
+    const contribution = buildGroupingContribution(fixture.value);
+
+    expect(contribution.presentation).toMatchObject({
+      title: "Group by project",
+      icon: ProjectIcon,
+    });
+
+    contribution.run();
+    expect(fixture.applied).toEqual(["project"]);
+  });
+
+  it("keeps a stable id across both modes so the registry tiebreak never moves", () => {
+    expect(buildGroupingContribution(source("project").value).id).toBe(
+      buildGroupingContribution(source("status").value).id,
+    );
+  });
+
+  it("stays out of the default empty-query list", () => {
+    for (const mode of ["project", "status"] as const) {
+      const contribution = buildGroupingContribution(source(mode).value);
+      expect(contribution.visibility).toBe("query");
+      expect(contribution.group).toBe("actions");
+      // 6 is keyboard-shortcuts and 7 belongs to the workspace actions in #3013.
+      expect(contribution.rank).toBe(8);
+    }
+  });
+});

--- a/packages/app/src/command-center/root-contributions.ts
+++ b/packages/app/src/command-center/root-contributions.ts
@@ -1,0 +1,39 @@
+import type { SidebarGroupMode } from "@/stores/sidebar-view-store";
+import type { CommandCenterContribution, CommandCenterIcon } from "./contributions";
+
+export interface GroupingCommandCenterSource {
+  groupMode: SidebarGroupMode;
+  labels: {
+    section: string;
+    groupByProject: string;
+    groupByStatus: string;
+  };
+  icons: {
+    project?: CommandCenterIcon;
+    status?: CommandCenterIcon;
+  };
+  setGroupMode(mode: SidebarGroupMode): void;
+}
+
+// One entry that always names the mode you are not in, so it can never read as a no-op.
+export function buildGroupingContribution(
+  source: GroupingCommandCenterSource,
+): CommandCenterContribution {
+  // Collapse into nextGroupMode() from sidebar-view-store once #2504 lands.
+  const target: SidebarGroupMode = source.groupMode === "project" ? "status" : "project";
+  return {
+    id: "sidebar-grouping",
+    group: "actions",
+    groupRank: 0,
+    rank: 8,
+    keywords: ["group", "grouping", "sort", "sidebar", "project", "status"],
+    visibility: "query",
+    run: () => source.setGroupMode(target),
+    presentation: {
+      kind: "action",
+      title: target === "status" ? source.labels.groupByStatus : source.labels.groupByProject,
+      sectionTitle: source.labels.section,
+      icon: target === "status" ? source.icons.status : source.icons.project,
+    },
+  };
+}

--- a/packages/app/src/command-center/root-registration.tsx
+++ b/packages/app/src/command-center/root-registration.tsx
@@ -3,6 +3,8 @@ import { router, type Href } from "expo-router";
 import { useTranslation } from "react-i18next";
 import {
   CalendarClock,
+  CircleDashed,
+  Folder,
   FolderPlus,
   History,
   Home,
@@ -18,6 +20,7 @@ import { keyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher"
 import { useKeyboardShortcutsAvailable } from "@/keyboard/availability";
 import { resolveShortcutKeysForAction } from "@/keyboard/keyboard-shortcuts";
 import { useKeyboardShortcutsStore } from "@/stores/keyboard-shortcuts-store";
+import { useSidebarViewStore } from "@/stores/sidebar-view-store";
 import { clearCommandCenterFocusRestoreElement } from "@/utils/command-center-focus-restore";
 import {
   buildOpenProjectRoute,
@@ -28,6 +31,7 @@ import {
 import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { CommandCenterContribution, CommandCenterIconProps } from "./contributions";
 import { useCommandCenterActions } from "./provider";
+import { buildGroupingContribution } from "./root-contributions";
 
 const ThemedPlus = withUnistyles(Plus, (theme) => ({ color: theme.colors.foregroundMuted }));
 const ThemedFolderPlus = withUnistyles(FolderPlus, (theme) => ({
@@ -46,6 +50,10 @@ const ThemedSettings = withUnistyles(Settings, (theme) => ({
   color: theme.colors.foregroundMuted,
 }));
 const ThemedHome = withUnistyles(Home, (theme) => ({ color: theme.colors.foregroundMuted }));
+const ThemedFolder = withUnistyles(Folder, (theme) => ({ color: theme.colors.foregroundMuted }));
+const ThemedCircleDashed = withUnistyles(CircleDashed, (theme) => ({
+  color: theme.colors.foregroundMuted,
+}));
 
 function PlusIcon({ size }: CommandCenterIconProps) {
   return <ThemedPlus size={size} strokeWidth={2.4} />;
@@ -75,6 +83,14 @@ function HomeIcon({ size }: CommandCenterIconProps) {
   return <ThemedHome size={size} strokeWidth={2.2} />;
 }
 
+function FolderIcon({ size }: CommandCenterIconProps) {
+  return <ThemedFolder size={size} strokeWidth={2.2} />;
+}
+
+function CircleDashedIcon({ size }: CommandCenterIconProps) {
+  return <ThemedCircleDashed size={size} strokeWidth={2.2} />;
+}
+
 export function CommandCenterRootActions() {
   const { t } = useTranslation();
   const { overrides } = useKeyboardShortcutOverrides();
@@ -85,6 +101,10 @@ export function CommandCenterRootActions() {
   const sessionsRoute = useMemo<Href>(() => buildSessionsRoute(), []);
   const schedulesRoute = useMemo<Href>(() => buildSchedulesRoute(), []);
   const setShortcutsDialogOpen = useKeyboardShortcutsStore((state) => state.setShortcutsDialogOpen);
+  // Narrow selector on purpose: a whole-store subscription would re-register every root action
+  // each time host filters are reconciled.
+  const groupMode = useSidebarViewStore((state) => state.groupMode);
+  const setGroupMode = useSidebarViewStore((state) => state.setGroupMode);
   const shortcutPlatform = useMemo(
     () => ({ isMac: getShortcutOs() === "mac", isDesktop: getIsElectronRuntime() }),
     [],
@@ -229,13 +249,28 @@ export function CommandCenterRootActions() {
       });
     }
 
+    availableActions.push(
+      buildGroupingContribution({
+        groupMode,
+        labels: {
+          section: t("shell.commandCenter.actions"),
+          groupByProject: t("shell.commandCenter.groupByProject"),
+          groupByStatus: t("shell.commandCenter.groupByStatus"),
+        },
+        icons: { project: FolderIcon, status: CircleDashedIcon },
+        setGroupMode,
+      }),
+    );
+
     return availableActions;
   }, [
+    groupMode,
     homeRoute,
     openAddProject,
     overrides,
     schedulesRoute,
     sessionsRoute,
+    setGroupMode,
     setShortcutsDialogOpen,
     settingsRoute,
     shortcutPlatform,

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -62,6 +62,8 @@ export const ar: TranslationResources = {
       newAgent: "وكيل جديد",
       addProject: "إضافة مشروع",
       home: "بيت",
+      groupByProject: "تجميع حسب المشروع",
+      groupByStatus: "تجميع حسب الحالة",
       modelGroupLabel: "النموذج",
       modelSearchKeywords: "تبديل النموذج تغيير النموذج تعيين النموذج اختيار النموذج",
       thinkingGroupLabel: "التفكير",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -60,6 +60,8 @@ export const en = {
       newAgent: "New agent",
       addProject: "Add project",
       home: "Home",
+      groupByProject: "Group by project",
+      groupByStatus: "Group by status",
       modelGroupLabel: "Model",
       modelSearchKeywords: "switch model change model set model select model",
       thinkingGroupLabel: "Thinking",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -62,6 +62,8 @@ export const es: TranslationResources = {
       newAgent: "Nuevo agente",
       addProject: "Agregar proyecto",
       home: "Hogar",
+      groupByProject: "Agrupar por proyecto",
+      groupByStatus: "Agrupar por estado",
       modelGroupLabel: "Modelo",
       modelSearchKeywords: "cambiar modelo modificar modelo establecer modelo seleccionar modelo",
       thinkingGroupLabel: "Razonamiento",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -63,6 +63,8 @@ export const fr: TranslationResources = {
       newAgent: "Nouvel agent",
       addProject: "Ajouter un projet",
       home: "Maison",
+      groupByProject: "Grouper par projet",
+      groupByStatus: "Grouper par statut",
       modelGroupLabel: "Modèle",
       modelSearchKeywords:
         "changer de modèle modifier le modèle définir le modèle sélectionner le modèle",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -62,6 +62,8 @@ export const ja: TranslationResources = {
       newAgent: "新しいエージェント",
       addProject: "プロジェクトを追加",
       home: "ホーム",
+      groupByProject: "プロジェクトでグループ化",
+      groupByStatus: "ステータスでグループ化",
       modelGroupLabel: "モデル",
       modelSearchKeywords: "モデルを切り替え モデルを変更 モデルを設定 モデルを選択",
       thinkingGroupLabel: "思考",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -62,6 +62,8 @@ export const ko: TranslationResources = {
       newAgent: "새 에이전트",
       addProject: "프로젝트 추가",
       home: "홈",
+      groupByProject: "프로젝트별 그룹화",
+      groupByStatus: "상태별 그룹화",
       modelGroupLabel: "모델",
       modelSearchKeywords: "모델 전환 모델 변경 모델 설정 모델 선택",
       thinkingGroupLabel: "추론",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -62,6 +62,8 @@ export const ptBR: TranslationResources = {
       newAgent: "Novo agente",
       addProject: "Adicionar projeto",
       home: "Início",
+      groupByProject: "Agrupar por projeto",
+      groupByStatus: "Agrupar por status",
       modelGroupLabel: "Modelo",
       modelSearchKeywords: "trocar modelo mudar modelo definir modelo selecionar modelo",
       thinkingGroupLabel: "Raciocínio",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -62,6 +62,8 @@ export const ru: TranslationResources = {
       newAgent: "Новый агент",
       addProject: "Добавить проект",
       home: "Дом",
+      groupByProject: "Группировать по проекту",
+      groupByStatus: "Группировать по статусу",
       modelGroupLabel: "Модель",
       modelSearchKeywords: "сменить модель изменить модель выбрать модель установить модель",
       thinkingGroupLabel: "Мышление",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -62,6 +62,8 @@ export const zhCN: TranslationResources = {
       newAgent: "新建 Agent",
       addProject: "添加 project",
       home: "首页",
+      groupByProject: "按项目分组",
+      groupByStatus: "按状态分组",
       modelGroupLabel: "模型",
       modelSearchKeywords: "切换模型 更改模型 设置模型 选择模型",
       thinkingGroupLabel: "思考",


### PR DESCRIPTION
### Type of change

- [x] New feature

### Reasoning

Switching the sidebar between Project and Status grouping takes three clicks today: open the display preferences menu, open Grouping, pick the mode. It is a view preference people flip several times a day depending on whether they are thinking in projects or in what is running right now, and it is the only sidebar preference with no fast path. The command center already covers the rest of the shell, so grouping belongs there too. Typing "group" in Cmd-K now offers a single entry that switches you to the mode you are not in.

### Goals

- One command center entry that switches the sidebar grouping mode, matching "group", "grouping", "sort", "sidebar", "project", and "status".
- The entry always names the mode you are not in, so it never reads as a no-op and you can see where you will land before running it.
- The default empty-query Cmd-K list is unchanged: the entry only appears once you type.
- Focus returns to whatever you were typing in, and the choice persists across a reload, same as the display preferences menu.

### Non-goals

- No keyboard shortcut. #2504 already proposes Cmd/Ctrl+Shift+G for the same thing, so this deliberately does not add a competing binding.
- The other sidebar display preferences (title source, row items, checks, trailing, host filters) stay in the menu. Title source would flip as cleanly, but this keeps the PR to one idea.
- The other root command center entries are left as they are. A pure builder is introduced for this entry only, rather than rewriting the file, so this does not collide with #3013.

### QA

**Tests:**

- `packages/app/src/command-center/root-contributions.test.ts` (new) - the contribution builder in both grouping modes: which mode it offers, which icon it carries, which mode it applies when run, that its id stays stable across modes so the registry tiebreak does not move, and that it stays query-only at the expected rank and group.
- `packages/app/e2e/browser/command-center-grouping.spec.ts` (new) - the entry is absent from the empty-query list, appears on "group" without its opposite alongside it, flips the sidebar from project to status grouping, survives a page reload, and flips back.

Manual pass on the desktop app (Electron, macOS): opened Cmd-K, typed "group", ran the entry and watched the sidebar regroup. Ran it again from the composer and confirmed the cursor returned to the composer instead of being lost. Reopened the palette afterwards, confirmed the entry then offered the way back, and ran it to return to project grouping.

<img width="639" height="136" alt="image" src="https://github.com/user-attachments/assets/62cdca8d-5d80-4545-be12-c4092ac4bb43" />

<img width="637" height="142" alt="image" src="https://github.com/user-attachments/assets/9d75947a-6534-4400-828c-9899bbcea895" />


Tested on desktop (Electron, macOS). Not tested: web, iOS, Android.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
