### PR TITLE
Stabilize archive descriptor coverage

### DIFF
--- a/packages/app/src/subagents/archive-finished.test.ts
+++ b/packages/app/src/subagents/archive-finished.test.ts
@@ -400,9 +400,11 @@ describe("createArchiveFinishedSubagents", () => {
   });
 
   it("dismisses finished provider rows locally without removing their descriptors", async () => {
+    const finishedDescriptor = provider("finished");
+    const runningDescriptor = provider("running", "running");
     const descriptors = new Map([
-      ["finished", provider("finished")],
-      ["running", provider("running", "running")],
+      ["finished", finishedDescriptor],
+      ["running", runningDescriptor],
     ]);
     const dismissed: string[][] = [];
     const archive = createArchiveFinishedSubagents([...descriptors.values()], {
@@ -420,7 +422,7 @@ describe("createArchiveFinishedSubagents", () => {
     });
 
     expect(dismissed).toEqual([["finished"]]);
-    expect(descriptors.get("finished")).toEqual(provider("finished"));
-    expect(descriptors.get("running")).toEqual(provider("running", "running"));
+    expect(descriptors.get("finished")).toBe(finishedDescriptor);
+    expect(descriptors.get("running")).toBe(runningDescriptor);
   });
 });


### PR DESCRIPTION
### Linked issue

No linked issue. Reproduced from [CI job 95133977065](https://github.com/getpaseo/paseo/actions/runs/31934384575/job/95133977065).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The archive-finished unit test rebuilt expected provider descriptors with fresh timestamps. The assertion passed only when fixture construction and verification landed in the same millisecond, causing the app test job to fail intermittently despite correct product behavior.

The test now retains the original descriptors and asserts their identities. This directly verifies that local dismissal neither removes nor replaces the descriptors without depending on the wall clock.

### Goals

- Keep archive descriptor coverage deterministic.
- Verify both finished and running provider descriptors remain the original objects after dismissal.

### Non-goals

- Change archive behavior or production code.
- Expand subagent coverage beyond the reported failure.

### QA

Before the fix:

`npx vitest run packages/app/src/subagents/archive-finished.test.ts -t "dismisses finished provider rows locally without removing their descriptors" --bail=1`

Observed the same failure as CI, with `createdAt` differing by 2 ms.

After the fix:

- `npx vitest run packages/app/src/subagents/archive-finished.test.ts --bail=1` — 11 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — 0 warnings and 0 errors.
- `npm run format` — passed.
- `git diff --check` — passed.

### Risk surface

Test-only. No runtime behavior, protocol, or UI changes.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense