### PR TITLE
fix(server): keep one-shot workspace inventory observer-free

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -5177,7 +5177,14 @@ export class Session {
       }
 
       const payload = await this.listFetchWorkspacesEntries(request);
-      this.workspaceGitObserver.syncObservers(payload.entries);
+      // A one-shot inventory read must stay read-only. Registering Git observers
+      // for every returned workspace can fan out thousands of Git commands on
+      // long-lived hosts even though the caller will disconnect after this
+      // response. Only a client that requested workspace updates owns that
+      // background observation cost.
+      if (subscriptionId) {
+        this.workspaceGitObserver.syncObservers(payload.entries);
+      }
       this.sessionLogger.debug(
         {
           requestId: request.requestId,

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -183,6 +183,9 @@ interface SessionTestAccess {
     peekSnapshot: (cwd: string) => WorkspaceGitRuntimeSnapshot | null;
     registerWorkspace: (params: { cwd: string }, listener: unknown) => { unsubscribe: () => void };
   };
+  workspaceGitObserver: {
+    syncObservers(entries: ReadonlyArray<Record<string, unknown>>): void;
+  };
   filesystem: {
     isDirectory(cwd: string): Promise<boolean>;
   };
@@ -2367,6 +2370,32 @@ test("non-git workspace uses deterministic directory name and no unknown branch 
   expect(result.entries).toHaveLength(1);
   expect(result.entries[0]?.name).toBe("non-git");
   expect(result.entries[0]?.name).not.toBe("Unknown branch");
+});
+
+test("one-shot workspace inventory does not register Git observers", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = createSessionForWorkspaceTests({
+    onMessage: (message) => emitted.push(message),
+  });
+  const syncObservers = vi.spyOn(session.workspaceGitObserver, "syncObservers");
+
+  await session.handleMessage({
+    type: "fetch_workspaces_request",
+    requestId: "req-one-shot-workspace-inventory",
+  });
+
+  expect(
+    emitted.find((message) => message.type === "fetch_workspaces_response")?.payload.requestId,
+  ).toBe("req-one-shot-workspace-inventory");
+  expect(syncObservers).not.toHaveBeenCalled();
+
+  await session.handleMessage({
+    type: "fetch_workspaces_request",
+    requestId: "req-subscribed-workspace-inventory",
+    subscribe: { subscriptionId: "workspace-updates" },
+  });
+
+  expect(syncObservers).toHaveBeenCalledTimes(1);
 });
 
 test("workspace placements preserve checkout facts independently from the project", async () => {


### PR DESCRIPTION
## Problem

A one-shot `fetch_workspaces_request` registers Git observers for every returned workspace even though the client disconnects after the response. On a long-lived host with 518 active workspace records, one CLI inventory read activated 518 observers, queued about 1,400 Git commands, stalled the event loop for 26 seconds, and triggered daemon heartbeat recovery.

## Change

Register workspace Git observers only when the request includes a workspace-update subscription. One-shot inventory remains a read-only snapshot. Subscribed desktop and long-lived clients keep the existing observer behavior.

## Proof

- `packages/server/src/server/session.workspaces.test.ts`: 106 passed, 4 skipped
- `@getpaseo/server` typecheck passed
- touched-file `oxfmt --check` passed
- touched-file `oxlint` passed with zero warnings

The regression asserts that a one-shot inventory does not call `syncObservers`, while a subscribed request does.
