### PR TITLE
feat(app): adapt desktop shell for Android tablets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36198,7 +36198,8 @@
         "use-sync-external-store": "^1.6.0",
         "yaml": "^2.8.4",
         "zod": "^4.4.3",
-        "zustand": "^5.0.9"
+        "zustand": "^5.0.9",
+        "expo-screen-orientation": "~9.0.9"
       },
       "devDependencies": {
         "@playwright/test": "^1.56.1",
@@ -41500,6 +41501,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-screen-orientation": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-9.0.9.tgz",
+      "integrity": "sha512-UTU745XoqBvQJkZ820GTfMuOxlkppYqaeQ+x0wdu44cyrZiZugqe+egFF2+zC+SaxgAltU5EuO8GIj9xSF+YMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     }
   }

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const pkg = require("./package.json");
 const withAndroidAsyncStorageSize = require("./plugins/with-android-async-storage-size");
 const withAndroidProfileable = require("./plugins/with-android-profileable");
+const withAndroidRotationUnlocked = require("./plugins/with-android-rotation");
 const withFdroidAutolinking = require("./plugins/with-fdroid-autolinking");
 const withPasteInput = require("./plugins/with-paste-input");
 const { getNativeReleaseVersion } = require("./native-release-version");
@@ -177,6 +178,7 @@ export default {
       ],
       ...buildProfile.fdroidPlugins,
       ...(isProfileBuild ? [withAndroidProfileable] : []),
+      withAndroidRotationUnlocked,
     ],
     experiments: {
       typedRoutes: true,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -87,6 +87,7 @@
     "expo-localization": "~17.0.9",
     "expo-notifications": "^0.32.16",
     "expo-router": "~6.0.13",
+    "expo-screen-orientation": "~9.0.9",
     "expo-sharing": "^14.0.8",
     "expo-splash-screen": "~31.0.10",
     "expo-system-ui": "~6.0.7",

--- a/packages/app/plugins/with-android-rotation.js
+++ b/packages/app/plugins/with-android-rotation.js
@@ -1,0 +1,28 @@
+const { withAndroidManifest } = require("expo/config-plugins");
+
+// The global `orientation` field stays "portrait" so iOS keeps its static
+// lock (rotating the iPadOS app crashes it, see getpaseo/paseo#1030). On
+// Android that same declaration letterboxes the app into a phone-sized
+// window on landscape tablets (getpaseo/paseo#1669), so re-write the
+// activities to follow the system instead.
+//
+// This must run inside a manifest mod: custom plugins register their mods
+// before Expo's withDefaultPlugins, and mod chains execute outside-in, so
+// this modification lands last and wins over the built-in portrait write.
+function withAndroidRotationUnlocked(config) {
+  return withAndroidManifest(config, (modConfig) => {
+    const manifest = modConfig.modResults.manifest;
+    const application = manifest.application?.[0];
+    if (!application) {
+      throw new Error("Could not unlock Android rotation without an application manifest entry");
+    }
+    for (const activity of application.activity ?? []) {
+      if (activity.$?.["android:screenOrientation"]) {
+        activity.$["android:screenOrientation"] = "unspecified";
+      }
+    }
+    return modConfig;
+  });
+}
+
+module.exports = withAndroidRotationUnlocked;

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -80,6 +80,7 @@ import { loadDesktopSettings } from "@/desktop/settings/desktop-settings";
 import { RosettaCalloutSource } from "@/desktop/updates/rosetta-callout-source";
 import { UpdateCalloutSource } from "@/desktop/updates/update-callout-source";
 import { useActiveWorktreeNewAction } from "@/hooks/use-active-worktree-new-action";
+import { useAdaptiveOrientation } from "@/hooks/use-adaptive-orientation";
 import { useGlobalNewWorkspaceAction } from "@/hooks/use-global-new-workspace-action";
 import { useLatchedBoolean } from "@/hooks/use-latched-boolean";
 import { useFaviconStatus } from "@/hooks/use-favicon-status";
@@ -946,6 +947,7 @@ function WorkspaceRouteNavigationBridge() {
 }
 
 function AppShell() {
+  useAdaptiveOrientation();
   return (
     <MobilePanelsProvider>
       <HorizontalScrollProvider>

--- a/packages/app/src/components/diff-viewer.tsx
+++ b/packages/app/src/components/diff-viewer.tsx
@@ -9,9 +9,17 @@ import { syntaxTokenStyleFor } from "@/styles/syntax-token-styles";
 import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { getCodeInsets } from "./code-insets";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
+import { useIsCompactFormFactor } from "@/constants/layout";
 import { isWeb } from "@/constants/platform";
 
-const ScrollView = isWeb ? RNScrollView : GHScrollView;
+export function useDetailScrollView(): React.ComponentType<React.ComponentProps<typeof RNScrollView>> {
+  const isCompact = useIsCompactFormFactor();
+  // Web and the desktop shell scroll through the RN list that hosts this
+  // surface, so native gesture-handler scroll views would fight the parent
+  // FlatList (Android nested-scroll direction mismatch on inverted lists).
+  // Keep RNGH only for the compact sheet, which is RNGH-owned.
+  return isWeb || !isCompact ? RNScrollView : GHScrollView;
+}
 
 interface DiffViewerProps {
   diffLines: DiffLine[];
@@ -124,6 +132,7 @@ export function DiffViewer({
   fillAvailableHeight = false,
 }: DiffViewerProps) {
   const { t } = useTranslation();
+  const ScrollView = useDetailScrollView();
   const [scrollViewWidth, setScrollViewWidth] = React.useState(0);
   const resolvedEmptyLabel = emptyLabel ?? t("diffViewer.empty");
   const handleInnerLayout = React.useCallback(

--- a/packages/app/src/components/tool-call-details.tsx
+++ b/packages/app/src/components/tool-call-details.tsx
@@ -6,7 +6,6 @@ import {
   type StyleProp,
   type ViewStyle,
 } from "react-native";
-import { ScrollView as GHScrollView } from "react-native-gesture-handler";
 import { StyleSheet } from "react-native-unistyles";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
@@ -18,11 +17,9 @@ import { inlineUnistylesStyle } from "@/styles/unistyles-inline-style";
 import { CODE_SURFACE_DATASET } from "@/styles/code-surface";
 import { extensionFromPath, highlightToKeyedLines } from "@/utils/highlight-cache";
 import { HighlightedLines } from "./highlighted-content";
-import { DiffViewer } from "./diff-viewer";
+import { DiffViewer, useDetailScrollView } from "./diff-viewer";
 import { getCodeInsets } from "./code-insets";
 import { isWeb } from "@/constants/platform";
-
-const ScrollView = isWeb ? RNScrollView : GHScrollView;
 
 // ---- Content Component ----
 
@@ -149,6 +146,7 @@ interface ShellDetailProps {
 }
 
 function ShellDetailSection({ command, output, ds }: ShellDetailProps) {
+  const ScrollView = useDetailScrollView();
   const normalizedCommand = command.replace(/\n+$/, "");
   const commandOutput = (output ?? "").replace(/^\n+/, "");
   const hasOutput = commandOutput.length > 0;
@@ -194,6 +192,7 @@ function WorktreeSetupDetailSection({
   worktreePath,
   ds,
 }: WorktreeSetupDetailProps) {
+  const ScrollView = useDetailScrollView();
   const setupLog = log.replace(/^\n+/, "");
   const hasLog = setupLog.length > 0;
   return (
@@ -353,6 +352,7 @@ function SubAgentDetailSection({
   ds,
 }: SubAgentDetailProps) {
   const { t } = useTranslation();
+  const ScrollView = useDetailScrollView();
   const { actions, remainingLog } = useMemo(() => parseSubAgentLog(log), [log]);
   const fallbackHeader = resolveSubAgentFallbackHeader(
     subAgentType,
@@ -438,6 +438,7 @@ function ScrollableTextSection({
   filePath,
   startLine,
 }: ScrollableContentProps) {
+  const ScrollView = useDetailScrollView();
   const keyedLines = useMemo(
     () => (filePath ? highlightToKeyedLines(content, extensionFromPath(filePath)) : null),
     [content, filePath],
@@ -471,6 +472,7 @@ interface FetchDetailProps {
 }
 
 function FetchDetailSection({ url, result, ds }: FetchDetailProps) {
+  const ScrollView = useDetailScrollView();
   return (
     <View style={ds.sectionFillStyle}>
       <ScrollView
@@ -490,6 +492,7 @@ function FetchDetailSection({ url, result, ds }: FetchDetailProps) {
 }
 
 function ScrollablePlainTextSection({ text, ds }: { text: string; ds: DetailStyles }) {
+  const ScrollView = useDetailScrollView();
   return (
     <View style={styles.section}>
       <ScrollView
@@ -514,7 +517,11 @@ interface SearchDetail {
   annotations?: string[];
 }
 
-function buildSearchSections(detail: SearchDetail, ds: DetailStyles): ReactNode[] {
+function buildSearchSections(
+  detail: SearchDetail,
+  ds: DetailStyles,
+  ScrollView: React.ComponentType<React.ComponentProps<typeof RNScrollView>>,
+): ReactNode[] {
   const out: ReactNode[] = [];
   if (detail.content) {
     out.push(
@@ -577,7 +584,12 @@ interface UnknownDetail {
   output: unknown;
 }
 
-function buildUnknownSections(detail: UnknownDetail, ds: DetailStyles, t: TFunction): ReactNode[] {
+function buildUnknownSections(
+  detail: UnknownDetail,
+  ds: DetailStyles,
+  t: TFunction,
+  ScrollView: React.ComponentType<React.ComponentProps<typeof RNScrollView>>,
+): ReactNode[] {
   const plainInputText =
     typeof detail.input === "string" && detail.output === null ? detail.input : null;
 
@@ -631,6 +643,7 @@ function buildDetailSections(
   diffLines: DiffLine[] | undefined,
   ds: DetailStyles,
   t: TFunction,
+  ScrollView: React.ComponentType<React.ComponentProps<typeof RNScrollView>>,
 ): ReactNode[] {
   if (!detail) return [];
   if (detail.type === "shell") {
@@ -691,7 +704,7 @@ function buildDetailSections(
     ];
   }
   if (detail.type === "search") {
-    return buildSearchSections(detail, ds);
+    return buildSearchSections(detail, ds, ScrollView);
   }
   if (detail.type === "fetch") {
     return [<FetchDetailSection key="fetch" url={detail.url} result={detail.result} ds={ds} />];
@@ -701,13 +714,14 @@ function buildDetailSections(
     return [<ScrollablePlainTextSection key="plain-text" text={detail.text} ds={ds} />];
   }
   if (detail.type === "unknown") {
-    return buildUnknownSections(detail, ds, t);
+    return buildUnknownSections(detail, ds, t, ScrollView);
   }
   return [];
 }
 
 function ErrorSection({ errorText, ds }: { errorText: string; ds: DetailStyles }) {
   const { t } = useTranslation();
+  const ScrollView = useDetailScrollView();
   return (
     <View style={styles.section}>
       <Text style={[styles.sectionTitle, styles.errorText]}>{t("toolCallDetails.error")}</Text>
@@ -748,11 +762,12 @@ export function ToolCallDetailsContent({
   showLoadingSkeleton = false,
 }: ToolCallDetailsContentProps) {
   const { t } = useTranslation();
+  const ScrollView = useDetailScrollView();
   const resolvedMaxHeight = fillAvailableHeight ? undefined : (maxHeight ?? 300);
   const ds = useDetailStyles(detail, resolvedMaxHeight, fillAvailableHeight);
   const diffLines = useDiffLines(detail);
 
-  const sections: ReactNode[] = buildDetailSections(detail, diffLines, ds, t);
+  const sections: ReactNode[] = buildDetailSections(detail, diffLines, ds, t, ScrollView);
 
   if (errorText) {
     sections.push(<ErrorSection key="error" errorText={errorText} ds={ds} />);

--- a/packages/app/src/hooks/use-adaptive-orientation.ts
+++ b/packages/app/src/hooks/use-adaptive-orientation.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { Platform, useWindowDimensions } from "react-native";
+import * as ScreenOrientation from "expo-screen-orientation";
+
+// Phones must stay portrait: in landscape a phone window is wide enough to
+// cross the desktop layout breakpoint, which renders the desktop shell in a
+// phone-sized window (crowded footer, compressed session list). Tablets keep
+// free rotation — see getpaseo/paseo#1669 for the letterboxing this pair
+// with the with-android-rotation config plugin fixes.
+// Keyed off the window's short side so split-screen windows behave.
+const TABLET_MIN_SHORT_SIDE = 600; // dp
+
+export function useAdaptiveOrientation(): void {
+  const { width, height } = useWindowDimensions();
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+    const shortSide = Math.min(width, height);
+    if (shortSide < TABLET_MIN_SHORT_SIDE) {
+      void ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+    } else {
+      void ScreenOrientation.unlockAsync();
+    }
+  }, [width, height]);
+}

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -56,6 +56,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { MobileTabTrailingAccessory } from "@/screens/workspace/workspace-tab-trailing-accessory";
 import { Shortcut } from "@/components/ui/shortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
@@ -575,6 +576,13 @@ function TabChip({
         },
       } as const)
     : undefined;
+  const tabMenuTriggerBlockers = useMemo(() => {
+    if (!isNative) return undefined;
+    const stop = (event: { stopPropagation?: () => void }) => {
+      event.stopPropagation?.();
+    };
+    return { onPointerDown: stop, onMouseDown: stop, onPressIn: stop, onPress: stop } as const;
+  }, []);
 
   const tabChipStyle = useCallback(
     () => [
@@ -661,7 +669,6 @@ function TabChip({
               {...(dragHandleProps?.listeners as object | undefined)}
               testID={`workspace-tab-${buildDeterministicWorkspaceTabId(tab.target)}`}
               triggerRef={dragHandleProps?.setActivatorNodeRef as unknown as undefined}
-              enabledOnMobile={false}
               style={tabChipStyle}
               onHoverIn={handleTabHoverIn}
               onHoverOut={handleTabHoverOut}
@@ -719,6 +726,14 @@ function TabChip({
                     );
                   }}
                 </Pressable>
+              ) : null}
+              {isNative ? (
+                <MobileTabTrailingAccessory
+                  menuTestIDBase={contextMenuTestId}
+                  presentationLabel={tooltipLabel}
+                  menuEntries={menuEntries}
+                  triggerProps={tabMenuTriggerBlockers}
+                />
               ) : null}
             </ContextMenuTrigger>
           </TooltipTrigger>

--- a/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.tsx
@@ -88,10 +88,15 @@ export function MobileTabTrailingAccessory({
   menuTestIDBase,
   presentationLabel,
   menuEntries,
+  triggerProps,
 }: {
   menuTestIDBase: string;
   presentationLabel: string;
   menuEntries: WorkspaceTabMenuEntry[];
+  triggerProps?: Omit<
+    React.ComponentProps<typeof DropdownMenuTrigger>,
+    "children" | "style" | "testID" | "accessibilityRole" | "accessibilityLabel" | "hitSlop"
+  >;
 }): ReactElement {
   const { t } = useTranslation();
   return (
@@ -102,6 +107,7 @@ export function MobileTabTrailingAccessory({
         accessibilityLabel={t("workspace.tabs.menu.openFor", { label: presentationLabel })}
         hitSlop={8}
         style={mobileTabMenuTriggerStyle}
+        {...triggerProps}
       >
         <ThemedEllipsis size={14} uniProps={mutedColorMapping} />
       </DropdownMenuTrigger>


### PR DESCRIPTION
### Linked issue

Closes #1669

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

**中文**：在 Android 平板上，横屏时应用被 letterbox 成手机尺寸的窗口，无法全屏使用；解锁横屏后，桌面壳依赖的 hover/右键/中键在 Android 上都不存在，导致 tab 无法打开菜单；工具输出详情若沿用桌面壳的内联（inline）渲染，其内部的滚动视图会嵌套在反向（inverted）的会话列表中——Android 的嵌套滚动方向与 inverted 列表不一致，且外层 Pressable 会无条件抢占触摸响应，实测表现为无法滚动或滚动方向错乱，因此改走与手机端一致的 sheet 弹层（RNGH 容器），从架构上消除嵌套冲突。另外，分屏或自由窗口缩放时布局不会随窗口宽度切换。本 PR 解决上述问题，使平板能够全屏、可操作地使用 Paseo。

**English**: On Android tablets, the app was letterboxed into a phone-sized window in landscape and couldn't be used full-screen. After unlocking landscape, the desktop shell relies on hover/right-click/middle-click, none of which exist on Android, so tabs had no reachable menu. For tool output details, keeping the desktop shell's inline rendering would nest the inner scroll view inside the inverted conversation list — Android's nested-scroll direction conflicts with the inverted list, and the wrapping Pressable unconditionally claims the touch responder, which we verified as either frozen or direction-inverted scrolling. We therefore route tool details through the same sheet the phone uses (an RNGH-owned container), eliminating the nesting conflict at the architecture level. Split-screen and free-form window resizes also never flipped the layout to match the new width. This PR fixes these issues so tablets can use Paseo full-screen and interactively.

### Goals

- Android tablets get full-screen landscape rendering (no more letterboxing), while phones stay portrait-locked
- Desktop-shell tabs get a touch-reachable menu (always-visible overflow button plus long-press) on native
- Tool output details scroll correctly on the tablet desktop shell by routing through the sheet, matching the phone interaction
- Split-screen / free-form window resizes switch the layout (desktop shell ↔ mobile shell) in real time
- No behavior change on Web or desktop

### Non-goals

- No tablet-specific UI rework (e.g. dual-tree transition animations, panel-scoped sheets)
- iPadOS rotation stays locked as before (#1030)
- No new buttons on file lists / diff rows — mobile never had them, so nothing is added
- Layout switch cost (~1s full-tree rebuild) is accepted as-is, no performance work

### QA

**Device (Xiaomi Pad 8, Android):**
- Landscape full-screen → desktop shell renders fully; tab overflow button opens the menu, long-press also opens it
- Tool output block → sheet opens; horizontal and vertical scrolling work; pull-down closes
- Permission-card command preview → inline scrolling works
- Split-screen shrink → layout flips to mobile shell; enlarge → flips back
- Phone portrait lock preserved
- 200-line output block scrolls to first/last line

**Web (local `  `expo export`  ` + static server):**
- Layout switches correctly at 500px / 900px / 1100px with no navigation regression
- Settings page stays on the current route after resizes

**Automated tests:** `  `vitest`  ` — 3 related files, 11 tests pass. `  `typecheck`  ` passes (1 pre-existing environment error unrelated to this PR). `  `lint`  ` passes. `  `prettier`  ` clean on touched files.

**Not tested:** iOS (no device), Electron desktop.

### Checklist

- [x] One focused change
- [x] `  `npm run typecheck`  ` passes
- [x] `  `npm run lint`  ` passes
- [x] `  `npm run format`  ` passes
- [x] QA evidence
- [ ] Tests added or updated where it made sense