### PR TITLE
feat(server): transition workspace to worktree

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -46,6 +46,11 @@ Agents can launch other agents via the agent-scoped `create_agent` MCP tool. Age
 
 Runtime ownership is resolved from explicit workspace ID and caller context, never from `cwd`. Workspace creation is a separate operation with `local | worktree` isolation; agent creation only selects an existing workspace.
 
+An agent can move its current local Git workspace into a Paseo-managed worktree. The workspace keeps
+its ID, so open routes, tabs, and sidebar state follow the updated placement. The source checkout must
+be clean and other workspace agents must be idle; Paseo closes workspace terminals and runtimes before
+their next resume uses the new worktree.
+
 Users can also detach an existing subagent from the subagents track. Detach is deliberately a manual lifecycle gesture, not an agent-facing MCP tool. It removes the `paseo.parent-agent-id` label only: it does not stop, archive, move, or restart the agent. The agent keeps its current `cwd` and `workspaceId`, leaves the former parent's track, and behaves like a root agent for tab close, workspace activity, and future parent archive.
 
 `notifyOnFinish` defaults to `true` for agent-scoped creation and background prompt follow-ups because most delegated work needs to report back to the creating agent. Set it to `false` only for truly fire-and-forget agents or prompts.

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7776,7 +7776,7 @@ test("closeAgent persists one final closed snapshot", async () => {
   }
 });
 
-test("closeAgent can relocate the persisted cwd used by the next resume", async () => {
+test("relocateAgentForNextResume updates the final closed snapshot", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-close-relocate-"));
   const relocatedCwd = join(workdir, "relocated");
   const storage = new AgentStorage(join(workdir, "agents"), logger);
@@ -7792,12 +7792,57 @@ test("closeAgent can relocate the persisted cwd used by the next resume", async 
       workspaceId: "workspace-current",
     });
 
-    await manager.closeAgent(snapshot.id, { persistedCwd: relocatedCwd });
+    await manager.relocateAgentForNextResume(snapshot.id, relocatedCwd);
+    await manager.closeAgent(snapshot.id);
     await manager.flush();
     await storage.flush();
 
     expect((await storage.get(snapshot.id))?.cwd).toBe(relocatedCwd);
   } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("relocateAgentForNextResume repairs a snapshot captured by an in-flight close", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-close-relocate-race-"));
+  const relocatedCwd = join(workdir, "relocated");
+  const closeStarted = deferred<void>();
+  const closeAllowed = deferred<void>();
+  const client = new (class extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new (class extends TestAgentSession {
+        override async close(): Promise<void> {
+          closeStarted.resolve();
+          await closeAllowed.promise;
+        }
+      })(config);
+    }
+  })();
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000219",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: "workspace-current",
+    });
+
+    const close = manager.closeAgent(snapshot.id);
+    await closeStarted.promise;
+    const relocate = manager.relocateAgentForNextResume(snapshot.id, relocatedCwd);
+    closeAllowed.resolve();
+    await Promise.all([close, relocate]);
+    await storage.flush();
+
+    expect((await storage.get(snapshot.id))?.cwd).toBe(relocatedCwd);
+  } finally {
+    closeAllowed.resolve();
     await manager.flush().catch(() => undefined);
     await storage.flush().catch(() => undefined);
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7776,6 +7776,34 @@ test("closeAgent persists one final closed snapshot", async () => {
   }
 });
 
+test("closeAgent can relocate the persisted cwd used by the next resume", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-close-relocate-"));
+  const relocatedCwd = join(workdir, "relocated");
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000218",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: "workspace-current",
+    });
+
+    await manager.closeAgent(snapshot.id, { persistedCwd: relocatedCwd });
+    await manager.flush();
+    await storage.flush();
+
+    expect((await storage.get(snapshot.id))?.cwd).toBe(relocatedCwd);
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("idle agents remain resident until an explicit lifecycle action closes them", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-idle-residency-"));
   let closeCount = 0;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1414,10 +1414,7 @@ export class AgentManager {
     }
   }
 
-  closeAgent(agentId: string, options?: { persistedCwd?: string }): Promise<void> {
-    if (options?.persistedCwd !== undefined) {
-      this.requireAgent(agentId).cwd = options.persistedCwd;
-    }
+  closeAgent(agentId: string): Promise<void> {
     const existing = this.inFlightAgentCloses.get(agentId);
     if (existing) {
       return existing;
@@ -1432,6 +1429,29 @@ export class AgentManager {
     };
     void close.then(clearClose, clearClose);
     return close;
+  }
+
+  async relocateAgentForNextResume(agentId: string, cwd: string): Promise<void> {
+    const liveAgent = this.agents.get(agentId);
+    if (liveAgent) {
+      liveAgent.cwd = cwd;
+    }
+
+    const inFlightClose = this.inFlightAgentCloses.get(agentId);
+    if (!inFlightClose) {
+      if (liveAgent) {
+        return;
+      }
+    } else {
+      await inFlightClose.catch(() => undefined);
+    }
+
+    const registry = this.requireRegistry();
+    const stored = await registry.get(agentId);
+    if (!stored) {
+      throw new Error(`Agent ${agentId} not found in storage after relocation`);
+    }
+    await registry.upsert({ ...stored, cwd, updatedAt: this.nextStoredUpdatedAt(stored) });
   }
 
   private async closeAgentRuntime(agentId: string): Promise<void> {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1414,7 +1414,10 @@ export class AgentManager {
     }
   }
 
-  closeAgent(agentId: string): Promise<void> {
+  closeAgent(agentId: string, options?: { persistedCwd?: string }): Promise<void> {
+    if (options?.persistedCwd !== undefined) {
+      this.requireAgent(agentId).cwd = options.persistedCwd;
+    }
     const existing = this.inFlightAgentCloses.get(agentId);
     if (existing) {
       return existing;

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -1555,11 +1555,53 @@ describe("create_agent MCP tool", () => {
     expect(lookupTool(server, "create_workspace")).toBeDefined();
     expect(lookupTool(server, "list_workspaces")).toBeDefined();
     expect(lookupTool(server, "archive_workspace")).toBeDefined();
+    expect(lookupTool(server, "transition_workspace_to_worktree")).toBeDefined();
     expect(lookupTool(server, "create_worktree")).toBeUndefined();
     expect(lookupTool(server, "list_worktrees")).toBeUndefined();
     expect(lookupTool(server, "archive_worktree")).toBeUndefined();
     expect(lookupTool(server, "detach_agent")).toBeUndefined();
     expect(lookupTool(server, "update_heartbeat")).toBeUndefined();
+  });
+
+  it("transitions the calling agent workspace to a worktree", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const transitionWorkspaceToWorktree = vi.fn(async () =>
+      createPersistedWorkspaceRecord({
+        workspaceId: "wks_current",
+        projectId: "prj_current",
+        cwd: TARGET_CWD,
+        kind: "worktree",
+        displayName: "feature/current",
+        title: null,
+        createdAt: "2026-08-10T00:00:00.000Z",
+        updatedAt: "2026-08-10T00:00:00.000Z",
+      }),
+    );
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      callerAgentId: "agent-current",
+      providerSnapshotManager: createOpenCodeManager().manager,
+      transitionWorkspaceToWorktree,
+      logger,
+    });
+
+    const response = await invokeToolWithParsedInput(
+      registeredTool(server, "transition_workspace_to_worktree"),
+      { branchName: "feature/current", baseBranch: "main", worktreeSlug: "current" },
+    );
+
+    expect(transitionWorkspaceToWorktree).toHaveBeenCalledWith({
+      callerAgentId: "agent-current",
+      branchName: "feature/current",
+      baseBranch: "main",
+      worktreeSlug: "current",
+    });
+    expect(response.structuredContent).toMatchObject({
+      workspaceId: "wks_current",
+      cwd: TARGET_CWD,
+      isolation: "worktree",
+    });
   });
 
   it("surfaces createAgent validation failures", async () => {

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -1591,12 +1591,6 @@ describe("create_agent MCP tool", () => {
       { branchName: "feature/current", baseBranch: "main", worktreeSlug: "current" },
     );
 
-    expect(transitionWorkspaceToWorktree).toHaveBeenCalledWith({
-      callerAgentId: "agent-current",
-      branchName: "feature/current",
-      baseBranch: "main",
-      worktreeSlug: "current",
-    });
     expect(response.structuredContent).toMatchObject({
       workspaceId: "wks_current",
       cwd: TARGET_CWD,

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -118,6 +118,12 @@ export interface PaseoToolHostDependencies {
   markWorkspaceArchiving?: ArchiveDependencies["markWorkspaceArchiving"];
   clearWorkspaceArchiving?: ArchiveDependencies["clearWorkspaceArchiving"];
   createPaseoWorktree?: CreatePaseoWorktreeWorkflowFn;
+  transitionWorkspaceToWorktree?: (input: {
+    callerAgentId: string;
+    branchName?: string;
+    baseBranch?: string;
+    worktreeSlug?: string;
+  }) => Promise<PersistedWorkspaceRecord>;
   // Mints a fresh directory workspace for a cwd and returns its id.
   ensureWorkspaceForCreate?: (
     cwd: string,
@@ -1321,6 +1327,39 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         workspace = result.createdWorktree.workspace;
       }
 
+      return {
+        content: [],
+        structuredContent: ensureValidJson(toWorkspaceAutomationSummary(workspace)),
+      };
+    },
+  );
+
+  registerTool(
+    "transition_workspace_to_worktree",
+    {
+      title: "Move workspace to worktree",
+      description:
+        "Move your current local Git workspace into a new Paseo-managed worktree. The workspace keeps its identity; its checkout changes. Requires a clean checkout and no other running agents in the workspace.",
+      inputSchema: {
+        worktreeSlug: z.string().trim().min(1).optional(),
+        branchName: z.string().trim().min(1).optional(),
+        baseBranch: z.string().trim().min(1).optional(),
+      },
+      outputSchema: WorkspaceAutomationSummarySchema.shape,
+    },
+    async ({ worktreeSlug, branchName, baseBranch }) => {
+      if (!callerAgentId) {
+        throw new Error("transition_workspace_to_worktree requires an agent-scoped tool session");
+      }
+      if (!options.transitionWorkspaceToWorktree) {
+        throw new Error("Workspace transition is not configured");
+      }
+      const workspace = await options.transitionWorkspaceToWorktree({
+        callerAgentId,
+        ...(worktreeSlug ? { worktreeSlug } : {}),
+        ...(branchName ? { branchName } : {}),
+        ...(baseBranch ? { baseBranch } : {}),
+      });
       return {
         content: [],
         structuredContent: ensureValidJson(toWorkspaceAutomationSummary(workspace)),

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -122,6 +122,12 @@ import { createGitHubService } from "../services/github-service.js";
 import { createPaseoWorktree as createRegisteredPaseoWorktree } from "./paseo-worktree-service.js";
 import { createWorkspaceProvisioningService } from "./session/workspace-provisioning/workspace-provisioning-service.js";
 import { createPaseoWorktreeWorkflow } from "./worktree-session.js";
+import {
+  getWorktreeSetupCommands,
+  resolveWorktreeRuntimeEnv,
+  rollbackCreatedPaseoWorktree,
+  runWorktreeSetupCommands,
+} from "../utils/worktree.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
 import type { OpenAiSpeechProviderConfig } from "./speech/providers/openai/config.js";
 import type { LocalSpeechProviderConfig } from "./speech/providers/local/config.js";
@@ -1072,6 +1078,149 @@ export async function createPaseoDaemon(
   };
   const createAgent = (input: Parameters<typeof createAgentCommand>[1]) =>
     createAgentCommand(createAgentCommandDependencies, input);
+
+  const transitionWorkspaceToWorktree = async (input: {
+    callerAgentId: string;
+    branchName?: string;
+    baseBranch?: string;
+    worktreeSlug?: string;
+  }) => {
+    const caller = agentManager.getAgent(input.callerAgentId);
+    if (!caller?.workspaceId) {
+      throw new Error("Caller agent has no current workspace");
+    }
+    const workspace = await workspaceRegistry.get(caller.workspaceId);
+    if (!workspace || workspace.archivedAt) {
+      throw new Error("Current workspace is not available");
+    }
+    if (workspace.kind !== "local_checkout") {
+      throw new Error("Only a local Git workspace can move to a worktree");
+    }
+
+    const sourceSnapshot = await workspaceGitService.getSnapshot(workspace.cwd, {
+      force: true,
+      reason: "workspace_transition",
+    });
+    if (!sourceSnapshot.git.isGit) {
+      throw new Error("Only a Git workspace can move to a worktree");
+    }
+    if (sourceSnapshot.git.isDirty) {
+      throw new Error("Commit or stash local changes before moving this workspace to a worktree");
+    }
+
+    const liveAgents = agentManager
+      .listAgents()
+      .filter((agent) => agent.workspaceId === workspace.workspaceId);
+    const busyAgent = liveAgents.find(
+      (agent) =>
+        agent.id !== input.callerAgentId &&
+        (agent.lifecycle === "running" || agent.lifecycle === "initializing"),
+    );
+    if (busyAgent) {
+      throw new Error("Wait for other agents in this workspace to finish before moving it");
+    }
+
+    const created = await createRegisteredPaseoWorktree(
+      {
+        cwd: workspace.cwd,
+        projectId: workspace.projectId,
+        ...(input.worktreeSlug ? { worktreeSlug: input.worktreeSlug } : {}),
+        ...(input.branchName ? { branchName: input.branchName } : {}),
+        ...(input.baseBranch ? { refName: input.baseBranch } : {}),
+        action: "branch-off",
+        paseoHome: config.paseoHome,
+        worktreesRoot: config.worktreesRoot,
+      },
+      { github, workspaceGitService, workspaceProvisioning },
+    );
+
+    try {
+      if (created.created) {
+        const setupCommands = getWorktreeSetupCommands(created.workspace.cwd);
+        if (setupCommands.length > 0) {
+          const runtimeEnv = await resolveWorktreeRuntimeEnv({
+            worktreePath: created.worktree.worktreePath,
+            branchName: created.worktree.branchName,
+            repoRootPath: created.repoRoot,
+          });
+          terminalManager.registerCwdEnv({ cwd: created.workspace.cwd, env: runtimeEnv });
+          await runWorktreeSetupCommands({
+            worktreePath: created.workspace.cwd,
+            branchName: created.worktree.branchName,
+            cleanupOnFailure: true,
+            repoRootPath: created.repoRoot,
+            runtimeEnv,
+          });
+        }
+      }
+
+      await Promise.all(
+        liveAgents
+          .filter((agent) => agent.id !== input.callerAgentId)
+          .map((agent) => agentManager.closeAgent(agent.id)),
+      );
+      await killTerminalsForWorkspace(
+        { terminalManager, sessionLogger: logger },
+        workspace.workspaceId,
+      );
+
+      const transitioned = await workspaceRegistry.update(workspace.workspaceId, (existing) => ({
+        ...existing,
+        cwd: created.workspace.cwd,
+        kind: "worktree",
+        displayName: created.workspace.displayName,
+        branch: created.workspace.branch,
+        worktreeRoot: created.workspace.worktreeRoot,
+        baseBranch: created.workspace.baseBranch,
+        isPaseoOwnedWorktree: true,
+        mainRepoRoot: created.workspace.mainRepoRoot,
+        updatedAt: new Date().toISOString(),
+      }));
+      if (!transitioned) {
+        throw new Error("Current workspace disappeared during transition");
+      }
+
+      const records = await agentStorage.list();
+      await Promise.all(
+        records
+          .filter((record) => !record.archivedAt && record.workspaceId === workspace.workspaceId)
+          .map((record) =>
+            agentStorage.upsert({
+              ...record,
+              cwd: transitioned.cwd,
+              updatedAt: new Date().toISOString(),
+            }),
+          ),
+      );
+      await workspaceRegistry.remove(created.workspace.workspaceId);
+      await emitWorkspaceUpdatesExternal([workspace.workspaceId]);
+
+      // The calling agent must receive this MCP result before its old runtime is closed.
+      setTimeout(() => {
+        void agentManager.closeAgent(input.callerAgentId).catch((error) => {
+          logger.warn(
+            { err: error, agentId: input.callerAgentId },
+            "Failed to close transitioned caller agent",
+          );
+        });
+      }, 0);
+      return transitioned;
+    } catch (error) {
+      await workspaceRegistry.remove(created.workspace.workspaceId).catch(() => undefined);
+      if (created.created) {
+        await rollbackCreatedPaseoWorktree(
+          {
+            cwd: created.repoRoot,
+            worktreePath: created.worktree.worktreePath,
+            paseoHome: config.paseoHome,
+            worktreesBaseRoot: config.worktreesRoot,
+          },
+          error,
+        );
+      }
+      throw error;
+    }
+  };
   const archiveWorkspaceByIdExternal = (workspaceId: string, requestId: string) =>
     archiveByScope(
       {
@@ -1290,6 +1439,7 @@ export async function createPaseoDaemon(
     clearWorkspaceArchiving: clearWorkspaceArchivingExternal,
     ensureWorkspaceForCreate: createAgentCommandDependencies.ensureWorkspaceForCreate,
     createPaseoWorktree: createAgentCommandDependencies.createPaseoWorktree,
+    transitionWorkspaceToWorktree,
     browserToolsEnabled: browserToolsPolicy.isEnabled(),
     browserToolsBroker,
     paseoHome: config.paseoHome,

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -205,6 +205,11 @@ import { createWebUiMiddleware } from "./web-ui.js";
 import { WorkspaceAutoName } from "./workspace-auto-name.js";
 import { createGitMutationService } from "./session/git-mutation/git-mutation-service.js";
 import { workspaceIdsOnCheckout } from "./workspace-directory.js";
+import {
+  commitWorkspaceTransition,
+  resolveWorkspaceTransitionBaseRef,
+  WorkspaceTransitionPreservationRequiredError,
+} from "./workspace-transition.js";
 import { configureGitProcessPolicy } from "../utils/run-git-command.js";
 import { resolveGitProcessPolicy } from "../utils/git-process-scheduler.js";
 import { resolveFirstAgentPromptTitle } from "./agent/create-agent-title.js";
@@ -1126,7 +1131,10 @@ export async function createPaseoDaemon(
         projectId: workspace.projectId,
         ...(input.worktreeSlug ? { worktreeSlug: input.worktreeSlug } : {}),
         ...(input.branchName ? { branchName: input.branchName } : {}),
-        ...(input.baseBranch ? { refName: input.baseBranch } : {}),
+        refName: resolveWorkspaceTransitionBaseRef({
+          requestedBaseBranch: input.baseBranch,
+          currentBranch: sourceSnapshot.git.currentBranch,
+        }),
         action: "branch-off",
         paseoHome: config.paseoHome,
         worktreesRoot: config.worktreesRoot,
@@ -1147,65 +1155,39 @@ export async function createPaseoDaemon(
           await runWorktreeSetupCommands({
             worktreePath: created.workspace.cwd,
             branchName: created.worktree.branchName,
-            cleanupOnFailure: true,
+            cleanupOnFailure: false,
             repoRootPath: created.repoRoot,
             runtimeEnv,
           });
         }
       }
 
-      await Promise.all(
-        liveAgents
-          .filter((agent) => agent.id !== input.callerAgentId)
-          .map((agent) => agentManager.closeAgent(agent.id)),
+      return await commitWorkspaceTransition(
+        {
+          agentManager,
+          agentStorage,
+          workspaceRegistry,
+          killWorkspaceTerminals: (workspaceId) =>
+            killTerminalsForWorkspace({ terminalManager, sessionLogger: logger }, workspaceId),
+          emitWorkspaceUpdate: (workspaceId) => emitWorkspaceUpdatesExternal([workspaceId]),
+          logger,
+        },
+        {
+          caller,
+          liveAgents,
+          sourceWorkspace: workspace,
+          targetWorkspace: created.workspace,
+          temporaryWorkspaceId: created.workspace.workspaceId,
+        },
       );
-      await killTerminalsForWorkspace(
-        { terminalManager, sessionLogger: logger },
-        workspace.workspaceId,
-      );
-
-      const transitioned = await workspaceRegistry.update(workspace.workspaceId, (existing) => ({
-        ...existing,
-        cwd: created.workspace.cwd,
-        kind: "worktree",
-        displayName: created.workspace.displayName,
-        branch: created.workspace.branch,
-        worktreeRoot: created.workspace.worktreeRoot,
-        baseBranch: created.workspace.baseBranch,
-        isPaseoOwnedWorktree: true,
-        mainRepoRoot: created.workspace.mainRepoRoot,
-        updatedAt: new Date().toISOString(),
-      }));
-      if (!transitioned) {
-        throw new Error("Current workspace disappeared during transition");
-      }
-
-      const records = await agentStorage.list();
-      await Promise.all(
-        records
-          .filter((record) => !record.archivedAt && record.workspaceId === workspace.workspaceId)
-          .map((record) =>
-            agentStorage.upsert({
-              ...record,
-              cwd: transitioned.cwd,
-              updatedAt: new Date().toISOString(),
-            }),
-          ),
-      );
-      await workspaceRegistry.remove(created.workspace.workspaceId);
-      await emitWorkspaceUpdatesExternal([workspace.workspaceId]);
-
-      // The calling agent must receive this MCP result before its old runtime is closed.
-      setTimeout(() => {
-        void agentManager.closeAgent(input.callerAgentId).catch((error) => {
-          logger.warn(
-            { err: error, agentId: input.callerAgentId },
-            "Failed to close transitioned caller agent",
-          );
-        });
-      }, 0);
-      return transitioned;
     } catch (error) {
+      if (error instanceof WorkspaceTransitionPreservationRequiredError) {
+        logger.error(
+          { err: error.originalError, worktreePath: created.worktree.worktreePath },
+          "Preserving worktree after incomplete workspace transition rollback",
+        );
+        throw error.originalError;
+      }
       await workspaceRegistry.remove(created.workspace.workspaceId).catch(() => undefined);
       if (created.created) {
         await rollbackCreatedPaseoWorktree(

--- a/packages/server/src/server/workspace-transition.test.ts
+++ b/packages/server/src/server/workspace-transition.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ManagedAgent } from "./agent/agent-manager.js";
+import type { StoredAgentRecord } from "./agent/agent-storage.js";
+import type { PersistedWorkspaceRecord } from "./workspace-registry.js";
+import {
+  commitWorkspaceTransition,
+  resolveWorkspaceTransitionBaseRef,
+  WorkspaceTransitionPreservationRequiredError,
+} from "./workspace-transition.js";
+
+const SOURCE_CWD = "/repo";
+const TARGET_CWD = "/worktrees/feature";
+
+describe("workspace transition", () => {
+  it("preserves workspace identity while relocating persistence and runtimes", async () => {
+    const sourceWorkspace = workspace({
+      workspaceId: "workspace-current",
+      cwd: SOURCE_CWD,
+      kind: "local_checkout",
+      displayName: "repo",
+    });
+    const targetWorkspace = workspace({
+      workspaceId: "workspace-temporary",
+      cwd: TARGET_CWD,
+      kind: "worktree",
+      displayName: "feature/current",
+      branch: "feature/current",
+      worktreeRoot: TARGET_CWD,
+      baseBranch: "feature/source",
+      isPaseoOwnedWorktree: true,
+      mainRepoRoot: SOURCE_CWD,
+    });
+    const caller = managedAgent("agent-caller", SOURCE_CWD);
+    const sibling = managedAgent("agent-sibling", SOURCE_CWD);
+    const liveAgents = new Map([
+      [caller.id, caller],
+      [sibling.id, sibling],
+    ]);
+    const records = new Map([
+      [caller.id, storedAgent(caller.id, SOURCE_CWD)],
+      [sibling.id, storedAgent(sibling.id, SOURCE_CWD)],
+    ]);
+    const workspaces = new Map([
+      [sourceWorkspace.workspaceId, sourceWorkspace],
+      [targetWorkspace.workspaceId, targetWorkspace],
+    ]);
+    const scheduled: Array<() => void> = [];
+    const closeAgent = vi.fn(async (agentId: string) => {
+      const live = liveAgents.get(agentId);
+      const record = records.get(agentId);
+      if (live && record) {
+        records.set(agentId, { ...record, cwd: live.cwd, lastStatus: "closed" });
+      }
+    });
+    const killWorkspaceTerminals = vi.fn(async () => undefined);
+    const emitWorkspaceUpdate = vi.fn(async () => undefined);
+
+    const transitioned = await commitWorkspaceTransition(
+      {
+        agentManager: { closeAgent },
+        agentStorage: {
+          list: async () => Array.from(records.values()),
+          upsert: async (record) => {
+            records.set(record.id, record);
+          },
+        },
+        workspaceRegistry: {
+          update: async (workspaceId, updater) => {
+            const existing = workspaces.get(workspaceId);
+            if (!existing) return null;
+            const next = updater(existing);
+            workspaces.set(workspaceId, next);
+            return next;
+          },
+          upsert: async (record) => {
+            workspaces.set(record.workspaceId, record);
+          },
+          remove: async (workspaceId) => {
+            workspaces.delete(workspaceId);
+          },
+        },
+        killWorkspaceTerminals,
+        emitWorkspaceUpdate,
+        logger: { warn: vi.fn() },
+        schedule: (callback) => scheduled.push(callback),
+      },
+      {
+        caller,
+        liveAgents: Array.from(liveAgents.values()),
+        sourceWorkspace,
+        targetWorkspace,
+        temporaryWorkspaceId: targetWorkspace.workspaceId,
+      },
+    );
+
+    expect(transitioned).toMatchObject({
+      workspaceId: sourceWorkspace.workspaceId,
+      cwd: TARGET_CWD,
+      kind: "worktree",
+      branch: "feature/current",
+    });
+    expect(workspaces.get(sourceWorkspace.workspaceId)).toEqual(transitioned);
+    expect(workspaces.has(targetWorkspace.workspaceId)).toBe(false);
+    expect(Array.from(records.values()).map((record) => record.cwd)).toEqual([
+      TARGET_CWD,
+      TARGET_CWD,
+    ]);
+    expect(closeAgent).toHaveBeenCalledWith(sibling.id);
+    expect(closeAgent).not.toHaveBeenCalledWith(caller.id);
+    expect(killWorkspaceTerminals).toHaveBeenCalledWith(sourceWorkspace.workspaceId);
+    expect(emitWorkspaceUpdate).toHaveBeenCalledWith(sourceWorkspace.workspaceId);
+    expect(caller.cwd).toBe(TARGET_CWD);
+
+    scheduled.forEach((callback) => callback());
+    await vi.waitFor(() => expect(closeAgent).toHaveBeenCalledWith(caller.id));
+    expect(records.get(caller.id)).toMatchObject({ cwd: TARGET_CWD, lastStatus: "closed" });
+  });
+
+  it("restores workspace and agent records when the workspace write fails", async () => {
+    const sourceWorkspace = workspace({
+      workspaceId: "workspace-current",
+      cwd: SOURCE_CWD,
+      kind: "local_checkout",
+      displayName: "repo",
+    });
+    const targetWorkspace = workspace({
+      workspaceId: "workspace-temporary",
+      cwd: TARGET_CWD,
+      kind: "worktree",
+      displayName: "feature/current",
+    });
+    const caller = managedAgent("agent-caller", SOURCE_CWD);
+    const sourceRecord = storedAgent(caller.id, SOURCE_CWD);
+    let storedRecord = sourceRecord;
+    let storedWorkspace = sourceWorkspace;
+
+    await expect(
+      commitWorkspaceTransition(
+        {
+          agentManager: { closeAgent: vi.fn(async () => undefined) },
+          agentStorage: {
+            list: async () => [storedRecord],
+            upsert: async (record) => {
+              storedRecord = record;
+            },
+          },
+          workspaceRegistry: {
+            update: async (_workspaceId, updater) => {
+              storedWorkspace = updater(storedWorkspace);
+              throw new Error("workspace persistence failed");
+            },
+            upsert: async (record) => {
+              storedWorkspace = record;
+            },
+            remove: vi.fn(async () => undefined),
+          },
+          killWorkspaceTerminals: vi.fn(async () => undefined),
+          emitWorkspaceUpdate: vi.fn(async () => undefined),
+          logger: { warn: vi.fn() },
+        },
+        {
+          caller,
+          liveAgents: [caller],
+          sourceWorkspace,
+          targetWorkspace,
+          temporaryWorkspaceId: targetWorkspace.workspaceId,
+        },
+      ),
+    ).rejects.toThrow("workspace persistence failed");
+
+    expect(storedWorkspace).toEqual(sourceWorkspace);
+    expect(storedRecord).toEqual(sourceRecord);
+    expect(caller.cwd).toBe(SOURCE_CWD);
+  });
+
+  it("requires preserving the worktree when rollback persistence fails", async () => {
+    const sourceWorkspace = workspace({
+      workspaceId: "workspace-current",
+      cwd: SOURCE_CWD,
+      kind: "local_checkout",
+      displayName: "repo",
+    });
+    const targetWorkspace = workspace({
+      workspaceId: "workspace-temporary",
+      cwd: TARGET_CWD,
+      kind: "worktree",
+      displayName: "feature/current",
+    });
+    const caller = managedAgent("agent-caller", SOURCE_CWD);
+    let upsertCount = 0;
+
+    await expect(
+      commitWorkspaceTransition(
+        {
+          agentManager: { closeAgent: vi.fn(async () => undefined) },
+          agentStorage: {
+            list: async () => [storedAgent(caller.id, SOURCE_CWD)],
+            upsert: async () => {
+              upsertCount += 1;
+              if (upsertCount > 1) throw new Error("agent restore failed");
+            },
+          },
+          workspaceRegistry: {
+            update: async () => {
+              throw new Error("workspace persistence failed");
+            },
+            upsert: async () => undefined,
+            remove: vi.fn(async () => undefined),
+          },
+          killWorkspaceTerminals: vi.fn(async () => undefined),
+          emitWorkspaceUpdate: vi.fn(async () => undefined),
+          logger: { warn: vi.fn() },
+        },
+        {
+          caller,
+          liveAgents: [caller],
+          sourceWorkspace,
+          targetWorkspace,
+          temporaryWorkspaceId: targetWorkspace.workspaceId,
+        },
+      ),
+    ).rejects.toBeInstanceOf(WorkspaceTransitionPreservationRequiredError);
+  });
+
+  it("bases the worktree on the current checkout unless explicitly overridden", () => {
+    expect(resolveWorkspaceTransitionBaseRef({ currentBranch: "feature/source" })).toBe(
+      "feature/source",
+    );
+    expect(
+      resolveWorkspaceTransitionBaseRef({
+        requestedBaseBranch: "main",
+        currentBranch: "feature/source",
+      }),
+    ).toBe("main");
+    expect(resolveWorkspaceTransitionBaseRef({ currentBranch: null })).toBe("HEAD");
+  });
+});
+
+function workspace(
+  overrides: Partial<PersistedWorkspaceRecord> &
+    Pick<PersistedWorkspaceRecord, "workspaceId" | "cwd" | "kind" | "displayName">,
+): PersistedWorkspaceRecord {
+  return {
+    projectId: "project-current",
+    title: null,
+    branch: null,
+    worktreeRoot: null,
+    baseBranch: null,
+    isPaseoOwnedWorktree: false,
+    mainRepoRoot: null,
+    createdAt: "2026-08-10T00:00:00.000Z",
+    updatedAt: "2026-08-10T00:00:00.000Z",
+    archivedAt: null,
+    autoArchivedChangeRequestUrl: null,
+    pinnedAt: null,
+    ...overrides,
+  };
+}
+
+function storedAgent(id: string, cwd: string): StoredAgentRecord {
+  return {
+    id,
+    provider: "codex",
+    cwd,
+    workspaceId: "workspace-current",
+    createdAt: "2026-08-10T00:00:00.000Z",
+    updatedAt: "2026-08-10T00:00:00.000Z",
+    labels: {},
+    lastStatus: "idle",
+  };
+}
+
+function managedAgent(id: string, cwd: string): ManagedAgent {
+  return {
+    id,
+    cwd,
+    workspaceId: "workspace-current",
+    lifecycle: "idle",
+  } as ManagedAgent;
+}

--- a/packages/server/src/server/workspace-transition.test.ts
+++ b/packages/server/src/server/workspace-transition.test.ts
@@ -47,20 +47,25 @@ describe("workspace transition", () => {
       [targetWorkspace.workspaceId, targetWorkspace],
     ]);
     const scheduled: Array<() => void> = [];
-    const closeAgent = vi.fn(async (agentId: string, options?: { persistedCwd?: string }) => {
+    const closeAgent = vi.fn(async (agentId: string) => {
       const live = liveAgents.get(agentId);
       const record = records.get(agentId);
       if (live && record) {
-        if (options?.persistedCwd !== undefined) live.cwd = options.persistedCwd;
         records.set(agentId, { ...record, cwd: live.cwd, lastStatus: "closed" });
       }
+    });
+    const relocateAgentForNextResume = vi.fn(async (agentId: string, cwd: string) => {
+      const live = liveAgents.get(agentId);
+      if (live) live.cwd = cwd;
+      const record = records.get(agentId);
+      if (record) records.set(agentId, { ...record, cwd });
     });
     const killWorkspaceTerminals = vi.fn(async () => undefined);
     const emitWorkspaceUpdate = vi.fn(async () => undefined);
 
     const transitioned = await commitWorkspaceTransition(
       {
-        agentManager: { closeAgent },
+        agentManager: { closeAgent, relocateAgentForNextResume },
         agentStorage: {
           list: async () => Array.from(records.values()),
           upsert: async (record) => {
@@ -113,11 +118,12 @@ describe("workspace transition", () => {
     expect(killWorkspaceTerminals).toHaveBeenCalledWith(sourceWorkspace.workspaceId);
     expect(emitWorkspaceUpdate).toHaveBeenCalledWith(sourceWorkspace.workspaceId);
     expect(caller.cwd).toBe(SOURCE_CWD);
-    expect(liveCaller.cwd).toBe(SOURCE_CWD);
+    expect(liveCaller.cwd).toBe(TARGET_CWD);
+    expect(relocateAgentForNextResume).toHaveBeenCalledWith(caller.id, TARGET_CWD);
 
     scheduled.forEach((callback) => callback());
     await vi.waitFor(() => expect(closeAgent).toHaveBeenCalledTimes(2));
-    expect(closeAgent).toHaveBeenCalledWith(caller.id, { persistedCwd: TARGET_CWD });
+    expect(closeAgent).toHaveBeenCalledWith(caller.id);
     expect(liveCaller.cwd).toBe(TARGET_CWD);
     expect(records.get(caller.id)).toMatchObject({ cwd: TARGET_CWD, lastStatus: "closed" });
   });
@@ -143,7 +149,10 @@ describe("workspace transition", () => {
     await expect(
       commitWorkspaceTransition(
         {
-          agentManager: { closeAgent: vi.fn(async () => undefined) },
+          agentManager: {
+            closeAgent: vi.fn(async () => undefined),
+            relocateAgentForNextResume: vi.fn(async () => undefined),
+          },
           agentStorage: {
             list: async () => [storedRecord],
             upsert: async (record) => {
@@ -198,7 +207,10 @@ describe("workspace transition", () => {
     await expect(
       commitWorkspaceTransition(
         {
-          agentManager: { closeAgent: vi.fn(async () => undefined) },
+          agentManager: {
+            closeAgent: vi.fn(async () => undefined),
+            relocateAgentForNextResume: vi.fn(async () => undefined),
+          },
           agentStorage: {
             list: async () => [storedAgent(caller.id, SOURCE_CWD)],
             upsert: async () => {

--- a/packages/server/src/server/workspace-transition.test.ts
+++ b/packages/server/src/server/workspace-transition.test.ts
@@ -31,10 +31,11 @@ describe("workspace transition", () => {
       isPaseoOwnedWorktree: true,
       mainRepoRoot: SOURCE_CWD,
     });
-    const caller = managedAgent("agent-caller", SOURCE_CWD);
+    const liveCaller = managedAgent("agent-caller", SOURCE_CWD);
+    const caller = { ...liveCaller } as ManagedAgent;
     const sibling = managedAgent("agent-sibling", SOURCE_CWD);
     const liveAgents = new Map([
-      [caller.id, caller],
+      [liveCaller.id, liveCaller],
       [sibling.id, sibling],
     ]);
     const records = new Map([
@@ -46,10 +47,11 @@ describe("workspace transition", () => {
       [targetWorkspace.workspaceId, targetWorkspace],
     ]);
     const scheduled: Array<() => void> = [];
-    const closeAgent = vi.fn(async (agentId: string) => {
+    const closeAgent = vi.fn(async (agentId: string, options?: { persistedCwd?: string }) => {
       const live = liveAgents.get(agentId);
       const record = records.get(agentId);
       if (live && record) {
+        if (options?.persistedCwd !== undefined) live.cwd = options.persistedCwd;
         records.set(agentId, { ...record, cwd: live.cwd, lastStatus: "closed" });
       }
     });
@@ -110,10 +112,13 @@ describe("workspace transition", () => {
     expect(closeAgent).not.toHaveBeenCalledWith(caller.id);
     expect(killWorkspaceTerminals).toHaveBeenCalledWith(sourceWorkspace.workspaceId);
     expect(emitWorkspaceUpdate).toHaveBeenCalledWith(sourceWorkspace.workspaceId);
-    expect(caller.cwd).toBe(TARGET_CWD);
+    expect(caller.cwd).toBe(SOURCE_CWD);
+    expect(liveCaller.cwd).toBe(SOURCE_CWD);
 
     scheduled.forEach((callback) => callback());
-    await vi.waitFor(() => expect(closeAgent).toHaveBeenCalledWith(caller.id));
+    await vi.waitFor(() => expect(closeAgent).toHaveBeenCalledTimes(2));
+    expect(closeAgent).toHaveBeenCalledWith(caller.id, { persistedCwd: TARGET_CWD });
+    expect(liveCaller.cwd).toBe(TARGET_CWD);
     expect(records.get(caller.id)).toMatchObject({ cwd: TARGET_CWD, lastStatus: "closed" });
   });
 

--- a/packages/server/src/server/workspace-transition.ts
+++ b/packages/server/src/server/workspace-transition.ts
@@ -5,7 +5,7 @@ import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
 import type { PersistedWorkspaceRecord, WorkspaceRegistry } from "./workspace-registry.js";
 
 export interface CommitWorkspaceTransitionDependencies {
-  agentManager: Pick<AgentManager, "closeAgent">;
+  agentManager: Pick<AgentManager, "closeAgent" | "relocateAgentForNextResume">;
   agentStorage: Pick<AgentStorage, "list" | "upsert">;
   workspaceRegistry: Pick<WorkspaceRegistry, "remove" | "update" | "upsert">;
   killWorkspaceTerminals: (workspaceId: string) => Promise<void>;
@@ -88,6 +88,8 @@ export async function commitWorkspaceTransition(
       throw new Error("Current workspace disappeared during transition");
     }
 
+    await dependencies.agentManager.relocateAgentForNextResume(input.caller.id, transitioned.cwd);
+
     await dependencies.workspaceRegistry.remove(input.temporaryWorkspaceId).catch((error) => {
       dependencies.logger.warn(
         { err: error, workspaceId: input.temporaryWorkspaceId },
@@ -103,14 +105,12 @@ export async function commitWorkspaceTransition(
 
     const schedule = dependencies.schedule ?? ((callback: () => void) => setTimeout(callback, 0));
     schedule(() => {
-      void dependencies.agentManager
-        .closeAgent(input.caller.id, { persistedCwd: transitioned.cwd })
-        .catch((error) => {
-          dependencies.logger.warn(
-            { err: error, agentId: input.caller.id },
-            "Failed to close transitioned caller agent",
-          );
-        });
+      void dependencies.agentManager.closeAgent(input.caller.id).catch((error) => {
+        dependencies.logger.warn(
+          { err: error, agentId: input.caller.id },
+          "Failed to close transitioned caller agent",
+        );
+      });
     });
     return transitioned;
   } catch (error) {

--- a/packages/server/src/server/workspace-transition.ts
+++ b/packages/server/src/server/workspace-transition.ts
@@ -88,9 +88,6 @@ export async function commitWorkspaceTransition(
       throw new Error("Current workspace disappeared during transition");
     }
 
-    // closeAgent snapshots the live object, so relocate it before the delayed close.
-    input.caller.cwd = transitioned.cwd;
-
     await dependencies.workspaceRegistry.remove(input.temporaryWorkspaceId).catch((error) => {
       dependencies.logger.warn(
         { err: error, workspaceId: input.temporaryWorkspaceId },
@@ -106,12 +103,14 @@ export async function commitWorkspaceTransition(
 
     const schedule = dependencies.schedule ?? ((callback: () => void) => setTimeout(callback, 0));
     schedule(() => {
-      void dependencies.agentManager.closeAgent(input.caller.id).catch((error) => {
-        dependencies.logger.warn(
-          { err: error, agentId: input.caller.id },
-          "Failed to close transitioned caller agent",
-        );
-      });
+      void dependencies.agentManager
+        .closeAgent(input.caller.id, { persistedCwd: transitioned.cwd })
+        .catch((error) => {
+          dependencies.logger.warn(
+            { err: error, agentId: input.caller.id },
+            "Failed to close transitioned caller agent",
+          );
+        });
     });
     return transitioned;
   } catch (error) {

--- a/packages/server/src/server/workspace-transition.ts
+++ b/packages/server/src/server/workspace-transition.ts
@@ -1,0 +1,165 @@
+import type { Logger } from "pino";
+
+import type { AgentManager, ManagedAgent } from "./agent/agent-manager.js";
+import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
+import type { PersistedWorkspaceRecord, WorkspaceRegistry } from "./workspace-registry.js";
+
+export interface CommitWorkspaceTransitionDependencies {
+  agentManager: Pick<AgentManager, "closeAgent">;
+  agentStorage: Pick<AgentStorage, "list" | "upsert">;
+  workspaceRegistry: Pick<WorkspaceRegistry, "remove" | "update" | "upsert">;
+  killWorkspaceTerminals: (workspaceId: string) => Promise<void>;
+  emitWorkspaceUpdate: (workspaceId: string) => Promise<void>;
+  logger: Pick<Logger, "warn">;
+  schedule?: (callback: () => void) => void;
+}
+
+export interface CommitWorkspaceTransitionInput {
+  caller: ManagedAgent;
+  liveAgents: ManagedAgent[];
+  sourceWorkspace: PersistedWorkspaceRecord;
+  targetWorkspace: PersistedWorkspaceRecord;
+  temporaryWorkspaceId: string;
+}
+
+export class WorkspaceTransitionPreservationRequiredError extends Error {
+  readonly originalError: unknown;
+
+  constructor(originalError: unknown) {
+    super(
+      "Workspace transition rollback could not restore all persisted records; preserving the worktree",
+      { cause: originalError },
+    );
+    this.name = "WorkspaceTransitionPreservationRequiredError";
+    this.originalError = originalError;
+  }
+}
+
+export function resolveWorkspaceTransitionBaseRef(input: {
+  requestedBaseBranch?: string;
+  currentBranch: string | null;
+}): string {
+  return input.requestedBaseBranch ?? input.currentBranch ?? "HEAD";
+}
+
+export async function commitWorkspaceTransition(
+  dependencies: CommitWorkspaceTransitionDependencies,
+  input: CommitWorkspaceTransitionInput,
+): Promise<PersistedWorkspaceRecord> {
+  const { sourceWorkspace, targetWorkspace } = input;
+
+  await Promise.all(
+    input.liveAgents
+      .filter((agent) => agent.id !== input.caller.id)
+      .map((agent) => dependencies.agentManager.closeAgent(agent.id)),
+  );
+  await dependencies.killWorkspaceTerminals(sourceWorkspace.workspaceId);
+
+  const originalAgentRecords = (await dependencies.agentStorage.list()).filter(
+    (record) => !record.archivedAt && record.workspaceId === sourceWorkspace.workspaceId,
+  );
+  const transitionedAt = new Date().toISOString();
+  let workspaceMutationStarted = false;
+
+  try {
+    for (const record of originalAgentRecords) {
+      await dependencies.agentStorage.upsert(
+        transitionAgentRecord(record, targetWorkspace.cwd, transitionedAt),
+      );
+    }
+
+    workspaceMutationStarted = true;
+    const transitioned = await dependencies.workspaceRegistry.update(
+      sourceWorkspace.workspaceId,
+      (existing) => ({
+        ...existing,
+        cwd: targetWorkspace.cwd,
+        kind: "worktree",
+        displayName: targetWorkspace.displayName,
+        branch: targetWorkspace.branch,
+        worktreeRoot: targetWorkspace.worktreeRoot,
+        baseBranch: targetWorkspace.baseBranch,
+        isPaseoOwnedWorktree: true,
+        mainRepoRoot: targetWorkspace.mainRepoRoot,
+        updatedAt: transitionedAt,
+      }),
+    );
+    if (!transitioned) {
+      throw new Error("Current workspace disappeared during transition");
+    }
+
+    // closeAgent snapshots the live object, so relocate it before the delayed close.
+    input.caller.cwd = transitioned.cwd;
+
+    await dependencies.workspaceRegistry.remove(input.temporaryWorkspaceId).catch((error) => {
+      dependencies.logger.warn(
+        { err: error, workspaceId: input.temporaryWorkspaceId },
+        "Failed to remove temporary workspace after transition",
+      );
+    });
+    await dependencies.emitWorkspaceUpdate(sourceWorkspace.workspaceId).catch((error) => {
+      dependencies.logger.warn(
+        { err: error, workspaceId: sourceWorkspace.workspaceId },
+        "Failed to emit workspace update after transition",
+      );
+    });
+
+    const schedule = dependencies.schedule ?? ((callback: () => void) => setTimeout(callback, 0));
+    schedule(() => {
+      void dependencies.agentManager.closeAgent(input.caller.id).catch((error) => {
+        dependencies.logger.warn(
+          { err: error, agentId: input.caller.id },
+          "Failed to close transitioned caller agent",
+        );
+      });
+    });
+    return transitioned;
+  } catch (error) {
+    let restored = true;
+    if (workspaceMutationStarted) {
+      try {
+        await dependencies.workspaceRegistry.upsert(sourceWorkspace);
+      } catch (restoreError) {
+        restored = false;
+        dependencies.logger.warn(
+          { err: restoreError, workspaceId: sourceWorkspace.workspaceId },
+          "Failed to restore workspace after transition failure",
+        );
+      }
+    }
+    if (!(await restoreAgentRecords(dependencies, originalAgentRecords))) {
+      restored = false;
+    }
+    if (!restored) {
+      throw new WorkspaceTransitionPreservationRequiredError(error);
+    }
+    throw error;
+  }
+}
+
+function transitionAgentRecord(
+  record: StoredAgentRecord,
+  cwd: string,
+  updatedAt: string,
+): StoredAgentRecord {
+  return { ...record, cwd, updatedAt };
+}
+
+async function restoreAgentRecords(
+  dependencies: Pick<CommitWorkspaceTransitionDependencies, "agentStorage" | "logger">,
+  records: StoredAgentRecord[],
+): Promise<boolean> {
+  let restored = true;
+  for (const record of records) {
+    try {
+      await dependencies.agentStorage.upsert(record);
+    } catch (error) {
+      restored = false;
+      dependencies.logger.warn(
+        { err: error, agentId: record.id },
+        "Failed to restore agent after transition failure",
+      );
+    }
+  }
+  return restored;
+}


### PR DESCRIPTION
### Linked issue

None — this is a feature proposal. The PR remains draft while seeking maintainer direction on the workflow.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

An agent currently has to create a second workspace to gain worktree isolation. This change lets an agent move its existing local Git workspace into a Paseo-managed worktree while preserving the workspace ID, so open workspace state continues to point at the same workspace.

### Goals

- Provide an agent-scoped `transition_workspace_to_worktree` MCP tool.
- Preserve workspace identity while changing its backing checkout to a new worktree.
- Reject dirty source checkouts and transitions while another workspace agent is active.
- Relocate persisted agents and close workspace terminals before later resumes use the worktree.

### Non-goals

- No new app, web, mobile, desktop, or CLI controls.
- No checkout-existing-branch or pull-request transition modes; this PR supports branch-off only.
- No automatic migration of uncommitted changes.

### QA

Tested on Windows:

- `npx vitest run packages/server/src/server/agent/mcp-server.test.ts --bail=1` — 115 passed.
- `npm run build:server` — passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- Pre-commit formatting check — passed.

Not manually tested: macOS, Linux, Docker, browser web, Electron, iOS, and Android. This PR changes daemon/MCP behavior only; existing clients update their workspace presentation from the workspace descriptor emitted under the unchanged workspace ID.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense