### PR TITLE
feat(grok): surface per-model reasoning effort controls

### DIFF
--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -48,6 +48,11 @@ const mockState = vi.hoisted(() => {
         env?: Record<string, string>;
         providerParams?: unknown;
       }>,
+      grok: [] as Array<{
+        command: string[];
+        env?: Record<string, string>;
+        providerParams?: unknown;
+      }>,
       pi: [] as ConstructorEntry[],
       genericAcp: [] as Array<{
         command: string[];
@@ -67,6 +72,7 @@ const mockState = vi.hoisted(() => {
       this.constructorArgs.cursor = [];
       this.constructorArgs.trae = [];
       this.constructorArgs.kimi = [];
+      this.constructorArgs.grok = [];
       this.constructorArgs.pi = [];
       this.constructorArgs.genericAcp = [];
       this.isCommandAvailable.mockReset();
@@ -528,6 +534,59 @@ vi.mock("./providers/kimi-acp-agent.js", () => ({
   },
 }));
 
+vi.mock("./providers/grok-acp-agent.js", () => ({
+  GrokACPAgentClient: class GrokACPAgentClient {
+    readonly capabilities = {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    };
+    readonly provider = "acp";
+    readonly runtimeSettings?: unknown;
+
+    constructor(options: {
+      command: string[];
+      env?: Record<string, string>;
+      providerParams?: unknown;
+    }) {
+      this.runtimeSettings = {
+        command: {
+          mode: "replace",
+          argv: options.command,
+        },
+        env: options.env,
+      };
+      mockState.constructorArgs.grok.push({
+        command: options.command,
+        env: options.env,
+        providerParams: options.providerParams,
+      });
+    }
+
+    async createSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async resumeSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async fetchCatalog(): Promise<ProviderCatalog> {
+      return {
+        models: mockState.runtimeModels.get(this.provider) ?? [],
+        modes: [],
+      };
+    }
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+  },
+}));
+
 import {
   AGENT_PROVIDER_DEFINITIONS,
   buildProviderRegistry,
@@ -941,6 +1000,33 @@ test("kimi provider extending acp uses KimiACPAgentClient", () => {
     },
     {
       command: ["kimi", "acp"],
+      env: undefined,
+      providerParams: undefined,
+    },
+  ]);
+  expect(mockState.constructorArgs.genericAcp).toEqual([]);
+});
+
+test("grok provider extending acp uses GrokACPAgentClient", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      grok: {
+        extends: "acp",
+        label: "Grok",
+        command: ["grok", "agent", "stdio"],
+      },
+    },
+  });
+
+  expect(registry.grok.createClient(logger).provider).toBe("grok");
+  expect(mockState.constructorArgs.grok).toEqual([
+    {
+      command: ["grok", "agent", "stdio"],
+      env: undefined,
+      providerParams: undefined,
+    },
+    {
+      command: ["grok", "agent", "stdio"],
       env: undefined,
       providerParams: undefined,
     },

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -37,6 +37,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -778,6 +779,9 @@ function addDerivedProviders(
           }
           if (providerId === "kimi") {
             return new KimiACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kiro") {
             return new KiroACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1120,6 +1120,58 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
+  test("uses the standard config option path when a thinking writer declines", async () => {
+    const thinkingOptionWriter = vi.fn(async () => ({ handled: false }));
+    const session = new ACPAgentSession(
+      {
+        provider: "grok",
+        cwd: "/tmp/paseo-acp-test",
+        thinkingOptionId: "low",
+      },
+      {
+        provider: "grok",
+        logger: createTestLogger(),
+        defaultCommand: ["grok", "agent", "stdio"],
+        defaultModes: [],
+        thinkingOptionWriter,
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+      },
+    );
+    const internals = asInternals<ACPModelSelectionInternals>(session);
+    const standardOption = selectConfigOption("thought_level", ["low", "medium"], "low");
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [selectConfigOption("thought_level", ["low", "medium"], "medium")],
+    }));
+    internals.sessionId = "session-1";
+    internals.configOptions = [standardOption];
+    internals.connection = { setSessionConfigOption };
+
+    await session.setThinkingOption("medium");
+
+    expect(thinkingOptionWriter).toHaveBeenCalledWith({
+      connection: internals.connection,
+      sessionId: "session-1",
+      requestedThinkingOptionId: "medium",
+      currentThinkingOptionId: "low",
+      configOptions: [standardOption],
+    });
+    expect(setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      configId: "thought_level-option",
+      value: "medium",
+    });
+    await expect(session.getRuntimeInfo()).resolves.toMatchObject({
+      thinkingOptionId: "medium",
+    });
+  });
+
   test("passes generic ACP permission requests through to the user", async () => {
     const session = createSessionWithConfig({
       provider: "cursor-acp",

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -426,10 +426,8 @@ interface ACPAgentClientOptions {
     context: ACPProviderModelWriterContext,
   ) => Promise<ACPProviderModelWriteResult>;
   thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+    context: ACPProviderThinkingOptionWriterContext,
+  ) => Promise<ACPProviderThinkingOptionWriteResult>;
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
   waitForInitialCommands?: boolean;
@@ -459,10 +457,8 @@ interface ACPAgentSessionOptions {
     context: ACPProviderModelWriterContext,
   ) => Promise<ACPProviderModelWriteResult>;
   thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+    context: ACPProviderThinkingOptionWriterContext,
+  ) => Promise<ACPProviderThinkingOptionWriteResult>;
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
   handle?: AgentPersistenceHandle;
@@ -604,11 +600,25 @@ export interface ACPProviderModelWriterContext {
   currentModelId: string | null;
   currentThinkingOptionId: string | null;
   availableModel: AvailableACPModel;
+  configOptions: SessionConfigOption[];
 }
 
 export interface ACPProviderModelWriteResult {
   handled: boolean;
   currentModelId?: string;
+  thinkingOptionId?: string | null;
+}
+
+export interface ACPProviderThinkingOptionWriterContext {
+  connection: ClientSideConnection;
+  sessionId: string;
+  requestedThinkingOptionId: string;
+  currentThinkingOptionId: string | null;
+  configOptions: SessionConfigOption[];
+}
+
+export interface ACPProviderThinkingOptionWriteResult {
+  handled: boolean;
   thinkingOptionId?: string | null;
 }
 
@@ -836,10 +846,8 @@ export class ACPAgentClient implements AgentClient {
     context: ACPProviderModelWriterContext,
   ) => Promise<ACPProviderModelWriteResult>;
   private readonly thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+    context: ACPProviderThinkingOptionWriterContext,
+  ) => Promise<ACPProviderThinkingOptionWriteResult>;
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
@@ -1431,10 +1439,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     context: ACPProviderModelWriterContext,
   ) => Promise<ACPProviderModelWriteResult>;
   private readonly thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+    context: ACPProviderThinkingOptionWriterContext,
+  ) => Promise<ACPProviderThinkingOptionWriteResult>;
   private readonly agentId?: string;
   private readonly launchEnv?: Record<string, string>;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
@@ -1953,6 +1959,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
           currentModelId: this.currentModel,
           currentThinkingOptionId: this.thinkingOptionId,
           availableModel: selection.availableModel,
+          configOptions: this.configOptions,
         });
         if (result.handled) {
           this.currentModel = result.currentModelId ?? modelId;
@@ -2035,14 +2042,22 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     if (this.thinkingOptionWriter) {
-      await this.thinkingOptionWriter(this.connection, this.sessionId, thinkingOptionId);
-      this.thinkingOptionId = thinkingOptionId;
-      this.pushEvent({
-        type: "thinking_option_changed",
-        provider: this.provider,
-        thinkingOptionId: this.thinkingOptionId,
+      const result = await this.thinkingOptionWriter({
+        connection: this.connection,
+        sessionId: this.sessionId,
+        requestedThinkingOptionId: thinkingOptionId,
+        currentThinkingOptionId: this.thinkingOptionId,
+        configOptions: this.configOptions,
       });
-      return;
+      if (result.handled) {
+        this.thinkingOptionId = result.thinkingOptionId ?? thinkingOptionId;
+        this.pushEvent({
+          type: "thinking_option_changed",
+          provider: this.provider,
+          thinkingOptionId: this.thinkingOptionId,
+        });
+        return;
+      }
     }
 
     const option = findSelectConfigOption({

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -385,6 +385,7 @@ export interface ACPCatalogModelResolverContext {
   connection: ClientSideConnection;
   sessionId: string;
   models: AgentModelDefinition[];
+  modelState: SessionModelState | null | undefined;
   configOptions: SessionConfigOption[] | null | undefined;
   runRequest: <T>(request: () => Promise<T>) => Promise<T>;
   transformConfigOptions: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
@@ -421,6 +422,9 @@ interface ACPAgentClientOptions {
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
   beforeModeWriter?: (context: ACPProviderModeWriterContext) => Promise<ACPBeforeModeWriteResult>;
+  providerModelWriter?: (
+    context: ACPProviderModelWriterContext,
+  ) => Promise<ACPProviderModelWriteResult>;
   thinkingOptionWriter?: (
     connection: ClientSideConnection,
     sessionId: string,
@@ -451,6 +455,9 @@ interface ACPAgentSessionOptions {
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
   beforeModeWriter?: (context: ACPProviderModeWriterContext) => Promise<ACPBeforeModeWriteResult>;
+  providerModelWriter?: (
+    context: ACPProviderModelWriterContext,
+  ) => Promise<ACPProviderModelWriteResult>;
   thinkingOptionWriter?: (
     connection: ClientSideConnection,
     sessionId: string,
@@ -588,6 +595,21 @@ export interface ACPProviderModeWriteResult {
 
 export interface ACPBeforeModeWriteResult {
   configOptions?: SessionConfigOption[];
+}
+
+export interface ACPProviderModelWriterContext {
+  connection: ClientSideConnection;
+  sessionId: string;
+  requestedModelId: string;
+  currentModelId: string | null;
+  currentThinkingOptionId: string | null;
+  availableModel: AvailableACPModel;
+}
+
+export interface ACPProviderModelWriteResult {
+  handled: boolean;
+  currentModelId?: string;
+  thinkingOptionId?: string | null;
 }
 
 export function mapACPUsage(usage: Usage | null | undefined): AgentUsage | undefined {
@@ -810,6 +832,9 @@ export class ACPAgentClient implements AgentClient {
   private readonly beforeModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPBeforeModeWriteResult>;
+  private readonly providerModelWriter?: (
+    context: ACPProviderModelWriterContext,
+  ) => Promise<ACPProviderModelWriteResult>;
   private readonly thinkingOptionWriter?: (
     connection: ClientSideConnection,
     sessionId: string,
@@ -842,6 +867,7 @@ export class ACPAgentClient implements AgentClient {
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
+    this.providerModelWriter = options.providerModelWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
@@ -871,6 +897,7 @@ export class ACPAgentClient implements AgentClient {
         toolSnapshotTransformer: this.toolSnapshotTransformer,
         providerModeWriter: this.providerModeWriter,
         beforeModeWriter: this.beforeModeWriter,
+        providerModelWriter: this.providerModelWriter,
         thinkingOptionWriter: this.thinkingOptionWriter,
         capabilities: this.capabilities,
         agentId: launchContext?.agentId,
@@ -921,6 +948,7 @@ export class ACPAgentClient implements AgentClient {
       toolSnapshotTransformer: this.toolSnapshotTransformer,
       providerModeWriter: this.providerModeWriter,
       beforeModeWriter: this.beforeModeWriter,
+      providerModelWriter: this.providerModelWriter,
       thinkingOptionWriter: this.thinkingOptionWriter,
       capabilities: this.capabilities,
       handle,
@@ -964,6 +992,7 @@ export class ACPAgentClient implements AgentClient {
               connection: initializedProbe.connection,
               sessionId: response.sessionId,
               models: derivedModels,
+              modelState: transformed.models,
               configOptions: transformed.configOptions,
               runRequest: (request) => this.runACPRequest(request),
               transformConfigOptions: (configOptions) =>
@@ -1398,6 +1427,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly beforeModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPBeforeModeWriteResult>;
+  private readonly providerModelWriter?: (
+    context: ACPProviderModelWriterContext,
+  ) => Promise<ACPProviderModelWriteResult>;
   private readonly thinkingOptionWriter?: (
     connection: ClientSideConnection,
     sessionId: string,
@@ -1460,6 +1492,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
+    this.providerModelWriter = options.providerModelWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.availableModes = options.defaultModes;
     this.agentId = options.agentId;
@@ -1910,6 +1943,34 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
       if (typeof this.connection.unstable_setSessionModel !== "function") {
         throw new Error(this.modelSelectionUnavailableMessage());
+      }
+
+      if (this.providerModelWriter) {
+        const result = await this.providerModelWriter({
+          connection: this.connection,
+          sessionId: this.sessionId,
+          requestedModelId: modelId,
+          currentModelId: this.currentModel,
+          currentThinkingOptionId: this.thinkingOptionId,
+          availableModel: selection.availableModel,
+        });
+        if (result.handled) {
+          this.currentModel = result.currentModelId ?? modelId;
+          if (result.thinkingOptionId !== undefined) {
+            this.thinkingOptionId = result.thinkingOptionId;
+            this.pushEvent({
+              type: "thinking_option_changed",
+              provider: this.provider,
+              thinkingOptionId: this.thinkingOptionId,
+            });
+          }
+          this.pushEvent({
+            type: "model_changed",
+            provider: this.provider,
+            runtimeInfo: this.runtimeInfo(),
+          });
+          return;
+        }
       }
 
       try {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,3 +1,4 @@
+import type { ClientSideConnection } from "@agentclientprotocol/sdk";
 import type { Logger } from "pino";
 import { z } from "zod";
 
@@ -10,6 +11,9 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPProviderModelWriterContext,
+  type ACPProviderModelWriteResult,
+  type SessionStateResponse,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -51,6 +55,15 @@ interface GenericACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
+  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  providerModelWriter?: (
+    context: ACPProviderModelWriterContext,
+  ) => Promise<ACPProviderModelWriteResult>;
+  thinkingOptionWriter?: (
+    connection: ClientSideConnection,
+    sessionId: string,
+    thinkingOptionId: string,
+  ) => Promise<void>;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -76,6 +89,9 @@ export class GenericACPAgentClient extends ACPAgentClient {
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
+      sessionResponseTransformer: options.sessionResponseTransformer,
+      providerModelWriter: options.providerModelWriter,
+      thinkingOptionWriter: options.thinkingOptionWriter,
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,4 +1,3 @@
-import type { ClientSideConnection } from "@agentclientprotocol/sdk";
 import type { Logger } from "pino";
 import { z } from "zod";
 
@@ -13,6 +12,8 @@ import {
   type ACPExtensionCommandsParser,
   type ACPProviderModelWriterContext,
   type ACPProviderModelWriteResult,
+  type ACPProviderThinkingOptionWriterContext,
+  type ACPProviderThinkingOptionWriteResult,
   type SessionStateResponse,
 } from "./acp-agent.js";
 import {
@@ -60,10 +61,8 @@ interface GenericACPAgentClientOptions {
     context: ACPProviderModelWriterContext,
   ) => Promise<ACPProviderModelWriteResult>;
   thinkingOptionWriter?: (
-    connection: ClientSideConnection,
-    sessionId: string,
-    thinkingOptionId: string,
-  ) => Promise<void>;
+    context: ACPProviderThinkingOptionWriterContext,
+  ) => Promise<ACPProviderThinkingOptionWriteResult>;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,4 +1,8 @@
-import type { ClientSideConnection, SessionModelState } from "@agentclientprotocol/sdk";
+import type {
+  ClientSideConnection,
+  SessionConfigOption,
+  SessionModelState,
+} from "@agentclientprotocol/sdk";
 import { describe, expect, test, vi } from "vitest";
 
 import type { AgentModelDefinition } from "../agent-sdk-types.js";
@@ -46,6 +50,29 @@ const grokModelState = {
     },
   ],
 } satisfies SessionModelState;
+
+const grokReasoningConfigOption = {
+  id: "_paseo.grok.reasoning_effort",
+  name: "Reasoning effort",
+  category: "thought_level",
+  type: "select",
+  currentValue: "high",
+  options: [
+    { value: "xhigh", name: "Extra High Effort" },
+    { value: "high", name: "High Effort" },
+    { value: "medium", name: "Medium Effort" },
+    { value: "low", name: "Low Effort" },
+  ],
+} satisfies SessionConfigOption;
+
+const standardThinkingConfigOption = {
+  id: "reasoning",
+  name: "Reasoning",
+  category: "thought_level",
+  type: "select",
+  currentValue: "medium",
+  options: [{ value: "medium", name: "Medium" }],
+} satisfies SessionConfigOption;
 
 describe("Grok ACP reasoning options", () => {
   test("keeps each model's effort levels separate and uses its reported current effort as default", () => {
@@ -163,16 +190,7 @@ describe("Grok ACP reasoning options", () => {
     const result = await resolveGrokCatalogModels({
       models,
       modelState: grokModelState,
-      configOptions: [
-        {
-          id: "reasoning",
-          name: "Reasoning",
-          category: "thought_level",
-          type: "select",
-          currentValue: "medium",
-          options: [{ value: "medium", name: "Medium" }],
-        },
-      ],
+      configOptions: [standardThinkingConfigOption],
     } as ACPCatalogModelResolverContext);
 
     expect(result).toBe(models);
@@ -181,17 +199,35 @@ describe("Grok ACP reasoning options", () => {
   test("writes a selected effort through Grok's ACP mode endpoint", async () => {
     const setSessionMode = vi.fn().mockResolvedValue({});
 
-    await writeGrokThinkingOption(
-      { setSessionMode } as unknown as ClientSideConnection,
-      "session-1",
-      "low",
-    );
+    const result = await writeGrokThinkingOption({
+      connection: { setSessionMode } as unknown as ClientSideConnection,
+      sessionId: "session-1",
+      requestedThinkingOptionId: "low",
+      currentThinkingOptionId: "high",
+      configOptions: [grokReasoningConfigOption],
+    });
 
     expect(setSessionMode).toHaveBeenCalledOnce();
     expect(setSessionMode).toHaveBeenCalledWith({
       sessionId: "session-1",
       modeId: "low",
     });
+    expect(result).toEqual({ handled: true, thinkingOptionId: "low" });
+  });
+
+  test("leaves standard ACP thinking writes to the base client", async () => {
+    const setSessionMode = vi.fn();
+
+    const result = await writeGrokThinkingOption({
+      connection: { setSessionMode } as unknown as ClientSideConnection,
+      sessionId: "session-1",
+      requestedThinkingOptionId: "medium",
+      currentThinkingOptionId: "high",
+      configOptions: [standardThinkingConfigOption],
+    });
+
+    expect(setSessionMode).not.toHaveBeenCalled();
+    expect(result).toEqual({ handled: false });
   });
 
   test("falls back to the target model's default effort when switching models", async () => {
@@ -206,6 +242,7 @@ describe("Grok ACP reasoning options", () => {
       currentModelId: "grok-4.6",
       currentThinkingOptionId: "xhigh",
       availableModel: grokModelState.availableModels[1],
+      configOptions: [grokReasoningConfigOption],
     });
 
     expect(unstableSetSessionModel).toHaveBeenCalledWith({
@@ -218,5 +255,24 @@ describe("Grok ACP reasoning options", () => {
       currentModelId: "grok-4.5",
       thinkingOptionId: "high",
     });
+  });
+
+  test("leaves standard ACP model writes to the base client", async () => {
+    const unstableSetSessionModel = vi.fn();
+
+    const result = await writeGrokModel({
+      connection: {
+        unstable_setSessionModel: unstableSetSessionModel,
+      } as unknown as ClientSideConnection,
+      sessionId: "session-1",
+      requestedModelId: "grok-4.5",
+      currentModelId: "grok-4.6",
+      currentThinkingOptionId: "medium",
+      availableModel: grokModelState.availableModels[1],
+      configOptions: [standardThinkingConfigOption],
+    });
+
+    expect(unstableSetSessionModel).not.toHaveBeenCalled();
+    expect(result).toEqual({ handled: false });
   });
 });

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,222 @@
+import type { ClientSideConnection, SessionModelState } from "@agentclientprotocol/sdk";
+import { describe, expect, test, vi } from "vitest";
+
+import type { AgentModelDefinition } from "../agent-sdk-types.js";
+import type { ACPCatalogModelResolverContext } from "./acp-agent.js";
+import {
+  applyGrokReasoningOptions,
+  resolveGrokCatalogModels,
+  transformGrokSessionResponse,
+  writeGrokModel,
+  writeGrokThinkingOption,
+} from "./grok-acp-agent.js";
+
+const grokModelState = {
+  currentModelId: "grok-4.6",
+  availableModels: [
+    {
+      modelId: "grok-4.6",
+      name: "Grok 4.6",
+      _meta: {
+        reasoningEffort: "high",
+        reasoningEfforts: [
+          {
+            id: "xhigh",
+            value: "xhigh",
+            label: "Extra High Effort",
+            default: true,
+          },
+          { id: "high", value: "high", label: "High Effort", default: true },
+          { id: "medium", value: "medium", label: "Medium Effort", default: false },
+          { id: "low", value: "low", label: "Low Effort", default: false },
+        ],
+      },
+    },
+    {
+      modelId: "grok-4.5",
+      name: "Grok 4.5",
+      _meta: {
+        reasoningEffort: "high",
+        reasoningEfforts: [
+          { id: "high", value: "high", label: "High Effort", default: true },
+          { id: "medium", value: "medium", label: "Medium Effort", default: false },
+          { id: "low", value: "low", label: "Low Effort", default: false },
+        ],
+      },
+    },
+  ],
+} satisfies SessionModelState;
+
+describe("Grok ACP reasoning options", () => {
+  test("keeps each model's effort levels separate and uses its reported current effort as default", () => {
+    const models: AgentModelDefinition[] = [
+      {
+        provider: "acp",
+        id: "grok-4.6",
+        label: "Grok 4.6",
+        isDefault: true,
+      },
+      {
+        provider: "acp",
+        id: "grok-4.5",
+        label: "Grok 4.5",
+        isDefault: false,
+      },
+    ];
+    const result = applyGrokReasoningOptions(models, grokModelState);
+
+    expect(result).toEqual([
+      {
+        ...models[0],
+        thinkingOptions: [
+          { id: "xhigh", label: "Extra High Effort", isDefault: false },
+          { id: "high", label: "High Effort", isDefault: true },
+          { id: "medium", label: "Medium Effort", isDefault: false },
+          { id: "low", label: "Low Effort", isDefault: false },
+        ],
+        defaultThinkingOptionId: "high",
+      },
+      {
+        ...models[1],
+        thinkingOptions: [
+          { id: "high", label: "High Effort", isDefault: true },
+          { id: "medium", label: "Medium Effort", isDefault: false },
+          { id: "low", label: "Low Effort", isDefault: false },
+        ],
+        defaultThinkingOptionId: "high",
+      },
+    ]);
+  });
+
+  test("maps the current model's actual effort into session thinking state", () => {
+    const result = transformGrokSessionResponse({
+      sessionId: "session-1",
+      models: grokModelState,
+    });
+
+    expect(result.configOptions).toEqual([
+      {
+        id: "_paseo.grok.reasoning_effort",
+        name: "Reasoning effort",
+        category: "thought_level",
+        type: "select",
+        currentValue: "high",
+        options: [
+          { value: "xhigh", name: "Extra High Effort", description: undefined },
+          { value: "high", name: "High Effort", description: undefined },
+          { value: "medium", name: "Medium Effort", description: undefined },
+          { value: "low", name: "Low Effort", description: undefined },
+        ],
+      },
+    ]);
+  });
+
+  test("does not leak the current model's options onto a model without effort metadata", async () => {
+    const models: AgentModelDefinition[] = [
+      {
+        provider: "acp",
+        id: "grok-4.6",
+        label: "Grok 4.6",
+        thinkingOptions: [{ id: "high", label: "High" }],
+        defaultThinkingOptionId: "high",
+      },
+      {
+        provider: "acp",
+        id: "custom-model",
+        label: "Custom model",
+        thinkingOptions: [{ id: "high", label: "High" }],
+        defaultThinkingOptionId: "high",
+      },
+    ];
+    const result = applyGrokReasoningOptions(models, {
+      ...grokModelState,
+      availableModels: [
+        grokModelState.availableModels[0],
+        { modelId: "custom-model", name: "Custom model" },
+      ],
+    });
+
+    expect(result[0]?.thinkingOptions?.map((option) => option.id)).toEqual([
+      "xhigh",
+      "high",
+      "medium",
+      "low",
+    ]);
+    expect(result[1]).toEqual({
+      provider: "acp",
+      id: "custom-model",
+      label: "Custom model",
+    });
+  });
+
+  test("keeps standard ACP thinking options authoritative", async () => {
+    const models: AgentModelDefinition[] = [
+      {
+        provider: "acp",
+        id: "grok-4.6",
+        label: "Grok 4.6",
+        thinkingOptions: [{ id: "medium", label: "Medium", isDefault: true }],
+        defaultThinkingOptionId: "medium",
+      },
+    ];
+
+    const result = await resolveGrokCatalogModels({
+      models,
+      modelState: grokModelState,
+      configOptions: [
+        {
+          id: "reasoning",
+          name: "Reasoning",
+          category: "thought_level",
+          type: "select",
+          currentValue: "medium",
+          options: [{ value: "medium", name: "Medium" }],
+        },
+      ],
+    } as ACPCatalogModelResolverContext);
+
+    expect(result).toBe(models);
+  });
+
+  test("writes a selected effort through Grok's ACP mode endpoint", async () => {
+    const setSessionMode = vi.fn().mockResolvedValue({});
+
+    await writeGrokThinkingOption(
+      { setSessionMode } as unknown as ClientSideConnection,
+      "session-1",
+      "low",
+    );
+
+    expect(setSessionMode).toHaveBeenCalledOnce();
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "low",
+    });
+  });
+
+  test("falls back to the target model's default effort when switching models", async () => {
+    const unstableSetSessionModel = vi.fn().mockResolvedValue({});
+
+    const result = await writeGrokModel({
+      connection: {
+        unstable_setSessionModel: unstableSetSessionModel,
+      } as unknown as ClientSideConnection,
+      sessionId: "session-1",
+      requestedModelId: "grok-4.5",
+      currentModelId: "grok-4.6",
+      currentThinkingOptionId: "xhigh",
+      availableModel: grokModelState.availableModels[1],
+    });
+
+    expect(unstableSetSessionModel).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modelId: "grok-4.5",
+      _meta: { reasoningEffort: "high" },
+    });
+    expect(result).toEqual({
+      handled: true,
+      currentModelId: "grok-4.5",
+      thinkingOptionId: "high",
+    });
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,8 +1,4 @@
-import type {
-  ClientSideConnection,
-  SessionConfigOption,
-  SessionModelState,
-} from "@agentclientprotocol/sdk";
+import type { SessionConfigOption, SessionModelState } from "@agentclientprotocol/sdk";
 import type { Logger } from "pino";
 import { z } from "zod";
 
@@ -11,6 +7,8 @@ import type {
   ACPCatalogModelResolverContext,
   ACPProviderModelWriterContext,
   ACPProviderModelWriteResult,
+  ACPProviderThinkingOptionWriterContext,
+  ACPProviderThinkingOptionWriteResult,
   SessionStateResponse,
 } from "./acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
@@ -167,13 +165,24 @@ export function transformGrokSessionResponse(response: SessionStateResponse): Se
   };
 }
 
-export async function writeGrokThinkingOption(
-  connection: ClientSideConnection,
-  sessionId: string,
-  thinkingOptionId: string,
-): Promise<void> {
+function hasGrokReasoningConfigOption(configOptions: SessionConfigOption[]): boolean {
+  return configOptions.some(
+    (option) => option.id === GROK_REASONING_CONFIG_ID && option.category === "thought_level",
+  );
+}
+
+export async function writeGrokThinkingOption({
+  connection,
+  sessionId,
+  requestedThinkingOptionId,
+  configOptions,
+}: ACPProviderThinkingOptionWriterContext): Promise<ACPProviderThinkingOptionWriteResult> {
+  if (!hasGrokReasoningConfigOption(configOptions)) {
+    return { handled: false };
+  }
   // Grok exposes reasoning effort through ACP's mode endpoint.
-  await connection.setSessionMode({ sessionId, modeId: thinkingOptionId });
+  await connection.setSessionMode({ sessionId, modeId: requestedThinkingOptionId });
+  return { handled: true, thinkingOptionId: requestedThinkingOptionId };
 }
 
 export async function writeGrokModel({
@@ -182,7 +191,11 @@ export async function writeGrokModel({
   requestedModelId,
   currentThinkingOptionId,
   availableModel,
+  configOptions,
 }: ACPProviderModelWriterContext): Promise<ACPProviderModelWriteResult> {
+  if (!hasGrokReasoningConfigOption(configOptions)) {
+    return { handled: false };
+  }
   const { options, defaultId } = reasoningOptions(availableModel._meta);
   const supportedEfforts = new Set(options.map((option) => option.id));
   const thinkingOptionId =

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,220 @@
+import type {
+  ClientSideConnection,
+  SessionConfigOption,
+  SessionModelState,
+} from "@agentclientprotocol/sdk";
+import type { Logger } from "pino";
+import { z } from "zod";
+
+import type { AgentModelDefinition, AgentSelectOption } from "../agent-sdk-types.js";
+import type {
+  ACPCatalogModelResolverContext,
+  ACPProviderModelWriterContext,
+  ACPProviderModelWriteResult,
+  SessionStateResponse,
+} from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+const GROK_REASONING_CONFIG_ID = "_paseo.grok.reasoning_effort";
+
+const GrokReasoningEffortSchema = z
+  .object({
+    id: z.string().optional(),
+    value: z.string().optional(),
+    label: z.string().optional(),
+    description: z.string().optional(),
+    default: z.boolean().optional(),
+  })
+  .passthrough();
+
+const GrokModelMetaSchema = z
+  .object({
+    supportsReasoningEffort: z.boolean().optional(),
+    reasoningEffort: z.string().optional(),
+    reasoningEfforts: z.array(GrokReasoningEffortSchema).optional(),
+  })
+  .passthrough();
+
+type GrokReasoningEffort = z.infer<typeof GrokReasoningEffortSchema>;
+
+function optionId(effort: GrokReasoningEffort): string | null {
+  const id = effort.id?.trim() || effort.value?.trim();
+  return id || null;
+}
+
+function reasoningOptions(meta: unknown): {
+  options: AgentSelectOption[];
+  defaultId: string | null;
+} {
+  const parsed = GrokModelMetaSchema.safeParse(meta);
+  if (!parsed.success || parsed.data.supportsReasoningEffort === false) {
+    return { options: [], defaultId: null };
+  }
+
+  const seen = new Set<string>();
+  const efforts = (parsed.data.reasoningEfforts ?? []).flatMap((effort) => {
+    const id = optionId(effort);
+    if (!id || seen.has(id)) {
+      return [];
+    }
+    seen.add(id);
+    return [{ effort, id }];
+  });
+  const currentId = parsed.data.reasoningEffort?.trim();
+  const defaultId =
+    (currentId && seen.has(currentId) ? currentId : null) ??
+    efforts.find(({ effort }) => effort.default === true)?.id ??
+    efforts[0]?.id ??
+    null;
+
+  return {
+    options: efforts.map(({ effort, id }) => ({
+      id,
+      label: effort.label?.trim() || id,
+      description: effort.description?.trim() || undefined,
+      isDefault: id === defaultId,
+    })),
+    defaultId,
+  };
+}
+
+export function applyGrokReasoningOptions(
+  models: AgentModelDefinition[],
+  modelState: SessionModelState | null | undefined,
+): AgentModelDefinition[] {
+  const rawModels = new Map(
+    modelState?.availableModels.map((model) => [model.modelId, model] as const) ?? [],
+  );
+  return models.map((model) => {
+    const { options, defaultId } = reasoningOptions(rawModels.get(model.id)?._meta);
+    if (options.length === 0 || !defaultId) {
+      const {
+        thinkingOptions: _thinkingOptions,
+        defaultThinkingOptionId: _defaultId,
+        ...plain
+      } = model;
+      return plain;
+    }
+    return {
+      ...model,
+      thinkingOptions: options,
+      defaultThinkingOptionId: defaultId,
+    };
+  });
+}
+
+export async function resolveGrokCatalogModels({
+  models,
+  modelState,
+  configOptions,
+}: ACPCatalogModelResolverContext): Promise<AgentModelDefinition[]> {
+  const standardThinkingOption = configOptions?.some(
+    (option) => option.category === "thought_level" && option.id !== GROK_REASONING_CONFIG_ID,
+  );
+  if (standardThinkingOption) {
+    return models;
+  }
+  return applyGrokReasoningOptions(models, modelState);
+}
+
+function grokThinkingConfigOption(
+  modelState: SessionModelState | null | undefined,
+): SessionConfigOption | null {
+  const currentModel = modelState?.availableModels.find(
+    (model) => model.modelId === modelState.currentModelId,
+  );
+  const { options, defaultId } = reasoningOptions(currentModel?._meta);
+  if (options.length === 0 || !defaultId) {
+    return null;
+  }
+  return {
+    id: GROK_REASONING_CONFIG_ID,
+    name: "Reasoning effort",
+    category: "thought_level",
+    type: "select",
+    currentValue: defaultId,
+    options: options.map((option) => ({
+      value: option.id,
+      name: option.label,
+      description: option.description,
+    })),
+  };
+}
+
+export function transformGrokSessionResponse(response: SessionStateResponse): SessionStateResponse {
+  const alreadyHasThinking = response.configOptions?.some(
+    (option) => option.category === "thought_level",
+  );
+  if (alreadyHasThinking) {
+    return response;
+  }
+  const thinkingOption = grokThinkingConfigOption(response.models);
+  if (!thinkingOption) {
+    return response;
+  }
+  return {
+    ...response,
+    configOptions: [...(response.configOptions ?? []), thinkingOption],
+  };
+}
+
+export async function writeGrokThinkingOption(
+  connection: ClientSideConnection,
+  sessionId: string,
+  thinkingOptionId: string,
+): Promise<void> {
+  // Grok exposes reasoning effort through ACP's mode endpoint.
+  await connection.setSessionMode({ sessionId, modeId: thinkingOptionId });
+}
+
+export async function writeGrokModel({
+  connection,
+  sessionId,
+  requestedModelId,
+  currentThinkingOptionId,
+  availableModel,
+}: ACPProviderModelWriterContext): Promise<ACPProviderModelWriteResult> {
+  const { options, defaultId } = reasoningOptions(availableModel._meta);
+  const supportedEfforts = new Set(options.map((option) => option.id));
+  const thinkingOptionId =
+    (currentThinkingOptionId && supportedEfforts.has(currentThinkingOptionId)
+      ? currentThinkingOptionId
+      : null) ?? defaultId;
+
+  await connection.unstable_setSessionModel({
+    sessionId,
+    modelId: requestedModelId,
+    ...(thinkingOptionId ? { _meta: { reasoningEffort: thinkingOptionId } } : {}),
+  });
+  return {
+    handled: true,
+    currentModelId: requestedModelId,
+    thinkingOptionId,
+  };
+}
+
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      catalogModelResolver: resolveGrokCatalogModels,
+      sessionResponseTransformer: transformGrokSessionResponse,
+      providerModelWriter: writeGrokModel,
+      thinkingOptionWriter: writeGrokThinkingOption,
+    });
+  }
+}


### PR DESCRIPTION
### Linked issue

Related to #2538 and the Grok reasoning-effort portion of #2289.

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Grok publishes reasoning-effort choices through vendor metadata instead of the standard ACP `thought_level` config option. Paseo therefore discovered Grok models but did not expose or apply their reasoning levels.

This change adds a focused Grok ACP adapter that translates the provider metadata into Paseo's existing thinking-level model. Each model keeps its own supported effort list, and model switches preserve the current effort when supported or fall back to the target model's reported default.

The adapter defers to standard ACP `thought_level` options if Grok exposes them in the future.

### Goals

- Expose Grok reasoning-effort choices through Paseo's existing thinking-level control.
- Keep effort choices scoped to the model that reported them.
- Apply effort changes through Grok's ACP `session/set_mode` behavior.
- Preserve a compatible effort when switching models.
- Fall back to the target model's default when the current effort is unsupported.
- Keep the generic ACP implementation provider-neutral.

### Non-goals

- No changes to Grok subagent, tool, import, or session-history support.
- No protocol or app UI changes.
- No behavior changes for other ACP providers.
- No fallback metadata mapping when a provider supplies standard ACP `thought_level` options.

### QA

Verified against the real Grok CLI 1.0.3 on Linux without sending a prompt.

Observed catalog:

```text
grok-4.6: default=high, options=xhigh,high,medium,low
grok-4.5: default=high, options=high,medium,low
```

Observed runtime behavior:

```text
create grok-4.6 with low  -> thinkingOptionId=low
switch to grok-4.5       -> thinkingOptionId=low

create grok-4.6 with xhigh -> thinkingOptionId=xhigh
switch to grok-4.5         -> thinkingOptionId=high
```

The second switch confirms fallback to the target model's default because Grok 4.5 does not support `xhigh`.

Automated checks:

```text
Test Files  5 passed (5)
Tests       165 passed (165)
```

Covered Grok metadata mapping, session-state initialization, standard ACP read/write precedence, effort writes, model-switch fallback, generic ACP behavior, Kimi behavior, and provider registration.

```text
npm run typecheck     passed
npm run lint          passed
npm run format        passed
npm run format:check  passed
```

Platform coverage:

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             | No     | No app or platform-specific code changed |
| Android         | No     | No app or platform-specific code changed |
| Web             | No     | No app or platform-specific code changed |
| Desktop macOS   | No     | Provider adapter is platform-neutral |
| Desktop Windows | No     | Provider adapter is platform-neutral |
| Desktop Linux   | Yes    | Real Grok 1.0.3 provider verification |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
