### PR TITLE
fix(acp): isolate Hermes state per Paseo agent

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -588,6 +588,34 @@ Ref: [Gemini CLI ACP mode docs](https://github.com/google-gemini/gemini-cli/blob
 }
 ```
 
+Paseo treats the canonical `hermes` provider ID as a stateful agent provider. Before starting a
+new or resumed Paseo agent, it derives a stable profile name from that Paseo agent ID, creates the
+profile from Hermes' `default` profile when necessary, and launches ACP with that profile's
+`HERMES_HOME`. Every Paseo agent, including the first one, therefore has separate Hermes sessions,
+memory files, state database, and profile-scoped external-memory configuration. A resumed Paseo
+agent reuses its original profile; archived agents retain their profiles so they remain resumable.
+Permanently deleting an agent also deletes its dedicated Hermes profile and copied credentials.
+
+Profile creation snapshots configuration, credentials, personality, and skills but resets
+`MEMORY.md` and `USER.md`; workers do not inherit the parent profile's durable memories. Later
+memory writes remain in the assigned profile and are not loaded by other Paseo agents. Paseo uses
+Hermes' supported profile CLI and does not create per-profile command aliases. Before every launch,
+Paseo keeps built-in `MEMORY.md` and
+`USER.md` enabled but disables external memory-provider writes, removes the shared `claude-mem` MCP
+server, and disables a cloned Claude Mem bridge. Honcho and Claude Mem are not used for worker
+memory because their shared workspace is not a strict profile boundary.
+
+Provider catalog and diagnostic probes use a separate deterministic probe profile. They never open
+ACP sessions in the default Hermes profile and never share an agent's profile.
+
+When a Paseo agent created before this isolation feature is resumed for the first time, Paseo uses
+Hermes' consistent quick-snapshot mechanism to copy the legacy default profile's runtime database
+into that agent's new profile before ACP loads the native session. Before launch, Paseo securely
+removes every session except the exact native session being resumed, including unrelated messages,
+usage records, delegation state, prompts, and routing state. This one-time migration preserves
+resumability without copying the former shared-history database into every worker. Newly created
+agents never receive legacy runtime state.
+
 Ref: [Hermes ACP docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/acp)
 
 ### How ACP providers work in Paseo

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2659,6 +2659,11 @@ export class AgentManager {
     await this.deleteCommittedTimeline(agentId);
   }
 
+  async deleteProviderAgentResources(agentId: string, provider: AgentProvider): Promise<void> {
+    const client = this.requireClient(provider);
+    await client.deleteAgentResources?.(agentId);
+  }
+
   async getLastAssistantMessage(agentId: string): Promise<string | null> {
     const agent = this.agents.get(agentId);
     if (!agent) {

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -749,6 +749,8 @@ export interface AgentClient {
    * Called before Paseo clears its archived flag so provider resume can succeed.
    */
   unarchiveNativeSession?(handle: AgentPersistenceHandle): Promise<void>;
+  /** Delete provider-owned resources that are scoped to one logical Paseo agent. */
+  deleteAgentResources?(agentId: string): Promise<void>;
   /**
    * Release any provider-owned resources held by this client (background
    * processes, sockets, cached subprocesses, etc.). Called when the daemon

--- a/packages/server/src/server/agent/lifecycle-command.test.ts
+++ b/packages/server/src/server/agent/lifecycle-command.test.ts
@@ -6,6 +6,7 @@ import type { StoredAgentRecord } from "./agent-storage.js";
 import {
   archiveAgentCommand,
   cancelAgentRunCommand,
+  deleteAgentPermanentlyCommand,
   detachAgentCommand,
   setAgentModeCommand,
   updateAgentCommand,
@@ -164,6 +165,33 @@ class FakeLifecycleAgentManager implements LifecycleAgentManager {
 const logger = createTestLogger();
 
 describe("agent lifecycle commands", () => {
+  test("permanently deletes durable state when provider resource cleanup fails", async () => {
+    const calls: string[] = [];
+
+    await deleteAgentPermanentlyCommand(
+      {
+        agentManager: {
+          async deleteProviderAgentResources() {
+            calls.push("provider-cleanup");
+            throw new Error("Hermes CLI unavailable");
+          },
+          async deleteAgentState(agentId: string) {
+            calls.push(`state:${agentId}`);
+          },
+        },
+        agentStorage: {
+          async remove(agentId: string) {
+            calls.push(`storage:${agentId}`);
+          },
+        },
+        logger,
+      },
+      { agentId: "agent-1", provider: "hermes" },
+    );
+
+    expect(calls).toEqual(["provider-cleanup", "storage:agent-1", "state:agent-1"]);
+  });
+
   test("cancels only when the agent has an in-flight run", async () => {
     const storage = new FakeLifecycleAgentStorage();
     const manager = new FakeLifecycleAgentManager(storage);

--- a/packages/server/src/server/agent/lifecycle-command.ts
+++ b/packages/server/src/server/agent/lifecycle-command.ts
@@ -6,7 +6,7 @@ import {
   type ManagedAgent,
 } from "./agent-manager.js";
 import type { StoredAgentRecord } from "./agent-storage.js";
-import type { AgentProviderNotice } from "./agent-sdk-types.js";
+import type { AgentProvider, AgentProviderNotice } from "./agent-sdk-types.js";
 
 export type LifecycleAgentSnapshot = Pick<ManagedAgent, "id" | "cwd" | "lifecycle">;
 
@@ -149,6 +149,39 @@ export async function closeAgentCommand(
   agentId: string,
 ): Promise<void> {
   await dependencies.agentManager.closeAgent(agentId);
+}
+
+interface PermanentDeleteAgentManager {
+  deleteProviderAgentResources(agentId: string, provider: AgentProvider): Promise<void>;
+  deleteAgentState(agentId: string): Promise<void>;
+}
+
+interface PermanentDeleteAgentStorage {
+  remove(agentId: string): Promise<void>;
+}
+
+export async function deleteAgentPermanentlyCommand(
+  dependencies: {
+    agentManager: PermanentDeleteAgentManager;
+    agentStorage: PermanentDeleteAgentStorage;
+    logger: Logger;
+  },
+  input: { agentId: string; provider: AgentProvider | null },
+): Promise<void> {
+  const { agentId, provider } = input;
+  if (provider) {
+    try {
+      await dependencies.agentManager.deleteProviderAgentResources(agentId, provider);
+    } catch (error) {
+      dependencies.logger.warn(
+        { err: error, agentId, provider },
+        "Provider resource cleanup failed during permanent agent deletion",
+      );
+    }
+  }
+
+  await dependencies.agentStorage.remove(agentId);
+  await dependencies.agentManager.deleteAgentState(agentId);
 }
 
 export interface UpdateAgentResult {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -124,7 +124,10 @@ interface ACPConfiguredOverrideInternals {
   applyConfiguredOverrides(): Promise<void>;
 }
 
-function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
+function createSession(
+  terminateProcess?: ProcessTerminator,
+  launchEnv?: Record<string, string>,
+): ACPAgentSession {
   return new ACPAgentSession(
     {
       provider: "claude-acp",
@@ -143,6 +146,7 @@ function createSession(terminateProcess?: ProcessTerminator): ACPAgentSession {
         supportsReasoningStream: true,
         supportsToolInvocations: true,
       },
+      launchEnv,
       ...(terminateProcess ? { terminateProcess } : {}),
     },
   );
@@ -653,6 +657,32 @@ describe("ACPAgentSession terminal tools", () => {
       "git",
       ["status", "--short"],
       expect.objectContaining({ cwd: "/repo" }),
+    );
+  });
+
+  test("keeps terminal subprocesses inside the session launch environment", async () => {
+    const child = createTerminalChildStub();
+    const spawn = vi.spyOn(spawnUtils, "spawnProcess").mockReturnValue(child);
+    const session = createSession(undefined, {
+      HERMES_HOME: "/profiles/paseo-isolated",
+      HERMES_PROFILE: "paseo-isolated",
+    });
+
+    await session.createTerminal({
+      sessionId: "session-1",
+      command: "env",
+      env: [{ name: "HERMES_HOME", value: "/profiles/attacker-controlled" }],
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      "env",
+      [],
+      expect.objectContaining({
+        envOverlay: expect.objectContaining({
+          HERMES_HOME: "/profiles/paseo-isolated",
+          HERMES_PROFILE: "paseo-isolated",
+        }),
+      }),
     );
   });
 

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2394,7 +2394,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       cwd: params.cwd ?? this.config.cwd,
       ...createProviderEnvSpec({
         runtimeSettings: this.runtimeSettings,
-        overlays: commandEnvOverlays,
+        overlays: [...commandEnvOverlays, this.launchEnv],
       }),
       shell: terminalCommand.shell,
       stdio: ["ignore", "pipe", "pipe"],

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -154,6 +154,34 @@ describe("GenericACPAgentClient diagnostics", () => {
     });
   });
 
+  test("launches a real ACP subprocess inside the prepared Hermes profile home", async () => {
+    await withFakeACPAgent("success", async (scriptPath, mode, testDir) => {
+      const envTracePath = path.join(testDir, "env.json");
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", envTracePath],
+        providerId: "hermes",
+        hermesProfileManager: {
+          async prepare(agentId: string) {
+            expect(agentId).toBe("agent-isolated");
+            return { profile: "paseo-isolated", home: "/profiles/paseo-isolated" };
+          },
+        },
+      });
+
+      const session = await client.createSession(
+        { provider: "acp", cwd: testDir },
+        { agentId: "agent-isolated" },
+      );
+      await session.close();
+
+      expect(JSON.parse(await readFile(envTracePath, "utf8"))).toEqual({
+        HERMES_HOME: "/profiles/paseo-isolated",
+        HERMES_PROFILE: "paseo-isolated",
+      });
+    });
+  });
+
   test("reports a missing launcher without dropping the rest of the diagnostic", async () => {
     await withTempDir("paseo-missing-acp-agent-", async (testDir) => {
       const missingCommand = path.join(testDir, "missing-acp-agent");
@@ -230,8 +258,15 @@ const readline = require("node:readline");
 const mode = process.argv[2];
 const pidPath = process.argv[3];
 const initializeTracePath = process.argv[4];
+const envTracePath = process.argv[5];
 if (pidPath) {
   fs.writeFileSync(pidPath, String(process.pid));
+}
+if (envTracePath) {
+  fs.writeFileSync(
+    envTracePath,
+    JSON.stringify({ HERMES_HOME: process.env.HERMES_HOME, HERMES_PROFILE: process.env.HERMES_PROFILE }),
+  );
 }
 const rl = readline.createInterface({ input: process.stdin });
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.diagnostic.test.ts
@@ -182,6 +182,119 @@ describe("GenericACPAgentClient diagnostics", () => {
     });
   });
 
+  test("resumes a real ACP subprocess inside the requested Hermes profile", async () => {
+    await withFakeACPAgent("success", async (scriptPath, mode, testDir) => {
+      const envTracePath = path.join(testDir, "resume-env.json");
+      const prepared: Array<{
+        agentId: string;
+        includeRuntimeState?: boolean;
+        runtimeSessionId?: string;
+      }> = [];
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", envTracePath],
+        providerId: "hermes",
+        hermesProfileManager: {
+          async prepare(
+            agentId: string,
+            options?: { includeRuntimeState?: boolean; runtimeSessionId?: string },
+          ) {
+            prepared.push({ agentId, ...options });
+            return { profile: "paseo-resumed", home: "/profiles/paseo-resumed" };
+          },
+        },
+      });
+
+      const session = await client.resumeSession(
+        {
+          provider: "acp",
+          sessionId: "native-session-1",
+          nativeHandle: "native-session-1",
+          metadata: { cwd: testDir },
+        },
+        undefined,
+        { agentId: "agent-resumed" },
+      );
+      await session.close();
+
+      expect(prepared).toEqual([
+        {
+          agentId: "agent-resumed",
+          includeRuntimeState: true,
+          runtimeSessionId: "native-session-1",
+        },
+      ]);
+      expect(JSON.parse(await readFile(envTracePath, "utf8"))).toEqual({
+        HERMES_HOME: "/profiles/paseo-resumed",
+        HERMES_PROFILE: "paseo-resumed",
+      });
+    });
+  });
+
+  test("launches provider probes in the dedicated Hermes probe profile", async () => {
+    await withFakeACPAgent("success", async (scriptPath, mode, testDir) => {
+      const envTracePath = path.join(testDir, "probe-env.json");
+      const prepared: string[] = [];
+      const client = new GenericACPAgentClient({
+        logger: createTestLogger(),
+        command: [process.execPath, scriptPath, mode, "", "", envTracePath],
+        providerId: "hermes",
+        hermesProfileManager: {
+          async prepare(agentId: string) {
+            prepared.push(agentId);
+            return { profile: "paseo-probe", home: "/profiles/paseo-probe" };
+          },
+        },
+      });
+
+      await client.fetchCatalog({ scope: "global", force: true });
+
+      expect(prepared).toEqual(["__paseo_provider_probe__"]);
+      expect(JSON.parse(await readFile(envTracePath, "utf8"))).toEqual({
+        HERMES_HOME: "/profiles/paseo-probe",
+        HERMES_PROFILE: "paseo-probe",
+      });
+    });
+  });
+
+  test("fails closed before spawning Hermes without a logical agent ID", async () => {
+    const client = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: [process.execPath, "unused-acp-agent.cjs"],
+      providerId: "hermes",
+      hermesProfileManager: {
+        async prepare() {
+          throw new Error("must not prepare without an agent ID");
+        },
+      },
+    });
+
+    await expect(client.createSession({ provider: "acp", cwd: tmpdir() })).rejects.toThrow(
+      "requires a Paseo agent ID",
+    );
+  });
+
+  test("deletes the dedicated Hermes profile through the public provider interface", async () => {
+    const deleted: string[] = [];
+    const client = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: [process.execPath, "unused-acp-agent.cjs"],
+      providerId: "hermes",
+      hermesProfileManager: {
+        async prepare() {
+          return { profile: "paseo-isolated", home: "/profiles/paseo-isolated" };
+        },
+        async delete(agentId: string) {
+          deleted.push(agentId);
+        },
+      },
+    });
+
+    await client.deleteAgentResources("agent-1");
+
+    expect(deleted).toEqual(["agent-1"]);
+  });
+
   test("reports a missing launcher without dropping the rest of the diagnostic", async () => {
     await withTempDir("paseo-missing-acp-agent-", async (testDir) => {
       const missingCommand = path.join(testDir, "missing-acp-agent");
@@ -285,12 +398,12 @@ rl.on("line", (line) => {
     }
     send(message.id, {
       protocolVersion: message.params?.protocolVersion ?? 1,
-      agentCapabilities: {},
+      agentCapabilities: { loadSession: true },
     });
     return;
   }
 
-  if (message.method === "session/new") {
+  if (message.method === "session/new" || message.method === "session/load") {
     if (mode === "hang-session") {
       return;
     }

--- a/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
@@ -4,11 +4,6 @@ import { createTestLogger } from "../../../test-utils/test-logger.js";
 
 const mockState = vi.hoisted(() => ({
   superConstructorOptions: [] as unknown[],
-  createSessionCalls: [] as unknown[],
-  resumeSessionCalls: [] as unknown[],
-  fetchCatalogCalls: [] as unknown[],
-  listFeaturesCalls: [] as unknown[],
-  listImportableSessionsCalls: [] as unknown[],
 }));
 
 vi.mock("./acp-agent.js", () => ({
@@ -25,44 +20,10 @@ vi.mock("./acp-agent.js", () => ({
   },
   ACPAgentClient: class ACPAgentClient {
     readonly provider: string;
-    protected readonly runtimeSettings?: { env?: Record<string, string> };
 
-    constructor(options: { runtimeSettings?: { env?: Record<string, string> } }) {
+    constructor(options: unknown) {
       this.provider = "acp";
-      this.runtimeSettings = options.runtimeSettings;
       mockState.superConstructorOptions.push(options);
-    }
-
-    async createSession(config: unknown, launchContext: unknown) {
-      mockState.createSessionCalls.push({ config, launchContext });
-      return { kind: "created" };
-    }
-
-    async resumeSession(handle: unknown, overrides: unknown, launchContext: unknown) {
-      mockState.resumeSessionCalls.push({ handle, overrides, launchContext });
-      return { kind: "resumed" };
-    }
-
-    async fetchCatalog(options: unknown, context: unknown) {
-      mockState.fetchCatalogCalls.push({
-        options,
-        context,
-        env: { ...this.runtimeSettings?.env },
-      });
-      return { models: [], modes: [] };
-    }
-
-    async listFeatures(config: unknown) {
-      mockState.listFeaturesCalls.push({ config, env: { ...this.runtimeSettings?.env } });
-      return [];
-    }
-
-    async listImportableSessions(options: unknown) {
-      mockState.listImportableSessionsCalls.push({
-        options,
-        env: { ...this.runtimeSettings?.env },
-      });
-      return [];
     }
   },
 }));
@@ -118,140 +79,6 @@ describe("GenericACPAgentClient", () => {
     expect(mockState.superConstructorOptions.at(-1)).toMatchObject({
       capabilities: {
         supportsMcpServers: false,
-      },
-    });
-  });
-
-  test("scopes new and resumed Hermes sessions to the agent profile home", async () => {
-    const prepared: Array<{
-      agentId: string;
-      includeRuntimeState?: boolean;
-      runtimeSessionId?: string;
-    }> = [];
-    const client = new GenericACPAgentClient({
-      logger: createTestLogger(),
-      command: ["hermes", "acp"],
-      providerId: "hermes",
-      hermesProfileManager: {
-        async prepare(
-          agentId: string,
-          options?: { includeRuntimeState?: boolean; runtimeSessionId?: string },
-        ) {
-          prepared.push({ agentId, ...options });
-          return { profile: "paseo-isolated", home: "/profiles/paseo-isolated" };
-        },
-      },
-    });
-
-    await client.createSession(
-      { provider: "hermes", cwd: "/workspace" },
-      { agentId: "agent-1", env: { PASEO_AGENT_ID: "agent-1" } },
-    );
-    await client.resumeSession(
-      { provider: "hermes", sessionId: "session-1", nativeHandle: "session-1" },
-      undefined,
-      { agentId: "agent-1", env: { PASEO_AGENT_ID: "agent-1" } },
-    );
-
-    expect(prepared).toEqual([
-      { agentId: "agent-1", includeRuntimeState: false },
-      { agentId: "agent-1", includeRuntimeState: true, runtimeSessionId: "session-1" },
-    ]);
-    expect(mockState.createSessionCalls.at(-1)).toMatchObject({
-      launchContext: {
-        agentId: "agent-1",
-        env: {
-          PASEO_AGENT_ID: "agent-1",
-          HERMES_HOME: "/profiles/paseo-isolated",
-          HERMES_PROFILE: "paseo-isolated",
-        },
-      },
-    });
-    expect(mockState.resumeSessionCalls.at(-1)).toMatchObject({
-      launchContext: {
-        agentId: "agent-1",
-        env: {
-          PASEO_AGENT_ID: "agent-1",
-          HERMES_HOME: "/profiles/paseo-isolated",
-          HERMES_PROFILE: "paseo-isolated",
-        },
-      },
-    });
-  });
-
-  test("deletes the dedicated Hermes profile with the logical agent", async () => {
-    const deleted: string[] = [];
-    const client = new GenericACPAgentClient({
-      logger: createTestLogger(),
-      command: ["hermes", "acp"],
-      providerId: "hermes",
-      hermesProfileManager: {
-        async prepare() {
-          return { profile: "paseo-isolated", home: "/profiles/paseo-isolated" };
-        },
-        async delete(agentId: string) {
-          deleted.push(agentId);
-        },
-      },
-    });
-
-    await client.deleteAgentResources("agent-1");
-
-    expect(deleted).toEqual(["agent-1"]);
-  });
-
-  test("fails closed when a Hermes session has no Paseo agent ID", async () => {
-    const client = new GenericACPAgentClient({
-      logger: createTestLogger(),
-      command: ["hermes", "acp"],
-      providerId: "hermes",
-      hermesProfileManager: {
-        async prepare() {
-          throw new Error("must not prepare without an agent ID");
-        },
-      },
-    });
-
-    await expect(client.createSession({ provider: "hermes", cwd: "/workspace" })).rejects.toThrow(
-      "requires a Paseo agent ID",
-    );
-  });
-
-  test("keeps provider catalog probes out of the default Hermes profile", async () => {
-    const prepared: string[] = [];
-    const client = new GenericACPAgentClient({
-      logger: createTestLogger(),
-      command: ["hermes", "acp"],
-      providerId: "hermes",
-      hermesProfileManager: {
-        async prepare(agentId: string) {
-          prepared.push(agentId);
-          return { profile: "paseo-probe", home: "/profiles/paseo-probe" };
-        },
-      },
-    });
-
-    await client.fetchCatalog({ scope: "global", force: true });
-    await client.listFeatures({ provider: "hermes", cwd: "/workspace" });
-    await client.listImportableSessions({ cwd: "/workspace" });
-
-    expect(prepared).toEqual(["__paseo_provider_probe__"]);
-    expect(mockState.fetchCatalogCalls.at(-1)).toMatchObject({
-      env: {
-        HERMES_HOME: "/profiles/paseo-probe",
-        HERMES_PROFILE: "paseo-probe",
-      },
-    });
-    expect(mockState.listFeaturesCalls.at(-1)).toMatchObject({
-      env: {
-        HERMES_HOME: "/profiles/paseo-probe",
-        HERMES_PROFILE: "paseo-probe",
-      },
-    });
-    expect(mockState.listImportableSessionsCalls.at(-1)).toMatchObject({
-      env: {
-        HERMES_HOME: "/profiles/paseo-probe",
-        HERMES_PROFILE: "paseo-probe",
       },
     });
   });

--- a/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.test.ts
@@ -4,6 +4,11 @@ import { createTestLogger } from "../../../test-utils/test-logger.js";
 
 const mockState = vi.hoisted(() => ({
   superConstructorOptions: [] as unknown[],
+  createSessionCalls: [] as unknown[],
+  resumeSessionCalls: [] as unknown[],
+  fetchCatalogCalls: [] as unknown[],
+  listFeaturesCalls: [] as unknown[],
+  listImportableSessionsCalls: [] as unknown[],
 }));
 
 vi.mock("./acp-agent.js", () => ({
@@ -20,10 +25,44 @@ vi.mock("./acp-agent.js", () => ({
   },
   ACPAgentClient: class ACPAgentClient {
     readonly provider: string;
+    protected readonly runtimeSettings?: { env?: Record<string, string> };
 
-    constructor(options: unknown) {
+    constructor(options: { runtimeSettings?: { env?: Record<string, string> } }) {
       this.provider = "acp";
+      this.runtimeSettings = options.runtimeSettings;
       mockState.superConstructorOptions.push(options);
+    }
+
+    async createSession(config: unknown, launchContext: unknown) {
+      mockState.createSessionCalls.push({ config, launchContext });
+      return { kind: "created" };
+    }
+
+    async resumeSession(handle: unknown, overrides: unknown, launchContext: unknown) {
+      mockState.resumeSessionCalls.push({ handle, overrides, launchContext });
+      return { kind: "resumed" };
+    }
+
+    async fetchCatalog(options: unknown, context: unknown) {
+      mockState.fetchCatalogCalls.push({
+        options,
+        context,
+        env: { ...this.runtimeSettings?.env },
+      });
+      return { models: [], modes: [] };
+    }
+
+    async listFeatures(config: unknown) {
+      mockState.listFeaturesCalls.push({ config, env: { ...this.runtimeSettings?.env } });
+      return [];
+    }
+
+    async listImportableSessions(options: unknown) {
+      mockState.listImportableSessionsCalls.push({
+        options,
+        env: { ...this.runtimeSettings?.env },
+      });
+      return [];
     }
   },
 }));
@@ -79,6 +118,140 @@ describe("GenericACPAgentClient", () => {
     expect(mockState.superConstructorOptions.at(-1)).toMatchObject({
       capabilities: {
         supportsMcpServers: false,
+      },
+    });
+  });
+
+  test("scopes new and resumed Hermes sessions to the agent profile home", async () => {
+    const prepared: Array<{
+      agentId: string;
+      includeRuntimeState?: boolean;
+      runtimeSessionId?: string;
+    }> = [];
+    const client = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["hermes", "acp"],
+      providerId: "hermes",
+      hermesProfileManager: {
+        async prepare(
+          agentId: string,
+          options?: { includeRuntimeState?: boolean; runtimeSessionId?: string },
+        ) {
+          prepared.push({ agentId, ...options });
+          return { profile: "paseo-isolated", home: "/profiles/paseo-isolated" };
+        },
+      },
+    });
+
+    await client.createSession(
+      { provider: "hermes", cwd: "/workspace" },
+      { agentId: "agent-1", env: { PASEO_AGENT_ID: "agent-1" } },
+    );
+    await client.resumeSession(
+      { provider: "hermes", sessionId: "session-1", nativeHandle: "session-1" },
+      undefined,
+      { agentId: "agent-1", env: { PASEO_AGENT_ID: "agent-1" } },
+    );
+
+    expect(prepared).toEqual([
+      { agentId: "agent-1", includeRuntimeState: false },
+      { agentId: "agent-1", includeRuntimeState: true, runtimeSessionId: "session-1" },
+    ]);
+    expect(mockState.createSessionCalls.at(-1)).toMatchObject({
+      launchContext: {
+        agentId: "agent-1",
+        env: {
+          PASEO_AGENT_ID: "agent-1",
+          HERMES_HOME: "/profiles/paseo-isolated",
+          HERMES_PROFILE: "paseo-isolated",
+        },
+      },
+    });
+    expect(mockState.resumeSessionCalls.at(-1)).toMatchObject({
+      launchContext: {
+        agentId: "agent-1",
+        env: {
+          PASEO_AGENT_ID: "agent-1",
+          HERMES_HOME: "/profiles/paseo-isolated",
+          HERMES_PROFILE: "paseo-isolated",
+        },
+      },
+    });
+  });
+
+  test("deletes the dedicated Hermes profile with the logical agent", async () => {
+    const deleted: string[] = [];
+    const client = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["hermes", "acp"],
+      providerId: "hermes",
+      hermesProfileManager: {
+        async prepare() {
+          return { profile: "paseo-isolated", home: "/profiles/paseo-isolated" };
+        },
+        async delete(agentId: string) {
+          deleted.push(agentId);
+        },
+      },
+    });
+
+    await client.deleteAgentResources("agent-1");
+
+    expect(deleted).toEqual(["agent-1"]);
+  });
+
+  test("fails closed when a Hermes session has no Paseo agent ID", async () => {
+    const client = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["hermes", "acp"],
+      providerId: "hermes",
+      hermesProfileManager: {
+        async prepare() {
+          throw new Error("must not prepare without an agent ID");
+        },
+      },
+    });
+
+    await expect(client.createSession({ provider: "hermes", cwd: "/workspace" })).rejects.toThrow(
+      "requires a Paseo agent ID",
+    );
+  });
+
+  test("keeps provider catalog probes out of the default Hermes profile", async () => {
+    const prepared: string[] = [];
+    const client = new GenericACPAgentClient({
+      logger: createTestLogger(),
+      command: ["hermes", "acp"],
+      providerId: "hermes",
+      hermesProfileManager: {
+        async prepare(agentId: string) {
+          prepared.push(agentId);
+          return { profile: "paseo-probe", home: "/profiles/paseo-probe" };
+        },
+      },
+    });
+
+    await client.fetchCatalog({ scope: "global", force: true });
+    await client.listFeatures({ provider: "hermes", cwd: "/workspace" });
+    await client.listImportableSessions({ cwd: "/workspace" });
+
+    expect(prepared).toEqual(["__paseo_provider_probe__"]);
+    expect(mockState.fetchCatalogCalls.at(-1)).toMatchObject({
+      env: {
+        HERMES_HOME: "/profiles/paseo-probe",
+        HERMES_PROFILE: "paseo-probe",
+      },
+    });
+    expect(mockState.listFeaturesCalls.at(-1)).toMatchObject({
+      env: {
+        HERMES_HOME: "/profiles/paseo-probe",
+        HERMES_PROFILE: "paseo-probe",
+      },
+    });
+    expect(mockState.listImportableSessionsCalls.at(-1)).toMatchObject({
+      env: {
+        HERMES_HOME: "/profiles/paseo-probe",
+        HERMES_PROFILE: "paseo-probe",
       },
     });
   });

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -1,7 +1,19 @@
 import type { Logger } from "pino";
 import { z } from "zod";
 
-import type { AgentCapabilityFlags } from "../agent-sdk-types.js";
+import type {
+  AgentCapabilityFlags,
+  AgentFeature,
+  AgentLaunchContext,
+  AgentPersistenceHandle,
+  AgentSession,
+  AgentSessionConfig,
+  FetchCatalogOptions,
+  ImportableProviderSession,
+  ListImportableSessionsOptions,
+  ProviderCatalog,
+  ProviderRefreshContext,
+} from "../agent-sdk-types.js";
 import { checkProviderLaunchAvailable, resolveProviderLaunch } from "../provider-launch-config.js";
 import {
   ACPAgentClient,
@@ -17,6 +29,7 @@ import {
   type DiagnosticEntry,
   toDiagnosticErrorMessage,
 } from "./diagnostic-utils.js";
+import { HermesCliProfileCommand, HermesProfileManager } from "./hermes-profile-manager.js";
 
 export const GenericACPProviderParamsSchema = z
   .object({
@@ -51,6 +64,8 @@ interface GenericACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
+  hermesProfileManager?: Pick<HermesProfileManager, "prepare"> &
+    Partial<Pick<HermesProfileManager, "delete">>;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -58,6 +73,9 @@ export class GenericACPAgentClient extends ACPAgentClient {
   private readonly providerId?: string;
   private readonly label?: string;
   private readonly diagnosticPhaseTimeoutMs?: number;
+  private readonly hermesProfileManager?: Pick<HermesProfileManager, "prepare"> &
+    Partial<Pick<HermesProfileManager, "delete">>;
+  private probeProfileReady?: Promise<void>;
 
   constructor(options: GenericACPAgentClientOptions) {
     const providerParams = parseGenericACPProviderParams(options.providerParams);
@@ -82,6 +100,63 @@ export class GenericACPAgentClient extends ACPAgentClient {
     this.providerId = options.providerId;
     this.label = options.label;
     this.diagnosticPhaseTimeoutMs = options.diagnosticPhaseTimeoutMs;
+    this.hermesProfileManager =
+      options.hermesProfileManager ??
+      (options.providerId === "hermes"
+        ? new HermesProfileManager({
+            command: new HermesCliProfileCommand({
+              executable: options.command[0],
+              env: options.env,
+            }),
+          })
+        : undefined);
+  }
+
+  override async createSession(
+    config: AgentSessionConfig,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    return super.createSession(config, await this.scopeHermesLaunchContext(launchContext));
+  }
+
+  override async resumeSession(
+    handle: AgentPersistenceHandle,
+    overrides?: Partial<AgentSessionConfig>,
+    launchContext?: AgentLaunchContext,
+  ): Promise<AgentSession> {
+    return super.resumeSession(
+      handle,
+      overrides,
+      await this.scopeHermesLaunchContext(launchContext, handle.sessionId),
+    );
+  }
+
+  async deleteAgentResources(agentId: string): Promise<void> {
+    if (!this.hermesProfileManager) return;
+    if (!this.hermesProfileManager.delete) {
+      throw new Error("Hermes profile isolation cannot delete provider-owned resources");
+    }
+    await this.hermesProfileManager.delete(agentId);
+  }
+
+  override async fetchCatalog(
+    options: FetchCatalogOptions,
+    context?: ProviderRefreshContext,
+  ): Promise<ProviderCatalog> {
+    await this.ensureHermesProbeProfile();
+    return super.fetchCatalog(options, context);
+  }
+
+  override async listFeatures(config: AgentSessionConfig): Promise<AgentFeature[]> {
+    await this.ensureHermesProbeProfile();
+    return super.listFeatures(config);
+  }
+
+  override async listImportableSessions(
+    options?: ListImportableSessionsOptions,
+  ): Promise<ImportableProviderSession[]> {
+    await this.ensureHermesProbeProfile();
+    return super.listImportableSessions(options);
   }
 
   protected override async resolveLaunchCommand(): Promise<{ command: string; args: string[] }> {
@@ -98,6 +173,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
   }
 
   async getDiagnostic(): Promise<{ diagnostic: string }> {
+    await this.ensureHermesProbeProfile();
     const providerName = formatProviderName(this.label, this.providerId);
     const entries: DiagnosticEntry[] = [
       { label: "Provider ID", value: this.providerId ?? "unknown" },
@@ -143,6 +219,48 @@ export class GenericACPAgentClient extends ACPAgentClient {
       commandConfig: { mode: "replace", argv: this.command },
       defaultBinary: this.command[0],
     });
+  }
+
+  private async scopeHermesLaunchContext(
+    launchContext?: AgentLaunchContext,
+    runtimeSessionId?: string,
+  ): Promise<AgentLaunchContext | undefined> {
+    if (!this.hermesProfileManager) return launchContext;
+    const agentId = launchContext?.agentId?.trim();
+    if (!agentId) {
+      throw new Error("Hermes profile isolation requires a Paseo agent ID");
+    }
+
+    const assignment = await this.hermesProfileManager.prepare(agentId, {
+      includeRuntimeState: runtimeSessionId !== undefined,
+      ...(runtimeSessionId === undefined ? {} : { runtimeSessionId }),
+    });
+    return {
+      ...launchContext,
+      env: {
+        ...launchContext?.env,
+        HERMES_HOME: assignment.home,
+        HERMES_PROFILE: assignment.profile,
+      },
+    };
+  }
+
+  private async ensureHermesProbeProfile(): Promise<void> {
+    if (!this.hermesProfileManager) return;
+    this.probeProfileReady ??= this.hermesProfileManager
+      .prepare("__paseo_provider_probe__")
+      .then((assignment) => {
+        if (!this.runtimeSettings) {
+          throw new Error("Hermes profile isolation requires provider runtime settings");
+        }
+        this.runtimeSettings.env = {
+          ...this.runtimeSettings.env,
+          HERMES_HOME: assignment.home,
+          HERMES_PROFILE: assignment.profile,
+        };
+        return undefined;
+      });
+    await this.probeProfileReady;
   }
 
   private async getACPProbeRowsForDiagnostic() {

--- a/packages/server/src/server/agent/providers/hermes-profile-manager.test.ts
+++ b/packages/server/src/server/agent/providers/hermes-profile-manager.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  HermesProfileManager,
+  profileNameForAgent,
+  type HermesProfileCommand,
+} from "./hermes-profile-manager.js";
+
+class FakeHermesProfileCommand implements HermesProfileCommand {
+  readonly profiles = new Map<string, string>();
+  readonly creates: Array<{
+    profile: string;
+    sourceProfile: string;
+  }> = [];
+  readonly runtimeState: Array<{
+    profile: string;
+    sourceProfile: string;
+    includeRuntimeState: boolean;
+    runtimeSessionId?: string;
+  }> = [];
+  readonly hardens: string[] = [];
+  failNextCreate = false;
+
+  async profileHome(profile: string): Promise<string | null> {
+    return this.profiles.get(profile) ?? null;
+  }
+
+  async createProfile(profile: string, sourceProfile: string): Promise<string> {
+    const existing = this.profiles.get(profile);
+    if (existing) return existing;
+    this.creates.push({ profile, sourceProfile });
+    if (this.failNextCreate) {
+      this.failNextCreate = false;
+      throw new Error("clone failed");
+    }
+    const home = `/profiles/${profile}`;
+    this.profiles.set(profile, home);
+    return home;
+  }
+
+  async deleteProfile(profile: string): Promise<void> {
+    this.profiles.delete(profile);
+  }
+
+  async hardenProfile(profile: string): Promise<void> {
+    this.hardens.push(profile);
+  }
+
+  async ensureRuntimeState(
+    profile: string,
+    sourceProfile: string,
+    _home: string,
+    includeRuntimeState: boolean,
+    runtimeSessionId?: string,
+  ): Promise<void> {
+    this.runtimeState.push({ profile, sourceProfile, includeRuntimeState, runtimeSessionId });
+  }
+}
+
+describe("HermesProfileManager", () => {
+  test("assigns every concurrent Paseo agent its own Hermes profile", async () => {
+    const command = new FakeHermesProfileCommand();
+    const manager = new HermesProfileManager({ command, sourceProfile: "default" });
+
+    const assignments = await Promise.all(
+      Array.from({ length: 10 }, (_, index) => manager.prepare(`agent-${index + 1}`)),
+    );
+
+    expect(new Set(assignments.map(({ profile }) => profile)).size).toBe(10);
+    expect(new Set(assignments.map(({ home }) => home)).size).toBe(10);
+    expect(assignments.every(({ profile }) => profile.startsWith("paseo-"))).toBe(true);
+    expect(command.creates).toHaveLength(10);
+    expect(command.hardens).toHaveLength(10);
+    expect(command.creates.every(({ sourceProfile }) => sourceProfile === "default")).toBe(true);
+    expect(command.runtimeState.every(({ includeRuntimeState }) => !includeRuntimeState)).toBe(
+      true,
+    );
+  });
+
+  test("coalesces concurrent preparation for the same agent", async () => {
+    const command = new FakeHermesProfileCommand();
+    const manager = new HermesProfileManager({ command });
+
+    const assignments = await Promise.all(
+      Array.from({ length: 10 }, () => manager.prepare("same-agent")),
+    );
+
+    expect(new Set(assignments.map(({ profile }) => profile)).size).toBe(1);
+    expect(command.creates).toHaveLength(1);
+  });
+
+  test("reuses the deterministic profile after a daemon restart", async () => {
+    const command = new FakeHermesProfileCommand();
+    const firstManager = new HermesProfileManager({ command });
+    const first = await firstManager.prepare("resumable-agent");
+
+    const restartedManager = new HermesProfileManager({ command });
+    const resumed = await restartedManager.prepare("resumable-agent");
+
+    expect(resumed).toEqual(first);
+    expect(command.creates).toHaveLength(1);
+    expect(command.hardens).toEqual([first.profile, first.profile]);
+  });
+
+  test("retries a failed clone without changing the assigned profile", async () => {
+    const command = new FakeHermesProfileCommand();
+    command.failNextCreate = true;
+    const manager = new HermesProfileManager({ command });
+
+    await expect(manager.prepare("retry-agent")).rejects.toThrow("clone failed");
+    const assignment = await manager.prepare("retry-agent");
+
+    expect(command.creates).toHaveLength(2);
+    expect(command.creates[0]?.profile).toBe(command.creates[1]?.profile);
+    expect(assignment.profile).toBe(command.creates[0]?.profile);
+  });
+
+  test("rehardens an existing profile before every launch", async () => {
+    const command = new FakeHermesProfileCommand();
+    const profile = profileNameForAgent("existing-agent");
+    command.profiles.set(profile, `/profiles/${profile}`);
+    const manager = new HermesProfileManager({ command });
+
+    await manager.prepare("existing-agent");
+    await manager.prepare("existing-agent");
+
+    expect(command.creates).toEqual([]);
+    expect(command.hardens).toEqual([profile, profile]);
+  });
+
+  test("copies legacy runtime state only when first preparing a resumed agent", async () => {
+    const command = new FakeHermesProfileCommand();
+    const manager = new HermesProfileManager({ command });
+
+    const assignment = await manager.prepare("legacy-agent", {
+      includeRuntimeState: true,
+      runtimeSessionId: "legacy-native-session",
+    });
+
+    expect(command.runtimeState).toEqual([
+      {
+        profile: assignment.profile,
+        sourceProfile: "default",
+        includeRuntimeState: true,
+        runtimeSessionId: "legacy-native-session",
+      },
+    ]);
+    expect(command.hardens).toEqual([assignment.profile]);
+  });
+});

--- a/packages/server/src/server/agent/providers/hermes-profile-manager.ts
+++ b/packages/server/src/server/agent/providers/hermes-profile-manager.ts
@@ -1,0 +1,611 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  access,
+  chmod,
+  copyFile,
+  cp,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+export interface HermesProfileCommand {
+  profileHome(profile: string): Promise<string | null>;
+  createProfile(profile: string, sourceProfile: string): Promise<string>;
+  deleteProfile(profile: string): Promise<void>;
+  ensureRuntimeState(
+    profile: string,
+    sourceProfile: string,
+    home: string,
+    includeRuntimeState: boolean,
+    runtimeSessionId?: string,
+  ): Promise<void>;
+  hardenProfile(profile: string, home: string): Promise<void>;
+}
+
+export interface HermesProfileAssignment {
+  profile: string;
+  home: string;
+}
+
+interface HermesProfileManagerOptions {
+  command: HermesProfileCommand;
+  sourceProfile?: string;
+}
+
+interface PrepareHermesProfileOptions {
+  includeRuntimeState?: boolean;
+  runtimeSessionId?: string;
+}
+
+export class HermesProfileManager {
+  private readonly command: HermesProfileCommand;
+  private readonly sourceProfile: string;
+  private readonly pending = new Map<string, Promise<HermesProfileAssignment>>();
+
+  constructor(options: HermesProfileManagerOptions) {
+    this.command = options.command;
+    this.sourceProfile = options.sourceProfile ?? "default";
+  }
+
+  prepare(
+    agentId: string,
+    options: PrepareHermesProfileOptions = {},
+  ): Promise<HermesProfileAssignment> {
+    const profile = profileNameForAgent(agentId);
+    const includeRuntimeState = options.includeRuntimeState ?? false;
+    const runtimeSessionId = options.runtimeSessionId;
+    const pendingKey = `${profile}:${includeRuntimeState ? (runtimeSessionId ?? "resume") : "fresh"}`;
+    const existing = this.pending.get(pendingKey);
+    if (existing) return existing;
+
+    const operation = this.prepareProfile(profile, includeRuntimeState, runtimeSessionId).finally(
+      () => {
+        this.pending.delete(pendingKey);
+      },
+    );
+    this.pending.set(pendingKey, operation);
+    return operation;
+  }
+
+  delete(agentId: string): Promise<void> {
+    return this.command.deleteProfile(profileNameForAgent(agentId));
+  }
+
+  private async prepareProfile(
+    profile: string,
+    includeRuntimeState: boolean,
+    runtimeSessionId?: string,
+  ): Promise<HermesProfileAssignment> {
+    const home = await this.command.createProfile(profile, this.sourceProfile);
+    await this.command.ensureRuntimeState(
+      profile,
+      this.sourceProfile,
+      home,
+      includeRuntimeState,
+      runtimeSessionId,
+    );
+    await this.command.hardenProfile(profile, home);
+    return { profile, home };
+  }
+}
+
+export function profileNameForAgent(agentId: string): string {
+  const digest = createHash("sha256").update(agentId).digest("hex").slice(0, 16);
+  return `paseo-${digest}`;
+}
+
+interface HermesCliProfileCommandOptions {
+  executable: string;
+  env?: Record<string, string>;
+}
+
+export class HermesCliProfileCommand implements HermesProfileCommand {
+  private readonly executable: string;
+  private readonly env?: Record<string, string>;
+  private readonly runtimeSnapshots = new Map<string, Promise<string>>();
+
+  constructor(options: HermesCliProfileCommandOptions) {
+    this.executable = options.executable;
+    this.env = options.env;
+  }
+
+  async profileHome(profile: string): Promise<string | null> {
+    const result = await this.run(["profile", "show", profile], true);
+    if (result.exitCode !== 0) return null;
+
+    const home = /^Path:\s+(.+)$/mu.exec(result.stdout)?.[1]?.trim();
+    if (!home) {
+      throw new Error(`Hermes profile '${profile}' exists but did not report its home path`);
+    }
+    return home;
+  }
+
+  async createProfile(profile: string, sourceProfile: string): Promise<string> {
+    return this.withProfileLock(profile, async () => {
+      const existing = await this.profileHome(profile);
+      if (existing) {
+        await this.ensureBaselineLocked(sourceProfile, existing);
+        return existing;
+      }
+      return this.createProfileLocked(profile, sourceProfile);
+    });
+  }
+
+  async deleteProfile(profile: string): Promise<void> {
+    return this.withProfileLock(profile, async () => {
+      if (!(await this.profileHome(profile))) return;
+      await this.run(["profile", "delete", "-y", profile], false);
+    });
+  }
+
+  private async createProfileLocked(profile: string, sourceProfile: string): Promise<string> {
+    const sourceHome = await this.profileHome(sourceProfile);
+    if (!sourceHome) {
+      throw new Error(`Hermes source profile '${sourceProfile}' does not exist`);
+    }
+    const result = await this.run(
+      [
+        "profile",
+        "create",
+        profile,
+        "--no-alias",
+        "--no-skills",
+        "--description",
+        "Paseo-managed isolated Hermes agent profile.",
+      ],
+      true,
+    );
+    if (result.exitCode !== 0) {
+      const racedHome = await this.profileHome(profile);
+      if (racedHome) return racedHome;
+      const detail = result.stderr.trim() || result.stdout.trim() || "no command output";
+      throw new Error(`Hermes profile command failed with exit code ${result.exitCode}: ${detail}`);
+    }
+    const reportedHome = /^Profile directory:\s+(.+)$/mu.exec(result.stdout)?.[1]?.trim();
+    const home = reportedHome ?? (await this.profileHome(profile));
+    if (!home) {
+      throw new Error(
+        `Hermes created profile '${profile}' but its home path could not be resolved`,
+      );
+    }
+    await this.ensureBaselineLocked(sourceProfile, home, sourceHome);
+    return home;
+  }
+
+  private async ensureBaselineLocked(
+    sourceProfile: string,
+    home: string,
+    knownSourceHome?: string,
+  ): Promise<void> {
+    const marker = join(home, ".paseo-baseline-ready");
+    if (await pathExists(marker)) return;
+
+    const sourceHome = knownSourceHome ?? (await this.profileHome(sourceProfile));
+    if (!sourceHome) {
+      throw new Error(`Hermes source profile '${sourceProfile}' does not exist`);
+    }
+    await this.copyBaseline(sourceHome, home);
+    if (!(await pathExists(join(home, ".paseo-runtime-state-ready")))) {
+      await resetProfileMemory(home);
+    }
+    await atomicWriteFile(marker, "ready\n", 0o600);
+  }
+
+  private async copyBaseline(sourceHome: string, targetHome: string): Promise<void> {
+    for (const file of ["config.yaml", ".env", "SOUL.md"]) {
+      const source = join(sourceHome, file);
+      if (!(await pathExists(source))) continue;
+      const target = join(targetHome, file);
+      await copyFile(source, target);
+      if (file === ".env") await chmod(target, 0o600);
+    }
+
+    const sourceSkills = join(sourceHome, "skills");
+    if (await pathExists(sourceSkills)) {
+      await cp(sourceSkills, join(targetHome, "skills"), { recursive: true, force: true });
+    }
+  }
+
+  private async withProfileLock<T>(profile: string, operation: () => Promise<T>): Promise<T> {
+    const homeScope = this.env?.HOME ?? process.env.HOME ?? "unknown-home";
+    const scope = createHash("sha256").update(homeScope).digest("hex").slice(0, 12);
+    const lock = join(tmpdir(), `paseo-hermes-profile-${scope}-${profile}.lock`);
+    const deadline = Date.now() + PROFILE_CREATION_LOCK_TIMEOUT_MS;
+
+    while (true) {
+      try {
+        await mkdir(lock, { mode: 0o700 });
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        const age = await stat(lock)
+          .then((entry) => Date.now() - entry.mtimeMs)
+          .catch(() => 0);
+        if (age > PROFILE_CREATION_LOCK_STALE_MS) {
+          await this.quarantineStaleLock(lock);
+          continue;
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting to create Hermes profile '${profile}'`, {
+            cause: error,
+          });
+        }
+        await delay(PROFILE_CREATION_LOCK_POLL_MS);
+      }
+    }
+
+    const heartbeat = setInterval(() => {
+      const now = new Date();
+      void utimes(lock, now, now).catch(() => undefined);
+    }, PROFILE_CREATION_LOCK_HEARTBEAT_MS);
+    heartbeat.unref();
+    try {
+      return await operation();
+    } finally {
+      clearInterval(heartbeat);
+      await rm(lock, { recursive: true, force: true });
+    }
+  }
+
+  private async quarantineStaleLock(lock: string): Promise<void> {
+    const quarantine = `${lock}.stale-${randomUUID()}`;
+    try {
+      await rename(lock, quarantine);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    await rm(quarantine, { recursive: true, force: true });
+  }
+
+  async ensureRuntimeState(
+    profile: string,
+    sourceProfile: string,
+    home: string,
+    includeRuntimeState: boolean,
+    runtimeSessionId?: string,
+  ): Promise<void> {
+    return this.withProfileLock(profile, () =>
+      this.ensureRuntimeStateLocked(
+        profile,
+        sourceProfile,
+        home,
+        includeRuntimeState,
+        runtimeSessionId,
+      ),
+    );
+  }
+
+  private async ensureRuntimeStateLocked(
+    profile: string,
+    sourceProfile: string,
+    home: string,
+    includeRuntimeState: boolean,
+    runtimeSessionId?: string,
+  ): Promise<void> {
+    const marker = join(home, ".paseo-runtime-state-ready");
+    try {
+      await readFile(marker, "utf8");
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+
+    await resetProfileMemory(home);
+
+    if (includeRuntimeState) {
+      if (!runtimeSessionId) {
+        throw new Error(
+          `Hermes profile '${profile}' runtime migration requires a native session ID`,
+        );
+      }
+      const snapshot = await this.runtimeSnapshot(sourceProfile, profile);
+      await copyFile(join(snapshot, "state.db"), join(home, "state.db"));
+      await retainOnlyRuntimeSession(join(home, "state.db"), runtimeSessionId);
+    }
+
+    await atomicWriteFile(marker, `${includeRuntimeState ? "migrated" : "fresh"}\n`, 0o600);
+  }
+
+  private runtimeSnapshot(sourceProfile: string, profile: string): Promise<string> {
+    const existing = this.runtimeSnapshots.get(sourceProfile);
+    if (existing) return existing;
+
+    const snapshot = this.createRuntimeSnapshot(sourceProfile, profile).catch((error) => {
+      this.runtimeSnapshots.delete(sourceProfile);
+      throw error;
+    });
+    this.runtimeSnapshots.set(sourceProfile, snapshot);
+    void snapshot.then(
+      (path) => {
+        return setTimeout(() => {
+          if (this.runtimeSnapshots.get(sourceProfile) !== snapshot) return;
+          this.runtimeSnapshots.delete(sourceProfile);
+          void rm(path, { recursive: true, force: true }).catch(() => undefined);
+        }, RUNTIME_SNAPSHOT_TTL_MS).unref();
+      },
+      () => undefined,
+    );
+    return snapshot;
+  }
+
+  private async createRuntimeSnapshot(sourceProfile: string, profile: string): Promise<string> {
+    const label = `${profile}-${randomUUID()}`;
+    const sourceHome = await this.profileHome(sourceProfile);
+    if (!sourceHome) {
+      throw new Error(`Hermes source profile '${sourceProfile}' has no home for runtime migration`);
+    }
+    const backup = await this.run(
+      ["--profile", sourceProfile, "backup", "--quick", "--label", label],
+      false,
+    );
+    const snapshotId = /^State snapshot created:\s+(.+)$/mu.exec(backup.stdout)?.[1]?.trim();
+    if (!snapshotId) {
+      throw new Error(`Hermes did not create a runtime snapshot for profile '${sourceProfile}'`);
+    }
+    return join(sourceHome, "state-snapshots", snapshotId);
+  }
+
+  async hardenProfile(profile: string, home: string): Promise<void> {
+    return this.withProfileLock(profile, () => this.hardenProfileLocked(profile, home));
+  }
+
+  private async hardenProfileLocked(profile: string, home: string): Promise<void> {
+    const configPath = join(home, "config.yaml");
+    const config = await readFile(configPath, "utf8");
+    const hardened = sanitizeProfileConfig(config);
+    await atomicWriteFile(configPath, hardened, 0o600);
+    if (
+      sanitizeProfileConfig(hardened) !== hardened ||
+      /claude[-_]mem/imu.test(hardened) ||
+      hasExternalMemoryProvider(hardened)
+    ) {
+      throw new Error(`Hermes profile '${profile}' external memory configuration was not hardened`);
+    }
+  }
+
+  private run(args: string[], allowFailure: boolean): Promise<CommandResult> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.executable, args, {
+        env: { ...process.env, ...this.env },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout = appendBounded(stdout, chunk);
+      });
+      child.stderr.on("data", (chunk: string) => {
+        stderr = appendBounded(stderr, chunk);
+      });
+      child.once("error", reject);
+      child.once("exit", (code, signal) => {
+        const exitCode = code ?? 1;
+        if (exitCode === 0 || allowFailure) {
+          resolve({ exitCode, stdout, stderr });
+          return;
+        }
+        const detail = stderr.trim() || stdout.trim() || "no command output";
+        reject(
+          new Error(
+            `Hermes profile command failed with ${signal ? `signal ${signal}` : `exit code ${exitCode}`}: ${detail}`,
+          ),
+        );
+      });
+    });
+  }
+}
+
+interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const MAX_COMMAND_OUTPUT = 16_384;
+const RUNTIME_SNAPSHOT_TTL_MS = 5 * 60 * 1000;
+const PROFILE_CREATION_LOCK_TIMEOUT_MS = 2 * 60 * 1000;
+const PROFILE_CREATION_LOCK_STALE_MS = 5 * 60 * 1000;
+const PROFILE_CREATION_LOCK_POLL_MS = 100;
+const PROFILE_CREATION_LOCK_HEARTBEAT_MS = 30 * 1000;
+
+function isClaudeMemIdentifier(value: string | undefined): boolean {
+  return ["claude-mem", "claude_mem", "claude-mem-bridge", "claude_mem_bridge"].includes(
+    value ?? "",
+  );
+}
+
+function isInlineMemoryConfig(trimmed: string, indent: number): boolean {
+  return indent === 0 && /^["']?memory["']?\s*:\s*\{/u.test(trimmed);
+}
+
+function sanitizeProfileConfig(config: string): string {
+  const output: string[] = [];
+  let topLevel = "";
+  let skippedIndent: number | null = null;
+
+  for (const line of config.split("\n")) {
+    const trimmed = line.trim();
+    const indent = line.length - line.trimStart().length;
+    if (isInlineMemoryConfig(trimmed, indent)) {
+      topLevel = "memory";
+      output.push("memory:", "  provider:");
+      skippedIndent = null;
+      continue;
+    }
+    if (skippedIndent !== null) {
+      if (!trimmed || indent > skippedIndent) continue;
+      skippedIndent = null;
+    }
+    if (indent === 0 && trimmed.endsWith(":")) {
+      topLevel = trimmed.slice(0, -1).replaceAll(/["']/gu, "");
+    }
+
+    const key = trimmed.split(":", 1)[0]?.replaceAll(/["']/gu, "");
+    if (topLevel === "memory" && indent > 0 && key === "provider") {
+      output.push("  provider:");
+      continue;
+    }
+    if (topLevel === "mcp_servers" && indent > 0 && isClaudeMemIdentifier(key)) {
+      skippedIndent = indent;
+      continue;
+    }
+    if (topLevel === "plugins" && isClaudeMemIdentifier(trimmed.slice(2))) {
+      continue;
+    }
+    if (topLevel === "plugins" && indent === 4 && isClaudeMemIdentifier(key)) {
+      skippedIndent = indent;
+      continue;
+    }
+    output.push(line);
+  }
+  return output.join("\n");
+}
+
+function hasExternalMemoryProvider(config: string): boolean {
+  let topLevel = "";
+  for (const line of config.split("\n")) {
+    const trimmed = line.trim();
+    const indent = line.length - line.trimStart().length;
+    if (indent === 0 && trimmed.endsWith(":")) {
+      topLevel = trimmed.slice(0, -1).replaceAll(/["']/gu, "");
+      continue;
+    }
+    if (topLevel !== "memory" || indent === 0) continue;
+    const separator = trimmed.indexOf(":");
+    if (separator < 0) continue;
+    const key = trimmed.slice(0, separator).replaceAll(/["']/gu, "");
+    if (key !== "provider") continue;
+    const value = trimmed
+      .slice(separator + 1)
+      .split("#", 1)[0]
+      ?.trim()
+      .replaceAll(/["']/gu, "");
+    if (value) return true;
+  }
+  return false;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resetProfileMemory(home: string): Promise<void> {
+  const memories = join(home, "memories");
+  await mkdir(memories, { recursive: true, mode: 0o700 });
+  await Promise.all(
+    ["MEMORY.md", "USER.md"].map((name) => writeFile(join(memories, name), "", { mode: 0o600 })),
+  );
+}
+
+async function atomicWriteFile(path: string, content: string, mode: number): Promise<void> {
+  const temporary = `${path}.tmp-${randomUUID()}`;
+  try {
+    await writeFile(temporary, content, { mode });
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+interface RuntimeSqliteStatement {
+  all(...params: string[]): Array<Record<string, unknown>>;
+  run(...params: string[]): unknown;
+}
+
+interface RuntimeSqliteDatabase {
+  close(): void;
+  exec(sql: string): void;
+  prepare(sql: string): RuntimeSqliteStatement;
+}
+
+async function retainOnlyRuntimeSession(databasePath: string, sessionId: string): Promise<void> {
+  const sqliteSpecifier: string = "node:sqlite";
+  const sqlite = (await import(sqliteSpecifier)) as unknown as {
+    DatabaseSync: new (path: string) => RuntimeSqliteDatabase;
+  };
+  const database = new sqlite.DatabaseSync(databasePath);
+  try {
+    const tables = new Set(
+      database
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all()
+        .map((row) => String(row.name)),
+    );
+    if (!tables.has("sessions")) {
+      throw new Error("Hermes runtime snapshot has no sessions table");
+    }
+
+    database.exec("PRAGMA secure_delete = ON; BEGIN IMMEDIATE");
+    if (tables.has("messages")) {
+      database.prepare("DELETE FROM messages WHERE session_id <> ?").run(sessionId);
+    }
+    if (tables.has("session_model_usage")) {
+      database.prepare("DELETE FROM session_model_usage WHERE session_id <> ?").run(sessionId);
+    }
+    if (tables.has("compression_locks")) {
+      database.prepare("DELETE FROM compression_locks WHERE session_id <> ?").run(sessionId);
+    }
+    if (tables.has("async_delegations")) {
+      database
+        .prepare(
+          "DELETE FROM async_delegations " +
+            "WHERE origin_session <> ? AND origin_session_id <> ? " +
+            "AND COALESCE(parent_session_id, '') <> ?",
+        )
+        .run(sessionId, sessionId, sessionId);
+    }
+    if (tables.has("gateway_routing")) {
+      database.exec("DELETE FROM gateway_routing");
+    }
+    database
+      .prepare(
+        "UPDATE sessions SET parent_session_id = NULL WHERE id = ? AND parent_session_id <> ?",
+      )
+      .run(sessionId, sessionId);
+    database.prepare("DELETE FROM sessions WHERE id <> ?").run(sessionId);
+    const retained = database.prepare("SELECT id FROM sessions").all();
+    if (retained.length !== 1 || retained[0]?.id !== sessionId) {
+      throw new Error(`Hermes runtime snapshot does not contain session '${sessionId}'`);
+    }
+    if (tables.has("system_prompts")) {
+      database.exec(
+        "DELETE FROM system_prompts WHERE hash NOT IN " +
+          "(SELECT system_prompt_hash FROM sessions WHERE system_prompt_hash IS NOT NULL)",
+      );
+    }
+    database.exec("COMMIT; VACUUM");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK");
+    } catch {
+      // The transaction may already have committed or failed before beginning.
+    }
+    throw error;
+  } finally {
+    database.close();
+  }
+}
+
+function appendBounded(current: string, chunk: string): string {
+  const combined = current + chunk;
+  return combined.length <= MAX_COMMAND_OUTPUT
+    ? combined
+    : combined.slice(combined.length - MAX_COMMAND_OUTPUT);
+}

--- a/packages/server/src/server/daemon-client.e2e.test.ts
+++ b/packages/server/src/server/daemon-client.e2e.test.ts
@@ -931,13 +931,10 @@ test("resume_agent auto-unarchives archived agents", async () => {
       throw new Error("Expected persistence handle for resume test");
     }
     const resumed = await ctx.client.resumeAgent(handle);
+    expect(resumed.id).toBe(created.id);
     const resumedDetails = await ctx.client.fetchAgent({ agentId: resumed.id });
     expect(resumedDetails).not.toBeNull();
     expect(resumedDetails?.agent.archivedAt).toBeNull();
-
-    if (resumed.id !== created.id) {
-      await ctx.client.deleteAgent(resumed.id);
-    }
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -88,6 +88,7 @@ import {
   archiveAgentCommand,
   cancelAgentRunCommand,
   closeAgentCommand,
+  deleteAgentPermanentlyCommand,
   detachAgentCommand,
   setAgentModeCommand,
   updateAgentCommand,
@@ -2548,13 +2549,15 @@ export class Session {
     // durable snapshot, otherwise an in-flight background write can recreate it.
     await this.agentManager.flush();
 
-    if (knownProvider) {
-      await this.agentManager.deleteProviderAgentResources(agentId, knownProvider);
-    }
-
     try {
-      await this.agentStorage.remove(agentId);
-      await this.agentManager.deleteAgentState(agentId);
+      await deleteAgentPermanentlyCommand(
+        {
+          agentManager: this.agentManager,
+          agentStorage: this.agentStorage,
+          logger: this.sessionLogger,
+        },
+        { agentId, provider: knownProvider },
+      );
     } catch (error) {
       this.sessionLogger.error({ err: error, agentId }, `Failed to fully delete agent ${agentId}`);
     }

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -2527,10 +2527,10 @@ export class Session {
   private async handleDeleteAgentRequest(agentId: string, requestId: string): Promise<void> {
     this.sessionLogger.info({ agentId }, `Deleting agent ${agentId} from registry`);
 
-    const knownWorkspaceId =
-      this.agentManager.getAgent(agentId)?.workspaceId ??
-      (await this.agentStorage.get(agentId))?.workspaceId ??
-      null;
+    const activeAgent = this.agentManager.getAgent(agentId);
+    const storedAgent = await this.agentStorage.get(agentId);
+    const knownWorkspaceId = activeAgent?.workspaceId ?? storedAgent?.workspaceId ?? null;
+    const knownProvider = activeAgent?.provider ?? storedAgent?.provider ?? null;
 
     // File-backed storage still needs an early delete fence before closeAgent().
     beginAgentDeleteIfSupported(this.agentStorage, agentId);
@@ -2547,6 +2547,10 @@ export class Session {
     // Drain queued persistence from the just-closed agent before removing its
     // durable snapshot, otherwise an in-flight background write can recreate it.
     await this.agentManager.flush();
+
+    if (knownProvider) {
+      await this.agentManager.deleteProviderAgentResources(agentId, knownProvider);
+    }
 
     try {
       await this.agentStorage.remove(agentId);
@@ -3499,7 +3503,11 @@ export class Session {
         : overrides;
       let snapshot: ManagedAgent;
       try {
-        snapshot = await this.agentManager.resumeAgentFromPersistence(handle, effectiveOverrides);
+        snapshot = await this.agentManager.resumeAgentFromPersistence(
+          handle,
+          effectiveOverrides,
+          matched?.record.id,
+        );
       } catch (error) {
         if (matched?.didUnarchive && matched.originalArchivedAt) {
           await this.agentManager.archiveSnapshot(matched.record.id, matched.originalArchivedAt);


### PR DESCRIPTION
## Summary
- assign each logical Paseo Hermes agent a deterministic persistent Hermes profile and isolated HERMES_HOME
- isolate native memory, state.db, sessions, subprocesses, provider probes, Honcho, and Claude Mem while preserving stable resume/archive identity
- migrate only the requested legacy native session and delete provider-owned profiles on permanent agent deletion
- supersede #3194: serialization prevented concurrent writers but did not isolate durable memory

## Safety
- fail-closed profile provisioning with per-profile cross-process locks, atomic readiness markers, YAML hardening, and dedicated probe profiles
- archive/unarchive retains identity; permanent deletion removes cloned profile resources
- no default Hermes profile writes from workers or probes

## Verification
- `npm run lint`
- `npm run typecheck`
- 219 focused ACP/profile/provider tests
- archive/unarchive resume identity regression
- packaged 10-agent acceptance: 10 isolated profiles, sessions, and conflicting memory canaries; default-home and external-memory leak checks; cleanup verified
- Claude Fable 5 high-thinking adversarial re-review: READY, no Critical or High defects

Supersedes #3194.