### PR TITLE
Fix Android clipboard image pasting

### DIFF
--- a/packages/app/src/attachments/local-file-attachment-store.test.ts
+++ b/packages/app/src/attachments/local-file-attachment-store.test.ts
@@ -3,6 +3,35 @@ import { createLocalFileAttachmentStore } from "./local-file-attachment-store";
 import { createTestAttachmentFileSystem } from "./test-attachment-file-system";
 
 describe("local file attachment store", () => {
+  it("decodes data URL sources before writing the managed file", async () => {
+    const fileSystem = createTestAttachmentFileSystem();
+    const store = createLocalFileAttachmentStore({
+      storageType: "native-file",
+      baseDirectoryName: "paseo-native-attachments",
+      fileSystem,
+      resolvePreviewUrl: async (attachment) => `file://${attachment.storageKey}`,
+    });
+
+    const attachment = await store.save({
+      id: "clipboard_image",
+      mimeType: "image/png",
+      fileName: "clipboard.png",
+      source: { kind: "data_url", dataUrl: "data:image/png;base64,AAECAw==" },
+    });
+
+    expect(attachment).toMatchObject({
+      id: "clipboard_image",
+      mimeType: "image/png",
+      storageType: "native-file",
+      storageKey: "/cache/paseo-native-attachments/clipboard_image.png",
+      fileName: "clipboard.png",
+      byteSize: 4,
+    });
+    expect(
+      fileSystem.files.get("file:///cache/paseo-native-attachments/clipboard_image.png"),
+    ).toEqual(new Uint8Array([0, 1, 2, 3]));
+  });
+
   it("writes raw byte sources directly to the managed file path", async () => {
     const fileSystem = createTestAttachmentFileSystem();
     const store = createLocalFileAttachmentStore({

--- a/packages/app/src/attachments/local-file-attachment-store.ts
+++ b/packages/app/src/attachments/local-file-attachment-store.ts
@@ -45,8 +45,13 @@ async function ensureDirectory(fileSystem: AttachmentFileSystem, uri: string): P
 }
 
 async function dataUrlToBytes(dataUrl: string): Promise<Uint8Array> {
-  const response = await fetch(dataUrl);
-  return new Uint8Array(await response.arrayBuffer());
+  const { base64 } = parseDataUrl(dataUrl);
+  const binary = globalThis.atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
 }
 
 async function blobToBytes(blob: Blob): Promise<Uint8Array> {


### PR DESCRIPTION
## Summary

- decode clipboard image data URLs directly instead of fetching them
- preserve the decoded bytes in the native attachment store
- add regression coverage for data URL attachment persistence

## Root cause

On React Native Android, fetching a data URL fails with TypeError: Network request failed. The clipboard image read succeeds, but attachment persistence fails before the image reaches the composer.

Observed on a Samsung Fold over wireless debugging.

## Validation

- npx vitest run packages/app/src/attachments/local-file-attachment-store.test.ts --bail=1
- npm run typecheck
- npm run lint -- packages/app/src/attachments/local-file-attachment-store.ts packages/app/src/attachments/local-file-attachment-store.test.ts