### PR TITLE
feat(acp): surface provider subagents and declared autonomous turns from external ACP agents

### DIFF
--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -37,6 +37,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GjcACPAgentClient } from "./providers/gjc-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -784,6 +785,9 @@ function addDerivedProviders(
           }
           if (providerId === "traecli") {
             return new TraeACPAgentClient(acpOptions);
+          }
+          if (providerId === "gjc") {
+            return new GjcACPAgentClient(acpOptions);
           }
           return new GenericACPAgentClient(acpOptions);
         },

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -13,11 +13,14 @@ import {
   RequestPermissionRequest,
   SessionConfigOption,
   SessionUpdate,
+  ToolCall,
 } from "@agentclientprotocol/sdk";
 
 import {
   ACPAgentClient,
   ACPAgentSession,
+  type ACPExtensionSubagentParser,
+  type ACPExtensionTurnSignalParser,
   type SpawnedACPProcess,
   type SessionStateResponse,
   buildACPClientCapabilities,
@@ -29,6 +32,8 @@ import {
   resolveACPModelSelection,
   summarizeACPRequestError,
 } from "./acp-agent.js";
+import type { ProviderSubagentInputEvent } from "../provider-subagents/store.js";
+
 import type { ProcessTerminator, TreeKillTarget } from "../../../utils/tree-kill.js";
 import {
   COPILOT_AGENT_FEATURE_OPTION,
@@ -45,6 +50,7 @@ import { GenericACPAgentClient } from "./generic-acp-agent.js";
 import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
+import type { AgentTimelineItem } from "../agent-sdk-types.js";
 import type { AgentCapabilityFlags, AgentPersistenceHandle } from "../agent-sdk-types.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import { buildStringCommandShellInvocation } from "../../../utils/string-command-shell.js";
@@ -86,9 +92,16 @@ describe("buildACPClientCapabilities", () => {
 
 interface ACPSessionInternals {
   sessionId: string | null;
-  connection: { prompt: (...args: unknown[]) => Promise<PromptResponse> };
+  connection: {
+    prompt: (...args: unknown[]) => Promise<PromptResponse>;
+    cancel?: (params: { sessionId: string }) => Promise<unknown>;
+  };
   activeForegroundTurnId: string | null;
   configOptions: SessionConfigOption[];
+  replayingHistory: boolean;
+  historyPending: boolean;
+  persistedHistory: AgentTimelineItem[];
+  handleChildExit(code: number | null, signal: NodeJS.Signals | null, diagnostic?: string): void;
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
   acpMcpServers(): unknown[];
 }
@@ -232,6 +245,60 @@ function createKiroSession(
       extensionCommandsParser: parseKiroExtensionCommands,
       waitForInitialCommands: options.waitForInitialCommands ?? false,
       initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
+    },
+  );
+}
+
+function createSessionWithSubagentParser(
+  subagentUpdateParser: ACPExtensionSubagentParser,
+  logger: ReturnType<typeof createTestLogger> = createTestLogger(),
+): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-acp-test",
+    },
+    {
+      provider: "acp",
+      logger,
+      defaultCommand: ["gjc", "acp"],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      subagentUpdateParser,
+    },
+  );
+}
+
+function createSessionWithTurnSignalParser(
+  turnSignalParser: ACPExtensionTurnSignalParser,
+  logger: ReturnType<typeof createTestLogger> = createTestLogger(),
+): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-acp-test",
+    },
+    {
+      provider: "acp",
+      logger,
+      defaultCommand: ["gjc", "acp"],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      turnSignalParser,
     },
   );
 }
@@ -2548,6 +2615,812 @@ describe("ACPAgentSession", () => {
     });
 
     expect(await listCommandsPromise).toEqual([]);
+  });
+
+  test("maps a vendor extension notification into provider-subagent events via subagentUpdateParser", async () => {
+    const parser: ACPExtensionSubagentParser = (method, params) => {
+      if (method !== "_gjc/sdk/subagent/update") return null;
+      const events = params.subagents;
+      return Array.isArray(events) ? (events as ProviderSubagentInputEvent[]) : null;
+    };
+    const session = createSessionWithSubagentParser(parser);
+    const received: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => received.push(event));
+
+    await session.extNotification("_gjc/sdk/subagent/update", {
+      sessionId: "session-1",
+      subagents: [
+        {
+          type: "upsert",
+          id: "subagent-1",
+          title: "Audit the repo",
+          status: "running",
+          toolCallId: "call-1",
+        },
+        {
+          type: "timeline",
+          id: "subagent-1",
+          item: { type: "assistant_message", text: "Started", messageId: "m1" },
+        },
+      ],
+    });
+
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "acp",
+        event: {
+          type: "upsert",
+          id: "subagent-1",
+          title: "Audit the repo",
+          status: "running",
+          toolCallId: "call-1",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "acp",
+        event: {
+          type: "timeline",
+          id: "subagent-1",
+          item: { type: "assistant_message", text: "Started", messageId: "m1" },
+        },
+      },
+    ]);
+  });
+
+  test("ignores extension notifications a subagentUpdateParser does not handle", async () => {
+    const parser: ACPExtensionSubagentParser = () => null;
+    const session = createSessionWithSubagentParser(parser);
+    const received: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => received.push(event));
+
+    await session.extNotification("_gjc/sdk/subagent/update", {
+      sessionId: "session-1",
+      subagents: [],
+    });
+
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([]);
+  });
+
+  test("ignores provider-subagent events when the parser returns an empty batch", async () => {
+    const parser: ACPExtensionSubagentParser = () => [];
+    const session = createSessionWithSubagentParser(parser);
+    const received: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => received.push(event));
+
+    await session.extNotification("_gjc/sdk/subagent/update", { sessionId: "session-1" });
+
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([]);
+  });
+
+  test("ignores provider-subagent events addressed to a different session", async () => {
+    const parser: ACPExtensionSubagentParser = () => [
+      { type: "upsert", id: "subagent-1", status: "running" },
+    ];
+    const session = createSessionWithSubagentParser(parser);
+    const received: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => received.push(event));
+
+    await session.extNotification("_gjc/sdk/subagent/update", {
+      sessionId: "other-session",
+    });
+
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([]);
+  });
+
+  test("flushes provider-subagent events buffered during resume replay to the first subscriber", async () => {
+    const parser: ACPExtensionSubagentParser = () => [
+      { type: "upsert", id: "subagent-1", status: "running" },
+      { type: "remove", id: "subagent-2" },
+    ];
+    const session = createSessionWithSubagentParser(parser);
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.replayingHistory = true;
+
+    // While `session/load` is still running the manager is not subscribed, so
+    // the events are buffered instead of pushed to an empty subscriber set.
+    await session.extNotification("_gjc/sdk/subagent/update", { sessionId: "session-1" });
+    const received: AgentStreamEvent[] = [];
+    session.subscribe((event) => received.push(event));
+
+    // The manager subscribes after registerSession(); the buffered events
+    // flush to it, so a reload that never hydrates still sees the snapshot.
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "acp",
+        event: { type: "upsert", id: "subagent-1", status: "running" },
+      },
+      { type: "provider_subagent", provider: "acp", event: { type: "remove", id: "subagent-2" } },
+    ]);
+    // The buffer was drained by the subscribe flush; a later streamHistory
+    // hydration finds nothing to re-apply.
+    expect(internals.historyPending).toBe(false);
+    const hydrated: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      hydrated.push(event);
+    }
+    expect(hydrated).toEqual([]);
+  });
+
+  test("delivers provider-subagent events buffered in the subscribe window on subscribe", async () => {
+    // Simulates the window after session/load resolves (replayingHistory
+    // already reset) but before AgentManager.registerSession() reaches
+    // subscribeToSession(): no subscribers exist, so the events must be
+    // buffered instead of pushed to an empty set.
+    const parser: ACPExtensionSubagentParser = () => [
+      { type: "upsert", id: "subagent-1", status: "running" },
+    ];
+    const session = createSessionWithSubagentParser(parser);
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.replayingHistory = false;
+    internals.historyPending = false;
+
+    await session.extNotification("_gjc/sdk/subagent/update", { sessionId: "session-1" });
+    // historyPending is forced so the event stays deliverable through either
+    // the subscribe flush or history hydration.
+    expect(internals.historyPending).toBe(true);
+
+    const received: AgentStreamEvent[] = [];
+    session.subscribe((event) => received.push(event));
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "acp",
+        event: { type: "upsert", id: "subagent-1", status: "running" },
+      },
+    ]);
+  });
+
+  test("keeps timeline replay pending after flushing buffered subagents on subscribe", async () => {
+    // session/load can buffer ordinary timeline history AND a subagent
+    // snapshot together; flushing the subagent events on subscribe must not
+    // strand the timeline replay, or a forced Refresh that already deleted the
+    // durable timeline would render the conversation empty.
+    const parser: ACPExtensionSubagentParser = () => [
+      { type: "upsert", id: "subagent-1", status: "running" },
+    ];
+    const session = createSessionWithSubagentParser(parser);
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.replayingHistory = true;
+    internals.persistedHistory = [{ type: "user_message", text: "hi", messageId: "m1" }];
+    internals.historyPending = true;
+
+    await session.extNotification("_gjc/sdk/subagent/update", { sessionId: "session-1" });
+    const received: AgentStreamEvent[] = [];
+    session.subscribe((event) => received.push(event));
+
+    // The subagent snapshot flushes to the subscriber...
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "acp",
+        event: { type: "upsert", id: "subagent-1", status: "running" },
+      },
+    ]);
+    // ...while the timeline replay stays pending for history hydration.
+    expect(internals.historyPending).toBe(true);
+    const hydrated: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      hydrated.push(event);
+    }
+    expect(hydrated).toEqual([
+      {
+        type: "timeline",
+        provider: "acp",
+        item: { type: "user_message", text: "hi", messageId: "m1" },
+      },
+    ]);
+  });
+
+  test("streamHistory drains provider-subagent events when consumed before subscribe", async () => {
+    // Hydration-before-subscribe ordering safety net: whoever consumes the
+    // buffer first (streamHistory or the subscribe flush) drains it, so the
+    // events are delivered exactly once.
+    const parser: ACPExtensionSubagentParser = () => [
+      { type: "upsert", id: "subagent-1", status: "running" },
+    ];
+    const session = createSessionWithSubagentParser(parser);
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.replayingHistory = true;
+
+    await session.extNotification("_gjc/sdk/subagent/update", { sessionId: "session-1" });
+    internals.historyPending = true;
+    const hydrated: AgentStreamEvent[] = [];
+    for await (const event of session.streamHistory()) {
+      hydrated.push(event);
+    }
+    expect(hydrated).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "acp",
+        event: { type: "upsert", id: "subagent-1", status: "running" },
+      },
+    ]);
+
+    // The buffer was drained by streamHistory, so the subscribe flush is a
+    // no-op and nothing is delivered twice.
+    const received: AgentStreamEvent[] = [];
+    session.subscribe((event) => received.push(event));
+    expect(received.filter((event) => event.type === "provider_subagent")).toEqual([]);
+  });
+
+  test("starts an autonomous turn from an explicit start signal", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+
+    const started = events.find((event) => event.type === "turn_started");
+    expect(started).toMatchObject({ type: "turn_started", provider: "acp" });
+    expect(typeof (started as { turnId?: unknown }).turnId).toBe("string");
+
+    // Timeline events emitted while the autonomous turn is active are tagged
+    // with its turn id so the manager attributes them to the autonomous run.
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "m1",
+        content: { type: "text", text: "hi" },
+      } as SessionUpdate,
+    });
+    const timeline = events.find((event) => event.type === "timeline");
+    expect((timeline as { turnId?: string }).turnId).toBe((started as { turnId: string }).turnId);
+  });
+
+  test("ignores a start signal while a foreground turn is active", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).activeForegroundTurnId = "foreground-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+
+    expect(events.filter((event) => event.type === "turn_started")).toEqual([]);
+  });
+
+  test("ignores end and fail signals without an active autonomous turn", async () => {
+    const parser: ACPExtensionTurnSignalParser = (method) =>
+      method.endsWith("/fail") ? { type: "fail", error: "boom" } : { type: "end" };
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/end", { sessionId: "session-1" });
+    await session.extNotification("_gjc/sdk/turn/fail", { sessionId: "session-1" });
+
+    expect(
+      events.filter((event) => event.type === "turn_completed" || event.type === "turn_failed"),
+    ).toEqual([]);
+  });
+
+  test("completes and fails an autonomous turn on end and fail signals", async () => {
+    const parser: ACPExtensionTurnSignalParser = (method) => {
+      if (method.endsWith("/fail")) {
+        return { type: "fail", error: "boom" };
+      }
+      if (method.endsWith("/end")) {
+        return { type: "end" };
+      }
+      return { type: "start" };
+    };
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+    await session.extNotification("_gjc/sdk/turn/end", { sessionId: "session-1" });
+    const completed = events.find((event) => event.type === "turn_completed");
+    expect(completed).toMatchObject({
+      type: "turn_completed",
+      provider: "acp",
+      turnId: started.turnId,
+    });
+
+    // A second start after completion opens a fresh turn.
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const second = events.filter((event) => event.type === "turn_started");
+    expect(second).toHaveLength(2);
+    expect((second[1] as { turnId: string }).turnId).not.toBe(started.turnId);
+
+    await session.extNotification("_gjc/sdk/turn/fail", { sessionId: "session-1" });
+    const failed = events.find((event) => event.type === "turn_failed");
+    expect(failed).toMatchObject({
+      type: "turn_failed",
+      provider: "acp",
+      error: "boom",
+    });
+  });
+
+  test("terminalizes running tool calls when an autonomous turn fails", async () => {
+    const parser: ACPExtensionTurnSignalParser = (method) =>
+      method.endsWith("/fail") ? { type: "fail", error: "boom" } : { type: "start" };
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "call-1",
+        name: "bash",
+        status: "running",
+      } as unknown as ToolCall,
+    });
+
+    await session.extNotification("_gjc/sdk/turn/fail", {
+      sessionId: "session-1",
+      error: "boom",
+    });
+
+    // Exactly one canceled row, tagged with the failed turn id.
+    const canceledTools = events.filter(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.status === "canceled",
+    );
+    expect(canceledTools).toHaveLength(1);
+    expect((canceledTools[0] as { turnId?: string }).turnId).toBe(started.turnId);
+  });
+
+  test("terminalizes running tool calls when an autonomous turn completes", async () => {
+    const parser: ACPExtensionTurnSignalParser = (method) =>
+      method.endsWith("/end") ? { type: "end" } : { type: "start" };
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "call-1",
+        name: "bash",
+        status: "running",
+      } as unknown as ToolCall,
+    });
+
+    await session.extNotification("_gjc/sdk/turn/end", { sessionId: "session-1" });
+
+    // Exactly one canceled row, tagged with the completed turn id, so the UI
+    // does not keep showing an indefinitely running tool after the turn closes.
+    const canceledTools = events.filter(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.status === "canceled",
+    );
+    expect(canceledTools).toHaveLength(1);
+    expect((canceledTools[0] as { turnId?: string }).turnId).toBe(started.turnId);
+  });
+
+  test("completes a pending autonomous turn before a foreground prompt", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    const prompt = vi.fn().mockResolvedValue({ stopReason: "end_turn" });
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+
+    await session.startTurn("hello");
+
+    const order = events.filter(
+      (event) => event.type === "turn_started" || event.type === "turn_completed",
+    );
+    const completedIndex = order.findIndex(
+      (event) =>
+        event.type === "turn_completed" && (event as { turnId?: string }).turnId === started.turnId,
+    );
+    const foregroundStartIndex = order.findIndex(
+      (event) =>
+        event.type === "turn_started" && (event as { turnId?: string }).turnId !== started.turnId,
+    );
+    expect(completedIndex).toBeGreaterThan(-1);
+    expect(foregroundStartIndex).toBeGreaterThan(completedIndex);
+  });
+
+  test("replays turn lifecycle events buffered during the initialization window on subscribe", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    // No subscribers yet (session/new, session/load, or the registerSession
+    // window): the start signal must be buffered, not pushed to an empty set.
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const received: AgentStreamEvent[] = [];
+    session.subscribe((event) => received.push(event));
+
+    const started = received.find((event) => event.type === "turn_started");
+    expect(started).toMatchObject({ type: "turn_started", provider: "acp" });
+    expect(typeof (started as { turnId?: unknown }).turnId).toBe("string");
+  });
+
+  test("replays a buffered start followed by an end in order", async () => {
+    const parser: ACPExtensionTurnSignalParser = (method) =>
+      method.endsWith("/end") ? { type: "end" } : { type: "start" };
+    const session = createSessionWithTurnSignalParser(parser);
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    await session.extNotification("_gjc/sdk/turn/end", { sessionId: "session-1" });
+    const received: AgentStreamEvent[] = [];
+    session.subscribe((event) => received.push(event));
+
+    const turns = received.filter(
+      (event) => event.type === "turn_started" || event.type === "turn_completed",
+    );
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ type: "turn_started" });
+    expect(turns[1]).toMatchObject({
+      type: "turn_completed",
+      turnId: (turns[0] as { turnId: string }).turnId,
+    });
+  });
+
+  test("buffers autonomous output emitted before the manager subscribes", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    // A turn start followed by ordinary session/update output, all before the
+    // manager subscribes: the timeline event must not be lost.
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "m1",
+        content: { type: "text", text: "hi" },
+      } as SessionUpdate,
+    });
+
+    const received: AgentStreamEvent[] = [];
+    session.subscribe((event) => received.push(event));
+
+    const started = received.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+    expect(started).toBeDefined();
+    const timeline = received.find((event) => event.type === "timeline");
+    expect(timeline).toMatchObject({ type: "timeline", turnId: started.turnId });
+    expect(received.indexOf(started)).toBeLessThan(received.indexOf(timeline as AgentStreamEvent));
+  });
+
+  test("finalizes buffered content at autonomous turn boundaries", async () => {
+    const parser: ACPExtensionTurnSignalParser = (method) =>
+      method.endsWith("/end") ? { type: "end" } : { type: "start" };
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    // Turn 1: start, ID-less assistant chunk, trailing user chunk, end.
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "one" },
+      } as SessionUpdate,
+    });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: "internal" },
+      } as SessionUpdate,
+    });
+    await session.extNotification("_gjc/sdk/turn/end", { sessionId: "session-1" });
+
+    // The trailing user chunk was flushed at the turn boundary, before the
+    // terminal, tagged with the closed turn id.
+    const userEvents = events.filter(
+      (event) => event.type === "timeline" && event.item.type === "user_message",
+    );
+    const completed = events.find((event) => event.type === "turn_completed") as {
+      turnId: string;
+    };
+    expect(userEvents).toHaveLength(1);
+    expect((userEvents[0] as { turnId?: string }).turnId).toBe(completed.turnId);
+    expect(events.indexOf(userEvents[0] as AgentStreamEvent)).toBeLessThan(
+      events.indexOf(completed),
+    );
+
+    // Turn 2: an ID-less assistant chunk must get a fresh synthetic message id
+    // instead of reusing turn 1's, which would merge the two turns in the
+    // timeline projection.
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "two" },
+      } as SessionUpdate,
+    });
+    const assistantIds = events
+      .filter((event) => event.type === "timeline" && event.item.type === "assistant_message")
+      .map((event) => (event.item as { messageId?: string }).messageId);
+    expect(assistantIds).toHaveLength(2);
+    expect(assistantIds[0]).not.toBe(assistantIds[1]);
+  });
+
+  test("cancels running tool calls when an autonomous turn is interrupted", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { cancel };
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "call-1",
+        name: "bash",
+        status: "running",
+      } as unknown as ToolCall,
+    });
+
+    await session.interrupt();
+
+    // The running tool row is synthesized as canceled and tagged with the
+    // closing autonomous turn id instead of staying running forever.
+    const canceledTool = events.find(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.status === "canceled",
+    );
+    expect(canceledTool).toBeDefined();
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+    expect((canceledTool as { turnId?: string }).turnId).toBe(started.turnId);
+  });
+
+  test("settles an active autonomous turn when the ACP process exits", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "call-1",
+        name: "bash",
+        status: "running",
+      } as unknown as ToolCall,
+    });
+
+    // The child exit handler routes here; without the autonomous branch the
+    // manager would stay stuck in the running state, and without tool cleanup
+    // the timeline would retain the running tool row forever.
+    asInternals<ACPSessionInternals>(session).handleChildExit(1, null, "boom");
+
+    const failed = events.find((event) => event.type === "turn_failed");
+    expect(failed).toMatchObject({
+      type: "turn_failed",
+      provider: "acp",
+      error: "ACP agent exited unexpectedly (1)",
+      diagnostic: "boom",
+      turnId: started.turnId,
+    });
+    const canceledTools = events.filter(
+      (event) =>
+        event.type === "timeline" &&
+        event.item.type === "tool_call" &&
+        event.item.status === "canceled",
+    );
+    // Exactly one canceled row: handleChildExit synthesizes once and
+    // failAutonomousTurn must not emit a duplicate for the same tool call.
+    expect(canceledTools).toHaveLength(1);
+    expect((canceledTools[0] as { turnId?: string }).turnId).toBe(started.turnId);
+  });
+
+  test("terminalizes running provider subagents when the ACP process exits", async () => {
+    const parser: ACPExtensionSubagentParser = () => [
+      { type: "upsert", id: "sub-1", status: "running" },
+    ];
+    const session = createSessionWithSubagentParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/subagent/update", { sessionId: "session-1" });
+    const running = events.find(
+      (event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "upsert" &&
+        event.event.status === "running",
+    );
+    expect(running).toBeDefined();
+
+    // The parent process is dead; the still-running subagent must be
+    // terminalized instead of staying displayed as running indefinitely.
+    asInternals<ACPSessionInternals>(session).handleChildExit(1, null);
+
+    const canceled = events.filter(
+      (event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "upsert" &&
+        event.event.status === "canceled",
+    );
+    expect(canceled).toHaveLength(1);
+    expect(canceled[0]).toMatchObject({
+      provider: "acp",
+      event: { type: "upsert", id: "sub-1", status: "canceled" },
+    });
+  });
+
+  test("terminalizes a default-running provider subagent on process exit", async () => {
+    // An upsert without status defaults to "running" in the store; the exit
+    // path must terminalize it too, not just explicitly-running updates.
+    const parser: ACPExtensionSubagentParser = () => [{ type: "upsert", id: "sub-1" }];
+    const session = createSessionWithSubagentParser(parser);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/subagent/update", { sessionId: "session-1" });
+    asInternals<ACPSessionInternals>(session).handleChildExit(1, null);
+
+    const canceled = events.filter(
+      (event) =>
+        event.type === "provider_subagent" &&
+        event.event.type === "upsert" &&
+        event.event.status === "canceled",
+    );
+    expect(canceled).toHaveLength(1);
+    expect(canceled[0]).toMatchObject({
+      provider: "acp",
+      event: { type: "upsert", id: "sub-1", status: "canceled" },
+    });
+  });
+
+  test("stops buffering after the initial manager subscription", async () => {
+    const session = createSession();
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    // The manager's first subscription; initialization is over.
+    const first: AgentStreamEvent[] = [];
+    const unsubscribe = session.subscribe((event) => first.push(event));
+    unsubscribe();
+
+    // An out-of-turn timeline event between sequential run() turns (zero
+    // subscribers, but not initialization) must not be buffered for the next
+    // run to drain into its own result.
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "m1",
+        content: { type: "text", text: "stale" },
+      } as SessionUpdate,
+    });
+
+    // A later subscription must not receive the stale event.
+    const second: AgentStreamEvent[] = [];
+    session.subscribe((event) => second.push(event));
+    expect(second.filter((event) => event.type === "timeline")).toEqual([]);
+  });
+
+  test("terminalizes running tool calls when an autonomous turn fails", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { cancel };
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+
+    await session.interrupt();
+
+    expect(cancel).toHaveBeenCalledWith({ sessionId: "session-1" });
+    const canceled = events.find((event) => event.type === "turn_canceled");
+    expect(canceled).toMatchObject({
+      type: "turn_canceled",
+      provider: "acp",
+      turnId: started.turnId,
+    });
+  });
+
+  test("keeps the autonomous turn active when the ACP cancel fails", async () => {
+    const parser: ACPExtensionTurnSignalParser = () => ({ type: "start" });
+    const session = createSessionWithTurnSignalParser(parser);
+    const cancel = vi.fn().mockRejectedValue(new Error("cancel refused"));
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { cancel };
+    session.subscribe((event) => events.push(event));
+
+    await session.extNotification("_gjc/sdk/turn/start", { sessionId: "session-1" });
+    const started = events.find((event) => event.type === "turn_started") as {
+      turnId: string;
+    };
+
+    await expect(session.interrupt()).rejects.toThrow("cancel refused");
+
+    // No terminal was emitted: the manager observes the failed interrupt as a
+    // refusal instead of a false settlement.
+    expect(
+      events.filter((event) => event.type === "turn_canceled" || event.type === "turn_completed"),
+    ).toEqual([]);
+
+    // autonomousTurnId is still set, so provider output keeps its turn tag.
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "m2",
+        content: { type: "text", text: "still running" },
+      } as SessionUpdate,
+    });
+    const timeline = events.find((event) => event.type === "timeline");
+    expect((timeline as { turnId?: string }).turnId).toBe(started.turnId);
+  });
+
+  test("ignores interrupt without an active foreground or autonomous turn", async () => {
+    const session = createSessionWithTurnSignalParser(() => ({ type: "start" }));
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { cancel };
+
+    await session.interrupt();
+
+    expect(cancel).not.toHaveBeenCalled();
   });
 
   test("emits assistant and reasoning chunks as deltas while user chunks stay accumulated", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -96,6 +96,10 @@ import {
   type ToolCallDetail,
   type ToolCallTimelineItem,
 } from "../agent-sdk-types.js";
+import type {
+  ProviderSubagentInputEvent,
+  ProviderSubagentStatus,
+} from "../provider-subagents/store.js";
 import {
   isDefaultAgentCreateConfigUnattended,
   resolveDefaultAgentCreateConfig,
@@ -376,6 +380,41 @@ export type ACPExtensionCommandsParser = (
 ) => AgentSlashCommand[] | null;
 
 /**
+ * Lets a provider that publishes subagent/background-task state through a
+ * vendor-specific ACP extension notification translate that payload into Paseo
+ * provider-subagent store events, without the generic ACP session/client
+ * carrying any vendor knowledge. Return the parsed events (possibly empty) for
+ * a notification this provider owns, or null to ignore notifications it does
+ * not handle.
+ */
+export type ACPExtensionSubagentParser = (
+  method: string,
+  params: Record<string, unknown>,
+) => ProviderSubagentInputEvent[] | null;
+
+/**
+ * An explicitly declared turn lifecycle signal from an ACP agent. Unlike
+ * implicit spontaneous session updates, only these signals may open or close a
+ * non-foreground (autonomous) turn: the earlier implicit approach (#2058, later
+ * reverted by #2148) could complete an active foreground run while its prompt
+ * was still streaming, because it minted turns for any out-of-prompt update.
+ */
+export type ACPTurnSignal = { type: "start" } | { type: "end" } | { type: "fail"; error: string };
+
+/**
+ * Lets a provider that runs its own background work declare turn lifecycle
+ * boundaries through a vendor-specific ACP extension notification. The generic
+ * ACP session translates a returned signal into `turn_started` /
+ * `turn_completed` / `turn_failed` events that the manager treats as an
+ * autonomous run, without the shared layer carrying any vendor knowledge.
+ * Return null to ignore notifications the provider does not handle.
+ */
+export type ACPExtensionTurnSignalParser = (
+  method: string,
+  params: Record<string, unknown>,
+) => ACPTurnSignal | null;
+
+/**
  * Context handed to an {@link ACPCatalogModelResolver} during `fetchCatalog`. It exposes
  * the already-derived models plus the live probe session so a resolver can refine them
  * (e.g. switch through each model to read back per-model options) without re-implementing
@@ -428,6 +467,8 @@ interface ACPAgentClientOptions {
   ) => Promise<void>;
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  subagentUpdateParser?: ACPExtensionSubagentParser;
+  turnSignalParser?: ACPExtensionTurnSignalParser;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -458,6 +499,8 @@ interface ACPAgentSessionOptions {
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  subagentUpdateParser?: ACPExtensionSubagentParser;
+  turnSignalParser?: ACPExtensionTurnSignalParser;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -818,6 +861,8 @@ export class ACPAgentClient implements AgentClient {
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly subagentUpdateParser?: ACPExtensionSubagentParser;
+  private readonly turnSignalParser?: ACPExtensionTurnSignalParser;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -846,6 +891,8 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.subagentUpdateParser = options.subagentUpdateParser;
+    this.turnSignalParser = options.turnSignalParser;
   }
 
   async createSession(
@@ -878,6 +925,8 @@ export class ACPAgentClient implements AgentClient {
         extensionCommandsParser: this.extensionCommandsParser,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
+        subagentUpdateParser: this.subagentUpdateParser,
+        turnSignalParser: this.turnSignalParser,
       },
     );
     await session.initializeNewSession();
@@ -927,6 +976,8 @@ export class ACPAgentClient implements AgentClient {
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       extensionCommandsParser: this.extensionCommandsParser,
+      subagentUpdateParser: this.subagentUpdateParser,
+      turnSignalParser: this.turnSignalParser,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1410,8 +1461,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private pendingUserMessage: PendingUserMessage | null = null;
   private submittedUserMessageTurnId: string | null = null;
   private readonly toolCalls = new Map<string, ACPToolSnapshot>();
+  private readonly synthesizedCanceledToolCallIds = new Set<string>();
   private readonly terminalEntries = new Map<string, TerminalEntry>();
   private readonly persistedHistory: AgentTimelineItem[] = [];
+  private readonly persistedProviderSubagentEvents: ProviderSubagentInputEvent[] = [];
+  private readonly pendingEvents: AgentStreamEvent[] = [];
+  private hasSubscribed = false;
+  /**
+   * Effective provider-subagent statuses mirroring ProviderSubagentStore's
+   * default/sticky semantics, so the process-exit path knows which forwarded
+   * subagents are still running.
+   */
+  private readonly providerSubagentStatuses = new Map<string, ProviderSubagentStatus>();
   private readonly initialHandle?: AgentPersistenceHandle;
 
   private readonly config: AgentSessionConfig;
@@ -1433,6 +1494,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly subagentUpdateParser?: ACPExtensionSubagentParser;
+  private readonly turnSignalParser?: ACPExtensionTurnSignalParser;
+  private autonomousTurnId: string | null = null;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
@@ -1473,6 +1537,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.subagentUpdateParser = options.subagentUpdateParser;
+    this.turnSignalParser = options.turnSignalParser;
   }
 
   get id(): string | null {
@@ -1534,7 +1600,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         );
         this.deliverTranslatedEvents(this.flushPendingUserMessage());
         this.replayingHistory = false;
-        this.historyPending = this.persistedHistory.length > 0;
+        this.historyPending =
+          this.persistedHistory.length > 0 || this.persistedProviderSubagentEvents.length > 0;
         this.applySessionState(response);
       } else if (sessionCapabilities?.resume) {
         const response = await this.runACPRequest(() =>
@@ -1597,6 +1664,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (this.activeForegroundTurnId) {
       throw new Error("A foreground turn is already active");
     }
+    // A foreground prompt owns the session, so close any open autonomous turn
+    // before starting it; otherwise its dangling run would keep the manager
+    // busy and the next turn terminal could misattribute the close.
+    this.completeAutonomousTurn();
 
     this.deliverTranslatedEvents(this.flushPendingUserMessage());
     const turnId = randomUUID();
@@ -1635,6 +1706,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
     this.subscribers.add(callback);
+    this.hasSubscribed = true;
     if (this.sessionId) {
       callback({
         type: "thread_started",
@@ -1642,20 +1714,56 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         sessionId: this.sessionId,
       });
     }
+    // Flush provider-subagent events buffered during the initialization window
+    // (before the manager subscribed). A history-preserving reload keeps
+    // `historyPrimed` true and never consumes streamHistory(), so without this
+    // flush the buffered snapshot would be lost and the reloaded session would
+    // show the previous run's terminalized rows. Either this or a streamHistory
+    // hydration drains the buffer first; whichever runs first wins.
+    if (this.persistedProviderSubagentEvents.length > 0) {
+      const subagentEvents = this.persistedProviderSubagentEvents.splice(0);
+      // Recompute instead of clearing: session/load may have buffered ordinary
+      // timeline history alongside the subagent snapshot, and that replay must
+      // stay pending for the manager's history hydration. Clearing the flag
+      // unconditionally strands persistedHistory and, after a forced Refresh
+      // that already deleted the durable timeline, leaves the conversation
+      // empty.
+      this.historyPending = this.persistedHistory.length > 0;
+      for (const event of subagentEvents) {
+        this.pushEvent({ type: "provider_subagent", provider: this.provider, event });
+      }
+    }
+    // Replay events buffered during the initialization window (turn lifecycle,
+    // timeline, tool activity) in arrival order so the manager actually sees
+    // the autonomous run the provider declared and its initial output.
+    if (this.pendingEvents.length > 0) {
+      const pendingEvents = this.pendingEvents.splice(0);
+      for (const event of pendingEvents) {
+        this.pushEvent(event);
+      }
+    }
     return () => {
       this.subscribers.delete(callback);
     };
   }
 
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
-    if (!this.historyPending || this.persistedHistory.length === 0) {
+    if (
+      !this.historyPending ||
+      (this.persistedHistory.length === 0 && this.persistedProviderSubagentEvents.length === 0)
+    ) {
       return;
     }
     const history = [...this.persistedHistory];
     this.persistedHistory.length = 0;
+    const subagentEvents = [...this.persistedProviderSubagentEvents];
+    this.persistedProviderSubagentEvents.length = 0;
     this.historyPending = false;
     for (const item of history) {
       yield { type: "timeline", provider: this.provider, item };
+    }
+    for (const event of subagentEvents) {
+      yield { type: "provider_subagent", provider: this.provider, event };
     }
   }
 
@@ -2155,8 +2263,20 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
     this.pendingPermissions.clear();
 
-    if (this.activeForegroundTurnId) {
-      await this.connection.cancel({ sessionId: this.sessionId });
+    if (this.activeForegroundTurnId || this.autonomousTurnId) {
+      if (this.autonomousTurnId) {
+        // Cancel the provider first and only close the local turn once the
+        // cancel is acknowledged: emitting `turn_canceled` before a failed or
+        // timed-out round-trip would settle the manager's autonomous run as
+        // success while the provider keeps running, and clearing
+        // autonomousTurnId would untag its later output. On failure the await
+        // throws, interrupt() propagates, and the manager reports the refusal
+        // while the turn stays active.
+        await this.connection.cancel({ sessionId: this.sessionId });
+        this.cancelAutonomousTurn();
+      } else {
+        await this.connection.cancel({ sessionId: this.sessionId });
+      }
     }
   }
 
@@ -2316,6 +2436,202 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
       });
     }
+
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : undefined;
+    const matchesSession =
+      sessionId === undefined || this.sessionId === null || sessionId === this.sessionId;
+
+    const parsedSubagentEvents = this.subagentUpdateParser?.(method, params);
+    if (parsedSubagentEvents && parsedSubagentEvents.length > 0 && matchesSession) {
+      this.applySubagentUpdates(parsedSubagentEvents);
+    }
+
+    const turnSignal = this.turnSignalParser?.(method, params);
+    if (turnSignal && matchesSession) {
+      this.applyTurnSignal(turnSignal);
+    }
+  }
+
+  /**
+   * Routes provider-subagent events either to subscribers or, while the
+   * manager has not subscribed yet (replay/initialization window, including
+   * `unstable_resumeSession()` providers), to the history buffer that the
+   * manager's hydration consumes after subscribing.
+   */
+  private applySubagentUpdates(parsedSubagentEvents: ProviderSubagentInputEvent[]): void {
+    this.trackProviderSubagentStatuses(parsedSubagentEvents);
+    if (this.replayingHistory || (!this.hasSubscribed && this.subscribers.size === 0)) {
+      this.persistedProviderSubagentEvents.push(...parsedSubagentEvents);
+      // The resume branch does not set historyPending on its own, so a buffer
+      // filled outside the replay path must force it to keep streamHistory()
+      // deliverable.
+      this.historyPending = true;
+    } else {
+      for (const event of parsedSubagentEvents) {
+        this.pushEvent({ type: "provider_subagent", provider: this.provider, event });
+      }
+    }
+  }
+
+  /**
+   * Mirrors ProviderSubagentStore.apply()'s status semantics: an omitted status
+   * on a new descriptor defaults to "running", and an omitted status on an
+   * existing one is sticky. The process-exit path uses this to terminalize
+   * still-running provider subagents (the manager's
+   * cancelRunningProviderSubagents only runs on reload/close).
+   */
+  private trackProviderSubagentStatuses(events: ProviderSubagentInputEvent[]): void {
+    for (const event of events) {
+      if (event.type === "upsert") {
+        const nextStatus = event.status ?? this.providerSubagentStatuses.get(event.id) ?? "running";
+        this.providerSubagentStatuses.set(event.id, nextStatus);
+      } else if (event.type === "remove") {
+        this.providerSubagentStatuses.delete(event.id);
+      }
+    }
+  }
+
+  /**
+   * Emits a canceled upsert for every still-running provider subagent, matching
+   * the status AgentManager.cancelRunningProviderSubagents uses on reload/close.
+   * applySubagentUpdates also updates the status map (canceled replaces running).
+   */
+  private terminalizeRunningProviderSubagents(): void {
+    const runningIds = [...this.providerSubagentStatuses.entries()]
+      .filter(([, status]) => status === "running")
+      .map(([id]) => id);
+    if (runningIds.length === 0) {
+      return;
+    }
+    const events: ProviderSubagentInputEvent[] = runningIds.map((id) => ({
+      type: "upsert",
+      id,
+      status: "canceled",
+    }));
+    this.applySubagentUpdates(events);
+  }
+
+  /**
+   * Applies an explicitly declared turn lifecycle signal. Only these signals
+   * may open or close a non-foreground turn; implicit spontaneous session
+   * updates must never mint one (see the ACPTurnSignal doc comment).
+   */
+  private applyTurnSignal(signal: ACPTurnSignal): void {
+    if (signal.type === "start") {
+      this.startAutonomousTurn();
+    } else if (signal.type === "end") {
+      this.completeAutonomousTurn();
+    } else {
+      this.failAutonomousTurn(signal.error);
+    }
+  }
+
+  /**
+   * Settles whichever turn is active when the ACP process dies: a foreground
+   * turn through finishTurn() and an autonomous turn through
+   * failAutonomousTurn(). Without the autonomous branch the manager would stay
+   * stuck in the running state, with Stop unable to recover because the cancel
+   * would be sent over the already-dead connection.
+   */
+  private handleChildExit(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    diagnostic?: string,
+  ): void {
+    const error = `ACP agent exited unexpectedly (${code ?? "null"}${signal ? `, ${signal}` : ""})`;
+    // Terminalize running provider subagents (the parent process is dead, so
+    // the manager's reload/close-only cancellation never runs and the store
+    // would keep them displayed as running indefinitely), then synthesize
+    // terminal tool rows before failing either active turn.
+    this.terminalizeRunningProviderSubagents();
+    this.synthesizeCanceledToolCalls();
+    if (this.activeForegroundTurnId) {
+      this.finishTurn({
+        type: "turn_failed",
+        provider: this.provider,
+        error,
+        ...(diagnostic ? { diagnostic } : {}),
+        turnId: this.activeForegroundTurnId,
+      });
+    }
+    if (this.autonomousTurnId) {
+      this.failAutonomousTurn(error, diagnostic);
+    }
+  }
+
+  /**
+   * Opens a non-foreground turn so the manager tracks it as an autonomous run
+   * (running status, activeTurn, stoppable from Paseo). A foreground turn owns
+   * the session, so a start signal while one is streaming is ignored — the
+   * failure mode that forced the #2058 autonomous-turn revert.
+   */
+  private startAutonomousTurn(): void {
+    if (this.activeForegroundTurnId || this.autonomousTurnId) {
+      return;
+    }
+    const turnId = randomUUID();
+    this.autonomousTurnId = turnId;
+    this.pushEvent({ type: "turn_started", provider: this.provider, turnId });
+  }
+
+  private completeAutonomousTurn(): void {
+    if (!this.autonomousTurnId) {
+      return;
+    }
+    const turnId = this.autonomousTurnId;
+    // Finalize buffered content exactly like finishTurn(): flush a trailing
+    // pending user chunk while the turn id is still active so it stays tagged,
+    // and reset the synthetic assistant message id so the next autonomous
+    // turn's ID-less response cannot merge into this one in the timeline
+    // projection.
+    this.deliverTranslatedEvents(this.flushPendingUserMessage());
+    // Terminalize outstanding running tools before closing the turn, same as
+    // the fail/cancel/exit paths; the idempotent synthesis prevents duplicates.
+    this.synthesizeCanceledToolCalls();
+    this.autonomousTurnId = null;
+    this.fallbackAssistantMessageId = null;
+    this.pushEvent({ type: "turn_completed", provider: this.provider, turnId });
+  }
+
+  private failAutonomousTurn(error: string, diagnostic?: string): void {
+    if (!this.autonomousTurnId) {
+      return;
+    }
+    const turnId = this.autonomousTurnId;
+    this.deliverTranslatedEvents(this.flushPendingUserMessage());
+    // Terminalize running tools while the turn id is still set so the cleanup
+    // rows retain the failed turn's id (same as cancelAutonomousTurn).
+    this.synthesizeCanceledToolCalls();
+    this.autonomousTurnId = null;
+    this.fallbackAssistantMessageId = null;
+    this.pushEvent({
+      type: "turn_failed",
+      provider: this.provider,
+      error,
+      ...(diagnostic ? { diagnostic } : {}),
+      turnId,
+    });
+  }
+
+  private cancelAutonomousTurn(): void {
+    if (!this.autonomousTurnId) {
+      return;
+    }
+    const turnId = this.autonomousTurnId;
+    this.deliverTranslatedEvents(this.flushPendingUserMessage());
+    // Synthesize canceled rows for running tool calls, like the foreground
+    // cancellation path, so the timeline does not show a tool running forever
+    // after Stop. Must run while autonomousTurnId is still set so the rows are
+    // tagged with the closing turn.
+    this.synthesizeCanceledToolCalls();
+    this.autonomousTurnId = null;
+    this.fallbackAssistantMessageId = null;
+    this.pushEvent({
+      type: "turn_canceled",
+      provider: this.provider,
+      reason: "Interrupted",
+      turnId,
+    });
   }
 
   // Cache an asynchronously-delivered slash-command batch and unblock any
@@ -2480,16 +2796,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       if (this.closed) {
         return;
       }
-      if (this.activeForegroundTurnId) {
-        this.synthesizeCanceledToolCalls();
-        this.finishTurn({
-          type: "turn_failed",
-          provider: this.provider,
-          error: `ACP agent exited unexpectedly (${code ?? "null"}${signal ? `, ${signal}` : ""})`,
-          diagnostic: stderrChunks.join("").trim() || undefined,
-          turnId: this.activeForegroundTurnId,
-        });
-      }
+      this.handleChildExit(code, signal, stderrChunks.join("").trim() || undefined);
     });
 
     const stream = createLoggedNdJsonStream(
@@ -2733,6 +3040,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (this.toolSnapshotTransformer) {
       snapshot = this.toolSnapshotTransformer(snapshot);
     }
+    // A fresh update supersedes any earlier synthesized cancellation for this
+    // call, so a re-running tool can be canceled again on a later stop.
+    this.synthesizedCanceledToolCallIds.delete(toolCallId);
     this.toolCalls.set(toolCallId, snapshot);
     return [this.wrapTimeline(mapToolSnapshotToTimeline(snapshot, this.terminalEntries))];
   }
@@ -2858,7 +3168,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       type: "timeline",
       provider: this.provider,
       item,
-      turnId: this.activeForegroundTurnId ?? undefined,
+      turnId: this.activeForegroundTurnId ?? this.autonomousTurnId ?? undefined,
     };
   }
 
@@ -2873,6 +3183,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       },
       "provider.acp.event_emit",
     );
+    if (!this.hasSubscribed && this.subscribers.size === 0) {
+      // The manager only subscribes after registerSession() completes, so a
+      // live delivery during session/new, session/load, or the awaited
+      // registerSession window would be dropped. Buffer everything emitted in
+      // that initialization window — turn lifecycle, timeline output, tool
+      // activity — and replay it in order when the first subscriber attaches.
+      // After the initial subscription, zero-subscriber periods (e.g. between
+      // sequential run() turns) must NOT buffer: the next run would drain the
+      // stale events into its own result.
+      this.pendingEvents.push(event);
+      return;
+    }
     for (const subscriber of this.subscribers) {
       subscriber(event);
     }
@@ -2941,17 +3263,25 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private synthesizeCanceledToolCalls(): void {
-    for (const snapshot of this.toolCalls.values()) {
-      const mapped = mapToolSnapshotToTimeline(snapshot, this.terminalEntries);
-      if (mapped.status === "running") {
-        this.pushEvent(
-          this.wrapTimeline({
-            ...mapped,
-            status: "canceled",
-            error: null,
-          }),
-        );
+    for (const [toolCallId, snapshot] of this.toolCalls) {
+      if (this.synthesizedCanceledToolCallIds.has(toolCallId)) {
+        continue;
       }
+      const mapped = mapToolSnapshotToTimeline(snapshot, this.terminalEntries);
+      if (mapped.status !== "running") {
+        continue;
+      }
+      this.pushEvent(
+        this.wrapTimeline({
+          ...mapped,
+          status: "canceled",
+          error: null,
+        }),
+      );
+      // Record the synthesis so a later call (e.g. handleChildExit followed by
+      // failAutonomousTurn on process exit) does not emit a duplicate canceled
+      // row for the same tool call.
+      this.synthesizedCanceledToolCallIds.add(toolCallId);
     }
   }
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -10,6 +10,8 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPExtensionSubagentParser,
+  type ACPExtensionTurnSignalParser,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -50,6 +52,8 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  subagentUpdateParser?: ACPExtensionSubagentParser;
+  turnSignalParser?: ACPExtensionTurnSignalParser;
   catalogModelResolver?: ACPCatalogModelResolver;
 }
 
@@ -75,6 +79,8 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
+      subagentUpdateParser: options.subagentUpdateParser,
+      turnSignalParser: options.turnSignalParser,
       catalogModelResolver: options.catalogModelResolver,
     });
 

--- a/packages/server/src/server/agent/providers/gjc-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/gjc-acp-agent.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+
+import { parseGjcExtensionSubagents, parseGjcTurnSignal } from "./gjc-acp-agent.js";
+
+test("parseGjcTurnSignal maps turn lifecycle methods", () => {
+  expect(parseGjcTurnSignal("_gjc/sdk/turn/start", {})).toEqual({ type: "start" });
+  expect(parseGjcTurnSignal("_gjc/sdk/turn/end", {})).toEqual({ type: "end" });
+  expect(parseGjcTurnSignal("_gjc/sdk/turn/fail", { error: "boom" })).toEqual({
+    type: "fail",
+    error: "boom",
+  });
+  expect(parseGjcTurnSignal("_gjc/sdk/turn/fail", {})).toEqual({
+    type: "fail",
+    error: "Autonomous turn failed",
+  });
+  expect(parseGjcTurnSignal("_gjc/sdk/subagent/update", {})).toBeNull();
+  expect(parseGjcTurnSignal("_kiro.dev/commands/available", {})).toBeNull();
+});
+
+test("parseGjcExtensionSubagents maps _gjc/sdk/subagent/update payloads", () => {
+  const events = parseGjcExtensionSubagents("_gjc/sdk/subagent/update", {
+    sessionId: "session-1",
+    subagents: [
+      {
+        type: "upsert",
+        id: "subagent-1",
+        title: "Audit the repo",
+        status: "running",
+        toolCallId: "call-1",
+        cwd: "/tmp/gjc",
+        subtitle: "Sub-agent",
+        timestamp: "2026-08-10T00:00:00Z",
+      },
+      {
+        type: "timeline",
+        id: "subagent-1",
+        item: { type: "assistant_message", text: "Started", messageId: "m1" },
+      },
+      { type: "remove", id: "subagent-2" },
+    ],
+  });
+  expect(events).toEqual([
+    {
+      type: "upsert",
+      id: "subagent-1",
+      title: "Audit the repo",
+      status: "running",
+      toolCallId: "call-1",
+      cwd: "/tmp/gjc",
+      subtitle: "Sub-agent",
+      timestamp: "2026-08-10T00:00:00Z",
+    },
+    {
+      type: "timeline",
+      id: "subagent-1",
+      item: { type: "assistant_message", text: "Started", messageId: "m1" },
+    },
+    { type: "remove", id: "subagent-2" },
+  ]);
+});
+
+test("parseGjcExtensionSubagents accepts a single event object and ignores other methods", () => {
+  expect(
+    parseGjcExtensionSubagents("_gjc/sdk/subagent/update", {
+      subagents: { type: "remove", id: "subagent-1" },
+    }),
+  ).toEqual([{ type: "remove", id: "subagent-1" }]);
+  expect(parseGjcExtensionSubagents("_gjc/sdk/other", { subagents: [] })).toBeNull();
+  expect(parseGjcExtensionSubagents("_kiro.dev/commands/available", {})).toBeNull();
+});
+
+test("parseGjcExtensionSubagents filters malformed entries and unknown statuses", () => {
+  const events = parseGjcExtensionSubagents("_gjc/sdk/subagent/update", {
+    subagents: [
+      { type: "bogus", id: "x" },
+      { type: "upsert", id: "" },
+      { type: "upsert", id: "subagent-1", status: "weird" },
+      { type: "timeline", id: "subagent-2" },
+      42,
+    ],
+  });
+  expect(events).toEqual([{ type: "upsert", id: "subagent-1" }]);
+});
+
+test("parseGjcExtensionSubagents validates timeline items and preserves explicit nulls", () => {
+  const events = parseGjcExtensionSubagents("_gjc/sdk/subagent/update", {
+    subagents: [
+      // Invalid timeline rows: tool_call without detail would crash the
+      // store's content bounding, and a partial tool_call (missing
+      // callId/name/status/error) fails the protocol schema and the client
+      // outbound validator.
+      { type: "timeline", id: "sub-1", item: { type: "tool_call" } },
+      { type: "timeline", id: "sub-2", item: { type: "assistant_message" } },
+      {
+        type: "timeline",
+        id: "sub-2b",
+        item: { type: "tool_call", detail: { type: "shell", output: "ok" } },
+      },
+      // A complete tool_call row passes through.
+      {
+        type: "timeline",
+        id: "sub-3",
+        item: {
+          type: "tool_call",
+          callId: "call-1",
+          name: "bash",
+          status: "completed",
+          error: null,
+          detail: { type: "shell", command: "echo ok", output: "ok" },
+        },
+      },
+      // Explicit nulls clear nullable fields; omissions retain them.
+      { type: "upsert", id: "sub-4", title: null, description: "kept", cwd: null },
+      { type: "upsert", id: "sub-5" },
+    ],
+  });
+  expect(events).toEqual([
+    {
+      type: "timeline",
+      id: "sub-3",
+      item: {
+        type: "tool_call",
+        callId: "call-1",
+        name: "bash",
+        status: "completed",
+        error: null,
+        detail: { type: "shell", command: "echo ok", output: "ok" },
+      },
+    },
+    { type: "upsert", id: "sub-4", title: null, description: "kept", cwd: null },
+    { type: "upsert", id: "sub-5" },
+  ]);
+});

--- a/packages/server/src/server/agent/providers/gjc-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/gjc-acp-agent.ts
@@ -1,0 +1,180 @@
+import type { Logger } from "pino";
+
+import { AgentTimelineItemPayloadSchema } from "@getpaseo/protocol/messages";
+
+import type { AgentTimelineItem } from "../agent-sdk-types.js";
+import type { ProviderSubagentInputEvent } from "../provider-subagents/store.js";
+import type { ACPExtensionSubagentParser, ACPExtensionTurnSignalParser } from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+interface GjcACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+// GJC publishes subagent/background-task state through this ACP extension
+// notification (per the `_`-prefixed vendor namespace convention). The payload
+// carries `ProviderSubagentInputEvent`-shaped entries that feed Paseo's
+// provider-subagent store: the subagents track, the read-only timeline panel,
+// and status reconciliation all consume those events unchanged.
+const GJC_SUBAGENT_UPDATE_METHOD = "_gjc/sdk/subagent/update";
+
+const SUBAGENT_EVENT_TYPES = new Set(["upsert", "timeline", "remove"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Structural validation of the timeline-item discriminated union against the
+ * protocol's authoritative schema. The provider-subagent store and the client
+ * outbound validator both consume `AgentTimelineItem`; a partial row (e.g. a
+ * tool_call without callId/name/status/error/detail) would crash content
+ * bounding or fail client outbound-message validation, so it must be dropped
+ * at this external boundary rather than cast through.
+ */
+function isValidTimelineItem(value: unknown): boolean {
+  return AgentTimelineItemPayloadSchema.safeParse(value).success;
+}
+
+/**
+ * The provider-subagent store distinguishes omitted fields (retain the
+ * previous value) from explicit `null` (clear it), so both strings and
+ * explicit nulls must be forwarded; anything else is treated as omitted.
+ */
+function stringOrNull(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizeSubagentUpdate(params: Record<string, unknown>): ProviderSubagentInputEvent[] {
+  const raw = params.subagents;
+  if (!raw) {
+    return [];
+  }
+  const entries = Array.isArray(raw) ? raw : [raw];
+  const result: ProviderSubagentInputEvent[] = [];
+  for (const entry of entries) {
+    const normalized = normalizeSubagentEntry(entry);
+    if (normalized) {
+      result.push(normalized);
+    }
+  }
+  return result;
+}
+
+function isSubagentStatus(
+  value: unknown,
+): value is "running" | "completed" | "failed" | "canceled" {
+  return value === "running" || value === "completed" || value === "failed" || value === "canceled";
+}
+
+function normalizeSubagentEntry(entry: unknown): ProviderSubagentInputEvent | undefined {
+  if (!isRecord(entry)) {
+    return undefined;
+  }
+  const type = entry.type;
+  const id = entry.id;
+  if (typeof type !== "string" || !SUBAGENT_EVENT_TYPES.has(type)) {
+    return undefined;
+  }
+  if (typeof id !== "string" || id.length === 0) {
+    return undefined;
+  }
+  if (type === "remove") {
+    return { type: "remove", id };
+  }
+  if (type === "timeline") {
+    // A timeline entry carries a Paseo timeline item; validate it against the
+    // discriminated union so a malformed row can never crash the store.
+    if (!isValidTimelineItem(entry.item)) {
+      return undefined;
+    }
+    return {
+      type: "timeline",
+      id,
+      item: entry.item as AgentTimelineItem,
+      ...(typeof entry.timestamp === "string" ? { timestamp: entry.timestamp } : {}),
+    };
+  }
+  const title = stringOrNull(entry.title);
+  const description = stringOrNull(entry.description);
+  const toolCallId = stringOrNull(entry.toolCallId);
+  const cwd = stringOrNull(entry.cwd);
+  const subtitle = stringOrNull(entry.subtitle);
+  return {
+    type: "upsert",
+    id,
+    ...(title !== undefined ? { title } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(isSubagentStatus(entry.status) ? { status: entry.status } : {}),
+    ...(toolCallId !== undefined ? { toolCallId } : {}),
+    ...(cwd !== undefined ? { cwd } : {}),
+    ...(subtitle !== undefined ? { subtitle } : {}),
+    ...(typeof entry.timestamp === "string" ? { timestamp: entry.timestamp } : {}),
+  };
+}
+
+// Provider-specific parser injected into the generic ACP session via the
+// `subagentUpdateParser` option (mirrors how Kiro injects its extension
+// commands parser). GJC reports subagent/background-task state through the
+// `_gjc/sdk/subagent/update` extension notification instead of any standard
+// ACP message; this recognizes that one method and returns the parsed
+// provider-subagent store events (possibly empty), or null for any other
+// notification so the base session ignores it.
+export const parseGjcExtensionSubagents: ACPExtensionSubagentParser = (method, params) => {
+  if (method !== GJC_SUBAGENT_UPDATE_METHOD) {
+    return null;
+  }
+  return normalizeSubagentUpdate(params);
+};
+
+// GJC declares its background/fresh-turn lifecycle through these extension
+// notifications. Unlike a spontaneous `session/update`, a start signal is an
+// explicit statement that a non-foreground turn is beginning, so the generic
+// ACP session may open an autonomous run for it without risking the #2148
+// regression (implicit updates must never mint turns).
+const GJC_TURN_START_METHOD = "_gjc/sdk/turn/start";
+const GJC_TURN_END_METHOD = "_gjc/sdk/turn/end";
+const GJC_TURN_FAIL_METHOD = "_gjc/sdk/turn/fail";
+
+/**
+ * Maps GJC's turn lifecycle extension notifications onto explicit turn signals.
+ */
+export const parseGjcTurnSignal: ACPExtensionTurnSignalParser = (method, params) => {
+  if (method === GJC_TURN_START_METHOD) {
+    return { type: "start" };
+  }
+  if (method === GJC_TURN_END_METHOD) {
+    return { type: "end" };
+  }
+  if (method === GJC_TURN_FAIL_METHOD) {
+    const error =
+      typeof params.error === "string" && params.error.length > 0
+        ? params.error
+        : "Autonomous turn failed";
+    return { type: "fail", error };
+  }
+  return null;
+};
+
+export class GjcACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GjcACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      subagentUpdateParser: parseGjcExtensionSubagents,
+      turnSignalParser: parseGjcTurnSignal,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Custom ACP providers registered with `"extends": "acp"` run through the generic ACP client, which drops vendor extension notifications. As a result, Paseo's provider-owned subagent surfaces are unusable from an external ACP agent (e.g. GJC): subagent/background-task state never reaches the subagents track, and a fresh non-foreground turn — an owned completion resuming the agent after its turn ended — can never re-open the session as `running`.

This PR makes subagents properly usable from ACP by giving the generic ACP client two **provider-declared extension surfaces**, both following the existing `extensionCommandsParser` opt-in parser pattern:

1. **Subagent state** — `subagentUpdateParser` maps a vendor notification into `ProviderSubagentInputEvent[]`; the session pushes them as `provider_subagent` stream events that feed the existing subagents track and read-only timeline panel unchanged. Events are buffered through the replay/initialization window (including `unstable_resumeSession()` providers and history-preserving reloads that never hydrate) and delivered exactly once via the first consumer of the buffer (subscribe flush or `streamHistory()` hydration).
2. **Declared turn lifecycle** — `turnSignalParser` maps a vendor notification onto an explicitly declared `start` / `end` / `fail` signal, which opens/closes a **non-foreground turn**. The manager treats the resulting `turn_started`/`turn_completed`/`turn_failed` events as a normal autonomous run: the agent flips to `running`, gains an `activeTurn` (stoppable from Paseo), streams, and returns to idle on completion.

**Why one PR, not two:** both surfaces are the same single integration contract — *"an external ACP provider declares its background work (state + lifecycle) to Paseo through vendor extension notifications"* — sharing the same seam (`extNotification`), the same parser pattern, the same GJC client wiring, and the same buffering/initialization semantics. Splitting them would force reviewers to evaluate the shared infrastructure twice. The two commits are the two layers of that one change: the generic hooks, then the concrete GJC consumer.

**Why explicit signals, not implicit updates:** the earlier implicit autonomous-turn approach (#2058) was reverted by #2148 because spontaneous out-of-prompt updates "do not define a turn lifecycle" and could complete an active foreground run mid-stream. This design makes that failure mode structurally impossible: a `start` signal is ignored while a foreground turn streams, `end`/`fail` are ignored without an open autonomous turn, a foreground prompt closes any pending autonomous turn first, and implicit `session/update`s never mint turns.

## Related work (not a duplicate)

- **#2289 (draft) — "feat(grok): specialize ACP provider for subagents, tools, and thinking"** — Grok-only vendor subclass parsing `x.ai/*` notifications. This PR is the provider-agnostic counterpart on the generic ACP client (config-registered parser options), usable by any external ACP provider without a vendor subclass. Same seam, different scope/shape; composes with #2289 if it lands.
- **#2182 (open) — "bug(grok/acp): hidden background-task reminders render as raw user messages"** — documents the ACP background-task display gap and explicitly calls for a "narrow extension point to the shared ACP client" without globally changing every ACP provider; this PR implements exactly that extension point.
- **#2058 / #2148** — the implicit autonomous-turn mechanism and its revert; the turn-signal design here re-adds the capability in the safe, explicit form (#2148's failure mode cannot occur, see above).
- **#2696 / #2336 (merged)** — OpenCode-native background wakeups (busy status, fresh-message-ID autonomous turns). Provider-native equivalents of the lifecycle surface this PR adds to ACP; they do not apply to ACP providers.

## Change scope

- `packages/server/src/server/agent/providers/acp-agent.ts` — `ACPExtensionSubagentParser`, `ACPTurnSignal`/`ACPExtensionTurnSignalParser`; `subagentUpdateParser` + `turnSignalParser` options forwarded client → session (create/resume); `extNotification()` consumption with session scoping; provider-subagent buffering (replay/init window, subscribe flush, `streamHistory` hydration, `historyPending` recompute); autonomous turn open/close/fail with foreground guards; `wrapTimeline` tagging.
- `packages/server/src/server/agent/providers/generic-acp-agent.ts` — forward both options.
- `packages/server/src/server/agent/providers/gjc-acp-agent.ts` — `GjcACPAgentClient` + `parseGjcExtensionSubagents` (`_gjc/sdk/subagent/update`) and `parseGjcTurnSignal` (`_gjc/sdk/turn/{start,end,fail}`), with timeline-item validation against the protocol schema.
- `packages/server/src/server/agent/provider-registry.ts` — select `GjcACPAgentClient` by `providerId === "gjc"` in the trusted `extends: "acp"` construction path (mirrors cursor/kimi/kiro/trae).
- Tests: `acp-agent.test.ts` + new `gjc-acp-agent.test.ts`.

No protocol changes, no UI changes, no changes to other providers. Default behavior for every other ACP provider is unchanged.

## Validation

### Tests

- `acp-agent.test.ts` (108) + `gjc-acp-agent.test.ts` (6): **114/114** — parser option behavior (subagent events, turn signals), replay/init-window buffering, subscribe flush, streamHistory-first ordering, timeline-replay pending after subagent flush, full tool-call shape validation, explicit-null preservation, autonomous-turn lifecycle (start/open+tagging, foreground-block, orphan end/fail, complete/fail, pre-prompt close), session-mismatch filtering.
- `generic-acp-agent.test.ts` + `provider-subagents/store` suite: green.

### Checks

- `npm run typecheck` (server workspace; full workspace typecheck passes on CI): pass
- `npm run format:check` (repo-wide): pass
- `npm run lint` (oxlint, repo-wide): 0 warnings / 0 errors
- Branch rebased onto latest `upstream/main` (base `42f1d0b28`); PR mergeable.
- CI extras from the repo lint job (lockfile-lint, `npm audit signatures`): pass (verified on the prior head; CI re-runs on this head)

### Platforms

Server-side TypeScript change; validated on macOS (arm64). Windows/Linux not run locally — CI covers them.

## Commit history

- `ef4efe633` feat(acp): add subagent-state and turn-signal extension hooks to the generic ACP client
- `4ed2a1497` feat(acp): wire GJC subagent and turn-signal parsers into the gjc provider

## Checklist

- [x] One focused change (single ACP integration contract; commits are its two layers)
- [x] Related work linked and non-duplicate explained (incl. the #2058/#2148 revert history)
- [x] Tests added and passing
- [x] QA evidence included
- [x] Maintainer edits enabled
- [x] Branch up to date with target (rebased onto latest main)
- [x] Commit history organized into meaningful units

> Written with agent assistance; implementation reviewed and tested before submission.
