### PR TITLE
fix(app): bound the queued-message list and scroll the overflow

### DIFF
--- a/packages/app/e2e/browser/composer-queue-bounds.spec.ts
+++ b/packages/app/e2e/browser/composer-queue-bounds.spec.ts
@@ -1,0 +1,60 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
+import {
+  fillComposerDraft,
+  sendDraftToQueue,
+  startRunningMockAgent,
+} from "../support/helpers/composer";
+import { queueTrackMaxHeight } from "@/composer/queue-track-metrics";
+
+const QUEUED_COUNT = 8;
+
+async function queueMessage(page: Page, prompt: string): Promise<void> {
+  await fillComposerDraft(page, prompt);
+  await sendDraftToQueue(page);
+}
+
+test("a long queue is bounded and scrolls instead of growing without end", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  const agent = await startRunningMockAgent(page, {
+    prefix: `queue-bounds-${testInfo.workerIndex}-`,
+    model: "one-minute-stream",
+    prompt: "Keep the agent running while messages queue.",
+  });
+
+  try {
+    for (let index = 1; index <= QUEUED_COUNT; index += 1) {
+      await queueMessage(page, `queued message ${index}`);
+    }
+
+    // Every queued message survives — the cap is visual only, it must not drop work.
+    await expect(page.getByRole("button", { name: "Send queued message now" })).toHaveCount(
+      QUEUED_COUNT,
+    );
+
+    const track = page.getByTestId("composer-queue-track");
+    await expect(track).toBeVisible();
+
+    const cap = queueTrackMaxHeight({ spacing: 8, borderWidth: 1 });
+    const box = await track.boundingBox();
+    expect(box).not.toBeNull();
+    // Eight rows would exceed the cap if the list still grew freely.
+    expect(box?.height ?? 0).toBeLessThanOrEqual(cap + 1);
+
+    // ...and the overflow stays reachable rather than being clipped away.
+    const scroll = page.getByTestId("composer-queue-scroll");
+    const overflow = await scroll.evaluate(
+      (node: HTMLElement) => node.scrollHeight - node.clientHeight,
+    );
+    expect(overflow).toBeGreaterThan(0);
+
+    // The message that goes in next stays pinned at the top; no auto-scroll.
+    const scrollTop = await scroll.evaluate((node: HTMLElement) => node.scrollTop);
+    expect(scrollTop).toBe(0);
+    await expect(track.getByText("queued message 1")).toBeVisible();
+  } finally {
+    await agent.cleanup();
+  }
+});

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -1,7 +1,9 @@
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { QUEUE_ACTION_BUTTON_SIZE, queueTrackMaxHeight } from "@/composer/queue-track-metrics";
 import {
   View,
   Pressable,
+  ScrollView,
   Text,
   StyleSheet as RNStyleSheet,
   type PressableStateCallbackType,
@@ -376,17 +378,27 @@ function renderQueueTrack(args: RenderQueueTrackArgs): ReactElement | null {
     args;
   if (queuedMessages.length === 0) return null;
   return (
-    <View style={styles.queueTrack}>
-      {queuedMessages.map((item) => (
-        <QueuedMessageRow
-          key={item.id}
-          item={item}
-          onEdit={handleEditQueuedMessage}
-          onSendNow={handleSendQueuedNow}
-          editLabel={editLabel}
-          sendNowLabel={sendNowLabel}
-        />
-      ))}
+    // Bounded so a long queue cannot push the composer off screen. The list stays
+    // in send order with the next message on top, and does not auto-scroll: the
+    // item about to go in should stay in view while later ones scroll.
+    <View style={styles.queueTrack} testID="composer-queue-track">
+      <ScrollView
+        style={styles.queueScroll}
+        testID="composer-queue-scroll"
+        contentContainerStyle={styles.queueTrackContent}
+        keyboardShouldPersistTaps="always"
+      >
+        {queuedMessages.map((item) => (
+          <QueuedMessageRow
+            key={item.id}
+            item={item}
+            onEdit={handleEditQueuedMessage}
+            onSendNow={handleSendQueuedNow}
+            editLabel={editLabel}
+            sendNowLabel={sendNowLabel}
+          />
+        ))}
+      </ScrollView>
     </View>
   );
 }
@@ -2452,6 +2464,17 @@ const styles = StyleSheet.create((theme: Theme) => ({
     opacity: 0.5,
   },
   queueTrack: {
+    // Derived from the row box rather than a magic number, so changing the
+    // action button size or row padding keeps showing the same item count.
+    maxHeight: queueTrackMaxHeight({
+      spacing: theme.spacing[2],
+      borderWidth: theme.borderWidth[1],
+    }),
+  },
+  queueScroll: {
+    flexGrow: 0,
+  },
+  queueTrackContent: {
     flexDirection: "column",
     gap: theme.spacing[2],
   },
@@ -2478,8 +2501,8 @@ const styles = StyleSheet.create((theme: Theme) => ({
     gap: theme.spacing[2],
   },
   queueActionButton: {
-    width: 32,
-    height: 32,
+    width: QUEUE_ACTION_BUTTON_SIZE,
+    height: QUEUE_ACTION_BUTTON_SIZE,
     borderRadius: theme.borderRadius.full,
     alignItems: "center",
     justifyContent: "center",

--- a/packages/app/src/composer/queue-track-metrics.test.ts
+++ b/packages/app/src/composer/queue-track-metrics.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  QUEUE_ACTION_BUTTON_SIZE,
+  QUEUE_VISIBLE_ITEMS,
+  queueTrackMaxHeight,
+} from "./queue-track-metrics.js";
+
+describe("queueTrackMaxHeight", () => {
+  it("fits exactly the visible rows and the gaps between them", () => {
+    // 5 rows of (32 + 8*2 + 1*2) plus 4 gaps of 8.
+    expect(queueTrackMaxHeight({ spacing: 8, borderWidth: 1 })).toBe(282);
+  });
+
+  it("counts one fewer gap than rows", () => {
+    const single = queueTrackMaxHeight({ spacing: 8, borderWidth: 1, visibleItems: 1 });
+    const double = queueTrackMaxHeight({ spacing: 8, borderWidth: 1, visibleItems: 2 });
+    const rowHeight = QUEUE_ACTION_BUTTON_SIZE + 8 * 2 + 1 * 2;
+    expect(single).toBe(rowHeight);
+    expect(double).toBe(rowHeight * 2 + 8);
+  });
+
+  it("tracks the row box so the visible count cannot drift", () => {
+    const base = queueTrackMaxHeight({ spacing: 8, borderWidth: 1 });
+    expect(queueTrackMaxHeight({ spacing: 12, borderWidth: 1 })).toBeGreaterThan(base);
+    expect(queueTrackMaxHeight({ spacing: 8, borderWidth: 2 })).toBeGreaterThan(base);
+  });
+
+  it("caps a queue longer than the visible count", () => {
+    const cap = queueTrackMaxHeight({ spacing: 8, borderWidth: 1 });
+    const twentyRows = queueTrackMaxHeight({ spacing: 8, borderWidth: 1, visibleItems: 20 });
+    expect(cap).toBeLessThan(twentyRows);
+    expect(QUEUE_VISIBLE_ITEMS).toBeLessThan(20);
+  });
+
+  it("collapses rather than returning a negative height", () => {
+    expect(queueTrackMaxHeight({ spacing: 8, borderWidth: 1, visibleItems: 0 })).toBe(0);
+  });
+});

--- a/packages/app/src/composer/queue-track-metrics.ts
+++ b/packages/app/src/composer/queue-track-metrics.ts
@@ -1,0 +1,34 @@
+/**
+ * Height metrics for the queued-message list.
+ *
+ * The queue used to grow without bound, so a long queue pushed the composer off
+ * screen. It is capped instead, and the cap is derived from the row box here
+ * rather than written as a pixel literal in the stylesheet: changing the action
+ * button size or the row padding then keeps showing the same number of items
+ * instead of silently showing a fraction more or fewer.
+ */
+
+/** Queued rows visible before the list scrolls. */
+export const QUEUE_VISIBLE_ITEMS = 5;
+
+/** Square edit/send buttons, which set the row's minimum content height. */
+export const QUEUE_ACTION_BUTTON_SIZE = 32;
+
+export interface QueueTrackMetrics {
+  /** Vertical padding applied to each row, and the gap between rows. */
+  spacing: number;
+  /** Row border width, counted on both edges. */
+  borderWidth: number;
+  /** Defaults to QUEUE_VISIBLE_ITEMS. */
+  visibleItems?: number;
+}
+
+export function queueTrackMaxHeight({
+  spacing,
+  borderWidth,
+  visibleItems = QUEUE_VISIBLE_ITEMS,
+}: QueueTrackMetrics): number {
+  if (visibleItems <= 0) return 0;
+  const rowHeight = QUEUE_ACTION_BUTTON_SIZE + spacing * 2 + borderWidth * 2;
+  return rowHeight * visibleItems + spacing * (visibleItems - 1);
+}


### PR DESCRIPTION
Fixes #3379.

## Problem

`renderQueueTrack` mapped every queued message into a plain `View` with no cap and no scroll, so the list grew one full-height row per queued message. Queue enough and it takes the whole conversation area and starts pushing the composer off screen.

## Before / after

Eight queued messages, same scenario in both.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/edihasaj/paseo/assets/queue-bounds/before.png" width="420"> | <img src="https://raw.githubusercontent.com/edihasaj/paseo/assets/queue-bounds/after.png" width="420"> |

Before, all eight rows render and the conversation is gone. After, the list stops at five, the conversation is visible again, and the remaining three are one scroll away.

## Change

- `packages/app/src/composer/index.tsx` — the track is now a height-bounded `View` wrapping a `ScrollView`, the same shape `components/ui/autocomplete.tsx` already uses. I followed that rather than relying on `ScrollView` auto-sizing.
- `packages/app/src/composer/queue-track-metrics.ts` (new) — the cap is derived from the row box, not a pixel literal:

  ```
  rowHeight = actionButtonSize + spacing * 2 + borderWidth * 2
  maxHeight = rowHeight * visibleItems + spacing * (visibleItems - 1)
  ```

  `queueActionButton` now reads its size from the same constant, so the height math and the row it measures cannot drift apart.

**Order is unchanged and deliberate.** The queue drains from the front (`runtime/host-runtime.ts:2163`, `const next = queue[0]`), so the top row is the message that goes in next. The list does not auto-scroll: scrolling to the newest would hide the message about to be sent. Covered by an assertion.

Five visible rows is the one number I picked, and it is a one-line change if you want a different count or a viewport-relative cap. Two other directions I considered and did not take, in case you prefer one: collapsing the overflow behind a "+3 more" affordance, or pinning the most recently queued row instead of the next-to-send.

## QA evidence

**The e2e spec fails on `main` and passes with the change.** I ran the committed spec against an otherwise untouched `main` composer to confirm it actually catches the bug:

```
# main composer, this branch's spec
1 failed
  [browser] › composer-queue-bounds.spec.ts:17:5 › a long queue is bounded and scrolls instead of growing without end

# with the fix
1 passed (15.3s)
```

The spec queues 8 messages and asserts all 8 still exist (the cap is visual — it must not drop queued work), the track stays within the cap, the overflow is actually reachable, `scrollTop` stays 0, and row 1 remains visible.

```
$ npx vitest run src/composer --root packages/app
Test Files  21 passed (21)
     Tests  152 passed (152)

$ npm run lint          → 0 warnings, 0 errors
$ npm run format:check  → all matched files use the correct format
$ npm run typecheck     → clean across all workspaces
```

`queue-track-metrics.test.ts` covers the height math directly: exact fit for the visible rows, one fewer gap than rows, that the result tracks the row box so the visible count cannot drift, and that a zero count collapses instead of returning a negative height.

## Platforms

Tested on macOS 26.5.2 (arm64), desktop and web, via the browser e2e project.

**Not tested: iOS and Android.** The composer is shared, so the cap should apply there too, but swapping a `View` for a `ScrollView` changes touch behavior — the queue becomes a nested vertical scroll area inside the composer. That deserves a check on a real device before this lands, and I could not do it here. Flagging it rather than implying coverage I do not have.
