### PR TITLE
fix(server): prevent concurrent duplicate agent creation

### DIFF
--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -366,6 +366,10 @@ type FetchAgentsResponsePageInfo = FetchAgentsResponsePayload["pageInfo"];
 type AgentUpdatesFilter = FetchAgentsRequestFilter;
 type CreateAgentRequestMessage = Extract<SessionInboundMessage, { type: "create_agent_request" }>;
 
+interface CreatedAgentRequest {
+  agent: AgentSnapshotPayload;
+}
+
 interface ResolvedSessionCreateAgentIntent {
   config: AgentSessionConfig;
   intent: CreateAgentIntent;
@@ -676,6 +680,10 @@ export class Session {
   private readonly hubExecutionController: HubExecutionController | null;
   private readonly workspaceScripts: WorkspaceScriptsService;
   private readonly createAgentLifecycleDispatch: CreateAgentLifecycleDispatch;
+  private readonly inFlightAgentCreationsByClientMessageId = new Map<
+    string,
+    Promise<CreatedAgentRequest>
+  >();
 
   constructor(options: SessionOptions) {
     const {
@@ -3102,10 +3110,86 @@ export class Session {
    * Handle create agent request
    */
   private async handleCreateAgentRequest(msg: CreateAgentRequestMessage): Promise<void> {
+    const clientMessageId = msg.clientMessageId?.trim();
+    const existingCreation = clientMessageId
+      ? this.inFlightAgentCreationsByClientMessageId.get(clientMessageId)
+      : undefined;
+    if (existingCreation) {
+      try {
+        const created = await existingCreation;
+        this.emitCreatedAgentResponse(msg.requestId, created.agent);
+      } catch (error) {
+        this.emitFailedAgentCreateResponse(msg.requestId, error);
+      }
+      return;
+    }
+
+    const creation = this.createAgentForRequest(msg);
+    if (clientMessageId) {
+      this.inFlightAgentCreationsByClientMessageId.set(clientMessageId, creation);
+    }
+    try {
+      const created = await creation;
+      this.emitCreatedAgentResponse(msg.requestId, created.agent);
+    } catch (error) {
+      const wireError = toWorktreeWireError(error);
+      this.sessionLogger.error({ err: error }, "Failed to create agent");
+      this.emitFailedAgentCreateResponse(msg.requestId, wireError);
+      this.emit({
+        type: "activity_log",
+        payload: {
+          id: uuidv4(),
+          timestamp: new Date(),
+          type: "error",
+          content: `Failed to create agent: ${wireError.message}`,
+        },
+      });
+    } finally {
+      if (
+        clientMessageId &&
+        this.inFlightAgentCreationsByClientMessageId.get(clientMessageId) === creation
+      ) {
+        this.inFlightAgentCreationsByClientMessageId.delete(clientMessageId);
+      }
+    }
+  }
+
+  private emitCreatedAgentResponse(
+    requestId: string | undefined,
+    agent: AgentSnapshotPayload,
+  ): void {
+    if (!requestId) return;
+    this.emit({
+      type: "status",
+      payload: {
+        status: "agent_created",
+        agentId: agent.id,
+        requestId,
+        agent,
+      },
+    });
+  }
+
+  private emitFailedAgentCreateResponse(requestId: string | undefined, error: unknown): void {
+    if (!requestId) return;
+    const wireError = toWorktreeWireError(error);
+    this.emit({
+      type: "status",
+      payload: {
+        status: "agent_create_failed",
+        requestId,
+        error: wireError.message,
+        errorCode: wireError.code,
+      },
+    });
+  }
+
+  private async createAgentForRequest(
+    msg: CreateAgentRequestMessage,
+  ): Promise<CreatedAgentRequest> {
     const {
       config,
       worktreeName,
-      requestId,
       initialPrompt,
       clientMessageId,
       outputSchema,
@@ -3205,50 +3289,19 @@ export class Session {
         agentId: snapshot.id,
         createdWorktree,
       });
-      if (requestId) {
-        const agentPayload = await this.buildAgentPayload(liveSnapshot);
-        this.emit({
-          type: "status",
-          payload: {
-            status: "agent_created",
-            agentId: liveSnapshot.id,
-            requestId,
-            agent: agentPayload,
-          },
-        });
-      }
+      const agentPayload = await this.buildAgentPayload(liveSnapshot);
 
       this.sessionLogger.info(
         { agentId: snapshot.id, provider: snapshot.provider },
         `Created agent ${snapshot.id} (${snapshot.provider})`,
       );
+      return { agent: agentPayload };
     } catch (error) {
       await this.createAgentLifecycleDispatch.cleanupCreatedWorktreeAfterFailedAgentCreate({
         createdWorktree: createdWorktreeForCleanup,
         createdAgentId,
       });
-      const wireError = toWorktreeWireError(error);
-      this.sessionLogger.error({ err: error }, "Failed to create agent");
-      if (requestId) {
-        this.emit({
-          type: "status",
-          payload: {
-            status: "agent_create_failed",
-            requestId,
-            error: wireError.message,
-            errorCode: wireError.code,
-          },
-        });
-      }
-      this.emit({
-        type: "activity_log",
-        payload: {
-          id: uuidv4(),
-          timestamp: new Date(),
-          type: "error",
-          content: `Failed to create agent: ${wireError.message}`,
-        },
-      });
+      throw error;
     }
   }
 

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -872,7 +872,7 @@ test("client heartbeat clears attention for the focused terminal", async () => {
   });
 });
 
-test("create_agent_request keeps requested child cwd when grouped under an existing parent workspace", async () => {
+test("create_agent_request deduplicates concurrent draft submission retries", async () => {
   const workdir = mkdtempSync(path.join(tmpdir(), "paseo-create-agent-cwd-"));
   try {
     const parent = path.join(workdir, "parent");
@@ -981,14 +981,26 @@ test("create_agent_request keeps requested child cwd when grouped under an exist
         terminalManager: null,
       }),
     );
-    await session.handleMessage({
-      type: "create_agent_request",
-      requestId: "req-create-child",
-      config: { provider: "codex", cwd: child },
-      attachments: [],
-    });
+    await Promise.all([
+      session.handleMessage({
+        type: "create_agent_request",
+        requestId: "req-create-child-1",
+        clientMessageId: "draft-submission-1",
+        config: { provider: "codex", cwd: child },
+        attachments: [],
+      }),
+      session.handleMessage({
+        type: "create_agent_request",
+        requestId: "req-create-child-2",
+        clientMessageId: "draft-submission-1",
+        config: { provider: "codex", cwd: child },
+        attachments: [],
+      }),
+    ]);
 
-    const [createdAgent] = agentManager.listAgents();
+    const createdAgents = agentManager.listAgents();
+    expect(createdAgents).toHaveLength(1);
+    const [createdAgent] = createdAgents;
     expect(createdAgent?.cwd).toBe(child);
     const createdWorkspace = await workspaceRegistry.get(createdAgent!.workspaceId!);
     expect(createdWorkspace).not.toBeNull();
@@ -1007,10 +1019,22 @@ test("create_agent_request keeps requested child cwd when grouped under an exist
       projectKey: createdWorkspace!.projectId,
       checkout: { cwd: child },
     });
-    expect(findByType(emitted, "status")?.payload).toMatchObject({
-      status: "agent_created",
-      agent: { cwd: child },
-    });
+    expect(
+      emitted.filter((message) => message.type === "status").map((message) => message.payload),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "agent_created",
+          requestId: "req-create-child-1",
+          agent: expect.objectContaining({ cwd: child }),
+        }),
+        expect.objectContaining({
+          status: "agent_created",
+          requestId: "req-create-child-2",
+          agent: expect.objectContaining({ cwd: child }),
+        }),
+      ]),
+    );
   } finally {
     rmSync(workdir, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Linked issue

Closes #3217
Refs #2673

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A repeated `create_agent_request` carrying the same client message identity started an independent server lifecycle for every request. Concurrent retries could therefore create multiple provider processes in the same workspace.

The session now owns one in-flight creation per client message identity. Every concurrent requester waits for that operation and receives the resulting agent, so one submission produces one agent while the client still gets its correlated response.

### Goals

- Create at most one agent for concurrent requests with the same client message identity.
- Return the created agent to every correlated requester.
- Preserve independent agent creation for distinct submissions.

### Non-goals

- Add durable recovery for retries that arrive after the original request has finished.
- Change initial-prompt timeout behavior.
- Change client-side draft or outline behavior.

### QA

The regression sends two concurrent `create_agent_request` messages with one client message identity and asserts that one agent is persisted while both callers receive an `agent_created` response.

```text
npx vitest run packages/server/src/server/session.workspaces.test.ts --bail=1
# 105 passed, 4 skipped
npm run typecheck
npm run lint
npm run format
# 0 warnings, 0 errors
```

Server-only lifecycle change; no UI or platform-specific behavior changed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense