### PR TITLE
feat(server): add durable workspace lifecycle owner

### DIFF
--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -75,6 +75,10 @@ import {
   type ProviderSubagentDescriptor,
   type ProviderSubagentStoreEvent,
 } from "./provider-subagents/store.js";
+import type {
+  WorkspaceLifecycleAdmission,
+  WorkspaceLifecycleOperationOwner,
+} from "../workspace-lifecycle-operation-service.js";
 
 const RELOAD_SESSION_CLOSE_TIMEOUT_MS = 3_000;
 const INTERRUPT_SESSION_TIMEOUT_MS = 2_000;
@@ -1094,12 +1098,47 @@ export class AgentManager {
     return this.providerSubagents.fetchTimeline(parentAgentId, subagentId, options);
   }
 
+  private workspaceLifecycleOperationsInstance: WorkspaceLifecycleOperationOwner | null = null;
+
+  /**
+   * The daemon-wide workspace lifecycle operation owner. The manager carries
+   * it so session and tool paths that already hold an AgentManager reference
+   * reach the single owner instance without new plumbing.
+   */
+  get workspaceLifecycleOperations(): WorkspaceLifecycleOperationOwner | null {
+    return this.workspaceLifecycleOperationsInstance;
+  }
+
+  setWorkspaceLifecycleOperations(operations: WorkspaceLifecycleOperationOwner): void {
+    this.workspaceLifecycleOperationsInstance = operations;
+  }
+
+  private withWorkspaceLifecycleAdmission<T>(
+    input: { workspaceId: string | undefined; cwd: string | undefined; actor: string },
+    action: () => Promise<T>,
+  ): Promise<T> {
+    const admission = this.workspaceLifecycleOperationsInstance;
+    if (!admission || !input.workspaceId) {
+      return action();
+    }
+    return withAgentWorkspaceLifecycleAdmission(
+      admission,
+      { workspaceId: input.workspaceId, cwd: input.cwd ?? "", actor: input.actor },
+      action,
+    );
+  }
+
   createAgent(
     config: AgentSessionConfig,
     agentId: string | undefined,
     options: CreateAgentOptions,
   ): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(this.createAgentInternal(config, agentId, options));
+    return this.trackAgentRegistrationOperation(
+      this.withWorkspaceLifecycleAdmission(
+        { workspaceId: options.workspaceId, cwd: config.cwd, actor: "agent:create" },
+        () => this.createAgentInternal(config, agentId, options),
+      ),
+    );
   }
 
   private async createAgentInternal(
@@ -1162,7 +1201,11 @@ export class AgentManager {
     resumeOptions?: AgentResumeSessionOptions,
   ): Promise<ManagedAgent> {
     return this.trackAgentRegistrationOperation(
-      this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      this.withWorkspaceLifecycleAdmission(
+        { workspaceId: options?.workspaceId, cwd: overrides?.cwd, actor: "agent:resume" },
+        () =>
+          this.resumeAgentFromPersistenceInternal(handle, overrides, agentId, options, resumeOptions),
+      ),
     );
   }
 
@@ -1225,7 +1268,12 @@ export class AgentManager {
     workspaceId: string;
     labels?: Record<string, string>;
   }): Promise<ManagedAgent> {
-    return this.trackAgentRegistrationOperation(this.importProviderSessionInternal(input));
+    return this.trackAgentRegistrationOperation(
+      this.withWorkspaceLifecycleAdmission(
+        { workspaceId: input.workspaceId, cwd: input.cwd, actor: "agent:import" },
+        () => this.importProviderSessionInternal(input),
+      ),
+    );
   }
 
   private async importProviderSessionInternal(input: {
@@ -4714,5 +4762,27 @@ export function commandMayHaveChangedExternalState(command: string): boolean {
     // Fetches update refs/remotes/ which our watchers do not watch, so
     // ahead/behind counts can drift stale until the next refresh.
     /\bgit\s+fetch\b/.test(normalized)
+  );
+}
+
+export interface AgentWorkspaceLifecycleAdmissionInput {
+  workspaceId: string;
+  cwd: string;
+  actor: string;
+}
+
+/**
+ * Runs an agent mutation under the workspace lifecycle owner's shared
+ * admission lease, so workspace removal cannot enter destructive mutation
+ * while the agent action is in flight.
+ */
+export async function withAgentWorkspaceLifecycleAdmission<T>(
+  admission: WorkspaceLifecycleAdmission,
+  input: AgentWorkspaceLifecycleAdmissionInput,
+  action: () => Promise<T>,
+): Promise<T> {
+  return admission.withSharedAdmission(
+    { resourceKey: `workspace:${input.workspaceId}`, actor: input.actor },
+    action,
   );
 }

--- a/packages/server/src/server/agent/create-agent-lifecycle-dispatch.ts
+++ b/packages/server/src/server/agent/create-agent-lifecycle-dispatch.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from "node:crypto";
 import type pino from "pino";
 
 import type { ForgeService } from "../../services/forge-service.js";
 import { isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
 import { archiveByScope, type ActiveWorkspaceRef } from "../workspace-archive-service.js";
+import { resolveWorkspaceLifecycleOperationOwner } from "../workspace-lifecycle-operation-service.js";
 import type {
   CreatePaseoWorktreeWorkflowFn,
   CreatePaseoWorktreeWorkflowResult,
@@ -62,6 +62,7 @@ export class CreateAgentLifecycleDispatch {
     target: CreateAgentWorktreeTarget | undefined;
     firstAgentContext: FirstAgentContext;
     hasLegacyGitOptions: boolean;
+    requestId: string;
   }): Promise<CreatePaseoWorktreeWorkflowResult | null> {
     if (input.target && input.hasLegacyGitOptions) {
       throw new Error("create_agent_request worktree cannot be combined with git options");
@@ -70,7 +71,12 @@ export class CreateAgentLifecycleDispatch {
       return null;
     }
 
-    return this.createWorktreeForTarget(input.cwd, input.target, input.firstAgentContext);
+    return this.createWorktreeForTarget(
+      input.cwd,
+      input.target,
+      input.firstAgentContext,
+      input.requestId,
+    );
   }
 
   registerAutoArchiveIfRequested(input: {
@@ -115,6 +121,7 @@ export class CreateAgentLifecycleDispatch {
     cwd: string,
     target: CreateAgentWorktreeTarget,
     firstAgentContext: FirstAgentContext,
+    requestId: string,
   ): Promise<CreatePaseoWorktreeWorkflowResult> {
     const baseInput = {
       cwd,
@@ -122,6 +129,8 @@ export class CreateAgentLifecycleDispatch {
       runSetup: false,
       paseoHome: this.dependencies.paseoHome,
       worktreesRoot: this.dependencies.worktreesRoot,
+      // The create_agent requestId is the durable create identity.
+      lifecycleOperationId: `create-agent-worktree:${requestId}`,
     } as const;
 
     switch (target.mode) {
@@ -213,11 +222,14 @@ export class CreateAgentLifecycleDispatch {
         markWorkspaceArchiving: this.dependencies.markWorkspaceArchiving,
         clearWorkspaceArchiving: this.dependencies.clearWorkspaceArchiving,
         killTerminalsForWorkspace: this.dependencies.killTerminalsForWorkspace,
+        lifecycle: resolveWorkspaceLifecycleOperationOwner(this.dependencies.agentManager),
         sessionLogger: this.dependencies.logger,
       },
       {
         scope: { kind: "workspace", workspaceId: createdWorktree.workspace.workspaceId },
-        requestId: randomUUID(),
+        // Durable per created worktree: retiring the same auto-created
+        // workspace twice replays the committed result instead of re-running.
+        requestId: `create-agent-auto-archive:${createdWorktree.workspace.workspaceId}`,
       },
     );
 

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -115,6 +115,11 @@ export interface CreateAgentFromMcpInput {
     action?: "branch-off" | "checkout";
     githubPrNumber?: number;
   };
+  /**
+   * Durable identity of the originating request, carried into any worktree
+   * this create provisions. Required by the workspace lifecycle owner.
+   */
+  lifecycleOperationId?: string;
 }
 
 export type CreateAgentCommandInput = CreateAgentFromSessionInput | CreateAgentFromMcpInput;
@@ -315,6 +320,7 @@ async function resolveMcpCreateAgent(
       cwd,
       worktree: input.worktree,
       initialPrompt: input.initialPrompt ?? "",
+      lifecycleOperationId: input.lifecycleOperationId,
     });
   if (createdWorktree) input.onWorktreeCreated?.(createdWorktree);
 
@@ -507,6 +513,7 @@ async function resolveMcpCwd(params: {
   cwd: string;
   initialPrompt: string;
   worktree: CreateAgentFromMcpInput["worktree"];
+  lifecycleOperationId: string | undefined;
 }): Promise<{
   resolvedCwd: string;
   setupContinuation?: AgentWorktreeSetupContinuation;
@@ -545,6 +552,7 @@ async function resolveMcpCwd(params: {
       runSetup: false,
       paseoHome: dependencies.paseoHome,
       worktreesRoot: dependencies.worktreesRoot,
+      lifecycleOperationId: params.lifecycleOperationId,
     },
     createPaseoWorktree: dependencies.createPaseoWorktree,
     resolveDefaultBranch: baseBranch ? async () => baseBranch : undefined,

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -58,6 +58,14 @@ import type { BrowserToolsBroker, BrowserToolsExecuteInput } from "../browser-to
 import type { BrowserToolsResponsePayload } from "../browser-tools/errors.js";
 import { readPaseoWorktreeMetadata } from "../../utils/worktree-metadata.js";
 import { createWorkspaceProvisioningService } from "../session/workspace-provisioning/workspace-provisioning-service.js";
+import { existsSync, mkdirSync, mkdtempSync } from "node:fs";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import type { AgentMcpServerOptions } from "./mcp-server.js";
+import { createWorktree } from "../../utils/worktree.js";
+import type { ActiveWorkspaceRef } from "../workspace-archive-service.js";
+import { PaseoWorkspaceLifecycleOperationService } from "../workspace-lifecycle-operation-service.js";
+import { FileBackedWorkspaceLifecycleOperationStore } from "../workspace-lifecycle-operation-store.js";
+import { createPaseoToolCatalog } from "./tools/paseo-tools.js";
 
 const REPO_CWD = resolvePath("/tmp/repo");
 const TARGET_CWD = resolvePath("/tmp/target");
@@ -5831,4 +5839,293 @@ describe("agent snapshot MCP serialization", () => {
     expect(content).not.toContain("second answer");
     expect(content).not.toContain("first answer");
   });
+});
+
+function createLifecycleGitRepo(): { tempDir: string; repoDir: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), "mcp-server-lifecycle-"));
+  const repoDir = join(tempDir, "repo");
+  mkdirSync(repoDir, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoDir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@getpaseo.local"], {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+  execFileSync("git", ["config", "user.name", "Paseo Test"], { cwd: repoDir, stdio: "pipe" });
+  execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "initial"], {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+  return { tempDir, repoDir };
+}
+
+interface LifecycleJsonRpcResponse {
+  id?: string | number;
+  result?: {
+    structuredContent?: Record<string, unknown>;
+    isError?: boolean;
+    content?: Array<{ type: string; text?: string }>;
+  };
+  error?: { message?: string };
+}
+
+interface LifecycleMcpClient {
+  call: (id: string | number, name: string, args: unknown) => Promise<LifecycleJsonRpcResponse>;
+  close: () => Promise<void>;
+}
+
+// Drives the real createAgentMcpServer over a linked in-memory transport with
+// hand-built JSON-RPC frames, so the exact wire-level request id types and the
+// transport session id reach the registered tool handlers.
+async function connectLifecycleMcp(
+  options: AgentMcpServerOptions,
+  sessionId?: string,
+): Promise<LifecycleMcpClient> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  if (sessionId !== undefined) {
+    serverTransport.sessionId = sessionId;
+  }
+  const server = await createAgentMcpServer(options);
+  const pending = new Map<string | number, (message: LifecycleJsonRpcResponse) => void>();
+  Object.assign(clientTransport, {
+    onmessage: (message: JSONRPCMessage) => {
+      const response = message as LifecycleJsonRpcResponse;
+      if (response.id !== undefined) {
+        pending.get(response.id)?.(response);
+        pending.delete(response.id);
+      }
+    },
+  });
+  await server.connect(serverTransport);
+  await clientTransport.start();
+
+  const request = (id: string | number, method: string, params: unknown) =>
+    new Promise<LifecycleJsonRpcResponse>((resolve) => {
+      pending.set(id, resolve);
+      void clientTransport.send({ jsonrpc: "2.0", id, method, params } as JSONRPCMessage);
+    });
+
+  await request("init", "initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "lifecycle-identity-test", version: "0.0.0" },
+  });
+  await clientTransport.send({
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+  } as JSONRPCMessage);
+
+  return {
+    call: (id, name, args) => request(id, "tools/call", { name, arguments: args }),
+    close: async () => {
+      // Deterministic teardown: closing the server closes its transport, and
+      // closing the client side releases the linked in-memory pair so the
+      // worker can exit naturally.
+      await server.close();
+      await clientTransport.close();
+    },
+  };
+}
+
+function createLifecycleToolOptions(paseoHome: string): {
+  options: AgentMcpServerOptions;
+  store: FileBackedWorkspaceLifecycleOperationStore;
+} {
+  const store = new FileBackedWorkspaceLifecycleOperationStore({
+    filePath: join(paseoHome, "workspace-lifecycle-operations.json"),
+    logger: createTestLogger(),
+  });
+  const lifecycle = new PaseoWorkspaceLifecycleOperationService({
+    store,
+    logger: createTestLogger(),
+  });
+  const agentManager = new AgentManager({ clients: {}, logger: createTestLogger() });
+  agentManager.setWorkspaceLifecycleOperations(lifecycle);
+  const options: AgentMcpServerOptions = {
+    agentManager,
+    agentStorage: new AgentStorage(join(paseoHome, "agents"), createTestLogger()),
+    // Only invalidate() is reachable through these tests.
+    github: { invalidate: () => {} } as unknown as ForgeService,
+    logger: createTestLogger(),
+    paseoHome,
+  };
+  return { options, store };
+}
+
+it("wire-level id types stay distinct archive identities and the same typed id replays", async () => {
+  const { tempDir, repoDir } = createLifecycleGitRepo();
+  let client: LifecycleMcpClient | undefined;
+  try {
+    const paseoHome = join(tempDir, ".paseo");
+    const slug = "mcp-wire-id";
+    const worktree = await createWorktree({
+      cwd: repoDir,
+      worktreeSlug: slug,
+      source: { kind: "branch-off", baseBranch: "main", branchName: slug },
+      runSetup: false,
+      paseoHome,
+    });
+    const recreateTargetWorktree = () =>
+      createWorktree({
+        cwd: repoDir,
+        worktreeSlug: slug,
+        source: { kind: "checkout-branch", branchName: slug },
+        runSetup: false,
+        paseoHome,
+      });
+    const workspaceRef: ActiveWorkspaceRef = {
+      workspaceId: "ws-mcp-wire",
+      cwd: worktree.worktreePath,
+      kind: "worktree",
+      worktreeRoot: worktree.worktreePath,
+      isPaseoOwnedWorktree: true,
+      mainRepoRoot: repoDir,
+    };
+
+    const { options, store } = createLifecycleToolOptions(paseoHome);
+    options.listActiveWorkspaces = async () => [workspaceRef];
+    options.findWorkspaceIdForCwd = async () => null;
+    options.archiveWorkspaceRecord = async () => {};
+    options.emitWorkspaceUpdatesForWorkspaceIds = async () => {};
+    options.markWorkspaceArchiving = () => {};
+    options.clearWorkspaceArchiving = () => {};
+    options.workspaceGitService = {
+      getSnapshot: async () => null,
+      listWorktrees: async () => [],
+      resolveRepoRoot: async () => repoDir,
+    } as unknown as AgentMcpServerOptions["workspaceGitService"];
+
+    client = await connectLifecycleMcp(options, "sess-wire");
+
+    const numeric = await client.call(1, "archive_workspace", { workspaceId: "ws-mcp-wire" });
+    expect(numeric.result?.structuredContent?.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(false);
+    const numericOperationId = "workspace-archive:mcp:archive_workspace:ws-mcp-wire:sess-wire:n:1";
+    expect((await store.get(numericOperationId))?.state).toBe("COMMITTED");
+
+    // The string id "1" is a different wire identity than the numeric id 1:
+    // it starts a fresh operation on the same target instead of replaying.
+    await recreateTargetWorktree();
+    const stringly = await client.call("1", "archive_workspace", { workspaceId: "ws-mcp-wire" });
+    expect(stringly.result?.structuredContent?.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(false);
+    const stringOperationId = "workspace-archive:mcp:archive_workspace:ws-mcp-wire:sess-wire:s:1";
+    const stringRecord = await store.get(stringOperationId);
+    expect(stringRecord?.state).toBe("COMMITTED");
+    expect(stringRecord?.generation).toBe(2);
+
+    // Retrying the exact same typed id replays the committed result without
+    // removing the directory again.
+    await recreateTargetWorktree();
+    const replayed = await client.call("1", "archive_workspace", { workspaceId: "ws-mcp-wire" });
+    expect(replayed.result?.structuredContent?.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(true);
+    expect(
+      (await store.findCurrentByResource(`worktree:${resolvePath(worktree.worktreePath)}`))
+        ?.generation,
+    ).toBe(2);
+  } finally {
+    await client?.close().catch(() => undefined);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+it("create_agent carries the exact session-scoped identity into worktree creation", async () => {
+  const { tempDir, repoDir } = createLifecycleGitRepo();
+  let client: LifecycleMcpClient | undefined;
+  try {
+    const paseoHome = join(tempDir, ".paseo");
+    const { options } = createLifecycleToolOptions(paseoHome);
+    const capturedCreatePaseoWorktree = vi.fn(async () => {
+      throw new Error("stop after capture");
+    });
+    options.createPaseoWorktree = capturedCreatePaseoWorktree;
+    options.ensureWorkspaceForCreate = async () => "ws-created";
+    options.findWorkspaceIdForCwd = async () => null;
+    options.listActiveWorkspaces = async () => [];
+
+    client = await connectLifecycleMcp(options, "sess-create");
+
+    const response = await client.call(7, "create_agent", {
+      provider: "codex/gpt-5.4",
+      title: "Lifecycle identity capture",
+      initialPrompt: "capture the id",
+      cwd: repoDir,
+      worktreeName: "wt-identity",
+      baseBranch: "main",
+    });
+
+    expect(capturedCreatePaseoWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeSlug: "wt-identity",
+        lifecycleOperationId: "mcp-create-agent:sess-create:n:7",
+      }),
+      expect.anything(),
+    );
+    expect(JSON.stringify(response)).toContain("stop after capture");
+  } finally {
+    await client?.close().catch(() => undefined);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+it("create_workspace carries the exact session-scoped identity into worktree creation", async () => {
+  const { tempDir, repoDir } = createLifecycleGitRepo();
+  let client: LifecycleMcpClient | undefined;
+  try {
+    const paseoHome = join(tempDir, ".paseo");
+    const { options } = createLifecycleToolOptions(paseoHome);
+    const capturedCreatePaseoWorktree = vi.fn(async () => {
+      throw new Error("stop after capture");
+    });
+    options.createPaseoWorktree = capturedCreatePaseoWorktree;
+
+    client = await connectLifecycleMcp(options, "sess-ws");
+
+    const response = await client.call(9, "create_workspace", {
+      isolation: "worktree",
+      path: repoDir,
+      worktreeSlug: "ws-identity",
+      baseBranch: "main",
+    });
+
+    expect(capturedCreatePaseoWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeSlug: "ws-identity",
+        lifecycleOperationId: "mcp-create-workspace:sess-ws:n:9",
+      }),
+    );
+    expect(JSON.stringify(response)).toContain("stop after capture");
+  } finally {
+    await client?.close().catch(() => undefined);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+it("create_workspace fails closed without a per-call id under the lifecycle owner", async () => {
+  const { tempDir, repoDir } = createLifecycleGitRepo();
+  try {
+    const paseoHome = join(tempDir, ".paseo");
+    const { options } = createLifecycleToolOptions(paseoHome);
+    const capturedCreatePaseoWorktree = vi.fn(async () => {
+      throw new Error("should not be reached");
+    });
+    options.createPaseoWorktree = capturedCreatePaseoWorktree;
+    const catalog = await createPaseoToolCatalog(options);
+
+    await expect(
+      catalog.executeTool(
+        "create_workspace",
+        {
+          isolation: "worktree",
+          path: repoDir,
+          worktreeSlug: "ws-no-identity",
+          baseBranch: "main",
+        },
+        {},
+      ),
+    ).rejects.toThrow(/per-call MCP request id/);
+    expect(capturedCreatePaseoWorktree).not.toHaveBeenCalled();
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });

--- a/packages/server/src/server/agent/mcp-server.ts
+++ b/packages/server/src/server/agent/mcp-server.ts
@@ -14,6 +14,16 @@ export type AgentMcpServerOptions = PaseoToolHostDependencies;
 
 type McpToolContext = RequestHandlerExtra<ServerRequest, ServerNotification>;
 
+// Type-tagged so the numeric JSON-RPC id 1 and the string id "1" stay
+// distinct lifecycle identities; the tag prefix keeps any string content
+// collision-safe against the numeric encoding.
+function normalizeMcpRequestId(requestId: string | number | undefined): string | undefined {
+  if (requestId === undefined) {
+    return undefined;
+  }
+  return typeof requestId === "number" ? `n:${requestId}` : `s:${requestId}`;
+}
+
 function toMcpToolResult(result: PaseoToolResult): CallToolResult {
   const modelVisibleResult = addModelVisibleStructuredContent(result);
   return {
@@ -44,7 +54,13 @@ export async function createAgentMcpServer(options: AgentMcpServerOptions): Prom
         inputSchema: tool.inputSchema,
       },
       async (args: unknown, context?: McpToolContext) =>
-        toMcpToolResult(await catalog.executeTool(tool.name, args, { signal: context?.signal })),
+        toMcpToolResult(
+          await catalog.executeTool(tool.name, args, {
+            signal: context?.signal,
+            requestId: normalizeMcpRequestId(context?.requestId),
+            sessionId: context?.sessionId,
+          }),
+        ),
     );
   }
 

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -31,6 +31,7 @@ import {
   requireActiveWorkspaceForArchive,
   type ArchiveDependencies,
 } from "../../workspace-archive-service.js";
+import { resolveWorkspaceLifecycleOperationOwner } from "../../workspace-lifecycle-operation-service.js";
 import { createAgentCommand, type CreateAgentFromMcpInput } from "../create-agent/create.js";
 import type { VoiceCallerContext, VoiceSpeakHandler } from "../../voice-types.js";
 import type { FirstAgentContext } from "../../messages.js";
@@ -1255,19 +1256,22 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       },
       outputSchema: WorkspaceAutomationSummarySchema.shape,
     },
-    async ({
-      isolation,
-      path,
-      projectId,
-      title,
-      mode,
-      worktreeSlug,
-      branchName,
-      baseBranch,
-      branch,
-      prNumber,
-      forge,
-    }) => {
+    async (
+      {
+        isolation,
+        path,
+        projectId,
+        title,
+        mode,
+        worktreeSlug,
+        branchName,
+        baseBranch,
+        branch,
+        prNumber,
+        forge,
+      },
+      context,
+    ) => {
       let workspace: PersistedWorkspaceRecord;
       if (isolation === "local") {
         const cwd = resolveScopedCwd(path, { required: true });
@@ -1296,6 +1300,12 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           }
           cwd = await resolveWorktreeSourceCwd({ projectId }, options.projectRegistry);
         }
+        const callIdentity = mcpToolCallIdentity(context);
+        if (callIdentity === undefined && resolveWorkspaceLifecycleOperationOwner(agentManager)) {
+          throw new Error(
+            "create_workspace requires a per-call MCP request id under the workspace lifecycle owner",
+          );
+        }
         const worktreeTarget = resolveWorkspaceWorktreeTarget({
           mode,
           worktreeSlug,
@@ -1317,6 +1327,11 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
             ...(worktreeSlug ? { worktreeSlug } : {}),
             ...worktreeTarget,
             ...(title ? { title } : {}),
+            // The session-scoped MCP request id is the durable identity of the
+            // worktree this call provisions.
+            ...(callIdentity !== undefined
+              ? { lifecycleOperationId: `mcp-create-workspace:${callIdentity}` }
+              : {}),
           },
         );
         if (!result.ok) {
@@ -1366,7 +1381,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         removedDirectory: z.boolean(),
       },
     },
-    async ({ workspaceId }) => {
+    async ({ workspaceId }, context) => {
       if (!options.listActiveWorkspaces) {
         throw new Error("Active workspace lister is required to archive workspaces");
       }
@@ -1374,6 +1389,12 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         { listActiveWorkspaces: options.listActiveWorkspaces },
         workspaceId,
       );
+      const callIdentity = mcpToolCallIdentity(context);
+      if (callIdentity === undefined && resolveWorkspaceLifecycleOperationOwner(agentManager)) {
+        throw new Error(
+          "archive_workspace requires a per-call MCP request id under the workspace lifecycle owner",
+        );
+      }
       const result = await archiveByScope(
         archiveWorktreeDependencies(options, {
           agentManager,
@@ -1382,7 +1403,10 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           logger: childLogger,
         }),
         {
-          requestId: "mcp:archive_workspace",
+          // The session-scoped MCP request id is the durable identity of this
+          // tool call: retrying the same call replays the committed result, a
+          // new call gets its own operation.
+          requestId: `mcp:archive_workspace:${workspace.workspaceId}:${callIdentity}`,
           scope: { kind: "workspace", workspaceId: workspace.workspaceId },
         },
       );
@@ -1417,9 +1441,10 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         guidance: z.string().optional(),
       },
     },
-    async (args: unknown) => {
+    async (args: unknown, context) => {
       const resolvedArgs = await resolveCreateAgentToolArgs(args);
       const { parsedArgs, worktree } = resolvedArgs;
+      const createCallIdentity = mcpToolCallIdentity(context);
       let requestedBackground: boolean;
       let notifyOnFinish: boolean;
       if (resolvedArgs.kind === "agent-scoped") {
@@ -1467,6 +1492,10 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           callerAgentId,
           callerContext,
           worktree,
+          // The session-scoped MCP request id is the durable identity for any
+          // worktree this create_agent call provisions.
+          lifecycleOperationId:
+            createCallIdentity !== undefined ? `mcp-create-agent:${createCallIdentity}` : undefined,
         },
       );
 
@@ -3163,6 +3192,19 @@ interface ArchiveWorktreeCommandContext {
   logger: Logger;
 }
 
+// The per-call identity for lifecycle operations started by an MCP tool call:
+// the type-tagged JSON-RPC request id, scoped by the transport session id when
+// the transport provides one. Without a session id, uniqueness holds only
+// within a single transport session.
+function mcpToolCallIdentity(context: PaseoToolExecutionContext): string | undefined {
+  if (context.requestId === undefined) {
+    return undefined;
+  }
+  return context.sessionId !== undefined
+    ? `${context.sessionId}:${context.requestId}`
+    : context.requestId;
+}
+
 function archiveWorktreeDependencies(
   options: PaseoToolHostDependencies,
   context: ArchiveWorktreeCommandContext,
@@ -3204,6 +3246,7 @@ function archiveWorktreeDependencies(
     emitWorkspaceUpdatesForWorkspaceIds: options.emitWorkspaceUpdatesForWorkspaceIds,
     markWorkspaceArchiving: options.markWorkspaceArchiving,
     clearWorkspaceArchiving: options.clearWorkspaceArchiving,
+    lifecycle: resolveWorkspaceLifecycleOperationOwner(context.agentManager),
     killTerminalsForWorkspace: (workspaceId: string) =>
       killTerminalsForWorkspace(
         {

--- a/packages/server/src/server/agent/tools/types.ts
+++ b/packages/server/src/server/agent/tools/types.ts
@@ -3,6 +3,18 @@ import type { z } from "zod";
 export interface PaseoToolExecutionContext {
   signal?: AbortSignal;
   sendUpdate?: (update: PaseoToolResult) => void;
+  /**
+   * The MCP JSON-RPC request id of this tool call, type-tagged (`n:<number>`
+   * or `s:<string>`) so numeric and string ids never collide. Tools use it as
+   * the durable identity of lifecycle operations they start.
+   */
+  requestId?: string;
+  /**
+   * The MCP transport session id, when the transport provides one. Combined
+   * with requestId it scopes the identity across connections; without it,
+   * uniqueness holds only within one transport session.
+   */
+  sessionId?: string;
 }
 
 export interface PaseoToolResult {

--- a/packages/server/src/server/agent/workspace-lifecycle-agent-admission.test.ts
+++ b/packages/server/src/server/agent/workspace-lifecycle-agent-admission.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { withAgentWorkspaceLifecycleAdmission } from "./agent-manager.js";
+import type { WorkspaceLifecycleAdmission } from "../workspace-lifecycle-operation-service.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createTestLogger } from "../../test-utils/test-logger.js";
+import { AgentManager } from "./agent-manager.js";
+import { PaseoWorkspaceLifecycleOperationService } from "../workspace-lifecycle-operation-service.js";
+import { FileBackedWorkspaceLifecycleOperationStore } from "../workspace-lifecycle-operation-store.js";
+
+describe("agent workspace lifecycle admission", () => {
+  test("uses the workspace resource lease before registering an agent", async () => {
+    const action = vi.fn(async () => "registered");
+    const withSharedAdmission = vi.fn(async (_input, callback) => callback());
+    const admission = { withSharedAdmission } as WorkspaceLifecycleAdmission;
+
+    await expect(
+      withAgentWorkspaceLifecycleAdmission(
+        admission,
+        { workspaceId: "wks_agent", cwd: "C:/repo", actor: "agent:create" },
+        action,
+      ),
+    ).resolves.toBe("registered");
+    expect(withSharedAdmission).toHaveBeenCalledWith(
+      { resourceKey: "workspace:wks_agent", actor: "agent:create" },
+      action,
+    );
+  });
+
+  test("does not start the agent mutation when admission rejects", async () => {
+    const action = vi.fn(async () => "registered");
+    const admission = {
+      withSharedAdmission: vi.fn(async () => {
+        throw new Error("workspace lifecycle admission closed");
+      }),
+    } as unknown as WorkspaceLifecycleAdmission;
+
+    await expect(
+      withAgentWorkspaceLifecycleAdmission(
+        admission,
+        { workspaceId: "wks_closed", cwd: "C:/repo", actor: "agent:run" },
+        action,
+      ),
+    ).rejects.toThrow(/admission closed/i);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  test("agent creation is refused while workspace lifecycle admission is closed", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-lifecycle-admission-"));
+    try {
+      const store = new FileBackedWorkspaceLifecycleOperationStore({
+        filePath: path.join(root, "workspace-lifecycle-operations.json"),
+        logger: createTestLogger(),
+      });
+      const lifecycle = new PaseoWorkspaceLifecycleOperationService({
+        store,
+        logger: createTestLogger(),
+      });
+      const manager = new AgentManager({
+        clients: {},
+        logger: createTestLogger(),
+      });
+      manager.setWorkspaceLifecycleOperations(lifecycle);
+
+      let releaseQuiesce!: () => void;
+      const removal = lifecycle.runRemoval({
+        operationId: "close-workspace-admission",
+        fingerprint: "close-workspace-admission",
+        resourceKey: "workspace:wks_admission",
+        allowDestructiveMutation: true,
+        quiesce: () => new Promise<void>((resolveQuiesce) => (releaseQuiesce = resolveQuiesce)),
+        verify: async () => true,
+        mutate: async () => ({ removed: true }),
+      });
+      await vi.waitFor(async () => {
+        expect((await store.get("close-workspace-admission"))?.state).toBe("ADMISSION_CLOSED");
+      });
+
+      await expect(
+        manager.createAgent({ provider: "codex", cwd: root }, undefined, {
+          workspaceId: "wks_admission",
+        }),
+      ).rejects.toThrow(/admission closed/i);
+
+      releaseQuiesce();
+      await expect(removal).resolves.toEqual({ removed: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/server/src/server/atomic-file.ts
+++ b/packages/server/src/server/atomic-file.ts
@@ -23,3 +23,65 @@ export async function writeFileAtomic(
 export async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
   await writeFileAtomic(filePath, JSON.stringify(value, null, 2));
 }
+
+function toBuffer(data: string | NodeJS.ArrayBufferView): Buffer {
+  if (typeof data === "string") {
+    return Buffer.from(data, "utf8");
+  }
+  return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+}
+
+async function syncParentDirectory(directoryPath: string): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const directory = await fs.open(directoryPath, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}
+
+/** Durable atomic write for lifecycle authority state. */
+export async function writeFileAtomicDurable(
+  filePath: string,
+  data: string | NodeJS.ArrayBufferView,
+): Promise<void> {
+  const directoryPath = path.dirname(filePath);
+  await fs.mkdir(directoryPath, { recursive: true });
+  const tempPath = path.join(
+    directoryPath,
+    "." + path.basename(filePath) + "." + process.pid + "." + Date.now() + "." + randomUUID() + ".tmp",
+  );
+  const expected = toBuffer(data);
+  let renamed = false;
+  try {
+    const handle = await fs.open(tempPath, "wx", 0o600);
+    try {
+      await handle.writeFile(expected);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await fs.rename(tempPath, filePath);
+    renamed = true;
+    const persisted = await fs.readFile(filePath);
+    if (!persisted.equals(expected)) {
+      throw new Error("Atomic durable write verification failed: " + filePath);
+    }
+    await syncParentDirectory(directoryPath);
+  } catch (error) {
+    if (!renamed) {
+      await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    }
+    throw error;
+  }
+}
+
+export async function writeJsonFileAtomicDurable(
+  filePath: string,
+  value: unknown,
+): Promise<void> {
+  await writeFileAtomicDurable(filePath, JSON.stringify(value, null, 2));
+}

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.test.ts
@@ -491,7 +491,7 @@ describe("archiveIfSafe", () => {
       }),
       {
         scope: { kind: "workspace", workspaceId: "ws-auto-archive" },
-        requestId: "auto-archive-on-merge",
+        requestId: "auto-archive-on-merge:ws-auto-archive:https://github.com/acme/repo/pull/123",
       },
     );
     expect(harness.log.info).toHaveBeenCalledWith(

--- a/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
+++ b/packages/server/src/server/auto-archive-on-merge/archive-if-safe.ts
@@ -13,6 +13,7 @@ import type {
   WorkspaceGitRuntimeSnapshot,
   WorkspaceGitServiceImpl,
 } from "../workspace-git-service.js";
+import { resolveWorkspaceLifecycleOperationOwner } from "../workspace-lifecycle-operation-service.js";
 import type { ForgeService } from "../../services/forge-service.js";
 import type { TerminalManager } from "../../terminal/terminal-manager.js";
 import { isPaseoOwnedWorktreeCwd } from "../../utils/worktree.js";
@@ -144,11 +145,14 @@ export async function archiveIfSafe(input: {
               },
               workspaceIdToKill,
             ),
+          lifecycle: resolveWorkspaceLifecycleOperationOwner(options.agentManager),
           sessionLogger: log,
         },
         {
           scope: { kind: "workspace", workspaceId },
-          requestId: "auto-archive-on-merge",
+          // The merged PR is the durable external identity: re-observing the
+          // same merge replays the committed archive instead of re-running.
+          requestId: `auto-archive-on-merge:${workspaceId}:${pullRequest.url}`,
         },
       );
       log.info({ cwd }, "Auto-archived worktree after PR merge");

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -120,6 +120,8 @@ import { VoiceAssistantWebSocketServer } from "./websocket-server.js";
 import { WorkspaceSetupRuntime } from "./workspace-setup-runtime.js";
 import { createGitHubService } from "../services/github-service.js";
 import { createPaseoWorktree as createRegisteredPaseoWorktree } from "./paseo-worktree-service.js";
+import { FileBackedWorkspaceLifecycleOperationStore } from "./workspace-lifecycle-operation-store.js";
+import { PaseoWorkspaceLifecycleOperationService } from "./workspace-lifecycle-operation-service.js";
 import { createWorkspaceProvisioningService } from "./session/workspace-provisioning/workspace-provisioning-service.js";
 import { createPaseoWorktreeWorkflow } from "./worktree-session.js";
 import { DownloadTokenStore } from "./file-download/token-store.js";
@@ -829,6 +831,27 @@ export async function createPaseoDaemon(
     isDev: config.isDev === true,
     extraClients: config.agentClients,
   });
+  // Single daemon-wide workspace lifecycle operation owner. Destructive
+  // mutation stays disabled at the service level; only the explicit workspace
+  // archive flow opts in per operation.
+  const workspaceLifecycleOperations = new PaseoWorkspaceLifecycleOperationService({
+    store: new FileBackedWorkspaceLifecycleOperationStore({
+      filePath: path.join(config.paseoHome, "workspace-lifecycle-operations.json"),
+      logger,
+    }),
+    logger,
+  });
+  // Fail closed on restart: operations a prior daemon left nonterminal are
+  // claimed to MANUAL_CLEANUP before anything can act on their resources. An
+  // unreadable journal aborts startup rather than running without the owner.
+  const interruptedLifecycleOperations =
+    await workspaceLifecycleOperations.recoverInterruptedOperations();
+  if (interruptedLifecycleOperations.length > 0) {
+    logger.warn(
+      { count: interruptedLifecycleOperations.length },
+      "Recovered interrupted workspace lifecycle operations to MANUAL_CLEANUP",
+    );
+  }
   const initialAgentManagerState = providerSnapshotManager.getAgentManagerProviderState();
   const agentManager = new AgentManager({
     clients: initialAgentManagerState.clients,
@@ -841,6 +864,7 @@ export async function createPaseoDaemon(
     mcpAuthToken: agentMcpAuthToken,
     logger,
   });
+  agentManager.setWorkspaceLifecycleOperations(workspaceLifecycleOperations);
 
   const detachAgentStoragePersistence = attachAgentStoragePersistence(
     logger,
@@ -1025,6 +1049,7 @@ export async function createPaseoDaemon(
               : {}),
             workspaceGitService,
             workspaceProvisioning,
+            lifecycle: workspaceLifecycleOperations,
           });
         },
         warmWorkspaceGitData: async (workspace) => {
@@ -1090,6 +1115,7 @@ export async function createPaseoDaemon(
         killTerminalsForWorkspace: (workspaceIdToKill) =>
           killTerminalsForWorkspace({ terminalManager, sessionLogger: logger }, workspaceIdToKill),
         stopWorkspaceSetup: (workspaceIdToStop) => workspaceSetupRuntime.stop(workspaceIdToStop),
+        lifecycle: workspaceLifecycleOperations,
         sessionLogger: logger,
       },
       { scope: { kind: "workspace", workspaceId }, requestId },
@@ -1146,6 +1172,7 @@ export async function createPaseoDaemon(
   const createScheduleLocalWorkspaceExternal = async (input: {
     cwd: string;
     firstAgentContext: FirstAgentContext;
+    runId: string;
   }) => {
     const workspace = await workspaceProvisioning.createWorkspaceForDirectory(
       input.cwd,
@@ -1162,15 +1189,18 @@ export async function createPaseoDaemon(
   const createSchedulePaseoWorktreeExternal = async (input: {
     cwd: string;
     firstAgentContext: FirstAgentContext;
+    runId: string;
   }) => {
     const result = await createPaseoWorktreeForTools({
       cwd: input.cwd,
       firstAgentContext: input.firstAgentContext,
+      // The schedule run id is the durable create identity.
+      lifecycleOperationId: `schedule-run:${input.runId}`,
     });
     await emitWorkspaceUpdatesExternal([result.workspace.workspaceId]);
     return result;
   };
-  const archiveScheduleWorkspaceExternal = async (workspaceId: string) => {
+  const archiveScheduleWorkspaceExternal = async (workspaceId: string, runId: string) => {
     await archiveByScope(
       {
         paseoHome: config.paseoHome,
@@ -1195,11 +1225,13 @@ export async function createPaseoDaemon(
             workspaceIdToKill,
           ),
         stopWorkspaceSetup: (workspaceIdToStop) => workspaceSetupRuntime.stop(workspaceIdToStop),
+        lifecycle: workspaceLifecycleOperations,
         sessionLogger: logger,
       },
       {
         scope: { kind: "workspace", workspaceId },
-        requestId: "schedule-run-finish",
+        // The schedule run id is the durable archive identity.
+        requestId: `schedule-run-finish:${runId}`,
       },
     );
   };

--- a/packages/server/src/server/paseo-worktree-service.test.ts
+++ b/packages/server/src/server/paseo-worktree-service.test.ts
@@ -21,6 +21,8 @@ import {
 } from "./paseo-worktree-service.js";
 import { readPaseoWorktreeMetadata } from "../utils/worktree-metadata.js";
 import { createWorktree, getPaseoWorktreesRoot } from "../utils/worktree.js";
+import { PaseoWorkspaceLifecycleOperationService } from "./workspace-lifecycle-operation-service.js";
+import { FileBackedWorkspaceLifecycleOperationStore } from "./workspace-lifecycle-operation-store.js";
 import { isPlatform } from "../test-utils/platform.js";
 import { areEquivalentPaths, createRealpathAwarePathMatcher } from "../utils/path.js";
 import { deriveProjectKey } from "./project-key.js";
@@ -85,6 +87,125 @@ test("creates a worktree and registers it in the source workspace project withou
     updatedAt: expect.any(String),
   });
   expect(events).toEqual([`workspace:${result.workspace.workspaceId}`]);
+});
+
+test("creation runs as a committed lifecycle operation owning the worktree resource", async () => {
+  const { repoDir, tempDir } = createGitRepo();
+  cleanupPaths.push(tempDir);
+  const deps = createDeps();
+  const sourceProject = createPersistedProjectRecordForTest({
+    projectId: "remote:github.com/acme/repo",
+    rootPath: repoDir,
+    displayName: "acme/repo",
+  });
+  const sourceWorkspace = createPersistedWorkspaceRecordForTest({
+    workspaceId: "ws-main-checkout",
+    projectId: sourceProject.projectId,
+    cwd: repoDir,
+    kind: "local_checkout",
+    displayName: "main",
+  });
+  deps.projects.set(sourceProject.projectId, sourceProject);
+  deps.workspaces.set(sourceWorkspace.workspaceId, sourceWorkspace);
+  const store = new FileBackedWorkspaceLifecycleOperationStore({
+    filePath: path.join(tempDir, "workspace-lifecycle-operations.json"),
+    logger: createTestLogger(),
+  });
+  deps.lifecycle = new PaseoWorkspaceLifecycleOperationService({
+    store,
+    logger: createTestLogger(),
+  });
+
+  const input = {
+    cwd: repoDir,
+    worktreeSlug: "lifecycle-owner-create",
+    runSetup: false,
+    paseoHome: path.join(tempDir, ".paseo"),
+    lifecycleOperationId: "create-req-1",
+  };
+  const result = await createPaseoWorktree(input, deps);
+
+  expect(result.created).toBe(true);
+  expect(result.workspace.cwd).toBe(result.worktree.worktreePath);
+  const record = await store.findCurrentByResource(
+    `worktree:${path.resolve(repoDir)}:lifecycle-owner-create`,
+  );
+  expect(record?.operationId).toBe("worktree-create:create-req-1");
+  expect(record?.state).toBe("COMMITTED");
+  expect(record?.kind).toBe("create");
+  expect(await store.listNonterminal()).toEqual([]);
+
+  // A retried request with the same durable identity replays the committed
+  // result instead of creating a replacement worktree.
+  const replayed = await createPaseoWorktree(input, deps);
+  expect(replayed).toEqual(result);
+  expect((await store.findCurrentByResource(
+    `worktree:${path.resolve(repoDir)}:lifecycle-owner-create`,
+  ))?.generation).toBe(1);
+
+  // Reusing the identity for a different target is rejected, never retried.
+  await expect(
+    createPaseoWorktree({ ...input, worktreeSlug: "lifecycle-owner-other" }, deps),
+  ).rejects.toThrow(/fingerprint|conflict/i);
+
+  // The owner path requires a request-scoped identity from the caller.
+  await expect(
+    createPaseoWorktree(
+      { ...input, worktreeSlug: "lifecycle-owner-no-id", lifecycleOperationId: undefined },
+      deps,
+    ),
+  ).rejects.toThrow(/lifecycleOperationId/);
+});
+
+test("failed post-create validation preserves directory and branch when git removal fails", async () => {
+  const { repoDir, tempDir } = createGitRepo();
+  cleanupPaths.push(tempDir);
+  const deps = createDeps();
+  const store = new FileBackedWorkspaceLifecycleOperationStore({
+    filePath: path.join(tempDir, "workspace-lifecycle-operations.json"),
+    logger: createTestLogger(),
+  });
+  deps.lifecycle = new PaseoWorkspaceLifecycleOperationService({
+    store,
+    logger: createTestLogger(),
+  });
+  // Post-create provisioning breaks git's worktree admin state and fails, so
+  // the strict git-only compensation cannot remove the worktree either.
+  deps.workspaceProvisioning = {
+    createWorkspaceForWorktree: async () => {
+      rmSync(path.join(repoDir, ".git", "worktrees"), { recursive: true, force: true });
+      throw new Error("provisioning failed");
+    },
+  };
+
+  await expect(
+    createPaseoWorktree(
+      {
+        cwd: repoDir,
+        worktreeSlug: "compensation-preserved",
+        runSetup: false,
+        paseoHome: path.join(tempDir, ".paseo"),
+        lifecycleOperationId: "create-req-compensation",
+      },
+      deps,
+    ),
+  ).rejects.toThrow(/strict compensation preserved/);
+
+  // No recursive delete ran: the directory and its branch survive for manual
+  // cleanup, and the operation is recorded MANUAL_CLEANUP.
+  const worktreesRoot = await getPaseoWorktreesRoot(repoDir, path.join(tempDir, ".paseo"));
+  expect(existsSync(path.join(worktreesRoot, "compensation-preserved"))).toBe(true);
+  expect(
+    execFileSync("git", ["branch", "--list", "compensation-preserved"], {
+      cwd: repoDir,
+      stdio: "pipe",
+    })
+      .toString()
+      .includes("compensation-preserved"),
+  ).toBe(true);
+  const record = await store.get("worktree-create:create-req-compensation");
+  expect(record?.state).toBe("MANUAL_CLEANUP");
+  expect(await store.listNonterminal()).toEqual([]);
 });
 
 test("refreshes a source project that became Git while creating a worktree", async () => {

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -12,7 +12,7 @@ import {
 } from "./worktree-core.js";
 import {
   mapWorkspaceRelativeCwdToWorktree,
-  rollbackCreatedPaseoWorktree,
+  removePaseoWorktreeStrict,
   seedPaseoConfigFile,
   validateBranchSlug,
   type WorktreeConfig,
@@ -29,10 +29,21 @@ import { resolveFirstAgentPromptTitle } from "./agent/create-agent-title.js";
 import { buildAgentBranchNameSeed } from "./agent/prompt-attachments.js";
 import type { FirstAgentContext } from "@getpaseo/protocol/messages";
 import { runWithGitCommandPriority } from "../utils/run-git-command.js";
+import {
+  fingerprintWorkspaceLifecycleRequest,
+  type WorkspaceLifecycleOperationOwner,
+} from "./workspace-lifecycle-operation-service.js";
 
 export interface CreatePaseoWorktreeInput extends CreateWorktreeCoreInput {
   projectId?: string;
   title?: string;
+  /**
+   * Durable identity of the logical create request, minted once at the request
+   * boundary (client requestId or a caller-scoped id). Required when the
+   * lifecycle owner is configured; a retried request replays the committed
+   * result instead of creating a replacement worktree.
+   */
+  lifecycleOperationId?: string;
 }
 
 export interface CreatePaseoWorktreeResult {
@@ -59,6 +70,10 @@ export interface AttemptFirstAgentBranchAutoNameResult {
 export interface CreatePaseoWorktreeDeps extends CreateWorktreeCoreDeps {
   workspaceGitService: WorkspaceGitService;
   workspaceProvisioning: Pick<WorkspaceProvisioningService, "createWorkspaceForWorktree">;
+  // The workspace lifecycle operation owner. When present, creation runs as a
+  // durable lifecycle operation with one nonterminal owner per target; when
+  // absent the direct path applies (kept for direct-dependency tests).
+  lifecycle?: WorkspaceLifecycleOperationOwner;
 }
 
 export async function createPaseoWorktree(
@@ -69,6 +84,42 @@ export async function createPaseoWorktree(
 }
 
 async function createPaseoWorktreeWithPriority(
+  input: CreatePaseoWorktreeInput,
+  deps: CreatePaseoWorktreeDeps,
+): Promise<CreatePaseoWorktreeResult> {
+  const lifecycle = deps.lifecycle;
+  if (!lifecycle) {
+    return createPaseoWorktreeDirect(input, deps);
+  }
+
+  const operationIdentity = input.lifecycleOperationId;
+  if (!operationIdentity) {
+    throw new Error(
+      "createPaseoWorktree requires input.lifecycleOperationId when the lifecycle owner is configured",
+    );
+  }
+  // Auto-named worktrees have no deterministic target before creation, so the
+  // request identity keys the resource; named targets get one nonterminal
+  // owner per target.
+  const targetIdentity =
+    input.worktreeSlug ??
+    input.refName ??
+    (input.githubPrNumber !== undefined
+      ? `pr-${input.githubPrNumber}`
+      : `auto-${operationIdentity}`);
+  return lifecycle.runCreate({
+    operationId: `worktree-create:${operationIdentity}`,
+    fingerprint: fingerprintWorkspaceLifecycleRequest({
+      cwd: resolve(input.cwd),
+      targetIdentity,
+      projectId: input.projectId ?? null,
+    }),
+    resourceKey: `worktree:${resolve(input.cwd)}:${targetIdentity}`,
+    create: () => createPaseoWorktreeDirect(input, deps),
+  });
+}
+
+async function createPaseoWorktreeDirect(
   input: CreatePaseoWorktreeInput,
   deps: CreatePaseoWorktreeDeps,
 ): Promise<CreatePaseoWorktreeResult> {
@@ -115,16 +166,25 @@ async function createPaseoWorktreeWithPriority(
     if (!createdWorktree.created) {
       throw error;
     }
-    return rollbackCreatedPaseoWorktree(
-      {
+    // Strict compensation: git-only removal of the just-created worktree. If
+    // that fails the directory and branch are preserved for manual cleanup —
+    // never a recursive delete.
+    try {
+      await removePaseoWorktreeStrict({
         cwd: createdWorktree.repoRoot,
         worktreePath: createdWorktree.worktree.worktreePath,
-        ...(input.runSetup === false ? { teardownCwds: [] } : {}),
         paseoHome: input.paseoHome,
         worktreesBaseRoot: input.worktreesRoot,
-      },
-      error,
-    );
+      });
+    } catch (compensationError) {
+      const failure = new Error(
+        `${error instanceof Error ? error.message : "Worktree workflow failed"}; strict compensation preserved ${createdWorktree.worktree.worktreePath}: ${compensationError instanceof Error ? compensationError.message : String(compensationError)}`,
+        { cause: error },
+      );
+      Object.assign(failure, { cleanupError: compensationError });
+      throw failure;
+    }
+    throw error;
   }
 }
 

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -211,6 +211,8 @@ type ScheduleAgentManager = Pick<
 interface ScheduleWorkspaceCreateInput {
   cwd: string;
   firstAgentContext: FirstAgentContext;
+  // Durable identity of the run this workspace belongs to.
+  runId: string;
 }
 
 export interface ScheduleServiceOptions {
@@ -225,7 +227,7 @@ export interface ScheduleServiceOptions {
   createPaseoWorktreeWorkspace: (
     input: ScheduleWorkspaceCreateInput,
   ) => Promise<CreatePaseoWorktreeWorkflowResult>;
-  archiveWorkspace: (workspaceId: string) => Promise<void>;
+  archiveWorkspace: (workspaceId: string, runId: string) => Promise<void>;
   now?: () => Date;
   runner?: (schedule: StoredSchedule, runId: string) => Promise<ScheduleExecutionResult>;
 }
@@ -242,7 +244,7 @@ export class ScheduleService {
   private readonly createPaseoWorktreeWorkspace: (
     input: ScheduleWorkspaceCreateInput,
   ) => Promise<CreatePaseoWorktreeWorkflowResult>;
-  private readonly archiveWorkspace: (workspaceId: string) => Promise<void>;
+  private readonly archiveWorkspace: (workspaceId: string, runId: string) => Promise<void>;
   private readonly now: () => Date;
   private readonly runner: (
     schedule: StoredSchedule,
@@ -638,7 +640,7 @@ export class ScheduleService {
       return;
     }
     try {
-      await this.archiveWorkspace(interruptedWorkspace.workspaceId);
+      await this.archiveWorkspace(interruptedWorkspace.workspaceId, interruptedWorkspace.runId);
     } catch (error) {
       this.logger.warn(
         {
@@ -863,7 +865,7 @@ export class ScheduleService {
     let workspace: PersistedWorkspaceRecord | null = null;
     let agentId: string | null = null;
     try {
-      workspace = await this.createScheduleRunWorkspace(config, schedule.prompt);
+      workspace = await this.createScheduleRunWorkspace(config, schedule.prompt, runId);
       await this.recordRunWorkspace({
         scheduleId: schedule.id,
         runId,
@@ -929,7 +931,7 @@ export class ScheduleService {
         shouldArchiveScheduleRunWorkspace({ agentId, archiveOnFinish: config.archiveOnFinish })
       ) {
         try {
-          await this.archiveWorkspace(workspace.workspaceId);
+          await this.archiveWorkspace(workspace.workspaceId, runId);
         } catch (error) {
           this.logger.warn(
             {
@@ -949,14 +951,16 @@ export class ScheduleService {
   private async createScheduleRunWorkspace(
     config: Extract<ScheduleTarget, { type: "new-agent" }>["config"],
     prompt: string,
+    runId: string,
   ): Promise<PersistedWorkspaceRecord> {
     const firstAgentContext = { prompt };
     switch (config.isolation ?? "local") {
       case "local":
-        return this.createDirectoryWorkspace({ cwd: config.cwd, firstAgentContext });
+        return this.createDirectoryWorkspace({ cwd: config.cwd, firstAgentContext, runId });
       case "worktree":
-        return (await this.createPaseoWorktreeWorkspace({ cwd: config.cwd, firstAgentContext }))
-          .workspace;
+        return (
+          await this.createPaseoWorktreeWorkspace({ cwd: config.cwd, firstAgentContext, runId })
+        ).workspace;
     }
   }
 

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -239,6 +239,7 @@ import {
 } from "./worktree-session.js";
 import { archiveByScope, type ActiveWorkspaceRef } from "./workspace-archive-service.js";
 import { WorkspaceSetupRuntime } from "./workspace-setup-runtime.js";
+import { resolveWorkspaceLifecycleOperationOwner } from "./workspace-lifecycle-operation-service.js";
 
 function resolveWorkspaceSetupRuntime(
   runtime: WorkspaceSetupRuntime | undefined,
@@ -803,6 +804,7 @@ export class Session {
       unarchiveWorkspace: async (workspace) => {
         await this.workspaceProvisioning.ensureWorkspaceRecordUnarchived(workspace);
       },
+      lifecycle: resolveWorkspaceLifecycleOperationOwner(options.agentManager),
     });
     this.checkoutSession = new CheckoutSession({
       host: {
@@ -3049,7 +3051,7 @@ export class Session {
     request: Extract<SessionInboundMessage, { type: "workspace.recovery.restore.request" }>,
   ): Promise<void> {
     try {
-      await this.restoreWorkspaceAndEmit(request.workspaceId);
+      await this.restoreWorkspaceAndEmit(request.workspaceId, request.requestId);
       this.emit({
         type: "workspace.recovery.restore.response",
         payload: {
@@ -3178,6 +3180,7 @@ export class Session {
         target: worktree,
         firstAgentContext,
         hasLegacyGitOptions: Boolean(git),
+        requestId,
       });
       createdWorktreeForCleanup = createdWorktree;
       const resolvedIntent = await this.resolveSessionCreateAgentIntent({
@@ -3215,7 +3218,15 @@ export class Session {
           provisionalTitle,
           firstAgentContext,
           buildSessionConfig: (sessionConfig, gitOptions, legacyWorktreeName, ctx) =>
-            this.buildAgentSessionConfig(sessionConfig, gitOptions, legacyWorktreeName, ctx),
+            this.buildAgentSessionConfig(
+              sessionConfig,
+              gitOptions,
+              legacyWorktreeName,
+              ctx,
+              // The create_agent requestId is the durable identity of any
+              // worktree the legacy git path provisions.
+              requestId ? `create-agent-worktree:${requestId}` : undefined,
+            ),
         },
       );
       createdAgentId = snapshot.id;
@@ -3496,7 +3507,7 @@ export class Session {
     this.sessionLogger.info({ agentId }, `Refreshing agent ${agentId} from persistence`);
 
     try {
-      await this.restoreOwningWorkspaceForLegacyAgentRefresh(agentId);
+      await this.restoreOwningWorkspaceForLegacyAgentRefresh(agentId, requestId);
       await unarchiveAgentState(this.agentStorage, this.agentManager, agentId);
       let snapshot: ManagedAgent;
       const existing = this.agentManager.getAgent(agentId);
@@ -3643,6 +3654,7 @@ export class Session {
     gitOptions?: GitSetupOptions,
     legacyWorktreeName?: string,
     firstAgentContext?: FirstAgentContext,
+    lifecycleOperationId?: string,
   ): Promise<{
     sessionConfig: AgentSessionConfig;
     setupContinuation?: CreatePaseoWorktreeWorkflowResult["setupContinuation"];
@@ -3683,6 +3695,7 @@ export class Session {
       gitOptions,
       legacyWorktreeName,
       firstAgentContext,
+      lifecycleOperationId,
     );
   }
 
@@ -4730,8 +4743,11 @@ export class Session {
     };
   }
 
-  private async restoreWorkspaceAndEmit(workspaceId: string): Promise<void> {
-    await this.workspaceRecovery.restore(workspaceId);
+  private async restoreWorkspaceAndEmit(workspaceId: string, requestId: string): Promise<void> {
+    await this.workspaceRecovery.restore(workspaceId, {
+      // The restore RPC requestId is the durable restore identity.
+      lifecycleOperationId: `workspace-restore:${requestId}`,
+    });
     const workspace = await this.workspaceRegistry.get(workspaceId);
     if (!workspace) {
       throw new Error(`Recovered workspace record not found: ${workspaceId}`);
@@ -4750,7 +4766,10 @@ export class Session {
     await this.refreshRecoveredWorkspaceForExternalMutation(workspace);
   }
 
-  private async restoreOwningWorkspaceForLegacyAgentRefresh(agentId: string): Promise<void> {
+  private async restoreOwningWorkspaceForLegacyAgentRefresh(
+    agentId: string,
+    requestId: string,
+  ): Promise<void> {
     // COMPAT(worktreeRestore): clients older than v0.1.105 used refresh_agent_request
     // as their explicit recovery RPC. Remove after 2027-01-11.
     if (!clientUsesLegacyWorkspaceRestore(this.appVersion)) {
@@ -4764,7 +4783,7 @@ export class Session {
     if (recovery.kind !== "recoverable") {
       return;
     }
-    await this.restoreWorkspaceAndEmit(record.workspaceId);
+    await this.restoreWorkspaceAndEmit(record.workspaceId, requestId);
   }
 
   private async createPaseoWorktree(
@@ -4780,6 +4799,7 @@ export class Session {
         : {}),
       workspaceGitService: this.workspaceGitService,
       workspaceProvisioning: this.workspaceProvisioning,
+      lifecycle: resolveWorkspaceLifecycleOperationOwner(this.agentManager),
     });
     void Promise.all([
       this.gitMutation.notifyGitMutation(input.cwd, "create-worktree"),
@@ -5514,6 +5534,7 @@ export class Session {
         githubPrNumber: source.githubPrNumber,
         firstAgentContext: request.firstAgentContext,
         title: request.title,
+        lifecycleOperationId: request.requestId,
       },
       source.baseBranch
         ? { resolveDefaultBranch: async () => source.baseBranch as string }
@@ -6116,6 +6137,7 @@ export class Session {
           killTerminalsForWorkspace: (workspaceId) =>
             this.terminalController.killTerminalsForWorkspace(workspaceId),
           stopWorkspaceSetup: (workspaceId) => this.workspaceSetupRuntime.stop(workspaceId),
+          lifecycle: resolveWorkspaceLifecycleOperationOwner(this.agentManager),
           sessionLogger: this.sessionLogger,
         },
         {

--- a/packages/server/src/server/session/workspace-recovery/workspace-recovery-service.test.ts
+++ b/packages/server/src/server/session/workspace-recovery/workspace-recovery-service.test.ts
@@ -14,6 +14,9 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
 import { createWorktree } from "../../../utils/worktree.js";
+import { PaseoWorkspaceLifecycleOperationService } from "../../workspace-lifecycle-operation-service.js";
+import { FileBackedWorkspaceLifecycleOperationStore } from "../../workspace-lifecycle-operation-store.js";
+import { createTestLogger } from "../../../test-utils/test-logger.js";
 import {
   createPersistedProjectRecord,
   createPersistedWorkspaceRecord,
@@ -264,6 +267,135 @@ describe("workspace recovery", () => {
       "The source repository needed to restore this worktree no longer exists.",
     );
     expect(unarchived).toEqual([]);
+  });
+
+  test("restore recreates the worktree as a committed lifecycle operation", async () => {
+    const { tempDir, repoDir } = createGitRepository();
+    const branch = "feature/lifecycle-restore";
+    execFileSync("git", ["branch", branch], { cwd: repoDir, stdio: "pipe" });
+    const paseoHome = join(tempDir, "paseo-home");
+    const worktreesRoot = join(tempDir, "worktrees");
+    const created = await createWorktree({
+      cwd: repoDir,
+      worktreeSlug: "lifecycle-restore",
+      source: { kind: "checkout-branch", branchName: branch },
+      runSetup: false,
+      paseoHome,
+      worktreesRoot,
+    });
+    const worktreeRoot = realpathSync(created.worktreePath);
+    rmSync(worktreeRoot, { recursive: true, force: true });
+    execFileSync("git", ["worktree", "prune"], { cwd: repoDir, stdio: "pipe" });
+
+    const project = createProject({ rootPath: repoDir });
+    const workspace = createWorkspace({
+      workspaceId: "ws-lifecycle-restore",
+      cwd: worktreeRoot,
+      branch,
+      worktreeRoot,
+      mainRepoRoot: repoDir,
+    });
+    const store = new FileBackedWorkspaceLifecycleOperationStore({
+      filePath: join(tempDir, "workspace-lifecycle-operations.json"),
+      logger: createTestLogger(),
+    });
+    const unarchived: string[] = [];
+    const service = createWorkspaceRecoveryService({
+      paseoHome,
+      worktreesRoot,
+      getWorkspace: async (workspaceId) =>
+        workspaceId === workspace.workspaceId ? workspace : null,
+      getProject: async (projectId) => (projectId === project.projectId ? project : null),
+      isDirectory: async (targetPath) =>
+        existsSync(targetPath) && statSync(targetPath).isDirectory(),
+      unarchiveWorkspace: async (record) => {
+        unarchived.push(record.workspaceId);
+      },
+      lifecycle: new PaseoWorkspaceLifecycleOperationService({
+        store,
+        logger: createTestLogger(),
+      }),
+    });
+
+    await expect(
+      service.restore(workspace.workspaceId, { lifecycleOperationId: "restore-req-1" }),
+    ).resolves.toEqual({
+      workspaceId: workspace.workspaceId,
+      action: "restore",
+    });
+    expect(existsSync(worktreeRoot)).toBe(true);
+    expect(unarchived).toEqual([workspace.workspaceId]);
+    const record = await store.get("worktree-restore:restore-req-1");
+    expect(record?.state).toBe("COMMITTED");
+    expect(record?.kind).toBe("create");
+    expect(await store.listNonterminal()).toEqual([]);
+  });
+
+  test("records MANUAL_CLEANUP and strictly compensates a diverged restore", async () => {
+    const { tempDir, repoDir } = createGitRepository();
+    const branch = "feature/lifecycle-diverged";
+    execFileSync("git", ["branch", branch], { cwd: repoDir, stdio: "pipe" });
+    const paseoHome = join(tempDir, "paseo-home");
+    const worktreesRoot = join(tempDir, "worktrees");
+    const created = await createWorktree({
+      cwd: repoDir,
+      worktreeSlug: "lifecycle-diverged",
+      source: { kind: "checkout-branch", branchName: branch },
+      runSetup: false,
+      paseoHome,
+      worktreesRoot,
+    });
+    const worktreeRoot = realpathSync(created.worktreePath);
+    const workspaceCwd = join(worktreeRoot, "packages", "app");
+    rmSync(worktreeRoot, { recursive: true, force: true });
+    execFileSync("git", ["worktree", "prune"], { cwd: repoDir, stdio: "pipe" });
+
+    const project = createProject({ rootPath: repoDir });
+    const workspace = createWorkspace({
+      workspaceId: "ws-lifecycle-diverged",
+      cwd: workspaceCwd,
+      branch,
+      worktreeRoot,
+      mainRepoRoot: repoDir,
+    });
+    const store = new FileBackedWorkspaceLifecycleOperationStore({
+      filePath: join(tempDir, "workspace-lifecycle-operations.json"),
+      logger: createTestLogger(),
+    });
+    const unarchived: string[] = [];
+    const service = createWorkspaceRecoveryService({
+      paseoHome,
+      worktreesRoot,
+      getWorkspace: async (workspaceId) =>
+        workspaceId === workspace.workspaceId ? workspace : null,
+      getProject: async (projectId) => (projectId === project.projectId ? project : null),
+      isDirectory: async (targetPath) =>
+        existsSync(targetPath) && statSync(targetPath).isDirectory(),
+      unarchiveWorkspace: async (record) => {
+        unarchived.push(record.workspaceId);
+      },
+      lifecycle: new PaseoWorkspaceLifecycleOperationService({
+        store,
+        logger: createTestLogger(),
+      }),
+    });
+
+    await expect(service.restore(workspace.workspaceId)).rejects.toThrow(
+      "Selected project directory is missing from the restored worktree",
+    );
+    expect(unarchived).toEqual([]);
+    // Strict git-only compensation removed the recreated worktree; the branch
+    // survives and no recursive delete ran.
+    expect(existsSync(worktreeRoot)).toBe(false);
+    expect(
+      execFileSync("git", ["branch", "--list", branch], { cwd: repoDir, stdio: "pipe" })
+        .toString()
+        .includes("lifecycle-diverged"),
+    ).toBe(true);
+    const record = await store.get(`worktree-restore:workspace-restore:${workspace.workspaceId}`);
+    expect(record?.state).toBe("MANUAL_CLEANUP");
+    expect(record?.evidence).toContain("create failed");
+    expect(await store.listNonterminal()).toEqual([]);
   });
 });
 

--- a/packages/server/src/server/session/workspace-recovery/workspace-recovery-service.ts
+++ b/packages/server/src/server/session/workspace-recovery/workspace-recovery-service.ts
@@ -6,8 +6,12 @@ import {
   createWorktree,
   isPaseoOwnedWorktreeCwd,
   mapWorkspaceCwdToWorktree,
-  rollbackCreatedPaseoWorktree,
+  removePaseoWorktreeStrict,
 } from "../../../utils/worktree.js";
+import {
+  fingerprintWorkspaceLifecycleRequest,
+  type WorkspaceLifecycleOperationOwner,
+} from "../../workspace-lifecycle-operation-service.js";
 import { WorktreeRequestError, toWorktreeRequestError } from "../../worktree-errors.js";
 import {
   resolveWorkspaceDisplayName,
@@ -40,7 +44,10 @@ export type WorkspaceRecoveryState =
 
 export interface WorkspaceRecoveryService {
   inspect(workspaceId: string): Promise<WorkspaceRecoveryState>;
-  restore(workspaceId: string): Promise<{ workspaceId: string; action: WorkspaceRecoveryAction }>;
+  restore(
+    workspaceId: string,
+    options?: { lifecycleOperationId?: string },
+  ): Promise<{ workspaceId: string; action: WorkspaceRecoveryAction }>;
 }
 
 type RecoveryPlan =
@@ -65,6 +72,11 @@ export function createWorkspaceRecoveryService(deps: {
   getProject: (projectId: string) => Promise<PersistedProjectRecord | null>;
   isDirectory: (path: string) => Promise<boolean>;
   unarchiveWorkspace: (workspace: PersistedWorkspaceRecord) => Promise<void>;
+  // The workspace lifecycle operation owner. When present, worktree
+  // re-creation runs as a durable lifecycle operation; when absent the direct
+  // path applies (kept for direct-dependency tests). Compensation is strict on
+  // both paths — a failed restore never falls through to a recursive delete.
+  lifecycle?: WorkspaceLifecycleOperationOwner;
 }): WorkspaceRecoveryService {
   async function resolveRecovery(
     workspaceId: string,
@@ -140,6 +152,7 @@ export function createWorkspaceRecoveryService(deps: {
 
   async function restore(
     workspaceId: string,
+    options?: { lifecycleOperationId?: string },
   ): Promise<{ workspaceId: string; action: WorkspaceRecoveryAction }> {
     const resolved = await resolveRecovery(workspaceId);
     if (resolved.kind === "unavailable") {
@@ -147,7 +160,11 @@ export function createWorkspaceRecoveryService(deps: {
     }
 
     if (resolved.kind === "restore") {
-      await recreateArchivedWorktree(resolved.workspace, resolved.sourceRepoRoot);
+      await recreateArchivedWorktree(
+        resolved.workspace,
+        resolved.sourceRepoRoot,
+        options?.lifecycleOperationId,
+      );
     }
     await deps.unarchiveWorkspace(resolved.workspace);
     return { workspaceId, action: resolved.kind };
@@ -156,6 +173,7 @@ export function createWorkspaceRecoveryService(deps: {
   async function recreateArchivedWorktree(
     workspace: PersistedWorkspaceRecord,
     sourceRepoRoot: string,
+    lifecycleOperationId: string | undefined,
   ): Promise<void> {
     const branch = workspace.branch;
     if (!branch) {
@@ -184,6 +202,34 @@ export function createWorkspaceRecoveryService(deps: {
         : workspace.cwd;
     }
 
+    const lifecycle = deps.lifecycle;
+    if (!lifecycle) {
+      await recreateWorktreeDirect(workspace, sourceRepoRoot, previousWorktreePath, branch);
+      return;
+    }
+
+    const operationIdentity = lifecycleOperationId ?? `workspace-restore:${workspace.workspaceId}`;
+    await lifecycle.runCreate({
+      operationId: `worktree-restore:${operationIdentity}`,
+      fingerprint: fingerprintWorkspaceLifecycleRequest({
+        workspaceId: workspace.workspaceId,
+        branch,
+        worktreePath: previousWorktreePath,
+      }),
+      resourceKey: `worktree:${previousWorktreePath}`,
+      create: async () => {
+        await recreateWorktreeDirect(workspace, sourceRepoRoot, previousWorktreePath, branch);
+        return { worktreePath: previousWorktreePath };
+      },
+    });
+  }
+
+  async function recreateWorktreeDirect(
+    workspace: PersistedWorkspaceRecord,
+    sourceRepoRoot: string,
+    previousWorktreePath: string,
+    branch: string,
+  ): Promise<void> {
     let recreatedWorktreePath: string;
     try {
       const result = await createWorktree({
@@ -218,16 +264,23 @@ export function createWorkspaceRecoveryService(deps: {
         });
       }
     } catch (error) {
-      return rollbackCreatedPaseoWorktree(
-        {
+      // Strict compensation: git-only removal of the just-created worktree.
+      // If that fails the directory is preserved for manual cleanup — never a
+      // recursive delete.
+      try {
+        await removePaseoWorktreeStrict({
           cwd: sourceRepoRoot,
           worktreePath: recreatedWorktreePath,
-          teardownCwds: [],
           paseoHome: deps.paseoHome,
           worktreesBaseRoot: deps.worktreesRoot,
-        },
-        error,
-      );
+        });
+      } catch (compensationError) {
+        throw new WorktreeRequestError({
+          code: "unknown",
+          message: `${error instanceof Error ? error.message : "Worktree restore failed"}; strict compensation preserved ${recreatedWorktreePath}: ${compensationError instanceof Error ? compensationError.message : String(compensationError)}`,
+        });
+      }
+      throw error;
     }
   }
 

--- a/packages/server/src/server/workspace-archive-service.test.ts
+++ b/packages/server/src/server/workspace-archive-service.test.ts
@@ -18,6 +18,8 @@ import {
   type ArchiveResult,
   resolveWorkspaceIdAtPath,
 } from "./workspace-archive-service.js";
+import { PaseoWorkspaceLifecycleOperationService } from "./workspace-lifecycle-operation-service.js";
+import { FileBackedWorkspaceLifecycleOperationStore } from "./workspace-lifecycle-operation-store.js";
 
 const cleanupPaths: string[] = [];
 
@@ -788,6 +790,186 @@ describe("archiveByScope", () => {
       expect.arrayContaining([workspaceA, workspaceB, workspaceC]),
     );
     expect(result.archivedWorkspaceIds).toHaveLength(3);
+    expect(result.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(false);
+  });
+});
+
+function createLifecycleOwner(root: string): {
+  store: FileBackedWorkspaceLifecycleOperationStore;
+  lifecycle: PaseoWorkspaceLifecycleOperationService;
+} {
+  const store = new FileBackedWorkspaceLifecycleOperationStore({
+    filePath: path.join(root, "workspace-lifecycle-operations.json"),
+    logger: createLogger(),
+  });
+  // Destructive mutation stays at the service default (disabled); only the
+  // archive flow's per-operation opt-in reaches the mutate step.
+  return {
+    store,
+    lifecycle: new PaseoWorkspaceLifecycleOperationService({ store, logger: createLogger() }),
+  };
+}
+
+function ownedWorkspaceRef(
+  workspaceId: string,
+  worktreePath: string,
+  repoDir: string,
+): ActiveWorkspaceRef {
+  return {
+    workspaceId,
+    cwd: worktreePath,
+    kind: "worktree",
+    worktreeRoot: worktreePath,
+    isPaseoOwnedWorktree: true,
+    mainRepoRoot: repoDir,
+  };
+}
+
+describe("archiveByScope through the workspace lifecycle owner", () => {
+  test("routes directory removal through the owner and keeps the branch", async () => {
+    const { tempDir, repoDir } = createGitRepo();
+    const paseoHome = path.join(tempDir, ".paseo");
+    const worktree = await createPaseoOwnedWorktree(repoDir, paseoHome, "lifecycle-owner-commit");
+    const workspaceId = "ws-lifecycle-owner-commit";
+    const { store, lifecycle } = createLifecycleOwner(paseoHome);
+    const deps = createArchiveDeps({
+      paseoHome,
+      activeWorkspaces: [ownedWorkspaceRef(workspaceId, worktree.worktreePath, repoDir)],
+    });
+    deps.lifecycle = lifecycle;
+
+    const result = await archiveByScope(deps, {
+      scope: { kind: "workspace", workspaceId },
+      requestId: "req-lifecycle-owner-commit",
+    });
+
+    expect(result.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(false);
+    expect(await store.listNonterminal()).toEqual([]);
+    const record = await store.findCurrentByResource(
+      `worktree:${path.resolve(worktree.worktreePath)}`,
+    );
+    expect(record?.operationId).toBe("workspace-archive:req-lifecycle-owner-commit");
+    expect(record?.state).toBe("COMMITTED");
+    expect(record?.kind).toBe("archive");
+    const branches = execFileSync("git", ["branch", "--list", "lifecycle-owner-commit"], {
+      cwd: repoDir,
+      stdio: "pipe",
+    }).toString();
+    expect(branches).toContain("lifecycle-owner-commit");
+  });
+
+  test("records MANUAL_CLEANUP and preserves the directory when git removal fails", async () => {
+    const { tempDir, repoDir } = createGitRepo();
+    const paseoHome = path.join(tempDir, ".paseo");
+    const worktree = await createPaseoOwnedWorktree(repoDir, paseoHome, "lifecycle-owner-manual");
+    const workspaceId = "ws-lifecycle-owner-manual";
+    const { store, lifecycle } = createLifecycleOwner(paseoHome);
+    const deps = createArchiveDeps({
+      paseoHome,
+      activeWorkspaces: [ownedWorkspaceRef(workspaceId, worktree.worktreePath, repoDir)],
+    });
+    deps.lifecycle = lifecycle;
+    rmSync(path.join(repoDir, ".git", "worktrees"), { recursive: true, force: true });
+
+    const result = await archiveByScope(deps, {
+      scope: { kind: "workspace", workspaceId },
+      requestId: "req-lifecycle-owner-manual",
+    });
+
+    expect(result.archivedWorkspaceIds).toEqual([workspaceId]);
+    expect(result.removedDirectory).toBe(false);
+    expect(existsSync(worktree.worktreePath)).toBe(true);
+    expect(await store.listNonterminal()).toEqual([]);
+    const record = await store.findCurrentByResource(
+      `worktree:${path.resolve(worktree.worktreePath)}`,
+    );
+    expect(record?.state).toBe("MANUAL_CLEANUP");
+  });
+
+  test("distinct MCP request ids do not replay and the same id replays", async () => {
+    const { tempDir, repoDir } = createGitRepo();
+    const paseoHome = path.join(tempDir, ".paseo");
+    const slug = "mcp-request-replay";
+    const worktree = await createPaseoOwnedWorktree(repoDir, paseoHome, slug);
+    const { store, lifecycle } = createLifecycleOwner(paseoHome);
+    const resourceKey = `worktree:${path.resolve(worktree.worktreePath)}`;
+
+    const archiveWith = async (workspaceId: string, requestId: string) => {
+      const deps = createArchiveDeps({
+        paseoHome,
+        activeWorkspaces: [ownedWorkspaceRef(workspaceId, worktree.worktreePath, repoDir)],
+      });
+      deps.lifecycle = lifecycle;
+      return archiveByScope(deps, {
+        scope: { kind: "workspace", workspaceId },
+        requestId,
+      });
+    };
+    const recreateWorktree = async () => {
+      await createWorktree({
+        cwd: repoDir,
+        worktreeSlug: slug,
+        source: { kind: "checkout-branch", branchName: slug },
+        runSetup: false,
+        paseoHome,
+      });
+    };
+
+    const first = await archiveWith("ws-mcp-replay-1", `mcp:archive_workspace:ws-mcp:1`);
+    expect(first.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(false);
+
+    // A different per-call request id on the same target starts a fresh
+    // operation instead of replaying the first one.
+    await recreateWorktree();
+    const second = await archiveWith("ws-mcp-replay-2", `mcp:archive_workspace:ws-mcp:2`);
+    expect(second.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(false);
+    expect((await store.findCurrentByResource(resourceKey))?.generation).toBe(2);
+
+    // Retrying the same request id replays the committed result without
+    // running the removal again.
+    await recreateWorktree();
+    const replayed = await archiveWith("ws-mcp-replay-3", `mcp:archive_workspace:ws-mcp:2`);
+    expect(replayed.removedDirectory).toBe(true);
+    expect(existsSync(worktree.worktreePath)).toBe(true);
+    expect((await store.findCurrentByResource(resourceKey))?.generation).toBe(2);
+  });
+
+  test("waits for a shared workspace admission before removing the directory", async () => {
+    const { tempDir, repoDir } = createGitRepo();
+    const paseoHome = path.join(tempDir, ".paseo");
+    const worktree = await createPaseoOwnedWorktree(repoDir, paseoHome, "lifecycle-owner-lease");
+    const workspaceId = "ws-lifecycle-owner-lease";
+    const { store, lifecycle } = createLifecycleOwner(paseoHome);
+    const deps = createArchiveDeps({
+      paseoHome,
+      activeWorkspaces: [ownedWorkspaceRef(workspaceId, worktree.worktreePath, repoDir)],
+    });
+    deps.lifecycle = lifecycle;
+
+    let releaseAgent!: () => void;
+    const agentLease = lifecycle.withSharedAdmission(
+      { resourceKey: `workspace:${workspaceId}`, actor: "agent:test" },
+      async () => new Promise<void>((resolveLease) => (releaseAgent = resolveLease)),
+    );
+
+    const archive = archiveByScope(deps, {
+      scope: { kind: "workspace", workspaceId },
+      requestId: "req-lifecycle-owner-lease",
+    });
+    await vi.waitFor(async () => {
+      const nonterminal = await store.listNonterminal();
+      expect(nonterminal).toHaveLength(1);
+      expect(nonterminal[0]?.state).toBe("ADMISSION_CLOSED");
+    });
+    expect(existsSync(worktree.worktreePath)).toBe(true);
+
+    releaseAgent();
+    await agentLease;
+    const result = await archive;
     expect(result.removedDirectory).toBe(true);
     expect(existsSync(worktree.worktreePath)).toBe(false);
   });

--- a/packages/server/src/server/workspace-archive-service.ts
+++ b/packages/server/src/server/workspace-archive-service.ts
@@ -9,9 +9,14 @@ import type { ForgeService } from "../services/forge-service.js";
 import {
   deletePaseoWorktree,
   isPaseoOwnedWorktreeCwd,
+  removePaseoWorktreeStrict,
   runWorktreeTeardownCommands,
   WorktreeTeardownError,
 } from "../utils/worktree.js";
+import {
+  fingerprintWorkspaceLifecycleRequest,
+  type WorkspaceLifecycleOperationOwner,
+} from "./workspace-lifecycle-operation-service.js";
 import type { TerminalManager } from "../terminal/terminal-manager.js";
 import type {
   PersistedWorkspaceRecord,
@@ -50,6 +55,10 @@ export interface ArchiveDependencies {
   clearWorkspaceArchiving: (workspaceIds: Iterable<string>) => void;
   killTerminalsForWorkspace: (workspaceId: string) => Promise<void>;
   stopWorkspaceSetup?: (workspaceId: string) => Promise<void>;
+  // The workspace lifecycle operation owner. When present, the destructive
+  // directory removal runs as a durable lifecycle operation; when absent the
+  // legacy direct removal path applies (kept for direct-dependency tests).
+  lifecycle?: WorkspaceLifecycleOperationOwner;
   sessionLogger?: Logger;
 }
 
@@ -398,6 +407,15 @@ async function maybeRemoveDirectory(
     return false;
   }
 
+  if (dependencies.lifecycle) {
+    return removeBackingDirectoryThroughLifecycleOwner(
+      dependencies,
+      request,
+      backing,
+      archivedWorkspaceIds,
+    );
+  }
+
   try {
     await deletePaseoWorktree({
       cwd: backing.mainRepoRoot,
@@ -413,6 +431,77 @@ async function maybeRemoveDirectory(
     dependencies.sessionLogger?.warn(
       { err: error, targetPath: backing.path, requestId: request.requestId },
       "Worktree disk removal failed during archive; workspace already archived",
+    );
+    return false;
+  }
+}
+
+// The destructive step runs as a durable lifecycle operation: admission for
+// the archived workspaces closes and drains, the unreferenced check re-runs
+// inside the operation, and the mutation is a strict git-only removal. Any
+// failure records MANUAL_CLEANUP and preserves the directory — the owner path
+// never falls through to a recursive delete and never deletes branches.
+async function removeBackingDirectoryThroughLifecycleOwner(
+  dependencies: ArchiveDependencies,
+  request: Pick<ArchiveByScopeRequest, "requestId">,
+  backing: BackingDirectory,
+  archivedWorkspaceIds: string[],
+): Promise<boolean> {
+  const lifecycle = dependencies.lifecycle;
+  if (!lifecycle) {
+    return false;
+  }
+  const repoRoot = backing.mainRepoRoot;
+  if (!repoRoot) {
+    dependencies.sessionLogger?.warn(
+      { targetPath: backing.path, requestId: request.requestId },
+      "Worktree removal skipped: backing repository root is unknown",
+    );
+    return false;
+  }
+
+  try {
+    // The external requestId is the durable operation identity: a retried
+    // request replays the committed result, a conflicting reuse is rejected by
+    // the fingerprint, and nothing here auto-retries. Callers mint one unique
+    // requestId per logical archive request.
+    const result = await lifecycle.runRemoval({
+      operationId: `workspace-archive:${request.requestId}`,
+      fingerprint: fingerprintWorkspaceLifecycleRequest({
+        requestId: request.requestId,
+        targetPath: backing.path,
+      }),
+      resourceKey: `worktree:${backing.path}`,
+      admissionResourceKeys: archivedWorkspaceIds.map((workspaceId) => `workspace:${workspaceId}`),
+      allowDestructiveMutation: true,
+      quiesce: async () => {
+        // Agents and terminals owned by the archived workspaces were torn down
+        // in archiveTargetRecords, and teardown commands already ran above.
+      },
+      verify: async () =>
+        isDirectoryUnreferenced(
+          await dependencies.listActiveWorkspaces(),
+          backing.path,
+          new Set(archivedWorkspaceIds),
+          dependencies,
+        ),
+      mutate: async () => {
+        await removePaseoWorktreeStrict({
+          cwd: repoRoot,
+          worktreePath: backing.path,
+          worktreesRoot: backing.paseoWorktreesRoot ?? undefined,
+          paseoHome: dependencies.paseoHome,
+          worktreesBaseRoot: dependencies.paseoWorktreesBaseRoot,
+        });
+        return { removedDirectory: true };
+      },
+    });
+    dependencies.github.invalidate({ cwd: backing.path });
+    return result.removedDirectory;
+  } catch (error) {
+    dependencies.sessionLogger?.warn(
+      { err: error, targetPath: backing.path, requestId: request.requestId },
+      "Worktree disk removal blocked by lifecycle owner; workspace already archived",
     );
     return false;
   }

--- a/packages/server/src/server/workspace-lifecycle-operation-service.test.ts
+++ b/packages/server/src/server/workspace-lifecycle-operation-service.test.ts
@@ -1,0 +1,186 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../test-utils/test-logger.js";
+import { FileBackedWorkspaceLifecycleOperationStore } from "./workspace-lifecycle-operation-store.js";
+import {
+  PaseoWorkspaceLifecycleOperationService,
+  WorkspaceLifecycleManualCleanupError,
+  fingerprintWorkspaceLifecycleRequest,
+} from "./workspace-lifecycle-operation-service.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const target of cleanupPaths.splice(0)) {
+    rmSync(target, { recursive: true, force: true });
+  }
+});
+
+function createService(options?: { allowDestructiveMutation?: boolean }) {
+  const root = mkdtempSync(path.join(tmpdir(), "paseo-lifecycle-service-"));
+  cleanupPaths.push(root);
+  const store = new FileBackedWorkspaceLifecycleOperationStore({
+    filePath: path.join(root, "workspace-lifecycle-operations.json"),
+    logger: createTestLogger(),
+  });
+  return {
+    store,
+    service: new PaseoWorkspaceLifecycleOperationService({
+      store,
+      logger: createTestLogger(),
+      allowDestructiveMutation: options?.allowDestructiveMutation ?? true,
+    }),
+  };
+}
+
+describe("PaseoWorkspaceLifecycleOperationService", () => {
+  test("replays one committed create result without creating a replacement", async () => {
+    const { service } = createService();
+    const create = vi.fn(async () => ({ workspaceId: "wks_created" }));
+    const input = {
+      operationId: "create-request",
+      fingerprint: fingerprintWorkspaceLifecycleRequest({ cwd: "C:/repo", slug: "feature" }),
+      resourceKey: "worktree:C:/repo/feature",
+      create,
+    };
+
+    await expect(service.runCreate(input)).resolves.toEqual({ workspaceId: "wks_created" });
+    await expect(service.runCreate(input)).resolves.toEqual({ workspaceId: "wks_created" });
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects replay with a conflicting request fingerprint", async () => {
+    const { service } = createService();
+    await service.runCreate({
+      operationId: "create-conflict",
+      fingerprint: "fingerprint-a",
+      resourceKey: "worktree:C:/repo/conflict",
+      create: async () => ({ workspaceId: "wks_conflict" }),
+    });
+
+    await expect(
+      service.runCreate({
+        operationId: "create-conflict",
+        fingerprint: "fingerprint-b",
+        resourceKey: "worktree:C:/repo/conflict",
+        create: async () => ({ workspaceId: "replacement" }),
+      }),
+    ).rejects.toThrow(/fingerprint|conflict/i);
+  });
+
+  test("waits for shared admissions before entering destructive mutation", async () => {
+    const { service } = createService();
+    let releaseReader!: () => void;
+    const reader = service.withSharedAdmission(
+      { resourceKey: "workspace:wks_lease", actor: "agent" },
+      async () => new Promise<void>((resolve) => (releaseReader = resolve)),
+    );
+    await Promise.resolve();
+    const mutate = vi.fn(async () => ({ removedDirectory: true }));
+    const removal = service.runRemoval({
+      operationId: "archive-lease",
+      fingerprint: "archive-fingerprint",
+      resourceKey: "workspace:wks_lease",
+      quiesce: async () => {},
+      verify: async () => true,
+      mutate,
+    });
+
+    await Promise.resolve();
+    expect(mutate).not.toHaveBeenCalled();
+    releaseReader();
+    await reader;
+    await expect(removal).resolves.toEqual({ removedDirectory: true });
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  test("records MANUAL_CLEANUP and preserves the resource when quiescence fails", async () => {
+    const { service, store } = createService();
+    const mutate = vi.fn(async () => ({ removedDirectory: true }));
+    await expect(
+      service.runRemoval({
+        operationId: "archive-quiescence",
+        fingerprint: "archive-fingerprint",
+        resourceKey: "workspace:wks_quiescence",
+        quiesce: async () => {
+          throw new Error("terminal refused to stop");
+        },
+        verify: async () => true,
+        mutate,
+      }),
+    ).rejects.toBeInstanceOf(WorkspaceLifecycleManualCleanupError);
+    expect(mutate).not.toHaveBeenCalled();
+    expect((await store.get("archive-quiescence"))?.state).toBe("MANUAL_CLEANUP");
+  });
+
+  test("keeps live automatic deletion disabled by default", async () => {
+    const { service, store } = createService({ allowDestructiveMutation: false });
+    const mutate = vi.fn(async () => ({ removedDirectory: true }));
+    await expect(
+      service.runRemoval({
+        operationId: "archive-disabled",
+        fingerprint: "archive-fingerprint",
+        resourceKey: "workspace:wks_disabled",
+        quiesce: async () => {},
+        verify: async () => true,
+        mutate,
+      }),
+    ).rejects.toBeInstanceOf(WorkspaceLifecycleManualCleanupError);
+    expect(mutate).not.toHaveBeenCalled();
+    expect((await store.get("archive-disabled"))?.state).toBe("MANUAL_CLEANUP");
+  });
+
+  test("startup recovery claims interrupted operations without creating replacements", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "paseo-lifecycle-restart-"));
+    cleanupPaths.push(root);
+    const filePath = path.join(root, "workspace-lifecycle-operations.json");
+    const crashedStore = new FileBackedWorkspaceLifecycleOperationStore({
+      filePath,
+      logger: createTestLogger(),
+    });
+    const reserved = await crashedStore.reserve({
+      operationId: "interrupted-archive",
+      kind: "archive",
+      fingerprint: "interrupted-fingerprint",
+      resourceKey: "worktree:C:/repo/interrupted",
+    });
+    await crashedStore.compareAndTransition({
+      operationId: reserved.record.operationId,
+      expectedVersion: reserved.record.version,
+      expectedState: "PREPARED",
+      expectedFence: reserved.record.fence,
+      nextState: "ADMISSION_CLOSED",
+    });
+
+    const restartedStore = new FileBackedWorkspaceLifecycleOperationStore({
+      filePath,
+      logger: createTestLogger(),
+    });
+    const restartedService = new PaseoWorkspaceLifecycleOperationService({
+      store: restartedStore,
+      logger: createTestLogger(),
+    });
+    const recovered = await restartedService.recoverInterruptedOperations();
+
+    expect(recovered).toHaveLength(1);
+    const record = await restartedStore.get("interrupted-archive");
+    expect(record?.state).toBe("MANUAL_CLEANUP");
+    expect(record?.claimedBy).toBe("startup-recovery");
+    expect(record?.evidence).toContain("ADMISSION_CLOSED");
+    expect(await restartedStore.listNonterminal()).toEqual([]);
+
+    // The claimed record frees the resource for an explicit new request.
+    const retried = await restartedStore.reserve({
+      operationId: "interrupted-archive-retry",
+      kind: "archive",
+      fingerprint: "retry-fingerprint",
+      resourceKey: "worktree:C:/repo/interrupted",
+    });
+    expect(retried.kind).toBe("created");
+    expect(retried.record.generation).toBe(2);
+  });
+});

--- a/packages/server/src/server/workspace-lifecycle-operation-service.ts
+++ b/packages/server/src/server/workspace-lifecycle-operation-service.ts
@@ -1,0 +1,348 @@
+import { createHash } from "node:crypto";
+
+import type { Logger } from "pino";
+
+import {
+  type FileBackedWorkspaceLifecycleOperationStore,
+  WorkspaceLifecycleOperationConflictError,
+  type WorkspaceLifecycleOperationRecord,
+  type WorkspaceLifecycleOperationState,
+} from "./workspace-lifecycle-operation-store.js";
+
+export interface WorkspaceLifecycleAdmissionInput {
+  resourceKey: string;
+  actor: string;
+}
+
+/**
+ * Shared admission lease on a lifecycle resource. Mutating consumers (agent
+ * registration, terminals) hold a shared admission while they work; removal
+ * closes admission and drains the active leases before destructive mutation.
+ */
+export interface WorkspaceLifecycleAdmission {
+  withSharedAdmission<T>(
+    input: WorkspaceLifecycleAdmissionInput,
+    action: () => Promise<T>,
+  ): Promise<T>;
+}
+
+export class WorkspaceLifecycleAdmissionClosedError extends Error {
+  constructor(
+    public readonly resourceKey: string,
+    public readonly actor: string,
+  ) {
+    super(`Workspace lifecycle admission closed for ${resourceKey} (requested by ${actor})`);
+    this.name = "WorkspaceLifecycleAdmissionClosedError";
+  }
+}
+
+export class WorkspaceLifecycleManualCleanupError extends Error {
+  constructor(
+    public readonly operationId: string,
+    public readonly resourceKey: string,
+    public readonly reason: string,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `Lifecycle operation ${operationId} on ${resourceKey} requires manual cleanup: ${reason}`,
+      options,
+    );
+    this.name = "WorkspaceLifecycleManualCleanupError";
+  }
+}
+
+/**
+ * Deterministic fingerprint for an idempotent lifecycle request. The same
+ * logical request always produces the same fingerprint, so a retried request
+ * replays the committed result instead of creating a second resource.
+ */
+export function fingerprintWorkspaceLifecycleRequest(request: Record<string, unknown>): string {
+  const canonical = JSON.stringify(
+    Object.keys(request)
+      .sort()
+      .map((key) => [key, request[key]]),
+  );
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export interface RunWorkspaceLifecycleCreateInput<TResult> {
+  operationId: string;
+  fingerprint: string;
+  resourceKey: string;
+  create: () => Promise<TResult>;
+}
+
+export interface RunWorkspaceLifecycleRemovalInput<TResult> {
+  operationId: string;
+  fingerprint: string;
+  resourceKey: string;
+  /**
+   * Additional admission gates to close and drain before destructive mutation,
+   * e.g. the `workspace:<id>` keys of every workspace record backed by the
+   * directory being removed. The operation's own resourceKey is always closed.
+   */
+  admissionResourceKeys?: readonly string[];
+  /**
+   * Per-operation destructive opt-in. Absent, the service-level default (off
+   * unless explicitly enabled at construction) applies. The only production
+   * caller that opts in is the explicit workspace archive flow, after records
+   * are archived and quiescence is verified.
+   */
+  allowDestructiveMutation?: boolean;
+  quiesce: () => Promise<void>;
+  verify: () => Promise<boolean>;
+  mutate: () => Promise<TResult>;
+}
+
+interface AdmissionGate {
+  closed: boolean;
+  /** Settled-safe wrappers of in-flight shared admissions. */
+  active: Set<Promise<void>>;
+}
+
+/**
+ * Owner of workspace lifecycle operations. Every create and removal runs as a
+ * durable operation record in the store; replays return the committed result,
+ * conflicting requests fail closed, and destructive mutation is reached only
+ * after admission is closed, active leases drain, and quiescence is verified.
+ */
+export class PaseoWorkspaceLifecycleOperationService implements WorkspaceLifecycleAdmission {
+  private readonly store: FileBackedWorkspaceLifecycleOperationStore;
+  private readonly logger: Logger;
+  private readonly allowDestructiveMutation: boolean;
+  private readonly gates = new Map<string, AdmissionGate>();
+
+  constructor(options: {
+    store: FileBackedWorkspaceLifecycleOperationStore;
+    logger: Logger;
+    allowDestructiveMutation?: boolean;
+  }) {
+    this.store = options.store;
+    this.logger = options.logger.child({ module: "workspace-lifecycle-operation-service" });
+    this.allowDestructiveMutation = options.allowDestructiveMutation ?? false;
+  }
+
+  async withSharedAdmission<T>(
+    input: WorkspaceLifecycleAdmissionInput,
+    action: () => Promise<T>,
+  ): Promise<T> {
+    const gate = this.gate(input.resourceKey);
+    if (gate.closed) {
+      throw new WorkspaceLifecycleAdmissionClosedError(input.resourceKey, input.actor);
+    }
+    // Registration is synchronous relative to the closed check above, so a
+    // concurrent close cannot miss this lease.
+    const admission = action();
+    const tracked = admission.then(
+      () => undefined,
+      () => undefined,
+    );
+    gate.active.add(tracked);
+    try {
+      return await admission;
+    } finally {
+      gate.active.delete(tracked);
+    }
+  }
+
+  async runCreate<TResult>(input: RunWorkspaceLifecycleCreateInput<TResult>): Promise<TResult> {
+    const reservation = await this.store.reserve({
+      operationId: input.operationId,
+      kind: "create",
+      fingerprint: input.fingerprint,
+      resourceKey: input.resourceKey,
+    });
+    if (reservation.kind === "replay") {
+      return this.replayTerminalResult<TResult>(reservation.record);
+    }
+
+    let record = await this.transition(reservation.record, "MUTATING");
+    let result: TResult;
+    try {
+      result = await input.create();
+    } catch (error) {
+      // The create callback compensates inline (rollback of a partially
+      // created resource) before rethrowing, so the record terminates here to
+      // release the resource for a retry under a new generation.
+      const compensating = await this.transition(record, "NEEDS_COMPENSATION", {
+        evidence: `create failed: ${describeError(error)}`,
+      });
+      await this.transition(compensating, "MANUAL_CLEANUP");
+      throw error;
+    }
+    record = await this.transition(record, "RESOURCE_CREATED", { result });
+    await this.transition(record, "COMMITTED");
+    return result;
+  }
+
+  async runRemoval<TResult>(input: RunWorkspaceLifecycleRemovalInput<TResult>): Promise<TResult> {
+    const reservation = await this.store.reserve({
+      operationId: input.operationId,
+      kind: "archive",
+      fingerprint: input.fingerprint,
+      resourceKey: input.resourceKey,
+    });
+    if (reservation.kind === "replay") {
+      return this.replayTerminalResult<TResult>(reservation.record);
+    }
+
+    let record = reservation.record;
+    if (!(input.allowDestructiveMutation ?? this.allowDestructiveMutation)) {
+      throw await this.failToManualCleanup(record, "automatic destructive mutation is disabled");
+    }
+
+    const draining: Promise<void>[] = [];
+    for (const key of [input.resourceKey, ...(input.admissionResourceKeys ?? [])]) {
+      const gate = this.gate(key);
+      gate.closed = true;
+      draining.push(...gate.active);
+    }
+    record = await this.transition(record, "ADMISSION_CLOSED");
+    await Promise.all(draining);
+
+    try {
+      await input.quiesce();
+    } catch (error) {
+      throw await this.failToManualCleanup(record, `quiescence failed: ${describeError(error)}`, {
+        cause: error,
+      });
+    }
+    record = await this.transition(record, "QUIESCED");
+
+    if (!(await input.verify())) {
+      throw await this.failToManualCleanup(record, "removal verification failed");
+    }
+    record = await this.transition(record, "MUTATING");
+
+    let result: TResult;
+    try {
+      result = await input.mutate();
+    } catch (error) {
+      throw await this.failToManualCleanup(record, `mutation failed: ${describeError(error)}`, {
+        cause: error,
+      });
+    }
+    record = await this.transition(record, "RESOURCE_REMOVED", { result });
+    await this.transition(record, "COMMITTED");
+    return result;
+  }
+
+  /**
+   * Fail-closed startup recovery. Every operation a prior process left
+   * nonterminal is claimed and recorded MANUAL_CLEANUP so its resource frees
+   * for an explicit retry. No create/mutate callbacks run — recovery never
+   * builds replacement resources.
+   */
+  async recoverInterruptedOperations(): Promise<WorkspaceLifecycleOperationRecord[]> {
+    const interrupted = await this.store.listNonterminal();
+    const recovered: WorkspaceLifecycleOperationRecord[] = [];
+    for (const record of interrupted) {
+      recovered.push(
+        await this.store.compareAndTransition({
+          operationId: record.operationId,
+          expectedVersion: record.version,
+          expectedState: record.state,
+          expectedFence: record.fence,
+          nextState: "MANUAL_CLEANUP",
+          evidence: `daemon restart found operation nonterminal in state ${record.state}`,
+          claimedBy: "startup-recovery",
+        }),
+      );
+      this.logger.warn(
+        {
+          operationId: record.operationId,
+          resourceKey: record.resourceKey,
+          priorState: record.state,
+        },
+        "Workspace lifecycle operation interrupted by restart; recorded MANUAL_CLEANUP",
+      );
+    }
+    return recovered;
+  }
+
+  private gate(resourceKey: string): AdmissionGate {
+    let gate = this.gates.get(resourceKey);
+    if (!gate) {
+      gate = { closed: false, active: new Set() };
+      this.gates.set(resourceKey, gate);
+    }
+    return gate;
+  }
+
+  private replayTerminalResult<TResult>(record: WorkspaceLifecycleOperationRecord): TResult {
+    if (record.state === "COMMITTED") {
+      return record.result as TResult;
+    }
+    if (record.state === "MANUAL_CLEANUP") {
+      throw new WorkspaceLifecycleManualCleanupError(
+        record.operationId,
+        record.resourceKey,
+        record.evidence ?? "operation previously recorded for manual cleanup",
+      );
+    }
+    throw new WorkspaceLifecycleOperationConflictError(
+      `Lifecycle operation ${record.operationId} is still in flight (state ${record.state})`,
+    );
+  }
+
+  private async transition(
+    record: WorkspaceLifecycleOperationRecord,
+    nextState: WorkspaceLifecycleOperationState,
+    updates?: { result?: unknown; evidence?: string | null },
+  ): Promise<WorkspaceLifecycleOperationRecord> {
+    return this.store.compareAndTransition({
+      operationId: record.operationId,
+      expectedVersion: record.version,
+      expectedState: record.state,
+      expectedFence: record.fence,
+      nextState,
+      result: updates?.result,
+      evidence: updates?.evidence,
+    });
+  }
+
+  private async failToManualCleanup(
+    record: WorkspaceLifecycleOperationRecord,
+    reason: string,
+    options?: { cause?: unknown },
+  ): Promise<WorkspaceLifecycleManualCleanupError> {
+    await this.transition(record, "MANUAL_CLEANUP", { evidence: reason });
+    this.logger.error(
+      { operationId: record.operationId, resourceKey: record.resourceKey, reason },
+      "Workspace lifecycle operation recorded MANUAL_CLEANUP",
+    );
+    return new WorkspaceLifecycleManualCleanupError(
+      record.operationId,
+      record.resourceKey,
+      reason,
+      options,
+    );
+  }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The capability surface production callers hold on the lifecycle owner. The
+ * daemon constructs one service instance and threads this view through the
+ * create, removal, and admission integration points.
+ */
+export type WorkspaceLifecycleOperationOwner = Pick<
+  PaseoWorkspaceLifecycleOperationService,
+  "runCreate" | "runRemoval" | "withSharedAdmission"
+>;
+
+/**
+ * Reads the lifecycle owner off a carrier (the daemon's AgentManager). Only a
+ * real owner object counts: carriers are frequently partial doubles whose
+ * unknown properties are not the owner, so anything that is not an object
+ * resolves to undefined and the caller stays on its non-owner path.
+ */
+export function resolveWorkspaceLifecycleOperationOwner(carrier: {
+  workspaceLifecycleOperations?: WorkspaceLifecycleOperationOwner | null;
+}): WorkspaceLifecycleOperationOwner | undefined {
+  const candidate = carrier.workspaceLifecycleOperations;
+  return candidate !== null && typeof candidate === "object" ? candidate : undefined;
+}

--- a/packages/server/src/server/workspace-lifecycle-operation-store.test.ts
+++ b/packages/server/src/server/workspace-lifecycle-operation-store.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { createTestLogger } from "../test-utils/test-logger.js";
+import {
+  FileBackedWorkspaceLifecycleOperationStore,
+  WorkspaceLifecycleOperationConflictError,
+} from "./workspace-lifecycle-operation-store.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const target of cleanupPaths.splice(0)) {
+    rmSync(target, { recursive: true, force: true });
+  }
+});
+
+function createStore() {
+  const root = mkdtempSync(path.join(tmpdir(), "paseo-lifecycle-store-"));
+  cleanupPaths.push(root);
+  const filePath = path.join(root, "workspace-lifecycle-operations.json");
+  return {
+    filePath,
+    store: new FileBackedWorkspaceLifecycleOperationStore({
+      filePath,
+      logger: createTestLogger(),
+    }),
+  };
+}
+
+describe("FileBackedWorkspaceLifecycleOperationStore", () => {
+  test("replays the same operation and rejects a conflicting fingerprint", async () => {
+    const { store } = createStore();
+    const first = await store.reserve({
+      operationId: "request-1",
+      kind: "create",
+      fingerprint: "fingerprint-a",
+      resourceKey: "worktree:repo/feature",
+    });
+    const replay = await store.reserve({
+      operationId: "request-1",
+      kind: "create",
+      fingerprint: "fingerprint-a",
+      resourceKey: "worktree:repo/feature",
+    });
+
+    expect(first.kind).toBe("created");
+    expect(replay).toEqual({ kind: "replay", record: first.record });
+    await expect(
+      store.reserve({
+        operationId: "request-1",
+        kind: "create",
+        fingerprint: "fingerprint-b",
+        resourceKey: "worktree:repo/feature",
+      }),
+    ).rejects.toBeInstanceOf(WorkspaceLifecycleOperationConflictError);
+  });
+
+  test("persists before publishing a compare-and-transition", async () => {
+    const { filePath, store } = createStore();
+    const reserved = await store.reserve({
+      operationId: "request-2",
+      kind: "archive",
+      fingerprint: "fingerprint",
+      resourceKey: "workspace:wks_1",
+    });
+    const transitioned = await store.compareAndTransition({
+      operationId: reserved.record.operationId,
+      expectedVersion: reserved.record.version,
+      expectedState: "PREPARED",
+      expectedFence: reserved.record.fence,
+      nextState: "ADMISSION_CLOSED",
+    });
+
+    const reopened = new FileBackedWorkspaceLifecycleOperationStore({
+      filePath,
+      logger: createTestLogger(),
+    });
+    await reopened.initialize();
+    expect(await reopened.get("request-2")).toEqual(transitioned);
+  });
+
+  test("rejects a stale fence and preserves the current record", async () => {
+    const { store } = createStore();
+    const reserved = await store.reserve({
+      operationId: "request-3",
+      kind: "archive",
+      fingerprint: "fingerprint",
+      resourceKey: "workspace:wks_2",
+    });
+
+    await expect(
+      store.compareAndTransition({
+        operationId: reserved.record.operationId,
+        expectedVersion: reserved.record.version,
+        expectedState: "PREPARED",
+        expectedFence: reserved.record.fence + 1,
+        nextState: "ADMISSION_CLOSED",
+      }),
+    ).rejects.toThrow(/stale/i);
+    expect((await store.get("request-3"))?.state).toBe("PREPARED");
+  });
+
+  test("fails closed when the journal is malformed", async () => {
+    const { filePath } = createStore();
+    writeFileSync(filePath, '{"schemaVersion":"1","operations":[]}', "utf8");
+    const reopened = new FileBackedWorkspaceLifecycleOperationStore({
+      filePath,
+      logger: createTestLogger(),
+    });
+    await expect(reopened.initialize()).rejects.toThrow();
+  });
+
+  test("allows only one nonterminal owner for a resource", async () => {
+    const { store } = createStore();
+    await store.reserve({
+      operationId: "request-owner-a",
+      kind: "archive",
+      fingerprint: "a",
+      resourceKey: "workspace:wks_3",
+    });
+    await expect(
+      store.reserve({
+        operationId: "request-owner-b",
+        kind: "archive",
+        fingerprint: "b",
+        resourceKey: "workspace:wks_3",
+      }),
+    ).rejects.toThrow(/owned|nonterminal|busy/i);
+  });
+});

--- a/packages/server/src/server/workspace-lifecycle-operation-store.ts
+++ b/packages/server/src/server/workspace-lifecycle-operation-store.ts
@@ -1,0 +1,287 @@
+import { promises as fs } from "node:fs";
+
+import type { Logger } from "pino";
+import { z } from "zod";
+
+import { writeJsonFileAtomicDurable } from "./atomic-file.js";
+
+export const WORKSPACE_LIFECYCLE_OPERATION_STATES = [
+  "PREPARED",
+  "ADMISSION_CLOSED",
+  "QUIESCED",
+  "MUTATING",
+  "RESOURCE_CREATED",
+  "RESOURCE_REMOVED",
+  "COMMITTED",
+  "NEEDS_COMPENSATION",
+  "MANUAL_CLEANUP",
+] as const;
+
+export type WorkspaceLifecycleOperationState =
+  (typeof WORKSPACE_LIFECYCLE_OPERATION_STATES)[number];
+export type WorkspaceLifecycleOperationKind = "create" | "archive" | "recovery" | "rollback";
+
+const terminalStates = new Set<WorkspaceLifecycleOperationState>([
+  "COMMITTED",
+  "MANUAL_CLEANUP",
+]);
+
+const operationRecordSchema = z
+  .object({
+    operationId: z.string().min(1),
+    kind: z.enum(["create", "archive", "recovery", "rollback"]),
+    fingerprint: z.string().min(1),
+    resourceKey: z.string().min(1),
+    generation: z.number().int().positive(),
+    fence: z.number().int().positive(),
+    version: z.number().int().positive(),
+    state: z.enum(WORKSPACE_LIFECYCLE_OPERATION_STATES),
+    result: z.unknown().nullable(),
+    evidence: z.string().nullable(),
+    claimedBy: z.string().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+const journalSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    operations: z.array(operationRecordSchema),
+  })
+  .strict();
+
+export type WorkspaceLifecycleOperationRecord = z.infer<typeof operationRecordSchema>;
+
+export class WorkspaceLifecycleOperationConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspaceLifecycleOperationConflictError";
+  }
+}
+
+export class WorkspaceLifecycleOperationStaleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspaceLifecycleOperationStaleError";
+  }
+}
+
+export interface ReserveWorkspaceLifecycleOperationInput {
+  operationId: string;
+  kind: WorkspaceLifecycleOperationKind;
+  fingerprint: string;
+  resourceKey: string;
+}
+
+export type ReserveWorkspaceLifecycleOperationResult =
+  | { kind: "created"; record: WorkspaceLifecycleOperationRecord }
+  | { kind: "replay"; record: WorkspaceLifecycleOperationRecord };
+
+export interface CompareWorkspaceLifecycleOperationInput {
+  operationId: string;
+  expectedVersion: number;
+  expectedState: WorkspaceLifecycleOperationState;
+  expectedFence: number;
+  nextState: WorkspaceLifecycleOperationState;
+  result?: unknown;
+  evidence?: string | null;
+  claimedBy?: string | null;
+}
+
+const allowedTransitions: Readonly<
+  Record<WorkspaceLifecycleOperationState, ReadonlySet<WorkspaceLifecycleOperationState>>
+> = {
+  PREPARED: new Set(["ADMISSION_CLOSED", "MUTATING", "NEEDS_COMPENSATION", "MANUAL_CLEANUP"]),
+  ADMISSION_CLOSED: new Set(["QUIESCED", "MANUAL_CLEANUP"]),
+  QUIESCED: new Set(["MUTATING", "MANUAL_CLEANUP"]),
+  MUTATING: new Set([
+    "RESOURCE_CREATED",
+    "RESOURCE_REMOVED",
+    "NEEDS_COMPENSATION",
+    "MANUAL_CLEANUP",
+  ]),
+  RESOURCE_CREATED: new Set(["COMMITTED", "NEEDS_COMPENSATION", "MANUAL_CLEANUP"]),
+  RESOURCE_REMOVED: new Set(["COMMITTED", "MANUAL_CLEANUP"]),
+  NEEDS_COMPENSATION: new Set(["MANUAL_CLEANUP"]),
+  COMMITTED: new Set(),
+  MANUAL_CLEANUP: new Set(),
+};
+
+export class FileBackedWorkspaceLifecycleOperationStore {
+  private readonly filePath: string;
+  private readonly logger: Logger;
+  private readonly now: () => Date;
+  private loaded = false;
+  private operations = new Map<string, WorkspaceLifecycleOperationRecord>();
+  private mutationQueue: Promise<void> = Promise.resolve();
+
+  constructor(options: { filePath: string; logger: Logger; now?: () => Date }) {
+    this.filePath = options.filePath;
+    this.logger = options.logger.child({ module: "workspace-lifecycle-operation-store" });
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async initialize(): Promise<void> {
+    await this.serializeMutation(async () => this.load());
+  }
+
+  async get(operationId: string): Promise<WorkspaceLifecycleOperationRecord | null> {
+    await this.initializeIfNeeded();
+    return this.operations.get(operationId) ?? null;
+  }
+
+  async listNonterminal(): Promise<WorkspaceLifecycleOperationRecord[]> {
+    await this.initializeIfNeeded();
+    return Array.from(this.operations.values()).filter((record) => !terminalStates.has(record.state));
+  }
+
+  async findCurrentByResource(
+    resourceKey: string,
+  ): Promise<WorkspaceLifecycleOperationRecord | null> {
+    await this.initializeIfNeeded();
+    const matches = Array.from(this.operations.values()).filter(
+      (record) => record.resourceKey === resourceKey,
+    );
+    matches.sort((left, right) => right.generation - left.generation);
+    return matches[0] ?? null;
+  }
+
+  async reserve(
+    input: ReserveWorkspaceLifecycleOperationInput,
+  ): Promise<ReserveWorkspaceLifecycleOperationResult> {
+    return this.serializeMutation(async () => {
+      await this.load();
+      const existing = this.operations.get(input.operationId);
+      if (existing) {
+        if (
+          existing.kind !== input.kind ||
+          existing.fingerprint !== input.fingerprint ||
+          existing.resourceKey !== input.resourceKey
+        ) {
+          throw new WorkspaceLifecycleOperationConflictError(
+            `Lifecycle operation ${input.operationId} conflicts with its durable fingerprint`,
+          );
+        }
+        return { kind: "replay", record: existing };
+      }
+
+      const resourceRecords = Array.from(this.operations.values()).filter(
+        (record) => record.resourceKey === input.resourceKey,
+      );
+      const activeOwner = resourceRecords.find((record) => !terminalStates.has(record.state));
+      if (activeOwner) {
+        throw new WorkspaceLifecycleOperationConflictError(
+          `Resource ${input.resourceKey} is owned by nonterminal operation ${activeOwner.operationId}`,
+        );
+      }
+      const generation =
+        resourceRecords.reduce((maximum, record) => Math.max(maximum, record.generation), 0) + 1;
+      const timestamp = this.now().toISOString();
+      const record: WorkspaceLifecycleOperationRecord = {
+        operationId: input.operationId,
+        kind: input.kind,
+        fingerprint: input.fingerprint,
+        resourceKey: input.resourceKey,
+        generation,
+        fence: generation,
+        version: 1,
+        state: "PREPARED",
+        result: null,
+        evidence: null,
+        claimedBy: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      const next = new Map(this.operations);
+      next.set(record.operationId, record);
+      await this.persist(next);
+      this.operations = next;
+      return { kind: "created", record };
+    });
+  }
+
+  async compareAndTransition(
+    input: CompareWorkspaceLifecycleOperationInput,
+  ): Promise<WorkspaceLifecycleOperationRecord> {
+    return this.serializeMutation(async () => {
+      await this.load();
+      const current = this.operations.get(input.operationId);
+      if (!current) {
+        throw new WorkspaceLifecycleOperationStaleError(
+          `Lifecycle operation ${input.operationId} is missing`,
+        );
+      }
+      if (
+        current.version !== input.expectedVersion ||
+        current.state !== input.expectedState ||
+        current.fence !== input.expectedFence
+      ) {
+        throw new WorkspaceLifecycleOperationStaleError(
+          `Lifecycle operation ${input.operationId} has a stale version, state, or fence`,
+        );
+      }
+      if (!allowedTransitions[current.state].has(input.nextState)) {
+        throw new WorkspaceLifecycleOperationConflictError(
+          `Invalid lifecycle transition ${current.state} -> ${input.nextState}`,
+        );
+      }
+      const nextRecord = operationRecordSchema.parse({
+        ...current,
+        version: current.version + 1,
+        state: input.nextState,
+        result: input.result === undefined ? current.result : input.result,
+        evidence: input.evidence === undefined ? current.evidence : input.evidence,
+        claimedBy: input.claimedBy === undefined ? current.claimedBy : input.claimedBy,
+        updatedAt: this.now().toISOString(),
+      });
+      const next = new Map(this.operations);
+      next.set(nextRecord.operationId, nextRecord);
+      await this.persist(next);
+      this.operations = next;
+      return nextRecord;
+    });
+  }
+
+  private async initializeIfNeeded(): Promise<void> {
+    if (!this.loaded) {
+      await this.initialize();
+    }
+  }
+
+  private async load(): Promise<void> {
+    if (this.loaded) return;
+    try {
+      const raw = await fs.readFile(this.filePath, "utf8");
+      const journal = journalSchema.parse(JSON.parse(raw));
+      this.operations = new Map(journal.operations.map((record) => [record.operationId, record]));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        this.logger.error({ err: error, filePath: this.filePath }, "Failed to load lifecycle journal");
+        throw error;
+      }
+      this.operations = new Map();
+    }
+    this.loaded = true;
+  }
+
+  private async persist(
+    operations: ReadonlyMap<string, WorkspaceLifecycleOperationRecord>,
+  ): Promise<void> {
+    await writeJsonFileAtomicDurable(this.filePath, {
+      schemaVersion: 1,
+      operations: Array.from(operations.values()).sort((left, right) =>
+        left.operationId.localeCompare(right.operationId),
+      ),
+    });
+  }
+
+  private serializeMutation<T>(mutation: () => Promise<T>): Promise<T> {
+    const result = this.mutationQueue.then(mutation);
+    this.mutationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}

--- a/packages/server/src/server/worktree-session.test.ts
+++ b/packages/server/src/server/worktree-session.test.ts
@@ -2133,3 +2133,45 @@ describe("handlePaseoWorktreeArchiveRequest worktree scope", () => {
     ).toHaveLength(2);
   });
 });
+
+test("buildAgentSessionConfig forwards the exact lifecycleOperationId to worktree creation", async () => {
+  const createPaseoWorktree = vi.fn(async () => {
+    throw new Error("stop after capture");
+  });
+
+  await expect(
+    buildAgentSessionConfig(
+      {
+        paseoHome: "/paseo-home",
+        sessionLogger: createLogger(),
+        workspaceGitService: {
+          resolveRepoRoot: vi.fn(async () => "/repo"),
+          resolveDefaultBranch: vi.fn(async () => "main"),
+        } as unknown as WorkspaceGitService,
+        createPaseoWorktree,
+        checkoutExistingBranch: async () => {
+          throw new Error("should not checkout existing branch");
+        },
+        createBranchFromBase: async () => {
+          throw new Error("should not create a new branch from base");
+        },
+      },
+      {
+        provider: "codex",
+        cwd: "/repo",
+      },
+      undefined,
+      "legacy-worktree",
+      undefined,
+      "create-agent-worktree:req-legacy-1",
+    ),
+  ).rejects.toThrow("stop after capture");
+
+  expect(createPaseoWorktree).toHaveBeenCalledWith(
+    expect.objectContaining({
+      worktreeSlug: "legacy-worktree",
+      lifecycleOperationId: "create-agent-worktree:req-legacy-1",
+    }),
+    expect.anything(),
+  );
+});

--- a/packages/server/src/server/worktree-session.ts
+++ b/packages/server/src/server/worktree-session.ts
@@ -197,6 +197,7 @@ export async function buildAgentSessionConfig(
   gitOptions?: GitSetupOptions,
   legacyWorktreeName?: string,
   firstAgentContext?: FirstAgentContext,
+  lifecycleOperationId?: string,
 ): Promise<{
   sessionConfig: AgentSessionConfig;
   setupContinuation?: AgentWorktreeSetupContinuation;
@@ -234,6 +235,7 @@ export async function buildAgentSessionConfig(
         runSetup: false,
         paseoHome: dependencies.paseoHome,
         worktreesRoot: dependencies.worktreesRoot,
+        lifecycleOperationId,
       },
       {
         resolveDefaultBranch: normalized.baseBranch
@@ -526,6 +528,7 @@ export async function handleCreatePaseoWorktreeRequest(
         action: request.action,
         checkoutSource: request.checkoutSource,
         githubPrNumber: request.githubPrNumber,
+        lifecycleOperationId: request.requestId,
       },
     );
 

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -1165,6 +1165,61 @@ export async function rollbackCreatedPaseoWorktree(
   throw cause;
 }
 
+export interface RemovePaseoWorktreeStrictOptions {
+  cwd: string;
+  worktreePath: string;
+  worktreesRoot?: string;
+  paseoHome?: string;
+  worktreesBaseRoot?: string;
+}
+
+/**
+ * Removal path for the workspace lifecycle owner: `git worktree remove` must
+ * succeed, or the caller records manual cleanup. Never falls through to a
+ * recursive directory delete and never touches branches.
+ */
+export async function removePaseoWorktreeStrict({
+  cwd,
+  worktreePath,
+  worktreesRoot,
+  paseoHome,
+  worktreesBaseRoot,
+}: RemovePaseoWorktreeStrictOptions): Promise<void> {
+  const resolvedWorktreesRoot =
+    worktreesRoot ?? (await getPaseoWorktreesRoot(cwd, paseoHome, worktreesBaseRoot));
+  const resolvedRequested = normalizePathForOwnership(worktreePath);
+  const ownership = await isPaseoOwnedWorktreeCwd(worktreePath, {
+    paseoHome,
+    worktreesRoot: worktreesBaseRoot,
+  });
+  const resolvedWorktree =
+    ownership.allowed && ownership.worktreePath ? ownership.worktreePath : resolvedRequested;
+
+  const relativeWorktreePath = getRealpathAwareRelativePath(
+    resolvedWorktreesRoot,
+    resolvedWorktree,
+  );
+  if (relativeWorktreePath === null || relativeWorktreePath === "") {
+    throw new Error("Refusing to delete non-Paseo worktree");
+  }
+
+  await runGitCommand(["worktree", "remove", resolvedWorktree, "--force"], {
+    cwd,
+    timeout: 120_000,
+  });
+  if (await pathExists(resolvedWorktree)) {
+    throw new Error(
+      `Worktree directory still exists after git worktree remove: ${resolvedWorktree}`,
+    );
+  }
+
+  try {
+    await runGitCommand(["worktree", "prune"], { cwd, timeout: 30_000 });
+  } catch {
+    // not critical; git will prune lazily
+  }
+}
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await stat(path);


### PR DESCRIPTION
## Summary
- add a durable file-backed lifecycle operation store and owner state machine
- fence workspace admission/removal and route sessions, recovery, schedules, MCP, and create-agent boundaries through one owner
- fail closed with strict Git worktree compensation and durable manual-cleanup evidence
- propagate collision-safe operation identities through production boundaries

## Test plan
- [x] precommit source/index audit by an existing read-only verifier (`PRECOMMIT_PASS`)
- [x] focused lifecycle/MCP tests on the source checkpoint (117/117 MCP; lifecycle batches green)
- [x] secret scan and `git diff --check`
- [x] authoritative CI on this rebased commit

## Known limits
- exact local typecheck/E2E on the rebased candidate was not established because of sandbox dependency-cache restrictions and Windows host commit exhaustion; CI is the acceptance authority
- MCP identity without a transport session ID is unique only within the transport request-ID lifetime
- rollback preserves/quarantines lifecycle journals and never blindly deletes `MANUAL_CLEANUP` or nonterminal evidence