### PR TITLE
Add opt-in terminal word shaping for contextual (calt) fonts like Fast-Font

### DIFF
--- a/packages/app/src/components/terminal-emulator-contract.ts
+++ b/packages/app/src/components/terminal-emulator-contract.ts
@@ -33,6 +33,7 @@ export interface TerminalEmulatorProps {
   scrollbackLines: number;
   fontFamily?: string;
   fontSize?: number;
+  wordShapingEnabled?: boolean;
   keyboardInset?: number;
   isKeyboardVisible?: boolean;
   swipeGesturesEnabled?: boolean;

--- a/packages/app/src/components/terminal-emulator.tsx
+++ b/packages/app/src/components/terminal-emulator.tsx
@@ -105,6 +105,7 @@ interface TerminalEmulatorProps {
   scrollbackLines: number;
   fontFamily?: string;
   fontSize?: number;
+  wordShapingEnabled?: boolean;
   keyboardInset?: number;
   isKeyboardVisible?: boolean;
   swipeGesturesEnabled?: boolean;
@@ -168,6 +169,7 @@ export default function TerminalEmulator({
   scrollbackLines,
   fontFamily,
   fontSize,
+  wordShapingEnabled = false,
   swipeGesturesEnabled = false,
   onSwipeLeft,
   onSwipeRight,
@@ -195,6 +197,8 @@ export default function TerminalEmulator({
   scrollbackLinesRef.current = scrollbackLines;
   fontFamilyRef.current = fontFamily;
   fontSizeRef.current = fontSize;
+  const wordShapingEnabledRef = useRef(wordShapingEnabled);
+  wordShapingEnabledRef.current = wordShapingEnabled;
   const themeKey = useMemo(() => buildXtermThemeKey(xtermTheme), [xtermTheme]);
   const xtermThemeRef = useRef(xtermTheme);
   xtermThemeRef.current = xtermTheme;
@@ -463,6 +467,7 @@ export default function TerminalEmulator({
       theme: mountedThemeRef.current,
       fontFamily: fontFamilyRef.current,
       fontSize: fontSizeRef.current,
+      wordShapingEnabled: wordShapingEnabledRef.current,
     });
     onRendererReadyChangeRef.current?.({ streamKey, isReady: true });
 
@@ -505,6 +510,10 @@ export default function TerminalEmulator({
   useEffect(() => {
     runtimeRef.current?.setFont({ fontFamily, fontSize });
   }, [fontFamily, fontSize]);
+
+  useEffect(() => {
+    runtimeRef.current?.setWordShapingEnabled(wordShapingEnabled);
+  }, [wordShapingEnabled]);
 
   useEffect(() => {
     if (focusRequestToken <= 0) {

--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -1053,6 +1053,7 @@ export function TerminalPane({
             scrollbackLines={settings.terminalScrollbackLines}
             fontFamily={terminalFontFamily}
             fontSize={settings.codeFontSize}
+            wordShapingEnabled={settings.terminalWordShaping}
             keyboardInset={keyboardInset}
             isKeyboardVisible={isKeyboardVisible}
             swipeGesturesEnabled={swipeGesturesEnabled}

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -123,6 +123,26 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.useLegacyTerminalRenderer).toBe(true);
   });
 
+  it("disables terminal word shaping by default", async () => {
+    const deps = makeDeps();
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.terminalWordShaping).toBe(false);
+  });
+
+  it("loads the terminal word shaping preference", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ terminalWordShaping: true }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.terminalWordShaping).toBe(true);
+  });
+
   it("loads configured terminal scrollback lines from app settings", async () => {
     const deps = makeDeps({
       storage: createInMemoryKeyValueStorage({

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -57,6 +57,7 @@ export interface AppSettings {
   serviceUrlBehavior: ServiceUrlBehavior;
   terminalScrollbackLines: number;
   useLegacyTerminalRenderer: boolean;
+  terminalWordShaping: boolean;
   uiFontFamily: string; // "" = platform default UI stack
   monoFontFamily: string; // "" = platform default mono stack
   uiFontSize: number; // clamped px, default 16
@@ -94,6 +95,7 @@ const StoredAppSettingsSchema = z.strictObject({
   serviceUrlBehavior: z.enum(["ask", "in-app", "external"]).optional(),
   terminalScrollbackLines: z.union([z.number(), z.string()]).optional(),
   useLegacyTerminalRenderer: z.boolean().optional(),
+  terminalWordShaping: z.boolean().optional(),
   uiFontFamily: z.string().optional(),
   monoFontFamily: z.string().optional(),
   uiFontSize: z.union([z.number(), z.string()]).optional(),
@@ -124,6 +126,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   serviceUrlBehavior: "ask",
   terminalScrollbackLines: DEFAULT_TERMINAL_SCROLLBACK_LINES,
   useLegacyTerminalRenderer: false,
+  terminalWordShaping: false,
   uiFontFamily: "",
   monoFontFamily: "",
   uiFontSize: DEFAULT_UI_FONT_SIZE,
@@ -274,6 +277,9 @@ function pickBooleanAppSettings(stored: StoredAppSettings): Partial<AppSettings>
   const result: Partial<AppSettings> = {};
   if (typeof stored.useLegacyTerminalRenderer === "boolean") {
     result.useLegacyTerminalRenderer = stored.useLegacyTerminalRenderer;
+  }
+  if (typeof stored.terminalWordShaping === "boolean") {
+    result.terminalWordShaping = stored.terminalWordShaping;
   }
   if (typeof stored.vimKeybindings === "boolean") {
     result.vimKeybindings = stored.vimKeybindings;

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1966,6 +1966,8 @@ export const ar: TranslationResources = {
         codeFontAccessibility: "عائلة خطوط الكود",
         codeSize: "حجم الكود",
         codeSizeAccessibility: "حجم خط الكود",
+        wordShaping: "تشكيل الكلمات في الطرفية",
+        wordShapingHint: "يشكّل الكلمات كاملة في الطرفية للخطوط السياقية مثل Fast-Font",
       },
       syntax: {
         title: "بناء الجملة",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -2021,6 +2021,8 @@ export const en = {
         codeFontAccessibility: "Code font family",
         codeSize: "Code size",
         codeSizeAccessibility: "Code font size",
+        wordShaping: "Terminal word shaping",
+        wordShapingHint: "Shape whole words in the terminal for contextual fonts like Fast-Font",
       },
       syntax: {
         title: "Syntax",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -2014,6 +2014,9 @@ export const es: TranslationResources = {
         codeFontAccessibility: "Familia de fuentes de código",
         codeSize: "Tamaño del código",
         codeSizeAccessibility: "Tamaño de fuente del código",
+        wordShaping: "Modelado de palabras en la terminal",
+        wordShapingHint:
+          "Da forma a palabras completas en la terminal para fuentes contextuales como Fast-Font",
       },
       syntax: {
         title: "Sintaxis",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -2017,6 +2017,9 @@ export const fr: TranslationResources = {
         codeFontAccessibility: "Famille de polices de code",
         codeSize: "Taille du code",
         codeSizeAccessibility: "Taille de la police du code",
+        wordShaping: "Composition des mots du terminal",
+        wordShapingHint:
+          "Compose les mots entiers dans le terminal pour les polices contextuelles comme Fast-Font",
       },
       syntax: {
         title: "Syntaxe",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1982,6 +1982,9 @@ export const ja: TranslationResources = {
         codeFontAccessibility: "コードフォントファミリー",
         codeSize: "コードサイズ",
         codeSizeAccessibility: "コードフォントサイズ",
+        wordShaping: "ターミナルの単語シェイピング",
+        wordShapingHint:
+          "Fast-Font などのコンテキストフォントに対応し、ターミナル内で単語単位のシェイピングを行います",
       },
       syntax: {
         title: "構文ハイライト",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1977,6 +1977,8 @@ export const ko: TranslationResources = {
         codeFontAccessibility: "코드 글꼴 패밀리",
         codeSize: "코드 크기",
         codeSizeAccessibility: "코드 글꼴 크기",
+        wordShaping: "터미널 단어 셰이핑",
+        wordShapingHint: "Fast-Font 같은 컨텍스트 글꼴을 위해 터미널에서 단어 전체를 셰이핑합니다",
       },
       syntax: {
         title: "구문",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1997,6 +1997,9 @@ export const ptBR: TranslationResources = {
         codeFontAccessibility: "Família da fonte de código",
         codeSize: "Tamanho do código",
         codeSizeAccessibility: "Tamanho da fonte de código",
+        wordShaping: "Modelagem de palavras no terminal",
+        wordShapingHint:
+          "Modela palavras inteiras no terminal para fontes contextuais como Fast-Font",
       },
       syntax: {
         title: "Sintaxe",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -2003,6 +2003,9 @@ export const ru: TranslationResources = {
         codeFontAccessibility: "Семейство шрифтов кода",
         codeSize: "Размер кода",
         codeSizeAccessibility: "Размер шрифта кода",
+        wordShaping: "Формирование слов в терминале",
+        wordShapingHint:
+          "Формирует целые слова в терминале для контекстных шрифтов вроде Fast-Font",
       },
       syntax: {
         title: "Синтаксис",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1943,6 +1943,8 @@ export const zhCN: TranslationResources = {
         codeFontAccessibility: "代码字体族",
         codeSize: "代码字号",
         codeSizeAccessibility: "代码字号",
+        wordShaping: "终端整词成形",
+        wordShapingHint: "为 Fast-Font 等上下文字体在终端中按整词成形",
       },
       syntax: {
         title: "语法",

--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -546,6 +546,11 @@ export function AppearanceSection() {
     [settings.monoFontFamily, updateSettings],
   );
 
+  const handleTerminalWordShapingChange = useCallback(
+    (terminalWordShaping: boolean) => void updateSettings({ terminalWordShaping }),
+    [updateSettings],
+  );
+
   const handleUiSizeChange = useCallback((value: string) => {
     setUiSizeDraft(value.replace(/[^\d]/g, ""));
   }, []);
@@ -657,6 +662,24 @@ export function AppearanceSection() {
             onChangeDraft={handleCodeSizeChange}
             onCommit={commitCodeSize}
           />
+          {showFontFamilyRows ? (
+            <View style={settingsStyles.row}>
+              <View style={settingsStyles.rowContent}>
+                <Text style={settingsStyles.rowTitle}>
+                  {t("settings.appearance.fonts.wordShaping")}
+                </Text>
+                <Text style={settingsStyles.rowHint}>
+                  {t("settings.appearance.fonts.wordShapingHint")}
+                </Text>
+              </View>
+              <Switch
+                value={settings.terminalWordShaping}
+                onValueChange={handleTerminalWordShapingChange}
+                accessibilityLabel={t("settings.appearance.fonts.wordShaping")}
+                testID="terminal-word-shaping-toggle"
+              />
+            </View>
+          ) : null}
         </View>
       </SettingsSection>
       <SettingsSection title={t("settings.appearance.syntax.title")}>

--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -29,6 +29,7 @@ import {
   type TerminalLocalFileLinkTarget,
 } from "../local-links/terminal-local-link-provider";
 import { resolveTerminalFontFamily, resolveTerminalFontSize } from "./terminal-font";
+import { enableTerminalWordShaping } from "./terminal-word-shaping";
 
 export type TerminalOutputData = Uint8Array;
 
@@ -40,6 +41,7 @@ export interface TerminalEmulatorRuntimeMountInput {
   theme: ITheme;
   fontFamily?: string;
   fontSize?: number;
+  wordShapingEnabled?: boolean;
 }
 
 export interface TerminalEmulatorRuntimeCallbacks {
@@ -190,6 +192,8 @@ export class TerminalEmulatorRuntime {
   private hasUngatedWrites = false;
   private readonly inputModeDecoder = new TextDecoder();
   private suppressInput = false;
+  private wordShapingEnabled = false;
+  private disableWordShaping: (() => void) | null = null;
   private readonly inputModeTracker = new TerminalInputModeTracker();
   private lastInputModeState: TerminalInputModeState = this.inputModeTracker.getState();
   private themeBackgroundElements: HTMLElement[] = [];
@@ -357,6 +361,10 @@ export class TerminalEmulatorRuntime {
     this.terminal = terminal;
     this.fitAddon = fitAddon;
     window.__paseoTerminal = terminal;
+    this.wordShapingEnabled = input.wordShapingEnabled ?? false;
+    if (this.wordShapingEnabled) {
+      this.disableWordShaping = enableTerminalWordShaping(terminal);
+    }
 
     const fitAndEmitResize = (resizeInput?: TerminalResizeRequest): void => {
       const forceRefresh = resizeInput?.forceRefresh ?? false;
@@ -726,6 +734,24 @@ export class TerminalEmulatorRuntime {
     this.refreshVisibleRows();
   }
 
+  setWordShapingEnabled(enabled: boolean): void {
+    const terminal = this.terminal;
+    if (!terminal || this.wordShapingEnabled === enabled) {
+      return;
+    }
+    this.wordShapingEnabled = enabled;
+    try {
+      this.disableWordShaping?.();
+    } catch {
+      // ignore
+    }
+    this.disableWordShaping = null;
+    if (enabled) {
+      this.disableWordShaping = enableTerminalWordShaping(terminal);
+    }
+    this.refreshVisibleRows();
+  }
+
   focus(input?: { forceRefocus?: boolean }): void {
     const terminal = this.terminal;
     if (!terminal) {
@@ -801,6 +827,8 @@ export class TerminalEmulatorRuntime {
     this.lastSize = null;
     this.themeBackgroundElements = [];
     this.suppressInput = false;
+    this.wordShapingEnabled = false;
+    this.disableWordShaping = null;
     this.inputModeDecoder.decode();
     this.inputModeTracker.reset();
     this.emitInputModeChange();

--- a/packages/app/src/terminal/runtime/terminal-word-shaping.test.ts
+++ b/packages/app/src/terminal/runtime/terminal-word-shaping.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { terminalWordShapingRanges } from "./terminal-word-shaping";
+
+describe("terminalWordShapingRanges", () => {
+  it("joins word runs", () => {
+    expect(terminalWordShapingRanges("hello world")).toEqual([
+      [0, 5],
+      [6, 11],
+    ]);
+  });
+
+  it("keeps identifiers whole across underscores and digits", () => {
+    expect(terminalWordShapingRanges("src/main.ts")).toEqual([
+      [0, 3],
+      [4, 8],
+      [9, 11],
+    ]);
+    expect(terminalWordShapingRanges("snake_case_42")).toEqual([[0, 13]]);
+  });
+
+  it("joins unicode letter runs", () => {
+    expect(terminalWordShapingRanges("Überprüfung läuft")).toEqual([
+      [0, 11],
+      [12, 17],
+    ]);
+  });
+
+  it("skips single characters, punctuation, spaces, and symbols", () => {
+    expect(terminalWordShapingRanges("a => b -> c")).toEqual([]);
+    expect(terminalWordShapingRanges("   ...---...   ")).toEqual([]);
+  });
+
+  it("returns no ranges for empty text", () => {
+    expect(terminalWordShapingRanges("")).toEqual([]);
+  });
+
+  it("does not join across non-word boundaries like apostrophes or hyphens", () => {
+    expect(terminalWordShapingRanges("don't well-known")).toEqual([
+      [0, 3],
+      [6, 10],
+      [11, 16],
+    ]);
+  });
+});

--- a/packages/app/src/terminal/runtime/terminal-word-shaping.ts
+++ b/packages/app/src/terminal/runtime/terminal-word-shaping.ts
@@ -1,0 +1,40 @@
+import type { Terminal } from "@xterm/xterm";
+
+/**
+ * Word-level shaping ranges for fonts whose behavior lives in OpenType contextual
+ * features (`calt`), such as Fast-Font. xterm renders each cell in isolation, so a
+ * character joiner must hand whole words to the renderer as a single unit for the
+ * platform shaper (HarfBuzz/CoreText) to apply the font's own contextual rules.
+ *
+ * The joiner intentionally does not parse the font: contextual fonts regularly use
+ * GSUB constructs that JS font parsers in this dependency tree do not support
+ * (Fast-Font's `calt` uses extension-wrapped format-3 chains, which both
+ * `font-ligatures` and `opentype.js` fail to read). The renderer's own shaper
+ * handles them fine as long as runs are joined.
+ */
+
+// Letter and number runs (plus underscore so identifiers stay whole; the font's
+// own classes decide where substitutions actually apply inside the run). Word
+// characters only: CJK/emoji/wide glyphs are left to per-cell rendering.
+const WORD_RUN = /[\p{L}\p{N}_]+/gu;
+
+export function terminalWordShapingRanges(text: string): [number, number][] {
+  const ranges: [number, number][] = [];
+  for (const match of text.matchAll(WORD_RUN)) {
+    const start = match.index;
+    const end = start + match[0].length;
+    // Single characters render identically either way; skipping them avoids
+    // pointless joined-glyph atlas entries.
+    if (end - start > 1) {
+      ranges.push([start, end]);
+    }
+  }
+  return ranges;
+}
+
+export function enableTerminalWordShaping(terminal: Terminal): () => void {
+  const joinerId = terminal.registerCharacterJoiner(terminalWordShapingRanges);
+  return () => {
+    terminal.deregisterCharacterJoiner(joinerId);
+  };
+}


### PR DESCRIPTION
## Problem

Fonts whose behavior lives in OpenType contextual features (`calt`) — e.g. [Fast-Font](https://github.com/Born2Root/Fast-Font), which bolds the leading portion of every word to guide reading — render as plain text in the terminal, while working fine everywhere else in the app.

The terminal renders each cell in isolation, so the platform shaper never sees a whole word and contextual substitution never fires. xterm.js already has the mechanism for this (`registerCharacterJoiner`: joined ranges are rasterized as one run through the browser's shaper), but nothing registers word-level joins, so `calt` fonts get per-letter shaping and render plain.

I want to read terminal output with a contextual font; today that only works in editors and browsers, not in Paseo.

## Change

One opt-in setting: **Settings → Appearance → Fonts → "Terminal word shaping"** (off by default).

- New `terminal-word-shaping.ts`: a character joiner that returns `[letter|digit|_]` runs of 2+ characters, so the renderer shapes whole words and the font's own `calt` rules apply. The joiner deliberately does not parse font files — contextual fonts regularly use GSUB structures that the JS font parsers in this tree can't read (Fast-Font's `calt` is extension-wrapped format-3 chains; both `font-ligatures` and `opentype.js` fail on it), while the browser's shaper handles them fine as long as runs are joined.
- `TerminalEmulatorRuntime` gains `wordShapingEnabled` at mount and `setWordShapingEnabled()` for live toggling; wired through the web terminal component and pane.
- Setting persisted with the other app settings, defaults to false. UI row sits next to the code font input and follows the same visibility rules.
- Strings translated for all locales.

Off by default because joining words costs atlas texture space for zero visual benefit on fonts without contextual features.

## Not in scope

- Mobile native-grid renderer (draws per-cell without xterm; unchanged behavior).
- Auto-detecting `calt` fonts: would require reading font binaries (Local Font Access permission) or shipping a font parser that handles these GSUB structures. Opt-in is simpler and permission-free.

## Tests

- `terminal-word-shaping.test.ts`: word/identifier/unicode ranges, punctuation and single-char exclusion, empty input (6 cases).
- `use-settings/storage.test.ts`: default false + persisted round-trip.
- Suite results: `vitest run src/terminal src/hooks` → **469 passed, 18 skipped**; `oxlint` → 0 warnings; `oxfmt --check` clean; full workspace `tsgo --noEmit` clean.

## QA evidence

Verified on the dev web app (`npm run dev:app`) with Fast_Mono and Fast_Sans installed, driving the real settings UI, WebGL renderer:

| State | Measured word ink ratio (left/right half) | Words with bold-leading |
|---|---|---|
| Toggle ON, Fast_Mono | 1.234 | 16/25 |
| Toggle OFF, Fast_Mono | 0.969 | 3/32 |
| Toggle ON, Fast_Sans | 1.309 | 20/31 |

(Ink ratio > 1 = leading letters bolder, i.e. the font's designed behavior.)

Screenshots (evidence branch [`evidence-terminal-word-shaping`](https://github.com/Ni7e/paseo/tree/evidence-terminal-word-shaping)):

| Setting off | Setting on |
|---|---|
| ![off](https://raw.githubusercontent.com/Ni7e/paseo/evidence-terminal-word-shaping/evidence/word-shaping-off.png) | ![on](https://raw.githubusercontent.com/Ni7e/paseo/evidence-terminal-word-shaping/evidence/word-shaping-on.png) |

Known-inherent xterm behaviors, unchanged by this PR: a word containing the cursor drops its join while the cursor is inside it; words with mid-word color changes split at the color boundary (same as VS Code).

Side observation (not addressed here): `LigaturesAddon` is loaded before `terminal.open()`, so its `activate()` throws and is silently caught — the fallback operator ligatures it would provide (`->`, `=>`) never render today either. Happy to split that into a separate fix if useful.

## Platforms

- Tested: macOS (dev web app, Chrome + SwiftShader WebGL)
- Not tested: Windows, Linux, mobile (mobile renderer intentionally unchanged)
