### PR TITLE
feat: show provider icons in sidebar workspace rows

### DIFF
--- a/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
@@ -9,6 +9,7 @@ import {
   WorkspaceMetaRow,
   type WorkspaceServiceSummary,
 } from "@/components/sidebar/workspace-meta-row";
+import { getProviderIcon } from "@/components/provider-icons";
 import { WorkspaceHoverCard } from "@/components/workspace-hover-card";
 import type { HostBadgeModel } from "@/hosts/appearance";
 import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
@@ -180,6 +181,7 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
           <WorkspaceStatusIndicator
             bucket={workspace.statusBucket}
             workspaceKind={workspace.workspaceKind}
+            provider={workspace.activeAgentProvider}
             loading={isLoading}
             reserveIdleSpace={reserveIdleStatusIndicatorSpace}
           />
@@ -210,11 +212,13 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
 function WorkspaceStatusIndicator({
   bucket,
   workspaceKind,
+  provider,
   loading = false,
   reserveIdleSpace = true,
 }: {
   bucket: SidebarWorkspaceEntry["statusBucket"];
   workspaceKind: SidebarWorkspaceEntry["workspaceKind"];
+  provider: SidebarWorkspaceEntry["activeAgentProvider"];
   loading?: boolean;
   reserveIdleSpace?: boolean;
 }) {
@@ -236,6 +240,10 @@ function WorkspaceStatusIndicator({
         <StatusRing />
       </View>
     );
+  }
+
+  if (provider) {
+    return <ProviderStatusIndicator bucket={bucket} provider={provider} />;
   }
 
   if (bucket === "needs_input") {
@@ -275,6 +283,23 @@ function WorkspaceStatusIndicator({
   return (
     <View style={styles.workspaceStatusDot} testID={`workspace-status-indicator-${bucket}`}>
       <KindIcon size={14} uniProps={foregroundMutedColorMapping} />
+      {dotColorStyle ? <StatusDotOverlay dotColorStyle={dotColorStyle} /> : null}
+    </View>
+  );
+}
+
+function ProviderStatusIndicator({
+  bucket,
+  provider,
+}: {
+  bucket: SidebarWorkspaceEntry["statusBucket"];
+  provider: NonNullable<SidebarWorkspaceEntry["activeAgentProvider"]>;
+}) {
+  const ProviderIcon = getProviderIcon(provider);
+  const dotColorStyle = getStatusDotColorStyle(bucket);
+  return (
+    <View style={styles.workspaceStatusDot} testID="workspace-provider-indicator">
+      <ProviderIcon size={14} color={styles.providerIcon.color} />
       {dotColorStyle ? <StatusDotOverlay dotColorStyle={dotColorStyle} /> : null}
     </View>
   );
@@ -529,6 +554,9 @@ const styles = StyleSheet.create((theme) => ({
     flexShrink: 0,
     alignItems: "center",
     justifyContent: "center",
+  },
+  providerIcon: {
+    color: theme.colors.foregroundMuted,
   },
   statusDotOverlay: {
     position: "absolute",

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -38,6 +38,7 @@ export interface SidebarStatusWorkspacePlacement extends SidebarWorkspacePlaceme
 export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
   workspaceDirectory: string;
   workspaceDirectoryLabel: string;
+  activeAgentProvider?: WorkspaceAgentActivity["provider"] | null;
   // Raw user-set title (null when the name is derived from branch/directory).
   // Prefills the rename input and signals whether a reset is available.
   title: string | null;
@@ -167,6 +168,7 @@ export function createSidebarWorkspaceEntry(input: {
     title: input.workspace.title ?? null,
     pinnedAt: input.workspace.pinnedAt,
     currentBranch: normalizeCurrentBranch(input.workspace.gitRuntime?.currentBranch),
+    activeAgentProvider: input.workspaceAgentActivity?.get(input.workspace.id)?.provider ?? null,
     statusBucket: effectiveStatus.status,
     statusEnteredAt: effectiveStatus.enteredAt,
     archivingAt: input.workspace.archivingAt,

--- a/packages/app/src/utils/workspace-agent-activity.test.ts
+++ b/packages/app/src/utils/workspace-agent-activity.test.ts
@@ -97,6 +97,7 @@ describe("workspace agent activity index", () => {
           "workspace-a",
           {
             agentId: "permission",
+            provider: "codex",
             status: "needs_input",
             enteredAt: new Date("2026-06-01T10:01:00.000Z"),
           },
@@ -105,6 +106,7 @@ describe("workspace agent activity index", () => {
           "workspace-b",
           {
             agentId: "attention",
+            provider: "codex",
             status: "attention",
             enteredAt: new Date("2026-06-01T10:02:00.000Z"),
           },
@@ -151,6 +153,7 @@ describe("workspace agent activity index", () => {
 
     expect(index.get("workspace-a")).toEqual({
       agentId: "root",
+      provider: "codex",
       status: "running",
       enteredAt: new Date("2026-06-01T10:00:00.000Z"),
     });
@@ -186,6 +189,7 @@ describe("workspace agent activity index", () => {
           "workspace-a",
           {
             agentId: "parent",
+            provider: "codex",
             status: "done",
             enteredAt: new Date("2026-06-01T10:00:00.000Z"),
           },
@@ -194,6 +198,7 @@ describe("workspace agent activity index", () => {
           "workspace-b",
           {
             agentId: "child",
+            provider: "codex",
             status: "running",
             enteredAt: new Date("2026-06-01T10:03:00.000Z"),
           },
@@ -270,6 +275,7 @@ describe("workspace agent activity index", () => {
     expect(next).not.toBe(previous);
     expect(next.get("workspace-a")).toEqual({
       agentId: "root",
+      provider: "codex",
       status: "needs_input",
       enteredAt: new Date("2026-06-01T10:05:00.000Z"),
     });

--- a/packages/app/src/utils/workspace-agent-activity.ts
+++ b/packages/app/src/utils/workspace-agent-activity.ts
@@ -4,6 +4,7 @@ import { deriveSidebarStateBucket } from "./sidebar-agent-state";
 
 export interface WorkspaceAgentActivity {
   agentId: string;
+  provider: Agent["provider"];
   status: WorkspaceDescriptor["status"];
   enteredAt: Date | null;
 }
@@ -36,6 +37,7 @@ export function buildWorkspaceAgentActivityIndex(
     });
     activityByWorkspaceId.set(agent.workspaceId, {
       agentId: agent.id,
+      provider: agent.provider,
       status,
       enteredAt,
     });
@@ -45,6 +47,7 @@ export function buildWorkspaceAgentActivityIndex(
     const previousActivity = previous?.get(workspaceId);
     if (
       previousActivity?.agentId === activity.agentId &&
+      previousActivity.provider === activity.provider &&
       previousActivity.status === activity.status
     ) {
       activityByWorkspaceId.set(workspaceId, previousActivity);


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Workspace rows in the sidebar showed status dots, but they did not identify which agent provider the active session belonged to. When several workspaces contain sessions from different providers, users have to open a workspace to tell whether it is a Codex, Claude Code, or other provider session.

This PR adds the active agent provider to the sidebar workspace row model and renders the existing provider icon in the row's leading slot. Status is still preserved with the existing loader or a small overlay dot where applicable.

### Goals

- Show the active root agent provider icon in sidebar workspace rows.
- Reuse the existing provider icon registry.
- Preserve existing status affordances for loading, running, attention, and error states.
- Keep the change scoped to the sidebar workspace list.

### Non-goals

- Do not change the History screen session list.
- Do not add new provider icon assets.
- Do not change workspace grouping, sorting, or selection behavior.
- Do not redesign sidebar row spacing beyond the icon swap.

### QA

Commands run:

```bash
npm run format:files -- packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx packages/app/src/hooks/sidebar-workspaces-view-model.ts packages/app/src/utils/workspace-agent-activity.ts packages/app/src/utils/workspace-agent-activity.test.ts
npm run lint -- packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx packages/app/src/hooks/sidebar-workspaces-view-model.ts packages/app/src/utils/workspace-agent-activity.ts packages/app/src/utils/workspace-agent-activity.test.ts
npm run typecheck
```

Observed:

- `npm run lint ...` passed with 0 warnings and 0 errors.
- `npm run typecheck` passed across workspaces.
- `npm run dev:app` served the app at `http://localhost:8081`.
- Web sidebar visually updated after reload.

Not run:

- Full `npm run format`; only the changed files were formatted.
- Targeted Vitest test did not run because local Vitest startup failed before test execution with `ERR_REQUIRE_ESM` while loading config.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense