### PR TITLE
fix(server): keep background subagents alive when prompting a busy agent

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5497,6 +5497,77 @@ test("failed replacement cancellation preserves an autonomous running state", as
   }
 });
 
+test("prompting an agent whose only run is autonomous starts a turn without interrupting", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-autonomous-prompt-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  class BackgroundWorkSession extends TestAgentSession {
+    interruptCount = 0;
+    readonly prompts: AgentPromptInput[] = [];
+
+    override async interrupt(): Promise<void> {
+      this.interruptCount += 1;
+    }
+
+    override async startTurn(prompt: AgentPromptInput): Promise<{ turnId: string }> {
+      this.prompts.push(prompt);
+      return { turnId: "foreground-after-background" };
+    }
+  }
+
+  class BackgroundWorkClient extends TestAgentClient {
+    readonly session = new BackgroundWorkSession({ provider: "codex", cwd: workdir });
+
+    override async createSession(): Promise<AgentSession> {
+      return this.session;
+    }
+  }
+
+  const client = new BackgroundWorkClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000131",
+  });
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const running = waitForAgentLifecycle(manager, agent.id, "running");
+
+    // The provider streams for work the session owns in the background — a Claude
+    // background subagent. The agent's own turn is over, but it reads as running.
+    client.session.pushEvent({
+      type: "turn_started",
+      provider: "codex",
+      turnId: "autonomous-background-1",
+    });
+    await running;
+    expect(manager.getAgent(agent.id)).toMatchObject({
+      lifecycle: "running",
+      activeForegroundTurnId: null,
+    });
+
+    await startAgentRun(manager, agent.id, "follow-up while the subagent works", logger, {
+      replaceRunning: true,
+    });
+
+    // Replacing would cancel the session, and for Claude that cancel is the SDK's
+    // stop-everything interrupt: it kills the background subagent this prompt was
+    // most likely asking about.
+    expect(client.session.interruptCount).toBe(0);
+    expect(client.session.prompts).toEqual(["follow-up while the subagent works"]);
+    expect(manager.getAgent(agent.id)).toMatchObject({
+      lifecycle: "running",
+      activeForegroundTurnId: "foreground-after-background",
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("waitForAgentEvent waitForActive resolves for autonomous live-event run", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-live-wait-"));
   const storagePath = join(workdir, "agents");

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5502,6 +5502,7 @@ test("prompting an agent whose only run is autonomous starts a turn without inte
   const storage = new AgentStorage(join(workdir, "agents"), logger);
 
   class BackgroundWorkSession extends TestAgentSession {
+    readonly acceptsPromptDuringAutonomousTurn = true;
     interruptCount = 0;
     readonly prompts: AgentPromptInput[] = [];
 
@@ -5562,6 +5563,85 @@ test("prompting an agent whose only run is autonomous starts a turn without inte
     expect(manager.getAgent(agent.id)).toMatchObject({
       lifecycle: "running",
       activeForegroundTurnId: "foreground-after-background",
+    });
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("prompting during an autonomous turn still replaces it when the provider refuses both", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-autonomous-refuses-"));
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  // OpenCode's startTurn throws while its runner is active, so the manager has
+  // to cancel the autonomous turn before prompting. Letting the prompt through
+  // would fail the turn and drop the run this agent is still tracking.
+  class ExclusiveTurnSession extends TestAgentSession {
+    interruptCount = 0;
+    autonomousTurnId: string | null = null;
+    readonly prompts: AgentPromptInput[] = [];
+
+    override async interrupt(): Promise<void> {
+      this.interruptCount += 1;
+      const turnId = this.autonomousTurnId;
+      if (!turnId) return;
+      this.autonomousTurnId = null;
+      this.pushEvent({
+        type: "turn_canceled",
+        provider: "codex",
+        turnId,
+        reason: "interrupted",
+      });
+    }
+
+    override async startTurn(prompt: AgentPromptInput): Promise<{ turnId: string }> {
+      if (this.autonomousTurnId) {
+        throw new Error("A foreground turn is already active");
+      }
+      this.prompts.push(prompt);
+      return { turnId: "foreground-after-cancel" };
+    }
+  }
+
+  class ExclusiveTurnClient extends TestAgentClient {
+    readonly session = new ExclusiveTurnSession({ provider: "codex", cwd: workdir });
+
+    override async createSession(): Promise<AgentSession> {
+      return this.session;
+    }
+  }
+
+  const client = new ExclusiveTurnClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000132",
+  });
+
+  try {
+    const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    const running = waitForAgentLifecycle(manager, agent.id, "running");
+
+    client.session.autonomousTurnId = "autonomous-exclusive-1";
+    client.session.pushEvent({
+      type: "turn_started",
+      provider: "codex",
+      turnId: "autonomous-exclusive-1",
+    });
+    await running;
+
+    await startAgentRun(manager, agent.id, "follow-up on an exclusive provider", logger, {
+      replaceRunning: true,
+    });
+
+    expect(client.session.interruptCount).toBe(1);
+    expect(client.session.prompts).toEqual(["follow-up on an exclusive provider"]);
+    expect(manager.getAgent(agent.id)).toMatchObject({
+      lifecycle: "running",
+      activeForegroundTurnId: "foreground-after-cancel",
     });
   } finally {
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -5501,30 +5501,28 @@ test("prompting an agent whose only run is autonomous starts a turn without inte
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-autonomous-prompt-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
 
-  class BackgroundWorkSession extends TestAgentSession {
+  class AutonomousSession extends TestAgentSession {
     readonly acceptsPromptDuringAutonomousTurn = true;
     interruptCount = 0;
-    readonly prompts: AgentPromptInput[] = [];
 
     override async interrupt(): Promise<void> {
       this.interruptCount += 1;
     }
 
-    override async startTurn(prompt: AgentPromptInput): Promise<{ turnId: string }> {
-      this.prompts.push(prompt);
-      return { turnId: "foreground-after-background" };
+    override async startTurn(): Promise<{ turnId: string }> {
+      return { turnId: "foreground-1" };
     }
   }
 
-  class BackgroundWorkClient extends TestAgentClient {
-    readonly session = new BackgroundWorkSession({ provider: "codex", cwd: workdir });
+  class AutonomousClient extends TestAgentClient {
+    readonly session = new AutonomousSession({ provider: "codex", cwd: workdir });
 
     override async createSession(): Promise<AgentSession> {
       return this.session;
     }
   }
 
-  const client = new BackgroundWorkClient();
+  const client = new AutonomousClient();
   const manager = new AgentManager({
     clients: { codex: client },
     registry: storage,
@@ -5537,81 +5535,53 @@ test("prompting an agent whose only run is autonomous starts a turn without inte
       workspaceId: undefined,
     });
     const running = waitForAgentLifecycle(manager, agent.id, "running");
-
-    // The provider streams for work the session owns in the background — a Claude
-    // background subagent. The agent's own turn is over, but it reads as running.
-    client.session.pushEvent({
-      type: "turn_started",
-      provider: "codex",
-      turnId: "autonomous-background-1",
-    });
+    client.session.pushEvent({ type: "turn_started", provider: "codex", turnId: "autonomous-1" });
     await running;
-    expect(manager.getAgent(agent.id)).toMatchObject({
-      lifecycle: "running",
-      activeForegroundTurnId: null,
-    });
 
-    await startAgentRun(manager, agent.id, "follow-up while the subagent works", logger, {
-      replaceRunning: true,
-    });
+    await startAgentRun(manager, agent.id, "follow-up", logger, { replaceRunning: true });
 
-    // Replacing would cancel the session, and for Claude that cancel is the SDK's
-    // stop-everything interrupt: it kills the background subagent this prompt was
-    // most likely asking about.
     expect(client.session.interruptCount).toBe(0);
-    expect(client.session.prompts).toEqual(["follow-up while the subagent works"]);
     expect(manager.getAgent(agent.id)).toMatchObject({
-      lifecycle: "running",
-      activeForegroundTurnId: "foreground-after-background",
+      activeForegroundTurnId: "foreground-1",
     });
   } finally {
     rmSync(workdir, { recursive: true, force: true });
   }
 });
 
-test("prompting during an autonomous turn still replaces it when the provider refuses both", async () => {
+test("prompting during an autonomous turn replaces it when the provider refuses both", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-autonomous-refuses-"));
   const storage = new AgentStorage(join(workdir, "agents"), logger);
 
-  // OpenCode's startTurn throws while its runner is active, so the manager has
-  // to cancel the autonomous turn before prompting. Letting the prompt through
-  // would fail the turn and drop the run this agent is still tracking.
-  class ExclusiveTurnSession extends TestAgentSession {
+  class ExclusiveSession extends TestAgentSession {
     interruptCount = 0;
-    autonomousTurnId: string | null = null;
-    readonly prompts: AgentPromptInput[] = [];
+    autonomousTurnId: string | null = "autonomous-1";
 
     override async interrupt(): Promise<void> {
       this.interruptCount += 1;
       const turnId = this.autonomousTurnId;
       if (!turnId) return;
       this.autonomousTurnId = null;
-      this.pushEvent({
-        type: "turn_canceled",
-        provider: "codex",
-        turnId,
-        reason: "interrupted",
-      });
+      this.pushEvent({ type: "turn_canceled", provider: "codex", turnId, reason: "interrupted" });
     }
 
-    override async startTurn(prompt: AgentPromptInput): Promise<{ turnId: string }> {
+    override async startTurn(): Promise<{ turnId: string }> {
       if (this.autonomousTurnId) {
         throw new Error("A foreground turn is already active");
       }
-      this.prompts.push(prompt);
-      return { turnId: "foreground-after-cancel" };
+      return { turnId: "foreground-1" };
     }
   }
 
-  class ExclusiveTurnClient extends TestAgentClient {
-    readonly session = new ExclusiveTurnSession({ provider: "codex", cwd: workdir });
+  class ExclusiveClient extends TestAgentClient {
+    readonly session = new ExclusiveSession({ provider: "codex", cwd: workdir });
 
     override async createSession(): Promise<AgentSession> {
       return this.session;
     }
   }
 
-  const client = new ExclusiveTurnClient();
+  const client = new ExclusiveClient();
   const manager = new AgentManager({
     clients: { codex: client },
     registry: storage,
@@ -5624,24 +5594,14 @@ test("prompting during an autonomous turn still replaces it when the provider re
       workspaceId: undefined,
     });
     const running = waitForAgentLifecycle(manager, agent.id, "running");
-
-    client.session.autonomousTurnId = "autonomous-exclusive-1";
-    client.session.pushEvent({
-      type: "turn_started",
-      provider: "codex",
-      turnId: "autonomous-exclusive-1",
-    });
+    client.session.pushEvent({ type: "turn_started", provider: "codex", turnId: "autonomous-1" });
     await running;
 
-    await startAgentRun(manager, agent.id, "follow-up on an exclusive provider", logger, {
-      replaceRunning: true,
-    });
+    await startAgentRun(manager, agent.id, "follow-up", logger, { replaceRunning: true });
 
     expect(client.session.interruptCount).toBe(1);
-    expect(client.session.prompts).toEqual(["follow-up on an exclusive provider"]);
     expect(manager.getAgent(agent.id)).toMatchObject({
-      lifecycle: "running",
-      activeForegroundTurnId: "foreground-after-cancel",
+      activeForegroundTurnId: "foreground-1",
     });
   } finally {
     rmSync(workdir, { recursive: true, force: true });

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -837,21 +837,29 @@ export class AgentManager {
   }
 
   /**
-   * Whether a foreground turn owns the session right now.
+   * Whether a new prompt has to replace the run in flight.
    *
-   * `hasInFlightRun` also counts autonomous runs — background provider work such
+   * `hasInFlightRun` also counts autonomous runs, background provider work such
    * as a Claude background subagent, which keeps the agent `running` while its
    * own turn is over. That is the right question for Stop, reload, and rewind,
    * which do mean to end that work. It is the wrong question for dispatching a
-   * prompt: only a foreground turn is something a new prompt has to replace.
+   * prompt, because replacement cancels the session and takes that background
+   * work with it.
+   *
+   * A foreground turn always has to be replaced. An autonomous run only has to
+   * be when the provider cannot open a foreground turn beside it.
    */
-  hasInFlightForegroundRun(agentId: string): boolean {
+  promptRequiresRunReplacement(agentId: string): boolean {
     const agent = this.agents.get(agentId);
     if (!agent) {
       return false;
     }
 
-    return Boolean(agent.activeForegroundTurnId) || this.runs.hasForegroundRun(agentId);
+    if (agent.activeForegroundTurnId || this.runs.hasForegroundRun(agentId)) {
+      return true;
+    }
+
+    return this.runs.hasRun(agentId) && !agent.session.acceptsPromptDuringAutonomousTurn;
   }
 
   subscribe(callback: AgentSubscriber, options?: SubscribeOptions): () => void {
@@ -2148,10 +2156,11 @@ export class AgentManager {
       },
       "agent.manager.stream.request",
     );
-    // Only a foreground turn conflicts. An autonomous run means the provider is
-    // still emitting for background work it owns; a new prompt opens a turn
-    // alongside it rather than being refused.
-    if (existingAgent.activeForegroundTurnId || this.runs.hasForegroundRun(agentId)) {
+    // An autonomous run does not conflict on a provider that can open a
+    // foreground turn beside its own background work. Where it does conflict,
+    // reject here rather than letting the provider throw from startTurn, which
+    // would fail the turn and drop the autonomous run this agent still has.
+    if (this.promptRequiresRunReplacement(agentId)) {
       this.logger.trace(
         {
           agentId,

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -836,30 +836,16 @@ export class AgentManager {
     );
   }
 
-  /**
-   * Whether a new prompt has to replace the run in flight.
-   *
-   * `hasInFlightRun` also counts autonomous runs, background provider work such
-   * as a Claude background subagent, which keeps the agent `running` while its
-   * own turn is over. That is the right question for Stop, reload, and rewind,
-   * which do mean to end that work. It is the wrong question for dispatching a
-   * prompt, because replacement cancels the session and takes that background
-   * work with it.
-   *
-   * A foreground turn always has to be replaced. An autonomous run only has to
-   * be when the provider cannot open a foreground turn beside it.
-   */
   promptRequiresRunReplacement(agentId: string): boolean {
     const agent = this.agents.get(agentId);
     if (!agent) {
       return false;
     }
-
-    if (agent.activeForegroundTurnId || this.runs.hasForegroundRun(agentId)) {
-      return true;
+    if (!agent.session.acceptsPromptDuringAutonomousTurn) {
+      return this.hasInFlightRun(agentId);
     }
 
-    return this.runs.hasRun(agentId) && !agent.session.acceptsPromptDuringAutonomousTurn;
+    return Boolean(agent.activeForegroundTurnId) || this.runs.hasForegroundRun(agentId);
   }
 
   subscribe(callback: AgentSubscriber, options?: SubscribeOptions): () => void {
@@ -2156,11 +2142,11 @@ export class AgentManager {
       },
       "agent.manager.stream.request",
     );
-    // An autonomous run does not conflict on a provider that can open a
-    // foreground turn beside its own background work. Where it does conflict,
-    // reject here rather than letting the provider throw from startTurn, which
-    // would fail the turn and drop the autonomous run this agent still has.
-    if (this.promptRequiresRunReplacement(agentId)) {
+    if (
+      existingAgent.activeForegroundTurnId ||
+      this.runs.hasForegroundRun(agentId) ||
+      (this.runs.hasRun(agentId) && !existingAgent.session.acceptsPromptDuringAutonomousTurn)
+    ) {
       this.logger.trace(
         {
           agentId,

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -836,7 +836,7 @@ export class AgentManager {
     );
   }
 
-  promptRequiresRunReplacement(agentId: string): boolean {
+  hasBlockingRun(agentId: string): boolean {
     const agent = this.agents.get(agentId);
     if (!agent) {
       return false;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -836,6 +836,24 @@ export class AgentManager {
     );
   }
 
+  /**
+   * Whether a foreground turn owns the session right now.
+   *
+   * `hasInFlightRun` also counts autonomous runs — background provider work such
+   * as a Claude background subagent, which keeps the agent `running` while its
+   * own turn is over. That is the right question for Stop, reload, and rewind,
+   * which do mean to end that work. It is the wrong question for dispatching a
+   * prompt: only a foreground turn is something a new prompt has to replace.
+   */
+  hasInFlightForegroundRun(agentId: string): boolean {
+    const agent = this.agents.get(agentId);
+    if (!agent) {
+      return false;
+    }
+
+    return Boolean(agent.activeForegroundTurnId) || this.runs.hasForegroundRun(agentId);
+  }
+
   subscribe(callback: AgentSubscriber, options?: SubscribeOptions): () => void {
     const targetAgentId =
       options?.agentId == null ? null : validateAgentId(options.agentId, "subscribe");
@@ -2130,7 +2148,10 @@ export class AgentManager {
       },
       "agent.manager.stream.request",
     );
-    if (existingAgent.activeForegroundTurnId || this.runs.hasRun(agentId)) {
+    // Only a foreground turn conflicts. An autonomous run means the provider is
+    // still emitting for background work it owns; a new prompt opens a turn
+    // alongside it rather than being refused.
+    if (existingAgent.activeForegroundTurnId || this.runs.hasForegroundRun(agentId)) {
       this.logger.trace(
         {
           agentId,

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -96,9 +96,7 @@ function createFinishNotificationScenario(
     return options?.childLastAssistantMessage ?? null;
   });
   Reflect.set(agentManager, "tryRunOutOfBand", () => false);
-  Reflect.set(agentManager, "promptRequiresRunReplacement", () =>
-    Boolean(options?.parentPromptError),
-  );
+  Reflect.set(agentManager, "hasBlockingRun", () => Boolean(options?.parentPromptError));
   Reflect.set(agentManager, "streamAgent", (_agentId: string, prompt: string) => {
     parentPrompted = true;
     parentPrompts.push(prompt);
@@ -260,7 +258,7 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
     vi.fn(() => agent),
   );
   Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
-  Reflect.set(agentManager, "promptRequiresRunReplacement", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasBlockingRun", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
 
   const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
@@ -513,7 +511,7 @@ it("does not notify archived callers", async () => {
       };
     }),
   );
-  Reflect.set(agentManager, "promptRequiresRunReplacement", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasBlockingRun", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
   Reflect.set(agentManager, "replaceAgentRun", replaceAgentRunSpy);
 

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -96,7 +96,7 @@ function createFinishNotificationScenario(
     return options?.childLastAssistantMessage ?? null;
   });
   Reflect.set(agentManager, "tryRunOutOfBand", () => false);
-  Reflect.set(agentManager, "hasInFlightRun", () => Boolean(options?.parentPromptError));
+  Reflect.set(agentManager, "hasInFlightForegroundRun", () => Boolean(options?.parentPromptError));
   Reflect.set(agentManager, "streamAgent", (_agentId: string, prompt: string) => {
     parentPrompted = true;
     parentPrompts.push(prompt);
@@ -258,7 +258,7 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
     vi.fn(() => agent),
   );
   Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
-  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightForegroundRun", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
 
   const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
@@ -511,7 +511,7 @@ it("does not notify archived callers", async () => {
       };
     }),
   );
-  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightForegroundRun", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
   Reflect.set(agentManager, "replaceAgentRun", replaceAgentRunSpy);
 

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -96,7 +96,9 @@ function createFinishNotificationScenario(
     return options?.childLastAssistantMessage ?? null;
   });
   Reflect.set(agentManager, "tryRunOutOfBand", () => false);
-  Reflect.set(agentManager, "hasInFlightForegroundRun", () => Boolean(options?.parentPromptError));
+  Reflect.set(agentManager, "promptRequiresRunReplacement", () =>
+    Boolean(options?.parentPromptError),
+  );
   Reflect.set(agentManager, "streamAgent", (_agentId: string, prompt: string) => {
     parentPrompted = true;
     parentPrompts.push(prompt);
@@ -258,7 +260,7 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
     vi.fn(() => agent),
   );
   Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
-  Reflect.set(agentManager, "hasInFlightForegroundRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "promptRequiresRunReplacement", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
 
   const agentStorage: AgentStorage = Object.create(AgentStorage.prototype);
@@ -511,7 +513,7 @@ it("does not notify archived callers", async () => {
       };
     }),
   );
-  Reflect.set(agentManager, "hasInFlightForegroundRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "promptRequiresRunReplacement", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
   Reflect.set(agentManager, "replaceAgentRun", replaceAgentRunSpy);
 

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -14,11 +14,7 @@ export type AgentUnarchiveController = Pick<AgentManager, "notifyAgentState" | "
 
 export type AgentRunController = Pick<
   AgentManager,
-  | "getAgent"
-  | "tryRunOutOfBand"
-  | "promptRequiresRunReplacement"
-  | "replaceAgentRun"
-  | "streamAgent"
+  "getAgent" | "tryRunOutOfBand" | "hasBlockingRun" | "replaceAgentRun" | "streamAgent"
 >;
 
 export interface StartAgentRunOptions {
@@ -52,9 +48,7 @@ export async function startAgentRun(
   if (agentManager.tryRunOutOfBand(agentId, prompt, options?.runOptions)) {
     return { outOfBand: true };
   }
-  const shouldReplace = Boolean(
-    options?.replaceRunning && agentManager.promptRequiresRunReplacement(agentId),
-  );
+  const shouldReplace = Boolean(options?.replaceRunning && agentManager.hasBlockingRun(agentId));
   const runOptions = options?.runOptions;
   const iterator = shouldReplace
     ? await agentManager.replaceAgentRun(agentId, prompt, runOptions)

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -14,7 +14,11 @@ export type AgentUnarchiveController = Pick<AgentManager, "notifyAgentState" | "
 
 export type AgentRunController = Pick<
   AgentManager,
-  "getAgent" | "tryRunOutOfBand" | "hasInFlightForegroundRun" | "replaceAgentRun" | "streamAgent"
+  | "getAgent"
+  | "tryRunOutOfBand"
+  | "promptRequiresRunReplacement"
+  | "replaceAgentRun"
+  | "streamAgent"
 >;
 
 export interface StartAgentRunOptions {
@@ -50,11 +54,11 @@ export async function startAgentRun(
   }
   // Replacement cancels the provider's turn, and for Claude that cancel is the
   // SDK's stop-everything interrupt: it terminates the session's background
-  // subagents too. Only replace when a foreground turn actually holds the
-  // session — an agent that is `running` purely because a background subagent
-  // is streaming has nothing to replace.
+  // subagents too. An agent that is `running` only because a background
+  // subagent is streaming has nothing worth replacing, so ask the manager
+  // rather than treating every running agent as busy.
   const shouldReplace = Boolean(
-    options?.replaceRunning && agentManager.hasInFlightForegroundRun(agentId),
+    options?.replaceRunning && agentManager.promptRequiresRunReplacement(agentId),
   );
   const runOptions = options?.runOptions;
   const iterator = shouldReplace

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -14,7 +14,7 @@ export type AgentUnarchiveController = Pick<AgentManager, "notifyAgentState" | "
 
 export type AgentRunController = Pick<
   AgentManager,
-  "getAgent" | "tryRunOutOfBand" | "hasInFlightRun" | "replaceAgentRun" | "streamAgent"
+  "getAgent" | "tryRunOutOfBand" | "hasInFlightForegroundRun" | "replaceAgentRun" | "streamAgent"
 >;
 
 export interface StartAgentRunOptions {
@@ -48,7 +48,14 @@ export async function startAgentRun(
   if (agentManager.tryRunOutOfBand(agentId, prompt, options?.runOptions)) {
     return { outOfBand: true };
   }
-  const shouldReplace = Boolean(options?.replaceRunning && agentManager.hasInFlightRun(agentId));
+  // Replacement cancels the provider's turn, and for Claude that cancel is the
+  // SDK's stop-everything interrupt: it terminates the session's background
+  // subagents too. Only replace when a foreground turn actually holds the
+  // session — an agent that is `running` purely because a background subagent
+  // is streaming has nothing to replace.
+  const shouldReplace = Boolean(
+    options?.replaceRunning && agentManager.hasInFlightForegroundRun(agentId),
+  );
   const runOptions = options?.runOptions;
   const iterator = shouldReplace
     ? await agentManager.replaceAgentRun(agentId, prompt, runOptions)

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -52,11 +52,6 @@ export async function startAgentRun(
   if (agentManager.tryRunOutOfBand(agentId, prompt, options?.runOptions)) {
     return { outOfBand: true };
   }
-  // Replacement cancels the provider's turn, and for Claude that cancel is the
-  // SDK's stop-everything interrupt: it terminates the session's background
-  // subagents too. An agent that is `running` only because a background
-  // subagent is streaming has nothing worth replacing, so ask the manager
-  // rather than treating every running agent as busy.
   const shouldReplace = Boolean(
     options?.replaceRunning && agentManager.promptRequiresRunReplacement(agentId),
   );

--- a/packages/server/src/server/agent/agent-run-state.ts
+++ b/packages/server/src/server/agent/agent-run-state.ts
@@ -42,6 +42,14 @@ export class AgentRunState {
   private readonly runs = new Map<string, TrackedAgentRun>();
 
   createPendingRun(agentId: string): PendingForegroundRun {
+    // A foreground turn supersedes background provider work, and one agent holds
+    // one run. Settle the autonomous run on the way out instead of dropping it
+    // from the map: an in-flight cancel awaits its settledPromise and would
+    // otherwise wait for the rescue timeout on a run nothing can terminate.
+    const superseded = this.runs.get(agentId);
+    if (superseded?.kind === "autonomous") {
+      this.clearRun(agentId, superseded);
+    }
     const pendingRun = createPendingForegroundRun();
     this.runs.set(agentId, pendingRun);
     return pendingRun;
@@ -62,6 +70,10 @@ export class AgentRunState {
 
   hasRun(agentId: string): boolean {
     return this.runs.has(agentId);
+  }
+
+  hasForegroundRun(agentId: string): boolean {
+    return this.runs.get(agentId)?.kind === "foreground";
   }
 
   trackAutonomousRun(agentId: string, turnId: string | null): TrackedAgentRun {

--- a/packages/server/src/server/agent/agent-run-state.ts
+++ b/packages/server/src/server/agent/agent-run-state.ts
@@ -42,10 +42,6 @@ export class AgentRunState {
   private readonly runs = new Map<string, TrackedAgentRun>();
 
   createPendingRun(agentId: string): PendingForegroundRun {
-    // A foreground turn supersedes background provider work, and one agent holds
-    // one run. Settle the autonomous run on the way out instead of dropping it
-    // from the map: an in-flight cancel awaits its settledPromise and would
-    // otherwise wait for the rescue timeout on a run nothing can terminate.
     const superseded = this.runs.get(agentId);
     if (superseded?.kind === "autonomous") {
       this.clearRun(agentId, superseded);

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -627,6 +627,16 @@ export interface AgentSession {
   readonly id: string | null;
   readonly capabilities: AgentCapabilityFlags;
   readonly features?: AgentFeature[];
+  /**
+   * Whether `startTurn` may open a foreground turn while the session is running
+   * an autonomous turn of its own. Claude does: its background subagents run
+   * beside a foreground turn, and `startTurn` completes the autonomous turn on
+   * the way in. OpenCode does not: `startTurn` throws while its runner is
+   * active, so the manager has to cancel that turn before prompting.
+   *
+   * Defaults to false, which keeps the cancel-then-prompt path.
+   */
+  readonly acceptsPromptDuringAutonomousTurn?: boolean;
   run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult>;
   startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<{ turnId: string }>;
   subscribe(callback: (event: AgentStreamEvent) => void): () => void;

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -627,15 +627,6 @@ export interface AgentSession {
   readonly id: string | null;
   readonly capabilities: AgentCapabilityFlags;
   readonly features?: AgentFeature[];
-  /**
-   * Whether `startTurn` may open a foreground turn while the session is running
-   * an autonomous turn of its own. Claude does: its background subagents run
-   * beside a foreground turn, and `startTurn` completes the autonomous turn on
-   * the way in. OpenCode does not: `startTurn` throws while its runner is
-   * active, so the manager has to cancel that turn before prompting.
-   *
-   * Defaults to false, which keeps the cancel-then-prompt path.
-   */
   readonly acceptsPromptDuringAutonomousTurn?: boolean;
   run(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<AgentRunResult>;
   startTurn(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<{ turnId: string }>;

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -219,6 +219,7 @@ function buildAgentManagerSpies() {
     appendTimelineItem: vi.fn().mockResolvedValue(undefined),
     emitLiveTimelineItem: vi.fn().mockResolvedValue(undefined),
     hasInFlightRun: vi.fn().mockReturnValue(false),
+    hasInFlightForegroundRun: vi.fn().mockReturnValue(false),
     tryRunOutOfBand: vi.fn().mockReturnValue(false),
     subscribe: vi.fn().mockReturnValue(() => {}),
     streamAgent: vi.fn(() => (async function* noop() {})()),

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -219,7 +219,7 @@ function buildAgentManagerSpies() {
     appendTimelineItem: vi.fn().mockResolvedValue(undefined),
     emitLiveTimelineItem: vi.fn().mockResolvedValue(undefined),
     hasInFlightRun: vi.fn().mockReturnValue(false),
-    promptRequiresRunReplacement: vi.fn().mockReturnValue(false),
+    hasBlockingRun: vi.fn().mockReturnValue(false),
     tryRunOutOfBand: vi.fn().mockReturnValue(false),
     subscribe: vi.fn().mockReturnValue(() => {}),
     streamAgent: vi.fn(() => (async function* noop() {})()),

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -219,7 +219,7 @@ function buildAgentManagerSpies() {
     appendTimelineItem: vi.fn().mockResolvedValue(undefined),
     emitLiveTimelineItem: vi.fn().mockResolvedValue(undefined),
     hasInFlightRun: vi.fn().mockReturnValue(false),
-    hasInFlightForegroundRun: vi.fn().mockReturnValue(false),
+    promptRequiresRunReplacement: vi.fn().mockReturnValue(false),
     tryRunOutOfBand: vi.fn().mockReturnValue(false),
     subscribe: vi.fn().mockReturnValue(() => {}),
     streamAgent: vi.fn(() => (async function* noop() {})()),

--- a/packages/server/src/server/agent/permission-response.test.ts
+++ b/packages/server/src/server/agent/permission-response.test.ts
@@ -40,7 +40,7 @@ class FakePermissionAgentManager {
     return undefined;
   }
 
-  hasInFlightRun(): boolean {
+  hasInFlightForegroundRun(): boolean {
     return this.hasRunInFlight;
   }
 

--- a/packages/server/src/server/agent/permission-response.test.ts
+++ b/packages/server/src/server/agent/permission-response.test.ts
@@ -40,7 +40,7 @@ class FakePermissionAgentManager {
     return undefined;
   }
 
-  hasInFlightForegroundRun(): boolean {
+  promptRequiresRunReplacement(): boolean {
     return this.hasRunInFlight;
   }
 

--- a/packages/server/src/server/agent/permission-response.test.ts
+++ b/packages/server/src/server/agent/permission-response.test.ts
@@ -12,7 +12,7 @@ import { respondToAgentPermission } from "./permission-response.js";
 
 class FakePermissionAgentManager {
   permissionResult: AgentPermissionResult | void;
-  hasRunInFlight = false;
+  blockingRun = false;
   outOfBandHandled = false;
   permissionResponses: Array<{
     agentId: string;
@@ -40,8 +40,8 @@ class FakePermissionAgentManager {
     return undefined;
   }
 
-  promptRequiresRunReplacement(): boolean {
-    return this.hasRunInFlight;
+  hasBlockingRun(): boolean {
+    return this.blockingRun;
   }
 
   streamAgent(
@@ -120,7 +120,7 @@ describe("respondToAgentPermission", () => {
 
   test("replaces an in-flight run for follow-up prompts", async () => {
     const agentManager = new FakePermissionAgentManager();
-    agentManager.hasRunInFlight = true;
+    agentManager.blockingRun = true;
     agentManager.permissionResult = { followUpPrompt: "continue after approval" };
 
     await respondToAgentPermission({

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2008,8 +2008,6 @@ class ClaudeContextUsageState {
 class ClaudeAgentSession implements AgentSession {
   readonly provider = "claude" as const;
   readonly capabilities = CLAUDE_CAPABILITIES;
-  // startTurn() completes the autonomous turn before pushing the prompt, so a
-  // foreground turn can open while background subagents keep streaming.
   readonly acceptsPromptDuringAutonomousTurn = true;
 
   private readonly config: ClaudeAgentConfig;

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2008,6 +2008,9 @@ class ClaudeContextUsageState {
 class ClaudeAgentSession implements AgentSession {
   readonly provider = "claude" as const;
   readonly capabilities = CLAUDE_CAPABILITIES;
+  // startTurn() completes the autonomous turn before pushing the prompt, so a
+  // foreground turn can open while background subagents keep streaming.
+  readonly acceptsPromptDuringAutonomousTurn = true;
 
   private readonly config: ClaudeAgentConfig;
   private readonly launchEnv?: Record<string, string>;


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

If an agent has a Claude background subagent running and you send it a message, the subagent gets killed:

```
{"success":false,"message":"Agent \"sleeper\" was stopped by the user and was not resumed.
 Treat its work as cancelled; only start a new agent for it if the user explicitly asks."}
```

Prompt dispatch checks `hasInFlightRun`, which is true whenever the agent is `running`. A background subagent keeps the parent `running` on an autonomous turn after the parent's own turn ends, so a normal follow-up gets dispatched as a replacement. Replacement cancels the provider turn, and on Claude that is `query.interrupt()`. The CLI treats that control request as stop everything and kills every running task in the session.

There's a second problem on the same path. The provider opens a new autonomous turn between the cancel and the new stream, so the prompt then gets refused with `already has an active run`, after the interrupt already fired. You lose the subagent and the message.

An autonomous run isn't something a prompt needs to replace.

### Goals

- Prompting an agent whose only active work is autonomous starts a turn instead of replacing one
- That prompt stops being refused with `already has an active run`
- Stop, reload and rewind keep using `hasInFlightRun`, so they still end background work
- A superseded autonomous run settles instead of being dropped, so a cancel waiting on it can't hang
- Providers opt in with `acceptsPromptDuringAutonomousTurn`. Only Claude sets it, because its `startTurn` completes the autonomous turn on the way in. OpenCode's `startTurn` throws while its runner is active, so it keeps cancelling first

### Non-goals

- Sending during a live foreground turn still interrupts, and still kills subagents. Fixing that means queueing the message instead of interrupting, like the TUI does when you type mid-turn, and like the VS Code extension does (it enqueues onto the CLI input stream without checking turn state). That needs provider capability gating and a queued state in the composer, so it's a separate PR.
- No change to `hasInFlightRun`, Stop, reload, rewind or the schedule service.
- macOS only.

### QA

macOS 15 arm64, Node 22, Claude Code 2.1.221, claude/claude-opus-5.

Before, on Paseo desktop 0.3.1. The agent spawns a background `sleeper` and finishes its own turn, but still reports `running` with `activeTurn: {"turnId":"autonomous-turn-2"}`. Sending a follow-up:

```
Error: Agent cf513290-45c4-4656-a4d9-7251db3312d5 already has an active run
```

Sending again works, and the agent's `SendMessage` to the subagent comes back:

```
{"success":false,"message":"Agent [id] was stopped by the user and won't be resumed. ..."}
```

To check this isn't just what interrupts do, same setup in the Claude Code TUI with no Paseo involved: spawn the subagent, start a foreground `sleep`, hit Esc. The shell stops, the subagent keeps running, and `SendMessage` returns:

```
{"success":true,"message":"Message sent to sleeper's inbox","msg_id":"56ab9233-3515-44d8-acf4-9de22577d02c"}
```

After, on a dev daemon built from this branch (`npm run dev`, port 6768):

```
$ npm run cli -- ls --json
  "status": "running"

$ npm run cli -- logs c70707f
  [Task]
  [Bash] sleep 400; echo ALIVE
  SPAWNED

$ npm run cli -- send c70707f "<ask it to message the sleeper and paste the result>"
  c70707f1-60f3-43de-8f63-248743089b65  completed   Agent completed processing the message

$ npm run cli -- logs c70707f
  {"success":true,"message":"Message queued for delivery to sleeper at its next tool round."}
```

Accepted first try, no interrupt, subagent still alive.

Tests:

```
agent-manager, agent-prompt, lifecycle-command, permission-response,
  mcp-server, create-agent, stream-coalescing               335 passed
session, session.workspaces, schedule/service, messages,
  claude subagent-interrupt, claude background-subagent,
  opencode-agent, agent-loading, agent-archive              423 passed, 4 skipped
```

Two tests, both of which push an autonomous `turn_started` and then dispatch through `startAgentRun(..., { replaceRunning: true })`.

The first uses a provider that accepts a prompt during an autonomous turn and checks the session was never interrupted. Reverting the source makes it fail on the interrupt count:

```
AssertionError: expected 1 to be +0
```

The second uses a provider whose `startTurn` throws while its autonomous turn is live, the OpenCode shape, and checks the manager still cancels first. Dropping the opt-in makes it fail the same way, from the other side:

```
AssertionError: expected +0 to be 1
```

Test doubles updated for the renamed `AgentRunController` member.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
