### PR TITLE
PR-6A: snapshot-capable Paseo inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ At the start of non-trivial work, list `docs/` and skim anything relevant to the
 | [docs/architecture.md](docs/architecture.md)                       | System design, package layering, WebSocket protocol, agent lifecycle, data flow                                                |
 | [docs/agent-lifecycle.md](docs/agent-lifecycle.md)                 | Agent states, parent/child relationships, archive semantics, tabs vs archive, subagents track                                  |
 | [docs/data-model.md](docs/data-model.md)                           | File-based JSON persistence, Zod schemas, atomic writes, no migrations                                                         |
+| [docs/inventory-snapshots.md](docs/inventory-snapshots.md)         | Read-only, complete Paseo inventory snapshots for external controllers                                                         |
 | [docs/glossary.md](docs/glossary.md)                               | Authoritative terminology — UI label wins, no synonyms                                                                         |
 | [docs/coding-standards.md](docs/coding-standards.md)               | Type hygiene, error handling, state design, React patterns, file organization                                                  |
 | [docs/design.md](docs/design.md)                                   | Design system — tokens, buttons, hierarchy, density, alignment rails, states, what's forbidden                                 |

--- a/docs/inventory-snapshots.md
+++ b/docs/inventory-snapshots.md
@@ -1,0 +1,101 @@
+# Inventory snapshots
+
+`inventory.sessions.request` is the read-only inventory API for a controller
+that must prove it enumerated every Paseo session in one daemon. It is not the
+UI directory API and must not be replaced with `fetch_agents_request` or
+`paseo ls`.
+
+## Scope
+
+One initial request has the fixed scope `all/global`: every record known to the
+daemon's canonical `AgentManager` and `$PASEO_HOME/agents/` registry. This
+includes running, initializing, idle, error, closed, archived, internal, and
+providers which are unavailable to the normal client directory. Project
+placement, active-workspace scope, provider visibility, and persisted-provider
+availability do not filter this inventory.
+
+The returned identity is `backend: "paseo"` plus `native_id`, the Paseo daemon
+agent UUID. A multi-host controller supplies its configured source/host when it
+forms its frozen `(source, backend, native_id)` identity; `native_id` alone is
+not cross-daemon identity. `persistence_session_id` is correlation metadata for
+the provider session, not a replacement identity.
+
+The daemon refuses the whole inventory if the persistent registry contains a
+malformed JSON record, a duplicate agent id, or a conflicting live/persisted
+provider. Those are explicit `rpc_error`s, never omitted rows.
+
+## Snapshot and pagination semantics
+
+The API uses materialized snapshot semantics. At the first page the daemon reads
+the manager and registry synchronously in one event-loop turn, validates the
+union, sorts it by `native_id`, deep-clones the full entries, and retains that
+immutable materialization for ten minutes. `snapshot_id` is the SHA-256 digest
+of its schema version and canonical complete entry list. It therefore names a
+specific enumerated set, not a request time or an arbitrary UUID.
+
+Every continuation sends both `snapshot_id` and `cursor`. The cursor is
+daemon-secret-bound to that snapshot and its absolute next offset. It cannot be
+used with another snapshot, changed into a different offset, or loop back to
+the first page. Page size is 1–200, ordering is deterministic, and only
+`has_more: false` proves the end. Replaying a valid snapshot/cursor pair returns
+the same page. A missing, malformed, foreign, looping, or expired cursor yields
+an explicit `rpc_error`; expiration is `inventory_snapshot_expired`.
+
+Later creation, deletion, lifecycle change, or archiving does not alter an
+existing snapshot. It appears in the next snapshot instead. The capability has
+no lifecycle, prompt, registry-write, provider, or recovery call path.
+
+## Wire contract
+
+Start an enumeration:
+
+```json
+{
+  "type": "inventory.sessions.request",
+  "requestId": "inventory-1",
+  "limit": 200
+}
+```
+
+Continue it with the returned values:
+
+```json
+{
+  "type": "inventory.sessions.request",
+  "requestId": "inventory-2",
+  "snapshot_id": "sha256:…",
+  "cursor": "…",
+  "limit": 200
+}
+```
+
+```json
+{
+  "type": "inventory.sessions.response",
+  "payload": {
+    "requestId": "inventory-1",
+    "schema_version": "paseo.inventory_sessions.v1",
+    "snapshot_id": "sha256:…",
+    "entries": [
+      {
+        "backend": "paseo",
+        "native_id": "6e77c819-…",
+        "provider": "claude",
+        "status_raw": "closed",
+        "archived": true,
+        "archived_at": "2026-08-10T12:00:00.000Z",
+        "internal": false,
+        "cwd": "/work/project",
+        "created_at": "2026-08-01T12:00:00.000Z",
+        "updated_at": "2026-08-10T12:00:00.000Z",
+        "persistence_session_id": "provider-session-id"
+      }
+    ],
+    "next_cursor": null,
+    "has_more": false
+  }
+}
+```
+
+The CLI exposes the same one-page contract as `paseo inventory sessions --json`
+and accepts `--snapshot-id`, `--cursor`, and `--limit` for continuation.

--- a/docs/inventory-snapshots.md
+++ b/docs/inventory-snapshots.md
@@ -32,20 +32,27 @@ delete, or otherwise modify those paths.
 
 ## Snapshot and pagination semantics
 
-The API uses materialized snapshot semantics. At the first page the daemon reads
-the manager and registry synchronously in one event-loop turn, validates the
-union, sorts it by `(backend, native_id)` using Unicode code-unit ordering,
-deep-clones the full entries, and retains that immutable materialization for
-ten minutes. `snapshot_id` is the SHA-256 digest of its schema version and
-canonical complete entry list. Canonical JSON sorts object keys with the same
-code-unit ordering, so insertion order and process locale do not change the
-id. It therefore names a specific enumerated set, not a request time or an
-arbitrary UUID.
+The API uses materialized snapshot semantics. At the first page the daemon
+performs an inventory-only fresh filesystem scan; it never treats the startup
+registry cache as proof of completeness. The scan classifies every root and
+project entry, validates every persisted record, and performs a second complete
+manifest scan. Directory entries, path identity/type/metadata, and record
+content hashes must match across both scans. A creation, deletion, replacement,
+symlink swap, permission failure, or content change during the scan fails the
+request closed. The completed scan is then combined with one synchronous
+`AgentManager` read, sorted by `(backend, native_id)` using Unicode code-unit
+ordering, deep-cloned, and retained for ten minutes.
+
+`snapshot_id` is the SHA-256 digest of its schema version and canonical complete
+entry list. Canonical JSON sorts object keys with the same code-unit ordering,
+so insertion order and process locale do not change the id. It therefore names
+a specific enumerated set, not a request time or an arbitrary UUID.
 
 Every continuation sends both `snapshot_id` and `cursor`. The cursor is
-daemon-secret-bound to that snapshot and its absolute next offset. It cannot be
-used with another snapshot, changed into a different offset, or loop back to
-the first page. Snapshot ownership is bound to `clientId`, but both the HMAC
+daemon-secret-bound to that snapshot, its absolute next offset, and the owner
+`clientId`. It uses strict canonical base64url encoding, so padded or altered
+variants are invalid. It cannot be used with another snapshot or client,
+changed into a different offset, or loop back to the first page. Both the HMAC
 secret and snapshot store belong to the daemon, not a WebSocket `Session`; a
 reconnect with the same client id can therefore continue until TTL expiry. A
 daemon restart naturally loses the store and never rebuilds an old snapshot.
@@ -129,4 +136,5 @@ Clients discover this RPC through
 same one-page contract as `paseo inventory sessions --json` and accepts
 `--snapshot-id`, `--cursor`, and `--limit` for continuation. It rejects every
 non-integer or out-of-range `--limit` locally (including `0`, floats, text, and
-values above 200).
+values above 200). Clients do not probe an old daemon with an unknown RPC: the
+CLI reports `UNSUPPORTED_BY_HOST` when the feature is absent.

--- a/docs/inventory-snapshots.md
+++ b/docs/inventory-snapshots.md
@@ -39,9 +39,15 @@ project entry, validates every persisted record, and performs a second complete
 manifest scan. Directory entries, path identity/type/metadata, and record
 content hashes must match across both scans. A creation, deletion, replacement,
 symlink swap, permission failure, or content change during the scan fails the
-request closed. The completed scan is then combined with one synchronous
-`AgentManager` read, sorted by `(backend, native_id)` using Unicode code-unit
-ordering, deep-cloned, and retained for ten minutes.
+request closed. To make the filesystem authority and live `AgentManager`
+authority one logical snapshot, the daemon first captures an immutable live
+projection plus a monotonic live inventory epoch, then performs the verified
+filesystem scan, and finally verifies that the epoch is unchanged. Thus the
+live projection was constant at the filesystem scan's materialization point.
+Any live or registry drift retries the whole capture at most three times and
+then returns `inventory_state_changed`; it never returns a mixed union. The
+result is sorted by `(backend, native_id)` using Unicode code-unit ordering,
+deep-cloned, and retained for ten minutes.
 
 `snapshot_id` is the SHA-256 digest of its schema version and canonical complete
 entry list. Canonical JSON sorts object keys with the same code-unit ordering,

--- a/docs/inventory-snapshots.md
+++ b/docs/inventory-snapshots.md
@@ -21,25 +21,44 @@ not cross-daemon identity. `persistence_session_id` is correlation metadata for
 the provider session, not a replacement identity.
 
 The daemon refuses the whole inventory if the persistent registry contains a
-malformed JSON record, a duplicate agent id, or a conflicting live/persisted
-provider. Those are explicit `rpc_error`s, never omitted rows.
+malformed JSON record, a duplicate agent id, a conflicting live/persisted
+provider, or any unreadable path within the registry scope. This includes the
+registry root, a project directory, and an individual record file. An absent
+registry root (`ENOENT`) means there are no persisted records and is tolerated;
+after a directory or record has been observed during a scan, even `ENOENT` is
+an explicit issue because it could hide a concurrently removed identity. Those
+are explicit `rpc_error`s, never omitted rows. Inventory reads never repair,
+delete, or otherwise modify those paths.
 
 ## Snapshot and pagination semantics
 
 The API uses materialized snapshot semantics. At the first page the daemon reads
 the manager and registry synchronously in one event-loop turn, validates the
-union, sorts it by `native_id`, deep-clones the full entries, and retains that
-immutable materialization for ten minutes. `snapshot_id` is the SHA-256 digest
-of its schema version and canonical complete entry list. It therefore names a
-specific enumerated set, not a request time or an arbitrary UUID.
+union, sorts it by `(backend, native_id)` using Unicode code-unit ordering,
+deep-clones the full entries, and retains that immutable materialization for
+ten minutes. `snapshot_id` is the SHA-256 digest of its schema version and
+canonical complete entry list. Canonical JSON sorts object keys with the same
+code-unit ordering, so insertion order and process locale do not change the
+id. It therefore names a specific enumerated set, not a request time or an
+arbitrary UUID.
 
 Every continuation sends both `snapshot_id` and `cursor`. The cursor is
 daemon-secret-bound to that snapshot and its absolute next offset. It cannot be
 used with another snapshot, changed into a different offset, or loop back to
-the first page. Page size is 1–200, ordering is deterministic, and only
-`has_more: false` proves the end. Replaying a valid snapshot/cursor pair returns
-the same page. A missing, malformed, foreign, looping, or expired cursor yields
-an explicit `rpc_error`; expiration is `inventory_snapshot_expired`.
+the first page. Snapshot ownership is bound to `clientId`, but both the HMAC
+secret and snapshot store belong to the daemon, not a WebSocket `Session`; a
+reconnect with the same client id can therefore continue until TTL expiry. A
+daemon restart naturally loses the store and never rebuilds an old snapshot.
+
+The daemon keeps at most 64 multi-page snapshots in an access-ordered LRU
+cache. A one-page response is not retained. Evicted, foreign-client, and
+post-restart cursors return `inventory_snapshot_not_found`; TTL expiry returns
+`inventory_snapshot_expired`; malformed, forged, mismatched, and invalid-offset
+cursors return `invalid_inventory_cursor`. Snapshot creation is not retried or
+silently regenerated on any continuation failure.
+
+Page size is 1–200, ordering is deterministic, and only `has_more: false`
+proves the end. Replaying a valid snapshot/cursor pair returns the same page.
 
 Later creation, deletion, lifecycle change, or archiving does not alter an
 existing snapshot. It appears in the next snapshot instead. The capability has
@@ -85,6 +104,7 @@ Continue it with the returned values:
         "archived": true,
         "archived_at": "2026-08-10T12:00:00.000Z",
         "internal": false,
+        "live": false,
         "cwd": "/work/project",
         "created_at": "2026-08-01T12:00:00.000Z",
         "updated_at": "2026-08-10T12:00:00.000Z",
@@ -97,5 +117,16 @@ Continue it with the returned values:
 }
 ```
 
-The CLI exposes the same one-page contract as `paseo inventory sessions --json`
-and accepts `--snapshot-id`, `--cursor`, and `--limit` for continuation.
+`live` is provenance for `status_raw`: `true` means it was read from the live
+`AgentManager` lifecycle. `false` means the record is persisted-only and
+`status_raw` is the historical `lastStatus`, not a claim about current runtime
+lifecycle. When both representations exist, the live record supplies
+`status_raw`, `cwd`, timestamps, and provider session correlation; persisted
+metadata supplies archived/internal state where relevant.
+
+Clients discover this RPC through
+`server_info.features.inventorySessionsSnapshot === true`. The CLI exposes the
+same one-page contract as `paseo inventory sessions --json` and accepts
+`--snapshot-id`, `--cursor`, and `--limit` for continuation. It rejects every
+non-integer or out-of-range `--limit` locally (including `0`, floats, text, and
+values above 200).

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,6 +13,7 @@ import { createWorkspaceCommand } from "./commands/workspace/index.js";
 import { createHeartbeatCommand } from "./commands/heartbeat/index.js";
 import { createHubCommand } from "./commands/hub/index.js";
 import { createHooksCommand } from "./commands/hooks.js";
+import { createInventoryCommand } from "./commands/inventory.js";
 import { startCommand as daemonStartCommand } from "./commands/daemon/start.js";
 import { runStatusCommand as runDaemonStatusCommand } from "./commands/daemon/status.js";
 import { runRestartCommand as runDaemonRestartCommand } from "./commands/daemon/restart.js";
@@ -170,6 +171,7 @@ export function createCli(): Command {
   // Daemon commands
   program.addCommand(createDaemonCommand());
   program.addCommand(createHubCommand());
+  program.addCommand(createInventoryCommand());
 
   // Chat commands
 

--- a/packages/cli/src/commands/inventory.test.ts
+++ b/packages/cli/src/commands/inventory.test.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { runInventorySessionsCommand } from "./inventory.js";
+
+describe("runInventorySessionsCommand", () => {
+  it.each([0, Number.NaN, 1.5, 201])(
+    "rejects invalid --limit %s before connecting",
+    async (limit) => {
+      await expect(
+        runInventorySessionsCommand({ limit, json: true }, new Command()),
+      ).rejects.toMatchObject({
+        code: "INVALID_INVENTORY_LIMIT",
+        message: "--limit must be an integer between 1 and 200",
+      });
+    },
+  );
+});

--- a/packages/cli/src/commands/inventory.test.ts
+++ b/packages/cli/src/commands/inventory.test.ts
@@ -1,9 +1,25 @@
 import { Command } from "commander";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const daemonClient = vi.hoisted(() => ({
+  close: vi.fn(async () => {}),
+  getLastServerInfoMessage: vi.fn(),
+  inventorySessions: vi.fn(),
+}));
+
+vi.mock("../utils/client.js", () => ({
+  connectToDaemon: vi.fn(async () => daemonClient),
+}));
 
 import { runInventorySessionsCommand } from "./inventory.js";
 
 describe("runInventorySessionsCommand", () => {
+  beforeEach(() => {
+    daemonClient.close.mockClear();
+    daemonClient.getLastServerInfoMessage.mockReset();
+    daemonClient.inventorySessions.mockReset();
+  });
+
   it.each([0, Number.NaN, 1.5, 201])(
     "rejects invalid --limit %s before connecting",
     async (limit) => {
@@ -15,4 +31,14 @@ describe("runInventorySessionsCommand", () => {
       });
     },
   );
+
+  it("returns UNSUPPORTED_BY_HOST without sending an unknown RPC to an old daemon", async () => {
+    daemonClient.getLastServerInfoMessage.mockReturnValue(null);
+
+    await expect(runInventorySessionsCommand({ json: true }, new Command())).rejects.toMatchObject({
+      code: "UNSUPPORTED_BY_HOST",
+    });
+    expect(daemonClient.inventorySessions).not.toHaveBeenCalled();
+    expect(daemonClient.close).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/cli/src/commands/inventory.ts
+++ b/packages/cli/src/commands/inventory.ts
@@ -37,7 +37,7 @@ export function createInventoryCommand(): Command {
       .description("Read one immutable page of the complete Paseo session inventory")
       .option("--snapshot-id <snapshot_id>", "Snapshot id returned by the preceding page")
       .option("--cursor <cursor>", "Cursor returned by the preceding page")
-      .option("--limit <count>", "Page size (1-200)", Number.parseInt),
+      .option("--limit <count>", "Page size (1-200)", Number),
   ).action(withOutput(runInventorySessionsCommand));
   return inventory;
 }
@@ -46,6 +46,16 @@ export async function runInventorySessionsCommand(
   options: InventorySessionsOptions,
   _command: Command,
 ): Promise<SingleResult<InventoryPageOutput>> {
+  if (
+    options.limit !== undefined &&
+    (!Number.isInteger(options.limit) || options.limit < 1 || options.limit > 200)
+  ) {
+    const error: CommandError = {
+      code: "INVALID_INVENTORY_LIMIT",
+      message: "--limit must be an integer between 1 and 200",
+    };
+    throw error;
+  }
   const client = await connectToDaemon({ host: options.host });
   try {
     const page = await client.inventorySessions({

--- a/packages/cli/src/commands/inventory.ts
+++ b/packages/cli/src/commands/inventory.ts
@@ -1,0 +1,68 @@
+import { Command } from "commander";
+import { connectToDaemon } from "../utils/client.js";
+import type { CommandError, CommandOptions, OutputSchema, SingleResult } from "../output/index.js";
+import { addJsonAndDaemonHostOptions } from "../utils/command-options.js";
+import { withOutput } from "../output/index.js";
+
+interface InventorySessionsOptions extends CommandOptions {
+  host?: string;
+  snapshotId?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+interface InventoryPageOutput {
+  schema_version: string;
+  snapshot_id: string;
+  entries: Array<Record<string, unknown>>;
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+const inventoryPageSchema: OutputSchema<InventoryPageOutput> = {
+  idField: "snapshot_id",
+  columns: [
+    { header: "SNAPSHOT", field: "snapshot_id" },
+    { header: "ENTRIES", field: (page) => page.entries.length },
+    { header: "HAS MORE", field: "has_more" },
+  ],
+  serialize: (page) => page,
+};
+
+export function createInventoryCommand(): Command {
+  const inventory = new Command("inventory").description("Read-only daemon inventory operations");
+  addJsonAndDaemonHostOptions(
+    inventory
+      .command("sessions")
+      .description("Read one immutable page of the complete Paseo session inventory")
+      .option("--snapshot-id <snapshot_id>", "Snapshot id returned by the preceding page")
+      .option("--cursor <cursor>", "Cursor returned by the preceding page")
+      .option("--limit <count>", "Page size (1-200)", Number.parseInt),
+  ).action(withOutput(runInventorySessionsCommand));
+  return inventory;
+}
+
+export async function runInventorySessionsCommand(
+  options: InventorySessionsOptions,
+  _command: Command,
+): Promise<SingleResult<InventoryPageOutput>> {
+  const client = await connectToDaemon({ host: options.host });
+  try {
+    const page = await client.inventorySessions({
+      ...(options.snapshotId !== undefined ? { snapshot_id: options.snapshotId } : {}),
+      ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
+      ...(options.limit !== undefined ? { limit: options.limit } : {}),
+    });
+    await client.close();
+    const { requestId: _requestId, ...data } = page;
+    return { type: "single", data, schema: inventoryPageSchema };
+  } catch (error) {
+    await client.close().catch(() => {});
+    const message = error instanceof Error ? error.message : String(error);
+    const commandError: CommandError = {
+      code: "INVENTORY_SESSIONS_FAILED",
+      message: `Failed to read Paseo inventory: ${message}`,
+    };
+    throw commandError;
+  }
+}

--- a/packages/cli/src/commands/inventory.ts
+++ b/packages/cli/src/commands/inventory.ts
@@ -57,6 +57,15 @@ export async function runInventorySessionsCommand(
     throw error;
   }
   const client = await connectToDaemon({ host: options.host });
+  if (client.getLastServerInfoMessage()?.features?.inventorySessionsSnapshot !== true) {
+    await client.close().catch(() => {});
+    const error: CommandError = {
+      code: "UNSUPPORTED_BY_HOST",
+      message: "This daemon does not support immutable session inventory snapshots.",
+      details: "Update the host to a newer Paseo version.",
+    };
+    throw error;
+  }
   try {
     const page = await client.inventorySessions({
       ...(options.snapshotId !== undefined ? { snapshot_id: options.snapshotId } : {}),

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -366,6 +366,26 @@ test("sets the complete viewed timeline subscription only when the daemon suppor
   });
 });
 
+test("does not send inventory RPCs to a daemon without the snapshot feature", async () => {
+  const mock = createMockTransport();
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "inventory_legacy",
+    transportFactory: () => mock.transport,
+    reconnect: { enabled: false },
+  });
+  clients.push(client);
+
+  const connecting = client.connect();
+  mock.triggerOpen();
+  await connecting;
+
+  await expect(client.inventorySessions()).rejects.toThrow(
+    "Update the host to use immutable session inventory snapshots.",
+  );
+  expect(mock.sent).toEqual([]);
+});
+
 test("normalizes legacy and dedicated agent attention notifications", async () => {
   const mock = createMockTransport();
   const client = new DaemonClient({
@@ -1297,6 +1317,49 @@ test("honors explicit fetchAgents timeout below the session RPC default", async 
   await vi.advanceTimersByTimeAsync(1_199);
   expect(settled).toBe(false);
 
+  await vi.advanceTimersByTimeAsync(1);
+  await expect(responsePromise).rejects.toThrow("Timeout waiting for message (1200ms)");
+});
+
+test("honors explicit inventorySessions timeout below the session RPC default", async () => {
+  useHeartbeatClock();
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "inventory_timeout",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connecting = client.connect();
+  mock.triggerOpen({ features: { inventorySessionsSnapshot: true } });
+  await connecting;
+
+  const responsePromise = client.inventorySessions({
+    requestId: "req-inventory-timeout",
+    timeout: 1_200,
+  });
+  let settled = false;
+  void responsePromise.then(
+    () => {
+      settled = true;
+      return undefined;
+    },
+    () => {
+      settled = true;
+      return undefined;
+    },
+  );
+  expect(parseSentFrame(mock.sent[0])).toEqual({
+    type: "inventory.sessions.request",
+    requestId: "req-inventory-timeout",
+  });
+
+  await vi.advanceTimersByTimeAsync(1_199);
+  expect(settled).toBe(false);
   await vi.advanceTimersByTimeAsync(1);
   await expect(responsePromise).rejects.toThrow("Timeout waiting for message (1200ms)");
 });

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2048,9 +2048,11 @@ export class DaemonClient {
     const message = SessionInboundMessageSchema.parse({
       type: "inventory.sessions.request",
       requestId: resolvedRequestId,
-      ...(options?.snapshot_id ? { snapshot_id: options.snapshot_id } : {}),
-      ...(options?.cursor ? { cursor: options.cursor } : {}),
-      ...(options?.limit ? { limit: options.limit } : {}),
+      ...(options && Object.hasOwn(options, "snapshot_id")
+        ? { snapshot_id: options.snapshot_id }
+        : {}),
+      ...(options && Object.hasOwn(options, "cursor") ? { cursor: options.cursor } : {}),
+      ...(options && Object.hasOwn(options, "limit") ? { limit: options.limit } : {}),
     });
     return this.sendRequest({
       requestId: resolvedRequestId,

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -637,6 +637,20 @@ export type FetchAgentsOptions = Omit<FetchAgentsRequest, "type" | "requestId"> 
 };
 export type FetchAgentsEntry = FetchAgentsPayload["entries"][number];
 export type FetchAgentsPageInfo = FetchAgentsPayload["pageInfo"];
+type InventorySessionsPayload = Extract<
+  SessionOutboundMessage,
+  { type: "inventory.sessions.response" }
+>["payload"];
+type InventorySessionsRequest = Extract<
+  SessionInboundMessage,
+  { type: "inventory.sessions.request" }
+>;
+export type InventorySessionsOptions = Omit<InventorySessionsRequest, "type" | "requestId"> & {
+  requestId?: string;
+  timeout?: number;
+};
+export type InventorySessionsEntry = InventorySessionsPayload["entries"][number];
+export type InventorySessionsPage = Omit<InventorySessionsPayload, "requestId">;
 type FetchAgentHistoryPayload = Extract<
   SessionOutboundMessage,
   { type: "fetch_agent_history_response" }
@@ -2019,6 +2033,31 @@ export class DaemonClient {
       options: { skipQueue: true },
       select: (msg) => {
         if (msg.type !== "fetch_agents_response") {
+          return null;
+        }
+        if (msg.payload.requestId !== resolvedRequestId) {
+          return null;
+        }
+        return msg.payload;
+      },
+    });
+  }
+
+  async inventorySessions(options?: InventorySessionsOptions): Promise<InventorySessionsPayload> {
+    const resolvedRequestId = this.createRequestId(options?.requestId);
+    const message = SessionInboundMessageSchema.parse({
+      type: "inventory.sessions.request",
+      requestId: resolvedRequestId,
+      ...(options?.snapshot_id ? { snapshot_id: options.snapshot_id } : {}),
+      ...(options?.cursor ? { cursor: options.cursor } : {}),
+      ...(options?.limit ? { limit: options.limit } : {}),
+    });
+    return this.sendRequest({
+      requestId: resolvedRequestId,
+      message,
+      options: { skipQueue: true },
+      select: (msg) => {
+        if (msg.type !== "inventory.sessions.response") {
           return null;
         }
         if (msg.payload.requestId !== resolvedRequestId) {

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2044,6 +2044,7 @@ export class DaemonClient {
   }
 
   async inventorySessions(options?: InventorySessionsOptions): Promise<InventorySessionsPayload> {
+    this.requireInventorySessionsSnapshotSupport();
     const resolvedRequestId = this.createRequestId(options?.requestId);
     const message = SessionInboundMessageSchema.parse({
       type: "inventory.sessions.request",
@@ -2057,6 +2058,7 @@ export class DaemonClient {
     return this.sendRequest({
       requestId: resolvedRequestId,
       message,
+      timeout: options?.timeout,
       options: { skipQueue: true },
       select: (msg) => {
         if (msg.type !== "inventory.sessions.response") {
@@ -5387,6 +5389,13 @@ export class DaemonClient {
     // COMPAT(daemonConfigReload): added in v0.4.0, remove gate after 2027-02-14.
     if (this.lastServerInfoMessage?.features?.daemonConfigReload !== true) {
       throw new Error("Update the host to reload daemon configuration.");
+    }
+  }
+
+  private requireInventorySessionsSnapshotSupport(): void {
+    // COMPAT(inventorySessionsSnapshot): added in v0.2.5, remove after 2027-02-10.
+    if (this.lastServerInfoMessage?.features?.inventorySessionsSnapshot !== true) {
+      throw new Error("Update the host to use immutable session inventory snapshots.");
     }
   }
 

--- a/packages/protocol/src/messages.checkout-pr-schema.test.ts
+++ b/packages/protocol/src/messages.checkout-pr-schema.test.ts
@@ -762,4 +762,18 @@ describe("checkout PR schemas", () => {
       providerRemoval: true,
     });
   });
+
+  test("accepts the snapshot inventory server_info feature flag", () => {
+    expect(
+      ServerInfoStatusPayloadSchema.parse({
+        status: "server_info",
+        serverId: "srv_test",
+        features: {
+          inventorySessionsSnapshot: true,
+        },
+      }).features,
+    ).toEqual({
+      inventorySessionsSnapshot: true,
+    });
+  });
 });

--- a/packages/protocol/src/messages.inventory-parity.test.ts
+++ b/packages/protocol/src/messages.inventory-parity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+import { SessionInboundMessageSchema, SessionOutboundMessageSchema } from "./messages.js";
+
+describe("inventory message schema parity", () => {
+  test("SessionInboundMessageSchema accepts a valid inventory.sessions.request", () => {
+    const parsed = SessionInboundMessageSchema.safeParse({
+      type: "inventory.sessions.request",
+      requestId: "req-1",
+      snapshot_id: "snap-1",
+      cursor: "cursor-1",
+      limit: 50,
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.type).toBe("inventory.sessions.request");
+    expect(parsed.data.requestId).toBe("req-1");
+    expect(parsed.data.snapshot_id).toBe("snap-1");
+    expect(parsed.data.cursor).toBe("cursor-1");
+    expect(parsed.data.limit).toBe(50);
+  });
+
+  test("SessionInboundMessageSchema rejects an unknown inventory type", () => {
+    const parsed = SessionInboundMessageSchema.safeParse({
+      type: "inventory.unknown.request",
+      requestId: "req-1",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("SessionInboundMessageSchema rejects an inventory.sessions.request with an out-of-range limit", () => {
+    const parsed = SessionInboundMessageSchema.safeParse({
+      type: "inventory.sessions.request",
+      requestId: "req-1",
+      limit: 250,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("SessionOutboundMessageSchema accepts a valid inventory.sessions.response", () => {
+    const parsed = SessionOutboundMessageSchema.safeParse({
+      type: "inventory.sessions.response",
+      payload: {
+        requestId: "req-1",
+        schema_version: "paseo.inventory_sessions.v1",
+        snapshot_id: "snap-1",
+        entries: [
+          {
+            backend: "paseo",
+            native_id: "agent-1",
+            provider: "claude",
+            status_raw: "idle",
+            archived: false,
+            archived_at: null,
+            internal: false,
+            live: true,
+            cwd: "/tmp/agent-1",
+            created_at: "2026-08-10T00:00:00.000Z",
+            updated_at: "2026-08-10T00:00:00.000Z",
+            persistence_session_id: null,
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.type).toBe("inventory.sessions.response");
+    expect(parsed.data.payload.snapshot_id).toBe("snap-1");
+    expect(parsed.data.payload.has_more).toBe(false);
+  });
+
+  test("SessionOutboundMessageSchema rejects a malformed inventory.sessions.response payload", () => {
+    const parsed = SessionOutboundMessageSchema.safeParse({
+      type: "inventory.sessions.response",
+      payload: {
+        requestId: "req-1",
+        schema_version: "paseo.inventory_sessions.v1",
+        // Missing snapshot_id
+        entries: [],
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("SessionOutboundMessageSchema rejects a corrupted entry inside the inventory response", () => {
+    const parsed = SessionOutboundMessageSchema.safeParse({
+      type: "inventory.sessions.response",
+      payload: {
+        requestId: "req-1",
+        schema_version: "paseo.inventory_sessions.v1",
+        snapshot_id: "snap-1",
+        entries: [
+          {
+            backend: "paseo",
+            native_id: "",
+            provider: "claude",
+            status_raw: "idle",
+            archived: false,
+            archived_at: null,
+            internal: false,
+            live: true,
+            cwd: "/tmp/agent-1",
+            created_at: "2026-08-10T00:00:00.000Z",
+            updated_at: "2026-08-10T00:00:00.000Z",
+            persistence_session_id: null,
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/protocol/src/messages.inventory-parity.ts
+++ b/packages/protocol/src/messages.inventory-parity.ts
@@ -1,0 +1,57 @@
+import type {
+  InventorySessionEntry,
+  InventorySessionsRequestMessage,
+  InventorySessionsResponseMessage,
+  InventorySessionsResponsePayload,
+  ServerInfoStatusFeatures,
+  SessionInboundMessage,
+  SessionOutboundMessage,
+} from "./messages.js";
+
+type Expect<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type NotAny<T> = IsAny<T> extends true ? false : true;
+type IsEqual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+/**
+ * Compile-time parity between the runtime WebSocket schemas and the generated
+ * TypeScript types. Each element must resolve to `true`; any mismatch or loss
+ * of a branch under `z.infer` turns into a type error.
+ */
+export type InventoryTypeParity = [
+  // 1. SessionInboundMessage accepts "inventory.sessions.request" and is not any.
+  Expect<NotAny<SessionInboundMessage>>,
+  Expect<
+    IsEqual<
+      Extract<SessionInboundMessage, { type: "inventory.sessions.request" }>,
+      InventorySessionsRequestMessage
+    >
+  >,
+
+  // 2. SessionOutboundMessage accepts "inventory.sessions.response" and is not any.
+  Expect<NotAny<SessionOutboundMessage>>,
+  Expect<
+    IsEqual<
+      Extract<SessionOutboundMessage, { type: "inventory.sessions.response" }>,
+      InventorySessionsResponseMessage
+    >
+  >,
+
+  // 3. Inventory response payload exposes the expected fields and entry shape.
+  Expect<NotAny<InventorySessionsResponsePayload>>,
+  Expect<IsEqual<InventorySessionsResponsePayload["snapshot_id"], string>>,
+  Expect<IsEqual<InventorySessionsResponsePayload["next_cursor"], string | null>>,
+  Expect<IsEqual<InventorySessionsResponsePayload["has_more"], boolean>>,
+  Expect<NotAny<InventorySessionsResponsePayload["entries"]>>,
+  Expect<NotAny<InventorySessionEntry>>,
+  Expect<IsEqual<InventorySessionEntry["backend"], "paseo">>,
+  Expect<IsEqual<InventorySessionEntry["native_id"], string>>,
+  Expect<IsEqual<InventorySessionEntry["persistence_session_id"], string | null>>,
+
+  // 4. ServerInfoStatusPayload["features"] exposes inventorySessionsSnapshot.
+  Expect<NotAny<ServerInfoStatusFeatures>>,
+  Expect<IsEqual<ServerInfoStatusFeatures["inventorySessionsSnapshot"], boolean | undefined>>,
+
+  // 5. Unknown inventory messages are not accepted by the inbound union.
+  Expect<IsEqual<Extract<SessionInboundMessage, { type: "inventory.unknown.request" }>, never>>,
+];

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3715,7 +3715,7 @@ export const FetchAgentsResponseMessageSchema = z.object({
   }),
 });
 
-const InventorySessionEntrySchema = z.object({
+export const InventorySessionEntrySchema = z.object({
   backend: z.literal("paseo"),
   native_id: z.string().min(1),
   provider: z.string().min(1),
@@ -3730,16 +3730,24 @@ const InventorySessionEntrySchema = z.object({
   persistence_session_id: z.string().nullable(),
 });
 
+export type InventorySessionEntry = z.infer<typeof InventorySessionEntrySchema>;
+
+export const InventorySessionsResponsePayloadSchema = z.object({
+  requestId: z.string(),
+  schema_version: z.literal("paseo.inventory_sessions.v1"),
+  snapshot_id: z.string().min(1),
+  entries: z.array(InventorySessionEntrySchema),
+  next_cursor: z.string().nullable(),
+  has_more: z.boolean(),
+});
+
+export type InventorySessionsResponsePayload = z.infer<
+  typeof InventorySessionsResponsePayloadSchema
+>;
+
 export const InventorySessionsResponseMessageSchema = z.object({
   type: z.literal("inventory.sessions.response"),
-  payload: z.object({
-    requestId: z.string(),
-    schema_version: z.literal("paseo.inventory_sessions.v1"),
-    snapshot_id: z.string().min(1),
-    entries: z.array(InventorySessionEntrySchema),
-    next_cursor: z.string().nullable(),
-    has_more: z.boolean(),
-  }),
+  payload: InventorySessionsResponsePayloadSchema,
 });
 
 export const FetchAgentHistoryResponseMessageSchema = z.object({
@@ -6145,6 +6153,7 @@ export type ServerCapabilityState = z.infer<typeof ServerCapabilityStateSchema>;
 export type ServerVoiceCapabilities = z.infer<typeof ServerVoiceCapabilitiesSchema>;
 export type ServerCapabilities = z.infer<typeof ServerCapabilitiesSchema>;
 export type ServerInfoStatusPayload = z.infer<typeof ServerInfoStatusPayloadSchema>;
+export type ServerInfoStatusFeatures = NonNullable<ServerInfoStatusPayload["features"]>;
 export type RpcErrorMessage = z.infer<typeof RpcErrorMessageSchema>;
 export type ArtifactMessage = z.infer<typeof ArtifactMessageSchema>;
 export type AgentUpdateMessage = z.infer<typeof AgentUpdateMessageSchema>;
@@ -6170,6 +6179,9 @@ export type FetchAgentsResponseMessage = z.infer<typeof FetchAgentsResponseMessa
 export type InventorySessionsResponseMessage = z.infer<
   typeof InventorySessionsResponseMessageSchema
 >;
+export type InventorySessionMessage =
+  | InventorySessionsRequestMessage
+  | InventorySessionsResponseMessage;
 export type FetchAgentHistoryResponseMessage = z.infer<
   typeof FetchAgentHistoryResponseMessageSchema
 >;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1759,6 +1759,18 @@ export const AgentRewindResponseMessageSchema = z.object({
   }),
 });
 
+// A deliberately separate, read-only inventory contract. It bypasses the UI
+// directory's provider, availability, project-placement, and active-scope
+// filters so an external controller can prove it reached the end of the whole
+// daemon registry snapshot.
+export const InventorySessionsRequestMessageSchema = z.object({
+  type: z.literal("inventory.sessions.request"),
+  requestId: z.string(),
+  snapshot_id: z.string().min(1).optional(),
+  cursor: z.string().min(1).optional(),
+  limit: z.number().int().positive().max(200).optional(),
+});
+
 export const UpdateAgentResponseMessageSchema = z.object({
   type: z.literal("update_agent_response"),
   payload: AgentActionResponsePayloadSchema,
@@ -2827,6 +2839,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   AbortRequestMessageSchema,
   AudioPlayedMessageSchema,
   FetchAgentsRequestMessageSchema,
+  InventorySessionsRequestMessageSchema,
   FetchAgentHistoryRequestMessageSchema,
   FetchRecentProviderSessionsRequestMessageSchema,
   FetchWorkspacesRequestMessageSchema,
@@ -3697,6 +3710,32 @@ export const FetchAgentsResponseMessageSchema = z.object({
     entries: z.array(AgentDirectoryResponseEntrySchema),
     pageInfo: AgentDirectoryPageInfoSchema,
     sync: DirectorySyncMetadataSchema.optional(),
+  }),
+});
+
+const InventorySessionEntrySchema = z.object({
+  backend: z.literal("paseo"),
+  native_id: z.string().min(1),
+  provider: z.string().min(1),
+  status_raw: z.string().min(1),
+  archived: z.boolean(),
+  archived_at: z.string().nullable(),
+  internal: z.boolean(),
+  cwd: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  persistence_session_id: z.string().nullable(),
+});
+
+export const InventorySessionsResponseMessageSchema = z.object({
+  type: z.literal("inventory.sessions.response"),
+  payload: z.object({
+    requestId: z.string(),
+    schema_version: z.literal("paseo.inventory_sessions.v1"),
+    snapshot_id: z.string().min(1),
+    entries: z.array(InventorySessionEntrySchema),
+    next_cursor: z.string().nullable(),
+    has_more: z.boolean(),
   }),
 });
 
@@ -5937,6 +5976,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   AgentStreamMessageSchema,
   AgentStatusMessageSchema,
   FetchAgentsResponseMessageSchema,
+  InventorySessionsResponseMessageSchema,
   FetchAgentHistoryResponseMessageSchema,
   FetchRecentProviderSessionsResponseMessageSchema,
   FetchWorkspacesResponseMessageSchema,
@@ -6124,6 +6164,9 @@ export type WorkspaceScriptLifecycle = z.infer<typeof WorkspaceScriptLifecycleSc
 export type WorkspaceScriptHealth = z.infer<typeof WorkspaceScriptHealthSchema>;
 export type WorkspaceScriptPayload = z.infer<typeof WorkspaceScriptPayloadSchema>;
 export type FetchAgentsResponseMessage = z.infer<typeof FetchAgentsResponseMessageSchema>;
+export type InventorySessionsResponseMessage = z.infer<
+  typeof InventorySessionsResponseMessageSchema
+>;
 export type FetchAgentHistoryResponseMessage = z.infer<
   typeof FetchAgentHistoryResponseMessageSchema
 >;
@@ -6266,6 +6309,7 @@ export type ActivityLogPayload = z.infer<typeof ActivityLogPayloadSchema>;
 // Type exports for inbound message types
 export type VoiceAudioChunkMessage = z.infer<typeof VoiceAudioChunkMessageSchema>;
 export type FetchAgentsRequestMessage = z.infer<typeof FetchAgentsRequestMessageSchema>;
+export type InventorySessionsRequestMessage = z.infer<typeof InventorySessionsRequestMessageSchema>;
 export type FetchAgentHistoryRequestMessage = z.infer<typeof FetchAgentHistoryRequestMessageSchema>;
 export type FetchRecentProviderSessionsRequestMessage = z.infer<
   typeof FetchRecentProviderSessionsRequestMessageSchema

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3281,6 +3281,8 @@ export const ServerInfoStatusPayloadSchema = z
         workspaceScriptManagement: z.boolean().optional(),
         // COMPAT(projectCustomIcon): added in v0.2.0, remove after 2027-01-20.
         projectCustomIcon: z.boolean().optional(),
+        // COMPAT(inventorySessionsSnapshot): added in v0.2.5, remove after 2027-02-10.
+        inventorySessionsSnapshot: z.boolean().optional(),
         // COMPAT(fsEntryOps): added in v0.3.0, remove gate after 2027-02-08.
         fsEntryOps: z.boolean().optional(),
         // COMPAT(fsEntryDuplicate): added in v0.3.0, remove gate after 2027-02-09.
@@ -3721,6 +3723,7 @@ const InventorySessionEntrySchema = z.object({
   archived: z.boolean(),
   archived_at: z.string().nullable(),
   internal: z.boolean(),
+  live: z.boolean(),
   cwd: z.string(),
   created_at: z.string(),
   updated_at: z.string(),

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4,7 +4,9 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import pino from "pino";
 
+import { captureInventorySessions } from "../session.js";
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import {
   AgentManager,
@@ -29,6 +31,7 @@ import type {
   AgentPersistenceHandle,
   AgentRunOptions,
   AgentRunResult,
+  AgentRuntimeInfo,
   AgentSession,
   AgentSessionConfig,
   AgentSlashCommand,
@@ -9375,4 +9378,319 @@ test("onWorkspaceStateMayHaveChanged is not called for running shell tool calls"
   await manager.runAgent(snapshot.id, { text: "merge it" });
 
   expect(onWorkspaceStateMayHaveChanged).not.toHaveBeenCalled();
+});
+
+class NoInitialPersistenceRuntimeInfoSession extends TestAgentSession {
+  private runtimeInfoQueue: Array<{
+    resolve: (value: AgentRuntimeInfo) => void;
+    reject: (reason?: unknown) => void;
+  }> = [];
+  private runtimeInfoRequestCount = 0;
+  private readonly runtimeInfoRequested = deferred<void>();
+
+  override describePersistence() {
+    return null;
+  }
+
+  waitForRuntimeInfoRequest(): Promise<void> {
+    return this.runtimeInfoRequested.promise;
+  }
+
+  finishNextRuntimeInfo(value: AgentRuntimeInfo): void {
+    const next = this.runtimeInfoQueue.shift();
+    if (next) {
+      next.resolve(value);
+    }
+  }
+
+  getRuntimeInfoRequestCount(): number {
+    return this.runtimeInfoRequestCount;
+  }
+
+  override async getRuntimeInfo() {
+    this.runtimeInfoRequested.resolve();
+    this.runtimeInfoRequestCount += 1;
+    return new Promise<AgentRuntimeInfo>((resolve, reject) => {
+      this.runtimeInfoQueue.push({ resolve, reject });
+    });
+  }
+}
+
+class HoldingInventoryStorage extends AgentStorage {
+  private firstScanResolve?: () => void;
+  private firstScanPromise: Promise<void> = Promise.resolve();
+  scanCount = 0;
+
+  constructor(baseDir: string, parentLogger: pino.Logger) {
+    super(baseDir, parentLogger);
+    const d = deferred<void>();
+    this.firstScanPromise = d.promise;
+    this.firstScanResolve = d.resolve;
+  }
+
+  override async inventoryFreshState() {
+    this.scanCount += 1;
+    if (this.firstScanResolve) {
+      await this.firstScanPromise;
+      this.firstScanResolve = undefined;
+    }
+    return super.inventoryFreshState();
+  }
+
+  releaseFirstScan(): void {
+    this.firstScanResolve?.();
+  }
+}
+
+function waitForRuntimeInfoRequestCount(
+  session: NoInitialPersistenceRuntimeInfoSession,
+  count: number,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const check = () => {
+      if (session.getRuntimeInfoRequestCount() >= count) {
+        resolve();
+      } else {
+        setTimeout(check, 0);
+      }
+    };
+    check();
+  });
+}
+
+test("B-NEW-4: registration refreshRuntimeInfo(emit:false) changes persistence and bumps inventory epoch", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bnew4-epoch-"));
+  const session = new NoInitialPersistenceRuntimeInfoSession({ provider: "codex", cwd: workdir });
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-0000000000b4",
+  });
+
+  try {
+    const agentId = "00000000-0000-4000-8000-0000000000b4";
+    const register = (
+      manager as unknown as { registerSession: (...args: unknown[]) => Promise<ManagedAgent> }
+    ).registerSession(session, { provider: "codex", cwd: workdir }, agentId, {
+      publishWhenReady: true,
+      workspaceId: undefined,
+    });
+    await session.waitForRuntimeInfoRequest();
+
+    const before = manager.captureInventoryLiveState();
+    expect(before.agents).toHaveLength(1);
+    expect(before.agents[0]?.persistence).toBeNull();
+    const epochBefore = before.epoch;
+
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "reg-session",
+      model: null,
+      modeId: null,
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const after = manager.captureInventoryLiveState();
+    expect(after.agents[0]?.persistence?.sessionId).toBe("reg-session");
+    expect(after.epoch).toBeGreaterThan(epochBefore);
+
+    await waitForRuntimeInfoRequestCount(session, 2);
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "reg-session",
+      model: null,
+      modeId: null,
+    });
+    await register;
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("B-NEW-4: persistence change during registration triggers inventory retry before mixed-authority materialization", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bnew4-retry-"));
+  const session = new NoInitialPersistenceRuntimeInfoSession({ provider: "codex", cwd: workdir });
+  const storage = new HoldingInventoryStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-0000000000b5",
+  });
+
+  try {
+    const agentId = "00000000-0000-4000-8000-0000000000b5";
+    const register = (
+      manager as unknown as { registerSession: (...args: unknown[]) => Promise<ManagedAgent> }
+    ).registerSession(session, { provider: "codex", cwd: workdir }, agentId, {
+      publishWhenReady: true,
+      workspaceId: undefined,
+    });
+    await session.waitForRuntimeInfoRequest();
+
+    const capture = captureInventorySessions(manager, storage);
+
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "reg-session",
+      model: null,
+      modeId: null,
+    });
+
+    await waitForRuntimeInfoRequestCount(session, 2);
+    storage.releaseFirstScan();
+
+    const entries = await capture;
+
+    expect(storage.scanCount).toBe(2);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      backend: "paseo",
+      native_id: agentId,
+      live: true,
+      persistence_session_id: "reg-session",
+    });
+
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "reg-session",
+      model: null,
+      modeId: null,
+    });
+    await register;
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("B-NEW-4: markInventoryVisiblePersistence bumps epoch only when persistence session id changes", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bnew4-mark-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-0000000000b6",
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const agent = (manager as unknown as { agents: Map<string, ManagedAgent> }).agents.get(
+      snapshot.id,
+    )!;
+    const mark = (
+      manager as unknown as {
+        markInventoryVisiblePersistence: (
+          agent: unknown,
+          handle: AgentPersistenceHandle | null,
+          options?: { bump?: boolean },
+        ) => boolean;
+      }
+    ).markInventoryVisiblePersistence;
+
+    const e0 = manager.captureInventoryLiveState().epoch;
+    mark.call(manager, agent, { provider: "codex", sessionId: "t1" });
+    const e1 = manager.captureInventoryLiveState().epoch;
+    expect(e1).toBeGreaterThan(e0);
+
+    mark.call(manager, agent, { provider: "codex", sessionId: "t1" });
+    const e2 = manager.captureInventoryLiveState().epoch;
+    expect(e2).toBe(e1);
+
+    mark.call(manager, agent, { provider: "codex", sessionId: "t2" });
+    const e3 = manager.captureInventoryLiveState().epoch;
+    expect(e3).toBeGreaterThan(e2);
+
+    mark.call(manager, agent, null);
+    const e4 = manager.captureInventoryLiveState().epoch;
+    expect(e4).toBeGreaterThan(e3);
+
+    mark.call(manager, agent, null);
+    const e5 = manager.captureInventoryLiveState().epoch;
+    expect(e5).toBe(e4);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("B-NEW-4: refreshRuntimeInfo(emit:false) bumps epoch only when persistence session id changes", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-bnew4-refresh-"));
+  const session = new NoInitialPersistenceRuntimeInfoSession({ provider: "codex", cwd: workdir });
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-0000000000b7",
+  });
+
+  try {
+    const agentId = "00000000-0000-4000-8000-0000000000b7";
+    const register = (
+      manager as unknown as { registerSession: (...args: unknown[]) => Promise<ManagedAgent> }
+    ).registerSession(session, { provider: "codex", cwd: workdir }, agentId, {
+      publishWhenReady: true,
+      workspaceId: undefined,
+    });
+    await session.waitForRuntimeInfoRequest();
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "r1",
+      model: null,
+      modeId: null,
+    });
+    await waitForRuntimeInfoRequestCount(session, 2);
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "r1",
+      model: null,
+      modeId: null,
+    });
+    await register;
+
+    const agent = (manager as unknown as { agents: Map<string, ManagedAgent> }).agents.get(
+      agentId,
+    )!;
+    const refreshRuntimeInfo = (
+      manager as unknown as {
+        refreshRuntimeInfo: (agent: unknown, options?: { emit?: boolean }) => Promise<void>;
+      }
+    ).refreshRuntimeInfo;
+
+    const e0 = manager.captureInventoryLiveState().epoch;
+    const same = refreshRuntimeInfo.call(manager, agent, { emit: false });
+    await waitForRuntimeInfoRequestCount(session, 3);
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "r1",
+      model: "gpt-5.2-codex",
+      modeId: null,
+    });
+    await same;
+    const e1 = manager.captureInventoryLiveState().epoch;
+    expect(e1).toBe(e0);
+
+    agent.persistence = null;
+    agent.runtimeInfo = undefined;
+    const e2 = manager.captureInventoryLiveState().epoch;
+    const changed = refreshRuntimeInfo.call(manager, agent, { emit: false });
+    await waitForRuntimeInfoRequestCount(session, 4);
+    session.finishNextRuntimeInfo({
+      provider: "codex",
+      sessionId: "r2",
+      model: null,
+      modeId: null,
+    });
+    await changed;
+    const e3 = manager.captureInventoryLiveState().epoch;
+    expect(e3).toBeGreaterThan(e2);
+    expect(agent.persistence?.sessionId).toBe("r2");
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
 });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -797,6 +797,37 @@ test("captures inventory live entries and epoch at one synchronous boundary", as
   expect(manager.captureInventoryLiveState().epoch).toBeGreaterThan(epochBeforeMutation);
 });
 
+test("inventory capture observes an epoch bump injected while copying a live entry", async () => {
+  const client = new SessionRecordingAgentClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000096",
+  });
+  const created = await manager.createAgent({ provider: "codex", cwd: process.cwd() }, undefined, {
+    workspaceId: undefined,
+  });
+  const agents = (manager as unknown as { agents: Map<string, ManagedAgent> }).agents;
+  const live = agents.get(created.id)!;
+  const epochBeforeBoundaryMutation = manager.captureInventoryLiveState().epoch;
+  let mutateDuringCopy = true;
+  Object.defineProperty(live, "id", {
+    configurable: true,
+    get() {
+      if (mutateDuringCopy) {
+        mutateDuringCopy = false;
+        manager.notifyAgentState(created.id);
+      }
+      return created.id;
+    },
+  });
+
+  manager.captureInventoryLiveState();
+  // Session capture compares this newer epoch after the registry await, so an
+  // entry copy spanning this boundary is retried rather than materialized.
+  expect(manager.captureInventoryLiveState().epoch).toBeGreaterThan(epochBeforeBoundaryMutation);
+});
+
 test("does not register a session that finishes starting after shutdown begins", async () => {
   const client = new HeldAgentCreationClient();
   const manager = new AgentManager({

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -768,6 +768,35 @@ function fakeCodexEmitting(args: FakeCodexEmitterArgs): AgentClient {
 
 const logger = createTestLogger();
 
+test("captures inventory live entries and epoch at one synchronous boundary", async () => {
+  const client = new SessionRecordingAgentClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000097",
+  });
+  const created = await manager.createAgent({ provider: "codex", cwd: process.cwd() }, undefined, {
+    workspaceId: undefined,
+  });
+
+  const beforeMutation = manager.captureInventoryLiveState();
+  const epochBeforeMutation = beforeMutation.epoch;
+  const started = waitForAgentLifecycle(manager, created.id, "running");
+  client.sessions[0]!.pushEvent({ type: "turn_started", provider: "codex", turnId: "inventory" });
+  await started;
+
+  // captureInventoryLiveState has no await: the captured entry remains the
+  // pre-mutation value and the next capture exposes a strictly newer epoch.
+  expect(beforeMutation.agents).toEqual([
+    expect.objectContaining({ id: created.id, lifecycle: "idle" }),
+  ]);
+  expect(manager.captureInventoryLiveState()).toMatchObject({
+    epoch: expect.any(Number),
+    agents: [expect.objectContaining({ id: created.id, lifecycle: "running" })],
+  });
+  expect(manager.captureInventoryLiveState().epoch).toBeGreaterThan(epochBeforeMutation);
+});
+
 test("does not register a session that finishes starting after shutdown begins", async () => {
   const client = new HeldAgentCreationClient();
   const manager = new AgentManager({

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -883,6 +883,16 @@ export class AgentManager {
       .map((agent) => Object.assign({}, agent));
   }
 
+  /**
+   * Canonical daemon state for the read-only inventory capability. Unlike the
+   * UI list, it deliberately includes internal agents: scope decisions belong
+   * to the inventory consumer and must never be hidden by a presentation
+   * filter.
+   */
+  listAgentsForInventory(): ManagedAgent[] {
+    return Array.from(this.agents.values()).map((agent) => Object.assign({}, agent));
+  }
+
   async listImportableSessions(
     options?: ImportablePersistedAgentQueryOptions,
   ): Promise<ManagedImportableProviderSession[]> {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -845,6 +845,21 @@ export class AgentManager {
     this.inventoryEpoch += 1;
   }
 
+  private markInventoryVisiblePersistence(
+    agent: ManagedAgent,
+    handle: AgentPersistenceHandle | null,
+    options?: { bump?: boolean },
+  ): boolean {
+    const previousSessionId = agent.persistence?.sessionId ?? null;
+    agent.persistence = attachPersistenceCwd(handle, agent.cwd);
+    const nextSessionId = agent.persistence?.sessionId ?? null;
+    const changed = previousSessionId !== nextSessionId;
+    if (changed && options?.bump !== false) {
+      this.bumpInventoryEpoch();
+    }
+    return changed;
+  }
+
   private nextStoredUpdatedAt(record: StoredAgentRecord): string {
     const previousMs = Date.parse(record.updatedAt);
     const nowMs = Date.now();
@@ -2340,7 +2355,9 @@ export class AgentManager {
         ? { provider: mutableAgent.provider, sessionId: mutableAgent.runtimeInfo.sessionId }
         : null);
     if (persistenceHandle) {
-      mutableAgent.persistence = attachPersistenceCwd(persistenceHandle, mutableAgent.cwd);
+      this.markInventoryVisiblePersistence(mutableAgent, persistenceHandle, {
+        bump: shouldHoldBusyForReplacement,
+      });
     }
     this.logger.trace(
       {
@@ -3447,14 +3464,17 @@ export class AgentManager {
         newInfo.sessionId !== agent.runtimeInfo?.sessionId ||
         newInfo.modeId !== agent.runtimeInfo?.modeId;
       agent.runtimeInfo = newInfo;
-      if (!agent.persistence && newInfo.sessionId) {
-        agent.persistence = attachPersistenceCwd(
-          { provider: agent.provider, sessionId: newInfo.sessionId },
-          agent.cwd,
-        );
+      const persistenceHandle =
+        !agent.persistence && newInfo.sessionId
+          ? { provider: agent.provider, sessionId: newInfo.sessionId }
+          : null;
+      const shouldEmit = changed && options?.emit !== false;
+      if (persistenceHandle) {
+        this.markInventoryVisiblePersistence(agent, persistenceHandle, {
+          bump: !shouldEmit,
+        });
       }
-      // Emit state if runtimeInfo changed so clients get the updated model
-      if (changed && options?.emit !== false) {
+      if (shouldEmit) {
         this.emitState(agent);
       }
     } catch {
@@ -3784,9 +3804,10 @@ export class AgentManager {
       case "model_changed":
         agent.runtimeInfo = event.runtimeInfo;
         if (!agent.persistence && event.runtimeInfo.sessionId) {
-          agent.persistence = attachPersistenceCwd(
+          this.markInventoryVisiblePersistence(
+            agent,
             { provider: agent.provider, sessionId: event.runtimeInfo.sessionId },
-            agent.cwd,
+            { bump: false },
           );
         }
         agent.currentModeId = event.runtimeInfo.modeId ?? agent.currentModeId;
@@ -3849,11 +3870,10 @@ export class AgentManager {
   }
 
   private onStreamThreadStarted(agent: ActiveManagedAgent): void {
-    const previousSessionId = agent.persistence?.sessionId ?? null;
     const handle = agent.session.describePersistence();
     if (handle) {
-      agent.persistence = attachPersistenceCwd(handle, agent.cwd);
-      if (agent.persistence?.sessionId !== previousSessionId) {
+      const changed = this.markInventoryVisiblePersistence(agent, handle, { bump: false });
+      if (changed) {
         this.emitState(agent);
       }
     }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -422,6 +422,27 @@ export interface AgentMetricsSnapshot {
   };
 }
 
+/**
+ * Immutable projection of the in-memory authority used by inventory capture.
+ * Keep this intentionally narrow: every field here is serialized by the
+ * inventory RPC and therefore protected by AgentManager's inventory epoch.
+ */
+export interface InventoryLiveAgent {
+  id: string;
+  provider: AgentProvider;
+  lifecycle: AgentLifecycleStatus;
+  internal?: boolean;
+  cwd: string;
+  createdAt: Date;
+  updatedAt: Date;
+  persistence: AgentPersistenceHandle | null;
+}
+
+export interface InventoryLiveState {
+  epoch: number;
+  agents: InventoryLiveAgent[];
+}
+
 type ActiveManagedAgent =
   | ManagedAgentInitializing
   | ManagedAgentIdle
@@ -656,6 +677,9 @@ export class AgentManager {
   private readonly inFlightAgentCloses = new Map<string, Promise<void>>();
   private readonly lifecycleMutationTails = new Map<string, Promise<void>>();
   private readonly agentStreamCoalescer: AgentStreamCoalescer;
+  // Monotonic, daemon-local generation for every inventory-visible live-state
+  // mutation. It is a capture-stability proof, never snapshot identity.
+  private inventoryEpoch = 0;
   private mcpBaseUrl: string | null;
   private readonly mcpAuthToken: string | null;
   private paseoToolsEnabled = true;
@@ -813,7 +837,12 @@ export class AgentManager {
     const nextMs = nowMs > previousMs ? nowMs : previousMs + 1;
     const next = new Date(nextMs);
     agent.updatedAt = next;
+    this.bumpInventoryEpoch();
     return next;
+  }
+
+  private bumpInventoryEpoch(): void {
+    this.inventoryEpoch += 1;
   }
 
   private nextStoredUpdatedAt(record: StoredAgentRecord): string {
@@ -891,6 +920,27 @@ export class AgentManager {
    */
   listAgentsForInventory(): ManagedAgent[] {
     return Array.from(this.agents.values()).map((agent) => Object.assign({}, agent));
+  }
+
+  /**
+   * Atomically captures the live authority and its generation for an inventory
+   * handshake. The value copies cannot be changed by later live mutations
+   * while an asynchronous registry scan is in progress.
+   */
+  captureInventoryLiveState(): InventoryLiveState {
+    return {
+      epoch: this.inventoryEpoch,
+      agents: Array.from(this.agents.values()).map((agent) => ({
+        id: agent.id,
+        provider: agent.provider,
+        lifecycle: agent.lifecycle,
+        internal: agent.internal,
+        cwd: agent.cwd,
+        createdAt: new Date(agent.createdAt),
+        updatedAt: new Date(agent.updatedAt),
+        persistence: agent.persistence ? { ...agent.persistence } : null,
+      })),
+    };
   }
 
   async listImportableSessions(
@@ -1547,6 +1597,9 @@ export class AgentManager {
 
     const { archivedAt } = await this.markRecordArchived(stored);
     agent.updatedAt = new Date(archivedAt);
+    // archiveAgent awaits before removing the live agent, so this direct
+    // inventory-visible timestamp change must advance the generation itself.
+    this.bumpInventoryEpoch();
     await this.closeAgent(agentId);
     this.discardRetainedAgentState(agentId);
 
@@ -2962,6 +3015,7 @@ export class AgentManager {
 
       this.assertAcceptingAgentRegistrations();
       this.agents.set(resolvedAgentId, managed);
+      this.bumpInventoryEpoch();
       registered = true;
       // Initialize previousStatus to track transitions
       this.previousStatuses.set(resolvedAgentId, managed.lifecycle);
@@ -3145,6 +3199,7 @@ export class AgentManager {
   ): ManagedAgentClosed {
     this.agentStreamCoalescer.flushAndDiscard(agent.id);
     this.agents.delete(agent.id);
+    this.bumpInventoryEpoch();
     this.previousStatuses.delete(agent.id);
     if (agent.unsubscribeSession) {
       agent.unsubscribeSession();
@@ -4188,6 +4243,10 @@ export class AgentManager {
   }
 
   private emitState(agent: ManagedAgent, options?: { persist?: boolean }): void {
+    // Some inventory-visible state (notably a newly discovered persistence
+    // handle) is updated by provider callbacks without touchUpdatedAt(). A
+    // conservative bump on every published live state closes that path too.
+    this.bumpInventoryEpoch();
     // Keep attention as an edge-triggered unread signal, not a level signal.
     this.checkAndSetAttention(agent);
     if (options?.persist !== false) {

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -704,4 +704,189 @@ describe("AgentStorage", () => {
 
     expect(await registryTreeHash(storagePath)).toBe(before);
   });
+
+  test.skipIf(process.platform === "win32")(
+    "inventoryState fails closed on a root-level symlink to a JSON record",
+    async () => {
+      await fs.mkdir(storagePath, { recursive: true });
+      const targetRecord = {
+        id: "symlinked-root-agent",
+        provider: "claude",
+        cwd: "/tmp/project",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        updatedAt: "2025-01-01T00:00:00.000Z",
+      };
+      const targetPath = path.join(tmpDir, "symlink-target.json");
+      await fs.writeFile(targetPath, JSON.stringify(targetRecord), "utf8");
+      const linkPath = path.join(storagePath, "root-link.json");
+      await fs.symlink(targetPath, linkPath);
+
+      const reloaded = new AgentStorage(storagePath, logger);
+      await reloaded.initialize();
+
+      expect(reloaded.inventoryState().records).toHaveLength(0);
+      expect(reloaded.inventoryState().issues).toContainEqual({
+        path: linkPath,
+        reason: "unreadable_path",
+      });
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "inventoryState fails closed on a symlinked project directory",
+    async () => {
+      await fs.mkdir(storagePath, { recursive: true });
+      const realProjectDir = path.join(tmpDir, "real-project");
+      await fs.mkdir(realProjectDir, { recursive: true });
+      await fs.writeFile(
+        path.join(realProjectDir, "agent-1.json"),
+        JSON.stringify({
+          id: "agent-in-symlinked-dir",
+          provider: "claude",
+          cwd: "/tmp/project",
+          createdAt: "2025-01-01T00:00:00.000Z",
+          updatedAt: "2025-01-01T00:00:00.000Z",
+        }),
+        "utf8",
+      );
+      const linkPath = path.join(storagePath, "project-link");
+      await fs.symlink(realProjectDir, linkPath, "dir");
+
+      const reloaded = new AgentStorage(storagePath, logger);
+      await reloaded.initialize();
+
+      expect(reloaded.inventoryState().records).toHaveLength(0);
+      expect(reloaded.inventoryState().issues).toContainEqual({
+        path: linkPath,
+        reason: "unreadable_path",
+      });
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "inventoryState fails closed on a symlink inside a project directory",
+    async () => {
+      const projectDir = path.join(storagePath, "tmp-project");
+      await fs.mkdir(projectDir, { recursive: true });
+      const targetPath = path.join(tmpDir, "outside.json");
+      await fs.writeFile(
+        targetPath,
+        JSON.stringify({
+          id: "symlinked-inside-agent",
+          provider: "claude",
+          cwd: "/tmp/project",
+          createdAt: "2025-01-01T00:00:00.000Z",
+          updatedAt: "2025-01-01T00:00:00.000Z",
+        }),
+        "utf8",
+      );
+      const linkPath = path.join(projectDir, "agent-link.json");
+      await fs.symlink(targetPath, linkPath);
+
+      const reloaded = new AgentStorage(storagePath, logger);
+      await reloaded.initialize();
+
+      expect(reloaded.inventoryState().records).toHaveLength(0);
+      expect(reloaded.inventoryState().issues).toContainEqual({
+        path: linkPath,
+        reason: "unreadable_path",
+      });
+    },
+  );
+
+  test("inventoryState fails closed on a nested directory inside a project directory", async () => {
+    const projectDir = path.join(storagePath, "tmp-project");
+    const nestedDir = path.join(projectDir, "nested");
+    await fs.mkdir(nestedDir, { recursive: true });
+
+    const reloaded = new AgentStorage(storagePath, logger);
+    await reloaded.initialize();
+
+    expect(reloaded.inventoryState().records).toHaveLength(0);
+    expect(reloaded.inventoryState().issues).toContainEqual({
+      path: nestedDir,
+      reason: "unreadable_path",
+    });
+  });
+
+  test("inventoryState reports unexpected regular files", async () => {
+    const projectDir = path.join(storagePath, "tmp-project");
+    await fs.mkdir(projectDir, { recursive: true });
+    const rootUnexpected = path.join(storagePath, "notes.txt");
+    const projectUnexpected = path.join(projectDir, "notes.txt");
+    await fs.writeFile(rootUnexpected, "not a record", "utf8");
+    await fs.writeFile(projectUnexpected, "not a record", "utf8");
+
+    const reloaded = new AgentStorage(storagePath, logger);
+    await reloaded.initialize();
+
+    expect(reloaded.inventoryState().records).toHaveLength(0);
+    expect(reloaded.inventoryState().issues).toContainEqual({
+      path: rootUnexpected,
+      reason: "unreadable_path",
+    });
+    expect(reloaded.inventoryState().issues).toContainEqual({
+      path: projectUnexpected,
+      reason: "unreadable_path",
+    });
+  });
+
+  test("inventoryState loads root-level and project JSON records", async () => {
+    await fs.mkdir(storagePath, { recursive: true });
+    const rootRecord = {
+      id: "root-agent",
+      provider: "claude",
+      cwd: "/tmp/project-a",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    };
+    await fs.writeFile(
+      path.join(storagePath, "root-agent.json"),
+      JSON.stringify(rootRecord),
+      "utf8",
+    );
+
+    const projectDir = path.join(storagePath, "tmp-project-b");
+    await fs.mkdir(projectDir, { recursive: true });
+    const projectRecord = {
+      id: "project-agent",
+      provider: "codex",
+      cwd: "/tmp/project-b",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    };
+    await fs.writeFile(
+      path.join(projectDir, "project-agent.json"),
+      JSON.stringify(projectRecord),
+      "utf8",
+    );
+
+    const reloaded = new AgentStorage(storagePath, logger);
+    await reloaded.initialize();
+
+    const ids = reloaded
+      .inventoryState()
+      .records.map((record) => record.id)
+      .sort();
+    expect(ids).toEqual(["project-agent", "root-agent"]);
+    expect(reloaded.inventoryState().issues).toEqual([]);
+  });
+
+  test("list still returns valid records when the registry contains anomalies", async () => {
+    const projectDir = path.join(storagePath, "tmp-project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await storage.applySnapshot(createManagedAgent({ id: "valid-agent", cwd: "/tmp/project" }));
+    const extraPath = path.join(projectDir, "extra.txt");
+    await fs.writeFile(extraPath, "not a record", "utf8");
+
+    const reloaded = new AgentStorage(storagePath, logger);
+    const records = await reloaded.list();
+    expect(records.map((record) => record.id)).toContain("valid-agent");
+
+    const state = reloaded.inventoryState();
+    expect(state.issues).toContainEqual({
+      path: extraPath,
+      reason: "unreadable_path",
+    });
+  });
 });

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import os from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { promises as fs } from "node:fs";
 
@@ -48,6 +49,25 @@ function buildManagedAgentConfig(
     config.featureValues = configOverrides.featureValues;
   }
   return config;
+}
+
+async function registryTreeHash(root: string): Promise<string> {
+  const hash = createHash("sha256");
+  async function visit(directory: string, relative = ""): Promise<void> {
+    const children = await fs.readdir(directory, { withFileTypes: true });
+    for (const child of children.sort((left, right) => (left.name < right.name ? -1 : 1))) {
+      const childRelative = path.join(relative, child.name);
+      const childPath = path.join(directory, child.name);
+      hash.update(`${child.isDirectory() ? "d" : "f"}\u0000${childRelative}\u0000`);
+      if (child.isDirectory()) {
+        await visit(childPath, childRelative);
+      } else {
+        hash.update(await fs.readFile(childPath));
+      }
+    }
+  }
+  await visit(root);
+  return hash.digest("hex");
 }
 
 function buildDefaultCapabilities() {
@@ -145,6 +165,7 @@ describe("AgentStorage", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -612,5 +633,75 @@ describe("AgentStorage", () => {
         { path: expect.any(String), reason: "duplicate_agent_id" },
       ]),
     );
+  });
+
+  test("inventoryState reports an unreadable root but tolerates an absent root", async () => {
+    await fs.writeFile(storagePath, "not a directory", "utf8");
+    const unreadable = new AgentStorage(storagePath, logger);
+    await unreadable.initialize();
+    expect(unreadable.inventoryState().issues).toEqual([
+      { path: storagePath, reason: "unreadable_path" },
+    ]);
+
+    const absent = new AgentStorage(path.join(tmpDir, "does-not-exist"), logger);
+    await absent.initialize();
+    expect(absent.inventoryState()).toEqual({ records: [], issues: [] });
+  });
+
+  test("inventoryState reports an unreadable nested registry path", async () => {
+    const projectDir = path.join(storagePath, "tmp-project");
+    await fs.mkdir(projectDir, { recursive: true });
+    const realReaddir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+      if (args[0] === projectDir) {
+        const error = new Error("permission denied") as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      }
+      return realReaddir(...args);
+    });
+
+    await storage.initialize();
+
+    expect(storage.inventoryState().issues).toContainEqual({
+      path: projectDir,
+      reason: "unreadable_path",
+    });
+  });
+
+  test("inventoryState reports an unreadable record without modifying it", async () => {
+    const projectDir = path.join(storagePath, "tmp-project");
+    const recordPath = path.join(projectDir, "unreadable.json");
+    await fs.mkdir(projectDir, { recursive: true });
+    const original = JSON.stringify({ invalid: true });
+    await fs.writeFile(recordPath, original, "utf8");
+    const realReadFile = fs.readFile;
+    vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      if (args[0] === recordPath) {
+        const error = new Error("permission denied") as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      }
+      return realReadFile(...args);
+    });
+
+    await storage.initialize();
+
+    expect(storage.inventoryState().issues).toContainEqual({
+      path: recordPath,
+      reason: "unreadable_path",
+    });
+    vi.restoreAllMocks();
+    expect(await fs.readFile(recordPath, "utf8")).toBe(original);
+  });
+
+  test("inventoryState is read-only and preserves the registry tree hash", async () => {
+    await storage.applySnapshot(createManagedAgent({ id: "read-only-agent" }));
+    const before = await registryTreeHash(storagePath);
+
+    await storage.initialize();
+    storage.inventoryState();
+
+    expect(await registryTreeHash(storagePath)).toBe(before);
   });
 });

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -152,6 +152,18 @@ function createManagedAgent(overrides: ManagedAgentOverrides = {}): ManagedAgent
   };
 }
 
+function persistedRecord(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    provider: "codex",
+    cwd: `/tmp/${id}`,
+    createdAt: "2026-08-13T00:00:00.000Z",
+    updatedAt: "2026-08-13T00:00:00.000Z",
+    lastStatus: "idle",
+    ...overrides,
+  };
+}
+
 describe("AgentStorage", () => {
   let tmpDir: string;
   let storagePath: string;
@@ -888,5 +900,225 @@ describe("AgentStorage", () => {
       path: extraPath,
       reason: "unreadable_path",
     });
+  });
+
+  test("inventoryFreshState sees a valid record written after startup and rejects a later unknown entry", async () => {
+    await storage.initialize();
+    const lateDir = path.join(storagePath, "late-project");
+    const latePath = path.join(lateDir, "late-agent.json");
+    await fs.mkdir(lateDir, { recursive: true });
+    await fs.writeFile(latePath, JSON.stringify(persistedRecord("late-agent")), "utf8");
+
+    await expect(storage.inventoryFreshState()).resolves.toMatchObject({
+      records: [expect.objectContaining({ id: "late-agent" })],
+      issues: [],
+    });
+
+    const unexpected = path.join(storagePath, "unexpected.unknown");
+    await fs.writeFile(unexpected, "unexpected", "utf8");
+    await expect(storage.inventoryFreshState()).resolves.toMatchObject({
+      records: expect.any(Array),
+      issues: expect.arrayContaining([
+        expect.objectContaining({ path: unexpected, reason: "unreadable_path" }),
+      ]),
+    });
+  });
+
+  test("inventoryFreshState fails closed when a valid file appears during its verified scan", async () => {
+    const projectDir = path.join(storagePath, "project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, "existing.json"),
+      JSON.stringify(persistedRecord("existing")),
+      "utf8",
+    );
+    const lateDir = path.join(storagePath, "late-project");
+    const realReaddir = fs.readdir;
+    let rootReads = 0;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+      if (args[0] === storagePath && ++rootReads === 2) {
+        await fs.mkdir(lateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(lateDir, "late.json"),
+          JSON.stringify(persistedRecord("late")),
+          "utf8",
+        );
+      }
+      return realReaddir(...args);
+    });
+
+    const state = await storage.inventoryFreshState();
+    expect(state).toEqual({
+      records: [],
+      issues: [{ path: storagePath, reason: "registry_changed" }],
+    });
+  });
+
+  test("inventoryFreshState fails closed when a listed record disappears during the scan", async () => {
+    const projectDir = path.join(storagePath, "project");
+    const recordPath = path.join(projectDir, "agent.json");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(recordPath, JSON.stringify(persistedRecord("agent")), "utf8");
+    const realReadFile = fs.readFile;
+    let intercepted = false;
+    vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      if (args[0] === recordPath && !intercepted) {
+        intercepted = true;
+        await fs.unlink(recordPath);
+      }
+      return realReadFile(...args);
+    });
+
+    const state = await storage.inventoryFreshState();
+    expect(state.issues).toContainEqual({ path: recordPath, reason: "registry_changed" });
+  });
+
+  test("inventoryFreshState fails closed when record content changes during the scan", async () => {
+    const projectDir = path.join(storagePath, "project");
+    const recordPath = path.join(projectDir, "agent.json");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(recordPath, JSON.stringify(persistedRecord("agent")), "utf8");
+    const realReadFile = fs.readFile;
+    let intercepted = false;
+    vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      if (args[0] === recordPath && !intercepted) {
+        intercepted = true;
+        const original = await realReadFile(...args);
+        await fs.writeFile(
+          recordPath,
+          JSON.stringify(persistedRecord("agent", { lastStatus: "error" })),
+          "utf8",
+        );
+        return original;
+      }
+      return realReadFile(...args);
+    });
+
+    const state = await storage.inventoryFreshState();
+    expect(state.issues).toContainEqual({ path: recordPath, reason: "registry_changed" });
+  });
+
+  test("inventoryFreshState fails closed when a listed record is replaced during the scan", async () => {
+    const projectDir = path.join(storagePath, "project");
+    const recordPath = path.join(projectDir, "agent.json");
+    const replacementPath = path.join(projectDir, "replacement.json");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(recordPath, JSON.stringify(persistedRecord("agent")), "utf8");
+    await fs.writeFile(replacementPath, JSON.stringify(persistedRecord("replacement")), "utf8");
+    const realReadFile = fs.readFile;
+    let intercepted = false;
+    vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      if (args[0] === recordPath && !intercepted) {
+        intercepted = true;
+        await fs.rename(replacementPath, recordPath);
+      }
+      return realReadFile(...args);
+    });
+
+    const state = await storage.inventoryFreshState();
+    expect(state.issues).toContainEqual({ path: recordPath, reason: "registry_changed" });
+  });
+
+  test("inventoryFreshState fails closed when a project directory disappears and reappears", async () => {
+    const projectDir = path.join(storagePath, "project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, "agent.json"),
+      JSON.stringify(persistedRecord("agent")),
+      "utf8",
+    );
+    const realReaddir = fs.readdir;
+    let intercepted = false;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+      if (args[0] === projectDir && !intercepted) {
+        intercepted = true;
+        await fs.rm(projectDir, { recursive: true, force: true });
+        await fs.mkdir(projectDir, { recursive: true });
+      }
+      return realReaddir(...args);
+    });
+
+    const state = await storage.inventoryFreshState();
+    expect(state).toEqual({
+      records: [],
+      issues: [{ path: storagePath, reason: "registry_changed" }],
+    });
+  });
+
+  test("inventoryFreshState fails closed when a project directory changes type during the scan", async () => {
+    const projectDir = path.join(storagePath, "project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, "agent.json"),
+      JSON.stringify(persistedRecord("agent")),
+      "utf8",
+    );
+    const realReaddir = fs.readdir;
+    let intercepted = false;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+      if (args[0] === projectDir && !intercepted) {
+        intercepted = true;
+        await fs.rm(projectDir, { recursive: true, force: true });
+        await fs.writeFile(projectDir, "no longer a directory", "utf8");
+      }
+      return realReaddir(...args);
+    });
+
+    const state = await storage.inventoryFreshState();
+    expect(state.issues).toContainEqual({ path: projectDir, reason: "unreadable_path" });
+  });
+
+  test("inventoryFreshState fails closed when an unknown entry appears during the scan", async () => {
+    const projectDir = path.join(storagePath, "project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, "agent.json"),
+      JSON.stringify(persistedRecord("agent")),
+      "utf8",
+    );
+    const unexpected = path.join(storagePath, "unexpected.unknown");
+    const realReaddir = fs.readdir;
+    let rootReads = 0;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+      if (args[0] === storagePath && ++rootReads === 2) {
+        await fs.writeFile(unexpected, "unexpected", "utf8");
+      }
+      return realReaddir(...args);
+    });
+
+    const state = await storage.inventoryFreshState();
+    expect(state.issues).toContainEqual({ path: unexpected, reason: "unreadable_path" });
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "inventoryFreshState fails closed when a regular record becomes a symlink during the scan",
+    async () => {
+      const projectDir = path.join(storagePath, "project");
+      const recordPath = path.join(projectDir, "agent.json");
+      const targetPath = path.join(tmpDir, "outside.json");
+      await fs.mkdir(projectDir, { recursive: true });
+      await fs.writeFile(recordPath, JSON.stringify(persistedRecord("agent")), "utf8");
+      await fs.writeFile(targetPath, JSON.stringify(persistedRecord("outside")), "utf8");
+      const realReadFile = fs.readFile;
+      let intercepted = false;
+      vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+        if (args[0] === recordPath && !intercepted) {
+          intercepted = true;
+          await fs.unlink(recordPath);
+          await fs.symlink(targetPath, recordPath);
+        }
+        return realReadFile(...args);
+      });
+
+      const state = await storage.inventoryFreshState();
+      expect(state.issues).toContainEqual({ path: recordPath, reason: "registry_changed" });
+    },
+  );
+
+  test("inventoryFreshState is read-only and preserves the registry tree hash", async () => {
+    await storage.applySnapshot(createManagedAgent({ id: "fresh-read-only-agent" }));
+    const before = await registryTreeHash(storagePath);
+    await storage.inventoryFreshState();
+    expect(await registryTreeHash(storagePath)).toBe(before);
   });
 });

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -1121,4 +1121,119 @@ describe("AgentStorage", () => {
     await storage.inventoryFreshState();
     expect(await registryTreeHash(storagePath)).toBe(before);
   });
+
+  test("writeRecord creates atomic temp files outside the registry scope", async () => {
+    await storage.initialize();
+    const paseoHome = path.dirname(storagePath);
+    const atomicTempDir = path.join(paseoHome, ".tmp", "atomic");
+    const realWriteFile = fs.writeFile;
+    const observedTempPaths: string[] = [];
+
+    const writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      if (typeof args[0] === "string" && args[0].startsWith(atomicTempDir)) {
+        observedTempPaths.push(args[0]);
+      }
+      return realWriteFile(...args);
+    });
+
+    await storage.applySnapshot(createManagedAgent({ id: "temp-location-agent" }));
+    writeFileSpy.mockRestore();
+
+    expect(observedTempPaths.length).toBeGreaterThan(0);
+    for (const tempPath of observedTempPaths) {
+      expect(tempPath.startsWith(atomicTempDir)).toBe(true);
+      expect(tempPath.startsWith(storagePath)).toBe(false);
+    }
+  });
+
+  test("writeRecord cleans up temp files on rename failure", async () => {
+    await storage.initialize();
+    const paseoHome = path.dirname(storagePath);
+    const atomicTempDir = path.join(paseoHome, ".tmp", "atomic");
+    const realRename = fs.rename;
+    let tempFilePath: string | null = null;
+
+    const writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      if (typeof args[0] === "string" && args[0].startsWith(atomicTempDir)) {
+        tempFilePath = args[0];
+      }
+      return realWriteFile(...args);
+    });
+
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+      if (tempFilePath !== null && args[0] === tempFilePath) {
+        throw new Error("injected rename failure");
+      }
+      return realRename(...args);
+    });
+
+    await expect(
+      storage.applySnapshot(createManagedAgent({ id: "failing-agent" })),
+    ).rejects.toThrow();
+
+    writeFileSpy.mockRestore();
+    renameSpy.mockRestore();
+
+    expect(tempFilePath).not.toBeNull();
+    await expect(fs.access(tempFilePath!)).rejects.toThrow();
+    const registryEntries = await fs.readdir(storagePath, { withFileTypes: true });
+    const tempInRegistry = registryEntries.filter((entry) => entry.name.endsWith(".tmp"));
+    expect(tempInRegistry).toHaveLength(0);
+  });
+
+  test("inventoryFreshState is stable while an applySnapshot atomic write is in progress", async () => {
+    await storage.initialize();
+    type InventoryFreshResult = Awaited<ReturnType<AgentStorage["inventoryFreshState"]>>;
+    const paseoHome = path.dirname(storagePath);
+    const atomicTempDir = path.join(paseoHome, ".tmp", "atomic");
+    const realWriteFile = fs.writeFile;
+    let inventoryResult: InventoryFreshResult | null = null;
+
+    const writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      const [filePath] = args;
+      if (typeof filePath === "string" && filePath.startsWith(atomicTempDir)) {
+        const result = await realWriteFile(...args);
+        inventoryResult = await storage.inventoryFreshState();
+        return result;
+      }
+      return realWriteFile(...args);
+    });
+
+    await storage.applySnapshot(createManagedAgent({ id: "concurrent-apply-agent" }));
+    writeFileSpy.mockRestore();
+
+    expect(inventoryResult).not.toBeNull();
+    expect(inventoryResult!.issues).toEqual([]);
+
+    const after = await storage.inventoryFreshState();
+    expect(after.issues).toEqual([]);
+    expect(after.records.map((record) => record.id)).toContain("concurrent-apply-agent");
+  });
+
+  test("inventoryFreshState is stable while an upsert atomic write is in progress", async () => {
+    await storage.applySnapshot(createManagedAgent({ id: "existing-upsert" }));
+    type InventoryFreshResult = Awaited<ReturnType<AgentStorage["inventoryFreshState"]>>;
+    const paseoHome = path.dirname(storagePath);
+    const atomicTempDir = path.join(paseoHome, ".tmp", "atomic");
+    const realWriteFile = fs.writeFile;
+    let inventoryResult: InventoryFreshResult | null = null;
+
+    const writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      const [filePath] = args;
+      if (typeof filePath === "string" && filePath.startsWith(atomicTempDir)) {
+        const result = await realWriteFile(...args);
+        inventoryResult = await storage.inventoryFreshState();
+        return result;
+      }
+      return realWriteFile(...args);
+    });
+
+    const existingRecord = await storage.get("existing-upsert");
+    expect(existingRecord).not.toBeNull();
+    await storage.upsert({ ...existingRecord!, title: "Updated title" });
+    writeFileSpy.mockRestore();
+
+    expect(inventoryResult).not.toBeNull();
+    expect(inventoryResult!.issues).toEqual([]);
+  });
 });

--- a/packages/server/src/server/agent/agent-storage.test.ts
+++ b/packages/server/src/server/agent/agent-storage.test.ts
@@ -575,4 +575,42 @@ describe("AgentStorage", () => {
     const after = await afterReload.list();
     expect(after.some((r) => r.id === agentId)).toBe(false);
   });
+
+  test("inventoryState reports malformed persisted records instead of silently omitting them", async () => {
+    const projectDir = path.join(storagePath, "tmp-project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(path.join(projectDir, "broken.json"), "{not json", "utf8");
+
+    await storage.initialize();
+
+    expect(storage.inventoryState()).toEqual({
+      records: [],
+      issues: [{ path: path.join(projectDir, "broken.json"), reason: "malformed_record" }],
+    });
+  });
+
+  test("inventoryState reports duplicate persisted agent identities", async () => {
+    await storage.applySnapshot(
+      createManagedAgent({ id: "duplicate-agent", cwd: "/tmp/project-a" }),
+    );
+    const stored = await storage.get("duplicate-agent");
+    expect(stored).not.toBeNull();
+
+    const projectDir = path.join(storagePath, "tmp-project-b");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, "duplicate-agent.json"),
+      JSON.stringify({ ...stored, cwd: "/tmp/project-b" }),
+      "utf8",
+    );
+
+    const reloaded = new AgentStorage(storagePath, logger);
+    await reloaded.initialize();
+    expect(reloaded.inventoryState().issues).toEqual(
+      expect.arrayContaining([
+        { path: expect.any(String), reason: "duplicate_agent_id" },
+        { path: expect.any(String), reason: "duplicate_agent_id" },
+      ]),
+    );
+  });
 });

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -246,8 +246,10 @@ export class AgentStorage {
     const agentId = record.id;
     const nextPath = this.buildRecordPath(record);
     const previousPath = this.pathById.get(agentId);
+    const paseoHome = path.dirname(this.baseDir);
+    const tempDir = path.join(paseoHome, ".tmp", "atomic");
 
-    await writeJsonFileAtomic(nextPath, record);
+    await writeJsonFileAtomic(nextPath, record, tempDir);
     this.addIndexedPath(agentId, nextPath);
 
     if (previousPath && previousPath !== nextPath) {

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -94,6 +94,11 @@ export function parseStoredAgentRecord(value: unknown): StoredAgentRecord {
   return STORED_AGENT_SCHEMA.parse(value);
 }
 
+export interface InventoryRegistryIssue {
+  path: string;
+  reason: "malformed_record" | "duplicate_agent_id";
+}
+
 export class AgentStorage {
   private cache: Map<string, StoredAgentRecord> = new Map();
   private pathById: Map<string, string> = new Map();
@@ -103,6 +108,7 @@ export class AgentStorage {
   private daemonAgentIdsByExecution: Map<string, string> = new Map();
   private daemonExecutionKeysByAgentId: Map<string, string> = new Map();
   private loaded = false;
+  private inventoryIssues: InventoryRegistryIssue[] = [];
   private baseDir: string;
   private loadPromise: Promise<StoredAgentRecord[]> | null = null;
   private logger: Logger;
@@ -119,6 +125,23 @@ export class AgentStorage {
   async list(): Promise<StoredAgentRecord[]> {
     await this.load();
     return Array.from(this.cache.values());
+  }
+
+  /**
+   * The inventory RPC reads this synchronous view together with AgentManager's
+   * in-memory map. Once bootstrap has initialized storage, no await occurs
+   * between those reads, giving the materializer one event-loop turn over the
+   * canonical registry state. Invalid or duplicate on-disk records are never
+   * silently omitted from a complete inventory claim.
+   */
+  inventoryState(): { records: StoredAgentRecord[]; issues: InventoryRegistryIssue[] } {
+    if (!this.loaded) {
+      throw new Error("Agent storage is not initialized");
+    }
+    return {
+      records: Array.from(this.cache.values()),
+      issues: this.inventoryIssues.map((issue) => ({ ...issue })),
+    };
   }
 
   async get(agentId: string): Promise<StoredAgentRecord | null> {
@@ -297,6 +320,7 @@ export class AgentStorage {
     this.pathsById.clear();
     this.daemonAgentIdsByExecution.clear();
     this.daemonExecutionKeysByAgentId.clear();
+    this.inventoryIssues = [];
 
     try {
       const records = await this.scanDisk();
@@ -354,9 +378,20 @@ export class AgentStorage {
       }),
     );
 
+    const recordPathById = new Map<string, string>();
     for (const item of loaded) {
       if (!item) continue;
       const { record, filePath } = item;
+      const previousPath = recordPathById.get(record.id);
+      if (previousPath) {
+        this.inventoryIssues.push({ path: filePath, reason: "duplicate_agent_id" });
+        this.inventoryIssues.push({ path: previousPath, reason: "duplicate_agent_id" });
+        // Keep the duplicate path indexed for remove(), even though a complete
+        // inventory correctly fails rather than selecting one arbitrarily.
+        this.addIndexedPath(record.id, filePath);
+        continue;
+      }
+      recordPathById.set(record.id, filePath);
       records.push(record);
       this.cache.set(record.id, record);
       this.indexOwner(record);
@@ -374,6 +409,7 @@ export class AgentStorage {
       return parseStoredAgentRecord(parsed);
     } catch (error) {
       this.logger.error({ err: error, filePath }, "Skipping invalid agent record");
+      this.inventoryIssues.push({ path: filePath, reason: "malformed_record" });
       return null;
     }
   }

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -96,7 +96,7 @@ export function parseStoredAgentRecord(value: unknown): StoredAgentRecord {
 
 export interface InventoryRegistryIssue {
   path: string;
-  reason: "malformed_record" | "duplicate_agent_id";
+  reason: "malformed_record" | "duplicate_agent_id" | "unreadable_path";
 }
 
 export class AgentStorage {
@@ -332,6 +332,7 @@ export class AgentStorage {
         return [];
       }
       this.logger.error({ err: error }, "Failed to load agents");
+      this.inventoryIssues.push({ path: this.baseDir, reason: "unreadable_path" });
       this.loaded = true;
       return [];
     }
@@ -364,7 +365,12 @@ export class AgentStorage {
           return files
             .filter((file) => file.isFile() && file.name.endsWith(".json"))
             .map((file) => path.join(projectDir, file.name));
-        } catch {
+        } catch (error) {
+          // The directory was observed in the root listing. Even ENOENT now
+          // means a record could have vanished during this scan, so inventory
+          // must fail closed rather than assert completeness over a subset.
+          this.logger.error({ err: error, projectDir }, "Failed to scan agent registry directory");
+          this.inventoryIssues.push({ path: projectDir, reason: "unreadable_path" });
           return [];
         }
       }),
@@ -403,8 +409,18 @@ export class AgentStorage {
   }
 
   private async readRecordFile(filePath: string): Promise<StoredAgentRecord | null> {
+    let content: string;
     try {
-      const content = await fs.readFile(filePath, "utf8");
+      content = await fs.readFile(filePath, "utf8");
+    } catch (error) {
+      // This file was observed in a directory listing. Its disappearance is
+      // not equivalent to an absent registry root: it may hide one inventory
+      // identity, so preserve legacy list behavior but fail inventory closed.
+      this.logger.error({ err: error, filePath }, "Failed to read agent record");
+      this.inventoryIssues.push({ path: filePath, reason: "unreadable_path" });
+      return null;
+    }
+    try {
       const parsed = JSON.parse(content);
       return parseStoredAgentRecord(parsed);
     } catch (error) {

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -1,4 +1,5 @@
-import { promises as fs, type Dirent } from "node:fs";
+import { createHash } from "node:crypto";
+import { promises as fs, type Dirent, type Stats } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 import type { Logger } from "pino";
@@ -96,7 +97,16 @@ export function parseStoredAgentRecord(value: unknown): StoredAgentRecord {
 
 export interface InventoryRegistryIssue {
   path: string;
-  reason: "malformed_record" | "duplicate_agent_id" | "unreadable_path";
+  reason: "malformed_record" | "duplicate_agent_id" | "unreadable_path" | "registry_changed";
+}
+
+interface InventoryRegistryState {
+  records: StoredAgentRecord[];
+  issues: InventoryRegistryIssue[];
+}
+
+interface InventoryRegistryScan extends InventoryRegistryState {
+  manifest: string[];
 }
 
 export class AgentStorage {
@@ -142,6 +152,31 @@ export class AgentStorage {
       records: Array.from(this.cache.values()),
       issues: this.inventoryIssues.map((issue) => ({ ...issue })),
     };
+  }
+
+  /**
+   * Reads the registry from disk for a new inventory snapshot. This intentionally
+   * bypasses the startup cache used by legacy/UI callers. Two complete manifests
+   * must match, otherwise an external filesystem mutation has invalidated the
+   * materialization point and inventory fails closed.
+   */
+  async inventoryFreshState(): Promise<InventoryRegistryState> {
+    const before = await this.scanInventoryRegistry();
+    if (before.issues.length > 0) {
+      return before;
+    }
+    const after = await this.scanInventoryRegistry();
+    if (after.issues.length > 0) {
+      return after;
+    }
+    if (!sameManifest(before.manifest, after.manifest)) {
+      this.logger.warn("Agent registry changed during inventory scan");
+      return {
+        records: [],
+        issues: [{ path: this.baseDir, reason: "registry_changed" }],
+      };
+    }
+    return { records: after.records, issues: [] };
   }
 
   async get(agentId: string): Promise<StoredAgentRecord | null> {
@@ -369,6 +404,189 @@ export class AgentStorage {
     return "rejected";
   }
 
+  private async scanInventoryRegistry(): Promise<InventoryRegistryScan> {
+    const issues: InventoryRegistryIssue[] = [];
+    const manifest: string[] = [];
+    const root = await this.inspectInventoryPath(this.baseDir, "root", manifest, issues, true);
+    if (root === "absent") {
+      return { records: [], issues, manifest };
+    }
+    if (root !== "directory") {
+      return { records: [], issues, manifest };
+    }
+
+    const rootEntries = await this.readInventoryDirectory(this.baseDir, "root", manifest, issues);
+    const recordPaths: string[] = [];
+    const projectDirs: string[] = [];
+    for (const entry of rootEntries) {
+      const entryPath = path.join(this.baseDir, entry.name);
+      const kind = await this.inspectInventoryPath(entryPath, "root", manifest, issues);
+      if (kind === "directory") {
+        projectDirs.push(entryPath);
+      } else if (kind === "record") {
+        recordPaths.push(entryPath);
+      }
+    }
+
+    for (const projectDir of projectDirs.sort(comparePathCodeUnits)) {
+      const projectEntries = await this.readInventoryDirectory(
+        projectDir,
+        "project",
+        manifest,
+        issues,
+      );
+      for (const entry of projectEntries) {
+        const entryPath = path.join(projectDir, entry.name);
+        if (
+          (await this.inspectInventoryPath(entryPath, "project", manifest, issues)) === "record"
+        ) {
+          recordPaths.push(entryPath);
+        }
+      }
+    }
+
+    const records: StoredAgentRecord[] = [];
+    const recordPathById = new Map<string, string>();
+    for (const recordPath of recordPaths.sort(comparePathCodeUnits)) {
+      const record = await this.readStableInventoryRecord(recordPath, manifest, issues);
+      if (!record) continue;
+      const previousPath = recordPathById.get(record.id);
+      if (previousPath) {
+        issues.push({ path: previousPath, reason: "duplicate_agent_id" });
+        issues.push({ path: recordPath, reason: "duplicate_agent_id" });
+        continue;
+      }
+      recordPathById.set(record.id, recordPath);
+      records.push(record);
+    }
+
+    manifest.sort(comparePathCodeUnits);
+    return { records, issues, manifest };
+  }
+
+  private async readInventoryDirectory(
+    directory: string,
+    context: "root" | "project",
+    manifest: string[],
+    issues: InventoryRegistryIssue[],
+  ): Promise<Dirent[]> {
+    try {
+      const entries = await fs.readdir(directory, { withFileTypes: true });
+      manifest.push(
+        `directory:${directory}:${entries
+          .map((entry) => entry.name)
+          .sort(comparePathCodeUnits)
+          .join("\u0000")}`,
+      );
+      return entries.sort((left, right) => comparePathCodeUnits(left.name, right.name));
+    } catch (error) {
+      this.logger.warn(
+        { err: error, directory, context },
+        "Failed to scan inventory registry directory",
+      );
+      issues.push({
+        path: directory,
+        reason:
+          (error as NodeJS.ErrnoException).code === "ENOENT"
+            ? "registry_changed"
+            : "unreadable_path",
+      });
+      return [];
+    }
+  }
+
+  private async inspectInventoryPath(
+    entryPath: string,
+    context: "root" | "project",
+    manifest: string[],
+    issues: InventoryRegistryIssue[],
+    allowAbsent = false,
+  ): Promise<"absent" | "directory" | "record" | "rejected"> {
+    let stats: Stats;
+    try {
+      stats = await fs.lstat(entryPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT" && allowAbsent) {
+        manifest.push(`absent:${entryPath}`);
+        return "absent";
+      }
+      this.logger.warn(
+        { err: error, entryPath, context },
+        "Failed to inspect inventory registry path",
+      );
+      issues.push({
+        path: entryPath,
+        reason:
+          (error as NodeJS.ErrnoException).code === "ENOENT"
+            ? "registry_changed"
+            : "unreadable_path",
+      });
+      return "rejected";
+    }
+    manifest.push(`path:${entryPath}:${inventoryPathFingerprint(stats)}`);
+    if (stats.isSymbolicLink()) {
+      issues.push({ path: entryPath, reason: "unreadable_path" });
+      return "rejected";
+    }
+    if (stats.isDirectory()) {
+      if (context === "project") {
+        issues.push({ path: entryPath, reason: "unreadable_path" });
+        return "rejected";
+      }
+      return "directory";
+    }
+    if (stats.isFile() && entryPath.endsWith(".json")) {
+      return "record";
+    }
+    issues.push({ path: entryPath, reason: "unreadable_path" });
+    return "rejected";
+  }
+
+  private async readStableInventoryRecord(
+    filePath: string,
+    manifest: string[],
+    issues: InventoryRegistryIssue[],
+  ): Promise<StoredAgentRecord | null> {
+    let before: Stats;
+    let content: string;
+    let after: Stats;
+    try {
+      before = await fs.lstat(filePath);
+      if (!before.isFile() || before.isSymbolicLink()) {
+        issues.push({ path: filePath, reason: "registry_changed" });
+        return null;
+      }
+      content = await fs.readFile(filePath, "utf8");
+      after = await fs.lstat(filePath);
+    } catch (error) {
+      this.logger.warn({ err: error, filePath }, "Failed to read inventory registry record");
+      issues.push({
+        path: filePath,
+        reason:
+          (error as NodeJS.ErrnoException).code === "ENOENT"
+            ? "registry_changed"
+            : "unreadable_path",
+      });
+      return null;
+    }
+    if (
+      !after.isFile() ||
+      after.isSymbolicLink() ||
+      inventoryPathFingerprint(before) !== inventoryPathFingerprint(after)
+    ) {
+      issues.push({ path: filePath, reason: "registry_changed" });
+      return null;
+    }
+    manifest.push(`content:${filePath}:${createHash("sha256").update(content).digest("hex")}`);
+    try {
+      return parseStoredAgentRecord(JSON.parse(content));
+    } catch (error) {
+      this.logger.warn({ err: error, filePath }, "Invalid inventory registry record");
+      issues.push({ path: filePath, reason: "malformed_record" });
+      return null;
+    }
+  }
+
   private async scanDisk(): Promise<StoredAgentRecord[]> {
     const records: StoredAgentRecord[] = [];
     let entries: Dirent[] = [];
@@ -519,6 +737,20 @@ export class AgentStorage {
   private async waitForPendingWrite(agentId: string): Promise<void> {
     await (this.pendingWrites.get(agentId) ?? Promise.resolve()).catch(() => undefined);
   }
+}
+
+function inventoryPathFingerprint(stats: Stats): string {
+  return [stats.dev, stats.ino, stats.mode, stats.size, stats.mtimeMs, stats.ctimeMs].join(":");
+}
+
+function sameManifest(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+function comparePathCodeUnits(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }
 
 function projectDirNameFromCwd(cwd: string): string {

--- a/packages/server/src/server/agent/agent-storage.ts
+++ b/packages/server/src/server/agent/agent-storage.ts
@@ -338,6 +338,37 @@ export class AgentStorage {
     }
   }
 
+  private classifyDirent(
+    entry: Dirent,
+    entryPath: string,
+    context: "root" | "project",
+  ): "directory" | "record" | "rejected" {
+    if (entry.isSymbolicLink()) {
+      this.logger.warn({ path: entryPath, context }, "Symbolic link in agent registry");
+      this.inventoryIssues.push({ path: entryPath, reason: "unreadable_path" });
+      return "rejected";
+    }
+    if (entry.isDirectory()) {
+      if (context === "project") {
+        this.logger.warn({ path: entryPath }, "Nested directory in agent project directory");
+        this.inventoryIssues.push({ path: entryPath, reason: "unreadable_path" });
+        return "rejected";
+      }
+      return "directory";
+    }
+    if (entry.isFile()) {
+      if (entry.name.endsWith(".json")) {
+        return "record";
+      }
+      this.logger.warn({ path: entryPath, context }, "Unexpected file in agent registry");
+      this.inventoryIssues.push({ path: entryPath, reason: "unreadable_path" });
+      return "rejected";
+    }
+    this.logger.warn({ path: entryPath, context }, "Unexpected entry in agent registry");
+    this.inventoryIssues.push({ path: entryPath, reason: "unreadable_path" });
+    return "rejected";
+  }
+
   private async scanDisk(): Promise<StoredAgentRecord[]> {
     const records: StoredAgentRecord[] = [];
     let entries: Dirent[] = [];
@@ -350,21 +381,32 @@ export class AgentStorage {
       throw error;
     }
 
-    const rootRecordPaths = entries
-      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-      .map((entry) => path.join(this.baseDir, entry.name));
+    const rootRecordPaths: string[] = [];
+    const projectDirs: string[] = [];
 
-    const projectDirs = entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(this.baseDir, entry.name));
+    for (const entry of entries) {
+      const entryPath = path.join(this.baseDir, entry.name);
+      const kind = this.classifyDirent(entry, entryPath, "root");
+      if (kind === "directory") {
+        projectDirs.push(entryPath);
+      } else if (kind === "record") {
+        rootRecordPaths.push(entryPath);
+      }
+    }
 
     const projectFileLists = await Promise.all(
       projectDirs.map(async (projectDir) => {
         try {
           const files = await fs.readdir(projectDir, { withFileTypes: true });
-          return files
-            .filter((file) => file.isFile() && file.name.endsWith(".json"))
-            .map((file) => path.join(projectDir, file.name));
+          const projectRecordPaths: string[] = [];
+          for (const file of files) {
+            const filePath = path.join(projectDir, file.name);
+            const kind = this.classifyDirent(file, filePath, "project");
+            if (kind === "record") {
+              projectRecordPaths.push(filePath);
+            }
+          }
+          return projectRecordPaths;
         } catch (error) {
           // The directory was observed in the root listing. Even ENOENT now
           // means a record could have vanished during this scan, so inventory

--- a/packages/server/src/server/agent/inventory-snapshot-service.test.ts
+++ b/packages/server/src/server/agent/inventory-snapshot-service.test.ts
@@ -3,6 +3,9 @@ import {
   INVENTORY_SCHEMA_VERSION,
   InventorySnapshotError,
   InventorySnapshotService,
+  MAX_SNAPSHOTS_PER_DAEMON,
+  type InventorySnapshotRequest,
+  type InventorySnapshotServiceOptions,
   type InventorySessionEntry,
 } from "./inventory-snapshot-service.js";
 
@@ -18,6 +21,7 @@ function entry(
     archived: false,
     archived_at: null,
     internal: false,
+    live: false,
     cwd: `/worktree/${index}`,
     created_at: "2026-08-10T00:00:00.000Z",
     updated_at: "2026-08-10T00:00:00.000Z",
@@ -28,28 +32,29 @@ function entry(
 
 function serviceFor(
   entries: InventorySessionEntry[],
-  options?: { ttlMs?: number; now?: () => number },
+  options: InventorySnapshotServiceOptions = {},
 ) {
-  return new InventorySnapshotService(() => entries, options?.now, options?.ttlMs);
+  return new InventorySnapshotService(() => entries, options);
 }
 
-function allIds(
+function page(
   service: InventorySnapshotService,
-  limit: number,
-): {
-  snapshotId: string;
-  ids: string[];
-  cursors: string[];
-} {
-  let page = service.page({ limit });
-  const snapshotId = page.snapshot_id;
-  const ids = page.entries.map((item) => item.native_id);
+  request: InventorySnapshotRequest,
+  clientId = "client-a",
+) {
+  return service.page(request, clientId);
+}
+
+function allIds(service: InventorySnapshotService, limit: number) {
+  let result = page(service, { limit });
+  const snapshotId = result.snapshot_id;
+  const ids = result.entries.map((item) => item.native_id);
   const cursors: string[] = [];
-  while (page.has_more) {
-    expect(page.next_cursor).not.toBeNull();
-    cursors.push(page.next_cursor!);
-    page = service.page({ snapshot_id: snapshotId, cursor: page.next_cursor!, limit });
-    ids.push(...page.entries.map((item) => item.native_id));
+  while (result.has_more) {
+    expect(result.next_cursor).not.toBeNull();
+    cursors.push(result.next_cursor!);
+    result = page(service, { snapshot_id: snapshotId, cursor: result.next_cursor!, limit });
+    ids.push(...result.entries.map((item) => item.native_id));
   }
   return { snapshotId, ids, cursors };
 }
@@ -65,177 +70,239 @@ function expectErrorCode(action: () => unknown, code: InventorySnapshotError["co
 }
 
 describe("InventorySnapshotService", () => {
-  it.each([0, 1, 199, 200, 201, 401])(
-    "materializes %i sessions with a bounded deterministic page contract",
-    (count) => {
-      const result = allIds(
-        serviceFor(Array.from({ length: count }, (_, index) => entry(index))),
-        200,
-      );
-      expect(result.ids).toHaveLength(count);
-      expect(new Set(result.ids)).toHaveLength(count);
-      expect(result.ids).toEqual([...result.ids].sort());
-    },
-  );
+  it.each([0, 1, 199, 200, 201, 401])("materializes %i sessions", (count) => {
+    const result = allIds(
+      serviceFor(Array.from({ length: count }, (_, index) => entry(index))),
+      200,
+    );
+    expect(result.ids).toHaveLength(count);
+    expect(new Set(result.ids)).toHaveLength(count);
+    expect(result.ids).toEqual([...result.ids].sort());
+  });
 
-  it("returns three pages with every identity exactly once and no cursor loop", () => {
+  it("returns three pages with all identities exactly once and no cursor loop", () => {
     const result = allIds(serviceFor(Array.from({ length: 401 }, (_, index) => entry(index))), 200);
     expect(result.cursors).toHaveLength(2);
-    expect(new Set(result.cursors)).toHaveLength(result.cursors.length);
-    expect(result.ids).toHaveLength(401);
-    expect(new Set(result.ids)).toHaveLength(401);
+    expect(new Set(result.cursors)).toHaveLength(2);
   });
 
-  it("fails closed for a duplicate canonical identity", () => {
-    const service = serviceFor([entry(1), entry(1, { provider: "codex" })]);
-    expectErrorCode(() => service.page({}), "inventory_snapshot_conflict");
-  });
-
-  it("rejects a cursor supplied with a different snapshot", () => {
-    const source = [entry(1), entry(2), entry(3)];
-    const service = serviceFor(source);
-    const first = service.page({ limit: 1 });
-    source[0].status_raw = "running";
-    const secondSnapshot = service.page({ limit: 2 });
+  it("fails closed for duplicate or malformed canonical state", () => {
     expectErrorCode(
-      () =>
-        service.page({
-          snapshot_id: secondSnapshot.snapshot_id,
-          cursor: first.next_cursor!,
-          limit: 1,
-        }),
-      "inventory_cursor_snapshot_mismatch",
+      () => page(serviceFor([entry(1), entry(1)]), {}),
+      "inventory_snapshot_conflict",
+    );
+    expectErrorCode(
+      () => page(serviceFor([entry(1, { updated_at: "not-a-timestamp" })]), {}),
+      "inventory_snapshot_conflict",
     );
   });
 
-  it("rejects an expired snapshot", () => {
-    let now = 0;
-    const service = serviceFor([entry(1), entry(2)], { ttlMs: 10, now: () => now });
-    const first = service.page({ limit: 1 });
-    now = 11;
-    expectErrorCode(
-      () => service.page({ snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
-      "inventory_snapshot_expired",
-    );
-  });
-
-  it("keeps lifecycle mutations out of an existing snapshot", () => {
+  it("keeps creation, deletion, archive, and lifecycle mutations out of an existing snapshot", () => {
     const source = [entry(1), entry(2), entry(3)];
     const service = serviceFor(source);
-    const first = service.page({ limit: 1 });
-    source[1].status_raw = "closed";
-    source[1].archived = true;
-    source[1].archived_at = "2026-08-10T00:01:00.000Z";
-    const second = service.page({
-      snapshot_id: first.snapshot_id,
-      cursor: first.next_cursor!,
-      limit: 2,
-    });
-    expect(second.entries[0]).toMatchObject({ native_id: "session-0002", status_raw: "idle" });
-  });
-
-  it("keeps deleted records in an existing snapshot", () => {
-    const source = [entry(1), entry(2), entry(3)];
-    const service = serviceFor(source);
-    const first = service.page({ limit: 1 });
+    const first = page(service, { limit: 1 });
     source.splice(1, 1);
-    const second = service.page({
+    source.push(
+      entry(4, { status_raw: "closed", archived: true, archived_at: "2026-08-10T00:01:00.000Z" }),
+    );
+    const second = page(service, {
       snapshot_id: first.snapshot_id,
       cursor: first.next_cursor!,
-      limit: 2,
+      limit: 3,
     });
     expect(second.entries.map((item) => item.native_id)).toEqual(["session-0002", "session-0003"]);
   });
 
-  it("does not add newly created records to an existing snapshot", () => {
-    const source = [entry(1), entry(3)];
-    const service = serviceFor(source);
-    const first = service.page({ limit: 1 });
-    source.push(entry(2));
-    const second = service.page({
-      snapshot_id: first.snapshot_id,
-      cursor: first.next_cursor!,
-      limit: 2,
-    });
-    expect(second.entries.map((item) => item.native_id)).toEqual(["session-0003"]);
-  });
-
-  it("includes archived, internal, and unavailable-provider records instead of filtering them", () => {
-    const service = serviceFor([
-      entry(1, { status_raw: "running" }),
-      entry(2, {
-        status_raw: "closed",
-        archived: true,
-        archived_at: "2026-08-10T00:01:00.000Z",
-      }),
-      entry(3, { provider: "unavailable-provider", internal: true, status_raw: "error" }),
-    ]);
-    const page = service.page({ limit: 200 });
-    expect(page.entries).toHaveLength(3);
-    expect(page.entries.map((item) => item.status_raw)).toEqual(["running", "closed", "error"]);
-    expect(page.entries[2]).toMatchObject({ provider: "unavailable-provider", internal: true });
-  });
-
-  it("replays the same snapshot and cursor deterministically", () => {
+  it("replays the same snapshot/cursor deterministically", () => {
     const service = serviceFor([entry(1), entry(2), entry(3)]);
-    const first = service.page({ limit: 1 });
-    const pageA = service.page({
-      snapshot_id: first.snapshot_id,
-      cursor: first.next_cursor!,
-      limit: 1,
-    });
-    const pageB = service.page({
-      snapshot_id: first.snapshot_id,
-      cursor: first.next_cursor!,
-      limit: 1,
-    });
-    expect(pageA).toEqual(pageB);
-    expect(pageA.schema_version).toBe(INVENTORY_SCHEMA_VERSION);
+    const first = page(service, { limit: 1 });
+    const replay = { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 };
+    expect(page(service, replay)).toEqual(page(service, replay));
   });
 
-  it("rejects invalid, incomplete, and forged cursors", () => {
-    const service = serviceFor([entry(1), entry(2)]);
-    const first = service.page({ limit: 1 });
-    for (const request of [
-      { snapshot_id: first.snapshot_id },
-      { cursor: first.next_cursor! },
-      { snapshot_id: first.snapshot_id, cursor: "not-a-cursor" },
-    ]) {
-      expect(() => service.page(request)).toThrow(InventorySnapshotError);
-    }
-  });
-
-  it("fails a cursor that would loop back to the first page", () => {
-    const service = serviceFor([entry(1), entry(2)]);
-    const first = service.page({ limit: 1 });
+  it("rejects forged, incomplete, foreign-snapshot, and looping cursors", () => {
+    const source = [entry(1), entry(2), entry(3)];
+    const service = serviceFor(source);
+    const first = page(service, { limit: 1 });
+    source[0].status_raw = "running";
+    const second = page(service, { limit: 1 });
+    expectErrorCode(
+      () =>
+        page(service, { snapshot_id: second.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
+      "invalid_inventory_cursor",
+    );
+    expect(() => page(service, { snapshot_id: first.snapshot_id })).toThrow(InventorySnapshotError);
+    expect(() => page(service, { cursor: first.next_cursor! })).toThrow(InventorySnapshotError);
+    expectErrorCode(
+      () => page(service, { snapshot_id: first.snapshot_id, cursor: "not-a-cursor" }),
+      "invalid_inventory_cursor",
+    );
     const loopCursor = (
-      service as unknown as { encodeCursor(snapshotId: string, offset: number): string }
+      service as unknown as { encodeCursor(id: string, offset: number): string }
     ).encodeCursor(first.snapshot_id, 0);
     expectErrorCode(
-      () => service.page({ snapshot_id: first.snapshot_id, cursor: loopCursor, limit: 1 }),
+      () => page(service, { snapshot_id: first.snapshot_id, cursor: loopCursor, limit: 1 }),
       "invalid_inventory_cursor",
     );
   });
 
-  it("fails closed for malformed canonical source state", () => {
-    const malformed = entry(1, { updated_at: "not-a-timestamp" });
-    expectErrorCode(() => serviceFor([malformed]).page({}), "inventory_snapshot_conflict");
+  it("expires snapshots but distinguishes eviction/daemon-restart from expiry", () => {
+    let now = 0;
+    const service = serviceFor([entry(1), entry(2)], { now: () => now, ttlMs: 10 });
+    const first = page(service, { limit: 1 });
+    now = 11;
+    expectErrorCode(
+      () => page(service, { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
+      "inventory_snapshot_expired",
+    );
+    const restarted = serviceFor([entry(1), entry(2)]);
+    expectErrorCode(
+      () =>
+        page(restarted, { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
+      "inventory_snapshot_not_found",
+    );
+  });
+
+  it("uses a bounded LRU cache, evicts the oldest snapshot, and skips single-page cache entries", () => {
+    const source = [entry(1), entry(2)];
+    const service = serviceFor(source, { maxSnapshots: 2 });
+    const snapshots = [0, 1, 2].map((index) => {
+      source[0].updated_at = `2026-08-10T00:00:0${index}.000Z`;
+      return page(service, { limit: 1 });
+    });
+    expectErrorCode(
+      () =>
+        page(service, {
+          snapshot_id: snapshots[0].snapshot_id,
+          cursor: snapshots[0].next_cursor!,
+          limit: 1,
+        }),
+      "inventory_snapshot_not_found",
+    );
+    expect(
+      page(service, {
+        snapshot_id: snapshots[2].snapshot_id,
+        cursor: snapshots[2].next_cursor!,
+        limit: 1,
+      }),
+    ).toMatchObject({ has_more: false });
+
+    const single = serviceFor([entry(99)]);
+    const onePage = page(single, { limit: 200 });
+    expect(onePage.has_more).toBe(false);
+    const syntheticCursor = (
+      single as unknown as { encodeCursor(id: string, offset: number): string }
+    ).encodeCursor(onePage.snapshot_id, 1);
+    expectErrorCode(
+      () =>
+        page(single, {
+          snapshot_id: onePage.snapshot_id,
+          cursor: syntheticCursor,
+          limit: 1,
+        }),
+      "inventory_snapshot_not_found",
+    );
+    expect(MAX_SNAPSHOTS_PER_DAEMON).toBeGreaterThan(0);
+  });
+
+  it("permits reconnect with the same client id before TTL and rejects another client", () => {
+    const service = serviceFor([entry(1), entry(2)]);
+    const first = page(service, { limit: 1 }, "stable-client-id");
+    expect(
+      page(
+        service,
+        { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 },
+        "stable-client-id",
+      ),
+    ).toMatchObject({ has_more: false });
+    expectErrorCode(
+      () =>
+        page(
+          service,
+          { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 },
+          "other-client",
+        ),
+      "inventory_snapshot_not_found",
+    );
+  });
+
+  it("hashes canonically and sorts with environment-independent code units", () => {
+    const serviceA = serviceFor([entry(2), entry(1)]);
+    const first = entry(1);
+    const second = entry(2);
+    const serviceB = serviceFor([
+      {
+        updated_at: first.updated_at,
+        native_id: first.native_id,
+        backend: first.backend,
+        archived: first.archived,
+        provider: first.provider,
+        status_raw: first.status_raw,
+        archived_at: first.archived_at,
+        internal: first.internal,
+        live: first.live,
+        cwd: first.cwd,
+        created_at: first.created_at,
+        persistence_session_id: first.persistence_session_id,
+      },
+      {
+        updated_at: second.updated_at,
+        native_id: second.native_id,
+        backend: second.backend,
+        archived: second.archived,
+        provider: second.provider,
+        status_raw: second.status_raw,
+        archived_at: second.archived_at,
+        internal: second.internal,
+        live: second.live,
+        cwd: second.cwd,
+        created_at: second.created_at,
+        persistence_session_id: second.persistence_session_id,
+      },
+    ]);
+    const pageA = page(serviceA, { limit: 200 });
+    const pageB = page(serviceB, { limit: 200 });
+    expect(pageA.snapshot_id).toBe(pageB.snapshot_id);
+    expect(pageA.entries.map((item) => item.native_id)).toEqual(["session-0001", "session-0002"]);
+
+    const localeSensitive = serviceFor([
+      entry(1, { native_id: "\u00e4" }),
+      entry(2, { native_id: "Z" }),
+    ]);
+    expect(page(localeSensitive, { limit: 200 }).entries.map((item) => item.native_id)).toEqual([
+      "Z",
+      "\u00e4",
+    ]);
+  });
+
+  it("includes scope records and preserves explicit provenance", () => {
+    const result = page(
+      serviceFor([
+        entry(1, { live: true, status_raw: "running" }),
+        entry(2, { live: false, status_raw: "running" }),
+        entry(3, {
+          provider: "unavailable-provider",
+          internal: true,
+          status_raw: "error",
+          archived: true,
+          archived_at: "2026-08-10T00:01:00.000Z",
+        }),
+      ]),
+      { limit: 200 },
+    );
+    expect(result.entries).toMatchObject([
+      { native_id: "session-0001", live: true, status_raw: "running" },
+      { native_id: "session-0002", live: false, status_raw: "running" },
+      { native_id: "session-0003", internal: true, archived: true },
+    ]);
+    expect(result.schema_version).toBe(INVENTORY_SCHEMA_VERSION);
   });
 
   it("only invokes the source read path and never a mutation path", () => {
     let reads = 0;
     let mutations = 0;
-    const source = {
-      read: () => {
-        reads += 1;
-        return [entry(1)];
-      },
-      mutate: () => {
-        mutations += 1;
-      },
-    };
-    const service = new InventorySnapshotService(source.read);
-    service.page({});
+    const source = { read: () => ((reads += 1), [entry(1)]), mutate: () => (mutations += 1) };
+    page(new InventorySnapshotService(source.read), {});
     expect(reads).toBe(1);
     expect(mutations).toBe(0);
   });

--- a/packages/server/src/server/agent/inventory-snapshot-service.test.ts
+++ b/packages/server/src/server/agent/inventory-snapshot-service.test.ts
@@ -37,7 +37,7 @@ function serviceFor(
   return new InventorySnapshotService(() => entries, options);
 }
 
-function page(
+async function page(
   service: InventorySnapshotService,
   request: InventorySnapshotRequest,
   clientId = "client-a",
@@ -45,23 +45,26 @@ function page(
   return service.page(request, clientId);
 }
 
-function allIds(service: InventorySnapshotService, limit: number) {
-  let result = page(service, { limit });
+async function allIds(service: InventorySnapshotService, limit: number) {
+  let result = await page(service, { limit });
   const snapshotId = result.snapshot_id;
   const ids = result.entries.map((item) => item.native_id);
   const cursors: string[] = [];
   while (result.has_more) {
     expect(result.next_cursor).not.toBeNull();
     cursors.push(result.next_cursor!);
-    result = page(service, { snapshot_id: snapshotId, cursor: result.next_cursor!, limit });
+    result = await page(service, { snapshot_id: snapshotId, cursor: result.next_cursor!, limit });
     ids.push(...result.entries.map((item) => item.native_id));
   }
   return { snapshotId, ids, cursors };
 }
 
-function expectErrorCode(action: () => unknown, code: InventorySnapshotError["code"]): void {
+async function expectErrorCode(
+  action: () => unknown | Promise<unknown>,
+  code: InventorySnapshotError["code"],
+): Promise<void> {
   try {
-    action();
+    await action();
     throw new Error("Expected inventory snapshot failure");
   } catch (error) {
     expect(error).toBeInstanceOf(InventorySnapshotError);
@@ -70,8 +73,8 @@ function expectErrorCode(action: () => unknown, code: InventorySnapshotError["co
 }
 
 describe("InventorySnapshotService", () => {
-  it.each([0, 1, 199, 200, 201, 401])("materializes %i sessions", (count) => {
-    const result = allIds(
+  it.each([0, 1, 199, 200, 201, 401])("materializes %i sessions", async (count) => {
+    const result = await allIds(
       serviceFor(Array.from({ length: count }, (_, index) => entry(index))),
       200,
     );
@@ -80,32 +83,35 @@ describe("InventorySnapshotService", () => {
     expect(result.ids).toEqual([...result.ids].sort());
   });
 
-  it("returns three pages with all identities exactly once and no cursor loop", () => {
-    const result = allIds(serviceFor(Array.from({ length: 401 }, (_, index) => entry(index))), 200);
+  it("returns three pages with all identities exactly once and no cursor loop", async () => {
+    const result = await allIds(
+      serviceFor(Array.from({ length: 401 }, (_, index) => entry(index))),
+      200,
+    );
     expect(result.cursors).toHaveLength(2);
     expect(new Set(result.cursors)).toHaveLength(2);
   });
 
-  it("fails closed for duplicate or malformed canonical state", () => {
-    expectErrorCode(
+  it("fails closed for duplicate or malformed canonical state", async () => {
+    await expectErrorCode(
       () => page(serviceFor([entry(1), entry(1)]), {}),
       "inventory_snapshot_conflict",
     );
-    expectErrorCode(
+    await expectErrorCode(
       () => page(serviceFor([entry(1, { updated_at: "not-a-timestamp" })]), {}),
       "inventory_snapshot_conflict",
     );
   });
 
-  it("keeps creation, deletion, archive, and lifecycle mutations out of an existing snapshot", () => {
+  it("keeps creation, deletion, archive, and lifecycle mutations out of an existing snapshot", async () => {
     const source = [entry(1), entry(2), entry(3)];
     const service = serviceFor(source);
-    const first = page(service, { limit: 1 });
+    const first = await page(service, { limit: 1 });
     source.splice(1, 1);
     source.push(
       entry(4, { status_raw: "closed", archived: true, archived_at: "2026-08-10T00:01:00.000Z" }),
     );
-    const second = page(service, {
+    const second = await page(service, {
       snapshot_id: first.snapshot_id,
       cursor: first.next_cursor!,
       limit: 3,
@@ -113,87 +119,108 @@ describe("InventorySnapshotService", () => {
     expect(second.entries.map((item) => item.native_id)).toEqual(["session-0002", "session-0003"]);
   });
 
-  it("replays the same snapshot/cursor deterministically", () => {
+  it("replays the same snapshot/cursor deterministically", async () => {
     const service = serviceFor([entry(1), entry(2), entry(3)]);
-    const first = page(service, { limit: 1 });
+    const first = await page(service, { limit: 1 });
     const replay = { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 };
-    expect(page(service, replay)).toEqual(page(service, replay));
+    await expect(page(service, replay)).resolves.toEqual(await page(service, replay));
   });
 
-  it("rejects forged, incomplete, foreign-snapshot, and looping cursors", () => {
+  it("rejects forged, incomplete, foreign-snapshot, and looping cursors", async () => {
     const source = [entry(1), entry(2), entry(3)];
     const service = serviceFor(source);
-    const first = page(service, { limit: 1 });
+    const first = await page(service, { limit: 1 });
     source[0].status_raw = "running";
-    const second = page(service, { limit: 1 });
-    expectErrorCode(
+    const second = await page(service, { limit: 1 });
+    await expectErrorCode(
       () =>
         page(service, { snapshot_id: second.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
       "invalid_inventory_cursor",
     );
-    expect(() => page(service, { snapshot_id: first.snapshot_id })).toThrow(InventorySnapshotError);
-    expect(() => page(service, { cursor: first.next_cursor! })).toThrow(InventorySnapshotError);
-    expectErrorCode(
+    await expect(page(service, { snapshot_id: first.snapshot_id })).rejects.toBeInstanceOf(
+      InventorySnapshotError,
+    );
+    await expect(page(service, { cursor: first.next_cursor! })).rejects.toBeInstanceOf(
+      InventorySnapshotError,
+    );
+    await expectErrorCode(
       () => page(service, { snapshot_id: first.snapshot_id, cursor: "not-a-cursor" }),
       "invalid_inventory_cursor",
     );
+    await expectErrorCode(
+      () =>
+        page(service, {
+          snapshot_id: first.snapshot_id,
+          cursor: `${first.next_cursor}!`,
+          limit: 1,
+        }),
+      "invalid_inventory_cursor",
+    );
     const loopCursor = (
-      service as unknown as { encodeCursor(id: string, offset: number): string }
-    ).encodeCursor(first.snapshot_id, 0);
-    expectErrorCode(
+      service as unknown as { encodeCursor(id: string, offset: number, clientId: string): string }
+    ).encodeCursor(first.snapshot_id, 0, "client-a");
+    await expectErrorCode(
       () => page(service, { snapshot_id: first.snapshot_id, cursor: loopCursor, limit: 1 }),
       "invalid_inventory_cursor",
     );
   });
 
-  it("expires snapshots but distinguishes eviction/daemon-restart from expiry", () => {
+  it("expires snapshots but distinguishes eviction/daemon-restart from expiry", async () => {
     let now = 0;
     const service = serviceFor([entry(1), entry(2)], { now: () => now, ttlMs: 10 });
-    const first = page(service, { limit: 1 });
+    const first = await page(service, { limit: 1 });
     now = 11;
-    expectErrorCode(
+    await expectErrorCode(
       () => page(service, { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
       "inventory_snapshot_expired",
     );
     const restarted = serviceFor([entry(1), entry(2)]);
-    expectErrorCode(
+    await expectErrorCode(
       () =>
         page(restarted, { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
       "inventory_snapshot_not_found",
     );
   });
 
-  it("uses a bounded LRU cache, evicts the oldest snapshot, and skips single-page cache entries", () => {
+  it("uses a bounded LRU cache, evicts the oldest snapshot, and skips single-page cache entries", async () => {
     const source = [entry(1), entry(2)];
     const service = serviceFor(source, { maxSnapshots: 2 });
-    const snapshots = [0, 1, 2].map((index) => {
+    const snapshots = [];
+    for (const index of [0, 1]) {
       source[0].updated_at = `2026-08-10T00:00:0${index}.000Z`;
-      return page(service, { limit: 1 });
+      snapshots.push(await page(service, { limit: 1 }));
+    }
+    await page(service, {
+      snapshot_id: snapshots[0].snapshot_id,
+      cursor: snapshots[0].next_cursor!,
+      limit: 1,
     });
-    expectErrorCode(
+    source[0].updated_at = "2026-08-10T00:00:02.000Z";
+    snapshots.push(await page(service, { limit: 1 }));
+    await expectErrorCode(
       () =>
         page(service, {
-          snapshot_id: snapshots[0].snapshot_id,
-          cursor: snapshots[0].next_cursor!,
+          snapshot_id: snapshots[1].snapshot_id,
+          cursor: snapshots[1].next_cursor!,
           limit: 1,
         }),
       "inventory_snapshot_not_found",
     );
-    expect(
+    await expect(
       page(service, {
         snapshot_id: snapshots[2].snapshot_id,
         cursor: snapshots[2].next_cursor!,
         limit: 1,
       }),
-    ).toMatchObject({ has_more: false });
+    ).resolves.toMatchObject({ has_more: false });
 
     const single = serviceFor([entry(99)]);
-    const onePage = page(single, { limit: 200 });
+    const onePage = await page(single, { limit: 200 });
     expect(onePage.has_more).toBe(false);
     const syntheticCursor = (
-      single as unknown as { encodeCursor(id: string, offset: number): string }
-    ).encodeCursor(onePage.snapshot_id, 1);
-    expectErrorCode(
+      single as unknown as { encodeCursor(id: string, offset: number, clientId: string): string }
+    ).encodeCursor(onePage.snapshot_id, 1, "client-a");
+    await expectErrorCode(
       () =>
         page(single, {
           snapshot_id: onePage.snapshot_id,
@@ -205,17 +232,51 @@ describe("InventorySnapshotService", () => {
     expect(MAX_SNAPSHOTS_PER_DAEMON).toBeGreaterThan(0);
   });
 
-  it("permits reconnect with the same client id before TTL and rejects another client", () => {
+  it("keeps the global cache bounded at 64 snapshots across client identities", async () => {
+    const source = [entry(1), entry(2)];
+    const service = serviceFor(source);
+    const snapshots = [];
+    for (let index = 0; index <= MAX_SNAPSHOTS_PER_DAEMON; index += 1) {
+      source[0].cwd = `/worktree/cache-${index}`;
+      snapshots.push(await page(service, { limit: 1 }, `client-${index}`));
+    }
+    await expectErrorCode(
+      () =>
+        page(
+          service,
+          {
+            snapshot_id: snapshots[0].snapshot_id,
+            cursor: snapshots[0].next_cursor!,
+            limit: 1,
+          },
+          "client-0",
+        ),
+      "inventory_snapshot_not_found",
+    );
+    await expect(
+      page(
+        service,
+        {
+          snapshot_id: snapshots.at(-1)!.snapshot_id,
+          cursor: snapshots.at(-1)!.next_cursor!,
+          limit: 1,
+        },
+        `client-${MAX_SNAPSHOTS_PER_DAEMON}`,
+      ),
+    ).resolves.toMatchObject({ has_more: false });
+  });
+
+  it("permits reconnect with the same client id before TTL and rejects another client", async () => {
     const service = serviceFor([entry(1), entry(2)]);
-    const first = page(service, { limit: 1 }, "stable-client-id");
-    expect(
+    const first = await page(service, { limit: 1 }, "stable-client-id");
+    await expect(
       page(
         service,
         { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 },
         "stable-client-id",
       ),
-    ).toMatchObject({ has_more: false });
-    expectErrorCode(
+    ).resolves.toMatchObject({ has_more: false });
+    await expectErrorCode(
       () =>
         page(
           service,
@@ -224,9 +285,21 @@ describe("InventorySnapshotService", () => {
         ),
       "inventory_snapshot_not_found",
     );
+
+    const sameSnapshotForOtherClient = await page(service, { limit: 1 }, "other-client");
+    expect(sameSnapshotForOtherClient.snapshot_id).toBe(first.snapshot_id);
+    await expectErrorCode(
+      () =>
+        page(
+          service,
+          { snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 },
+          "other-client",
+        ),
+      "invalid_inventory_cursor",
+    );
   });
 
-  it("hashes canonically and sorts with environment-independent code units", () => {
+  it("hashes canonically and sorts with environment-independent code units", async () => {
     const serviceA = serviceFor([entry(2), entry(1)]);
     const first = entry(1);
     const second = entry(2);
@@ -260,8 +333,8 @@ describe("InventorySnapshotService", () => {
         persistence_session_id: second.persistence_session_id,
       },
     ]);
-    const pageA = page(serviceA, { limit: 200 });
-    const pageB = page(serviceB, { limit: 200 });
+    const pageA = await page(serviceA, { limit: 200 });
+    const pageB = await page(serviceB, { limit: 200 });
     expect(pageA.snapshot_id).toBe(pageB.snapshot_id);
     expect(pageA.entries.map((item) => item.native_id)).toEqual(["session-0001", "session-0002"]);
 
@@ -269,14 +342,13 @@ describe("InventorySnapshotService", () => {
       entry(1, { native_id: "\u00e4" }),
       entry(2, { native_id: "Z" }),
     ]);
-    expect(page(localeSensitive, { limit: 200 }).entries.map((item) => item.native_id)).toEqual([
-      "Z",
-      "\u00e4",
-    ]);
+    expect(
+      (await page(localeSensitive, { limit: 200 })).entries.map((item) => item.native_id),
+    ).toEqual(["Z", "\u00e4"]);
   });
 
-  it("includes scope records and preserves explicit provenance", () => {
-    const result = page(
+  it("includes scope records and preserves explicit provenance", async () => {
+    const result = await page(
       serviceFor([
         entry(1, { live: true, status_raw: "running" }),
         entry(2, { live: false, status_raw: "running" }),
@@ -298,11 +370,11 @@ describe("InventorySnapshotService", () => {
     expect(result.schema_version).toBe(INVENTORY_SCHEMA_VERSION);
   });
 
-  it("only invokes the source read path and never a mutation path", () => {
+  it("only invokes the source read path and never a mutation path", async () => {
     let reads = 0;
     let mutations = 0;
     const source = { read: () => ((reads += 1), [entry(1)]), mutate: () => (mutations += 1) };
-    page(new InventorySnapshotService(source.read), {});
+    await page(new InventorySnapshotService(source.read), {});
     expect(reads).toBe(1);
     expect(mutations).toBe(0);
   });

--- a/packages/server/src/server/agent/inventory-snapshot-service.test.ts
+++ b/packages/server/src/server/agent/inventory-snapshot-service.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+import {
+  INVENTORY_SCHEMA_VERSION,
+  InventorySnapshotError,
+  InventorySnapshotService,
+  type InventorySessionEntry,
+} from "./inventory-snapshot-service.js";
+
+function entry(
+  index: number,
+  overrides: Partial<InventorySessionEntry> = {},
+): InventorySessionEntry {
+  return {
+    backend: "paseo",
+    native_id: `session-${String(index).padStart(4, "0")}`,
+    provider: "claude",
+    status_raw: "idle",
+    archived: false,
+    archived_at: null,
+    internal: false,
+    cwd: `/worktree/${index}`,
+    created_at: "2026-08-10T00:00:00.000Z",
+    updated_at: "2026-08-10T00:00:00.000Z",
+    persistence_session_id: `provider-${index}`,
+    ...overrides,
+  };
+}
+
+function serviceFor(
+  entries: InventorySessionEntry[],
+  options?: { ttlMs?: number; now?: () => number },
+) {
+  return new InventorySnapshotService(() => entries, options?.now, options?.ttlMs);
+}
+
+function allIds(
+  service: InventorySnapshotService,
+  limit: number,
+): {
+  snapshotId: string;
+  ids: string[];
+  cursors: string[];
+} {
+  let page = service.page({ limit });
+  const snapshotId = page.snapshot_id;
+  const ids = page.entries.map((item) => item.native_id);
+  const cursors: string[] = [];
+  while (page.has_more) {
+    expect(page.next_cursor).not.toBeNull();
+    cursors.push(page.next_cursor!);
+    page = service.page({ snapshot_id: snapshotId, cursor: page.next_cursor!, limit });
+    ids.push(...page.entries.map((item) => item.native_id));
+  }
+  return { snapshotId, ids, cursors };
+}
+
+function expectErrorCode(action: () => unknown, code: InventorySnapshotError["code"]): void {
+  try {
+    action();
+    throw new Error("Expected inventory snapshot failure");
+  } catch (error) {
+    expect(error).toBeInstanceOf(InventorySnapshotError);
+    expect((error as InventorySnapshotError).code).toBe(code);
+  }
+}
+
+describe("InventorySnapshotService", () => {
+  it.each([0, 1, 199, 200, 201, 401])(
+    "materializes %i sessions with a bounded deterministic page contract",
+    (count) => {
+      const result = allIds(
+        serviceFor(Array.from({ length: count }, (_, index) => entry(index))),
+        200,
+      );
+      expect(result.ids).toHaveLength(count);
+      expect(new Set(result.ids)).toHaveLength(count);
+      expect(result.ids).toEqual([...result.ids].sort());
+    },
+  );
+
+  it("returns three pages with every identity exactly once and no cursor loop", () => {
+    const result = allIds(serviceFor(Array.from({ length: 401 }, (_, index) => entry(index))), 200);
+    expect(result.cursors).toHaveLength(2);
+    expect(new Set(result.cursors)).toHaveLength(result.cursors.length);
+    expect(result.ids).toHaveLength(401);
+    expect(new Set(result.ids)).toHaveLength(401);
+  });
+
+  it("fails closed for a duplicate canonical identity", () => {
+    const service = serviceFor([entry(1), entry(1, { provider: "codex" })]);
+    expectErrorCode(() => service.page({}), "inventory_snapshot_conflict");
+  });
+
+  it("rejects a cursor supplied with a different snapshot", () => {
+    const source = [entry(1), entry(2), entry(3)];
+    const service = serviceFor(source);
+    const first = service.page({ limit: 1 });
+    source[0].status_raw = "running";
+    const secondSnapshot = service.page({ limit: 2 });
+    expectErrorCode(
+      () =>
+        service.page({
+          snapshot_id: secondSnapshot.snapshot_id,
+          cursor: first.next_cursor!,
+          limit: 1,
+        }),
+      "inventory_cursor_snapshot_mismatch",
+    );
+  });
+
+  it("rejects an expired snapshot", () => {
+    let now = 0;
+    const service = serviceFor([entry(1), entry(2)], { ttlMs: 10, now: () => now });
+    const first = service.page({ limit: 1 });
+    now = 11;
+    expectErrorCode(
+      () => service.page({ snapshot_id: first.snapshot_id, cursor: first.next_cursor!, limit: 1 }),
+      "inventory_snapshot_expired",
+    );
+  });
+
+  it("keeps lifecycle mutations out of an existing snapshot", () => {
+    const source = [entry(1), entry(2), entry(3)];
+    const service = serviceFor(source);
+    const first = service.page({ limit: 1 });
+    source[1].status_raw = "closed";
+    source[1].archived = true;
+    source[1].archived_at = "2026-08-10T00:01:00.000Z";
+    const second = service.page({
+      snapshot_id: first.snapshot_id,
+      cursor: first.next_cursor!,
+      limit: 2,
+    });
+    expect(second.entries[0]).toMatchObject({ native_id: "session-0002", status_raw: "idle" });
+  });
+
+  it("keeps deleted records in an existing snapshot", () => {
+    const source = [entry(1), entry(2), entry(3)];
+    const service = serviceFor(source);
+    const first = service.page({ limit: 1 });
+    source.splice(1, 1);
+    const second = service.page({
+      snapshot_id: first.snapshot_id,
+      cursor: first.next_cursor!,
+      limit: 2,
+    });
+    expect(second.entries.map((item) => item.native_id)).toEqual(["session-0002", "session-0003"]);
+  });
+
+  it("does not add newly created records to an existing snapshot", () => {
+    const source = [entry(1), entry(3)];
+    const service = serviceFor(source);
+    const first = service.page({ limit: 1 });
+    source.push(entry(2));
+    const second = service.page({
+      snapshot_id: first.snapshot_id,
+      cursor: first.next_cursor!,
+      limit: 2,
+    });
+    expect(second.entries.map((item) => item.native_id)).toEqual(["session-0003"]);
+  });
+
+  it("includes archived, internal, and unavailable-provider records instead of filtering them", () => {
+    const service = serviceFor([
+      entry(1, { status_raw: "running" }),
+      entry(2, {
+        status_raw: "closed",
+        archived: true,
+        archived_at: "2026-08-10T00:01:00.000Z",
+      }),
+      entry(3, { provider: "unavailable-provider", internal: true, status_raw: "error" }),
+    ]);
+    const page = service.page({ limit: 200 });
+    expect(page.entries).toHaveLength(3);
+    expect(page.entries.map((item) => item.status_raw)).toEqual(["running", "closed", "error"]);
+    expect(page.entries[2]).toMatchObject({ provider: "unavailable-provider", internal: true });
+  });
+
+  it("replays the same snapshot and cursor deterministically", () => {
+    const service = serviceFor([entry(1), entry(2), entry(3)]);
+    const first = service.page({ limit: 1 });
+    const pageA = service.page({
+      snapshot_id: first.snapshot_id,
+      cursor: first.next_cursor!,
+      limit: 1,
+    });
+    const pageB = service.page({
+      snapshot_id: first.snapshot_id,
+      cursor: first.next_cursor!,
+      limit: 1,
+    });
+    expect(pageA).toEqual(pageB);
+    expect(pageA.schema_version).toBe(INVENTORY_SCHEMA_VERSION);
+  });
+
+  it("rejects invalid, incomplete, and forged cursors", () => {
+    const service = serviceFor([entry(1), entry(2)]);
+    const first = service.page({ limit: 1 });
+    for (const request of [
+      { snapshot_id: first.snapshot_id },
+      { cursor: first.next_cursor! },
+      { snapshot_id: first.snapshot_id, cursor: "not-a-cursor" },
+    ]) {
+      expect(() => service.page(request)).toThrow(InventorySnapshotError);
+    }
+  });
+
+  it("fails a cursor that would loop back to the first page", () => {
+    const service = serviceFor([entry(1), entry(2)]);
+    const first = service.page({ limit: 1 });
+    const loopCursor = (
+      service as unknown as { encodeCursor(snapshotId: string, offset: number): string }
+    ).encodeCursor(first.snapshot_id, 0);
+    expectErrorCode(
+      () => service.page({ snapshot_id: first.snapshot_id, cursor: loopCursor, limit: 1 }),
+      "invalid_inventory_cursor",
+    );
+  });
+
+  it("fails closed for malformed canonical source state", () => {
+    const malformed = entry(1, { updated_at: "not-a-timestamp" });
+    expectErrorCode(() => serviceFor([malformed]).page({}), "inventory_snapshot_conflict");
+  });
+
+  it("only invokes the source read path and never a mutation path", () => {
+    let reads = 0;
+    let mutations = 0;
+    const source = {
+      read: () => {
+        reads += 1;
+        return [entry(1)];
+      },
+      mutate: () => {
+        mutations += 1;
+      },
+    };
+    const service = new InventorySnapshotService(source.read);
+    service.page({});
+    expect(reads).toBe(1);
+    expect(mutations).toBe(0);
+  });
+});

--- a/packages/server/src/server/agent/inventory-snapshot-service.ts
+++ b/packages/server/src/server/agent/inventory-snapshot-service.ts
@@ -1,0 +1,238 @@
+import { createHash, createHmac, randomBytes } from "node:crypto";
+
+export const INVENTORY_SCHEMA_VERSION = "paseo.inventory_sessions.v1";
+const DEFAULT_PAGE_LIMIT = 200;
+const MAX_PAGE_LIMIT = 200;
+const DEFAULT_SNAPSHOT_TTL_MS = 10 * 60 * 1000;
+
+export interface InventorySessionEntry {
+  backend: "paseo";
+  native_id: string;
+  provider: string;
+  status_raw: string;
+  archived: boolean;
+  archived_at: string | null;
+  internal: boolean;
+  cwd: string;
+  created_at: string;
+  updated_at: string;
+  persistence_session_id: string | null;
+}
+
+export interface InventorySnapshotPage {
+  schema_version: typeof INVENTORY_SCHEMA_VERSION;
+  snapshot_id: string;
+  entries: InventorySessionEntry[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+export class InventorySnapshotError extends Error {
+  constructor(
+    readonly code:
+      | "invalid_inventory_cursor"
+      | "inventory_cursor_snapshot_mismatch"
+      | "inventory_snapshot_expired"
+      | "inventory_snapshot_not_found"
+      | "inventory_snapshot_conflict",
+    message: string,
+  ) {
+    super(message);
+    this.name = "InventorySnapshotError";
+  }
+}
+
+interface FrozenInventorySnapshot {
+  entries: InventorySessionEntry[];
+  expiresAt: number;
+}
+
+interface CursorPayload {
+  snapshot_id: string;
+  offset: number;
+  proof: string;
+}
+
+export interface InventorySnapshotRequest {
+  snapshot_id?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+/**
+ * A daemon-local, immutable materialization of the Paseo registry inventory.
+ *
+ * The snapshot id is the SHA-256 of the canonical, fully materialized entry
+ * list. A cursor is HMAC-bound and names both that id and an
+ * absolute offset, so it cannot be moved to another snapshot or forged into a
+ * different position. Snapshot entries are cloned before storage: later
+ * lifecycle mutations cannot change a page already belonging to this snapshot.
+ */
+export class InventorySnapshotService {
+  private readonly snapshots = new Map<string, FrozenInventorySnapshot>();
+  private readonly cursorSecret = randomBytes(32).toString("base64url");
+
+  constructor(
+    private readonly captureEntries: () => InventorySessionEntry[],
+    private readonly now: () => number = Date.now,
+    private readonly ttlMs = DEFAULT_SNAPSHOT_TTL_MS,
+  ) {}
+
+  page(request: InventorySnapshotRequest): InventorySnapshotPage {
+    this.removeExpiredSnapshots();
+    const limit = this.normalizeLimit(request.limit);
+    const hasSnapshotId = request.snapshot_id !== undefined;
+    const hasCursor = request.cursor !== undefined;
+    if (hasSnapshotId !== hasCursor) {
+      throw new InventorySnapshotError(
+        "invalid_inventory_cursor",
+        "inventory snapshot_id and cursor must be supplied together after the first page",
+      );
+    }
+
+    if (!hasSnapshotId) {
+      const entries = this.freezeAndValidate(this.captureEntries());
+      const snapshotId = this.snapshotId(entries);
+      this.snapshots.set(snapshotId, { entries, expiresAt: this.now() + this.ttlMs });
+      return this.buildPage(snapshotId, entries, 0, limit);
+    }
+
+    const snapshotId = request.snapshot_id!;
+    const cursor = this.decodeCursor(request.cursor!);
+    if (cursor.snapshot_id !== snapshotId) {
+      throw new InventorySnapshotError(
+        "inventory_cursor_snapshot_mismatch",
+        "inventory cursor belongs to a different snapshot_id",
+      );
+    }
+    const snapshot = this.snapshots.get(snapshotId);
+    if (!snapshot) {
+      throw new InventorySnapshotError(
+        "inventory_snapshot_expired",
+        "inventory snapshot has expired or is unknown",
+      );
+    }
+    if (snapshot.expiresAt <= this.now()) {
+      this.snapshots.delete(snapshotId);
+      throw new InventorySnapshotError(
+        "inventory_snapshot_expired",
+        "inventory snapshot has expired",
+      );
+    }
+    if (cursor.offset <= 0 || cursor.offset >= snapshot.entries.length) {
+      throw new InventorySnapshotError(
+        "invalid_inventory_cursor",
+        "inventory cursor offset is invalid",
+      );
+    }
+    return this.buildPage(snapshotId, snapshot.entries, cursor.offset, limit);
+  }
+
+  private normalizeLimit(limit: number | undefined): number {
+    if (limit === undefined) return DEFAULT_PAGE_LIMIT;
+    if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_PAGE_LIMIT) {
+      throw new InventorySnapshotError(
+        "invalid_inventory_cursor",
+        `inventory page limit must be an integer between 1 and ${MAX_PAGE_LIMIT}`,
+      );
+    }
+    return limit;
+  }
+
+  private buildPage(
+    snapshotId: string,
+    entries: InventorySessionEntry[],
+    offset: number,
+    limit: number,
+  ): InventorySnapshotPage {
+    const pageEntries = entries.slice(offset, offset + limit);
+    const nextOffset = offset + pageEntries.length;
+    const hasMore = nextOffset < entries.length;
+    return {
+      schema_version: INVENTORY_SCHEMA_VERSION,
+      snapshot_id: snapshotId,
+      entries: structuredClone(pageEntries),
+      next_cursor: hasMore ? this.encodeCursor(snapshotId, nextOffset) : null,
+      has_more: hasMore,
+    };
+  }
+
+  private freezeAndValidate(entries: InventorySessionEntry[]): InventorySessionEntry[] {
+    const byIdentity = new Set<string>();
+    const frozen = entries
+      .map((entry) => structuredClone(entry))
+      .sort((left, right) => left.native_id.localeCompare(right.native_id));
+    for (const entry of frozen) {
+      if (
+        !entry.native_id ||
+        !entry.provider ||
+        !entry.status_raw ||
+        Number.isNaN(Date.parse(entry.created_at)) ||
+        Number.isNaN(Date.parse(entry.updated_at))
+      ) {
+        throw new InventorySnapshotError(
+          "inventory_snapshot_conflict",
+          "inventory source returned a malformed session entry",
+        );
+      }
+      const identity = `${entry.backend}\u0000${entry.native_id}`;
+      if (byIdentity.has(identity)) {
+        throw new InventorySnapshotError(
+          "inventory_snapshot_conflict",
+          `duplicate canonical inventory identity: ${entry.backend}/${entry.native_id}`,
+        );
+      }
+      byIdentity.add(identity);
+    }
+    return frozen;
+  }
+
+  private snapshotId(entries: InventorySessionEntry[]): string {
+    const canonical = JSON.stringify({ schema_version: INVENTORY_SCHEMA_VERSION, entries });
+    return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+  }
+
+  private encodeCursor(snapshotId: string, offset: number): string {
+    const proof = this.cursorProof(snapshotId, offset);
+    return Buffer.from(JSON.stringify({ snapshot_id: snapshotId, offset, proof })).toString(
+      "base64url",
+    );
+  }
+
+  private decodeCursor(cursor: string): CursorPayload {
+    try {
+      const parsed: unknown = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        typeof (parsed as CursorPayload).snapshot_id !== "string" ||
+        !Number.isInteger((parsed as CursorPayload).offset) ||
+        typeof (parsed as CursorPayload).proof !== "string"
+      ) {
+        throw new Error("invalid shape");
+      }
+      const payload = parsed as CursorPayload;
+      if (payload.proof !== this.cursorProof(payload.snapshot_id, payload.offset)) {
+        throw new Error("invalid proof");
+      }
+      return payload;
+    } catch {
+      throw new InventorySnapshotError("invalid_inventory_cursor", "inventory cursor is invalid");
+    }
+  }
+
+  private cursorProof(snapshotId: string, offset: number): string {
+    return createHmac("sha256", this.cursorSecret)
+      .update(`${snapshotId}\u0000${offset}`)
+      .digest("base64url");
+  }
+
+  private removeExpiredSnapshots(): void {
+    const now = this.now();
+    for (const [snapshotId, snapshot] of this.snapshots) {
+      if (snapshot.expiresAt <= now) {
+        this.snapshots.delete(snapshotId);
+      }
+    }
+  }
+}

--- a/packages/server/src/server/agent/inventory-snapshot-service.ts
+++ b/packages/server/src/server/agent/inventory-snapshot-service.ts
@@ -84,7 +84,9 @@ export class InventorySnapshotService {
   private readonly maxSnapshots: number;
 
   constructor(
-    private readonly captureEntries: () => InventorySessionEntry[],
+    private readonly captureEntries: () =>
+      | InventorySessionEntry[]
+      | Promise<InventorySessionEntry[]>,
     options: InventorySnapshotServiceOptions = {},
   ) {
     this.now = options.now ?? Date.now;
@@ -95,7 +97,7 @@ export class InventorySnapshotService {
     }
   }
 
-  page(request: InventorySnapshotRequest, clientId: string): InventorySnapshotPage {
+  async page(request: InventorySnapshotRequest, clientId: string): Promise<InventorySnapshotPage> {
     this.removeExpiredSnapshots();
     const limit = this.normalizeLimit(request.limit);
     const hasSnapshotId = request.snapshot_id !== undefined;
@@ -108,12 +110,12 @@ export class InventorySnapshotService {
     }
 
     if (!hasSnapshotId) {
-      const entries = this.freezeAndValidate(this.captureEntries());
+      const entries = this.freezeAndValidate(await this.captureEntries());
       const snapshotId = this.snapshotId(entries);
       if (entries.length > limit) {
         this.storeSnapshot(snapshotId, clientId, entries);
       }
-      return this.buildPage(snapshotId, entries, 0, limit);
+      return this.buildPage(snapshotId, entries, 0, limit, clientId);
     }
 
     const snapshotId = request.snapshot_id!;
@@ -139,7 +141,7 @@ export class InventorySnapshotService {
         "inventory snapshot is unknown, evicted, or owned by another client",
       );
     }
-    if (cursor.proof !== this.cursorProof(cursor.snapshot_id, cursor.offset)) {
+    if (cursor.proof !== this.cursorProof(cursor.snapshot_id, cursor.offset, clientId)) {
       throw new InventorySnapshotError("invalid_inventory_cursor", "inventory cursor is invalid");
     }
     if (snapshot.expiresAt <= this.now()) {
@@ -156,7 +158,7 @@ export class InventorySnapshotService {
       );
     }
     this.touchSnapshot(snapshotKey, snapshot);
-    return this.buildPage(snapshotId, snapshot.entries, cursor.offset, limit);
+    return this.buildPage(snapshotId, snapshot.entries, cursor.offset, limit, clientId);
   }
 
   private normalizeLimit(limit: number | undefined): number {
@@ -175,6 +177,7 @@ export class InventorySnapshotService {
     entries: InventorySessionEntry[],
     offset: number,
     limit: number,
+    clientId: string,
   ): InventorySnapshotPage {
     const pageEntries = entries.slice(offset, offset + limit);
     const nextOffset = offset + pageEntries.length;
@@ -183,7 +186,7 @@ export class InventorySnapshotService {
       schema_version: INVENTORY_SCHEMA_VERSION,
       snapshot_id: snapshotId,
       entries: structuredClone(pageEntries),
-      next_cursor: hasMore ? this.encodeCursor(snapshotId, nextOffset) : null,
+      next_cursor: hasMore ? this.encodeCursor(snapshotId, nextOffset, clientId) : null,
       has_more: hasMore,
     };
   }
@@ -246,8 +249,8 @@ export class InventorySnapshotService {
     return `${clientId}\u0000${snapshotId}`;
   }
 
-  private encodeCursor(snapshotId: string, offset: number): string {
-    const proof = this.cursorProof(snapshotId, offset);
+  private encodeCursor(snapshotId: string, offset: number, clientId: string): string {
+    const proof = this.cursorProof(snapshotId, offset, clientId);
     return Buffer.from(JSON.stringify({ snapshot_id: snapshotId, offset, proof })).toString(
       "base64url",
     );
@@ -255,6 +258,9 @@ export class InventorySnapshotService {
 
   private decodeCursor(cursor: string): CursorPayload {
     try {
+      if (!/^[A-Za-z0-9_-]+$/.test(cursor)) {
+        throw new Error("invalid base64url alphabet");
+      }
       const parsed: unknown = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
       if (
         typeof parsed !== "object" ||
@@ -265,15 +271,20 @@ export class InventorySnapshotService {
       ) {
         throw new Error("invalid shape");
       }
-      return parsed as CursorPayload;
+      const payload = parsed as CursorPayload;
+      const canonical = Buffer.from(JSON.stringify(payload)).toString("base64url");
+      if (canonical !== cursor) {
+        throw new Error("non-canonical cursor");
+      }
+      return payload;
     } catch {
       throw new InventorySnapshotError("invalid_inventory_cursor", "inventory cursor is invalid");
     }
   }
 
-  private cursorProof(snapshotId: string, offset: number): string {
+  private cursorProof(snapshotId: string, offset: number, clientId: string): string {
     return createHmac("sha256", this.cursorSecret)
-      .update(`${snapshotId}\u0000${offset}`)
+      .update(`${snapshotId}\u0000${offset}\u0000${clientId}`)
       .digest("base64url");
   }
 

--- a/packages/server/src/server/agent/inventory-snapshot-service.ts
+++ b/packages/server/src/server/agent/inventory-snapshot-service.ts
@@ -4,6 +4,7 @@ export const INVENTORY_SCHEMA_VERSION = "paseo.inventory_sessions.v1";
 const DEFAULT_PAGE_LIMIT = 200;
 const MAX_PAGE_LIMIT = 200;
 const DEFAULT_SNAPSHOT_TTL_MS = 10 * 60 * 1000;
+export const MAX_SNAPSHOTS_PER_DAEMON = 64;
 
 export interface InventorySessionEntry {
   backend: "paseo";
@@ -13,6 +14,8 @@ export interface InventorySessionEntry {
   archived: boolean;
   archived_at: string | null;
   internal: boolean;
+  /** True only when status_raw came from the live AgentManager map. */
+  live: boolean;
   cwd: string;
   created_at: string;
   updated_at: string;
@@ -31,7 +34,6 @@ export class InventorySnapshotError extends Error {
   constructor(
     readonly code:
       | "invalid_inventory_cursor"
-      | "inventory_cursor_snapshot_mismatch"
       | "inventory_snapshot_expired"
       | "inventory_snapshot_not_found"
       | "inventory_snapshot_conflict",
@@ -59,26 +61,41 @@ export interface InventorySnapshotRequest {
   limit?: number;
 }
 
+export interface InventorySnapshotServiceOptions {
+  now?: () => number;
+  ttlMs?: number;
+  maxSnapshots?: number;
+}
+
 /**
  * A daemon-local, immutable materialization of the Paseo registry inventory.
  *
- * The snapshot id is the SHA-256 of the canonical, fully materialized entry
- * list. A cursor is HMAC-bound and names both that id and an
- * absolute offset, so it cannot be moved to another snapshot or forged into a
- * different position. Snapshot entries are cloned before storage: later
- * lifecycle mutations cannot change a page already belonging to this snapshot.
+ * The snapshot id is SHA-256 over canonical JSON. A cursor is HMAC-bound to
+ * that id and absolute offset. Entries are cloned before storage, and the
+ * bounded LRU cache is shared by all sessions in one daemon when injected by
+ * WebSocketServer.
  */
 export class InventorySnapshotService {
   private readonly snapshots = new Map<string, FrozenInventorySnapshot>();
+  private readonly expiredSnapshots = new Set<string>();
   private readonly cursorSecret = randomBytes(32).toString("base64url");
+  private readonly now: () => number;
+  private readonly ttlMs: number;
+  private readonly maxSnapshots: number;
 
   constructor(
     private readonly captureEntries: () => InventorySessionEntry[],
-    private readonly now: () => number = Date.now,
-    private readonly ttlMs = DEFAULT_SNAPSHOT_TTL_MS,
-  ) {}
+    options: InventorySnapshotServiceOptions = {},
+  ) {
+    this.now = options.now ?? Date.now;
+    this.ttlMs = options.ttlMs ?? DEFAULT_SNAPSHOT_TTL_MS;
+    this.maxSnapshots = options.maxSnapshots ?? MAX_SNAPSHOTS_PER_DAEMON;
+    if (!Number.isInteger(this.maxSnapshots) || this.maxSnapshots <= 0) {
+      throw new Error("maxSnapshots must be a positive integer");
+    }
+  }
 
-  page(request: InventorySnapshotRequest): InventorySnapshotPage {
+  page(request: InventorySnapshotRequest, clientId: string): InventorySnapshotPage {
     this.removeExpiredSnapshots();
     const limit = this.normalizeLimit(request.limit);
     const hasSnapshotId = request.snapshot_id !== undefined;
@@ -93,7 +110,9 @@ export class InventorySnapshotService {
     if (!hasSnapshotId) {
       const entries = this.freezeAndValidate(this.captureEntries());
       const snapshotId = this.snapshotId(entries);
-      this.snapshots.set(snapshotId, { entries, expiresAt: this.now() + this.ttlMs });
+      if (entries.length > limit) {
+        this.storeSnapshot(snapshotId, clientId, entries);
+      }
       return this.buildPage(snapshotId, entries, 0, limit);
     }
 
@@ -101,19 +120,30 @@ export class InventorySnapshotService {
     const cursor = this.decodeCursor(request.cursor!);
     if (cursor.snapshot_id !== snapshotId) {
       throw new InventorySnapshotError(
-        "inventory_cursor_snapshot_mismatch",
+        "invalid_inventory_cursor",
         "inventory cursor belongs to a different snapshot_id",
       );
     }
-    const snapshot = this.snapshots.get(snapshotId);
+
+    const snapshotKey = this.snapshotKey(snapshotId, clientId);
+    const snapshot = this.snapshots.get(snapshotKey);
     if (!snapshot) {
+      if (this.expiredSnapshots.has(snapshotKey)) {
+        throw new InventorySnapshotError(
+          "inventory_snapshot_expired",
+          "inventory snapshot has expired",
+        );
+      }
       throw new InventorySnapshotError(
-        "inventory_snapshot_expired",
-        "inventory snapshot has expired or is unknown",
+        "inventory_snapshot_not_found",
+        "inventory snapshot is unknown, evicted, or owned by another client",
       );
     }
+    if (cursor.proof !== this.cursorProof(cursor.snapshot_id, cursor.offset)) {
+      throw new InventorySnapshotError("invalid_inventory_cursor", "inventory cursor is invalid");
+    }
     if (snapshot.expiresAt <= this.now()) {
-      this.snapshots.delete(snapshotId);
+      this.expireSnapshot(snapshotKey);
       throw new InventorySnapshotError(
         "inventory_snapshot_expired",
         "inventory snapshot has expired",
@@ -125,6 +155,7 @@ export class InventorySnapshotService {
         "inventory cursor offset is invalid",
       );
     }
+    this.touchSnapshot(snapshotKey, snapshot);
     return this.buildPage(snapshotId, snapshot.entries, cursor.offset, limit);
   }
 
@@ -159,9 +190,7 @@ export class InventorySnapshotService {
 
   private freezeAndValidate(entries: InventorySessionEntry[]): InventorySessionEntry[] {
     const byIdentity = new Set<string>();
-    const frozen = entries
-      .map((entry) => structuredClone(entry))
-      .sort((left, right) => left.native_id.localeCompare(right.native_id));
+    const frozen = entries.map((entry) => structuredClone(entry)).sort(compareInventoryIdentity);
     for (const entry of frozen) {
       if (
         !entry.native_id ||
@@ -188,8 +217,33 @@ export class InventorySnapshotService {
   }
 
   private snapshotId(entries: InventorySessionEntry[]): string {
-    const canonical = JSON.stringify({ schema_version: INVENTORY_SCHEMA_VERSION, entries });
+    const canonical = canonicalStringify({ schema_version: INVENTORY_SCHEMA_VERSION, entries });
     return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+  }
+
+  private storeSnapshot(
+    snapshotId: string,
+    clientId: string,
+    entries: InventorySessionEntry[],
+  ): void {
+    const key = this.snapshotKey(snapshotId, clientId);
+    this.snapshots.delete(key);
+    this.expiredSnapshots.delete(key);
+    while (this.snapshots.size >= this.maxSnapshots) {
+      const oldest = this.snapshots.keys().next().value;
+      if (oldest === undefined) break;
+      this.snapshots.delete(oldest);
+    }
+    this.snapshots.set(key, { entries, expiresAt: this.now() + this.ttlMs });
+  }
+
+  private touchSnapshot(key: string, snapshot: FrozenInventorySnapshot): void {
+    this.snapshots.delete(key);
+    this.snapshots.set(key, snapshot);
+  }
+
+  private snapshotKey(snapshotId: string, clientId: string): string {
+    return `${clientId}\u0000${snapshotId}`;
   }
 
   private encodeCursor(snapshotId: string, offset: number): string {
@@ -211,11 +265,7 @@ export class InventorySnapshotService {
       ) {
         throw new Error("invalid shape");
       }
-      const payload = parsed as CursorPayload;
-      if (payload.proof !== this.cursorProof(payload.snapshot_id, payload.offset)) {
-        throw new Error("invalid proof");
-      }
-      return payload;
+      return parsed as CursorPayload;
     } catch {
       throw new InventorySnapshotError("invalid_inventory_cursor", "inventory cursor is invalid");
     }
@@ -229,10 +279,59 @@ export class InventorySnapshotService {
 
   private removeExpiredSnapshots(): void {
     const now = this.now();
-    for (const [snapshotId, snapshot] of this.snapshots) {
+    for (const [snapshotKey, snapshot] of this.snapshots) {
       if (snapshot.expiresAt <= now) {
-        this.snapshots.delete(snapshotId);
+        this.expireSnapshot(snapshotKey);
       }
     }
   }
+
+  private expireSnapshot(snapshotKey: string): void {
+    this.snapshots.delete(snapshotKey);
+    this.expiredSnapshots.delete(snapshotKey);
+    this.expiredSnapshots.add(snapshotKey);
+    while (this.expiredSnapshots.size > this.maxSnapshots) {
+      const oldest = this.expiredSnapshots.values().next().value;
+      if (oldest === undefined) break;
+      this.expiredSnapshots.delete(oldest);
+    }
+  }
+}
+
+function compareInventoryIdentity(
+  left: InventorySessionEntry,
+  right: InventorySessionEntry,
+): number {
+  const backendOrder = compareCodeUnits(left.backend, right.backend);
+  if (backendOrder !== 0) return backendOrder;
+  const nativeIdOrder = compareCodeUnits(left.native_id, right.native_id);
+  if (nativeIdOrder !== 0) return nativeIdOrder;
+  return 0;
+}
+
+function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new InventorySnapshotError("inventory_snapshot_conflict", "non-finite inventory value");
+    }
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalStringify).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).sort(compareCodeUnits);
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalStringify(record[key])}`).join(",")}}`;
+  }
+  throw new InventorySnapshotError("inventory_snapshot_conflict", "unsupported inventory value");
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }

--- a/packages/server/src/server/atomic-file.ts
+++ b/packages/server/src/server/atomic-file.ts
@@ -5,13 +5,17 @@ import path from "node:path";
 export async function writeFileAtomic(
   filePath: string,
   data: string | NodeJS.ArrayBufferView,
+  tempDir?: string,
 ): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   const tempPath = path.join(
-    path.dirname(filePath),
+    tempDir ?? path.dirname(filePath),
     `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
   );
   try {
+    if (tempDir !== undefined) {
+      await fs.mkdir(tempDir, { recursive: true });
+    }
     await fs.writeFile(tempPath, data, "utf8");
     await fs.rename(tempPath, filePath);
   } catch (error) {
@@ -20,6 +24,10 @@ export async function writeFileAtomic(
   }
 }
 
-export async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
-  await writeFileAtomic(filePath, JSON.stringify(value, null, 2));
+export async function writeJsonFileAtomic(
+  filePath: string,
+  value: unknown,
+  tempDir?: string,
+): Promise<void> {
+  await writeFileAtomic(filePath, JSON.stringify(value, null, 2), tempDir);
 }

--- a/packages/server/src/server/session-inventory.e2e.test.ts
+++ b/packages/server/src/server/session-inventory.e2e.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { promises as fs } from "node:fs";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
@@ -13,6 +14,14 @@ let client: DaemonClient;
 let cwd: string;
 const clientId = "inventory-reconnect-fixture";
 const execFileAsync = promisify(execFile);
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 async function registryTreeHash(root: string): Promise<string> {
   const hash = createHash("sha256");
@@ -181,4 +190,58 @@ test("CLI inventory sees post-start persisted state and fails closed for a post-
   const beforeFailure = await registryTreeHash(registry);
   await expect(inventoryViaCli(daemon.port)).rejects.toThrow("inventory_malformed_state");
   expect(await registryTreeHash(registry)).toBe(beforeFailure);
+}, 30000);
+
+test("inventory never returns an impossible persisted/live union during cross-authority capture", async () => {
+  const registry = path.join(daemon.paseoHome, "agents");
+  await mkdir(registry, { recursive: true });
+
+  const rootReaddirReached = deferred<void>();
+  const allowFirstRootReaddir = deferred<void>();
+  const originalReaddir = fs.readdir;
+  let heldFirstRootReaddir = false;
+  const readdirSpy = vi.spyOn(fs, "readdir").mockImplementation((async (
+    ...args: Parameters<typeof fs.readdir>
+  ) => {
+    const entries = await originalReaddir(...args);
+    if (!heldFirstRootReaddir && args[0] === registry) {
+      heldFirstRootReaddir = true;
+      rootReaddirReached.resolve();
+      await allowFirstRootReaddir.promise;
+    }
+    return entries;
+  }) as typeof fs.readdir);
+
+  try {
+    const inventory = client.inventorySessions({ limit: 200 });
+    await rootReaddirReached.promise;
+
+    const persistedDir = path.join(registry, "race-project");
+    await mkdir(persistedDir, { recursive: true });
+    await writeFile(
+      path.join(persistedDir, "persisted-race.json"),
+      JSON.stringify({
+        id: "persisted-race",
+        provider: "codex",
+        cwd: "/tmp/persisted-race",
+        createdAt: "2026-08-14T00:00:00.000Z",
+        updatedAt: "2026-08-14T00:00:00.000Z",
+        lastStatus: "idle",
+      }),
+      "utf8",
+    );
+    const live = await client.createAgent({
+      config: { ...getFullAccessConfig("codex"), cwd, title: "live-race" },
+    });
+
+    allowFirstRootReaddir.resolve();
+    const page = await inventory;
+    const identities = page.entries.map((entry) => entry.native_id);
+    expect(identities).toContain("persisted-race");
+    expect(identities).toContain(live.id);
+    expect(identities).not.toEqual([live.id]);
+  } finally {
+    allowFirstRootReaddir.resolve();
+    readdirSpy.mockRestore();
+  }
 }, 30000);

--- a/packages/server/src/server/session-inventory.e2e.test.ts
+++ b/packages/server/src/server/session-inventory.e2e.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, expect, test } from "vitest";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createTestPaseoDaemon, DaemonClient, type TestPaseoDaemon } from "./test-utils/index.js";
@@ -9,6 +12,44 @@ let daemon: TestPaseoDaemon;
 let client: DaemonClient;
 let cwd: string;
 const clientId = "inventory-reconnect-fixture";
+const execFileAsync = promisify(execFile);
+
+async function registryTreeHash(root: string): Promise<string> {
+  const hash = createHash("sha256");
+  async function visit(directory: string, relative = ""): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries.sort((left, right) => (left.name < right.name ? -1 : 1))) {
+      const entryPath = path.join(directory, entry.name);
+      const entryRelative = path.join(relative, entry.name);
+      hash.update(`${entry.isDirectory() ? "d" : "f"}\u0000${entryRelative}\u0000`);
+      if (entry.isDirectory()) {
+        await visit(entryPath, entryRelative);
+      } else {
+        hash.update(await readFile(entryPath));
+      }
+    }
+  }
+  await visit(root);
+  return hash.digest("hex");
+}
+
+async function inventoryViaCli(
+  daemonPort: number,
+): Promise<{ entries: Array<Record<string, unknown>> }> {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      path.join(process.cwd(), "packages/cli/bin/paseo"),
+      "inventory",
+      "sessions",
+      "--host",
+      `127.0.0.1:${daemonPort}`,
+      "--json",
+    ],
+    { cwd: process.cwd() },
+  );
+  return JSON.parse(stdout) as { entries: Array<Record<string, unknown>> };
+}
 
 beforeEach(async () => {
   daemon = await createTestPaseoDaemon();
@@ -108,4 +149,36 @@ test("reports a seeded persisted-only running status as non-live", async () => {
     await persistedDaemon.close();
     await rm(homeRoot, { recursive: true, force: true });
   }
+}, 30000);
+
+test("CLI inventory sees post-start persisted state and fails closed for a post-start unknown entry", async () => {
+  expect((await inventoryViaCli(daemon.port)).entries).toEqual([]);
+
+  const registry = path.join(daemon.paseoHome, "agents");
+  const lateDir = path.join(registry, "late-project");
+  await mkdir(lateDir, { recursive: true });
+  await writeFile(
+    path.join(lateDir, "late-agent.json"),
+    JSON.stringify({
+      id: "late-agent",
+      provider: "codex",
+      cwd: "/tmp/late-agent",
+      createdAt: "2026-08-13T00:00:00.000Z",
+      updatedAt: "2026-08-13T00:00:00.000Z",
+      lastStatus: "idle",
+    }),
+    "utf8",
+  );
+  const beforeValidRead = await registryTreeHash(registry);
+  const fresh = await inventoryViaCli(daemon.port);
+  expect(fresh.entries).toContainEqual(
+    expect.objectContaining({ native_id: "late-agent", live: false }),
+  );
+  expect(await registryTreeHash(registry)).toBe(beforeValidRead);
+
+  const unknown = path.join(registry, "unexpected.unknown");
+  await writeFile(unknown, "unexpected", "utf8");
+  const beforeFailure = await registryTreeHash(registry);
+  await expect(inventoryViaCli(daemon.port)).rejects.toThrow("inventory_malformed_state");
+  expect(await registryTreeHash(registry)).toBe(beforeFailure);
 }, 30000);

--- a/packages/server/src/server/session-inventory.e2e.test.ts
+++ b/packages/server/src/server/session-inventory.e2e.test.ts
@@ -1,26 +1,35 @@
 import { afterEach, beforeEach, expect, test } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { createDaemonTestContext, type DaemonTestContext } from "./test-utils/index.js";
+import { createTestPaseoDaemon, DaemonClient, type TestPaseoDaemon } from "./test-utils/index.js";
 import { getFullAccessConfig } from "./daemon-e2e/agent-configs.js";
 
-let ctx: DaemonTestContext;
+let daemon: TestPaseoDaemon;
+let client: DaemonClient;
 let cwd: string;
+const clientId = "inventory-reconnect-fixture";
 
 beforeEach(async () => {
-  ctx = await createDaemonTestContext();
+  daemon = await createTestPaseoDaemon();
+  client = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    clientId,
+  });
+  await client.connect();
+  await client.fetchAgents({ subscribe: { subscriptionId: "inventory-fixture" } });
   cwd = await mkdtemp(path.join(tmpdir(), "paseo-inventory-e2e-"));
 });
 
 afterEach(async () => {
-  await ctx.cleanup();
+  await client.close();
+  await daemon.close();
   await rm(cwd, { recursive: true, force: true });
 });
 
-test("enumerates an isolated daemon inventory beyond the legacy 200-row ceiling", async () => {
-  for (let index = 0; index < 201; index += 1) {
-    await ctx.client.createAgent({
+test("reconnects an isolated daemon inventory snapshot across 200 fixture records", async () => {
+  for (let index = 0; index < 200; index += 1) {
+    await client.createAgent({
       config: {
         ...getFullAccessConfig("codex"),
         cwd,
@@ -29,27 +38,74 @@ test("enumerates an isolated daemon inventory beyond the legacy 200-row ceiling"
     });
   }
 
-  const first = await ctx.client.inventorySessions({ limit: 200 });
+  const first = await client.inventorySessions({ limit: 100 });
   expect(first).toMatchObject({
     schema_version: "paseo.inventory_sessions.v1",
     entries: expect.any(Array),
     has_more: true,
   });
-  expect(first.entries).toHaveLength(200);
+  expect(first.entries).toHaveLength(100);
   expect(first.next_cursor).not.toBeNull();
 
-  const second = await ctx.client.inventorySessions({
+  await client.close();
+  client = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    clientId,
+  });
+  await client.connect();
+
+  const second = await client.inventorySessions({
     snapshot_id: first.snapshot_id,
     cursor: first.next_cursor!,
-    limit: 200,
+    limit: 100,
   });
   expect(second).toMatchObject({
     snapshot_id: first.snapshot_id,
     has_more: false,
     next_cursor: null,
   });
-  expect(second.entries).toHaveLength(1);
+  expect(second.entries).toHaveLength(100);
 
   const identities = [...first.entries, ...second.entries].map((entry) => entry.native_id);
-  expect(new Set(identities)).toHaveLength(201);
+  expect(new Set(identities)).toHaveLength(200);
 }, 60000);
+
+test("reports a seeded persisted-only running status as non-live", async () => {
+  const homeRoot = await mkdtemp(path.join(tmpdir(), "paseo-inventory-persisted-"));
+  const recordDir = path.join(homeRoot, ".paseo", "agents", "tmp-persisted-only");
+  const recordPath = path.join(recordDir, "persisted-only.json");
+  await mkdir(recordDir, { recursive: true });
+  await writeFile(
+    recordPath,
+    JSON.stringify({
+      id: "persisted-only",
+      provider: "codex",
+      cwd: "/tmp/persisted-only",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-10T00:00:00.000Z",
+      lastStatus: "running",
+    }),
+    "utf8",
+  );
+
+  const persistedDaemon = await createTestPaseoDaemon({ paseoHomeRoot: homeRoot });
+  const persistedClient = new DaemonClient({
+    url: `ws://127.0.0.1:${persistedDaemon.port}/ws`,
+    clientId: "persisted-only-fixture",
+  });
+  try {
+    await persistedClient.connect();
+    const page = await persistedClient.inventorySessions({ limit: 200 });
+    expect(page.entries).toContainEqual(
+      expect.objectContaining({
+        native_id: "persisted-only",
+        status_raw: "running",
+        live: false,
+      }),
+    );
+  } finally {
+    await persistedClient.close();
+    await persistedDaemon.close();
+    await rm(homeRoot, { recursive: true, force: true });
+  }
+}, 30000);

--- a/packages/server/src/server/session-inventory.e2e.test.ts
+++ b/packages/server/src/server/session-inventory.e2e.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createDaemonTestContext, type DaemonTestContext } from "./test-utils/index.js";
+import { getFullAccessConfig } from "./daemon-e2e/agent-configs.js";
+
+let ctx: DaemonTestContext;
+let cwd: string;
+
+beforeEach(async () => {
+  ctx = await createDaemonTestContext();
+  cwd = await mkdtemp(path.join(tmpdir(), "paseo-inventory-e2e-"));
+});
+
+afterEach(async () => {
+  await ctx.cleanup();
+  await rm(cwd, { recursive: true, force: true });
+});
+
+test("enumerates an isolated daemon inventory beyond the legacy 200-row ceiling", async () => {
+  for (let index = 0; index < 201; index += 1) {
+    await ctx.client.createAgent({
+      config: {
+        ...getFullAccessConfig("codex"),
+        cwd,
+        title: `inventory-fixture-${index}`,
+      },
+    });
+  }
+
+  const first = await ctx.client.inventorySessions({ limit: 200 });
+  expect(first).toMatchObject({
+    schema_version: "paseo.inventory_sessions.v1",
+    entries: expect.any(Array),
+    has_more: true,
+  });
+  expect(first.entries).toHaveLength(200);
+  expect(first.next_cursor).not.toBeNull();
+
+  const second = await ctx.client.inventorySessions({
+    snapshot_id: first.snapshot_id,
+    cursor: first.next_cursor!,
+    limit: 200,
+  });
+  expect(second).toMatchObject({
+    snapshot_id: first.snapshot_id,
+    has_more: false,
+    next_cursor: null,
+  });
+  expect(second.entries).toHaveLength(1);
+
+  const identities = [...first.entries, ...second.entries].map((entry) => entry.native_id);
+  expect(new Set(identities)).toHaveLength(201);
+}, 60000);

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -495,7 +495,7 @@ test("routes plugin management requests and catalog notifications", async () => 
   expect(listeners.size).toBe(0);
 });
 
-test("inventory capture marks live lifecycle and persisted lastStatus provenance explicitly", () => {
+test("inventory capture marks live lifecycle and persisted lastStatus provenance explicitly", async () => {
   const storedRecords = [
     {
       id: "persisted-only",
@@ -536,10 +536,10 @@ test("inventory capture marks live lifecycle and persisted lastStatus provenance
     listAgentsForInventory: () => liveAgents,
   } as unknown as AgentManager;
   const agentStorage = {
-    inventoryState: () => ({ records: storedRecords, issues: [] }),
+    inventoryFreshState: async () => ({ records: storedRecords, issues: [] }),
   } as unknown as AgentStorage;
 
-  const first = captureInventorySessions(agentManager, agentStorage);
+  const first = await captureInventorySessions(agentManager, agentStorage);
   expect(first).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -560,11 +560,11 @@ test("inventory capture marks live lifecycle and persisted lastStatus provenance
   const snapshots = new InventorySnapshotService(() =>
     captureInventorySessions(agentManager, agentStorage),
   );
-  const liveSnapshot = snapshots.page({}, "client-a").snapshot_id;
+  const liveSnapshot = (await snapshots.page({}, "client-a")).snapshot_id;
   liveAgents = [];
-  const persistedSnapshot = snapshots.page({}, "client-a").snapshot_id;
+  const persistedSnapshot = (await snapshots.page({}, "client-a")).snapshot_id;
   expect(persistedSnapshot).not.toBe(liveSnapshot);
-  expect(snapshots.page({}, "client-a").entries).toEqual(
+  expect((await snapshots.page({}, "client-a")).entries).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         native_id: "live-and-persisted",
@@ -675,7 +675,7 @@ test("inventory RPC fails closed before creating a snapshot for an unreadable re
     messages,
     agentManager: { listAgentsForInventory: vi.fn(() => []) },
     agentStorage: {
-      inventoryState: vi.fn(() => ({
+      inventoryFreshState: vi.fn(async () => ({
         records: [],
         issues: [{ path: "/tmp/paseo-home/agents/project", reason: "unreadable_path" }],
       })),

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -20,7 +20,10 @@ import {
 } from "@getpaseo/protocol/binary-frames/index";
 import { captureInventorySessions, isSessionRpcAllowed, Session } from "./session.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
-import { InventorySnapshotService } from "./agent/inventory-snapshot-service.js";
+import {
+  InventorySnapshotService,
+  type InventorySessionEntry,
+} from "./agent/inventory-snapshot-service.js";
 import { StructuredAgentFallbackError } from "./agent/agent-response-loop.js";
 import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
 import type { AgentManager, AgentManagerEvent } from "./agent/agent-manager.js";
@@ -730,6 +733,86 @@ test("inventory RPC fails closed before creating a snapshot for an unreadable re
       payload: expect.objectContaining({ code: "inventory_malformed_state" }),
     }),
   ]);
+});
+
+test("inventory sessions RPC paginates 401 records into three 200/200/1 pages", async () => {
+  const entries: InventorySessionEntry[] = Array.from({ length: 401 }, (_, index) => ({
+    backend: "paseo",
+    native_id: `session-${String(index).padStart(4, "0")}`,
+    provider: "claude",
+    status_raw: "idle",
+    archived: false,
+    archived_at: null,
+    internal: false,
+    live: false,
+    cwd: `/worktree/${index}`,
+    created_at: "2026-08-10T00:00:00.000Z",
+    updated_at: "2026-08-10T00:00:00.000Z",
+    persistence_session_id: `provider-${index}`,
+  }));
+  const snapshots = new InventorySnapshotService(() => entries);
+  const messages: SessionOutboundMessage[] = [];
+  const session = createSessionForTest({
+    clientId: "client-401",
+    inventorySnapshots: snapshots,
+    messages,
+  });
+
+  await session.handleMessage({
+    type: "inventory.sessions.request",
+    requestId: "p1",
+    limit: 200,
+  });
+  const r1 = messages.find(
+    (msg): msg is Extract<SessionOutboundMessage, { type: "inventory.sessions.response" }> =>
+      msg.type === "inventory.sessions.response" && msg.payload.requestId === "p1",
+  );
+  expect(r1).toBeDefined();
+  expect(r1!.payload.entries).toHaveLength(200);
+  expect(r1!.payload.has_more).toBe(true);
+  expect(r1!.payload.next_cursor).toEqual(expect.any(String));
+  const snapshotId = r1!.payload.snapshot_id;
+
+  await session.handleMessage({
+    type: "inventory.sessions.request",
+    requestId: "p2",
+    snapshot_id: snapshotId,
+    cursor: r1!.payload.next_cursor!,
+    limit: 200,
+  });
+  const r2 = messages.find(
+    (msg): msg is Extract<SessionOutboundMessage, { type: "inventory.sessions.response" }> =>
+      msg.type === "inventory.sessions.response" && msg.payload.requestId === "p2",
+  );
+  expect(r2).toBeDefined();
+  expect(r2!.payload.entries).toHaveLength(200);
+  expect(r2!.payload.has_more).toBe(true);
+  expect(r2!.payload.next_cursor).toEqual(expect.any(String));
+  expect(r2!.payload.snapshot_id).toBe(snapshotId);
+
+  await session.handleMessage({
+    type: "inventory.sessions.request",
+    requestId: "p3",
+    snapshot_id: snapshotId,
+    cursor: r2!.payload.next_cursor!,
+    limit: 200,
+  });
+  const r3 = messages.find(
+    (msg): msg is Extract<SessionOutboundMessage, { type: "inventory.sessions.response" }> =>
+      msg.type === "inventory.sessions.response" && msg.payload.requestId === "p3",
+  );
+  expect(r3).toBeDefined();
+  expect(r3!.payload.entries).toHaveLength(1);
+  expect(r3!.payload.has_more).toBe(false);
+  expect(r3!.payload.next_cursor).toBeNull();
+  expect(r3!.payload.snapshot_id).toBe(snapshotId);
+
+  const allIds = [...r1!.payload.entries, ...r2!.payload.entries, ...r3!.payload.entries].map(
+    (entry) => entry.native_id,
+  );
+  expect(allIds).toHaveLength(401);
+  expect(new Set(allIds)).toHaveLength(401);
+  expect(allIds).toEqual([...allIds].sort());
 });
 
 describe("session authorization scopes", () => {

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -18,11 +18,12 @@ import {
   FileTransferOpcode,
   type FileTransferFrame,
 } from "@getpaseo/protocol/binary-frames/index";
-import { isSessionRpcAllowed, Session } from "./session.js";
+import { captureInventorySessions, isSessionRpcAllowed, Session } from "./session.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
+import { InventorySnapshotService } from "./agent/inventory-snapshot-service.js";
 import { StructuredAgentFallbackError } from "./agent/agent-response-loop.js";
-import type { StoredAgentRecord } from "./agent/agent-storage.js";
-import type { AgentManagerEvent } from "./agent/agent-manager.js";
+import type { AgentStorage, StoredAgentRecord } from "./agent/agent-storage.js";
+import type { AgentManager, AgentManagerEvent } from "./agent/agent-manager.js";
 import type { ProviderSnapshotManager } from "./agent/provider-snapshot-manager.js";
 import { createPersistedProjectRecord } from "./workspace-registry.js";
 import { deriveProjectKey } from "./project-key.js";
@@ -280,9 +281,11 @@ vi.mock("./worktree-bootstrap.js", async (importOriginal) => {
 });
 
 interface SessionForTestOptions {
+  clientId?: string;
   scopes?: readonly string[];
   agentManager?: { [K in keyof SessionOptions["agentManager"]]?: unknown };
   agentStorage?: { [K in keyof SessionOptions["agentStorage"]]?: unknown };
+  inventorySnapshots?: SessionOptions["inventorySnapshots"];
   github?: Partial<ForgeService & GitHubService>;
   checkoutDiffManager?: { scheduleRefreshForCwd: ReturnType<typeof vi.fn> };
   workspaceGitService?: {
@@ -356,7 +359,7 @@ function createSessionForTest(options: SessionForTestOptions = {}): Session {
   const messages = options.messages ?? [];
 
   const sessionOptions: SessionOptions = {
-    clientId: "test-client",
+    clientId: options.clientId ?? "test-client",
     onMessage: (message) => messages.push(message),
     ...(options.targetedMessages
       ? {
@@ -380,6 +383,7 @@ function createSessionForTest(options: SessionForTestOptions = {}): Session {
       list: vi.fn().mockResolvedValue([]),
       ...options.agentStorage,
     }),
+    inventorySnapshots: options.inventorySnapshots,
     projectRegistry: {
       list: vi.fn().mockResolvedValue([]),
       get: vi.fn(),
@@ -489,6 +493,207 @@ test("routes plugin management requests and catalog notifications", async () => 
   });
   await session.cleanup();
   expect(listeners.size).toBe(0);
+});
+
+test("inventory capture marks live lifecycle and persisted lastStatus provenance explicitly", () => {
+  const storedRecords = [
+    {
+      id: "persisted-only",
+      provider: "claude",
+      lastStatus: "running",
+      archivedAt: null,
+      internal: false,
+      cwd: "/tmp/persisted",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-10T00:00:00.000Z",
+      persistence: { sessionId: "persisted-provider-session" },
+    },
+    {
+      id: "live-and-persisted",
+      provider: "claude",
+      lastStatus: "closed",
+      archivedAt: null,
+      internal: false,
+      cwd: "/tmp/persisted-live",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-10T00:00:00.000Z",
+      persistence: { sessionId: "persisted-live-provider-session" },
+    },
+  ] as unknown as StoredAgentRecord[];
+  let liveAgents = [
+    {
+      id: "live-and-persisted",
+      provider: "claude",
+      lifecycle: "running",
+      internal: false,
+      cwd: "/tmp/live",
+      createdAt: new Date("2026-08-10T00:00:00.000Z"),
+      updatedAt: new Date("2026-08-10T00:01:00.000Z"),
+      persistence: { sessionId: "live-provider-session" },
+    },
+  ];
+  const agentManager = {
+    listAgentsForInventory: () => liveAgents,
+  } as unknown as AgentManager;
+  const agentStorage = {
+    inventoryState: () => ({ records: storedRecords, issues: [] }),
+  } as unknown as AgentStorage;
+
+  const first = captureInventorySessions(agentManager, agentStorage);
+  expect(first).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        native_id: "persisted-only",
+        status_raw: "running",
+        live: false,
+      }),
+      expect.objectContaining({
+        native_id: "live-and-persisted",
+        status_raw: "running",
+        live: true,
+        cwd: "/tmp/live",
+        persistence_session_id: "live-provider-session",
+      }),
+    ]),
+  );
+
+  const snapshots = new InventorySnapshotService(() =>
+    captureInventorySessions(agentManager, agentStorage),
+  );
+  const liveSnapshot = snapshots.page({}, "client-a").snapshot_id;
+  liveAgents = [];
+  const persistedSnapshot = snapshots.page({}, "client-a").snapshot_id;
+  expect(persistedSnapshot).not.toBe(liveSnapshot);
+  expect(snapshots.page({}, "client-a").entries).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        native_id: "live-and-persisted",
+        status_raw: "closed",
+        live: false,
+      }),
+    ]),
+  );
+});
+
+test("a daemon-shared inventory service survives a session reconnect for the same client", async () => {
+  const snapshots = new InventorySnapshotService(() => [
+    {
+      backend: "paseo" as const,
+      native_id: "agent-1",
+      provider: "claude",
+      status_raw: "idle",
+      archived: false,
+      archived_at: null,
+      internal: false,
+      live: true,
+      cwd: "/tmp/agent-1",
+      created_at: "2026-08-10T00:00:00.000Z",
+      updated_at: "2026-08-10T00:00:00.000Z",
+      persistence_session_id: null,
+    },
+    {
+      backend: "paseo" as const,
+      native_id: "agent-2",
+      provider: "claude",
+      status_raw: "idle",
+      archived: false,
+      archived_at: null,
+      internal: false,
+      live: true,
+      cwd: "/tmp/agent-2",
+      created_at: "2026-08-10T00:00:00.000Z",
+      updated_at: "2026-08-10T00:00:00.000Z",
+      persistence_session_id: null,
+    },
+  ]);
+  const firstMessages: SessionOutboundMessage[] = [];
+  const firstSession = createSessionForTest({
+    clientId: "reconnecting-client",
+    inventorySnapshots: snapshots,
+    messages: firstMessages,
+  });
+  await firstSession.handleMessage({
+    type: "inventory.sessions.request",
+    requestId: "page-1",
+    limit: 1,
+  });
+  const firstResponse = firstMessages.find(
+    (
+      message,
+    ): message is Extract<SessionOutboundMessage, { type: "inventory.sessions.response" }> =>
+      message.type === "inventory.sessions.response",
+  );
+  expect(firstResponse?.payload.next_cursor).toEqual(expect.any(String));
+
+  const secondMessages: SessionOutboundMessage[] = [];
+  const reconnectedSession = createSessionForTest({
+    clientId: "reconnecting-client",
+    inventorySnapshots: snapshots,
+    messages: secondMessages,
+  });
+  await reconnectedSession.handleMessage({
+    type: "inventory.sessions.request",
+    requestId: "page-2",
+    snapshot_id: firstResponse!.payload.snapshot_id,
+    cursor: firstResponse!.payload.next_cursor!,
+    limit: 1,
+  });
+  expect(secondMessages).toContainEqual(
+    expect.objectContaining({
+      type: "inventory.sessions.response",
+      payload: expect.objectContaining({
+        has_more: false,
+        snapshot_id: firstResponse!.payload.snapshot_id,
+      }),
+    }),
+  );
+
+  const foreignMessages: SessionOutboundMessage[] = [];
+  const foreignSession = createSessionForTest({
+    clientId: "different-client",
+    inventorySnapshots: snapshots,
+    messages: foreignMessages,
+  });
+  await foreignSession.handleMessage({
+    type: "inventory.sessions.request",
+    requestId: "foreign-page-2",
+    snapshot_id: firstResponse!.payload.snapshot_id,
+    cursor: firstResponse!.payload.next_cursor!,
+    limit: 1,
+  });
+  expect(foreignMessages).toContainEqual(
+    expect.objectContaining({
+      type: "rpc_error",
+      payload: expect.objectContaining({ code: "inventory_snapshot_not_found" }),
+    }),
+  );
+});
+
+test("inventory RPC fails closed before creating a snapshot for an unreadable registry path", async () => {
+  const messages: SessionOutboundMessage[] = [];
+  const session = createSessionForTest({
+    messages,
+    agentManager: { listAgentsForInventory: vi.fn(() => []) },
+    agentStorage: {
+      inventoryState: vi.fn(() => ({
+        records: [],
+        issues: [{ path: "/tmp/paseo-home/agents/project", reason: "unreadable_path" }],
+      })),
+    },
+  });
+
+  await session.handleMessage({
+    type: "inventory.sessions.request",
+    requestId: "unreadable-registry",
+    limit: 1,
+  });
+
+  expect(messages).toEqual([
+    expect.objectContaining({
+      type: "rpc_error",
+      payload: expect.objectContaining({ code: "inventory_malformed_state" }),
+    }),
+  ]);
 });
 
 describe("session authorization scopes", () => {

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -532,8 +532,9 @@ test("inventory capture marks live lifecycle and persisted lastStatus provenance
       persistence: { sessionId: "live-provider-session" },
     },
   ];
+  let liveEpoch = 0;
   const agentManager = {
-    listAgentsForInventory: () => liveAgents,
+    captureInventoryLiveState: () => ({ epoch: liveEpoch, agents: liveAgents }),
   } as unknown as AgentManager;
   const agentStorage = {
     inventoryFreshState: async () => ({ records: storedRecords, issues: [] }),
@@ -562,6 +563,7 @@ test("inventory capture marks live lifecycle and persisted lastStatus provenance
   );
   const liveSnapshot = (await snapshots.page({}, "client-a")).snapshot_id;
   liveAgents = [];
+  liveEpoch += 1;
   const persistedSnapshot = (await snapshots.page({}, "client-a")).snapshot_id;
   expect(persistedSnapshot).not.toBe(liveSnapshot);
   expect((await snapshots.page({}, "client-a")).entries).toEqual(
@@ -573,6 +575,40 @@ test("inventory capture marks live lifecycle and persisted lastStatus provenance
       }),
     ]),
   );
+});
+
+test("inventory capture retries the whole cross-authority capture after live epoch drift", async () => {
+  let epoch = 0;
+  let scans = 0;
+  const agentManager = {
+    captureInventoryLiveState: () => ({ epoch, agents: [] }),
+  } as unknown as AgentManager;
+  const agentStorage = {
+    inventoryFreshState: async () => {
+      scans += 1;
+      if (scans === 1) {
+        epoch += 1;
+      }
+      return { records: [], issues: [] };
+    },
+  } as unknown as AgentStorage;
+
+  await expect(captureInventorySessions(agentManager, agentStorage)).resolves.toEqual([]);
+  expect(scans).toBe(2);
+});
+
+test("inventory capture fails closed after bounded cross-authority drift retries", async () => {
+  let epoch = 0;
+  const agentManager = {
+    captureInventoryLiveState: () => ({ epoch: epoch++, agents: [] }),
+  } as unknown as AgentManager;
+  const agentStorage = {
+    inventoryFreshState: async () => ({ records: [], issues: [] }),
+  } as unknown as AgentStorage;
+
+  await expect(captureInventorySessions(agentManager, agentStorage)).rejects.toMatchObject({
+    code: "inventory_state_changed",
+  });
 });
 
 test("a daemon-shared inventory service survives a session reconnect for the same client", async () => {
@@ -673,7 +709,7 @@ test("inventory RPC fails closed before creating a snapshot for an unreadable re
   const messages: SessionOutboundMessage[] = [];
   const session = createSessionForTest({
     messages,
-    agentManager: { listAgentsForInventory: vi.fn(() => []) },
+    agentManager: { captureInventoryLiveState: vi.fn(() => ({ epoch: 0, agents: [] })) },
     agentStorage: {
       inventoryFreshState: vi.fn(async () => ({
         records: [],

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -429,22 +429,48 @@ async function captureFreshInventorySessions(
   agentManager: AgentManager,
   agentStorage: AgentStorage,
 ): Promise<InventorySessionEntry[]> {
-  const registry = await agentStorage.inventoryFreshState();
-  if (registry.issues.length > 0) {
-    throw new SessionRequestError(
-      "inventory_malformed_state",
-      `Paseo registry contains ${registry.issues.length} malformed, duplicate, unreadable, or changing path(s)`,
-    );
+  // The two inventory authorities do not share a filesystem lock. Capture the
+  // live map before the asynchronous verified registry scan, then require its
+  // generation to remain unchanged until the scan has completed. If it did,
+  // the live projection was constant at the registry scan's materialization
+  // point, so their union has a real linearization point.
+  for (let attempt = 0; attempt < INVENTORY_CAPTURE_MAX_ATTEMPTS; attempt += 1) {
+    const live = agentManager.captureInventoryLiveState();
+    const registry = await agentStorage.inventoryFreshState();
+    if (registry.issues.length > 0) {
+      if (registry.issues.every((issue) => issue.reason === "registry_changed")) {
+        continue;
+      }
+      throw new SessionRequestError(
+        "inventory_malformed_state",
+        `Paseo registry contains ${registry.issues.length} malformed, duplicate, or unreadable path(s)`,
+      );
+    }
+    if (agentManager.captureInventoryLiveState().epoch !== live.epoch) {
+      continue;
+    }
+
+    return materializeInventorySessions(registry.records, live.agents);
   }
 
-  // The fresh scan is complete before this one synchronous AgentManager read.
-  // InventorySnapshotService freezes the resulting union before pagination.
-  const storedById = new Map(registry.records.map((record) => [record.id, record]));
+  throw new SessionRequestError(
+    "inventory_state_changed",
+    "Paseo live state or registry changed while inventory was being materialized",
+  );
+}
+
+const INVENTORY_CAPTURE_MAX_ATTEMPTS = 3;
+
+function materializeInventorySessions(
+  records: StoredAgentRecord[],
+  liveAgents: ReturnType<AgentManager["captureInventoryLiveState"]>["agents"],
+): InventorySessionEntry[] {
+  const storedById = new Map(records.map((record) => [record.id, record]));
   const entriesById = new Map<string, InventorySessionEntry>();
-  for (const record of registry.records) {
+  for (const record of records) {
     entriesById.set(record.id, inventoryEntryFromStored(record));
   }
-  for (const live of agentManager.listAgentsForInventory()) {
+  for (const live of liveAgents) {
     const stored = storedById.get(live.id);
     if (stored && stored.provider !== live.provider) {
       throw new SessionRequestError(

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -418,6 +418,79 @@ class SessionRequestError extends Error {
   }
 }
 
+export function captureInventorySessions(
+  agentManager: AgentManager,
+  agentStorage: AgentStorage,
+): InventorySessionEntry[] {
+  const registry = agentStorage.inventoryState();
+  if (registry.issues.length > 0) {
+    throw new SessionRequestError(
+      "inventory_malformed_state",
+      `Paseo registry contains ${registry.issues.length} malformed, duplicate, or unreadable path(s)`,
+    );
+  }
+
+  // No await occurs between these two canonical in-memory reads. The snapshot
+  // service freezes the resulting union before pagination starts.
+  const storedById = new Map(registry.records.map((record) => [record.id, record]));
+  const entriesById = new Map<string, InventorySessionEntry>();
+  for (const record of registry.records) {
+    entriesById.set(record.id, inventoryEntryFromStored(record));
+  }
+  for (const live of agentManager.listAgentsForInventory()) {
+    const stored = storedById.get(live.id);
+    if (stored && stored.provider !== live.provider) {
+      throw new SessionRequestError(
+        "inventory_identity_conflict",
+        `Paseo agent ${live.id} has conflicting live and persisted providers`,
+      );
+    }
+    entriesById.set(live.id, {
+      backend: "paseo",
+      native_id: live.id,
+      provider: live.provider,
+      status_raw: live.lifecycle,
+      archived: Boolean(stored?.archivedAt),
+      archived_at: stored?.archivedAt ?? null,
+      internal: live.internal === true || stored?.internal === true,
+      live: true,
+      cwd: live.cwd,
+      created_at: live.createdAt.toISOString(),
+      updated_at: live.updatedAt.toISOString(),
+      persistence_session_id: live.persistence?.sessionId ?? stored?.persistence?.sessionId ?? null,
+    });
+  }
+  return Array.from(entriesById.values());
+}
+
+function inventoryEntryFromStored(record: StoredAgentRecord): InventorySessionEntry {
+  return {
+    backend: "paseo",
+    native_id: record.id,
+    provider: record.provider,
+    status_raw: record.lastStatus,
+    archived: Boolean(record.archivedAt),
+    archived_at: record.archivedAt ?? null,
+    internal: record.internal === true,
+    live: false,
+    cwd: record.cwd,
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+    persistence_session_id: record.persistence?.sessionId ?? null,
+  };
+}
+
+function resolveInventorySnapshotService(
+  inventorySnapshots: InventorySnapshotService | undefined,
+  agentManager: AgentManager,
+  agentStorage: AgentStorage,
+): InventorySnapshotService {
+  return (
+    inventorySnapshots ??
+    new InventorySnapshotService(() => captureInventorySessions(agentManager, agentStorage))
+  );
+}
+
 export interface SessionFileSystem {
   isDirectory(path: string): Promise<boolean>;
 }
@@ -451,6 +524,7 @@ export interface SessionOptions {
   worktreesRoot?: string;
   agentManager: AgentManager;
   agentStorage: AgentStorage;
+  inventorySnapshots?: InventorySnapshotService;
   projectRegistry: ProjectRegistry;
   workspaceRegistry: WorkspaceRegistry;
   directorySync?: DirectorySyncService;
@@ -731,6 +805,7 @@ export class Session {
       worktreesRoot,
       agentManager,
       agentStorage,
+      inventorySnapshots,
       projectRegistry,
       workspaceRegistry,
       directorySync,
@@ -801,7 +876,11 @@ export class Session {
     });
     this.agentManager = agentManager;
     this.agentStorage = agentStorage;
-    this.inventorySnapshots = new InventorySnapshotService(() => this.captureInventorySessions());
+    this.inventorySnapshots = resolveInventorySnapshotService(
+      inventorySnapshots,
+      this.agentManager,
+      this.agentStorage,
+    );
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
     this.directorySync = resolveDirectorySync(directorySync);
@@ -4175,67 +4254,6 @@ export class Session {
   /**
    * Build the current agent list payload (live + persisted), optionally filtered by labels.
    */
-  private captureInventorySessions(): InventorySessionEntry[] {
-    const registry = this.agentStorage.inventoryState();
-    if (registry.issues.length > 0) {
-      throw new SessionRequestError(
-        "inventory_malformed_state",
-        `Paseo registry contains ${registry.issues.length} malformed or duplicate record(s)`,
-      );
-    }
-
-    // This method intentionally performs no await. AgentStorage and AgentManager
-    // are the daemon's two canonical in-memory views; reading both in one event
-    // loop turn gives the materializer a single linearization point before it
-    // freezes pages in InventorySnapshotService.
-    const storedById = new Map(registry.records.map((record) => [record.id, record]));
-    const entriesById = new Map<string, InventorySessionEntry>();
-    for (const record of registry.records) {
-      entriesById.set(record.id, this.inventoryEntryFromStored(record));
-    }
-
-    for (const live of this.agentManager.listAgentsForInventory()) {
-      const stored = storedById.get(live.id);
-      if (stored && stored.provider !== live.provider) {
-        throw new SessionRequestError(
-          "inventory_identity_conflict",
-          `Paseo agent ${live.id} has conflicting live and persisted providers`,
-        );
-      }
-      entriesById.set(live.id, {
-        backend: "paseo",
-        native_id: live.id,
-        provider: live.provider,
-        status_raw: live.lifecycle,
-        archived: Boolean(stored?.archivedAt),
-        archived_at: stored?.archivedAt ?? null,
-        internal: live.internal === true || stored?.internal === true,
-        cwd: live.cwd,
-        created_at: live.createdAt.toISOString(),
-        updated_at: live.updatedAt.toISOString(),
-        persistence_session_id:
-          live.persistence?.sessionId ?? stored?.persistence?.sessionId ?? null,
-      });
-    }
-    return Array.from(entriesById.values());
-  }
-
-  private inventoryEntryFromStored(record: StoredAgentRecord): InventorySessionEntry {
-    return {
-      backend: "paseo",
-      native_id: record.id,
-      provider: record.provider,
-      status_raw: record.lastStatus,
-      archived: Boolean(record.archivedAt),
-      archived_at: record.archivedAt ?? null,
-      internal: record.internal === true,
-      cwd: record.cwd,
-      created_at: record.createdAt,
-      updated_at: record.updatedAt,
-      persistence_session_id: record.persistence?.sessionId ?? null,
-    };
-  }
-
   private async listAgentPayloads(filter?: {
     labels?: Record<string, string>;
     includeArchived?: boolean;
@@ -5315,11 +5333,14 @@ export class Session {
     request: Extract<SessionInboundMessage, { type: "inventory.sessions.request" }>,
   ): Promise<void> {
     try {
-      const page = this.inventorySnapshots.page({
-        snapshot_id: request.snapshot_id,
-        cursor: request.cursor,
-        limit: request.limit,
-      });
+      const page = this.inventorySnapshots.page(
+        {
+          snapshot_id: request.snapshot_id,
+          cursor: request.cursor,
+          limit: request.limit,
+        },
+        this.clientId,
+      );
       this.emit({
         type: "inventory.sessions.response",
         payload: { requestId: request.requestId, ...page },

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -421,17 +421,24 @@ class SessionRequestError extends Error {
 export function captureInventorySessions(
   agentManager: AgentManager,
   agentStorage: AgentStorage,
-): InventorySessionEntry[] {
-  const registry = agentStorage.inventoryState();
+): Promise<InventorySessionEntry[]> {
+  return captureFreshInventorySessions(agentManager, agentStorage);
+}
+
+async function captureFreshInventorySessions(
+  agentManager: AgentManager,
+  agentStorage: AgentStorage,
+): Promise<InventorySessionEntry[]> {
+  const registry = await agentStorage.inventoryFreshState();
   if (registry.issues.length > 0) {
     throw new SessionRequestError(
       "inventory_malformed_state",
-      `Paseo registry contains ${registry.issues.length} malformed, duplicate, or unreadable path(s)`,
+      `Paseo registry contains ${registry.issues.length} malformed, duplicate, unreadable, or changing path(s)`,
     );
   }
 
-  // No await occurs between these two canonical in-memory reads. The snapshot
-  // service freezes the resulting union before pagination starts.
+  // The fresh scan is complete before this one synchronous AgentManager read.
+  // InventorySnapshotService freezes the resulting union before pagination.
   const storedById = new Map(registry.records.map((record) => [record.id, record]));
   const entriesById = new Map<string, InventorySessionEntry>();
   for (const record of registry.records) {
@@ -5333,7 +5340,7 @@ export class Session {
     request: Extract<SessionInboundMessage, { type: "inventory.sessions.request" }>,
   ): Promise<void> {
     try {
-      const page = this.inventorySnapshots.page(
+      const page = await this.inventorySnapshots.page(
         {
           snapshot_id: request.snapshot_id,
           cursor: request.cursor,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -120,6 +120,11 @@ import {
 import type { StoredAgentRecord } from "./agent/agent-storage.js";
 import type { AgentStorage } from "./agent/agent-storage.js";
 import {
+  InventorySnapshotError,
+  InventorySnapshotService,
+  type InventorySessionEntry,
+} from "./agent/inventory-snapshot-service.js";
+import {
   ImportSessionsRequestError,
   importProviderSession,
   listImportableProviderSessions,
@@ -704,6 +709,7 @@ export class Session {
   private readonly hubExecutionController: HubExecutionController | null;
   private readonly workspaceScripts: WorkspaceScriptsService;
   private readonly createAgentLifecycleDispatch: CreateAgentLifecycleDispatch;
+  private readonly inventorySnapshots: InventorySnapshotService;
 
   constructor(options: SessionOptions) {
     const {
@@ -795,6 +801,7 @@ export class Session {
     });
     this.agentManager = agentManager;
     this.agentStorage = agentStorage;
+    this.inventorySnapshots = new InventorySnapshotService(() => this.captureInventorySessions());
     this.projectRegistry = projectRegistry;
     this.workspaceRegistry = workspaceRegistry;
     this.directorySync = resolveDirectorySync(directorySync);
@@ -2112,13 +2119,11 @@ export class Session {
   }
 
   private dispatchAgentLifecycleMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    const directoryOperation = this.dispatchAgentDirectoryMessage(msg);
+    if (directoryOperation) {
+      return directoryOperation;
+    }
     switch (msg.type) {
-      case "fetch_agents_request":
-        return this.handleFetchAgents(msg);
-      case "fetch_agent_history_request":
-        return this.handleFetchAgentHistory(msg);
-      case "fetch_recent_provider_sessions_request":
-        return this.handleFetchRecentProviderSessions(msg);
       case "fetch_agent_request":
         return this.handleFetchAgent(msg.agentId, msg.requestId);
       case "delete_agent_request":
@@ -2151,6 +2156,21 @@ export class Session {
         return this.handleAgentPermissionResponse(msg.agentId, msg.requestId, msg.response);
       case "clear_agent_attention":
         return this.handleClearAgentAttention(msg.agentId, msg.requestId);
+      default:
+        return undefined;
+    }
+  }
+
+  private dispatchAgentDirectoryMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    switch (msg.type) {
+      case "fetch_agents_request":
+        return this.handleFetchAgents(msg);
+      case "inventory.sessions.request":
+        return this.handleInventorySessions(msg);
+      case "fetch_agent_history_request":
+        return this.handleFetchAgentHistory(msg);
+      case "fetch_recent_provider_sessions_request":
+        return this.handleFetchRecentProviderSessions(msg);
       default:
         return undefined;
     }
@@ -4155,6 +4175,67 @@ export class Session {
   /**
    * Build the current agent list payload (live + persisted), optionally filtered by labels.
    */
+  private captureInventorySessions(): InventorySessionEntry[] {
+    const registry = this.agentStorage.inventoryState();
+    if (registry.issues.length > 0) {
+      throw new SessionRequestError(
+        "inventory_malformed_state",
+        `Paseo registry contains ${registry.issues.length} malformed or duplicate record(s)`,
+      );
+    }
+
+    // This method intentionally performs no await. AgentStorage and AgentManager
+    // are the daemon's two canonical in-memory views; reading both in one event
+    // loop turn gives the materializer a single linearization point before it
+    // freezes pages in InventorySnapshotService.
+    const storedById = new Map(registry.records.map((record) => [record.id, record]));
+    const entriesById = new Map<string, InventorySessionEntry>();
+    for (const record of registry.records) {
+      entriesById.set(record.id, this.inventoryEntryFromStored(record));
+    }
+
+    for (const live of this.agentManager.listAgentsForInventory()) {
+      const stored = storedById.get(live.id);
+      if (stored && stored.provider !== live.provider) {
+        throw new SessionRequestError(
+          "inventory_identity_conflict",
+          `Paseo agent ${live.id} has conflicting live and persisted providers`,
+        );
+      }
+      entriesById.set(live.id, {
+        backend: "paseo",
+        native_id: live.id,
+        provider: live.provider,
+        status_raw: live.lifecycle,
+        archived: Boolean(stored?.archivedAt),
+        archived_at: stored?.archivedAt ?? null,
+        internal: live.internal === true || stored?.internal === true,
+        cwd: live.cwd,
+        created_at: live.createdAt.toISOString(),
+        updated_at: live.updatedAt.toISOString(),
+        persistence_session_id:
+          live.persistence?.sessionId ?? stored?.persistence?.sessionId ?? null,
+      });
+    }
+    return Array.from(entriesById.values());
+  }
+
+  private inventoryEntryFromStored(record: StoredAgentRecord): InventorySessionEntry {
+    return {
+      backend: "paseo",
+      native_id: record.id,
+      provider: record.provider,
+      status_raw: record.lastStatus,
+      archived: Boolean(record.archivedAt),
+      archived_at: record.archivedAt ?? null,
+      internal: record.internal === true,
+      cwd: record.cwd,
+      created_at: record.createdAt,
+      updated_at: record.updatedAt,
+      persistence_session_id: record.persistence?.sessionId ?? null,
+    };
+  }
+
   private async listAgentPayloads(filter?: {
     labels?: Record<string, string>;
     includeArchived?: boolean;
@@ -5218,6 +5299,38 @@ export class Session {
       const code = error instanceof SessionRequestError ? error.code : "fetch_agents_failed";
       const message = error instanceof Error ? error.message : "Failed to fetch agents";
       this.sessionLogger.error({ err: error }, "Failed to handle fetch_agents_request");
+      this.emit({
+        type: "rpc_error",
+        payload: {
+          requestId: request.requestId,
+          requestType: request.type,
+          error: message,
+          code,
+        },
+      });
+    }
+  }
+
+  private async handleInventorySessions(
+    request: Extract<SessionInboundMessage, { type: "inventory.sessions.request" }>,
+  ): Promise<void> {
+    try {
+      const page = this.inventorySnapshots.page({
+        snapshot_id: request.snapshot_id,
+        cursor: request.cursor,
+        limit: request.limit,
+      });
+      this.emit({
+        type: "inventory.sessions.response",
+        payload: { requestId: request.requestId, ...page },
+      });
+    } catch (error) {
+      let code = "inventory_snapshot_failed";
+      if (error instanceof InventorySnapshotError || error instanceof SessionRequestError) {
+        code = error.code;
+      }
+      const message = error instanceof Error ? error.message : "Failed to capture Paseo inventory";
+      this.sessionLogger.error({ err: error }, "Failed to handle inventory.sessions.request");
       this.emit({
         type: "rpc_error",
         payload: {

--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -925,6 +925,7 @@ describe("relay external socket reconnect behavior", () => {
     expect(serverInfo.features?.providersSnapshotCwd).toBe(true);
     expect(serverInfo.features?.["terminal-input-mode-replay"]).toBe(true);
     expect(serverInfo.features?.["terminal-size-ownership"]).toBe(true);
+    expect(serverInfo.features?.inventorySessionsSnapshot).toBe(true);
     expect(serverInfo.features?.agentTurnIdentity).toBeUndefined();
     await server.close();
   });

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -31,11 +31,13 @@ import type { TerminalActivity } from "@getpaseo/protocol/terminal-activity";
 import type { HostnamesConfig } from "./hostnames.js";
 import { isHostnameAllowed } from "./hostnames.js";
 import {
+  captureInventorySessions,
   Session,
   type SessionLifecycleIntent,
   type SessionOptions,
   type SessionRuntimeMetrics,
 } from "./session.js";
+import { InventorySnapshotService } from "./agent/inventory-snapshot-service.js";
 import type { HubRelationshipManagement } from "./hub/relationship-controller.js";
 import { WorkspaceSetupRuntime } from "./workspace-setup-runtime.js";
 import type { HubExecutionAgents } from "./hub/daemon-executions.js";
@@ -535,6 +537,7 @@ export class VoiceAssistantWebSocketServer {
   private readonly daemonRuntimeConfig: DaemonRuntimeConfig | undefined;
   private readonly agentManager: AgentManager;
   private readonly agentStorage: AgentStorage;
+  private readonly inventorySnapshots: InventorySnapshotService;
   private readonly projectRegistry: ProjectRegistry;
   private readonly workspaceRegistry: WorkspaceRegistry;
   private readonly scheduleService: ScheduleService;
@@ -649,6 +652,9 @@ export class VoiceAssistantWebSocketServer {
     this.pluginRuntime = pluginRuntime;
     this.agentManager = agentManager;
     this.agentStorage = agentStorage;
+    this.inventorySnapshots = new InventorySnapshotService(() =>
+      captureInventorySessions(this.agentManager, this.agentStorage),
+    );
     this.projectRegistry = projectRegistry ?? createNoopProjectRegistry();
     this.workspaceRegistry = workspaceRegistry ?? createNoopWorkspaceRegistry();
     const requiredServices = requireWebSocketServices({
@@ -1367,6 +1373,7 @@ export class VoiceAssistantWebSocketServer {
       worktreesRoot: this.worktreesRoot,
       agentManager: this.agentManager,
       agentStorage: this.agentStorage,
+      inventorySnapshots: this.inventorySnapshots,
       projectRegistry: this.projectRegistry,
       workspaceRegistry: this.workspaceRegistry,
       directorySync: this.directorySync,
@@ -1657,6 +1664,8 @@ export class VoiceAssistantWebSocketServer {
         workspaceScriptManagement: true,
         // COMPAT(projectCustomIcon): added in v0.2.0, remove after 2027-01-20.
         projectCustomIcon: true,
+        // COMPAT(inventorySessionsSnapshot): added in v0.2.5, remove after 2027-02-10.
+        inventorySessionsSnapshot: true,
         // COMPAT(fsEntryOps): added in v0.3.0, remove gate after 2027-02-08.
         fsEntryOps: true,
         // COMPAT(fsEntryDuplicate): added in v0.3.0, remove gate after 2027-02-09.


### PR DESCRIPTION
## Summary
- add a separate read-only `inventory.sessions` RPC and `paseo inventory sessions` CLI
- materialize a complete daemon inventory into immutable SHA-256-bound snapshots with cursor validation/expiry
- include archived, internal, unavailable-provider and unplaced records; fail closed on malformed or duplicate registry state

## Verification
- `npm run build:server`
- server and CLI scoped typechecks
- `npm run lint`
- `npm run format:check`
- targeted 46-test inventory/protocol suite, including 201-record isolated-daemon E2E

`npm run typecheck` at repository scope remains blocked by a pre-existing unrelated app error in `packages/app/src/components/draggable-list.native.tsx` (`dragGestureHostPresented` is absent from the installed draggable-list type).

## Follow-up
ACP PR #31 must consume this new snapshot contract; this PR intentionally does not change ACP.