### PR TITLE
fix(app): show finalized Codex output immediately

### DIFF
--- a/packages/app/src/types/stream-event.test.ts
+++ b/packages/app/src/types/stream-event.test.ts
@@ -132,6 +132,37 @@ describe("applyStreamEvent", () => {
     expect(result.tail[0].kind).toBe("assistant_message");
   });
 
+  it("replaces a stale tail item with the finalized head item on turn completion", () => {
+    const result = applyStreamEvent({
+      tail: [
+        {
+          kind: "assistant_message",
+          id: "assistant-shared",
+          text: "Partial answer",
+          timestamp: new Date(0),
+        },
+      ],
+      head: [
+        {
+          kind: "assistant_message",
+          id: "assistant-shared",
+          text: "Partial answer with the final result",
+          timestamp: new Date(1),
+        },
+      ],
+      event: completionEvent(),
+      timestamp: baseTimestamp,
+    });
+
+    expect(result.head).toHaveLength(0);
+    expect(result.tail).toHaveLength(1);
+    expect(result.tail[0]).toMatchObject({
+      kind: "assistant_message",
+      id: "assistant-shared",
+      text: "Partial answer with the final result",
+    });
+  });
+
   it("does not continue a tail assistant message when the incoming message id differs", () => {
     const result = applyStreamEvent({
       tail: [

--- a/packages/app/src/types/stream.ts
+++ b/packages/app/src/types/stream.ts
@@ -1695,7 +1695,7 @@ function promoteCompletedAssistantBlocks(params: { tail: StreamItem[]; head: Str
 }
 
 /**
- * Flush head items to tail, avoiding duplicates.
+ * Flush head items to tail, replacing stale copies with their finalized version.
  */
 export function flushHeadToTail(tail: StreamItem[], head: StreamItem[]): StreamItem[] {
   if (head.length === 0) {
@@ -1703,13 +1703,29 @@ export function flushHeadToTail(tail: StreamItem[], head: StreamItem[]): StreamI
   }
 
   const finalized = finalizeHeadItems(head);
-  const tailIds = new Set(tail.map((item) => item.id));
-  const newItems = finalized.filter((item) => !tailIds.has(item.id));
+  const tailIndexById = new Map(tail.map((item, index) => [item.id, index]));
+  let nextTail = tail;
 
-  if (newItems.length === 0) {
-    return tail;
+  for (const item of finalized) {
+    const existingIndex = tailIndexById.get(item.id);
+    if (existingIndex === undefined) {
+      if (nextTail === tail) {
+        nextTail = [...tail];
+      }
+      nextTail.push(item);
+      tailIndexById.set(item.id, nextTail.length - 1);
+      continue;
+    }
+
+    if (nextTail[existingIndex] !== item) {
+      if (nextTail === tail) {
+        nextTail = [...tail];
+      }
+      nextTail[existingIndex] = item;
+    }
   }
-  return [...tail, ...newItems];
+
+  return nextTail;
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace stale tail items with the finalized head item when a turn completes
- preserve existing append behavior for new item IDs
- add a regression test for partial assistant text being retained after completion

## Root cause

`flushHeadToTail` treated a matching item ID as a duplicate and discarded the finalized head item. When the tail already contained a partial assistant message with that ID, the UI kept the partial text until a later timeline refresh (for example, the next user message).

## Test plan

- `npx vitest run packages/app/src/types/stream-event.test.ts packages/app/src/types/stream.test.ts --bail=1` (62 tests passed)
- pre-commit hook: lint passed
- pre-commit hook: format passed
- pre-commit hook: all-workspace typecheck passed

## TDD evidence

The new regression test failed before the implementation because the tail retained `Partial answer`; after the fix it retains `Partial answer with the final result`.