### PR TITLE
Show Grok reasoning effort in the composer

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -45,7 +45,7 @@ Extend `ACPAgentClient` from `packages/server/src/server/agent/providers/acp-age
 
 The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based but is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md). Catalog ACP providers that need a vendor quirk get a thin subclass: Cursor, Grok, Kimi, Kiro, Trae.
 
-Grok does not advertise ACP `thought_level` config options. Effort levels live on each model's `_meta.reasoningEfforts`, and changing effort is `session/set_mode` with the effort id — Grok has no ACP session modes of its own. `GrokACPAgentClient` maps that onto the same thinking control Codex uses. Do not treat those mode ids as permission modes.
+Grok has no ACP session modes. Values written with `session/set_mode` are reasoning-effort ids, not permission modes.
 
 Copilot custom agents are exposed through ACP session config, not the slash-command list. When custom agents are available, Copilot returns a select config option with `id: "agent"` and `category: "_agent"`; Paseo maps that to the `agent` provider feature. Copilot uses the agent display name as the option value, and the blank value means the default Copilot agent.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -43,7 +43,9 @@ and tool identity without approving native tools.
 
 Extend `ACPAgentClient` from `packages/server/src/server/agent/providers/acp-agent.ts`. The base class handles process spawning, stdio transport, session lifecycle, streaming, permissions, and model discovery. You provide configuration (command, modes, capabilities) and optionally override `isAvailable()` for auth checks.
 
-The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based but is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md).
+The only built-in ACP provider today is `copilot` (`copilot-acp-agent.ts`). `GenericACPAgentClient` (`generic-acp-agent.ts`) is also ACP-based but is used for user-defined custom providers configured via `extends: "acp"` overrides — see [docs/custom-providers.md](custom-providers.md). Catalog ACP providers that need a vendor quirk get a thin subclass: Cursor, Grok, Kimi, Kiro, Trae.
+
+Grok does not advertise ACP `thought_level` config options. Effort levels live on each model's `_meta.reasoningEfforts`, and changing effort is `session/set_mode` with the effort id — Grok has no ACP session modes of its own. `GrokACPAgentClient` maps that onto the same thinking control Codex uses. Do not treat those mode ids as permission modes.
 
 Copilot custom agents are exposed through ACP session config, not the slash-command list. When custom agents are available, Copilot returns a select config option with `id: "agent"` and `category: "_agent"`; Paseo maps that to the `agent` provider feature. Copilot uses the agent display name as the option value, and the blank value means the default Copilot agent.
 

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -43,6 +43,11 @@ const mockState = vi.hoisted(() => {
         env?: Record<string, string>;
         providerParams?: unknown;
       }>,
+      grok: [] as Array<{
+        command: string[];
+        env?: Record<string, string>;
+        providerParams?: unknown;
+      }>,
       kimi: [] as Array<{
         command: string[];
         env?: Record<string, string>;
@@ -66,6 +71,7 @@ const mockState = vi.hoisted(() => {
       this.constructorArgs.copilot = [];
       this.constructorArgs.cursor = [];
       this.constructorArgs.trae = [];
+      this.constructorArgs.grok = [];
       this.constructorArgs.kimi = [];
       this.constructorArgs.pi = [];
       this.constructorArgs.genericAcp = [];
@@ -448,6 +454,59 @@ vi.mock("./providers/trae-acp-agent.js", () => ({
         env: options.env,
       };
       mockState.constructorArgs.trae.push({
+        command: options.command,
+        env: options.env,
+        providerParams: options.providerParams,
+      });
+    }
+
+    async createSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async resumeSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async fetchCatalog(): Promise<ProviderCatalog> {
+      return {
+        models: mockState.runtimeModels.get(this.provider) ?? [],
+        modes: [],
+      };
+    }
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+  },
+}));
+
+vi.mock("./providers/grok-acp-agent.js", () => ({
+  GrokACPAgentClient: class GrokACPAgentClient {
+    readonly capabilities = {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    };
+    readonly provider = "acp";
+    readonly runtimeSettings?: unknown;
+
+    constructor(options: {
+      command: string[];
+      env?: Record<string, string>;
+      providerParams?: unknown;
+    }) {
+      this.runtimeSettings = {
+        command: {
+          mode: "replace",
+          argv: options.command,
+        },
+        env: options.env,
+      };
+      mockState.constructorArgs.grok.push({
         command: options.command,
         env: options.env,
         providerParams: options.providerParams,
@@ -941,6 +1000,33 @@ test("kimi provider extending acp uses KimiACPAgentClient", () => {
     },
     {
       command: ["kimi", "acp"],
+      env: undefined,
+      providerParams: undefined,
+    },
+  ]);
+  expect(mockState.constructorArgs.genericAcp).toEqual([]);
+});
+
+test("grok provider extending acp uses GrokACPAgentClient", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      grok: {
+        extends: "acp",
+        label: "Grok",
+        command: ["grok", "agent", "stdio"],
+      },
+    },
+  });
+
+  expect(registry.grok.createClient(logger).provider).toBe("grok");
+  expect(mockState.constructorArgs.grok).toEqual([
+    {
+      command: ["grok", "agent", "stdio"],
+      env: undefined,
+      providerParams: undefined,
+    },
+    {
+      command: ["grok", "agent", "stdio"],
       env: undefined,
       providerParams: undefined,
     },

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -43,11 +43,6 @@ const mockState = vi.hoisted(() => {
         env?: Record<string, string>;
         providerParams?: unknown;
       }>,
-      grok: [] as Array<{
-        command: string[];
-        env?: Record<string, string>;
-        providerParams?: unknown;
-      }>,
       kimi: [] as Array<{
         command: string[];
         env?: Record<string, string>;
@@ -62,6 +57,12 @@ const mockState = vi.hoisted(() => {
         providerParams?: unknown;
       }>,
     },
+    genericAcpHooks: [] as Array<{
+      providerId?: string;
+      thinkingOptionWriter: boolean;
+      sessionResponseTransformer: boolean;
+      modelTransformer: boolean;
+    }>,
     isCommandAvailable: vi.fn(async (_command: string) => false),
     runtimeModels: new Map<string, AgentModelDefinition[]>(),
     cursorListFeaturesConfigs: [] as AgentSessionConfig[],
@@ -71,10 +72,10 @@ const mockState = vi.hoisted(() => {
       this.constructorArgs.copilot = [];
       this.constructorArgs.cursor = [];
       this.constructorArgs.trae = [];
-      this.constructorArgs.grok = [];
       this.constructorArgs.kimi = [];
       this.constructorArgs.pi = [];
       this.constructorArgs.genericAcp = [];
+      this.genericAcpHooks = [];
       this.isCommandAvailable.mockReset();
       this.isCommandAvailable.mockImplementation(async (_command: string) => false);
       this.runtimeModels.clear();
@@ -311,6 +312,9 @@ vi.mock("./providers/generic-acp-agent.js", () => ({
       providerId?: string;
       label?: string;
       providerParams?: unknown;
+      thinkingOptionWriter?: unknown;
+      sessionResponseTransformer?: unknown;
+      modelTransformer?: unknown;
     }) {
       const providerParams =
         options.providerParams &&
@@ -338,6 +342,12 @@ vi.mock("./providers/generic-acp-agent.js", () => ({
         providerId: options.providerId,
         label: options.label,
         providerParams: options.providerParams,
+      });
+      mockState.genericAcpHooks.push({
+        providerId: options.providerId,
+        thinkingOptionWriter: typeof options.thinkingOptionWriter === "function",
+        sessionResponseTransformer: typeof options.sessionResponseTransformer === "function",
+        modelTransformer: typeof options.modelTransformer === "function",
       });
     }
 
@@ -454,59 +464,6 @@ vi.mock("./providers/trae-acp-agent.js", () => ({
         env: options.env,
       };
       mockState.constructorArgs.trae.push({
-        command: options.command,
-        env: options.env,
-        providerParams: options.providerParams,
-      });
-    }
-
-    async createSession(): Promise<never> {
-      throw new Error("not implemented");
-    }
-
-    async resumeSession(): Promise<never> {
-      throw new Error("not implemented");
-    }
-
-    async fetchCatalog(): Promise<ProviderCatalog> {
-      return {
-        models: mockState.runtimeModels.get(this.provider) ?? [],
-        modes: [],
-      };
-    }
-
-    async isAvailable(): Promise<boolean> {
-      return true;
-    }
-  },
-}));
-
-vi.mock("./providers/grok-acp-agent.js", () => ({
-  GrokACPAgentClient: class GrokACPAgentClient {
-    readonly capabilities = {
-      supportsStreaming: true,
-      supportsSessionPersistence: true,
-      supportsDynamicModes: true,
-      supportsMcpServers: true,
-      supportsReasoningStream: true,
-      supportsToolInvocations: true,
-    };
-    readonly provider = "acp";
-    readonly runtimeSettings?: unknown;
-
-    constructor(options: {
-      command: string[];
-      env?: Record<string, string>;
-      providerParams?: unknown;
-    }) {
-      this.runtimeSettings = {
-        command: {
-          mode: "replace",
-          argv: options.command,
-        },
-        env: options.env,
-      };
-      mockState.constructorArgs.grok.push({
         command: options.command,
         env: options.env,
         providerParams: options.providerParams,
@@ -1018,20 +975,22 @@ test("grok provider extending acp uses GrokACPAgentClient", () => {
     },
   });
 
-  expect(registry.grok.createClient(logger).provider).toBe("grok");
-  expect(mockState.constructorArgs.grok).toEqual([
+  const client = registry.grok.createClient(logger);
+  expect(client.provider).toBe("grok");
+  expect(mockState.genericAcpHooks).toEqual([
     {
-      command: ["grok", "agent", "stdio"],
-      env: undefined,
-      providerParams: undefined,
+      providerId: "grok",
+      thinkingOptionWriter: true,
+      sessionResponseTransformer: true,
+      modelTransformer: true,
     },
     {
-      command: ["grok", "agent", "stdio"],
-      env: undefined,
-      providerParams: undefined,
+      providerId: "grok",
+      thinkingOptionWriter: true,
+      sessionResponseTransformer: true,
+      modelTransformer: true,
     },
   ]);
-  expect(mockState.constructorArgs.genericAcp).toEqual([]);
 });
 
 test('extends: "acp" without command throws', () => {

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -37,6 +37,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -775,6 +776,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kimi") {
             return new KimiACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,7 +1,8 @@
+import type { ClientSideConnection } from "@agentclientprotocol/sdk";
 import type { Logger } from "pino";
 import { z } from "zod";
 
-import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
+import type { AgentCapabilityFlags, AgentModelDefinition } from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
@@ -10,6 +11,7 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type SessionStateResponse,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -51,6 +53,13 @@ interface GenericACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
+  modelTransformer?: (models: AgentModelDefinition[]) => AgentModelDefinition[];
+  sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
+  thinkingOptionWriter?: (
+    connection: ClientSideConnection,
+    sessionId: string,
+    thinkingOptionId: string,
+  ) => Promise<void>;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -76,6 +85,9 @@ export class GenericACPAgentClient extends ACPAgentClient {
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
+      modelTransformer: options.modelTransformer,
+      sessionResponseTransformer: options.sessionResponseTransformer,
+      thinkingOptionWriter: options.thinkingOptionWriter,
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { AgentModelDefinition } from "../agent-sdk-types.js";
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import type { SessionStateResponse, SpawnedACPProcess } from "./acp-agent.js";
+import {
+  applyGrokThinkingToModels,
+  extractGrokThinkingByModel,
+  GrokACPAgentClient,
+  transformGrokSessionResponse,
+  writeGrokThinkingOption,
+} from "./grok-acp-agent.js";
+
+function grok46Meta(currentEffort = "high") {
+  return {
+    totalContextTokens: 500000,
+    agentType: "grok-build-plan",
+    supportsReasoningEffort: true,
+    reasoningEffort: currentEffort,
+    reasoningEfforts: [
+      {
+        id: "xhigh",
+        value: "xhigh",
+        label: "Extra High Effort",
+        description: "Highest effort and reasoning level",
+        default: true,
+      },
+      {
+        id: "high",
+        value: "high",
+        label: "High Effort",
+        description: "Higher implementation quality with extensive reasoning",
+        default: true,
+      },
+      {
+        id: "medium",
+        value: "medium",
+        label: "Medium Effort",
+        description: "Balanced effort with standard implementation and testing",
+        default: false,
+      },
+      {
+        id: "low",
+        value: "low",
+        label: "Low Effort",
+        description: "Quick, fast implementations",
+        default: false,
+      },
+    ],
+  };
+}
+
+function grok45Meta() {
+  return {
+    totalContextTokens: 500000,
+    agentType: "grok-build-plan",
+    supportsReasoningEffort: true,
+    reasoningEffort: "high",
+    reasoningEfforts: [
+      {
+        id: "high",
+        value: "high",
+        label: "High Effort",
+        description: "Highest implementation quality with extensive reasoning",
+        default: true,
+      },
+      {
+        id: "medium",
+        value: "medium",
+        label: "Medium Effort",
+        description: "Balanced effort with standard implementation and testing",
+        default: false,
+      },
+      {
+        id: "low",
+        value: "low",
+        label: "Low Effort",
+        description: "Quick, fast implementations",
+        default: false,
+      },
+    ],
+  };
+}
+
+function grokSessionResponse(): SessionStateResponse {
+  return {
+    sessionId: "session-1",
+    models: {
+      currentModelId: "grok-4.6",
+      availableModels: [
+        {
+          modelId: "grok-4.6",
+          name: "Grok 4.6",
+          description: "SpaceXAI's latest frontier model",
+          _meta: grok46Meta(),
+        },
+        {
+          modelId: "grok-4.5",
+          name: "Grok 4.5",
+          _meta: grok45Meta(),
+        },
+      ],
+    },
+    _meta: {
+      "x.ai/sessionConfig": {
+        options: [
+          { id: "grok-4.6", category: "model", label: "Grok 4.6", selected: true },
+          { id: "xhigh", category: "mode", label: "Extra High Effort", selected: false },
+          { id: "high", category: "mode", label: "High Effort", selected: true },
+          { id: "medium", category: "mode", label: "Medium Effort", selected: false },
+          { id: "low", category: "mode", label: "Low Effort", selected: false },
+        ],
+      },
+    },
+  };
+}
+
+function createGrokClient(spawnProcess: () => Promise<SpawnedACPProcess>): GrokACPAgentClient {
+  class TestGrokACPAgentClient extends GrokACPAgentClient {
+    protected override async spawnProcess(): Promise<SpawnedACPProcess> {
+      return spawnProcess();
+    }
+
+    protected override async closeProbe(): Promise<void> {}
+  }
+
+  return new TestGrokACPAgentClient({
+    logger: createTestLogger(),
+    command: ["grok", "agent", "stdio"],
+    providerId: "grok",
+    label: "Grok",
+  });
+}
+
+describe("GrokACPAgentClient thinking options", () => {
+  test("maps per-model reasoning efforts from ACP model _meta", () => {
+    const thinkingByModel = extractGrokThinkingByModel(grokSessionResponse());
+
+    expect(thinkingByModel.get("grok-4.6")).toEqual({
+      currentId: "high",
+      options: [
+        expect.objectContaining({ id: "xhigh", label: "Extra High Effort", isDefault: false }),
+        expect.objectContaining({ id: "high", label: "High Effort", isDefault: true }),
+        expect.objectContaining({ id: "medium", label: "Medium Effort", isDefault: false }),
+        expect.objectContaining({ id: "low", label: "Low Effort", isDefault: false }),
+      ],
+    });
+    expect(thinkingByModel.get("grok-4.5")?.options.map((option) => option.id)).toEqual([
+      "high",
+      "medium",
+      "low",
+    ]);
+  });
+
+  test("synthesizes a thought_level config option from the current model's efforts", () => {
+    const transformed = transformGrokSessionResponse(grokSessionResponse());
+
+    expect(transformed.configOptions).toEqual([
+      {
+        id: "thought_level",
+        name: "Effort",
+        category: "thought_level",
+        type: "select",
+        currentValue: "high",
+        options: [
+          {
+            value: "xhigh",
+            name: "Extra High Effort",
+            description: "Highest effort and reasoning level",
+          },
+          {
+            value: "high",
+            name: "High Effort",
+            description: "Higher implementation quality with extensive reasoning",
+          },
+          {
+            value: "medium",
+            name: "Medium Effort",
+            description: "Balanced effort with standard implementation and testing",
+          },
+          {
+            value: "low",
+            name: "Low Effort",
+            description: "Quick, fast implementations",
+          },
+        ],
+      },
+    ]);
+    expect(transformed.modes).toBeUndefined();
+  });
+
+  test("falls back to x.ai/sessionConfig effort rows when model _meta has no efforts", () => {
+    const thinkingByModel = extractGrokThinkingByModel({
+      sessionId: "session-1",
+      models: {
+        currentModelId: "grok-4.6",
+        availableModels: [{ modelId: "grok-4.6", name: "Grok 4.6" }],
+      },
+      _meta: {
+        "x.ai/sessionConfig": {
+          options: [
+            { id: "grok-4.6", category: "model", label: "Grok 4.6", selected: true },
+            { id: "high", category: "mode", label: "High Effort", selected: true },
+            { id: "low", category: "mode", label: "Low Effort", selected: false },
+          ],
+        },
+      },
+    });
+
+    expect(thinkingByModel.get("grok-4.6")).toEqual({
+      currentId: "high",
+      options: [
+        expect.objectContaining({ id: "high", isDefault: true }),
+        expect.objectContaining({ id: "low", isDefault: false }),
+      ],
+    });
+  });
+
+  test("catalog probe attaches distinct thinking options per model", async () => {
+    const client = createGrokClient(async () => {
+      return {
+        child: { kill: vi.fn(), exitCode: 0, signalCode: null, once: vi.fn() },
+        connection: {
+          newSession: vi.fn().mockResolvedValue(grokSessionResponse()),
+        },
+        initialize: { agentCapabilities: {} },
+      } as unknown as SpawnedACPProcess;
+    });
+
+    const catalog = await client.fetchCatalog({
+      scope: "workspace",
+      cwd: "/tmp/acp-grok-thinking",
+      force: false,
+    });
+
+    const grok46 = catalog.models.find((model) => model.id === "grok-4.6");
+    const grok45 = catalog.models.find((model) => model.id === "grok-4.5");
+
+    expect(grok46?.thinkingOptions?.map((option) => option.id)).toEqual([
+      "xhigh",
+      "high",
+      "medium",
+      "low",
+    ]);
+    expect(grok46?.defaultThinkingOptionId).toBe("high");
+    expect(grok45?.thinkingOptions?.map((option) => option.id)).toEqual(["high", "medium", "low"]);
+    expect(grok45?.defaultThinkingOptionId).toBe("high");
+  });
+
+  test("writes thinking changes through session/set_mode", async () => {
+    const setSessionMode = vi.fn().mockResolvedValue({});
+
+    await writeGrokThinkingOption({ setSessionMode } as never, "session-1", "low");
+
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      modeId: "low",
+    });
+  });
+
+  test("model transformer overlays extracted thinking onto catalog models", () => {
+    const models: AgentModelDefinition[] = [
+      {
+        provider: "acp",
+        id: "grok-4.6",
+        label: "Grok 4.6",
+        isDefault: true,
+      },
+      {
+        provider: "acp",
+        id: "grok-4.5",
+        label: "Grok 4.5",
+      },
+    ];
+    const thinkingByModelId = extractGrokThinkingByModel(grokSessionResponse());
+
+    expect(applyGrokThinkingToModels(models, thinkingByModelId)).toEqual([
+      {
+        provider: "acp",
+        id: "grok-4.6",
+        label: "Grok 4.6",
+        isDefault: true,
+        thinkingOptions: thinkingByModelId.get("grok-4.6")?.options,
+        defaultThinkingOptionId: "high",
+      },
+      {
+        provider: "acp",
+        id: "grok-4.5",
+        label: "Grok 4.5",
+        thinkingOptions: thinkingByModelId.get("grok-4.5")?.options,
+        defaultThinkingOptionId: "high",
+      },
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,259 @@
+import type { ClientSideConnection, SessionConfigOption } from "@agentclientprotocol/sdk";
+import type { Logger } from "pino";
+
+import type { AgentModelDefinition, AgentSelectOption } from "../agent-sdk-types.js";
+import type { SessionStateResponse } from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+export interface GrokModelThinking {
+  currentId: string | null;
+  options: AgentSelectOption[];
+}
+
+const GROK_THOUGHT_LEVEL_CONFIG_ID = "thought_level";
+const GROK_EFFORT_IDS = new Set(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseGrokReasoningEffort(entry: unknown): AgentSelectOption | null {
+  if (!isRecord(entry)) {
+    return null;
+  }
+  const id = readString(entry.value) ?? readString(entry.id);
+  if (!id) {
+    return null;
+  }
+  const label = readString(entry.label) ?? id;
+  const description = readString(entry.description) ?? undefined;
+  return {
+    id,
+    label,
+    description,
+    isDefault: entry.default === true,
+  };
+}
+
+function resolveGrokCurrentEffortId(
+  options: AgentSelectOption[],
+  currentId: string | null,
+): string | null {
+  if (currentId && options.some((option) => option.id === currentId)) {
+    return currentId;
+  }
+  return options.find((option) => option.isDefault)?.id ?? options[0]?.id ?? null;
+}
+
+function withResolvedDefaults(
+  options: AgentSelectOption[],
+  currentId: string | null,
+): GrokModelThinking {
+  const resolvedCurrentId = resolveGrokCurrentEffortId(options, currentId);
+  return {
+    currentId: resolvedCurrentId,
+    options: options.map((option) => ({
+      ...option,
+      isDefault: option.id === resolvedCurrentId,
+    })),
+  };
+}
+
+function extractThinkingFromModelMeta(meta: unknown): GrokModelThinking | null {
+  if (!isRecord(meta) || meta.supportsReasoningEffort === false) {
+    return null;
+  }
+  if (!Array.isArray(meta.reasoningEfforts)) {
+    return null;
+  }
+  const options = meta.reasoningEfforts
+    .map((entry) => parseGrokReasoningEffort(entry))
+    .filter((option): option is AgentSelectOption => option !== null);
+  if (options.length === 0) {
+    return null;
+  }
+  return withResolvedDefaults(options, readString(meta.reasoningEffort));
+}
+
+function extractThinkingFromSessionConfig(meta: unknown): GrokModelThinking | null {
+  if (!isRecord(meta)) {
+    return null;
+  }
+  const sessionConfig = meta["x.ai/sessionConfig"];
+  if (!isRecord(sessionConfig) || !Array.isArray(sessionConfig.options)) {
+    return null;
+  }
+
+  const options: AgentSelectOption[] = [];
+  let currentId: string | null = null;
+  for (const entry of sessionConfig.options) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const id = readString(entry.id);
+    const category = readString(entry.category);
+    if (!id || !GROK_EFFORT_IDS.has(id)) {
+      continue;
+    }
+    if (category !== "mode" && category !== "thought_level" && category !== "effort") {
+      continue;
+    }
+    options.push({
+      id,
+      label: readString(entry.label) ?? id,
+      description: readString(entry.description) ?? undefined,
+      isDefault: entry.selected === true,
+    });
+    if (entry.selected === true) {
+      currentId = id;
+    }
+  }
+  if (options.length === 0) {
+    return null;
+  }
+  return withResolvedDefaults(options, currentId);
+}
+
+export function extractGrokThinkingByModel(
+  response: SessionStateResponse,
+): Map<string, GrokModelThinking> {
+  const thinkingByModelId = new Map<string, GrokModelThinking>();
+  const availableModels = response.models?.availableModels ?? [];
+  for (const model of availableModels) {
+    const thinking = extractThinkingFromModelMeta(model._meta);
+    if (thinking) {
+      thinkingByModelId.set(model.modelId, thinking);
+    }
+  }
+  if (thinkingByModelId.size > 0) {
+    return thinkingByModelId;
+  }
+
+  const fallback = extractThinkingFromSessionConfig(response._meta);
+  if (!fallback) {
+    return thinkingByModelId;
+  }
+  for (const model of availableModels) {
+    thinkingByModelId.set(model.modelId, fallback);
+  }
+  return thinkingByModelId;
+}
+
+function upsertThoughtLevelConfig(
+  configOptions: SessionConfigOption[],
+  thinking: GrokModelThinking,
+): SessionConfigOption[] {
+  const currentValue = thinking.currentId ?? thinking.options[0]?.id;
+  if (!currentValue) {
+    return configOptions;
+  }
+
+  const thoughtLevel: SessionConfigOption = {
+    id: GROK_THOUGHT_LEVEL_CONFIG_ID,
+    name: "Effort",
+    category: "thought_level",
+    type: "select",
+    currentValue,
+    options: thinking.options.map((option) => ({
+      value: option.id,
+      name: option.label,
+      description: option.description ?? null,
+    })),
+  };
+
+  const withoutThoughtLevel = configOptions.filter(
+    (option) => option.category !== "thought_level" && option.id !== GROK_THOUGHT_LEVEL_CONFIG_ID,
+  );
+  return [...withoutThoughtLevel, thoughtLevel];
+}
+
+export function transformGrokSessionResponse(
+  response: SessionStateResponse,
+  thinkingByModelId?: Map<string, GrokModelThinking>,
+): SessionStateResponse {
+  const extracted = extractGrokThinkingByModel(response);
+  if (thinkingByModelId && extracted.size > 0) {
+    thinkingByModelId.clear();
+    for (const [modelId, thinking] of extracted) {
+      thinkingByModelId.set(modelId, thinking);
+    }
+  }
+
+  const currentModelId = response.models?.currentModelId;
+  const currentThinking =
+    (currentModelId ? extracted.get(currentModelId) : undefined) ??
+    (currentModelId && thinkingByModelId ? thinkingByModelId.get(currentModelId) : undefined);
+  if (!currentThinking || currentThinking.options.length === 0) {
+    return response;
+  }
+
+  return {
+    ...response,
+    configOptions: upsertThoughtLevelConfig(response.configOptions ?? [], currentThinking),
+  };
+}
+
+export function applyGrokThinkingToModels(
+  models: AgentModelDefinition[],
+  thinkingByModelId: ReadonlyMap<string, GrokModelThinking>,
+): AgentModelDefinition[] {
+  return models.map((model) => {
+    const thinking = thinkingByModelId.get(model.id);
+    if (!thinking || thinking.options.length === 0) {
+      return model;
+    }
+    return {
+      ...model,
+      thinkingOptions: thinking.options,
+      defaultThinkingOptionId: thinking.currentId ?? thinking.options[0]?.id,
+    };
+  });
+}
+
+// Grok ACP has no session modes. session/set_mode with an effort id is how it
+// changes reasoning effort; it does not implement session/set_config_option.
+export async function writeGrokThinkingOption(
+  connection: ClientSideConnection,
+  sessionId: string,
+  thinkingOptionId: string,
+): Promise<void> {
+  await connection.setSessionMode({
+    sessionId,
+    modeId: thinkingOptionId,
+  });
+}
+
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    const thinkingByModelId = new Map<string, GrokModelThinking>();
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      sessionResponseTransformer: (response) =>
+        transformGrokSessionResponse(response, thinkingByModelId),
+      modelTransformer: (models) => applyGrokThinkingToModels(models, thinkingByModelId),
+      thinkingOptionWriter: writeGrokThinkingOption,
+    });
+  }
+}


### PR DESCRIPTION
### Linked issue

None. The missing composer control was described in #2538, which was closed as a feature request.

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Grok already reports reasoning effort over ACP, but the composer never showed the thinking control that Codex, Claude, and Cursor get. Paseo only reads a standard `thought_level` config option. Grok does not send that field. Effort lives on each model's `_meta.reasoningEfforts`, and a live change is `session/set_mode` with the effort id.

Without a Grok-specific mapping, changing effort means leaving Paseo and using the Grok CLI. This adapter feeds the existing thinking control and writes the selected level back through `session/set_mode`, so a Grok session can switch effort from the composer the same way a Codex session does.

### Goals

- Attach per-model thinking options from Grok ACP model `_meta.reasoningEfforts`.
- Keep grok-4.6's Extra High option off grok-4.5, which does not advertise it.
- Apply a selected thinking option on create and mid-session through `session/set_mode`.
- Do not treat Grok's `x.ai/sessionConfig` effort rows as permission modes.
- Cover the mapping, catalog probe, and write path with unit tests.

### Non-goals

- Make Grok a first-class built-in provider.
- Change the shared thinking UI.
- Add Grok permission modes, plan mode, or usage-card work.
- Wait for Grok to ship standard `thought_level` + `session/set_config_option`.

### QA

Real Grok CLI 1.0.3 ACP probe (`grok agent --always-approve stdio`):

- `session/new` returns `models.availableModels[]._meta.reasoningEfforts` (grok-4.6: xhigh/high/medium/low; grok-4.5: high/medium/low) and no top-level `configOptions` or `modes`.
- `session/set_config_option` returns method-not-found.
- `session/set_mode` with `modeId: "low"` updates effort. The agent then notified:

```text
_x.ai/session_notification
sessionUpdate=model_changed
model_id=grok-4.6
reasoning_effort=low
```

Automated tests:

```text
npm exec --workspace=@getpaseo/server -- vitest run \
  src/server/agent/providers/grok-acp-agent.test.ts \
  src/server/agent/provider-registry.test.ts \
  src/server/agent/providers/generic-acp-agent.test.ts \
  --bail=1

Test Files  3 passed (3)
Tests       58 passed (58)
```

The Grok file covers `_meta` mapping, thought_level synthesis, the sessionConfig fallback, per-model catalog options, and the `set_mode` write.

```text
npm run typecheck --workspace=@getpaseo/server
passed

npm run lint -- packages/server/src/server/agent/providers/grok-acp-agent.ts \
  packages/server/src/server/agent/providers/grok-acp-agent.test.ts \
  packages/server/src/server/agent/providers/generic-acp-agent.ts \
  packages/server/src/server/agent/provider-registry.ts \
  packages/server/src/server/agent/provider-registry.test.ts
Found 0 warnings and 0 errors.

npm run format:files -- <same files plus docs/providers.md>
passed
```

No new UI was added. The existing thinking control appears once the catalog model carries `thinkingOptions`. I did not click through a live Paseo composer against this branch.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | No UI change; not tested |
| Android         |        | No UI change; not tested |
| Web             |        | No live composer run |
| Desktop macOS   | x      | Adapter tests + real `grok` 1.0.3 ACP probe |
| Desktop Windows |        | Not tested |
| Desktop Linux   |        | Not tested |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
