### PR TITLE
feat: add complete MiniMax TTS support

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -125,6 +125,7 @@ import { createPaseoWorktreeWorkflow } from "./worktree-session.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
 import type { OpenAiSpeechProviderConfig } from "./speech/providers/openai/config.js";
 import type { LocalSpeechProviderConfig } from "./speech/providers/local/config.js";
+import type { MiniMaxSpeechProviderConfig } from "./speech/providers/minimax/config.js";
 import type { RequestedSpeechProviders } from "./speech/speech-types.js";
 import { createSpeechService } from "./speech/speech-runtime.js";
 import { AgentManager } from "./agent/agent-manager.js";
@@ -349,6 +350,7 @@ function summarizeAgentMcpDebugBody(body: unknown): Record<string, unknown> {
 }
 
 export type PaseoOpenAIConfig = OpenAiSpeechProviderConfig;
+export type PaseoMiniMaxConfig = MiniMaxSpeechProviderConfig;
 export type PaseoLocalSpeechConfig = LocalSpeechProviderConfig;
 
 export interface PaseoSpeechSttLanguages {
@@ -419,6 +421,7 @@ export interface PaseoDaemonConfig {
   };
   appBaseUrl?: string;
   auth?: DaemonAuthConfig;
+  minimax?: PaseoMiniMaxConfig;
   openai?: PaseoOpenAIConfig;
   speech?: PaseoSpeechConfig;
   voiceLlmProvider?: AgentProvider | null;
@@ -1419,6 +1422,7 @@ export async function createPaseoDaemon(
 
   const speechService = createSpeechService({
     logger,
+    minimaxConfig: config.minimax,
     openaiConfig: config.openai,
     speechConfig: config.speech,
   });

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -506,7 +506,7 @@ export function loadConfig(
   const serviceProxy = resolveServiceProxyConfig(env, persisted);
   const webUi = resolveWebUiConfig(paseoHome, env, options?.cli, persisted);
 
-  const { openai, speech } = resolveSpeechConfig({
+  const { minimax, openai, speech } = resolveSpeechConfig({
     paseoHome,
     env,
     persisted,
@@ -549,6 +549,7 @@ export function loadConfig(
     webUi,
     appBaseUrl,
     auth: resolveAuthConfig(env, persisted),
+    minimax,
     openai,
     speech,
     voiceLlmProvider: voiceLlm.provider,

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -68,10 +68,27 @@ const LocalSpeechProviderSchema = z
   })
   .strict();
 
+const MiniMaxSpeechEndpointSchema = z
+  .object({
+    apiKey: z.string().trim().min(1).optional(),
+    baseUrl: z.string().trim().url().optional(),
+  })
+  .strict();
+
+const MiniMaxProviderSchema = z
+  .object({
+    apiKey: z.string().trim().min(1).optional(),
+    baseUrl: z.string().trim().url().optional(),
+    region: z.enum(["global_en", "cn_zh"]).optional(),
+    tts: MiniMaxSpeechEndpointSchema.optional(),
+  })
+  .strict();
+
 const ProvidersSchema = z
   .object({
     openai: OpenAiProviderSchema.optional(),
     local: LocalSpeechProviderSchema.optional(),
+    minimax: MiniMaxProviderSchema.optional(),
   })
   .strict();
 
@@ -96,7 +113,7 @@ const SpeechProviderIdSchema = z
   .string()
   .trim()
   .toLowerCase()
-  .pipe(z.enum(["openai", "local"]));
+  .pipe(z.enum(["openai", "local", "minimax"]));
 
 const FeatureDictationSchema = z
   .object({
@@ -141,7 +158,7 @@ const FeatureVoiceModeSchema = z
       .object({
         provider: SpeechProviderIdSchema.optional(),
         model: z.string().min(1).optional(),
-        voice: z.enum(["alloy", "echo", "fable", "onyx", "nova", "shimmer"]).optional(),
+        voice: z.string().trim().min(1).optional(),
         speakerId: z.number().int().optional(),
         speed: z.number().optional(),
       })

--- a/packages/server/src/server/speech/providers/minimax/config.test.ts
+++ b/packages/server/src/server/speech/providers/minimax/config.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import { PersistedConfigSchema } from "../../../persisted-config.js";
+import {
+  MINIMAX_TTS_AUDIO_FORMATS,
+  MINIMAX_TTS_MODELS,
+  resolveMiniMaxSpeechConfig,
+} from "./config.js";
+
+describe("resolveMiniMaxSpeechConfig", () => {
+  test("registers every supported model and audio format", () => {
+    expect(MINIMAX_TTS_MODELS).toEqual([
+      "speech-2.8-hd",
+      "speech-2.8-turbo",
+      "speech-2.6-hd",
+      "speech-2.6-turbo",
+      "speech-02-hd",
+      "speech-02-turbo",
+      "speech-01-hd",
+      "speech-01-turbo",
+    ]);
+    expect(MINIMAX_TTS_AUDIO_FORMATS).toEqual(["mp3", "wav", "flac", "pcm"]);
+  });
+
+  test("resolves China routing and feature-level model settings", () => {
+    const persisted = PersistedConfigSchema.parse({
+      providers: {
+        minimax: { apiKey: "test-key", region: "cn_zh" },
+      },
+      features: {
+        voiceMode: {
+          tts: {
+            provider: "minimax",
+            model: "speech-2.6-turbo",
+            voice: "test-voice",
+          },
+        },
+      },
+    });
+    const config = resolveMiniMaxSpeechConfig({
+      env: { MINIMAX_TTS_FORMAT: "flac" },
+      persisted,
+      providers: {
+        dictationStt: { provider: "local", explicit: false },
+        voiceTurnDetection: { provider: "local", explicit: false },
+        voiceStt: { provider: "local", explicit: false },
+        voiceTts: { provider: "minimax", explicit: true },
+      },
+    });
+
+    expect(config?.tts).toEqual({
+      apiKey: "test-key",
+      model: "speech-2.6-turbo",
+      region: "cn_zh",
+      responseFormat: "flac",
+      voiceId: "test-voice",
+    });
+  });
+});

--- a/packages/server/src/server/speech/providers/minimax/config.ts
+++ b/packages/server/src/server/speech/providers/minimax/config.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import type { PersistedConfig } from "../../../persisted-config.js";
+import type { RequestedSpeechProviders } from "../../speech-types.js";
+import type { MiniMaxTTSConfig } from "./tts.js";
+
+export const MINIMAX_TTS_MODELS = [
+  "speech-2.8-hd",
+  "speech-2.8-turbo",
+  "speech-2.6-hd",
+  "speech-2.6-turbo",
+  "speech-02-hd",
+  "speech-02-turbo",
+  "speech-01-hd",
+  "speech-01-turbo",
+] as const;
+
+export const MINIMAX_TTS_REGIONS = ["global_en", "cn_zh"] as const;
+export const MINIMAX_TTS_AUDIO_FORMATS = ["mp3", "wav", "flac", "pcm"] as const;
+
+export const DEFAULT_MINIMAX_TTS_MODEL = "speech-2.8-hd";
+export const DEFAULT_MINIMAX_TTS_REGION = "global_en";
+
+const MiniMaxTtsModelSchema = z.enum(MINIMAX_TTS_MODELS);
+const MiniMaxTtsRegionSchema = z.enum(MINIMAX_TTS_REGIONS);
+const MiniMaxTtsAudioFormatSchema = z.enum(MINIMAX_TTS_AUDIO_FORMATS);
+
+const OptionalTrimmedStringSchema = z
+  .string()
+  .trim()
+  .optional()
+  .transform((value) => (value && value.length > 0 ? value : undefined));
+
+const MiniMaxTtsOptionsSchema = z.object({
+  model: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .pipe(MiniMaxTtsModelSchema)
+    .default(DEFAULT_MINIMAX_TTS_MODEL),
+  region: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .pipe(MiniMaxTtsRegionSchema)
+    .default(DEFAULT_MINIMAX_TTS_REGION),
+  format: z.string().trim().toLowerCase().pipe(MiniMaxTtsAudioFormatSchema).default("mp3"),
+  voiceId: OptionalTrimmedStringSchema,
+});
+
+export interface MiniMaxSpeechProviderConfig {
+  tts?: Partial<MiniMaxTTSConfig> & { apiKey?: string };
+}
+
+interface MiniMaxTtsSources {
+  env: NodeJS.ProcessEnv;
+  persisted: PersistedConfig;
+  provider: NonNullable<NonNullable<PersistedConfig["providers"]>["minimax"]> | undefined;
+  selectedTts: boolean;
+}
+
+function firstDefined<T>(values: Array<T | null | undefined>): T | undefined {
+  for (const value of values) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === "string" && value.trim().length === 0) continue;
+    return value;
+  }
+  return undefined;
+}
+
+function resolveMiniMaxTtsOptions(sources: MiniMaxTtsSources) {
+  const { env, persisted, provider, selectedTts } = sources;
+  return MiniMaxTtsOptionsSchema.parse({
+    model: firstDefined([
+      env.MINIMAX_TTS_MODEL,
+      selectedTts ? persisted.features?.voiceMode?.tts?.model : undefined,
+      DEFAULT_MINIMAX_TTS_MODEL,
+    ]),
+    region: firstDefined([env.MINIMAX_REGION, provider?.region, DEFAULT_MINIMAX_TTS_REGION]),
+    format: firstDefined([env.MINIMAX_TTS_FORMAT, "mp3"]),
+    voiceId: firstDefined([
+      env.MINIMAX_TTS_VOICE,
+      selectedTts ? persisted.features?.voiceMode?.tts?.voice : undefined,
+    ]),
+  });
+}
+
+export function resolveMiniMaxSpeechConfig(params: {
+  env: NodeJS.ProcessEnv;
+  persisted: PersistedConfig;
+  providers: RequestedSpeechProviders;
+}): MiniMaxSpeechProviderConfig | undefined {
+  const { env, persisted, providers } = params;
+  const provider = persisted.providers?.minimax;
+  const apiKey = firstDefined([provider?.tts?.apiKey, provider?.apiKey, env.MINIMAX_API_KEY]);
+
+  if (!apiKey) return undefined;
+
+  const selectedTts =
+    providers.voiceTts.enabled !== false && providers.voiceTts.provider === "minimax";
+  const options = resolveMiniMaxTtsOptions({ env, persisted, provider, selectedTts });
+  const baseUrl = firstDefined([
+    provider?.tts?.baseUrl,
+    provider?.baseUrl,
+    env.MINIMAX_TTS_BASE_URL,
+    env.MINIMAX_BASE_URL,
+  ]);
+
+  return {
+    tts: {
+      apiKey,
+      model: options.model,
+      region: options.region,
+      responseFormat: options.format,
+      ...(options.voiceId ? { voiceId: options.voiceId } : {}),
+      ...(baseUrl ? { baseUrl } : {}),
+    },
+  };
+}

--- a/packages/server/src/server/speech/providers/minimax/runtime.test.ts
+++ b/packages/server/src/server/speech/providers/minimax/runtime.test.ts
@@ -1,0 +1,24 @@
+import pino from "pino";
+import { describe, expect, test } from "vitest";
+
+import { initializeMiniMaxTts } from "./runtime.js";
+import { MiniMaxTTS } from "./tts.js";
+
+describe("initializeMiniMaxTts", () => {
+  test("initializes the selected TTS provider", () => {
+    const result = initializeMiniMaxTts({
+      providers: {
+        dictationStt: { provider: "local", explicit: false },
+        voiceTurnDetection: { provider: "local", explicit: false },
+        voiceStt: { provider: "local", explicit: false },
+        voiceTts: { provider: "minimax", explicit: true },
+      },
+      config: { tts: { apiKey: "test-key", model: "speech-2.8-hd" } },
+      existing: null,
+      logger: pino({ level: "silent" }),
+    });
+
+    expect(result.service).toBeInstanceOf(MiniMaxTTS);
+    expect(result.provider).toBe(result.service);
+  });
+});

--- a/packages/server/src/server/speech/providers/minimax/runtime.ts
+++ b/packages/server/src/server/speech/providers/minimax/runtime.ts
@@ -1,0 +1,38 @@
+import type { Logger } from "pino";
+
+import type { TextToSpeechProvider } from "../../speech-provider.js";
+import type { RequestedSpeechProviders } from "../../speech-types.js";
+import type { MiniMaxSpeechProviderConfig } from "./config.js";
+import { MiniMaxTTS } from "./tts.js";
+
+export function getMiniMaxSpeechAvailability(config: MiniMaxSpeechProviderConfig | undefined): {
+  tts: boolean;
+} {
+  return { tts: Boolean(config?.tts?.apiKey) };
+}
+
+export function initializeMiniMaxTts(params: {
+  providers: RequestedSpeechProviders;
+  config: MiniMaxSpeechProviderConfig | undefined;
+  existing: TextToSpeechProvider | null;
+  logger: Logger;
+}): { service: TextToSpeechProvider | null; provider: MiniMaxTTS | null } {
+  const needsMiniMax =
+    !params.existing &&
+    params.providers.voiceTts.enabled !== false &&
+    params.providers.voiceTts.provider === "minimax";
+  const apiKey = params.config?.tts?.apiKey;
+  if (!needsMiniMax || !apiKey) {
+    if (needsMiniMax) {
+      params.logger.warn(
+        "Invalid speech configuration: MiniMax provider selected but credentials are missing",
+      );
+    }
+    return { service: params.existing, provider: null };
+  }
+
+  const { apiKey: _apiKey, ...config } = params.config?.tts ?? {};
+  const provider = new MiniMaxTTS({ apiKey, ...config }, params.logger);
+  params.logger.info("MiniMax speech provider initialized");
+  return { service: provider, provider };
+}

--- a/packages/server/src/server/speech/providers/minimax/tts.test.ts
+++ b/packages/server/src/server/speech/providers/minimax/tts.test.ts
@@ -1,0 +1,138 @@
+import pino from "pino";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { MiniMaxTTS, resolveMiniMaxTtsUrls } from "./tts.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("MiniMaxTTS", () => {
+  test("routes global and China operations to their regional hosts", () => {
+    expect(resolveMiniMaxTtsUrls({ apiKey: "test", region: "global_en" })).toEqual({
+      synthesis: "https://api.minimax.io/v1/t2a_v2",
+      asyncCreate: "https://api.minimax.io/v1/t2a_async_v2",
+      asyncQuery: "https://api.minimax.io/v1/query/t2a_async_query_v2",
+      websocket: "wss://api.minimax.io/ws/v1/t2a_v2",
+    });
+    expect(resolveMiniMaxTtsUrls({ apiKey: "test", region: "cn_zh" })).toEqual({
+      synthesis: "https://api.minimaxi.com/v1/t2a_v2",
+      asyncCreate: "https://api.minimaxi.com/v1/t2a_async_v2",
+      asyncQuery: "https://api.minimaxi.com/v1/query/t2a_async_query_v2",
+      websocket: "wss://api.minimaxi.com/ws/v1/t2a_v2",
+    });
+  });
+
+  test("synthesizes hex audio with the complete request options", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ data: { audio: "6869", status: "success" }, base_resp: { status_code: 0 } }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new MiniMaxTTS(
+      {
+        apiKey: "test-key",
+        region: "cn_zh",
+        model: "speech-2.8-turbo",
+        voiceId: "test-voice",
+        responseFormat: "wav",
+      },
+      pino({ level: "silent" }),
+    );
+
+    const result = await provider.synthesizeSpeech("hello", {
+      languageBoost: "English",
+      pronunciationDictionary: { tone: ["Paseo/(pəˈseɪoʊ)"] },
+      voiceModify: { pitch: 2 },
+      subtitleEnabled: true,
+      audioSetting: { format: "pcm", sampleRate: 32_000, bitrate: 128_000, channel: 1 },
+    });
+    const chunks: Buffer[] = [];
+    for await (const chunk of result.stream) chunks.push(Buffer.from(chunk));
+
+    expect(Buffer.concat(chunks).toString()).toBe("hi");
+    expect(result.format).toBe("pcm");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.minimaxi.com/v1/t2a_v2",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-key",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(request.body))).toEqual({
+      model: "speech-2.8-turbo",
+      text: "hello",
+      stream: false,
+      output_format: "hex",
+      language_boost: "English",
+      voice_setting: { voice_id: "test-voice" },
+      pronunciation_dict: { tone: ["Paseo/(pəˈseɪoʊ)"] },
+      audio_setting: { format: "pcm", sample_rate: 32_000, bitrate: 128_000, channel: 1 },
+      voice_modify: { pitch: 2 },
+      subtitle_enable: true,
+    });
+  });
+
+  test("supports asynchronous create and query operations", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ task_id: "task-1", task_token: "token-1", file_id: 12 }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ task_id: "task-1", status: "Success", file_id: 12 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new MiniMaxTTS({ apiKey: "test-key" }, pino({ level: "silent" }));
+
+    await expect(provider.createAsyncSpeech("hello")).resolves.toEqual({
+      taskId: "task-1",
+      taskToken: "token-1",
+      fileId: 12,
+    });
+    await expect(provider.queryAsyncSpeech("task-1")).resolves.toEqual({
+      taskId: "task-1",
+      status: "Success",
+      fileId: 12,
+    });
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://api.minimax.io/v1/t2a_async_v2",
+      "https://api.minimax.io/v1/query/t2a_async_query_v2",
+    ]);
+    const createRequest = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(JSON.parse(String(createRequest?.body))).toEqual({
+      model: "speech-2.8-hd",
+      text: "hello",
+      audio_setting: { format: "mp3" },
+    });
+    const queryRequest = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
+    expect(JSON.parse(String(queryRequest?.body))).toEqual({
+      task_id: "task-1",
+    });
+  });
+
+  test("builds a streaming WebSocket request with required fields", () => {
+    const provider = new MiniMaxTTS(
+      { apiKey: "test-key", model: "speech-01-hd" },
+      pino({ level: "silent" }),
+    );
+
+    expect(provider.buildWebSocketRequest("hello")).toEqual({
+      model: "speech-01-hd",
+      text: "hello",
+      stream: true,
+      output_format: "hex",
+      audio_setting: { format: "mp3" },
+    });
+  });
+});

--- a/packages/server/src/server/speech/providers/minimax/tts.ts
+++ b/packages/server/src/server/speech/providers/minimax/tts.ts
@@ -1,0 +1,297 @@
+import { Readable } from "node:stream";
+import type pino from "pino";
+import { WebSocket } from "ws";
+
+import type { SpeechStreamResult, TextToSpeechProvider } from "../../speech-provider.js";
+import {
+  DEFAULT_MINIMAX_TTS_MODEL,
+  DEFAULT_MINIMAX_TTS_REGION,
+  type MINIMAX_TTS_AUDIO_FORMATS,
+  type MINIMAX_TTS_MODELS,
+  type MINIMAX_TTS_REGIONS,
+} from "./config.js";
+
+export type MiniMaxTtsModel = (typeof MINIMAX_TTS_MODELS)[number];
+export type MiniMaxTtsRegion = (typeof MINIMAX_TTS_REGIONS)[number];
+export type MiniMaxTtsAudioFormat = (typeof MINIMAX_TTS_AUDIO_FORMATS)[number];
+
+export const MINIMAX_TTS_ENDPOINTS: Record<MiniMaxTtsRegion, string> = {
+  global_en: "https://api.minimax.io/v1/t2a_v2",
+  cn_zh: "https://api.minimaxi.com/v1/t2a_v2",
+};
+
+export interface MiniMaxVoiceSetting {
+  voiceId: string;
+  speed?: number;
+  volume?: number;
+  pitch?: number;
+  emotion?: string;
+}
+
+export interface MiniMaxAudioSetting {
+  format?: MiniMaxTtsAudioFormat;
+  sampleRate?: number;
+  bitrate?: number;
+  channel?: number;
+}
+
+export interface MiniMaxSynthesisOptions {
+  languageBoost?: string;
+  outputFormat?: "hex" | "url";
+  voiceSetting?: MiniMaxVoiceSetting;
+  pronunciationDictionary?: { tone: string[] };
+  audioSetting?: MiniMaxAudioSetting;
+  voiceModify?: Record<string, unknown>;
+  subtitleEnabled?: boolean;
+}
+
+export interface MiniMaxTTSConfig {
+  apiKey: string;
+  baseUrl?: string;
+  region?: MiniMaxTtsRegion;
+  model?: MiniMaxTtsModel;
+  voiceId?: string;
+  responseFormat?: MiniMaxTtsAudioFormat;
+}
+
+export interface MiniMaxAsyncTask {
+  taskId?: string;
+  taskToken?: string;
+  fileId?: number;
+}
+
+export interface MiniMaxAsyncStatus {
+  taskId?: string;
+  status?: string;
+  fileId?: number;
+}
+
+interface MiniMaxApiResponse {
+  data?: {
+    audio?: string;
+    status?: string;
+    task_id?: string;
+    task_token?: string;
+    file_id?: number;
+  };
+  task_id?: string;
+  task_token?: string;
+  file_id?: number;
+  status?: string;
+  base_resp?: {
+    status_code?: number;
+    status_msg?: string;
+  };
+}
+
+type MiniMaxRequest = Record<string, unknown>;
+
+function buildVoiceSetting(setting: MiniMaxVoiceSetting): Record<string, unknown> {
+  const result: Record<string, unknown> = { voice_id: setting.voiceId };
+  if (setting.speed !== undefined) result.speed = setting.speed;
+  if (setting.volume !== undefined) result.vol = setting.volume;
+  if (setting.pitch !== undefined) result.pitch = setting.pitch;
+  if (setting.emotion) result.emotion = setting.emotion;
+  return result;
+}
+
+function buildAudioSetting(
+  setting: MiniMaxAudioSetting | undefined,
+  defaultFormat: MiniMaxTtsAudioFormat,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { format: setting?.format ?? defaultFormat };
+  if (setting?.sampleRate !== undefined) result.sample_rate = setting.sampleRate;
+  if (setting?.bitrate !== undefined) result.bitrate = setting.bitrate;
+  if (setting?.channel !== undefined) result.channel = setting.channel;
+  return result;
+}
+
+function endpointForPath(config: MiniMaxTTSConfig, path: string): string {
+  const synthesisEndpoint =
+    config.baseUrl ?? MINIMAX_TTS_ENDPOINTS[config.region ?? DEFAULT_MINIMAX_TTS_REGION];
+  const url = new URL(synthesisEndpoint);
+  url.pathname = path;
+  url.search = "";
+  return url.toString();
+}
+
+export function resolveMiniMaxTtsUrls(config: MiniMaxTTSConfig): {
+  synthesis: string;
+  asyncCreate: string;
+  asyncQuery: string;
+  websocket: string;
+} {
+  const websocket = new URL(endpointForPath(config, "/ws/v1/t2a_v2"));
+  websocket.protocol = "wss:";
+  return {
+    synthesis: endpointForPath(config, "/v1/t2a_v2"),
+    asyncCreate: endpointForPath(config, "/v1/t2a_async_v2"),
+    asyncQuery: endpointForPath(config, "/v1/query/t2a_async_query_v2"),
+    websocket: websocket.toString(),
+  };
+}
+
+function buildSynthesisRequest(
+  text: string,
+  config: MiniMaxTTSConfig,
+  options: MiniMaxSynthesisOptions,
+  stream: boolean,
+): MiniMaxRequest {
+  const voiceSetting =
+    options.voiceSetting ?? (config.voiceId ? { voiceId: config.voiceId } : null);
+  const request: MiniMaxRequest = {
+    model: config.model ?? DEFAULT_MINIMAX_TTS_MODEL,
+    text,
+    stream,
+    output_format: options.outputFormat ?? "hex",
+    audio_setting: buildAudioSetting(options.audioSetting, config.responseFormat ?? "mp3"),
+  };
+  if (options.languageBoost) request.language_boost = options.languageBoost;
+  if (voiceSetting) request.voice_setting = buildVoiceSetting(voiceSetting);
+  if (options.pronunciationDictionary) {
+    request.pronunciation_dict = options.pronunciationDictionary;
+  }
+  if (options.voiceModify) request.voice_modify = options.voiceModify;
+  if (options.subtitleEnabled !== undefined) request.subtitle_enable = options.subtitleEnabled;
+  return request;
+}
+
+function buildAsyncRequest(
+  text: string,
+  config: MiniMaxTTSConfig,
+  options: MiniMaxSynthesisOptions,
+): MiniMaxRequest {
+  const request = buildSynthesisRequest(text, config, options, false);
+  delete request.stream;
+  delete request.output_format;
+  delete request.subtitle_enable;
+  return request;
+}
+
+export class MiniMaxTTSError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "MiniMaxTTSError";
+  }
+}
+
+export class MiniMaxTTS implements TextToSpeechProvider {
+  private readonly config: MiniMaxTTSConfig;
+  private readonly logger: pino.Logger;
+
+  constructor(ttsConfig: MiniMaxTTSConfig, parentLogger: pino.Logger) {
+    this.config = {
+      region: DEFAULT_MINIMAX_TTS_REGION,
+      model: DEFAULT_MINIMAX_TTS_MODEL,
+      responseFormat: "mp3",
+      ...ttsConfig,
+    };
+    this.logger = parentLogger.child({ module: "agent", provider: "minimax", component: "tts" });
+  }
+
+  public getConfig(): MiniMaxTTSConfig {
+    return this.config;
+  }
+
+  public async synthesizeSpeech(
+    text: string,
+    options: MiniMaxSynthesisOptions = {},
+  ): Promise<SpeechStreamResult> {
+    const response = await this.request(
+      "/v1/t2a_v2",
+      buildSynthesisRequest(text, this.config, options, false),
+    );
+    const audio = response.data?.audio;
+    if (!audio) {
+      throw new MiniMaxTTSError("MiniMax TTS response did not include audio data");
+    }
+
+    return {
+      stream: Readable.from(Buffer.from(audio, "hex")),
+      format: options.audioSetting?.format ?? this.config.responseFormat ?? "mp3",
+    };
+  }
+
+  public async createAsyncSpeech(
+    text: string,
+    options: MiniMaxSynthesisOptions = {},
+  ): Promise<MiniMaxAsyncTask> {
+    const response = await this.request(
+      "/v1/t2a_async_v2",
+      buildAsyncRequest(text, this.config, options),
+    );
+    return {
+      taskId: response.task_id ?? response.data?.task_id,
+      taskToken: response.task_token ?? response.data?.task_token,
+      fileId: response.file_id ?? response.data?.file_id,
+    };
+  }
+
+  public async queryAsyncSpeech(taskId: string): Promise<MiniMaxAsyncStatus> {
+    const response = await this.request("/v1/query/t2a_async_query_v2", { task_id: taskId });
+    return {
+      taskId: response.task_id ?? response.data?.task_id,
+      status: response.status ?? response.data?.status,
+      fileId: response.file_id ?? response.data?.file_id,
+    };
+  }
+
+  public createWebSocket(): WebSocket {
+    return new WebSocket(resolveMiniMaxTtsUrls(this.config).websocket, {
+      headers: { Authorization: `Bearer ${this.config.apiKey}` },
+    });
+  }
+
+  public buildWebSocketRequest(
+    text: string,
+    options: MiniMaxSynthesisOptions = {},
+  ): MiniMaxRequest {
+    this.validateText(text);
+    return buildSynthesisRequest(text, this.config, options, true);
+  }
+
+  private validateText(text: string): void {
+    if (!text || text.trim().length === 0) {
+      throw new MiniMaxTTSError("Cannot synthesize empty text");
+    }
+  }
+
+  private async request(path: string, body: MiniMaxRequest): Promise<MiniMaxApiResponse> {
+    const text = body.text;
+    if (typeof text === "string") this.validateText(text);
+
+    let response: Response;
+    try {
+      response = await fetch(endpointForPath(this.config, path), {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      throw new MiniMaxTTSError("MiniMax TTS request failed", undefined, { cause: error });
+    }
+
+    const payload: unknown = await response.json().catch(() => null);
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new MiniMaxTTSError("MiniMax TTS returned an invalid response", response.status);
+    }
+    const parsed = payload as MiniMaxApiResponse;
+    const apiStatus = parsed.base_resp?.status_code;
+    if (!response.ok || (apiStatus !== undefined && apiStatus !== 0)) {
+      const detail = parsed.base_resp?.status_msg ?? response.statusText;
+      this.logger.error({ statusCode: response.status, apiStatus }, "MiniMax TTS request failed");
+      throw new MiniMaxTTSError(
+        detail ? `MiniMax TTS request failed: ${detail}` : "MiniMax TTS request failed",
+        response.status,
+      );
+    }
+    return parsed;
+  }
+}

--- a/packages/server/src/server/speech/speech-config-resolver.ts
+++ b/packages/server/src/server/speech/speech-config-resolver.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 
 import type { PersistedConfig } from "../persisted-config.js";
-import type { PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
+import type { PaseoMiniMaxConfig, PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
 import { resolveLocalSpeechConfig } from "./providers/local/config.js";
+import { resolveMiniMaxSpeechConfig } from "./providers/minimax/config.js";
 import { resolveOpenAiSpeechConfig } from "./providers/openai/config.js";
 import {
   SpeechProviderIdSchema,
@@ -148,6 +149,7 @@ export function resolveSpeechConfig(params: {
   env: NodeJS.ProcessEnv;
   persisted: PersistedConfig;
 }): {
+  minimax: PaseoMiniMaxConfig | undefined;
   openai: PaseoOpenAIConfig | undefined;
   speech: PaseoSpeechConfig;
 } {
@@ -169,7 +171,14 @@ export function resolveSpeechConfig(params: {
     providers,
   });
 
+  const minimax = resolveMiniMaxSpeechConfig({
+    env: params.env,
+    persisted: params.persisted,
+    providers,
+  });
+
   return {
+    minimax,
     openai,
     speech: {
       providers,

--- a/packages/server/src/server/speech/speech-runtime.ts
+++ b/packages/server/src/server/speech/speech-runtime.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import type { Logger } from "pino";
 
-import type { PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
+import type { PaseoMiniMaxConfig, PaseoOpenAIConfig, PaseoSpeechConfig } from "../bootstrap.js";
 import type { LocalSpeechModelId } from "./providers/local/config.js";
 import {
   ensureLocalSpeechModels,
@@ -10,6 +10,7 @@ import {
   listLocalSpeechModels,
 } from "./providers/local/models.js";
 import { initializeLocalSpeechServices } from "./providers/local/runtime.js";
+import { getMiniMaxSpeechAvailability, initializeMiniMaxTts } from "./providers/minimax/runtime.js";
 import {
   getOpenAiSpeechAvailability,
   initializeOpenAiSpeechServices,
@@ -314,9 +315,11 @@ function describeRequestedProviders(providers: RequestedSpeechProviders): {
 function resolveVoiceTtsLabel(
   ttsService: TextToSpeechProvider | null,
   localVoiceTtsProvider: TextToSpeechProvider | null,
-): "unavailable" | "local" | "openai" {
+  miniMaxVoiceTtsProvider: TextToSpeechProvider | null,
+): "unavailable" | "local" | "minimax" | "openai" {
   if (!ttsService) return "unavailable";
   if (ttsService === localVoiceTtsProvider) return "local";
+  if (ttsService === miniMaxVoiceTtsProvider) return "minimax";
   return "openai";
 }
 
@@ -326,6 +329,7 @@ function resolveEffectiveProviderIds(params: {
   ttsService: TextToSpeechProvider | null;
   dictationSttService: SpeechToTextProvider | null;
   localVoiceTtsProvider: TextToSpeechProvider | null;
+  miniMaxVoiceTtsProvider: TextToSpeechProvider | null;
 }): {
   dictationStt: string;
   voiceTurnDetection: string;
@@ -336,7 +340,11 @@ function resolveEffectiveProviderIds(params: {
     dictationStt: params.dictationSttService?.id ?? "unavailable",
     voiceTurnDetection: params.turnDetectionService?.id ?? "unavailable",
     voiceStt: params.sttService?.id ?? "unavailable",
-    voiceTts: resolveVoiceTtsLabel(params.ttsService, params.localVoiceTtsProvider),
+    voiceTts: resolveVoiceTtsLabel(
+      params.ttsService,
+      params.localVoiceTtsProvider,
+      params.miniMaxVoiceTtsProvider,
+    ),
   };
 }
 
@@ -356,11 +364,13 @@ export interface SpeechService {
 
 export function createSpeechService(params: {
   logger: Logger;
+  minimaxConfig?: PaseoMiniMaxConfig;
   openaiConfig?: PaseoOpenAIConfig;
   speechConfig?: PaseoSpeechConfig;
 }): SpeechService {
   const logger = params.logger.child({ module: "speech-runtime" });
   const speechConfig = params.speechConfig ?? null;
+  const minimaxConfig = params.minimaxConfig;
   const openaiConfig = params.openaiConfig;
   const providers = resolveRequestedSpeechProviders(speechConfig);
   const requestedProviders = describeRequestedProviders(providers);
@@ -375,6 +385,7 @@ export function createSpeechService(params: {
     {
       requestedProviders,
       availability: {
+        minimax: getMiniMaxSpeechAvailability(minimaxConfig),
         openai: getOpenAiSpeechAvailability(openaiConfig),
       },
     },
@@ -391,6 +402,7 @@ export function createSpeechService(params: {
   } | null = null;
   let localCleanup = () => {};
   let localVoiceTtsProvider: TextToSpeechProvider | null = null;
+  let miniMaxVoiceTtsProvider: TextToSpeechProvider | null = null;
 
   let missingLocalModelIds: LocalSpeechModelId[] = [];
   let backgroundDownloadInProgress = false;
@@ -514,14 +526,21 @@ export function createSpeechService(params: {
       },
       logger,
     });
+    const nextMiniMaxTts = initializeMiniMaxTts({
+      providers,
+      config: minimaxConfig,
+      existing: nextOpenAiSpeech.ttsService,
+      logger,
+    });
 
     const previousLocalCleanup = localCleanup;
     turnDetectionService = nextOpenAiSpeech.turnDetectionService;
     sttService = nextOpenAiSpeech.sttService;
-    ttsService = nextOpenAiSpeech.ttsService;
+    ttsService = nextMiniMaxTts.service;
     dictationSttService = nextOpenAiSpeech.dictationSttService;
     localModelConfig = nextLocalSpeech.localModelConfig;
     localVoiceTtsProvider = nextLocalSpeech.localVoiceTtsProvider;
+    miniMaxVoiceTtsProvider = nextMiniMaxTts.provider;
     localCleanup = nextLocalSpeech.cleanup;
     previousLocalCleanup();
 
@@ -533,6 +552,7 @@ export function createSpeechService(params: {
       ttsService,
       dictationSttService,
       localVoiceTtsProvider,
+      miniMaxVoiceTtsProvider,
     });
     const unavailableFeatures = [
       providers.dictationStt.enabled !== false && !dictationSttService ? "dictation.stt" : null,

--- a/packages/server/src/server/speech/speech-types.ts
+++ b/packages/server/src/server/speech/speech-types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const SpeechProviderIdSchema = z.enum(["openai", "local"]);
+export const SpeechProviderIdSchema = z.enum(["openai", "local", "minimax"]);
 export type SpeechProviderId = z.infer<typeof SpeechProviderIdSchema>;
 
 export const RequestedSpeechProviderSchema = z.object({

--- a/packages/server/src/server/test-utils/paseo-daemon.ts
+++ b/packages/server/src/server/test-utils/paseo-daemon.ts
@@ -6,6 +6,7 @@ import pino from "pino";
 import {
   createPaseoDaemon,
   type PaseoDaemonConfig,
+  type PaseoMiniMaxConfig,
   type PaseoOpenAIConfig,
   type PaseoSpeechConfig,
 } from "../bootstrap.js";
@@ -35,6 +36,7 @@ interface TestPaseoDaemonOptions {
   paseoHomeRoot?: string;
   staticDir?: string;
   cleanup?: boolean;
+  minimax?: PaseoMiniMaxConfig;
   openai?: PaseoOpenAIConfig;
   speech?: PaseoSpeechConfig;
   voiceLlmProvider?: PaseoDaemonConfig["voiceLlmProvider"];
@@ -189,6 +191,7 @@ async function prepareTestDaemonConfig(
     serviceProxy: options.serviceProxy,
     webUi: options.webUi,
     trustedProxies: options.trustedProxies,
+    minimax: options.minimax,
     openai: options.openai,
     speech: options.speech,
     voiceLlmProvider: options.voiceLlmProvider ?? null,


### PR DESCRIPTION
Reason: Add complete MiniMax TTS support with regional routing, the full supported model and audio format catalog, and synchronous HTTP, asynchronous, and WebSocket operations.

This supersedes #274 with an implementation updated for the current speech runtime.

## Summary

- Register MiniMax as a voice TTS provider with global and China endpoint selection.
- Support all eight configured speech models and MP3, WAV, FLAC, and PCM audio.
- Implement synchronous synthesis, asynchronous task creation and querying, and WebSocket request construction.
- Add focused coverage for configuration, runtime selection, request payloads, response parsing, and regional URLs.

## Checks

- `npm exec --workspace=@getpaseo/server vitest -- run src/server/speech/providers/minimax/config.test.ts src/server/speech/providers/minimax/runtime.test.ts src/server/speech/providers/minimax/tts.test.ts --bail=1`
- `npm run lint --` for all changed files
- `npm run typecheck --workspace=@getpaseo/server`
- `npm run build:server`
- `npm run typecheck`
