### PR TITLE
fix(relay): do not reject sends on a mid-close relay socket

### DIFF
--- a/packages/server/src/server/relay-transport.test.ts
+++ b/packages/server/src/server/relay-transport.test.ts
@@ -389,10 +389,10 @@ describe("relay-transport control lifecycle", () => {
       onerror: null,
     };
     dataSocket.onSend = (data) => {
-      clientTransport.onmessage?.(
-        data instanceof Uint8Array ? data.slice().buffer : data,
-        data instanceof ArrayBuffer || data instanceof Uint8Array,
-      );
+      clientTransport.onmessage?.({
+        data: data instanceof Uint8Array ? data.slice().buffer : data,
+        isBinary: data instanceof ArrayBuffer || data instanceof Uint8Array,
+      });
     };
     let resolveClientOpen: (() => void) | undefined;
     const clientOpen = new Promise<void>((resolve) => {
@@ -413,5 +413,4 @@ describe("relay-transport control lifecycle", () => {
     await expect(encryptedSocket.send(new Uint8Array([1, 2, 3]))).resolves.toBeUndefined();
     expect(hasLogMessage(logger, "warn", "relay_socket_send_failed")).toBe(false);
   });
-
 });

--- a/packages/server/src/server/relay-transport.test.ts
+++ b/packages/server/src/server/relay-transport.test.ts
@@ -28,6 +28,7 @@ function hasLogMessage(logger: TestLogger, level: "info" | "warn", message: stri
 class FakeRelayWebSocket {
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
+  static readonly CLOSING = 2;
   static readonly CLOSED = 3;
 
   readyState = FakeRelayWebSocket.CONNECTING;
@@ -67,6 +68,12 @@ class FakeRelayWebSocket {
   }
 
   send(data: string | Uint8Array | ArrayBuffer, callback?: (error?: Error) => void) {
+    if (this.readyState === FakeRelayWebSocket.CLOSING) {
+      // The underlying ws library surfaces a CLOSING send via the callback with an
+      // error rather than throwing. Mirror it so the adapter callback branch runs.
+      callback?.(new Error(`WebSocket is not open: readyState ${this.readyState} (CLOSING)`));
+      return;
+    }
     if (this.readyState !== FakeRelayWebSocket.OPEN) {
       throw new Error(`WebSocket not open (readyState=${this.readyState})`);
     }
@@ -349,4 +356,62 @@ describe("relay-transport control lifecycle", () => {
     expect(relay.sockets[0]?.url).toMatch(/^wss:\/\/\[::1\]\/ws\?/);
     expect(relay.sockets[1]?.url).toMatch(/^wss:\/\/\[::1\]\/ws\?/);
   });
+  test("does not reject a send when the physical relay socket is mid-close", async () => {
+    const logger = createMockLogger();
+    const daemonKeyPair = generateKeyPair();
+    let resolveAttached: ((socket: unknown) => void) | undefined;
+    const attached = new Promise<unknown>((resolve) => {
+      resolveAttached = resolve;
+    });
+    const controller = startRelayTransport({
+      logger: logger as unknown as pino.Logger,
+      attachSocket: async (socket) => resolveAttached?.(socket),
+      relayEndpoint: "relay.paseo.sh:443",
+      relayUseTls: true,
+      serverId: "srv_test",
+      daemonKeyPair,
+      createWebSocket: relay.createWebSocket,
+    });
+    controllers.push(controller);
+
+    const control = relay.sockets[0];
+    control.open();
+    control.message(JSON.stringify({ type: "sync", connectionIds: [] }), false);
+    control.message(JSON.stringify({ type: "connected", connectionId: "clt_test" }), false);
+
+    const dataSocket = relay.sockets[1];
+    dataSocket.open();
+    let clientTransport: Transport = {
+      send: (data) => dataSocket.message(data, data instanceof ArrayBuffer),
+      close: () => undefined,
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+    };
+    dataSocket.onSend = (data) => {
+      clientTransport.onmessage?.(
+        data instanceof Uint8Array ? data.slice().buffer : data,
+        data instanceof ArrayBuffer || data instanceof Uint8Array,
+      );
+    };
+    let resolveClientOpen: (() => void) | undefined;
+    const clientOpen = new Promise<void>((resolve) => {
+      resolveClientOpen = resolve;
+    });
+    await createClientChannel(clientTransport, exportPublicKey(daemonKeyPair.publicKey), {
+      onopen: () => resolveClientOpen?.(),
+    });
+    await clientOpen;
+
+    const encryptedSocket = (await attached) as {
+      send: (data: Uint8Array) => void | Promise<void>;
+    };
+    // Simulate the underlying relay socket closing before the encrypted wrapper
+    // observes it: this is the race that previously produced relay_socket_send_failed.
+    dataSocket.readyState = FakeRelayWebSocket.CLOSING;
+
+    await expect(encryptedSocket.send(new Uint8Array([1, 2, 3]))).resolves.toBeUndefined();
+    expect(hasLogMessage(logger, "warn", "relay_socket_send_failed")).toBe(false);
+  });
+
 });

--- a/packages/server/src/server/relay-transport.ts
+++ b/packages/server/src/server/relay-transport.ts
@@ -469,6 +469,14 @@ function createRelayTransportAdapter(
   const relayTransport: RelayTransport = {
     send: (data) =>
       new Promise<void>((resolve, reject) => {
+        // A physical relay socket in the middle of closing must not fail a send.
+        // Mirrors websocket/physical-socket.ts (sendBoundedPhysicalFrame returns
+        // false for a non-OPEN socket) so a dying relay leg cannot poison the
+        // shared fan-out to healthy direct peers on the same session.
+        if (socket.readyState !== WebSocket.OPEN) {
+          resolve();
+          return;
+        }
         try {
           socket.send(data, (error) => {
             if (!error) {


### PR DESCRIPTION
# Do not reject outbound frames on a mid-close relay socket

## Problem

When a device is attached over the relay and then drops the relay leg (for
example while also being reachable on a direct LAN path), the window between
the underlying relay WebSocket starting to close and the encrypted wrapper
observing its `close` event lets a daemon broadcast hit a socket whose physical
`readyState` has already left `OPEN`.

The relay adapter (`createRelayTransportAdapter.send`) calls the underlying
`socket.send(data, cb)` without first checking readyState. The `ws` library
surfaces that asynchronously:

```
Error: WebSocket is not open: readyState 2 (CLOSING)
    at relay-transport.js:397 (socket.send(data, (error) => ...))
```

The error is logged as `relay_socket_send_failed` and the send promise rejects.
That rejection originates from `sendMessageToSockets`/`sendFrameToClient`, which
fans one message out to every socket on a session. When a session holds both a
dying relay socket and a healthy direct socket, the relay leg's rejection
surfaces as a `Client error` and a dropped frame, and the session looks
"connected but no updates" to the user.

Observed while a phone held both a relay and a direct Tailscale connection for
the same session:

```
07:16:06  relay_socket_send_failed -> Client error
07:25:12  Client connected via hello (direct)
07:25:13  Registered push token     (relay, same sessionId)
```

## Change

In `packages/server/src/server/relay-transport.ts`, guard the relay send against
a socket that is no longer `OPEN`. Treat a closing/closed socket as an
already-sent no-op instead of rejecting:

```ts
send: (data) =>
  new Promise<void>((resolve, reject) => {
    if (socket.readyState !== WebSocket.OPEN) {
      resolve();
      return;
    }
    try {
      socket.send(data, (error) => { ... });
    } catch (error) { ... }
  }),
```

This matches the semantics the direct/WAN path already uses in
`websocket/physical-socket.ts` (sendBoundedPhysicalFrame returns false for a
non-OPEN socket instead of throwing).

## Behavior preserved

- Frames for a socket that is already gone are dropped, never delivered, exactly
  as before. The change only stops treating that drop as an error that poisons
  the shared fan-out.
- A send on an OPEN relay socket that still fails is logged and rejected as
  before.
- Control keepalive, data attach, and close handling are unchanged.

## Testing

- Regression added in `packages/server/src/server/relay-transport.test.ts`:
  drive an encrypted relay socket whose physical `FakeRelayWebSocket` is set to
  `CLOSING`, and assert the send resolves without a `relay_socket_send_failed`
  warning.
- `FakeRelayWebSocket` gained `CLOSING = 2` and now surfaces a CLOSING send via
  the send callback with an error (mirroring `ws`) instead of throwing.

## Reproduced during triage

Live daemon log while a device kept both a relay and a direct (Tailscale) socket
on the same session; each broadcast hit the closing relay socket, logged
`relay_socket_send_failed`, and the session stopped updating on the user side.
