### PR TITLE
feat(agent): opt-in notifyMode "each" keeps the finish watcher armed

### DIFF
--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -13,6 +13,7 @@ import {
   isSystemInjectedEnvelope,
   setupFinishNotification,
   waitForAgentRunStartWithTimeout,
+  type FinishNotifyMode,
 } from "./agent-prompt.js";
 import type { AgentManagerEvent, ManagedAgent } from "./agent-manager.js";
 import type {
@@ -51,6 +52,8 @@ interface FinishNotificationScenarioOptions {
   childParentAgentId?: string | null;
   requireParentOwnership?: boolean;
   parentPromptError?: Error;
+  callerArchived?: boolean;
+  notifyMode?: FinishNotifyMode;
   logger?: Logger;
 }
 
@@ -66,6 +69,7 @@ interface FinishNotificationScenario {
   parentPrompts(): string[];
   steerAttemptCount(): number;
   wasParentPrompted(): boolean;
+  subscriberCount(): number;
 }
 
 function createFinishNotificationScenario(
@@ -134,6 +138,9 @@ function createFinishNotificationScenario(
         labels: parentAgentId ? { "paseo.parent-agent-id": parentAgentId } : {},
       };
     }
+    if (agentId === "caller-agent" && options?.callerArchived) {
+      return { title: "Caller Agent", archivedAt: new Date().toISOString() };
+    }
     return null;
   });
 
@@ -145,6 +152,7 @@ function createFinishNotificationScenario(
         childAgentId: "child-agent",
         callerAgentId: "caller-agent",
         requireParentOwnership: options?.requireParentOwnership,
+        ...(options?.notifyMode ? { notifyMode: options.notifyMode } : {}),
         logger: options?.logger ?? createTestLogger(),
       });
     },
@@ -255,6 +263,9 @@ function createFinishNotificationScenario(
     },
     wasParentPrompted() {
       return parentPrompted;
+    },
+    subscriberCount() {
+      return subscriber ? 1 : 0;
     },
   };
 }
@@ -761,4 +772,58 @@ test("waiting for a run start still gives up at the run start budget", async () 
     vi.useRealTimers();
     await scenario.cleanup();
   }
+});
+
+test("the watcher stops after the first finish by default", async () => {
+  const scenario = createFinishNotificationScenario();
+
+  scenario.startWatchingChild();
+  await scenario.finishChildAndReadParentPrompt();
+  scenario.finishChild();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(scenario.parentPrompts()).toHaveLength(1);
+});
+
+test('notifyMode "each" notifies the caller on every finish', async () => {
+  const scenario = createFinishNotificationScenario({ notifyMode: "each" });
+
+  scenario.startWatchingChild();
+  await scenario.finishChildAndReadParentPrompt();
+  await scenario.finishChildAndReadParentPrompt();
+  await scenario.finishChildAndReadParentPrompt();
+
+  expect(scenario.parentPrompts()).toHaveLength(3);
+  for (const prompt of scenario.parentPrompts()) {
+    expect(prompt).toContain("Agent child-agent (Child Agent) finished.");
+  }
+});
+
+test('notifyMode "each" still stops when the child closes', async () => {
+  const scenario = createFinishNotificationScenario({ notifyMode: "each" });
+
+  scenario.startWatchingChild();
+  await scenario.finishChildAndReadParentPrompt();
+  await scenario.closeChildAndReadParentPrompt();
+  scenario.finishChild();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(scenario.parentPrompts()).toHaveLength(2);
+  expect(scenario.parentPrompts()[1]).toContain("was closed.");
+});
+
+test('notifyMode "each" stops once the caller is archived', async () => {
+  const scenario = createFinishNotificationScenario({
+    notifyMode: "each",
+    callerArchived: true,
+  });
+
+  scenario.startWatchingChild();
+  scenario.finishChild();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  scenario.finishChild();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(scenario.wasParentPrompted()).toBe(false);
+  expect(scenario.subscriberCount()).toBe(0);
 });

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -334,8 +334,18 @@ export interface SetupFinishNotificationParams {
   childAgentId: string;
   callerAgentId: string;
   requireParentOwnership?: boolean;
+  /**
+   * How long the watcher stays armed. `"once"` (the default, and the behaviour
+   * before this option existed) sends one notification and disarms. `"each"`
+   * re-arms after every finish, so a caller driving one long-lived child across
+   * many turns hears about all of them; it disarms when the child closes or
+   * errors, or when the caller is archived.
+   */
+  notifyMode?: FinishNotifyMode;
   logger: Logger;
 }
+
+export type FinishNotifyMode = "once" | "each";
 
 type FinishNotificationReason = "finished" | "errored" | "needs permission" | "was closed";
 
@@ -389,6 +399,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     childAgentId,
     callerAgentId,
     requireParentOwnership = false,
+    notifyMode = "once",
     logger,
   } = params;
   let hasSeenRunning = false;
@@ -409,6 +420,10 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
   ): Promise<void> {
     const callerRecord = await agentStorage.get(callerAgentId);
     if (callerRecord?.archivedAt) {
+      // Under "once" the watcher has already stopped before this runs, so this
+      // only matters for "each": nobody is left to hear it, and a watcher that
+      // stays armed would hold the subscription for the child's whole life.
+      if (notifyMode === "each") stop();
       return;
     }
 
@@ -473,6 +488,14 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
           return;
         }
         if (event.agent.lifecycle === "idle" && hasSeenRunning) {
+          if (notifyMode === "each") {
+            // Stay armed and reset the run gate, so the child's next
+            // running -> idle cycle notifies again. "was closed" and "errored"
+            // are still terminal, and so is an archived caller.
+            hasSeenRunning = false;
+            notifySafely("finished", { terminal: false });
+            return;
+          }
           notifySafely("finished");
           return;
         }

--- a/packages/server/src/server/agent/create-agent/create.ts
+++ b/packages/server/src/server/agent/create-agent/create.ts
@@ -17,6 +17,7 @@ import type { AgentStorage } from "../agent-storage.js";
 import type { AgentOwner } from "../agent-owner.js";
 import type { ProviderSnapshotManager } from "../provider-snapshot-manager.js";
 import { setupFinishNotification, startCreatedAgentInitialPrompt } from "../agent-prompt.js";
+import type { FinishNotifyMode } from "../agent-prompt.js";
 import { resolveCreateAgentTitles } from "../create-agent-title.js";
 import { buildAgentPrompt } from "../prompt-attachments.js";
 import { normalizeClientMessageId, resolveClientMessageId } from "../../client-message-id.js";
@@ -93,6 +94,7 @@ export interface CreateAgentFromMcpInput {
   promptFailure?: CreateAgentPromptFailureMode;
   background: boolean;
   notifyOnFinish: boolean;
+  notifyMode?: FinishNotifyMode;
   internal?: boolean;
   detached?: boolean;
   owner?: AgentOwner;
@@ -210,6 +212,7 @@ export async function createAgentCommand(
       childAgentId: snapshot.id,
       callerAgentId: input.callerAgentId,
       requireParentOwnership: true,
+      ...(input.notifyMode ? { notifyMode: input.notifyMode } : {}),
       logger: dependencies.logger,
     });
   }

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -61,6 +61,7 @@ import {
   waitForAgentWithTimeout,
 } from "../mcp-shared.js";
 import { sendPromptToAgent, setupFinishNotification } from "../agent-prompt.js";
+import type { FinishNotifyMode } from "../agent-prompt.js";
 import { respondToAgentPermission } from "../permission-response.js";
 import {
   archiveAgentCommand,
@@ -1016,8 +1017,15 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         "Existing workspace id. Agent-scoped calls default to the caller workspace; top-level calls create a new local workspace when omitted.",
       ),
   };
+  const notifyModeField = z
+    .enum(["once", "each"])
+    .optional()
+    .describe(
+      'How long the finish watcher stays armed. "once" (default) sends one notification, then stops. "each" re-notifies on every finish until the agent closes or errors — use it when the agent you are watching takes several turns, for example because it orchestrates children of its own.',
+    );
   const agentToAgentInputSchema = {
     ...canonicalCreateAgentFields,
+    notifyMode: notifyModeField,
     notifyOnFinish: z
       .boolean()
       .optional()
@@ -1046,6 +1054,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
   const legacyAgentToAgentInputSchema = {
     ...commonCreateAgentFields,
     ...legacyCreateAgentPlacementFields,
+    notifyMode: notifyModeField,
     notifyOnFinish: agentToAgentInputSchema.notifyOnFinish,
   };
   const legacyTopLevelCreateAgentInputSchema = {
@@ -1110,6 +1119,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
   };
   const agentToAgentSendAgentPromptInputSchema = {
     ...commonSendAgentPromptInputSchema,
+    notifyMode: notifyModeField,
     background: z
       .boolean()
       .optional()
@@ -1428,9 +1438,11 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       const { parsedArgs, worktree } = resolvedArgs;
       let requestedBackground: boolean;
       let notifyOnFinish: boolean;
+      let notifyMode: FinishNotifyMode = "once";
       if (resolvedArgs.kind === "agent-scoped") {
         requestedBackground = true;
         notifyOnFinish = parsedArgs.notifyOnFinish;
+        notifyMode = ("notifyMode" in parsedArgs ? parsedArgs.notifyMode : undefined) ?? "once";
       } else {
         requestedBackground = resolvedArgs.parsedArgs.background;
         notifyOnFinish = resolvedArgs.parsedArgs.notifyOnFinish ?? false;
@@ -1469,6 +1481,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           mode: parsedArgs.settings?.modeId,
           background: requestedBackground,
           notifyOnFinish,
+          notifyMode,
           detached: resolvedArgs.detached,
           callerAgentId,
           callerContext,
@@ -1886,6 +1899,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       sessionMode,
       background = Boolean(callerAgentId),
       notifyOnFinish = Boolean(callerAgentId),
+      notifyMode,
     }) => {
       const shouldNotifyOnFinish = Boolean(callerAgentId && notifyOnFinish && background);
 
@@ -1904,6 +1918,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           agentStorage,
           childAgentId: agentId,
           callerAgentId,
+          ...(notifyMode ? { notifyMode } : {}),
           logger: childLogger,
         });
       }


### PR DESCRIPTION
Resubmission of the third patch from #2879, in the opt-in shape. That PR changed the default for every existing caller, which is why you closed it; the other two landed as #3192. This one changes nothing for anyone who does not ask for it.

## The problem

`setupFinishNotification` unsubscribes after the first finish. That fits a caller which delegates one unit of work and waits for it. It does not fit a caller which drives one long-lived child across many turns — it hears about turn one and then sleeps through everything after, because the watcher is gone.

Concretely: an orchestrating agent sends a child a second `send_agent_prompt` and never learns that it completed.

## The change

`notifyMode` on the **agent-scoped** `create_agent` and `send_agent_prompt` schemas:

- `"once"` — the default, and exactly today's behaviour: one notification, then disarm.
- `"each"` — re-arm after every finish; disarm when the child closes or errors, or when the caller is archived.

The watcher change is one argument wide — `"each"` passes `{ terminal: false }` on the `"finished"` path and resets the run gate, so the child's next running → idle cycle notifies again. It builds directly on the `terminal` option added in #3177.

## Notes on shape

**The default path is untouched.** A test asserts the watcher still stops after the first finish when no mode is given.

**The archived-caller disarm is scoped to `"each"`.** Under `"once"` the watcher has already stopped before that code runs, so the existing path is unchanged. Under `"each"` it would otherwise hold the subscription for the child's whole life with nobody left to hear it.

**The field is `.optional()` with no `.default()`.** A default injects the key into every parsed result, and `legacyAgentToAgentInputSchema` is `.strict()`, so calls that never named the field would start failing. The read site coalesces to `"once"` instead. (Learned the hard way on a sibling patch — `.default()` there turned several `mcp-parity.e2e.test.ts` cases red.)

## Verification

- Four new tests in `agent-prompt.test.ts`, each **mutation-checked**: making `"each"` terminal, defaulting to `"each"`, and dropping the archived-caller disarm each turn the suite red.
- `packages/server/src/server/agent` unit suites: **1962 passed**, 21 skipped.
- `tsc -p tsconfig.server.json --noEmit`: clean. `biome check` on the touched files: clean.
- `mcp-parity.e2e.test.ts`: 5 failed / 26 passed **both with and without this patch** — identical to the `upstream/main` baseline on this machine, so those failures are environmental, and the parity cases that guard schema injection pass.

Happy to rename the modes or move the field if you would rather it lived somewhere else.