### PR TITLE
Kimi: surface plan label + let custom profiles keep per-model thinking

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -516,6 +516,32 @@ Only enable capabilities Paseo should execute. When the agent and Paseo run in
 different environments, configure equivalent absolute workspace paths before
 delegating filesystem or terminal operations to Paseo.
 
+### Custom profiles of a built-in ACP agent
+
+A few catalog agents ship a specialized adapter selected by provider id: `kimi` (per-model
+thinking probe), `cursor` (fast mode), `kiro`, and `traecli`. A custom profile has its own id, so
+`extends: "acp"` alone gives it the generic adapter. Set `params.acpVariant` to opt a profile back
+into one of those adapters. This is what lets you run two Kimi accounts as separate profiles
+without losing per-model thinking:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "kimi-work": {
+        "extends": "acp",
+        "label": "Kimi (Work)",
+        "command": ["kimi", "acp"],
+        "params": { "acpVariant": "kimi" }
+      }
+    }
+  }
+}
+```
+
+Valid values: `cursor`, `kimi`, `kiro`, `traecli`. Any other value falls back to the generic ACP
+adapter. The profile keeps its own id, label, credentials, and models.
+
 ### Generic ACP diagnostics
 
 Paseo diagnostics for `extends: "acp"` providers report the configured command, resolved launcher binary, version output, ACP `initialize`, ACP `session/new`, model count, modes, and final status.

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -948,6 +948,34 @@ test("kimi provider extending acp uses KimiACPAgentClient", () => {
   expect(mockState.constructorArgs.genericAcp).toEqual([]);
 });
 
+test("custom ACP profile opts into the Kimi adapter via params.acpVariant", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      "kimi-work": {
+        extends: "acp",
+        label: "Kimi (Work)",
+        command: ["kimi", "acp"],
+        params: { acpVariant: "kimi" },
+      },
+    },
+  });
+
+  expect(registry["kimi-work"].createClient(logger).provider).toBe("kimi-work");
+  expect(mockState.constructorArgs.kimi).toEqual([
+    {
+      command: ["kimi", "acp"],
+      env: undefined,
+      providerParams: { acpVariant: "kimi" },
+    },
+    {
+      command: ["kimi", "acp"],
+      env: undefined,
+      providerParams: { acpVariant: "kimi" },
+    },
+  ]);
+  expect(mockState.constructorArgs.genericAcp).toEqual([]);
+});
+
 test('extends: "acp" without command throws', () => {
   expect(() =>
     buildProviderRegistry(logger, {

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -724,6 +724,23 @@ function buildResolvedBuiltinProviders(
   return resolvedProviders;
 }
 
+const SPECIALIZED_ACP_VARIANTS = ["cursor", "kimi", "kiro", "traecli"] as const;
+
+const AcpVariantParamsSchema = z
+  .object({
+    acpVariant: z.enum(SPECIALIZED_ACP_VARIANTS).optional(),
+  })
+  .passthrough();
+
+// A specialized ACP adapter (Kimi's per-model thinking probe, Cursor's fast mode, TRAE, Kiro) is
+// otherwise selected by the exact provider id. Custom profiles get their own id, so a renamed
+// profile such as "kimi-work" would silently fall back to the generic adapter. `params.acpVariant`
+// lets a profile opt back into the built-in adapter it derives from.
+function resolveAcpVariant(providerId: string, params: unknown): string {
+  const parsed = AcpVariantParamsSchema.safeParse(params ?? {});
+  return parsed.success && parsed.data.acpVariant ? parsed.data.acpVariant : providerId;
+}
+
 function addDerivedProviders(
   resolvedProviders: Map<string, ResolvedProvider>,
   providerOverrides: Record<string, ProviderOverride>,
@@ -773,16 +790,17 @@ function addDerivedProviders(
             label: override.label ?? providerId,
             providerParams: override.params,
           };
-          if (providerId === "cursor") {
+          const acpVariant = resolveAcpVariant(providerId, override.params);
+          if (acpVariant === "cursor") {
             return new CursorACPAgentClient(acpOptions);
           }
-          if (providerId === "kimi") {
+          if (acpVariant === "kimi") {
             return new KimiACPAgentClient(acpOptions);
           }
-          if (providerId === "kiro") {
+          if (acpVariant === "kiro") {
             return new KiroACPAgentClient(acpOptions);
           }
-          if (providerId === "traecli") {
+          if (acpVariant === "traecli") {
             return new TraeACPAgentClient(acpOptions);
           }
           return new GenericACPAgentClient(acpOptions);

--- a/packages/server/src/services/quota-fetcher/providers/kimi.ts
+++ b/packages/server/src/services/quota-fetcher/providers/kimi.ts
@@ -41,13 +41,27 @@ const KimiUsageLimitSchema = z
   })
   .passthrough();
 
+const KimiMembershipSchema = z
+  .object({
+    level: ApiOptionalStringSchema,
+  })
+  .passthrough();
+
+const KimiUserSchema = z
+  .object({
+    membership: KimiMembershipSchema.nullish(),
+  })
+  .passthrough();
+
 const KimiUsageResponseSchema = z.object({
   usage: z.unknown().nullish(),
   limits: z.unknown().nullish(),
+  user: KimiUserSchema.nullish(),
 });
 
 type KimiUsageFields = z.infer<typeof KimiUsageFieldsSchema>;
 type KimiUsageLimit = z.infer<typeof KimiUsageLimitSchema>;
+type KimiUsageResponse = z.infer<typeof KimiUsageResponseSchema>;
 
 function parseUsageFields(value: unknown): KimiUsageFields | null {
   const parsed = KimiUsageFieldsSchema.safeParse(value);
@@ -191,10 +205,9 @@ function uniqueWindowId(baseId: string, seenIds: Set<string>): string {
 }
 
 function kimiUsageWindowsFromPayload(
-  payload: unknown,
+  response: KimiUsageResponse,
   logger: Pick<Logger, "debug">,
 ): ProviderUsageWindow[] {
-  const response = KimiUsageResponseSchema.parse(payload);
   const windows: ProviderUsageWindow[] = [];
   const seenWindowIds = new Set<string>();
   const usage = parseUsageFields(response.usage);
@@ -236,6 +249,18 @@ function kimiUsageWindowsFromPayload(
   }
 
   return windows;
+}
+
+// Kimi reports the subscription tier as an enum like "LEVEL_INTERMEDIATE". Strip the prefix and
+// title-case it so the UI shows a plan name instead of the raw enum; unknown future tiers still
+// render legibly rather than being dropped.
+function planLabelFromMembershipLevel(level: string | null | undefined): string | null {
+  const words = (level ?? "")
+    .replace(/^LEVEL_/i, "")
+    .split(/[_\s]+/)
+    .filter((word) => word.length > 0);
+  if (words.length === 0) return null;
+  return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(" ");
 }
 
 const KimiAuthSchema = z
@@ -302,13 +327,14 @@ export class KimiQuotaProvider implements ProviderUsageFetcher {
       return unavailableUsage(this);
     }
 
-    const windows = kimiUsageWindowsFromPayload(await res.json(), this.logger);
+    const response = KimiUsageResponseSchema.parse(await res.json());
+    const windows = kimiUsageWindowsFromPayload(response, this.logger);
 
     return {
       providerId: this.providerId,
       displayName: this.displayName,
       status: "available",
-      planLabel: null,
+      planLabel: planLabelFromMembershipLevel(response.user?.membership?.level),
       windows,
       balances: [],
       details: [],

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -1842,6 +1842,31 @@ describe("KimiQuotaProvider usage windows", () => {
     ]);
   });
 
+  it("surfaces the membership level as the plan label", async () => {
+    process.env["KIMI_TOKEN"] = "kimi_test_token";
+    const fetchApi = vi.fn(async () =>
+      jsonResponse({
+        usage: { limit: "100", remaining: "74", resetTime: "2026-02-11T17:32:50Z" },
+        user: { membership: { level: "LEVEL_INTERMEDIATE" } },
+      }),
+    );
+    const provider = new KimiQuotaProvider({ logger: createLogger(), fetch: fetchApi });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.planLabel).toBe("Intermediate");
+  });
+
+  it("omits the plan label when Kimi returns no membership level", async () => {
+    process.env["KIMI_TOKEN"] = "kimi_test_token";
+    const fetchApi = vi.fn(async () => jsonResponse({ usage: { limit: "100", remaining: "74" } }));
+    const provider = new KimiQuotaProvider({ logger: createLogger(), fetch: fetchApi });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.planLabel).toBeNull();
+  });
+
   it("keeps window ids unique when Kimi returns duplicate limit descriptors", async () => {
     process.env["KIMI_TOKEN"] = "kimi_test_token";
     const duplicate = {


### PR DESCRIPTION
## Summary

Two small, focused Kimi fixes found during an audit of the Kimi implementation.

- **Plan label (#1).** The Kimi coding usages endpoint returns `user.membership.level` (e.g. `LEVEL_INTERMEDIATE`), but `KimiQuotaProvider` always reported `planLabel: null`, so the usage card showed no plan for Kimi while Claude/Cursor/Codex/Copilot/Z.AI all do. Parse the membership level, strip the `LEVEL_` prefix, and title-case it. The existing generic usage card (`packages/app/src/provider-usage/card.tsx`) already renders `planLabel` as a badge and no-ops on null, so no app change is needed.
- **Per-model thinking for custom Kimi profiles (#2).** Specialized ACP adapters (Kimi's per-model thinking probe, Cursor fast mode, Kiro, TRAE) were selected by exact provider id. A second Kimi profile such as `kimi-work` (a documented, encouraged setup) has its own id, so it silently fell back to the generic adapter and lost per-model thinking. Added `params.acpVariant` so a renamed profile can opt back into the built-in adapter it derives from; unknown values fall back to generic. Documented in `docs/custom-providers.md`.

Minimal diff: server-only logic + tests + one doc section. Protocol untouched (`params` is already an open `record`).

## Test plan

- [x] `provider-registry.test.ts`, `kimi-acp-agent.test.ts`, `service.test.ts` — 124 passed (added: plan label present/absent, custom `acpVariant` profile → `KimiACPAgentClient`).
- [x] `npm run typecheck` (all workspaces, via pre-commit) — pass
- [x] `npm run lint` / `format:check` on changed files — pass
- [x] Verified `planLabel` render path in `provider-usage/card.tsx` (badge, null-safe).
- [ ] **Not verified against a live Kimi account** — the `user.membership.level` shape is confirmed from public Kimi Code API references, not a real subscription. Needs a manual check by someone with a Kimi plan before/at merge, per `docs/qa.md`.

### Platform matrix

| Platform | Tested | Notes |
| --------------- | ------ | ----- |
| iOS | n/a | server-only + existing generic UI |
| Android | n/a | server-only + existing generic UI |
| Web | n/a | server-only + existing generic UI |
| Desktop | n/a | server-only + existing generic UI |

No UI code changed; #1 flows through the existing provider-usage card, #2 is daemon config.

Made with [Cursor](https://cursor.com)