### PR TITLE
fix(server): map Paseo yolo mode to Kimi auto

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -4085,4 +4085,270 @@ describe("KimiACPAgentClient", () => {
     expect(setSessionConfigOption).not.toHaveBeenCalled();
     expect(internals.currentMode).toBe("yolo");
   });
+
+  test("keeps yolo logical mode when Kimi echoes auto through config_option_update", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "yolo",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeMapper: mapKimiPaseoToProviderMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<
+      ACPConfiguredOverrideInternals & {
+        providerCurrentMode: string | null;
+        translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
+      }
+    >(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "plan", label: "Plan" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = "yolo";
+    internals.providerCurrentMode = "auto";
+
+    const events = internals.translateSessionUpdate({
+      sessionUpdate: "config_option_update",
+      configOptions: [selectConfigOption("mode", ["plan", "yolo", "auto"], "auto")],
+    });
+
+    expect(events).toMatchObject([{ type: "mode_changed", currentModeId: "yolo" }]);
+    expect(internals.currentMode).toBe("yolo");
+    expect(internals.providerCurrentMode).toBe("auto");
+  });
+
+  test("keeps a genuine Paseo auto selection as auto through config_option_update", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "auto",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeMapper: mapKimiPaseoToProviderMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<
+      ACPConfiguredOverrideInternals & {
+        providerCurrentMode: string | null;
+        translateSessionUpdate(update: SessionUpdate): AgentStreamEvent[];
+      }
+    >(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "plan", label: "Plan" },
+      { id: "auto", label: "Auto" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = "auto";
+    internals.providerCurrentMode = "auto";
+
+    const events = internals.translateSessionUpdate({
+      sessionUpdate: "config_option_update",
+      configOptions: [selectConfigOption("mode", ["plan", "yolo", "auto"], "auto")],
+    });
+
+    expect(events).toMatchObject([{ type: "mode_changed", currentModeId: "auto" }]);
+    expect(internals.currentMode).toBe("auto");
+    expect(internals.providerCurrentMode).toBe("auto");
+  });
+
+  test("switches from yolo to plan and back", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeMapper: mapKimiPaseoToProviderMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "plan", label: "Plan" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = "yolo";
+
+    await session.setMode("plan");
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "plan" });
+    expect(internals.currentMode).toBe("plan");
+
+    setSessionMode.mockClear();
+
+    await session.setMode("yolo");
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto" });
+    expect(internals.currentMode).toBe("yolo");
+  });
+
+  test("does not affect generic ACP providers without Kimi mapping", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "custom-acp",
+        cwd: "/tmp/paseo-acp-test",
+      },
+      {
+        provider: "custom-acp",
+        logger: createTestLogger(),
+        defaultCommand: ["acp-agent"],
+        defaultModes: [
+          { id: "yolo", label: "YOLO" },
+          { id: "plan", label: "Plan" },
+        ],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "yolo", label: "YOLO" },
+      { id: "plan", label: "Plan" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = "plan";
+
+    await session.setMode("yolo");
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "yolo" });
+    expect(internals.currentMode).toBe("yolo");
+  });
+
+  test("resumes yolo session and sends auto to Kimi", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "yolo",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeMapper: mapKimiPaseoToProviderMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<
+      ACPConfiguredOverrideInternals & { applySessionState(response: SessionStateResponse): void }
+    >(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+
+    internals.applySessionState({
+      sessionId: "session-1",
+      configOptions: [],
+      modes: {
+        currentModeId: "yolo",
+        availableModes: [
+          { id: "yolo", name: "YOLO" },
+          { id: "auto", name: "Auto" },
+          { id: "plan", name: "Plan" },
+        ],
+      },
+    });
+
+    await internals.applyConfiguredOverrides();
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto" });
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+    expect(internals.currentMode).toBe("yolo");
+  });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -42,7 +42,11 @@ import {
   writeCopilotProviderMode,
 } from "./copilot-acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
-import { kimiProviderToPaseoMode, writeKimiMode } from "./kimi-acp-agent.js";
+import {
+  kimiProviderToPaseoMode,
+  mapKimiPaseoToProviderMode,
+  writeKimiMode,
+} from "./kimi-acp-agent.js";
 import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
@@ -3977,5 +3981,108 @@ describe("KimiACPAgentClient", () => {
   test("does not map an unknown provider mode to yolo", () => {
     expect(kimiProviderToPaseoMode("manual", "yolo")).toBe("manual");
     expect(kimiProviderToPaseoMode("unknown", "yolo")).toBe("unknown");
+  });
+
+  test("preserves available modes when selecting Paseo yolo for Kimi", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    const initialModes = [
+      { id: "plan", label: "Plan" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.availableModes = initialModes;
+    internals.configOptions = [];
+    internals.currentMode = "plan";
+
+    await session.setMode("yolo");
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto" });
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+    expect(internals.currentMode).toBe("yolo");
+    expect(internals.availableModes).toEqual(initialModes);
+  });
+
+  test("sends auto when Kimi starts in provider yolo but user configured Paseo yolo", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "yolo",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeMapper: mapKimiPaseoToProviderMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<
+      ACPConfiguredOverrideInternals & { applySessionState(response: SessionStateResponse): void }
+    >(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+
+    internals.applySessionState({
+      sessionId: "session-1",
+      configOptions: [],
+      modes: {
+        currentModeId: "yolo",
+        availableModes: [
+          { id: "yolo", name: "YOLO" },
+          { id: "auto", name: "Auto" },
+          { id: "plan", name: "Plan" },
+        ],
+      },
+    });
+
+    await internals.applyConfiguredOverrides();
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto" });
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+    expect(internals.currentMode).toBe("yolo");
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -42,6 +42,7 @@ import {
   writeCopilotProviderMode,
 } from "./copilot-acp-agent.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
+import { kimiProviderToPaseoMode, writeKimiMode } from "./kimi-acp-agent.js";
 import { parseKiroExtensionCommands } from "./kiro-acp-agent.js";
 import { transformPiModels } from "./pi/agent.js";
 import type { AgentStreamEvent } from "../agent-sdk-types.js";
@@ -3772,5 +3773,209 @@ describe("ACP session/load invariant — cwd and mcpServers always passed", () =
       cwd: "/tmp/paseo-acp-test",
       mcpServers: [],
     });
+  });
+});
+
+describe("KimiACPAgentClient", () => {
+  test("maps Paseo yolo mode to Kimi auto mode and reports yolo to Paseo", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "yolo",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "plan", label: "Plan" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = null;
+
+    await internals.applyConfiguredOverrides();
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto" });
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+    await expect(session.getCurrentMode()).resolves.toBe("yolo");
+  });
+
+  test("leaves plan mode unchanged", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "plan",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "plan", label: "Plan" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = null;
+
+    await internals.applyConfiguredOverrides();
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "plan" });
+    await expect(session.getCurrentMode()).resolves.toBe("plan");
+  });
+
+  test("keeps a genuine Paseo auto selection as auto when Kimi reports auto", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "auto",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "plan", label: "Plan" },
+      { id: "auto", label: "Auto" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = null;
+
+    await internals.applyConfiguredOverrides();
+
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto" });
+    await expect(session.getCurrentMode()).resolves.toBe("auto");
+
+    // Simulate Kimi echoing the effective mode back in a current_mode_update.
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: { sessionUpdate: "current_mode_update", currentModeId: "auto" },
+    });
+
+    await expect(session.getCurrentMode()).resolves.toBe("auto");
+  });
+
+  test("maps provider auto back to yolo only when Paseo requested yolo", async () => {
+    const session = new ACPAgentSession(
+      {
+        provider: "kimi",
+        cwd: "/tmp/paseo-acp-test",
+        modeId: "yolo",
+      },
+      {
+        provider: "kimi",
+        logger: createTestLogger(),
+        defaultCommand: ["kimi", "acp"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+        modeIdTransformer: kimiProviderToPaseoMode,
+        providerModeWriter: writeKimiMode,
+      },
+    );
+
+    const setSessionMode = vi.fn(async () => undefined);
+    const setSessionConfigOption = vi.fn(async () => ({
+      configOptions: [],
+    }));
+    const internals = asInternals<ACPConfiguredOverrideInternals>(session);
+    internals.sessionId = "session-1";
+    internals.connection = { setSessionMode, setSessionConfigOption };
+    internals.availableModes = [
+      { id: "plan", label: "Plan" },
+      { id: "yolo", label: "YOLO" },
+    ];
+    internals.configOptions = [];
+    internals.currentMode = null;
+
+    await internals.applyConfiguredOverrides();
+    expect(setSessionMode).toHaveBeenCalledWith({ sessionId: "session-1", modeId: "auto" });
+    await expect(session.getCurrentMode()).resolves.toBe("yolo");
+
+    // Kimi confirms the effective auto mode.
+    await session.sessionUpdate({
+      sessionId: "session-1",
+      update: { sessionUpdate: "current_mode_update", currentModeId: "auto" },
+    });
+
+    await expect(session.getCurrentMode()).resolves.toBe("yolo");
+  });
+
+  test("does not map an unknown provider mode to yolo", () => {
+    expect(kimiProviderToPaseoMode("manual", "yolo")).toBe("manual");
+    expect(kimiProviderToPaseoMode("unknown", "yolo")).toBe("unknown");
   });
 });

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2834,7 +2834,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     const nextThinkingOptionId = deriveCurrentConfigValue(this.configOptions, "thought_level");
 
     this.availableModes = modeInfo.modes;
-    this.currentMode = nextMode ?? this.currentMode;
+    this.currentMode = this.transformModeId(nextMode, this.currentMode) ?? this.currentMode;
     this.providerCurrentMode =
       this.currentMode !== null && this.providerModeMapper
         ? this.providerModeMapper(this.currentMode)

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -420,6 +420,7 @@ interface ACPAgentClientOptions {
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string, currentModeId?: string | null) => string | null;
+  providerModeMapper?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -450,6 +451,7 @@ interface ACPAgentSessionOptions {
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   modeIdTransformer?: (modeId: string, currentModeId?: string | null) => string | null;
+  providerModeMapper?: (modeId: string) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -810,6 +812,7 @@ export class ACPAgentClient implements AgentClient {
     modeId: string,
     currentModeId?: string | null,
   ) => string | null;
+  private readonly providerModeMapper?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -846,6 +849,7 @@ export class ACPAgentClient implements AgentClient {
     this.clientCapabilities = options.clientCapabilities;
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
+    this.providerModeMapper = options.providerModeMapper;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
@@ -875,6 +879,7 @@ export class ACPAgentClient implements AgentClient {
         clientCapabilities: this.clientCapabilities,
         clientCapabilityMeta: this.clientCapabilityMeta,
         modeIdTransformer: this.modeIdTransformer,
+        providerModeMapper: this.providerModeMapper,
         toolSnapshotTransformer: this.toolSnapshotTransformer,
         providerModeWriter: this.providerModeWriter,
         beforeModeWriter: this.beforeModeWriter,
@@ -925,6 +930,7 @@ export class ACPAgentClient implements AgentClient {
       clientCapabilities: this.clientCapabilities,
       clientCapabilityMeta: this.clientCapabilityMeta,
       modeIdTransformer: this.modeIdTransformer,
+      providerModeMapper: this.providerModeMapper,
       toolSnapshotTransformer: this.toolSnapshotTransformer,
       providerModeWriter: this.providerModeWriter,
       beforeModeWriter: this.beforeModeWriter,
@@ -1418,6 +1424,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     modeId: string,
     currentModeId?: string | null,
   ) => string | null;
+  private readonly providerModeMapper?: (modeId: string) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -1447,6 +1454,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private agentCapabilities: ACPAgentCapabilities | null = null;
   private sessionId: string | null = null;
   private currentMode: string | null = null;
+  private providerCurrentMode: string | null = null;
   private availableModes: AgentMode[];
   private currentModel: string | null = null;
   private availableModels: AvailableACPModel[] | null = null;
@@ -1484,11 +1492,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.clientCapabilities = options.clientCapabilities;
     this.clientCapabilityMeta = options.clientCapabilityMeta;
     this.modeIdTransformer = options.modeIdTransformer;
+    this.providerModeMapper = options.providerModeMapper;
     this.toolSnapshotTransformer = options.toolSnapshotTransformer;
     this.providerModeWriter = options.providerModeWriter;
     this.beforeModeWriter = options.beforeModeWriter;
     this.thinkingOptionWriter = options.thinkingOptionWriter;
     this.availableModes = options.defaultModes;
+    this.providerCurrentMode = null;
     this.agentId = options.agentId;
     this.launchEnv = options.launchEnv;
     this.initialHandle = options.handle;
@@ -1792,10 +1802,14 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       : { handled: false };
     if (providerResult.handled) {
       this.currentMode = providerResult.currentModeId ?? modeId;
-      if (providerResult.configOptions) {
+      if (providerResult.configOptions !== undefined) {
         this.configOptions = this.transformConfigOptions(providerResult.configOptions);
+        this.availableModes = deriveModesFromACP(this.defaultModes, null, this.configOptions).modes;
       }
-      this.availableModes = deriveModesFromACP(this.defaultModes, null, this.configOptions).modes;
+      this.providerCurrentMode =
+        this.currentMode !== null && this.providerModeMapper
+          ? this.providerModeMapper(this.currentMode)
+          : this.currentMode;
       this.pushEvent({
         type: "mode_changed",
         provider: this.provider,
@@ -2564,6 +2578,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     const modeInfo = deriveModesFromACP(this.defaultModes, transformed.modes, this.configOptions);
     this.availableModes = modeInfo.modes;
+    this.providerCurrentMode = modeInfo.currentModeId;
     this.currentMode = this.transformModeId(
       modeInfo.currentModeId ?? this.currentMode,
       this.config.modeId ?? this.currentMode,
@@ -2589,13 +2604,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
   private async applyConfiguredOverrides(): Promise<void> {
     const configuredModeId = this.config.modeId;
-    if (configuredModeId && configuredModeId !== this.currentMode) {
-      const selection = resolveACPModeSelection({
-        modeId: configuredModeId,
-        availableModes: this.availableModes,
-        configOptions: this.configOptions,
-      });
-      await this.setModeWithSelection({ modeId: configuredModeId, selection });
+    if (configuredModeId) {
+      const shouldApply = this.providerModeMapper
+        ? this.providerModeMapper(configuredModeId) !== this.providerCurrentMode
+        : configuredModeId !== this.currentMode;
+      if (shouldApply) {
+        const selection = resolveACPModeSelection({
+          modeId: configuredModeId,
+          availableModes: this.availableModes,
+          configOptions: this.configOptions,
+        });
+        await this.setModeWithSelection({ modeId: configuredModeId, selection });
+      }
     }
     const configuredModelId = this.config.model;
     if (configuredModelId && configuredModelId !== this.currentModel) {
@@ -2802,6 +2822,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private handleCurrentModeUpdate(update: CurrentModeUpdate): void {
+    this.providerCurrentMode = update.currentModeId;
     this.currentMode = this.transformModeId(update.currentModeId, this.currentMode);
   }
 
@@ -2814,6 +2835,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     this.availableModes = modeInfo.modes;
     this.currentMode = nextMode ?? this.currentMode;
+    this.providerCurrentMode =
+      this.currentMode !== null && this.providerModeMapper
+        ? this.providerModeMapper(this.currentMode)
+        : this.currentMode;
     this.currentModel = nextModel ?? this.currentModel;
     this.thinkingOptionId = nextThinkingOptionId ?? this.thinkingOptionId;
 

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -419,7 +419,7 @@ interface ACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
-  modeIdTransformer?: (modeId: string) => string | null;
+  modeIdTransformer?: (modeId: string, currentModeId?: string | null) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -449,7 +449,7 @@ interface ACPAgentSessionOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   clientCapabilities?: ACPClientCapabilities;
   clientCapabilityMeta?: ACPClientCapabilityMeta;
-  modeIdTransformer?: (modeId: string) => string | null;
+  modeIdTransformer?: (modeId: string, currentModeId?: string | null) => string | null;
   toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -806,7 +806,10 @@ export class ACPAgentClient implements AgentClient {
   private readonly configFeatureOptions: ACPConfigFeatureOption[];
   private readonly clientCapabilities?: ACPClientCapabilities;
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
-  private readonly modeIdTransformer?: (modeId: string) => string | null;
+  private readonly modeIdTransformer?: (
+    modeId: string,
+    currentModeId?: string | null,
+  ) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -1411,7 +1414,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly configFeatureOptions: ACPConfigFeatureOption[];
   private readonly clientCapabilities?: ACPClientCapabilities;
   private readonly clientCapabilityMeta?: ACPClientCapabilityMeta;
-  private readonly modeIdTransformer?: (modeId: string) => string | null;
+  private readonly modeIdTransformer?: (
+    modeId: string,
+    currentModeId?: string | null,
+  ) => string | null;
   private readonly toolSnapshotTransformer?: (snapshot: ACPToolSnapshot) => ACPToolSnapshot;
   private readonly providerModeWriter?: (
     context: ACPProviderModeWriterContext,
@@ -2558,7 +2564,10 @@ export class ACPAgentSession implements AgentSession, ACPClient {
 
     const modeInfo = deriveModesFromACP(this.defaultModes, transformed.modes, this.configOptions);
     this.availableModes = modeInfo.modes;
-    this.currentMode = modeInfo.currentModeId ?? this.currentMode;
+    this.currentMode = this.transformModeId(
+      modeInfo.currentModeId ?? this.currentMode,
+      this.config.modeId ?? this.currentMode,
+    );
 
     this.availableModels = transformed.models?.availableModels ?? null;
     this.currentModel =
@@ -2573,8 +2582,9 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       : configOptions;
   }
 
-  private transformModeId(modeId: string): string | null {
-    return this.modeIdTransformer ? this.modeIdTransformer(modeId) : modeId;
+  private transformModeId(modeId: string | null, currentModeId?: string | null): string | null {
+    if (modeId === null) return null;
+    return this.modeIdTransformer ? this.modeIdTransformer(modeId, currentModeId) : modeId;
   }
 
   private async applyConfiguredOverrides(): Promise<void> {
@@ -2792,7 +2802,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private handleCurrentModeUpdate(update: CurrentModeUpdate): void {
-    this.currentMode = this.transformModeId(update.currentModeId);
+    this.currentMode = this.transformModeId(update.currentModeId, this.currentMode);
   }
 
   private handleConfigOptionUpdate(update: ConfigOptionUpdate): AgentStreamEvent[] {

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -10,6 +10,8 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPProviderModeWriteResult,
+  type ACPProviderModeWriterContext,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -51,6 +53,10 @@ interface GenericACPAgentClientOptions {
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
+  modeIdTransformer?: (modeId: string, currentModeId?: string | null) => string | null;
+  providerModeWriter?: (
+    context: ACPProviderModeWriterContext,
+  ) => Promise<ACPProviderModeWriteResult>;
 }
 
 export class GenericACPAgentClient extends ACPAgentClient {
@@ -76,6 +82,8 @@ export class GenericACPAgentClient extends ACPAgentClient {
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
+      modeIdTransformer: options.modeIdTransformer,
+      providerModeWriter: options.providerModeWriter,
     });
 
     this.command = options.command;

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -54,6 +54,7 @@ interface GenericACPAgentClientOptions {
   extensionCommandsParser?: ACPExtensionCommandsParser;
   catalogModelResolver?: ACPCatalogModelResolver;
   modeIdTransformer?: (modeId: string, currentModeId?: string | null) => string | null;
+  providerModeMapper?: (modeId: string) => string | null;
   providerModeWriter?: (
     context: ACPProviderModeWriterContext,
   ) => Promise<ACPProviderModeWriteResult>;
@@ -83,6 +84,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       extensionCommandsParser: options.extensionCommandsParser,
       catalogModelResolver: options.catalogModelResolver,
       modeIdTransformer: options.modeIdTransformer,
+      providerModeMapper: options.providerModeMapper,
       providerModeWriter: options.providerModeWriter,
     });
 

--- a/packages/server/src/server/agent/providers/kimi-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/kimi-acp-agent.ts
@@ -5,6 +5,8 @@ import {
   type ACPCatalogModelResolverContext,
   deriveSelectorOptions,
   findSelectConfigOption,
+  type ACPProviderModeWriteResult,
+  type ACPProviderModeWriterContext,
 } from "./acp-agent.js";
 import { toDiagnosticErrorMessage } from "./diagnostic-utils.js";
 import { GenericACPAgentClient } from "./generic-acp-agent.js";
@@ -82,16 +84,75 @@ export async function resolveKimiCatalogModels({
   return resolved;
 }
 
+// Kimi exposes three internal permission modes: yolo, manual, auto.
+// The Kimi "yolo" mode auto-approves tool calls but still allows the
+// model to ask questions. The "auto" mode is the truly autonomous mode
+// that prevents operator questions. Paseo's "yolo" mode means "no
+// operator questions for pre-approved work", so we map it to Kimi
+// "auto".
+const KIMI_PASEO_TO_PROVIDER_MODE: Record<string, string> = {
+  yolo: "auto",
+  auto: "auto",
+  plan: "plan",
+};
+
+// Map a Kimi-reported mode id back to the Paseo UI mode id.
+//
+// The only non-identity mapping is the auto → yolo echo: when the user
+// selects Paseo "yolo" we send Kimi "auto", and Kimi later echoes "auto" in
+// current_mode_update. In that case we keep showing "yolo" to the user. For
+// every other combination we preserve the provider's own id, so a genuine
+// Paseo "auto" selection (which also maps to Kimi "auto") stays "auto" in
+// the UI instead of being falsely renamed to "yolo".
+export function kimiProviderToPaseoMode(
+  providerModeId: string,
+  currentPaseoModeId: string | null | undefined,
+): string | null {
+  if (providerModeId === "auto" && currentPaseoModeId === "yolo") {
+    return "yolo";
+  }
+  if (providerModeId === "yolo" || providerModeId === "auto" || providerModeId === "plan") {
+    return providerModeId;
+  }
+  return providerModeId;
+}
+
 export class KimiACPAgentClient extends GenericACPAgentClient {
   constructor(options: KimiACPAgentClientOptions) {
     super({
-      logger: options.logger,
-      command: options.command,
-      env: options.env,
-      providerId: options.providerId,
-      label: options.label,
-      providerParams: options.providerParams,
+      ...options,
       catalogModelResolver: resolveKimiCatalogModels,
+      modeIdTransformer: (providerModeId, currentModeId) =>
+        kimiProviderToPaseoMode(providerModeId, currentModeId),
+      providerModeWriter: (context) => writeKimiMode(context),
     });
   }
+}
+
+export async function writeKimiMode(
+  context: ACPProviderModeWriterContext,
+): Promise<ACPProviderModeWriteResult> {
+  const providerModeId = KIMI_PASEO_TO_PROVIDER_MODE[context.requestedModeId];
+  if (!providerModeId) {
+    return { handled: false };
+  }
+
+  // If the provider already exposes this mode under the same id, let the
+  // default ACP path handle the switch so we do not bypass any config-option
+  // bookkeeping unnecessarily.
+  if (
+    context.selection.availableMode?.id === providerModeId ||
+    context.selection.configChoice?.value === providerModeId
+  ) {
+    return { handled: false };
+  }
+
+  await context.connection.setSessionMode({
+    sessionId: context.sessionId,
+    modeId: providerModeId,
+  });
+
+  // Report the Paseo mode id back so the UI stays aligned with the user's
+  // selection, even though Kimi is operating in a different internal mode.
+  return { handled: true, currentModeId: context.requestedModeId };
 }

--- a/packages/server/src/server/agent/providers/kimi-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/kimi-acp-agent.ts
@@ -96,6 +96,12 @@ const KIMI_PASEO_TO_PROVIDER_MODE: Record<string, string> = {
   plan: "plan",
 };
 
+// Map a Paseo UI mode id to the provider mode id that Kimi will actually
+// receive over ACP. Paseo "yolo" and "auto" both map to Kimi "auto".
+export function mapKimiPaseoToProviderMode(paseoModeId: string): string | null {
+  return KIMI_PASEO_TO_PROVIDER_MODE[paseoModeId] ?? null;
+}
+
 // Map a Kimi-reported mode id back to the Paseo UI mode id.
 //
 // The only non-identity mapping is the auto → yolo echo: when the user
@@ -124,6 +130,7 @@ export class KimiACPAgentClient extends GenericACPAgentClient {
       catalogModelResolver: resolveKimiCatalogModels,
       modeIdTransformer: (providerModeId, currentModeId) =>
         kimiProviderToPaseoMode(providerModeId, currentModeId),
+      providerModeMapper: (paseoModeId) => mapKimiPaseoToProviderMode(paseoModeId),
       providerModeWriter: (context) => writeKimiMode(context),
     });
   }


### PR DESCRIPTION
### Linked issue

N/A — this is a standalone server-side fix.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Kimi exposes three permission modes: `yolo`, `manual`, and `auto`.
The Kimi `yolo` mode auto-approves tool calls but still allows the model to ask the operator questions. Paseo's `yolo` mode means "no operator questions for pre-approved work", so a user selecting Paseo `yolo` for Kimi was not getting true autonomy: the session could still pause on `AskUserQuestion` / approval forms.

This change maps Paseo `yolo` to Kimi `auto` on the way out, and preserves the logical Paseo mode on the way back. When Kimi later echoes `auto` in a `current_mode_update`, we only translate it back to Paseo `yolo` if the user actually selected Paseo `yolo`. A genuine Paseo `auto` selection (which also maps to Kimi `auto`) therefore stays `auto` in the UI instead of being falsely renamed to `yolo`.

### Goals

- Make Paseo `yolo` mode behave truly autonomously for Kimi sessions.
- Keep Paseo `auto` mode displayed correctly as `auto` when Kimi reports `auto`.
- Add regression coverage for both the forward (`yolo -> auto`) and reverse (`auto -> yolo`, conditional) mapping.

### Non-goals

- No unrelated refactors or changes to other ACP providers.
- No changes to `provider-registry.ts`; `KimiACPAgentClient` is already registered there in the current base.

### QA

- Reproduced the conceptual mismatch from the Kimi mode definitions and existing ACP mode handling.
- Verified the fix with `packages/server/src/server/agent/providers/acp-agent.test.ts` — 101 tests passed.
- Ran `npm run typecheck --workspace=@getpaseo/server` — passed.
- Ran `npm run lint` on the changed files — 0 warnings, 0 errors.
- Ran `npm run format:check:files` on the changed files — all formatted.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
