### PR TITLE
fix(server): read Claude transcripts from the provider's config dir

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.provider-config-dir.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.provider-config-dir.test.ts
@@ -1,0 +1,169 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createTestLogger } from "../../../../test-utils/test-logger.js";
+import type { AgentPersistenceHandle, AgentStreamEvent } from "../../agent-sdk-types.js";
+import { ClaudeAgentClient } from "./agent.js";
+import { claudeProjectDirSync } from "./project-dir.js";
+
+// A custom Claude provider carries its own CLAUDE_CONFIG_DIR (docs/custom-providers.md).
+// That value only ever reaches the provider's runtime settings, never the daemon's own
+// environment, so history hydration has to read it from there. See issue #2005.
+
+const PROFILE_USER_MARKER = "PROFILE_HISTORY_USER_MARKER";
+const PROFILE_ASSISTANT_MARKER = "PROFILE_HISTORY_ASSISTANT_MARKER";
+const SESSION_ID = "profile-session";
+
+const queryFactory = vi.fn();
+
+function buildSdkQueryMock() {
+  return {
+    next: vi.fn(async () => ({ done: true, value: undefined })),
+    interrupt: vi.fn(async () => undefined),
+    return: vi.fn(async () => undefined),
+    close: vi.fn(() => undefined),
+    setPermissionMode: vi.fn(async () => undefined),
+    setModel: vi.fn(async () => undefined),
+    supportedModels: vi.fn(async () => [{ value: "opus", displayName: "Opus" }]),
+    supportedCommands: vi.fn(async () => []),
+    rewindFiles: vi.fn(async () => ({ canRewind: true })),
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}
+
+function writeTranscript(configDir: string, cwd: string): void {
+  const historyDir = claudeProjectDirSync(cwd, { configDir });
+  mkdirSync(historyDir, { recursive: true });
+  writeFileSync(
+    path.join(historyDir, `${SESSION_ID}.jsonl`),
+    [
+      JSON.stringify({
+        type: "user",
+        uuid: "profile-user-uuid",
+        sessionId: SESSION_ID,
+        cwd,
+        message: { role: "user", content: PROFILE_USER_MARKER },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        sessionId: SESSION_ID,
+        cwd,
+        message: { role: "assistant", content: PROFILE_ASSISTANT_MARKER },
+      }),
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function collectTimelineText(events: AgentStreamEvent[]): string {
+  const chunks: string[] = [];
+  for (const event of events) {
+    if (event.type !== "timeline") {
+      continue;
+    }
+    if (event.item.type === "user_message" || event.item.type === "assistant_message") {
+      chunks.push(event.item.text);
+    }
+  }
+  return chunks.join("\n");
+}
+
+async function readHistory(client: ClaudeAgentClient, cwd: string): Promise<string> {
+  const handle: AgentPersistenceHandle = {
+    provider: "claude",
+    sessionId: SESSION_ID,
+    nativeHandle: SESSION_ID,
+    metadata: { provider: "claude", cwd },
+  };
+  const session = await client.resumeSession(handle, { cwd });
+  const events: AgentStreamEvent[] = [];
+  try {
+    for await (const event of session.streamHistory()) {
+      events.push(event);
+    }
+  } finally {
+    await session.close();
+  }
+  return collectTimelineText(events);
+}
+
+describe("Claude history hydration with a provider-scoped CLAUDE_CONFIG_DIR", () => {
+  let tempRoot: string;
+  let cwd: string;
+  let profileConfigDir: string;
+  let previousClaudeConfigDir: string | undefined;
+
+  beforeEach(() => {
+    queryFactory.mockImplementation(() => buildSdkQueryMock());
+
+    tempRoot = mkdtempSync(path.join(os.tmpdir(), "claude-profile-config-dir-"));
+    cwd = path.join(tempRoot, "repo");
+    profileConfigDir = path.join(tempRoot, "profile-claude-config");
+    mkdirSync(cwd, { recursive: true });
+    writeTranscript(profileConfigDir, cwd);
+
+    // The daemon-wide value must stay unset: it is the blind spot this covers.
+    previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.CLAUDE_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    queryFactory.mockReset();
+    if (previousClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  test("reads the transcript from the provider's config dir", async () => {
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+      runtimeSettings: { env: { CLAUDE_CONFIG_DIR: profileConfigDir } },
+    });
+
+    const timelineText = await readHistory(client, cwd);
+
+    expect(timelineText).toContain(PROFILE_USER_MARKER);
+    expect(timelineText).toContain(PROFILE_ASSISTANT_MARKER);
+  });
+
+  test("prefers the provider's config dir over the daemon environment", async () => {
+    // Two profiles cannot share one daemon-wide value, so the provider's own
+    // setting has to win over whatever the daemon happens to carry.
+    const decoyConfigDir = path.join(tempRoot, "daemon-claude-config");
+    mkdirSync(decoyConfigDir, { recursive: true });
+    process.env.CLAUDE_CONFIG_DIR = decoyConfigDir;
+
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+      runtimeSettings: { env: { CLAUDE_CONFIG_DIR: profileConfigDir } },
+    });
+
+    const timelineText = await readHistory(client, cwd);
+
+    expect(timelineText).toContain(PROFILE_USER_MARKER);
+  });
+
+  test("lists importable sessions from the provider's config dir", async () => {
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+      runtimeSettings: { env: { CLAUDE_CONFIG_DIR: profileConfigDir } },
+    });
+
+    const sessions = await client.listImportableSessions({ cwd });
+
+    expect(sessions.map((session) => session.providerHandleId)).toContain(SESSION_ID);
+  });
+});

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -2,7 +2,6 @@ import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { promises } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   type AgentDefinition,
@@ -78,6 +77,7 @@ import { renderPromptAttachmentAsText } from "../../prompt-attachments.js";
 import { claudeQuery, type ClaudeOptions, type ClaudeQueryFactory } from "./query.js";
 import { realClaudeRewindSdk, revertClaudeConversation, revertClaudeFiles } from "./rewind.js";
 import { normalizeProviderReplayTimestamp } from "../../provider-history-timestamps.js";
+import { resolveClaudeConfigDir } from "./config-dir.js";
 import { claudeProjectDirSync } from "./project-dir.js";
 import { THINKING_APPLIES_NEXT_TURN_NOTICE } from "../../provider-notices.js";
 import {
@@ -1613,7 +1613,7 @@ export class ClaudeAgentClient implements AgentClient {
   async listImportableSessions(
     options?: ListImportableSessionsOptions,
   ): Promise<ImportableProviderSession[]> {
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const configDir = resolveClaudeConfigDir({ runtimeSettings: this.runtimeSettings });
     const sessionsRoot = options?.cwd
       ? claudeProjectDirSync(options.cwd, { configDir })
       : path.join(configDir, "projects");
@@ -4850,6 +4850,10 @@ class ClaudeAgentSession implements AgentSession {
       this.taskState.reset();
       const historyPath = this.resolveHistoryPath(sessionId);
       if (!historyPath || !fs.existsSync(historyPath)) {
+        this.logger.debug(
+          { sessionId, historyPath },
+          "No Claude transcript to hydrate history from",
+        );
         return;
       }
       const content = fs.readFileSync(historyPath, "utf8");
@@ -4858,8 +4862,8 @@ class ClaudeAgentSession implements AgentSession {
         readClaudeSidechainHistory(historyPath),
       );
       this.ingestPersistedHistory(content, replay);
-    } catch {
-      // ignore history load failures
+    } catch (error) {
+      this.logger.warn({ err: error, sessionId }, "Failed to load persisted Claude history");
     }
   }
 
@@ -5021,7 +5025,10 @@ class ClaudeAgentSession implements AgentSession {
   private resolveHistoryPath(sessionId: string): string | null {
     const cwd = this.config.cwd;
     if (!cwd) return null;
-    const configDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+    const configDir = resolveClaudeConfigDir({
+      runtimeSettings: this.runtimeSettings,
+      overlays: [this.launchEnv],
+    });
     const candidates = [cwd];
     try {
       const realCwd = fs.realpathSync(cwd);

--- a/packages/server/src/server/agent/providers/claude/config-dir.ts
+++ b/packages/server/src/server/agent/providers/claude/config-dir.ts
@@ -1,0 +1,25 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { ProviderRuntimeSettings } from "@getpaseo/protocol/provider-config";
+import type { ProcessEnvRecord } from "../../../paseo-env.js";
+import { createProviderEnv } from "../../provider-launch-config.js";
+
+export interface ClaudeConfigDirSources {
+  runtimeSettings?: ProviderRuntimeSettings;
+  overlays?: Array<ProcessEnvRecord | undefined>;
+}
+
+// Resolves CLAUDE_CONFIG_DIR from the same env Claude Code is launched with, so
+// transcripts are read back from the directory the CLI writes them to. A custom
+// provider carries its own CLAUDE_CONFIG_DIR, which the daemon-wide environment
+// cannot represent once a second profile exists.
+export function resolveClaudeConfigDir(sources?: ClaudeConfigDirSources): string {
+  const env = createProviderEnv({
+    baseEnv: process.env,
+    runtimeSettings: sources?.runtimeSettings,
+    overlays: sources?.overlays,
+  });
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+  return configDir ? configDir : join(homedir(), ".claude");
+}


### PR DESCRIPTION
### Linked issue

Closes #2005

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Paseo read Claude transcripts from the daemon's own `CLAUDE_CONFIG_DIR`. A custom provider declares that variable per profile, and only the provider's runtime settings ever see it. So the profile writes its transcript to one directory and then reads history back from another. The chat comes up empty after every daemon restart, with the transcript still sitting on disk.

The fix reads the directory from the same environment the CLI is launched with, both when hydrating history and when listing importable sessions. A profile that sets nothing still gets the daemon-wide value, so single-profile setups behave as before.

`loadPersistedHistory` also logs now instead of swallowing the failure, which is why nothing about this ever reached the daemon log.

Two cases it does not cover. A profile that picks its directory inside a wrapper command is still invisible to Paseo. And agent-scoped launch env isn't reapplied on the resume paths, so it still lands on the profile directory after a restart. I'd rather handle those separately.

### How did you verify it

I ran a scratch daemon with its own `PASEO_HOME`, gave it a profile pointing at its own `CLAUDE_CONFIG_DIR`, seeded a transcript there and imported it with `paseo agent import`. After `paseo daemon restart`, `paseo agent logs <id>` printed `No activity to display.` on a stock build of `main`. On this branch it printed the conversation back. The only thing I changed between the two runs was the build.

The three new tests set the directory only in the provider's runtime settings, never in `process.env`. That is the gap that let this through, since the existing history tests all set `process.env`. They go through `resumeSession`, `streamHistory` and `listImportableSessions` rather than checking the helper on its own, and all three fail on `main`.

The Claude provider suite (353 tests), typecheck, lint and format all pass. One unrelated thing I hit: `agent-refresh-rehydrates-timeline.e2e.test.ts` already fails on `main` on macOS, because its own path helper doesn't canonicalise `/var` to `/private/var`. I left it alone, and it should pass on Linux CI.

No UI changes.

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran (Biome)
- [ ] UI changes include screenshots or video for every affected platform
- [x] Tests added or updated where it made sense
