### PR TITLE
Fix worktree PR remote fallback

### DIFF
--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -411,6 +411,54 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       expect(currentBranch).toBe("Feature.X");
     });
 
+    it("tries other configured remotes when the PR ref is absent from origin", async () => {
+      const originDir = join(tempDir, "fork.git");
+      const upstreamDir = join(tempDir, "upstream.git");
+      const upstreamCloneDir = join(tempDir, "upstream-clone");
+      execFileSync("git", ["clone", "--bare", repoDir, originDir]);
+      execFileSync("git", ["clone", "--bare", repoDir, upstreamDir]);
+      execFileSync("git", ["remote", "add", "origin", originDir], { cwd: repoDir });
+      execFileSync("git", ["remote", "add", "upstream", upstreamDir], { cwd: repoDir });
+
+      execFileSync("git", ["clone", upstreamDir, upstreamCloneDir]);
+      execFileSync("git", ["config", "user.email", "test@test.com"], {
+        cwd: upstreamCloneDir,
+      });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: upstreamCloneDir });
+      execFileSync("git", ["checkout", "-b", "contributor/remote-pr"], {
+        cwd: upstreamCloneDir,
+      });
+      writeFileSync(join(upstreamCloneDir, "file.txt"), "from-upstream-pr\n");
+      execFileSync("git", ["add", "file.txt"], { cwd: upstreamCloneDir });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "upstream pr"], {
+        cwd: upstreamCloneDir,
+      });
+      const prHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: upstreamCloneDir })
+        .toString()
+        .trim();
+      execFileSync("git", ["push", "origin", "contributor/remote-pr"], {
+        cwd: upstreamCloneDir,
+      });
+      execFileSync("git", [`--git-dir=${upstreamDir}`, "update-ref", "refs/pull/44/head", prHead]);
+
+      const result = await createLegacyWorktreeForTest({
+        cwd: repoDir,
+        worktreeSlug: "pr-44",
+        source: {
+          kind: "checkout-github-pr",
+          githubPrNumber: 44,
+          headRef: "contributor/remote-pr",
+          baseRefName: "main",
+        },
+        runSetup: false,
+        paseoHome,
+      });
+
+      expect(readFileSync(join(result.worktreePath, "file.txt"), "utf8")).toBe(
+        "from-upstream-pr\n",
+      );
+    });
+
     it("uses the selected local or origin ref when both exist", async () => {
       const remoteDir = join(tempDir, "remote.git");
       const remoteCloneDir = join(tempDir, "remote-clone");

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1465,33 +1465,44 @@ async function fetchWorktreeCheckoutRefs(options: {
   localBranchName: string;
   checkoutRefs: WorktreeCheckoutRef[];
 }): Promise<void> {
+  const { stdout: remoteOutput } = await runGitCommand(["remote"], { cwd: options.cwd });
+  const configuredRemotes = remoteOutput
+    .split(/\r?\n/)
+    .map((remoteName) => remoteName.trim())
+    .filter((remoteName) => remoteName.length > 0);
+  const attemptedRefs: string[] = [];
   let lastResult:
     | Awaited<ReturnType<typeof runGitCommand>>
     | { stderr: string; stdout: string; exitCode: number | null }
     | null = null;
   for (const checkoutRef of options.checkoutRefs) {
-    lastResult = await runGitCommand(
-      [
-        "fetch",
-        checkoutRef.remoteName ?? "origin",
-        `+${checkoutRef.remoteRef}:refs/heads/${options.localBranchName}`,
-        "--force",
-      ],
-      {
-        cwd: options.cwd,
-        timeout: 120_000,
-        acceptExitCodes: [0, 1, 128],
-      },
-    );
-    if (lastResult.exitCode === 0) {
-      return;
+    const preferredRemote = checkoutRef.remoteName ?? "origin";
+    const candidateRemotes = [
+      preferredRemote,
+      ...configuredRemotes.filter((remoteName) => remoteName !== preferredRemote),
+    ];
+    for (const remoteName of candidateRemotes) {
+      attemptedRefs.push(`${remoteName} ${checkoutRef.remoteRef}`);
+      lastResult = await runGitCommand(
+        [
+          "fetch",
+          remoteName,
+          `+${checkoutRef.remoteRef}:refs/heads/${options.localBranchName}`,
+          "--force",
+        ],
+        {
+          cwd: options.cwd,
+          timeout: 120_000,
+          acceptExitCodes: [0, 1, 128],
+        },
+      );
+      if (lastResult.exitCode === 0) {
+        return;
+      }
     }
   }
-  const attemptedRefs = options.checkoutRefs
-    .map((checkoutRef) => `${checkoutRef.remoteName ?? "origin"} ${checkoutRef.remoteRef}`)
-    .join(", ");
   throw new Error(
-    `Unable to fetch change request refs for worktree branch ${options.localBranchName}: ${attemptedRefs}${lastResult?.stderr ? `\n${lastResult.stderr}` : ""}`,
+    `Unable to fetch change request refs for worktree branch ${options.localBranchName}: ${attemptedRefs.join(", ")}${lastResult?.stderr ? `\n${lastResult.stderr}` : ""}`,
   );
 }
 


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A user selected a GitHub PR from an upstream repository. Their `origin` remote pointed to a fork.

Paseo fetched `refs/pull/256/head` from `origin`, which did not contain the PR ref. The configured `upstream` remote contained the ref.

Paseo now tries each PR or MR ref on the preferred remote first. It then tries the other configured remotes.

Paseo completes these attempts before it tries a less-specific branch ref. This order prevents an unrelated branch on `origin` from winning early.

### Goals

- Create a worktree from a PR ref that exists on `upstream` but not `origin`.
- Preserve the preferred remote as the first fetch target.
- Preserve the order of specific and fallback checkout refs.
- Report every attempted remote and ref when all fetches fail.

### Non-goals

- Change branch-only worktree checkout behavior.
- Change the forge search results or picker UI.
- Add or change Git remotes.

### QA

Reproduced on Linux with a fork checkout. The production daemon logged:

```text
Unable to fetch change request refs for worktree branch tnull/2026-08-update-mcp: origin refs/pull/256/head
fatal: couldn't find remote ref refs/pull/256/head
```

The ref was absent from `origin` and present on `upstream`:

```text
$ git ls-remote origin refs/pull/256/head

$ git ls-remote upstream refs/pull/256/head
09cdb76c8efd2a4103560d3e3c8b944689c2b35a refs/pull/256/head
```

Added a POSIX worktree regression test with two bare remotes. The test puts the PR ref only on `upstream`.

```text
$ GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null npx vitest run packages/server/src/utils/worktree.posix.test.ts --bail=1
Test Files  1 passed (1)
Tests  47 passed | 1 skipped (48)
```

```text
$ npm run build:server
Completed successfully.

$ npm run typecheck
Completed successfully.

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format
Finished successfully on 3651 files.
```

Tested on Linux. macOS and Windows were not tested. This change does not modify the UI.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
