### PR TITLE
fix(app): copy the branch name, not the workspace title, in the sidebar

### DIFF
--- a/packages/app/e2e/browser/sidebar-copy-branch-name.spec.ts
+++ b/packages/app/e2e/browser/sidebar-copy-branch-name.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect, type Page } from "../support/fixtures";
+import { gotoAppShell } from "../support/helpers/app";
+import { seedWorkspace } from "../support/helpers/seed-client";
+import { getServerId } from "../support/helpers/server-id";
+import { copyBranchNameFromSidebar, selectSidebarStatusGrouping } from "../support/helpers/sidebar";
+
+async function readClipboard(page: Page): Promise<string> {
+  return page.evaluate(() => navigator.clipboard.readText());
+}
+
+// The sidebar has one row implementation per grouping mode, and each one wires the menu's
+// copy action itself. The status-grouped row copied the workspace name — which the daemon
+// resolves to the custom title whenever one is set — so the seeded title here must differ
+// from the branch. A workspace whose title still matches its branch passes either way.
+test.describe("Sidebar copy branch name", () => {
+  test("copies the branch, not the title, from a status-grouped row", async ({ context, page }) => {
+    const customTitle = "Payments Refactor";
+    const workspace = await seedWorkspace({
+      repoPrefix: "sidebar-copy-branch-",
+      title: customTitle,
+    });
+
+    try {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+      await gotoAppShell(page);
+
+      const row = page.getByTestId(
+        `sidebar-workspace-row-${getServerId()}:${workspace.workspaceId}`,
+      );
+      await expect(row).toContainText(customTitle, { timeout: 30_000 });
+
+      await selectSidebarStatusGrouping(page);
+      await copyBranchNameFromSidebar(page, workspace.workspaceId);
+
+      // createTempGitRepo seeds `git init -b main` and leaves HEAD on main.
+      await expect.poll(() => readClipboard(page)).toBe("main");
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+});

--- a/packages/app/e2e/support/helpers/sidebar.ts
+++ b/packages/app/e2e/support/helpers/sidebar.ts
@@ -150,6 +150,15 @@ export async function pinWorkspaceFromSidebar(page: Page, workspaceId: string): 
   await pinItem.click();
 }
 
+export async function copyBranchNameFromSidebar(page: Page, workspaceId: string): Promise<void> {
+  const serverId = await openWorkspaceSidebarKebab(page, workspaceId);
+  const copyItem = page.getByTestId(
+    `sidebar-workspace-menu-copy-branch-name-${serverId}:${workspaceId}`,
+  );
+  await expect(copyItem).toBeVisible({ timeout: 10_000 });
+  await copyItem.click();
+}
+
 export async function archiveWorkspaceFromSidebar(page: Page, workspaceId: string): Promise<void> {
   // A clean workspace archives with no prompt. Managed worktree backing may raise
   // a browser confirm for unsynced work, so accept it when present.

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -1377,7 +1377,9 @@ function WorkspaceRowWithMenu({
         archiveStatus={isArchiving ? "pending" : "idle"}
         archivePendingLabel={t("sidebar.workspace.actions.archiving")}
         onArchive={handleArchive}
-        onCopyBranchName={canCopyBranchName ? handleCopyBranchName : undefined}
+        onCopyBranchName={
+          canCopyBranchName && workspace.currentBranch ? handleCopyBranchName : undefined
+        }
         onCopyPath={handleCopyPath}
         onRename={handleOpenRename}
         onMarkAsRead={hasClearableAttention ? handleMarkAsRead : undefined}

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -622,13 +622,16 @@ function StatusWorkspaceRowWithMenu({
       return;
     }
     void Clipboard.setStringAsync(copyTargetDirectory);
-    toast.copied("Path copied");
-  }, [toast, workspace.workspaceDirectory, workspace.workspaceId]);
+    toast.copied(t("sidebar.workspace.toasts.pathCopied"));
+  }, [t, toast, workspace.workspaceDirectory, workspace.workspaceId]);
 
   const handleCopyBranchName = useCallback(() => {
-    void Clipboard.setStringAsync(workspace.name);
-    toast.copied("Branch name copied");
-  }, [toast, workspace.name]);
+    if (!workspace.currentBranch) {
+      return;
+    }
+    void Clipboard.setStringAsync(workspace.currentBranch);
+    toast.copied(t("sidebar.workspace.toasts.branchNameCopied"));
+  }, [t, toast, workspace.currentBranch]);
 
   const renameMutation = useMutation({
     mutationFn: async (title: string) => {
@@ -690,7 +693,11 @@ function StatusWorkspaceRowWithMenu({
         archiveStatus={isArchiving ? "pending" : "idle"}
         archivePendingLabel={t("sidebar.workspace.actions.archiving")}
         onArchive={handleArchive}
-        onCopyBranchName={workspace.projectKind === "git" ? handleCopyBranchName : undefined}
+        onCopyBranchName={
+          workspace.projectKind === "git" && workspace.currentBranch
+            ? handleCopyBranchName
+            : undefined
+        }
         onCopyPath={handleCopyPath}
         onRename={handleOpenRename}
         onMarkAsRead={hasClearableAttention ? handleMarkAsRead : undefined}


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Reasoning

"Copy branch name" in the sidebar workspace menu puts the workspace title on the clipboard instead of the branch. The same action works correctly in the workspace header menu and in the hover card, so the clipboard holds a different value depending on where you copied from.

### Goals

- Copy the branch name to the clipboard from every sidebar workspace menu, in both grouping modes.
- Hide "Copy branch name" when the workspace has no branch, so the menu never shows an action that does nothing.
- Translate the two toasts in the status-grouped row that were still hardcoded English.
- Cover the fix with an end-to-end test that fails against the old code.

### Non-goals

- No shared hook for the two row implementations. The duplicated action handlers are why the two rows drifted apart, but that refactor rewrites the row that works today.
- No deletion of `packages/app/src/components/sidebar/sidebar-workspace-row.tsx`, which is a third unused copy of the same row. It is a separate change.
- No change to the unawaited clipboard write. Every copy action in these files reports success before the write resolves, and a fix belongs across all of them.
- No new i18n keys. The two toasts here use keys that already exist.

### QA

**Tests:**

- `packages/app/e2e/browser/sidebar-copy-branch-name.spec.ts` (new) - copies the branch name from a status-grouped sidebar row, for a workspace whose seeded title differs from its branch, and reads the clipboard back. Verified failing against the unfixed code, where it reads the title.

Before the change, "Copy branch name" in "Group by status" put the workspace title on the clipboard. After the change it puts the branch there. I checked the same workspace in "Group by project", in the workspace header menu, and in the hover card, and all of them now give the same string. With a detached HEAD the action no longer appears in the row menu. The app took about 30 seconds to show that state after the checkout.

Detached HEAD now hides "Copy branch name":

<img width="301" height="181" alt="image" src="https://github.com/user-attachments/assets/dc242176-7d4c-4f78-b4c5-5ee3d794629d" />

The other changes are not visual.

Tested on desktop (Electron, macOS). Not tested: web, iOS, Android.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
