### PR TITLE
Preserve dictation recordings across WebSocket interruptions

### DIFF
--- a/packages/app/src/dictation/dictation-stream-sender.test.ts
+++ b/packages/app/src/dictation/dictation-stream-sender.test.ts
@@ -38,6 +38,10 @@ class FakeDaemonClient {
   cancels: string[] = [];
   private readonly rawMessageListeners = new Set<FakeRawMessageListener>();
 
+  get rawMessageListenerCount(): number {
+    return this.rawMessageListeners.size;
+  }
+
   async startDictationStream(dictationId: string, format: string): Promise<void> {
     this.starts.push({ dictationId, format });
   }
@@ -91,6 +95,16 @@ class FakeDaemonClient {
 const tick = async () => {
   await Promise.resolve();
   await Promise.resolve();
+};
+
+const promiseOutcome = async <T>(promise: Promise<T>, timeoutMs: number) => {
+  return Promise.race([
+    promise.then(
+      () => "resolved" as const,
+      () => "rejected" as const,
+    ),
+    new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), timeoutMs)),
+  ]);
 };
 
 describe("DictationStreamSender", () => {
@@ -199,6 +213,18 @@ describe("DictationStreamSender", () => {
     expect(sender.getSegmentCount()).toBe(3);
   });
 
+  it("removes its raw-message listener when disposed", () => {
+    const client = new FakeDaemonClient();
+    const sender = new DictationStreamSender({
+      client,
+      format: "audio/pcm;rate=16000;bits=16",
+    });
+
+    expect(client.rawMessageListenerCount).toBe(1);
+    sender.dispose();
+    expect(client.rawMessageListenerCount).toBe(0);
+  });
+
   it("replays segments captured before, during, and after an outage from seq 0", async () => {
     const client = new FakeDaemonClient();
     const ids = ["d1", "d2"];
@@ -247,13 +273,7 @@ describe("DictationStreamSender", () => {
 
       client.setConnected(true);
       const finish = sender.finish(sender.getFinalSeq());
-      const outcome = Promise.race([
-        finish.then(
-          () => "resolved" as const,
-          () => "rejected" as const,
-        ),
-        new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 1)),
-      ]);
+      const outcome = promiseOutcome(finish, 1);
 
       await tick();
       client.setConnected(false);

--- a/packages/app/src/dictation/dictation-stream-sender.test.ts
+++ b/packages/app/src/dictation/dictation-stream-sender.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from "vitest";
-import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
-
+import { describe, expect, it, vi } from "vitest";
+import type { SessionOutboundMessage } from "@getpaseo/protocol/messages";
 import { DictationStreamSender } from "@/dictation/dictation-stream-sender";
 
 interface FakeFinish {
@@ -18,19 +17,62 @@ interface FakeChunk {
   format: string;
 }
 
+interface FakeAck {
+  type: "dictation_stream_ack";
+  payload: {
+    dictationId: string;
+    ackSeq: number;
+  };
+}
+
+type FakeRawMessageListener = (message: SessionOutboundMessage) => void;
+
 class FakeDaemonClient {
   isConnected = true;
+  autoAck = true;
+  throwOnNextChunk = false;
+  disconnectOnChunkError = false;
   starts: FakeStart[] = [];
   chunks: FakeChunk[] = [];
   finishes: FakeFinish[] = [];
   cancels: string[] = [];
+  private readonly rawMessageListeners = new Set<FakeRawMessageListener>();
 
   async startDictationStream(dictationId: string, format: string): Promise<void> {
     this.starts.push({ dictationId, format });
   }
 
   sendDictationStreamChunk(dictationId: string, seq: number, audio: string, format: string): void {
+    if (this.throwOnNextChunk) {
+      this.throwOnNextChunk = false;
+      if (this.disconnectOnChunkError) {
+        this.isConnected = false;
+      }
+      throw new Error("WebSocket is closing");
+    }
     this.chunks.push({ dictationId, seq, audio, format });
+    if (this.autoAck) {
+      this.emitAck(dictationId, seq);
+    }
+  }
+
+  subscribeRawMessages(handler: FakeRawMessageListener): () => void {
+    this.rawMessageListeners.add(handler);
+    return () => this.rawMessageListeners.delete(handler);
+  }
+
+  setConnected(isConnected: boolean): void {
+    this.isConnected = isConnected;
+  }
+
+  emitAck(dictationId: string, ackSeq: number): void {
+    const message: FakeAck = {
+      type: "dictation_stream_ack",
+      payload: { dictationId, ackSeq },
+    };
+    for (const listener of this.rawMessageListeners) {
+      listener(message);
+    }
   }
 
   async finishDictationStream(
@@ -56,7 +98,7 @@ describe("DictationStreamSender", () => {
     const client = new FakeDaemonClient();
     const ids = ["d1"];
     const sender = new DictationStreamSender({
-      client: client as unknown as DaemonClient,
+      client,
       format: "audio/pcm;rate=16000;bits=16",
       createDictationId: () => ids.shift() ?? "dX",
     });
@@ -77,7 +119,7 @@ describe("DictationStreamSender", () => {
     const client = new FakeDaemonClient();
     const ids = ["d1", "d2"];
     const sender = new DictationStreamSender({
-      client: client as unknown as DaemonClient,
+      client,
       format: "audio/pcm;rate=16000;bits=16",
       createDictationId: () => ids.shift() ?? "dX",
     });
@@ -100,7 +142,7 @@ describe("DictationStreamSender", () => {
     const client = new FakeDaemonClient();
     const ids = ["d1"];
     const sender = new DictationStreamSender({
-      client: client as unknown as DaemonClient,
+      client,
       format: "audio/pcm;rate=16000;bits=16",
       createDictationId: () => ids.shift() ?? "dX",
     });
@@ -121,7 +163,7 @@ describe("DictationStreamSender", () => {
     client.isConnected = false;
     const ids = ["d1"];
     const sender = new DictationStreamSender({
-      client: client as unknown as DaemonClient,
+      client,
       format: "audio/pcm;rate=16000;bits=16",
       createDictationId: () => ids.shift() ?? "dX",
     });
@@ -138,11 +180,125 @@ describe("DictationStreamSender", () => {
     expect(client.chunks.map((c) => c.seq)).toEqual([0, 1]);
   });
 
+  it("keeps capture safe and buffers later segments when a chunk send throws", async () => {
+    const client = new FakeDaemonClient();
+    const sender = new DictationStreamSender({
+      client,
+      format: "audio/pcm;rate=16000;bits=16",
+      createDictationId: () => "d1",
+    });
+
+    sender.enqueueSegment("before-outage");
+    await tick();
+
+    client.throwOnNextChunk = true;
+    client.disconnectOnChunkError = true;
+
+    expect(() => sender.enqueueSegment("during-outage")).not.toThrow();
+    expect(() => sender.enqueueSegment("after-outage")).not.toThrow();
+    expect(sender.getSegmentCount()).toBe(3);
+  });
+
+  it("replays segments captured before, during, and after an outage from seq 0", async () => {
+    const client = new FakeDaemonClient();
+    const ids = ["d1", "d2"];
+    const sender = new DictationStreamSender({
+      client,
+      format: "audio/pcm;rate=16000;bits=16",
+      createDictationId: () => ids.shift() ?? "dX",
+    });
+
+    sender.enqueueSegment("before-outage");
+    await tick();
+
+    client.throwOnNextChunk = true;
+    client.disconnectOnChunkError = true;
+    expect(() => sender.enqueueSegment("during-outage")).not.toThrow();
+    sender.enqueueSegment("after-outage");
+
+    client.setConnected(true);
+    await sender.restartStream("reconnect");
+
+    const replay = client.chunks
+      .filter((chunk) => chunk.dictationId === "d2")
+      .map((chunk) => [chunk.seq, chunk.audio]);
+    expect(replay).toEqual([
+      [0, "before-outage"],
+      [1, "during-outage"],
+      [2, "after-outage"],
+    ]);
+  });
+
+  it("fails finish after a transport transition without losing buffered audio", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new FakeDaemonClient();
+      client.setConnected(false);
+      const ids = ["d1", "d2"];
+      const sender = new DictationStreamSender({
+        client,
+        format: "audio/pcm;rate=16000;bits=16",
+        createDictationId: () => ids.shift() ?? "dX",
+      });
+
+      for (let seq = 0; seq < 129; seq += 1) {
+        sender.enqueueSegment(`segment-${seq}`);
+      }
+
+      client.setConnected(true);
+      const finish = sender.finish(sender.getFinalSeq());
+      const outcome = Promise.race([
+        finish.then(
+          () => "resolved" as const,
+          () => "rejected" as const,
+        ),
+        new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 1)),
+      ]);
+
+      await tick();
+      client.setConnected(false);
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expect(outcome).resolves.toBe("rejected");
+      expect(sender.getSegmentCount()).toBe(129);
+      expect(sender.getFinalSeq()).toBe(128);
+
+      client.setConnected(true);
+      sender.resetStreamForReplay();
+      await sender.restartStream("retry");
+      await expect(sender.finish(128)).resolves.toEqual({ dictationId: "d2", text: "ok" });
+      expect(client.chunks.filter((chunk) => chunk.dictationId === "d2")).toHaveLength(129);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for server delivery acknowledgement before finishing", async () => {
+    const client = new FakeDaemonClient();
+    client.autoAck = false;
+    const sender = new DictationStreamSender({
+      client,
+      format: "audio/pcm;rate=16000;bits=16",
+      createDictationId: () => "d1",
+    });
+
+    sender.enqueueSegment("seg0");
+    sender.enqueueSegment("seg1");
+    await tick();
+
+    const finish = sender.finish(1);
+    await tick();
+    expect(client.finishes).toEqual([]);
+
+    client.emitAck("d1", 1);
+    await expect(finish).resolves.toEqual({ dictationId: "d1", text: "ok" });
+  });
+
   it("does not replay long buffered native dictation in one synchronous burst", async () => {
     const client = new FakeDaemonClient();
     client.isConnected = false;
     const sender = new DictationStreamSender({
-      client: client as unknown as DaemonClient,
+      client,
       format: "audio/pcm;rate=16000;bits=16",
       createDictationId: () => "d1",
     });

--- a/packages/app/src/dictation/dictation-stream-sender.ts
+++ b/packages/app/src/dictation/dictation-stream-sender.ts
@@ -103,6 +103,10 @@ export class DictationStreamSender {
     return this.segments.length;
   }
 
+  dispose(): void {
+    this.setClient(null);
+  }
+
   getFinalSeq(): number {
     return this.segments.length - 1;
   }
@@ -158,17 +162,17 @@ export class DictationStreamSender {
     }
 
     let sent = 0;
-    try {
-      while (this.sendSeq < this.segments.length && sent < MAX_CHUNKS_PER_FLUSH_TURN) {
-        const seq = this.sendSeq;
-        const audio = this.segments[seq];
+    while (this.sendSeq < this.segments.length && sent < MAX_CHUNKS_PER_FLUSH_TURN) {
+      const seq = this.sendSeq;
+      const audio = this.segments[seq];
+      try {
         client.sendDictationStreamChunk(dictationId, seq, audio, this.format);
-        this.sendSeq = seq + 1;
-        sent += 1;
+      } catch {
+        this.invalidateStream();
+        return sent;
       }
-    } catch {
-      this.invalidateStream();
-      return sent;
+      this.sendSeq = seq + 1;
+      sent += 1;
     }
 
     if (this.hasPendingSegments()) {

--- a/packages/app/src/dictation/dictation-stream-sender.ts
+++ b/packages/app/src/dictation/dictation-stream-sender.ts
@@ -1,13 +1,32 @@
 import { generateMessageId } from "@/types/stream";
-import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
+import type { SessionOutboundMessage } from "@getpaseo/protocol/messages";
 import { i18n } from "@/i18n/i18next";
 
 const MAX_CHUNKS_PER_FLUSH_TURN = 128;
+const DICTATION_DRAIN_IDLE_TIMEOUT_MS = 30_000;
 
 const waitForNextFlushTurn = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
+type DictationStreamAckMessage = Extract<SessionOutboundMessage, { type: "dictation_stream_ack" }>;
+
+interface DrainWaitResult {
+  kind: "signaled" | "timed-out";
+}
+
+export interface DictationStreamClient {
+  readonly isConnected: boolean;
+  startDictationStream(dictationId: string, format: string): Promise<void>;
+  sendDictationStreamChunk(dictationId: string, seq: number, audio: string, format: string): void;
+  finishDictationStream(
+    dictationId: string,
+    finalSeq: number,
+  ): Promise<{ dictationId: string; text: string }>;
+  cancelDictationStream(dictationId: string): void;
+  subscribeRawMessages(handler: (message: SessionOutboundMessage) => void): () => void;
+}
+
 export interface DictationStreamSenderParams {
-  client: DaemonClient | null;
+  client: DictationStreamClient | null;
   format: string;
   createDictationId?: () => string;
 }
@@ -30,28 +49,50 @@ interface DictationFinishResult {
  * so enqueues can't "miss" a flush due to in-flight await/coalescing bugs.
  */
 export class DictationStreamSender {
-  private client: DaemonClient | null;
+  private client: DictationStreamClient | null = null;
   private readonly format: string;
   private readonly createDictationId: () => string;
 
   private dictationId: string | null = null;
   private sendSeq = 0;
+  private acknowledgedSeq = -1;
   private segments: string[] = [];
   private streamReady = false;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private drainWaiters: Array<() => void> = [];
+  private clientCleanup: (() => void) | null = null;
 
   private startGeneration = 0;
   private startPromise: Promise<void> | null = null;
 
   constructor(params: DictationStreamSenderParams) {
-    this.client = params.client;
     this.format = params.format;
     this.createDictationId = params.createDictationId ?? generateMessageId;
+    this.setClient(params.client);
   }
 
-  setClient(client: DaemonClient | null): void {
+  setClient(client: DictationStreamClient | null): void {
+    if (this.client === client) {
+      return;
+    }
+
+    if (this.clientCleanup) {
+      this.clientCleanup();
+      this.clientCleanup = null;
+    }
+    this.resetStreamForReplay();
     this.client = client;
+
+    if (!client) {
+      return;
+    }
+
+    this.clientCleanup = client.subscribeRawMessages((message) => {
+      if (message.type !== "dictation_stream_ack") {
+        return;
+      }
+      this.handleAck(message);
+    });
   }
 
   getDictationId(): string | null {
@@ -71,22 +112,19 @@ export class DictationStreamSender {
   }
 
   clearAll(): void {
-    this.clearScheduledFlush();
-    this.dictationId = null;
-    this.sendSeq = 0;
+    this.resetStreamForReplay();
     this.segments = [];
-    this.streamReady = false;
-    this.startPromise = null;
-    this.startGeneration += 1;
   }
 
   resetStreamForReplay(): void {
     this.clearScheduledFlush();
     this.dictationId = null;
     this.sendSeq = 0;
+    this.acknowledgedSeq = -1;
     this.streamReady = false;
     this.startPromise = null;
     this.startGeneration += 1;
+    this.resolveDrainWaiters();
   }
 
   enqueueSegment(base64Pcm: string): void {
@@ -113,17 +151,26 @@ export class DictationStreamSender {
     const client = this.client;
     const dictationId = this.dictationId;
     if (!client?.isConnected || !dictationId || !this.streamReady) {
+      if (!client?.isConnected && this.hasPendingSegments()) {
+        this.invalidateStream();
+      }
       return 0;
     }
 
     let sent = 0;
-    while (this.sendSeq < this.segments.length && sent < MAX_CHUNKS_PER_FLUSH_TURN) {
-      const seq = this.sendSeq;
-      const audio = this.segments[seq];
-      client.sendDictationStreamChunk(dictationId, seq, audio, this.format);
-      this.sendSeq = seq + 1;
-      sent += 1;
+    try {
+      while (this.sendSeq < this.segments.length && sent < MAX_CHUNKS_PER_FLUSH_TURN) {
+        const seq = this.sendSeq;
+        const audio = this.segments[seq];
+        client.sendDictationStreamChunk(dictationId, seq, audio, this.format);
+        this.sendSeq = seq + 1;
+        sent += 1;
+      }
+    } catch {
+      this.invalidateStream();
+      return sent;
     }
+
     if (this.hasPendingSegments()) {
       this.scheduleFlush();
     } else {
@@ -144,6 +191,7 @@ export class DictationStreamSender {
     const dictationId = this.createDictationId();
     this.dictationId = dictationId;
     this.sendSeq = 0;
+    this.acknowledgedSeq = -1;
     this.streamReady = false;
 
     const start = (async () => {
@@ -161,7 +209,10 @@ export class DictationStreamSender {
         // If starting failed, keep the segments for retry but clear the stream so finish can error cleanly.
         if (this.startGeneration === generation && this.dictationId === dictationId) {
           this.dictationId = null;
+          this.sendSeq = 0;
+          this.acknowledgedSeq = -1;
           this.streamReady = false;
+          this.resolveDrainWaiters();
         }
         throw error;
       })
@@ -198,7 +249,7 @@ export class DictationStreamSender {
     }
 
     this.flush();
-    await this.waitForFlushDrain();
+    await this.waitForFlushDrain(finalSeq);
     return client.finishDictationStream(dictationId, finalSeq);
   }
 
@@ -213,6 +264,25 @@ export class DictationStreamSender {
 
   private hasPendingSegments(): boolean {
     return this.sendSeq < this.segments.length;
+  }
+
+  private hasPendingDelivery(finalSeq: number): boolean {
+    return this.hasPendingSegments() || this.acknowledgedSeq < finalSeq;
+  }
+
+  private handleAck(message: DictationStreamAckMessage): void {
+    if (message.payload.dictationId !== this.dictationId) {
+      return;
+    }
+    if (message.payload.ackSeq <= this.acknowledgedSeq) {
+      return;
+    }
+    this.acknowledgedSeq = message.payload.ackSeq;
+    this.resolveDrainWaiters();
+  }
+
+  private invalidateStream(): void {
+    this.resetStreamForReplay();
   }
 
   private scheduleFlush(): void {
@@ -233,17 +303,42 @@ export class DictationStreamSender {
     this.flushTimer = null;
   }
 
-  private async waitForFlushDrain(): Promise<void> {
-    while (this.hasPendingSegments()) {
+  private async waitForFlushDrain(finalSeq: number): Promise<void> {
+    while (this.hasPendingDelivery(finalSeq)) {
       const client = this.client;
       if (!client?.isConnected || !this.dictationId || !this.streamReady) {
         throw new Error("Failed to flush dictation stream");
       }
-      await new Promise<void>((resolve) => {
-        this.drainWaiters.push(resolve);
-      });
+      const result = await this.waitForDrainSignal();
+      if (result.kind === "timed-out") {
+        this.invalidateStream();
+        throw new Error("Timed out waiting for dictation stream delivery");
+      }
       await waitForNextFlushTurn();
     }
+  }
+
+  private waitForDrainSignal(): Promise<DrainWaitResult> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    let waiter: (() => void) | null = null;
+    const signal = new Promise<"signaled">((resolve) => {
+      waiter = () => resolve("signaled");
+      this.drainWaiters.push(waiter);
+    });
+    const timeout = new Promise<"timed-out">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timed-out"), DICTATION_DRAIN_IDLE_TIMEOUT_MS);
+    });
+
+    return Promise.race([signal, timeout])
+      .finally(() => {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+        }
+        if (waiter) {
+          this.drainWaiters = this.drainWaiters.filter((candidate) => candidate !== waiter);
+        }
+      })
+      .then((kind) => ({ kind }));
   }
 
   private resolveDrainWaiters(): void {

--- a/packages/app/src/hooks/use-dictation.ts
+++ b/packages/app/src/hooks/use-dictation.ts
@@ -449,6 +449,7 @@ export function useDictation(options: UseDictationOptions): UseDictationResult {
       attemptGuard.cancel();
       stopDurationTracking();
       void audioStop.current().catch(() => undefined);
+      senderRef.current?.dispose();
     };
   }, [stopDurationTracking]);
 


### PR DESCRIPTION
### Linked issue

Closes #3066

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Long dictations could leave the composer in processing forever after a WebSocket send failed during a closing/reconnecting race. The sender now treats its existing local PCM segment array as authoritative: transport failures invalidate only the active stream cursors, while reconnect/retry starts a new stream and replays the complete ordered buffer.

### Goals

- Keep recording and local segment buffering independent of transport availability.
- Prevent synchronous chunk-send failures from escaping the audio capture callback or scheduled flush.
- Replay segments captured before, during, and after an outage from sequence 0 on the next stream.
- Gate finish on server ACK delivery and fail an ACK-idle drain instead of waiting forever, preserving audio for the existing retry path.
- Preserve the existing 128-segment flush-turn backpressure behavior.

### Non-goals

- No WebSocket protocol or schema changes; existing ACK messages are used.
- No audio codec, compression, or bandwidth redesign.
- No new UI failure/retry flow; the existing retryable dictation failure state remains the user-facing path.

### Risk surface

The change is isolated to the app-side dictation sender and its unit adapter. It changes when `dictation_stream_finish` is sent: only after the daemon has acknowledged the requested final sequence. A missing ACK now fails after a 30-second idle window and leaves the local segments available for retry. Reconnect orchestration remains in `useDictation`; no daemon or protocol code changed.

### QA

Before the fix, the new regression failed because `enqueueSegment()` synchronously leaked `Error: WebSocket is closing` from the transport send. After the fix:

- `npx vitest run packages/app/src/dictation/dictation-stream-sender.test.ts --bail=1` — 1 file, 9 tests passed.
- Coverage includes transport-send failure during capture, ordered seq-0 replay across an outage, bounded finish failure with complete-buffer retry, ACK-gated finish, and existing long-buffer pacing.
- `npm run typecheck` — passed for all workspaces.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format` — completed; the commit hook also passed format checks.

Platform coverage: the changed module is shared app TypeScript. I did not run a device or browser session in this worktree, so iOS, Android, browser web, and Electron runtime QA are not covered here; typecheck covers their shared compile surface.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
