### PR TITLE
Persist hidden provider subagents across restarts

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -150,7 +150,12 @@ Claude Code announces subagent lifecycle on the SDK stream (`task_started` / `ta
 
 Archived Paseo subagents disappear from the track, by design. To remove one from the track without closing its tab, use the **archive button** on the row — it opens a confirm dialog and archives the subagent on confirm. Provider-owned rows have no individual Paseo lifecycle controls.
 
-The track header's **Archive finished** action hides finished provider-owned rows in the current app session. Their native sessions and timelines are untouched, and managed Paseo subagents are not archived by this bulk action. If a hidden provider child starts running again, the app brings it back to the track.
+The track header's **Hide finished** action hides finished provider-owned rows on that client. The
+hidden child ids are stored in AsyncStorage, so refreshes, reconnects, and app restarts keep them
+hidden. Their native sessions and timelines are untouched, and managed Paseo subagents are not
+archived by this bulk action. If every row is hidden, the track releases its composer row. Use
+**Show hidden subagents** in the parent agent's tab menu to restore the rows. If a hidden provider
+child starts running again, the app brings it back to the track automatically.
 
 To keep the agent alive but remove it from the parent's track, use **detach**. The daemon clears the parent label, emits the normal agent update, and every client reclassifies the agent from subagent to root/sibling from that updated snapshot.
 
@@ -170,7 +175,10 @@ We considered universal decoupling (no tab close ever archives, archive is alway
 
 ### Subagent accumulation under long-lived parents
 
-A parent that spawns many subagents will see the track grow. Managed Paseo subagents can be archived individually. Finished provider-owned rows can be hidden together with **Archive finished**; this is app-local presentation state and resets when the app restarts.
+A parent that spawns many subagents will see the track grow. Managed Paseo subagents can be archived
+individually. Finished provider-owned rows can be hidden together with **Hide finished**. This is
+per-client presentation state: it survives that client's restarts but does not follow the parent to
+another client.
 
 ### Cross-client tab dismissal
 

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1554,8 +1554,9 @@ export const ar: TranslationResources = {
     detachTooltip: "فصل الوكيل الفرعي",
     archiveAction: "أرشيف{{label}}",
     archiveTooltip: "أرشفة الوكيل الفرعي",
-    archiveFinishedAction: "أرشفة الوكلاء الفرعيين المكتملين",
-    archiveFinishedTooltip: "أرشفة المكتملين",
+    archiveFinishedAction: "إخفاء الوكلاء الفرعيين المكتملين",
+    archiveFinishedTooltip: "إخفاء المكتملين",
+    showHiddenAction: "إظهار الوكلاء الفرعيين المخفيين",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1565,8 +1565,9 @@ export const en = {
     detachTooltip: "Detach subagent",
     archiveAction: "Archive {{label}}",
     archiveTooltip: "Archive subagent",
-    archiveFinishedAction: "Archive finished subagents",
-    archiveFinishedTooltip: "Archive finished",
+    archiveFinishedAction: "Hide finished subagents",
+    archiveFinishedTooltip: "Hide finished",
+    showHiddenAction: "Show hidden subagents",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1597,8 +1597,9 @@ export const es: TranslationResources = {
     detachTooltip: "Separar subagente",
     archiveAction: "Archivo{{label}}",
     archiveTooltip: "Subagente de archivo",
-    archiveFinishedAction: "Archivar subagentes finalizados",
-    archiveFinishedTooltip: "Archivar finalizados",
+    archiveFinishedAction: "Ocultar subagentes finalizados",
+    archiveFinishedTooltip: "Ocultar finalizados",
+    showHiddenAction: "Mostrar subagentes ocultos",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1601,8 +1601,9 @@ export const fr: TranslationResources = {
     detachTooltip: "Detacher le sous-agent",
     archiveAction: "Archiver{{label}}",
     archiveTooltip: "Sous-agent d'archivage",
-    archiveFinishedAction: "Archiver les sous-agents terminés",
-    archiveFinishedTooltip: "Archiver les terminés",
+    archiveFinishedAction: "Masquer les sous-agents terminés",
+    archiveFinishedTooltip: "Masquer les terminés",
+    showHiddenAction: "Afficher les sous-agents masqués",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1570,8 +1570,9 @@ export const ja: TranslationResources = {
     detachTooltip: "サブエージェントを切り離す",
     archiveAction: "{{label}}をアーカイブ",
     archiveTooltip: "サブエージェントをアーカイブ",
-    archiveFinishedAction: "完了したサブエージェントをアーカイブ",
-    archiveFinishedTooltip: "完了した項目をアーカイブ",
+    archiveFinishedAction: "完了したサブエージェントを非表示",
+    archiveFinishedTooltip: "完了項目を非表示",
+    showHiddenAction: "非表示のサブエージェントを表示",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1564,8 +1564,9 @@ export const ko: TranslationResources = {
     detachTooltip: "하위 에이전트 분리",
     archiveAction: "{{label}} 보관",
     archiveTooltip: "서브에이전트 보관",
-    archiveFinishedAction: "완료된 하위 에이전트 보관",
-    archiveFinishedTooltip: "아카이브 완료",
+    archiveFinishedAction: "완료된 하위 에이전트 숨기기",
+    archiveFinishedTooltip: "완료 항목 숨기기",
+    showHiddenAction: "숨긴 하위 에이전트 표시",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1583,8 +1583,9 @@ export const ptBR: TranslationResources = {
     detachTooltip: "Desanexar subagente",
     archiveAction: "Arquivar {{label}}",
     archiveTooltip: "Arquivar subagente",
-    archiveFinishedAction: "Arquivar subagentes concluídos",
-    archiveFinishedTooltip: "Arquivar concluídos",
+    archiveFinishedAction: "Ocultar subagentes concluídos",
+    archiveFinishedTooltip: "Ocultar concluídos",
+    showHiddenAction: "Mostrar subagentes ocultos",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1588,8 +1588,9 @@ export const ru: TranslationResources = {
     detachTooltip: "Отсоединить субагент",
     archiveAction: "Архив{{label}}",
     archiveTooltip: "Архивный субагент",
-    archiveFinishedAction: "Архивировать завершенные субагенты",
-    archiveFinishedTooltip: "Архивировать завершенные",
+    archiveFinishedAction: "Скрыть завершённых субагентов",
+    archiveFinishedTooltip: "Скрыть завершённые",
+    showHiddenAction: "Показать скрытых субагентов",
   },
   panels: {
     draft: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1534,8 +1534,9 @@ export const zhCN: TranslationResources = {
     detachTooltip: "分离 subagent",
     archiveAction: "归档 {{label}}",
     archiveTooltip: "归档 subagent",
-    archiveFinishedAction: "归档已完成的 subagent",
-    archiveFinishedTooltip: "归档已完成项",
+    archiveFinishedAction: "隐藏已完成的子代理",
+    archiveFinishedTooltip: "隐藏已完成项",
+    showHiddenAction: "显示隐藏的子代理",
   },
   panels: {
     draft: {

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -89,6 +89,10 @@ import { runPinnedTabTarget, type TabTargetHandlers } from "@/workspace-pins/run
 import type { PinnedTabTarget } from "@/workspace-pins/target";
 import { PinnedTargetsRow } from "@/workspace-pins/pinned-targets-row";
 import { PinnableMenuItem } from "@/workspace-pins/pinnable-menu-item";
+import {
+  hasHiddenProviderSubagentsForParent,
+  useProviderSubagentStore,
+} from "@/subagents/provider-store";
 
 const DROPDOWN_WIDTH = 220;
 const LOADING_TAB_LABEL_SKELETON_WIDTH = 80;
@@ -790,6 +794,7 @@ export function WorkspaceDesktopTabsRow({
 }: WorkspaceDesktopTabsRowProps) {
   const { t } = useTranslation();
   const router = useRouter();
+  const hiddenProviderSubagents = useProviderSubagentStore((state) => state.hiddenFromTrack);
   const newTabKeys = useShortcutKeys("workspace-tab-new");
   const focusModeKeys = useShortcutKeys("toggle-focus");
   const splitRightKeys = useShortcutKeys("workspace-pane-split-right");
@@ -849,6 +854,7 @@ export function WorkspaceDesktopTabsRow({
     () => ({
       copyResumeCommand: t("workspace.tabs.menu.copyResumeCommand"),
       copyAgentId: t("workspace.tabs.menu.copyAgentId"),
+      showHiddenSubagents: t("subagents.showHiddenAction"),
       copyTerminalId: t("workspace.tabs.menu.copyTerminalId"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
       rename: t("workspace.tabs.menu.rename"),
@@ -898,6 +904,13 @@ export function WorkspaceDesktopTabsRow({
     onCreateDraftTab({ paneId });
   }, [onCreateDraftTab, paneId]);
 
+  const handleShowHiddenProviderSubagents = useCallback(
+    (agentId: string) => {
+      useProviderSubagentStore.getState().showHiddenForParent(normalizedServerId, agentId);
+    },
+    [normalizedServerId],
+  );
+
   const handleCreateTerminal = useCallback(() => {
     onCreateTerminalTab({ paneId });
   }, [onCreateTerminalTab, paneId]);
@@ -935,6 +948,13 @@ export function WorkspaceDesktopTabsRow({
         activeDragTabId !== null &&
         tabDropPreviewIndex === tabs.length &&
         index === tabs.length - 1;
+      const hasHiddenProviderSubagents =
+        item.tab.target.kind === "agent" &&
+        hasHiddenProviderSubagentsForParent(
+          hiddenProviderSubagents,
+          normalizedServerId,
+          item.tab.target.agentId,
+        );
 
       return (
         <ResolvedDesktopTabChip
@@ -948,6 +968,8 @@ export function WorkspaceDesktopTabsRow({
           normalizedWorkspaceId={normalizedWorkspaceId}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
+          hasHiddenProviderSubagents={hasHiddenProviderSubagents}
+          onShowHiddenProviderSubagents={handleShowHiddenProviderSubagents}
           onCopyTerminalId={onCopyTerminalId}
           onCopyFilePath={onCopyFilePath}
           onReloadAgent={onReloadAgent}
@@ -973,6 +995,8 @@ export function WorkspaceDesktopTabsRow({
       isFocused,
       layout.closeButtonPolicy,
       layout.items,
+      hiddenProviderSubagents,
+      handleShowHiddenProviderSubagents,
       normalizedServerId,
       normalizedWorkspaceId,
       onCloseOtherTabs,
@@ -1102,6 +1126,8 @@ function ResolvedDesktopTabChip({
   normalizedWorkspaceId,
   onCopyResumeCommand,
   onCopyAgentId,
+  hasHiddenProviderSubagents,
+  onShowHiddenProviderSubagents,
   onCopyTerminalId,
   onCopyFilePath,
   onReloadAgent,
@@ -1129,6 +1155,8 @@ function ResolvedDesktopTabChip({
   normalizedWorkspaceId: string;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  hasHiddenProviderSubagents: boolean;
+  onShowHiddenProviderSubagents: (agentId: string) => void;
   onCopyTerminalId: (terminalId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
@@ -1156,6 +1184,8 @@ function ResolvedDesktopTabChip({
         tabCount,
         onCopyResumeCommand,
         onCopyAgentId,
+        hasHiddenProviderSubagents,
+        onShowHiddenProviderSubagents,
         onCopyTerminalId,
         onCopyFilePath,
         onReloadAgent,
@@ -1174,6 +1204,8 @@ function ResolvedDesktopTabChip({
       onCloseTabsToLeft,
       onCloseTabsToRight,
       onCopyAgentId,
+      hasHiddenProviderSubagents,
+      onShowHiddenProviderSubagents,
       onCopyTerminalId,
       onCopyFilePath,
       onCopyResumeCommand,

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -159,6 +159,10 @@ import {
   type WorkspacePaneContentModel,
 } from "@/screens/workspace/workspace-pane-content";
 import { useMountedTabSet } from "@/screens/workspace/use-mounted-tab-set";
+import {
+  hasHiddenProviderSubagentsForParent,
+  useProviderSubagentStore,
+} from "@/subagents/provider-store";
 import { WorkspaceFocusProvider } from "@/workspace/focus";
 import { shouldSeedEmptyWorkspaceDraft } from "@/screens/workspace/workspace-empty-draft-seed";
 import {
@@ -525,6 +529,8 @@ function MobileWorkspaceTabOption({
   onPress,
   onCopyResumeCommand,
   onCopyAgentId,
+  hasHiddenProviderSubagents,
+  onShowHiddenProviderSubagents,
   onCopyTerminalId,
   onCopyFilePath,
   onReloadAgent,
@@ -544,6 +550,8 @@ function MobileWorkspaceTabOption({
   onPress: () => void;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  hasHiddenProviderSubagents: boolean;
+  onShowHiddenProviderSubagents: (agentId: string) => void;
   onCopyTerminalId: (terminalId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
@@ -558,6 +566,7 @@ function MobileWorkspaceTabOption({
     () => ({
       copyResumeCommand: t("workspace.tabs.menu.copyResumeCommand"),
       copyAgentId: t("workspace.tabs.menu.copyAgentId"),
+      showHiddenSubagents: t("subagents.showHiddenAction"),
       copyTerminalId: t("workspace.tabs.menu.copyTerminalId"),
       copyFilePath: t("workspace.tabs.menu.copyFilePath"),
       rename: t("workspace.tabs.menu.rename"),
@@ -581,6 +590,8 @@ function MobileWorkspaceTabOption({
     menuTestIDBase,
     onCopyResumeCommand,
     onCopyAgentId,
+    hasHiddenProviderSubagents,
+    onShowHiddenProviderSubagents,
     onCopyTerminalId,
     onCopyFilePath,
     onReloadAgent,
@@ -660,6 +671,7 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
   onCloseOtherTabs,
 }: MobileWorkspaceTabSwitcherProps) {
   const { t } = useTranslation();
+  const hiddenProviderSubagents = useProviderSubagentStore((state) => state.hiddenFromTrack);
   const [isOpen, setIsOpen] = useState(false);
   const anchorRef = useRef<View>(null);
   const tabIndexByKey = useMemo(() => {
@@ -674,6 +686,12 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
     Keyboard.dismiss();
     setIsOpen(true);
   }, []);
+  const handleShowHiddenProviderSubagents = useCallback(
+    (agentId: string) => {
+      useProviderSubagentStore.getState().showHiddenForParent(normalizedServerId, agentId);
+    },
+    [normalizedServerId],
+  );
 
   const renderTabOption = useCallback(
     ({
@@ -695,6 +713,13 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       if (tabIndex < 0) {
         return <View />;
       }
+      const hasHiddenProviderSubagents =
+        tab.target.kind === "agent" &&
+        hasHiddenProviderSubagentsForParent(
+          hiddenProviderSubagents,
+          normalizedServerId,
+          tab.target.agentId,
+        );
       return (
         <MobileWorkspaceTabOption
           tab={tab}
@@ -707,6 +732,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
           onPress={onPress}
           onCopyResumeCommand={onCopyResumeCommand}
           onCopyAgentId={onCopyAgentId}
+          hasHiddenProviderSubagents={hasHiddenProviderSubagents}
+          onShowHiddenProviderSubagents={handleShowHiddenProviderSubagents}
           onCopyTerminalId={onCopyTerminalId}
           onCopyFilePath={onCopyFilePath}
           onReloadAgent={onReloadAgent}
@@ -726,6 +753,8 @@ const MobileWorkspaceTabSwitcher = memo(function MobileWorkspaceTabSwitcher({
       normalizedWorkspaceId,
       onCopyResumeCommand,
       onCopyAgentId,
+      hiddenProviderSubagents,
+      handleShowHiddenProviderSubagents,
       onCopyTerminalId,
       onCopyFilePath,
       onReloadAgent,

--- a/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.test.ts
@@ -179,6 +179,69 @@ describe("buildWorkspaceTabMenuEntries", () => {
     expect(onRenameTab).toHaveBeenCalledWith(tab);
   });
 
+  it("reveals hidden provider subagents from the parent agent tab menu", () => {
+    const onShowHiddenProviderSubagents = vi.fn();
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "mobile",
+      tab: createAgentTab(),
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-menu-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      hasHiddenProviderSubagents: true,
+      onShowHiddenProviderSubagents,
+      onCopyTerminalId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    const revealEntry = entries.find(
+      (entry) => entry.kind === "item" && entry.key === "show-hidden-provider-subagents",
+    );
+    if (!revealEntry || revealEntry.kind !== "item") {
+      throw new Error("Show hidden provider subagents entry missing");
+    }
+    expect(revealEntry.label).toBe("Show hidden subagents");
+
+    revealEntry.onSelect();
+
+    expect(onShowHiddenProviderSubagents).toHaveBeenCalledWith("agent-123");
+  });
+
+  it("omits the hidden provider subagent action when there is no hidden history", () => {
+    const entries = buildWorkspaceTabMenuEntries({
+      surface: "mobile",
+      tab: createAgentTab(),
+      index: 0,
+      tabCount: 1,
+      menuTestIDBase: "workspace-tab-menu-agent_123",
+      onCopyResumeCommand: vi.fn(),
+      onCopyAgentId: vi.fn(),
+      hasHiddenProviderSubagents: false,
+      onShowHiddenProviderSubagents: vi.fn(),
+      onCopyTerminalId: vi.fn(),
+      onCopyFilePath: vi.fn(),
+      onReloadAgent: vi.fn(),
+      onRenameTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onCloseTabsBefore: vi.fn(),
+      onCloseTabsAfter: vi.fn(),
+      onCloseOtherTabs: vi.fn(),
+    });
+
+    expect(
+      entries.some(
+        (entry) => entry.kind === "item" && entry.key === "show-hidden-provider-subagents",
+      ),
+    ).toBe(false);
+  });
+
   it("includes copy id and rename for terminal tabs", () => {
     const onRenameTab = vi.fn();
     const onCopyTerminalId = vi.fn();

--- a/packages/app/src/screens/workspace/workspace-tab-menu.ts
+++ b/packages/app/src/screens/workspace/workspace-tab-menu.ts
@@ -8,6 +8,7 @@ export type WorkspaceTabMenuSurface = "desktop" | "mobile";
 export interface WorkspaceTabMenuLabels {
   copyResumeCommand: string;
   copyAgentId: string;
+  showHiddenSubagents: string;
   copyTerminalId: string;
   copyFilePath: string;
   rename: string;
@@ -24,6 +25,7 @@ export interface WorkspaceTabMenuLabels {
 export const DEFAULT_WORKSPACE_TAB_MENU_LABELS: WorkspaceTabMenuLabels = {
   copyResumeCommand: i18n.t("workspace.tabs.menu.copyResumeCommand"),
   copyAgentId: i18n.t("workspace.tabs.menu.copyAgentId"),
+  showHiddenSubagents: i18n.t("subagents.showHiddenAction"),
   copyTerminalId: i18n.t("workspace.tabs.menu.copyTerminalId"),
   copyFilePath: i18n.t("workspace.tabs.menu.copyFilePath"),
   rename: i18n.t("workspace.tabs.menu.rename"),
@@ -70,6 +72,8 @@ interface BuildWorkspaceTabMenuEntriesInput {
   menuTestIDBase: string;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  hasHiddenProviderSubagents?: boolean;
+  onShowHiddenProviderSubagents?: (agentId: string) => void;
   onCopyTerminalId: (terminalId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
@@ -87,6 +91,8 @@ interface BuildWorkspaceDesktopTabActionsInput {
   tabCount: number;
   onCopyResumeCommand: (agentId: string) => Promise<void> | void;
   onCopyAgentId: (agentId: string) => Promise<void> | void;
+  hasHiddenProviderSubagents?: boolean;
+  onShowHiddenProviderSubagents?: (agentId: string) => void;
   onCopyTerminalId: (terminalId: string) => Promise<void> | void;
   onCopyFilePath: (path: string) => Promise<void> | void;
   onReloadAgent: (agentId: string) => Promise<void> | void;
@@ -179,6 +185,7 @@ export function buildWorkspaceTabMenuEntries(
   const isLastTab = index === tabCount - 1;
   const isOnlyTab = tabCount <= 1;
   const entries: WorkspaceTabMenuEntry[] = [];
+  const onShowHiddenProviderSubagents = input.onShowHiddenProviderSubagents;
 
   if (tab.target.kind === "agent") {
     const { agentId } = tab.target;
@@ -203,6 +210,17 @@ export function buildWorkspaceTabMenuEntries(
         void onCopyAgentId(agentId);
       },
     });
+    if (input.hasHiddenProviderSubagents && onShowHiddenProviderSubagents) {
+      entries.push({
+        kind: "item",
+        key: "show-hidden-provider-subagents",
+        label: labels.showHiddenSubagents,
+        testID: `${menuTestIDBase}-show-hidden-provider-subagents`,
+        onSelect: () => {
+          onShowHiddenProviderSubagents(agentId);
+        },
+      });
+    }
   }
 
   if (tab.target.kind === "terminal") {
@@ -326,6 +344,8 @@ export function buildWorkspaceDesktopTabActions(
       menuTestIDBase: contextMenuTestId,
       onCopyResumeCommand: input.onCopyResumeCommand,
       onCopyAgentId: input.onCopyAgentId,
+      hasHiddenProviderSubagents: input.hasHiddenProviderSubagents,
+      onShowHiddenProviderSubagents: input.onShowHiddenProviderSubagents,
       onCopyTerminalId: input.onCopyTerminalId,
       onCopyFilePath: input.onCopyFilePath,
       onReloadAgent: input.onReloadAgent,

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,9 +1,36 @@
-import { afterEach, describe, expect, test } from "vitest";
-import { providerSubagentKey, useProviderSubagentStore } from "./provider-store";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { StateStorage } from "zustand/middleware";
+import {
+  createProviderSubagentStore,
+  hasHiddenProviderSubagentsForParent,
+  providerSubagentKey,
+  useProviderSubagentStore,
+} from "./provider-store";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn().mockResolvedValue(null),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 
 const SERVER_ID = "server-1";
 const PARENT_ID = "parent-1";
 const SUBAGENT_ID = "child-1";
+
+function createMemoryStorage(): StateStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (name) => values.get(name) ?? null,
+    setItem: (name, value) => {
+      values.set(name, value);
+    },
+    removeItem: (name) => {
+      values.delete(name);
+    },
+  };
+}
 
 afterEach(() => {
   useProviderSubagentStore.setState({
@@ -169,6 +196,107 @@ describe("provider subagent client store", () => {
     expect(state.timelines.get(key)?.tail).toEqual([
       expect.objectContaining({ kind: "assistant_message", text: "Finished output." }),
     ]);
+  });
+
+  test("restores hidden finished children without persisting runtime descriptors or timelines", () => {
+    const storage = createMemoryStorage();
+    const firstStore = createProviderSubagentStore(storage);
+    const key = providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID);
+    firstStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: SUBAGENT_ID,
+        parentAgentId: PARENT_ID,
+        provider: "codex",
+        title: "Finished child",
+        description: null,
+        status: "completed",
+        createdAt: "2026-07-12T10:00:00.000Z",
+        updatedAt: "2026-07-12T10:00:02.000Z",
+        toolCallId: "call-1",
+      },
+    });
+    firstStore.getState().applyUpdate(SERVER_ID, {
+      kind: "timeline",
+      parentAgentId: PARENT_ID,
+      subagentId: SUBAGENT_ID,
+      provider: "codex",
+      epoch: "epoch-1",
+      seq: 1,
+      timestamp: "2026-07-12T10:00:01.000Z",
+      item: { type: "assistant_message", text: "Finished output." },
+    });
+    firstStore.getState().hideFinishedForParent(SERVER_ID, PARENT_ID);
+
+    const restoredStore = createProviderSubagentStore(storage);
+
+    expect(restoredStore.getState().hiddenFromTrack.has(key)).toBe(true);
+    expect(restoredStore.getState().descriptors.size).toBe(0);
+    expect(restoredStore.getState().timelines.size).toBe(0);
+  });
+
+  test("keeps multiple finished provider children hidden after restart and history replay", () => {
+    const storage = createMemoryStorage();
+    const firstStore = createProviderSubagentStore(storage);
+    const children = [
+      { id: "oneshot-supervisor", title: "oneshot_supervisor" },
+      { id: "taxi-supervisor", title: "taxi_supervisor" },
+    ];
+
+    for (const child of children) {
+      firstStore.getState().applyUpdate(SERVER_ID, {
+        kind: "upsert",
+        subagent: {
+          id: child.id,
+          parentAgentId: PARENT_ID,
+          provider: "codex",
+          title: child.title,
+          description: null,
+          status: "completed",
+          createdAt: "2026-07-12T10:00:00.000Z",
+          updatedAt: "2026-07-12T10:00:02.000Z",
+          toolCallId: `call-${child.id}`,
+        },
+      });
+    }
+    firstStore.getState().hideFinishedForParent(SERVER_ID, PARENT_ID);
+
+    const restoredStore = createProviderSubagentStore(storage);
+    restoredStore.getState().replaceList(
+      SERVER_ID,
+      PARENT_ID,
+      children.map((child) => ({
+        id: child.id,
+        parentAgentId: PARENT_ID,
+        provider: "codex" as const,
+        title: child.title,
+        description: null,
+        status: "completed" as const,
+        createdAt: "2026-07-12T10:00:00.000Z",
+        updatedAt: "2026-07-12T10:00:02.000Z",
+        toolCallId: `call-${child.id}`,
+      })),
+    );
+
+    expect(
+      children.every((child) =>
+        restoredStore
+          .getState()
+          .hiddenFromTrack.has(providerSubagentKey(SERVER_ID, PARENT_ID, child.id)),
+      ),
+    ).toBe(true);
+  });
+
+  test("reveals hidden history only for the selected parent", () => {
+    const firstKey = providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID);
+    const secondKey = providerSubagentKey(SERVER_ID, "parent-2", "child-2");
+    useProviderSubagentStore.setState({ hiddenFromTrack: new Set([firstKey, secondKey]) });
+
+    useProviderSubagentStore.getState().showHiddenForParent(SERVER_ID, PARENT_ID);
+
+    const hiddenFromTrack = useProviderSubagentStore.getState().hiddenFromTrack;
+    expect(hasHiddenProviderSubagentsForParent(hiddenFromTrack, SERVER_ID, PARENT_ID)).toBe(false);
+    expect(hasHiddenProviderSubagentsForParent(hiddenFromTrack, SERVER_ID, "parent-2")).toBe(true);
   });
 
   test("reveals a hidden child when the provider reports it running again", () => {

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,19 +1,10 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import type { StateStorage } from "zustand/middleware";
 import {
   createProviderSubagentStore,
   hasHiddenProviderSubagentsForParent,
   providerSubagentKey,
-  useProviderSubagentStore,
 } from "./provider-store";
-
-vi.mock("@react-native-async-storage/async-storage", () => ({
-  default: {
-    getItem: vi.fn().mockResolvedValue(null),
-    setItem: vi.fn().mockResolvedValue(undefined),
-    removeItem: vi.fn().mockResolvedValue(undefined),
-  },
-}));
 
 const SERVER_ID = "server-1";
 const PARENT_ID = "parent-1";
@@ -30,6 +21,39 @@ function createMemoryStorage(): StateStorage {
       values.delete(name);
     },
   };
+}
+
+const useProviderSubagentStore = createProviderSubagentStore(createMemoryStorage());
+
+function createDeferredHydrationStorage(hiddenFromTrack: string[]): {
+  storage: StateStorage;
+  resolveRead(): void;
+} {
+  const snapshot = JSON.stringify({ state: { hiddenFromTrack }, version: 1 });
+  let resolveRead: ((value: string | null) => void) | undefined;
+  const read = new Promise<string | null>((resolve) => {
+    resolveRead = resolve;
+  });
+  return {
+    storage: {
+      getItem: () => read,
+      setItem: () => undefined,
+      removeItem: () => undefined,
+    },
+    resolveRead: () => {
+      resolveRead?.(snapshot);
+    },
+  };
+}
+
+function waitForHydration(store: ReturnType<typeof createProviderSubagentStore>): Promise<void> {
+  if (store.persist.hasHydrated()) return Promise.resolve();
+  return new Promise((resolve) => {
+    const unsubscribe = store.persist.onFinishHydration(() => {
+      unsubscribe();
+      resolve();
+    });
+  });
 }
 
 afterEach(() => {
@@ -233,6 +257,82 @@ describe("provider subagent client store", () => {
     expect(restoredStore.getState().hiddenFromTrack.has(key)).toBe(true);
     expect(restoredStore.getState().descriptors.size).toBe(0);
     expect(restoredStore.getState().timelines.size).toBe(0);
+  });
+
+  test("does not let stale hydration hide a child that ran during startup replay", async () => {
+    const key = providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID);
+    const unrelatedKey = providerSubagentKey(SERVER_ID, "parent-2", "child-2");
+    const deferred = createDeferredHydrationStorage([key, unrelatedKey]);
+    const store = createProviderSubagentStore(deferred.storage);
+    const hydrated = waitForHydration(store);
+    const descriptor = {
+      id: SUBAGENT_ID,
+      parentAgentId: PARENT_ID,
+      provider: "codex" as const,
+      title: "Replayed child",
+      description: null,
+      status: "running" as const,
+      createdAt: "2026-07-12T10:00:00.000Z",
+      updatedAt: "2026-07-12T10:00:01.000Z",
+      toolCallId: "call-1",
+    };
+
+    store.getState().applyUpdate(SERVER_ID, { kind: "upsert", subagent: descriptor });
+    store.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        ...descriptor,
+        status: "completed",
+        updatedAt: "2026-07-12T10:00:02.000Z",
+      },
+    });
+    deferred.resolveRead();
+    await hydrated;
+
+    expect(store.getState().descriptors.get(key)?.status).toBe("completed");
+    expect(store.getState().hiddenFromTrack.has(key)).toBe(false);
+    expect(store.getState().hiddenFromTrack.has(unrelatedKey)).toBe(true);
+  });
+
+  test("does not let stale hydration undo a hide made while storage is loading", async () => {
+    const key = providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID);
+    const deferred = createDeferredHydrationStorage([]);
+    const store = createProviderSubagentStore(deferred.storage);
+    const hydrated = waitForHydration(store);
+    store.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: SUBAGENT_ID,
+        parentAgentId: PARENT_ID,
+        provider: "codex",
+        title: "Finished child",
+        description: null,
+        status: "completed",
+        createdAt: "2026-07-12T10:00:00.000Z",
+        updatedAt: "2026-07-12T10:00:02.000Z",
+        toolCallId: "call-1",
+      },
+    });
+    store.getState().hideFinishedForParent(SERVER_ID, PARENT_ID);
+
+    deferred.resolveRead();
+    await hydrated;
+
+    expect(store.getState().hiddenFromTrack.has(key)).toBe(true);
+  });
+
+  test("does not let stale hydration undo an explicit reveal", async () => {
+    const key = providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID);
+    const deferred = createDeferredHydrationStorage([key]);
+    const store = createProviderSubagentStore(deferred.storage);
+    const hydrated = waitForHydration(store);
+    store.setState({ hiddenFromTrack: new Set([key]) });
+
+    store.getState().showHiddenForParent(SERVER_ID, PARENT_ID);
+    deferred.resolveRead();
+    await hydrated;
+
+    expect(store.getState().hiddenFromTrack.has(key)).toBe(false);
   });
 
   test("keeps multiple finished provider children hidden after restart and history replay", () => {

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -1,10 +1,12 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import type {
   AgentStreamEventPayload,
   ProviderSubagentDescriptorPayload,
   SessionOutboundMessage,
 } from "@getpaseo/protocol/messages";
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-import { create } from "zustand";
+import { create, type StateCreator } from "zustand";
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 import { applyStreamEvent } from "@/types/stream";
 import type { StreamItem } from "@/types/stream";
 import type { AgentLifecycleStatus } from "@getpaseo/protocol/agent-lifecycle";
@@ -29,11 +31,12 @@ export interface ProviderSubagentTimelineState {
   rows: Map<number, ProviderSubagentTimelineRow>;
 }
 
-interface ProviderSubagentState {
+export interface ProviderSubagentState {
   descriptors: Map<string, ProviderSubagentDescriptorPayload>;
   timelines: Map<string, ProviderSubagentTimelineState>;
   hiddenFromTrack: Set<string>;
   hideFinishedForParent(serverId: string, parentAgentId: string): void;
+  showHiddenForParent(serverId: string, parentAgentId: string): void;
   replaceList(
     serverId: string,
     parentAgentId: string,
@@ -104,6 +107,43 @@ export function refreshProviderSubagents(
 
 function parentPrefix(serverId: string, parentAgentId: string): string {
   return `${serverId}\0${parentAgentId}\0`;
+}
+
+export function hasHiddenProviderSubagentsForParent(
+  hiddenFromTrack: ReadonlySet<string>,
+  serverId: string,
+  parentAgentId: string,
+): boolean {
+  const prefix = parentPrefix(serverId, parentAgentId);
+  for (const key of hiddenFromTrack) {
+    if (key.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function serializeProviderSubagentVisibility(state: ProviderSubagentState): {
+  hiddenFromTrack: string[];
+} {
+  return { hiddenFromTrack: [...state.hiddenFromTrack] };
+}
+
+function mergeProviderSubagentVisibility(
+  persistedState: unknown,
+  currentState: ProviderSubagentState,
+): ProviderSubagentState {
+  if (!persistedState || typeof persistedState !== "object" || Array.isArray(persistedState)) {
+    return currentState;
+  }
+  const hiddenFromTrack = Object.hasOwn(persistedState, "hiddenFromTrack")
+    ? Reflect.get(persistedState, "hiddenFromTrack")
+    : undefined;
+  if (!Array.isArray(hiddenFromTrack)) return currentState;
+  return {
+    ...currentState,
+    hiddenFromTrack: new Set(
+      hiddenFromTrack.filter((key): key is string => typeof key === "string"),
+    ),
+  };
 }
 
 const EMPTY_TIMELINE: ProviderSubagentTimelineState = {
@@ -192,7 +232,7 @@ function buildTimelineResponseRows(
   return rows;
 }
 
-export const useProviderSubagentStore = create<ProviderSubagentState>((set) => ({
+const createProviderSubagentState: StateCreator<ProviderSubagentState> = (set) => ({
   descriptors: new Map(),
   timelines: new Map(),
   hiddenFromTrack: new Set(),
@@ -204,6 +244,16 @@ export const useProviderSubagentStore = create<ProviderSubagentState>((set) => (
         if (key.startsWith(prefix) && subagent.status !== "running") {
           hiddenFromTrack.add(key);
         }
+      }
+      return { hiddenFromTrack };
+    });
+  },
+  showHiddenForParent(serverId, parentAgentId) {
+    set((state) => {
+      const prefix = parentPrefix(serverId, parentAgentId);
+      const hiddenFromTrack = new Set(state.hiddenFromTrack);
+      for (const key of hiddenFromTrack) {
+        if (key.startsWith(prefix)) hiddenFromTrack.delete(key);
       }
       return { hiddenFromTrack };
     });
@@ -325,4 +375,18 @@ export const useProviderSubagentStore = create<ProviderSubagentState>((set) => (
       return { timelines };
     });
   },
-}));
+});
+
+export function createProviderSubagentStore(storage: StateStorage = AsyncStorage) {
+  return create<ProviderSubagentState>()(
+    persist(createProviderSubagentState, {
+      name: "provider-subagent-visibility",
+      version: 1,
+      storage: createJSONStorage(() => storage),
+      partialize: serializeProviderSubagentVisibility,
+      merge: mergeProviderSubagentVisibility,
+    }),
+  );
+}
+
+export const useProviderSubagentStore = createProviderSubagentStore();

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -130,6 +130,7 @@ function serializeProviderSubagentVisibility(state: ProviderSubagentState): {
 function mergeProviderSubagentVisibility(
   persistedState: unknown,
   currentState: ProviderSubagentState,
+  revealedKeys: ReadonlySet<string>,
 ): ProviderSubagentState {
   if (!persistedState || typeof persistedState !== "object" || Array.isArray(persistedState)) {
     return currentState;
@@ -138,12 +139,15 @@ function mergeProviderSubagentVisibility(
     ? Reflect.get(persistedState, "hiddenFromTrack")
     : undefined;
   if (!Array.isArray(hiddenFromTrack)) return currentState;
-  return {
-    ...currentState,
-    hiddenFromTrack: new Set(
-      hiddenFromTrack.filter((key): key is string => typeof key === "string"),
-    ),
-  };
+  const mergedHiddenFromTrack = new Set(
+    hiddenFromTrack.filter((key): key is string => typeof key === "string"),
+  );
+  for (const key of revealedKeys) mergedHiddenFromTrack.delete(key);
+  for (const key of currentState.hiddenFromTrack) mergedHiddenFromTrack.add(key);
+  for (const [key, descriptor] of currentState.descriptors) {
+    if (descriptor.status === "running") mergedHiddenFromTrack.delete(key);
+  }
+  return { ...currentState, hiddenFromTrack: mergedHiddenFromTrack };
 }
 
 const EMPTY_TIMELINE: ProviderSubagentTimelineState = {
@@ -378,13 +382,51 @@ const createProviderSubagentState: StateCreator<ProviderSubagentState> = (set) =
 });
 
 export function createProviderSubagentStore(storage: StateStorage = AsyncStorage) {
+  let hydrationInProgress = false;
+  const revealedKeys = new Set<string>();
+  // AsyncStorage can resolve after startup replay or a user action. Remember visibility wins
+  // observed during that window so the older snapshot cannot hide those children again.
+  const observedStateCreator: StateCreator<ProviderSubagentState> = (set, get, store) => {
+    const observedSet: typeof set = (...args) => {
+      const previousState = get();
+      const [nextState, replace] = args;
+      if (replace === true) {
+        set(
+          nextState as
+            | ProviderSubagentState
+            | ((state: ProviderSubagentState) => ProviderSubagentState),
+          true,
+        );
+      } else {
+        set(nextState, false);
+      }
+      if (!hydrationInProgress) return;
+      const currentState = get();
+      for (const key of previousState.hiddenFromTrack) {
+        if (!currentState.hiddenFromTrack.has(key)) revealedKeys.add(key);
+      }
+      for (const [key, descriptor] of currentState.descriptors) {
+        if (descriptor.status === "running") revealedKeys.add(key);
+      }
+    };
+    return createProviderSubagentState(observedSet, get, store);
+  };
   return create<ProviderSubagentState>()(
-    persist(createProviderSubagentState, {
+    persist(observedStateCreator, {
       name: "provider-subagent-visibility",
       version: 1,
       storage: createJSONStorage(() => storage),
       partialize: serializeProviderSubagentVisibility,
-      merge: mergeProviderSubagentVisibility,
+      merge: (persistedState, currentState) =>
+        mergeProviderSubagentVisibility(persistedState, currentState, revealedKeys),
+      onRehydrateStorage: () => {
+        hydrationInProgress = true;
+        revealedKeys.clear();
+        return () => {
+          hydrationInProgress = false;
+          revealedKeys.clear();
+        };
+      },
     }),
   );
 }

--- a/packages/app/src/subagents/select.test.ts
+++ b/packages/app/src/subagents/select.test.ts
@@ -1,8 +1,16 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { selectProviderSubagentsForParent, selectSubagentsForParent } from "./select";
 import { useProviderSubagentStore } from "./provider-store";
 import { useSessionStore, type Agent } from "@/stores/session-store";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn().mockResolvedValue(null),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 
 const SERVER_ID = "server-1";
 const AGENT_TIMESTAMP = new Date("2026-03-08T10:00:00.000Z");

--- a/packages/app/src/subagents/select.test.ts
+++ b/packages/app/src/subagents/select.test.ts
@@ -1,16 +1,24 @@
 import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import type { StateStorage } from "zustand/middleware";
 import { selectProviderSubagentsForParent, selectSubagentsForParent } from "./select";
-import { useProviderSubagentStore } from "./provider-store";
+import { createProviderSubagentStore } from "./provider-store";
 import { useSessionStore, type Agent } from "@/stores/session-store";
 
-vi.mock("@react-native-async-storage/async-storage", () => ({
-  default: {
-    getItem: vi.fn().mockResolvedValue(null),
-    setItem: vi.fn().mockResolvedValue(undefined),
-    removeItem: vi.fn().mockResolvedValue(undefined),
-  },
-}));
+function createMemoryStorage(): StateStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (name) => values.get(name) ?? null,
+    setItem: (name, value) => {
+      values.set(name, value);
+    },
+    removeItem: (name) => {
+      values.delete(name);
+    },
+  };
+}
+
+const useProviderSubagentStore = createProviderSubagentStore(createMemoryStorage());
 
 const SERVER_ID = "server-1";
 const AGENT_TIMESTAMP = new Date("2026-03-08T10:00:00.000Z");


### PR DESCRIPTION
## Summary

- persist client-side hidden state for finished provider subagents
- keep hidden provider rows dismissed across app restarts and provider history replay
- add a parent-agent tab action to restore hidden provider subagents on desktop and mobile
- update lifecycle documentation and translations

## Problem

The existing **Hide finished** action only updated in-memory state. After a client restart or a fresh provider history replay, completed provider subagents appeared above the composer again. On mobile, even a collapsed track consumes a line of limited screen space.

## Implementation

Only the hidden provider-subagent keys are persisted through Zustand and AsyncStorage. Runtime descriptors and timelines remain transient. If a hidden subagent becomes active again, the provider update reveals it automatically. The parent agent tab menu exposes **Show hidden subagents** when restorable history exists.

This is intentionally client-local and does not add a daemon or protocol mutation.

## Verification

- focused tests: 4 files, 38 tests passed
- app TypeScript check passed
- formatting check passed
- `git diff --check` passed
- focused lint: 0 errors (3 pre-existing warnings in `workspace-screen.tsx`)

The regression coverage includes two completed provider subagents named `oneshot_supervisor` and `taxi_supervisor`, followed by store recreation and provider-list replay.