### PR TITLE
fix: preserve settings sidebar scroll position

### DIFF
--- a/packages/app/e2e/browser/settings-navigation.spec.ts
+++ b/packages/app/e2e/browser/settings-navigation.spec.ts
@@ -73,6 +73,29 @@ test.describe("Settings sidebar navigation", () => {
     await expectAppearanceContent(page);
   });
 
+  test("sidebar scroll position survives section navigation", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 500 });
+    await gotoAppShell(page);
+    await openSettings(page);
+
+    const sidebarScroll = page.getByTestId("settings-sidebar-scroll");
+    await sidebarScroll.evaluate((element) => {
+      element.scrollTo({ top: 160 });
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    const scrollOffset = await sidebarScroll.evaluate((element) => element.scrollTop);
+    expect(scrollOffset).toBeGreaterThan(0);
+    await expect(sidebarScroll.getByRole("button", { name: "About", exact: true })).toBeVisible();
+
+    await openSettingsSection(page, "about");
+    await expectSettingsHeader(page, "About");
+    await expectAboutContent(page);
+
+    const replacementSidebarScroll = page.getByTestId("settings-sidebar-scroll");
+    await expect(replacementSidebarScroll).toBeVisible();
+    await expect(replacementSidebarScroll).toHaveJSProperty("scrollTop", scrollOffset);
+  });
+
   test("/h/[serverId]/settings redirects to the host connections section", async ({ page }) => {
     await gotoAppShell(page);
     await verifyLegacyHostSettingsRedirect(page);

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -7,6 +7,8 @@ import {
   Text,
   TextInput,
   View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   type PressableStateCallbackType,
 } from "react-native";
 import { useRouter } from "expo-router";
@@ -268,6 +270,7 @@ function getActiveLocale(language: string | undefined): SupportedLocale {
 }
 
 const SERVICE_URL_BEHAVIOR_VALUES: ServiceUrlBehavior[] = ["ask", "in-app", "external"];
+let desktopSidebarScrollOffset = 0;
 
 // ---------------------------------------------------------------------------
 // Section components
@@ -1018,6 +1021,7 @@ function SettingsSidebar({
   const items = SIDEBAR_SECTION_ITEMS.filter((item) => !item.desktopOnly || isDesktopApp);
   const insets = useSafeAreaInsets();
   const isDesktop = layout === "desktop";
+  const scrollViewRef = useRef<ScrollView>(null);
   const outerContainerStyle = useMemo(
     () => [isDesktop ? sidebarStyles.desktopContainer : sidebarStyles.mobileContainer],
     [isDesktop],
@@ -1027,6 +1031,13 @@ function SettingsSidebar({
     [insets.top, isDesktop],
   );
   const selectedSectionId = view.kind === "section" ? view.section : null;
+  const handleSidebarScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    desktopSidebarScrollOffset = event.nativeEvent.contentOffset.y;
+  }, []);
+  useEffect(() => {
+    if (!isDesktop) return;
+    scrollViewRef.current?.scrollTo({ y: desktopSidebarScrollOffset, animated: false });
+  }, [isDesktop]);
   let selectedHostSection: HostSectionSlug | null = null;
   if (view.kind === "host") selectedHostSection = view.section;
   if (view.kind === "project") selectedHostSection = "projects";
@@ -1120,7 +1131,14 @@ function SettingsSidebar({
               testID="settings-back-to-workspace"
             />
           </View>
-          <ScrollView style={sidebarStyles.scrollBody} showsVerticalScrollIndicator={false}>
+          <ScrollView
+            ref={scrollViewRef}
+            style={sidebarStyles.scrollBody}
+            showsVerticalScrollIndicator={false}
+            onScroll={handleSidebarScroll}
+            scrollEventThrottle={16}
+            testID="settings-sidebar-scroll"
+          >
             {sidebarBody}
           </ScrollView>
         </View>


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Keep the last desktop settings-sidebar offset in module-owned transient state, update it from the production `ScrollView` scroll callback, and restore it without animation when a route change mounts the replacement sidebar. Scope the behavior to the desktop sidebar; compact settings replaces the list with a detail screen and should retain its existing navigation behavior. Give the scroll viewport a stable test ID, then extend the existing settings navigation Playwright spec to scroll the real viewport, select a sidebar destination, wait for the route/content transition, and assert that the replacement viewport retains the same non-zero offset.

Closes #1532

### Goals

Not applicable to this change.

### Non-goals

Not applicable to this change.

### QA

Not applicable to this change.

### Checklist

- [ ] One focused change
- [ ] `npm run typecheck` passes
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `npm run lint` passes
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `npm run format` passes
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] QA evidence
- [x] Tests added or updated where it made sense

AI was used for assistance.
