### PR TITLE
Keep Pi prompts queued and ordered through session settlement

### DIFF
--- a/packages/app/src/types/stream.test.ts
+++ b/packages/app/src/types/stream.test.ts
@@ -1302,6 +1302,45 @@ describe("turn lifecycle events", () => {
     },
   );
 
+  it("keeps a submitted prompt before assistant output when its canonical echo arrives late", () => {
+    const submitted = createUserMessage({
+      clientMessageId: "msg_submitted_late_echo",
+      text: "continue after compaction",
+      timestamp: new Date("2025-01-01T15:02:00Z"),
+    });
+    const response = applyStreamEvent({
+      tail: [submitted],
+      head: [],
+      event: assistantTimeline("new response", "pi", "response-after-compaction"),
+      timestamp: new Date("2025-01-01T15:02:01Z"),
+      source: "live",
+      timelineCursor: { epoch: "epoch-1", seq: 2 },
+    });
+
+    const canonical = applyStreamEvent({
+      tail: response.tail,
+      head: response.head,
+      event: {
+        type: "timeline",
+        provider: "pi",
+        item: {
+          type: "user_message",
+          text: submitted.text,
+          messageId: "provider-owned-late-echo",
+          clientMessageId: submitted.clientMessageId,
+        },
+      },
+      timestamp: new Date("2025-01-01T15:02:02Z"),
+      source: "live",
+      timelineCursor: { epoch: "epoch-1", seq: 1 },
+    });
+
+    expect([...canonical.tail, ...canonical.head].map((item) => item.kind)).toEqual([
+      "user_message",
+      "assistant_message",
+    ]);
+  });
+
   it("replaces one submitted plain-text user message with the next live server user message", () => {
     const submittedTimestamp = new Date("2025-01-01T15:03:00Z");
     const serverTimestamp = new Date("2025-01-01T15:03:01Z");

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -383,13 +383,14 @@ export function upsertUserMessageAcrossStream(
   };
 }
 
-function placeCanonicalUserMessageAtTail(
+function upsertCanonicalUserMessageInTail(
   tail: StreamItem[],
   message: UserMessageItem,
   insertWhenUnmatched: boolean,
+  placement: "preserve-existing" | "event-order",
 ): Pick<UserMessageProductionResult, "items" | "message" | "matched"> {
   const produced = produceUserMessage(tail, message, null, "existing");
-  if (!produced.matched && !insertWhenUnmatched) {
+  if ((produced.matched && placement === "preserve-existing") || !insertWhenUnmatched) {
     return produced;
   }
   const preceding = produced.matched
@@ -1690,9 +1691,10 @@ function applyCanonicalUserMessageEvent(params: {
   event: AgentStreamEventPayload;
   timestamp: Date;
   timelineCursor?: TimelinePosition;
+  source: StreamUpdateSource;
   unmatchedInsert?: "tail" | "head";
 }): ApplyStreamEventResult | null {
-  const { tail, head, event, timestamp, timelineCursor, unmatchedInsert = "tail" } = params;
+  const { tail, head, event, timestamp, timelineCursor, source, unmatchedInsert = "tail" } = params;
   if (event.type !== "timeline" || event.item.type !== "user_message") return null;
   const normalized = normalizeChunk(event.item.text);
 
@@ -1727,7 +1729,14 @@ function applyCanonicalUserMessageEvent(params: {
           : [],
     };
   }
-  const reconciled = placeCanonicalUserMessageAtTail(flushedTail, canonical, normalized.hasContent);
+  // A live echo acknowledges the submitted row and may arrive after response output.
+  // Canonical replay, unlike that acknowledgement, follows event sequence.
+  const reconciled = upsertCanonicalUserMessageInTail(
+    flushedTail,
+    canonical,
+    normalized.hasContent,
+    source === "live" ? "preserve-existing" : "event-order",
+  );
   return {
     tail: reconciled.items,
     head: flushedHead,
@@ -1761,16 +1770,17 @@ export function applyStreamEvent(params: {
   unmatchedUserMessageInsert?: "tail" | "head";
 }): ApplyStreamEventResult {
   const { tail, head, event, timestamp } = params;
+  const source = params.source ?? "live";
   const canonicalUserResult = applyCanonicalUserMessageEvent({
     tail,
     head,
     event,
     timestamp,
     timelineCursor: params.timelineCursor,
+    source,
     unmatchedInsert: params.unmatchedUserMessageInsert,
   });
   if (canonicalUserResult) return canonicalUserResult;
-  const source = params.source ?? "live";
   let nextTail = tail;
   let nextHead = head;
   let changedTail = false;

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.test.ts
@@ -150,6 +150,27 @@ describe("PiCliRuntime", () => {
     ]);
   });
 
+  test("queues prompts as follow-ups while Pi is still settling", async () => {
+    const child = createPiChild();
+    const pendingPrompt = capturePendingCommand(child, "prompt");
+    const session = await createRuntime(child).startSession({ cwd: "/workspace/project" });
+
+    const prompt = session.prompt("continue after compaction");
+    const promptCommand = await pendingPrompt;
+
+    expect(promptCommand).toMatchObject({
+      type: "prompt",
+      message: "continue after compaction",
+      streamingBehavior: "followUp",
+      id: expect.any(String),
+    });
+
+    writePiResponse(child, promptCommand);
+    await expect(prompt).resolves.toEqual({
+      requestId: promptCommand.id,
+    });
+  });
+
   test("passes an MCP config path to Pi", async () => {
     const child = createPiChild();
     replyToCommands(child, () => ({}));

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -112,6 +112,9 @@ class PiCliRuntimeSession implements PiRuntimeSession {
       type: "prompt",
       message,
       ...(images?.length ? { images } : {}),
+      // Pi can stay active for compaction or retry after emitting agent_end.
+      // Queue a prompt sent in that settlement gap instead of rejecting it.
+      streamingBehavior: "followUp",
     });
     const data = await promise;
     if (typeof data === "object" && data !== null && !Array.isArray(data)) {


### PR DESCRIPTION
## Summary

- send Pi RPC prompts with `streamingBehavior: "followUp"` so a prompt submitted after `agent_end` but during post-run compaction or retry is queued instead of rejected as already processing
- keep a submitted user row in its optimistic timeline position when a delayed live canonical echo arrives after assistant output
- retain event-order placement for canonical replay/catch-up history

## Regression coverage

- Pi runtime command includes the `followUp` queueing behavior
- a delayed Pi user-message echo no longer moves the user's bubble below the response
- existing catch-up history placement remains covered

## Validation

- targeted Vitest suite: 223 passed
- full pre-commit lint, format check, and workspace typecheck
