### PR TITLE
fix(desktop): capture full pages without repeated viewports

### DIFF
--- a/docs/browser-capture-harness.md
+++ b/docs/browser-capture-harness.md
@@ -95,11 +95,15 @@ plane stays below the overlay plane regardless of body insertion order; menus ke
 layering inside `overlay-root`. Activating a presented browser also focuses its registered guest
 `WebContents` in main so macOS assigns keyboard first-responder ownership to the page.
 
-There is no renderer prep/restore handshake. Main disables guest background throttling
-once when the webview attaches, then screenshot capture uses the shared serialized queue,
-invalidates before each attempt, and retries known first-frame failures within the
-5-second capture budget. Viewport screenshots use `capturePage({ stayHidden:false })`.
+There is no host-renderer parking handshake. Main disables guest background throttling once
+when the webview attaches, then screenshot capture uses the shared serialized queue, invalidates
+before each attempt, and retries known first-frame failures. Viewport screenshots retain the
+5-second budget and use `capturePage({ stayHidden:false })`.
+
 Electron guest `captureBeyondViewport` repeats the current compositor viewport below the fold,
-so full-page capture scrolls the guest, captures each painted viewport through CDP, stitches the
-bitmap tiles, and restores the original scroll position. The harness checks the distinct bottom
-marker so a correctly sized repeated viewport cannot pass.
+so full-page capture uses a bounded 30-second scroll-and-stitch path. It verifies the scroll before
+and after every CDP tile, retries changing layouts up to three passes, renders fixed elements only
+in the first viewport, temporarily removes sticky positioning, and restores page state afterward.
+Captures are capped at 128 tiles and a 128 MiB raw bitmap; timeout aborts the active capture instead
+of leaving work in the CDP queue. The harness checks the distinct bottom marker so a correctly
+sized repeated viewport cannot pass.

--- a/docs/browser-capture-harness.md
+++ b/docs/browser-capture-harness.md
@@ -10,8 +10,8 @@ It validates the compositor behavior that unit tests cannot see:
   stacking changes;
 - a newly attached resident webview whose first useful frame is delayed can be captured
   by retrying until the frame appears;
-- both viewport `capturePage` and full-page CDP screenshots return real pixels from
-  the permanent production parking state;
+- both viewport `capturePage` and the compiled production full-page capture return real pixels
+  from the permanent production parking state, including the fixture's bottom marker;
 - guest background throttling can be disabled once at attach without per-capture
   renderer coordination;
 - the real-Electron host-composer sentinel proves guest Enter cannot submit a focused
@@ -30,11 +30,10 @@ Run it with the repo Electron:
 npm run capture-harness --workspace=@getpaseo/desktop
 ```
 
-Build the desktop main process before the automation group so its production guest
-preload is available:
+The command builds the desktop main process first so the harness exercises the compiled
+production full-page capture, keyboard boundary, and guest preload. Run the automation group with:
 
 ```bash
-npm run build:main --workspace=@getpaseo/desktop
 PASEO_CAPTURE_HARNESS_GROUP=automation npm run capture-harness --workspace=@getpaseo/desktop
 ```
 
@@ -99,5 +98,8 @@ layering inside `overlay-root`. Activating a presented browser also focuses its 
 There is no renderer prep/restore handshake. Main disables guest background throttling
 once when the webview attaches, then screenshot capture uses the shared serialized queue,
 invalidates before each attempt, and retries known first-frame failures within the
-5-second capture budget. Viewport screenshots use `capturePage({ stayHidden:false })`;
-full-page screenshots use the existing CDP path with layout metrics and screenshot clip.
+5-second capture budget. Viewport screenshots use `capturePage({ stayHidden:false })`.
+Electron guest `captureBeyondViewport` repeats the current compositor viewport below the fold,
+so full-page capture scrolls the guest, captures each painted viewport through CDP, stitches the
+bitmap tiles, and restores the original scroll position. The harness checks the distinct bottom
+marker so a correctly sized repeated viewport cannot pass.

--- a/packages/desktop/capture-harness/main.js
+++ b/packages/desktop/capture-harness/main.js
@@ -7,6 +7,16 @@ const { app, BrowserWindow, ipcMain, Menu, nativeImage, screen, session } = requ
 
 const ROOT = __dirname;
 const OUT_DIR = process.env.PASEO_CAPTURE_HARNESS_OUT_DIR || path.join(ROOT, "out");
+const PRODUCTION_BROWSER_AUTOMATION_DIR = path.join(
+  ROOT,
+  "..",
+  "dist",
+  "features",
+  "browser-automation",
+);
+const { captureFullPage } = require(
+  path.join(PRODUCTION_BROWSER_AUTOMATION_DIR, "full-page-capture.js"),
+);
 const PRODUCTION_BROWSER_KEYBOARD_DIR = path.join(
   ROOT,
   "..",
@@ -248,6 +258,26 @@ function isBrightMagenta(bitmap, offset) {
   return c0 > 200 && c1 < 90 && c2 > 200;
 }
 
+function hasBottomMarker(bitmap, width, height, devicePixelRatio) {
+  const crop = {
+    left: Math.min(width, Math.round(40 * devicePixelRatio)),
+    top: Math.min(height, Math.round(1320 * devicePixelRatio)),
+    right: Math.min(width, Math.round(1150 * devicePixelRatio)),
+    bottom: Math.min(height, Math.round(1500 * devicePixelRatio)),
+  };
+  let pixels = 0;
+  let nonBright = 0;
+  for (let y = crop.top; y < crop.bottom; y += 1) {
+    for (let x = crop.left; x < crop.right; x += 1) {
+      pixels += 1;
+      if (!isBrightMagenta(bitmap, pixelOffset(width, x, y))) {
+        nonBright += 1;
+      }
+    }
+  }
+  return pixels > 0 && nonBright / pixels > 0.01;
+}
+
 function analyzeImage(image, expected, guestMetrics) {
   if (!image || image.isEmpty()) {
     return {
@@ -257,6 +287,7 @@ function analyzeImage(image, expected, guestMetrics) {
       logicalHeightAtDpr: 0,
       brightRatio: 0,
       textNonUniform: false,
+      bottomMarkerVisible: false,
       matchedSize: false,
       pass: false,
     };
@@ -326,6 +357,8 @@ function analyzeImage(image, expected, guestMetrics) {
     cropNonBright / cropPixels > 0.02 &&
     quantized.size >= 4 &&
     luminanceVariance > 100;
+  const bottomMarkerVisible = hasBottomMarker(bitmap, width, height, devicePixelRatio);
+  const requiredPixelsVisible = !expected.requiresBottomMarker || bottomMarkerVisible;
 
   return {
     width,
@@ -334,15 +367,25 @@ function analyzeImage(image, expected, guestMetrics) {
     logicalHeightAtDpr: height / devicePixelRatio,
     brightRatio,
     textNonUniform,
+    bottomMarkerVisible,
     matchedSize,
-    pass: matchedSize && brightRatio >= expected.minBrightRatio && textNonUniform,
+    pass:
+      matchedSize &&
+      brightRatio >= expected.minBrightRatio &&
+      textNonUniform &&
+      requiredPixelsVisible,
   };
 }
 
 function expectedForMode(mode) {
   return mode === "viewport"
     ? { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT, minBrightRatio: 0.65 }
-    : { width: VIEWPORT_WIDTH, height: FULL_PAGE_HEIGHT, minBrightRatio: 0.55 };
+    : {
+        width: VIEWPORT_WIDTH,
+        height: FULL_PAGE_HEIGHT,
+        minBrightRatio: 0.55,
+        requiresBottomMarker: true,
+      };
 }
 
 function summarizeAnalysis(analysis) {
@@ -354,6 +397,7 @@ function summarizeAnalysis(analysis) {
       logicalHeightAtDpr: 0,
       brightRatio: 0,
       textNonUniform: false,
+      bottomMarkerVisible: false,
       matchedSize: false,
       pass: false,
     };
@@ -365,6 +409,7 @@ function summarizeAnalysis(analysis) {
     logicalHeightAtDpr: analysis.logicalHeightAtDpr,
     brightRatio: analysis.brightRatio,
     textNonUniform: analysis.textNonUniform,
+    bottomMarkerVisible: analysis.bottomMarkerVisible,
     matchedSize: analysis.matchedSize,
     pass: analysis.pass,
   };
@@ -446,47 +491,29 @@ async function capturePageSequence(contents) {
   return await withTimeout(contents.capturePage(undefined, { stayHidden: false }), "capturePage");
 }
 
-async function captureFullPage(contents) {
+async function captureFullPageSequence(contents) {
   let attachedHere = false;
   if (!contents.debugger.isAttached()) {
     contents.debugger.attach("1.3");
     attachedHere = true;
   }
   try {
-    const metrics = await contents.debugger.sendCommand("Page.getLayoutMetrics");
-    const contentSize = metrics.cssContentSize ||
-      metrics.contentSize || {
-        x: 0,
-        y: 0,
-        width: VIEWPORT_WIDTH,
-        height: FULL_PAGE_HEIGHT,
-      };
-    const clip = {
-      x: Math.floor(contentSize.x || 0),
-      y: Math.floor(contentSize.y || 0),
-      width: Math.ceil(contentSize.width || VIEWPORT_WIDTH),
-      height: Math.ceil(contentSize.height || FULL_PAGE_HEIGHT),
-      scale: 1,
-    };
-    const result = await withTimeout(
-      contents.debugger.sendCommand("Page.captureScreenshot", {
-        format: "png",
-        captureBeyondViewport: true,
-        clip,
-      }),
-      "CDP Page.captureScreenshot",
-    );
-    return nativeImage.createFromBuffer(Buffer.from(result.data, "base64"));
+    return await captureFullPage({
+      executeJavaScript: (script) =>
+        withTimeout(contents.executeJavaScript(script, true), "full-page guest script"),
+      sendDebugCommand: (method, params) =>
+        withTimeout(contents.debugger.sendCommand(method, params), `full-page ${method}`),
+      invalidate: () => contents.invalidate(),
+      createImageFromPng: (dataBase64) =>
+        nativeImage.createFromBuffer(Buffer.from(dataBase64, "base64")),
+      createImageFromBitmap: (bitmap, size) =>
+        nativeImage.createFromBitmap(Buffer.from(bitmap), { ...size, scaleFactor: 1 }),
+    });
   } finally {
     if (attachedHere && contents.debugger.isAttached()) {
       contents.debugger.detach();
     }
   }
-}
-
-async function captureFullPageSequence(contents) {
-  contents.invalidate();
-  return await captureFullPage(contents);
 }
 
 function installHarnessWebviewGuards(win, options = {}) {
@@ -698,7 +725,7 @@ async function measurePermanentCapture({
           pass: true,
         };
         pass(
-          `permanent ${state.code} ${variant.code} ${phase} ${mode} webview ${targetIndex + 1} ${repeatIndex}/${repeatTotal} attempts=${attempt} size=${analysisSize(lastAnalysis)} logical=${analysisLogicalSize(lastAnalysis)} bright=${lastAnalysis.brightRatio.toFixed(4)} text=${lastAnalysis.textNonUniform} file=${outputPath}`,
+          `permanent ${state.code} ${variant.code} ${phase} ${mode} webview ${targetIndex + 1} ${repeatIndex}/${repeatTotal} attempts=${attempt} size=${analysisSize(lastAnalysis)} logical=${analysisLogicalSize(lastAnalysis)} bright=${lastAnalysis.brightRatio.toFixed(4)} text=${lastAnalysis.textNonUniform} bottom=${lastAnalysis.bottomMarkerVisible} file=${outputPath}`,
         );
         return result;
       }
@@ -813,7 +840,7 @@ async function captureWithPrep({
           );
           return analysis;
         }
-        lastFailure = `size=${size} logical=${logicalSize} bright=${bright} text=${analysis.textNonUniform}`;
+        lastFailure = `size=${size} logical=${logicalSize} bright=${bright} text=${analysis.textNonUniform} bottom=${analysis.bottomMarkerVisible}`;
       } catch (error) {
         lastFailure = error instanceof Error ? error.message : String(error);
       }

--- a/packages/desktop/e2e/browser-tabs.e2e.mjs
+++ b/packages/desktop/e2e/browser-tabs.e2e.mjs
@@ -201,14 +201,28 @@ async function startTargetPage() {
           <title>Desktop browser target</title>
           <style>
             html, body { min-height: 1600px; margin: 0; background: #111; }
-            #full-page-marker { position: absolute; left: 40px; top: 1370px; width: 200px; height: 100px; background: #00ff00; }
+            #fixed-capture-header { position: fixed; z-index: 2; pointer-events: none; left: 0; top: 0; width: 100%; height: 30px; background: #f01414; }
+            #sticky-capture-label { position: sticky; top: 0; width: 180px; height: 30px; margin-top: 100px; background: #ffff00; }
+            #full-page-marker { position: absolute; left: 40px; top: 1870px; width: 200px; height: 100px; background: #00ff00; }
           </style>
         </head>
         <body>
+          <div id="fixed-capture-header"></div>
           <button id="bridge-target" onclick="this.textContent = 'Clicked'">Bridge target</button>
           <label for="typing-target">Typing target</label>
           <input id="typing-target" />
-          <div id="full-page-marker"></div>
+          <div id="sticky-capture-label"></div>
+          <script>
+            let expanded = false;
+            addEventListener('scroll', () => {
+              if (expanded || scrollY <= 0) return;
+              expanded = true;
+              document.body.style.minHeight = '2000px';
+              const marker = document.createElement('div');
+              marker.id = 'full-page-marker';
+              document.body.appendChild(marker);
+            }, { passive: true });
+          </script>
         </body>
       </html>`);
   });
@@ -237,14 +251,6 @@ function mcpPayload(result, command) {
 
 async function callBrowserTool(client, name, args = {}) {
   return mcpPayload(await client.callTool({ name, args }), name);
-}
-
-async function callBrowserScreenshot(client, args) {
-  const response = await client.callTool({ name: "browser_screenshot", args });
-  const result = mcpPayload(response, "browser_screenshot");
-  const image = response.content.find((entry) => entry.type === "image");
-  assert(image?.data, `browser_screenshot returned no image content: ${JSON.stringify(response)}`);
-  return { ...result, dataBase64: image.data };
 }
 
 async function createCallerAgent(daemonPort) {
@@ -366,6 +372,14 @@ async function readScreenshotPixel(page, input) {
   }, input);
 }
 
+async function callBrowserScreenshot(client, args) {
+  const response = await client.callTool({ name: "browser_screenshot", args });
+  const result = mcpPayload(response, "browser_screenshot");
+  const image = response.content.find((entry) => entry.type === "image");
+  assert(image?.data, `browser_screenshot returned no image content: ${JSON.stringify(response)}`);
+  return { ...result, dataBase64: image.data };
+}
+
 async function verifyFullPageScreenshot(page, client, browserId) {
   const constraints = await callBrowserTool(client, "browser_evaluate", {
     browserId,
@@ -389,11 +403,11 @@ async function verifyFullPageScreenshot(page, client, browserId) {
     `Full-page scroll constraints were not installed: ${constraints.resultJson}`,
   );
   const screenshot = await callBrowserScreenshot(client, { browserId, fullPage: true });
-  const scale = screenshot.height / 1600;
+  const scale = screenshot.height / 2000;
   const markerPixel = await readScreenshotPixel(page, {
     dataBase64: screenshot.dataBase64,
     x: Math.round(100 * scale),
-    y: Math.round(1400 * scale),
+    y: Math.round(1900 * scale),
   });
   assert(
     markerPixel.width === screenshot.width && markerPixel.height === screenshot.height,
@@ -402,7 +416,25 @@ async function verifyFullPageScreenshot(page, client, browserId) {
   const [red, green, blue, alpha] = markerPixel.rgba;
   assert(
     red < 80 && green > 200 && blue < 100 && alpha === 255,
-    `Full-page screenshot did not include the bottom marker: ${JSON.stringify(markerPixel)}`,
+    `Full-page screenshot did not include the dynamically added bottom marker: ${JSON.stringify(markerPixel)}`,
+  );
+  const fixedAtTop = await readScreenshotPixel(page, {
+    dataBase64: screenshot.dataBase64,
+    x: Math.round(350 * scale),
+    y: Math.round(15 * scale),
+  });
+  const fixedBelowFold = await readScreenshotPixel(page, {
+    dataBase64: screenshot.dataBase64,
+    x: Math.round(350 * scale),
+    y: Math.round(682 * scale),
+  });
+  assert(
+    fixedAtTop.rgba[0] > 200 && fixedAtTop.rgba[1] < 80 && fixedAtTop.rgba[2] < 80,
+    `Full-page screenshot lost the fixed header at the page top: ${JSON.stringify(fixedAtTop)}`,
+  );
+  assert(
+    !(fixedBelowFold.rgba[0] > 200 && fixedBelowFold.rgba[1] < 80 && fixedBelowFold.rgba[2] < 80),
+    `Full-page screenshot repeated the fixed header below the fold: ${JSON.stringify(fixedBelowFold)}`,
   );
   const restoredScroll = await callBrowserTool(client, "browser_evaluate", {
     browserId,
@@ -411,6 +443,19 @@ async function verifyFullPageScreenshot(page, client, browserId) {
   assert(
     restoredScroll.resultJson === '{"x":0,"y":0}',
     `Full-page screenshot did not restore page scroll: ${restoredScroll.resultJson}`,
+  );
+  const restoredStyles = await callBrowserTool(client, "browser_evaluate", {
+    browserId,
+    function: `() => ({
+      fixedVisibility: getComputedStyle(document.querySelector("#fixed-capture-header")).visibility,
+      stickyPosition: getComputedStyle(document.querySelector("#sticky-capture-label")).position,
+      captureStateCount: Object.keys(globalThis).filter((key) => key.startsWith("__paseoFullPageCapture_")).length
+    })`,
+  });
+  assert(
+    restoredStyles.resultJson ===
+      '{"fixedVisibility":"visible","stickyPosition":"sticky","captureStateCount":0}',
+    `Full-page screenshot did not restore temporary page styles: ${restoredStyles.resultJson}`,
   );
   const cleanup = await callBrowserTool(client, "browser_evaluate", {
     browserId,

--- a/packages/desktop/e2e/browser-tabs.e2e.mjs
+++ b/packages/desktop/e2e/browser-tabs.e2e.mjs
@@ -197,11 +197,18 @@ async function startTargetPage() {
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     response.end(`<!doctype html>
       <html>
-        <head><title>Desktop browser target</title></head>
+        <head>
+          <title>Desktop browser target</title>
+          <style>
+            html, body { min-height: 1600px; margin: 0; background: #111; }
+            #full-page-marker { position: absolute; left: 40px; top: 1370px; width: 200px; height: 100px; background: #00ff00; }
+          </style>
+        </head>
         <body>
           <button id="bridge-target" onclick="this.textContent = 'Clicked'">Bridge target</button>
           <label for="typing-target">Typing target</label>
           <input id="typing-target" />
+          <div id="full-page-marker"></div>
         </body>
       </html>`);
   });
@@ -230,6 +237,14 @@ function mcpPayload(result, command) {
 
 async function callBrowserTool(client, name, args = {}) {
   return mcpPayload(await client.callTool({ name, args }), name);
+}
+
+async function callBrowserScreenshot(client, args) {
+  const response = await client.callTool({ name: "browser_screenshot", args });
+  const result = mcpPayload(response, "browser_screenshot");
+  const image = response.content.find((entry) => entry.type === "image");
+  assert(image?.data, `browser_screenshot returned no image content: ${JSON.stringify(response)}`);
+  return { ...result, dataBase64: image.data };
 }
 
 async function createCallerAgent(daemonPort) {
@@ -324,6 +339,60 @@ async function readViewport(client, browserId) {
     function: "() => ({ width: window.innerWidth, height: window.innerHeight })",
   });
   return JSON.parse(evaluated.resultJson);
+}
+
+async function readScreenshotPixel(page, input) {
+  return await page.evaluate(async ({ dataBase64, x, y }) => {
+    const image = new Image();
+    const loaded = new Promise((resolve, reject) => {
+      image.addEventListener("load", resolve, { once: true });
+      image.addEventListener("error", () => reject(new Error("Screenshot PNG did not decode")), {
+        once: true,
+      });
+    });
+    image.src = `data:image/png;base64,${dataBase64}`;
+    await loaded;
+    const canvas = document.createElement("canvas");
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) throw new Error("Screenshot canvas context was unavailable");
+    context.drawImage(image, 0, 0);
+    return {
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+      rgba: Array.from(context.getImageData(x, y, 1, 1).data),
+    };
+  }, input);
+}
+
+async function collectFullPageScreenshotFailures(page, client, browserId) {
+  const failures = [];
+  const screenshot = await callBrowserScreenshot(client, { browserId, fullPage: true });
+  const scale = screenshot.height / 1600;
+  const markerPixel = await readScreenshotPixel(page, {
+    dataBase64: screenshot.dataBase64,
+    x: Math.round(100 * scale),
+    y: Math.round(1400 * scale),
+  });
+  assert(
+    markerPixel.width === screenshot.width && markerPixel.height === screenshot.height,
+    `Full-page screenshot metadata did not match its PNG: ${JSON.stringify(markerPixel)}`,
+  );
+  const [red, green, blue, alpha] = markerPixel.rgba;
+  if (red >= 80 || green <= 200 || blue >= 100 || alpha !== 255) {
+    failures.push(
+      `full-page screenshot includes the bottom marker: ${JSON.stringify(markerPixel)}`,
+    );
+  }
+  const restoredScroll = await callBrowserTool(client, "browser_evaluate", {
+    browserId,
+    function: "() => ({ x: scrollX, y: scrollY })",
+  });
+  if (restoredScroll.resultJson !== '{"x":0,"y":0}') {
+    failures.push(`full-page screenshot restores page scroll: ${restoredScroll.resultJson}`);
+  }
+  return failures;
 }
 
 async function clickGuestElement(page, client, browserId, selector) {
@@ -455,6 +524,8 @@ async function runRegression({ page, client, serverId, targetUrl, callerAgentId 
     text: "Bridge target",
     timeoutMs: 5_000,
   });
+  failures.push(...(await collectFullPageScreenshotFailures(page, client, browserId)));
+
   const requestedViewport = { width: 640, height: 480 };
   await callBrowserTool(client, "browser_resize", { browserId, ...requestedViewport });
   recordViewportMismatch(

--- a/packages/desktop/e2e/browser-tabs.e2e.mjs
+++ b/packages/desktop/e2e/browser-tabs.e2e.mjs
@@ -366,8 +366,28 @@ async function readScreenshotPixel(page, input) {
   }, input);
 }
 
-async function collectFullPageScreenshotFailures(page, client, browserId) {
-  const failures = [];
+async function verifyFullPageScreenshot(page, client, browserId) {
+  const constraints = await callBrowserTool(client, "browser_evaluate", {
+    browserId,
+    function: `() => {
+      document.documentElement.style.scrollSnapType = "y mandatory";
+      document.body.style.overflow = "hidden";
+      globalThis.__paseoOriginalScrollTo = globalThis.scrollTo;
+      globalThis.scrollTo = () => {
+        (document.scrollingElement ?? document.documentElement).scrollTop = 0;
+      };
+      return {
+        snapType: document.documentElement.style.scrollSnapType,
+        overflow: document.body.style.overflow,
+        scrollToOverridden: globalThis.scrollTo !== globalThis.__paseoOriginalScrollTo
+      };
+    }`,
+  });
+  assert(
+    constraints.resultJson ===
+      '{"snapType":"y mandatory","overflow":"hidden","scrollToOverridden":true}',
+    `Full-page scroll constraints were not installed: ${constraints.resultJson}`,
+  );
   const screenshot = await callBrowserScreenshot(client, { browserId, fullPage: true });
   const scale = screenshot.height / 1600;
   const markerPixel = await readScreenshotPixel(page, {
@@ -380,19 +400,29 @@ async function collectFullPageScreenshotFailures(page, client, browserId) {
     `Full-page screenshot metadata did not match its PNG: ${JSON.stringify(markerPixel)}`,
   );
   const [red, green, blue, alpha] = markerPixel.rgba;
-  if (red >= 80 || green <= 200 || blue >= 100 || alpha !== 255) {
-    failures.push(
-      `full-page screenshot includes the bottom marker: ${JSON.stringify(markerPixel)}`,
-    );
-  }
+  assert(
+    red < 80 && green > 200 && blue < 100 && alpha === 255,
+    `Full-page screenshot did not include the bottom marker: ${JSON.stringify(markerPixel)}`,
+  );
   const restoredScroll = await callBrowserTool(client, "browser_evaluate", {
     browserId,
     function: "() => ({ x: scrollX, y: scrollY })",
   });
-  if (restoredScroll.resultJson !== '{"x":0,"y":0}') {
-    failures.push(`full-page screenshot restores page scroll: ${restoredScroll.resultJson}`);
-  }
-  return failures;
+  assert(
+    restoredScroll.resultJson === '{"x":0,"y":0}',
+    `Full-page screenshot did not restore page scroll: ${restoredScroll.resultJson}`,
+  );
+  const cleanup = await callBrowserTool(client, "browser_evaluate", {
+    browserId,
+    function: `() => {
+      globalThis.scrollTo = globalThis.__paseoOriginalScrollTo;
+      delete globalThis.__paseoOriginalScrollTo;
+      document.documentElement.style.removeProperty("scroll-snap-type");
+      document.body.style.removeProperty("overflow");
+      return true;
+    }`,
+  });
+  assert(cleanup.resultJson === "true", "Full-page test constraints were not removed");
 }
 
 async function clickGuestElement(page, client, browserId, selector) {
@@ -524,7 +554,7 @@ async function runRegression({ page, client, serverId, targetUrl, callerAgentId 
     text: "Bridge target",
     timeoutMs: 5_000,
   });
-  failures.push(...(await collectFullPageScreenshotFailures(page, client, browserId)));
+  await verifyFullPageScreenshot(page, client, browserId);
 
   const requestedViewport = { width: 640, height: 480 };
   await callBrowserTool(client, "browser_resize", { browserId, ...requestedViewport });

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "npm --prefix ../.. run build:server:clean && npm run build:main && electron-builder --config electron-builder.yml",
     "build:main": "tsc -p tsconfig.json",
-    "capture-harness": "./capture-harness/run.sh",
+    "capture-harness": "npm run build:main && ./capture-harness/run.sh",
     "dev": "./scripts/dev.sh",
     "dev:win": "powershell ./scripts/dev.ps1",
     "test:e2e:renderer": "cross-env E2E_DESKTOP_RUNTIME=1 playwright test --config=playwright.config.ts --project=desktop",

--- a/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+import {
+  captureFullPage,
+  type FullPageCaptureImage,
+  type FullPageCaptureTarget,
+} from "./full-page-capture.js";
+
+function solidBitmap(width: number, height: number, value: number): Uint8Array {
+  const bitmap = new Uint8Array(width * height * 4);
+  bitmap.fill(value);
+  return bitmap;
+}
+
+class FakeImage implements FullPageCaptureImage {
+  public constructor(
+    private readonly bitmap: Uint8Array,
+    private readonly size: { width: number; height: number },
+  ) {}
+
+  public getSize(): { width: number; height: number } {
+    return this.size;
+  }
+
+  public toBitmap(): Uint8Array {
+    return this.bitmap;
+  }
+
+  public toPNG(): Uint8Array {
+    return this.bitmap;
+  }
+}
+
+class FullPageCaptureHarness implements FullPageCaptureTarget {
+  public readonly scripts: string[] = [];
+  public readonly debugCommands: string[] = [];
+  public invalidations = 0;
+  public outputBitmap: Uint8Array | null = null;
+  public outputSize: { width: number; height: number } | null = null;
+  private captureIndex = 0;
+
+  public constructor(
+    private readonly contentSize: { width: number; height: number },
+    private readonly tiles: FullPageCaptureImage[],
+    private readonly scrollPosition: (x: number, y: number) => { x: number; y: number } = (
+      x,
+      y,
+    ) => ({ x, y }),
+  ) {}
+
+  public async executeJavaScript(code: string): Promise<unknown> {
+    this.scripts.push(code);
+    if (code.includes("viewportWidth: innerWidth")) {
+      return {
+        scrollX: 1,
+        scrollY: 1,
+        scrollBehavior: "smooth",
+        viewportWidth: 2,
+        viewportHeight: 2,
+      };
+    }
+    const scrollMatch = code.match(/scrollTo\((\d+), (\d+)\)/);
+    if (scrollMatch && code.includes("({ x: scrollX, y: scrollY })")) {
+      return this.scrollPosition(Number(scrollMatch[1]), Number(scrollMatch[2]));
+    }
+    return undefined;
+  }
+
+  public invalidate(): void {
+    this.invalidations += 1;
+  }
+
+  public async sendDebugCommand(command: string): Promise<unknown> {
+    this.debugCommands.push(command);
+    if (command === "Page.getLayoutMetrics") {
+      return { cssContentSize: this.contentSize };
+    }
+    if (command === "Page.captureScreenshot") {
+      return { data: `tile-${this.captureIndex++}` };
+    }
+    throw new Error(`Unexpected command: ${command}`);
+  }
+
+  public createImageFromPng(dataBase64: string): FullPageCaptureImage {
+    const index = Number(dataBase64.replace("tile-", ""));
+    const tile = this.tiles[index];
+    if (!tile) {
+      throw new Error(`Missing tile ${index}`);
+    }
+    return tile;
+  }
+
+  public createImageFromBitmap(
+    bitmap: Uint8Array,
+    size: { width: number; height: number },
+  ): FullPageCaptureImage {
+    this.outputBitmap = bitmap;
+    this.outputSize = size;
+    return new FakeImage(bitmap, size);
+  }
+}
+
+describe("captureFullPage", () => {
+  test("stitches successive viewport rows and restores the page scroll state", async () => {
+    const top = new FakeImage(solidBitmap(2, 2, 1), { width: 2, height: 2 });
+    const bottom = new FakeImage(solidBitmap(2, 2, 2), { width: 2, height: 2 });
+    const harness = new FullPageCaptureHarness({ width: 2, height: 4 }, [top, bottom]);
+
+    const image = await captureFullPage(harness);
+
+    expect(image.getSize()).toEqual({ width: 2, height: 4 });
+    expect(Array.from(image.toBitmap())).toEqual([...Array(16).fill(1), ...Array(16).fill(2)]);
+    expect(harness.debugCommands).toEqual([
+      "Page.getLayoutMetrics",
+      "Page.captureScreenshot",
+      "Page.captureScreenshot",
+    ]);
+    expect(harness.invalidations).toBe(2);
+    expect(harness.scripts.at(-2)).toContain(
+      'document.documentElement.style.scrollBehavior = "smooth"',
+    );
+    expect(harness.scripts.at(-2)).toContain("scrollTo(1, 1)");
+  });
+
+  test("crops the final tile when the browser clamps its scroll position", async () => {
+    const first = new FakeImage(solidBitmap(2, 2, 1), { width: 2, height: 2 });
+    const second = new FakeImage(solidBitmap(2, 2, 2), { width: 2, height: 2 });
+    const finalBitmap = new Uint8Array([...Array(8).fill(3), ...Array(8).fill(4)]);
+    const final = new FakeImage(finalBitmap, { width: 2, height: 2 });
+    const harness = new FullPageCaptureHarness(
+      { width: 2, height: 5 },
+      [first, second, final],
+      (x, y) => ({ x, y: Math.min(y, 3) }),
+    );
+
+    const image = await captureFullPage(harness);
+
+    expect(image.getSize()).toEqual({ width: 2, height: 5 });
+    expect(Array.from(image.toBitmap().slice(-8))).toEqual(Array(8).fill(4));
+  });
+});

--- a/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
@@ -115,10 +115,11 @@ describe("captureFullPage", () => {
       "Page.captureScreenshot",
     ]);
     expect(harness.invalidations).toBe(2);
-    expect(harness.scripts.at(-2)).toContain(
-      'document.documentElement.style.scrollBehavior = "smooth"',
+    const restoreScript = harness.scripts.at(-2) ?? "";
+    expect(restoreScript).toContain('document.documentElement.style.scrollBehavior = "smooth"');
+    expect(restoreScript.indexOf("scrollTo(1, 1)")).toBeLessThan(
+      restoreScript.indexOf('style.scrollBehavior = "smooth"'),
     );
-    expect(harness.scripts.at(-2)).toContain("scrollTo(1, 1)");
   });
 
   test("crops the final tile when the browser clamps its scroll position", async () => {
@@ -136,5 +137,15 @@ describe("captureFullPage", () => {
 
     expect(image.getSize()).toEqual({ width: 2, height: 5 });
     expect(Array.from(image.toBitmap().slice(-8))).toEqual(Array(8).fill(4));
+  });
+
+  test("restores the page after a tile capture fails", async () => {
+    const harness = new FullPageCaptureHarness({ width: 2, height: 2 }, []);
+
+    await expect(captureFullPage(harness)).rejects.toThrow("Missing tile 0");
+
+    const restoreScript = harness.scripts.at(-2) ?? "";
+    expect(restoreScript).toContain("scrollTo(1, 1)");
+    expect(restoreScript).toContain('document.documentElement.style.scrollBehavior = "smooth"');
   });
 });

--- a/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
@@ -53,14 +53,14 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
       return {
         scrollX: 1,
         scrollY: 1,
-        scrollBehavior: "smooth",
         viewportWidth: 2,
         viewportHeight: 2,
       };
     }
-    const scrollMatch = code.match(/scrollTo\((\d+), (\d+)\)/);
-    if (scrollMatch && code.includes("({ x: scrollX, y: scrollY })")) {
-      return this.scrollPosition(Number(scrollMatch[1]), Number(scrollMatch[2]));
+    const scrollXMatch = code.match(/scrollingElement\.scrollLeft = (-?\d+(?:\.\d+)?)/);
+    const scrollYMatch = code.match(/scrollingElement\.scrollTop = (-?\d+(?:\.\d+)?)/);
+    if (scrollXMatch && scrollYMatch && code.includes("return { x: scrollingElement.scrollLeft")) {
+      return this.scrollPosition(Number(scrollXMatch[1]), Number(scrollYMatch[1]));
     }
     return undefined;
   }
@@ -115,10 +115,19 @@ describe("captureFullPage", () => {
       "Page.captureScreenshot",
     ]);
     expect(harness.invalidations).toBe(2);
+    const preparationScript = harness.scripts[1] ?? "";
+    expect(preparationScript).toContain("scroll-snap-type: none !important");
+    expect(preparationScript).toContain("overflow: auto !important");
+    const captureScrollScript = harness.scripts.find((script) =>
+      script.includes("return { x: scrollingElement.scrollLeft"),
+    );
+    expect(captureScrollScript).toContain("scrollingElement.scrollTop = 0");
+    expect(captureScrollScript).not.toContain("scrollTo(");
     const restoreScript = harness.scripts.at(-2) ?? "";
-    expect(restoreScript).toContain('document.documentElement.style.scrollBehavior = "smooth"');
-    expect(restoreScript.indexOf("scrollTo(1, 1)")).toBeLessThan(
-      restoreScript.indexOf('style.scrollBehavior = "smooth"'),
+    expect(restoreScript).toContain("scrollingElement.scrollLeft = 1");
+    expect(restoreScript).toContain("scrollingElement.scrollTop = 1");
+    expect(restoreScript.indexOf("scrollingElement.scrollTop = 1")).toBeLessThan(
+      restoreScript.indexOf("?.remove()"),
     );
   });
 
@@ -145,7 +154,8 @@ describe("captureFullPage", () => {
     await expect(captureFullPage(harness)).rejects.toThrow("Missing tile 0");
 
     const restoreScript = harness.scripts.at(-2) ?? "";
-    expect(restoreScript).toContain("scrollTo(1, 1)");
-    expect(restoreScript).toContain('document.documentElement.style.scrollBehavior = "smooth"');
+    expect(restoreScript).toContain("scrollingElement.scrollLeft = 1");
+    expect(restoreScript).toContain("scrollingElement.scrollTop = 1");
+    expect(restoreScript).toContain("?.remove()");
   });
 });

--- a/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
@@ -60,12 +60,6 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
         viewportHeight: 2,
       };
     }
-    if (code.includes("requestAnimationFrame")) {
-      if (this.options.afterPaint) {
-        this.scroll = this.options.afterPaint(this.scroll);
-      }
-      return undefined;
-    }
     const scrollXMatch = code.match(/scrollingElement\.scrollLeft = (-?\d+(?:\.\d+)?)/);
     const scrollYMatch = code.match(/scrollingElement\.scrollTop = (-?\d+(?:\.\d+)?)/);
     if (scrollXMatch && scrollYMatch) {
@@ -86,6 +80,12 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
 
   public invalidate(): void {
     this.invalidations += 1;
+  }
+
+  public async waitForPaint(): Promise<void> {
+    if (this.options.afterPaint) {
+      this.scroll = this.options.afterPaint(this.scroll);
+    }
   }
 
   public async sendDebugCommand(command: string): Promise<unknown> {
@@ -138,11 +138,11 @@ describe("captureFullPage", () => {
 
     expect(captured.getSize()).toEqual({ width: 2, height: 4 });
     expect(Array.from(captured.toBitmap())).toEqual([...Array(16).fill(1), ...Array(16).fill(2)]);
-    expect(harness.invalidations).toBe(2);
+    expect(harness.invalidations).toBeGreaterThanOrEqual(2);
     expect(harness.scripts.some((script) => script.includes("position === 'fixed'"))).toBe(true);
     expect(harness.scripts.some((script) => script.includes("position', 'relative'"))).toBe(true);
     expect(harness.scripts.some((script) => script.includes("if (false)"))).toBe(true);
-    const restoreScript = harness.scripts.at(-2) ?? "";
+    const restoreScript = harness.scripts.at(-1) ?? "";
     expect(restoreScript).toContain("scrollingElement.scrollLeft = 1");
     expect(restoreScript).toContain("state.fixedElements");
     expect(restoreScript).toContain("state.stickyElements");
@@ -226,7 +226,7 @@ describe("captureFullPage", () => {
 
     await expect(captureFullPage(harness)).rejects.toThrow("Missing tile 0");
 
-    const restoreScript = harness.scripts.at(-2) ?? "";
+    const restoreScript = harness.scripts.at(-1) ?? "";
     expect(restoreScript).toContain("scrollingElement.scrollLeft = 1");
     expect(restoreScript).toContain("state.style.remove()");
   });

--- a/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from "node:vm";
 import { describe, expect, test } from "vitest";
 import {
   captureFullPage,
@@ -120,6 +121,82 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
   }
 }
 
+class FakeStyleDeclaration {
+  private readonly priorities = new Map<string, string>();
+  private readonly values = new Map<string, string>();
+
+  public constructor(initial: Record<string, string>) {
+    for (const [property, value] of Object.entries(initial)) {
+      this.values.set(property, value);
+    }
+  }
+
+  public getPropertyValue(property: string): string {
+    return this.values.get(property) ?? "";
+  }
+
+  public getPropertyPriority(property: string): string {
+    return this.priorities.get(property) ?? "";
+  }
+
+  public setProperty(property: string, value: string, priority = ""): void {
+    this.values.set(property, value);
+    if (priority) {
+      this.priorities.set(property, priority);
+    } else {
+      this.priorities.delete(property);
+    }
+  }
+
+  public removeProperty(property: string): void {
+    this.values.delete(property);
+    this.priorities.delete(property);
+  }
+}
+
+class FakePageElement {
+  public isConnected = true;
+  public readonly style = new FakeStyleDeclaration({ position: "sticky", top: "12px" });
+}
+
+class ScriptedPageCaptureHarness extends FullPageCaptureHarness {
+  public readonly sticky = new FakePageElement();
+  private readonly scriptContext: Record<string, unknown>;
+
+  public constructor(options: HarnessOptions) {
+    super(options);
+    const scrollingElement = { scrollLeft: 0, scrollTop: 0 };
+    this.scriptContext = {
+      document: {
+        scrollingElement,
+        documentElement: {
+          scrollLeft: 0,
+          scrollTop: 0,
+          appendChild: () => undefined,
+        },
+        createElement: () => ({ textContent: "", remove: () => undefined }),
+        querySelectorAll: () => [this.sticky],
+      },
+      getComputedStyle: (element: unknown) => ({
+        position: element === this.sticky ? "sticky" : "static",
+      }),
+    };
+  }
+
+  public override async executeJavaScript(code: string): Promise<unknown> {
+    const scripted = await super.executeJavaScript(code);
+    const isPageStateRead = code.includes("viewportWidth: innerWidth");
+    const isScrollRead = code.includes("return { x: scrollingElement.scrollLeft");
+    const isTileScrollWrite =
+      code.includes("scrollingElement.scrollLeft =") &&
+      !code.includes("restoreProperty(entry.element");
+    if (isPageStateRead || isScrollRead || isTileScrollWrite) {
+      return scripted;
+    }
+    return runInNewContext(code, this.scriptContext);
+  }
+}
+
 function image(width: number, height: number, value: number): FakeImage {
   return new FakeImage(solidBitmap(width, height, value), { width, height });
 }
@@ -147,6 +224,27 @@ describe("captureFullPage", () => {
     expect(restoreScript).toContain("state.fixedElements");
     expect(restoreScript).toContain("state.stickyElements");
     expect(restoreScript).toContain("state.style.remove()");
+  });
+
+  test("restores inline styles on elements detached during capture", async () => {
+    let sticky: FakePageElement | undefined;
+    const harness = new ScriptedPageCaptureHarness({
+      contentSizes: [{ width: 2, height: 2 }],
+      tiles: [image(2, 2, 1)],
+      afterPaint: (position) => {
+        if (sticky) {
+          sticky.isConnected = false;
+        }
+        return position;
+      },
+    });
+    sticky = harness.sticky;
+
+    await captureFullPage(harness);
+
+    expect(harness.sticky.isConnected).toBe(false);
+    expect(harness.sticky.style.getPropertyValue("position")).toBe("sticky");
+    expect(harness.sticky.style.getPropertyValue("top")).toBe("12px");
   });
 
   test("crops the final tile when the browser clamps its scroll position", async () => {

--- a/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   captureFullPage,
+  FullPageCaptureUnsupportedError,
   type FullPageCaptureImage,
   type FullPageCaptureTarget,
 } from "./full-page-capture.js";
@@ -30,6 +31,13 @@ class FakeImage implements FullPageCaptureImage {
   }
 }
 
+interface HarnessOptions {
+  contentSizes: { width: number; height: number }[];
+  tiles: FullPageCaptureImage[];
+  scrollPosition?: (x: number, y: number) => { x: number; y: number };
+  afterPaint?: (position: { x: number; y: number }) => { x: number; y: number };
+}
+
 class FullPageCaptureHarness implements FullPageCaptureTarget {
   public readonly scripts: string[] = [];
   public readonly debugCommands: string[] = [];
@@ -37,15 +45,10 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
   public outputBitmap: Uint8Array | null = null;
   public outputSize: { width: number; height: number } | null = null;
   private captureIndex = 0;
+  private metricsIndex = 0;
+  private scroll = { x: 1, y: 1 };
 
-  public constructor(
-    private readonly contentSize: { width: number; height: number },
-    private readonly tiles: FullPageCaptureImage[],
-    private readonly scrollPosition: (x: number, y: number) => { x: number; y: number } = (
-      x,
-      y,
-    ) => ({ x, y }),
-  ) {}
+  public constructor(private readonly options: HarnessOptions) {}
 
   public async executeJavaScript(code: string): Promise<unknown> {
     this.scripts.push(code);
@@ -57,10 +60,26 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
         viewportHeight: 2,
       };
     }
+    if (code.includes("requestAnimationFrame")) {
+      if (this.options.afterPaint) {
+        this.scroll = this.options.afterPaint(this.scroll);
+      }
+      return undefined;
+    }
     const scrollXMatch = code.match(/scrollingElement\.scrollLeft = (-?\d+(?:\.\d+)?)/);
     const scrollYMatch = code.match(/scrollingElement\.scrollTop = (-?\d+(?:\.\d+)?)/);
-    if (scrollXMatch && scrollYMatch && code.includes("return { x: scrollingElement.scrollLeft")) {
-      return this.scrollPosition(Number(scrollXMatch[1]), Number(scrollYMatch[1]));
+    if (scrollXMatch && scrollYMatch) {
+      const requested = {
+        x: Number(scrollXMatch[1]),
+        y: Number(scrollYMatch[1]),
+      };
+      this.scroll = this.options.scrollPosition
+        ? this.options.scrollPosition(requested.x, requested.y)
+        : requested;
+      return undefined;
+    }
+    if (code.includes("return { x: scrollingElement.scrollLeft")) {
+      return this.scroll;
     }
     return undefined;
   }
@@ -72,7 +91,9 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
   public async sendDebugCommand(command: string): Promise<unknown> {
     this.debugCommands.push(command);
     if (command === "Page.getLayoutMetrics") {
-      return { cssContentSize: this.contentSize };
+      const index = Math.min(this.metricsIndex, this.options.contentSizes.length - 1);
+      this.metricsIndex += 1;
+      return { cssContentSize: this.options.contentSizes[index] };
     }
     if (command === "Page.captureScreenshot") {
       return { data: `tile-${this.captureIndex++}` };
@@ -82,7 +103,7 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
 
   public createImageFromPng(dataBase64: string): FullPageCaptureImage {
     const index = Number(dataBase64.replace("tile-", ""));
-    const tile = this.tiles[index];
+    const tile = this.options.tiles[index];
     if (!tile) {
       throw new Error(`Missing tile ${index}`);
     }
@@ -99,63 +120,114 @@ class FullPageCaptureHarness implements FullPageCaptureTarget {
   }
 }
 
+function image(width: number, height: number, value: number): FakeImage {
+  return new FakeImage(solidBitmap(width, height, value), { width, height });
+}
+
 describe("captureFullPage", () => {
-  test("stitches successive viewport rows and restores the page scroll state", async () => {
-    const top = new FakeImage(solidBitmap(2, 2, 1), { width: 2, height: 2 });
-    const bottom = new FakeImage(solidBitmap(2, 2, 2), { width: 2, height: 2 });
-    const harness = new FullPageCaptureHarness({ width: 2, height: 4 }, [top, bottom]);
+  test("stitches successive viewport rows and restores temporary page state", async () => {
+    const harness = new FullPageCaptureHarness({
+      contentSizes: [
+        { width: 2, height: 4 },
+        { width: 2, height: 4 },
+      ],
+      tiles: [image(2, 2, 1), image(2, 2, 2)],
+    });
 
-    const image = await captureFullPage(harness);
+    const captured = await captureFullPage(harness);
 
-    expect(image.getSize()).toEqual({ width: 2, height: 4 });
-    expect(Array.from(image.toBitmap())).toEqual([...Array(16).fill(1), ...Array(16).fill(2)]);
-    expect(harness.debugCommands).toEqual([
-      "Page.getLayoutMetrics",
-      "Page.captureScreenshot",
-      "Page.captureScreenshot",
-    ]);
+    expect(captured.getSize()).toEqual({ width: 2, height: 4 });
+    expect(Array.from(captured.toBitmap())).toEqual([...Array(16).fill(1), ...Array(16).fill(2)]);
     expect(harness.invalidations).toBe(2);
-    const preparationScript = harness.scripts[1] ?? "";
-    expect(preparationScript).toContain("scroll-snap-type: none !important");
-    expect(preparationScript).toContain("overflow: auto !important");
-    const captureScrollScript = harness.scripts.find((script) =>
-      script.includes("return { x: scrollingElement.scrollLeft"),
-    );
-    expect(captureScrollScript).toContain("scrollingElement.scrollTop = 0");
-    expect(captureScrollScript).not.toContain("scrollTo(");
+    expect(harness.scripts.some((script) => script.includes("position === 'fixed'"))).toBe(true);
+    expect(harness.scripts.some((script) => script.includes("position', 'relative'"))).toBe(true);
+    expect(harness.scripts.some((script) => script.includes("if (false)"))).toBe(true);
     const restoreScript = harness.scripts.at(-2) ?? "";
     expect(restoreScript).toContain("scrollingElement.scrollLeft = 1");
-    expect(restoreScript).toContain("scrollingElement.scrollTop = 1");
-    expect(restoreScript.indexOf("scrollingElement.scrollTop = 1")).toBeLessThan(
-      restoreScript.indexOf("?.remove()"),
-    );
+    expect(restoreScript).toContain("state.fixedElements");
+    expect(restoreScript).toContain("state.stickyElements");
+    expect(restoreScript).toContain("state.style.remove()");
   });
 
   test("crops the final tile when the browser clamps its scroll position", async () => {
-    const first = new FakeImage(solidBitmap(2, 2, 1), { width: 2, height: 2 });
-    const second = new FakeImage(solidBitmap(2, 2, 2), { width: 2, height: 2 });
     const finalBitmap = new Uint8Array([...Array(8).fill(3), ...Array(8).fill(4)]);
-    const final = new FakeImage(finalBitmap, { width: 2, height: 2 });
-    const harness = new FullPageCaptureHarness(
-      { width: 2, height: 5 },
-      [first, second, final],
-      (x, y) => ({ x, y: Math.min(y, 3) }),
+    const harness = new FullPageCaptureHarness({
+      contentSizes: [
+        { width: 2, height: 5 },
+        { width: 2, height: 5 },
+      ],
+      tiles: [image(2, 2, 1), image(2, 2, 2), new FakeImage(finalBitmap, { width: 2, height: 2 })],
+      scrollPosition: (x, y) => ({ x, y: Math.min(y, 3) }),
+    });
+
+    const captured = await captureFullPage(harness);
+
+    expect(captured.getSize()).toEqual({ width: 2, height: 5 });
+    expect(Array.from(captured.toBitmap().slice(-8))).toEqual(Array(8).fill(4));
+  });
+
+  test("rejects a page that asynchronously redirects the requested scroll", async () => {
+    const harness = new FullPageCaptureHarness({
+      contentSizes: [{ width: 2, height: 4 }],
+      tiles: [image(2, 2, 1)],
+      afterPaint: (position) => ({ x: position.x, y: position.y > 0 ? 0 : position.y }),
+    });
+
+    await expect(captureFullPage(harness)).rejects.toThrow(
+      "stable scroll position for full-page capture",
     );
 
-    const image = await captureFullPage(harness);
+    expect(
+      harness.debugCommands.filter((command) => command === "Page.captureScreenshot"),
+    ).toHaveLength(1);
+  });
 
-    expect(image.getSize()).toEqual({ width: 2, height: 5 });
-    expect(Array.from(image.toBitmap().slice(-8))).toEqual(Array(8).fill(4));
+  test("recaptures when scrolling expands the document", async () => {
+    const harness = new FullPageCaptureHarness({
+      contentSizes: [
+        { width: 2, height: 4 },
+        { width: 2, height: 6 },
+        { width: 2, height: 6 },
+      ],
+      tiles: [image(2, 2, 1), image(2, 2, 2), image(2, 2, 3), image(2, 2, 4), image(2, 2, 5)],
+    });
+
+    const captured = await captureFullPage(harness);
+
+    expect(captured.getSize()).toEqual({ width: 2, height: 6 });
+    expect(Array.from(captured.toBitmap())).toEqual([
+      ...Array(16).fill(3),
+      ...Array(16).fill(4),
+      ...Array(16).fill(5),
+    ]);
+  });
+
+  test("rejects captures that exceed tile or bitmap limits", async () => {
+    const tooManyTiles = new FullPageCaptureHarness({
+      contentSizes: [{ width: 2, height: 258 }],
+      tiles: [],
+    });
+    await expect(captureFullPage(tooManyTiles)).rejects.toBeInstanceOf(
+      FullPageCaptureUnsupportedError,
+    );
+
+    const oversizedBitmap = new FullPageCaptureHarness({
+      contentSizes: [{ width: 2, height: 2 }],
+      tiles: [new FakeImage(new Uint8Array(), { width: 10_000, height: 10_000 })],
+    });
+    await expect(captureFullPage(oversizedBitmap)).rejects.toThrow("maximum is 128 MiB");
   });
 
   test("restores the page after a tile capture fails", async () => {
-    const harness = new FullPageCaptureHarness({ width: 2, height: 2 }, []);
+    const harness = new FullPageCaptureHarness({
+      contentSizes: [{ width: 2, height: 2 }],
+      tiles: [],
+    });
 
     await expect(captureFullPage(harness)).rejects.toThrow("Missing tile 0");
 
     const restoreScript = harness.scripts.at(-2) ?? "";
     expect(restoreScript).toContain("scrollingElement.scrollLeft = 1");
-    expect(restoreScript).toContain("scrollingElement.scrollTop = 1");
-    expect(restoreScript).toContain("?.remove()");
+    expect(restoreScript).toContain("state.style.remove()");
   });
 });

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -305,6 +305,7 @@ async function captureViewportTile(input: {
       input.captureToken,
       input.position.x === 0 && input.position.y === 0,
     );
+    throwIfAborted(input.signal);
     await setGuestScroll(input.target, input.position);
     await waitForGuestPaint(input.target, input.signal);
     const actualScroll = await readGuestScroll(input.target);
@@ -439,6 +440,7 @@ export async function captureFullPage(
   target: FullPageCaptureTarget,
   options: FullPageCaptureOptions = {},
 ): Promise<FullPageCaptureImage> {
+  throwIfAborted(options.signal);
   const captureToken = `__paseoFullPageCapture_${randomUUID().replaceAll("-", "")}`;
   const originalState = readPageCaptureState(
     await target.executeJavaScript(`({
@@ -450,6 +452,7 @@ export async function captureFullPage(
   );
   let image: FullPageCaptureImage | undefined;
   let captureError: unknown;
+  let captureFailed = false;
 
   try {
     throwIfAborted(options.signal);
@@ -503,9 +506,11 @@ export async function captureFullPage(
     image = target.createImageFromBitmap(capture.bitmap, capture.size);
   } catch (error) {
     captureError = error;
+    captureFailed = true;
   }
 
   let cleanupError: unknown;
+  let cleanupFailed = false;
   try {
     await target.executeJavaScript(`(() => {
         const state = globalThis[${JSON.stringify(captureToken)}];
@@ -536,12 +541,13 @@ export async function captureFullPage(
     }
   } catch (error) {
     cleanupError = error;
+    cleanupFailed = true;
   }
 
-  if (captureError) {
+  if (captureFailed) {
     throw captureError;
   }
-  if (cleanupError) {
+  if (cleanupFailed) {
     throw cleanupError;
   }
   if (!image) {

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -539,9 +539,7 @@ export async function captureFullPage(
         delete globalThis[${JSON.stringify(captureToken)}];
         return true;
       })()`);
-    if (!options.signal?.aborted) {
-      await waitForGuestPaint(target, options.signal);
-    }
+    await waitForGuestPaint(target, undefined);
   } catch (error) {
     cleanupError = error;
     cleanupFailed = true;

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -271,8 +271,8 @@ export async function captureFullPage(
     await target.executeJavaScript(`
       globalThis[${JSON.stringify(captureToken)}]?.remove();
       delete globalThis[${JSON.stringify(captureToken)}];
-      document.documentElement.style.scrollBehavior = ${JSON.stringify(originalState.scrollBehavior)};
       scrollTo(${originalState.scrollX}, ${originalState.scrollY});
+      document.documentElement.style.scrollBehavior = ${JSON.stringify(originalState.scrollBehavior)};
     `);
     await waitForGuestPaint(target);
   }

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from "node:crypto";
+
+export interface FullPageCaptureImage {
+  getSize(): { width: number; height: number };
+  toBitmap(): Uint8Array;
+  toPNG(): Uint8Array;
+}
+
+export interface FullPageCaptureTarget {
+  executeJavaScript(code: string): Promise<unknown>;
+  invalidate(): void;
+  sendDebugCommand(command: string, params?: Record<string, unknown>): Promise<unknown>;
+  createImageFromPng(dataBase64: string): FullPageCaptureImage;
+  createImageFromBitmap(
+    bitmap: Uint8Array,
+    size: { width: number; height: number },
+  ): FullPageCaptureImage;
+}
+
+interface PageCaptureState {
+  scrollX: number;
+  scrollY: number;
+  scrollBehavior: string;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+interface PageContentSize {
+  width: number;
+  height: number;
+}
+
+interface PixelScale {
+  x: number;
+  y: number;
+}
+
+export class FullPageCaptureError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "FullPageCaptureError";
+  }
+}
+
+function readRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    throw new FullPageCaptureError(`${label} returned invalid data`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function readFiniteNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new FullPageCaptureError(`${label} returned an invalid number`);
+  }
+  return value;
+}
+
+function readPositiveDimension(value: unknown, label: string): number {
+  const dimension = Math.ceil(readFiniteNumber(value, label));
+  if (dimension <= 0) {
+    throw new FullPageCaptureError(`${label} returned a non-positive dimension`);
+  }
+  return dimension;
+}
+
+function readPageCaptureState(value: unknown): PageCaptureState {
+  const state = readRecord(value, "Browser page state");
+  return {
+    scrollX: readFiniteNumber(state.scrollX, "Browser scrollX"),
+    scrollY: readFiniteNumber(state.scrollY, "Browser scrollY"),
+    scrollBehavior: typeof state.scrollBehavior === "string" ? state.scrollBehavior : "",
+    viewportWidth: readPositiveDimension(state.viewportWidth, "Browser viewport width"),
+    viewportHeight: readPositiveDimension(state.viewportHeight, "Browser viewport height"),
+  };
+}
+
+function readScrollPosition(value: unknown): { x: number; y: number } {
+  const position = readRecord(value, "Browser scroll position");
+  return {
+    x: readFiniteNumber(position.x, "Browser scroll x"),
+    y: readFiniteNumber(position.y, "Browser scroll y"),
+  };
+}
+
+function readContentSize(value: unknown): PageContentSize {
+  const metrics = readRecord(value, "Page.getLayoutMetrics");
+  const content = readRecord(metrics.cssContentSize ?? metrics.contentSize, "Page content size");
+  return {
+    width: readPositiveDimension(content.width, "Page content width"),
+    height: readPositiveDimension(content.height, "Page content height"),
+  };
+}
+
+function readScreenshotData(value: unknown): string {
+  const screenshot = readRecord(value, "Page.captureScreenshot");
+  if (typeof screenshot.data !== "string" || screenshot.data.length === 0) {
+    throw new FullPageCaptureError("Page.captureScreenshot returned no data");
+  }
+  return screenshot.data;
+}
+
+function tileOrigins(total: number, viewport: number): number[] {
+  const origins: number[] = [];
+  for (let origin = 0; origin < total; origin += viewport) {
+    origins.push(origin);
+  }
+  return origins;
+}
+
+function copyTile(input: {
+  output: Uint8Array;
+  outputWidth: number;
+  content: PageContentSize;
+  viewport: { width: number; height: number };
+  target: { x: number; y: number };
+  actualScroll: { x: number; y: number };
+  tile: FullPageCaptureImage;
+  scale: PixelScale;
+}): void {
+  const tileSize = input.tile.getSize();
+  const targetLeft = Math.round(input.target.x * input.scale.x);
+  const targetTop = Math.round(input.target.y * input.scale.y);
+  const targetRight = Math.round(
+    Math.min(input.target.x + input.viewport.width, input.content.width) * input.scale.x,
+  );
+  const targetBottom = Math.round(
+    Math.min(input.target.y + input.viewport.height, input.content.height) * input.scale.y,
+  );
+  const copyWidth = targetRight - targetLeft;
+  const copyHeight = targetBottom - targetTop;
+  const sourceLeft = Math.round((input.target.x - input.actualScroll.x) * input.scale.x);
+  const sourceTop = Math.round((input.target.y - input.actualScroll.y) * input.scale.y);
+  if (
+    sourceLeft < 0 ||
+    sourceTop < 0 ||
+    sourceLeft + copyWidth > tileSize.width ||
+    sourceTop + copyHeight > tileSize.height
+  ) {
+    throw new FullPageCaptureError("Full-page tile does not cover its target region");
+  }
+
+  const bitmap = input.tile.toBitmap();
+  if (bitmap.length < tileSize.width * tileSize.height * 4) {
+    throw new FullPageCaptureError("Full-page tile returned an incomplete bitmap");
+  }
+  for (let row = 0; row < copyHeight; row += 1) {
+    const sourceOffset = ((sourceTop + row) * tileSize.width + sourceLeft) * 4;
+    const targetOffset = ((targetTop + row) * input.outputWidth + targetLeft) * 4;
+    input.output.set(bitmap.subarray(sourceOffset, sourceOffset + copyWidth * 4), targetOffset);
+  }
+}
+
+async function waitForGuestPaint(target: FullPageCaptureTarget): Promise<void> {
+  await target.executeJavaScript(`new Promise((resolve) => {
+    let resolved = false;
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      resolve();
+    };
+    requestAnimationFrame(() => requestAnimationFrame(finish));
+    setTimeout(finish, 100);
+  })`);
+}
+
+async function captureTiles(
+  target: FullPageCaptureTarget,
+  viewport: { width: number; height: number },
+): Promise<{ bitmap: Uint8Array; size: { width: number; height: number } }> {
+  const content = readContentSize(await target.sendDebugCommand("Page.getLayoutMetrics"));
+  const targetXs = tileOrigins(content.width, viewport.width);
+  const targetYs = tileOrigins(content.height, viewport.height);
+  let output: Uint8Array | null = null;
+  let outputSize = { width: 0, height: 0 };
+  let scale: PixelScale | null = null;
+
+  for (const y of targetYs) {
+    for (const x of targetXs) {
+      const actualScroll = readScrollPosition(
+        await target.executeJavaScript(`scrollTo(${x}, ${y}); ({ x: scrollX, y: scrollY })`),
+      );
+      await waitForGuestPaint(target);
+      target.invalidate();
+      const dataBase64 = readScreenshotData(
+        await target.sendDebugCommand("Page.captureScreenshot", {
+          format: "png",
+          captureBeyondViewport: false,
+        }),
+      );
+      const tile = target.createImageFromPng(dataBase64);
+      const tileSize = tile.getSize();
+      if (!scale) {
+        scale = {
+          x: tileSize.width / viewport.width,
+          y: tileSize.height / viewport.height,
+        };
+        if (
+          !Number.isFinite(scale.x) ||
+          !Number.isFinite(scale.y) ||
+          scale.x <= 0 ||
+          scale.y <= 0 ||
+          Math.abs(scale.x - scale.y) > 0.01
+        ) {
+          throw new FullPageCaptureError("Full-page tile returned an invalid pixel scale");
+        }
+        outputSize = {
+          width: Math.round(content.width * scale.x),
+          height: Math.round(content.height * scale.y),
+        };
+        output = new Uint8Array(outputSize.width * outputSize.height * 4);
+      }
+      if (!output || !scale) {
+        throw new FullPageCaptureError("Full-page capture did not initialize its bitmap");
+      }
+      if (
+        tileSize.width !== Math.round(viewport.width * scale.x) ||
+        tileSize.height !== Math.round(viewport.height * scale.y)
+      ) {
+        throw new FullPageCaptureError("Full-page tile dimensions changed during capture");
+      }
+      copyTile({
+        output,
+        outputWidth: outputSize.width,
+        content,
+        viewport,
+        target: { x, y },
+        actualScroll,
+        tile,
+        scale,
+      });
+    }
+  }
+
+  if (!output) {
+    throw new FullPageCaptureError("Full-page capture produced no tiles");
+  }
+  return { bitmap: output, size: outputSize };
+}
+
+export async function captureFullPage(
+  target: FullPageCaptureTarget,
+): Promise<FullPageCaptureImage> {
+  const captureToken = `__paseoFullPageCapture_${randomUUID().replaceAll("-", "")}`;
+  const originalState = readPageCaptureState(
+    await target.executeJavaScript(`({
+      scrollX,
+      scrollY,
+      scrollBehavior: document.documentElement.style.scrollBehavior,
+      viewportWidth: innerWidth,
+      viewportHeight: innerHeight
+    })`),
+  );
+
+  try {
+    await target.executeJavaScript(`(() => {
+      const style = document.createElement('style');
+      style.textContent = '::-webkit-scrollbar { display: none !important; }';
+      document.documentElement.appendChild(style);
+      globalThis[${JSON.stringify(captureToken)}] = style;
+      document.documentElement.style.scrollBehavior = 'auto';
+    })()`);
+    await waitForGuestPaint(target);
+
+    const capture = await captureTiles(target, {
+      width: originalState.viewportWidth,
+      height: originalState.viewportHeight,
+    });
+    return target.createImageFromBitmap(capture.bitmap, capture.size);
+  } finally {
+    await target.executeJavaScript(`
+      globalThis[${JSON.stringify(captureToken)}]?.remove();
+      delete globalThis[${JSON.stringify(captureToken)}];
+      document.documentElement.style.scrollBehavior = ${JSON.stringify(originalState.scrollBehavior)};
+      scrollTo(${originalState.scrollX}, ${originalState.scrollY});
+    `);
+    await waitForGuestPaint(target);
+  }
+}

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -519,7 +519,6 @@ export async function captureFullPage(
         const state = globalThis[${JSON.stringify(captureToken)}];
         if (!state) return false;
         const restoreProperty = (element, snapshot) => {
-          if (!element.isConnected) return;
           if (snapshot.value) {
             element.style.setProperty(snapshot.property, snapshot.value, snapshot.priority);
           } else {

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { z, type ZodType } from "zod";
 
 export interface FullPageCaptureImage {
   getSize(): { width: number; height: number };
@@ -17,18 +18,30 @@ export interface FullPageCaptureTarget {
   ): FullPageCaptureImage;
 }
 
-interface PageCaptureState {
-  scrollX: number;
-  scrollY: number;
-  scrollBehavior: string;
-  viewportWidth: number;
-  viewportHeight: number;
-}
+const FiniteNumberSchema = z.number().finite();
+const PositiveDimensionSchema = FiniteNumberSchema.positive().transform(Math.ceil);
+const PageCaptureStateSchema = z.object({
+  scrollX: FiniteNumberSchema,
+  scrollY: FiniteNumberSchema,
+  viewportWidth: PositiveDimensionSchema,
+  viewportHeight: PositiveDimensionSchema,
+});
+const ScrollPositionSchema = z.object({
+  x: FiniteNumberSchema,
+  y: FiniteNumberSchema,
+});
+const PageContentSizeSchema = z.object({
+  width: PositiveDimensionSchema,
+  height: PositiveDimensionSchema,
+});
+const LayoutMetricsSchema = z.object({
+  cssContentSize: PageContentSizeSchema.optional(),
+  contentSize: PageContentSizeSchema.optional(),
+});
+const ScreenshotResultSchema = z.object({ data: z.string().min(1) });
 
-interface PageContentSize {
-  width: number;
-  height: number;
-}
+type PageCaptureState = z.output<typeof PageCaptureStateSchema>;
+type PageContentSize = z.output<typeof PageContentSizeSchema>;
 
 interface PixelScale {
   x: number;
@@ -42,62 +55,33 @@ export class FullPageCaptureError extends Error {
   }
 }
 
-function readRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object") {
+function parseBoundary<T>(schema: ZodType<T>, value: unknown, label: string): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
     throw new FullPageCaptureError(`${label} returned invalid data`);
   }
-  return value as Record<string, unknown>;
-}
-
-function readFiniteNumber(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new FullPageCaptureError(`${label} returned an invalid number`);
-  }
-  return value;
-}
-
-function readPositiveDimension(value: unknown, label: string): number {
-  const dimension = Math.ceil(readFiniteNumber(value, label));
-  if (dimension <= 0) {
-    throw new FullPageCaptureError(`${label} returned a non-positive dimension`);
-  }
-  return dimension;
+  return parsed.data;
 }
 
 function readPageCaptureState(value: unknown): PageCaptureState {
-  const state = readRecord(value, "Browser page state");
-  return {
-    scrollX: readFiniteNumber(state.scrollX, "Browser scrollX"),
-    scrollY: readFiniteNumber(state.scrollY, "Browser scrollY"),
-    scrollBehavior: typeof state.scrollBehavior === "string" ? state.scrollBehavior : "",
-    viewportWidth: readPositiveDimension(state.viewportWidth, "Browser viewport width"),
-    viewportHeight: readPositiveDimension(state.viewportHeight, "Browser viewport height"),
-  };
+  return parseBoundary(PageCaptureStateSchema, value, "Browser page state");
 }
 
 function readScrollPosition(value: unknown): { x: number; y: number } {
-  const position = readRecord(value, "Browser scroll position");
-  return {
-    x: readFiniteNumber(position.x, "Browser scroll x"),
-    y: readFiniteNumber(position.y, "Browser scroll y"),
-  };
+  return parseBoundary(ScrollPositionSchema, value, "Browser scroll position");
 }
 
 function readContentSize(value: unknown): PageContentSize {
-  const metrics = readRecord(value, "Page.getLayoutMetrics");
-  const content = readRecord(metrics.cssContentSize ?? metrics.contentSize, "Page content size");
-  return {
-    width: readPositiveDimension(content.width, "Page content width"),
-    height: readPositiveDimension(content.height, "Page content height"),
-  };
+  const metrics = parseBoundary(LayoutMetricsSchema, value, "Page.getLayoutMetrics");
+  const content = metrics.cssContentSize ?? metrics.contentSize;
+  if (!content) {
+    throw new FullPageCaptureError("Page.getLayoutMetrics returned no content size");
+  }
+  return content;
 }
 
 function readScreenshotData(value: unknown): string {
-  const screenshot = readRecord(value, "Page.captureScreenshot");
-  if (typeof screenshot.data !== "string" || screenshot.data.length === 0) {
-    throw new FullPageCaptureError("Page.captureScreenshot returned no data");
-  }
-  return screenshot.data;
+  return parseBoundary(ScreenshotResultSchema, value, "Page.captureScreenshot").data;
 }
 
 function tileOrigins(total: number, viewport: number): number[] {
@@ -164,6 +148,20 @@ async function waitForGuestPaint(target: FullPageCaptureTarget): Promise<void> {
   })`);
 }
 
+async function scrollGuest(
+  target: FullPageCaptureTarget,
+  position: { x: number; y: number },
+): Promise<{ x: number; y: number }> {
+  return readScrollPosition(
+    await target.executeJavaScript(`(() => {
+      const scrollingElement = document.scrollingElement ?? document.documentElement;
+      scrollingElement.scrollLeft = ${position.x};
+      scrollingElement.scrollTop = ${position.y};
+      return { x: scrollingElement.scrollLeft, y: scrollingElement.scrollTop };
+    })()`),
+  );
+}
+
 async function captureTiles(
   target: FullPageCaptureTarget,
   viewport: { width: number; height: number },
@@ -177,9 +175,7 @@ async function captureTiles(
 
   for (const y of targetYs) {
     for (const x of targetXs) {
-      const actualScroll = readScrollPosition(
-        await target.executeJavaScript(`scrollTo(${x}, ${y}); ({ x: scrollX, y: scrollY })`),
-      );
+      const actualScroll = await scrollGuest(target, { x, y });
       await waitForGuestPaint(target);
       target.invalidate();
       const dataBase64 = readScreenshotData(
@@ -246,7 +242,6 @@ export async function captureFullPage(
     await target.executeJavaScript(`({
       scrollX,
       scrollY,
-      scrollBehavior: document.documentElement.style.scrollBehavior,
       viewportWidth: innerWidth,
       viewportHeight: innerHeight
     })`),
@@ -255,10 +250,13 @@ export async function captureFullPage(
   try {
     await target.executeJavaScript(`(() => {
       const style = document.createElement('style');
-      style.textContent = '::-webkit-scrollbar { display: none !important; }';
+      style.textContent = [
+        ':root { overflow: auto !important; overflow-anchor: none !important; scroll-behavior: auto !important; scroll-snap-type: none !important; }',
+        'body { overflow: visible !important; overflow-anchor: none !important; scroll-behavior: auto !important; scroll-snap-type: none !important; }',
+        '::-webkit-scrollbar { display: none !important; }'
+      ].join(' ');
       document.documentElement.appendChild(style);
       globalThis[${JSON.stringify(captureToken)}] = style;
-      document.documentElement.style.scrollBehavior = 'auto';
     })()`);
     await waitForGuestPaint(target);
 
@@ -268,12 +266,16 @@ export async function captureFullPage(
     });
     return target.createImageFromBitmap(capture.bitmap, capture.size);
   } finally {
-    await target.executeJavaScript(`
-      globalThis[${JSON.stringify(captureToken)}]?.remove();
-      delete globalThis[${JSON.stringify(captureToken)}];
-      scrollTo(${originalState.scrollX}, ${originalState.scrollY});
-      document.documentElement.style.scrollBehavior = ${JSON.stringify(originalState.scrollBehavior)};
-    `);
+    await target.executeJavaScript(`(() => {
+      const scrollingElement = document.scrollingElement ?? document.documentElement;
+      try {
+        scrollingElement.scrollLeft = ${originalState.scrollX};
+        scrollingElement.scrollTop = ${originalState.scrollY};
+      } finally {
+        globalThis[${JSON.stringify(captureToken)}]?.remove();
+        delete globalThis[${JSON.stringify(captureToken)}];
+      }
+    })()`);
     await waitForGuestPaint(target);
   }
 }

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -18,6 +18,10 @@ export interface FullPageCaptureTarget {
   ): FullPageCaptureImage;
 }
 
+export interface FullPageCaptureOptions {
+  signal?: AbortSignal;
+}
+
 const FiniteNumberSchema = z.number().finite();
 const PositiveDimensionSchema = FiniteNumberSchema.positive().transform(Math.ceil);
 const PageCaptureStateSchema = z.object({
@@ -48,10 +52,29 @@ interface PixelScale {
   y: number;
 }
 
+interface CapturedBitmap {
+  bitmap: Uint8Array;
+  size: { width: number; height: number };
+  content: PageContentSize;
+}
+
+const MAX_FULL_PAGE_BITMAP_BYTES = 128 * 1024 * 1024;
+const MAX_FULL_PAGE_TILES = 128;
+const MAX_LAYOUT_PASSES = 3;
+const MAX_TILE_SCROLL_ATTEMPTS = 3;
+const SCROLL_EPSILON = 1;
+
 export class FullPageCaptureError extends Error {
   public constructor(message: string) {
     super(message);
     this.name = "FullPageCaptureError";
+  }
+}
+
+export class FullPageCaptureUnsupportedError extends FullPageCaptureError {
+  public constructor(message: string) {
+    super(message);
+    this.name = "FullPageCaptureUnsupportedError";
   }
 }
 
@@ -84,12 +107,56 @@ function readScreenshotData(value: unknown): string {
   return parseBoundary(ScreenshotResultSchema, value, "Page.captureScreenshot").data;
 }
 
-function tileOrigins(total: number, viewport: number): number[] {
-  const origins: number[] = [];
-  for (let origin = 0; origin < total; origin += viewport) {
-    origins.push(origin);
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return;
   }
-  return origins;
+  if (signal.reason instanceof Error) {
+    throw signal.reason;
+  }
+  throw new FullPageCaptureError("Full-page capture was aborted");
+}
+
+function tileOrigins(
+  content: PageContentSize,
+  viewport: { width: number; height: number },
+): { x: number[]; y: number[] } {
+  const columns = Math.ceil(content.width / viewport.width);
+  const rows = Math.ceil(content.height / viewport.height);
+  const tileCount = columns * rows;
+  if (!Number.isSafeInteger(tileCount) || tileCount > MAX_FULL_PAGE_TILES) {
+    throw new FullPageCaptureUnsupportedError(
+      `Full-page screenshot requires ${tileCount} tiles; the maximum is ${MAX_FULL_PAGE_TILES}.`,
+    );
+  }
+  return {
+    x: Array.from({ length: columns }, (_, index) => index * viewport.width),
+    y: Array.from({ length: rows }, (_, index) => index * viewport.height),
+  };
+}
+
+function createOutputBitmap(
+  content: PageContentSize,
+  scale: PixelScale,
+): {
+  bitmap: Uint8Array;
+  size: { width: number; height: number };
+} {
+  const size = {
+    width: Math.round(content.width * scale.x),
+    height: Math.round(content.height * scale.y),
+  };
+  const byteLength = size.width * size.height * 4;
+  if (
+    !Number.isSafeInteger(byteLength) ||
+    byteLength <= 0 ||
+    byteLength > MAX_FULL_PAGE_BITMAP_BYTES
+  ) {
+    throw new FullPageCaptureUnsupportedError(
+      `Full-page screenshot bitmap requires ${Math.ceil(byteLength / 1024 / 1024)} MiB; the maximum is ${MAX_FULL_PAGE_BITMAP_BYTES / 1024 / 1024} MiB.`,
+    );
+  }
+  return { bitmap: new Uint8Array(byteLength), size };
 }
 
 function copyTile(input: {
@@ -121,7 +188,9 @@ function copyTile(input: {
     sourceLeft + copyWidth > tileSize.width ||
     sourceTop + copyHeight > tileSize.height
   ) {
-    throw new FullPageCaptureError("Full-page tile does not cover its target region");
+    throw new FullPageCaptureUnsupportedError(
+      "The page prevented the requested full-page scroll position.",
+    );
   }
 
   const bitmap = input.tile.toBitmap();
@@ -135,7 +204,11 @@ function copyTile(input: {
   }
 }
 
-async function waitForGuestPaint(target: FullPageCaptureTarget): Promise<void> {
+async function waitForGuestPaint(
+  target: FullPageCaptureTarget,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  throwIfAborted(signal);
   await target.executeJavaScript(`new Promise((resolve) => {
     let resolved = false;
     const finish = () => {
@@ -146,50 +219,152 @@ async function waitForGuestPaint(target: FullPageCaptureTarget): Promise<void> {
     requestAnimationFrame(() => requestAnimationFrame(finish));
     setTimeout(finish, 100);
   })`);
+  throwIfAborted(signal);
 }
 
-async function scrollGuest(
+async function setGuestScroll(
   target: FullPageCaptureTarget,
   position: { x: number; y: number },
-): Promise<{ x: number; y: number }> {
+): Promise<void> {
+  await target.executeJavaScript(`(() => {
+    const scrollingElement = document.scrollingElement ?? document.documentElement;
+    scrollingElement.scrollLeft = ${position.x};
+    scrollingElement.scrollTop = ${position.y};
+  })()`);
+}
+
+async function readGuestScroll(target: FullPageCaptureTarget): Promise<{ x: number; y: number }> {
   return readScrollPosition(
     await target.executeJavaScript(`(() => {
       const scrollingElement = document.scrollingElement ?? document.documentElement;
-      scrollingElement.scrollLeft = ${position.x};
-      scrollingElement.scrollTop = ${position.y};
       return { x: scrollingElement.scrollLeft, y: scrollingElement.scrollTop };
     })()`),
   );
 }
 
-async function captureTiles(
+async function setFixedElementsVisible(
   target: FullPageCaptureTarget,
-  viewport: { width: number; height: number },
-): Promise<{ bitmap: Uint8Array; size: { width: number; height: number } }> {
-  const content = readContentSize(await target.sendDebugCommand("Page.getLayoutMetrics"));
-  const targetXs = tileOrigins(content.width, viewport.width);
-  const targetYs = tileOrigins(content.height, viewport.height);
+  captureToken: string,
+  visible: boolean,
+): Promise<void> {
+  await target.executeJavaScript(`(() => {
+    const state = globalThis[${JSON.stringify(captureToken)}];
+    if (!state) return;
+    for (const entry of state.fixedElements) {
+      if (!entry.element.isConnected) continue;
+      if (${visible}) {
+        if (entry.visibility.value) {
+          entry.element.style.setProperty('visibility', entry.visibility.value, entry.visibility.priority);
+        } else {
+          entry.element.style.removeProperty('visibility');
+        }
+      } else {
+        entry.element.style.setProperty('visibility', 'hidden', 'important');
+      }
+    }
+  })()`);
+}
+
+function scrollCoversTarget(input: {
+  actual: { x: number; y: number };
+  target: { x: number; y: number };
+  viewport: { width: number; height: number };
+  content: PageContentSize;
+}): boolean {
+  const targetRight = Math.min(input.target.x + input.viewport.width, input.content.width);
+  const targetBottom = Math.min(input.target.y + input.viewport.height, input.content.height);
+  return (
+    input.actual.x <= input.target.x + SCROLL_EPSILON &&
+    input.actual.y <= input.target.y + SCROLL_EPSILON &&
+    input.actual.x + input.viewport.width >= targetRight - SCROLL_EPSILON &&
+    input.actual.y + input.viewport.height >= targetBottom - SCROLL_EPSILON
+  );
+}
+
+function sameScrollPosition(
+  first: { x: number; y: number },
+  second: { x: number; y: number },
+): boolean {
+  return (
+    Math.abs(first.x - second.x) <= SCROLL_EPSILON && Math.abs(first.y - second.y) <= SCROLL_EPSILON
+  );
+}
+
+async function captureViewportTile(input: {
+  target: FullPageCaptureTarget;
+  captureToken: string;
+  content: PageContentSize;
+  viewport: { width: number; height: number };
+  position: { x: number; y: number };
+  signal?: AbortSignal;
+}): Promise<{ image: FullPageCaptureImage; actualScroll: { x: number; y: number } }> {
+  for (let attempt = 0; attempt < MAX_TILE_SCROLL_ATTEMPTS; attempt += 1) {
+    throwIfAborted(input.signal);
+    await setFixedElementsVisible(
+      input.target,
+      input.captureToken,
+      input.position.x === 0 && input.position.y === 0,
+    );
+    await setGuestScroll(input.target, input.position);
+    await waitForGuestPaint(input.target, input.signal);
+    const actualScroll = await readGuestScroll(input.target);
+    if (
+      !scrollCoversTarget({
+        actual: actualScroll,
+        target: input.position,
+        viewport: input.viewport,
+        content: input.content,
+      })
+    ) {
+      continue;
+    }
+
+    input.target.invalidate();
+    const dataBase64 = readScreenshotData(
+      await input.target.sendDebugCommand("Page.captureScreenshot", {
+        format: "png",
+        captureBeyondViewport: false,
+      }),
+    );
+    throwIfAborted(input.signal);
+    const scrollAfterCapture = await readGuestScroll(input.target);
+    if (!sameScrollPosition(actualScroll, scrollAfterCapture)) {
+      continue;
+    }
+    return {
+      image: input.target.createImageFromPng(dataBase64),
+      actualScroll,
+    };
+  }
+
+  throw new FullPageCaptureUnsupportedError(
+    "The page did not remain at a stable scroll position for full-page capture.",
+  );
+}
+
+async function captureTiles(input: {
+  target: FullPageCaptureTarget;
+  captureToken: string;
+  content: PageContentSize;
+  viewport: { width: number; height: number };
+  signal?: AbortSignal;
+}): Promise<CapturedBitmap> {
+  const origins = tileOrigins(input.content, input.viewport);
   let output: Uint8Array | null = null;
   let outputSize = { width: 0, height: 0 };
   let scale: PixelScale | null = null;
 
-  for (const y of targetYs) {
-    for (const x of targetXs) {
-      const actualScroll = await scrollGuest(target, { x, y });
-      await waitForGuestPaint(target);
-      target.invalidate();
-      const dataBase64 = readScreenshotData(
-        await target.sendDebugCommand("Page.captureScreenshot", {
-          format: "png",
-          captureBeyondViewport: false,
-        }),
-      );
-      const tile = target.createImageFromPng(dataBase64);
-      const tileSize = tile.getSize();
+  for (const y of origins.y) {
+    for (const x of origins.x) {
+      const tileCapture = await captureViewportTile({
+        ...input,
+        position: { x, y },
+      });
+      const tileSize = tileCapture.image.getSize();
       if (!scale) {
         scale = {
-          x: tileSize.width / viewport.width,
-          y: tileSize.height / viewport.height,
+          x: tileSize.width / input.viewport.width,
+          y: tileSize.height / input.viewport.height,
         };
         if (
           !Number.isFinite(scale.x) ||
@@ -200,29 +375,27 @@ async function captureTiles(
         ) {
           throw new FullPageCaptureError("Full-page tile returned an invalid pixel scale");
         }
-        outputSize = {
-          width: Math.round(content.width * scale.x),
-          height: Math.round(content.height * scale.y),
-        };
-        output = new Uint8Array(outputSize.width * outputSize.height * 4);
+        const created = createOutputBitmap(input.content, scale);
+        output = created.bitmap;
+        outputSize = created.size;
       }
       if (!output || !scale) {
         throw new FullPageCaptureError("Full-page capture did not initialize its bitmap");
       }
       if (
-        tileSize.width !== Math.round(viewport.width * scale.x) ||
-        tileSize.height !== Math.round(viewport.height * scale.y)
+        tileSize.width !== Math.round(input.viewport.width * scale.x) ||
+        tileSize.height !== Math.round(input.viewport.height * scale.y)
       ) {
         throw new FullPageCaptureError("Full-page tile dimensions changed during capture");
       }
       copyTile({
         output,
         outputWidth: outputSize.width,
-        content,
-        viewport,
+        content: input.content,
+        viewport: input.viewport,
         target: { x, y },
-        actualScroll,
-        tile,
+        actualScroll: tileCapture.actualScroll,
+        tile: tileCapture.image,
         scale,
       });
     }
@@ -231,11 +404,40 @@ async function captureTiles(
   if (!output) {
     throw new FullPageCaptureError("Full-page capture produced no tiles");
   }
-  return { bitmap: output, size: outputSize };
+  return { bitmap: output, size: outputSize, content: input.content };
+}
+
+function sameContentSize(first: PageContentSize, second: PageContentSize): boolean {
+  return first.width === second.width && first.height === second.height;
+}
+
+async function captureStableLayout(input: {
+  target: FullPageCaptureTarget;
+  captureToken: string;
+  viewport: { width: number; height: number };
+  signal?: AbortSignal;
+}): Promise<CapturedBitmap> {
+  let content = readContentSize(await input.target.sendDebugCommand("Page.getLayoutMetrics"));
+  for (let pass = 0; pass < MAX_LAYOUT_PASSES; pass += 1) {
+    throwIfAborted(input.signal);
+    const capture = await captureTiles({ ...input, content });
+    await waitForGuestPaint(input.target, input.signal);
+    const nextContent = readContentSize(
+      await input.target.sendDebugCommand("Page.getLayoutMetrics"),
+    );
+    if (sameContentSize(content, nextContent)) {
+      return capture;
+    }
+    content = nextContent;
+  }
+  throw new FullPageCaptureUnsupportedError(
+    "The page layout kept changing during full-page capture.",
+  );
 }
 
 export async function captureFullPage(
   target: FullPageCaptureTarget,
+  options: FullPageCaptureOptions = {},
 ): Promise<FullPageCaptureImage> {
   const captureToken = `__paseoFullPageCapture_${randomUUID().replaceAll("-", "")}`;
   const originalState = readPageCaptureState(
@@ -246,8 +448,11 @@ export async function captureFullPage(
       viewportHeight: innerHeight
     })`),
   );
+  let image: FullPageCaptureImage | undefined;
+  let captureError: unknown;
 
   try {
+    throwIfAborted(options.signal);
     await target.executeJavaScript(`(() => {
       const style = document.createElement('style');
       style.textContent = [
@@ -256,26 +461,91 @@ export async function captureFullPage(
         '::-webkit-scrollbar { display: none !important; }'
       ].join(' ');
       document.documentElement.appendChild(style);
-      globalThis[${JSON.stringify(captureToken)}] = style;
-    })()`);
-    await waitForGuestPaint(target);
-
-    const capture = await captureTiles(target, {
-      width: originalState.viewportWidth,
-      height: originalState.viewportHeight,
-    });
-    return target.createImageFromBitmap(capture.bitmap, capture.size);
-  } finally {
-    await target.executeJavaScript(`(() => {
-      const scrollingElement = document.scrollingElement ?? document.documentElement;
-      try {
-        scrollingElement.scrollLeft = ${originalState.scrollX};
-        scrollingElement.scrollTop = ${originalState.scrollY};
-      } finally {
-        globalThis[${JSON.stringify(captureToken)}]?.remove();
-        delete globalThis[${JSON.stringify(captureToken)}];
+      const state = { style, fixedElements: [], stickyElements: [] };
+      globalThis[${JSON.stringify(captureToken)}] = state;
+      const rememberProperty = (element, property) => ({
+        property,
+        value: element.style.getPropertyValue(property),
+        priority: element.style.getPropertyPriority(property)
+      });
+      for (const element of document.querySelectorAll('*')) {
+        const position = getComputedStyle(element).position;
+        if (position === 'fixed') {
+          state.fixedElements.push({
+            element,
+            visibility: rememberProperty(element, 'visibility')
+          });
+        } else if (position === 'sticky' || position === '-webkit-sticky') {
+          const properties = ['position', 'top', 'right', 'bottom', 'left'].map((property) =>
+            rememberProperty(element, property)
+          );
+          state.stickyElements.push({ element, properties });
+          element.style.setProperty('position', 'relative', 'important');
+          element.style.setProperty('top', 'auto', 'important');
+          element.style.setProperty('right', 'auto', 'important');
+          element.style.setProperty('bottom', 'auto', 'important');
+          element.style.setProperty('left', 'auto', 'important');
+        }
       }
     })()`);
-    await waitForGuestPaint(target);
+    await waitForGuestPaint(target, options.signal);
+
+    const capture = await captureStableLayout({
+      target,
+      captureToken,
+      viewport: {
+        width: originalState.viewportWidth,
+        height: originalState.viewportHeight,
+      },
+      ...(options.signal ? { signal: options.signal } : {}),
+    });
+    throwIfAborted(options.signal);
+    image = target.createImageFromBitmap(capture.bitmap, capture.size);
+  } catch (error) {
+    captureError = error;
   }
+
+  let cleanupError: unknown;
+  try {
+    await target.executeJavaScript(`(() => {
+        const state = globalThis[${JSON.stringify(captureToken)}];
+        if (!state) return false;
+        const restoreProperty = (element, snapshot) => {
+          if (!element.isConnected) return;
+          if (snapshot.value) {
+            element.style.setProperty(snapshot.property, snapshot.value, snapshot.priority);
+          } else {
+            element.style.removeProperty(snapshot.property);
+          }
+        };
+        const scrollingElement = document.scrollingElement ?? document.documentElement;
+        scrollingElement.scrollLeft = ${originalState.scrollX};
+        scrollingElement.scrollTop = ${originalState.scrollY};
+        for (const entry of state.fixedElements) {
+          restoreProperty(entry.element, entry.visibility);
+        }
+        for (const entry of state.stickyElements) {
+          for (const property of entry.properties) restoreProperty(entry.element, property);
+        }
+        state.style.remove();
+        delete globalThis[${JSON.stringify(captureToken)}];
+        return true;
+      })()`);
+    if (!options.signal?.aborted) {
+      await waitForGuestPaint(target, options.signal);
+    }
+  } catch (error) {
+    cleanupError = error;
+  }
+
+  if (captureError) {
+    throw captureError;
+  }
+  if (cleanupError) {
+    throw cleanupError;
+  }
+  if (!image) {
+    throw new FullPageCaptureError("Full-page capture returned no image");
+  }
+  return image;
 }

--- a/packages/desktop/src/features/browser-automation/full-page-capture.ts
+++ b/packages/desktop/src/features/browser-automation/full-page-capture.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import { z, type ZodType } from "zod";
 
 export interface FullPageCaptureImage {
@@ -10,6 +11,7 @@ export interface FullPageCaptureImage {
 export interface FullPageCaptureTarget {
   executeJavaScript(code: string): Promise<unknown>;
   invalidate(): void;
+  waitForPaint?(signal?: AbortSignal): Promise<void>;
   sendDebugCommand(command: string, params?: Record<string, unknown>): Promise<unknown>;
   createImageFromPng(dataBase64: string): FullPageCaptureImage;
   createImageFromBitmap(
@@ -209,16 +211,17 @@ async function waitForGuestPaint(
   signal: AbortSignal | undefined,
 ): Promise<void> {
   throwIfAborted(signal);
-  await target.executeJavaScript(`new Promise((resolve) => {
-    let resolved = false;
-    const finish = () => {
-      if (resolved) return;
-      resolved = true;
-      resolve();
-    };
-    requestAnimationFrame(() => requestAnimationFrame(finish));
-    setTimeout(finish, 100);
-  })`);
+  target.invalidate();
+  try {
+    if (target.waitForPaint) {
+      await target.waitForPaint(signal);
+    } else {
+      await delay(100, undefined, signal ? { signal } : undefined);
+    }
+  } catch (error) {
+    throwIfAborted(signal);
+    throw error;
+  }
   throwIfAborted(signal);
 }
 

--- a/packages/desktop/src/features/browser-automation/ipc.test.ts
+++ b/packages/desktop/src/features/browser-automation/ipc.test.ts
@@ -1,12 +1,16 @@
 import type { Rectangle } from "electron";
 import { describe, expect, test, vi } from "vitest";
-import type { TabImage } from "./service.js";
+import type { FullPageCaptureImage } from "./full-page-capture.js";
 import { adaptWebContents, HostSnapshotEngineRegistry } from "./ipc.js";
 import type { IsolatedKeyboardInputEvent } from "./trusted-input.js";
 
-class FakeImage implements TabImage {
+class FakeImage implements FullPageCaptureImage {
   public toPNG(): Uint8Array {
     return new Uint8Array([137, 80, 78, 71]);
+  }
+
+  public toBitmap(): Uint8Array {
+    return new Uint8Array(640 * 480 * 4);
   }
 
   public getSize(): { width: number; height: number } {
@@ -170,7 +174,7 @@ class FakeWebContents {
   public async capturePage(
     rect?: Rectangle,
     options?: { stayHidden?: boolean },
-  ): Promise<TabImage> {
+  ): Promise<FullPageCaptureImage> {
     this.captures.push({ rect, options });
     return new FakeImage();
   }

--- a/packages/desktop/src/features/browser-automation/ipc.ts
+++ b/packages/desktop/src/features/browser-automation/ipc.ts
@@ -133,24 +133,27 @@ export function adaptWebContents(contents: BrowserAutomationWebContents): TabCon
     goForward: () => contents.goForward(),
     reload: () => contents.reload(),
     capturePage: (captureOptions) => contents.capturePage(undefined, captureOptions),
-    captureFullPage: () =>
+    captureFullPage: (options) =>
       cdpQueue.run(async () => {
         if (!contents.debugger.isAttached()) {
           contents.debugger.attach("1.3");
         }
-        return captureFullPageImage({
-          executeJavaScript: (code) => contents.executeJavaScript(code),
-          invalidate: () => contents.invalidate(),
-          sendDebugCommand: (command, params) =>
-            contents.debugger.sendCommand(command, params ?? {}),
-          createImageFromPng: (dataBase64) =>
-            nativeImage.createFromBuffer(Buffer.from(dataBase64, "base64")),
-          createImageFromBitmap: (bitmap, size) =>
-            nativeImage.createFromBitmap(Buffer.from(bitmap), {
-              ...size,
-              scaleFactor: 1,
-            }),
-        });
+        return captureFullPageImage(
+          {
+            executeJavaScript: (code) => contents.executeJavaScript(code),
+            invalidate: () => contents.invalidate(),
+            sendDebugCommand: (command, params) =>
+              contents.debugger.sendCommand(command, params ?? {}),
+            createImageFromPng: (dataBase64) =>
+              nativeImage.createFromBuffer(Buffer.from(dataBase64, "base64")),
+            createImageFromBitmap: (bitmap, size) =>
+              nativeImage.createFromBitmap(Buffer.from(bitmap), {
+                ...size,
+                scaleFactor: 1,
+              }),
+          },
+          options,
+        );
       }),
     invalidate: () => contents.invalidate(),
     sendInputEvent: (event) => contents.sendInputEvent(event),

--- a/packages/desktop/src/features/browser-automation/ipc.ts
+++ b/packages/desktop/src/features/browser-automation/ipc.ts
@@ -1,11 +1,11 @@
 import type { Rectangle } from "electron";
-import { ipcMain } from "electron";
+import { ipcMain, nativeImage } from "electron";
 import { BrowserAutomationExecuteRequestSchema } from "@getpaseo/protocol/browser-automation/rpc-schemas";
 import type {
   BrowserAutomationConsoleLogEntry,
   BrowserAutomationDialogEvent,
 } from "@getpaseo/protocol/browser-automation/rpc-schemas";
-import type { TabContents, BrowserRegistry, TabImage } from "./service.js";
+import type { TabContents, BrowserRegistry } from "./service.js";
 import type { IsolatedKeyboardInputEvent } from "./trusted-input.js";
 import { CdpSessionQueue } from "./cdp-session-queue.js";
 import {
@@ -17,6 +17,10 @@ import {
   promptShimRestoreScript,
 } from "./dialog-handling.js";
 import { executeAutomationCommand } from "./service.js";
+import {
+  captureFullPage as captureFullPageImage,
+  type FullPageCaptureImage,
+} from "./full-page-capture.js";
 import { BrowserSnapshotEngine } from "./snapshot-engine.js";
 import {
   listRegisteredPaseoBrowserIds,
@@ -105,7 +109,7 @@ interface BrowserAutomationWebContents extends ConsoleMessageEmitter {
   goBack(): void;
   goForward(): void;
   reload(): void;
-  capturePage(rect?: Rectangle, options?: { stayHidden?: boolean }): Promise<TabImage>;
+  capturePage(rect?: Rectangle, options?: { stayHidden?: boolean }): Promise<FullPageCaptureImage>;
   invalidate(): void;
   sendInputEvent(event: IsolatedKeyboardInputEvent): void;
 }
@@ -129,6 +133,25 @@ export function adaptWebContents(contents: BrowserAutomationWebContents): TabCon
     goForward: () => contents.goForward(),
     reload: () => contents.reload(),
     capturePage: (captureOptions) => contents.capturePage(undefined, captureOptions),
+    captureFullPage: () =>
+      cdpQueue.run(async () => {
+        if (!contents.debugger.isAttached()) {
+          contents.debugger.attach("1.3");
+        }
+        return captureFullPageImage({
+          executeJavaScript: (code) => contents.executeJavaScript(code),
+          invalidate: () => contents.invalidate(),
+          sendDebugCommand: (command, params) =>
+            contents.debugger.sendCommand(command, params ?? {}),
+          createImageFromPng: (dataBase64) =>
+            nativeImage.createFromBuffer(Buffer.from(dataBase64, "base64")),
+          createImageFromBitmap: (bitmap, size) =>
+            nativeImage.createFromBitmap(Buffer.from(bitmap), {
+              ...size,
+              scaleFactor: 1,
+            }),
+        });
+      }),
     invalidate: () => contents.invalidate(),
     sendInputEvent: (event) => contents.sendInputEvent(event),
     getConsoleMessages: () => consoleMessagesByContentsId.get(contentsId) ?? [],

--- a/packages/desktop/src/features/browser-automation/service.test.ts
+++ b/packages/desktop/src/features/browser-automation/service.test.ts
@@ -76,7 +76,7 @@ class FakeTab implements TabContents {
     cssLayoutViewport: { clientWidth: 390, clientHeight: 844 },
     cssContentSize: { width: 390, height: 1200 },
   };
-  public fullPageScreenshotData = "fullPagePng";
+  public fullPageScreenshotData = "ZnVsbFBhZ2VQbmc=";
   public documentNodeId = 1;
   public queriedNodeId = 2;
   public canNavigateBack = true;
@@ -181,6 +181,21 @@ class FakeTab implements TabContents {
       });
     }
     return new FakeImage();
+  }
+
+  public async captureFullPage(): Promise<TabImage> {
+    this.actions.push("capture-full-page");
+    if (this.fullPageCaptureFailuresBeforeSuccess > 0) {
+      this.fullPageCaptureFailuresBeforeSuccess -= 1;
+      throw new Error(this.fullPageScreenshotErrorMessage);
+    }
+    if (this.fullPageScreenshotThrows) {
+      throw new Error(this.fullPageScreenshotErrorMessage);
+    }
+    return new FakeImage(Buffer.from(this.fullPageScreenshotData, "base64"), {
+      width: 390,
+      height: 1200,
+    });
   }
 
   public invalidate(): void {
@@ -1749,7 +1764,7 @@ describe("executeAutomationCommand", () => {
     expect(secondTab.actions).toEqual(["invalidate", "capture"]);
   });
 
-  test("screenshot with fullPage captures the page content area through CDP", async () => {
+  test("screenshot with fullPage returns the captured page image", async () => {
     const browser = new BrowserAutomationHarness();
 
     const result = await browser.execute({
@@ -1764,30 +1779,15 @@ describe("executeAutomationCommand", () => {
         command: "screenshot",
         browserId: BROWSER_A,
         mimeType: "image/png",
-        dataBase64: "fullPagePng",
+        dataBase64: "ZnVsbFBhZ2VQbmc=",
         width: 390,
         height: 1200,
       },
     });
-    expect(browser.tab.debugCommands).toEqual([
-      { command: "Page.getLayoutMetrics" },
-      {
-        command: "Page.captureScreenshot",
-        params: {
-          format: "png",
-          captureBeyondViewport: true,
-          clip: { x: 0, y: 0, width: 390, height: 1200, scale: 1 },
-        },
-      },
-    ]);
-    expect(browser.tab.actions).toEqual([
-      "invalidate",
-      "debug:Page.getLayoutMetrics",
-      "debug:Page.captureScreenshot",
-    ]);
+    expect(browser.tab.actions).toEqual(["invalidate", "capture-full-page"]);
   });
 
-  test("screenshot with fullPage returns unsupported when CDP returns no image", async () => {
+  test("screenshot with fullPage returns unsupported when capture returns no image", async () => {
     const browser = new BrowserAutomationHarness();
     browser.tab.fullPageScreenshotData = "";
 
@@ -1805,14 +1805,10 @@ describe("executeAutomationCommand", () => {
         retryable: false,
       },
     });
-    expect(browser.tab.actions).toEqual([
-      "invalidate",
-      "debug:Page.getLayoutMetrics",
-      "debug:Page.captureScreenshot",
-    ]);
+    expect(browser.tab.actions).toEqual(["invalidate", "capture-full-page"]);
   });
 
-  test("screenshot with fullPage retries UnknownVizError until the first CDP frame appears", async () => {
+  test("screenshot with fullPage retries UnknownVizError until the first frame appears", async () => {
     vi.useFakeTimers();
     try {
       const browser = new BrowserAutomationHarness();
@@ -1831,25 +1827,23 @@ describe("executeAutomationCommand", () => {
           command: "screenshot",
           browserId: BROWSER_A,
           mimeType: "image/png",
-          dataBase64: "fullPagePng",
+          dataBase64: "ZnVsbFBhZ2VQbmc=",
           width: 390,
           height: 1200,
         },
       });
       expect(browser.tab.actions).toEqual([
         "invalidate",
-        "debug:Page.getLayoutMetrics",
-        "debug:Page.captureScreenshot",
+        "capture-full-page",
         "invalidate",
-        "debug:Page.getLayoutMetrics",
-        "debug:Page.captureScreenshot",
+        "capture-full-page",
       ]);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  test("screenshot with fullPage surfaces ordinary CDP capture errors", async () => {
+  test("screenshot with fullPage surfaces ordinary capture errors", async () => {
     const browser = new BrowserAutomationHarness();
     browser.tab.fullPageScreenshotThrows = true;
     browser.tab.fullPageScreenshotErrorMessage = "Debugger detached";
@@ -1860,11 +1854,7 @@ describe("executeAutomationCommand", () => {
         args: { browserId: BROWSER_A, fullPage: true },
       }),
     ).rejects.toThrow("Debugger detached");
-    expect(browser.tab.actions).toEqual([
-      "invalidate",
-      "debug:Page.getLayoutMetrics",
-      "debug:Page.captureScreenshot",
-    ]);
+    expect(browser.tab.actions).toEqual(["invalidate", "capture-full-page"]);
   });
 
   test("upload resolves workspace files before setting them on the file input", async () => {

--- a/packages/desktop/src/features/browser-automation/service.test.ts
+++ b/packages/desktop/src/features/browser-automation/service.test.ts
@@ -42,6 +42,7 @@ class FakeTab implements TabContents {
   public readonly inputEvents: IsolatedKeyboardInputEvent[] = [];
   private readonly captureStartWaiters: Array<() => void> = [];
   private readonly deferredCaptures: Array<(image: TabImage) => void> = [];
+  private finishFullPageAbort: (() => void) | null = null;
 
   public destroyed = false;
   public bodyText = "";
@@ -74,6 +75,7 @@ class FakeTab implements TabContents {
   public fullPageScreenshotErrorMessage = "UnknownVizError";
   public fullPageCaptureFailuresBeforeSuccess = 0;
   public fullPageCaptureWaitsForAbort = false;
+  public fullPageAbortCleanupDeferred = false;
   public fullPageCaptureAborted = false;
   public fullPageCaptureError: Error | null = null;
   public layoutMetrics = {
@@ -195,7 +197,12 @@ class FakeTab implements TabContents {
           "abort",
           () => {
             this.fullPageCaptureAborted = true;
-            reject(options.signal?.reason);
+            const finish = () => reject(options.signal?.reason);
+            if (this.fullPageAbortCleanupDeferred) {
+              this.finishFullPageAbort = finish;
+            } else {
+              finish();
+            }
           },
           { once: true },
         );
@@ -274,6 +281,15 @@ class FakeTab implements TabContents {
         }
       });
     });
+  }
+
+  public finishFullPageAbortCleanup(): void {
+    const finish = this.finishFullPageAbort;
+    if (!finish) {
+      throw new Error("No full-page abort cleanup is waiting");
+    }
+    this.finishFullPageAbort = null;
+    finish();
   }
 
   public finishNextCapture(): void {
@@ -1903,13 +1919,22 @@ describe("executeAutomationCommand", () => {
     try {
       const browser = new BrowserAutomationHarness();
       browser.tab.fullPageCaptureWaitsForAbort = true;
+      browser.tab.fullPageAbortCleanupDeferred = true;
 
       const pending = browser.execute({
         command: "screenshot",
         args: { browserId: BROWSER_A, fullPage: true },
       });
+      let settled = false;
+      void pending.then(() => {
+        settled = true;
+        return undefined;
+      });
       await vi.advanceTimersByTimeAsync(30_000);
 
+      expect(browser.tab.fullPageCaptureAborted).toBe(true);
+      expect(settled).toBe(false);
+      browser.tab.finishFullPageAbortCleanup();
       await expect(pending).resolves.toEqual({
         requestId: "req-screenshot",
         ok: false,

--- a/packages/desktop/src/features/browser-automation/service.test.ts
+++ b/packages/desktop/src/features/browser-automation/service.test.ts
@@ -7,6 +7,7 @@ import type {
   BrowserAutomationDialogEvent,
   BrowserAutomationExecuteRequest,
 } from "@getpaseo/protocol/browser-automation/rpc-schemas";
+import { FullPageCaptureUnsupportedError } from "./full-page-capture.js";
 import { BrowserSnapshotEngine } from "./snapshot-engine.js";
 import type { BrowserRegistry, TabContents, TabImage } from "./service.js";
 import { executeAutomationCommand } from "./service.js";
@@ -72,6 +73,9 @@ class FakeTab implements TabContents {
   public fullPageScreenshotThrows = false;
   public fullPageScreenshotErrorMessage = "UnknownVizError";
   public fullPageCaptureFailuresBeforeSuccess = 0;
+  public fullPageCaptureWaitsForAbort = false;
+  public fullPageCaptureAborted = false;
+  public fullPageCaptureError: Error | null = null;
   public layoutMetrics = {
     cssLayoutViewport: { clientWidth: 390, clientHeight: 844 },
     cssContentSize: { width: 390, height: 1200 },
@@ -183,8 +187,23 @@ class FakeTab implements TabContents {
     return new FakeImage();
   }
 
-  public async captureFullPage(): Promise<TabImage> {
+  public async captureFullPage(options?: { signal?: AbortSignal }): Promise<TabImage> {
     this.actions.push("capture-full-page");
+    if (this.fullPageCaptureWaitsForAbort) {
+      return new Promise<TabImage>((_resolve, reject) => {
+        options?.signal?.addEventListener(
+          "abort",
+          () => {
+            this.fullPageCaptureAborted = true;
+            reject(options.signal?.reason);
+          },
+          { once: true },
+        );
+      });
+    }
+    if (this.fullPageCaptureError) {
+      throw this.fullPageCaptureError;
+    }
     if (this.fullPageCaptureFailuresBeforeSuccess > 0) {
       this.fullPageCaptureFailuresBeforeSuccess -= 1;
       throw new Error(this.fullPageScreenshotErrorMessage);
@@ -1855,6 +1874,55 @@ describe("executeAutomationCommand", () => {
       }),
     ).rejects.toThrow("Debugger detached");
     expect(browser.tab.actions).toEqual(["invalidate", "capture-full-page"]);
+  });
+
+  test("screenshot with fullPage returns an explicit unsupported-page failure", async () => {
+    const browser = new BrowserAutomationHarness();
+    browser.tab.fullPageCaptureError = new FullPageCaptureUnsupportedError(
+      "The page did not remain at a stable scroll position for full-page capture.",
+    );
+
+    await expect(
+      browser.execute({
+        command: "screenshot",
+        args: { browserId: BROWSER_A, fullPage: true },
+      }),
+    ).resolves.toEqual({
+      requestId: "req-screenshot",
+      ok: false,
+      error: {
+        code: "browser_unsupported",
+        message: "The page did not remain at a stable scroll position for full-page capture.",
+        retryable: false,
+      },
+    });
+  });
+
+  test("screenshot with fullPage aborts work after its capture budget", async () => {
+    vi.useFakeTimers();
+    try {
+      const browser = new BrowserAutomationHarness();
+      browser.tab.fullPageCaptureWaitsForAbort = true;
+
+      const pending = browser.execute({
+        command: "screenshot",
+        args: { browserId: BROWSER_A, fullPage: true },
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(pending).resolves.toEqual({
+        requestId: "req-screenshot",
+        ok: false,
+        error: {
+          code: "browser_timeout",
+          message: "Full-page screenshot exceeded the 30-second capture budget.",
+          retryable: true,
+        },
+      });
+      expect(browser.tab.fullPageCaptureAborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("upload resolves workspace files before setting them on the file input", async () => {

--- a/packages/desktop/src/features/browser-automation/service.ts
+++ b/packages/desktop/src/features/browser-automation/service.ts
@@ -36,6 +36,7 @@ export interface TabContents {
   goForward(): void;
   reload(): void;
   capturePage(options?: TabCapturePageOptions): Promise<TabImage>;
+  captureFullPage?(): Promise<TabImage>;
   invalidate(): void;
   sendInputEvent(event: IsolatedKeyboardInputEvent): void;
   getConsoleMessages?(): BrowserAutomationConsoleLogEntry[];
@@ -1220,29 +1221,6 @@ async function executeScreenshot(
   });
 }
 
-interface CdpLayoutMetrics {
-  cssLayoutViewport?: {
-    clientWidth?: number;
-    clientHeight?: number;
-  };
-  layoutViewport?: {
-    clientWidth?: number;
-    clientHeight?: number;
-  };
-  cssContentSize?: {
-    width?: number;
-    height?: number;
-  };
-  contentSize?: {
-    width?: number;
-    height?: number;
-  };
-}
-
-interface CdpCaptureScreenshotResult {
-  data?: string;
-}
-
 interface CdpRuntimeEvaluateResult {
   result?: {
     objectId?: string;
@@ -1258,26 +1236,6 @@ interface CdpDescribeNodeResult {
   };
 }
 
-async function getCdpLayoutMetrics(contents: TabContents): Promise<{
-  viewportWidth: number;
-  viewportHeight: number;
-  contentWidth: number;
-  contentHeight: number;
-}> {
-  if (!contents.sendDebugCommand) {
-    return { viewportWidth: 0, viewportHeight: 0, contentWidth: 0, contentHeight: 0 };
-  }
-  const metrics = (await contents.sendDebugCommand("Page.getLayoutMetrics")) as CdpLayoutMetrics;
-  const viewport = metrics.cssLayoutViewport ?? metrics.layoutViewport;
-  const contentSize = metrics.cssContentSize ?? metrics.contentSize;
-  return {
-    viewportWidth: Math.ceil(viewport?.clientWidth ?? 0),
-    viewportHeight: Math.ceil(viewport?.clientHeight ?? 0),
-    contentWidth: Math.ceil(contentSize?.width ?? 0),
-    contentHeight: Math.ceil(contentSize?.height ?? 0),
-  };
-}
-
 async function executeFullPageScreenshot(
   requestId: string,
   workspaceId: string | undefined,
@@ -1289,33 +1247,24 @@ async function executeFullPageScreenshot(
     return target;
   }
   return withDialogCapture(target.contents, async () => {
-    if (!target.contents.sendDebugCommand) {
+    const captureFullPage = target.contents.captureFullPage?.bind(target.contents);
+    if (!captureFullPage) {
       return fail(requestId, "browser_unsupported", "browser_screenshot fullPage requires CDP");
     }
-    const sendDebugCommand = target.contents.sendDebugCommand.bind(target.contents);
-    let screenshot: CdpCaptureScreenshotResult;
-    let width = 0;
-    let height = 0;
+    let image: TabImage;
     try {
-      screenshot = await runPaintedPixelCapture(target.contents, async () => {
-        const metrics = await getCdpLayoutMetrics(target.contents);
-        width = metrics.contentWidth;
-        height = metrics.contentHeight;
-        return (await sendDebugCommand("Page.captureScreenshot", {
-          format: "png",
-          captureBeyondViewport: true,
-          clip: { x: 0, y: 0, width, height, scale: 1 },
-        })) as CdpCaptureScreenshotResult;
-      });
+      image = await runPaintedPixelCapture(target.contents, captureFullPage);
     } catch (error) {
       if (isScreenshotNoFrameError(error)) {
         return screenshotNoFrameFailure(requestId, error);
       }
       throw error;
     }
-    if (!screenshot.data) {
+    const png = image.toPNG();
+    if (png.length === 0) {
       return fail(requestId, "browser_unsupported", "browser_screenshot fullPage returned no data");
     }
+    const size = image.getSize();
     return {
       requestId,
       ok: true,
@@ -1323,9 +1272,9 @@ async function executeFullPageScreenshot(
         command: "screenshot",
         browserId: target.browserId,
         mimeType: "image/png",
-        dataBase64: screenshot.data,
-        width,
-        height,
+        dataBase64: Buffer.from(png).toString("base64"),
+        width: size.width,
+        height: size.height,
       },
     };
   });

--- a/packages/desktop/src/features/browser-automation/service.ts
+++ b/packages/desktop/src/features/browser-automation/service.ts
@@ -10,6 +10,7 @@ import type {
   BrowserAutomationNetworkLogEntry,
 } from "@getpaseo/protocol/browser-automation/rpc-schemas";
 import { waitForActionableTarget, type ActionabilityResult } from "./actionability.js";
+import { FullPageCaptureUnsupportedError } from "./full-page-capture.js";
 import { BrowserSnapshotEngine } from "./snapshot-engine.js";
 import {
   dispatchTrustedClick,
@@ -36,7 +37,7 @@ export interface TabContents {
   goForward(): void;
   reload(): void;
   capturePage(options?: TabCapturePageOptions): Promise<TabImage>;
-  captureFullPage?(): Promise<TabImage>;
+  captureFullPage?(options?: { signal?: AbortSignal }): Promise<TabImage>;
   invalidate(): void;
   sendInputEvent(event: IsolatedKeyboardInputEvent): void;
   getConsoleMessages?(): BrowserAutomationConsoleLogEntry[];
@@ -70,6 +71,7 @@ const defaultSnapshotEngine = new BrowserSnapshotEngine();
 const DEFAULT_WAIT_TIMEOUT_MS = 5_000;
 const WAIT_POLL_INTERVAL_MS = 25;
 const PIXEL_CAPTURE_TIMEOUT_MS = 5_000;
+const FULL_PAGE_CAPTURE_TIMEOUT_MS = 30_000;
 const PIXEL_CAPTURE_RETRY_INTERVAL_MS = 200;
 const SCREENSHOT_NO_FRAME_MESSAGE = "The tab has not painted yet. Retry the screenshot.";
 const ALLOWED_PAGE_URL_PROTOCOLS = new Set(["http:", "https:"]);
@@ -105,6 +107,13 @@ class ScreenshotNoFrameError extends Error {
   }
 }
 
+class ScreenshotCaptureTimeoutError extends Error {
+  public constructor() {
+    super("Full-page screenshot exceeded the 30-second capture budget.");
+    this.name = "ScreenshotCaptureTimeoutError";
+  }
+}
+
 function isScreenshotNoFrameError(error: unknown): error is ScreenshotNoFrameError {
   return error instanceof ScreenshotNoFrameError;
 }
@@ -116,22 +125,33 @@ function screenshotNoFrameFailure(
   return fail(requestId, "screenshot_no_frame", error.message, true);
 }
 
-async function withPixelCaptureTimeout<T>(
-  capture: Promise<T>,
-  timeoutMs = PIXEL_CAPTURE_TIMEOUT_MS,
-): Promise<T> {
-  if (timeoutMs <= 0) {
-    throw new ScreenshotNoFrameError();
+interface PixelCaptureOptions {
+  timeoutMs?: number;
+  createTimeoutError?: () => Error;
+}
+
+async function withPixelCaptureTimeout<T>(input: {
+  capture: Promise<T>;
+  timeoutMs: number;
+  abort: (reason: Error) => void;
+  createTimeoutError: () => Error;
+}): Promise<T> {
+  if (input.timeoutMs <= 0) {
+    const error = input.createTimeoutError();
+    input.abort(error);
+    throw error;
   }
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      reject(new ScreenshotNoFrameError());
-    }, timeoutMs);
+      const error = input.createTimeoutError();
+      input.abort(error);
+      reject(error);
+    }, input.timeoutMs);
   });
 
   try {
-    return await Promise.race([capture, timeout]);
+    return await Promise.race([input.capture, timeout]);
   } finally {
     if (timeoutId) {
       clearTimeout(timeoutId);
@@ -161,15 +181,24 @@ async function runSerializedPixelCapture<T>(capture: () => Promise<T>): Promise<
 
 async function capturePixelFrameWithRetry<T>(
   contents: TabContents,
-  capture: () => Promise<T>,
+  capture: (signal: AbortSignal) => Promise<T>,
+  options: PixelCaptureOptions = {},
 ): Promise<T> {
-  const deadline = Date.now() + PIXEL_CAPTURE_TIMEOUT_MS;
+  const timeoutMs = options.timeoutMs ?? PIXEL_CAPTURE_TIMEOUT_MS;
+  const createTimeoutError = options.createTimeoutError ?? (() => new ScreenshotNoFrameError());
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    const controller = new AbortController();
     try {
       contents.invalidate();
-      return await withPixelCaptureTimeout(capture(), deadline - Date.now());
+      return await withPixelCaptureTimeout({
+        capture: capture(controller.signal),
+        timeoutMs: deadline - Date.now(),
+        abort: (reason) => controller.abort(reason),
+        createTimeoutError,
+      });
     } catch (error) {
-      if (isScreenshotNoFrameError(error)) {
+      if (isScreenshotNoFrameError(error) || error instanceof ScreenshotCaptureTimeoutError) {
         throw error;
       }
       if (!isKnownNoFrameCaptureError(error)) {
@@ -178,7 +207,7 @@ async function capturePixelFrameWithRetry<T>(
       await delay(Math.min(PIXEL_CAPTURE_RETRY_INTERVAL_MS, Math.max(0, deadline - Date.now())));
     }
   }
-  throw new ScreenshotNoFrameError();
+  throw createTimeoutError();
 }
 
 function isKnownNoFrameCaptureError(error: unknown): boolean {
@@ -192,9 +221,10 @@ function isKnownNoFrameCaptureError(error: unknown): boolean {
 
 async function runPaintedPixelCapture<T>(
   contents: TabContents,
-  capture: () => Promise<T>,
+  capture: (signal: AbortSignal) => Promise<T>,
+  options?: PixelCaptureOptions,
 ): Promise<T> {
-  return runSerializedPixelCapture(() => capturePixelFrameWithRetry(contents, capture));
+  return runSerializedPixelCapture(() => capturePixelFrameWithRetry(contents, capture, options));
 }
 
 async function capturePaintedViewport(contents: TabContents): Promise<TabImage> {
@@ -1253,10 +1283,23 @@ async function executeFullPageScreenshot(
     }
     let image: TabImage;
     try {
-      image = await runPaintedPixelCapture(target.contents, captureFullPage);
+      image = await runPaintedPixelCapture(
+        target.contents,
+        (signal) => captureFullPage({ signal }),
+        {
+          timeoutMs: FULL_PAGE_CAPTURE_TIMEOUT_MS,
+          createTimeoutError: () => new ScreenshotCaptureTimeoutError(),
+        },
+      );
     } catch (error) {
       if (isScreenshotNoFrameError(error)) {
         return screenshotNoFrameFailure(requestId, error);
+      }
+      if (error instanceof ScreenshotCaptureTimeoutError) {
+        return fail(requestId, "browser_timeout", error.message, true);
+      }
+      if (error instanceof FullPageCaptureUnsupportedError) {
+        return fail(requestId, "browser_unsupported", error.message);
       }
       throw error;
     }

--- a/packages/desktop/src/features/browser-automation/service.ts
+++ b/packages/desktop/src/features/browser-automation/service.ts
@@ -141,6 +141,9 @@ async function withPixelCaptureTimeout<T>(input: {
   if (input.timeoutMs <= 0) {
     const error = input.createTimeoutError();
     input.abort(error);
+    if (input.waitForCaptureAfterTimeout) {
+      await input.capture.catch(() => undefined);
+    }
     throw error;
   }
   let timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/packages/desktop/src/features/browser-automation/service.ts
+++ b/packages/desktop/src/features/browser-automation/service.ts
@@ -128,6 +128,7 @@ function screenshotNoFrameFailure(
 interface PixelCaptureOptions {
   timeoutMs?: number;
   createTimeoutError?: () => Error;
+  waitForCaptureAfterTimeout?: boolean;
 }
 
 async function withPixelCaptureTimeout<T>(input: {
@@ -135,6 +136,7 @@ async function withPixelCaptureTimeout<T>(input: {
   timeoutMs: number;
   abort: (reason: Error) => void;
   createTimeoutError: () => Error;
+  waitForCaptureAfterTimeout: boolean;
 }): Promise<T> {
   if (input.timeoutMs <= 0) {
     const error = input.createTimeoutError();
@@ -142,16 +144,22 @@ async function withPixelCaptureTimeout<T>(input: {
     throw error;
   }
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: Error | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      const error = input.createTimeoutError();
-      input.abort(error);
-      reject(error);
+      timeoutError = input.createTimeoutError();
+      input.abort(timeoutError);
+      reject(timeoutError);
     }, input.timeoutMs);
   });
 
   try {
     return await Promise.race([input.capture, timeout]);
+  } catch (error) {
+    if (error === timeoutError && input.waitForCaptureAfterTimeout) {
+      await input.capture.catch(() => undefined);
+    }
+    throw error;
   } finally {
     if (timeoutId) {
       clearTimeout(timeoutId);
@@ -196,6 +204,7 @@ async function capturePixelFrameWithRetry<T>(
         timeoutMs: deadline - Date.now(),
         abort: (reason) => controller.abort(reason),
         createTimeoutError,
+        waitForCaptureAfterTimeout: options.waitForCaptureAfterTimeout ?? false,
       });
     } catch (error) {
       if (isScreenshotNoFrameError(error) || error instanceof ScreenshotCaptureTimeoutError) {
@@ -1289,6 +1298,7 @@ async function executeFullPageScreenshot(
         {
           timeoutMs: FULL_PAGE_CAPTURE_TIMEOUT_MS,
           createTimeoutError: () => new ScreenshotCaptureTimeoutError(),
+          waitForCaptureAfterTimeout: true,
         },
       );
     } catch (error) {


### PR DESCRIPTION
### Linked issue

Closes #3196

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Desktop users and agents asking for a full-page browser screenshot received a PNG with the expected full height, but Electron repeated the currently painted guest viewport below the fold. Correct dimensions therefore hid missing page content.

This change temporarily neutralizes root scroll constraints, verifies the guest position before and after every CDP tile, and stitches only stable painted viewports. It retries bounded layout growth, shows fixed elements once, removes sticky behavior during capture, and restores page state before returning. Full-page capture has its own abortable 30-second budget plus 128-tile and 128 MiB bitmap limits; timeout responses await state cleanup before releasing capture serialization, while retaining first-frame retry behavior.

### Goals

- Return actual below-the-fold pixels from `browser_screenshot({ fullPage: true })`.
- Preserve pixel scaling and crop clamped final tiles without seams.
- Restore page scroll and temporary fixed, sticky, scrollbar, and scroll-behavior changes after success or failure.
- Reject unstable programmatic scrolling instead of returning a repeated or misaligned image.
- Recapture bounded lazy layout growth and bound time, tile count, and raw bitmap memory.
- Cover the behavior with bitmap unit tests, the browser desktop E2E, and the real-Electron capture harness.

### Non-goals

- Change the normal viewport screenshot path.
- Change element annotation or screenshot-element selection.
- Capture unbounded/infinite feeds whose document height never stabilizes after three passes.

### QA

#### Before

On main `334bf623709d91b9b9d5217fb17acc289ed16622`:

```bash
PASEO_CAPTURE_HARNESS_SOAK_MS=0 \
  PASEO_CAPTURE_HARNESS_OUT_DIR=/tmp/paseo-fullpage-before \
  npm run capture-harness --workspace=@getpaseo/desktop
```

The output was 1280×1600, but its two 800-row halves were exactly identical and the bottom marker was absent:

```text
PASS permanent P1 attach-off settled full-page webview 2 1/5 attempts=1 size=1280x1600 logical=1280x1600 bright=0.8886 text=true file=/tmp/paseo-fullpage-before/permanent-parking/attach-off-throttling/p1-overflow-1x1/settled-full-page-webview-2-1.png
```

```json
{"width":1280,"height":1600,"identicalPixelRatio":1,"meanChannelDifference":0}
```

<img src="https://raw.githubusercontent.com/dgk-dev/paseo/qa-full-page-capture-evidence/qa-evidence/full-page-capture/before-repeated-viewport.png" width="420" alt="Before: visible viewport repeated in both halves" />

#### After

```bash
npx vitest run \
  packages/desktop/src/features/browser-automation/full-page-capture.test.ts \
  packages/desktop/src/features/browser-automation/service.test.ts \
  packages/desktop/src/features/browser-automation/ipc.test.ts --bail=1
```

```text
Test Files  3 passed (3)
Tests       75 passed (75)
```

```bash
npm run test:e2e:browser-tabs --workspace=@getpaseo/desktop
```

```text
Browser desktop browser E2E passed: WebContents 2 remained 2; viewport, inactive capture, focus continuity, list, snapshot, click passed.
```

The E2E starts with a 375×1600 page, installs mandatory scroll snapping, overflow locking, and an overridden `window.scrollTo`, then expands the document to 2000px during scrolling. It verifies the dynamically added green bottom marker, confirms a fixed header appears only once, restores sticky/fixed styles, and returns scroll to `{ "x": 0, "y": 0 }`.

```bash
PASEO_CAPTURE_HARNESS_SOAK_MS=0 \
  PASEO_CAPTURE_HARNESS_OUT_DIR=/tmp/paseo-fullpage-production-helper \
  npm run capture-harness --workspace=@getpaseo/desktop
```

The compiled production helper passed fresh, settled, soak, multi-tab, occluded, and minimized full-page captures. Representative raw result:

```text
PASS permanent P1 attach-off settled full-page webview 2 1/5 attempts=1 size=1280x1600 logical=1280x1600 bright=0.9293 text=true bottom=true file=/tmp/paseo-fullpage-production-helper/permanent-parking/attach-off-throttling/p1-overflow-1x1/settled-full-page-webview-2-1.png
PASS capture harness permanent-parking complete output=/tmp/paseo-fullpage-production-helper
```

<img src="https://raw.githubusercontent.com/dgk-dev/paseo/qa-full-page-capture-evidence/qa-evidence/full-page-capture/after-stitched-page.png" width="420" alt="After: actual page bottom marker is present" />

Additional real-Electron edge audit:

```json
{"redirectedScroll":"FullPageCaptureUnsupportedError","finalScroll":{"x":0,"y":0}}
{"fixedHeaderSamples":{"y20":"red","y320":"green","y620":"blue"}}
{"dynamicHeight":{"screenshotHeight":1500,"documentHeightAfterCapture":1500}}
{"longPage":{"elapsedMs":12058,"ok":true,"width":400,"height":30000}}
```

The pre-fix 30,000px service call returned a misleading `screenshot_no_frame` after 6782ms. It now succeeds under the bounded 30-second budget; a true timeout aborts the active helper and returns `browser_timeout`. Unstable JS scroll redirection returns an explicit `browser_unsupported` failure instead of a corrupted success image.

Also passed:

```text
npm run typecheck     # passed all workspaces
npm run lint          # 0 warnings, 0 errors across 3343 files
npm run format:check  # all 3579 files correctly formatted
git diff --check      # clean
```

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

