### PR TITLE
fix(app): keep the side-by-side diff inside the viewport

### DIFF
--- a/packages/app/src/git/diff-horizontal-surface.tsx
+++ b/packages/app/src/git/diff-horizontal-surface.tsx
@@ -9,6 +9,10 @@ import { DiffScroll } from "@/components/diff-scroll";
 
 const FILL: ViewStyle = { flex: 1 };
 const CLIP: ViewStyle = { flex: 1, overflow: "hidden" };
+// The pinned viewport lives inside a horizontal scroll content container, so a
+// growing flex child would stretch to the full scroll width. Split layout sizes
+// its two columns with flex:1 against this box, so it has to stay viewport-sized.
+const PINNED: ViewStyle = { flexGrow: 0, flexShrink: 0, flexBasis: "auto" };
 
 const DiffHorizontalOffsetContext = createContext<SharedValue<number> | null>(null);
 
@@ -31,6 +35,10 @@ export function DiffHorizontalSurface({
     () => [{ flexGrow: 1 }, { minWidth: Math.max(viewportWidth, contentWidth) }],
     [contentWidth, viewportWidth],
   );
+  const pinnedSizeStyle = useMemo<StyleProp<ViewStyle>>(
+    () => (viewportWidth > 0 ? [PINNED, { width: viewportWidth }] : FILL),
+    [viewportWidth],
+  );
   return (
     <DiffHorizontalOffsetContext.Provider value={offset}>
       <DiffScroll
@@ -40,9 +48,7 @@ export function DiffHorizontalSurface({
         contentContainerStyle={contentContainerStyle}
         testID="diff-horizontal-scroll"
       >
-        <Animated.View style={[FILL, { width: viewportWidth }, pinnedViewportStyle]}>
-          {children}
-        </Animated.View>
+        <Animated.View style={[pinnedSizeStyle, pinnedViewportStyle]}>{children}</Animated.View>
       </DiffScroll>
     </DiffHorizontalOffsetContext.Provider>
   );


### PR DESCRIPTION
Toggling **Switch to side-by-side diff** looked like it did nothing: the preference flipped and the button changed, but the diff still showed a single column with blank vertical gaps where the other side should be. The right-hand column was rendered far off-screen.

## Cause

`DiffHorizontalSurface` pins a viewport-sized box inside the horizontal scroll content container and counter-translates it so it stays put while the code scrolls. That box was styled `[FILL, { width: viewportWidth }]`, and `FILL` is `flex: 1` — which resolves to `flex-grow: 1; flex-basis: 0%` and overrides the explicit `width`. Inside a row-direction content container carrying `minWidth: max(viewportWidth, contentWidth)`, it grew to the whole content width.

Measured in a dev build, viewport 682px:

| | before | after |
| --- | --- | --- |
| scroll viewport | 682px | 682px |
| scroll content | 58134px | 29408px |
| **pinned box** | **58134px** | **682px** |

Unified layout never showed the problem, because its rows size themselves with their own `minWidth`. Split layout sizes its two columns with `flex: 1` against the pinned box, so each column became ~29000px and only the left one was reachable.

Introduced by #3212, which moved the diff onto a single shared horizontal surface; the split path was not adapted to it.

## Fix

Size the pinned box explicitly and stop it growing, keeping `flex: 1` as the fallback until `onLayout` has measured the viewport (it starts at 0).

## Verification

Dev build on web, `paseo-dev` workspace with an uncommitted diff (+988/-197):

- side-by-side renders both columns, old left / new right, in the wide Changes tab and in the narrow Changes sidebar;
- horizontal scrolling stays in sync across both columns with the line-number gutters pinned;
- unified layout unchanged;
- `npm run typecheck`, `npm run lint`, `npm run format` clean.

@nikuscs heads up — this is on current `main`, so it is not in `bundle/local-desktop` yet (that branch still has `diff-flat-items.ts`, i.e. it predates #3212).