### PR TITLE
Reject low-order peer keys in X25519 key agreement

### DIFF
--- a/packages/relay/src/crypto.low-order.test.ts
+++ b/packages/relay/src/crypto.low-order.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import nacl from "tweetnacl";
 
-import { InvalidPeerKeyError, deriveSharedKey, generateKeyPair } from "./index.js";
+import {
+  CANONICAL_LOW_ORDER_POINTS,
+  InvalidPeerKeyError,
+  deriveSharedKey,
+  generateKeyPair,
+} from "./index.js";
 
 /**
  * Negative tests for peer-key validation.
@@ -31,15 +36,10 @@ function bytesToHex(bytes: Uint8Array): string {
  * that they were transcribed correctly. A blacklist with a mistyped constant
  * would otherwise pass every test while protecting nothing.
  */
-const CANONICAL_LOW_ORDER_POINT_HEX = [
-  "0000000000000000000000000000000000000000000000000000000000000000",
-  "0100000000000000000000000000000000000000000000000000000000000000",
-  "e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800",
-  "5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157",
-  "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
-  "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
-  "eeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
-] as const;
+// The shipped table, not a copy of it. Transcribing it here meant the suite
+// could exercise a different blacklist from the one that ships, the moment
+// either drifted.
+const CANONICAL_LOW_ORDER_POINT_HEX = CANONICAL_LOW_ORDER_POINTS;
 
 /** Each canonical point plus its high-bit-set encoding, which X25519 treats identically. */
 const LOW_ORDER_POINT_HEX = CANONICAL_LOW_ORDER_POINT_HEX.flatMap((hex) => {
@@ -100,35 +100,46 @@ describe("low-order point rejection", () => {
 });
 
 describe("validation and derivation see the same bytes", () => {
-  // Checking one value and deriving from another is the classic way a
-  // validation gets stepped around: a caller can pass an object whose indexed
-  // reads change between the check and the use. deriveSharedKey is exported,
-  // so "no caller in this repo does that" is not the bar.
-  it("rejects a peer key whose bytes change after validation", () => {
+  // The property, not one implementation's read count: every index of the
+  // caller's array must be read exactly once. An earlier version of this test
+  // only switched the bytes after 480 reads, so an unsafe implementation making
+  // 64 reads passed it while still validating one value and deriving another.
+  it("reads each index of the peer key exactly once", () => {
     const basepoint = new Uint8Array(32);
     basepoint[0] = 9;
     const zero = new Uint8Array(32);
+    const reads: number[] = Array.from({ length: 32 }, () => 0);
 
-    let reads = 0;
-    const shifting = new Proxy(basepoint, {
+    const onceOnly = new Proxy(basepoint, {
       get(target, prop) {
         if (typeof prop === "string" && /^\d+$/.test(prop)) {
-          reads += 1;
-          // Honest while inspected, all-zero once the checks are done.
-          return reads <= 480 ? basepoint[Number(prop)] : zero[Number(prop)];
+          const i = Number(prop);
+          reads[i] = (reads[i] ?? 0) + 1;
+          // Honest the first time, hostile every time after. Any implementation
+          // that reads an index twice derives from the all-zero point.
+          return (reads[i] as number) === 1 ? basepoint[i] : zero[i];
         }
         return Reflect.get(target, prop);
       },
     }) as Uint8Array;
 
     const secret = generateKeyPair().secretKey;
-    const derived = deriveSharedKey(secret, shifting);
+    const derived = deriveSharedKey(secret, onceOnly);
 
-    // The all-zero point yields this key for every secret; deriving it would
-    // mean the peer knows the session key.
+    expect(reads.every((n) => n === 1)).toBe(true);
+    expect(bytesToHex(derived)).toBe(bytesToHex(deriveSharedKey(secret, basepoint)));
     expect(bytesToHex(derived)).not.toBe(
       "351f86faa3b988468a850122b65b0acece9c4826806aeee63de9c0da2bd7f91e",
     );
-    expect(bytesToHex(derived)).toBe(bytesToHex(deriveSharedKey(secret, basepoint)));
+  });
+
+  it("rejects key material that is not a full sequence of bytes", () => {
+    // A one-byte array claiming to be 32 used to be zero-padded into the very
+    // point the blacklist rejects.
+    const short = new Uint8Array(1);
+    short[0] = 9;
+    Object.defineProperty(short, "byteLength", { value: 32 });
+
+    expect(() => deriveSharedKey(generateKeyPair().secretKey, short)).toThrow(InvalidPeerKeyError);
   });
 });

--- a/packages/relay/src/crypto.low-order.test.ts
+++ b/packages/relay/src/crypto.low-order.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import nacl from "tweetnacl";
+
+import { InvalidPeerKeyError, deriveSharedKey, generateKeyPair } from "./crypto.js";
+
+/**
+ * Negative tests for peer-key validation.
+ *
+ * `crypto.test.ts` covers the happy path. Nothing there feeds a hostile key,
+ * which is exactly how the low-order-point flaw survived: every positive test
+ * passed while an attacker could force a predictable shared key.
+ */
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * The same table `crypto.ts` rejects, repeated here on purpose.
+ *
+ * Duplicating it means the suite fails if either copy drifts, and the
+ * self-check below proves these are genuinely low order rather than trusting
+ * that they were transcribed correctly. A blacklist with a mistyped constant
+ * would otherwise pass every test while protecting nothing.
+ */
+const CANONICAL_LOW_ORDER_POINT_HEX = [
+  "0000000000000000000000000000000000000000000000000000000000000000",
+  "0100000000000000000000000000000000000000000000000000000000000000",
+  "e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800",
+  "5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157",
+  "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+  "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+  "eeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+] as const;
+
+/** Each canonical point plus its high-bit-set encoding, which X25519 treats identically. */
+const LOW_ORDER_POINT_HEX = CANONICAL_LOW_ORDER_POINT_HEX.flatMap((hex) => {
+  const withHighBit =
+    hex.slice(0, 62) +
+    ((Number.parseInt(hex.slice(62), 16) | 0x80) >>> 0).toString(16).padStart(2, "0");
+  return [hex, withHighBit];
+});
+
+describe("low-order point rejection", () => {
+  // This is the load-bearing test. If a constant above is wrong, the point is
+  // not actually low order, the assertion fails, and we learn the blacklist is
+  // broken -- instead of shipping a check that silently matches nothing.
+  it.each(LOW_ORDER_POINT_HEX)("%s is genuinely a low-order point", (hex) => {
+    const point = hexToBytes(hex);
+    const secret = generateKeyPair().secretKey;
+
+    const raw = nacl.scalarMult(secret, point);
+
+    expect(bytesToHex(raw)).toBe("00".repeat(32));
+  });
+
+  it.each(LOW_ORDER_POINT_HEX)("deriveSharedKey rejects %s", (hex) => {
+    const secret = generateKeyPair().secretKey;
+
+    expect(() => deriveSharedKey(secret, hexToBytes(hex))).toThrow(InvalidPeerKeyError);
+  });
+
+  it("rejects the all-zero peer key", () => {
+    const secret = generateKeyPair().secretKey;
+
+    expect(() => deriveSharedKey(secret, new Uint8Array(32))).toThrow(InvalidPeerKeyError);
+  });
+
+  // The attack: without validation both sides derive a key the attacker can
+  // compute for ANY secret key, because the X25519 output is a constant.
+  it("would otherwise yield an attacker-predictable key for any secret", () => {
+    const zeroPoint = new Uint8Array(32);
+
+    const rawA = nacl.scalarMult(generateKeyPair().secretKey, zeroPoint);
+    const rawB = nacl.scalarMult(generateKeyPair().secretKey, zeroPoint);
+
+    // Two unrelated secrets, identical output -- this is why it must be rejected.
+    expect(bytesToHex(rawA)).toBe(bytesToHex(rawB));
+    expect(bytesToHex(rawA)).toBe("00".repeat(32));
+  });
+
+  it("still accepts honest keys", () => {
+    const alice = generateKeyPair();
+    const bob = generateKeyPair();
+
+    const ab = deriveSharedKey(alice.secretKey, bob.publicKey);
+    const ba = deriveSharedKey(bob.secretKey, alice.publicKey);
+
+    expect(bytesToHex(ab)).toBe(bytesToHex(ba));
+    expect(bytesToHex(ab)).not.toBe("00".repeat(32));
+  });
+});

--- a/packages/relay/src/crypto.low-order.test.ts
+++ b/packages/relay/src/crypto.low-order.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import nacl from "tweetnacl";
 
-import { InvalidPeerKeyError, deriveSharedKey, generateKeyPair } from "./crypto.js";
+import { InvalidPeerKeyError, deriveSharedKey, generateKeyPair } from "./index.js";
 
 /**
  * Negative tests for peer-key validation.
@@ -96,5 +96,39 @@ describe("low-order point rejection", () => {
 
     expect(bytesToHex(ab)).toBe(bytesToHex(ba));
     expect(bytesToHex(ab)).not.toBe("00".repeat(32));
+  });
+});
+
+describe("validation and derivation see the same bytes", () => {
+  // Checking one value and deriving from another is the classic way a
+  // validation gets stepped around: a caller can pass an object whose indexed
+  // reads change between the check and the use. deriveSharedKey is exported,
+  // so "no caller in this repo does that" is not the bar.
+  it("rejects a peer key whose bytes change after validation", () => {
+    const basepoint = new Uint8Array(32);
+    basepoint[0] = 9;
+    const zero = new Uint8Array(32);
+
+    let reads = 0;
+    const shifting = new Proxy(basepoint, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) {
+          reads += 1;
+          // Honest while inspected, all-zero once the checks are done.
+          return reads <= 480 ? basepoint[Number(prop)] : zero[Number(prop)];
+        }
+        return Reflect.get(target, prop);
+      },
+    }) as Uint8Array;
+
+    const secret = generateKeyPair().secretKey;
+    const derived = deriveSharedKey(secret, shifting);
+
+    // The all-zero point yields this key for every secret; deriving it would
+    // mean the peer knows the session key.
+    expect(bytesToHex(derived)).not.toBe(
+      "351f86faa3b988468a850122b65b0acece9c4826806aeee63de9c0da2bd7f91e",
+    );
+    expect(bytesToHex(derived)).toBe(bytesToHex(deriveSharedKey(secret, basepoint)));
   });
 });

--- a/packages/relay/src/crypto.ts
+++ b/packages/relay/src/crypto.ts
@@ -114,6 +114,102 @@ export function importSecretKey(base64: string): Uint8Array {
   return bytes;
 }
 
+/**
+ * Raised when a peer-supplied public key is unusable for key agreement.
+ *
+ * Distinct from a generic Error so callers can close the channel uniformly
+ * without leaking *which* validation fired, and so tests can assert on the
+ * specific failure rather than on any throw.
+ */
+export class InvalidPeerKeyError extends Error {
+  constructor(message = "Invalid peer public key") {
+    super(message);
+    this.name = "InvalidPeerKeyError";
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/**
+ * Curve25519 points of small order, little-endian u-coordinates.
+ *
+ * A peer supplying one of these forces the X25519 output to the all-zero
+ * value, so both sides derive a shared key the attacker knows without ever
+ * possessing the corresponding secret. RFC 7748 section 6 prescribes
+ * rejecting the all-zero result for exactly this reason.
+ *
+ * The all-zero output check in `deriveSharedKey` is on its own sufficient —
+ * with clamped scalars every low-order input produces it. This table is
+ * defense in depth plus an early reject, so we never run the scalar
+ * multiplication on a known-bad point. `crypto.negative.test.ts` proves each
+ * entry really is low order, so a mistyped constant fails the suite instead
+ * of silently weakening the check.
+ */
+const CANONICAL_LOW_ORDER_POINTS: readonly string[] = [
+  // 0 and 1
+  "0000000000000000000000000000000000000000000000000000000000000000",
+  "0100000000000000000000000000000000000000000000000000000000000000",
+  // the two points of order 8
+  "e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800",
+  "5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157",
+  // p-1 (order 2), p (= 0), p+1 (= 1)
+  "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+  "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+  "eeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+];
+
+/**
+ * X25519 ignores the top bit of the final byte, so each canonical point above
+ * has a second encoding with that bit set which is equally dangerous. Derive
+ * those rather than transcribing another seven constants -- every hand-copied
+ * value is a chance to write one that matches nothing.
+ */
+const LOW_ORDER_POINTS: readonly Uint8Array[] = Object.freeze(
+  CANONICAL_LOW_ORDER_POINTS.flatMap((hex) => {
+    const canonical = hexToBytes(hex);
+    const highBitSet = Uint8Array.from(canonical);
+    highBitSet[31] = (highBitSet[31] as number) | 0x80;
+    return [canonical, highBitSet];
+  }),
+);
+
+/**
+ * True when every byte is zero.
+ *
+ * Accumulates over the whole buffer with no early exit because the input is
+ * derived from a secret key. JavaScript cannot guarantee constant time (JIT,
+ * GC), but not short-circuiting removes the obvious signal.
+ */
+function isAllZero(bytes: Uint8Array): boolean {
+  let acc = 0;
+  for (let i = 0; i < bytes.length; i++) acc |= bytes[i] as number;
+  return acc === 0;
+}
+
+/**
+ * True when `publicKey` is one of the known small-order points.
+ *
+ * Both operands are public, so this needs no timing guarantee; it still
+ * avoids an early exit to keep the shape identical to `isAllZero`.
+ */
+function isLowOrderPoint(publicKey: Uint8Array): boolean {
+  let matched = 0;
+  for (const candidate of LOW_ORDER_POINTS) {
+    let diff = 0;
+    for (let i = 0; i < candidate.length; i++) {
+      diff |= (publicKey[i] as number) ^ (candidate[i] as number);
+    }
+    matched |= diff === 0 ? 1 : 0;
+  }
+  return matched === 1;
+}
+
 export function deriveSharedKey(ourSecretKey: Uint8Array, peerPublicKey: Uint8Array): SharedKey {
   if (ourSecretKey.byteLength !== nacl.box.secretKeyLength) {
     throw new Error(`Invalid secret key length (expected ${nacl.box.secretKeyLength})`);
@@ -121,6 +217,17 @@ export function deriveSharedKey(ourSecretKey: Uint8Array, peerPublicKey: Uint8Ar
   if (peerPublicKey.byteLength !== nacl.box.publicKeyLength) {
     throw new Error(`Invalid peer public key length (expected ${nacl.box.publicKeyLength})`);
   }
+  if (isLowOrderPoint(peerPublicKey)) {
+    throw new InvalidPeerKeyError("Peer public key is a low-order Curve25519 point");
+  }
+
+  // `box.before` hashes the raw X25519 output through HSalsa20, so inspecting
+  // its result cannot detect the all-zero case. Check the raw scalar
+  // multiplication directly.
+  if (isAllZero(nacl.scalarMult(ourSecretKey, peerPublicKey))) {
+    throw new InvalidPeerKeyError("X25519 key agreement produced an all-zero shared secret");
+  }
+
   return nacl.box.before(peerPublicKey, ourSecretKey);
 }
 

--- a/packages/relay/src/crypto.ts
+++ b/packages/relay/src/crypto.ts
@@ -151,7 +151,7 @@ function hexToBytes(hex: string): Uint8Array {
  * entry really is low order, so a mistyped constant fails the suite instead
  * of silently weakening the check.
  */
-const CANONICAL_LOW_ORDER_POINTS: readonly string[] = [
+export const CANONICAL_LOW_ORDER_POINTS: readonly string[] = [
   // 0 and 1
   "0000000000000000000000000000000000000000000000000000000000000000",
   "0100000000000000000000000000000000000000000000000000000000000000",
@@ -221,7 +221,15 @@ function isLowOrderPoint(publicKey: Uint8Array): boolean {
 function snapshot(source: Uint8Array, length: number): Uint8Array {
   const copy = new Uint8Array(length);
   for (let i = 0; i < length; i++) {
-    copy[i] = source[i] as number;
+    const byte: unknown = source[i];
+    // A missing index reads as undefined, and assigning that to a Uint8Array
+    // stores 0 -- so a one-byte source claiming a byteLength of 32 would be
+    // silently zero-padded into the all-zero point this function exists to
+    // reject. Every byte has to be a real byte.
+    if (typeof byte !== "number" || !Number.isInteger(byte) || byte < 0 || byte > 255) {
+      throw new InvalidPeerKeyError("Key material is not a sequence of bytes");
+    }
+    copy[i] = byte;
   }
   return copy;
 }

--- a/packages/relay/src/crypto.ts
+++ b/packages/relay/src/crypto.ts
@@ -210,6 +210,22 @@ function isLowOrderPoint(publicKey: Uint8Array): boolean {
   return matched === 1;
 }
 
+/**
+ * A private copy, reading each index exactly once.
+ *
+ * `Uint8Array.from` refuses a Proxy-wrapped typed array outright, which would
+ * fail closed but with a TypeError that says nothing useful. Reading index by
+ * index works for any array-like and pins each byte to its first read, so the
+ * value that is validated is the value that is used.
+ */
+function snapshot(source: Uint8Array, length: number): Uint8Array {
+  const copy = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    copy[i] = source[i] as number;
+  }
+  return copy;
+}
+
 export function deriveSharedKey(ourSecretKey: Uint8Array, peerPublicKey: Uint8Array): SharedKey {
   if (ourSecretKey.byteLength !== nacl.box.secretKeyLength) {
     throw new Error(`Invalid secret key length (expected ${nacl.box.secretKeyLength})`);
@@ -217,18 +233,27 @@ export function deriveSharedKey(ourSecretKey: Uint8Array, peerPublicKey: Uint8Ar
   if (peerPublicKey.byteLength !== nacl.box.publicKeyLength) {
     throw new Error(`Invalid peer public key length (expected ${nacl.box.publicKeyLength})`);
   }
-  if (isLowOrderPoint(peerPublicKey)) {
+
+  // Validate and derive from the same bytes. Without the copies a caller can
+  // pass an object whose indexed reads change between the check and the use --
+  // a Proxy returning the basepoint while it is inspected and the all-zero
+  // point afterwards passes every check above and still yields the predictable
+  // key. Copying costs 64 bytes and removes the gap entirely.
+  const secret = snapshot(ourSecretKey, nacl.box.secretKeyLength);
+  const peer = snapshot(peerPublicKey, nacl.box.publicKeyLength);
+
+  if (isLowOrderPoint(peer)) {
     throw new InvalidPeerKeyError("Peer public key is a low-order Curve25519 point");
   }
 
   // `box.before` hashes the raw X25519 output through HSalsa20, so inspecting
   // its result cannot detect the all-zero case. Check the raw scalar
   // multiplication directly.
-  if (isAllZero(nacl.scalarMult(ourSecretKey, peerPublicKey))) {
+  if (isAllZero(nacl.scalarMult(secret, peer))) {
     throw new InvalidPeerKeyError("X25519 key agreement produced an all-zero shared secret");
   }
 
-  return nacl.box.before(peerPublicKey, ourSecretKey);
+  return nacl.box.before(peer, secret);
 }
 
 /**

--- a/packages/relay/src/e2ee.ts
+++ b/packages/relay/src/e2ee.ts
@@ -3,6 +3,7 @@ export type { Transport, TransportMessage, EncryptedChannelEvents } from "./encr
 
 export {
   InvalidPeerKeyError,
+  CANONICAL_LOW_ORDER_POINTS,
   generateKeyPair,
   exportPublicKey,
   importPublicKey,

--- a/packages/relay/src/e2ee.ts
+++ b/packages/relay/src/e2ee.ts
@@ -2,6 +2,7 @@ export { createClientChannel, createDaemonChannel, EncryptedChannel } from "./en
 export type { Transport, TransportMessage, EncryptedChannelEvents } from "./encrypted-channel.js";
 
 export {
+  InvalidPeerKeyError,
   generateKeyPair,
   exportPublicKey,
   importPublicKey,

--- a/packages/relay/src/encrypted-channel.ts
+++ b/packages/relay/src/encrypted-channel.ts
@@ -10,6 +10,7 @@ import {
   generateKeyPair,
   exportPublicKey,
   importPublicKey,
+  InvalidPeerKeyError,
   deriveSharedKey,
   encrypt,
   decrypt,
@@ -503,7 +504,24 @@ export class EncryptedChannel {
   private async handleDaemonRehello(message: E2EEHelloMessage): Promise<void> {
     if (!this.options.daemonKeyPair) return;
     const clientPublicKey = importPublicKey(message.key);
-    const nextSharedKey = deriveSharedKey(this.options.daemonKeyPair.secretKey, clientPublicKey);
+
+    // A key we refuse is a key mismatch, and takes the same exit as any other
+    // unacceptable re-handshake key. Letting InvalidPeerKeyError escape puts it
+    // in the caller's "that was not plaintext handshake traffic" catch, which
+    // then decrypts the hello as ciphertext and closes 1011 for a decrypt
+    // failure -- reporting a rejected key as a corrupt frame.
+    let nextSharedKey: SharedKey;
+    try {
+      nextSharedKey = deriveSharedKey(this.options.daemonKeyPair.secretKey, clientPublicKey);
+    } catch (error) {
+      if (!(error instanceof InvalidPeerKeyError)) throw error;
+      this.state = "closed";
+      this.transport.close(
+        REHANDSHAKE_KEY_MISMATCH_CLOSE_CODE,
+        REHANDSHAKE_KEY_MISMATCH_CLOSE_REASON,
+      );
+      return;
+    }
 
     // If it's the same client key (handshake retry), re-send
     // "ready" but do not re-key. Re-keying here would desync

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -1,6 +1,7 @@
 export type { ConnectionRole, RelaySessionAttachment } from "./types.js";
 
 export {
+  InvalidPeerKeyError,
   generateKeyPair,
   exportPublicKey,
   importPublicKey,

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -2,6 +2,7 @@ export type { ConnectionRole, RelaySessionAttachment } from "./types.js";
 
 export {
   InvalidPeerKeyError,
+  CANONICAL_LOW_ORDER_POINTS,
   generateKeyPair,
   exportPublicKey,
   importPublicKey,


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Remote access is the reason people run Paseo — the daemon sits on your machine and you reach it from your phone. Everything protecting that path rests on the E2EE handshake, and `deriveSharedKey` validated the peer's public key by length alone.

A peer that supplies a low-order Curve25519 point forces the X25519 output to a constant, so both sides derive a shared key **the peer can compute without holding any secret**. Against `main` today that key is:

```
351f86faa3b988468a850122b65b0acece9c4826806aeee63de9c0da2bd7f91e
```

The same value for every daemon secret. The X25519 output itself is all zeros; the hex above is what `box.before` produces after hashing it through HSalsa20, so the derived key is not itself all zeros and the check has to be made on the raw output before `box.before` rather than on its result. RFC 7748 §6.1 lets both sides check the raw all-zero output and abort; before this change we did not.

For a Paseo user this removes the case where a peer holding no secret at all can force a session key the daemon will accept. It does not authenticate peer keys, so anyone able to substitute a keypair of their own is still out of scope; see non-goals.

### Goals

- Reject low-order Curve25519 points and any all-zero X25519 result in `deriveSharedKey`
- Validate and derive from the same bytes, so the check cannot be stepped around
- Keep honest handshakes byte-identical — no behaviour change for real keys
- Make a rejected key close the channel as a key mismatch (1008), not a decrypt failure (1011)
- Tests that fail against `main` and pass here

### Non-goals

- **No client authentication.** The relay path still accepts any client key that isn't low-order. That's a much larger conversation and belongs in its own PR, not smuggled into this one.
- No change to the relay protocol or the wire format beyond the close code for a rejected peer key, which becomes 1008 (key mismatch) instead of 1011 (decrypt failure) — both are codes the relay already uses, and only this error's routing changes. No public API change beyond exporting `InvalidPeerKeyError` so callers can catch it, and `CANONICAL_LOW_ORDER_POINTS` so the tests assert against the same table the check uses.
- No performance work. The added cost is two 32-byte copies, one comparison against the low-order table, and one additional scalar multiplication per handshake — `box.before` hashes its X25519 output through HSalsa20, so the all-zero check needs its own `scalarMult`.

### QA

Against this branch, in a worktree off `main`:

```
$ npx vitest run packages/relay
 Test Files  6 passed | 2 skipped (8)
      Tests  67 passed | 4 skipped (71)

$ npm run typecheck
0 errors

$ npm run lint -- packages/relay/src/crypto.ts packages/relay/src/crypto.low-order.test.ts
Found 0 warnings and 0 errors.
```

**Reproducing the bug on `main` first.** Built `main`'s relay and derived a key from the all-zero point:

```
$ node -e 'import("./packages/relay/dist/crypto.js").then(({deriveSharedKey,generateKeyPair})=>
    console.log(Buffer.from(deriveSharedKey(generateKeyPair().secretKey,new Uint8Array(32))).toString("hex")))'
351f86faa3b988468a850122b65b0acece9c4826806aeee63de9c0da2bd7f91e
```

Same output for any secret. With this branch it throws `InvalidPeerKeyError`.

**Confirming the tests are bound to the fix.** Reverted `crypto.ts` to `main`'s version and re-ran the two crypto suites, so a green run cannot be mistaken for coverage:

```
this branch:           Test Files  2 passed (2)      Tests  41 passed (41)
with main's crypto.ts: Test Files  1 failed | 1 passed (2)   Tests  8 passed (8)
```

The failing file is `crypto.low-order.test.ts`, and it fails at load: `main`'s `crypto.ts` exports neither `CANONICAL_LOW_ORDER_POINTS` nor `InvalidPeerKeyError`, so the import throws before any test runs. That shows the suite cannot pass against unpatched code, but it is a weaker demonstration than a test failing on behaviour, and I would rather say so than let the numbers imply otherwise. The behavioural evidence is the `node` reproduction above, which needs none of this branch's exports.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense


