### PR TITLE
Show the source branch on development builds

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,10 @@ Desktop dev launches its desktop-managed daemon with `PASEO_NODE_ENV=development
 so development-only providers such as Mock Load Test are available. Packaged
 desktop launches always force the daemon to production mode.
 
+The web and desktop dev launchers pass the current Git branch to Metro as
+`EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL`. The expanded desktop sidebar shows it in
+the titlebar row. Production builds leave the variable unset and show no label.
+
 `npm run dev` is only a shorthand for `npm run dev:server`. Keep `127.0.0.1:6767` for the packaged app and production-style `~/.paseo` state.
 
 ## Nix desktop package

--- a/packages/app/src/components/left-sidebar.tsx
+++ b/packages/app/src/components/left-sidebar.tsx
@@ -2,6 +2,7 @@ import { router, usePathname } from "expo-router";
 import {
   CalendarClock,
   FolderPlus,
+  GitBranch,
   History,
   Home,
   Plus,
@@ -76,6 +77,8 @@ import { SidebarCalloutSlot } from "./sidebar-callout-slot";
 import { SidebarWorkspaceList } from "./sidebar-workspace-list";
 
 type SidebarTheme = ReturnType<typeof useUnistyles>["theme"];
+
+const DEV_BUILD_LABEL = process.env.EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL?.trim() || null;
 
 interface SidebarSharedProps {
   theme: SidebarTheme;
@@ -853,9 +856,22 @@ function DesktopSidebar({
     >
       <View style={desktopSidebarBorderStyle}>
         <View style={styles.sidebarDragArea}>
-          {ownsTopLeft ? (
+          {ownsTopLeft || DEV_BUILD_LABEL ? (
             <View style={styles.desktopChromeRow}>
               <TitlebarDragRegion />
+              {DEV_BUILD_LABEL ? (
+                <View
+                  pointerEvents="none"
+                  style={styles.devBuildBadge}
+                  testID="dev-build-label"
+                  accessibilityLabel={`Development build: ${DEV_BUILD_LABEL}`}
+                >
+                  <GitBranch size={12} color={theme.colors.accentForeground} />
+                  <Text numberOfLines={1} ellipsizeMode="tail" style={styles.devBuildBadgeText}>
+                    {DEV_BUILD_LABEL}
+                  </Text>
+                </View>
+              ) : null}
             </View>
           ) : (
             <TitlebarDragRegion />
@@ -1080,8 +1096,27 @@ const styles = StyleSheet.create((theme) => ({
     height: HEADER_INNER_HEIGHT,
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "flex-end",
+    paddingHorizontal: theme.spacing[3],
     borderBottomWidth: theme.borderWidth[1],
     borderBottomColor: "transparent",
+  },
+  devBuildBadge: {
+    maxWidth: "60%",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[2],
+    paddingVertical: 2,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.accent,
+  },
+  devBuildBadgeText: {
+    minWidth: 0,
+    flexShrink: 1,
+    color: theme.colors.accentForeground,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
   },
   sidebarFooter: {
     flexDirection: "row",

--- a/packages/desktop/scripts/dev-runner.mjs
+++ b/packages/desktop/scripts/dev-runner.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import net from "node:net";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { createElectronSpawnOptions, resolveChildKillTarget } from "./dev-runner-config.mjs";
@@ -27,6 +27,10 @@ const colorEnv = {
   FORCE_COLOR: process.env.FORCE_COLOR || "1",
   npm_config_color: process.env.npm_config_color || "always",
 };
+const devBuildLabel = execFileSync("git", ["branch", "--show-current"], {
+  cwd: rootDir,
+  encoding: "utf8",
+}).trim();
 
 const children = new Map();
 let stopping = false;
@@ -166,6 +170,7 @@ spawnChild("metro", "npx", ["expo", "start", "--port", String(expoPort)], {
     ...colorEnv,
     BROWSER: "none",
     APP_VARIANT: "development",
+    EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL: devBuildLabel,
     PASEO_WEB_PLATFORM: "electron",
   },
 });

--- a/packages/desktop/scripts/dev.ps1
+++ b/packages/desktop/scripts/dev.ps1
@@ -32,7 +32,7 @@ try {
 
 # Set EXPO_DEV_URL in the environment so Electron inherits it
 $env:EXPO_DEV_URL = "http://localhost:$($env:EXPO_PORT)"
-$DevBuildLabel = (git -C $RootDir branch --show-current).Trim()
+$env:EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL = (git -C $RootDir branch --show-current).Trim()
 
 $env:PASEO_DEV_ROOT = $RootDir
 $env:PASEO_DEV_RUNTIME_FALLBACK_ROOT = $RootDir
@@ -115,5 +115,5 @@ concurrently `
     --kill-others `
     --names "metro,electron" `
     --prefix-colors "magenta,cyan" `
-    "cd `"$AppDir`" && cross-env PASEO_WEB_PLATFORM=electron EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL=$DevBuildLabel npx expo start --port $($env:EXPO_PORT)" `
+    "cd `"$AppDir`" && cross-env PASEO_WEB_PLATFORM=electron npx expo start --port $($env:EXPO_PORT)" `
     "npx wait-on tcp:$($env:EXPO_PORT) && npx electron `"$DesktopDir`""

--- a/packages/desktop/scripts/dev.ps1
+++ b/packages/desktop/scripts/dev.ps1
@@ -32,6 +32,7 @@ try {
 
 # Set EXPO_DEV_URL in the environment so Electron inherits it
 $env:EXPO_DEV_URL = "http://localhost:$($env:EXPO_PORT)"
+$DevBuildLabel = (git -C $RootDir branch --show-current).Trim()
 
 $env:PASEO_DEV_ROOT = $RootDir
 $env:PASEO_DEV_RUNTIME_FALLBACK_ROOT = $RootDir
@@ -114,5 +115,5 @@ concurrently `
     --kill-others `
     --names "metro,electron" `
     --prefix-colors "magenta,cyan" `
-    "cd `"$AppDir`" && cross-env PASEO_WEB_PLATFORM=electron npx expo start --port $($env:EXPO_PORT)" `
+    "cd `"$AppDir`" && cross-env PASEO_WEB_PLATFORM=electron EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL=$DevBuildLabel npx expo start --port $($env:EXPO_PORT)" `
     "npx wait-on tcp:$($env:EXPO_PORT) && npx electron `"$DesktopDir`""

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -12,6 +12,7 @@ configure_dev_paseo_home
 
 EXPO_PORT="${EXPO_PORT:-8081}"
 DAEMON_ENDPOINT="$(resolve_dev_daemon_endpoint)"
+DEV_BUILD_LABEL="$(git -C "$ROOT_DIR" branch --show-current 2>/dev/null || true)"
 
 echo "══════════════════════════════════════════════════════"
 echo "  Paseo App Dev"
@@ -24,5 +25,6 @@ echo "════════════════════════�
 exec cross-env \
   BROWSER="${BROWSER:-none}" \
   APP_VARIANT=development \
+  EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL="$DEV_BUILD_LABEL" \
   EXPO_PUBLIC_LOCAL_DAEMON="$DAEMON_ENDPOINT" \
   npm run start:expo --workspace=@getpaseo/app -- --port "$EXPO_PORT"

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -50,13 +50,13 @@ $env:PASEO_CORS_ORIGINS = "*"
 # Configure the app to auto-connect to this daemon on localhost
 $env:APP_VARIANT = "development"
 $env:EXPO_PUBLIC_LOCAL_DAEMON = "localhost:6768"
+$env:EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL = (git branch --show-current).Trim()
 $env:PASEO_LISTEN = "127.0.0.1:6768"
 $env:BROWSER = "none"
-$DevBuildLabel = (git branch --show-current).Trim()
 
 # Run both with concurrently
 concurrently `
     --names "daemon,metro" `
     --prefix-colors "cyan,magenta" `
     "npm run dev:server:watch" `
-    "cd packages/app && cross-env EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL=$DevBuildLabel npx expo start"
+    "cd packages/app && npx expo start"

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -52,10 +52,11 @@ $env:APP_VARIANT = "development"
 $env:EXPO_PUBLIC_LOCAL_DAEMON = "localhost:6768"
 $env:PASEO_LISTEN = "127.0.0.1:6768"
 $env:BROWSER = "none"
+$DevBuildLabel = (git branch --show-current).Trim()
 
 # Run both with concurrently
 concurrently `
     --names "daemon,metro" `
     --prefix-colors "cyan,magenta" `
     "npm run dev:server:watch" `
-    "cd packages/app && npx expo start"
+    "cd packages/app && cross-env EXPO_PUBLIC_PASEO_DEV_BUILD_LABEL=$DevBuildLabel npx expo start"


### PR DESCRIPTION
Development web and Electron builds now identify their source branch in the expanded sidebar, so multiple running worktree builds are easy to tell apart. The dev-only accent badge includes a branch icon, truncates long names, and disappears with the sidebar.

### Linked issue

No matching open issue found.

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Running several development desktop apps at once previously left no visible way to tell which worktree produced each window. The dev launcher already owns build-time environment, so it supplies the checked-out branch to Metro without adding runtime Git access or persisted application state.

### Goals

- Show the current checkout branch in the expanded desktop-form-factor sidebar.
- Keep the label development-only and absent from production builds.
- Support both browser web and Electron development launchers.
- Use the accent palette, include a branch icon, and truncate long branch names.
- Keep the label out of the collapsed sidebar and compact/mobile layouts.

### Non-goals

- Label production or packaged builds.
- Persist or configure build labels in application settings.
- Show the badge on compact/mobile layouts.
- Add runtime Git queries to the renderer.

### QA

Automated browser driving against the real app and daemon:

- Browser web: launched through `scripts/dev-app.sh`, confirmed `add-branch-name-badge` rendered with the branch glyph in `[data-testid="dev-build-label"]`, and measured the badge at 177×19 px inside the titlebar row.
- Electron macOS: launched through `npm run dev:desktop` on isolated Metro/CDP ports, confirmed the same label in a real Electron runtime and measured it at 177×18 px inside the titlebar row.
- Windows launcher review: branch names travel through inherited process environment rather than `concurrently`/`cmd.exe` command strings, so valid ref metacharacters such as `&` and `|` are never reparsed as shell syntax. PowerShell was not available for a local Windows run.
- Captures: `/tmp/add-branch-name-badge-web.png` and `/tmp/add-branch-name-badge-electron.png` (local QA artifacts; the Electron capture shows the sidebar toggle and badge together).
- Sidebar remained usable and long branch text truncated without moving the titlebar row.

Project gates:

- `npm run typecheck` — passed across all workspaces.
- `npm run lint` — 0 warnings and 0 errors across 3,368 files.
- `npm run format:check` — all 3,603 files correctly formatted.
- Pre-commit hook reran focused formatting/lint and workspace-wide typecheck — passed.

Platform matrix:

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | n/a | Badge is desktop-form-factor dev chrome. |
| Android | n/a | Badge is desktop-form-factor dev chrome. |
| Web | Yes | Real Chromium against the dev launcher. |
| Desktop macOS | Yes | Real Electron BrowserWindow through CDP. |
| Desktop Windows | No | Static command strings reviewed; PowerShell runtime not available locally. |
| Desktop Linux | No | Shares the Electron dev-runner path, not exercised locally. |

Risk surface: development launch scripts and the expanded left-sidebar titlebar row only. Protocol, daemon state, packaged builds, and production runtime behavior are unchanged.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
