### PR TITLE
Document per-execution Hub worktree branch names

### DIFF
--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -76,11 +76,18 @@ environments:
       base: origin/main
 ```
 
-`${{ paseo.execution.id }}` renders the execution UUID, so every execution that selects this environment branches off `origin/main` into its own branch instead of contending for one name. Hub renders it before it persists or dispatches the launch, so recovery after a restart reuses the branch it already created. Each step run is a separate execution: two steps selecting the same environment get two branches.
+`newBranch` is a literal branch name that may embed `${{ paseo.execution.id }}`, which renders the execution's UUID.
 
-The template is optional. A literal name such as `newBranch: paseo/review` remains supported and reuses that one branch across executions.
+| `newBranch`                         | Branches created                                         |
+| ----------------------------------- | -------------------------------------------------------- |
+| `paseo/review`                      | One, reused by every execution.                          |
+| `trigger-${{ paseo.execution.id }}` | One per execution, kept when Hub retries or recovers it. |
 
-`newBranch` accepts `${{ paseo.execution.id }}` and no other expression. `paseo.prompt`, `paseo.context`, `paseo.inputs.*`, `values.*`, `steps.<id>.outputs.*`, and provider event fields are unavailable here; any of them fails bundle activation with the authored file and field in the error, such as `.paseo/hub.yml.environments.review.worktree.newBranch`. `paseo.execution` is rejected everywhere else in a bundle. Only `branch-off` renders the template; `checkout-branch` and `checkout-pr` take literal targets.
+One execution is one step run, so two steps selecting the same environment get separate branches.
+
+`${{ paseo.execution.id }}` is the only expression `newBranch` accepts. `paseo.prompt`, `paseo.context`, `paseo.inputs.*`, `values.*`, `steps.<id>.outputs.*`, and provider event fields are unavailable here, and each one fails bundle activation at the authored field, such as `.paseo/hub.yml.environments.review.worktree.newBranch`.
+
+`${{ paseo.execution.id }}` fails activation the same way anywhere else in a bundle. `branch` and `prNumber` take literal values.
 
 An environment is a complete named object. A step selects its name; objects are not inherited, merged, or partially overridden.
 

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -76,12 +76,7 @@ environments:
       base: origin/main
 ```
 
-`newBranch` is a literal branch name that may embed `${{ paseo.execution.id }}`, which renders the execution's UUID.
-
-| `newBranch`                         | Branches created                                         |
-| ----------------------------------- | -------------------------------------------------------- |
-| `paseo/review`                      | One, reused by every execution.                          |
-| `trigger-${{ paseo.execution.id }}` | One per execution, kept when Hub retries or recovers it. |
+`newBranch` is a branch-name string. Embed `${{ paseo.execution.id }}`, which renders the execution's UUID, so every execution branches off `base` on its own branch and keeps it when Hub retries or recovers that execution.
 
 One execution is one step run, so two steps selecting the same environment get separate branches.
 

--- a/public-docs/hub/configuration/hub-yml.md
+++ b/public-docs/hub/configuration/hub-yml.md
@@ -72,9 +72,15 @@ environments:
     cwd: /workspace/project
     worktree:
       mode: branch-off
-      newBranch: paseo/review
+      newBranch: trigger-${{ paseo.execution.id }}
       base: origin/main
 ```
+
+`${{ paseo.execution.id }}` renders the execution UUID, so every execution that selects this environment branches off `origin/main` into its own branch instead of contending for one name. Hub renders it before it persists or dispatches the launch, so recovery after a restart reuses the branch it already created. Each step run is a separate execution: two steps selecting the same environment get two branches.
+
+The template is optional. A literal name such as `newBranch: paseo/review` remains supported and reuses that one branch across executions.
+
+`newBranch` accepts `${{ paseo.execution.id }}` and no other expression. `paseo.prompt`, `paseo.context`, `paseo.inputs.*`, `values.*`, `steps.<id>.outputs.*`, and provider event fields are unavailable here; any of them fails bundle activation with the authored file and field in the error, such as `.paseo/hub.yml.environments.review.worktree.newBranch`. `paseo.execution` is rejected everywhere else in a bundle. Only `branch-off` renders the template; `checkout-branch` and `checkout-pr` take literal targets.
 
 An environment is a complete named object. A step selects its name; objects are not inherited, merged, or partially overridden.
 

--- a/public-docs/hub/daemons.md
+++ b/public-docs/hub/daemons.md
@@ -84,7 +84,7 @@ worktree:
   base: origin/main
 ```
 
-`${{ paseo.execution.id }}` is optional and gives every execution its own branch off `origin/main`. A literal such as `newBranch: hub/investigation` reuses one branch instead.
+`${{ paseo.execution.id }}` renders the execution's UUID, so every execution gets its own branch off `origin/main`.
 
 [Environment fields](/docs/hub/configuration/hub-yml#environments) lists what `newBranch` accepts. See [Git worktrees](/docs/worktrees) for setup hooks and scripts.
 

--- a/public-docs/hub/daemons.md
+++ b/public-docs/hub/daemons.md
@@ -84,9 +84,9 @@ worktree:
   base: origin/main
 ```
 
-`${{ paseo.execution.id }}` gives each execution its own branch, so repeated triggers against this environment do not contend for one name. It is optional: a literal such as `hub/investigation` still works and reuses that branch. `newBranch` accepts no other expression — see the [configuration reference](/docs/hub/configuration/hub-yml#environments).
+`${{ paseo.execution.id }}` is optional and gives every execution its own branch off `origin/main`. A literal such as `newBranch: hub/investigation` reuses one branch instead.
 
-See [Git worktrees](/docs/worktrees) for setup hooks and scripts.
+[Environment fields](/docs/hub/configuration/hub-yml#environments) lists what `newBranch` accepts. See [Git worktrees](/docs/worktrees) for setup hooks and scripts.
 
 ## What Hub owns
 

--- a/public-docs/hub/daemons.md
+++ b/public-docs/hub/daemons.md
@@ -80,9 +80,11 @@ To keep executions off your working tree, add a worktree:
 ```yaml
 worktree:
   mode: branch-off
-  newBranch: hub/investigation
+  newBranch: trigger-${{ paseo.execution.id }}
   base: origin/main
 ```
+
+`${{ paseo.execution.id }}` gives each execution its own branch, so repeated triggers against this environment do not contend for one name. It is optional: a literal such as `hub/investigation` still works and reuses that branch. `newBranch` accepts no other expression — see the [configuration reference](/docs/hub/configuration/hub-yml#environments).
 
 See [Git worktrees](/docs/worktrees) for setup hooks and scripts.
 


### PR DESCRIPTION
### Linked issue

No filed issue — this documents the Hub contract shipped in getpaseo/hub#43 (`8c2a78d354ad6ce7d29438cbbed34283c945ab55`).

### Type of change

- [x] Docs

### Reasoning

A Hub daemon environment with `worktree.mode: branch-off` used to take a literal `newBranch`, so every execution that selected that environment aimed at the same branch name. Hub now accepts `${{ paseo.execution.id }}` inside `newBranch`, which gives every execution its own branch and keeps that branch when the execution is retried or recovered. That is the configuration these docs teach. The public docs still taught only literal names, so users had no way to know the template exists or what it accepts.

### Goals

- Document `newBranch: trigger-${{ paseo.execution.id }}` in the daemon environment guide and the configuration reference.
- Present `newBranch: trigger-${{ paseo.execution.id }}` as the guidance for a branch-off environment, with no literal-branch alternative shown.
- State precisely that `newBranch` accepts execution-scoped expressions only, that anything else fails bundle activation, and that the failure reports the authored field (`.paseo/hub.yml.environments.<name>.worktree.newBranch`).
- Note the boundaries a reader would otherwise guess at: one execution is one step run, `${{ paseo.execution.id }}` is rejected elsewhere in a bundle, and `branch`/`prNumber` do not take the template.
- Give each page the shape its reader needs: the daemon page is a task guide and carries only the choice plus a link; the reference owns the exhaustive contract at the field.
- Keep `newBranch`'s type as a syntax fact only, without presenting one reused branch as a workflow.

### Non-goals

- No change to prompt or context semantics, expression grammar prose, or any workflow behavior.
- No unrelated cleanup of the Hub docs.
- No product or server code changes; this repo does not implement the Hub contract.

### QA

Docs-only change, verified against Hub at the pinned merge commit:

- Read `src/config/compiler.ts`, `src/workflows/expression.ts`, and `src/workflows/engine.ts` at `8c2a78d` to confirm the accepted path, the `branch-off`-only scope, and the retry/recovery behavior.
- Confirmed the documented example string matches the one Hub's own compiler test accepts verbatim (`"trigger-${{ paseo.execution.id }}"`), and that the documented failure path matches Hub's bundle test assertion on `.paseo/hub.yml.environments.paseo.worktree.newBranch`.
- Replayed the invariants in `packages/website/src/hub-doc-examples.test.ts` over the docs tree: 35 YAML examples parse, resource maps stay canonical, no removed authoring paths. The `newBranch` value parses as the intended plain scalar `trigger-${{ paseo.execution.id }}`.
- `npm run typecheck --workspace=@getpaseo/website` and `npm run build --workspace=@getpaseo/website` pass; the site builds with the edited pages.
- Link target `/docs/hub/configuration/hub-yml#environments` matches the existing `### Environments` heading and the anchor style already used by other Hub docs.
- Read both pages back as a user configuring a fresh per-execution worktree: the daemon page answers the choice in two sentences, the reference answers "what else can I put here" without leaving the field.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [ ] Tests added or updated where it made sense — docs-only; the existing Hub doc example test already covers these files
