### PR TITLE
feat(app): add "Always open Changes in a tab" setting

### DIFF
--- a/packages/app/e2e/browser/changes-pane.spec.ts
+++ b/packages/app/e2e/browser/changes-pane.spec.ts
@@ -5,6 +5,7 @@ import { type Locator, type Page } from "@playwright/test";
 import { buildHostWorkspaceRoute, buildSettingsSectionRoute } from "../../src/utils/host-routes";
 import { test, expect } from "../support/fixtures";
 import { daemonWsRoutePattern } from "../support/helpers/daemon-port";
+import { addInlineReviewComment } from "../support/helpers/review";
 import { getServerId } from "../support/helpers/server-id";
 import { connectSeedClient } from "../support/helpers/seed-client";
 import { createTempGitRepo } from "../support/helpers/workspace";
@@ -62,6 +63,7 @@ async function failNextDiscardRequest(page: Page): Promise<void> {
 }
 
 const CHANGES_PREFERENCES_KEY = "@paseo:changes-preferences";
+const CHANGES_PREFERENCES_SEEDED_KEY = "@paseo:e2e-changes-preferences-seeded";
 
 function diffGroups(scope: Page | Locator, fileIndex = 0): Locator {
   return scope.getByTestId(new RegExp(`^diff-file-${fileIndex}-group-\\d+$`));
@@ -523,6 +525,89 @@ test("Changes switches between inline and full-tab navigation", async ({ page })
   await expect(diffGroups(page.getByTestId("explorer-content-area"))).toHaveCount(0);
 });
 
+test("Changes always-open preference sends file presses to the tab", async ({ page }) => {
+  const workspace = await createWorkspaceWithMountedTabDiff({ includeDeletedFile: true });
+  await resetChangesPreferencesOnce(page);
+  await openWorkspaceChanges(page, workspace);
+
+  const explorer = page.getByTestId("explorer-content-area");
+  const changesTabClose = page.getByTestId(/^workspace-working-diff-close-/);
+  await expect(diffGroups(explorer).first()).toBeVisible();
+  await expect(page.getByTestId("changes-toggle-expand-all")).toBeVisible();
+  await expect(page.getByTestId("changes-toggle-layout")).toBeVisible();
+
+  await toggleAlwaysOpenChangesInTab(page);
+
+  // Inline bodies and the controls that produce them are gone, along with the toolbar tab toggle
+  // the preference has made redundant. No tab has opened yet.
+  await expect(diffGroups(explorer)).toHaveCount(0);
+  await expect(page.getByTestId("changes-toggle-expand-all")).toHaveCount(0);
+  await expect(page.getByTestId("changes-toggle-layout")).toHaveCount(0);
+  await expect(page.getByTestId("changes-open-tab")).toHaveCount(0);
+  await expect(changesTabClose).toHaveCount(0);
+
+  await explorer.getByTestId("diff-file-0-toggle").click();
+  const visiblePanel = page.getByTestId("working-diff-panel").filter({ visible: true });
+  await expect(visiblePanel).toBeVisible();
+  await expect(diffGroups(visiblePanel).first()).toBeVisible();
+  await expect(diffGroups(explorer)).toHaveCount(0);
+  await expect(changesTabClose).toHaveCount(1);
+
+  await page.reload();
+  await waitForWorkspaceTabsVisible(page);
+  await expect(page.getByTestId("explorer-tab-changes")).toBeVisible({ timeout: 30_000 });
+  await expect(explorer.getByText("use-mounted-tab-set.ts").first()).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(changesTabClose).toHaveCount(1);
+
+  // The preference survived the reload: closing the tab does not bring inline diffs back, and
+  // the next press reopens the tab. Closing goes through the tab's own button because the
+  // toolbar toggle is hidden while the preference routes every press.
+  await expect(page.getByTestId("changes-open-tab")).toHaveCount(0);
+  await changesTabClose.click();
+  await expect(changesTabClose).toHaveCount(0);
+  await expect(diffGroups(explorer)).toHaveCount(0);
+  await explorer.getByTestId("diff-file-0-toggle").click();
+  await expect(changesTabClose).toHaveCount(1);
+
+  await changesTabClose.click();
+  await expect(changesTabClose).toHaveCount(0);
+  await toggleAlwaysOpenChangesInTab(page);
+
+  // Turning it off restores the expansion the sidebar had before, not a blank list.
+  await expect(diffGroups(explorer).first()).toBeVisible();
+  await expect(page.getByTestId("changes-toggle-expand-all")).toBeVisible();
+  await expect(page.getByTestId("changes-toggle-layout")).toBeVisible();
+});
+
+test("Changes keeps the review attachment across the sidebar-to-tab handoff", async ({ page }) => {
+  const workspace = await createWorkspaceWithMountedTabDiff();
+  await resetChangesPreferencesOnce(page);
+  await openWorkspaceChanges(page, workspace);
+
+  const explorer = page.getByTestId("explorer-content-area");
+  const reviewPill = page.getByTestId("composer-review-attachment-pill");
+  await addInlineReviewComment(page, { root: explorer, rowIndex: 1, body: "Needs a guard" });
+  await expect(reviewPill).toBeVisible();
+
+  // The sidebar is still the publisher here: the preference is on but no tab exists yet.
+  await toggleAlwaysOpenChangesInTab(page);
+  await expect(diffGroups(explorer)).toHaveCount(0);
+  await expect(reviewPill).toBeVisible();
+
+  // The publisher swaps from the sidebar to the tab panel on this press. Sample through the
+  // handoff rather than after it — a gap would leave the composer silently without the changes.
+  await explorer.getByTestId("diff-file-0-toggle").click();
+  await expectAttachmentPillStaysMounted(page, reviewPill);
+  await expect(page.getByTestId("working-diff-panel").filter({ visible: true })).toBeVisible();
+  await expect(reviewPill).toHaveCount(1);
+
+  // Closing the tab hands publishing back to the sidebar with the draft intact.
+  await page.getByTestId(/^workspace-working-diff-close-/).click();
+  await expect(reviewPill).toBeVisible();
+});
+
 test("changes diff switches between flat and tree file lists", async ({ page }) => {
   const workspace = await createWorkspaceWithMountedTabDiff();
   await useUnwrappedDiffLines(page);
@@ -737,6 +822,74 @@ async function useUnwrappedDiffLines(page: Page): Promise<void> {
     },
     { preferencesKey: CHANGES_PREFERENCES_KEY },
   );
+}
+
+/**
+ * Resets the diff preferences once per browser context, in setup rather than teardown so a
+ * failing test cannot leak `alwaysOpenInTab` into the next one. Later loads keep whatever the
+ * app itself stored, which is what makes the across-reload assertions meaningful.
+ */
+async function resetChangesPreferencesOnce(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ preferencesKey, seededKey }) => {
+      if (localStorage.getItem(seededKey)) {
+        return;
+      }
+      localStorage.setItem(seededKey, "1");
+      localStorage.setItem(
+        preferencesKey,
+        JSON.stringify({
+          layout: "unified",
+          viewMode: "flat",
+          wrapLines: false,
+          hideWhitespace: false,
+          alwaysOpenInTab: false,
+        }),
+      );
+    },
+    { preferencesKey: CHANGES_PREFERENCES_KEY, seededKey: CHANGES_PREFERENCES_SEEDED_KEY },
+  );
+}
+
+async function readStoredAlwaysOpenInTab(page: Page): Promise<boolean> {
+  const raw = await page.evaluate(
+    (preferencesKey) => localStorage.getItem(preferencesKey),
+    CHANGES_PREFERENCES_KEY,
+  );
+  return raw ? Boolean(JSON.parse(raw).alwaysOpenInTab) : false;
+}
+
+/**
+ * Flips the preference where it actually lives — Settings → General — and walks back to the
+ * workspace. The round trip is the point: the setting is global, so the Changes pane has to pick
+ * the new value up from the shared store rather than from local state it owns.
+ */
+async function toggleAlwaysOpenChangesInTab(page: Page): Promise<void> {
+  const before = await readStoredAlwaysOpenInTab(page);
+  await page.getByTestId("sidebar-settings").click();
+  await expect(page).toHaveURL(new RegExp(`${buildSettingsSectionRoute("general")}|/settings$`));
+
+  const toggle = page.getByTestId("always-open-changes-in-tab-toggle");
+  await expect(toggle).toBeVisible();
+  await toggle.click();
+  await expect.poll(() => readStoredAlwaysOpenInTab(page)).toBe(!before);
+
+  await page.getByTestId("settings-back-to-workspace").click();
+  await waitForWorkspaceTabsVisible(page);
+  await openChangesInVisibleExplorer(page);
+}
+
+/**
+ * Samples the pill repeatedly instead of asserting once, so a publisher gap during the handoff
+ * fails instead of being papered over by Playwright's retry. Mounted, not visible: opening a tab
+ * hides the launcher composer in a workspace with no agent, which is #2298's layout, not a lost
+ * attachment.
+ */
+async function expectAttachmentPillStaysMounted(page: Page, pill: Locator): Promise<void> {
+  for (let sample = 0; sample < 20; sample += 1) {
+    expect(await pill.count(), `review attachment disappeared on sample ${sample}`).toBe(1);
+    await page.waitForTimeout(50);
+  }
 }
 
 async function expectFlatFileList(page: Page): Promise<void> {

--- a/packages/app/e2e/support/helpers/review.ts
+++ b/packages/app/e2e/support/helpers/review.ts
@@ -1,0 +1,23 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Adds an inline review comment to a visible diff row.
+ *
+ * The gutter "+" button only renders while the row is hovered, so the hover is part of the
+ * contract here, not incidental. `row` is the `diff-code-row-<n>` locator of the line to comment
+ * on; the matching gutter action carries the same index.
+ */
+export async function addInlineReviewComment(
+  page: Page,
+  input: { root?: Locator; rowIndex: number; body: string },
+): Promise<void> {
+  const root = input.root ?? page.locator("body");
+  await root.getByTestId(`diff-code-row-${input.rowIndex}`).hover();
+  await root.getByTestId(`diff-gutter-action-${input.rowIndex}`).click();
+
+  const editor = page.getByTestId("inline-review-editor").filter({ visible: true });
+  await expect(editor).toBeVisible();
+  await editor.getByTestId("inline-review-editor-input").fill(input.body);
+  await editor.getByTestId("inline-review-editor-save").click();
+  await expect(editor).toHaveCount(0);
+}

--- a/packages/app/src/git/changes-tab-navigation.test.ts
+++ b/packages/app/src/git/changes-tab-navigation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { shouldRouteDiffsToChangesTab } from "./changes-tab-navigation";
+
+const READY = {
+  isMobile: false,
+  canOpenTab: true,
+  layoutHydrated: true,
+  preferencesLoaded: true,
+  changesTabOpen: false,
+  alwaysOpenInTab: false,
+} as const;
+
+describe("shouldRouteDiffsToChangesTab", () => {
+  it("expands inline when neither the tab nor the preference asks for it", () => {
+    expect(shouldRouteDiffsToChangesTab(READY)).toBe(false);
+  });
+
+  it("routes to the tab while a Changes tab is open", () => {
+    expect(shouldRouteDiffsToChangesTab({ ...READY, changesTabOpen: true })).toBe(true);
+  });
+
+  it("routes to the tab with the preference on and no tab open yet", () => {
+    expect(shouldRouteDiffsToChangesTab({ ...READY, alwaysOpenInTab: true })).toBe(true);
+  });
+
+  it("keeps compact layouts on inline expansion", () => {
+    expect(shouldRouteDiffsToChangesTab({ ...READY, isMobile: true, alwaysOpenInTab: true })).toBe(
+      false,
+    );
+  });
+
+  it("keeps inline expansion when no tab can be opened", () => {
+    expect(
+      shouldRouteDiffsToChangesTab({ ...READY, canOpenTab: false, alwaysOpenInTab: true }),
+    ).toBe(false);
+  });
+
+  it("keeps inline expansion until the layout store has hydrated", () => {
+    expect(
+      shouldRouteDiffsToChangesTab({ ...READY, layoutHydrated: false, alwaysOpenInTab: true }),
+    ).toBe(false);
+  });
+
+  it("keeps inline expansion until preferences have loaded", () => {
+    expect(
+      shouldRouteDiffsToChangesTab({ ...READY, preferencesLoaded: false, alwaysOpenInTab: true }),
+    ).toBe(false);
+  });
+
+  it("ignores an already-open tab while the guards are unmet", () => {
+    expect(
+      shouldRouteDiffsToChangesTab({ ...READY, layoutHydrated: false, changesTabOpen: true }),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/git/changes-tab-navigation.ts
+++ b/packages/app/src/git/changes-tab-navigation.ts
@@ -1,0 +1,39 @@
+/**
+ * Does the Changes explorer hand diffs to the workspace tab instead of rendering them inline?
+ *
+ * Single source of truth for two decisions that must never disagree:
+ *   1. a changed-file press focuses/opens the Changes tab instead of expanding inline
+ *   2. the sidebar hides its inline-expansion controls (expand-all, unified/split)
+ *
+ * Deliberately NOT used by the review-attachment publish in diff-pane.tsx. That one stays
+ * keyed on `changesTabOpen` alone, because the tab panel only publishes while it is mounted
+ * and active (panels/diff-panel.tsx). Keying it here would leave "preference on, tab closed"
+ * with no publisher at all, and the composer would silently lose the changes attachment.
+ *
+ *   isMobile / !canOpenTab / !layoutHydrated / !preferencesLoaded
+ *                       │
+ *                       ▼
+ *              inline expansion (today's behavior)
+ *                       │
+ *   changesTabOpen ─────┴──── alwaysOpenInTab
+ *                       │
+ *                       ▼
+ *                  Changes tab
+ */
+export function shouldRouteDiffsToChangesTab(input: {
+  /** Compact layouts keep #2298's sidebar-only behavior. */
+  isMobile: boolean;
+  /** False when the workspace has no tab persistence key, so no tab can ever open. */
+  canOpenTab: boolean;
+  /** Opening a tab before the layout store rehydrates loses it to the rehydrated state. */
+  layoutHydrated: boolean;
+  /** Deciding from a default that is about to change would retract a diff the user just opened. */
+  preferencesLoaded: boolean;
+  changesTabOpen: boolean;
+  alwaysOpenInTab: boolean;
+}): boolean {
+  if (!input.canOpenTab || input.isMobile || !input.layoutHydrated || !input.preferencesLoaded) {
+    return false;
+  }
+  return input.changesTabOpen || input.alwaysOpenInTab;
+}

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -97,7 +97,11 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { useOverlayFlatListScrollbar } from "@/components/ui/overlay-scrollbar/use-overlay-flat-list-scrollbar";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { usePanelStore } from "@/stores/panel-store";
-import { collectAllTabs, useWorkspaceLayoutStore } from "@/stores/workspace-layout-store";
+import {
+  collectAllTabs,
+  useWorkspaceLayoutStore,
+  useWorkspaceLayoutStoreHydrated,
+} from "@/stores/workspace-layout-store";
 import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { buildWorkspaceExplorerStateKey } from "@/hooks/use-file-explorer-actions";
 import {
@@ -129,6 +133,7 @@ import {
   type UnifiedRowGroupItem,
 } from "@/git/diff-rows/model";
 import { DiffHorizontalContent, DiffHorizontalSurface } from "@/git/diff-horizontal-surface";
+import { shouldRouteDiffsToChangesTab } from "@/git/changes-tab-navigation";
 
 export type { GitActionId, GitAction, GitActions } from "@/git/policy";
 
@@ -1618,6 +1623,8 @@ export function DiffLayoutToggle({
 
 interface ChangesTabToggleProps {
   isMobile: boolean;
+  /** False once the always-open preference routes every press, which leaves this nothing to do. */
+  visible: boolean;
   selected: boolean;
   onPress: () => void;
 }
@@ -1676,7 +1683,7 @@ export function DiffModeMenu({
   );
 }
 
-function ChangesTabToggle({ isMobile, selected, onPress }: ChangesTabToggleProps) {
+function ChangesTabToggle({ isMobile, visible, selected, onPress }: ChangesTabToggleProps) {
   const { t } = useTranslation();
   const buttonStyle = useMemo(
     () => buildToggleButtonStyle(selected, styles.expandAllButton),
@@ -1685,7 +1692,7 @@ function ChangesTabToggle({ isMobile, selected, onPress }: ChangesTabToggleProps
   const label = t(
     selected ? "workspace.git.diff.closeChangesTab" : "workspace.git.diff.openChangesTab",
   );
-  if (isMobile) {
+  if (isMobile || !visible) {
     return null;
   }
   return (
@@ -2812,14 +2819,15 @@ function useChangesTreeState({
   cwd,
   files,
   viewMode,
-  changesTabOpen,
+  inlineDiffsSuppressed,
   onViewModeChange,
 }: {
   workspaceId?: string | null;
   cwd: string;
   files: ParsedDiffFile[];
   viewMode: "flat" | "tree";
-  changesTabOpen: boolean;
+  /** The Changes tab owns the diff bodies, so the sidebar renders rows only. */
+  inlineDiffsSuppressed: boolean;
   onViewModeChange: (viewMode: "flat" | "tree") => void;
 }) {
   const workspaceStateKey = useMemo(
@@ -2846,7 +2854,7 @@ function useChangesTreeState({
   );
   const folderPathSet = useMemo(() => new Set(folderPaths), [folderPaths]);
   const allExpanded = useMemo(() => {
-    if (files.length === 0 || changesTabOpen) {
+    if (files.length === 0 || inlineDiffsSuppressed) {
       return false;
     }
     const everyFileExpanded = files.every((file) => stableExpandedPaths.includes(file.path));
@@ -2854,7 +2862,14 @@ function useChangesTreeState({
       viewMode !== "tree" ||
       stableCollapsedFolders.every((folderPath) => !folderPathSet.has(folderPath));
     return everyFileExpanded && everyFolderExpanded;
-  }, [changesTabOpen, files, folderPathSet, stableCollapsedFolders, stableExpandedPaths, viewMode]);
+  }, [
+    files,
+    folderPathSet,
+    inlineDiffsSuppressed,
+    stableCollapsedFolders,
+    stableExpandedPaths,
+    viewMode,
+  ]);
   const toggleViewMode = useCallback(() => {
     const nextViewMode = viewMode === "flat" ? "tree" : "flat";
     if (nextViewMode === "tree" && workspaceStateKey) {
@@ -2907,7 +2922,8 @@ function useChangesTreeState({
   );
 
   return {
-    expandedPaths: changesTabOpen ? EMPTY_PATH_LIST : stableExpandedPaths,
+    // Swapped, not cleared: turning the tab or the preference off restores what was expanded.
+    expandedPaths: inlineDiffsSuppressed ? EMPTY_PATH_LIST : stableExpandedPaths,
     collapsedFolders: stableCollapsedFolders,
     allExpanded,
     toggleViewMode,
@@ -2922,14 +2938,19 @@ function useDiffTabNavigation({
   workspaceId,
   cwd,
   isMobile,
+  alwaysOpenInTab,
+  preferencesLoaded,
 }: {
   serverId: string;
   workspaceId?: string | null;
   cwd: string;
   isMobile: boolean;
+  alwaysOpenInTab: boolean;
+  preferencesLoaded: boolean;
 }) {
   const openWorkspaceTabFocused = useWorkspaceLayoutStore((state) => state.openTabFocused);
   const closeWorkspaceTab = useWorkspaceLayoutStore((state) => state.closeTab);
+  const layoutHydrated = useWorkspaceLayoutStoreHydrated();
   const persistenceKey = useMemo(
     () => buildWorkspaceTabPersistenceKey({ serverId, workspaceId: workspaceId ?? cwd }),
     [cwd, serverId, workspaceId],
@@ -2944,6 +2965,14 @@ function useDiffTabNavigation({
     );
   });
   const changesTabOpen = !isMobile && Boolean(changesTabId);
+  const routeToTab = shouldRouteDiffsToChangesTab({
+    isMobile,
+    canOpenTab: Boolean(persistenceKey),
+    layoutHydrated,
+    preferencesLoaded,
+    changesTabOpen,
+    alwaysOpenInTab,
+  });
   const openChanges = useCallback(
     (path?: string) => {
       if (!persistenceKey || isMobile) {
@@ -2957,7 +2986,8 @@ function useDiffTabNavigation({
     [isMobile, openWorkspaceTabFocused, persistenceKey],
   );
   const toggleChanges = useCallback(() => {
-    if (!persistenceKey || isMobile) {
+    // Rehydration shallow-replaces layoutByWorkspace, so a tab opened before it lands is lost.
+    if (!persistenceKey || isMobile || !layoutHydrated) {
       return;
     }
     if (changesTabId) {
@@ -2965,7 +2995,7 @@ function useDiffTabNavigation({
       return;
     }
     openChanges();
-  }, [changesTabId, closeWorkspaceTab, isMobile, openChanges, persistenceKey]);
+  }, [changesTabId, closeWorkspaceTab, isMobile, layoutHydrated, openChanges, persistenceKey]);
   const openCommit = useCallback(
     (sha: string) => {
       if (persistenceKey) {
@@ -2976,10 +3006,15 @@ function useDiffTabNavigation({
   );
   return {
     changesTabOpen,
+    routeToTab,
+    // The toolbar toggle has nothing left to do once the preference routes every press: opening
+    // is what the next press does anyway, and closing is undone by it. The tab keeps its own
+    // close button in the tab bar, so hiding this does not strand an open tab.
+    changesTabToggleVisible: !(routeToTab && alwaysOpenInTab),
     openChanges,
     toggleChanges,
     openCommit,
-    onChangesFilePress: changesTabOpen ? openChanges : undefined,
+    onChangesFilePress: routeToTab ? openChanges : undefined,
   };
 }
 
@@ -2995,8 +3030,11 @@ export function GitDiffPane({
   const { t } = useTranslation();
   const isMobile = useIsCompactFormFactor();
   const canUseSplitLayout = isWeb && !isMobile;
-  const { preferences: changesPreferences, updatePreferences: updateChangesPreferences } =
-    useChangesPreferences();
+  const {
+    preferences: changesPreferences,
+    isLoading: changesPreferencesLoading,
+    updatePreferences: updateChangesPreferences,
+  } = useChangesPreferences();
   const wrapLines = changesPreferences.wrapLines;
   const viewMode = changesPreferences.viewMode;
   const effectiveLayout = resolveDiffLayout(changesPreferences.layout, canUseSplitLayout);
@@ -3038,10 +3076,19 @@ export function GitDiffPane({
   const fileManagerTarget = desktopOpenTargets.find((target) => target.kind === "file-manager");
   const {
     changesTabOpen,
+    routeToTab,
+    changesTabToggleVisible,
     toggleChanges: handleToggleChangesTab,
     openCommit: handleCommitPress,
     onChangesFilePress,
-  } = useDiffTabNavigation({ serverId, workspaceId, cwd, isMobile });
+  } = useDiffTabNavigation({
+    serverId,
+    workspaceId,
+    cwd,
+    isMobile,
+    alwaysOpenInTab: changesPreferences.alwaysOpenInTab,
+    preferencesLoaded: !changesPreferencesLoading,
+  });
   const refreshSupported = useSessionStore(
     (s) => s.sessions[serverId]?.serverInfo?.features?.checkoutRefresh === true,
   );
@@ -3093,6 +3140,9 @@ export function GitDiffPane({
     workspaceId: workspaceId ?? undefined,
     cwd,
     attachment: reviewAttachment,
+    // Keyed on the tab existing, NOT on routeToTab: the tab panel publishes only while it is
+    // mounted, so handing this to the preference would leave preference-on/tab-closed with no
+    // publisher at all and silently drop the composer's changes attachment.
     enabled: !changesTabOpen,
   });
   const {
@@ -3134,7 +3184,7 @@ export function GitDiffPane({
     cwd,
     files,
     viewMode,
-    changesTabOpen,
+    inlineDiffsSuppressed: routeToTab,
     onViewModeChange: handleViewModeChange,
   });
   const sharedDisplayPreferences = useMemo(
@@ -3325,10 +3375,11 @@ export function GitDiffPane({
             <View style={styles.diffStatusButtons}>
               <ChangesTabToggle
                 isMobile={isMobile}
+                visible={changesTabToggleVisible}
                 selected={changesTabOpen}
                 onPress={handleToggleChangesTab}
               />
-              {canUseSplitLayout && !changesTabOpen ? (
+              {canUseSplitLayout && !routeToTab ? (
                 <DiffLayoutToggle
                   layout={changesPreferences.layout}
                   isMobile={isMobile}
@@ -3344,10 +3395,11 @@ export function GitDiffPane({
                   onToggle={changesTree.toggleViewMode}
                 />
               ) : null}
-              {files.length > 0 && !changesTabOpen ? (
+              {files.length > 0 && !routeToTab ? (
                 <DiffFilesToolbar
                   allFileDiffsExpanded={changesTree.allExpanded}
                   isMobile={isMobile}
+                  testID="changes-toggle-expand-all"
                   expandAllToggleStyle={expandAllToggleStyle}
                   onToggleExpandAll={changesTree.toggleExpandAll}
                 />

--- a/packages/app/src/hooks/use-changes-preferences/storage.test.ts
+++ b/packages/app/src/hooks/use-changes-preferences/storage.test.ts
@@ -32,6 +32,7 @@ describe("loadChangesPreferencesFromStorage", () => {
       wrapLines: true,
       hideWhitespace: false,
       commitsCollapsed: true,
+      alwaysOpenInTab: false,
     });
     expect(storage.entries.get(CHANGES_PREFERENCES_STORAGE_KEY)).toBe(JSON.stringify(result));
   });
@@ -55,6 +56,7 @@ describe("loadChangesPreferencesFromStorage", () => {
       hideWhitespace: true,
       wrapLines: false,
       commitsCollapsed: true,
+      alwaysOpenInTab: false,
     });
     expect(storage.entries.get(CHANGES_PREFERENCES_STORAGE_KEY)).toBe(persisted);
     expect(storage.entries.size).toBe(1);
@@ -84,6 +86,44 @@ describe("changes preferences commitsCollapsed", () => {
     const prefs = await loadChangesPreferencesFromStorage(storage);
 
     expect(prefs.commitsCollapsed).toBe(true);
+  });
+});
+
+describe("changes preferences alwaysOpenInTab", () => {
+  it("expands diffs inline by default", () => {
+    expect(DEFAULT_CHANGES_PREFERENCES.alwaysOpenInTab).toBe(false);
+  });
+
+  it("round-trips alwaysOpenInTab: true", async () => {
+    const storage = createInMemoryKeyValueStorage({
+      [CHANGES_PREFERENCES_STORAGE_KEY]: JSON.stringify({ alwaysOpenInTab: true }),
+    });
+
+    const prefs = await loadChangesPreferencesFromStorage(storage);
+
+    expect(prefs.alwaysOpenInTab).toBe(true);
+  });
+
+  it("falls back to inline for invalid alwaysOpenInTab", async () => {
+    const storage = createInMemoryKeyValueStorage({
+      [CHANGES_PREFERENCES_STORAGE_KEY]: JSON.stringify({ alwaysOpenInTab: "nope" }),
+    });
+
+    const prefs = await loadChangesPreferencesFromStorage(storage);
+
+    expect(prefs.alwaysOpenInTab).toBe(false);
+  });
+
+  it("keeps stored preferences that predate the field", async () => {
+    const storage = createInMemoryKeyValueStorage({
+      [CHANGES_PREFERENCES_STORAGE_KEY]: JSON.stringify({ layout: "split", wrapLines: true }),
+    });
+
+    const prefs = await loadChangesPreferencesFromStorage(storage);
+
+    expect(prefs.layout).toBe("split");
+    expect(prefs.wrapLines).toBe(true);
+    expect(prefs.alwaysOpenInTab).toBe(false);
   });
 });
 

--- a/packages/app/src/hooks/use-changes-preferences/storage.ts
+++ b/packages/app/src/hooks/use-changes-preferences/storage.ts
@@ -11,6 +11,7 @@ const changesPreferencesSchema = z.object({
   wrapLines: z.boolean().optional(),
   hideWhitespace: z.boolean().optional(),
   commitsCollapsed: z.boolean().optional(),
+  alwaysOpenInTab: z.boolean().optional(),
 });
 
 export interface ChangesPreferences {
@@ -19,6 +20,8 @@ export interface ChangesPreferences {
   wrapLines: boolean;
   hideWhitespace: boolean;
   commitsCollapsed: boolean;
+  /** Route changed-file presses to the Changes tab instead of expanding diffs inline. */
+  alwaysOpenInTab: boolean;
 }
 
 export const DEFAULT_CHANGES_PREFERENCES: ChangesPreferences = {
@@ -27,6 +30,7 @@ export const DEFAULT_CHANGES_PREFERENCES: ChangesPreferences = {
   wrapLines: false,
   hideWhitespace: false,
   commitsCollapsed: true,
+  alwaysOpenInTab: false,
 };
 
 export interface KeyValueStorage {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1822,6 +1822,11 @@ export const ar: TranslationResources = {
         description: "يتم الاحتفاظ بالخطوط في المخزن المؤقت الطرفي المدمج",
         accessibilityLabel: "خطوط التمرير Terminal",
       },
+      alwaysOpenChangesInTab: {
+        label: "فتح التغييرات دائمًا في علامة تبويب",
+        description:
+          "النقر على ملف معدَّل يفتح علامة تبويب التغييرات بدلاً من عرض الفروق في الشريط الجانبي.",
+      },
       autoExpandReasoning: {
         label: "عرض التفكير دائماً",
         description: "إظهار تفكير الوكيل وخطوات الاستدلال بشكل كامل بشكل افتراضي",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1832,6 +1832,11 @@ export const en = {
         description: "Lines kept in the built-in terminal buffer",
         accessibilityLabel: "Terminal scrollback lines",
       },
+      alwaysOpenChangesInTab: {
+        label: "Always open Changes in a tab",
+        description:
+          "Clicking a changed file opens the Changes tab instead of expanding the diff in the sidebar.",
+      },
       autoExpandReasoning: {
         label: "Always expand reasoning",
         description: "Show agent thinking and chain-of-thought blocks fully expanded by default",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1868,6 +1868,11 @@ export const es: TranslationResources = {
         description: "Líneas mantenidas en el búfer de terminal incorporado",
         accessibilityLabel: "Líneas del historial de terminal",
       },
+      alwaysOpenChangesInTab: {
+        label: "Abrir siempre Cambios en una pestaña",
+        description:
+          "Al hacer clic en un archivo modificado se abre la pestaña Cambios en lugar de expandir el diff en la barra lateral.",
+      },
       autoExpandReasoning: {
         label: "Siempre expandir razonamiento",
         description:

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1871,6 +1871,11 @@ export const fr: TranslationResources = {
         description: "Lignes conservées dans le tampon du terminal intégré",
         accessibilityLabel: "Lignes de défilementTerminal",
       },
+      alwaysOpenChangesInTab: {
+        label: "Toujours ouvrir Modifications dans un onglet",
+        description:
+          "Cliquer sur un fichier modifié ouvre l'onglet Modifications au lieu d'afficher le diff dans la barre latérale.",
+      },
       autoExpandReasoning: {
         label: "Toujours afficher le raisonnement",
         description: "Afficher le raisonnement de l'agent entièrement développé par défaut",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1837,6 +1837,11 @@ export const ja: TranslationResources = {
         description: "組み込みターミナルバッファに保持する行数",
         accessibilityLabel: "ターミナルスクロールバック行数",
       },
+      alwaysOpenChangesInTab: {
+        label: "変更を常にタブで開く",
+        description:
+          "変更されたファイルをクリックすると、サイドバーで差分を展開する代わりに変更タブが開きます。",
+      },
       autoExpandReasoning: {
         label: "常に思考プロセスを展開",
         description: "デフォルトでAIのエージェント思考・推論ブロックを完全に展開して表示します",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1833,6 +1833,11 @@ export const ko: TranslationResources = {
         description: "내장 터미널 버퍼에 보관되는 줄 수",
         accessibilityLabel: "터미널 스크롤백 줄 수",
       },
+      alwaysOpenChangesInTab: {
+        label: "항상 탭에서 변경사항 열기",
+        description:
+          "변경된 파일을 클릭하면 사이드바에서 차이를 펼치는 대신 변경사항 탭이 열립니다.",
+      },
       autoExpandReasoning: {
         label: "추론 항상 펼치기",
         description: "에이전트의 사고 및 추론 블록을 기본적으로 모두 펼쳐 표시합니다.",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1852,6 +1852,11 @@ export const ptBR: TranslationResources = {
         description: "Linhas mantidas no buffer do terminal integrado",
         accessibilityLabel: "Linhas do scrollback do terminal",
       },
+      alwaysOpenChangesInTab: {
+        label: "Sempre abrir Alterações em uma aba",
+        description:
+          "Clicar em um arquivo alterado abre a aba Alterações em vez de expandir o diff na barra lateral.",
+      },
       autoExpandReasoning: {
         label: "Sempre expandir raciocínio",
         description:

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1856,6 +1856,11 @@ export const ru: TranslationResources = {
         description: "Строки, хранящиеся во встроенном буфере терминала.",
         accessibilityLabel: "Линии прокрутки Terminal",
       },
+      alwaysOpenChangesInTab: {
+        label: "Всегда открывать «Изменения» во вкладке",
+        description:
+          "Клик по изменённому файлу открывает вкладку «Изменения» вместо разворачивания различий в боковой панели.",
+      },
       autoExpandReasoning: {
         label: "Всегда разворачивать размышления",
         description:

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1800,6 +1800,10 @@ export const zhCN: TranslationResources = {
         description: "内置终端缓冲区保留的行数",
         accessibilityLabel: "终端回滚行数",
       },
+      alwaysOpenChangesInTab: {
+        label: "始终在标签页中打开“更改”",
+        description: "点击已更改的文件时打开“更改”标签页，而不是在侧边栏中展开差异。",
+      },
       autoExpandReasoning: {
         label: "始终展开推理过程",
         description: "默认情况下完全展开 AI 的思考和推理过程",

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -73,6 +73,7 @@ import { AddHostMethodModal } from "@/components/add-host-method-modal";
 import { AddHostModal } from "@/components/add-host-modal";
 import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
+import { ChangesTabRow } from "@/screens/settings/changes-tab-row";
 import { EditorSection } from "@/screens/settings/editor-section";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -464,6 +465,7 @@ function GeneralSection({
             accessibilityLabel={t("settings.general.terminalScrollback.accessibilityLabel")}
           />
         </View>
+        <ChangesTabRow />
       </View>
     </SettingsSection>
   );

--- a/packages/app/src/screens/settings/changes-tab-row.tsx
+++ b/packages/app/src/screens/settings/changes-tab-row.tsx
@@ -12,6 +12,11 @@ import { settingsStyles } from "@/styles/settings";
  * preferences already live. The store is client-local and react-query backed, so the Changes pane
  * picks the new value up without any explicit propagation.
  *
+ * The switch is disabled until the query resolves. `saveChangesPreferences` merges onto whatever is
+ * in the cache, which is `DEFAULT_CHANGES_PREFERENCES` while the read is in flight, so a press
+ * during that window both writes the other preferences back to their defaults and loses to the
+ * resolving query, which overwrites the cache with the stale stored value.
+ *
  * The row renders on every form factor even though `shouldRouteDiffsToChangesTab` ignores the
  * preference below the `sm` breakpoint, where #2298 has no Changes tab to route to. Settings is a
  * reference surface, so a row that disappears while you drag a window edge reads as a bug; the
@@ -20,7 +25,7 @@ import { settingsStyles } from "@/styles/settings";
  */
 export function ChangesTabRow() {
   const { t } = useTranslation();
-  const { preferences, updatePreferences } = useChangesPreferences();
+  const { preferences, isLoading, updatePreferences } = useChangesPreferences();
 
   const handleChange = useCallback(
     (alwaysOpenInTab: boolean) => void updatePreferences({ alwaysOpenInTab }),
@@ -40,6 +45,7 @@ export function ChangesTabRow() {
       <Switch
         value={preferences.alwaysOpenInTab}
         onValueChange={handleChange}
+        disabled={isLoading}
         accessibilityLabel={label}
         testID="always-open-changes-in-tab-toggle"
       />

--- a/packages/app/src/screens/settings/changes-tab-row.tsx
+++ b/packages/app/src/screens/settings/changes-tab-row.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Text, View } from "react-native";
+import { Switch } from "@/components/ui/switch";
+import { useChangesPreferences } from "@/hooks/use-changes-preferences";
+import { settingsStyles } from "@/styles/settings";
+
+/**
+ * "Always open Changes in a tab" — a row in Settings → General.
+ *
+ * Reads and writes `ChangesPreferences` rather than app settings, because that is where the diff
+ * preferences already live. The store is client-local and react-query backed, so the Changes pane
+ * picks the new value up without any explicit propagation.
+ *
+ * The row renders on every form factor even though `shouldRouteDiffsToChangesTab` ignores the
+ * preference below the `sm` breakpoint, where #2298 has no Changes tab to route to. Settings is a
+ * reference surface, so a row that disappears while you drag a window edge reads as a bug; the
+ * preference is simply inert at that width, and saying so in the hint cost more confusion than it
+ * bought — "wide layouts" is not a term this product uses anywhere else.
+ */
+export function ChangesTabRow() {
+  const { t } = useTranslation();
+  const { preferences, updatePreferences } = useChangesPreferences();
+
+  const handleChange = useCallback(
+    (alwaysOpenInTab: boolean) => void updatePreferences({ alwaysOpenInTab }),
+    [updatePreferences],
+  );
+
+  const label = t("settings.general.alwaysOpenChangesInTab.label");
+
+  return (
+    <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
+      <View style={settingsStyles.rowContent}>
+        <Text style={settingsStyles.rowTitle}>{label}</Text>
+        <Text style={settingsStyles.rowHint}>
+          {t("settings.general.alwaysOpenChangesInTab.description")}
+        </Text>
+      </View>
+      <Switch
+        value={preferences.alwaysOpenInTab}
+        onValueChange={handleChange}
+        accessibilityLabel={label}
+        testID="always-open-changes-in-tab-toggle"
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
### Type of change

- [x] Enhancement

### Reasoning

Since #2298, pressing a changed file focuses the Changes tab instead of expanding the diff in the sidebar, but only while such a tab exists. That state is derived from the workspace layout, not stored as a preference, so it is per-workspace by accident: every workspace you have not opened the tab in, and every one where you closed it, silently falls back to inline diffs. If you prefer reviewing in the tab, you re-open it by hand in each new workspace, and the sidebar keeps offering an inline diff you did not want. This adds the preference that #2298 left implicit.

### Goals

- With the preference on, pressing a changed file opens or focuses the Changes tab in any workspace, even when none is open yet, and the sidebar stops offering inline diff bodies at all. Lazy: turning it on opens nothing until the first press. Off by default, so nothing changes for anyone who does not enable it.
- The preference lives in Settings > General, is client-local, and survives reload. It is stored alongside the other Changes preferences rather than in app settings, so the pane picks up a change without any explicit propagation.
- One predicate drives both file routing and inline-expansion suppression, so expand-all cannot smuggle inline diffs back in. It falls back to inline diffs while the layout store is unhydrated, while preferences are still loading, when there is no persistence key, and on compact layouts. Stored expansion state is swapped rather than cleared, so turning the preference off restores what was expanded.
- The #2298 toolbar tab toggle is hidden while the preference is on, where it has nothing left to do: opening is what the next press does anyway, and closing is undone by that same press. The tab keeps its own close button, so an open tab is never stranded.

### Non-goals

- No compact-layout support. #2298 excluded it deliberately and there is no Changes tab to route to below the `sm` breakpoint, so the preference is simply inert there. The settings row still renders on every form factor: Settings is a reference surface, and a row that disappears while you drag a window edge reads as a bug.
- The toolbar toggle does not write the preference and the preference does not close the tab. With the preference off, closing the tab still returns you to inline diffs; with it on, the next press reopens the tab. The toggle owns this workspace's tab, the preference owns what a press does.
- The tab does not open when the Changes pane opens, only on the first press, so you do not get tabs you did not ask for. The preference is client-global rather than per-workspace, matching every other entry in the Changes preferences.

### QA

New Setting:

<img width="701" height="83" alt="image" src="https://github.com/user-attachments/assets/1d1db6f8-8fb8-4ae8-b2ab-64e534cd5745" />

Buttons hidden if setting is active:

<img width="276" height="117" alt="image" src="https://github.com/user-attachments/assets/5a7c4453-5e35-4a97-b4cc-416f7ad24fea" />

Buttons shown if setting is inactive (as before):

<img width="281" height="116" alt="image" src="https://github.com/user-attachments/assets/601da601-4180-4884-bc07-d650330e814b" />


Tested on desktop (Electron, macOS). Not tested: web browser, iOS, Android.

Ran against a dev daemon with the preference on:

- In a workspace with no Changes tab open, pressing a changed file opened the Changes tab and scrolled to that file. The sidebar showed no inline diff body, and expand-all and the split toggle were gone from its toolbar.
- Reloading kept the preference on, and the first press in a second workspace opened a tab there too.

**Tests:**

- `packages/app/src/git/changes-tab-navigation.test.ts` (new) - the routing predicate across every not-ready state (compact, no persistence key, unhydrated layout store, preferences still loading) and both ways it returns true.
- `packages/app/src/hooks/use-changes-preferences/storage.test.ts` (extended) - the new field's default, its round trip through storage, and its fallback when the stored value is not a boolean.
- `packages/app/e2e/browser/changes-pane.spec.ts` (extended) - toggling the setting from Settings > General and walking back, then the tab opening on a first press with no tab open, the toolbar toggle being absent while the preference is on, and inline expansion returning with its previous state when it is off.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
