### PR TITLE
Show Grok usage in the composer tooltip

### DIFF
--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -43,6 +43,11 @@ const mockState = vi.hoisted(() => {
         env?: Record<string, string>;
         providerParams?: unknown;
       }>,
+      grok: [] as Array<{
+        command: string[];
+        env?: Record<string, string>;
+        providerParams?: unknown;
+      }>,
       kimi: [] as Array<{
         command: string[];
         env?: Record<string, string>;
@@ -66,6 +71,7 @@ const mockState = vi.hoisted(() => {
       this.constructorArgs.copilot = [];
       this.constructorArgs.cursor = [];
       this.constructorArgs.trae = [];
+      this.constructorArgs.grok = [];
       this.constructorArgs.kimi = [];
       this.constructorArgs.pi = [];
       this.constructorArgs.genericAcp = [];
@@ -448,6 +454,59 @@ vi.mock("./providers/trae-acp-agent.js", () => ({
         env: options.env,
       };
       mockState.constructorArgs.trae.push({
+        command: options.command,
+        env: options.env,
+        providerParams: options.providerParams,
+      });
+    }
+
+    async createSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async resumeSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async fetchCatalog(): Promise<ProviderCatalog> {
+      return {
+        models: mockState.runtimeModels.get(this.provider) ?? [],
+        modes: [],
+      };
+    }
+
+    async isAvailable(): Promise<boolean> {
+      return true;
+    }
+  },
+}));
+
+vi.mock("./providers/grok-acp-agent.js", () => ({
+  GrokACPAgentClient: class GrokACPAgentClient {
+    readonly capabilities = {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    };
+    readonly provider = "acp";
+    readonly runtimeSettings?: unknown;
+
+    constructor(options: {
+      command: string[];
+      env?: Record<string, string>;
+      providerParams?: unknown;
+    }) {
+      this.runtimeSettings = {
+        command: {
+          mode: "replace",
+          argv: options.command,
+        },
+        env: options.env,
+      };
+      mockState.constructorArgs.grok.push({
         command: options.command,
         env: options.env,
         providerParams: options.providerParams,
@@ -914,6 +973,33 @@ test("traecli provider extending acp uses TraeACPAgentClient", () => {
     },
     {
       command: ["traecli", "acp", "serve"],
+      env: undefined,
+      providerParams: undefined,
+    },
+  ]);
+  expect(mockState.constructorArgs.genericAcp).toEqual([]);
+});
+
+test("grok provider extending acp uses GrokACPAgentClient", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      grok: {
+        extends: "acp",
+        label: "Grok",
+        command: ["grok", "agent", "stdio"],
+      },
+    },
+  });
+
+  expect(registry.grok.createClient(logger).provider).toBe("grok");
+  expect(mockState.constructorArgs.grok).toEqual([
+    {
+      command: ["grok", "agent", "stdio"],
+      env: undefined,
+      providerParams: undefined,
+    },
+    {
+      command: ["grok", "agent", "stdio"],
       env: undefined,
       providerParams: undefined,
     },

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -37,6 +37,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -775,6 +776,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kimi") {
             return new KimiACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -25,6 +25,7 @@ import {
   deriveModelDefinitionsFromACP,
   deriveModesFromACP,
   mapACPUsage,
+  mapACPUsageUpdate,
   resolveACPModeSelection,
   resolveACPModelSelection,
   summarizeACPRequestError,
@@ -698,6 +699,34 @@ describe("mapACPUsage", () => {
       inputTokens: 11,
       outputTokens: 7,
       cachedInputTokens: 5,
+    });
+  });
+});
+
+describe("mapACPUsageUpdate", () => {
+  test("maps context window size and used tokens", () => {
+    expect(
+      mapACPUsageUpdate({
+        size: 200_000,
+        used: 87_000,
+      }),
+    ).toEqual({
+      contextWindowMaxTokens: 200_000,
+      contextWindowUsedTokens: 87_000,
+    });
+  });
+
+  test("maps USD cost onto totalCostUsd", () => {
+    expect(
+      mapACPUsageUpdate({
+        size: 128_000,
+        used: 1_000,
+        cost: { amount: 0.42, currency: "usd" },
+      }),
+    ).toEqual({
+      contextWindowMaxTokens: 128_000,
+      contextWindowUsedTokens: 1_000,
+      totalCostUsd: 0.42,
     });
   });
 });
@@ -2448,6 +2477,37 @@ describe("ACPAgentSession", () => {
     });
     expect(summary.message).not.toContain("[object Object]");
     expect(summary.diagnostic).toContain("Droid process exited unexpectedly");
+  });
+
+  test("emits usage_updated from ACP usage_update session notifications", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        size: 200_000,
+        used: 174_000,
+        cost: { amount: 1.25, currency: "USD" },
+      },
+    });
+
+    expect(events.filter((event) => event.type === "usage_updated")).toEqual([
+      {
+        type: "usage_updated",
+        provider: "claude-acp",
+        usage: {
+          contextWindowMaxTokens: 200_000,
+          contextWindowUsedTokens: 174_000,
+          totalCostUsd: 1.25,
+        },
+      },
+    ]);
   });
 
   test("accepts ACP extension notifications without failing the JSON-RPC connection", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -375,6 +375,17 @@ export type ACPExtensionCommandsParser = (
   params: Record<string, unknown>,
 ) => AgentSlashCommand[] | null;
 
+export type ACPExtensionNotificationHandler = (
+  method: string,
+  params: Record<string, unknown>,
+  context: { sessionId: string | null; cwd: string; provider: string },
+) => AgentStreamEvent[];
+
+export type ACPSessionNotificationUsage = (
+  params: SessionNotification,
+  context: { sessionId: string | null; cwd: string },
+) => AgentUsage | undefined;
+
 /**
  * Context handed to an {@link ACPCatalogModelResolver} during `fetchCatalog`. It exposes
  * the already-derived models plus the live probe session so a resolver can refine them
@@ -428,6 +439,8 @@ interface ACPAgentClientOptions {
   ) => Promise<void>;
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
+  sessionNotificationUsage?: ACPSessionNotificationUsage;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -458,6 +471,8 @@ interface ACPAgentSessionOptions {
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
+  sessionNotificationUsage?: ACPSessionNotificationUsage;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -600,6 +615,36 @@ export function mapACPUsage(usage: Usage | null | undefined): AgentUsage | undef
     outputTokens: usage.outputTokens ?? undefined,
     cachedInputTokens: usage.cachedReadTokens ?? undefined,
   };
+}
+
+export function sameAgentUsage(current: AgentUsage | undefined, next: AgentUsage): boolean {
+  if (!current) return false;
+  return (
+    current.inputTokens === next.inputTokens &&
+    current.outputTokens === next.outputTokens &&
+    current.cachedInputTokens === next.cachedInputTokens &&
+    current.totalCostUsd === next.totalCostUsd &&
+    current.contextWindowMaxTokens === next.contextWindowMaxTokens &&
+    current.contextWindowUsedTokens === next.contextWindowUsedTokens
+  );
+}
+
+export function mapACPUsageUpdate(update: UsageUpdate): AgentUsage | undefined {
+  const usage: AgentUsage = {};
+  if (Number.isFinite(update.size) && update.size > 0) {
+    usage.contextWindowMaxTokens = update.size;
+  }
+  if (Number.isFinite(update.used) && update.used >= 0) {
+    usage.contextWindowUsedTokens = update.used;
+  }
+  if (
+    update.cost &&
+    update.cost.currency.toUpperCase() === "USD" &&
+    Number.isFinite(update.cost.amount)
+  ) {
+    usage.totalCostUsd = update.cost.amount;
+  }
+  return Object.keys(usage).length > 0 ? usage : undefined;
 }
 
 export function resolveACPModeSelection({
@@ -818,6 +863,8 @@ export class ACPAgentClient implements AgentClient {
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly extensionNotificationHandler?: ACPExtensionNotificationHandler;
+  private readonly sessionNotificationUsage?: ACPSessionNotificationUsage;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -846,6 +893,8 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.extensionNotificationHandler = options.extensionNotificationHandler;
+    this.sessionNotificationUsage = options.sessionNotificationUsage;
   }
 
   async createSession(
@@ -876,6 +925,8 @@ export class ACPAgentClient implements AgentClient {
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
         extensionCommandsParser: this.extensionCommandsParser,
+        extensionNotificationHandler: this.extensionNotificationHandler,
+        sessionNotificationUsage: this.sessionNotificationUsage,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -927,6 +978,8 @@ export class ACPAgentClient implements AgentClient {
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       extensionCommandsParser: this.extensionCommandsParser,
+      extensionNotificationHandler: this.extensionNotificationHandler,
+      sessionNotificationUsage: this.sessionNotificationUsage,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1433,6 +1486,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly extensionNotificationHandler?: ACPExtensionNotificationHandler;
+  private readonly sessionNotificationUsage?: ACPSessionNotificationUsage;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
@@ -1473,6 +1528,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.extensionNotificationHandler = options.extensionNotificationHandler;
+    this.sessionNotificationUsage = options.sessionNotificationUsage;
   }
 
   get id(): string | null {
@@ -2269,6 +2326,16 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
 
     const events = this.translateSessionUpdate(params.update);
+    const notificationUsage = this.sessionNotificationUsage?.(params, {
+      sessionId: this.sessionId,
+      cwd: this.config.cwd,
+    });
+    if (
+      notificationUsage &&
+      !sameAgentUsage(this.currentTurnUsage, { ...this.currentTurnUsage, ...notificationUsage })
+    ) {
+      events.push(this.applyUsageUpdate(notificationUsage));
+    }
     this.logger.trace(
       {
         agentId: this.agentId,
@@ -2298,7 +2365,19 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
+  async extMethod(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    this.handleExtensionMessage(method, params);
+    return {};
+  }
+
   async extNotification(method: string, params: Record<string, unknown>): Promise<void> {
+    this.handleExtensionMessage(method, params);
+  }
+
+  private handleExtensionMessage(method: string, params: Record<string, unknown>): void {
     this.logger.trace(
       {
         agentId: this.agentId,
@@ -2315,6 +2394,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       this.applyResolvedCommands(parsedCommands, {
         sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
       });
+    }
+
+    const extensionEvents = this.extensionNotificationHandler?.(method, params, {
+      sessionId: this.sessionId,
+      cwd: this.config.cwd,
+      provider: this.provider,
+    });
+    if (extensionEvents && extensionEvents.length > 0) {
+      const applied = extensionEvents.map((event) =>
+        event.type === "usage_updated" ? this.applyUsageUpdate(event.usage, event.turnId) : event,
+      );
+      this.deliverTranslatedEvents(applied);
     }
   }
 
@@ -2660,8 +2751,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.handleSessionInfoUpdate(update);
         return pendingUserEvents;
       case "usage_update":
-        this.handleUsageUpdate(update);
-        return pendingUserEvents;
+        return [...pendingUserEvents, ...this.handleUsageUpdate(update)];
       case "available_commands_update":
         this.cachedCommands = update.availableCommands.map((command) => ({
           name: command.name,
@@ -2821,12 +2911,31 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
-  private handleUsageUpdate(update: UsageUpdate): void {
-    void update;
+  private handleUsageUpdate(update: UsageUpdate): AgentStreamEvent[] {
+    const usage = mapACPUsageUpdate(update);
+    if (!usage) {
+      return [];
+    }
+    return [this.applyUsageUpdate(usage)];
+  }
+
+  private applyUsageUpdate(usage: AgentUsage, turnId?: string): AgentStreamEvent {
+    this.currentTurnUsage = { ...this.currentTurnUsage, ...usage };
+    return {
+      type: "usage_updated",
+      provider: this.provider,
+      usage: this.currentTurnUsage,
+      ...(turnId || this.activeForegroundTurnId
+        ? { turnId: turnId ?? this.activeForegroundTurnId ?? undefined }
+        : {}),
+    };
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
-    this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
+    const promptUsage = mapACPUsage(response.usage);
+    if (promptUsage) {
+      this.currentTurnUsage = { ...this.currentTurnUsage, ...promptUsage };
+    }
 
     switch (response.stopReason) {
       case "cancelled":

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -10,6 +10,8 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPExtensionNotificationHandler,
+  type ACPSessionNotificationUsage,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -50,6 +52,8 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
+  sessionNotificationUsage?: ACPSessionNotificationUsage;
   catalogModelResolver?: ACPCatalogModelResolver;
 }
 
@@ -75,6 +79,8 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
+      extensionNotificationHandler: options.extensionNotificationHandler,
+      sessionNotificationUsage: options.sessionNotificationUsage,
       catalogModelResolver: options.catalogModelResolver,
     });
 

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -103,6 +103,19 @@ describe("readGrokContextUsage", () => {
       contextWindowMaxTokens: 500000,
     });
   });
+
+  test("returns null for missing or corrupt Grok session signals", () => {
+    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
+    homes.push(home);
+    const cwd = "/Users/nexmoe/project";
+    const sessionId = "session-corrupt";
+    const path = grokSessionSignalsPath(cwd, sessionId, home);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "{not-json");
+
+    expect(readGrokContextUsage(cwd, "missing", home)).toBeNull();
+    expect(readGrokContextUsage(cwd, sessionId, home)).toBeNull();
+  });
 });
 
 describe("grokUsageFromSessionNotification", () => {

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,262 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { asInternals } from "../../test-utils/class-mocks.js";
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import type { AgentStreamEvent } from "../agent-sdk-types.js";
+import { ACPAgentSession, type ACPSessionNotificationUsage } from "./acp-agent.js";
+import {
+  grokSessionSignalsPath,
+  grokUsageFromSessionNotification,
+  handleGrokExtensionNotification,
+  mapGrokTurnUsage,
+  readGrokContextUsage,
+} from "./grok-acp-agent.js";
+
+function createGrokSession(
+  options: {
+    extensionNotificationHandler?: typeof handleGrokExtensionNotification;
+    sessionNotificationUsage?: ACPSessionNotificationUsage;
+  } = {},
+): ACPAgentSession {
+  return new ACPAgentSession(
+    {
+      provider: "grok",
+      cwd: "/tmp/paseo-grok-test",
+    },
+    {
+      provider: "grok",
+      logger: createTestLogger(),
+      defaultCommand: ["grok", "agent", "stdio"],
+      defaultModes: [],
+      capabilities: {
+        supportsStreaming: true,
+        supportsSessionPersistence: true,
+        supportsDynamicModes: true,
+        supportsMcpServers: true,
+        supportsReasoningStream: true,
+        supportsToolInvocations: true,
+      },
+      extensionNotificationHandler:
+        options.extensionNotificationHandler ?? handleGrokExtensionNotification,
+      sessionNotificationUsage: options.sessionNotificationUsage,
+    },
+  );
+}
+
+describe("mapGrokTurnUsage", () => {
+  test("maps token buckets and cost ticks onto AgentUsage", () => {
+    expect(
+      mapGrokTurnUsage(
+        {
+          inputTokens: 183563,
+          outputTokens: 5934,
+          cachedReadTokens: 91648,
+          costUsdTicks: 12_689_050_000,
+        },
+        {
+          contextWindowUsedTokens: 131259,
+          contextWindowMaxTokens: 500000,
+        },
+      ),
+    ).toEqual({
+      inputTokens: 183563,
+      outputTokens: 5934,
+      cachedInputTokens: 91648,
+      totalCostUsd: 1.268905,
+      contextWindowUsedTokens: 131259,
+      contextWindowMaxTokens: 500000,
+    });
+  });
+});
+
+describe("readGrokContextUsage", () => {
+  const homes: string[] = [];
+
+  afterEach(() => {
+    for (const home of homes.splice(0)) {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("reads context window usage from Grok session signals", () => {
+    const home = mkdtempSync(join(tmpdir(), "paseo-grok-home-"));
+    homes.push(home);
+    const cwd = "/Users/nexmoe/project";
+    const sessionId = "session-signals";
+    const path = grokSessionSignalsPath(cwd, sessionId, home);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        contextTokensUsed: 331488,
+        contextWindowTokens: 500000,
+        contextWindowUsage: 66,
+      }),
+    );
+
+    expect(readGrokContextUsage(cwd, sessionId, home)).toEqual({
+      contextWindowUsedTokens: 331488,
+      contextWindowMaxTokens: 500000,
+    });
+  });
+});
+
+describe("grokUsageFromSessionNotification", () => {
+  test("maps Grok session/update _meta.totalTokens onto the context window", () => {
+    expect(
+      grokUsageFromSessionNotification(
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "pong" },
+          },
+          _meta: { totalTokens: 11493 },
+        },
+        {
+          sessionId: "session-1",
+          cwd: "/tmp/project",
+          defaultContextWindow: 500000,
+        },
+      ),
+    ).toEqual({
+      contextWindowUsedTokens: 11493,
+      contextWindowMaxTokens: 500000,
+    });
+  });
+});
+
+describe("handleGrokExtensionNotification", () => {
+  test("emits usage_updated from _x.ai turn_completed with session signals", () => {
+    const events = handleGrokExtensionNotification(
+      "_x.ai/session/update",
+      {
+        sessionId: "session-1",
+        update: {
+          sessionUpdate: "turn_completed",
+          usage: {
+            inputTokens: 100,
+            outputTokens: 20,
+            cachedReadTokens: 40,
+            costUsdTicks: 10_000_000_000,
+          },
+        },
+      },
+      {
+        sessionId: "session-1",
+        cwd: "/tmp/project",
+        provider: "grok",
+        readSignals: () => ({
+          contextWindowUsedTokens: 174000,
+          contextWindowMaxTokens: 200000,
+        }),
+      },
+    );
+
+    expect(events).toEqual([
+      {
+        type: "usage_updated",
+        provider: "grok",
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cachedInputTokens: 40,
+          totalCostUsd: 1,
+          contextWindowUsedTokens: 174000,
+          contextWindowMaxTokens: 200000,
+        },
+      },
+    ]);
+  });
+
+  test("ignores non-turn Grok extension updates", () => {
+    expect(
+      handleGrokExtensionNotification(
+        "_x.ai/session/update",
+        { update: { sessionUpdate: "task_backgrounded" } },
+        { sessionId: "session-1", cwd: "/tmp/project", provider: "grok" },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("Grok ACP session usage", () => {
+  test("emits usage_updated from Grok session/update _meta.totalTokens", async () => {
+    const session = createGrokSession({
+      sessionNotificationUsage: (params, context) =>
+        grokUsageFromSessionNotification(params, {
+          ...context,
+          defaultContextWindow: 500000,
+        }),
+    });
+    asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "pong" },
+      },
+      _meta: { totalTokens: 11493 },
+    });
+
+    expect(events.filter((event) => event.type === "usage_updated")).toEqual([
+      {
+        type: "usage_updated",
+        provider: "grok",
+        usage: {
+          contextWindowUsedTokens: 11493,
+          contextWindowMaxTokens: 500000,
+        },
+      },
+    ]);
+  });
+
+  test("forwards Grok turn_completed extension usage onto subscribers", async () => {
+    const session = createGrokSession({
+      extensionNotificationHandler: (method, params, context) =>
+        handleGrokExtensionNotification(method, params, {
+          ...context,
+          readSignals: () => ({
+            contextWindowUsedTokens: 87000,
+            contextWindowMaxTokens: 100000,
+          }),
+        }),
+    });
+    asInternals<{ sessionId: string | null }>(session).sessionId = "session-1";
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    await session.extMethod("_x.ai/session/update", {
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "turn_completed",
+        usage: { inputTokens: 10, outputTokens: 4, costUsdTicks: 0 },
+      },
+    });
+
+    expect(events.filter((event) => event.type === "usage_updated")).toEqual([
+      {
+        type: "usage_updated",
+        provider: "grok",
+        usage: {
+          inputTokens: 10,
+          outputTokens: 4,
+          totalCostUsd: 0,
+          contextWindowUsedTokens: 87000,
+          contextWindowMaxTokens: 100000,
+        },
+      },
+    ]);
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,215 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import type { Logger } from "pino";
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import type { AgentStreamEvent, AgentUsage } from "../agent-sdk-types.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+const GROK_USD_TICKS_PER_DOLLAR = 10_000_000_000;
+const GROK_SESSION_UPDATE_METHOD = "_x.ai/session/update";
+
+const GrokTurnUsageSchema = z.object({
+  inputTokens: z.number().finite().optional(),
+  outputTokens: z.number().finite().optional(),
+  cachedReadTokens: z.number().finite().optional(),
+  costUsdTicks: z.number().finite().optional(),
+});
+
+const GrokSignalsSchema = z.object({
+  contextTokensUsed: z.number().finite().optional(),
+  contextWindowTokens: z.number().finite().optional(),
+});
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+  grokHome?: string;
+  readSignals?: (cwd: string, sessionId: string) => GrokContextUsage | null;
+}
+
+export interface GrokContextUsage {
+  contextWindowUsedTokens: number;
+  contextWindowMaxTokens: number;
+}
+
+interface GrokSessionUsageContext {
+  sessionId: string | null;
+  cwd: string;
+  grokHome?: string;
+  readSignals?: (cwd: string, sessionId: string) => GrokContextUsage | null;
+  defaultContextWindow?: number | null;
+}
+
+interface GrokExtensionUsageContext {
+  sessionId: string | null;
+  cwd: string;
+  provider: string;
+  readSignals?: (cwd: string, sessionId: string) => GrokContextUsage | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function grokHomeDir(grokHome?: string): string {
+  return grokHome || process.env["GROK_HOME"] || join(homedir(), ".grok");
+}
+
+export function grokSessionSignalsPath(cwd: string, sessionId: string, grokHome?: string): string {
+  return join(
+    grokHomeDir(grokHome),
+    "sessions",
+    encodeURIComponent(cwd),
+    sessionId,
+    "signals.json",
+  );
+}
+
+export function readGrokDefaultContextWindow(grokHome?: string): number | null {
+  const path = join(grokHomeDir(grokHome), "models_cache.json");
+  if (!existsSync(path)) return null;
+  try {
+    const raw: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!isRecord(raw) || !isRecord(raw.models)) return null;
+    const preferred = isRecord(raw.models["grok-4.6"])
+      ? raw.models["grok-4.6"]
+      : Object.values(raw.models).find(isRecord);
+    if (!preferred || !isRecord(preferred.info)) return null;
+    const contextWindow = preferred.info["context_window"];
+    return typeof contextWindow === "number" && contextWindow > 0 ? contextWindow : null;
+  } catch {
+    return null;
+  }
+}
+
+export function grokUsageFromSessionNotification(
+  params: SessionNotification,
+  context: GrokSessionUsageContext,
+): AgentUsage | undefined {
+  const totalTokens = params._meta?.["totalTokens"];
+  if (typeof totalTokens !== "number" || !Number.isFinite(totalTokens) || totalTokens < 0) {
+    return undefined;
+  }
+
+  const sessionId = params.sessionId || context.sessionId;
+  const signals =
+    sessionId === null || sessionId.length === 0
+      ? null
+      : (context.readSignals ?? readGrokContextUsage)(context.cwd, sessionId);
+  const maxTokens = signals?.contextWindowMaxTokens ?? context.defaultContextWindow ?? null;
+  const usage: AgentUsage = {
+    contextWindowUsedTokens: totalTokens,
+  };
+  if (maxTokens !== null) {
+    usage.contextWindowMaxTokens = maxTokens;
+  }
+  return usage;
+}
+
+export function readGrokContextUsage(
+  cwd: string,
+  sessionId: string,
+  grokHome?: string,
+): GrokContextUsage | null {
+  const path = grokSessionSignalsPath(cwd, sessionId, grokHome);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = GrokSignalsSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
+    if (!parsed.success) return null;
+    const used = parsed.data.contextTokensUsed;
+    const max = parsed.data.contextWindowTokens;
+    if (typeof used !== "number" || used < 0 || typeof max !== "number" || max <= 0) {
+      return null;
+    }
+    return { contextWindowUsedTokens: used, contextWindowMaxTokens: max };
+  } catch {
+    return null;
+  }
+}
+
+export function mapGrokTurnUsage(
+  rawUsage: unknown,
+  context: GrokContextUsage | null,
+): AgentUsage | undefined {
+  const parsed = GrokTurnUsageSchema.safeParse(rawUsage);
+  const usage: AgentUsage = {};
+  if (parsed.success) {
+    if (parsed.data.inputTokens !== undefined) usage.inputTokens = parsed.data.inputTokens;
+    if (parsed.data.outputTokens !== undefined) usage.outputTokens = parsed.data.outputTokens;
+    if (parsed.data.cachedReadTokens !== undefined) {
+      usage.cachedInputTokens = parsed.data.cachedReadTokens;
+    }
+    if (parsed.data.costUsdTicks !== undefined && parsed.data.costUsdTicks >= 0) {
+      usage.totalCostUsd = parsed.data.costUsdTicks / GROK_USD_TICKS_PER_DOLLAR;
+    }
+  }
+  if (context) {
+    usage.contextWindowUsedTokens = context.contextWindowUsedTokens;
+    usage.contextWindowMaxTokens = context.contextWindowMaxTokens;
+  }
+  return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
+export function handleGrokExtensionNotification(
+  method: string,
+  params: Record<string, unknown>,
+  context: GrokExtensionUsageContext,
+): AgentStreamEvent[] {
+  if (method !== GROK_SESSION_UPDATE_METHOD) return [];
+  if (!isRecord(params.update)) return [];
+  if (params.update["sessionUpdate"] !== "turn_completed") return [];
+
+  const sessionId = typeof params.sessionId === "string" ? params.sessionId : context.sessionId;
+  const signals =
+    sessionId === null
+      ? null
+      : (context.readSignals ?? readGrokContextUsage)(context.cwd, sessionId);
+  const usage = mapGrokTurnUsage(params.update["usage"], signals);
+  if (!usage) return [];
+
+  return [
+    {
+      type: "usage_updated",
+      provider: context.provider,
+      usage,
+    },
+  ];
+}
+
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    const readSignals = options.readSignals;
+    const grokHome = options.grokHome;
+    const resolveSignals =
+      readSignals ??
+      ((cwd: string, sessionId: string) => readGrokContextUsage(cwd, sessionId, grokHome));
+    const defaultContextWindow = readGrokDefaultContextWindow(grokHome);
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId,
+      label: options.label,
+      providerParams: options.providerParams,
+      extensionNotificationHandler: (method, params, context) =>
+        handleGrokExtensionNotification(method, params, {
+          ...context,
+          readSignals: resolveSignals,
+        }),
+      sessionNotificationUsage: (params, context) =>
+        grokUsageFromSessionNotification(params, {
+          ...context,
+          grokHome,
+          readSignals: resolveSignals,
+          defaultContextWindow,
+        }),
+    });
+  }
+}

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -58,6 +58,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function readJsonFileOrNull(path: string): unknown | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    if (error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
 function grokHomeDir(grokHome?: string): string {
   return grokHome || process.env["GROK_HOME"] || join(homedir(), ".grok");
 }
@@ -73,20 +83,14 @@ export function grokSessionSignalsPath(cwd: string, sessionId: string, grokHome?
 }
 
 export function readGrokDefaultContextWindow(grokHome?: string): number | null {
-  const path = join(grokHomeDir(grokHome), "models_cache.json");
-  if (!existsSync(path)) return null;
-  try {
-    const raw: unknown = JSON.parse(readFileSync(path, "utf8"));
-    if (!isRecord(raw) || !isRecord(raw.models)) return null;
-    const preferred = isRecord(raw.models["grok-4.6"])
-      ? raw.models["grok-4.6"]
-      : Object.values(raw.models).find(isRecord);
-    if (!preferred || !isRecord(preferred.info)) return null;
-    const contextWindow = preferred.info["context_window"];
-    return typeof contextWindow === "number" && contextWindow > 0 ? contextWindow : null;
-  } catch {
-    return null;
-  }
+  const raw = readJsonFileOrNull(join(grokHomeDir(grokHome), "models_cache.json"));
+  if (!isRecord(raw) || !isRecord(raw.models)) return null;
+  const preferred = isRecord(raw.models["grok-4.6"])
+    ? raw.models["grok-4.6"]
+    : Object.values(raw.models).find(isRecord);
+  if (!preferred || !isRecord(preferred.info)) return null;
+  const contextWindow = preferred.info["context_window"];
+  return typeof contextWindow === "number" && contextWindow > 0 ? contextWindow : null;
 }
 
 export function grokUsageFromSessionNotification(
@@ -118,20 +122,16 @@ export function readGrokContextUsage(
   sessionId: string,
   grokHome?: string,
 ): GrokContextUsage | null {
-  const path = grokSessionSignalsPath(cwd, sessionId, grokHome);
-  if (!existsSync(path)) return null;
-  try {
-    const parsed = GrokSignalsSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
-    if (!parsed.success) return null;
-    const used = parsed.data.contextTokensUsed;
-    const max = parsed.data.contextWindowTokens;
-    if (typeof used !== "number" || used < 0 || typeof max !== "number" || max <= 0) {
-      return null;
-    }
-    return { contextWindowUsedTokens: used, contextWindowMaxTokens: max };
-  } catch {
+  const parsed = GrokSignalsSchema.safeParse(
+    readJsonFileOrNull(grokSessionSignalsPath(cwd, sessionId, grokHome)),
+  );
+  if (!parsed.success) return null;
+  const used = parsed.data.contextTokensUsed;
+  const max = parsed.data.contextWindowTokens;
+  if (typeof used !== "number" || used < 0 || typeof max !== "number" || max <= 0) {
     return null;
   }
+  return { contextWindowUsedTokens: used, contextWindowMaxTokens: max };
 }
 
 export function mapGrokTurnUsage(

--- a/packages/server/src/server/daemon-e2e/grok-usage.local.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/grok-usage.local.e2e.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { DaemonClient } from "../test-utils/daemon-client.js";
+import { createTestPaseoDaemon, type TestPaseoDaemon } from "../test-utils/paseo-daemon.js";
+
+function isGrokInstalled(): boolean {
+  try {
+    return execFileSync("which", ["grok"], { encoding: "utf8" }).trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+const grokAvailable = isGrokInstalled();
+
+describe.skipIf(!grokAvailable)("Grok usage through a live Paseo daemon", () => {
+  let daemon: TestPaseoDaemon;
+  let client: DaemonClient;
+  let cwd: string;
+
+  beforeAll(async () => {
+    cwd = mkdtempSync(path.join(tmpdir(), "paseo-grok-usage-"));
+    daemon = await createTestPaseoDaemon({
+      agentClients: {},
+      mcpEnabled: false,
+      providerOverrides: {
+        grok: {
+          extends: "acp",
+          label: "Grok",
+          command: ["grok", "agent", "--always-approve", "stdio"],
+        },
+      },
+    });
+    client = new DaemonClient({
+      url: `ws://127.0.0.1:${daemon.port}/ws`,
+      appVersion: "0.4.0",
+    });
+    await client.connect();
+    await client.fetchAgents({ subscribe: { subscriptionId: "grok-usage" } });
+  }, 30_000);
+
+  afterAll(async () => {
+    await client?.close().catch(() => undefined);
+    await daemon?.close().catch(() => undefined);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  test("provider.usage.list returns SuperGrok Heavy weekly limit", async () => {
+    const payload = await client.listProviderUsage();
+    const grok = payload.providers.find((provider) => provider.providerId === "grok");
+
+    expect(grok).toMatchObject({
+      providerId: "grok",
+      displayName: "Grok",
+      status: "available",
+      planLabel: "SuperGrok Heavy",
+    });
+    expect(grok?.windows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "weekly",
+          label: "Weekly",
+          usedPct: expect.any(Number),
+          remainingPct: expect.any(Number),
+          resetsAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+        }),
+      ]),
+    );
+    expect(grok?.windows[0]?.usedPct).toBeGreaterThanOrEqual(0);
+    expect(grok?.windows[0]?.usedPct).toBeLessThanOrEqual(100);
+  }, 30_000);
+
+  test("a Grok turn publishes context-window usage onto the agent snapshot", async () => {
+    const workspace = await client.createWorkspace({
+      source: { kind: "directory", path: cwd },
+    });
+    if (!workspace.workspace) {
+      throw new Error(workspace.error ?? "failed to create workspace");
+    }
+
+    const created = await client.createAgent({
+      provider: "grok",
+      cwd,
+      workspaceId: workspace.workspace.id,
+      title: "Grok usage live test",
+      initialPrompt: "Reply with exactly the word pong and nothing else.",
+    });
+
+    const snapshot = await client.waitForAgentUpsert(
+      created.id,
+      (agent) =>
+        agent.lastUsage?.contextWindowMaxTokens === 500_000 &&
+        typeof agent.lastUsage.contextWindowUsedTokens === "number" &&
+        agent.lastUsage.contextWindowUsedTokens >= 0,
+      180_000,
+    );
+
+    expect(snapshot.lastUsage).toEqual(
+      expect.objectContaining({
+        contextWindowMaxTokens: 500_000,
+        contextWindowUsedTokens: expect.any(Number),
+      }),
+    );
+    expect(snapshot.lastUsage?.contextWindowUsedTokens).toBeLessThan(500_000);
+  }, 180_000);
+});

--- a/packages/server/src/server/daemon-e2e/grok-usage.local.e2e.test.ts
+++ b/packages/server/src/server/daemon-e2e/grok-usage.local.e2e.test.ts
@@ -78,14 +78,13 @@ describe.skipIf(!grokAvailable)("Grok usage through a live Paseo daemon", () => 
     const workspace = await client.createWorkspace({
       source: { kind: "directory", path: cwd },
     });
-    if (!workspace.workspace) {
-      throw new Error(workspace.error ?? "failed to create workspace");
-    }
+    const workspaceId = workspace.workspace?.id ?? "";
+    expect(workspaceId).toEqual(expect.stringMatching(/\S/));
 
     const created = await client.createAgent({
       provider: "grok",
       cwd,
-      workspaceId: workspace.workspace.id,
+      workspaceId,
       title: "Grok usage live test",
       initialPrompt: "Reply with exactly the word pong and nothing else.",
     });

--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -71,26 +71,21 @@ interface GrokQuotaProviderOptions {
   homeDir?: string;
 }
 
-async function readJsonBodyOrNull(response: Response): Promise<unknown | null> {
-  try {
-    return await response.json();
-  } catch (error) {
-    if (error instanceof SyntaxError) return null;
-    throw error;
-  }
-}
-
 async function readGrokPlanLabel(
   settingsResult: PromiseSettledResult<Response>,
 ): Promise<string | null> {
   if (settingsResult.status !== "fulfilled" || !settingsResult.value.ok) {
     return null;
   }
-  const parsed = GrokSettingsResponseSchema.safeParse(
-    await readJsonBodyOrNull(settingsResult.value),
-  );
-  const label = parsed.success ? parsed.data.subscription_tier_display : undefined;
-  return label && label.length > 0 ? label : null;
+  try {
+    const parsed = GrokSettingsResponseSchema.safeParse(await settingsResult.value.json());
+    const label = parsed.success ? parsed.data.subscription_tier_display : undefined;
+    return label && label.length > 0 ? label : null;
+  } catch {
+    // Settings is optional decoration. Abort, stream failure, or invalid JSON
+    // must not hide a successful billing fetch.
+    return null;
+  }
 }
 
 function wrappedNumber(value: { val?: number } | null | undefined): number | null {

--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -3,36 +3,65 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Logger } from "pino";
 import { z } from "zod";
-import type { ProviderUsage, ProviderUsageBalance } from "../../../server/messages.js";
+import type {
+  ProviderUsage,
+  ProviderUsageBalance,
+  ProviderUsageWindow,
+} from "../../../server/messages.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNumberSchema,
+  ApiOptionalStringSchema,
   toneFromUsedPct,
   usedPctOf,
   fetchProviderApi,
   unavailableUsage,
+  windowFromUsedPct,
 } from "../usage.js";
+
+const GrokWrappedNumberSchema = z
+  .object({
+    val: ApiNumberSchema.optional(),
+  })
+  .nullish();
+
+const GrokPeriodSchema = z
+  .object({
+    type: ApiOptionalStringSchema,
+    start: ApiOptionalStringSchema,
+    end: ApiOptionalStringSchema,
+  })
+  .nullish();
 
 const GrokUsageResponseSchema = z.object({
   config: z
     .object({
-      monthlyLimit: z
-        .object({
-          val: ApiNumberSchema.optional(),
-        })
-        .nullish(),
-      used: z
-        .object({
-          val: ApiNumberSchema.optional(),
-        })
-        .nullish(),
+      monthlyLimit: GrokWrappedNumberSchema,
+      weeklyLimit: GrokWrappedNumberSchema,
+      used: GrokWrappedNumberSchema,
+      weeklyUsed: GrokWrappedNumberSchema,
+      creditUsagePercent: ApiNumberSchema.optional(),
+      currentPeriod: GrokPeriodSchema,
+      prepaidBalance: GrokWrappedNumberSchema,
+      billingPeriodStart: ApiOptionalStringSchema,
+      billingPeriodEnd: ApiOptionalStringSchema,
     })
     .nullish(),
   usage: z
     .object({
       creditUsage: ApiNumberSchema.optional(),
+      weeklyUsage: ApiNumberSchema.optional(),
     })
     .nullish(),
+});
+
+// Grok CLI `/usage` reads this query. Plain `/v1/billing` returns monthly
+// credits only and hides the weekly SuperGrok pool.
+const GROK_BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+const GROK_SETTINGS_URL = "https://cli-chat-proxy.grok.com/v1/settings";
+
+const GrokSettingsResponseSchema = z.object({
+  subscription_tier_display: ApiOptionalStringSchema,
 });
 
 interface GrokQuotaProviderOptions {
@@ -40,6 +69,162 @@ interface GrokQuotaProviderOptions {
   fetch?: ProviderApiFetch;
   /** Override home directory (tests). Production uses os.homedir(). */
   homeDir?: string;
+}
+
+async function readGrokPlanLabel(
+  settingsResult: PromiseSettledResult<Response>,
+): Promise<string | null> {
+  if (settingsResult.status !== "fulfilled" || !settingsResult.value.ok) {
+    return null;
+  }
+  const parsed = GrokSettingsResponseSchema.safeParse(await settingsResult.value.json());
+  const label = parsed.success ? parsed.data.subscription_tier_display : undefined;
+  return label && label.length > 0 ? label : null;
+}
+
+function wrappedNumber(value: { val?: number } | null | undefined): number | null {
+  return value?.val ?? null;
+}
+
+function grokLimitWindow(input: {
+  id: string;
+  label: string;
+  used: number | null;
+  limit: number | null;
+  usedPct?: number | null;
+  resetsAt: string | null;
+}): ProviderUsageWindow | null {
+  const usedPct = input.usedPct ?? usedPctOf(input.used, input.limit);
+  if (usedPct === null) return null;
+  return windowFromUsedPct({
+    id: input.id,
+    label: input.label,
+    utilizationPct: usedPct,
+    resetsAt: input.resetsAt,
+    tone: toneFromUsedPct(usedPct),
+  });
+}
+
+function grokPeriodWindow(
+  percent: number | null | undefined,
+  periodType: string | undefined,
+  resetsAt: string | null,
+): ProviderUsageWindow | null {
+  if (typeof percent !== "number") return null;
+  const weekly = (periodType ?? "").toUpperCase().includes("WEEKLY");
+  return grokLimitWindow({
+    id: weekly ? "weekly" : "monthly",
+    label: weekly ? "Weekly" : "Monthly",
+    used: null,
+    limit: null,
+    usedPct: percent,
+    resetsAt,
+  });
+}
+
+function mergeGrokWindows(
+  periodWindow: ProviderUsageWindow | null,
+  countedWindows: ProviderUsageWindow[],
+): ProviderUsageWindow[] {
+  if (periodWindow && !countedWindows.some((window) => window.id === periodWindow.id)) {
+    return [periodWindow, ...countedWindows];
+  }
+  return countedWindows;
+}
+
+function grokPrepaidBalance(prepaid: number | null): ProviderUsageBalance | null {
+  if (prepaid === null || prepaid <= 0) return null;
+  return {
+    id: "credits",
+    label: "Credits",
+    remaining: prepaid,
+    unit: "credits",
+    tone: "ok",
+  };
+}
+
+interface GrokBillingAmounts {
+  monthlyLimit: number | null;
+  creditUsage: number | null;
+  weeklyLimit: number | null;
+  weeklyUsed: number | null;
+  periodResetsAt: string | null;
+  usagePercent: number | undefined;
+  periodType: string | undefined;
+  prepaid: number | null;
+}
+
+function readGrokBillingAmounts(resp: z.infer<typeof GrokUsageResponseSchema>): GrokBillingAmounts {
+  const config = resp.config;
+  return {
+    monthlyLimit: wrappedNumber(config?.monthlyLimit),
+    // Live CLI billing uses config.used.val; older mocks used usage.creditUsage.
+    creditUsage: wrappedNumber(config?.used) ?? resp.usage?.creditUsage ?? null,
+    weeklyLimit: wrappedNumber(config?.weeklyLimit),
+    weeklyUsed: wrappedNumber(config?.weeklyUsed) ?? resp.usage?.weeklyUsage ?? null,
+    periodResetsAt: config?.currentPeriod?.end ?? config?.billingPeriodEnd ?? null,
+    usagePercent: config?.creditUsagePercent,
+    periodType: config?.currentPeriod?.type,
+    prepaid: wrappedNumber(config?.prepaidBalance),
+  };
+}
+
+interface GrokUsageBars {
+  windows: ProviderUsageWindow[];
+  balances: ProviderUsageBalance[];
+}
+
+function grokWindowsFromBilling(resp: z.infer<typeof GrokUsageResponseSchema>): GrokUsageBars {
+  const amounts = readGrokBillingAmounts(resp);
+  const windows = mergeGrokWindows(
+    grokPeriodWindow(amounts.usagePercent, amounts.periodType, amounts.periodResetsAt),
+    [
+      grokLimitWindow({
+        id: "monthly",
+        label: "Monthly",
+        used: amounts.creditUsage,
+        limit: amounts.monthlyLimit,
+        resetsAt: amounts.periodResetsAt,
+      }),
+      grokLimitWindow({
+        id: "weekly",
+        label: "Weekly",
+        used: amounts.weeklyUsed,
+        limit: amounts.weeklyLimit,
+        resetsAt: amounts.periodResetsAt,
+      }),
+    ].filter((window): window is ProviderUsageWindow => window !== null),
+  );
+
+  const creditBalance =
+    grokCreditBalance({
+      used: amounts.creditUsage,
+      limit: amounts.monthlyLimit,
+      resetsAt: amounts.periodResetsAt,
+    }) ?? grokPrepaidBalance(amounts.prepaid);
+
+  return { windows, balances: creditBalance ? [creditBalance] : [] };
+}
+
+function grokCreditBalance(input: {
+  used: number | null;
+  limit: number | null;
+  resetsAt: string | null;
+}): ProviderUsageBalance | null {
+  const hasCreditQuota = (input.limit !== null && input.limit > 0) || (input.used ?? 0) > 0;
+  if (!hasCreditQuota) return null;
+  const remaining =
+    input.limit !== null && input.used !== null ? Math.max(0, input.limit - input.used) : null;
+  return {
+    id: "credits",
+    label: "Credits",
+    used: input.used,
+    remaining,
+    limit: input.limit,
+    unit: "credits",
+    resetsAt: input.resetsAt,
+    tone: toneFromUsedPct(usedPctOf(input.used, input.limit)),
+  };
 }
 
 /** Resolve a Grok CLI token from ~/.grok/auth.json (legacy or current nested shape). */
@@ -87,50 +272,33 @@ export class GrokQuotaProvider implements ProviderUsageFetcher {
 
     if (!token) return unavailableUsage(this);
 
-    const res = await fetchProviderApi(
-      this.fetchApi,
-      "https://cli-chat-proxy.grok.com/v1/billing",
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "X-XAI-Token-Auth": "xai-grok-cli",
-          Accept: "application/json",
-        },
-      },
-    );
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      "X-XAI-Token-Auth": "xai-grok-cli",
+      Accept: "application/json",
+    };
 
-    if (!res.ok) {
-      this.logger.debug({ status: res.status }, "Grok usage fetch failed");
+    const [billingResult, settingsResult] = await Promise.allSettled([
+      fetchProviderApi(this.fetchApi, GROK_BILLING_URL, { headers }),
+      fetchProviderApi(this.fetchApi, GROK_SETTINGS_URL, { headers }),
+    ]);
+
+    if (billingResult.status === "rejected" || !billingResult.value.ok) {
+      const status = billingResult.status === "fulfilled" ? billingResult.value.status : undefined;
+      this.logger.debug({ status }, "Grok usage fetch failed");
       return unavailableUsage(this);
     }
 
-    const resp = GrokUsageResponseSchema.parse(await res.json());
-    const monthlyLimit = resp.config?.monthlyLimit?.val ?? null;
-    // Live CLI billing uses config.used.val; older mocks used usage.creditUsage.
-    const creditUsage = resp.config?.used?.val ?? resp.usage?.creditUsage ?? null;
-    const balances: ProviderUsageBalance[] = [];
-    if (monthlyLimit !== null || creditUsage !== null) {
-      const remaining =
-        monthlyLimit !== null && creditUsage !== null
-          ? Math.max(0, monthlyLimit - creditUsage)
-          : null;
-      balances.push({
-        id: "monthly_credits",
-        label: "Monthly credits",
-        used: creditUsage,
-        remaining,
-        limit: monthlyLimit,
-        unit: "credits",
-        tone: toneFromUsedPct(usedPctOf(creditUsage, monthlyLimit)),
-      });
-    }
+    const { windows, balances } = grokWindowsFromBilling(
+      GrokUsageResponseSchema.parse(await billingResult.value.json()),
+    );
 
     return {
       providerId: this.providerId,
       displayName: this.displayName,
       status: "available",
-      planLabel: null,
-      windows: [],
+      planLabel: await readGrokPlanLabel(settingsResult),
+      windows,
       balances,
       details: [],
       error: null,

--- a/packages/server/src/services/quota-fetcher/providers/grok.ts
+++ b/packages/server/src/services/quota-fetcher/providers/grok.ts
@@ -71,13 +71,24 @@ interface GrokQuotaProviderOptions {
   homeDir?: string;
 }
 
+async function readJsonBodyOrNull(response: Response): Promise<unknown | null> {
+  try {
+    return await response.json();
+  } catch (error) {
+    if (error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
 async function readGrokPlanLabel(
   settingsResult: PromiseSettledResult<Response>,
 ): Promise<string | null> {
   if (settingsResult.status !== "fulfilled" || !settingsResult.value.ok) {
     return null;
   }
-  const parsed = GrokSettingsResponseSchema.safeParse(await settingsResult.value.json());
+  const parsed = GrokSettingsResponseSchema.safeParse(
+    await readJsonBodyOrNull(settingsResult.value),
+  );
   const label = parsed.success ? parsed.data.subscription_tier_display : undefined;
   return label && label.length > 0 ? label : null;
 }

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -837,7 +837,7 @@ describe("real provider usage fetchers", () => {
     fetchApi = mockFetch(
       new Map([
         [
-          "https://cli-chat-proxy.grok.com/v1/billing",
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
           () =>
             jsonResponse({
               config: { monthlyLimit: { val: 0 }, used: { val: 0 } },
@@ -850,14 +850,9 @@ describe("real provider usage fetchers", () => {
 
     expect(grok).toMatchObject({
       status: "available",
-      balances: [
-        expect.objectContaining({
-          id: "monthly_credits",
-          used: 0,
-          remaining: 0,
-          limit: 0,
-        }),
-      ],
+      planLabel: null,
+      windows: [],
+      balances: [],
     });
   });
 
@@ -866,7 +861,7 @@ describe("real provider usage fetchers", () => {
     fetchApi = mockFetch(
       new Map([
         [
-          "https://cli-chat-proxy.grok.com/v1/billing",
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
           () =>
             jsonResponse({
               config: {
@@ -884,9 +879,16 @@ describe("real provider usage fetchers", () => {
 
     expect(grok).toMatchObject({
       status: "available",
+      windows: [
+        expect.objectContaining({
+          id: "monthly",
+          label: "Monthly",
+          usedPct: expect.closeTo((37886 / 150000) * 100),
+        }),
+      ],
       balances: [
         expect.objectContaining({
-          id: "monthly_credits",
+          id: "credits",
           used: 37886,
           remaining: 112114,
           limit: 150000,
@@ -923,9 +925,10 @@ describe("real provider usage fetchers", () => {
     expect(authorization).toBe("Bearer nested_jwt_token");
     expect(grok).toMatchObject({
       status: "available",
+      windows: [expect.objectContaining({ id: "monthly", usedPct: 25 })],
       balances: [
         expect.objectContaining({
-          id: "monthly_credits",
+          id: "credits",
           used: 25,
           remaining: 75,
           limit: 100,
@@ -939,7 +942,7 @@ describe("real provider usage fetchers", () => {
     fetchApi = mockFetch(
       new Map([
         [
-          "https://cli-chat-proxy.grok.com/v1/billing",
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
           () =>
             jsonResponse({
               config: { monthlyLimit: { val: 50 } },
@@ -953,12 +956,117 @@ describe("real provider usage fetchers", () => {
 
     expect(grok).toMatchObject({
       status: "available",
+      windows: [expect.objectContaining({ id: "monthly", usedPct: 20 })],
       balances: [
         expect.objectContaining({
-          id: "monthly_credits",
+          id: "credits",
           used: 10,
           remaining: 40,
           limit: 50,
+        }),
+      ],
+    });
+  });
+
+  it("fetches Grok weekly usage percent from billing?format=credits", async () => {
+    process.env["GROK_API_KEY"] = "grok_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+          () =>
+            jsonResponse({
+              config: {
+                currentPeriod: {
+                  type: "USAGE_PERIOD_TYPE_WEEKLY",
+                  start: "2026-08-08T00:00:00+00:00",
+                  end: "2026-08-15T00:00:00+00:00",
+                },
+                creditUsagePercent: 5,
+                onDemandCap: { val: 0 },
+                onDemandUsed: { val: 0 },
+                productUsage: [{ product: "GrokBuild", usagePercent: 5 }],
+                isUnifiedBillingUser: true,
+                prepaidBalance: { val: 0 },
+                billingPeriodStart: "2026-08-08T00:00:00+00:00",
+                billingPeriodEnd: "2026-08-15T00:00:00+00:00",
+              },
+            }),
+        ],
+        [
+          "https://cli-chat-proxy.grok.com/v1/settings",
+          () => jsonResponse({ subscription_tier_display: "SuperGrok Heavy" }),
+        ],
+      ]),
+    );
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(grok).toMatchObject({
+      status: "available",
+      planLabel: "SuperGrok Heavy",
+      windows: [
+        expect.objectContaining({
+          id: "weekly",
+          label: "Weekly",
+          usedPct: 5,
+          remainingPct: 95,
+          resetsAt: "2026-08-15T00:00:00+00:00",
+        }),
+      ],
+      balances: [],
+    });
+  });
+
+  it("fetches Grok plan label and weekly/monthly windows", async () => {
+    process.env["GROK_API_KEY"] = "grok_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+          () =>
+            jsonResponse({
+              config: {
+                monthlyLimit: { val: 150000 },
+                used: { val: 37500 },
+                weeklyLimit: { val: 40000 },
+                weeklyUsed: { val: 34800 },
+                billingPeriodEnd: "2026-09-01T00:00:00+00:00",
+              },
+            }),
+        ],
+        [
+          "https://cli-chat-proxy.grok.com/v1/settings",
+          () => jsonResponse({ subscription_tier_display: "SuperGrok Heavy" }),
+        ],
+      ]),
+    );
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(grok).toMatchObject({
+      status: "available",
+      planLabel: "SuperGrok Heavy",
+      windows: [
+        expect.objectContaining({
+          id: "monthly",
+          label: "Monthly",
+          usedPct: 25,
+          resetsAt: "2026-09-01T00:00:00+00:00",
+        }),
+        expect.objectContaining({
+          id: "weekly",
+          label: "Weekly",
+          usedPct: 87,
+        }),
+      ],
+      balances: [
+        expect.objectContaining({
+          id: "credits",
+          label: "Credits",
+          used: 37500,
+          remaining: 112500,
+          limit: 150000,
         }),
       ],
     });

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -1018,6 +1018,43 @@ describe("real provider usage fetchers", () => {
     });
   });
 
+  it("keeps Grok weekly usage when settings returns invalid JSON", async () => {
+    process.env["GROK_API_KEY"] = "grok_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+          () =>
+            jsonResponse({
+              config: {
+                currentPeriod: {
+                  type: "USAGE_PERIOD_TYPE_WEEKLY",
+                  end: "2026-08-15T00:00:00+00:00",
+                },
+                creditUsagePercent: 5,
+              },
+            }),
+        ],
+        [
+          "https://cli-chat-proxy.grok.com/v1/settings",
+          () =>
+            new Response("not-json", {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+        ],
+      ]),
+    );
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(grok).toMatchObject({
+      status: "available",
+      planLabel: null,
+      windows: [expect.objectContaining({ id: "weekly", usedPct: 5 })],
+    });
+  });
+
   it("fetches Grok plan label and weekly/monthly windows", async () => {
     process.env["GROK_API_KEY"] = "grok_test_token";
     fetchApi = mockFetch(

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -1018,6 +1018,47 @@ describe("real provider usage fetchers", () => {
     });
   });
 
+  it("keeps Grok weekly usage when settings body read aborts", async () => {
+    process.env["GROK_API_KEY"] = "grok_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+          () =>
+            jsonResponse({
+              config: {
+                currentPeriod: {
+                  type: "USAGE_PERIOD_TYPE_WEEKLY",
+                  end: "2026-08-15T00:00:00+00:00",
+                },
+                creditUsagePercent: 5,
+              },
+            }),
+        ],
+        [
+          "https://cli-chat-proxy.grok.com/v1/settings",
+          () => {
+            const response = jsonResponse({ subscription_tier_display: "SuperGrok Heavy" });
+            Object.defineProperty(response, "json", {
+              value: async () => {
+                throw new TypeError("terminated");
+              },
+            });
+            return response;
+          },
+        ],
+      ]),
+    );
+
+    const grok = findProvider(await service().listUsage(), "grok");
+
+    expect(grok).toMatchObject({
+      status: "available",
+      planLabel: null,
+      windows: [expect.objectContaining({ id: "weekly", usedPct: 5 })],
+    });
+  });
+
   it("keeps Grok weekly usage when settings returns invalid JSON", async () => {
     process.env["GROK_API_KEY"] = "grok_test_token";
     fetchApi = mockFetch(


### PR DESCRIPTION
### Linked issue

None. Related to #3298 and #3301, which also add a `grok-acp-agent.ts` adapter. This PR is the usage follow-up and will need a rebase if either of those lands first.

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Grok CLI already shows weekly SuperGrok limits in `/usage` and live context-window tokens in the session. Paseo treated Grok as a generic ACP provider and fetched the wrong billing URL, so the composer meter stayed empty and Host Usage never showed the weekly bar.

This PR maps those two Grok facts onto the existing Codex-style usage surfaces: the context-window meter and the Host Usage / tooltip bars. No new UI.

### Goals

- Fetch SuperGrok weekly usage from `/v1/billing?format=credits` (the same query Grok CLI `/usage` uses).
- Show the plan label from `/v1/settings` (`subscription_tier_display`).
- Publish live context-window used/max tokens from Grok ACP `session/update` `_meta.totalTokens`.
- Route the `grok` ACP provider through a dedicated adapter, matching Cursor / Kimi.
- Cover the mapping with unit tests and a local live daemon e2e against a real Grok CLI.

### Non-goals

- Change the shared usage UI.
- Add 5-hour windows. Grok's current billing response only publishes a weekly pool for SuperGrok Heavy.
- Merge or rebase onto #3298 / #3301. All three add `grok-acp-agent.ts`.
- Silence unrelated `_x.ai/*` ACP extension methods that are not usage.

### QA

Grok CLI `/usage` on this machine (SuperGrok Heavy) shows **Weekly limit 5%**, reset **August 15, 08:00**. The same account through Paseo's quota fetcher now returns:

```text
{
  "providerId": "grok",
  "displayName": "Grok",
  "status": "available",
  "planLabel": "SuperGrok Heavy",
  "windows": [
    {
      "id": "weekly",
      "label": "Weekly",
      "usedPct": 5,
      "remainingPct": 95,
      "resetsAt": "2026-08-15T00:00:00+00:00",
      "tone": "ok"
    }
  ],
  "balances": [],
  "details": [],
  "error": null
}
```

Live isolated daemon (does not touch port 6767):

```text
npx vitest run packages/server/src/server/daemon-e2e/grok-usage.local.e2e.test.ts --bail=1

✓ provider.usage.list returns SuperGrok Heavy weekly limit  6848ms
✓ a Grok turn publishes context-window usage onto the agent snapshot  41168ms

Test Files  1 passed (1)
Tests       2 passed (2)
```

The second test created a real `grok agent --always-approve stdio` session, sent `Reply with exactly the word pong and nothing else.`, and waited until `agent.lastUsage` had `contextWindowMaxTokens === 500000` and a used-token count.

Automated unit tests:

```text
npx vitest run \
  packages/server/src/services/quota-fetcher/service.test.ts \
  packages/server/src/server/agent/providers/grok-acp-agent.test.ts \
  packages/server/src/server/agent/providers/acp-agent.test.ts \
  packages/server/src/server/agent/provider-registry.test.ts \
  --bail=1

Test Files  4 passed (4)
Tests       229 passed (229)
```

```text
npm run typecheck
passed (pre-commit, all workspaces)

npm run lint -- <changed files>
Found 0 warnings and 0 errors.

npm run format:files -- <changed files>
passed
```

No new UI. The existing context-window meter and Host Usage bars render once the daemon publishes Grok windows and `lastUsage`. I did not click through a live Paseo composer or Host Usage screen on this branch; the daemon RPC and agent snapshot are the same payloads those surfaces read.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | No UI change; not tested |
| Android         |        | No UI change; not tested |
| Web             |        | No live composer/Host Usage click-through |
| Desktop macOS   | x      | Isolated daemon + real Grok CLI 1.0.3 |
| Desktop Windows |        | Not tested |
| Desktop Linux   |        | Not tested |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
