### PR TITLE
feat(claude): choose the permission mode when implementing a plan

### DIFF
--- a/packages/app/e2e/support/helpers/permissions.ts
+++ b/packages/app/e2e/support/helpers/permissions.ts
@@ -4,9 +4,21 @@ export async function waitForPermissionPrompt(page: Page, timeout = 30_000): Pro
   await expect(page.getByTestId("permission-request-question").first()).toBeVisible({ timeout });
 }
 
+/**
+ * On a plan card this button approves in the mode named on it, which comes from
+ * client storage. E2E runs start with empty storage, so it is always the
+ * "Accept File Edits" default — asserted rather than assumed, because a change
+ * to that default silently changes what every plan-approving spec approves with.
+ * The mode picker beside it is what marks a card as a plan card; other
+ * permission cards have no mode and no such text.
+ */
 export async function allowPermission(page: Page): Promise<void> {
   const acceptButton = page.getByTestId("permission-request-accept").first();
   await expect(acceptButton).toBeVisible({ timeout: 5_000 });
+  const modePicker = page.getByTestId("permission-request-implement-mode").first();
+  if (await modePicker.isVisible()) {
+    await expect(acceptButton).toContainText("Accept File Edits");
+  }
   await acceptButton.click();
 }
 

--- a/packages/app/e2e/support/helpers/permissions.ts
+++ b/packages/app/e2e/support/helpers/permissions.ts
@@ -4,21 +4,9 @@ export async function waitForPermissionPrompt(page: Page, timeout = 30_000): Pro
   await expect(page.getByTestId("permission-request-question").first()).toBeVisible({ timeout });
 }
 
-/**
- * On a plan card this button approves in the mode named on it, which comes from
- * client storage. E2E runs start with empty storage, so it is always the
- * "Accept File Edits" default — asserted rather than assumed, because a change
- * to that default silently changes what every plan-approving spec approves with.
- * The mode picker beside it is what marks a card as a plan card; other
- * permission cards have no mode and no such text.
- */
 export async function allowPermission(page: Page): Promise<void> {
   const acceptButton = page.getByTestId("permission-request-accept").first();
   await expect(acceptButton).toBeVisible({ timeout: 5_000 });
-  const modePicker = page.getByTestId("permission-request-implement-mode").first();
-  if (await modePicker.isVisible()) {
-    await expect(acceptButton).toContainText("Accept File Edits");
-  }
   await acceptButton.click();
 }
 

--- a/packages/app/src/agent-stream/plan-implement-modes.test.ts
+++ b/packages/app/src/agent-stream/plan-implement-modes.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPlanImplementModes,
+  getPlanImplementModeScope,
+  resolvePlanImplementMode,
+} from "./plan-implement-modes";
+
+const OFFERED = [
+  { id: "default", label: "Always Ask" },
+  { id: "acceptEdits", label: "Accept File Edits" },
+  { id: "auto", label: "Auto mode" },
+  { id: "bypassPermissions", label: "Bypass" },
+];
+
+describe("getPlanImplementModes", () => {
+  it("returns the modes a plan request offers", () => {
+    expect(getPlanImplementModes({ metadata: { implementModes: OFFERED } })).toEqual(OFFERED);
+  });
+
+  it("drops entries that are not a well-formed mode", () => {
+    expect(
+      getPlanImplementModes({
+        metadata: {
+          implementModes: [
+            { id: "default", label: "Always Ask" },
+            { id: "", label: "Blank" },
+            { id: "acceptEdits" },
+            "acceptEdits",
+            null,
+            { id: "auto", label: "Auto mode" },
+          ],
+        },
+      }),
+    ).toEqual([
+      { id: "default", label: "Always Ask" },
+      { id: "auto", label: "Auto mode" },
+    ]);
+  });
+
+  it("returns nothing when the daemon sends no modes", () => {
+    // An older daemon, or a provider that does not change mode on plan approval.
+    expect(getPlanImplementModes({ metadata: undefined })).toEqual([]);
+    expect(getPlanImplementModes({ metadata: { planText: "- do the thing" } })).toEqual([]);
+    expect(getPlanImplementModes({ metadata: { implementModes: "acceptEdits" } })).toEqual([]);
+  });
+
+  it("returns nothing when a single mode is offered, so no picker appears", () => {
+    expect(
+      getPlanImplementModes({ metadata: { implementModes: [{ id: "auto", label: "Auto mode" }] } }),
+    ).toEqual([]);
+  });
+});
+
+describe("resolvePlanImplementMode", () => {
+  it("keeps the remembered mode when it is still offered", () => {
+    expect(resolvePlanImplementMode(OFFERED, "auto")).toEqual({ id: "auto", label: "Auto mode" });
+  });
+
+  it("falls back to Accept File Edits when the remembered mode is no longer offered", () => {
+    const withoutAuto = OFFERED.filter((mode) => mode.id !== "auto");
+    expect(resolvePlanImplementMode(withoutAuto, "auto")).toEqual({
+      id: "acceptEdits",
+      label: "Accept File Edits",
+    });
+  });
+
+  it("falls back to Accept File Edits when no mode has ever been chosen", () => {
+    expect(resolvePlanImplementMode(OFFERED, null)).toEqual({
+      id: "acceptEdits",
+      label: "Accept File Edits",
+    });
+  });
+
+  it("falls back to the first offered mode when Accept File Edits is missing", () => {
+    expect(resolvePlanImplementMode([{ id: "auto", label: "Auto mode" }], "gone")).toEqual({
+      id: "auto",
+      label: "Auto mode",
+    });
+  });
+
+  it("resolves nothing while the remembered mode is still loading", () => {
+    expect(resolvePlanImplementMode(OFFERED, undefined)).toBeNull();
+  });
+
+  it("resolves nothing when no modes are offered", () => {
+    expect(resolvePlanImplementMode([], "auto")).toBeNull();
+  });
+});
+
+describe("getPlanImplementModeScope", () => {
+  it("scopes to the project so every worktree of a repo shares one answer", () => {
+    expect(
+      getPlanImplementModeScope({
+        projectKey: "remote:github.com/getpaseo/paseo",
+        cwd: "/Users/me/worktrees/feature-a",
+      }),
+    ).toBe("remote:github.com/getpaseo/paseo");
+    expect(
+      getPlanImplementModeScope({
+        projectKey: "remote:github.com/getpaseo/paseo",
+        cwd: "/Users/me/worktrees/feature-b",
+      }),
+    ).toBe("remote:github.com/getpaseo/paseo");
+  });
+
+  it("keeps separate projects apart", () => {
+    expect(getPlanImplementModeScope({ projectKey: "/Users/me/scratch" })).not.toBe(
+      getPlanImplementModeScope({ projectKey: "/Users/me/work" }),
+    );
+  });
+
+  it("falls back to the checkout path when the agent has no project placement", () => {
+    expect(getPlanImplementModeScope({ projectKey: null, cwd: "/Users/me/loose-dir" })).toBe(
+      "/Users/me/loose-dir",
+    );
+    expect(getPlanImplementModeScope({ projectKey: "   ", cwd: "/Users/me/loose-dir" })).toBe(
+      "/Users/me/loose-dir",
+    );
+  });
+
+  it("falls back to one shared bucket when nothing identifies the agent", () => {
+    expect(getPlanImplementModeScope({})).toBe("");
+    expect(getPlanImplementModeScope({ projectKey: null, cwd: null })).toBe("");
+  });
+});

--- a/packages/app/src/agent-stream/plan-implement-modes.ts
+++ b/packages/app/src/agent-stream/plan-implement-modes.ts
@@ -1,0 +1,81 @@
+import type {
+  AgentPermissionRequest,
+  AgentPlanImplementMode,
+} from "@getpaseo/protocol/agent-types";
+
+/**
+ * Mode a plan approval falls back to when the daemon offers a picker but the
+ * user has never chosen, or their previous choice is no longer on offer (Auto
+ * mode disappears on Bedrock/Vertex hosts). Matches the mode the daemon applies
+ * for a response that carries no mode at all.
+ */
+export const DEFAULT_PLAN_IMPLEMENT_MODE_ID = "acceptEdits";
+
+/**
+ * Permission modes this plan request offers as implementation choices.
+ *
+ * The daemon sends these in `metadata` rather than as extra `actions` because a
+ * permission request is built once and broadcast to every client: extra actions
+ * would render as extra buttons on apps that predate the picker. Fewer than two
+ * entries means no picker — an older daemon, or a provider that does not change
+ * mode on plan approval at all.
+ */
+export function getPlanImplementModes(
+  request: Pick<AgentPermissionRequest, "metadata">,
+): AgentPlanImplementMode[] {
+  const raw = request.metadata?.["implementModes"];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const modes = raw.flatMap((entry): AgentPlanImplementMode[] => {
+    if (typeof entry !== "object" || entry === null) {
+      return [];
+    }
+    const { id, label } = entry as { id?: unknown; label?: unknown };
+    if (typeof id !== "string" || typeof label !== "string" || id.length === 0) {
+      return [];
+    }
+    return [{ id, label }];
+  });
+  return modes.length > 1 ? modes : [];
+}
+
+/**
+ * Bucket the remembered implement mode is stored under.
+ *
+ * The project, not the workspace: worktrees of one repo share a workflow, so
+ * scoping any narrower would forget the choice every time you branch. Falls back
+ * to the checkout path for agents with no project placement (a non-git or
+ * ungrouped directory), and to one shared bucket when even that is missing.
+ */
+export function getPlanImplementModeScope(input: {
+  projectKey?: string | null;
+  cwd?: string | null;
+}): string {
+  return input.projectKey?.trim() || input.cwd?.trim() || "";
+}
+
+/**
+ * The mode a plan card should start on.
+ *
+ * Returns `null` while the remembered choice is still loading from storage, so
+ * callers can hold the decision rather than freeze the fallback and silently
+ * discard what the user actually picked last time.
+ */
+export function resolvePlanImplementMode(
+  offeredModes: readonly AgentPlanImplementMode[],
+  rememberedModeId: string | null | undefined,
+): AgentPlanImplementMode | null {
+  if (rememberedModeId === undefined || offeredModes.length === 0) {
+    return null;
+  }
+  const remembered = offeredModes.find((mode) => mode.id === rememberedModeId);
+  if (remembered) {
+    return remembered;
+  }
+  return (
+    offeredModes.find((mode) => mode.id === DEFAULT_PLAN_IMPLEMENT_MODE_ID) ??
+    offeredModes[0] ??
+    null
+  );
+}

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
   useState,
   type ComponentProps,
+  type ComponentType,
   type ReactNode,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -47,7 +48,22 @@ import type {
   AgentCapabilityFlags,
   AgentPermissionAction,
   AgentPermissionResponse,
+  AgentPlanImplementMode,
 } from "@getpaseo/protocol/agent-types";
+import { AGENT_PROVIDER_DEFINITIONS } from "@getpaseo/protocol/provider-manifest";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { getAgentModeOptionIcon, type AgentControlIcon } from "@/agent-controls/icons";
+import {
+  getPlanImplementModes,
+  getPlanImplementModeScope,
+  resolvePlanImplementMode,
+} from "./plan-implement-modes";
+import { usePreferredPlanImplementMode } from "@/hooks/use-preferred-plan-implement-mode";
 import type { AgentScreenAgent } from "@/hooks/use-agent-screen-state-machine";
 import { useSessionStore } from "@/stores/session-store";
 import { useFileExplorerActions } from "@/hooks/use-file-explorer-actions";
@@ -125,6 +141,7 @@ function renderLiveAuxiliaryNode(input: {
 function renderPendingPermissionsNode(input: {
   pendingPermissions: PendingPermission[];
   client: DaemonClient | null;
+  planImplementModeScope: string;
 }): ReactNode {
   if (input.pendingPermissions.length === 0) {
     return null;
@@ -132,7 +149,12 @@ function renderPendingPermissionsNode(input: {
   return (
     <View style={stylesheet.permissionsContainer}>
       {input.pendingPermissions.map((permission) => (
-        <PermissionRequestCard key={permission.key} permission={permission} client={input.client} />
+        <PermissionRequestCard
+          key={permission.key}
+          permission={permission}
+          client={input.client}
+          planImplementModeScope={input.planImplementModeScope}
+        />
       ))}
     </View>
   );
@@ -843,13 +865,23 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       [pendingPermissions, agentId],
     );
 
+    const planImplementModeScope = useMemo(
+      () =>
+        getPlanImplementModeScope({
+          projectKey: context.projectPlacement?.projectKey,
+          cwd: context.cwd,
+        }),
+      [context.projectPlacement?.projectKey, context.cwd],
+    );
+
     const pendingPermissionsNode = useMemo(
       () =>
         renderPendingPermissionsNode({
           pendingPermissions: pendingPermissionItems,
           client,
+          planImplementModeScope,
         }),
-      [client, pendingPermissionItems],
+      [client, pendingPermissionItems, planImplementModeScope],
     );
     const turnFooterNode = useMemo(
       () =>
@@ -1177,28 +1209,199 @@ function ToolCallSlot({
 const ThemedLoadingSpinner = withUnistyles(LoadingSpinner);
 const ThemedCheckIcon = withUnistyles(Check);
 const ThemedXIcon = withUnistyles(X);
+const ThemedChevronDown = withUnistyles(ChevronDown);
 
-const primaryColorMapping = (theme: Theme) => ({
-  color: theme.colors.foreground,
-});
 const mutedColorMapping = (theme: Theme) => ({
   color: theme.colors.foregroundMuted,
 });
 
-const pressableStyle = ({
+function buildPressableStyle(isPrimary: boolean) {
+  // Every `permissionStyles` read stays inside the callback: the stylesheet is
+  // created at the bottom of this module, after these constants are assigned.
+  return ({ pressed, hovered = false }: PressableStateCallbackType & { hovered?: boolean }) => {
+    const hoveredStyle = isPrimary
+      ? permissionStyles.optionButtonPrimaryHovered
+      : permissionStyles.optionButtonHovered;
+    return [
+      permissionStyles.optionButton,
+      isPrimary ? permissionStyles.optionButtonPrimary : null,
+      hovered ? hoveredStyle : null,
+      pressed ? permissionStyles.optionButtonPressed : null,
+    ];
+  };
+}
+
+const pressableStyle = buildPressableStyle(false);
+const primaryPressableStyle = buildPressableStyle(true);
+
+const accentColorMapping = (theme: Theme) => ({
+  color: theme.colors.accentForeground,
+});
+
+const implementActionStyle = ({
   pressed,
   hovered = false,
 }: PressableStateCallbackType & { hovered?: boolean }) => [
-  permissionStyles.optionButton,
-  hovered ? permissionStyles.optionButtonHovered : null,
-  pressed ? permissionStyles.optionButtonPressed : null,
+  permissionStyles.implementAction,
+  hovered || pressed ? permissionStyles.optionButtonPrimaryHovered : null,
 ];
+
+const implementCaretStyle = ({
+  hovered,
+  pressed,
+  open,
+}: {
+  hovered: boolean;
+  pressed: boolean;
+  open: boolean;
+}) => [
+  permissionStyles.implementCaret,
+  hovered || pressed || open ? permissionStyles.optionButtonPrimaryHovered : null,
+];
+
+/**
+ * `withUnistyles` wrappers for the mode icons, cached by icon component. The
+ * icon is picked per mode at render time, so wrapping inline would hand React a
+ * new component type on every render and remount the icon each time.
+ */
+const themedModeIcons = new Map<AgentControlIcon, ComponentType<{ size: number }>>();
+
+function getThemedModeIcon(icon: AgentControlIcon): ComponentType<{ size: number }> {
+  const cached = themedModeIcons.get(icon);
+  if (cached) {
+    return cached;
+  }
+  const themed = withUnistyles(icon, mutedColorMapping);
+  themedModeIcons.set(icon, themed);
+  return themed;
+}
+
+interface PlanImplementButtonProps {
+  label: string;
+  provider: string;
+  modes: AgentPlanImplementMode[];
+  selectedMode: AgentPlanImplementMode | null;
+  isResponding: boolean;
+  isRespondingImplement: boolean;
+  onSelectMode: (mode: AgentPlanImplementMode) => void;
+  onImplement: () => void;
+}
+
+/**
+ * Approve the plan, and pick the permission mode the agent continues in.
+ *
+ * One accent surface, split by a hairline rather than a border, so it reads as a
+ * single call to action carrying its setting — the shape a merge button uses for
+ * its merge strategy. Built out of separate bordered boxes it read as a third
+ * action next to Reject and Implement; parked beside the question line it read as
+ * an unrelated control. Picking a mode only changes what the button will do.
+ */
+function PlanImplementButton({
+  label,
+  provider,
+  modes,
+  selectedMode,
+  isResponding,
+  isRespondingImplement,
+  onSelectMode,
+  onImplement,
+}: PlanImplementButtonProps) {
+  const { t } = useTranslation();
+  // Until the stored mode lands there is no honest label, and a pick made now
+  // would be overwritten by it a moment later.
+  const isHydrating = selectedMode === null;
+
+  return (
+    <View style={permissionStyles.implementButton}>
+      <Pressable
+        accessibilityRole="button"
+        testID="permission-request-accept"
+        style={implementActionStyle}
+        onPress={onImplement}
+        disabled={isResponding || isHydrating}
+      >
+        {isRespondingImplement || !selectedMode ? (
+          <ThemedLoadingSpinner size="small" uniProps={accentColorMapping} />
+        ) : (
+          <View style={permissionStyles.optionContent}>
+            <ThemedCheckIcon size={14} uniProps={accentColorMapping} />
+            <Text style={[permissionStyles.optionText, permissionStyles.optionTextPrimary]}>
+              {label}
+            </Text>
+            <Text style={permissionStyles.implementModeText} numberOfLines={1}>
+              {selectedMode.label}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+      <View style={permissionStyles.implementDivider} />
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          testID="permission-request-implement-mode"
+          style={implementCaretStyle}
+          accessibilityRole="button"
+          accessibilityLabel={t("agentStream.permission.chooseImplementMode")}
+          disabled={isResponding || isHydrating}
+        >
+          <ThemedChevronDown size={14} uniProps={accentColorMapping} />
+        </DropdownMenuTrigger>
+        {/* No `side` override: opening down reads better on a wide card, and the anchor
+            already flips the menu up on its own where there is no room below. */}
+        <DropdownMenuContent align="end" minWidth={192} testID="permission-request-mode-menu">
+          {modes.map((mode) => (
+            <PlanImplementModeMenuItem
+              key={mode.id}
+              provider={provider}
+              mode={mode}
+              isSelected={mode.id === selectedMode?.id}
+              onSelect={onSelectMode}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </View>
+  );
+}
+
+function PlanImplementModeMenuItem({
+  provider,
+  mode,
+  isSelected,
+  onSelect,
+}: {
+  provider: string;
+  mode: AgentPlanImplementMode;
+  isSelected: boolean;
+  onSelect: (mode: AgentPlanImplementMode) => void;
+}) {
+  const icon = getAgentModeOptionIcon(provider, mode.id, AGENT_PROVIDER_DEFINITIONS);
+  const handleSelect = useCallback(() => onSelect(mode), [onSelect, mode]);
+  const leading = useMemo(() => {
+    if (!icon) {
+      return null;
+    }
+    const Icon = getThemedModeIcon(icon);
+    return <Icon size={16} />;
+  }, [icon]);
+  return (
+    <DropdownMenuItem
+      testID={`permission-request-implement-mode-${mode.id}`}
+      onSelect={handleSelect}
+      selected={isSelected}
+      showSelectedCheck
+      leading={leading}
+    >
+      {mode.label}
+    </DropdownMenuItem>
+  );
+}
 
 interface PermissionActionButtonProps {
   action: AgentPermissionAction;
   isRespondingAction: boolean;
   isResponding: boolean;
   isPrimary: boolean;
+  isDisabled?: boolean;
   Icon: typeof ThemedCheckIcon;
   testID: string;
   onPress: (action: AgentPermissionAction) => void;
@@ -1209,6 +1412,7 @@ function PermissionActionButton({
   isRespondingAction,
   isResponding,
   isPrimary,
+  isDisabled = false,
   Icon,
   testID,
   onPress,
@@ -1217,14 +1421,14 @@ function PermissionActionButton({
   const optionTextStyle = isPrimary
     ? [permissionStyles.optionText, permissionStyles.optionTextPrimary]
     : permissionStyles.optionText;
-  const colorMapping = isPrimary ? primaryColorMapping : mutedColorMapping;
+  const colorMapping = isPrimary ? accentColorMapping : mutedColorMapping;
   return (
     <Pressable
       accessibilityRole="button"
       testID={testID}
-      style={pressableStyle}
+      style={isPrimary ? primaryPressableStyle : pressableStyle}
       onPress={handlePress}
-      disabled={isResponding}
+      disabled={isResponding || isDisabled}
     >
       {isRespondingAction ? (
         <ThemedLoadingSpinner size="small" uniProps={colorMapping} />
@@ -1241,9 +1445,11 @@ function PermissionActionButton({
 function PermissionRequestCard({
   permission,
   client,
+  planImplementModeScope,
 }: {
   permission: PendingPermission;
   client: DaemonClient | null;
+  planImplementModeScope: string;
 }) {
   const { t } = useTranslation();
   const isMobile = useIsCompactFormFactor();
@@ -1329,11 +1535,32 @@ function PermissionRequestCard({
   } = permissionMutation;
 
   const [respondingActionId, setRespondingActionId] = useState<string | null>(null);
+  const [chosenImplementMode, setChosenImplementMode] = useState<AgentPlanImplementMode | null>(
+    null,
+  );
 
   useEffect(() => {
     resetPermissionMutation();
     setRespondingActionId(null);
+    setChosenImplementMode(null);
   }, [permission.request.id, resetPermissionMutation]);
+
+  const implementModes = useMemo(() => getPlanImplementModes(request), [request]);
+  const showImplementModePicker = isPlanRequest && implementModes.length > 1;
+  const { preferredPlanImplementModeId, updatePreferredPlanImplementMode } =
+    usePreferredPlanImplementMode(planImplementModeScope);
+  const hydratedImplementMode = resolvePlanImplementMode(
+    implementModes,
+    preferredPlanImplementModeId,
+  );
+  // Pin the mode as soon as storage answers, so the button's label cannot change
+  // under a user who is already reading it.
+  useEffect(() => {
+    if (hydratedImplementMode) {
+      setChosenImplementMode((current) => current ?? hydratedImplementMode);
+    }
+  }, [hydratedImplementMode]);
+
   const handleResponse = useCallback(
     (response: AgentPermissionResponse) => {
       respondToPermission({
@@ -1353,6 +1580,7 @@ function PermissionRequestCard({
         handleResponse({
           behavior: "allow",
           selectedActionId: action.id,
+          ...(chosenImplementMode ? { mode: chosenImplementMode.id } : {}),
         });
         return;
       }
@@ -1362,7 +1590,24 @@ function PermissionRequestCard({
         message: "Denied by user",
       });
     },
-    [handleResponse],
+    [chosenImplementMode, handleResponse],
+  );
+
+  const handleImplementPress = useCallback(() => {
+    const implementAction = resolvedActions.find((action) => action.behavior === "allow");
+    if (implementAction) {
+      handleActionPress(implementAction);
+    }
+  }, [handleActionPress, resolvedActions]);
+
+  // Picking from the menu only changes what the button will do, and is
+  // remembered right away so the next plan card opens on the same mode.
+  const handleSelectImplementMode = useCallback(
+    (mode: AgentPlanImplementMode) => {
+      setChosenImplementMode(mode);
+      updatePreferredPlanImplementMode(mode.id);
+    },
+    [updatePreferredPlanImplementMode],
   );
 
   const optionsContainerStyle = useMemo(
@@ -1394,6 +1639,21 @@ function PermissionRequestCard({
           const isPrimary = action.variant === "primary";
           const isRespondingAction = respondingActionId === action.id;
           const Icon = action.behavior === "allow" ? ThemedCheckIcon : ThemedXIcon;
+          if (showImplementModePicker && action.behavior === "allow") {
+            return (
+              <PlanImplementButton
+                key={action.id}
+                label={action.label}
+                provider={request.provider}
+                modes={implementModes}
+                selectedMode={chosenImplementMode}
+                isResponding={isResponding}
+                isRespondingImplement={isRespondingAction}
+                onSelectMode={handleSelectImplementMode}
+                onImplement={handleImplementPress}
+              />
+            );
+          }
           let testID: string;
           if (action.behavior === "deny") testID = "permission-request-deny";
           else if (action.id === "accept" || action.id === "implement")
@@ -1593,6 +1853,13 @@ const permissionStyles = StyleSheet.create((theme) => ({
   optionButtonHovered: {
     backgroundColor: theme.colors.surface2,
   },
+  optionButtonPrimary: {
+    backgroundColor: theme.colors.accent,
+    borderColor: theme.colors.accent,
+  },
+  optionButtonPrimaryHovered: {
+    opacity: 0.9,
+  },
   optionButtonPressed: {
     opacity: 0.9,
   },
@@ -1607,7 +1874,49 @@ const permissionStyles = StyleSheet.create((theme) => ({
     color: theme.colors.foregroundMuted,
   },
   optionTextPrimary: {
-    color: theme.colors.foreground,
+    color: theme.colors.accentForeground,
+  },
+  implementButton: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    borderRadius: theme.borderRadius.md,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.accent,
+    backgroundColor: theme.colors.accent,
+    overflow: "hidden",
+  },
+  // flex, not flexShrink: when the card stacks its buttons full width the label
+  // group centres like Reject's does and the caret stays pinned to the trailing
+  // edge, instead of the whole thing bunching up on the left.
+  implementAction: {
+    flex: 1,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  // A hairline, not a border: the two halves are one surface, and a full-strength
+  // divider is what made the earlier split read as two buttons.
+  implementDivider: {
+    width: theme.borderWidth[1],
+    backgroundColor: theme.colors.accentForeground,
+    opacity: 0.2,
+    marginVertical: theme.spacing[2],
+  },
+  implementCaret: {
+    paddingHorizontal: theme.spacing[2],
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  implementModeText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.normal,
+    color: theme.colors.accentForeground,
+    opacity: 0.7,
+    flexShrink: 1,
+  },
+  splitButtonSegmentHovered: {
+    backgroundColor: theme.colors.surface2,
   },
 }));
 

--- a/packages/app/src/hooks/use-preferred-plan-implement-mode.ts
+++ b/packages/app/src/hooks/use-preferred-plan-implement-mode.ts
@@ -1,0 +1,71 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useCallback } from "react";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface PreferredPlanImplementModeState {
+  modeIdByScope: Record<string, string>;
+  /**
+   * Storage has been read, successfully or not. Tracked here rather than through
+   * `persist.hasHydrated()`, which stays false forever when the read rejects —
+   * that would leave the Implement button spinning with no way to approve a plan.
+   */
+  hasLoaded: boolean;
+  setModeId: (scope: string, modeId: string) => void;
+}
+
+export const usePreferredPlanImplementModeStore = create<PreferredPlanImplementModeState>()(
+  persist(
+    (set) => ({
+      modeIdByScope: {},
+      hasLoaded: false,
+      setModeId: (scope, modeId) =>
+        set((state) => ({ modeIdByScope: { ...state.modeIdByScope, [scope]: modeId } })),
+    }),
+    {
+      name: "preferred-plan-implement-mode",
+      version: 2,
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ modeIdByScope: state.modeIdByScope }),
+      // v1 held one mode for the whole install. There is no way to tell which
+      // project it was meant for, so it is dropped rather than guessed onto one.
+      // Present mainly so a version bump does not log a migration error.
+      migrate: () => ({ modeIdByScope: {} }),
+      // Runs on both the success and the failure path of the initial read.
+      onRehydrateStorage: () => () => {
+        usePreferredPlanImplementModeStore.setState({ hasLoaded: true });
+      },
+    },
+  ),
+);
+
+/**
+ * The permission mode this project's plans were last implemented with.
+ *
+ * Scoped per project rather than per install because how much rein you give an
+ * agent is a property of the code it is working on: a scratch repo and a
+ * production one earn different answers. A project with no answer yet starts at
+ * the usual fallback rather than inheriting the last project's choice, so a
+ * permissive mode picked once cannot follow you into a repo where you did not
+ * want it. Build the scope with `getPlanImplementModeScope`.
+ *
+ * `preferredPlanImplementModeId` is `undefined` until storage has been read, so
+ * callers can hold a decision instead of committing to the fallback and then
+ * changing it under the user.
+ */
+export function usePreferredPlanImplementMode(scope: string): {
+  preferredPlanImplementModeId: string | null | undefined;
+  updatePreferredPlanImplementMode: (modeId: string) => void;
+} {
+  const modeId = usePreferredPlanImplementModeStore((state) => state.modeIdByScope[scope] ?? null);
+  const hasLoaded = usePreferredPlanImplementModeStore((state) => state.hasLoaded);
+  const setModeId = usePreferredPlanImplementModeStore((state) => state.setModeId);
+  const updatePreferredPlanImplementMode = useCallback(
+    (nextModeId: string) => setModeId(scope, nextModeId),
+    [scope, setModeId],
+  );
+  return {
+    preferredPlanImplementModeId: hasLoaded ? modeId : undefined,
+    updatePreferredPlanImplementMode,
+  };
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -199,6 +199,7 @@ export const ar: TranslationResources = {
       deny: "ينكر",
       accept: "يقبل",
       implement: "ينفذ",
+      chooseImplementMode: "اختر وضع التنفيذ",
       question: "كيف تريد المتابعة؟",
       proposedPlan: "الخطة المقترحة",
     },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -197,6 +197,7 @@ export const en = {
       deny: "Deny",
       accept: "Accept",
       implement: "Implement",
+      chooseImplementMode: "Choose implement mode",
       question: "How would you like to proceed?",
       proposedPlan: "Proposed plan",
     },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -199,6 +199,7 @@ export const es: TranslationResources = {
       deny: "Denegar",
       accept: "Aceptar",
       implement: "Implementar",
+      chooseImplementMode: "Elegir modo de implementación",
       question: "¿Cómo le gustaría proceder?",
       proposedPlan: "Plan propuesto",
     },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -201,6 +201,7 @@ export const fr: TranslationResources = {
       deny: "Refuser",
       accept: "Accepter",
       implement: "Mettre en œuvre",
+      chooseImplementMode: "Choisir le mode d'implémentation",
       question: "Comment souhaitez-vous procéder?",
       proposedPlan: "Plan proposé",
     },

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -199,6 +199,7 @@ export const ja: TranslationResources = {
       deny: "拒否",
       accept: "承認",
       implement: "実装",
+      chooseImplementMode: "実装モードを選択",
       question: "どのように続けますか？",
       proposedPlan: "提案されたプラン",
     },

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -199,6 +199,7 @@ export const ko: TranslationResources = {
       deny: "거부",
       accept: "수락",
       implement: "구현",
+      chooseImplementMode: "구현 모드 선택",
       question: "어떻게 진행할까요?",
       proposedPlan: "제안된 계획",
     },

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -199,6 +199,7 @@ export const ptBR: TranslationResources = {
       deny: "Negar",
       accept: "Aceitar",
       implement: "Implementar",
+      chooseImplementMode: "Escolher modo de implementação",
       question: "Como você quer prosseguir?",
       proposedPlan: "Plano proposto",
     },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -199,6 +199,7 @@ export const ru: TranslationResources = {
       deny: "Отрицать",
       accept: "Принимать",
       implement: "Осуществлять",
+      chooseImplementMode: "Выбрать режим реализации",
       question: "Как бы вы хотели продолжить?",
       proposedPlan: "Предлагаемый план",
     },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -199,6 +199,7 @@ export const zhCN: TranslationResources = {
       deny: "拒绝",
       accept: "接受",
       implement: "实施",
+      chooseImplementMode: "选择实施模式",
       question: "你想如何继续？",
       proposedPlan: "建议计划",
     },

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -417,6 +417,17 @@ export interface AgentPermissionAction {
   intent?: "implement" | "implement_resume" | "dismiss";
 }
 
+/**
+ * A permission mode a `plan` request offers as an implementation choice,
+ * carried in the request's `metadata.implementModes`. Metadata rather than
+ * `actions` so that clients which predate the picker keep rendering the plain
+ * two-button plan card instead of one button per mode.
+ */
+export interface AgentPlanImplementMode {
+  id: string;
+  label: string;
+}
+
 export interface AgentPermissionRequest {
   id: string;
   provider: AgentProvider;
@@ -435,6 +446,12 @@ export type AgentPermissionResponse =
   | {
       behavior: "allow";
       selectedActionId?: string;
+      /**
+       * Permission mode the agent should switch to as part of this approval.
+       * Only meaningful for `plan` requests, and only honored when the mode was
+       * offered by the request itself (see `implementModes` in its metadata).
+       */
+      mode?: string;
       updatedInput?: AgentMetadata;
       updatedPermissions?: AgentPermissionUpdate[];
     }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -406,6 +406,7 @@ export const AgentPermissionResponseSchema: z.ZodType<AgentPermissionResponse> =
     z.object({
       behavior: z.literal("allow"),
       selectedActionId: z.string().optional(),
+      mode: z.string().optional(),
       updatedInput: z.record(z.string(), z.unknown()).optional(),
       updatedPermissions: z.array(AgentPermissionUpdateSchema).optional(),
     }),

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -461,6 +461,17 @@ export interface AgentPermissionAction {
   intent?: "implement" | "implement_resume" | "dismiss";
 }
 
+/**
+ * A permission mode a `plan` request offers as an implementation choice,
+ * carried in the request's `metadata.implementModes`. Metadata rather than
+ * `actions` so that clients which predate the picker keep rendering the plain
+ * two-button plan card instead of one button per mode.
+ */
+export interface AgentPlanImplementMode {
+  id: string;
+  label: string;
+}
+
 export interface AgentPermissionRequest {
   id: string;
   provider: AgentProvider;
@@ -479,6 +490,12 @@ export type AgentPermissionResponse =
   | {
       behavior: "allow";
       selectedActionId?: string;
+      /**
+       * Permission mode the agent should switch to as part of this approval.
+       * Only meaningful for `plan` requests, and only honored when the mode was
+       * offered by the request itself (see `implementModes` in its metadata).
+       */
+      mode?: string;
       updatedInput?: AgentMetadata;
       updatedPermissions?: AgentPermissionUpdate[];
     }

--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -1035,7 +1035,36 @@ test("preserves bypass capability across query restarts triggered by thinking ch
   }
 });
 
-test("plan approval exposes a resume-bypass action and can return to bypassPermissions", async () => {
+interface PlanPermissionInternals {
+  handlePermissionRequest: (
+    toolName: string,
+    input: Record<string, unknown>,
+    options: Record<string, unknown>,
+  ) => Promise<unknown>;
+}
+
+async function openPlanPermission(
+  session: Awaited<ReturnType<typeof createSession>>,
+  events: AgentStreamEvent[],
+) {
+  await session.setMode("plan");
+  const internal: PlanPermissionInternals = asInternals(session);
+  const resolution = internal.handlePermissionRequest(
+    "ExitPlanMode",
+    { plan: "- Implement the approved plan" },
+    {},
+  );
+  const requestEvent = events.find(
+    (event): event is Extract<AgentStreamEvent, { type: "permission_requested" }> =>
+      event.type === "permission_requested" && event.request.kind === "plan",
+  );
+  if (!requestEvent) {
+    throw new Error("Expected plan permission request");
+  }
+  return { resolution, request: requestEvent.request };
+}
+
+test("plan request keeps the two-button action list and offers the modes in metadata", async () => {
   const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
   sdkQueryFactory.mockImplementation(() => queryMock);
 
@@ -1044,30 +1073,11 @@ test("plan approval exposes a resume-bypass action and can return to bypassPermi
   session.subscribe((event) => events.push(event));
 
   try {
-    await session.setMode("bypassPermissions");
-    await session.setMode("plan");
+    const { resolution, request } = await openPlanPermission(session, events);
 
-    const internal: {
-      handlePermissionRequest: (
-        toolName: string,
-        input: Record<string, unknown>,
-        options: Record<string, unknown>,
-      ) => Promise<unknown>;
-    } = asInternals(session);
-
-    const pendingResolution = internal.handlePermissionRequest(
-      "ExitPlanMode",
-      { plan: "- Implement the approved plan" },
-      {},
-    );
-
-    const requestEvent = events.find(
-      (event): event is Extract<AgentStreamEvent, { type: "permission_requested" }> =>
-        event.type === "permission_requested" && event.request.kind === "plan",
-    );
-
-    expect(requestEvent).toBeDefined();
-    expect(requestEvent?.request.actions).toEqual([
+    // An app that predates the mode picker renders one button per action, so the
+    // extra modes must not arrive as actions.
+    expect(request.actions).toEqual([
       {
         id: "reject",
         label: "Reject",
@@ -1082,30 +1092,169 @@ test("plan approval exposes a resume-bypass action and can return to bypassPermi
         variant: "primary",
         intent: "implement",
       },
-      {
-        id: "implement_resume",
-        label: "Implement with Bypass",
-        behavior: "allow",
-        variant: "secondary",
-        intent: "implement_resume",
-      },
+    ]);
+    expect(request.metadata?.implementModes).toEqual([
+      { id: "default", label: "Always Ask" },
+      { id: "acceptEdits", label: "Accept File Edits" },
+      { id: "auto", label: "Auto mode" },
+      { id: "bypassPermissions", label: "Bypass" },
     ]);
 
-    if (!requestEvent) {
-      throw new Error("Expected plan permission request");
+    await session.respondToPermission(request.id, {
+      behavior: "allow",
+      selectedActionId: "implement",
+    });
+    await expect(resolution).resolves.toMatchObject({ behavior: "allow" });
+  } finally {
+    await session.close();
+  }
+});
+
+for (const transport of ["CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX"] as const) {
+  test(`plan request omits Auto mode when ${transport} is set`, async () => {
+    vi.stubEnv(transport, "1");
+    const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+    sdkQueryFactory.mockImplementation(() => queryMock);
+
+    const session = await createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      const { resolution, request } = await openPlanPermission(session, events);
+      expect(request.metadata?.implementModes).toEqual([
+        { id: "default", label: "Always Ask" },
+        { id: "acceptEdits", label: "Accept File Edits" },
+        { id: "bypassPermissions", label: "Bypass" },
+      ]);
+
+      await session.respondToPermission(request.id, {
+        behavior: "allow",
+        selectedActionId: "implement",
+      });
+      await expect(resolution).resolves.toMatchObject({ behavior: "allow" });
+    } finally {
+      await session.close();
+      vi.unstubAllEnvs();
     }
+  });
+}
 
-    await session.respondToPermission(requestEvent.request.id, {
+for (const modeId of ["default", "acceptEdits", "auto", "bypassPermissions"] as const) {
+  test(`plan approval switches to the offered mode '${modeId}'`, async () => {
+    const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+    sdkQueryFactory.mockImplementation(() => queryMock);
+
+    const session = await createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      const { resolution, request } = await openPlanPermission(session, events);
+      await session.respondToPermission(request.id, {
+        behavior: "allow",
+        selectedActionId: "implement",
+        mode: modeId,
+      });
+
+      await expect(resolution).resolves.toMatchObject({
+        behavior: "allow",
+        updatedInput: { plan: "- Implement the approved plan" },
+      });
+      expect(queryMock.setPermissionMode).toHaveBeenLastCalledWith(modeId);
+      expect(await session.getCurrentMode()).toBe(modeId);
+    } finally {
+      await session.close();
+    }
+  });
+}
+
+for (const [name, mode] of [
+  ["no mode at all", undefined],
+  ["a mode the request never offered", "somethingElse"],
+  ["plan mode, which is never offered", "plan"],
+] as const) {
+  test(`plan approval falls back to acceptEdits for ${name}`, async () => {
+    const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+    sdkQueryFactory.mockImplementation(() => queryMock);
+
+    const session = await createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      const { resolution, request } = await openPlanPermission(session, events);
+      await session.respondToPermission(request.id, {
+        behavior: "allow",
+        selectedActionId: "implement",
+        ...(mode === undefined ? {} : { mode }),
+      });
+
+      await expect(resolution).resolves.toMatchObject({ behavior: "allow" });
+      expect(queryMock.setPermissionMode).toHaveBeenLastCalledWith("acceptEdits");
+      expect(await session.getCurrentMode()).toBe("acceptEdits");
+
+      // The rejected choice stays visible, so a client asking for a mode that was
+      // never offered is diagnosable from the timeline.
+      const planApproval = events.find(
+        (event) =>
+          event.type === "timeline" &&
+          event.item.type === "tool_call" &&
+          event.item.name === "plan_approval",
+      );
+      if (planApproval?.type !== "timeline" || planApproval.item.type !== "tool_call") {
+        throw new Error("Expected a plan_approval tool call");
+      }
+      expect(planApproval.item.detail).toMatchObject({
+        output: { requestedMode: mode ?? null, targetMode: "acceptEdits", mode: "acceptEdits" },
+      });
+    } finally {
+      await session.close();
+    }
+  });
+}
+
+test("plan approval still resolves and reports an error when the mode switch fails", async () => {
+  const queryMock = createBaseQueryMock(vi.fn(async () => ({ done: true, value: undefined })));
+  sdkQueryFactory.mockImplementation(() => queryMock);
+
+  const session = await createSession();
+  const events: AgentStreamEvent[] = [];
+  session.subscribe((event) => events.push(event));
+
+  try {
+    const { resolution, request } = await openPlanPermission(session, events);
+    queryMock.setPermissionMode.mockRejectedValueOnce(new Error("transport closed"));
+
+    await session.respondToPermission(request.id, {
       behavior: "allow",
-      selectedActionId: "implement_resume",
+      selectedActionId: "implement",
+      mode: "bypassPermissions",
     });
 
-    await expect(pendingResolution).resolves.toMatchObject({
-      behavior: "allow",
-      updatedInput: { plan: "- Implement the approved plan" },
+    // The pending entry is deleted before the mode switch, so a throw there would
+    // strand the request forever.
+    await expect(resolution).resolves.toMatchObject({ behavior: "allow" });
+
+    const errorItem = events.find(
+      (event) => event.type === "timeline" && event.item.type === "error",
+    );
+    expect(errorItem).toBeDefined();
+
+    const planApproval = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.name === "plan_approval",
+    );
+    expect(planApproval).toBeDefined();
+    if (planApproval?.type !== "timeline" || planApproval.item.type !== "tool_call") {
+      throw new Error("Expected a plan_approval tool call");
+    }
+    expect(planApproval.item.detail).toMatchObject({
+      output: { requestedMode: "bypassPermissions", mode: "plan" },
     });
-    expect(queryMock.setPermissionMode).toHaveBeenLastCalledWith("bypassPermissions");
-    expect(await session.getCurrentMode()).toBe("bypassPermissions");
+    expect(await session.getCurrentMode()).toBe("plan");
   } finally {
     await session.close();
   }

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -99,6 +99,7 @@ import {
   type AgentModelDefinition,
   type AgentPermissionRequest,
   type AgentPermissionRequestKind,
+  type AgentPlanImplementMode,
   type AgentPermissionResponse,
   type AgentPermissionUpdate,
   type AgentPersistenceHandle,
@@ -1055,14 +1056,8 @@ function buildClaudeQuestionPermissionSummary(
   return labels.length > 0 ? { title, description: labels.join(" / ") } : { title };
 }
 
-function getClaudeModeLabel(modeId: PermissionMode): string {
-  return DEFAULT_MODES.find((mode) => mode.id === modeId)?.label ?? modeId;
-}
-
-function buildClaudePlanPermissionActions(
-  resumeMode: PermissionMode | null,
-): AgentPermissionAction[] {
-  const actions: AgentPermissionAction[] = [
+function buildClaudePlanPermissionActions(): AgentPermissionAction[] {
+  return [
     {
       id: "reject",
       label: "Reject",
@@ -1078,18 +1073,52 @@ function buildClaudePlanPermissionActions(
       intent: "implement",
     },
   ];
+}
 
-  if (resumeMode === "bypassPermissions") {
-    actions.push({
-      id: "implement_resume",
-      label: `Implement with ${getClaudeModeLabel(resumeMode)}`,
-      behavior: "allow",
-      variant: "secondary",
-      intent: "implement_resume",
-    });
+/**
+ * Permission modes the client may pick from when approving a plan.
+ *
+ * These ride in the request's `metadata` rather than as extra `actions`: the
+ * request is built once and broadcast to every connected client, so an app that
+ * predates the mode picker would render one button per action. It ignores
+ * metadata it does not understand, so the old card stays a two-button card.
+ */
+function buildClaudePlanImplementModes(env: NodeJS.ProcessEnv): AgentPlanImplementMode[] {
+  return DEFAULT_MODES.filter((mode) => mode.id !== "plan")
+    .filter(
+      // Auto mode is unusable on these transports and setMode() throws for it.
+      (mode) => mode.id !== "auto" || detectIneligibleAutoModeTransport(env) === null,
+    )
+    .map((mode) => ({ id: mode.id, label: mode.label }));
+}
+
+function readClaudePlanImplementModes(request: AgentPermissionRequest): AgentPlanImplementMode[] {
+  const raw = request.metadata?.implementModes;
+  if (!Array.isArray(raw)) {
+    return [];
   }
+  return raw.flatMap((entry) => {
+    if (!isMetadata(entry) || typeof entry.id !== "string" || typeof entry.label !== "string") {
+      return [];
+    }
+    return [{ id: entry.id, label: entry.label }];
+  });
+}
 
-  return actions;
+/**
+ * The mode a plan approval should land in: whatever the client picked, but only
+ * if the request itself offered it. Anything else falls back to the historical
+ * behavior so an old or malformed client cannot pick a mode we never advertised.
+ */
+function resolveClaudePlanApprovalMode(
+  request: AgentPermissionRequest,
+  requestedMode: string | undefined,
+): PermissionMode {
+  if (!requestedMode || !isPermissionMode(requestedMode)) {
+    return "acceptEdits";
+  }
+  const offered = readClaudePlanImplementModes(request);
+  return offered.some((mode) => mode.id === requestedMode) ? requestedMode : "acceptEdits";
 }
 
 interface TimelineFragment {
@@ -2015,7 +2044,6 @@ class ClaudeAgentSession implements AgentSession {
   private claudeSessionId: string | null;
   private persistence: AgentPersistenceHandle | null;
   private currentMode: PermissionMode;
-  private planResumeMode: PermissionMode | null = null;
   private availableModes: AgentMode[] = DEFAULT_MODES;
   private toolUseCache = new Map<string, ToolUseCacheEntry>();
   private toolUseIndexToId = new Map<number, string>();
@@ -2101,9 +2129,6 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     this.currentMode = isPermissionMode(config.modeId) ? config.modeId : "default";
-    if (this.currentMode !== "plan") {
-      this.planResumeMode = this.currentMode;
-    }
   }
 
   get id(): string | null {
@@ -2305,16 +2330,8 @@ class ClaudeAgentSession implements AgentSession {
 
     const normalized = isPermissionMode(modeId) ? modeId : "default";
     assertClaudeAutoModeEligible(normalized, this.buildSdkEnv());
-    const previousMode = this.currentMode;
     const activeQuery = await this.ensureQuery();
     await activeQuery.setPermissionMode(normalized);
-    if (normalized === "plan") {
-      if (previousMode !== "plan") {
-        this.planResumeMode = previousMode;
-      }
-    } else {
-      this.planResumeMode = normalized;
-    }
     this.currentMode = normalized;
   }
 
@@ -2409,6 +2426,56 @@ class ClaudeAgentSession implements AgentSession {
     return Array.from(this.pendingPermissions.values()).map((entry) => entry.request);
   }
 
+  /**
+   * Switch to the mode the client approved the plan in, and record what actually
+   * happened. Never throws: the caller has already removed the pending entry and
+   * has yet to resolve it, so an escaping error would hang the agent on a promise
+   * nobody can settle.
+   */
+  private async applyPlanApproval(
+    request: AgentPermissionRequest,
+    response: Extract<AgentPermissionResponse, { behavior: "allow" }>,
+  ): Promise<void> {
+    const targetMode = resolveClaudePlanApprovalMode(request, response.mode);
+    if (response.mode && response.mode !== targetMode) {
+      this.logger.warn(
+        { requestedMode: response.mode, targetMode },
+        "Plan approval requested a mode this request did not offer",
+      );
+    }
+    let landedMode: PermissionMode = targetMode;
+    try {
+      await this.setMode(targetMode);
+    } catch (error) {
+      landedMode = this.currentMode ?? "default";
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        { targetMode, landedMode, error: message },
+        "Failed to apply plan approval mode",
+      );
+      this.enqueueTimeline({
+        type: "error",
+        message: `Could not switch to ${targetMode}. The plan was approved in ${landedMode} instead. ${message}`,
+      });
+    }
+    this.pushToolCall(
+      mapClaudeCompletedToolCall({
+        name: "plan_approval",
+        callId: request.id,
+        input: request.input ?? null,
+        output: {
+          approved: true,
+          actionId: response.selectedActionId ?? "implement",
+          // What the client asked for, what we agreed to apply, and where we
+          // ended up — a rejected or failed mode switch is otherwise invisible.
+          requestedMode: response.mode ?? null,
+          targetMode,
+          mode: landedMode,
+        },
+      }),
+    );
+  }
+
   async respondToPermission(requestId: string, response: AgentPermissionResponse): Promise<void> {
     const pending = this.pendingPermissions.get(requestId);
     if (!pending) {
@@ -2419,24 +2486,7 @@ class ClaudeAgentSession implements AgentSession {
 
     if (response.behavior === "allow") {
       if (pending.request.kind === "plan") {
-        const selectedActionId = response.selectedActionId;
-        const shouldResumePriorMode =
-          selectedActionId === "implement_resume" && this.planResumeMode === "bypassPermissions";
-        const targetMode: PermissionMode = shouldResumePriorMode
-          ? "bypassPermissions"
-          : "acceptEdits";
-        await this.setMode(targetMode);
-        this.pushToolCall(
-          mapClaudeCompletedToolCall({
-            name: "plan_approval",
-            callId: pending.request.id,
-            input: pending.request.input ?? null,
-            output: {
-              approved: true,
-              actionId: selectedActionId ?? "implement",
-            },
-          }),
-        );
+        await this.applyPlanApproval(pending.request, response);
       }
       const updatedInput =
         pending.request.kind === "question"
@@ -4304,9 +4354,6 @@ class ClaudeAgentSession implements AgentSession {
     }
     this.availableModes = DEFAULT_MODES;
     this.currentMode = message.permissionMode;
-    if (this.currentMode !== "plan") {
-      this.planResumeMode = this.currentMode;
-    }
     this.persistence = null;
     if (message.model) {
       const normalizedRuntimeModel = normalizeClaudeRuntimeModelId(message.model);
@@ -4367,6 +4414,9 @@ class ClaudeAgentSession implements AgentSession {
     if (toolName === "ExitPlanMode" && typeof input.plan === "string") {
       metadata.planText = input.plan;
     }
+    if (kind === "plan") {
+      metadata.implementModes = buildClaudePlanImplementModes(this.buildSdkEnv());
+    }
     const toolDetail =
       kind === "tool"
         ? mapClaudeRunningToolCall({
@@ -4388,7 +4438,7 @@ class ClaudeAgentSession implements AgentSession {
       suggestions: options.suggestions?.map((suggestion) => ({
         ...suggestion,
       })),
-      actions: kind === "plan" ? buildClaudePlanPermissionActions(this.planResumeMode) : undefined,
+      actions: kind === "plan" ? buildClaudePlanPermissionActions() : undefined,
       metadata: Object.keys(metadata).length ? metadata : undefined,
     };
 


### PR DESCRIPTION
### Type of change

- [x] New feature

### Reasoning

Approving a plan always drops the agent into Accept File Edits, whatever mode you were in before planning. If you want the agent to run unattended after approving, you have to approve, notice it is asking again, and switch the mode by hand. The one escape today is a second "Implement with Bypass" button, which only appears if you happened to be in Bypass before the plan, so most people never see it and cannot tell why it showed up that once. This PR puts the decision on the button you are already pressing: Implement carries the mode it will apply, and a caret beside it opens the four Claude modes. The choice is remembered, so the common case is one press.

### Goals

- The Implement button on a Claude plan card names the mode it will apply, and a caret beside it opens the modes the daemon offered: Always Ask, Accept File Edits, Auto mode, Bypass.
- Picking a mode from the menu only changes what the button will do. Approval still takes an explicit press of Implement.
- The choice is remembered per project and becomes the default for that project's next plan card. Different repos earn different answers: how much rein you give an agent is a property of the code it is working on, so a scratch repo and a production one do not have to share one setting. A project you have not answered for yet starts at Accept File Edits rather than inheriting the last project's pick, so a permissive mode cannot follow you into a repo where you did not want it.
- The daemon validates the requested mode against the list it advertised for that request, falling back to Accept File Edits, so the client can never apply a mode the request did not offer.
- Auto mode is left out of the offered list on Bedrock and Vertex, where `setMode` rejects it. If a mode switch fails anyway, the approval still resolves and the failure surfaces as an error item rather than leaving the agent waiting forever.
- The wire shape stays backward compatible in both directions: the offered modes ride in request metadata and the choice on an optional response field, so an old app sees the plan card it sees today and a new app against an old daemon renders no caret.
- The conditional "Implement with Bypass" action is gone. It only appeared when the pre-plan mode was already Bypass, which is state the user cannot see, and the dropdown covers it for every mode.

### Non-goals

- Other providers. Codex, Copilot and OpenCode plan approval does not set a mode at all, so their plan cards are untouched and render exactly as they do today.
- Reverting the mode after the implementation turn. Picking Bypass leaves the agent in Bypass for the rest of the session, which is already true of the forced Accept File Edits today.
- Scoping the remembered mode narrower than the project. Worktrees of one repo share a workflow, so keying it per workspace would forget the choice every time you branch. It is also not synced between installs: a phone and a desktop keep their own answers.
- Pruning the remembered modes when a project goes away. Each entry is one short string, and nothing else in the app prunes its per-project storage either.
- Honouring the agent's live mode over the picked one. A plan card only exists while the agent is in Plan Mode and the resolution is frozen when the card opens, so switching the agent's mode while a card is open is ignored. Use the dropdown.

### QA

**Tests:**

- `packages/server/src/server/agent/providers/claude/agent.redesign.test.ts` (extended) - the modes a plan request advertises and the Bedrock and Vertex carve-out, that each offered mode is applied on approval, that an absent or unoffered mode falls back to Accept File Edits, and that a failing mode switch still resolves the permission and emits an error item.
- `packages/app/src/agent-stream/plan-implement-modes.test.ts` (new) - reading the offered modes off a permission request, including the malformed and single-entry cases that keep other providers' plan cards unchanged, resolving the remembered mode against them while device storage is still hydrating, and the storage scope: worktrees of one repo share an answer, separate projects do not, and an agent with no project placement falls back to its checkout path.

**Manual:**

Ran a Claude agent in Plan Mode until it produced a plan, opened the caret on the Implement button and picked Auto mode. The button label changed and the plan stayed pending, which is the point of the split: the menu sets the mode, only Implement approves. Pressing Implement then continued the turn in Auto mode, with the composer mode chip switching to match. The next plan card in the same session opened defaulted to Auto mode. Checked at both a desktop and a compact width; at compact the buttons stack full width and the menu opens upward on its own when there is no room below.

A plan card in a second project still defaults to Accept File Edits after Auto mode was picked in the first, and each project keeps its own answer across cards.


Button with dropdown:

<img width="401" height="175" alt="image" src="https://github.com/user-attachments/assets/686c5634-6939-4be7-959b-f50a5b4db720" />

Dropdown clicked:

<img width="430" height="346" alt="image" src="https://github.com/user-attachments/assets/c223b542-2a85-46a1-9fae-894da753522c" />

Compact mode:

<img width="401" height="175" alt="image" src="https://github.com/user-attachments/assets/3303877b-bf70-4d6c-9f93-ffbbc773d452" />

Dropdown clicked compact mode:

<img width="409" height="404" alt="image" src="https://github.com/user-attachments/assets/1b086ffb-86db-476f-8d8e-20cdaab17b70" />



Tested on desktop (Electron, macOS). Not tested: web, iOS, Android.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

