### PR TITLE
feat: import sessions from new workspaces

### DIFF
--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1123,6 +1123,7 @@ export const ar: TranslationResources = {
       createWorktreeFailed: "فشل في إنشاء شجرة العمل",
       composerStateRequired: "حالة الملحن مطلوبة",
       selectModel: "اختر نموذجا",
+      importedSessionWorkspaceMissing: "تفتقد الجلسة المستوردة معلومات مساحة العمل",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1132,6 +1132,7 @@ export const en = {
       createWorktreeFailed: "Failed to create worktree",
       composerStateRequired: "Composer state is required",
       selectModel: "Select a model",
+      importedSessionWorkspaceMissing: "The imported session is missing workspace information",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1154,6 +1154,8 @@ export const es: TranslationResources = {
       createWorktreeFailed: "No se pudo crear el árbol de trabajo",
       composerStateRequired: "Se requiere el estado del compositor",
       selectModel: "Selecciona un modelo",
+      importedSessionWorkspaceMissing:
+        "La sesión importada no contiene información del espacio de trabajo",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1153,6 +1153,8 @@ export const fr: TranslationResources = {
       createWorktreeFailed: "Échec de la création de l'arbre de travail",
       composerStateRequired: "L'état du compositeur est requis",
       selectModel: "Sélectionnez un modèle",
+      importedSessionWorkspaceMissing:
+        "La session importée ne contient pas d'informations sur l'espace de travail",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1134,6 +1134,7 @@ export const ja: TranslationResources = {
       createWorktreeFailed: "ワークツリーの作成に失敗しました",
       composerStateRequired: "コンポーザーの状態が必要です",
       selectModel: "モデルを選択してください",
+      importedSessionWorkspaceMissing: "インポートしたセッションにワークスペース情報がありません",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1130,6 +1130,7 @@ export const ko: TranslationResources = {
       createWorktreeFailed: "워크트리를 생성하지 못했습니다",
       composerStateRequired: "작성기 상태가 필요합니다",
       selectModel: "모델을 선택하세요",
+      importedSessionWorkspaceMissing: "가져온 세션에 워크스페이스 정보가 없습니다",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1145,6 +1145,7 @@ export const ptBR: TranslationResources = {
       createWorktreeFailed: "Falha ao criar worktree",
       composerStateRequired: "O estado do composer é obrigatório",
       selectModel: "Selecione um modelo",
+      importedSessionWorkspaceMissing: "A sessão importada não contém informações do workspace",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1145,6 +1145,8 @@ export const ru: TranslationResources = {
       createWorktreeFailed: "Не удалось создать рабочее дерево.",
       composerStateRequired: "Требуется состояние композитора.",
       selectModel: "Выберите модель",
+      importedSessionWorkspaceMissing:
+        "В импортированном сеансе отсутствуют сведения о рабочем пространстве",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1112,6 +1112,7 @@ export const zhCN: TranslationResources = {
       createWorktreeFailed: "创建 worktree 失败",
       composerStateRequired: "Composer 状态必填",
       selectModel: "请选择模型",
+      importedSessionWorkspaceMissing: "导入的会话缺少 workspace 信息",
     },
     tooltips: {
       project: "Choose the project",

--- a/packages/app/src/screens/new-workspace-import-session.test.ts
+++ b/packages/app/src/screens/new-workspace-import-session.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { importedSessionWorkspaceNavigation } from "./new-workspace-import-session";
+
+describe("importedSessionWorkspaceNavigation", () => {
+  it("opens the imported agent in the workspace created by the daemon", () => {
+    expect(
+      importedSessionWorkspaceNavigation("server-1", {
+        id: "agent-1",
+        workspaceId: "workspace-1",
+      }),
+    ).toEqual({
+      serverId: "server-1",
+      workspaceId: "workspace-1",
+      target: { kind: "agent", agentId: "agent-1" },
+    });
+  });
+
+  it("does not build a route when an older daemon omits the workspace id", () => {
+    expect(importedSessionWorkspaceNavigation("server-1", { id: "agent-1" })).toBeNull();
+  });
+});

--- a/packages/app/src/screens/new-workspace-import-session.ts
+++ b/packages/app/src/screens/new-workspace-import-session.ts
@@ -1,0 +1,17 @@
+import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
+import type { NavigateToWorkspaceInput } from "@/stores/navigation-active-workspace-store";
+
+export function importedSessionWorkspaceNavigation(
+  serverId: string,
+  agent: Pick<AgentSnapshotPayload, "id" | "workspaceId">,
+): NavigateToWorkspaceInput | null {
+  const workspaceId = agent.workspaceId?.trim();
+  if (!workspaceId) {
+    return null;
+  }
+  return {
+    serverId,
+    workspaceId,
+    target: { kind: "agent", agentId: agent.id },
+  };
+}

--- a/packages/app/src/screens/new-workspace-screen.tsx
+++ b/packages/app/src/screens/new-workspace-screen.tsx
@@ -9,8 +9,16 @@ import { StyleSheet, useUnistyles, withUnistyles } from "react-native-unistyles"
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { createNameId } from "mnemonic-id";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, Folder, FolderPlus, GitBranch, GitPullRequest } from "lucide-react-native";
+import {
+  ChevronDown,
+  Folder,
+  FolderPlus,
+  GitBranch,
+  GitPullRequest,
+  Inbox,
+} from "lucide-react-native";
 import { Composer } from "@/composer";
+import { ImportSessionSheet } from "@/components/import-session-sheet";
 import { FileDropZone } from "@/components/file-drop/file-drop-zone";
 import {
   resolveComposerAttachmentSubmitFormat,
@@ -87,7 +95,11 @@ import type { ComposerAttachment } from "@/attachments/types";
 import { useDraftWorkspaceAttachmentScopeKey } from "@/attachments/workspace-attachments-store";
 import type { MessagePayload } from "@/composer/types";
 import type { UserComposerAttachment } from "@/attachments/types";
-import type { AgentAttachment, ForgeSearchItem } from "@getpaseo/protocol/messages";
+import type {
+  AgentAttachment,
+  AgentSnapshotPayload,
+  ForgeSearchItem,
+} from "@getpaseo/protocol/messages";
 import type { CreatePaseoWorktreeInput } from "@getpaseo/client/internal/daemon-client";
 import type { AgentProvider } from "@getpaseo/protocol/agent-types";
 import type { WorkspaceDraftTabSetup, WorkspaceTabTarget } from "@/workspace-tabs/model";
@@ -116,6 +128,7 @@ import {
   resolveNewWorkspaceAutomaticServerId,
   resolveNewWorkspaceInitialServerId,
 } from "./new-workspace-initial-context";
+import { importedSessionWorkspaceNavigation } from "./new-workspace-import-session";
 import { useNewWorkspaceProjectPicker } from "./new-workspace/project-picker";
 
 const ThemedFolderPlus = withUnistyles(FolderPlus);
@@ -1336,12 +1349,15 @@ interface NewWorkspaceFormStackInput {
     profiles: readonly TerminalProfile[];
     disabled: boolean;
   };
+  importSession: {
+    onOpen: () => void;
+  };
 }
 
 function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactElement {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
-  const { isCompact, isPending, project, host, isolation, base, launch } = input;
+  const { isCompact, isPending, project, host, isolation, base, launch, importSession } = input;
 
   const selectedHostLabel =
     host.allHosts.find((h) => h.serverId === host.selectedServerId)?.label ?? "Host";
@@ -1514,6 +1530,31 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
     />
   );
 
+  const importSessionControl = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Pressable
+          onPress={importSession.onOpen}
+          disabled={isPending}
+          style={badgePressableStyle}
+          accessibilityRole="button"
+          accessibilityLabel={t("importSession.title")}
+          testID="new-workspace-import-session"
+        >
+          <View style={styles.badgeIconBox}>
+            <Inbox size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
+          </View>
+          <Text style={styles.badgeText} numberOfLines={1}>
+            {t("importSession.title")}
+          </Text>
+        </Pressable>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="center" offset={8}>
+        <Text style={styles.tooltipText}>{t("importSession.title")}</Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+
   return isCompact ? (
     <View testID="new-workspace-ref-picker-row" style={styles.formStack}>
       <FormRow>{projectControl}</FormRow>
@@ -1521,6 +1562,7 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
       {isolationControl ? <FormRow>{isolationControl}</FormRow> : null}
       {baseControl ? <FormRow>{baseControl}</FormRow> : null}
       <FormRow>{launchControl}</FormRow>
+      <FormRow>{importSessionControl}</FormRow>
       {/* Keep fixed stack height without separating the visible controls. */}
       {isolationControl ? null : <View style={styles.baseSpacer} />}
       {baseControl ? null : <View style={styles.baseSpacer} />}
@@ -1533,6 +1575,7 @@ function useNewWorkspaceFormStack(input: NewWorkspaceFormStackInput): ReactEleme
       {baseControl}
       <View style={styles.launchSpacer} />
       {launchControl}
+      {importSessionControl}
     </View>
   );
 }
@@ -1578,6 +1621,7 @@ export function NewWorkspaceScreen({
   const [pendingAction, setPendingAction] = useState<"chat" | "empty" | "terminal" | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+  const [importSessionOpen, setImportSessionOpen] = useState(false);
   const openAddProjectPicker = useOpenAddProject();
   const [isolationPickerOpen, setIsolationPickerOpen] = useState(false);
   const [pickerSearchQuery, setPickerSearchQuery] = useState("");
@@ -1944,6 +1988,22 @@ export function NewWorkspaceScreen({
     setProjectPickerOpen(nextOpen);
   }, []);
 
+  const handleOpenImportSession = useCallback(() => setImportSessionOpen(true), []);
+  const handleCloseImportSession = useCallback(() => setImportSessionOpen(false), []);
+  const handleImportedSession = useCallback(
+    (agent: AgentSnapshotPayload) => {
+      const navigation = importedSessionWorkspaceNavigation(selectedServerId, agent);
+      if (!navigation) {
+        const message = t("newWorkspace.errors.importedSessionWorkspaceMissing");
+        setErrorMessage(message);
+        toast.error(message);
+        return;
+      }
+      navigateToWorkspace(navigation);
+    },
+    [selectedServerId, t, toast],
+  );
+
   const buildCreateWorktreeInput = useCallback(
     (input: {
       cwd: string;
@@ -2275,6 +2335,9 @@ export function NewWorkspaceScreen({
       profiles: terminalProfiles,
       disabled: isPending,
     },
+    importSession: {
+      onOpen: handleOpenImportSession,
+    },
   });
 
   const screenHeaderLeft = useMemo(() => <SidebarMenuToggle />, []);
@@ -2350,6 +2413,14 @@ export function NewWorkspaceScreen({
           {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
         </ReanimatedAnimated.View>
       </View>
+      <ImportSessionSheet
+        visible={importSessionOpen}
+        client={client}
+        serverId={selectedServerId}
+        cwd={selectedSourceDirectory}
+        onClose={handleCloseImportSession}
+        onImported={handleImportedSession}
+      />
     </FileDropZone>
   );
 }
@@ -2400,6 +2471,7 @@ const styles = StyleSheet.create((theme) => ({
   },
   formStackDesktop: {
     flexDirection: "row",
+    flexWrap: "wrap",
     alignItems: "center",
     marginBottom: theme.spacing[8],
     // The badge adds its own left padding; offset it so the project icon's left


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Importing an existing provider session currently requires creating or opening a Workspace first, then navigating to its import action. Adding the existing import sheet to New Workspace makes that flow available at the point where users choose a Project, host, and source directory.

After import, the screen navigates to the imported agent in the Workspace returned by the daemon. If an older daemon omits the Workspace ID, the form keeps the user in place and shows an actionable error instead of navigating to an invalid route.

### Goals

- Add an Import session action to the New Workspace form.
- Open the existing import sheet using the selected host and source directory.
- Navigate directly to the imported agent's Workspace after success.
- Surface a visible error when the imported agent has no Workspace ID.
- Keep the desktop form controls from overflowing after adding the action.

### Non-goals

- Change how importable sessions are discovered or filtered.
- Change daemon-side Workspace placement.
- Add a second session-import implementation.

### QA

- `npm run typecheck` — passed across all workspaces.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format` and `npm run format:check` — passed.
- `npx vitest run packages/app/src/screens/new-workspace-import-session.test.ts --bail=1` — 2 passed.

Manual UI capture has not been run.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense