### PR TITLE
Fix: Recognize symlinks to dirs as directories for file explorer entries

### DIFF
--- a/packages/server/src/server/file-explorer/service.posix.test.ts
+++ b/packages/server/src/server/file-explorer/service.posix.test.ts
@@ -77,6 +77,29 @@ describe.skipIf(isPlatform("win32"))("service POSIX-only", () => {
     }
   });
 
+  it("lists symlinked directories inside the workspace as expandable directories", async () => {
+    const root = await createTempDir("paseo-file-explorer-");
+
+    try {
+      const target = path.join(root, "shared");
+      await mkdir(target);
+      await writeFile(path.join(target, "inner.txt"), "inner\n", "utf-8");
+      await symlink("shared", path.join(root, "shared-link"));
+
+      const listing = await listDirectoryEntries({ root });
+      const link = listing.entries.find((entry) => entry.name === "shared-link");
+
+      expect(link?.kind).toBe("directory");
+
+      const expanded = await listDirectoryEntries({ root, relativePath: "shared-link" });
+
+      expect(expanded.path).toBe("shared-link");
+      expect(expanded.entries.map((entry) => entry.name)).toContain("inner.txt");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("uses canonical paths for downloadable symlink targets inside the workspace", async () => {
     const root = await createTempDir("paseo-file-explorer-");
 

--- a/packages/server/src/server/file-explorer/service.ts
+++ b/packages/server/src/server/file-explorer/service.ts
@@ -136,7 +136,6 @@ interface EntryPayloadParams {
   root: string;
   targetPath: string;
   name: string;
-  kind: ExplorerEntryKind;
 }
 
 export async function listDirectoryEntries({
@@ -155,13 +154,11 @@ export async function listDirectoryEntries({
   const entriesWithNulls = await Promise.all(
     dirents.map(async (dirent) => {
       const targetPath = path.join(directoryPath.requestedPath, dirent.name);
-      const kind: ExplorerEntryKind = dirent.isDirectory() ? "directory" : "file";
       try {
         return await buildEntryPayload({
           root,
           targetPath,
           name: dirent.name,
-          kind,
         });
       } catch (error) {
         // Directories can contain dangling links (e.g. AGENTS.md -> CLAUDE.md).
@@ -609,7 +606,6 @@ async function buildEntryPayload({
   root,
   targetPath,
   name,
-  kind,
 }: EntryPayloadParams): Promise<FileExplorerEntry> {
   const entryPath = await resolveScopedPath({
     root,
@@ -619,7 +615,7 @@ async function buildEntryPayload({
   return {
     name,
     path: normalizeRelativePath({ root, targetPath }),
-    kind,
+    kind: stats.isDirectory() ? "directory" : "file",
     size: stats.size,
     modifiedAt: stats.mtime.toISOString(),
   };


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

Closes #1891

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

<!-- A short description of the reasoning of this change in your own words. What was wrong, and how do you hope this PR fixes it. If you can't explain this briefly, the PR is probably too big. This description must be grounded in real user flows and framed as value provider to Paseo users. -->

- Current code treated all symlinks as files, so buildEntryPayload in `packages/server/src/server/file-explorer/service.ts` doesn't list directory contents of a symlink
- I've just removed the `kind` argument into the function completely, and used the `fs.stat` output to infer the file / directory status. We're already doing this for getting the file size of the actual (= symlinked to, or real) file.

### Goals

<!-- A bullet list of what this PR wants to accomplish, include requirements and acceptance criteria. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->

- Display symlinked folders (with source and target within a workspace) correctly.

### Non-goals

<!-- A bullet list of what this PR does not want to accomplish. Add any intentional trade offs taken. This helps lock down the scope of the PR and prevent expanding scope over the intended goal. -->

- Allow symlinks outside of a workspace

### QA

<!--
This is the section I read most carefully. I need to see that *you* tested this, not that the diff looks plausible.

- For UI changes: a screenshot or short video on every affected platform (mobile, web, desktop). UI claims without visual proof are not enough.
- For behavior changes: the actual steps you ran, and what you observed.
- For bug fixes: how you reproduced the bug before, and confirmed it's fixed after.
-->

In an open paseo workspace:

Create a directory with a file, and a simple symlink to it:
```bash
mkdir test && cd test && touch x.txt && cd .. && ln -s ./test symlink-folder
```

On master, symlink-folder is displayed as a 0 line change in the `Uncommited` Changes section, but not shown at all in the Files section.

<img width="423" height="225" alt="Screenshot 2026-08-10 at 11 55 53" src="https://github.com/user-attachments/assets/99e46165-ae37-4a2d-b677-eba9544c4dc5" />


After this change, the symlinked folder shows up correctly in the Files tab.


### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
