### PR TITLE
feat(server): expand {repoRoot} in worktrees.root

### DIFF
--- a/packages/server/src/server/config-relay.test.ts
+++ b/packages/server/src/server/config-relay.test.ts
@@ -262,4 +262,40 @@ describe("daemon worktree root config", () => {
       path.join(os.tmpdir(), "paseo-custom-worktrees"),
     );
   });
+
+  test("keeps a repo-relative worktrees.root unresolved for per-project expansion", async () => {
+    const home = await createPaseoHome({
+      version: 1,
+      worktrees: { root: "{repoRoot}/.worktrees" },
+    });
+
+    expect(loadConfig(home, { env: {} }).worktreesRoot).toBe("{repoRoot}/.worktrees");
+  });
+
+  test("rejects {repoRoot} outside the first path segment", async () => {
+    const home = await createPaseoHome({
+      version: 1,
+      worktrees: { root: path.join(os.tmpdir(), "shared", "{repoRoot}") },
+    });
+
+    expect(() => loadConfig(home, { env: {} })).toThrow(/first path segment/);
+  });
+
+  test("rejects a repo-relative root that is not separated from the placeholder", async () => {
+    const home = await createPaseoHome({
+      version: 1,
+      worktrees: { root: "{repoRoot}worktrees" },
+    });
+
+    expect(() => loadConfig(home, { env: {} })).toThrow(/path separator/);
+  });
+
+  test("rejects a repo-relative root that climbs out of the repo", async () => {
+    const home = await createPaseoHome({
+      version: 1,
+      worktrees: { root: "{repoRoot}/../shared-worktrees" },
+    });
+
+    expect(() => loadConfig(home, { env: {} })).toThrow(/cannot leave the repo/);
+  });
 });

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolvePaseoNodeEnv } from "./paseo-env.js";
 import { z } from "zod";
-import { expandTilde } from "../utils/path.js";
+import { expandTilde, isRepoRelativeWorktreesRoot } from "../utils/path.js";
 
 import type { PaseoDaemonConfig } from "./bootstrap.js";
 import {
@@ -422,6 +422,12 @@ function resolveWorktreesRoot(
   const configuredRoot = persisted.worktrees?.root?.trim();
   if (!configuredRoot) {
     return undefined;
+  }
+
+  // A repo-relative root has no single answer at startup: it resolves against whichever
+  // repo a worktree is being cut from, so the template travels as-is.
+  if (isRepoRelativeWorktreesRoot(configuredRoot)) {
+    return configuredRoot;
   }
 
   const expandedRoot = expandTilde(configuredRoot);

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -11,6 +11,7 @@ import type { AgentProviderRuntimeSettingsMap } from "./agent/provider-launch-co
 import { ensurePrivateFile, writePrivateFileAtomicSync } from "./private-files.js";
 import { AgentProfileSchema, TerminalProfileSchema } from "@getpaseo/protocol/messages";
 import { PaseoServicePortAllocationSchema } from "@getpaseo/protocol/paseo-config-schema";
+import { repoRelativeWorktreesRootError, REPO_ROOT_PLACEHOLDER } from "../utils/path.js";
 
 export const LogLevelSchema = z.enum(["trace", "debug", "info", "warn", "error", "fatal"]);
 export const LogFormatSchema = z.enum(["pretty", "json"]);
@@ -77,7 +78,19 @@ const ProvidersSchema = z
 
 const WorktreesConfigSchema = z
   .object({
-    root: z.string().min(1).optional(),
+    root: z
+      .string()
+      .min(1)
+      .superRefine((value, context) => {
+        if (!value.includes(REPO_ROOT_PLACEHOLDER)) {
+          return;
+        }
+        const error = repoRelativeWorktreesRootError(value.trim());
+        if (error) {
+          context.addIssue({ code: "custom", message: error });
+        }
+      })
+      .optional(),
     servicePorts: PaseoServicePortAllocationSchema.optional(),
   })
   .strict();

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1021,6 +1021,8 @@ async function getMainRepoRootFromCommonDir(
       !isPaseoWorktreePath(wt.path, {
         paseoHome: context?.paseoHome,
         worktreesRoot: context?.worktreesRoot,
+        // Bare repo: the common dir is the repo root a repo-relative root expands against.
+        repoRoot: normalized,
       }),
   );
   const childrenOfBareRepo = nonBareNonPaseo.filter((wt) => isDescendantPath(wt.path, normalized));
@@ -1037,10 +1039,11 @@ export interface GitWorktreeEntry {
 /** Check whether a path is under Paseo's worktree root. */
 export function isPaseoWorktreePath(
   p: string,
-  options?: { paseoHome?: string; worktreesRoot?: string },
+  options?: { paseoHome?: string; worktreesRoot?: string; repoRoot?: string },
 ): boolean {
   if (options?.worktreesRoot || options?.paseoHome) {
-    return isDescendantPath(p, resolvePaseoWorktreesBaseRoot(options));
+    const baseRoot = resolvePaseoWorktreesBaseRoot(options);
+    return baseRoot !== undefined && isDescendantPath(p, baseRoot);
   }
   return /[/\\]\.paseo[/\\]worktrees[/\\]/.test(p);
 }

--- a/packages/server/src/utils/path.ts
+++ b/packages/server/src/utils/path.ts
@@ -17,6 +17,42 @@ export function expandTilde(path: string): string {
 }
 
 /**
+ * Placeholder in `worktrees.root` that stands for the repo root a worktree is cut from,
+ * so one global setting can keep every project's worktrees inside that project.
+ */
+export const REPO_ROOT_PLACEHOLDER = "{repoRoot}";
+
+/** True when `worktrees.root` is resolved per project instead of once at startup. */
+export function isRepoRelativeWorktreesRoot(
+  worktreesRoot: string | undefined,
+): worktreesRoot is string {
+  return worktreesRoot?.startsWith(REPO_ROOT_PLACEHOLDER) ?? false;
+}
+
+/** The literal part of a repo-relative `worktrees.root`, as path segments. */
+export function repoRelativeWorktreesRootSegments(worktreesRoot: string): string[] {
+  return worktreesRoot
+    .slice(REPO_ROOT_PLACEHOLDER.length)
+    .split(/[/\\]/)
+    .filter((segment) => segment.length > 0);
+}
+
+/** Why a `worktrees.root` containing the placeholder is unusable, if it is. */
+export function repoRelativeWorktreesRootError(worktreesRoot: string): string | undefined {
+  if (!isRepoRelativeWorktreesRoot(worktreesRoot)) {
+    return `${REPO_ROOT_PLACEHOLDER} is only supported as the first path segment`;
+  }
+  const remainder = worktreesRoot.slice(REPO_ROOT_PLACEHOLDER.length);
+  if (remainder.length > 0 && !/^[/\\]/.test(remainder)) {
+    return `${REPO_ROOT_PLACEHOLDER} must be followed by a path separator`;
+  }
+  if (repoRelativeWorktreesRootSegments(worktreesRoot).includes("..")) {
+    return `${REPO_ROOT_PLACEHOLDER} paths cannot leave the repo with ".."`;
+  }
+  return undefined;
+}
+
+/**
  * Compare two path strings as filesystem-equivalent for cwd filtering.
  *
  * This is a string-only comparison: it normalizes separators and dot segments,

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -163,6 +163,68 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(existsSync(result.worktreePath)).toBe(false);
     });
 
+    it("creates and owns worktrees under a repo-relative root", async () => {
+      const worktreesRoot = "{repoRoot}/.worktrees";
+      const projectHash = await deriveWorktreeProjectHash(repoDir);
+      const result = await createLegacyWorktreeForTest({
+        branchName: "repo-relative",
+        cwd: repoDir,
+        baseBranch: "main",
+        worktreeSlug: "repo-relative",
+        paseoHome,
+        worktreesRoot,
+      });
+
+      expect(result.worktreePath).toBe(join(repoDir, ".worktrees", projectHash, "repo-relative"));
+      await expect(
+        isPaseoOwnedWorktreeCwd(result.worktreePath, { paseoHome, worktreesRoot }),
+      ).resolves.toMatchObject({
+        allowed: true,
+        worktreeRoot: join(repoDir, ".worktrees", projectHash),
+      });
+      await expect(
+        isPaseoOwnedWorktreeCwd(join(result.worktreePath, "packages", "app"), {
+          paseoHome,
+          worktreesRoot,
+        }),
+      ).resolves.toMatchObject({ allowed: true });
+
+      const worktrees = await listPaseoWorktrees({ cwd: repoDir, paseoHome, worktreesRoot });
+      expect(worktrees.map((entry) => entry.path)).toContain(result.worktreePath);
+
+      await deletePaseoWorktree({
+        cwd: repoDir,
+        worktreePath: result.worktreePath,
+        paseoHome,
+        worktreesBaseRoot: worktreesRoot,
+      });
+      expect(existsSync(result.worktreePath)).toBe(false);
+    });
+
+    it("owns a repo-relative worktree whose git admin file is gone", async () => {
+      const worktreesRoot = "{repoRoot}/.worktrees";
+      const projectHash = await deriveWorktreeProjectHash(repoDir);
+      const result = await createLegacyWorktreeForTest({
+        branchName: "orphaned",
+        cwd: repoDir,
+        baseBranch: "main",
+        worktreeSlug: "orphaned",
+        paseoHome,
+        worktreesRoot,
+      });
+
+      // Archive has to keep working after a half-finished cleanup. The worktree lives
+      // inside the repo, so git still reaches the repo's own admin dir from here.
+      rmSync(join(result.worktreePath, ".git"), { force: true });
+
+      await expect(
+        isPaseoOwnedWorktreeCwd(result.worktreePath, { paseoHome, worktreesRoot }),
+      ).resolves.toMatchObject({
+        allowed: true,
+        worktreeRoot: join(repoDir, ".worktrees", projectHash),
+      });
+    });
+
     it.skip("detects paseo-owned worktrees across realpath differences (macOS /var vs /private/var)", async () => {
       // Intentionally create repo using the non-realpath tmpdir() variant (often /var/... on macOS).
       const varTempDir = mkdtempSync(join(tmpdir(), "worktree-realpath-test-"));

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -37,7 +37,13 @@ import { writeFileAtomic } from "../server/atomic-file.js";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
 import { validateBranchSlug } from "@getpaseo/protocol/branch-slug";
-import { expandTilde, getRealpathAwareRelativePath, isPathInsideRoot } from "./path.js";
+import {
+  expandTilde,
+  getRealpathAwareRelativePath,
+  isPathInsideRoot,
+  isRepoRelativeWorktreesRoot,
+  repoRelativeWorktreesRootSegments,
+} from "./path.js";
 import { terminateWithTreeKill } from "./tree-kill.js";
 
 export { slugify, validateBranchSlug } from "@getpaseo/protocol/branch-slug";
@@ -165,6 +171,7 @@ export interface PaseoWorktreeOwnershipOptions extends WorktreeRootOptions {
 export interface WorktreeRootOptions {
   paseoHome?: string;
   worktreesRoot?: string;
+  repoRoot?: string;
 }
 
 export interface WorktreeCheckoutRef {
@@ -837,20 +844,38 @@ function deriveShortAlphanumericHash(value: string): string {
   return hashValue.toString(36).padStart(13, "0").slice(0, WORKTREE_PROJECT_HASH_LENGTH);
 }
 
-export async function deriveWorktreeProjectHash(cwd: string): Promise<string> {
+/**
+ * Repo root the project hash is derived from: the main checkout for every worktree of a
+ * repo, so all of them hash to the same project.
+ */
+async function resolveWorktreeProjectRoot(cwd: string): Promise<string> {
   try {
-    const commonDir = await getGitCommonDir(cwd);
-    const normalizedCommonDir = normalizePathForOwnership(commonDir);
-    const repoRoot =
-      basename(normalizedCommonDir) === ".git" ? dirname(normalizedCommonDir) : normalizedCommonDir;
-    return deriveShortAlphanumericHash(repoRoot);
+    return resolveRepoRootFromGitCommonDir(await getGitCommonDir(cwd));
   } catch {
-    return deriveShortAlphanumericHash(normalizePathForOwnership(cwd));
+    return normalizePathForOwnership(cwd);
   }
 }
 
-export function resolvePaseoWorktreesBaseRoot(options?: WorktreeRootOptions): string {
+export async function deriveWorktreeProjectHash(cwd: string): Promise<string> {
+  return deriveShortAlphanumericHash(await resolveWorktreeProjectRoot(cwd));
+}
+
+/**
+ * Base root every project's worktrees live under. Undefined when the configured root is
+ * repo-relative and no repo root was resolved, which callers read as "this path is not one
+ * of ours" rather than guessing a directory to write to or delete.
+ */
+export function resolvePaseoWorktreesBaseRoot(options?: WorktreeRootOptions): string | undefined {
   if (options?.worktreesRoot) {
+    if (isRepoRelativeWorktreesRoot(options.worktreesRoot)) {
+      if (!options.repoRoot) {
+        return undefined;
+      }
+      return resolve(
+        join(options.repoRoot, ...repoRelativeWorktreesRootSegments(options.worktreesRoot)),
+      );
+    }
+
     const expandedRoot = expandTilde(options.worktreesRoot);
     if (isAbsolute(expandedRoot)) {
       return resolve(expandedRoot);
@@ -868,9 +893,12 @@ export async function getPaseoWorktreesRoot(
   paseoHome?: string,
   worktreesRoot?: string,
 ): Promise<string> {
-  const baseRoot = resolvePaseoWorktreesBaseRoot({ paseoHome, worktreesRoot });
-  const projectHash = await deriveWorktreeProjectHash(cwd);
-  return join(baseRoot, projectHash);
+  const repoRoot = await resolveWorktreeProjectRoot(cwd);
+  const baseRoot = resolvePaseoWorktreesBaseRoot({ paseoHome, worktreesRoot, repoRoot });
+  if (baseRoot === undefined) {
+    throw new Error(`Could not resolve worktrees.root "${worktreesRoot}" for ${cwd}`);
+  }
+  return join(baseRoot, deriveShortAlphanumericHash(repoRoot));
 }
 
 export async function computeWorktreePath(
@@ -928,6 +956,28 @@ function resolveRepoRootFromGitCommonDir(commonDir: string): string {
     : normalizedCommonDir;
 }
 
+/**
+ * Best-effort repo root for a workspace cwd. A workspace can point at a subdirectory that
+ * no longer exists, and git cannot run from a missing directory, so climb to the nearest
+ * ancestor that does. A repo-relative worktrees root needs this to resolve at all.
+ */
+async function resolveRepoRootFromNearestAncestor(cwd: string): Promise<string | undefined> {
+  let candidate = resolve(cwd);
+  while (!existsSync(candidate)) {
+    const parent = dirname(candidate);
+    if (parent === candidate) {
+      return undefined;
+    }
+    candidate = parent;
+  }
+
+  try {
+    return resolveRepoRootFromGitCommonDir(await getGitCommonDir(candidate));
+  } catch {
+    return undefined;
+  }
+}
+
 export async function isPaseoOwnedWorktreeCwd(
   cwd: string,
   options?: PaseoWorktreeOwnershipOptions,
@@ -941,15 +991,21 @@ export async function isPaseoOwnedWorktreeCwd(
   if (options?.knownGitCommonDir) {
     repoRoot = resolveRepoRootFromGitCommonDir(options.knownGitCommonDir);
   } else if (options?.knownGitCommonDir === undefined) {
-    try {
-      const gitCommonDir = await getGitCommonDir(cwd);
-      repoRoot = resolveRepoRootFromGitCommonDir(gitCommonDir);
-    } catch {
-      // ignore
-    }
+    repoRoot = await resolveRepoRootFromNearestAncestor(cwd);
   }
 
-  const worktreesBaseRoot = resolvePaseoWorktreesBaseRoot(options);
+  const worktreesBaseRoot = resolvePaseoWorktreesBaseRoot({
+    ...options,
+    repoRoot: repoRoot ?? options?.repoRoot,
+  });
+  if (worktreesBaseRoot === undefined) {
+    return {
+      allowed: false,
+      ...(repoRoot !== undefined ? { repoRoot } : {}),
+      worktreePath: resolvedCwd,
+    };
+  }
+
   const relativePath = getRealpathAwareRelativePath(worktreesBaseRoot, resolvedCwd);
 
   // Ownership is defined by the path living under <worktrees-root>/<hash>/<slug>[/...].

--- a/public-docs/configuration.md
+++ b/public-docs/configuration.md
@@ -69,6 +69,18 @@ New worktrees are created under `$PASEO_HOME/worktrees` by default. To place new
 
 Relative paths are resolved against `PASEO_HOME`. Existing worktrees remain where they are; changing this setting only changes where Paseo creates and discovers Paseo-managed worktrees going forward.
 
+To keep each project's worktrees inside that project, start the path with `{repoRoot}`:
+
+```json
+{
+  "worktrees": {
+    "root": "{repoRoot}/.worktrees"
+  }
+}
+```
+
+`{repoRoot}` expands to the source checkout each worktree is cut from, so one setting covers every project and the value carries no user or machine specifics. It only works as the first segment, has to be followed by a separator, and cannot climb out of the repo with `..`; anything else is rejected when the config loads. Ignore the directory in the repos that use it, or the worktrees show up as untracked files in the checkout they live in.
+
 ## Voice
 
 Voice is configured through `features.dictation` and `features.voiceMode`, with provider credentials under `providers`.

--- a/public-docs/worktrees.md
+++ b/public-docs/worktrees.md
@@ -35,6 +35,17 @@ With a custom root, Paseo keeps the same hashed layout under that directory:
 }
 ```
 
+A root starting with `{repoRoot}` keeps the same layout inside each project instead:
+
+```
+~/dev/my-app/.worktrees/
+└── 1vnnm9k3/
+    ├── tidy-fox/
+    └── bold-owl/
+```
+
+The hash stays either way. Paseo owns `<root>/<hash>/<slug>` and reads that shape as proof a directory is its own. See [Configuration](/docs/configuration#worktrees) for the rules on repo-relative roots.
+
 1. Create a workspace with worktree isolation, Paseo creates the worktree and runs your setup hooks
 2. Launch one or more agents in that workspace
 3. Review the diff against the base branch


### PR DESCRIPTION
### Linked issue

None. No prior issue or discussion — happy to open a Discussion and settle the direction there first.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

`worktrees.root` is a single global path resolved at daemon startup, with no repo in scope. If you want each project's worktrees to sit inside that project, next to the checkout they belong to, you have to point the global root at one specific repo — and then every other project's worktrees land inside that repo too, under their own hash directory. The value also has to spell out a home directory, so it can't be shared across machines or with teammates.

A leading `{repoRoot}` expands to the checkout each worktree is cut from, so `"{repoRoot}/.worktrees"` is one setting that keeps every project's worktrees inside that project and holds no user or machine specifics.

### Goals

- `"root": "{repoRoot}/.worktrees"` creates worktrees under the source checkout they belong to
- One value that works for every project and on any machine
- Unchanged layout beneath the root: `<root>/<hash>/<slug>`
- Archive still removes worktrees, including when the git admin dir is already gone
- Absolute and `PASEO_HOME`-relative roots behave exactly as before

### Non-goals

- No per-project override in `paseo.json`; this stays a machine-level setting
- Not dropping the project-hash segment, redundant as it looks under a repo-scoped root. `isPaseoOwnedWorktreeCwd` treats `<hash>/<slug>` as proof Paseo owns a directory, so a one-segment layout would make a hand-made `.worktrees/foo` look Paseo-owned
- `{repoRoot}` is supported only as the first segment, has to be followed by a separator, and cannot climb out of the repo with `..`. Anything else is rejected at config load rather than silently resolving somewhere unexpected
- Paseo does not add the `.gitignore` entry for you; both docs pages tell you to
- No Windows verification

### QA

macOS 15 (arm64, Node 22); not run on Linux or Windows.

Created a workspace through the real daemon and CLI with `"root": "{repoRoot}/.worktrees"`. It landed at `/private/tmp/paseo-inrepo-demo/.worktrees/2yx76c0b/in-repo`, `git worktree list` registered it, `git status` showed `?? .worktrees/` until ignored, and archiving removed and deregistered it.

```
$ npx vitest run src/utils/worktree.posix.test.ts --bail=1   → 48 passed | 1 skipped
$ npx vitest run src/server/config-relay.test.ts --bail=1    → 24 passed
```

Tests added: create/own/list/delete under a repo-relative root against a real repo; ownership with the git admin dir unavailable, plus a wrong-hash look-alike that must not be owned; `loadConfig` keeps the template unresolved and rejects malformed placeholders.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
