### PR TITLE
fix(codex): keep archived history resumes inert

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -1115,7 +1115,7 @@ describe("Codex app-server provider", () => {
     await session.close();
   });
 
-  test("loads archived Codex history without resuming the native thread", async () => {
+  test("loads archived Codex history without resuming an unarchived native thread", async () => {
     const threadRequests: string[] = [];
     const appServer = createFakeCodexAppServer({
       "thread/loaded/list": () => {
@@ -1124,7 +1124,7 @@ describe("Codex app-server provider", () => {
       },
       "thread/resume": () => {
         threadRequests.push("thread/resume");
-        return Promise.reject(new Error(archivedThreadErrorMessage("archived-thread-id")));
+        return { thread: { id: "archived-thread-id" } };
       },
       "thread/read": () => {
         threadRequests.push("thread/read");
@@ -1137,7 +1137,7 @@ describe("Codex app-server provider", () => {
       purpose: "history",
     });
 
-    expect(threadRequests).toEqual(["thread/loaded/list", "thread/resume", "thread/read"]);
+    expect(threadRequests).toEqual(["thread/read"]);
     await session.close();
     appServer.assertNoErrors();
   });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -116,14 +116,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
-function isArchivedCodexThreadResumeError(error: unknown, threadId: string): boolean {
-  if (!(error instanceof Error)) return false;
-  const expectedMessage =
-    `session ${threadId} is archived. ` +
-    `Run \`codex unarchive ${threadId}\` to unarchive it first.`;
-  return error.message === expectedMessage;
-}
-
 function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return message.includes(`no archived rollout found for thread id ${threadId}`);
@@ -3365,9 +3357,9 @@ export class CodexAppServerAgentSession implements AgentSession {
       await this.loadSkills();
 
       if (this.currentThreadId) {
-        await this.ensureThreadLoaded({
-          allowArchivedHistory: this.initialResumePurpose === "history",
-        });
+        if (this.initialResumePurpose !== "history") {
+          await this.ensureThreadLoaded();
+        }
         await this.loadPersistedHistory();
       }
 
@@ -3743,9 +3735,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
   }
 
-  private async ensureThreadLoaded(
-    options: { allowArchivedHistory?: boolean } = {},
-  ): Promise<void> {
+  private async ensureThreadLoaded(): Promise<void> {
     if (!this.client || !this.currentThreadId) return;
     try {
       const loaded = toObjectRecord(await this.client.request("thread/loaded/list", {}));
@@ -3770,16 +3760,6 @@ export class CodexAppServerAgentSession implements AgentSession {
     } catch (error) {
       const threadId = this.currentThreadId;
       const message = error instanceof Error ? error.message : String(error);
-      if (
-        options.allowArchivedHistory === true &&
-        isArchivedCodexThreadResumeError(error, threadId)
-      ) {
-        this.logger.info(
-          { threadId },
-          "Loading archived Codex thread history without resuming the native session",
-        );
-        return;
-      }
       this.logger.warn({ error, threadId }, "Failed to resume persisted Codex thread");
       throw new Error(`Failed to resume Codex thread ${threadId}: ${message}`, { cause: error });
     }


### PR DESCRIPTION
## Summary

- keep Codex sessions opened for archived history in a read-only state
- hydrate persisted timelines with `thread/read` without calling `thread/loaded/list` or `thread/resume`
- add a regression test for the case where Paseo archived the agent record but native Codex archival failed

## Why

Paseo's native provider archive hook is best-effort. If Codex native archival fails, the thread remains unarchived even though the Paseo record is archived. Opening that agent from History currently calls `thread/resume`; because the native thread is still unarchived, the call succeeds and creates a live app-server writer for an agent that should be history-only. A second Codex client can then fail to resume the same thread with an active-writer conflict.

`thread/read` can hydrate the timeline without loading the thread. Skipping `ensureThreadLoaded()` for the existing `purpose: "history"` path preserves the lifecycle contract that only an explicit Unarchive may return an archived agent to an interactive runtime. Interactive resumes still use the existing load/resume path.

## Verification

- `npm exec -- vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1` (128 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run format`
