### PR TITLE
fix(workspace): report archive cleanup outcome

### DIFF
--- a/packages/cli/src/commands/workspace/archive.test.ts
+++ b/packages/cli/src/commands/workspace/archive.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildWorkspaceArchiveResult } from "./archive.js";
+
+describe("workspace archive receipt", () => {
+  it.each([
+    { removedDirectory: true, expected: true },
+    { removedDirectory: false, expected: false },
+    { removedDirectory: undefined, expected: null },
+  ])("returns cleanup result $expected", ({ removedDirectory, expected }) => {
+    expect(
+      buildWorkspaceArchiveResult("workspace-1", {
+        archivedAt: "2026-08-09T00:00:00.000Z",
+        removedDirectory,
+      }),
+    ).toEqual({
+      workspaceId: "workspace-1",
+      status: "archived",
+      archivedAt: "2026-08-09T00:00:00.000Z",
+      removedDirectory: expected,
+    });
+  });
+});

--- a/packages/cli/src/commands/workspace/archive.ts
+++ b/packages/cli/src/commands/workspace/archive.ts
@@ -2,10 +2,11 @@ import type { Command } from "commander";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type { CommandError, OutputSchema, SingleResult } from "../../output/index.js";
 
-interface WorkspaceArchiveResult {
+export interface WorkspaceArchiveResult {
   workspaceId: string;
   status: "archived";
   archivedAt: string;
+  removedDirectory: boolean | null;
 }
 
 const workspaceArchiveSchema: OutputSchema<WorkspaceArchiveResult> = {
@@ -14,8 +15,21 @@ const workspaceArchiveSchema: OutputSchema<WorkspaceArchiveResult> = {
     { header: "WORKSPACE ID", field: "workspaceId", width: 20 },
     { header: "STATUS", field: "status", width: 10 },
     { header: "ARCHIVED AT", field: "archivedAt", width: 26 },
+    { header: "REMOVED DIRECTORY", field: "removedDirectory", width: 19 },
   ],
 };
+
+export function buildWorkspaceArchiveResult(
+  workspaceId: string,
+  payload: { archivedAt: string; removedDirectory?: boolean },
+): WorkspaceArchiveResult {
+  return {
+    workspaceId,
+    status: "archived",
+    archivedAt: payload.archivedAt,
+    removedDirectory: payload.removedDirectory ?? null,
+  };
+}
 
 export async function runArchiveCommand(
   workspaceId: string,
@@ -40,7 +54,10 @@ export async function runArchiveCommand(
     }
     return {
       type: "single",
-      data: { workspaceId, status: "archived", archivedAt: payload.archivedAt },
+      data: buildWorkspaceArchiveResult(workspaceId, {
+        archivedAt: payload.archivedAt,
+        removedDirectory: payload.removedDirectory,
+      }),
       schema: workspaceArchiveSchema,
     };
   } catch (error) {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3673,6 +3673,8 @@ export const ArchiveWorkspaceResponseMessageSchema = z.object({
     requestId: z.string(),
     workspaceId: z.string(),
     archivedAt: z.string().nullable(),
+    // COMPAT(workspaceArchiveCleanupReceipt): added in v0.3.2, remove after 2027-08-09 when old daemons are unsupported.
+    removedDirectory: z.boolean().optional(),
     error: z.string().nullable(),
   }),
 });

--- a/packages/protocol/src/messages.wire-compat.test.ts
+++ b/packages/protocol/src/messages.wire-compat.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   AgentSnapshotPayloadSchema,
   AgentTimelineItemPayloadSchema,
+  ArchiveWorkspaceResponseMessageSchema,
   ServerInfoStatusPayloadSchema,
   WSHelloMessageSchema,
 } from "./messages.js";
@@ -42,7 +43,39 @@ const LegacyAgentSnapshotPayloadSchema = AgentSnapshotPayloadSchema.extend({
   capabilities: LegacyAgentCapabilityFlagsSchema,
 });
 
+const LegacyArchiveWorkspaceResponseMessageSchema = z.object({
+  type: z.literal("archive_workspace_response"),
+  payload: z.object({
+    requestId: z.string(),
+    workspaceId: z.string(),
+    archivedAt: z.string().nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
 describe("wire schema compatibility", () => {
+  test("workspace archive cleanup receipt is optional for old daemons and ignored by old clients", () => {
+    const legacyPayload = {
+      type: "archive_workspace_response" as const,
+      payload: {
+        requestId: "archive-1",
+        workspaceId: "workspace-1",
+        archivedAt: "2026-08-09T00:00:00.000Z",
+        error: null,
+      },
+    };
+    const currentPayload = {
+      ...legacyPayload,
+      payload: { ...legacyPayload.payload, removedDirectory: false },
+    };
+
+    expect(ArchiveWorkspaceResponseMessageSchema.parse(legacyPayload)).toEqual(legacyPayload);
+    expect(ArchiveWorkspaceResponseMessageSchema.parse(currentPayload)).toEqual(currentPayload);
+    expect(LegacyArchiveWorkspaceResponseMessageSchema.parse(currentPayload)).toEqual(
+      legacyPayload,
+    );
+  });
+
   test("hello parses with and without the project update capability", () => {
     const legacy = WSHelloMessageSchema.parse({
       type: "hello",

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -6027,7 +6027,7 @@ export class Session {
         throw new Error(`Workspace not found: ${request.workspaceId}`);
       }
 
-      await archiveByScope(
+      const { removedDirectory } = await archiveByScope(
         {
           paseoHome: this.paseoHome,
           paseoWorktreesBaseRoot: this.worktreesRoot,
@@ -6063,6 +6063,7 @@ export class Session {
           requestId: request.requestId,
           workspaceId: request.workspaceId,
           archivedAt,
+          removedDirectory,
           error: null,
         },
       });

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -5782,6 +5782,7 @@ test("archive_workspace_request hides non-destructive workspace records", async 
     | { payload: Record<string, unknown> }
     | undefined;
   expect(response?.payload.error).toBeNull();
+  expect(response?.payload.removedDirectory).toBe(false);
 });
 
 test("archive_workspace_request archives a worktree-kind workspace and removes the directory on last reference", async () => {
@@ -5884,6 +5885,7 @@ test("archive_workspace_request archives a worktree-kind workspace and removes t
       | { payload: Record<string, unknown> }
       | undefined;
     expect(response?.payload.error).toBeNull();
+    expect(response?.payload.removedDirectory).toBe(true);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts
+++ b/packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -359,6 +359,21 @@ test.skipIf(process.platform === "win32")(
   "repeating archive removes a residual worktree for an already-archived workspace",
   async () => {
     const repoDir = createGitRepo();
+    const allowTeardownPath = path.join(repoDir, "allow-teardown");
+    writeFileSync(
+      path.join(repoDir, "paseo.json"),
+      JSON.stringify({
+        worktree: {
+          teardown: [`test -f ${JSON.stringify(allowTeardownPath)}`],
+        },
+      }),
+    );
+    execFileSync("git", ["add", "paseo.json"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync(
+      "git",
+      ["-c", "commit.gpgsign=false", "commit", "-m", "add gated worktree teardown"],
+      { cwd: repoDir, stdio: "pipe" },
+    );
     const result = await ctx.client.createWorkspace({
       source: {
         kind: "worktree",
@@ -372,44 +387,19 @@ test.skipIf(process.platform === "win32")(
       throw new Error(result.error ?? "Failed to create worktree workspace");
     }
 
-    const writerStartedPath = path.join(repoDir, "writer-started");
-    const stopWriterPath = path.join(repoDir, "stop-writer");
-    const target = path.join(
-      workspace.workspaceDirectory,
-      "node_modules/react-native-svg/lib/typescript",
-    );
-    const writer = spawn(
-      process.execPath,
-      [
-        "-e",
-        `const fs=require('fs'),path=require('path');const target=${JSON.stringify(target)};const started=${JSON.stringify(writerStartedPath)};const stop=${JSON.stringify(stopWriterPath)};fs.writeFileSync(started,'started');while(!fs.existsSync(stop)){try{fs.mkdirSync(target,{recursive:true});fs.writeFileSync(path.join(target,'active'),String(Date.now()))}catch{}}`,
-      ],
-      { stdio: "ignore" },
-    );
-    const writerExit = new Promise<void>((resolve) => writer.once("exit", () => resolve()));
+    const firstArchive = await ctx.client.archiveWorkspace(workspace.id);
 
-    try {
-      await expect.poll(() => existsSync(writerStartedPath), { timeout: 10000 }).toBe(true);
+    expect(firstArchive.error).toBeNull();
+    expect(firstArchive.removedDirectory).toBe(false);
+    expect((await activeWorkspaceIds()).has(workspace.id)).toBe(false);
+    expect(existsSync(workspace.workspaceDirectory)).toBe(true);
 
-      const firstArchive = await ctx.client.archiveWorkspace(workspace.id);
+    writeFileSync(allowTeardownPath, "allow\n");
+    const retry = await ctx.client.archiveWorkspace(workspace.id);
 
-      expect(firstArchive.error).toBeNull();
-      expect(firstArchive.removedDirectory).toBe(false);
-      expect((await activeWorkspaceIds()).has(workspace.id)).toBe(false);
-      expect(existsSync(workspace.workspaceDirectory)).toBe(true);
-
-      writeFileSync(stopWriterPath, "stop\n");
-      await writerExit;
-
-      const retry = await ctx.client.archiveWorkspace(workspace.id);
-
-      expect(retry.error).toBeNull();
-      expect(retry.removedDirectory).toBe(true);
-      expect(existsSync(workspace.workspaceDirectory)).toBe(false);
-    } finally {
-      writeFileSync(stopWriterPath, "stop\n");
-      await writerExit;
-    }
+    expect(retry.error).toBeNull();
+    expect(retry.removedDirectory).toBe(true);
+    expect(existsSync(workspace.workspaceDirectory)).toBe(false);
   },
   60000,
 );

--- a/packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts
+++ b/packages/server/src/server/workspace-archive-record-scoped.e2e.test.ts
@@ -394,6 +394,7 @@ test.skipIf(process.platform === "win32")(
       const firstArchive = await ctx.client.archiveWorkspace(workspace.id);
 
       expect(firstArchive.error).toBeNull();
+      expect(firstArchive.removedDirectory).toBe(false);
       expect((await activeWorkspaceIds()).has(workspace.id)).toBe(false);
       expect(existsSync(workspace.workspaceDirectory)).toBe(true);
 
@@ -403,6 +404,7 @@ test.skipIf(process.platform === "win32")(
       const retry = await ctx.client.archiveWorkspace(workspace.id);
 
       expect(retry.error).toBeNull();
+      expect(retry.removedDirectory).toBe(true);
       expect(existsSync(workspace.workspaceDirectory)).toBe(false);
     } finally {
       writeFileSync(stopWriterPath, "stop\n");


### PR DESCRIPTION
## Summary

- expose the existing workspace archive `removedDirectory` result in the daemon response
- report `true`, `false`, or `null` from `paseo workspace archive`, with `null` preserving compatibility with older daemons
- keep exact-ID archive retryable so a retained busy managed worktree can be removed once it becomes safe

The archive service already returned the cleanup result, but the session response discarded it. The CLI therefore reported `archived` without saying whether the physical managed directory remained. This change carries the service result through the optional wire field and makes cleanup state explicit without weakening any archive safety check.

## Verification

- protocol and CLI focused tests: 10 passed
- archive session tests: 2 passed, 107 skipped by focus filter
- exact-ID retained-directory retry: 1 passed, 7 skipped by focus filter
- `npm run build:server`
- `npm run typecheck`
- touched-file format, lint, and `git diff --check`

The retry regression proves `removedDirectory: false` while a writer keeps the directory busy, followed by `removedDirectory: true` when the same archived workspace ID is retried after the directory becomes safe.
