### PR TITLE
Use saved Project Settings for new worktree setup

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -295,7 +295,9 @@ another remote fails closed until the worktree records an explicit local target.
 the optional field and retain the previous local-first behavior; older worktree metadata without the
 exact ref also resolves through its stored branch name.
 
-Worktrees inherit committed Git state only; uncommitted source-checkout changes are not copied.
+Worktrees inherit committed Git state. Before lifecycle setup, Paseo copies the source checkout's
+`paseo.json` over the worktree copy so saved Project Settings apply without a commit. Other
+uncommitted source-checkout changes are not copied.
 
 ## paseo.json service scripts
 

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -13,7 +13,7 @@ import {
 import {
   mapWorkspaceRelativeCwdToWorktree,
   rollbackCreatedPaseoWorktree,
-  seedPaseoConfigFile,
+  copySourcePaseoConfigFile,
   validateBranchSlug,
   type WorktreeConfig,
 } from "../utils/worktree.js";
@@ -85,7 +85,7 @@ async function createPaseoWorktreeWithPriority(
     }
 
     if (createdWorktree.created) {
-      await seedPaseoConfigFile({
+      await copySourcePaseoConfigFile({
         sourceCwd: workspaceCwdPlan.inputCwd,
         targetCwd: workspaceCwd,
       });

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -1188,10 +1188,10 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       });
     });
 
-    it("does not overwrite a committed paseo.json with uncommitted edits in the main repo", async () => {
+    it("runs setup from the edited source config when the selected ref already has paseo.json", async () => {
       writeFileSync(
         join(repoDir, "paseo.json"),
-        JSON.stringify({ scripts: { dev: { command: "committed" } } }),
+        JSON.stringify({ worktree: { setup: 'echo "committed" > committed-setup.log' } }),
       );
       execFileSync("git", ["add", "paseo.json"], { cwd: repoDir });
       execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "add paseo.json"], {
@@ -1200,21 +1200,23 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
 
       writeFileSync(
         join(repoDir, "paseo.json"),
-        JSON.stringify({ scripts: { dev: { command: "uncommitted" } } }),
+        JSON.stringify({ worktree: { setup: 'echo "edited" > edited-setup.log' } }),
       );
 
       const result = await createLegacyWorktreeForTest({
         cwd: repoDir,
-        worktreeSlug: "preserve-committed",
-        source: { kind: "branch-off", baseBranch: "main", branchName: "feature/preserve" },
-        runSetup: false,
+        worktreeSlug: "edited-config",
+        source: { kind: "branch-off", baseBranch: "main", branchName: "feature/edited-config" },
+        runSetup: true,
         paseoHome,
       });
 
       const worktreeConfigPath = join(result.worktreePath, "paseo.json");
       expect(JSON.parse(readFileSync(worktreeConfigPath, "utf8"))).toEqual({
-        scripts: { dev: { command: "committed" } },
+        worktree: { setup: 'echo "edited" > edited-setup.log' },
       });
+      expect(readFileSync(join(result.worktreePath, "edited-setup.log"), "utf8")).toBe("edited\n");
+      expect(existsSync(join(result.worktreePath, "committed-setup.log"))).toBe(false);
     });
 
     it("creates a worktree without error when no paseo.json exists in the main repo", async () => {

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -40,6 +40,9 @@ import {
   writeFileSync,
   readFileSync,
   chmodSync,
+  lstatSync,
+  symlinkSync,
+  unlinkSync,
 } from "fs";
 import { delimiter, dirname, join } from "path";
 import { tmpdir } from "os";
@@ -1215,6 +1218,44 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(JSON.parse(readFileSync(worktreeConfigPath, "utf8"))).toEqual({
         worktree: { setup: 'echo "edited" > edited-setup.log' },
       });
+      expect(readFileSync(join(result.worktreePath, "edited-setup.log"), "utf8")).toBe("edited\n");
+      expect(existsSync(join(result.worktreePath, "committed-setup.log"))).toBe(false);
+    });
+
+    it("replaces a selected ref's paseo.json symlink without writing through it", async () => {
+      const sourceConfigPath = join(repoDir, "paseo.json");
+      const externalConfigPath = join(tempDir, "external-paseo.json");
+      const committedConfig = JSON.stringify({
+        worktree: { setup: 'echo "committed" > committed-setup.log' },
+      });
+      const editedConfig = JSON.stringify({
+        worktree: { setup: 'echo "edited" > edited-setup.log' },
+      });
+      writeFileSync(externalConfigPath, committedConfig);
+      symlinkSync(externalConfigPath, sourceConfigPath);
+      execFileSync("git", ["add", "paseo.json"], { cwd: repoDir });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "add config link"], {
+        cwd: repoDir,
+      });
+      unlinkSync(sourceConfigPath);
+      writeFileSync(sourceConfigPath, editedConfig);
+
+      const result = await createLegacyWorktreeForTest({
+        cwd: repoDir,
+        worktreeSlug: "replace-config-link",
+        source: {
+          kind: "branch-off",
+          baseBranch: "main",
+          branchName: "feature/replace-config-link",
+        },
+        runSetup: true,
+        paseoHome,
+      });
+
+      const worktreeConfigPath = join(result.worktreePath, "paseo.json");
+      expect(readFileSync(externalConfigPath, "utf8")).toBe(committedConfig);
+      expect(lstatSync(worktreeConfigPath).isFile()).toBe(true);
+      expect(readFileSync(worktreeConfigPath, "utf8")).toBe(editedConfig);
       expect(readFileSync(join(result.worktreePath, "edited-setup.log"), "utf8")).toBe("edited\n");
       expect(existsSync(join(result.worktreePath, "committed-setup.log"))).toBe(false);
     });

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -793,18 +793,12 @@ export async function runWorktreeTeardownCommands(options: {
   return results;
 }
 
-export async function seedPaseoConfigFile(options: {
+export async function copySourcePaseoConfigFile(options: {
   sourceCwd: string;
   targetCwd: string;
 }): Promise<void> {
   const sourceConfigPath = join(options.sourceCwd, "paseo.json");
   const targetConfigPath = join(options.targetCwd, "paseo.json");
-  try {
-    await stat(targetConfigPath);
-    return;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-  }
   await copyFile(sourceConfigPath, targetConfigPath).catch((error) => {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   });
@@ -1257,7 +1251,7 @@ export const createWorktree = async ({
       : {}),
   });
 
-  await seedPaseoConfigFile({ sourceCwd: cwd, targetCwd: worktreePath });
+  await copySourcePaseoConfigFile({ sourceCwd: cwd, targetCwd: worktreePath });
 
   if (runSetup) {
     await runWorktreeSetupCommands({

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { existsSync, mkdirSync, realpathSync, rmSync, statSync } from "fs";
-import { copyFile, rm, stat } from "fs/promises";
+import { readFile, rm, stat } from "fs/promises";
 import { join, basename, dirname, isAbsolute, resolve, sep } from "path";
 import net from "node:net";
 import { createHash } from "node:crypto";
@@ -33,6 +33,7 @@ import {
 import { runGitCommand } from "./run-git-command.js";
 import { spawnProcess } from "./spawn.js";
 import { resolvePaseoHome } from "../server/paseo-home.js";
+import { writeFileAtomic } from "../server/atomic-file.js";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
 import { validateBranchSlug } from "@getpaseo/protocol/branch-slug";
@@ -799,9 +800,14 @@ export async function copySourcePaseoConfigFile(options: {
 }): Promise<void> {
   const sourceConfigPath = join(options.sourceCwd, "paseo.json");
   const targetConfigPath = join(options.targetCwd, "paseo.json");
-  await copyFile(sourceConfigPath, targetConfigPath).catch((error) => {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-  });
+  let sourceConfig: Buffer;
+  try {
+    sourceConfig = await readFile(sourceConfigPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  await writeFileAtomic(targetConfigPath, sourceConfig);
 }
 
 /**


### PR DESCRIPTION
### Linked issue

Reported in [Discord](https://discord.com/channels/1481169421832814616/1481169422990184542/1536800004625408020).

Refs #2558, whose worktree launch-readiness goal remains independent. This PR establishes that the configuration saved in Project Settings is the configuration copied into a newly created worktree.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Saving a new `worktree.setup` command in Project Settings updated the source checkout's `paseo.json`, but new worktrees kept an older committed copy from their selected Git ref. Setup then ran the old command even though Project Settings displayed the new one.

New worktrees now materialize the source checkout's `paseo.json` before lifecycle setup. The source is read first and atomically renamed over the target path, so a selected ref cannot redirect the write through a committed symlink. This gives the project settings UI and worktree runtime one configuration authority while preserving the selected ref when the source checkout has no config file.

### Goals

- Run the setup command currently saved in Project Settings for every newly created worktree.
- Cover the reported committed-old/config-edited workflow with a real Git worktree regression test.
- Replace a selected ref's config path without following repository-controlled symlinks.
- Keep exact-subproject worktree config copying on the same policy.
- Document the `paseo.json` exception to committed-only worktree state.

### Non-goals

- Change setup execution, shell selection, progress reporting, or readiness semantics.
- Copy any other uncommitted source-checkout files.
- Modify existing worktrees.

New worktrees may begin with a modified `paseo.json` when the source config differs from the selected ref. Paseo already permits this for first-time uncommitted project configuration; this change applies the same user contract when the selected ref already contains the file.

### QA

TDD reproduction before the implementation:

- `npx vitest run packages/server/src/utils/worktree.posix.test.ts -t 'runs setup from the edited source config when the selected ref already has paseo.json' --bail=1`
- Failed because the worktree contained and ran `echo "committed" > committed-setup.log` instead of the saved `edited` command.

Security-review reproduction before the follow-up:

- `npx vitest run packages/server/src/utils/worktree.posix.test.ts -t "replaces a selected ref's paseo.json symlink without writing through it" --bail=1`
- Failed because copying over the checked-out symlink changed the external config file from the committed bytes to the edited bytes.

Verification after both fixes:

- `npx vitest run packages/server/src/utils/worktree.posix.test.ts --bail=1` — 46 passed, 1 skipped.
- `npx vitest run packages/server/src/server/paseo-worktree-service.test.ts --bail=1` — 25 passed.
- The symlink regression proves the external file is unchanged, the worktree config is a regular file with the edited bytes, the edited setup runs, and the committed setup does not.
- `npm run typecheck` — passed across all workspaces.
- `npm run lint -- packages/server/src/utils/worktree.ts packages/server/src/utils/worktree.posix.test.ts packages/server/src/server/paseo-worktree-service.ts` — 0 warnings, 0 errors.
- `npm run format` and `npm run format:check` — passed.

Tested with real Git worktrees on macOS. No UI code changed; web, Electron, iOS, Android, Linux, and Windows were not manually tested.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
