### PR TITLE
fix(release): refresh nix/npm-deps.hash before the version commit so release tags build

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "build:desktop": "npm run build:app-deps:clean && cd packages/app && cross-env PASEO_WEB_PLATFORM=electron npx expo export --platform web && cd ../.. && npm run build --workspace=@getpaseo/desktop --",
     "db:query": "npm run db:query --workspace=@getpaseo/server --",
     "cli": "./scripts/dev-home.sh npx tsx packages/cli/src/index.js",
-    "version": "npm run version:sync-internal && npm run release:prepare && git add -A",
+    "version": "npm run version:sync-internal && npm run release:prepare && ./scripts/update-nix.sh && git add -A",
     "version:sync-internal": "node scripts/sync-workspace-versions.mjs",
     "release:prepare": "npm install --workspaces --include-workspace-root",
     "version:all:patch": "node scripts/set-release-version.mjs --mode patch",


### PR DESCRIPTION
Fixes #3308.

Release tags currently ship a stale `nix/npm-deps.hash`: the version bump changes `package-lock.json`, the tag gets cut, and the hash only gets corrected afterwards by the bot commit on `main`. That makes every tagged release fail to build with Nix (details and a table of affected releases in the issue).

This adds one step to the root `version` lifecycle script, which `npm version` runs before creating the release commit that gets tagged:

```
npm run version:sync-internal && npm run release:prepare && ./scripts/update-nix.sh && git add -A
```

`scripts/update-nix.sh` is the same script CI already runs; doing it before the commit means the tagged commit carries the correct hash, and the post-release bot commit becomes a no-op.

Two tradeoffs to be aware of:

1. The release environment now needs `nix` installed, since `update-nix.sh` resolves `prefetch-npm-deps` through `nix shell`. If that is a problem for whoever cuts releases, this could be guarded with `command -v nix` at the cost of tags staying stale on machines without Nix.
2. It adds a few minutes to a release: `prefetch-npm-deps` downloads all npm tarballs to compute the hash.

I could not test the release flow end to end (it involves publishing), so please treat this as a proposal. The change is deliberately minimal; happy to adjust if you would rather hook it into `set-release-version.mjs` or the tag push script instead.
