### PR TITLE
Fix Codex native archive ordering

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -293,11 +293,22 @@ class HeldReloadCloseClient extends TestAgentClient {
 class NativeArchiveRecordingClient extends TestAgentClient {
   readonly archivedHandles: AgentPersistenceHandle[] = [];
   readonly unarchivedHandles: AgentPersistenceHandle[] = [];
+  readonly archiveEvents: string[] = [];
   readArchivedAtDuringUnarchive: (() => Promise<string | null | undefined>) | null = null;
   archivedAtDuringUnarchive: string | null | undefined;
   unarchiveFailure: Error | null = null;
 
+  override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+    const events = this.archiveEvents;
+    return new (class extends TestAgentSession {
+      override async close(): Promise<void> {
+        events.push("runtime_closed");
+      }
+    })(config);
+  }
+
   async archiveNativeSession(handle: AgentPersistenceHandle): Promise<void> {
+    this.archiveEvents.push("native_archived");
     this.archivedHandles.push(handle);
   }
 
@@ -6567,6 +6578,33 @@ test("unarchiveSnapshot skips native provider unarchive for active records", asy
 
   expect(unarchived).toBe(false);
   expect(client.unarchivedHandles).toEqual([]);
+});
+
+test("archiveAgent closes the live provider before archiving its native session", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-native-archive-order-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const client = new NativeArchiveRecordingClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  const agent = await manager.createAgent(
+    {
+      provider: "codex",
+      cwd: workdir,
+      title: "Native archive ordering target",
+    },
+    undefined,
+    { workspaceId: undefined },
+  );
+
+  await manager.archiveAgent(agent.id);
+
+  expect(client.archiveEvents).toEqual(["runtime_closed", "native_archived"]);
+  expect(client.archivedHandles).toHaveLength(1);
 });
 
 test("unarchiveSnapshot unarchives native provider storage before clearing archivedAt", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1510,6 +1510,7 @@ export class AgentManager {
     const { archivedAt } = await this.markRecordArchived(stored);
     agent.updatedAt = new Date(archivedAt);
     await this.closeAgent(agentId);
+    await this.archiveNativeSessionBestEffort(stored.provider, stored.persistence);
     this.discardRetainedAgentState(agentId);
 
     await this.cascadeArchiveChildren(agentId);
@@ -1548,8 +1549,6 @@ export class AgentManager {
     const archivedRecord = buildArchivedAgentRecord(record, { archivedAt, updatedAt: archivedAt });
 
     await registry.upsert(archivedRecord);
-
-    await this.archiveNativeSessionBestEffort(record.provider, record.persistence);
 
     if (this.agents.has(record.id)) {
       this.notifyAgentState(record.id);
@@ -4570,7 +4569,7 @@ export class AgentManager {
       await client.archiveNativeSession(persistence);
     } catch (error) {
       this.logger.warn(
-        { error, provider, sessionId: persistence.sessionId },
+        { err: error, provider, sessionId: persistence.sessionId },
         "Failed to archive native session (best-effort)",
       );
     }


### PR DESCRIPTION
### Linked issue

Closes #3200

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`archiveAgent()` marked the record archived and asked Codex to archive its native session before closing the live provider runtime. In repeated real runs, Paseo logged `Failed to archive native session (best-effort)` and the session stayed under `~/.codex/sessions`.

Close the live provider first, then perform the native archive. Also log the caught exception through Pino's `err` field so a future provider failure retains its details.

### Goals

- Close the live provider session before moving its native persistence.
- Keep snapshot-only archive behavior unchanged.
- Preserve best-effort handling while making failures diagnosable.
- Cover the ordering contract with an automated regression test.

### Non-goals

- Change unarchive behavior.
- Change archive cascading or record state transitions.
- Make native provider archival mandatory for providers that do not support it.

### QA

Observed before on macOS 15.7.7 with Paseo 0.2.5, 0.3.0, and 0.3.1:

```text
{"level":40,"daemonVersion":"0.3.1","module":"agent","component":"agent-manager","error":{},"provider":"codex","sessionId":"019feed0-974d-7ac1-8632-de2ad745a56e","msg":"Failed to archive native session (best-effort)"}
```

Automated verification after the change:

```text
$ npm run test:unit -- src/server/agent/agent-manager.test.ts
Test Files  1 passed (1)
Tests       152 passed (152)

$ git commit -m "fix Codex native archive ordering"
✓ format
✓ lint
✓ typecheck
```

The added test records provider close/archive events and asserts `runtime_closed` occurs before `native_archived`.

Tested on macOS 15.7.7. Windows and Linux were not manually tested. There is no visual UI change.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
