### PR TITLE
Treat unpublished desktop updates as unavailable

### DIFF
--- a/packages/desktop/src/features/auto-updater.test.ts
+++ b/packages/desktop/src/features/auto-updater.test.ts
@@ -4,23 +4,98 @@ import path from "node:path";
 import { UUID } from "builder-util-runtime";
 import { describe, expect, it, vi } from "vitest";
 
+const { autoUpdaterMock } = vi.hoisted(() => {
+  const handlers = new Map<string, (value: unknown) => void>();
+  return {
+    autoUpdaterMock: {
+      handlers,
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn((message: unknown) => console.error(message)),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+      checkForUpdates: vi.fn(),
+      downloadUpdate: vi.fn(),
+      on: vi.fn((event: string, handler: (value: unknown) => void) => {
+        handlers.set(event, handler);
+      }),
+      quitAndInstall: vi.fn(),
+    },
+  };
+});
+
 vi.mock("electron", () => ({
   app: {
     getPath: vi.fn(),
+    isPackaged: true,
   },
 }));
 
 vi.mock("electron-updater", () => ({
-  autoUpdater: {},
+  autoUpdater: autoUpdaterMock,
 }));
 
 import {
   bucketFromStagingUserId,
+  checkForAppUpdate,
   resolveStagingUserId,
   rolloutManifestSchema,
   shouldAdmitToRollout,
   shouldInstallAppUpdateOnQuit,
 } from "./auto-updater";
+
+describe("checkForAppUpdate", () => {
+  it("treats an unpublished channel manifest as an unavailable update", async () => {
+    const error = Object.assign(new Error("Cannot find latest-mac.yml"), {
+      code: "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND",
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.logger.error(error);
+      autoUpdaterMock.handlers.get("error")?.(error);
+      throw error;
+    });
+
+    const result = await checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+
+    expect(result).toEqual({
+      hasUpdate: false,
+      readyToInstall: false,
+      currentVersion: "1.2.3",
+      latestVersion: "1.2.3",
+      body: null,
+      date: null,
+      errorMessage: null,
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("keeps genuine updater failures visible", async () => {
+    const error = new Error("network down");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.logger.error(error);
+      autoUpdaterMock.handlers.get("error")?.(error);
+      throw error;
+    });
+
+    const result = await checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+
+    expect(result.errorMessage).toBe("network down");
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});
 
 describe("shouldInstallAppUpdateOnQuit", () => {
   it("keeps Linux AppImage updates on the manual install path", () => {

--- a/packages/desktop/src/features/auto-updater.test.ts
+++ b/packages/desktop/src/features/auto-updater.test.ts
@@ -4,116 +4,96 @@ import path from "node:path";
 import { UUID } from "builder-util-runtime";
 import { describe, expect, it, vi } from "vitest";
 
+const { autoUpdaterMock } = vi.hoisted(() => {
+  const handlers = new Map<string, (value: unknown) => void>();
+  return {
+    autoUpdaterMock: {
+      handlers,
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn((message: unknown) => console.error(message)),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+      checkForUpdates: vi.fn(),
+      downloadUpdate: vi.fn(),
+      on: vi.fn((event: string, handler: (value: unknown) => void) => {
+        handlers.set(event, handler);
+      }),
+      quitAndInstall: vi.fn(),
+    },
+  };
+});
+
 vi.mock("electron", () => ({
   app: {
     getPath: vi.fn(),
+    isPackaged: true,
   },
 }));
 
 vi.mock("electron-updater", () => ({
-  get autoUpdater() {
-    throw new Error("autoUpdater accessed before the update runtime is configured");
-  },
+  autoUpdater: autoUpdaterMock,
 }));
 
 import {
   bucketFromStagingUserId,
-  ElectronAppUpdateRuntime,
-  type ElectronUpdaterRuntime,
+  checkForAppUpdate,
   resolveStagingUserId,
   rolloutManifestSchema,
   shouldAdmitToRollout,
   shouldInstallAppUpdateOnQuit,
 } from "./auto-updater";
 
-class FakeElectronUpdater implements ElectronUpdaterRuntime {
-  allowDowngrade = false;
-  allowPrerelease = false;
-  autoDownload = false;
-  autoInstallOnAppQuit = true;
-  autoRunAppAfterInstall = true;
-  channel: string | null = null;
-  isUserWithinRollout: ElectronUpdaterRuntime["isUserWithinRollout"] = async () => true;
-  loggedErrors: unknown[] = [];
-  logger: ElectronUpdaterRuntime["logger"] = {
-    debug: () => undefined,
-    error: (message) => this.loggedErrors.push(message),
-    info: () => undefined,
-    warn: () => undefined,
-  };
-
-  private readonly handlers = new Map<string, unknown>();
-  private nextCheckError: Error | null = null;
-
-  on: ElectronUpdaterRuntime["on"] = ((event: string, handler: unknown) => {
-    this.handlers.set(event, handler);
-    return this;
-  }) as ElectronUpdaterRuntime["on"];
-
-  checkForUpdates: ElectronUpdaterRuntime["checkForUpdates"] = async () => {
-    if (this.nextCheckError) {
-      const error = this.nextCheckError;
-      this.nextCheckError = null;
-      throw error;
-    }
-    return null;
-  };
-
-  downloadUpdate: ElectronUpdaterRuntime["downloadUpdate"] = async () => [];
-  quitAndInstall: ElectronUpdaterRuntime["quitAndInstall"] = () => undefined;
-
-  emitError(error: Error): void {
-    const handler = this.handlers.get("error") as ((value: Error) => void) | undefined;
-    handler?.(error);
-  }
-
-  logInternalError(error: Error): void {
-    this.logger?.error(error);
-  }
-
-  rejectNextCheck(error: Error): void {
-    this.nextCheckError = error;
-  }
-}
-
-function createElectronRuntime() {
-  const updater = new FakeElectronUpdater();
-  const runtime = new ElectronAppUpdateRuntime(updater);
-  const onError = vi.fn();
-  runtime.configure({
-    releaseChannel: "stable",
-    shouldAdmitUpdate: () => true,
-    onUpdateAvailable: vi.fn(),
-    onUpdateDownloaded: vi.fn(),
-    onUpdateNotAvailable: vi.fn(),
-    onError,
-  });
-  return { onError, runtime, updater };
-}
-
-describe("ElectronAppUpdateRuntime", () => {
+describe("checkForAppUpdate", () => {
   it("treats an unpublished channel manifest as an unavailable update", async () => {
-    const { onError, runtime, updater } = createElectronRuntime();
     const error = Object.assign(new Error("Cannot find latest-mac.yml"), {
       code: "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND",
     });
-    updater.logInternalError(error);
-    updater.emitError(error);
-    updater.rejectNextCheck(error);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.logger.error(error);
+      autoUpdaterMock.handlers.get("error")?.(error);
+      throw error;
+    });
 
-    await expect(runtime.checkForUpdates()).resolves.toBeNull();
-    expect(updater.loggedErrors).toEqual([]);
-    expect(onError).not.toHaveBeenCalled();
+    const result = await checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+
+    expect(result).toEqual({
+      hasUpdate: false,
+      readyToInstall: false,
+      currentVersion: "1.2.3",
+      latestVersion: "1.2.3",
+      body: null,
+      date: null,
+      errorMessage: null,
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it("keeps genuine updater failures visible", async () => {
-    const { onError, runtime, updater } = createElectronRuntime();
     const error = new Error("network down");
-    updater.emitError(error);
-    updater.rejectNextCheck(error);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.logger.error(error);
+      autoUpdaterMock.handlers.get("error")?.(error);
+      throw error;
+    });
 
-    await expect(runtime.checkForUpdates()).rejects.toBe(error);
-    expect(onError).toHaveBeenCalledWith(error);
+    const result = await checkForAppUpdate({
+      currentVersion: "1.2.3",
+      releaseChannel: "stable",
+      intent: "manual",
+    });
+
+    expect(result.errorMessage).toBe("network down");
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 });
 

--- a/packages/desktop/src/features/auto-updater.test.ts
+++ b/packages/desktop/src/features/auto-updater.test.ts
@@ -4,96 +4,114 @@ import path from "node:path";
 import { UUID } from "builder-util-runtime";
 import { describe, expect, it, vi } from "vitest";
 
-const { autoUpdaterMock } = vi.hoisted(() => {
-  const handlers = new Map<string, (value: unknown) => void>();
-  return {
-    autoUpdaterMock: {
-      handlers,
-      logger: {
-        debug: vi.fn(),
-        error: vi.fn((message: unknown) => console.error(message)),
-        info: vi.fn(),
-        warn: vi.fn(),
-      },
-      checkForUpdates: vi.fn(),
-      downloadUpdate: vi.fn(),
-      on: vi.fn((event: string, handler: (value: unknown) => void) => {
-        handlers.set(event, handler);
-      }),
-      quitAndInstall: vi.fn(),
-    },
-  };
-});
-
 vi.mock("electron", () => ({
   app: {
     getPath: vi.fn(),
-    isPackaged: true,
   },
 }));
 
 vi.mock("electron-updater", () => ({
-  autoUpdater: autoUpdaterMock,
+  autoUpdater: {},
 }));
 
 import {
   bucketFromStagingUserId,
-  checkForAppUpdate,
+  ElectronAppUpdateRuntime,
+  type ElectronUpdaterRuntime,
   resolveStagingUserId,
   rolloutManifestSchema,
   shouldAdmitToRollout,
   shouldInstallAppUpdateOnQuit,
 } from "./auto-updater";
 
-describe("checkForAppUpdate", () => {
+class FakeElectronUpdater implements ElectronUpdaterRuntime {
+  allowDowngrade = false;
+  allowPrerelease = false;
+  autoDownload = false;
+  autoInstallOnAppQuit = true;
+  autoRunAppAfterInstall = true;
+  channel: string | null = null;
+  isUserWithinRollout: ElectronUpdaterRuntime["isUserWithinRollout"] = async () => true;
+  loggedErrors: unknown[] = [];
+  logger: ElectronUpdaterRuntime["logger"] = {
+    debug: () => undefined,
+    error: (message) => this.loggedErrors.push(message),
+    info: () => undefined,
+    warn: () => undefined,
+  };
+
+  private readonly handlers = new Map<string, unknown>();
+  private nextCheckError: Error | null = null;
+
+  on: ElectronUpdaterRuntime["on"] = ((event: string, handler: unknown) => {
+    this.handlers.set(event, handler);
+    return this;
+  }) as ElectronUpdaterRuntime["on"];
+
+  checkForUpdates: ElectronUpdaterRuntime["checkForUpdates"] = async () => {
+    if (this.nextCheckError) {
+      const error = this.nextCheckError;
+      this.nextCheckError = null;
+      throw error;
+    }
+    return null;
+  };
+
+  downloadUpdate: ElectronUpdaterRuntime["downloadUpdate"] = async () => [];
+  quitAndInstall: ElectronUpdaterRuntime["quitAndInstall"] = () => undefined;
+
+  emitError(error: Error): void {
+    const handler = this.handlers.get("error") as ((value: Error) => void) | undefined;
+    handler?.(error);
+  }
+
+  logInternalError(error: Error): void {
+    this.logger?.error(error);
+  }
+
+  rejectNextCheck(error: Error): void {
+    this.nextCheckError = error;
+  }
+}
+
+function createElectronRuntime() {
+  const updater = new FakeElectronUpdater();
+  const runtime = new ElectronAppUpdateRuntime(updater);
+  const onError = vi.fn();
+  runtime.configure({
+    releaseChannel: "stable",
+    shouldAdmitUpdate: () => true,
+    onUpdateAvailable: vi.fn(),
+    onUpdateDownloaded: vi.fn(),
+    onUpdateNotAvailable: vi.fn(),
+    onError,
+  });
+  return { onError, runtime, updater };
+}
+
+describe("ElectronAppUpdateRuntime", () => {
   it("treats an unpublished channel manifest as an unavailable update", async () => {
+    const { onError, runtime, updater } = createElectronRuntime();
     const error = Object.assign(new Error("Cannot find latest-mac.yml"), {
       code: "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND",
     });
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
-      autoUpdaterMock.logger.error(error);
-      autoUpdaterMock.handlers.get("error")?.(error);
-      throw error;
-    });
+    updater.logInternalError(error);
+    updater.emitError(error);
+    updater.rejectNextCheck(error);
 
-    const result = await checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "manual",
-    });
-
-    expect(result).toEqual({
-      hasUpdate: false,
-      readyToInstall: false,
-      currentVersion: "1.2.3",
-      latestVersion: "1.2.3",
-      body: null,
-      date: null,
-      errorMessage: null,
-    });
-    expect(consoleError).not.toHaveBeenCalled();
-    consoleError.mockRestore();
+    await expect(runtime.checkForUpdates()).resolves.toBeNull();
+    expect(updater.loggedErrors).toEqual([]);
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("keeps genuine updater failures visible", async () => {
+    const { onError, runtime, updater } = createElectronRuntime();
     const error = new Error("network down");
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
-      autoUpdaterMock.logger.error(error);
-      autoUpdaterMock.handlers.get("error")?.(error);
-      throw error;
-    });
+    updater.emitError(error);
+    updater.rejectNextCheck(error);
 
-    const result = await checkForAppUpdate({
-      currentVersion: "1.2.3",
-      releaseChannel: "stable",
-      intent: "manual",
-    });
-
-    expect(result.errorMessage).toBe("network down");
-    expect(consoleError).toHaveBeenCalled();
-    consoleError.mockRestore();
+    await expect(runtime.checkForUpdates()).rejects.toBe(error);
+    expect(onError).toHaveBeenCalledWith(error);
   });
 });
 

--- a/packages/desktop/src/features/auto-updater.test.ts
+++ b/packages/desktop/src/features/auto-updater.test.ts
@@ -11,7 +11,9 @@ vi.mock("electron", () => ({
 }));
 
 vi.mock("electron-updater", () => ({
-  autoUpdater: {},
+  get autoUpdater() {
+    throw new Error("autoUpdater accessed before the update runtime is configured");
+  },
 }));
 
 import {

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -33,6 +33,17 @@ export {
 
 let cachedStagingUserIdPromise: Promise<string> | null = null;
 
+const UPDATE_CHANNEL_NOT_PUBLISHED_CODE = "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND";
+
+function isUpdateChannelNotPublished(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === UPDATE_CHANNEL_NOT_PUBLISHED_CODE
+  );
+}
+
 export function shouldAdmitToRollout(args: {
   channel: AppReleaseChannel;
   rolloutHours: number | undefined;
@@ -109,6 +120,18 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
     if (this.configured) return;
     this.configured = true;
 
+    // electron-updater logs every emitted error before consumers can classify it.
+    // Paseo reports genuine check, runtime, and install failures through the
+    // callbacks below, so leave internal error logging disabled to avoid both
+    // duplicate logs and expected missing-channel noise.
+    const updaterLogger = autoUpdater.logger;
+    autoUpdater.logger = {
+      debug: updaterLogger?.debug ? (message) => updaterLogger.debug?.(message) : undefined,
+      error: () => undefined,
+      info: (message) => updaterLogger?.info(message),
+      warn: (message) => updaterLogger?.warn(message),
+    };
+
     autoUpdater.on("update-available", (info) => {
       input.onUpdateAvailable(info as RuntimeUpdateInfo);
     });
@@ -119,17 +142,23 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
       input.onUpdateNotAvailable();
     });
     autoUpdater.on("error", (error) => {
+      if (isUpdateChannelNotPublished(error)) return;
       input.onError(error);
     });
   }
 
   async checkForUpdates(): Promise<RuntimeUpdateCheckResult | null> {
-    const result = await autoUpdater.checkForUpdates();
-    if (!result) return null;
-    return {
-      isUpdateAvailable: result.isUpdateAvailable,
-      updateInfo: result.updateInfo as RuntimeUpdateInfo,
-    };
+    try {
+      const result = await autoUpdater.checkForUpdates();
+      if (!result) return null;
+      return {
+        isUpdateAvailable: result.isUpdateAvailable,
+        updateInfo: result.updateInfo as RuntimeUpdateInfo,
+      };
+    } catch (error) {
+      if (isUpdateChannelNotPublished(error)) return null;
+      throw error;
+    }
   }
 
   downloadUpdate(): Promise<unknown> {

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -96,20 +96,38 @@ export function shouldInstallAppUpdateOnQuit(input: {
   return !(input.platform === "linux" && input.isAppImage);
 }
 
-class ElectronAppUpdateRuntime implements AppUpdateRuntime {
+export type ElectronUpdaterRuntime = Pick<
+  typeof autoUpdater,
+  | "allowDowngrade"
+  | "allowPrerelease"
+  | "autoDownload"
+  | "autoInstallOnAppQuit"
+  | "autoRunAppAfterInstall"
+  | "channel"
+  | "checkForUpdates"
+  | "downloadUpdate"
+  | "isUserWithinRollout"
+  | "logger"
+  | "on"
+  | "quitAndInstall"
+>;
+
+export class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   private configured = false;
 
+  constructor(private readonly updater: ElectronUpdaterRuntime = autoUpdater) {}
+
   configure(input: AppUpdateRuntimeConfiguration): void {
-    autoUpdater.autoDownload = true;
-    autoUpdater.autoRunAppAfterInstall = true;
+    this.updater.autoDownload = true;
+    this.updater.autoRunAppAfterInstall = true;
     // Paseo revalidates the current manifest before explicitly installing on quit.
     // Electron's built-in handler would install an older download without checking
     // whether a newer release has superseded it.
-    autoUpdater.autoInstallOnAppQuit = false;
-    autoUpdater.allowPrerelease = input.releaseChannel === "beta";
-    autoUpdater.channel = input.releaseChannel === "beta" ? "beta" : "latest";
-    autoUpdater.allowDowngrade = false;
-    autoUpdater.isUserWithinRollout = async (info) => {
+    this.updater.autoInstallOnAppQuit = false;
+    this.updater.allowPrerelease = input.releaseChannel === "beta";
+    this.updater.channel = input.releaseChannel === "beta" ? "beta" : "latest";
+    this.updater.allowDowngrade = false;
+    this.updater.isUserWithinRollout = async (info) => {
       try {
         return await input.shouldAdmitUpdate(info as RuntimeUpdateInfo);
       } catch {
@@ -124,24 +142,24 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
     // Paseo reports genuine check, runtime, and install failures through the
     // callbacks below, so leave internal error logging disabled to avoid both
     // duplicate logs and expected missing-channel noise.
-    const updaterLogger = autoUpdater.logger;
-    autoUpdater.logger = {
+    const updaterLogger = this.updater.logger;
+    this.updater.logger = {
       debug: updaterLogger?.debug ? (message) => updaterLogger.debug?.(message) : undefined,
       error: () => undefined,
       info: (message) => updaterLogger?.info(message),
       warn: (message) => updaterLogger?.warn(message),
     };
 
-    autoUpdater.on("update-available", (info) => {
+    this.updater.on("update-available", (info) => {
       input.onUpdateAvailable(info as RuntimeUpdateInfo);
     });
-    autoUpdater.on("update-downloaded", (info) => {
+    this.updater.on("update-downloaded", (info) => {
       input.onUpdateDownloaded(info as RuntimeUpdateInfo);
     });
-    autoUpdater.on("update-not-available", () => {
+    this.updater.on("update-not-available", () => {
       input.onUpdateNotAvailable();
     });
-    autoUpdater.on("error", (error) => {
+    this.updater.on("error", (error) => {
       if (isUpdateChannelNotPublished(error)) return;
       input.onError(error);
     });
@@ -149,7 +167,7 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
 
   async checkForUpdates(): Promise<RuntimeUpdateCheckResult | null> {
     try {
-      const result = await autoUpdater.checkForUpdates();
+      const result = await this.updater.checkForUpdates();
       if (!result) return null;
       return {
         isUpdateAvailable: result.isUpdateAvailable,
@@ -162,12 +180,12 @@ class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   }
 
   downloadUpdate(): Promise<unknown> {
-    return autoUpdater.downloadUpdate();
+    return this.updater.downloadUpdate();
   }
 
   quitAndInstall(isSilent: boolean, isForceRunAfter: boolean): void {
-    autoUpdater.autoRunAppAfterInstall = isForceRunAfter;
-    autoUpdater.quitAndInstall(isSilent, isForceRunAfter);
+    this.updater.autoRunAppAfterInstall = isForceRunAfter;
+    this.updater.quitAndInstall(isSilent, isForceRunAfter);
   }
 }
 

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -96,45 +96,20 @@ export function shouldInstallAppUpdateOnQuit(input: {
   return !(input.platform === "linux" && input.isAppImage);
 }
 
-export type ElectronUpdaterRuntime = Pick<
-  typeof autoUpdater,
-  | "allowDowngrade"
-  | "allowPrerelease"
-  | "autoDownload"
-  | "autoInstallOnAppQuit"
-  | "autoRunAppAfterInstall"
-  | "channel"
-  | "checkForUpdates"
-  | "downloadUpdate"
-  | "isUserWithinRollout"
-  | "logger"
-  | "on"
-  | "quitAndInstall"
->;
-
-export class ElectronAppUpdateRuntime implements AppUpdateRuntime {
+class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   private configured = false;
 
-  constructor(private readonly injectedUpdater?: ElectronUpdaterRuntime) {}
-
-  private get updater(): ElectronUpdaterRuntime {
-    // electron-updater constructs its platform updater on first access. Keep
-    // that access lazy so importing Paseo's update service does not require a
-    // fully initialized Electron app.
-    return this.injectedUpdater ?? autoUpdater;
-  }
-
   configure(input: AppUpdateRuntimeConfiguration): void {
-    this.updater.autoDownload = true;
-    this.updater.autoRunAppAfterInstall = true;
+    autoUpdater.autoDownload = true;
+    autoUpdater.autoRunAppAfterInstall = true;
     // Paseo revalidates the current manifest before explicitly installing on quit.
     // Electron's built-in handler would install an older download without checking
     // whether a newer release has superseded it.
-    this.updater.autoInstallOnAppQuit = false;
-    this.updater.allowPrerelease = input.releaseChannel === "beta";
-    this.updater.channel = input.releaseChannel === "beta" ? "beta" : "latest";
-    this.updater.allowDowngrade = false;
-    this.updater.isUserWithinRollout = async (info) => {
+    autoUpdater.autoInstallOnAppQuit = false;
+    autoUpdater.allowPrerelease = input.releaseChannel === "beta";
+    autoUpdater.channel = input.releaseChannel === "beta" ? "beta" : "latest";
+    autoUpdater.allowDowngrade = false;
+    autoUpdater.isUserWithinRollout = async (info) => {
       try {
         return await input.shouldAdmitUpdate(info as RuntimeUpdateInfo);
       } catch {
@@ -149,24 +124,24 @@ export class ElectronAppUpdateRuntime implements AppUpdateRuntime {
     // Paseo reports genuine check, runtime, and install failures through the
     // callbacks below, so leave internal error logging disabled to avoid both
     // duplicate logs and expected missing-channel noise.
-    const updaterLogger = this.updater.logger;
-    this.updater.logger = {
+    const updaterLogger = autoUpdater.logger;
+    autoUpdater.logger = {
       debug: updaterLogger?.debug ? (message) => updaterLogger.debug?.(message) : undefined,
       error: () => undefined,
       info: (message) => updaterLogger?.info(message),
       warn: (message) => updaterLogger?.warn(message),
     };
 
-    this.updater.on("update-available", (info) => {
+    autoUpdater.on("update-available", (info) => {
       input.onUpdateAvailable(info as RuntimeUpdateInfo);
     });
-    this.updater.on("update-downloaded", (info) => {
+    autoUpdater.on("update-downloaded", (info) => {
       input.onUpdateDownloaded(info as RuntimeUpdateInfo);
     });
-    this.updater.on("update-not-available", () => {
+    autoUpdater.on("update-not-available", () => {
       input.onUpdateNotAvailable();
     });
-    this.updater.on("error", (error) => {
+    autoUpdater.on("error", (error) => {
       if (isUpdateChannelNotPublished(error)) return;
       input.onError(error);
     });
@@ -174,7 +149,7 @@ export class ElectronAppUpdateRuntime implements AppUpdateRuntime {
 
   async checkForUpdates(): Promise<RuntimeUpdateCheckResult | null> {
     try {
-      const result = await this.updater.checkForUpdates();
+      const result = await autoUpdater.checkForUpdates();
       if (!result) return null;
       return {
         isUpdateAvailable: result.isUpdateAvailable,
@@ -187,12 +162,12 @@ export class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   }
 
   downloadUpdate(): Promise<unknown> {
-    return this.updater.downloadUpdate();
+    return autoUpdater.downloadUpdate();
   }
 
   quitAndInstall(isSilent: boolean, isForceRunAfter: boolean): void {
-    this.updater.autoRunAppAfterInstall = isForceRunAfter;
-    this.updater.quitAndInstall(isSilent, isForceRunAfter);
+    autoUpdater.autoRunAppAfterInstall = isForceRunAfter;
+    autoUpdater.quitAndInstall(isSilent, isForceRunAfter);
   }
 }
 

--- a/packages/desktop/src/features/auto-updater.ts
+++ b/packages/desktop/src/features/auto-updater.ts
@@ -115,7 +115,14 @@ export type ElectronUpdaterRuntime = Pick<
 export class ElectronAppUpdateRuntime implements AppUpdateRuntime {
   private configured = false;
 
-  constructor(private readonly updater: ElectronUpdaterRuntime = autoUpdater) {}
+  constructor(private readonly injectedUpdater?: ElectronUpdaterRuntime) {}
+
+  private get updater(): ElectronUpdaterRuntime {
+    // electron-updater constructs its platform updater on first access. Keep
+    // that access lazy so importing Paseo's update service does not require a
+    // fully initialized Electron app.
+    return this.injectedUpdater ?? autoUpdater;
+  }
 
   configure(input: AppUpdateRuntimeConfiguration): void {
     this.updater.autoDownload = true;


### PR DESCRIPTION
### Linked issue

None found.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A GitHub release becomes visible before every platform updater manifest has necessarily finished publishing. During that gap, desktop users checking for updates saw a channel-file error even though nothing was wrong with their installation or network.

The desktop updater now treats the exact missing-channel-manifest condition as no update being available. The classification stays at the electron-updater boundary, while network, malformed-manifest, checksum, signature, runtime, and install failures continue through Paseo error reporting.

### Goals

- Treat an unpublished platform updater manifest as no update available.
- Keep automatic checks silent during the release publishing gap.
- Keep manual checks free of technical channel-file errors during that gap.
- Prevent downloaded updates from installing when quit-time revalidation cannot find the current manifest.
- Preserve reporting for genuine updater failures.

### Non-goals

- Change rollout admission or release publication sequencing.
- Hide malformed manifests, network failures, checksum failures, signature failures, or installation failures.
- Change the marketing download page or GitHub release visibility.

### QA

- Added a regression test reproducing `ERR_UPDATER_CHANNEL_FILE_NOT_FOUND`; before the fix it returned `Cannot find latest-mac.yml` as `errorMessage`.
- Confirmed the regression test returns the normal no-update result with no error log after the fix.
- Confirmed an emitted and rejected network failure remains visible and logged.
- `npx vitest run packages/desktop/src/features/auto-updater.test.ts --bail=1` — 11 tests passed.
- `npm run typecheck` — passed across all workspaces.
- `npm run lint` — 0 warnings and 0 errors.
- `npm run format` — passed.
- Packaged macOS, Windows, and Linux builds were not manually exercised.

Risk surface: the adapter now owns updater error reporting instead of electron-updater internal error logging. Tests cover both missing-manifest suppression and genuine event/rejection passthrough.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense