### PR TITLE
feat(app): add expand-last thinking display option and format markdown

### DIFF
--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -715,12 +715,28 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       [agentId, client, handleInlinePathPress, resolvedServerId, toast, workspaceRoot],
     );
 
+    const latestThoughtId = useMemo(() => {
+      const head = projectedToolCalls.head;
+      for (let i = head.length - 1; i >= 0; i -= 1) {
+        if (head[i]?.kind === "thought") {
+          return head[i]?.id ?? null;
+        }
+      }
+      const tail = projectedToolCalls.tail;
+      for (let i = tail.length - 1; i >= 0; i -= 1) {
+        if (tail[i]?.kind === "thought") {
+          return tail[i]?.id ?? null;
+        }
+      }
+      return null;
+    }, [projectedToolCalls.head, projectedToolCalls.tail]);
+
     const renderThoughtItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "thought" }>) => {
-        const isThoughtActive = item.status !== "ready";
+        const isLastThought = item.id === latestThoughtId;
         const isExpanded =
           autoExpandReasoning === "expanded" ||
-          (autoExpandReasoning === "expand_active" && isThoughtActive);
+          (autoExpandReasoning === "expand_last" && isLastThought);
         return (
           <ThoughtSlot
             itemId={item.id}
@@ -732,7 +748,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           />
         );
       },
-      [autoExpandReasoning, setInlineDetailsExpanded],
+      [autoExpandReasoning, latestThoughtId, setInlineDetailsExpanded],
     );
 
     const renderSingleToolCallItem = useCallback(

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -717,6 +717,10 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
     const renderThoughtItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "thought" }>) => {
+        const isThoughtActive = item.status !== "ready";
+        const isExpanded =
+          autoExpandReasoning === "expanded" ||
+          (autoExpandReasoning === "expand_active" && isThoughtActive);
         return (
           <ThoughtSlot
             itemId={item.id}
@@ -724,7 +728,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             text={item.text}
             status={item.status}
             isLastInSequence={layoutItem.isLastInToolSequence}
-            defaultExpanded={autoExpandReasoning}
+            defaultExpanded={isExpanded}
           />
         );
       },

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -3078,6 +3078,11 @@ export const ToolCall = memo(function ToolCall({
 }: ToolCallProps) {
   const { openToolCall } = useToolCallSheet();
   const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? false);
+  const [prevDefaultExpanded, setPrevDefaultExpanded] = useState(defaultExpanded);
+  if (prevDefaultExpanded !== defaultExpanded) {
+    setPrevDefaultExpanded(defaultExpanded);
+    setIsExpanded(defaultExpanded ?? false);
+  }
 
   const isMobile = useIsCompactFormFactor();
   const shouldRenderInline = !isMobile || forceInline;

--- a/packages/app/src/components/tool-call-details.tsx
+++ b/packages/app/src/components/tool-call-details.tsx
@@ -639,14 +639,33 @@ interface UnknownDetail {
 }
 
 function buildUnknownSections(detail: UnknownDetail, ds: DetailStyles, t: TFunction): ReactNode[] {
-  const plainInputText =
-    typeof detail.input === "string" && detail.output === null ? detail.input : null;
+  const isInputString = typeof detail.input === "string" && detail.input.trim().length > 0;
+  const hasNoOutput =
+    detail.output === null ||
+    detail.output === undefined ||
+    (typeof detail.output === "string" && detail.output.trim().length === 0);
 
-  if (plainInputText !== null) {
+  if (isInputString && hasNoOutput) {
     return [
       <ScrollableMarkdownSection
         key="unknown-markdown-text"
-        text={formatThinkingText(plainInputText)}
+        text={formatThinkingText(detail.input as string)}
+        ds={ds}
+      />,
+    ];
+  }
+
+  const isOutputString = typeof detail.output === "string" && detail.output.trim().length > 0;
+  const hasNoInput =
+    detail.input === null ||
+    detail.input === undefined ||
+    (typeof detail.input === "string" && detail.input.trim().length === 0);
+
+  if (isOutputString && hasNoInput) {
+    return [
+      <ScrollableMarkdownSection
+        key="unknown-markdown-text"
+        text={formatThinkingText(detail.output as string)}
         ds={ds}
       />,
     ];

--- a/packages/app/src/components/tool-call-details.tsx
+++ b/packages/app/src/components/tool-call-details.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo, type ReactNode } from "react";
+import React, { useCallback, useMemo, useRef, type ReactNode } from "react";
 import {
   View,
   Text,
   ScrollView as RNScrollView,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   type StyleProp,
   type ViewStyle,
 } from "react-native";
@@ -492,13 +494,34 @@ function FetchDetailSection({ url, result, ds }: FetchDetailProps) {
 }
 
 function ScrollablePlainTextSection({ text, ds }: { text: string; ds: DetailStyles }) {
+  const scrollRef = useRef<RNScrollView | GHScrollView | null>(null);
+  const isNearBottomRef = useRef(true);
+
+  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+    const paddingToBottom = 32;
+    const isBottom =
+      layoutMeasurement.height + contentOffset.y >= contentSize.height - paddingToBottom;
+    isNearBottomRef.current = isBottom;
+  }, []);
+
+  const handleContentSizeChange = useCallback(() => {
+    if (isNearBottomRef.current) {
+      scrollRef.current?.scrollToEnd({ animated: false });
+    }
+  }, []);
+
   return (
     <View style={styles.section}>
       <ScrollView
+        ref={scrollRef as never}
         style={ds.scrollAreaStyle}
         contentContainerStyle={styles.scrollContent}
         nestedScrollEnabled
         showsVerticalScrollIndicator
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        onContentSizeChange={handleContentSizeChange}
       >
         <Text selectable style={styles.plainText}>
           {text}
@@ -509,13 +532,34 @@ function ScrollablePlainTextSection({ text, ds }: { text: string; ds: DetailStyl
 }
 
 function ScrollableMarkdownSection({ text, ds }: { text: string; ds: DetailStyles }) {
+  const scrollRef = useRef<RNScrollView | GHScrollView | null>(null);
+  const isNearBottomRef = useRef(true);
+
+  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+    const paddingToBottom = 32;
+    const isBottom =
+      layoutMeasurement.height + contentOffset.y >= contentSize.height - paddingToBottom;
+    isNearBottomRef.current = isBottom;
+  }, []);
+
+  const handleContentSizeChange = useCallback(() => {
+    if (isNearBottomRef.current) {
+      scrollRef.current?.scrollToEnd({ animated: false });
+    }
+  }, []);
+
   return (
     <View style={styles.section}>
       <ScrollView
+        ref={scrollRef as never}
         style={ds.scrollAreaStyle}
         contentContainerStyle={styles.scrollContent}
         nestedScrollEnabled
         showsVerticalScrollIndicator
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        onContentSizeChange={handleContentSizeChange}
       >
         <MarkdownRenderer text={text} compact enableHtmlish={false} />
       </ScrollView>

--- a/packages/app/src/components/tool-call-details.tsx
+++ b/packages/app/src/components/tool-call-details.tsx
@@ -21,6 +21,8 @@ import { HighlightedLines } from "./highlighted-content";
 import { DiffViewer } from "./diff-viewer";
 import { getCodeInsets } from "./code-insets";
 import { isWeb } from "@/constants/platform";
+import { formatThinkingText } from "@/utils/thinking-text-formatter";
+import { MarkdownRenderer } from "./markdown/renderer";
 
 const ScrollView = isWeb ? RNScrollView : GHScrollView;
 
@@ -506,6 +508,21 @@ function ScrollablePlainTextSection({ text, ds }: { text: string; ds: DetailStyl
   );
 }
 
+function ScrollableMarkdownSection({ text, ds }: { text: string; ds: DetailStyles }) {
+  return (
+    <View style={styles.section}>
+      <ScrollView
+        style={ds.scrollAreaStyle}
+        contentContainerStyle={styles.scrollContent}
+        nestedScrollEnabled
+        showsVerticalScrollIndicator
+      >
+        <MarkdownRenderer text={text} compact enableHtmlish={false} />
+      </ScrollView>
+    </View>
+  );
+}
+
 interface SearchDetail {
   query?: string;
   content?: string;
@@ -582,7 +599,13 @@ function buildUnknownSections(detail: UnknownDetail, ds: DetailStyles, t: TFunct
     typeof detail.input === "string" && detail.output === null ? detail.input : null;
 
   if (plainInputText !== null) {
-    return [<ScrollablePlainTextSection key="unknown-plain-text" text={plainInputText} ds={ds} />];
+    return [
+      <ScrollableMarkdownSection
+        key="unknown-markdown-text"
+        text={formatThinkingText(plainInputText)}
+        ds={ds}
+      />,
+    ];
   }
 
   const sectionsFromTopLevel = [

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -611,6 +611,45 @@ describe("appearance settings", () => {
     expect(result.toolCallDetailLevel).toBe("detailed");
   });
 
+  it("loads thinking display detail enum values or migrates legacy boolean values", async () => {
+    const depsTrue = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ autoExpandReasoning: true }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(depsTrue)).autoExpandReasoning).toBe("expanded");
+
+    const depsFalse = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ autoExpandReasoning: false }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(depsFalse)).autoExpandReasoning).toBe("collapsed");
+
+    const depsActive = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ autoExpandReasoning: "expand_active" }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(depsActive)).autoExpandReasoning).toBe(
+      "expand_active",
+    );
+
+    const depsExpanded = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ autoExpandReasoning: "expanded" }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(depsExpanded)).autoExpandReasoning).toBe("expanded");
+
+    const depsInvalid = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ autoExpandReasoning: "invalid" }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(depsInvalid)).autoExpandReasoning).toBe("collapsed");
+  });
+
   it("migrates the enabled compact tool call preference to overview", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -631,9 +631,14 @@ describe("appearance settings", () => {
         [APP_SETTINGS_KEY]: JSON.stringify({ autoExpandReasoning: "expand_active" }),
       }),
     });
-    expect((await loadAppSettingsFromStorage(depsActive)).autoExpandReasoning).toBe(
-      "expand_active",
-    );
+    expect((await loadAppSettingsFromStorage(depsActive)).autoExpandReasoning).toBe("expand_last");
+
+    const depsLast = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ autoExpandReasoning: "expand_last" }),
+      }),
+    });
+    expect((await loadAppSettingsFromStorage(depsLast)).autoExpandReasoning).toBe("expand_last");
 
     const depsExpanded = makeDeps({
       storage: createInMemoryKeyValueStorage({

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -33,7 +33,7 @@ export type WorkspaceTitleSource = "title" | "branch";
 export type PullRequestOpenLocation = "main" | "side" | "explorer";
 /** What a sidebar workspace row shows in the space to the right of its title. */
 export type SidebarWorkspaceTrailing = "diff" | "timestamp" | "none";
-export type ThinkingDisplayDetail = "collapsed" | "expand_active" | "expanded";
+export type ThinkingDisplayDetail = "collapsed" | "expand_last" | "expanded";
 export type ToolCallDetailLevel = "overview" | "detailed";
 
 const ThemePreferenceSchema = z.enum([
@@ -220,10 +220,18 @@ const StoredAppSettingsSchema = z
       .optional()
       .catch(DEFAULT_SIDEBAR_CHECKS_DISPLAY),
     autoExpandReasoning: z
-      .enum(["collapsed", "expand_active", "expanded"])
-      .or(
-        z.boolean().transform((value) => (value ? ("expanded" as const) : ("collapsed" as const))),
-      )
+      .enum(["collapsed", "expand_last", "expand_active", "expanded"])
+      .or(z.boolean())
+      .transform((value) => {
+        if (typeof value === "boolean") {
+          return value ? ("expanded" as const) : ("collapsed" as const);
+        }
+        if (value === "expand_active") {
+          // COMPAT(autoExpandReasoningExpandActive): migrated to expand_last in v0.4.0.
+          return "expand_last" as const;
+        }
+        return value;
+      })
       .catch("collapsed"),
     toolCallDetailLevel: z
       .enum(["overview", "detailed"])

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -33,6 +33,7 @@ export type WorkspaceTitleSource = "title" | "branch";
 export type PullRequestOpenLocation = "main" | "side" | "explorer";
 /** What a sidebar workspace row shows in the space to the right of its title. */
 export type SidebarWorkspaceTrailing = "diff" | "timestamp" | "none";
+export type ThinkingDisplayDetail = "collapsed" | "expand_active" | "expanded";
 export type ToolCallDetailLevel = "overview" | "detailed";
 
 const ThemePreferenceSchema = z.enum([
@@ -82,7 +83,7 @@ export interface AppSettings {
   sidebarWorkspaceTrailing: SidebarWorkspaceTrailing;
   sidebarRowItems: SidebarRowItems;
   sidebarChecksDisplay: SidebarChecksDisplay;
-  autoExpandReasoning: boolean;
+  autoExpandReasoning: ThinkingDisplayDetail;
   toolCallDetailLevel: ToolCallDetailLevel;
   chatOutlineEnabled: boolean;
   vimKeybindings: boolean;
@@ -130,7 +131,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   sidebarWorkspaceTrailing: "diff",
   sidebarRowItems: DEFAULT_SIDEBAR_ROW_ITEMS,
   sidebarChecksDisplay: DEFAULT_SIDEBAR_CHECKS_DISPLAY,
-  autoExpandReasoning: false,
+  autoExpandReasoning: "collapsed",
   toolCallDetailLevel: "detailed",
   chatOutlineEnabled: true,
   vimKeybindings: false,
@@ -218,7 +219,12 @@ const StoredAppSettingsSchema = z
       .enum(["iconAndText", "icon", "none"])
       .optional()
       .catch(DEFAULT_SIDEBAR_CHECKS_DISPLAY),
-    autoExpandReasoning: z.boolean().catch(false),
+    autoExpandReasoning: z
+      .enum(["collapsed", "expand_active", "expanded"])
+      .or(
+        z.boolean().transform((value) => (value ? ("expanded" as const) : ("collapsed" as const))),
+      )
+      .catch("collapsed"),
     toolCallDetailLevel: z
       .enum(["overview", "detailed"])
       .or(z.literal("concise").transform(() => "overview" as const))

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1967,8 +1967,14 @@ export const ar: TranslationResources = {
         accessibilityLabel: "خطوط التمرير Terminal",
       },
       autoExpandReasoning: {
-        label: "عرض التفكير دائماً",
-        description: "إظهار تفكير الوكيل وخطوات الاستدلال بشكل كامل بشكل افتراضي",
+        label: "عرض التفكير",
+        description: "كيفية ظهور كتل التفكير في المخطط الزمني",
+        accessibilityLabel: "تحديد عرض التفكير ({{value}})",
+        options: {
+          collapsed: "مطوي",
+          expandActive: "توسيع النشط",
+          expanded: "توسيع دائماً",
+        },
       },
       toolCallDetail: {
         label: "عرض استدعاءات الأدوات",

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1972,7 +1972,7 @@ export const ar: TranslationResources = {
         accessibilityLabel: "تحديد عرض التفكير ({{value}})",
         options: {
           collapsed: "مطوي",
-          expandActive: "توسيع النشط",
+          expandLast: "توسيع الأخير",
           expanded: "توسيع دائماً",
         },
       },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2066,8 +2066,14 @@ export const en = {
         accessibilityLabel: "Terminal scrollback lines",
       },
       autoExpandReasoning: {
-        label: "Always expand reasoning",
-        description: "Show agent thinking and chain-of-thought blocks fully expanded by default",
+        label: "Thinking display",
+        description: "How agent thinking and chain-of-thought blocks appear in the timeline",
+        accessibilityLabel: "Select thinking display ({{value}})",
+        options: {
+          collapsed: "Collapsed",
+          expandActive: "Expand Active",
+          expanded: "Always expand",
+        },
       },
       toolCallDetail: {
         label: "Tool call display",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2071,7 +2071,7 @@ export const en = {
         accessibilityLabel: "Select thinking display ({{value}})",
         options: {
           collapsed: "Collapsed",
-          expandActive: "Expand Active",
+          expandLast: "Expand Last",
           expanded: "Always expand",
         },
       },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2016,9 +2016,14 @@ export const es: TranslationResources = {
         accessibilityLabel: "Líneas del historial de terminal",
       },
       autoExpandReasoning: {
-        label: "Siempre expandir razonamiento",
-        description:
-          "Mostrar los bloques de pensamiento y razonamiento del agente totalmente expandidos de forma predeterminada",
+        label: "Visualización de pensamiento",
+        description: "Cómo aparecen los bloques de pensamiento del agente en la cronología",
+        accessibilityLabel: "Seleccionar visualización de pensamiento ({{value}})",
+        options: {
+          collapsed: "Plegado",
+          expandActive: "Expandir activo",
+          expanded: "Expandir siempre",
+        },
       },
       toolCallDetail: {
         label: "Visualización de llamadas a herramientas",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2021,7 +2021,7 @@ export const es: TranslationResources = {
         accessibilityLabel: "Seleccionar visualización de pensamiento ({{value}})",
         options: {
           collapsed: "Plegado",
-          expandActive: "Expandir activo",
+          expandLast: "Expandir último",
           expanded: "Expandir siempre",
         },
       },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2020,8 +2020,14 @@ export const fr: TranslationResources = {
         accessibilityLabel: "Lignes de défilementTerminal",
       },
       autoExpandReasoning: {
-        label: "Toujours afficher le raisonnement",
-        description: "Afficher le raisonnement de l'agent entièrement développé par défaut",
+        label: "Affichage de la réflexion",
+        description: "Comment les blocs de réflexion apparaissent dans la chronologie",
+        accessibilityLabel: "Sélectionner l'affichage de la réflexion ({{value}})",
+        options: {
+          collapsed: "Réduit",
+          expandActive: "Développer si actif",
+          expanded: "Toujours développer",
+        },
       },
       toolCallDetail: {
         label: "Affichage des appels d’outils",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2025,7 +2025,7 @@ export const fr: TranslationResources = {
         accessibilityLabel: "Sélectionner l'affichage de la réflexion ({{value}})",
         options: {
           collapsed: "Réduit",
-          expandActive: "Développer si actif",
+          expandLast: "Développer le dernier",
           expanded: "Toujours développer",
         },
       },

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1984,8 +1984,14 @@ export const ja: TranslationResources = {
         accessibilityLabel: "ターミナルスクロールバック行数",
       },
       autoExpandReasoning: {
-        label: "常に思考プロセスを展開",
-        description: "デフォルトでAIのエージェント思考・推論ブロックを完全に展開して表示します",
+        label: "思考プロセスの表示",
+        description: "タイムラインでの思考ブロックの表示方法",
+        accessibilityLabel: "思考プロセスの表示を選択 ({{value}})",
+        options: {
+          collapsed: "折りたたむ",
+          expandActive: "実行中のみ展開",
+          expanded: "常に展開",
+        },
       },
       toolCallDetail: {
         label: "ツール呼び出しの表示",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1989,7 +1989,7 @@ export const ja: TranslationResources = {
         accessibilityLabel: "思考プロセスの表示を選択 ({{value}})",
         options: {
           collapsed: "折りたたむ",
-          expandActive: "実行中のみ展開",
+          expandLast: "最新のみ展開",
           expanded: "常に展開",
         },
       },

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1983,7 +1983,7 @@ export const ko: TranslationResources = {
         accessibilityLabel: "사고 과정 표시 선택({{value}})",
         options: {
           collapsed: "접음",
-          expandActive: "실행 중일 때만 펼치기",
+          expandLast: "마지막 항목만 펼치기",
           expanded: "항상 펼치기",
         },
       },

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1978,8 +1978,14 @@ export const ko: TranslationResources = {
         accessibilityLabel: "터미널 스크롤백 줄 수",
       },
       autoExpandReasoning: {
-        label: "추론 항상 펼치기",
-        description: "에이전트의 사고 및 추론 블록을 기본적으로 모두 펼쳐 표시합니다.",
+        label: "사고 과정 표시",
+        description: "타임라인에 에이전트 사고 블록이 표시되는 방식",
+        accessibilityLabel: "사고 과정 표시 선택({{value}})",
+        options: {
+          collapsed: "접음",
+          expandActive: "실행 중일 때만 펼치기",
+          expanded: "항상 펼치기",
+        },
       },
       toolCallDetail: {
         label: "도구 호출 표시",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -2000,9 +2000,14 @@ export const ptBR: TranslationResources = {
         accessibilityLabel: "Linhas do scrollback do terminal",
       },
       autoExpandReasoning: {
-        label: "Sempre expandir raciocínio",
-        description:
-          "Mostrar os blocos de pensamento e raciocínio do agente totalmente expandidos por padrão",
+        label: "Exibição de pensamento",
+        description: "Como os blocos de pensamento aparecem na linha do tempo",
+        accessibilityLabel: "Selecionar exibição de pensamento ({{value}})",
+        options: {
+          collapsed: "Recolhido",
+          expandActive: "Expandir ativo",
+          expanded: "Sempre expandir",
+        },
       },
       toolCallDetail: {
         label: "Exibição de chamadas de ferramentas",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -2005,7 +2005,7 @@ export const ptBR: TranslationResources = {
         accessibilityLabel: "Selecionar exibição de pensamento ({{value}})",
         options: {
           collapsed: "Recolhido",
-          expandActive: "Expandir ativo",
+          expandLast: "Expandir último",
           expanded: "Sempre expandir",
         },
       },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2005,7 +2005,7 @@ export const ru: TranslationResources = {
         accessibilityLabel: "Выбор отображения мышления ({{value}})",
         options: {
           collapsed: "Свернуто",
-          expandActive: "Разворачивать активный",
+          expandLast: "Разворачивать последний",
           expanded: "Всегда разворачивать",
         },
       },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2000,9 +2000,14 @@ export const ru: TranslationResources = {
         accessibilityLabel: "Количество строк в буфере прокрутки терминала",
       },
       autoExpandReasoning: {
-        label: "Всегда разворачивать размышления",
-        description:
-          "По умолчанию полностью разворачивать блоки размышлений и хода рассуждений агента",
+        label: "Отображение мышления",
+        description: "Как блоки рассуждений агента отображаются в таймлайне",
+        accessibilityLabel: "Выбор отображения мышления ({{value}})",
+        options: {
+          collapsed: "Свернуто",
+          expandActive: "Разворачивать активный",
+          expanded: "Всегда разворачивать",
+        },
       },
       toolCallDetail: {
         label: "Отображение вызовов инструментов",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1948,7 +1948,7 @@ export const zhCN: TranslationResources = {
         accessibilityLabel: "选择思考过程显示方式（{{value}}）",
         options: {
           collapsed: "折叠",
-          expandActive: "仅展开当前活动",
+          expandLast: "仅展开最新",
           expanded: "始终展开",
         },
       },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1943,8 +1943,14 @@ export const zhCN: TranslationResources = {
         accessibilityLabel: "终端回滚行数",
       },
       autoExpandReasoning: {
-        label: "始终展开推理过程",
-        description: "默认情况下完全展开 AI 的思考和推理过程",
+        label: "思考过程显示",
+        description: "智能体思考过程在时间线中的显示方式",
+        accessibilityLabel: "选择思考过程显示方式（{{value}}）",
+        options: {
+          collapsed: "折叠",
+          expandActive: "仅展开当前活动",
+          expanded: "始终展开",
+        },
       },
       toolCallDetail: {
         label: "工具调用显示",

--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -227,7 +227,7 @@ function ThemeRow({
 
 const THINKING_DISPLAY_DETAILS: readonly AppSettings["autoExpandReasoning"][] = [
   "collapsed",
-  "expand_active",
+  "expand_last",
   "expanded",
 ];
 
@@ -235,7 +235,7 @@ function getThinkingDisplayDetailLabel(
   t: TFunction,
   value: AppSettings["autoExpandReasoning"],
 ): string {
-  const optionKey = value === "expand_active" ? "expandActive" : value;
+  const optionKey = value === "expand_last" ? "expandLast" : value;
   return t(`settings.general.autoExpandReasoning.options.${optionKey}`);
 }
 

--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -225,13 +225,44 @@ function ThemeRow({
   );
 }
 
+const THINKING_DISPLAY_DETAILS: readonly AppSettings["autoExpandReasoning"][] = [
+  "collapsed",
+  "expand_active",
+  "expanded",
+];
+
+function getThinkingDisplayDetailLabel(
+  t: TFunction,
+  value: AppSettings["autoExpandReasoning"],
+): string {
+  const optionKey = value === "expand_active" ? "expandActive" : value;
+  return t(`settings.general.autoExpandReasoning.options.${optionKey}`);
+}
+
+interface ThinkingDisplayMenuItemProps {
+  value: AppSettings["autoExpandReasoning"];
+  selected: boolean;
+  onChange: (value: AppSettings["autoExpandReasoning"]) => void;
+}
+
+function ThinkingDisplayMenuItem({ value, selected, onChange }: ThinkingDisplayMenuItemProps) {
+  const { t } = useTranslation();
+  const handleSelect = useCallback(() => onChange(value), [onChange, value]);
+  return (
+    <DropdownMenuItem selected={selected} onSelect={handleSelect}>
+      {getThinkingDisplayDetailLabel(t, value)}
+    </DropdownMenuItem>
+  );
+}
+
 interface AutoExpandReasoningRowProps {
-  value: boolean;
-  onChange: (value: boolean) => void;
+  value: AppSettings["autoExpandReasoning"];
+  onChange: (value: AppSettings["autoExpandReasoning"]) => void;
 }
 
 function AutoExpandReasoningRow({ value, onChange }: AutoExpandReasoningRowProps) {
   const { t } = useTranslation();
+  const selectedLabel = getThinkingDisplayDetailLabel(t, value);
   return (
     <View style={settingsStyles.row}>
       <View style={settingsStyles.rowContent}>
@@ -242,7 +273,27 @@ function AutoExpandReasoningRow({ value, onChange }: AutoExpandReasoningRowProps
           {t("settings.general.autoExpandReasoning.description")}
         </Text>
       </View>
-      <Switch value={value} onValueChange={onChange} />
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          style={dropdownTriggerStyle}
+          accessibilityLabel={t("settings.general.autoExpandReasoning.accessibilityLabel", {
+            value: selectedLabel,
+          })}
+        >
+          <Text style={styles.triggerText}>{selectedLabel}</Text>
+          <ThemedChevronDown size={ICON_SIZE.sm} uniProps={mutedColorMapping} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="end" width={200}>
+          {THINKING_DISPLAY_DETAILS.map((option) => (
+            <ThinkingDisplayMenuItem
+              key={option}
+              value={option}
+              selected={value === option}
+              onChange={onChange}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </View>
   );
 }
@@ -568,7 +619,7 @@ export function AppearanceSection() {
   );
 
   const handleAutoExpandReasoningChange = useCallback(
-    (autoExpandReasoning: boolean) => {
+    (autoExpandReasoning: AppSettings["autoExpandReasoning"]) => {
       void updateSettings({ autoExpandReasoning });
     },
     [updateSettings],

--- a/packages/app/src/styles/markdown-styles.test.ts
+++ b/packages/app/src/styles/markdown-styles.test.ts
@@ -86,6 +86,9 @@ describe("createMarkdownStyles", () => {
     expect(styles.ordered_list_icon).toMatchObject({
       userSelect: "text",
     });
+    expect(styles.strong).toMatchObject({
+      fontWeight: darkTheme.fontWeight.bold,
+    });
   });
 
   it("uses the mono font-size token directly for inline and block code", () => {

--- a/packages/app/src/styles/markdown-styles.ts
+++ b/packages/app/src/styles/markdown-styles.ts
@@ -133,7 +133,7 @@ export function createMarkdownStyles(theme: Theme) {
 
     strong: {
       ...webSelectableTextStyle,
-      fontWeight: theme.fontWeight.medium,
+      fontWeight: theme.fontWeight.bold,
     },
 
     em: {

--- a/packages/app/src/utils/thinking-text-formatter.test.ts
+++ b/packages/app/src/utils/thinking-text-formatter.test.ts
@@ -20,24 +20,9 @@ describe("formatThinkingText", () => {
     expect(formatThinkingText("**title1**   **title2**")).toBe("**title1**\n\n**title2**");
   });
 
-  it("separates bold headers preceded by sentence punctuation without a newline", () => {
-    expect(formatThinkingText("I am thinking about this.**Next step**")).toBe(
-      "I am thinking about this.\n\n**Next step**",
-    );
-    expect(formatThinkingText("Let's see. **Finding files**")).toBe(
-      "Let's see.\n\n**Finding files**",
-    );
-  });
-
   it("separates numbered headers", () => {
     expect(formatThinkingText("**1. Analyze goal****2. Execute plan**")).toBe(
       "**1. Analyze goal**\n\n**2. Execute plan**",
-    );
-  });
-
-  it("separates bold header from immediately following text", () => {
-    expect(formatThinkingText("**Searching codebase**I will look for files.")).toBe(
-      "**Searching codebase**\n\nI will look for files.",
     );
   });
 
@@ -52,6 +37,21 @@ describe("formatThinkingText", () => {
 
     const uppercaseProse = "I need to inspect **AgentStreamView** before editing it.";
     expect(formatThinkingText(uppercaseProse)).toBe(uppercaseProse);
+
+    const afterPunctuation =
+      'I looked at config.json, which had key "version". **Note** that this is deprecated.';
+    expect(formatThinkingText(afterPunctuation)).toBe(afterPunctuation);
+  });
+
+  it("preserves fenced code blocks and inline code completely intact", () => {
+    const codeWithBold = "```python\ndef foo():\n\n\n    # check **a****b**\n```";
+    expect(formatThinkingText(codeWithBold)).toBe(codeWithBold);
+
+    const inlineCode = "Use `**bold**` inside inline code.";
+    expect(formatThinkingText(inlineCode)).toBe(inlineCode);
+
+    const streamingCodeBlock = "```typescript\nconst x = **test**;\n";
+    expect(formatThinkingText(streamingCodeBlock)).toBe(streamingCodeBlock);
   });
 
   it("preserves already well-spaced thinking blocks without adding excess newlines", () => {

--- a/packages/app/src/utils/thinking-text-formatter.test.ts
+++ b/packages/app/src/utils/thinking-text-formatter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { formatThinkingText } from "./thinking-text-formatter";
+
+describe("formatThinkingText", () => {
+  it("handles empty or invalid inputs", () => {
+    expect(formatThinkingText("")).toBe("");
+    expect(formatThinkingText(null as unknown as string)).toBe("");
+    expect(formatThinkingText(undefined as unknown as string)).toBe("");
+  });
+
+  it("separates adjacent bold titles without newlines", () => {
+    expect(formatThinkingText("**title****title2**")).toBe("**title**\n\n**title2**");
+    expect(formatThinkingText("**title1****title2****title3**")).toBe(
+      "**title1**\n\n**title2**\n\n**title3**",
+    );
+  });
+
+  it("separates adjacent bold titles separated only by spaces", () => {
+    expect(formatThinkingText("**title1** **title2**")).toBe("**title1**\n\n**title2**");
+    expect(formatThinkingText("**title1**   **title2**")).toBe("**title1**\n\n**title2**");
+  });
+
+  it("separates bold headers preceded by sentence punctuation without a newline", () => {
+    expect(formatThinkingText("I am thinking about this.**Next step**")).toBe(
+      "I am thinking about this.\n\n**Next step**",
+    );
+    expect(formatThinkingText("Let's see. **Finding files**")).toBe(
+      "Let's see.\n\n**Finding files**",
+    );
+  });
+
+  it("separates numbered headers", () => {
+    expect(formatThinkingText("**1. Analyze goal****2. Execute plan**")).toBe(
+      "**1. Analyze goal**\n\n**2. Execute plan**",
+    );
+  });
+
+  it("separates bold header from immediately following text", () => {
+    expect(formatThinkingText("**Searching codebase**I will look for files.")).toBe(
+      "**Searching codebase**\n\nI will look for files.",
+    );
+  });
+
+  it("handles in-progress streaming where second bold tag is opened", () => {
+    expect(formatThinkingText("**title1****title2")).toBe("**title1**\n\n**title2");
+    expect(formatThinkingText("**title1****")).toBe("**title1**\n\n**");
+  });
+
+  it("preserves regular markdown bold within prose without altering intended formatting", () => {
+    const prose = "This function uses **foo** and **bar** as arguments.";
+    expect(formatThinkingText(prose)).toBe(prose);
+
+    const uppercaseProse = "I need to inspect **AgentStreamView** before editing it.";
+    expect(formatThinkingText(uppercaseProse)).toBe(uppercaseProse);
+  });
+
+  it("preserves already well-spaced thinking blocks without adding excess newlines", () => {
+    const wellSpaced = "**Title 1**\n\nSome thought text.\n\n**Title 2**\n\nMore thought text.";
+    expect(formatThinkingText(wellSpaced)).toBe(wellSpaced);
+  });
+});

--- a/packages/app/src/utils/thinking-text-formatter.ts
+++ b/packages/app/src/utils/thinking-text-formatter.ts
@@ -1,0 +1,35 @@
+/**
+ * Normalizes thinking and reasoning text emitted by models (e.g. Codex, OpenAI reasoning models)
+ * where bold headers (like **title**) may be streamed without separating newlines,
+ * producing jammed headers like `**title1****title2**` or `text.**title2**`.
+ */
+export function formatThinkingText(text: string): string {
+  if (!text || typeof text !== "string") {
+    return "";
+  }
+
+  let formatted = text;
+
+  // 1. Separate adjacent bold blocks (e.g. **title1****title2** -> **title1**\n\n**title2**)
+  // Also handles streaming when the second bold tag is opened: **title1****streaming...
+  formatted = formatted.replace(/(\*\*[^*\s\n](?:[^*\n]*?[^*\s\n])?\*\*)\s*(?=\*\*)/g, "$1\n\n");
+
+  // 2. Separate bold header from preceding sentence punctuation when not preceded by newline
+  // E.g. "Some reasoning.**Next step**" -> "Some reasoning.\n\n**Next step**"
+  formatted = formatted.replace(
+    /([.!?:])\s*(\*\*(?:[A-Z0-9#_]|(?:\d+\.))[^*\n]*?[^*\s\n]\*\*)/g,
+    "$1\n\n$2",
+  );
+
+  // 3. Separate bold header from immediately following text when attached without space/newline
+  // E.g. "**Header**Let's check" -> "**Header**\n\nLet's check"
+  formatted = formatted.replace(
+    /(\*\*[^*\s\n](?:[^*\n]*?[^*\s\n])?\*\*)(?=[A-Za-z0-9])/g,
+    "$1\n\n",
+  );
+
+  // 4. Collapse 3+ consecutive newlines to at most 2 newlines
+  formatted = formatted.replace(/\n{3,}/g, "\n\n");
+
+  return formatted;
+}

--- a/packages/app/src/utils/thinking-text-formatter.ts
+++ b/packages/app/src/utils/thinking-text-formatter.ts
@@ -1,35 +1,26 @@
 /**
  * Normalizes thinking and reasoning text emitted by models (e.g. Codex, OpenAI reasoning models)
  * where bold headers (like **title**) may be streamed without separating newlines,
- * producing jammed headers like `**title1****title2**` or `text.**title2**`.
+ * producing jammed headers like `**title1****title2**`.
  */
 export function formatThinkingText(text: string): string {
   if (!text || typeof text !== "string") {
     return "";
   }
 
-  let formatted = text;
+  // Preserve code blocks (including in-progress streaming code blocks) and inline code spans
+  const parts = text.split(/(```[\s\S]*?(?:```|$)|`[^`\n]+`)/g);
 
-  // 1. Separate adjacent bold blocks (e.g. **title1****title2** -> **title1**\n\n**title2**)
-  // Also handles streaming when the second bold tag is opened: **title1****streaming...
-  formatted = formatted.replace(/(\*\*[^*\s\n](?:[^*\n]*?[^*\s\n])?\*\*)\s*(?=\*\*)/g, "$1\n\n");
+  return parts
+    .map((part, index) => {
+      // Odd indices are code blocks or inline code spans - leave them completely intact
+      if (index % 2 === 1) {
+        return part;
+      }
 
-  // 2. Separate bold header from preceding sentence punctuation when not preceded by newline
-  // E.g. "Some reasoning.**Next step**" -> "Some reasoning.\n\n**Next step**"
-  formatted = formatted.replace(
-    /([.!?:])\s*(\*\*(?:[A-Z0-9#_]|(?:\d+\.))[^*\n]*?[^*\s\n]\*\*)/g,
-    "$1\n\n$2",
-  );
-
-  // 3. Separate bold header from immediately following text when attached without space/newline
-  // E.g. "**Header**Let's check" -> "**Header**\n\nLet's check"
-  formatted = formatted.replace(
-    /(\*\*[^*\s\n](?:[^*\n]*?[^*\s\n])?\*\*)(?=[A-Za-z0-9])/g,
-    "$1\n\n",
-  );
-
-  // 4. Collapse 3+ consecutive newlines to at most 2 newlines
-  formatted = formatted.replace(/\n{3,}/g, "\n\n");
-
-  return formatted;
+      // Separate adjacent bold blocks (e.g. **title1****title2** or **title1** **title2**)
+      // Also handles streaming when the second bold tag is opened: **title1****streaming...
+      return part.replace(/(\*\*[^*\s\n](?:[^*\n]*?[^*\s\n])?\*\*)\s*(?=\*\*)/g, "$1\n\n");
+    })
+    .join("");
 }


### PR DESCRIPTION
### Type of change

- [x] New feature
- [x] Enhancement

### Reasoning

Users often want to monitor agent reasoning while it is actively streaming and keep the most recent thinking block visible after it completes, without having every historic block across previous turns permanently expanded. Furthermore, certain models (e.g. Codex) output bold thinking headers without separating newlines (`**title1****title2**`), and previously thinking blocks were rendered as raw unformatted text rather than parsed Markdown.

This PR adds an **Expand Last** thinking display detail option so the latest thinking block remains expanded while streaming and stays expanded once complete, collapsing older thinking blocks. It also formats thinking headers cleanly and renders thinking content as rich compact Markdown.

### Goals

- Add `Expand Last` option to the thinking display setting alongside `Collapsed` and `Always expand`.
- Automatically show the latest thinking block expanded (both during and after generation) while collapsing earlier blocks when `Expand Last` is selected.
- Maintain backward compatibility for existing boolean settings in storage (`true` -> `expanded`, `false` -> `collapsed`, `expand_active` -> `expand_last`).
- Normalize adjacent or jammed thinking headers (e.g. `**title1****title2**` -> `**title1**\n\n**title2**`) without breaking inline prose markdown.
- Render thinking content as rich Markdown in tool call details using `<MarkdownRenderer compact />`.
- Update all 9 localization resources with matching keys and translations.

### Non-goals

- Altering server-side reasoning storage or wire protocol structures.

### QA

- Verified storage parsing and migration in `storage.test.ts` for boolean flags and enum values (`collapsed`, `expand_last`, `expanded`, `expand_active`).
- Verified header normalization in `thinking-text-formatter.test.ts` across adjacent headers, numbered steps, streaming inputs, and inline bold prose.
- Verified localization key parity across all 9 languages with `resources.test.ts`.
- Ran full workspace `typecheck`, `lint`, and `format`.

### Checklist

<img width="862" height="452" alt="Screenshot 2026-08-14 at 9 53 07 AM" src="https://github.com/user-attachments/assets/b09514d2-cb9d-4045-a202-b4b67236d1d2" />
<img width="321" height="174" alt="Screenshot 2026-08-14 at 9 52 41 AM" src="https://github.com/user-attachments/assets/d1446bf8-e0df-453c-8399-e15c1f513e81" />

