### PR TITLE
Show Grok plan mode in the composer

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -7613,6 +7613,10 @@ test("respondToPermission refreshes features and runtime info after provider-man
     {
       provider: "codex",
       cwd: workdir,
+      featureValues: {
+        fast_mode: true,
+        plan_mode: true,
+      },
     },
     undefined,
     { workspaceId: undefined },
@@ -7641,6 +7645,10 @@ test("respondToPermission refreshes features and runtime info after provider-man
     createFeature({ id: "fast_mode", label: "Fast", value: true }),
     createFeature({ id: "plan_mode", label: "Plan", value: false }),
   ]);
+  expect(updated?.config.featureValues).toEqual({
+    fast_mode: true,
+    plan_mode: false,
+  });
   expect(updated?.runtimeInfo).toMatchObject({
     model: "gpt-5.4",
     extra: { collaborationMode: "Code" },
@@ -7651,6 +7659,10 @@ test("respondToPermission refreshes features and runtime info after provider-man
     createFeature({ id: "fast_mode", label: "Fast", value: true }),
     createFeature({ id: "plan_mode", label: "Plan", value: false }),
   ]);
+  expect(persisted?.config?.featureValues).toEqual({
+    fast_mode: true,
+    plan_mode: false,
+  });
 });
 
 test("respondToPermission emits refreshed state before permission_resolved", async () => {

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -4207,8 +4207,28 @@ export class AgentManager {
   }
 
   private syncFeaturesFromSession(agent: ManagedAgent): void {
-    if ("session" in agent && agent.session?.features) {
-      agent.features = agent.session.features;
+    if (!("session" in agent) || !agent.session?.features) {
+      return;
+    }
+    agent.features = agent.session.features;
+    const current = agent.config.featureValues;
+    if (current == null) {
+      return;
+    }
+    let changed = false;
+    const next = { ...current };
+    for (const feature of agent.features) {
+      if (!Object.prototype.hasOwnProperty.call(next, feature.id)) {
+        continue;
+      }
+      if (next[feature.id] === feature.value) {
+        continue;
+      }
+      next[feature.id] = feature.value;
+      changed = true;
+    }
+    if (changed) {
+      agent.config.featureValues = next;
     }
   }
 

--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -43,6 +43,11 @@ const mockState = vi.hoisted(() => {
         env?: Record<string, string>;
         providerParams?: unknown;
       }>,
+      grok: [] as Array<{
+        command: string[];
+        env?: Record<string, string>;
+        providerParams?: unknown;
+      }>,
       kimi: [] as Array<{
         command: string[];
         env?: Record<string, string>;
@@ -66,6 +71,7 @@ const mockState = vi.hoisted(() => {
       this.constructorArgs.copilot = [];
       this.constructorArgs.cursor = [];
       this.constructorArgs.trae = [];
+      this.constructorArgs.grok = [];
       this.constructorArgs.kimi = [];
       this.constructorArgs.pi = [];
       this.constructorArgs.genericAcp = [];
@@ -448,6 +454,59 @@ vi.mock("./providers/trae-acp-agent.js", () => ({
         env: options.env,
       };
       mockState.constructorArgs.trae.push({
+        command: options.command,
+        env: options.env,
+        providerParams: options.providerParams,
+      });
+    }
+
+    async createSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async resumeSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async fetchCatalog(): Promise<ProviderCatalog> {
+      return {
+        models: mockState.runtimeModels.get(this.provider) ?? [],
+        modes: [],
+      };
+    }
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+  },
+}));
+
+vi.mock("./providers/grok-acp-agent.js", () => ({
+  GrokACPAgentClient: class GrokACPAgentClient {
+    readonly capabilities = {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    };
+    readonly provider = "acp";
+    readonly runtimeSettings?: unknown;
+
+    constructor(options: {
+      command: string[];
+      env?: Record<string, string>;
+      providerParams?: unknown;
+    }) {
+      this.runtimeSettings = {
+        command: {
+          mode: "replace",
+          argv: options.command,
+        },
+        env: options.env,
+      };
+      mockState.constructorArgs.grok.push({
         command: options.command,
         env: options.env,
         providerParams: options.providerParams,
@@ -914,6 +973,33 @@ test("traecli provider extending acp uses TraeACPAgentClient", () => {
     },
     {
       command: ["traecli", "acp", "serve"],
+      env: undefined,
+      providerParams: undefined,
+    },
+  ]);
+  expect(mockState.constructorArgs.genericAcp).toEqual([]);
+});
+
+test("grok provider extending acp uses GrokACPAgentClient", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      grok: {
+        extends: "acp",
+        label: "Grok",
+        command: ["grok", "agent", "stdio"],
+      },
+    },
+  });
+
+  expect(registry.grok.createClient(logger).provider).toBe("grok");
+  expect(mockState.constructorArgs.grok).toEqual([
+    {
+      command: ["grok", "agent", "stdio"],
+      env: undefined,
+      providerParams: undefined,
+    },
+    {
+      command: ["grok", "agent", "stdio"],
       env: undefined,
       providerParams: undefined,
     },

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -37,6 +37,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -775,6 +776,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kimi") {
             return new KimiACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1169,6 +1169,76 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
+  test("applies client-permission feature updates before respondToPermission returns", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "acp",
+        cwd: "/tmp/paseo-acp-test",
+        featureValues: { plan_mode: true },
+      },
+      {
+        provider: "acp",
+        logger: createTestLogger(),
+        defaultCommand: ["grok", "agent", "stdio"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        staticToggleFeatures: [{ id: "plan_mode", label: "Plan" }],
+        extMethodHandler: async (_method, _params, context) => {
+          const response = await context.requestPermission(
+            {
+              id: "perm-plan-1",
+              provider: "acp",
+              name: "PlanApproval",
+              kind: "plan",
+              input: { plan: "- add tests" },
+            },
+            (resolved) => {
+              if (resolved.behavior === "allow") {
+                context.config.featureValues = {
+                  ...context.config.featureValues,
+                  plan_mode: false,
+                };
+              }
+            },
+          );
+          return { outcome: response.behavior };
+        },
+      },
+    );
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const extMethod = session.extMethod("test/exit_plan_mode", { sessionId: "session-1" });
+    await Promise.resolve();
+
+    const requested = events.find((event) => event.type === "permission_requested");
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
+    expect(session.features).toContainEqual(
+      expect.objectContaining({ type: "toggle", id: "plan_mode", value: true }),
+    );
+
+    await session.respondToPermission(requested.request.id, {
+      behavior: "allow",
+      selectedActionId: "implement",
+    });
+    expect(session.features).toContainEqual(
+      expect.objectContaining({ type: "toggle", id: "plan_mode", value: false }),
+    );
+    await expect(extMethod).resolves.toEqual({ outcome: "allow" });
+  });
+
   test("preserves ACP chooser actions and returns the selected option", async () => {
     const session = createSessionWithConfig({
       provider: "kimi-acp",

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -515,6 +515,7 @@ interface PendingPermission {
 interface PendingClientPermission {
   request: AgentPermissionRequest;
   resolve: (response: AgentPermissionResponse) => void;
+  onResponse?: ACPClientPermissionResponseHandler;
   turnId: string | null;
 }
 
@@ -578,11 +579,16 @@ export interface ACPFeatureWriterContext {
 
 export type ACPFeatureWriter = (context: ACPFeatureWriterContext) => Promise<boolean>;
 
+export type ACPClientPermissionResponseHandler = (response: AgentPermissionResponse) => void;
+
 export interface ACPExtMethodContext {
   provider: string;
   sessionId: string | null;
   config: AgentSessionConfig;
-  requestPermission: (request: AgentPermissionRequest) => Promise<AgentPermissionResponse>;
+  requestPermission: (
+    request: AgentPermissionRequest,
+    onResponse?: ACPClientPermissionResponseHandler,
+  ) => Promise<AgentPermissionResponse>;
   emitTimeline: (item: AgentTimelineItem) => void;
 }
 
@@ -2210,6 +2216,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const clientPending = this.pendingClientPermissions.get(requestId);
     if (clientPending) {
       this.pendingClientPermissions.delete(requestId);
+      // Ext-method handlers apply feature/timeline side effects here so
+      // session.features is current before AgentManager refreshes and persists.
+      clientPending.onResponse?.(response);
       clientPending.resolve(response);
       this.pushEvent({
         type: "permission_resolved",
@@ -2460,7 +2469,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       provider: this.provider,
       sessionId: this.sessionId,
       config: this.config,
-      requestPermission: (request) => this.enqueueClientPermission(request),
+      requestPermission: (request, onResponse) => this.enqueueClientPermission(request, onResponse),
       emitTimeline: (item) => {
         this.pushEvent({ type: "timeline", provider: this.provider, item });
       },
@@ -2473,11 +2482,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private enqueueClientPermission(
     request: AgentPermissionRequest,
+    onResponse?: ACPClientPermissionResponseHandler,
   ): Promise<AgentPermissionResponse> {
     return new Promise((resolve) => {
       this.pendingClientPermissions.set(request.id, {
         request,
         resolve,
+        onResponse,
         turnId: this.activeForegroundTurnId,
       });
       this.pushEvent({

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -413,6 +413,10 @@ interface ACPAgentClientOptions {
   sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
   configFeatureOptions?: ACPConfigFeatureOption[];
+  staticToggleFeatures?: ACPStaticToggleFeature[];
+  featureWriter?: ACPFeatureWriter;
+  extMethodHandler?: ACPExtMethodHandler;
+  currentModeListener?: ACPCurrentModeListener;
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string) => string | null;
@@ -443,6 +447,10 @@ interface ACPAgentSessionOptions {
   sessionResponseTransformer?: (response: SessionStateResponse) => SessionStateResponse;
   configOptionsTransformer?: (configOptions: SessionConfigOption[]) => SessionConfigOption[];
   configFeatureOptions?: ACPConfigFeatureOption[];
+  staticToggleFeatures?: ACPStaticToggleFeature[];
+  featureWriter?: ACPFeatureWriter;
+  extMethodHandler?: ACPExtMethodHandler;
+  currentModeListener?: ACPCurrentModeListener;
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string) => string | null;
@@ -504,6 +512,12 @@ interface PendingPermission {
   turnId: string | null;
 }
 
+interface PendingClientPermission {
+  request: AgentPermissionRequest;
+  resolve: (response: AgentPermissionResponse) => void;
+  turnId: string | null;
+}
+
 interface PendingUserMessage {
   text: string;
   messageId?: string;
@@ -546,6 +560,39 @@ export interface ACPConfigFeatureOption {
   icon?: string;
   emptyOptionLabel?: string;
 }
+
+export interface ACPStaticToggleFeature {
+  id: string;
+  label: string;
+  description?: string;
+  tooltip?: string;
+  icon?: string;
+}
+
+export interface ACPFeatureWriterContext {
+  connection: ClientSideConnection;
+  sessionId: string;
+  featureId: string;
+  value: unknown;
+}
+
+export type ACPFeatureWriter = (context: ACPFeatureWriterContext) => Promise<boolean>;
+
+export interface ACPExtMethodContext {
+  provider: string;
+  sessionId: string | null;
+  config: AgentSessionConfig;
+  requestPermission: (request: AgentPermissionRequest) => Promise<AgentPermissionResponse>;
+  emitTimeline: (item: AgentTimelineItem) => void;
+}
+
+export type ACPExtMethodHandler = (
+  method: string,
+  params: Record<string, unknown>,
+  context: ACPExtMethodContext,
+) => Promise<Record<string, unknown> | null>;
+
+export type ACPCurrentModeListener = (modeId: string | null, config: AgentSessionConfig) => void;
 
 export type SelectConfigOption = Extract<SessionConfigOption, { type: "select" }>;
 interface SelectConfigChoice {
@@ -747,6 +794,21 @@ function buildACPAutoAcceptFeature(config: AgentSessionConfig): AgentFeature {
   };
 }
 
+function buildStaticToggleFeatures(
+  features: ACPStaticToggleFeature[],
+  config: AgentSessionConfig,
+): AgentFeature[] {
+  return features.map((feature) => ({
+    type: "toggle" as const,
+    id: feature.id,
+    label: feature.label,
+    description: feature.description,
+    tooltip: feature.tooltip,
+    icon: feature.icon,
+    value: config.featureValues?.[feature.id] === true,
+  }));
+}
+
 function resolveACPCreateConfig(
   input: ResolveAgentCreateConfigInput,
 ): ResolveAgentCreateConfigResult {
@@ -800,6 +862,10 @@ export class ACPAgentClient implements AgentClient {
     configOptions: SessionConfigOption[],
   ) => SessionConfigOption[];
   private readonly configFeatureOptions: ACPConfigFeatureOption[];
+  private readonly staticToggleFeatures: ACPStaticToggleFeature[];
+  private readonly featureWriter?: ACPFeatureWriter;
+  private readonly extMethodHandler?: ACPExtMethodHandler;
+  private readonly currentModeListener?: ACPCurrentModeListener;
   private readonly clientCapabilities?: ACPClientCapabilities;
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
@@ -836,6 +902,10 @@ export class ACPAgentClient implements AgentClient {
     this.sessionResponseTransformer = options.sessionResponseTransformer;
     this.configOptionsTransformer = options.configOptionsTransformer;
     this.configFeatureOptions = options.configFeatureOptions ?? [];
+    this.staticToggleFeatures = options.staticToggleFeatures ?? [];
+    this.featureWriter = options.featureWriter;
+    this.extMethodHandler = options.extMethodHandler;
+    this.currentModeListener = options.currentModeListener;
     this.clientCapabilities = options.clientCapabilities;
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
@@ -865,6 +935,10 @@ export class ACPAgentClient implements AgentClient {
         sessionResponseTransformer: this.sessionResponseTransformer,
         configOptionsTransformer: this.configOptionsTransformer,
         configFeatureOptions: this.configFeatureOptions,
+        staticToggleFeatures: this.staticToggleFeatures,
+        featureWriter: this.featureWriter,
+        extMethodHandler: this.extMethodHandler,
+        currentModeListener: this.currentModeListener,
         clientCapabilities: this.clientCapabilities,
         clientCapabilityMeta: this.clientCapabilityMeta,
         modeIdTransformer: this.modeIdTransformer,
@@ -915,6 +989,10 @@ export class ACPAgentClient implements AgentClient {
       sessionResponseTransformer: this.sessionResponseTransformer,
       configOptionsTransformer: this.configOptionsTransformer,
       configFeatureOptions: this.configFeatureOptions,
+      staticToggleFeatures: this.staticToggleFeatures,
+      featureWriter: this.featureWriter,
+      extMethodHandler: this.extMethodHandler,
+      currentModeListener: this.currentModeListener,
       clientCapabilities: this.clientCapabilities,
       clientCapabilityMeta: this.clientCapabilityMeta,
       modeIdTransformer: this.modeIdTransformer,
@@ -999,8 +1077,9 @@ export class ACPAgentClient implements AgentClient {
 
   async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
     const autoAcceptFeature = buildACPAutoAcceptFeature(config);
+    const staticFeatures = buildStaticToggleFeatures(this.staticToggleFeatures, config);
     if (this.configFeatureOptions.length === 0) {
-      return [autoAcceptFeature];
+      return [autoAcceptFeature, ...staticFeatures];
     }
 
     this.assertProvider(config);
@@ -1015,6 +1094,7 @@ export class ACPAgentClient implements AgentClient {
       const transformed = this.transformSessionResponse(response);
       return [
         autoAcceptFeature,
+        ...staticFeatures,
         ...deriveFeaturesFromACP(transformed.configOptions, this.configFeatureOptions),
       ];
     } finally {
@@ -1388,6 +1468,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     configOptions: SessionConfigOption[],
   ) => SessionConfigOption[];
   private readonly configFeatureOptions: ACPConfigFeatureOption[];
+  private readonly staticToggleFeatures: ACPStaticToggleFeature[];
+  private readonly featureWriter?: ACPFeatureWriter;
+  private readonly extMethodHandler?: ACPExtMethodHandler;
+  private readonly currentModeListener?: ACPCurrentModeListener;
   private readonly clientCapabilities?: ACPClientCapabilities;
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
   private readonly modeIdTransformer?: (modeId: string) => string | null;
@@ -1407,6 +1491,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly launchEnv?: Record<string, string>;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly pendingPermissions = new Map<string, PendingPermission>();
+  private readonly pendingClientPermissions = new Map<string, PendingClientPermission>();
   private pendingUserMessage: PendingUserMessage | null = null;
   private submittedUserMessageTurnId: string | null = null;
   private readonly toolCalls = new Map<string, ACPToolSnapshot>();
@@ -1454,6 +1539,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.sessionResponseTransformer = options.sessionResponseTransformer;
     this.configOptionsTransformer = options.configOptionsTransformer;
     this.configFeatureOptions = options.configFeatureOptions ?? [];
+    this.staticToggleFeatures = options.staticToggleFeatures ?? [];
+    this.featureWriter = options.featureWriter;
+    this.extMethodHandler = options.extMethodHandler;
+    this.currentModeListener = options.currentModeListener;
     this.clientCapabilities = options.clientCapabilities;
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
@@ -1674,6 +1763,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   get features(): AgentFeature[] {
     return [
       buildACPAutoAcceptFeature(this.config),
+      ...buildStaticToggleFeatures(this.staticToggleFeatures, this.config),
       ...deriveFeaturesFromACP(this.configOptions, this.configFeatureOptions),
     ];
   }
@@ -2023,6 +2113,27 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       return;
     }
 
+    const staticFeature = this.staticToggleFeatures.find((feature) => feature.id === featureId);
+    if (staticFeature) {
+      const enabled = value === true;
+      if (this.featureWriter) {
+        const handled = await this.featureWriter({
+          connection: this.connection,
+          sessionId: this.sessionId,
+          featureId,
+          value: enabled,
+        });
+        if (!handled) {
+          throw new Error(`${this.provider} does not expose feature '${featureId}'`);
+        }
+      }
+      this.config.featureValues = {
+        ...this.config.featureValues,
+        [featureId]: enabled,
+      };
+      return;
+    }
+
     const featureOption = this.configFeatureOptions.find((option) => option.id === featureId);
     if (!featureOption) {
       throw new Error(`Unknown ${this.provider} feature: ${featureId}`);
@@ -2089,10 +2200,27 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   getPendingPermissions(): AgentPermissionRequest[] {
-    return Array.from(this.pendingPermissions.values(), (entry) => entry.request);
+    return [
+      ...Array.from(this.pendingPermissions.values(), (entry) => entry.request),
+      ...Array.from(this.pendingClientPermissions.values(), (entry) => entry.request),
+    ];
   }
 
   async respondToPermission(requestId: string, response: AgentPermissionResponse): Promise<void> {
+    const clientPending = this.pendingClientPermissions.get(requestId);
+    if (clientPending) {
+      this.pendingClientPermissions.delete(requestId);
+      clientPending.resolve(response);
+      this.pushEvent({
+        type: "permission_resolved",
+        provider: this.provider,
+        requestId,
+        resolution: response,
+        turnId: clientPending.turnId ?? undefined,
+      });
+      return;
+    }
+
     const pending = this.pendingPermissions.get(requestId);
     if (!pending) {
       throw new Error(`No pending permission request with id '${requestId}'`);
@@ -2154,6 +2282,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       pending.resolve({ outcome: { outcome: "cancelled" } });
     }
     this.pendingPermissions.clear();
+    this.rejectPendingClientPermissions();
 
     if (this.activeForegroundTurnId) {
       await this.connection.cancel({ sessionId: this.sessionId });
@@ -2173,6 +2302,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       pending.resolve({ outcome: { outcome: "cancelled" } });
     }
     this.pendingPermissions.clear();
+    this.rejectPendingClientPermissions();
 
     if (this.connection && this.sessionId) {
       try {
@@ -2316,6 +2446,61 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
       });
     }
+  }
+
+  async extMethod(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!this.extMethodHandler) {
+      throw new Error(`Unknown ACP extension method: ${method}`);
+    }
+
+    const result = await this.extMethodHandler(method, params, {
+      provider: this.provider,
+      sessionId: this.sessionId,
+      config: this.config,
+      requestPermission: (request) => this.enqueueClientPermission(request),
+      emitTimeline: (item) => {
+        this.pushEvent({ type: "timeline", provider: this.provider, item });
+      },
+    });
+    if (result === null) {
+      throw new Error(`Unknown ACP extension method: ${method}`);
+    }
+    return result;
+  }
+
+  private enqueueClientPermission(
+    request: AgentPermissionRequest,
+  ): Promise<AgentPermissionResponse> {
+    return new Promise((resolve) => {
+      this.pendingClientPermissions.set(request.id, {
+        request,
+        resolve,
+        turnId: this.activeForegroundTurnId,
+      });
+      this.pushEvent({
+        type: "permission_requested",
+        provider: this.provider,
+        request,
+        turnId: this.activeForegroundTurnId ?? undefined,
+      });
+    });
+  }
+
+  private rejectPendingClientPermissions(): void {
+    for (const [requestId, pending] of this.pendingClientPermissions) {
+      pending.resolve({ behavior: "deny", interrupt: true });
+      this.pushEvent({
+        type: "permission_resolved",
+        provider: this.provider,
+        requestId,
+        resolution: { behavior: "deny", interrupt: true },
+        turnId: pending.turnId ?? undefined,
+      });
+    }
+    this.pendingClientPermissions.clear();
   }
 
   // Cache an asynchronously-delivered slash-command batch and unblock any
@@ -2589,6 +2774,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       await this.setThinkingOption(this.config.thinkingOptionId);
     }
     const configuredFeatureValues = this.config.featureValues ?? {};
+    for (const feature of this.staticToggleFeatures) {
+      if (!Object.prototype.hasOwnProperty.call(configuredFeatureValues, feature.id)) {
+        continue;
+      }
+      await this.setFeature(feature.id, configuredFeatureValues[feature.id]);
+    }
     for (const featureOption of this.configFeatureOptions) {
       if (!Object.prototype.hasOwnProperty.call(configuredFeatureValues, featureOption.id)) {
         continue;
@@ -2771,7 +2962,11 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private handleCurrentModeUpdate(update: CurrentModeUpdate): void {
-    this.currentMode = this.transformModeId(update.currentModeId);
+    this.currentModeListener?.(update.currentModeId, this.config);
+    const nextMode = this.transformModeId(update.currentModeId);
+    if (nextMode !== null) {
+      this.currentMode = nextMode;
+    }
   }
 
   private handleConfigOptionUpdate(update: ConfigOptionUpdate): AgentStreamEvent[] {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -8,6 +8,10 @@ import {
   type ACPCatalogModelResolver,
   type ACPClientCapabilityMeta,
   type ACPConfigFeatureOption,
+  type ACPCurrentModeListener,
+  type ACPExtMethodHandler,
+  type ACPFeatureWriter,
+  type ACPStaticToggleFeature,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
 } from "./acp-agent.js";
@@ -49,6 +53,11 @@ interface GenericACPAgentClientOptions {
   diagnosticPhaseTimeoutMs?: number;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
+  staticToggleFeatures?: ACPStaticToggleFeature[];
+  featureWriter?: ACPFeatureWriter;
+  extMethodHandler?: ACPExtMethodHandler;
+  currentModeListener?: ACPCurrentModeListener;
+  modeIdTransformer?: (modeId: string) => string | null;
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
 }
@@ -74,6 +83,13 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilities: providerParams.clientCapabilities,
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
+      ...(options.staticToggleFeatures
+        ? { staticToggleFeatures: options.staticToggleFeatures }
+        : {}),
+      ...(options.featureWriter ? { featureWriter: options.featureWriter } : {}),
+      ...(options.extMethodHandler ? { extMethodHandler: options.extMethodHandler } : {}),
+      ...(options.currentModeListener ? { currentModeListener: options.currentModeListener } : {}),
+      ...(options.modeIdTransformer ? { modeIdTransformer: options.modeIdTransformer } : {}),
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
     });

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,63 +1,47 @@
 import { describe, expect, test, vi } from "vitest";
 
-import type { AgentPermissionResponse, AgentSessionConfig } from "../agent-sdk-types.js";
-import { ACPAgentSession } from "./acp-agent.js";
+import type { AgentSessionConfig, AgentTimelineItem } from "../agent-sdk-types.js";
+import type { ACPExtMethodContext } from "./acp-agent.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import {
   GROK_AGENT_MODE_ID,
-  GROK_PLAN_MODE_FEATURE,
   GROK_PLAN_MODE_FEATURE_ID,
   GROK_PLAN_MODE_ID,
   GrokACPAgentClient,
   buildGrokPlanModeFeature,
-  buildGrokPlanPermissionRequest,
-  buildGrokPlanTimelineItem,
   handleGrokExtMethod,
   mapGrokPlanPermissionResponse,
-  normalizeGrokExtMethod,
   parseGrokExitPlanModeRequest,
   syncGrokPlanModeFromCurrentMode,
   transformGrokModeId,
   writeGrokFeature,
 } from "./grok-acp-agent.js";
 
-const GROK_CAPABILITIES = {
-  supportsStreaming: true,
-  supportsSessionPersistence: true,
-  supportsDynamicModes: true,
-  supportsMcpServers: true,
-  supportsReasoningStream: true,
-  supportsToolInvocations: true,
-};
-
-function createGrokSession(featureValues?: Record<string, unknown>): ACPAgentSession {
-  return new ACPAgentSession(
-    {
-      provider: "acp",
-      cwd: "/tmp/paseo-grok-test",
-      featureValues,
-    },
-    {
-      provider: "acp",
-      logger: createTestLogger(),
-      defaultCommand: ["grok", "agent", "stdio"],
-      defaultModes: [],
-      staticToggleFeatures: [GROK_PLAN_MODE_FEATURE],
-      featureWriter: writeGrokFeature,
-      extMethodHandler: handleGrokExtMethod,
-      currentModeListener: syncGrokPlanModeFromCurrentMode,
-      modeIdTransformer: transformGrokModeId,
-      capabilities: GROK_CAPABILITIES,
-    },
-  );
+function createExtMethodContext(
+  overrides: Partial<ACPExtMethodContext> = {},
+): ACPExtMethodContext & { timeline: AgentTimelineItem[] } {
+  const timeline: AgentTimelineItem[] = [];
+  const config: AgentSessionConfig = {
+    provider: "acp",
+    cwd: "/tmp/paseo-grok-test",
+    featureValues: { [GROK_PLAN_MODE_FEATURE_ID]: true },
+  };
+  return {
+    provider: "acp",
+    sessionId: "sess-1",
+    requestPermission: async () => ({ behavior: "allow", selectedActionId: "implement" }),
+    ...overrides,
+    config: overrides.config ?? config,
+    emitTimeline:
+      overrides.emitTimeline ??
+      ((item) => {
+        timeline.push(item);
+      }),
+    timeline,
+  };
 }
 
 describe("Grok plan mode helpers", () => {
-  test("normalizes underscored extension methods", () => {
-    expect(normalizeGrokExtMethod("_x.ai/exit_plan_mode")).toBe("x.ai/exit_plan_mode");
-    expect(normalizeGrokExtMethod("x.ai/exit_plan_mode")).toBe("x.ai/exit_plan_mode");
-  });
-
   test("parses camelCase exit_plan_mode params", () => {
     expect(
       parseGrokExitPlanModeRequest({
@@ -104,35 +88,6 @@ describe("Grok plan mode helpers", () => {
     expect(mapGrokPlanPermissionResponse({ behavior: "deny", interrupt: true })).toEqual({
       outcome: "cancelled",
     });
-  });
-
-  test("builds a plan permission with implement and dismiss actions", () => {
-    expect(
-      buildGrokPlanPermissionRequest({ provider: "acp", planContent: "- step" }),
-    ).toMatchObject({
-      provider: "acp",
-      name: "GrokPlanApproval",
-      kind: "plan",
-      title: "Plan",
-      input: { plan: "- step" },
-      detail: { type: "plan", text: "- step" },
-      actions: [
-        { id: "dismiss", behavior: "deny", intent: "dismiss" },
-        { id: "implement", behavior: "allow", intent: "implement" },
-      ],
-    });
-  });
-
-  test("builds a completed plan timeline item only when the plan has text", () => {
-    expect(buildGrokPlanTimelineItem({ toolCallId: "tc-1", planContent: "# Ship it" })).toEqual({
-      type: "tool_call",
-      callId: "tc-1",
-      name: "plan",
-      status: "completed",
-      error: null,
-      detail: { type: "plan", text: "# Ship it" },
-    });
-    expect(buildGrokPlanTimelineItem({ toolCallId: "tc-1", planContent: "  " })).toBeNull();
   });
 
   test("writeGrokFeature toggles session/set_mode between plan and agent", async () => {
@@ -218,54 +173,80 @@ describe("GrokACPAgentClient", () => {
   });
 });
 
-describe("Grok ACP session plan support", () => {
-  test("exposes plan_mode from restored feature values", () => {
-    const session = createGrokSession({ [GROK_PLAN_MODE_FEATURE_ID]: true });
-    expect(session.features).toEqual(expect.arrayContaining([buildGrokPlanModeFeature(true)]));
+describe("Grok exit_plan_mode handling", () => {
+  test("approves a plan and records it on the timeline", async () => {
+    const context = createExtMethodContext();
+
+    await expect(
+      handleGrokExtMethod(
+        "x.ai/exit_plan_mode",
+        {
+          sessionId: "sess-1",
+          toolCallId: "tc-plan",
+          planContent: "- add tests",
+        },
+        context,
+      ),
+    ).resolves.toEqual({ outcome: "approved" });
+
+    expect(context.config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: false });
+    expect(context.timeline).toEqual([
+      {
+        type: "tool_call",
+        callId: "tc-plan",
+        name: "plan",
+        status: "completed",
+        error: null,
+        detail: { type: "plan", text: "- add tests" },
+      },
+    ]);
   });
 
-  test("approves an exit_plan_mode ext method through the plan permission card", async () => {
-    const session = createGrokSession({ [GROK_PLAN_MODE_FEATURE_ID]: true });
-    const events: unknown[] = [];
-    session.subscribe((event) => {
-      events.push(event);
-    });
-    Object.assign(session, { sessionId: "sess-1" });
-
-    const extMethod = session.extMethod("x.ai/exit_plan_mode", {
-      sessionId: "sess-1",
-      toolCallId: "tc-plan",
-      planContent: "- add tests",
+  test("does not record a completed plan when the user dismisses approval", async () => {
+    const context = createExtMethodContext({
+      requestPermission: async () => ({ behavior: "deny", selectedActionId: "dismiss" }),
     });
 
-    const requested = events.find(
-      (event) =>
-        typeof event === "object" &&
-        event !== null &&
-        "type" in event &&
-        event.type === "permission_requested",
-    ) as { request: { id: string } } | undefined;
-    expect(requested?.request.id).toEqual(expect.any(String));
+    await expect(
+      handleGrokExtMethod(
+        "_x.ai/exit_plan_mode",
+        {
+          sessionId: "sess-1",
+          toolCallId: "tc-plan",
+          planContent: "- add tests",
+        },
+        context,
+      ),
+    ).resolves.toEqual({ outcome: "cancelled" });
 
-    const response: AgentPermissionResponse = {
-      behavior: "allow",
-      selectedActionId: "implement",
-    };
-    await session.respondToPermission(requested!.request.id, response);
+    expect(context.config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: true });
+    expect(context.timeline).toEqual([]);
+  });
 
-    await expect(extMethod).resolves.toEqual({ outcome: "approved" });
-    expect(session.features).toEqual(expect.arrayContaining([buildGrokPlanModeFeature(false)]));
-    expect(events).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "timeline",
-          item: expect.objectContaining({
-            type: "tool_call",
-            callId: "tc-plan",
-            detail: { type: "plan", text: "- add tests" },
-          }),
-        }),
-      ]),
-    );
+  test("rejects an exit_plan_mode request for a different session", async () => {
+    const context = createExtMethodContext();
+
+    await expect(
+      handleGrokExtMethod(
+        "x.ai/exit_plan_mode",
+        {
+          sessionId: "other-session",
+          toolCallId: "tc-plan",
+          planContent: "- add tests",
+        },
+        context,
+      ),
+    ).rejects.toThrow("exit_plan_mode sessionId does not match the active session");
+    expect(context.timeline).toEqual([]);
+  });
+
+  test("ignores unrelated extension methods", async () => {
+    await expect(
+      handleGrokExtMethod(
+        "x.ai/ask_user_question",
+        { sessionId: "sess-1" },
+        createExtMethodContext(),
+      ),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
 
-import type { AgentSessionConfig, AgentTimelineItem } from "../agent-sdk-types.js";
-import type { ACPExtMethodContext } from "./acp-agent.js";
+import type {
+  AgentPermissionResponse,
+  AgentSessionConfig,
+  AgentTimelineItem,
+} from "../agent-sdk-types.js";
+import type { ACPClientPermissionResponseHandler, ACPExtMethodContext } from "./acp-agent.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import {
   GROK_AGENT_MODE_ID,
@@ -29,7 +33,14 @@ function createExtMethodContext(
   return {
     provider: "acp",
     sessionId: "sess-1",
-    requestPermission: async () => ({ behavior: "allow", selectedActionId: "implement" }),
+    requestPermission: async (_request, onResponse) => {
+      const response: AgentPermissionResponse = {
+        behavior: "allow",
+        selectedActionId: "implement",
+      };
+      onResponse?.(response);
+      return response;
+    },
     ...overrides,
     config: overrides.config ?? config,
     emitTimeline:
@@ -204,7 +215,14 @@ describe("Grok exit_plan_mode handling", () => {
 
   test("does not record a completed plan when the user dismisses approval", async () => {
     const context = createExtMethodContext({
-      requestPermission: async () => ({ behavior: "deny", selectedActionId: "dismiss" }),
+      requestPermission: async (_request, onResponse) => {
+        const response: AgentPermissionResponse = {
+          behavior: "deny",
+          selectedActionId: "dismiss",
+        };
+        onResponse?.(response);
+        return response;
+      },
     });
 
     await expect(
@@ -221,6 +239,52 @@ describe("Grok exit_plan_mode handling", () => {
 
     expect(context.config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: true });
     expect(context.timeline).toEqual([]);
+  });
+
+  test("turns plan mode off when Implement is resolved, before the handler resumes", async () => {
+    let resolvePermission!: (response: AgentPermissionResponse) => void;
+    let onResponse: ACPClientPermissionResponseHandler | undefined;
+    const context = createExtMethodContext({
+      requestPermission: (_request, handler) => {
+        onResponse = handler;
+        return new Promise((resolve) => {
+          resolvePermission = resolve;
+        });
+      },
+    });
+
+    const pending = handleGrokExtMethod(
+      "x.ai/exit_plan_mode",
+      {
+        sessionId: "sess-1",
+        toolCallId: "tc-plan",
+        planContent: "- add tests",
+      },
+      context,
+    );
+
+    expect(context.config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: true });
+    expect(context.timeline).toEqual([]);
+
+    const response: AgentPermissionResponse = {
+      behavior: "allow",
+      selectedActionId: "implement",
+    };
+    onResponse?.(response);
+    expect(context.config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: false });
+    expect(context.timeline).toEqual([
+      {
+        type: "tool_call",
+        callId: "tc-plan",
+        name: "plan",
+        status: "completed",
+        error: null,
+        detail: { type: "plan", text: "- add tests" },
+      },
+    ]);
+
+    resolvePermission(response);
+    await expect(pending).resolves.toEqual({ outcome: "approved" });
   });
 
   test("rejects an exit_plan_mode request for a different session", async () => {

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { AgentPermissionResponse, AgentSessionConfig } from "../agent-sdk-types.js";
+import { ACPAgentSession } from "./acp-agent.js";
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import {
+  GROK_AGENT_MODE_ID,
+  GROK_PLAN_MODE_FEATURE,
+  GROK_PLAN_MODE_FEATURE_ID,
+  GROK_PLAN_MODE_ID,
+  GrokACPAgentClient,
+  buildGrokPlanModeFeature,
+  buildGrokPlanPermissionRequest,
+  buildGrokPlanTimelineItem,
+  handleGrokExtMethod,
+  mapGrokPlanPermissionResponse,
+  normalizeGrokExtMethod,
+  parseGrokExitPlanModeRequest,
+  syncGrokPlanModeFromCurrentMode,
+  transformGrokModeId,
+  writeGrokFeature,
+} from "./grok-acp-agent.js";
+
+const GROK_CAPABILITIES = {
+  supportsStreaming: true,
+  supportsSessionPersistence: true,
+  supportsDynamicModes: true,
+  supportsMcpServers: true,
+  supportsReasoningStream: true,
+  supportsToolInvocations: true,
+};
+
+function createGrokSession(featureValues?: Record<string, unknown>): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "acp",
+      cwd: "/tmp/paseo-grok-test",
+      featureValues,
+    },
+    {
+      provider: "acp",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: [],
+      staticToggleFeatures: [GROK_PLAN_MODE_FEATURE],
+      featureWriter: writeGrokFeature,
+      extMethodHandler: handleGrokExtMethod,
+      currentModeListener: syncGrokPlanModeFromCurrentMode,
+      modeIdTransformer: transformGrokModeId,
+      capabilities: GROK_CAPABILITIES,
+    },
+  );
+}
+
+describe("Grok plan mode helpers", () => {
+  test("normalizes underscored extension methods", () => {
+    expect(normalizeGrokExtMethod("_x.ai/exit_plan_mode")).toBe("x.ai/exit_plan_mode");
+    expect(normalizeGrokExtMethod("x.ai/exit_plan_mode")).toBe("x.ai/exit_plan_mode");
+  });
+
+  test("parses camelCase exit_plan_mode params", () => {
+    expect(
+      parseGrokExitPlanModeRequest({
+        sessionId: "sess-1",
+        toolCallId: "tc-1",
+        planContent: "# Plan",
+      }),
+    ).toEqual({
+      sessionId: "sess-1",
+      toolCallId: "tc-1",
+      planContent: "# Plan",
+    });
+  });
+
+  test("parses snake_case exit_plan_mode params", () => {
+    expect(
+      parseGrokExitPlanModeRequest({
+        session_id: "sess-1",
+        tool_call_id: "tc-1",
+        plan_content: null,
+      }),
+    ).toEqual({
+      sessionId: "sess-1",
+      toolCallId: "tc-1",
+      planContent: null,
+    });
+  });
+
+  test("rejects exit_plan_mode params without session or tool identity", () => {
+    expect(() => parseGrokExitPlanModeRequest({ planContent: "# Plan" })).toThrow(
+      "Invalid exit_plan_mode params",
+    );
+  });
+
+  test("maps implement to approved and dismiss to cancelled", () => {
+    expect(
+      mapGrokPlanPermissionResponse({ behavior: "allow", selectedActionId: "implement" }),
+    ).toEqual({ outcome: "approved" });
+    expect(
+      mapGrokPlanPermissionResponse({ behavior: "deny", selectedActionId: "dismiss" }),
+    ).toEqual({
+      outcome: "cancelled",
+    });
+    expect(mapGrokPlanPermissionResponse({ behavior: "deny", interrupt: true })).toEqual({
+      outcome: "cancelled",
+    });
+  });
+
+  test("builds a plan permission with implement and dismiss actions", () => {
+    expect(
+      buildGrokPlanPermissionRequest({ provider: "acp", planContent: "- step" }),
+    ).toMatchObject({
+      provider: "acp",
+      name: "GrokPlanApproval",
+      kind: "plan",
+      title: "Plan",
+      input: { plan: "- step" },
+      detail: { type: "plan", text: "- step" },
+      actions: [
+        { id: "dismiss", behavior: "deny", intent: "dismiss" },
+        { id: "implement", behavior: "allow", intent: "implement" },
+      ],
+    });
+  });
+
+  test("builds a completed plan timeline item only when the plan has text", () => {
+    expect(buildGrokPlanTimelineItem({ toolCallId: "tc-1", planContent: "# Ship it" })).toEqual({
+      type: "tool_call",
+      callId: "tc-1",
+      name: "plan",
+      status: "completed",
+      error: null,
+      detail: { type: "plan", text: "# Ship it" },
+    });
+    expect(buildGrokPlanTimelineItem({ toolCallId: "tc-1", planContent: "  " })).toBeNull();
+  });
+
+  test("writeGrokFeature toggles session/set_mode between plan and agent", async () => {
+    const setSessionMode = vi.fn().mockResolvedValue({});
+    await expect(
+      writeGrokFeature({
+        connection: { setSessionMode } as never,
+        sessionId: "sess-1",
+        featureId: GROK_PLAN_MODE_FEATURE_ID,
+        value: true,
+      }),
+    ).resolves.toBe(true);
+    expect(setSessionMode).toHaveBeenCalledWith({
+      sessionId: "sess-1",
+      modeId: GROK_PLAN_MODE_ID,
+    });
+
+    await writeGrokFeature({
+      connection: { setSessionMode } as never,
+      sessionId: "sess-1",
+      featureId: GROK_PLAN_MODE_FEATURE_ID,
+      value: false,
+    });
+    expect(setSessionMode).toHaveBeenLastCalledWith({
+      sessionId: "sess-1",
+      modeId: GROK_AGENT_MODE_ID,
+    });
+
+    await expect(
+      writeGrokFeature({
+        connection: { setSessionMode } as never,
+        sessionId: "sess-1",
+        featureId: "auto_accept",
+        value: true,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test("syncs plan_mode from Grok current_mode_update ids only", () => {
+    const config: AgentSessionConfig = { provider: "acp", cwd: "/tmp" };
+    syncGrokPlanModeFromCurrentMode(GROK_PLAN_MODE_ID, config);
+    expect(config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: true });
+    syncGrokPlanModeFromCurrentMode(GROK_AGENT_MODE_ID, config);
+    expect(config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: false });
+    syncGrokPlanModeFromCurrentMode("default", config);
+    expect(config.featureValues).toEqual({ [GROK_PLAN_MODE_FEATURE_ID]: false });
+  });
+
+  test("hides Grok collaboration modes from the permission-mode picker", () => {
+    expect(transformGrokModeId(GROK_PLAN_MODE_ID)).toBeNull();
+    expect(transformGrokModeId(GROK_AGENT_MODE_ID)).toBeNull();
+    expect(transformGrokModeId("default")).toBe("default");
+  });
+});
+
+describe("GrokACPAgentClient", () => {
+  test("lists plan_mode without probing a session", async () => {
+    const client = new GrokACPAgentClient({
+      logger: createTestLogger(),
+      command: ["grok", "agent", "stdio"],
+      providerId: "grok",
+      label: "Grok",
+    });
+
+    await expect(
+      client.listFeatures({
+        provider: "acp",
+        cwd: "/tmp/paseo-grok-test",
+        featureValues: { [GROK_PLAN_MODE_FEATURE_ID]: true },
+      }),
+    ).resolves.toEqual([
+      {
+        type: "toggle",
+        id: "auto_accept",
+        label: "Auto Accept",
+        description: "Automatically approves ACP permission prompts.",
+        tooltip: "Auto accept permission prompts",
+        icon: "shield-check",
+        value: false,
+      },
+      buildGrokPlanModeFeature(true),
+    ]);
+  });
+});
+
+describe("Grok ACP session plan support", () => {
+  test("exposes plan_mode from restored feature values", () => {
+    const session = createGrokSession({ [GROK_PLAN_MODE_FEATURE_ID]: true });
+    expect(session.features).toEqual(expect.arrayContaining([buildGrokPlanModeFeature(true)]));
+  });
+
+  test("approves an exit_plan_mode ext method through the plan permission card", async () => {
+    const session = createGrokSession({ [GROK_PLAN_MODE_FEATURE_ID]: true });
+    const events: unknown[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+    Object.assign(session, { sessionId: "sess-1" });
+
+    const extMethod = session.extMethod("x.ai/exit_plan_mode", {
+      sessionId: "sess-1",
+      toolCallId: "tc-plan",
+      planContent: "- add tests",
+    });
+
+    const requested = events.find(
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        event.type === "permission_requested",
+    ) as { request: { id: string } } | undefined;
+    expect(requested?.request.id).toEqual(expect.any(String));
+
+    const response: AgentPermissionResponse = {
+      behavior: "allow",
+      selectedActionId: "implement",
+    };
+    await session.respondToPermission(requested!.request.id, response);
+
+    await expect(extMethod).resolves.toEqual({ outcome: "approved" });
+    expect(session.features).toEqual(expect.arrayContaining([buildGrokPlanModeFeature(false)]));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "timeline",
+          item: expect.objectContaining({
+            type: "tool_call",
+            callId: "tc-plan",
+            detail: { type: "plan", text: "- add tests" },
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,249 @@
+// Grok does not publish ACP availableModes. Plan is a session/set_mode pair
+// (plan|agent) plus a reverse x.ai/exit_plan_mode ext_method for approval.
+// The composer surface matches Codex: a plan_mode toggle and a plan card.
+
+import { randomUUID } from "node:crypto";
+
+import type { Logger } from "pino";
+
+import type {
+  AgentFeatureToggle,
+  AgentPermissionRequest,
+  AgentPermissionResponse,
+  AgentSessionConfig,
+  AgentTimelineItem,
+} from "../agent-sdk-types.js";
+import type {
+  ACPExtMethodContext,
+  ACPFeatureWriterContext,
+  ACPStaticToggleFeature,
+} from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+export const GROK_PLAN_MODE_FEATURE_ID = "plan_mode";
+export const GROK_PLAN_MODE_ID = "plan";
+export const GROK_AGENT_MODE_ID = "agent";
+export const GROK_EXIT_PLAN_MODE_METHOD = "x.ai/exit_plan_mode";
+
+export const GROK_PLAN_MODE_FEATURE: ACPStaticToggleFeature = {
+  id: GROK_PLAN_MODE_FEATURE_ID,
+  label: "Plan",
+  description: "Switch Grok into planning-only collaboration mode",
+  tooltip: "Toggle plan mode",
+  icon: "list-todo",
+};
+
+export interface GrokExitPlanModeRequest {
+  sessionId: string;
+  toolCallId: string;
+  planContent: string | null;
+}
+
+export interface GrokExitPlanModeResponse {
+  outcome: "approved" | "cancelled" | "abandoned";
+  feedback?: string;
+}
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+export function buildGrokPlanModeFeature(enabled: boolean): AgentFeatureToggle {
+  return {
+    ...GROK_PLAN_MODE_FEATURE,
+    type: "toggle",
+    value: enabled,
+  };
+}
+
+export function normalizeGrokExtMethod(method: string): string {
+  return method.startsWith("_") ? method.slice(1) : method;
+}
+
+export function parseGrokExitPlanModeRequest(
+  params: Record<string, unknown>,
+): GrokExitPlanModeRequest {
+  const sessionId = readOptionalString(params, ["sessionId", "session_id"]);
+  const toolCallId = readOptionalString(params, ["toolCallId", "tool_call_id"]);
+  if (!sessionId || !toolCallId) {
+    throw new Error("Invalid exit_plan_mode params");
+  }
+
+  return {
+    sessionId,
+    toolCallId,
+    planContent: readOptionalString(params, ["planContent", "plan_content"]),
+  };
+}
+
+export function mapGrokPlanPermissionResponse(
+  response: AgentPermissionResponse,
+): GrokExitPlanModeResponse {
+  if (response.behavior === "allow") {
+    return { outcome: "approved" };
+  }
+  return { outcome: "cancelled" };
+}
+
+export function buildGrokPlanPermissionRequest(params: {
+  provider: string;
+  planContent: string | null;
+}): AgentPermissionRequest {
+  const planText = params.planContent?.trim() ?? "";
+  return {
+    id: `grok-plan-${randomUUID()}`,
+    provider: params.provider,
+    name: "GrokPlanApproval",
+    kind: "plan",
+    title: "Plan",
+    description: "Review the proposed plan before implementation starts.",
+    input: { plan: planText },
+    detail: planText
+      ? {
+          type: "plan",
+          text: planText,
+        }
+      : undefined,
+    actions: [
+      {
+        id: "dismiss",
+        label: "Dismiss",
+        behavior: "deny",
+        variant: "danger",
+        intent: "dismiss",
+      },
+      {
+        id: "implement",
+        label: "Implement",
+        behavior: "allow",
+        variant: "primary",
+        intent: "implement",
+      },
+    ],
+    metadata: {
+      planText,
+      source: "grok_plan_approval",
+    },
+  };
+}
+
+export function buildGrokPlanTimelineItem(params: {
+  toolCallId: string;
+  planContent: string | null;
+}): Extract<AgentTimelineItem, { type: "tool_call" }> | null {
+  const text = params.planContent?.trim() ?? "";
+  if (!text) {
+    return null;
+  }
+  return {
+    type: "tool_call",
+    callId: params.toolCallId,
+    name: "plan",
+    status: "completed",
+    error: null,
+    detail: {
+      type: "plan",
+      text,
+    },
+  };
+}
+
+export async function writeGrokFeature(context: ACPFeatureWriterContext): Promise<boolean> {
+  if (context.featureId !== GROK_PLAN_MODE_FEATURE_ID) {
+    return false;
+  }
+
+  await context.connection.setSessionMode({
+    sessionId: context.sessionId,
+    modeId: context.value === true ? GROK_PLAN_MODE_ID : GROK_AGENT_MODE_ID,
+  });
+  return true;
+}
+
+export function syncGrokPlanModeFromCurrentMode(
+  modeId: string | null,
+  config: AgentSessionConfig,
+): void {
+  if (modeId !== GROK_PLAN_MODE_ID && modeId !== GROK_AGENT_MODE_ID) {
+    return;
+  }
+  config.featureValues = {
+    ...config.featureValues,
+    [GROK_PLAN_MODE_FEATURE_ID]: modeId === GROK_PLAN_MODE_ID,
+  };
+}
+
+export function transformGrokModeId(modeId: string): string | null {
+  if (modeId === GROK_PLAN_MODE_ID || modeId === GROK_AGENT_MODE_ID) {
+    return null;
+  }
+  return modeId;
+}
+
+export async function handleGrokExtMethod(
+  method: string,
+  params: Record<string, unknown>,
+  context: ACPExtMethodContext,
+): Promise<Record<string, unknown> | null> {
+  if (normalizeGrokExtMethod(method) !== GROK_EXIT_PLAN_MODE_METHOD) {
+    return null;
+  }
+
+  const request = parseGrokExitPlanModeRequest(params);
+  if (context.sessionId && request.sessionId !== context.sessionId) {
+    throw new Error("exit_plan_mode sessionId does not match the active session");
+  }
+
+  const permission = buildGrokPlanPermissionRequest({
+    provider: context.provider,
+    planContent: request.planContent,
+  });
+  const response = await context.requestPermission(permission);
+  const timelineItem = buildGrokPlanTimelineItem({
+    toolCallId: request.toolCallId,
+    planContent: request.planContent,
+  });
+  if (timelineItem) {
+    context.emitTimeline(timelineItem);
+  }
+  if (response.behavior === "allow") {
+    syncGrokPlanModeFromCurrentMode(GROK_AGENT_MODE_ID, context.config);
+  }
+  return { ...mapGrokPlanPermissionResponse(response) };
+}
+
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      staticToggleFeatures: [GROK_PLAN_MODE_FEATURE],
+      featureWriter: writeGrokFeature,
+      extMethodHandler: handleGrokExtMethod,
+      currentModeListener: syncGrokPlanModeFromCurrentMode,
+      modeIdTransformer: transformGrokModeId,
+    });
+  }
+}
+
+function readOptionalString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+    if (value === null) {
+      return null;
+    }
+  }
+  return null;
+}

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -203,18 +203,28 @@ export async function handleGrokExtMethod(
     provider: context.provider,
     planContent: request.planContent,
   });
-  const response = await context.requestPermission(permission);
-  if (response.behavior === "allow") {
-    const timelineItem = buildGrokPlanTimelineItem({
-      toolCallId: request.toolCallId,
-      planContent: request.planContent,
-    });
-    if (timelineItem) {
-      context.emitTimeline(timelineItem);
-    }
-    syncGrokPlanModeFromCurrentMode(GROK_AGENT_MODE_ID, context.config);
-  }
+  const response = await context.requestPermission(permission, (resolved) => {
+    applyGrokPlanApproval(resolved, request, context);
+  });
   return { ...mapGrokPlanPermissionResponse(response) };
+}
+
+function applyGrokPlanApproval(
+  response: AgentPermissionResponse,
+  request: GrokExitPlanModeRequest,
+  context: ACPExtMethodContext,
+): void {
+  if (response.behavior !== "allow") {
+    return;
+  }
+  const timelineItem = buildGrokPlanTimelineItem({
+    toolCallId: request.toolCallId,
+    planContent: request.planContent,
+  });
+  if (timelineItem) {
+    context.emitTimeline(timelineItem);
+  }
+  syncGrokPlanModeFromCurrentMode(GROK_AGENT_MODE_ID, context.config);
 }
 
 export class GrokACPAgentClient extends GenericACPAgentClient {

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -61,7 +61,7 @@ export function buildGrokPlanModeFeature(enabled: boolean): AgentFeatureToggle {
   };
 }
 
-export function normalizeGrokExtMethod(method: string): string {
+function normalizeGrokExtMethod(method: string): string {
   return method.startsWith("_") ? method.slice(1) : method;
 }
 
@@ -90,7 +90,7 @@ export function mapGrokPlanPermissionResponse(
   return { outcome: "cancelled" };
 }
 
-export function buildGrokPlanPermissionRequest(params: {
+function buildGrokPlanPermissionRequest(params: {
   provider: string;
   planContent: string | null;
 }): AgentPermissionRequest {
@@ -132,7 +132,7 @@ export function buildGrokPlanPermissionRequest(params: {
   };
 }
 
-export function buildGrokPlanTimelineItem(params: {
+function buildGrokPlanTimelineItem(params: {
   toolCallId: string;
   planContent: string | null;
 }): Extract<AgentTimelineItem, { type: "tool_call" }> | null {
@@ -204,14 +204,14 @@ export async function handleGrokExtMethod(
     planContent: request.planContent,
   });
   const response = await context.requestPermission(permission);
-  const timelineItem = buildGrokPlanTimelineItem({
-    toolCallId: request.toolCallId,
-    planContent: request.planContent,
-  });
-  if (timelineItem) {
-    context.emitTimeline(timelineItem);
-  }
   if (response.behavior === "allow") {
+    const timelineItem = buildGrokPlanTimelineItem({
+      toolCallId: request.toolCallId,
+      planContent: request.planContent,
+    });
+    if (timelineItem) {
+      context.emitTimeline(timelineItem);
+    }
     syncGrokPlanModeFromCurrentMode(GROK_AGENT_MODE_ID, context.config);
   }
   return { ...mapGrokPlanPermissionResponse(response) };


### PR DESCRIPTION
### Linked issue

None. Related to #3298, which added a Grok ACP adapter for reasoning effort and explicitly left plan mode out of scope. This PR is the plan-mode follow-up.

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Grok already has a first-class plan workflow: `session/set_mode` with `plan` / `agent`, and a reverse `x.ai/exit_plan_mode` ext method when the agent is ready for review. Paseo still launched Grok as a generic ACP provider, so that surface never appeared. There is no `availableModes` list, no `thought_level`-style config option, and the existing composer Plan control only lights up for a `plan_mode` feature or a published planning mode.

Without a Grok-specific adapter, the only way to enter plan mode is the Grok CLI. This PR maps Grok's native plan/agent modes onto the same `plan_mode` toggle Codex already uses, and turns `x.ai/exit_plan_mode` into the existing plan permission card. A Grok session can then plan, review, and implement from the composer instead of leaving Paseo.

### Goals

- Advertise a `plan_mode` toggle for Grok without publishing `plan` / `agent` as permission modes.
- Write the toggle through `session/set_mode` (`plan` on, `agent` off).
- Keep the toggle in sync when Grok itself changes mode (`enter_plan_mode`, resume, etc.).
- Handle `x.ai/exit_plan_mode` as a plan permission: Implement → `approved`, Dismiss → `cancelled`.
- Persist the approved plan on the timeline so it remains visible after the card closes.
- Cover the mapping, feature write, and approval path with unit tests.

### Non-goals

- Change the shared plan UI.
- Add line comments or a third "request changes" action. Dismiss keeps Grok in plan mode (`cancelled`); the user can still turn the toggle off.
- Make Grok a first-class built-in provider.
- Merge or rebase onto #3298. Both PRs add `grok-acp-agent.ts`; they will need a rebase if both land.

### QA

Real Grok CLI 1.0.3 ACP probe (`grok agent stdio`):

- `session/new` does not return `modes` or `availableModes`.
- `session/set_mode` with `modeId: "plan"` is accepted and the agent notifies:

```text
session/update
sessionUpdate=current_mode_update
currentModeId=plan
```

- `session/set_mode` with `modeId: "agent"` returns to agent mode.
- Other mode ids (`default`, `normal`, `ask`, `yolo`) are accepted but do not emit `current_mode_update`.
- `_x.ai/toggle_plan_mode` as a client request is method-not-found. The live toggle is `session/set_mode`.
- Wire types for approval come from Grok Build's published `ExitPlanModeExtRequest` / `ExitPlanModeExtResponse`: `{ sessionId, toolCallId, planContent? }` → `{ outcome: "approved" | "cancelled" | "abandoned" }`.

Automated tests:

```text
cd packages/server && npm run test:unit -- \
  src/server/agent/providers/grok-acp-agent.test.ts \
  src/server/agent/providers/generic-acp-agent.test.ts \
  src/server/agent/provider-registry.test.ts \
  src/server/agent/providers/acp-agent.test.ts \
  --bail=1

Test Files  4 passed (4)
Tests       161 passed (161)
```

The Grok file covers request parsing, Implement/Dismiss mapping, `set_mode` writes, current-mode sync, and a live ext-method → plan card → `approved` path.

```text
npm run typecheck --workspace=@getpaseo/server
passed

npm run lint -- packages/server/src/server/agent/providers/grok-acp-agent.ts \
  packages/server/src/server/agent/providers/grok-acp-agent.test.ts \
  packages/server/src/server/agent/providers/acp-agent.ts \
  packages/server/src/server/agent/providers/generic-acp-agent.ts \
  packages/server/src/server/agent/provider-registry.ts \
  packages/server/src/server/agent/provider-registry.test.ts
Found 0 warnings and 0 errors.

npm run format:files -- <same files>
passed
```

No new UI was added. The existing Plan toggle and plan permission card appear once the adapter advertises `plan_mode` and emits a `kind: "plan"` permission. I did not click through a live Paseo composer against this branch. I also did not run a full Grok plan turn end-to-end in Paseo; the approval path is covered by the unit test plus the published Grok ext-method schema.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | No UI change; not tested |
| Android         |        | No UI change; not tested |
| Web             |        | No live composer run |
| Desktop macOS   | x      | Adapter tests + real `grok` 1.0.3 ACP probe |
| Desktop Windows |        | Not tested |
| Desktop Linux   |        | Not tested |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
