### PR TITLE
fix(desktop): add a persistent macOS daemon LaunchAgent

### DIFF
--- a/packages/cli/src/commands/daemon/local-daemon.supervision.test.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.supervision.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -133,6 +134,19 @@ describe("local daemon launch supervision", () => {
     expect(launch?.command).toBe(process.execPath);
     expectSupervisorLaunch(launch?.args ?? []);
     expect(launch?.args).toContain("--no-mcp");
+  });
+
+  test("detached start clears a pending explicit stop intent", async () => {
+    vi.useFakeTimers();
+    const home = await createPaseoHome({ version: 1 });
+    const stopIntentPath = path.join(home, "daemon-explicit-stop");
+    await writeFile(stopIntentPath, "4242\n");
+    const runtime = new FakeDaemonRuntime();
+
+    const resultPromise = startLocalDaemonDetached({ home }, runtime);
+    expect(existsSync(stopIntentPath)).toBe(false);
+    await vi.advanceTimersByTimeAsync(1200);
+    await resultPromise;
   });
 
   test("relay TLS flag is passed to the supervised daemon", async () => {

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -2,7 +2,13 @@ import { spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { loadConfig, resolvePaseoHome, spawnProcess } from "@getpaseo/server";
+import {
+  clearDaemonExplicitStopIntent,
+  loadConfig,
+  resolvePaseoHome,
+  spawnProcess,
+  writeDaemonExplicitStopIntent,
+} from "@getpaseo/server";
 import treeKill from "tree-kill";
 import { tryConnectToDaemon } from "../../utils/client.js";
 
@@ -489,8 +495,22 @@ async function waitForStopAfterRequest(args: {
       : await waitForDaemonUnreachable(state, timeoutMs);
 
   if (!stopped && force && state.running && pid !== null) {
-    await signalProcessTreeOrOwnerSafely(pid, "SIGKILL");
-    stopped = await waitForPidExit(pid, killTimeoutMs);
+    const persistExplicitStop = state.pidInfo?.desktopManaged === true;
+    if (persistExplicitStop) {
+      writeDaemonExplicitStopIntent(state.home, pid);
+    }
+    try {
+      await signalProcessTreeOrOwnerSafely(pid, "SIGKILL");
+      stopped = await waitForPidExit(pid, killTimeoutMs);
+    } catch (error) {
+      if (persistExplicitStop) {
+        clearDaemonExplicitStopIntent(state.home);
+      }
+      throw error;
+    }
+    if (!stopped && persistExplicitStop) {
+      clearDaemonExplicitStopIntent(state.home);
+    }
     return { stopped, forced: true };
   }
 
@@ -588,6 +608,7 @@ export async function startLocalDaemonDetached(
   const childEnv = buildChildEnv(options);
 
   const paseoHome = runtime.resolveHome(childEnv);
+  clearDaemonExplicitStopIntent(paseoHome);
   const logPath = path.join(paseoHome, DAEMON_LOG_FILENAME);
   const child = runtime.spawnDetached(
     process.execPath,
@@ -655,6 +676,7 @@ export function startLocalDaemonForeground(
 
   const daemonRunnerEntry = runtime.resolveRunnerEntry();
   const childEnv = buildChildEnv(options);
+  clearDaemonExplicitStopIntent(runtime.resolveHome(childEnv));
   const result = runtime.spawnForeground(
     process.execPath,
     [...process.execArgv, daemonRunnerEntry, ...buildRunnerArgs(options)],

--- a/packages/cli/tests/33-daemon-stop-tree-kill.test.ts
+++ b/packages/cli/tests/33-daemon-stop-tree-kill.test.ts
@@ -120,6 +120,7 @@ try {
       pid: ownerProcess.pid,
       listen: "127.0.0.1:1",
       startedAt: new Date().toISOString(),
+      desktopManaged: true,
     }),
   );
 
@@ -171,6 +172,11 @@ try {
     () => !isProcessRunning(ownerPid ?? -1) && !isProcessRunning(descendantPid ?? -1),
     5000,
     `owner (${ownerPid}) or descendant (${descendantPid}) survived forced stop`,
+  );
+  assert.strictEqual(
+    await readFile(join(paseoHome, "daemon-explicit-stop"), "utf8"),
+    `${ownerPid}\n`,
+    "forced desktop daemon stop should persist its explicit stop intent",
   );
   console.log("✓ forced stop killed the full process tree\n");
 } finally {

--- a/packages/desktop/bin/paseo-daemon-launcher
+++ b/packages/desktop/bin/paseo-daemon-launcher
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+# LaunchAgents receive a small environment. Add stable command locations before
+# inherited entries without loading user shell startup files.
+STABLE_PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+if [ -n "${PATH:-}" ]; then
+  PATH="${STABLE_PATH}:${PATH}"
+else
+  PATH="${STABLE_PATH}"
+fi
+export PATH
+unset ENV BASH_ENV
+
+if [ -n "${PASEO_HOME:-}" ]; then
+  STOP_INTENT_PATH="${PASEO_HOME}/daemon-explicit-stop"
+else
+  STOP_INTENT_PATH="${HOME}/.paseo/daemon-explicit-stop"
+fi
+if [ -f "$STOP_INTENT_PATH" ]; then
+  rm -f -- "$STOP_INTENT_PATH"
+  exit 0
+fi
+
+SCRIPT_PATH=$0
+case "$SCRIPT_PATH" in
+  /*) ;;
+  *) SCRIPT_PATH="$(pwd)/$SCRIPT_PATH" ;;
+esac
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)
+RESOURCES_DIR=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
+
+export ELECTRON_RUN_AS_NODE=1
+export PASEO_NODE_ENV=production
+export PASEO_DESKTOP_MANAGED=1
+export PASEO_CLI="${RESOURCES_DIR}/bin/paseo"
+export PASEO_WEB_UI_ENABLED=false
+
+exec "${RESOURCES_DIR}/../Frameworks/Paseo Helper.app/Contents/MacOS/Paseo Helper" \
+  --disable-warning=DEP0040 \
+  "${RESOURCES_DIR}/app.asar.unpacked/dist/daemon/node-entrypoint-runner.js" \
+  node-script \
+  "${RESOURCES_DIR}/app.asar/node_modules/@getpaseo/server/dist/scripts/supervisor-entrypoint.js"

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -48,6 +48,8 @@ mac:
   extraResources:
     - from: bin/paseo
       to: bin/paseo
+    - from: bin/paseo-daemon-launcher
+      to: bin/paseo-daemon-launcher
     - from: assets/icon.png
       to: icon.png
   target:

--- a/packages/desktop/src/daemon/daemon-manager.test.ts
+++ b/packages/desktop/src/daemon/daemon-manager.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     env: {},
   })),
   spawnProcess: vi.fn(),
+  clearDaemonExplicitStopIntent: vi.fn(),
   logInfo: vi.fn(),
   logError: vi.fn(),
   appLogPath: "/tmp/paseo-desktop-daemon-manager-test-main.log",
@@ -52,6 +53,7 @@ vi.mock("electron-log/main", () => ({
 }));
 
 vi.mock("@getpaseo/server", () => ({
+  clearDaemonExplicitStopIntent: mocks.clearDaemonExplicitStopIntent,
   resolvePaseoHome: vi.fn(() => mocks.paseoHome),
   spawnProcess: mocks.spawnProcess,
 }));
@@ -117,6 +119,7 @@ describe("daemon-manager commands", () => {
     mocks.createNodeEntrypointInvocation.mockReset();
     mocks.createNodeEntrypointInvocation.mockReturnValue({ command: "node", args: [], env: {} });
     mocks.spawnProcess.mockReset();
+    mocks.clearDaemonExplicitStopIntent.mockReset();
     mocks.logInfo.mockReset();
     mocks.logError.mockReset();
     mocks.getElectronLogFile.mockReset();
@@ -441,6 +444,7 @@ describe("daemon-manager commands", () => {
     const message = thrown?.message ?? "";
     const recentLogsLabel = message.match(/Recent logs \(([^)]*)\):/)?.[1];
     expect(message).toContain("Daemon failed to start: exit code 1");
+    expect(mocks.clearDaemonExplicitStopIntent).toHaveBeenCalledWith(mocks.paseoHome);
     expect(recentLogsLabel?.split(/[\\/]/).at(-1)).toBe("daemon.log");
     expect(message).toContain("recent daemon failure");
     expect(mocks.createNodeEntrypointInvocation).toHaveBeenCalledWith(

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { app, ipcMain, powerMonitor } from "electron";
 import log from "electron-log/main";
-import { resolvePaseoHome, spawnProcess } from "@getpaseo/server";
+import { clearDaemonExplicitStopIntent, resolvePaseoHome, spawnProcess } from "@getpaseo/server";
 import {
   copyAttachmentFileToManagedStorage,
   deleteManagedAttachmentFile,
@@ -365,6 +365,7 @@ async function startDaemon(): Promise<DesktopDaemonStatus> {
     }
   }
 
+  clearDaemonExplicitStopIntent(getPaseoHome());
   const daemonRunner = resolveDaemonRunnerEntrypoint();
   const reclaimStalePidLock =
     current.status === "errored" && current.desktopManaged && current.error === null;

--- a/packages/desktop/src/daemon/desktop-packaging.test.ts
+++ b/packages/desktop/src/daemon/desktop-packaging.test.ts
@@ -2,10 +2,12 @@ import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -14,6 +16,8 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const STABLE_MACOS_PATH =
+  "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 
 function writeExecutable(filePath: string, contents: string): void {
   writeFileSync(filePath, contents, "utf8");
@@ -23,12 +27,15 @@ function writeExecutable(filePath: string, contents: string): void {
 function createFakeMacBundle(options: { includeHelper: boolean }): {
   root: string;
   shimPath: string;
+  daemonLauncherPath: string;
+  resourcesPath: string;
 } {
   const root = mkdtempSync(join(tmpdir(), "paseo-cli-shim-test-"));
   const appPath = join(root, "Paseo.app");
   const contentsPath = join(appPath, "Contents");
   const resourcesPath = join(contentsPath, "Resources");
   const shimPath = join(resourcesPath, "bin", "paseo");
+  const daemonLauncherPath = join(resourcesPath, "bin", "paseo-daemon-launcher");
   const mainPath = join(contentsPath, "MacOS", "Paseo");
   const helperPath = join(
     contentsPath,
@@ -43,6 +50,8 @@ function createFakeMacBundle(options: { includeHelper: boolean }): {
   mkdirSync(dirname(mainPath), { recursive: true });
   copyFileSync(join(packageRoot, "bin", "paseo"), shimPath);
   chmodSync(shimPath, 0o755);
+  copyFileSync(join(packageRoot, "bin", "paseo-daemon-launcher"), daemonLauncherPath);
+  chmodSync(daemonLauncherPath, 0o755);
 
   writeExecutable(mainPath, "#!/bin/sh\necho main-executable\n");
 
@@ -52,14 +61,16 @@ function createFakeMacBundle(options: { includeHelper: boolean }): {
       helperPath,
       [
         "#!/bin/sh",
-        'printf "helper env=%s/%s cli=%s\\n" "$ELECTRON_RUN_AS_NODE" "$PASEO_NODE_ENV" "$PASEO_CLI"',
+        'printf "helper env=%s/%s cli=%s web=%s\\n" "$ELECTRON_RUN_AS_NODE" "$PASEO_NODE_ENV" "$PASEO_CLI" "${PASEO_WEB_UI_ENABLED:-}"',
+        'printf "path=%s\\n" "$PATH"',
         'printf "args=%s\\n" "$*"',
+        'exit "${PASEO_HELPER_EXIT_CODE:-0}"',
         "",
       ].join("\n"),
     );
   }
 
-  return { root, shimPath };
+  return { root, shimPath, daemonLauncherPath, resourcesPath };
 }
 
 describe("desktop packaging", () => {
@@ -94,6 +105,16 @@ describe("desktop packaging", () => {
 
     expect(config).toContain("name: Paseo agent link");
     expect(config).toContain("- paseo");
+  });
+
+  it("packages the executable daemon launcher in the macOS resources", () => {
+    const config = readFileSync(join(packageRoot, "electron-builder.yml"), "utf8");
+    const launcherPath = join(packageRoot, "bin", "paseo-daemon-launcher");
+
+    expect(config).toContain(
+      "- from: bin/paseo-daemon-launcher\n      to: bin/paseo-daemon-launcher",
+    );
+    expect(statSync(launcherPath).mode & 0o111).toBe(0o111);
   });
 
   // electron-builder packs production dependencies declared in package.json into
@@ -142,6 +163,106 @@ describe("desktop packaging", () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("Bundled Paseo Helper executable not found");
       expect(result.stdout).not.toContain("main-executable");
+    } finally {
+      rmSync(bundle.root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepends stable macOS command paths and preserves the inherited PATH", () => {
+    if (process.platform === "win32") return;
+
+    const bundle = createFakeMacBundle({ includeHelper: true });
+    try {
+      const result = spawnSync(bundle.daemonLauncherPath, [], {
+        encoding: "utf8",
+        env: { ...process.env, PATH: "/custom/bin:/custom/sbin" },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        `helper env=1/production cli=${join(bundle.resourcesPath, "bin", "paseo")} web=false`,
+      );
+      expect(result.stdout).toContain(`path=${STABLE_MACOS_PATH}:/custom/bin:/custom/sbin\n`);
+      expect(result.stdout).toContain("node-entrypoint-runner.js");
+      expect(result.stdout).toContain("node-script");
+      expect(result.stdout).toContain("@getpaseo/server/dist/scripts/supervisor-entrypoint.js");
+    } finally {
+      rmSync(bundle.root, { recursive: true, force: true });
+    }
+  });
+
+  it("consumes an explicit stop intent without launching the daemon", () => {
+    if (process.platform === "win32") return;
+
+    const bundle = createFakeMacBundle({ includeHelper: true });
+    const paseoHome = join(bundle.root, "paseo-home");
+    const stopIntentPath = join(paseoHome, "daemon-explicit-stop");
+    mkdirSync(paseoHome, { recursive: true });
+    writeFileSync(stopIntentPath, "4242\n", "utf8");
+
+    try {
+      const result = spawnSync(bundle.daemonLauncherPath, [], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PASEO_HOME: paseoHome,
+          PASEO_HELPER_EXIT_CODE: "23",
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(existsSync(stopIntentPath)).toBe(false);
+      expect(result.stdout).not.toContain("helper env=");
+    } finally {
+      rmSync(bundle.root, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates an unexpected daemon failure to launchd", () => {
+    if (process.platform === "win32") return;
+
+    const bundle = createFakeMacBundle({ includeHelper: true });
+    try {
+      const result = spawnSync(bundle.daemonLauncherPath, [], {
+        encoding: "utf8",
+        env: { ...process.env, PASEO_HELPER_EXIT_CODE: "23" },
+      });
+
+      expect(result.status).toBe(23);
+      expect(result.stdout).toContain("helper env=");
+    } finally {
+      rmSync(bundle.root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not read user shell startup files", () => {
+    if (process.platform === "win32") return;
+
+    const bundle = createFakeMacBundle({ includeHelper: true });
+    const home = join(bundle.root, "home");
+    const startupFile = join(home, "startup-file");
+    const startupMarker = join(home, "startup-file-read");
+    mkdirSync(home, { recursive: true });
+    writeFileSync(startupFile, ': > "$PASEO_STARTUP_MARKER"\nexit 91\n', "utf8");
+    for (const name of [".profile", ".zprofile", ".zshrc", ".zshenv"]) {
+      copyFileSync(startupFile, join(home, name));
+    }
+
+    try {
+      const result = spawnSync(bundle.daemonLauncherPath, [], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: home,
+          SHELL: "/bin/zsh",
+          ENV: startupFile,
+          BASH_ENV: startupFile,
+          PASEO_STARTUP_MARKER: startupMarker,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(existsSync(startupMarker)).toBe(false);
     } finally {
       rmSync(bundle.root, { recursive: true, force: true });
     }

--- a/packages/desktop/src/daemon/launch-agent.test.ts
+++ b/packages/desktop/src/daemon/launch-agent.test.ts
@@ -1,0 +1,118 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createPaseoLaunchAgentPlist,
+  PASEO_LAUNCH_AGENT_LABEL,
+  PaseoLaunchAgentOwnershipError,
+  reconcilePaseoLaunchAgent,
+  resolvePaseoLaunchAgentPath,
+} from "./launch-agent";
+
+const tempRoots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), "paseo-launch-agent-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function appResourcesPath(root: string, appName = "Paseo.app"): string {
+  return path.join(root, "Applications", appName, "Contents", "Resources");
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("Paseo LaunchAgent", () => {
+  it("owns a generic upstream service file that runs the packaged launcher", () => {
+    const home = tempRoot();
+    const resourcesPath = appResourcesPath(home);
+    const plist = createPaseoLaunchAgentPlist({ home, resourcesPath });
+
+    expect(PASEO_LAUNCH_AGENT_LABEL).toBe("sh.paseo.desktop.daemon");
+    expect(resolvePaseoLaunchAgentPath(home)).toBe(
+      path.join(home, "Library", "LaunchAgents", "sh.paseo.desktop.daemon.plist"),
+    );
+    expect(plist).toContain(
+      `<string>${path.join(resourcesPath, "bin", "paseo-daemon-launcher")}</string>`,
+    );
+    expect(plist).toContain("<key>PASEO_DESKTOP_MANAGED</key>");
+    expect(plist).toContain(`  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>`);
+    expect(plist).not.toContain("<key>KeepAlive</key>\n  <true/>");
+  });
+
+  it("leaves an unchanged owned service file in place", () => {
+    const home = tempRoot();
+    const resourcesPath = appResourcesPath(home);
+    const filePath = resolvePaseoLaunchAgentPath(home);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, createPaseoLaunchAgentPlist({ home, resourcesPath }));
+    const inode = statSync(filePath).ino;
+
+    expect(reconcilePaseoLaunchAgent({ home, resourcesPath, platform: "darwin" })).toEqual({
+      path: filePath,
+      changed: false,
+    });
+    expect(statSync(filePath).ino).toBe(inode);
+  });
+
+  it("atomically replaces an outdated owned service file", () => {
+    const home = tempRoot();
+    const filePath = resolvePaseoLaunchAgentPath(home);
+    const oldResourcesPath = appResourcesPath(home, "Paseo Old.app");
+    const resourcesPath = appResourcesPath(home);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, createPaseoLaunchAgentPlist({ home, resourcesPath: oldResourcesPath }));
+    const oldInode = statSync(filePath).ino;
+
+    expect(reconcilePaseoLaunchAgent({ home, resourcesPath, platform: "darwin" })).toEqual({
+      path: filePath,
+      changed: true,
+    });
+    expect(readFileSync(filePath, "utf8")).toBe(
+      createPaseoLaunchAgentPlist({ home, resourcesPath }),
+    );
+    expect(statSync(filePath).ino).not.toBe(oldInode);
+    expect(readdirSync(path.dirname(filePath))).toEqual([path.basename(filePath)]);
+  });
+
+  it("refuses to overwrite an unmanaged service file with the same label", () => {
+    const home = tempRoot();
+    const resourcesPath = appResourcesPath(home);
+    const filePath = resolvePaseoLaunchAgentPath(home);
+    const unmanaged = `<?xml version="1.0"?><plist><dict><key>Label</key><string>${PASEO_LAUNCH_AGENT_LABEL}</string></dict></plist>`;
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, unmanaged);
+
+    let thrown: unknown;
+    try {
+      reconcilePaseoLaunchAgent({ home, resourcesPath, platform: "darwin" });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(PaseoLaunchAgentOwnershipError);
+    expect(thrown).toMatchObject({
+      name: "PaseoLaunchAgentOwnershipError",
+      filePath,
+      message: `refusing to overwrite unmanaged LaunchAgent at ${filePath}`,
+    });
+    expect(readFileSync(filePath, "utf8")).toBe(unmanaged);
+  });
+});

--- a/packages/desktop/src/daemon/launch-agent.ts
+++ b/packages/desktop/src/daemon/launch-agent.ts
@@ -1,0 +1,127 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const PASEO_LAUNCH_AGENT_LABEL = "sh.paseo.desktop.daemon";
+
+export interface PaseoLaunchAgentInput {
+  home?: string;
+  resourcesPath: string;
+  platform?: NodeJS.Platform;
+}
+
+export interface PaseoLaunchAgentResult {
+  path: string;
+  changed: boolean;
+}
+
+export class PaseoLaunchAgentOwnershipError extends Error {
+  constructor(public readonly filePath: string) {
+    super(`refusing to overwrite unmanaged LaunchAgent at ${filePath}`);
+    this.name = "PaseoLaunchAgentOwnershipError";
+  }
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function requireAbsolutePath(value: string, label: string): string {
+  if (!path.isAbsolute(value) || value.includes("\n") || value.includes("\r")) {
+    throw new Error(`${label} must be an absolute single-line path`);
+  }
+  return value;
+}
+
+function launchAgentDirectory(home: string): string {
+  return path.join(home, "Library", "LaunchAgents");
+}
+
+export function resolvePaseoLaunchAgentPath(home = os.homedir()): string {
+  return path.join(launchAgentDirectory(home), `${PASEO_LAUNCH_AGENT_LABEL}.plist`);
+}
+
+export function createPaseoLaunchAgentPlist(input: {
+  home: string;
+  resourcesPath: string;
+}): string {
+  const home = requireAbsolutePath(input.home, "home");
+  const resourcesPath = requireAbsolutePath(input.resourcesPath, "resourcesPath");
+  const daemonLauncher = path.join(resourcesPath, "bin", "paseo-daemon-launcher");
+  const cliPath = path.join(resourcesPath, "bin", "paseo");
+  const logDirectory = path.join(home, ".paseo");
+
+  const text = (value: string): string => `<string>${escapeXml(value)}</string>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  ${text(PASEO_LAUNCH_AGENT_LABEL)}
+  <key>ProgramArguments</key>
+  <array>
+    ${text(daemonLauncher)}
+  </array>
+  <key>WorkingDirectory</key>
+  ${text(home)}
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PASEO_DESKTOP_MANAGED</key>
+    <string>1</string>
+    <key>PASEO_CLI</key>
+    ${text(cliPath)}
+    <key>PASEO_WEB_UI_ENABLED</key>
+    <string>false</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  ${text(path.join(logDirectory, "launchd.stdout.log"))}
+  <key>StandardErrorPath</key>
+  ${text(path.join(logDirectory, "launchd.stderr.log"))}
+</dict>
+</plist>
+`;
+}
+
+function readExistingManagedLaunchAgent(filePath: string): string | null {
+  if (!existsSync(filePath)) return null;
+  const existing = readFileSync(filePath, "utf8");
+  if (
+    !existing.includes(`<string>${PASEO_LAUNCH_AGENT_LABEL}</string>`) ||
+    !existing.includes("<key>PASEO_DESKTOP_MANAGED</key>")
+  ) {
+    throw new PaseoLaunchAgentOwnershipError(filePath);
+  }
+  return existing;
+}
+
+export function reconcilePaseoLaunchAgent(
+  input: PaseoLaunchAgentInput,
+): PaseoLaunchAgentResult | null {
+  if ((input.platform ?? process.platform) !== "darwin") return null;
+
+  const home = input.home ?? os.homedir();
+  const filePath = resolvePaseoLaunchAgentPath(home);
+  const contents = createPaseoLaunchAgentPlist({ home, resourcesPath: input.resourcesPath });
+  const existing = readExistingManagedLaunchAgent(filePath);
+  if (existing === contents) {
+    return { path: filePath, changed: false };
+  }
+
+  mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(tempPath, contents, { encoding: "utf8", mode: 0o600 });
+  renameSync(tempPath, filePath);
+  return { path: filePath, changed: true };
+}

--- a/packages/desktop/src/desktop-startup.test.ts
+++ b/packages/desktop/src/desktop-startup.test.ts
@@ -11,6 +11,7 @@ describe("desktop startup", () => {
         return true;
       }),
       inheritLoginShellEnv: vi.fn(() => calls.push("env")),
+      reconcileLaunchAgent: vi.fn(() => calls.push("launch-agent")),
       bootstrapGui: vi.fn(async () => {
         calls.push("gui");
       }),
@@ -34,6 +35,21 @@ describe("desktop startup", () => {
     });
 
     expect(calls).toEqual(["cli", "env", "gui"]);
+  });
+
+  it("reconciles the owned LaunchAgent after environment inheritance and before GUI startup", async () => {
+    const calls: string[] = [];
+    await runDesktopStartup({
+      hasPendingGuiLaunchRequest: false,
+      runCliPassthroughIfRequested: vi.fn(async () => false),
+      inheritLoginShellEnv: vi.fn(() => calls.push("env")),
+      reconcileLaunchAgent: vi.fn(() => calls.push("launch-agent")),
+      bootstrapGui: vi.fn(async () => {
+        calls.push("gui");
+      }),
+    });
+
+    expect(calls).toEqual(["env", "launch-agent", "gui"]);
   });
 
   it("starts skills auto-update after GUI startup", async () => {

--- a/packages/desktop/src/desktop-startup.ts
+++ b/packages/desktop/src/desktop-startup.ts
@@ -2,6 +2,7 @@ export interface DesktopStartupDependencies {
   hasPendingGuiLaunchRequest: boolean;
   runCliPassthroughIfRequested: () => Promise<boolean>;
   inheritLoginShellEnv: () => void;
+  reconcileLaunchAgent?: () => void;
   bootstrapGui: () => Promise<void>;
   autoUpdateInstalledSkills?: () => void;
 }
@@ -12,6 +13,7 @@ export async function runDesktopStartup(deps: DesktopStartupDependencies): Promi
   }
 
   deps.inheritLoginShellEnv();
+  deps.reconcileLaunchAgent?.();
   await deps.bootstrapGui();
   deps.autoUpdateInstalledSkills?.();
 }

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -82,6 +82,10 @@ import {
   stopDesktopDaemonViaCli,
 } from "./daemon/daemon-manager.js";
 import {
+  PaseoLaunchAgentOwnershipError,
+  reconcilePaseoLaunchAgent,
+} from "./daemon/launch-agent.js";
+import {
   createQuitLifecycle,
   stopDesktopManagedDaemonOnQuitIfNeeded,
 } from "./daemon/quit-lifecycle.js";
@@ -1033,6 +1037,23 @@ void runDesktopStartup({
   hasPendingGuiLaunchRequest: Boolean(pendingOpenProjectPath || pendingAgentNavigation),
   runCliPassthroughIfRequested,
   inheritLoginShellEnv,
+  reconcileLaunchAgent: () => {
+    if (!app.isPackaged || process.platform !== "darwin") return;
+    try {
+      const result = reconcilePaseoLaunchAgent({
+        home: app.getPath("home"),
+        resourcesPath: process.resourcesPath,
+      });
+      if (result?.changed) {
+        log.info("[desktop daemon] reconciled persistent LaunchAgent", { path: result.path });
+      }
+    } catch (error) {
+      if (!(error instanceof PaseoLaunchAgentOwnershipError)) {
+        throw error;
+      }
+      log.warn("[desktop daemon] could not reconcile persistent LaunchAgent", error);
+    }
+  },
   bootstrapGui: bootstrap,
   autoUpdateInstalledSkills: () => {
     void autoUpdateInstalledSkills().catch((error) => {

--- a/packages/server/src/server/daemon-explicit-stop.ts
+++ b/packages/server/src/server/daemon-explicit-stop.ts
@@ -1,0 +1,20 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const DAEMON_EXPLICIT_STOP_FILENAME = "daemon-explicit-stop";
+
+function resolveDaemonExplicitStopPath(paseoHome: string): string {
+  return path.join(paseoHome, DAEMON_EXPLICIT_STOP_FILENAME);
+}
+
+export function writeDaemonExplicitStopIntent(paseoHome: string, ownerPid: number): void {
+  mkdirSync(paseoHome, { recursive: true });
+  writeFileSync(resolveDaemonExplicitStopPath(paseoHome), `${ownerPid}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+export function clearDaemonExplicitStopIntent(paseoHome: string): void {
+  rmSync(resolveDaemonExplicitStopPath(paseoHome), { force: true });
+}

--- a/packages/server/src/server/exports.ts
+++ b/packages/server/src/server/exports.ts
@@ -2,6 +2,10 @@
 export { createPaseoDaemon, type PaseoDaemon, type PaseoDaemonConfig } from "./bootstrap.js";
 export { loadConfig, type CliConfigOverrides } from "./config.js";
 export { resolvePaseoHome } from "./paseo-home.js";
+export {
+  clearDaemonExplicitStopIntent,
+  writeDaemonExplicitStopIntent,
+} from "./daemon-explicit-stop.js";
 export { getOrCreateServerId } from "./server-id.js";
 export { createRootLogger, type LogLevel, type LogFormat } from "./logger.js";
 export {


### PR DESCRIPTION
## Problem

The desktop-managed daemon is coupled to a detached child process. A GUI or `launchd` start can also have a reduced `PATH`, which makes provider command discovery unreliable.

## Change

- Add a packaged, non-interactive daemon launcher.
- Prepend stable macOS command paths and preserve inherited `PATH` entries.
- Add an owned LaunchAgent definition with atomic reconciliation.
- Refuse to replace an unmanaged service file.
- Do not load, restart, or reload the service during reconciliation.
- Reconcile before graphical startup without creating another window.

The service label and paths are generic to upstream Paseo.

## Verification

- Focused desktop tests: 19 passed.
- Desktop main build: passed.
- Desktop and repository typechecks: passed.
- Lint and format checks: passed.
- Launcher shell syntax check: passed.

Based directly on Paseo `v0.3.0`.
