### PR TITLE
fix: auto-archive-on-merge liveness and matching (#2886)

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6108,6 +6108,53 @@ test("hasWorkspaceInFlightRun sees an internal agent's in-flight run that listAg
   }
 });
 
+test("hasWorkspaceInFlightRun sees a running provider-native subagent even while its parent is idle", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-subagent-liveness-"));
+  const workspaceId = "ws-subagent-liveness";
+  const sessionHolder: { current: TestAgentSession | null } = { current: null };
+  class SubagentCapableClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      sessionHolder.current = new TestAgentSession(config);
+      return sessionHolder.current;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new SubagentCapableClient() },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    logger,
+  });
+
+  const parent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+    workspaceId,
+  });
+
+  // Parent has never run a turn: idle by every existing measure.
+  expect(manager.getAgent(parent.id)?.lifecycle).toBe("idle");
+  expect(manager.hasWorkspaceInFlightRun(workspaceId)).toBe(false);
+
+  // A provider-native subagent (e.g. a Task tool child) is running under it.
+  // docs/agent-lifecycle.md: "a parent agent is idle when its own turn is
+  // idle, even if a child is running" — that must still count as workspace
+  // activity for archival safety.
+  sessionHolder.current?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "native-child", title: "Native child", status: "running" },
+  });
+  await manager.flush();
+
+  expect(manager.hasWorkspaceInFlightRun(workspaceId)).toBe(true);
+
+  sessionHolder.current?.pushEvent({
+    type: "provider_subagent",
+    provider: "codex",
+    event: { type: "upsert", id: "native-child", status: "completed" },
+  });
+  await manager.flush();
+
+  expect(manager.hasWorkspaceInFlightRun(workspaceId)).toBe(false);
+});
+
 test("subscribe hides provider subagents of internal parents from global subscribers", async () => {
   const internalAgentId = "00000000-0000-4000-8000-000000000117";
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-internal-provider-child-"));

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -6068,6 +6068,46 @@ test("subscribe does not emit state events for internal agents to global subscri
   expect(receivedEvents.filter((id) => id === generatedAgentIds[1]).length).toBe(0);
 });
 
+test("hasWorkspaceInFlightRun sees an internal agent's in-flight run that listAgents hides", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-internal-liveness-"));
+  const workspaceId = "ws-internal-liveness";
+  const turnId = "turn-internal-liveness";
+  let session: ControlledInterruptSession | null = null;
+  class HoldingClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      session = new ControlledInterruptSession(config, turnId, async () => {});
+      return session;
+    }
+  }
+  const manager = new AgentManager({
+    clients: { codex: new HoldingClient() },
+    registry: new AgentStorage(join(workdir, "agents"), logger),
+    logger,
+  });
+
+  const internalAgent = await manager.createAgent(
+    { provider: "codex", cwd: workdir, internal: true },
+    undefined,
+    { workspaceId },
+  );
+
+  const run = manager.streamAgent(internalAgent.id, "go");
+  void (async () => {
+    for await (const _event of run) {
+      // Keep the foreground stream subscribed until the controlled turn settles.
+    }
+  })();
+  await manager.waitForAgentRunStart(internalAgent.id);
+
+  try {
+    expect(manager.listAgents().some((agent) => agent.workspaceId === workspaceId)).toBe(false);
+    expect(manager.hasWorkspaceInFlightRun(workspaceId)).toBe(true);
+    expect(manager.hasWorkspaceInFlightRun("some-other-workspace")).toBe(false);
+  } finally {
+    await manager.closeAgent(internalAgent.id);
+  }
+});
+
 test("subscribe hides provider subagents of internal parents from global subscribers", async () => {
   const internalAgentId = "00000000-0000-4000-8000-000000000117";
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-internal-provider-child-"));

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -836,6 +836,18 @@ export class AgentManager {
     );
   }
 
+  // why: unlike listAgents(), this walks every live agent including internal
+  // ones (e.g. branch-name/git-metadata generators) — callers that need to
+  // know whether a workspace is safe to tear down must not miss those.
+  hasWorkspaceInFlightRun(workspaceId: string): boolean {
+    for (const agent of this.agents.values()) {
+      if (agent.workspaceId === workspaceId && this.hasInFlightRun(agent.id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   subscribe(callback: AgentSubscriber, options?: SubscribeOptions): () => void {
     const targetAgentId =
       options?.agentId == null ? null : validateAgentId(options.agentId, "subscribe");

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -838,10 +838,19 @@ export class AgentManager {
 
   // why: unlike listAgents(), this walks every live agent including internal
   // ones (e.g. branch-name/git-metadata generators) — callers that need to
-  // know whether a workspace is safe to tear down must not miss those.
+  // know whether a workspace is safe to tear down must not miss those. It
+  // also checks provider-native subagents directly: a parent agent is idle
+  // when its own turn is idle even while a native child is still running
+  // (docs/agent-lifecycle.md), so hasInFlightRun(parent) alone would miss it.
   hasWorkspaceInFlightRun(workspaceId: string): boolean {
     for (const agent of this.agents.values()) {
-      if (agent.workspaceId === workspaceId && this.hasInFlightRun(agent.id)) {
+      if (agent.workspaceId !== workspaceId) {
+        continue;
+      }
+      if (this.hasInFlightRun(agent.id)) {
+        return true;
+      }
+      if (this.providerSubagents.list(agent.id).some((subagent) => subagent.status === "running")) {
         return true;
       }
     }

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   archiveIfSafe,
   type ArchiveIfSafeDependencies,
+  type ArchiveIfSafeOutcome,
   type AutoArchiveArchiveOptions,
 } from "./archive-if-safe.js";
 import type { ArchiveResult, ActiveWorkspaceRef } from "../workspace-archive-service.js";
@@ -73,6 +74,7 @@ function createLogger(): Logger {
     child: () => logger,
     info: vi.fn(),
     warn: vi.fn(),
+    debug: vi.fn(),
   };
   return logger as unknown as Logger;
 }
@@ -84,6 +86,7 @@ function createHarness(overrides?: {
   isPaseoOwnedWorktreeCwd?: ArchiveIfSafeDependencies["isPaseoOwnedWorktreeCwd"];
   archiveByScope?: ArchiveIfSafeDependencies["archiveByScope"];
   resolveWorkspaceIdAtPath?: ArchiveIfSafeDependencies["resolveWorkspaceIdAtPath"];
+  hasWorkspaceInFlightRun?: (workspaceId: string) => boolean;
 }) {
   const getConfig = vi.fn(() => ({
     autoArchiveAfterMerge: overrides?.autoArchiveAfterMerge ?? true,
@@ -94,6 +97,7 @@ function createHarness(overrides?: {
   const workspaceGitService = {
     getSnapshot,
   } as unknown as AutoArchiveArchiveOptions["workspaceGitService"];
+  const hasWorkspaceInFlightRun = vi.fn(overrides?.hasWorkspaceInFlightRun ?? (() => false));
   const options: AutoArchiveArchiveOptions = {
     paseoHome: PASEO_HOME,
     daemonConfigStore: {
@@ -101,7 +105,9 @@ function createHarness(overrides?: {
     } as unknown as AutoArchiveArchiveOptions["daemonConfigStore"],
     workspaceGitService,
     github: {} as AutoArchiveArchiveOptions["github"],
-    agentManager: {} as AutoArchiveArchiveOptions["agentManager"],
+    agentManager: {
+      hasWorkspaceInFlightRun,
+    } as unknown as AutoArchiveArchiveOptions["agentManager"],
     agentStorage: {} as AutoArchiveArchiveOptions["agentStorage"],
     terminalManager: {} as AutoArchiveArchiveOptions["terminalManager"],
     findWorkspaceIdForCwd: vi.fn(async () => "ws-auto-archive"),
@@ -148,6 +154,7 @@ function createHarness(overrides?: {
     deps,
     getConfig,
     getSnapshot,
+    hasWorkspaceInFlightRun,
     inFlight,
     log,
     options,
@@ -160,8 +167,8 @@ async function runArchiveIfSafe(
     cwd?: string;
     pullRequest?: WorkspaceGitRuntimeSnapshot["forge"]["pullRequest"];
   },
-): Promise<void> {
-  await archiveIfSafe({
+): Promise<ArchiveIfSafeOutcome> {
+  return await archiveIfSafe({
     cwd: overrides?.cwd ?? CWD,
     pullRequest:
       overrides && "pullRequest" in overrides
@@ -301,6 +308,7 @@ function createRealOutcomeHarness(input: {
     } as unknown as AutoArchiveArchiveOptions["workspaceGitService"],
     github: createGitHubServiceStub(),
     agentManager: {
+      hasWorkspaceInFlightRun: () => false,
       listAgents: () => [],
       archiveAgent: vi.fn(async () => ({ archivedAt: new Date().toISOString() })),
       archiveSnapshot: vi.fn(async () => {
@@ -375,28 +383,59 @@ describe("archiveIfSafe", () => {
     const harness = createHarness();
     harness.inFlight.add(CWD);
 
-    await runArchiveIfSafe(harness);
+    const outcome = await runArchiveIfSafe(harness);
 
     expect(harness.getSnapshot).not.toHaveBeenCalled();
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
     expect(harness.inFlight.has(CWD)).toBe(true);
+    // Distinct from "skipped": a collision with another in-flight check for
+    // this cwd is a transient concurrency artifact, not a verdict that the
+    // workspace is ineligible — callers must not stop watching it for this.
+    expect(outcome).toEqual({ status: "inconclusive" });
   });
 
-  test("logs and skips when reading the snapshot fails", async () => {
+  test("is inconclusive (not skipped) when reading the snapshot fails on the retry too", async () => {
     const harness = createHarness({
       getSnapshot: async () => {
         throw new Error("snapshot failed");
       },
     });
 
-    await runArchiveIfSafe(harness);
+    const outcome = await runArchiveIfSafe(harness);
 
     expect(harness.log.warn).toHaveBeenCalledWith(
       { err: expect.any(Error), cwd: CWD },
-      "Failed to read snapshot for auto-archive; skipping",
+      "Failed to read snapshot for auto-archive after a retry; will try again later",
     );
+    expect(harness.getSnapshot).toHaveBeenCalledTimes(2);
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
     expect(harness.inFlight.has(CWD)).toBe(false);
+    // Not "skipped": a repeated I/O failure is not a verdict about the
+    // workspace, so callers must keep this cwd on their retry list.
+    expect(outcome).toEqual({ status: "inconclusive" });
+  });
+
+  test("recovers from a single transient snapshot-read failure and archives", async () => {
+    let callCount = 0;
+    const harness = createHarness({
+      getSnapshot: async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          throw new Error("transient snapshot failure");
+        }
+        return createSnapshot();
+      },
+    });
+
+    const outcome = await runArchiveIfSafe(harness);
+
+    expect(harness.getSnapshot).toHaveBeenCalledTimes(2);
+    expect(outcome).toEqual({ status: "archived" });
+    expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
+    expect(harness.log.debug).toHaveBeenCalledWith(
+      { err: expect.any(Error), cwd: CWD },
+      "Failed to read snapshot for auto-archive; retrying once",
+    );
   });
 
   test("does nothing when there is no snapshot", async () => {
@@ -454,20 +493,140 @@ describe("archiveIfSafe", () => {
     expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
   });
 
-  test("logs and does not throw when archiving fails", async () => {
+  test("does nothing when the merged PR's head branch does not match this worktree's branch", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { currentBranch: "unrelated-branch" } }),
+    });
+
+    const outcome = await runArchiveIfSafe(harness, {
+      pullRequest: createPullRequest({ headRefName: "feature", isMerged: true }),
+    });
+
+    expect(harness.deps.isPaseoOwnedWorktreeCwd).not.toHaveBeenCalled();
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ status: "skipped" });
+  });
+
+  test("does nothing when the worktree has no resolvable current branch", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { currentBranch: null } }),
+    });
+
+    await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("archives when the merged PR's head branch matches this worktree's branch", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { currentBranch: "feature" } }),
+    });
+
+    const outcome = await runArchiveIfSafe(harness, {
+      pullRequest: createPullRequest({ headRefName: "feature", isMerged: true }),
+    });
+
+    expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ status: "archived" });
+  });
+
+  test("does not (yet) archive a forked-PR checkout using the owner/branch local-name convention", async () => {
+    // Known limitation: a worktree checked out from a fork PR can get a local
+    // branch named "<owner>/<headRef>" (see doesLocalBranchNameIdentifyTrackedHead
+    // in checkout-git.ts), but WorkspaceGitRuntimeSnapshot's pullRequest has no
+    // headRepositoryOwner to verify that prefix against — a suffix-only match
+    // would wrongly match an unrelated "otherowner/feature" branch too, so this
+    // case intentionally stays unmatched (safe direction: never over-archive).
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { currentBranch: "contributor/feature" } }),
+    });
+
+    const outcome = await runArchiveIfSafe(harness, {
+      pullRequest: createPullRequest({ headRefName: "feature", isMerged: true }),
+    });
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ status: "skipped" });
+  });
+
+  test("does not archive an unrelated sibling branch that merely shares a suffix with the head ref", async () => {
+    const harness = createHarness({
+      getSnapshot: async () => createSnapshot({ git: { currentBranch: "bob/feature" } }),
+    });
+
+    const outcome = await runArchiveIfSafe(harness, {
+      pullRequest: createPullRequest({ headRefName: "feature", isMerged: true }),
+    });
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ status: "skipped" });
+  });
+
+  test("defers instead of archiving when the workspace has an in-flight run", async () => {
+    const harness = createHarness({
+      hasWorkspaceInFlightRun: (workspaceId) => workspaceId === "ws-auto-archive",
+    });
+
+    const outcome = await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ status: "deferred", workspaceId: "ws-auto-archive" });
+    expect(harness.inFlight.has(CWD)).toBe(false);
+  });
+
+  test("uses the workspace-scoped liveness check, not a per-agent one — this must include internal agents", async () => {
+    const harness = createHarness({
+      hasWorkspaceInFlightRun: (workspaceId) => workspaceId === "ws-auto-archive",
+    });
+
+    await runArchiveIfSafe(harness);
+
+    // The workspace-scoped check (AgentManager.hasWorkspaceInFlightRun) walks every
+    // live agent including internal ones (e.g. branch-name/git-metadata generators).
+    // A per-agent-id check built on the internal-filtering listAgents() would miss
+    // those and archive out from under them (#2886).
+    expect(harness.hasWorkspaceInFlightRun).toHaveBeenCalledWith("ws-auto-archive");
+  });
+
+  test("ignores other workspaces when checking liveness", async () => {
+    const harness = createHarness({
+      hasWorkspaceInFlightRun: (workspaceId) => workspaceId === "ws-other-workspace",
+    });
+
+    const outcome = await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ status: "archived" });
+  });
+
+  test("archives once the workspace has no in-flight run", async () => {
+    const harness = createHarness({
+      hasWorkspaceInFlightRun: () => false,
+    });
+
+    const outcome = await runArchiveIfSafe(harness);
+
+    expect(harness.deps.archiveByScope).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ status: "archived" });
+  });
+
+  test("logs and does not throw when archiving fails, and stays inconclusive so it retries later", async () => {
     const harness = createHarness({
       archiveByScope: async () => {
         throw new Error("archive failed");
       },
     });
 
-    await runArchiveIfSafe(harness);
+    const outcome = await runArchiveIfSafe(harness);
 
     expect(harness.log.warn).toHaveBeenCalledWith(
       { err: expect.any(Error), cwd: CWD },
-      "Auto-archive after merge failed",
+      "Auto-archive after merge failed; will try again later",
     );
     expect(harness.inFlight.has(CWD)).toBe(false);
+    // A failed archive attempt (e.g. a transient filesystem error) is not a
+    // verdict that the workspace is ineligible — keep it on the retry list.
+    expect(outcome).toEqual({ status: "inconclusive" });
   });
 
   test("archives a clean Paseo-owned worktree after merge", async () => {

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -50,6 +50,22 @@ const defaultDependencies: ArchiveIfSafeDependencies = {
   killTerminalsForWorkspace,
 };
 
+export type ArchiveIfSafeOutcome =
+  | { status: "archived" }
+  | { status: "skipped" }
+  // why: "skipped" is a verdict about the workspace (not merged, disabled,
+  // dirty, branch mismatch, already handled, ...) — it means don't bother
+  // rechecking without a new git/forge event. "inconclusive" means the check
+  // itself failed for a transient reason (a concurrent in-flight collision, a
+  // snapshot read that failed even after retry, an archive attempt that
+  // threw) with no judgment reached at all — callers that track "worth
+  // rechecking" (e.g. the deferred-workspace poll in index.ts) must keep
+  // watching a cwd on "inconclusive" the same way they would on "deferred".
+  | { status: "inconclusive" }
+  | { status: "deferred"; workspaceId: string };
+
+const SKIPPED: ArchiveIfSafeOutcome = { status: "skipped" };
+
 export async function archiveIfSafe(input: {
   cwd: string;
   pullRequest: WorkspaceGitRuntimeSnapshot["forge"]["pullRequest"];
@@ -57,18 +73,18 @@ export async function archiveIfSafe(input: {
   options: AutoArchiveArchiveOptions;
   log: Logger;
   deps?: ArchiveIfSafeDependencies;
-}): Promise<void> {
+}): Promise<ArchiveIfSafeOutcome> {
   const { cwd, pullRequest, inFlight, options, log } = input;
   const deps = input.deps ?? defaultDependencies;
 
   if (!pullRequest?.isMerged) {
-    return;
+    return SKIPPED;
   }
   if (options.daemonConfigStore.get().autoArchiveAfterMerge !== true) {
-    return;
+    return SKIPPED;
   }
   if (inFlight.has(cwd)) {
-    return;
+    return { status: "inconclusive" };
   }
 
   inFlight.add(cwd);
@@ -78,19 +94,57 @@ export async function archiveIfSafe(input: {
       snapshot = await options.workspaceGitService.getSnapshot(cwd, {
         reason: "auto-archive-on-merge",
       });
-    } catch (error) {
-      log.warn({ err: error, cwd }, "Failed to read snapshot for auto-archive; skipping");
-      return;
+    } catch (firstError) {
+      // why: a workspace deferred for a live agent (#2886) is only re-checked
+      // when that agent later goes idle — a bare git-read hiccup right at that
+      // moment would otherwise leave it deferred forever, so retry once
+      // immediately before giving up.
+      log.debug(
+        { err: firstError, cwd },
+        "Failed to read snapshot for auto-archive; retrying once",
+      );
+      try {
+        snapshot = await options.workspaceGitService.getSnapshot(cwd, {
+          reason: "auto-archive-on-merge",
+        });
+      } catch (error) {
+        log.warn(
+          { err: error, cwd },
+          "Failed to read snapshot for auto-archive after a retry; will try again later",
+        );
+        return { status: "inconclusive" };
+      }
     }
     if (!snapshot) {
-      return;
+      return SKIPPED;
+    }
+
+    // why: a merged PR anywhere in the repo must not reap an unrelated worktree
+    // (#2886) — only the PR for this worktree's own head branch is eligible.
+    // Exact match only: a fork-PR checkout can name its local branch
+    // "<owner>/<headRef>" (see doesLocalBranchNameIdentifyTrackedHead in
+    // checkout-git.ts), but WorkspaceGitRuntimeSnapshot's pullRequest carries
+    // no headRepositoryOwner to verify that prefix against, and a suffix-only
+    // match ("bob/feature" matching a merged "alice/feature" PR) reopens the
+    // same false-positive-archive class this check exists to close. Known
+    // limitation: fork-PR checkouts using that convention won't auto-archive.
+    if (snapshot.git.currentBranch !== pullRequest.headRefName) {
+      log.info(
+        {
+          cwd,
+          currentBranch: snapshot.git.currentBranch,
+          pullRequestHeadRefName: pullRequest.headRefName,
+        },
+        "Skipping auto-archive: merged PR's head branch does not match this worktree",
+      );
+      return SKIPPED;
     }
 
     if (snapshot.git.isDirty === true) {
-      return;
+      return SKIPPED;
     }
     if (typeof snapshot.git.aheadOfOrigin === "number" && snapshot.git.aheadOfOrigin > 0) {
-      return;
+      return SKIPPED;
     }
 
     const ownership = await deps.isPaseoOwnedWorktreeCwd(cwd, {
@@ -98,7 +152,7 @@ export async function archiveIfSafe(input: {
       worktreesRoot: options.paseoWorktreesBaseRoot,
     });
     if (!ownership.allowed) {
-      return;
+      return SKIPPED;
     }
 
     try {
@@ -111,12 +165,24 @@ export async function archiveIfSafe(input: {
       );
       if (!workspaceId) {
         log.warn({ cwd }, "Auto-archive could not resolve a workspace for cwd; skipping");
-        return;
+        return SKIPPED;
       }
       const autoArchivedChangeRequestUrl =
         await options.getAutoArchivedChangeRequestUrl(workspaceId);
       if (autoArchivedChangeRequestUrl === pullRequest.url) {
-        return;
+        return SKIPPED;
+      }
+
+      // why: closing a running provider session mid-turn corrupts it (#2886) —
+      // defer archival until every attached agent in this workspace is idle.
+      // hasWorkspaceInFlightRun (not listAgents + hasInFlightRun) because
+      // listAgents() hides internal agents, which must still block archival.
+      if (options.agentManager.hasWorkspaceInFlightRun(workspaceId)) {
+        log.info(
+          { cwd, workspaceId },
+          "Deferring auto-archive after merge until attached agent is idle",
+        );
+        return { status: "deferred", workspaceId };
       }
 
       await deps.archiveByScope(
@@ -152,8 +218,10 @@ export async function archiveIfSafe(input: {
         },
       );
       log.info({ cwd }, "Auto-archived worktree after PR merge");
+      return { status: "archived" };
     } catch (error) {
-      log.warn({ err: error, cwd }, "Auto-archive after merge failed");
+      log.warn({ err: error, cwd }, "Auto-archive after merge failed; will try again later");
+      return { status: "inconclusive" };
     }
   } finally {
     inFlight.delete(cwd);

--- a/packages/server/src/server/auto-archive-on-merge/index.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/index.test.ts
@@ -149,6 +149,13 @@ async function waitForDeferral(harness: ReturnType<typeof createTestHarness>): P
   });
 }
 
+// Lets any fire-and-forget `void attemptArchive(...)`/`void recheckWatchedCwds()`
+// call already in flight settle before asserting "nothing happened" — those
+// calls have no observable signal of their own to wait on.
+async function settlePendingWork(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
 describe("setupAutoArchiveOnMerge", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -195,7 +202,7 @@ describe("setupAutoArchiveOnMerge", () => {
       agent: { id: "agent-1", workspaceId: WORKSPACE_ID } as never,
     });
 
-    await new Promise((resolve) => setImmediate(resolve));
+    await settlePendingWork();
     expect(getSnapshot).toHaveBeenCalledTimes(1);
     expect(harness.archiveByScope).not.toHaveBeenCalled();
   });
@@ -229,7 +236,7 @@ describe("setupAutoArchiveOnMerge", () => {
       await vi.waitFor(() => {
         expect(getSnapshot).toHaveBeenCalledTimes(2);
       });
-      await new Promise((resolve) => setImmediate(resolve));
+      await settlePendingWork();
     } finally {
       process.off("unhandledRejection", onUnhandledRejection);
     }

--- a/packages/server/src/server/auto-archive-on-merge/index.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/index.test.ts
@@ -1,0 +1,436 @@
+import type { Logger } from "pino";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  DEFERRED_POLL_INTERVAL_MS,
+  setupAutoArchiveOnMerge,
+  type AutoArchiveOnMergeOptions,
+} from "./index.js";
+import type { ArchiveIfSafeDependencies } from "./archive-if-safe.js";
+import type { WorkspaceGitRuntimeSnapshot } from "../workspace-git-service.js";
+import type { AgentSubscriber } from "../agent/agent-manager.js";
+
+const CWD = "/tmp/paseo/worktrees/repo/branch";
+const WORKSPACE_ID = "ws-auto-archive";
+
+function createPullRequest(
+  overrides?: Partial<NonNullable<WorkspaceGitRuntimeSnapshot["forge"]["pullRequest"]>>,
+): NonNullable<WorkspaceGitRuntimeSnapshot["forge"]["pullRequest"]> {
+  return {
+    url: "https://github.com/acme/repo/pull/123",
+    title: "Merge me",
+    state: "open",
+    baseRefName: "main",
+    headRefName: "feature",
+    isMerged: true,
+    ...overrides,
+  };
+}
+
+function createSnapshot(): WorkspaceGitRuntimeSnapshot {
+  return {
+    cwd: CWD,
+    git: {
+      isGit: true,
+      repoRoot: "/tmp/repo",
+      mainRepoRoot: "/tmp/repo",
+      currentBranch: "feature",
+      remoteUrl: "https://github.com/acme/repo.git",
+      isPaseoOwnedWorktree: true,
+      isDirty: false,
+      baseRef: "main",
+      aheadBehind: { ahead: 0, behind: 0 },
+      aheadOfOrigin: 0,
+      behindOfOrigin: 0,
+      hasRemote: true,
+      diffStat: { additions: 0, deletions: 0 },
+    },
+    forge: {
+      featuresEnabled: true,
+      pullRequest: createPullRequest(),
+      error: null,
+    },
+  };
+}
+
+function createLogger(): Logger {
+  const logger = {
+    child: () => logger,
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  };
+  return logger as unknown as Logger;
+}
+
+function createTestHarness(input: {
+  getSnapshot: ReturnType<typeof vi.fn>;
+  agentBusy: () => boolean;
+  autoArchiveAfterMerge?: () => boolean;
+}) {
+  let capturedSubscriber: AgentSubscriber | undefined;
+  let snapshotListener: ((snapshot: WorkspaceGitRuntimeSnapshot) => void) | undefined;
+  const unsubscribeGitSnapshot = vi.fn();
+  const unsubscribeAgentEvents = vi.fn();
+
+  const archiveByScope = vi.fn(async () => ({
+    archivedAgentIds: [],
+    archivedWorkspaceIds: [WORKSPACE_ID],
+    removedDirectory: false,
+  }));
+
+  const log = createLogger();
+
+  const options: AutoArchiveOnMergeOptions = {
+    logger: log,
+    paseoHome: "/tmp/paseo",
+    daemonConfigStore: {
+      get: () => ({ autoArchiveAfterMerge: (input.autoArchiveAfterMerge ?? (() => true))() }),
+    } as unknown as AutoArchiveOnMergeOptions["daemonConfigStore"],
+    workspaceGitService: {
+      getSnapshot: input.getSnapshot,
+      onSnapshotUpdated: (listener: (snapshot: WorkspaceGitRuntimeSnapshot) => void) => {
+        snapshotListener = listener;
+        return { unsubscribe: unsubscribeGitSnapshot };
+      },
+    } as unknown as AutoArchiveOnMergeOptions["workspaceGitService"],
+    github: {} as AutoArchiveOnMergeOptions["github"],
+    agentManager: {
+      hasInFlightRun: () => input.agentBusy(),
+      hasWorkspaceInFlightRun: (workspaceId: string) =>
+        workspaceId === WORKSPACE_ID && input.agentBusy(),
+      subscribe: (subscriber: AgentSubscriber) => {
+        capturedSubscriber = subscriber;
+        return unsubscribeAgentEvents;
+      },
+    } as unknown as AutoArchiveOnMergeOptions["agentManager"],
+    agentStorage: {} as AutoArchiveOnMergeOptions["agentStorage"],
+    terminalManager: {} as AutoArchiveOnMergeOptions["terminalManager"],
+    findWorkspaceIdForCwd: vi.fn(async () => WORKSPACE_ID),
+    listActiveWorkspaces: vi.fn(async () => []),
+    getAutoArchivedChangeRequestUrl: vi.fn(async () => null),
+    archiveWorkspaceRecord: vi.fn(async () => {}),
+    markWorkspaceArchiving: vi.fn(),
+    clearWorkspaceArchiving: vi.fn(),
+    emitWorkspaceUpdatesForWorkspaceIds: vi.fn(async () => {}),
+  };
+
+  const deps: ArchiveIfSafeDependencies = {
+    archiveByScope,
+    resolveWorkspaceIdAtPath: vi.fn(async () => WORKSPACE_ID),
+    isPaseoOwnedWorktreeCwd: vi.fn(async () => ({
+      allowed: true,
+      repoRoot: "/tmp/repo",
+      worktreeRoot: "/tmp/paseo/worktrees/repo",
+      worktreePath: CWD,
+    })),
+    killTerminalsForWorkspace: vi.fn(),
+  } as unknown as ArchiveIfSafeDependencies;
+
+  const subscription = setupAutoArchiveOnMerge({ options, deps });
+
+  return {
+    archiveByScope,
+    log,
+    subscription,
+    unsubscribeGitSnapshot,
+    unsubscribeAgentEvents,
+    getSnapshotListener: () => snapshotListener,
+    getSubscriber: () => capturedSubscriber,
+  };
+}
+
+async function waitForDeferral(harness: ReturnType<typeof createTestHarness>): Promise<void> {
+  await vi.waitFor(() => {
+    expect(harness.log.info).toHaveBeenCalledWith(
+      expect.anything(),
+      "Deferring auto-archive after merge until attached agent is idle",
+    );
+  });
+}
+
+describe("setupAutoArchiveOnMerge", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("retries and archives once the deferring agent goes idle", async () => {
+    let agentBusy = true;
+    const getSnapshot = vi.fn(async () => createSnapshot());
+    const harness = createTestHarness({ getSnapshot, agentBusy: () => agentBusy });
+
+    expect(harness.getSnapshotListener()).toBeDefined();
+    expect(harness.getSubscriber()).toBeDefined();
+
+    // Merge event fires while the agent is still busy: must defer, not archive.
+    harness.getSnapshotListener()?.(createSnapshot());
+    await waitForDeferral(harness);
+    expect(harness.archiveByScope).not.toHaveBeenCalled();
+
+    // Agent goes idle: the manager's agent_state event must trigger a recheck
+    // that re-evaluates and now succeeds.
+    agentBusy = false;
+    harness.getSubscriber()?.({
+      type: "agent_state",
+      agent: { id: "agent-1", workspaceId: WORKSPACE_ID } as never,
+    });
+
+    await vi.waitFor(() => {
+      expect(harness.archiveByScope).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("ignores agent_state events while the agent is still busy", async () => {
+    const getSnapshot = vi.fn(async () => createSnapshot());
+    const harness = createTestHarness({ getSnapshot, agentBusy: () => true });
+
+    harness.getSnapshotListener()?.(createSnapshot());
+    await waitForDeferral(harness);
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+
+    // A busy-state update (e.g. token usage) fires agent_state without the
+    // agent going idle: must not trigger the expensive recheck.
+    harness.getSubscriber()?.({
+      type: "agent_state",
+      agent: { id: "agent-1", workspaceId: WORKSPACE_ID } as never,
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.archiveByScope).not.toHaveBeenCalled();
+  });
+
+  test("does not crash the daemon when the recheck's own snapshot read fails", async () => {
+    let agentBusy = true;
+    const getSnapshot = vi.fn(async () => {
+      if (getSnapshot.mock.calls.length === 1) {
+        return createSnapshot();
+      }
+      throw new Error("git read failed");
+    });
+    const harness = createTestHarness({ getSnapshot, agentBusy: () => agentBusy });
+
+    harness.getSnapshotListener()?.(createSnapshot());
+    await waitForDeferral(harness);
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
+
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      // Agent goes idle: the recheck's own snapshot read throws. This must
+      // not surface as an unhandled rejection, and must not crash — the
+      // periodic poll (or a later agent_state event) will retry it.
+      agentBusy = false;
+      harness.getSubscriber()?.({
+        type: "agent_state",
+        agent: { id: "agent-1", workspaceId: WORKSPACE_ID } as never,
+      });
+      await vi.waitFor(() => {
+        expect(getSnapshot).toHaveBeenCalledTimes(2);
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+
+    expect(unhandledRejections).toEqual([]);
+    expect(harness.archiveByScope).not.toHaveBeenCalled();
+    expect(harness.log.debug).toHaveBeenCalledWith(
+      { err: expect.any(Error), cwd: CWD },
+      "Failed to read snapshot while rechecking a deferred auto-archive; will retry",
+    );
+  });
+
+  test("recovers from a single transient snapshot-read failure inside archiveIfSafe's own fetch", async () => {
+    let agentBusy = true;
+    let callCount = 0;
+    const getSnapshot = vi.fn(async () => {
+      callCount += 1;
+      // Call 1: initial defer. Call 2: recheck's own fetch (succeeds, feeds
+      // attemptArchive). Call 3: archiveIfSafe's own internal fetch fails
+      // transiently. Call 4: archiveIfSafe's immediate re-retry succeeds.
+      if (callCount === 3) {
+        throw new Error("transient git read failure");
+      }
+      return createSnapshot();
+    });
+    const harness = createTestHarness({ getSnapshot, agentBusy: () => agentBusy });
+
+    harness.getSnapshotListener()?.(createSnapshot());
+    await waitForDeferral(harness);
+
+    agentBusy = false;
+    harness.getSubscriber()?.({
+      type: "agent_state",
+      agent: { id: "agent-1", workspaceId: WORKSPACE_ID } as never,
+    });
+
+    await vi.waitFor(() => {
+      expect(harness.archiveByScope).toHaveBeenCalledTimes(1);
+    });
+    expect(getSnapshot).toHaveBeenCalledTimes(4);
+  });
+
+  test("keeps watching (does not abandon) a workspace whose archiveIfSafe check was inconclusive", async () => {
+    // If archiveIfSafe's own snapshot fetch fails on both the first attempt
+    // and its immediate retry, that's not a verdict about the workspace
+    // (#2886) — the workspace must stay watched so a later poll tick still
+    // retries it, instead of being silently abandoned forever.
+    vi.useFakeTimers();
+    let agentBusy = true;
+    let callCount = 0;
+    const getSnapshot = vi.fn(async () => {
+      callCount += 1;
+      // Call 1: initial defer. Call 2: recheck's own fetch (feeds
+      // attemptArchive). Calls 3-4: archiveIfSafe's own fetch and its
+      // immediate retry both fail — "inconclusive". Call 5+ (next poll
+      // tick): everything succeeds.
+      if (callCount === 3 || callCount === 4) {
+        throw new Error("transient git read failure");
+      }
+      return createSnapshot();
+    });
+    const harness = createTestHarness({ getSnapshot, agentBusy: () => agentBusy });
+
+    harness.getSnapshotListener()?.(createSnapshot());
+    await vi.waitFor(
+      () => {
+        expect(harness.log.info).toHaveBeenCalledWith(
+          expect.anything(),
+          "Deferring auto-archive after merge until attached agent is idle",
+        );
+      },
+      { timeout: 1000 },
+    );
+
+    agentBusy = false;
+    harness.getSubscriber()?.({
+      type: "agent_state",
+      agent: { id: "agent-1", workspaceId: WORKSPACE_ID } as never,
+    });
+    await vi.waitFor(
+      () => {
+        expect(getSnapshot.mock.calls.length).toBeGreaterThanOrEqual(4);
+      },
+      { timeout: 1000 },
+    );
+    expect(harness.archiveByScope).not.toHaveBeenCalled();
+
+    // The next poll tick must still retry this cwd instead of having
+    // abandoned it.
+    await vi.advanceTimersByTimeAsync(DEFERRED_POLL_INTERVAL_MS);
+    expect(harness.archiveByScope).toHaveBeenCalledTimes(1);
+  });
+
+  test("the periodic poll archives a deferred workspace even when no agent_state event ever fires for it", async () => {
+    // Mirrors a workspace deferred solely because of an internal agent
+    // (branch-name/git-metadata generator): AgentManager.dispatch() hides
+    // internal agents' agent_state events from global subscribers, so the
+    // fast path in this module never fires for them (#2886). The periodic
+    // poll must still catch and archive the workspace once it's idle.
+    vi.useFakeTimers();
+    let agentBusy = true;
+    const getSnapshot = vi.fn(async () => createSnapshot());
+    const harness = createTestHarness({ getSnapshot, agentBusy: () => agentBusy });
+
+    harness.getSnapshotListener()?.(createSnapshot());
+    await vi.waitFor(
+      () => {
+        expect(harness.log.info).toHaveBeenCalledWith(
+          expect.anything(),
+          "Deferring auto-archive after merge until attached agent is idle",
+        );
+      },
+      { timeout: 1000 },
+    );
+    expect(harness.archiveByScope).not.toHaveBeenCalled();
+
+    // The internal agent goes idle, but — unlike every other test in this
+    // file — no agent_state event is ever delivered for it. Only the timer
+    // can unstick this workspace now.
+    agentBusy = false;
+
+    await vi.advanceTimersByTimeAsync(DEFERRED_POLL_INTERVAL_MS);
+
+    expect(harness.archiveByScope).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops polling a workspace once it becomes permanently ineligible instead of polling it forever", async () => {
+    vi.useFakeTimers();
+    let agentBusy = true;
+    let autoArchiveAfterMerge = true;
+    const getSnapshot = vi.fn(async () => createSnapshot());
+    const harness = createTestHarness({
+      getSnapshot,
+      agentBusy: () => agentBusy,
+      autoArchiveAfterMerge: () => autoArchiveAfterMerge,
+    });
+
+    harness.getSnapshotListener()?.(createSnapshot());
+    await vi.waitFor(
+      () => {
+        expect(harness.log.info).toHaveBeenCalledWith(
+          expect.anything(),
+          "Deferring auto-archive after merge until attached agent is idle",
+        );
+      },
+      { timeout: 1000 },
+    );
+    const callsAtDefer = getSnapshot.mock.calls.length;
+
+    // The feature gets disabled entirely before the agent goes idle. The
+    // recheck now permanently skips (not a transient collision), so this
+    // workspace must stop being watched — otherwise it polls forever.
+    autoArchiveAfterMerge = false;
+    agentBusy = false;
+    harness.getSubscriber()?.({
+      type: "agent_state",
+      agent: { id: "agent-1", workspaceId: WORKSPACE_ID } as never,
+    });
+    await vi.waitFor(
+      () => {
+        expect(getSnapshot.mock.calls.length).toBeGreaterThan(callsAtDefer);
+      },
+      { timeout: 1000 },
+    );
+    const callsAfterPermanentSkip = getSnapshot.mock.calls.length;
+    expect(harness.archiveByScope).not.toHaveBeenCalled();
+
+    // A later poll tick must not touch this cwd again.
+    await vi.advanceTimersByTimeAsync(DEFERRED_POLL_INTERVAL_MS);
+    expect(getSnapshot.mock.calls.length).toBe(callsAfterPermanentSkip);
+  });
+
+  test("unsubscribe() tears down the poll timer and both underlying subscriptions", async () => {
+    // The daemon must be able to fully stop this feature (e.g. on shutdown,
+    // or in a test harness that starts/stops multiple daemon instances in
+    // one process) — a leaked poll timer would keep firing forever.
+    vi.useFakeTimers();
+    let agentBusy = true;
+    const getSnapshot = vi.fn(async () => createSnapshot());
+    const harness = createTestHarness({ getSnapshot, agentBusy: () => agentBusy });
+
+    harness.getSnapshotListener()?.(createSnapshot());
+    await vi.waitFor(
+      () => {
+        expect(harness.log.info).toHaveBeenCalledWith(
+          expect.anything(),
+          "Deferring auto-archive after merge until attached agent is idle",
+        );
+      },
+      { timeout: 1000 },
+    );
+    const callsBeforeUnsubscribe = getSnapshot.mock.calls.length;
+
+    harness.subscription.unsubscribe();
+
+    expect(harness.unsubscribeGitSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.unsubscribeAgentEvents).toHaveBeenCalledTimes(1);
+
+    // The poll timer must be cleared too: advancing past an interval must
+    // not touch the still-deferred (but now orphaned) workspace.
+    await vi.advanceTimersByTimeAsync(DEFERRED_POLL_INTERVAL_MS * 2);
+    expect(getSnapshot.mock.calls.length).toBe(callsBeforeUnsubscribe);
+  });
+});

--- a/packages/server/src/server/auto-archive-on-merge/index.ts
+++ b/packages/server/src/server/auto-archive-on-merge/index.ts
@@ -1,25 +1,116 @@
 import type { Logger } from "pino";
 
-import { archiveIfSafe, type AutoArchiveArchiveOptions } from "./archive-if-safe.js";
-import type { WorkspaceGitSubscription } from "../workspace-git-service.js";
+import {
+  archiveIfSafe,
+  type ArchiveIfSafeDependencies,
+  type AutoArchiveArchiveOptions,
+} from "./archive-if-safe.js";
+import type {
+  WorkspaceGitRuntimeSnapshot,
+  WorkspaceGitSubscription,
+} from "../workspace-git-service.js";
 
 export interface AutoArchiveOnMergeOptions extends AutoArchiveArchiveOptions {
   logger: Logger;
 }
 
-export function setupAutoArchiveOnMerge(
-  options: AutoArchiveOnMergeOptions,
-): WorkspaceGitSubscription {
+// why: the poll is the correctness backstop (see setupAutoArchiveOnMerge), not
+// the primary path, so this only bounds how late a stuck-internal-agent
+// workspace gets swept — 30s is frequent enough not to matter in practice.
+export const DEFERRED_POLL_INTERVAL_MS = 30_000;
+
+export function setupAutoArchiveOnMerge({
+  options,
+  deps,
+}: {
+  options: AutoArchiveOnMergeOptions;
+  deps?: ArchiveIfSafeDependencies;
+}): WorkspaceGitSubscription {
   const log = options.logger.child({ module: "auto-archive-on-merge" });
   const inFlight = new Set<string>();
+  // why: a workspace deferred for a live agent (#2886) needs to be re-checked
+  // once every attached agent goes idle. AgentManager.dispatch() hides
+  // internal agents' (e.g. branch-name/git-metadata generators) agent_state
+  // events from global subscribers like the one below, so an internal-agent
+  // -only defer would never get retried by events alone — poll every watched
+  // cwd periodically as the correctness backstop; the event subscription
+  // below is just a fast path that reacts sooner in the common case.
+  const watchedCwds = new Set<string>();
 
-  return options.workspaceGitService.onSnapshotUpdated((snapshot) => {
-    void archiveIfSafe({
-      cwd: snapshot.cwd,
-      pullRequest: snapshot.forge.pullRequest,
-      inFlight,
-      options,
-      log,
-    });
+  async function attemptArchive(input: {
+    cwd: string;
+    pullRequest: WorkspaceGitRuntimeSnapshot["forge"]["pullRequest"];
+  }): Promise<void> {
+    const { cwd, pullRequest } = input;
+    const outcome = await archiveIfSafe({ cwd, pullRequest, inFlight, options, log, deps });
+    if (outcome.status === "deferred" || outcome.status === "inconclusive") {
+      // "inconclusive" (an in-flight collision, a snapshot read that failed
+      // even after retry, or an archive attempt that threw) means no verdict
+      // was reached at all — keep watching so the poll or next idle event
+      // tries again, exactly like "deferred".
+      watchedCwds.add(cwd);
+    } else {
+      // Every other outcome ("archived" or a genuine "skipped" — not merged,
+      // disabled, dirty, branch mismatch, etc.) means this cwd will never
+      // become archivable by polling alone, so stop watching it: further
+      // eligibility can only come from a fresh onSnapshotUpdated event.
+      watchedCwds.delete(cwd);
+    }
+  }
+
+  async function recheckWatchedCwds(): Promise<void> {
+    for (const cwd of watchedCwds) {
+      let snapshot: WorkspaceGitRuntimeSnapshot | null;
+      try {
+        snapshot = await options.workspaceGitService.getSnapshot(cwd, {
+          reason: "auto-archive-on-merge-recheck",
+        });
+      } catch (error) {
+        log.debug(
+          { err: error, cwd },
+          "Failed to read snapshot while rechecking a deferred auto-archive; will retry",
+        );
+        continue;
+      }
+      if (!snapshot) {
+        watchedCwds.delete(cwd);
+        continue;
+      }
+      void attemptArchive({ cwd, pullRequest: snapshot.forge.pullRequest });
+    }
+  }
+
+  const gitSubscription = options.workspaceGitService.onSnapshotUpdated((snapshot) => {
+    void attemptArchive({ cwd: snapshot.cwd, pullRequest: snapshot.forge.pullRequest });
   });
+
+  const pollTimer = setInterval(() => {
+    void recheckWatchedCwds();
+  }, DEFERRED_POLL_INTERVAL_MS);
+  pollTimer.unref?.();
+
+  const unsubscribeAgentEvents = options.agentManager.subscribe(
+    (event) => {
+      if (event.type !== "agent_state" || !event.agent.workspaceId) {
+        return;
+      }
+      // why: agent_state fires on every busy-state update (token usage, mode
+      // changes, etc.) during a turn, not just idle transitions — only a
+      // transition to idle can unblock a deferred archive, so skip the
+      // expensive re-check (which shells out to git) while still busy.
+      if (options.agentManager.hasInFlightRun(event.agent.id)) {
+        return;
+      }
+      void recheckWatchedCwds();
+    },
+    { replayState: false },
+  );
+
+  return {
+    unsubscribe: () => {
+      clearInterval(pollTimer);
+      gitSubscription.unsubscribe();
+      unsubscribeAgentEvents();
+    },
+  };
 }

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -987,24 +987,26 @@ export async function createPaseoDaemon(
     logger,
   });
 
-  setupAutoArchiveOnMerge({
-    paseoHome: config.paseoHome,
-    paseoWorktreesBaseRoot: config.worktreesRoot,
-    daemonConfigStore,
-    workspaceGitService,
-    github,
-    agentManager,
-    agentStorage,
-    terminalManager,
-    logger,
-    findWorkspaceIdForCwd: findWorkspaceIdForCwdExternal,
-    listActiveWorkspaces: listActiveWorkspacesExternal,
-    getAutoArchivedChangeRequestUrl: async (workspaceId) =>
-      (await workspaceRegistry.get(workspaceId))?.autoArchivedChangeRequestUrl ?? null,
-    archiveWorkspaceRecord: archiveWorkspaceRecordExternal,
-    markWorkspaceArchiving: markWorkspaceArchivingExternal,
-    clearWorkspaceArchiving: clearWorkspaceArchivingExternal,
-    emitWorkspaceUpdatesForWorkspaceIds: emitWorkspaceUpdatesExternal,
+  const autoArchiveOnMergeSubscription = setupAutoArchiveOnMerge({
+    options: {
+      paseoHome: config.paseoHome,
+      paseoWorktreesBaseRoot: config.worktreesRoot,
+      daemonConfigStore,
+      workspaceGitService,
+      github,
+      agentManager,
+      agentStorage,
+      terminalManager,
+      logger,
+      findWorkspaceIdForCwd: findWorkspaceIdForCwdExternal,
+      listActiveWorkspaces: listActiveWorkspacesExternal,
+      getAutoArchivedChangeRequestUrl: async (workspaceId) =>
+        (await workspaceRegistry.get(workspaceId))?.autoArchivedChangeRequestUrl ?? null,
+      archiveWorkspaceRecord: archiveWorkspaceRecordExternal,
+      markWorkspaceArchiving: markWorkspaceArchivingExternal,
+      clearWorkspaceArchiving: clearWorkspaceArchivingExternal,
+      emitWorkspaceUpdatesForWorkspaceIds: emitWorkspaceUpdatesExternal,
+    },
   });
 
   const createPaseoWorktreeForTools = async (
@@ -1615,6 +1617,7 @@ export async function createPaseoDaemon(
   const stop = async () => {
     await hubRelationships.stop();
     workspaceReconciliation.dispose();
+    autoArchiveOnMergeSubscription.unsubscribe();
     scriptHealthMonitor.stop();
     // Freeze both ingress and registration before taking the agent closure snapshot.
     wsServer?.prepareForShutdown();


### PR DESCRIPTION
## Summary

Fixes #2886 — three related liveness/matching defects in `autoArchiveAfterMerge`, the last found by review on this PR.

**1. Wrong matching.** A worktree was archived whenever *any* PR merged in the repo, not its own PR. Root cause: `snapshot.git` (synchronous git refresh) and `snapshot.forge` (an independently-scheduled async PR poll) in `workspace-git-service.ts` are merged non-atomically in `combineSnapshot` (`:3018-3028`), and a branch/poll-target change reschedules the forge poll asynchronously (`:2421-2428`) rather than invalidating the cached PR synchronously — so `getSnapshot`'s cached path (`:681-691`) could return a merged-PR object left over from a different branch context. `archiveIfSafe` now requires an exact match between `snapshot.git.currentBranch` and `pullRequest.headRefName` before archiving.

**2. No liveness check.** Archival proceeded while an agent session was attached and running, force-closing the provider mid-turn (`AgentManager.closeAgentRuntime` → `session.close()`). Added `AgentManager.hasWorkspaceInFlightRun(workspaceId)`, which — unlike `listAgents()` — also sees internal agents (branch-name/git-metadata generators). Archival now defers instead of proceeding while any agent in the workspace is busy, with a retry mechanism: a fast `agent_state` path for the common case, plus a 30s poll backstop, because `AgentManager.dispatch()` filters internal-agent `agent_state` events from global subscribers — confirmed the poll is load-bearing, not redundant, since the event-only path would silently never retry the exact internal-agent case the liveness check exists to catch.

**3. Provider-native subagents bypassed the liveness gate** (found by [Greptile review](https://github.com/getpaseo/paseo/pull/3348#discussion_r3781234285) on this PR, confirmed against the code and fixed). A parent agent goes idle when its own turn is idle even while a provider-native child (e.g. a Task tool subagent) is still running. `hasWorkspaceInFlightRun` now also checks `AgentManager`'s provider-subagent store for any child with `status === "running"`, not just managed-agent runs.

Also distinguishes a transient `"inconclusive"` outcome (retry, keep watching) from a genuine `"skipped"` verdict (stop watching), so a momentary I/O failure can't cause a deferred workspace to be silently abandoned, and wires the new subscription into daemon shutdown to avoid leaking the poll timer.

## Known, documented limitation (not fixed, safe direction)

Fork-PR checkouts using the `<owner>/<branch>` local-branch-name convention (see `doesLocalBranchNameIdentifyTrackedHead` in `checkout-git.ts`) won't auto-archive, since `WorkspaceGitRuntimeSnapshot`'s `pullRequest` carries no `headRepositoryOwner` to safely verify that prefix. An earlier version of this fix loosened the branch match to a suffix check to cover this case, but review found it reopens a false-positive-archive vector (an unrelated sibling branch sharing a suffix, e.g. `bob/feature` matching a merged `alice/feature` PR) — reverted to exact match. Never over-archives; the cost is these workspaces stay un-archived until manually cleaned up.

## Pre-existing, out-of-scope gap found during investigation

`workspace-archive-service.ts`'s `archiveWorkspaceContents` also enumerates agents via the internal-agent-hiding `agentManager.listAgents()` when tearing down a workspace's agents. Once the liveness gate here correctly clears, the actual teardown step still won't explicitly close an internal agent's session record, even though the worktree directory gets removed. This file is untouched by this PR — it's pre-existing and affects every archive path app-wide (manual archive, schedule-triggered archive, MCP `archive_workspace`), not just `autoArchiveAfterMerge`. Flagging as a follow-up, out of scope here.

Closes #2886

## Test plan

- [x] Root-cause and reproduce defect 1 via regression tests (repo-level match instead of branch-level match) — confirmed the staleness mechanism against `workspace-git-service.ts`, not a live end-to-end GitHub repro
- [x] Root-cause and reproduce defect 2 via regression tests (archive while agent session is live) — confirmed against the reporter's stack trace and `AgentManager`'s close path
- [x] Root-cause and reproduce defect 3 via regression tests (provider-native subagent bypasses liveness) — found by review, confirmed against `AgentManager.dispatch()`/`ProviderSubagentStore`
- [x] Add automated tests covering all three, each verified RED (fails on old code) → GREEN (passes on fixed code)
- [x] QA evidence per docs/qa.md — see [PR comment](https://github.com/getpaseo/paseo/pull/3348#issuecomment-5289655533)