### PR TITLE
fix(server): notify the caller when a detached child finishes

### DIFF
--- a/packages/server/src/server/agent/create-agent/create.test.ts
+++ b/packages/server/src/server/agent/create-agent/create.test.ts
@@ -10,7 +10,7 @@ import { AgentManager } from "../agent-manager.js";
 import { AgentStorage } from "../agent-storage.js";
 import type { CreatePaseoWorktreeWorkflowResult } from "../../worktree-session.js";
 import { createAgentCommand } from "./create.js";
-import type { ManagedAgent } from "../agent-manager.js";
+import type { AgentManagerEvent, ManagedAgent } from "../agent-manager.js";
 
 const logger = createTestLogger();
 
@@ -470,4 +470,122 @@ test("session create keeps an explicit title after the initial prompt settles", 
   } finally {
     await removeRealAgentManagerWorkdir({ agentManager, storage, workdir });
   }
+});
+
+// notifyOnFinish for an agent-created child: drives the real finish watcher so
+// the assertion is "did the caller actually get woken", not "which flag was
+// passed". A detached child has no parent label by construction, which is the
+// case that used to be silenced.
+function createNotifyOnFinishScenario(options: { detached: boolean }) {
+  let subscriber: ((event: AgentManagerEvent) => void) | null = null;
+  const callerPrompts: string[] = [];
+
+  const child = {
+    id: "child-agent",
+    provider: "codex",
+    cwd: "/tmp/paseo-create-test",
+    lifecycle: "idle",
+    config: { title: "Child Agent" },
+    runtimeInfo: null,
+  } as unknown as ManagedAgent;
+  const caller = {
+    id: "caller-agent",
+    provider: "codex",
+    cwd: "/tmp/paseo-create-test",
+    workspaceId: "ws-create-test",
+    lifecycle: "idle",
+    runtimeInfo: null,
+  } as unknown as ManagedAgent;
+
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(agentManager, "createAgent", async () => child);
+  Reflect.set(agentManager, "getAgent", (agentId: string) =>
+    agentId === "caller-agent" ? caller : child,
+  );
+  Reflect.set(agentManager, "subscribe", (callback: (event: AgentManagerEvent) => void) => {
+    subscriber = callback;
+    return () => {
+      subscriber = null;
+    };
+  });
+  Reflect.set(agentManager, "waitForAgentRunStart", async () => {});
+  Reflect.set(agentManager, "tryRunOutOfBand", () => false);
+  Reflect.set(agentManager, "hasInFlightRun", () => false);
+  Reflect.set(agentManager, "getLastAssistantMessage", async () => "child done");
+  Reflect.set(agentManager, "streamAgent", (agentId: string, prompt: string) => {
+    if (agentId === "caller-agent") {
+      callerPrompts.push(prompt);
+    }
+    return (async function* noop() {})();
+  });
+
+  const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
+  Reflect.set(agentStorage, "get", async (agentId: string) => {
+    if (agentId === "child-agent") {
+      return {
+        title: "Child Agent",
+        // resolveCreateAgentIntent strips the parent label for a detached child.
+        labels: options.detached ? {} : { "paseo.parent-agent-id": "caller-agent" },
+      };
+    }
+    return { title: "Caller Agent", labels: {} };
+  });
+
+  return {
+    async createChild() {
+      await createAgentCommand(
+        {
+          agentManager,
+          agentStorage,
+          logger: createTestLogger(),
+          providerSnapshotManager: {
+            resolveCreateConfig: vi.fn(async () => ({})),
+          } as unknown as Parameters<typeof createAgentCommand>[0]["providerSnapshotManager"],
+        } as Parameters<typeof createAgentCommand>[0],
+        {
+          kind: "mcp",
+          provider: "codex",
+          cwd: "/tmp/paseo-create-test",
+          workspaceId: "ws-create-test",
+          title: "child",
+          initialPrompt: "go",
+          background: true,
+          notifyOnFinish: true,
+          callerAgentId: "caller-agent",
+          detached: options.detached,
+        },
+      );
+    },
+    finishChild() {
+      for (const lifecycle of ["running", "idle"] as const) {
+        Reflect.set(child, "lifecycle", lifecycle);
+        subscriber?.({ type: "agent_state", agent: child });
+      }
+    },
+    async flush() {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    },
+    callerPrompts,
+  };
+}
+
+test("a detached child still notifies the caller that created it", async () => {
+  const scenario = createNotifyOnFinishScenario({ detached: true });
+
+  await scenario.createChild();
+  scenario.finishChild();
+  await scenario.flush();
+
+  expect(scenario.callerPrompts).toHaveLength(1);
+  expect(scenario.callerPrompts[0]).toContain("child done");
+});
+
+test("a parented child notifies the caller that created it", async () => {
+  const scenario = createNotifyOnFinishScenario({ detached: false });
+
+  await scenario.createChild();
+  scenario.finishChild();
+  await scenario.flush();
+
+  expect(scenario.callerPrompts).toHaveLength(1);
 });

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -209,7 +209,13 @@ export async function createAgentCommand(
       agentStorage: dependencies.agentStorage,
       childAgentId: snapshot.id,
       callerAgentId: input.callerAgentId,
-      requireParentOwnership: true,
+      // A detached child has its parent label stripped on purpose
+      // (resolveCreateAgentIntent), so requiring parent ownership here compares
+      // an absent label against the caller and can never pass. That makes
+      // `relationship: { kind: "detached" }` and `notifyOnFinish` silently
+      // incompatible — the caller waits forever on a child it created itself.
+      // Only require ownership for children that actually carry a parent label.
+      requireParentOwnership: !(input.detached ?? false),
       logger: dependencies.logger,
     });
   }


### PR DESCRIPTION
## Problem

`create_agent` with `relationship: { kind: "detached" }` and `notifyOnFinish` never notifies. The two options are silently incompatible today — no error, nothing in the logs, the caller just waits forever.

`resolveCreateAgentIntent` strips `paseo.parent-agent-id` for a detached child [on purpose](https://github.com/getpaseo/paseo/blob/main/packages/server/src/server/agent/create-agent/intent.ts):

```ts
if (input.legacyDetached) {
  delete labels[PARENT_AGENT_ID_LABEL];
}
```

But `createAgentCommand` then arms the finish watcher with `requireParentOwnership: true` unconditionally. When the child finishes, the watcher compares its (absent) parent label against the caller:

```ts
if (requireParentOwnership && getParentAgentIdFromLabels(record?.labels) !== callerAgentId) {
  return;
}
```

`null !== callerAgentId` is always true, so the notification is dropped every time. An agent that deliberately creates a detached child *and* asks to be told when it finishes is guaranteed never to hear back.

Measured in an orchestration setup that spawns detached children: the child finished at `13:43:39Z` and its creator did not wake until `14:07:25Z` — 23m46s later, and only because an unrelated scheduled task happened to run. Without that schedule it would have hung indefinitely.

## Fix

```ts
requireParentOwnership: !(input.detached ?? false),
```

Children that carry a parent label are unaffected — the guard still stops notifying a caller once the child is re-parented away, which is what `agent-prompt.test.ts` → *"detaching a child ends its parent-owned finish notification"* covers. That test still passes untouched.

## Why not fix it in `setupFinishNotification`

That was my first attempt (snapshot ownership when the watcher arms, enforce it only for a child that was parented then). It cannot work: at that layer, a child **created** detached and a child **detached after the fact** are the same input — neither has a parent label. The existing test above constructs exactly the former and asserts silence, so narrowing the guard there breaks it.

Only the create call site knows the caller explicitly asked for a detached child, so the decision belongs there.

## Tests

Two tests appended to `create.test.ts`. They drive the **real** finish watcher through `createAgentCommand` and assert the caller is actually prompted — no mocking of `setupFinishNotification`, so the assertion is "did the caller get woken", not "which flag was passed". Both the detached and parented cases are covered; the detached one fails without the change.

- `npx vitest run src/server/agent/create-agent/create.test.ts` → 12 passed
- `npx vitest run src/server/agent/agent-prompt.test.ts` → 7 passed (the guard's existing coverage)
- `npm run typecheck`, `npm run lint`, `npm run format:check` → clean

Verified end-to-end on a live daemon as well: a caller spawned a detached child (`labels: {}` confirmed on the stored record), ended its turn, and received the finish notification 3.9s later.

## Note

Independent of #2879 — that one is entirely in `agent-prompt.ts`, this is one argument in `create.ts`. They can land in either order.
