### PR TITLE
fix(server): let agent-scoped create_agent ask for a detached child

### DIFF
--- a/packages/server/src/server/agent/mcp-parity.e2e.test.ts
+++ b/packages/server/src/server/agent/mcp-parity.e2e.test.ts
@@ -225,6 +225,19 @@ async function createChildAgent(args?: Partial<StructuredContent>): Promise<stri
   return str(payload.agentId);
 }
 
+// Same child, canonical placement: no `relationship`, no `workspace`, so the
+// agent-scoped branch resolves it instead of the COMPAT nested one.
+async function createCanonicalChildAgent(args?: Partial<StructuredContent>): Promise<string> {
+  const payload = await callToolStructured(agentScopedClient, "create_agent", {
+    title: "Parity canonical child",
+    provider: "claude/claude-test-model",
+    initialPrompt: "say done and stop",
+    notifyOnFinish: false,
+    ...args,
+  });
+  return str(payload.agentId);
+}
+
 async function archiveAgentIfPresent(agentId: string | null | undefined): Promise<void> {
   if (!agentId) {
     return;
@@ -346,6 +359,32 @@ describe("Suite A: Core Fixes", () => {
       agentId = await createChildAgent({ relationship: { kind: "detached" } });
       const snapshot = daemonHandle.daemon.agentManager.getAgent(agentId);
       expect(snapshot?.labels?.[PARENT_AGENT_ID_LABEL]).toBeUndefined();
+    } finally {
+      await archiveAgentIfPresent(agentId);
+    }
+  });
+
+  // The canonical shape carries no `relationship`, so `detached` is the only way
+  // to ask for a root agent without the COMPAT nested placement.
+  test("create_agent detached:true omits the parent agent label", async () => {
+    let agentId: string | null = null;
+    try {
+      agentId = await createCanonicalChildAgent({ detached: true });
+      const snapshot = daemonHandle.daemon.agentManager.getAgent(agentId);
+      expect(snapshot?.labels?.[PARENT_AGENT_ID_LABEL]).toBeUndefined();
+    } finally {
+      await archiveAgentIfPresent(agentId);
+    }
+  });
+
+  test("create_agent without detached keeps the parent agent label", async () => {
+    let agentId: string | null = null;
+    try {
+      agentId = await createCanonicalChildAgent();
+      const snapshot = daemonHandle.daemon.agentManager.getAgent(agentId);
+      expect(snapshot?.labels).toMatchObject({
+        [PARENT_AGENT_ID_LABEL]: parentAgentId,
+      });
     } finally {
       await archiveAgentIfPresent(agentId);
     }

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -1015,6 +1015,18 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       .describe(
         "Get notified when the created agent finishes, errors, or needs permission. Set false only for truly fire-and-forget agents.",
       ),
+    // Detached creation is otherwise reachable only through the COMPAT nested
+    // `relationship` placement, which this schema does not advertise — so a
+    // client that trusts the advertised schema cannot express the request.
+    // No `.default()`: a default makes the tool schema inject the key into every
+    // parsed call, and the legacy placement schema is `.strict()`, so legacy
+    // callers would start failing on an unrecognized `detached`.
+    detached: z
+      .boolean()
+      .optional()
+      .describe(
+        "Create a root agent instead of a child on your subagent track. A detached agent does not appear in your subagent track and is not archived when you are.",
+      ),
   };
   const canonicalTopLevelInputSchema = {
     ...canonicalCreateAgentFields,
@@ -1565,7 +1577,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       return {
         kind: "agent-scoped",
         parsedArgs: parsed,
-        detached: false,
+        detached: parsed.detached ?? false,
         cwd,
         workspaceId,
         worktree: undefined,


### PR DESCRIPTION
## Problem

The agent-scoped `create_agent` schema has no way to say "create this as a root agent". `resolveCreateAgentToolArgs` hardcodes it:

```ts
const parsed = agentToAgentCreateAgentArgsSchema.parse(args);
…
return { kind: "agent-scoped", parsedArgs: parsed, detached: false, … };
```

Detached creation is therefore reachable only through the COMPAT nested placement, `relationship: { kind: "detached" }` — a shape the advertised schema never mentions, and one already tagged `COMPAT(nestedCreateAgentPlacement)` for removal after 2027-01-17. So the only way to request a detached child is a deprecated path that clients cannot discover.

## Why this bites in practice

A client that trusts the advertised schema cannot represent an argument the schema does not declare. It falls back to sending the object as a **string**, and the call dies:

```
[{"code":"invalid_type","expected":"object","path":["relationship"],
  "message":"Invalid input: expected object, received string"}]
```

Measured against daemon 0.3.1, two MCP clients given a byte-identical prompt:

| Client | What it sent | Result |
| --- | --- | --- |
| A | `"relationship":{"kind":"detached"}` | agent created |
| B | `"relationship":"{\"kind\": \"detached\"}"` | rejected |

For client B there is no working way to create a detached agent — not a formatting nit, a capability that is simply unreachable.

## Fix

An optional `detached` boolean on the agent-scoped schema, honoured at the read site. Two lines plus a description; top-level creation is unaffected (it is already detached by construction).

**Deliberately no `.default(false)`.** A default makes the tool schema inject `detached` into *every* parsed call, and the legacy placement schema is `.strict()` — so legacy callers immediately start failing on an unrecognized key. Three existing tests in `mcp-parity.e2e.test.ts` went red when I tried it; that is how the default was found and dropped. Keeping the field `.optional()` and coalescing at the read site leaves the legacy path untouched.

## Tests

Two cases in `mcp-parity.e2e.test.ts`, placed next to the legacy-shape test they mirror, driving a real MCP tool call against a real daemon:

- canonical `detached: true` → no parent label
- canonical without the flag → parent label kept (default behaviour preserved)

The first fails without this change (verified by reverting the read site: `1 failed | 31 skipped`).

## Test-run state on my machine

`mcp-parity.e2e.test.ts` has **4 pre-existing failures unrelated to this PR**, all in the worktree group. Identical before and after:

| | Tests |
| --- | --- |
| pristine `upstream/main` | 4 failed, 26 passed (30) |
| this branch | 4 failed, 28 passed (32) |

Same four names both times (`list_worktrees on empty repo`, `create_worktree and list_worktrees`, `archive_worktree removes worktree`, `archive_worktree succeeds when caller cwd is inside the archived worktree`). They look environmental on this machine; flagging rather than hiding them.

`npm run typecheck`, `npm run lint`, `npm run format:check` all clean.

## Relation to #3094

Independent, different files, either order. #3094 makes a detached child *notify* the caller that created it; this makes a detached child *requestable* from the canonical shape. Together they close the loop, but each stands alone.
