### PR TITLE
fix(server): don't report a still-tracked run as canceled

### DIFF
--- a/packages/server/src/server/agent/agent-manager-cancel-pending-run.test.ts
+++ b/packages/server/src/server/agent/agent-manager-cancel-pending-run.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from "vitest";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { AgentManager } from "./agent-manager.js";
+import type {
+  AgentCapabilityFlags,
+  AgentClient,
+  AgentPermissionRequest,
+  AgentPersistenceHandle,
+  AgentProvider,
+  AgentRunResult,
+  AgentSession,
+  AgentSessionConfig,
+  AgentStreamEvent,
+} from "./agent-sdk-types.js";
+
+const CAPABILITIES: AgentCapabilityFlags = {
+  supportsStreaming: true,
+  supportsSessionPersistence: true,
+  supportsDynamicModes: false,
+  supportsMcpServers: false,
+  supportsReasoningStream: false,
+  supportsToolInvocations: false,
+  supportsRewindConversation: false,
+  supportsRewindFiles: false,
+  supportsRewindBoth: false,
+};
+
+/**
+ * A session whose `startTurn` never resolves, modelling a provider that is slow to
+ * accept a turn. The manager has a pending foreground run for it, but that run has
+ * no turn id yet. `interrupt` resolves, so the manager treats the cancellation as
+ * acknowledged even though nothing can settle the pending run.
+ */
+class StalledStartTurnSession implements AgentSession {
+  readonly provider: AgentProvider = "claude";
+  readonly id = "stalled-start-turn-session";
+  readonly capabilities = CAPABILITIES;
+  interruptCount = 0;
+
+  private subscribers = new Set<(event: AgentStreamEvent) => void>();
+
+  async run(): Promise<AgentRunResult> {
+    return { sessionId: this.id, finalText: "", timeline: [] };
+  }
+
+  startTurn(): Promise<{ turnId: string }> {
+    return new Promise<{ turnId: string }>(() => {
+      // Never resolves: the provider has not accepted the turn yet.
+    });
+  }
+
+  subscribe(callback: (event: AgentStreamEvent) => void): () => void {
+    this.subscribers.add(callback);
+    return () => this.subscribers.delete(callback);
+  }
+
+  async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
+    // No history.
+  }
+
+  async getRuntimeInfo() {
+    return { provider: this.provider, sessionId: this.id };
+  }
+
+  async getAvailableModes() {
+    return [];
+  }
+
+  async getCurrentMode() {
+    return null;
+  }
+
+  async setMode(): Promise<void> {}
+
+  getPendingPermissions(): AgentPermissionRequest[] {
+    return [];
+  }
+
+  async respondToPermission(): Promise<void> {}
+
+  describePersistence(): AgentPersistenceHandle {
+    return { provider: this.provider, sessionId: this.id };
+  }
+
+  async interrupt(): Promise<void> {
+    // Acknowledged by the provider, but there is no accepted turn to cancel, so
+    // nothing settles the manager's pending run.
+    this.interruptCount += 1;
+  }
+
+  async close(): Promise<void> {}
+}
+
+class StalledStartTurnClient implements AgentClient {
+  readonly provider = "claude";
+  readonly capabilities = CAPABILITIES;
+
+  constructor(readonly session: StalledStartTurnSession) {}
+
+  async createSession(_config: AgentSessionConfig): Promise<AgentSession> {
+    return this.session;
+  }
+
+  async resumeSession(): Promise<AgentSession> {
+    return this.session;
+  }
+
+  async fetchCatalog() {
+    return { models: [], modes: [] };
+  }
+
+  async isAvailable() {
+    return true;
+  }
+}
+
+/**
+ * A pending foreground run carries no turn id until the provider accepts the turn,
+ * and `settleTerminalRun` ignores runs it cannot match by turn id. Cancellation
+ * therefore cannot clear this run, and reporting it as "settled" made
+ * `replaceAgentRun` continue into `streamAgent`, which rejected the prompt with
+ * the misleading "already has an active run".
+ */
+test("replacing a run the provider never accepted reports a cancellation failure", async () => {
+  const session = new StalledStartTurnSession();
+  const manager = new AgentManager({
+    clients: { claude: new StalledStartTurnClient(session) },
+    logger: createTestLogger(),
+    idFactory: () => "00000000-0000-4000-8000-000000003061",
+  });
+  const agent = await manager.createAgent({ provider: "claude", cwd: process.cwd() }, undefined, {
+    workspaceId: undefined,
+  });
+
+  // Start a run the provider never accepts, and drain it the way startAgentRun does.
+  const first = manager.streamAgent(agent.id, "first prompt");
+  void first.next().catch(() => {
+    // The stalled turn never produces events.
+  });
+  expect(manager.hasInFlightRun(agent.id)).toBe(true);
+
+  await expect(manager.replaceAgentRun(agent.id, "second prompt")).rejects.toThrow(
+    `Cannot replace agent ${agent.id} because its active run cancellation was not acknowledged`,
+  );
+  expect(session.interruptCount).toBeGreaterThan(0);
+}, 15_000);

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2450,6 +2450,20 @@ export class AgentManager {
       this.touchUpdatedAt(agent);
       this.emitState(agent);
     }
+
+    // A foreground run that has not been assigned a turn id yet cannot be canceled:
+    // settleTerminalRun ignores it (there is no turn id to match), so only its own
+    // stream generator can clear it. Reporting "settled" while the run is still
+    // tracked makes replaceAgentRun continue into streamAgent, which then rejects
+    // the prompt with "already has an active run". Report the cancellation as
+    // refused instead, so callers surface a typed AgentRunCancellationError.
+    if (this.runs.hasRun(agentId)) {
+      this.logger.warn(
+        { agentId, kind: run.kind, turnId: run.turnId },
+        "cancelAgentRun: run still tracked after cancellation, reporting refused",
+      );
+      return { status: "refused" };
+    }
     return { status: "settled" };
   }
 


### PR DESCRIPTION
### Linked issue

Refs #3061 (item 4), related to #2495

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Sending a prompt to an agent can fail with `Agent <id> already has an active run` even when the caller did nothing wrong. It happens while orchestrating agents over MCP: a coordinator sends a prompt, the provider is slow to accept the turn, and the next prompt is rejected with an error that reads like the caller raced itself. It didn't — the daemon's own bookkeeping is stale.

`streamAgent` creates the pending foreground run synchronously, but its `turnId` is only assigned once `session.startTurn()` returns. That provider round-trip is a window where `run.turnId === null`. `settleTerminalRun` early-returns for a foreground run it cannot match by turn id, so during that window *nothing* can clear the run except its own stream generator — no force-cancel reaches it.

`cancelAgentRun` doesn't account for that. When settlement times out in this window it matches neither force-cancel branch (one needs `run.turnId`, the other needs `kind === "autonomous"`) and falls through to `return { status: "settled" }` while the run is still tracked. `cancelAgentRunBefore` only throws on `refused`, so `replaceAgentRun` continues into `streamAgent`, which sees the tracked run and throws.

So a prompt that should have produced a clear "this agent is busy" signal instead produces an error blaming the caller, and orchestrators have to pattern-match on the message to work around it.

This reports `refused` when the run is still tracked after cancellation, so callers get the typed `AgentRunCancellationError` the codebase already defines for exactly this case.

### Goals

- A cancellation that leaves the run tracked is reported as `refused`, never `settled`.
- `replaceAgentRun` fails with `AgentRunCancellationError` instead of `already has an active run` when the underlying run could not be cleared.
- A warn-level log records the agent, run kind, and turn id when this happens, so it is diagnosable in `daemon.log`.

### Non-goals

- No prompt queueing. #3061 asks for "queue or clean reject"; this is the clean-reject half. Queueing is a larger behavioral change and belongs in its own PR.
- No change to the cases that already work: an acknowledged interrupt that settles still returns `settled`, and an unacknowledged one still returns `refused`.
- Does not change how a pending foreground run gets cleared. Making the null-turn-id window itself cancellable is a deeper change to run tracking; this PR only stops the manager from reporting success it didn't achieve.

### QA

Added `agent-manager-cancel-pending-run.test.ts`, which drives the real failure through `replaceAgentRun` using a session whose `startTurn` never resolves and whose `interrupt` resolves (so cancellation is "acknowledged" but nothing settles).

Reproduced the bug before the fix — the test fails with exactly the error from the field report:

```
AssertionError: expected [Function] to throw error including 'Cannot replace agent 00000000-0000-40…'
  but got 'Agent 00000000-0000-4000-8000-0000000…'
Received: "Agent 00000000-0000-4000-8000-000000003061 already has an active run"
```

Confirmed fixed after — 1 passed.

Regression runs on `packages/server`:

- `agent-manager.test.ts`, `rewind/`, `agent-prompt.test.ts`, `agent-manager-stream-coalescing.test.ts`, plus the new test — **190 passed**
- `npm run test:unit -- src/server/agent` — **1697 passed**, 17 skipped. The 2 failures in that run (`providers/claude/models.test.ts`, `mcp-server.test.ts`) reproduce identically on an unmodified checkout of `01a1d3b`, so they are pre-existing and unrelated.
- `npm run typecheck` — clean
- `npm run lint` — 0 warnings, 0 errors
- `oxfmt --check` on both changed files — correctly formatted

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
