### PR TITLE
fix(app): support copying Hermes resume commands

### DIFF
--- a/packages/app/src/utils/provider-command-templates.test.ts
+++ b/packages/app/src/utils/provider-command-templates.test.ts
@@ -3,6 +3,16 @@ import { describe, expect, test } from "vitest";
 import { buildProviderCommand } from "@/utils/provider-command-templates";
 
 describe("buildProviderCommand", () => {
+  test("builds Hermes resume commands from native session ids", () => {
+    expect(
+      buildProviderCommand({
+        provider: "hermes",
+        id: "resume",
+        sessionId: "20260813_111500_abc123",
+      }),
+    ).toBe("hermes --resume 20260813_111500_abc123");
+  });
+
   test("builds OpenCode resume commands from native session ids", () => {
     expect(
       buildProviderCommand({

--- a/packages/app/src/utils/provider-command-templates.ts
+++ b/packages/app/src/utils/provider-command-templates.ts
@@ -17,6 +17,9 @@ export const PROVIDER_COMMAND_TEMPLATES: Record<
   claude: {
     resume: "claude --resume {sessionId}",
   },
+  hermes: {
+    resume: "hermes --resume {sessionId}",
+  },
   pi: {
     resume: "pi --session {sessionId}",
   },


### PR DESCRIPTION
### Linked issue

Closes #3299

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo already offers **Copy resume command** for provider-native sessions, but Hermes is missing from the command template map. On Paseo 0.3.1 Desktop for macOS, the Hermes action therefore returns `Resume command not available` even though the Hermes CLI supports `--resume`.

This keeps the fix at the existing provider-command boundary: add Hermes's native command template and cover it with the same unit test used for the other providers.

### Goals

- [x] Copy `hermes --resume <native session id>` for Hermes agents.
- [x] Keep the existing command behavior for every other provider unchanged.
- [x] Prevent the missing template from regressing.

### Non-goals

- No changes to Hermes session handling or ACP process management.
- No UI, protocol, or provider launch changes.
- No changes to how native session IDs are discovered or stored.

### QA

Reproduction before the fix was captured in [#3299](https://github.com/getpaseo/paseo/issues/3299): Paseo Desktop 0.3.1 on macOS 15.6.1 showed `Resume command not available` for a Hermes agent.

Focused regression test on `origin/main` before the implementation:

```text
$ npm exec --workspace=@getpaseo/app vitest run src/utils/provider-command-templates.test.ts --bail=1

❯ unit src/utils/provider-command-templates.test.ts (2 tests | 1 failed)
× builds Hermes resume commands from native session ids
AssertionError: expected null to be 'hermes --resume 20260813_111500_abc123'
✓ builds OpenCode resume commands from native session ids
Tests 1 failed | 1 passed (2)
```

After the implementation:

```text
$ npm exec --workspace=@getpaseo/app vitest run src/utils/provider-command-templates.test.ts --bail=1

✓ unit src/utils/provider-command-templates.test.ts (2 tests)
Test Files 1 passed (1)
Tests 2 passed (2)
```

Static checks:

```text
$ npm run lint
Found 0 warnings and 0 errors.
Finished in 727ms on 3415 files.

$ npm run format:check
All matched files use the correct format.
Finished in 2736ms on 3651 files.

$ npm run typecheck
# passed after the repository dependency builds; all workspaces exited 0
```

The pre-commit hook also reran lint, format, and the root typecheck successfully on the two changed files.

Platforms:

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop macOS | Yes | Reproduction environment; command construction is platform-independent |
| Desktop Windows | No | No Windows host available |
| Desktop Linux | No | No Linux host available |
| Web/iOS/Android | No | No device/browser run; shared app command construction only |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
