### PR TITLE
fix(cli): expose provider mode IDs in JSON

### DIFF
--- a/packages/cli/src/commands/provider/ls.ts
+++ b/packages/cli/src/commands/provider/ls.ts
@@ -8,9 +8,14 @@ export interface ProviderListItem {
   provider: ProviderSnapshotEntry["provider"];
   label: string;
   status: string;
-  enabled: "Enabled" | "Disabled";
-  defaultMode: string;
-  modes: string;
+  enabled: boolean;
+  defaultModeId: string | null;
+  modes: ProviderListMode[];
+}
+
+export interface ProviderListMode {
+  id: string;
+  label: string;
 }
 
 /** Derive provider list from the manifest — single source of truth */
@@ -18,9 +23,9 @@ const PROVIDERS: ProviderListItem[] = AGENT_PROVIDER_DEFINITIONS.map((def) => ({
   provider: def.id,
   label: def.label,
   status: "available",
-  enabled: def.enabledByDefault === false ? "Disabled" : "Enabled",
-  defaultMode: def.defaultModeId ?? "-",
-  modes: def.modes.length > 0 ? def.modes.map((m) => m.label).join(", ") : "-",
+  enabled: def.enabledByDefault !== false,
+  defaultModeId: def.defaultModeId,
+  modes: def.modes.map((mode) => ({ id: mode.id, label: mode.label })),
 }));
 
 function getStaticProviders(): ProviderListItem[] {
@@ -43,9 +48,22 @@ export const providerLsSchema: OutputSchema<ProviderListItem> = {
         return undefined;
       },
     },
-    { header: "ENABLED", field: "enabled", width: 10 },
-    { header: "DEFAULT MODE", field: "defaultMode", width: 14 },
-    { header: "MODES", field: "modes", width: 30 },
+    {
+      header: "ENABLED",
+      field: (item) => (item.enabled ? "Enabled" : "Disabled"),
+      width: 10,
+    },
+    {
+      header: "DEFAULT MODE",
+      field: (item) => item.defaultModeId ?? "-",
+      width: 14,
+    },
+    {
+      header: "MODES",
+      field: (item) =>
+        item.modes.length > 0 ? item.modes.map((mode) => mode.label).join(", ") : "-",
+      width: 30,
+    },
   ],
 };
 
@@ -77,9 +95,9 @@ export async function runLsCommand(
         provider: entry.provider,
         label: entry.label ?? entry.provider,
         status: entry.status === "ready" ? "available" : entry.status,
-        enabled: !entry.enabled ? "Disabled" : "Enabled",
-        defaultMode: entry.defaultModeId ?? "default",
-        modes: (entry.modes ?? []).map((mode) => mode.label).join(", "),
+        enabled: entry.enabled,
+        defaultModeId: entry.defaultModeId ?? null,
+        modes: (entry.modes ?? []).map((mode) => ({ id: mode.id, label: mode.label })),
       })),
       schema: providerLsSchema,
     };

--- a/packages/cli/tests/15-provider.test.ts
+++ b/packages/cli/tests/15-provider.test.ts
@@ -37,11 +37,18 @@ interface ProviderModel {
   description?: string;
 }
 
+interface ProviderListMode {
+  id: string;
+  label: string;
+}
+
 interface ProviderListRow {
   provider: string;
   label: string;
   status: string;
-  enabled: string;
+  enabled: boolean;
+  defaultModeId: string | null;
+  modes: ProviderListMode[];
 }
 
 const EXPECTED_CLAUDE_MODELS = [
@@ -236,12 +243,25 @@ try {
     for (const provider of ["claude", "codex", "opencode"] as const) {
       const row = rows.find((p) => p.provider === provider);
       assert(row, `should include ${provider}`);
-      assert.strictEqual(row.enabled, "Enabled", `${provider} should report Enabled`);
+      assert.strictEqual(row.enabled, true, `${provider} should report enabled`);
     }
+
+    const codex = rows.find((p) => p.provider === "codex");
+    assert(codex, "should include codex");
+    assert.strictEqual(codex.defaultModeId, "auto-review");
+    assert.deepStrictEqual(
+      codex.modes.map((mode) => mode.id),
+      ["auto", "auto-review", "full-access"],
+      "codex modes should expose IDs accepted by --mode",
+    );
+
+    const opencode = rows.find((p) => p.provider === "opencode");
+    assert(opencode, "should include opencode");
+    assert.strictEqual(opencode.defaultModeId, null, "missing defaults should stay null");
 
     const omp = rows.find((p) => p.provider === "omp");
     assert(omp, "should include omp");
-    assert.strictEqual(omp.enabled, "Disabled", "omp should report Disabled by default");
+    assert.strictEqual(omp.enabled, false, "omp should report disabled by default");
     console.log("✓ provider ls --json outputs valid JSON\n");
   }
 
@@ -274,11 +294,11 @@ try {
       const data = JSON.parse(result.stdout.trim()) as ProviderListRow[];
       const claude = data.find((p) => p.provider === "claude");
       assert(claude, "disabled claude provider should stay in provider ls");
-      assert.strictEqual(claude.enabled, "Disabled", "disabled provider should report Disabled");
+      assert.strictEqual(claude.enabled, false, "disabled provider should report disabled");
 
       const opencode = data.find((p) => p.provider === "opencode");
       assert(opencode, "enabled opencode provider should stay in provider ls");
-      assert.strictEqual(opencode.enabled, "Enabled", "enabled provider should report Enabled");
+      assert.strictEqual(opencode.enabled, true, "enabled provider should report enabled");
 
       const modelsResult = await runPaseoCli(disabledCtx, ["provider", "models", "claude"]);
       assert.notStrictEqual(


### PR DESCRIPTION
### Linked issue

Closes #3135

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

I use `paseo provider ls --json` to choose a provider mode before starting an agent. The command returned display labels such as `Auto-review`, but `paseo run --mode` accepts IDs such as `auto-review`. It also represented the enabled state as `"Enabled"` or `"Disabled"`.

This change keeps the table readable while preserving machine-readable values in JSON and YAML: a boolean enabled state, a nullable `defaultModeId`, and mode objects with `id` and `label`.

### Goals

- Expose mode IDs that can be passed to `paseo run --mode`.
- Return the enabled state as a boolean.
- Represent a missing provider default as `null`.
- Keep the existing table and quiet output behavior.
- Cover daemon-backed provider output with an automated test.

### Non-goals

- Change mode validation or add a generic `default` mode alias.
- Change provider discovery, configuration, or UI behavior.
- Expose provider-specific mode metadata beyond ID and label.

### QA

Tested on macOS 26.5.2 arm64 with Node 22.17.1 and Paseo 0.3.1.

Before:

```console
$ paseo provider ls --json
{
  "provider": "codex",
  "enabled": "Enabled",
  "defaultMode": "auto-review",
  "modes": "Default Permissions, Auto-review, Full Access"
}

$ paseo run --background --provider codex --mode Auto-review --json "Reply exactly DONE."
{
  "error": {
    "code": "AGENT_CREATE_FAILED",
    "message": "Failed to create agent: Invalid mode 'Auto-review' for provider 'codex'. Available modes: auto, auto-review, full-access"
  }
}
```

The failed command did not create an agent.

After:

```json
{
  "provider": "codex",
  "label": "Codex",
  "status": "available",
  "enabled": true,
  "defaultModeId": "auto-review",
  "modes": [
    { "id": "auto", "label": "Default Permissions" },
    { "id": "auto-review", "label": "Auto-review" },
    { "id": "full-access", "label": "Full Access" }
  ]
}
```

Commands run:

```console
$ npm run build:server
# exit 0

$ npx tsx packages/cli/tests/15-provider.test.ts
=== All provider tests passed ===

$ npm run typecheck
# exit 0 for all workspaces

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.
```

Not tested on Windows or Linux. This is a CLI serialization change with no platform-specific code.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
