### PR TITLE
fix(app): restore terminal surface after tab hide so CJK cells redraw

### DIFF
--- a/packages/app/src/components/terminal-emulator-contract.ts
+++ b/packages/app/src/components/terminal-emulator-contract.ts
@@ -19,6 +19,7 @@ export interface TerminalEmulatorHandle {
   copySelection: (clipboard: TerminalClipboardWriter) => Promise<string>;
   clear: () => void;
   claimSize: () => void;
+  restoreSurface: () => void;
   showKeyboard: () => void;
   blur: () => void;
 }

--- a/packages/app/src/components/terminal-emulator-native-grid.native.tsx
+++ b/packages/app/src/components/terminal-emulator-native-grid.native.tsx
@@ -567,6 +567,7 @@ function NativeTerminalEmulator({
         schedulePaint();
       },
       claimSize: claimActiveTerminalSize,
+      restoreSurface: claimActiveTerminalSize,
       showKeyboard: () => {
         inputRef.current?.showKeyboard();
         claimActiveTerminalSizeForAction("showKeyboard");

--- a/packages/app/src/components/terminal-emulator-webview.native.tsx
+++ b/packages/app/src/components/terminal-emulator-webview.native.tsx
@@ -345,6 +345,9 @@ export default function WebViewTerminalEmulator({
       claimSize: () => {
         sendToWebView({ type: "resize", streamKey, forceClaim: true });
       },
+      restoreSurface: () => {
+        sendToWebView({ type: "resize", streamKey, forceClaim: false, shouldClaim: false });
+      },
       showKeyboard: () => {
         sendToWebView({ type: "focus", streamKey, forceRefocus: true });
         webViewRef.current?.requestFocus();

--- a/packages/app/src/components/terminal-emulator.tsx
+++ b/packages/app/src/components/terminal-emulator.tsx
@@ -48,6 +48,7 @@ export interface TerminalEmulatorHandle {
   copySelection: (clipboard: TerminalClipboardWriter) => Promise<string>;
   clear: () => void;
   claimSize: () => void;
+  restoreSurface: () => void;
   showKeyboard: () => void;
   blur: () => void;
 }
@@ -270,6 +271,9 @@ export default function TerminalEmulator({
       claimSize: () => {
         runtimeRef.current?.resize({ forceClaim: true, shouldClaim: true });
       },
+      restoreSurface: () => {
+        runtimeRef.current?.restoreSurface();
+      },
       showKeyboard: () => {
         runtimeRef.current?.resize({ forceClaim: true, shouldClaim: true });
         runtimeRef.current?.focus();
@@ -301,6 +305,9 @@ export default function TerminalEmulator({
       },
       claimSize: () => {
         runtimeRef.current?.resize({ forceClaim: true, shouldClaim: true });
+      },
+      restoreSurface: () => {
+        runtimeRef.current?.restoreSurface();
       },
       showKeyboard: () => {
         runtimeRef.current?.resize({ forceClaim: true, shouldClaim: true });

--- a/packages/app/src/components/terminal-pane.tsx
+++ b/packages/app/src/components/terminal-pane.tsx
@@ -340,6 +340,13 @@ export function TerminalPane({
   );
 
   useEffect(() => {
+    if (!isTerminalActive) {
+      return;
+    }
+    emulatorRef.current?.restoreSurface();
+  }, [isTerminalActive]);
+
+  useEffect(() => {
     if (isMobile || !isPaneFocused || !terminalId) {
       lastAutoFocusKeyRef.current = null;
       return;

--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.test.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.test.ts
@@ -599,6 +599,40 @@ describe("terminal-emulator-runtime", () => {
     expect(refresh).toHaveBeenCalledWith(0, 11);
   });
 
+  it("restoreSurface refits and reloads the WebGL renderer", () => {
+    const runtime = new TerminalEmulatorRuntime();
+    const fitAndEmitResize = vi.fn();
+    const restoreWebglRenderer = vi.fn();
+    const raf = vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+
+    (
+      runtime as unknown as {
+        fitAndEmitResize: typeof fitAndEmitResize;
+        restoreWebglRenderer: typeof restoreWebglRenderer;
+      }
+    ).fitAndEmitResize = fitAndEmitResize;
+    (
+      runtime as unknown as {
+        restoreWebglRenderer: typeof restoreWebglRenderer;
+      }
+    ).restoreWebglRenderer = restoreWebglRenderer;
+    (globalThis as unknown as { window: { requestAnimationFrame: typeof raf } }).window = {
+      requestAnimationFrame: raf,
+    };
+
+    runtime.restoreSurface();
+
+    expect(restoreWebglRenderer).toHaveBeenCalledTimes(2);
+    expect(fitAndEmitResize).toHaveBeenCalledTimes(2);
+    expect(fitAndEmitResize).toHaveBeenCalledWith({
+      forceRefresh: true,
+      shouldClaim: false,
+    });
+  });
+
   it("passively refits when the page becomes visible again", () => {
     const runtime = new TerminalEmulatorRuntime();
     const fitAndEmitResize = vi.fn();

--- a/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
+++ b/packages/app/src/terminal/runtime/terminal-emulator-runtime.ts
@@ -147,6 +147,24 @@ export function encodeTerminalOutput(text: string): TerminalOutputData {
   return terminalOutputEncoder.encode(text);
 }
 
+function hostHasLayoutSize(root: HTMLElement): boolean {
+  return root.offsetWidth > 0 && root.offsetHeight > 0;
+}
+
+function shouldSkipUnchangedFit(input: {
+  shouldRefresh: boolean;
+  previous: { rows: number; cols: number } | null;
+  nextRows: number;
+  nextCols: number;
+}): boolean {
+  return (
+    !input.shouldRefresh &&
+    input.previous !== null &&
+    input.previous.rows === input.nextRows &&
+    input.previous.cols === input.nextCols
+  );
+}
+
 function prependTerminalOutput(
   prefix: TerminalOutputData,
   data: TerminalOutputData,
@@ -175,6 +193,8 @@ export class TerminalEmulatorRuntime {
   private fitAddon: FitAddon | null = null;
   private fitAndEmitResize: ((input?: TerminalResizeRequest) => void) | null = null;
   private lastSize: { rows: number; cols: number } | null = null;
+  private hostCollapsed = false;
+  private restoreWebglRenderer: (() => void) | null = null;
   private cleanup: (() => void) | null = null;
   private outputOperations: TerminalOutputOperation[] = [];
   private inFlightOutputOperation: TerminalOutputOperation | null = null;
@@ -199,13 +219,25 @@ export class TerminalEmulatorRuntime {
       return;
     }
 
+    this.restoreSurface();
+  };
+
+  /**
+   * Re-measure and redraw after the host was hidden (`display: none` / collapsed)
+   * or a WebGL context was lost. Tab switches keep `document.visibilityState`
+   * visible, so callers must invoke this on panel restore — not only on
+   * document visibilitychange.
+   */
+  restoreSurface(): void {
+    this.restoreWebglRenderer?.();
     this.fitAndEmitResize?.({ forceRefresh: true, shouldClaim: false });
     if (typeof window.requestAnimationFrame === "function") {
       window.requestAnimationFrame(() => {
+        this.restoreWebglRenderer?.();
         this.fitAndEmitResize?.({ forceRefresh: true, shouldClaim: false });
       });
     }
-  };
+  }
 
   setCallbacks(input: { callbacks: TerminalEmulatorRuntimeCallbacks }): void {
     this.callbacks = input.callbacks;
@@ -224,6 +256,8 @@ export class TerminalEmulatorRuntime {
 
     input.host.innerHTML = "";
     this.lastSize = null;
+    this.hostCollapsed = false;
+    this.restoreWebglRenderer = null;
     this.inputModeTracker.reset();
     this.emitInputModeChange();
 
@@ -329,10 +363,14 @@ export class TerminalEmulatorRuntime {
     };
     registerProtocolQuerySuppression();
 
-    let webglAddonRaf: number | null = requestAnimationFrame(() => {
-      webglAddonRaf = null;
+    const tryLoadWebglRenderer = (): void => {
+      if (webglAddon) {
+        return;
+      }
+      if (!hostHasLayoutSize(input.root)) {
+        return;
+      }
       try {
-        disposeWebglRenderer();
         webglAddon = new WebglAddon();
         webglAddon.onContextLoss(() => {
           disposeWebglRenderer();
@@ -345,6 +383,12 @@ export class TerminalEmulatorRuntime {
       } catch {
         disposeWebglRenderer();
       }
+    };
+    this.restoreWebglRenderer = tryLoadWebglRenderer;
+
+    let webglAddonRaf: number | null = requestAnimationFrame(() => {
+      webglAddonRaf = null;
+      tryLoadWebglRenderer();
     });
 
     const restoreDocumentStyles = this.applyDocumentBoundsStyles({
@@ -368,8 +412,15 @@ export class TerminalEmulatorRuntime {
         return;
       }
 
-      if (input.root.offsetWidth === 0 || input.root.offsetHeight === 0) {
+      if (!hostHasLayoutSize(input.root)) {
+        this.hostCollapsed = true;
         return;
+      }
+
+      const restoringCollapsedHost = this.hostCollapsed;
+      if (restoringCollapsedHost) {
+        this.hostCollapsed = false;
+        this.restoreWebglRenderer?.();
       }
 
       try {
@@ -380,13 +431,13 @@ export class TerminalEmulatorRuntime {
 
       const nextRows = currentTerminal.rows;
       const nextCols = currentTerminal.cols;
-      const previous = this.lastSize;
       if (
-        !forceRefresh &&
-        !forceClaim &&
-        previous &&
-        previous.rows === nextRows &&
-        previous.cols === nextCols
+        shouldSkipUnchangedFit({
+          shouldRefresh: forceRefresh || restoringCollapsedHost || forceClaim,
+          previous: this.lastSize,
+          nextRows,
+          nextCols,
+        })
       ) {
         return;
       }
@@ -799,6 +850,8 @@ export class TerminalEmulatorRuntime {
     this.fitAddon = null;
     this.fitAndEmitResize = null;
     this.lastSize = null;
+    this.hostCollapsed = false;
+    this.restoreWebglRenderer = null;
     this.themeBackgroundElements = [];
     this.suppressInput = false;
     this.inputModeDecoder.decode();


### PR DESCRIPTION
### Linked issue

Closes #3434

### Type of change

- [x] Bug fix
- [ ] New feature (with prior issue + design alignment)
- [ ] Refactor / code improvement
- [ ] Docs

### What does this PR do

Hangul (and other CJK wide characters) paint correctly on first show, then gain an extra trailing cell after switching away from the terminal pane and back.

Retained workspace/split panels hide with `display: none`. That does **not** change `document.visibilityState`, so the existing visibilitychange/window-focus refit never ran. Coming back, `FitAddon.fit()` often kept the same cols/rows and skipped `refresh()`, while Chromium may also have dropped the WebGL context. Buffer width stays 2 cells; the glyph is redrawn at ~1 cell.

This change:

- treats a host that grew from 0×0 as a surface restore (force refresh + reload WebGL if it was lost)
- exposes `restoreSurface()` and calls it when the terminal pane becomes active again
- keeps the document-visibility path, now going through the same restore

Not the same as #2193 / #2319 (capture text inserting spaces) or #2973 (native grid column width).

### How did you verify it

- `npx vitest run packages/app/src/terminal/runtime/terminal-emulator-runtime.test.ts --bail=1` — 20 passed, including `restoreSurface` and the existing visibility-restore cases
- lint / format / typecheck on touched files — pass
- Did **not** re-run the desktop app click-through (Hangul → switch tab → switch back) in this pass

### Checklist

- [x] One focused change. Unrelated cleanups split out.
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` ran
- [ ] UI changes include screenshots or video for every affected platform (desktop terminal; no new screenshot this pass)
- [x] Tests added or updated where it made sense