### PR TITLE
feat(providers): steer prompts into running turns without interrupting

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -9316,3 +9316,128 @@ test("onWorkspaceStateMayHaveChanged is not called for running shell tool calls"
 
   expect(onWorkspaceStateMayHaveChanged).not.toHaveBeenCalled();
 });
+
+test("trySteerAgent records the submitted prompt when the session steers", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-try-steer-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class SteerSession extends TestAgentSession {
+    steeredPrompts: Array<{ prompt: AgentPromptInput; options?: AgentRunOptions }> = [];
+
+    override async trySteer(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean> {
+      this.steeredPrompts.push({ prompt, options });
+      return true;
+    }
+  }
+
+  class SteerClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new SteerSession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new SteerClient() },
+    registry: storage,
+    logger,
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+
+    const steered = await manager.trySteerAgent(snapshot.id, "steer me", {
+      clientMessageId: "msg-steer-1",
+    });
+    expect(steered).toBe(true);
+
+    const session = manager.getAgent(snapshot.id)!.session as SteerSession;
+    expect(session.steeredPrompts).toEqual([
+      { prompt: "steer me", options: { clientMessageId: "msg-steer-1" } },
+    ]);
+
+    const timeline = manager.fetchTimeline(snapshot.id, { direction: "tail", limit: 5 }).rows;
+    expect(timeline[0]?.item).toMatchObject({
+      type: "user_message",
+      text: "steer me",
+      clientMessageId: "msg-steer-1",
+    });
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("trySteerAgent returns false when the provider has no native steering", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-no-steer-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const manager = new AgentManager({
+    clients: { codex: new TestAgentClient() },
+    registry: storage,
+    logger,
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+
+    const steered = await manager.trySteerAgent(snapshot.id, "steer me", {
+      clientMessageId: "msg-steer-1",
+    });
+    expect(steered).toBe(false);
+    expect(manager.fetchTimeline(snapshot.id, { direction: "tail", limit: 5 }).rows).toHaveLength(
+      0,
+    );
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("trySteerAgent returns false when the session declines to steer", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-decline-steer-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+
+  class DecliningSteerSession extends TestAgentSession {
+    override async trySteer(): Promise<boolean> {
+      return false;
+    }
+  }
+
+  class DecliningSteerClient extends TestAgentClient {
+    override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+      return new DecliningSteerSession(config);
+    }
+  }
+
+  const manager = new AgentManager({
+    clients: { codex: new DecliningSteerClient() },
+    registry: storage,
+    logger,
+  });
+
+  try {
+    const snapshot = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+
+    const steered = await manager.trySteerAgent(snapshot.id, "steer me", {
+      clientMessageId: "msg-steer-1",
+    });
+    expect(steered).toBe(false);
+    expect(manager.fetchTimeline(snapshot.id, { direction: "tail", limit: 5 }).rows).toHaveLength(
+      0,
+    );
+  } finally {
+    await manager.flush().catch(() => undefined);
+    await storage.flush().catch(() => undefined);
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2079,6 +2079,35 @@ export class AgentManager {
     return true;
   }
 
+  /**
+   * Try to steer a prompt into the running agent without interrupting the
+   * active turn. Providers that support native steering (e.g. Pi) queue the
+   * message and deliver it after the current tool-call batch. Returns true when
+   * the prompt was queued; the submitted message is recorded immediately and
+   * the running turn keeps broadcasting its events.
+   */
+  async trySteerAgent(
+    agentId: string,
+    prompt: AgentPromptInput,
+    options?: AgentRunOptions,
+  ): Promise<boolean> {
+    const agent = this.requireSessionAgent(agentId);
+    const handler = agent.session.trySteer;
+    if (!handler) {
+      return false;
+    }
+    const steered = await handler.call(agent.session, prompt, options);
+    if (!steered) {
+      return false;
+    }
+    if (options?.clientMessageId) {
+      this.recordSubmittedPrompt(agent, prompt, options.clientMessageId);
+    }
+    this.touchUpdatedAt(agent);
+    this.emitState(agent);
+    return true;
+  }
+
   async appendTimelineItem(agentId: string, item: AgentTimelineItem): Promise<void> {
     const agent = this.requireAgent(agentId);
     item = limitAgentTimelineItemContent(item);

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -9,6 +9,7 @@ import {
   isSystemInjectedEnvelope,
   sendPromptToAgent,
   setupFinishNotification,
+  startAgentRun,
 } from "./agent-prompt.js";
 import type { AgentManagerEvent, ManagedAgent } from "./agent-manager.js";
 
@@ -96,6 +97,7 @@ function createFinishNotificationScenario(
     return options?.childLastAssistantMessage ?? null;
   });
   Reflect.set(agentManager, "tryRunOutOfBand", () => false);
+  Reflect.set(agentManager, "trySteerAgent", async () => false);
   Reflect.set(agentManager, "hasInFlightRun", () => Boolean(options?.parentPromptError));
   Reflect.set(agentManager, "streamAgent", (_agentId: string, prompt: string) => {
     parentPrompted = true;
@@ -258,6 +260,7 @@ test("sendPromptToAgent forwards the client message id as run options", async ()
     vi.fn(() => agent),
   );
   Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "trySteerAgent", vi.fn().mockResolvedValue(false));
   Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
 
@@ -512,6 +515,7 @@ it("does not notify archived callers", async () => {
     }),
   );
   Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "trySteerAgent", vi.fn().mockResolvedValue(false));
   Reflect.set(agentManager, "streamAgent", streamAgentSpy);
   Reflect.set(agentManager, "replaceAgentRun", replaceAgentRunSpy);
 
@@ -549,4 +553,71 @@ it("does not notify archived callers", async () => {
 
   expect(streamAgentSpy).not.toHaveBeenCalled();
   expect(replaceAgentRunSpy).not.toHaveBeenCalled();
+});
+
+test("startAgentRun steers into a running agent instead of replacing the turn", async () => {
+  const agent: ManagedAgent = Object.create(null);
+  Reflect.set(agent, "id", "agent-1");
+  Reflect.set(agent, "provider", "pi");
+
+  const streamAgentSpy = vi.fn(() => (async function* noop() {})());
+  const replaceAgentRunSpy = vi.fn(() => (async function* noop() {})());
+  const trySteerAgentSpy = vi.fn().mockResolvedValue(true);
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => agent),
+  );
+  Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(true));
+  Reflect.set(agentManager, "trySteerAgent", trySteerAgentSpy);
+  Reflect.set(agentManager, "streamAgent", streamAgentSpy);
+  Reflect.set(agentManager, "replaceAgentRun", replaceAgentRunSpy);
+
+  const result = await startAgentRun(agentManager, "agent-1", "steer me", createTestLogger(), {
+    replaceRunning: true,
+    runOptions: { clientMessageId: "msg-1" },
+  });
+
+  expect(result).toEqual({ outOfBand: false, steered: true });
+  expect(trySteerAgentSpy).toHaveBeenCalledWith("agent-1", "steer me", {
+    clientMessageId: "msg-1",
+  });
+  expect(replaceAgentRunSpy).not.toHaveBeenCalled();
+  expect(streamAgentSpy).not.toHaveBeenCalled();
+});
+
+test("startAgentRun falls back to replacing the turn when steering is unavailable", async () => {
+  const agent: ManagedAgent = Object.create(null);
+  Reflect.set(agent, "id", "agent-1");
+  Reflect.set(agent, "provider", "pi");
+
+  const replaceAgentRunSpy = vi.fn(() => (async function* noop() {})());
+  const trySteerAgentSpy = vi.fn().mockResolvedValue(false);
+  const agentManager: AgentManager = Object.create(AgentManager.prototype);
+  Reflect.set(
+    agentManager,
+    "getAgent",
+    vi.fn(() => agent),
+  );
+  Reflect.set(agentManager, "tryRunOutOfBand", vi.fn().mockReturnValue(false));
+  Reflect.set(agentManager, "hasInFlightRun", vi.fn().mockReturnValue(true));
+  Reflect.set(agentManager, "trySteerAgent", trySteerAgentSpy);
+  Reflect.set(
+    agentManager,
+    "streamAgent",
+    vi.fn(() => (async function* noop() {})()),
+  );
+  Reflect.set(agentManager, "replaceAgentRun", replaceAgentRunSpy);
+
+  const result = await startAgentRun(agentManager, "agent-1", "steer me", createTestLogger(), {
+    replaceRunning: true,
+    runOptions: { clientMessageId: "msg-1" },
+  });
+
+  expect(result).toEqual({ outOfBand: false, steered: false });
+  expect(replaceAgentRunSpy).toHaveBeenCalledWith("agent-1", "steer me", {
+    clientMessageId: "msg-1",
+  });
 });

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -14,7 +14,12 @@ export type AgentUnarchiveController = Pick<AgentManager, "notifyAgentState" | "
 
 export type AgentRunController = Pick<
   AgentManager,
-  "getAgent" | "tryRunOutOfBand" | "hasInFlightRun" | "replaceAgentRun" | "streamAgent"
+  | "getAgent"
+  | "tryRunOutOfBand"
+  | "trySteerAgent"
+  | "hasInFlightRun"
+  | "replaceAgentRun"
+  | "streamAgent"
 >;
 
 export interface StartAgentRunOptions {
@@ -28,7 +33,7 @@ export async function startAgentRun(
   prompt: AgentPromptInput,
   logger: Logger,
   options?: StartAgentRunOptions,
-): Promise<{ outOfBand: boolean }> {
+): Promise<{ outOfBand: boolean; steered: boolean }> {
   const snapshot = agentManager.getAgent(agentId);
   logger.trace(
     {
@@ -46,10 +51,18 @@ export async function startAgentRun(
   // in-flight turn — replaceAgentRun would interrupt the running turn. The
   // intercept lives at this layer so it covers every prompt entrypoint.
   if (agentManager.tryRunOutOfBand(agentId, prompt, options?.runOptions)) {
-    return { outOfBand: true };
+    return { outOfBand: true, steered: false };
   }
-  const shouldReplace = Boolean(options?.replaceRunning && agentManager.hasInFlightRun(agentId));
+  const shouldReplace = shouldReplaceRunningAgent(agentManager, agentId, options?.replaceRunning);
   const runOptions = options?.runOptions;
+  // Steering is a provider-native capability: providers that implement it (e.g.
+  // Pi) queue the prompt into the running turn instead of aborting it. The
+  // submitted message is recorded immediately and the running turn keeps
+  // broadcasting events, so no new run is allocated. Providers without native
+  // steering fall through to the interrupt + fresh turn path below.
+  if (await trySteerRunningAgent(agentManager, agentId, prompt, runOptions, shouldReplace)) {
+    return { outOfBand: false, steered: true };
+  }
   const iterator = shouldReplace
     ? await agentManager.replaceAgentRun(agentId, prompt, runOptions)
     : agentManager.streamAgent(agentId, prompt, runOptions);
@@ -88,7 +101,28 @@ export async function startAgentRun(
       logger.error({ err: error, agentId }, "Agent stream failed");
     }
   })();
-  return { outOfBand: false };
+  return { outOfBand: false, steered: false };
+}
+
+async function trySteerRunningAgent(
+  agentManager: AgentRunController,
+  agentId: string,
+  prompt: AgentPromptInput,
+  runOptions: AgentRunOptions | undefined,
+  shouldReplace: boolean,
+): Promise<boolean> {
+  if (!shouldReplace) {
+    return false;
+  }
+  return await agentManager.trySteerAgent(agentId, prompt, runOptions);
+}
+
+function shouldReplaceRunningAgent(
+  agentManager: AgentRunController,
+  agentId: string,
+  replaceRunning: boolean | undefined,
+): boolean {
+  return Boolean(replaceRunning && agentManager.hasInFlightRun(agentId));
 }
 
 /**
@@ -180,13 +214,13 @@ export async function waitForAgentRunStartWithTimeout(
  */
 export async function sendPromptToAgent(
   params: SendPromptToAgentParams,
-): Promise<{ outOfBand: boolean }> {
+): Promise<{ outOfBand: boolean; steered: boolean }> {
   const unarchive = params.unarchive ?? true;
 
   const record = await params.agentStorage.get(params.agentId);
   if (record?.archivedAt) {
     if (!unarchive) {
-      return { outOfBand: false };
+      return { outOfBand: false, steered: false };
     }
     await unarchiveAgentState(params.agentStorage, params.agentManager, params.agentId);
   }

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -662,6 +662,15 @@ export interface AgentSession {
   tryHandleOutOfBand?(prompt: AgentPromptInput): {
     run(ctx: { emit: (event: AgentStreamEvent) => void }): Promise<void>;
   } | null;
+  /**
+   * Mid-turn steering. When the agent already has an active turn, providers
+   * that support native steering (e.g. Pi) queue the prompt instead of forcing
+   * an interrupt; the provider decides when to deliver it. Returns true when
+   * the prompt was queued (the manager records the submitted message and does
+   * not allocate a new run), false when the caller should fall back to
+   * interrupt + fresh turn.
+   */
+  trySteer?(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean>;
 }
 
 export type FetchCatalogOptions =

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -3170,6 +3170,111 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("steers user input into the active Codex turn", async () => {
+    const session = createSession();
+    const requests: Array<{ method: string; params: unknown }> = [];
+    session.client = {
+      request: async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        return {};
+      },
+    } as never;
+
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "test-thread",
+      turn: { id: "native-turn-1" },
+    });
+
+    const steered = await session.trySteer("focus on failing tests first", {
+      clientMessageId: "msg-steer-1",
+    });
+
+    expect(steered).toBe(true);
+    expect(requests).toContainEqual({
+      method: "turn/steer",
+      params: {
+        threadId: "test-thread",
+        input: [{ type: "text", text: "focus on failing tests first", text_elements: [] }],
+        expectedTurnId: "native-turn-1",
+        clientUserMessageId: "msg-steer-1",
+      },
+    });
+  });
+
+  test("echoes the steered user message under the steer clientMessageId", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    session.subscribe((event) => events.push(event));
+    session.client = {
+      request: async () => ({}),
+    } as never;
+
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "test-thread",
+      turn: { id: "native-turn-1" },
+    });
+    await session.trySteer("focus on failing tests first", {
+      clientMessageId: "msg-steer-1",
+    });
+
+    asInternals(session).handleNotification("item/started", {
+      threadId: "test-thread",
+      item: {
+        type: "userMessage",
+        id: "item-steer-1",
+        content: [{ type: "text", text: "focus on failing tests first" }],
+      },
+    });
+
+    expect(events).toContainEqual({
+      type: "timeline",
+      provider: "codex",
+      turnId: "test-turn",
+      item: {
+        type: "user_message",
+        text: "focus on failing tests first",
+        messageId: "item-steer-1",
+        clientMessageId: "msg-steer-1",
+      },
+    });
+  });
+
+  test("declines to steer without an active turn or identified native turn", async () => {
+    const session = createSession();
+    const requests: Array<{ method: string; params: unknown }> = [];
+    session.client = {
+      request: async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        return {};
+      },
+    } as never;
+
+    session.activeForegroundTurnId = null;
+    expect(await session.trySteer("hello", { clientMessageId: "msg-1" })).toBe(false);
+
+    session.activeForegroundTurnId = "test-turn";
+    session.currentTurnId = null;
+    expect(await session.trySteer("hello", { clientMessageId: "msg-2" })).toBe(false);
+
+    expect(requests).toEqual([]);
+  });
+
+  test("falls back when Codex rejects the steer request", async () => {
+    const session = createSession();
+    session.client = {
+      request: async () => {
+        throw new Error("turn/steer requires experimentalApi capability");
+      },
+    } as never;
+
+    asInternals(session).handleNotification("turn/started", {
+      threadId: "test-thread",
+      turn: { id: "native-turn-1" },
+    });
+
+    await expect(session.trySteer("hello", { clientMessageId: "msg-1" })).resolves.toBe(false);
+  });
+
   test("never replaces the root identity with an early child thread start", () => {
     const session = createSession();
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -4096,6 +4096,29 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
   }
 
+  async trySteer(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean> {
+    if (!this.activeForegroundTurnId || !this.currentTurnId || !this.client) {
+      return false;
+    }
+    const input = await this.buildUserInput(prompt);
+    // Codex appends the input to the in-flight turn without creating a new one.
+    // The next user-message item echo picks up activeClientMessageId, so the
+    // steered message lands under the right clientMessageId on the timeline.
+    this.activeClientMessageId = options?.clientMessageId ?? null;
+    try {
+      await this.client.request("turn/steer", {
+        threadId: this.currentThreadId,
+        input,
+        expectedTurnId: this.currentTurnId,
+        ...(options?.clientMessageId ? { clientUserMessageId: options.clientMessageId } : {}),
+      });
+      return true;
+    } catch {
+      // Older Codex binaries lack turn/steer; fall back to interrupt + fresh turn.
+      return false;
+    }
+  }
+
   private rememberCodexUserMessageTurn(messageId: string | null | undefined): boolean {
     if (typeof messageId !== "string" || messageId.length === 0) {
       return false;

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -251,6 +251,67 @@ class SessionEvents {
 }
 
 describe("PiRpcAgentSession", () => {
+  test("steers a prompt into the running Pi turn without aborting", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("first task");
+
+    const steered = await session.trySteer("second instruction", {
+      clientMessageId: "msg-steer-1",
+    });
+    expect(steered).toBe(true);
+
+    expect(fakeSession.abortRequested).toBe(false);
+    expect(fakeSession.prompts.at(-1)).toEqual({
+      message: "second instruction",
+      imageCount: 0,
+      streamingBehavior: "steer",
+    });
+
+    // Pi delivers the steered message after the current tool-call batch; the
+    // submitted-user-entry echo carries the steer clientMessageId and the turn
+    // stays open.
+    fakeSession.finishSubmittedUserMessage({
+      id: "entry-steer-1",
+      parentId: null,
+      text: "second instruction",
+    });
+    await flushTurnScheduling();
+    expect(events.timelineItems()).toContainEqual({
+      type: "user_message",
+      text: "second instruction",
+      messageId: "entry-steer-1",
+      clientMessageId: "msg-steer-1",
+    });
+    expect(events.turnCompletedEvents()).toHaveLength(0);
+
+    fakeSession.finishTurn();
+    await events.nextTurnCompletion();
+  });
+
+  test("does not steer when no turn is active", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    const steered = await session.trySteer("hello", { clientMessageId: "msg-1" });
+    expect(steered).toBe(false);
+    expect(fakeSession.prompts).toHaveLength(0);
+  });
+
+  test("falls back when Pi rejects the steer prompt", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("first task");
+    fakeSession.holdNextPrompt();
+    const steerPromise = session.trySteer("steer message");
+    await flushTurnScheduling();
+    await fakeSession.failHeldPrompt(new Error("rejected"));
+
+    await expect(steerPromise).resolves.toBe(false);
+  });
+
   test("bridges Pi RPC select extension UI requests through question permissions", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1358,6 +1358,27 @@ export class PiRpcAgentSession implements AgentSession {
     return { turnId };
   }
 
+  async trySteer(prompt: AgentPromptInput, options?: AgentRunOptions): Promise<boolean> {
+    if (!this.activeTurnId) {
+      return false;
+    }
+    const payload = convertPromptInput(prompt, { model: this.state.model });
+    // Pi delivers the steered message after the current tool-call batch finishes,
+    // then keeps running the same turn. Point the submitted-user-entry echo at
+    // this prompt so the timeline shows it under the right clientMessageId.
+    this.activeClientMessageId = options?.clientMessageId ?? null;
+    try {
+      await this.runtimeSession.prompt(payload.text, payload.images, {
+        streamingBehavior: "steer",
+      });
+      return true;
+    } catch {
+      // Older Pi binaries may reject streamingBehavior; fall back to the
+      // interrupt + fresh turn path.
+      return false;
+    }
+  }
+
   subscribe(callback: (event: AgentStreamEvent) => void): () => void {
     this.subscribers.add(callback);
     return () => {

--- a/packages/server/src/server/agent/providers/pi/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/cli-runtime.ts
@@ -111,11 +111,13 @@ class PiCliRuntimeSession implements PiRuntimeSession {
   async prompt(
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
+    options?: { streamingBehavior?: "steer" | "followUp" },
   ): Promise<PiPromptAck> {
     const { id: requestId, promise } = this.process.startRequest({
       type: "prompt",
       message,
       ...(images?.length ? { images } : {}),
+      ...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior } : {}),
     });
     const data = await promise;
     if (typeof data === "object" && data !== null && !Array.isArray(data)) {

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -127,7 +127,13 @@ export interface PiRpcSlashCommand {
 }
 
 export type PiRpcCommand =
-  | { id?: string; type: "prompt"; message: string; images?: PiImageContent[] }
+  | {
+      id?: string;
+      type: "prompt";
+      message: string;
+      images?: PiImageContent[];
+      streamingBehavior?: "steer" | "followUp";
+    }
   | { id?: string; type: "compact"; customInstructions?: string }
   | { id?: string; type: "set_auto_compaction"; enabled: boolean }
   | { id?: string; type: "abort" }

--- a/packages/server/src/server/agent/providers/pi/runtime.ts
+++ b/packages/server/src/server/agent/providers/pi/runtime.ts
@@ -44,6 +44,7 @@ export interface PiRuntimeSession {
   prompt(
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
+    options?: { streamingBehavior?: "steer" | "followUp" },
   ): Promise<PiPromptAck>;
   compact(customInstructions?: string): Promise<void>;
   setAutoCompaction(enabled: boolean): Promise<void>;

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -93,7 +93,11 @@ export class FakePi implements PiRuntime {
 }
 
 export class FakePiSession implements PiRuntimeSession {
-  readonly prompts: Array<{ message: string; imageCount: number }> = [];
+  readonly prompts: Array<{
+    message: string;
+    imageCount: number;
+    streamingBehavior?: "steer" | "followUp";
+  }> = [];
   readonly compactRequests: Array<{ customInstructions?: string }> = [];
   readonly setAutoCompactionRequests: boolean[] = [];
   readonly subagentSubscriptionRequests: FakePiSubagentSubscriptionLevel[] = [];
@@ -160,8 +164,13 @@ export class FakePiSession implements PiRuntimeSession {
   async prompt(
     message: string,
     images?: Array<{ type: "image"; data: string; mimeType: string }>,
+    options?: { streamingBehavior?: "steer" | "followUp" },
   ): Promise<PiPromptAck> {
-    this.prompts.push({ message, imageCount: images?.length ?? 0 });
+    this.prompts.push({
+      message,
+      imageCount: images?.length ?? 0,
+      ...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior } : {}),
+    });
     const heldPrompt = this.nextHeldPrompt;
     if (heldPrompt) {
       this.nextHeldPrompt = null;

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -6895,7 +6895,7 @@ export class Session {
         },
         "agent.session.send_agent_message",
       );
-      let dispatchResult: { outOfBand: boolean };
+      let dispatchResult: { outOfBand: boolean; steered: boolean };
       try {
         dispatchResult = await sendPromptToAgent({
           agentManager: this.agentManager,
@@ -6920,7 +6920,10 @@ export class Session {
         return;
       }
 
-      if (dispatchResult.outOfBand) {
+      // Steered prompts (provider-native mid-turn queue) are accepted
+      // immediately; the running turn keeps broadcasting events, so there is no
+      // new run start to wait for.
+      if (dispatchResult.outOfBand || dispatchResult.steered) {
         this.emit({
           type: "send_agent_message_response",
           payload: {


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

N/A

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

When a user sends a message while an agent is running, Paseo aborted the in-flight turn (discarding the tool work already done and the streamed output) and started a fresh turn. Two supported providers expose a native mechanism to accept the prompt mid-turn without interrupting: Pi's `streamingBehavior: "steer"` and Codex's app-server `turn/steer`. This PR lets those providers keep working when the user redirects them, instead of throwing away the current turn.

Steering is now a provider-native capability (`AgentSession.trySteer?`): providers that implement it queue the prompt into the active turn and Paseo records the submitted message immediately, while the running turn keeps broadcasting its events. Providers without native steering (Claude, OpenCode, OMP) are unchanged and still use the interrupt + fresh turn path. Queueing is deliberately NOT delegated to providers — Paseo keeps its own send-when-idle queue (`sendBehavior="queue"`) as the provider-agnostic fallback.

### Goals

- Send a message to a running Pi agent without aborting it: Pi queues the prompt and delivers it after the current tool-call batch, then keeps running the same turn.
- Send a message to a running Codex agent without aborting it: `turn/steer` appends the input to the in-flight turn (requires `expectedTurnId`; Paseo already opts into `experimentalApi`).
- The steered message appears in the timeline under the correct clientMessageId immediately (submitted state), and its provider echo reconciles on delivery.
- `send_agent_message` acknowledges steered prompts immediately; no new run is allocated, so there is nothing to wait for.
- Non-steering providers keep the existing interrupt behavior — no behavior change for Claude/OpenCode/OMP.

### Non-goals

- Moving Paseo's send-when-idle queue from the app client into the daemon. Queue stays a Paseo-side concern and is intentionally not backed by any provider RPC (e.g. Pi `follow_up`).
- Surfacing a pending-steer indicator in the UI (Pi's `queue_update` / Codex steer queue state).
- Steering for Claude/OpenCode/OMP — they have no native equivalent today.

### QA

Behavior verified against the provider protocol docs and unit tests:

- Pi: `prompt` RPC forwards `streamingBehavior: "steer"`; Pi delivers after the current tool-call batch, emits a normal `message_start` (user), and the existing `PASEO_SUBMITTED_USER_ENTRY` extension marker echoes it to the timeline under the steer clientMessageId. Tests: `packages/server/src/server/agent/providers/pi/agent.test.ts` (steer delivery, no active turn fallback, rejected prompt fallback).
- Codex: `turn/steer` appends user input to the active in-flight turn (protocol: `expectedTurnId` must match; returns accepted `turnId`; no new `turn/started`). The next user-message item echo picks up the steer clientMessageId. Tests: `codex-app-server-agent.test.ts` (request params, message echo, decline without active turn, request failure fallback).
- Dispatch: `startAgentRun` returns an explicit `steered` result (no longer reusing `outOfBand`); `send_agent_message` acknowledges steered prompts without waiting for a run start. Tests: `agent-prompt.test.ts` (steer vs replace fallback), `agent-manager.test.ts` (submitted prompt recorded, no-capability/decline fallback).

Ran: `npm run typecheck` ✓, `npm run lint` ✓, `npm run format:check` ✓, `vitest` on the four affected test files (364 tests) ✓.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
