### PR TITLE
Support asynchronous commands for custom ACP providers

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -532,6 +532,30 @@ Only enable capabilities Paseo should execute. When the agent and Paseo run in
 different environments, configure equivalent absolute workspace paths before
 delegating filesystem or terminal operations to Paseo.
 
+Some ACP agents publish slash commands asynchronously after `session/new`.
+Enable initial command waiting for those providers so the new-agent composer
+does not read an empty command list before the update arrives:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "my-agent": {
+        "extends": "acp",
+        "label": "My Agent",
+        "command": ["my-agent", "acp"],
+        "params": {
+          "waitForInitialCommands": true,
+          "initialCommandsWaitTimeoutMs": 1500
+        }
+      }
+    }
+  }
+}
+```
+
+Keep the default timeout unless the provider documents a longer command-discovery delay.
+
 ### Generic ACP diagnostics
 
 Paseo diagnostics for `extends: "acp"` providers report the configured command, resolved launcher binary, version output, ACP `initialize`, ACP `session/new`, model count, modes, and final status.

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2363,6 +2363,7 @@ describe("ACPAgentSession slash commands", () => {
         {
           name: "research_codebase",
           description: "Search the workspace for relevant files",
+          input: { hint: "query" },
         },
         {
           name: "create_plan",
@@ -2375,7 +2376,7 @@ describe("ACPAgentSession slash commands", () => {
       {
         name: "research_codebase",
         description: "Search the workspace for relevant files",
-        argumentHint: "",
+        argumentHint: "query",
         kind: "command",
       },
       {
@@ -2390,7 +2391,7 @@ describe("ACPAgentSession slash commands", () => {
       {
         name: "research_codebase",
         description: "Search the workspace for relevant files",
-        argumentHint: "",
+        argumentHint: "query",
         kind: "command",
       },
       {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2687,7 +2687,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.cachedCommands = update.availableCommands.map((command) => ({
           name: command.name,
           description: command.description,
-          argumentHint: "",
+          argumentHint: command.input?.hint ?? "",
           kind: "command",
         }));
         this.settleCommandsReady();

--- a/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
@@ -82,4 +82,21 @@ describe("GenericACPAgentClient", () => {
       },
     });
   });
+
+  test("uses provider params to wait for asynchronously published slash commands", () => {
+    const _client = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["zcode-acp-server"],
+      providerParams: {
+        waitForInitialCommands: true,
+        initialCommandsWaitTimeoutMs: 2_000,
+      },
+    });
+    void _client;
+
+    expect(mockState.superConstructorOptions.at(-1)).toMatchObject({
+      waitForInitialCommands: true,
+      initialCommandsWaitTimeoutMs: 2_000,
+    });
+  });
 });

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -21,6 +21,8 @@ import {
 export const GenericACPProviderParamsSchema = z
   .object({
     supportsMcpServers: z.boolean().optional(),
+    waitForInitialCommands: z.boolean().optional(),
+    initialCommandsWaitTimeoutMs: z.number().int().positive().optional(),
     clientCapabilities: z
       .object({
         fs: z
@@ -69,8 +71,10 @@ export class GenericACPAgentClient extends ACPAgentClient {
       },
       defaultCommand: options.command,
       capabilities: buildGenericACPCapabilities(providerParams),
-      waitForInitialCommands: options.waitForInitialCommands,
-      initialCommandsWaitTimeoutMs: options.initialCommandsWaitTimeoutMs,
+      waitForInitialCommands:
+        options.waitForInitialCommands ?? providerParams.waitForInitialCommands,
+      initialCommandsWaitTimeoutMs:
+        options.initialCommandsWaitTimeoutMs ?? providerParams.initialCommandsWaitTimeoutMs,
       clientCapabilities: providerParams.clientCapabilities,
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,


### PR DESCRIPTION
## Summary

- let custom ACP providers opt into Paseo's existing initial-command wait through durable provider params
- preserve ACP command input hints in Paseo autocomplete entries
- document the configuration for agents that publish `available_commands_update` after `session/new`

## Problem

Generic ACP draft sessions call `listCommands()` immediately after `session/new`. Providers such as `zcode-acp-server` publish commands asynchronously, so the new-agent composer can cache an empty list. The same timing class already has provider-specific handling for Cursor, Trae, and Kiro.

## Verification

- `npx vitest run packages/server/src/server/agent/providers/generic-acp-agent.test.ts --bail=1`
- targeted ACP command translation test
- `npm run build:server`
- `npm run typecheck`
- targeted lint and formatting
- isolated Paseo 0.4 daemon with real ZCode ACP: GLM-5.3 draft query returned 78 commands, including argument hints

## Configuration

```json
"params": {
  "waitForInitialCommands": true,
  "initialCommandsWaitTimeoutMs": 1500
}
```
