### PR TITLE
fix(acp): share Hermes process across independent agent sessions

### DIFF
--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -108,11 +108,12 @@ export interface BuildProviderRegistryOptions {
   managedProcesses?: ManagedProcessRegistry;
   isDev?: boolean;
   ompRuntime?: OmpRuntime;
+  hermesSharedProcessScope?: object;
 }
 
 interface ProviderClientFactoryOptions extends Pick<
   BuildProviderRegistryOptions,
-  "workspaceGitService" | "managedProcesses" | "ompRuntime"
+  "workspaceGitService" | "managedProcesses" | "ompRuntime" | "hermesSharedProcessScope"
 > {
   providerParams?: unknown;
   customProvider?: {
@@ -700,7 +701,7 @@ function buildResolvedBuiltinProviders(
   runtimeSettings: AgentProviderRuntimeSettingsMap | undefined,
   options: Pick<
     BuildProviderRegistryOptions,
-    "workspaceGitService" | "managedProcesses" | "ompRuntime"
+    "workspaceGitService" | "managedProcesses" | "ompRuntime" | "hermesSharedProcessScope"
   >,
   isDev: boolean,
 ): Map<string, ResolvedProvider> {
@@ -732,6 +733,7 @@ function buildResolvedBuiltinProviders(
           workspaceGitService: options.workspaceGitService,
           managedProcesses: options.managedProcesses,
           ompRuntime: options.ompRuntime,
+          hermesSharedProcessScope: options.hermesSharedProcessScope,
           providerParams: override?.params,
         }),
       contract: PROVIDER_CONTRACTS[definition.id] ?? UNSUPPORTED_PROVIDER_CONTRACT,
@@ -744,7 +746,7 @@ function buildResolvedBuiltinProviders(
 function addDerivedProviders(
   resolvedProviders: Map<string, ResolvedProvider>,
   providerOverrides: Record<string, ProviderOverride>,
-  options: Pick<BuildProviderRegistryOptions, "managedProcesses">,
+  options: Pick<BuildProviderRegistryOptions, "managedProcesses" | "hermesSharedProcessScope">,
 ): void {
   for (const [providerId, override] of Object.entries(providerOverrides)) {
     if (resolvedProviders.has(providerId) || BUILTIN_PROVIDER_IDS.includes(providerId)) {
@@ -789,6 +791,8 @@ function addDerivedProviders(
             providerId,
             label: override.label ?? providerId,
             providerParams: override.params,
+            sharedProcessScope:
+              providerId === "hermes" ? options.hermesSharedProcessScope : undefined,
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
@@ -840,6 +844,7 @@ function addDerivedProviders(
       createBaseClient: (logger) =>
         baseFactory(logger, mergedRuntimeSettings, {
           managedProcesses: options.managedProcesses,
+          hermesSharedProcessScope: options.hermesSharedProcessScope,
           providerParams,
           customProvider: {
             id: providerId,
@@ -865,11 +870,13 @@ export function buildProviderRegistry(
       workspaceGitService: options?.workspaceGitService,
       managedProcesses: options?.managedProcesses,
       ompRuntime: options?.ompRuntime,
+      hermesSharedProcessScope: options?.hermesSharedProcessScope,
     },
     options?.isDev === true,
   );
   addDerivedProviders(resolvedProviders, providerOverrides, {
     managedProcesses: options?.managedProcesses,
+    hermesSharedProcessScope: options?.hermesSharedProcessScope,
   });
 
   return Object.fromEntries(

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -204,6 +204,7 @@ export class ProviderSnapshotManager {
   private readonly managedProcesses?: ManagedProcessRegistry;
   private readonly isDev: boolean;
   private readonly extraClients: Partial<Record<AgentProvider, AgentClient>>;
+  private readonly hermesSharedProcessScope = {};
   private runtimeSettings: AgentProviderRuntimeSettingsMap | undefined;
   private providerOverrides: Record<string, ProviderOverride> | undefined;
   private baseProviderOverrides: Record<string, ProviderOverride> | undefined;
@@ -511,6 +512,7 @@ export class ProviderSnapshotManager {
       workspaceGitService: this.workspaceGitService,
       managedProcesses: this.managedProcesses,
       isDev: this.isDev,
+      hermesSharedProcessScope: this.hermesSharedProcessScope,
     });
 
     for (const [provider, client] of Object.entries(this.extraClients) as Array<

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -53,6 +53,14 @@ import { buildStringCommandShellInvocation } from "../../../utils/string-command
 import { asInternals } from "../../test-utils/class-mocks.js";
 import * as spawnUtils from "../../../utils/spawn.js";
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
 describe("buildACPClientCapabilities", () => {
   test("keeps filesystem and terminal execution with the agent by default", () => {
     expect(buildACPClientCapabilities()).toEqual({
@@ -253,6 +261,7 @@ describe("ACPAgentClient shared process", () => {
 
   test("applies each caller timeout to a coalesced catalog request", async () => {
     let resolveNewSession!: (value: { sessionId: string }) => void;
+    const newSessionStarted = createDeferred<void>();
 
     class TestSharedACPAgentClient extends ACPAgentClient {
       constructor() {
@@ -280,6 +289,7 @@ describe("ACPAgentClient shared process", () => {
               () =>
                 new Promise<{ sessionId: string }>((resolve) => {
                   resolveNewSession = resolve;
+                  newSessionStarted.resolve();
                 }),
             ),
           } as unknown as ClientSideConnection,
@@ -292,12 +302,79 @@ describe("ACPAgentClient shared process", () => {
 
     const client = new TestSharedACPAgentClient();
     const longRequest = client.fetchCatalog({ scope: "global", force: true, timeoutMs: 100 });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await newSessionStarted.promise;
     await expect(
       client.fetchCatalog({ scope: "global", force: true, timeoutMs: 5 }),
     ).rejects.toThrow("ACP catalog probe timed out after 5ms");
     resolveNewSession({ sessionId: "session-catalog" });
     await expect(longRequest).resolves.toEqual({ models: [], modes: [] });
+  });
+
+  test("does not invalidate active sessions when a catalog probe times out", async () => {
+    const catalogStarted = createDeferred<void>();
+    const catalogResponse = createDeferred<{ sessionId: string }>();
+    const terminateProcess: ProcessTerminator = vi.fn(async (child: TreeKillTarget) => {
+      (child as ChildProcess).emit("exit", null, "SIGTERM");
+      return "terminated" as const;
+    });
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      spawnCount = 0;
+      newSessionCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: {},
+            }),
+            newSession: vi.fn(() => {
+              this.newSessionCount += 1;
+              if (this.newSessionCount === 1) {
+                return Promise.resolve({ sessionId: "session-active" });
+              }
+              catalogStarted.resolve();
+              return catalogResponse.promise;
+            }),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    const session = await client.createSession(
+      { provider: "acp", cwd: "/tmp/worktree" },
+      { agentId: "agent-active" },
+    );
+    const catalogRequest = client.fetchCatalog({ scope: "global", force: true, timeoutMs: 5 });
+    await catalogStarted.promise;
+    await expect(catalogRequest).rejects.toThrow("ACP catalog probe timed out after 5ms");
+    expect(terminateProcess).not.toHaveBeenCalled();
+    expect(client.spawnCount).toBe(1);
+
+    catalogResponse.resolve({ sessionId: "session-catalog" });
+    await session.close();
+    expect(terminateProcess).not.toHaveBeenCalled();
   });
 
   test("terminates and replaces a shared host after a catalog timeout", async () => {
@@ -467,19 +544,18 @@ describe("ACPAgentClient shared process", () => {
       .finally(() => {
         settled = true;
       });
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    const timedOutResult = await timedOutCatalog;
     expect(settled).toBe(true);
-    expect(await timedOutCatalog).toEqual(
+    expect(timedOutResult).toEqual(
       expect.objectContaining({ message: "ACP initialize timed out after 5ms" }),
     );
     expect(client.spawnCount).toBe(1);
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 5 }),
+    ).rejects.toThrow("ACP initialize timed out after 5ms");
+    expect(client.spawnCount).toBe(1);
 
     children[0]?.emit("exit", null, "SIGKILL");
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await expect(
-      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 100 }),
-    ).resolves.toEqual({ models: [], modes: [] });
-    expect(client.spawnCount).toBe(2);
   });
 
   test("applies the diagnostic phase timeout to shared initialization", async () => {
@@ -530,6 +606,7 @@ describe("ACPAgentClient shared process", () => {
 
   test("bounds a management probe joining an already-initializing host", async () => {
     const children: ChildProcessWithoutNullStreams[] = [];
+    const initializeStarted = createDeferred<void>();
     const terminateProcess: ProcessTerminator = vi.fn(async () => "kill-timeout" as const);
 
     class TestSharedACPAgentClient extends ACPAgentClient {
@@ -556,7 +633,10 @@ describe("ACPAgentClient shared process", () => {
         return {
           child,
           connection: {
-            initialize: vi.fn(() => new Promise<never>(() => undefined)),
+            initialize: vi.fn(() => {
+              initializeStarted.resolve();
+              return new Promise<never>(() => undefined);
+            }),
           } as unknown as ClientSideConnection,
           stderrChunks: [],
           spawnReady: Promise.resolve(),
@@ -576,7 +656,7 @@ describe("ACPAgentClient shared process", () => {
         () => null,
         (error: unknown) => error,
       );
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await initializeStarted.promise;
     await expect(client.diagnosticRows()).resolves.toContainEqual({
       label: "ACP shared probe",
       value: "error: ACP initialize timed out after 5ms",

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -95,6 +95,68 @@ describe("buildACPClientCapabilities", () => {
 });
 
 describe("ACPAgentClient shared process", () => {
+  test("shares one process across replacement clients in the same daemon scope", async () => {
+    const sharedProcessScope = {};
+    let spawnCount = 0;
+    let sessionCount = 0;
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      constructor() {
+        const options = {
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"] as [string, ...string[]],
+          shareProcess: true,
+          sharedProcessScope,
+        };
+        super(options);
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        spawnCount += 1;
+        clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: {},
+            }),
+            newSession: vi.fn(async () => ({ sessionId: `session-${++sessionCount}` })),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    const originalClient = new TestSharedACPAgentClient();
+    const originalSession = await originalClient.createSession({
+      provider: "acp",
+      cwd: "/tmp/original",
+    });
+    const replacementClient = new TestSharedACPAgentClient();
+    const replacementSession = await replacementClient.createSession({
+      provider: "acp",
+      cwd: "/tmp/replacement",
+    });
+
+    expect(spawnCount).toBe(1);
+    expect(originalSession.id).not.toBe(replacementSession.id);
+    await expect(
+      replacementClient.createSession(
+        { provider: "acp", cwd: "/tmp/different-environment" },
+        { env: { CUSTOM_VALUE: "different" } },
+      ),
+    ).rejects.toThrow("Shared ACP sessions require the same launch environment");
+    expect(spawnCount).toBe(1);
+    await Promise.all([originalSession.close(), replacementSession.close()]);
+  });
+
   test("coalesces catalog probes and creates ten sessions on one process", async () => {
     class TestSharedACPAgentClient extends ACPAgentClient {
       readonly newSession = vi.fn(async () => ({

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -190,6 +190,83 @@ describe("ACPAgentClient shared process", () => {
     await Promise.all(sessions.map((session) => session.close()));
   });
 
+  test("delivers session updates that arrive before session registration", async () => {
+    let router: ACPClient | undefined;
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      readonly newSession = vi.fn(async () => {
+        const sessionId = `session-${this.newSession.mock.calls.length}`;
+        // Simulate an agent that pushes its slash-command batch immediately
+        // after the session/new response, before the client continuation has
+        // registered the session with the shared router.
+        if (router?.sessionUpdate) {
+          try {
+            await router.sessionUpdate({
+              sessionId,
+              update: {
+                sessionUpdate: "available_commands_update",
+                availableCommands: [
+                  {
+                    name: "what-did-you-learn",
+                    description: "Run an evidence-based retrospective",
+                  },
+                ],
+              } as SessionUpdate,
+            });
+          } catch {
+            // The ACP SDK logs and swallows notification handler errors;
+            // this mirrors that delivery boundary.
+          }
+        }
+        return { sessionId };
+      });
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+        });
+      }
+
+      protected override async spawnTransport(
+        launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        router = clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: {},
+            }),
+            newSession: this.newSession,
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    const session = await client.createSession(
+      { provider: "acp", cwd: "/tmp/worktree-1" },
+      { agentId: "agent-1" },
+    );
+
+    expect(await session.listCommands?.()).toEqual([
+      {
+        name: "what-did-you-learn",
+        description: "Run an evidence-based retrospective",
+        argumentHint: "",
+        kind: "command",
+      },
+    ]);
+    await session.close();
+  });
+
   test("preserves caller launch variables while removing agent-scoped values", async () => {
     class TestSharedACPAgentClient extends ACPAgentClient {
       launchEnv: Record<string, string> | undefined;

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -8,6 +8,7 @@ import {
   RequestError,
   ndJsonStream,
   type Agent,
+  type Client as ACPClient,
   PermissionOption,
   PromptResponse,
   RequestPermissionRequest,
@@ -18,6 +19,7 @@ import {
 import {
   ACPAgentClient,
   ACPAgentSession,
+  type ACPProcessTransport,
   type SpawnedACPProcess,
   type SessionStateResponse,
   buildACPClientCapabilities,
@@ -81,6 +83,637 @@ describe("buildACPClientCapabilities", () => {
       terminal: true,
       _meta: { source: "provider" },
     });
+  });
+});
+
+describe("ACPAgentClient shared process", () => {
+  test("coalesces catalog probes and creates ten sessions on one process", async () => {
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      readonly newSession = vi.fn(async () => ({
+        sessionId: `session-${this.newSession.mock.calls.length}`,
+      }));
+      readonly listSessions = vi.fn(async () => ({ sessions: [] }));
+      readonly launchEnvs: Array<Record<string, string> | undefined> = [];
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+        });
+      }
+
+      protected override async spawnTransport(
+        launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        this.launchEnvs.push(launchEnv);
+        clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: { sessionCapabilities: { list: {} } },
+            }),
+            newSession: this.newSession,
+            listSessions: this.listSessions,
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+
+      diagnosticRows() {
+        return this.buildACPProbeDiagnosticRows();
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    const catalogs = await Promise.all(
+      Array.from({ length: 10 }, () => client.fetchCatalog({ scope: "global", force: true })),
+    );
+    expect(catalogs).toHaveLength(10);
+    expect(client.spawnCount).toBe(1);
+    expect(client.newSession).toHaveBeenCalledTimes(1);
+
+    const sessions = await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        client.createSession(
+          { provider: "acp", cwd: `/tmp/worktree-${index + 1}` },
+          {
+            agentId: `agent-${index + 1}`,
+            env: {
+              PASEO_AGENT_ID: `agent-${index + 1}`,
+              PASEO_AGENT_CWD: `/tmp/worktree-${index + 1}`,
+            },
+          },
+        ),
+      ),
+    );
+
+    expect(client.spawnCount).toBe(1);
+    expect(client.newSession).toHaveBeenCalledTimes(11);
+    expect(new Set(sessions.map((session) => session.id)).size).toBe(10);
+    expect(client.launchEnvs).toEqual([undefined]);
+    await expect(
+      client.createSession(
+        { provider: "acp", cwd: "/tmp/different" },
+        {
+          agentId: "different-agent",
+          env: {
+            PASEO_AGENT_ID: "different-agent",
+            PASEO_AGENT_CWD: "/tmp/different",
+            PASEO_WORKSPACE_ID: "different-workspace",
+            SHARED_VALUE: "different",
+          },
+        },
+      ),
+    ).rejects.toThrow("Shared ACP sessions require the same launch environment");
+    await expect(client.listImportableSessions()).resolves.toEqual([]);
+    const diagnosticRows = await client.diagnosticRows();
+    expect(diagnosticRows).toContainEqual({ label: "ACP initialize", value: "ok (shared)" });
+    expect(client.spawnCount).toBe(1);
+    expect(client.newSession).toHaveBeenCalledTimes(12);
+    await Promise.all(sessions.map((session) => session.close()));
+  });
+
+  test("preserves caller launch variables while removing agent-scoped values", async () => {
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      launchEnv: Record<string, string> | undefined;
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+        });
+      }
+
+      protected override async spawnTransport(
+        launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        this.launchEnv = launchEnv;
+        clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: { sessionCapabilities: { list: {} } },
+            }),
+            newSession: vi.fn().mockResolvedValue({ sessionId: "session-env" }),
+            listSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+
+      diagnosticRows() {
+        return this.buildACPProbeDiagnosticRows();
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    const session = await client.createSession(
+      { provider: "acp", cwd: "/tmp/worktree" },
+      {
+        agentId: "agent-env",
+        env: {
+          PASEO_AGENT_ID: "agent-env",
+          PASEO_AGENT_CWD: "/tmp/worktree",
+          PASEO_WORKSPACE_ID: "workspace-env",
+          CUSTOM_ENDPOINT: "https://example.test",
+        },
+      },
+    );
+
+    expect(client.launchEnv).toEqual({ CUSTOM_ENDPOINT: "https://example.test" });
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 100 }),
+    ).resolves.toEqual({ models: [], modes: [] });
+    await expect(client.listImportableSessions()).resolves.toEqual([]);
+    await expect(client.diagnosticRows()).resolves.toContainEqual({
+      label: "ACP initialize",
+      value: "ok (shared)",
+    });
+    expect(client.spawnCount).toBe(1);
+    await session.close();
+  });
+
+  test("applies each caller timeout to a coalesced catalog request", async () => {
+    let resolveNewSession!: (value: { sessionId: string }) => void;
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: {},
+            }),
+            newSession: vi.fn(
+              () =>
+                new Promise<{ sessionId: string }>((resolve) => {
+                  resolveNewSession = resolve;
+                }),
+            ),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    const longRequest = client.fetchCatalog({ scope: "global", force: true, timeoutMs: 100 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 5 }),
+    ).rejects.toThrow("ACP catalog probe timed out after 5ms");
+    resolveNewSession({ sessionId: "session-catalog" });
+    await expect(longRequest).resolves.toEqual({ models: [], modes: [] });
+  });
+
+  test("terminates and replaces a shared host after a catalog timeout", async () => {
+    const terminateProcess: ProcessTerminator = vi.fn(async (child: TreeKillTarget) => {
+      (child as ChildProcess).emit("exit", null, "SIGTERM");
+      return "terminated" as const;
+    });
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        clientFactory?.();
+        const newSession =
+          this.spawnCount === 1
+            ? vi.fn(() => new Promise<never>(() => undefined))
+            : vi.fn().mockResolvedValue({ sessionId: "session-recovered" });
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: {},
+            }),
+            newSession,
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 5 }),
+    ).rejects.toThrow("ACP catalog probe timed out after 5ms");
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 100 }),
+    ).resolves.toEqual({ models: [], modes: [] });
+    expect(client.spawnCount).toBe(2);
+    expect(terminateProcess).toHaveBeenCalledTimes(1);
+  });
+
+  test("bounds shared host initialization with the catalog timeout", async () => {
+    const terminateProcess: ProcessTerminator = vi.fn(async (child: TreeKillTarget) => {
+      (child as ChildProcess).emit("exit", null, "SIGTERM");
+      return "terminated" as const;
+    });
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        clientFactory?.();
+        const initialize =
+          this.spawnCount === 1
+            ? vi.fn(() => new Promise<never>(() => undefined))
+            : vi.fn().mockResolvedValue({
+                protocolVersion: PROTOCOL_VERSION,
+                agentCapabilities: {},
+              });
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize,
+            newSession: vi.fn().mockResolvedValue({ sessionId: "session-recovered" }),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 5 }),
+    ).rejects.toThrow("ACP initialize timed out after 5ms");
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 100 }),
+    ).resolves.toEqual({ models: [], modes: [] });
+    expect(client.spawnCount).toBe(2);
+    expect(terminateProcess).toHaveBeenCalledTimes(1);
+  });
+
+  test("retains a timed-out initializing host until its process exits", async () => {
+    const children: ChildProcessWithoutNullStreams[] = [];
+    const terminateProcess: ProcessTerminator = vi.fn(async () => "kill-timeout" as const);
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        clientFactory?.();
+        const child = createProbeChildStub();
+        children.push(child);
+        return {
+          child,
+          connection: {
+            initialize:
+              this.spawnCount === 1
+                ? vi.fn(() => new Promise<never>(() => undefined))
+                : vi.fn().mockResolvedValue({
+                    protocolVersion: PROTOCOL_VERSION,
+                    agentCapabilities: {},
+                  }),
+            newSession: vi.fn().mockResolvedValue({ sessionId: "session-recovered" }),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    let settled = false;
+    const timedOutCatalog = client
+      .fetchCatalog({ scope: "global", force: true, timeoutMs: 5 })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      )
+      .finally(() => {
+        settled = true;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(true);
+    expect(await timedOutCatalog).toEqual(
+      expect.objectContaining({ message: "ACP initialize timed out after 5ms" }),
+    );
+    expect(client.spawnCount).toBe(1);
+
+    children[0]?.emit("exit", null, "SIGKILL");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(
+      client.fetchCatalog({ scope: "global", force: true, timeoutMs: 100 }),
+    ).resolves.toEqual({ models: [], modes: [] });
+    expect(client.spawnCount).toBe(2);
+  });
+
+  test("applies the diagnostic phase timeout to shared initialization", async () => {
+    const terminateProcess: ProcessTerminator = vi.fn(async (child: TreeKillTarget) => {
+      (child as ChildProcess).emit("exit", null, "SIGTERM");
+      return "terminated" as const;
+    });
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn(() => new Promise<never>(() => undefined)),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+
+      diagnosticRows() {
+        return this.buildACPProbeDiagnosticRows({ phaseTimeoutMs: 5 });
+      }
+    }
+
+    const rows = await new TestSharedACPAgentClient().diagnosticRows();
+    expect(rows).toContainEqual({
+      label: "ACP shared probe",
+      value: "error: ACP initialize timed out after 5ms",
+    });
+    expect(terminateProcess).toHaveBeenCalledTimes(1);
+  });
+
+  test("bounds a management probe joining an already-initializing host", async () => {
+    const children: ChildProcessWithoutNullStreams[] = [];
+    const terminateProcess: ProcessTerminator = vi.fn(async () => "kill-timeout" as const);
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        clientFactory?.();
+        const child = createProbeChildStub();
+        children.push(child);
+        return {
+          child,
+          connection: {
+            initialize: vi.fn(() => new Promise<never>(() => undefined)),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+
+      diagnosticRows() {
+        return this.buildACPProbeDiagnosticRows({ phaseTimeoutMs: 5 });
+      }
+    }
+
+    const client = new TestSharedACPAgentClient();
+    const initializingCatalog = client
+      .fetchCatalog({ scope: "global", force: true, timeoutMs: 30 })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(client.diagnosticRows()).resolves.toContainEqual({
+      label: "ACP shared probe",
+      value: "error: ACP initialize timed out after 5ms",
+    });
+    expect(client.spawnCount).toBe(1);
+
+    children[0]?.emit("exit", null, "SIGKILL");
+    expect(await initializingCatalog).toEqual(
+      expect.objectContaining({ message: "ACP initialize timed out after 30ms" }),
+    );
+  });
+
+  test("waits for idle shutdown before starting a replacement host", async () => {
+    vi.useFakeTimers();
+    let finishTermination!: () => void;
+    const terminationGate = new Promise<void>((resolve) => {
+      finishTermination = resolve;
+    });
+    const terminateProcess: ProcessTerminator = vi.fn(async (child: TreeKillTarget) => {
+      await terminationGate;
+      (child as ChildProcess).emit("exit", null, "SIGTERM");
+      return "terminated" as const;
+    });
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        clientFactory?.();
+        return {
+          child: createProbeChildStub(),
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: {},
+            }),
+            newSession: vi.fn().mockResolvedValue({ sessionId: `session-${this.spawnCount}` }),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    try {
+      const client = new TestSharedACPAgentClient();
+      const first = await client.createSession({ provider: "acp", cwd: "/tmp/first" });
+      await first.close();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      const secondPromise = client.createSession({ provider: "acp", cwd: "/tmp/second" });
+      await Promise.resolve();
+      expect(client.spawnCount).toBe(1);
+
+      finishTermination();
+      const second = await secondPromise;
+      expect(client.spawnCount).toBe(2);
+      await second.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not replace a host until a timed-out process actually exits", async () => {
+    vi.useFakeTimers();
+    const children: ChildProcessWithoutNullStreams[] = [];
+    const terminateProcess: ProcessTerminator = vi.fn(async () => "kill-timeout" as const);
+
+    class TestSharedACPAgentClient extends ACPAgentClient {
+      spawnCount = 0;
+
+      constructor() {
+        super({
+          provider: "acp",
+          logger: createTestLogger(),
+          defaultCommand: ["hermes", "acp"],
+          shareProcess: true,
+          terminateProcess,
+        });
+      }
+
+      protected override async spawnTransport(
+        _launchEnv?: Record<string, string>,
+        clientFactory?: () => ACPClient,
+      ): Promise<ACPProcessTransport> {
+        this.spawnCount += 1;
+        clientFactory?.();
+        const child = createProbeChildStub();
+        children.push(child);
+        return {
+          child,
+          connection: {
+            initialize: vi.fn().mockResolvedValue({
+              protocolVersion: PROTOCOL_VERSION,
+              agentCapabilities: {},
+            }),
+            newSession: vi.fn().mockResolvedValue({ sessionId: `session-${this.spawnCount}` }),
+          } as unknown as ClientSideConnection,
+          stderrChunks: [],
+          spawnReady: Promise.resolve(),
+          spawnError: new Promise<never>(() => undefined),
+        };
+      }
+    }
+
+    try {
+      const client = new TestSharedACPAgentClient();
+      const first = await client.createSession({ provider: "acp", cwd: "/tmp/first" });
+      await first.close();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      const secondPromise = client.createSession({ provider: "acp", cwd: "/tmp/second" });
+      await Promise.resolve();
+      expect(client.spawnCount).toBe(1);
+
+      children[0]?.emit("exit", null, "SIGKILL");
+      const second = await secondPromise;
+      expect(client.spawnCount).toBe(2);
+      await second.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -1167,6 +1800,32 @@ describe("ACPAgentSession Zed parity", () => {
     await expect(permission).resolves.toEqual({
       outcome: { outcome: "selected", optionId: "allow-once" },
     });
+  });
+
+  test("cancels pending permissions when the shared process exits", async () => {
+    const session = createSessionWithConfig({ provider: "cursor-acp" });
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+
+    const permission = session.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "tool-crash",
+        title: "Edit file",
+        kind: "edit",
+        status: "pending",
+      },
+      options: [{ optionId: "allow-once", name: "Allow", kind: "allow_once" }],
+    } satisfies RequestPermissionRequest);
+    await Promise.resolve();
+    const [pending] = session.getPendingPermissions();
+    expect(pending).toBeDefined();
+
+    session.handleSharedProcessExit(null, "SIGKILL", "crashed");
+    await expect(permission).resolves.toEqual({ outcome: { outcome: "cancelled" } });
+    expect(session.getPendingPermissions()).toEqual([]);
+    await expect(session.respondToPermission(pending!.id, { behavior: "allow" })).rejects.toThrow(
+      "No pending permission request",
+    );
   });
 
   test("preserves ACP chooser actions and returns the selected option", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -140,6 +140,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
+function createSharedACPLaunchEnv(
+  launchEnv?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!launchEnv) {
+    return undefined;
+  }
+  const sharedEntries = Object.entries(launchEnv).filter(
+    ([key]) =>
+      key !== "PASEO_AGENT_ID" && key !== "PASEO_AGENT_CWD" && key !== "PASEO_WORKSPACE_ID",
+  );
+  return sharedEntries.length > 0 ? Object.fromEntries(sharedEntries) : undefined;
+}
+
+function stableEnvKey(env?: Record<string, string>): string {
+  return JSON.stringify(
+    Object.entries(env ?? {}).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
 function isACPError(value: unknown): value is ACPError {
   return isRecord(value) && typeof value.message === "string" && typeof value.code === "number";
 }
@@ -272,7 +291,10 @@ export function buildACPClientCapabilities(
 // sign-in URL in the browser) when probing an ACP agent for models/modes.
 // NO_BROWSER is honored by Gemini CLI; other ACP agents ignore it.
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
+const ACP_CATALOG_TIMEOUT_MS = 60_000;
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
+
+type ACPFetchCatalogOptions = FetchCatalogOptions & { timeoutMs?: number };
 
 function summarizeMalformedACPStdoutError(error: unknown): { type: string; message: string } {
   return {
@@ -435,6 +457,7 @@ interface ACPAgentClientOptions {
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
+  shareProcess?: boolean;
 }
 
 interface ACPAgentSessionOptions {
@@ -468,6 +491,31 @@ interface ACPAgentSessionOptions {
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
+  sharedProcess?: ACPSharedProcessLease;
+}
+
+interface ACPSharedRouteTarget extends Pick<
+  ACPAgentSession,
+  | "requestPermission"
+  | "sessionUpdate"
+  | "readTextFile"
+  | "writeTextFile"
+  | "createTerminal"
+  | "terminalOutput"
+  | "waitForTerminalExit"
+  | "releaseTerminal"
+  | "killTerminal"
+  | "extNotification"
+> {
+  handleSharedProcessExit?: ACPAgentSession["handleSharedProcessExit"];
+}
+
+interface ACPSharedProcessLease {
+  connection: ClientSideConnection;
+  initialize: InitializeResponse;
+  register(sessionId: string, client: ACPSharedRouteTarget): void;
+  release(sessionId: string | null): void;
+  invalidate(reason: Error): Promise<void>;
 }
 
 export interface SpawnedACPProcess {
@@ -481,7 +529,7 @@ type UninitializedACPProcess = Omit<SpawnedACPProcess, "initialize"> & {
   initialize?: InitializeResponse;
 };
 
-interface ACPProcessTransport {
+export interface ACPProcessTransport {
   child: ChildProcessWithoutNullStreams;
   connection: ClientSideConnection;
   stderrChunks: string[];
@@ -823,6 +871,12 @@ export class ACPAgentClient implements AgentClient {
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   protected readonly terminateProcess: ProcessTerminator;
+  private readonly shareProcess: boolean;
+  private sharedProcessHost: Promise<ACPSharedProcessHost> | null = null;
+  private sharedProcessLaunchEnvKey: string | null = null;
+  private sharedProcessInitializationAbort: (() => Promise<void>) | null = null;
+  private sharedCatalog: ProviderCatalog | null = null;
+  private sharedCatalogRequest: Promise<ProviderCatalog> | null = null;
 
   constructor(options: ACPAgentClientOptions) {
     this.provider = options.provider;
@@ -850,6 +904,7 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.shareProcess = options.shareProcess ?? false;
   }
 
   async createSession(
@@ -857,6 +912,9 @@ export class ACPAgentClient implements AgentClient {
     launchContext?: AgentLaunchContext,
   ): Promise<AgentSession> {
     this.assertProvider(config);
+    const sharedProcess = this.shareProcess
+      ? await this.acquireSharedProcess(launchContext?.env)
+      : undefined;
     const session = new ACPAgentSession(
       { ...config, provider: this.provider },
       {
@@ -882,6 +940,7 @@ export class ACPAgentClient implements AgentClient {
         extensionCommandsParser: this.extensionCommandsParser,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
+        sharedProcess,
       },
     );
     await session.initializeNewSession();
@@ -909,6 +968,9 @@ export class ACPAgentClient implements AgentClient {
       provider: this.provider,
       cwd,
     };
+    const sharedProcess = this.shareProcess
+      ? await this.acquireSharedProcess(launchContext?.env)
+      : undefined;
     const session = new ACPAgentSession(mergedConfig, {
       provider: this.provider,
       logger: this.logger,
@@ -933,15 +995,49 @@ export class ACPAgentClient implements AgentClient {
       extensionCommandsParser: this.extensionCommandsParser,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
+      sharedProcess,
     });
     await session.initializeResumedSession();
     return session;
   }
 
   async fetchCatalog(
-    options: FetchCatalogOptions,
+    options: ACPFetchCatalogOptions,
     context?: ProviderRefreshContext,
   ): Promise<ProviderCatalog> {
+    if (this.shareProcess) {
+      if (!options.force && this.sharedCatalog) {
+        return this.sharedCatalog;
+      }
+      if (this.sharedCatalogRequest) {
+        const timeoutMs = options.timeoutMs ?? ACP_CATALOG_TIMEOUT_MS;
+        return runProviderRefreshActivity(context, "shared-catalog", () =>
+          raceProviderRefreshAbort(
+            context?.signal,
+            withTimeout(
+              this.sharedCatalogRequest!,
+              timeoutMs,
+              `ACP catalog probe timed out after ${timeoutMs}ms`,
+            ),
+          ),
+        );
+      }
+      const request = this.fetchCatalogFromSharedProcess(options).then((catalog) => {
+        this.sharedCatalog = catalog;
+        return catalog;
+      });
+      this.sharedCatalogRequest = request;
+      try {
+        return await runProviderRefreshActivity(context, "shared-catalog", () =>
+          raceProviderRefreshAbort(context?.signal, request),
+        );
+      } finally {
+        if (this.sharedCatalogRequest === request) {
+          this.sharedCatalogRequest = null;
+        }
+      }
+    }
+
     const cwd = options.scope === "global" ? homedir() : options.cwd;
     let probe: UninitializedACPProcess | null = null;
     let closePromise: Promise<void> | null = null;
@@ -1018,6 +1114,95 @@ export class ACPAgentClient implements AgentClient {
     }
   }
 
+  private async fetchCatalogFromSharedProcess(
+    options: ACPFetchCatalogOptions,
+  ): Promise<ProviderCatalog> {
+    const startedAt = Date.now();
+    const cwd = options.scope === "global" ? homedir() : options.cwd;
+    const timeoutMs = options.timeoutMs ?? ACP_CATALOG_TIMEOUT_MS;
+    const sharedProcess = await this.acquireSharedProcess(undefined, timeoutMs, true);
+    const remainingTimeoutMs = Math.max(1, timeoutMs - (Date.now() - startedAt));
+    let requestSettled = false;
+    const request = (async () => {
+      let sessionId: string | null = null;
+      const unsupported = async (): Promise<never> => {
+        throw new Error("ACP catalog probe does not support client callbacks");
+      };
+      const routeTarget: ACPSharedRouteTarget = {
+        requestPermission: unsupported,
+        sessionUpdate: async () => {},
+        readTextFile: unsupported,
+        writeTextFile: unsupported,
+        createTerminal: unsupported,
+        terminalOutput: unsupported,
+        waitForTerminalExit: unsupported,
+        releaseTerminal: unsupported,
+        killTerminal: unsupported,
+        extNotification: async () => {},
+      };
+
+      try {
+        const response = await this.runACPRequest(() =>
+          sharedProcess.connection.newSession({ cwd, mcpServers: [] }),
+        );
+        const createdSessionId = response.sessionId;
+        sessionId = createdSessionId;
+        sharedProcess.register(createdSessionId, routeTarget);
+        const transformed = this.transformSessionResponse(response);
+        const derivedModels = deriveModelDefinitionsFromACP(
+          this.provider,
+          transformed.models,
+          transformed.configOptions,
+        );
+        const models = this.catalogModelResolver
+          ? await this.catalogModelResolver({
+              connection: sharedProcess.connection,
+              sessionId: createdSessionId,
+              models: derivedModels,
+              configOptions: transformed.configOptions,
+              runRequest: (catalogRequest) => this.runACPRequest(catalogRequest),
+              transformConfigOptions: (configOptions) =>
+                this.configOptionsTransformer
+                  ? this.configOptionsTransformer(configOptions)
+                  : configOptions,
+              logger: this.logger,
+              provider: this.provider,
+            })
+          : derivedModels;
+        const modeInfo = deriveModesFromACP(
+          this.defaultModes,
+          transformed.modes,
+          transformed.configOptions,
+        );
+        return {
+          models: this.modelTransformer ? this.modelTransformer(models) : models,
+          modes: modeInfo.modes,
+        };
+      } finally {
+        if (sessionId && sharedProcess.initialize.agentCapabilities?.sessionCapabilities?.close) {
+          try {
+            await sharedProcess.connection.unstable_closeSession({ sessionId });
+          } catch (error) {
+            this.logger.debug({ err: error }, "ACP shared catalog session close failed");
+          }
+        }
+        sharedProcess.release(sessionId);
+      }
+    })().finally(() => {
+      requestSettled = true;
+    });
+
+    const timeoutMessage = `ACP catalog probe timed out after ${timeoutMs}ms`;
+    try {
+      return await withTimeout(request, remainingTimeoutMs, timeoutMessage);
+    } catch (error) {
+      if (!requestSettled) {
+        await sharedProcess.invalidate(new Error(timeoutMessage));
+      }
+      throw error;
+    }
+  }
+
   async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
     const autoAcceptFeature = buildACPAutoAcceptFeature(config);
     if (this.configFeatureOptions.length === 0) {
@@ -1046,7 +1231,7 @@ export class ACPAgentClient implements AgentClient {
   async listImportableSessions(
     options?: ListImportableSessionsOptions,
   ): Promise<ImportableProviderSession[]> {
-    const probe = await this.spawnProcess(PROBE_ENV);
+    const probe = await this.acquireSessionListingConnection();
     try {
       if (!probe.initialize.agentCapabilities?.sessionCapabilities?.list) {
         return [];
@@ -1081,8 +1266,33 @@ export class ACPAgentClient implements AgentClient {
 
       return typeof options?.limit === "number" ? sessions.slice(0, options.limit) : sessions;
     } finally {
-      await this.closeProbe(probe);
+      await probe.release();
     }
+  }
+
+  private async acquireSessionListingConnection(): Promise<{
+    connection: ClientSideConnection;
+    initialize: InitializeResponse;
+    release: () => Promise<void>;
+  }> {
+    if (this.shareProcess) {
+      const sharedProcess = await this.acquireSharedProcess(
+        undefined,
+        ACP_CATALOG_TIMEOUT_MS,
+        true,
+      );
+      return {
+        connection: sharedProcess.connection,
+        initialize: sharedProcess.initialize,
+        release: async () => sharedProcess.release(null),
+      };
+    }
+    const probe = await this.spawnProcess(PROBE_ENV);
+    return {
+      connection: probe.connection,
+      initialize: probe.initialize,
+      release: async () => this.closeProbe(probe),
+    };
   }
 
   async importSession(input: ImportProviderSessionInput, context: ImportProviderSessionContext) {
@@ -1131,7 +1341,10 @@ export class ACPAgentClient implements AgentClient {
     }
   }
 
-  protected async spawnTransport(launchEnv?: Record<string, string>): Promise<ACPProcessTransport> {
+  protected async spawnTransport(
+    launchEnv?: Record<string, string>,
+    clientFactory: () => ACPClient = () => this.buildProbeClient(),
+  ): Promise<ACPProcessTransport> {
     const { command, args } = await this.resolveLaunchCommand();
     const child = spawnProcess(command, args, {
       cwd: process.cwd(),
@@ -1165,7 +1378,7 @@ export class ACPAgentClient implements AgentClient {
       Readable.toWeb(child.stdout),
       { logger: this.logger, provider: this.provider },
     );
-    const connection = new ClientSideConnection(() => this.buildProbeClient(), stream);
+    const connection = new ClientSideConnection(clientFactory, stream);
 
     return {
       child,
@@ -1207,6 +1420,120 @@ export class ACPAgentClient implements AgentClient {
     } finally {
       if (timeout) {
         clearTimeout(timeout);
+      }
+    }
+  }
+
+  private async acquireSharedProcess(
+    launchEnv?: Record<string, string>,
+    initializeTimeoutMs = ACP_CATALOG_TIMEOUT_MS,
+    reuseActiveLaunchEnvironment = false,
+  ): Promise<ACPSharedProcessLease> {
+    const sharedLaunchEnv = createSharedACPLaunchEnv(launchEnv);
+    const requestedLaunchEnvKey = stableEnvKey(sharedLaunchEnv);
+    for (;;) {
+      const launchEnvKey =
+        reuseActiveLaunchEnvironment && this.sharedProcessHost && this.sharedProcessLaunchEnvKey
+          ? this.sharedProcessLaunchEnvKey
+          : requestedLaunchEnvKey;
+      if (this.sharedProcessHost && this.sharedProcessLaunchEnvKey !== launchEnvKey) {
+        const existingHost = await this.awaitSharedProcessHost(
+          this.sharedProcessHost,
+          initializeTimeoutMs,
+        );
+        if (existingHost.isStopped()) {
+          await existingHost.whenStopped();
+          continue;
+        }
+        if (!existingHost.hasReferences()) {
+          await existingHost.retire();
+          continue;
+        }
+        throw new Error(
+          "Shared ACP sessions require the same launch environment; refusing to reuse a process with different environment values",
+        );
+      }
+      if (!this.sharedProcessHost) {
+        let hostPromise: Promise<ACPSharedProcessHost>;
+        hostPromise = this.createSharedProcessHost(sharedLaunchEnv, initializeTimeoutMs, () => {
+          if (this.sharedProcessHost === hostPromise) {
+            this.sharedProcessHost = null;
+            this.sharedProcessLaunchEnvKey = null;
+          }
+        });
+        this.sharedProcessHost = hostPromise;
+        this.sharedProcessLaunchEnvKey = launchEnvKey;
+        void hostPromise.catch(() => {
+          if (this.sharedProcessHost === hostPromise) {
+            this.sharedProcessHost = null;
+            this.sharedProcessLaunchEnvKey = null;
+          }
+        });
+      }
+      const host = await this.awaitSharedProcessHost(this.sharedProcessHost, initializeTimeoutMs);
+      if (host.isStopped()) {
+        await host.whenStopped();
+        continue;
+      }
+      return host.acquire();
+    }
+  }
+
+  private async awaitSharedProcessHost(
+    hostPromise: Promise<ACPSharedProcessHost>,
+    timeoutMs: number,
+  ): Promise<ACPSharedProcessHost> {
+    try {
+      return await withTimeout(
+        hostPromise,
+        timeoutMs,
+        `ACP initialize timed out after ${timeoutMs}ms`,
+      );
+    } catch (error) {
+      if (this.sharedProcessHost === hostPromise && this.sharedProcessInitializationAbort) {
+        const abort = this.sharedProcessInitializationAbort;
+        void abort().then(() => {
+          if (this.sharedProcessHost === hostPromise) {
+            this.sharedProcessHost = null;
+            this.sharedProcessLaunchEnvKey = null;
+          }
+          return undefined;
+        });
+      }
+      throw error;
+    }
+  }
+
+  private async createSharedProcessHost(
+    launchEnv?: Record<string, string>,
+    initializeTimeoutMs = ACP_CATALOG_TIMEOUT_MS,
+    onStopped: () => void = () => {},
+  ): Promise<ACPSharedProcessHost> {
+    const router = new ACPSharedClientRouter();
+    const transport = await this.spawnTransport(launchEnv, () => router);
+    let cleanupPromise: Promise<void> | null = null;
+    const abortInitialization = (): Promise<void> => {
+      cleanupPromise ??= terminateChildProcess(transport.child, 2_000, this.terminateProcess, true);
+      return cleanupPromise;
+    };
+    this.sharedProcessInitializationAbort = abortInitialization;
+    try {
+      const initialize = await this.initializeTransport(transport, initializeTimeoutMs);
+      return new ACPSharedProcessHost({
+        child: transport.child,
+        connection: transport.connection,
+        initialize,
+        stderrChunks: transport.stderrChunks,
+        router,
+        terminateProcess: this.terminateProcess,
+        onStopped,
+      });
+    } catch (error) {
+      await abortInitialization();
+      throw error;
+    } finally {
+      if (this.sharedProcessInitializationAbort === abortInitialization) {
+        this.sharedProcessInitializationAbort = null;
       }
     }
   }
@@ -1256,6 +1583,10 @@ export class ACPAgentClient implements AgentClient {
       phaseTimeoutMs?: number;
     } = {},
   ): Promise<DiagnosticEntry[]> {
+    if (this.shareProcess) {
+      return this.buildSharedACPProbeDiagnosticRows(options);
+    }
+
     const rows: DiagnosticEntry[] = [];
     const phaseTimeoutMs = options.phaseTimeoutMs ?? ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS;
     const cwd = options.cwd ?? homedir();
@@ -1358,6 +1689,49 @@ export class ACPAgentClient implements AgentClient {
     }
   }
 
+  private async buildSharedACPProbeDiagnosticRows(
+    options: {
+      cwd?: string;
+      phaseTimeoutMs?: number;
+    } = {},
+  ): Promise<DiagnosticEntry[]> {
+    const rows: DiagnosticEntry[] = [];
+    const startedAt = Date.now();
+    let sharedProcess: ACPSharedProcessLease | null = null;
+    try {
+      sharedProcess = await this.acquireSharedProcess(
+        undefined,
+        options.phaseTimeoutMs ?? ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS,
+        true,
+      );
+      rows.push(
+        { label: "ACP spawn", value: `ok (${formatDurationMs(startedAt)}; shared)` },
+        { label: "ACP initialize", value: "ok (shared)" },
+      );
+      const catalogStartedAt = Date.now();
+      const catalog = await this.fetchCatalogFromSharedProcess({
+        scope: "workspace",
+        cwd: options.cwd ?? homedir(),
+        force: true,
+        timeoutMs: options.phaseTimeoutMs ?? ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS,
+      });
+      rows.push({
+        label: "ACP session/new",
+        value: `ok (${formatDurationMs(catalogStartedAt)}; models=${catalog.models.length}; modes=${catalog.modes.length}; shared)`,
+      });
+      return rows;
+    } catch (error) {
+      rows.push({
+        label: "ACP shared probe",
+        value: `error: ${toDiagnosticErrorMessage(error)}`,
+      });
+      return rows;
+    } finally {
+      sharedProcess?.release(null);
+      rows.push({ label: "ACP cleanup", value: "ok (shared lease released)" });
+    }
+  }
+
   protected async resolveLaunchCommand(): Promise<{ command: string; args: string[] }> {
     const prefix = await resolveProviderLaunch({
       commandConfig: this.runtimeSettings?.command,
@@ -1434,6 +1808,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly terminalEntries = new Map<string, TerminalEntry>();
   private readonly persistedHistory: AgentTimelineItem[] = [];
   private readonly initialHandle?: AgentPersistenceHandle;
+  private readonly sharedProcess?: ACPSharedProcessLease;
 
   private readonly config: AgentSessionConfig;
   private child: ChildProcessWithoutNullStreams | null = null;
@@ -1486,6 +1861,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
     this.initialHandle = options.handle;
+    this.sharedProcess = options.sharedProcess;
     this.config = { ...config, provider: options.provider };
     this.currentMode = config.modeId ?? null;
     this.currentModel = config.model ?? null;
@@ -1502,10 +1878,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   async initializeNewSession(): Promise<void> {
     try {
-      const spawned = await this.spawnProcess();
-      this.child = spawned.child;
-      this.connection = spawned.connection;
-      this.agentCapabilities = spawned.initialize.agentCapabilities ?? null;
+      await this.attachProcess();
 
       const response = await this.runACPRequest(() =>
         this.connection!.newSession({
@@ -1514,6 +1887,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         }),
       );
       this.sessionId = response.sessionId;
+      this.sharedProcess?.register(response.sessionId, this);
       this.bootstrapThreadEventPending = true;
       this.applySessionState(response);
       await this.applyConfiguredOverrides();
@@ -1536,11 +1910,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         throw new Error("Resume requested without persistence handle");
       }
 
-      const spawned = await this.spawnProcess();
-      this.child = spawned.child;
-      this.connection = spawned.connection;
-      this.agentCapabilities = spawned.initialize.agentCapabilities ?? null;
+      await this.attachProcess();
       this.sessionId = handle.sessionId;
+      this.sharedProcess?.register(handle.sessionId, this);
       this.bootstrapThreadEventPending = true;
 
       const sessionCapabilities = this.agentCapabilities?.sessionCapabilities;
@@ -1586,6 +1958,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       );
     }
     throw error;
+  }
+
+  private async attachProcess(): Promise<void> {
+    if (this.sharedProcess) {
+      this.connection = this.sharedProcess.connection;
+      this.agentCapabilities = this.sharedProcess.initialize.agentCapabilities ?? null;
+      return;
+    }
+    const spawned = await this.spawnProcess();
+    this.child = spawned.child;
+    this.connection = spawned.connection;
+    this.agentCapabilities = spawned.initialize.agentCapabilities ?? null;
   }
 
   async run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult> {
@@ -2223,11 +2607,37 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (this.child) {
       await this.terminateProcess(this.child, { gracefulTimeoutMs: 2_000, forceTimeoutMs: 2_000 });
     }
+    this.sharedProcess?.release(this.sessionId);
 
     this.subscribers.clear();
     this.connection = null;
     this.child = null;
     this.activeForegroundTurnId = null;
+  }
+
+  handleSharedProcessExit(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    diagnostic?: string,
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    this.connection = null;
+    for (const pending of this.pendingPermissions.values()) {
+      pending.resolve({ outcome: { outcome: "cancelled" } });
+    }
+    this.pendingPermissions.clear();
+    if (this.activeForegroundTurnId) {
+      this.synthesizeCanceledToolCalls();
+      this.finishTurn({
+        type: "turn_failed",
+        provider: this.provider,
+        error: `Shared ACP agent exited unexpectedly (${code ?? "null"}${signal ? `, ${signal}` : ""})`,
+        diagnostic: diagnostic || undefined,
+        turnId: this.activeForegroundTurnId,
+      });
+    }
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
@@ -2996,6 +3406,237 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 }
 
+class ACPSharedClientRouter implements ACPClient {
+  private readonly sessions = new Map<string, ACPSharedRouteTarget>();
+
+  register(sessionId: string, client: ACPSharedRouteTarget): void {
+    this.sessions.set(sessionId, client);
+  }
+
+  unregister(sessionId: string | null): void {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+    }
+  }
+
+  notifyProcessExit(code: number | null, signal: NodeJS.Signals | null, diagnostic?: string): void {
+    for (const session of this.sessions.values()) {
+      session.handleSharedProcessExit?.(code, signal, diagnostic);
+    }
+    this.sessions.clear();
+  }
+
+  async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+    return this.session(params.sessionId).requestPermission(params);
+  }
+
+  async sessionUpdate(params: SessionNotification): Promise<void> {
+    return this.session(params.sessionId).sessionUpdate(params);
+  }
+
+  async readTextFile(params: ReadTextFileRequest): Promise<{ content: string }> {
+    return this.session(params.sessionId).readTextFile(params);
+  }
+
+  async writeTextFile(params: WriteTextFileRequest): Promise<Record<string, never>> {
+    return this.session(params.sessionId).writeTextFile(params);
+  }
+
+  async createTerminal(params: CreateTerminalRequest): Promise<{ terminalId: string }> {
+    return this.session(params.sessionId).createTerminal(params);
+  }
+
+  async terminalOutput(params: TerminalOutputRequest): Promise<TerminalOutputResponse> {
+    return this.session(params.sessionId).terminalOutput(params);
+  }
+
+  async waitForTerminalExit(params: WaitForTerminalExitRequest): Promise<TerminalExit> {
+    return this.session(params.sessionId).waitForTerminalExit(params);
+  }
+
+  async releaseTerminal(params: { sessionId: string; terminalId: string }): Promise<void> {
+    return this.session(params.sessionId).releaseTerminal(params);
+  }
+
+  async killTerminal(params: KillTerminalRequest): Promise<Record<string, never>> {
+    return this.session(params.sessionId).killTerminal(params);
+  }
+
+  async extNotification(method: string, params: Record<string, unknown>): Promise<void> {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : null;
+    if (sessionId) {
+      await this.session(sessionId).extNotification(method, params);
+      return;
+    }
+    await Promise.all(
+      Array.from(this.sessions.values(), (session) => session.extNotification(method, params)),
+    );
+  }
+
+  private session(sessionId: string): ACPSharedRouteTarget {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`ACP shared process sent a request for unknown session '${sessionId}'`);
+    }
+    return session;
+  }
+}
+
+class ACPSharedProcessHost {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly connection: ClientSideConnection;
+  private readonly initialize: InitializeResponse;
+  private readonly stderrChunks: string[];
+  private readonly router: ACPSharedClientRouter;
+  private readonly terminateProcess: ProcessTerminator;
+  private readonly onStopped: () => void;
+  private readonly stoppedPromise: Promise<void>;
+  private resolveStopped!: () => void;
+  private references = 0;
+  private stopTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+  private stopFinalized = false;
+
+  constructor(options: {
+    child: ChildProcessWithoutNullStreams;
+    connection: ClientSideConnection;
+    initialize: InitializeResponse;
+    stderrChunks: string[];
+    router: ACPSharedClientRouter;
+    terminateProcess: ProcessTerminator;
+    onStopped: () => void;
+  }) {
+    this.child = options.child;
+    this.connection = options.connection;
+    this.initialize = options.initialize;
+    this.stderrChunks = options.stderrChunks;
+    this.router = options.router;
+    this.terminateProcess = options.terminateProcess;
+    this.onStopped = options.onStopped;
+    this.stoppedPromise = new Promise<void>((resolve) => {
+      this.resolveStopped = resolve;
+    });
+    this.child.once("exit", (code, signal) => {
+      this.handleExit(code, signal);
+    });
+  }
+
+  isStopped(): boolean {
+    return this.stopped;
+  }
+
+  hasReferences(): boolean {
+    return this.references > 0;
+  }
+
+  whenStopped(): Promise<void> {
+    return this.stoppedPromise;
+  }
+
+  retire(): Promise<void> {
+    return this.stop();
+  }
+
+  acquire(): ACPSharedProcessLease {
+    if (this.stopped) {
+      throw new Error("ACP shared process is no longer available");
+    }
+    this.references += 1;
+    if (this.stopTimer) {
+      clearTimeout(this.stopTimer);
+      this.stopTimer = null;
+    }
+    let released = false;
+    return {
+      connection: this.connection,
+      initialize: this.initialize,
+      register: (sessionId, client) => {
+        this.router.register(sessionId, client);
+      },
+      invalidate: (reason) => this.invalidate(reason),
+      release: (sessionId) => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.router.unregister(sessionId);
+        this.references = Math.max(0, this.references - 1);
+        if (this.references === 0) {
+          this.scheduleStop();
+        }
+      },
+    };
+  }
+
+  private scheduleStop(): void {
+    this.stopTimer = setTimeout(() => {
+      this.stopTimer = null;
+      void this.stop();
+    }, 1_000);
+    this.stopTimer.unref?.();
+  }
+
+  private async stop(): Promise<void> {
+    if (this.stopped || this.references > 0) {
+      return;
+    }
+    this.stopped = true;
+    await this.terminateAndFinalizeWhenExited();
+  }
+
+  private async invalidate(reason: Error): Promise<void> {
+    if (this.stopped) {
+      return this.stoppedPromise;
+    }
+    this.stopped = true;
+    if (this.stopTimer) {
+      clearTimeout(this.stopTimer);
+      this.stopTimer = null;
+    }
+    this.router.notifyProcessExit(null, null, reason.message);
+    await this.terminateAndFinalizeWhenExited();
+  }
+
+  private async terminateAndFinalizeWhenExited(): Promise<void> {
+    try {
+      const result = await this.terminateProcess(this.child, {
+        gracefulTimeoutMs: 2_000,
+        forceTimeoutMs: 2_000,
+      });
+      if (result !== "kill-timeout") {
+        this.finalizeStop();
+      }
+    } catch {
+      if (typeof this.child.exitCode === "number" || this.child.signalCode != null) {
+        this.finalizeStop();
+      }
+    }
+  }
+
+  private handleExit(code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.stopped) {
+      this.finalizeStop();
+      return;
+    }
+    this.stopped = true;
+    if (this.stopTimer) {
+      clearTimeout(this.stopTimer);
+      this.stopTimer = null;
+    }
+    this.router.notifyProcessExit(code, signal, this.stderrChunks.join("").trim() || undefined);
+    this.finalizeStop();
+  }
+
+  private finalizeStop(): void {
+    if (this.stopFinalized) {
+      return;
+    }
+    this.stopFinalized = true;
+    this.onStopped();
+    this.resolveStopped();
+  }
+}
+
 export function findSelectConfigOption({
   configOptions,
   category,
@@ -3674,12 +4315,36 @@ async function terminateChildProcess(
   child: ChildProcessWithoutNullStreams,
   timeoutMs: number,
   terminate: ProcessTerminator,
+  waitForExitOnTimeout = false,
 ): Promise<void> {
+  const exited = waitForExitOnTimeout
+    ? new Promise<void>((resolve) => {
+        child.once("exit", () => resolve());
+      })
+    : null;
+  let result: Awaited<ReturnType<ProcessTerminator>> | null = null;
+  let terminationError: unknown;
   try {
-    await terminate(child, { gracefulTimeoutMs: timeoutMs, forceTimeoutMs: timeoutMs });
+    result = await terminate(child, {
+      gracefulTimeoutMs: timeoutMs,
+      forceTimeoutMs: timeoutMs,
+    });
+  } catch (error) {
+    terminationError = error;
   } finally {
     child.stdin.destroy();
     child.stdout.destroy();
     child.stderr.destroy();
+  }
+  if (
+    waitForExitOnTimeout &&
+    (result === "kill-timeout" || terminationError !== undefined) &&
+    typeof child.exitCode !== "number" &&
+    child.signalCode == null
+  ) {
+    await exited;
+  }
+  if (terminationError !== undefined && !waitForExitOnTimeout) {
+    throw terminationError;
   }
 }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -514,6 +514,7 @@ interface ACPSharedProcessLease {
   connection: ClientSideConnection;
   initialize: InitializeResponse;
   register(sessionId: string, client: ACPSharedRouteTarget): void;
+  hasOtherReferences(): boolean;
   release(sessionId: string | null): void;
   invalidate(reason: Error): Promise<void>;
 }
@@ -1197,7 +1198,11 @@ export class ACPAgentClient implements AgentClient {
       return await withTimeout(request, remainingTimeoutMs, timeoutMessage);
     } catch (error) {
       if (!requestSettled) {
-        await sharedProcess.invalidate(new Error(timeoutMessage));
+        const hasOtherReferences = sharedProcess.hasOtherReferences();
+        sharedProcess.release(null);
+        if (!hasOtherReferences) {
+          await sharedProcess.invalidate(new Error(timeoutMessage));
+        }
       }
       throw error;
     }
@@ -3553,6 +3558,7 @@ class ACPSharedProcessHost {
       register: (sessionId, client) => {
         this.router.register(sessionId, client);
       },
+      hasOtherReferences: () => this.references > 1,
       invalidate: (reason) => this.invalidate(reason),
       release: (sessionId) => {
         if (released) {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -459,6 +459,36 @@ interface ACPAgentClientOptions {
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
   shareProcess?: boolean;
+  sharedProcessScope?: object;
+}
+
+interface ACPSharedProcessState {
+  host: Promise<ACPSharedProcessHost> | null;
+  launchEnvKey: string | null;
+  initializationAbort: (() => Promise<void>) | null;
+}
+
+const SHARED_PROCESS_STATES = new WeakMap<object, ACPSharedProcessState>();
+
+function createACPSharedProcessState(): ACPSharedProcessState {
+  return {
+    host: null,
+    launchEnvKey: null,
+    initializationAbort: null,
+  };
+}
+
+function resolveACPSharedProcessState(scope?: object): ACPSharedProcessState {
+  if (!scope) {
+    return createACPSharedProcessState();
+  }
+  const existing = SHARED_PROCESS_STATES.get(scope);
+  if (existing) {
+    return existing;
+  }
+  const state = createACPSharedProcessState();
+  SHARED_PROCESS_STATES.set(scope, state);
+  return state;
 }
 
 interface ACPAgentSessionOptions {
@@ -874,9 +904,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
   protected readonly terminateProcess: ProcessTerminator;
   private readonly shareProcess: boolean;
-  private sharedProcessHost: Promise<ACPSharedProcessHost> | null = null;
-  private sharedProcessLaunchEnvKey: string | null = null;
-  private sharedProcessInitializationAbort: (() => Promise<void>) | null = null;
+  private readonly sharedProcessState: ACPSharedProcessState;
   private sharedCatalog: ProviderCatalog | null = null;
   private sharedCatalogRequest: Promise<ProviderCatalog> | null = null;
 
@@ -907,6 +935,7 @@ export class ACPAgentClient implements AgentClient {
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
     this.shareProcess = options.shareProcess ?? false;
+    this.sharedProcessState = resolveACPSharedProcessState(options.sharedProcessScope);
   }
 
   async createSession(
@@ -1439,12 +1468,14 @@ export class ACPAgentClient implements AgentClient {
     const requestedLaunchEnvKey = stableEnvKey(sharedLaunchEnv);
     for (;;) {
       const launchEnvKey =
-        reuseActiveLaunchEnvironment && this.sharedProcessHost && this.sharedProcessLaunchEnvKey
-          ? this.sharedProcessLaunchEnvKey
+        reuseActiveLaunchEnvironment &&
+        this.sharedProcessState.host &&
+        this.sharedProcessState.launchEnvKey
+          ? this.sharedProcessState.launchEnvKey
           : requestedLaunchEnvKey;
-      if (this.sharedProcessHost && this.sharedProcessLaunchEnvKey !== launchEnvKey) {
+      if (this.sharedProcessState.host && this.sharedProcessState.launchEnvKey !== launchEnvKey) {
         const existingHost = await this.awaitSharedProcessHost(
-          this.sharedProcessHost,
+          this.sharedProcessState.host,
           initializeTimeoutMs,
         );
         if (existingHost.isStopped()) {
@@ -1459,24 +1490,27 @@ export class ACPAgentClient implements AgentClient {
           "Shared ACP sessions require the same launch environment; refusing to reuse a process with different environment values",
         );
       }
-      if (!this.sharedProcessHost) {
+      if (!this.sharedProcessState.host) {
         let hostPromise: Promise<ACPSharedProcessHost>;
         hostPromise = this.createSharedProcessHost(sharedLaunchEnv, initializeTimeoutMs, () => {
-          if (this.sharedProcessHost === hostPromise) {
-            this.sharedProcessHost = null;
-            this.sharedProcessLaunchEnvKey = null;
+          if (this.sharedProcessState.host === hostPromise) {
+            this.sharedProcessState.host = null;
+            this.sharedProcessState.launchEnvKey = null;
           }
         });
-        this.sharedProcessHost = hostPromise;
-        this.sharedProcessLaunchEnvKey = launchEnvKey;
+        this.sharedProcessState.host = hostPromise;
+        this.sharedProcessState.launchEnvKey = launchEnvKey;
         void hostPromise.catch(() => {
-          if (this.sharedProcessHost === hostPromise) {
-            this.sharedProcessHost = null;
-            this.sharedProcessLaunchEnvKey = null;
+          if (this.sharedProcessState.host === hostPromise) {
+            this.sharedProcessState.host = null;
+            this.sharedProcessState.launchEnvKey = null;
           }
         });
       }
-      const host = await this.awaitSharedProcessHost(this.sharedProcessHost, initializeTimeoutMs);
+      const host = await this.awaitSharedProcessHost(
+        this.sharedProcessState.host,
+        initializeTimeoutMs,
+      );
       if (host.isStopped()) {
         await host.whenStopped();
         continue;
@@ -1496,12 +1530,15 @@ export class ACPAgentClient implements AgentClient {
         `ACP initialize timed out after ${timeoutMs}ms`,
       );
     } catch (error) {
-      if (this.sharedProcessHost === hostPromise && this.sharedProcessInitializationAbort) {
-        const abort = this.sharedProcessInitializationAbort;
+      if (
+        this.sharedProcessState.host === hostPromise &&
+        this.sharedProcessState.initializationAbort
+      ) {
+        const abort = this.sharedProcessState.initializationAbort;
         void abort().then(() => {
-          if (this.sharedProcessHost === hostPromise) {
-            this.sharedProcessHost = null;
-            this.sharedProcessLaunchEnvKey = null;
+          if (this.sharedProcessState.host === hostPromise) {
+            this.sharedProcessState.host = null;
+            this.sharedProcessState.launchEnvKey = null;
           }
           return undefined;
         });
@@ -1522,7 +1559,7 @@ export class ACPAgentClient implements AgentClient {
       cleanupPromise ??= terminateChildProcess(transport.child, 2_000, this.terminateProcess, true);
       return cleanupPromise;
     };
-    this.sharedProcessInitializationAbort = abortInitialization;
+    this.sharedProcessState.initializationAbort = abortInitialization;
     try {
       const initialize = await this.initializeTransport(transport, initializeTimeoutMs);
       return new ACPSharedProcessHost({
@@ -1538,8 +1575,8 @@ export class ACPAgentClient implements AgentClient {
       await abortInitialization();
       throw error;
     } finally {
-      if (this.sharedProcessInitializationAbort === abortInitialization) {
-        this.sharedProcessInitializationAbort = null;
+      if (this.sharedProcessState.initializationAbort === abortInitialization) {
+        this.sharedProcessState.initializationAbort = null;
       }
     }
   }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -292,6 +292,7 @@ export function buildACPClientCapabilities(
 // NO_BROWSER is honored by Gemini CLI; other ACP agents ignore it.
 const PROBE_ENV: Record<string, string> = { NO_BROWSER: "true" };
 const ACP_CATALOG_TIMEOUT_MS = 60_000;
+const MAX_PENDING_SESSION_UPDATES_PER_SESSION = 100;
 const ACP_DIAGNOSTIC_PHASE_TIMEOUT_MS = 20_000;
 
 type ACPFetchCatalogOptions = FetchCatalogOptions & { timeoutMs?: number };
@@ -3413,14 +3414,23 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
 class ACPSharedClientRouter implements ACPClient {
   private readonly sessions = new Map<string, ACPSharedRouteTarget>();
+  private readonly pendingSessionUpdates = new Map<string, SessionNotification[]>();
 
   register(sessionId: string, client: ACPSharedRouteTarget): void {
     this.sessions.set(sessionId, client);
+    const pending = this.pendingSessionUpdates.get(sessionId);
+    if (pending) {
+      this.pendingSessionUpdates.delete(sessionId);
+      for (const params of pending) {
+        void client.sessionUpdate(params);
+      }
+    }
   }
 
   unregister(sessionId: string | null): void {
     if (sessionId) {
       this.sessions.delete(sessionId);
+      this.pendingSessionUpdates.delete(sessionId);
     }
   }
 
@@ -3429,6 +3439,7 @@ class ACPSharedClientRouter implements ACPClient {
       session.handleSharedProcessExit?.(code, signal, diagnostic);
     }
     this.sessions.clear();
+    this.pendingSessionUpdates.clear();
   }
 
   async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
@@ -3436,7 +3447,21 @@ class ACPSharedClientRouter implements ACPClient {
   }
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
-    return this.session(params.sessionId).sessionUpdate(params);
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      // Agents may push session-scoped notifications (for example
+      // `available_commands_update`) immediately after the session/new
+      // response, before the client has registered the session with this
+      // router. Buffer them instead of dropping; register() replays them in
+      // arrival order once the session is known.
+      const pending = this.pendingSessionUpdates.get(params.sessionId) ?? [];
+      if (pending.length < MAX_PENDING_SESSION_UPDATES_PER_SESSION) {
+        pending.push(params);
+        this.pendingSessionUpdates.set(params.sessionId, pending);
+      }
+      return;
+    }
+    return session.sessionUpdate(params);
   }
 
   async readTextFile(params: ReadTextFileRequest): Promise<{ content: string }> {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
@@ -68,10 +68,15 @@ describe("GenericACPAgentClient", () => {
   });
 
   test("shares the ACP process only for the built-in Hermes provider", () => {
-    const hermesClient = new GenericACPAgentClient({
+    const sharedProcessScope = {};
+    const hermesOptions = {
       logger: createTestLogger(),
-      command: ["hermes", "acp"],
+      command: ["hermes", "acp"] as [string, ...string[]],
       providerId: "hermes",
+      sharedProcessScope,
+    };
+    const hermesClient = new GenericACPAgentClient({
+      ...hermesOptions,
     });
     const otherClient = new GenericACPAgentClient({
       logger: createTestLogger(),
@@ -81,7 +86,10 @@ describe("GenericACPAgentClient", () => {
     void hermesClient;
     void otherClient;
 
-    expect(mockState.superConstructorOptions.at(-2)).toMatchObject({ shareProcess: true });
+    expect(mockState.superConstructorOptions.at(-2)).toMatchObject({
+      shareProcess: true,
+      sharedProcessScope,
+    });
     expect(mockState.superConstructorOptions.at(-1)).toMatchObject({ shareProcess: false });
   });
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
@@ -41,7 +41,7 @@ describe("GenericACPAgentClient", () => {
     });
     void _client;
 
-    expect(mockState.superConstructorOptions).toEqual([
+    expect(mockState.superConstructorOptions).toMatchObject([
       {
         provider: "acp",
         logger: expect.any(Object),
@@ -62,8 +62,27 @@ describe("GenericACPAgentClient", () => {
           supportsRewindFiles: false,
           supportsRewindBoth: false,
         },
+        shareProcess: false,
       },
     ]);
+  });
+
+  test("shares the ACP process only for the built-in Hermes provider", () => {
+    const hermesClient = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["hermes", "acp"],
+      providerId: "hermes",
+    });
+    const otherClient = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["other-acp"],
+      providerId: "other",
+    });
+    void hermesClient;
+    void otherClient;
+
+    expect(mockState.superConstructorOptions.at(-2)).toMatchObject({ shareProcess: true });
+    expect(mockState.superConstructorOptions.at(-1)).toMatchObject({ shareProcess: false });
   });
 
   test("uses provider params to report MCP support", () => {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -76,6 +76,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
+      shareProcess: options.providerId === "hermes",
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -51,6 +51,7 @@ interface GenericACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
+  sharedProcessScope?: object;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -77,6 +78,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
       shareProcess: options.providerId === "hermes",
+      sharedProcessScope: options.sharedProcessScope,
     });
 
     this.command = options.command;


### PR DESCRIPTION
### Linked issue

Closes #3193

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo's built-in Hermes integration currently launches one ACP subprocess per Paseo agent. That normally gives providers process isolation, but Hermes's durable profile is shared outside the workspace. Parallel agents therefore become concurrent OS-process writers to the same profile-level memory and configuration even when every agent has a separate Paseo workspace and Git worktree.

The user-visible workflow is ordinary Paseo parallelism: open Paseo, select Hermes, and start several agents. Users reasonably expect separate conversations, but they should not need to know that repository isolation does not isolate a provider's global durable state or that the built-in provider requires a one-process rule.

Hermes's ACP server already supports the primitive needed to fix this without merging conversations: one transport can host multiple native ACP sessions. This change makes that process sharing an explicit ACP-client capability and enables it only for the built-in `hermes` provider. Each Paseo agent still creates and owns a separate native ACP session, transcript, turn state, permissions, terminals, and cancellation path. The shared process only centralizes ownership of the profile writer.

The alternatives did not preserve the intended workflow:

- **Git worktrees:** isolate repository files, not `~/.hermes` or another provider home.
- **One profile clone per agent:** the tested profile was about 24 GB, took about 45 seconds per clone, caused multi-agent startup timeouts, and fragmented one durable agent identity into divergent copies.
- **Serialize turns while keeping one process per agent:** processes launch before `startTurn()`, so a turn gate cannot prevent concurrent profile writers. It also defeats parallel work.
- **Tell users to run one Hermes agent at a time:** avoids the symptom by removing Paseo's parallel-agent workflow.

The implementation keeps ordinary ACP providers on the existing one-process-per-agent path. Process sharing is opt-in in `ACPAgentClient`; `GenericACPAgentClient` enables it only when `providerId === "hermes"`.

### What changes

- Adds a provider/launch-environment-scoped shared ACP host and lease registry.
- Uses one `ClientSideConnection` for many independent native ACP sessions.
- Routes every callback by native ACP session ID and fails closed for missing, unknown, or stale IDs.
- Removes only Paseo's per-agent variables (`PASEO_AGENT_ID`, `PASEO_AGENT_CWD`, `PASEO_WORKSPACE_ID`) from shared launch identity; other provider environment values remain part of the key and launch environment.
- Makes catalog discovery, diagnostics, and importable-session probes reuse the same Hermes host rather than spawning probe writers.
- Separates session lifetime from process lifetime: closing one session does not close sibling sessions.
- Handles cancellation, session setup failures, provider exit, stale host replacement, daemon restart/resume, and idle shutdown.
- Carries one timeout budget through host acquisition and ACP initialization.
- Retains registry ownership until a timed-out process is confirmed exited, preventing an old and replacement Hermes process from overlapping.
- Cancels pending permission requests when the shared process exits.

### Goals

- [x] Parallel Hermes-backed Paseo agents use exactly one Hermes ACP OS process per launch identity/profile.
- [x] Every Paseo agent has a different native ACP session and independent turn history.
- [x] Native-session callback routing cannot leak events, permissions, terminals, or filesystem requests across agents.
- [x] Missing, stale, or unknown native session IDs fail closed.
- [x] Catalog and management probes cannot create a second profile writer.
- [x] Process death fails attached sessions and permits replacement only after the old process is known gone.
- [x] Existing non-Hermes ACP provider behavior is unchanged.
- [x] No profile selection, profile cloning, lock management, or workflow change is required from the user.

### Non-goals

- Sharing processes for all ACP providers. Other providers remain independent unless they explicitly opt in later.
- Sharing conversation state between Paseo agents. Native ACP sessions remain separate.
- Changing Hermes's memory policy or deciding which information Hermes persists.
- Implementing a generic cross-process file lock around arbitrary provider homes.
- Adding UI or protocol changes.

### QA

#### Automated provider coverage

Commands run from the rebased feature worktree at `40b97e09893c7887cecc599af2da98c5053542c1`:

```text
$ npm exec vitest run -- src/server/agent/providers/acp-agent.test.ts src/server/agent/providers/generic-acp-agent.test.ts

Test Files  2 passed (2)
Tests       111 passed (111)
```

The tests cover:

- one spawn with ten independent native sessions;
- strict callback routing and unknown-session rejection;
- per-session cancellation, close, permissions, terminals, and filesystem callbacks;
- caller/provider environment preservation and per-agent environment exclusion;
- environment mismatch rejection;
- catalog request coalescing with per-caller deadlines;
- catalog, diagnostic, and import probes reusing an active custom-environment host;
- bounded ACP initialization and cleanup after hung handshakes;
- process termination timeout ownership;
- process exit, stale host replacement, and no overlapping replacement writer;
- independent behavior for non-Hermes ACP providers.

#### Static and build checks

```text
$ npm run lint
Found 0 warnings and 0 errors.
Finished on 3341 files.

$ npm run format:check
All matched files use the correct format.
Finished on 3577 files.

$ npm run generate:validators --workspace=@getpaseo/protocol
$ npm run typecheck --workspace=@getpaseo/client
$ npm run typecheck --workspace=@getpaseo/server
$ npm run typecheck --workspace=@getpaseo/app
$ npm run typecheck --workspace=@getpaseo/cli
# all exited 0 when run sequentially

$ npm run build:server
# server, client dependencies, and CLI exited 0

$ CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:desktop -- --publish never --mac --arm64 --dir
# exited 0; packaged macOS app launched successfully after consistent local ad-hoc signing
```

The root typecheck script runs protocol generation and consumers concurrently. In this checkout that produced transient missing generated-message types. Running protocol generation first and each consumer sequentially passed. This PR does not touch protocol or generated files.

#### Full server-suite reconciliation

A highly parallel full server run completed 319 files and 4,701 tests, with 41 timeout/path failures concentrated in seven unrelated supervisor/workspace/WebSocket/Hub files:

```text
Test Files  7 failed | 319 passed | 3 skipped
Tests       41 failed | 4701 passed | 43 skipped
```

Every affected area was then rerun serially with a canonical macOS temp directory:

```text
$ TMPDIR=/private/tmp npm exec vitest run -- --maxWorkers=1 --no-file-parallelism \
    scripts/supervisor.logging.test.ts \
    src/server/websocket-server.browser-tools.test.ts \
    src/server/workspace-git-service.observation.test.ts \
    src/server/workspace-service-port-allocator.test.ts \
    src/server/hub/daemon-executions.test.ts \
    src/server/hub/execution-session.websocket.test.ts \
    src/server/hub/hub-cli-contract.test.ts \
    src/server/hub/relationship-controller.test.ts

Test Files  8 passed (8)
Tests       128 passed (128)
```

#### Real Hermes acceptance: source build

I ran ten real Paseo agents in parallel through matching server and CLI binaries, using Hermes 0.20.0 and `deepseek:deepseek-v4-flash`. A process-tree monitor started before provider discovery and sampled the daemon descendants throughout the run.

```text
Paseo agents:                  10
Unique Paseo agent IDs:        10
Unique native ACP session IDs: 10
Idle terminal states:          10/10
Exact completion markers:      10/10
Process samples:               838
Maximum hermes acp processes:  1
Samples above one process:     0
Observed PID sets:             ['49683']
```

#### Real Hermes acceptance: packaged installed artifact

I built the macOS Electron package, installed that artifact, launched its bundled daemon and CLI on isolated disposable Paseo state, and repeated the ten-agent test against the packaged code rather than the source server.

```text
Paseo agents:                  10
Unique Paseo agent IDs:        10
Unique native ACP session IDs: 10
Idle terminal states:          10/10
Exact completion markers:      10/10
Process samples:               681
Maximum hermes acp processes:  1
Samples above one process:     0
Observed PID sets:             ['43302']
```

#### Durable-memory behavior

Using a disposable Hermes profile:

1. Two independent Paseo agents concurrently wrote different durable facts.
2. Both writes completed and both facts appeared in the disposable profile.
3. A third independent agent/session recalled both facts.
4. All three agents had different native ACP session IDs.
5. The process monitor never observed more than one `hermes acp` process.

```text
Concurrent writers:            2
Independent reader:            1
Unique native ACP sessions:    3
Recall marker:                 MEMORY_RECALL_OK
Process samples:               418
Maximum hermes acp processes:  1
Samples above one process:     0
```

No acceptance marker was written to the user's normal Hermes profile.

#### Lifecycle and regression checks

- Cancelling one session did not interrupt a concurrently running sibling session.
- Killing the shared Hermes process failed both attached sessions.
- The next agent created exactly one replacement process and completed.
- Restarting the disposable Paseo daemon resumed a persisted agent and retained its earlier exchange.
- A live non-Hermes `mock` provider agent completed normally on the independent-process path.
- An independent read-only defect-first review of the final diff returned `PASS` after timeout, termination ownership, environment reuse, and pending-permission lifecycle findings were fixed and covered by tests.

Greptile's first public review identified that a timed-out management probe could invalidate a healthy shared host and fail unrelated active sessions. Commit `3d4653a70` now releases the abandoned probe lease without invalidating a host that has other references; an isolated host is still invalidated and replaced. A new regression test keeps an agent session attached while a catalog probe hangs and verifies that the process is not terminated. The same review flagged fixed-duration sleeps in timeout tests; all of those sleeps were replaced with explicit deferred synchronization. The updated focused suite is 111/111, and the full pre-commit lint, format, and workspace typecheck hook passes.

#### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop macOS | Yes | Apple Silicon, macOS 15.6.1; source daemon and packaged Electron artifact |
| Desktop Windows | No | Process lifecycle is covered by mocked cross-platform unit tests; no Windows host was available |
| Desktop Linux | No | Process lifecycle is covered by mocked cross-platform unit tests; no Linux host was used |
| Web/iOS/Android | Not affected | No app UI or wire-protocol change |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes when protocol generation and dependent workspaces run sequentially; see QA note about the root script's generation race
- [x] `npm run lint` passes
- [x] `npm run format` / `npm run format:check` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
