### PR TITLE
fix(providers): recover from expired provider credentials

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -130,6 +130,14 @@ Boundary tests should assert observable behavior: cold reads may call provider a
 
 ---
 
+## Expired Credentials
+
+A provider whose credentials expire mid-session reports it as an ordinary turn failure, so an expired token is otherwise indistinguishable from a crash. Classify it instead: pass the failure text through `isProviderAuthError` in `packages/server/src/server/agent/providers/auth-error.ts` and set `authState: "expired"` on the `turn_failed` event. `AgentManager` uses that flag to append `buildProviderAuthRecoveryGuidance`, which names the credential that failed and gives the runtime's login steps. Add those steps to `PROVIDER_LOGIN_STEPS` when adding a provider; without an entry the guidance falls back to a generic line.
+
+Runtimes cache credentials in the running process, so re-authenticating elsewhere changes nothing until that process is replaced. A provider that classifies an auth failure should also retire its runtime so the next turn spawns a fresh one on the same session — the Claude client sets `queryRestartNeeded`, and only while a query is live, since `ensureQuery()` clears that flag as part of retiring an existing process.
+
+Runtimes launched non-interactively have no login command. If a runtime advertises one anyway (Claude Code tells users to run `/login`), intercept it locally and answer with the recovery guidance rather than forwarding it to a process that will reject it.
+
 ## Provider Usage Fetchers
 
 Provider plan usage is fetch-on-demand, not a daemon push subscription. The app calls `provider.usage.list.request` through React Query when the usage tooltip or Host Usage settings screen is shown, and the daemon returns the normalized `ProviderUsage` list directly.

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -379,6 +379,8 @@ export type AgentStreamEvent =
       error: string;
       code?: string;
       diagnostic?: string;
+      /** Set when the failure was the provider's credentials, not the run itself. */
+      authState?: "expired";
       turnId?: string;
     }
   | { type: "turn_canceled"; provider: AgentProvider; reason: string; turnId?: string }

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -745,6 +745,7 @@ export const AgentStreamEventPayloadSchema = z.discriminatedUnion("type", [
     error: z.string(),
     code: z.string().optional(),
     diagnostic: z.string().optional(),
+    authState: z.literal("expired").optional(),
   }),
   z.object({
     type: z.literal("turn_canceled"),

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -16,6 +16,7 @@ import type { Logger } from "pino";
 import type { ProviderOptions, ToolPolicy } from "@getpaseo/protocol/agent-types";
 import { z } from "zod";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
+import { buildProviderAuthRecoveryGuidance } from "./providers/auth-error.js";
 
 import {
   getAgentStreamEventTurnId,
@@ -4396,6 +4397,11 @@ export class AgentManager {
     const diagnostic = event.diagnostic?.trim();
     if (diagnostic && diagnostic !== base) {
       parts.push(diagnostic);
+    }
+    if (event.authState === "expired") {
+      // The runtime's own text names neither the credential that failed nor a
+      // recovery path that exists inside Paseo. Supply both.
+      parts.push(buildProviderAuthRecoveryGuidance({ provider: event.provider }));
     }
     return parts.join("\n\n");
   }

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -422,6 +422,8 @@ export type AgentStreamEvent =
       error: string;
       code?: string;
       diagnostic?: string;
+      /** Set when the failure was the provider's credentials, not the run itself. */
+      authState?: "expired";
       turnId?: string;
     }
   | { type: "turn_canceled"; provider: AgentProvider; reason: string; turnId?: string }

--- a/packages/server/src/server/agent/providers/auth-error.test.ts
+++ b/packages/server/src/server/agent/providers/auth-error.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProviderAuthRecoveryGuidance, isProviderAuthError } from "./auth-error.js";
+
+describe("isProviderAuthError", () => {
+  it.each([
+    "Failed to authenticate. API Error: 401 OAuth access token has been revoked.",
+    "Failed to authenticate: OAuth session expired and could not be refreshed",
+    "Not logged in · Please run /login",
+    "OAuth token has expired",
+    "API error: 401 invalid api key",
+    "authentication_error: credentials rejected",
+  ])("classifies %j as an auth failure", (message) => {
+    expect(isProviderAuthError(message)).toBe(true);
+  });
+
+  it.each([
+    "Claude stopped unexpectedly (exit code 1).",
+    "Tool call failed: ENOENT",
+    // Loose tokens must stay tied to an auth-ish neighbour, or ordinary output
+    // that happens to quote them would be misread as an expired credential.
+    "server.ts:401 unauthorized_user_ids is not defined",
+    "Request failed with status 500",
+    "",
+    undefined,
+    null,
+  ])("does not classify %j", (message) => {
+    expect(isProviderAuthError(message)).toBe(false);
+  });
+});
+
+describe("buildProviderAuthRecoveryGuidance", () => {
+  it("names the provider and gives its exact login steps", () => {
+    const guidance = buildProviderAuthRecoveryGuidance({ provider: "claude" });
+    expect(guidance).toContain("Claude Code");
+    expect(guidance).toContain("/logout");
+    expect(guidance).toContain("/login");
+  });
+
+  it("distinguishes the credential from unrelated logins", () => {
+    const guidance = buildProviderAuthRecoveryGuidance({ provider: "codex" });
+    expect(guidance).toContain("codex login");
+    expect(guidance).toMatch(/not your Paseo, Git forge, or cloud CLI login/);
+  });
+
+  it("falls back to the provider id when the runtime is unknown", () => {
+    const guidance = buildProviderAuthRecoveryGuidance({ provider: "acme-agent" });
+    expect(guidance).toContain("acme-agent");
+    expect(guidance).toContain("login flow in a terminal");
+  });
+
+  it("prefers an explicit label over the built-in default", () => {
+    const guidance = buildProviderAuthRecoveryGuidance({
+      provider: "claude",
+      providerLabel: "Claude (work profile)",
+    });
+    expect(guidance).toContain("Claude (work profile)");
+  });
+});

--- a/packages/server/src/server/agent/providers/auth-error.ts
+++ b/packages/server/src/server/agent/providers/auth-error.ts
@@ -1,0 +1,65 @@
+/**
+ * Provider credentials expire mid-session. The runtime reports that as an
+ * ordinary turn failure, so without classification an expired token is
+ * indistinguishable from a crash: the user is told "Failed to authenticate"
+ * with no indication of which credential died, and the runtime's own advice
+ * ("run /login") targets an interactive CLI that does not exist here.
+ *
+ * Classifying the failure lets the agent recycle its runtime process so an
+ * external re-login is picked up, and lets the manager attach recovery steps
+ * that can actually be followed from inside Paseo.
+ */
+
+// Matched against a runtime's failure text, which is far narrower than agent
+// output, but still keep the loose tokens (401, unauthorized) tied to an
+// auth-ish neighbour so a diff or a log line quoting them is not misread.
+const AUTH_ERROR_PATTERNS: readonly RegExp[] = [
+  /\bfailed to authenticate\b/i,
+  /\bnot logged in\b/i,
+  /\bplease run\s+\/login\b/i,
+  /\boauth\b[^\n]{0,80}\b(?:expired|revoked|refresh(?:ed)?)\b/i,
+  /\b(?:session|token|credentials?)\b[^\n]{0,80}\b(?:expired|revoked)\b/i,
+  /\b(?:401|unauthorized)\b[^\n]{0,80}\b(?:oauth|token|credentials?|auth\w*|api[ _-]?key)\b/i,
+  /\b(?:oauth|token|credentials?|auth\w*|api[ _-]?key)\b[^\n]{0,80}\b(?:401|unauthorized)\b/i,
+  /\bauthentication_error\b/i,
+  /\binvalid[ _-]?api[ _-]?key\b/i,
+];
+
+/** Re-authentication steps for the runtimes whose flow we can state exactly. */
+const PROVIDER_LOGIN_STEPS: Readonly<Record<string, string>> = {
+  claude: "run `claude` in a terminal, then `/logout` followed by `/login`",
+  codex: "run `codex login` in a terminal",
+};
+
+/** Display names for providers reached by id alone, away from the snapshot manager. */
+const PROVIDER_LABELS: Readonly<Record<string, string>> = {
+  claude: "Claude Code",
+  codex: "Codex",
+};
+
+export function isProviderAuthError(text: string | null | undefined): boolean {
+  if (!text) {
+    return false;
+  }
+  return AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Names the credential that failed and gives steps that work from here. The
+ * runtime holds its credentials in memory, so a re-login is only picked up
+ * once the process is replaced — say so rather than leaving the user to guess
+ * why a successful login changed nothing.
+ */
+export function buildProviderAuthRecoveryGuidance(options: {
+  provider: string;
+  providerLabel?: string;
+}): string {
+  const label =
+    options.providerLabel?.trim() || PROVIDER_LABELS[options.provider] || options.provider;
+  const steps =
+    PROVIDER_LOGIN_STEPS[options.provider] ?? `re-run the ${label} login flow in a terminal`;
+  return [
+    `${label} credentials are no longer valid. This is ${label}'s own authentication, not your Paseo, Git forge, or cloud CLI login.`,
+    `To recover, ${steps}, then send another message here — this agent restarts its ${label} process on the next turn, so it will pick up the refreshed credentials.`,
+  ].join("\n\n");
+}

--- a/packages/server/src/server/agent/providers/claude/agent.auth-failure.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.auth-failure.test.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import type { Query } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../../test-utils/test-logger.js";
+import * as spawnUtils from "../../../../utils/spawn.js";
+import type { AgentStreamEvent } from "../../agent-sdk-types.js";
+import { ClaudeAgentClient } from "./agent.js";
+import type { ClaudeQueryInput } from "./query.js";
+
+function createQueryMock(events: unknown[]): Query {
+  let index = 0;
+  return {
+    next: vi.fn(async () =>
+      index < events.length
+        ? { done: false, value: events[index++] }
+        : { done: true, value: undefined },
+    ),
+    return: vi.fn(async () => ({ done: true, value: undefined })),
+    interrupt: vi.fn(async () => undefined),
+    close: vi.fn(() => undefined),
+    setPermissionMode: vi.fn(async () => undefined),
+    setModel: vi.fn(async () => undefined),
+    supportedModels: vi.fn(async () => [{ value: "opus", displayName: "Opus" }]),
+    supportedCommands: vi.fn(async () => []),
+    rewindFiles: vi.fn(async () => ({ canRewind: true })),
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } as Query;
+}
+
+function createChildProcessStub(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  child.stderr = new EventEmitter() as ChildProcess["stderr"];
+  child.kill = ((signal?: NodeJS.Signals | number) => {
+    child.emit("exit", null, typeof signal === "string" ? signal : "SIGTERM");
+    return true;
+  }) as ChildProcess["kill"];
+  return child;
+}
+
+const INIT_EVENT = {
+  type: "system",
+  subtype: "init",
+  session_id: "claude-auth-failure-session",
+  permissionMode: "default",
+  model: "opus",
+};
+
+function failingTurn(error: string) {
+  return [INIT_EVENT, { type: "result", subtype: "error_during_execution", errors: [error] }];
+}
+
+function createClient(events: unknown[]) {
+  const queryFactory = vi.fn((_input: ClaudeQueryInput) => createQueryMock(events));
+  vi.spyOn(spawnUtils, "spawnProcess").mockReturnValue(createChildProcessStub());
+  const client = new ClaudeAgentClient({
+    logger: createTestLogger(),
+    queryFactory,
+    resolveBinary: async () => "/test/claude/bin",
+  });
+  return { client, queryFactory };
+}
+
+describe("Claude auth failures", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("marks an expired credential so it is not mistaken for a crash", async () => {
+    const { client } = createClient(
+      failingTurn("Failed to authenticate: OAuth session expired and could not be refreshed"),
+    );
+    const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      await expect(session.run("hello")).rejects.toThrow(/Failed to authenticate/);
+
+      const failure = events.find((event) => event.type === "turn_failed");
+      expect(failure).toBeDefined();
+      expect(failure && "authState" in failure ? failure.authState : undefined).toBe("expired");
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("leaves ordinary failures unflagged", async () => {
+    const { client } = createClient(failingTurn("Tool call failed: ENOENT"));
+    const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      await expect(session.run("hello")).rejects.toThrow(/ENOENT/);
+
+      const failure = events.find((event) => event.type === "turn_failed");
+      expect(failure).toBeDefined();
+      expect(failure && "authState" in failure ? failure.authState : undefined).toBeUndefined();
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("answers /login locally instead of forwarding it to a runtime that rejects it", async () => {
+    const { client, queryFactory } = createClient([INIT_EVENT]);
+    const session = await client.createSession({ provider: "claude", cwd: process.cwd() });
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      await session.startTurn("/login");
+
+      const message = events.find(
+        (event) => event.type === "timeline" && event.item.type === "assistant_message",
+      );
+      expect(message).toBeDefined();
+      const text =
+        message && message.type === "timeline" && message.item.type === "assistant_message"
+          ? message.item.text
+          : "";
+      expect(text).toContain("Claude Code");
+      expect(text).toContain("/logout");
+      expect(events.some((event) => event.type === "turn_completed")).toBe(true);
+      // The point of the interception: never reaches the SDK.
+      expect(queryFactory).not.toHaveBeenCalled();
+    } finally {
+      await session.close();
+    }
+  });
+});

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -68,6 +68,7 @@ import {
   formatProviderDiagnostic,
   formatProviderDiagnosticError,
 } from "../diagnostic-utils.js";
+import { buildProviderAuthRecoveryGuidance, isProviderAuthError } from "../auth-error.js";
 import { appendOrReplaceGrowingAssistantMessage, runProviderTurn } from "../provider-runner.js";
 import {
   applyClaudeToolPolicy,
@@ -350,6 +351,10 @@ const REWIND_COMMAND: AgentSlashCommand = {
   description: "Rewind tracked files to a previous user message",
   argumentHint: "[user_message_uuid]",
 };
+// Claude Code's own advice on an expired token is "run /login", but the SDK
+// runtime has no interactive login. Intercept these locally so the user gets
+// steps that work instead of "/login isn't available in this environment."
+const AUTH_COMMAND_NAMES = new Set(["login", "logout"]);
 const CLAUDE_ROOT_ONLY_COMMANDS = new Set([
   "clear",
   "compact",
@@ -2199,6 +2204,13 @@ class ClaudeAgentSession implements AgentSession {
     }
 
     const slashCommand = this.resolveSlashCommandInvocation(prompt);
+    if (slashCommand && AUTH_COMMAND_NAMES.has(slashCommand.commandName)) {
+      const turnId = this.createTurnId("foreground");
+      this.activeForegroundTurnId = turnId;
+      this.transitionTurnState("foreground", "auth command");
+      this.executeAuthCommandTurn();
+      return { turnId };
+    }
     if (slashCommand?.commandName === REWIND_COMMAND_NAME) {
       const turnId = this.createTurnId("foreground");
       this.activeForegroundTurnId = turnId;
@@ -2776,10 +2788,10 @@ class ClaudeAgentSession implements AgentSession {
     if (!parsed) {
       return null;
     }
-    return parsed.commandName === REWIND_COMMAND_NAME ||
-      CLAUDE_ROOT_ONLY_COMMANDS.has(parsed.commandName)
-      ? parsed
-      : null;
+    const isPaseoHandledCommand =
+      parsed.commandName === REWIND_COMMAND_NAME || AUTH_COMMAND_NAMES.has(parsed.commandName);
+    const isRootOnlyCommand = CLAUDE_ROOT_ONLY_COMMANDS.has(parsed.commandName);
+    return isPaseoHandledCommand || isRootOnlyCommand ? parsed : null;
   }
 
   private parseSlashCommandInput(text: string): SlashCommandInvocation | null {
@@ -3429,12 +3441,22 @@ class ClaudeAgentSession implements AgentSession {
     const exitCodeMatch = normalized.match(/\bcode\s+(\d+)\b/i);
     const code = exitCodeMatch ? exitCodeMatch[1] : undefined;
     const diagnostic = this.getRecentStderrDiagnostic();
+    const authExpired = isProviderAuthError(normalized) || isProviderAuthError(diagnostic);
+    if (authExpired && this.query) {
+      // Claude Code caches credentials in the running process, so re-authenticating
+      // elsewhere does nothing until that process is replaced. Retire it here and
+      // the next turn spawns a fresh one on the same session. Only flag a live
+      // query: ensureQuery() clears the flag while retiring an existing process,
+      // so setting it against a dead one would retire the replacement instead.
+      this.queryRestartNeeded = true;
+    }
     return {
       type: "turn_failed",
       provider: "claude",
       error: normalized,
       ...(code ? { code } : {}),
       ...(diagnostic ? { diagnostic } : {}),
+      ...(authExpired ? { authState: "expired" as const } : {}),
     };
   }
 
@@ -3486,6 +3508,27 @@ class ClaudeAgentSession implements AgentSession {
       event.type === "turn_failed" ||
       event.type === "turn_canceled"
     );
+  }
+
+  private executeAuthCommandTurn(): void {
+    this.notifySubscribers({ type: "turn_started", provider: "claude" });
+    // Force a fresh process on the next turn so credentials refreshed by the
+    // steps below are actually picked up.
+    if (this.query) {
+      this.queryRestartNeeded = true;
+    }
+    this.notifySubscribers({
+      type: "timeline",
+      provider: "claude",
+      item: {
+        type: "assistant_message",
+        text: buildProviderAuthRecoveryGuidance({
+          provider: "claude",
+          providerLabel: "Claude Code",
+        }),
+      },
+    });
+    this.finishForegroundTurn({ type: "turn_completed", provider: "claude" });
   }
 
   private async executeRewindTurn(


### PR DESCRIPTION
Fixes the recovery half of #3325. #3023 tracks the upstream Claude OAuth regression; this changes what happens in Paseo when any provider's credentials expire, which stays broken regardless of that upstream fix.

## Problem

When credentials expire mid-session the runtime reports an ordinary turn failure, so Paseo relays it verbatim and the session dead-ends:

```
Failed to authenticate. API Error: 401 OAuth access token has been revoked.
Not logged in · Please run /login
/login → /login isn't available in this environment.
```

Three separate failures there: the message names no credential (I re-authenticated the wrong service first), re-authenticating externally changed nothing, and the only advice given cannot be followed anywhere in the product.

## Change

- **Classify auth failures.** New `providers/auth-error.ts` exports `isProviderAuthError`; `turn_failed` carries `authState: "expired"` so an expired token stops being indistinguishable from a crash. Previously `buildTurnFailedEvent` classified exit codes only.
- **Name the credential and give steps that work.** `AgentManager.formatTurnFailedMessage` appends `buildProviderAuthRecoveryGuidance`, which says which runtime's login failed — explicitly *not* your Paseo, Git forge, or cloud CLI login — and gives that runtime's login command.
- **Pick up an external re-login.** Runtimes cache credentials in the running process, which is why logging in elsewhere appeared to do nothing. On an auth failure the Claude client sets the existing `queryRestartNeeded`, so the next turn spawns a fresh process on the same session, with no manual reload.
- **Answer `/login` locally.** Intercepted alongside `/logout` using the existing `REWIND_COMMAND` pattern, so it returns the recovery steps instead of being forwarded to a runtime that rejects it.

Kept to the server and protocol; `formatTurnFailedMessage` is the single seam where user-visible failure text is composed, so no UI component changes were needed.

## Design notes

- The loose tokens (`401`, `unauthorized`) only match next to an auth-ish neighbour, so a diff or log line quoting them is not misread as an expired credential. Covered by negative tests.
- `queryRestartNeeded` is only set while a query is live: `ensureQuery()` clears the flag as part of retiring an existing process, so setting it against a dead one would retire the *replacement* instead.
- Providers beyond Claude get classification and guidance for free via `AgentManager`; `PROVIDER_LOGIN_STEPS` carries exact steps for Claude and Codex and falls back to a generic line. Contract documented in `docs/providers.md`.

## Tests

`packages/server/src/server/agent/providers/auth-error.test.ts` (17) — classification over the real messages above, negatives for the loose tokens, and guidance content including the unknown-provider fallback.

`packages/server/src/server/agent/providers/claude/agent.auth-failure.test.ts` (3) — an expired credential sets `authState`, an ordinary failure does not, and `/login` is answered locally and never reaches the SDK.

```
✓ auth-error.test.ts (17)
✓ agent.auth-failure.test.ts (3)
✓ src/server/agent (1920 passed | 22 skipped)
```

Full `npm run typecheck` passes across all workspaces; `lint` and `format:check` clean.

**Tested on:** macOS 26.5.2 (arm64), Node via the repo toolchain, against Claude Code 2.1.228.

**Not tested:** Windows and Linux; no real expired-token run against a live provider — the failure paths are exercised through the SDK-level test harness, not by revoking a real token. Codex's `PROVIDER_LOGIN_STEPS` entry is written from its documented flow, not verified against an expired Codex session.

**Pre-existing failures, unrelated and present on a clean `origin/main` checkout** (verified in a scratch worktree at `d0d60a405`): 4 worktree cases in `mcp-parity.e2e.test.ts`, plus `*.real.e2e` and OpenCode local e2e suites that need `OPENROUTER_API_KEY` and provider binaries.

No UI change, so no video — the user-visible difference is the text of the system error message and the `/login` reply.
