### PR TITLE
Skip timeline index requests for draft agents

### DIFF
--- a/packages/app/src/agent-stream/chat-outline/use-chat-outline.test.tsx
+++ b/packages/app/src/agent-stream/chat-outline/use-chat-outline.test.tsx
@@ -45,6 +45,25 @@ describe("useChatOutline", () => {
     runtime.on.mockClear();
   });
 
+  it("does not request a prompt index when the outline is disabled", () => {
+    const viewportRef = createRef<StreamViewportHandle>();
+    renderHook(() =>
+      useChatOutline({
+        agentId: "draft_msg_1",
+        serverId: "server-1",
+        timelineEpoch: null,
+        tail: [],
+        head: [],
+        enabled: false,
+        viewportRef,
+        onJumpError: vi.fn(),
+      }),
+    );
+
+    expect(runtime.listAgentTimelinePrompts).not.toHaveBeenCalled();
+    expect(runtime.on).not.toHaveBeenCalled();
+  });
+
   it("drops a late prompt index after the authoritative timeline epoch changes", async () => {
     const first = deferred<{ epoch: string; prompts: [] }>();
     const second = deferred<{

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -547,7 +547,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       timelineEpoch,
       tail: effectiveStreamItems,
       head: effectiveStreamHead,
-      enabled: supportsChatOutline && chatOutlineEnabled,
+      enabled: supportsChatOutline && chatOutlineEnabled && isAuthoritativeHistoryReady,
       viewportRef,
       onJumpError: handleTimelineHistoryLoadError,
     });

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -665,6 +665,7 @@ export function WorkspaceDraftAgentTab({
               pendingMessageSubmissions={pendingMessageSubmissions}
               turnPresentation={turnPresentation}
               pendingPermissions={EMPTY_PENDING_PERMISSIONS}
+              isAuthoritativeHistoryReady={false}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
             />
           </View>


### PR DESCRIPTION
### Linked issue

Closes #3201

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

During the first-message create flow, the draft tab renders an optimistic `AgentStreamView` with a temporary `draft_msg_*` ID. Chat outline sees the server capability and immediately asks for that ID's timeline prompt index. The daemon correctly rejects it because no such agent exists.

Mark the optimistic draft stream as lacking authoritative history and require authoritative history before enabling Chat outline requests. Real agent panels already supply their history readiness, so their outline loads once the server timeline has been applied.

### Goals

- Do not send agent timeline requests for optimistic draft IDs.
- Continue showing the optimistic first message while agent creation is in flight.
- Enable Chat outline normally after the real agent's authoritative history is ready.
- Cover the disabled-outline no-request contract with an automated test.

### Non-goals

- Change draft creation or optimistic message rendering.
- Change the Chat outline UI or user setting.
- Hide genuine missing-agent errors from the daemon.

### QA

Observed before on macOS 15.7.7 with Paseo 0.3.0 and 0.3.1:

```text
{"level":50,"daemonVersion":"0.3.1","module":"session","err":{"type":"Error","message":"Agent not found: draft_msg_1786426817104_xprtf1qy9"},"agentId":"draft_msg_1786426817104_xprtf1qy9","msg":"Failed to handle agent.timeline.list_prompts.request"}
```

Automated verification after the change:

```text
$ npm test --workspace=@getpaseo/app -- --run src/agent-stream/chat-outline/use-chat-outline.test.tsx
Test Files  1 passed (1)
Tests       4 passed (4)

$ git commit -m "fix draft timeline index requests"
✓ format
✓ lint
✓ typecheck
```

The added test verifies a disabled outline neither calls `listAgentTimelinePrompts` nor subscribes to the agent stream.

Tested on the web-targeted hook environment and macOS 15.7.7 logs. The packaged Desktop, iOS, and Android apps were not manually tested. There is no visible UI change, so no screenshot applies.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
