### PR TITLE
Let a provider opt out of Paseo's own tools

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -684,8 +684,29 @@ Every entry under `agents.providers` accepts these fields:
 | `models`           | `ProviderProfileModel[]`  | No                | Static model list (overrides runtime discovery)                    |
 | `additionalModels` | `ProviderProfileModel[]`  | No                | Static model additions (merged with runtime discovery or `models`) |
 | `disallowedTools`  | `string[]`                | No                | Tool names to disable for this provider (e.g. `["WebSearch"]`)     |
+| `paseoTools`       | `{ enabled: boolean }`    | No                | Whether this provider's agents get Paseo's own tools               |
 | `enabled`          | `boolean`                 | No                | Set to `false` to hide the provider (default: `true`)              |
 | `order`            | `number`                  | No                | Sort order in the provider list                                    |
+
+### Paseo tools
+
+`daemon.mcp.injectIntoAgents` turns Paseo's orchestration tools (`create_agent`, `send_agent_prompt`, and the rest of the catalog in [the MCP reference](../public-docs/mcp.md)) on for the host. `paseoTools` narrows that per provider:
+
+```json
+{
+  "claude": { "paseoTools": { "enabled": true } },
+  "claude-worker": { "extends": "claude", "label": "Worker", "paseoTools": { "enabled": false } },
+  "codex": { "paseoTools": { "enabled": false } }
+}
+```
+
+The orchestrator profile keeps the tools; the worker profile it spawns and Codex get neither the native catalog nor the injected `paseo` MCP server. A provider can opt out from under the global switch but cannot opt in past it, and a provider that says nothing keeps whatever the global switch gives it.
+
+A derived profile inherits its base provider's `paseoTools` until it declares its own, which replaces the base. This is unlike `disallowedTools`, which merges.
+
+This decides what Paseo offers an agent, nothing more. An agent with shell access on the host can still reach whatever its user can, so do not reach for `paseoTools` to sandbox one.
+
+The policy is re-read at every launch, so changing it takes effect on the next create, resume or reload. Running agents keep what they started with.
 
 ### Model definition
 

--- a/packages/protocol/src/provider-config.ts
+++ b/packages/protocol/src/provider-config.ts
@@ -22,10 +22,24 @@ export const ProviderCommandSchema = z.discriminatedUnion("mode", [
   ProviderCommandReplaceSchema,
 ]);
 
+/**
+ * Whether this provider's agents get Paseo's own tools. See
+ * `docs/custom-providers.md` for what that covers and what it does not.
+ *
+ * This never crosses the wire — it lives in persisted daemon config. The
+ * compatibility case is an older daemon reading a config.json a newer one
+ * wrote, which is why this is an object rather than a bare boolean and is not
+ * `.strict()`.
+ */
+export const PaseoToolsPolicySchema = z.object({
+  enabled: z.boolean(),
+});
+
 export const ProviderRuntimeSettingsSchema = z.object({
   command: ProviderCommandSchema.optional(),
   env: z.record(z.string(), z.string()).optional(),
   disallowedTools: z.array(z.string()).optional(),
+  paseoTools: PaseoToolsPolicySchema.optional(),
 });
 
 const ProviderProfileThinkingOptionSchema = z.object({
@@ -53,6 +67,7 @@ export const ProviderOverrideSchema = z.object({
   models: z.array(ProviderProfileModelSchema).optional(),
   additionalModels: z.array(ProviderProfileModelSchema).optional(),
   disallowedTools: z.array(z.string()).optional(),
+  paseoTools: PaseoToolsPolicySchema.optional(),
   enabled: z.boolean().optional(),
   order: z.number().optional(),
 });
@@ -126,6 +141,7 @@ export const AgentProviderRuntimeSettingsMapSchema = z
   });
 
 export type ProviderCommand = z.infer<typeof ProviderCommandSchema>;
+export type PaseoToolsPolicy = z.infer<typeof PaseoToolsPolicySchema>;
 export type ProviderRuntimeSettings = z.infer<typeof ProviderRuntimeSettingsSchema>;
 export type ProviderProfileModel = z.infer<typeof ProviderProfileModelSchema>;
 export type ProviderOverride = z.infer<typeof ProviderOverrideSchema>;

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -10799,4 +10799,244 @@ test("onWorkspaceStateMayHaveChanged is not called for running shell tool calls"
   await manager.runAgent(snapshot.id, { text: "merge it" });
 
   expect(onWorkspaceStateMayHaveChanged).not.toHaveBeenCalled();
+});
+
+describe("paseoTools provider policy", () => {
+  class LaunchCaptureClient extends TestAgentClient {
+    readonly launchConfigs: AgentSessionConfig[] = [];
+    readonly launchContexts: AgentLaunchContext[] = [];
+
+    override async createSession(
+      config: AgentSessionConfig,
+      launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> {
+      this.launchConfigs.push(config);
+      if (launchContext) this.launchContexts.push(launchContext);
+      return new McpCapableTestAgentSession(config);
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config: AgentSessionConfig,
+      launchContext?: AgentLaunchContext,
+    ): Promise<AgentSession> {
+      this.launchConfigs.push(config);
+      if (launchContext) this.launchContexts.push(launchContext);
+      return new McpCapableTestAgentSession(config);
+    }
+
+    override async importSession(
+      input: ImportProviderSessionInput,
+      context: ImportProviderSessionContext,
+    ) {
+      this.launchConfigs.push(context.config);
+      if (context.launchContext) this.launchContexts.push(context.launchContext);
+      return {
+        session: new McpCapableTestAgentSession(context.storedConfig),
+        config: context.storedConfig,
+        persistence: {
+          provider: "codex" as const,
+          sessionId: input.providerHandleId,
+          nativeHandle: input.providerHandleId,
+          metadata: { provider: "codex", cwd: context.storedConfig.cwd },
+        },
+        timeline: [],
+      };
+    }
+  }
+
+  /** Native Paseo tools are a provider capability, so it belongs on the class. */
+  class NativeToolsLaunchCaptureClient extends LaunchCaptureClient {
+    override readonly capabilities = {
+      ...TEST_CAPABILITIES,
+      supportsMcpServers: true,
+      supportsNativePaseoTools: true,
+    };
+  }
+
+  function createManager(options: {
+    client: LaunchCaptureClient;
+    storage: AgentStorage;
+    paseoTools?: { enabled: boolean };
+    globallyEnabled?: boolean;
+  }) {
+    return new AgentManager({
+      clients: { codex: options.client },
+      providerDefinitions: {
+        codex: { enabled: true, ...(options.paseoTools ? { paseoTools: options.paseoTools } : {}) },
+      },
+      registry: options.storage,
+      logger,
+      mcpBaseUrl: "http://127.0.0.1:6767/mcp/agents",
+      paseoToolsEnabled: options.globallyEnabled ?? true,
+      paseoToolCatalogFactory: () => ({
+        tools: new Map(),
+        getTool: () => undefined,
+        executeTool: async () => ({ content: [] }),
+      }),
+      idFactory: () => "00000000-0000-4000-8000-0000000001aa",
+    });
+  }
+
+  function withWorkdir<T>(run: (workdir: string, storage: AgentStorage) => Promise<T>) {
+    return async () => {
+      const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
+      try {
+        return await run(workdir, new AgentStorage(join(workdir, "agents"), logger));
+      } finally {
+        rmSync(workdir, { recursive: true, force: true });
+      }
+    };
+  }
+
+  test(
+    "createAgent injects the paseo MCP server when the provider opts in",
+    withWorkdir(async (workdir, storage) => {
+      const client = new LaunchCaptureClient();
+      const manager = createManager({ client, storage, paseoTools: { enabled: true } });
+
+      await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      });
+
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeDefined();
+    }),
+  );
+
+  test(
+    "createAgent omits the paseo MCP server when the provider opts out",
+    withWorkdir(async (workdir, storage) => {
+      const client = new LaunchCaptureClient();
+      const manager = createManager({ client, storage, paseoTools: { enabled: false } });
+
+      await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      });
+
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeUndefined();
+    }),
+  );
+
+  test(
+    "a provider that declares nothing keeps the current behavior",
+    withWorkdir(async (workdir, storage) => {
+      const client = new LaunchCaptureClient();
+      const manager = createManager({ client, storage });
+
+      await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      });
+
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeDefined();
+    }),
+  );
+
+  test(
+    "the global switch beats a provider that opts in",
+    withWorkdir(async (workdir, storage) => {
+      const client = new LaunchCaptureClient();
+      const manager = createManager({
+        client,
+        storage,
+        paseoTools: { enabled: true },
+        globallyEnabled: false,
+      });
+
+      await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      });
+
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeUndefined();
+    }),
+  );
+
+  test(
+    "opting out also withholds the native tool catalog",
+    withWorkdir(async (workdir, storage) => {
+      const client = new NativeToolsLaunchCaptureClient();
+      const manager = createManager({ client, storage, paseoTools: { enabled: false } });
+
+      await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      });
+
+      expect(client.launchContexts.at(-1)?.paseoTools).toBeUndefined();
+    }),
+  );
+
+  test(
+    "opting in still provides the native tool catalog",
+    withWorkdir(async (workdir, storage) => {
+      const client = new NativeToolsLaunchCaptureClient();
+      const manager = createManager({ client, storage, paseoTools: { enabled: true } });
+
+      await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      });
+
+      expect(client.launchContexts.at(-1)?.paseoTools).toBeDefined();
+    }),
+  );
+
+  test(
+    "resume applies the policy that is configured now, not the one the agent started with",
+    withWorkdir(async (workdir, storage) => {
+      const client = new LaunchCaptureClient();
+      const manager = createManager({ client, storage, paseoTools: { enabled: true } });
+
+      const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+        workspaceId: undefined,
+      });
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeDefined();
+
+      manager.updateProviderRegistry({
+        providerDefinitions: { codex: { enabled: true, paseoTools: { enabled: false } } },
+        clients: { codex: client },
+      });
+      await manager.reloadAgentSession(snapshot.id);
+
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeUndefined();
+    }),
+  );
+
+  test(
+    "importProviderSession withholds both the MCP entry and the native catalog",
+    withWorkdir(async (workdir, storage) => {
+      const client = new NativeToolsLaunchCaptureClient();
+      const manager = createManager({ client, storage, paseoTools: { enabled: false } });
+
+      await manager.importProviderSession({
+        provider: "codex",
+        providerHandleId: "session-import-1",
+        cwd: workdir,
+        workspaceId: "wks_import",
+      });
+
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeUndefined();
+      expect(client.launchContexts.at(-1)?.paseoTools).toBeUndefined();
+    }),
+  );
+
+  test(
+    "resumeAgentFromPersistence drops a stored paseo entry for an opted-out provider",
+    withWorkdir(async (workdir, storage) => {
+      const client = new LaunchCaptureClient();
+      const manager = createManager({ client, storage, paseoTools: { enabled: false } });
+
+      await manager.resumeAgentFromPersistence(
+        { provider: "codex", sessionId: "session-123", metadata: { cwd: workdir } },
+        {
+          cwd: workdir,
+          mcpServers: {
+            paseo: {
+              type: "http",
+              url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=stale-agent",
+            },
+          },
+        },
+      );
+
+      expect(client.launchConfigs.at(-1)?.mcpServers?.paseo).toBeUndefined();
+    }),
+  );
 });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -73,6 +73,7 @@ import { isSystemInjectedEnvelope } from "./agent-prompt.js";
 import { stripInternalPaseoMcpServer, withRuntimePaseoMcpServer } from "./runtime-mcp-config.js";
 import { resolveCreateAgentTitles } from "./create-agent-title.js";
 import type { PaseoToolCatalogFactory } from "./tools/types.js";
+import type { PaseoToolsPolicy } from "./provider-launch-config.js";
 import {
   ProviderSubagentStore,
   type ProviderSubagentDescriptor,
@@ -129,6 +130,7 @@ export type AgentRunCancellationResult =
 interface PreparedSessionConfig {
   storedConfig: AgentSessionConfig;
   launchConfig: AgentSessionConfig;
+  paseoToolsEnabled: boolean;
 }
 
 interface NormalizeConfigOptions {
@@ -240,6 +242,7 @@ interface AgentManagerRescueTimeouts {
 
 interface ProviderEnabledFlag {
   enabled: boolean;
+  paseoTools?: PaseoToolsPolicy;
   derivedFromProviderId?: string | null;
   validateOptions?: (options: ProviderOptions | undefined) => ProviderOptions | undefined;
   applyOptions?: (
@@ -810,6 +813,21 @@ export class AgentManager {
     return this.mcpAuthToken;
   }
 
+  /**
+   * Whether this provider's agents get Paseo's tools, read fresh at every launch
+   * so a config change takes effect on the next create, resume or reload rather
+   * than being frozen into a persisted launch config.
+   *
+   * `daemon.mcp.injectIntoAgents` is the master switch; a provider can opt out
+   * under it but cannot opt in past it.
+   */
+  resolvePaseoToolsEnabled(provider: AgentProvider): boolean {
+    if (!this.paseoToolsEnabled) {
+      return false;
+    }
+    return this.providerDefinitions.get(provider)?.paseoTools?.enabled ?? true;
+  }
+
   setAppendSystemPrompt(prompt: string | null | undefined): void {
     this.appendSystemPrompt = prompt ?? "";
   }
@@ -1153,7 +1171,7 @@ export class AgentManager {
     this.assertAcceptingAgentRegistrations();
     const resolvedAgentId = validateAgentId(agentId ?? this.idFactory(), "createAgent");
     await this.deleteAgentState(resolvedAgentId);
-    const { storedConfig, launchConfig } = await this.prepareSessionConfig(
+    const { storedConfig, launchConfig, paseoToolsEnabled } = await this.prepareSessionConfig(
       config,
       resolvedAgentId,
       options?.env,
@@ -1166,6 +1184,7 @@ export class AgentManager {
       resolvedAgentId,
       client,
       storedConfig.cwd,
+      paseoToolsEnabled,
       options?.env,
     );
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
@@ -1235,7 +1254,7 @@ export class AgentManager {
       ...overrides,
       provider: handle.provider,
     } as AgentSessionConfig;
-    const { storedConfig, launchConfig } = await this.prepareSessionConfig(
+    const { storedConfig, launchConfig, paseoToolsEnabled } = await this.prepareSessionConfig(
       mergedConfig,
       resolvedAgentId,
     );
@@ -1247,7 +1266,12 @@ export class AgentManager {
         `Provider '${handle.provider}' is not available. Please ensure the CLI is installed.`,
       );
     }
-    const launchContext = await this.buildLaunchContext(resolvedAgentId, client, storedConfig.cwd);
+    const launchContext = await this.buildLaunchContext(
+      resolvedAgentId,
+      client,
+      storedConfig.cwd,
+      paseoToolsEnabled,
+    );
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
     const session = await client.resumeSession(
       handle,
@@ -1288,14 +1312,19 @@ export class AgentManager {
       throw new Error(`Provider '${input.provider}' does not support importing sessions`);
     }
 
-    const { storedConfig, launchConfig } = await this.prepareSessionConfig(
+    const { storedConfig, launchConfig, paseoToolsEnabled } = await this.prepareSessionConfig(
       {
         provider: input.provider,
         cwd: input.cwd,
       },
       resolvedAgentId,
     );
-    const launchContext = await this.buildLaunchContext(resolvedAgentId, client, storedConfig.cwd);
+    const launchContext = await this.buildLaunchContext(
+      resolvedAgentId,
+      client,
+      storedConfig.cwd,
+      paseoToolsEnabled,
+    );
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
     const imported = await client.importSession(
       {
@@ -1375,8 +1404,16 @@ export class AgentManager {
       ...overrides,
       provider,
     } as AgentSessionConfig;
-    const { storedConfig, launchConfig } = await this.prepareSessionConfig(refreshConfig, agentId);
-    const launchContext = await this.buildLaunchContext(agentId, client, storedConfig.cwd);
+    const { storedConfig, launchConfig, paseoToolsEnabled } = await this.prepareSessionConfig(
+      refreshConfig,
+      agentId,
+    );
+    const launchContext = await this.buildLaunchContext(
+      agentId,
+      client,
+      storedConfig.cwd,
+      paseoToolsEnabled,
+    );
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
 
     const session = handle
@@ -4801,15 +4838,20 @@ export class AgentManager {
     env?: Record<string, string>,
   ): Promise<PreparedSessionConfig> {
     const storedConfig = await this.normalizeConfig(stripInternalPaseoMcpServer(config), { env });
+    const paseoToolsEnabled = this.resolvePaseoToolsEnabled(storedConfig.provider);
     const launchConfig = this.applyDaemonAppendSystemPrompt(
-      withRuntimePaseoMcpServer({
-        config: storedConfig,
-        agentId,
-        mcpBaseUrl: this.mcpBaseUrl,
-        mcpAuthToken: this.mcpAuthToken,
-      }),
+      // A provider that opted out gets no internal `paseo` MCP entry at all, so
+      // there is nothing for it to discover or reconnect to.
+      paseoToolsEnabled
+        ? withRuntimePaseoMcpServer({
+            config: storedConfig,
+            agentId,
+            mcpBaseUrl: this.mcpBaseUrl,
+            mcpAuthToken: this.mcpAuthToken,
+          })
+        : storedConfig,
     );
-    return { storedConfig, launchConfig };
+    return { storedConfig, launchConfig, paseoToolsEnabled };
   }
 
   private applyDaemonAppendSystemPrompt(config: AgentSessionConfig): AgentSessionConfig {
@@ -4829,6 +4871,7 @@ export class AgentManager {
     agentId: string,
     client: AgentClient,
     cwd: string,
+    paseoToolsEnabled: boolean,
     env?: Record<string, string>,
   ): Promise<AgentLaunchContext> {
     const context: AgentLaunchContext = {
@@ -4840,7 +4883,7 @@ export class AgentManager {
       },
     };
     if (
-      this.paseoToolsEnabled &&
+      paseoToolsEnabled &&
       client.capabilities.supportsNativePaseoTools &&
       this.paseoToolCatalogFactory
     ) {

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -6,12 +6,14 @@ import {
 import { createExternalProcessEnv, type ProcessEnvRecord } from "../paseo-env.js";
 export {
   AgentProviderRuntimeSettingsMapSchema,
+  PaseoToolsPolicySchema,
   ProviderCommandSchema,
   ProviderOverrideSchema,
   ProviderOverridesSchema,
   ProviderProfileModelSchema,
   ProviderRuntimeSettingsSchema,
   type AgentProviderRuntimeSettingsMap,
+  type PaseoToolsPolicy,
   type ProviderCommand,
   type ProviderOverride,
   type ProviderOverrides,

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -1831,3 +1831,48 @@ describe("fetchCatalog", () => {
     expect(catalog.modes.map((mode) => mode.id)).toEqual(["ask"]);
   });
 });
+
+describe("paseoTools provider policy", () => {
+  test("a provider that declares nothing has no policy", () => {
+    expect(buildProviderRegistry(logger).claude.paseoTools).toBeUndefined();
+  });
+
+  test("a builtin provider carries its declared policy", () => {
+    const registry = buildProviderRegistry(logger, {
+      providerOverrides: {
+        claude: { paseoTools: { enabled: true } },
+        codex: { paseoTools: { enabled: false } },
+      },
+    });
+
+    expect(registry.claude.paseoTools).toEqual({ enabled: true });
+    expect(registry.codex.paseoTools).toEqual({ enabled: false });
+  });
+
+  test("a derived profile inherits its base policy when it declares none", () => {
+    const registry = buildProviderRegistry(logger, {
+      providerOverrides: {
+        claude: { paseoTools: { enabled: true } },
+        "claude-worker": { extends: "claude", label: "Claude Worker" },
+      },
+    });
+
+    expect(registry["claude-worker"].paseoTools).toEqual({ enabled: true });
+  });
+
+  test("a derived profile overrides its base policy", () => {
+    const registry = buildProviderRegistry(logger, {
+      providerOverrides: {
+        claude: { paseoTools: { enabled: true } },
+        "claude-worker": {
+          extends: "claude",
+          label: "Claude Worker",
+          paseoTools: { enabled: false },
+        },
+      },
+    });
+
+    expect(registry.claude.paseoTools).toEqual({ enabled: true });
+    expect(registry["claude-worker"].paseoTools).toEqual({ enabled: false });
+  });
+});

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -30,6 +30,7 @@ import type { WorkspaceGitService } from "../workspace-git-service.js";
 import type { ManagedProcessRegistry } from "../managed-processes/managed-processes.js";
 import type {
   AgentProviderRuntimeSettingsMap,
+  PaseoToolsPolicy,
   ProviderOverride,
   ProviderProfileModel,
   ProviderRuntimeSettings,
@@ -70,6 +71,11 @@ export { AGENT_PROVIDER_DEFINITIONS, getAgentProviderDefinition };
 
 export interface ProviderDefinition extends AgentProviderDefinition {
   enabled: boolean;
+  /**
+   * Whether this provider's agents get Paseo's own tools. `undefined` means the
+   * operator said nothing, so `daemon.mcp.injectIntoAgents` decides.
+   */
+  paseoTools: PaseoToolsPolicy | undefined;
   /**
    * The id of another *registered* provider this one extends (e.g. a Z.AI
    * profile that extends "claude"). null for built-in providers and for
@@ -252,7 +258,7 @@ function getProviderClientFactory(provider: string): ProviderClientFactory {
 }
 
 function toRuntimeSettings(override?: ProviderOverride): ProviderRuntimeSettings | undefined {
-  if (!override?.command && !override?.env && !override?.disallowedTools) {
+  if (!override?.command && !override?.env && !override?.disallowedTools && !override?.paseoTools) {
     return undefined;
   }
 
@@ -265,7 +271,28 @@ function toRuntimeSettings(override?: ProviderOverride): ProviderRuntimeSettings
       : undefined,
     env: override.env,
     disallowedTools: override.disallowedTools,
+    paseoTools: override.paseoTools,
   };
+}
+
+function mergeRuntimeEnv(
+  base: ProviderRuntimeSettings | undefined,
+  override: ProviderRuntimeSettings | undefined,
+): Record<string, string> | undefined {
+  if (!base?.env && !override?.env) {
+    return undefined;
+  }
+  return { ...base?.env, ...override?.env };
+}
+
+function mergeDisallowedTools(
+  base: ProviderRuntimeSettings | undefined,
+  override: ProviderRuntimeSettings | undefined,
+): string[] | undefined {
+  if (!base?.disallowedTools && !override?.disallowedTools) {
+    return undefined;
+  }
+  return [...(base?.disallowedTools ?? []), ...(override?.disallowedTools ?? [])];
 }
 
 function mergeRuntimeSettings(
@@ -278,17 +305,12 @@ function mergeRuntimeSettings(
 
   return {
     command: override?.command ?? base?.command,
-    env:
-      base?.env || override?.env
-        ? {
-            ...base?.env,
-            ...override?.env,
-          }
-        : undefined,
-    disallowedTools:
-      base?.disallowedTools || override?.disallowedTools
-        ? [...(base?.disallowedTools ?? []), ...(override?.disallowedTools ?? [])]
-        : undefined,
+    env: mergeRuntimeEnv(base, override),
+    disallowedTools: mergeDisallowedTools(base, override),
+    // Replaced rather than merged, unlike disallowedTools: a profile that
+    // declares paseoTools states its whole answer, so opting out is not
+    // undone by the base opting in.
+    paseoTools: override?.paseoTools ?? base?.paseoTools,
   };
 }
 
@@ -606,6 +628,7 @@ function createRegistryEntry(
   return {
     ...resolved.definition,
     enabled: resolved.enabled,
+    paseoTools: resolved.runtimeSettings?.paseoTools,
     derivedFromProviderId: resolved.derivedFromProviderId,
     optionsSchema: resolved.contract.optionsSchema,
     supportsExactMcpPreapproval: resolved.contract.supportsExactMcpPreapproval,

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -169,7 +169,12 @@ export interface AgentManagerProviderState {
       AgentProvider,
       Pick<
         ProviderDefinition,
-        "enabled" | "derivedFromProviderId" | "validateOptions" | "applyOptions" | "applyToolPolicy"
+        | "enabled"
+        | "paseoTools"
+        | "derivedFromProviderId"
+        | "validateOptions"
+        | "applyOptions"
+        | "applyToolPolicy"
       >
     >
   >;
@@ -306,6 +311,7 @@ export class ProviderSnapshotManager {
     for (const [provider, definition] of Object.entries(this.providerRegistry)) {
       providerDefinitions[provider] = {
         enabled: definition.enabled,
+        paseoTools: definition.paseoTools,
         derivedFromProviderId: definition.derivedFromProviderId,
         validateOptions: definition.validateOptions,
         applyOptions: definition.applyOptions,

--- a/packages/server/src/server/agent/providers/opencode/server-manager.ts
+++ b/packages/server/src/server/agent/providers/opencode/server-manager.ts
@@ -71,6 +71,20 @@ export interface OpenCodeServerManagerOptions {
   createEventSource?: OpenCodeEventConsumerFactory;
 }
 
+/**
+ * Identity of the shared OpenCode server process. Only settings that change the
+ * process belong here — `paseoTools` is daemon-side provider policy the server
+ * never sees, so two profiles differing only in it must not look like a
+ * conflicting reinitialization.
+ */
+function serverIdentityKey(runtimeSettings: ProviderRuntimeSettings | undefined): string {
+  if (!runtimeSettings) {
+    return "{}";
+  }
+  const { paseoTools: _paseoTools, ...processSettings } = runtimeSettings;
+  return JSON.stringify(processSettings);
+}
+
 export class OpenCodeServerManager implements OpenCodeServerManagerLike {
   private static instance: OpenCodeServerManager | null = null;
   private static exitHandlerRegistered = false;
@@ -94,7 +108,7 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
     this.logger = options.logger;
     this.baseEnv = options.baseEnv;
     this.runtimeSettings = options.runtimeSettings;
-    this.runtimeSettingsKey = JSON.stringify(this.runtimeSettings ?? {});
+    this.runtimeSettingsKey = serverIdentityKey(this.runtimeSettings);
     this.managedProcesses = options.managedProcesses;
     this.terminateProcess = options.terminateProcess ?? terminateWithTreeKill;
     this.portAllocator = options.portAllocator ?? findAvailablePort;
@@ -112,7 +126,7 @@ export class OpenCodeServerManager implements OpenCodeServerManagerLike {
     runtimeSettings?: ProviderRuntimeSettings,
     options: Omit<OpenCodeServerManagerOptions, "logger" | "runtimeSettings"> = {},
   ): OpenCodeServerManager {
-    const nextSettingsKey = JSON.stringify(runtimeSettings ?? {});
+    const nextSettingsKey = serverIdentityKey(runtimeSettings);
     if (!OpenCodeServerManager.instance) {
       OpenCodeServerManager.instance = new OpenCodeServerManager({
         logger,

--- a/packages/server/src/server/persisted-config.test.ts
+++ b/packages/server/src/server/persisted-config.test.ts
@@ -780,3 +780,44 @@ describe.skipIf(process.platform === "win32")("persisted config file permissions
     }
   });
 });
+
+describe("PersistedConfigSchema paseoTools policy", () => {
+  test("accepts a provider that opts in or out", () => {
+    const parsed = PersistedConfigSchema.parse({
+      agents: {
+        providers: {
+          claude: { paseoTools: { enabled: true } },
+          codex: { paseoTools: { enabled: false } },
+        },
+      },
+    });
+
+    expect(parsed.agents?.providers?.claude?.paseoTools).toEqual({ enabled: true });
+    expect(parsed.agents?.providers?.codex?.paseoTools).toEqual({ enabled: false });
+  });
+
+  test("rejects a policy without enabled", () => {
+    expect(
+      PersistedConfigSchema.safeParse({
+        agents: { providers: { claude: { paseoTools: {} } } },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("a derived profile may declare its own policy", () => {
+    const parsed = PersistedConfigSchema.parse({
+      agents: {
+        providers: {
+          claude: { paseoTools: { enabled: true } },
+          "claude-worker": {
+            extends: "claude",
+            label: "Claude Worker",
+            paseoTools: { enabled: false },
+          },
+        },
+      },
+    });
+
+    expect(parsed.agents?.providers?.["claude-worker"]?.paseoTools).toEqual({ enabled: false });
+  });
+});

--- a/public-docs/custom-providers.md
+++ b/public-docs/custom-providers.md
@@ -192,4 +192,4 @@ Any agent that speaks [ACP](https://agentclientprotocol.com) over stdio can be a
 
 ## Full reference
 
-For the complete field reference (`extends`, `label`, `command`, `env`, `models`, `additionalModels`, `disallowedTools`, `enabled`, `order`), model and thinking-option schemas, and deeper examples for each plan, see [docs/custom-providers.md](https://github.com/getpaseo/paseo/blob/main/docs/custom-providers.md) on GitHub.
+For the complete field reference, model and thinking-option schemas, and deeper examples for each plan, see [docs/custom-providers.md](https://github.com/getpaseo/paseo/blob/main/docs/custom-providers.md) on GitHub.

--- a/public-docs/mcp.md
+++ b/public-docs/mcp.md
@@ -16,6 +16,8 @@ Depending on the provider, Paseo delivers the catalog through its native tool in
 
 The MCP server itself is controlled by `daemon.mcp.enabled`. Existing agents may need a reload.
 
+Individual providers can opt out with `agents.providers.<id>.paseoTools`, so an orchestrator profile keeps these tools while the workers it spawns do not. See [Custom provider configuration](https://github.com/getpaseo/paseo/blob/main/docs/custom-providers.md#paseo-tools).
+
 ## Mental model
 
 Workspaces decide where work happens; agent parentage decides who owns the work.


### PR DESCRIPTION
### Linked issue

No issue

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`daemon.mcp.injectIntoAgents` applies for all agents and cannot be changed per-provider. With orchestrator and worker profiles, even the workers could spawn other agents and that might not be desired.

### Goals

- allow per-provider enabling/disabling of Paseo MCP injection

### Non-goals

- do not expose this in UI
- do not provide whitelist/blacklist for individual tools

### QA

Verified via added tests.
Please note that this was not tested in a running daemon by checking which tools a real Claude/Codex session has enabled, as I don't currently have that set up properly. I could do that if necessary, but it might take me a while.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
