### PR TITLE
fix(server): keep Pi turns active after custom messages

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -808,9 +808,10 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
-  test("surfaces Pi extension command messages and completes when no agent turn starts", async () => {
+  test("surfaces Pi extension command messages and completes from the prompt result", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
+    fakeSession.promptAck = { agentInvoked: false };
 
     await session.startTurn("/show-status");
     fakeSession.emit({
@@ -820,14 +821,54 @@ describe("PiRpcAgentSession", () => {
         content: [{ type: "text", text: "Extension command output" }],
       },
     });
+    await flushTurnScheduling();
 
     expect(events.timelineAndCompletionEvents()).toEqual([
       {
         type: "timeline",
         item: { type: "assistant_message", text: "Extension command output" },
       },
+      { type: "timeline", item: { type: "user_message", text: "/show-status" } },
       { type: "turn_completed" },
     ]);
+  });
+
+  test("keeps a Pi turn active when a custom message triggers continuation", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const { turnId } = await session.startTurn("research this");
+    fakeSession.emit({ type: "turn_start" });
+    fakeSession.emit({
+      type: "message_end",
+      message: {
+        role: "custom",
+        content: [
+          {
+            type: "text",
+            text: "Content fetched for 0/7 URLs [fetch-1]. Full page content now available.",
+          },
+        ],
+      },
+    });
+
+    expect(events.timelineItems()).toContainEqual({
+      type: "assistant_message",
+      text: "Content fetched for 0/7 URLs [fetch-1]. Full page content now available.",
+    });
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+    await expect(session.startTurn("do not overlap")).rejects.toThrow(
+      "A Pi turn is already active",
+    );
+
+    fakeSession.emit({
+      type: "agent_end",
+      messages: [{ role: "assistant", content: [] }],
+    });
+    await expect(events.nextTurnCompletion()).resolves.toMatchObject({
+      type: "turn_completed",
+      turnId,
+    });
   });
 
   test("canceling a silent Pi extension command leaves the session usable", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2244,7 +2244,6 @@ export class PiRpcAgentSession implements AgentSession {
           item: { type: "assistant_message", text },
         });
       }
-      this.completeTurn(turnId, []);
       return;
     }
   }


### PR DESCRIPTION
### Linked issue

No linked issue. This regression affects Pi extensions that emit a custom message and then continue the same agent turn, including background web-access results.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo currently treats every Pi `custom` message as a terminal turn. Extensions can use `sendMessage(..., { triggerTurn: true })` to publish an intermediate result and immediately continue with another model turn. The UI therefore reports `turn_completed` before Pi has actually finished.

### Goals

- Keep the turn active after an intermediate Pi custom message.
- Complete locally handled extension commands from Pi's `prompt_result` with `agentInvoked: false`.
- Add regression coverage for an extension message followed by continued agent work.

### Non-goals

- Change Pi retry policy or provider lifecycle handling.
- Change the content or ordering of custom-message timeline items.
- Add terminal activity hooks or managed-build packaging behavior.

### QA

- `npm run build:protocol` — passed.
- `npm run build:highlight` — passed.
- `npm exec -- vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1` — 57 tests passed.
- `npm run typecheck --workspace=@getpaseo/server` — passed.
- `npm exec -- oxfmt --check packages/server/src/server/agent/providers/pi/agent.ts packages/server/src/server/agent/providers/pi/agent.test.ts` — passed.
- `npm exec -- oxlint packages/server/src/server/agent/providers/pi/agent.ts packages/server/src/server/agent/providers/pi/agent.test.ts` — 0 warnings, 0 errors.

The full `npm run lint` wrapper was also attempted locally but exited before diagnostics with `ESLint output (JSON parse failed: EOF...)`; the changed-file `oxlint` invocation passed and GitHub CI remains authoritative for the full repository check.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes for changed files
- [x] `npm run format` passes for changed files
- [x] QA evidence
- [x] Tests added or updated where it made sense
