### PR TITLE
Fix relay pairing when daemon is stopped

### DIFF
--- a/packages/cli/src/commands/daemon/pair.ts
+++ b/packages/cli/src/commands/daemon/pair.ts
@@ -8,7 +8,7 @@ import {
   resolvePaseoHome,
 } from "@getpaseo/server";
 import { tryConnectToDaemon } from "../../utils/client.js";
-import { resolveLocalDaemonState } from "./local-daemon.js";
+import { resolveLocalDaemonState, startLocalDaemonDetached } from "./local-daemon.js";
 import { addJsonOption } from "../../utils/command-options.js";
 import { formatPairingInstructions } from "../../output/pairing.js";
 
@@ -87,7 +87,20 @@ export async function resolveLocalPairingOffer(options: {
 
   const config = loadConfig(options.paseoHome);
   if (options.enableRelay && !config.relayEnabled) {
-    throw new Error("Start the daemon before enabling relay for pairing.");
+    await startLocalDaemonDetached({
+      home: options.paseoHome,
+      relay: true,
+    });
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const offer = await resolveDaemonPairingOffer(state.listen, serverId, true);
+      if (offer) return offer;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    throw new Error(
+      "The daemon started but did not provide a relay pairing offer. Check the daemon logs.",
+    );
   }
 
   return generateLocalPairingOffer({

--- a/packages/cli/tests/03-daemon.test.ts
+++ b/packages/cli/tests/03-daemon.test.ts
@@ -32,6 +32,21 @@ console.log("=== Daemon Commands ===\n");
 const port = 10000 + Math.floor(Math.random() * 50000);
 const paseoHome = await mkdtemp(join(tmpdir(), "paseo-test-home-"));
 const require = createRequire(import.meta.url);
+await writeFile(
+  join(paseoHome, "config.json"),
+  `${JSON.stringify(
+    {
+      version: 1,
+      daemon: {
+        listen: `127.0.0.1:${port}`,
+        relay: { enabled: false },
+      },
+    },
+    null,
+    2,
+  )}\n`,
+  "utf-8",
+);
 
 function daemonCommand(args: string[]) {
   return runLocalPaseo(["daemon", ...args], { PASEO_HOME: paseoHome });
@@ -158,9 +173,23 @@ try {
     console.log("✓ daemon pair --json reports relay disabled\n");
   }
 
-  // Test 5: daemon status --json outputs valid JSON
+  // Test 5: explicit relay pairing starts a stopped daemon and returns an offer
   {
-    console.log("Test 5: daemon status --json outputs JSON");
+    console.log("Test 5: daemon pair --relay starts the daemon");
+    const result = await daemonCommand(["pair", "--relay", "--json"]);
+    assert.strictEqual(result.exitCode, 0, "daemon pair --relay should start the daemon");
+    const pairing = JSON.parse(result.stdout);
+    assert.strictEqual(pairing.relayEnabled, true, "pairing should enable relay");
+    assert(pairing.url?.includes("#offer="), "pairing should include a relay offer URL");
+
+    const cleanup = await daemonCommand(["stop", "--force"]);
+    assert.strictEqual(cleanup.exitCode, 0, "cleanup stop should succeed after pairing");
+    console.log("✓ daemon pair --relay starts the daemon\n");
+  }
+
+  // Test 6: daemon status --json outputs valid JSON
+  {
+    console.log("Test 6: daemon status --json outputs JSON");
     const result = await daemonCommand(["status", "--json"]);
     assert.strictEqual(result.exitCode, 0, "--json status should succeed");
     const status = JSON.parse(result.stdout);


### PR DESCRIPTION
## What changed

Start the local daemon with relay enabled when `paseo daemon pair --relay` or interactive relay consent is used while the daemon is stopped.

## Why

The command previously prompted to enable relay and then threw `Start the daemon before enabling relay for pairing.` when no daemon was running. That made the documented pairing flow fail on a fresh headless installation.

The fix starts the daemon through the existing detached startup path and retries the daemon pairing RPC until the relay offer is available. A regression test covers pairing from an isolated, stopped daemon home.

## Validation

- `npx tsx packages/cli/tests/03-daemon.test.ts`
- `npm run typecheck --workspace=@getpaseo/cli`
- `npx oxfmt --check packages/cli/src/commands/daemon/pair.ts packages/cli/tests/03-daemon.test.ts`
- `git diff --check`
