### PR TITLE
Restore model-default variant selection

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -824,7 +824,57 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
   }, 180_000);
 });
 
-describe("OpenCode adapter context-window normalization", () => {
+describe("OpenCode adapter normalization", () => {
+  test("includes the implicit model default before explicit OpenCode variants", () => {
+    const definition = __openCodeInternals.buildOpenCodeModelDefinition(
+      { id: "catalog-provider", name: "Catalog Provider" },
+      "single-variant-model",
+      {
+        name: "Single Variant Model",
+        variants: { max: { reasoningEffort: "max" } },
+      },
+    );
+
+    expect(definition.thinkingOptions).toEqual([
+      { id: "default", label: "Default", isDefault: true },
+      { id: "max", label: "max" },
+    ]);
+    expect(definition.defaultThinkingOptionId).toBe("default");
+  });
+
+  test("omits OpenCode's implicit default variant from new and updated sessions", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    openCode.sessionCreateResponse = { data: { id: "ses_default_variant" } };
+    openCode.sessionPromptAsyncEvents = [
+      { type: "session.idle", properties: { sessionID: "ses_default_variant" } },
+    ];
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+      model: "catalog-provider/single-variant-model",
+      thinkingOptionId: "default",
+    });
+
+    await collectTurnEvents(streamSession(session, "Use the model default"));
+    await session.setThinkingOption?.("max");
+    await collectTurnEvents(streamSession(session, "Use max"));
+    await session.setThinkingOption?.("default");
+    await collectTurnEvents(streamSession(session, "Return to the model default"));
+
+    expect(openCode.calls.sessionPromptAsync).toEqual([
+      expect.not.objectContaining({ variant: expect.anything() }),
+      expect.objectContaining({ variant: "max" }),
+      expect.not.objectContaining({ variant: expect.anything() }),
+    ]);
+    await session.close();
+  });
+
   test("builds OpenCode file parts for image prompt blocks", () => {
     expect(
       __openCodeInternals.buildOpenCodePromptParts([

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -480,6 +480,7 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
             models: {
               "big-pickle": {
                 name: "Big Pickle",
+                variants: { max: { reasoningEffort: "max" } },
                 limit: {
                   context: 200_000,
                 },
@@ -529,6 +530,11 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
     expect(catalog.models[0]).toMatchObject({
       id: TEST_MODEL,
       label: "Big Pickle",
+      thinkingOptions: [
+        { id: "default", label: "Default", isDefault: true },
+        { id: "max", label: "max" },
+      ],
+      defaultThinkingOptionId: "default",
       metadata: {
         providerId: "opencode",
         modelId: "big-pickle",
@@ -825,23 +831,6 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
 });
 
 describe("OpenCode adapter normalization", () => {
-  test("includes the implicit model default before explicit OpenCode variants", () => {
-    const definition = __openCodeInternals.buildOpenCodeModelDefinition(
-      { id: "catalog-provider", name: "Catalog Provider" },
-      "single-variant-model",
-      {
-        name: "Single Variant Model",
-        variants: { max: { reasoningEffort: "max" } },
-      },
-    );
-
-    expect(definition.thinkingOptions).toEqual([
-      { id: "default", label: "Default", isDefault: true },
-      { id: "max", label: "max" },
-    ]);
-    expect(definition.defaultThinkingOptionId).toBe("default");
-  });
-
   test("omits OpenCode's implicit default variant from new and updated sessions", async () => {
     const runtime = new TestOpenCodeHarness();
     const openCode = new TestOpenCodeClient();

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -111,6 +111,7 @@ const OPENCODE_CAPABILITIES: AgentCapabilityFlags = {
 
 const OPENCODE_BUILD_MODE_ID = "build";
 const OPENCODE_LEGACY_FULL_ACCESS_MODE_ID = "full-access";
+const OPENCODE_DEFAULT_VARIANT_ID = "default";
 const OPENCODE_AUTO_ACCEPT_FEATURE_ID = "auto_accept";
 const OPENCODE_PERSISTED_SESSION_LIMIT = 200;
 const OPENCODE_PENDING_ABORT_START_TIMEOUT_MS = 10_000;
@@ -580,6 +581,14 @@ function normalizeOpenCodeModeId(modeId: string | null | undefined): string | nu
   return trimmed;
 }
 
+function normalizeOpenCodeVariantId(variantId: string | null | undefined): string | null {
+  const trimmed = typeof variantId === "string" ? variantId.trim() : "";
+  if (!trimmed || trimmed === OPENCODE_DEFAULT_VARIANT_ID) {
+    return null;
+  }
+  return trimmed;
+}
+
 function resolveOpenCodeRuntimeAgentId(modeId: string | null | undefined): string | undefined {
   const normalizedModeId = normalizeOpenCodeModeId(modeId);
   if (normalizedModeId === null) {
@@ -591,15 +600,19 @@ function resolveOpenCodeRuntimeAgentId(modeId: string | null | undefined): strin
 }
 
 function normalizeOpenCodeConfig(config: OpenCodeAgentConfig): OpenCodeAgentConfig {
-  if (normalizeOpenCodeModeId(config.modeId) !== OPENCODE_LEGACY_FULL_ACCESS_MODE_ID) {
-    return { ...config };
+  const normalized = {
+    ...config,
+    thinkingOptionId: normalizeOpenCodeVariantId(config.thinkingOptionId) ?? undefined,
+  };
+  if (normalizeOpenCodeModeId(normalized.modeId) !== OPENCODE_LEGACY_FULL_ACCESS_MODE_ID) {
+    return normalized;
   }
 
   return {
-    ...config,
+    ...normalized,
     modeId: OPENCODE_BUILD_MODE_ID,
     featureValues: {
-      ...config.featureValues,
+      ...normalized.featureValues,
       [OPENCODE_AUTO_ACCEPT_FEATURE_ID]: true,
     },
   };
@@ -723,11 +736,13 @@ function buildOpenCodeModelDefinition(
   },
 ): AgentModelDefinition {
   const rawVariants = model.variants ? Object.keys(model.variants) : [];
-  const thinkingOptions = rawVariants.map((id, index) => ({
-    id,
-    label: id,
-    isDefault: index === 0,
-  }));
+  // OpenCode lists only overrides; its base model behavior is selected by omitting `variant`.
+  const thinkingOptions = rawVariants.length
+    ? [
+        { id: OPENCODE_DEFAULT_VARIANT_ID, label: "Default", isDefault: true },
+        ...rawVariants.map((id) => ({ id, label: id })),
+      ]
+    : [];
 
   return {
     provider: "opencode",
@@ -3195,10 +3210,7 @@ class OpenCodeAgentSession implements AgentSession {
   }
 
   async setThinkingOption(thinkingOptionId: string | null): Promise<void> {
-    const normalizedThinkingOptionId =
-      typeof thinkingOptionId === "string" && thinkingOptionId.trim().length > 0
-        ? thinkingOptionId
-        : null;
+    const normalizedThinkingOptionId = normalizeOpenCodeVariantId(thinkingOptionId);
     this.config.thinkingOptionId = normalizedThinkingOptionId ?? undefined;
   }
 


### PR DESCRIPTION
### Linked issue

Reported in Discord; no GitHub issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Models exposed through the OpenCode provider list explicit variant overrides but represent the base model behavior by omitting the variant field. Paseo treated the first explicit override as the default, so a model with one override offered no way to return to its base behavior.

The adapter now exposes that implicit base state as Default and translates it back to an omitted provider variant. The provider boundary owns both directions; the generic picker and protocol remain unchanged.

### Goals

- Show Default alongside every model that has explicit OpenCode variants.
- Keep explicit variant overrides selectable.
- Omit the provider variant when a new or running session selects Default.
- Cover catalog normalization and live selection with automated regression tests.

### Non-goals

- Change variant metadata supplied by OpenCode.
- Add model-specific variant rules.
- Change generic model or thinking-option UI behavior.

### QA

Red reproduction before the fix:

```text
FAIL includes the implicit model default before explicit OpenCode variants
Expected: [default, max]
Received: [max]
```

Verification after the fix:

```text
npx vitest run packages/server/src/server/agent/providers/opencode-agent.test.ts --bail=1
Test Files  1 passed (1)
Tests       96 passed (96)

npm run typecheck
passed

npm run lint
Found 0 warnings and 0 errors.

npm run format
passed
```

The behavioral test creates a session on Default, switches to an explicit override, then returns to Default. It asserts the provider receives no `variant`, then `variant: "max"`, then no `variant`.

Platforms tested: provider adapter tests on macOS. No platform-specific UI code changed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

