### PR TITLE
fix(acp): surface context usage updates

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2849,22 +2849,22 @@ describe("ACPAgentSession", () => {
         cachedReadTokens: 5_000,
       },
     });
-    await Promise.resolve();
-    await Promise.resolve();
 
-    expect(events.find((event) => event.type === "turn_completed")).toEqual({
-      type: "turn_completed",
-      provider: "claude-acp",
-      turnId,
-      usage: {
-        inputTokens: 30_000,
-        outputTokens: 12_000,
-        cachedInputTokens: 5_000,
-        contextWindowMaxTokens: 200_000,
-        contextWindowUsedTokens: 45_000,
-        totalCostUsd: undefined,
-      },
-    });
+    await vi.waitFor(() =>
+      expect(events).toContainEqual({
+        type: "turn_completed",
+        provider: "claude-acp",
+        turnId,
+        usage: {
+          inputTokens: 30_000,
+          outputTokens: 12_000,
+          cachedInputTokens: 5_000,
+          contextWindowMaxTokens: 200_000,
+          contextWindowUsedTokens: 45_000,
+          totalCostUsd: undefined,
+        },
+      }),
+    );
   });
 
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2780,6 +2780,93 @@ describe("ACPAgentSession", () => {
     expect(asInternals<ACPSessionInternals>(session).activeForegroundTurnId).toBeNull();
   });
 
+  test("emits ACP context window usage updates and keeps them on turn completion", async () => {
+    const session = createSession();
+    const events: AgentStreamEvent[] = [];
+    let resolvePrompt!: (value: PromptResponse) => void;
+    const prompt = vi.fn(
+      () =>
+        new Promise<PromptResponse>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    asInternals<ACPSessionInternals>(session).connection = { prompt };
+    session.subscribe((event) => {
+      events.push(event);
+    });
+
+    const { turnId } = await session.startTurn("hello");
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 42_000,
+        size: 200_000,
+        cost: { amount: 0.25, currency: "USD" },
+      },
+    });
+
+    expect(events.find((event) => event.type === "usage_updated")).toEqual({
+      type: "usage_updated",
+      provider: "claude-acp",
+      turnId,
+      usage: {
+        contextWindowMaxTokens: 200_000,
+        contextWindowUsedTokens: 42_000,
+        totalCostUsd: 0.25,
+      },
+    });
+
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 45_000,
+        size: 200_000,
+        cost: { amount: 0.2, currency: "EUR" },
+      },
+    });
+
+    expect(events.findLast((event) => event.type === "usage_updated")).toEqual({
+      type: "usage_updated",
+      provider: "claude-acp",
+      turnId,
+      usage: {
+        contextWindowMaxTokens: 200_000,
+        contextWindowUsedTokens: 45_000,
+        totalCostUsd: undefined,
+      },
+    });
+
+    resolvePrompt({
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 30_000,
+        outputTokens: 12_000,
+        totalTokens: 42_000,
+        cachedReadTokens: 5_000,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events.find((event) => event.type === "turn_completed")).toEqual({
+      type: "turn_completed",
+      provider: "claude-acp",
+      turnId,
+      usage: {
+        inputTokens: 30_000,
+        outputTokens: 12_000,
+        cachedInputTokens: 5_000,
+        contextWindowMaxTokens: 200_000,
+        contextWindowUsedTokens: 45_000,
+        totalCostUsd: undefined,
+      },
+    });
+  });
+
   test("startTurn emits the submitted user message even when ACP does not echo it", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -606,6 +606,14 @@ export function mapACPUsage(usage: Usage | null | undefined): AgentUsage | undef
   };
 }
 
+function mapACPUsageUpdate(update: UsageUpdate): AgentUsage {
+  return {
+    contextWindowMaxTokens: update.size,
+    contextWindowUsedTokens: update.used,
+    totalCostUsd: update.cost?.currency === "USD" ? update.cost.amount : undefined,
+  };
+}
+
 export function resolveACPModeSelection({
   modeId,
   availableModes,
@@ -1623,6 +1631,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const turnId = randomUUID();
     const messageId = options?.clientMessageId ?? randomUUID();
     this.activeForegroundTurnId = turnId;
+    this.currentTurnUsage = undefined;
     this.fallbackAssistantMessageId = null;
     this.submittedUserMessageTurnId = null;
     this.emitBootstrapThreadEvent();
@@ -2681,8 +2690,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
         this.handleSessionInfoUpdate(update);
         return pendingUserEvents;
       case "usage_update":
-        this.handleUsageUpdate(update);
-        return pendingUserEvents;
+        return [...pendingUserEvents, this.handleUsageUpdate(update)];
       case "available_commands_update":
         this.cachedCommands = update.availableCommands.map((command) => ({
           name: command.name,
@@ -2842,12 +2850,24 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     }
   }
 
-  private handleUsageUpdate(update: UsageUpdate): void {
-    void update;
+  private handleUsageUpdate(update: UsageUpdate): AgentStreamEvent {
+    const usage = mapACPUsageUpdate(update);
+    if (this.activeForegroundTurnId) {
+      this.currentTurnUsage = { ...this.currentTurnUsage, ...usage };
+    }
+    return {
+      type: "usage_updated",
+      provider: this.provider,
+      usage,
+      turnId: this.activeForegroundTurnId ?? undefined,
+    };
   }
 
   private handlePromptResponse(response: PromptResponse, turnId: string): void {
-    this.currentTurnUsage = mapACPUsage(response.usage) ?? this.currentTurnUsage;
+    const responseUsage = mapACPUsage(response.usage);
+    if (responseUsage) {
+      this.currentTurnUsage = { ...this.currentTurnUsage, ...responseUsage };
+    }
 
     switch (response.stopReason) {
       case "cancelled":


### PR DESCRIPTION
### Linked issue

Closes #1390.

Replaces #2094, whose branch is currently conflicted with `main` and 533 commits behind it. This PR applies the fix to current `main` and adds regression coverage.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

ACP providers send `usage_update` session notifications with context-window usage, but the shared ACP adapter discards them. Agents using Hermes and other ACP providers therefore never publish `contextWindowMaxTokens` or `contextWindowUsedTokens`, so Paseo cannot show their context meter.

Map each ACP usage snapshot into the existing `usage_updated` stream event and associate it with the active turn. Keep that context snapshot when the prompt response adds input, output, and cached-token counts at turn completion. Per-turn usage is reset before the next prompt, and non-USD updates cannot retain an older USD cost.

### Goals

- Surface ACP `size` and `used` as context-window usage.
- Surface cumulative ACP cost when its currency is USD.
- Preserve the latest context snapshot alongside prompt token counts on `turn_completed`.
- Attach live usage to the active turn and prevent usage from leaking across turns.
- Cover live updates, completion merging, and unsupported-currency cost clearing.

### Non-goals

- Synthesize usage for ACP providers that do not emit `usage_update`.
- Convert non-USD currencies.
- Change the protocol or context-meter UI.

### QA

Automated checks on Linux 6.12.63+deb13-amd64 x86_64:

```text
$ npx vitest run packages/server/src/server/agent/providers/acp-agent.test.ts --bail=1
Test Files  1 passed (1)
Tests       97 passed (97)

$ npm run typecheck
All workspace typechecks passed.

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format
Finished successfully on 3824 files.

$ npm run build:server
Protocol, client, server, and CLI builds passed.
```

Real provider check with Hermes Agent v0.15.1 and `hermes acp`: I started the modified `ACPAgentSession`, ran Hermes' local `/context` command, and captured the emitted events below. `/context` is handled inside Hermes, so this did not call a model. The temporary Hermes session was deleted afterward, and the main Paseo daemon was not touched.

```json
{
  "usageUpdated": {
    "type": "usage_updated",
    "provider": "acp",
    "usage": {
      "contextWindowMaxTokens": 256000,
      "contextWindowUsedTokens": 10501
    },
    "turnId": "dfc1459b-36fc-4863-b46f-42ceb3f1fe0e"
  },
  "turnCompleted": {
    "type": "turn_completed",
    "provider": "acp",
    "usage": {
      "contextWindowMaxTokens": 256000,
      "contextWindowUsedTokens": 10501
    },
    "turnId": "dfc1459b-36fc-4863-b46f-42ceb3f1fe0e"
  }
}
```

Tested on the Linux daemon. macOS, Windows, and Docker daemon builds were not run locally. No UI code or visual output changed, so screenshots are not applicable.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
