### PR TITLE
fix(omp): render tool result images

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -385,6 +385,123 @@ describe("OMP agent client and session", () => {
     ]);
   });
 
+  test("renders live tool-result images after the completed tool call", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const runtime = omp.runtime();
+
+    runtime.emit({
+      type: "tool_execution_start",
+      toolCallId: "screenshot-1",
+      toolName: "browser_screenshot",
+      args: { browserId: "browser-1", fullPage: true },
+    });
+    runtime.emit({
+      type: "tool_execution_end",
+      toolCallId: "screenshot-1",
+      toolName: "browser_screenshot",
+      result: {
+        content: [
+          { type: "text", text: "Captured browser screenshot (1280x800)." },
+          { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+        ],
+      },
+      isError: false,
+    });
+
+    expect(omp.timeline()).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        callId: "screenshot-1",
+        status: "running",
+      }),
+      expect.objectContaining({
+        type: "tool_call",
+        callId: "screenshot-1",
+        status: "completed",
+      }),
+      {
+        type: "assistant_message",
+        text: expect.stringMatching(/^!\[Image\]\(file:\/\/.*\.png\)$/),
+      },
+    ]);
+  });
+
+  test("does not retain base64 image data in failed live tool calls", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const runtime = omp.runtime();
+
+    runtime.emit({
+      type: "tool_execution_start",
+      toolCallId: "screenshot-1",
+      toolName: "browser_screenshot",
+      args: { browserId: "browser-1", fullPage: true },
+    });
+    runtime.emit({
+      type: "tool_execution_end",
+      toolCallId: "screenshot-1",
+      toolName: "browser_screenshot",
+      result: {
+        content: [
+          { type: "text", text: "Screenshot failed after capture." },
+          { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+        ],
+      },
+      isError: true,
+    });
+
+    expect(omp.timeline()).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        callId: "screenshot-1",
+        status: "running",
+      }),
+      expect.objectContaining({
+        type: "tool_call",
+        callId: "screenshot-1",
+        status: "failed",
+        error: {
+          content: [
+            { type: "text", text: "Screenshot failed after capture." },
+            { type: "text", text: "[image]" },
+          ],
+        },
+      }),
+      {
+        type: "assistant_message",
+        text: expect.stringMatching(/^!\[Image\]\(file:\/\/.*\.png\)$/),
+      },
+    ]);
+  });
+
+  test("does not retain base64 image data in live tool updates", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const runtime = omp.runtime();
+
+    runtime.emit({
+      type: "tool_execution_start",
+      toolCallId: "screenshot-1",
+      toolName: "browser_screenshot",
+      args: { browserId: "browser-1", fullPage: true },
+    });
+    runtime.emit({
+      type: "tool_execution_update",
+      toolCallId: "screenshot-1",
+      toolName: "browser_screenshot",
+      partialResult: {
+        content: [
+          { type: "text", text: "Capturing browser screenshot." },
+          { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+        ],
+      },
+    });
+
+    expect(omp.timeline()).toHaveLength(2);
+    expect(JSON.stringify(omp.timeline())).not.toContain("iVBORw0KGgo=");
+  });
+
   test("does not complete a queued model turn from OMP's local-only hint", async () => {
     const omp = new OmpHarness();
     await omp.start();

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -498,8 +498,27 @@ describe("OMP agent client and session", () => {
       },
     });
 
-    expect(omp.timeline()).toHaveLength(2);
-    expect(JSON.stringify(omp.timeline())).not.toContain("iVBORw0KGgo=");
+    expect(omp.timeline()).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        callId: "screenshot-1",
+        status: "running",
+        detail: expect.objectContaining({ output: null }),
+      }),
+      expect.objectContaining({
+        type: "tool_call",
+        callId: "screenshot-1",
+        status: "running",
+        detail: expect.objectContaining({
+          output: {
+            content: [
+              { type: "text", text: "Capturing browser screenshot." },
+              { type: "text", text: "[image]" },
+            ],
+          },
+        }),
+      }),
+    ]);
   });
 
   test("does not complete a queued model turn from OMP's local-only hint", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -68,7 +68,10 @@ import { OmpSubagentCardTracker, type OmpSubagentCardScheduler } from "./subagen
 import { shouldDisplayOmpCustomMessage } from "./custom-message.js";
 import { getUserMessageText } from "./message-history.js";
 import { mapOmpSystemNoticeToToolCall } from "./system-notice.js";
-import { materializeProviderImage } from "../provider-image-output.js";
+import {
+  materializeProviderImage,
+  renderProviderImageOutputAsAssistantMarkdown,
+} from "../provider-image-output.js";
 import { OmpCliRuntime } from "./cli-runtime.js";
 import { listOmpImportableSessions, readOmpImportSessionConfig } from "./session-descriptor.js";
 import type { OmpRuntime, OmpRuntimeSession, OmpStartSessionInput } from "./runtime.js";
@@ -85,6 +88,7 @@ import {
   parseToolArgs,
   parseToolResult,
   resolveToolCallName,
+  sanitizeOmpToolResultImages,
   type OmpToolResult,
   type OmpTrackedToolCall,
 } from "./tool-call-detail.js";
@@ -1842,7 +1846,8 @@ export class OmpAgentSession implements AgentSession {
           return;
         }
 
-        const partialResult = parseToolResult(event.partialResult);
+        const sanitized = sanitizeOmpToolResultImages(event.partialResult);
+        const partialResult = parseToolResult(sanitized.result);
         this.emitToolCallEvent(event.toolCallId, toolCall, "running", partialResult, null);
         return;
       }
@@ -1907,10 +1912,19 @@ export class OmpAgentSession implements AgentSession {
       this.pendingCombinedAskUserResponse = null;
     }
 
-    const result = parseToolResult(event.result);
-    const error = event.isError ? event.result : null;
+    const sanitized = sanitizeOmpToolResultImages(event.result);
+    const result = parseToolResult(sanitized.result);
+    const error = event.isError ? sanitized.result : null;
     const status = event.isError ? "failed" : "completed";
     this.emitToolCallEvent(event.toolCallId, toolCall, status, result, error);
+    for (const image of sanitized.images) {
+      const item = renderProviderImageOutputAsAssistantMarkdown(image, {
+        materialize: materializeProviderImage,
+      });
+      if (item) {
+        this.emit({ type: "timeline", provider: this.provider, turnId, item });
+      }
+    }
     if (event.toolName === "task") {
       this.subagentCardTracker.delete(event.toolCallId);
     }

--- a/packages/server/src/server/agent/providers/omp/history-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/omp/history-mapper.test.ts
@@ -88,6 +88,83 @@ describe("OMP history mapper", () => {
     ]);
   });
 
+  test("renders replayed tool-result images after the tool call", async () => {
+    const events = await collectHistory([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "screenshot-1",
+            name: "browser_screenshot",
+            arguments: { browserId: "browser-1", fullPage: true },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "screenshot-1",
+        toolName: "browser_screenshot",
+        content: [
+          { type: "text", text: "Captured browser screenshot (1280x800)." },
+          { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+        ],
+      },
+    ]);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        item: expect.objectContaining({
+          type: "tool_call",
+          callId: "screenshot-1",
+          status: "running",
+        }),
+      }),
+      expect.objectContaining({
+        item: expect.objectContaining({
+          type: "tool_call",
+          callId: "screenshot-1",
+          status: "completed",
+        }),
+      }),
+      expect.objectContaining({
+        item: {
+          type: "assistant_message",
+          text: expect.stringMatching(/^!\[Image\]\(file:\/\/.*\.png\)$/),
+        },
+      }),
+    ]);
+  });
+
+  test("ignores malformed replayed image blocks without crashing", async () => {
+    const events = await collectHistory([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "screenshot-1",
+            name: "browser_screenshot",
+            arguments: { browserId: "browser-1", fullPage: true },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "screenshot-1",
+        toolName: "browser_screenshot",
+        content: [
+          { type: "text", text: "Malformed screenshot result." },
+          { type: "image", data: "iVBORw0KGgo=" },
+        ],
+      },
+    ]);
+
+    expect(events).toHaveLength(2);
+    expect(events.every((event) => event.item.type === "tool_call")).toBe(true);
+    expect(JSON.stringify(events)).not.toContain("iVBORw0KGgo=");
+  });
+
   test("absorbs replayed omp system-notice custom messages as synthetic tool calls", async () => {
     const notice = [
       "<system-notice>",

--- a/packages/server/src/server/agent/providers/omp/history-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/omp/history-mapper.test.ts
@@ -160,9 +160,30 @@ describe("OMP history mapper", () => {
       },
     ]);
 
-    expect(events).toHaveLength(2);
-    expect(events.every((event) => event.item.type === "tool_call")).toBe(true);
-    expect(JSON.stringify(events)).not.toContain("iVBORw0KGgo=");
+    expect(events).toEqual([
+      expect.objectContaining({
+        item: expect.objectContaining({
+          type: "tool_call",
+          callId: "screenshot-1",
+          status: "running",
+        }),
+      }),
+      expect.objectContaining({
+        item: expect.objectContaining({
+          type: "tool_call",
+          callId: "screenshot-1",
+          status: "completed",
+          detail: expect.objectContaining({
+            output: {
+              content: [
+                { type: "text", text: "Malformed screenshot result." },
+                { type: "text", text: "[image]" },
+              ],
+            },
+          }),
+        }),
+      }),
+    ]);
   });
 
   test("absorbs replayed omp system-notice custom messages as synthetic tool calls", async () => {

--- a/packages/server/src/server/agent/providers/omp/message-history.ts
+++ b/packages/server/src/server/agent/providers/omp/message-history.ts
@@ -1,4 +1,8 @@
 import type { AgentStreamEvent, AgentTimelineItem, ToolCallDetail } from "../../agent-sdk-types.js";
+import {
+  materializeProviderImage,
+  renderProviderImageOutputAsAssistantMarkdown,
+} from "../provider-image-output.js";
 import type { OmpAgentMessage, OmpImageContent, OmpTextContent } from "./rpc-types.js";
 import { shouldDisplayOmpCustomMessage } from "./custom-message.js";
 import {
@@ -7,6 +11,7 @@ import {
   parseToolArgs,
   parseToolResult,
   resolveToolCallName,
+  sanitizeOmpToolResultImages,
   type OmpToolResult,
   type OmpTrackedToolCall,
 } from "./tool-call-detail.js";
@@ -79,13 +84,9 @@ export class OmpHistoryMapper {
         case "assistant":
           events.push(...this.mapAssistantMessage(message));
           break;
-        case "toolResult": {
-          const event = this.mapToolResultMessage(message);
-          if (event) {
-            events.push(event);
-          }
+        case "toolResult":
+          events.push(...this.mapToolResultMessage(message));
           break;
-        }
         case "bashExecution":
           events.push(this.mapBashExecutionMessage(message));
           break;
@@ -187,26 +188,42 @@ export class OmpHistoryMapper {
 
   private mapToolResultMessage(
     message: Extract<OmpAgentMessage, { role: "toolResult" }>,
-  ): AgentStreamEvent | null {
+  ): AgentStreamEvent[] {
     const tracked =
       this.pendingToolCalls.get(message.toolCallId) ?? parseToolArgs(message.toolName, null);
     this.pendingToolCalls.delete(message.toolCallId);
-    const result = parseToolResult({ content: message.content, details: message.details });
+    const sanitized = sanitizeOmpToolResultImages({
+      content: message.content,
+      details: message.details,
+    });
+    const result = parseToolResult(sanitized.result);
     const detail = this.mapToolDetail(message.toolCallId, tracked, result);
     if (!detail) {
-      return null;
+      return [];
     }
-    return {
-      type: "timeline",
-      provider: this.provider,
-      item: toToolResultTimelineItem({
-        callId: this.resolveToolCallId(message.toolCallId, tracked),
-        name: resolveToolCallName(tracked, result),
-        isError: Boolean(message.isError),
-        detail,
-        errorText: extractTextFromToolResult(result) ?? "Tool call failed",
-      }),
-    };
+
+    const events: AgentStreamEvent[] = [
+      {
+        type: "timeline",
+        provider: this.provider,
+        item: toToolResultTimelineItem({
+          callId: this.resolveToolCallId(message.toolCallId, tracked),
+          name: resolveToolCallName(tracked, result),
+          isError: Boolean(message.isError),
+          detail,
+          errorText: extractTextFromToolResult(result) ?? "Tool call failed",
+        }),
+      },
+    ];
+    for (const image of sanitized.images) {
+      const item = renderProviderImageOutputAsAssistantMarkdown(image, {
+        materialize: materializeProviderImage,
+      });
+      if (item) {
+        events.push({ type: "timeline", provider: this.provider, item });
+      }
+    }
+    return events;
   }
 
   private mapBashExecutionMessage(

--- a/packages/server/src/server/agent/providers/omp/tool-call-detail.ts
+++ b/packages/server/src/server/agent/providers/omp/tool-call-detail.ts
@@ -68,11 +68,20 @@ interface OmpToolResultTextContent {
   text: string;
 }
 
+interface OmpToolResultImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
 interface OmpToolResultUnknownContent {
   type: string;
 }
 
-type OmpToolResultContent = OmpToolResultTextContent | OmpToolResultUnknownContent;
+type OmpToolResultContent =
+  | OmpToolResultTextContent
+  | OmpToolResultImageContent
+  | OmpToolResultUnknownContent;
 export type OmpToolResult = string | OmpToolResultObject | null;
 
 interface OmpBashToolCall {
@@ -142,6 +151,11 @@ const OmpToolResultTextContentSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
 });
+const OmpToolResultImageContentSchema = z.object({
+  type: z.literal("image"),
+  data: z.string(),
+  mimeType: z.string(),
+});
 
 const OmpToolResultUnknownContentSchema = z
   .object({
@@ -151,6 +165,7 @@ const OmpToolResultUnknownContentSchema = z
 
 const OmpToolResultContentSchema = z.union([
   OmpToolResultTextContentSchema,
+  OmpToolResultImageContentSchema,
   OmpToolResultUnknownContentSchema,
 ]);
 
@@ -242,6 +257,42 @@ export function parseToolResult(rawResult: unknown): OmpToolResult {
     return parsed.data;
   }
   return null;
+}
+export interface OmpToolResultImage {
+  data: string;
+  mimeType: string;
+}
+
+export function sanitizeOmpToolResultImages(result: unknown): {
+  images: OmpToolResultImage[];
+  result: unknown;
+} {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    return { images: [], result };
+  }
+  const content = Reflect.get(result, "content");
+  if (!Array.isArray(content)) {
+    return { images: [], result };
+  }
+
+  const images: OmpToolResultImage[] = [];
+  const sanitizedContent = content.map((block) => {
+    if (
+      typeof block !== "object" ||
+      block === null ||
+      Array.isArray(block) ||
+      Reflect.get(block, "type") !== "image"
+    ) {
+      return block;
+    }
+    const image = OmpToolResultImageContentSchema.safeParse(block);
+    if (image.success) {
+      images.push({ data: image.data.data, mimeType: image.data.mimeType });
+    }
+    return { type: "text" as const, text: "[image]" };
+  });
+
+  return { images, result: { ...result, content: sanitizedContent } };
 }
 
 export function extractTextFromToolResult(result: OmpToolResult): string | undefined {


### PR DESCRIPTION
### Linked issue

Closes #3244

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

OMP tool results can contain image content blocks, including screenshots captured by Paseo's browser tools. The OMP provider mapped only text into the timeline, so users saw a successful screenshot tool call without the screenshot. Claude and Codex already materialize provider image outputs and emit them as assistant image messages.

This change applies the existing provider image-output path to OMP. It sanitizes image blocks before timeline parsing, preserves an `[image]` placeholder in tool details, materializes valid images, and emits image messages after the terminal tool call. The same behavior applies to live output and replayed history. Malformed image-tagged blocks and partial updates are scrubbed so base64 data does not leak into timeline state.

### Goals

- Render valid OMP tool-result images in live conversations.
- Render the same images when replaying OMP history.
- Keep tool-call text and image ordering stable.
- Remove image base64 from completed, failed, malformed, and partial tool details.
- Reuse the existing cross-provider image materialization behavior.

### Non-goals

- Change browser screenshot capture or browser-host behavior.
- Change the conversation image component or visual design.
- Change Claude, Codex, Pi, or OpenCode provider mapping.
- Add a new wire-protocol field.

### QA

#### Before

Using Paseo daemon 0.2.5, web client 0.3.0, and OMP 17.2.10:

1. Opened `https://example.com` with `browser_new_tab`.
2. Called `browser_screenshot`.
3. Observed the raw tool success:

```text
Captured browser screenshot (1280x800).
```

4. No image appeared in the Paseo conversation.
5. Saving and opening the same result as a PNG verified that capture itself succeeded.

#### Automated regression

The new tests cover:

- valid live tool-result images;
- valid replayed tool-result images;
- failed live image results without retained base64;
- partial live updates without retained base64;
- malformed replayed image blocks without crashes or retained base64.

```text
$ npx vitest run packages/server/src/server/agent/providers/omp/history-mapper.test.ts packages/server/src/server/agent/providers/omp/agent.test.ts --bail=1

Test Files  2 passed (2)
Tests      42 passed (42)
```

```text
$ npm run lint -- packages/server/src/server/agent/providers/omp/tool-call-detail.ts packages/server/src/server/agent/providers/omp/message-history.ts packages/server/src/server/agent/providers/omp/agent.ts packages/server/src/server/agent/providers/omp/history-mapper.test.ts packages/server/src/server/agent/providers/omp/agent.test.ts

Finished with 177 rules on 5 files.
```

```text
$ npm run typecheck

@getpaseo/protocol, client, server, app, relay, website, desktop, and cli typechecks passed.
```

```text
$ npm run format:check

All matched files use the correct format.
```

#### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| Web | Partial | Reproduced with the real OMP provider and Paseo browser host; patched live/replay boundaries covered by regression tests. |
| Desktop Linux | Partial | Browser capture and saved PNG verified through Ubuntu XRDP; no Electron-specific code changed. |
| iOS | No | Server/provider-only change. |
| Android | No | Server/provider-only change. |
| Desktop macOS | No | Server/provider-only change. |
| Desktop Windows | No | Server/provider-only change. |

The patched daemon was not substituted for the production daemon managing the active agent session, so post-patch manual verification against the real provider remains untested. The focused live-provider harness exercises the same `tool_execution_update` and `tool_execution_end` event boundary.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
