### PR TITLE
Prevent concurrent draft agent creation

### DIFF
--- a/packages/app/src/composer/draft/create-flow.test.ts
+++ b/packages/app/src/composer/draft/create-flow.test.ts
@@ -88,6 +88,43 @@ describe("useDraftAgentCreateFlow", () => {
     expect(onCreateSuccess).toHaveBeenCalledTimes(1);
   });
 
+  it("starts one create request when submit is invoked twice before React rerenders", async () => {
+    let resolveCreate: ((value: { agentId: string; result: { id: string } }) => void) | undefined;
+    const createRequest = vi.fn(
+      () =>
+        new Promise<{ agentId: string; result: { id: string } }>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    const onCreateSuccess = vi.fn();
+    const { result } = renderHook(() =>
+      useDraftAgentCreateFlow({
+        draftId: "draft-1",
+        getPendingServerId: () => "server-1",
+        buildDraftAgent: (attempt) => ({ attempt }),
+        createRequest,
+        onCreateSuccess,
+      }),
+    );
+    const submission = { text: "build this", attachments: [], cwd: "/repo" };
+
+    let first: Promise<void>;
+    let duplicate: Promise<void>;
+    act(() => {
+      first = result.current.handleCreateFromInput(submission);
+      duplicate = result.current.handleCreateFromInput(submission);
+    });
+
+    await expect(duplicate!).rejects.toThrow();
+    expect(createRequest).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCreate?.({ agentId: "agent-1", result: { id: "agent-1" } });
+      await first!;
+    });
+    expect(onCreateSuccess).toHaveBeenCalledTimes(1);
+  });
+
   it("allows retrying an empty prompt when the draft still has context attachments", async () => {
     const attachment = {
       kind: "chat_history",

--- a/packages/app/src/composer/draft/create-flow.ts
+++ b/packages/app/src/composer/draft/create-flow.ts
@@ -84,6 +84,17 @@ interface CreateRequestContext {
   cwd: string;
 }
 
+function assertCreateAvailable(input: {
+  draftId: string;
+  isSubmitting: boolean;
+  alreadyLoadingMessage: string;
+}): void {
+  const pending = useCreateFlowStore.getState().pendingByDraftId[input.draftId];
+  if (input.isSubmitting || pending?.lifecycle === "active") {
+    throw new Error(input.alreadyLoadingMessage);
+  }
+}
+
 interface UseDraftAgentCreateFlowOptions<TDraftAgent, TCreateResult> {
   draftId: string;
   getPendingServerId: () => string | null;
@@ -239,9 +250,11 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
 
   const handleCreateFromInput = useCallback(
     async ({ text, attachments, cwd }: SubmitContext) => {
-      if (isSubmitting) {
-        throw new Error(t("composer.errors.alreadyLoading"));
-      }
+      assertCreateAvailable({
+        draftId,
+        isSubmitting,
+        alreadyLoadingMessage: t("composer.errors.alreadyLoading"),
+      });
 
       dispatch({ type: "DRAFT_SET_ERROR", message: "" });
       const trimmedPrompt = text.trim();


### PR DESCRIPTION
### Linked issue

Refs #3217

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Draft creation used React render state as its only in-flight guard. Multiple submit callbacks entering before React committed the first state transition each started a separate agent creation request. The shared create-flow store is updated synchronously before the request, so it is the operation owner that can reject later callbacks in the same render.

This fixes the demonstrated client-side duplicate-submit producer. It does not claim to explain the paired six outline requests in #3217; the hosted relay path does not fan out client frames, so that part remains under investigation.

### Goals

- Permit at most one active create request for a draft.
- Reject a concurrent callback before it sends another daemon RPC.
- Preserve retries after a failed attempt clears the shared state.

### Non-goals

- Change relay routing.
- Claim that this alone closes #3217.
- Add daemon-side idempotency in this change.

### Supersedes

- [PR #2614 — Prevent duplicate draft agent creation](https://github.com/getpaseo/paseo/pull/2614) — This branch carries the same focused client-operation fix on current `main` with failing-first regression coverage.

### QA

- Before the fix: `npx vitest run packages/app/src/composer/draft/create-flow.test.ts --bail=1` timed out because both same-render submissions entered the unresolved create request.
- After the fix: the same focused test file passes, including the new assertion that only one request starts.
- `npm run typecheck` passes.
- `npm run lint` passes.
- `npm run format:files -- packages/app/src/composer/draft/create-flow.ts packages/app/src/composer/draft/create-flow.test.ts` passes.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
