### PR TITLE
Keep Android workspace selection from crashing across hosts

### DIFF
--- a/packages/app/src/data/provider-snapshot-cache.ts
+++ b/packages/app/src/data/provider-snapshot-cache.ts
@@ -136,7 +136,7 @@ export function createProviderSnapshotCache(
     }
 
     let totalBytes = entries.reduce((total, entry) => total + entry.bytes, 0);
-    const retainedEntries = entries.toSorted(oldestFirst);
+    const retainedEntries = [...entries].sort(oldestFirst);
     while (totalBytes > maxBytes) {
       const evicted = retainedEntries.shift();
       if (!evicted) break;
@@ -186,7 +186,7 @@ export function createProviderSnapshotCache(
     if (canStoreIncoming) projectedBytes += incomingBytes;
 
     const keysToRemove: string[] = [];
-    for (const candidate of retainedEntries.toSorted(oldestFirst)) {
+    for (const candidate of [...retainedEntries].sort(oldestFirst)) {
       if (projectedBytes <= maxBytes) break;
       projectedBytes -= candidate.bytes;
       keysToRemove.push(candidate.key);

--- a/packages/app/src/projects/host-project-model.ts
+++ b/packages/app/src/projects/host-project-model.ts
@@ -194,7 +194,7 @@ export function resolveEquivalentHostProjectCandidate(input: {
     (project) => project.projectKey === input.candidate.projectKey,
   );
   if (equivalents.length === 0) return null;
-  return equivalents.toSorted((left, right) =>
+  return equivalents.sort((left, right) =>
     compareHostProjectsForServer(left, right, input.serverId),
   )[0]!;
 }

--- a/packages/app/src/projects/host-projects.test.ts
+++ b/packages/app/src/projects/host-projects.test.ts
@@ -7,6 +7,7 @@ import {
   getWorktreeSupportForHostProject,
   hostProjectFromRoute,
   hostProjectFromWorkspace,
+  resolveEquivalentHostProjectCandidate,
 } from "./host-project-model";
 import { normalizeWorkspaceDescriptor } from "@/stores/session-store";
 
@@ -36,6 +37,31 @@ function project(): HostProjectListItem {
 }
 
 describe("host project lookups", () => {
+  test("resolves equivalent projects without Array.prototype.toSorted", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Array.prototype, "toSorted");
+    Reflect.deleteProperty(Array.prototype, "toSorted");
+    const first = project();
+    first.viewKey = "view:first";
+    first.projectName = "First";
+    const second = project();
+    second.viewKey = "view:second";
+    second.projectName = "Second";
+    const projects = [second, first];
+
+    try {
+      expect(
+        resolveEquivalentHostProjectCandidate({
+          candidate: first,
+          projects,
+          serverId: "host-a",
+        }),
+      ).toBe(first);
+      expect(projects).toEqual([second, first]);
+    } finally {
+      if (descriptor) Reflect.defineProperty(Array.prototype, "toSorted", descriptor);
+    }
+  });
+
   test("returns host-local ids and roots without falling back to the grouping key", () => {
     expect(getHostProjectId(project(), "host-b")).toBe("prj_b");
     expect(getHostProjectSourceDirectory(project(), "host-b")).toBe("/repo/b");


### PR DESCRIPTION
Android users can open the new-workspace flow while connected to multiple hosts without hitting the fatal error boundary. Provider snapshot cache sorting now uses the same Hermes-compatible path.

### Linked issue

None. Reported from a production 0.3.1 APK.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

React Native 0.81.5's Hermes runtime does not provide `Array.prototype.toSorted`. Multi-host project selection reached that method while evaluating projects across hosts and crashed with `TypeError: undefined is not a function`. The provider snapshot cache had since acquired the same unsupported call.

The project resolver sorts the fresh array returned by `filter`, while cache eviction sorts explicit copies where later code still needs the original order. This preserves deterministic selection and eviction without a global polyfill.

### Goals

- Keep multi-host new-workspace selection working on Android/Hermes.
- Keep provider snapshot reconciliation and eviction working on Android/Hermes.
- Preserve deterministic ordering and existing mutation boundaries.

### Non-goals

- Change project equivalence or host-selection policy.
- Add a global JavaScript polyfill.
- Change cache size or eviction policy.

### QA

- Red reproduction: `npx vitest run packages/app/src/projects/host-projects.test.ts --bail=1` failed at `resolveEquivalentHostProjectCandidate` with `TypeError: equivalents.toSorted is not a function` after removing the builtin to match Hermes.
- Green verification: `npx vitest run packages/app/src/projects/host-projects.test.ts packages/app/src/data/provider-snapshot-cache.test.ts --bail=1` — 2 files and 26 tests passed.
- Runtime evidence: the Hermes VM bundled with React Native 0.81.5 reports `Array.prototype.toSorted=undefined` and reproduces `TypeError: undefined is not a function` at the equivalent-project resolver.
- `npm run typecheck` passed for every workspace.
- `npm run lint` passed with 0 warnings and 0 errors across 3,409 files.
- `npm run format` passed.
- Not manually tested in a rebuilt Android APK; the available production emulator install is 0.2.5.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
