### PR TITLE
fix(highlight): highlight Svelte components

### DIFF
--- a/nix/npm-deps.hash
+++ b/nix/npm-deps.hash
@@ -1,1 +1,1 @@
-sha256-Ep6Z+J0urY1L66cXGe9bB6tQr8T3TY73GkLrvhf8FmA=
+sha256-WblXeNn1wUUaxElDGNXHcWdvvHJhqp7LySanhLDv5lQ=

--- a/package-lock.json
+++ b/package-lock.json
@@ -2573,6 +2573,54 @@
         "@lezer/common": "^1.1.0"
       }
     },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.12.tgz",
+      "integrity": "sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.12.4",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
@@ -2594,6 +2642,18 @@
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/search": {
@@ -11166,6 +11226,25 @@
         "@codemirror/view": "^6.0.0",
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@replit/codemirror-lang-svelte": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-lang-svelte/-/codemirror-lang-svelte-6.0.0.tgz",
+      "integrity": "sha512-U2OqqgMM6jKelL0GNWbAmqlu1S078zZNoBqlJBW+retTc5M4Mha6/Y2cf4SVg6ddgloJvmcSpt4hHrVoM4ePRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.1",
+        "@codemirror/lang-html": "^6.2.0",
+        "@codemirror/lang-javascript": "^6.1.1",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/javascript": "^1.2.0",
         "@lezer/lr": "^1.0.0"
       }
     },
@@ -38597,6 +38676,7 @@
         "@lezer/yaml": "^1.0.4",
         "@replit/codemirror-lang-csharp": "^6.2.0",
         "@replit/codemirror-lang-nix": "^6.0.1",
+        "@replit/codemirror-lang-svelte": "^6.0.0",
         "lezer-elixir": "^1.1.2"
       },
       "devDependencies": {

--- a/packages/highlight/package.json
+++ b/packages/highlight/package.json
@@ -47,6 +47,7 @@
     "@lezer/yaml": "^1.0.4",
     "@replit/codemirror-lang-csharp": "^6.2.0",
     "@replit/codemirror-lang-nix": "^6.0.1",
+    "@replit/codemirror-lang-svelte": "^6.0.0",
     "lezer-elixir": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -86,6 +86,38 @@ describe("highlightCode", () => {
     expect(stringToken?.style).toBe("string");
   });
 
+  it("highlights Svelte components across script, markup, and style", () => {
+    const code = [
+      '<script lang="ts">',
+      "  let count: number = 1;",
+      "</script>",
+      "",
+      "{#if count > 0}",
+      '  <span class="badge">{count}</span>',
+      "{/if}",
+      "",
+      "<style>",
+      "  .badge {",
+      "    color: red;",
+      "  }",
+      "</style>",
+    ].join("\n");
+    const result = highlightCode(code, "Counter.svelte");
+
+    expect(result[1].find((t) => t.text === "let")?.style).toBe("keyword");
+    expect(result[1].find((t) => t.text === "number")?.style).toBe("type");
+
+    expect(result[4].find((t) => t.text === "if")?.style).toBe("keyword");
+    expect(result[4].find((t) => t.text === "count")?.style).toBe("variable");
+
+    expect(result[5].find((t) => t.text === "span")?.style).toBe("tag");
+    expect(result[5].find((t) => t.text === "class")?.style).toBe("attribute");
+    expect(result[5].find((t) => t.text === "count")?.style).toBe("variable");
+
+    expect(result[9].find((t) => t.text === "badge")?.style).toBe("class");
+    expect(result[10].find((t) => t.text === "color")?.style).toBe("property");
+  });
+
   it("highlights TSX code with correct dialect", () => {
     const code = 'const el = <div className="test">hello</div>;';
     const result = highlightCode(code, "test.tsx");

--- a/packages/highlight/src/__tests__/parsers.test.ts
+++ b/packages/highlight/src/__tests__/parsers.test.ts
@@ -23,6 +23,7 @@ describe("isLanguageSupported", () => {
     expect(isLanguageSupported("test.cs")).toBe(true);
     expect(isLanguageSupported("test.nix")).toBe(true);
     expect(isLanguageSupported("test.ex")).toBe(true);
+    expect(isLanguageSupported("Counter.svelte")).toBe(true);
   });
 
   it("returns false for unsupported file extensions", () => {
@@ -63,6 +64,7 @@ describe("getSupportedExtensions", () => {
     expect(extensions).toContain("cs");
     expect(extensions).toContain("nix");
     expect(extensions).toContain("json");
+    expect(extensions).toContain("svelte");
   });
 });
 

--- a/packages/highlight/src/parsers.ts
+++ b/packages/highlight/src/parsers.ts
@@ -16,6 +16,7 @@ import { parser as xmlParser } from "@lezer/xml";
 import { parser as yamlParser } from "@lezer/yaml";
 import { csharpLanguage } from "@replit/codemirror-lang-csharp";
 import { nixLanguage } from "@replit/codemirror-lang-nix";
+import { svelteLanguage } from "@replit/codemirror-lang-svelte";
 import { parser as elixirParser } from "lezer-elixir";
 import type { Parser } from "@lezer/common";
 
@@ -49,6 +50,8 @@ const languagesByExtension: Record<string, Language> = {
   // HTML
   html: language(htmlParser),
   htm: language(htmlParser),
+  // Svelte
+  svelte: svelteLanguage,
   // XML
   xml: language(xmlParser),
   // Java

--- a/packages/server/src/server/utils/diff-highlighter.test.ts
+++ b/packages/server/src/server/utils/diff-highlighter.test.ts
@@ -160,6 +160,21 @@ index 1234567..abcdefg 100644
  </config>
 `;
 
+const SVELTE_DIFF = `diff --git a/Counter.svelte b/Counter.svelte
+index 1234567..abcdefg 100644
+--- a/Counter.svelte
++++ b/Counter.svelte
+@@ -1,7 +1,7 @@
+ <script lang="ts">
+-  let count: number = 1;
++  let count: number = 2;
+ </script>
+
+ {#if count > 0}
+   <span class="badge">{count}</span>
+ {/if}
+`;
+
 describe("parseDiff", () => {
   it("parses a simple diff with one hunk", () => {
     const files = parseDiff(SIMPLE_DIFF);
@@ -469,6 +484,33 @@ describe("highlightDiffFromHunks", () => {
     );
     expect(addedLine?.tokens).toBeDefined();
     expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+  });
+
+  it("adds syntax highlighting tokens to Svelte components", () => {
+    const files = parseDiff(SVELTE_DIFF);
+    const highlighted = highlightDiffFromHunks(files[0]);
+    const hunk = highlighted.hunks[0];
+
+    const scriptLine = hunk.lines[1];
+    expect(scriptLine.tokens).toBeDefined();
+    expect(scriptLine.tokens!.some((t) => t.text === "script" && t.style === "tag")).toBe(true);
+
+    const addedLine = hunk.lines.find(
+      (line) => line.type === "add" && line.content.includes("count"),
+    );
+    expect(addedLine?.tokens).toBeDefined();
+    expect(addedLine!.tokens!.some((t) => t.text === "let" && t.style === "keyword")).toBe(true);
+    expect(addedLine!.tokens!.some((t) => t.text === "number" && t.style === "type")).toBe(true);
+    expect(addedLine!.tokens!.some((t) => t.text === "2" && t.style === "number")).toBe(true);
+
+    const blockLine = hunk.lines.find((line) => line.content.includes("{#if"));
+    expect(blockLine?.tokens).toBeDefined();
+    expect(blockLine!.tokens!.some((t) => t.text === "if" && t.style === "keyword")).toBe(true);
+    expect(blockLine!.tokens!.some((t) => t.text === "count" && t.style === "variable")).toBe(true);
+
+    const markupLine = hunk.lines.find((line) => line.content.includes("<span"));
+    expect(markupLine?.tokens).toBeDefined();
+    expect(markupLine!.tokens!.some((t) => t.text === "span" && t.style === "tag")).toBe(true);
   });
 
   it("adds syntax highlighting tokens to Objective-C file extensions", () => {


### PR DESCRIPTION
Fixes #3364.

`.svelte` had no entry in the extension table in `packages/highlight/src/parsers.ts`, so `highlightCode` fell through to one unstyled token per line. Everything that resolves a language by extension goes through that table (the file pane, the daemon's diff highlighter, markdown fences and the web editor), which is why a component reads as plain text when you review it.

## What I changed

Registered `@replit/codemirror-lang-svelte` as `svelte`. Its `svelteLanguage` already wires the mixed parsing for `<script>` and `<style>`, so all three regions of a component get roles. It comes from the same publisher as the `@replit/codemirror-lang-csharp` entry already in this package, it is MIT, and only the grammar itself is declared: its CodeMirror peers resolve the same way the C# grammar's peers already do, so `package.json` grows by one line.

The production diff is 7 lines: one import, one table entry, one dependency. The rest is tests.

## Why this grammar

I measured four options on a real component (TS script with runes, markup with directives and mustaches, a style block), counting the share of non-whitespace characters that get a syntax role, per region:

| option | overall | script | markup | style |
| --- | --- | --- | --- | --- |
| today, no entry | 0% | 0% | 0% | 0% |
| `@lezer/html` bare | 22.3% | 7.2% | 44.5% | 15.8% |
| `@lezer/html` + `parseMixed` into JS/CSS | 78.5% | 99.4% | 44.5% | 96.8% |
| `@replit` `svelteParser` (bare) | 30.0% | 7.2% | 65.0% | 15.8% |
| `@replit` `svelteLanguage.parser` | 97.5% | 99.4% | 95.3% | 96.8% |

The hand-rolled mixed parser over `@lezer/html` needs no new dependency, and that is the one I wanted to land, but it leaves every `{#if}`, `{#each}` and `{expr}` in the template unstyled, so the template is exactly where it fails. Note the bare `svelteParser` export is the wrong one to reach for: only `svelteLanguage.parser` carries the script and style nesting.

## Known limitation

The grammar was published in 2022, so it predates Svelte 5's `{#snippet}` and `{@render}`. Those two block keywords stay unstyled. They produce no error nodes and the damage does not cascade: markup inside a snippet highlights normally. I checked the rest of the modern surface and it holds up, including `{@const}`, `{@html}`, `{#key}`, `{#await}`/`{:then}`/`{:catch}`, lowercase event attributes, and runes in the script (to the parser the script is plain TS).

```
snippet      coverage  40%  errorNodes   0
awaitBlock   coverage  93%  errorNodes   0
keyBlock     coverage 100%  errorNodes   0
constBlock   coverage 100%  errorNodes   0
html         coverage 100%  errorNodes   0
eventAttr    coverage  97%  errorNodes   0
runesScript  coverage 100%  errorNodes   0
```

## QA

### Tests fail on the old code for the reported reason

Both new tests, with the registry entry reverted and `@getpaseo/highlight` rebuilt:

```
$ npx vitest run packages/server/src/server/utils/diff-highlighter.test.ts packages/highlight/src/__tests__/ -t "Svelte"
 × highlights Svelte components across script, markup, and style 8ms
 × adds syntax highlighting tokens to Svelte components 11ms
AssertionError: expected undefined to be 'keyword'
AssertionError: expected undefined to be defined
 Test Files  2 failed | 3 skipped (5)
      Tests  2 failed | 95 skipped (97)
```

The failure is the bug itself: with no entry for the extension there is no `let` token at all, because the whole line is one unstyled token.

### Tests with the fix

```
$ npx vitest run packages/server/src/server/utils/diff-highlighter.test.ts packages/highlight/src/__tests__/
 Test Files  5 passed (5)
      Tests  97 passed (97)

$ npx vitest run packages/app/src/utils/diff-highlight.test.ts packages/app/src/utils/highlight-cache.test.ts
 Test Files  2 passed (2)
      Tests  13 passed (13)

$ npm run typecheck
exit=0, 0 errors
```

The new coverage is in two places on purpose. `packages/highlight` asserts the roles per region (script keyword and type, template block keyword and mustache variable, markup tag and attribute, CSS class and property). `packages/server` asserts the same thing through `highlightDiffFromHunks`, because the review surface in the issue is the diff and the daemon is what tokenizes it.

### Before and after in the app

Real daemon (`npm run dev:server` with `PASEO_WEB_UI_ENABLED=true`) and the bundled web UI in Chromium, same workspace, same file, same window state. The only difference between the two runs is the registry entry, with `@getpaseo/highlight` rebuilt and the daemon restarted in between, since the diff tokens come from the daemon.

Before:

![before](https://raw.githubusercontent.com/fiorelorenzo/paseo/qa-evidence-svelte/qa/before-svelte-diff-plain.png)

After:

![after](https://raw.githubusercontent.com/fiorelorenzo/paseo/qa-evidence-svelte/qa/after-svelte-diff-highlighted.png)

### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | no | |
| Android | no | |
| Web | yes | bundled daemon web UI in Chromium on Linux, screenshots above |
| Desktop macOS | no | |
| Desktop Windows | no | |
| Desktop Linux | daemon only | daemon-side diff highlighting, which is where the tokens in the screenshots come from |

I only have Linux here. The change is a table entry consumed by pure JS tokenizing, with no platform-gated code and no native module, so I would expect it to behave the same everywhere the same daemon and bundle run, but I have not put eyes on it outside the web client.

I did not visually confirm the file preview pane, the markdown fence path or the CodeMirror editor. They resolve through the same table (`highlight-cache.ts`, `diff-highlight.ts`, `getLanguageForFile` in `view.web.tsx`), and the unit tests cover the table, but that is code reading and not a screenshot.
