### PR TITLE
fix: preserve Codex goals and expose controls

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -55,6 +55,12 @@ Implement the `AgentClient` and `AgentSession` interfaces from `agent-sdk-types.
 
 Existing direct providers: `claude` (in `providers/claude/agent.ts`), `codex` (`codex-app-server-agent.ts`), `opencode` (`opencode-agent.ts`), `pi` (`providers/pi/agent.ts`), and `omp` (`providers/omp/agent.ts`). The dev-only `mock` provider (`mock-load-test-agent.ts`) is also direct.
 
+Provider-owned goals are projected through the optional `AgentSession.getGoal()` method and
+`goal_changed` stream event. Codex restores the durable value with `thread/goal/get` and maps
+`thread/goal/updated` and `thread/goal/cleared` notifications. Agent snapshots expose the current
+goal as an optional field so older clients and daemons remain wire-compatible; the provider remains
+the source of truth after reconnect or resume.
+
 Claude first-party model metadata lives in `packages/server/src/server/agent/providers/claude/model-manifest.ts`. When adding or updating a Claude model, update that manifest only; the model picker thinking options and Claude-specific feature gates are derived from the manifest. Do not add model-specific Claude capability lists in feature code.
 
 Paseo tools are not implemented as MCP tools internally. They live in a shared tool catalog under `packages/server/src/server/agent/tools/`; MCP is only the fallback adapter. A provider that can register runtime tools directly should set `supportsNativePaseoTools: true` and consume `launchContext.paseoTools` in `createSession`/`resumeSession`. When native tools are present, `AgentManager` strips the internal Paseo MCP server from the provider launch config so the provider does not receive the same tools twice. Providers that only know MCP should keep `supportsMcpServers: true` and let the daemon inject `/mcp/agents`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -57,9 +57,12 @@ Existing direct providers: `claude` (in `providers/claude/agent.ts`), `codex` (`
 
 Provider-owned goals are projected through the optional `AgentSession.getGoal()` method and
 `goal_changed` stream event. Codex restores the durable value with `thread/goal/get` and maps
-`thread/goal/updated` and `thread/goal/cleared` notifications. Agent snapshots expose the current
-goal as an optional field so older clients and daemons remain wire-compatible; the provider remains
-the source of truth after reconnect or resume.
+`thread/goal/updated` and `thread/goal/cleared` notifications. This projection is independent of how
+the goal was created, including `/goal` commands and goals Codex creates while handling a normal
+natural-language turn. Agent snapshots expose the current goal as an optional field so older clients
+and daemons remain wire-compatible; the provider remains the source of truth after reconnect or
+resume. A failed `getGoal()` refresh preserves the last provider projection because only a successful
+null lookup or `goal_changed(null)` is an authoritative clear.
 
 Claude first-party model metadata lives in `packages/server/src/server/agent/providers/claude/model-manifest.ts`. When adding or updating a Claude model, update that manifest only; the model picker thinking options and Claude-specific feature gates are derived from the manifest. Do not add model-specific Claude capability lists in feature code.
 

--- a/packages/app/src/composer/actions.test.ts
+++ b/packages/app/src/composer/actions.test.ts
@@ -21,6 +21,7 @@ import {
   cancelComposerAgent,
   dispatchComposerAgentMessage,
   editQueuedComposerMessage,
+  removeQueuedComposerMessage,
   findGithubItemByOption,
   isAttachmentSelectedForGithubItem,
   openComposerAttachment,
@@ -786,6 +787,40 @@ describe("editQueuedComposerMessage", () => {
       attachments: [{ kind: "image", metadata: image }],
     });
     expect(queue.state.get("agent")).toEqual([]);
+  });
+});
+
+describe("removeQueuedComposerMessage", () => {
+  it("removes and returns the matching queued message", () => {
+    const queue = createFakeQueue(
+      new Map([
+        [
+          "agent",
+          [
+            { id: "msg-1", text: "remove me", attachments: [] },
+            { id: "msg-2", text: "keep me", attachments: [] },
+          ],
+        ],
+      ]),
+    );
+
+    expect(removeQueuedComposerMessage({ agentId: "agent", messageId: "msg-1", queue })).toEqual({
+      id: "msg-1",
+      text: "remove me",
+      attachments: [],
+    });
+    expect(queue.state.get("agent")?.map((message) => message.id)).toEqual(["msg-2"]);
+  });
+
+  it("leaves the queue untouched when the message is missing", () => {
+    const queue = createFakeQueue(
+      new Map([["agent", [{ id: "msg-1", text: "keep me", attachments: [] }]]]),
+    );
+
+    expect(
+      removeQueuedComposerMessage({ agentId: "agent", messageId: "missing", queue }),
+    ).toBeNull();
+    expect(queue.state.get("agent")).toHaveLength(1);
   });
 });
 

--- a/packages/app/src/composer/actions.ts
+++ b/packages/app/src/composer/actions.ts
@@ -274,6 +274,24 @@ export function editQueuedComposerMessage(
   };
 }
 
+export function removeQueuedComposerMessage(input: {
+  agentId: string;
+  messageId: string;
+  queue: QueueWriter;
+}): QueuedComposerMessage | null {
+  const item = input.queue.read(input.agentId).find((queued) => queued.id === input.messageId);
+  if (!item) return null;
+  input.queue.write((prev) => {
+    const next = new Map(prev);
+    next.set(
+      input.agentId,
+      (prev.get(input.agentId) ?? []).filter((queued) => queued.id !== input.messageId),
+    );
+    return next;
+  });
+  return item;
+}
+
 export interface SendQueuedComposerMessageNowInput {
   agentId: string;
   messageId: string;

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -22,9 +22,7 @@ import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { useShallow } from "zustand/shallow";
 import {
-  ArrowUp,
   Square,
-  Pencil,
   AudioLines,
   CircleDot,
   FileText,
@@ -32,6 +30,9 @@ import {
   Image as ImageIcon,
   ClipboardPaste,
   Paperclip,
+  ListEnd,
+  CornerDownRight,
+  Trash2,
 } from "lucide-react-native";
 import * as Clipboard from "expo-clipboard";
 import Animated from "react-native-reanimated";
@@ -61,12 +62,12 @@ import { focusWithRetries } from "@/utils/web-focus";
 import {
   cancelComposerAgent,
   dispatchComposerAgentMessage,
-  editQueuedComposerMessage,
   findGithubItemByOption,
   isAttachmentSelectedForGithubItem,
   openComposerAttachment,
   pickAndPersistImages,
   queueComposerMessage,
+  removeQueuedComposerMessage,
   removeComposerAttachmentAtIndex,
   sendQueuedComposerMessageNow,
   toggleGithubAttachmentFromPicker,
@@ -365,25 +366,34 @@ function renderAttachmentTray(args: RenderAttachmentTrayArgs): ReactElement | nu
 
 interface RenderQueueTrackArgs {
   queuedMessages: readonly QueuedMessage[];
-  handleEditQueuedMessage: (id: string) => void;
   handleSendQueuedNow: (id: string) => Promise<void>;
-  editLabel: string;
+  handleRemoveQueuedMessage: (id: string) => void;
+  steerLabel: string;
+  removeLabel: string;
   sendNowLabel: string;
 }
 
 function renderQueueTrack(args: RenderQueueTrackArgs): ReactElement | null {
-  const { queuedMessages, handleEditQueuedMessage, handleSendQueuedNow, editLabel, sendNowLabel } =
-    args;
+  const {
+    queuedMessages,
+    handleSendQueuedNow,
+    handleRemoveQueuedMessage,
+    steerLabel,
+    removeLabel,
+    sendNowLabel,
+  } = args;
   if (queuedMessages.length === 0) return null;
   return (
     <View style={styles.queueTrack}>
-      {queuedMessages.map((item) => (
+      {queuedMessages.map((item, index) => (
         <QueuedMessageRow
           key={item.id}
           item={item}
-          onEdit={handleEditQueuedMessage}
+          isLast={index === queuedMessages.length - 1}
           onSendNow={handleSendQueuedNow}
-          editLabel={editLabel}
+          onRemove={handleRemoveQueuedMessage}
+          steerLabel={steerLabel}
+          removeLabel={removeLabel}
           sendNowLabel={sendNowLabel}
         />
       ))}
@@ -653,46 +663,54 @@ function resolveMessageInputPassthroughAction(
 
 interface QueuedMessageRowProps {
   item: QueuedMessage;
-  onEdit: (id: string) => void;
+  isLast: boolean;
   onSendNow: (id: string) => void;
-  editLabel: string;
+  onRemove: (id: string) => void;
+  steerLabel: string;
+  removeLabel: string;
   sendNowLabel: string;
 }
 
 function QueuedMessageRow({
   item,
-  onEdit,
+  isLast,
   onSendNow,
-  editLabel,
+  onRemove,
+  steerLabel,
+  removeLabel,
   sendNowLabel,
 }: QueuedMessageRowProps) {
-  const handleEdit = useCallback(() => {
-    onEdit(item.id);
-  }, [onEdit, item.id]);
   const handleSendNow = useCallback(() => {
     onSendNow(item.id);
   }, [onSendNow, item.id]);
+  const handleRemove = useCallback(() => {
+    onRemove(item.id);
+  }, [onRemove, item.id]);
   return (
-    <View style={styles.queueItem}>
-      <Text style={styles.queueText} numberOfLines={2} ellipsizeMode="tail">
-        {item.text}
-      </Text>
+    <View style={[styles.queueItem, !isLast && styles.queueItemDivider]}>
+      <View style={styles.queueSummary}>
+        <ThemedListEnd size={ICON_SIZE.xs} uniProps={iconForegroundMutedMapping} />
+        <Text style={styles.queueText} numberOfLines={1} ellipsizeMode="tail">
+          {item.text}
+        </Text>
+      </View>
       <View style={styles.queueActions}>
         <Pressable
-          onPress={handleEdit}
-          style={styles.queueActionButton}
-          accessibilityLabel={editLabel}
-          accessibilityRole="button"
-        >
-          <ThemedPencil size={ICON_SIZE.sm} uniProps={iconForegroundMapping} />
-        </Pressable>
-        <Pressable
           onPress={handleSendNow}
-          style={[styles.queueActionButton, styles.queueSendButton]}
+          style={[styles.queueActionButton, styles.queueSteerButton]}
           accessibilityLabel={sendNowLabel}
           accessibilityRole="button"
         >
-          <ThemedArrowUp size={ICON_SIZE.sm} uniProps={iconAccentForegroundMapping} />
+          <ThemedCornerDownRight size={ICON_SIZE.xs} uniProps={iconForegroundMutedMapping} />
+          <Text style={styles.queueSteerText}>{steerLabel}</Text>
+        </Pressable>
+        <Pressable
+          onPress={handleRemove}
+          style={styles.queueActionButton}
+          accessibilityLabel={removeLabel}
+          accessibilityRole="button"
+        >
+          <ThemedTrash2 size={ICON_SIZE.xs} uniProps={iconForegroundMutedMapping} />
         </Pressable>
       </View>
     </View>
@@ -955,8 +973,8 @@ interface ComposerProps {
   onAttentionPromptSend?: () => void;
   /** Controlled agent controls rendered in input area (draft flows). */
   agentControls?: DraftAgentControlsProps;
-  /** Compact contextual content rendered inside the bordered input surface, above the text. */
-  surfaceHeader?: React.ReactNode;
+  /** Optional persistent row shown after queued messages in the inset composer tray. */
+  contextTrayFooter?: React.ReactNode;
   /** Extra styles merged onto the message input wrapper (e.g. elevated background). */
   inputWrapperStyle?: import("react-native").ViewStyle;
   /** When true, a parent wrapper owns the keyboard shift, so the composer skips its own. */
@@ -1173,7 +1191,7 @@ function ComposerContentImpl({
   onAttentionInputFocus,
   onAttentionPromptSend,
   agentControls,
-  surfaceHeader,
+  contextTrayFooter,
   inputWrapperStyle,
   externalKeyboardShift,
   isCompactLayout: isCompactLayoutOverride,
@@ -1820,20 +1838,6 @@ function ComposerContentImpl({
     });
   }, [agentId, hasAgent, isConnected, serverId, voice]);
 
-  const handleEditQueuedMessage = useCallback(
-    (id: string) => {
-      const result = editQueuedComposerMessage({
-        agentId,
-        messageId: id,
-        queue: queueWriter,
-      });
-      if (!result) return;
-      replaceUserInput(result.text);
-      setSelectedAttachments(result.attachments);
-    },
-    [agentId, queueWriter, replaceUserInput, setSelectedAttachments],
-  );
-
   const handleSendQueuedNow = useCallback(
     async (id: string) => {
       if (!sendAgentMessageRef.current && !onSubmitMessageRef.current) return;
@@ -1851,6 +1855,23 @@ function ComposerContentImpl({
       }
     },
     [agentId, queueWriter, submitMessage, t],
+  );
+
+  const handleRemoveQueuedMessage = useCallback(
+    (id: string) => {
+      const removed = removeQueuedComposerMessage({
+        agentId,
+        messageId: id,
+        queue: queueWriter,
+      });
+      if (!removed) return;
+      void deleteAttachments(
+        removed.attachments.flatMap((attachment) =>
+          attachment.kind === "image" ? [attachment.metadata] : [],
+        ),
+      );
+    },
+    [agentId, queueWriter],
   );
 
   const handleQueue = useCallback(
@@ -2210,12 +2231,25 @@ function ComposerContentImpl({
     () =>
       renderQueueTrack({
         queuedMessages,
-        handleEditQueuedMessage,
         handleSendQueuedNow,
-        editLabel: t("composer.attachments.editQueuedMessage"),
+        handleRemoveQueuedMessage,
+        steerLabel: t("composer.attachments.steerQueuedMessage"),
+        removeLabel: t("composer.attachments.removeQueuedMessage"),
         sendNowLabel: t("composer.attachments.sendQueuedMessageNow"),
       }),
-    [handleEditQueuedMessage, handleSendQueuedNow, queuedMessages, t],
+    [handleRemoveQueuedMessage, handleSendQueuedNow, queuedMessages, t],
+  );
+  const contextTray = useMemo(
+    () =>
+      queueList || contextTrayFooter ? (
+        <View style={styles.contextTray} testID="composer-context-tray">
+          {queueList}
+          {contextTrayFooter ? (
+            <View style={queueList && styles.contextTrayFooterSeparated}>{contextTrayFooter}</View>
+          ) : null}
+        </View>
+      ) : null,
+    [contextTrayFooter, queueList],
   );
 
   const messageInputContainerRef = useRef<View>(null);
@@ -2270,7 +2304,6 @@ function ComposerContentImpl({
         {/* Input area */}
         <View style={inputAreaContainerStyle}>
           <View style={styles.inputAreaContent}>
-            {queueList}
             {sendErrorNode}
 
             <View ref={messageInputContainerRef} style={styles.messageInputContainer}>
@@ -2285,6 +2318,8 @@ function ComposerContentImpl({
                 loadingText={autocomplete.loadingText}
                 emptyText={autocomplete.emptyText}
               />
+
+              {contextTray}
 
               {/* MessageInput handles everything: text, dictation, attachments, all buttons */}
               <RenderProfile id="MessageInput">
@@ -2328,14 +2363,7 @@ function ComposerContentImpl({
                   onFocusChange={handleFocusChange}
                   onHeightChange={onComposerHeightChange}
                   inputWrapperStyle={inputWrapperStyle}
-                  attachmentSlot={
-                    surfaceHeader || attachmentTray ? (
-                      <>
-                        {surfaceHeader}
-                        {attachmentTray}
-                      </>
-                    ) : null
-                  }
+                  attachmentSlot={attachmentTray}
                   inputMode={inputMode}
                   readOnly={readOnly}
                   textReplacementKey={textReplacementKey}
@@ -2404,7 +2432,22 @@ const styles = StyleSheet.create((theme: Theme) => ({
   messageInputContainer: {
     position: "relative",
     width: "100%",
-    gap: theme.spacing[3],
+  },
+  contextTray: {
+    marginHorizontal: theme.spacing[3],
+    marginBottom: -theme.spacing[3],
+    paddingHorizontal: theme.spacing[1],
+    paddingTop: theme.spacing[1],
+    paddingBottom: theme.spacing[4],
+    overflow: "hidden",
+    backgroundColor: theme.colors.surface2,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.borderAccent,
+    borderRadius: theme.borderRadius["2xl"],
+  },
+  contextTrayFooterSeparated: {
+    borderTopWidth: theme.borderWidth[1],
+    borderTopColor: theme.colors.border,
   },
   cancelButton: {
     width: 28,
@@ -2463,40 +2506,52 @@ const styles = StyleSheet.create((theme: Theme) => ({
   },
   queueTrack: {
     flexDirection: "column",
-    gap: theme.spacing[2],
   },
   queueItem: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: theme.spacing[3],
-    paddingVertical: theme.spacing[2],
-    backgroundColor: theme.colors.surface1,
-    borderRadius: theme.borderRadius.lg,
-    borderWidth: theme.borderWidth[1],
-    borderColor: theme.colors.border,
+    minHeight: 32,
+    paddingHorizontal: theme.spacing[2],
+    gap: theme.spacing[2],
+  },
+  queueItemDivider: {
+    borderBottomWidth: theme.borderWidth[1],
+    borderBottomColor: theme.colors.border,
+  },
+  queueSummary: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
     gap: theme.spacing[2],
   },
   queueText: {
     flex: 1,
     color: theme.colors.foreground,
-    fontSize: theme.fontSize.base,
+    fontSize: theme.fontSize.xs,
   },
   queueActions: {
     flexDirection: "row",
     alignItems: "center",
-    gap: theme.spacing[2],
+    gap: theme.spacing[1],
   },
   queueActionButton: {
-    width: 32,
-    height: 32,
+    minWidth: 28,
+    height: 24,
+    paddingHorizontal: theme.spacing[1],
     borderRadius: theme.borderRadius.full,
+    flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: theme.colors.surface2,
   },
-  queueSendButton: {
-    backgroundColor: theme.colors.accent,
+  queueSteerButton: {
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+  },
+  queueSteerText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
   },
   sendErrorText: {
     color: theme.colors.palette.red[500],
@@ -2504,8 +2559,6 @@ const styles = StyleSheet.create((theme: Theme) => ({
   },
 })) as unknown as Record<string, object>;
 
-const ThemedPencil = withUnistyles(Pencil);
-const ThemedArrowUp = withUnistyles(ArrowUp);
 const ThemedGitPullRequest = withUnistyles(GitPullRequest);
 const ThemedCircleDot = withUnistyles(CircleDot);
 const ThemedAudioLines = withUnistyles(AudioLines);
@@ -2513,9 +2566,11 @@ const ThemedPaperclip = withUnistyles(Paperclip);
 const ThemedImageIcon = withUnistyles(ImageIcon);
 const ThemedClipboardPaste = withUnistyles(ClipboardPaste);
 const ThemedFileText = withUnistyles(FileText);
+const ThemedListEnd = withUnistyles(ListEnd);
+const ThemedCornerDownRight = withUnistyles(CornerDownRight);
+const ThemedTrash2 = withUnistyles(Trash2);
 const iconForegroundMapping = (theme: Theme) => ({ color: theme.colors.foreground });
 const iconForegroundMutedMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
-const iconAccentForegroundMapping = (theme: Theme) => ({ color: theme.colors.accentForeground });
 
 function renderForgeAttachmentIcon(icon: string): ReactElement {
   return (

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -955,6 +955,8 @@ interface ComposerProps {
   onAttentionPromptSend?: () => void;
   /** Controlled agent controls rendered in input area (draft flows). */
   agentControls?: DraftAgentControlsProps;
+  /** Compact contextual content rendered inside the bordered input surface, above the text. */
+  surfaceHeader?: React.ReactNode;
   /** Extra styles merged onto the message input wrapper (e.g. elevated background). */
   inputWrapperStyle?: import("react-native").ViewStyle;
   /** When true, a parent wrapper owns the keyboard shift, so the composer skips its own. */
@@ -1171,6 +1173,7 @@ function ComposerContentImpl({
   onAttentionInputFocus,
   onAttentionPromptSend,
   agentControls,
+  surfaceHeader,
   inputWrapperStyle,
   externalKeyboardShift,
   isCompactLayout: isCompactLayoutOverride,
@@ -2325,7 +2328,14 @@ function ComposerContentImpl({
                   onFocusChange={handleFocusChange}
                   onHeightChange={onComposerHeightChange}
                   inputWrapperStyle={inputWrapperStyle}
-                  attachmentSlot={attachmentTray}
+                  attachmentSlot={
+                    surfaceHeader || attachmentTray ? (
+                      <>
+                        {surfaceHeader}
+                        {attachmentTray}
+                      </>
+                    ) : null
+                  }
                   inputMode={inputMode}
                   readOnly={readOnly}
                   textReplacementKey={textReplacementKey}

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -2529,7 +2529,7 @@ const styles = StyleSheet.create((theme: Theme) => ({
   queueText: {
     flex: 1,
     color: theme.colors.foreground,
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
   },
   queueActions: {
     flexDirection: "row",
@@ -2551,7 +2551,7 @@ const styles = StyleSheet.create((theme: Theme) => ({
   },
   queueSteerText: {
     color: theme.colors.foregroundMuted,
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
   },
   sendErrorText: {
     color: theme.colors.palette.red[500],

--- a/packages/app/src/goals/presentation.test.ts
+++ b/packages/app/src/goals/presentation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import type { AgentGoal } from "@getpaseo/protocol/agent-types";
+import { goalActions, goalStatusKey } from "./presentation";
+
+const goal: AgentGoal = {
+  objective: "Ship persistent goal controls",
+  status: "active",
+  tokenBudget: null,
+  tokensUsed: 0,
+  timeUsedSeconds: 0,
+};
+
+describe("goal presentation", () => {
+  test("offers pause for active goals and resume for paused goals", () => {
+    expect(goalActions(goal)).toEqual(["pause", "clear"]);
+    expect(goalActions({ ...goal, status: "paused" })).toEqual(["resume", "clear"]);
+    expect(goalActions({ ...goal, status: "complete" })).toEqual(["clear"]);
+  });
+
+  test("maps limit states to stable translation keys", () => {
+    expect(goalStatusKey("usageLimited")).toBe("goals.status.usageLimited");
+    expect(goalStatusKey("budgetLimited")).toBe("goals.status.budgetLimited");
+  });
+});

--- a/packages/app/src/goals/presentation.test.ts
+++ b/packages/app/src/goals/presentation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { AgentGoal } from "@getpaseo/protocol/agent-types";
-import { goalActions, goalStatusKey } from "./presentation";
+import { formatGoalDuration, goalActions, goalStatusKey } from "./presentation";
 
 const goal: AgentGoal = {
   objective: "Ship persistent goal controls",
@@ -20,5 +20,11 @@ describe("goal presentation", () => {
   test("maps limit states to stable translation keys", () => {
     expect(goalStatusKey("usageLimited")).toBe("goals.status.usageLimited");
     expect(goalStatusKey("budgetLimited")).toBe("goals.status.budgetLimited");
+  });
+
+  test("formats elapsed goal time compactly", () => {
+    expect(formatGoalDuration(2.9)).toBe("2s");
+    expect(formatGoalDuration(125)).toBe("2m");
+    expect(formatGoalDuration(7_400)).toBe("2h");
   });
 });

--- a/packages/app/src/goals/presentation.ts
+++ b/packages/app/src/goals/presentation.ts
@@ -6,6 +6,14 @@ export function goalStatusKey(status: AgentGoalStatus): `goals.status.${AgentGoa
   return `goals.status.${status}`;
 }
 
+export function formatGoalDuration(timeUsedSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(timeUsedSeconds));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.floor(minutes / 60)}h`;
+}
+
 export function goalActions(goal: AgentGoal): GoalAction[] {
   if (goal.status === "complete") return ["clear"];
   return goal.status === "paused" ? ["resume", "clear"] : ["pause", "clear"];

--- a/packages/app/src/goals/presentation.ts
+++ b/packages/app/src/goals/presentation.ts
@@ -1,0 +1,12 @@
+import type { AgentGoal, AgentGoalStatus } from "@getpaseo/protocol/agent-types";
+
+export type GoalAction = "pause" | "resume" | "clear";
+
+export function goalStatusKey(status: AgentGoalStatus): `goals.status.${AgentGoalStatus}` {
+  return `goals.status.${status}`;
+}
+
+export function goalActions(goal: AgentGoal): GoalAction[] {
+  if (goal.status === "complete") return ["clear"];
+  return goal.status === "paused" ? ["resume", "clear"] : ["pause", "clear"];
+}

--- a/packages/app/src/goals/track.tsx
+++ b/packages/app/src/goals/track.tsx
@@ -114,18 +114,18 @@ const styles = StyleSheet.create((theme) => ({
   },
   status: {
     flexShrink: 0,
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.foreground,
   },
   objective: {
     flex: 1,
     minWidth: 0,
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.foregroundMuted,
   },
   duration: {
     flexShrink: 0,
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.foregroundMuted,
   },
   actions: {
@@ -135,7 +135,7 @@ const styles = StyleSheet.create((theme) => ({
   },
   error: {
     paddingBottom: theme.spacing[1],
-    fontSize: theme.fontSize.xs,
+    fontSize: theme.fontSize.sm,
     color: theme.colors.statusDanger,
   },
 }));

--- a/packages/app/src/goals/track.tsx
+++ b/packages/app/src/goals/track.tsx
@@ -4,8 +4,6 @@ import { Text, View } from "react-native";
 import type { AgentGoal } from "@getpaseo/protocol/agent-types";
 import { StyleSheet } from "react-native-unistyles";
 import { Button } from "@/components/ui/button";
-import { StatusBadge } from "@/components/ui/status-badge";
-import { MAX_CONTENT_WIDTH } from "@/constants/layout";
 import { goalActions, goalStatusKey, type GoalAction } from "./presentation";
 
 export function GoalTrack({
@@ -33,36 +31,43 @@ export function GoalTrack({
   if (!goal) return null;
 
   return (
-    <View style={styles.outer} testID="goal-track">
-      <View style={styles.track}>
-        <View style={styles.surface}>
-          <View style={styles.summary}>
-            <StatusBadge
-              label={t(goalStatusKey(goal.status))}
-              variant={goal.status === "complete" ? "success" : undefined}
+    <View style={styles.root} testID="goal-track">
+      <View style={styles.row}>
+        <View style={styles.summary}>
+          <View
+            style={[
+              styles.statusDot,
+              goal.status === "active" && styles.statusDotActive,
+              goal.status === "blocked" && styles.statusDotBlocked,
+              (goal.status === "usageLimited" || goal.status === "budgetLimited") &&
+                styles.statusDotLimited,
+              goal.status === "complete" && styles.statusDotComplete,
+            ]}
+          />
+          <Text style={styles.status} numberOfLines={1}>
+            {t(goalStatusKey(goal.status))}
+          </Text>
+          <Text style={styles.objective} numberOfLines={1} testID="goal-track-objective">
+            {goal.objective}
+          </Text>
+        </View>
+        <View style={styles.actions}>
+          {goalActions(goal).map((action) => (
+            <GoalActionButton
+              key={action}
+              action={action}
+              label={t(`goals.actions.${action}`)}
+              pendingAction={pendingAction}
+              onAction={handleAction}
             />
-            <Text style={styles.objective} numberOfLines={2} testID="goal-track-objective">
-              {goal.objective}
-            </Text>
-          </View>
-          <View style={styles.actions}>
-            {goalActions(goal).map((action) => (
-              <GoalActionButton
-                key={action}
-                action={action}
-                label={t(`goals.actions.${action}`)}
-                pendingAction={pendingAction}
-                onAction={handleAction}
-              />
-            ))}
-          </View>
-          {error ? (
-            <Text style={styles.error} accessibilityRole="alert" testID="goal-track-error">
-              {error}
-            </Text>
-          ) : null}
+          ))}
         </View>
       </View>
+      {error ? (
+        <Text style={styles.error} accessibilityRole="alert" testID="goal-track-error">
+          {error}
+        </Text>
+      ) : null}
     </View>
   );
 }
@@ -94,48 +99,61 @@ function GoalActionButton({
 }
 
 const styles = StyleSheet.create((theme) => ({
-  outer: {
-    width: "100%",
+  root: {
+    marginBottom: -theme.spacing[1],
+    paddingBottom: theme.spacing[1],
+    borderBottomWidth: theme.borderWidth[1],
+    borderBottomColor: theme.colors.border,
+  },
+  row: {
+    minHeight: 28,
+    flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: theme.spacing[4],
-  },
-  track: {
-    width: "100%",
-    maxWidth: MAX_CONTENT_WIDTH,
-    marginBottom: -theme.spacing[4],
-  },
-  surface: {
-    alignSelf: "stretch",
-    backgroundColor: theme.colors.surface1,
-    borderWidth: theme.borderWidth[1],
-    borderColor: theme.colors.borderAccent,
-    borderBottomWidth: 0,
-    borderTopLeftRadius: theme.borderRadius["2xl"],
-    borderTopRightRadius: theme.borderRadius["2xl"],
-    paddingHorizontal: theme.spacing[3],
-    paddingTop: theme.spacing[2],
-    paddingBottom: theme.spacing[6],
+    gap: theme.spacing[1],
   },
   summary: {
+    flex: 1,
     minWidth: 0,
     flexDirection: "row",
     alignItems: "center",
-    gap: theme.spacing[2],
+    gap: theme.spacing[1],
+  },
+  statusDot: {
+    width: 6,
+    height: 6,
+    flexShrink: 0,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.foregroundMuted,
+  },
+  statusDotActive: {
+    backgroundColor: theme.colors.statusDotRunning,
+  },
+  statusDotBlocked: {
+    backgroundColor: theme.colors.statusDotDanger,
+  },
+  statusDotLimited: {
+    backgroundColor: theme.colors.statusDotWarning,
+  },
+  statusDotComplete: {
+    backgroundColor: theme.colors.statusDotSuccess,
+  },
+  status: {
+    flexShrink: 0,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
   },
   objective: {
     flex: 1,
     minWidth: 0,
-    fontSize: theme.fontSize.sm,
+    fontSize: theme.fontSize.xs,
     color: theme.colors.foreground,
   },
   actions: {
     flexDirection: "row",
-    justifyContent: "flex-end",
     alignItems: "center",
-    marginTop: theme.spacing[1],
+    flexShrink: 0,
   },
   error: {
-    marginTop: theme.spacing[1],
     fontSize: theme.fontSize.xs,
     color: theme.colors.statusDanger,
   },

--- a/packages/app/src/goals/track.tsx
+++ b/packages/app/src/goals/track.tsx
@@ -2,9 +2,11 @@ import { useCallback, useState, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { Text, View } from "react-native";
 import type { AgentGoal } from "@getpaseo/protocol/agent-types";
-import { StyleSheet } from "react-native-unistyles";
+import { Pause, Play, Target, Trash2 } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import { Button } from "@/components/ui/button";
-import { goalActions, goalStatusKey, type GoalAction } from "./presentation";
+import { ICON_SIZE, type Theme } from "@/styles/theme";
+import { formatGoalDuration, goalActions, goalStatusKey, type GoalAction } from "./presentation";
 
 export function GoalTrack({
   goal,
@@ -34,22 +36,14 @@ export function GoalTrack({
     <View style={styles.root} testID="goal-track">
       <View style={styles.row}>
         <View style={styles.summary}>
-          <View
-            style={[
-              styles.statusDot,
-              goal.status === "active" && styles.statusDotActive,
-              goal.status === "blocked" && styles.statusDotBlocked,
-              (goal.status === "usageLimited" || goal.status === "budgetLimited") &&
-                styles.statusDotLimited,
-              goal.status === "complete" && styles.statusDotComplete,
-            ]}
-          />
+          <ThemedTarget size={ICON_SIZE.xs} uniProps={iconForegroundMutedMapping} />
           <Text style={styles.status} numberOfLines={1}>
             {t(goalStatusKey(goal.status))}
           </Text>
           <Text style={styles.objective} numberOfLines={1} testID="goal-track-objective">
             {goal.objective}
           </Text>
+          <Text style={styles.duration}>· {formatGoalDuration(goal.timeUsedSeconds)}</Text>
         </View>
         <View style={styles.actions}>
           {goalActions(goal).map((action) => (
@@ -84,29 +78,29 @@ function GoalActionButton({
   onAction: (action: GoalAction) => void;
 }): ReactElement {
   const handlePress = useCallback(() => onAction(action), [action, onAction]);
+  let icon = ThemedTrash2;
+  if (action === "pause") icon = ThemedPause;
+  if (action === "resume") icon = ThemedPlay;
   return (
     <Button
       size="xs"
       variant="ghost"
+      leftIcon={icon}
       disabled={pendingAction !== null}
       loading={pendingAction === action}
+      accessibilityLabel={label}
       testID={`goal-track-${action}`}
       onPress={handlePress}
-    >
-      {label}
-    </Button>
+    />
   );
 }
 
 const styles = StyleSheet.create((theme) => ({
   root: {
-    marginBottom: -theme.spacing[1],
-    paddingBottom: theme.spacing[1],
-    borderBottomWidth: theme.borderWidth[1],
-    borderBottomColor: theme.colors.border,
+    paddingHorizontal: theme.spacing[2],
   },
   row: {
-    minHeight: 28,
+    minHeight: 32,
     flexDirection: "row",
     alignItems: "center",
     gap: theme.spacing[1],
@@ -118,35 +112,21 @@ const styles = StyleSheet.create((theme) => ({
     alignItems: "center",
     gap: theme.spacing[1],
   },
-  statusDot: {
-    width: 6,
-    height: 6,
-    flexShrink: 0,
-    borderRadius: theme.borderRadius.full,
-    backgroundColor: theme.colors.foregroundMuted,
-  },
-  statusDotActive: {
-    backgroundColor: theme.colors.statusDotRunning,
-  },
-  statusDotBlocked: {
-    backgroundColor: theme.colors.statusDotDanger,
-  },
-  statusDotLimited: {
-    backgroundColor: theme.colors.statusDotWarning,
-  },
-  statusDotComplete: {
-    backgroundColor: theme.colors.statusDotSuccess,
-  },
   status: {
     flexShrink: 0,
     fontSize: theme.fontSize.xs,
-    color: theme.colors.foregroundMuted,
+    color: theme.colors.foreground,
   },
   objective: {
     flex: 1,
     minWidth: 0,
     fontSize: theme.fontSize.xs,
-    color: theme.colors.foreground,
+    color: theme.colors.foregroundMuted,
+  },
+  duration: {
+    flexShrink: 0,
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foregroundMuted,
   },
   actions: {
     flexDirection: "row",
@@ -154,7 +134,14 @@ const styles = StyleSheet.create((theme) => ({
     flexShrink: 0,
   },
   error: {
+    paddingBottom: theme.spacing[1],
     fontSize: theme.fontSize.xs,
     color: theme.colors.statusDanger,
   },
 }));
+
+const ThemedTarget = withUnistyles(Target);
+const ThemedPause = withUnistyles(Pause);
+const ThemedPlay = withUnistyles(Play);
+const ThemedTrash2 = withUnistyles(Trash2);
+const iconForegroundMutedMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });

--- a/packages/app/src/goals/track.tsx
+++ b/packages/app/src/goals/track.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useState, type ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { Text, View } from "react-native";
+import type { AgentGoal } from "@getpaseo/protocol/agent-types";
+import { StyleSheet } from "react-native-unistyles";
+import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { MAX_CONTENT_WIDTH } from "@/constants/layout";
+import { goalActions, goalStatusKey, type GoalAction } from "./presentation";
+
+export function GoalTrack({
+  goal,
+  onAction,
+}: {
+  goal: AgentGoal | null;
+  onAction: (action: GoalAction) => Promise<void>;
+}): ReactElement | null {
+  const { t } = useTranslation();
+  const [pendingAction, setPendingAction] = useState<GoalAction | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAction = useCallback(
+    (action: GoalAction) => {
+      setPendingAction(action);
+      setError(null);
+      void onAction(action)
+        .catch((reason) => setError(reason instanceof Error ? reason.message : String(reason)))
+        .finally(() => setPendingAction(null));
+    },
+    [onAction],
+  );
+
+  if (!goal) return null;
+
+  return (
+    <View style={styles.outer} testID="goal-track">
+      <View style={styles.track}>
+        <View style={styles.surface}>
+          <View style={styles.summary}>
+            <StatusBadge
+              label={t(goalStatusKey(goal.status))}
+              variant={goal.status === "complete" ? "success" : undefined}
+            />
+            <Text style={styles.objective} numberOfLines={2} testID="goal-track-objective">
+              {goal.objective}
+            </Text>
+          </View>
+          <View style={styles.actions}>
+            {goalActions(goal).map((action) => (
+              <GoalActionButton
+                key={action}
+                action={action}
+                label={t(`goals.actions.${action}`)}
+                pendingAction={pendingAction}
+                onAction={handleAction}
+              />
+            ))}
+          </View>
+          {error ? (
+            <Text style={styles.error} accessibilityRole="alert" testID="goal-track-error">
+              {error}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function GoalActionButton({
+  action,
+  label,
+  pendingAction,
+  onAction,
+}: {
+  action: GoalAction;
+  label: string;
+  pendingAction: GoalAction | null;
+  onAction: (action: GoalAction) => void;
+}): ReactElement {
+  const handlePress = useCallback(() => onAction(action), [action, onAction]);
+  return (
+    <Button
+      size="xs"
+      variant="ghost"
+      disabled={pendingAction !== null}
+      loading={pendingAction === action}
+      testID={`goal-track-${action}`}
+      onPress={handlePress}
+    >
+      {label}
+    </Button>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  outer: {
+    width: "100%",
+    alignItems: "center",
+    paddingHorizontal: theme.spacing[4],
+  },
+  track: {
+    width: "100%",
+    maxWidth: MAX_CONTENT_WIDTH,
+    marginBottom: -theme.spacing[4],
+  },
+  surface: {
+    alignSelf: "stretch",
+    backgroundColor: theme.colors.surface1,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.borderAccent,
+    borderBottomWidth: 0,
+    borderTopLeftRadius: theme.borderRadius["2xl"],
+    borderTopRightRadius: theme.borderRadius["2xl"],
+    paddingHorizontal: theme.spacing[3],
+    paddingTop: theme.spacing[2],
+    paddingBottom: theme.spacing[6],
+  },
+  summary: {
+    minWidth: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  objective: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.foreground,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    marginTop: theme.spacing[1],
+  },
+  error: {
+    marginTop: theme.spacing[1],
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.statusDanger,
+  },
+}));

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1695,6 +1695,17 @@ export const ar: TranslationResources = {
     archiveFinishedAction: "أرشفة الوكلاء الفرعيين المكتملين",
     archiveFinishedRetry: "إعادة المحاولة ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "نشط",
+      paused: "متوقف مؤقتًا",
+      blocked: "محظور",
+      usageLimited: "تم بلوغ حد الاستخدام",
+      budgetLimited: "تم بلوغ حد الميزانية",
+      complete: "مكتمل",
+    },
+    actions: { pause: "إيقاف مؤقت", resume: "استئناف", clear: "مسح" },
+  },
   panels: {
     draft: {
       newAgent: "وكيل جديد",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -131,6 +131,8 @@ export const ar: TranslationResources = {
       dropImagesHere: "إسقاط الصور هنا",
       dropFilesHere: "Drop files here",
       editQueuedMessage: "تحرير الرسالة في قائمة الانتظار",
+      steerQueuedMessage: "توجيه",
+      removeQueuedMessage: "إزالة الرسالة من قائمة الانتظار",
       sendQueuedMessageNow: "إرسال رسالة في قائمة الانتظار الآن",
       openImage: "فتح مرفق الصورة",
       removeImage: "إزالة مرفق الصورة",
@@ -1697,7 +1699,7 @@ export const ar: TranslationResources = {
   },
   goals: {
     status: {
-      active: "نشط",
+      active: "متابعة الهدف",
       paused: "متوقف مؤقتًا",
       blocked: "محظور",
       usageLimited: "تم بلوغ حد الاستخدام",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -128,6 +128,8 @@ export const en = {
       dropImagesHere: "Drop images here",
       dropFilesHere: "Drop files here",
       editQueuedMessage: "Edit queued message",
+      steerQueuedMessage: "Steer",
+      removeQueuedMessage: "Remove queued message",
       sendQueuedMessageNow: "Send queued message now",
       openImage: "Open image attachment",
       removeImage: "Remove image attachment",
@@ -1707,7 +1709,7 @@ export const en = {
   },
   goals: {
     status: {
-      active: "Active",
+      active: "Pursuing goal",
       paused: "Paused",
       blocked: "Blocked",
       usageLimited: "Usage limited",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1705,6 +1705,17 @@ export const en = {
     archiveFinishedAction: "Archive finished subagents",
     archiveFinishedRetry: "Retry ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "Active",
+      paused: "Paused",
+      blocked: "Blocked",
+      usageLimited: "Usage limited",
+      budgetLimited: "Budget limited",
+      complete: "Complete",
+    },
+    actions: { pause: "Pause", resume: "Resume", clear: "Clear" },
+  },
   panels: {
     draft: {
       newAgent: "New Agent",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -131,6 +131,8 @@ export const es: TranslationResources = {
       dropImagesHere: "Suelta imágenes aquí",
       dropFilesHere: "Drop files here",
       editQueuedMessage: "Editar mensaje en cola",
+      steerQueuedMessage: "Dirigir",
+      removeQueuedMessage: "Eliminar mensaje en cola",
       sendQueuedMessageNow: "Enviar mensaje en cola ahora",
       openImage: "Abrir imagen adjunta",
       removeImage: "Quitar imagen adjunta",
@@ -1743,7 +1745,7 @@ export const es: TranslationResources = {
   },
   goals: {
     status: {
-      active: "Activo",
+      active: "Persiguiendo objetivo",
       paused: "En pausa",
       blocked: "Bloqueado",
       usageLimited: "Límite de uso alcanzado",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1741,6 +1741,17 @@ export const es: TranslationResources = {
     archiveFinishedAction: "Archivar subagentes finalizados",
     archiveFinishedRetry: "Reintentar ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "Activo",
+      paused: "En pausa",
+      blocked: "Bloqueado",
+      usageLimited: "Límite de uso alcanzado",
+      budgetLimited: "Límite de presupuesto alcanzado",
+      complete: "Completado",
+    },
+    actions: { pause: "Pausar", resume: "Reanudar", clear: "Borrar" },
+  },
   panels: {
     draft: {
       newAgent: "Nuevo agente",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1745,6 +1745,17 @@ export const fr: TranslationResources = {
     archiveFinishedAction: "Archiver les sous-agents terminés",
     archiveFinishedRetry: "Réessayer ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "Actif",
+      paused: "En pause",
+      blocked: "Bloqué",
+      usageLimited: "Limite d’utilisation atteinte",
+      budgetLimited: "Limite de budget atteinte",
+      complete: "Terminé",
+    },
+    actions: { pause: "Mettre en pause", resume: "Reprendre", clear: "Effacer" },
+  },
   panels: {
     draft: {
       newAgent: "Nouvel agent",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -133,6 +133,8 @@ export const fr: TranslationResources = {
       dropImagesHere: "Déposez des images ici",
       dropFilesHere: "Drop files here",
       editQueuedMessage: "Modifier le message en file d'attente",
+      steerQueuedMessage: "Orienter",
+      removeQueuedMessage: "Supprimer le message en file d'attente",
       sendQueuedMessageNow: "Envoyer le message en file d'attente maintenant",
       openImage: "Ouvrir la pièce jointe de l'image",
       removeImage: "Supprimer l'image jointe",
@@ -1747,7 +1749,7 @@ export const fr: TranslationResources = {
   },
   goals: {
     status: {
-      active: "Actif",
+      active: "Objectif en cours",
       paused: "En pause",
       blocked: "Bloqué",
       usageLimited: "Limite d’utilisation atteinte",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -131,6 +131,8 @@ export const ja: TranslationResources = {
       dropImagesHere: "ここに画像をドロップ",
       dropFilesHere: "ここにファイルをドロップ",
       editQueuedMessage: "キューに入れたメッセージを編集",
+      steerQueuedMessage: "指示",
+      removeQueuedMessage: "キューからメッセージを削除",
       sendQueuedMessageNow: "キューに入れたメッセージを今すぐ送信",
       openImage: "画像添付ファイルを開く",
       removeImage: "画像添付ファイルを削除",
@@ -1714,7 +1716,7 @@ export const ja: TranslationResources = {
   },
   goals: {
     status: {
-      active: "実行中",
+      active: "目標を追跡中",
       paused: "一時停止中",
       blocked: "ブロック中",
       usageLimited: "使用量上限",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1712,6 +1712,17 @@ export const ja: TranslationResources = {
     archiveFinishedAction: "完了したサブエージェントをアーカイブ",
     archiveFinishedRetry: "再試行 ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "実行中",
+      paused: "一時停止中",
+      blocked: "ブロック中",
+      usageLimited: "使用量上限",
+      budgetLimited: "予算上限",
+      complete: "完了",
+    },
+    actions: { pause: "一時停止", resume: "再開", clear: "クリア" },
+  },
   panels: {
     draft: {
       newAgent: "新しいエージェント",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1705,6 +1705,17 @@ export const ko: TranslationResources = {
     archiveFinishedAction: "완료된 하위 에이전트 보관",
     archiveFinishedRetry: "다시 시도 ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "활성",
+      paused: "일시 중지됨",
+      blocked: "차단됨",
+      usageLimited: "사용량 제한",
+      budgetLimited: "예산 제한",
+      complete: "완료",
+    },
+    actions: { pause: "일시 중지", resume: "재개", clear: "지우기" },
+  },
   panels: {
     draft: {
       newAgent: "새 에이전트",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -131,6 +131,8 @@ export const ko: TranslationResources = {
       dropImagesHere: "여기에 이미지를 끌어다 놓으세요",
       dropFilesHere: "여기에 파일을 끌어다 놓으세요",
       editQueuedMessage: "대기 중인 메시지 편집",
+      steerQueuedMessage: "지시",
+      removeQueuedMessage: "대기열 메시지 제거",
       sendQueuedMessageNow: "대기 중인 메시지 지금 보내기",
       openImage: "이미지 첨부 열기",
       removeImage: "이미지 첨부 제거",
@@ -1707,7 +1709,7 @@ export const ko: TranslationResources = {
   },
   goals: {
     status: {
-      active: "활성",
+      active: "목표 수행 중",
       paused: "일시 중지됨",
       blocked: "차단됨",
       usageLimited: "사용량 제한",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -131,6 +131,8 @@ export const ptBR: TranslationResources = {
       dropImagesHere: "Solte imagens aqui",
       dropFilesHere: "Solte arquivos aqui",
       editQueuedMessage: "Editar mensagem na fila",
+      steerQueuedMessage: "Direcionar",
+      removeQueuedMessage: "Remover mensagem da fila",
       sendQueuedMessageNow: "Enviar mensagem da fila agora",
       openImage: "Abrir anexo de imagem",
       removeImage: "Remover anexo de imagem",
@@ -1729,7 +1731,7 @@ export const ptBR: TranslationResources = {
   },
   goals: {
     status: {
-      active: "Ativa",
+      active: "Perseguindo objetivo",
       paused: "Pausada",
       blocked: "Bloqueada",
       usageLimited: "Limite de uso atingido",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1727,6 +1727,17 @@ export const ptBR: TranslationResources = {
     archiveFinishedAction: "Arquivar subagentes concluídos",
     archiveFinishedRetry: "Tentar novamente ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "Ativa",
+      paused: "Pausada",
+      blocked: "Bloqueada",
+      usageLimited: "Limite de uso atingido",
+      budgetLimited: "Limite de orçamento atingido",
+      complete: "Concluída",
+    },
+    actions: { pause: "Pausar", resume: "Retomar", clear: "Limpar" },
+  },
   panels: {
     draft: {
       newAgent: "Novo Agente",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -131,6 +131,8 @@ export const ru: TranslationResources = {
       dropImagesHere: "Скиньте изображения сюда",
       dropFilesHere: "Переместите файлы сюда",
       editQueuedMessage: "Изменить сообщение из очереди",
+      steerQueuedMessage: "Направить",
+      removeQueuedMessage: "Удалить сообщение из очереди",
       sendQueuedMessageNow: "Отправить сообщение из очереди сейчас",
       openImage: "Открыть прикрепленное изображение",
       removeImage: "Удалить прикрепленное изображение",
@@ -1727,7 +1729,7 @@ export const ru: TranslationResources = {
   },
   goals: {
     status: {
-      active: "Активна",
+      active: "Выполнение цели",
       paused: "Приостановлена",
       blocked: "Заблокирована",
       usageLimited: "Лимит использования",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1725,6 +1725,17 @@ export const ru: TranslationResources = {
     archiveFinishedAction: "Архивировать завершенные субагенты",
     archiveFinishedRetry: "Повторить ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "Активна",
+      paused: "Приостановлена",
+      blocked: "Заблокирована",
+      usageLimited: "Лимит использования",
+      budgetLimited: "Лимит бюджета",
+      complete: "Завершена",
+    },
+    actions: { pause: "Пауза", resume: "Продолжить", clear: "Очистить" },
+  },
   panels: {
     draft: {
       newAgent: "Новый агент",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1674,6 +1674,17 @@ export const zhCN: TranslationResources = {
     archiveFinishedAction: "归档已完成的 subagent",
     archiveFinishedRetry: "重试 ({{failed}}/{{total}})",
   },
+  goals: {
+    status: {
+      active: "进行中",
+      paused: "已暂停",
+      blocked: "已阻塞",
+      usageLimited: "已达使用上限",
+      budgetLimited: "已达预算上限",
+      complete: "已完成",
+    },
+    actions: { pause: "暂停", resume: "继续", clear: "清除" },
+  },
   panels: {
     draft: {
       newAgent: "新建 Agent",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -131,6 +131,8 @@ export const zhCN: TranslationResources = {
       dropImagesHere: "将图片拖放到这里",
       dropFilesHere: "Drop files here",
       editQueuedMessage: "编辑排队消息",
+      steerQueuedMessage: "引导",
+      removeQueuedMessage: "移除排队消息",
       sendQueuedMessageNow: "立即发送排队消息",
       openImage: "打开图片附件",
       removeImage: "移除图片附件",
@@ -1676,7 +1678,7 @@ export const zhCN: TranslationResources = {
   },
   goals: {
     status: {
-      active: "进行中",
+      active: "正在执行目标",
       paused: "已暂停",
       blocked: "已阻塞",
       usageLimited: "已达使用上限",

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1623,8 +1623,8 @@ function ActiveAgentComposer({
     },
     [agentId, client],
   );
-  const goalSurfaceHeader = useMemo(
-    () => <GoalTrack goal={goal} onAction={handleGoalAction} />,
+  const goalTrayFooter = useMemo(
+    () => (goal ? <GoalTrack goal={goal} onAction={handleGoalAction} /> : null),
     [goal, handleGoalAction],
   );
   const workspaceAttachmentScopeKey = useWorkspaceAttachmentScopeKey({
@@ -1728,7 +1728,7 @@ function ActiveAgentComposer({
         onMessageSent={onMessageSent}
         onClientSlashCommand={handleClientSlashCommand}
         isCompactLayout={isCompactComposerLayout}
-        surfaceHeader={goalSurfaceHeader}
+        contextTrayFooter={goalTrayFooter}
       />
     </ReanimatedAnimated.View>
   );

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -97,8 +97,10 @@ import { buildWorkspaceTabPersistenceKey } from "@/workspace-tabs/model";
 import { openSidePanelView } from "@/workspace-tabs/side-panel";
 import type { Theme } from "@/styles/theme";
 import type { PendingPermission } from "@/types/shared";
-import type { StreamItem, TodoEntry } from "@/types/stream";
+import { generateMessageId, type StreamItem, type TodoEntry } from "@/types/stream";
 import { useArchiveFinishedSubagents, useSubagentsForParent } from "@/subagents";
+import { GoalTrack } from "@/goals/track";
+import type { GoalAction } from "@/goals/presentation";
 import { getInitDeferred, getInitKey } from "@/utils/agent-initialization";
 import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agent-snapshots";
 import { applyLegacyDaemonWorkspaceOwnership } from "@/workspace/legacy-daemon-workspaces";
@@ -1604,6 +1606,23 @@ function ActiveAgentComposer({
   const closeWorkspaceTab = useWorkspaceLayoutStore((state) => state.closeTab);
   const hideWorkspaceAgent = useWorkspaceLayoutStore((state) => state.hideAgent);
   const unpinWorkspaceAgent = useWorkspaceLayoutStore((state) => state.unpinAgent);
+  const client = useHostRuntimeClient(serverId);
+  const goal = useSessionStore(
+    (state) => resolveChatAgentFromSession(state, serverId, agentId)?.goal ?? null,
+  );
+  const handleGoalAction = useCallback(
+    async (action: GoalAction) => {
+      if (!client) {
+        throw new Error("Host disconnected");
+      }
+      await client.sendAgentMessage(agentId, `/goal ${action}`, {
+        messageId: generateMessageId(),
+        images: [],
+        attachments: [],
+      });
+    },
+    [agentId, client],
+  );
   const workspaceAttachmentScopeKey = useWorkspaceAttachmentScopeKey({
     serverId,
     cwd,
@@ -1681,6 +1700,7 @@ function ActiveAgentComposer({
 
   return (
     <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
+      <GoalTrack goal={goal} onAction={handleGoalAction} />
       <Composer
         agentId={agentId}
         serverId={serverId}

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -1623,6 +1623,10 @@ function ActiveAgentComposer({
     },
     [agentId, client],
   );
+  const goalSurfaceHeader = useMemo(
+    () => <GoalTrack goal={goal} onAction={handleGoalAction} />,
+    [goal, handleGoalAction],
+  );
   const workspaceAttachmentScopeKey = useWorkspaceAttachmentScopeKey({
     serverId,
     cwd,
@@ -1700,7 +1704,6 @@ function ActiveAgentComposer({
 
   return (
     <ReanimatedAnimated.View style={inputAreaStyle} onLayout={onInputAreaLayout}>
-      <GoalTrack goal={goal} onAction={handleGoalAction} />
       <Composer
         agentId={agentId}
         serverId={serverId}
@@ -1725,6 +1728,7 @@ function ActiveAgentComposer({
         onMessageSent={onMessageSent}
         onClientSlashCommand={handleClientSlashCommand}
         isCompactLayout={isCompactComposerLayout}
+        surfaceHeader={goalSurfaceHeader}
       />
     </ReanimatedAnimated.View>
   );

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -27,6 +27,7 @@ import type { AgentLifecycleStatus } from "@getpaseo/protocol/agent-lifecycle";
 import type {
   AgentPermissionRequest,
   AgentFeature,
+  AgentGoal,
   AgentProvider,
   AgentMode,
   AgentCapabilityFlags,
@@ -87,6 +88,7 @@ export interface Agent {
   pendingPermissions: AgentPermissionRequest[];
   persistence: AgentPersistenceHandle | null;
   runtimeInfo?: AgentRuntimeInfo;
+  goal?: AgentGoal | null;
   lastUsage?: AgentUsage;
   lastError?: string | null;
   title: string | null;

--- a/packages/app/src/utils/agent-snapshots.test.ts
+++ b/packages/app/src/utils/agent-snapshots.test.ts
@@ -18,6 +18,7 @@ function createSnapshot(
     lastUserMessageAt: input.lastUserMessageAt ?? null,
     status: input.status ?? "idle",
     activeTurn: input.activeTurn,
+    goal: input.goal,
     capabilities: input.capabilities ?? {
       supportsStreaming: true,
       supportsSessionPersistence: true,
@@ -78,6 +79,19 @@ describe("normalizeAgentSnapshot", () => {
 
     expect(agent.parentAgentId).toBe("parent-1");
     expect(agent.labels).toEqual(labels);
+  });
+
+  it("preserves goal state across snapshot normalization", () => {
+    const goal = {
+      objective: "Ship persistent goal controls",
+      status: "active" as const,
+      tokenBudget: null,
+      tokensUsed: 7,
+      timeUsedSeconds: 3,
+    };
+
+    expect(normalizeAgentSnapshot(createSnapshot({ goal }), "server-1").goal).toEqual(goal);
+    expect(normalizeAgentSnapshot(createSnapshot(), "server-1").goal).toBeNull();
   });
 
   it("trims whitespace around the parent label", () => {

--- a/packages/app/src/utils/agent-snapshots.ts
+++ b/packages/app/src/utils/agent-snapshots.ts
@@ -106,6 +106,7 @@ export function normalizeAgentSnapshot(snapshot: AgentSnapshotPayload, serverId:
     pendingPermissions: snapshot.pendingPermissions ?? [],
     persistence: snapshot.persistence ?? null,
     runtimeInfo: snapshot.runtimeInfo,
+    goal: snapshot.goal ?? null,
     lastUsage: snapshot.lastUsage,
     lastError: snapshot.lastError ?? null,
     title: snapshot.title ?? null,

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -347,6 +347,22 @@ export interface AgentTaskItem {
   activeForm?: string;
 }
 
+export type AgentGoalStatus =
+  | "active"
+  | "paused"
+  | "blocked"
+  | "usageLimited"
+  | "budgetLimited"
+  | "complete";
+
+export interface AgentGoal {
+  objective: string;
+  status: AgentGoalStatus;
+  tokenBudget: number | null;
+  tokensUsed: number;
+  timeUsedSeconds: number;
+}
+
 export type AgentTimelineItem =
   | { type: "user_message"; text: string; messageId?: string; clientMessageId?: string }
   | { type: "assistant_message"; text: string; messageId?: string }
@@ -373,6 +389,7 @@ export type AgentStreamEvent =
       provider: AgentProvider;
       thinkingOptionId: string | null;
     }
+  | { type: "goal_changed"; provider: AgentProvider; goal: AgentGoal | null }
   | {
       type: "turn_failed";
       provider: AgentProvider;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -721,6 +721,14 @@ export const AgentTimelineItemPayloadSchema: z.ZodType<AgentTimelineItem, unknow
   }),
 ]);
 
+export const AgentGoalPayloadSchema = z.object({
+  objective: z.string(),
+  status: z.enum(["active", "paused", "blocked", "usageLimited", "budgetLimited", "complete"]),
+  tokenBudget: z.number().nullable(),
+  tokensUsed: z.number(),
+  timeUsedSeconds: z.number(),
+});
+
 export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("thread_started"),
@@ -751,6 +759,11 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
     provider: AgentProviderSchema,
     turnId: z.string().optional(),
     reason: z.string(),
+  }),
+  z.object({
+    type: z.literal("goal_changed"),
+    provider: AgentProviderSchema,
+    goal: AgentGoalPayloadSchema.nullable(),
   }),
   z.object({
     type: z.literal("timeline"),
@@ -827,6 +840,7 @@ export const AgentSnapshotPayloadSchema = z.object({
   lastUserMessageAt: z.string().nullable(),
   status: AgentStatusSchema,
   activeTurn: AgentActiveTurnPayloadSchema.nullable().optional(),
+  goal: AgentGoalPayloadSchema.nullable().optional(),
   capabilities: AgentCapabilityFlagsSchema,
   currentModeId: z.string().nullable(),
   availableModes: z.array(AgentModeSchema),

--- a/packages/protocol/src/messages.wire-compat.test.ts
+++ b/packages/protocol/src/messages.wire-compat.test.ts
@@ -243,5 +243,42 @@ describe("wire schema compatibility", () => {
     expect(parsed.capabilities.supportsRewindConversation).toBe(false);
     expect(parsed.capabilities.supportsRewindFiles).toBe(false);
     expect(parsed.capabilities.supportsRewindBoth).toBe(false);
+    expect(parsed.goal).toBeUndefined();
+  });
+
+  test("goal state is optional and preserves non-color-only status", () => {
+    const parsed = AgentSnapshotPayloadSchema.parse({
+      id: "agent-1",
+      provider: "codex",
+      cwd: "/tmp/project",
+      model: null,
+      createdAt: "2026-08-10T00:00:00.000Z",
+      updatedAt: "2026-08-10T00:00:00.000Z",
+      lastUserMessageAt: null,
+      status: "idle",
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: false,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      currentModeId: null,
+      availableModes: [],
+      pendingPermissions: [],
+      persistence: null,
+      title: null,
+      labels: {},
+      goal: {
+        objective: "Ship persistent goal controls",
+        status: "blocked",
+        tokenBudget: null,
+        tokensUsed: 12,
+        timeUsedSeconds: 5,
+      },
+    });
+
+    expect(parsed.goal).toMatchObject({ status: "blocked" });
   });
 });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4284,6 +4284,49 @@ test("session config drift events update state through the stream channel", asyn
   expect(streams.map((event) => event.type)).toEqual([]);
 });
 
+test("goal refresh failure clears a stale projection", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-goal-refresh-failure-"));
+  class GoalRefreshSession extends TestAgentSession {
+    failGoalRefresh = false;
+
+    async getGoal() {
+      if (this.failGoalRefresh) {
+        throw new Error("goal lookup unavailable");
+      }
+      return {
+        objective: "Keep this projection authoritative",
+        status: "active" as const,
+        tokenBudget: null,
+        tokensUsed: 4,
+        timeUsedSeconds: 2,
+      };
+    }
+  }
+  let session: GoalRefreshSession | null = null;
+  class GoalRefreshClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new GoalRefreshSession(config);
+      return session;
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new GoalRefreshClient() },
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000134",
+  });
+  const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId: undefined,
+  });
+  expect(manager.getAgent(snapshot.id)?.goal?.status).toBe("active");
+
+  if (!session) throw new Error("Expected goal refresh session");
+  session.failGoalRefresh = true;
+  await manager.respondToPermission(snapshot.id, "refresh-goal", { behavior: "allow" });
+
+  expect(manager.getAgent(snapshot.id)?.goal).toBeNull();
+});
+
 test("setLabels merges and persists labels", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-set-labels-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -4251,6 +4251,17 @@ test("session config drift events update state through the stream channel", asyn
     provider: "codex",
     thinkingOptionId: "high",
   });
+  capturedSession?.pushEvent({
+    type: "goal_changed",
+    provider: "codex",
+    goal: {
+      objective: "Ship persistent goal controls",
+      status: "blocked",
+      tokenBudget: null,
+      tokensUsed: 12,
+      timeUsedSeconds: 5,
+    },
+  });
   await manager.flush();
 
   const agent = manager.getAgent(snapshot.id);
@@ -4265,6 +4276,11 @@ test("session config drift events update state through the stream channel", asyn
     modeId: "build",
     thinkingOptionId: "high",
   });
+  expect(agent?.goal).toMatchObject({
+    objective: "Ship persistent goal controls",
+    status: "blocked",
+  });
+  expect(agent ? toAgentPayload(agent).goal : null).toMatchObject({ status: "blocked" });
   expect(streams.map((event) => event.type)).toEqual([]);
 });
 

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -30,6 +30,7 @@ import type {
   AgentClient,
   AgentCreateSessionOptions,
   AgentFeature,
+  AgentGoal,
   AgentLaunchContext,
   AgentPromptInput,
   AgentProvider,
@@ -4284,22 +4285,23 @@ test("session config drift events update state through the stream channel", asyn
   expect(streams.map((event) => event.type)).toEqual([]);
 });
 
-test("goal refresh failure clears a stale projection", async () => {
+test("goal refresh failure preserves the last authoritative projection", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-goal-refresh-failure-"));
   class GoalRefreshSession extends TestAgentSession {
     failGoalRefresh = false;
+    goal: AgentGoal | null = {
+      objective: "Keep this projection authoritative",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 4,
+      timeUsedSeconds: 2,
+    };
 
     async getGoal() {
       if (this.failGoalRefresh) {
         throw new Error("goal lookup unavailable");
       }
-      return {
-        objective: "Keep this projection authoritative",
-        status: "active" as const,
-        tokenBudget: null,
-        tokensUsed: 4,
-        timeUsedSeconds: 2,
-      };
+      return this.goal;
     }
   }
   let session: GoalRefreshSession | null = null;
@@ -4322,6 +4324,15 @@ test("goal refresh failure clears a stale projection", async () => {
 
   if (!session) throw new Error("Expected goal refresh session");
   session.failGoalRefresh = true;
+  await manager.respondToPermission(snapshot.id, "refresh-goal", { behavior: "allow" });
+
+  expect(manager.getAgent(snapshot.id)?.goal).toMatchObject({
+    objective: "Keep this projection authoritative",
+    status: "active",
+  });
+
+  session.failGoalRefresh = false;
+  session.goal = null;
   await manager.respondToPermission(snapshot.id, "refresh-goal", { behavior: "allow" });
 
   expect(manager.getAgent(snapshot.id)?.goal).toBeNull();

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3625,11 +3625,8 @@ export class AgentManager {
         { err: error, agentId: agent.id, provider: agent.provider },
         "Failed to refresh agent goal",
       );
-      const changed = agent.goal != null;
-      agent.goal = null;
-      if (changed && options?.emit !== false) {
-        this.emitState(agent);
-      }
+      // A failed lookup is not an authoritative clear. Keep the last provider
+      // projection until getGoal succeeds or a goal_changed(null) event arrives.
     }
   }
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -3620,8 +3620,16 @@ export class AgentManager {
       if (changed && options?.emit !== false) {
         this.emitState(agent);
       }
-    } catch {
-      // Keep the last projected goal when the provider cannot refresh it.
+    } catch (error) {
+      this.logger.warn(
+        { err: error, agentId: agent.id, provider: agent.provider },
+        "Failed to refresh agent goal",
+      );
+      const changed = agent.goal != null;
+      agent.goal = null;
+      if (changed && options?.emit !== false) {
+        this.emitState(agent);
+      }
     }
   }
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -24,6 +24,7 @@ import {
   type AgentCreateSessionOptions,
   type AgentResumeSessionOptions,
   type AgentFeature,
+  type AgentGoal,
   type AgentLaunchContext,
   type AgentSlashCommand,
   type AgentMode,
@@ -340,6 +341,18 @@ interface StreamEventFlags {
   shouldNotifyWaiters: boolean;
 }
 
+function areAgentGoalsEqual(left: AgentGoal | null, right: AgentGoal | null): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.objective === right.objective &&
+    left.status === right.status &&
+    left.tokenBudget === right.tokenBudget &&
+    left.tokensUsed === right.tokensUsed &&
+    left.timeUsedSeconds === right.timeUsedSeconds
+  );
+}
+
 type ActiveTurnTerminalDisposition = "closed_current" | "stale" | "untracked";
 
 interface HandleStreamEventOptions {
@@ -360,6 +373,7 @@ interface ManagedAgentBase {
   capabilities: AgentCapabilityFlags;
   config: AgentSessionConfig;
   runtimeInfo?: AgentRuntimeInfo;
+  goal?: AgentGoal | null;
   createdAt: Date;
   updatedAt: Date;
   availableModes: AgentMode[];
@@ -1669,6 +1683,7 @@ export class AgentManager {
         capabilities: STORED_AGENT_CAPABILITIES,
         config: buildStoredAgentConfig(record),
         runtimeInfo: undefined,
+        goal: null,
         lifecycle: "closed",
         createdAt: new Date(record.createdAt),
         updatedAt,
@@ -3303,6 +3318,7 @@ export class AgentManager {
       capabilities: session.capabilities,
       config,
       runtimeInfo: undefined,
+      goal: null,
       lifecycle: "initializing",
       createdAt: options?.createdAt ?? now,
       updatedAt: options?.updatedAt ?? now,
@@ -3588,7 +3604,25 @@ export class AgentManager {
     }
 
     this.syncFeaturesFromSession(agent);
+    await this.refreshGoal(agent, options);
     await this.refreshRuntimeInfo(agent, options);
+  }
+
+  private async refreshGoal(
+    agent: ActiveManagedAgent,
+    options?: { emit?: boolean },
+  ): Promise<void> {
+    if (!agent.session.getGoal) return;
+    try {
+      const goal = await agent.session.getGoal();
+      const changed = !areAgentGoalsEqual(goal, agent.goal ?? null);
+      agent.goal = goal;
+      if (changed && options?.emit !== false) {
+        this.emitState(agent);
+      }
+    } catch {
+      // Keep the last projected goal when the provider cannot refresh it.
+    }
   }
 
   private async refreshRuntimeInfo(
@@ -3961,6 +3995,11 @@ export class AgentManager {
             thinkingOptionId: event.thinkingOptionId,
           };
         }
+        flags.shouldDispatchEvent = false;
+        this.emitState(agent);
+        return undefined;
+      case "goal_changed":
+        agent.goal = event.goal;
         flags.shouldDispatchEvent = false;
         this.emitState(agent);
         return undefined;

--- a/packages/server/src/server/agent/agent-projections.ts
+++ b/packages/server/src/server/agent/agent-projections.ts
@@ -127,6 +127,7 @@ export function toAgentPayload(
           startedAt: agent.activeTurnStartedAt?.toISOString() ?? null,
         }
       : null,
+    goal: agent.goal ?? null,
     capabilities: cloneCapabilities(agent.capabilities),
     currentModeId: agent.currentModeId,
     availableModes: cloneAvailableModes(agent.availableModes),

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentGoal,
   AgentProviderNotice,
   AgentTaskItem,
   ProviderOptions,
@@ -7,7 +8,12 @@ import type {
 import type { AgentAttachment } from "@getpaseo/protocol/messages";
 import type { PaseoToolCatalog } from "./tools/types.js";
 
-export type { AgentProviderNotice, AgentTaskItem };
+export type {
+  AgentGoal,
+  AgentGoalStatus,
+  AgentProviderNotice,
+  AgentTaskItem,
+} from "@getpaseo/protocol/agent-types";
 
 export type AgentProvider = string;
 
@@ -388,22 +394,6 @@ export interface CompactionTimelineItem {
   status: "loading" | "completed";
   trigger?: "auto" | "manual";
   preTokens?: number;
-}
-
-export type AgentGoalStatus =
-  | "active"
-  | "paused"
-  | "blocked"
-  | "usageLimited"
-  | "budgetLimited"
-  | "complete";
-
-export interface AgentGoal {
-  objective: string;
-  status: AgentGoalStatus;
-  tokenBudget: number | null;
-  tokensUsed: number;
-  timeUsedSeconds: number;
 }
 
 export type AgentTimelineItem =

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -390,6 +390,22 @@ export interface CompactionTimelineItem {
   preTokens?: number;
 }
 
+export type AgentGoalStatus =
+  | "active"
+  | "paused"
+  | "blocked"
+  | "usageLimited"
+  | "budgetLimited"
+  | "complete";
+
+export interface AgentGoal {
+  objective: string;
+  status: AgentGoalStatus;
+  tokenBudget: number | null;
+  tokensUsed: number;
+  timeUsedSeconds: number;
+}
+
 export type AgentTimelineItem =
   | { type: "user_message"; text: string; messageId?: string; clientMessageId?: string }
   | { type: "assistant_message"; text: string; messageId?: string }
@@ -416,6 +432,7 @@ export type AgentStreamEvent =
       provider: AgentProvider;
       thinkingOptionId: string | null;
     }
+  | { type: "goal_changed"; provider: AgentProvider; goal: AgentGoal | null }
   | {
       type: "turn_failed";
       provider: AgentProvider;
@@ -646,6 +663,7 @@ export interface AgentSession {
   getRuntimeInfo(): Promise<AgentRuntimeInfo>;
   getAvailableModes(): Promise<AgentMode[]>;
   getCurrentMode(): Promise<string | null>;
+  getGoal?(): Promise<AgentGoal | null>;
   setMode(modeId: string): Promise<void | AgentProviderNotice>;
   getPendingPermissions(): AgentPermissionRequest[];
   respondToPermission(

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4553,6 +4553,47 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
+  test("restores and emits durable Codex goal state", async () => {
+    const session = createSession({}, { goalsEnabled: true });
+    const goal = {
+      objective: "Ship persistent goal controls",
+      status: "active" as const,
+      tokenBudget: null,
+      tokensUsed: 42,
+      timeUsedSeconds: 8,
+    };
+    session.client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "thread/loaded/list") return { data: ["test-thread"] };
+        if (method === "thread/goal/get") return { goal };
+        return {};
+      }),
+    };
+
+    await expect(session.getGoal?.()).resolves.toEqual(goal);
+
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    asInternals(session).handleNotification("thread/goal/updated", {
+      threadId: "test-thread",
+      turnId: null,
+      goal: { ...goal, status: "paused" },
+    });
+    asInternals(session).handleNotification("thread/goal/cleared", {
+      threadId: "test-thread",
+    });
+
+    expect(events).toEqual([
+      {
+        type: "goal_changed",
+        provider: "codex",
+        goal: { ...goal, status: "paused" },
+        turnId: "test-turn",
+      },
+      { type: "goal_changed", provider: "codex", goal: null, turnId: "test-turn" },
+    ]);
+  });
+
   test("lists /compact and sends Codex compaction out of band", async () => {
     const requests: Array<{ method: string; params: unknown }> = [];
     const session = createSession();

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4553,7 +4553,7 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
-  test("restores and emits durable Codex goal state", async () => {
+  test("restores and emits goal state created during a normal Codex turn", async () => {
     const session = createSession({}, { goalsEnabled: true });
     const goal = {
       objective: "Ship persistent goal controls",
@@ -4571,13 +4571,18 @@ describe("Codex app-server provider", () => {
     };
 
     await expect(session.getGoal?.()).resolves.toEqual(goal);
+    expect(
+      session.tryHandleOutOfBand?.(
+        "Set up a goal, keep working on it, test end to end, and commit as you go",
+      ),
+    ).toBeNull();
 
     const events: AgentStreamEvent[] = [];
     session.subscribe((event) => events.push(event));
     asInternals(session).handleNotification("thread/goal/updated", {
       threadId: "test-thread",
       turnId: null,
-      goal: { ...goal, status: "paused" },
+      goal,
     });
     asInternals(session).handleNotification("thread/goal/cleared", {
       threadId: "test-thread",
@@ -4587,7 +4592,7 @@ describe("Codex app-server provider", () => {
       {
         type: "goal_changed",
         provider: "codex",
-        goal: { ...goal, status: "paused" },
+        goal,
         turnId: "test-turn",
       },
       { type: "goal_changed", provider: "codex", goal: null, turnId: "test-turn" },

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -5,6 +5,7 @@ import {
   type AgentClient,
   type AgentCreateSessionOptions,
   type AgentFeature,
+  type AgentGoal,
   type AgentLaunchContext,
   type AgentResumeSessionOptions,
   type AgentMode,
@@ -2087,6 +2088,25 @@ const ThreadStartedNotificationSchema = z
   })
   .passthrough();
 
+const CodexGoalSchema = z.object({
+  objective: z.string(),
+  status: z.enum(["active", "paused", "blocked", "usageLimited", "budgetLimited", "complete"]),
+  tokenBudget: z.number().nullable(),
+  tokensUsed: z.number(),
+  timeUsedSeconds: z.number(),
+});
+
+const ThreadGoalUpdatedNotificationSchema = z
+  .object({
+    threadId: z.string(),
+    goal: CodexGoalSchema,
+  })
+  .passthrough();
+
+const ThreadGoalClearedNotificationSchema = z.object({ threadId: z.string() }).passthrough();
+
+const ThreadGoalGetResponseSchema = z.object({ goal: CodexGoalSchema.nullable() }).passthrough();
+
 const TurnStartedNotificationSchema = z
   .object({
     threadId: z.string().optional(),
@@ -2372,6 +2392,8 @@ const CodexEventThreadRolledBackNotificationSchema = z
 
 type ParsedCodexNotification =
   | { kind: "thread_started"; threadId: string }
+  | { kind: "goal_updated"; threadId: string; goal: AgentGoal }
+  | { kind: "goal_cleared"; threadId: string }
   | { kind: "turn_started"; turnId: string; threadId: string | null }
   | {
       kind: "turn_completed";
@@ -2500,6 +2522,43 @@ const CodexNotificationSchema = z.union([
       }),
     ),
   z.object({ method: z.literal("thread/started"), params: z.unknown() }).transform(
+    ({ method, params }): ParsedCodexNotification => ({
+      kind: "invalid_payload",
+      method,
+      params,
+    }),
+  ),
+  z
+    .object({
+      method: z.literal("thread/goal/updated"),
+      params: ThreadGoalUpdatedNotificationSchema,
+    })
+    .transform(
+      ({ params }): ParsedCodexNotification => ({
+        kind: "goal_updated",
+        threadId: params.threadId,
+        goal: params.goal,
+      }),
+    ),
+  z.object({ method: z.literal("thread/goal/updated"), params: z.unknown() }).transform(
+    ({ method, params }): ParsedCodexNotification => ({
+      kind: "invalid_payload",
+      method,
+      params,
+    }),
+  ),
+  z
+    .object({
+      method: z.literal("thread/goal/cleared"),
+      params: ThreadGoalClearedNotificationSchema,
+    })
+    .transform(
+      ({ params }): ParsedCodexNotification => ({
+        kind: "goal_cleared",
+        threadId: params.threadId,
+      }),
+    ),
+  z.object({ method: z.literal("thread/goal/cleared"), params: z.unknown() }).transform(
     ({ method, params }): ParsedCodexNotification => ({
       kind: "invalid_payload",
       method,
@@ -4320,6 +4379,23 @@ export class CodexAppServerAgentSession implements AgentSession {
     return { ...info };
   }
 
+  async getGoal(): Promise<AgentGoal | null> {
+    if (!this.goalsEnabled) return null;
+    await this.connect();
+    if (this.currentThreadId) {
+      await this.ensureThreadLoaded();
+    } else {
+      await this.ensureThread();
+    }
+    if (!this.client || !this.currentThreadId) {
+      throw new Error("Codex thread is not available");
+    }
+    const response = await this.client.request("thread/goal/get", {
+      threadId: this.currentThreadId,
+    });
+    return ThreadGoalGetResponseSchema.parse(response).goal;
+  }
+
   async getAvailableModes(): Promise<AgentMode[]> {
     if (this.autoReviewEnabled) {
       return CODEX_MODES;
@@ -5148,6 +5224,12 @@ export class CodexAppServerAgentSession implements AgentSession {
       return;
     }
     switch (parsed.kind) {
+      case "goal_updated":
+        this.emitEvent({ type: "goal_changed", provider: CODEX_PROVIDER, goal: parsed.goal });
+        return;
+      case "goal_cleared":
+        this.emitEvent({ type: "goal_changed", provider: CODEX_PROVIDER, goal: null });
+        return;
       case "thread_started":
         this.handleThreadStartedNotification(parsed);
         return;


### PR DESCRIPTION
### Linked issue

Closes #3098

Related: #781

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Codex goals outlive their one-time timeline acknowledgement, but Paseo discarded their durable state. Once that message scrolled away, users could not tell whether a goal was active, paused, blocked, limited, or complete, and controls were only discoverable through `/goal` commands.

This projects provider-owned goal state through the existing agent snapshot and stream contract and keeps a compact status, objective, duration, and relevant controls in the composer tray. Codex remains authoritative after resume/reconnect and when it creates a goal during a normal natural-language turn.

During the rebase, current `main` already contained the broader provider-neutral active-turn steering implementation for Claude, Codex, OpenCode, and mock providers. The older Codex-only steering commit from this branch was dropped instead of reintroducing duplicate transport and lifecycle paths. The queue/goal tray now composes with `main`'s existing steering behavior.

### Goals

- Persist Codex goal status, objective, usage, and duration in the agent UI.
- Track goals created by Codex during normal turns, not only `/goal` commands.
- Restore state from `thread/goal/get` after resume or reconnect.
- Update from native goal notifications.
- Preserve the last authoritative goal when a refresh fails transiently; clear only after an authoritative null result or clear notification.
- Expose compact Pause, Resume, and Clear actions for the current state.
- Keep queued messages and the goal together in a compact inset composer tray.
- Preserve wire compatibility when a provider or older peer does not expose goal state.

### Non-goals

- Change Codex goal execution semantics.
- Infer goals by parsing natural-language prompts in Paseo.
- Add a second Paseo-owned goal store.
- Reimplement active-turn steering already present on current `main`.

### QA

Rebased onto current `main` (`8d92e1cc1`) and resolved composer, panel, protocol, and agent-type refactors.

- `npm run build:server` — passed.
- `npm run build:app-deps` — passed.
- `npm run typecheck` — all workspaces passed.
- Focused goal/composer/protocol/manager/Codex tests — 373 passed.
- `npm run format:check` — passed.
- `npm run lint` — 0 warnings, 0 errors.
- Browser E2E: `restores an ambiguous Steer failure without retrying or interrupting` — passed against the rebased composer, proving the retained queue tray still uses `main`'s canonical steering path.

Manual web QA before the rebase verified active, paused, resumed, and cleared goal presentation. The rebase retained the same shared UI while adopting the current `sm` compact typography token.

![Paused goal state with objective, Resume, and Clear controls above the composer](https://raw.githubusercontent.com/edihasaj/paseo/a629956ae55d0cec76aaedf7eedcee7f0f18802d/pr-assets/3179/goal-status-paused.png)

Tested: automated browser + unit/integration gates on macOS. Not manually retested on packaged Electron, iOS, or Android.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
