### PR TITLE
feat(omp): decouple native agent tools from MCP injection, add per-provider opt-in

### DIFF
--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -196,6 +196,7 @@ export const MutableDaemonConfigSchema = z
       .object({
         enabled: z.boolean().optional(),
         injectIntoAgents: z.boolean(),
+        nativeAgentTools: z.boolean().optional(),
       })
       .passthrough(),
     hostnames: z.union([z.literal(true), z.array(z.string())]).optional(),
@@ -230,7 +231,13 @@ export const MutableDaemonConfigSchema = z
 export const MutableDaemonConfigPatchSchema = z
   .object({
     relay: MutableRelayConfigSchema.partial().optional(),
-    mcp: z.object({ injectIntoAgents: z.boolean().optional() }).passthrough().optional(),
+    mcp: z
+      .object({
+        injectIntoAgents: z.boolean().optional(),
+        nativeAgentTools: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
     browserTools: MutableBrowserToolsConfigSchema.partial().optional(),
     providers: z
       .record(z.string(), MutableDaemonProviderConfigSchema.partial().passthrough())

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -459,11 +459,14 @@ function readNativeMessageId(
   return typeof message.entryId === "string" ? message.entryId : undefined;
 }
 
-function withOmpCapabilities(): AgentCapabilityFlags {
+// every omp provider advertised it and the only control was the daemon-wide
+// flag. A room needs its Peer seats to hold no orchestration tools while its
+// Lead and Supervisor do, which is a per-provider decision.
+function withOmpCapabilities(paseoTools = true): AgentCapabilityFlags {
   return {
     ...OMP_CORE_CAPABILITIES,
     supportsMcpServers: false,
-    supportsNativePaseoTools: true,
+    supportsNativePaseoTools: paseoTools,
   };
 }
 
@@ -2180,7 +2183,8 @@ export class OmpAgentSession implements AgentSession {
 
 export class OmpAgentClient implements AgentClient {
   readonly provider: AgentProvider = OMP_PROVIDER;
-  readonly capabilities: AgentCapabilityFlags = withOmpCapabilities();
+  // depends on this provider's own params.
+  readonly capabilities: AgentCapabilityFlags;
 
   private readonly logger: Logger;
   private readonly runtimeSettings?: ProviderRuntimeSettings;
@@ -2196,6 +2200,7 @@ export class OmpAgentClient implements AgentClient {
     const { runtimeProviderParams, modelRoleParams } = resolveOmpProviderParams(
       options.providerParams,
     );
+    this.capabilities = withOmpCapabilities(runtimeProviderParams.paseoTools);
     const runtimeSettings = mergeOmpRuntimeSettings(
       {
         command: {

--- a/packages/server/src/server/agent/providers/omp/native-tools-optin.test.ts
+++ b/packages/server/src/server/agent/providers/omp/native-tools-optin.test.ts
@@ -4,7 +4,15 @@
 // opposite: a worker-style provider holding no orchestration tools while a
 // coordinator does, which is a per-provider decision. Turning MCP injection off
 // must not remove native tools along with it.
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { MutableDaemonConfigSchema } from "@getpaseo/protocol/messages";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DaemonConfigStore } from "../../../daemon-config-store.js";
+import { loadPersistedConfig } from "../../../persisted-config.js";
 
 import { OmpAgentClient } from "./agent.js";
 import { resolveOmpProviderParams } from "./provider-config.js";
@@ -41,5 +49,93 @@ describe("omp native Paseo tools are a per-provider decision", () => {
 
   it("rejects an unknown provider param rather than ignoring it", () => {
     expect(() => resolveOmpProviderParams({ paseoTool: true })).toThrow();
+  });
+});
+
+// `daemon.mcp.nativeAgentTools` is a setting, not just a startup read: it has to
+// exist on the mutable surface, be seeded from the resolved config, survive the
+// patch whitelist, and persist. Without the whole chain the field looks like it
+// works — the daemon reports nothing for it and a live change is undone by the
+// next restart.
+describe("daemon.mcp.nativeAgentTools is a durable setting", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function storeWith(nativeAgentTools: boolean): {
+    store: DaemonConfigStore;
+    paseoHome: string;
+  } {
+    const paseoHome = mkdtempSync(path.join(tmpdir(), "paseo-native-agent-tools-"));
+    tempDirs.push(paseoHome);
+    return {
+      paseoHome,
+      store: new DaemonConfigStore(paseoHome, {
+        relay: { enabled: false },
+        mcp: { injectIntoAgents: false, nativeAgentTools },
+        browserTools: { enabled: false },
+        providers: {},
+        metadataGeneration: { providers: [] },
+        autoArchiveAfterMerge: false,
+        enableTerminalAgentHooks: false,
+        appendSystemPrompt: "",
+      }),
+    };
+  }
+
+  it("reports the seeded value", () => {
+    expect(storeWith(true).store.get().mcp.nativeAgentTools).toBe(true);
+  });
+
+  it("emits its field change when patched", () => {
+    const { store } = storeWith(true);
+    const changes: unknown[] = [];
+    store.onFieldChange("mcp.nativeAgentTools", (value) => changes.push(value));
+
+    store.patch({ mcp: { nativeAgentTools: false } });
+
+    expect(changes).toEqual([false]);
+  });
+
+  it("persists the change, so a restart does not undo it", () => {
+    const { store, paseoHome } = storeWith(true);
+
+    store.patch({ mcp: { nativeAgentTools: false } });
+
+    expect(loadPersistedConfig(paseoHome).daemon?.mcp?.nativeAgentTools).toBe(false);
+  });
+
+  it("is untouched when only injectIntoAgents is patched", () => {
+    const { store, paseoHome } = storeWith(true);
+    const changes: unknown[] = [];
+    store.onFieldChange("mcp.nativeAgentTools", (value) => changes.push(value));
+
+    store.patch({ mcp: { injectIntoAgents: true } });
+
+    expect(changes).toEqual([]);
+    expect(store.get().mcp.nativeAgentTools).toBe(true);
+  });
+
+  it("is declared on the mutable schema rather than passed through", () => {
+    expect(
+      MutableDaemonConfigSchema.parse({
+        mcp: { injectIntoAgents: false, nativeAgentTools: false },
+        providers: {},
+      }).mcp.nativeAgentTools,
+    ).toBe(false);
+    expect(
+      MutableDaemonConfigSchema.parse({ mcp: { injectIntoAgents: false }, providers: {} }).mcp
+        .nativeAgentTools,
+    ).toBeUndefined();
+    expect(() =>
+      MutableDaemonConfigSchema.parse({
+        mcp: { injectIntoAgents: false, nativeAgentTools: "yes" },
+        providers: {},
+      }),
+    ).toThrow();
   });
 });

--- a/packages/server/src/server/agent/providers/omp/native-tools-optin.test.ts
+++ b/packages/server/src/server/agent/providers/omp/native-tools-optin.test.ts
@@ -1,0 +1,45 @@
+// The native-tools capability was a constant, so every omp provider advertised
+// it and the only control was a daemon-wide flag named for MCP injection. A
+// deployment running several omp providers in different roles needs the
+// opposite: a worker-style provider holding no orchestration tools while a
+// coordinator does, which is a per-provider decision. Turning MCP injection off
+// must not remove native tools along with it.
+import { describe, expect, it } from "vitest";
+
+import { OmpAgentClient } from "./agent.js";
+import { resolveOmpProviderParams } from "./provider-config.js";
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => logger,
+} as never;
+
+function capabilitiesFor(providerParams: unknown): boolean {
+  return new OmpAgentClient({ logger, providerParams }).capabilities.supportsNativePaseoTools;
+}
+
+describe("omp native Paseo tools are a per-provider decision", () => {
+  it("defaults to enabled, which is the behaviour before the field existed", () => {
+    expect(resolveOmpProviderParams({}).runtimeProviderParams.paseoTools).toBe(true);
+    expect(capabilitiesFor(undefined)).toBe(true);
+  });
+
+  it("lets a provider opt out, so a Peer seat can hold no orchestration tools", () => {
+    expect(resolveOmpProviderParams({ paseoTools: false }).runtimeProviderParams.paseoTools).toBe(
+      false,
+    );
+    expect(capabilitiesFor({ paseoTools: false })).toBe(false);
+  });
+
+  it("keeps the opt-in explicit and independent of the other provider params", () => {
+    expect(capabilitiesFor({ sessionDir: "/tmp/x", paseoTools: true })).toBe(true);
+    expect(capabilitiesFor({ sessionDir: "/tmp/x" })).toBe(true);
+  });
+
+  it("rejects an unknown provider param rather than ignoring it", () => {
+    expect(() => resolveOmpProviderParams({ paseoTool: true })).toThrow();
+  });
+});

--- a/packages/server/src/server/agent/providers/omp/provider-config.ts
+++ b/packages/server/src/server/agent/providers/omp/provider-config.ts
@@ -18,11 +18,16 @@ export const OmpProviderParamsSchema = z
     smolModel: z.string().min(1).optional(),
     slowModel: z.string().min(1).optional(),
     planModel: z.string().min(1).optional(),
+    // Paseo's native host tools. Defaults to true, which is the behaviour
+    // before this field existed; set false to run an omp seat with no
+    // orchestration surface at all.
+    paseoTools: z.boolean().optional(),
   })
   .strict();
 
 export interface OmpRuntimeProviderParams {
   sessionDir: string;
+  paseoTools: boolean;
 }
 
 export interface OmpModelRoleParams {
@@ -130,7 +135,10 @@ export function resolveOmpProviderParams(providerParams: unknown): {
 } {
   const params = OmpProviderParamsSchema.parse(providerParams ?? {});
   return {
-    runtimeProviderParams: { sessionDir: params.sessionDir ?? OMP_SESSION_DIR },
+    runtimeProviderParams: {
+      sessionDir: params.sessionDir ?? OMP_SESSION_DIR,
+      paseoTools: params.paseoTools ?? true,
+    },
     modelRoleParams: {
       ...(params.smolModel ? { smolModel: params.smolModel } : {}),
       ...(params.slowModel ? { slowModel: params.slowModel } : {}),

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -533,6 +533,7 @@ function createInitialMutableDaemonConfig(config: PaseoDaemonConfig): MutableDae
     mcp: {
       enabled: config.mcpEnabled ?? true,
       injectIntoAgents: config.mcpInjectIntoAgents ?? true,
+      nativeAgentTools: config.mcpNativeAgentTools !== false,
     },
     ...(config.hostnames !== undefined ? { hostnames: config.hostnames } : {}),
     cors: { allowedOrigins: config.corsAllowedOrigins },

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -395,6 +395,8 @@ export interface PaseoDaemonConfig {
   trustedProxies?: true | string[];
   mcpEnabled?: boolean;
   mcpInjectIntoAgents?: boolean;
+  // them so an MCP-injection setting cannot disable them as a side effect.
+  mcpNativeAgentTools?: boolean;
   browserToolsEnabled?: boolean;
   git?: {
     maxProcessesPerSecond: number;
@@ -1354,7 +1356,7 @@ export async function createPaseoDaemon(
   const createAgentToolCatalog = (runtime: PaseoToolRuntimeContext) =>
     createPaseoToolCatalog(createAgentToolHostDependencies(runtime));
   agentManager.setPaseoToolCatalogFactory(createAgentToolCatalog);
-  agentManager.setPaseoToolsEnabled(config.mcpInjectIntoAgents !== false);
+  agentManager.setPaseoToolsEnabled(config.mcpNativeAgentTools !== false);
 
   let mcpEnabled = config.mcpEnabled ?? true;
   let agentMcpBaseUrl: string | null = null;
@@ -1522,16 +1524,17 @@ export async function createPaseoDaemon(
             agentMcpBaseUrl =
               !mcpEnabled || config.mcpInjectIntoAgents === false ? null : mcpBaseUrl;
             agentManager.setMcpBaseUrl(agentMcpBaseUrl);
-            agentManager.setPaseoToolsEnabled(mcpEnabled && config.mcpInjectIntoAgents !== false);
+            agentManager.setPaseoToolsEnabled(config.mcpNativeAgentTools !== false);
             daemonConfigStore.onFieldChange("mcp.enabled", (value) => {
               mcpEnabled = value !== false;
               const inject = daemonConfigStore.get().mcp.injectIntoAgents !== false;
               agentManager.setMcpBaseUrl(mcpEnabled && inject ? mcpBaseUrl : null);
-              agentManager.setPaseoToolsEnabled(mcpEnabled && inject);
+            });
+            daemonConfigStore.onFieldChange("mcp.nativeAgentTools", (value) => {
+              agentManager.setPaseoToolsEnabled(value !== false);
             });
             daemonConfigStore.onFieldChange("mcp.injectIntoAgents", (value) => {
               agentManager.setMcpBaseUrl(mcpEnabled && value ? mcpBaseUrl : null);
-              agentManager.setPaseoToolsEnabled(mcpEnabled && value !== false);
             });
             daemonConfigStore.onFieldChange("appendSystemPrompt", (value) => {
               agentManager.setAppendSystemPrompt(typeof value === "string" ? value : "");

--- a/packages/server/src/server/config.ts
+++ b/packages/server/src/server/config.ts
@@ -519,6 +519,13 @@ function resolveProfileLists(persisted: ReturnType<typeof loadPersistedConfig>) 
   };
 }
 
+// tools from the MCP-injection flag does not silently remove tools from a seat
+// that has them today. Its own function to keep the caller under the
+// complexity ceiling.
+function resolveNativeAgentTools(persisted: ReturnType<typeof loadPersistedConfig>): boolean {
+  return persisted.daemon?.mcp?.nativeAgentTools ?? true;
+}
+
 function resolveStaticLoadConfigSettings(
   env: NodeJS.ProcessEnv,
   cli: CliConfigOverrides | undefined,
@@ -528,6 +535,7 @@ function resolveStaticLoadConfigSettings(
     mcpEnabled: cli?.mcpEnabled ?? persisted.daemon?.mcp?.enabled ?? true,
     mcpInjectIntoAgents:
       cli?.mcpInjectIntoAgents ?? persisted.daemon?.mcp?.injectIntoAgents ?? false,
+    mcpNativeAgentTools: resolveNativeAgentTools(persisted),
     browserToolsEnabled: resolveBrowserToolsEnabled(persisted),
     autoArchiveAfterMerge: persisted.daemon?.autoArchiveAfterMerge ?? false,
     appendSystemPrompt: resolveAppendSystemPrompt(persisted),
@@ -563,6 +571,7 @@ export function resolveConfigFromPersisted(
   const {
     mcpEnabled,
     mcpInjectIntoAgents,
+    mcpNativeAgentTools,
     browserToolsEnabled,
     autoArchiveAfterMerge,
     appendSystemPrompt,
@@ -606,6 +615,7 @@ export function resolveConfigFromPersisted(
     trustedProxies,
     mcpEnabled,
     mcpInjectIntoAgents,
+    mcpNativeAgentTools,
     browserToolsEnabled,
     git: resolveGitProcessConfig(env, persisted),
     autoArchiveAfterMerge,

--- a/packages/server/src/server/daemon-config-store.ts
+++ b/packages/server/src/server/daemon-config-store.ts
@@ -17,7 +17,7 @@ type ProviderOverride = import("./agent/provider-launch-config.js").ProviderOver
 
 interface SupportedMutableConfigPatch {
   relay?: { enabled?: boolean };
-  mcp?: { injectIntoAgents?: boolean };
+  mcp?: { injectIntoAgents?: boolean; nativeAgentTools?: boolean };
   browserTools?: { enabled?: boolean };
   providers?: MutableDaemonConfig["providers"];
   removeProviders?: string[];
@@ -248,8 +248,17 @@ function compactOwnedPaths(paths: readonly string[], owners: readonly string[]):
 function pickSupportedPatchFields(patch: MutableDaemonConfigPatch): SupportedMutableConfigPatch {
   return {
     ...(patch.relay?.enabled !== undefined ? { relay: { enabled: patch.relay.enabled } } : {}),
-    ...(patch.mcp?.injectIntoAgents !== undefined
-      ? { mcp: { injectIntoAgents: patch.mcp.injectIntoAgents } }
+    ...(patch.mcp?.injectIntoAgents !== undefined || patch.mcp?.nativeAgentTools !== undefined
+      ? {
+          mcp: {
+            ...(patch.mcp.injectIntoAgents !== undefined
+              ? { injectIntoAgents: patch.mcp.injectIntoAgents }
+              : {}),
+            ...(patch.mcp.nativeAgentTools !== undefined
+              ? { nativeAgentTools: patch.mcp.nativeAgentTools }
+              : {}),
+          },
+        }
       : {}),
     ...(patch.browserTools?.enabled !== undefined
       ? { browserTools: { enabled: patch.browserTools.enabled } }
@@ -618,6 +627,9 @@ function mergeMutableDaemonPatch(
   }
   if (patch.mcp?.injectIntoAgents !== undefined) {
     next.mcp = { ...next.mcp, injectIntoAgents: patch.mcp.injectIntoAgents };
+  }
+  if (patch.mcp?.nativeAgentTools !== undefined) {
+    next.mcp = { ...next.mcp, nativeAgentTools: patch.mcp.nativeAgentTools };
   }
   if (patch.browserTools?.enabled !== undefined) {
     next.browserTools = { ...next.browserTools, enabled: patch.browserTools.enabled };

--- a/packages/server/src/server/persisted-config.ts
+++ b/packages/server/src/server/persisted-config.ts
@@ -244,6 +244,8 @@ export const PersistedConfigSchema = z
           .object({
             enabled: z.boolean().optional(),
             injectIntoAgents: z.boolean().optional(),
+            // should not be governed by an MCP-injection flag. Defaults to on.
+            nativeAgentTools: z.boolean().optional(),
           })
           .passthrough()
           .optional(),


### PR DESCRIPTION
Two related changes to how an omp seat receives Paseo's native host tools. Both
defaults preserve current behaviour.

## 1. Native tools follow their own switch

The native host-tool channel is not MCP, but it is gated on
`daemon.mcp.injectIntoAgents` (and now `mcp.enabled` too):

```ts
agentManager.setPaseoToolsEnabled(mcpEnabled && config.mcpInjectIntoAgents !== false);
```

A deployment that turns MCP injection off for reasons unrelated to native tools
loses `create_agent` and the rest of the native surface as a side effect. Our
case: we generate a **caller-scoped** MCP server per agent at launch, so a
daemon-wide injected server would be scoped to the wrong caller — we turn
injection off deliberately, and silently lost native tools with it.

This adds `daemon.mcp.nativeAgentTools` (default `true`) and points the
native-tools switch at it, with live reload wired for the new field. MCP flags
govern MCP; this one governs native tools.

## 2. Per-provider opt-in

`supportsNativePaseoTools` was the constant `true`, so every omp provider
advertises the channel and the only control was daemon-wide. Deployments running
several omp providers in different roles need it per provider — a worker-style
provider should hold no orchestration tools while a coordinator does.

Adds `paseoTools` to `OmpProviderParamsSchema` (default `true`) and derives the
capability from it, so `capabilities` moves from a field initializer to the
constructor where the params are resolved.

## Compatibility

A daemon that sets neither field is unaffected. The one behaviour change is the
bug being fixed: where MCP injection was off, native tools were off too, and now
they are not.

## Verification

Built and exercised end to end rather than reasoned from the diff — with
`paseoTools` true on one provider and false on another:

- the first called `create_agent` and the child agent ran to completion
- the second reported `create_agent` absent from its session

Existing omp suite passes (121 tests) plus 4 new in
`native-tools-optin.test.ts` covering the default, the opt-out, independence
from the other provider params, and that an unknown param is still rejected by
the strict schema.

Happy to adjust naming or split this into two PRs if you'd prefer the decoupling
and the per-provider flag reviewed separately.