### PR TITLE
Keep archived OpenCode history sessions inert

### DIFF
--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -321,6 +321,83 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
+  test("loads archived history without attaching to or aborting the live OpenCode session", async () => {
+    const cwd = tmpCwd();
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(logger, undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+
+    const session = await client.resumeSession(
+      {
+        provider: "opencode",
+        sessionId: "session-1",
+        metadata: { cwd },
+      },
+      undefined,
+      undefined,
+      { purpose: "history" },
+    );
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    openCode.emitEvent({
+      type: "session.status",
+      properties: { sessionID: "session-1", status: { type: "busy" } },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toEqual([]);
+    expect(openCode.calls.globalEvent).toEqual([]);
+
+    for await (const _event of session.streamHistory()) {
+      // The empty test history is sufficient to prove the read path is usable.
+    }
+    expect(openCode.calls.sessionMessages).toEqual([{ sessionID: "session-1", directory: cwd }]);
+
+    await session.close();
+    expect(openCode.calls.sessionAbort).toEqual([]);
+    expect(runtime.acquisitions).toEqual([{ kind: "current", releaseCount: 1 }]);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  test("promotes a history-only OpenCode session when a new turn is explicitly started", async () => {
+    const cwd = tmpCwd();
+    const runtime = new TestOpenCodeHarness();
+    const openCode = new TestOpenCodeClient();
+    openCode.sessionPromptAsyncEvents = assistantTurnEvents();
+    runtime.enqueueClient(openCode);
+    const client = new OpenCodeAgentClient(logger, undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+
+    const session = await client.resumeSession(
+      {
+        provider: "opencode",
+        sessionId: "session-1",
+        metadata: { cwd },
+      },
+      undefined,
+      undefined,
+      { purpose: "history" },
+    );
+
+    const turn = await collectTurnEvents(streamSession(session, "Resume deliberately"));
+
+    expect(turn.turnCompleted).toBe(true);
+    expect(openCode.calls.globalEvent).toHaveLength(1);
+    expect(openCode.calls.sessionPromptAsync).toHaveLength(1);
+
+    await session.close();
+    expect(openCode.calls.sessionAbort).toEqual([{ sessionID: "session-1", directory: cwd }]);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
   test("single turn completes with streaming deltas", async () => {
     const cwd = tmpCwd();
     const runtime = new TestOpenCodeHarness();

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -33,6 +33,7 @@ import {
   type AgentPromptInput,
   type AgentRunOptions,
   type AgentRunResult,
+  type AgentResumeSessionOptions,
   type AgentRuntimeInfo,
   type AgentSession,
   type AgentSessionConfig,
@@ -1378,6 +1379,7 @@ export class OpenCodeAgentClient implements AgentClient {
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,
     launchContext?: AgentLaunchContext,
+    options?: AgentResumeSessionOptions,
   ): Promise<AgentSession> {
     const metadata = (handle.metadata ?? {}) as Partial<AgentSessionConfig>;
     const cwd = overrides?.cwd ?? metadata.cwd;
@@ -1421,6 +1423,7 @@ export class OpenCodeAgentClient implements AgentClient {
         launchContext?.agentId,
         url,
         registeredAcquisition !== null,
+        options?.purpose === "history",
       );
     } catch (error) {
       await acquisition.release();
@@ -3190,6 +3193,7 @@ class OpenCodeAgentSession implements AgentSession {
     private readonly agentId?: string,
     private readonly serverUrl?: string,
     private readonly externallyDriven = false,
+    private historyOnly = false,
   ) {
     this.config = config;
     this.client = client;
@@ -3203,7 +3207,9 @@ class OpenCodeAgentSession implements AgentSession {
     this.selectedModelContextWindowMaxTokens = this.resolveConfiguredModelContextWindowMaxTokens(
       config.model,
     );
-    this.startEventStream();
+    if (!this.historyOnly) {
+      this.startEventStream();
+    }
   }
 
   get id(): string | null {
@@ -3415,6 +3421,13 @@ class OpenCodeAgentSession implements AgentSession {
     if (this.turnState.status === "running") {
       throw new Error("A foreground turn is already active");
     }
+    // An archived history view must stay detached from live OpenCode state.
+    // A deliberate new prompt is the boundary that promotes it back to an
+    // interactive session.
+    if (this.historyOnly) {
+      this.historyOnly = false;
+      this.startChildSessionHydration();
+    }
     await this.awaitRunnerQuiescence();
     if (this.turnState.status !== "idle") {
       throw new Error("OpenCode is still stopping the previous turn");
@@ -3619,8 +3632,10 @@ class OpenCodeAgentSession implements AgentSession {
   }
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
     this.subscribers.add(callback);
-    this.startExternalStatusReconciliation();
-    this.startChildSessionHydration();
+    if (!this.historyOnly) {
+      this.startExternalStatusReconciliation();
+      this.startChildSessionHydration();
+    }
     return () => {
       this.subscribers.delete(callback);
     };
@@ -4425,12 +4440,14 @@ class OpenCodeAgentSession implements AgentSession {
       this.eventStreamReady = null;
       this.eventStreamTask = null;
       this.subscribers.clear();
-      await abortOpenCodeSession({
-        client: this.client,
-        sessionId: this.sessionId,
-        directory: this.config.cwd,
-        logger: this.logger,
-      });
+      if (!this.historyOnly) {
+        await abortOpenCodeSession({
+          client: this.client,
+          sessionId: this.sessionId,
+          directory: this.config.cwd,
+          logger: this.logger,
+        });
+      }
       await this.deleteProviderSessionIfEphemeral();
       this.turnState = { status: "idle" };
     } finally {


### PR DESCRIPTION
## Summary

- pass the resume purpose through the OpenCode adapter
- keep history-only sessions detached from live OpenCode event/status reconciliation
- avoid aborting the native OpenCode session when an archived history view closes
- promote the session to interactive mode only when a new prompt is explicitly started

## Root cause

Archived agent history is loaded through `resumeSession(..., { purpose: "history" })`, but the OpenCode adapter ignored that purpose. Constructing and subscribing to the resumed session eagerly attached event/status reconciliation, and `close()` unconditionally called the native OpenCode session abort endpoint.

As a result, merely opening archived history could make the agent appear to be running again, and closing that history view could interrupt the underlying live OpenCode session.

## Reproduction

The regression test was first run unchanged against the official `v0.4.0` tag:

- history-only resume started one global OpenCode event stream instead of zero
- closing the history-only session issued one native `sessionAbort` call instead of zero

## Validation

- `npm exec -- vitest run packages/server/src/server/agent/providers/opencode-agent.test.ts` — 98 passed
- `npm run build:server-deps`
- `npm run typecheck --workspace=@getpaseo/server`
