### PR TITLE
perf(client): reconnect immediately on app resume, skipping backoff

### DIFF
--- a/packages/app/src/hooks/use-client-activity.ts
+++ b/packages/app/src/hooks/use-client-activity.ts
@@ -50,11 +50,15 @@ export function useClientActivity({
   // Track app visibility via AppState (native).
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextState) => {
-      tracker.notifyAppVisibility(nextState === "active");
+      const visible = nextState === "active";
+      tracker.notifyAppVisibility(visible);
+      if (visible) {
+        client.resumeConnection();
+      }
       tracker.sendHeartbeat();
     });
     return () => subscription.remove();
-  }, [tracker]);
+  }, [client, tracker]);
 
   // Track user activity and visibility on web.
   useEffect(() => {
@@ -70,6 +74,7 @@ export function useClientActivity({
       const visible = document.visibilityState === "visible";
       const { changed } = tracker.notifyAppVisibility(visible);
       if (changed && visible) {
+        client.resumeConnection();
         tracker.maybeSendImmediateHeartbeat();
       }
     };
@@ -89,7 +94,7 @@ export function useClientActivity({
       window.removeEventListener("wheel", handleUserActivity);
       window.removeEventListener("touchstart", handleUserActivity);
     };
-  }, [tracker]);
+  }, [client, tracker]);
 
   // Track OS-wide activity in Electron so backgrounded desktop windows still report presence.
   useEffect(() => {

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -119,7 +119,7 @@ interface ChatAgentStateShape {
   lastError?: Agent["lastError"] | null;
 }
 
-const RECONNECT_TOAST_DELAY_MS = 1_000;
+const RECONNECT_TOAST_DELAY_MS = 1_500;
 
 const reconnectToastStateByServerId = new Map<string, ReconnectToastState>();
 

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -944,6 +944,140 @@ test("does not reconnect after close when ensureConnected is called", async () =
   expect(client.getConnectionState().status).toBe("disposed");
 });
 
+test("resumeConnection reconnects immediately while disconnected, skipping backoff", async () => {
+  useHeartbeatClock();
+  try {
+    const logger = createMockLogger();
+    const first = createMockTransport();
+    const second = createMockTransport();
+    const transports = [first, second];
+    let transportIndex = 0;
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_unit_test",
+      logger,
+      reconnect: {
+        enabled: true,
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+      },
+      transportFactory: () => {
+        const next = transports[Math.min(transportIndex, transports.length - 1)];
+        transportIndex += 1;
+        return next.transport;
+      },
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    first.triggerOpen();
+    await connectPromise;
+    expect(client.getConnectionState().status).toBe("connected");
+
+    first.triggerClose({ code: 1006 });
+    expect(client.getConnectionState().status).toBe("disconnected");
+
+    client.resumeConnection();
+    expect(client.getConnectionState().status).toBe("connecting");
+
+    second.triggerOpen();
+    expect(client.getConnectionState().status).toBe("connected");
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("resumeConnection is a no-op while connecting", async () => {
+  useHeartbeatClock();
+  try {
+    const logger = createMockLogger();
+    const first = createMockTransport();
+    const second = createMockTransport();
+    const transports = [first, second];
+    let transportIndex = 0;
+
+    const client = new DaemonClient({
+      url: "ws://test",
+      clientId: "clsk_unit_test",
+      logger,
+      reconnect: { enabled: true, baseDelayMs: 5, maxDelayMs: 5 },
+      transportFactory: () => {
+        const next = transports[Math.min(transportIndex, transports.length - 1)];
+        transportIndex += 1;
+        return next.transport;
+      },
+    });
+    clients.push(client);
+
+    const connectPromise = client.connect();
+    first.triggerOpen();
+    await connectPromise;
+
+    first.triggerClose({ code: 1006 });
+    expect(client.getConnectionState().status).toBe("disconnected");
+
+    await vi.advanceTimersByTimeAsync(5);
+    expect(client.getConnectionState().status).toBe("connecting");
+
+    const transportCountBefore = transportIndex;
+    client.resumeConnection();
+    expect(client.getConnectionState().status).toBe("connecting");
+    expect(transportIndex).toBe(transportCountBefore);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("resumeConnection is a no-op while connected", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+  const transportFactory = vi.fn(() => mock.transport);
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: true },
+    transportFactory,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+  expect(client.getConnectionState().status).toBe("connected");
+
+  const callsBefore = transportFactory.mock.calls.length;
+  client.resumeConnection();
+  expect(client.getConnectionState().status).toBe("connected");
+  expect(transportFactory.mock.calls.length).toBe(callsBefore);
+});
+
+test("resumeConnection is a no-op on a disposed client", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  await client.close();
+  expect(client.getConnectionState().status).toBe("disposed");
+
+  client.resumeConnection();
+  expect(client.getConnectionState().status).toBe("disposed");
+});
+
 test("keeps the transport connected when a session RPC ping times out", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -1452,6 +1452,30 @@ export class DaemonClient {
     void this.connect();
   }
 
+  /**
+   * Called when the app returns to the foreground. If the connection dropped
+   * while backgrounded, skip the exponential backoff and reconnect immediately.
+   * No-op for any other state — the existing reconnect path or live connection
+   * handles those cases.
+   */
+  resumeConnection(): void {
+    if (this.connectionState.status === "disposed") {
+      return;
+    }
+    if (this.connectionState.status !== "disconnected") {
+      return;
+    }
+    if (!this.shouldReconnect) {
+      this.shouldReconnect = true;
+    }
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+    this.reconnectAttempt = 0;
+    this.attemptConnect();
+  }
+
   getConnectionState(): ConnectionState {
     return this.connectionState;
   }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -361,6 +361,7 @@ export interface PaseoClient {
   connect(): Promise<void>;
   close(): Promise<void>;
   ensureConnected(): void;
+  resumeConnection(): void;
   getConnectionState(): ConnectionState;
 }
 
@@ -450,6 +451,7 @@ export function createPaseoClient(config: PaseoClientConfig): PaseoClient {
     connect: () => daemonClient.connect(),
     close: () => daemonClient.close(),
     ensureConnected: () => daemonClient.ensureConnected(),
+    resumeConnection: () => daemonClient.resumeConnection(),
     getConnectionState: () => daemonClient.getConnectionState(),
   };
 }


### PR DESCRIPTION
## Related issue

Related to #964 (reconnect after interruption is slow/unreliable).

## Problem

When the app returns from the background, the WebSocket to the daemon is almost always dead, but recovery waits for the first-attempt backoff (~1500ms) before even trying to reconnect, surfacing a ~3s "Reconnecting" toast on every resume.

## Solution

Add `DaemonClient.resumeConnection()` that clears the pending backoff timer and calls `attemptConnect()` immediately when the client is disconnected; it is a no-op for connecting/connected/disposed states. It is called from `useClientActivity` on `AppState` → active (native) and `visibilitychange` → visible (web).

Also raise the reconnect-toast threshold from 1000ms to 1500ms so that a sub-second resume reconnect never flashes the indicator.

Cuts resume-to-session-ready from ~3s to ~300-500ms on Android; web and Electron get the same fast path on tab/window refocus. Passive backoff for transient drops while the app is running is unchanged.

## QA / testing evidence

Automated checks:

- `npm run typecheck` — all workspaces pass.
- Repository lint and formatting checks pass (lefthook pre-commit).
- Focused Vitest: `packages/client/src/daemon-client.test.ts` — 112 tests pass, including new coverage for `resumeConnection()` (immediate reconnect when disconnected, no-op for connecting/connected/disposed, backoff state reset).

UI QA:

- Android: verified by the author on a physical device during branch development; resume-to-session-ready dropped from ~3s to ~300-500ms and the reconnect toast no longer appears on quick resumes.
- iOS: not tested; no iOS simulator was available. The change only touches reconnect timing via the cross-platform `AppState` API, with no platform-specific code.
- Web / Desktop: not tested interactively; they share the same `visibilitychange` fast path, and the behavior is covered by the client unit tests.