### PR TITLE
Fix direct LAN connections regressing on macOS desktop (#3067)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,8 @@ PASEO_DEV_RESET_HOME=1 npm run dev            # clear and reseed the derived wor
 
 In Paseo-managed worktree services, use the injected service environment rather than hardcoded root checkout ports.
 
+**Desktop dev connects with a different WebSocket `Origin` than the packaged app.** The dev renderer is served over `http://localhost:808x`; the packaged renderer runs on `paseo://app`, which the daemon allowlists. A remote daemon rejects the dev origin on the `/ws` upgrade with `403 Origin not allowed`, which the renderer reports as close code `1006`. The desktop dev daemon works because its launcher sets `PASEO_CORS_ORIGINS=*`. To test a dev desktop build against another daemon, set `PASEO_CORS_ORIGINS` on that daemon to include your dev origin, or test with a packaged build. Direct transport selection (renderer vs main-process bridge) lives in `packages/app/src/runtime/direct-transport.ts`.
+
 ### Expo Router
 
 Route ownership, startup restore, and native blank-screen gotchas live in

--- a/packages/app/src/runtime/direct-transport.test.ts
+++ b/packages/app/src/runtime/direct-transport.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { shouldRouteDirectTcpThroughHeaderBridge } from "./direct-transport";
+
+describe("shouldRouteDirectTcpThroughHeaderBridge", () => {
+  it("stays on the renderer WebSocket for headerless direct connections", () => {
+    expect(
+      shouldRouteDirectTcpThroughHeaderBridge({
+        headers: undefined,
+        hasWebSocketTransportFactory: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("stays on the renderer WebSocket when headers is an empty object", () => {
+    expect(
+      shouldRouteDirectTcpThroughHeaderBridge({
+        headers: {},
+        hasWebSocketTransportFactory: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("uses the main-process bridge when custom headers are set", () => {
+    expect(
+      shouldRouteDirectTcpThroughHeaderBridge({
+        headers: { "X-Tenant": "acme" },
+        hasWebSocketTransportFactory: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("cannot use the bridge when no bridge factory is available (e.g. non-Electron)", () => {
+    expect(
+      shouldRouteDirectTcpThroughHeaderBridge({
+        headers: { "X-Tenant": "acme" },
+        hasWebSocketTransportFactory: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/runtime/direct-transport.ts
+++ b/packages/app/src/runtime/direct-transport.ts
@@ -1,0 +1,32 @@
+/**
+ * Decide whether a direct-TCP connection must open through the Electron
+ * main-process Node `ws` bridge instead of the renderer browser WebSocket.
+ *
+ * Two layers force this choice and they point in opposite directions:
+ *
+ * - **macOS Local Network privacy** blocks the main process from reaching LAN
+ *   hosts (`connect EHOSTUNREACH`); the renderer (Chromium) is not blocked. So
+ *   the renderer WebSocket is the only transport that reaches a LAN daemon on
+ *   macOS.
+ * - **The renderer WebSocket always sends an `Origin` header** the browser
+ *   controls, and the daemon rejects unlisted origins on the `/ws` upgrade
+ *   (403, surfaced to the renderer as close code 1006). The Node bridge sends
+ *   no `Origin`, so it always passes that check. It is also the only transport
+ *   that can set the custom headers added in #2922.
+ *
+ * The packaged desktop renderer runs on `paseo://app`, which the daemon
+ * allowlists (`packages/server/src/server/bootstrap.ts`), so headerless direct
+ * connections work over the renderer. Custom headers can only travel over the
+ * bridge, so header-bearing direct connections must use it and remain subject
+ * to the macOS LAN limit.
+ */
+export function shouldRouteDirectTcpThroughHeaderBridge(input: {
+  headers: Record<string, string> | undefined;
+  hasWebSocketTransportFactory: boolean;
+}): boolean {
+  return (
+    input.hasWebSocketTransportFactory &&
+    input.headers !== undefined &&
+    Object.keys(input.headers).length > 0
+  );
+}

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -480,7 +480,7 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
     createClient: ({ host, connection, clientId, runtimeGeneration }) => {
       const localTransportFactory = createDesktopLocalDaemonTransportFactory();
       const webSocketTransportFactory = createDesktopWebSocketTransportFactory();
-      const webSocketConfig = webSocketTransportFactory
+      const relayWebSocketConfig = webSocketTransportFactory
         ? { transportFactory: webSocketTransportFactory }
         : { webSocketFactory: createAppWebSocketFactory() };
       const base = {
@@ -503,9 +503,22 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
         });
       }
       if (connection.type === "directTcp") {
+        // The main-process Node `ws` bridge is only needed to send custom
+        // request headers, which the renderer browser WebSocket can't set. On
+        // macOS the main process lacks the Local Network privacy grant, so
+        // routing headerless LAN connections through it fails with
+        // EHOSTUNREACH. Keep headerless direct connections on the renderer
+        // WebSocket and only use the bridge when headers are configured.
+        const useHeaderBridge =
+          webSocketTransportFactory &&
+          connection.headers &&
+          Object.keys(connection.headers).length > 0;
+        const directWebSocketConfig = useHeaderBridge
+          ? { transportFactory: webSocketTransportFactory }
+          : { webSocketFactory: createAppWebSocketFactory() };
         return new DaemonClient({
           ...base,
-          ...webSocketConfig,
+          ...directWebSocketConfig,
           url: buildDaemonWebSocketUrl(connection.endpoint, {
             useTls: connection.useTls ?? false,
           }),
@@ -515,7 +528,7 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
       }
       return new DaemonClient({
         ...base,
-        ...webSocketConfig,
+        ...relayWebSocketConfig,
         url: buildRelayWebSocketUrl({
           endpoint: connection.relayEndpoint,
           useTls: connection.useTls ?? shouldUseTlsForDefaultHostedRelay(connection.relayEndpoint),

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -59,6 +59,7 @@ import { DirectorySync, type RefreshAgentDirectoryResult } from "@/runtime/direc
 import { ReplicaCache } from "@/runtime/replica-cache";
 import { nativePerformanceTrace } from "@/performance/native-trace";
 import { createAppWebSocketFactory } from "./websocket-factory";
+import { shouldRouteDirectTcpThroughHeaderBridge } from "./direct-transport";
 
 export type HostRuntimeConnectionStatus = "idle" | "connecting" | "online" | "offline" | "error";
 export type HostRegistryStatus = "loading" | "ready";
@@ -503,16 +504,16 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
         });
       }
       if (connection.type === "directTcp") {
-        // The main-process Node `ws` bridge is only needed to send custom
-        // request headers, which the renderer browser WebSocket can't set. On
-        // macOS the main process lacks the Local Network privacy grant, so
-        // routing headerless LAN connections through it fails with
-        // EHOSTUNREACH. Keep headerless direct connections on the renderer
-        // WebSocket and only use the bridge when headers are configured.
+        // See shouldRouteDirectTcpThroughHeaderBridge: headerless direct
+        // connections stay on the renderer WebSocket (works on macOS LAN,
+        // paseo://app origin is allowlisted); header-bearing ones use the
+        // main-process bridge so the custom headers can be sent.
         const useHeaderBridge =
-          webSocketTransportFactory &&
-          connection.headers &&
-          Object.keys(connection.headers).length > 0;
+          webSocketTransportFactory !== null &&
+          shouldRouteDirectTcpThroughHeaderBridge({
+            headers: connection.headers,
+            hasWebSocketTransportFactory: true,
+          });
         const directWebSocketConfig = useHeaderBridge
           ? { transportFactory: webSocketTransportFactory }
           : { webSocketFactory: createAppWebSocketFactory() };

--- a/packages/app/src/utils/test-daemon-connection.test.ts
+++ b/packages/app/src/utils/test-daemon-connection.test.ts
@@ -174,6 +174,28 @@ describe("test-daemon-connection connectToDaemon", () => {
     expect(probe.createdConfigs()[0]?.transportFactory).toBe(transportFactory);
   });
 
+  it("skips the main-process WebSocket bridge for headerless direct connections", async () => {
+    const { connectToDaemon } = await import("./test-daemon-connection");
+    const transportFactory: NonNullable<DaemonClientConfig["transportFactory"]> = () => {
+      throw new Error("Headerless direct connections must not use the bridge.");
+    };
+    const result = await connectToDaemon(
+      {
+        id: "direct:lan:6767",
+        type: "directTcp",
+        endpoint: "lan:6767",
+      },
+      undefined,
+      {
+        ...probe.deps,
+        createWebSocketTransportFactory: () => transportFactory,
+      },
+    );
+    await result.client.close();
+
+    expect(probe.createdConfigs()[0]?.transportFactory).toBeUndefined();
+  });
+
   it("passes performance tracing into the connected client", async () => {
     const { connectToDaemon } = await import("./test-daemon-connection");
     const trace = {

--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -13,6 +13,7 @@ import {
   createDesktopLocalDaemonTransportFactory,
   createDesktopWebSocketTransportFactory,
 } from "@/desktop/daemon/desktop-daemon-transport";
+import { shouldRouteDirectTcpThroughHeaderBridge } from "@/runtime/direct-transport";
 
 export interface DaemonProbeClient {
   readonly lastError: string | null;
@@ -48,14 +49,20 @@ function resolveDirectTcpTransportFactory(
   connection: Extract<HostConnection, { type: "directTcp" }>,
   deps: Pick<DaemonConnectionDependencies<DaemonProbeClient>, "createWebSocketTransportFactory">,
 ): DaemonClientConfig["transportFactory"] {
-  // Only route through the main-process bridge when custom headers are set;
-  // headerless direct connections must stay on the renderer WebSocket so LAN
-  // targets aren't blocked by the macOS Local Network privacy gate. See
-  // host-runtime.ts createClient for the matching runtime decision.
-  if (!connection.headers || Object.keys(connection.headers).length === 0) {
+  // Mirror host-runtime.ts createClient: only header-bearing direct
+  // connections use the main-process bridge. Headerless ones return undefined
+  // so the client falls back to the renderer WebSocket. See
+  // shouldRouteDirectTcpThroughHeaderBridge for why.
+  const factory = deps.createWebSocketTransportFactory?.() ?? undefined;
+  if (
+    !shouldRouteDirectTcpThroughHeaderBridge({
+      headers: connection.headers,
+      hasWebSocketTransportFactory: factory !== undefined,
+    })
+  ) {
     return undefined;
   }
-  return deps.createWebSocketTransportFactory?.() ?? undefined;
+  return factory;
 }
 
 function normalizeNonEmptyString(value: unknown): string | null {

--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -44,9 +44,17 @@ const defaultDaemonConnectionDependencies: DaemonConnectionDependencies<DaemonCl
   createClient: (config) => new DaemonClient(config),
 };
 
-function resolveWebSocketTransportFactory(
+function resolveDirectTcpTransportFactory(
+  connection: Extract<HostConnection, { type: "directTcp" }>,
   deps: Pick<DaemonConnectionDependencies<DaemonProbeClient>, "createWebSocketTransportFactory">,
 ): DaemonClientConfig["transportFactory"] {
+  // Only route through the main-process bridge when custom headers are set;
+  // headerless direct connections must stay on the renderer WebSocket so LAN
+  // targets aren't blocked by the macOS Local Network privacy gate. See
+  // host-runtime.ts createClient for the matching runtime decision.
+  if (!connection.headers || Object.keys(connection.headers).length === 0) {
+    return undefined;
+  }
   return deps.createWebSocketTransportFactory?.() ?? undefined;
 }
 
@@ -148,7 +156,7 @@ export async function buildClientConfig(
   if (connection.type === "directTcp") {
     return {
       ...base,
-      transportFactory: resolveWebSocketTransportFactory(deps),
+      transportFactory: resolveDirectTcpTransportFactory(connection, deps),
       url: buildDaemonWebSocketUrl(connection.endpoint, { useTls: connection.useTls ?? false }),
       ...(connection.password ? { password: connection.password } : {}),
       ...(connection.headers ? { headers: connection.headers } : {}),


### PR DESCRIPTION
### Linked issue

Closes #3067

### Type of change

- [x] Bug fix

### Reasoning

Paseo Desktop `0.3.0` can't connect directly to a daemon on another Mac over the LAN; `0.2.5` connects to the same daemon and address. This breaks "connect to my dev box from another machine on the same LAN."

The direct-TCP transport sits between two macOS/daemon constraints that pull in opposite directions:

- **macOS Local Network privacy** blocks the Electron **main process** from reaching LAN hosts (`connect EHOSTUNREACH`); the **renderer** (Chromium) is not blocked. So the renderer WebSocket is the only client transport that reaches a LAN daemon on macOS.
- **The daemon rejects unlisted origins on the `/ws` upgrade** (`403 Origin not allowed`, surfaced to a browser WebSocket as close code `1006`). The renderer WebSocket always sends an `Origin`; the **main-process Node `ws` bridge sends none**, so the bridge always passes that check — and it's the only transport that can send the custom headers added in #2922.

`0.2.5` used the renderer WebSocket for direct TCP (the `DaemonClient` default in the renderer). #2922 (`73ba37a07`) routed **every** Electron direct WebSocket through the main-process bridge to enable custom headers — including headerless ones — which exposed them to the macOS Local Network block and produced the reported `EHOSTUNREACH`.

Fix: pick the transport per connection. Headerless direct connections go back to the renderer WebSocket (reaches the LAN on macOS; the packaged renderer's `paseo://app` origin is allowlisted by the daemon in `bootstrap.ts`, so the upgrade is accepted). Header-bearing connections keep the main-process bridge so their headers can be sent. The decision is one pure predicate, `shouldRouteDirectTcpThroughHeaderBridge`, shared by the runtime client (`host-runtime.ts`) and the connection probe (`test-daemon-connection.ts`) so the two paths can't drift.

### Goals

- Restore headerless direct LAN connections on macOS Desktop (regression `0.2.5` → `0.3.0`).
- Keep custom-header direct connections (#2922) working via the main-process bridge.
- Keep probe and runtime transport selection identical.

### Non-goals

- Relay connections are untouched (still bridge + E2EE).
- Not solving header-bearing direct LAN connections on macOS. Those still use the bridge and remain subject to Local Network privacy — see Known limitations.
- No daemon/protocol changes; the daemon already allowlists `paseo://app`.

### QA

**Regression test proves the bug and the fix.** `test-daemon-connection.test.ts` gained `skips the main-process WebSocket bridge for headerless direct connections`; it fails on pre-fix code for the reported reason (bridge used for a headerless connection) and passes after. New `direct-transport.test.ts` covers the predicate's four branches. The existing `uses the Electron WebSocket transport for the initial probe` test carries an `X-Tenant` header, guarding the header-bearing path.

```
$ git stash push -- packages/app/src/utils/test-daemon-connection.ts packages/app/src/runtime/host-runtime.ts packages/app/src/runtime/direct-transport.ts
$ npx vitest run packages/app/src/utils/test-daemon-connection.test.ts -t "skips the main-process WebSocket bridge"
 Test Files  1 failed (1)
      Tests  1 failed | 9 skipped (10)     # fails on old code, as required

$ npx vitest run packages/app/src/runtime/direct-transport.test.ts packages/app/src/utils/test-daemon-connection.test.ts --bail=1
 Test Files  2 passed (2)
      Tests  14 passed (14)
```

Checks:
```
$ npm run lint          # 0 warnings, 0 errors (full repo)
$ npm run format:check  # all files correct
$ npm run typecheck --workspace @getpaseo/app   # clean except one pre-existing, unrelated failure
```
Full-repo typecheck has one **pre-existing, unrelated** failure in `packages/app/src/components/draggable-list.native.tsx`, present at the base commit `01a1d3b2b` (last touched by #2709), not introduced here. The full-repo pre-commit typecheck hook was skipped for that reason; lint and format ran clean.

**Root cause confirmed against a live daemon.** The client host (`192.168.1.91`) reaches the daemon host (`192.168.1.98`) directly:
```
$ nc -vz 192.168.1.98 6767
Connection to 192.168.1.98 port 6767 succeeded!
$ curl -i --noproxy '*' http://192.168.1.98:6767
HTTP/1.1 404 Not Found        # daemon up, plain HTTP answers
```
With the pre-fix build the app failed with `connect EHOSTUNREACH` (main-process bridge, Local Network block). With this build it uses the renderer WebSocket, so the failure mode moves to the daemon's `/ws` origin check when the origin isn't allowlisted.

Platforms:

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | N/A — Electron transport only |
| Android         |        | N/A |
| Web             |        | N/A — plain browser web already used the renderer WebSocket |
| Desktop macOS   | ⚠️      | Root cause + fix verified by automated tests and live network probes above. Final happy-path click-through must be a **packaged** build (origin `paseo://app`, allowlisted); a `npm run dev:desktop` build sends `http://localhost:808x` and is correctly rejected by remote daemons that don't allowlist it — a dev-build artifact, not a fix failure. Now documented in `docs/development.md`. |
| Desktop Windows |        | Unaffected by the macOS Local Network gate; headerless behavior unchanged (renderer WebSocket) |
| Desktop Linux   |        | Same as Windows |

### Known limitations

- **Header-bearing direct LAN connections on macOS** still use the main-process bridge and remain blocked by Local Network privacy (`EHOSTUNREACH`). Resolving that needs the Local Network permission/entitlement work referenced by #2880 / #2856, out of scope here.
- **Dev desktop builds** can't connect to daemons that don't allowlist `http://localhost:808x`; use a packaged build or set `PASEO_CORS_ORIGINS` on the target daemon. Documented in `docs/development.md`.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes — app workspace clean; full repo has a pre-existing unrelated `draggable-list.native.tsx` failure on the base commit
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
