### PR TITLE
Keep Pi sessions active while async subagents run

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -112,7 +112,7 @@ The asymmetry is intentional: a subagent's persistent relationship lives in the 
 
 ## Workspace activity
 
-Agent lifecycle status stays literal: a parent agent is `idle` when its own turn is idle, even if a child is running.
+Stored agent lifecycle status stays literal: a parent agent is `idle` when its own turn is idle, even if a child is running. Session lists may project that parent as `running` while a provider-owned child runs; this does not make the parent turn busy.
 
 Workspace status is an aggregate activity signal computed **per `workspaceId`**. Ownership is never derived from `cwd` — many workspaces may share one directory, and same-`cwd` siblings do not clump under one status. Root agents and cross-workspace subagents contribute their normal state bucket to their own workspace. Same-workspace descendants contribute `running` to the nearest ancestor in that workspace; their non-running attention, permission, and error states stay in the parent's subagents track. This makes a cross-workspace subagent behave like a detached agent for workspace visibility and status without removing its parent relationship.
 
@@ -128,13 +128,17 @@ The collapsible track above the composer in an agent's pane (`packages/app/src/s
 parentAgentId === thisAgent.id  AND  !archivedAt
 ```
 
-- **Provider subagents** are child executions owned by Claude, Codex, or OpenCode. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track.
+- **Provider subagents** are child executions owned by Claude, Codex, OpenCode, or Pi. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track.
 
 Clicking either kind opens a workspace tab. A Paseo subagent tab is a normal interactive agent pane. A provider subagent tab is a read-only timeline pane with no composer, archive, detach, rewind, or fork actions. Both panes use `AgentStreamView`, so message, reasoning, tool-call, and layout rendering stay identical.
 
 Provider timelines use the same structural timeline item format but deliberately have a separate lifecycle and transport. A provider thread/session identifier is not a Paseo agent identifier, and closing its tab is always layout-only.
 
 Provider descriptors may include one compact subtitle. The provider owns its contents and formatting; clients display and truncate it without interpreting provider-specific model, thinking, or usage fields.
+
+### Pi provider subagents
+
+Pi's RPC stream does not expose extension event-bus messages. Paseo's injected Pi extension listens for `pi-subagents` async start and completion events and forwards them through the RPC extension-notification channel. Foreground subagents need no bridge because their tool call keeps the parent turn running.
 
 ### Claude provider subagents: the task protocol
 

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -37,7 +37,11 @@ import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { AgentSessionConfig } from "@getpaseo/protocol/agent-types";
 import type { GitSetupOptions } from "@getpaseo/protocol/messages";
 import type { AgentPermissionResponse } from "@getpaseo/protocol/agent-types";
-import { getHostRuntimeStore, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import {
+  getHostRuntimeStore,
+  useHostRuntimeAgentDirectoryStatus,
+  useHostRuntimeIsConnected,
+} from "@/runtime/host-runtime";
 import { useVoiceAudioEngineOptional, useVoiceRuntimeOptional } from "@/contexts/voice-context";
 import type { AudioPlaybackSource } from "@/voice/audio-engine-types";
 import {
@@ -65,7 +69,11 @@ import { useToast } from "@/contexts/toast-context";
 import { toErrorMessage } from "@/utils/error-messages";
 import { showProviderNoticeToast } from "@/utils/provider-notice-toast";
 import { applyCheckoutStatusUpdateFromEvent } from "@/git/checkout-status-cache";
-import { useProviderSubagentStore } from "@/subagents/provider-store";
+import {
+  refreshProviderSubagents,
+  resetProviderSubagents,
+  useProviderSubagentStore,
+} from "@/subagents/provider-store";
 import { revalidateSessionAfterResume } from "@/contexts/session-resume-revalidation";
 
 // Re-export types from session-store and draft-store for backward compatibility
@@ -338,6 +346,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
   const voiceAudioEngine = useVoiceAudioEngineOptional();
   const queryClient = useQueryClient();
   const isConnected = useHostRuntimeIsConnected(serverId);
+  const agentDirectoryStatus = useHostRuntimeAgentDirectoryStatus(serverId);
   const toast = useToast();
 
   // Zustand store actions
@@ -367,6 +376,9 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
   const updateSessionServerInfo = useSessionStore((state) => state.updateSessionServerInfo);
   const setViewedTimelineSync = useSessionStore((state) => state.setViewedTimelineSync);
   const upsertWorkspaceSetupProgress = useWorkspaceSetupStore((state) => state.upsertProgress);
+  const providerSubagentsSupported = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.providerSubagents === true,
+  );
 
   // Track focused agent for heartbeat
   const focusedAgentId = useSessionStore(
@@ -536,8 +548,17 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     if (!isConnected) {
       flushAgentLastActivity();
       setInitializingAgents(serverId, new Map());
+      resetProviderSubagents(client, serverId);
     }
-  }, [flushAgentLastActivity, serverId, isConnected, setInitializingAgents]);
+  }, [client, flushAgentLastActivity, serverId, isConnected, setInitializingAgents]);
+
+  useEffect(() => {
+    if (!isConnected || !providerSubagentsSupported || agentDirectoryStatus !== "ready") return;
+    const agents = useSessionStore.getState().sessions[serverId]?.agents;
+    for (const parentAgentId of agents?.keys() ?? []) {
+      void refreshProviderSubagents(client, serverId, parentAgentId).catch(() => undefined);
+    }
+  }, [agentDirectoryStatus, client, isConnected, providerSubagentsSupported, serverId]);
 
   useEffect(
     () =>

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -554,10 +554,28 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
 
   useEffect(() => {
     if (!isConnected || !providerSubagentsSupported || agentDirectoryStatus !== "ready") return;
-    const agents = useSessionStore.getState().sessions[serverId]?.agents;
-    for (const parentAgentId of agents?.keys() ?? []) {
-      void refreshProviderSubagents(client, serverId, parentAgentId).catch(() => undefined);
-    }
+    const parentAgentIds = [
+      ...(useSessionStore.getState().sessions[serverId]?.agents.keys() ?? []),
+    ];
+    let canceled = false;
+    let retryDelayMs = 1_000;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    const refresh = () => {
+      void Promise.all(
+        parentAgentIds.map((parentAgentId) =>
+          refreshProviderSubagents(client, serverId, parentAgentId),
+        ),
+      ).catch(() => {
+        if (canceled) return;
+        retryTimeout = setTimeout(refresh, retryDelayMs);
+        retryDelayMs = Math.min(retryDelayMs * 2, 30_000);
+      });
+    };
+    refresh();
+    return () => {
+      canceled = true;
+      if (retryTimeout) clearTimeout(retryTimeout);
+    };
   }, [agentDirectoryStatus, client, isConnected, providerSubagentsSupported, serverId]);
 
   useEffect(

--- a/packages/app/src/hooks/use-aggregated-agents.ts
+++ b/packages/app/src/hooks/use-aggregated-agents.ts
@@ -5,6 +5,7 @@ import { useSessionStore } from "@/stores/session-store";
 import type { AgentDirectoryEntry } from "@/types/agent-directory";
 import type { Agent } from "@/stores/session-store";
 import { getHostRuntimeStore, useHosts } from "@/runtime/host-runtime";
+import { hasRunningProviderSubagent, useProviderSubagentStore } from "@/subagents/provider-store";
 
 export interface AggregatedAgent extends AgentDirectoryEntry {
   serverId: string;
@@ -40,6 +41,7 @@ export function useAggregatedAgents(options?: {
       return result;
     }),
   );
+  const providerSubagentDescriptors = useProviderSubagentStore((state) => state.descriptors);
 
   const refreshAll = useCallback(() => {
     runtime.refreshAllAgentDirectories();
@@ -75,7 +77,11 @@ export function useAggregatedAgents(options?: {
           serverId,
           serverLabel,
           title: agent.title ?? null,
-          status: agent.status,
+          status:
+            agent.status === "idle" &&
+            hasRunningProviderSubagent(providerSubagentDescriptors, serverId, agent.id)
+              ? "running"
+              : agent.status,
           lastActivityAt: agent.lastActivityAt,
           cwd: agent.cwd,
           workspaceId: agent.workspaceId,
@@ -147,7 +153,14 @@ export function useAggregatedAgents(options?: {
       isInitialLoad,
       isRevalidating,
     };
-  }, [daemons, includeArchived, runtime, runtimeVersion, sessionAgents]);
+  }, [
+    daemons,
+    includeArchived,
+    providerSubagentDescriptors,
+    runtime,
+    runtimeVersion,
+    sessionAgents,
+  ]);
 
   return {
     ...result,

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { providerSubagentKey, useProviderSubagentStore } from "./provider-store";
+import {
+  hasRunningProviderSubagent,
+  providerSubagentKey,
+  useProviderSubagentStore,
+} from "./provider-store";
 
 const SERVER_ID = "server-1";
 const PARENT_ID = "parent-1";
@@ -14,6 +18,31 @@ afterEach(() => {
 });
 
 describe("provider subagent client store", () => {
+  test("reports running activity for the parent session", () => {
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: SUBAGENT_ID,
+        parentAgentId: PARENT_ID,
+        provider: "pi",
+        title: "reviewer",
+        description: "Review the change",
+        status: "running",
+        createdAt: "2026-07-12T10:00:00.000Z",
+        updatedAt: "2026-07-12T10:00:00.000Z",
+        toolCallId: null,
+      },
+    });
+
+    expect(
+      hasRunningProviderSubagent(
+        useProviderSubagentStore.getState().descriptors,
+        SERVER_ID,
+        PARENT_ID,
+      ),
+    ).toBe(true);
+  });
+
   test("builds a shared stream model from ordered provider updates", () => {
     const subagents = useProviderSubagentStore.getState();
     subagents.applyUpdate(SERVER_ID, {

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, test } from "vitest";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import {
   hasRunningProviderSubagent,
   providerSubagentKey,
+  refreshProviderSubagents,
+  resetProviderSubagents,
   useProviderSubagentStore,
 } from "./provider-store";
 
@@ -41,6 +44,50 @@ describe("provider subagent client store", () => {
         PARENT_ID,
       ),
     ).toBe(true);
+  });
+
+  test("clears disconnected activity and ignores an in-flight stale list", async () => {
+    type ListPayload = Awaited<ReturnType<DaemonClient["listProviderSubagents"]>>;
+    let resolveList!: (value: ListPayload) => void;
+    const client = {
+      listProviderSubagents: () =>
+        new Promise<ListPayload>((resolve) => {
+          resolveList = resolve;
+        }),
+    };
+    const running = {
+      id: SUBAGENT_ID,
+      parentAgentId: PARENT_ID,
+      provider: "pi" as const,
+      title: "reviewer",
+      description: "Review the change",
+      status: "running" as const,
+      createdAt: "2026-07-12T10:00:00.000Z",
+      updatedAt: "2026-07-12T10:00:00.000Z",
+      toolCallId: null,
+    };
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: running,
+    });
+    const staleRefresh = refreshProviderSubagents(client, SERVER_ID, PARENT_ID);
+
+    resetProviderSubagents(client, SERVER_ID);
+    resolveList({
+      requestId: "stale-request",
+      parentAgentId: PARENT_ID,
+      subagents: [running],
+      error: null,
+    });
+    await staleRefresh;
+
+    expect(
+      hasRunningProviderSubagent(
+        useProviderSubagentStore.getState().descriptors,
+        SERVER_ID,
+        PARENT_ID,
+      ),
+    ).toBe(false);
   });
 
   test("builds a shared stream model from ordered provider updates", () => {

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -63,6 +63,18 @@ export function providerSubagentKey(
   return `${serverId}\0${parentAgentId}\0${subagentId}`;
 }
 
+export function hasRunningProviderSubagent(
+  descriptors: ReadonlyMap<string, ProviderSubagentDescriptorPayload>,
+  serverId: string,
+  parentAgentId: string,
+): boolean {
+  const prefix = parentPrefix(serverId, parentAgentId);
+  for (const [key, subagent] of descriptors) {
+    if (key.startsWith(prefix) && subagent.status === "running") return true;
+  }
+  return false;
+}
+
 export function providerSubagentLifecycleStatus(
   status: ProviderSubagentDescriptorPayload["status"],
 ): AgentLifecycleStatus {

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -86,6 +86,19 @@ export function providerSubagentLifecycleStatus(
 type ProviderSubagentListClient = Pick<DaemonClient, "listProviderSubagents">;
 
 const pendingListRequests = new WeakMap<ProviderSubagentListClient, Map<string, Promise<void>>>();
+const serverGenerations = new Map<string, number>();
+
+export function resetProviderSubagents(client: ProviderSubagentListClient, serverId: string): void {
+  serverGenerations.set(serverId, (serverGenerations.get(serverId) ?? 0) + 1);
+  const prefix = `${serverId}\0`;
+  const requests = pendingListRequests.get(client);
+  for (const key of requests?.keys() ?? []) {
+    if (key.startsWith(prefix)) requests?.delete(key);
+  }
+  useProviderSubagentStore.setState((state) => ({
+    descriptors: new Map([...state.descriptors].filter(([key]) => !key.startsWith(prefix))),
+  }));
+}
 
 export function refreshProviderSubagents(
   client: ProviderSubagentListClient,
@@ -101,14 +114,17 @@ export function refreshProviderSubagents(
   const pending = clientRequests.get(requestKey);
   if (pending) return pending;
 
-  const request = client
+  const generation = serverGenerations.get(serverId) ?? 0;
+  let request: Promise<void>;
+  request = client
     .listProviderSubagents(parentAgentId)
     .then((payload) => {
+      if ((serverGenerations.get(serverId) ?? 0) !== generation) return;
       useProviderSubagentStore.getState().replaceList(serverId, parentAgentId, payload.subagents);
       return undefined;
     })
     .finally(() => {
-      clientRequests?.delete(requestKey);
+      if (clientRequests?.get(requestKey) === request) clientRequests.delete(requestKey);
     });
   clientRequests.set(requestKey, request);
   return request;

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -58,20 +58,33 @@ function readUtf8File(pathname: string): string {
 }
 
 type PaseoExtensionListener = (event: unknown, context?: unknown) => unknown;
+type PaseoExtensionEventListener = (data: unknown) => void;
 
 async function loadPaseoExtensionListeners(
   extensionPath: string,
+  extensionEventListeners = new Map<string, Set<PaseoExtensionEventListener>>(),
 ): Promise<Map<string, PaseoExtensionListener>> {
   const listeners = new Map<string, PaseoExtensionListener>();
   const extension = (await import(pathToFileURL(extensionPath).href)) as {
     default: (piApi: {
       on: (event: string, listener: PaseoExtensionListener) => void;
       registerCommand: () => void;
+      events: {
+        on: (event: string, listener: PaseoExtensionEventListener) => () => void;
+      };
     }) => void;
   };
   extension.default({
     on: (event, listener) => listeners.set(event, listener),
     registerCommand: () => undefined,
+    events: {
+      on: (event, listener) => {
+        const eventListeners = extensionEventListeners.get(event) ?? new Set();
+        eventListeners.add(listener);
+        extensionEventListeners.set(event, eventListeners);
+        return () => eventListeners.delete(listener);
+      },
+    },
   });
   return listeners;
 }
@@ -192,6 +205,13 @@ class SessionEvents {
     );
   }
 
+  providerSubagentEvents() {
+    return this.events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+        event.type === "provider_subagent",
+    );
+  }
+
   nextTurnCompletion(): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
     return this.nextEvent(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
@@ -251,6 +271,47 @@ class SessionEvents {
 }
 
 describe("PiRpcAgentSession", () => {
+  test("maps Pi subagent lifecycle markers to provider subagents", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-started",
+      method: "notify",
+      message:
+        'PASEO_PI_SUBAGENT {"id":"run-1","title":"reviewer","description":"Review the change","status":"running","cwd":"/workspace"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-completed",
+      method: "notify",
+      message: 'PASEO_PI_SUBAGENT {"id":"run-1","status":"completed"}',
+    });
+
+    expect(events.providerSubagentEvents()).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "run-1",
+          title: "reviewer",
+          description: "Review the change",
+          status: "running",
+          cwd: "/workspace",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: { type: "upsert", id: "run-1", status: "completed" },
+      },
+    ]);
+
+    await session.close();
+  });
+
   test("bridges Pi RPC select extension UI requests through question permissions", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
@@ -991,6 +1052,41 @@ describe("PiRpcAgentSession", () => {
     expect(notifications).toEqual([
       'PASEO_SUBMITTED_USER_ENTRY {"entry":{"id":"entry-new","parentId":"entry-old-assistant","text":"new prompt"}}',
     ]);
+
+    await session.close();
+  });
+
+  test("reports pi-subagents async lifecycle through the Paseo extension", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const session = await client.createSession(createConfig());
+    const extensionPath = pi.recordedLaunches[0]?.extensionPaths[0];
+    expect(extensionPath).toBeDefined();
+    const extensionEvents = new Map<string, Set<PaseoExtensionEventListener>>();
+    const listeners = await loadPaseoExtensionListeners(extensionPath!, extensionEvents);
+    const notifications: string[] = [];
+    const context = {
+      sessionManager: { getEntries: () => [] },
+      ui: { notify: (message: string) => notifications.push(message) },
+    };
+
+    await listeners.get("session_start")?.({}, context);
+    extensionEvents.get("subagent:async-started")?.forEach((listener) =>
+      listener({
+        id: "run-1",
+        agent: "reviewer",
+        goal: "Review the change",
+        cwd: "/workspace",
+      }),
+    );
+    extensionEvents
+      .get("subagent:async-complete")
+      ?.forEach((listener) => listener({ runId: "run-1", state: "complete", success: true }));
+
+    expect(notifications).toContain(
+      'PASEO_PI_SUBAGENT {"id":"run-1","title":"reviewer","description":"Review the change","status":"running","cwd":"/workspace"}',
+    );
+    expect(notifications).toContain('PASEO_PI_SUBAGENT {"id":"run-1","status":"completed"}');
 
     await session.close();
   });

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -94,6 +94,7 @@ const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
 const PASEO_PI_SUBMITTED_USER_ENTRY_MARKER = "PASEO_SUBMITTED_USER_ENTRY";
 const PASEO_PI_COMMAND_RESULT_MARKER = "PASEO_COMMAND_RESULT";
+const PASEO_PI_SUBAGENT_MARKER = "PASEO_PI_SUBAGENT";
 const DEFAULT_PI_EXTENSION_RESULT_TIMEOUT_MS = 30_000;
 const QUESTION_RESPONSE_HEADER = "Response";
 const QUESTION_COMMENT_HEADER = "Comment";
@@ -674,8 +675,54 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	  );
 	}
 
+	function subagentId(payload) {
+	  const value = payload && (payload.runId || payload.id);
+	  return typeof value === "string" && value ? value : undefined;
+	}
+
+	function reportSubagent(ctx, event) {
+	  if (!ctx || !event.id) return;
+	  ctx.ui.notify("${PASEO_PI_SUBAGENT_MARKER} " + JSON.stringify(event), "info");
+	}
+
+	function reportSubagentStarted(ctx, payload) {
+	  const id = subagentId(payload);
+	  if (!id) return;
+	  const title = typeof payload.agent === "string"
+	    ? payload.agent
+	    : payload.mode === "workflow" ? "Workflow" : "Pi subagent";
+	  const description = typeof payload.goal === "string"
+	    ? payload.goal
+	    : typeof payload.task === "string" ? payload.task : undefined;
+	  reportSubagent(ctx, {
+	    id,
+	    title,
+	    description,
+	    status: "running",
+	    cwd: typeof payload.cwd === "string" ? payload.cwd : undefined,
+	  });
+	}
+
+	function reportSubagentCompleted(ctx, payload) {
+	  const id = subagentId(payload);
+	  if (!id) return;
+	  const status = payload.stopped || payload.state === "stopped" || payload.state === "paused"
+	    ? "canceled"
+	    : payload.success === false || payload.state === "failed" || payload.state === "rejected"
+	      ? "failed"
+	      : "completed";
+	  reportSubagent(ctx, { id, status });
+	}
+
 	export default function paseoIntegration(pi) {
 	  const submittedUserMessages = [];
+	  let subagentContext;
+	  const unsubscribeSubagentStarted = pi.events.on("subagent:async-started", (payload) => {
+	    reportSubagentStarted(subagentContext, payload);
+	  });
+	  const unsubscribeSubagentCompleted = pi.events.on("subagent:async-complete", (payload) => {
+	    reportSubagentCompleted(subagentContext, payload);
+	  });
 
 	  function emitSubmittedUserEntries(ctx) {
 	    const entries = ctx.sessionManager.getEntries();
@@ -708,7 +755,14 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
     }
 
 	  pi.on("session_start", async (_event, ctx) => {
+	    subagentContext = ctx;
 	    emitEntryCapture(ctx, "session_start");
+	  });
+
+	  pi.on("session_shutdown", async () => {
+	    subagentContext = undefined;
+	    unsubscribeSubagentStarted?.();
+	    unsubscribeSubagentCompleted?.();
 	  });
 
 	  pi.on("message_end", async (event) => {
@@ -1913,6 +1967,40 @@ export class PiRpcAgentSession implements AgentSession {
     return true;
   }
 
+  private handlePiSubagentMarker(message: string): boolean {
+    const payload = parseExtensionMarkerPayload(message, PASEO_PI_SUBAGENT_MARKER);
+    if (!payload) {
+      return false;
+    }
+    const id = optionalString(payload.id)?.trim();
+    const status = optionalString(payload.status);
+    if (
+      !id ||
+      (status !== "running" &&
+        status !== "completed" &&
+        status !== "failed" &&
+        status !== "canceled")
+    ) {
+      return true;
+    }
+    const title = optionalString(payload.title)?.trim();
+    const description = optionalString(payload.description)?.trim();
+    const cwd = optionalString(payload.cwd)?.trim();
+    this.emit({
+      type: "provider_subagent",
+      provider: this.provider,
+      event: {
+        type: "upsert",
+        id,
+        status,
+        ...(title ? { title } : {}),
+        ...(description ? { description } : {}),
+        ...(cwd ? { cwd } : {}),
+      },
+    });
+    return true;
+  }
+
   private handleExtensionUiRequest(
     event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
   ): void {
@@ -1921,7 +2009,8 @@ export class PiRpcAgentSession implements AgentSession {
       if (
         this.handleSubmittedUserEntryMarker(message) ||
         this.handleEntryCaptureMarker(message) ||
-        this.handleCommandResultMarker(message)
+        this.handleCommandResultMarker(message) ||
+        this.handlePiSubagentMarker(message)
       ) {
         return;
       }

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -706,11 +706,16 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	function reportSubagentCompleted(ctx, payload) {
 	  const id = subagentId(payload);
 	  if (!id) return;
-	  const status = payload.stopped || payload.state === "stopped" || payload.state === "paused"
-	    ? "canceled"
-	    : payload.success === false || payload.state === "failed" || payload.state === "rejected"
-	      ? "failed"
-	      : "completed";
+	  let status = "completed";
+	  if (payload.stopped || payload.state === "stopped" || payload.state === "paused") {
+	    status = "canceled";
+	  } else if (
+	    payload.success === false ||
+	    payload.state === "failed" ||
+	    payload.state === "rejected"
+	  ) {
+	    status = "failed";
+	  }
 	  reportSubagent(ctx, { id, status });
 	}
 


### PR DESCRIPTION
### Linked issue

Closes #3160

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A Pi parent can finish its own turn while an asynchronous `pi-subagents` child keeps working. Paseo had no path from Pi's extension event bus to the provider-subagent stream, so the child was invisible and the parent looked done. This bridges the live child lifecycle into Paseo and projects an otherwise-idle parent as running in session lists until its Pi-owned work settles.

### Goals

- Surface live Pi asynchronous children in the existing provider-subagent track.
- Keep session and workspace activity visible while a Pi-owned child is running.
- Preserve the parent's literal stored lifecycle and foreground-turn semantics.
- Map child completion, failure, and cancellation to terminal provider-subagent states.
- Cover the bridge and parent activity projection with regression tests.

### Non-goals

- Converting Pi-owned children into managed Paseo agents.
- Changing parent turn state or persisted parent lifecycle status.
- Adding a second bridge for foreground children; their tool call already keeps the parent turn running.
- Replaying provider-subagent events that occurred before the live Pi session connection.

### QA

Automated regression coverage:

```text
$ npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1
✓ packages/server/src/server/agent/providers/pi/agent.test.ts (58 tests) 81ms
Test Files  1 passed (1)
Tests       58 passed (58)

$ npx vitest run packages/app/src/subagents/provider-store.test.ts --bail=1
✓ packages/app/src/subagents/provider-store.test.ts (12 tests) 7ms
Test Files  1 passed (1)
Tests       12 passed (12)
```

Repository checks:

```text
$ npm run format
Finished in 867ms on 3596 files using 24 threads.

$ npm run typecheck
@getpaseo/expo-two-way-audio, highlight, protocol, client, server, app,
relay, website, desktop, and cli completed with exit code 0.

$ npm run lint
Found 0 warnings and 0 errors.
Finished in 1.0s on 3357 files with 177 rules using 24 threads.

$ git diff --check
(exit 0, no output)
```

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Shared client projection path; not manually tested. |
| Android | No | Shared client projection path; not manually tested. |
| Web | No | Shared client projection path; not manually tested. |
| Desktop macOS | Automated only | Tests and repository checks ran on macOS 26.6.1 arm64. Real-provider before/after video is still outstanding. |
| Desktop Windows | No | Not available locally. |
| Desktop Linux | No | Not available locally. |

This is a draft because manual verification against Pi 0.80.6 with `pi-subagents` 0.41.0 and the required UI video have not been completed. No main Paseo daemon was restarted for this change.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense
