### PR TITLE
feat: let a workspace pick its comparison base branch

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -29,6 +29,11 @@ mutable placement facts, but never changes `projectId`, `cwd`, `displayName`, or
 Workspace archive runs lifecycle teardown from the exact `cwd` but removes only the backing
 `worktreeRoot` after its last active reference disappears. Worktree recovery recreates that backing
 checkout from `mainRepoRoot`, then restores the relative path from `worktreeRoot` to `cwd`.
+`baseBranch` remains a creation/recovery fact. `comparisonBaseBranch` is the independent user
+override for committed diffs; missing or null follows the repository default remote-tracking ref
+such as `origin/main`. Paseo prefers `origin`; when it is absent, it uses the first remote from
+`git remote -v`. It falls back to a local default branch only when the selected remote has no
+default ref.
 
 Paseo uses **file-based JSON persistence** instead of a traditional database. All data is validated at runtime with Zod schemas. Most stores write atomically (write to temp file, then rename); a few still use plain `writeFile` — see each section. There is no schema-versioning/migration framework — schemas rely on optional fields with defaults for forward compatibility, with a small amount of inline normalization in `persisted-config.ts` for legacy provider/speech entries.
 
@@ -406,6 +411,7 @@ Array of workspace records. A workspace is a specific working directory within a
 | `branch`                       | `string \| null`                                | The current Git branch for git-backed workspaces. Separate from `displayName`/`title`; a background branch refresh never rewrites the name.                                                   |
 | `worktreeRoot`                 | `string \| null`                                | Backing checkout/worktree root. May differ from `cwd` for exact subprojects and remains persisted after the worktree is deleted so restore can reproduce the placement.                       |
 | `baseBranch`                   | `string \| null`                                | Normalized branch the Paseo worktree was created from; null for directories, local checkouts, and checkout-branch worktrees                                                                   |
+| `comparisonBaseBranch`         | `string?` (nullable)                            | User-set committed-diff base override. Missing or null follows the selected remote's default tracking ref (for example, `origin/main`); it never changes worktree recovery placement.         |
 | `isPaseoOwnedWorktree`         | `boolean`                                       | Whether Paseo owns and may remove/recreate the backing `worktreeRoot`                                                                                                                         |
 | `mainRepoRoot`                 | `string \| null`                                | Main repository root for worktree checkouts, independent of both exact `cwd` and backing `worktreeRoot`                                                                                       |
 | `createdAt`                    | `string` (ISO 8601)                             |                                                                                                                                                                                               |

--- a/packages/app/src/components/ui/dropdown-menu.tsx
+++ b/packages/app/src/components/ui/dropdown-menu.tsx
@@ -8,6 +8,7 @@ import {
   MenuSurface,
   MenuTrigger,
   useMenuContext,
+  type MenuPresentation,
   type MenuSurfaceProps,
   type MenuTriggerProps,
 } from "@/components/ui/menu";
@@ -38,4 +39,9 @@ export function DropdownMenuContent(props: MenuSurfaceProps): ReactElement | nul
 export function useDropdownMenuClose(): () => void {
   const { setOpen } = useMenuContext("useDropdownMenuClose");
   return useCallback(() => setOpen(false), [setOpen]);
+}
+
+/** Whether the menu is drawing as a popover or a bottom sheet, for content that must adapt. */
+export function useDropdownMenuPresentation(): MenuPresentation {
+  return useMenuContext("useDropdownMenuPresentation").presentation;
 }

--- a/packages/app/src/git/checkout-status-cache.test.ts
+++ b/packages/app/src/git/checkout-status-cache.test.ts
@@ -174,6 +174,7 @@ describe("applyCheckoutStatusUpdateFromEvent", () => {
   it("invalidates recent commits when checkout status is pushed", () => {
     const queryClient = createQueryClient();
     queryClient.setQueryData(checkoutCommitsQueryKey(serverId, cwd), { commits: [] });
+    queryClient.setQueryData(checkoutCommitsQueryKey(serverId, cwd, "main"), { commits: [] });
     queryClient.setQueryData(checkoutCommitsQueryKey(serverId, "/repo2"), { commits: [] });
 
     applyCheckoutStatusUpdateFromEvent({
@@ -185,6 +186,9 @@ describe("applyCheckoutStatusUpdateFromEvent", () => {
     expect(queryClient.getQueryState(checkoutCommitsQueryKey(serverId, cwd))?.isInvalidated).toBe(
       true,
     );
+    expect(
+      queryClient.getQueryState(checkoutCommitsQueryKey(serverId, cwd, "main"))?.isInvalidated,
+    ).toBe(true);
     expect(
       queryClient.getQueryState(checkoutCommitsQueryKey(serverId, "/repo2"))?.isInvalidated,
     ).toBe(false);

--- a/packages/app/src/git/commits-section/commits-section.tsx
+++ b/packages/app/src/git/commits-section/commits-section.tsx
@@ -12,6 +12,7 @@ import { CommitRow } from "./commit-row";
 interface CommitsSectionProps {
   serverId: string;
   cwd: string;
+  baseRef?: string;
   onCommitPress: (sha: string) => void;
 }
 
@@ -82,7 +83,7 @@ function CommitsSectionContent({
   );
 }
 
-export function CommitsSection({ serverId, cwd, onCommitPress }: CommitsSectionProps) {
+export function CommitsSection({ serverId, cwd, baseRef, onCommitPress }: CommitsSectionProps) {
   const { t } = useTranslation();
   const { preferences, updatePreferences } = useChangesPreferences();
   const isPanelActive = useRetainedPanelActive();
@@ -92,6 +93,7 @@ export function CommitsSection({ serverId, cwd, onCommitPress }: CommitsSectionP
   const query = useCheckoutCommitsQuery({
     serverId,
     cwd,
+    baseRef,
     enabled: !collapsed,
   });
 

--- a/packages/app/src/git/diff-pane.tsx
+++ b/packages/app/src/git/diff-pane.tsx
@@ -75,6 +75,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import * as Clipboard from "expo-clipboard";
@@ -122,6 +123,12 @@ import {
 import { usePublishWorkingDiffAttachment, useWorkingDiff } from "@/git/use-working-diff";
 import { DiffTooLargeState } from "@/git/diff-too-large-state";
 import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+import {
+  formatWorkspaceBaseBranchLabel,
+  useWorkspaceBaseBranchControl,
+  WorkspaceBaseBranchMenuPage,
+  type WorkspaceBaseBranchMenuConfig,
+} from "@/git/workspace-base-branch-menu";
 
 export type { GitActionId, GitAction, GitActions } from "@/git/policy";
 
@@ -1532,10 +1539,16 @@ interface ChangesTabToggleProps {
   onPress: () => void;
 }
 
+/** Caps the diff mode popover so a long branch list scrolls instead of overflowing the screen. */
+const BASE_BRANCH_MENU_MAX_HEIGHT = 360;
+
 interface DiffModeMenuProps {
   diffMode: "uncommitted" | "base";
   committedDescription?: string;
+  baseBranchMenu?: WorkspaceBaseBranchMenuConfig;
+  open?: boolean;
   testIDPrefix?: string;
+  onOpenChange?: (open: boolean) => void;
   onSelectUncommitted: () => void;
   onSelectBase: () => void;
 }
@@ -1543,7 +1556,10 @@ interface DiffModeMenuProps {
 export function DiffModeMenu({
   diffMode,
   committedDescription,
+  baseBranchMenu,
+  open,
   testIDPrefix = "changes-diff",
+  onOpenChange,
   onSelectUncommitted,
   onSelectBase,
 }: DiffModeMenuProps) {
@@ -1551,8 +1567,21 @@ export function DiffModeMenu({
   const triggerStyle = useMemo(() => buildDiffModeTriggerStyle(), []);
   const uncommittedLabel = t("workspace.git.diff.uncommitted");
   const committedLabel = t("workspace.git.diff.committed");
+  const baseBranchPages = useMemo(
+    () =>
+      baseBranchMenu
+        ? [
+            {
+              id: "baseBranch",
+              title: t("workspace.git.diff.baseBranch.label"),
+              content: <WorkspaceBaseBranchMenuPage config={baseBranchMenu} />,
+            },
+          ]
+        : undefined,
+    [baseBranchMenu, t],
+  );
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <DropdownMenuTrigger
         testID={`${testIDPrefix}-status-trigger`}
         style={triggerStyle}
@@ -1564,7 +1593,17 @@ export function DiffModeMenu({
         </Text>
         <ThemedChevronDown size={12} uniProps={foregroundMutedIconColorMapping} />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" width={260} testID={`${testIDPrefix}-status-menu`}>
+      <DropdownMenuContent
+        align="start"
+        width={260}
+        pages={baseBranchPages}
+        // The base branch page lists every branch in the repository, so the surface has to cap
+        // itself and scroll rather than run off the bottom of the screen.
+        scrollable
+        maxHeight={BASE_BRANCH_MENU_MAX_HEIGHT}
+        sheetTitle={t("workspace.git.diff.diffMode")}
+        testID={`${testIDPrefix}-status-menu`}
+      >
         <DropdownMenuItem
           testID={`${testIDPrefix}-mode-uncommitted`}
           selected={diffMode === "uncommitted"}
@@ -1581,6 +1620,22 @@ export function DiffModeMenu({
         >
           {committedLabel}
         </DropdownMenuItem>
+        {baseBranchMenu ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuSubTrigger
+              id="baseBranch"
+              value={
+                formatWorkspaceBaseBranchLabel(baseBranchMenu.effectiveBaseBranch) ??
+                t("workspace.git.diff.base")
+              }
+              indicator={baseBranchMenu.baseBranchOverride !== null}
+              testID={`${testIDPrefix}-base-branch`}
+            >
+              {t("workspace.git.diff.baseBranch.label")}
+            </DropdownMenuSubTrigger>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -2552,9 +2607,7 @@ export function SharedDiffView({ files, displayPreferences, mode }: SharedDiffVi
 }
 
 function computeBaseRefLabel(baseRef: string | undefined, fallbackLabel: string): string {
-  if (!baseRef) return fallbackLabel;
-  const trimmed = baseRef.replace(/^refs\/(heads|remotes)\//, "").trim();
-  return trimmed.startsWith("origin/") ? trimmed.slice("origin/".length) : trimmed;
+  return formatWorkspaceBaseBranchLabel(baseRef ?? null) ?? fallbackLabel;
 }
 
 function computeCommittedDiffDescription(
@@ -2894,6 +2947,7 @@ export function GitDiffPane({
     isLocalExecution: isLocalDaemon,
   });
   const fileManagerTarget = desktopOpenTargets.find((target) => target.kind === "file-manager");
+  const baseBranchControl = useWorkspaceBaseBranchControl({ serverId, workspaceId, cwd });
   const {
     changesTabOpen,
     toggleChanges: handleToggleChangesTab,
@@ -2943,6 +2997,7 @@ export function GitDiffPane({
     serverId,
     workspaceId: workspaceId ?? undefined,
     cwd,
+    comparisonBaseRef: baseBranchControl.comparisonBaseRef,
     ignoreWhitespace: changesPreferences.hideWhitespace,
     enabled: enabled !== false,
   });
@@ -3177,6 +3232,9 @@ export function GitDiffPane({
             <DiffModeMenu
               diffMode={diffMode}
               committedDescription={committedDiffDescription}
+              baseBranchMenu={baseBranchControl.menuConfig}
+              open={baseBranchControl.menuOpen}
+              onOpenChange={baseBranchControl.setMenuOpen}
               onSelectUncommitted={handleSelectUncommitted}
               onSelectBase={handleSelectBase}
             />
@@ -3237,7 +3295,12 @@ export function GitDiffPane({
 
       <View style={styles.diffContainer}>{bodyContent}</View>
 
-      <CommitsSection serverId={serverId} cwd={cwd} onCommitPress={handleCommitPress} />
+      <CommitsSection
+        serverId={serverId}
+        cwd={cwd}
+        baseRef={baseRef}
+        onCommitPress={handleCommitPress}
+      />
     </View>
   );
 }

--- a/packages/app/src/git/query-keys.test.ts
+++ b/packages/app/src/git/query-keys.test.ts
@@ -26,6 +26,7 @@ describe("checkout query keys", () => {
     });
     queryClient.setQueryData(checkoutPrStatusQueryKey(serverId, cwd), { status: { number: 12 } });
     queryClient.setQueryData(checkoutCommitsQueryKey(serverId, cwd), { commits: [] });
+    queryClient.setQueryData(checkoutCommitsQueryKey(serverId, cwd, "main"), { commits: [] });
     queryClient.setQueryData(checkoutCommitsQueryKey(serverId, "/tmp/other"), { commits: [] });
     queryClient.setQueryData(prPaneTimelineQueryKey({ serverId, cwd, prNumber: 12 }), {
       items: [],
@@ -68,6 +69,9 @@ describe("checkout query keys", () => {
     expect(queryClient.getQueryState(checkoutCommitsQueryKey(serverId, cwd))?.isInvalidated).toBe(
       true,
     );
+    expect(
+      queryClient.getQueryState(checkoutCommitsQueryKey(serverId, cwd, "main"))?.isInvalidated,
+    ).toBe(true);
     expect(
       queryClient.getQueryState(checkoutCommitsQueryKey(serverId, "/tmp/other"))?.isInvalidated,
     ).toBe(false);

--- a/packages/app/src/git/query-keys.ts
+++ b/packages/app/src/git/query-keys.ts
@@ -35,8 +35,9 @@ export function checkoutPrStatusQueryKey(serverId: string, cwd: string) {
   return ["checkoutPrStatus", serverId, cwd] as const;
 }
 
-export function checkoutCommitsQueryKey(serverId: string, cwd: string) {
-  return ["checkoutCommits", serverId, cwd] as const;
+export function checkoutCommitsQueryKey(serverId: string, cwd: string, baseRef?: string) {
+  const checkoutKey = ["checkoutCommits", serverId, cwd] as const;
+  return baseRef ? ([...checkoutKey, baseRef] as const) : checkoutKey;
 }
 
 export function checkoutCommitFileDiffQueryKey(

--- a/packages/app/src/git/use-actions.tsx
+++ b/packages/app/src/git/use-actions.tsx
@@ -100,8 +100,7 @@ function resolveBranchLabel(input: {
 
 function formatBaseRefLabel(baseRef: string | undefined, fallbackLabel: string): string {
   if (!baseRef) return fallbackLabel;
-  const trimmed = baseRef.replace(/^refs\/(heads|remotes)\//, "").trim();
-  return trimmed.startsWith("origin/") ? trimmed.slice("origin/".length) : trimmed;
+  return baseRef.replace(/^refs\/(heads|remotes)\//, "").trim();
 }
 
 type PrStatusValue = NonNullable<CheckoutPrStatusPayload["status"]> | null;

--- a/packages/app/src/git/use-commits-query.ts
+++ b/packages/app/src/git/use-commits-query.ts
@@ -13,6 +13,7 @@ const CHECKOUT_COMMITS_STALE_TIME = 30_000;
 interface UseCheckoutCommitsQueryOptions {
   serverId: string;
   cwd: string;
+  baseRef?: string;
   enabled?: boolean;
 }
 
@@ -71,6 +72,7 @@ export function resolveCheckoutCommitsQueryResult({
 export function useCheckoutCommitsQuery({
   serverId,
   cwd,
+  baseRef,
   enabled = true,
 }: UseCheckoutCommitsQueryOptions): CheckoutCommitsQueryResult {
   const retainedPanelActive = useRetainedPanelActive();
@@ -90,12 +92,12 @@ export function useCheckoutCommitsQuery({
   const queryEnabled = queryEnabledByCaller && capabilityPresent && canFetch;
 
   const query = useFetchQuery<CheckoutCommitsData>({
-    queryKey: checkoutCommitsQueryKey(serverId, cwd),
+    queryKey: checkoutCommitsQueryKey(serverId, cwd, baseRef),
     queryFn: async () => {
       if (!client) {
         throw new Error("Host disconnected");
       }
-      const data = await client.listCheckoutCommits(cwd);
+      const data = await client.listCheckoutCommits(cwd, { baseRef });
       const commits = data.commits.map((commit) => {
         invariant(commit.isOnBase !== undefined, "Host omitted commit base classification");
         return { ...commit, isOnBase: commit.isOnBase };

--- a/packages/app/src/git/use-working-diff.ts
+++ b/packages/app/src/git/use-working-diff.ts
@@ -18,6 +18,7 @@ interface UseWorkingDiffOptions {
   serverId: string;
   workspaceId?: string;
   cwd: string;
+  comparisonBaseRef?: string | null;
   ignoreWhitespace: boolean;
   enabled: boolean;
   queryScope?: string;
@@ -27,6 +28,7 @@ export function useWorkingDiff({
   serverId,
   workspaceId,
   cwd,
+  comparisonBaseRef,
   ignoreWhitespace,
   enabled,
   queryScope,
@@ -43,7 +45,11 @@ export function useWorkingDiff({
   const statusErrorMessage =
     status?.error?.message ??
     (isStatusError && statusError instanceof Error ? statusError.message : null);
-  const baseRef = gitStatus?.baseRef ?? undefined;
+  // COMPAT(workspaceBaseBranch): added in v0.3.0, remove fallback after 2027-02-07.
+  const baseRef =
+    comparisonBaseRef !== undefined
+      ? (comparisonBaseRef ?? undefined)
+      : (gitStatus?.baseRef ?? undefined);
   const hasUncommittedChanges = Boolean(gitStatus?.isDirty);
   const currentBranchName =
     gitStatus?.currentBranch && gitStatus.currentBranch !== "HEAD" ? gitStatus.currentBranch : null;

--- a/packages/app/src/git/workspace-base-branch-filter.test.ts
+++ b/packages/app/src/git/workspace-base-branch-filter.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { filterBranches } from "./workspace-base-branch-filter";
+
+const BRANCHES = ["main", "jstrain/fix-hover", "mmilenkovic/feat-hover-intent", "hotfix/main-sync"];
+
+describe("filterBranches", () => {
+  it("returns every branch when the query is blank", () => {
+    expect(filterBranches(BRANCHES, "   ")).toEqual(BRANCHES);
+  });
+
+  it("matches anywhere in the name, case-insensitively", () => {
+    expect(filterBranches(BRANCHES, "HOVER")).toEqual([
+      "jstrain/fix-hover",
+      "mmilenkovic/feat-hover-intent",
+    ]);
+  });
+
+  it("ranks earlier matches first", () => {
+    expect(filterBranches(BRANCHES, "main")).toEqual(["main", "hotfix/main-sync"]);
+  });
+
+  it("returns nothing when no branch matches", () => {
+    expect(filterBranches(BRANCHES, "nope")).toEqual([]);
+  });
+});

--- a/packages/app/src/git/workspace-base-branch-filter.ts
+++ b/packages/app/src/git/workspace-base-branch-filter.ts
@@ -1,0 +1,15 @@
+/**
+ * Substring match, prefix hits first. Branch names are long and share prefixes
+ * (`mmilenkovic/feat-…`), so the useful query is usually a fragment from the middle.
+ */
+export function filterBranches(branches: readonly string[], query: string): string[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [...branches];
+  const matches: { branch: string; index: number }[] = [];
+  for (const branch of branches) {
+    const index = branch.toLowerCase().indexOf(needle);
+    if (index >= 0) matches.push({ branch, index });
+  }
+  matches.sort((a, b) => a.index - b.index);
+  return matches.map((match) => match.branch);
+}

--- a/packages/app/src/git/workspace-base-branch-menu.tsx
+++ b/packages/app/src/git/workspace-base-branch-menu.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { SearchInput } from "@/components/ui/combobox";
+import { filterBranches } from "@/git/workspace-base-branch-filter";
+import {
+  DropdownMenuHint,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  useDropdownMenuClose,
+  useDropdownMenuPresentation,
+} from "@/components/ui/dropdown-menu";
+import { useFetchQuery } from "@/data/query";
+import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import { useSessionStore } from "@/stores/session-store";
+import { useWorkspaceFields } from "@/stores/session-store-hooks";
+
+export interface WorkspaceBaseBranchMenuConfig {
+  effectiveBaseBranch: string | null;
+  baseBranchOverride: string | null;
+  branches: string[];
+  branchesError: string | null;
+  branchesLoading: boolean;
+  onRetryBranches: () => void;
+  onSelect: (baseBranch: string | null) => Promise<void>;
+}
+
+interface WorkspaceBaseBranchControl {
+  comparisonBaseRef: string | null | undefined;
+  menuConfig: WorkspaceBaseBranchMenuConfig | undefined;
+  menuOpen: boolean;
+  setMenuOpen: (open: boolean) => void;
+}
+
+interface PendingBaseBranchSelection {
+  baseBranch: string | null;
+}
+
+export function formatWorkspaceBaseBranchLabel(baseBranch: string | null): string | null {
+  if (!baseBranch) return null;
+  return baseBranch.replace(/^refs\/(heads|remotes)\//, "").trim();
+}
+
+function resolveQueryError(error: Error | null, fallback: string): string | null {
+  if (!error) return null;
+  return error.message || fallback;
+}
+
+export function useWorkspaceBaseBranchControl(input: {
+  serverId: string;
+  workspaceId?: string | null;
+  cwd: string;
+}): WorkspaceBaseBranchControl {
+  const { t } = useTranslation();
+  const client = useHostRuntimeClient(input.serverId);
+  const isConnected = useHostRuntimeIsConnected(input.serverId);
+  const supported = useSessionStore(
+    (state) => state.sessions[input.serverId]?.serverInfo?.features?.workspaceBaseBranch === true,
+  );
+  const workspaceBaseBranch = useWorkspaceFields(
+    input.serverId,
+    input.workspaceId ?? null,
+    (workspace) => ({
+      baseBranch: workspace.baseBranch,
+      baseBranchOverride: workspace.baseBranchOverride,
+    }),
+  );
+  const comparisonBaseRef =
+    supported && workspaceBaseBranch?.baseBranch !== undefined
+      ? workspaceBaseBranch.baseBranch
+      : undefined;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const branchesQuery = useFetchQuery<string[]>({
+    queryKey: ["workspaceBaseBranchSuggestions", input.serverId, input.workspaceId, input.cwd],
+    queryFn: async () => {
+      if (!client) {
+        throw new Error(t("common.errors.daemonClientUnavailable"));
+      }
+      const result = await client.getBranchSuggestions({ cwd: input.cwd, limit: 200 });
+      if (result.error) {
+        throw new Error(result.error);
+      }
+      return result.branches;
+    },
+    enabled: menuOpen && supported && Boolean(input.workspaceId) && Boolean(client) && isConnected,
+    retry: false,
+    staleTimeMs: 15_000,
+    dataShape: "list",
+  });
+  const retryBranches = branchesQuery.refetch;
+  const handleRetryBranches = useCallback(() => {
+    void retryBranches();
+  }, [retryBranches]);
+  const handleSelect = useCallback(
+    async (nextBaseBranch: string | null) => {
+      if (!client || !input.workspaceId) {
+        throw new Error(t("common.errors.daemonClientUnavailable"));
+      }
+      await client.setWorkspaceBaseBranch(input.workspaceId, nextBaseBranch);
+    },
+    [client, input.workspaceId, t],
+  );
+  const menuConfig = useMemo<WorkspaceBaseBranchMenuConfig | undefined>(() => {
+    if (!supported || !input.workspaceId || workspaceBaseBranch?.baseBranchOverride === undefined) {
+      return undefined;
+    }
+    return {
+      effectiveBaseBranch: comparisonBaseRef ?? null,
+      baseBranchOverride: workspaceBaseBranch.baseBranchOverride,
+      branches: branchesQuery.data ?? [],
+      branchesError: resolveQueryError(
+        branchesQuery.error,
+        t("workspace.git.diff.baseBranch.loadFailed"),
+      ),
+      branchesLoading: branchesQuery.isPending || branchesQuery.isFetching,
+      onRetryBranches: handleRetryBranches,
+      onSelect: handleSelect,
+    };
+  }, [
+    branchesQuery.data,
+    branchesQuery.error,
+    branchesQuery.isFetching,
+    branchesQuery.isPending,
+    comparisonBaseRef,
+    handleRetryBranches,
+    handleSelect,
+    input.workspaceId,
+    supported,
+    t,
+    workspaceBaseBranch,
+  ]);
+
+  return { comparisonBaseRef, menuConfig, menuOpen, setMenuOpen };
+}
+
+/**
+ * Below this many branches the list fits without hunting, and a search field costs more attention
+ * than it saves.
+ */
+const SEARCH_THRESHOLD = 8;
+
+function BaseBranchOption({
+  branch,
+  selected,
+  disabled,
+  pending,
+  pendingLabel,
+  onSelect,
+}: {
+  branch: string;
+  selected: boolean;
+  disabled: boolean;
+  pending: boolean;
+  pendingLabel: string;
+  onSelect: (branch: string) => void;
+}) {
+  const handleSelect = useCallback(() => onSelect(branch), [branch, onSelect]);
+  return (
+    <DropdownMenuItem
+      selected={selected}
+      showSelectedCheck
+      closeOnSelect={false}
+      disabled={disabled}
+      status={pending ? "pending" : "idle"}
+      pendingLabel={pendingLabel}
+      testID={`changes-diff-base-branch-${branch}`}
+      onSelect={handleSelect}
+    >
+      {branch}
+    </DropdownMenuItem>
+  );
+}
+
+function renderBranchOptions(input: {
+  config: WorkspaceBaseBranchMenuConfig;
+  branches: readonly string[];
+  pendingSelection: PendingBaseBranchSelection | null;
+  pendingLabel: string;
+  loadingLabel: string;
+  retryLabel: string;
+  emptyLabel: string;
+  onSelect: (branch: string) => void;
+}): ReactNode {
+  if (input.config.branchesLoading) {
+    return <DropdownMenuItem disabled>{input.loadingLabel}</DropdownMenuItem>;
+  }
+  if (input.config.branchesError) {
+    return (
+      <>
+        <DropdownMenuHint>{input.config.branchesError}</DropdownMenuHint>
+        <DropdownMenuItem closeOnSelect={false} onSelect={input.config.onRetryBranches}>
+          {input.retryLabel}
+        </DropdownMenuItem>
+      </>
+    );
+  }
+  if (input.branches.length === 0) {
+    return <DropdownMenuHint>{input.emptyLabel}</DropdownMenuHint>;
+  }
+  return input.branches.map((branch) => (
+    <BaseBranchOption
+      key={branch}
+      branch={branch}
+      selected={input.config.baseBranchOverride === branch}
+      disabled={input.pendingSelection !== null && input.pendingSelection.baseBranch !== branch}
+      pending={input.pendingSelection?.baseBranch === branch}
+      pendingLabel={input.pendingLabel}
+      onSelect={input.onSelect}
+    />
+  ));
+}
+
+export function WorkspaceBaseBranchMenuPage({ config }: { config: WorkspaceBaseBranchMenuConfig }) {
+  const { t } = useTranslation();
+  const closeMenu = useDropdownMenuClose();
+  const presentation = useDropdownMenuPresentation();
+  const [pendingSelection, setPendingSelection] = useState<PendingBaseBranchSelection | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  const selectBaseBranch = useCallback(
+    (baseBranch: string | null) => {
+      if (pendingSelection !== null) return;
+      setPendingSelection({ baseBranch });
+      setSaveError(null);
+      void config
+        .onSelect(baseBranch)
+        .then(closeMenu)
+        .catch((error) => {
+          setPendingSelection(null);
+          setSaveError(
+            error instanceof Error ? error.message : t("workspace.git.diff.baseBranch.saveFailed"),
+          );
+        });
+    },
+    [closeMenu, config, pendingSelection, t],
+  );
+  const selectRepositoryDefault = useCallback(() => selectBaseBranch(null), [selectBaseBranch]);
+  const selectNamedBranch = useCallback(
+    (branch: string) => selectBaseBranch(branch),
+    [selectBaseBranch],
+  );
+  const isSaving = pendingSelection !== null;
+  const visibleBranches = useMemo(
+    () => filterBranches(config.branches, query),
+    [config.branches, query],
+  );
+  const showSearch =
+    !config.branchesLoading && !config.branchesError && config.branches.length >= SEARCH_THRESHOLD;
+  const branchOptions = renderBranchOptions({
+    config,
+    branches: visibleBranches,
+    pendingSelection,
+    pendingLabel: t("workspace.git.diff.baseBranch.saving"),
+    loadingLabel: t("workspace.git.diff.baseBranch.loadingBranches"),
+    retryLabel: t("common.actions.retry"),
+    emptyLabel: t("workspace.git.diff.baseBranch.noMatches"),
+    onSelect: selectNamedBranch,
+  });
+  const repositoryDefaultLabel = t("workspace.git.diff.baseBranch.repositoryDefault");
+  const showRepositoryDefault =
+    !query.trim() || repositoryDefaultLabel.toLowerCase().includes(query.trim().toLowerCase());
+
+  return (
+    <>
+      {showSearch ? (
+        <SearchInput
+          placeholder={t("workspace.git.diff.baseBranch.searchPlaceholder")}
+          onChangeText={setQuery}
+          // The sheet keeps its own keyboard-aware input, and autofocus fights the menu's
+          // dismiss-keyboard-on-open.
+          autoFocus={presentation === "popover"}
+          useBottomSheetInput={presentation === "sheet"}
+        />
+      ) : null}
+      {showRepositoryDefault ? (
+        <>
+          <DropdownMenuItem
+            selected={config.baseBranchOverride === null}
+            showSelectedCheck
+            closeOnSelect={false}
+            disabled={isSaving && pendingSelection?.baseBranch !== null}
+            status={pendingSelection?.baseBranch === null ? "pending" : "idle"}
+            pendingLabel={t("workspace.git.diff.baseBranch.saving")}
+            description={
+              config.baseBranchOverride === null
+                ? (formatWorkspaceBaseBranchLabel(config.effectiveBaseBranch) ?? undefined)
+                : undefined
+            }
+            testID="changes-diff-base-repository-default"
+            onSelect={selectRepositoryDefault}
+          >
+            {repositoryDefaultLabel}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+        </>
+      ) : null}
+      {branchOptions}
+      {saveError ? <DropdownMenuHint>{saveError}</DropdownMenuHint> : null}
+    </>
+  );
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -860,6 +860,16 @@ export const ar: TranslationResources = {
         committed: "ملتزم",
         branchUnknown: "مجهول",
         base: "قاعدة",
+        baseBranch: {
+          label: "الفرع الأساسي",
+          repositoryDefault: "الفرع الافتراضي للمستودع",
+          searchPlaceholder: "البحث في الفروع",
+          noMatches: "لا توجد فروع مطابقة",
+          loadingBranches: "جارٍ تحميل الفروع…",
+          saving: "جارٍ الحفظ…",
+          loadFailed: "فشل تحميل الفروع",
+          saveFailed: "فشل حفظ الفرع الأساسي",
+        },
         newFile: "جديد",
         deletedFile: "تم الحذف",
         commits: {

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -870,6 +870,16 @@ export const en = {
         committed: "Committed",
         branchUnknown: "Unknown",
         base: "base",
+        baseBranch: {
+          label: "Base branch",
+          repositoryDefault: "Repository default",
+          searchPlaceholder: "Search branches",
+          noMatches: "No matching branches",
+          loadingBranches: "Loading branches…",
+          saving: "Saving…",
+          loadFailed: "Failed to load branches",
+          saveFailed: "Failed to save base branch",
+        },
         newFile: "New",
         deletedFile: "Deleted",
         commits: {

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -891,6 +891,16 @@ export const es: TranslationResources = {
         committed: "Comprometido",
         branchUnknown: "Desconocido",
         base: "base",
+        baseBranch: {
+          label: "Rama base",
+          repositoryDefault: "Predeterminada del repositorio",
+          searchPlaceholder: "Buscar ramas",
+          noMatches: "No hay ramas coincidentes",
+          loadingBranches: "Cargando ramas…",
+          saving: "Guardando…",
+          loadFailed: "No se pudieron cargar las ramas",
+          saveFailed: "No se pudo guardar la rama base",
+        },
         newFile: "Nuevo",
         deletedFile: "Eliminado",
         commits: {

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -890,6 +890,16 @@ export const fr: TranslationResources = {
         committed: "Engagé",
         branchUnknown: "Inconnu",
         base: "base",
+        baseBranch: {
+          label: "Branche de base",
+          repositoryDefault: "Valeur par défaut du dépôt",
+          searchPlaceholder: "Rechercher des branches",
+          noMatches: "Aucune branche correspondante",
+          loadingBranches: "Chargement des branches…",
+          saving: "Enregistrement…",
+          loadFailed: "Échec du chargement des branches",
+          saveFailed: "Échec de l’enregistrement de la branche de base",
+        },
         newFile: "Nouveau",
         deletedFile: "Supprimé",
         commits: {

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -871,6 +871,16 @@ export const ja: TranslationResources = {
         committed: "コミット済み",
         branchUnknown: "不明",
         base: "ベース",
+        baseBranch: {
+          label: "ベースブランチ",
+          repositoryDefault: "リポジトリのデフォルト",
+          searchPlaceholder: "ブランチを検索",
+          noMatches: "一致するブランチがありません",
+          loadingBranches: "ブランチを読み込み中…",
+          saving: "保存中…",
+          loadFailed: "ブランチを読み込めませんでした",
+          saveFailed: "ベースブランチを保存できませんでした",
+        },
         newFile: "新規",
         deletedFile: "削除済み",
         commits: {

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -867,6 +867,16 @@ export const ko: TranslationResources = {
         committed: "커밋됨",
         branchUnknown: "알 수 없음",
         base: "기준",
+        baseBranch: {
+          label: "기준 브랜치",
+          repositoryDefault: "저장소 기본값",
+          searchPlaceholder: "브랜치 검색",
+          noMatches: "일치하는 브랜치 없음",
+          loadingBranches: "브랜치 불러오는 중…",
+          saving: "저장 중…",
+          loadFailed: "브랜치를 불러오지 못했습니다",
+          saveFailed: "기준 브랜치를 저장하지 못했습니다",
+        },
         newFile: "신규",
         deletedFile: "삭제됨",
         commits: {

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -882,6 +882,16 @@ export const ptBR: TranslationResources = {
         committed: "Com commit",
         branchUnknown: "Desconhecido",
         base: "base",
+        baseBranch: {
+          label: "Branch base",
+          repositoryDefault: "Padrão do repositório",
+          searchPlaceholder: "Buscar branches",
+          noMatches: "Nenhuma branch correspondente",
+          loadingBranches: "Carregando branches…",
+          saving: "Salvando…",
+          loadFailed: "Falha ao carregar branches",
+          saveFailed: "Falha ao salvar a branch base",
+        },
         newFile: "Novo",
         deletedFile: "Excluído",
         commits: {

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -882,6 +882,16 @@ export const ru: TranslationResources = {
         committed: "Преданный идее",
         branchUnknown: "Неизвестный",
         base: "база",
+        baseBranch: {
+          label: "Базовая ветка",
+          repositoryDefault: "По умолчанию в репозитории",
+          searchPlaceholder: "Поиск веток",
+          noMatches: "Нет подходящих веток",
+          loadingBranches: "Загрузка веток…",
+          saving: "Сохранение…",
+          loadFailed: "Не удалось загрузить ветки",
+          saveFailed: "Не удалось сохранить базовую ветку",
+        },
         newFile: "Новый",
         deletedFile: "Удалено",
         commits: {

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -852,6 +852,16 @@ export const zhCN: TranslationResources = {
         committed: "已 commit",
         branchUnknown: "未知",
         base: "base",
+        baseBranch: {
+          label: "基准分支",
+          repositoryDefault: "仓库默认分支",
+          searchPlaceholder: "搜索分支",
+          noMatches: "没有匹配的分支",
+          loadingBranches: "正在加载分支…",
+          saving: "正在保存…",
+          loadFailed: "无法加载分支",
+          saveFailed: "无法保存基准分支",
+        },
         newFile: "新增",
         deletedFile: "已删除",
         commits: {

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -157,6 +157,8 @@ export interface WorkspaceDescriptor {
   workspaceKind: WorkspaceDescriptorPayload["workspaceKind"];
   name: string;
   title?: string | null;
+  baseBranch?: string | null;
+  baseBranchOverride?: string | null;
   pinnedAt?: string | null;
   status: WorkspaceDescriptorPayload["status"];
   statusEnteredAt: Date | null;
@@ -193,6 +195,8 @@ export function normalizeWorkspaceDescriptor(
     workspaceKind: payload.workspaceKind,
     name: payload.name,
     title: payload.title ?? null,
+    baseBranch: payload.baseBranch,
+    baseBranchOverride: payload.baseBranchOverride,
     pinnedAt: payload.pinnedAt ?? null,
     status: payload.status,
     statusEnteredAt,

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -2578,6 +2578,29 @@ export class DaemonClient {
     return { title: payload.title };
   }
 
+  async setWorkspaceBaseBranch(
+    workspaceId: string,
+    baseBranch: string | null,
+    requestId?: string,
+  ): Promise<{ baseBranch: string | null; baseBranchOverride: string | null }> {
+    const payload =
+      await this.sendNamespacedCorrelatedSessionRequest<"workspace.base_branch.set.response">({
+        requestId,
+        message: {
+          type: "workspace.base_branch.set.request",
+          workspaceId,
+          baseBranch,
+        },
+      });
+    if (!payload.accepted) {
+      throw new Error(payload.error ?? "setWorkspaceBaseBranch rejected");
+    }
+    return {
+      baseBranch: payload.baseBranch,
+      baseBranchOverride: payload.baseBranchOverride,
+    };
+  }
+
   async setWorkspacePinned(
     workspaceId: string,
     pinned: boolean,
@@ -3706,14 +3729,17 @@ export class DaemonClient {
 
   async listCheckoutCommits(
     cwd: string,
-    requestId?: string,
+    options?: { baseRef?: string; requestId?: string } | string,
   ): Promise<{ baseRef: string | null; commits: CheckoutCommit[] }> {
+    const requestId = typeof options === "string" ? options : options?.requestId;
+    const baseRef = typeof options === "string" ? undefined : options?.baseRef;
     const payload =
       await this.sendNamespacedCorrelatedSessionRequest<"checkout.commits.list.response">({
         requestId,
         message: {
           type: "checkout.commits.list.request",
           cwd,
+          ...(baseRef ? { baseRef } : {}),
         },
         timeout: 60000,
       });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -899,6 +899,14 @@ export const WorkspaceTitleSetRequestSchema = z.object({
   requestId: z.string(),
 });
 
+export const WorkspaceBaseBranchSetRequestSchema = z.object({
+  type: z.literal("workspace.base_branch.set.request"),
+  workspaceId: z.string(),
+  // Null clears the workspace override and follows the repository default branch.
+  baseBranch: z.string().nullable(),
+  requestId: z.string(),
+});
+
 export const WorkspacePinSetRequestSchema = z.object({
   type: z.literal("workspace.pin.set.request"),
   workspaceId: z.string(),
@@ -1629,6 +1637,20 @@ export const WorkspaceTitleSetResponseSchema = z.object({
   payload: WorkspaceTitleSetResponsePayloadSchema,
 });
 
+export const WorkspaceBaseBranchSetResponsePayloadSchema = z.object({
+  requestId: z.string(),
+  workspaceId: z.string(),
+  accepted: z.boolean(),
+  baseBranch: z.string().nullable(),
+  baseBranchOverride: z.string().nullable(),
+  error: z.string().nullable(),
+});
+
+export const WorkspaceBaseBranchSetResponseSchema = z.object({
+  type: z.literal("workspace.base_branch.set.response"),
+  payload: WorkspaceBaseBranchSetResponsePayloadSchema,
+});
+
 export const WorkspacePinSetResponsePayloadSchema = z.object({
   requestId: z.string(),
   workspaceId: z.string(),
@@ -1840,6 +1862,7 @@ const CheckoutCommitSchema = z.object({
 export const CheckoutCommitsListRequestSchema = z.object({
   type: z.literal("checkout.commits.list.request"),
   cwd: z.string(),
+  baseRef: z.string().optional(),
   requestId: z.string(),
 });
 
@@ -2656,6 +2679,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   ProjectIconSetRequestSchema,
   ProjectRemoveRequestSchema,
   WorkspaceTitleSetRequestSchema,
+  WorkspaceBaseBranchSetRequestSchema,
   WorkspacePinSetRequestSchema,
   WorkspaceRecoveryInspectRequestSchema,
   WorkspaceRecoveryRestoreRequestSchema,
@@ -3031,6 +3055,8 @@ export const ServerInfoStatusPayloadSchema = z
         providerSubagents: z.boolean().optional(),
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
         workspacePinning: z.boolean().optional(),
+        // COMPAT(workspaceBaseBranch): added in v0.3.0, remove after 2027-02-07.
+        workspaceBaseBranch: z.boolean().optional(),
         // COMPAT(hubRelationship): added in v0.1.X, drop the gate when floor >= v0.1.X.
         hubRelationship: z.boolean().optional(),
         // COMPAT(projectGithubClone): added in v0.1.108, remove gate after 2027-01-15.
@@ -3355,6 +3381,11 @@ export const WorkspaceDescriptorPayloadSchema = z
     // its input and offer a "reset to branch name" action. Null means the name
     // is derived from the branch/directory.
     title: z.string().nullable().optional(),
+    // COMPAT(workspaceBaseBranch): added in v0.3.0, remove optional after 2027-02-07.
+    // Effective comparison branch. When the override is null, this is the repository default.
+    baseBranch: z.string().nullable().optional(),
+    // Raw workspace override. Null means follow the repository default branch.
+    baseBranchOverride: z.string().nullable().optional(),
     // COMPAT(workspacePinning): added in v0.1.107, remove optional after 2027-01-12.
     pinnedAt: z.string().nullable().optional(),
     archivingAt: z.string().nullable().optional().default(null),
@@ -5655,6 +5686,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   ProjectIconSetResponseSchema,
   ProjectRemoveResponseSchema,
   WorkspaceTitleSetResponseSchema,
+  WorkspaceBaseBranchSetResponseSchema,
   WorkspacePinSetResponseSchema,
   WorkspaceRecoveryInspectResponseSchema,
   WorkspaceRecoveryRestoreResponseSchema,
@@ -5852,6 +5884,10 @@ export type WorkspaceTitleSetResponse = z.infer<typeof WorkspaceTitleSetResponse
 export type WorkspaceTitleSetResponsePayload = z.infer<
   typeof WorkspaceTitleSetResponsePayloadSchema
 >;
+export type WorkspaceBaseBranchSetResponse = z.infer<typeof WorkspaceBaseBranchSetResponseSchema>;
+export type WorkspaceBaseBranchSetResponsePayload = z.infer<
+  typeof WorkspaceBaseBranchSetResponsePayloadSchema
+>;
 export type WorkspacePinSetResponse = z.infer<typeof WorkspacePinSetResponseSchema>;
 export type WorkspacePinSetResponsePayload = z.infer<typeof WorkspacePinSetResponsePayloadSchema>;
 export type WorkspaceRecoveryState = z.infer<typeof WorkspaceRecoveryStateSchema>;
@@ -5998,6 +6034,7 @@ export type ProjectRenameRequest = z.infer<typeof ProjectRenameRequestSchema>;
 export type ProjectIconSetRequest = z.infer<typeof ProjectIconSetRequestSchema>;
 export type ProjectRemoveRequest = z.infer<typeof ProjectRemoveRequestSchema>;
 export type WorkspaceTitleSetRequest = z.infer<typeof WorkspaceTitleSetRequestSchema>;
+export type WorkspaceBaseBranchSetRequest = z.infer<typeof WorkspaceBaseBranchSetRequestSchema>;
 export type WorkspacePinSetRequest = z.infer<typeof WorkspacePinSetRequestSchema>;
 export type WorkspaceRecoveryInspectRequest = z.infer<typeof WorkspaceRecoveryInspectRequestSchema>;
 export type WorkspaceRecoveryRestoreRequest = z.infer<typeof WorkspaceRecoveryRestoreRequestSchema>;

--- a/packages/protocol/src/messages.workspaces.test.ts
+++ b/packages/protocol/src/messages.workspaces.test.ts
@@ -10,6 +10,38 @@ import {
 } from "./messages.js";
 
 describe("workspace message schemas", () => {
+  test("parses workspace base branch updates", () => {
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "workspace.base_branch.set.request",
+        requestId: "req-base",
+        workspaceId: "ws-1",
+        baseBranch: "release",
+      }),
+    ).toMatchObject({
+      type: "workspace.base_branch.set.request",
+      workspaceId: "ws-1",
+      baseBranch: "release",
+    });
+
+    expect(
+      SessionOutboundMessageSchema.parse({
+        type: "workspace.base_branch.set.response",
+        payload: {
+          requestId: "req-base",
+          workspaceId: "ws-1",
+          accepted: true,
+          baseBranch: "release",
+          baseBranchOverride: "release",
+          error: null,
+        },
+      }),
+    ).toMatchObject({
+      type: "workspace.base_branch.set.response",
+      payload: { baseBranch: "release", baseBranchOverride: "release" },
+    });
+  });
+
   test("parses fetch_workspaces_request", () => {
     const parsed = SessionInboundMessageSchema.parse({
       type: "fetch_workspaces_request",

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1828,6 +1828,7 @@ export class Session {
       this.dispatchAgentConfigMessage(msg) ??
       this.dispatchCheckoutMessage(msg) ??
       this.dispatchWorkspaceRecoveryMessage(msg) ??
+      this.dispatchWorkspaceMetadataMessage(msg) ??
       this.dispatchWorkspaceAndProjectMessage(msg) ??
       this.dispatchWorkspaceFileMessage(msg, source) ??
       this.dispatchProviderMessage(msg) ??
@@ -2151,8 +2152,21 @@ export class Session {
         return this.handleWorkspaceCreateRequest(msg);
       case "workspace.clear_attention.request":
         return this.handleWorkspaceClearAttentionRequest(msg);
+      default:
+        return undefined;
+    }
+  }
+
+  private dispatchWorkspaceMetadataMessage(msg: SessionInboundMessage): Promise<void> | undefined {
+    switch (msg.type) {
       case "workspace.title.set.request":
         return this.handleWorkspaceTitleSetRequest(msg.workspaceId, msg.title, msg.requestId);
+      case "workspace.base_branch.set.request":
+        return this.handleWorkspaceBaseBranchSetRequest(
+          msg.workspaceId,
+          msg.baseBranch,
+          msg.requestId,
+        );
       case "workspace.pin.set.request":
         return this.handleWorkspacePinSetRequest(msg.workspaceId, msg.pinned, msg.requestId);
       default:
@@ -2951,6 +2965,93 @@ export class Session {
           error: getErrorMessageOr(error, "Failed to set workspace title"),
         },
       });
+    }
+  }
+
+  private async handleWorkspaceBaseBranchSetRequest(
+    workspaceId: string,
+    baseBranch: string | null,
+    requestId: string,
+  ): Promise<void> {
+    const emitResponse = (
+      accepted: boolean,
+      effectiveBaseBranch: string | null,
+      baseBranchOverride: string | null,
+      error: string | null,
+    ) => {
+      this.emit({
+        type: "workspace.base_branch.set.response",
+        payload: {
+          requestId,
+          workspaceId,
+          accepted,
+          baseBranch: effectiveBaseBranch,
+          baseBranchOverride,
+          error,
+        },
+      });
+    };
+
+    try {
+      const workspace = await this.workspaceRegistry.get(workspaceId);
+      if (!workspace) {
+        emitResponse(false, null, null, "Workspace not found");
+        return;
+      }
+      if (workspace.kind === "directory") {
+        emitResponse(false, null, null, "Workspace is not a Git checkout");
+        return;
+      }
+
+      const requestedBaseBranch = baseBranch?.trim() ?? "";
+      let nextOverride: string | null = null;
+      let effectiveBaseBranch: string;
+      if (requestedBaseBranch) {
+        const resolution = await this.workspaceGitService.validateBranchRef(
+          workspace.cwd,
+          requestedBaseBranch,
+        );
+        if (resolution.kind === "not-found") {
+          emitResponse(
+            false,
+            await this.resolveWorkspaceComparisonBaseBranch(workspace),
+            workspace.comparisonBaseBranch ?? null,
+            `Base branch not found: ${requestedBaseBranch}`,
+          );
+          return;
+        }
+        nextOverride = resolution.name;
+        effectiveBaseBranch = resolution.name;
+      } else {
+        effectiveBaseBranch = await this.workspaceGitService.resolveDefaultBranch(workspace.cwd, {
+          force: true,
+          reason: "workspace base branch reset",
+        });
+      }
+
+      const updated = await this.workspaceRegistry.update(workspaceId, (existing) => ({
+        ...existing,
+        comparisonBaseBranch: nextOverride,
+        updatedAt: new Date().toISOString(),
+      }));
+      if (!updated) {
+        emitResponse(false, null, null, "Workspace not found");
+        return;
+      }
+
+      emitResponse(true, effectiveBaseBranch, nextOverride, null);
+      await this.emitWorkspaceUpdatesForWorkspaceIds([workspaceId]);
+    } catch (error) {
+      this.sessionLogger.error(
+        { err: error, workspaceId, requestId },
+        "session: workspace.base_branch.set.request error",
+      );
+      emitResponse(
+        false,
+        null,
+        null,
+        getErrorMessageOr(error, "Failed to set workspace base branch"),
+      );
     }
   }
 
@@ -4421,6 +4522,7 @@ export class Session {
       workspace.isPaseoOwnedWorktree && workspace.worktreeRoot
         ? basename(workspace.worktreeRoot)
         : undefined;
+    const baseBranch = await this.resolveWorkspaceComparisonBaseBranch(workspace);
 
     return {
       id: workspace.workspaceId,
@@ -4437,6 +4539,8 @@ export class Session {
       workspaceKind: workspace.kind,
       name: resolveWorkspaceDisplayName(workspace),
       title: workspace.title,
+      baseBranch,
+      baseBranchOverride: workspace.comparisonBaseBranch ?? null,
       pinnedAt: workspace.pinnedAt,
       archivingAt: null,
       status: "done",
@@ -4450,6 +4554,26 @@ export class Session {
           }
         : {}),
     };
+  }
+
+  private async resolveWorkspaceComparisonBaseBranch(
+    workspace: PersistedWorkspaceRecord,
+  ): Promise<string | null> {
+    if (workspace.kind === "directory") {
+      return null;
+    }
+    if (workspace.comparisonBaseBranch) {
+      return workspace.comparisonBaseBranch;
+    }
+    try {
+      return await this.workspaceGitService.resolveDefaultBranch(workspace.cwd);
+    } catch (error) {
+      this.sessionLogger.warn(
+        { err: error, workspaceId: workspace.workspaceId, cwd: workspace.cwd },
+        "Unable to resolve workspace comparison base branch",
+      );
+      return null;
+    }
   }
 
   private buildWorkspaceGitRuntimePayload(
@@ -4510,6 +4634,7 @@ export class Session {
     result: CreatePaseoWorktreeResult,
   ): Promise<WorkspaceDescriptorPayload> {
     const projectRecord = await this.projectRegistry.get(result.workspace.projectId);
+    const baseBranch = await this.resolveWorkspaceComparisonBaseBranch(result.workspace);
     return {
       id: result.workspace.workspaceId,
       projectId: result.workspace.projectId,
@@ -4528,6 +4653,8 @@ export class Session {
         derivedDisplayName: result.worktree.branchName || result.workspace.displayName,
       }),
       title: result.workspace.title,
+      baseBranch,
+      baseBranchOverride: result.workspace.comparisonBaseBranch ?? null,
       pinnedAt: result.workspace.pinnedAt,
       archivingAt: null,
       status: "done",

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -8089,6 +8089,125 @@ test("workspace.title.set.request stores the title and emits an updated descript
   });
 });
 
+test("workspace base branch defaults to the repository default and accepts an override", async () => {
+  const emitted: SessionOutboundMessage[] = [];
+  const session = asTestSession(
+    createSessionForWorkspaceTests({
+      onMessage: (message) => emitted.push(message),
+      workspaceGitService: createNoopWorkspaceGitService({
+        resolveDefaultBranch: async () => "refs/remotes/origin/main",
+        validateBranchRef: async (_cwd, ref) =>
+          ref === "release" ? { kind: "local", name: "release" } : { kind: "not-found" },
+      }),
+    }),
+  );
+  const project = createPersistedProjectRecord({
+    projectId: "proj-1",
+    rootPath: REPO_CWD,
+    kind: "git",
+    displayName: "acme/repo",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const workspace = createPersistedWorkspaceRecord({
+    workspaceId: "ws-1",
+    projectId: project.projectId,
+    cwd: REPO_CWD,
+    kind: "worktree",
+    displayName: "feature",
+    branch: "feature",
+    baseBranch: "feature-parent",
+    createdAt: "2026-03-01T12:00:00.000Z",
+    updatedAt: "2026-03-01T12:00:00.000Z",
+  });
+  const projects = new Map([[project.projectId, project]]);
+  const workspaces = new Map([[workspace.workspaceId, workspace]]);
+  session.projectRegistry.get = async (id: string) => projects.get(id) ?? null;
+  session.projectRegistry.list = async () => Array.from(projects.values());
+  session.workspaceRegistry.list = async () => Array.from(workspaces.values());
+  session.workspaceRegistry.get = async (id: string) => workspaces.get(id) ?? null;
+  session.workspaceRegistry.update = async (id, updater) => {
+    const existing = workspaces.get(id);
+    if (!existing) return null;
+    const updated = updater(existing);
+    workspaces.set(id, updated);
+    return updated;
+  };
+  session.workspaceUpdatesSubscription = {
+    subscriptionId: "sub-workspaces",
+    filter: {},
+    isBootstrapping: false,
+    lastEmittedByWorkspaceId: new Map(),
+    pendingUpdatesByWorkspaceId: new Map(),
+  };
+
+  await expect(session.describeWorkspaceRecord(workspace, project)).resolves.toMatchObject({
+    baseBranch: "refs/remotes/origin/main",
+    baseBranchOverride: null,
+  });
+
+  await session.handleMessage({
+    type: "workspace.base_branch.set.request",
+    workspaceId: workspace.workspaceId,
+    baseBranch: "release",
+    requestId: "req-base-1",
+  });
+
+  expect(findByType(emitted, "workspace.base_branch.set.response")?.payload).toEqual({
+    requestId: "req-base-1",
+    workspaceId: workspace.workspaceId,
+    accepted: true,
+    baseBranch: "release",
+    baseBranchOverride: "release",
+    error: null,
+  });
+  expect(workspaces.get(workspace.workspaceId)?.comparisonBaseBranch).toBe("release");
+  expect(findByType(emitted, "workspace_update")?.payload).toMatchObject({
+    kind: "upsert",
+    workspace: {
+      id: workspace.workspaceId,
+      baseBranch: "release",
+      baseBranchOverride: "release",
+    },
+  });
+
+  emitted.length = 0;
+  await session.handleMessage({
+    type: "workspace.base_branch.set.request",
+    workspaceId: workspace.workspaceId,
+    baseBranch: "missing",
+    requestId: "req-base-missing",
+  });
+
+  expect(findByType(emitted, "workspace.base_branch.set.response")?.payload).toEqual({
+    requestId: "req-base-missing",
+    workspaceId: workspace.workspaceId,
+    accepted: false,
+    baseBranch: "release",
+    baseBranchOverride: "release",
+    error: "Base branch not found: missing",
+  });
+  expect(workspaces.get(workspace.workspaceId)?.comparisonBaseBranch).toBe("release");
+
+  emitted.length = 0;
+  await session.handleMessage({
+    type: "workspace.base_branch.set.request",
+    workspaceId: workspace.workspaceId,
+    baseBranch: null,
+    requestId: "req-base-reset",
+  });
+
+  expect(findByType(emitted, "workspace.base_branch.set.response")?.payload).toEqual({
+    requestId: "req-base-reset",
+    workspaceId: workspace.workspaceId,
+    accepted: true,
+    baseBranch: "refs/remotes/origin/main",
+    baseBranchOverride: null,
+    error: null,
+  });
+  expect(workspaces.get(workspace.workspaceId)?.comparisonBaseBranch).toBeNull();
+});
+
 test("workspace.pin.set.request stores the pin timestamp and emits an updated descriptor", async () => {
   const emitted: SessionOutboundMessage[] = [];
   const session = asTestSession(

--- a/packages/server/src/server/session/checkout/checkout-session.ts
+++ b/packages/server/src/server/session/checkout/checkout-session.ts
@@ -267,13 +267,13 @@ export class CheckoutSession {
   }
 
   async handleCommitsListRequest(msg: CheckoutCommitsListRequest): Promise<void> {
-    const { cwd, requestId } = msg;
+    const { cwd, baseRef, requestId } = msg;
 
     try {
-      const { baseRef, commits } = await listCheckoutCommits({ cwd: expandTilde(cwd) });
+      const result = await listCheckoutCommits({ cwd: expandTilde(cwd), baseRef });
       this.host.emit({
         type: "checkout.commits.list.response",
-        payload: { cwd, baseRef, commits, error: null, requestId },
+        payload: { cwd, baseRef: result.baseRef, commits: result.commits, error: null, requestId },
       });
     } catch (error) {
       this.host.emit({

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1595,6 +1595,8 @@ export class VoiceAssistantWebSocketServer {
         providerSubagents: true,
         // COMPAT(workspacePinning): added in v0.1.107, remove gate after 2027-01-12.
         workspacePinning: true,
+        // COMPAT(workspaceBaseBranch): added in v0.3.0, remove after 2027-02-07.
+        workspaceBaseBranch: true,
         // COMPAT(hubRelationship): added in v0.1.X, drop the gate when floor >= v0.1.X.
         hubRelationship: true,
         // COMPAT(projectGithubClone): added in v0.1.108, remove gate after 2027-01-15.

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -75,6 +75,9 @@ const PersistedWorkspaceRecordSchema = z.object({
     .nullable()
     .optional()
     .transform((value) => value ?? null),
+  // User-selected comparison branch for committed diffs. Missing or null follows
+  // the repository default; this stays separate from the creation-time baseBranch.
+  comparisonBaseBranch: z.string().nullable().optional(),
   isPaseoOwnedWorktree: z.boolean().default(false),
   mainRepoRoot: z.string().nullable().default(null),
   createdAt: z.string(),
@@ -549,6 +552,7 @@ export function createPersistedWorkspaceRecord(input: {
   branch?: string | null;
   worktreeRoot?: string | null;
   baseBranch?: string | null;
+  comparisonBaseBranch?: string | null;
   isPaseoOwnedWorktree?: boolean;
   mainRepoRoot?: string | null;
   createdAt: string;
@@ -563,6 +567,9 @@ export function createPersistedWorkspaceRecord(input: {
     branch: input.branch ?? null,
     worktreeRoot: input.worktreeRoot ?? null,
     baseBranch: input.baseBranch ?? null,
+    ...(input.comparisonBaseBranch !== undefined
+      ? { comparisonBaseBranch: input.comparisonBaseBranch }
+      : {}),
     isPaseoOwnedWorktree: input.isPaseoOwnedWorktree ?? false,
     mainRepoRoot: input.mainRepoRoot ?? null,
     archivedAt: input.archivedAt ?? null,

--- a/packages/server/src/utils/checkout-git.commits.test.ts
+++ b/packages/server/src/utils/checkout-git.commits.test.ts
@@ -157,6 +157,26 @@ describe("listCheckoutCommits", () => {
     expect(commits.map((entry) => entry.isOnBase)).toEqual([false, true]);
   });
 
+  it("uses an explicit comparison branch instead of saved worktree ancestry", async () => {
+    const { repoDir, tempDir } = initRepoOnMain();
+    git(["branch", "release"], repoDir);
+    const worktreesRoot = join(tempDir, "worktrees");
+    const worktreeDir = join(worktreesRoot, "repo-hash", "feature");
+    mkdirSync(join(worktreesRoot, "repo-hash"), { recursive: true });
+    git(["worktree", "add", "-b", "feature", worktreeDir], repoDir);
+    commitFile(worktreeDir, "feature.txt", "feature\n", "Feature work");
+    writePaseoWorktreeMetadata(worktreeDir, { baseRefName: "release" });
+
+    const { baseRef, commits } = await listCheckoutCommits({
+      cwd: worktreeDir,
+      baseRef: "main",
+      context: { worktreesRoot },
+    });
+
+    expect(baseRef).toBe("main");
+    expect(commits.map((entry) => entry.subject)).toEqual(["Feature work", "initial"]);
+  });
+
   it("marks all commits local-only when there is no remote", async () => {
     const { repoDir } = initRepoOnMain();
     git(["checkout", "-b", "feature"], repoDir);
@@ -198,6 +218,27 @@ describe("listCheckoutCommits", () => {
     expect(commits.map(({ subject, isOnBase }) => ({ subject, isOnBase }))).toEqual([
       { subject: "Feature work", isOnBase: false },
       { subject: "Local base work", isOnBase: true },
+      { subject: "initial", isOnBase: true },
+    ]);
+  });
+
+  it("keeps an explicit origin base ref when the local default branch is ahead", async () => {
+    const { repoDir, tempDir } = initRepoOnMain();
+    addBareRemote(repoDir, tempDir);
+    git(["push", "-u", "origin", "main"], repoDir);
+    commitFile(repoDir, "local-base.txt", "base\n", "Local base work");
+    git(["checkout", "-b", "feature"], repoDir);
+    commitFile(repoDir, "feature.txt", "feature\n", "Feature work");
+
+    const { baseRef, commits } = await listCheckoutCommits({
+      cwd: repoDir,
+      baseRef: "origin/main",
+    });
+
+    expect(baseRef).toBe("origin/main");
+    expect(commits.map(({ subject, isOnBase }) => ({ subject, isOnBase }))).toEqual([
+      { subject: "Feature work", isOnBase: false },
+      { subject: "Local base work", isOnBase: false },
       { subject: "initial", isOnBase: true },
     ]);
   });

--- a/packages/server/src/utils/checkout-git.test.ts
+++ b/packages/server/src/utils/checkout-git.test.ts
@@ -3481,7 +3481,8 @@ const x = 1;
     expect(baseDiff.diff).not.toContain("file.txt");
   });
 
-  it("names both refs when a requested base ref does not match the stored one", async () => {
+  it("uses an explicit comparison branch instead of the worktree creation base", async () => {
+    execFileSync("git", ["branch", "other"], { cwd: repoDir });
     const worktree = await createLegacyWorktreeForTest({
       branchName: "mismatch-feature",
       cwd: repoDir,
@@ -3490,9 +3491,18 @@ const x = 1;
       paseoHome,
     });
 
-    await expect(
-      getCheckoutDiff(worktree.worktreePath, { mode: "base", baseRef: "other" }, { paseoHome }),
-    ).rejects.toThrow("Base ref mismatch: stored refs/heads/main, requested other");
+    writeFileSync(join(worktree.worktreePath, "override.txt"), "override\n");
+    execFileSync("git", ["add", "override.txt"], { cwd: worktree.worktreePath });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "override"], {
+      cwd: worktree.worktreePath,
+    });
+
+    const result = await getCheckoutDiff(
+      worktree.worktreePath,
+      { mode: "base", baseRef: "other" },
+      { paseoHome },
+    );
+    expect(result.diff).toContain("override.txt");
   });
 
   it("excludes dirty working tree changes from Paseo worktree base diffs", async () => {
@@ -3541,7 +3551,26 @@ const x = 1;
       cwd: repoDir,
     });
 
-    await expect(resolveRepositoryDefaultBranch(repoDir)).resolves.toBe("main");
+    await expect(resolveRepositoryDefaultBranch(repoDir)).resolves.toBe("refs/remotes/origin/main");
+  });
+
+  it("uses the first configured remote when origin is unavailable", async () => {
+    execFileSync("git", ["checkout", "-b", "develop"], { cwd: repoDir });
+    execFileSync("git", ["remote", "add", "upstream", "https://github.com/acme/repo.git"], {
+      cwd: repoDir,
+    });
+    execFileSync("git", ["update-ref", "refs/remotes/upstream/develop", "refs/heads/develop"], {
+      cwd: repoDir,
+    });
+    execFileSync(
+      "git",
+      ["symbolic-ref", "refs/remotes/upstream/HEAD", "refs/remotes/upstream/develop"],
+      { cwd: repoDir },
+    );
+
+    await expect(resolveRepositoryDefaultBranch(repoDir)).resolves.toBe(
+      "refs/remotes/upstream/develop",
+    );
   });
 
   it("merges to stored baseRefName when baseRef is not provided", async () => {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1435,34 +1435,45 @@ async function abortGitPullConflictState(cwd: string): Promise<void> {
 }
 
 export async function resolveRepositoryDefaultBranch(repoRoot: string): Promise<string | null> {
-  try {
-    const { stdout } = await runGitCommand(
-      ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
-      {
-        cwd: repoRoot,
-        envOverlay: READ_ONLY_GIT_ENV,
-      },
-    );
-    const ref = stdout.trim();
-    if (ref) {
-      // Prefer a local branch name (e.g. "main") over the remote-tracking ref (e.g. "origin/main")
-      // so that status/diff/merge all operate against the same base ref.
-      const remoteShort = ref.replace(/^refs\/remotes\//, "");
-      const localName = remoteShort.startsWith("origin/")
-        ? remoteShort.slice("origin/".length)
-        : remoteShort;
-      try {
-        await runGitCommand(["show-ref", "--verify", "--quiet", `refs/heads/${localName}`], {
+  const { stdout: remotesOutput } = await runGitCommand(["remote", "-v"], {
+    cwd: repoRoot,
+    envOverlay: READ_ONLY_GIT_ENV,
+  });
+  const remoteNames = Array.from(
+    new Set(
+      remotesOutput
+        .split("\n")
+        .map((line) => line.trim().match(/^(\S+)\s+/)?.[1] ?? null)
+        .filter((name): name is string => name !== null),
+    ),
+  );
+  const defaultRemote = remoteNames.includes("origin") ? "origin" : (remoteNames[0] ?? null);
+
+  if (defaultRemote) {
+    try {
+      const { stdout } = await runGitCommand(
+        ["symbolic-ref", "--quiet", `refs/remotes/${defaultRemote}/HEAD`],
+        {
           cwd: repoRoot,
           envOverlay: READ_ONLY_GIT_ENV,
-        });
-        return localName;
-      } catch {
-        return remoteShort;
+        },
+      );
+      const ref = stdout.trim();
+      if (ref) {
+        return ref;
       }
+    } catch {
+      // Fall through to conventional branch names on the selected remote.
     }
-  } catch {
-    // ignore
+
+    const remoteMainRef = `refs/remotes/${defaultRemote}/main`;
+    if (await doesGitRefExist(repoRoot, remoteMainRef)) {
+      return remoteMainRef;
+    }
+    const remoteMasterRef = `refs/remotes/${defaultRemote}/master`;
+    if (await doesGitRefExist(repoRoot, remoteMasterRef)) {
+      return remoteMasterRef;
+    }
   }
 
   const { stdout } = await runGitCommand(["branch", "--format=%(refname:short)"], {
@@ -1561,6 +1572,13 @@ async function resolveBestComparisonBaseRef(
 }
 
 async function resolveMostAheadBaseRef(cwd: string, baseRef: string): Promise<string> {
+  if (baseRef.startsWith("origin/")) {
+    const remoteRef = `refs/remotes/${baseRef}`;
+    if (await doesGitRefExist(cwd, remoteRef)) {
+      return baseRef;
+    }
+    throw new Error(`Base ref not found: ${baseRef}`);
+  }
   if (isQualifiedBranchRef(baseRef)) {
     if (await doesGitRefExist(cwd, baseRef)) {
       return baseRef;
@@ -2415,9 +2433,11 @@ async function tryResolveCheckoutCommitsBaseRef(
 
 export async function listCheckoutCommits({
   cwd,
+  baseRef,
   context,
 }: {
   cwd: string;
+  baseRef?: string;
   context?: CheckoutContext;
 }): Promise<CheckoutCommitsResult> {
   const currentBranch = await getCurrentBranch(cwd);
@@ -2425,7 +2445,14 @@ export async function listCheckoutCommits({
     return { baseRef: null, commits: [] };
   }
 
-  const { resolvedBaseRef } = await resolveBaseRefForCwd(cwd, context);
+  const storedResolution = await resolveBaseRefForCwd(cwd, context);
+  const requestedBaseRef = baseRef?.trim();
+  // COMPAT(workspaceBaseBranch): clients before v0.3.0 omit baseRef; preserve the
+  // legacy local-vs-origin heuristic until the daemon floor is past v0.3.0.
+  const resolvedBaseRef =
+    requestedBaseRef ||
+    storedResolution.storedBaseRef ||
+    (storedResolution.resolvedBaseRef ? branchNameFromRef(storedResolution.resolvedBaseRef) : null);
   const normalizedBaseRef = resolvedBaseRef ? branchNameFromRef(resolvedBaseRef) : null;
   let comparisonBaseRef = await tryResolveCheckoutCommitsBaseRef(
     cwd,
@@ -3176,11 +3203,9 @@ async function resolveCheckoutDiffRefs(
     return { baseRef: "HEAD", includeUntracked: true };
   }
   const { storedBaseRef, resolvedBaseRef } = await resolveBaseRefForCwd(cwd, context);
-  const baseRef = resolveOperationBaseRef({
-    storedBaseRef,
-    resolvedBaseRef,
-    requestedBaseRef: compare.baseRef,
-  });
+  // A committed diff is an inspection operation, so an explicit comparison branch
+  // is authoritative. The stored worktree base remains a creation/recovery fact.
+  const baseRef = compare.baseRef?.trim() || storedBaseRef || resolvedBaseRef;
   if (!baseRef) {
     return null;
   }


### PR DESCRIPTION

<img width="655" height="580" alt="image" src="https://github.com/user-attachments/assets/64b99038-f67f-4829-b895-044d84e7672f" />


### Linked issue

Related to #2919, which was moved to [Discussion #3052](https://github.com/getpaseo/paseo/discussions/3052). This PR addresses the comparison-base part of that workflow; it does not close the broader stacked-PR request.

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Committed diffs and the commits list use the branch recorded when a worktree was created. That becomes the wrong inspection target when a workspace outlives that branch relationship or when a developer works on a branch stack.

This adds a workspace-level comparison branch that can be changed from the diff mode menu without changing the workspace's creation and recovery base. Repository-default comparisons resolve to a remote-tracking ref, so a local `main` that has drifted ahead of `origin/main` does not hide commits from the diff.

### Goals

- Let a user select or reset a workspace's comparison base from the Changes menu.
- Persist the override independently from the workspace creation/recovery base.
- Apply the selected base to committed diffs and the commits list.
- Prefer `origin` for the repository default, fall back to the first configured remote, then use a local default branch when the remote has no default ref.
- Keep the new RPC and descriptor fields compatible across app/daemon version drift.

### Non-goals

- Change the branch used to create, restore, merge, or update a worktree.
- Change the target branch when opening a pull request.
- Model parent/child branch stacks or add restacking helpers.
- Fetch remotes or change remote-tracking ref freshness.

### Compatibility

- Old app + new daemon: the new descriptor fields are optional, and a client that omits the new commit-list `baseRef` keeps the previous local-vs-origin classification behavior.
- New app + old daemon: the menu and explicit comparison queries are gated once on `server_info.features.workspaceBaseBranch`; existing diff and commit behavior remains in use.
- New app + new daemon: the selected override is persisted through `workspace.base_branch.set`, while a null override follows the repository default remote-tracking ref.

### QA

Automated validation on macOS:

```text
npm run build:server
# passed

env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false \
  npx vitest run packages/app/src/git/checkout-status-cache.test.ts \
  packages/app/src/git/query-keys.test.ts \
  packages/app/src/git/workspace-base-branch-filter.test.ts \
  packages/protocol/src/messages.workspaces.test.ts \
  packages/server/src/server/session.workspaces.test.ts \
  packages/server/src/utils/checkout-git.commits.test.ts \
  packages/server/src/utils/checkout-git.test.ts --bail=1
# Test Files  7 passed (7)
# Tests       328 passed | 5 skipped (333)

npm run typecheck
# passed across all workspaces

npm run lint
# Found 0 warnings and 0 errors.

npm run format
# Finished successfully.
```

Manual UI testing and screenshots/video were not produced. Browser, Electron, iOS, and Android still need visual QA before this draft is ready for review.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense
