### PR TITLE
fix(server): read Claude usage from CLAUDE_CONFIG_DIR

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -325,7 +325,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   constructor(options: ClaudeQuotaProviderOptions) {
     this.logger = options.logger.child({ module: "claude-quota-provider" });
     this.claudeHome =
-      options.claudeHome || process.env["CLAUDE_HOME"] || join(homedir(), ".claude");
+      options.claudeHome || process.env["CLAUDE_CONFIG_DIR"] || join(homedir(), ".claude");
     this.readKeychainCredentials = options.claudeKeychainReader ?? readClaudeKeychainCredentials;
     this.platform = options.platform ?? process.platform;
     this.fetchApi = options.fetch ?? fetch;


### PR DESCRIPTION
## Summary
- The provider usage fetcher resolved Claude's config dir from `CLAUDE_HOME`, an env var Claude Code does not use.
- Users who set `CLAUDE_CONFIG_DIR` (XDG or custom dirs) had usage look in `~/.claude`, miss `.credentials.json`, and report "unavailable".
- Switched to `CLAUDE_CONFIG_DIR`, matching the canonical resolution used everywhere else in the repo (e.g. `project-dir.ts`, `agent.ts`).

## Test plan
- [ ] With `CLAUDE_CONFIG_DIR` set to a non-default dir containing valid Claude Code credentials, the Claude usage card shows windows instead of "unavailable".
- [ ] Default setup (no `CLAUDE_CONFIG_DIR`) still resolves `~/.claude`.
