### PR TITLE
fix(terminal): support CJK IME composition on mobile

### DIFF
--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -325,6 +325,19 @@ describe("native terminal typed input", () => {
     expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
   });
 
+  it("keeps CJK composition enabled after Backspace removes an emoji", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("😀")).toEqual({ data: "😀", shouldClear: false });
+    expect(input.receiveKeyPress("Backspace")).toEqual({ data: "\x7f", shouldClear: false });
+
+    expect(input.receiveTextChange("nihao")).toEqual({ data: "nihao", shouldClear: false });
+    expect(input.receiveTextChange("你好")).toEqual({
+      data: "\x7f\x7f\x7f\x7f\x7f你好",
+      shouldClear: false,
+    });
+  });
+
   it("stops rubbing out once a swallowed replacement leaves the terminal ahead", () => {
     const input = createTerminalTextInputState();
 

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -228,4 +228,59 @@ describe("native terminal typed input", () => {
       shouldClear: false,
     });
   });
+
+  it("types Hangul by rubbing out the syllable the IME rewrites in place", () => {
+    const input = createTerminalTextInputState();
+
+    // 한글: the composing syllable is rewritten on every jamo, never appended.
+    expect(input.receiveTextChange("ㅎ")).toEqual({ data: "ㅎ", shouldClear: false });
+    expect(input.receiveTextChange("하")).toEqual({ data: "\x7f하", shouldClear: false });
+    expect(input.receiveTextChange("한")).toEqual({ data: "\x7f한", shouldClear: false });
+    expect(input.receiveTextChange("한ㄱ")).toEqual({ data: "ㄱ", shouldClear: false });
+    expect(input.receiveTextChange("한그")).toEqual({ data: "\x7f그", shouldClear: false });
+    expect(input.receiveTextChange("한글")).toEqual({ data: "\x7f글", shouldClear: false });
+  });
+
+  it("types Hangul when a final consonant migrates into the next syllable", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("안")).toEqual({ data: "안", shouldClear: false });
+    // Typing ㅣ moves ㄴ off 안 and onto the new syllable: 안 → 아니.
+    expect(input.receiveTextChange("아니")).toEqual({ data: "\x7f아니", shouldClear: false });
+  });
+
+  it("does not dispatch Hangul through the keypress path", () => {
+    const input = createTerminalTextInputState();
+
+    // The IME reports the jamo it is composing; the text change reports the
+    // syllable. Dispatching both would put two conflicting characters on the wire.
+    expect(input.receiveKeyPress("ㅎ")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("ㅎ")).toEqual({ data: "ㅎ", shouldClear: false });
+    expect(input.receiveKeyPress("ㅏ")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("하")).toEqual({ data: "\x7f하", shouldClear: false });
+  });
+
+  it("still swallows replacement edits wider than one composing syllable", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
+    // Two syllables at once is a suggestion replacement, not composition.
+    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+  });
+
+  it("does not treat a non-Hangul trailing edit as composition", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("ls -a")).toEqual({ data: "ls -a", shouldClear: false });
+    expect(input.receiveTextChange("ls -l")).toEqual({ data: "", shouldClear: false });
+  });
+
+  it("keeps anticipated text aligned when Backspace decomposes a syllable", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한")).toEqual({ data: "한", shouldClear: false });
+    // The rubout already removed the whole syllable, so the redraw is a plain append.
+    expect(input.receiveKeyPress("Backspace")).toEqual({ data: "\x7f", shouldClear: false });
+    expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
+  });
 });

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -344,6 +344,23 @@ describe("native terminal typed input", () => {
     expect(input.receiveTextChange("th")).toEqual({ data: "", shouldClear: false });
   });
 
+  it("keeps replacement desync protection after Backspace empties the hidden input", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("teh")).toEqual({ data: "teh", shouldClear: false });
+    // Autocorrect changes the buffer but cannot rewrite the terminal.
+    expect(input.receiveTextChange("the")).toEqual({ data: "", shouldClear: false });
+
+    for (const text of ["th", "t", ""]) {
+      expect(input.receiveKeyPress("Backspace")).toEqual({ data: "", shouldClear: false });
+      expect(input.receiveTextChange(text)).toEqual({ data: "", shouldClear: false });
+    }
+
+    expect(input.receiveTextChange("nihao")).toEqual({ data: "nihao", shouldClear: false });
+    // The terminal still contains `teh`, so this must not rub it out.
+    expect(input.receiveTextChange("你好")).toEqual({ data: "", shouldClear: false });
+  });
+
   it("resumes composition once the line is cleared", () => {
     const input = createTerminalTextInputState();
 

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -335,6 +335,15 @@ describe("native terminal typed input", () => {
     expect(input.receiveTextChange("他们")).toEqual({ data: "", shouldClear: false });
   });
 
+  it("does not backspace terminal content after a swallowed replacement", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("teh")).toEqual({ data: "teh", shouldClear: false });
+    expect(input.receiveTextChange("the")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveKeyPress("Backspace")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("th")).toEqual({ data: "", shouldClear: false });
+  });
+
   it("resumes composition once the line is cleared", () => {
     const input = createTerminalTextInputState();
 

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -283,4 +283,26 @@ describe("native terminal typed input", () => {
     expect(input.receiveKeyPress("Backspace")).toEqual({ data: "\x7f", shouldClear: false });
     expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
   });
+
+  it("stops rubbing out once a swallowed replacement leaves the terminal ahead", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
+    // Swallowed: the terminal still holds 한글 while the buffer moved to 우리.
+    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+    // A rubout here would delete 글 off the terminal and leave 한루 behind.
+    expect(input.receiveTextChange("우루")).toEqual({ data: "", shouldClear: false });
+  });
+
+  it("resumes composition once the line is cleared", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
+    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+
+    input.reset();
+
+    expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
+    expect(input.receiveTextChange("한")).toEqual({ data: "\x7f한", shouldClear: false });
+  });
 });

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.test.ts
@@ -249,6 +249,48 @@ describe("native terminal typed input", () => {
     expect(input.receiveTextChange("아니")).toEqual({ data: "\x7f아니", shouldClear: false });
   });
 
+  it("commits a Chinese pinyin reading as Han characters", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("n")).toEqual({ data: "n", shouldClear: false });
+    expect(input.receiveTextChange("ni")).toEqual({ data: "i", shouldClear: false });
+    expect(input.receiveTextChange("nih")).toEqual({ data: "h", shouldClear: false });
+    expect(input.receiveTextChange("niha")).toEqual({ data: "a", shouldClear: false });
+    expect(input.receiveTextChange("nihao")).toEqual({ data: "o", shouldClear: false });
+    expect(input.receiveTextChange("你好")).toEqual({
+      data: "\x7f\x7f\x7f\x7f\x7f你好",
+      shouldClear: false,
+    });
+  });
+
+  it("updates a multi-character Chinese candidate", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("nihao")).toEqual({ data: "nihao", shouldClear: false });
+    expect(input.receiveTextChange("你好")).toEqual({
+      data: "\x7f\x7f\x7f\x7f\x7f你好",
+      shouldClear: false,
+    });
+    expect(input.receiveTextChange("拟好")).toEqual({
+      data: "\x7f\x7f拟好",
+      shouldClear: false,
+    });
+  });
+
+  it("commits and converts a Japanese reading", () => {
+    const input = createTerminalTextInputState();
+
+    expect(input.receiveTextChange("nihongo")).toEqual({ data: "nihongo", shouldClear: false });
+    expect(input.receiveTextChange("にほんご")).toEqual({
+      data: "\x7f\x7f\x7f\x7f\x7f\x7f\x7fにほんご",
+      shouldClear: false,
+    });
+    expect(input.receiveTextChange("日本語")).toEqual({
+      data: "\x7f\x7f\x7f\x7f日本語",
+      shouldClear: false,
+    });
+  });
+
   it("does not dispatch Hangul through the keypress path", () => {
     const input = createTerminalTextInputState();
 
@@ -260,12 +302,11 @@ describe("native terminal typed input", () => {
     expect(input.receiveTextChange("하")).toEqual({ data: "\x7f하", shouldClear: false });
   });
 
-  it("still swallows replacement edits wider than one composing syllable", () => {
+  it("still swallows non-CJK replacement edits", () => {
     const input = createTerminalTextInputState();
 
-    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
-    // Two syllables at once is a suggestion replacement, not composition.
-    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("teh")).toEqual({ data: "teh", shouldClear: false });
+    expect(input.receiveTextChange("the")).toEqual({ data: "", shouldClear: false });
   });
 
   it("does not treat a non-Hangul trailing edit as composition", () => {
@@ -287,22 +328,25 @@ describe("native terminal typed input", () => {
   it("stops rubbing out once a swallowed replacement leaves the terminal ahead", () => {
     const input = createTerminalTextInputState();
 
-    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
-    // Swallowed: the terminal still holds 한글 while the buffer moved to 우리.
-    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
-    // A rubout here would delete 글 off the terminal and leave 한루 behind.
-    expect(input.receiveTextChange("우루")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("teh")).toEqual({ data: "teh", shouldClear: false });
+    // Swallowed: the terminal still holds teh while the buffer moved to the.
+    expect(input.receiveTextChange("the")).toEqual({ data: "", shouldClear: false });
+    // A composition rewrite here would delete text from an already-desynced terminal.
+    expect(input.receiveTextChange("他们")).toEqual({ data: "", shouldClear: false });
   });
 
   it("resumes composition once the line is cleared", () => {
     const input = createTerminalTextInputState();
 
-    expect(input.receiveTextChange("한글")).toEqual({ data: "한글", shouldClear: false });
-    expect(input.receiveTextChange("우리")).toEqual({ data: "", shouldClear: false });
+    expect(input.receiveTextChange("teh")).toEqual({ data: "teh", shouldClear: false });
+    expect(input.receiveTextChange("the")).toEqual({ data: "", shouldClear: false });
 
     input.reset();
 
-    expect(input.receiveTextChange("하")).toEqual({ data: "하", shouldClear: false });
-    expect(input.receiveTextChange("한")).toEqual({ data: "\x7f한", shouldClear: false });
+    expect(input.receiveTextChange("nihao")).toEqual({ data: "nihao", shouldClear: false });
+    expect(input.receiveTextChange("你好")).toEqual({
+      data: "\x7f\x7f\x7f\x7f\x7f你好",
+      shouldClear: false,
+    });
   });
 });

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -115,7 +115,7 @@ export function createTerminalTextInputState(): TerminalTextInputState {
         return { data: "", key: terminalKey, shouldClear: false };
       }
       if (key === "Backspace") {
-        previousText = previousText.slice(0, -1);
+        previousText = Array.from(previousText).slice(0, -1).join("");
         if (replacementDesynced) {
           return { data: "", shouldClear: false };
         }

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -40,10 +40,11 @@ interface TerminalInputProps {
   style?: StyleProp<TextStyle>;
 }
 
-// Hangul jamo, compatibility jamo, and precomposed syllables. A Korean IME
-// commits every syllable except the one it is still composing, so a composition
-// edit only ever rewrites the final character of the buffer.
-const HANGUL_PATTERN = /^[\u1100-\u11ff\u3130-\u318f\ua960-\ua97f\uac00-\ud7a3\ud7b0-\ud7ff]/;
+// Scripts produced by CJK IMEs when they commit or update a candidate. The
+// native input does not expose marked-text ranges, so the committed script is
+// the only reliable distinction between composition and ordinary autocorrect.
+const CJK_COMPOSITION_PATTERN =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Bopomofo}]/u;
 
 // Only ASCII travels the keypress path. An IME script reports the jamo it is
 // composing, which the text-change diff below immediately contradicts, so
@@ -52,7 +53,7 @@ function isPrintableKey(key: string): boolean {
   return key.length === 1 && key >= " " && key <= "~";
 }
 
-function getCommonPrefixLength(left: string, right: string): number {
+function getCommonPrefixLength(left: string[], right: string[]): number {
   const limit = Math.min(left.length, right.length);
   let index = 0;
   while (index < limit && left[index] === right[index]) {
@@ -64,26 +65,28 @@ function getCommonPrefixLength(left: string, right: string): number {
 /**
  * What the terminal receives for an edit that is not a plain append.
  *
- * A Korean IME rewrites the syllable it is composing in place — `ㅎ` becomes
- * `하` becomes `한`. None of those are appends, so forwarding appends alone
- * drops every keystroke after the first jamo and Korean cannot be typed at all.
- * Rub out the rewritten character and send the replacement.
+ * CJK IMEs rewrite their composing suffix in place. Korean updates one
+ * syllable at a time (`ㅎ` -> `하` -> `한`), while Chinese and Japanese replace
+ * a multi-character reading (`nihao` -> `你好`, `にほんご` -> `日本語`). None of
+ * those are appends, so rub out the rewritten suffix and send the replacement.
  *
- * Only a single trailing character qualifies. A wider rewrite is an autocorrect
- * or suggestion replacement, which stays swallowed: the hidden input can edit
- * text the terminal has already committed, and the terminal cannot take it back.
+ * The inserted suffix must contain a CJK script. Ordinary autocorrect and
+ * suggestion replacements stay swallowed: the hidden input can edit text the
+ * terminal has already committed, and the terminal cannot take it back.
  */
 function resolveCompositionEdit(previousText: string, text: string): string {
-  const commonPrefixLength = getCommonPrefixLength(previousText, text);
-  const removed = previousText.slice(commonPrefixLength);
-  const inserted = text.slice(commonPrefixLength);
-  if (removed.length !== 1 || inserted.length === 0) {
+  const previousCharacters = Array.from(previousText);
+  const nextCharacters = Array.from(text);
+  const commonPrefixLength = getCommonPrefixLength(previousCharacters, nextCharacters);
+  const removed = previousCharacters.slice(commonPrefixLength);
+  const inserted = nextCharacters.slice(commonPrefixLength).join("");
+  if (removed.length === 0 || inserted.length === 0) {
     return "";
   }
-  if (!HANGUL_PATTERN.test(removed) || !HANGUL_PATTERN.test(inserted)) {
+  if (!CJK_COMPOSITION_PATTERN.test(inserted)) {
     return "";
   }
-  return `\x7f${inserted}`;
+  return `${"\x7f".repeat(removed.length)}${inserted}`;
 }
 
 export function resolveTerminalInputFocusRequest(input: {

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -99,6 +99,11 @@ export function resolveTerminalInputFocusRequest(input: {
 export function createTerminalTextInputState(): TerminalTextInputState {
   let previousText = "";
   let submittedText: string | null = null;
+  // A swallowed replacement leaves the terminal holding text the buffer no
+  // longer describes. A composition rubout deletes from the terminal, so it
+  // would delete whatever is actually sitting there rather than the character
+  // the buffer thinks it is replacing. Stay off until the line is cleared.
+  let replacementDesynced = false;
 
   return {
     receiveKeyPress(key: string): TerminalTextInputChange {
@@ -126,22 +131,30 @@ export function createTerminalTextInputState(): TerminalTextInputState {
         submittedText = null;
         if (text === lateSubmitText) {
           previousText = "";
+          replacementDesynced = false;
           return { data: "", shouldClear: false };
         }
       }
 
       if (text.length === 0) {
         previousText = "";
+        replacementDesynced = false;
         return { data: "", shouldClear: false };
       }
 
       if (text.includes("\n") || text.includes("\r")) {
         previousText = "";
+        replacementDesynced = false;
         return { data: "", shouldClear: true };
       }
 
       if (!text.startsWith(previousText)) {
-        const compositionEdit = resolveCompositionEdit(previousText, text);
+        const compositionEdit = replacementDesynced
+          ? ""
+          : resolveCompositionEdit(previousText, text);
+        if (compositionEdit === "") {
+          replacementDesynced = true;
+        }
         previousText = text;
         return { data: compositionEdit, shouldClear: false };
       }
@@ -155,6 +168,7 @@ export function createTerminalTextInputState(): TerminalTextInputState {
     },
     reset(): void {
       previousText = "";
+      replacementDesynced = false;
     },
   };
 }

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -116,6 +116,9 @@ export function createTerminalTextInputState(): TerminalTextInputState {
       }
       if (key === "Backspace") {
         previousText = previousText.slice(0, -1);
+        if (replacementDesynced) {
+          return { data: "", shouldClear: false };
+        }
         return { data: "\x7f", shouldClear: false };
       }
       if (key === "Enter" || key === "Return" || key === "return") {
@@ -152,9 +155,10 @@ export function createTerminalTextInputState(): TerminalTextInputState {
       }
 
       if (!text.startsWith(previousText)) {
-        const compositionEdit = replacementDesynced
-          ? ""
-          : resolveCompositionEdit(previousText, text);
+        let compositionEdit = "";
+        if (!replacementDesynced) {
+          compositionEdit = resolveCompositionEdit(previousText, text);
+        }
         if (compositionEdit === "") {
           replacementDesynced = true;
         }

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -40,8 +40,50 @@ interface TerminalInputProps {
   style?: StyleProp<TextStyle>;
 }
 
+// Hangul jamo, compatibility jamo, and precomposed syllables. A Korean IME
+// commits every syllable except the one it is still composing, so a composition
+// edit only ever rewrites the final character of the buffer.
+const HANGUL_PATTERN = /^[\u1100-\u11ff\u3130-\u318f\ua960-\ua97f\uac00-\ud7a3\ud7b0-\ud7ff]/;
+
+// Only ASCII travels the keypress path. An IME script reports the jamo it is
+// composing, which the text-change diff below immediately contradicts, so
+// forwarding both would put two conflicting characters on the wire.
 function isPrintableKey(key: string): boolean {
-  return key.length === 1 && key >= " " && key !== "\x7f";
+  return key.length === 1 && key >= " " && key <= "~";
+}
+
+function getCommonPrefixLength(left: string, right: string): number {
+  const limit = Math.min(left.length, right.length);
+  let index = 0;
+  while (index < limit && left[index] === right[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+/**
+ * What the terminal receives for an edit that is not a plain append.
+ *
+ * A Korean IME rewrites the syllable it is composing in place — `ㅎ` becomes
+ * `하` becomes `한`. None of those are appends, so forwarding appends alone
+ * drops every keystroke after the first jamo and Korean cannot be typed at all.
+ * Rub out the rewritten character and send the replacement.
+ *
+ * Only a single trailing character qualifies. A wider rewrite is an autocorrect
+ * or suggestion replacement, which stays swallowed: the hidden input can edit
+ * text the terminal has already committed, and the terminal cannot take it back.
+ */
+function resolveCompositionEdit(previousText: string, text: string): string {
+  const commonPrefixLength = getCommonPrefixLength(previousText, text);
+  const removed = previousText.slice(commonPrefixLength);
+  const inserted = text.slice(commonPrefixLength);
+  if (removed.length !== 1 || inserted.length === 0) {
+    return "";
+  }
+  if (!HANGUL_PATTERN.test(removed) || !HANGUL_PATTERN.test(inserted)) {
+    return "";
+  }
+  return `\x7f${inserted}`;
 }
 
 export function resolveTerminalInputFocusRequest(input: {
@@ -99,8 +141,9 @@ export function createTerminalTextInputState(): TerminalTextInputState {
       }
 
       if (!text.startsWith(previousText)) {
+        const compositionEdit = resolveCompositionEdit(previousText, text);
         previousText = text;
-        return { data: "", shouldClear: false };
+        return { data: compositionEdit, shouldClear: false };
       }
 
       const appendedText = text.slice(previousText.length);
@@ -240,6 +283,9 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
     );
 
     return (
+      // No keyboardType prop: `ascii-capable` drops the globe key on iOS, which
+      // is how you reach the Korean layout. Terminal safety comes from
+      // autoCorrect/spellCheck/autoCapitalize being off, not from the layout.
       <TextInput
         ref={inputRef}
         accessibilityLabel="Terminal input"
@@ -251,7 +297,6 @@ export const TerminalInput = forwardRef<TerminalInputHandle, TerminalInputProps>
         defaultValue=""
         blurOnSubmit={false}
         importantForAutofill="no"
-        keyboardType="ascii-capable"
         multiline={true}
         onChangeText={handleChangeText}
         onBlur={handleBlur}

--- a/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
+++ b/packages/app/src/terminal/native-renderer/terminal-input.native.tsx
@@ -105,7 +105,7 @@ export function createTerminalTextInputState(): TerminalTextInputState {
   // A swallowed replacement leaves the terminal holding text the buffer no
   // longer describes. A composition rubout deletes from the terminal, so it
   // would delete whatever is actually sitting there rather than the character
-  // the buffer thinks it is replacing. Stay off until the line is cleared.
+  // the buffer thinks it is replacing. Stay off until the input state resets.
   let replacementDesynced = false;
 
   return {
@@ -144,7 +144,6 @@ export function createTerminalTextInputState(): TerminalTextInputState {
 
       if (text.length === 0) {
         previousText = "";
-        replacementDesynced = false;
         return { data: "", shouldClear: false };
       }
 


### PR DESCRIPTION
### Linked issues

Closes #3390
Closes #3384
Extends #3387

### What changed

Mobile terminal input now treats a trailing replacement as IME composition when the inserted suffix contains Han, Hiragana, Katakana, Hangul, or Bopomofo. It emits one DEL per replaced Unicode code point followed by the committed candidate, covering flows such as `nihao -> 你好` and `nihongo -> にほんご -> 日本語`. Ordinary non-CJK autocorrect replacements remain swallowed so native suggestions cannot rewrite text already committed to the PTY.

This branch includes the two commits from #3387 and generalizes that PR's single-syllable Hangul state machine. If #3387 lands first, I can rebase this PR down to the CJK-only delta.

### Verification

- `npx vitest run packages/app/src/terminal/native-renderer/terminal-input.native.test.ts` — 29 passed
- Changed-file `oxlint` — passed with zero warnings/errors
- Changed-file `oxfmt --check` — passed
- `git diff --check` — passed
- Full repository typecheck remains blocked on current `main` by the unrelated `dragGestureHostPresented` error in `draggable-list.native.tsx`; full app lint likewise reports existing unrelated test `react/display-name` errors.

Added regressions for Chinese pinyin commit, Chinese candidate replacement, Japanese reading conversion, ordinary English autocorrect, desync protection, and reset recovery.