### PR TITLE
feat(terminal): notify when Pi settles

### DIFF
--- a/docs/terminal-activity.md
+++ b/docs/terminal-activity.md
@@ -72,6 +72,15 @@ OpenCode uses a server plugin instead of command hooks. The plugin listens to Op
 - `permission.asked` → `needs-input`
 - `permission.replied` → `running`
 
+Pi extension mapping:
+
+- `agent_start` -> `running`
+- `agent_settled` -> `idle`
+- `ask_user` starts -> `needs-input`
+- `ask_user` completes -> `running`
+
+An active `/goal` whose continuation has already started or queued stays working across intermediate settlement. If Pi remains idle with an active, paused, blocked, usage-limited, or budget-limited goal, the terminal becomes `needs-input`.
+
 The daemon maps hook states onto terminal activity like an agent lifecycle plus unread attention: `running` → `state: working`, `idle` → `state: idle`, and `needs-input` → `state: idle` with `attentionReason: needs_input`. A `working` → `idle` transition records `state: idle` with `attentionReason: finished` until the user focuses that terminal; plain idle terminals still contribute no workspace status.
 
 ## Focus clearing
@@ -95,6 +104,7 @@ When enabled, Paseo installs provider hooks globally:
 - Claude hooks are written to `~/.claude/settings.json` (or `CLAUDE_CONFIG_DIR/settings.json` when that override is set).
 - Codex hooks are written to `~/.codex/hooks.json` (or `CODEX_HOME/hooks.json` when that override is set). Codex supports a native `commandWindows`, so each Paseo hook includes both POSIX and Windows commands. Non-managed Codex hooks are trust-gated by Codex; users may see Codex's hook review prompt before the hook runs.
 - OpenCode gets a self-contained plugin at `$XDG_CONFIG_HOME/opencode/plugins/paseo-terminal-activity.js` (or `~/.config/opencode/plugins/paseo-terminal-activity.js` when XDG is unset; `OPENCODE_CONFIG_DIR` still wins when set).
+- Pi gets a self-contained extension at `$PI_CODING_AGENT_DIR/extensions/paseo-terminal-activity.ts` or `~/.pi/agent/extensions/paseo-terminal-activity.ts`. It is inert outside Paseo terminals and in Pi RPC, JSON, print, or child-subagent modes.
 
 Installation is marker-based/idempotent for config hooks and exact-file/idempotent for the OpenCode plugin. Paseo preserves user hooks, removes only its own marker-matched command hooks, and leaves hooks installed across daemon shutdown. Outside a Paseo terminal they are inert because the command or plugin is gated on `PASEO_TERMINAL_ID`.
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve as resolvePath } from "node:path";
+import { join } from "node:path";
 import type { Logger } from "pino";
 import stripAnsi from "strip-ansi";
 import { z } from "zod";
@@ -38,6 +38,7 @@ import {
   type ProviderRefreshContext,
   type ToolCallDetail,
 } from "../../agent-sdk-types.js";
+import { expandUserPath } from "../../../path-utils.js";
 import { importSessionFromPersistence } from "../../provider-session-import.js";
 import { runProviderRefreshActivity } from "../../provider-refresh-deadline.js";
 import { runProviderTurn } from "../provider-runner.js";
@@ -528,16 +529,7 @@ function toPiMcpConfig(config: McpServerConfig): PiMcpServerConfig {
 
 function resolvePiAgentDir(env: Record<string, string> | undefined): string {
   const configured = env?.PI_CODING_AGENT_DIR?.trim() || process.env.PI_CODING_AGENT_DIR?.trim();
-  if (!configured) {
-    return join(homedir(), ".pi", "agent");
-  }
-  if (configured === "~") {
-    return homedir();
-  }
-  if (configured.startsWith("~/")) {
-    return resolvePath(homedir(), configured.slice(2));
-  }
-  return resolvePath(configured);
+  return configured ? expandUserPath(configured) : join(homedir(), ".pi", "agent");
 }
 
 function readPiGlobalMcpConfig(env: Record<string, string> | undefined): Record<string, unknown> {

--- a/packages/server/src/server/path-utils.ts
+++ b/packages/server/src/server/path-utils.ts
@@ -1,6 +1,11 @@
 import { homedir } from "node:os";
 import { isAbsolute, posix, resolve, win32 } from "node:path";
 
+export interface ExpandUserPathOptions {
+  cwd?: string;
+  homeDir?: string;
+}
+
 export function assertAbsolutePath(cwd: string): void {
   if (!posix.isAbsolute(cwd) && !win32.isAbsolute(cwd)) {
     throw new Error("cwd must be absolute path");
@@ -8,15 +13,19 @@ export function assertAbsolutePath(cwd: string): void {
 }
 
 function hasHomePrefix(value: string): boolean {
-  return value === "~" || value.startsWith("~/");
+  return (
+    value === "~" ||
+    value.startsWith("~/") ||
+    (process.platform === "win32" && value.startsWith("~\\"))
+  );
 }
 
-export function expandUserPath(value: string): string {
+export function expandUserPath(value: string, options: ExpandUserPathOptions = {}): string {
   const trimmed = value.trim();
   if (hasHomePrefix(trimmed)) {
-    return resolve(homedir(), trimmed.slice(2));
+    return resolve(options.homeDir ?? homedir(), trimmed === "~" ? "" : trimmed.slice(2));
   }
-  return resolve(trimmed);
+  return resolve(options.cwd ?? process.cwd(), trimmed);
 }
 
 export function resolvePathFromBase(baseCwd: string, requestedPath: string): string {

--- a/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
+++ b/packages/server/src/terminal/agent-hooks/agent-hook-installer.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { expandUserPath } from "../../server/path-utils.js";
 import { writePrivateFileAtomicSync } from "../../server/private-files.js";
 
 export interface AgentHookEventDefinition {
@@ -34,6 +35,7 @@ interface AgentHookInstallStrategyBase {
   configDirBase?: "home" | "xdg-config";
   configFile: string;
   configDirEnvOverride?: string;
+  configDirEnvOverrideResolution?: "verbatim" | "user-path";
   hookMarker: string;
 }
 
@@ -59,6 +61,7 @@ export interface AgentHookConfigFormat<TConfig> {
 export interface AgentHookInstallOptions {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
+  cwd?: string;
   configDir?: string;
 }
 
@@ -129,6 +132,7 @@ function resolveAgentHookInstallPath<TConfig>(
       install,
       env: options.env ?? process.env,
       homeDir: options.homeDir ?? homedir(),
+      cwd: options.cwd ?? process.cwd(),
     });
   return path.join(configDir, install.configFile);
 }
@@ -206,11 +210,18 @@ function resolveConfiguredDirectory<TConfig>(input: {
   install: AgentHookInstallStrategy<TConfig>;
   env: NodeJS.ProcessEnv;
   homeDir: string;
+  cwd: string;
 }): string {
   const overrideName = input.install.configDirEnvOverride;
-  const override = overrideName ? input.env[overrideName] : undefined;
+  const rawOverride = overrideName ? input.env[overrideName] : undefined;
+  const override =
+    input.install.configDirEnvOverrideResolution === "user-path"
+      ? rawOverride?.trim()
+      : rawOverride;
   if (override) {
-    return override;
+    return input.install.configDirEnvOverrideResolution === "user-path"
+      ? expandUserPath(override, input)
+      : override;
   }
 
   if (input.install.configDirBase === "xdg-config") {

--- a/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
+++ b/packages/server/src/terminal/agent-hooks/claude/claude.test.ts
@@ -171,7 +171,7 @@ describe("Claude terminal agent hooks", () => {
     ).toLowerCase();
 
     for (const providerId of Object.keys(AGENT_HOOK_PROVIDERS)) {
-      expect(source).not.toContain(providerId);
+      expect(source).not.toMatch(new RegExp(`["']${providerId}["']`, "u"));
     }
   });
 

--- a/packages/server/src/terminal/agent-hooks/pi/pi-extension.ts
+++ b/packages/server/src/terminal/agent-hooks/pi/pi-extension.ts
@@ -1,0 +1,162 @@
+import type { AgentHookPluginFileInstallStrategy } from "../agent-hook-installer.js";
+
+export const PI_EXTENSION_SOURCE = String.raw`import { spawn } from "node:child_process";
+
+const GOAL_STATE_ENTRY_TYPE = "goal-state";
+const STOPPED_GOAL_STATUSES = new Set([
+  "paused",
+  "blocked",
+  "usage_limited",
+  "budget_limited",
+]);
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasPaseoTerminalTarget(env) {
+  return Boolean(
+    env.PASEO_TERMINAL_ID &&
+      env.PASEO_ACTIVITY_TOKEN &&
+      env.PASEO_TERMINAL_ACTIVITY_URL,
+  );
+}
+
+function isEligible(ctx, env) {
+  return (
+    ctx.mode === "tui" &&
+    env.PI_SUBAGENT_CHILD !== "1" &&
+    hasPaseoTerminalTarget(env)
+  );
+}
+
+function readGoalState(ctx) {
+  const entries = ctx.sessionManager?.getBranch?.() ?? [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.type !== "custom" || entry.customType !== GOAL_STATE_ENTRY_TYPE) continue;
+    if (!isRecord(entry.data)) return { status: null, pending: false };
+    const goal = isRecord(entry.data.goal) ? entry.data.goal : null;
+    return {
+      status: typeof goal?.status === "string" ? goal.status : null,
+      pending:
+        (Array.isArray(entry.data.queue) && entry.data.queue.length > 0) ||
+        isRecord(entry.data.pendingAction),
+    };
+  }
+  return { status: null, pending: false };
+}
+
+function spawnPaseoHook(event, env) {
+  try {
+    const child = spawn(env.PASEO_HOOK_CLI || "paseo", ["hooks", "pi", event], {
+      env,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.once("error", () => {});
+    child.unref();
+  } catch {
+    // Terminal activity is best effort and must never interrupt Pi.
+  }
+}
+
+export function registerPaseoTerminalActivity(pi, options = {}) {
+  const env = options.env ?? process.env;
+  const report = options.report ?? ((event) => spawnPaseoHook(event, env));
+  const settleDelayMs = options.settleDelayMs ?? 50;
+  let enabled = false;
+  let running = false;
+  let waitingForInput = false;
+  let generation = 0;
+  let settleTimer;
+
+  function cancelPendingSettle() {
+    generation += 1;
+    if (settleTimer !== undefined) {
+      clearTimeout(settleTimer);
+      settleTimer = undefined;
+    }
+  }
+
+  pi.on("session_start", (_event, ctx) => {
+    cancelPendingSettle();
+    enabled = isEligible(ctx, env);
+    running = false;
+    waitingForInput = false;
+  });
+
+  pi.on("agent_start", (_event, ctx) => {
+    if (!isEligible(ctx, env)) return;
+    enabled = true;
+    cancelPendingSettle();
+    running = true;
+    waitingForInput = false;
+    report("agent_start");
+  });
+
+  pi.on("tool_execution_start", (event, ctx) => {
+    if (!enabled || !running || event.toolName !== "ask_user" || !isEligible(ctx, env)) return;
+    waitingForInput = true;
+    report("needs_input");
+  });
+
+  pi.on("tool_execution_end", (event, ctx) => {
+    if (!enabled || !waitingForInput || event.toolName !== "ask_user" || !isEligible(ctx, env)) {
+      return;
+    }
+    waitingForInput = false;
+    report("resume");
+  });
+
+  pi.on("agent_settled", (_event, ctx) => {
+    if (!enabled || !running || !isEligible(ctx, env)) return;
+    cancelPendingSettle();
+    const settleGeneration = generation;
+    settleTimer = setTimeout(() => {
+      settleTimer = undefined;
+      if (generation !== settleGeneration || ctx.isIdle?.() !== true) return;
+
+      const goal = readGoalState(ctx);
+      if (
+        goal.status === "active" ||
+        goal.status === "queued" ||
+        goal.pending ||
+        (goal.status && STOPPED_GOAL_STATUSES.has(goal.status))
+      ) {
+        running = false;
+        waitingForInput = true;
+        report("needs_input");
+        return;
+      }
+
+      running = false;
+      waitingForInput = false;
+      report("agent_settled");
+    }, settleDelayMs);
+  });
+
+  pi.on("session_shutdown", () => {
+    cancelPendingSettle();
+    enabled = false;
+    running = false;
+    waitingForInput = false;
+  });
+}
+
+export default function paseoTerminalActivityExtension(pi) {
+  registerPaseoTerminalActivity(pi);
+}
+`;
+
+export function createPiExtensionInstallStrategy(): AgentHookPluginFileInstallStrategy {
+  return {
+    kind: "plugin-file",
+    configDir: ".pi/agent",
+    configFile: "extensions/paseo-terminal-activity.ts",
+    configDirEnvOverride: "PI_CODING_AGENT_DIR",
+    configDirEnvOverrideResolution: "user-path",
+    hookMarker: "hooks pi",
+    source: PI_EXTENSION_SOURCE,
+  };
+}

--- a/packages/server/src/terminal/agent-hooks/pi/pi.test.ts
+++ b/packages/server/src/terminal/agent-hooks/pi/pi.test.ts
@@ -1,0 +1,329 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  agentHooksAreInstalled,
+  installAgentHooks,
+  resolveAgentHookConfigPath,
+  uninstallAgentHooks,
+} from "../agent-hook-installer.js";
+import { PI_EXTENSION_SOURCE } from "./pi-extension.js";
+import { piAgentHookProvider } from "./pi.js";
+
+const temporaryDirs: string[] = [];
+let extensionModuleId = 0;
+
+afterEach(() => {
+  vi.useRealTimers();
+  while (temporaryDirs.length > 0) {
+    const dir = temporaryDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirs.push(dir);
+  return dir;
+}
+
+interface FakeContext {
+  mode: "tui" | "rpc";
+  isIdle(): boolean;
+  sessionManager: {
+    getBranch(): unknown[];
+  };
+}
+
+interface FakeExtensionApi {
+  on(event: string, handler: (event: unknown, ctx: FakeContext) => void): void;
+}
+
+function createFakePi() {
+  const handlers = new Map<string, Array<(event: unknown, ctx: FakeContext) => void>>();
+  const pi: FakeExtensionApi = {
+    on(event, handler) {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    },
+  };
+  return {
+    pi,
+    emit(event: string, payload: unknown, ctx: FakeContext) {
+      for (const handler of handlers.get(event) ?? []) {
+        handler(payload, ctx);
+      }
+    },
+  };
+}
+
+function createContext(options?: {
+  mode?: "tui" | "rpc";
+  idle?: boolean;
+  entries?: unknown[];
+}): FakeContext {
+  return {
+    mode: options?.mode ?? "tui",
+    isIdle: () => options?.idle ?? true,
+    sessionManager: {
+      getBranch: () => options?.entries ?? [],
+    },
+  };
+}
+
+function goalEntry(status: string, options?: { queued?: boolean; pending?: boolean }) {
+  return {
+    type: "custom",
+    customType: "goal-state",
+    data: {
+      goal: { status },
+      ...(options?.queued ? { queue: [{ status: "queued" }] } : {}),
+      ...(options?.pending ? { pendingAction: { kind: "advance" } } : {}),
+    },
+  };
+}
+
+async function loadExtension() {
+  const dir = createTempDir("paseo-pi-extension-runtime-");
+  const extensionPath = join(dir, "paseo-terminal-activity.mjs");
+  writeFileSync(extensionPath, PI_EXTENSION_SOURCE);
+  const extension = await import(
+    `${pathToFileURL(extensionPath).href}?test=${extensionModuleId++}`
+  );
+  vi.useFakeTimers();
+  return extension as {
+    registerPaseoTerminalActivity(
+      pi: FakeExtensionApi,
+      options: {
+        env: NodeJS.ProcessEnv;
+        report: (event: string) => void;
+        settleDelayMs: number;
+      },
+    ): void;
+  };
+}
+
+function paseoEnv(overrides?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    PASEO_TERMINAL_ID: "terminal-1",
+    PASEO_ACTIVITY_TOKEN: "token-1",
+    PASEO_TERMINAL_ACTIVITY_URL: "http://127.0.0.1:6767/api/terminal-activity",
+    PASEO_HOOK_CLI: "/tmp/paseo",
+    ...overrides,
+  };
+}
+
+async function flushSettleTimer(): Promise<void> {
+  await vi.runAllTimersAsync();
+}
+
+describe("Pi terminal agent hooks", () => {
+  it("installs and uninstalls the Pi extension idempotently", () => {
+    const agentDir = createTempDir("paseo-pi-agent-dir-");
+
+    const firstInstall = installAgentHooks(piAgentHookProvider, { configDir: agentDir });
+    const secondInstall = installAgentHooks(piAgentHookProvider, { configDir: agentDir });
+
+    expect(firstInstall.configPath).toBe(
+      join(agentDir, "extensions", "paseo-terminal-activity.ts"),
+    );
+    expect(firstInstall.changed).toBe(true);
+    expect(secondInstall.changed).toBe(false);
+    expect(readFileSync(firstInstall.configPath, "utf8")).toBe(PI_EXTENSION_SOURCE);
+    expect(agentHooksAreInstalled(piAgentHookProvider, { configDir: agentDir })).toBe(true);
+
+    const uninstall = uninstallAgentHooks(piAgentHookProvider, { configDir: agentDir });
+    expect(uninstall).toEqual({ configPath: firstInstall.configPath, changed: true });
+    expect(existsSync(firstInstall.configPath)).toBe(false);
+  });
+
+  it("matches Pi path resolution for custom agent directories", () => {
+    const homeDir = createTempDir("paseo-pi-home-");
+    const cwd = createTempDir("paseo-pi-cwd-");
+    const absoluteDir = createTempDir("paseo-pi-agent-absolute-");
+    const extensionPath = join("extensions", "paseo-terminal-activity.ts");
+
+    expect(
+      resolveAgentHookConfigPath(piAgentHookProvider, {
+        env: { PI_CODING_AGENT_DIR: absoluteDir },
+        homeDir,
+        cwd,
+      }),
+    ).toBe(join(absoluteDir, extensionPath));
+    expect(
+      resolveAgentHookConfigPath(piAgentHookProvider, {
+        env: { PI_CODING_AGENT_DIR: "~/pi-agent" },
+        homeDir,
+        cwd,
+      }),
+    ).toBe(join(homeDir, "pi-agent", extensionPath));
+    expect(
+      resolveAgentHookConfigPath(piAgentHookProvider, {
+        env: { PI_CODING_AGENT_DIR: "./pi-agent" },
+        homeDir,
+        cwd,
+      }),
+    ).toBe(join(cwd, "pi-agent", extensionPath));
+  });
+
+  it.each([
+    ["agent_start", "running"],
+    ["agent_settled", "idle"],
+    ["needs_input", "needs-input"],
+    ["resume", "running"],
+  ] as const)("maps %s to %s", async (event, state) => {
+    await expect(
+      piAgentHookProvider.resolveActivity({ event, input: { read: async () => null } }),
+    ).resolves.toBe(state);
+  });
+
+  it("reports one running-to-idle lifecycle after Pi fully settles", async () => {
+    const extension = await loadExtension();
+    const runtime = createFakePi();
+    const events: string[] = [];
+    const ctx = createContext();
+    extension.registerPaseoTerminalActivity(runtime.pi, {
+      env: paseoEnv(),
+      report: (event) => events.push(event),
+      settleDelayMs: 0,
+    });
+
+    runtime.emit("session_start", { reason: "startup" }, ctx);
+    runtime.emit("agent_start", {}, ctx);
+    runtime.emit("agent_settled", {}, ctx);
+    runtime.emit("agent_settled", {}, ctx);
+    await flushSettleTimer();
+
+    expect(events).toEqual(["agent_start", "agent_settled"]);
+  });
+
+  it("keeps an automatically continuing Goal running without a false completion", async () => {
+    const extension = await loadExtension();
+    const runtime = createFakePi();
+    const events: string[] = [];
+    let idle = true;
+    const activeGoalContext = createContext({ entries: [goalEntry("active")] });
+    activeGoalContext.isIdle = () => idle;
+    extension.registerPaseoTerminalActivity(runtime.pi, {
+      env: paseoEnv(),
+      report: (event) => events.push(event),
+      settleDelayMs: 0,
+    });
+
+    runtime.emit("session_start", { reason: "startup" }, activeGoalContext);
+    runtime.emit("agent_start", {}, activeGoalContext);
+    runtime.emit("agent_settled", {}, activeGoalContext);
+    idle = false;
+    await flushSettleTimer();
+
+    expect(events).toEqual(["agent_start"]);
+  });
+
+  it("reports an active Goal that remains idle as needing input", async () => {
+    const extension = await loadExtension();
+    const runtime = createFakePi();
+    const events: string[] = [];
+    const activeGoalContext = createContext({ entries: [goalEntry("active")] });
+    extension.registerPaseoTerminalActivity(runtime.pi, {
+      env: paseoEnv(),
+      report: (event) => events.push(event),
+      settleDelayMs: 0,
+    });
+
+    runtime.emit("session_start", { reason: "startup" }, activeGoalContext);
+    runtime.emit("agent_start", {}, activeGoalContext);
+    runtime.emit("agent_settled", {}, activeGoalContext);
+    await flushSettleTimer();
+
+    expect(events).toEqual(["agent_start", "needs_input"]);
+  });
+
+  it.each(["paused", "blocked", "usage_limited", "budget_limited"])(
+    "reports a stopped %s Goal as needing input",
+    async (status) => {
+      const extension = await loadExtension();
+      const runtime = createFakePi();
+      const events: string[] = [];
+      const runningContext = createContext();
+      const stoppedGoalContext = createContext({ entries: [goalEntry(status)] });
+      extension.registerPaseoTerminalActivity(runtime.pi, {
+        env: paseoEnv(),
+        report: (event) => events.push(event),
+        settleDelayMs: 0,
+      });
+
+      runtime.emit("session_start", { reason: "startup" }, runningContext);
+      runtime.emit("agent_start", {}, runningContext);
+      runtime.emit("agent_settled", {}, stoppedGoalContext);
+      await flushSettleTimer();
+
+      expect(events).toEqual(["agent_start", "needs_input"]);
+    },
+  );
+
+  it("reports ask_user waiting and resume before final settlement", async () => {
+    const extension = await loadExtension();
+    const runtime = createFakePi();
+    const events: string[] = [];
+    const ctx = createContext();
+    extension.registerPaseoTerminalActivity(runtime.pi, {
+      env: paseoEnv(),
+      report: (event) => events.push(event),
+      settleDelayMs: 0,
+    });
+
+    runtime.emit("session_start", { reason: "startup" }, ctx);
+    runtime.emit("agent_start", {}, ctx);
+    runtime.emit("tool_execution_start", { toolName: "ask_user" }, ctx);
+    runtime.emit("tool_execution_end", { toolName: "ask_user" }, ctx);
+    runtime.emit("agent_settled", {}, ctx);
+    await flushSettleTimer();
+
+    expect(events).toEqual(["agent_start", "needs_input", "resume", "agent_settled"]);
+  });
+
+  it.each([
+    ["RPC mode", paseoEnv(), createContext({ mode: "rpc" })],
+    ["a child Pi", paseoEnv({ PI_SUBAGENT_CHILD: "1" }), createContext()],
+    ["a non-Paseo terminal", {}, createContext()],
+  ])("stays silent in %s", async (_label, env, ctx) => {
+    const extension = await loadExtension();
+    const runtime = createFakePi();
+    const events: string[] = [];
+    extension.registerPaseoTerminalActivity(runtime.pi, {
+      env,
+      report: (event) => events.push(event),
+      settleDelayMs: 0,
+    });
+
+    runtime.emit("session_start", { reason: "startup" }, ctx);
+    runtime.emit("agent_start", {}, ctx);
+    runtime.emit("agent_settled", {}, ctx);
+    await flushSettleTimer();
+
+    expect(events).toEqual([]);
+  });
+
+  it("cancels a pending completion report on session shutdown", async () => {
+    const extension = await loadExtension();
+    const runtime = createFakePi();
+    const events: string[] = [];
+    const ctx = createContext();
+    extension.registerPaseoTerminalActivity(runtime.pi, {
+      env: paseoEnv(),
+      report: (event) => events.push(event),
+      settleDelayMs: 0,
+    });
+
+    runtime.emit("session_start", { reason: "startup" }, ctx);
+    runtime.emit("agent_start", {}, ctx);
+    runtime.emit("agent_settled", {}, ctx);
+    runtime.emit("session_shutdown", { reason: "quit" }, ctx);
+    await flushSettleTimer();
+
+    expect(events).toEqual(["agent_start"]);
+  });
+});

--- a/packages/server/src/terminal/agent-hooks/pi/pi.ts
+++ b/packages/server/src/terminal/agent-hooks/pi/pi.ts
@@ -1,0 +1,23 @@
+import type { AgentHookActivityState, AgentHookProvider } from "../agent-hook-installer.js";
+import { createPiExtensionInstallStrategy } from "./pi-extension.js";
+
+const PI_EVENT_STATES: Record<string, AgentHookActivityState> = {
+  agent_start: "running",
+  agent_settled: "idle",
+  needs_input: "needs-input",
+  resume: "running",
+};
+
+export const piAgentHookProvider: AgentHookProvider = {
+  id: "pi",
+  events: [
+    { event: "agent_start" },
+    { event: "agent_settled" },
+    { event: "needs_input" },
+    { event: "resume" },
+  ],
+  install: createPiExtensionInstallStrategy(),
+  async resolveActivity({ event }) {
+    return PI_EVENT_STATES[event] ?? null;
+  },
+};

--- a/packages/server/src/terminal/agent-hooks/provider-registry.test.ts
+++ b/packages/server/src/terminal/agent-hooks/provider-registry.test.ts
@@ -52,6 +52,7 @@ describe("terminal agent hook provider registry", () => {
         CLAUDE_CONFIG_DIR: badClaudeConfigDir,
         CODEX_HOME: codexHome,
         OPENCODE_CONFIG_DIR: opencodeConfigDir,
+        PI_CODING_AGENT_DIR: join(root, "pi"),
       },
       homeDir: join(root, "home"),
       logger,
@@ -60,9 +61,11 @@ describe("terminal agent hook provider registry", () => {
     expect(results.map((result) => result.configPath)).toEqual([
       join(codexHome, "hooks.json"),
       join(opencodeConfigDir, "plugins", "paseo-terminal-activity.js"),
+      join(root, "pi", "extensions", "paseo-terminal-activity.ts"),
     ]);
     expect(existsSync(join(codexHome, "hooks.json"))).toBe(true);
     expect(existsSync(join(opencodeConfigDir, "plugins", "paseo-terminal-activity.js"))).toBe(true);
+    expect(existsSync(join(root, "pi", "extensions", "paseo-terminal-activity.ts"))).toBe(true);
     expect(logger.entries).toEqual([
       {
         bindings: expect.objectContaining({ err: expect.any(Error), provider: "claude" }),

--- a/packages/server/src/terminal/agent-hooks/provider-registry.ts
+++ b/packages/server/src/terminal/agent-hooks/provider-registry.ts
@@ -12,6 +12,7 @@ import {
 import { claudeAgentHookProvider } from "./claude/claude.js";
 import { codexAgentHookProvider } from "./codex/codex.js";
 import { opencodeAgentHookProvider } from "./opencode/opencode.js";
+import { piAgentHookProvider } from "./pi/pi.js";
 
 export type {
   AgentHookActivityInput,
@@ -23,6 +24,7 @@ export const AGENT_HOOK_PROVIDERS = {
   [claudeAgentHookProvider.id]: claudeAgentHookProvider,
   [codexAgentHookProvider.id]: codexAgentHookProvider,
   [opencodeAgentHookProvider.id]: opencodeAgentHookProvider,
+  [piAgentHookProvider.id]: piAgentHookProvider,
 } satisfies Record<string, AgentHookProvider>;
 
 export type AgentHookProviderId = keyof typeof AGENT_HOOK_PROVIDERS;

--- a/packages/server/src/terminal/agent-hooks/terminal-agent-hook-setting.test.ts
+++ b/packages/server/src/terminal/agent-hooks/terminal-agent-hook-setting.test.ts
@@ -27,6 +27,7 @@ function createInstallEnv(root: string) {
       CLAUDE_CONFIG_DIR: join(root, "claude"),
       CODEX_HOME: join(root, "codex"),
       OPENCODE_CONFIG_DIR: join(root, "opencode"),
+      PI_CODING_AGENT_DIR: join(root, "pi"),
     },
     homeDir: join(root, "home"),
   };
@@ -37,6 +38,7 @@ function hookPaths(root: string) {
     claude: join(root, "claude", "settings.json"),
     codex: join(root, "codex", "hooks.json"),
     opencode: join(root, "opencode", "plugins", "paseo-terminal-activity.js"),
+    pi: join(root, "pi", "extensions", "paseo-terminal-activity.ts"),
   };
 }
 
@@ -66,6 +68,7 @@ describe("applyTerminalAgentHookSetting", () => {
     expect(existsSync(paths.claude)).toBe(false);
     expect(existsSync(paths.codex)).toBe(false);
     expect(existsSync(paths.opencode)).toBe(false);
+    expect(existsSync(paths.pi)).toBe(false);
   });
 
   it("installs agent hooks when the setting is enabled", () => {
@@ -78,6 +81,7 @@ describe("applyTerminalAgentHookSetting", () => {
     expect(existsSync(paths.claude)).toBe(true);
     expect(existsSync(paths.codex)).toBe(true);
     expect(existsSync(paths.opencode)).toBe(true);
+    expect(existsSync(paths.pi)).toBe(true);
   });
 
   it("installs on enable and removes hooks on disable when toggled live", () => {
@@ -91,8 +95,10 @@ describe("applyTerminalAgentHookSetting", () => {
     store.patch({ enableTerminalAgentHooks: true });
     expect(existsSync(paths.codex)).toBe(true);
     expect(existsSync(paths.opencode)).toBe(true);
+    expect(existsSync(paths.pi)).toBe(true);
 
     store.patch({ enableTerminalAgentHooks: false });
     expect(existsSync(paths.opencode)).toBe(false);
+    expect(existsSync(paths.pi)).toBe(false);
   });
 });


### PR DESCRIPTION
### Linked issue

No linked issue. This adds Pi support to Paseo's existing terminal activity hook system.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo can already report terminal activity for several providers, but Pi terminals were missing from that lifecycle. A self-contained Pi extension can report running, settled, needs-input, and resume states while remaining inert in RPC, JSON, print, and child-subagent modes.

### Goals

- Install an idempotent Pi terminal activity extension when terminal hooks are enabled.
- Report `agent_start`, `agent_settled`, `ask_user`, and resume transitions.
- Keep active or queued `/goal` continuation visible as working, and surface stopped goals as needs-input.
- Preserve user Pi behavior outside a Paseo terminal and for Pi child processes.
- Add unit coverage for installation, lifecycle mapping, goal states, ask-user flow, and ineligible modes.

### Non-goals

- Change Pi RPC provider turn completion or retry behavior.
- Expose Pi child-subagent timelines in Paseo.
- Add a managed build command or change server packaging.

### QA

- `npm run build:protocol` — passed.
- `npm run build:highlight` — passed.
- `npm exec -- vitest run packages/server/src/terminal/agent-hooks/pi/pi.test.ts --bail=1` — 18 tests passed.
- `npm run typecheck --workspace=@getpaseo/server` — passed.
- `npm exec -- oxfmt --check packages/server/src/terminal/agent-hooks/pi/pi-extension.ts packages/server/src/terminal/agent-hooks/pi/pi.test.ts packages/server/src/terminal/agent-hooks/pi/pi.ts` — passed.
- `npm exec -- oxlint packages/server/src/terminal/agent-hooks/pi/pi-extension.ts packages/server/src/terminal/agent-hooks/pi/pi.test.ts packages/server/src/terminal/agent-hooks/pi/pi.ts` — 0 warnings, 0 errors.

The full `npm run lint` wrapper was also attempted locally but exited before diagnostics with `ESLint output (JSON parse failed: EOF...)`; the changed-file `oxlint` invocation passed and GitHub CI remains authoritative for the full repository check.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes for changed files
- [x] `npm run format` passes for changed files
- [x] QA evidence
- [x] Tests added or updated where it made sense
