### PR TITLE
Add ZCode to the ACP provider catalog

### DIFF
--- a/packages/app/src/data/acp-provider-catalog.ts
+++ b/packages/app/src/data/acp-provider-catalog.ts
@@ -358,6 +358,16 @@ const CATALOG_DATA = [
       VT_ACP_ZED_ENABLED: "1",
     },
   },
+  {
+    id: "zcode",
+    title: "ZCode",
+    description:
+      "Z.ai's coding agent with GLM models, exposed over ACP by the community zcode-acp-server adapter",
+    version: "0.1.0",
+    iconId: null,
+    installLink: "https://github.com/william0wang/zcode-acp",
+    command: ["zcode-acp-server"],
+  },
 ] as const;
 
 export const ACP_PROVIDER_CATALOG: AcpProviderCatalogEntry[] = CATALOG_DATA.map((entry) => ({

--- a/packages/app/src/hooks/use-acp-provider-catalog.test.ts
+++ b/packages/app/src/hooks/use-acp-provider-catalog.test.ts
@@ -48,6 +48,7 @@ describe("ACP provider catalog", () => {
     expect(findProvider("kiro").command).toEqual(["kiro-cli", "acp"]);
     expect(findProvider("poolside").command).toEqual(["pool", "acp"]);
     expect(findProvider("traecli").command).toEqual(["traecli", "acp", "serve"]);
+    expect(findProvider("zcode").command).toEqual(["zcode-acp-server"]);
   });
 
   it("maps a catalog entry to the daemon provider config patch", () => {
@@ -58,6 +59,18 @@ describe("ACP provider catalog", () => {
           label: "Amp",
           description: "ACP wrapper for Amp - the frontier coding agent",
           command: ["amp-acp"],
+          env: {},
+        },
+      },
+    });
+    expect(buildAcpProviderConfigPatch(findProvider("zcode"))).toEqual({
+      providers: {
+        zcode: {
+          extends: "acp",
+          label: "ZCode",
+          description:
+            "Z.ai's coding agent with GLM models, exposed over ACP by the community zcode-acp-server adapter",
+          command: ["zcode-acp-server"],
           env: {},
         },
       },

--- a/public-docs/supported-providers.md
+++ b/public-docs/supported-providers.md
@@ -58,5 +58,6 @@ Pick any of these from the in-app provider catalog. Each entry is a one-click in
 - [Stakpak](https://stakpak.dev/), Rust-based DevOps agent.
 - [TRAE CLI](https://docs.trae.cn/cli_get-started-with-trae-cli), ByteDance's official TRAE coding agent.
 - [VT Code](https://github.com/vinhnx/VTCode/blob/main/docs/guides/zed-acp.md), open-source multi-provider coding agent.
+- [ZCode](https://github.com/william0wang/zcode-acp), Z.ai's coding agent with GLM models, via the community zcode-acp-server ACP adapter.
 
 The in-app catalog is the canonical, version-pinned source. Anything not listed here can still be added manually, see [Custom providers](/docs/custom-providers).


### PR DESCRIPTION
I've been running ZCode (Z.ai's coding agent with the GLM models) as my daily driver and wanted it side by side with Claude/Codex in Paseo. ZCode itself doesn't speak ACP, but there's a community adapter — [zcode-acp-server](https://github.com/william0wang/zcode-acp) (Apache-2.0) — that bridges ZCode's app-server protocol to standard ACP. That's the same shape as the Kimi and Codex CLI entries: a binary on PATH driven by the generic ACP client.

Today the only way to set that up is hand-editing `config.json` with an `extends: "acp"` block. This PR adds the catalog entry so it's one click in the UI instead, plus the `supported-providers.md` line (matching what the TRAE CLI addition #1831 touched).

**QA — full run against the real adapter and a real agent (macOS arm64, daemon 0.3.0-beta.1):**

- `paseo provider ls` → ZCode available; modes (plan/build/edit/yolo/auto), thinking options (low/high/max) and 17 models discovered at runtime from the ACP handshake
- `paseo run --provider zcode/GLM-5.3` real task → correct file written, thought/tool/message streams visible in `paseo attach` and the timeline
- follow-up prompt resumes the same session (context kept)
- build mode → permission request surfaces in `paseo permit`, allow → task completes
- `paseo stop` mid-task → INTERRUPTED, no orphan zcode processes; archiving the agent exits the adapter process cleanly
- model switching verified for builtin and third-party models; the injected Paseo MCP server is reachable from the agent (`mcp__paseo__list_agents` etc. work)
- one-shot `paseo schedule create` and `--new-workspace worktree` (branch-off) both ran the task correctly

**Two honest caveats:**

1. No icon — ZCode's logo only ships as a bitmap and I didn't want to hand-trace one, so the entry falls back like Kiro's `iconId: null`. Happy to vendor an official SVG if one appears.
2. The adapter's npm release (0.1.0) predates a runtime-prefs handshake fix that ZCode ≥0.16 needs; the fix is merged on its main but unreleased ([william0wang/zcode-acp#41](https://github.com/william0wang/zcode-acp/issues/41)). Until it ships, users installing from npm may hit it — building from the repo's main works, which is what I tested against.

Tests: catalog id/command assertions and the config-patch shape for the new entry (12 tests green in the touched suites). My files pass oxfmt and oxlint; the repo-wide typecheck on a cold checkout has pre-existing failures in unbuilt workspaces (identical count with and without this change), so I committed with `--no-verify` — CI should arbitrate.

Only macOS tested — nothing here looks platform-specific, but I haven't run it elsewhere. If you'd rather discuss the entry first, happy to move this to Discussions instead.