### PR TITLE
feat: add Haskell syntax highlighting

### DIFF
--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -75,6 +75,17 @@ describe("highlightCode", () => {
     expect(stringToken?.style).toBe("string");
   });
 
+  it("highlights Haskell code", () => {
+    const code = 'main = putStrLn "hello"';
+    const result = highlightCode(code, "Main.hs");
+
+    const operatorToken = result[0].find((token) => token.text === "=");
+    expect(operatorToken?.style).toBe("keyword");
+
+    const stringToken = result[0].find((token) => token.text.includes("hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
   it("highlights TSX code with correct dialect", () => {
     const code = 'const el = <div className="test">hello</div>;';
     const result = highlightCode(code, "test.tsx");

--- a/packages/highlight/src/__tests__/parsers.test.ts
+++ b/packages/highlight/src/__tests__/parsers.test.ts
@@ -21,6 +21,7 @@ describe("isLanguageSupported", () => {
     expect(isLanguageSupported("test.swift")).toBe(true);
     expect(isLanguageSupported("test.dart")).toBe(true);
     expect(isLanguageSupported("test.cs")).toBe(true);
+    expect(isLanguageSupported("test.hs")).toBe(true);
     expect(isLanguageSupported("test.ex")).toBe(true);
   });
 
@@ -60,6 +61,7 @@ describe("getSupportedExtensions", () => {
     expect(extensions).toContain("swift");
     expect(extensions).toContain("dart");
     expect(extensions).toContain("cs");
+    expect(extensions).toContain("hs");
     expect(extensions).toContain("json");
   });
 });

--- a/packages/highlight/src/parsers.ts
+++ b/packages/highlight/src/parsers.ts
@@ -1,5 +1,6 @@
 import { defineLanguageFacet, Language, StreamLanguage } from "@codemirror/language";
 import { dart } from "@codemirror/legacy-modes/mode/clike";
+import { haskell } from "@codemirror/legacy-modes/mode/haskell";
 import { swift } from "@codemirror/legacy-modes/mode/swift";
 import { parser as jsParser } from "@lezer/javascript";
 import { parser as jsonParser } from "@lezer/json";
@@ -69,6 +70,8 @@ const languagesByExtension: Record<string, Language> = {
   dart: StreamLanguage.define(dart),
   // C#
   cs: csharpLanguage,
+  // Haskell
+  hs: StreamLanguage.define(haskell),
   // Elixir
   ex: language(elixirParser),
   exs: language(elixirParser),


### PR DESCRIPTION
Adds Haskell (`.hs`) to the highlight package's language registry.

## Changes

- `hs` → `StreamLanguage.define(haskell)` in `languagesByExtension` (`packages/highlight/src/parsers.ts`), using the `haskell` mode from `@codemirror/legacy-modes` — already a dependency, so no lockfile change
- Tests: `isLanguageSupported` for the extension, `getSupportedExtensions()` contains `hs`, and a `highlightCode` case asserting `=` highlights as `keyword` and the string literal as `string`

## Testing

`npx vitest run packages/highlight/src/__tests__` — 4 files, 68 tests passing. `npm run format:check` clean.

## Note

Independent of #3110 (Nix highlighting) — both branch from `main`, but they touch adjacent lines in `parsers.ts` and the two test files, so whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)