### PR TITLE
fix(server): rebind injected Paseo MCP on Codex resume after daemon restart

### DIFF
--- a/packages/server/src/server/agent-mcp-auth-token.test.ts
+++ b/packages/server/src/server/agent-mcp-auth-token.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  AGENT_MCP_AUTH_TOKEN_FILENAME,
+  getOrCreateAgentMcpAuthToken,
+} from "./agent-mcp-auth-token.js";
+import { PRIVATE_FILE_MODE } from "./private-files.js";
+
+const MODE_MASK = 0o777;
+const PERMISSIVE_FILE_MODE = 0o644;
+
+function tmpHome(): string {
+  return mkdtempSync(path.join(tmpdir(), "paseo-agent-mcp-auth-token-"));
+}
+
+function modeOf(filePath: string): number {
+  return statSync(filePath).mode & MODE_MASK;
+}
+
+describe("getOrCreateAgentMcpAuthToken", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = tmpHome();
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("creates and reuses a stable token per PASEO_HOME", () => {
+    const first = getOrCreateAgentMcpAuthToken(home);
+    const second = getOrCreateAgentMcpAuthToken(home);
+    expect(first).toBe(second);
+    expect(first).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+
+    const tokenPath = path.join(home, AGENT_MCP_AUTH_TOKEN_FILENAME);
+    expect(existsSync(tokenPath)).toBe(true);
+    expect(readFileSync(tokenPath, "utf8").trim()).toBe(first);
+  });
+
+  it("regenerates when the persisted value is not a UUID", () => {
+    const tokenPath = path.join(home, AGENT_MCP_AUTH_TOKEN_FILENAME);
+    writeFileSync(tokenPath, "not-a-token\n", { mode: PRIVATE_FILE_MODE });
+
+    const token = getOrCreateAgentMcpAuthToken(home);
+    expect(token).not.toBe("not-a-token");
+    expect(readFileSync(tokenPath, "utf8").trim()).toBe(token);
+  });
+
+  describe.skipIf(process.platform === "win32")("file permissions", () => {
+    it("creates the token file with private permissions", () => {
+      getOrCreateAgentMcpAuthToken(home);
+      expect(modeOf(path.join(home, AGENT_MCP_AUTH_TOKEN_FILENAME))).toBe(PRIVATE_FILE_MODE);
+    });
+
+    it("repairs existing token file permissions when loading", () => {
+      const tokenPath = path.join(home, AGENT_MCP_AUTH_TOKEN_FILENAME);
+      const existing = "11111111-1111-4111-8111-111111111111";
+      writeFileSync(tokenPath, `${existing}\n`, { mode: PERMISSIVE_FILE_MODE });
+      chmodSync(tokenPath, PERMISSIVE_FILE_MODE);
+
+      expect(getOrCreateAgentMcpAuthToken(home)).toBe(existing);
+      expect(modeOf(tokenPath)).toBe(PRIVATE_FILE_MODE);
+    });
+  });
+});

--- a/packages/server/src/server/agent-mcp-auth-token.ts
+++ b/packages/server/src/server/agent-mcp-auth-token.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+import { ensurePrivateFile, writePrivateFileAtomicSync } from "./private-files.js";
+
+interface LoggerLike {
+  child(bindings: Record<string, unknown>): LoggerLike;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+}
+
+export const AGENT_MCP_AUTH_TOKEN_FILENAME = "agent-mcp-auth-token";
+
+// Accept any RFC 4122 UUID the daemon previously wrote. The value is a local
+// capability secret, not a version-specific identifier.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function getLogger(logger: LoggerLike | undefined): LoggerLike | undefined {
+  return logger?.child({ module: "agent-mcp-auth-token" });
+}
+
+export function getAgentMcpAuthTokenPath(paseoHome: string): string {
+  return path.join(paseoHome, AGENT_MCP_AUTH_TOKEN_FILENAME);
+}
+
+/**
+ * Capability token authenticating the daemon's own agents to `/mcp/agents`.
+ *
+ * Persisted under `$PASEO_HOME` so a daemon restart can re-inject the same
+ * bearer into resumed Codex threads. The file is local-only (mode 0600) and is
+ * never sent to remote clients.
+ */
+export function getOrCreateAgentMcpAuthToken(
+  paseoHome: string,
+  options?: { logger?: LoggerLike },
+): string {
+  const log = getLogger(options?.logger);
+  const tokenPath = getAgentMcpAuthTokenPath(paseoHome);
+
+  if (existsSync(tokenPath)) {
+    try {
+      ensurePrivateFile(tokenPath);
+      const parsed = readFileSync(tokenPath, "utf8").trim();
+      if (UUID_RE.test(parsed)) {
+        return parsed;
+      }
+      log?.warn("Ignoring invalid persisted Agent MCP auth token, regenerating");
+    } catch (error) {
+      log?.warn({ error }, "Failed to read Agent MCP auth token, regenerating");
+    }
+  }
+
+  const created = randomUUID();
+  try {
+    writePrivateFileAtomicSync(tokenPath, `${created}\n`);
+  } catch (error) {
+    log?.warn({ error }, "Failed to persist Agent MCP auth token (continuing in-memory)");
+  }
+  return created;
+}

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4157,6 +4157,110 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
+  test("rebinds injected MCP servers when resuming an unloaded Codex thread", async () => {
+    const session = createSession({
+      mcpServers: {
+        paseo: {
+          type: "http",
+          url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1",
+          headers: { Authorization: "Bearer cap-token" },
+        },
+      },
+    });
+    session.currentThreadId = "persisted-thread-id";
+    const requests: Array<{ method: string; params: unknown }> = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        if (method === "thread/loaded/list") return { data: [] };
+        if (method === "thread/resume") return {};
+        if (method === "mcpServerStatus/list") return { data: [] };
+        throw new Error(`Unexpected request: ${method}`);
+      }),
+    };
+
+    await asInternals(session).ensureThreadLoaded();
+
+    expect(requests).toEqual([
+      { method: "thread/loaded/list", params: {} },
+      {
+        method: "thread/resume",
+        params: {
+          threadId: "persisted-thread-id",
+          config: {
+            mcp_servers: {
+              paseo: {
+                url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1",
+                http_headers: { Authorization: "Bearer cap-token" },
+              },
+            },
+          },
+        },
+      },
+      {
+        method: "mcpServerStatus/list",
+        params: { threadId: "persisted-thread-id", detail: "toolsAndAuthOnly" },
+      },
+    ]);
+  });
+
+  test("rebinds injected MCP servers on an already-loaded Codex thread", async () => {
+    const session = createSession({
+      mcpServers: {
+        paseo: {
+          type: "http",
+          url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1",
+          headers: { Authorization: "Bearer cap-token" },
+        },
+      },
+    });
+    session.currentThreadId = "persisted-thread-id";
+    const requests: Array<{ method: string; params: unknown }> = [];
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        if (method === "thread/loaded/list") return { data: ["persisted-thread-id"] };
+        if (method === "mcpServerStatus/list") return { data: [] };
+        throw new Error(`Unexpected request: ${method}`);
+      }),
+    };
+
+    await asInternals(session).ensureThreadLoaded();
+
+    expect(requests).toEqual([
+      { method: "thread/loaded/list", params: {} },
+      {
+        method: "mcpServerStatus/list",
+        params: { threadId: "persisted-thread-id", detail: "toolsAndAuthOnly" },
+      },
+    ]);
+  });
+
+  test("keeps a resumed Codex thread when MCP status listing is unavailable", async () => {
+    const session = createSession({
+      mcpServers: {
+        paseo: {
+          type: "http",
+          url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1",
+        },
+      },
+    });
+    session.currentThreadId = "persisted-thread-id";
+    session.client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "thread/loaded/list") return { data: [] };
+        if (method === "thread/resume") return {};
+        if (method === "mcpServerStatus/list") {
+          throw new Error("method not found");
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      }),
+    };
+
+    await expect(asInternals(session).ensureThreadLoaded()).resolves.toBeUndefined();
+    expect(session.currentThreadId).toBe("persisted-thread-id");
+  });
+
   test("appends blank-line spacing to /goal status messages", async () => {
     const requests: Array<{ method: string; params: unknown }> = [];
     const session = createSession({}, { goalsEnabled: true });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3750,23 +3750,23 @@ export class CodexAppServerAgentSession implements AgentSession {
     try {
       const loaded = toObjectRecord(await this.client.request("thread/loaded/list", {}));
       const ids = Array.isArray(loaded?.data) ? loaded.data : [];
-      if (ids.includes(this.currentThreadId)) {
-        return;
+      if (!ids.includes(this.currentThreadId)) {
+        const params: Record<string, unknown> = { threadId: this.currentThreadId };
+        const developerInstructions = composeSystemPromptParts(
+          this.config.systemPrompt,
+          this.config.daemonAppendSystemPrompt,
+        );
+        if (developerInstructions) {
+          params.developerInstructions = developerInstructions;
+        }
+        const codexConfig = this.buildCodexInnerConfig();
+        if (codexConfig) {
+          params.config = codexConfig;
+        }
+        const response = await this.client.request("thread/resume", params);
+        this.rememberResolvedSandboxPolicy(response);
       }
-      const params: Record<string, unknown> = { threadId: this.currentThreadId };
-      const developerInstructions = composeSystemPromptParts(
-        this.config.systemPrompt,
-        this.config.daemonAppendSystemPrompt,
-      );
-      if (developerInstructions) {
-        params.developerInstructions = developerInstructions;
-      }
-      const codexConfig = this.buildCodexInnerConfig();
-      if (codexConfig) {
-        params.config = codexConfig;
-      }
-      const response = await this.client.request("thread/resume", params);
-      this.rememberResolvedSandboxPolicy(response);
+      await this.ensureInjectedMcpServersReady();
     } catch (error) {
       const threadId = this.currentThreadId;
       const message = error instanceof Error ? error.message : String(error);
@@ -3782,6 +3782,34 @@ export class CodexAppServerAgentSession implements AgentSession {
       }
       this.logger.warn({ error, threadId }, "Failed to resume persisted Codex thread");
       throw new Error(`Failed to resume Codex thread ${threadId}: ${message}`, { cause: error });
+    }
+  }
+
+  private hasInjectedMcpServers(): boolean {
+    return Object.keys(this.config.mcpServers ?? {}).length > 0;
+  }
+
+  /**
+   * Codex keeps injected HTTP MCP on the thread overlay. After a Paseo daemon
+   * restart those connections are dead, and `thread/resume` does not reliably
+   * re-list tools. `mcpServerStatus/list` forces the thread's runtime MCP
+   * config to initialize without reloading disk config (which would drop the
+   * app-injected `paseo` server on Codex 0.147).
+   */
+  private async ensureInjectedMcpServersReady(): Promise<void> {
+    if (!this.client || !this.currentThreadId || !this.hasInjectedMcpServers()) {
+      return;
+    }
+    try {
+      await this.client.request("mcpServerStatus/list", {
+        threadId: this.currentThreadId,
+        detail: "toolsAndAuthOnly",
+      });
+    } catch (error) {
+      this.logger.debug(
+        { err: error, threadId: this.currentThreadId },
+        "Codex mcpServerStatus/list is unavailable; injected MCP may stay disconnected until the next turn",
+      );
     }
   }
 

--- a/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
+++ b/packages/server/src/server/agent/providers/codex/test-utils/fake-app-server.ts
@@ -138,6 +138,7 @@ export function createFakeCodexAppServer(
     "thread/start": () => ({ thread: { id: "thread-1" } }),
     "thread/loaded/list": () => ({ data: [] }),
     "thread/resume": () => ({}),
+    "mcpServerStatus/list": () => ({ data: [], next_cursor: null }),
     "turn/start": () => ({}),
     "thread/fork": (params) => ({
       thread: {

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -2,7 +2,6 @@ import express from "express";
 import { createServer as createHTTPServer, type IncomingMessage, type ServerResponse } from "http";
 import { constants, existsSync, unlinkSync } from "fs";
 import { open } from "fs/promises";
-import { randomUUID } from "node:crypto";
 import { hostname as getHostname } from "node:os";
 import path from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -166,6 +165,7 @@ import { loadOrCreateDaemonKeyPair } from "./daemon-keypair.js";
 import { createRelayRuntime, type RelayRuntime } from "./relay-runtime.js";
 import type { PushNotificationSender } from "./push/index.js";
 import { getOrCreateServerId } from "./server-id.js";
+import { getOrCreateAgentMcpAuthToken } from "./agent-mcp-auth-token.js";
 import { resolveDaemonVersion } from "./daemon-version.js";
 import type { AgentClient, AgentProvider } from "./agent/agent-sdk-types.js";
 import type { AgentProfile, FirstAgentContext, TerminalProfile } from "@getpaseo/protocol/messages";
@@ -582,13 +582,14 @@ export async function createPaseoDaemon(
   });
 
   // Capability token authenticating the daemon's own agents to the loopback
-  // Agent MCP endpoint (/mcp/agents). Random per daemon run, injected only into
-  // local agent configs and the daemon's own MCP client — never sent to remote
-  // clients — so it cannot be replayed off-box. This lets the injected MCP
-  // authenticate even when the daemon password is set via the app (hash only,
-  // no plaintext available). Mirrors the /api/files/download capability-token
-  // pattern.
-  const agentMcpAuthToken = randomUUID();
+  // Agent MCP endpoint (/mcp/agents). Persisted under $PASEO_HOME so a daemon
+  // restart can re-inject the same bearer into resumed provider sessions.
+  // Injected only into local agent configs and the daemon's own MCP client —
+  // never sent to remote clients — so it cannot be replayed off-box. This lets
+  // the injected MCP authenticate even when the daemon password is set via the
+  // app (hash only, no plaintext available). Mirrors the /api/files/download
+  // capability-token pattern.
+  const agentMcpAuthToken = getOrCreateAgentMcpAuthToken(config.paseoHome, { logger });
 
   const listenTarget = parseListenString(config.listen);
 

--- a/public-docs/mcp.md
+++ b/public-docs/mcp.md
@@ -14,7 +14,7 @@ Paseo can inject these tools into every new agent it launches. Open **Settings â
 
 Depending on the provider, Paseo delivers the catalog through its native tool interface or MCP. The capabilities are the same either way.
 
-The MCP server itself is controlled by `daemon.mcp.enabled`. Existing agents may need a reload.
+The MCP server itself is controlled by `daemon.mcp.enabled`. Codex sessions rebind injected Paseo tools on resume after a daemon restart; other providers may still need a reload.
 
 ## Mental model
 


### PR DESCRIPTION
### Linked issue

Closes #3283

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

After a daemon restart, continuing an existing Codex conversation no longer exposes injected Paseo MCP tools (`create_agent`, `list_agents`, …). A brand-new Codex conversation on the same daemon does. That forces users to throw away the original Codex thread (and its prompt cache) just to get orchestration tools back.

Two small daemon-side gaps cause this:

1. The `/mcp/agents` capability token was `randomUUID()` per process, so resumed threads still holding the previous bearer could not authenticate once a password is set, and the overlay was not stable across restarts.
2. Codex `ensureThreadLoaded()` returned early when the thread was already in `thread/loaded/list`, so it never re-sent `config.mcp_servers`. Codex 0.147 also ignores `thread/resume` `config` overlays on loaded threads. `mcpServer/refresh` is unsafe here: that Codex build reloads from disk and drops app-injected MCP servers.

This PR persists the local capability token under `$PASEO_HOME` (mode 0600, never sent to remote clients) and, after resume, calls `mcpServerStatus/list` on the thread so Codex initializes the runtime overlay without a disk reload.

### Goals

- Existing Codex threads keep injected Paseo MCP tools across `paseo daemon restart` without creating a new conversation.
- The Agent MCP bearer is stable for a given `$PASEO_HOME`.
- Missing `mcpServerStatus/list` on older Codex must not fail resume.

### Non-goals

- Making Codex native `supportsNativePaseoTools` (see #3009 / #1933).
- Changing `mcpServer/refresh` / writing `paseo` into `~/.codex/config.toml`.
- Live end-to-end daemon-restart QA on this host (restarting the daemon kills running agents). Coverage is unit tests plus the repro in #3283.

### QA

Unit tests (vitest 4.1.7, from a checkout of this branch against an existing `node_modules`):

```text
✓ getOrCreateAgentMcpAuthToken > creates and reuses a stable token per PASEO_HOME
✓ getOrCreateAgentMcpAuthToken > regenerates when the persisted value is not a UUID
✓ getOrCreateAgentMcpAuthToken > file permissions > creates the token file with private permissions
✓ getOrCreateAgentMcpAuthToken > file permissions > repairs existing token file permissions when loading
✓ resumeSession does not replace a persisted Codex thread when app-server resume fails
✓ does not replace a persisted Codex thread when app-server resume fails
✓ rebinds injected MCP servers when resuming an unloaded Codex thread
✓ rebinds injected MCP servers on an already-loaded Codex thread
✓ keeps a resumed Codex thread when MCP status listing is unavailable

Test Files  2 passed (2)
     Tests  9 passed | 126 skipped (135)
```

Command:

```bash
npx vitest run \
  packages/server/src/server/agent-mcp-auth-token.test.ts \
  packages/server/src/server/agent/providers/codex-app-server-agent.test.ts \
  -t "rebinds injected MCP|keeps a resumed Codex thread|getOrCreateAgentMcpAuthToken|does not replace a persisted Codex thread"
```

Not tested here: live `paseo daemon restart` against a long Codex thread (would terminate other running agents on this machine). Platforms not tested: macOS, Windows, iOS, Android, web UI.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes (not run; change is server-only + docs)
- [ ] `npm run lint` passes (not run)
- [ ] `npm run format` passes (not run)
- [x] QA evidence
- [x] Tests added or updated where it made sense

Made with [Cursor](https://cursor.com)