### PR TITLE
fix(usage): read Cursor plan usage from cursor-agent auth.json

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -141,6 +141,8 @@ Keep the protocol shape provider-agnostic. Do not add provider-specific renderer
 
 Kimi Code usage follows the CLI-managed credential file at `KIMI_CODE_HOME` or `~/.kimi-code/credentials/kimi-code.json`; do not probe the legacy `~/.kimi` path as the primary source for current Kimi Code installs.
 
+Cursor usage reads the desktop `state.vscdb` token first, then `cursor-agent`'s `~/.config/cursor/auth.json`. Headless hosts only have the CLI file.
+
 ---
 
 ## ACP Provider Checklist

--- a/packages/server/src/services/quota-fetcher/providers/cursor.ts
+++ b/packages/server/src/services/quota-fetcher/providers/cursor.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Logger } from "pino";
@@ -14,11 +15,13 @@ import {
   unavailableUsage,
 } from "../usage.js";
 
-// Cursor stores auth in VS Code's ItemTable (state.vscdb). Modern builds keep the
-// access token as a plain JWT string under `cursorAuth/accessToken`; older builds
+// Cursor desktop stores auth in VS Code's ItemTable (state.vscdb). Modern builds keep
+// the access token as a plain JWT string under `cursorAuth/accessToken`; older builds
 // kept a JSON blob under `cursorAuthStatus`. Read it with node:sqlite so we don't
 // depend on a `sqlite3` CLI, which isn't installed by default on Windows (or on many
 // Linux hosts) — a missing binary silently rendered Cursor usage unavailable.
+// Headless hosts (VPS, cursor-agent only) have no desktop db; their session lives in
+// ~/.config/cursor/auth.json instead.
 const CURSOR_ACCESS_TOKEN_KEY = "cursorAuth/accessToken";
 const CURSOR_LEGACY_AUTH_KEY = "cursorAuthStatus";
 
@@ -157,6 +160,21 @@ async function readCursorTokenFromSqlite(homeDir: string, logger: Logger): Promi
   return null;
 }
 
+async function readCursorTokenFromAuthJson(
+  homeDir: string,
+  logger: Logger,
+): Promise<string | null> {
+  const path = join(homeDir, ".config", "cursor", "auth.json");
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = CursorAuthStatusSchema.parse(JSON.parse(await readFile(path, "utf8")));
+    return parsed.accessToken?.trim() || null;
+  } catch (err) {
+    logger.debug({ err, path }, "Failed to read Cursor token from auth.json");
+    return null;
+  }
+}
+
 export class CursorQuotaProvider implements ProviderUsageFetcher {
   readonly providerId = "cursor";
   readonly displayName = "Cursor";
@@ -175,7 +193,8 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
     const token =
       process.env["CURSOR_ACCESS_TOKEN"] ||
       process.env["CURSOR_TOKEN"] ||
-      (await readCursorTokenFromSqlite(this.homeDir, this.logger));
+      (await readCursorTokenFromSqlite(this.homeDir, this.logger)) ||
+      (await readCursorTokenFromAuthJson(this.homeDir, this.logger));
 
     if (!token) return unavailableUsage(this);
 

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -84,6 +84,12 @@ function writeCursorStateDb(homeDir: string, rows: Record<string, string | Uint8
   db.close();
 }
 
+function writeCursorAuthJson(homeDir: string, accessToken: string): void {
+  const dir = join(homeDir, ".config", "cursor");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "auth.json"), JSON.stringify({ accessToken }));
+}
+
 function writeGrokAuth(home: string, auth: Record<string, unknown>): void {
   mkdirSync(join(home, ".grok"), { recursive: true });
   writeFileSync(join(home, ".grok", "auth.json"), JSON.stringify(auth));
@@ -777,6 +783,52 @@ describe("real provider usage fetchers", () => {
     const cursor = findProvider(await service({ cursorHomeDir: homeDir }).listUsage(), "cursor");
 
     expect(authorization).toBe("Bearer cursor_legacy_jwt");
+    expect(cursor.status).toBe("available");
+  });
+
+  it("reads the Cursor token from cursor-agent ~/.config/cursor/auth.json when desktop state is absent", async () => {
+    writeCursorAuthJson(homeDir, "cursor_cli_jwt");
+    let authorization: string | null = null;
+    fetchApi = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      authorization = (init?.headers as Record<string, string> | undefined)?.Authorization ?? null;
+      return jsonResponse({
+        planUsage: {
+          totalSpend: "1500",
+          includedSpend: "1000",
+          bonusSpend: "500",
+          remaining: "2500",
+          limit: "4000",
+        },
+        billingCycleStart: "2026-01-14T12:42:14.000Z",
+        billingCycleEnd: "2026-02-14T12:42:14.000Z",
+      });
+    }) as unknown as typeof fetch;
+
+    const cursor = findProvider(await service({ cursorHomeDir: homeDir }).listUsage(), "cursor");
+
+    expect(authorization).toBe("Bearer cursor_cli_jwt");
+    expect(cursor).toMatchObject({
+      status: "available",
+      balances: [expect.objectContaining({ id: "plan_usage", used: 15, remaining: 25, limit: 40 })],
+    });
+  });
+
+  it("prefers the desktop state.vscdb token over cursor-agent auth.json", async () => {
+    writeCursorStateDb(homeDir, { "cursorAuth/accessToken": "cursor_desktop_jwt" });
+    writeCursorAuthJson(homeDir, "cursor_cli_jwt");
+    let authorization: string | null = null;
+    fetchApi = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      authorization = (init?.headers as Record<string, string> | undefined)?.Authorization ?? null;
+      return jsonResponse({
+        planUsage: { totalSpend: "0", remaining: "100", limit: "100" },
+        billingCycleStart: null,
+        billingCycleEnd: null,
+      });
+    }) as unknown as typeof fetch;
+
+    const cursor = findProvider(await service({ cursorHomeDir: homeDir }).listUsage(), "cursor");
+
+    expect(authorization).toBe("Bearer cursor_desktop_jwt");
     expect(cursor.status).toBe("available");
   });
 


### PR DESCRIPTION
### Linked issue

Related to #2403 (headless `cursor-agent` token path only; does not close Ultra/included-spend metering).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Settings → Usage stayed unavailable on VPS-style hosts that only have a `cursor-agent` login. The quota fetcher read env tokens and the Cursor desktop `state.vscdb`, never `~/.config/cursor/auth.json`, so it never reached `GetCurrentPeriodUsage`.

This adds that CLI file as a fallback after desktop sqlite, so a signed-in `cursor-agent` can show Plan usage without a desktop install.

### Goals

- Headless hosts with only `~/.config/cursor/auth.json` fetch and display Cursor Plan usage
- Desktop `state.vscdb` still wins when both credential sources exist
- Env `CURSOR_ACCESS_TOKEN` / `CURSOR_TOKEN` unchanged

### Non-goals

- Ultra / Pro+ meter alignment with dashboard percentages (`includedSpend`, `totalPercentUsed`) — still #2403
- Team-seat `GetTeamSpend` fallback — still #2877
- Kitchen-sink work from #2385

### QA

- Targeted tests: `packages/server/src/services/quota-fetcher/service.test.ts` Cursor cases (CLI `auth.json` available; desktop sqlite preferred over CLI)
- Live on a Linux VPS with `cursor-agent` signed in and no Cursor desktop `state.vscdb`:
  1. Ran a checkout-local daemon on `127.0.0.1:6768`
  2. Paired a client to that daemon
  3. Settings → Usage showed Cursor Plan usage (`$19.63 / $20.00 · resets 19d`), matching live `GetCurrentPeriodUsage` `totalSpend`/`limit` (1963¢ / 2000¢)

Not retested: Windows/macOS desktop sqlite path (unchanged except fallback order).

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

Made with [Cursor](https://cursor.com)