### PR TITLE
fix(app): reconcile workspace draft modes

### DIFF
--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -17,7 +17,10 @@ import type { CreateAgentInitialValues } from "@/hooks/use-agent-form-state";
 import { useDraftAgentCreateFlow, type DraftCreateAttempt } from "@/composer/draft/create-flow";
 import { resolveTurnPresentation, TURN_LIVENESS_IDLE } from "@/timeline/turn-liveness";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
-import { buildWorkspaceDraftAgentConfig } from "@/screens/workspace/workspace-draft-agent-config";
+import {
+  buildWorkspaceDraftAgentConfig,
+  resolveWorkspaceDraftModeId,
+} from "@/screens/workspace/workspace-draft-agent-config";
 import { buildDraftStoreKey } from "@/stores/draft-keys";
 import { usePanelStore } from "@/stores/panel-store";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
@@ -88,50 +91,6 @@ function resolveAutoSubmitConfig(
   };
 }
 
-// Reconcile the form's selected mode against the currently discovered modes.
-// The mode picker displays modeOptions[0] when the stored mode isn't in the
-// list (e.g. a globally-remembered "plan" that this workspace's OpenCode config
-// no longer defines), so the submitted mode must match that display — otherwise
-// we'd send a stale mode the provider rejects while the UI showed a valid one.
-function reconcileSelectedMode(modeOptionIds: readonly string[], selectedMode: string): string {
-  if (modeOptionIds.length === 0) {
-    return "";
-  }
-  return modeOptionIds.includes(selectedMode) ? selectedMode : (modeOptionIds[0] ?? "");
-}
-
-function resolveDraftModeIdOverride(input: {
-  autoSubmitConfig: AutoSubmitConfig | null;
-  modeOptionIds: readonly string[];
-  selectedMode: string;
-}): { modeId: string } | Record<string, never> {
-  const { autoSubmitConfig, modeOptionIds, selectedMode } = input;
-  if (autoSubmitConfig?.modeId) {
-    return { modeId: autoSubmitConfig.modeId };
-  }
-  const reconciled = reconcileSelectedMode(modeOptionIds, selectedMode);
-  if (reconciled !== "") {
-    return { modeId: reconciled };
-  }
-  return {};
-}
-
-function resolveDraftModeId(input: {
-  autoSubmitConfig: AutoSubmitConfig | null;
-  modeOptionIds: readonly string[];
-  selectedMode: string;
-}): string | null {
-  const { autoSubmitConfig, modeOptionIds, selectedMode } = input;
-  if (autoSubmitConfig?.modeId !== undefined) {
-    return autoSubmitConfig.modeId;
-  }
-  const reconciled = reconcileSelectedMode(modeOptionIds, selectedMode);
-  if (reconciled !== "") {
-    return reconciled;
-  }
-  return null;
-}
-
 async function submitDraftCreateRequest(input: {
   attempt: { clientMessageId: string };
   text: string;
@@ -176,15 +135,15 @@ async function submitDraftCreateRequest(input: {
   if (!provider) {
     throw new Error(input.selectModelMessage);
   }
-  const modeIdOverride = resolveDraftModeIdOverride({
-    autoSubmitConfig,
+  const modeId = resolveWorkspaceDraftModeId({
+    requestedModeId: autoSubmitConfig?.modeId,
     modeOptionIds: composerState.modeOptions.map((mode) => mode.id),
-    selectedMode: composerState.selectedMode,
+    selectedModeId: composerState.selectedMode,
   });
   const config = buildWorkspaceDraftAgentConfig({
     provider,
     cwd,
-    ...modeIdOverride,
+    modeId,
     model: autoSubmitConfig?.model ?? (composerState.effectiveModelId || undefined),
     thinkingOptionId:
       autoSubmitConfig?.thinkingOptionId ?? (composerState.effectiveThinkingOptionId || undefined),
@@ -230,10 +189,10 @@ function buildDraftAgentSnapshot(input: {
   const model = autoSubmitConfig?.model ?? (composerState.effectiveModelId || null);
   const thinkingOptionId =
     autoSubmitConfig?.thinkingOptionId ?? (composerState.effectiveThinkingOptionId || null);
-  const modeId = resolveDraftModeId({
-    autoSubmitConfig,
+  const modeId = resolveWorkspaceDraftModeId({
+    requestedModeId: autoSubmitConfig?.modeId,
     modeOptionIds: composerState.modeOptions.map((mode) => mode.id),
-    selectedMode: composerState.selectedMode,
+    selectedModeId: composerState.selectedMode,
   });
   const provider = autoSubmitConfig?.provider ?? composerState.selectedProvider;
   if (!provider) {

--- a/packages/app/src/screens/workspace/workspace-draft-agent-config.test.ts
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildWorkspaceDraftAgentConfig } from "./workspace-draft-agent-config";
+import {
+  buildWorkspaceDraftAgentConfig,
+  resolveWorkspaceDraftModeId,
+} from "./workspace-draft-agent-config";
 
 describe("workspace-draft-agent-config", () => {
   it("builds chat-only config for workspace draft agents", () => {
@@ -17,6 +20,57 @@ describe("workspace-draft-agent-config", () => {
       modeId: "auto",
       model: "gpt-5.4",
       thinkingOptionId: "high",
+    });
+  });
+});
+
+describe("resolveWorkspaceDraftModeId", () => {
+  it("uses a valid selected mode", () => {
+    const input = {
+      requestedModeId: undefined,
+      modeOptionIds: ["plan", "agent"],
+      selectedModeId: "agent",
+    };
+
+    expect(resolveWorkspaceDraftModeId(input)).toBe("agent");
+  });
+
+  it("uses a valid requested mode", () => {
+    expect(
+      resolveWorkspaceDraftModeId({
+        requestedModeId: "agent",
+        modeOptionIds: ["plan", "agent"],
+        selectedModeId: "plan",
+      }),
+    ).toBe("agent");
+  });
+
+  it("reconciles a requested mode with the provider modes", () => {
+    expect(
+      resolveWorkspaceDraftModeId({
+        requestedModeId: "full-access",
+        modeOptionIds: ["agent"],
+        selectedModeId: "agent",
+      }),
+    ).toBe("agent");
+  });
+
+  it("omits a requested mode for a modeless provider", () => {
+    const input = {
+      requestedModeId: "agent",
+      modeOptionIds: [],
+      selectedModeId: "agent",
+    };
+
+    expect(
+      buildWorkspaceDraftAgentConfig({
+        provider: "pi",
+        cwd: "/tmp/project",
+        modeId: resolveWorkspaceDraftModeId(input),
+      }),
+    ).toEqual({
+      provider: "pi",
+      cwd: "/tmp/project",
     });
   });
 });

--- a/packages/app/src/screens/workspace/workspace-draft-agent-config.ts
+++ b/packages/app/src/screens/workspace/workspace-draft-agent-config.ts
@@ -1,9 +1,27 @@
 import type { AgentSessionConfig } from "@getpaseo/protocol/agent-types";
 
+interface WorkspaceDraftModeInput {
+  requestedModeId: string | null | undefined;
+  modeOptionIds: readonly string[];
+  selectedModeId: string;
+}
+
+export function resolveWorkspaceDraftModeId(input: WorkspaceDraftModeInput): string | null {
+  const requestedModeId = input.requestedModeId || input.selectedModeId;
+  if (input.modeOptionIds.length === 0) {
+    return null;
+  }
+  // The picker displays the first available mode when stored state is stale,
+  // so the submitted and optimistic modes must match that display.
+  return input.modeOptionIds.includes(requestedModeId)
+    ? requestedModeId
+    : (input.modeOptionIds[0] ?? null);
+}
+
 export function buildWorkspaceDraftAgentConfig(input: {
   provider: AgentSessionConfig["provider"];
   cwd: string;
-  modeId?: string;
+  modeId?: string | null;
   model?: string;
   thinkingOptionId?: string;
   featureValues?: Record<string, unknown>;


### PR DESCRIPTION
### Linked issue

Closes #3316

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

New Workspace creation is a two-stage flow: the first screen stores the selected agent configuration, then the destination workspace auto-submits that configuration after its provider snapshot resolves.

The existing submission code reconciled the live form mode against the destination provider's available modes, but trusted a mode carried in the pending auto-submit configuration. That allowed stale or cross-provider values such as `agent` and `full-access` to reach the server unchanged. Pi advertises `modes: []`, so its correctly strict server-side validation rejected the initial agent and left users with a newly created workspace but no agent.

This change performs the reconciliation once at the final submission boundary. Modeless providers omit `modeId`; providers with modes keep a valid requested/selected mode or fall back to their first available mode. The optimistic draft snapshot uses the same result as the create request.

### Goals

- Allow the initial Pi agent to be created in a new workspace even when pending form state carries a stale mode.
- Never send a mode that the resolved destination provider does not advertise.
- Keep the optimistic draft agent mode consistent with the actual create request.
- Preserve valid requested and selected modes for providers that support modes.
- Add a deterministic regression test for the modeless-provider case.

### Non-goals

- Relaxing server-side mode validation.
- Changing Pi's provider manifest or adding modes to Pi.
- Clearing saved create-agent preferences during provider discovery.
- Changing provider/model selection UI.

### QA

Reproduced before the fix with a pending Pi draft carrying `modeId: "agent"` while the resolved Pi mode list was empty. The regression assertion failed with:

```text
AssertionError: expected 'agent' to be null

Expected: null
Received: "agent"
```

After the fix:

```text
$ node node_modules/vitest/vitest.mjs run packages/app/src/screens/workspace/workspace-draft-agent-config.test.ts

Test Files  1 passed (1)
Tests       5 passed (5)
```

The tests cover:

- a valid selected mode;
- a valid requested mode;
- fallback when a requested mode is not advertised;
- omission of an inherited/requested mode for a modeless Pi provider;
- the existing workspace draft config shape.

The repository pre-commit hook also passed on Node 24.14.1:

```text
✓ format
✓ lint — 0 warnings, 0 errors
✓ typecheck — all workspaces
```

Additional checks run successfully:

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `git diff --check`

Platform evidence:

- Desktop/macOS arm64, Paseo 0.4.0-beta.2: original failure observed in app and daemon logs.
- Patched desktop GUI: not manually rebuilt/retested; behavior is validated at the final request-config boundary by the focused unit test.
- No visual screenshots are included because this change has no visual output.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense