### PR TITLE
fix(nix): properly install node-pty

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -127,6 +127,10 @@ buildNpmPackage rec {
     # Web UI Assets
     cp -r packages/server/dist/server/web-ui $out/lib/paseo/packages/server/dist/server/
 
+    # `node-pty` native module
+    cp -r packages/server/node_modules/node-pty/prebuilds \
+        "$out/lib/paseo/packages/server/node_modules/node-pty/"
+
     # Create wrapper for the server entry point (for systemd / direct use)
     mkdir -p $out/bin
     # Keep Paseo's runtime mode separate from NODE_ENV, which belongs to spawned agents.


### PR DESCRIPTION
### Linked issue
Closes #3249 
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

I see that in the `package.nix` there is an attempt to statically trace all assets needed to be copied into the nix derivation, but it misses `node-pty`. I kept this as a draft because I assume fixing the dependency tracing would be correct thing to do, but I don't know node/TS well enough to attempt. Maybe it's an `aarch64-linux` only thing? In any case, this workaround works fine for my uses.

### Goals

- Allow terminal panes to start when `paseo` daemon is built by Nix.

### Non-goals

- Change terminal-pane behavior outside of Nix package.

### QA

I applied `cp -r ...` one-liner in the nix `postInstall` stage in my personal NixOS configuration and it fixes the linked issue.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format` passes
- [x] QA evidence
- [ ] Tests added or updated where it made sense