### PR TITLE
feat: bridge Claude prompt suggestions

### DIFF
--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -375,6 +375,13 @@ export type AgentStreamEvent =
     }
   | { type: "turn_canceled"; provider: AgentProvider; reason: string; turnId?: string }
   | {
+      type: "prompt_suggestion";
+      provider: AgentProvider;
+      turnId: string;
+      suggestion: string;
+      messageId: string;
+    }
+  | {
       type: "timeline";
       item: AgentTimelineItem;
       provider: AgentProvider;

--- a/packages/protocol/src/client-capabilities.ts
+++ b/packages/protocol/src/client-capabilities.ts
@@ -24,6 +24,9 @@ export const CLIENT_CAPS = {
   // provider catalogs with shared thinking sets and may revalidate by content hash.
   // Remove the legacy snapshot encoding after 2027-02-04.
   compactProviderSnapshots: "compact_provider_snapshots",
+  // COMPAT(promptSuggestions): added in v0.3.X. The event is a new discriminated-union
+  // variant, so only clients that advertise support may receive it. Remove after 2027-02-09.
+  promptSuggestions: "prompt_suggestions",
   browserHost: "browser_host",
 } as const;
 

--- a/packages/protocol/src/messages.prompt-suggestion.test.ts
+++ b/packages/protocol/src/messages.prompt-suggestion.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { CLIENT_CAPS } from "./client-capabilities.js";
+import {
+  AgentStreamEventPayloadSchema,
+  ServerInfoStatusPayloadSchema,
+  WSHelloMessageSchema,
+} from "./messages.js";
+
+describe("prompt suggestion wire contract", () => {
+  test("round-trips the exact suggestion and completed turn identity", () => {
+    const payload = {
+      type: "prompt_suggestion",
+      provider: "claude",
+      turnId: "foreground-turn-7",
+      suggestion: "Run the focused tests, then ship it.",
+      messageId: "suggestion-message-1",
+    } as const;
+
+    expect(AgentStreamEventPayloadSchema.parse(payload)).toEqual(payload);
+  });
+
+  test("accepts an opt-in client capability without changing legacy hello", () => {
+    const legacy = WSHelloMessageSchema.parse({
+      type: "hello",
+      clientId: "legacy-client",
+      clientType: "mcp",
+      protocolVersion: 1,
+    });
+    const capable = WSHelloMessageSchema.parse({
+      type: "hello",
+      clientId: "capable-client",
+      clientType: "mcp",
+      protocolVersion: 1,
+      capabilities: { [CLIENT_CAPS.promptSuggestions]: true },
+    });
+
+    expect(legacy.capabilities).toBeUndefined();
+    expect(capable.capabilities).toEqual({ prompt_suggestions: true });
+  });
+
+  test("preserves the server support feature", () => {
+    const parsed = ServerInfoStatusPayloadSchema.parse({
+      status: "server_info",
+      serverId: "server-1",
+      features: { promptSuggestions: true },
+    });
+
+    expect(parsed.features?.promptSuggestions).toBe(true);
+  });
+});

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -675,6 +675,13 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
     reason: z.string(),
   }),
   z.object({
+    type: z.literal("prompt_suggestion"),
+    provider: AgentProviderSchema,
+    turnId: z.string(),
+    suggestion: z.string(),
+    messageId: z.string(),
+  }),
+  z.object({
     type: z.literal("timeline"),
     provider: AgentProviderSchema,
     item: AgentTimelineItemPayloadSchema,
@@ -2921,6 +2928,8 @@ export const ServerInfoStatusPayloadSchema = z
         agentTimelinePromptIndex: z.boolean().optional(),
         // COMPAT(agentHistorySearch): added in v0.3.0, remove gate after 2027-02-07.
         agentHistorySearch: z.boolean().optional(),
+        // COMPAT(promptSuggestions): added in v0.3.X, remove gate after 2027-02-09.
+        promptSuggestions: z.boolean().optional(),
         // COMPAT(checkoutRefresh): added in v0.1.86, remove gate after 2026-11-29.
         checkoutRefresh: z.boolean().optional(),
         // COMPAT(workspaceMultiplicity): added in v0.1.97, drop the gate when floor >= v0.1.97
@@ -6039,6 +6048,7 @@ export const WSHelloMessageSchema = z.object({
       [CLIENT_CAPS.providerSubagents]: z.boolean().optional(),
       [CLIENT_CAPS.projectUpdates]: z.boolean().optional(),
       [CLIENT_CAPS.compactProviderSnapshots]: z.boolean().optional(),
+      [CLIENT_CAPS.promptSuggestions]: z.boolean().optional(),
       [CLIENT_CAPS.browserHost]: BrowserAutomationHostCapabilitySchema.optional(),
     })
     .passthrough()

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -414,6 +414,13 @@ export type AgentStreamEvent =
     }
   | { type: "turn_canceled"; provider: AgentProvider; reason: string; turnId?: string }
   | {
+      type: "prompt_suggestion";
+      provider: AgentProvider;
+      turnId: string;
+      suggestion: string;
+      messageId: string;
+    }
+  | {
       type: "timeline";
       item: AgentTimelineItem;
       provider: AgentProvider;

--- a/packages/server/src/server/agent/providers/claude/agent.prompt-suggestion.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.prompt-suggestion.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../../test-utils/test-logger.js";
+import type { AgentStreamEvent } from "../../agent-sdk-types.js";
+import { ClaudeAgentClient } from "./agent.js";
+
+interface AsyncQueue<T> {
+  push(value: T): void;
+  next(): Promise<IteratorResult<T, void>>;
+  end(): void;
+}
+
+interface ScriptedQuery {
+  emit(message: Record<string, unknown>): void;
+  end(): void;
+  next: ReturnType<typeof vi.fn>;
+  interrupt: ReturnType<typeof vi.fn>;
+  return: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  setPermissionMode: ReturnType<typeof vi.fn>;
+  setModel: ReturnType<typeof vi.fn>;
+  getContextUsage: ReturnType<typeof vi.fn>;
+  supportedModels: ReturnType<typeof vi.fn>;
+  supportedCommands: ReturnType<typeof vi.fn>;
+  rewindFiles: ReturnType<typeof vi.fn>;
+  [Symbol.asyncIterator](): AsyncIterator<Record<string, unknown>, void>;
+}
+
+const queryFactory = vi.fn();
+
+function createAsyncQueue<T>(): AsyncQueue<T> {
+  const items: T[] = [];
+  const waiters: Array<(value: IteratorResult<T, void>) => void> = [];
+  let ended = false;
+
+  return {
+    push(value) {
+      if (ended) return;
+      const waiter = waiters.shift();
+      if (waiter) waiter({ value, done: false });
+      else items.push(value);
+    },
+    async next() {
+      const value = items.shift();
+      if (value !== undefined) return { value, done: false };
+      if (ended) return { value: undefined, done: true };
+      return await new Promise<IteratorResult<T, void>>((resolve) => waiters.push(resolve));
+    },
+    end() {
+      ended = true;
+      for (const waiter of waiters.splice(0)) waiter({ value: undefined, done: true });
+    },
+  };
+}
+
+function createScriptedQuery(sessionId: string): ScriptedQuery {
+  const output = createAsyncQueue<Record<string, unknown>>();
+  const query = {
+    emit(message: Record<string, unknown>) {
+      output.push(message);
+    },
+    end() {
+      output.end();
+    },
+    next: vi.fn(() => output.next()),
+    interrupt: vi.fn(async () => undefined),
+    return: vi.fn(async () => output.end()),
+    close: vi.fn(() => undefined),
+    setPermissionMode: vi.fn(async () => undefined),
+    setModel: vi.fn(async () => undefined),
+    getContextUsage: vi.fn(async () => undefined),
+    supportedModels: vi.fn(async () => [{ value: "opus", displayName: "Opus" }]),
+    supportedCommands: vi.fn(async () => []),
+    rewindFiles: vi.fn(async () => ({ canRewind: true })),
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } satisfies ScriptedQuery;
+  query.emit({
+    type: "system",
+    subtype: "init",
+    session_id: sessionId,
+    permissionMode: "default",
+    model: "opus",
+  });
+  return query;
+}
+
+function successResult(sessionId: string, uuid: string): Record<string, unknown> {
+  return {
+    type: "result",
+    subtype: "success",
+    uuid,
+    session_id: sessionId,
+    usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+    total_cost_usd: 0,
+  };
+}
+
+function promptSuggestion(
+  sessionId: string,
+  uuid: string,
+  suggestion: string,
+): Record<string, unknown> {
+  return {
+    type: "prompt_suggestion",
+    session_id: sessionId,
+    uuid,
+    suggestion,
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for Claude event");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function suggestions(events: AgentStreamEvent[]) {
+  return events.filter(
+    (event): event is Extract<AgentStreamEvent, { type: "prompt_suggestion" }> =>
+      event.type === "prompt_suggestion",
+  );
+}
+
+afterEach(() => {
+  queryFactory.mockReset();
+});
+
+test("enables SDK suggestions and attaches the post-result message to its completed turn", async () => {
+  const sessionId = "claude-prompt-suggestion-session";
+  const query = createScriptedQuery(sessionId);
+  let options: Record<string, unknown> | undefined;
+  queryFactory.mockImplementation(
+    (input: { prompt: AsyncIterable<unknown>; options: Record<string, unknown> }) => {
+      options = input.options;
+      return query;
+    },
+  );
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+  });
+  const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+  const events: AgentStreamEvent[] = [];
+  const unsubscribe = session.subscribe((event) => events.push(event));
+
+  try {
+    const started = await session.startTurn("First prompt");
+    expect(options?.promptSuggestions).toBe(true);
+
+    query.emit(successResult(sessionId, "11111111-1111-4111-8111-111111111111"));
+    await waitFor(() => events.some((event) => event.type === "turn_completed"));
+    query.emit(
+      promptSuggestion(
+        sessionId,
+        "22222222-2222-4222-8222-222222222222",
+        "Run the focused tests, then ship it.",
+      ),
+    );
+    await waitFor(() => suggestions(events).length === 1);
+
+    const suggestion = suggestions(events)[0];
+    expect(suggestion).toEqual({
+      type: "prompt_suggestion",
+      provider: "claude",
+      turnId: started.turnId,
+      suggestion: "Run the focused tests, then ship it.",
+      messageId: "22222222-2222-4222-8222-222222222222",
+    });
+    expect(events.findIndex((event) => event.type === "turn_completed")).toBeLessThan(
+      events.findIndex((event) => event.type === "prompt_suggestion"),
+    );
+  } finally {
+    unsubscribe();
+    await session.close();
+  }
+});
+
+test("lets an explicit provider option disable SDK suggestions", async () => {
+  const query = createScriptedQuery("claude-option-override-session");
+  let options: Record<string, unknown> | undefined;
+  queryFactory.mockImplementation((input: { options: Record<string, unknown> }) => {
+    options = input.options;
+    return query;
+  });
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+  });
+  const session = await client.createSession({
+    provider: "claude",
+    cwd: process.cwd(),
+    providerOptions: { promptSuggestions: false },
+  });
+
+  try {
+    await session.startTurn("No suggestion please");
+    expect(options?.promptSuggestions).toBe(false);
+  } finally {
+    await session.close();
+  }
+});
+
+test("drops a completed turn suggestion after a newer turn starts", async () => {
+  const sessionId = "claude-stale-suggestion-session";
+  const query = createScriptedQuery(sessionId);
+  queryFactory.mockReturnValue(query);
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+  });
+  const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+  const events: AgentStreamEvent[] = [];
+  const unsubscribe = session.subscribe((event) => events.push(event));
+
+  try {
+    await session.startTurn("First prompt");
+    query.emit(successResult(sessionId, "33333333-3333-4333-8333-333333333333"));
+    await waitFor(() => events.filter((event) => event.type === "turn_completed").length === 1);
+
+    const second = await session.startTurn("Second prompt");
+    query.emit(
+      promptSuggestion(
+        sessionId,
+        "44444444-4444-4444-8444-444444444444",
+        "This stale suggestion must disappear.",
+      ),
+    );
+    query.emit({
+      type: "assistant",
+      session_id: sessionId,
+      uuid: "55555555-5555-4555-8555-555555555555",
+      message: { content: "Second turn marker" },
+    });
+    await waitFor(() =>
+      events.some(
+        (event) =>
+          event.type === "timeline" &&
+          event.item.type === "assistant_message" &&
+          event.item.text.includes("Second turn marker"),
+      ),
+    );
+    expect(suggestions(events)).toEqual([]);
+
+    query.emit(successResult(sessionId, "66666666-6666-4666-8666-666666666666"));
+    await waitFor(() => events.filter((event) => event.type === "turn_completed").length === 2);
+    query.emit(
+      promptSuggestion(
+        sessionId,
+        "77777777-7777-4777-8777-777777777777",
+        "Use the current turn suggestion.",
+      ),
+    );
+    await waitFor(() => suggestions(events).length === 1);
+    expect(suggestions(events)[0]?.turnId).toBe(second.turnId);
+  } finally {
+    unsubscribe();
+    await session.close();
+  }
+});
+
+test.each([
+  {
+    name: "mismatched session",
+    sessionId: "another-session",
+    suggestion: "Wrong conversation",
+  },
+  { name: "blank text", sessionId: "claude-invalid-suggestion-session", suggestion: "   \n" },
+  {
+    name: "overlong text",
+    sessionId: "claude-invalid-suggestion-session",
+    suggestion: "x".repeat(501),
+  },
+])("drops $name suggestions", async ({ sessionId: messageSessionId, suggestion }) => {
+  const sessionId = "claude-invalid-suggestion-session";
+  const query = createScriptedQuery(sessionId);
+  queryFactory.mockReturnValue(query);
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+  });
+  const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+  const events: AgentStreamEvent[] = [];
+  const unsubscribe = session.subscribe((event) => events.push(event));
+
+  try {
+    await session.startTurn("Prompt");
+    query.emit(successResult(sessionId, "88888888-8888-4888-8888-888888888888"));
+    await waitFor(() => events.some((event) => event.type === "turn_completed"));
+    query.emit(
+      promptSuggestion(messageSessionId, "99999999-9999-4999-8999-999999999999", suggestion),
+    );
+    query.emit({
+      type: "system",
+      subtype: "status",
+      session_id: sessionId,
+      status: "compacting",
+    });
+    await waitFor(() => query.next.mock.calls.length >= 4);
+    expect(suggestions(events)).toEqual([]);
+  } finally {
+    unsubscribe();
+    await session.close();
+  }
+});

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -360,6 +360,7 @@ const CLAUDE_ROOT_ONLY_COMMANDS = new Set([
 const INTERRUPT_TOOL_USE_PLACEHOLDER = "[Request interrupted by user for tool use]";
 const INTERRUPT_PLACEHOLDER_PATTERN = /^\[Request interrupted by user(?:[^\]]*)\]$/;
 const NO_RESPONSE_REQUESTED_PLACEHOLDER = "No response requested.";
+const MAX_PROMPT_SUGGESTION_SCALARS = 500;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface SlashCommandInvocation {
@@ -2022,6 +2023,7 @@ class ClaudeAgentSession implements AgentSession {
   private toolUseInputBuffers = new Map<string, string>();
   private pendingPermissions = new Map<string, PendingPermission>();
   private activeForegroundTurnId: string | null = null;
+  private pendingPromptSuggestionTarget: { turnId: string; sessionId: string } | null = null;
   private autonomousTurn: AutonomousTurnState | null = null;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly timelineAssembler = new TimelineAssembler();
@@ -2172,6 +2174,7 @@ class ClaudeAgentSession implements AgentSession {
     if (this.activeForegroundTurnId) {
       throw new Error("A foreground turn is already active");
     }
+    this.pendingPromptSuggestionTarget = null;
 
     const slashCommand = this.resolveSlashCommandInvocation(prompt);
     if (slashCommand?.commandName === REWIND_COMMAND_NAME) {
@@ -2517,6 +2520,7 @@ class ClaudeAgentSession implements AgentSession {
     this.cancelCurrentTurn?.();
     this.subscribers.clear();
     this.activeForegroundTurnId = null;
+    this.pendingPromptSuggestionTarget = null;
     this.autonomousTurn = null;
     this.cancelCurrentTurn = null;
     this.turnState = "idle";
@@ -3136,6 +3140,9 @@ class ClaudeAgentSession implements AgentSession {
       },
       // Required for provider-level /rewind support.
       enableFileCheckpointing: true,
+      // Claude emits the suggestion after the terminal result. Paseo retains the
+      // completed foreground turn long enough to attach that optional follow-up.
+      promptSuggestions: true,
       // If we have a session ID from a previous query (e.g., after interrupt),
       // resume that session to continue the conversation history.
       ...sessionBinding,
@@ -3455,6 +3462,7 @@ class ClaudeAgentSession implements AgentSession {
   }
 
   private failActiveTurns(errorMessage: string): void {
+    this.pendingPromptSuggestionTarget = null;
     const failure = this.buildTurnFailedEvent(errorMessage);
     this.flushPendingToolCalls();
     if (this.activeForegroundTurnId) {
@@ -3657,6 +3665,10 @@ class ClaudeAgentSession implements AgentSession {
     if (this.shouldSuppressStaleResult(message)) {
       return;
     }
+    if (message.type === "prompt_suggestion") {
+      this.handlePromptSuggestion(message);
+      return;
+    }
 
     const isForeground = Boolean(this.activeForegroundTurnId);
     if (!isForeground && this.isAssistantishMessage(message)) {
@@ -3698,6 +3710,13 @@ class ClaudeAgentSession implements AgentSession {
       this.logger.debug("Suppressing stale Claude interrupt terminal result");
       return;
     }
+    this.recordPumpedEventActivity(events);
+    this.updatePromptSuggestionTarget(message, events, { isForeground, turnId });
+
+    this.dispatchEvents(events);
+  }
+
+  private recordPumpedEventActivity(events: AgentStreamEvent[]): void {
     if (
       events.some((event) => event.type === "timeline" && event.item.type === "assistant_message")
     ) {
@@ -3714,8 +3733,56 @@ class ClaudeAgentSession implements AgentSession {
     ) {
       this.foregroundHasVisibleActivity = true;
     }
+  }
 
-    this.dispatchEvents(events);
+  private updatePromptSuggestionTarget(
+    message: SDKMessage,
+    events: AgentStreamEvent[],
+    context: { isForeground: boolean; turnId: string | null },
+  ): void {
+    if (message.type !== "result") {
+      return;
+    }
+    const isSuccessfulForegroundResult =
+      message.subtype === "success" &&
+      context.isForeground &&
+      context.turnId !== null &&
+      events.some((event) => event.type === "turn_completed");
+    const sessionId = isSuccessfulForegroundResult
+      ? readTrimmedString(message.session_id)
+      : undefined;
+    this.pendingPromptSuggestionTarget =
+      sessionId && context.turnId ? { turnId: context.turnId, sessionId } : null;
+  }
+
+  private handlePromptSuggestion(
+    message: Extract<SDKMessage, { type: "prompt_suggestion" }>,
+  ): void {
+    const target = this.pendingPromptSuggestionTarget;
+    this.pendingPromptSuggestionTarget = null;
+    if (!target) {
+      return;
+    }
+
+    const sessionId = readTrimmedString(message.session_id);
+    const messageId = readTrimmedString(message.uuid);
+    const suggestion = typeof message.suggestion === "string" ? message.suggestion : "";
+    if (
+      sessionId !== target.sessionId ||
+      !messageId ||
+      suggestion.trim().length === 0 ||
+      [...suggestion].length > MAX_PROMPT_SUGGESTION_SCALARS
+    ) {
+      return;
+    }
+
+    this.notifySubscribers({
+      type: "prompt_suggestion",
+      provider: "claude",
+      turnId: target.turnId,
+      suggestion,
+      messageId,
+    });
   }
 
   private async buildPumpedMessageEvents(
@@ -3795,6 +3862,7 @@ class ClaudeAgentSession implements AgentSession {
     this.queryRestartNeeded = false;
     this.autonomousTurn = null;
     this.activeForegroundTurnId = null;
+    this.pendingPromptSuggestionTarget = null;
     this.syncTurnState("missing resumed conversation");
     return true;
   }

--- a/packages/server/src/server/agent/providers/claude/options.ts
+++ b/packages/server/src/server/agent/providers/claude/options.ts
@@ -48,6 +48,7 @@ export const ClaudeProviderOptionsSchema = z
     allowedTools: z.array(z.string()).optional(),
     disallowedTools: z.array(z.string()).optional(),
     additionalDirectories: z.array(z.string()).optional(),
+    promptSuggestions: z.boolean().optional(),
     sandbox: z
       .object({
         enabled: z.boolean().optional(),

--- a/packages/server/src/server/messages.test.ts
+++ b/packages/server/src/server/messages.test.ts
@@ -4,6 +4,18 @@ import type { AgentStreamEvent } from "./agent/agent-sdk-types.js";
 import { SessionInboundMessageSchema, serializeAgentStreamEvent } from "./messages.js";
 
 describe("serializeAgentStreamEvent", () => {
+  test("preserves prompt suggestions without changing their text", () => {
+    const event: AgentStreamEvent = {
+      type: "prompt_suggestion",
+      provider: "claude",
+      turnId: "foreground-turn-7",
+      suggestion: "Run the focused tests, then ship it.",
+      messageId: "suggestion-message-1",
+    };
+
+    expect(serializeAgentStreamEvent(event)).toEqual(event);
+  });
+
   test("preserves daemon turn identity on lifecycle events", () => {
     expect(
       serializeAgentStreamEvent({

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -4926,6 +4926,61 @@ test("sends project updates only to capable sockets in a retained session", () =
   ]);
 });
 
+test("sends prompt suggestions only to capable sockets in a retained session", () => {
+  const messages: SessionOutboundMessage[] = [];
+  const targetedMessages: Array<{ source: object; message: SessionOutboundMessage }> = [];
+  const agentEventListeners: Array<(event: AgentManagerEvent) => void> = [];
+  const session = createSessionForTest({
+    messages,
+    targetedMessages,
+    agentManager: {
+      subscribe: vi.fn((listener: (event: AgentManagerEvent) => void) => {
+        agentEventListeners.push(listener);
+        return () => {};
+      }),
+    },
+  });
+  const legacySocket = {};
+  const capableSocket = {};
+  session.updateClientCapabilities(null, legacySocket);
+  session.updateClientCapabilities({ [CLIENT_CAPS.promptSuggestions]: true }, capableSocket);
+
+  const listener = agentEventListeners[0];
+  if (!listener) throw new Error("Agent event listener was not installed");
+  listener({
+    type: "agent_stream",
+    agentId: "agent-with-suggestion",
+    event: {
+      type: "prompt_suggestion",
+      provider: "claude",
+      turnId: "foreground-turn-7",
+      suggestion: "Run the focused tests, then ship it.",
+      messageId: "suggestion-message-1",
+    },
+  });
+
+  expect(messages).toEqual([]);
+  expect(targetedMessages).toEqual([
+    {
+      source: capableSocket,
+      message: {
+        type: "agent_stream",
+        payload: {
+          agentId: "agent-with-suggestion",
+          timestamp: expect.any(String),
+          event: {
+            type: "prompt_suggestion",
+            provider: "claude",
+            turnId: "foreground-turn-7",
+            suggestion: "Run the focused tests, then ship it.",
+            messageId: "suggestion-message-1",
+          },
+        },
+      },
+    },
+  ]);
+});
+
 test("project.list returns every active project descriptor", async () => {
   const messages: SessionOutboundMessage[] = [];
   const active = createPersistedProjectRecord({

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1102,6 +1102,12 @@ export class Session {
     serializedEvent: Extract<SessionOutboundMessage, { type: "agent_stream" }>["payload"]["event"],
   ): void {
     if (this.clientCapabilitiesBySource.size === 0 || !this.onMessageToSource) {
+      if (
+        serializedEvent.type === "prompt_suggestion" &&
+        !this.supports(CLIENT_CAPS.promptSuggestions)
+      ) {
+        return;
+      }
       if (this.usesSelectiveTimelineDelivery() && serializedEvent.type === "attention_required") {
         this.emit({
           type: "agent_attention_required",
@@ -1126,6 +1132,12 @@ export class Session {
     }
 
     for (const [source, capabilities] of this.clientCapabilitiesBySource) {
+      if (
+        serializedEvent.type === "prompt_suggestion" &&
+        !capabilities.has(CLIENT_CAPS.promptSuggestions)
+      ) {
+        continue;
+      }
       const supportsSelectiveDelivery = capabilities.has(CLIENT_CAPS.selectiveAgentTimeline);
       if (supportsSelectiveDelivery && serializedEvent.type === "attention_required") {
         this.onMessageToSource(source, {

--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -933,6 +933,7 @@ describe("relay external socket reconnect behavior", () => {
 
     expect(serverInfo.features?.stableProjectIdentity).toBe(true);
     expect(serverInfo.features?.canonicalSubmittedPrompts).toBe(true);
+    expect(serverInfo.features?.promptSuggestions).toBe(true);
     expect(serverInfo.features?.["terminal-input-mode-replay"]).toBe(true);
     expect(serverInfo.features?.["terminal-size-ownership"]).toBe(true);
     expect(serverInfo.features?.agentTurnIdentity).toBeUndefined();

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1552,6 +1552,8 @@ export class VoiceAssistantWebSocketServer {
         agentTimelinePromptIndex: true,
         // COMPAT(agentHistorySearch): added in v0.3.0, remove gate after 2027-02-07.
         agentHistorySearch: true,
+        // COMPAT(promptSuggestions): added in v0.3.X, remove gate after 2027-02-09.
+        promptSuggestions: true,
         // COMPAT(checkoutRefresh): added in v0.1.86, remove gate after 2026-11-29.
         checkoutRefresh: true,
         // COMPAT(workspaceMultiplicity): added in v0.1.97, drop the gate when floor >= v0.1.97


### PR DESCRIPTION
### Linked issue\n\nNone — this bridges an existing Claude Agent SDK event for a downstream self-hosted client workflow.\n\n### Type of change\n\n- [ ] Bug fix\n- [x] New feature\n- [ ] Enhancement\n- [ ] Refactor\n- [ ] Docs\n\n### Reasoning\n\nClaude Agent SDK can emit a prompt_suggestion after a successful foreground turn, but Paseo currently drops that event. Downstream clients therefore cannot offer the provider-authored next prompt without owning a second Claude integration. This change carries the suggestion as an optional, capability-gated stream event while keeping older clients and non-Claude providers unchanged.\n\n### Goals\n\n- Preserve the originating foreground turn ID after its successful result so a later suggestion stays attached to the correct turn.\n- Emit only nonblank suggestions up to 500 Unicode code points.\n- Advertise and gate the event with the prompt_suggestions client capability, including per-source fanout.\n- Enable Claude suggestions by default while honoring an explicit provider option of false.\n- Clear retained targets on new turns, failure, close, and session mismatch.\n\n### Non-goals\n\n- Add or change client UI.\n- Generate suggestions inside Paseo.\n- Add suggestion support to providers that do not emit this event.\n- Treat suggestions as permissions or required responses.\n\n### QA\n\n- Targeted Vitest run across the new protocol/provider tests plus messages, session, and relay reconnect coverage: 193 tests passed.\n- npm run format:check: passed.\n- npm run typecheck: passed.\n- npm run lint: passed.\n- Server/protocol-only change; no mobile, web, or desktop UI surface changed.\n\n### Checklist\n\n- [x] One focused change\n- [x] npm run typecheck passes\n- [x] npm run lint passes\n- [x] npm run format passes\n- [x] QA evidence\n- [x] Tests added or updated where it made sense