### PR TITLE
feat(app): adapt desktop shell for Android tablets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36198,7 +36198,8 @@
         "use-sync-external-store": "^1.6.0",
         "yaml": "^2.8.4",
         "zod": "^4.4.3",
-        "zustand": "^5.0.9"
+        "zustand": "^5.0.9",
+        "expo-screen-orientation": "~9.0.9"
       },
       "devDependencies": {
         "@playwright/test": "^1.56.1",
@@ -41500,6 +41501,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-screen-orientation": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-9.0.9.tgz",
+      "integrity": "sha512-UTU745XoqBvQJkZ820GTfMuOxlkppYqaeQ+x0wdu44cyrZiZugqe+egFF2+zC+SaxgAltU5EuO8GIj9xSF+YMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     }
   }

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const pkg = require("./package.json");
 const withAndroidAsyncStorageSize = require("./plugins/with-android-async-storage-size");
 const withAndroidProfileable = require("./plugins/with-android-profileable");
+const withAndroidRotationUnlocked = require("./plugins/with-android-rotation");
 const withFdroidAutolinking = require("./plugins/with-fdroid-autolinking");
 const withPasteInput = require("./plugins/with-paste-input");
 const { getNativeReleaseVersion } = require("./native-release-version");
@@ -177,6 +178,7 @@ export default {
       ],
       ...buildProfile.fdroidPlugins,
       ...(isProfileBuild ? [withAndroidProfileable] : []),
+      withAndroidRotationUnlocked,
     ],
     experiments: {
       typedRoutes: true,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -87,6 +87,7 @@
     "expo-localization": "~17.0.9",
     "expo-notifications": "^0.32.16",
     "expo-router": "~6.0.13",
+    "expo-screen-orientation": "~9.0.9",
     "expo-sharing": "^14.0.8",
     "expo-splash-screen": "~31.0.10",
     "expo-system-ui": "~6.0.7",

--- a/packages/app/plugins/with-android-rotation.js
+++ b/packages/app/plugins/with-android-rotation.js
@@ -1,0 +1,28 @@
+const { withAndroidManifest } = require("expo/config-plugins");
+
+// The global `orientation` field stays "portrait" so iOS keeps its static
+// lock (rotating the iPadOS app crashes it, see getpaseo/paseo#1030). On
+// Android that same declaration letterboxes the app into a phone-sized
+// window on landscape tablets (getpaseo/paseo#1669), so re-write the
+// activities to follow the system instead.
+//
+// This must run inside a manifest mod: custom plugins register their mods
+// before Expo's withDefaultPlugins, and mod chains execute outside-in, so
+// this modification lands last and wins over the built-in portrait write.
+function withAndroidRotationUnlocked(config) {
+  return withAndroidManifest(config, (modConfig) => {
+    const manifest = modConfig.modResults.manifest;
+    const application = manifest.application?.[0];
+    if (!application) {
+      throw new Error("Could not unlock Android rotation without an application manifest entry");
+    }
+    for (const activity of application.activity ?? []) {
+      if (activity.$?.["android:screenOrientation"]) {
+        activity.$["android:screenOrientation"] = "unspecified";
+      }
+    }
+    return modConfig;
+  });
+}
+
+module.exports = withAndroidRotationUnlocked;

--- a/packages/app/src/agent-stream/chat-outline/rail.tsx
+++ b/packages/app/src/agent-stream/chat-outline/rail.tsx
@@ -1,3 +1,9 @@
+import { useCallback, useRef, useState, useSyncExternalStore } from "react";
+import type { ReactElement } from "react";
+import { Pressable, Text, View, type GestureResponderEvent, type LayoutChangeEvent } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import * as Haptics from "expo-haptics";
+import { useContainerWidthBelow } from "@/hooks/use-container-width";
 import type { ActivePromptSource, ChatOutlinePrompt } from "./model";
 
 export interface ChatOutlineRailProps {
@@ -6,8 +12,219 @@ export interface ChatOutlineRailProps {
   onJumpToPrompt: (seq: number) => void;
 }
 
-// The outline is a wide-layout pointer affordance. Native navigates the transcript by
-// scrolling, so there is no rail to render.
-export function ChatOutlineRail(_props: ChatOutlineRailProps): null {
-  return null;
+const RAIL_WIDTH = 36;
+const SLOT_HEIGHT = 8;
+const MIN_PANEL_WIDTH = 918;
+const RESTING_PILL_HEIGHT = 2;
+const ACTIVE_PILL_WIDTH = 18;
+const RESTING_PILL_WIDTH = 10;
+const PREVIEW_WIDTH = 260;
+const PREVIEW_HEIGHT = 48;
+const PREVIEW_GAP = 4;
+
+/**
+ * Native touch version of the chat outline rail. The rail is a scrubber:
+ * touching anywhere opens a preview of the prompt under the finger, sliding
+ * moves between prompts, and the preview persists after release until it is
+ * tapped (jump) or the rail is touched again (dismiss). This replaces the
+ * hover-driven web rail, which has no equivalent on touch screens.
+ */
+export function ChatOutlineRail({
+  prompts,
+  activePrompt,
+  onJumpToPrompt,
+}: ChatOutlineRailProps): ReactElement | null {
+  const activeSeq = useSyncExternalStore(activePrompt.subscribe, activePrompt.getActiveSeq);
+  const { onLayout, isBelow: isPanelNarrow } = useContainerWidthBelow(MIN_PANEL_WIDTH);
+  const [scrubIndex, setScrubIndex] = useState<number | null>(null);
+  const scrubIndexRef = useRef<number | null>(null);
+  const railHeightRef = useRef(0);
+
+  const resolveTickIndex = useCallback(
+    (locationY: number): number | null => {
+      const height = railHeightRef.current;
+      if (height <= 0 || prompts.length === 0) {
+        return null;
+      }
+      const raw = Math.floor((locationY / height) * prompts.length);
+      return Math.max(0, Math.min(prompts.length - 1, raw));
+    },
+    [prompts.length],
+  );
+
+  const applyScrubIndex = useCallback((index: number) => {
+    if (scrubIndexRef.current !== index) {
+      scrubIndexRef.current = index;
+      setScrubIndex(index);
+      void Haptics.selectionAsync().catch(() => {});
+    }
+  }, []);
+
+  const handleRailLayout = useCallback((event: LayoutChangeEvent) => {
+    railHeightRef.current = event.nativeEvent.layout.height;
+  }, []);
+
+  const handleGrant = useCallback(
+    (event: GestureResponderEvent) => {
+      if (scrubIndexRef.current !== null) {
+        // A second touch dismisses the persisted preview.
+        scrubIndexRef.current = null;
+        setScrubIndex(null);
+        return;
+      }
+      const index = resolveTickIndex(event.nativeEvent.locationY);
+      if (index !== null) {
+        applyScrubIndex(index);
+      }
+    },
+    [applyScrubIndex, resolveTickIndex],
+  );
+
+  const handleMove = useCallback(
+    (event: GestureResponderEvent) => {
+      if (scrubIndexRef.current === null) {
+        return;
+      }
+      const index = resolveTickIndex(event.nativeEvent.locationY);
+      if (index !== null) {
+        applyScrubIndex(index);
+      }
+    },
+    [applyScrubIndex, resolveTickIndex],
+  );
+
+  const handleJump = useCallback(
+    (seq: number) => {
+      scrubIndexRef.current = null;
+      setScrubIndex(null);
+      onJumpToPrompt(seq);
+    },
+    [onJumpToPrompt],
+  );
+
+  if (prompts.length < 2) {
+    return null;
+  }
+
+  const previewPrompt = scrubIndex !== null ? prompts[scrubIndex] : null;
+
+  return (
+    <View style={styles.panelMeasure} pointerEvents="box-none" onLayout={onLayout}>
+      {isPanelNarrow ? null : (
+        <View style={styles.railOuter}>
+          <View
+            style={styles.rail}
+            testID="chat-outline-rail"
+            onLayout={handleRailLayout}
+            onStartShouldSetResponder={() => true}
+            onMoveShouldSetResponder={() => true}
+            onResponderGrant={handleGrant}
+            onResponderMove={handleMove}
+          >
+            {prompts.map((prompt, index) => (
+              <ChatOutlineTick
+                key={prompt.seq}
+                isActive={prompt.seq === activeSeq}
+                hasAttention={scrubIndex === index}
+              />
+            ))}
+          </View>
+          {previewPrompt ? (
+            <Pressable
+              style={styles.preview}
+              testID="chat-outline-preview"
+              accessibilityRole="button"
+              accessibilityLabel={`${previewPrompt.seq}`}
+              onPress={() => handleJump(previewPrompt.seq)}
+            >
+              <Text style={styles.previewText} numberOfLines={2}>
+                {previewPrompt.preview}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      )}
+    </View>
+  );
 }
+
+function ChatOutlineTick({
+  isActive,
+  hasAttention,
+}: {
+  isActive: boolean;
+  hasAttention: boolean;
+}) {
+  return (
+    <View style={styles.slot}>
+      <View
+        style={[
+          styles.pill,
+          isActive && styles.pillActive,
+          hasAttention && styles.pillAttention,
+        ]}
+        testID="chat-outline-tick"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  panelMeasure: {
+    position: "absolute",
+    inset: 0,
+  },
+  railOuter: {
+    position: "absolute",
+    left: theme.spacing[2],
+    top: "10%",
+    bottom: "10%",
+    width: RAIL_WIDTH,
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 2,
+  },
+  rail: {
+    width: RAIL_WIDTH,
+    flex: 1,
+  },
+  slot: {
+    width: RAIL_WIDTH,
+    flexBasis: SLOT_HEIGHT,
+    flexShrink: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pill: {
+    width: RESTING_PILL_WIDTH,
+    height: RESTING_PILL_HEIGHT,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.borderAccent,
+  },
+  pillActive: {
+    width: ACTIVE_PILL_WIDTH,
+    backgroundColor: theme.colors.foregroundExtraMuted,
+  },
+  pillAttention: {
+    backgroundColor: theme.colors.foreground,
+  },
+  preview: {
+    position: "absolute",
+    left: RAIL_WIDTH + PREVIEW_GAP,
+    top: "50%",
+    marginTop: -PREVIEW_HEIGHT / 2,
+    width: PREVIEW_WIDTH,
+    height: PREVIEW_HEIGHT,
+    justifyContent: "center",
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.lg,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface2,
+    ...theme.shadow.md,
+  },
+  previewText: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.foreground,
+  },
+}));

--- a/packages/app/src/agent-stream/chat-outline/use-chat-outline.ts
+++ b/packages/app/src/agent-stream/chat-outline/use-chat-outline.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import type { AgentTimelinePromptIndexPayload } from "@getpaseo/client/internal/daemon-client";
-import { isWeb } from "@/constants/platform";
 import { useStableEvent } from "@/hooks/use-stable-event";
 import { getHostRuntimeStore } from "@/runtime/host-runtime";
 import { planTimelinePromptJump } from "@/timeline/timeline-sync-plan";
@@ -62,7 +61,7 @@ export function useChatOutline({
   const prompts = enabled ? (index?.prompts ?? NO_PROMPTS) : NO_PROMPTS;
 
   useEffect(() => {
-    if (!isWeb || !enabled) {
+    if (!enabled) {
       setIndex(null);
       return;
     }

--- a/packages/app/src/agent-stream/strategy-native.tsx
+++ b/packages/app/src/agent-stream/strategy-native.tsx
@@ -98,6 +98,7 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
     routeBottomAnchorRequest,
     isAuthoritativeHistoryReady,
     onNearBottomChange,
+    onReadingPositionChange,
     onNearHistoryStart,
     isLoadingOlderHistory,
     hasOlderHistory,
@@ -158,6 +159,29 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
         historyRowRevision?.contentById.has(item.id) ? { ...item } : item,
       ),
     [displayStateHistoryRows, historyRowRevision?.contentById],
+  );
+  const historyRowsRef = useRef<StreamItem[]>([]);
+  historyRowsRef.current = historyRows;
+
+  // The chat outline rail needs a reading position. Web reports the row near a
+  // fixed reading line; the native list approximates it with viewability (the
+  // first visible row, which on the inverted list is the newest visible one).
+  const viewabilityConfig = useMemo(() => ({ itemVisiblePercentThreshold: 25 }), []);
+  const handleViewableItemsChanged = useStableEvent(
+    ({ viewableItems }: { viewableItems: Array<{ item: StreamItem }> }) => {
+      onReadingPositionChange?.(viewableItems[0]?.item?.id ?? null);
+    },
+  );
+  // Rows are not measured, so scrollToIndex can miss an unrendered window; fall
+  // back to an offset estimate so the rail jump still lands.
+  const handleScrollToIndexFailed = useCallback(
+    (info: { index: number; averageItemLength: number }) => {
+      flatListRef.current?.scrollToOffset({
+        offset: info.averageItemLength * info.index,
+        animated: true,
+      });
+    },
+    [],
   );
   const getHistoryStartPaginationInput = useStableEvent((): HistoryStartPaginationInput => {
     const metrics = streamViewportMetricsRef.current;
@@ -375,6 +399,12 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
           agentId,
           reason,
         });
+      },
+      scrollToMessage: (itemId: string) => {
+        const index = historyRowsRef.current.findIndex((row) => row.id === itemId);
+        if (index >= 0) {
+          flatListRef.current?.scrollToIndex({ index, viewPosition: 0.5, animated: true });
+        }
       },
       prepareForViewportChange: () => {
         bottomAnchorController.prepareForStickyViewportChange();
@@ -625,6 +655,9 @@ function NativeStreamViewport(props: StreamRenderInput & { strategy: StreamStrat
       scrollEnabled={scrollEnabled}
       showsVerticalScrollIndicator
       inverted
+      viewabilityConfig={viewabilityConfig}
+      onViewableItemsChanged={handleViewableItemsChanged}
+      onScrollToIndexFailed={handleScrollToIndexFailed}
     />
   );
 }

--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -80,6 +80,7 @@ import { loadDesktopSettings } from "@/desktop/settings/desktop-settings";
 import { RosettaCalloutSource } from "@/desktop/updates/rosetta-callout-source";
 import { UpdateCalloutSource } from "@/desktop/updates/update-callout-source";
 import { useActiveWorktreeNewAction } from "@/hooks/use-active-worktree-new-action";
+import { useAdaptiveOrientation } from "@/hooks/use-adaptive-orientation";
 import { useGlobalNewWorkspaceAction } from "@/hooks/use-global-new-workspace-action";
 import { useLatchedBoolean } from "@/hooks/use-latched-boolean";
 import { useFaviconStatus } from "@/hooks/use-favicon-status";
@@ -946,6 +947,7 @@ function WorkspaceRouteNavigationBridge() {
 }
 
 function AppShell() {
+  useAdaptiveOrientation();
   return (
     <MobilePanelsProvider>
       <HorizontalScrollProvider>

--- a/packages/app/src/components/combined-model-selector.tsx
+++ b/packages/app/src/components/combined-model-selector.tsx
@@ -176,7 +176,7 @@ export function CombinedModelSelector({
       onEditProfiles={onEditProfiles ? handleEditProfiles : undefined}
       onRetryProvider={onRetryProvider}
       isRetryingProvider={isRetryingProvider}
-      scrolling={isWeb ? "independent" : "sheet"}
+      scrolling="independent"
     />
   ) : (
     <View style={styles.sheetLoadingState}>

--- a/packages/app/src/components/context-window-meter.tsx
+++ b/packages/app/src/components/context-window-meter.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProviderUsageTooltipSection } from "@/provider-usage/tooltip-section";
 import { useProviderUsage } from "@/provider-usage/use-provider-usage";
+import { useIsCompactFormFactor } from "@/constants/layout";
+import { isNative } from "@/constants/platform";
 import { formatTokenCount } from "./context-window-meter.utils";
 
 interface ContextWindowMeterProps {
@@ -108,6 +110,7 @@ export function ContextWindowMeter({
 }: ContextWindowMeterProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
+  const isCompact = useIsCompactFormFactor();
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const { view: providerUsageView, refresh: refreshProviderUsage } = useProviderUsage(
     serverId ?? null,
@@ -173,6 +176,7 @@ export function ContextWindowMeter({
       delayDuration={0}
       enabledOnDesktop
       enabledOnMobile
+      openOnPress={isCompact || isNative}
     >
       <TooltipTrigger asChild triggerRefProp="ref">
         <Pressable

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -83,7 +83,7 @@ import { getDefaultMarkdownClipboardEnvironment } from "@/utils/rich-clipboard-d
 import { setAssistantMarkdownBlockHeight } from "@/utils/assistant-message-height-estimate";
 import { getAgentAttachmentPillContent } from "@/attachments/attachment-pill-content";
 import { PlanCard } from "./plan-card";
-import { useToolCallSheet } from "./tool-call-sheet";
+import { useToolCallSheet, type ToolCallSheetData } from "./tool-call-sheet";
 import { ToolCallDetailsContent } from "./tool-call-details";
 import {
   AssistantInlineCodePathLink,
@@ -3070,8 +3070,9 @@ export const ToolCall = memo(function ToolCall({
   forceInline = false,
   maxDetailHeight = 400,
 }: ToolCallProps) {
-  const { openToolCall } = useToolCallSheet();
+  const { openToolCall, syncToolCallData } = useToolCallSheet();
   const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? false);
+  const sheetTokenRef = useRef<object | null>(null);
 
   const isMobile = useIsCompactFormFactor();
   // The desktop shell renders tool details inline, but on native tablets that
@@ -3116,29 +3117,35 @@ export const ToolCall = memo(function ToolCall({
     return () => onOpenFilePath(openFilePath);
   }, [presentation.openFilePath, onOpenFilePath]);
 
+  const buildSheetData = useCallback(
+    (): ToolCallSheetData => ({
+      displayName: presentation.displayName,
+      summary: presentation.summary,
+      detail: effectiveDetail,
+      errorText: presentation.errorText,
+      icon: presentation.icon,
+      showLoadingSkeleton: presentation.isLoadingDetails,
+    }),
+    [presentation, effectiveDetail],
+  );
+
   const handleToggle = useCallback(() => {
     if (!shouldRenderInline) {
-      openToolCall({
-        displayName: presentation.displayName,
-        summary: presentation.summary,
-        detail: effectiveDetail,
-        errorText: presentation.errorText,
-        icon: presentation.icon,
-        showLoadingSkeleton: presentation.isLoadingDetails,
-      });
+      const token = {};
+      sheetTokenRef.current = token;
+      openToolCall(token, buildSheetData());
     } else {
       setIsExpanded((prev) => !prev);
     }
-  }, [
-    shouldRenderInline,
-    openToolCall,
-    presentation.displayName,
-    presentation.summary,
-    presentation.errorText,
-    presentation.icon,
-    presentation.isLoadingDetails,
-    effectiveDetail,
-  ]);
+  }, [shouldRenderInline, openToolCall, buildSheetData]);
+
+  // Re-sync the open sheet with the live tool call as stream updates arrive, so
+  // streaming output keeps growing instead of freezing at open time.
+  useEffect(() => {
+    if (sheetTokenRef.current) {
+      syncToolCallData(sheetTokenRef.current, buildSheetData());
+    }
+  }, [buildSheetData, syncToolCallData]);
 
   useEffect(() => {
     if (!onInlineDetailsHoverChange || !shouldRenderInline || isExpanded) {

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -2990,14 +2990,25 @@ export const ExpandableBadge = memo(function ExpandableBadge({
         </View>
       </Pressable>
       {detailContent ? (
-        <Pressable
-          ref={detailWrapperRef}
-          style={detailWrapperStyle}
-          onHoverIn={handleDetailHoverIn}
-          onHoverOut={handleDetailHoverOut}
-        >
-          {detailContent}
-        </Pressable>
+        isNative ? (
+          // A Pressable claims the touch responder unconditionally on native
+          // (Pressability returns true from onStartShouldSetResponder unless
+          // disabled), which swallows the scroll gestures of the detail
+          // content's inner scroll views. The wrapper only needs hover
+          // (web-only), so render a plain View on native.
+          <View ref={detailWrapperRef} style={detailWrapperStyle}>
+            {detailContent}
+          </View>
+        ) : (
+          <Pressable
+            ref={detailWrapperRef}
+            style={detailWrapperStyle}
+            onHoverIn={handleDetailHoverIn}
+            onHoverOut={handleDetailHoverOut}
+          >
+            {detailContent}
+          </Pressable>
+        )
       ) : null}
     </View>
   );
@@ -3063,7 +3074,12 @@ export const ToolCall = memo(function ToolCall({
   const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? false);
 
   const isMobile = useIsCompactFormFactor();
-  const shouldRenderInline = !isMobile || forceInline;
+  // The desktop shell renders tool details inline, but on native tablets that
+  // nests a scroll view inside the inverted conversation FlatList, which
+  // fights the parent gesture (Android nested scroll inverts the direction).
+  // Route native tablets through the sheet like phones do — the sheet is an
+  // RNGH-owned container, so the inner scroll view scrolls cleanly.
+  const shouldRenderInline = (!isMobile && !isNative) || forceInline;
 
   const effectiveDetail = useMemo<ToolCallDetail | undefined>(() => {
     if (detail) {

--- a/packages/app/src/components/sortable-inline-list.native.tsx
+++ b/packages/app/src/components/sortable-inline-list.native.tsx
@@ -1,10 +1,54 @@
-import type { ReactElement } from "react";
+import { Fragment, useCallback, useMemo, useRef, useState, type ReactElement } from "react";
+import type { LayoutChangeEvent } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue } from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
+import * as Haptics from "expo-haptics";
 import type { DraggableRenderItemInfo } from "./draggable-list.types";
+
+// Mirrors the sidebar's long-press drag values (use-long-press-drag-interaction
+// arm delay + DraggableFlatList activationDistance + resize fail offset).
+const LONG_PRESS_ACTIVATION_MS = 180;
+const HORIZONTAL_ACTIVATION_SLOP = 20;
+const VERTICAL_SCROLL_SLOP = 12;
+const DRAG_SCALE = 1.02;
+const DRAG_OPACITY = 0.9;
+
+/**
+ * Resolves the index a chip would land on given a finger offset relative to
+ * the chip's original left edge. Chips have measured (per-item) widths, so the
+ * math walks cumulative widths instead of assuming a fixed stride.
+ */
+function computeTargetIndex(startIndex: number, translation: number, widths: number[]): number {
+  "worklet";
+  if (widths.length === 0) {
+    return startIndex;
+  }
+  let prefix = 0;
+  for (let i = 0; i < startIndex && i < widths.length; i++) {
+    prefix += widths[i];
+  }
+  const finger = prefix + translation;
+  let acc = 0;
+  for (let i = 0; i < widths.length; i++) {
+    acc += widths[i];
+    if (finger <= acc) {
+      return i;
+    }
+  }
+  return widths.length - 1;
+}
 
 export function SortableInlineList<T>({
   data,
   keyExtractor,
   renderItem,
+  onDragEnd,
+  useDragHandle: _useDragHandle,
+  disabled = false,
+  externalDndContext = false,
+  activeId: _activeId,
+  getItemData: _getItemData,
 }: {
   data: T[];
   keyExtractor: (item: T, index: number) => string;
@@ -16,32 +60,212 @@ export function SortableInlineList<T>({
   activeId?: string | null;
   getItemData?: (item: T, index: number) => Record<string, unknown>;
 }): ReactElement {
+  // Cross-pane drags need the external dnd context, which native does not have.
+  const canDrag = !disabled && !externalDndContext && data.length > 1;
+  const dragIndex = useSharedValue(-1);
+  const translationX = useSharedValue(0);
+  const targetIndex = useSharedValue(-1);
+  const widths = useSharedValue<number[]>([]);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const dataRef = useRef(data);
+  dataRef.current = data;
+  const onDragEndRef = useRef(onDragEnd);
+  onDragEndRef.current = onDragEnd;
+
+  const commitReorder = useCallback((from: number, to: number) => {
+    if (from === to) {
+      return;
+    }
+    const current = dataRef.current;
+    const next = [...current];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    onDragEndRef.current?.(next);
+  }, []);
+
+  const resetDragState = useCallback(() => {
+    "worklet";
+    dragIndex.value = -1;
+    translationX.value = 0;
+    targetIndex.value = -1;
+    runOnJS(setActiveIndex)(null);
+  }, [dragIndex, targetIndex, translationX]);
+
+  if (!canDrag) {
+    return (
+      <>
+        {data.map((item, index) => {
+          const id = keyExtractor(item, index);
+          const info: DraggableRenderItemInfo<T> = {
+            item,
+            index,
+            drag: () => {},
+            isActive: false,
+          };
+          return <Fragment key={id}>{renderItem(info)}</Fragment>;
+        })}
+      </>
+    );
+  }
+
   return (
     <>
       {data.map((item, index) => {
         const id = keyExtractor(item, index);
+        const info: DraggableRenderItemInfo<T> = {
+          item,
+          index,
+          drag: () => {},
+          isActive: activeIndex === index,
+        };
         return (
-          <SortableInlineListItem key={id} item={item} index={index} renderItem={renderItem} />
+          <SortableNativeItem
+            key={id}
+            index={index}
+            renderItem={renderItem}
+            info={info}
+            dragIndex={dragIndex}
+            translationX={translationX}
+            targetIndex={targetIndex}
+            widths={widths}
+            setActiveIndex={setActiveIndex}
+            commitReorder={commitReorder}
+            resetDragState={resetDragState}
+          />
         );
       })}
     </>
   );
 }
 
-function SortableInlineListItem<T>({
-  item,
-  index,
-  renderItem,
-}: {
-  item: T;
+interface SortableNativeItemProps<T> {
   index: number;
   renderItem: (info: DraggableRenderItemInfo<T>) => ReactElement;
-}): ReactElement {
-  const info: DraggableRenderItemInfo<T> = {
-    item,
-    index,
-    drag: () => {},
-    isActive: false,
-  };
-  return renderItem(info);
+  info: DraggableRenderItemInfo<T>;
+  dragIndex: SharedValue<number>;
+  translationX: SharedValue<number>;
+  targetIndex: SharedValue<number>;
+  widths: SharedValue<number[]>;
+  setActiveIndex: (index: number | null) => void;
+  commitReorder: (from: number, to: number) => void;
+  resetDragState: () => void;
+}
+
+function SortableNativeItem<T>({
+  index,
+  renderItem,
+  info,
+  dragIndex,
+  translationX,
+  targetIndex,
+  widths,
+  setActiveIndex,
+  commitReorder,
+  resetDragState,
+}: SortableNativeItemProps<T>) {
+  const touchStartX = useSharedValue(0);
+  const touchStartY = useSharedValue(0);
+  const touchStartTime = useSharedValue(0);
+
+  const gesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .manualActivation(true)
+        .shouldCancelWhenOutside(false)
+        .onTouchesDown((event, stateManager) => {
+          const touch = event.changedTouches[0];
+          if (!touch) {
+            stateManager.fail();
+            return;
+          }
+          touchStartX.value = touch.absoluteX;
+          touchStartY.value = touch.absoluteY;
+          touchStartTime.value = Date.now();
+        })
+        .onTouchesMove((event, stateManager) => {
+          const touch = event.changedTouches[0];
+          if (!touch) {
+            return;
+          }
+          const dx = touch.absoluteX - touchStartX.value;
+          const dy = touch.absoluteY - touchStartY.value;
+          // Vertical intent keeps scrolling the tab row instead of dragging.
+          if (Math.abs(dy) > VERTICAL_SCROLL_SLOP && Math.abs(dy) > Math.abs(dx)) {
+            stateManager.fail();
+            return;
+          }
+          const elapsed = Date.now() - touchStartTime.value;
+          if (elapsed >= LONG_PRESS_ACTIVATION_MS && Math.abs(dx) > HORIZONTAL_ACTIVATION_SLOP) {
+            stateManager.activate();
+          }
+        })
+        .onStart(() => {
+          dragIndex.value = index;
+          translationX.value = 0;
+          targetIndex.value = index;
+          runOnJS(setActiveIndex)(index);
+          void Haptics.selectionAsync().catch(() => {});
+        })
+        .onUpdate((event) => {
+          translationX.value = event.translationX;
+          targetIndex.value = computeTargetIndex(index, event.translationX, widths.value);
+        })
+        .onEnd((_event, success) => {
+          const from = dragIndex.value;
+          const to = targetIndex.value;
+          resetDragState();
+          if (success && from >= 0 && to >= 0) {
+            runOnJS(commitReorder)(from, to);
+          }
+        })
+        .onFinalize(() => {
+          if (dragIndex.value === index) {
+            resetDragState();
+          }
+        }),
+    [commitReorder, dragIndex, index, resetDragState, setActiveIndex, targetIndex, touchStartTime, touchStartX, touchStartY, translationX, widths],
+  );
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const next = widths.value.slice();
+      next[index] = event.nativeEvent.layout.width;
+      widths.value = next;
+    },
+    [index, widths],
+  );
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const dragging = dragIndex.value;
+    if (dragging < 0) {
+      return {};
+    }
+    if (index === dragging) {
+      return {
+        transform: [{ translateX: translationX.value }, { scale: DRAG_SCALE }],
+        zIndex: 10,
+        opacity: DRAG_OPACITY,
+      };
+    }
+    const target = targetIndex.value;
+    if (target < 0) {
+      return {};
+    }
+    const shift = widths.value[dragging] ?? 0;
+    if (index < dragging && index >= target) {
+      return { transform: [{ translateX: shift }] };
+    }
+    if (index > dragging && index <= target) {
+      return { transform: [{ translateX: -shift }] };
+    }
+    return {};
+  });
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View onLayout={handleLayout} style={animatedStyle}>
+        {renderItem(info)}
+      </Animated.View>
+    </GestureDetector>
+  );
 }

--- a/packages/app/src/components/tool-call-sheet.tsx
+++ b/packages/app/src/components/tool-call-sheet.tsx
@@ -1,8 +1,9 @@
-import React, { createContext, useContext, useCallback, useMemo } from "react";
+import React, { createContext, useContext, useCallback, useEffect, useMemo } from "react";
 import type { ReactNode } from "react";
-import { View, Text, Pressable } from "react-native";
+import { BackHandler, View, Text, Pressable } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import Animated from "react-native-reanimated";
+import { isWeb } from "@/constants/platform";
 import {
   BottomSheetScrollView,
   BottomSheetBackdrop,
@@ -29,8 +30,9 @@ export interface ToolCallSheetData {
 }
 
 interface ToolCallSheetContextValue {
-  openToolCall: (data: ToolCallSheetData) => void;
+  openToolCall: (token: object, data: ToolCallSheetData) => void;
   closeToolCall: () => void;
+  syncToolCallData: (token: object, data: ToolCallSheetData) => void;
 }
 
 // ----- Context -----
@@ -62,21 +64,49 @@ interface ToolCallSheetProviderProps {
   children: ReactNode;
 }
 
+// The sheet renders live tool call data through a token-scoped sync: the caller
+// opens with an opaque token and re-syncs on every stream update, so the sheet
+// follows streaming output instead of freezing at the moment it was opened.
+interface ToolCallSheetSession {
+  token: object;
+  data: ToolCallSheetData;
+}
+
 export function ToolCallSheetProvider({ children }: ToolCallSheetProviderProps) {
   const { theme } = useUnistyles();
-  const [sheetData, setSheetData] = React.useState<ToolCallSheetData | null>(null);
+  const [session, setSession] = React.useState<ToolCallSheetSession | null>(null);
   const [isSheetOpen, setIsSheetOpen] = React.useState(false);
 
   const snapPoints = useMemo(() => ["60%", "95%"], []);
 
-  const openToolCall = useCallback((data: ToolCallSheetData) => {
-    setSheetData(data);
+  const openToolCall = useCallback((token: object, data: ToolCallSheetData) => {
+    setSession({ token, data });
     setIsSheetOpen(true);
   }, []);
 
   const closeToolCall = useCallback(() => {
     setIsSheetOpen(false);
   }, []);
+
+  const syncToolCallData = useCallback((token: object, data: ToolCallSheetData) => {
+    setSession((current) =>
+      current !== null && current.token === token ? { ...current, data } : current,
+    );
+  }, []);
+
+  // Android's hardware back closes the sheet instead of exiting the app. Gorhom
+  // v5 mounts no native Modal, so no onRequestClose exists; a BackHandler is the
+  // only path. Web and desktop never see this handler.
+  useEffect(() => {
+    if (isWeb || !isSheetOpen) {
+      return;
+    }
+    const handler = BackHandler.addEventListener("hardwareBackPress", () => {
+      closeToolCall();
+      return true;
+    });
+    return () => handler.remove();
+  }, [closeToolCall, isSheetOpen]);
 
   const {
     sheetRef: bottomSheetRef,
@@ -89,7 +119,7 @@ export function ToolCallSheetProvider({ children }: ToolCallSheetProviderProps) 
 
   const handleToolCallSheetDismiss = useCallback(() => {
     handleSheetDismiss();
-    setSheetData(null);
+    setSession(null);
   }, [handleSheetDismiss]);
 
   const renderBackdrop = useCallback(
@@ -100,8 +130,8 @@ export function ToolCallSheetProvider({ children }: ToolCallSheetProviderProps) 
   );
 
   const contextValue = useMemo(
-    () => ({ openToolCall, closeToolCall }),
-    [openToolCall, closeToolCall],
+    () => ({ openToolCall, closeToolCall, syncToolCallData }),
+    [openToolCall, closeToolCall, syncToolCallData],
   );
 
   const handleIndicatorStyle = useMemo(
@@ -125,7 +155,7 @@ export function ToolCallSheetProvider({ children }: ToolCallSheetProviderProps) 
         backgroundComponent={CustomSheetBackground}
         handleIndicatorStyle={handleIndicatorStyle}
       >
-        {sheetData && <ToolCallSheetContent data={sheetData} onClose={closeToolCall} />}
+        {session && <ToolCallSheetContent data={session.data} onClose={closeToolCall} />}
       </IsolatedBottomSheetModal>
     </ToolCallSheetContext.Provider>
   );

--- a/packages/app/src/components/ui/tooltip.tsx
+++ b/packages/app/src/components/ui/tooltip.tsx
@@ -231,6 +231,7 @@ export function Tooltip({
   delayDuration = 0,
   enabledOnDesktop = true,
   enabledOnMobile = false,
+  openOnPress,
   children,
 }: PropsWithChildren<{
   open?: boolean;
@@ -239,6 +240,8 @@ export function Tooltip({
   delayDuration?: number;
   enabledOnDesktop?: boolean;
   enabledOnMobile?: boolean;
+  /** Override the compact-layout press-to-open behavior (e.g. native tablets). */
+  openOnPress?: boolean;
 }>): ReactElement {
   const triggerRef = useRef<View>(null);
   const [isOpen, setIsOpen] = useControllableOpenState({
@@ -249,6 +252,7 @@ export function Tooltip({
 
   const isCompact = useIsCompactFormFactor();
   const enabled = isCompact ? enabledOnMobile : enabledOnDesktop;
+  const resolvedOpenOnPress = openOnPress ?? isCompact;
 
   const value = useMemo<TooltipContextValue>(
     () => ({
@@ -256,10 +260,10 @@ export function Tooltip({
       setOpen: setIsOpen,
       triggerRef,
       enabled,
-      openOnPress: isCompact,
+      openOnPress: resolvedOpenOnPress,
       delayDuration,
     }),
-    [isOpen, setIsOpen, enabled, isCompact, delayDuration],
+    [isOpen, setIsOpen, enabled, resolvedOpenOnPress, delayDuration],
   );
 
   return <TooltipContext.Provider value={value}>{children}</TooltipContext.Provider>;

--- a/packages/app/src/constants/layout.ts
+++ b/packages/app/src/constants/layout.ts
@@ -1,5 +1,6 @@
 import { useWindowDimensions } from "react-native";
 import { isWeb } from "@/constants/platform";
+import { APP_BREAKPOINTS } from "@/styles/unistyles";
 
 export const FOOTER_HEIGHT = 75;
 
@@ -41,14 +42,16 @@ export {
  * Always use this instead of reading UnistylesRuntime.breakpoint directly.
  */
 export function useIsCompactFormFactor(): boolean {
-  // Use RN's useWindowDimensions instead of the Unistyles breakpoint: on
-  // Android the Unistyles mini-runtime only refreshes its screen dimensions
-  // on an ACTION_CONFIGURATION_CHANGED broadcast, which Android does not send
-  // while resizing a split-screen or free-form window. RN's dimensions update
-  // through onGlobalLayout, which fires continuously during those resizes.
-  // Keep the thresholds aligned with the Unistyles breakpoints (md = 720).
+  // Read the width through RN's useWindowDimensions rather than the
+  // Unistyles breakpoint: on Android the Unistyles mini-runtime only
+  // refreshes its screen dimensions on an ACTION_CONFIGURATION_CHANGED
+  // broadcast, which Android does not send while a split-screen or free-form
+  // window is being resized — and a stale breakpoint from a small start size
+  // would keep the layout compact forever. RN's dimensions update through
+  // onGlobalLayout, which fires continuously during those resizes, so the
+  // width is always current. The threshold is the md breakpoint.
   const { width } = useWindowDimensions();
-  return width < 720;
+  return width < APP_BREAKPOINTS.md;
 }
 
 // SplitContainer relies on dnd-kit and DOM-backed accessibility helpers.

--- a/packages/app/src/constants/layout.ts
+++ b/packages/app/src/constants/layout.ts
@@ -1,4 +1,4 @@
-import { useUnistyles } from "react-native-unistyles";
+import { useWindowDimensions } from "react-native";
 import { isWeb } from "@/constants/platform";
 
 export const FOOTER_HEIGHT = 75;
@@ -41,8 +41,14 @@ export {
  * Always use this instead of reading UnistylesRuntime.breakpoint directly.
  */
 export function useIsCompactFormFactor(): boolean {
-  const { rt } = useUnistyles();
-  return rt.breakpoint === "xs" || rt.breakpoint === "sm";
+  // Use RN's useWindowDimensions instead of the Unistyles breakpoint: on
+  // Android the Unistyles mini-runtime only refreshes its screen dimensions
+  // on an ACTION_CONFIGURATION_CHANGED broadcast, which Android does not send
+  // while resizing a split-screen or free-form window. RN's dimensions update
+  // through onGlobalLayout, which fires continuously during those resizes.
+  // Keep the thresholds aligned with the Unistyles breakpoints (md = 720).
+  const { width } = useWindowDimensions();
+  return width < 720;
 }
 
 // SplitContainer relies on dnd-kit and DOM-backed accessibility helpers.

--- a/packages/app/src/hooks/use-adaptive-orientation.ts
+++ b/packages/app/src/hooks/use-adaptive-orientation.ts
@@ -29,7 +29,9 @@ export function useAdaptiveOrientation(): void {
     }
     lastLockedRef.current = shouldLock;
     if (shouldLock) {
-      void ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+      void ScreenOrientation.lockAsync(
+        ScreenOrientation.OrientationLock.PORTRAIT_UP
+      );
     } else {
       void ScreenOrientation.unlockAsync();
     }

--- a/packages/app/src/hooks/use-adaptive-orientation.ts
+++ b/packages/app/src/hooks/use-adaptive-orientation.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { Platform, useWindowDimensions } from "react-native";
+import * as ScreenOrientation from "expo-screen-orientation";
+
+// Phones must stay portrait: in landscape a phone window is wide enough to
+// cross the desktop layout breakpoint, which renders the desktop shell in a
+// phone-sized window (crowded footer, compressed session list). Tablets keep
+// free rotation — see getpaseo/paseo#1669 for the letterboxing this pair
+// with the with-android-rotation config plugin fixes.
+// Keyed off the window's short side so split-screen windows behave.
+const TABLET_MIN_SHORT_SIDE = 600; // dp
+
+export function useAdaptiveOrientation(): void {
+  const { width, height } = useWindowDimensions();
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+    const shortSide = Math.min(width, height);
+    if (shortSide < TABLET_MIN_SHORT_SIDE) {
+      void ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+    } else {
+      void ScreenOrientation.unlockAsync();
+    }
+  }, [width, height]);
+}

--- a/packages/app/src/hooks/use-adaptive-orientation.ts
+++ b/packages/app/src/hooks/use-adaptive-orientation.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Platform, useWindowDimensions } from "react-native";
 import * as ScreenOrientation from "expo-screen-orientation";
 
@@ -12,12 +12,23 @@ const TABLET_MIN_SHORT_SIDE = 600; // dp
 
 export function useAdaptiveOrientation(): void {
   const { width, height } = useWindowDimensions();
+  // Resize events arrive continuously while a split-screen or free-form
+  // window is being dragged, and each lock/unlock call makes Android re-layout
+  // the whole activity. Remember the last applied state so only actual
+  // transitions (phone <-> tablet) hit the native orientation API.
+  const lastLockedRef = useRef<boolean | null>(null);
+
   useEffect(() => {
     if (Platform.OS !== "android") {
       return;
     }
     const shortSide = Math.min(width, height);
-    if (shortSide < TABLET_MIN_SHORT_SIDE) {
+    const shouldLock = shortSide < TABLET_MIN_SHORT_SIDE;
+    if (lastLockedRef.current === shouldLock) {
+      return;
+    }
+    lastLockedRef.current = shouldLock;
+    if (shouldLock) {
       void ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
     } else {
       void ScreenOrientation.unlockAsync();

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -56,6 +56,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { MobileTabTrailingAccessory } from "@/screens/workspace/workspace-tab-trailing-accessory";
 import { Shortcut } from "@/components/ui/shortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useShortcutKeys } from "@/hooks/use-shortcut-keys";
@@ -575,6 +576,13 @@ function TabChip({
         },
       } as const)
     : undefined;
+  const tabMenuTriggerBlockers = useMemo(() => {
+    if (!isNative) return undefined;
+    const stop = (event: { stopPropagation?: () => void }) => {
+      event.stopPropagation?.();
+    };
+    return { onPointerDown: stop, onMouseDown: stop, onPressIn: stop, onPress: stop } as const;
+  }, []);
 
   const tabChipStyle = useCallback(
     () => [
@@ -661,7 +669,6 @@ function TabChip({
               {...(dragHandleProps?.listeners as object | undefined)}
               testID={`workspace-tab-${buildDeterministicWorkspaceTabId(tab.target)}`}
               triggerRef={dragHandleProps?.setActivatorNodeRef as unknown as undefined}
-              enabledOnMobile={false}
               style={tabChipStyle}
               onHoverIn={handleTabHoverIn}
               onHoverOut={handleTabHoverOut}
@@ -719,6 +726,14 @@ function TabChip({
                     );
                   }}
                 </Pressable>
+              ) : null}
+              {isNative ? (
+                <MobileTabTrailingAccessory
+                  menuTestIDBase={contextMenuTestId}
+                  presentationLabel={tooltipLabel}
+                  menuEntries={menuEntries}
+                  triggerProps={tabMenuTriggerBlockers}
+                />
               ) : null}
             </ContextMenuTrigger>
           </TooltipTrigger>

--- a/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
+++ b/packages/app/src/screens/workspace/workspace-desktop-tabs-row.tsx
@@ -665,6 +665,7 @@ function TabChip({
         <Tooltip delayDuration={400} enabledOnDesktop enabledOnMobile={false}>
           <TooltipTrigger asChild triggerRefProp="triggerRef">
             <ContextMenuTrigger
+              enabledOnMobile={false}
               {...(dragHandleProps?.attributes as object | undefined)}
               {...(dragHandleProps?.listeners as object | undefined)}
               testID={`workspace-tab-${buildDeterministicWorkspaceTabId(tab.target)}`}

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -1945,7 +1945,11 @@ function WorkspaceScreenContent({
   );
 
   useEffect(() => {
-    if (!isRouteFocused || isWeb || !isExplorerOpen) {
+    // Only the compact layout registers this handler: the mobile explorer panel
+    // is a full-screen overlay that back should dismiss. In the desktop shell
+    // the explorer is an inline pane with its own close button, so back exits
+    // the app directly like every other desktop window.
+    if (!isRouteFocused || isWeb || !isMobile || !isExplorerOpen) {
       return;
     }
 
@@ -1958,7 +1962,7 @@ function WorkspaceScreenContent({
     });
 
     return () => handler.remove();
-  }, [isExplorerOpen, isRouteFocused, showMobileAgent]);
+  }, [isExplorerOpen, isMobile, isRouteFocused, showMobileAgent]);
 
   const workspaceLayout = useWorkspaceLayoutStore((state) =>
     persistenceKey ? (state.layoutByWorkspace[persistenceKey] ?? null) : null,

--- a/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.tsx
+++ b/packages/app/src/screens/workspace/workspace-tab-trailing-accessory.tsx
@@ -88,10 +88,15 @@ export function MobileTabTrailingAccessory({
   menuTestIDBase,
   presentationLabel,
   menuEntries,
+  triggerProps,
 }: {
   menuTestIDBase: string;
   presentationLabel: string;
   menuEntries: WorkspaceTabMenuEntry[];
+  triggerProps?: Omit<
+    React.ComponentProps<typeof DropdownMenuTrigger>,
+    "children" | "style" | "testID" | "accessibilityRole" | "accessibilityLabel" | "hitSlop"
+  >;
 }): ReactElement {
   const { t } = useTranslation();
   return (
@@ -102,6 +107,7 @@ export function MobileTabTrailingAccessory({
         accessibilityLabel={t("workspace.tabs.menu.openFor", { label: presentationLabel })}
         hitSlop={8}
         style={mobileTabMenuTriggerStyle}
+        {...triggerProps}
       >
         <ThemedEllipsis size={14} uniProps={mutedColorMapping} />
       </DropdownMenuTrigger>

--- a/packages/app/src/styles/unistyles.ts
+++ b/packages/app/src/styles/unistyles.ts
@@ -1,15 +1,17 @@
 import { StyleSheet } from "react-native-unistyles";
 import { REGISTERED_THEMES } from "./theme";
 
+export const APP_BREAKPOINTS = {
+  xs: 0,
+  sm: 576,
+  md: 720,
+  lg: 992,
+  xl: 1200,
+} as const;
+
 StyleSheet.configure({
   themes: REGISTERED_THEMES,
-  breakpoints: {
-    xs: 0,
-    sm: 576,
-    md: 720,
-    lg: 992,
-    xl: 1200,
-  },
+  breakpoints: APP_BREAKPOINTS,
   settings: {
     adaptiveThemes: true,
   },


### PR DESCRIPTION
### Linked issue

Closes #1669

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

**中文**：在 Android 平板上，横屏时应用被 letterbox 成手机尺寸的窗口，无法全屏使用；解锁横屏后，桌面壳依赖的 hover/右键/中键在 Android 上都不存在，导致 tab 无法打开菜单；工具输出详情若沿用桌面壳的内联（inline）渲染，其内部的滚动视图会嵌套在反向（inverted）的会话列表中——Android 的嵌套滚动方向与 inverted 列表不一致，且外层 Pressable 会无条件抢占触摸响应，实测表现为无法滚动或滚动方向错乱，因此改走与手机端一致的 sheet 弹层（RNGH 容器），从架构上消除嵌套冲突。另外，分屏或自由窗口缩放时布局不会随窗口宽度切换。本 PR 解决上述问题，使平板能够全屏、可操作地使用 Paseo。

**English**: On Android tablets, the app was letterboxed into a phone-sized window in landscape and couldn't be used full-screen. After unlocking landscape, the desktop shell relies on hover/right-click/middle-click, none of which exist on Android, so tabs had no reachable menu. For tool output details, keeping the desktop shell's inline rendering would nest the inner scroll view inside the inverted conversation list — Android's nested-scroll direction conflicts with the inverted list, and the wrapping Pressable unconditionally claims the touch responder, which we verified as either frozen or direction-inverted scrolling. We therefore route tool details through the same sheet the phone uses (an RNGH-owned container), eliminating the nesting conflict at the architecture level. Split-screen and free-form window resizes also never flipped the layout to match the new width. This PR fixes these issues so tablets can use Paseo full-screen and interactively.

### Goals

- Android tablets get full-screen landscape rendering (no more letterboxing), while phones stay portrait-locked
- Desktop-shell tabs get a touch-reachable menu (always-visible overflow button plus long-press) on native
- Tool output details scroll correctly on the tablet desktop shell by routing through the sheet, matching the phone interaction
- Split-screen / free-form window resizes switch the layout (desktop shell ↔ mobile shell) in real time
- No behavior change on Web or desktop

### Non-goals

- No tablet-specific UI rework (e.g. dual-tree transition animations, panel-scoped sheets)
- iPadOS rotation stays locked as before (#1030)
- No new buttons on file lists / diff rows — mobile never had them, so nothing is added
- Layout switch cost (~1s full-tree rebuild) is accepted as-is, no performance work

### QA

**Device (Xiaomi Pad 8, Android):**
- Landscape full-screen → desktop shell renders fully; tab overflow button opens the menu, long-press also opens it
- Tool output block → sheet opens; horizontal and vertical scrolling work; pull-down closes
- Permission-card command preview → inline scrolling works
- Split-screen shrink → layout flips to mobile shell; enlarge → flips back
- Phone portrait lock preserved
- 200-line output block scrolls to first/last line

**Web (local expo export + static server):**
- Layout switches correctly at 500px / 900px / 1100px with no navigation regression
- Settings page stays on the current route after resizes

**Automated tests:** vitest — 3 related files, 11 tests pass. typecheck passes (1 pre-existing environment error unrelated to this PR). lint passes. prettier clean on touched files.

**Not tested:** iOS (no device), Electron desktop.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [ ] Tests added or updated where it made sense