### PR TITLE
fix(cli): include Pi in daemon status fallback

### DIFF
--- a/packages/cli/src/commands/daemon/status.test.ts
+++ b/packages/cli/src/commands/daemon/status.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { selectRelayStatus } from "./status.js";
+import { PROVIDER_BINARIES, selectRelayStatus } from "./status.js";
+
+describe("PROVIDER_BINARIES", () => {
+  test("includes Pi in the local fallback probe", () => {
+    expect(PROVIDER_BINARIES).toContainEqual({ label: "Pi", binary: "pi" });
+  });
+});
 
 describe("selectRelayStatus", () => {
   const persisted = {

--- a/packages/cli/src/commands/daemon/status.ts
+++ b/packages/cli/src/commands/daemon/status.ts
@@ -156,10 +156,11 @@ function toStatusRows(status: DaemonStatus): StatusRow[] {
   return rows;
 }
 
-const PROVIDER_BINARIES: { label: string; binary: string }[] = [
+export const PROVIDER_BINARIES: { label: string; binary: string }[] = [
   { label: "Claude", binary: "claude" },
   { label: "Codex", binary: "codex" },
   { label: "OpenCode", binary: "opencode" },
+  { label: "Pi", binary: "pi" },
 ];
 
 async function checkProviderBinary(


### PR DESCRIPTION
## Problem

When the daemon detail request is unavailable during cold start, `paseo daemon status` falls back to probing a hard-coded local binary list. That list includes Claude, Codex, and OpenCode but omits Pi, so a ready Pi installation disappears from the status output.

Fixes #3385.

## Change

- Include `pi` in the local provider binary fallback.
- Add a regression test that keeps Pi in the fallback probe list.

## QA

Tested on Linux only:

```text
$ npm run build:server
@getpaseo/cli build: passed
@getpaseo/server build: passed

$ cd packages/cli && npx vitest run src/commands/daemon/status.test.ts
Test Files  1 passed (1)
Tests       3 passed (3)

$ npm run typecheck --workspace=@getpaseo/cli
passed

$ npm run format:check:files -- packages/cli/src/commands/daemon/status.ts packages/cli/src/commands/daemon/status.test.ts
All matched files use the correct format.
```

Built CLI fallback check with no daemon running:

```json
{
  "localDaemon": "stopped",
  "pi": {
    "label": "Pi",
    "path": "/home/Kei/.nvm/versions/node/v24.14.0/bin/pi",
    "version": "0.84.1"
  }
}
```

Raspberry Pi 5 / Debian 13 arm64 live verification before the patch confirmed the provider itself was healthy:

```text
Version: 0.84.1
Models: 7
Status: Ready
```

A Paseo-managed Pi run using `bigmodel/glm-5.3` completed and returned `PASEO_PI_OK`.

Not tested on macOS or Windows.

## Known repository baseline

The full pre-commit typecheck reaches and passes `@getpaseo/cli`, but currently fails in the unrelated app workspace:

```text
packages/app/src/components/draggable-list.native.tsx(122,7):
Property 'dragGestureHostPresented' does not exist on type ...
```

The scoped CLI typecheck above passes.
