### PR TITLE
fix(server): parallelize Codex subagent history reads

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -3578,6 +3578,69 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("loads independent persisted sub-agent histories with bounded concurrency", async () => {
+    const session = createSession();
+    const childThreadIds = Array.from({ length: 10 }, (_, index) => `child-thread-${index}`);
+    const childStartedItems = childThreadIds.map((childThreadId, index) => ({
+      type: "subAgentActivity",
+      id: `child-started-${index}`,
+      kind: "started",
+      agentThreadId: childThreadId,
+      agentPath: `/root/child-${index}`,
+    }));
+    const requestedChildThreadIds = new Set<string>();
+    let activeChildReads = 0;
+    let peakChildReads = 0;
+    let releaseChildReads = () => {};
+    const childReadGate = new Promise<void>((resolve) => {
+      releaseChildReads = resolve;
+    });
+    session.client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method !== "thread/read") {
+          return {};
+        }
+        const threadId = (params as { threadId?: string }).threadId;
+        if (threadId === "test-thread") {
+          return {
+            thread: {
+              turns: [
+                {
+                  items: childStartedItems,
+                },
+              ],
+            },
+          };
+        }
+
+        if (threadId) {
+          requestedChildThreadIds.add(threadId);
+        }
+        activeChildReads += 1;
+        peakChildReads = Math.max(peakChildReads, activeChildReads);
+        try {
+          await childReadGate;
+          return { thread: { turns: [] } };
+        } finally {
+          activeChildReads -= 1;
+        }
+      }),
+    };
+
+    const historyLoad = asInternals(session).loadPersistedHistory();
+    try {
+      await vi.waitFor(() => {
+        expect(peakChildReads).toBe(8);
+      });
+    } finally {
+      releaseChildReads();
+      await historyLoad;
+    }
+
+    expect(requestedChildThreadIds).toEqual(new Set(childThreadIds));
+    expect(activeChildReads).toBe(0);
+  });
+
   test("coalesces persisted MultiAgentV2 activity for one child into one terminal card", async () => {
     const session = createSession();
     session.client = {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -134,6 +134,7 @@ function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolea
 
 const TURN_START_TIMEOUT_MS = 90 * 1000;
 const INTERRUPT_TIMEOUT_MS = 2_000;
+const PERSISTED_SUBAGENT_HISTORY_CONCURRENCY = 8;
 const CODEX_PROVIDER = "codex" as const;
 // Codex treats most app-server client names as the model-request originator.
 // This reserved Codex name is non-originating, so requests keep Codex's default
@@ -3715,33 +3716,55 @@ export class CodexAppServerAgentSession implements AgentSession {
     const queue = rootRoutes.map((route) => ({ route, parentCallId: null as string | null }));
     const visitedThreadIds = new Set(this.currentThreadId ? [this.currentThreadId] : []);
     while (queue.length > 0 && visitedThreadIds.size < 100) {
-      const next = queue.shift();
-      if (!next || visitedThreadIds.has(next.route.childThreadId)) {
-        continue;
-      }
-      visitedThreadIds.add(next.route.childThreadId);
-      this.registerSubAgentToolCall({
-        timelineItem: next.route.toolCall,
-        rawItem: { agentThreadId: next.route.childThreadId },
-        parentCallId: next.parentCallId,
-      });
-      try {
-        const childHistory = await loadCodexThreadHistoryTimeline({
-          threadId: next.route.childThreadId,
-          cwd: this.config.cwd ?? null,
-          requestThread: (childThreadId) => readCodexThread(client, childThreadId),
+      const batch: Array<{ route: PersistedSubAgentRoute; parentCallId: string | null }> = [];
+      while (
+        batch.length < PERSISTED_SUBAGENT_HISTORY_CONCURRENCY &&
+        queue.length > 0 &&
+        visitedThreadIds.size < 100
+      ) {
+        const next = queue.shift();
+        if (!next || visitedThreadIds.has(next.route.childThreadId)) {
+          continue;
+        }
+        visitedThreadIds.add(next.route.childThreadId);
+        this.registerSubAgentToolCall({
+          timelineItem: next.route.toolCall,
+          rawItem: { agentThreadId: next.route.childThreadId },
+          parentCallId: next.parentCallId,
         });
-        for (const entry of childHistory.timeline) {
-          this.emitProviderSubagentTimeline(next.route.childThreadId, entry.item, entry.timestamp);
-        }
-        for (const route of childHistory.subAgentRoutes) {
-          queue.push({ route, parentCallId: next.route.toolCall.callId });
-        }
-      } catch (error) {
-        this.logger.trace(
-          { err: error, childThreadId: next.route.childThreadId },
-          "Failed to load persisted Codex child history",
-        );
+        batch.push(next);
+      }
+
+      const nestedRoutes = await Promise.all(
+        batch.map(async (next) => {
+          try {
+            const childHistory = await loadCodexThreadHistoryTimeline({
+              threadId: next.route.childThreadId,
+              cwd: this.config.cwd ?? null,
+              requestThread: (childThreadId) => readCodexThread(client, childThreadId),
+            });
+            for (const entry of childHistory.timeline) {
+              this.emitProviderSubagentTimeline(
+                next.route.childThreadId,
+                entry.item,
+                entry.timestamp,
+              );
+            }
+            return childHistory.subAgentRoutes.map((route) => ({
+              route,
+              parentCallId: next.route.toolCall.callId,
+            }));
+          } catch (error) {
+            this.logger.trace(
+              { err: error, childThreadId: next.route.childThreadId },
+              "Failed to load persisted Codex child history",
+            );
+            return [];
+          }
+        }),
+      );
+      for (const routes of nestedRoutes) {
+        queue.push(...routes);
       }
     }
   }


### PR DESCRIPTION
### Linked issue

Closes #3355

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Archived Codex agents restore persisted sub-agent histories before activity is returned. Those child `thread/read` requests were awaited one at a time, so agents with many children paid the sum of every child read latency and could leave `get_agent_activity` waiting for tens of seconds even with a small limit.

This change reads independent child histories in bounded batches of eight. It keeps the existing traversal and complete timeline semantics while removing the serial latency multiplier for users reopening or querying larger archived agent trees.

### Goals

- Start independent persisted Codex child-history reads concurrently.
- Bound provider fan-out at eight reads at a time.
- Preserve the existing 100-thread cap, deduplication, nested route traversal, tool-call registration, and per-child error isolation.
- Add a deterministic regression test that proves the concurrency bound and verifies every child is still loaded.

### Non-goals

- Apply the activity `limit` before provider hydration or redesign the history-read API; #2388 covers that broader architecture.
- Change the restored timeline contents or ordering guarantees.
- Remove the existing 100-thread safety cap or use unbounded concurrency.
- Address the broader timeline-size work tracked in #2300.

### QA

Before the change, querying the same archived Codex parent in a current Paseo session did not return within 60 seconds with `limit: 100`, or within 30 seconds with `limit: 20`; smaller archived agents returned in roughly 0.7–3.9 seconds. Code inspection on current `main` (`770b87a15`) confirmed child history reads were serialized.

Added `loads independent persisted sub-agent histories with bounded concurrency`, which gates ten child reads and observes the number in flight:

- Negative control with the concurrency constant set to `1`: failed with `expected 8, received 1`.
- Final implementation with a bound of `8`: passed and verified all ten child thread IDs were read and no reads remained active.

Commands run:

- `npx vitest run packages/server/src/server/agent/providers/codex-app-server-agent.test.ts --bail=1` — 129 tests passed.
- `npm run build --workspace @getpaseo/server` — passed.
- `npm run typecheck` — passed for all workspaces after building the local server package.
- `npm run lint` — 0 warnings, 0 errors.
- `npm run format` — passed.
- `npm run format:check:files -- packages/server/src/server/agent/providers/codex-app-server-agent.test.ts packages/server/src/server/agent/providers/codex-app-server-agent.ts` — passed.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense