### PR TITLE
fix(server): keep Pi turns active through provider retries

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -965,6 +965,12 @@ describe("PiRpcAgentSession", () => {
       ],
     });
 
+    expect(events.timelineItems()).toContainEqual({
+      type: "error",
+      message:
+        "Provider retry (attempt 1): OpenAI API error (503): upstream failed (stopReason=error, model=openrouter/model-a)",
+    });
+    expect(events.eventTypes()).not.toContain("turn_failed");
     expect(events.turnCompletedEvents()).toHaveLength(0);
     await expect(session.startTurn("do not overlap")).rejects.toThrow(
       "A Pi turn is already active",

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -944,6 +944,207 @@ describe("PiRpcAgentSession", () => {
     });
   });
 
+  test("keeps a Pi turn active across automatic retries", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId } = await session.startTurn("retry this request");
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: true,
+      messages: [
+        {
+          role: "assistant",
+          provider: "openrouter",
+          model: "model-a",
+          stopReason: "error",
+          errorMessage: "OpenAI API error (503): upstream failed",
+          content: [],
+        },
+      ],
+    });
+
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+    await expect(session.startTurn("do not overlap")).rejects.toThrow(
+      "A Pi turn is already active",
+    );
+
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: false,
+      messages: [{ role: "assistant", content: [] }],
+    });
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+
+    fakeSession.emit({ type: "agent_settled" });
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({
+      type: "turn_completed",
+      turnId,
+    });
+    expect(events.turnCompletedEvents()).toHaveLength(1);
+  });
+
+  test("completes legacy Pi agent_end events without agent_settled", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId } = await session.startTurn("complete with legacy Pi events");
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.emit({
+      type: "agent_end",
+      messages: [{ role: "assistant", content: [] }],
+    });
+
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({
+      type: "turn_completed",
+      turnId,
+    });
+  });
+
+  test("ignores a duplicated Pi terminal pair before the next turn starts", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId: firstTurnId } = await session.startTurn("first request");
+    fakeSession.finishTurn();
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({ turnId: firstTurnId });
+
+    const { turnId: recoveryTurnId } = await session.startTurn("next request");
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: false,
+      messages: [{ role: "assistant", content: [] }],
+    });
+    fakeSession.emit({ type: "agent_settled" });
+    expect(events.turnCompletedEvents()).toHaveLength(1);
+
+    fakeSession.finishTurn();
+    await vi.waitFor(() => {
+      expect(events.turnCompletedEvents()).toHaveLength(2);
+    });
+    expect(events.turnCompletedEvents().at(-1)).toMatchObject({
+      turnId: recoveryTurnId,
+    });
+  });
+
+  test("clears a buffered Pi retry when the runtime exits", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("retry before exit");
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: true,
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "OpenAI API error (503): upstream failed",
+          content: [],
+        },
+      ],
+    });
+    fakeSession.emit({ type: "process_exit", error: "Pi exited" });
+
+    await expect(events.nextTurnFailure()).resolves.toMatchObject({ error: "Pi exited" });
+
+    const { turnId } = await session.startTurn("recover after exit");
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: false,
+      messages: [{ role: "assistant", content: [] }],
+    });
+    fakeSession.emit({ type: "agent_settled" });
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+
+    fakeSession.finishTurn();
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({
+      type: "turn_completed",
+      turnId,
+    });
+  });
+
+  test("ignores late Pi settlement after an interrupted retry", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId } = await session.startTurn("retry before interrupt");
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: true,
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "OpenAI API error (503): upstream failed",
+          content: [],
+        },
+      ],
+    });
+
+    await session.interrupt();
+    await expect(events.nextTurnCancellation()).resolves.toMatchObject({ turnId });
+
+    fakeSession.emit({ type: "agent_settled" });
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+
+    const { turnId: recoveryTurnId } = await session.startTurn("recover after interrupt");
+    fakeSession.finishTurn();
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({
+      type: "turn_completed",
+      turnId: recoveryTurnId,
+    });
+  });
+
+  test("waits for Pi to settle after overflow compaction before completing", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("compact and retry this request");
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: false,
+      messages: [
+        {
+          role: "assistant",
+          provider: "openrouter",
+          model: "model-a",
+          stopReason: "error",
+          errorMessage: "Context window exceeded",
+          content: [],
+        },
+      ],
+    });
+    fakeSession.emit({ type: "compaction_start", reason: "overflow" });
+    fakeSession.emit({
+      type: "compaction_end",
+      reason: "overflow",
+      willRetry: true,
+    });
+
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+    expect((events as unknown as { events: AgentStreamEvent[] }).events).not.toContainEqual(
+      expect.objectContaining({ type: "turn_failed" }),
+    );
+
+    fakeSession.emit({ type: "agent_start" });
+    fakeSession.emit({
+      type: "agent_end",
+      willRetry: false,
+      messages: [{ role: "assistant", content: [] }],
+    });
+    fakeSession.emit({ type: "agent_settled" });
+
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({
+      type: "turn_completed",
+    });
+  });
+
   test("resumes by launching Pi with the persisted session file and cwd metadata", async () => {
     const pi = new FakePi();
     const client = createClient(pi);

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -229,10 +229,12 @@ class SessionEvents {
     );
   }
 
-  nextTurnCompletion(): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
+  nextTurnCompletion(
+    turnId?: string,
+  ): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
     return this.nextEvent(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
-        event.type === "turn_completed",
+        event.type === "turn_completed" && (turnId === undefined || event.turnId === turnId),
     );
   }
 
@@ -1027,12 +1029,10 @@ describe("PiRpcAgentSession", () => {
     expect(events.turnCompletedEvents()).toHaveLength(1);
 
     fakeSession.finishTurn();
-    await vi.waitFor(() => {
-      expect(events.turnCompletedEvents()).toHaveLength(2);
-    });
-    expect(events.turnCompletedEvents().at(-1)).toMatchObject({
+    await expect(events.nextTurnCompletion(recoveryTurnId)).resolves.toMatchObject({
       turnId: recoveryTurnId,
     });
+    expect(events.turnCompletedEvents()).toHaveLength(2);
   });
 
   test("clears a buffered Pi retry when the runtime exits", async () => {
@@ -1134,9 +1134,7 @@ describe("PiRpcAgentSession", () => {
     });
 
     expect(events.turnCompletedEvents()).toHaveLength(0);
-    expect((events as unknown as { events: AgentStreamEvent[] }).events).not.toContainEqual(
-      expect.objectContaining({ type: "turn_failed" }),
-    );
+    expect(events.eventTypes()).not.toContain("turn_failed");
 
     fakeSession.emit({ type: "agent_start" });
     fakeSession.emit({

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1216,6 +1216,7 @@ export class PiRpcAgentSession implements AgentSession {
   private readonly pendingExtensionResults = new Map<string, PendingExtensionResult>();
   private activeAgentLifecycleTurnId: string | null = null;
   private pendingAgentEnd: { turnId: string; messages: PiAgentMessage[] } | null = null;
+  private piRetryAttempt = 0;
   private outOfBandCompactionEmit: ((event: AgentStreamEvent) => void) | null = null;
   private outOfBandCompactionStarted = false;
   private outOfBandCompactionCompleted = false;
@@ -1302,6 +1303,7 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnStarted = false;
     this.activeAgentLifecycleTurnId = null;
     this.pendingAgentEnd = null;
+    this.piRetryAttempt = 0;
     this.activePromptRequestId = null;
     this.clearNoTurnBuffers();
     this.activeNoTurnPromptText = payload.text;
@@ -1335,6 +1337,7 @@ export class PiRpcAgentSession implements AgentSession {
         this.activeTurnStarted = false;
         this.activeAgentLifecycleTurnId = null;
         this.pendingAgentEnd = null;
+        this.piRetryAttempt = 0;
         this.activeAssistantMessageId = null;
         this.clearNoTurnBuffers();
         if (isPiRequestAbortError(error)) {
@@ -2060,6 +2063,7 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnStarted = false;
     this.activeAgentLifecycleTurnId = null;
     this.pendingAgentEnd = null;
+    this.piRetryAttempt = 0;
     this.clearNoTurnBuffers();
     this.emit({
       type: "turn_failed",
@@ -2169,9 +2173,25 @@ export class PiRpcAgentSession implements AgentSession {
       this.completeTurn(lifecycleTurnId, event.messages ?? []);
       return;
     }
+    const messages = event.messages ?? [];
+    if (event.willRetry) {
+      this.piRetryAttempt += 1;
+      const errorMessage = latestPiErrorMessage(messages);
+      this.emit({
+        type: "timeline",
+        provider: this.provider,
+        turnId: lifecycleTurnId,
+        item: {
+          type: "error",
+          message: errorMessage
+            ? `Provider retry (attempt ${this.piRetryAttempt}): ${errorMessage}`
+            : `Provider retry (attempt ${this.piRetryAttempt})`,
+        },
+      });
+    }
     this.pendingAgentEnd = {
       turnId: lifecycleTurnId,
-      messages: event.messages ?? [],
+      messages,
     };
   }
 
@@ -2357,6 +2377,7 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
     this.pendingAgentEnd = null;
+    this.piRetryAttempt = 0;
     this.activeAgentLifecycleTurnId = null;
     this.activeTurnId = null;
     this.activeClientMessageId = null;

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1003,6 +1003,7 @@ function isPiAgentSessionEvent(event: PiRuntimeEvent): event is PiAgentSessionEv
     case "compaction_start":
     case "compaction_end":
     case "agent_end":
+    case "agent_settled":
       return true;
     default:
       return false;
@@ -1213,6 +1214,8 @@ export class PiRpcAgentSession implements AgentSession {
   private readonly capturedUserEntries: PiCapturedEntry[] = [];
   private readonly capturedUserEntriesById = new Map<string, PiCapturedEntry>();
   private readonly pendingExtensionResults = new Map<string, PendingExtensionResult>();
+  private activeAgentLifecycleTurnId: string | null = null;
+  private pendingAgentEnd: { turnId: string; messages: PiAgentMessage[] } | null = null;
   private outOfBandCompactionEmit: ((event: AgentStreamEvent) => void) | null = null;
   private outOfBandCompactionStarted = false;
   private outOfBandCompactionCompleted = false;
@@ -1297,6 +1300,8 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeClientMessageId = options?.clientMessageId ?? null;
     this.activeAssistantMessageId = null;
     this.activeTurnStarted = false;
+    this.activeAgentLifecycleTurnId = null;
+    this.pendingAgentEnd = null;
     this.activePromptRequestId = null;
     this.clearNoTurnBuffers();
     this.activeNoTurnPromptText = payload.text;
@@ -1328,6 +1333,8 @@ export class PiRpcAgentSession implements AgentSession {
         this.activeTurnId = null;
         this.activeClientMessageId = null;
         this.activeTurnStarted = false;
+        this.activeAgentLifecycleTurnId = null;
+        this.pendingAgentEnd = null;
         this.activeAssistantMessageId = null;
         this.clearNoTurnBuffers();
         if (isPiRequestAbortError(error)) {
@@ -1453,6 +1460,8 @@ export class PiRpcAgentSession implements AgentSession {
         const terminalError = this.interruptedTerminalError;
         this.interruptedTerminalError = null;
         this.usagePoller.stopTurn();
+        this.pendingAgentEnd = null;
+        this.activeAgentLifecycleTurnId = null;
         this.activeTurnId = null;
         this.activeClientMessageId = null;
         this.activeTurnStarted = false;
@@ -1470,6 +1479,8 @@ export class PiRpcAgentSession implements AgentSession {
     if (turnId && this.activeTurnId === turnId) {
       this.usagePoller.stopTurn();
       this.activeTurnId = null;
+      this.pendingAgentEnd = null;
+      this.activeAgentLifecycleTurnId = null;
       this.activeClientMessageId = null;
       this.activeTurnStarted = false;
       this.activeAssistantMessageId = null;
@@ -2047,6 +2058,8 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeTurnStarted = false;
+    this.activeAgentLifecycleTurnId = null;
+    this.pendingAgentEnd = null;
     this.clearNoTurnBuffers();
     this.emit({
       type: "turn_failed",
@@ -2061,8 +2074,11 @@ export class PiRpcAgentSession implements AgentSession {
 
     switch (event.type) {
       case "agent_start":
-        this.activeTurnStarted = true;
-        this.clearNoTurnBuffers();
+        if (this.activeTurnId) {
+          this.activeTurnStarted = true;
+          this.activeAgentLifecycleTurnId = this.activeTurnId;
+          this.clearNoTurnBuffers();
+        }
         this.emit({
           type: "thread_started",
           provider: this.provider,
@@ -2070,8 +2086,11 @@ export class PiRpcAgentSession implements AgentSession {
         });
         return;
       case "turn_start":
-        this.activeTurnStarted = true;
-        this.clearNoTurnBuffers();
+        if (this.activeTurnId) {
+          this.activeTurnStarted = true;
+          this.activeAgentLifecycleTurnId = this.activeTurnId;
+          this.clearNoTurnBuffers();
+        }
         this.emit({
           type: "turn_started",
           provider: this.provider,
@@ -2129,11 +2148,47 @@ export class PiRpcAgentSession implements AgentSession {
         });
         return;
       case "agent_end":
-        this.completeTurn(turnId, event.messages ?? []);
+        this.handleAgentEnd(event);
+        return;
+      case "agent_settled":
+        this.handleAgentSettled();
         return;
       default:
         return;
     }
+  }
+
+  private handleAgentEnd(event: Extract<PiAgentSessionEvent, { type: "agent_end" }>): void {
+    const lifecycleTurnId = this.activeAgentLifecycleTurnId;
+    if (!lifecycleTurnId || lifecycleTurnId !== this.activeTurnId) {
+      return;
+    }
+    // COMPAT(piAgentSettled): preserve Pi <=0.83 behavior; remove after 2027-02-07 once the
+    // supported Pi floor is >=0.84. Pi 0.84+ includes willRetry and agent_settled.
+    if (event.willRetry === undefined) {
+      this.completeTurn(lifecycleTurnId, event.messages ?? []);
+      return;
+    }
+    this.pendingAgentEnd = {
+      turnId: lifecycleTurnId,
+      messages: event.messages ?? [],
+    };
+  }
+
+  private handleAgentSettled(): void {
+    const pendingAgentEnd = this.pendingAgentEnd;
+    if (!pendingAgentEnd) {
+      return;
+    }
+    if (
+      pendingAgentEnd.turnId !== this.activeTurnId ||
+      pendingAgentEnd.turnId !== this.activeAgentLifecycleTurnId
+    ) {
+      this.pendingAgentEnd = null;
+      return;
+    }
+    this.pendingAgentEnd = null;
+    this.completeTurn(pendingAgentEnd.turnId, pendingAgentEnd.messages);
   }
 
   private handleToolExecutionEnd(
@@ -2301,6 +2356,8 @@ export class PiRpcAgentSession implements AgentSession {
       this.lastInterruptedTurnId = null;
       return;
     }
+    this.pendingAgentEnd = null;
+    this.activeAgentLifecycleTurnId = null;
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -186,8 +186,15 @@ export type PiAgentSessionEvent =
       isError?: boolean;
     }
   | { type: "compaction_start"; reason?: "manual" | "threshold" | "overflow" | string }
-  | { type: "compaction_end"; reason?: string; errorMessage?: string; aborted?: boolean }
-  | { type: "agent_end"; messages?: PiAgentMessage[] };
+  | {
+      type: "compaction_end";
+      reason?: string;
+      errorMessage?: string;
+      aborted?: boolean;
+      willRetry?: boolean;
+    }
+  | { type: "agent_end"; messages?: PiAgentMessage[]; willRetry?: boolean }
+  | { type: "agent_settled" };
 
 export type PiRuntimeEvent =
   | PiAgentSessionEvent

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -356,7 +356,9 @@ export class FakePiSession implements PiRuntimeSession {
 
   finishTurn(message: PiAgentMessage = { role: "assistant", content: [] }): void {
     this.messages = [...this.messages, message];
-    this.emit({ type: "agent_end", messages: this.messages });
+    this.emit({ type: "agent_start" });
+    this.emit({ type: "agent_end", willRetry: false, messages: this.messages });
+    this.emit({ type: "agent_settled" });
   }
 
   finishSubmittedUserMessage(entry: FakePiUserEntry): void {


### PR DESCRIPTION
### Linked issue

No linked issue. This regression was found while integrating Pi 0.84 RPC lifecycle events.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Pi 0.84 emits `agent_end` for each provider attempt. A retryable attempt can be followed by another attempt or overflow compaction, and only `agent_settled` represents the end of the user turn. Treating every `agent_end` as terminal makes Paseo show a completed turn while Pi is still working.

### Goals

- Keep a Pi turn active across automatic provider retries and overflow compaction.
- Wait for `agent_settled` before completing modern Pi turns.
- Surface retry attempt numbers and provider error messages as non-terminal timeline notices.
- Preserve immediate completion for legacy Pi versions without retry lifecycle fields.
- Preserve Pi-owned retry behavior without replaying prompts from Paseo.

### Non-goals

- Change Pi retry policy, retry limits, or backoff behavior.
- Replay prompts or create a second writer for the same Pi session.
- Change other provider implementations.
- Change custom-message continuation behavior; that is covered by a separate focused PR.
- Add Paseo terminal hooks or managed-build packaging behavior.

### QA

- `npm run build:protocol` — passed.
- `npm run build:highlight` — passed.
- `npm exec -- vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1` — 62 tests passed.
- `npm run typecheck --workspace=@getpaseo/server` — passed.
- `npm exec -- oxfmt --check packages/server/src/server/agent/providers/pi/agent.ts packages/server/src/server/agent/providers/pi/agent.test.ts` — passed.
- `npm exec -- oxlint packages/server/src/server/agent/providers/pi/agent.ts packages/server/src/server/agent/providers/pi/agent.test.ts` — 0 warnings, 0 errors.

The full `npm run lint` wrapper was also attempted locally but exited before diagnostics with `ESLint output (JSON parse failed: EOF...)`; the changed-file `oxlint` invocation passed and GitHub CI remains authoritative for the full repository check.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes for changed files
- [x] `npm run format` passes for changed files
- [x] QA evidence
- [x] Tests added or updated where it made sense
