### PR TITLE
feat(server): allow create_agent system prompts

### DIFF
--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -1404,6 +1404,54 @@ describe("create_agent MCP tool", () => {
     );
   });
 
+  it("passes an agent-scoped system prompt through createAgent", async () => {
+    const { agentManager, agentStorage, spies } = createTestDeps();
+    spies.agentManager.getAgent.mockReturnValue({
+      id: "parent-agent",
+      cwd: existingCwd,
+      workspaceId: "wks_parent",
+      provider: "codex",
+      currentModeId: "full-access",
+      config: { systemPrompt: "Parent instructions must not be inherited." },
+    } as ManagedAgent);
+    spies.agentManager.createAgent.mockResolvedValue({
+      id: "child-agent",
+      provider: "codex",
+      cwd: existingCwd,
+      workspaceId: "wks_parent",
+      lifecycle: "idle",
+      currentModeId: null,
+      availableModes: [],
+      config: { title: "System prompt test", systemPrompt: "Child instructions." },
+    } as ManagedAgent);
+
+    const server = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      callerAgentId: "parent-agent",
+      logger,
+    });
+    const tool = registeredTool(server, "create_agent");
+
+    await tool.handler({
+      ...subagentCurrentWorkspace(),
+      title: "System prompt test",
+      provider: "codex/gpt-5.4",
+      initialPrompt: "Do work",
+      systemPrompt: "Child instructions.",
+      notifyOnFinish: false,
+    });
+
+    expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: "Child instructions.",
+      }),
+      undefined,
+      expect.objectContaining({ workspaceId: "wks_parent" }),
+    );
+  });
+
   it("returns create_agent structured content with full provider modes", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
     spies.agentManager.createAgent.mockResolvedValue({

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -646,6 +646,20 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
     return { providerOptions: callerAgent.config.providerOptions };
   };
 
+  const resolveCreateAgentConfig = (
+    selectedProvider: string,
+    systemPrompt: string | undefined,
+  ): Pick<AgentSessionConfig, "providerOptions" | "systemPrompt"> | undefined => {
+    const inheritedConfig = resolveInheritedProviderConfig(selectedProvider);
+    if (!inheritedConfig && !systemPrompt) {
+      return undefined;
+    }
+    return {
+      ...inheritedConfig,
+      ...(systemPrompt ? { systemPrompt } : {}),
+    };
+  };
+
   const resolveScopedCwd = (requestedCwd?: string, opts?: { required?: boolean }): string => {
     const callerAgent = resolveCallerAgent();
     if (callerAgent) {
@@ -991,6 +1005,12 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       .trim()
       .min(1, "initialPrompt is required")
       .describe("Required first task to run immediately after creation."),
+    systemPrompt: z
+      .string()
+      .trim()
+      .min(1, "systemPrompt cannot be empty")
+      .optional()
+      .describe("Optional system instructions for the new agent."),
   };
   const legacyCreateAgentPlacementFields = {
     relationship: AgentRelationshipInputSchema.describe(
@@ -1430,7 +1450,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         notifyOnFinish = resolvedArgs.parsedArgs.notifyOnFinish ?? false;
       }
       const selectedProvider = resolveRequiredProviderModel(parsedArgs.provider).provider;
-      const inheritedConfig = resolveInheritedProviderConfig(selectedProvider);
+      const createConfig = resolveCreateAgentConfig(selectedProvider, parsedArgs.systemPrompt);
       const {
         snapshot,
         background: createdInBackground,
@@ -1454,7 +1474,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           provider: parsedArgs.provider,
           title: parsedArgs.title,
           initialPrompt: parsedArgs.initialPrompt,
-          config: inheritedConfig,
+          config: createConfig,
           cwd: resolvedArgs.cwd,
           workspaceId: resolvedArgs.workspaceId,
           thinking: parsedArgs.settings?.thinkingOptionId,


### PR DESCRIPTION
## Summary

- accept an optional `systemPrompt` in the MCP `create_agent` tool
- merge the requested prompt with provider options inherited from a same-provider parent
- verify child instructions are passed without inheriting the parent system prompt

## Testing

- `npx vitest run packages/server/src/server/agent/mcp-server.test.ts --bail=1`
- `npm run typecheck`
- `npm run lint`
- `npm run format`