### PR TITLE
fix(terminal): let Korean be typed in the mobile terminal

### DIFF
--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -228,4 +228,59 @@ describe("native terminal typed input", () => {
       shouldClear: false,
     });
   });
+
+  it("types Hangul by rubbing out the syllable the IME rewrites in place", () => {
+    const input = createTerminalTextInputState();
+
+    // 한글: the composing syllable is rewritten on every jamo, never appended.
+    expect(input.receiveTextChange("ㅎ")).toEqual({ data: "ㅎ", shouldClear: false });
+    expect(input.receiveTextChange("하")).toEqual({ data: "\x7f하", shouldClear: false });
+    expect(input.receiveTextChange("한")).toEqual({ data: "\x7f한", shouldClear: false });
+    expect(input.receiveTextChange("한ㄱ")).toEqual({ data: "ㄱ", shouldClear: false });
+    expect(input.receiveTextChange("한그")).toEqual({ data: "\x7f그", shouldClear: false });
+    expect(input.receiveTextChange("한글")).toEqual({ data: "\x7f글", shouldClear: false });
+  });
+
+  it("types Hangul when a final consonant migrates into the next syllable", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("안")).toEqual({ data: "안", shouldClear: false });
+    // Typing ㅣ moves ㄴ off 안 and onto the new syllable: 안 → 아니.
+    expect(input.receiveTextChange("아니")).toEqual({ data: "\x7f아니", shouldClear: false });
+  });
+
+  it("does not dispatch Hangul through the keypress path", () => {
+    const input = createTerminalTextInputState();
+
+    // The IME reports the jamo it is composing; the text change reports the
+    // syllable. Dispatching both would put two conflicting characters on the wire.
+    expect(input.receiveKeyPress("ㅎ")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("ㅎ")).toEqual({ data: "ㅎ", shouldClear: false });
+    expect(input.receiveKeyPress("ㅏ")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("하")).toEqual({ data: "\x7f하", shouldClear: false });
+  });
+
+  it("still swallows replacement edits wider than one composing syllable", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
+    // Two syllables at once is a suggestion replacement, not composition.
+    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+  });
+
+  it("does not treat a non-Hangul trailing edit as composition", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("ls -a")).toEqual({ data: "ls -a", shouldClear: false });
+    expect(input.receiveTextChange("ls -l")).toEqual({ data: "", shouldClear: false });
+  });
+
+  it("keeps anticipated text aligned when Backspace decomposes a syllable", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한")).toEqual({ data: "한", shouldClear: false });
+    // The rubout already removed the whole syllable, so the redraw is a plain append.
+    expect(input.receiveKeyPress("Backspace")).toEqual({ data: "\x7f", shouldClear: false });
+    expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
+  });
 });

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -283,4 +283,26 @@ describe("native terminal typed input", () => {
     expect(input.receiveKeyPress("Backspace")).toEqual({ data: "\x7f", shouldClear: false });
     expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
   });
+
+  it("stops rubbing out once a swallowed replacement leaves the terminal ahead", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
+    // Swallowed: the terminal still holds 한글 while the buffer moved to 우리.
+    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+    // A rubout here would delete 글 off the terminal and leave 한루 behind.
+    expect(input.receiveTextChange("우루")).toEqual({ data: "", shouldClear: false });
+  });
+
+  it("resumes composition once the line is cleared", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
+    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+
+    input.reset();
+
+    expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
+    expect(input.receiveTextChange("한")).toEqual({ data: "\x7f한", shouldClear: false });
+  });
 });

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -99,6 +99,11 @@ export function resolveTerminalInputFocusRequest(input: {
 export function createTerminalTextInputState(): TerminalTextInputState {
   let previousText = "";
   let submittedText: string | null = null;
+  // A swallowed replacement leaves the terminal holding text the buffer no
+  // longer describes. A composition rubout deletes from the terminal, so it
+  // would delete whatever is actually sitting there rather than the character
+  // the buffer thinks it is replacing. Stay off until the line is cleared.
+  let replacementDesynced = false;
 
   return {
     receiveKeyPress(key: string): TerminalTextInputChange {
@@ -126,22 +131,30 @@ export function createTerminalTextInputState(): TerminalTextInputState {
         submittedText = null;
         if (text === lateSubmitText) {
           previousText = "";
+          replacementDesynced = false;
           return { data: "", shouldClear: false };
         }
       }
 
       if (text.length === 0) {
         previousText = "";
+        replacementDesynced = false;
         return { data: "", shouldClear: false };
       }
 
       if (text.includes("\n") || text.includes("\r")) {
         previousText = "";
+        replacementDesynced = false;
         return { data: "", shouldClear: true };
       }
 
       if (!text.startsWith(previousText)) {
-        const compositionEdit = resolveCompositionEdit(previousText, text);
+        const compositionEdit = replacementDesynced
+          ? ""
+          : resolveCompositionEdit(previousText, text);
+        if (compositionEdit === "") {
+          replacementDesynced = true;
+        }
         previousText = text;
         return { data: compositionEdit, shouldClear: false };
       }
@@ -155,6 +168,7 @@ export function createTerminalTextInputState(): TerminalTextInputState {
     },
     reset(): void {
       previousText = "";
+      replacementDesynced = false;
     },
   };
 }

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -40,8 +40,50 @@ interface TerminalInputProps {
   style?: StyleProp<TextStyle>;
 }
 
+// Hangul jamo, compatibility jamo, and precomposed syllables. A Korean IME
+// commits every syllable except the one it is still composing, so a composition
+// edit only ever rewrites the final character of the buffer.
+const HANGUL_PATTERN = /^[\u1100-\u11ff\u3130-\u318f\ua960-\ua97f\uac00-\ud7a3\ud7b0-\ud7ff]/;
+
+// Only ASCII travels the keypress path. An IME script reports the jamo it is
+// composing, which the text-change diff below immediately contradicts, so
+// forwarding both would put two conflicting characters on the wire.
 function isPrintableKey(key: string): boolean {
-  return key.length === 1 && key >= " " && key !== "\x7f";
+  return key.length === 1 && key >= " " && key <= "~";
+}
+
+function getCommonPrefixLength(left: string, right: string): number {
+  const limit = Math.min(left.length, right.length);
+  let index = 0;
+  while (index < limit && left[index] === right[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+/**
+ * What the terminal receives for an edit that is not a plain append.
+ *
+ * A Korean IME rewrites the syllable it is composing in place — `ㅎ` becomes
+ * `하` becomes `한`. None of those are appends, so forwarding appends alone
+ * drops every keystroke after the first jamo and Korean cannot be typed at all.
+ * Rub out the rewritten character and send the replacement.
+ *
+ * Only a single trailing character qualifies. A wider rewrite is an autocorrect
+ * or suggestion replacement, which stays swallowed: the hidden input can edit
+ * text the terminal has already committed, and the terminal cannot take it back.
+ */
+function resolveCompositionEdit(previousText: string, text: string): string {
+  const commonPrefixLength = getCommonPrefixLength(previousText, text);
+  const removed = previousText.slice(commonPrefixLength);
+  const inserted = text.slice(commonPrefixLength);
+  if (removed.length !== 1 || inserted.length === 0) {
+    return "";
+  }
+  if (!HANGUL_PATTERN.test(removed) || !HANGUL_PATTERN.test(inserted)) {
+    return "";
+  }
+  return `\x7f${inserted}`;
 }
 
 export function resolveTerminalInputFocusRequest(input: {
@@ -99,8 +141,9 @@ export function createTerminalTextInputState(): TerminalTextInputState {
       }
 
       if (!text.startsWith(previousText)) {
+        const compositionEdit = resolveCompositionEdit(previousText, text);
         previousText = text;
-        return { data: "", shouldClear: false };
+        return { data: compositionEdit, shouldClear: false };
       }
 
       const appendedText = text.slice(previousText.length);
@@ -240,6 +283,9 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
     );
 
     return (
+      // No keyboardType prop: `ascii-capable` drops the globe key on iOS, which
+      // is how you reach the Korean layout. Terminal safety comes from
+      // autoCorrect/spellCheck/autoCapitalize being off, not from the layout.
       <TextInput
         ref={inputRef}
         accessibilityLabel="Terminal input"
@@ -251,7 +297,6 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
         defaultValue=""
         blurOnSubmit={false}
         importantForAutofill="no"
-        keyboardType="ascii-capable"
         multiline={true}
         onChangeText={handleChangeText}
         onBlur={handleBlur}


### PR DESCRIPTION
### Linked issue

Closes #3384

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A Korean user cannot type Korean into a terminal on their phone. They reported it as "the 한/영 toggle button isn't there", and that is the first half of it — but fixing only that still leaves the terminal unusable, because the composition never reaches the wire either.

**The globe key is missing.** The hidden terminal input sets `keyboardType="ascii-capable"`. On iOS that restricts the keyboard to ASCII-capable layouts, which removes the globe key — the way you reach a Hangul keyboard. There is no route to a Korean layout from a terminal at all.

**Composition is dropped.** `receiveTextChange` forwards a change only when it extends the previous buffer. A Korean IME rewrites the syllable it is composing in place instead of appending:

| keystroke | buffer | `startsWith(previous)` | forwarded |
| --- | --- | --- | --- |
| ㅎ | `ㅎ` | true | `ㅎ` |
| ㅏ | `하` | **false** | *(dropped)* |
| ㄴ | `한` | **false** | *(dropped)* |

One stray jamo lands and everything after it disappears.

The swallow is deliberate and worth keeping — it stops an autocorrect replacement from rewriting a line the terminal already committed, which is issue #2904's failure mode in the composer. It just could not tell composition apart from replacement. This PR draws that line: exactly one trailing Hangul character rewritten is composition, anything wider is a replacement and stays swallowed.

Latin typing is unaffected — it appends, so it never reaches the new branch.

### Goals

- Reach a Korean keyboard from a mobile terminal (drop `ascii-capable`).
- Forward Hangul composition to the terminal as a rubout plus the replacement syllable.
- Keep the existing autocorrect/suggestion swallow intact.
- Keep Hangul off the keypress path, so the jamo the IME reports and the syllable the text change reports do not both go on the wire.

### Non-goals

- **Japanese and Chinese.** Their composing region spans several characters and conversion replaces the whole run, so the one-character rule here does not cover them. They are no worse than before. Worth a follow-up with its own tests rather than a guess folded into this PR.
- **Widening the swallow.** A multi-character rewrite is still dropped. That is the conservative side of the trade: a missed edit is recoverable, a corrupted committed line is not.
- **Smart punctuation.** Dropping `ascii-capable` means iOS picks the layout. `autoCorrect`, `spellCheck` and `autoCapitalize` are already off, which is what keeps the terminal safe; the keyboard type was never what did it.

### QA

**Reproduced first.** iOS, App Store build 0.4.0, workspace terminal: no globe key on the keyboard, and with a Hangul keyboard forced, typing `한글` puts `ㅎ` on the line and nothing more. The same phone types Korean fine in the chat composer, and pasting Korean into the terminal works — a paste is an append, so it passes `startsWith`. That asymmetry is what pointed at the diff.

**Unit tests**, `npx vitest run packages/app/src/terminal/native-renderer/terminal-input.native.test.ts` — 24 passed, 6 new:

- full `한글` sequence, asserting each byte the terminal receives: `ㅎ`, `\x7f하`, `\x7f한`, `ㄱ`, `\x7f그`, `\x7f글`
- final-consonant migration `안` → `아니`, where one keystroke rewrites the syllable and adds another
- Hangul does not dispatch through the keypress path
- a two-syllable rewrite (`한글` → `우리`) is still swallowed
- a non-Hangul trailing edit (`ls -a` → `ls -l`) is still swallowed
- Backspace decomposing `한` → `하` stays aligned

The 18 pre-existing tests pass unchanged, including `does not translate replacement edits into terminal text` and `does not duplicate printable keypresses when the native text change also arrives`.

`npm run typecheck`, `npm run lint`, `npm run format` all pass.

**What I could not verify:** I do not have a device build, so the globe key returning is reasoned from `ascii-capable` semantics, not observed. Someone with an iOS device should confirm the keyboard shows the globe key and that a real Korean IME drives the sequence the tests encode. The composition logic itself is pure and fully covered above.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
