### PR TITLE
Notify callers when watched children close and cap responses

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -51,6 +51,7 @@ Users can also detach an existing subagent from the subagents track. Detach is d
 `notifyOnFinish` defaults to `true` for agent-scoped creation and background prompt follow-ups because most delegated work needs to report back to the creating agent. Set it to `false` only for truly fire-and-forget agents or prompts.
 Permission requests are notification checkpoints, not the end of that subscription. The caller is notified again after a permission response when the child finishes, errors, or requests another permission.
 The permission notification includes the normalized request plus the child and request IDs, so the caller can inspect it and respond without fetching agent status.
+A watched child that closes before its finish event also notifies the caller so delegated work cannot disappear silently during archive or workspace teardown.
 
 ## Provider-managed child agents
 

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -299,6 +299,23 @@ test("finish notifications tell the parent the child's last assistant message", 
   );
 });
 
+test("finish notifications truncate oversized child responses", async () => {
+  const included = "x".repeat(4000);
+  const omitted = "TAIL-MARKER".repeat(50);
+  const scenario = createFinishNotificationScenario({
+    childLastAssistantMessage: included + omitted,
+  });
+
+  scenario.startWatchingChild();
+  const parentPrompt = await scenario.finishChildAndReadParentPrompt();
+
+  expect(parentPrompt).toContain(included);
+  expect(parentPrompt).toContain(
+    `[truncated ${omitted.length} chars; use get_agent_activity for the full response]`,
+  );
+  expect(parentPrompt).not.toContain("TAIL-MARKER");
+});
+
 test("closing a watched child notifies the caller", async () => {
   const scenario = createFinishNotificationScenario();
 

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -52,6 +52,7 @@ interface FinishNotificationScenario {
   resolveChildPermissionWhileIdle(requestId?: string): void;
   finishChild(): void;
   finishChildAndReadParentPrompt(): Promise<string>;
+  closeChildAndReadParentPrompt(): Promise<string>;
   parentPrompts(): string[];
   wasParentPrompted(): boolean;
 }
@@ -211,6 +212,25 @@ function createFinishNotificationScenario(
 
       return parentPrompt;
     },
+    async closeChildAndReadParentPrompt() {
+      const parentPrompt = new Promise<string>((resolve) => {
+        resolveParentPrompt = resolve;
+      });
+
+      childAgent.lifecycle = "running";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+
+      childAgent.lifecycle = "closed";
+      subscriber?.({
+        type: "agent_state",
+        agent: childAgent,
+      });
+
+      return parentPrompt;
+    },
     parentPrompts() {
       return parentPrompts;
     },
@@ -276,6 +296,17 @@ test("finish notifications tell the parent the child's last assistant message", 
     formatSystemNotificationPrompt(
       "Agent child-agent (Child Agent) finished.\n\n<agent-response>\nImplemented the cleanup and all checks pass.\n</agent-response>",
     ),
+  );
+});
+
+test("closing a watched child notifies the caller", async () => {
+  const scenario = createFinishNotificationScenario();
+
+  scenario.startWatchingChild();
+  const parentPrompt = await scenario.closeChildAndReadParentPrompt();
+
+  expect(parentPrompt).toEqual(
+    formatSystemNotificationPrompt("Agent child-agent (Child Agent) was closed."),
   );
 });
 

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -253,10 +253,12 @@ export interface SetupFinishNotificationParams {
   logger: Logger;
 }
 
+type FinishNotificationReason = "finished" | "errored" | "needs permission" | "was closed";
+
 interface FinishNotificationBodyInput {
   childAgentId: string;
   title: string;
-  reason: "finished" | "errored" | "needs permission";
+  reason: FinishNotificationReason;
   lastAssistantMessage: string | null;
   permissionRequest?: AgentPermissionRequest;
 }
@@ -312,7 +314,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
   }
 
   async function notify(
-    reason: "finished" | "errored" | "needs permission",
+    reason: FinishNotificationReason,
     permissionRequest?: AgentPermissionRequest,
   ): Promise<void> {
     const callerRecord = await agentStorage.get(callerAgentId);
@@ -344,10 +346,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     });
   }
 
-  function notifySafely(
-    reason: "finished" | "errored" | "needs permission",
-    options: NotifySafelyOptions = {},
-  ): void {
+  function notifySafely(reason: FinishNotificationReason, options: NotifySafelyOptions = {}): void {
     if (stopped) return;
     if (options.terminal ?? true) stop();
     notificationQueue = notificationQueue
@@ -387,7 +386,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
           return;
         }
         if (event.agent.lifecycle === "closed") {
-          stop();
+          notifySafely("was closed");
           return;
         }
         return;

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -255,6 +255,8 @@ export interface SetupFinishNotificationParams {
 
 type FinishNotificationReason = "finished" | "errored" | "needs permission" | "was closed";
 
+const FINISH_NOTIFICATION_MESSAGE_LIMIT = 4000;
+
 interface FinishNotificationBodyInput {
   childAgentId: string;
   title: string;
@@ -280,8 +282,12 @@ function formatFinishNotificationBody(params: FinishNotificationBodyInput): stri
       )}\n</permission-request>`,
     );
   }
-  const lastAssistantMessage = params.lastAssistantMessage?.trim();
+  let lastAssistantMessage = params.lastAssistantMessage?.trim();
   if (lastAssistantMessage) {
+    if (lastAssistantMessage.length > FINISH_NOTIFICATION_MESSAGE_LIMIT) {
+      const omitted = lastAssistantMessage.length - FINISH_NOTIFICATION_MESSAGE_LIMIT;
+      lastAssistantMessage = `${lastAssistantMessage.slice(0, FINISH_NOTIFICATION_MESSAGE_LIMIT)}\n[truncated ${omitted} chars; use get_agent_activity for the full response]`;
+    }
     sections.push(`<agent-response>\n${lastAssistantMessage}\n</agent-response>`);
   }
   return sections.join("\n\n");


### PR DESCRIPTION
## What changed

- notify the caller when a watched child transitions from `running` to `closed`
- cap child responses embedded in finish notifications at 4,000 characters, with a pointer to `get_agent_activity` for the full response
- document the close-notification contract
- add regression coverage for the lifecycle transition and response cap

## Why

`setupFinishNotification()` currently treats `closed` as silent watcher teardown. A delegated child can therefore disappear without waking its caller when PR-merge cleanup, workspace teardown, or an explicit archive closes the runtime before the normal `running -> idle` finish edge is observed.

The same notification path embeds the child's entire last assistant message. A verbose child can therefore consume an outsized portion of its caller's next context window.

I reproduced the closed-child failure on Paseo 0.3.1 on macOS: a delegated child completed its task, its isolated worktree was archived after the PR merged, the persisted child became `closed`, and the parent stayed asleep until the user manually asked for the result. There was no notification failure log because the `closed` branch intentionally called `stop()` without attempting delivery.

This is a focused successor to #2879, rebased onto current `main` after #3177. It carries the closed-child wakeup and response truncation forward. The original #2879 author is credited on both commits. It does not include the repeated-finish watcher behavior.

## Behavior

- A watcher that observes `running -> closed` sends `Agent <id> (<title>) was closed.`
- A child that is already closed when the watcher is installed remains silent, preserving the existing startup guard.
- Archived callers and detached/re-parented children retain their existing guards.
- An assistant response longer than 4,000 characters is truncated in the notification; the full response remains available through `get_agent_activity`.

## Verification

- Regression test before the close implementation: timed out after 5 seconds because the parent was never prompted.
- `npx vitest run packages/server/src/server/agent/agent-prompt.test.ts --bail=1` — 13 passed.
- `npm run typecheck` — passed.
- `npm run lint` — 0 warnings, 0 errors.
- `npm run format` and the pre-commit formatting check — passed.
- Pre-commit hook reran targeted lint, formatting, and workspace typecheck successfully.

Platform coverage: daemon behavior verified on macOS. No app, protocol, or platform-specific code changed; CI provides the repository's routed cross-platform coverage.
