### PR TITLE
Keep terminal sessions alive across host sleep

### DIFF
--- a/packages/server/scripts/supervisor.logging.test.ts
+++ b/packages/server/scripts/supervisor.logging.test.ts
@@ -10,9 +10,15 @@ import { resolveSupervisorLogFile } from "./supervisor-log-config.js";
 const repoRoot = path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
 const supervisorPath = fileURLToPath(new URL("./supervisor.ts", import.meta.url));
 
+interface SupervisorSuspension {
+  afterMs: number;
+  durationMs: number;
+}
+
 async function runSupervisorFixture(options: {
   workerSource: string;
   restartOnCrash?: boolean;
+  suspension?: SupervisorSuspension;
   timeoutMs?: number;
 }): Promise<{
   code: number | null;
@@ -52,9 +58,22 @@ async function runSupervisorFixture(options: {
   const startedAt = Date.now();
   const child = spawn(process.execPath, ["--import", "tsx", runnerPath], {
     cwd: repoRoot,
+    detached: options.suspension !== undefined,
     env: { ...process.env },
     stdio: ["ignore", "pipe", "pipe"],
   });
+
+  if (options.suspension) {
+    const supervisorPid = child.pid;
+    if (supervisorPid === undefined) {
+      throw new Error("Supervisor fixture did not start");
+    }
+    const { afterMs, durationMs } = options.suspension;
+    setTimeout(() => {
+      process.kill(-supervisorPid, "SIGSTOP");
+      setTimeout(() => process.kill(-supervisorPid, "SIGCONT"), durationMs);
+    }, afterMs);
+  }
 
   let stdout = "";
   let stderr = "";
@@ -240,6 +259,40 @@ describe("supervisor durable logging", () => {
     expect(result.log).not.toContain('"reason":"unexpected_heartbeat_restart"');
     expect(result.log).not.toContain('"msg":"Worker heartbeat timed out; restarting worker"');
   }, 10_000);
+
+  test.skipIf(isPlatform("win32"))(
+    "keeps a healthy worker alive after the host resumes from sleep",
+    async () => {
+      const result = await runSupervisorFixture({
+        suspension: { afterMs: 1_000, durationMs: 16_000 },
+        timeoutMs: 25_000,
+        workerSource: `
+          import { existsSync, writeFileSync } from "node:fs";
+
+          const marker = process.argv[1] + ".started";
+          if (!existsSync(marker)) {
+            writeFileSync(marker, "started");
+            setInterval(() => {
+              process.send?.({ type: "paseo:worker-heartbeat" });
+            }, 250);
+            setTimeout(() => {
+              process.send?.({ type: "paseo:shutdown", reason: "sleep_resume_test_complete" });
+            }, 17_000);
+          } else {
+            process.send?.({ type: "paseo:shutdown", reason: "unexpected_sleep_restart" });
+          }
+          setInterval(() => {}, 1_000);
+        `,
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.log).toContain('"reason":"sleep_resume_test_complete"');
+      expect(result.log).not.toContain('"reason":"unexpected_sleep_restart"');
+      expect(result.log).not.toContain('"msg":"Worker heartbeat timed out; restarting worker"');
+    },
+    30_000,
+  );
 
   test.skipIf(isPlatform("win32"))(
     "forces shutdown when a worker ignores SIGTERM",

--- a/packages/server/scripts/supervisor.ts
+++ b/packages/server/scripts/supervisor.ts
@@ -5,7 +5,7 @@ import { createStream as createRotatingFileStream } from "rotating-file-stream";
 import { signalProcessTree } from "../src/utils/tree-kill.js";
 
 const WORKER_HEARTBEAT_INTERVAL_MS = 1_000;
-const WORKER_HEARTBEAT_TIMEOUT_MS = 15_000;
+const WORKER_HEARTBEAT_MISSED_CHECK_LIMIT = 15;
 const WORKER_TERMINATION_GRACE_MS = 10_000;
 
 interface SupervisorLogFileOptions {
@@ -250,7 +250,7 @@ export function runSupervisor(options: SupervisorOptions): SupervisorController 
     }
 
     const currentChild = child;
-    let lastWorkerHeartbeatAt = Date.now();
+    let missedWorkerHeartbeatChecks = 0;
     const heartbeat = setInterval(() => {
       const message: SupervisorHeartbeatMessage = { type: "paseo:supervisor-heartbeat" };
       if (currentChild.connected) {
@@ -271,12 +271,12 @@ export function runSupervisor(options: SupervisorOptions): SupervisorController 
       if (child !== currentChild || restarting || shuttingDown) {
         return;
       }
-      const heartbeatAgeMs = Date.now() - lastWorkerHeartbeatAt;
-      if (heartbeatAgeMs < WORKER_HEARTBEAT_TIMEOUT_MS) {
+      missedWorkerHeartbeatChecks += 1;
+      if (missedWorkerHeartbeatChecks < WORKER_HEARTBEAT_MISSED_CHECK_LIMIT) {
         return;
       }
       writeLifecycleLog("Worker heartbeat timed out; restarting worker", {
-        heartbeatAgeMs,
+        missedHeartbeatChecks: missedWorkerHeartbeatChecks,
         supervisorPid: process.pid,
         workerPid: currentChild.pid ?? null,
       });
@@ -300,7 +300,7 @@ export function runSupervisor(options: SupervisorOptions): SupervisorController 
 
     child.on("message", (msg: unknown) => {
       if (isWorkerHeartbeatMessage(msg)) {
-        lastWorkerHeartbeatAt = Date.now();
+        missedWorkerHeartbeatChecks = 0;
         return;
       }
       const lifecycleMessage = parseLifecycleMessage(msg);


### PR DESCRIPTION
### Linked issue

Refs #3061

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Sleeping a host longer than the daemon worker's 15-second heartbeat timeout made the supervisor treat suspended wall-clock time as proof that the worker had stalled. The resulting restart closed every live terminal session, so terminal tabs and the processes running inside them disappeared after wake.

The watchdog now counts consecutive supervisor checks that observe no worker heartbeat. Host sleep produces one delayed observation after wake, while a genuinely unresponsive worker still reaches the same 15-check restart limit.

### Goals

- Keep healthy daemon workers and their terminal sessions alive across host sleep and resume.
- Preserve automatic recovery when a worker genuinely stops sending heartbeats.
- Cover host suspension through the real supervisor/worker process boundary.

### Non-goals

- Persist or reconstruct terminal processes after an intentional daemon restart or crash.
- Change provider-turn recovery across daemon restarts.
- Add platform-specific power-management integration.

### QA

- Reproduced before the fix by suspending the real supervisor and worker process group for 16 seconds with `SIGSTOP`; the test failed after logging `worker_heartbeat_timeout` and spawning a replacement worker.
- Confirmed after the fix with `npx vitest run packages/server/scripts/supervisor.logging.test.ts --bail=1`: 13 tests passed, including sleep/resume, a seven-second transient heartbeat pause, genuine heartbeat loss, and forced worker cleanup.
- `npm run typecheck` passed.
- `npm run lint -- packages/server/scripts/supervisor.ts packages/server/scripts/supervisor.logging.test.ts` passed.
- `npm run format` passed.
- Tested on macOS. The process-suspension regression test is skipped on Windows because it relies on POSIX signals; the watchdog implementation itself is platform-independent.

### Risk surface

The change is confined to daemon worker supervision. A worker that remains dead after the supervisor resumes now receives a fresh active-observation window of up to 15 checks before restart; graceful termination and forced process-tree cleanup are unchanged.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
