### PR TITLE
feat: import sessions from linked worktrees

### DIFF
--- a/packages/app/src/components/import-session-sheet-view-model.test.ts
+++ b/packages/app/src/components/import-session-sheet-view-model.test.ts
@@ -77,6 +77,8 @@ describe("requiresImportSessionsHostUpgrade", () => {
       requiresImportSessionsHostUpgrade({
         supportsSnapshot: true,
         workspaceId: null,
+        usesLinkedWorktreeScope: false,
+        supportsLinkedWorktrees: false,
         supportsWorkspaceTarget: false,
       }),
     ).toBe(false);
@@ -87,6 +89,8 @@ describe("requiresImportSessionsHostUpgrade", () => {
       requiresImportSessionsHostUpgrade({
         supportsSnapshot: true,
         workspaceId: "ws-current",
+        usesLinkedWorktreeScope: false,
+        supportsLinkedWorktrees: false,
         supportsWorkspaceTarget: false,
       }),
     ).toBe(true);
@@ -94,6 +98,29 @@ describe("requiresImportSessionsHostUpgrade", () => {
       requiresImportSessionsHostUpgrade({
         supportsSnapshot: true,
         workspaceId: "ws-current",
+        usesLinkedWorktreeScope: false,
+        supportsLinkedWorktrees: false,
+        supportsWorkspaceTarget: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires host support when a cwd import scans linked worktrees", () => {
+    expect(
+      requiresImportSessionsHostUpgrade({
+        supportsSnapshot: true,
+        workspaceId: null,
+        usesLinkedWorktreeScope: true,
+        supportsLinkedWorktrees: false,
+        supportsWorkspaceTarget: true,
+      }),
+    ).toBe(true);
+    expect(
+      requiresImportSessionsHostUpgrade({
+        supportsSnapshot: true,
+        workspaceId: null,
+        usesLinkedWorktreeScope: true,
+        supportsLinkedWorktrees: true,
         supportsWorkspaceTarget: true,
       }),
     ).toBe(false);

--- a/packages/app/src/components/import-session-sheet-view-model.ts
+++ b/packages/app/src/components/import-session-sheet-view-model.ts
@@ -8,9 +8,15 @@ export const ALL_FILTER_VALUE = "__all__";
 export function requiresImportSessionsHostUpgrade(input: {
   supportsSnapshot: boolean;
   workspaceId?: string | null;
+  usesLinkedWorktreeScope: boolean;
+  supportsLinkedWorktrees: boolean;
   supportsWorkspaceTarget: boolean;
 }): boolean {
-  return !input.supportsSnapshot || (Boolean(input.workspaceId) && !input.supportsWorkspaceTarget);
+  return (
+    !input.supportsSnapshot ||
+    (Boolean(input.workspaceId) && !input.supportsWorkspaceTarget) ||
+    (input.usesLinkedWorktreeScope && !input.supportsLinkedWorktrees)
+  );
 }
 
 export interface SessionsQueryResult {

--- a/packages/app/src/components/import-session-sheet.test.tsx
+++ b/packages/app/src/components/import-session-sheet.test.tsx
@@ -163,12 +163,17 @@ vi.mock("@/hooks/use-providers-snapshot", () => ({
   }),
 }));
 
+vi.mock("@/runtime/host-features", () => ({
+  useHostFeature: () => true,
+}));
+
 interface RenderOptions {
   visible?: boolean;
   onClose?: () => void;
   onImportedAgent?: (agentId: string) => void;
   onImported?: (agent: Awaited<ReturnType<DaemonClient["importAgent"]>>) => void;
   cwd?: string | null;
+  workspaceId?: string | null;
   snapshot?: {
     entries?: ProviderSnapshotEntry[];
     supportsSnapshot?: boolean;
@@ -192,6 +197,12 @@ function renderSheet(
   });
 
   const cwd = options && "cwd" in options ? (options.cwd ?? undefined) : "/repo/paseo";
+  let workspaceId: string | undefined;
+  if (options && "workspaceId" in options) {
+    workspaceId = options.workspaceId ?? undefined;
+  } else if (cwd) {
+    workspaceId = "workspace-paseo";
+  }
 
   return render(
     <QueryClientProvider client={queryClient}>
@@ -200,6 +211,7 @@ function renderSheet(
         client={client}
         serverId="server-1"
         cwd={cwd}
+        workspaceId={workspaceId}
         onClose={options?.onClose ?? vi.fn()}
         onImportedAgent={options?.onImportedAgent ?? vi.fn()}
         onImported={options?.onImported}
@@ -451,6 +463,7 @@ describe("ImportSessionSheet", () => {
             client={client}
             serverId="server-1"
             cwd="/repo/paseo"
+            workspaceId="workspace-paseo"
             onClose={vi.fn()}
             onImportedAgent={vi.fn()}
           />
@@ -511,6 +524,7 @@ describe("ImportSessionSheet", () => {
         providerId: "claude",
         providerHandleId: "provider-thread-1",
         cwd: "/repo/paseo-realpath",
+        workspaceId: "workspace-paseo",
       });
     });
     expect(onImportedAgent).toHaveBeenCalledWith("agent-imported");
@@ -547,6 +561,7 @@ describe("ImportSessionSheet", () => {
       providerId: "claude",
       providerHandleId: "provider-thread-1",
       cwd: "/repo/paseo",
+      workspaceId: "workspace-paseo",
     });
     expect(onImportedAgent).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
@@ -838,6 +853,47 @@ describe("ImportSessionSheet", () => {
     expect(onImported).toHaveBeenCalledWith(expect.objectContaining({ id: "agent-imported" }));
     expect(onImportedAgent).toHaveBeenCalledWith("agent-imported");
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists linked-worktree sessions for an unbound cwd and resumes one in its original cwd", async () => {
+    const linkedCwd = "/home/me/worktrees/paseo-feature";
+    const fetchRecentProviderSessions = vi.fn(async () => ({
+      requestId: "recent-provider-sessions",
+      entries: [
+        createProviderSessionEntry({
+          providerId: "claude",
+          providerLabel: "Claude Code",
+          cwd: linkedCwd,
+        }),
+      ],
+    }));
+    const importAgent = vi.fn(async () => createImportedAgentSnapshot("agent-imported"));
+
+    renderSheet(createRecentSessionsClient(fetchRecentProviderSessions, importAgent), {
+      cwd: "/home/me/paseo",
+      workspaceId: null,
+      snapshot: { supportsSnapshot: true, entries: [createSnapshotEntry("claude")] },
+    });
+
+    await waitFor(() => {
+      expect(fetchRecentProviderSessions).toHaveBeenCalledWith({
+        cwd: "/home/me/paseo",
+        includeLinkedWorktrees: true,
+        providers: ["claude"],
+        limit: 15,
+      });
+    });
+    await screen.findByText(linkedCwd);
+    fireEvent.click(await screen.findByTestId("import-session-session-claude-provider-thread-1"));
+
+    await waitFor(() => {
+      expect(importAgent).toHaveBeenCalledWith({
+        providerId: "claude",
+        providerHandleId: "provider-thread-1",
+        cwd: linkedCwd,
+        sourceCwd: "/home/me/paseo",
+      });
+    });
   });
 
   it("refetches sessions when the refresh button is clicked", async () => {

--- a/packages/app/src/components/import-session-sheet.tsx
+++ b/packages/app/src/components/import-session-sheet.tsx
@@ -62,16 +62,33 @@ interface SessionsQueryConfig {
   queryFn: () => Promise<RecentSessionsResponse>;
 }
 
+function getSessionsRequestScope(
+  cwd: string | null | undefined,
+  workspaceId: string | null | undefined,
+): { cwd?: string; includeLinkedWorktrees?: boolean } {
+  if (cwd && !workspaceId) return { cwd, includeLinkedWorktrees: true };
+  if (cwd) return { cwd };
+  return {};
+}
+
 function buildSessionsQueriesConfig(args: {
   providersToFetch: AgentProvider[] | null;
   sessionsQueryRoot: ReadonlyArray<string | null>;
   visible: boolean;
   client: RecentProviderSessionsClient | null;
   cwd: string | null | undefined;
+  workspaceId: string | null | undefined;
   hostDisconnectedMessage?: string;
 }): SessionsQueryConfig[] {
-  const { providersToFetch, sessionsQueryRoot, visible, client, cwd, hostDisconnectedMessage } =
-    args;
+  const {
+    providersToFetch,
+    sessionsQueryRoot,
+    visible,
+    client,
+    cwd,
+    workspaceId,
+    hostDisconnectedMessage,
+  } = args;
   if (providersToFetch === null) return [];
   const enabled = visible && Boolean(client);
   return providersToFetch.map((provider) => ({
@@ -82,7 +99,7 @@ function buildSessionsQueriesConfig(args: {
         throw new Error(hostDisconnectedMessage ?? i18n.t("workspace.terminal.hostDisconnected"));
       }
       return await client.fetchRecentProviderSessions({
-        ...(cwd ? { cwd } : {}),
+        ...getSessionsRequestScope(cwd, workspaceId),
         providers: [provider],
         limit: PER_PROVIDER_LIMIT,
       });
@@ -277,9 +294,13 @@ export function ImportSessionSheet({
     enabled: visible,
   });
   const supportsWorkspaceTarget = useHostFeature(serverId, "importSessionWorkspaceTarget");
+  const supportsLinkedWorktrees = useHostFeature(serverId, "importSessionLinkedWorktrees");
+  const usesLinkedWorktreeScope = Boolean(cwd && !workspaceId);
   const requiresHostUpgrade = requiresImportSessionsHostUpgrade({
     supportsSnapshot,
     workspaceId,
+    usesLinkedWorktreeScope,
+    supportsLinkedWorktrees,
     supportsWorkspaceTarget,
   });
 
@@ -294,8 +315,8 @@ export function ImportSessionSheet({
   );
 
   const sessionsQueryRoot = useMemo(
-    () => ["recent-provider-sessions", cwd ?? null] as const,
-    [cwd],
+    () => ["recent-provider-sessions", serverId, workspaceId ?? null, cwd ?? null] as const,
+    [cwd, serverId, workspaceId],
   );
 
   const queriesConfig = useMemo(
@@ -306,9 +327,10 @@ export function ImportSessionSheet({
         visible,
         client,
         cwd,
+        workspaceId,
         hostDisconnectedMessage: t("workspace.terminal.hostDisconnected"),
       }),
-    [providersToFetch, sessionsQueryRoot, visible, client, cwd, t],
+    [providersToFetch, sessionsQueryRoot, visible, client, cwd, workspaceId, t],
   );
 
   const queries = useQueries({ queries: queriesConfig });
@@ -419,6 +441,7 @@ export function ImportSessionSheet({
         providerHandleId: entry.providerHandleId,
         cwd: entry.cwd,
         ...(workspaceId ? { workspaceId } : {}),
+        ...(usesLinkedWorktreeScope && cwd ? { sourceCwd: cwd } : {}),
       });
       return agent;
     },
@@ -548,7 +571,7 @@ export function ImportSessionSheet({
               entry={entry}
               disabled={importMutation.isPending}
               importing={importingSessionKey === `${entry.providerId}:${entry.providerHandleId}`}
-              showCwd={!cwd}
+              showCwd={!workspaceId}
               onImportSession={handleImportSession}
             />
           ))}

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -4464,6 +4464,135 @@ test("fetches scoped recent provider sessions", async () => {
   });
 });
 
+test("fetches and imports linked-worktree sessions when the host supports it", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen({ features: { importSessionLinkedWorktrees: true } });
+  await connectPromise;
+
+  const listPromise = client.fetchRecentProviderSessions({
+    cwd: "/tmp/main-worktree",
+    includeLinkedWorktrees: true,
+    providers: ["codex"],
+  });
+  const listRequest = JSON.parse(String(mock.sent.at(-1))) as {
+    message: { requestId: string; includeLinkedWorktrees?: boolean; cwd?: string };
+  };
+  expect(listRequest.message).toMatchObject({
+    cwd: "/tmp/main-worktree",
+    includeLinkedWorktrees: true,
+  });
+  mock.triggerMessage(
+    JSON.stringify({
+      type: "session",
+      message: {
+        type: "fetch_recent_provider_sessions_response",
+        payload: { requestId: listRequest.message.requestId, entries: [] },
+      },
+    }),
+  );
+  await expect(listPromise).resolves.toMatchObject({ entries: [] });
+
+  const importPromise = client.importAgent({
+    providerId: "codex",
+    providerHandleId: "thread-1",
+    cwd: "/tmp/linked-worktree",
+    sourceCwd: "/tmp/main-worktree",
+  });
+  const importRequest = JSON.parse(String(mock.sent.at(-1))) as {
+    message: { requestId: string; sourceCwd?: string; cwd?: string };
+  };
+  expect(importRequest.message).toMatchObject({
+    cwd: "/tmp/linked-worktree",
+    sourceCwd: "/tmp/main-worktree",
+  });
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "status",
+      payload: {
+        status: "agent_resumed",
+        requestId: importRequest.message.requestId,
+        agentId: "agent-project",
+        timelineSize: 0,
+        agent: {
+          id: "agent-project",
+          provider: "codex",
+          cwd: "/tmp/linked-worktree",
+          model: null,
+          features: [],
+          thinkingOptionId: null,
+          effectiveThinkingOptionId: null,
+          createdAt: "2026-04-30T00:00:00.000Z",
+          updatedAt: "2026-04-30T00:00:00.000Z",
+          lastUserMessageAt: null,
+          status: "idle",
+          capabilities: {
+            supportsStreaming: false,
+            supportsSessionPersistence: false,
+            supportsDynamicModes: false,
+            supportsMcpServers: false,
+            supportsReasoningStream: false,
+            supportsToolInvocations: false,
+          },
+          currentModeId: null,
+          availableModes: [],
+          pendingPermissions: [],
+          persistence: { provider: "codex", sessionId: "thread-1" },
+          title: null,
+          labels: {},
+          workspaceId: "workspace-project",
+          requiresAttention: false,
+          attentionReason: null,
+        },
+      },
+    }),
+  );
+  await expect(importPromise).resolves.toMatchObject({ id: "agent-project" });
+});
+
+test("rejects linked-worktree session requests on older hosts", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  await expect(
+    client.fetchRecentProviderSessions({
+      cwd: "/tmp/main-worktree",
+      includeLinkedWorktrees: true,
+    }),
+  ).rejects.toThrow("Update the host to import sessions from linked worktrees.");
+  await expect(
+    client.importAgent({
+      providerId: "codex",
+      providerHandleId: "thread-1",
+      cwd: "/tmp/linked-worktree",
+      sourceCwd: "/tmp/main-worktree",
+    }),
+  ).rejects.toThrow("Update the host to import sessions from linked worktrees.");
+  expect(mock.sent).toHaveLength(0);
+});
+
 test("imports an agent by provider handle id", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -177,6 +177,7 @@ const PROJECT_GITHUB_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
 interface ImportAgentInputBase {
   cwd?: string;
   workspaceId?: string;
+  sourceCwd?: string;
   labels?: Record<string, string>;
 }
 
@@ -2061,11 +2062,15 @@ export class DaemonClient {
   async fetchRecentProviderSessions(
     options?: FetchRecentProviderSessionsOptions,
   ): Promise<FetchRecentProviderSessionsPayload> {
+    this.assertImportSessionLinkedWorktreesSupported(options?.includeLinkedWorktrees === true);
     const resolvedRequestId = this.createRequestId(options?.requestId);
     const message = SessionInboundMessageSchema.parse({
       type: "fetch_recent_provider_sessions_request",
       requestId: resolvedRequestId,
       ...(options?.cwd ? { cwd: options.cwd } : {}),
+      ...(options?.includeLinkedWorktrees !== undefined
+        ? { includeLinkedWorktrees: options.includeLinkedWorktrees }
+        : {}),
       ...(options?.providers ? { providers: options.providers } : {}),
       ...(options?.since ? { since: options.since } : {}),
       ...(options?.limit ? { limit: options.limit } : {}),
@@ -2677,6 +2682,7 @@ export class DaemonClient {
   }
 
   async importAgent(input: ImportAgentInput): Promise<AgentSnapshotPayload> {
+    this.assertImportSessionLinkedWorktreesSupported(input.sourceCwd !== undefined);
     const requestId = this.createRequestId();
     const message = SessionInboundMessageSchema.parse({
       type: "import_agent_request",
@@ -2686,6 +2692,7 @@ export class DaemonClient {
         : { provider: input.provider, sessionId: input.sessionId }),
       ...(input.cwd ? { cwd: input.cwd } : {}),
       ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+      ...(input.sourceCwd !== undefined ? { sourceCwd: input.sourceCwd } : {}),
       ...(input.labels && Object.keys(input.labels).length > 0 ? { labels: input.labels } : {}),
     });
 
@@ -2716,6 +2723,12 @@ export class DaemonClient {
     }
 
     return status.agent;
+  }
+
+  private assertImportSessionLinkedWorktreesSupported(requested: boolean): void {
+    if (requested && this.lastServerInfoMessage?.features?.importSessionLinkedWorktrees !== true) {
+      throw new Error("Update the host to import sessions from linked worktrees.");
+    }
   }
 
   async refreshAgent(agentId: string, requestId?: string): Promise<AgentRefreshedStatusPayload> {

--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -344,6 +344,34 @@ describe("agent detach RPC", () => {
     }
     expect(parsed.features?.importSessionWorkspaceTarget).toBe(true);
   });
+
+  test("parses linked-worktree session import messages and feature gate", () => {
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "fetch_recent_provider_sessions_request",
+        requestId: "list-linked-sessions",
+        cwd: "/tmp/main",
+        includeLinkedWorktrees: true,
+      }),
+    ).toMatchObject({ cwd: "/tmp/main", includeLinkedWorktrees: true });
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "import_agent_request",
+        requestId: "import-linked-session",
+        providerId: "codex",
+        providerHandleId: "thread-1",
+        cwd: "/tmp/worktree",
+        sourceCwd: "/tmp/main",
+      }),
+    ).toMatchObject({ sourceCwd: "/tmp/main" });
+
+    const parsed = parseServerInfoStatusPayload({
+      status: "server_info",
+      serverId: "srv-test",
+      features: { importSessionLinkedWorktrees: true },
+    });
+    expect(parsed?.features?.importSessionLinkedWorktrees).toBe(true);
+  });
 });
 
 describe("agent setting action responses", () => {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1281,6 +1281,8 @@ export const FetchRecentProviderSessionsRequestMessageSchema = z.object({
   type: z.literal("fetch_recent_provider_sessions_request"),
   requestId: z.string(),
   cwd: z.string().optional(),
+  // COMPAT(importSessionLinkedWorktrees): added in v0.4.1, remove optional after 2027-02-17.
+  includeLinkedWorktrees: z.boolean().optional(),
   providers: z.array(z.string()).optional(),
   since: z.string().optional(),
   limit: z.number().int().positive().max(200).optional(),
@@ -1564,6 +1566,8 @@ export const ImportAgentRequestMessageSchema = z.object({
   providerHandleId: z.string().optional(),
   cwd: z.string().optional(),
   workspaceId: z.string().optional(),
+  // COMPAT(importSessionLinkedWorktrees): added in v0.4.1, remove optional after 2027-02-17.
+  sourceCwd: z.string().min(1).optional(),
   labels: z.record(z.string(), z.string()).optional(),
   requestId: z.string(),
 });
@@ -3267,6 +3271,8 @@ export const ServerInfoStatusPayloadSchema = z
         providerRemoval: z.boolean().optional(),
         // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
         importSessionWorkspaceTarget: z.boolean().optional(),
+        // COMPAT(importSessionLinkedWorktrees): added in v0.4.1, remove gate after 2027-02-17.
+        importSessionLinkedWorktrees: z.boolean().optional(),
         // COMPAT(forgeProviders): added in v0.1.106, drop the gate when daemon floor >= v0.1.106.
         // Daemon advertises pluggable non-GitHub forge support (the forge registry);
         // the client gates non-GitHub setup UI on it.

--- a/packages/server/src/server/agent/import-sessions.test.ts
+++ b/packages/server/src/server/agent/import-sessions.test.ts
@@ -470,6 +470,80 @@ test("listImportableProviderSessions keeps realpath-equivalent cwd matches", asy
   expect(result.entries.map((entry) => entry.providerHandleId)).toEqual(["pi-handle"]);
 });
 
+test("listImportableProviderSessions scans every linked worktree for a cwd scope", async () => {
+  const mainCwd = "/tmp/project-main";
+  const linkedCwd = "/tmp/project-linked";
+  const listImportableSessions = vi.fn(async ({ cwd }: { cwd?: string }) => {
+    if (cwd === mainCwd) {
+      return [
+        makeImportableSession({
+          sessionId: "main-session",
+          cwd: mainCwd,
+          lastActivityAt: "2026-04-30T12:00:00.000Z",
+        }),
+      ];
+    }
+    return [
+      makeImportableSession({
+        sessionId: "linked-session",
+        cwd: linkedCwd,
+        lastActivityAt: "2026-04-30T12:01:00.000Z",
+      }),
+      makeImportableSession({
+        sessionId: "outside-session",
+        cwd: "/tmp/other-project",
+        lastActivityAt: "2026-04-30T12:02:00.000Z",
+      }),
+    ];
+  });
+  const exactCwds = [mainCwd, linkedCwd];
+
+  const result = await listImportableProviderSessions({
+    request: makeRequest({
+      cwd: mainCwd,
+      includeLinkedWorktrees: true,
+      providers: ["codex"],
+    }),
+    agentManager: { listAgents: () => [], listImportableSessions },
+    agentStorage: { list: async () => [] },
+    providerSnapshotManager: { getProviderLabel: () => "Codex" },
+    importSessionCwdScopeResolver: {
+      resolve: async () => ({
+        sourceCwd: mainCwd,
+        exactCwds,
+        matchesCwd: async (candidate) => exactCwds.includes(candidate),
+      }),
+    },
+  });
+
+  expect(listImportableSessions).toHaveBeenCalledTimes(2);
+  expect(listImportableSessions).toHaveBeenCalledWith({
+    cwd: mainCwd,
+    limit: 20,
+    providerFilter: new Set(["codex"]),
+  });
+  expect(listImportableSessions).toHaveBeenCalledWith({
+    cwd: linkedCwd,
+    limit: 20,
+    providerFilter: new Set(["codex"]),
+  });
+  expect(result.entries.map((entry) => entry.providerHandleId)).toEqual([
+    "linked-session",
+    "main-session",
+  ]);
+});
+
+test("listImportableProviderSessions rejects linked-worktree scope without a cwd", async () => {
+  await expect(
+    listImportableProviderSessions({
+      request: makeRequest({ includeLinkedWorktrees: true }),
+      agentManager: { listAgents: () => [], listImportableSessions: async () => [] },
+      agentStorage: { list: async () => [] },
+      providerSnapshotManager: { getProviderLabel: () => "" },
+    }),
+  ).rejects.toMatchObject({ code: "invalid_scope" });
+});
+
 test("listImportableProviderSessions rejects invalid since values", async () => {
   await expect(
     listImportableProviderSessions({
@@ -514,6 +588,29 @@ test("normalizeImportAgentRequest accepts new and legacy import handle shapes", 
     provider: "codex",
     providerHandleId: "thread-2",
   });
+});
+
+test("normalizeImportAgentRequest preserves a source cwd and rejects ambiguous placement", () => {
+  expect(
+    normalizeImportAgentRequest({
+      type: "import_agent_request",
+      requestId: "linked-worktree-shape",
+      providerId: "codex",
+      providerHandleId: "thread-1",
+      sourceCwd: "/tmp/main-worktree",
+    }),
+  ).toMatchObject({ sourceCwd: "/tmp/main-worktree" });
+
+  expect(
+    normalizeImportAgentRequest({
+      type: "import_agent_request",
+      requestId: "ambiguous-shape",
+      providerId: "codex",
+      providerHandleId: "thread-1",
+      workspaceId: "workspace-1",
+      sourceCwd: "/tmp/main-worktree",
+    }),
+  ).toEqual({ error: "Import cannot target both a workspace and a source directory" });
 });
 
 function makeStoredProviderSession(input: {

--- a/packages/server/src/server/agent/import-sessions.ts
+++ b/packages/server/src/server/agent/import-sessions.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import type { Logger } from "pino";
+import pLimit from "p-limit";
 import type { ProviderSnapshotManager } from "./provider-snapshot-manager.js";
 import type {
   AgentManager,
@@ -20,11 +21,17 @@ import type {
 } from "@getpaseo/protocol/messages";
 import { getParentAgentIdFromLabels, PARENT_AGENT_ID_LABEL } from "@getpaseo/protocol/agent-labels";
 import { createRealpathAwarePathMatcher } from "../../utils/path.js";
+import type {
+  ImportSessionCwdScope,
+  ImportSessionCwdScopeResolver,
+} from "../import-session-cwd-scope.js";
 
 type ImportAgentRequestMessage = z.infer<typeof ImportAgentRequestMessageSchema>;
 
 const METADATA_GENERATION_PROMPT_PREFIX =
   "Generate metadata for a coding agent based on the user prompt.";
+const IMPORT_SESSION_CWD_FANOUT_CONCURRENCY = 4;
+const importSessionCwdFanoutLimits = new WeakMap<object, ReturnType<typeof pLimit>>();
 export type ImportSessionAgentManager = AgentLoaderManager &
   Pick<
     AgentManager,
@@ -46,6 +53,7 @@ export interface NormalizedImportAgentRequest {
   providerHandleId: string;
   cwd?: string;
   workspaceId?: string;
+  sourceCwd?: string;
   labels?: Record<string, string>;
   requestId: string;
 }
@@ -65,6 +73,7 @@ export interface ListImportableProviderSessionsInput {
   agentManager: Pick<AgentManager, "listAgents" | "listImportableSessions">;
   agentStorage: Pick<AgentStorage, "list">;
   providerSnapshotManager: Pick<ProviderSnapshotManager, "getProviderLabel">;
+  importSessionCwdScopeResolver?: ImportSessionCwdScopeResolver;
 }
 
 export interface ListImportableProviderSessionsResult {
@@ -104,11 +113,15 @@ export function normalizeImportAgentRequest(
   if (!provider || !providerHandleId) {
     return { error: "Import requires providerId and providerHandleId" };
   }
+  if (msg.workspaceId !== undefined && msg.sourceCwd !== undefined) {
+    return { error: "Import cannot target both a workspace and a source directory" };
+  }
   return {
     provider: provider as AgentProvider,
     providerHandleId,
     cwd: msg.cwd,
     workspaceId: msg.workspaceId,
+    sourceCwd: msg.sourceCwd,
     labels: msg.labels,
     requestId: msg.requestId,
   };
@@ -118,6 +131,19 @@ export async function listImportableProviderSessions(
   input: ListImportableProviderSessionsInput,
 ): Promise<ListImportableProviderSessionsResult> {
   const { request, agentManager, agentStorage, providerSnapshotManager } = input;
+  const requestCwd = request.cwd;
+  if (request.includeLinkedWorktrees && requestCwd === undefined) {
+    throw new ImportSessionsRequestError(
+      "invalid_scope",
+      "Linked-worktree provider session import requires a cwd",
+    );
+  }
+  const cwdScope =
+    request.includeLinkedWorktrees && requestCwd !== undefined
+      ? await requireImportSessionCwdScopeResolver(input).resolve(requestCwd, {
+          reason: "list-provider-sessions",
+        })
+      : null;
   const limit = request.limit ?? 20;
   const sinceTimestamp = parseRecentProviderSessionsSince(request.since);
   const providerFilter = request.providers ? new Set(request.providers) : undefined;
@@ -128,16 +154,28 @@ export async function listImportableProviderSessions(
   );
   const importedHandles = importedSessions.handles;
 
-  const sessions = await agentManager.listImportableSessions({
-    limit: limit + importedSessions.count,
-    providerFilter,
-    cwd: request.cwd,
-  });
+  const sessions = cwdScope
+    ? await listImportableSessionsForCwdScope({
+        cwdScope,
+        agentManager,
+        limit: limit + importedSessions.count,
+        providerFilter,
+      })
+    : await agentManager.listImportableSessions({
+        limit: limit + importedSessions.count,
+        providerFilter,
+        cwd: requestCwd,
+      });
   let filteredAlreadyImportedCount = 0;
   const candidates: ManagedImportableProviderSession[] = [];
-  const matchesRequestCwd = request.cwd ? createRealpathAwarePathMatcher(request.cwd) : null;
+  let matchesRequestCwd: ((candidate: string) => boolean | Promise<boolean>) | null = null;
+  if (cwdScope) {
+    matchesRequestCwd = (candidate) => cwdScope.matchesCwd(candidate);
+  } else if (requestCwd) {
+    matchesRequestCwd = createRealpathAwarePathMatcher(requestCwd);
+  }
   for (const session of sessions) {
-    if (matchesRequestCwd && !matchesRequestCwd(session.cwd)) {
+    if (matchesRequestCwd && !(await matchesRequestCwd(session.cwd))) {
       continue;
     }
     if (sinceTimestamp !== null && session.lastActivityAt.getTime() < sinceTimestamp) {
@@ -177,7 +215,11 @@ export async function importProviderSession(
   const key = await resolveProviderSessionImportMutationKey(input);
   return serializeProviderSessionImport(input.agentManager, key, async () => {
     const placement = await input.workspaceProvisioning.runInImportWorkspace(
-      { cwd, requestedWorkspaceId: input.request.workspaceId },
+      {
+        cwd,
+        requestedWorkspaceId: input.request.workspaceId,
+        requestedSourceCwd: input.request.sourceCwd,
+      },
       (workspace) => importProviderSessionNow(input, cwd, workspace.workspaceId),
     );
     return { ...placement.value, createdWorkspace: placement.createdWorkspace };
@@ -312,6 +354,61 @@ async function rollbackArchivedImport(
       "Failed to restore archived agent record after import failure",
     );
   }
+}
+
+function requireImportSessionCwdScopeResolver(
+  input: ListImportableProviderSessionsInput,
+): ImportSessionCwdScopeResolver {
+  if (!input.importSessionCwdScopeResolver) {
+    throw new ImportSessionsRequestError(
+      "linked_worktree_scope_unavailable",
+      "Linked-worktree provider session import is unavailable",
+    );
+  }
+  return input.importSessionCwdScopeResolver;
+}
+
+async function listImportableSessionsForCwdScope(input: {
+  cwdScope: ImportSessionCwdScope;
+  agentManager: Pick<AgentManager, "listImportableSessions">;
+  limit: number;
+  providerFilter: Set<string> | undefined;
+}): Promise<ManagedImportableProviderSession[]> {
+  const limit = getImportSessionCwdFanoutLimit(input.agentManager);
+  const lists = await Promise.all(
+    input.cwdScope.exactCwds.map((cwd) =>
+      limit(() =>
+        input.agentManager.listImportableSessions({
+          limit: input.limit,
+          providerFilter: input.providerFilter,
+          cwd,
+        }),
+      ),
+    ),
+  );
+
+  const sessionsByHandle = new Map<string, ManagedImportableProviderSession>();
+  for (const session of lists.flat()) {
+    // A provider can treat cwd as a hint. Filter before deduplication so an
+    // out-of-scope descriptor cannot displace the valid scoped descriptor.
+    if (!(await input.cwdScope.matchesCwd(session.cwd))) continue;
+    const key = toProviderSessionHandleKey(session.provider, session.providerHandleId);
+    const previous = sessionsByHandle.get(key);
+    if (!previous || previous.lastActivityAt.getTime() < session.lastActivityAt.getTime()) {
+      sessionsByHandle.set(key, session);
+    }
+  }
+  return Array.from(sessionsByHandle.values()).sort(
+    (left, right) => right.lastActivityAt.getTime() - left.lastActivityAt.getTime(),
+  );
+}
+
+function getImportSessionCwdFanoutLimit(agentManager: object): ReturnType<typeof pLimit> {
+  const existing = importSessionCwdFanoutLimits.get(agentManager);
+  if (existing) return existing;
+  const created = pLimit({ concurrency: IMPORT_SESSION_CWD_FANOUT_CONCURRENCY });
+  importSessionCwdFanoutLimits.set(agentManager, created);
+  return created;
 }
 
 function parseRecentProviderSessionsSince(since: string | undefined): number | null {

--- a/packages/server/src/server/import-session-cwd-scope.posix.test.ts
+++ b/packages/server/src/server/import-session-cwd-scope.posix.test.ts
@@ -1,0 +1,183 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createTestLogger } from "../test-utils/test-logger.js";
+import { normalizePathForIdentity } from "../utils/path.js";
+import {
+  createImportSessionCwdScopeResolver,
+  ImportSessionCwdScopeError,
+} from "./import-session-cwd-scope.js";
+import { WorkspaceGitServiceImpl } from "./workspace-git-service.js";
+
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+describePosix("import session cwd scope", () => {
+  let tempRoot: string;
+  let gitService: WorkspaceGitServiceImpl;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "import-session-cwd-scope-"));
+    gitService = new WorkspaceGitServiceImpl({
+      logger: createTestLogger(),
+      paseoHome: join(tempRoot, "paseo-home"),
+    });
+  });
+
+  afterEach(() => {
+    gitService.dispose();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  test("maps an exact selected subdirectory across arbitrary linked worktree names", async () => {
+    const repo = createRepository(join(tempRoot, "main", "lpu-monorepo"));
+    const selectedRoot = join(repo, "packages", "compiler");
+    const codexWorktree = join(tempRoot, ".codex", "worktrees", "a227", "unexpected-name");
+    const paseoWorktree = join(tempRoot, ".paseo", "worktrees", "hash", "military-elephant");
+    addWorktree(repo, codexWorktree, "codex-feature");
+    addWorktree(repo, paseoWorktree, "paseo-feature");
+    const independentClone = join(tempRoot, "independent", "lpu-monorepo");
+    git(["clone", repo, independentClone], tempRoot);
+
+    const scope = await createResolver(gitService).resolve(selectedRoot);
+
+    expect(scope.sourceCwd).toBe(selectedRoot);
+    await expect(scope.matchesCwd(selectedRoot)).resolves.toBe(true);
+    await expect(scope.matchesCwd(join(codexWorktree, "packages", "compiler"))).resolves.toBe(true);
+    await expect(scope.matchesCwd(join(paseoWorktree, "packages", "compiler"))).resolves.toBe(true);
+    await expect(scope.matchesCwd(repo)).resolves.toBe(false);
+    await expect(scope.matchesCwd(join(selectedRoot, "src"))).resolves.toBe(false);
+    await expect(scope.matchesCwd(join(independentClone, "packages", "compiler"))).resolves.toBe(
+      false,
+    );
+    expect(scope.exactCwds).toHaveLength(3);
+  });
+
+  test("excludes missing, nested-repository, and symlinked-independent mapped directories", async () => {
+    const repo = createRepository(join(tempRoot, "repo"));
+    const selectedRoot = join(repo, "packages", "compiler");
+    const missingWorktree = join(tempRoot, "linked", "missing");
+    const nestedWorktree = join(tempRoot, "linked", "nested");
+    const symlinkWorktree = join(tempRoot, "linked", "symlink");
+    addWorktree(repo, missingWorktree, "missing-feature");
+    addWorktree(repo, nestedWorktree, "nested-feature");
+    addWorktree(repo, symlinkWorktree, "symlink-feature");
+
+    rmSync(join(missingWorktree, "packages", "compiler"), { recursive: true, force: true });
+
+    const nestedRoot = join(nestedWorktree, "packages", "compiler");
+    rmSync(nestedRoot, { recursive: true, force: true });
+    mkdirSync(nestedRoot, { recursive: true });
+    git(["init", "-b", "main"], nestedRoot);
+
+    const independent = createRepository(join(tempRoot, "independent"));
+    const symlinkRoot = join(symlinkWorktree, "packages", "compiler");
+    rmSync(symlinkRoot, { recursive: true, force: true });
+    symlinkSync(independent, symlinkRoot, "dir");
+
+    const scope = await createResolver(gitService).resolve(selectedRoot);
+
+    expect(scope.exactCwds.map(normalizePathForIdentity)).toEqual([
+      normalizePathForIdentity(selectedRoot),
+    ]);
+    await expect(scope.matchesCwd(join(missingWorktree, "packages", "compiler"))).resolves.toBe(
+      false,
+    );
+    await expect(scope.matchesCwd(nestedRoot)).resolves.toBe(false);
+    await expect(scope.matchesCwd(symlinkRoot)).resolves.toBe(false);
+  });
+
+  test("drops deleted prunable worktrees and refreshes the cached linked set on forced import", async () => {
+    const repo = createRepository(join(tempRoot, "repo"));
+    const selectedRoot = join(repo, "packages", "compiler");
+    const deletedWorktree = join(tempRoot, "linked", "deleted");
+    addWorktree(repo, deletedWorktree, "deleted-feature");
+    rmSync(deletedWorktree, { recursive: true, force: true });
+
+    const resolver = createResolver(gitService);
+    const initial = await resolver.resolve(selectedRoot);
+    expect(initial.exactCwds.map(normalizePathForIdentity)).toEqual([
+      normalizePathForIdentity(selectedRoot),
+    ]);
+
+    const laterWorktree = join(tempRoot, "linked", "later");
+    addWorktree(repo, laterWorktree, "later-feature");
+    const cached = await resolver.resolve(selectedRoot);
+    await expect(cached.matchesCwd(join(laterWorktree, "packages", "compiler"))).resolves.toBe(
+      false,
+    );
+
+    const fresh = await resolver.resolve(selectedRoot, {
+      force: true,
+      reason: "provider-session-import",
+    });
+    await expect(fresh.matchesCwd(join(laterWorktree, "packages", "compiler"))).resolves.toBe(true);
+  });
+
+  test("excludes a bare repository entry from the linked worktree set", async () => {
+    const seed = createRepository(join(tempRoot, "seed"));
+    const bare = join(tempRoot, "repo.git");
+    git(["clone", "--bare", seed, bare], tempRoot);
+    const linked = join(tempRoot, "linked", "checkout");
+    mkdirSync(join(linked, ".."), { recursive: true });
+    git([`--git-dir=${bare}`, "worktree", "add", linked, "main"], tempRoot);
+
+    const identities = await gitService.listLinkedWorktrees(linked);
+
+    expect(identities.map((identity) => normalizePathForIdentity(identity.worktreeRoot))).toEqual([
+      normalizePathForIdentity(linked),
+    ]);
+    expect(
+      identities.some(
+        (identity) =>
+          normalizePathForIdentity(identity.worktreeRoot) === normalizePathForIdentity(bare),
+      ),
+    ).toBe(false);
+  });
+
+  test("uses one exact root outside Git and rejects an unavailable source directory", async () => {
+    const plainRoot = join(tempRoot, "plain");
+    const aliasRoot = join(tempRoot, "plain-alias");
+    mkdirSync(plainRoot, { recursive: true });
+    symlinkSync(plainRoot, aliasRoot, "dir");
+    const resolver = createResolver(gitService);
+
+    const scope = await resolver.resolve(plainRoot);
+    await expect(scope.matchesCwd(plainRoot)).resolves.toBe(true);
+    await expect(scope.matchesCwd(aliasRoot)).resolves.toBe(true);
+    await expect(scope.matchesCwd(join(plainRoot, "child"))).resolves.toBe(false);
+    await expect(
+      resolver.resolve(join(tempRoot, "missing")),
+    ).rejects.toMatchObject<ImportSessionCwdScopeError>({
+      code: "unavailable_source_cwd",
+    });
+  });
+});
+
+function createResolver(gitService: WorkspaceGitServiceImpl) {
+  return createImportSessionCwdScopeResolver({ workspaceGitService: gitService });
+}
+
+function createRepository(repo: string): string {
+  mkdirSync(repo, { recursive: true });
+  git(["init", "-b", "main"], repo);
+  git(["config", "user.email", "test@example.com"], repo);
+  git(["config", "user.name", "Paseo Test"], repo);
+  mkdirSync(join(repo, "packages", "compiler", "src"), { recursive: true });
+  writeFileSync(join(repo, "packages", "compiler", "README.md"), "compiler\n");
+  git(["add", "."], repo);
+  git(["-c", "commit.gpgsign=false", "commit", "-m", "initial"], repo);
+  return repo;
+}
+
+function addWorktree(repo: string, worktree: string, branch: string): void {
+  mkdirSync(join(worktree, ".."), { recursive: true });
+  git(["worktree", "add", "-b", branch, worktree], repo);
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] })
+    .toString()
+    .trim();
+}

--- a/packages/server/src/server/import-session-cwd-scope.ts
+++ b/packages/server/src/server/import-session-cwd-scope.ts
@@ -1,0 +1,137 @@
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import pLimit from "p-limit";
+import {
+  createRealpathAwarePathMatcher,
+  getRealpathAwareRelativePath,
+  normalizePathForIdentity,
+} from "../utils/path.js";
+import type { WorkspaceGitReadOptions, WorkspaceGitService } from "./workspace-git-service.js";
+
+const IMPORT_SESSION_SCOPE_GIT_CONCURRENCY = 4;
+
+export class ImportSessionCwdScopeError extends Error {
+  constructor(
+    readonly code: "unavailable_source_cwd",
+    sourceCwd: string,
+  ) {
+    super(`Import source directory is unavailable: ${sourceCwd}`);
+    this.name = "ImportSessionCwdScopeError";
+  }
+}
+
+export interface ImportSessionCwdScope {
+  sourceCwd: string;
+  exactCwds: readonly string[];
+  matchesCwd(candidate: string): Promise<boolean>;
+}
+
+export interface ResolveImportSessionCwdScopeOptions {
+  force?: boolean;
+  reason?: string;
+}
+
+export interface ImportSessionCwdScopeResolver {
+  resolve(
+    sourceCwd: string,
+    options?: ResolveImportSessionCwdScopeOptions,
+  ): Promise<ImportSessionCwdScope>;
+}
+
+export function createImportSessionCwdScopeResolver(deps: {
+  workspaceGitService: Pick<WorkspaceGitService, "getGitCheckoutIdentity" | "listLinkedWorktrees">;
+}): ImportSessionCwdScopeResolver {
+  return {
+    async resolve(sourceCwd, options = {}) {
+      const sourceRoot = resolve(sourceCwd);
+      const sourceStats = await stat(sourceRoot).catch(() => null);
+      if (!sourceStats?.isDirectory()) throw unavailableSourceCwd(sourceRoot);
+
+      const readOptions = toGitReadOptions(options);
+      const selectedIdentity = await deps.workspaceGitService.getGitCheckoutIdentity(
+        sourceRoot,
+        readOptions,
+      );
+      if (!selectedIdentity) return buildScope(sourceRoot, [sourceRoot]);
+
+      const relativeSourceCwd = getRealpathAwareRelativePath(
+        selectedIdentity.worktreeRoot,
+        sourceRoot,
+      );
+      if (relativeSourceCwd === null) throw unavailableSourceCwd(sourceRoot);
+
+      const linkedWorktrees = await deps.workspaceGitService.listLinkedWorktrees(
+        sourceRoot,
+        readOptions,
+      );
+      const selectedIsLinked = linkedWorktrees.some(
+        (worktree) =>
+          createRealpathAwarePathMatcher(selectedIdentity.worktreeRoot)(worktree.worktreeRoot) &&
+          createRealpathAwarePathMatcher(selectedIdentity.commonDir)(worktree.commonDir),
+      );
+      if (!selectedIsLinked) throw unavailableSourceCwd(sourceRoot);
+
+      const limit = pLimit({ concurrency: IMPORT_SESSION_SCOPE_GIT_CONCURRENCY });
+      const mappedCwds = await Promise.all(
+        linkedWorktrees.map((worktree) =>
+          limit(async () => {
+            const mappedCwd = resolve(worktree.worktreeRoot, relativeSourceCwd);
+            const mappedStats = await stat(mappedCwd).catch(() => null);
+            if (!mappedStats?.isDirectory()) return null;
+
+            // The mapped directory can itself be a nested repository or a symlink to an
+            // independent clone. Re-read its lightweight Git identity before trusting it.
+            const mappedIdentity = await deps.workspaceGitService.getGitCheckoutIdentity(
+              mappedCwd,
+              readOptions,
+            );
+            if (!mappedIdentity) return null;
+            if (
+              !createRealpathAwarePathMatcher(worktree.worktreeRoot)(mappedIdentity.worktreeRoot)
+            ) {
+              return null;
+            }
+            if (
+              !createRealpathAwarePathMatcher(selectedIdentity.commonDir)(mappedIdentity.commonDir)
+            ) {
+              return null;
+            }
+            return mappedCwd;
+          }),
+        ),
+      );
+
+      const exactCwds = mappedCwds.filter((cwd): cwd is string => cwd !== null);
+      if (!exactCwds.some(createRealpathAwarePathMatcher(sourceRoot))) {
+        throw unavailableSourceCwd(sourceRoot);
+      }
+      return buildScope(sourceRoot, exactCwds);
+    },
+  };
+}
+
+function buildScope(sourceCwd: string, cwds: readonly string[]): ImportSessionCwdScope {
+  const exactCwds = Array.from(
+    new Map(cwds.map((cwd) => [normalizePathForIdentity(cwd), resolve(cwd)])).values(),
+  ).sort((left, right) => left.localeCompare(right));
+  const matchers = exactCwds.map((cwd) => createRealpathAwarePathMatcher(cwd));
+  return {
+    sourceCwd,
+    exactCwds,
+    matchesCwd: async (candidate) => matchers.some((matches) => matches(candidate)),
+  };
+}
+
+function toGitReadOptions(options: ResolveImportSessionCwdScopeOptions): WorkspaceGitReadOptions {
+  if (options.force) {
+    return {
+      force: true,
+      reason: options.reason ?? "import-session-cwd-scope",
+    };
+  }
+  return { reason: options.reason ?? "import-session-cwd-scope" };
+}
+
+function unavailableSourceCwd(sourceCwd: string): ImportSessionCwdScopeError {
+  return new ImportSessionCwdScopeError("unavailable_source_cwd", sourceCwd);
+}

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -65,6 +65,10 @@ import { getErrorMessage, getErrorMessageOr } from "@getpaseo/protocol/error-uti
 import { getAgentStatusPriority } from "@getpaseo/protocol/agent-state-bucket";
 import { getParentAgentIdFromLabels } from "@getpaseo/protocol/agent-labels";
 import type { WorkspaceGitRuntimeSnapshot, WorkspaceGitService } from "./workspace-git-service.js";
+import {
+  createImportSessionCwdScopeResolver,
+  type ImportSessionCwdScopeResolver,
+} from "./import-session-cwd-scope.js";
 import type { ProjectUpdate } from "./workspace-reconciliation-service.js";
 import {
   CLIENT_SHUTDOWN_RPC_REASON,
@@ -647,6 +651,7 @@ export class Session {
   private readonly github: ForgeService;
   private readonly renameCurrentBranch: typeof renameCurrentBranchDefault;
   private readonly workspaceGitService: WorkspaceGitService;
+  private readonly importSessionCwdScopeResolver: ImportSessionCwdScopeResolver;
   private readonly workspaceAutoName: WorkspaceAutoName;
   private readonly gitMutation: GitMutationService;
   private readonly workspaceProvisioning: WorkspaceProvisioningService;
@@ -803,6 +808,9 @@ export class Session {
     this.github = github ?? createGitHubService();
     this.renameCurrentBranch = renameCurrentBranch ?? renameCurrentBranchDefault;
     this.workspaceGitService = workspaceGitService;
+    this.importSessionCwdScopeResolver = createImportSessionCwdScopeResolver({
+      workspaceGitService: this.workspaceGitService,
+    });
     this.gitMutation = createGitMutationService({
       workspaceGitService: this.workspaceGitService,
       logger: this.sessionLogger,
@@ -813,6 +821,7 @@ export class Session {
       workspaceRegistry: this.workspaceRegistry,
       projectRegistry: this.projectRegistry,
       workspaceGitService: this.workspaceGitService,
+      importSessionCwdScopeResolver: this.importSessionCwdScopeResolver,
       logger: this.sessionLogger,
     });
     this.workspaceRecovery = createWorkspaceRecoveryService({
@@ -5280,6 +5289,7 @@ export class Session {
         agentManager: this.agentManager,
         agentStorage: this.agentStorage,
         providerSnapshotManager: this.providerSnapshotManager,
+        importSessionCwdScopeResolver: this.importSessionCwdScopeResolver,
       });
       this.emit({
         type: "fetch_recent_provider_sessions_response",

--- a/packages/server/src/server/session.workspaces.test.ts
+++ b/packages/server/src/server/session.workspaces.test.ts
@@ -3222,6 +3222,53 @@ test("fetch_recent_provider_sessions_request lists importable provider sessions 
   ]);
 });
 
+test("fetch_recent_provider_sessions_request resolves and applies a linked-worktree cwd scope", async () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "session-import-cwd-scope-"));
+  const emitted: Array<{ type: string; payload: Record<string, unknown> }> = [];
+  try {
+    const session = createSessionForWorkspaceTests();
+    const requestedCwds: Array<string | undefined> = [];
+    session.emit = (message) =>
+      emitted.push(message as { type: string; payload: Record<string, unknown> });
+    session.agentManager.listAgents = () => [];
+    session.agentStorage.list = async () => [];
+    session.agentManager.listImportableSessions = async (options?: unknown) => {
+      const cwd = (options as { cwd?: string } | undefined)?.cwd;
+      requestedCwds.push(cwd);
+      return [
+        makeImportableProviderSession({
+          provider: "codex",
+          sessionId: "project-session",
+          cwd: tempDir,
+          title: "Project session",
+          lastActivityAt: "2026-08-10T12:00:00.000Z",
+        }),
+      ];
+    };
+
+    await session.handleMessage({
+      type: "fetch_recent_provider_sessions_request",
+      requestId: "req-linked-worktree-scope",
+      cwd: tempDir,
+      includeLinkedWorktrees: true,
+      providers: ["codex"],
+    });
+
+    expect(requestedCwds).toEqual([tempDir]);
+    expect(emitted).toEqual([
+      expect.objectContaining({
+        type: "fetch_recent_provider_sessions_response",
+        payload: expect.objectContaining({
+          requestId: "req-linked-worktree-scope",
+          entries: [expect.objectContaining({ providerHandleId: "project-session", cwd: tempDir })],
+        }),
+      }),
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("fetch_recent_provider_sessions_request forwards providerFilter to agent manager", async () => {
   const emitted: Array<{ type: string; payload: unknown }> = [];
   const session = createSessionForWorkspaceTests();

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 import { createTestLogger } from "../../../test-utils/test-logger.js";
 import {
@@ -17,6 +17,8 @@ import {
   type WorkspaceRegistry,
 } from "../../workspace-registry.js";
 import type { CreatePaseoWorktreeWorkflowResult } from "../../worktree-session.js";
+import type { ImportSessionCwdScopeResolver } from "../../import-session-cwd-scope.js";
+import { createRealpathAwarePathMatcher } from "../../../utils/path.js";
 import {
   createWorkspaceProvisioningService,
   WorkspaceProvisioningError,
@@ -696,6 +698,146 @@ test("runInImportWorkspace creates one fresh workspace for an untargeted import"
   expect(await workspaceRegistry.list()).toEqual([result.createdWorkspace]);
 });
 
+test("runInImportWorkspace creates a linked-worktree workspace under the source project", async () => {
+  const projectRoot = path.join(tmpDir, "main-project");
+  const linkedCwd = path.join(tmpDir, "linked-worktree");
+  mkdirSync(projectRoot);
+  mkdirSync(linkedCwd);
+  const project = await projectRegistry.getOrCreateActiveByRoot({
+    rootPath: projectRoot,
+    kind: "non_git",
+    displayName: "main-project",
+    timestamp: "2026-08-10T00:00:00.000Z",
+  });
+  const resolver = cwdScopeResolver([projectRoot, linkedCwd]);
+  provisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: gitService(),
+    importSessionCwdScopeResolver: resolver,
+    logger,
+  });
+
+  const result = await provisioning.runInImportWorkspace(
+    { cwd: linkedCwd, requestedSourceCwd: projectRoot },
+    async (workspace) => workspace,
+  );
+
+  expect(result.value).toMatchObject({ cwd: linkedCwd, projectId: project.projectId });
+  expect(result.createdWorkspace).toEqual(result.value);
+  expect(resolver.resolve).toHaveBeenCalledWith(projectRoot, {
+    force: true,
+    reason: "provider-session-import",
+  });
+});
+
+test("runInImportWorkspace rejects a cwd outside the source scope without registry mutation", async () => {
+  const projectRoot = path.join(tmpDir, "main-project");
+  const unrelatedCwd = path.join(tmpDir, "unrelated");
+  mkdirSync(projectRoot);
+  mkdirSync(unrelatedCwd);
+  const project = await projectRegistry.getOrCreateActiveByRoot({
+    rootPath: projectRoot,
+    kind: "non_git",
+    displayName: "main-project",
+    timestamp: "2026-08-10T00:00:00.000Z",
+  });
+  const resolver = cwdScopeResolver([projectRoot]);
+  provisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: gitService(),
+    importSessionCwdScopeResolver: resolver,
+    logger,
+  });
+
+  await expect(
+    provisioning.runInImportWorkspace(
+      { cwd: unrelatedCwd, requestedSourceCwd: projectRoot },
+      async () => undefined,
+    ),
+  ).rejects.toThrow(`Import cwd is not linked to source directory: ${projectRoot}`);
+  expect(await workspaceRegistry.list()).toEqual([]);
+  expect(await projectRegistry.list()).toEqual([project]);
+});
+
+test("runInImportWorkspace rolls back a failed linked-worktree import", async () => {
+  const projectRoot = path.join(tmpDir, "main-project");
+  const linkedCwd = path.join(tmpDir, "linked-worktree");
+  mkdirSync(projectRoot);
+  mkdirSync(linkedCwd);
+  const project = await projectRegistry.getOrCreateActiveByRoot({
+    rootPath: projectRoot,
+    kind: "non_git",
+    displayName: "main-project",
+    timestamp: "2026-08-10T00:00:00.000Z",
+  });
+  provisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: gitService(),
+    importSessionCwdScopeResolver: cwdScopeResolver([projectRoot, linkedCwd]),
+    logger,
+  });
+
+  await expect(
+    provisioning.runInImportWorkspace(
+      { cwd: linkedCwd, requestedSourceCwd: projectRoot },
+      async () => {
+        throw new Error("provider session is unavailable");
+      },
+    ),
+  ).rejects.toThrow("provider session is unavailable");
+  expect(await workspaceRegistry.list()).toEqual([]);
+  expect(await projectRegistry.list()).toEqual([project]);
+});
+
+test("runInImportWorkspace preserves a concurrent active-project update after import failure", async () => {
+  const projectRoot = path.join(tmpDir, "main-project");
+  const linkedCwd = path.join(tmpDir, "linked-worktree");
+  mkdirSync(projectRoot);
+  mkdirSync(linkedCwd);
+  const project = await projectRegistry.getOrCreateActiveByRoot({
+    rootPath: projectRoot,
+    kind: "non_git",
+    displayName: "main-project",
+    timestamp: "2026-08-10T00:00:00.000Z",
+  });
+  provisioning = createWorkspaceProvisioningService({
+    workspaceRegistry,
+    projectRegistry,
+    workspaceGitService: gitService(),
+    importSessionCwdScopeResolver: cwdScopeResolver([projectRoot, linkedCwd]),
+    logger,
+  });
+
+  await expect(
+    provisioning.runInImportWorkspace(
+      { cwd: linkedCwd, requestedSourceCwd: projectRoot },
+      async () => {
+        const current = await projectRegistry.get(project.projectId);
+        if (!current) throw new Error("project disappeared during import");
+        await projectRegistry.upsert({ ...current, customName: "Concurrent project rename" });
+        throw new Error("provider session is unavailable");
+      },
+    ),
+  ).rejects.toThrow("provider session is unavailable");
+
+  expect(await workspaceRegistry.list()).toEqual([]);
+  expect(await projectRegistry.get(project.projectId)).toMatchObject({
+    customName: "Concurrent project rename",
+  });
+});
+
+test("runInImportWorkspace rejects simultaneous workspace and source-directory targets", async () => {
+  await expect(
+    provisioning.runInImportWorkspace(
+      { cwd: tmpDir, requestedWorkspaceId: "workspace", requestedSourceCwd: tmpDir },
+      async () => undefined,
+    ),
+  ).rejects.toThrow("Import cannot target both a workspace and a source directory");
+});
+
 test.each(["missing", "archived"] as const)(
   "runInImportWorkspace restores the exact %s project state when an untargeted import fails",
   async (state) => {
@@ -718,3 +860,14 @@ test.each(["missing", "archived"] as const)(
     expect(await projectRegistry.list()).toEqual(previousProject ? [previousProject] : []);
   },
 );
+
+function cwdScopeResolver(exactCwds: string[]): ImportSessionCwdScopeResolver {
+  const matchers = exactCwds.map((cwd) => createRealpathAwarePathMatcher(cwd));
+  return {
+    resolve: vi.fn(async (sourceCwd: string) => ({
+      sourceCwd,
+      exactCwds,
+      matchesCwd: async (candidate: string) => matchers.some((matches) => matches(candidate)),
+    })),
+  };
+}

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -1,4 +1,5 @@
 import { basename, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { Logger } from "pino";
 import {
   generateWorkspaceId,
@@ -16,6 +17,10 @@ import type { WorkspaceGitService } from "../../workspace-git-service.js";
 import type { CreatePaseoWorktreeWorkflowResult } from "../../worktree-session.js";
 import { deriveProjectKey } from "../../project-key.js";
 import { areEquivalentPaths, createRealpathAwarePathMatcher } from "../../../utils/path.js";
+import {
+  createImportSessionCwdScopeResolver,
+  type ImportSessionCwdScopeResolver,
+} from "../../import-session-cwd-scope.js";
 
 export interface ResolveOrCreateWorkspaceIdInput {
   createdWorktree: CreatePaseoWorktreeWorkflowResult | null;
@@ -27,6 +32,7 @@ export interface ResolveOrCreateWorkspaceIdInput {
 export interface ImportWorkspaceInput {
   cwd: string;
   requestedWorkspaceId?: string;
+  requestedSourceCwd?: string;
 }
 
 export interface ImportWorkspaceResult<T> {
@@ -88,16 +94,30 @@ export function createWorkspaceProvisioningService(deps: {
   serverId?: string;
   workspaceRegistry: WorkspaceRegistry;
   projectRegistry: ProjectRegistry;
-  workspaceGitService: Pick<WorkspaceGitService, "getCheckout" | "getSnapshot" | "peekSnapshot">;
+  workspaceGitService: Pick<
+    WorkspaceGitService,
+    | "getCheckout"
+    | "getSnapshot"
+    | "peekSnapshot"
+    | "getGitCheckoutIdentity"
+    | "listLinkedWorktrees"
+  >;
+  importSessionCwdScopeResolver?: ImportSessionCwdScopeResolver;
   logger: Logger;
 }): WorkspaceProvisioningService {
   const { serverId, workspaceRegistry, projectRegistry, workspaceGitService, logger } = deps;
+  const importSessionCwdScopeResolver =
+    deps.importSessionCwdScopeResolver ??
+    createImportSessionCwdScopeResolver({ workspaceGitService });
 
   async function runInImportWorkspace<T>(
     input: ImportWorkspaceInput,
     operation: (workspace: PersistedWorkspaceRecord) => Promise<T>,
   ): Promise<ImportWorkspaceResult<T>> {
-    if (input.requestedWorkspaceId) {
+    if (input.requestedWorkspaceId !== undefined && input.requestedSourceCwd !== undefined) {
+      throw new Error("Import cannot target both a workspace and a source directory");
+    }
+    if (input.requestedWorkspaceId !== undefined) {
       const workspace = await workspaceRegistry.get(input.requestedWorkspaceId);
       if (!workspace || workspace.archivedAt) {
         throw new Error(`Workspace not found: ${input.requestedWorkspaceId}`);
@@ -116,9 +136,25 @@ export function createWorkspaceProvisioningService(deps: {
     }
 
     const projectsBeforeImport = await projectRegistry.list();
-    const workspace = await createWorkspaceForDirectory(input.cwd);
+    let projectIdForImport: string | undefined;
+    if (input.requestedSourceCwd !== undefined) {
+      const scope = await importSessionCwdScopeResolver.resolve(input.requestedSourceCwd, {
+        force: true,
+        reason: "provider-session-import",
+      });
+      if (!(await scope.matchesCwd(input.cwd))) {
+        throw new Error(
+          `Import cwd is not linked to source directory: ${input.requestedSourceCwd}`,
+        );
+      }
+      projectIdForImport = (await findOrCreateProjectForDirectory(input.requestedSourceCwd))
+        .projectId;
+    }
+
+    const workspace = await createWorkspaceForDirectory(input.cwd, null, projectIdForImport);
     const previousProject =
       projectsBeforeImport.find((project) => project.projectId === workspace.projectId) ?? null;
+    const projectAfterWorkspace = await projectRegistry.get(workspace.projectId);
 
     try {
       return {
@@ -126,7 +162,7 @@ export function createWorkspaceProvisioningService(deps: {
         createdWorkspace: workspace,
       };
     } catch (error) {
-      await rollbackFailedImportWorkspace(workspace, previousProject);
+      await rollbackFailedImportWorkspace(workspace, previousProject, projectAfterWorkspace);
       throw error;
     }
   }
@@ -134,6 +170,7 @@ export function createWorkspaceProvisioningService(deps: {
   async function rollbackFailedImportWorkspace(
     workspace: PersistedWorkspaceRecord,
     previousProject: PersistedProjectRecord | null,
+    projectAfterWorkspace: PersistedProjectRecord | null,
   ): Promise<void> {
     try {
       await workspaceRegistry.remove(workspace.workspaceId);
@@ -143,9 +180,17 @@ export function createWorkspaceProvisioningService(deps: {
       if (projectHasActiveWorkspace) {
         return;
       }
-      if (previousProject?.archivedAt) {
+      const currentProject = await projectRegistry.get(workspace.projectId);
+      if (
+        !currentProject ||
+        !projectAfterWorkspace ||
+        !isDeepStrictEqual(currentProject, projectAfterWorkspace)
+      ) {
+        return;
+      }
+      if (previousProject) {
         await projectRegistry.upsert(previousProject);
-      } else if (!previousProject) {
+      } else {
         await projectRegistry.remove(workspace.projectId);
       }
     } catch (error) {

--- a/packages/server/src/server/test-utils/workspace-git-service-stub.ts
+++ b/packages/server/src/server/test-utils/workspace-git-service-stub.ts
@@ -55,6 +55,8 @@ export function createNoopWorkspaceGitService(
     suggestBranchesForCwd: async () => [],
     listStashes: async () => [],
     listWorktrees: async () => [],
+    getGitCheckoutIdentity: async () => null,
+    listLinkedWorktrees: async () => [],
     getProjectSlug: async (cwd: string) => {
       const snapshot = createNoGitWorkspaceRuntimeSnapshot(cwd);
       return deriveProjectSlug(cwd, snapshot.git.isGit ? snapshot.git.remoteUrl : null);

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -231,6 +231,8 @@ function createFallbackWorkspaceGitService(): WorkspaceGitService {
     suggestBranchesForCwd: async () => [],
     listStashes: async () => [],
     listWorktrees: async () => [],
+    getGitCheckoutIdentity: async () => null,
+    listLinkedWorktrees: async () => [],
     getProjectSlug: async (cwd: string) => {
       const snapshot = createFallbackWorkspaceGitSnapshot(cwd);
       return deriveProjectSlug(cwd, snapshot.git.isGit ? snapshot.git.remoteUrl : null);
@@ -1727,6 +1729,8 @@ export class VoiceAssistantWebSocketServer {
         providerRemoval: true,
         // COMPAT(importSessionWorkspaceTarget): added in v0.1.110, remove gate after 2027-01-16.
         importSessionWorkspaceTarget: true,
+        // COMPAT(importSessionLinkedWorktrees): added in v0.4.1, remove gate after 2027-02-17.
+        importSessionLinkedWorktrees: true,
         // COMPAT(forgeProviders): added in v0.1.106, drop the gate when daemon floor >= v0.1.106.
         forgeProviders: true,
         // COMPAT(selectiveAgentTimeline): added in v0.1.106, remove after 2027-01-12.

--- a/packages/server/src/server/workspace-git-service.ts
+++ b/packages/server/src/server/workspace-git-service.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { LRUCache } from "lru-cache";
 import pLimit from "p-limit";
@@ -13,6 +13,7 @@ import {
   type CheckoutSnapshotFacts,
   type CheckoutDiffCompare,
   type CheckoutDiffResult,
+  type GitWorktreeEntry,
   getCheckoutDiff,
   getCheckoutRefDerivedState,
   getCheckoutSnapshotFacts,
@@ -26,6 +27,7 @@ import {
   resolveRepositoryDefaultBranch,
   resolveBranchCheckout,
   resolveAbsoluteGitDir,
+  parseWorktreeList,
 } from "../utils/checkout-git.js";
 import type {
   ForgeAuthState,
@@ -44,6 +46,7 @@ import {
   createRealpathAwarePathMatcher,
   getRealpathAwareRelativePath,
   isRealpathInsideRoot,
+  normalizePathForIdentity,
 } from "../utils/path.js";
 import { runGitCommand } from "../utils/run-git-command.js";
 import { branchNameFromRef } from "../utils/worktree-metadata.js";
@@ -213,6 +216,14 @@ export interface WorkspaceGitService {
     cwdOrRepoRoot: string,
     options?: WorkspaceGitReadOptions,
   ): Promise<WorkspaceGitWorktreeInfo[]>;
+  getGitCheckoutIdentity(
+    cwd: string,
+    options?: WorkspaceGitReadOptions,
+  ): Promise<WorkspaceGitCheckoutIdentity | null>;
+  listLinkedWorktrees(
+    cwd: string,
+    options?: WorkspaceGitReadOptions,
+  ): Promise<WorkspaceGitCheckoutIdentity[]>;
   getProjectSlug(cwd: string, options?: WorkspaceGitReadOptions): Promise<string>;
   resolveRepoRoot(cwd: string, options?: WorkspaceGitReadOptions): Promise<string>;
   resolveDefaultBranch(cwdOrRepoRoot: string, options?: WorkspaceGitReadOptions): Promise<string>;
@@ -286,6 +297,12 @@ export interface WorkspaceGitStashEntry {
 export type WorkspaceGitBranchValidationResult = BranchCheckoutResolution;
 export type WorkspaceGitBranchSuggestion = BranchSuggestion;
 export type WorkspaceGitWorktreeInfo = PaseoWorktreeInfo;
+
+/** Lightweight Git identity used to prove that two directories are linked worktrees. */
+export interface WorkspaceGitCheckoutIdentity {
+  worktreeRoot: string;
+  commonDir: string;
+}
 
 export type WorkspaceGitSnapshotOptions =
   | {
@@ -561,6 +578,14 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
   private readonly worktreeListCache = new LRUCache<
     string,
     WorkspaceGitAuxiliaryReadCacheEntry<WorkspaceGitWorktreeInfo[]>
+  >({ max: WORKSPACE_GIT_AUXILIARY_CACHE_MAX });
+  private readonly gitCheckoutIdentityCache = new LRUCache<
+    string,
+    WorkspaceGitAuxiliaryReadCacheEntry<WorkspaceGitCheckoutIdentity | null>
+  >({ max: WORKSPACE_GIT_AUXILIARY_CACHE_MAX });
+  private readonly linkedWorktreeListCache = new LRUCache<
+    string,
+    WorkspaceGitAuxiliaryReadCacheEntry<WorkspaceGitCheckoutIdentity[]>
   >({ max: WORKSPACE_GIT_AUXILIARY_CACHE_MAX });
   private readonly defaultBranchCache = new LRUCache<
     string,
@@ -853,6 +878,98 @@ export class WorkspaceGitServiceImpl implements WorkspaceGitService {
         worktreesRoot: this.worktreesRoot,
       }),
     );
+  }
+
+  getGitCheckoutIdentity(
+    cwd: string,
+    options?: WorkspaceGitReadOptions,
+  ): Promise<WorkspaceGitCheckoutIdentity | null> {
+    this.assertNotDisposed();
+    const normalizedCwd = resolve(cwd);
+    const key = JSON.stringify(["git-checkout-identity", normalizedCwd]);
+    return this.readAuxiliaryCache(this.gitCheckoutIdentityCache, key, options, async () => {
+      const cwdStats = await stat(normalizedCwd).catch(() => null);
+      if (!cwdStats?.isDirectory()) return null;
+
+      try {
+        const [{ stdout: worktreeRootOutput }, { stdout: commonDirOutput }] = await Promise.all([
+          this.deps.runGitCommand(["rev-parse", "--show-toplevel"], {
+            cwd: normalizedCwd,
+            envOverlay: READ_ONLY_GIT_ENV,
+          }),
+          this.deps.runGitCommand(["rev-parse", "--git-common-dir"], {
+            cwd: normalizedCwd,
+            envOverlay: READ_ONLY_GIT_ENV,
+          }),
+        ]);
+        const worktreeRootValue = parseGitRevParsePath(worktreeRootOutput);
+        const commonDirValue = parseGitRevParsePath(commonDirOutput);
+        if (!worktreeRootValue || !commonDirValue) return null;
+
+        const worktreeRoot = resolve(normalizedCwd, worktreeRootValue);
+        const commonDir = resolve(normalizedCwd, commonDirValue);
+        const [worktreeStats, commonDirStats] = await Promise.all([
+          stat(worktreeRoot).catch(() => null),
+          stat(commonDir).catch(() => null),
+        ]);
+        if (!worktreeStats?.isDirectory() || !commonDirStats?.isDirectory()) return null;
+
+        return {
+          worktreeRoot: normalizePathForIdentity(worktreeRoot),
+          commonDir: normalizePathForIdentity(commonDir),
+        };
+      } catch {
+        return null;
+      }
+    });
+  }
+
+  async listLinkedWorktrees(
+    cwd: string,
+    options?: WorkspaceGitReadOptions,
+  ): Promise<WorkspaceGitCheckoutIdentity[]> {
+    this.assertNotDisposed();
+    const selected = await this.getGitCheckoutIdentity(cwd, options);
+    if (!selected) return [];
+
+    const key = JSON.stringify(["linked-worktrees", selected.commonDir]);
+    return this.readAuxiliaryCache(this.linkedWorktreeListCache, key, options, async () => {
+      const { stdout } = await this.deps.runGitCommand(["worktree", "list", "--porcelain"], {
+        cwd: selected.worktreeRoot,
+        envOverlay: READ_ONLY_GIT_ENV,
+      });
+      const candidates = parseWorktreeList(stdout).filter(
+        (entry) => !entry.isBare && !entry.isPrunable,
+      );
+      const limit = pLimit({ concurrency: WORKSPACE_GIT_REFRESH_CONCURRENCY });
+      const verified = await Promise.all(
+        candidates.map((entry) =>
+          limit(() => this.verifyLinkedWorktreeCandidate(entry, selected, options)),
+        ),
+      );
+
+      const unique = new Map<string, WorkspaceGitCheckoutIdentity>();
+      for (const identity of verified) {
+        if (identity) unique.set(identity.worktreeRoot, identity);
+      }
+      return Array.from(unique.values());
+    });
+  }
+
+  private async verifyLinkedWorktreeCandidate(
+    entry: GitWorktreeEntry,
+    selected: WorkspaceGitCheckoutIdentity,
+    options?: WorkspaceGitReadOptions,
+  ): Promise<WorkspaceGitCheckoutIdentity | null> {
+    const expectedRoot = resolve(entry.path);
+    const expectedStats = await stat(expectedRoot).catch(() => null);
+    if (!expectedStats?.isDirectory()) return null;
+
+    const identity = await this.getGitCheckoutIdentity(expectedRoot, options);
+    if (!identity) return null;
+    if (!createRealpathAwarePathMatcher(expectedRoot)(identity.worktreeRoot)) return null;
+    if (!createRealpathAwarePathMatcher(selected.commonDir)(identity.commonDir)) return null;
+    return identity;
   }
 
   async resolveRepoRoot(cwd: string, options?: WorkspaceGitReadOptions): Promise<string> {

--- a/packages/server/src/utils/checkout-git.ts
+++ b/packages/server/src/utils/checkout-git.ts
@@ -1032,6 +1032,7 @@ export interface GitWorktreeEntry {
   path: string;
   branchRef?: string;
   isBare?: boolean;
+  isPrunable?: boolean;
 }
 
 /** Check whether a path is under Paseo's worktree root. */
@@ -1079,6 +1080,9 @@ export function parseWorktreeList(output: string): GitWorktreeEntry[] {
     }
     if (current && trimmed === "bare") {
       current.isBare = true;
+    }
+    if (current && (trimmed === "prunable" || trimmed.startsWith("prunable "))) {
+      current.isPrunable = true;
     }
   }
   if (current) {


### PR DESCRIPTION
### Linked issue

None.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Provider sessions started in linked Git worktrees are invisible when session import searches only the selected directory. Importing one as an unscoped session also creates a separate Project for the worktree path, even though the checkout belongs with the source Project.

This change lets an unbound directory import scan the same relative directory across linked worktrees. Paseo resumes the provider session in its original checkout, creates a Workspace there, and associates that Workspace with the Project rooted at the directory where import started. Workspace-bound imports remain exact, and host-global imports remain global.

### Goals

- Discover importable sessions from the selected directory and its linked Git worktrees.
- Preserve subdirectory selection by mapping the same relative path across each worktree.
- Resume the provider session in its original working directory.
- Create the imported session's Workspace under the source Project instead of creating a duplicate Project for an external worktree path.
- Revalidate linked-worktree membership immediately before import.
- Preserve exact Workspace imports and host-global imports behind protocol capability gates.

### Non-goals

- Move or copy a provider session into another checkout.
- Check out a historical session commit in detached HEAD.
- Create a new Git worktree for the imported session.
- Treat separate clones with matching remotes as linked worktrees.
- Add session pagination or change provider ordering.

### QA

- `npm run build:server` — passed.
- `npm run typecheck` — passed across all workspaces.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format` and `npm run format:check` — passed.
- `npx vitest run packages/protocol/src/messages.test.ts --bail=1` — 23 passed.
- `npx vitest run packages/client/src/daemon-client.test.ts --bail=1` — 116 passed.
- `npx vitest run packages/app/src/components/import-session-sheet-view-model.test.ts --bail=1` — 31 passed.
- `npx vitest run packages/app/src/components/import-session-sheet.test.tsx --bail=1` — 18 passed.
- `npx vitest run packages/server/src/server/agent/import-sessions.test.ts --bail=1` — 18 passed.
- `npx vitest run packages/server/src/server/import-session-cwd-scope.posix.test.ts --bail=1` — 5 passed.
- `npx vitest run packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.test.ts --bail=1` — 40 passed.
- `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false npx vitest run packages/server/src/server/session.workspaces.test.ts --bail=1` — 107 passed, 4 skipped.

Manual UI capture has not been run; this remains a draft.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense