### PR TITLE
fix(desktop): keep browser annotation card visible and interactive

### DIFF
--- a/packages/app/src/attachments/workspace-attachments-store.test.ts
+++ b/packages/app/src/attachments/workspace-attachments-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { collectRetainedAttachmentIds } from "./gc-retention";
 import type { WorkspaceComposerAttachment } from "./types";
 import {
   appendWorkspaceAttachment,
@@ -45,6 +46,32 @@ function reviewAttachment(body: string): WorkspaceComposerAttachment {
           },
         },
       ],
+    },
+  };
+}
+
+function browserElementAttachment(screenshotId: string): WorkspaceComposerAttachment {
+  return {
+    kind: "browser_element",
+    attachment: {
+      url: "https://example.com",
+      selector: "#target",
+      tag: "button",
+      text: "Target",
+      outerHTML: '<button id="target">Target</button>',
+      computedStyles: {},
+      boundingRect: { x: 0, y: 0, width: 100, height: 40 },
+      reactSource: null,
+      parentChain: [],
+      children: [],
+      screenshot: {
+        id: screenshotId,
+        mimeType: "image/png",
+        storageType: "desktop-file",
+        storageKey: `/tmp/${screenshotId}.png`,
+        createdAt: 1,
+      },
+      formatted: "selector: #target",
     },
   };
 }
@@ -147,6 +174,24 @@ describe("workspace attachments store", () => {
     const replacement = chatHistoryAttachment("chat_history:draft-1", "Updated chat.");
 
     expect(appendWorkspaceAttachment([original], replacement)).toEqual([replacement]);
+  });
+
+  it("retains browser screenshots while their workspace attachment exists", () => {
+    resetWorkspaceAttachmentsStore();
+    const scopeKey = buildWorkspaceAttachmentScopeKey({
+      serverId: "local",
+      workspaceId: "workspace-1",
+      cwd: "/repo",
+    });
+    const attachment = browserElementAttachment("screenshot-1");
+
+    useWorkspaceAttachmentsStore.getState().addWorkspaceAttachment({ scopeKey, attachment });
+
+    expect(collectRetainedAttachmentIds()).toContain("screenshot-1");
+
+    useWorkspaceAttachmentsStore.getState().clearWorkspaceAttachments({ scopeKey });
+
+    expect(collectRetainedAttachmentIds()).not.toContain("screenshot-1");
   });
 
   it("adds a workspace attachment against the current scope state", () => {

--- a/packages/app/src/attachments/workspace-attachments-store.ts
+++ b/packages/app/src/attachments/workspace-attachments-store.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { create } from "zustand";
 import { useShallow } from "zustand/shallow";
+import { retainAttachmentForGarbageCollection } from "./gc-retention";
 import type { WorkspaceComposerAttachment } from "./types";
 
 const EMPTY_WORKSPACE_ATTACHMENTS: readonly WorkspaceComposerAttachment[] = [];
@@ -98,6 +99,35 @@ function getContextAttachmentKey(attachment: WorkspaceComposerAttachment): strin
   });
 }
 
+const retainedBrowserScreenshotReleases = new Map<string, () => void>();
+
+function syncRetainedBrowserScreenshots(
+  attachmentsByScope: Record<string, readonly WorkspaceComposerAttachment[]>,
+): void {
+  const referencedIds = new Set<string>();
+  for (const attachments of Object.values(attachmentsByScope)) {
+    for (const attachment of attachments) {
+      if (attachment.kind === "browser_element" && attachment.attachment.screenshot) {
+        referencedIds.add(attachment.attachment.screenshot.id);
+      }
+    }
+  }
+  for (const screenshotId of referencedIds) {
+    if (!retainedBrowserScreenshotReleases.has(screenshotId)) {
+      retainedBrowserScreenshotReleases.set(
+        screenshotId,
+        retainAttachmentForGarbageCollection(screenshotId),
+      );
+    }
+  }
+  for (const [screenshotId, release] of retainedBrowserScreenshotReleases) {
+    if (!referencedIds.has(screenshotId)) {
+      release();
+      retainedBrowserScreenshotReleases.delete(screenshotId);
+    }
+  }
+}
+
 export function appendWorkspaceAttachment(
   current: readonly WorkspaceComposerAttachment[],
   attachment: WorkspaceComposerAttachment,
@@ -127,14 +157,15 @@ export const useWorkspaceAttachmentsStore = create<WorkspaceAttachmentsStore>()(
         }
         const next = { ...state.attachmentsByScope };
         delete next[scopeKey];
+        syncRetainedBrowserScreenshots(next);
         return { attachmentsByScope: next };
       }
-      return {
-        attachmentsByScope: {
-          ...state.attachmentsByScope,
-          [scopeKey]: attachments,
-        },
+      const next = {
+        ...state.attachmentsByScope,
+        [scopeKey]: attachments,
       };
+      syncRetainedBrowserScreenshots(next);
+      return { attachmentsByScope: next };
     });
   },
   addWorkspaceAttachment: ({ scopeKey, attachment }) => {
@@ -144,12 +175,12 @@ export const useWorkspaceAttachmentsStore = create<WorkspaceAttachmentsStore>()(
       if (areWorkspaceAttachmentsEqual(current, attachments)) {
         return state;
       }
-      return {
-        attachmentsByScope: {
-          ...state.attachmentsByScope,
-          [scopeKey]: attachments,
-        },
+      const next = {
+        ...state.attachmentsByScope,
+        [scopeKey]: attachments,
       };
+      syncRetainedBrowserScreenshots(next);
+      return { attachmentsByScope: next };
     });
   },
   clearWorkspaceAttachments: ({ scopeKey }) => {
@@ -159,6 +190,7 @@ export const useWorkspaceAttachmentsStore = create<WorkspaceAttachmentsStore>()(
       }
       const next = { ...state.attachmentsByScope };
       delete next[scopeKey];
+      syncRetainedBrowserScreenshots(next);
       return { attachmentsByScope: next };
     });
   },
@@ -230,5 +262,6 @@ export function useWorkspaceAttachmentsForScopes(
 }
 
 export function resetWorkspaceAttachmentsStore(): void {
+  syncRetainedBrowserScreenshots({});
   useWorkspaceAttachmentsStore.setState({ attachmentsByScope: {} });
 }

--- a/packages/app/src/desktop/browser/pane/index.electron.tsx
+++ b/packages/app/src/desktop/browser/pane/index.electron.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
   createElement,
 } from "react";
+import { createPortal } from "react-dom";
 import { Pressable, Text, TextInput, View, type StyleProp, type ViewStyle } from "react-native";
 import {
   ArrowLeft,
@@ -1671,6 +1672,13 @@ export function BrowserPane({
     webviewClipRef.current = node instanceof HTMLElement ? node : null;
   }, []);
 
+  // The webview paints outside #root in a fixed resident surface. Portal the
+  // card beside it so local z-index and React event handling both stay intact.
+  const residentSurface = webviewRef.current?.parentElement;
+  const annotationPortalTarget = residentSurface?.hasAttribute("data-paseo-browser-surface")
+    ? residentSurface
+    : null;
+
   if (!isElectronRuntime()) {
     return (
       <View style={styles.unavailableState}>
@@ -1792,13 +1800,16 @@ export function BrowserPane({
           ref: setWebviewHostNode,
           style: webviewHostStyle,
         })}
-        {pendingSelection ? (
-          <BrowserElementAnnotationCard
-            selection={pendingSelection}
-            onSubmit={submitAnnotation}
-            onCancel={cancelAnnotation}
-          />
-        ) : null}
+        {pendingSelection && annotationPortalTarget
+          ? createPortal(
+              <BrowserElementAnnotationCard
+                selection={pendingSelection}
+                onSubmit={submitAnnotation}
+                onCancel={cancelAnnotation}
+              />,
+              annotationPortalTarget,
+            )
+          : null}
       </View>
     </View>
   );

--- a/packages/app/src/desktop/browser/pane/index.electron.tsx
+++ b/packages/app/src/desktop/browser/pane/index.electron.tsx
@@ -96,6 +96,13 @@ interface BrowserElementAnnotation {
   comment: string;
 }
 
+interface BrowserElementAnnotationDraft {
+  generation: number;
+  selection: BrowserElementSelection;
+  captureStatus: "capturing" | "ready";
+  screenshot?: AttachmentMetadata;
+}
+
 type DeviceSizeId =
   | "responsive"
   | "iphone-se"
@@ -647,6 +654,7 @@ export function BrowserPane({
   const isPresentedRef = useRef(isPresented);
   isPresentedRef.current = isPresented;
   const webviewRef = useRef<ElectronWebview | null>(null);
+  const mountedRef = useRef(true);
   const webviewHostRef = useRef<HTMLDivElement | null>(null);
   const webviewClipRef = useRef<HTMLElement | null>(null);
   const urlInputRef = useRef<WebTextInput | null>(null);
@@ -666,19 +674,16 @@ export function BrowserPane({
   const toast = useToast();
   const toastRef = useRef(toast);
   toastRef.current = toast;
-  const [pendingSelection, setPendingSelection] = useState<BrowserElementSelection | null>(null);
-  // Screenshot is captured at selection time (overlay already torn down, no
-  // scroll drift) and reused when the annotation card is submitted.
-  const pendingScreenshotRef = useRef<AttachmentMetadata | undefined>(undefined);
+  const [annotationDraft, setAnnotationDraft] = useState<BrowserElementAnnotationDraft | null>(
+    null,
+  );
+  const annotationCaptureGenerationRef = useRef(0);
   const [draftUrl, setDraftUrl] = useState(browser?.url ?? "https://example.com");
   const workspaceAttachmentScopeKey = useMemo(
     () => buildBrowserAttachmentScopeKey({ cwd, serverId, workspaceId }),
     [cwd, serverId, workspaceId],
   );
   const workspaceAttachments = useWorkspaceAttachments(workspaceAttachmentScopeKey ?? "");
-  const setWorkspaceAttachments = useWorkspaceAttachmentsStore(
-    (state) => state.setWorkspaceAttachments,
-  );
   const titleStyle = useMemo(
     () => [styles.unavailableTitle, { color: theme.colors.foreground }],
     [theme.colors.foreground],
@@ -712,6 +717,13 @@ export function BrowserPane({
   );
   const browserErrorLabelsRef = useRef(browserErrorLabels);
   browserErrorLabelsRef.current = browserErrorLabels;
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      annotationCaptureGenerationRef.current += 1;
+    };
+  }, []);
 
   useEffect(() => {
     const nextUrl = browser?.url ?? "https://example.com";
@@ -1103,18 +1115,15 @@ export function BrowserPane({
       if (!workspaceAttachmentScopeKey) {
         return;
       }
-      setWorkspaceAttachments({
+      useWorkspaceAttachmentsStore.getState().addWorkspaceAttachment({
         scopeKey: workspaceAttachmentScopeKey,
-        attachments: [
-          ...workspaceAttachments,
-          {
-            kind: "browser_element",
-            attachment: buildBrowserElementAttachment(selection, annotation, screenshot),
-          },
-        ],
+        attachment: {
+          kind: "browser_element",
+          attachment: buildBrowserElementAttachment(selection, annotation, screenshot),
+        },
       });
     },
-    [setWorkspaceAttachments, workspaceAttachmentScopeKey, workspaceAttachments],
+    [workspaceAttachmentScopeKey],
   );
 
   const captureElementScreenshot = useCallback(
@@ -1202,10 +1211,23 @@ export function BrowserPane({
         void screenshotElementToClipboard(selection);
         return;
       }
-      pendingScreenshotRef.current = undefined;
-      setPendingSelection(selection);
+      const generation = annotationCaptureGenerationRef.current + 1;
+      const selectedBrowserId = browserIdRef.current;
+      annotationCaptureGenerationRef.current = generation;
+      setAnnotationDraft({ generation, selection, captureStatus: "capturing" });
       void captureElementScreenshot(selection).then((screenshot) => {
-        pendingScreenshotRef.current = screenshot;
+        if (!mountedRef.current || browserIdRef.current !== selectedBrowserId) {
+          return undefined;
+        }
+        setAnnotationDraft((current) => {
+          if (!current || current.generation !== generation) {
+            return current;
+          }
+          if (screenshot) {
+            return { ...current, captureStatus: "ready", screenshot };
+          }
+          return { ...current, captureStatus: "ready" };
+        });
         return undefined;
       });
     },
@@ -1214,21 +1236,19 @@ export function BrowserPane({
 
   const submitAnnotation = useCallback(
     (annotation: BrowserElementAnnotation) => {
-      const selection = pendingSelection;
-      const screenshot = pendingScreenshotRef.current;
-      pendingScreenshotRef.current = undefined;
-      setPendingSelection(null);
-      if (!selection) {
+      if (!annotationDraft || annotationDraft.captureStatus === "capturing") {
         return;
       }
-      addElementAttachment(selection, annotation, screenshot);
+      annotationCaptureGenerationRef.current += 1;
+      setAnnotationDraft(null);
+      addElementAttachment(annotationDraft.selection, annotation, annotationDraft.screenshot);
     },
-    [addElementAttachment, pendingSelection],
+    [addElementAttachment, annotationDraft],
   );
 
   const cancelAnnotation = useCallback(() => {
-    pendingScreenshotRef.current = undefined;
-    setPendingSelection(null);
+    annotationCaptureGenerationRef.current += 1;
+    setAnnotationDraft(null);
   }, []);
 
   const startElementSelector = useCallback(
@@ -1238,8 +1258,8 @@ export function BrowserPane({
       // Annotate needs a workspace scope to attach to; screenshot only copies.
       if (mode === "annotate" && !workspaceAttachmentScopeKey) return;
       selectorModeRef.current = mode;
-      pendingScreenshotRef.current = undefined;
-      setPendingSelection(null);
+      annotationCaptureGenerationRef.current += 1;
+      setAnnotationDraft(null);
       setSelectorMode(mode);
 
       const js = `
@@ -1800,10 +1820,11 @@ export function BrowserPane({
           ref: setWebviewHostNode,
           style: webviewHostStyle,
         })}
-        {pendingSelection && annotationPortalTarget
+        {annotationDraft && annotationPortalTarget
           ? createPortal(
               <BrowserElementAnnotationCard
-                selection={pendingSelection}
+                selection={annotationDraft.selection}
+                isCapturing={annotationDraft.captureStatus === "capturing"}
                 onSubmit={submitAnnotation}
                 onCancel={cancelAnnotation}
               />,
@@ -1817,10 +1838,12 @@ export function BrowserPane({
 
 function BrowserElementAnnotationCard({
   selection,
+  isCapturing,
   onSubmit,
   onCancel,
 }: {
   selection: BrowserElementSelection;
+  isCapturing: boolean;
   onSubmit: (annotation: BrowserElementAnnotation) => void;
   onCancel: () => void;
 }) {
@@ -1830,8 +1853,10 @@ function BrowserElementAnnotationCard({
   commentRef.current = comment;
 
   const handleSubmit = useCallback(() => {
-    onSubmit({ comment: commentRef.current });
-  }, [onSubmit]);
+    if (!isCapturing) {
+      onSubmit({ comment: commentRef.current });
+    }
+  }, [isCapturing, onSubmit]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -1889,7 +1914,7 @@ function BrowserElementAnnotationCard({
           <Button variant="ghost" size="sm" onPress={onCancel}>
             {t("workspace.browser.annotate.cancel")}
           </Button>
-          <Button variant="default" size="sm" onPress={handleSubmit}>
+          <Button variant="default" size="sm" loading={isCapturing} onPress={handleSubmit}>
             {t("workspace.browser.annotate.submit")}
           </Button>
         </View>

--- a/packages/desktop/e2e/browser-tabs.e2e.mjs
+++ b/packages/desktop/e2e/browser-tabs.e2e.mjs
@@ -682,6 +682,39 @@ async function runRegression({ page, client, serverId, targetUrl, callerAgentId 
   if (JSON.parse(selectorResult.resultJson) !== true) {
     failures.push("reused loaded browser remains ready for element annotation after remount");
   }
+  await clickGuestElement(page, client, browserId, "#bridge-target");
+  const annotationInput = page.getByRole("textbox", {
+    name: "Message to the agent about this element…",
+  });
+  await annotationInput.waitFor({ state: "attached", timeout: 5_000 });
+  const annotationPresentation = await annotationInput.evaluate((input) => {
+    const rect = input.getBoundingClientRect();
+    const centerTarget = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    );
+    return {
+      visible:
+        rect.width > 0 &&
+        rect.height > 0 &&
+        rect.bottom > 0 &&
+        rect.top < window.innerHeight &&
+        getComputedStyle(input).visibility !== "hidden",
+      targetTag: centerTarget instanceof Element ? centerTarget.tagName : null,
+      targetInsideInput: input === centerTarget || input.contains(centerTarget),
+    };
+  });
+  assert(
+    annotationPresentation.visible,
+    `Browser annotation input has no visible bounds: ${JSON.stringify(annotationPresentation)}`,
+  );
+  assert(
+    annotationPresentation.targetInsideInput,
+    `Browser surface covers the annotation input: ${JSON.stringify(annotationPresentation)}`,
+  );
+  await annotationInput.fill("Visible annotation");
+  await page.getByRole("button", { name: "Attach" }).click();
+  await annotationInput.waitFor({ state: "detached", timeout: 5_000 });
 
   if (failures.length > 0) {
     throw new Error(`Browser viewport regressions:\n- ${failures.join("\n- ")}`);

--- a/packages/desktop/e2e/browser-tabs.e2e.mjs
+++ b/packages/desktop/e2e/browser-tabs.e2e.mjs
@@ -713,7 +713,14 @@ async function runRegression({ page, client, serverId, targetUrl, callerAgentId 
     `Browser surface covers the annotation input: ${JSON.stringify(annotationPresentation)}`,
   );
   await annotationInput.fill("Visible annotation");
-  await page.getByRole("button", { name: "Attach" }).click();
+  const attachButton = page.getByRole("button", { name: "Attach" });
+  await attachButton.waitFor({ state: "visible", timeout: 5_000 });
+  await page.waitForFunction(
+    (button) => button?.getAttribute("aria-busy") !== "true" && !button?.hasAttribute("disabled"),
+    await attachButton.elementHandle(),
+    { timeout: 5_000 },
+  );
+  await attachButton.click();
   await annotationInput.waitFor({ state: "detached", timeout: 5_000 });
 
   if (failures.length > 0) {


### PR DESCRIPTION
## Summary

- render the element annotation card through a React portal into the active resident browser surface
- keep the card in the same paint plane as the `<webview>` so its local z-index places it above the guest
- preserve React ownership so the comment input, Attach, Cancel, and keyboard handlers remain functional
- extend the real Electron browser E2E to verify the input is visible, wins hit testing over the guest, accepts text, and submits through the Attach button

Fixes #3277.

## Why this target

The resident `<webview>` is hosted in a fixed body-level surface outside `#root`, while the card was previously rendered inline under `#root`. Portaling the card into that resident surface puts both in one stacking context. React still owns the portal, so event delegation continues to work; the E2E exercises a real pointer click on **Attach** rather than relying only on keyboard shortcuts.

## Validation

Validated from a clean `origin/main` baseline:

- `npm run test:e2e:browser-tabs --workspace=@getpaseo/desktop`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check:files -- packages/app/src/desktop/browser/pane/index.electron.tsx packages/desktop/e2e/browser-tabs.e2e.mjs`
