### PR TITLE
삭제된 Claude native cwd 세션 자동 복구

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -1602,6 +1602,291 @@ describe("ClaudeAgentSession context window usage", () => {
     await session.close();
   });
 
+  test("retries a resumed prompt in the current cwd when Claude's native session cwd is gone", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paseo-claude-current-cwd-"));
+    const staleNativeCwd = path.join(cwd, "deleted-worktree");
+    const prompts: unknown[] = [];
+    let launchIndex = 0;
+    let markUserTimelineVisible: () => void = () => undefined;
+    const userTimelineVisible = new Promise<void>((resolve) => {
+      markUserTimelineVisible = resolve;
+    });
+    const asyncNoop = async () => undefined;
+    const asyncEmpty = async () => [];
+    const asyncRewind = async () => ({ canRewind: true });
+    const queryFactory = vi.fn(
+      ({
+        prompt,
+        options,
+      }: {
+        prompt: AsyncIterable<unknown>;
+        options: Record<string, unknown>;
+      }) => {
+        const thisLaunch = launchIndex;
+        launchIndex += 1;
+        return {
+          async *[Symbol.asyncIterator]() {
+            for await (const message of prompt) {
+              prompts.push(message);
+              if (thisLaunch === 0) {
+                await userTimelineVisible;
+                const stderr = options.stderr;
+                if (typeof stderr === "function") {
+                  stderr(`Path "${staleNativeCwd}" does not exist`);
+                }
+                throw new Error("Claude Code process exited with code 1");
+              }
+              const sessionId = String(options.sessionId);
+              yield message as SDKMessage;
+              yield createInitMessage(sessionId) as SDKMessage;
+              yield createSuccessResult({ session_id: sessionId }) as SDKMessage;
+            }
+          },
+          interrupt: vi.fn(asyncNoop),
+          return: vi.fn(asyncNoop),
+          close: vi.fn(),
+          setPermissionMode: vi.fn(asyncNoop),
+          setModel: vi.fn(asyncNoop),
+          getContextUsage: vi.fn(asyncNoop),
+          supportedModels: vi.fn(asyncEmpty),
+          supportedCommands: vi.fn(asyncEmpty),
+          rewindFiles: vi.fn(asyncRewind),
+        };
+      },
+    );
+    const client = new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.resumeSession({
+      provider: "claude",
+      sessionId: "stale-native-session",
+      nativeHandle: "stale-native-session",
+      metadata: { provider: "claude", cwd },
+    });
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "timeline" && event.item.type === "user_message") {
+        markUserTimelineVisible();
+      }
+    });
+
+    try {
+      await expect(session.run("continue the task")).resolves.toMatchObject({
+        sessionId: expect.any(String),
+      });
+      expect(queryFactory).toHaveBeenCalledTimes(2);
+      expect(queryFactory.mock.calls[0]?.[0].options).toMatchObject({
+        cwd,
+        resume: "stale-native-session",
+      });
+      expect(queryFactory.mock.calls[1]?.[0].options).toMatchObject({
+        cwd,
+        sessionId: expect.any(String),
+      });
+      expect(queryFactory.mock.calls[1]?.[0].options.resume).toBeUndefined();
+      expect(prompts).toHaveLength(2);
+      const firstPrompt = prompts[0] as { session_id?: string; uuid?: string };
+      const retriedPrompt = prompts[1] as { session_id?: string; uuid?: string };
+      expect(firstPrompt.session_id).toBe("stale-native-session");
+      expect(retriedPrompt.session_id).toBe(queryFactory.mock.calls[1]?.[0].options.sessionId);
+      expect(retriedPrompt.uuid).toBe(firstPrompt.uuid);
+      expect(
+        events.filter((event) => event.type === "timeline" && event.item.type === "user_message"),
+      ).toHaveLength(1);
+      expect(events.some((event) => event.type === "turn_failed")).toBe(false);
+    } finally {
+      await session.close();
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("restores the stale session when the replacement query fails before provider activity", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paseo-claude-fallback-fail-"));
+    const staleNativeCwd = path.join(cwd, "deleted-worktree");
+    const asyncNoop = async () => undefined;
+    const asyncEmpty = async () => [];
+    const asyncRewind = async () => ({ canRewind: true });
+    let markUserTimelineVisible: () => void = () => undefined;
+    const userTimelineVisible = new Promise<void>((resolve) => {
+      markUserTimelineVisible = resolve;
+    });
+    let launchIndex = 0;
+    const queryFactory = vi.fn(
+      ({
+        prompt,
+        options,
+      }: {
+        prompt: AsyncIterable<unknown>;
+        options: Record<string, unknown>;
+      }) => ({
+        async *[Symbol.asyncIterator](): AsyncGenerator<SDKMessage, void, unknown> {
+          const thisLaunch = launchIndex;
+          launchIndex += 1;
+          for await (const message of prompt) {
+            if (thisLaunch === 0 || thisLaunch === 2) {
+              await userTimelineVisible;
+              const stderr = options.stderr;
+              if (typeof stderr === "function") {
+                stderr(`Path "${staleNativeCwd}" does not exist`);
+              }
+              throw new Error("Claude Code process exited with code 1");
+            }
+            if (thisLaunch === 1) {
+              throw new Error("fresh replacement query failed");
+            }
+            const sessionId = String(options.sessionId);
+            yield message as SDKMessage;
+            yield createInitMessage(sessionId) as SDKMessage;
+            yield createSuccessResult({ session_id: sessionId }) as SDKMessage;
+          }
+        },
+        interrupt: vi.fn(asyncNoop),
+        return: vi.fn(asyncNoop),
+        close: vi.fn(),
+        setPermissionMode: vi.fn(asyncNoop),
+        setModel: vi.fn(asyncNoop),
+        getContextUsage: vi.fn(asyncNoop),
+        supportedModels: vi.fn(asyncEmpty),
+        supportedCommands: vi.fn(asyncEmpty),
+        rewindFiles: vi.fn(asyncRewind),
+      }),
+    );
+    const client = new ClaudeAgentClient({
+      logger,
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.resumeSession({
+      provider: "claude",
+      sessionId: "stale-native-session",
+      nativeHandle: "stale-native-session",
+      metadata: { provider: "claude", cwd },
+    });
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "timeline" && event.item.type === "user_message") {
+        markUserTimelineVisible();
+      }
+    });
+
+    try {
+      await expect(session.run("continue the task")).rejects.toThrow(
+        "fresh replacement query failed",
+      );
+      expect(events.filter((event) => event.type === "turn_failed")).toHaveLength(1);
+      expect(session.describePersistence()).toMatchObject({
+        sessionId: "stale-native-session",
+        nativeHandle: "stale-native-session",
+      });
+      await expect(session.run("retry the task")).resolves.toMatchObject({
+        sessionId: expect.any(String),
+      });
+      expect(queryFactory).toHaveBeenCalledTimes(4);
+      expect(session.describePersistence()?.sessionId).not.toBe("stale-native-session");
+    } finally {
+      await session.close();
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("rolls back the provisional session when canceled during fresh initialization", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paseo-claude-fallback-cancel-"));
+    const staleNativeCwd = path.join(cwd, "deleted-worktree");
+    const asyncNoop = async () => undefined;
+    const asyncEmpty = async () => [];
+    const asyncRewind = async () => ({ canRewind: true });
+    let markUserTimelineVisible: () => void = () => undefined;
+    const userTimelineVisible = new Promise<void>((resolve) => {
+      markUserTimelineVisible = resolve;
+    });
+
+    let markFreshEnsureStarted: () => void = () => undefined;
+    const freshEnsureStarted = new Promise<void>((resolve) => {
+      markFreshEnsureStarted = resolve;
+    });
+    let releaseFreshEnsure: () => void = () => undefined;
+    const freshEnsureRelease = new Promise<void>((resolve) => {
+      releaseFreshEnsure = resolve;
+    });
+    let binaryResolutionCount = 0;
+    const resolveBinary = vi.fn(async () => {
+      binaryResolutionCount += 1;
+      if (binaryResolutionCount === 2) {
+        markFreshEnsureStarted();
+        await freshEnsureRelease;
+      }
+      return "/test/claude/bin";
+    });
+    const queryFactory = vi.fn(
+      ({
+        prompt,
+        options,
+      }: {
+        prompt: AsyncIterable<unknown>;
+        options: Record<string, unknown>;
+      }) => ({
+        async *[Symbol.asyncIterator]() {
+          for await (const message of prompt) {
+            if (options.resume) {
+              await userTimelineVisible;
+              const stderr = options.stderr;
+              if (typeof stderr === "function") {
+                stderr(`Path "${staleNativeCwd}" does not exist`);
+              }
+              throw new Error("Claude Code process exited with code 1");
+            }
+            const sessionId = String(options.sessionId);
+            yield message as SDKMessage;
+            yield createInitMessage(sessionId) as SDKMessage;
+            yield createSuccessResult({ session_id: sessionId }) as SDKMessage;
+          }
+        },
+        interrupt: vi.fn(asyncNoop),
+        return: vi.fn(asyncNoop),
+        close: vi.fn(),
+        setPermissionMode: vi.fn(asyncNoop),
+        setModel: vi.fn(asyncNoop),
+        getContextUsage: vi.fn(asyncNoop),
+        supportedModels: vi.fn(asyncEmpty),
+        supportedCommands: vi.fn(asyncEmpty),
+        rewindFiles: vi.fn(asyncRewind),
+      }),
+    );
+    const client = new ClaudeAgentClient({ logger, queryFactory, resolveBinary });
+    const session = await client.resumeSession({
+      provider: "claude",
+      sessionId: "stale-native-session",
+      nativeHandle: "stale-native-session",
+      metadata: { provider: "claude", cwd },
+    });
+    session.subscribe((event) => {
+      if (event.type === "timeline" && event.item.type === "user_message") {
+        markUserTimelineVisible();
+      }
+    });
+
+    try {
+      const canceledRun = session.run("cancel during fresh initialization");
+      await freshEnsureStarted;
+      await session.interrupt();
+      await expect(canceledRun).resolves.toMatchObject({
+        sessionId: "stale-native-session",
+      });
+      expect(session.describePersistence()).toMatchObject({
+        sessionId: "stale-native-session",
+        nativeHandle: "stale-native-session",
+      });
+    } finally {
+      releaseFreshEnsure();
+      await session.close();
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   test("passes persistSession through to the Claude SDK query options", async () => {
     const createResultTurn = (sessionId: string) => [
       {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2055,12 +2055,16 @@ class ClaudeAgentSession implements AgentSession {
   private queryRestartNeeded = false;
   private pendingInterruptAbort = false;
   private foregroundHasVisibleActivity = false;
+  private foregroundHasProviderActivity = false;
   private activeTurnHasAssistantText = false;
+  private activeForegroundMessage: SDKUserMessage | null = null;
   private readonly contextUsage: ClaudeContextUsageState;
   private userMessageIds: string[] = [];
   private readonly emittedUserMessageIds = new Set<string>();
   private readonly rewindTurnAnchors: ClaudeRewindTurnAnchor[] = [];
   private pendingFreshSessionId: string | null = null;
+  private staleNativeCwdFallbackAvailable: boolean;
+  private pendingStaleNativeCwdFallbackRollback: (() => void) | null = null;
   private recentStderr = "";
   private closed = false;
 
@@ -2079,6 +2083,7 @@ class ClaudeAgentSession implements AgentSession {
       findClaudeModel(this.config.model)?.contextWindowMaxTokens,
     );
     const handle = options.handle;
+    this.staleNativeCwdFallbackAvailable = Boolean(handle);
 
     if (handle) {
       if (!handle.sessionId) {
@@ -2187,12 +2192,14 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     const sdkMessage = this.toSdkUserMessage(prompt);
+    this.activeForegroundMessage = sdkMessage;
     const sdkUserMessageId =
       typeof sdkMessage.uuid === "string" && sdkMessage.uuid.length > 0 ? sdkMessage.uuid : null;
     this.rememberRewindUserAnchor(sdkUserMessageId);
     const turnId = this.createTurnId("foreground");
     this.activeForegroundTurnId = turnId;
     this.foregroundHasVisibleActivity = false;
+    this.foregroundHasProviderActivity = false;
     this.activeTurnHasAssistantText = false;
     this.contextUsage.beginTurn();
     this.transitionTurnState("foreground", "foreground turn started");
@@ -3400,6 +3407,7 @@ class ClaudeAgentSession implements AgentSession {
   private finishForegroundTurn(
     event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
   ): void {
+    this.settlePendingStaleNativeCwdFallback(event);
     if (event.type === "turn_failed" || event.type === "turn_canceled") {
       this.flushPendingToolCalls();
     }
@@ -3407,11 +3415,23 @@ class ClaudeAgentSession implements AgentSession {
     this.activeForegroundTurnId = null;
     this.cancelCurrentTurn = null;
     this.activeTurnHasAssistantText = false;
+    this.activeForegroundMessage = null;
     this.syncTurnState("foreground turn terminal");
   }
 
   private dispatchEvents(events: AgentStreamEvent[]): void {
     let terminalSeen = false;
+    const terminalEvent = events.find(
+      (
+        event,
+      ): event is Extract<
+        AgentStreamEvent,
+        { type: "turn_completed" | "turn_failed" | "turn_canceled" }
+      > => this.isTerminalTurnEvent(event),
+    );
+    if (terminalEvent) {
+      this.settlePendingStaleNativeCwdFallback(terminalEvent);
+    }
     for (const event of events) {
       this.notifySubscribers(event);
       terminalSeen ||= this.isTerminalTurnEvent(event);
@@ -3422,6 +3442,7 @@ class ClaudeAgentSession implements AgentSession {
         this.activeForegroundTurnId = null;
         this.cancelCurrentTurn = null;
         this.activeTurnHasAssistantText = false;
+        this.activeForegroundMessage = null;
         this.syncTurnState("foreground turn terminal");
       } else if (this.autonomousTurn) {
         this.autonomousTurn = null;
@@ -3613,7 +3634,7 @@ class ClaudeAgentSession implements AgentSession {
           }
           if (!this.closed && this.query === activeQuery) {
             await this.awaitRecentStderrAfterProcessExit(error);
-            this.failActiveTurns(error instanceof Error ? error.message : "Claude stream failed");
+            await this.handleQueryPumpFailure(error, activeQuery);
           }
           return;
         }
@@ -3624,6 +3645,201 @@ class ClaudeAgentSession implements AgentSession {
         this.input = null;
       }
     }
+  }
+
+  private async handleQueryPumpFailure(error: unknown, activeQuery: Query): Promise<void> {
+    try {
+      if (await this.retryAfterStaleNativeCwd(error, activeQuery)) {
+        return;
+      }
+    } catch (fallbackError) {
+      this.failActiveTurns(
+        fallbackError instanceof Error ? fallbackError.message : "Claude fallback failed",
+      );
+      return;
+    }
+    this.failActiveTurns(error instanceof Error ? error.message : "Claude stream failed");
+  }
+
+  private async retryAfterStaleNativeCwd(error: unknown, activeQuery: Query): Promise<boolean> {
+    const staleCwd = this.readStaleNativeCwdFromStderr();
+    const message = this.activeForegroundMessage;
+    const turnId = this.activeForegroundTurnId;
+    if (
+      !this.staleNativeCwdFallbackAvailable ||
+      !staleCwd ||
+      !message ||
+      !turnId ||
+      this.foregroundHasProviderActivity ||
+      !/\bprocess exited with code\s+1\b/i.test(errorToMessageString(error)) ||
+      fs.existsSync(staleCwd) ||
+      !this.isExistingDirectory(this.config.cwd) ||
+      path.resolve(staleCwd) === path.resolve(this.config.cwd)
+    ) {
+      return false;
+    }
+
+    const previousSessionState = this.captureConversationSessionState();
+    this.pendingStaleNativeCwdFallbackRollback = () => {
+      this.restoreConversationSessionState(previousSessionState);
+    };
+    this.staleNativeCwdFallbackAvailable = false;
+    this.logger.warn(
+      { staleCwd, cwd: this.config.cwd },
+      "Claude native session cwd no longer exists; retrying prompt in a fresh session",
+    );
+
+    const oldInput = this.input;
+    const retiredChild = this.childProcess;
+    this.query = null;
+    this.input = null;
+    this.childProcess = null;
+    oldInput?.end();
+    activeQuery.close?.();
+    await this.awaitWithTimeout(activeQuery.return?.(), "query return on stale native cwd");
+    try {
+      if (retiredChild) {
+        await terminateWithTreeKill(retiredChild, {
+          gracefulTimeoutMs: 2_000,
+          forceTimeoutMs: 2_000,
+        });
+      }
+    } catch {
+      // 프로세스가 이미 종료됐을 수 있다.
+    }
+
+    if (!this.canContinueStaleNativeCwdFallback(turnId, message)) {
+      this.rollbackPendingStaleNativeCwdFallback();
+      return true;
+    }
+
+    try {
+      this.startFreshConversationSession();
+      this.queryRestartNeeded = false;
+      const retryMessage = { ...message, session_id: this.claudeSessionId ?? "" };
+      this.activeForegroundMessage = retryMessage;
+      this.rememberUserMessageId(retryMessage.uuid);
+      this.rememberEmittedUserMessageId(retryMessage.uuid);
+      this.rememberRewindUserAnchor(retryMessage.uuid);
+      this.clearRecentStderr();
+      await this.ensureQuery();
+      if (!this.canContinueStaleNativeCwdFallback(turnId, retryMessage)) {
+        await this.retireCurrentQuerySilently();
+        this.rollbackPendingStaleNativeCwdFallback();
+        return true;
+      }
+      const retryInput = this.input as AsyncMessageInput<SDKUserMessage> | null;
+      if (!retryInput) {
+        throw new Error("Claude fallback input stream not initialized");
+      }
+      retryInput.push(retryMessage);
+      await this.runQueryPump();
+      return true;
+    } catch (fallbackError) {
+      await this.retireCurrentQuerySilently();
+      this.rollbackPendingStaleNativeCwdFallback();
+      throw fallbackError;
+    }
+  }
+
+  private rollbackPendingStaleNativeCwdFallback(): void {
+    const rollback = this.pendingStaleNativeCwdFallbackRollback;
+    this.pendingStaleNativeCwdFallbackRollback = null;
+    rollback?.();
+  }
+
+  private settlePendingStaleNativeCwdFallback(
+    event: Extract<AgentStreamEvent, { type: "turn_completed" | "turn_failed" | "turn_canceled" }>,
+  ): void {
+    if (event.type === "turn_completed") {
+      this.pendingStaleNativeCwdFallbackRollback = null;
+      return;
+    }
+    this.rollbackPendingStaleNativeCwdFallback();
+  }
+
+  private canContinueStaleNativeCwdFallback(turnId: string, message: SDKUserMessage): boolean {
+    return (
+      !this.closed &&
+      !this.pendingInterruptAbort &&
+      this.activeForegroundTurnId === turnId &&
+      this.activeForegroundMessage === message &&
+      this.cancelCurrentTurn !== null
+    );
+  }
+
+  private isExistingDirectory(candidate: string): boolean {
+    try {
+      return fs.statSync(candidate).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  private captureConversationSessionState() {
+    return {
+      claudeSessionId: this.claudeSessionId,
+      pendingFreshSessionId: this.pendingFreshSessionId,
+      persistence: this.persistence,
+      cachedRuntimeInfo: this.cachedRuntimeInfo,
+      lastOptionsModel: this.lastOptionsModel,
+      queryRestartNeeded: this.queryRestartNeeded,
+      staleNativeCwdFallbackAvailable: this.staleNativeCwdFallbackAvailable,
+      persistedHistory: [...this.persistedHistory],
+      persistedProviderSubagentEvents: [...this.persistedProviderSubagentEvents],
+      historyPending: this.historyPending,
+      userMessageIds: [...this.userMessageIds],
+      emittedUserMessageIds: [...this.emittedUserMessageIds],
+      rewindTurnAnchors: this.rewindTurnAnchors.map((anchor) => ({ ...anchor })),
+    };
+  }
+
+  private restoreConversationSessionState(
+    state: ReturnType<ClaudeAgentSession["captureConversationSessionState"]>,
+  ): void {
+    this.claudeSessionId = state.claudeSessionId;
+    this.pendingFreshSessionId = state.pendingFreshSessionId;
+    this.persistence = state.persistence;
+    this.cachedRuntimeInfo = state.cachedRuntimeInfo;
+    this.lastOptionsModel = state.lastOptionsModel;
+    this.queryRestartNeeded = state.queryRestartNeeded;
+    this.staleNativeCwdFallbackAvailable = state.staleNativeCwdFallbackAvailable;
+    this.persistedHistory = state.persistedHistory;
+    this.persistedProviderSubagentEvents = state.persistedProviderSubagentEvents;
+    this.historyPending = state.historyPending;
+    this.userMessageIds = state.userMessageIds;
+    this.emittedUserMessageIds.clear();
+    for (const messageId of state.emittedUserMessageIds) {
+      this.emittedUserMessageIds.add(messageId);
+    }
+    this.rewindTurnAnchors.splice(0, this.rewindTurnAnchors.length, ...state.rewindTurnAnchors);
+  }
+
+  private async retireCurrentQuerySilently(): Promise<void> {
+    const retiredQuery = this.query;
+    const retiredInput = this.input;
+    const retiredChild = this.childProcess;
+    this.query = null;
+    this.input = null;
+    this.childProcess = null;
+    retiredInput?.end();
+    retiredQuery?.close?.();
+    await this.awaitWithTimeout(retiredQuery?.return?.(), "query return after fallback failure");
+    try {
+      if (retiredChild) {
+        await terminateWithTreeKill(retiredChild, {
+          gracefulTimeoutMs: 2_000,
+          forceTimeoutMs: 2_000,
+        });
+      }
+    } catch {
+      // 프로세스가 이미 종료됐을 수 있다.
+    }
+  }
+
+  private readStaleNativeCwdFromStderr(): string | null {
+    const match = this.recentStderr.match(/Path "([^"\r\n]+)" does not exist/);
+    return match?.[1] ?? null;
   }
 
   private shouldSuppressStaleResult(message: SDKMessage): boolean {
@@ -3703,19 +3919,28 @@ class ClaudeAgentSession implements AgentSession {
     ) {
       this.activeTurnHasAssistantText = true;
     }
+    this.markForegroundActivity(message, events);
+
+    this.dispatchEvents(events);
+  }
+
+  private markForegroundActivity(message: SDKMessage, events: AgentStreamEvent[]): void {
     if (
-      this.activeForegroundTurnId &&
-      events.some(
+      !this.activeForegroundTurnId ||
+      !events.some(
         (event) =>
           event.type === "timeline" ||
           event.type === "permission_requested" ||
           event.type === "permission_resolved",
       )
     ) {
-      this.foregroundHasVisibleActivity = true;
+      return;
     }
-
-    this.dispatchEvents(events);
+    this.foregroundHasVisibleActivity = true;
+    if (message.type !== "user") {
+      this.foregroundHasProviderActivity = true;
+      this.pendingStaleNativeCwdFallbackRollback = null;
+    }
   }
 
   private async buildPumpedMessageEvents(


### PR DESCRIPTION
## 문제

Paseo가 보존한 Claude native session이 이미 삭제된 worktree cwd를 참조하면 첫 prompt가 `Path "..." does not exist`와 exit code 1로 즉시 실패합니다.

## 변경

- 이 오류를 삭제된 native cwd + exit code 1 조합으로 좁게 식별합니다.
- provider activity가 발생하기 전인 resumed foreground turn에서만 현재 agent cwd로 fresh Claude session을 한 번 생성해 같은 prompt를 재전송합니다.
- cancel·close·fresh 초기화 실패 시 기존 session ID와 persistence를 terminal event 전에 원자적으로 복원합니다.
- SDK user echo 중복, 무한 retry, 다른 resume 오류의 오탐을 방지합니다.

## 검증

- `npm run lint`
- `npm run build --workspace=@getpaseo/protocol`
- `npm run typecheck --workspace=@getpaseo/server`
- `npx vitest run packages/server/src/server/agent/providers/claude/agent.test.ts` — 70/70 PASS
- `git diff --check origin/main...HEAD`