### PR TITLE
fix(server): don't treat a forbidden usage response as stale auth

### DIFF
--- a/packages/server/src/services/quota-fetcher/providers/claude.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.test.ts
@@ -1,0 +1,46 @@
+import pino from "pino";
+import { describe, expect, it } from "vitest";
+import { ClaudeQuotaProvider } from "./claude.js";
+
+const logger = pino({ level: "silent" });
+
+function forbiddenResponse(): Response {
+  return new Response(JSON.stringify({ error: { type: "forbidden" } }), { status: 403 });
+}
+
+describe("ClaudeQuotaProvider forbidden handling", () => {
+  it("surfaces a 403 as an error state instead of a silent blank card", async () => {
+    // Keychain-sourced credentials (filePath null); a 403 must not be treated as a stale
+    // token and must not blank out silently.
+    const provider = new ClaudeQuotaProvider({
+      logger,
+      platform: "darwin",
+      claudeHome: "/nonexistent-claude-home",
+      claudeKeychainReader: async () => ({
+        claudeAiOauth: { accessToken: "t", refreshToken: "r" },
+      }),
+      fetch: async () => forbiddenResponse(),
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.status).toBe("error");
+    expect(usage.error).toMatch(/organization/i);
+    expect(usage.windows).toHaveLength(0);
+  });
+
+  it("reports plain unavailable when no credentials exist", async () => {
+    const provider = new ClaudeQuotaProvider({
+      logger,
+      platform: "linux",
+      claudeHome: "/nonexistent-claude-home",
+      claudeKeychainReader: async () => null,
+      fetch: async () => new Response("{}", { status: 200 }),
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usage.status).toBe("unavailable");
+    expect(usage.error).toBeNull();
+  });
+});

--- a/packages/server/src/services/quota-fetcher/providers/claude.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.test.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import pino from "pino";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ClaudeQuotaProvider } from "./claude.js";
 
 const logger = pino({ level: "silent" });
@@ -25,8 +28,32 @@ describe("ClaudeQuotaProvider forbidden handling", () => {
     const usage = await provider.fetchUsage();
 
     expect(usage.status).toBe("error");
-    expect(usage.error).toMatch(/organization/i);
+    expect(usage.error).toMatch(/current Claude Code credentials/i);
     expect(usage.windows).toHaveLength(0);
+  });
+
+  it("does not attempt a token refresh on a 403", async () => {
+    let refreshCalls = 0;
+    const provider = new ClaudeQuotaProvider({
+      logger,
+      platform: "darwin",
+      claudeHome: "/nonexistent-claude-home",
+      claudeKeychainReader: async () => ({
+        claudeAiOauth: { accessToken: "t", refreshToken: "r" },
+      }),
+      fetch: async (input) => {
+        if (String(input).includes("/oauth/token")) {
+          refreshCalls += 1;
+          return new Response(JSON.stringify({ access_token: "new" }), { status: 200 });
+        }
+        return forbiddenResponse();
+      },
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(refreshCalls).toBe(0);
+    expect(usage.status).toBe("error");
   });
 
   it("reports plain unavailable when no credentials exist", async () => {
@@ -42,5 +69,46 @@ describe("ClaudeQuotaProvider forbidden handling", () => {
 
     expect(usage.status).toBe("unavailable");
     expect(usage.error).toBeNull();
+  });
+});
+
+describe("ClaudeQuotaProvider refresh-then-forbidden", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "claude-quota-"));
+    writeFileSync(
+      join(home, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "stale", refreshToken: "r" } }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("surfaces the forbidden message when a refreshed token is still forbidden", async () => {
+    // File-based creds -> the 401 refresh path runs; the retried call then returns 403,
+    // which must map to the explicit message, not generic unavailable.
+    let usageCalls = 0;
+    const provider = new ClaudeQuotaProvider({
+      logger,
+      platform: "linux",
+      claudeHome: home,
+      claudeKeychainReader: async () => null,
+      fetch: async (input) => {
+        if (String(input).includes("/oauth/token")) {
+          return new Response(JSON.stringify({ access_token: "fresh" }), { status: 200 });
+        }
+        usageCalls += 1;
+        return usageCalls === 1 ? new Response("{}", { status: 401 }) : forbiddenResponse();
+      },
+    });
+
+    const usage = await provider.fetchUsage();
+
+    expect(usageCalls).toBe(2);
+    expect(usage.status).toBe("error");
+    expect(usage.error).toMatch(/current Claude Code credentials/i);
   });
 });

--- a/packages/server/src/services/quota-fetcher/providers/claude.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.test.ts
@@ -28,7 +28,7 @@ describe("ClaudeQuotaProvider forbidden handling", () => {
     const usage = await provider.fetchUsage();
 
     expect(usage.status).toBe("error");
-    expect(usage.error).toMatch(/current Claude Code credentials/i);
+    expect(usage.error).toMatch(/refused \(HTTP 403\)/i);
     expect(usage.windows).toHaveLength(0);
   });
 
@@ -109,6 +109,6 @@ describe("ClaudeQuotaProvider refresh-then-forbidden", () => {
 
     expect(usageCalls).toBe(2);
     expect(usage.status).toBe("error");
-    expect(usage.error).toMatch(/current Claude Code credentials/i);
+    expect(usage.error).toMatch(/refused \(HTTP 403\)/i);
   });
 });

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -83,11 +83,12 @@ type ClaudeLimit = z.infer<typeof ClaudeLimitSchema>;
 
 const SCOPED_WEEKLY_KIND = "weekly_scoped";
 
-// A 403 is a valid credential that simply isn't allowed to read usage through this path,
-// as opposed to a 401, which is a stale token worth refreshing. Refreshing can't widen a
-// credential's access, so surface it plainly instead of blanking the card or retrying.
+// A 403 is not a stale token, so refreshing cannot clear it: the request was rejected
+// before any credential check, which an unauthenticated probe returning 403 rather than
+// 401 confirms. Observed causes are environmental (the daemon's egress being refused),
+// so the message names the refusal without guessing which one it was.
 const CLAUDE_USAGE_FORBIDDEN_MESSAGE =
-  "Usage can't be fetched for this account with the current Claude Code credentials.";
+  "Usage request was refused (HTTP 403). Check the daemon's network access to api.anthropic.com.";
 
 interface ClaudeCredentialRecord {
   oauth: { accessToken: string } & NonNullable<ClaudeCredentials["claudeAiOauth"]>;

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -83,10 +83,9 @@ type ClaudeLimit = z.infer<typeof ClaudeLimitSchema>;
 
 const SCOPED_WEEKLY_KIND = "weekly_scoped";
 
-// A 403 is not a stale token, so refreshing cannot clear it: the request was rejected
-// before any credential check, which an unauthenticated probe returning 403 rather than
-// 401 confirms. Observed causes are environmental (the daemon's egress being refused),
-// so the message names the refusal without guessing which one it was.
+// A 403 is not a stale token, so refreshing cannot clear it, and refreshing anyway rewrites
+// the credentials on every poll. What causes the refusal is not visible from here, so the
+// message names the refusal rather than guessing at a reason.
 const CLAUDE_USAGE_FORBIDDEN_MESSAGE =
   "Usage request was refused (HTTP 403). Check the daemon's network access to api.anthropic.com.";
 
@@ -332,7 +331,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   constructor(options: ClaudeQuotaProviderOptions) {
     this.logger = options.logger.child({ module: "claude-quota-provider" });
     this.claudeHome =
-      options.claudeHome || process.env["CLAUDE_CONFIG_DIR"] || join(homedir(), ".claude");
+      options.claudeHome || process.env["CLAUDE_HOME"] || join(homedir(), ".claude");
     this.readKeychainCredentials = options.claudeKeychainReader ?? readClaudeKeychainCredentials;
     this.platform = options.platform ?? process.platform;
     this.fetchApi = options.fetch ?? fetch;

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -325,7 +325,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
   constructor(options: ClaudeQuotaProviderOptions) {
     this.logger = options.logger.child({ module: "claude-quota-provider" });
     this.claudeHome =
-      options.claudeHome || process.env["CLAUDE_HOME"] || join(homedir(), ".claude");
+      options.claudeHome || process.env["CLAUDE_CONFIG_DIR"] || join(homedir(), ".claude");
     this.readKeychainCredentials = options.claudeKeychainReader ?? readClaudeKeychainCredentials;
     this.platform = options.platform ?? process.platform;
     this.fetchApi = options.fetch ?? fetch;

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -83,11 +83,11 @@ type ClaudeLimit = z.infer<typeof ClaudeLimitSchema>;
 
 const SCOPED_WEEKLY_KIND = "weekly_scoped";
 
-// A 403 from the usage endpoint is permanent, not a stale token: Team/Enterprise seats are
-// scoped to inference and manage usage at the org level, so the endpoint forbids them. Say
-// so instead of blanking the card or pointlessly refreshing a token that will still be 403.
+// A 403 is a valid credential that simply isn't allowed to read usage through this path,
+// as opposed to a 401, which is a stale token worth refreshing. Refreshing can't widen a
+// credential's access, so surface it plainly instead of blanking the card or retrying.
 const CLAUDE_USAGE_FORBIDDEN_MESSAGE =
-  "Usage not available for this account (managed at the organization level).";
+  "Usage can't be fetched for this account with the current Claude Code credentials.";
 
 interface ClaudeCredentialRecord {
   oauth: { accessToken: string } & NonNullable<ClaudeCredentials["claudeAiOauth"]>;
@@ -348,11 +348,7 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
     let resp = await this.callClaudeApi(oauth.accessToken);
 
     if (resp === "FORBIDDEN") {
-      return unavailableUsage({
-        providerId: this.providerId,
-        displayName: this.displayName,
-        error: CLAUDE_USAGE_FORBIDDEN_MESSAGE,
-      });
+      return this.forbiddenUsage();
     }
 
     if (resp === "NEEDS_AUTH") {
@@ -372,9 +368,12 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
       });
 
       resp = await this.callClaudeApi(refreshed.access_token);
-      // A fresh token that still can't authenticate (or is now forbidden) has nothing left
-      // to try; the forbidden message only matters on the first, un-refreshed call.
-      if (typeof resp === "string") {
+      // A refreshed token that is still forbidden gets the same explicit message; a still
+      // unauthenticated one is a genuine auth failure and stays generic unavailable.
+      if (resp === "FORBIDDEN") {
+        return this.forbiddenUsage();
+      }
+      if (resp === "NEEDS_AUTH") {
         return unavailableUsage(this);
       }
     }
@@ -440,6 +439,14 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
       parsed.push(limit);
     }
     return parsed;
+  }
+
+  private forbiddenUsage(): ProviderUsage {
+    return unavailableUsage({
+      providerId: this.providerId,
+      displayName: this.displayName,
+      error: CLAUDE_USAGE_FORBIDDEN_MESSAGE,
+    });
   }
 
   private async readCredentials(): Promise<ClaudeCredentialRecord | null> {

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -83,6 +83,12 @@ type ClaudeLimit = z.infer<typeof ClaudeLimitSchema>;
 
 const SCOPED_WEEKLY_KIND = "weekly_scoped";
 
+// A 403 from the usage endpoint is permanent, not a stale token: Team/Enterprise seats are
+// scoped to inference and manage usage at the org level, so the endpoint forbids them. Say
+// so instead of blanking the card or pointlessly refreshing a token that will still be 403.
+const CLAUDE_USAGE_FORBIDDEN_MESSAGE =
+  "Usage not available for this account (managed at the organization level).";
+
 interface ClaudeCredentialRecord {
   oauth: { accessToken: string } & NonNullable<ClaudeCredentials["claudeAiOauth"]>;
   filePath: string | null;
@@ -341,6 +347,14 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
     const plan = buildClaudePlan(oauth.subscriptionType, oauth.rateLimitTier);
     let resp = await this.callClaudeApi(oauth.accessToken);
 
+    if (resp === "FORBIDDEN") {
+      return unavailableUsage({
+        providerId: this.providerId,
+        displayName: this.displayName,
+        error: CLAUDE_USAGE_FORBIDDEN_MESSAGE,
+      });
+    }
+
     if (resp === "NEEDS_AUTH") {
       if (!filePath || !oauth.refreshToken) {
         return unavailableUsage(this);
@@ -358,7 +372,9 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
       });
 
       resp = await this.callClaudeApi(refreshed.access_token);
-      if (resp === "NEEDS_AUTH") {
+      // A fresh token that still can't authenticate (or is now forbidden) has nothing left
+      // to try; the forbidden message only matters on the first, un-refreshed call.
+      if (typeof resp === "string") {
         return unavailableUsage(this);
       }
     }
@@ -454,7 +470,9 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
     return null;
   }
 
-  private async callClaudeApi(token: string): Promise<ClaudeUsageResponse | "NEEDS_AUTH"> {
+  private async callClaudeApi(
+    token: string,
+  ): Promise<ClaudeUsageResponse | "NEEDS_AUTH" | "FORBIDDEN"> {
     const res = await fetchProviderApi(this.fetchApi, "https://api.anthropic.com/api/oauth/usage", {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -462,7 +480,8 @@ export class ClaudeQuotaProvider implements ProviderUsageFetcher {
         "anthropic-beta": CLAUDE_OAUTH_BETA,
       },
     });
-    if (res.status === 401 || res.status === 403) return "NEEDS_AUTH";
+    if (res.status === 401) return "NEEDS_AUTH";
+    if (res.status === 403) return "FORBIDDEN";
     if (!res.ok) throw new Error(`Claude usage API returned ${res.status}`);
     return ClaudeUsageResponseSchema.parse(await res.json());
   }


### PR DESCRIPTION
## Summary
`callClaudeApi` mapped both **401** and **403** to `NEEDS_AUTH`, so a forbidden response was handled as if the token were stale.

Two consequences:

1. **Credentials are rewritten on every poll.** With file-based credentials, a persistent 403 runs the refresh path on each usage fetch — exchanging the refresh token and rewriting `.credentials.json` roughly every five minutes to recover from something a refresh cannot fix. The token exchange rotates the refresh token, so this churns live credentials on a timer.
2. **The card goes blank with no reason.** Both give-up paths return `unavailable` with `error: null`, so the UI shows an empty card and nothing explains why.

This PR separates the two cases:

- **401** → stale authentication; refresh path unchanged.
- **403** → returned as an `error` status with a message, and **no refresh is attempted**.
- **401 → refresh → 403** → same message, rather than falling back to a blank `unavailable`.
- **401 → refresh → 401** → unchanged (generic `unavailable`).

Message:

> Usage request was refused (HTTP 403). Check the daemon's network access to api.anthropic.com.

A 403 can have several causes and the daemon cannot tell them apart from the response, so the message names the refusal and its status code rather than asserting a reason.

## Notes

- Scoped deliberately to the status distinction. Credential-directory handling (`CLAUDE_CONFIG_DIR`) is a separate concern tracked in #3589.
- Independent of #3595 / #3597, which fix *which* Keychain item is read. That work selects the credential; this changes how the outcome is reported. They compose: once a live item is selected, a machine that previously returned 401 can begin returning 403, which is the path this PR gives a message to.

## Test plan

`packages/server/src/services/quota-fetcher/providers/claude.test.ts`:

- 403 → `status: "error"` carrying the message, no windows
- 403 → no token refresh attempted
- 401 → refresh → 403 → same message (not blank `unavailable`)
- no credentials → plain `unavailable` with `error: null`

CI runs typecheck and tests; `node_modules` was not installed in the environment this was written in, so they were not run locally.
