### PR TITLE
fix(cli): preserve supervisor during managed restart

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -332,6 +332,10 @@ the launch environment remains authoritative. Lower values reduce machine pressu
 Git RPCs wait longer. See [Git process limits](data-model.md#git-process-limits) for defaults,
 semantics, and environment-variable overrides.
 
+When `paseo daemon restart` runs inside a Paseo-owned agent, the CLI asks the existing supervisor to
+recycle its daemon worker so the command cannot kill its own restart process. Run the command from an
+external shell when changing launch options such as `--listen`, `--port`, or relay settings.
+
 ### Agent Tool Catalog Measurement
 
 Measure the MCP `tools/list` payload that Paseo injects into agents with:

--- a/packages/cli/src/commands/daemon/restart.test.ts
+++ b/packages/cli/src/commands/daemon/restart.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Command } from "commander";
+import { runRestartCommand, type RestartCommandDependencies } from "./restart";
+
+function makeDependencies(input?: {
+  env?: NodeJS.ProcessEnv;
+  currentHome?: string;
+  targetHome?: string;
+}) {
+  const restartServer = vi.fn(async () => undefined);
+  const close = vi.fn(async () => undefined);
+  const connectToDaemon = vi.fn(async () => ({ restartServer, close }));
+  const stopLocalDaemon = vi.fn(async () => ({
+    action: "stopped" as const,
+    home: input?.targetHome ?? "/tmp/paseo",
+    pid: 100,
+    forced: false,
+    usedLifecycleRpc: true,
+    reason: "lifecycle_shutdown_rpc" as const,
+    message: "Daemon stopped gracefully",
+  }));
+  const startLocalDaemonDetached = vi.fn(async () => ({
+    pid: 200,
+    logPath: "/tmp/paseo/daemon.log",
+  }));
+  const currentHome = input?.currentHome ?? "/tmp/paseo";
+  const targetHome = input?.targetHome ?? currentHome;
+  const dependencies: RestartCommandDependencies = {
+    env: input?.env ?? {},
+    connectToDaemon,
+    resolveLocalDaemonState: () => ({
+      home: targetHome,
+      listen: "127.0.0.1:6767",
+      relayEnabled: false,
+      relayEndpoint: "relay.paseo.sh:443",
+      relayUseTls: true,
+      relayPublicUseTls: true,
+      logPath: `${targetHome}/daemon.log`,
+      pidPath: `${targetHome}/paseo.pid`,
+      pidInfo: { pid: 100, listen: "127.0.0.1:6767" },
+      running: true,
+      stalePidFile: false,
+    }),
+    resolveLocalPaseoHome: (home) => home ?? currentHome,
+    startLocalDaemonDetached,
+    stopLocalDaemon,
+  };
+  return {
+    dependencies,
+    restartServer,
+    close,
+    connectToDaemon,
+    stopLocalDaemon,
+    startLocalDaemonDetached,
+  };
+}
+
+describe("runRestartCommand", () => {
+  it("recycles the supervised worker when called by an agent owned by that daemon", async () => {
+    const fake = makeDependencies({ env: { PASEO_AGENT_ID: "agent-1" } });
+
+    const result = await runRestartCommand(
+      { mcp: true, injectMcp: true },
+      {} as Command,
+      fake.dependencies,
+    );
+
+    expect(fake.connectToDaemon).toHaveBeenCalledWith({
+      host: "127.0.0.1:6767",
+      timeout: 15_000,
+    });
+    expect(fake.restartServer).toHaveBeenCalledWith("cli_daemon_restart");
+    expect(fake.close).toHaveBeenCalledOnce();
+    expect(fake.stopLocalDaemon).not.toHaveBeenCalled();
+    expect(fake.startLocalDaemonDetached).not.toHaveBeenCalled();
+    expect(result.data).toMatchObject({
+      action: "restart_requested",
+      home: "/tmp/paseo",
+      pid: "100",
+    });
+  });
+
+  it("keeps the stop-start path for restarts issued outside a managed agent", async () => {
+    const fake = makeDependencies();
+
+    const result = await runRestartCommand({}, {} as Command, fake.dependencies);
+
+    expect(fake.stopLocalDaemon).toHaveBeenCalledOnce();
+    expect(fake.startLocalDaemonDetached).toHaveBeenCalledOnce();
+    expect(fake.connectToDaemon).not.toHaveBeenCalled();
+    expect(result.data).toMatchObject({ action: "restarted", pid: "200" });
+  });
+
+  it("keeps the stop-start path when a managed agent targets another daemon home", async () => {
+    const fake = makeDependencies({
+      env: { PASEO_AGENT_ID: "agent-1" },
+      currentHome: "/tmp/owning-daemon",
+      targetHome: "/tmp/other-daemon",
+    });
+
+    await runRestartCommand({ home: "/tmp/other-daemon" }, {} as Command, fake.dependencies);
+
+    expect(fake.stopLocalDaemon).toHaveBeenCalledOnce();
+    expect(fake.startLocalDaemonDetached).toHaveBeenCalledOnce();
+    expect(fake.connectToDaemon).not.toHaveBeenCalled();
+  });
+
+  it("rejects launch-option changes that cannot survive an owning worker recycle", async () => {
+    const fake = makeDependencies({ env: { PASEO_AGENT_ID: "agent-1" } });
+
+    await expect(
+      runRestartCommand({ port: "7000" }, {} as Command, fake.dependencies),
+    ).rejects.toMatchObject({
+      code: "INVALID_OPTIONS",
+      message: "Cannot change daemon launch options from a Paseo-owned agent",
+    });
+
+    expect(fake.restartServer).not.toHaveBeenCalled();
+    expect(fake.stopLocalDaemon).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/daemon/restart.ts
+++ b/packages/cli/src/commands/daemon/restart.ts
@@ -1,10 +1,13 @@
 import type { Command } from "commander";
 import {
+  resolveLocalDaemonState,
+  resolveLocalPaseoHome,
   startLocalDaemonDetached,
   stopLocalDaemon,
   DEFAULT_STOP_TIMEOUT_MS,
   type DaemonStartOptions,
 } from "./local-daemon.js";
+import { connectToDaemon } from "../../utils/client.js";
 import type {
   CommandOptions,
   SingleResult,
@@ -13,7 +16,7 @@ import type {
 } from "../../output/index.js";
 
 interface RestartResult {
-  action: "restarted";
+  action: "restarted" | "restart_requested";
   home: string;
   pid: string;
   message: string;
@@ -34,6 +37,29 @@ const restartResultSchema: OutputSchema<RestartResult> = {
 };
 
 export type RestartCommandResult = SingleResult<RestartResult>;
+
+interface RestartDaemonClient {
+  restartServer(reason?: string): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export interface RestartCommandDependencies {
+  env: NodeJS.ProcessEnv;
+  connectToDaemon(options: { host?: string; timeout?: number }): Promise<RestartDaemonClient>;
+  resolveLocalDaemonState: typeof resolveLocalDaemonState;
+  resolveLocalPaseoHome: typeof resolveLocalPaseoHome;
+  startLocalDaemonDetached: typeof startLocalDaemonDetached;
+  stopLocalDaemon: typeof stopLocalDaemon;
+}
+
+const defaultDependencies: RestartCommandDependencies = {
+  env: process.env,
+  connectToDaemon,
+  resolveLocalDaemonState,
+  resolveLocalPaseoHome,
+  startLocalDaemonDetached,
+  stopLocalDaemon,
+};
 
 function parseTimeoutMs(raw: unknown): number {
   if (typeof raw !== "string" || raw.trim().length === 0) {
@@ -76,18 +102,96 @@ function toStartOptions(options: CommandOptions): DaemonStartOptions {
   return startOptions;
 }
 
+function hasLaunchOverrides(options: DaemonStartOptions): boolean {
+  return (
+    options.listen !== undefined ||
+    options.port !== undefined ||
+    options.relay !== undefined ||
+    options.mcp === false ||
+    options.injectMcp === false ||
+    options.webUi !== undefined ||
+    options.hostnames !== undefined
+  );
+}
+
+function targetsOwningDaemon(
+  options: DaemonStartOptions,
+  dependencies: RestartCommandDependencies,
+): boolean {
+  if (!dependencies.env.PASEO_AGENT_ID?.trim()) {
+    return false;
+  }
+
+  return dependencies.resolveLocalPaseoHome(options.home) === dependencies.resolveLocalPaseoHome();
+}
+
+async function requestSupervisedRestart(
+  options: DaemonStartOptions,
+  timeoutMs: number,
+  dependencies: RestartCommandDependencies,
+): Promise<RestartCommandResult> {
+  const state = dependencies.resolveLocalDaemonState({ home: options.home });
+  const client = await dependencies.connectToDaemon({
+    host: state.listen,
+    timeout: timeoutMs,
+  });
+  try {
+    await client.restartServer("cli_daemon_restart");
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+
+  const pid = state.pidInfo?.pid ?? null;
+  return {
+    type: "single",
+    data: {
+      action: "restart_requested",
+      home: state.home,
+      pid: pid === null ? "-" : String(pid),
+      message:
+        pid === null
+          ? "Daemon worker restart requested through its supervisor"
+          : `Daemon worker restart requested through supervisor PID ${pid}`,
+    },
+    schema: restartResultSchema,
+  };
+}
+
 export async function runRestartCommand(
   options: CommandOptions,
   _command: Command,
+  dependencies: RestartCommandDependencies = defaultDependencies,
 ): Promise<RestartCommandResult> {
   const timeoutMs = parseTimeoutMs(options.timeout);
   const force = options.force === true;
   const startOptions = toStartOptions(options);
 
+  if (targetsOwningDaemon(startOptions, dependencies)) {
+    if (hasLaunchOverrides(startOptions)) {
+      const error: CommandError = {
+        code: "INVALID_OPTIONS",
+        message: "Cannot change daemon launch options from a Paseo-owned agent",
+        details: "Run the restart from an external shell, or omit the launch options",
+      };
+      throw error;
+    }
+
+    try {
+      return await requestSupervisedRestart(startOptions, timeoutMs, dependencies);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const error: CommandError = {
+        code: "RESTART_FAILED",
+        message: `Failed to request supervised daemon restart: ${message}`,
+      };
+      throw error;
+    }
+  }
+
   try {
     let stopResult: Awaited<ReturnType<typeof stopLocalDaemon>>;
     try {
-      stopResult = await stopLocalDaemon({
+      stopResult = await dependencies.stopLocalDaemon({
         home: startOptions.home,
         timeoutMs,
         force,
@@ -96,7 +200,7 @@ export async function runRestartCommand(
       const isTimeout =
         err instanceof Error && err.message.includes("Timed out waiting for daemon PID");
       if (!force && isTimeout) {
-        stopResult = await stopLocalDaemon({
+        stopResult = await dependencies.stopLocalDaemon({
           home: startOptions.home,
           timeoutMs,
           force: true,
@@ -106,7 +210,7 @@ export async function runRestartCommand(
       }
     }
 
-    const startup = await startLocalDaemonDetached(startOptions);
+    const startup = await dependencies.startLocalDaemonDetached(startOptions);
     const before = stopResult.pid === null ? "not running" : `PID ${stopResult.pid}`;
     const after = startup.pid === null ? "unknown PID" : `PID ${startup.pid}`;
 

--- a/packages/cli/tests/25-daemon-restart-supervisor.test.ts
+++ b/packages/cli/tests/25-daemon-restart-supervisor.test.ts
@@ -239,6 +239,39 @@ try {
     `restart should log supervisor signal dispatch, logs:\n${capturedSupervisorLogs}`,
   );
   console.log("✓ app-style restart keeps daemon healthy and restarts worker\n");
+
+  console.log("Test 3: a Paseo-owned CLI restart recycles the worker, not the supervisor");
+  const workerPidBeforeCliRestart = workerPidAfterRestart;
+  const cliRestart =
+    await $`PASEO_HOME=${paseoHome} PASEO_AGENT_ID=managed-test-agent PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD=${testEnv.PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD} PASEO_DICTATION_ENABLED=${testEnv.PASEO_DICTATION_ENABLED} PASEO_VOICE_MODE_ENABLED=${testEnv.PASEO_VOICE_MODE_ENABLED} npx paseo daemon restart --home ${paseoHome} --json`.nothrow();
+  assert.strictEqual(
+    cliRestart.exitCode,
+    0,
+    `managed CLI restart should succeed:\nstdout:\n${cliRestart.stdout}\nstderr:\n${cliRestart.stderr}`,
+  );
+  const cliRestartOutput = JSON.parse(cliRestart.stdout) as { action?: unknown; pid?: unknown };
+  assert.strictEqual(cliRestartOutput.action, "restart_requested");
+  assert.strictEqual(cliRestartOutput.pid, String(supervisorPid));
+
+  await waitFor(
+    () => {
+      const workerPid = readWorkerPid(supervisorPid);
+      return (
+        workerPid !== null && workerPid !== workerPidBeforeCliRestart && isProcessRunning(workerPid)
+      );
+    },
+    20000,
+    "worker pid did not change after managed CLI restart",
+  );
+
+  const statusAfterCliRestart = await readDaemonStatus(paseoHome);
+  assert.strictEqual(statusAfterCliRestart.localDaemon, "running");
+  assert.strictEqual(
+    statusAfterCliRestart.pid,
+    supervisorPid,
+    "managed CLI restart must preserve the owning supervisor",
+  );
+  console.log("✓ managed CLI restart preserves supervisor and recycles worker\n");
 } finally {
   if (supervisorProcess?.pid && isProcessRunning(supervisorProcess.pid)) {
     supervisorProcess.kill("SIGTERM");
@@ -251,7 +284,6 @@ try {
     });
   }
 
-  await $`PASEO_HOME=${paseoHome} PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD=${testEnv.PASEO_LOCAL_SPEECH_AUTO_DOWNLOAD} PASEO_DICTATION_ENABLED=${testEnv.PASEO_DICTATION_ENABLED} PASEO_VOICE_MODE_ENABLED=${testEnv.PASEO_VOICE_MODE_ENABLED} npx paseo daemon stop --home ${paseoHome} --force`.nothrow();
   await rm(paseoHome, { recursive: true, force: true });
 }
 

--- a/packages/cli/tests/25-daemon-restart-supervisor.test.ts
+++ b/packages/cli/tests/25-daemon-restart-supervisor.test.ts
@@ -94,6 +94,17 @@ async function readDaemonStatus(paseoHome: string): Promise<DaemonStatus> {
   }
 }
 
+async function waitForRunningDaemon(paseoHome: string, supervisorPid: number): Promise<void> {
+  await waitFor(
+    async () => {
+      const status = await readDaemonStatus(paseoHome);
+      return status.localDaemon === "running" && status.pid === supervisorPid;
+    },
+    120000,
+    "daemon did not become responsive after worker restart",
+  );
+}
+
 async function readCapturedSupervisorLogs(paseoHome: string, recentLogs: string): Promise<string> {
   const durableLogs = await readFile(join(paseoHome, "daemon.log"), "utf8").catch(() => "");
   return `${recentLogs}\n${durableLogs}`;
@@ -216,6 +227,7 @@ try {
     "worker pid should change after restart",
   );
 
+  await waitForRunningDaemon(paseoHome, supervisorPid);
   const statusAfterRestart = await readDaemonStatus(paseoHome);
   assert.strictEqual(
     statusAfterRestart.localDaemon,
@@ -264,6 +276,7 @@ try {
     "worker pid did not change after managed CLI restart",
   );
 
+  await waitForRunningDaemon(paseoHome, supervisorPid);
   const statusAfterCliRestart = await readDaemonStatus(paseoHome);
   assert.strictEqual(statusAfterCliRestart.localDaemon, "running");
   assert.strictEqual(


### PR DESCRIPTION
Closes #1555.

## Summary

- detect `paseo daemon restart` when invoked by an agent owned by the target daemon
- ask the existing supervisor to recycle only its worker, preserving the restart caller and desktop connection
- reject launch-option changes from the managed path and retain normal stop/start behavior for external callers
- add unit coverage, an isolated supervisor regression, and operator documentation

## Verification

- focused restart unit tests: 4 passed
- full CLI unit suite: 230 passed
- CLI TypeScript production build: passed
- lint and format: passed
- supervisor lifecycle regression: passed in an isolated Linux x64 vmlab container with no host Docker socket

The repository-wide `tsgo` hook still reports unrelated baseline failures: missing `remark-directive` in the website package and existing implicit-any errors in other CLI commands.