### PR TITLE
Fix PR status polling in detached worktrees

### DIFF
--- a/packages/server/src/services/github-service.test.ts
+++ b/packages/server/src/services/github-service.test.ts
@@ -311,6 +311,15 @@ function noPullRequestError(args: string[] = ["pr", "view"]): GitHubCommandError
   });
 }
 
+function detachedHeadError(args: string[] = ["pr", "view"]): GitHubCommandError {
+  return new GitHubCommandError({
+    args,
+    cwd: "/repo",
+    exitCode: 1,
+    stderr: "could not determine current branch: failed to run git: not on any branch\n",
+  });
+}
+
 function statusCheckRollupPermissionError(args: string[]): GitHubCommandError {
   return new GitHubCommandError({
     args,
@@ -2782,6 +2791,58 @@ describe("ForgeService", () => {
       headRefName: "feature/fork",
     });
     expect(runner.calls[2]?.args).toContain("forkOwner:feature/fork");
+  });
+
+  it("falls back to the known head ref when the checkout has detached HEAD", async () => {
+    const runner = createScriptedRunner([
+      { error: detachedHeadError() },
+      JSON.stringify([
+        {
+          number: 89,
+          url: "https://github.com/repoOwner/repo/pull/89",
+          title: "Detached worktree PR",
+          state: "OPEN",
+          isDraft: false,
+          baseRefName: "main",
+          headRefName: "feature/detached",
+          mergedAt: null,
+          statusCheckRollup: [],
+          reviewDecision: null,
+          headRepositoryOwner: { login: "repoOwner" },
+        },
+      ]),
+    ]);
+    const service = createGitHubService({
+      runner: runner.runner,
+      resolveGhPath: async () => "/usr/bin/gh",
+      now: () => 100,
+    });
+
+    const status = await service.getCurrentPullRequestStatus({
+      cwd: "/repo",
+      headRef: "feature/detached",
+      headRepositoryOwner: "repoOwner",
+    });
+
+    expect(status).toMatchObject({
+      number: 89,
+      headRefName: "feature/detached",
+    });
+    expect(runner.calls.slice(0, 2).map((call) => call.args)).toEqual([
+      ["pr", "view", "--json", CURRENT_PR_STATUS_FIELDS],
+      [
+        "pr",
+        "list",
+        "--state",
+        "all",
+        "--head",
+        "feature/detached",
+        "--limit",
+        "10",
+        "--json",
+        CURRENT_PR_STATUS_FIELDS,
+      ],
+    ]);
   });
 
   it("propagates DNS errors while resolving the current PR view", async () => {

--- a/packages/server/src/services/github-service.ts
+++ b/packages/server/src/services/github-service.ts
@@ -1870,6 +1870,14 @@ function isNoPullRequestFoundError(error: unknown): boolean {
   return text.includes("no pull requests found");
 }
 
+function isDetachedHeadError(error: unknown): boolean {
+  if (!(error instanceof GitHubCommandError)) {
+    return false;
+  }
+  const text = error.stderr.toLowerCase();
+  return text.includes("could not determine current branch") && text.includes("not on any branch");
+}
+
 function isStatusCheckRollupPermissionError(error: unknown): boolean {
   if (!(error instanceof GitHubCommandError)) {
     return false;
@@ -2003,7 +2011,7 @@ async function tryCurrentPullRequestView(options: {
       cwd: options.cwd,
     });
   } catch (error) {
-    if (isNoPullRequestFoundError(error)) {
+    if (isNoPullRequestFoundError(error) || isDetachedHeadError(error)) {
       return null;
     }
     throw error;


### PR DESCRIPTION
### Linked issue

Closes #3199

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo knows the branch head ref for managed worktrees, but current PR resolution first runs a bare `gh pr view`. In detached HEAD worktrees, GitHub CLI cannot infer a current branch and throws before Paseo reaches its existing `gh pr list --head <known-ref>` fallback.

Treat only GitHub CLI's detached-HEAD signature as an unavailable direct view, allowing the existing head-ref lookup to continue. Other failures, including DNS errors, still propagate.

### Goals

- Resolve PR status for detached worktrees using the already-known head ref.
- Retain the existing fork-owner and candidate matching rules.
- Keep unrelated GitHub CLI failures visible.
- Cover the exact observed CLI stderr with a regression test.

### Non-goals

- Change how Paseo creates or checks out worktrees.
- Suppress general `gh` command, authentication, or network errors.
- Change PR candidate selection.

### QA

Observed before on macOS 15.7.7 with Paseo 0.2.5 (the same direct-view path remains on current `main`):

```text
command: gh pr view --json number,url,title,state,isDraft,baseRefName,headRefName,headRefOid,mergedAt,reviewDecision,mergeable,headRepositoryOwner,statusCheckRollup
exitCode: 1
stderr: could not determine current branch: failed to run git: not on any branch
headRef: agent/feat-notion-root-projection
reason: self-heal-forge-pr-status
```

Automated verification after the change:

```text
$ npm run test:unit -- src/services/github-service.test.ts
Test Files  1 passed (1)
Tests       93 passed (93)

$ git commit --amend --no-edit
✓ format
✓ lint
✓ typecheck
```

The regression test feeds the exact detached-HEAD stderr and verifies the next command is `gh pr list --head feature/detached`, returning the matching PR. The existing DNS propagation test remains green.

Tested on macOS 15.7.7. Windows and Linux were not manually tested. There is no visual UI change.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
