### PR TITLE
Confirm external links from agent messages

### DIFF
--- a/packages/app/src/assistant-file-links/use-file-link.test.tsx
+++ b/packages/app/src/assistant-file-links/use-file-link.test.tsx
@@ -4,7 +4,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import React, { useCallback, useMemo, useState, type ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ToastApi } from "@/components/toast-host";
 import type { InlinePathTarget } from "./parse";
 import { AssistantFileLinkResolverProvider } from "./provider";
@@ -12,8 +12,12 @@ import type { DirectorySuggestionResult } from "./resolver";
 import { useFileLink } from "./use-file-link";
 import type { OpenFileDisposition } from "@/workspace/file-open";
 
-vi.mock("@/utils/open-external-url", () => ({
-  openExternalUrl: vi.fn(async () => {}),
+const { confirmationGate } = vi.hoisted(() => ({
+  confirmationGate: vi.fn(async () => {}),
+}));
+
+vi.mock("@/utils/confirm-agent-external-url", () => ({
+  confirmAndOpenAgentExternalUrl: confirmationGate,
 }));
 
 const SOURCE = {
@@ -21,6 +25,8 @@ const SOURCE = {
   text: "dumm.md",
   markup: "linkify",
 };
+
+const EXTERNAL_SOURCE = { href: "https://example.com/live?source=agent" };
 
 function resolvedSuggestions(
   entries: DirectorySuggestionResult["entries"],
@@ -99,6 +105,47 @@ function createWrapper(input: { client: TestClient; openedFiles: OpenedFile[]; t
 }
 
 describe("useFileLink", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends external assistant links through the confirmation gate", async () => {
+    const openedFiles: OpenedFile[] = [];
+    const { result } = renderHook(() => useFileLink(EXTERNAL_SOURCE), {
+      wrapper: createWrapper({
+        client: { getDirectorySuggestions: async () => resolvedSuggestions([]) },
+        openedFiles,
+      }),
+    });
+
+    act(() => {
+      result.current.onPress();
+    });
+
+    await waitFor(() => {
+      expect(confirmationGate).toHaveBeenCalledWith("https://example.com/live?source=agent");
+    });
+  });
+
+  it("keeps direct workspace file links in the existing in-app path", async () => {
+    const openedFiles: OpenedFile[] = [];
+    const { result } = renderHook(() => useFileLink({ href: "src/message.tsx:12" }), {
+      wrapper: createWrapper({
+        client: { getDirectorySuggestions: async () => resolvedSuggestions([]) },
+        openedFiles,
+      }),
+    });
+
+    act(() => {
+      result.current.onPress();
+    });
+
+    await waitFor(() => {
+      expect(openedFiles).toHaveLength(1);
+    });
+    expect(confirmationGate).not.toHaveBeenCalled();
+  });
+
   it("returns the same object across no-op parent rerenders", () => {
     const getDirectorySuggestions = vi.fn(async () => resolvedSuggestions([]));
     const queryClient = createQueryClient();

--- a/packages/app/src/assistant-file-links/use-file-link.ts
+++ b/packages/app/src/assistant-file-links/use-file-link.ts
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import type { OpenFileDisposition } from "@/workspace/file-open";
-import { openExternalUrl } from "@/utils/open-external-url";
+import { confirmAndOpenAgentExternalUrl } from "@/utils/confirm-agent-external-url";
 import type { InlinePathTarget } from "./parse";
 import {
   useAssistantFileLinkResolverContext,
@@ -320,7 +320,7 @@ async function dispatchExternalUrl(input: {
   ) {
     return;
   }
-  await openExternalUrl(input.url);
+  await confirmAndOpenAgentExternalUrl(input.url);
 }
 
 async function dispatchUnresolvedError(input: {

--- a/packages/app/src/utils/confirm-agent-external-url.test.ts
+++ b/packages/app/src/utils/confirm-agent-external-url.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { confirmDialog, openExternalUrl } = vi.hoisted(() => ({
+  confirmDialog: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("@/utils/confirm-dialog", () => ({ confirmDialog }));
+vi.mock("@/utils/open-external-url", () => ({ openExternalUrl }));
+
+import {
+  agentExternalUrlConfirmationMessage,
+  confirmAndOpenAgentExternalUrl,
+  parseAgentExternalUrl,
+} from "./confirm-agent-external-url";
+
+describe("agent external URL confirmation", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not retain the old one-click open behavior", async () => {
+    confirmDialog.mockResolvedValue(false);
+
+    await confirmAndOpenAgentExternalUrl("https://example.com/live?source=agent");
+
+    expect(confirmDialog).toHaveBeenCalledOnce();
+    expect(openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("opens only after the explicit Open live site action", async () => {
+    confirmDialog.mockResolvedValue(true);
+
+    await confirmAndOpenAgentExternalUrl("https://example.com/live?source=agent");
+
+    expect(confirmDialog).toHaveBeenCalledWith({
+      title: "Open external link",
+      message: expect.stringContaining("Full URL: https://example.com/live?source=agent"),
+      confirmLabel: "Open live site",
+      cancelLabel: "Cancel",
+    });
+    expect(openExternalUrl).toHaveBeenCalledOnce();
+    expect(openExternalUrl).toHaveBeenCalledWith("https://example.com/live?source=agent");
+  });
+
+  it("fails closed for malformed and non-http targets", async () => {
+    await confirmAndOpenAgentExternalUrl("javascript:alert(1)");
+    await confirmAndOpenAgentExternalUrl("not a url");
+
+    expect(confirmDialog).not.toHaveBeenCalled();
+    expect(openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("shows internationalized destinations with their ASCII punycode hostname", () => {
+    const destination = parseAgentExternalUrl("https://faß.de/path");
+
+    expect(destination).toEqual({
+      hostname: "xn--fa-hia.de",
+      url: "https://xn--fa-hia.de/path",
+    });
+    expect(agentExternalUrlConfirmationMessage(destination!)).toContain(
+      "Destination hostname (ASCII/punycode): xn--fa-hia.de",
+    );
+  });
+});

--- a/packages/app/src/utils/confirm-agent-external-url.test.ts
+++ b/packages/app/src/utils/confirm-agent-external-url.test.ts
@@ -55,11 +55,25 @@ describe("agent external URL confirmation", () => {
     const destination = parseAgentExternalUrl("https://faß.de/path");
 
     expect(destination).toEqual({
+      host: "xn--fa-hia.de",
       hostname: "xn--fa-hia.de",
       url: "https://xn--fa-hia.de/path",
     });
     expect(agentExternalUrlConfirmationMessage(destination!)).toContain(
-      "Destination hostname (ASCII/punycode): xn--fa-hia.de",
+      "Destination host (ASCII/punycode): xn--fa-hia.de",
+    );
+  });
+
+  it("shows an explicit non-default port in the destination host", () => {
+    const destination = parseAgentExternalUrl("https://example.com:8443/path");
+
+    expect(destination).toEqual({
+      host: "example.com:8443",
+      hostname: "example.com",
+      url: "https://example.com:8443/path",
+    });
+    expect(agentExternalUrlConfirmationMessage(destination!)).toContain(
+      "Destination host: example.com:8443",
     );
   });
 });

--- a/packages/app/src/utils/confirm-agent-external-url.ts
+++ b/packages/app/src/utils/confirm-agent-external-url.ts
@@ -4,6 +4,7 @@ import { openExternalUrl } from "@/utils/open-external-url";
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 
 export interface AgentExternalUrlDestination {
+  host: string;
   hostname: string;
   url: string;
 }
@@ -18,7 +19,7 @@ export function parseAgentExternalUrl(url: string): AgentExternalUrlDestination 
     if (!ALLOWED_PROTOCOLS.has(destination.protocol) || !destination.hostname) {
       return null;
     }
-    return { hostname: destination.hostname, url: destination.href };
+    return { host: destination.host, hostname: destination.hostname, url: destination.href };
   } catch {
     return null;
   }
@@ -28,10 +29,10 @@ export function agentExternalUrlConfirmationMessage(
   destination: AgentExternalUrlDestination,
 ): string {
   const hostnameLabel = destination.hostname.includes("xn--")
-    ? "Destination hostname (ASCII/punycode)"
-    : "Destination hostname";
+    ? "Destination host (ASCII/punycode)"
+    : "Destination host";
   return [
-    `${hostnameLabel}: ${destination.hostname}`,
+    `${hostnameLabel}: ${destination.host}`,
     `Full URL: ${destination.url}`,
     "",
     "This link was supplied by an agent. The live destination may differ from content inspected elsewhere.",

--- a/packages/app/src/utils/confirm-agent-external-url.ts
+++ b/packages/app/src/utils/confirm-agent-external-url.ts
@@ -1,0 +1,57 @@
+import { confirmDialog } from "@/utils/confirm-dialog";
+import { openExternalUrl } from "@/utils/open-external-url";
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+export interface AgentExternalUrlDestination {
+  hostname: string;
+  url: string;
+}
+
+/**
+ * The URL constructor canonicalizes internationalized hostnames to ASCII, so
+ * the destination shown to the user cannot conceal a lookalike Unicode domain.
+ */
+export function parseAgentExternalUrl(url: string): AgentExternalUrlDestination | null {
+  try {
+    const destination = new URL(url);
+    if (!ALLOWED_PROTOCOLS.has(destination.protocol) || !destination.hostname) {
+      return null;
+    }
+    return { hostname: destination.hostname, url: destination.href };
+  } catch {
+    return null;
+  }
+}
+
+export function agentExternalUrlConfirmationMessage(
+  destination: AgentExternalUrlDestination,
+): string {
+  const hostnameLabel = destination.hostname.includes("xn--")
+    ? "Destination hostname (ASCII/punycode)"
+    : "Destination hostname";
+  return [
+    `${hostnameLabel}: ${destination.hostname}`,
+    `Full URL: ${destination.url}`,
+    "",
+    "This link was supplied by an agent. The live destination may differ from content inspected elsewhere.",
+  ].join("\n");
+}
+
+/** Opens an agent-supplied external URL only after an explicit confirmation. */
+export async function confirmAndOpenAgentExternalUrl(url: string): Promise<void> {
+  const destination = parseAgentExternalUrl(url);
+  if (!destination) {
+    return;
+  }
+
+  const confirmed = await confirmDialog({
+    title: "Open external link",
+    message: agentExternalUrlConfirmationMessage(destination),
+    confirmLabel: "Open live site",
+    cancelLabel: "Cancel",
+  });
+  if (confirmed) {
+    await openExternalUrl(destination.url);
+  }
+}


### PR DESCRIPTION
Fixes #3319

## Summary
- Gate http(s) URLs from assistant-message links behind the existing cross-platform `confirmDialog`.
- Show the canonical destination host (including a non-default port), full URL, and ASCII/punycode for IDN hosts.
- Keep workspace/file targets on their existing direct in-app path.

## Tests
```text
npx vitest run packages/app/src/utils/confirm-agent-external-url.test.ts packages/app/src/assistant-file-links/use-file-link.test.tsx --bail=1
Test Files  2 passed (2)
Tests  13 passed (13)

npm run typecheck
All workspace typechecks passed

npm run lint
Found 0 warnings and 0 errors.

npm run format:check
All matched files use the correct format.
```

## QA evidence
- Focused unit coverage proves cancel does not call the platform opener and explicit confirmation calls it exactly once.
- Covers malformed/non-http(s), full URL, IDN/punycode, an explicit `:8443` port, and direct workspace file links.
- Traced linked assistant images: `AssistantMessage` supplies `handleMarkdownLinkPress`; it calls `fileLinkActions.open()` and returns `false`, so both image paths cancel their fallback `openExternalUrl` call and use this gate.

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Uses existing native `Alert` confirmation path; no device available |
| Android | No | Uses existing native `Alert` confirmation path; no emulator available |
| Web | No | Browser visual run not completed on this host |
| Desktop Linux | No | Uses existing Electron dialog bridge; not run |
| Desktop macOS | No | Not available |
| Desktop Windows | No | Not available |
