### PR TITLE
Show TeamClaude active account usage

### DIFF
--- a/packages/app/e2e/browser/provider-usage-tooltip.spec.ts
+++ b/packages/app/e2e/browser/provider-usage-tooltip.spec.ts
@@ -31,7 +31,8 @@ test.describe("provider usage tooltip", () => {
             providerId: "mock",
             displayName: "Mock provider",
             status: "available",
-            planLabel: "Test plan",
+            planLabel: "active@example.com",
+            sourceLabel: "TeamClaude active account",
             windows: [
               {
                 id: "session",
@@ -39,6 +40,20 @@ test.describe("provider usage tooltip", () => {
                 usedPct: 42,
                 remainingPct: 58,
                 resetsAt: "2026-06-19T05:00:00.000Z",
+              },
+              {
+                id: "weekly",
+                label: "Weekly",
+                usedPct: 41,
+                remainingPct: 59,
+                resetsAt: "2026-06-26T00:00:00.000Z",
+              },
+              {
+                id: "weekly_model_fable",
+                label: "Weekly \u00b7 Fable",
+                usedPct: 60,
+                remainingPct: 40,
+                resetsAt: "2026-06-26T00:00:00.000Z",
               },
             ],
           },
@@ -55,8 +70,11 @@ test.describe("provider usage tooltip", () => {
       await expect(page.getByText("Mock provider", { exact: true })).toBeVisible({
         timeout: 10_000,
       });
-      await expect(page.getByText("Test plan")).toBeVisible();
+      await expect(page.getByText("active@example.com")).toBeVisible();
       await expect(page.getByText("Session", { exact: true })).toBeVisible();
+      await expect(page.getByText("Weekly", { exact: true })).toBeVisible();
+      await expect(page.getByText("Weekly \u00b7 Fable", { exact: true })).toBeVisible();
+      await expect(page.getByText(/TeamClaude active account/)).toBeVisible();
       await expect(page.getByText("42%")).toBeVisible();
     } finally {
       await session.cleanup();

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -539,6 +539,14 @@ function createInitialMutableDaemonConfig(config: PaseoDaemonConfig): MutableDae
   return initialConfig;
 }
 
+function createClaudeUsageLaunchConfig(settings: AgentProviderRuntimeSettingsMap["claude"]) {
+  return {
+    command: settings?.command?.mode === "replace" ? settings.command.argv : undefined,
+    teamClaudeConfigPath: settings?.env?.["TEAMCLAUDE_CONFIG"],
+    xdgConfigHome: settings?.env?.["XDG_CONFIG_HOME"],
+  };
+}
+
 export async function createPaseoDaemon(
   config: PaseoDaemonConfig,
   rootLogger: Logger,
@@ -1552,6 +1560,7 @@ export async function createPaseoDaemon(
               browserToolsBroker,
               hubRelationships,
               workspaceSetupRuntime,
+              createClaudeUsageLaunchConfig(config.agentProviderSettings?.claude),
             );
             relayRuntime = createRelayRuntime({
               config: {

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -78,6 +78,8 @@ import {
   type WebSocketRuntimeDiagnosticSnapshot,
 } from "./websocket/runtime-metrics.js";
 import { ProviderUsageService } from "../services/quota-fetcher/service.js";
+import { createProviderUsageFetchers } from "../services/quota-fetcher/manifest.js";
+import type { ClaudeUsageLaunchConfig } from "../services/quota-fetcher/provider.js";
 import { getProcessMemoryDiagnostics, getProcessUptimeSeconds } from "./process-diagnostics.js";
 import {
   CLIENT_SHUTDOWN_RPC_REASON,
@@ -621,6 +623,7 @@ export class VoiceAssistantWebSocketServer {
     browserToolsBroker?: BrowserToolsBroker | null,
     hubRelationships?: HubRelationshipManagement | null,
     workspaceSetupRuntime: WorkspaceSetupRuntime = new WorkspaceSetupRuntime(),
+    claudeUsageLaunch?: ClaudeUsageLaunchConfig,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
     this.workspaceSetupRuntime = workspaceSetupRuntime;
@@ -700,6 +703,10 @@ export class VoiceAssistantWebSocketServer {
 
     this.providerUsageService = new ProviderUsageService({
       logger: this.logger,
+      fetchers: createProviderUsageFetchers({
+        logger: this.logger,
+        claudeLaunch: claudeUsageLaunch,
+      }),
     });
 
     this.wss = this.createWebSocketServer(server, wsConfig, auth);

--- a/packages/server/src/services/quota-fetcher/manifest.ts
+++ b/packages/server/src/services/quota-fetcher/manifest.ts
@@ -19,6 +19,7 @@ export const PROVIDER_USAGE_FETCHERS: readonly ProviderUsageFetcherManifestEntry
       new ClaudeQuotaProvider({
         logger: options.logger,
         fetch: options.fetch,
+        claudeLaunch: options.claudeLaunch,
       }),
   },
   {

--- a/packages/server/src/services/quota-fetcher/provider.ts
+++ b/packages/server/src/services/quota-fetcher/provider.ts
@@ -3,6 +3,12 @@ import type { ProviderUsage } from "../../server/messages.js";
 
 export type ProviderApiFetch = typeof fetch;
 
+export interface ClaudeUsageLaunchConfig {
+  command?: readonly string[];
+  teamClaudeConfigPath?: string;
+  xdgConfigHome?: string;
+}
+
 export interface ProviderUsageFetcher {
   readonly providerId: string;
   readonly displayName: string;
@@ -12,6 +18,7 @@ export interface ProviderUsageFetcher {
 export interface ProviderUsageFetcherFactoryOptions {
   logger: Logger;
   fetch?: ProviderApiFetch;
+  claudeLaunch?: ClaudeUsageLaunchConfig;
 }
 
 export interface ProviderUsageFetcherManifestEntry {

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -10,11 +10,16 @@ import type {
   ProviderUsageDetail,
   ProviderUsageWindow,
 } from "../../../server/messages.js";
-import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
+import type {
+  ClaudeUsageLaunchConfig,
+  ProviderApiFetch,
+  ProviderUsageFetcher,
+} from "../provider.js";
 import {
   ApiNumberSchema,
   fetchProviderApi,
   toneFromUsedPct,
+  toIsoStringOrNull,
   unavailableUsage,
   windowFromUsedPct,
 } from "../usage.js";
@@ -24,6 +29,8 @@ const CLAUDE_KEYCHAIN_TIMEOUT_MS = 2_000;
 const CLAUDE_OAUTH_BETA = "oauth-2025-04-20";
 const CLAUDE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
+const TEAMCLAUDE_STATUS_TIMEOUT_MS = 2_000;
+const TEAMCLAUDE_SOURCE_LABEL = "TeamClaude active account";
 
 const ClaudeCredentialsSchema = z.object({
   claudeAiOauth: z
@@ -76,6 +83,37 @@ const ClaudeTokenRefreshSchema = z.object({
   refresh_token: z.string().optional(),
 });
 
+const TeamClaudeServerStateSchema = z.object({
+  port: z.number().int().min(1).max(65_535),
+});
+
+const TeamClaudeQuotaWindowSchema = z.object({
+  utilization: ApiNumberSchema.refine((value) => value >= 0),
+  reset: ApiNumberSchema.nullish(),
+});
+
+const TeamClaudeAccountSchema = z.object({
+  name: z.string().min(1),
+  provider: z.literal("anthropic"),
+  quota: z.object({
+    unified5h: ApiNumberSchema.refine((value) => value >= 0).nullish(),
+    unified7d: ApiNumberSchema.refine((value) => value >= 0).nullish(),
+    unified5hReset: ApiNumberSchema.nullish(),
+    unified7dReset: ApiNumberSchema.nullish(),
+    modelWeekly: z
+      .object({
+        "7d_oi": TeamClaudeQuotaWindowSchema.optional(),
+      })
+      .passthrough()
+      .nullish(),
+  }),
+});
+
+const TeamClaudeStatusSchema = z.object({
+  currentAccount: z.string().min(1),
+  accounts: z.array(z.unknown()),
+});
+
 type ClaudeCredentials = z.infer<typeof ClaudeCredentialsSchema>;
 type ClaudeUsageResponse = z.infer<typeof ClaudeUsageResponseSchema>;
 type ClaudeTokenRefresh = z.infer<typeof ClaudeTokenRefreshSchema>;
@@ -94,6 +132,7 @@ interface ClaudeQuotaProviderOptions {
   claudeKeychainReader?: () => Promise<unknown | null>;
   platform?: typeof process.platform;
   fetch?: ProviderApiFetch;
+  claudeLaunch?: ClaudeUsageLaunchConfig;
 }
 
 function buildClaudePlan(
@@ -297,6 +336,28 @@ function scopedWindows(limits: ScopedLimit[]): ProviderUsageWindow[] {
   });
 }
 
+function isTeamClaudeRunCommand(command: readonly string[] | undefined): boolean {
+  const executable = command?.[0]?.split(/[\\/]/).at(-1);
+  return executable === "teamcodex" && command?.[1] === "run";
+}
+
+function teamClaudeWindow(input: {
+  id: string;
+  label: string;
+  utilization: number | null | undefined;
+  reset: number | null | undefined;
+}): ProviderUsageWindow | null {
+  if (input.utilization == null) return null;
+  const usedPct = input.utilization * 100;
+  return windowFromUsedPct({
+    id: input.id,
+    label: input.label,
+    utilizationPct: usedPct,
+    resetsAt: input.reset == null ? null : toIsoStringOrNull(input.reset),
+    tone: toneFromUsedPct(usedPct),
+  });
+}
+
 async function readClaudeKeychainCredentials(): Promise<unknown | null> {
   try {
     const { stdout } = await execFileAsync(
@@ -321,6 +382,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   private readonly readKeychainCredentials: () => Promise<unknown | null>;
   private readonly platform: typeof process.platform;
   private readonly fetchApi: ProviderApiFetch;
+  private readonly claudeLaunch: ClaudeUsageLaunchConfig | undefined;
 
   constructor(options: ClaudeQuotaProviderOptions) {
     this.logger = options.logger.child({ module: "claude-quota-provider" });
@@ -329,9 +391,14 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
     this.readKeychainCredentials = options.claudeKeychainReader ?? readClaudeKeychainCredentials;
     this.platform = options.platform ?? process.platform;
     this.fetchApi = options.fetch ?? fetch;
+    this.claudeLaunch = options.claudeLaunch;
   }
 
   async fetchUsage(): Promise<ProviderUsage> {
+    if (isTeamClaudeRunCommand(this.claudeLaunch?.command)) {
+      return this.fetchTeamClaudeUsage();
+    }
+
     const credentials = await this.readCredentials();
     if (!credentials) {
       return unavailableUsage(this);
@@ -396,6 +463,79 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
       details,
       error: null,
     };
+  }
+
+  private async fetchTeamClaudeUsage(): Promise<ProviderUsage> {
+    try {
+      const state = TeamClaudeServerStateSchema.parse(
+        JSON.parse(await fs.readFile(this.teamClaudeStatePath(), "utf8")),
+      );
+      const response = await fetchProviderApi(
+        this.fetchApi,
+        `http://127.0.0.1:${state.port}/teamclaude/status`,
+        {
+          method: "GET",
+          signal: AbortSignal.timeout(TEAMCLAUDE_STATUS_TIMEOUT_MS),
+        },
+      );
+      if (!response.ok) return unavailableUsage(this);
+
+      const status = TeamClaudeStatusSchema.parse(await response.json());
+      const activeAccount = status.accounts
+        .map((account) => TeamClaudeAccountSchema.safeParse(account))
+        .find((account) => account.success && account.data.name === status.currentAccount);
+      if (!activeAccount?.success) return unavailableUsage(this);
+
+      const quota = activeAccount.data.quota;
+      const windows = [
+        teamClaudeWindow({
+          id: "five_hour",
+          label: "Session",
+          utilization: quota.unified5h,
+          reset: quota.unified5hReset,
+        }),
+        teamClaudeWindow({
+          id: "weekly",
+          label: "Weekly",
+          utilization: quota.unified7d,
+          reset: quota.unified7dReset,
+        }),
+        teamClaudeWindow({
+          id: "weekly_model_fable",
+          label: "Weekly \u00b7 Fable",
+          utilization: quota.modelWeekly?.["7d_oi"]?.utilization,
+          reset: quota.modelWeekly?.["7d_oi"]?.reset,
+        }),
+      ].filter((window): window is ProviderUsageWindow => window !== null);
+
+      return {
+        providerId: this.providerId,
+        displayName: this.displayName,
+        status: "available",
+        planLabel: activeAccount.data.name,
+        sourceLabel: TEAMCLAUDE_SOURCE_LABEL,
+        windows,
+        balances: [],
+        details: [],
+        error: null,
+      };
+    } catch (error) {
+      this.logger.debug({ err: error }, "TeamClaude usage is unavailable");
+      return unavailableUsage(this);
+    }
+  }
+
+  private teamClaudeStatePath(): string {
+    const configPath = this.claudeLaunch?.teamClaudeConfigPath ?? process.env["TEAMCLAUDE_CONFIG"];
+    const resolvedConfigPath =
+      configPath ??
+      join(
+        this.claudeLaunch?.xdgConfigHome ??
+          process.env["XDG_CONFIG_HOME"] ??
+          join(homedir(), ".config"),
+        "teamclaude.json",
+      );
+    return `${resolvedConfigPath.replace(/\.json$/, "")}.server.json`;
   }
 
   /**

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -31,6 +31,10 @@ function writeClaudeCredentials(
   );
 }
 
+function writeTeamClaudeServerState(dir: string, port = 3456): void {
+  writeFileSync(join(dir, "teamclaude.server.json"), JSON.stringify({ port }));
+}
+
 function writeCodexAuth(dir: string, accessToken: string, refreshToken = "rt_codex"): void {
   writeFileSync(
     join(dir, "auth.json"),
@@ -550,6 +554,184 @@ describe("real provider usage fetchers", () => {
       "https://api.anthropic.com/api/oauth/usage",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer at_expired" }),
+      }),
+    );
+  });
+
+  it("returns the TeamClaude active account usage without using Claude credentials", async () => {
+    writeClaudeCredentials(claudeHome, "at_direct_claude");
+    writeTeamClaudeServerState(homeDir);
+    const keychain = vi.fn(async () => ({
+      claudeAiOauth: { accessToken: "at_keychain_claude" },
+    }));
+    fetchApi = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      expect(url.toString()).toBe("http://127.0.0.1:3456/teamclaude/status");
+      expect(init).toEqual({
+        method: "GET",
+        signal: expect.any(AbortSignal),
+      });
+      expect(new Headers(init?.headers).has("authorization")).toBe(false);
+      expect(new Headers(init?.headers).has("x-api-key")).toBe(false);
+      return jsonResponse({
+        currentAccount: "active@example.com",
+        switchThreshold: 0.98,
+        accounts: [
+          {
+            name: "other@example.com",
+            provider: "anthropic",
+            quota: { unified5h: 0.1, unified7d: 0.2, modelWeekly: {} },
+          },
+          {
+            name: "active@example.com",
+            provider: "anthropic",
+            quota: {
+              unified5h: 0.98,
+              unified7d: 0.41,
+              unified5hReset: 1_786_467_000_000,
+              unified7dReset: 1_787_014_800_000,
+              modelWeekly: {
+                "7d_oi": { utilization: 0.6, reset: 1_787_014_800_000 },
+              },
+            },
+          },
+        ],
+      });
+    }) as never;
+
+    const usage = await new ClaudeQuotaProvider({
+      logger: createLogger(),
+      claudeHome,
+      claudeKeychainReader: keychain,
+      platform: "darwin",
+      fetch: fetchApi,
+      claudeLaunch: {
+        command: ["/opt/homebrew/bin/teamcodex", "run", "--"],
+        xdgConfigHome: homeDir,
+      },
+    }).fetchUsage();
+
+    expect(usage).toEqual({
+      providerId: "claude",
+      displayName: "Claude",
+      status: "available",
+      planLabel: "active@example.com",
+      sourceLabel: "TeamClaude active account",
+      windows: [
+        {
+          id: "five_hour",
+          label: "Session",
+          usedPct: 98,
+          remainingPct: 2,
+          resetsAt: "2026-08-11T16:50:00.000Z",
+          tone: "danger",
+        },
+        {
+          id: "weekly",
+          label: "Weekly",
+          usedPct: 41,
+          remainingPct: 59,
+          resetsAt: "2026-08-18T01:00:00.000Z",
+          tone: "ok",
+        },
+        {
+          id: "weekly_model_fable",
+          label: "Weekly \u00b7 Fable",
+          usedPct: 60,
+          remainingPct: 40,
+          resetsAt: "2026-08-18T01:00:00.000Z",
+          tone: "ok",
+        },
+      ],
+      balances: [],
+      details: [],
+      error: null,
+    });
+    expect(fetchApi).toHaveBeenCalledTimes(1);
+    expect(keychain).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to direct Claude usage when configured TeamClaude is unavailable", async () => {
+    writeClaudeCredentials(claudeHome, "at_direct_claude");
+    const keychain = vi.fn(async () => ({
+      claudeAiOauth: { accessToken: "at_keychain_claude" },
+    }));
+    fetchApi = vi.fn() as never;
+
+    const usage = await new ClaudeQuotaProvider({
+      logger: createLogger(),
+      claudeHome,
+      claudeKeychainReader: keychain,
+      platform: "darwin",
+      fetch: fetchApi,
+      claudeLaunch: {
+        command: ["teamcodex", "run", "--"],
+        xdgConfigHome: homeDir,
+      },
+    }).fetchUsage();
+
+    expect(usage.status).toBe("unavailable");
+    expect(fetchApi).not.toHaveBeenCalled();
+    expect(keychain).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed TeamClaude status without falling back to direct Claude usage", async () => {
+    writeClaudeCredentials(claudeHome, "at_direct_claude");
+    writeTeamClaudeServerState(homeDir);
+    fetchApi = vi.fn(async () =>
+      jsonResponse({
+        currentAccount: "active@example.com",
+        accounts: [
+          {
+            name: "active@example.com",
+            provider: "anthropic",
+            quota: { unified5h: "almost full" },
+          },
+        ],
+      }),
+    ) as never;
+
+    const usage = await new ClaudeQuotaProvider({
+      logger: createLogger(),
+      claudeHome,
+      fetch: fetchApi,
+      claudeLaunch: {
+        command: ["teamcodex", "run", "--"],
+        xdgConfigHome: homeDir,
+      },
+    }).fetchUsage();
+
+    expect(usage.status).toBe("unavailable");
+    expect(fetchApi).toHaveBeenCalledTimes(1);
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.anything(),
+    );
+  });
+
+  it("preserves direct Claude usage when the configured command is not teamcodex run", async () => {
+    writeClaudeCredentials(claudeHome, "at_direct_claude");
+    fetchApi = mockFetch(
+      new Map([
+        ["https://api.anthropic.com/api/oauth/usage", () => jsonResponse(makeClaudeResponse())],
+      ]),
+    );
+
+    const usage = await new ClaudeQuotaProvider({
+      logger: createLogger(),
+      claudeHome,
+      fetch: fetchApi,
+      claudeLaunch: {
+        command: ["teamcodex", "status"],
+        xdgConfigHome: homeDir,
+      },
+    }).fetchUsage();
+
+    expect(usage.status).toBe("available");
+    expect(usage.sourceLabel).toBeUndefined();
+    expect(fetchApi).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer at_direct_claude" }),
       }),
     );
   });


### PR DESCRIPTION
### Linked issue

None. This is an unsolicited, workflow-focused enhancement submitted as a draft for direction feedback.

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

I launch Claude through TeamClaude, while Paseo currently reads Claude usage from its own direct OAuth account.

When those accounts differ, the Context window tooltip shows usage for the wrong account and cannot answer which quota the active workflow is consuming.

This change detects the built-in Claude command `teamcodex run`, reads TeamClaude's localhost status endpoint without sending credentials, and maps the globally active account into Paseo's existing provider-usage response.

The existing tooltip then shows the active account name, `TeamClaude active account`, and Session, Weekly, and Fable usage without adding a new UI or protocol shape.

### Goals

- Show the exact TeamClaude global active account in the existing Context window tooltip.
- Show Session, Weekly, and Fable usage and reset times for that account.
- Send no OAuth token, API key, or authorization header to TeamClaude.
- Fail closed when TeamClaude state or status data is unavailable or malformed.
- Preserve direct Claude OAuth behavior when the configured command is not `teamcodex run`.

### Non-goals

- Account switching or account-management UI.
- Copying or storing TeamClaude credentials in Paseo.
- Claiming per-agent account affinity; TeamClaude exposes a global active account.
- Supporting arbitrary custom Claude wrapper commands.
- Changing Paseo's provider-usage protocol or tooltip design.

### QA

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| Web | Yes | Existing tooltip flow exercised in Playwright with isolated Metro and daemon. |
| Daemon on macOS | Yes | Unit/integration tests plus a read-only call to the running TeamClaude localhost endpoint. |
| iOS | No | No native UI code changed. |
| Android | No | No native UI code changed. |
| Desktop Windows | No | TeamClaude was not available on this machine. |
| Desktop Linux | No | TeamClaude was not available on this machine. |

Focused server behavior:

```text
$ npx vitest run packages/server/src/services/quota-fetcher/service.test.ts --bail=1
Test Files  1 passed (1)
Tests       72 passed (72)
```

The assertions cover the returned `ProviderUsage` state, exact active-account matching, all three usage windows, credential-free requests, malformed/unavailable TeamClaude responses, and the direct-Claude negative control.

Tooltip browser flow:

```text
$ npx playwright test e2e/browser/provider-usage-tooltip.spec.ts --project=browser --workers=1
✓ fetches usage when the context tooltip opens and renders the active provider
✓ refreshes usage again each time the tooltip is shown
2 passed (18.5s)
```

The run used an isolated Metro server and temporary daemon; the developer daemon on port 6767 was not touched.

Read-only real-provider check on macOS:

```text
TeamClaude status: available
currentAccount: exact account match
windows: Session, Weekly, Weekly · Fable
authorization headers sent: none
```

Repository checks:

```text
$ npm run build:server
passed
$ npm run typecheck
passed
$ npm run lint
passed with zero warnings and errors
$ npm run format
passed
$ npm run format:check
passed
```

This contribution was prepared with agent assistance. The behavior was verified with the commands and live read-only check above.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
