### PR TITLE
fix(codex): honor Full Access MCP elicitation contract

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -37,6 +37,11 @@ Each provider definition owns its option schema and exact MCP preapproval mappin
 must fail closed for Hub unattended execution until it can approve one exact injected MCP server
 and tool identity without approving native tools.
 
+Codex **Full Access** sends `approvalPolicy: "never"` and `danger-full-access` to the app server.
+If a permission-only MCP form still reaches the provider, Paseo accepts it when its schema has no
+properties. Forms with fields and URL/auth flows are declined because Paseo cannot supply user data
+or credentials. Restricted Codex modes keep their existing approval behavior.
+
 ## Two Integration Patterns
 
 ### ACP (Agent Client Protocol) -- recommended

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -564,6 +564,32 @@ describe("Codex app-server provider", () => {
     }
   });
 
+  test("launches full-access turns with Codex's no-approval unrestricted policy", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project", modeId: "full-access" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+
+    try {
+      await session.connect();
+      await session.startTurn("run an ordinary command");
+
+      await expect(appServer.waitForThreadStart()).resolves.toMatchObject({
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+      });
+      await expect(appServer.waitForTurnStart()).resolves.toMatchObject({
+        approvalPolicy: "never",
+        sandboxPolicy: { type: "dangerFullAccess" },
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
   test("preapproves only granted tools on the injected Codex MCP server", async () => {
     const session = createSession({
       modeId: undefined,
@@ -1022,6 +1048,80 @@ describe("Codex app-server provider", () => {
       resolution: { behavior: "deny", interrupt: true },
     });
     await session.close();
+  });
+
+  test("allows permission-only MCP elicitations in full-access mode", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project", modeId: "full-access" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+    const events: AgentStreamEvent[] = [];
+
+    await session.connect();
+    session.subscribe((event) => events.push(event));
+
+    try {
+      appServer.requestMcpElicitation({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        serverName: "github",
+        message: "Allow Codex to use the GitHub connector?",
+        requestedSchema: {
+          type: "object",
+          properties: {},
+        },
+      });
+
+      await expect(appServer.waitForMcpElicitationDecision()).resolves.toEqual({
+        action: "accept",
+        content: {},
+        _meta: null,
+      });
+      expect(events).not.toContainEqual(expect.objectContaining({ type: "permission_requested" }));
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("does not fabricate data for a data-bearing full-access MCP elicitation", async () => {
+    const appServer = createFakeCodexAppServer();
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project", modeId: "full-access" }),
+      null,
+      createTestLogger(),
+      async () => appServer.child,
+    );
+    const events: AgentStreamEvent[] = [];
+
+    await session.connect();
+    session.subscribe((event) => events.push(event));
+
+    try {
+      appServer.requestMcpElicitation({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        serverName: "github",
+        message: "Enter the repository name to use.",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            repository: { type: "string" },
+          },
+        },
+      });
+
+      await expect(appServer.waitForMcpElicitationDecision()).resolves.toEqual({
+        action: "decline",
+        content: null,
+        _meta: null,
+      });
+      expect(events).not.toContainEqual(expect.objectContaining({ type: "permission_requested" }));
+    } finally {
+      await session.close();
+    }
   });
 
   test("initializes Codex app-server without making Paseo the request originator", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -830,6 +830,22 @@ function toObjectRecord(value: unknown): Record<string, unknown> | undefined {
   return isRecord(value) ? value : undefined;
 }
 
+function isPermissionOnlyMcpElicitationSchema(schema: unknown): boolean {
+  const schemaRecord = toObjectRecord(schema);
+  const properties = toObjectRecord(schemaRecord?.properties);
+  return properties !== undefined && Object.keys(properties).length === 0;
+}
+
+function isCodexFullAccessMode(modeId: string, providerOptions: CodexProviderOptions): boolean {
+  return (
+    modeId === "full-access" &&
+    (providerOptions.approval_policy === undefined ||
+      providerOptions.approval_policy === "never") &&
+    (providerOptions.sandbox_mode === undefined ||
+      providerOptions.sandbox_mode === "danger-full-access")
+  );
+}
+
 // Codex app-server API response types
 interface CodexReasoningEffortEntry {
   reasoningEffort?: string;
@@ -6413,6 +6429,16 @@ export class CodexAppServerAgentSession implements AgentSession {
       .parse(params);
     if (parsed.mode === "url") {
       return Promise.resolve({ action: "decline", content: null, _meta: null });
+    }
+    if (isCodexFullAccessMode(this.currentMode, this.providerOptions)) {
+      // Codex's never-ask policy accepts only empty MCP forms and declines
+      // forms that need data. Keep that provider contract when an app-server
+      // request still reaches Paseo; never fabricate form or auth values.
+      return Promise.resolve(
+        isPermissionOnlyMcpElicitationSchema(parsed.requestedSchema)
+          ? { action: "accept", content: {}, _meta: null }
+          : { action: "decline", content: null, _meta: null },
+      );
     }
     const requiredFields = toObjectRecord(parsed.requestedSchema)?.required;
     if (Array.isArray(requiredFields) && requiredFields.length > 0) {

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -48,6 +48,7 @@ export interface FakeCodexAppServer {
   readonly child: CodexAppServerChildProcess;
   readonly recordedRollbacks: JsonObject[];
   assertNoErrors(): void;
+  waitForThreadStart(): Promise<JsonObject>;
   waitForTurnStart(): Promise<JsonObject>;
   nextResponse(): Promise<string>;
   startsTurn(params: { threadId: string; turnId?: string }): void;
@@ -296,6 +297,13 @@ export function createFakeCodexAppServer(
       if (errors.length > 0) {
         throw errors[0];
       }
+    },
+    async waitForThreadStart() {
+      const message = await waitForMessage(
+        (candidate) => candidate.method === "thread/start",
+        "thread start request",
+      );
+      return toJsonObject(message.params);
     },
     async waitForTurnStart() {
       const message = await waitForMessage(


### PR DESCRIPTION
### Linked issue

Refs #1713

Related: #2001

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

When a Paseo Codex session uses `full-access`, users expect Codex-authorized actions to run without a Paseo approval prompt. Paseo already launches the app server with `approvalPolicy: "never"` and unrestricted sandbox settings, but its elicitation adapter still routed permission-only MCP forms into the permission channel. This change mirrors Codex's provider-side contract: accept empty-schema permission elicitations in full-access mode, while declining forms that require data or authentication rather than inventing answers.

### Goals

- Keep full-access Codex thread and turn configuration explicitly unrestricted and non-interactive.
- Allow permission-only MCP elicitations with an empty `properties` schema inside the Codex provider.
- Never fabricate values for data-bearing forms or URL/authentication flows.
- Preserve existing approval behavior for restricted Codex modes.
- Preserve exact Codex provider options and Hub exact MCP tool grants.

### Non-goals

- No cross-provider permission abstraction or changes to Claude/OpenCode behavior.
- No OAuth, credential, or structured form collection in Paseo.
- No UI-only suppression or silent rejection of permission requests.
- No changes to the user's `~/.codex/config.toml`.

### QA

The failing-first reproduction used Paseo's real Codex app-server session boundary and a test app-server transport. Before the fix, the full-access empty-schema elicitation timed out waiting for a response while the permission event remained pending.

Focused provider contract tests after the fix:

```text
npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1
1 file, 124 passed, 0 failed

npx vitest run packages/server/src/server/agent/providers/codex/app-server-transport.test.ts --bail=1
1 file, 7 passed, 0 failed
```

The contract tests cover full-access launch policy, ordinary approval bypass, empty-schema MCP acceptance, non-fabrication for data-bearing forms, restricted-mode approval, and Hub exact tool grants/provider options.

Real installed Codex app-server evidence:

```text
npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.local.e2e.test.ts --bail=1
1 file, 1 passed, 0 failed

{"mode":"full-access","finalText":"DONE","fileExists":true,"fileContent":"full-access-ok","permissionEvents":[]}
```

The direct smoke used the installed `codex-cli 0.144.0`, the Paseo Codex provider client, the authenticated local Codex session, and a temporary directory that was removed afterward. It also listed the live model catalog and completed a full-access prompt. No user Codex configuration was modified.

Repository checks passed: `npm run typecheck`, targeted `npm run lint`, and `npm run format:check`.

The repository's OpenRouter-backed real-provider test reached the app server but could not authenticate in this environment: `401 Unauthorized: Missing Authentication header` from `https://openrouter.ai/api/v1/responses`. The local real app-server evidence above does not depend on that missing test credential.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
