### PR TITLE
fix(app): align the macOS window controls with the sidebar toggle

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -44,9 +44,9 @@ import { WorkspaceShortcutTargetsSubscriber } from "@/components/workspace-short
 import { FloatingPanelPortalHost } from "@/components/ui/floating-panel-portal";
 import { HostChooserModal, useHostChooser } from "@/hosts/host-chooser";
 import {
+  DESKTOP_TRAFFIC_LIGHT_CENTER_Y,
+  DESKTOP_TRAFFIC_LIGHT_OFFSET_Y,
   getIsElectronRuntime,
-  getIsElectronRuntimeMac,
-  HEADER_INNER_HEIGHT,
   useIsCompactFormFactor,
 } from "@/constants/layout";
 import {
@@ -116,6 +116,7 @@ import type { HostProfile } from "@/types/host-connection";
 import { toggleDesktopSidebarsWithCheckoutIntent } from "@/utils/desktop-sidebar-toggle";
 import {
   useHasWindowChromeObstruction,
+  useNativeChromeScale,
   WindowChromeProvider,
   WindowChromeRegion,
   WindowChromeSafeArea,
@@ -572,14 +573,7 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
       {workspaceChrome}
       {!isCompactLayout && appChromeLayout.sidebarToggleOwner === "window" ? (
         <WindowChromeRegion corners="top-left">
-          <WindowChromeSafeArea
-            placement="inline"
-            horizontalPadding={WINDOW_SIDEBAR_TOGGLE_HORIZONTAL_PADDING}
-            pointerEvents="box-none"
-            style={layoutStyles.windowSidebarToggle}
-          >
-            <WindowSidebarMenuToggle />
-          </WindowChromeSafeArea>
+          <WindowSidebarToggleOverlay />
         </WindowChromeRegion>
       ) : null}
       <FloatingPanelPortalHost />
@@ -609,6 +603,35 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
   );
 
   return <CommandCenterProvider>{content}</CommandCenterProvider>;
+}
+
+/**
+ * The sidebar toggle that sits beside the macOS window buttons, drawn at the buttons' own
+ * scale. Page zoom multiplies every length here and cannot touch native window furniture,
+ * so without undoing it the toggle would drift off the traffic lights' line and outgrow
+ * them. Scaling the whole row keeps its padding, height and icon in one system: the numbers
+ * below are the points the shell pins the buttons in.
+ */
+function WindowSidebarToggleOverlay() {
+  const nativeScale = useNativeChromeScale();
+  const style = useMemo(
+    () =>
+      nativeScale === 1
+        ? layoutStyles.windowSidebarToggle
+        : [layoutStyles.windowSidebarToggle, { transform: [{ scale: nativeScale }] }],
+    [nativeScale],
+  );
+
+  return (
+    <WindowChromeSafeArea
+      placement="inline"
+      horizontalPadding={WINDOW_SIDEBAR_TOGGLE_HORIZONTAL_PADDING}
+      pointerEvents="box-none"
+      style={style}
+    >
+      <WindowSidebarMenuToggle />
+    </WindowChromeSafeArea>
+  );
 }
 
 function SidebarChrome({
@@ -702,23 +725,17 @@ function DesktopWindowControlsSync({ enabled }: { enabled: boolean }) {
   const { theme } = useUnistyles();
   const surface0 = theme.colors.surface0;
   const foreground = theme.colors.foreground;
-  const pathname = usePathname();
-  const isFocusModeEnabled = usePanelStore((state) => state.desktop.focusModeEnabled);
-  const liftTrafficLights =
-    getIsElectronRuntimeMac() &&
-    isFocusModeEnabled &&
-    parseHostWorkspaceRouteFromPathname(pathname) !== null;
 
   useEffect(() => {
     if (!enabled || isNative) return;
     void updateDesktopWindowControls({
       backgroundColor: surface0,
       foregroundColor: foreground,
-      trafficLightOffsetY: liftTrafficLights ? -5 : 0.5,
+      trafficLightOffsetY: DESKTOP_TRAFFIC_LIGHT_OFFSET_Y,
     }).catch((error) => {
       console.warn("[DesktopWindow] Failed to update window controls overlay", error);
     });
-  }, [enabled, surface0, foreground, liftTrafficLights]);
+  }, [enabled, surface0, foreground]);
 
   return null;
 }
@@ -1037,14 +1054,17 @@ const layoutStyles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.surface0,
   },
   windowSidebarToggle: {
+    // The toggle sits next to the traffic lights, so it centers on their line rather than on
+    // the header row. A row twice the center line tall puts its own center on that line
+    // whatever the button slot measures at the current breakpoint. WindowSidebarToggleOverlay
+    // scales the row from this corner, so the corner is where the measurements start.
     position: "absolute",
-    top: 1,
+    top: 0,
     left: 0,
+    transformOrigin: "top left",
     zIndex: 20,
-    height: HEADER_INNER_HEIGHT,
+    height: DESKTOP_TRAFFIC_LIGHT_CENTER_Y * 2,
     flexDirection: "row",
     alignItems: "center",
-    borderBottomWidth: theme.borderWidth[1],
-    borderBottomColor: "transparent",
   },
 }));

--- a/packages/app/src/constants/layout.test.ts
+++ b/packages/app/src/constants/layout.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_TRAFFIC_LIGHT_BASE_TOP,
+  DESKTOP_TRAFFIC_LIGHT_BUTTON_HEIGHT,
+  DESKTOP_TRAFFIC_LIGHT_CENTER_Y,
+  DESKTOP_TRAFFIC_LIGHT_OFFSET_Y,
+  HEADER_INNER_HEIGHT,
+  WORKSPACE_SECONDARY_HEADER_HEIGHT,
+} from "./layout";
+
+// The desktop shell drops an offset it considers out of range instead of applying it, which
+// leaves the buttons at their pinned position with no error. Mirrors MAX_TRAFFIC_LIGHT_OFFSET_Y
+// in packages/desktop/src/window/window-manager.ts.
+const MAX_TRAFFIC_LIGHT_OFFSET_Y = 10;
+
+// Every row that can own the window's top-left corner: the header row, and the shorter tab
+// strip that replaces it in focus mode.
+const TOP_LEFT_ROW_HEIGHTS = [HEADER_INNER_HEIGHT, WORKSPACE_SECONDARY_HEADER_HEIGHT];
+
+describe("traffic light placement", () => {
+  it("puts the buttons on the center line the app aligns to", () => {
+    const centerY =
+      DESKTOP_TRAFFIC_LIGHT_BASE_TOP +
+      DESKTOP_TRAFFIC_LIGHT_OFFSET_Y +
+      DESKTOP_TRAFFIC_LIGHT_BUTTON_HEIGHT / 2;
+    expect(centerY).toBe(DESKTOP_TRAFFIC_LIGHT_CENTER_Y);
+  });
+
+  it("keeps the buttons inside every row that can own the top-left corner", () => {
+    for (const rowHeight of TOP_LEFT_ROW_HEIGHTS) {
+      expect(
+        DESKTOP_TRAFFIC_LIGHT_CENTER_Y - DESKTOP_TRAFFIC_LIGHT_BUTTON_HEIGHT / 2,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        DESKTOP_TRAFFIC_LIGHT_CENTER_Y + DESKTOP_TRAFFIC_LIGHT_BUTTON_HEIGHT / 2,
+      ).toBeLessThanOrEqual(rowHeight);
+    }
+  });
+
+  it("stays within the offset range the desktop shell accepts", () => {
+    expect(Math.abs(DESKTOP_TRAFFIC_LIGHT_OFFSET_Y)).toBeLessThanOrEqual(
+      MAX_TRAFFIC_LIGHT_OFFSET_Y,
+    );
+  });
+
+  it("needs no correction at startup, so the buttons do not move as the app loads", () => {
+    expect(DESKTOP_TRAFFIC_LIGHT_OFFSET_Y).toBe(0);
+  });
+});

--- a/packages/app/src/constants/layout.ts
+++ b/packages/app/src/constants/layout.ts
@@ -27,6 +27,30 @@ export const SETTINGS_DESKTOP_SPLIT_MIN_WIDTH =
 export const DESKTOP_TRAFFIC_LIGHT_WIDTH = 78;
 export const DESKTOP_TRAFFIC_LIGHT_HEIGHT = 45;
 
+// Where the macOS traffic lights sit, and the line anything beside them aligns to.
+//
+// CENTER_Y is one line for every mode. The buttons are window furniture: they hold the position
+// a macOS user aims at whatever the app draws behind them. Two rows can own the top-left corner
+// and they disagree, because the header row centers its content at 24 and the shorter tab strip
+// that focus mode puts in its place centers its own at 18. One line has to serve both, so it
+// sits between them, a little high for the header row and a little low for the tab strip.
+//
+// BASE_TOP mirrors MAC_TRAFFIC_LIGHT_POSITION in packages/desktop/src/window/window-manager.ts,
+// where the shell pins the buttons before the renderer is up. Keeping the two equal makes
+// OFFSET_Y come out at 0, so the buttons are already in place at startup and the renderer's
+// update moves nothing. Change one without the other and they visibly jump as the app loads.
+//
+// BUTTON_HEIGHT is the vertical measure, and the buttons are wider than they are tall. Electron
+// exposes no API for it, so it is measured from a build. The macOS 26 SDK makes them bigger:
+// raise it when Electron rebuilds against that SDK, or they drift off the line.
+export const DESKTOP_TRAFFIC_LIGHT_BASE_TOP = 13;
+export const DESKTOP_TRAFFIC_LIGHT_BUTTON_HEIGHT = 14;
+export const DESKTOP_TRAFFIC_LIGHT_CENTER_Y = 20;
+export const DESKTOP_TRAFFIC_LIGHT_OFFSET_Y =
+  DESKTOP_TRAFFIC_LIGHT_CENTER_Y -
+  DESKTOP_TRAFFIC_LIGHT_BUTTON_HEIGHT / 2 -
+  DESKTOP_TRAFFIC_LIGHT_BASE_TOP;
+
 // Windows/Linux window controls (minimize/maximize/close) — top-right
 export const DESKTOP_WINDOW_CONTROLS_WIDTH = 140;
 export const DESKTOP_WINDOW_CONTROLS_HEIGHT = 48;

--- a/packages/app/src/desktop/electron/window.ts
+++ b/packages/app/src/desktop/electron/window.ts
@@ -32,6 +32,28 @@ export async function isDesktopFullscreen(): Promise<boolean> {
   return await win.isFullscreen();
 }
 
+/** The window's page zoom factor, or null when the host cannot report one. */
+export async function readDesktopZoomFactor(): Promise<number | null> {
+  const win = getDesktopWindow();
+  if (!win || typeof win.getZoomFactor !== "function") {
+    return null;
+  }
+  const zoomFactor = await win.getZoomFactor();
+  return typeof zoomFactor === "number" && Number.isFinite(zoomFactor) && zoomFactor > 0
+    ? zoomFactor
+    : null;
+}
+
+export async function subscribeToDesktopZoomChanged(
+  handler: () => void,
+): Promise<(() => void) | null> {
+  const win = getDesktopWindow();
+  if (!win || typeof win.onZoomChanged !== "function") {
+    return null;
+  }
+  return await win.onZoomChanged(handler);
+}
+
 export async function updateDesktopWindowControls(
   update: DesktopWindowControlsOverlayUpdate,
 ): Promise<void> {

--- a/packages/app/src/desktop/host.ts
+++ b/packages/app/src/desktop/host.ts
@@ -105,6 +105,10 @@ export interface DesktopWindowBridge {
   setFullscreen?: (fullscreen: boolean) => Promise<void>;
   isFullscreen?: () => Promise<boolean>;
   updateWindowControls?: (update: DesktopWindowControlsOverlayUpdate) => Promise<void>;
+  getZoomFactor?: () => Promise<number>;
+  onZoomChanged?: <TEvent = unknown>(
+    handler: (event: TEvent) => void,
+  ) => Promise<() => void> | (() => void);
   onResized?: <TEvent = unknown>(
     handler: (event: TEvent) => void,
   ) => Promise<() => void> | (() => void);

--- a/packages/app/src/utils/desktop-window.test.ts
+++ b/packages/app/src/utils/desktop-window.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   intersectWindowChromeCorners,
   resolveHasOwnedWindowChromeObstruction,
+  resolveNativeChromeScale,
   resolveWindowChromeObstruction,
   resolveWindowChromeSafeArea,
 } from "@/utils/desktop-window";
@@ -39,6 +40,19 @@ describe("window chrome", () => {
     expect(
       resolveWindowChromeSafeArea({ obstruction, corners: "top-right", placement: "inline" }),
     ).toEqual({ paddingLeft: 0, paddingRight: 48 });
+  });
+
+  it("undoes page zoom so chrome draws at the native controls' scale", () => {
+    expect(resolveNativeChromeScale(1)).toBe(1);
+    expect(resolveNativeChromeScale(2)).toBe(0.5);
+    expect(resolveNativeChromeScale(0.5)).toBe(2);
+  });
+
+  it("draws chrome unscaled when the host reports no usable zoom factor", () => {
+    expect(resolveNativeChromeScale(0)).toBe(1);
+    expect(resolveNativeChromeScale(-1)).toBe(1);
+    expect(resolveNativeChromeScale(Number.NaN)).toBe(1);
+    expect(resolveNativeChromeScale(Number.POSITIVE_INFINITY)).toBe(1);
   });
 
   it("intersects identical and empty corner claims", () => {

--- a/packages/app/src/utils/desktop-window.tsx
+++ b/packages/app/src/utils/desktop-window.tsx
@@ -8,7 +8,11 @@ import {
   getIsElectronRuntime,
   getIsElectronRuntimeMac,
 } from "@/constants/layout";
-import { getDesktopWindow } from "@/desktop/electron/window";
+import {
+  getDesktopWindow,
+  readDesktopZoomFactor,
+  subscribeToDesktopZoomChanged,
+} from "@/desktop/electron/window";
 import { isNative } from "@/constants/platform";
 
 export type WindowChromeCorners = "none" | "top-left" | "top-right" | "both";
@@ -31,6 +35,7 @@ type WindowChromeSafeAreaStyle = { height: number } | { paddingLeft: number; pad
 const EMPTY_OBSTRUCTION: WindowChromeObstruction = { topLeft: null, topRight: null };
 const WindowChromeContext = createContext<WindowChromeObstruction>(EMPTY_OBSTRUCTION);
 const WindowChromeCornersContext = createContext<WindowChromeCorners>("none");
+const WindowChromeZoomContext = createContext(1);
 
 function windowChromeCornersFromFlags(topLeft: boolean, topRight: boolean): WindowChromeCorners {
   if (topLeft && topRight) return "both";
@@ -107,6 +112,72 @@ export function resolveWindowChromeSafeArea(input: {
     return { height: Math.max(topLeft?.height ?? 0, topRight?.height ?? 0) };
   }
   return { paddingLeft: topLeft?.width ?? 0, paddingRight: topRight?.width ?? 0 };
+}
+
+/**
+ * What to scale a surface by so it renders at the size the native window controls are drawn
+ * at. Page zoom multiplies every length the renderer declares and leaves the native buttons
+ * alone, so anything that has to stay on their line has to divide the zoom back out.
+ */
+export function resolveNativeChromeScale(zoomFactor: number): number {
+  if (!Number.isFinite(zoomFactor) || zoomFactor <= 0) {
+    return 1;
+  }
+  return 1 / zoomFactor;
+}
+
+/**
+ * The window's page zoom factor, 1 outside Electron. The value is read back over the bridge
+ * on every change rather than carried in the event, so it is always the applied one. Takes
+ * the provider's readiness rather than probing for the bridge itself, because the desktop
+ * bridge can land after the first render.
+ */
+function useDesktopZoomFactor(enabled: boolean): number {
+  const [zoomFactor, setZoomFactor] = useState(1);
+
+  useEffect(() => {
+    if (!enabled || isNative) return;
+    let active = true;
+    let dispose: (() => void) | undefined;
+
+    function sync() {
+      void (async () => {
+        try {
+          const next = await readDesktopZoomFactor();
+          if (active && next !== null) setZoomFactor(next);
+        } catch (error) {
+          if (active) console.warn("[DesktopWindow] Failed to read the zoom factor", error);
+        }
+      })();
+    }
+
+    void (async () => {
+      try {
+        const nextDispose = await subscribeToDesktopZoomChanged(sync);
+        if (!nextDispose) return;
+        if (!active) {
+          nextDispose();
+          return;
+        }
+        dispose = nextDispose;
+      } catch (error) {
+        if (active) console.warn("[DesktopWindow] Failed to subscribe to zoom changes", error);
+      }
+    })();
+    sync();
+
+    return () => {
+      active = false;
+      dispose?.();
+    };
+  }, [enabled]);
+
+  return zoomFactor;
+}
+
+/** @see resolveNativeChromeScale */
+export function useNativeChromeScale(): number {
+  return resolveNativeChromeScale(useContext(WindowChromeZoomContext));
 }
 
 export function WindowChromeProvider({ children }: { children: ReactNode }) {
@@ -190,11 +261,14 @@ export function WindowChromeProvider({ children }: { children: ReactNode }) {
       }),
     [isElectronReady, isFullscreen],
   );
+  const zoomFactor = useDesktopZoomFactor(isElectronReady);
   return (
     <WindowChromeContext.Provider value={obstruction}>
-      <WindowChromeCornersContext.Provider value="both">
-        {children}
-      </WindowChromeCornersContext.Provider>
+      <WindowChromeZoomContext.Provider value={zoomFactor}>
+        <WindowChromeCornersContext.Provider value="both">
+          {children}
+        </WindowChromeCornersContext.Provider>
+      </WindowChromeZoomContext.Provider>
     </WindowChromeContext.Provider>
   );
 }

--- a/packages/desktop/src/features/menu.ts
+++ b/packages/desktop/src/features/menu.ts
@@ -1,5 +1,6 @@
 import { app, Menu, BrowserWindow, ipcMain } from "electron";
 import { getActivePaseoBrowserWebContentsForHostWindow } from "./browser-webviews/index.js";
+import { setWindowZoomLevel } from "../window/window-manager.js";
 
 interface ShowContextMenuInput {
   kind?: "terminal";
@@ -122,7 +123,7 @@ function buildApplicationMenuTemplate(
           accelerator: "CmdOrCtrl+=",
           enabled: zoomEnabled,
           click: withBrowserWindow((win) => {
-            win.webContents.setZoomLevel(win.webContents.getZoomLevel() + 0.5);
+            setWindowZoomLevel(win, win.webContents.getZoomLevel() + 0.5);
           }),
         },
         {
@@ -130,7 +131,7 @@ function buildApplicationMenuTemplate(
           accelerator: "CmdOrCtrl+-",
           enabled: zoomEnabled,
           click: withBrowserWindow((win) => {
-            win.webContents.setZoomLevel(win.webContents.getZoomLevel() - 0.5);
+            setWindowZoomLevel(win, win.webContents.getZoomLevel() - 0.5);
           }),
         },
         {
@@ -138,7 +139,7 @@ function buildApplicationMenuTemplate(
           accelerator: "CmdOrCtrl+0",
           enabled: zoomEnabled,
           click: withBrowserWindow((win) => {
-            win.webContents.setZoomLevel(0);
+            setWindowZoomLevel(win, 0);
           }),
         },
         { type: "separator" },

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -34,6 +34,7 @@ import {
   resolveSystemWindowTheme,
   resolveWindowBounds,
   setupWindowResizeEvents,
+  setupWindowZoomEvents,
   setupWindowStatePersistence,
   setupDefaultContextMenu,
   setupDragDropPrevention,
@@ -751,6 +752,7 @@ async function createWindow(
 
   setupDarwinCompositorWatchdog(mainWindow);
   setupWindowResizeEvents(mainWindow);
+  setupWindowZoomEvents(mainWindow);
   if (windowStateStore) {
     setupWindowStatePersistence(mainWindow, windowStateStore);
   }

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -55,6 +55,16 @@ contextBridge.exposeInMainWorld("paseoDesktop", {
         foregroundColor?: string;
         trafficLightOffsetY?: number;
       }) => ipcRenderer.invoke("paseo:window:updateWindowControls", update),
+      getZoomFactor: () => ipcRenderer.invoke("paseo:window:getZoomFactor"),
+      onZoomChanged: (handler: EventHandler): (() => void) => {
+        const listener = (_ipcEvent: Electron.IpcRendererEvent, payload: unknown) => {
+          handler(payload);
+        };
+        ipcRenderer.on("paseo:window:zoom-changed", listener);
+        return () => {
+          ipcRenderer.removeListener("paseo:window:zoom-changed", listener);
+        };
+      },
       onResized: (handler: EventHandler): (() => void) => {
         const listener = (_ipcEvent: Electron.IpcRendererEvent, payload: unknown) => {
           handler(payload);

--- a/packages/desktop/src/window/window-manager.test.ts
+++ b/packages/desktop/src/window/window-manager.test.ts
@@ -8,11 +8,13 @@ import {
   DEFAULT_WINDOW_WIDTH,
   getMainWindowChromeOptions,
   getTitleBarOverlayOptions,
+  notifyWindowZoomChanged,
   readBadgeCount,
   readWindowControlsOverlayUpdate,
   readWindowTheme,
   resolveRuntimeTitleBarOverlayOptions,
   resolveWindowBounds,
+  setWindowZoomLevel,
 } from "./window-manager";
 
 describe("window-manager", () => {
@@ -162,8 +164,40 @@ describe("window-manager", () => {
         update: { trafficLightOffsetY: 0.5 },
       });
 
-      expect(setWindowButtonPosition).toHaveBeenNthCalledWith(1, { x: 16, y: 9 });
-      expect(setWindowButtonPosition).toHaveBeenNthCalledWith(2, { x: 16, y: 14.5 });
+      expect(setWindowButtonPosition).toHaveBeenNthCalledWith(1, { x: 16, y: 8 });
+      expect(setWindowButtonPosition).toHaveBeenNthCalledWith(2, { x: 16, y: 13.5 });
+    });
+  });
+
+  describe("setWindowZoomLevel", () => {
+    function createZoomWindow(destroyed = false) {
+      const setZoomLevel = vi.fn();
+      const send = vi.fn();
+      return {
+        setZoomLevel,
+        send,
+        win: {
+          isDestroyed: () => destroyed,
+          webContents: { isDestroyed: () => destroyed, send, setZoomLevel },
+        },
+      };
+    }
+
+    it("announces the change so the renderer can re-read the applied factor", () => {
+      const { win, setZoomLevel, send } = createZoomWindow();
+
+      setWindowZoomLevel(win, 1.5);
+
+      expect(setZoomLevel).toHaveBeenCalledWith(1.5);
+      expect(send).toHaveBeenCalledWith("paseo:window:zoom-changed", {});
+    });
+
+    it("sends nothing to a window that is tearing down", () => {
+      const { win, send } = createZoomWindow(true);
+
+      notifyWindowZoomChanged(win);
+
+      expect(send).not.toHaveBeenCalled();
     });
   });
 
@@ -213,7 +247,7 @@ describe("window-manager", () => {
       ).toEqual({
         titleBarStyle: "hidden",
         titleBarOverlay: true,
-        trafficLightPosition: { x: 16, y: 14 },
+        trafficLightPosition: { x: 16, y: 13 },
       });
     });
   });

--- a/packages/desktop/src/window/window-manager.ts
+++ b/packages/desktop/src/window/window-manager.ts
@@ -13,7 +13,11 @@ import {
 import type { WindowState, WindowStateStore } from "../settings/window-state.js";
 
 const WINDOW_STATE_SAVE_DEBOUNCE_MS = 400;
-const MAC_TRAFFIC_LIGHT_POSITION = { x: 16, y: 14 } as const;
+// Where the buttons are pinned when the window is created, before the renderer is up. Mirrors
+// DESKTOP_TRAFFIC_LIGHT_BASE_TOP in packages/app/src/constants/layout.ts, which the renderer
+// measures its offset from. Keep the two equal: when they agree the renderer sends an offset
+// of 0 and the buttons never move, and when they disagree you see them jump on startup.
+const MAC_TRAFFIC_LIGHT_POSITION = { x: 16, y: 13 } as const;
 const MAX_TRAFFIC_LIGHT_OFFSET_Y = 10;
 
 export function readBadgeCount(input: unknown): number {
@@ -231,6 +235,11 @@ export function registerWindowManager(): void {
     BrowserWindow.fromWebContents(event.sender)?.setFullScreen(fullscreen);
   });
 
+  ipcMain.handle("paseo:window:getZoomFactor", (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    return win?.webContents.getZoomFactor() ?? 1;
+  });
+
   ipcMain.handle("paseo:window:setBadgeCount", (_event, count?: unknown) => {
     if (process.platform === "darwin" || process.platform === "linux") {
       const badgeCount = readBadgeCount(count);
@@ -275,6 +284,47 @@ export function registerWindowManager(): void {
     });
     overlayStateByWindow.set(win, nextState);
   });
+}
+
+/**
+ * Tell the renderer the zoom factor changed. The renderer reads the new value back over
+ * IPC rather than taking it from a payload here, because Chromium emits `zoom-changed`
+ * around the change and the level it reports mid-event is not dependable. A round trip
+ * lands after the change either way, and the next zoom step corrects a stale read.
+ */
+interface ZoomNotifiableWindow {
+  isDestroyed(): boolean;
+  webContents: {
+    isDestroyed(): boolean;
+    send(channel: string, payload: unknown): void;
+  };
+}
+
+export function notifyWindowZoomChanged(win: ZoomNotifiableWindow): void {
+  if (win.isDestroyed() || win.webContents.isDestroyed()) {
+    return;
+  }
+  win.webContents.send("paseo:window:zoom-changed", {});
+}
+
+/**
+ * Page zoom moves everything the renderer draws and leaves the native window buttons
+ * where they are, so the renderer needs the zoom factor to keep the chrome beside them
+ * at their scale. Chromium only emits `zoom-changed` for wheel zoom, so every other
+ * caller has to announce its own change — route menu zoom through setWindowZoomLevel.
+ */
+export function setupWindowZoomEvents(win: BrowserWindow): void {
+  win.webContents.on("zoom-changed", () => {
+    notifyWindowZoomChanged(win);
+  });
+}
+
+export function setWindowZoomLevel(
+  win: ZoomNotifiableWindow & { webContents: { setZoomLevel(level: number): void } },
+  level: number,
+): void {
+  win.webContents.setZoomLevel(level);
+  notifyWindowZoomChanged(win);
 }
 
 export function setupWindowResizeEvents(win: BrowserWindow): void {


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Reasoning

On macOS the sidebar toggle sat below the traffic lights instead of next to them, because it centered in the 48px header row while the buttons were pinned a few pixels above that row's center. Two more hand-tuned numbers placed the same buttons: focus mode sent a second offset, so they jumped whenever you entered or left focus mode, and the desktop shell pinned them somewhere else again while it created the window, so they moved a third time a few seconds into startup when the renderer sent its correction. None of the three numbers was tied to the row it had to sit in, or to each other.

Page zoom broke the alignment a fourth way. Zoom multiplies every length the app draws with and cannot move native window buttons, so the toggle drifted further from the buttons at each zoom step. The toggle belongs to the buttons, so it now draws at their scale instead of the content's.

### Goals

- The sidebar toggle sits on the same line as the traffic lights, with the sidebar open and with it closed.
- The traffic lights hold one position. Entering or leaving focus mode does not move them, and neither does app startup.
- One exported center line places the buttons and everything that aligns to them, so no future mode can put them somewhere else.
- Zoom does not move the toggle. It scales by the inverse of the zoom factor from the window's top left corner, which holds its padding, its height and its icon in the points the shell pins the buttons in.

### Non-goals

- The focus mode tab strip keeps its 36px height. Growing it to the header's 48px would let the buttons center exactly in both rows, but focus mode exists to give content the space, so the center line sits between the two rows instead. It is 4px high for the header row and 2px low for the tab strip.
- The top-right window controls on Windows and Linux are untouched. The overlay there has its own height and needs no offset, and whether Chromium scales those controls with page zoom is not something this change assumes either way.
- The button height is a constant measured from a build, not read from the system. Electron exposes no API for it.
- The reserved corner the header pads itself by stays in app pixels, so the gap between the toggle and the header title still grows with zoom. Only the toggle is pinned to the buttons.

### QA

**Tests:**

- `packages/app/src/constants/layout.test.ts` (new) - the placement of the traffic lights: that the offset puts the buttons on the center line the app aligns to, that they stay inside both rows that can own the top-left corner, that the offset stays inside the range the desktop shell accepts, and that it is 0 so nothing moves at startup. The shell drops an out-of-range offset silently, so a row height that pushed past it would otherwise leave the buttons at their pinned position with no error.
- `packages/desktop/src/window/window-manager.test.ts` (extended) - the pin the shell applies when it creates the window, the position it computes from a renderer offset, and that a zoom change reaches the renderer while a window that is tearing down is sent nothing.
- `packages/app/src/utils/desktop-window.test.ts` (extended) - the scale that undoes page zoom, and that a host which reports no usable zoom factor leaves the chrome unscaled.

The app and the shell hold the same base position in two packages, and `packages/desktop` cannot import from `packages/app`. The 0 offset test is what stops them drifting apart: change the center line, the button height, or the shell's pin on its own and it fails, rather than someone finding the startup jump by eye later.

**Before**

Icon alignment:

<img width="354" height="89" alt="image" src="https://github.com/user-attachments/assets/e89f1b15-5f96-4524-bd85-26ca454d1e3c" />

Traffic lights jumping when entering or leaving focus mode:

https://github.com/user-attachments/assets/47d367ab-1527-46f1-ba1f-0bd5829c9052

Toggle leaving the buttons' line as the zoom level changes:

<img width="279" height="67" alt="image" src="https://github.com/user-attachments/assets/82af3ec9-c3c6-4c73-b0f4-2db62dd8d5c8" />

<img width="241" height="69" alt="image" src="https://github.com/user-attachments/assets/0b2d6b97-703e-4d37-80da-3ea0aa1e6ebe" />



**After**

Icon alignment:

<img width="320" height="82" alt="image" src="https://github.com/user-attachments/assets/2dd5f474-8ba5-43c2-8ba9-d26405195710" />

Entering and leaving focus mode:

https://github.com/user-attachments/assets/d63dcac3-e962-4aa1-bf6f-9626ff33e742

Zooming in and out:

<img width="247" height="93" alt="image" src="https://github.com/user-attachments/assets/cf6be766-59e0-4f47-bee9-6339b7991d9c" />

<img width="467" height="129" alt="image" src="https://github.com/user-attachments/assets/2dd16ea2-2483-495d-b31b-b1e55ad7f0f6" />


Checked on macOS with the sidebar open, with the sidebar closed, in focus mode, through app startup, and across zoom steps in both directions. Before the change the toggle sat below the buttons in both sidebar states, the buttons moved vertically on every focus mode toggle, they moved again a few seconds after launch, and the toggle left the buttons' line at every zoom step. After the change the toggle is on the buttons' line in both sidebar states, the buttons hold their position through mode changes and startup, and zoom leaves the toggle where it is.

Tested on desktop (Electron, macOS). Not tested: web, iOS, Android, Windows, Linux.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
