### PR TITLE
fix(server): preflight working directory access

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -2371,24 +2372,93 @@ test("createAgent fails when cwd does not exist", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const storagePath = join(workdir, "agents");
   const storage = new AgentStorage(storagePath, logger);
+  const client = new TestAgentClient();
   const manager = new AgentManager({
     clients: {
-      codex: new TestAgentClient(),
+      codex: client,
     },
     registry: storage,
     logger,
   });
+  const missingPath = join(workdir, "does-not-exist");
 
-  await expect(
-    manager.createAgent(
-      {
-        provider: "codex",
-        cwd: join(workdir, "does-not-exist"),
+  try {
+    await expect(
+      manager.createAgent(
+        {
+          provider: "codex",
+          cwd: missingPath,
+        },
+        undefined,
+        { workspaceId: undefined },
+      ),
+    ).rejects.toThrow(`Working directory does not exist: ${missingPath}`);
+    expect(client.createdConfigs).toEqual([]);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("createAgent fails when cwd is not a directory", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+  const filePath = join(workdir, "file.txt");
+  writeFileSync(filePath, "not a directory");
+  const client = new TestAgentClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    logger,
+  });
+
+  try {
+    await expect(
+      manager.createAgent({ provider: "codex", cwd: filePath }, undefined, {
+        workspaceId: undefined,
+      }),
+    ).rejects.toThrow(`Working directory is not a directory: ${filePath}`);
+    expect(client.createdConfigs).toEqual([]);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("createAgent reports denied cwd access before provider work", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+  const openedPaths: string[] = [];
+  class AccessDeniedClient extends TestAgentClient {
+    fetchCatalogCalls = 0;
+
+    override async fetchCatalog() {
+      this.fetchCatalogCalls += 1;
+      return await super.fetchCatalog();
+    }
+  }
+  const client = new AccessDeniedClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    fileSystem: {
+      stat,
+      async opendir(path) {
+        openedPaths.push(path);
+        throw Object.assign(new Error("Operation not permitted"), { code: "EPERM" });
       },
-      undefined,
-      { workspaceId: undefined },
-    ),
-  ).rejects.toThrow("Working directory does not exist");
+    },
+    logger,
+  });
+
+  try {
+    await expect(
+      manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      }),
+    ).rejects.toThrow(
+      `The Paseo daemon needs access to the folder "${workdir}". Grant access and try again.`,
+    );
+    expect(openedPaths).toEqual([workdir]);
+    expect(client.fetchCatalogCalls).toBe(0);
+    expect(client.createdConfigs).toEqual([]);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });
 
 test("createAgent reports configured providers when provider is unknown", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
+import type { Dir, Stats } from "node:fs";
+import { opendir, stat } from "node:fs/promises";
 import { resolve } from "node:path";
-import { stat } from "node:fs/promises";
 import {
   AGENT_LIFECYCLE_STATUSES,
   type AgentLifecycleStatus,
@@ -129,6 +130,11 @@ interface PreparedSessionConfig {
 interface NormalizeConfigOptions {
   resolveDefaultModel?: boolean;
   env?: Record<string, string>;
+}
+
+interface AgentManagerFileSystem {
+  stat(path: string): Promise<Stats>;
+  opendir(path: string): Promise<Dir>;
 }
 
 interface TimeoutOptions {
@@ -276,6 +282,7 @@ export interface AgentManagerOptions {
   appendSystemPrompt?: string;
   agentStreamCoalesceWindowMs?: number;
   rescueTimeouts?: AgentManagerRescueTimeouts;
+  fileSystem?: AgentManagerFileSystem;
   logger: Logger;
 }
 
@@ -641,6 +648,7 @@ export class AgentManager {
   private onAgentArchived?: AgentArchivedCallback;
   private onWorkspaceStateMayHaveChanged?: (params: { cwd: string }) => void;
   private logger: Logger;
+  private readonly fileSystem: AgentManagerFileSystem;
   private readonly rescueTimeouts: Required<AgentManagerRescueTimeouts>;
   private acceptingAgentRegistrations = true;
 
@@ -655,6 +663,7 @@ export class AgentManager {
     this.configurePaseoTools(options);
     this.appendSystemPrompt = options.appendSystemPrompt ?? "";
     this.logger = options.logger.child({ module: "agent", component: "agent-manager" });
+    this.fileSystem = options.fileSystem ?? { stat, opendir };
     this.rescueTimeouts = {
       reloadSessionCloseMs:
         options.rescueTimeouts?.reloadSessionCloseMs ?? RELOAD_SESSION_CLOSE_TIMEOUT_MS,
@@ -4364,17 +4373,29 @@ export class AgentManager {
     if (normalized.cwd) {
       normalized.cwd = resolve(normalized.cwd);
       try {
-        const cwdStats = await stat(normalized.cwd);
+        const cwdStats = await this.fileSystem.stat(normalized.cwd);
         if (!cwdStats.isDirectory()) {
           throw new Error(`Working directory is not a directory: ${normalized.cwd}`);
         }
+        const cwdHandle = await this.fileSystem.opendir(normalized.cwd);
+        try {
+          await cwdHandle.read();
+        } finally {
+          await cwdHandle.close();
+        }
       } catch (error) {
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          (error as NodeJS.ErrnoException).code === "ENOENT"
-        ) {
+        const errorCode =
+          error instanceof Error && "code" in error
+            ? (error as NodeJS.ErrnoException).code
+            : undefined;
+        if (errorCode === "ENOENT") {
           throw new Error(`Working directory does not exist: ${normalized.cwd}`, { cause: error });
+        }
+        if (["EACCES", "EPERM"].includes(errorCode ?? "")) {
+          throw new Error(
+            `The Paseo daemon needs access to the folder "${normalized.cwd}". Grant access and try again.`,
+            { cause: error },
+          );
         }
         if (error instanceof Error) {
           throw error;


### PR DESCRIPTION
## Problem

`AgentManager.normalizeConfig` checks working-directory metadata with `stat`, but macOS can allow metadata while denying directory reads. Paseo then starts Git or the provider and reports a late `Operation not permitted` failure.

## Change

- Open and read the directory before model discovery or provider session creation.
- Map `EACCES` and `EPERM` to an actionable error with the exact path.
- Preserve missing-path and non-directory behavior.
- Do not request or bypass operating-system privacy permissions.

## Verification

- Focused server tests: 153 passed.
- Full workspace typecheck: passed.
- Server build: passed.
- Targeted lint and format checks: passed.

Based directly on Paseo `v0.3.0`.
