### PR TITLE
fix(server): avoid false user interrupt on ACP session close

### DIFF
--- a/packages/cli/src/commands/daemon/local-daemon.stop-ownership.test.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.stop-ownership.test.ts
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const { shutdownServer, close, tryConnectToDaemon } = vi.hoisted(() => {
+  const shutdownServerMock = vi.fn(async () => {});
+  const closeMock = vi.fn(async () => {});
+  const tryConnectToDaemonMock = vi.fn(async () => ({
+    getLastServerInfoMessage: () => ({ serverId: "srv_unrelated_main_daemon" }),
+    shutdownServer: shutdownServerMock,
+    close: closeMock,
+  }));
+  return {
+    shutdownServer: shutdownServerMock,
+    close: closeMock,
+    tryConnectToDaemon: tryConnectToDaemonMock,
+  };
+});
+
+vi.mock("../../utils/client.js", () => ({ tryConnectToDaemon }));
+
+import { stopLocalDaemon } from "./local-daemon.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  vi.clearAllMocks();
+});
+
+describe("local daemon stop ownership", () => {
+  test("an empty isolated PASEO_HOME cannot shut down an unrelated daemon on port 6767", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "paseo-stop-ownership-"));
+    tempRoots.push(root);
+    const paseoHome = path.join(root, ".paseo");
+    await mkdir(paseoHome, { recursive: true });
+    await writeFile(
+      path.join(paseoHome, "config.json"),
+      JSON.stringify({ version: 1, daemon: { listen: "127.0.0.1:6767" } }),
+    );
+
+    await expect(stopLocalDaemon({ home: paseoHome, timeoutMs: 50 })).resolves.toMatchObject({
+      action: "not_running",
+      usedLifecycleRpc: false,
+      reason: "not_running",
+    });
+
+    expect(tryConnectToDaemon).toHaveBeenCalledWith({
+      host: "127.0.0.1:6767",
+      timeout: 50,
+    });
+    expect(shutdownServer).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/commands/daemon/local-daemon.ts
+++ b/packages/cli/src/commands/daemon/local-daemon.ts
@@ -2,7 +2,7 @@ import { spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { loadConfig, resolvePaseoHome, spawnProcess } from "@getpaseo/server";
+import { getOrCreateServerId, loadConfig, resolvePaseoHome, spawnProcess } from "@getpaseo/server";
 import treeKill from "tree-kill";
 import { tryConnectToDaemon } from "../../utils/client.js";
 
@@ -694,6 +694,21 @@ async function requestLifecycleShutdown(
   }
 
   try {
+    const expectedServerId = getOrCreateServerId(state.home);
+    const connectedServerId = client.getLastServerInfoMessage()?.serverId.trim() ?? null;
+    if (!connectedServerId) {
+      return {
+        requested: false,
+        reason: "connected daemon did not provide an identity, refusing lifecycle shutdown",
+      };
+    }
+    if (connectedServerId !== expectedServerId) {
+      return {
+        requested: false,
+        reason: `daemon at ${host} belongs to a different Paseo home, refusing lifecycle shutdown`,
+      };
+    }
+
     await client.shutdownServer({ timeout: Math.min(remainingTimeoutMs(), 5000) });
     return { requested: true };
   } catch (error) {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -482,6 +482,8 @@ class McpCapableTestAgentClient extends TestAgentClient {
 
 class ControlledInterruptSession extends TestAgentSession {
   interruptCalled = false;
+  interruptCallCount = 0;
+  closeCallCount = 0;
 
   constructor(
     config: AgentSessionConfig,
@@ -500,7 +502,12 @@ class ControlledInterruptSession extends TestAgentSession {
 
   override async interrupt(): Promise<void> {
     this.interruptCalled = true;
+    this.interruptCallCount += 1;
     await this.interruptBehavior(this);
+  }
+
+  override async close(): Promise<void> {
+    this.closeCallCount += 1;
   }
 }
 
@@ -554,7 +561,9 @@ async function createControlledInterruptFixture(options: {
       await manager.waitForAgentRunStart(agent.id);
     },
     async cleanup() {
-      await manager.closeAgent(agent.id);
+      if (manager.getAgent(agent.id)?.lifecycle !== "closed") {
+        await manager.closeAgent(agent.id);
+      }
       rmSync(workdir, { recursive: true, force: true });
     },
   };
@@ -1597,6 +1606,116 @@ test("reloadAgentSession completes when the previous session close hangs", async
     expect(client.resumeSessionCalls).toBe(1);
   } finally {
     rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("technical reload closes an active run without invoking provider interrupt", async () => {
+  const fixture = await createControlledInterruptFixture({
+    name: "technical-reload-close",
+    agentId: "00000000-0000-4000-8000-000000000316",
+    turnId: "active-read-shell-turn",
+    interrupt: async (session) => {
+      session.pushEvent({
+        type: "turn_canceled",
+        provider: session.provider,
+        reason: "Canceled due to user interrupt",
+        turnId: "active-read-shell-turn",
+      });
+    },
+  });
+
+  try {
+    await fixture.startForegroundRun();
+    fixture.session.pushEvent({
+      type: "timeline",
+      provider: fixture.session.provider,
+      turnId: "active-read-shell-turn",
+      item: {
+        type: "tool_call",
+        callId: "shell-background",
+        name: "Shell",
+        status: "completed",
+        error: null,
+        detail: {
+          type: "shell",
+          command: "sleep 90",
+          output: "Command running in background with ID: shell-background",
+        },
+      },
+    });
+    fixture.session.pushEvent({
+      type: "timeline",
+      provider: fixture.session.provider,
+      turnId: "active-read-shell-turn",
+      item: {
+        type: "tool_call",
+        callId: "get-output",
+        name: "Read shell",
+        status: "running",
+        error: null,
+        detail: {
+          type: "unknown",
+          input: { shell_id: "shell-background", timeout: 120_000 },
+          output: null,
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(fixture.manager.getTimeline(fixture.agentId)).toContainEqual(
+        expect.objectContaining({
+          type: "tool_call",
+          callId: "get-output",
+          status: "running",
+        }),
+      );
+    });
+
+    const reloaded = await fixture.manager.reloadAgentSession(
+      fixture.agentId,
+      { systemPrompt: "Paseo voice mode is now off." },
+      { activeRunPolicy: "close" },
+    );
+
+    expect(fixture.session.interruptCallCount).toBe(0);
+    expect(fixture.session.closeCallCount).toBe(1);
+    expect(fixture.manager.hasInFlightRun(fixture.agentId)).toBe(false);
+    expect(reloaded).toMatchObject({
+      lifecycle: "idle",
+      config: { systemPrompt: "Paseo voice mode is now off." },
+    });
+    expect(JSON.stringify(fixture.manager.getTimeline(fixture.agentId))).not.toContain(
+      "Canceled due to user interrupt",
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("explicit user cancellation still invokes provider interrupt exactly once", async () => {
+  const fixture = await createControlledInterruptFixture({
+    name: "explicit-user-interrupt",
+    agentId: "00000000-0000-4000-8000-000000000317",
+    turnId: "explicit-user-interrupt-turn",
+    interrupt: async (session) => {
+      session.pushEvent({
+        type: "turn_canceled",
+        provider: session.provider,
+        reason: "Interrupted",
+        turnId: "explicit-user-interrupt-turn",
+      });
+    },
+  });
+
+  try {
+    await fixture.startForegroundRun();
+
+    await expect(fixture.manager.cancelAgentRun(fixture.agentId)).resolves.toEqual({
+      status: "settled",
+    });
+    expect(fixture.session.interruptCallCount).toBe(1);
+    expect(fixture.session.closeCallCount).toBe(0);
+  } finally {
+    await fixture.cleanup();
   }
 });
 

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -121,6 +121,15 @@ export type AgentRunCancellationResult =
   | { status: "settled" }
   | { status: "refused" };
 
+export interface ReloadAgentSessionOptions {
+  rehydrateFromDisk?: boolean;
+  /**
+   * User-requested reloads interrupt an active turn. Technical teardown can
+   * instead close the runtime without sending a provider user-cancel signal.
+   */
+  activeRunPolicy?: "interrupt" | "close";
+}
+
 interface PreparedSessionConfig {
   storedConfig: AgentSessionConfig;
   launchConfig: AgentSessionConfig;
@@ -1276,7 +1285,7 @@ export class AgentManager {
   reloadAgentSession(
     agentId: string,
     overrides?: Partial<AgentSessionConfig>,
-    options?: { rehydrateFromDisk?: boolean },
+    options?: ReloadAgentSessionOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
       this.reloadAgentSessionInternal(agentId, overrides, options),
@@ -1286,11 +1295,12 @@ export class AgentManager {
   private async reloadAgentSessionInternal(
     agentId: string,
     overrides?: Partial<AgentSessionConfig>,
-    options?: { rehydrateFromDisk?: boolean },
+    options?: ReloadAgentSessionOptions,
   ): Promise<ManagedAgent> {
     this.assertAcceptingAgentRegistrations();
     let existing = this.requireSessionAgent(agentId);
-    if (this.hasInFlightRun(agentId)) {
+    const hasInFlightRun = this.hasInFlightRun(agentId);
+    if (hasInFlightRun && options?.activeRunPolicy !== "close") {
       await this.cancelAgentRunBefore(agentId, "reload");
       existing = this.requireSessionAgent(agentId);
     }
@@ -1311,6 +1321,29 @@ export class AgentManager {
     const launchContext = await this.buildLaunchContext(agentId, client, storedConfig.cwd);
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
 
+    const closeBeforeResume = hasInFlightRun && options?.activeRunPolicy === "close";
+    const closeExisting = async (): Promise<void> => {
+      this.cancelRunningProviderSubagents(agentId);
+      const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
+      if (closeBeforeResume) {
+        // Persist the restored voice config even if provider resume fails after
+        // technical disposal. A later lazy resume will then start voice-off.
+        closedExisting.config = storedConfig;
+      }
+      try {
+        await this.persistSnapshot(closedExisting);
+      } finally {
+        await this.closeReloadedSession(existing.session, agentId);
+      }
+    };
+
+    if (closeBeforeResume) {
+      // A technical owner teardown must not become a provider-visible user
+      // interrupt. Retire the active runtime via AgentSession.close() before
+      // resuming its replacement; ACP close does not send session/cancel.
+      await closeExisting();
+    }
+
     const session = handle
       ? await client.resumeSession(handle, providerLaunchConfig, launchContext)
       : await client.createSession(providerLaunchConfig, launchContext);
@@ -1320,12 +1353,8 @@ export class AgentManager {
     try {
       this.assertAcceptingAgentRegistrations();
 
-      this.cancelRunningProviderSubagents(agentId);
-      const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
-      try {
-        await this.persistSnapshot(closedExisting);
-      } finally {
-        await this.closeReloadedSession(existing.session, agentId);
+      if (!closeBeforeResume) {
+        await closeExisting();
       }
 
       if (rehydrateFromDisk) {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -3774,3 +3774,229 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
     });
   });
 });
+
+describe("ACP runtime-originated cancellation vs client-initiated cancellation", () => {
+  test("runtime-originated stopReason 'cancelled' emits turn_completed, not turn_canceled", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.startTurn("run long shell command");
+
+    resolvePrompt({ stopReason: "cancelled" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const turnCanceled = events.find((e) => e.type === "turn_canceled");
+    const turnCompleted = events.find((e) => e.type === "turn_completed");
+    expect(turnCanceled).toBeUndefined();
+    expect(turnCompleted).toBeDefined();
+  });
+
+  test("client-initiated interrupt emits turn_canceled when stopReason is 'cancelled'", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+    const cancel = vi.fn(async () => {});
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.startTurn("hello");
+    await session.interrupt();
+
+    resolvePrompt({ stopReason: "cancelled" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const turnCanceled = events.find((e) => e.type === "turn_canceled");
+    expect(turnCanceled).toBeDefined();
+    expect(turnCanceled).toMatchObject({
+      type: "turn_canceled",
+      reason: "Interrupted",
+    });
+  });
+
+  test("cancelRequestedByClient flag is reset on each new turn", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+    const cancel = vi.fn(async () => {});
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt, cancel };
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.startTurn("first turn");
+    await session.interrupt();
+    resolvePrompt({ stopReason: "cancelled" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    events.length = 0;
+
+    await session.startTurn("second turn — runtime self-cancel");
+    resolvePrompt({ stopReason: "cancelled" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const turnCanceled = events.find((e) => e.type === "turn_canceled");
+    const turnCompleted = events.find((e) => e.type === "turn_completed");
+    expect(turnCanceled).toBeUndefined();
+    expect(turnCompleted).toBeDefined();
+  });
+
+  test("runtime-originated cancellation does not synthesize canceled tool calls", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.startTurn("run shell");
+
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.translateSessionUpdate({
+      sessionUpdate: "tool_call",
+      sessionId: "session-1",
+      toolCallId: "tool-1",
+      title: "Shell: npm run test",
+      kind: "shell",
+      status: "in_progress",
+    });
+
+    resolvePrompt({ stopReason: "cancelled" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const canceledToolCalls = events.filter(
+      (e) =>
+        e.type === "timeline" &&
+        "item" in e &&
+        (e as { item: { type: string; status?: string } }).item.type === "tool_call" &&
+        (e as { item: { type: string; status?: string } }).item.status === "canceled",
+    );
+    expect(canceledToolCalls).toHaveLength(0);
+  });
+});
+
+describe("ACP close() must not send session/cancel", () => {
+  test("close() with active foreground turn does NOT send session/cancel", async () => {
+    const session = createSession();
+    const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+    const cancel = vi.fn(async () => {});
+    const unstable_closeSession = vi.fn(async () => {});
+
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { prompt, cancel, unstable_closeSession } as never;
+
+    await session.startTurn("run long command");
+    expect(internals.activeForegroundTurnId).not.toBeNull();
+
+    await session.close();
+
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  test("close() without active foreground turn does NOT send session/cancel", async () => {
+    const session = createSession();
+    const cancel = vi.fn(async () => {});
+
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { cancel } as never;
+
+    expect(internals.activeForegroundTurnId).toBeNull();
+
+    await session.close();
+
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  test("interrupt() still sends session/cancel when foreground turn is active", async () => {
+    const session = createSession();
+    const prompt = vi.fn(() => new Promise<PromptResponse>(() => {}));
+    const cancel = vi.fn(async () => {});
+
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { prompt, cancel } as never;
+
+    await session.startTurn("hello");
+    await session.interrupt();
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith({ sessionId: "session-1" });
+  });
+
+  test("close() after interrupt() does not double-send session/cancel", async () => {
+    const session = createSession();
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+    const cancel = vi.fn(async () => {});
+
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { prompt, cancel } as never;
+
+    await session.startTurn("hello");
+    await session.interrupt();
+    expect(cancel).toHaveBeenCalledOnce();
+
+    resolvePrompt({ stopReason: "cancelled" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await session.close();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -87,6 +87,7 @@ describe("buildACPClientCapabilities", () => {
 interface ACPSessionInternals {
   sessionId: string | null;
   connection: { prompt: (...args: unknown[]) => Promise<PromptResponse> };
+  agentCapabilities: { sessionCapabilities?: { close?: unknown } } | null;
   activeForegroundTurnId: string | null;
   configOptions: SessionConfigOption[];
   translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
@@ -3135,6 +3136,37 @@ describe("ACPAgentSession", () => {
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
   });
 
+  test("transport disconnect/reconnect boundary is a technical failure, not user interrupt", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let rejectPrompt!: (error: Error) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((_, reject) => {
+          rejectPrompt = reject;
+        }),
+    );
+
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = "session-before-disconnect";
+    internals.connection = { prompt };
+    session.subscribe((event) => events.push(event));
+
+    await session.startTurn("wait for shell output");
+    rejectPrompt(new Error("ACP transport disconnected; reconnect required"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn_failed",
+        error: "ACP transport disconnected; reconnect required",
+      }),
+    );
+    expect(JSON.stringify(events)).not.toContain("user interrupt");
+    expect(events.some((event) => event.type === "turn_canceled")).toBe(false);
+  });
+
   test("flushes an image-only provider echo before a rejected turn finishes", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];
@@ -3776,7 +3808,7 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
 });
 
 describe("ACP runtime-originated cancellation vs client-initiated cancellation", () => {
-  test("runtime-originated stopReason 'cancelled' emits turn_completed, not turn_canceled", async () => {
+  test("runtime-originated stopReason 'cancelled' emits a technical failure, not user cancellation", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];
     let resolvePrompt!: (value: PromptResponse) => void;
@@ -3800,10 +3832,15 @@ describe("ACP runtime-originated cancellation vs client-initiated cancellation",
     await Promise.resolve();
     await Promise.resolve();
 
-    const turnCanceled = events.find((e) => e.type === "turn_canceled");
-    const turnCompleted = events.find((e) => e.type === "turn_completed");
-    expect(turnCanceled).toBeUndefined();
-    expect(turnCompleted).toBeDefined();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn_failed",
+        error: "ACP runtime canceled the turn",
+        code: "runtime_cancelled",
+      }),
+    );
+    expect(events.some((event) => event.type === "turn_canceled")).toBe(false);
+    expect(events.some((event) => event.type === "turn_completed")).toBe(false);
   });
 
   test("client-initiated interrupt emits turn_canceled when stopReason is 'cancelled'", async () => {
@@ -3872,10 +3909,10 @@ describe("ACP runtime-originated cancellation vs client-initiated cancellation",
     await Promise.resolve();
     await Promise.resolve();
 
-    const turnCanceled = events.find((e) => e.type === "turn_canceled");
-    const turnCompleted = events.find((e) => e.type === "turn_completed");
-    expect(turnCanceled).toBeUndefined();
-    expect(turnCompleted).toBeDefined();
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "turn_failed", code: "runtime_cancelled" }),
+    );
+    expect(events.some((event) => event.type === "turn_canceled")).toBe(false);
   });
 
   test("runtime-originated cancellation does not synthesize canceled tool calls", async () => {
@@ -3898,14 +3935,15 @@ describe("ACP runtime-originated cancellation vs client-initiated cancellation",
 
     await session.startTurn("run shell");
 
-    const internals = asInternals<ACPSessionInternals>(session);
-    internals.translateSessionUpdate({
-      sessionUpdate: "tool_call",
+    await session.sessionUpdate({
       sessionId: "session-1",
-      toolCallId: "tool-1",
-      title: "Shell: npm run test",
-      kind: "shell",
-      status: "in_progress",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "Shell: npm run test",
+        kind: "execute",
+        status: "in_progress",
+      },
     });
 
     resolvePrompt({ stopReason: "cancelled" });
@@ -3920,6 +3958,104 @@ describe("ACP runtime-originated cancellation vs client-initiated cancellation",
         (e as { item: { type: string; status?: string } }).item.status === "canceled",
     );
     expect(canceledToolCalls).toHaveLength(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "turn_failed", code: "runtime_cancelled" }),
+    );
+  });
+
+  test.each([
+    {
+      name: "poll timeout",
+      title: "Read Shell: get_output",
+      rawOutput: { message: "Timed out waiting for shell output" },
+    },
+    {
+      name: "stale task handle",
+      title: "Read Shell: get_output",
+      rawOutput: { message: "Unknown background shell task 'stale-task'" },
+    },
+    {
+      name: "non-zero command exit",
+      title: "Shell: exit 17",
+      rawOutput: { message: "Command exited with code 17" },
+    },
+    {
+      name: "runtime-killed command",
+      title: "Shell: npm run test:local",
+      rawOutput: { message: "Command terminated by runtime signal SIGTERM" },
+    },
+  ])(
+    "maps $name to a technical tool failure, never user interrupt",
+    async ({ title, rawOutput }) => {
+      const session = createSession();
+      const events: AgentStreamEvent[] = [];
+      asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+      session.subscribe((event) => events.push(event));
+
+      await session.sessionUpdate({
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "tool-1",
+          title,
+          kind: "execute",
+          status: "failed",
+          rawOutput,
+        },
+      });
+
+      const toolCall = events.find(
+        (event) => event.type === "timeline" && event.item.type === "tool_call",
+      );
+      expect(toolCall).toMatchObject({
+        type: "timeline",
+        item: {
+          type: "tool_call",
+          status: "failed",
+          error: { message: rawOutput.message },
+        },
+      });
+      expect(JSON.stringify(events)).not.toContain("user interrupt");
+      expect(events.some((event) => event.type === "turn_canceled")).toBe(false);
+    },
+  );
+
+  test.each([
+    {
+      name: "backgrounding",
+      title: "Shell: npm run test:local",
+      rawOutput: { message: "Command running in background with ID: shell-1" },
+    },
+    {
+      name: "zero command exit",
+      title: "Shell: exit 0",
+      rawOutput: { exitCode: 0 },
+    },
+  ])("maps $name to normal tool completion", async ({ title, rawOutput }) => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title,
+        kind: "execute",
+        status: "completed",
+        rawOutput,
+      },
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "timeline",
+        item: expect.objectContaining({ type: "tool_call", status: "completed", error: null }),
+      }),
+    );
+    expect(events.some((event) => event.type === "turn_canceled")).toBe(false);
   });
 });
 
@@ -3940,6 +4076,82 @@ describe("ACP close() must not send session/cancel", () => {
     await session.close();
 
     expect(cancel).not.toHaveBeenCalled();
+  });
+
+  test("shutdown while get_output waits on a background shell does not send user interrupt", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    const cancel = vi.fn(async () => {});
+    const clientToAgent = new TransformStream();
+    const agentToClient = new TransformStream();
+    const agent: Agent = {
+      async initialize() {
+        return {
+          protocolVersion: PROTOCOL_VERSION,
+          agentCapabilities: {
+            loadSession: true,
+            sessionCapabilities: { list: {} },
+          },
+          authMethods: [],
+        };
+      },
+      async newSession() {
+        return { sessionId: "session-1" };
+      },
+      async prompt() {
+        return new Promise<PromptResponse>(() => {});
+      },
+      async authenticate() {},
+      cancel,
+    };
+    const agentConnection = new AgentSideConnection(
+      () => agent,
+      ndJsonStream(agentToClient.writable, clientToAgent.readable),
+    );
+    const connection = new ClientSideConnection(
+      () => session,
+      ndJsonStream(clientToAgent.writable, agentToClient.readable),
+    );
+    const initialize = await connection.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {},
+      clientInfo: { name: "Paseo regression test", version: "dev" },
+    });
+    const sessionResponse = await connection.newSession({ cwd: "/tmp", mcpServers: [] });
+    const internals = asInternals<ACPSessionInternals>(session);
+    internals.sessionId = sessionResponse.sessionId;
+    internals.connection = connection;
+    internals.agentCapabilities = initialize.agentCapabilities;
+    session.subscribe((event) => events.push(event));
+
+    await session.startTurn("run CLI local tests");
+    await agentConnection.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "shell-1",
+        title: "Shell: npm run test:local",
+        kind: "execute",
+        status: "completed",
+        rawOutput: { message: "Command running in background with ID: shell-1" },
+      },
+    });
+    await agentConnection.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "poll-1",
+        title: "Read Shell: get_output",
+        kind: "execute",
+        status: "in_progress",
+      },
+    });
+
+    await session.close();
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(JSON.stringify(events)).not.toContain("user interrupt");
+    expect(events.some((event) => event.type === "turn_canceled")).toBe(false);
   });
 
   test("close() without active foreground turn does NOT send session/cancel", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2838,9 +2838,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           });
         } else {
           this.finishTurn({
-            type: "turn_completed",
+            type: "turn_failed",
             provider: this.provider,
-            usage: this.currentTurnUsage,
+            error: "ACP runtime canceled the turn",
+            code: "runtime_cancelled",
             turnId,
           });
         }

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -1437,6 +1437,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
   private closed = false;
+  private cancelRequestedByClient = false;
   private historyPending = false;
   private replayingHistory = false;
   private bootstrapThreadEventPending = false;
@@ -1602,6 +1603,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const turnId = randomUUID();
     const messageId = options?.clientMessageId ?? randomUUID();
     this.activeForegroundTurnId = turnId;
+    this.cancelRequestedByClient = false;
     this.fallbackAssistantMessageId = null;
     this.submittedUserMessageTurnId = null;
     this.emitBootstrapThreadEvent();
@@ -2126,6 +2128,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     });
 
     if (response.behavior === "deny" && response.interrupt && this.connection && this.sessionId) {
+      this.cancelRequestedByClient = true;
       await this.connection.cancel({ sessionId: this.sessionId });
     }
   }
@@ -2156,6 +2159,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.pendingPermissions.clear();
 
     if (this.activeForegroundTurnId) {
+      this.cancelRequestedByClient = true;
       await this.connection.cancel({ sessionId: this.sessionId });
     }
   }
@@ -2175,12 +2179,6 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.pendingPermissions.clear();
 
     if (this.connection && this.sessionId) {
-      try {
-        if (this.activeForegroundTurnId) {
-          await this.connection.cancel({ sessionId: this.sessionId });
-        }
-      } catch {}
-
       try {
         if (this.agentCapabilities?.sessionCapabilities?.close) {
           await this.connection.unstable_closeSession({ sessionId: this.sessionId });
@@ -2830,13 +2828,22 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     switch (response.stopReason) {
       case "cancelled":
-        this.synthesizeCanceledToolCalls();
-        this.finishTurn({
-          type: "turn_canceled",
-          provider: this.provider,
-          reason: "Interrupted",
-          turnId,
-        });
+        if (this.cancelRequestedByClient) {
+          this.synthesizeCanceledToolCalls();
+          this.finishTurn({
+            type: "turn_canceled",
+            provider: this.provider,
+            reason: "Interrupted",
+            turnId,
+          });
+        } else {
+          this.finishTurn({
+            type: "turn_completed",
+            provider: this.provider,
+            usage: this.currentTurnUsage,
+            turnId,
+          });
+        }
         break;
       case "end_turn":
       case "max_tokens":

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -994,8 +994,8 @@ export class Session {
             agentStorage: this.agentStorage,
             logger: this.sessionLogger,
           }),
-        reloadAgentSession: (agentId, overrides) =>
-          this.agentManager.reloadAgentSession(agentId, overrides),
+        reloadAgentSession: (agentId, overrides, reloadOptions) =>
+          this.agentManager.reloadAgentSession(agentId, overrides, reloadOptions),
         sendSpokenInput: async (agentId, text) => {
           await this.handleSendAgentMessage(
             agentId,

--- a/packages/server/src/server/session/voice/voice-session.test.ts
+++ b/packages/server/src/server/session/voice/voice-session.test.ts
@@ -3,7 +3,8 @@ import pino from "pino";
 import { describe, expect, test, vi } from "vitest";
 
 import { VoiceSession, type VoiceSessionHost } from "./voice-session.js";
-import type { ManagedAgent } from "../../agent/agent-manager.js";
+import type { ManagedAgent, ReloadAgentSessionOptions } from "../../agent/agent-manager.js";
+import type { AgentSessionConfig } from "../../agent/agent-sdk-types.js";
 import type { SessionOutboundMessage } from "../../messages.js";
 import type {
   SpeechToTextProvider,
@@ -57,24 +58,34 @@ class FakeVoiceSttSession extends EventEmitter implements StreamingTranscription
 interface FakeVoiceHost extends VoiceSessionHost {
   readonly emitted: SessionOutboundMessage[];
   readonly spokenInput: Array<{ agentId: string; text: string }>;
+  readonly reloads: Array<{
+    agentId: string;
+    overrides: Partial<AgentSessionConfig>;
+    options?: ReloadAgentSessionOptions;
+  }>;
 }
 
 function createFakeHost(): FakeVoiceHost {
   const emitted: SessionOutboundMessage[] = [];
   const spokenInput: Array<{ agentId: string; text: string }> = [];
+  const reloads: FakeVoiceHost["reloads"] = [];
   return {
     emitted,
     spokenInput,
+    reloads,
     emit: (msg) => {
       emitted.push(msg);
     },
     loadAgent: async (agentId) =>
       ({ id: agentId, config: { systemPrompt: undefined } }) as unknown as ManagedAgent,
-    reloadAgentSession: async (agentId) => ({ id: agentId }) as unknown as ManagedAgent,
+    reloadAgentSession: async (agentId, overrides, options) => {
+      reloads.push({ agentId, overrides, options });
+      return { id: agentId } as unknown as ManagedAgent;
+    },
     sendSpokenInput: async (agentId, text) => {
       spokenInput.push({ agentId, text });
     },
-    interruptAgentIfRunning: async () => {},
+    interruptAgentIfRunning: vi.fn(async () => {}),
     hasActiveAgentRun: () => false,
   };
 }
@@ -110,6 +121,30 @@ async function settle(): Promise<void> {
 }
 
 describe("VoiceSession streaming transcription", () => {
+  test("technical cleanup restores voice config without user-interrupt semantics", async () => {
+    const { voiceSession, host } = createVoiceSession();
+
+    await voiceSession.handleSetVoiceMode(true, VOICE_AGENT_ID);
+    expect(host.reloads).toHaveLength(1);
+    expect(host.reloads[0]?.options).toBeUndefined();
+    expect(host.reloads[0]?.overrides.systemPrompt).toContain("Paseo voice mode is now on.");
+
+    await voiceSession.cleanup();
+
+    expect(host.reloads).toHaveLength(2);
+    expect(host.reloads[1]).toMatchObject({
+      agentId: VOICE_AGENT_ID,
+      options: { activeRunPolicy: "close" },
+    });
+    expect(host.reloads[1]?.overrides.systemPrompt).toContain("Paseo voice mode is now off.");
+    expect(host.interruptAgentIfRunning).not.toHaveBeenCalled();
+
+    // Cleanup cleared the voice owner state, so a repeated teardown cannot
+    // trigger another runtime close/reload.
+    await voiceSession.cleanup();
+    expect(host.reloads).toHaveLength(2);
+  });
+
   test("surfaces a refused voice-mode agent interruption", async () => {
     const { voiceSession, host } = createVoiceSession();
     host.interruptAgentIfRunning = vi.fn(async () => {

--- a/packages/server/src/server/session/voice/voice-session.ts
+++ b/packages/server/src/server/session/voice/voice-session.ts
@@ -16,7 +16,7 @@ import {
 import { createVoiceTurnController, type VoiceTurnController } from "./voice-turn-controller.js";
 import { buildVoiceModeSystemPrompt, stripVoiceModeSystemPrompt } from "../../voice-config.js";
 import type { VoiceCallerContext, VoiceSpeakHandler } from "../../voice-types.js";
-import type { ManagedAgent } from "../../agent/agent-manager.js";
+import type { ManagedAgent, ReloadAgentSessionOptions } from "../../agent/agent-manager.js";
 import type { AgentSessionConfig } from "../../agent/agent-sdk-types.js";
 import type { LocalSpeechModelId } from "../../speech/providers/local/models.js";
 import { toResolver, type Resolvable } from "../../speech/provider-resolver.js";
@@ -125,6 +125,7 @@ export interface VoiceSessionHost {
   reloadAgentSession(
     agentId: string,
     overrides: Partial<AgentSessionConfig>,
+    options?: ReloadAgentSessionOptions,
   ): Promise<ManagedAgent>;
   sendSpokenInput(agentId: string, text: string): Promise<void>;
   interruptAgentIfRunning(agentId: string): Promise<void>;
@@ -507,7 +508,10 @@ export class VoiceSession {
     }
   }
 
-  private async disableVoiceModeForActiveAgent(restoreAgentConfig: boolean): Promise<void> {
+  private async disableVoiceModeForActiveAgent(
+    restoreAgentConfig: boolean,
+    options?: { technicalCleanup?: boolean },
+  ): Promise<void> {
     await this.stopVoiceTurnController();
 
     const agentId = this.voiceModeAgentId;
@@ -522,9 +526,13 @@ export class VoiceSession {
     if (restoreAgentConfig && this.voiceModeBaseConfig) {
       const baseConfig = this.voiceModeBaseConfig;
       try {
-        await this.host.reloadAgentSession(agentId, {
-          systemPrompt: buildVoiceModeSystemPrompt(baseConfig.systemPrompt, false),
-        });
+        await this.host.reloadAgentSession(
+          agentId,
+          {
+            systemPrompt: buildVoiceModeSystemPrompt(baseConfig.systemPrompt, false),
+          },
+          options?.technicalCleanup ? { activeRunPolicy: "close" } : undefined,
+        );
       } catch (error) {
         this.sessionLogger.warn(
           { err: error, agentId },
@@ -1303,7 +1311,7 @@ export class VoiceSession {
     this.sttManager.cleanup();
     this.dictationStreamManager.cleanupAll();
 
-    await this.disableVoiceModeForActiveAgent(true);
+    await this.disableVoiceModeForActiveAgent(true, { technicalCleanup: true });
     this.isVoiceMode = false;
   }
 }


### PR DESCRIPTION
## Summary

Fixes false "user interrupt" cancellations for ACP agents during daemon/session shutdown.

`ACPAgentSession.close()` previously sent `session/cancel` whenever a foreground turn was active. During daemon shutdown/restart this caused ACP runtimes such as Devin to interpret infrastructure shutdown as an explicit user cancellation, marking active tool calls as failed with messages such as:

`Canceled due to user interrupt`

## Root cause

`close()` used the same cancellation path as an explicit user `interrupt()`.

This conflated:

- session/runtime shutdown
- explicit user interruption

## Fix

- `close()` no longer sends `session/cancel`
- explicit `interrupt()` and deny+interrupt still send `session/cancel`
- client-initiated cancellation state is tracked separately from runtime-originated `stopReason="cancelled"`

## Tests

Added regression coverage for:

- close with active turn does not send `session/cancel`
- explicit interrupt still sends cancel
- explicit interrupt still produces user-cancel semantics
- runtime-originated cancellation is not misclassified as user cancellation
- cancellation state is reset between turns

Validated with:

- ACP agent tests: 104/104
- agent-manager tests: 151/151
- session tests: 144/144
- server typecheck
- lint
- format check
- server build
- git diff --check

Also reproduced and validated end-to-end with Devin/SWE-1.7.
