### PR TITLE
feat(app): add selected-text annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ tsconfig.tsbuildinfo
 
 # Testing
 coverage/
+**/.vitest-attachments/
 
 # Playwright
 test-results/

--- a/docs/floating-panels.md
+++ b/docs/floating-panels.md
@@ -78,6 +78,14 @@ ordinary portals regardless of `z-index`, which would hide app toasts and
 tooltips behind the menu. The shared overlay scale keeps menus below toasts and
 lets tooltip portals paint above both.
 
+Fixed decorations that belong to document content, such as selection highlights
+and annotation markers, render into `content-adornment-root`. That root is a
+separate surface plane below `overlay-root`, so descendant `z-index` values can
+order decorations among themselves without covering menus, hover cards, or modals.
+Clip highlights to their owning chat viewport; this viewport ends where the
+composer begins. Interactive markers additionally suppress themselves when their
+hit area intersects the composer.
+
 The shared overlay scale is relative for interactive surfaces: a base floating
 panel is below a base modal, while a floating panel rendered from inside a modal
 inherits that modal's layer and paints above it. Wrap portal content in

--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -102,6 +102,11 @@ import { isWeb } from "@/constants/platform";
 import type { Theme } from "@/styles/theme";
 import { recordRenderProfileReasons } from "@/utils/render-profiler";
 import { useRetainedPanelActive } from "@/components/retained-panel";
+import type {
+  AssistantSelectionAnnotation,
+  SelectedTextAnnotationEdit,
+} from "@/assistant-selection-copy/types";
+import type { SelectedTextComposerAttachment } from "@/attachments/types";
 
 function renderLiveAuxiliaryNode(input: {
   pendingPermissions: ReactNode;
@@ -231,6 +236,7 @@ function renderLiveHeadStreamItem(input: {
 
 export interface AgentStreamViewHandle {
   scrollToBottom(reason?: BottomAnchorLocalRequest["reason"]): void;
+  scrollToMessage(itemId: string): void;
   prepareForViewportChange(): void;
 }
 
@@ -247,6 +253,13 @@ export interface AgentStreamViewProps {
   isAuthoritativeHistoryReady?: boolean;
   toast?: ToastApi | null;
   onOpenWorkspaceFile?: (request: WorkspaceFileOpenRequest) => void;
+  isPaneFocused?: boolean;
+  onCommentSelection?: (annotation: AssistantSelectionAnnotation) => void;
+  selectedTextAnnotations?: readonly SelectedTextComposerAttachment[];
+  onOpenSelectedText?: (annotation: SelectedTextComposerAttachment) => void;
+  selectedTextAnnotationToEdit?: SelectedTextComposerAttachment | null;
+  onEditSelectedText?: (input: SelectedTextAnnotationEdit) => void;
+  onDismissSelectedTextEdit?: () => void;
   readOnly?: boolean;
   historyPagination?: {
     hasOlder: boolean;
@@ -295,6 +308,13 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
       isAuthoritativeHistoryReady = true,
       toast,
       onOpenWorkspaceFile,
+      isPaneFocused = true,
+      onCommentSelection,
+      selectedTextAnnotations,
+      onOpenSelectedText,
+      selectedTextAnnotationToEdit,
+      onEditSelectedText,
+      onDismissSelectedTextEdit,
       readOnly = false,
       historyPagination,
     },
@@ -558,6 +578,9 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
         scrollToBottom(reason = "jump-to-bottom") {
           viewportRef.current?.scrollToBottom(reason);
         },
+        scrollToMessage(itemId: string) {
+          viewportRef.current?.scrollToMessage?.(itemId);
+        },
         prepareForViewportChange() {
           viewportRef.current?.prepareForViewportChange();
         },
@@ -638,24 +661,26 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     const renderAssistantMessageItem = useCallback(
       (layoutItem: StreamLayoutItem, item: Extract<StreamItem, { kind: "assistant_message" }>) => {
         return (
-          <AssistantFileLinkResolverProvider
-            client={client}
-            serverId={resolvedServerId}
-            workspaceRoot={workspaceRoot}
-            onOpenWorkspaceFile={handleInlinePathPress}
-            toast={toast}
-          >
-            <AssistantMessage
-              occurrenceKey={createAssistantImageOccurrenceKey({ agentId, itemId: item.id })}
-              message={item.text}
-              timestamp={item.timestamp.getTime()}
-              workspaceRoot={workspaceRoot}
-              serverId={resolvedServerId}
+          <View testID={`assistant-message-item:${item.id}`}>
+            <AssistantFileLinkResolverProvider
               client={client}
-              spacing={layoutItem.assistantSpacing}
-              phase={layoutItem.phase}
-            />
-          </AssistantFileLinkResolverProvider>
+              serverId={resolvedServerId}
+              workspaceRoot={workspaceRoot}
+              onOpenWorkspaceFile={handleInlinePathPress}
+              toast={toast}
+            >
+              <AssistantMessage
+                occurrenceKey={createAssistantImageOccurrenceKey({ agentId, itemId: item.id })}
+                message={item.text}
+                timestamp={item.timestamp.getTime()}
+                workspaceRoot={workspaceRoot}
+                serverId={resolvedServerId}
+                client={client}
+                spacing={layoutItem.assistantSpacing}
+                phase={layoutItem.phase}
+              />
+            </AssistantFileLinkResolverProvider>
+          </View>
         );
       },
       [agentId, client, handleInlinePathPress, resolvedServerId, toast, workspaceRoot],
@@ -981,7 +1006,21 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
 
     return (
       <ToolCallSheetProvider>
-        <AssistantSelectionCopySurface style={stylesheet.container}>
+        <AssistantSelectionCopySurface
+          style={stylesheet.container}
+          visible={isPaneFocused}
+          onCommentSelection={readOnly ? undefined : onCommentSelection}
+          addToCommentLabel={t("agentStream.addToComment")}
+          addToConversationLabel={t("agentStream.addToConversation")}
+          commentPlaceholder={t("agentStream.commentPlaceholder")}
+          saveCommentLabel={t("agentStream.saveComment")}
+          cancelCommentLabel={t("agentStream.cancelComment")}
+          selectedTextAnnotations={selectedTextAnnotations}
+          onOpenAnnotation={onOpenSelectedText}
+          selectedTextAnnotationToEdit={selectedTextAnnotationToEdit}
+          onEditComment={onEditSelectedText}
+          onDismissEditComment={onDismissSelectedTextEdit}
+        >
           <MessageOuterSpacingProvider disableOuterSpacing>
             {streamRenderStrategy.render({
               agentId,
@@ -1144,12 +1183,29 @@ function agentStreamViewPropsEqual(
   }
   if (left.toast !== right.toast) reasons.push("toast");
   if (left.onOpenWorkspaceFile !== right.onOpenWorkspaceFile) reasons.push("onOpenWorkspaceFile");
+  collectPropDiff(reasons, "isPaneFocused", left.isPaneFocused, right.isPaneFocused);
+  if (left.onCommentSelection !== right.onCommentSelection) reasons.push("onCommentSelection");
+  if (left.selectedTextAnnotations !== right.selectedTextAnnotations) {
+    reasons.push("selectedTextAnnotations");
+  }
+  if (left.onOpenSelectedText !== right.onOpenSelectedText) reasons.push("onOpenSelectedText");
+  if (left.selectedTextAnnotationToEdit !== right.selectedTextAnnotationToEdit) {
+    reasons.push("selectedTextAnnotationToEdit");
+  }
+  if (left.onEditSelectedText !== right.onEditSelectedText) reasons.push("onEditSelectedText");
+  if (left.onDismissSelectedTextEdit !== right.onDismissSelectedTextEdit) {
+    reasons.push("onDismissSelectedTextEdit");
+  }
   if (left.readOnly !== right.readOnly) reasons.push("readOnly");
   if (!historyPaginationPropsEqual(left.historyPagination, right.historyPagination)) {
     reasons.push("historyPagination");
   }
   recordRenderProfileReasons(`AgentStreamView:${right.agentId}`, reasons);
   return reasons.length === 0;
+}
+
+function collectPropDiff<T>(reasons: string[], label: string, left: T, right: T): void {
+  if (left !== right) reasons.push(label);
 }
 
 export const AgentStreamView = memo(AgentStreamViewComponent, agentStreamViewPropsEqual);

--- a/packages/app/src/assistant-selection-copy/scroll.ts
+++ b/packages/app/src/assistant-selection-copy/scroll.ts
@@ -1,0 +1,56 @@
+import { isWeb } from "@/constants/platform";
+import type { SelectedTextComposerAttachment } from "@/attachments/types";
+
+const ASSISTANT_MESSAGE_SELECTOR = '[data-testid="assistant-message"]';
+const ASSISTANT_MESSAGE_ITEM_SELECTOR = '[data-testid^="assistant-message-item:"]';
+
+export function scrollToSelectedText(
+  attachment: SelectedTextComposerAttachment,
+  scrollToMessage?: (messageId: string) => void,
+): void {
+  if (!isWeb) {
+    return;
+  }
+
+  let didRequestMessageScroll = false;
+  let attemptsRemaining = scrollToMessage ? 20 : 0;
+  const focusSelection = () => {
+    const message = findAssistantMessage(attachment);
+    if (!message) {
+      if (attachment.sourceMessageId && scrollToMessage && !didRequestMessageScroll) {
+        didRequestMessageScroll = true;
+        scrollToMessage(attachment.sourceMessageId);
+      }
+      if (attemptsRemaining > 0) {
+        attemptsRemaining -= 1;
+        window.requestAnimationFrame(focusSelection);
+      }
+      return;
+    }
+
+    message.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  focusSelection();
+}
+
+function findAssistantMessage(attachment: SelectedTextComposerAttachment): Element | null {
+  const messageItems = Array.from(
+    document.querySelectorAll<HTMLElement>(ASSISTANT_MESSAGE_ITEM_SELECTOR),
+  );
+  if (attachment.sourceMessageId) {
+    const source = messageItems.find(
+      (item) => item.dataset.testid === `assistant-message-item:${attachment.sourceMessageId}`,
+    );
+    if (source) {
+      return source.querySelector(ASSISTANT_MESSAGE_SELECTOR);
+    }
+  }
+
+  const preview = attachment.text.replace(/\s+/g, " ").trim();
+  return (
+    messageItems
+      .map((item) => item.querySelector(ASSISTANT_MESSAGE_SELECTOR))
+      .find((message) => message?.textContent?.replace(/\s+/g, " ").includes(preview)) ?? null
+  );
+}

--- a/packages/app/src/assistant-selection-copy/surface.tsx
+++ b/packages/app/src/assistant-selection-copy/surface.tsx
@@ -1,9 +1,29 @@
 import type { ReactNode } from "react";
 import { View, type StyleProp, type ViewStyle } from "react-native";
+import type { SelectedTextComposerAttachment } from "@/attachments/types";
+import type { AssistantSelectionAnnotation, SelectedTextAnnotationEdit } from "./types";
 
 interface AssistantSelectionCopySurfaceProps {
   children: ReactNode;
   style?: StyleProp<ViewStyle>;
+  visible?: boolean;
+  onCommentSelection?: (annotation: AssistantSelectionAnnotation) => void;
+  addToCommentLabel?: string;
+  addToConversationLabel?: string;
+  commentPlaceholder?: string;
+  saveCommentLabel?: string;
+  cancelCommentLabel?: string;
+  selectedTextAnnotationToEdit?: {
+    id: string;
+    text: string;
+    sourceMessageId?: string;
+    occurrence?: number;
+    comment?: string;
+  } | null;
+  selectedTextAnnotations?: readonly SelectedTextComposerAttachment[];
+  onOpenAnnotation?: (annotation: SelectedTextComposerAttachment) => void;
+  onEditComment?: (input: SelectedTextAnnotationEdit) => void;
+  onDismissEditComment?: () => void;
 }
 
 export function AssistantSelectionCopySurface({

--- a/packages/app/src/assistant-selection-copy/surface.web.browser.test.tsx
+++ b/packages/app/src/assistant-selection-copy/surface.web.browser.test.tsx
@@ -1,0 +1,806 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SelectedTextComposerAttachment } from "@/attachments/types";
+import { getOverlayRoot, WEB_SURFACE_PLANE } from "@/lib/overlay-root";
+import { AssistantSelectionCopySurface } from "./surface.web";
+import type { AssistantSelectionAnnotation, SelectedTextAnnotationEdit } from "./types";
+
+interface MountedSurface {
+  root: Root;
+  container: HTMLDivElement;
+  rerender: (options: SurfaceOptions) => void;
+}
+
+interface SurfaceOptions {
+  composerOcclusionTop?: number;
+  contentViewportBottom?: number;
+  contentViewportTop?: number;
+  visible?: boolean;
+  onEditComment?: (edit: SelectedTextAnnotationEdit) => void;
+  onOpenAnnotation?: (annotation: SelectedTextComposerAttachment) => void;
+  selectedTextAnnotations?: readonly SelectedTextComposerAttachment[];
+  selectedTextAnnotationToEdit?: {
+    id: string;
+    text: string;
+    sourceMessageId?: string;
+    occurrence?: number;
+    comment?: string;
+  };
+}
+
+const mountedSurfaces: MountedSurface[] = [];
+
+function mountSurface(
+  onCommentSelection: (annotation: AssistantSelectionAnnotation) => void,
+  onDismissEditComment?: () => void,
+  options?: SurfaceOptions,
+): MountedSurface {
+  const container = document.createElement("div");
+  if (options?.contentViewportTop == null && options?.contentViewportBottom == null) {
+    document.body.appendChild(container);
+  } else {
+    const contentViewport = document.createElement("div");
+    contentViewport.dataset.testid = "agent-chat-scroll";
+    const contentTop = options.contentViewportTop ?? 0;
+    Object.assign(contentViewport.style, {
+      position: "fixed",
+      top: `${contentTop}px`,
+      right: "0",
+      left: "0",
+      overflow: "visible",
+    });
+    if (options.contentViewportBottom == null) {
+      contentViewport.style.bottom = "0";
+    } else {
+      contentViewport.style.height = `${options.contentViewportBottom - contentTop}px`;
+    }
+    contentViewport.appendChild(container);
+    document.body.appendChild(contentViewport);
+  }
+  const root = createRoot(container);
+  if (options?.composerOcclusionTop != null) {
+    const composerOcclusion = document.createElement("div");
+    composerOcclusion.dataset.testid = "composer-input-area";
+    Object.assign(composerOcclusion.style, {
+      position: "fixed",
+      top: `${options.composerOcclusionTop}px`,
+      right: "0",
+      bottom: "0",
+      left: "0",
+    });
+    document.body.appendChild(composerOcclusion);
+  }
+  const renderSurface = (currentOptions?: SurfaceOptions) => {
+    root.render(
+      <AssistantSelectionCopySurface
+        visible={currentOptions?.visible}
+        onCommentSelection={onCommentSelection}
+        onDismissEditComment={onDismissEditComment}
+        onEditComment={currentOptions?.onEditComment}
+        onOpenAnnotation={currentOptions?.onOpenAnnotation}
+        selectedTextAnnotations={currentOptions?.selectedTextAnnotations}
+        selectedTextAnnotationToEdit={currentOptions?.selectedTextAnnotationToEdit}
+        addToCommentLabel="Add to comment"
+      >
+        <div data-testid="assistant-message-item:assistant-1">
+          <div data-testid="assistant-message">
+            <div data-paseo-markdown-tag="p">
+              Keep <strong data-paseo-markdown-tag="strong">this invariant</strong> intact.
+            </div>
+            <div data-paseo-markdown-tag="p">
+              Repeat{" "}
+              <strong data-testid="second-invariant" data-paseo-markdown-tag="strong">
+                this invariant
+              </strong>{" "}
+              here.
+            </div>
+            <div data-testid="overlapping-repeat" data-paseo-markdown-tag="p">
+              哈哈哈
+            </div>
+            <div data-paseo-markdown-tag="p">Review checklist:</div>
+            <div data-paseo-markdown-tag="ul">
+              <div data-paseo-markdown-tag="li">
+                <span data-paseo-markdown-ignore="true" data-paseo-markdown-list-marker="true">
+                  •
+                </span>
+                <div>
+                  <strong data-paseo-markdown-tag="strong">first item</strong>
+                </div>
+              </div>
+              <div data-paseo-markdown-tag="li">
+                <span data-paseo-markdown-ignore="true" data-paseo-markdown-list-marker="true">
+                  •
+                </span>
+                <div>second item</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </AssistantSelectionCopySurface>,
+    );
+  };
+  act(() => {
+    renderSurface(options);
+  });
+  const mounted = {
+    root,
+    container,
+    rerender: (nextOptions: SurfaceOptions) => act(() => renderSurface(nextOptions)),
+  };
+  mountedSurfaces.push(mounted);
+  return mounted;
+}
+
+function setInputValue(input: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+  const prototype =
+    input instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+  if (!valueSetter) {
+    throw new Error("HTML input value setter is unavailable");
+  }
+  valueSetter.call(input, value);
+  act(() => input.dispatchEvent(new InputEvent("input", { bubbles: true, data: value })));
+}
+
+function selectContents(element: Element): void {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("Expected browser selection");
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function selectTextOffsets(element: Element, start: number, end: number): void {
+  const textNode = element.firstChild;
+  if (!textNode || textNode.nodeType !== Node.TEXT_NODE) {
+    throw new Error("Expected a direct text node");
+  }
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, end);
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("Expected browser selection");
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function getPointerHitTarget(element: HTMLElement): Element | null {
+  const rect = element.getBoundingClientRect();
+  return document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+}
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges();
+  for (const mounted of mountedSurfaces.splice(0)) {
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+  }
+  document.body.replaceChildren();
+});
+
+describe("assistant selection comment action", () => {
+  it("offers a comment action and returns the Markdown selection", () => {
+    const selections: AssistantSelectionAnnotation[] = [];
+    const mounted = mountSurface((annotation) => selections.push(annotation));
+    const selected = mounted.container.querySelector("strong");
+    if (!selected) {
+      throw new Error("Expected selectable assistant text");
+    }
+
+    selectContents(selected);
+    act(() => {
+      selected.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    });
+
+    const action = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-comment-button"]',
+    );
+    expect(action).not.toBeNull();
+
+    expect(action?.textContent).toContain("Add to comment");
+    expect(document.querySelector('[data-testid="assistant-selection-comment-editor"]')).toBeNull();
+
+    act(() => action?.click());
+
+    const editor = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-comment-editor"]',
+    );
+    expect(editor).not.toBeNull();
+    if (!editor) {
+      throw new Error("Expected comment editor");
+    }
+    expect(editor.dataset.editorMode).toBe("create");
+    const compactPanel = editor.firstElementChild;
+    if (!(compactPanel instanceof HTMLElement)) {
+      throw new Error("Expected compact editor panel");
+    }
+    expect(Number.parseFloat(window.getComputedStyle(compactPanel).borderRadius)).toBe(24);
+    const selectionRect = selected.getBoundingClientRect();
+    const editorRect = editor.getBoundingClientRect();
+    const verticalGap = Math.min(
+      Math.abs(editorRect.top - selectionRect.bottom),
+      Math.abs(selectionRect.top - editorRect.bottom),
+    );
+    expect(editorRect.top).toBeGreaterThanOrEqual(0);
+    expect(editorRect.bottom).toBeLessThanOrEqual(window.innerHeight);
+    expect(verticalGap).toBeLessThanOrEqual(16);
+    const input = document.querySelector<HTMLTextAreaElement>(
+      '[data-testid="assistant-selection-comment-input"]',
+    );
+    if (!input) {
+      throw new Error("Expected comment input");
+    }
+    expect(input.tagName).toBe("TEXTAREA");
+    setInputValue(input, "Please explain this");
+
+    const save = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-comment-save"]',
+    );
+    expect(save?.textContent).not.toContain("Save");
+    if (!save) {
+      throw new Error("Expected compact save button");
+    }
+    const compactPanelRect = compactPanel.getBoundingClientRect();
+    const saveRect = save.getBoundingClientRect();
+    expect(Math.abs(compactPanelRect.right - saveRect.right)).toBeLessThanOrEqual(8);
+    expect(Math.abs(compactPanelRect.bottom - saveRect.bottom)).toBeLessThanOrEqual(8);
+    act(() => save?.click());
+
+    expect(selections).toEqual([
+      {
+        text: "**this invariant**",
+        sourceMessageId: "assistant-1",
+        occurrence: 0,
+        comment: "Please explain this",
+      },
+    ]);
+    expect(window.getSelection()?.toString()).toBe("");
+    expect(document.querySelector('[data-testid="assistant-selection-comment-button"]')).toBeNull();
+  });
+
+  it("does not offer the action for text outside an assistant response", () => {
+    const mounted = mountSurface(() => undefined);
+    const outside = document.createElement("span");
+    outside.textContent = "outside";
+    document.body.appendChild(outside);
+    selectContents(outside);
+
+    act(() => {
+      mounted.container.firstElementChild?.dispatchEvent(
+        new PointerEvent("pointerup", { bubbles: true }),
+      );
+    });
+
+    expect(document.querySelector('[data-testid="assistant-selection-comment-button"]')).toBeNull();
+  });
+
+  it("preserves which repeated text occurrence the user selected", async () => {
+    const selections: AssistantSelectionAnnotation[] = [];
+    const mounted = mountSurface((annotation) => selections.push(annotation));
+    const selected = mounted.container.querySelector('[data-testid="second-invariant"]');
+    if (!selected) throw new Error("Expected the second repeated selection");
+
+    selectContents(selected);
+    act(() => selected.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })));
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-button"]')
+        ?.click(),
+    );
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-save"]')
+        ?.click(),
+    );
+
+    expect(selections[0]?.occurrence).toBe(1);
+    mounted.rerender({
+      selectedTextAnnotationToEdit: {
+        id: "selected-text-second-occurrence",
+        ...selections[0],
+      },
+      onEditComment: () => undefined,
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+    const highlight = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-annotation-highlight"]',
+    );
+    expect(highlight?.getBoundingClientRect().top).toBe(selected.getBoundingClientRect().top);
+  });
+
+  it("preserves an overlapping repeated text occurrence", () => {
+    const selections: AssistantSelectionAnnotation[] = [];
+    const mounted = mountSurface((annotation) => selections.push(annotation));
+    const selected = mounted.container.querySelector('[data-testid="overlapping-repeat"]');
+    if (!selected) throw new Error("Expected the overlapping repeated selection");
+
+    selectTextOffsets(selected, 1, 3);
+    act(() => selected.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })));
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-button"]')
+        ?.click(),
+    );
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-save"]')
+        ?.click(),
+    );
+
+    expect(selections[0]).toMatchObject({ text: "哈哈", occurrence: 1 });
+  });
+
+  it("dismisses the action when the browser selection is cleared elsewhere", () => {
+    const mounted = mountSurface(() => undefined);
+    const selected = mounted.container.querySelector("strong");
+    if (!selected) {
+      throw new Error("Expected selectable assistant text");
+    }
+    selectContents(selected);
+    act(() => {
+      selected.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    });
+    expect(
+      document.querySelector('[data-testid="assistant-selection-comment-button"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      window.getSelection()?.removeAllRanges();
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+
+    expect(document.querySelector('[data-testid="assistant-selection-comment-button"]')).toBeNull();
+  });
+
+  it("temporarily hides the editor when its input loses focus", async () => {
+    let dismissCount = 0;
+    const mounted = mountSurface(
+      () => undefined,
+      () => {
+        dismissCount += 1;
+      },
+    );
+    const selected = mounted.container.querySelector("strong");
+    if (!selected) {
+      throw new Error("Expected selectable assistant text");
+    }
+    selectContents(selected);
+    act(() => {
+      selected.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    });
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-button"]')
+        ?.click(),
+    );
+    const input = document.querySelector<HTMLTextAreaElement>(
+      '[data-testid="assistant-selection-comment-input"]',
+    );
+    if (!input) {
+      throw new Error("Expected comment input");
+    }
+    const outsideButton = document.createElement("button");
+    outsideButton.textContent = "Outside editor";
+    document.body.appendChild(outsideButton);
+
+    act(() => {
+      input.focus();
+      outsideButton.focus();
+    });
+    await act(() => new Promise((resolve) => window.setTimeout(resolve, 0)));
+
+    expect(document.querySelector('[data-testid="assistant-selection-comment-editor"]')).toBeNull();
+    expect(dismissCount).toBe(1);
+  });
+
+  it("keeps the compact create editor open when its growing input scrolls", () => {
+    const mounted = mountSurface(() => undefined);
+    const selected = mounted.container.querySelector("strong");
+    if (!selected) {
+      throw new Error("Expected selectable assistant text");
+    }
+    selectContents(selected);
+    act(() => {
+      selected.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    });
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-button"]')
+        ?.click(),
+    );
+    const input = document.querySelector<HTMLTextAreaElement>(
+      '[data-testid="assistant-selection-comment-input"]',
+    );
+    if (!input) {
+      throw new Error("Expected compact comment input");
+    }
+    setInputValue(input, "A growing multiline comment ".repeat(20));
+    act(() => input.dispatchEvent(new Event("scroll")));
+
+    expect(
+      document
+        .querySelector('[data-testid="assistant-selection-comment-editor"]')
+        ?.getAttribute("data-editor-mode"),
+    ).toBe("create");
+    const compactPanel = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-comment-editor"] > div',
+    );
+    if (!compactPanel) {
+      throw new Error("Expected growing compact editor panel");
+    }
+    expect(Number.parseFloat(window.getComputedStyle(compactPanel).borderRadius)).toBe(24);
+  });
+
+  it("centers the create editor when its selected text scrolls out of view", async () => {
+    const mounted = mountSurface(() => undefined);
+    const selected = mounted.container.querySelector("strong");
+    if (!selected) throw new Error("Expected selectable assistant text");
+
+    selectContents(selected);
+    act(() => selected.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })));
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-button"]')
+        ?.click(),
+    );
+    const selectedLine = selected.parentElement;
+    if (!selectedLine) throw new Error("Expected selected text line");
+    selectedLine.style.transform = "translateY(1000px)";
+    act(() => document.dispatchEvent(new Event("scroll", { bubbles: true })));
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    const editor = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-comment-editor"]',
+    );
+    expect(editor).not.toBeNull();
+    expect(editor?.dataset.editorPlacement).toBe("centered");
+  });
+
+  it("keeps numbered annotation markers beside saved selections", async () => {
+    const openedAnnotations: SelectedTextComposerAttachment[] = [];
+    mountSurface(() => undefined, undefined, {
+      onOpenAnnotation: (annotation) => openedAnnotations.push(annotation),
+      selectedTextAnnotations: [
+        {
+          kind: "selected_text",
+          id: "selected-text-1",
+          text: "**this invariant**",
+          sourceMessageId: "assistant-1",
+          comment: "First comment",
+        },
+        {
+          kind: "selected_text",
+          id: "selected-text-2",
+          text: "**this invariant**",
+          sourceMessageId: "assistant-1",
+          comment: "Second comment",
+        },
+      ],
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    const markers = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-testid^="assistant-selection-annotation-marker-"]',
+      ),
+    );
+    expect(markers).toHaveLength(2);
+    expect(markers.map((marker) => marker.textContent)).toEqual(["1", "2"]);
+
+    const secondMarker = markers[1];
+    if (!secondMarker) throw new Error("Expected second annotation marker");
+    const hitTarget = getPointerHitTarget(secondMarker);
+    expect(secondMarker.contains(hitTarget)).toBe(true);
+    await act(async () => (hitTarget as HTMLElement | null)?.click());
+    expect(openedAnnotations.map((annotation) => annotation.id)).toEqual(["selected-text-2"]);
+  });
+
+  it("refreshes a marker's annotation payload after editing its comment", async () => {
+    const openedAnnotations: SelectedTextComposerAttachment[] = [];
+    const initial: SelectedTextComposerAttachment = {
+      kind: "selected_text",
+      id: "selected-text-edited-marker",
+      text: "**this invariant**",
+      sourceMessageId: "assistant-1",
+      comment: "Original comment",
+    };
+    const mounted = mountSurface(() => undefined, undefined, {
+      onOpenAnnotation: (annotation) => openedAnnotations.push(annotation),
+      selectedTextAnnotations: [initial],
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    mounted.rerender({
+      onOpenAnnotation: (annotation) => openedAnnotations.push(annotation),
+      selectedTextAnnotations: [{ ...initial, comment: "Edited comment" }],
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+    act(() =>
+      document
+        .querySelector<HTMLElement>(
+          '[data-testid="assistant-selection-annotation-marker-selected-text-edited-marker"]',
+        )
+        ?.click(),
+    );
+
+    expect(openedAnnotations.at(-1)?.comment).toBe("Edited comment");
+  });
+
+  it("locates more than six markers and highlights a multiline Markdown annotation", async () => {
+    const openedAnnotations: SelectedTextComposerAttachment[] = [];
+    const repeatedAnnotations: SelectedTextComposerAttachment[] = Array.from(
+      { length: 6 },
+      (_, index) => ({
+        kind: "selected_text",
+        id: `selected-text-${index + 1}`,
+        text: "**this invariant**",
+        sourceMessageId: "assistant-1",
+      }),
+    );
+    mountSurface(() => undefined, undefined, {
+      onOpenAnnotation: (annotation) => openedAnnotations.push(annotation),
+      selectedTextAnnotations: [
+        ...repeatedAnnotations,
+        {
+          kind: "selected_text",
+          id: "selected-text-7",
+          text: "Review checklist:\n\n- **first item**",
+          sourceMessageId: "assistant-1",
+        },
+        {
+          kind: "selected_text",
+          id: "selected-text-8",
+          text: "**first item**\n\n- second item",
+          sourceMessageId: "assistant-1",
+        },
+      ],
+      selectedTextAnnotationToEdit: {
+        id: "selected-text-8",
+        text: "**first item**\n\n- second item",
+        sourceMessageId: "assistant-1",
+      },
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    const markers = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-testid^="assistant-selection-annotation-marker-"]',
+      ),
+    );
+    expect(markers).toHaveLength(8);
+    expect(markers.map((marker) => marker.textContent)).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+    ]);
+    await act(async () => markers[7]?.click());
+    expect(openedAnnotations.map((annotation) => annotation.id)).toEqual(["selected-text-8"]);
+    expect(
+      document.querySelectorAll('[data-testid="assistant-selection-annotation-highlight"]'),
+    ).toHaveLength(2);
+  });
+
+  it("does not render annotation portals while its pane is hidden", async () => {
+    mountSurface(() => undefined, undefined, {
+      visible: false,
+      selectedTextAnnotations: [
+        {
+          kind: "selected_text",
+          id: "selected-text-hidden",
+          text: "**this invariant**",
+          sourceMessageId: "assistant-1",
+          comment: "Hidden comment",
+        },
+      ],
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    expect(
+      document.querySelectorAll('[data-testid^="assistant-selection-annotation-marker-"]'),
+    ).toHaveLength(0);
+    expect(document.querySelector('[data-testid="assistant-selection-comment-editor"]')).toBeNull();
+  });
+
+  it("keeps annotation markers in the content plane below every global overlay", async () => {
+    mountSurface(() => undefined, undefined, {
+      selectedTextAnnotations: [
+        {
+          kind: "selected_text",
+          id: "selected-text-layered",
+          text: "**this invariant**",
+          sourceMessageId: "assistant-1",
+          comment: "Layered comment",
+        },
+      ],
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    const adornmentRoot = document.getElementById("content-adornment-root");
+    const marker = document.querySelector(
+      '[data-testid^="assistant-selection-annotation-marker-"]',
+    );
+    expect(adornmentRoot?.contains(marker)).toBe(true);
+    expect(Number(adornmentRoot?.style.zIndex)).toBe(WEB_SURFACE_PLANE.contentAdornment);
+    expect(WEB_SURFACE_PLANE.contentAdornment).toBeLessThan(Number(getOverlayRoot().style.zIndex));
+  });
+
+  it("hides annotation markers behind the main composer", async () => {
+    mountSurface(() => undefined, undefined, {
+      composerOcclusionTop: 0,
+      selectedTextAnnotations: [
+        {
+          kind: "selected_text",
+          id: "selected-text-occluded",
+          text: "**this invariant**",
+          sourceMessageId: "assistant-1",
+          comment: "Occluded comment",
+        },
+      ],
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    expect(
+      document.querySelectorAll('[data-testid^="assistant-selection-annotation-marker-"]'),
+    ).toHaveLength(0);
+  });
+
+  it("keeps markers and highlights within the chat viewport top boundary", async () => {
+    const annotation: SelectedTextComposerAttachment = {
+      kind: "selected_text",
+      id: "selected-text-top-boundary",
+      text: "**this invariant**",
+      sourceMessageId: "assistant-1",
+      comment: "Top boundary",
+    };
+    mountSurface(() => undefined, undefined, {
+      contentViewportTop: 100,
+      selectedTextAnnotations: [annotation],
+      selectedTextAnnotationToEdit: annotation,
+      onOpenAnnotation: () => undefined,
+      onEditComment: () => undefined,
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    expect(
+      document.querySelectorAll('[data-testid^="assistant-selection-annotation-marker-"]'),
+    ).toHaveLength(0);
+    const highlights = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-testid="assistant-selection-annotation-highlight"]',
+      ),
+    );
+    expect(highlights.length).toBeGreaterThan(0);
+    expect(highlights.every((highlight) => highlight.getBoundingClientRect().top >= 100)).toBe(
+      true,
+    );
+  });
+
+  it("clips annotation highlights to the chat viewport before the composer", async () => {
+    mountSurface(() => undefined, undefined, {
+      contentViewportBottom: 10,
+      selectedTextAnnotationToEdit: {
+        id: "selected-text-highlight-before-composer",
+        text: "**this invariant**",
+        sourceMessageId: "assistant-1",
+        comment: "Clipped highlight",
+      },
+      onEditComment: () => undefined,
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    const highlights = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-testid="assistant-selection-annotation-highlight"]',
+      ),
+    );
+    expect(highlights.length).toBeGreaterThan(0);
+    expect(highlights.every((highlight) => highlight.getBoundingClientRect().bottom <= 10)).toBe(
+      true,
+    );
+  });
+
+  it("centers the edit dialog in the content area when its anchor cannot fit", async () => {
+    mountSurface(() => undefined, undefined, {
+      composerOcclusionTop: 180,
+      selectedTextAnnotationToEdit: {
+        id: "selected-text-centered-editor",
+        text: "**this invariant**",
+        sourceMessageId: "assistant-1",
+        comment: "Centered editor",
+      },
+      onEditComment: () => undefined,
+    });
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    const editor = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-comment-editor"]',
+    );
+    const composer = document.querySelector<HTMLElement>('[data-testid="composer-input-area"]');
+    expect(editor?.dataset.editorPlacement).toBe("centered");
+    expect(editor?.getBoundingClientRect().top).toBeGreaterThanOrEqual(0);
+    expect(editor?.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      composer?.getBoundingClientRect().top ?? 0,
+    );
+  });
+
+  it("highlights an existing annotation and keeps its full editor open during input scroll", async () => {
+    const edits: SelectedTextAnnotationEdit[] = [];
+    let dismissCount = 0;
+    mountSurface(
+      () => undefined,
+      () => {
+        dismissCount += 1;
+      },
+      {
+        selectedTextAnnotationToEdit: {
+          id: "selected-text-1",
+          text: "**this invariant**",
+          sourceMessageId: "assistant-1",
+          comment: "Original comment",
+        },
+        onEditComment: (edit) => edits.push(edit),
+      },
+    );
+    await act(() => new Promise((resolve) => window.requestAnimationFrame(resolve)));
+
+    const editor = document.querySelector<HTMLElement>(
+      '[data-testid="assistant-selection-comment-editor"]',
+    );
+    expect(editor?.dataset.editorMode).toBe("edit");
+    expect(
+      document.querySelector('[data-testid="assistant-selection-annotation-highlight"]'),
+    ).not.toBeNull();
+    expect(window.getSelection()?.toString()).toBe("");
+
+    const input = document.querySelector<HTMLTextAreaElement>(
+      '[data-testid="assistant-selection-comment-input"]',
+    );
+    if (!input) {
+      throw new Error("Expected edit comment input");
+    }
+    expect(input.tagName).toBe("TEXTAREA");
+    expect(input.value).toBe("Original comment");
+    act(() => {
+      input.blur();
+      document.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    expect(
+      document.querySelector('[data-testid="assistant-selection-comment-editor"]'),
+    ).not.toBeNull();
+    setInputValue(input, "A much longer revised comment ".repeat(20));
+    act(() => input.dispatchEvent(new Event("scroll")));
+
+    expect(
+      document.querySelector('[data-testid="assistant-selection-comment-editor"]'),
+    ).not.toBeNull();
+    expect(dismissCount).toBe(0);
+    act(() =>
+      document
+        .querySelector<HTMLElement>('[data-testid="assistant-selection-comment-save"]')
+        ?.click(),
+    );
+    expect(edits).toEqual([
+      {
+        attachmentId: "selected-text-1",
+        comment: "A much longer revised comment ".repeat(20).trim(),
+      },
+    ]);
+    expect(document.querySelector('[data-testid="assistant-selection-comment-editor"]')).toBeNull();
+    expect(
+      document.querySelector('[data-testid="assistant-selection-annotation-highlight"]'),
+    ).toBeNull();
+  });
+});

--- a/packages/app/src/assistant-selection-copy/surface.web.tsx
+++ b/packages/app/src/assistant-selection-copy/surface.web.tsx
@@ -1,18 +1,200 @@
-import { useCallback, type ClipboardEvent, type CSSProperties, type ReactNode } from "react";
-import { View, type StyleProp, type ViewStyle } from "react-native";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type CSSProperties,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  Pressable,
+  Text,
+  TextInput,
+  View,
+  type PressableStateCallbackType,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+import { ArrowUp, Check, X } from "lucide-react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import Svg, { Path } from "react-native-svg";
+import type { SelectedTextComposerAttachment } from "@/attachments/types";
+import { Button } from "@/components/ui/button";
+import { getContentAdornmentRoot } from "@/lib/overlay-root";
+import type { Theme } from "@/styles/theme";
+import { ICON_SIZE } from "@/styles/theme";
+import { createAssistantMarkdownParser } from "@/utils/assistant-markdown-parser";
 import { createAssistantSelectionClipboardContent } from "./content.web";
+import { MARKDOWN_COPY_IGNORE_ATTRIBUTE } from "./markup";
+import type { AssistantSelectionAnnotation, SelectedTextAnnotationEdit } from "./types";
 
 interface AssistantSelectionCopySurfaceProps {
   children: ReactNode;
   style?: StyleProp<ViewStyle>;
+  visible?: boolean;
+  onCommentSelection?: (annotation: AssistantSelectionAnnotation) => void;
+  addToCommentLabel?: string;
+  addToConversationLabel?: string;
+  commentPlaceholder?: string;
+  saveCommentLabel?: string;
+  cancelCommentLabel?: string;
+  selectedTextAnnotationToEdit?: {
+    id: string;
+    text: string;
+    sourceMessageId?: string;
+    occurrence?: number;
+    comment?: string;
+  } | null;
+  selectedTextAnnotations?: readonly SelectedTextComposerAttachment[];
+  onOpenAnnotation?: (annotation: SelectedTextComposerAttachment) => void;
+  onEditComment?: (input: SelectedTextAnnotationEdit) => void;
+  onDismissEditComment?: () => void;
 }
 
 const DISPLAY_CONTENTS: CSSProperties = { display: "contents" };
+const EDITOR_GUTTER = 16;
+const EDITOR_MAX_WIDTH = 420;
+const COMPACT_EDITOR_MAX_WIDTH = 360;
+const COMPACT_EDITOR_MIN_INPUT_HEIGHT = 44;
+const COMPACT_EDITOR_MAX_INPUT_HEIGHT = 112;
+const EDITOR_MIN_WORKING_HEIGHT = 160;
+const ANNOTATION_MARKER_Z_INDEX = 8;
+const ASSISTANT_MESSAGE_SELECTOR = '[data-testid="assistant-message"]';
+const ASSISTANT_MESSAGE_ITEM_SELECTOR = '[data-testid^="assistant-message-item:"]';
+const CHAT_SCROLL_SELECTOR = '[data-testid="agent-chat-scroll"]';
+const COMPOSER_INPUT_AREA_SELECTOR = '[data-testid="composer-input-area"]';
+const markdownParser = createAssistantMarkdownParser();
+
+interface EditorPosition {
+  left: number;
+  top: number;
+  placeBelow: boolean;
+  centered: boolean;
+}
+
+interface SelectionAction {
+  annotation: AssistantSelectionAnnotation;
+  range: Range;
+  buttonLeft: number;
+  buttonTop: number;
+  editorPosition: EditorPosition;
+}
+
+interface CommentEditorState extends EditorPosition {
+  annotation: AssistantSelectionAnnotation;
+  comment: string;
+  attachmentId?: string;
+}
+
+interface SelectionHighlightRect {
+  key: string;
+  style: CSSProperties;
+}
+
+interface AnnotationMarker {
+  annotation: SelectedTextComposerAttachment;
+  id: string;
+  left: number;
+  number: number;
+  style: CSSProperties;
+  top: number;
+}
+
+const EMPTY_SELECTED_TEXT_ANNOTATIONS: readonly SelectedTextComposerAttachment[] = [];
+
+const ThemedCheck = withUnistyles(Check);
+const ThemedX = withUnistyles(X);
+const ThemedAnnotationMarkerShape = withUnistyles(AnnotationMarkerShape);
+const iconForegroundMapping = (theme: Theme) => ({ color: theme.colors.foreground });
+const iconSaveMapping = (theme: Theme) => ({ color: theme.colors.background });
+const annotationMarkerShapeMapping = (theme: Theme) => ({
+  fill: theme.colors.palette.blue[500],
+  stroke: theme.colors.palette.white,
+});
+
+function annotationMarkerButtonStyle({
+  pressed,
+}: PressableStateCallbackType): StyleProp<ViewStyle> {
+  return [styles.annotationMarkerButton, pressed ? styles.annotationMarkerPressed : null];
+}
+
+function visibleValue<T>(visible: boolean, value: T, hiddenValue: T): T {
+  return visible ? value : hiddenValue;
+}
 
 export function AssistantSelectionCopySurface({
   children,
   style,
+  visible = true,
+  onCommentSelection,
+  addToCommentLabel = "Add to comment",
+  addToConversationLabel = "Add to conversation",
+  commentPlaceholder = "Add a comment about this selection",
+  saveCommentLabel = "Save",
+  cancelCommentLabel = "Cancel",
+  selectedTextAnnotations = EMPTY_SELECTED_TEXT_ANNOTATIONS,
+  onOpenAnnotation,
+  selectedTextAnnotationToEdit = null,
+  onEditComment,
+  onDismissEditComment,
 }: AssistantSelectionCopySurfaceProps) {
+  const [selectionAction, setSelectionAction] = useState<SelectionAction | null>(null);
+  const [commentEditor, setCommentEditor] = useState<CommentEditorState | null>(null);
+  const [isEditorFocused, setIsEditorFocused] = useState(false);
+  const [compactInputHeight, setCompactInputHeight] = useState(COMPACT_EDITOR_MIN_INPUT_HEIGHT);
+  const [selectionHighlightRects, setSelectionHighlightRects] = useState<SelectionHighlightRect[]>(
+    [],
+  );
+  const [annotationMarkers, setAnnotationMarkers] = useState<AnnotationMarker[]>([]);
+  const editorElementRef = useRef<HTMLDivElement | null>(null);
+  const commentEditorRef = useRef<CommentEditorState | null>(null);
+  const activeAnnotationRangeRef = useRef<Range | null>(null);
+  const visibleSelectedTextAnnotations = visibleValue(
+    visible,
+    selectedTextAnnotations,
+    EMPTY_SELECTED_TEXT_ANNOTATIONS,
+  );
+  const visibleOnCommentSelection = visibleValue(visible, onCommentSelection, undefined);
+  const visibleSelectedTextAnnotationToEdit = visibleValue(
+    visible,
+    selectedTextAnnotationToEdit,
+    null,
+  );
+
+  useEffect(() => {
+    commentEditorRef.current = commentEditor;
+  }, [commentEditor]);
+  useKeepEditorInsideContentViewport(commentEditor, setCommentEditor, editorElementRef);
+
+  const refreshAnnotationMarkers = useCallback(() => {
+    setAnnotationMarkers((current) => {
+      const next = getAnnotationMarkers(visibleSelectedTextAnnotations);
+      return annotationMarkersEqual(current, next) ? current : next;
+    });
+  }, [visibleSelectedTextAnnotations]);
+
+  useEffect(() => {
+    let animationFrame = 0;
+    let attemptsRemaining = 30;
+    const refreshUntilMounted = () => {
+      const markers = getAnnotationMarkers(visibleSelectedTextAnnotations);
+      setAnnotationMarkers((current) =>
+        annotationMarkersEqual(current, markers) ? current : markers,
+      );
+      if (markers.length < visibleSelectedTextAnnotations.length && attemptsRemaining > 0) {
+        attemptsRemaining -= 1;
+        animationFrame = window.requestAnimationFrame(refreshUntilMounted);
+      }
+    };
+    refreshUntilMounted();
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [visibleSelectedTextAnnotations]);
+
   const handleCopy = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
     const content = createAssistantSelectionClipboardContent(window.getSelection());
     if (!content) {
@@ -24,9 +206,1045 @@ export function AssistantSelectionCopySurface({
     event.clipboardData.setData("text/html", content.html);
   }, []);
 
+  const updateSelectionAction = useCallback(() => {
+    if (!visibleOnCommentSelection) {
+      return;
+    }
+    const selection = window.getSelection();
+    const content = createAssistantSelectionClipboardContent(selection);
+    if (!content || !selection || selection.rangeCount !== 1) {
+      setSelectionAction(null);
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+    const message = closestAssistantMessage(range);
+    if (!message || (rect.width === 0 && rect.height === 0)) {
+      setSelectionAction(null);
+      return;
+    }
+    const sourceMessageId = getAssistantMessageId(message);
+    const occurrence = getRangeTextOccurrence(message, content.plainText, range);
+    setCommentEditor(null);
+    setSelectionAction({
+      annotation: {
+        text: content.plainText,
+        ...(sourceMessageId ? { sourceMessageId } : {}),
+        ...(occurrence != null ? { occurrence } : {}),
+        comment: "",
+      },
+      range: range.cloneRange(),
+      editorPosition: getEditorPosition(rect, COMPACT_EDITOR_MAX_WIDTH),
+      ...getSelectionButtonPosition(rect),
+    });
+  }, [visibleOnCommentSelection]);
+
+  useEffect(() => {
+    if (!visibleOnCommentSelection && visibleSelectedTextAnnotations.length === 0) {
+      return;
+    }
+    const clearSelectionAction = () => {
+      setSelectionAction(null);
+    };
+    const hideSelectionActionWhenSelectionClears = () => {
+      if (commentEditorRef.current) {
+        return;
+      }
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) {
+        clearSelectionAction();
+      }
+    };
+    const updateAnchoredSurface = (event?: Event) => {
+      clearSelectionAction();
+      if (event?.target instanceof Node && editorElementRef.current?.contains(event.target)) {
+        return;
+      }
+      refreshAnnotationMarkers();
+      const range = activeAnnotationRangeRef.current;
+      const editor = commentEditorRef.current;
+      if (!range || !editor) {
+        return;
+      }
+      const rect = range.getBoundingClientRect();
+      setSelectionHighlightRects(editor.attachmentId ? getSelectionHighlightRects(range) : []);
+      setCommentEditor((current) =>
+        current
+          ? {
+              ...current,
+              ...getEditorPosition(
+                rect,
+                current.attachmentId ? EDITOR_MAX_WIDTH : COMPACT_EDITOR_MAX_WIDTH,
+              ),
+            }
+          : current,
+      );
+    };
+    document.addEventListener("scroll", updateAnchoredSurface, true);
+    document.addEventListener("selectionchange", hideSelectionActionWhenSelectionClears);
+    window.addEventListener("resize", updateAnchoredSurface);
+    const composerResizeObserver = new ResizeObserver(refreshAnnotationMarkers);
+    for (const composer of document.querySelectorAll(COMPOSER_INPUT_AREA_SELECTOR)) {
+      composerResizeObserver.observe(composer);
+    }
+    return () => {
+      document.removeEventListener("scroll", updateAnchoredSurface, true);
+      document.removeEventListener("selectionchange", hideSelectionActionWhenSelectionClears);
+      window.removeEventListener("resize", updateAnchoredSurface);
+      composerResizeObserver.disconnect();
+    };
+  }, [refreshAnnotationMarkers, visibleOnCommentSelection, visibleSelectedTextAnnotations.length]);
+
+  const handleEditorMouseDown = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+  }, []);
+  const handleSelectionButtonMouseDown = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  }, []);
+  const handleCommentChange = useCallback((comment: string) => {
+    setCommentEditor((current) => (current ? { ...current, comment } : current));
+  }, []);
+  const handleCompactContentSizeChange = useCallback(
+    (event: { nativeEvent: { contentSize: { height: number } } }) => {
+      setCompactInputHeight(
+        Math.min(
+          COMPACT_EDITOR_MAX_INPUT_HEIGHT,
+          Math.max(COMPACT_EDITOR_MIN_INPUT_HEIGHT, event.nativeEvent.contentSize.height),
+        ),
+      );
+    },
+    [],
+  );
+  const dismissCommentEditor = useCallback(() => {
+    setCommentEditor(null);
+    setIsEditorFocused(false);
+    setSelectionHighlightRects([]);
+    activeAnnotationRangeRef.current = null;
+    onDismissEditComment?.();
+  }, [onDismissEditComment]);
+  useDismissEditorOnOutsideInteraction(commentEditor, editorElementRef, dismissCommentEditor);
+
+  useEffect(() => {
+    if (visible) return;
+    setSelectionAction(null);
+    setAnnotationMarkers([]);
+    dismissCommentEditor();
+  }, [dismissCommentEditor, visible]);
+  const handleCancelComment = useCallback(() => dismissCommentEditor(), [dismissCommentEditor]);
+  const handleEditorFocus = useCallback(() => setIsEditorFocused(true), []);
+  const handleEditorBlur = useCallback(() => setIsEditorFocused(false), []);
+  const handleOpenCommentEditor = useCallback(() => {
+    if (!selectionAction || !onCommentSelection) {
+      return;
+    }
+    setCommentEditor({
+      annotation: selectionAction.annotation,
+      ...selectionAction.editorPosition,
+      comment: "",
+    });
+    activeAnnotationRangeRef.current = selectionAction.range;
+    setCompactInputHeight(COMPACT_EDITOR_MIN_INPUT_HEIGHT);
+    setSelectionAction(null);
+  }, [onCommentSelection, selectionAction]);
+
+  const handleSaveComment = useCallback(() => {
+    if (!commentEditor) {
+      return;
+    }
+    const comment = commentEditor.comment.trim();
+    if (commentEditor.attachmentId && onEditComment) {
+      onEditComment({ attachmentId: commentEditor.attachmentId, comment });
+    } else if (onCommentSelection) {
+      onCommentSelection({ ...commentEditor.annotation, comment });
+    } else {
+      return;
+    }
+    window.getSelection()?.removeAllRanges();
+    setCommentEditor(null);
+    setSelectionHighlightRects([]);
+    activeAnnotationRangeRef.current = null;
+  }, [commentEditor, onCommentSelection, onEditComment]);
+
+  useEffect(() => {
+    if (!visibleSelectedTextAnnotationToEdit) {
+      activeAnnotationRangeRef.current = null;
+      setSelectionHighlightRects([]);
+      setCommentEditor(closeEditCommentEditor);
+      return;
+    }
+    let animationFrame = 0;
+    let attemptsRemaining = 20;
+    const openAnnotationEditor = () => {
+      const message = findMessageForAnnotation(visibleSelectedTextAnnotationToEdit);
+      const range = message
+        ? findTextRange(
+            message,
+            visibleSelectedTextAnnotationToEdit.text,
+            visibleSelectedTextAnnotationToEdit.occurrence,
+          )
+        : null;
+      if (!range && attemptsRemaining > 0) {
+        attemptsRemaining -= 1;
+        animationFrame = window.requestAnimationFrame(openAnnotationEditor);
+        return;
+      }
+      activeAnnotationRangeRef.current = range;
+      setSelectionHighlightRects(range ? getSelectionHighlightRects(range) : []);
+      setCommentEditor({
+        annotation: {
+          text: visibleSelectedTextAnnotationToEdit.text,
+          ...(visibleSelectedTextAnnotationToEdit.sourceMessageId
+            ? { sourceMessageId: visibleSelectedTextAnnotationToEdit.sourceMessageId }
+            : {}),
+          ...(visibleSelectedTextAnnotationToEdit.occurrence != null
+            ? { occurrence: visibleSelectedTextAnnotationToEdit.occurrence }
+            : {}),
+          comment: visibleSelectedTextAnnotationToEdit.comment ?? "",
+        },
+        attachmentId: visibleSelectedTextAnnotationToEdit.id,
+        comment: visibleSelectedTextAnnotationToEdit.comment ?? "",
+        ...getEditorPosition(range?.getBoundingClientRect() ?? null),
+      });
+      setSelectionAction(null);
+    };
+    openAnnotationEditor();
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [visibleSelectedTextAnnotationToEdit]);
+
+  const selectionButtonPositionStyle = useMemo<CSSProperties | undefined>(() => {
+    if (!selectionAction) {
+      return undefined;
+    }
+    return {
+      position: "fixed",
+      zIndex: 1000,
+      pointerEvents: "auto",
+      left: selectionAction.buttonLeft,
+      top: selectionAction.buttonTop,
+      transform: "translateY(-50%)",
+    };
+  }, [selectionAction]);
+
+  const commentEditorPositionStyle = useMemo<CSSProperties | undefined>(() => {
+    if (!commentEditor) {
+      return undefined;
+    }
+    let transform = "translate(-50%, -100%)";
+    if (commentEditor.centered) {
+      transform = "translate(-50%, -50%)";
+    } else if (commentEditor.placeBelow) {
+      transform = "translate(-50%, 0)";
+    }
+    return {
+      position: "fixed",
+      zIndex: 1001,
+      left: commentEditor.left,
+      top: commentEditor.top,
+      transform,
+    };
+  }, [commentEditor]);
+  const editorContainerStyle = useMemo<CSSProperties | undefined>(() => {
+    if (!commentEditorPositionStyle || !commentEditor) {
+      return undefined;
+    }
+    let availableHeight = commentEditor.top - EDITOR_GUTTER;
+    if (commentEditor.centered) {
+      const viewport = getContentViewportBounds();
+      availableHeight = viewport.bottom - viewport.top - EDITOR_GUTTER * 2;
+    } else if (commentEditor.placeBelow) {
+      availableHeight = getContentViewportBounds().bottom - commentEditor.top - EDITOR_GUTTER;
+    }
+    return {
+      ...commentEditorPositionStyle,
+      pointerEvents: "auto",
+      width: `min(${commentEditor.attachmentId ? EDITOR_MAX_WIDTH : COMPACT_EDITOR_MAX_WIDTH}px, calc(100vw - ${EDITOR_GUTTER * 2}px))`,
+      maxWidth: `calc(100vw - ${EDITOR_GUTTER * 2}px)`,
+      maxHeight: Math.max(96, availableHeight),
+      boxSizing: "border-box",
+      overflow: "auto",
+    };
+  }, [commentEditor, commentEditorPositionStyle]);
+
+  const editor =
+    commentEditor && (onCommentSelection || onEditComment)
+      ? createPortal(
+          <div
+            ref={editorElementRef}
+            data-testid="assistant-selection-comment-editor"
+            data-editor-mode={commentEditor.attachmentId ? "edit" : "create"}
+            data-editor-placement={commentEditor.centered ? "centered" : "anchored"}
+            onMouseDown={handleEditorMouseDown}
+            style={editorContainerStyle}
+          >
+            {commentEditor.attachmentId ? (
+              <View style={[styles.editor, isEditorFocused && styles.editorFocused]}>
+                <View style={styles.editorHeader}>
+                  <Text style={styles.editorTitle}>{addToConversationLabel}</Text>
+                </View>
+                <TextInput
+                  testID="assistant-selection-comment-input"
+                  autoFocus
+                  multiline
+                  value={commentEditor.comment}
+                  onChangeText={handleCommentChange}
+                  onFocus={handleEditorFocus}
+                  onBlur={handleEditorBlur}
+                  placeholder={commentPlaceholder}
+                  style={styles.editorInput}
+                />
+                <View style={styles.editorFooter}>
+                  <Pressable
+                    testID="assistant-selection-comment-cancel"
+                    accessibilityRole="button"
+                    accessibilityLabel={cancelCommentLabel}
+                    onPress={handleCancelComment}
+                    style={styles.editorCancel}
+                  >
+                    <ThemedX size={ICON_SIZE.sm} uniProps={iconForegroundMapping} />
+                    <Text style={styles.editorCancelText}>{cancelCommentLabel}</Text>
+                  </Pressable>
+                  <Pressable
+                    testID="assistant-selection-comment-save"
+                    accessibilityRole="button"
+                    accessibilityLabel={saveCommentLabel}
+                    onPress={handleSaveComment}
+                    style={styles.editorSave}
+                  >
+                    <ThemedCheck size={ICON_SIZE.sm} uniProps={iconSaveMapping} />
+                    <Text style={styles.editorSaveText}>{saveCommentLabel}</Text>
+                  </Pressable>
+                </View>
+              </View>
+            ) : (
+              <View style={[styles.compactEditor, isEditorFocused && styles.compactEditorFocused]}>
+                <TextInput
+                  testID="assistant-selection-comment-input"
+                  autoFocus
+                  multiline
+                  value={commentEditor.comment}
+                  onChangeText={handleCommentChange}
+                  onContentSizeChange={handleCompactContentSizeChange}
+                  onFocus={handleEditorFocus}
+                  onBlur={handleEditorBlur}
+                  placeholder={commentPlaceholder}
+                  style={[styles.compactEditorInput, { height: compactInputHeight }]}
+                />
+                <Button
+                  testID="assistant-selection-comment-save"
+                  accessibilityLabel={saveCommentLabel}
+                  variant="secondary"
+                  size="md"
+                  leftIcon={ArrowUp}
+                  onPress={handleSaveComment}
+                  style={styles.compactEditorSave}
+                />
+              </View>
+            )}
+          </div>,
+          getContentAdornmentRoot(),
+        )
+      : null;
+
+  const selectionHighlight = renderSelectionHighlight(commentEditor, selectionHighlightRects);
+
+  const annotationMarkerPortal =
+    annotationMarkers.length > 0
+      ? createPortal(
+          <>
+            {annotationMarkers.map((marker) => (
+              <AnnotationMarkerButton
+                key={marker.id}
+                marker={marker}
+                onOpenAnnotation={onOpenAnnotation}
+              />
+            ))}
+          </>,
+          getContentAdornmentRoot(),
+        )
+      : null;
+
+  const selectionButton =
+    selectionAction && onCommentSelection
+      ? createPortal(
+          <div onMouseDown={handleSelectionButtonMouseDown} style={selectionButtonPositionStyle}>
+            <Pressable
+              testID="assistant-selection-comment-button"
+              accessibilityRole="button"
+              accessibilityLabel={addToCommentLabel}
+              onPress={handleOpenCommentEditor}
+              style={styles.selectionButton}
+            >
+              <Text style={styles.selectionButtonText}>{addToCommentLabel}</Text>
+            </Pressable>
+          </div>,
+          getContentAdornmentRoot(),
+        )
+      : null;
+
   return (
-    <div onCopy={handleCopy} style={DISPLAY_CONTENTS}>
+    <div
+      onCopy={handleCopy}
+      onPointerUp={visibleValue(visible, updateSelectionAction, undefined)}
+      onKeyUp={visibleValue(visible, updateSelectionAction, undefined)}
+      style={DISPLAY_CONTENTS}
+    >
       <View style={style}>{children}</View>
+      {visibleValue(visible, selectionHighlight, null)}
+      {visibleValue(visible, annotationMarkerPortal, null)}
+      {visibleValue(visible, selectionButton, null)}
+      {visibleValue(visible, editor, null)}
     </div>
   );
 }
+
+function closeEditCommentEditor(current: CommentEditorState | null): CommentEditorState | null {
+  return current?.attachmentId ? null : current;
+}
+
+function useKeepEditorInsideContentViewport(
+  commentEditor: CommentEditorState | null,
+  setCommentEditor: React.Dispatch<React.SetStateAction<CommentEditorState | null>>,
+  editorElementRef: React.RefObject<HTMLDivElement | null>,
+): void {
+  useLayoutEffect(() => {
+    if (!commentEditor || commentEditor.centered) return;
+    const editor = editorElementRef.current;
+    if (!editor || !isOutsideContentViewport(editor.getBoundingClientRect())) return;
+
+    const maxWidth = commentEditor.attachmentId ? EDITOR_MAX_WIDTH : COMPACT_EDITOR_MAX_WIDTH;
+    setCommentEditor((current) =>
+      current && !current.centered
+        ? { ...current, ...getCenteredEditorPosition(maxWidth) }
+        : current,
+    );
+  }, [commentEditor, editorElementRef, setCommentEditor]);
+}
+
+function useDismissEditorOnOutsideInteraction(
+  commentEditor: CommentEditorState | null,
+  editorElementRef: React.RefObject<HTMLDivElement | null>,
+  dismissCommentEditor: () => void,
+): void {
+  useEffect(() => {
+    if (!commentEditor) return;
+    const dismissForOutsideTarget = (event: Event) => {
+      if (event.target instanceof Node && !editorElementRef.current?.contains(event.target)) {
+        dismissCommentEditor();
+      }
+    };
+    document.addEventListener("pointerdown", dismissForOutsideTarget, true);
+    document.addEventListener("focusin", dismissForOutsideTarget, true);
+    return () => {
+      document.removeEventListener("pointerdown", dismissForOutsideTarget, true);
+      document.removeEventListener("focusin", dismissForOutsideTarget, true);
+    };
+  }, [commentEditor, dismissCommentEditor, editorElementRef]);
+}
+
+function renderSelectionHighlight(
+  commentEditor: CommentEditorState | null,
+  rects: SelectionHighlightRect[],
+): ReactNode {
+  if (!commentEditor?.attachmentId || rects.length === 0) return null;
+  return createPortal(
+    <>
+      {rects.map((rect) => (
+        <div
+          key={rect.key}
+          data-testid="assistant-selection-annotation-highlight"
+          style={rect.style}
+        >
+          <View style={styles.annotationHighlight} />
+        </div>
+      ))}
+    </>,
+    getContentAdornmentRoot(),
+  );
+}
+
+function getEditorPosition(rect: DOMRect | null, maxWidth = EDITOR_MAX_WIDTH): EditorPosition {
+  const viewportWidth = window.innerWidth;
+  const contentViewport = getContentViewportBounds();
+  const editorWidth = Math.min(maxWidth, Math.max(240, viewportWidth - EDITOR_GUTTER * 2));
+  const anchorX = rect ? rect.left + rect.width / 2 : viewportWidth / 2;
+  const left = Math.min(
+    viewportWidth - EDITOR_GUTTER - editorWidth / 2,
+    Math.max(EDITOR_GUTTER + editorWidth / 2, anchorX),
+  );
+  if (!rect) {
+    return getCenteredEditorPosition(maxWidth);
+  }
+
+  const spaceAbove = rect.top - contentViewport.top - EDITOR_GUTTER - 12;
+  const spaceBelow = contentViewport.bottom - rect.bottom - EDITOR_GUTTER - 12;
+  if (
+    rect.bottom <= contentViewport.top + EDITOR_GUTTER ||
+    rect.top >= contentViewport.bottom - EDITOR_GUTTER ||
+    Math.max(spaceAbove, spaceBelow) < EDITOR_MIN_WORKING_HEIGHT
+  ) {
+    return getCenteredEditorPosition(maxWidth);
+  }
+  const placeBelow = spaceBelow >= EDITOR_MIN_WORKING_HEIGHT || spaceBelow >= spaceAbove;
+  if (placeBelow) {
+    return { left, top: rect.bottom + 12, placeBelow: true, centered: false };
+  }
+  return { left, top: rect.top - 12, placeBelow: false, centered: false };
+}
+
+function getCenteredEditorPosition(maxWidth: number): EditorPosition {
+  const viewportWidth = window.innerWidth;
+  const editorWidth = Math.min(maxWidth, Math.max(240, viewportWidth - EDITOR_GUTTER * 2));
+  const left = Math.min(
+    viewportWidth - EDITOR_GUTTER - editorWidth / 2,
+    Math.max(EDITOR_GUTTER + editorWidth / 2, viewportWidth / 2),
+  );
+  return {
+    left,
+    top: (getContentViewportBounds().top + getContentViewportBounds().bottom) / 2,
+    placeBelow: true,
+    centered: true,
+  };
+}
+
+function getContentViewportBounds(): { top: number; bottom: number } {
+  const chatRect = getVisibleChatScrollRect();
+  return {
+    top: Math.max(0, chatRect?.top ?? 0),
+    bottom: Math.min(
+      window.innerHeight,
+      chatRect?.bottom ?? window.innerHeight,
+      getVisibleComposerInputRect()?.top ?? window.innerHeight,
+    ),
+  };
+}
+
+function isOutsideContentViewport(rect: DOMRect): boolean {
+  const viewport = getContentViewportBounds();
+  return (
+    rect.left < EDITOR_GUTTER ||
+    rect.right > window.innerWidth - EDITOR_GUTTER ||
+    rect.top < viewport.top + EDITOR_GUTTER ||
+    rect.bottom > viewport.bottom - EDITOR_GUTTER
+  );
+}
+
+function getSelectionButtonPosition(
+  rect: DOMRect,
+): Pick<SelectionAction, "buttonLeft" | "buttonTop"> {
+  const buttonWidth = 116;
+  const rightCandidate = rect.right + 8;
+  const left =
+    rightCandidate + buttonWidth <= window.innerWidth - EDITOR_GUTTER
+      ? rightCandidate
+      : Math.max(EDITOR_GUTTER, rect.left - buttonWidth - 8);
+  return {
+    buttonLeft: left,
+    buttonTop: rect.top + rect.height / 2,
+  };
+}
+
+function closestAssistantMessage(range: Range): Element | null {
+  const start =
+    range.startContainer instanceof Element
+      ? range.startContainer
+      : range.startContainer.parentElement;
+  const end =
+    range.endContainer instanceof Element ? range.endContainer : range.endContainer.parentElement;
+  const startMessage = start?.closest(ASSISTANT_MESSAGE_SELECTOR) ?? null;
+  const endMessage = end?.closest(ASSISTANT_MESSAGE_SELECTOR) ?? null;
+  return startMessage && startMessage === endMessage ? startMessage : null;
+}
+
+function getAssistantMessageId(message: Element): string | null {
+  const item = message.closest<HTMLElement>(ASSISTANT_MESSAGE_ITEM_SELECTOR);
+  const testId = item?.dataset.testid;
+  const prefix = "assistant-message-item:";
+  return testId?.startsWith(prefix) ? testId.slice(prefix.length) : null;
+}
+
+function findMessageForAnnotation(annotation: {
+  text: string;
+  sourceMessageId?: string;
+  occurrence?: number;
+}): Element | null {
+  const items = Array.from(document.querySelectorAll<HTMLElement>(ASSISTANT_MESSAGE_ITEM_SELECTOR));
+  if (annotation.sourceMessageId) {
+    const source = items.find(
+      (item) => item.dataset.testid === `assistant-message-item:${annotation.sourceMessageId}`,
+    );
+    if (source) {
+      return source.querySelector(ASSISTANT_MESSAGE_SELECTOR);
+    }
+  }
+  return (
+    items
+      .map((item) => item.querySelector(ASSISTANT_MESSAGE_SELECTOR))
+      .find(
+        (message) => message && findTextRange(message, annotation.text, annotation.occurrence),
+      ) ?? null
+  );
+}
+
+function findTextRange(root: Element, text: string, occurrence = 0): Range | null {
+  const searchText = markdownSelectionText(text);
+  if (!searchText) {
+    return null;
+  }
+  const searchable = searchableTextNodes(root);
+  const start = findTextOccurrenceStart(searchable.text, searchText, occurrence);
+  if (start < 0) {
+    return null;
+  }
+  const startPoint = searchable.points[start];
+  const endPoint = searchable.points[start + searchText.length - 1];
+  if (!startPoint || !endPoint) {
+    return null;
+  }
+  const range = document.createRange();
+  range.setStart(startPoint.node, startPoint.offset);
+  range.setEnd(endPoint.node, endPoint.offset + 1);
+  return range;
+}
+
+function getRangeTextOccurrence(root: Element, text: string, selectedRange: Range): number | null {
+  const searchText = markdownSelectionText(text);
+  if (!searchText) return null;
+  const searchable = searchableTextNodes(root);
+  const selectedStart = searchable.points.findIndex(
+    (point) => selectedRange.comparePoint(point.node, point.offset) === 0,
+  );
+  if (selectedStart < 0) return null;
+
+  let occurrence = 0;
+  let start = findTextOccurrenceStart(searchable.text, searchText, occurrence);
+  while (start >= 0) {
+    if (selectedStart === start) return occurrence;
+    occurrence += 1;
+    start = findTextOccurrenceStart(searchable.text, searchText, occurrence);
+  }
+  return null;
+}
+
+function findTextOccurrenceStart(text: string, searchText: string, occurrence: number): number {
+  let start = -1;
+  let fromIndex = 0;
+  for (let index = 0; index <= occurrence; index += 1) {
+    start = text.indexOf(searchText, fromIndex);
+    if (start < 0) return -1;
+    fromIndex = start + 1;
+  }
+  return start;
+}
+
+interface TextPoint {
+  node: Node;
+  offset: number;
+}
+
+function markdownSelectionText(markdown: string): string {
+  const container = document.createElement("div");
+  container.innerHTML = markdownParser.render(markdown);
+  return normalizeSearchText(container.textContent ?? "");
+}
+
+function normalizeSearchText(text: string): string {
+  return text.replace(/\s/g, "");
+}
+
+function searchableTextNodes(root: Element): { text: string; points: TextPoint[] } {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const points: TextPoint[] = [];
+  let text = "";
+  let node = walker.nextNode();
+  while (node) {
+    const isIgnored = node.parentElement?.closest(`[${MARKDOWN_COPY_IGNORE_ATTRIBUTE}]`);
+    if (!isIgnored) {
+      const content = node.textContent ?? "";
+      for (let offset = 0; offset < content.length; offset += 1) {
+        const character = content[offset];
+        if (character && !/\s/.test(character)) {
+          text += character;
+          points.push({ node, offset });
+        }
+      }
+    }
+    node = walker.nextNode();
+  }
+  return { text, points };
+}
+
+function getSelectionHighlightRects(range: Range): SelectionHighlightRect[] {
+  const contentViewport = getRangeContentViewportRect(range);
+  const contentTop = contentViewport?.top ?? 0;
+  const contentBottom = contentViewport?.bottom ?? window.innerHeight;
+  return getTextRangeClientRects(range)
+    .filter((rect) => rect.width > 0 && rect.height > 0)
+    .flatMap((rect, index) => {
+      const top = Math.max(contentTop, rect.top);
+      const bottom = Math.min(contentBottom, rect.bottom);
+      const height = bottom - top;
+      if (height <= 0) return [];
+      return [
+        {
+          key: `${index}:${rect.left}:${top}:${rect.width}:${height}`,
+          style: {
+            position: "fixed" as const,
+            zIndex: 999,
+            pointerEvents: "none" as const,
+            height,
+            left: rect.left,
+            top,
+            width: rect.width,
+          },
+        },
+      ];
+    });
+}
+
+function getRangeContentViewportRect(range: Range): DOMRect | null {
+  return (
+    closestAssistantMessage(range)?.closest(CHAT_SCROLL_SELECTOR)?.getBoundingClientRect() ?? null
+  );
+}
+
+function getTextRangeClientRects(range: Range): DOMRect[] {
+  const commonAncestor = range.commonAncestorContainer;
+  const textNodes: Node[] = [];
+  if (commonAncestor.nodeType === Node.TEXT_NODE) {
+    textNodes.push(commonAncestor);
+  } else {
+    const walker = document.createTreeWalker(commonAncestor, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      if (node.nodeType === Node.TEXT_NODE) textNodes.push(node);
+      node = walker.nextNode();
+    }
+  }
+
+  return textNodes.flatMap((node) => {
+    if (
+      node.parentElement?.closest(`[${MARKDOWN_COPY_IGNORE_ATTRIBUTE}]`) ||
+      !range.intersectsNode(node)
+    ) {
+      return [];
+    }
+    const start = node === range.startContainer ? range.startOffset : 0;
+    const end = node === range.endContainer ? range.endOffset : (node.textContent?.length ?? 0);
+    if (start >= end) return [];
+
+    const textRange = document.createRange();
+    textRange.setStart(node, start);
+    textRange.setEnd(node, end);
+    return Array.from(textRange.getClientRects());
+  });
+}
+
+function getAnnotationMarkers(
+  annotations: readonly SelectedTextComposerAttachment[],
+): AnnotationMarker[] {
+  const markerWidth = 26;
+  const markerHeight = 28;
+  const viewportGutter = 8;
+  const composerRect = getVisibleComposerInputRect();
+  return annotations.flatMap((annotation, index) => {
+    const message = findMessageForAnnotation(annotation);
+    const range = message ? findTextRange(message, annotation.text, annotation.occurrence) : null;
+    const rects = range ? Array.from(range.getClientRects()) : [];
+    const anchor = rects.at(-1);
+    const contentViewport = message?.closest(CHAT_SCROLL_SELECTOR)?.getBoundingClientRect() ?? null;
+    const contentTop = contentViewport?.top ?? 0;
+    const unclampedTop = anchor ? anchor.top - markerHeight + 6 : 0;
+    if (
+      !anchor ||
+      anchor.width <= 0 ||
+      anchor.height <= 0 ||
+      anchor.bottom < 0 ||
+      anchor.top > window.innerHeight ||
+      (contentViewport && unclampedTop < contentTop + viewportGutter)
+    ) {
+      return [];
+    }
+    const left = Math.min(
+      window.innerWidth - viewportGutter - markerWidth,
+      Math.max(viewportGutter, anchor.right - markerWidth / 2),
+    );
+    const top = Math.min(
+      window.innerHeight - viewportGutter - markerHeight,
+      Math.max(contentViewport ? contentTop + viewportGutter : viewportGutter, unclampedTop),
+    );
+    if (composerRect && rectanglesIntersect(left, top, markerWidth, markerHeight, composerRect)) {
+      return [];
+    }
+    return [
+      {
+        annotation,
+        id: annotation.id,
+        left,
+        number: index + 1,
+        top,
+        style: {
+          position: "fixed",
+          zIndex: ANNOTATION_MARKER_Z_INDEX,
+          pointerEvents: "auto",
+          height: markerHeight,
+          left,
+          top,
+          width: markerWidth,
+        },
+      },
+    ];
+  });
+}
+
+function getVisibleComposerInputRect(): DOMRect | null {
+  for (const element of document.querySelectorAll(COMPOSER_INPUT_AREA_SELECTOR)) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0 && rect.bottom > 0 && rect.top < window.innerHeight) {
+      return rect;
+    }
+  }
+  return null;
+}
+
+function getVisibleChatScrollRect(): DOMRect | null {
+  for (const element of document.querySelectorAll(CHAT_SCROLL_SELECTOR)) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0 && rect.bottom > 0 && rect.top < window.innerHeight) {
+      return rect;
+    }
+  }
+  return null;
+}
+
+function rectanglesIntersect(
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  obstacle: DOMRect,
+): boolean {
+  return (
+    left < obstacle.right &&
+    left + width > obstacle.left &&
+    top < obstacle.bottom &&
+    top + height > obstacle.top
+  );
+}
+
+function AnnotationMarkerButton({
+  marker,
+  onOpenAnnotation,
+}: {
+  marker: AnnotationMarker;
+  onOpenAnnotation?: (annotation: SelectedTextComposerAttachment) => void;
+}) {
+  const handlePress = useCallback(
+    () => onOpenAnnotation?.(marker.annotation),
+    [marker.annotation, onOpenAnnotation],
+  );
+  return (
+    <div style={marker.style}>
+      <Pressable
+        testID={`assistant-selection-annotation-marker-${marker.id}`}
+        accessibilityRole="button"
+        accessibilityLabel={`${marker.number}`}
+        disabled={!onOpenAnnotation}
+        onPress={handlePress}
+        style={annotationMarkerButtonStyle}
+      >
+        <ThemedAnnotationMarkerShape uniProps={annotationMarkerShapeMapping} />
+        <Text style={styles.annotationMarkerText}>{marker.number}</Text>
+      </Pressable>
+    </div>
+  );
+}
+
+function AnnotationMarkerShape({ fill, stroke }: { fill: string; stroke: string }) {
+  return (
+    <Svg width={26} height={28} viewBox="0 0 26 28" style={styles.annotationMarkerShape}>
+      <Path
+        d="M13 1.25c6.49 0 11.75 5.09 11.75 11.37S19.49 24 13 24c-1.21 0-2.38-.18-3.48-.51L4.4 26.65l1.43-4.72c-2.79-2.08-4.58-5.44-4.58-9.31C1.25 6.34 6.51 1.25 13 1.25Z"
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}
+
+function annotationMarkersEqual(left: AnnotationMarker[], right: AnnotationMarker[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (marker, index) =>
+        marker.id === right[index]?.id &&
+        marker.annotation === right[index]?.annotation &&
+        marker.number === right[index]?.number &&
+        marker.left === right[index]?.left &&
+        marker.top === right[index]?.top,
+    )
+  );
+}
+
+const styles = StyleSheet.create((theme: Theme) => ({
+  selectionButton: {
+    minHeight: 34,
+    paddingHorizontal: theme.spacing[3],
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.surface2,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    boxShadow: "0 6px 18px rgba(0, 0, 0, 0.24)",
+  },
+  selectionButtonText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+  annotationHighlight: {
+    width: "100%",
+    height: "100%",
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.palette.blue[500],
+    opacity: theme.opacity[50],
+  },
+  annotationMarkerButton: {
+    position: "relative",
+    width: 26,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    filter: "drop-shadow(0 2px 4px rgba(0, 0, 0, 0.28))",
+  },
+  annotationMarkerPressed: {
+    opacity: 0.8,
+    transform: [{ scale: 0.94 }],
+  },
+  annotationMarkerShape: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  annotationMarkerText: {
+    position: "absolute",
+    top: 4,
+    left: 0,
+    width: 26,
+    lineHeight: 16,
+    textAlign: "center",
+    color: theme.colors.palette.white,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+  },
+  compactEditor: {
+    position: "relative",
+    width: "100%",
+    minHeight: 52,
+    padding: theme.spacing[1],
+    paddingLeft: theme.spacing[4],
+    borderRadius: theme.borderRadius["3xl"],
+    backgroundColor: theme.colors.surface2,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    boxShadow: "0 10px 28px rgba(0, 0, 0, 0.32)",
+  },
+  compactEditorFocused: {
+    borderColor: theme.colors.borderAccent,
+  },
+  compactEditorInput: {
+    width: "100%",
+    minWidth: 0,
+    minHeight: COMPACT_EDITOR_MIN_INPUT_HEIGHT,
+    maxHeight: COMPACT_EDITOR_MAX_INPUT_HEIGHT,
+    backgroundColor: "transparent",
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    lineHeight: theme.fontSize.base * 1.4,
+    paddingLeft: 0,
+    paddingRight: theme.spacing[12],
+    paddingVertical: theme.spacing[2],
+    outlineWidth: 0,
+    outlineColor: "transparent",
+  },
+  compactEditorSave: {
+    position: "absolute",
+    right: theme.spacing[1],
+    bottom: theme.spacing[1],
+    width: 44,
+    height: 44,
+    paddingHorizontal: theme.spacing[0],
+    borderRadius: theme.borderRadius.full,
+  },
+  editor: {
+    width: "100%",
+    maxHeight: 300,
+    padding: theme.spacing[3],
+    borderRadius: theme.borderRadius.xl,
+    backgroundColor: theme.colors.surface2,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    boxShadow: "0 10px 28px rgba(0, 0, 0, 0.32)",
+  },
+  editorFocused: {
+    borderColor: theme.colors.borderAccent,
+  },
+  editorHeader: {
+    marginBottom: theme.spacing[2],
+  },
+  editorTitle: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    fontWeight: theme.fontWeight.medium,
+  },
+  editorInput: {
+    minHeight: 70,
+    maxHeight: 140,
+    backgroundColor: "transparent",
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    lineHeight: theme.fontSize.base * 1.4,
+    padding: 0,
+    outlineWidth: 0,
+    outlineColor: "transparent",
+  },
+  editorFooter: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: theme.spacing[2],
+    marginTop: theme.spacing[3],
+  },
+  editorCancel: {
+    minHeight: 32,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.full,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+  },
+  editorCancelText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  editorSave: {
+    minHeight: 32,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.foreground,
+  },
+  editorSaveText: {
+    color: theme.colors.background,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+  },
+}));

--- a/packages/app/src/assistant-selection-copy/types.ts
+++ b/packages/app/src/assistant-selection-copy/types.ts
@@ -1,0 +1,12 @@
+export interface AssistantSelectionAnnotation {
+  text: string;
+  sourceMessageId?: string;
+  occurrence?: number;
+  comment: string;
+  attachmentId?: string;
+}
+
+export interface SelectedTextAnnotationEdit {
+  attachmentId: string;
+  comment: string;
+}

--- a/packages/app/src/attachments/selected-text.test.ts
+++ b/packages/app/src/attachments/selected-text.test.ts
@@ -1,48 +1,96 @@
 import { describe, expect, it } from "vitest";
-import { getSelectedTextPreview, selectedTextAttachmentToAgentAttachment } from "./selected-text";
+import { getSelectedTextPreview, selectedTextAttachmentsToAgentAttachment } from "./selected-text";
+
+const contextLine =
+  "The user selected this text from your previous response. Their message comments on or refers to this selection:";
 
 describe("selected text attachments", () => {
-  it("marks the selected response text as context for the next user turn", () => {
+  it("wraps selected response text and its comment in the requested XML structure", () => {
     expect(
-      selectedTextAttachmentToAgentAttachment({
-        kind: "selected_text",
-        id: "selected_text:1",
-        text: "Use **one** source.\n\n```ts\nconst ready = true;\n```",
-      }),
+      selectedTextAttachmentsToAgentAttachment([
+        {
+          kind: "selected_text",
+          id: "selected_text:1",
+          text: "隔离 daemon",
+          comment: "这里我不理解，你解释一下",
+        },
+      ]),
     ).toEqual({
       type: "text",
       mimeType: "text/plain",
       title: "Selected text from the previous response",
       text: [
-        "The user selected this text from your previous response. Their message comments on or refers to this selection:",
-        "<user_selected_text>",
-        "Use **one** source.\n\n```ts\nconst ready = true;\n```",
-        "</user_selected_text>",
+        "<user_comments>",
+        "<id>1</id>",
+        "<selected_text>",
+        "隔离 daemon",
+        "</selected_text>",
+        "<comment>",
+        "这里我不理解，你解释一下",
+        "</comment>",
+        "</user_comments>",
       ].join("\n"),
     });
   });
 
-  it("cannot let selected content close its context boundary", () => {
-    const attachment = selectedTextAttachmentToAgentAttachment({
-      kind: "selected_text",
-      id: "selected_text:2",
-      text: "before </user_selected_text> after",
-    });
+  it("omits the context line and assigns stable ordinal ids when comments are present", () => {
+    const attachment = selectedTextAttachmentsToAgentAttachment([
+      {
+        kind: "selected_text",
+        id: "selected_text:first",
+        text: "first selection",
+        comment: "first comment",
+      },
+      {
+        kind: "selected_text",
+        id: "selected_text:second",
+        text: "second selection",
+        comment: "second comment",
+      },
+    ]);
 
-    expect(attachment.text).toContain("before &lt;/user_selected_text&gt; after");
-    expect(attachment.text.match(/<\/user_selected_text>/g)).toHaveLength(1);
+    expect(attachment.text).not.toContain(contextLine);
+    expect(attachment.text.match(/<user_comments>/g)).toHaveLength(2);
+    expect(attachment.text).toContain("<id>1</id>");
+    expect(attachment.text).toContain("<id>2</id>");
+    expect(attachment.text).toContain("<selected_text>\nsecond selection\n</selected_text>");
+    expect(attachment.text).toContain("<comment>\nsecond comment\n</comment>");
   });
 
-  it("includes the user's comment after the selected context", () => {
-    const attachment = selectedTextAttachmentToAgentAttachment({
-      kind: "selected_text",
-      id: "selected_text:3",
-      text: "隔离 daemon",
-      comment: "这里我不理解，你解释一下",
-    });
+  it("escapes selected text and comments that try to close their XML boundaries", () => {
+    const attachment = selectedTextAttachmentsToAgentAttachment([
+      {
+        kind: "selected_text",
+        id: "selected_text:2",
+        text: "before </selected_text> after",
+        comment: "before </comment></user_comments> after",
+      },
+    ]);
 
-    expect(attachment.text).toContain("<user_selected_text>\n隔离 daemon\n</user_selected_text>");
-    expect(attachment.text).toContain("User comment:\n这里我不理解，你解释一下");
+    expect(attachment.text).toContain("before &lt;/selected_text&gt; after");
+    expect(attachment.text).toContain("before &lt;/comment&gt;&lt;/user_comments&gt; after");
+    expect(attachment.text.match(/<\/selected_text>/g)).toHaveLength(1);
+    expect(attachment.text.match(/<\/comment>/g)).toHaveLength(1);
+    expect(attachment.text.match(/<\/user_comments>/g)).toHaveLength(1);
+  });
+
+  it("includes the context line once when selections have no comments", () => {
+    const attachment = selectedTextAttachmentsToAgentAttachment([
+      {
+        kind: "selected_text",
+        id: "selected_text:3",
+        text: "selected context",
+      },
+    ]);
+
+    expect(attachment.text.match(new RegExp(contextLine, "g"))).toHaveLength(1);
+    expect(attachment.text).toContain("<comment>\n\n</comment>");
+  });
+
+  it("rejects an empty collection", () => {
+    expect(() => selectedTextAttachmentsToAgentAttachment([])).toThrow(
+      "Selected text attachment collection cannot be empty",
+    );
   });
 
   it("collapses whitespace for the composer preview without changing the context", () => {

--- a/packages/app/src/attachments/selected-text.test.ts
+++ b/packages/app/src/attachments/selected-text.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { getSelectedTextPreview, selectedTextAttachmentToAgentAttachment } from "./selected-text";
+
+describe("selected text attachments", () => {
+  it("marks the selected response text as context for the next user turn", () => {
+    expect(
+      selectedTextAttachmentToAgentAttachment({
+        kind: "selected_text",
+        id: "selected_text:1",
+        text: "Use **one** source.\n\n```ts\nconst ready = true;\n```",
+      }),
+    ).toEqual({
+      type: "text",
+      mimeType: "text/plain",
+      title: "Selected text from the previous response",
+      text: [
+        "The user selected this text from your previous response. Their message comments on or refers to this selection:",
+        "<user_selected_text>",
+        "Use **one** source.\n\n```ts\nconst ready = true;\n```",
+        "</user_selected_text>",
+      ].join("\n"),
+    });
+  });
+
+  it("cannot let selected content close its context boundary", () => {
+    const attachment = selectedTextAttachmentToAgentAttachment({
+      kind: "selected_text",
+      id: "selected_text:2",
+      text: "before </user_selected_text> after",
+    });
+
+    expect(attachment.text).toContain("before &lt;/user_selected_text&gt; after");
+    expect(attachment.text.match(/<\/user_selected_text>/g)).toHaveLength(1);
+  });
+
+  it("includes the user's comment after the selected context", () => {
+    const attachment = selectedTextAttachmentToAgentAttachment({
+      kind: "selected_text",
+      id: "selected_text:3",
+      text: "隔离 daemon",
+      comment: "这里我不理解，你解释一下",
+    });
+
+    expect(attachment.text).toContain("<user_selected_text>\n隔离 daemon\n</user_selected_text>");
+    expect(attachment.text).toContain("User comment:\n这里我不理解，你解释一下");
+  });
+
+  it("collapses whitespace for the composer preview without changing the context", () => {
+    expect(getSelectedTextPreview("  first\n\n  second  ")).toBe("first second");
+  });
+});

--- a/packages/app/src/attachments/selected-text.ts
+++ b/packages/app/src/attachments/selected-text.ts
@@ -1,0 +1,28 @@
+import type { AgentAttachment } from "@getpaseo/protocol/messages";
+import type { SelectedTextComposerAttachment } from "@/attachments/types";
+
+const SELECTED_TEXT_OPEN_TAG = "<user_selected_text>";
+const SELECTED_TEXT_CLOSE_TAG = "</user_selected_text>";
+
+export function selectedTextAttachmentToAgentAttachment(
+  attachment: SelectedTextComposerAttachment,
+): Extract<AgentAttachment, { type: "text" }> {
+  const text = attachment.text.replaceAll(SELECTED_TEXT_CLOSE_TAG, "&lt;/user_selected_text&gt;");
+  const comment = attachment.comment?.trim();
+  return {
+    type: "text",
+    mimeType: "text/plain",
+    title: "Selected text from the previous response",
+    text: [
+      "The user selected this text from your previous response. Their message comments on or refers to this selection:",
+      SELECTED_TEXT_OPEN_TAG,
+      text,
+      SELECTED_TEXT_CLOSE_TAG,
+      ...(comment ? ["User comment:", comment] : []),
+    ].join("\n"),
+  };
+}
+
+export function getSelectedTextPreview(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}

--- a/packages/app/src/attachments/selected-text.ts
+++ b/packages/app/src/attachments/selected-text.ts
@@ -1,28 +1,42 @@
 import type { AgentAttachment } from "@getpaseo/protocol/messages";
 import type { SelectedTextComposerAttachment } from "@/attachments/types";
 
-const SELECTED_TEXT_OPEN_TAG = "<user_selected_text>";
-const SELECTED_TEXT_CLOSE_TAG = "</user_selected_text>";
+const SELECTED_TEXT_CONTEXT =
+  "The user selected this text from your previous response. Their message comments on or refers to this selection:";
 
-export function selectedTextAttachmentToAgentAttachment(
-  attachment: SelectedTextComposerAttachment,
+export function selectedTextAttachmentsToAgentAttachment(
+  attachments: readonly SelectedTextComposerAttachment[],
 ): Extract<AgentAttachment, { type: "text" }> {
-  const text = attachment.text.replaceAll(SELECTED_TEXT_CLOSE_TAG, "&lt;/user_selected_text&gt;");
-  const comment = attachment.comment?.trim();
+  if (attachments.length === 0) {
+    throw new Error("Selected text attachment collection cannot be empty");
+  }
+  const hasUserComment = attachments.some((attachment) => Boolean(attachment.comment?.trim()));
+
   return {
     type: "text",
     mimeType: "text/plain",
     title: "Selected text from the previous response",
     text: [
-      "The user selected this text from your previous response. Their message comments on or refers to this selection:",
-      SELECTED_TEXT_OPEN_TAG,
-      text,
-      SELECTED_TEXT_CLOSE_TAG,
-      ...(comment ? ["User comment:", comment] : []),
+      ...(hasUserComment ? [] : [SELECTED_TEXT_CONTEXT]),
+      ...attachments.flatMap((attachment, index) => [
+        "<user_comments>",
+        `<id>${index + 1}</id>`,
+        "<selected_text>",
+        escapeXmlText(attachment.text),
+        "</selected_text>",
+        "<comment>",
+        escapeXmlText(attachment.comment?.trim() ?? ""),
+        "</comment>",
+        "</user_comments>",
+      ]),
     ].join("\n"),
   };
 }
 
 export function getSelectedTextPreview(text: string): string {
   return text.replace(/\s+/g, " ").trim();
+}
+
+function escapeXmlText(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }

--- a/packages/app/src/attachments/types.ts
+++ b/packages/app/src/attachments/types.ts
@@ -103,10 +103,20 @@ export interface WorkspaceFileComposerAttachment {
   selection: WorkspaceFileSelection;
 }
 
+export interface SelectedTextComposerAttachment {
+  kind: "selected_text";
+  id: string;
+  text: string;
+  sourceMessageId?: string;
+  occurrence?: number;
+  comment?: string;
+}
+
 export type UserComposerAttachment =
   | { kind: "image"; metadata: AttachmentMetadata }
   | { kind: "file"; attachment: UploadedFileAttachment }
   | WorkspaceFileComposerAttachment
+  | SelectedTextComposerAttachment
   | PluginResourceComposerAttachment
   | { kind: "forge_issue"; item: ForgeSearchItem }
   | { kind: "forge_change_request"; item: ForgeSearchItem }

--- a/packages/app/src/components/workspace-hover-card.tsx
+++ b/packages/app/src/components/workspace-hover-card.tsx
@@ -8,6 +8,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { Dimensions, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { FadeIn, FadeOut } from "react-native-reanimated";
@@ -30,8 +31,6 @@ import type { Theme } from "@/styles/theme";
 import { DiffStat } from "@/components/diff-stat";
 import { Pressable } from "react-native";
 import type { GestureResponderEvent } from "react-native";
-import { Portal } from "@gorhom/portal";
-import { useBottomSheetModalInternal } from "@gorhom/bottom-sheet";
 import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
 import type { PrHint } from "@/git/use-pr-status-query";
 import { openExternalUrl } from "@/utils/open-external-url";
@@ -41,6 +40,7 @@ import { useHoverSafeZone } from "@/hooks/use-hover-safe-zone";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import { FloatingSurface } from "@/components/ui/floating";
 import { isWeb } from "@/constants/platform";
+import { getOverlayRoot, OverlayLayerProvider, useOverlayLayer } from "@/lib/overlay-root";
 import { useHosts } from "@/runtime/host-runtime";
 
 interface Rect {
@@ -222,7 +222,7 @@ function WorkspaceHoverCardContent({
   contentRef: React.RefObject<View | null>;
 }): ReactElement | null {
   const { t } = useTranslation();
-  const bottomSheetInternal = useBottomSheetModalInternal(true);
+  const floatingLayer = useOverlayLayer("floating");
   const [triggerRect, setTriggerRect] = useState<Rect | null>(null);
   const [contentSize, setContentSize] = useState<{ width: number; height: number } | null>(null);
   const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
@@ -274,9 +274,9 @@ function WorkspaceHoverCardContent({
     [position?.x, position?.y],
   );
 
-  return (
-    <Portal hostName={bottomSheetInternal?.hostName}>
-      <View pointerEvents="box-none" style={styles.portalOverlay}>
+  return createPortal(
+    <OverlayLayerProvider layer={floatingLayer}>
+      <View pointerEvents="box-none" style={[styles.portalOverlay, { zIndex: floatingLayer }]}>
         <FloatingSurface
           ref={contentRef}
           entering={FadeIn.duration(80)}
@@ -335,7 +335,8 @@ function WorkspaceHoverCardContent({
           ) : null}
         </FloatingSurface>
       </View>
-    </Portal>
+    </OverlayLayerProvider>,
+    getOverlayRoot(),
   );
 }
 

--- a/packages/app/src/composer/actions.ts
+++ b/packages/app/src/composer/actions.ts
@@ -324,7 +324,11 @@ export function openComposerAttachment(input: OpenComposerAttachmentInput): void
     input.setLightboxMetadata(input.attachment.metadata);
     return;
   }
-  if (input.attachment.kind === "file" || input.attachment.kind === "workspace_file") {
+  if (
+    input.attachment.kind === "file" ||
+    input.attachment.kind === "workspace_file" ||
+    input.attachment.kind === "selected_text"
+  ) {
     return;
   }
   if (isWorkspaceAttachment(input.attachment)) {

--- a/packages/app/src/composer/attachments/submit.test.ts
+++ b/packages/app/src/composer/attachments/submit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { splitComposerAttachmentsForSubmit } from "./submit";
+
+describe("selected text composer submission", () => {
+  it("sends selected assistant text as a text context attachment", () => {
+    expect(
+      splitComposerAttachmentsForSubmit([
+        {
+          kind: "selected_text",
+          id: "selected_text:1",
+          text: "Keep this invariant.",
+        },
+      ]),
+    ).toEqual({
+      images: [],
+      attachments: [
+        {
+          type: "text",
+          mimeType: "text/plain",
+          title: "Selected text from the previous response",
+          text: [
+            "The user selected this text from your previous response. Their message comments on or refers to this selection:",
+            "<user_selected_text>",
+            "Keep this invariant.",
+            "</user_selected_text>",
+          ].join("\n"),
+        },
+      ],
+    });
+  });
+});

--- a/packages/app/src/composer/attachments/submit.test.ts
+++ b/packages/app/src/composer/attachments/submit.test.ts
@@ -2,30 +2,48 @@ import { describe, expect, it } from "vitest";
 import { splitComposerAttachmentsForSubmit } from "./submit";
 
 describe("selected text composer submission", () => {
-  it("sends selected assistant text as a text context attachment", () => {
-    expect(
-      splitComposerAttachmentsForSubmit([
-        {
-          kind: "selected_text",
-          id: "selected_text:1",
-          text: "Keep this invariant.",
-        },
-      ]),
-    ).toEqual({
-      images: [],
-      attachments: [
-        {
-          type: "text",
-          mimeType: "text/plain",
-          title: "Selected text from the previous response",
-          text: [
-            "The user selected this text from your previous response. Their message comments on or refers to this selection:",
-            "<user_selected_text>",
-            "Keep this invariant.",
-            "</user_selected_text>",
-          ].join("\n"),
-        },
-      ],
+  it("sends all selected-text comments in one context attachment", () => {
+    const result = splitComposerAttachmentsForSubmit([
+      {
+        kind: "selected_text",
+        id: "selected_text:1",
+        text: "Keep this invariant.",
+        comment: "Explain why",
+      },
+      {
+        kind: "selected_text",
+        id: "selected_text:2",
+        text: "Do not retry.",
+        comment: "Is this still required?",
+      },
+    ]);
+
+    expect(result.images).toEqual([]);
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0]).toEqual({
+      type: "text",
+      mimeType: "text/plain",
+      title: "Selected text from the previous response",
+      text: [
+        "<user_comments>",
+        "<id>1</id>",
+        "<selected_text>",
+        "Keep this invariant.",
+        "</selected_text>",
+        "<comment>",
+        "Explain why",
+        "</comment>",
+        "</user_comments>",
+        "<user_comments>",
+        "<id>2</id>",
+        "<selected_text>",
+        "Do not retry.",
+        "</selected_text>",
+        "<comment>",
+        "Is this still required?",
+        "</comment>",
+        "</user_comments>",
+      ].join("\n"),
     });
   });
 });

--- a/packages/app/src/composer/attachments/submit.ts
+++ b/packages/app/src/composer/attachments/submit.ts
@@ -1,4 +1,4 @@
-import type { ComposerAttachment } from "@/attachments/types";
+import type { ComposerAttachment, SelectedTextComposerAttachment } from "@/attachments/types";
 import type { ImageAttachment } from "@/composer/types";
 import {
   isWorkspaceAttachment,
@@ -11,7 +11,7 @@ import {
 } from "@/utils/review-attachments";
 import { workspaceFileAttachmentToAgentAttachment } from "@/attachments/workspace-file";
 import { pluginResourceAttachmentToAgentAttachment } from "@/plugins/attachments";
-import { selectedTextAttachmentToAgentAttachment } from "@/attachments/selected-text";
+import { selectedTextAttachmentsToAgentAttachment } from "@/attachments/selected-text";
 
 export type ComposerAttachmentSubmitFormat = "forge" | "legacy-github";
 
@@ -35,6 +35,11 @@ export function splitComposerAttachmentsForSubmit(
 } {
   const images: ImageAttachment[] = [];
   const agentAttachments: AgentAttachment[] = [];
+  const selectedTextAttachments = attachments.filter(
+    (attachment): attachment is SelectedTextComposerAttachment =>
+      attachment.kind === "selected_text",
+  );
+  let addedSelectedTextAttachment = false;
   // COMPAT(forgeSearch): added in v0.1.106, remove github_search fallback after 2026-12-28.
   const buildSearchAttachment =
     options.format === "legacy-github"
@@ -58,7 +63,10 @@ export function splitComposerAttachmentsForSubmit(
     }
 
     if (attachment.kind === "selected_text") {
-      agentAttachments.push(selectedTextAttachmentToAgentAttachment(attachment));
+      if (!addedSelectedTextAttachment) {
+        agentAttachments.push(selectedTextAttachmentsToAgentAttachment(selectedTextAttachments));
+        addedSelectedTextAttachment = true;
+      }
       continue;
     }
 

--- a/packages/app/src/composer/attachments/submit.ts
+++ b/packages/app/src/composer/attachments/submit.ts
@@ -11,6 +11,7 @@ import {
 } from "@/utils/review-attachments";
 import { workspaceFileAttachmentToAgentAttachment } from "@/attachments/workspace-file";
 import { pluginResourceAttachmentToAgentAttachment } from "@/plugins/attachments";
+import { selectedTextAttachmentToAgentAttachment } from "@/attachments/selected-text";
 
 export type ComposerAttachmentSubmitFormat = "forge" | "legacy-github";
 
@@ -53,6 +54,11 @@ export function splitComposerAttachmentsForSubmit(
 
     if (attachment.kind === "workspace_file") {
       agentAttachments.push(workspaceFileAttachmentToAgentAttachment(attachment));
+      continue;
+    }
+
+    if (attachment.kind === "selected_text") {
+      agentAttachments.push(selectedTextAttachmentToAgentAttachment(attachment));
       continue;
     }
 

--- a/packages/app/src/composer/draft/input-draft.ts
+++ b/packages/app/src/composer/draft/input-draft.ts
@@ -60,6 +60,8 @@ export interface AgentInputDraft {
   clear: (lifecycle: "sent" | "abandoned") => void;
   isHydrated: boolean;
   attachmentFocusRequestId: number;
+  focusRequestId: number;
+  requestFocus: () => void;
   composerState: DraftComposerState | null;
 }
 
@@ -87,6 +89,7 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
   );
   const [hydratedDraftKey, setHydratedDraftKey] = useState<string | null>(null);
   const [textReplacementRevision, setTextReplacementRevision] = useState(0);
+  const [focusRequestId, setFocusRequestId] = useState(0);
   const text = draft?.text ?? "";
   const attachments = draft?.attachments ?? [];
   const isHydrated = hydratedDraftKey === draftKey;
@@ -141,6 +144,10 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     },
     [draftKey],
   );
+
+  const requestFocus = useCallback(() => {
+    setFocusRequestId((requestId) => requestId + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -284,6 +291,8 @@ export function useAgentInputDraft(input: UseAgentInputDraftInput): AgentInputDr
     clear,
     isHydrated,
     attachmentFocusRequestId,
+    focusRequestId,
+    requestFocus,
     composerState,
   };
 }

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -116,6 +116,7 @@ import { getFileTypeLabel } from "@/attachments/file-types";
 import { Combobox, ComboboxItem, type ComboboxOption } from "@/components/ui/combobox";
 import { AttachmentLabel, AttachmentPill, AttachmentThumbnail } from "@/components/attachment-pill";
 import { AttachmentLightbox } from "@/components/attachment-lightbox";
+import { SelectedTextAnnotations } from "@/composer/selected-text-annotations";
 import { openExternalUrl } from "@/utils/open-external-url";
 import { useIsDictationReady } from "@/hooks/use-is-dictation-ready";
 import { useForgeSearchQuery } from "@/git/use-forge-search-query";
@@ -320,8 +321,18 @@ function renderLeftContent(args: RenderLeftContentArgs): ReactElement | null {
 interface RenderAttachmentTrayArgs {
   selectedAttachments: ComposerAttachment[];
   isComposerLocked: boolean;
+  isPaneFocused: boolean;
   handleOpenAttachment: (attachment: ComposerAttachment) => void;
   handleRemoveAttachment: (index: number) => void;
+  handleOpenSelectedText: (
+    attachment: Extract<ComposerAttachment, { kind: "selected_text" }>,
+  ) => void;
+  handleRemoveSelectedText: (id: string) => void;
+  selectedTextLabels: {
+    count: string;
+    remove: string;
+    noComment: string;
+  };
   labels: {
     openImage: string;
     removeImage: string;
@@ -335,23 +346,45 @@ function renderAttachmentTray(args: RenderAttachmentTrayArgs): ReactElement | nu
   const {
     selectedAttachments,
     isComposerLocked,
+    isPaneFocused,
     handleOpenAttachment,
     handleRemoveAttachment,
+    handleOpenSelectedText,
+    handleRemoveSelectedText,
+    selectedTextLabels,
     labels,
   } = args;
   if (selectedAttachments.length === 0) return null;
+  const selectedTextAttachments = selectedAttachments.filter(
+    (attachment): attachment is Extract<ComposerAttachment, { kind: "selected_text" }> =>
+      attachment.kind === "selected_text",
+  );
+  const regularAttachments = selectedAttachments.filter(
+    (attachment) => attachment.kind !== "selected_text",
+  );
   return (
     <View style={styles.attachmentTray} testID="composer-attachment-tray">
-      {selectedAttachments.map((attachment, index) =>
-        renderComposerAttachmentPill({
+      {regularAttachments.map((attachment) => {
+        const index = selectedAttachments.indexOf(attachment);
+        return renderComposerAttachmentPill({
           attachment,
           index,
           disabled: isComposerLocked,
           onOpen: handleOpenAttachment,
           onRemove: handleRemoveAttachment,
           labels,
-        }),
-      )}
+        });
+      })}
+      {selectedTextAttachments.length > 0 ? (
+        <SelectedTextAnnotations
+          annotations={selectedTextAttachments}
+          disabled={isComposerLocked}
+          isPaneFocused={isPaneFocused}
+          labels={selectedTextLabels}
+          onOpen={handleOpenSelectedText}
+          onRemove={handleRemoveSelectedText}
+        />
+      ) : null}
     </View>
   );
 }
@@ -393,7 +426,7 @@ interface RenderComposerAttachmentPillArgs {
   labels: RenderAttachmentTrayArgs["labels"];
 }
 
-function renderComposerAttachmentPill(args: RenderComposerAttachmentPillArgs): ReactElement {
+function renderComposerAttachmentPill(args: RenderComposerAttachmentPillArgs): ReactElement | null {
   const { attachment, index, disabled, onOpen, onRemove, labels } = args;
   if (attachment.kind === "image") {
     return (
@@ -432,6 +465,9 @@ function renderComposerAttachmentPill(args: RenderComposerAttachmentPillArgs): R
         removeLabel={labels.removeFile}
       />
     );
+  }
+  if (attachment.kind === "selected_text") {
+    return null;
   }
   if (composerWorkspaceAttachment.is(attachment)) {
     return composerWorkspaceAttachment.renderPill({
@@ -866,6 +902,7 @@ interface ComposerProps {
   attachments: UserComposerAttachment[];
   attachmentScopeKeys?: readonly string[];
   onOpenWorkspaceAttachment?: (attachment: WorkspaceComposerAttachment) => void;
+  onOpenSelectedText?: (attachment: Extract<ComposerAttachment, { kind: "selected_text" }>) => void;
   onChangeAttachments: (updater: AttachmentListUpdater) => void;
   onGithubPrDetected?: () => void;
   onGithubPrAutoAttach?: (item: ForgeSearchItem) => void;
@@ -1075,6 +1112,7 @@ export function Composer({
   attachments,
   attachmentScopeKeys = EMPTY_ATTACHMENT_SCOPE_KEYS,
   onOpenWorkspaceAttachment,
+  onOpenSelectedText,
   onChangeAttachments,
   onGithubPrDetected,
   onGithubPrAutoAttach,
@@ -1632,6 +1670,25 @@ export function Composer({
     [githubAutoAttach, removeAttachment, selectedAttachments, setSelectedAttachments],
   );
 
+  const handleOpenSelectedText = useCallback(
+    (attachment: Extract<ComposerAttachment, { kind: "selected_text" }>) => {
+      onOpenSelectedText?.(attachment);
+    },
+    [onOpenSelectedText],
+  );
+
+  const handleRemoveSelectedText = useCallback(
+    (id: string) => {
+      const index = selectedAttachments.findIndex(
+        (attachment) => attachment.kind === "selected_text" && attachment.id === id,
+      );
+      if (index >= 0) {
+        handleRemoveAttachment(index);
+      }
+    },
+    [handleRemoveAttachment, selectedAttachments],
+  );
+
   const handleOpenAttachment = useCallback(
     (attachment: ComposerAttachment) => {
       openComposerAttachment({
@@ -2114,8 +2171,19 @@ export function Composer({
       renderAttachmentTray({
         selectedAttachments,
         isComposerLocked,
+        isPaneFocused,
         handleOpenAttachment,
         handleRemoveAttachment,
+        handleOpenSelectedText,
+        handleRemoveSelectedText,
+        selectedTextLabels: {
+          count: t("composer.attachments.selectedTextCount", {
+            count: selectedAttachments.filter((attachment) => attachment.kind === "selected_text")
+              .length,
+          }),
+          remove: t("composer.attachments.removeSelectedText"),
+          noComment: t("composer.attachments.selectedTextNoComment"),
+        },
         labels: {
           openImage: t("composer.attachments.openImage"),
           removeImage: t("composer.attachments.removeImage"),
@@ -2126,7 +2194,16 @@ export function Composer({
             t("composer.attachments.removeGithub", { kind, number: numberLabel }),
         },
       }),
-    [handleOpenAttachment, handleRemoveAttachment, isComposerLocked, selectedAttachments, t],
+    [
+      handleOpenAttachment,
+      handleOpenSelectedText,
+      handleRemoveAttachment,
+      handleRemoveSelectedText,
+      isComposerLocked,
+      isPaneFocused,
+      selectedAttachments,
+      t,
+    ],
   );
 
   const queueList = useMemo(
@@ -2176,7 +2253,7 @@ export function Composer({
       <Animated.View style={composerContainerStyle}>
         <AttachmentLightbox metadata={lightboxMetadata} onClose={handleLightboxClose} />
         {/* Input area */}
-        <View style={inputAreaContainerStyle}>
+        <View style={inputAreaContainerStyle} testID="composer-input-area">
           <View style={styles.inputAreaContent}>
             {queueList}
             {sendErrorNode}

--- a/packages/app/src/composer/selected-text-annotations-portal.tsx
+++ b/packages/app/src/composer/selected-text-annotations-portal.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { Portal } from "@gorhom/portal";
+import { View, type StyleProp, type ViewStyle } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+
+export interface SelectedTextAnnotationsPortalProps {
+  children: ReactNode;
+  hostName: string;
+  hostStyle: StyleProp<ViewStyle>;
+  webStyle: StyleProp<ViewStyle>;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+}
+
+export function SelectedTextAnnotationsPortal({
+  children,
+  hostName,
+  hostStyle,
+  onPointerEnter,
+  onPointerLeave,
+}: SelectedTextAnnotationsPortalProps) {
+  return (
+    <Portal hostName={hostName}>
+      <View style={styles.overlay} pointerEvents="box-none">
+        <View
+          style={hostStyle}
+          onPointerEnter={onPointerEnter}
+          onPointerLeave={onPointerLeave}
+          testID="composer-selected-text-annotations-details"
+        >
+          {children}
+        </View>
+      </View>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: "absolute",
+    zIndex: 1002,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+});

--- a/packages/app/src/composer/selected-text-annotations-portal.web.tsx
+++ b/packages/app/src/composer/selected-text-annotations-portal.web.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { View, type StyleProp, type ViewStyle } from "react-native";
+import { getContentAdornmentRoot } from "@/lib/overlay-root";
+
+interface SelectedTextAnnotationsPortalProps {
+  children: ReactNode;
+  hostName: string;
+  hostStyle: StyleProp<ViewStyle>;
+  webStyle: StyleProp<ViewStyle>;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+}
+
+export function SelectedTextAnnotationsPortal({
+  children,
+  webStyle,
+  onPointerEnter,
+  onPointerLeave,
+}: SelectedTextAnnotationsPortalProps) {
+  return createPortal(
+    <View
+      pointerEvents="auto"
+      style={webStyle}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+      testID="composer-selected-text-annotations-details"
+    >
+      {children}
+    </View>,
+    getContentAdornmentRoot(),
+  );
+}

--- a/packages/app/src/composer/selected-text-annotations.test.tsx
+++ b/packages/app/src/composer/selected-text-annotations.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { PortalProvider } from "@gorhom/portal";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FloatingPanelPortalHost } from "@/components/ui/floating-panel-portal";
+import { SelectedTextAnnotations } from "./selected-text-annotations";
+
+beforeEach(() => vi.stubGlobal("React", React));
+
+const labels = { count: "1 comment", remove: "Remove", noComment: "No comment" };
+
+describe("SelectedTextAnnotations", () => {
+  it("starts collapsed and keeps an explicit collapse after hover ends", async () => {
+    const onOpen = vi.fn();
+    const view = render(
+      <PortalProvider>
+        <FloatingPanelPortalHost />
+        <SelectedTextAnnotations
+          annotations={Array.from({ length: 20 }, (_, index) => ({
+            kind: "selected_text" as const,
+            id: `selected_text:${index + 1}`,
+            text: `selected response text ${index + 1}`,
+            comment: "Explain this",
+          }))}
+          disabled={false}
+          isPaneFocused
+          labels={labels}
+          onOpen={onOpen}
+          onRemove={vi.fn()}
+        />
+      </PortalProvider>,
+    );
+
+    const root = view.getByTestId("composer-selected-text-annotations");
+    const trigger = view.getByTestId("composer-selected-text-annotations-trigger");
+    expect(view.queryByTestId("composer-selected-text-annotations-details")).toBeNull();
+
+    fireEvent.pointerEnter(root);
+    await waitFor(() =>
+      expect(view.getByTestId("composer-selected-text-annotations-details")).toBeTruthy(),
+    );
+    const details = view.getByTestId("composer-selected-text-annotations-details");
+    const list = view.getByTestId("composer-selected-text-annotations-list");
+    expect(details.style.maxHeight).not.toBe("");
+    expect(["auto", "scroll"]).toContain(window.getComputedStyle(list).overflowY);
+    expect(document.getElementById("content-adornment-root")?.contains(details)).toBe(true);
+
+    fireEvent.click(trigger);
+    expect(view.queryByTestId("composer-selected-text-annotations-details")).toBeNull();
+
+    fireEvent.pointerLeave(root);
+    fireEvent.pointerEnter(root);
+    expect(view.queryByTestId("composer-selected-text-annotations-details")).toBeNull();
+
+    fireEvent.click(trigger);
+    await waitFor(() =>
+      expect(view.getByTestId("composer-selected-text-annotations-details")).toBeTruthy(),
+    );
+
+    fireEvent.pointerDown(document.body);
+    expect(view.queryByTestId("composer-selected-text-annotations-details")).toBeNull();
+
+    fireEvent.click(trigger);
+    await waitFor(() =>
+      expect(view.getByTestId("composer-selected-text-annotations-details")).toBeTruthy(),
+    );
+
+    fireEvent.blur(window);
+    expect(view.queryByTestId("composer-selected-text-annotations-details")).toBeNull();
+
+    fireEvent.click(trigger);
+    await waitFor(() =>
+      expect(view.getByTestId("composer-selected-text-annotations-details")).toBeTruthy(),
+    );
+
+    fireEvent.click(view.getByTestId("composer-selected-text-annotation-selected_text:1"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(view.queryByTestId("composer-selected-text-annotations-details")).toBeNull();
+  });
+});

--- a/packages/app/src/composer/selected-text-annotations.tsx
+++ b/packages/app/src/composer/selected-text-annotations.tsx
@@ -1,0 +1,408 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, MessageSquare, X } from "lucide-react-native";
+import {
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+  useWindowDimensions,
+  type PressableStateCallbackType,
+} from "react-native";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import type { SelectedTextComposerAttachment } from "@/attachments/types";
+import { getSelectedTextPreview } from "@/attachments/selected-text";
+import {
+  measureFloatingPanelPortalHost,
+  useFloatingPanelPortalHostName,
+} from "@/components/ui/floating-panel-portal";
+import type { Theme } from "@/styles/theme";
+import { ICON_SIZE } from "@/styles/theme";
+import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
+import { SelectedTextAnnotationsPortal } from "./selected-text-annotations-portal";
+import { useSelectedTextAnnotationsDismiss } from "./use-selected-text-annotations-dismiss";
+
+interface SelectedTextAnnotationsLabels {
+  count: string;
+  remove: string;
+  noComment: string;
+}
+
+interface SelectedTextAnnotationsProps {
+  annotations: SelectedTextComposerAttachment[];
+  disabled: boolean;
+  isPaneFocused: boolean;
+  labels: SelectedTextAnnotationsLabels;
+  onOpen: (annotation: SelectedTextComposerAttachment) => void;
+  onRemove: (id: string) => void;
+}
+
+const ThemedMessageSquare = withUnistyles(MessageSquare);
+const ThemedChevronDown = withUnistyles(ChevronDown);
+const ThemedX = withUnistyles(X);
+const iconMutedMapping = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+const iconForegroundMapping = (theme: Theme) => ({ color: theme.colors.foreground });
+const DETAILS_GUTTER = 8;
+const DETAILS_MAX_WIDTH = 380;
+
+interface AnnotationDetailsPosition {
+  hostBottom: number;
+  hostLeft: number;
+  hostMaxHeight: number;
+  windowBottom: number;
+  windowLeft: number;
+  windowMaxHeight: number;
+  width: number;
+}
+
+function measureElement(element: View): Promise<{ x: number; y: number; width: number }> {
+  return new Promise((resolve) => {
+    element.measureInWindow((x, y, width) => resolve({ x, y, width }));
+  });
+}
+
+export function SelectedTextAnnotations({
+  annotations,
+  disabled,
+  isPaneFocused,
+  labels,
+  onOpen,
+  onRemove,
+}: SelectedTextAnnotationsProps) {
+  const [isPinnedOpen, setIsPinnedOpen] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [isHoverSuppressed, setIsHoverSuppressed] = useState(false);
+  const [detailsPosition, setDetailsPosition] = useState<AnnotationDetailsPosition | null>(null);
+  const anchorRef = useRef<View>(null);
+  const hoverLeaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const portalHostName = useFloatingPanelPortalHostName();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+  const showDetails = isPaneFocused && (isPinnedOpen || (isHovered && !isHoverSuppressed));
+  const handlePointerEnter = useCallback(() => {
+    if (hoverLeaveTimerRef.current) clearTimeout(hoverLeaveTimerRef.current);
+    setIsHovered(true);
+  }, []);
+  const handlePointerLeave = useCallback(() => {
+    if (hoverLeaveTimerRef.current) clearTimeout(hoverLeaveTimerRef.current);
+    hoverLeaveTimerRef.current = setTimeout(() => setIsHovered(false), 80);
+  }, []);
+  const handleToggle = useCallback(() => {
+    if (showDetails) {
+      setIsPinnedOpen(false);
+      setIsHoverSuppressed(true);
+      return;
+    }
+    setIsPinnedOpen(true);
+    setIsHoverSuppressed(false);
+  }, [showDetails]);
+  const dismissDetails = useCallback(() => {
+    setIsPinnedOpen(false);
+    setIsHovered(false);
+    setIsHoverSuppressed(true);
+  }, []);
+  useSelectedTextAnnotationsDismiss({ visible: showDetails, onDismiss: dismissDetails });
+  const handleOpenAnnotation = useCallback(
+    (annotation: SelectedTextComposerAttachment) => {
+      setIsPinnedOpen(false);
+      setIsHoverSuppressed(true);
+      onOpen(annotation);
+    },
+    [onOpen],
+  );
+  const triggerStyle = useCallback(
+    ({ pressed }: PressableStateCallbackType) => [styles.trigger, pressed && styles.triggerPressed],
+    [],
+  );
+
+  useEffect(() => {
+    if (!showDetails) {
+      setDetailsPosition(null);
+      return;
+    }
+    let cancelled = false;
+    const measure = () => {
+      const anchor = anchorRef.current;
+      if (!anchor) return;
+      void Promise.all([
+        measureElement(anchor),
+        measureFloatingPanelPortalHost(portalHostName),
+      ]).then(([anchorRect, hostRect]) => {
+        if (cancelled || !hostRect) return undefined;
+        const width = Math.min(DETAILS_MAX_WIDTH, hostRect.width - DETAILS_GUTTER * 2);
+        const anchorLeft = anchorRect.x - hostRect.x;
+        const hostLeft = Math.max(
+          DETAILS_GUTTER,
+          Math.min(anchorLeft, hostRect.width - width - DETAILS_GUTTER),
+        );
+        setDetailsPosition({
+          hostBottom: hostRect.height - (anchorRect.y - hostRect.y) + DETAILS_GUTTER,
+          hostLeft,
+          hostMaxHeight: Math.max(0, anchorRect.y - hostRect.y - DETAILS_GUTTER * 2),
+          windowBottom: windowHeight - anchorRect.y + DETAILS_GUTTER,
+          windowLeft: hostRect.x + hostLeft,
+          windowMaxHeight: Math.max(0, anchorRect.y - DETAILS_GUTTER * 2),
+          width,
+        });
+        return undefined;
+      });
+    };
+    measure();
+    const frame = requestAnimationFrame(measure);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+    };
+  }, [annotations.length, portalHostName, showDetails, windowHeight, windowWidth]);
+
+  useEffect(
+    () => () => {
+      if (hoverLeaveTimerRef.current) clearTimeout(hoverLeaveTimerRef.current);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!isPaneFocused) dismissDetails();
+  }, [dismissDetails, isPaneFocused]);
+
+  const floatingDetailsStyle = useMemo(
+    () =>
+      detailsPosition
+        ? inlineUnistylesStyle({
+            position: "absolute" as const,
+            bottom: detailsPosition.hostBottom,
+            left: detailsPosition.hostLeft,
+            maxHeight: detailsPosition.hostMaxHeight,
+            width: detailsPosition.width,
+          })
+        : null,
+    [detailsPosition],
+  );
+  const webFloatingDetailsStyle = useMemo(
+    () =>
+      detailsPosition
+        ? inlineUnistylesStyle({
+            position: "fixed" as const,
+            zIndex: 1002,
+            bottom: detailsPosition.windowBottom,
+            left: detailsPosition.windowLeft,
+            maxHeight: detailsPosition.windowMaxHeight,
+            width: detailsPosition.width,
+          })
+        : null,
+    [detailsPosition],
+  );
+
+  return (
+    <View
+      ref={anchorRef}
+      style={styles.root}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+      testID="composer-selected-text-annotations"
+    >
+      <Pressable
+        testID="composer-selected-text-annotations-trigger"
+        accessibilityRole="button"
+        accessibilityLabel={labels.count}
+        disabled={disabled}
+        onPress={handleToggle}
+        style={triggerStyle}
+      >
+        <ThemedMessageSquare size={ICON_SIZE.sm} uniProps={iconMutedMapping} />
+        <Text style={styles.triggerText}>{labels.count}</Text>
+        <ThemedChevronDown size={ICON_SIZE.sm} uniProps={iconMutedMapping} />
+      </Pressable>
+      {showDetails && floatingDetailsStyle && webFloatingDetailsStyle ? (
+        <SelectedTextAnnotationsPortal
+          hostName={portalHostName}
+          hostStyle={[styles.details, floatingDetailsStyle]}
+          webStyle={[styles.details, webFloatingDetailsStyle]}
+          onPointerEnter={handlePointerEnter}
+          onPointerLeave={handlePointerLeave}
+        >
+          <ScrollView
+            testID="composer-selected-text-annotations-list"
+            style={styles.detailsScroll}
+            showsVerticalScrollIndicator
+          >
+            {annotations.map((annotation, index) => (
+              <AnnotationRow
+                key={annotation.id}
+                annotation={annotation}
+                index={index}
+                disabled={disabled}
+                noCommentLabel={labels.noComment}
+                removeLabel={labels.remove}
+                onOpen={handleOpenAnnotation}
+                onRemove={onRemove}
+              />
+            ))}
+          </ScrollView>
+        </SelectedTextAnnotationsPortal>
+      ) : null}
+    </View>
+  );
+}
+
+function AnnotationRow({
+  annotation,
+  index,
+  disabled,
+  noCommentLabel,
+  removeLabel,
+  onOpen,
+  onRemove,
+}: {
+  annotation: SelectedTextComposerAttachment;
+  index: number;
+  disabled: boolean;
+  noCommentLabel: string;
+  removeLabel: string;
+  onOpen: (annotation: SelectedTextComposerAttachment) => void;
+  onRemove: (id: string) => void;
+}) {
+  const handleOpen = useCallback(() => onOpen(annotation), [annotation, onOpen]);
+  const handleRemove = useCallback(() => onRemove(annotation.id), [annotation.id, onRemove]);
+  const annotationMainStyle = useCallback(
+    ({ pressed }: PressableStateCallbackType) => [
+      styles.annotationMain,
+      pressed && styles.annotationPressed,
+    ],
+    [],
+  );
+  const preview = getSelectedTextPreview(annotation.text);
+  const comment = annotation.comment?.trim();
+
+  return (
+    <View style={[styles.annotationRow, index > 0 && styles.annotationRowBorder]}>
+      <Pressable
+        testID={`composer-selected-text-annotation-${annotation.id}`}
+        accessibilityRole="button"
+        accessibilityLabel={preview}
+        disabled={disabled}
+        onPress={handleOpen}
+        style={annotationMainStyle}
+      >
+        <View style={styles.annotationIndex}>
+          <Text style={styles.annotationIndexText}>{index + 1}</Text>
+        </View>
+        <View style={styles.annotationCopy}>
+          <Text style={styles.annotationSelection} numberOfLines={2}>
+            {preview}
+          </Text>
+          <Text
+            style={comment ? styles.annotationComment : styles.annotationNoComment}
+            numberOfLines={2}
+          >
+            {comment || noCommentLabel}
+          </Text>
+        </View>
+      </Pressable>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={removeLabel}
+        disabled={disabled}
+        onPress={handleRemove}
+        hitSlop={6}
+        style={styles.annotationRemove}
+      >
+        <ThemedX size={ICON_SIZE.sm} uniProps={iconForegroundMapping} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme: Theme) => ({
+  root: {
+    position: "relative",
+    zIndex: 10,
+  },
+  trigger: {
+    minHeight: 32,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[1],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.md,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.borderAccent,
+    backgroundColor: theme.colors.surface1,
+  },
+  triggerPressed: {
+    opacity: 0.82,
+  },
+  triggerText: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.sm,
+  },
+  details: {
+    padding: theme.spacing[2],
+    borderRadius: theme.borderRadius.xl,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface2,
+    boxShadow: "0 10px 28px rgba(0, 0, 0, 0.3)",
+  },
+  detailsScroll: {
+    flexShrink: 1,
+  },
+  annotationRow: {
+    minHeight: 52,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  annotationRowBorder: {
+    borderTopWidth: theme.borderWidth[1],
+    borderTopColor: theme.colors.border,
+  },
+  annotationMain: {
+    minWidth: 0,
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[2],
+    borderRadius: theme.borderRadius.md,
+  },
+  annotationPressed: {
+    backgroundColor: theme.colors.surface3,
+  },
+  annotationIndex: {
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.palette.blue[500],
+  },
+  annotationIndexText: {
+    color: theme.colors.accentForeground,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.medium,
+  },
+  annotationCopy: {
+    minWidth: 0,
+    flex: 1,
+    gap: theme.spacing[1],
+  },
+  annotationSelection: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
+  },
+  annotationComment: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  annotationNoComment: {
+    color: theme.colors.foregroundExtraMuted,
+    fontSize: theme.fontSize.xs,
+  },
+  annotationRemove: {
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+}));

--- a/packages/app/src/composer/use-selected-text-annotations-dismiss.ts
+++ b/packages/app/src/composer/use-selected-text-annotations-dismiss.ts
@@ -1,0 +1,4 @@
+export function useSelectedTextAnnotationsDismiss(_input: {
+  visible: boolean;
+  onDismiss: () => void;
+}): void {}

--- a/packages/app/src/composer/use-selected-text-annotations-dismiss.web.ts
+++ b/packages/app/src/composer/use-selected-text-annotations-dismiss.web.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+
+const ANNOTATION_SURFACE_SELECTOR =
+  '[data-testid="composer-selected-text-annotations"], [data-testid="composer-selected-text-annotations-details"]';
+
+export function useSelectedTextAnnotationsDismiss({
+  visible,
+  onDismiss,
+}: {
+  visible: boolean;
+  onDismiss: () => void;
+}): void {
+  useEffect(() => {
+    if (!visible) return undefined;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Element && target.closest(ANNOTATION_SURFACE_SELECTOR)) return;
+      onDismiss();
+    };
+    const handleWindowBlur = () => onDismiss();
+    const handleVisibilityChange = () => {
+      if (document.hidden) onDismiss();
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("blur", handleWindowBlur);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [onDismiss, visible]);
+}

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -138,6 +138,10 @@ export const ar: TranslationResources = {
       removeBrowserElement: "إزالة مرفق عنصر المتصفح",
       openReview: "فتح مرفق المراجعة",
       removeReview: "إزالة مرفق المراجعة",
+      selectedText: "النص المحدد",
+      removeSelectedText: "إزالة النص المحدد",
+      selectedTextCount: "{{count}} تعليق",
+      selectedTextNoComment: "لا يوجد تعليق",
     },
     errors: {
       failedToSend: "فشل في إرسال الرسالة",
@@ -199,6 +203,12 @@ export const ar: TranslationResources = {
     empty: "ابدأ الدردشة مع هذا الوكيل...",
     scrollToBottom: "قم بالتمرير إلى الأسفل",
     historyLoadFailed: "تعذر تحميل سجل الوكيل",
+    commentOnSelection: "إضافة تعليق",
+    addToComment: "إضافة إلى التعليق",
+    addToConversation: "إضافة إلى المحادثة",
+    commentPlaceholder: "أضف تعليقًا اختياريًا...",
+    saveComment: "حفظ",
+    cancelComment: "إلغاء",
     permission: {
       plan: "يخطط",
       required: "الإذن مطلوب",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -135,6 +135,10 @@ export const en = {
       removeBrowserElement: "Remove browser element attachment",
       openReview: "Open review attachment",
       removeReview: "Remove review attachment",
+      selectedText: "Selected text",
+      removeSelectedText: "Remove selected text",
+      selectedTextCount: "{{count}} comments",
+      selectedTextNoComment: "No comment",
     },
     errors: {
       failedToSend: "Failed to send message",
@@ -196,6 +200,12 @@ export const en = {
     empty: "Start chatting with this agent...",
     scrollToBottom: "Scroll to bottom",
     historyLoadFailed: "Couldn't load agent history",
+    commentOnSelection: "Add comment",
+    addToComment: "Add to comment",
+    addToConversation: "Add to conversation",
+    commentPlaceholder: "Add an optional comment...",
+    saveComment: "Save",
+    cancelComment: "Cancel",
     permission: {
       plan: "Plan",
       required: "Permission Required",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -138,6 +138,10 @@ export const es: TranslationResources = {
       removeBrowserElement: "Eliminar el archivo adjunto del elemento del navegador",
       openReview: "Abrir archivo adjunto de reseña",
       removeReview: "Eliminar archivo adjunto de reseña",
+      selectedText: "Texto seleccionado",
+      removeSelectedText: "Eliminar texto seleccionado",
+      selectedTextCount: "{{count}} comentarios",
+      selectedTextNoComment: "Sin comentario",
     },
     errors: {
       failedToSend: "No se pudo enviar el mensaje",
@@ -199,6 +203,12 @@ export const es: TranslationResources = {
     empty: "Comience a chatear con este agente...",
     scrollToBottom: "Desplazarse hacia abajo",
     historyLoadFailed: "No se pudo cargar el historial del agente",
+    commentOnSelection: "Añadir comentario",
+    addToComment: "Añadir al comentario",
+    addToConversation: "Añadir a la conversación",
+    commentPlaceholder: "Añade un comentario opcional...",
+    saveComment: "Guardar",
+    cancelComment: "Cancelar",
     permission: {
       plan: "Plan",
       required: "Permiso requerido",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -140,6 +140,10 @@ export const fr: TranslationResources = {
       removeBrowserElement: "Supprimer la pièce jointe d'un élément de navigateur",
       openReview: "Ouvrir la pièce jointe de l'avis",
       removeReview: "Supprimer la pièce jointe de l'avis",
+      selectedText: "Texte sélectionné",
+      removeSelectedText: "Supprimer le texte sélectionné",
+      selectedTextCount: "{{count}} commentaires",
+      selectedTextNoComment: "Aucun commentaire",
     },
     errors: {
       failedToSend: "Échec de l'envoi du message",
@@ -201,6 +205,12 @@ export const fr: TranslationResources = {
     empty: "Commencez à discuter avec cet agent...",
     scrollToBottom: "Faire défiler vers le bas",
     historyLoadFailed: "Impossible de charger l’historique de l’agent",
+    commentOnSelection: "Ajouter un commentaire",
+    addToComment: "Ajouter au commentaire",
+    addToConversation: "Ajouter à la conversation",
+    commentPlaceholder: "Ajouter un commentaire facultatif...",
+    saveComment: "Enregistrer",
+    cancelComment: "Annuler",
     permission: {
       plan: "Plan",
       required: "Autorisation requise",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -138,6 +138,10 @@ export const ja: TranslationResources = {
       removeBrowserElement: "ブラウザ要素の添付ファイルを削除",
       openReview: "レビュー添付ファイルを開く",
       removeReview: "レビュー添付ファイルを削除",
+      selectedText: "選択したテキスト",
+      removeSelectedText: "選択したテキストを削除",
+      selectedTextCount: "{{count}} 件のコメント",
+      selectedTextNoComment: "コメントなし",
     },
     errors: {
       failedToSend: "メッセージの送信に失敗しました",
@@ -199,6 +203,12 @@ export const ja: TranslationResources = {
     empty: "このエージェントとチャットを始めましょう...",
     scrollToBottom: "下にスクロール",
     historyLoadFailed: "エージェントの履歴を読み込めませんでした",
+    commentOnSelection: "コメントを追加",
+    addToComment: "コメントに追加",
+    addToConversation: "会話に追加",
+    commentPlaceholder: "任意のコメントを追加...",
+    saveComment: "保存",
+    cancelComment: "キャンセル",
     permission: {
       plan: "プラン",
       required: "権限が必要です",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -138,6 +138,10 @@ export const ko: TranslationResources = {
       removeBrowserElement: "브라우저 요소 첨부 제거",
       openReview: "리뷰 첨부 열기",
       removeReview: "리뷰 첨부 제거",
+      selectedText: "선택한 텍스트",
+      removeSelectedText: "선택한 텍스트 제거",
+      selectedTextCount: "댓글 {{count}}개",
+      selectedTextNoComment: "댓글 없음",
     },
     errors: {
       failedToSend: "메시지를 보내지 못했습니다",
@@ -199,6 +203,12 @@ export const ko: TranslationResources = {
     empty: "이 에이전트와 대화를 시작하세요...",
     scrollToBottom: "맨 아래로 스크롤",
     historyLoadFailed: "에이전트 기록을 로드할 수 없습니다.",
+    commentOnSelection: "댓글 추가",
+    addToComment: "댓글에 추가",
+    addToConversation: "대화에 추가",
+    commentPlaceholder: "선택 댓글 추가...",
+    saveComment: "저장",
+    cancelComment: "취소",
     permission: {
       plan: "계획",
       required: "권한 필요",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -138,6 +138,10 @@ export const ptBR: TranslationResources = {
       removeBrowserElement: "Remover anexo de elemento do navegador",
       openReview: "Abrir anexo de revisão",
       removeReview: "Remover anexo de revisão",
+      selectedText: "Texto selecionado",
+      removeSelectedText: "Remover texto selecionado",
+      selectedTextCount: "{{count}} comentários",
+      selectedTextNoComment: "Sem comentário",
     },
     errors: {
       failedToSend: "Falha ao enviar mensagem",
@@ -199,6 +203,12 @@ export const ptBR: TranslationResources = {
     empty: "Comece a conversar com este agente...",
     scrollToBottom: "Rolar para o fim",
     historyLoadFailed: "Não foi possível carregar o histórico do agente",
+    commentOnSelection: "Adicionar comentário",
+    addToComment: "Adicionar ao comentário",
+    addToConversation: "Adicionar à conversa",
+    commentPlaceholder: "Adicione um comentário opcional...",
+    saveComment: "Salvar",
+    cancelComment: "Cancelar",
     permission: {
       plan: "Plano",
       required: "Permissão necessária",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -138,6 +138,10 @@ export const ru: TranslationResources = {
       removeBrowserElement: "Удалить вложение элемента браузера",
       openReview: "Открыть прикрепленный файл с отзывом",
       removeReview: "Удалить прикрепленный отзыв",
+      selectedText: "Выбранный текст",
+      removeSelectedText: "Удалить выбранный текст",
+      selectedTextCount: "Комментариев: {{count}}",
+      selectedTextNoComment: "Без комментария",
     },
     errors: {
       failedToSend: "Не удалось отправить сообщение",
@@ -199,6 +203,12 @@ export const ru: TranslationResources = {
     empty: "Начните общаться с этим агентом...",
     scrollToBottom: "Прокрутить вниз",
     historyLoadFailed: "Не удалось загрузить историю агента",
+    commentOnSelection: "Добавить комментарий",
+    addToComment: "Добавить к комментарию",
+    addToConversation: "Добавить в разговор",
+    commentPlaceholder: "Добавьте необязательный комментарий...",
+    saveComment: "Сохранить",
+    cancelComment: "Отмена",
     permission: {
       plan: "План",
       required: "Требуется разрешение",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -138,6 +138,10 @@ export const zhCN: TranslationResources = {
       removeBrowserElement: "移除浏览器元素附件",
       openReview: "打开 review 附件",
       removeReview: "移除 review 附件",
+      selectedText: "选中的文本",
+      removeSelectedText: "移除选中的文本",
+      selectedTextCount: "{{count}} 条注释",
+      selectedTextNoComment: "未添加评论",
     },
     errors: {
       failedToSend: "发送消息失败",
@@ -199,6 +203,12 @@ export const zhCN: TranslationResources = {
     empty: "开始和这个 Agent 对话...",
     scrollToBottom: "滚动到底部",
     historyLoadFailed: "无法加载智能体历史记录",
+    commentOnSelection: "添加评论",
+    addToComment: "添加到评论",
+    addToConversation: "添加到对话",
+    commentPlaceholder: "添加可选评论...",
+    saveComment: "保存",
+    cancelComment: "取消",
     permission: {
       plan: "Plan",
       required: "需要权限",

--- a/packages/app/src/lib/overlay-root.ts
+++ b/packages/app/src/lib/overlay-root.ts
@@ -37,9 +37,29 @@ export function getOverlayRoot(): HTMLElement {
   return el;
 }
 
+/**
+ * Shared web plane for fixed adornments that belong to page content, such as
+ * selected-text highlights and annotation markers. The root is above ordinary
+ * document paint but caps every descendant below menus, hover cards, and modals.
+ */
+export function getContentAdornmentRoot(): HTMLElement {
+  let el = document.getElementById("content-adornment-root");
+  if (!el) {
+    el = document.createElement("div");
+    el.id = "content-adornment-root";
+    document.body.appendChild(el);
+  }
+  el.style.position = "fixed";
+  el.style.inset = "0";
+  el.style.pointerEvents = "none";
+  el.style.zIndex = String(WEB_SURFACE_PLANE.contentAdornment);
+  return el;
+}
+
 export const WEB_SURFACE_PLANE = {
   browser: 0,
-  overlay: 1,
+  contentAdornment: 1,
+  overlay: 2,
 } as const;
 
 export const OVERLAY_Z = {

--- a/packages/app/src/panels/agent-panel.tsx
+++ b/packages/app/src/panels/agent-panel.tsx
@@ -34,7 +34,16 @@ import {
   type ToastApi,
   type ToastState,
 } from "@/components/toast-host";
-import type { WorkspaceComposerAttachment } from "@/attachments/types";
+import type {
+  SelectedTextComposerAttachment,
+  UserComposerAttachment,
+  WorkspaceComposerAttachment,
+} from "@/attachments/types";
+import type {
+  AssistantSelectionAnnotation,
+  SelectedTextAnnotationEdit,
+} from "@/assistant-selection-copy/types";
+import { scrollToSelectedText } from "@/assistant-selection-copy/scroll";
 import { useWorkspaceAttachmentScopeKey } from "@/attachments/workspace-attachments-store";
 import { COMPACT_FORM_FACTOR_WIDTH, useIsCompactFormFactor } from "@/constants/layout";
 import { isWeb } from "@/constants/platform";
@@ -95,7 +104,7 @@ import {
 } from "@/subagents";
 import { SubagentsTrack } from "@/subagents/track";
 import type { PendingPermission } from "@/types/shared";
-import type { StreamItem } from "@/types/stream";
+import { generateMessageId, type StreamItem } from "@/types/stream";
 import { getInitDeferred, getInitKey } from "@/utils/agent-initialization";
 import { derivePendingPermissionKey, normalizeAgentSnapshot } from "@/utils/agent-snapshots";
 import { applyLegacyDaemonWorkspaceOwnership } from "@/workspace/legacy-daemon-workspaces";
@@ -1172,6 +1181,26 @@ function ChatAgentContent({
   );
 }
 
+function updateSelectedTextComment(
+  attachment: UserComposerAttachment,
+  attachmentId: string,
+  comment: string,
+): UserComposerAttachment {
+  return attachment.kind === "selected_text" && attachment.id === attachmentId
+    ? { ...attachment, comment }
+    : attachment;
+}
+
+function updateSelectedTextComments(
+  attachments: UserComposerAttachment[],
+  attachmentId: string,
+  comment: string,
+): UserComposerAttachment[] {
+  return attachments.map((attachment) =>
+    updateSelectedTextComment(attachment, attachmentId, comment),
+  );
+}
+
 const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
   serverId,
   agentId,
@@ -1236,6 +1265,8 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
     clear,
     isHydrated,
     attachmentFocusRequestId,
+    focusRequestId,
+    requestFocus,
     composerState,
   } = rawAgentInputDraft;
   const agentInputDraft = useMemo(
@@ -1249,6 +1280,8 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
       clear,
       isHydrated,
       attachmentFocusRequestId,
+      focusRequestId,
+      requestFocus,
       composerState,
     }),
     [
@@ -1261,9 +1294,65 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
       clear,
       isHydrated,
       attachmentFocusRequestId,
+      focusRequestId,
+      requestFocus,
       composerState,
     ],
   );
+  const [selectedTextAnnotationToEdit, setSelectedTextAnnotationToEdit] =
+    useState<SelectedTextComposerAttachment | null>(null);
+  const selectedTextAnnotations = useMemo(
+    () =>
+      attachments.filter(
+        (attachment): attachment is SelectedTextComposerAttachment =>
+          attachment.kind === "selected_text",
+      ),
+    [attachments],
+  );
+  const handleCommentSelection = useCallback(
+    (annotation: AssistantSelectionAnnotation) => {
+      const selectedTextContext = annotation.text.trim();
+      if (!selectedTextContext) {
+        return;
+      }
+      setAttachments((current) => [
+        ...current,
+        {
+          kind: "selected_text",
+          id: `selected_text:${generateMessageId()}`,
+          text: selectedTextContext,
+          ...(annotation.sourceMessageId ? { sourceMessageId: annotation.sourceMessageId } : {}),
+          ...(annotation.occurrence != null ? { occurrence: annotation.occurrence } : {}),
+          ...(annotation.comment.trim() ? { comment: annotation.comment.trim() } : {}),
+        },
+      ]);
+      requestFocus();
+    },
+    [requestFocus, setAttachments],
+  );
+  const handleOpenSelectedText = useCallback(
+    (attachment: SelectedTextComposerAttachment) => {
+      // A fresh object makes repeated presses on the same annotation a new edit request.
+      setSelectedTextAnnotationToEdit({ ...attachment });
+      if (attachment.sourceMessageId) {
+        streamViewRef.current?.scrollToMessage(attachment.sourceMessageId);
+      }
+      scrollToSelectedText(attachment, (messageId) =>
+        streamViewRef.current?.scrollToMessage(messageId),
+      );
+    },
+    [streamViewRef],
+  );
+  const handleEditSelectedText = useCallback(
+    ({ attachmentId, comment }: SelectedTextAnnotationEdit) => {
+      setAttachments((current) => updateSelectedTextComments(current, attachmentId, comment));
+      setSelectedTextAnnotationToEdit(null);
+    },
+    [setAttachments],
+  );
+  const handleDismissSelectedTextEdit = useCallback(() => {
+    setSelectedTextAnnotationToEdit(null);
+  }, []);
   const streamSection = (
     <RenderProfile id={`AgentStreamSection:${agentId}`}>
       <AgentStreamSection
@@ -1274,6 +1363,13 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
         routeBottomAnchorRequest={routeBottomAnchorRequest}
         hasAppliedAuthoritativeHistory={hasAppliedAuthoritativeHistory}
         toast={toastApi}
+        isPaneFocused={isPaneFocused}
+        onCommentSelection={handleCommentSelection}
+        selectedTextAnnotations={selectedTextAnnotations}
+        onOpenSelectedText={handleOpenSelectedText}
+        selectedTextAnnotationToEdit={selectedTextAnnotationToEdit}
+        onEditSelectedText={handleEditSelectedText}
+        onDismissSelectedTextEdit={handleDismissSelectedTextEdit}
         onOpenWorkspaceFile={onOpenWorkspaceFile}
       />
     </RenderProfile>
@@ -1293,6 +1389,7 @@ const ChatAgentReadyContent = memo(function ChatAgentReadyContent({
         onAttentionPromptSend={onAttentionPromptSend}
         onComposerHeightChange={handleComposerHeightChange}
         onMessageSent={handleMessageSent}
+        onOpenSelectedText={handleOpenSelectedText}
       />
     </RenderProfile>
   );
@@ -1349,7 +1446,14 @@ const AgentStreamSection = memo(function AgentStreamSection({
   routeBottomAnchorRequest,
   hasAppliedAuthoritativeHistory,
   toast,
+  isPaneFocused,
   onOpenWorkspaceFile,
+  onCommentSelection,
+  selectedTextAnnotations,
+  onOpenSelectedText,
+  selectedTextAnnotationToEdit,
+  onEditSelectedText,
+  onDismissSelectedTextEdit,
 }: {
   streamViewRef: React.RefObject<AgentStreamViewHandle | null>;
   serverId: string;
@@ -1358,7 +1462,14 @@ const AgentStreamSection = memo(function AgentStreamSection({
   routeBottomAnchorRequest: RouteBottomAnchorRequest;
   hasAppliedAuthoritativeHistory: boolean;
   toast: ReturnType<typeof useToastHost>["api"];
+  isPaneFocused: boolean;
   onOpenWorkspaceFile?: (request: WorkspaceFileOpenRequest) => void;
+  onCommentSelection?: (annotation: AssistantSelectionAnnotation) => void;
+  selectedTextAnnotations?: readonly SelectedTextComposerAttachment[];
+  onOpenSelectedText?: (annotation: SelectedTextComposerAttachment) => void;
+  selectedTextAnnotationToEdit?: SelectedTextComposerAttachment | null;
+  onEditSelectedText?: (input: SelectedTextAnnotationEdit) => void;
+  onDismissSelectedTextEdit?: () => void;
 }) {
   const streamItemsRaw = useSessionStore((state) =>
     agentId ? state.sessions[serverId]?.agentStreamTail?.get(agentId) : undefined,
@@ -1416,9 +1527,16 @@ const AgentStreamSection = memo(function AgentStreamSection({
       routeBottomAnchorRequest={routeBottomAnchorRequest}
       isAuthoritativeHistoryReady={hasAppliedAuthoritativeHistory}
       toast={toast}
+      isPaneFocused={isPaneFocused}
       pendingMessageSubmissions={pendingMessageSubmissions}
       turnPresentation={turnPresentation}
       onOpenWorkspaceFile={onOpenWorkspaceFile}
+      onCommentSelection={onCommentSelection}
+      selectedTextAnnotations={selectedTextAnnotations}
+      onOpenSelectedText={onOpenSelectedText}
+      selectedTextAnnotationToEdit={selectedTextAnnotationToEdit}
+      onEditSelectedText={onEditSelectedText}
+      onDismissSelectedTextEdit={onDismissSelectedTextEdit}
     />
   );
 });
@@ -1436,6 +1554,7 @@ const AgentComposerSection = memo(function AgentComposerSection({
   onAttentionPromptSend,
   onComposerHeightChange,
   onMessageSent,
+  onOpenSelectedText,
 }: {
   agentId?: string;
   serverId: string;
@@ -1449,6 +1568,7 @@ const AgentComposerSection = memo(function AgentComposerSection({
   onAttentionPromptSend: () => void;
   onComposerHeightChange: (height: number) => void;
   onMessageSent: () => void;
+  onOpenSelectedText: (attachment: SelectedTextComposerAttachment) => void;
 }) {
   if (!agentId) {
     return null;
@@ -1472,6 +1592,7 @@ const AgentComposerSection = memo(function AgentComposerSection({
       onAttentionPromptSend={onAttentionPromptSend}
       onComposerHeightChange={onComposerHeightChange}
       onMessageSent={onMessageSent}
+      onOpenSelectedText={onOpenSelectedText}
     />
   );
 });
@@ -1487,6 +1608,7 @@ function ActiveAgentComposer({
   onAttentionPromptSend,
   onComposerHeightChange,
   onMessageSent,
+  onOpenSelectedText,
 }: {
   agentId: string;
   serverId: string;
@@ -1498,6 +1620,7 @@ function ActiveAgentComposer({
   onAttentionPromptSend: () => void;
   onComposerHeightChange: (height: number) => void;
   onMessageSent: () => void;
+  onOpenSelectedText: (attachment: SelectedTextComposerAttachment) => void;
 }) {
   const insets = useSafeAreaInsets();
   const isCompactFormFactor = useIsCompactFormFactor();
@@ -1649,12 +1772,13 @@ function ActiveAgentComposer({
         cwd={cwd}
         clearDraft={agentInputDraft.clear}
         autoFocus={isPaneFocused}
-        autoFocusKey={String(agentInputDraft.attachmentFocusRequestId)}
+        autoFocusKey={`${agentInputDraft.attachmentFocusRequestId}:${agentInputDraft.focusRequestId}`}
         isSubmitLoading={isSubmitLoading}
         onAttentionInputFocus={onAttentionInputFocus}
         onAttentionPromptSend={onAttentionPromptSend}
         onComposerHeightChange={onComposerHeightChange}
         onMessageSent={onMessageSent}
+        onOpenSelectedText={onOpenSelectedText}
         onClientSlashCommand={handleClientSlashCommand}
         isCompactLayout={isCompactComposerLayout}
       />

--- a/packages/app/src/stores/draft-store/state.test.ts
+++ b/packages/app/src/stores/draft-store/state.test.ts
@@ -139,6 +139,24 @@ describe("draft-store normalization", () => {
     ).toEqual({ text: "Review this", attachments: [attachment] });
   });
 
+  it("preserves selected response text when hydrating a draft", () => {
+    const attachment = {
+      kind: "selected_text" as const,
+      id: "selected_text:1",
+      text: "Keep this invariant.",
+      occurrence: 1,
+    };
+
+    expect(
+      toDraftInputIfReady({
+        input: { text: "Why?", attachments: [attachment] },
+        lifecycle: "active",
+        updatedAt: 1,
+        version: 1,
+      }),
+    ).toEqual({ text: "Why?", attachments: [attachment] });
+  });
+
   it("preserves New Workspace picker ownership when hydrating a draft", () => {
     const pickerAttachment = {
       kind: "github_pr" as const,

--- a/packages/app/src/stores/draft-store/state.ts
+++ b/packages/app/src/stores/draft-store/state.ts
@@ -82,6 +82,14 @@ export const UserComposerAttachmentSchema: z.ZodType<UserComposerAttachment> = z
     z.strictObject({ kind: z.literal("image"), metadata: AttachmentMetadataSchema }),
     z.strictObject({ kind: z.literal("file"), attachment: UploadedFileSchema }),
     z.strictObject({
+      kind: z.literal("selected_text"),
+      id: z.string(),
+      text: z.string().min(1),
+      sourceMessageId: z.string().optional(),
+      occurrence: z.number().int().nonnegative().optional(),
+      comment: z.string().optional(),
+    }),
+    z.strictObject({
       kind: z.literal("workspace_file"),
       path: z.string(),
       selection: z.discriminatedUnion("kind", [

--- a/packages/app/src/styles/theme.ts
+++ b/packages/app/src/styles/theme.ts
@@ -560,6 +560,7 @@ export const BORDER_RADIUS = {
   lg: 8,
   xl: 12,
   "2xl": 16,
+  "3xl": 24,
   full: 9999,
 } as const;
 

--- a/packages/app/test-stubs/react-native-unistyles.ts
+++ b/packages/app/test-stubs/react-native-unistyles.ts
@@ -18,7 +18,7 @@ const testTheme = {
     borderAccent: "#a1a1aa",
     palette: {
       amber: { 500: "#f59e0b" },
-      blue: { 300: "#93c5fd" },
+      blue: { 300: "#93c5fd", 500: "#3b82f6" },
       red: { 300: "#fca5a5" },
       white: "#ffffff",
     },
@@ -39,6 +39,8 @@ const testTheme = {
     md: 6,
     lg: 8,
     xl: 12,
+    "2xl": 16,
+    "3xl": 24,
     full: 9999,
   },
   iconSize: { sm: 16 },


### PR DESCRIPTION
## Summary

This PR adds response text annotations to Paseo.

Users can now select text from an assistant response, attach a comment to that selection, and include the annotated excerpts in their next message. Existing annotations can be revisited from either the inline numbered marker or the annotation overview in the composer.

The interaction is modeled after response annotation workflows in Codex and ChatGPT, while being adapted to Paseo’s composer, scrolling, overlay, and cross-platform architecture.

## Why

Long agent responses often contain several independent details that need clarification or revision. Previously, users had to copy excerpts manually, paste them into the composer, and explain which part of the response each comment referred to.

That workflow has several problems:

- It loses the visual relationship between a comment and the original response.
- Repeated text can make a quoted excerpt ambiguous.
- Discussing multiple parts of one response produces a noisy message.
- Users cannot easily return to an earlier excerpt to review or edit its comment.
- Manually copied context is more likely to omit formatting or identify the wrong passage.

Response annotations provide a structured way to preserve that relationship. Each annotation keeps the selected text, its source message, its occurrence within that message, and the optional user comment. The annotations are then added to the next turn as explicit context.

In this PR I chose a codex-like approach to implement this.

## User experience

### Creating an annotation

1. Select text inside an assistant response.
2. Choose **Add to comment** from the contextual action.
3. Enter an optional comment in the compact editor.
4. Confirm the annotation using the icon-only submit button.

The initial editor starts as a single-line capsule. It grows into a multiline rounded panel when the comment becomes longer, with a constrained width and scrollable content.

### Viewing annotations

Each saved annotation displays a small numbered conversation marker next to its source text.

The composer shows only the annotation count by default. Hovering or clicking the annotation tab opens an overview containing the selected excerpts and their comments.

The overview remains collapsed after adding an annotation and closes when it loses focus.

### Navigating and editing

Selecting an annotation from the composer overview:

- scrolls to the source response;
- highlights the annotated text without creating a native browser selection;
- opens the full annotation editor next to the source text.

Clicking an inline numbered marker performs the same action.

The editor is temporarily hidden when focus moves outside it. Long comments remain editable and scroll inside the editor instead of causing the editor to disappear.

## Technical implementation

### Annotation data model

Added a selected-text attachment model containing:

- the selected Markdown text;
- the source assistant message ID;
- the zero-based occurrence of the selected text within that message;
- the user comment;
- a stable annotation ID used for editing and rendering.

Annotations are stored as part of the composer draft so they survive normal composer state updates and workspace navigation.

Draft validation accepts the new attachment shape while keeping the additional occurrence field optional for compatibility with previously created draft state.

### Message submission

Selected-text attachments are converted into structured response annotations when the composer is submitted.

This keeps the annotation metadata separate from ordinary file and image attachments while still injecting the selected excerpts and comments into the next agent turn.

Submission tests cover annotation conversion and verify that the selected text, source message, occurrence, and comment are preserved.

### Markdown-aware selection

The web selection surface converts DOM selections back into Markdown-aware text instead of relying only on `Selection.toString()`.

The conversion preserves supported response structure, including:

- inline emphasis;
- list items;
- nested response content;
- ignored presentation-only elements such as list markers.

Selections are limited to assistant response content and are rejected when they originate outside the response surface.

### Repeated and overlapping text

A selected excerpt is not identified by text alone.

The implementation records which occurrence of the excerpt was selected within the source response. This allows annotations to resolve the correct passage when identical text appears multiple times.

Occurrence detection uses the exact normalized start of the DOM range. This also handles overlapping matches correctly—for example, selecting the final two characters in `哈哈哈` resolves to occurrence `1` of `哈哈`, rather than occurrence `0`.

### Highlight rendering

Saved annotations use custom highlight geometry rather than restoring a browser-native selection.

The renderer:

- recreates the source DOM range from the stored annotation;
- derives client rectangles for wrapped and multiline text;
- clips highlights to the visible conversation viewport;
- updates geometry during scrolling and layout changes;
- keeps marker payloads synchronized after comment edits;
- supports more than six annotations without relying on a fixed marker limit.

This allows navigation and editing without taking over the user’s current browser selection.

### Numbered annotation markers

Numbered markers are rendered in a dedicated conversation-content overlay plane.

The markers:

- remain attached to the annotated text;
- use a compact conversation-bubble shape;
- include a smooth pointer without raster or border aliasing;
- reopen the corresponding editor when clicked;
- are hidden when their source content is outside the active conversation surface.

Marker placement is recalculated from the source range instead of being permanently positioned from the original selection event.

### Adaptive editor positioning

Both the compact creation editor and the full editing panel use range-based adaptive positioning.

The positioning logic:

- prefers a location next to the selected text;
- flips above or below the range when space is constrained;
- clamps the panel horizontally to the viewport;
- accounts for the visible conversation boundaries;
- repositions during conversation scrolling;
- falls back to a centered position when the source range is outside the usable viewport;
- avoids disappearing when content growth changes the panel dimensions.

The compact creation editor and the full editing panel use different size constraints while sharing the same range anchoring behavior.

### Composer annotation overview

The composer now includes a selected-text annotation overview.

Its implementation includes:

- a collapsed annotation-count tab;
- hover and click expansion on web;
- explicit pinned/open state handling;
- outside-focus dismissal;
- navigation back to the source annotation;
- annotation removal;
- scrolling and maximum-height constraints for large annotation sets.

The overview is rendered through a platform-specific portal layer so the web implementation can escape local clipping contexts while native platforms retain a safe fallback.

### Overlay and stacking behavior

Annotation UI introduced several interactions with existing floating surfaces, including the composer, workspace hover cards, menus, and other global overlays.

This PR separates overlays by responsibility:

- annotation highlights and markers belong to the conversation-content plane;
- the main composer remains above conversation annotations;
- annotation editors and overviews use the appropriate floating-panel layer;
- application menus, workspace previews, and global popovers remain above conversation annotations.

The implementation uses shared overlay roots and stacking tokens instead of giving markers a globally dominant `z-index`. Existing composer collision handling is retained for marker geometry, while highlights use viewport clipping so they cannot paint over the composer.

The workspace hover card was also moved onto the shared global overlay layer to avoid local stacking-context conflicts.

### Focus and dismissal behavior

The annotation editor distinguishes between actual outside interaction and internal editor updates.

This prevents the editor from closing when:

- the textarea grows;
- the comment wraps onto additional lines;
- the save button is used;
- focus moves between controls inside the editor.

True outside focus or pointer interaction temporarily hides the editor. Reopening the marker or overview item restores the editing state.

### Theme support

Annotation surfaces use existing theme tokens for backgrounds, borders, text, and focus states.

The confirmation icon explicitly follows the button foreground color, keeping it visible in both light and dark themes. Focus borders use a subtle theme-derived color instead of a hard-coded green outline.

### Cross-platform behavior

DOM selection, range geometry, portals, and pointer listeners are isolated in web-specific modules.

Native platforms receive compatible component interfaces and safe fallback implementations without importing browser APIs. This keeps the shared composer and agent-stream code cross-platform.

No raw DOM API is introduced into the native bundle.

### Localization

Added labels for the annotation workflow to all existing application locale resources, including:

- adding a selection to the comment;
- annotation counts;
- optional comment placeholders;
- save, edit, and delete actions;
- selected-text context labels.

## Documentation

Updated the floating panel documentation with the stacking and ownership rules introduced by response annotations, including the distinction between conversation-content overlays and global application overlays.

## Validation

Automated validation completed:

- 18 browser interaction tests passed.
- 13 focused unit tests passed.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run format:check` passed.
- Git pre-commit checks passed.

Browser coverage includes:

- initial annotation creation;
- compact and multiline editor behavior;
- repeated and overlapping text;
- marker navigation;
- overview navigation and dismissal;
- annotation editing;
- scroll-based repositioning;
- viewport fallback positioning;
- highlight clipping;
- marker updates after comment edits;
- long annotation overview scrolling;
- composer and overlay stacking behavior.

## Scope

This PR adds the client-side response annotation workflow and injects the resulting annotations into the next composer submission.

It does not introduce a new daemon RPC or change the existing wire protocol.

## Preview
<img width="1636" height="1578" alt="image" src="https://github.com/user-attachments/assets/17d79edc-f61c-4549-aad2-65d7542e5384" />
<img width="1666" height="1658" alt="image" src="https://github.com/user-attachments/assets/61a847c1-b5a2-496f-8bf0-6e792f0dce33" />
