### PR TITLE
feat: add Remote SSH host connections

### DIFF
--- a/packages/app/src/components/add-host-method-modal.tsx
+++ b/packages/app/src/components/add-host-method-modal.tsx
@@ -1,11 +1,19 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, Text, View } from "react-native";
-import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import { QrCode, Link2, ClipboardPaste } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { QrCode, Link2, ClipboardPaste, Terminal } from "lucide-react-native";
 import { AdaptiveModalSheet, type SheetHeader } from "./adaptive-modal-sheet";
 import { isFdroidBuild } from "@/constants/build-profile";
 import { isNative } from "@/constants/platform";
+import { isElectronRuntime } from "@/desktop/host";
+import type { Theme } from "@/styles/theme";
+
+const ThemedQrCode = withUnistyles(QrCode);
+const ThemedLink2 = withUnistyles(Link2);
+const ThemedClipboardPaste = withUnistyles(ClipboardPaste);
+const ThemedTerminal = withUnistyles(Terminal);
+const foregroundIconMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 
 const styles = StyleSheet.create((theme) => ({
   option: {
@@ -37,6 +45,7 @@ export interface AddHostMethodModalProps {
   visible: boolean;
   onClose: () => void;
   onDirectConnection: () => void;
+  onRemoteSsh: () => void;
   onScanQr: () => void;
   onPasteLink: () => void;
 }
@@ -45,10 +54,10 @@ export function AddHostMethodModal({
   visible,
   onClose,
   onDirectConnection,
+  onRemoteSsh,
   onScanQr,
   onPasteLink,
 }: AddHostMethodModalProps) {
-  const { theme } = useUnistyles();
   const { t } = useTranslation();
   const header = useMemo<SheetHeader>(() => ({ title: t("pairing.connectionMethods.title") }), [t]);
 
@@ -59,6 +68,10 @@ export function AddHostMethodModal({
   const handleScan = useCallback(() => {
     onScanQr();
   }, [onScanQr]);
+
+  const handleRemoteSsh = useCallback(() => {
+    onRemoteSsh();
+  }, [onRemoteSsh]);
 
   const handlePaste = useCallback(() => {
     onPasteLink();
@@ -78,7 +91,7 @@ export function AddHostMethodModal({
         accessibilityLabel={t("pairing.connectionMethods.direct.title")}
         testID="add-host-method-direct"
       >
-        <Link2 size={18} color={theme.colors.foreground} />
+        <ThemedLink2 size={18} uniProps={foregroundIconMapping} />
         <View style={styles.optionBody}>
           <Text style={styles.optionText}>{t("pairing.connectionMethods.direct.title")}</Text>
           <Text style={styles.optionSubtext}>
@@ -87,6 +100,24 @@ export function AddHostMethodModal({
         </View>
       </Pressable>
 
+      {isElectronRuntime() ? (
+        <Pressable
+          style={styles.option}
+          onPress={handleRemoteSsh}
+          accessibilityRole="button"
+          accessibilityLabel={t("pairing.connectionMethods.remoteSsh.title")}
+          testID="add-host-method-remote-ssh"
+        >
+          <ThemedTerminal size={18} uniProps={foregroundIconMapping} />
+          <View style={styles.optionBody}>
+            <Text style={styles.optionText}>{t("pairing.connectionMethods.remoteSsh.title")}</Text>
+            <Text style={styles.optionSubtext}>
+              {t("pairing.connectionMethods.remoteSsh.description")}
+            </Text>
+          </View>
+        </Pressable>
+      ) : null}
+
       {isNative && !isFdroidBuild ? (
         <Pressable
           style={styles.option}
@@ -94,7 +125,7 @@ export function AddHostMethodModal({
           accessibilityRole="button"
           accessibilityLabel={t("pairing.connectionMethods.scanQr.title")}
         >
-          <QrCode size={18} color={theme.colors.foreground} />
+          <ThemedQrCode size={18} uniProps={foregroundIconMapping} />
           <View style={styles.optionBody}>
             <Text style={styles.optionText}>{t("pairing.connectionMethods.scanQr.title")}</Text>
             <Text style={styles.optionSubtext}>
@@ -111,7 +142,7 @@ export function AddHostMethodModal({
         accessibilityLabel={t("pairing.connectionMethods.pasteLink.title")}
         testID="add-host-method-pair-link"
       >
-        <ClipboardPaste size={18} color={theme.colors.foreground} />
+        <ThemedClipboardPaste size={18} uniProps={foregroundIconMapping} />
         <View style={styles.optionBody}>
           <Text style={styles.optionText}>{t("pairing.connectionMethods.pasteLink.title")}</Text>
           <Text style={styles.optionSubtext}>

--- a/packages/app/src/components/add-remote-ssh-host-modal.tsx
+++ b/packages/app/src/components/add-remote-ssh-host-modal.tsx
@@ -1,0 +1,246 @@
+import { useCallback, useMemo, useReducer, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Text, View } from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import { Terminal } from "lucide-react-native";
+import type { HostProfile } from "@/types/host-connection";
+import { useHostMutations, useHosts } from "@/runtime/host-runtime";
+import { Button } from "@/components/ui/button";
+import { DaemonConnectionTestError } from "@/utils/test-daemon-connection";
+import { AdaptiveModalSheet, AdaptiveTextInput, type SheetHeader } from "./adaptive-modal-sheet";
+
+const FLEX_ONE_STYLE = { flex: 1 } as const;
+const ThemedTerminal = withUnistyles(Terminal);
+
+const styles = StyleSheet.create((theme) => ({
+  helper: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  field: {
+    gap: theme.spacing[2],
+  },
+  label: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+  input: {
+    backgroundColor: theme.colors.surface2,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[3],
+    color: theme.colors.foreground,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  error: {
+    color: theme.colors.destructive,
+    fontSize: theme.fontSize.sm,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: theme.spacing[3],
+    marginTop: theme.spacing[2],
+  },
+}));
+
+interface RemoteSshDraft {
+  host: string;
+  port: string;
+  identityFile: string;
+}
+
+type RemoteSshDraftAction =
+  | { type: "host"; value: string }
+  | { type: "port"; value: string }
+  | { type: "identityFile"; value: string }
+  | { type: "reset" };
+
+const EMPTY_DRAFT: RemoteSshDraft = { host: "", port: "", identityFile: "" };
+
+function reduceDraft(state: RemoteSshDraft, action: RemoteSshDraftAction): RemoteSshDraft {
+  if (action.type === "reset") return EMPTY_DRAFT;
+  return { ...state, [action.type]: action.value };
+}
+
+export interface AddRemoteSshHostModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onCancel?: () => void;
+  onSaved?: (result: {
+    profile: HostProfile;
+    serverId: string;
+    hostname: string | null;
+    isNewHost: boolean;
+  }) => void;
+}
+
+export function AddRemoteSshHostModal({
+  visible,
+  onClose,
+  onCancel,
+  onSaved,
+}: AddRemoteSshHostModalProps) {
+  const { t } = useTranslation();
+  const hosts = useHosts();
+  const { probeAndUpsertRemoteSshConnection } = useHostMutations();
+  const [draft, dispatch] = useReducer(reduceDraft, EMPTY_DRAFT);
+  const [resetKey, bumpResetKey] = useReducer((value: number) => value + 1, 0);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const header = useMemo<SheetHeader>(() => ({ title: t("pairing.remoteSsh.title") }), [t]);
+
+  const clear = useCallback(() => {
+    dispatch({ type: "reset" });
+    bumpResetKey();
+    setErrorMessage("");
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (isSaving) return;
+    clear();
+    onClose();
+  }, [clear, isSaving, onClose]);
+
+  const handleCancel = useCallback(() => {
+    if (isSaving) return;
+    clear();
+    (onCancel ?? onClose)();
+  }, [clear, isSaving, onCancel, onClose]);
+
+  const handleSave = useCallback(async () => {
+    if (isSaving) return;
+    const host = draft.host.trim();
+    if (!host) {
+      setErrorMessage(t("pairing.remoteSsh.errors.hostRequired"));
+      return;
+    }
+    if (/\s/.test(host) || host.startsWith("-")) {
+      setErrorMessage(t("pairing.remoteSsh.errors.invalidHost"));
+      return;
+    }
+    const rawPort = draft.port.trim();
+    const sshPort = rawPort ? Number(rawPort) : undefined;
+    if (sshPort !== undefined && (!Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535)) {
+      setErrorMessage(t("pairing.remoteSsh.errors.invalidPort"));
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      setErrorMessage("");
+      const result = await probeAndUpsertRemoteSshConnection({
+        host,
+        ...(sshPort !== undefined ? { sshPort } : {}),
+        ...(draft.identityFile.trim() ? { identityFile: draft.identityFile.trim() } : {}),
+      });
+      onSaved?.({
+        ...result,
+        isNewHost: !hosts.some((profile) => profile.serverId === result.serverId),
+      });
+      clear();
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof DaemonConnectionTestError
+          ? t("pairing.remoteSsh.errors.failedToConnect", { detail: error.message })
+          : t("common.errors.unableToSave");
+      setErrorMessage(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [clear, draft, hosts, isSaving, onClose, onSaved, probeAndUpsertRemoteSshConnection, t]);
+
+  const handleSubmit = useCallback(() => void handleSave(), [handleSave]);
+  const handleHostChange = useCallback((value: string) => dispatch({ type: "host", value }), []);
+  const handlePortChange = useCallback((value: string) => dispatch({ type: "port", value }), []);
+  const handleIdentityFileChange = useCallback(
+    (value: string) => dispatch({ type: "identityFile", value }),
+    [],
+  );
+
+  return (
+    <AdaptiveModalSheet
+      header={header}
+      visible={visible}
+      onClose={handleClose}
+      testID="add-remote-ssh-host-modal"
+    >
+      <Text style={styles.helper}>{t("pairing.remoteSsh.helper")}</Text>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>{t("pairing.remoteSsh.fields.host")}</Text>
+        <AdaptiveTextInput
+          testID="remote-ssh-host-input"
+          initialValue={draft.host}
+          resetKey={`remote-ssh-host-${resetKey}`}
+          onChangeText={handleHostChange}
+          placeholder="user@example.com"
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isSaving}
+          returnKeyType="next"
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>{t("pairing.remoteSsh.fields.port")}</Text>
+        <AdaptiveTextInput
+          testID="remote-ssh-port-input"
+          initialValue={draft.port}
+          resetKey={`remote-ssh-port-${resetKey}`}
+          onChangeText={handlePortChange}
+          placeholder={t("pairing.remoteSsh.fields.optional")}
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="number-pad"
+          editable={!isSaving}
+          returnKeyType="next"
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>{t("pairing.remoteSsh.fields.identityFile")}</Text>
+        <AdaptiveTextInput
+          testID="remote-ssh-identity-input"
+          initialValue={draft.identityFile}
+          resetKey={`remote-ssh-identity-${resetKey}`}
+          onChangeText={handleIdentityFileChange}
+          placeholder={t("pairing.remoteSsh.fields.optional")}
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!isSaving}
+          returnKeyType="done"
+          onSubmitEditing={handleSubmit}
+        />
+        {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+      </View>
+
+      <View style={styles.actions}>
+        <Button
+          style={FLEX_ONE_STYLE}
+          variant="secondary"
+          onPress={handleCancel}
+          disabled={isSaving}
+        >
+          {t("pairing.remoteSsh.actions.cancel")}
+        </Button>
+        <Button
+          style={FLEX_ONE_STYLE}
+          onPress={handleSubmit}
+          disabled={isSaving}
+          leftIcon={ThemedTerminal}
+          testID="remote-ssh-submit"
+        >
+          {isSaving
+            ? t("pairing.remoteSsh.actions.connecting")
+            : t("pairing.remoteSsh.actions.connect")}
+        </Button>
+      </View>
+    </AdaptiveModalSheet>
+  );
+}

--- a/packages/app/src/components/welcome-screen.tsx
+++ b/packages/app/src/components/welcome-screen.tsx
@@ -3,11 +3,19 @@ import { useTranslation } from "react-i18next";
 import { Pressable, Text, View, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
-import { QrCode, Link2, ClipboardPaste, ExternalLink, Settings } from "lucide-react-native";
+import {
+  QrCode,
+  Link2,
+  ClipboardPaste,
+  ExternalLink,
+  Settings,
+  Terminal,
+} from "lucide-react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { HostProfile } from "@/types/host-connection";
 import { getHostRuntimeStore, isHostRuntimeConnected, useHosts } from "@/runtime/host-runtime";
 import { AddHostModal } from "./add-host-modal";
+import { AddRemoteSshHostModal } from "./add-remote-ssh-host-modal";
 import { PairLinkModal } from "./pair-link-modal";
 import { Button } from "@/components/ui/button";
 import { resolveAppVersion } from "@/utils/app-version";
@@ -17,9 +25,10 @@ import { PaseoLogo } from "@/components/icons/paseo-logo";
 import { openExternalUrl } from "@/utils/open-external-url";
 import { isFdroidBuild } from "@/constants/build-profile";
 import { isWeb, isNative } from "@/constants/platform";
+import { isElectronRuntime } from "@/desktop/host";
 
 interface WelcomeAction {
-  key: "scan-qr" | "direct-connection" | "paste-pairing-link";
+  key: "scan-qr" | "direct-connection" | "remote-ssh" | "paste-pairing-link";
   label: string;
   testID: string;
   primary: boolean;
@@ -165,6 +174,7 @@ export function WelcomeScreen({ onHostAdded }: WelcomeScreenProps) {
   const appVersion = resolveAppVersion();
   const appVersionText = formatVersionWithPrefix(appVersion);
   const [isDirectOpen, setIsDirectOpen] = useState(false);
+  const [isRemoteSshOpen, setIsRemoteSshOpen] = useState(false);
   const [isPasteLinkOpen, setIsPasteLinkOpen] = useState(false);
   const hosts = useHosts();
   const anyOnlineServerId = useAnyHostOnline(hosts.map((h) => h.serverId));
@@ -188,6 +198,8 @@ export function WelcomeScreen({ onHostAdded }: WelcomeScreenProps) {
 
   const handleOpenDirect = useCallback(() => setIsDirectOpen(true), []);
   const handleCloseDirect = useCallback(() => setIsDirectOpen(false), []);
+  const handleOpenRemoteSsh = useCallback(() => setIsRemoteSshOpen(true), []);
+  const handleCloseRemoteSsh = useCallback(() => setIsRemoteSshOpen(false), []);
   const handleOpenPasteLink = useCallback(() => setIsPasteLinkOpen(true), []);
   const handleClosePasteLink = useCallback(() => setIsPasteLinkOpen(false), []);
   const handleScanQr = useCallback(() => {
@@ -249,6 +261,17 @@ export function WelcomeScreen({ onHostAdded }: WelcomeScreenProps) {
           },
         ];
 
+  if (isElectronRuntime()) {
+    actions.splice(1, 0, {
+      key: "remote-ssh",
+      label: t("pairing.connectionMethods.remoteSsh.title"),
+      testID: "welcome-remote-ssh",
+      primary: false,
+      icon: Terminal,
+      onPress: handleOpenRemoteSsh,
+    });
+  }
+
   const scrollContentContainerStyle = useMemo(
     () => [styles.container, { paddingBottom: theme.spacing[6] + insets.bottom }],
     [theme.spacing, insets.bottom],
@@ -297,6 +320,12 @@ export function WelcomeScreen({ onHostAdded }: WelcomeScreenProps) {
         <AddHostModal
           visible={isDirectOpen}
           onClose={handleCloseDirect}
+          onSaved={handleHostSaved}
+        />
+
+        <AddRemoteSshHostModal
+          visible={isRemoteSshOpen}
+          onClose={handleCloseRemoteSsh}
           onSaved={handleHostSaved}
         />
 

--- a/packages/app/src/desktop/daemon/desktop-daemon-transport.test.ts
+++ b/packages/app/src/desktop/daemon/desktop-daemon-transport.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
-import { createDesktopLocalDaemonTransportFactory } from "./desktop-daemon-transport";
+import {
+  buildDesktopDaemonTransportUrl,
+  createDesktopDaemonTransportFactory,
+} from "./desktop-daemon-transport";
 import { createFakeLocalDaemonTransportRpc } from "./test-local-daemon-transport-rpc";
 
-const LOCAL_URL = "paseo+local://socket?path=%2Ftmp%2Fpaseo.sock";
+const LOCAL_URL = "paseo+desktop://socket?path=%2Ftmp%2Fpaseo.sock";
 
 describe("desktop-daemon-transport", () => {
-  it("emits open after the session resolves even if the rust open event raced earlier", async () => {
+  it("uses the main-process event as readiness when it races registration", async () => {
     const rpc = createFakeLocalDaemonTransportRpc();
-    const transportFactory = createDesktopLocalDaemonTransportFactory(rpc);
+    const cleanup = vi.fn();
+    const transportFactory = createDesktopDaemonTransportFactory(rpc);
     expect(transportFactory).not.toBeNull();
 
     const transport = transportFactory!({ url: LOCAL_URL });
@@ -15,32 +19,93 @@ describe("desktop-daemon-transport", () => {
     const onOpen = vi.fn();
     transport.onOpen(onOpen);
 
-    rpc.emitEvent({ sessionId: "local-session-1", kind: "open" });
-    expect(onOpen).not.toHaveBeenCalled();
+    rpc.resolveListen(cleanup);
+    await Promise.resolve();
 
-    rpc.resolveOpen("local-session-1");
+    const sessionId = rpc.openCalls[0]?.sessionId ?? "";
+    expect(sessionId).not.toBe("");
+    rpc.emitEvent({ sessionId, kind: "open" });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    rpc.resolveRegistration();
     await Promise.resolve();
 
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it("cleans up late async setup after the transport is closed", async () => {
+  it("does not start a session when listener setup finishes after close", async () => {
     const rpc = createFakeLocalDaemonTransportRpc();
     const cleanup = vi.fn();
 
-    const transportFactory = createDesktopLocalDaemonTransportFactory(rpc);
+    const transportFactory = createDesktopDaemonTransportFactory(rpc);
     expect(transportFactory).not.toBeNull();
 
     const transport = transportFactory!({ url: LOCAL_URL });
 
     transport.close();
 
-    rpc.resolveOpen("local-session-2");
     rpc.resolveListen(cleanup);
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(rpc.closedSessions).toEqual(["local-session-2"]);
+    expect(rpc.openCalls).toHaveLength(0);
+    expect(rpc.closedSessions).toHaveLength(1);
     expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a registered session while readiness is pending", async () => {
+    const rpc = createFakeLocalDaemonTransportRpc();
+    const transportFactory = createDesktopDaemonTransportFactory(rpc);
+    expect(transportFactory).not.toBeNull();
+
+    const transport = transportFactory!({ url: LOCAL_URL });
+    rpc.resolveListen(vi.fn());
+    await Promise.resolve();
+
+    const sessionId = rpc.openCalls[0]?.sessionId ?? "";
+    expect(sessionId).not.toBe("");
+
+    transport.close();
+
+    expect(rpc.closedSessions).toEqual([sessionId]);
+  });
+
+  it("passes Remote SSH parameters to the desktop transport bridge", async () => {
+    const rpc = createFakeLocalDaemonTransportRpc();
+    const transportFactory = createDesktopDaemonTransportFactory(rpc);
+    expect(transportFactory).not.toBeNull();
+
+    const url = buildDesktopDaemonTransportUrl({
+      transportType: "ssh",
+      host: "deploy@example.com",
+      sshPort: 2222,
+      identityFile: "/Users/example/.ssh/paseo",
+    });
+    transportFactory!({ url });
+    rpc.resolveListen(vi.fn());
+    await Promise.resolve();
+
+    expect(rpc.openCalls).toHaveLength(1);
+    expect(rpc.openCalls[0]?.target).toEqual({
+      transportType: "ssh",
+      host: "deploy@example.com",
+      sshPort: 2222,
+      identityFile: "/Users/example/.ssh/paseo",
+    });
+  });
+
+  it.each([0, 65536])("rejects an out-of-range Remote SSH port (%s)", (sshPort) => {
+    const transportFactory = createDesktopDaemonTransportFactory(
+      createFakeLocalDaemonTransportRpc(),
+    );
+    expect(transportFactory).not.toBeNull();
+
+    const url = buildDesktopDaemonTransportUrl({
+      transportType: "ssh",
+      host: "deploy@example.com",
+      sshPort,
+    });
+
+    expect(() => transportFactory!({ url })).toThrow("Invalid SSH transport target");
   });
 });

--- a/packages/app/src/desktop/daemon/desktop-daemon-transport.ts
+++ b/packages/app/src/desktop/daemon/desktop-daemon-transport.ts
@@ -2,13 +2,14 @@ import type {
   DaemonTransport,
   DaemonTransportFactory,
 } from "@getpaseo/client/internal/daemon-client";
-import type { LocalTransportTarget } from "./desktop-daemon";
+import type { DesktopDaemonTransportTarget } from "./desktop-daemon";
 import {
   defaultLocalDaemonTransportRpc,
+  type LocalDaemonTransportEvent,
   type LocalDaemonTransportRpc,
 } from "./local-daemon-transport-rpc";
 
-const LOCAL_TRANSPORT_SCHEME = "paseo+local:";
+const DESKTOP_TRANSPORT_SCHEME = "paseo+desktop:";
 
 function encodeBinaryToBase64(data: Uint8Array | ArrayBuffer): string {
   const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
@@ -28,21 +29,49 @@ function decodeBase64ToBytes(base64: string): Uint8Array {
   return bytes;
 }
 
-export function buildLocalDaemonTransportUrl(target: LocalTransportTarget): string {
-  const url = new URL(`${LOCAL_TRANSPORT_SCHEME}//${target.transportType}`);
-  url.searchParams.set("path", target.transportPath);
+export function buildDesktopDaemonTransportUrl(target: DesktopDaemonTransportTarget): string {
+  const url = new URL(`${DESKTOP_TRANSPORT_SCHEME}//${target.transportType}`);
+  if (target.transportType === "ssh") {
+    url.searchParams.set("host", target.host);
+    if (target.sshPort !== undefined) {
+      url.searchParams.set("port", String(target.sshPort));
+    }
+    if (target.identityFile) {
+      url.searchParams.set("identity", target.identityFile);
+    }
+  } else {
+    url.searchParams.set("path", target.transportPath);
+  }
   return url.toString();
 }
 
-function parseLocalDaemonTransportUrl(url: string): LocalTransportTarget {
+function parseDesktopDaemonTransportUrl(url: string): DesktopDaemonTransportTarget {
   const parsed = new URL(url);
-  if (parsed.protocol !== LOCAL_TRANSPORT_SCHEME) {
-    throw new Error(`Unsupported local transport URL: ${url}`);
+  if (parsed.protocol !== DESKTOP_TRANSPORT_SCHEME) {
+    throw new Error(`Unsupported desktop transport URL: ${url}`);
   }
   const transportType = parsed.hostname;
+  if (transportType === "ssh") {
+    const host = parsed.searchParams.get("host")?.trim() ?? "";
+    const rawPort = parsed.searchParams.get("port");
+    const sshPort = rawPort === null ? undefined : Number(rawPort);
+    const identityFile = parsed.searchParams.get("identity")?.trim() || undefined;
+    if (!host) {
+      throw new Error(`Invalid SSH transport target: ${url}`);
+    }
+    if (sshPort !== undefined && (!Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535)) {
+      throw new Error(`Invalid SSH transport target: ${url}`);
+    }
+    return {
+      transportType,
+      host,
+      ...(sshPort !== undefined ? { sshPort } : {}),
+      ...(identityFile ? { identityFile } : {}),
+    };
+  }
   const transportPath = parsed.searchParams.get("path")?.trim() ?? "";
   if ((transportType !== "socket" && transportType !== "pipe") || !transportPath) {
-    throw new Error(`Invalid local transport target: ${url}`);
+    throw new Error(`Invalid desktop transport target: ${url}`);
   }
   return {
     transportType,
@@ -50,12 +79,12 @@ function parseLocalDaemonTransportUrl(url: string): LocalTransportTarget {
   };
 }
 
-export function createDesktopLocalDaemonTransportFactory(
+export function createDesktopDaemonTransportFactory(
   rpc: LocalDaemonTransportRpc = defaultLocalDaemonTransportRpc,
 ): DaemonTransportFactory | null {
   return ({ url }) => {
-    const target = parseLocalDaemonTransportUrl(url);
-    let sessionId: string | null = null;
+    const target = parseDesktopDaemonTransportUrl(url);
+    const sessionId = `local-session-${globalThis.crypto.randomUUID()}`;
     let unlisten: (() => void) | null = null;
     let disposed = false;
     let didEmitOpen = false;
@@ -80,6 +109,9 @@ export function createDesktopLocalDaemonTransportFactory(
       }
     };
     const emitError = (event?: unknown) => {
+      if (disposed) {
+        return;
+      }
       for (const handler of errorHandlers) {
         handler(event);
       }
@@ -90,61 +122,49 @@ export function createDesktopLocalDaemonTransportFactory(
       }
     };
 
-    void rpc
-      .listenToEvents((payload) => {
-        if (disposed || !sessionId || payload.sessionId !== sessionId) {
+    const handleEvent = (payload: LocalDaemonTransportEvent) => {
+      if (disposed || payload.sessionId !== sessionId) {
+        return;
+      }
+      if (payload.kind === "open") {
+        emitOpen();
+        return;
+      }
+      if (payload.kind === "message") {
+        if (payload.text) {
+          emitMessage(payload.text, false);
           return;
         }
-        if (payload.kind === "open") {
-          emitOpen();
-          return;
+        if (payload.binaryBase64) {
+          emitMessage(decodeBase64ToBytes(payload.binaryBase64), true);
         }
-        if (payload.kind === "message") {
-          if (payload.text) {
-            emitMessage(payload.text, false);
-            return;
-          }
-          if (payload.binaryBase64) {
-            emitMessage(decodeBase64ToBytes(payload.binaryBase64), true);
-          }
-          return;
-        }
-        if (payload.kind === "close") {
-          emitClose(payload);
-          return;
-        }
-        emitError(payload.error ?? "Local daemon transport error");
-      })
-      .then((cleanup) => {
+        return;
+      }
+      if (payload.kind === "close") {
+        emitClose(payload);
+        return;
+      }
+      emitError(payload.error ?? "Local daemon transport error");
+    };
+
+    void (async () => {
+      try {
+        const cleanup = await rpc.listenToEvents(handleEvent);
         if (disposed) {
           cleanup();
           return;
         }
         unlisten = cleanup;
-        return;
-      })
-      .catch((error) => {
-        emitError(error);
-      });
 
-    void rpc
-      .openSession(target)
-      .then((id) => {
-        if (disposed) {
-          void rpc.closeSession(id).catch((error) => emitError(error));
-          return;
-        }
-        sessionId = id;
-        emitOpen();
-        return;
-      })
-      .catch((error) => {
+        await rpc.openSession({ sessionId, target });
+      } catch (error) {
         emitError(error);
-      });
+      }
+    })();
 
     const transport: DaemonTransport = {
       send: (data) => {
-        if (!sessionId) {
+        if (!didEmitOpen) {
           return;
         }
         if (typeof data === "string") {
@@ -157,12 +177,11 @@ export function createDesktopLocalDaemonTransportFactory(
         void rpc.sendMessage({ sessionId, binaryBase64 }).catch((error) => emitError(error));
       },
       close: () => {
-        disposed = true;
-        const currentSessionId = sessionId;
-        sessionId = null;
-        if (currentSessionId) {
-          void rpc.closeSession(currentSessionId).catch((error) => emitError(error));
+        if (disposed) {
+          return;
         }
+        disposed = true;
+        void rpc.closeSession(sessionId).catch((error) => emitError(error));
         unlisten?.();
         unlisten = null;
       },

--- a/packages/app/src/desktop/daemon/desktop-daemon.ts
+++ b/packages/app/src/desktop/daemon/desktop-daemon.ts
@@ -40,6 +40,22 @@ export interface LocalTransportTarget {
   transportPath: string;
 }
 
+export interface RemoteSshTransportTarget {
+  [key: string]: unknown;
+  transportType: "ssh";
+  host: string;
+  sshPort?: number;
+  identityFile?: string;
+}
+
+export type DesktopDaemonTransportTarget = LocalTransportTarget | RemoteSshTransportTarget;
+
+export interface OpenLocalTransportSessionInput {
+  [key: string]: unknown;
+  sessionId: string;
+  target: DesktopDaemonTransportTarget;
+}
+
 interface LocalTransportEventPayload {
   sessionId: string;
   kind: "open" | "message" | "close" | "error";
@@ -179,12 +195,10 @@ export async function listenToLocalTransportEvents(
   return typeof unlisten === "function" ? unlisten : () => {};
 }
 
-export async function openLocalTransportSession(target: LocalTransportTarget): Promise<string> {
-  const raw = await invokeDesktopCommand<unknown>("open_local_daemon_transport", target);
-  if (typeof raw !== "string" || raw.trim().length === 0) {
-    throw new Error("Unexpected local transport session response.");
-  }
-  return raw;
+export async function openLocalTransportSession(
+  input: OpenLocalTransportSessionInput,
+): Promise<void> {
+  await invokeDesktopCommand("open_local_daemon_transport", input);
 }
 
 export async function sendLocalTransportMessage(input: {

--- a/packages/app/src/desktop/daemon/local-daemon-transport-rpc.ts
+++ b/packages/app/src/desktop/daemon/local-daemon-transport-rpc.ts
@@ -3,7 +3,7 @@ import {
   listenToLocalTransportEvents,
   openLocalTransportSession,
   sendLocalTransportMessage,
-  type LocalTransportTarget,
+  type OpenLocalTransportSessionInput,
 } from "./desktop-daemon";
 
 export interface LocalDaemonTransportEvent {
@@ -17,7 +17,7 @@ export interface LocalDaemonTransportEvent {
 }
 
 export interface LocalDaemonTransportRpc {
-  openSession(target: LocalTransportTarget): Promise<string>;
+  openSession(input: OpenLocalTransportSessionInput): Promise<void>;
   listenToEvents(handler: (event: LocalDaemonTransportEvent) => void): Promise<() => void>;
   sendMessage(input: { sessionId: string; text?: string; binaryBase64?: string }): Promise<void>;
   closeSession(sessionId: string): Promise<void>;

--- a/packages/app/src/desktop/daemon/test-local-daemon-transport-rpc.ts
+++ b/packages/app/src/desktop/daemon/test-local-daemon-transport-rpc.ts
@@ -1,4 +1,4 @@
-import type { LocalTransportTarget } from "./desktop-daemon";
+import type { OpenLocalTransportSessionInput } from "./desktop-daemon";
 import type {
   LocalDaemonTransportEvent,
   LocalDaemonTransportRpc,
@@ -11,10 +11,10 @@ export interface RecordedSend {
 }
 
 export interface FakeLocalDaemonTransportRpc extends LocalDaemonTransportRpc {
-  readonly openCalls: LocalTransportTarget[];
+  readonly openCalls: OpenLocalTransportSessionInput[];
   readonly recordedSends: RecordedSend[];
   readonly closedSessions: string[];
-  resolveOpen(sessionId: string): void;
+  resolveRegistration(): void;
   rejectOpen(error: Error): void;
   resolveListen(cleanup: () => void): void;
   rejectListen(error: Error): void;
@@ -22,12 +22,12 @@ export interface FakeLocalDaemonTransportRpc extends LocalDaemonTransportRpc {
 }
 
 export function createFakeLocalDaemonTransportRpc(): FakeLocalDaemonTransportRpc {
-  const openCalls: LocalTransportTarget[] = [];
+  const openCalls: OpenLocalTransportSessionInput[] = [];
   const recordedSends: RecordedSend[] = [];
   const closedSessions: string[] = [];
   let eventHandler: ((event: LocalDaemonTransportEvent) => void) | null = null;
-  let resolveOpenSession: ((sessionId: string) => void) | null = null;
-  let rejectOpenSession: ((error: Error) => void) | null = null;
+  let resolveRegistrationPromise: (() => void) | null = null;
+  let rejectRegistrationPromise: ((error: Error) => void) | null = null;
   let resolveListenPromise: ((cleanup: () => void) => void) | null = null;
   let rejectListenPromise: ((error: Error) => void) | null = null;
 
@@ -35,11 +35,11 @@ export function createFakeLocalDaemonTransportRpc(): FakeLocalDaemonTransportRpc
     openCalls,
     recordedSends,
     closedSessions,
-    openSession(target) {
-      openCalls.push(target);
-      return new Promise<string>((resolve, reject) => {
-        resolveOpenSession = resolve;
-        rejectOpenSession = reject;
+    openSession(input) {
+      openCalls.push(input);
+      return new Promise<void>((resolve, reject) => {
+        resolveRegistrationPromise = resolve;
+        rejectRegistrationPromise = reject;
       });
     },
     listenToEvents(handler) {
@@ -55,17 +55,17 @@ export function createFakeLocalDaemonTransportRpc(): FakeLocalDaemonTransportRpc
     async closeSession(sessionId) {
       closedSessions.push(sessionId);
     },
-    resolveOpen(sessionId) {
-      if (!resolveOpenSession) {
+    resolveRegistration() {
+      if (!resolveRegistrationPromise) {
         throw new Error("openSession was not called");
       }
-      resolveOpenSession(sessionId);
+      resolveRegistrationPromise();
     },
     rejectOpen(error) {
-      if (!rejectOpenSession) {
+      if (!rejectRegistrationPromise) {
         throw new Error("openSession was not called");
       }
-      rejectOpenSession(error);
+      rejectRegistrationPromise(error);
     },
     resolveListen(cleanup) {
       if (!resolveListenPromise) {

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1515,6 +1515,10 @@ export const ar: TranslationResources = {
         title: "اتصال مباشر",
         description: "الشبكة المحلية أو VPN.",
       },
+      remoteSsh: {
+        title: "SSH عن بُعد",
+        description: "الاتصال عبر عميل SSH لسطح المكتب.",
+      },
       scanQr: {
         title: "مسح رمز QR",
         description: "اتصال التتابع المشفر.",
@@ -1565,6 +1569,27 @@ export const ar: TranslationResources = {
         unableToConnect:
           "غير قادر على الاتصال. تحقق من المضيف /port ومن إمكانية الوصول إلى البرنامج الخفي.",
         details: "التفاصيل:{{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "SSH عن بُعد",
+      helper: "الاتصال بخادم Paseo يعمل على المضيف البعيد.",
+      fields: {
+        host: "المضيف",
+        port: "منفذ SSH",
+        identityFile: "مسار ملف الهوية",
+        optional: "اختياري",
+      },
+      actions: {
+        cancel: "إلغاء",
+        connect: "اتصال",
+        connecting: "جارٍ الاتصال...",
+      },
+      errors: {
+        hostRequired: "المضيف مطلوب",
+        invalidHost: "أدخل مضيف SSH صالحًا",
+        invalidPort: "يجب أن يكون منفذ SSH بين 1 و65535",
+        failedToConnect: "تعذر الاتصال عبر SSH. {{detail}}",
       },
     },
     link: {
@@ -2188,6 +2213,7 @@ export const ar: TranslationResources = {
       badges: {
         relay: "تتابع",
         local: "محلي",
+        remoteSsh: "SSH عن بُعد",
       },
       connections: {
         title: "اتصالات",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1525,6 +1525,10 @@ export const en = {
         title: "Direct connection",
         description: "Local network or VPN.",
       },
+      remoteSsh: {
+        title: "Remote SSH",
+        description: "Connect through the desktop SSH client.",
+      },
       scanQr: {
         title: "Scan QR code",
         description: "Encrypted relay connection.",
@@ -1574,6 +1578,27 @@ export const en = {
           "TLS error. Direct connections use SSL only when a TLS terminator is in front of the daemon.",
         unableToConnect: "Unable to connect. Check the host/port and that the daemon is reachable.",
         details: "Details: {{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "Remote SSH",
+      helper: "Connect to a Paseo daemon running on the remote host.",
+      fields: {
+        host: "Host",
+        port: "SSH port",
+        identityFile: "Identity file path",
+        optional: "Optional",
+      },
+      actions: {
+        cancel: "Cancel",
+        connect: "Connect",
+        connecting: "Connecting...",
+      },
+      errors: {
+        hostRequired: "Host is required",
+        invalidHost: "Enter a valid SSH host",
+        invalidPort: "SSH port must be between 1 and 65535",
+        failedToConnect: "Unable to connect over SSH. {{detail}}",
       },
     },
     link: {
@@ -2252,6 +2277,7 @@ export const en = {
       badges: {
         relay: "Relay",
         local: "Local",
+        remoteSsh: "Remote SSH",
       },
       connections: {
         title: "Connections",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1559,6 +1559,10 @@ export const es: TranslationResources = {
         title: "Conexión directa",
         description: "Red local o VPN.",
       },
+      remoteSsh: {
+        title: "SSH remoto",
+        description: "Conéctate mediante el cliente SSH de escritorio.",
+      },
       scanQr: {
         title: "Escanea el códigoQR",
         description: "Conexión de retransmisión cifrada.",
@@ -1609,6 +1613,27 @@ export const es: TranslationResources = {
         unableToConnect:
           "No se puede conectar. Verifique el host/porty que se pueda acceder al demonio.",
         details: "Detalles:{{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "SSH remoto",
+      helper: "Conéctate a un daemon de Paseo en el host remoto.",
+      fields: {
+        host: "Host",
+        port: "Puerto SSH",
+        identityFile: "Ruta del archivo de identidad",
+        optional: "Opcional",
+      },
+      actions: {
+        cancel: "Cancelar",
+        connect: "Conectar",
+        connecting: "Conectando...",
+      },
+      errors: {
+        hostRequired: "El host es obligatorio",
+        invalidHost: "Introduce un host SSH válido",
+        invalidPort: "El puerto SSH debe estar entre 1 y 65535",
+        failedToConnect: "No se pudo conectar por SSH. {{detail}}",
       },
     },
     link: {
@@ -2239,6 +2264,7 @@ export const es: TranslationResources = {
       badges: {
         relay: "Relé",
         local: "Local",
+        remoteSsh: "SSH remoto",
       },
       connections: {
         title: "Conexiones",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1563,6 +1563,10 @@ export const fr: TranslationResources = {
         title: "Connexion directe",
         description: "Réseau local ou VPN.",
       },
+      remoteSsh: {
+        title: "SSH distant",
+        description: "Connectez-vous avec le client SSH de bureau.",
+      },
       scanQr: {
         title: "Scanner le codeQR",
         description: "Connexion relais cryptée.",
@@ -1613,6 +1617,27 @@ export const fr: TranslationResources = {
         unableToConnect:
           "Impossible de se connecter. Vérifiez l'hôte/portet que le démon est accessible.",
         details: "Détails:{{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "SSH distant",
+      helper: "Connectez-vous à un daemon Paseo sur l’hôte distant.",
+      fields: {
+        host: "Hôte",
+        port: "Port SSH",
+        identityFile: "Chemin du fichier d’identité",
+        optional: "Facultatif",
+      },
+      actions: {
+        cancel: "Annuler",
+        connect: "Connecter",
+        connecting: "Connexion...",
+      },
+      errors: {
+        hostRequired: "L’hôte est requis",
+        invalidHost: "Saisissez un hôte SSH valide",
+        invalidPort: "Le port SSH doit être compris entre 1 et 65535",
+        failedToConnect: "Connexion SSH impossible. {{detail}}",
       },
     },
     link: {
@@ -2244,6 +2269,7 @@ export const fr: TranslationResources = {
       badges: {
         relay: "Relais",
         local: "Locale",
+        remoteSsh: "SSH distant",
       },
       connections: {
         title: "Relations",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1530,6 +1530,10 @@ export const ja: TranslationResources = {
         title: "直接接続",
         description: "ローカルネットワークまたはVPN。",
       },
+      remoteSsh: {
+        title: "リモート SSH",
+        description: "デスクトップの SSH クライアント経由で接続します。",
+      },
       scanQr: {
         title: "QRコードをスキャン",
         description: "暗号化されたリレー接続。",
@@ -1579,6 +1583,27 @@ export const ja: TranslationResources = {
         tlsError: "TLSエラー。直接接続は、デーモンの前にTLS終端がある場合のみSSLを使用します。",
         unableToConnect: "接続できません。ホスト/ポートとデーモンが到達可能かを確認してください。",
         details: "詳細: {{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "リモート SSH",
+      helper: "リモートホストで動作する Paseo デーモンに接続します。",
+      fields: {
+        host: "ホスト",
+        port: "SSH ポート",
+        identityFile: "秘密鍵ファイルのパス",
+        optional: "任意",
+      },
+      actions: {
+        cancel: "キャンセル",
+        connect: "接続",
+        connecting: "接続中...",
+      },
+      errors: {
+        hostRequired: "ホストは必須です",
+        invalidHost: "有効な SSH ホストを入力してください",
+        invalidPort: "SSH ポートは 1 から 65535 の間で指定してください",
+        failedToConnect: "SSH で接続できません。{{detail}}",
       },
     },
     link: {
@@ -2207,6 +2232,7 @@ export const ja: TranslationResources = {
       badges: {
         relay: "リレー",
         local: "ローカル",
+        remoteSsh: "リモート SSH",
       },
       connections: {
         title: "接続",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1525,6 +1525,10 @@ export const ko: TranslationResources = {
         title: "직접 연결",
         description: "로컬 네트워크 또는 VPN.",
       },
+      remoteSsh: {
+        title: "원격 SSH",
+        description: "데스크톱 SSH 클라이언트를 통해 연결합니다.",
+      },
       scanQr: {
         title: "QR 코드 스캔",
         description: "암호화된 릴레이 연결.",
@@ -1573,6 +1577,27 @@ export const ko: TranslationResources = {
         tlsError: "TLS 오류. 직접 연결은 데몬 앞에 TLS 종단 장치가 있을 때만 SSL을 사용합니다.",
         unableToConnect: "연결할 수 없습니다. 호스트/포트와 데몬에 접근 가능한지 확인하세요.",
         details: "세부 정보: {{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "원격 SSH",
+      helper: "원격 호스트에서 실행 중인 Paseo 데몬에 연결합니다.",
+      fields: {
+        host: "호스트",
+        port: "SSH 포트",
+        identityFile: "ID 파일 경로",
+        optional: "선택 사항",
+      },
+      actions: {
+        cancel: "취소",
+        connect: "연결",
+        connecting: "연결 중...",
+      },
+      errors: {
+        hostRequired: "호스트가 필요합니다",
+        invalidHost: "유효한 SSH 호스트를 입력하세요",
+        invalidPort: "SSH 포트는 1에서 65535 사이여야 합니다",
+        failedToConnect: "SSH로 연결할 수 없습니다. {{detail}}",
       },
     },
     link: {
@@ -2199,6 +2224,7 @@ export const ko: TranslationResources = {
       badges: {
         relay: "릴레이",
         local: "로컬",
+        remoteSsh: "원격 SSH",
       },
       connections: {
         title: "연결",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1545,6 +1545,10 @@ export const ptBR: TranslationResources = {
         title: "Conexão direta",
         description: "Rede local ou VPN.",
       },
+      remoteSsh: {
+        title: "SSH remoto",
+        description: "Conecte-se pelo cliente SSH do desktop.",
+      },
       scanQr: {
         title: "Escanear QR code",
         description: "Conexão relay criptografada.",
@@ -1595,6 +1599,27 @@ export const ptBR: TranslationResources = {
         unableToConnect:
           "Não foi possível conectar. Verifique o host/porta e se o daemon está acessível.",
         details: "Detalhes: {{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "SSH remoto",
+      helper: "Conecte-se a um daemon Paseo no host remoto.",
+      fields: {
+        host: "Host",
+        port: "Porta SSH",
+        identityFile: "Caminho do arquivo de identidade",
+        optional: "Opcional",
+      },
+      actions: {
+        cancel: "Cancelar",
+        connect: "Conectar",
+        connecting: "Conectando...",
+      },
+      errors: {
+        hostRequired: "O host é obrigatório",
+        invalidHost: "Insira um host SSH válido",
+        invalidPort: "A porta SSH deve estar entre 1 e 65535",
+        failedToConnect: "Não foi possível conectar por SSH. {{detail}}",
       },
     },
     link: {
@@ -2223,6 +2248,7 @@ export const ptBR: TranslationResources = {
       badges: {
         relay: "Relay",
         local: "Local",
+        remoteSsh: "SSH remoto",
       },
       connections: {
         title: "Conexões",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1548,6 +1548,10 @@ export const ru: TranslationResources = {
         title: "Прямое подключение",
         description: "Локальная сеть или VPN.",
       },
+      remoteSsh: {
+        title: "Удалённый SSH",
+        description: "Подключение через SSH-клиент настольного приложения.",
+      },
       scanQr: {
         title: "Сканировать код QR",
         description: "Зашифрованное релейное соединение.",
@@ -1598,6 +1602,27 @@ export const ru: TranslationResources = {
         unableToConnect:
           "Не удалось подключиться. Проверьте хост /port и убедитесь, что демон доступен.",
         details: "Подробности:{{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "Удалённый SSH",
+      helper: "Подключитесь к демону Paseo на удалённом хосте.",
+      fields: {
+        host: "Хост",
+        port: "Порт SSH",
+        identityFile: "Путь к файлу ключа",
+        optional: "Необязательно",
+      },
+      actions: {
+        cancel: "Отмена",
+        connect: "Подключить",
+        connecting: "Подключение...",
+      },
+      errors: {
+        hostRequired: "Укажите хост",
+        invalidHost: "Укажите корректный SSH-хост",
+        invalidPort: "Порт SSH должен быть от 1 до 65535",
+        failedToConnect: "Не удалось подключиться по SSH. {{detail}}",
       },
     },
     link: {
@@ -2228,6 +2253,7 @@ export const ru: TranslationResources = {
       badges: {
         relay: "Реле",
         local: "Местный",
+        remoteSsh: "Удалённый SSH",
       },
       connections: {
         title: "Соединения",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1498,6 +1498,10 @@ export const zhCN: TranslationResources = {
         title: "直接连接",
         description: "本地网络或 VPN。",
       },
+      remoteSsh: {
+        title: "远程 SSH",
+        description: "通过桌面 SSH 客户端连接。",
+      },
       scanQr: {
         title: "扫描二维码",
         description: "加密 relay 连接。",
@@ -1546,6 +1550,27 @@ export const zhCN: TranslationResources = {
         tlsError: "TLS 错误。只有 daemon 前方有 TLS terminator 时，直接连接才使用 SSL。",
         unableToConnect: "无法连接。请检查 host/port，并确认 daemon 可达。",
         details: "详情：{{detail}}",
+      },
+    },
+    remoteSsh: {
+      title: "远程 SSH",
+      helper: "连接到远程主机上运行的 Paseo 守护进程。",
+      fields: {
+        host: "主机",
+        port: "SSH 端口",
+        identityFile: "身份文件路径",
+        optional: "可选",
+      },
+      actions: {
+        cancel: "取消",
+        connect: "连接",
+        connecting: "正在连接...",
+      },
+      errors: {
+        hostRequired: "主机为必填项",
+        invalidHost: "请输入有效的 SSH 主机",
+        invalidPort: "SSH 端口必须介于 1 和 65535 之间",
+        failedToConnect: "无法通过 SSH 连接。{{detail}}",
       },
     },
     link: {
@@ -2164,6 +2189,7 @@ export const zhCN: TranslationResources = {
       badges: {
         relay: "Relay",
         local: "本地",
+        remoteSsh: "远程 SSH",
       },
       connections: {
         title: "连接",

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "@getpaseo/client/internal/daemon-client";
 import {
   connectionFromListen,
+  createRemoteSshHostConnection,
   normalizeStoredHostProfile,
   upsertHostConnectionInProfiles,
   registryHasConnection,
@@ -38,8 +39,8 @@ import {
   type ConnectionProbeState,
 } from "@/utils/connection-selection";
 import {
-  buildLocalDaemonTransportUrl,
-  createDesktopLocalDaemonTransportFactory,
+  buildDesktopDaemonTransportUrl,
+  createDesktopDaemonTransportFactory,
 } from "@/desktop/daemon/desktop-daemon-transport";
 import { getDesktopHost } from "@/desktop/host";
 import { CLIENT_CAPS } from "@getpaseo/protocol/client-capabilities";
@@ -73,6 +74,7 @@ export type ActiveConnection =
   | { type: "directTcp"; endpoint: string; display: string }
   | { type: "directSocket"; endpoint: string; display: "socket" }
   | { type: "directPipe"; endpoint: string; display: "pipe" }
+  | { type: "remoteSsh"; endpoint: string; display: string }
   | { type: "relay"; endpoint: string; display: "relay" };
 
 export type HostRuntimeAgentDirectoryStatus =
@@ -202,6 +204,13 @@ function toActiveConnection(connection: HostConnection): ActiveConnection {
       type: "directPipe",
       endpoint: connection.path,
       display: "pipe",
+    };
+  }
+  if (connection.type === "remoteSsh") {
+    return {
+      type: "remoteSsh",
+      endpoint: connection.host,
+      display: connection.host,
     };
   }
   if (connection.type === "directTcp") {
@@ -485,7 +494,7 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
 
   return {
     createClient: ({ host, connection, clientId, runtimeGeneration }) => {
-      const localTransportFactory = createDesktopLocalDaemonTransportFactory();
+      const desktopTransportFactory = createDesktopDaemonTransportFactory();
       const webSocketConfig = { webSocketFactory: createAppWebSocketFactory() };
       const base = {
         suppressSendErrors: true,
@@ -499,10 +508,25 @@ function createDefaultDeps(): HostRuntimeControllerDeps {
       if (connection.type === "directSocket" || connection.type === "directPipe") {
         return new DaemonClient({
           ...base,
-          ...(localTransportFactory ? { transportFactory: localTransportFactory } : {}),
-          url: buildLocalDaemonTransportUrl({
+          ...(desktopTransportFactory ? { transportFactory: desktopTransportFactory } : {}),
+          url: buildDesktopDaemonTransportUrl({
             transportType: connection.type === "directSocket" ? "socket" : "pipe",
             transportPath: connection.path,
+          }),
+        });
+      }
+      if (connection.type === "remoteSsh") {
+        if (!desktopTransportFactory) {
+          throw new Error("Remote SSH is only available in the desktop app.");
+        }
+        return new DaemonClient({
+          ...base,
+          transportFactory: desktopTransportFactory,
+          url: buildDesktopDaemonTransportUrl({
+            transportType: "ssh",
+            host: connection.host,
+            ...(connection.sshPort !== undefined ? { sshPort: connection.sshPort } : {}),
+            ...(connection.identityFile ? { identityFile: connection.identityFile } : {}),
           }),
         });
       }
@@ -1738,6 +1762,18 @@ export class HostRuntimeStore {
     });
   }
 
+  async probeAndUpsertRemoteSshConnection(input: {
+    host: string;
+    sshPort?: number;
+    identityFile?: string;
+    label?: string;
+  }): Promise<{ profile: HostProfile; serverId: string; hostname: string | null }> {
+    return this.probeAndUpsertConnection({
+      label: input.label,
+      connection: createRemoteSshHostConnection(input),
+    });
+  }
+
   async upsertRelayConnection(input: {
     serverId: string;
     relayEndpoint: string;
@@ -2484,6 +2520,12 @@ export interface HostMutations {
     password?: string;
     label?: string;
   }) => Promise<{ profile: HostProfile; serverId: string; hostname: string | null }>;
+  probeAndUpsertRemoteSshConnection: (input: {
+    host: string;
+    sshPort?: number;
+    identityFile?: string;
+    label?: string;
+  }) => Promise<{ profile: HostProfile; serverId: string; hostname: string | null }>;
   upsertRelayConnection: (input: {
     serverId: string;
     relayEndpoint: string;
@@ -2509,6 +2551,7 @@ export function useHostMutations(): HostMutations {
     () => ({
       upsertDirectConnection: (input) => store.upsertDirectConnection(input),
       probeAndUpsertDirectConnection: (input) => store.probeAndUpsertDirectConnection(input),
+      probeAndUpsertRemoteSshConnection: (input) => store.probeAndUpsertRemoteSshConnection(input),
       upsertRelayConnection: (input) => store.upsertRelayConnection(input),
       upsertConnectionFromOffer: (offer, label) => store.upsertConnectionFromOffer(offer, label),
       upsertConnectionFromOfferUrl: (url, label) => store.upsertConnectionFromOfferUrl(url, label),

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -72,6 +72,7 @@ import { BackHeader } from "@/components/headers/back-header";
 import { ScreenHeader } from "@/components/headers/screen-header";
 import { AddHostMethodModal } from "@/components/add-host-method-modal";
 import { AddHostModal } from "@/components/add-host-modal";
+import { AddRemoteSshHostModal } from "@/components/add-remote-ssh-host-modal";
 import { PairLinkModal } from "@/components/pair-link-modal";
 import { KeyboardShortcutsSection } from "@/screens/settings/keyboard-shortcuts-section";
 import { EditorSection } from "@/screens/settings/editor-section";
@@ -1144,6 +1145,7 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const { settings, isLoading: settingsLoading, updateSettings } = useAppSettings();
   const [isAddHostMethodVisible, setIsAddHostMethodVisible] = useState(false);
   const [isDirectHostVisible, setIsDirectHostVisible] = useState(false);
+  const [isRemoteSshVisible, setIsRemoteSshVisible] = useState(false);
   const [isPasteLinkVisible, setIsPasteLinkVisible] = useState(false);
   const [isPlaybackTestRunning, setIsPlaybackTestRunning] = useState(false);
   const [playbackTestResult, setPlaybackTestResult] = useState<string | null>(null);
@@ -1250,11 +1252,13 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const closeAddConnectionFlow = useCallback(() => {
     setIsAddHostMethodVisible(false);
     setIsDirectHostVisible(false);
+    setIsRemoteSshVisible(false);
     setIsPasteLinkVisible(false);
   }, []);
 
   const goBackToAddConnectionMethods = useCallback(() => {
     setIsDirectHostVisible(false);
+    setIsRemoteSshVisible(false);
     setIsPasteLinkVisible(false);
     setIsAddHostMethodVisible(true);
   }, []);
@@ -1274,6 +1278,11 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
   const handleSelectDirectConnection = useCallback(() => {
     setIsAddHostMethodVisible(false);
     setIsDirectHostVisible(true);
+  }, []);
+
+  const handleSelectRemoteSsh = useCallback(() => {
+    setIsAddHostMethodVisible(false);
+    setIsRemoteSshVisible(true);
   }, []);
 
   const handleSelectPasteLink = useCallback(() => {
@@ -1484,11 +1493,18 @@ export default function SettingsScreen({ view, openAddHostIntent = null }: Setti
         visible={isAddHostMethodVisible}
         onClose={closeAddConnectionFlow}
         onDirectConnection={handleSelectDirectConnection}
+        onRemoteSsh={handleSelectRemoteSsh}
         onPasteLink={handleSelectPasteLink}
         onScanQr={handleScanQr}
       />
       <AddHostModal
         visible={isDirectHostVisible}
+        onClose={closeAddConnectionFlow}
+        onCancel={goBackToAddConnectionMethods}
+        onSaved={handleHostAdded}
+      />
+      <AddRemoteSshHostModal
+        visible={isRemoteSshVisible}
         onClose={closeAddConnectionFlow}
         onCancel={goBackToAddConnectionMethods}
         onSaved={handleHostAdded}

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -29,6 +29,7 @@ import { Alert as InlineAlert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { StatusBadge, type StatusBadgeVariant } from "@/components/ui/status-badge";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   ProfileDraft,
   TerminalProfileEditModal,
@@ -49,6 +50,7 @@ import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
 import {
   getHostRuntimeStore,
   isHostRuntimeConnected,
+  type HostRuntimeConnectionStatus,
   useHostMutations,
   useHostRuntimeClient,
   useHostRuntimeIsConnected,
@@ -111,6 +113,9 @@ function formatHostConnectionLabel(connection: HostConnection, t: TFunction): st
   if (connection.type === "directSocket" || connection.type === "directPipe") {
     return `${t("settings.host.badges.local")} (${connection.path})`;
   }
+  if (connection.type === "remoteSsh") {
+    return `${t("settings.host.badges.remoteSsh")} (${connection.host})`;
+  }
   return `TCP (${connection.endpoint})`;
 }
 
@@ -130,6 +135,12 @@ function formatActiveConnectionBadge(
     return {
       icon: <Monitor size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />,
       text: t("settings.host.badges.local"),
+    };
+  }
+  if (activeConnection.type === "remoteSsh") {
+    return {
+      icon: <Globe size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />,
+      text: t("settings.host.badges.remoteSsh"),
     };
   }
   return {
@@ -160,6 +171,47 @@ function HostNotFound() {
   );
 }
 
+function normalizeConnectionDetail(
+  status: HostRuntimeConnectionStatus,
+  error: string | null,
+): string | null {
+  const trimmed = error?.trim();
+  return status === "online" || !trimmed ? null : trimmed;
+}
+
+function ConnectionStatusPill({
+  label,
+  variant,
+  dotColor,
+  detail,
+}: {
+  label: string;
+  variant: StatusBadgeVariant;
+  dotColor: string;
+  detail: string | null;
+}) {
+  const dotStyle = useMemo(() => [styles.statusDot, { backgroundColor: dotColor }], [dotColor]);
+  const leading = useMemo(() => <View style={dotStyle} />, [dotStyle]);
+  const pill = (
+    <View testID="host-page-connection-status">
+      <StatusBadge label={label} variant={variant} leading={leading} />
+    </View>
+  );
+
+  if (!detail) return pill;
+
+  return (
+    <Tooltip delayDuration={250} enabledOnDesktop enabledOnMobile>
+      <TooltipTrigger accessibilityRole="button" accessibilityLabel={`${label}: ${detail}`}>
+        {pill}
+      </TooltipTrigger>
+      <TooltipContent side="top" align="start" offset={8} maxWidth={420}>
+        <Text style={styles.statusTooltipText}>{detail}</Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function HostStatusBadges({ serverId }: { serverId: string }) {
   const { t } = useTranslation();
   const { theme } = useUnistyles();
@@ -169,6 +221,8 @@ function HostStatusBadges({ serverId }: { serverId: string }) {
   );
 
   const connectionStatus = snapshot?.connectionStatus ?? "connecting";
+  const lastError = snapshot?.lastError ?? snapshot?.client?.lastError ?? null;
+  const connectionDetail = normalizeConnectionDetail(connectionStatus, lastError);
   const activeConnection = snapshot?.activeConnection ?? null;
   const statusLabel = formatConnectionStatus(connectionStatus);
   const statusTone = getConnectionStatusTone(connectionStatus);
@@ -187,15 +241,14 @@ function HostStatusBadges({ serverId }: { serverId: string }) {
   const connectionBadge = formatActiveConnectionBadge(activeConnection, theme, t);
   const versionBadgeText = formatDaemonVersionBadge(daemonVersion);
 
-  const statusDotStyle = useMemo(
-    () => [styles.statusDot, { backgroundColor: statusDotColor }],
-    [statusDotColor],
-  );
-  const statusLeading = useMemo(() => <View style={statusDotStyle} />, [statusDotStyle]);
-
   return (
     <View style={styles.identityBadges} testID="host-page-identity">
-      <StatusBadge label={statusLabel} variant={statusVariant} leading={statusLeading} />
+      <ConnectionStatusPill
+        label={statusLabel}
+        variant={statusVariant}
+        dotColor={statusDotColor}
+        detail={connectionDetail}
+      />
       {connectionBadge ? (
         <View style={styles.badgePill}>
           {connectionBadge.icon}
@@ -1828,6 +1881,11 @@ const styles = StyleSheet.create((theme) => ({
     width: 6,
     height: 6,
     borderRadius: theme.borderRadius.full,
+  },
+  statusTooltipText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    lineHeight: theme.fontSize.sm * 1.4,
   },
   badgePill: {
     flexDirection: "row",

--- a/packages/app/src/types/host-connection.test.ts
+++ b/packages/app/src/types/host-connection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { defaultHostAppearance } from "@/hosts/appearance";
 import {
+  createRemoteSshHostConnection,
   normalizeStoredHostProfile,
   orderHostsLocalFirst,
   resolveActiveHostServerId,
@@ -140,6 +141,48 @@ describe("normalizeStoredHostProfile", () => {
     });
 
     expect(profile?.appearance).toEqual({ color: "teal", badgeDisplay: "icon" });
+  });
+
+  it("normalizes stored Remote SSH connection parameters", () => {
+    const profile = normalizeStoredHostProfile({
+      serverId: "srv_ssh",
+      connections: [
+        {
+          type: "remoteSsh",
+          host: " deploy@example.com ",
+          sshPort: 2222,
+          identityFile: " ~/.ssh/paseo ",
+        },
+      ],
+    });
+
+    expect(profile?.connections[0]).toEqual({
+      id: "ssh:deploy%40example.com:2222:~%2F.ssh%2Fpaseo",
+      type: "remoteSsh",
+      host: "deploy@example.com",
+      sshPort: 2222,
+      identityFile: "~/.ssh/paseo",
+    });
+  });
+});
+
+describe("createRemoteSshHostConnection", () => {
+  it("keeps optional SSH settings absent", () => {
+    expect(createRemoteSshHostConnection({ host: "build-box" })).toEqual({
+      id: "ssh:build-box::",
+      type: "remoteSsh",
+      host: "build-box",
+    });
+  });
+
+  it("rejects invalid SSH destinations and ports", () => {
+    expect(() => createRemoteSshHostConnection({ host: "" })).toThrow("SSH host is required");
+    expect(() => createRemoteSshHostConnection({ host: "bad host" })).toThrow(
+      "SSH host is invalid",
+    );
+    expect(() => createRemoteSshHostConnection({ host: "build-box", sshPort: 70000 })).toThrow(
+      "SSH port must be between 1 and 65535",
+    );
   });
 });
 

--- a/packages/app/src/types/host-connection.ts
+++ b/packages/app/src/types/host-connection.ts
@@ -27,6 +27,14 @@ export interface DirectPipeHostConnection {
   path: string;
 }
 
+export interface RemoteSshHostConnection {
+  id: string;
+  type: "remoteSsh";
+  host: string;
+  sshPort?: number;
+  identityFile?: string;
+}
+
 export interface RelayHostConnection {
   id: string;
   type: "relay";
@@ -39,6 +47,7 @@ export type HostConnection =
   | DirectTcpHostConnection
   | DirectSocketHostConnection
   | DirectPipeHostConnection
+  | RemoteSshHostConnection
   | RelayHostConnection;
 
 export type HostLifecycle = Record<string, never>;
@@ -123,6 +132,9 @@ function hostConnectionEquals(left: HostConnection, right: HostConnection): bool
   if (left.type === "directPipe" && right.type === "directPipe") {
     return left.path === right.path;
   }
+  if (left.type === "remoteSsh" && right.type === "remoteSsh") {
+    return remoteSshConnectionEquals(left, right);
+  }
   if (left.type === "relay" && right.type === "relay") {
     return (
       left.relayEndpoint === right.relayEndpoint &&
@@ -132,6 +144,17 @@ function hostConnectionEquals(left: HostConnection, right: HostConnection): bool
   }
 
   return false;
+}
+
+function remoteSshConnectionEquals(
+  left: RemoteSshHostConnection,
+  right: RemoteSshHostConnection,
+): boolean {
+  return (
+    left.host === right.host &&
+    left.sshPort === right.sshPort &&
+    left.identityFile === right.identityFile
+  );
 }
 
 function hostLifecycleEquals(left: HostLifecycle, right: HostLifecycle): boolean {
@@ -294,6 +317,41 @@ export function connectionFromListen(listen: string): HostConnection | null {
   }
 }
 
+export function createRemoteSshHostConnection(input: {
+  host: string;
+  sshPort?: number;
+  identityFile?: string;
+}): RemoteSshHostConnection {
+  const host = input.host.trim();
+  if (!host) {
+    throw new Error("SSH host is required");
+  }
+  if (/\s/.test(host) || host.startsWith("-")) {
+    throw new Error("SSH host is invalid");
+  }
+
+  const sshPort = input.sshPort;
+  if (sshPort !== undefined && (!Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535)) {
+    throw new Error("SSH port must be between 1 and 65535");
+  }
+
+  const identityFile = input.identityFile?.trim() || undefined;
+  const id = [
+    "ssh",
+    encodeURIComponent(host),
+    sshPort === undefined ? "" : String(sshPort),
+    encodeURIComponent(identityFile ?? ""),
+  ].join(":");
+
+  return {
+    id,
+    type: "remoteSsh",
+    host,
+    ...(sshPort !== undefined ? { sshPort } : {}),
+    ...(identityFile ? { identityFile } : {}),
+  };
+}
+
 const StoredHostConnectionSchema = z.discriminatedUnion("type", [
   z.strictObject({
     id: z.string().optional(),
@@ -311,6 +369,13 @@ const StoredHostConnectionSchema = z.discriminatedUnion("type", [
     id: z.string().optional(),
     type: z.literal("directPipe"),
     path: z.string(),
+  }),
+  z.strictObject({
+    id: z.string().optional(),
+    type: z.literal("remoteSsh"),
+    host: z.string(),
+    sshPort: z.number().optional(),
+    identityFile: z.string().optional(),
   }),
   z.strictObject({
     id: z.string().optional(),
@@ -355,6 +420,17 @@ function normalizeStoredConnection(connection: StoredHostConnection): HostConnec
   if (connection.type === "directPipe") {
     const path = connection.path.trim();
     return path ? { id: `pipe:${path}`, type: "directPipe", path } : null;
+  }
+  if (connection.type === "remoteSsh") {
+    try {
+      return createRemoteSshHostConnection({
+        host: connection.host,
+        ...(connection.sshPort !== undefined ? { sshPort: connection.sshPort } : {}),
+        ...(connection.identityFile !== undefined ? { identityFile: connection.identityFile } : {}),
+      });
+    } catch {
+      return null;
+    }
   }
   if (connection.type === "relay") {
     try {

--- a/packages/app/src/utils/test-daemon-connection.test.ts
+++ b/packages/app/src/utils/test-daemon-connection.test.ts
@@ -43,9 +43,13 @@ class FakeDaemonProbe {
       return "cid_shared_probe_test";
     },
     resolveAppVersion: () => null,
-    createLocalTransportFactory: () => null,
-    buildLocalTransportUrl: ({ transportType, transportPath }) =>
-      `paseo+local://${transportType}?path=${encodeURIComponent(transportPath)}`,
+    createDesktopTransportFactory: () => null,
+    buildDesktopTransportUrl: (target) => {
+      if (target.transportType === "ssh") {
+        return `paseo+desktop://ssh?host=${encodeURIComponent(target.host)}`;
+      }
+      return `paseo+desktop://${target.transportType}?path=${encodeURIComponent(target.transportPath)}`;
+    },
     createClient: (config) => {
       const client = new FakeDaemonClient(this, config);
       this.createdClients.push(client);
@@ -137,7 +141,32 @@ describe("test-daemon-connection connectToDaemon", () => {
     );
     await result.client.close();
 
-    expect(probe.createdConfigs()[0]?.url).toBe("paseo+local://socket?path=%2Ftmp%2Fpaseo.sock");
+    expect(probe.createdConfigs()[0]?.url).toBe("paseo+desktop://socket?path=%2Ftmp%2Fpaseo.sock");
+  });
+
+  it("uses the desktop transport for Remote SSH connections", async () => {
+    const { connectToDaemon } = await import("./test-daemon-connection");
+    const transportFactory = vi.fn();
+    const result = await connectToDaemon(
+      {
+        id: "ssh:deploy%40example.com:2222:%2Fkeys%2Fpaseo",
+        type: "remoteSsh",
+        host: "deploy@example.com",
+        sshPort: 2222,
+        identityFile: "/keys/paseo",
+      },
+      undefined,
+      {
+        ...probe.deps,
+        createDesktopTransportFactory: () => transportFactory,
+      },
+    );
+    await result.client.close();
+
+    expect(probe.createdConfigs()[0]).toMatchObject({
+      url: "paseo+desktop://ssh?host=deploy%40example.com",
+      transportFactory,
+    });
   });
 
   it("passes direct TCP connection passwords into the client config", async () => {

--- a/packages/app/src/utils/test-daemon-connection.ts
+++ b/packages/app/src/utils/test-daemon-connection.ts
@@ -9,9 +9,10 @@ import {
   shouldUseTlsForDefaultHostedRelay,
 } from "./daemon-endpoints";
 import {
-  buildLocalDaemonTransportUrl,
-  createDesktopLocalDaemonTransportFactory,
+  buildDesktopDaemonTransportUrl,
+  createDesktopDaemonTransportFactory,
 } from "@/desktop/daemon/desktop-daemon-transport";
+import type { DesktopDaemonTransportTarget } from "@/desktop/daemon/desktop-daemon";
 
 export interface DaemonProbeClient {
   readonly lastError: string | null;
@@ -20,26 +21,42 @@ export interface DaemonProbeClient {
   getLastServerInfoMessage(): { serverId: string; hostname: string | null } | null;
 }
 
-interface LocalTransportUrlInput {
-  transportType: "socket" | "pipe";
-  transportPath: string;
-}
-
 export interface DaemonConnectionDependencies<TClient extends DaemonProbeClient> {
   getClientId(): Promise<string>;
   resolveAppVersion(): string | null;
-  createLocalTransportFactory(): DaemonClientConfig["transportFactory"] | null;
-  buildLocalTransportUrl(input: LocalTransportUrlInput): string;
+  createDesktopTransportFactory(): DaemonClientConfig["transportFactory"] | null;
+  buildDesktopTransportUrl(input: DesktopDaemonTransportTarget): string;
   createClient(config: DaemonClientConfig): TClient;
 }
 
 const defaultDaemonConnectionDependencies: DaemonConnectionDependencies<DaemonClient> = {
   getClientId: getOrCreateClientId,
   resolveAppVersion,
-  createLocalTransportFactory: createDesktopLocalDaemonTransportFactory,
-  buildLocalTransportUrl: buildLocalDaemonTransportUrl,
+  createDesktopTransportFactory: createDesktopDaemonTransportFactory,
+  buildDesktopTransportUrl: buildDesktopDaemonTransportUrl,
   createClient: (config) => new DaemonClient(config),
 };
+
+function buildRemoteSshClientConfig(input: {
+  connection: Extract<HostConnection, { type: "remoteSsh" }>;
+  base: Omit<DaemonClientConfig, "url">;
+  desktopTransportFactory: DaemonClientConfig["transportFactory"] | null;
+  buildDesktopTransportUrl: (target: DesktopDaemonTransportTarget) => string;
+}): DaemonClientConfig {
+  if (!input.desktopTransportFactory) {
+    throw new Error("Remote SSH is only available in the desktop app.");
+  }
+  return {
+    ...input.base,
+    transportFactory: input.desktopTransportFactory,
+    url: input.buildDesktopTransportUrl({
+      transportType: "ssh",
+      host: input.connection.host,
+      ...(input.connection.sshPort !== undefined ? { sshPort: input.connection.sshPort } : {}),
+      ...(input.connection.identityFile ? { identityFile: input.connection.identityFile } : {}),
+    }),
+  };
+}
 
 function normalizeNonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -103,11 +120,14 @@ export async function buildClientConfig(
   },
   deps: Pick<
     DaemonConnectionDependencies<DaemonProbeClient>,
-    "getClientId" | "resolveAppVersion" | "createLocalTransportFactory" | "buildLocalTransportUrl"
+    | "getClientId"
+    | "resolveAppVersion"
+    | "createDesktopTransportFactory"
+    | "buildDesktopTransportUrl"
   > = defaultDaemonConnectionDependencies,
 ): Promise<DaemonClientConfig> {
   const clientId = await deps.getClientId();
-  const localTransportFactory = deps.createLocalTransportFactory();
+  const desktopTransportFactory = deps.createDesktopTransportFactory();
   const base = {
     clientId,
     clientType: "mobile" as const,
@@ -117,19 +137,28 @@ export async function buildClientConfig(
     ...(options?.capabilities ? { capabilities: options.capabilities } : {}),
     ...(options?.trace ? { trace: options.trace } : {}),
     ...((connection.type === "directSocket" || connection.type === "directPipe") &&
-    localTransportFactory
-      ? { transportFactory: localTransportFactory }
+    desktopTransportFactory
+      ? { transportFactory: desktopTransportFactory }
       : {}),
   };
 
   if (connection.type === "directSocket" || connection.type === "directPipe") {
     return {
       ...base,
-      url: deps.buildLocalTransportUrl({
+      url: deps.buildDesktopTransportUrl({
         transportType: connection.type === "directSocket" ? "socket" : "pipe",
         transportPath: connection.path,
       }),
     };
+  }
+
+  if (connection.type === "remoteSsh") {
+    return buildRemoteSshClientConfig({
+      connection,
+      base,
+      desktopTransportFactory,
+      buildDesktopTransportUrl: deps.buildDesktopTransportUrl,
+    });
   }
 
   if (connection.type === "directTcp") {
@@ -233,7 +262,9 @@ interface ProbeOptions {
 
 function resolveTimeout(connection: HostConnection, options?: ProbeOptions): number {
   if (options?.timeoutMs) return options.timeoutMs;
-  return connection.type === "relay" ? 10_000 : 6_000;
+  if (connection.type === "relay") return 10_000;
+  if (connection.type === "remoteSsh") return 15_000;
+  return 6_000;
 }
 
 export function connectToDaemon(

--- a/packages/desktop/src/daemon/daemon-manager.ts
+++ b/packages/desktop/src/daemon/daemon-manager.ts
@@ -536,10 +536,7 @@ export function createDaemonCommandHandlers(): Record<string, DesktopCommandHand
     read_file_base64: (args) => readManagedFileBase64(args ?? {}),
     delete_attachment_file: (args) => deleteManagedAttachmentFile(args ?? {}),
     garbage_collect_attachment_files: (args) => garbageCollectManagedAttachmentFiles(args ?? {}),
-    open_local_daemon_transport: async (args) => {
-      const target = args as { transportType: "socket" | "pipe"; transportPath: string };
-      return await openLocalTransportSession(target);
-    },
+    open_local_daemon_transport: async (args) => await openLocalTransportSession(args),
     send_local_daemon_transport_message: async (args) => {
       await sendLocalTransportMessage(
         args as { sessionId: string; text?: string; binaryBase64?: string },

--- a/packages/desktop/src/daemon/local-transport.test.ts
+++ b/packages/desktop/src/daemon/local-transport.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSshArgs,
+  createLocalTransportManager,
+  LOCAL_TRANSPORT_SETUP_TIMEOUT_MS,
+  parseTransportTarget,
+  type TransportEndpoint,
+  type TransportEventPayload,
+  type TransportWebSocket,
+} from "./local-transport";
+
+const SESSION_INPUT = {
+  sessionId: "local-session-test",
+  target: { transportType: "ssh", host: "build-box" },
+} as const;
+
+function createConnectingSocket(): TransportWebSocket & {
+  close: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+} {
+  return {
+    readyState: 0,
+    once: vi.fn(),
+    on: vi.fn(),
+    send: vi.fn(),
+    close: vi.fn(),
+    terminate: vi.fn(),
+  } as unknown as TransportWebSocket & {
+    close: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createEndpoint(): TransportEndpoint & { close: ReturnType<typeof vi.fn> } {
+  return {
+    url: "ws://127.0.0.1:12345/ws",
+    close: vi.fn(),
+    failureDetail: () => null,
+  };
+}
+
+interface ScheduledTimeout {
+  callback: () => void;
+  delayMs: number;
+  cancelled: boolean;
+}
+
+function createManagerHarness(
+  resolveEndpoint: () => Promise<TransportEndpoint>,
+  sockets: TransportWebSocket[],
+) {
+  const events: TransportEventPayload[] = [];
+  const scheduledTimeouts: ScheduledTimeout[] = [];
+  const createWebSocket = vi.fn(() => {
+    const socket = sockets.shift();
+    if (!socket) {
+      throw new Error("No fake WebSocket is available");
+    }
+    return socket;
+  });
+  const manager = createLocalTransportManager({
+    resolveEndpoint,
+    createWebSocket,
+    scheduleTimeout(callback, delayMs) {
+      const scheduled = { callback, delayMs, cancelled: false };
+      scheduledTimeouts.push(scheduled);
+      return () => {
+        scheduled.cancelled = true;
+      };
+    },
+    emitEvent: (event) => events.push(event),
+  });
+  return { createWebSocket, events, manager, scheduledTimeouts };
+}
+
+describe("Remote SSH desktop transport", () => {
+  it("builds a batch-mode SSH stdio tunnel with optional connection settings", () => {
+    expect(
+      buildSshArgs({
+        transportType: "ssh",
+        host: "deploy@example.com",
+        sshPort: 2222,
+        identityFile: "/Users/example/.ssh/paseo",
+      }),
+    ).toEqual([
+      "-T",
+      "-S",
+      "none",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "-o",
+      "ClearAllForwardings=yes",
+      "-o",
+      "ExitOnForwardFailure=yes",
+      "-p",
+      "2222",
+      "-i",
+      "/Users/example/.ssh/paseo",
+      "-W",
+      "127.0.0.1:6767",
+      "deploy@example.com",
+    ]);
+  });
+
+  it("rejects unsafe SSH targets at the IPC boundary", () => {
+    expect(() =>
+      parseTransportTarget({ transportType: "ssh", host: "-oProxyCommand=bad" }),
+    ).toThrow("SSH host is invalid");
+    expect(() =>
+      parseTransportTarget({ transportType: "ssh", host: "build-box", sshPort: 0 }),
+    ).toThrow("SSH port must be between 1 and 65535");
+  });
+});
+
+describe("local transport session lifecycle", () => {
+  it("releases an opening transport when its setup deadline expires", async () => {
+    const firstEndpoint = createEndpoint();
+    const secondEndpoint = createEndpoint();
+    const firstSocket = createConnectingSocket();
+    const secondSocket = createConnectingSocket();
+    const endpoints = [firstEndpoint, secondEndpoint];
+    const { events, manager, scheduledTimeouts } = createManagerHarness(
+      async () => endpoints.shift() ?? createEndpoint(),
+      [firstSocket, secondSocket],
+    );
+
+    manager.open(SESSION_INPUT);
+    await Promise.resolve();
+
+    expect(scheduledTimeouts[0]?.delayMs).toBe(LOCAL_TRANSPORT_SETUP_TIMEOUT_MS);
+    scheduledTimeouts[0]?.callback();
+
+    expect(firstSocket.terminate).toHaveBeenCalledTimes(1);
+    expect(firstEndpoint.close).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      {
+        sessionId: SESSION_INPUT.sessionId,
+        kind: "error",
+        error: "Connection to Remote SSH host build-box timed out during setup.",
+      },
+    ]);
+
+    manager.close(SESSION_INPUT.sessionId);
+    expect(firstSocket.terminate).toHaveBeenCalledTimes(1);
+    expect(firstEndpoint.close).toHaveBeenCalledTimes(1);
+
+    expect(() => manager.open(SESSION_INPUT)).not.toThrow();
+    await Promise.resolve();
+    manager.close(SESSION_INPUT.sessionId);
+    expect(secondSocket.terminate).toHaveBeenCalledTimes(1);
+    expect(secondEndpoint.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a connecting transport when the caller closes it", async () => {
+    const endpoint = createEndpoint();
+    const socket = createConnectingSocket();
+    const { events, manager, scheduledTimeouts } = createManagerHarness(
+      async () => endpoint,
+      [socket],
+    );
+
+    manager.open(SESSION_INPUT);
+    await Promise.resolve();
+    manager.close(SESSION_INPUT.sessionId);
+    manager.close(SESSION_INPUT.sessionId);
+
+    expect(socket.terminate).toHaveBeenCalledTimes(1);
+    expect(endpoint.close).toHaveBeenCalledTimes(1);
+    expect(scheduledTimeouts[0]?.cancelled).toBe(true);
+    expect(events).toEqual([]);
+  });
+
+  it("closes an endpoint that resolves after the caller cancels setup", async () => {
+    const endpoint = createEndpoint();
+    let resolveEndpoint: ((endpoint: TransportEndpoint) => void) | null = null;
+    const endpointPromise = new Promise<TransportEndpoint>((resolve) => {
+      resolveEndpoint = resolve;
+    });
+    const socket = createConnectingSocket();
+    const { createWebSocket, events, manager } = createManagerHarness(
+      () => endpointPromise,
+      [socket],
+    );
+
+    manager.open(SESSION_INPUT);
+    manager.close(SESSION_INPUT.sessionId);
+    resolveEndpoint?.(endpoint);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(endpoint.close).toHaveBeenCalledTimes(1);
+    expect(createWebSocket).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/desktop/src/daemon/local-transport.ts
+++ b/packages/desktop/src/daemon/local-transport.ts
@@ -1,12 +1,23 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createServer, type Server, type Socket } from "node:net";
 import { BrowserWindow } from "electron";
 import { WebSocket, type RawData } from "ws";
 
-interface TransportTarget {
+export interface LocalTransportTarget {
   transportType: "socket" | "pipe";
   transportPath: string;
 }
 
-interface TransportEventPayload {
+export interface SshTransportTarget {
+  transportType: "ssh";
+  host: string;
+  sshPort?: number;
+  identityFile?: string;
+}
+
+export type TransportTarget = LocalTransportTarget | SshTransportTarget;
+
+export interface TransportEventPayload {
   sessionId: string;
   kind: "open" | "message" | "close" | "error";
   text?: string | null;
@@ -18,14 +29,53 @@ interface TransportEventPayload {
 
 interface Session {
   id: string;
-  ws: WebSocket;
-  state: "opening" | "open" | "closing" | "closed";
+  target: TransportTarget;
+  ws: TransportWebSocket | null;
+  state: "opening" | "open" | "closed";
+  closeTarget: (() => void) | null;
+  cancelSetupDeadline: () => void;
+}
+
+interface OpenTransportSessionInput {
+  sessionId: string;
+  target: TransportTarget;
+}
+
+export interface TransportEndpoint {
+  url: string;
+  close: () => void;
+  failureDetail: () => string | null;
+}
+
+export interface TransportWebSocket {
+  readonly readyState: number;
+  once(event: "open", listener: () => void): void;
+  on(event: "message", listener: (data: RawData, isBinary: boolean) => void): void;
+  on(event: "close", listener: (code: number, reason?: Buffer | string) => void): void;
+  on(event: "error", listener: (error: Error) => void): void;
+  send(data: string | Buffer, callback: (error?: Error) => void): void;
+  close(): void;
+  terminate(): void;
+}
+
+export interface LocalTransportManagerDependencies {
+  resolveEndpoint(target: TransportTarget): Promise<TransportEndpoint>;
+  createWebSocket(url: string): TransportWebSocket;
+  scheduleTimeout(callback: () => void, delayMs: number): () => void;
+  emitEvent(payload: TransportEventPayload): void;
+}
+
+export interface LocalTransportManager {
+  open(rawInput: unknown): void;
+  send(input: { sessionId: string; text?: string; binaryBase64?: string }): Promise<void>;
+  close(sessionId: string): void;
+  closeAll(): void;
 }
 
 const WS_ENDPOINT_PATH = "/ws";
-
-let nextSessionId = 0;
-const sessions = new Map<string, Session>();
+const REMOTE_DAEMON_ENDPOINT = "127.0.0.1:6767";
+const SSH_STDERR_LIMIT = 8192;
+export const LOCAL_TRANSPORT_SETUP_TIMEOUT_MS = 30_000;
 
 function emitTransportEvent(payload: TransportEventPayload): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -43,13 +93,196 @@ function emitTransportEvent(payload: TransportEventPayload): void {
  * The part before `:` is the IPC path, the part after is the HTTP request
  * path used during the WebSocket upgrade handshake.
  */
-function buildLocalWebSocketUrl(target: TransportTarget): string {
+function buildLocalWebSocketUrl(target: LocalTransportTarget): string {
   const ipcPath = target.transportPath;
   return `ws+unix://${ipcPath}:${WS_ENDPOINT_PATH}`;
 }
 
 function describeTransportTarget(target: TransportTarget): string {
+  if (target.transportType === "ssh") {
+    return `Remote SSH host ${target.host}`;
+  }
   return target.transportType === "pipe" ? "local daemon pipe" : "local daemon socket";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseTransportTarget(value: unknown): TransportTarget {
+  if (!isRecord(value)) {
+    throw new Error("Desktop transport target must be an object.");
+  }
+
+  if (value.transportType === "socket" || value.transportType === "pipe") {
+    const transportPath = typeof value.transportPath === "string" ? value.transportPath.trim() : "";
+    if (!transportPath) {
+      throw new Error("Local transport path is required.");
+    }
+    return { transportType: value.transportType, transportPath };
+  }
+
+  if (value.transportType !== "ssh") {
+    throw new Error("Unsupported desktop transport type.");
+  }
+
+  const host = typeof value.host === "string" ? value.host.trim() : "";
+  if (!host) {
+    throw new Error("SSH host is required.");
+  }
+  if (/\s/.test(host) || host.startsWith("-")) {
+    throw new Error("SSH host is invalid.");
+  }
+
+  const sshPort = value.sshPort;
+  if (
+    sshPort !== undefined &&
+    (typeof sshPort !== "number" || !Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535)
+  ) {
+    throw new Error("SSH port must be between 1 and 65535.");
+  }
+
+  const identityFile =
+    typeof value.identityFile === "string" ? value.identityFile.trim() || undefined : undefined;
+  return {
+    transportType: "ssh",
+    host,
+    ...(sshPort !== undefined ? { sshPort } : {}),
+    ...(identityFile ? { identityFile } : {}),
+  };
+}
+
+function parseOpenTransportSessionInput(value: unknown): OpenTransportSessionInput {
+  if (!isRecord(value)) {
+    throw new Error("Desktop transport open input must be an object.");
+  }
+
+  const sessionId = typeof value.sessionId === "string" ? value.sessionId.trim() : "";
+  if (!/^[A-Za-z0-9_-]{1,128}$/u.test(sessionId)) {
+    throw new Error("Desktop transport session ID is invalid.");
+  }
+
+  return {
+    sessionId,
+    target: parseTransportTarget(value.target),
+  };
+}
+
+export function buildSshArgs(target: SshTransportTarget): string[] {
+  const args = [
+    "-T",
+    "-S",
+    "none",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ConnectTimeout=10",
+    "-o",
+    "ClearAllForwardings=yes",
+    "-o",
+    "ExitOnForwardFailure=yes",
+  ];
+  if (target.sshPort !== undefined) {
+    args.push("-p", String(target.sshPort));
+  }
+  if (target.identityFile) {
+    args.push("-i", target.identityFile);
+  }
+  args.push("-W", REMOTE_DAEMON_ENDPOINT, target.host);
+  return args;
+}
+
+function formatSshFailure(
+  stderr: string,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): string {
+  const detail = stderr.trim();
+  if (detail) return detail;
+  if (signal) return `ssh exited with signal ${signal}`;
+  return `ssh exited with code ${code ?? "unknown"}`;
+}
+
+function createSshProxy(target: SshTransportTarget): Promise<TransportEndpoint> {
+  let server: Server | null = null;
+  let socket: Socket | null = null;
+  let child: ChildProcessWithoutNullStreams | null = null;
+  let stderr = "";
+  let failure: string | null = null;
+
+  function close(): void {
+    server?.close();
+    server = null;
+    socket?.destroy();
+    socket = null;
+    if (child && !child.killed) {
+      child.kill();
+    }
+    child = null;
+  }
+
+  return new Promise((resolve, reject) => {
+    server = createServer((acceptedSocket) => {
+      socket = acceptedSocket;
+      server?.close();
+      server = null;
+
+      child = spawn("ssh", buildSshArgs(target), {
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+      child.stderr.on("data", (chunk: Buffer | string) => {
+        stderr = `${stderr}${chunk.toString()}`.slice(-SSH_STDERR_LIMIT);
+      });
+      child.on("error", (error) => {
+        failure = error.message;
+        acceptedSocket.destroy(error);
+      });
+      child.on("exit", (code, signal) => {
+        if (code !== 0 || signal) {
+          failure = formatSshFailure(stderr, code, signal);
+        }
+        acceptedSocket.destroy(failure ? new Error(failure) : undefined);
+      });
+
+      acceptedSocket.on("error", () => undefined);
+      acceptedSocket.on("close", () => {
+        if (child && !child.killed) {
+          child.kill();
+        }
+      });
+      acceptedSocket.pipe(child.stdin);
+      child.stdout.pipe(acceptedSocket);
+    });
+    server.once("error", (error) => {
+      close();
+      reject(error);
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server?.address();
+      if (!address || typeof address === "string") {
+        close();
+        reject(new Error("Failed to allocate the Remote SSH proxy port."));
+        return;
+      }
+      resolve({
+        url: `ws://127.0.0.1:${address.port}${WS_ENDPOINT_PATH}`,
+        close,
+        failureDetail: () => failure,
+      });
+    });
+  });
+}
+
+async function resolveTransportEndpoint(target: TransportTarget): Promise<TransportEndpoint> {
+  if (target.transportType === "ssh") {
+    return createSshProxy(target);
+  }
+  return {
+    url: buildLocalWebSocketUrl(target),
+    close: () => undefined,
+    failureDetail: () => null,
+  };
 }
 
 function decodeTransportMessage(input: { text?: string; binaryBase64?: string }): string | Buffer {
@@ -64,94 +297,272 @@ function decodeTransportMessage(input: { text?: string; binaryBase64?: string })
   throw new Error("Local transport send requires text or binary payload.");
 }
 
-export function openLocalTransportSession(target: TransportTarget): Promise<string> {
-  const sessionId = `local-session-${++nextSessionId}`;
-  const url = buildLocalWebSocketUrl(target);
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(url);
-    const session: Session = {
-      id: sessionId,
-      ws,
-      state: "opening",
-    };
-    sessions.set(sessionId, session);
+export function createLocalTransportManager(
+  deps: LocalTransportManagerDependencies,
+): LocalTransportManager {
+  const sessions = new Map<string, Session>();
 
-    let openSettled = false;
+  function isCurrent(session: Session): boolean {
+    return sessions.get(session.id) === session && session.state !== "closed";
+  }
 
-    const finalizeOpenFailure = (message: string): void => {
-      if (openSettled) {
+  function emitEvent(payload: TransportEventPayload): void {
+    try {
+      deps.emitEvent(payload);
+    } catch {
+      // A renderer may disappear while the main process is broadcasting an event.
+    }
+  }
+
+  function disposeSession(session: Session): void {
+    if (session.state === "closed") {
+      return;
+    }
+
+    session.state = "closed";
+    try {
+      session.cancelSetupDeadline();
+    } catch {
+      // Continue releasing the socket and endpoint if a runtime adapter fails.
+    }
+    session.cancelSetupDeadline = () => undefined;
+    if (sessions.get(session.id) === session) {
+      sessions.delete(session.id);
+    }
+
+    const ws = session.ws;
+    session.ws = null;
+    if (ws) {
+      try {
+        if (ws.readyState === WebSocket.CONNECTING) {
+          ws.terminate();
+        } else if (ws.readyState === WebSocket.OPEN) {
+          ws.close();
+        }
+      } catch {
+        // Closing is best-effort; the endpoint still owns the underlying transport.
+      }
+    }
+
+    const closeTarget = session.closeTarget;
+    session.closeTarget = null;
+    try {
+      closeTarget?.();
+    } catch {
+      // Closing is best-effort and must not prevent the registry from being released.
+    }
+  }
+
+  function failOpeningSession(session: Session, message: string): void {
+    if (!isCurrent(session) || session.state !== "opening") {
+      return;
+    }
+    disposeSession(session);
+    emitEvent({ sessionId: session.id, kind: "error", error: message });
+  }
+
+  async function connectSession(session: Session): Promise<void> {
+    let endpoint: TransportEndpoint;
+    try {
+      endpoint = await deps.resolveEndpoint(session.target);
+    } catch (error) {
+      failOpeningSession(
+        session,
+        `Failed to connect to ${describeTransportTarget(session.target)}: ${getErrorMessage(error)}`,
+      );
+      return;
+    }
+
+    if (!isCurrent(session) || session.state !== "opening") {
+      try {
+        endpoint.close();
+      } catch {
+        // The cancelled session no longer owns any other resources to release.
+      }
+      return;
+    }
+
+    let targetClosed = false;
+    session.closeTarget = () => {
+      if (targetClosed) {
         return;
       }
-
-      openSettled = true;
-      session.state = "closed";
-      sessions.delete(sessionId);
-      reject(new Error(message));
+      targetClosed = true;
+      endpoint.close();
     };
 
+    let ws: TransportWebSocket;
+    try {
+      ws = deps.createWebSocket(endpoint.url);
+    } catch (error) {
+      failOpeningSession(
+        session,
+        `Failed to connect to ${describeTransportTarget(session.target)}: ${getErrorMessage(error)}`,
+      );
+      return;
+    }
+    session.ws = ws;
+
     ws.once("open", () => {
-      openSettled = true;
+      if (!isCurrent(session) || session.state !== "opening") {
+        return;
+      }
+      session.cancelSetupDeadline();
+      session.cancelSetupDeadline = () => undefined;
       session.state = "open";
-      resolve(sessionId);
-      emitTransportEvent({ sessionId, kind: "open" });
+      emitEvent({ sessionId: session.id, kind: "open" });
     });
 
     ws.on("message", (data: RawData, isBinary: boolean) => {
+      if (!isCurrent(session) || session.state !== "open") {
+        return;
+      }
       if (isBinary || data instanceof Buffer) {
         const buf = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer);
-        emitTransportEvent({
-          sessionId,
+        emitEvent({
+          sessionId: session.id,
           kind: "message",
           binaryBase64: buf.toString("base64"),
         });
         return;
       }
 
-      emitTransportEvent({
-        sessionId,
+      emitEvent({
+        sessionId: session.id,
         kind: "message",
         text: data.toString(),
       });
     });
 
     ws.on("close", (code: number, reason?: Buffer | string) => {
-      const shouldEmitClose = session.state === "open" || session.state === "closing";
-      session.state = "closed";
-      sessions.delete(sessionId);
-
-      if (!openSettled) {
-        finalizeOpenFailure(
-          `${describeTransportTarget(target)} closed before the session became ready.`,
+      if (!isCurrent(session)) {
+        return;
+      }
+      if (session.state === "opening") {
+        const failureDetail = endpoint.failureDetail();
+        const detail = failureDetail ? `: ${failureDetail}` : "";
+        failOpeningSession(
+          session,
+          `${describeTransportTarget(session.target)} closed before the session became ready${detail}.`,
         );
         return;
       }
 
-      if (shouldEmitClose) {
-        emitTransportEvent({
-          sessionId,
-          kind: "close",
-          code,
-          reason: reason ? String(reason) : "",
-        });
-      }
-    });
-
-    ws.on("error", (err: Error) => {
-      if (!openSettled) {
-        finalizeOpenFailure(
-          `Failed to connect to ${describeTransportTarget(target)}: ${err.message}`,
-        );
-        return;
-      }
-
-      emitTransportEvent({
-        sessionId,
-        kind: "error",
-        error: err.message,
+      disposeSession(session);
+      emitEvent({
+        sessionId: session.id,
+        kind: "close",
+        code,
+        reason: reason ? String(reason) : "",
       });
     });
-  });
+
+    ws.on("error", (error: Error) => {
+      if (!isCurrent(session)) {
+        return;
+      }
+      const failureDetail = endpoint.failureDetail();
+      const detail = failureDetail ? `${error.message}: ${failureDetail}` : error.message;
+      if (session.state === "opening") {
+        failOpeningSession(
+          session,
+          `Failed to connect to ${describeTransportTarget(session.target)}: ${detail}`,
+        );
+        return;
+      }
+
+      emitEvent({ sessionId: session.id, kind: "error", error: detail });
+    });
+  }
+
+  function open(rawInput: unknown): void {
+    const { sessionId, target } = parseOpenTransportSessionInput(rawInput);
+    if (sessions.has(sessionId)) {
+      throw new Error(`Local transport session already exists: ${sessionId}`);
+    }
+
+    const session: Session = {
+      id: sessionId,
+      target,
+      ws: null,
+      state: "opening",
+      closeTarget: null,
+      cancelSetupDeadline: () => undefined,
+    };
+    sessions.set(sessionId, session);
+    session.cancelSetupDeadline = deps.scheduleTimeout(() => {
+      failOpeningSession(
+        session,
+        `Connection to ${describeTransportTarget(target)} timed out during setup.`,
+      );
+    }, LOCAL_TRANSPORT_SETUP_TIMEOUT_MS);
+    void connectSession(session);
+  }
+
+  async function send(input: {
+    sessionId: string;
+    text?: string;
+    binaryBase64?: string;
+  }): Promise<void> {
+    const session = sessions.get(input.sessionId);
+    if (!session) {
+      throw new Error(`Local transport session not found: ${input.sessionId}`);
+    }
+
+    const ws = session.ws;
+    if (session.state !== "open" || !ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error(
+        session.state === "opening"
+          ? "Local transport session is not open yet."
+          : "Local transport session is closed.",
+      );
+    }
+
+    const payload = decodeTransportMessage(input);
+    await new Promise<void>((resolve, reject) => {
+      ws.send(payload, (error) => {
+        if (error) {
+          reject(new Error(`Local transport write failed: ${error.message}`));
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  function close(sessionId: string): void {
+    const session = sessions.get(sessionId);
+    if (session) {
+      disposeSession(session);
+    }
+  }
+
+  function closeAll(): void {
+    for (const session of sessions.values()) {
+      disposeSession(session);
+    }
+  }
+
+  return { open, send, close, closeAll };
+}
+
+const localTransportManager = createLocalTransportManager({
+  resolveEndpoint: resolveTransportEndpoint,
+  createWebSocket: (url) => new WebSocket(url),
+  scheduleTimeout: (callback, delayMs) => {
+    const timeout = setTimeout(callback, delayMs);
+    timeout.unref();
+    return () => clearTimeout(timeout);
+  },
+  emitEvent: emitTransportEvent,
+});
+
+export function openLocalTransportSession(rawInput: unknown): void {
+  localTransportManager.open(rawInput);
 }
 
 export async function sendLocalTransportMessage(input: {
@@ -159,51 +570,13 @@ export async function sendLocalTransportMessage(input: {
   text?: string;
   binaryBase64?: string;
 }): Promise<void> {
-  const session = sessions.get(input.sessionId);
-  if (!session) {
-    throw new Error(`Local transport session not found: ${input.sessionId}`);
-  }
-
-  if (session.state !== "open" || session.ws.readyState !== WebSocket.OPEN) {
-    throw new Error(
-      session.state === "opening"
-        ? "Local transport session is not open yet."
-        : "Local transport session is closed.",
-    );
-  }
-
-  const payload = decodeTransportMessage(input);
-  await new Promise<void>((resolve, reject) => {
-    session.ws.send(payload, (error) => {
-      if (error) {
-        reject(new Error(`Local transport write failed: ${error.message}`));
-        return;
-      }
-      resolve();
-    });
-  });
+  await localTransportManager.send(input);
 }
 
 export function closeLocalTransportSession(sessionId: string): void {
-  const session = sessions.get(sessionId);
-  if (!session) return;
-
-  try {
-    if (session.ws.readyState === WebSocket.CONNECTING) {
-      session.state = "closed";
-      session.ws.terminate();
-    } else {
-      session.state = "closing";
-      session.ws.close();
-    }
-  } catch {
-    // ignore close errors
-  }
-  sessions.delete(sessionId);
+  localTransportManager.close(sessionId);
 }
 
 export function closeAllTransportSessions(): void {
-  for (const [id] of sessions) {
-    closeLocalTransportSession(id);
-  }
+  localTransportManager.closeAll();
 }


### PR DESCRIPTION
Adds a `remoteSsh` host connection type so the desktop app can reach a daemon on another machine over SSH, without exposing the daemon's port or going through the relay.

## How it works

`ssh -W 127.0.0.1:6767` gives a stdio-piped channel to the remote daemon. The desktop main process wraps that in a loopback TCP listener (bound to `127.0.0.1`, ephemeral port) and hands the renderer a plain `ws://127.0.0.1:<port>/ws` URL, so `DaemonClient` needs no SSH awareness.

SSH runs with `BatchMode=yes` (no interactive prompts — key auth only), `ConnectTimeout=10`, and `ClearAllForwardings=yes` + `ExitOnForwardFailure=yes`. `ssh` stderr is captured (capped at 8 KB) and surfaced as the connection failure reason instead of a bare exit code.

## Changes

- **`packages/app/src/types/host-connection.ts`** — `RemoteSshHostConnection` (`host`, optional `sshPort`, `identityFile`) in the `HostConnection` union, plus equality and a validating `createRemoteSshHostConnection`
- **`packages/desktop/src/daemon/local-transport.ts`** — target type widened from local-only to `socket | pipe | ssh`; `parseTransportTarget` validates the untrusted renderer payload, `buildSshArgs` builds the argv, `createSshProxy` manages the listener/child lifecycle
- **`packages/app/src/desktop/daemon/desktop-daemon-transport.ts`** — `buildLocalDaemonTransportUrl`/`createDesktopLocalDaemonTransportFactory` renamed to `buildDesktopDaemonTransportUrl`/`createDesktopDaemonTransportFactory`, since the transport is no longer local-only
- **`packages/app/src/runtime/host-runtime.ts`** — `remoteSsh` branch in `createClient` (throws outside desktop), `probeAndUpsertRemoteSshConnection` on the store and `HostMutations`
- **UI** — new `add-remote-ssh-host-modal.tsx`, entry points in the add-host method modal and welcome screen, host settings display
- **i18n** — new strings across all 9 locales

Host and port are rejected if they contain whitespace or lead with `-`, at both the app boundary and again in the main process, so a connection record can't smuggle extra flags into the `ssh` argv.

## Testing

Run in a clean install of the branch:

- `npm run typecheck` — `@getpaseo/app` and `@getpaseo/desktop` clean
- `npx vitest run` over the four touched test files (`host-connection`, `test-daemon-connection`, `desktop-daemon-transport`, `local-transport`) — 34 tests passing
- `npm run lint` — 0 warnings, 0 errors; `npm run format:check` clean

Not yet done: no manual QA against a real remote host, and no docs written for the new connection type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)