### PR TITLE
Harden legacy relay against duplicate data sockets

### DIFF
--- a/packages/relay/src/cloudflare-adapter.test.ts
+++ b/packages/relay/src/cloudflare-adapter.test.ts
@@ -230,6 +230,39 @@ describe("RelayDurableObject control nudge/reset behavior", () => {
   });
 });
 
+describe("RelayDurableObject data forwarding", () => {
+  it("forwards a client frame only to the newest daemon socket during replacement", () => {
+    const connectionId = "clt_replacing_daemon";
+    const client = createMockSocket({
+      version: "2",
+      role: "client",
+      connectionId,
+      serverId: "srv_test",
+      createdAt: 1,
+    });
+    const daemonSockets = Array.from({ length: 6 }, (_, index) =>
+      createMockSocket({
+        version: "2",
+        role: "server",
+        connectionId,
+        serverId: "srv_test",
+        createdAt: index + 1,
+      }),
+    );
+    const { state, setTagSockets } = createMockState();
+    setTagSockets(`server:${connectionId}`, daemonSockets);
+
+    const relay = new RelayDurableObject(state as unknown as DurableObjectStateArg);
+    relay.webSocketMessage(client as unknown as WebSocket, "create_agent_request");
+
+    for (const staleSocket of daemonSockets.slice(0, -1)) {
+      expect(staleSocket.send).not.toHaveBeenCalled();
+    }
+    expect(daemonSockets.at(-1)?.send).toHaveBeenCalledOnce();
+    expect(daemonSockets.at(-1)?.send).toHaveBeenCalledWith("create_agent_request");
+  });
+});
+
 describe("relay worker endpoint routing", () => {
   it("routes missing v to legacy v1 isolated DO ids", async () => {
     const fetch = vi.fn(

--- a/packages/relay/src/cloudflare-adapter.test.ts
+++ b/packages/relay/src/cloudflare-adapter.test.ts
@@ -246,7 +246,8 @@ describe("RelayDurableObject data forwarding", () => {
         role: "server",
         connectionId,
         serverId: "srv_test",
-        createdAt: index + 1,
+        generation: index + 1,
+        createdAt: 1,
       }),
     );
     const { state, setTagSockets } = createMockState();
@@ -260,6 +261,40 @@ describe("RelayDurableObject data forwarding", () => {
     }
     expect(daemonSockets.at(-1)?.send).toHaveBeenCalledOnce();
     expect(daemonSockets.at(-1)?.send).toHaveBeenCalledWith("create_agent_request");
+  });
+
+  it("prefers a generated replacement over rollout sockets without generations", () => {
+    const connectionId = "clt_rollout";
+    const client = createMockSocket({
+      version: "2",
+      role: "client",
+      connectionId,
+      serverId: "srv_test",
+      createdAt: 1,
+    });
+    const staleSocket = createMockSocket({
+      version: "2",
+      role: "server",
+      connectionId,
+      serverId: "srv_test",
+      createdAt: 2,
+    });
+    const replacementSocket = createMockSocket({
+      version: "2",
+      role: "server",
+      connectionId,
+      serverId: "srv_test",
+      generation: 1,
+      createdAt: 2,
+    });
+    const { state, setTagSockets } = createMockState();
+    setTagSockets(`server:${connectionId}`, [staleSocket, replacementSocket]);
+
+    const relay = new RelayDurableObject(state as unknown as DurableObjectStateArg);
+    relay.webSocketMessage(client as unknown as WebSocket, "create_agent_request");
+
+    expect(staleSocket.send).not.toHaveBeenCalled();
+    expect(replacementSocket.send).toHaveBeenCalledWith("create_agent_request");
   });
 });
 

--- a/packages/relay/src/cloudflare-adapter.ts
+++ b/packages/relay/src/cloudflare-adapter.ts
@@ -86,23 +86,27 @@ function getString(record: Record<string, unknown>, key: string): string | undef
   return typeof value === "string" ? value : undefined;
 }
 
-function getSocketCreatedAt(ws: WebSocket): number {
+function getSocketGeneration(ws: WebSocket): number {
   const attachment = deserializeAttachment(ws);
   if (!isRecord(attachment)) return 0;
-  return typeof attachment.createdAt === "number" ? attachment.createdAt : 0;
+  return typeof attachment.generation === "number" ? attachment.generation : 0;
 }
 
 function selectNewestSocket(sockets: WebSocket[]): WebSocket | null {
   let newest: WebSocket | null = null;
-  let newestCreatedAt = Number.NEGATIVE_INFINITY;
+  let newestGeneration = Number.NEGATIVE_INFINITY;
   for (const socket of sockets) {
-    const createdAt = getSocketCreatedAt(socket);
-    if (createdAt >= newestCreatedAt) {
+    const generation = getSocketGeneration(socket);
+    if (generation > newestGeneration) {
       newest = socket;
-      newestCreatedAt = createdAt;
+      newestGeneration = generation;
     }
   }
   return newest;
+}
+
+function nextSocketGeneration(sockets: WebSocket[]): number {
+  return sockets.reduce((highest, socket) => Math.max(highest, getSocketGeneration(socket)), 0) + 1;
 }
 
 function getGlobalWebSocketPair(): (new () => WebSocketPair) | undefined {
@@ -371,6 +375,9 @@ export class RelayDurableObject {
 
     const isServerControl = role === "server" && !resolvedConnectionId;
     const isServerData = role === "server" && !!resolvedConnectionId;
+    const serverDataGeneration = isServerData
+      ? nextSocketGeneration(this.state.getWebSockets(`server:${resolvedConnectionId}`))
+      : undefined;
 
     // Close any existing server-side connection with the same identity.
     // - server-control: single per serverId
@@ -396,6 +403,7 @@ export class RelayDurableObject {
       role,
       version: CURRENT_RELAY_VERSION,
       connectionId: resolvedConnectionId || null,
+      ...(serverDataGeneration === undefined ? {} : { generation: serverDataGeneration }),
       createdAt: Date.now(),
     };
     serializeAttachment(server, attachment);

--- a/packages/relay/src/cloudflare-adapter.ts
+++ b/packages/relay/src/cloudflare-adapter.ts
@@ -86,6 +86,25 @@ function getString(record: Record<string, unknown>, key: string): string | undef
   return typeof value === "string" ? value : undefined;
 }
 
+function getSocketCreatedAt(ws: WebSocket): number {
+  const attachment = deserializeAttachment(ws);
+  if (!isRecord(attachment)) return 0;
+  return typeof attachment.createdAt === "number" ? attachment.createdAt : 0;
+}
+
+function selectNewestSocket(sockets: WebSocket[]): WebSocket | null {
+  let newest: WebSocket | null = null;
+  let newestCreatedAt = Number.NEGATIVE_INFINITY;
+  for (const socket of sockets) {
+    const createdAt = getSocketCreatedAt(socket);
+    if (createdAt >= newestCreatedAt) {
+      newest = socket;
+      newestCreatedAt = createdAt;
+    }
+  }
+  return newest;
+}
+
 function getGlobalWebSocketPair(): (new () => WebSocketPair) | undefined {
   // Access WebSocketPair from global scope (Cloudflare Workers runtime)
   // Use Reflect to access global property without type assertions
@@ -484,12 +503,11 @@ export class RelayDurableObject {
         this.bufferFrame(connectionId, message);
         return;
       }
-      for (const target of servers) {
-        try {
-          target.send(message);
-        } catch (error) {
-          console.error(`[Relay DO] Failed to forward client->server(${connectionId}):`, error);
-        }
+      const target = selectNewestSocket(servers);
+      try {
+        target?.send(message);
+      } catch (error) {
+        console.error(`[Relay DO] Failed to forward client->server(${connectionId}):`, error);
       }
       return;
     }

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -24,5 +24,7 @@ export interface RelaySessionAttachment {
    * independent socket + E2EE channel per connected connection.
    */
   connectionId?: string | null;
+  /** Monotonic acceptance order for v2 daemon data sockets sharing a connectionId. */
+  generation?: number;
   createdAt: number;
 }


### PR DESCRIPTION
### Linked issue

Refs #3217

### Type of change

- [x] Hardening
- [ ] Incident fix

### Reasoning

The legacy Cloudflare Durable Object relay can retain more than one daemon data socket carrying the same connection tag while a replacement closes asynchronously. Forwarding a client frame to every tagged daemon socket would multiply that frame in self-hosted deployments using this adapter.

Select the daemon socket with the highest persisted per-connection `generation`. Client sockets remain fan-out targets as designed.

This does **not** close #3217. The reported 0.3.1 incident used the hosted Elixir relay, whose client-to-daemon route owns one data socket and writes each inbound frame once. The incident's six client frames therefore originated elsewhere. The reproduction here exercises a real hardening gap in the legacy adapter, not the reported end-to-end failure.

### Goals

- Deliver each client frame to one daemon data socket in the legacy Cloudflare adapter.
- Preserve replacement behavior while old sockets are still closing.
- Order replacements without relying on wall-clock timestamps.

### Non-goals

- Diagnose or close #3217.
- Change the hosted Elixir relay.
- Change direct WebSocket transport behavior.
- Add application-level create deduplication.
- Change relay fan-out from daemon to client sockets.

### QA

The regression test supplies six daemon sockets for one connection and verifies that only the highest-generation socket receives the frame. This proves the adapter boundary invariant; it does not reproduce #3217.

- `npx vitest run packages/relay/src/cloudflare-adapter.test.ts --bail=1` — 10 passed
- `npm run typecheck` — passed
- `npm run lint` — passed, 0 warnings/errors
- `npm run format:check` — passed

### Risk surface

Legacy Cloudflare relay v2 client-to-daemon forwarding only. Existing rollout sockets without a generation rank below the first generated replacement.

### Checklist

- [x] One focused change
- [x] Typecheck passed
- [x] Lint passed
- [x] Format check passed
- [x] Tests added
