### PR TITLE
fix(claude): suppress stale compact cancellation

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.redesign.test.ts
@@ -456,6 +456,35 @@ test("interruptActiveTurn only interrupts the active query without info logs", a
   }
 });
 
+test("suppresses a stale successful local-command cancellation after a replacement starts", async () => {
+  const session = await createSession();
+  const events: AgentStreamEvent[] = [];
+  session.subscribe((event) => events.push(event));
+  const internal: {
+    pendingInterruptAbort: boolean;
+    activeForegroundTurnId: string | null;
+    foregroundHasVisibleActivity: boolean;
+    routeSdkMessageFromPump: (message: Record<string, unknown>) => void;
+  } = asInternals(session);
+
+  internal.pendingInterruptAbort = true;
+  internal.activeForegroundTurnId = "replacement-turn";
+  internal.foregroundHasVisibleActivity = true;
+  internal.routeSdkMessageFromPump({
+    type: "result",
+    subtype: "success",
+    result: "Compaction canceled.",
+    usage: { ...buildUsage(), output_tokens: 0 },
+    total_cost_usd: 0,
+  });
+
+  expect(events).toEqual([]);
+  expect(internal.pendingInterruptAbort).toBe(false);
+  expect(internal.activeForegroundTurnId).toBe("replacement-turn");
+
+  await session.close();
+});
+
 test("extracts identifiers from fixture-driven protocol shape variants", () => {
   const fixtures = [
     {

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -3633,11 +3633,12 @@ class ClaudeAgentSession implements AgentSession {
   private shouldSuppressStaleResult(message: SDKMessage): boolean {
     // Suppress stale results from interrupted requests. The cancel path already
     // emitted the terminal event; this result is leftover from the killed API
-    // request. Consume the flag on ANY result so it doesn't linger.
+    // request. Claude reports a canceled built-in /compact as a zero-token
+    // success, so subtype alone is not a reliable stale-result discriminator.
     if (message.type === "result" && this.pendingInterruptAbort) {
-      this.pendingInterruptAbort = false;
-      if (message.subtype !== "success") {
-        this.logger.debug("Suppressing stale non-success result from interrupted request");
+      if (message.subtype !== "success" || this.isCanceledCompactResult(message)) {
+        this.pendingInterruptAbort = false;
+        this.logger.debug("Suppressing stale result from interrupted request");
         return true;
       }
     }
@@ -3646,6 +3647,14 @@ class ClaudeAgentSession implements AgentSession {
       return true;
     }
     return false;
+  }
+
+  private isCanceledCompactResult(message: Extract<SDKMessage, { type: "result" }>): boolean {
+    if (message.subtype !== "success" || message.usage?.output_tokens !== 0) {
+      return false;
+    }
+    const text = typeof message.result === "string" ? message.result.trim().toLowerCase() : "";
+    return text === "compaction canceled." || text === "compaction cancelled.";
   }
 
   private isAssistantishMessage(message: SDKMessage): boolean {
@@ -3692,15 +3701,17 @@ class ClaudeAgentSession implements AgentSession {
     if (events.length === 0) {
       return;
     }
-    if (
+    const pendingInterruptTerminal =
       this.pendingInterruptAbort &&
       message.type === "result" &&
-      events.some((event) => event.type === "turn_completed" || event.type === "turn_failed") &&
-      (!this.activeForegroundTurnId || !this.foregroundHasVisibleActivity)
-    ) {
+      events.some((event) => event.type === "turn_completed" || event.type === "turn_failed");
+    if (pendingInterruptTerminal) {
+      const shouldSuppress = !this.activeForegroundTurnId || !this.foregroundHasVisibleActivity;
       this.pendingInterruptAbort = false;
-      this.logger.debug("Suppressing stale Claude interrupt terminal result");
-      return;
+      if (shouldSuppress) {
+        this.logger.debug("Suppressing stale Claude interrupt terminal result");
+        return;
+      }
     }
     if (
       events.some((event) => event.type === "timeline" && event.item.type === "assistant_message")


### PR DESCRIPTION
### Linked issue

None — live regression reproduced from provider events.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

When an active Claude query is interrupted and a replacement turn starts, the SDK can report the canceled built-in `/compact` as a zero-token successful result whose text is exactly `Compaction canceled.`. The existing interrupt filter treated every successful result as potentially belonging to the replacement, so that stale sentinel could be translated into visible output and a terminal event for the new turn.

This change recognizes that exact provider sentinel while an interrupt result is pending and drops it before translation. Other successful terminal results still reach the existing replacement-turn routing decision.

### Goals

- Suppress the exact zero-token Claude compact-cancellation sentinel after an interrupt.
- Preserve real successful replacement-turn results.
- Lock the reported sequence down with an automated regression test.

### Non-goals

- Deduplicating `/compact` requests in clients or API gateways.
- Filtering arbitrary assistant text that happens to mention compaction.
- Restarting or changing the production daemon as part of this PR.

### QA

RED: the new regression emitted assistant timeline output plus `turn_completed` for the replacement turn before the fix.

GREEN on current `origin/main`:

- `npm run build:server` — passed.
- `npx vitest run packages/server/src/server/agent/providers/claude/agent.redesign.test.ts packages/server/src/server/agent/providers/claude/agent.interrupt-restart-regression.test.ts --bail=1` — 2 files, 32 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — 0 warnings, 0 errors.
- `npm run format:check` — passed.

Not live-tested against the main daemon because restarting port 6767 would interrupt active user agents; the regression routes the exact SDK result shape through `ClaudeAgentSession`.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense