### PR TITLE
fix(codex): warn when /goal is set in Plan mode

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4553,6 +4553,43 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
+  test("warns that a goal set in Plan mode won't auto-run", async () => {
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const session = createSession({ featureValues: { plan_mode: true } }, { goalsEnabled: true });
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        if (method === "thread/loaded/list") {
+          return { data: ["test-thread"] };
+        }
+        return {};
+      }),
+    };
+
+    const handler = session.tryHandleOutOfBand?.("/goal ship feature");
+    expect(handler).not.toBeNull();
+
+    const events: AgentStreamEvent[] = [];
+    await handler?.run({ emit: (event) => events.push(event) });
+
+    expect(requests).toContainEqual({
+      method: "thread/goal/set",
+      params: {
+        threadId: "test-thread",
+        objective: "ship feature",
+        status: "active",
+      },
+    });
+    const message = events.at(-1);
+    expect(message?.type).toBe("timeline");
+    if (message?.type !== "timeline" || message.item.type !== "assistant_message") {
+      throw new Error("Expected assistant_message timeline event");
+    }
+    expect(message.item.text).toContain("Goal set: ship feature");
+    expect(message.item.text).toContain("Plan mode");
+    expect(message.item.text).toContain("Switch to Default or Code mode");
+  });
+
   test("lists /compact and sends Codex compaction out of band", async () => {
     const requests: Array<{ method: string; params: unknown }> = [];
     const session = createSession();

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -453,6 +453,13 @@ function asInternals(session: CodexTestSession): CodexSessionTestAccess {
   return castInternals<CodexSessionTestAccess>(session);
 }
 
+function assistantMessageText(event: AgentStreamEvent | undefined): string {
+  if (event?.type !== "timeline" || event.item.type !== "assistant_message") {
+    throw new Error("Expected assistant_message timeline event");
+  }
+  return event.item.text;
+}
+
 function markdownImageSource(markdown: string): string {
   const match = markdown.match(/^!\[[^\]]*]\((.*)\)$/);
   if (!match) {
@@ -4580,14 +4587,10 @@ describe("Codex app-server provider", () => {
         status: "active",
       },
     });
-    const message = events.at(-1);
-    expect(message?.type).toBe("timeline");
-    if (message?.type !== "timeline" || message.item.type !== "assistant_message") {
-      throw new Error("Expected assistant_message timeline event");
-    }
-    expect(message.item.text).toContain("Goal set: ship feature");
-    expect(message.item.text).toContain("Plan mode");
-    expect(message.item.text).toContain("Switch to Default or Code mode");
+    const message = assistantMessageText(events.at(-1));
+    expect(message).toContain("Goal set: ship feature");
+    expect(message).toContain("Plan mode");
+    expect(message).toContain("Switch to Default or Code mode");
   });
 
   test("lists /compact and sends Codex compaction out of band", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -4861,6 +4861,13 @@ export class CodexAppServerAgentSession implements AgentSession {
             objective: subcommand.objective,
             status: "active",
           });
+          if (this.planModeEnabled) {
+            return (
+              `Goal set: ${subcommand.objective}\n\n` +
+              "Note: the goal was saved but won't start automatically in Plan mode. " +
+              "Switch to Default or Code mode to run it."
+            );
+          }
           return `Goal set: ${subcommand.objective}`;
         }
         case "pause": {


### PR DESCRIPTION
## Problem

Fixes #2093.

In Plan mode, Codex saves the goal but never starts a turn. Paseo returned an unconditional `Goal set: ...` acknowledgement with no explanation, so `/goal` appeared broken or intermittent. The same command auto-runs in Default mode, so the behavior is mode-specific.

Per the reporter's diagnosis, the goal is persisted as active but no goal turn starts and Paseo gives no reason.

## Change

In `executeGoalSubcommand`, when `planModeEnabled` is set, the `set` case now appends a note after saving the goal:

```
Goal set: <objective>

Note: the goal was saved but won't start automatically in Plan mode. Switch to Default or Code mode to run it.
```

This matches the issue's first suggested option (warn + suggest switching modes) while keeping the goal saved. `pause`/`resume`/`clear` and Default-mode behavior are unchanged. One focused change, server-only.

## QA evidence

Targeted unit tests (existing `/goal` spacing test + new Plan-mode regression test) pass:

```
$ npx vitest run src/server/agent/providers/codex-app-server-agent.test.ts -t "goal"
 ✓ src/server/agent/providers/codex-app-server-agent.test.ts (122 tests | 120 skipped) 4ms
 Test Files  1 passed (1)
      Tests  2 passed | 120 skipped (122)
```

Full test file (no regressions):

```
$ npx vitest run src/server/agent/providers/codex-app-server-agent.test.ts
 ✓ src/server/agent/providers/codex-app-server-agent.test.ts (122 tests) 1073ms
 Test Files  1 passed (1)
      Tests  122 passed (122)
```

Server typecheck + lint + format on the changed files are clean:

```
$ npm run typecheck --workspace=@getpaseo/server   # passes
$ npx oxlint <changed files>                        # 0 warnings, 0 errors
$ npx oxfmt --check <changed files>                 # formatted
```

## New automated test

`warns that a goal set in Plan mode won't auto-run` — creates a session with `plan_mode: true`, runs `/goal ship feature`, asserts `thread/goal/set` is still called and the emitted message contains the Plan-mode warning and the mode-switch hint.

## Platforms tested

- Automated tests + typecheck/lint/format on macOS.
- No UI changes (server-side status text only), so no screenshots/video. Not manually tested against a live Codex 0.144.x binary in Plan mode.
