### PR TITLE
fix(cli): keep streamed message fragments together in logs --follow

### DIFF
--- a/packages/cli/src/commands/agent/logs.test.ts
+++ b/packages/cli/src/commands/agent/logs.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
+import { createFollowTranscriptWriter, formatAgentActivityTranscript } from "./logs.js";
+
+function collect(items: readonly AgentTimelineItem[], turnId?: string): string {
+  let output = "";
+  const writer = createFollowTranscriptWriter((chunk) => {
+    output += chunk;
+  });
+  for (const item of items) {
+    writer.push(item, turnId);
+  }
+  writer.end();
+  return output;
+}
+
+describe("createFollowTranscriptWriter", () => {
+  it("keeps a word that arrives split across fragments intact", () => {
+    const output = collect([
+      { type: "assistant_message", text: "the paseo-pr", messageId: "msg_1" },
+      { type: "assistant_message", text: "-cycle label\n", messageId: "msg_1" },
+    ]);
+
+    expect(output).toBe("the paseo-pr-cycle label\n");
+  });
+
+  it("streams text as it arrives without inventing a line break", () => {
+    const chunks: string[] = [];
+    const writer = createFollowTranscriptWriter((chunk) => {
+      chunks.push(chunk);
+    });
+
+    writer.push({ type: "assistant_message", text: "first line", messageId: "msg_1" });
+    expect(chunks.join("")).toBe("first line");
+
+    writer.push({ type: "assistant_message", text: "\nsecond", messageId: "msg_1" });
+    expect(chunks.join("")).toBe("first line\nsecond");
+
+    writer.push({ type: "assistant_message", text: " line\n", messageId: "msg_1" });
+    expect(chunks.join("")).toBe("first line\nsecond line");
+
+    writer.end();
+    expect(chunks.join("")).toBe("first line\nsecond line\n");
+  });
+
+  it("emits the same transcript the one-shot command prints for the same items", () => {
+    const items: AgentTimelineItem[] = [
+      { type: "assistant_message", text: "Plan for paseo-pr", messageId: "msg_1" },
+      { type: "assistant_message", text: "-cycle:\n- build\n- test\n", messageId: "msg_1" },
+      { type: "error", message: "boom" },
+      { type: "assistant_message", text: "done", messageId: "msg_2" },
+    ];
+
+    expect(collect(items).trimEnd()).toBe(formatAgentActivityTranscript(items));
+  });
+
+  it("starts a new message when the messageId changes", () => {
+    const output = collect([
+      { type: "assistant_message", text: "first", messageId: "msg_1" },
+      { type: "assistant_message", text: "second", messageId: "msg_2" },
+    ]);
+
+    expect(output).toBe("first\nsecond\n");
+  });
+
+  it("does not merge fragments across turns", () => {
+    let output = "";
+    const writer = createFollowTranscriptWriter((chunk) => {
+      output += chunk;
+    });
+
+    writer.push({ type: "assistant_message", text: "first" }, "turn_1");
+    writer.push({ type: "assistant_message", text: "second" }, "turn_2");
+    writer.end();
+
+    expect(output).toBe("first\nsecond\n");
+  });
+
+  it("prints the thought prefix once for a merged reasoning stream", () => {
+    const output = collect([
+      { type: "reasoning", text: "checking the" },
+      { type: "reasoning", text: " lockfile\nthen the build\n" },
+    ]);
+
+    expect(output).toBe("[Thought] checking the lockfile\nthen the build\n");
+  });
+
+  it("keeps interior blank lines and drops trailing whitespace", () => {
+    const output = collect([
+      { type: "assistant_message", text: "  # Title\n\nBody\n\n  ", messageId: "msg_1" },
+    ]);
+
+    expect(output).toBe("# Title\n\nBody\n");
+  });
+});

--- a/packages/cli/src/commands/agent/logs.ts
+++ b/packages/cli/src/commands/agent/logs.ts
@@ -53,6 +53,129 @@ export function formatAgentActivityTranscript(
   );
 }
 
+type StreamingTextType = "assistant_message" | "reasoning";
+
+const THOUGHT_PREFIX = "[Thought] ";
+
+interface PendingStreamingText {
+  type: StreamingTextType;
+  turnId: string | undefined;
+  messageId: string | undefined;
+  buffer: string;
+  emitted: boolean;
+}
+
+export interface FollowTranscriptWriter {
+  push(item: AgentTimelineItem, turnId?: string): void;
+  end(): void;
+}
+
+function lastNonWhitespaceIndex(text: string): number {
+  for (let index = text.length - 1; index >= 0; index -= 1) {
+    if (!/\s/.test(text[index])) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Follow mode receives one streaming fragment per event, while the one-shot
+ * transcript sees the whole timeline and merges consecutive assistant and
+ * reasoning fragments with exact concatenation (`projectTimelineRows`). Printing
+ * each fragment on its own line splits words at fragment boundaries and
+ * reprints the reasoning prefix, so a chain of fragments is written as one
+ * stream instead: text goes out as it arrives, and only the trailing whitespace
+ * is held back so the message ends trimmed the way the transcript does.
+ */
+export function createFollowTranscriptWriter(
+  write: (chunk: string) => void = (chunk) => void process.stdout.write(chunk),
+): FollowTranscriptWriter {
+  let pending: PendingStreamingText | null = null;
+
+  const emit = (chain: PendingStreamingText, text: string): void => {
+    if (!chain.emitted) {
+      chain.emitted = true;
+      if (chain.type === "reasoning") {
+        write(THOUGHT_PREFIX);
+      }
+    }
+    write(text);
+  };
+
+  const flushContent = (chain: PendingStreamingText): void => {
+    if (!chain.emitted) {
+      chain.buffer = chain.buffer.replace(/^\s+/, "");
+    }
+    const lastContent = lastNonWhitespaceIndex(chain.buffer);
+    if (lastContent < 0) {
+      return;
+    }
+    emit(chain, chain.buffer.slice(0, lastContent + 1));
+    chain.buffer = chain.buffer.slice(lastContent + 1);
+  };
+
+  const closePending = (): void => {
+    const chain = pending;
+    pending = null;
+    if (!chain) {
+      return;
+    }
+    const tail = chain.emitted ? chain.buffer.trimEnd() : chain.buffer.trim();
+    if (tail) {
+      emit(chain, tail);
+    }
+    if (chain.emitted) {
+      write("\n");
+    }
+  };
+
+  const continuesChain = (item: AgentTimelineItem, turnId: string | undefined): boolean => {
+    if (!pending || pending.type !== item.type || pending.turnId !== turnId) {
+      return false;
+    }
+    if (item.type !== "assistant_message") {
+      return true;
+    }
+    return item.messageId === undefined || item.messageId === pending.messageId;
+  };
+
+  const startChain = (
+    item: Extract<AgentTimelineItem, { type: StreamingTextType }>,
+    turnId: string | undefined,
+  ): PendingStreamingText => {
+    closePending();
+    const chain: PendingStreamingText = {
+      type: item.type,
+      turnId,
+      messageId: item.type === "assistant_message" ? item.messageId : undefined,
+      buffer: "",
+      emitted: false,
+    };
+    pending = chain;
+    return chain;
+  };
+
+  return {
+    push(item, turnId) {
+      if (item.type === "assistant_message" || item.type === "reasoning") {
+        const chain = continuesChain(item, turnId) && pending ? pending : startChain(item, turnId);
+        chain.buffer += item.text;
+        flushContent(chain);
+        return;
+      }
+      closePending();
+      const transcript = formatAgentActivityTranscript([item]);
+      if (transcript && transcript !== NO_ACTIVITY_MESSAGE) {
+        write(`${transcript}\n`);
+      }
+    },
+    end() {
+      closePending();
+    },
+  };
+}
+
 function parseTailCount(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   const parsed = Number.parseInt(raw, 10);
@@ -204,6 +327,8 @@ async function runFollowMode(
     tailCount === 0 ? "no history" : `last ${tailCount} entr${tailCount === 1 ? "y" : "ies"}`;
   console.log(`\n--- Following logs (${tailLabel}; Ctrl+C to stop) ---\n`);
 
+  const writer = createFollowTranscriptWriter();
+
   const unsubscribe = client.on("agent_stream", (msg: unknown) => {
     const message = msg as AgentStreamMessage;
     if (message.type !== "agent_stream") return;
@@ -215,17 +340,14 @@ async function runFollowMode(
       if (options.filter && !matchesFilter(item, options.filter)) {
         return;
       }
-      // Print each timeline item as it arrives using the curator format
-      const transcript = formatAgentActivityTranscript([item]);
-      if (transcript !== NO_ACTIVITY_MESSAGE) {
-        console.log(transcript);
-      }
+      writer.push(item, message.payload.event.turnId);
     }
   });
 
   // Wait for interrupt
   await new Promise<void>((resolve) => {
     const cleanup = () => {
+      writer.end();
       unsubscribe();
       resolve();
     };


### PR DESCRIPTION
Fixes #3437 (the plain-output half of it, see below).

`paseo logs` without `-f` fetches the timeline with `projection: "projected"`, and `projectTimelineRows` merges consecutive assistant fragments by exact concatenation, `` `${previousAssistant.text}${entryAssistant.text}` `` (`packages/server/src/server/agent/timeline-projection.ts:206-256`), gated on the same `turnId` and a matching `messageId`. `mergeReasoningChunks` does the same for reasoning right above it. Follow mode never reached either: it called `formatAgentActivityTranscript([item])` once per arriving event (`logs.ts:219`), so every fragment was projected alone and printed on its own line with `console.log`.

So this is not a missing feature, it is `-f` diverging from what the same command prints without `-f`. The visible damage: words break at transport boundaries, a reader cannot tell an author newline from a fragment one, and `[Thought]` is reprinted for every reasoning chunk.

## What I changed

Follow mode keeps a fragment chain open, using the same merge rule as the projection (same kind, same `turnId`, matching `messageId` when the event carries one), and writes text as it arrives rather than one line per event. Only trailing whitespace is held back, so a message still ends trimmed exactly the way the one-shot transcript ends it. The chain closes when another kind of item arrives, or when follow stops.

Reasoning is fixed in the same pass because it is the same defect in the same loop, and the two merge functions sit next to each other.

I deliberately did not implement option 1 from the issue (`--json` NDJSON). That is a new interface contract for tooling, not a bug, so it belongs in a discussion and in your hands, not in this PR.

## QA

### Real agent, before and after

Same agent (`claude/claude-haiku-4-5`), same kind of prompt, a live daemon from this checkout, `--filter text --tail 0` so only the streamed text is in frame:

```
$ npm run cli -- run -d --provider claude/claude-haiku-4-5 --title logs-repro "reply with the single word ready"
$ npm run cli -- logs -f <id> --filter text --tail 0 > /tmp/follow.txt
$ npm run cli -- send --no-wait <id> "Write a 200-word markdown report in Korean about CI pipelines. Use the exact token paseo-pr-cycle at least 5 times."
```

Before, on `main` (excerpt, line breaks exactly as printed):

```text
[Thought] The user is asking me to write another 200-word markdown report in
[Thought] Korean about CI pipelines, using "
[Thought] paseo-pr-cycle" at least 5 times. This is essentially the same request as before, just repeated. I should write a different
[Thought] report, not just copy the previous one.
...
지속적 통합(CI
)은 개발 프로세스의 필수 요소입니다. **paseo-pr-cycle**은 이러
한 통합 파이프라인의 핵심 메커니즘으로 작동합니다.
## 기술적 구성

**paseo-pr-cycle**의 첫 번째 단계는 소스 코드
수집 및 빌드입니다. 개발자가 커밋을 푸시하
면 **paseo-pr-cycle**이 자동으로 트리거되어 빌드 프로세스를 시작합니다. 다
음으로 **paseo-pr-cycle**은 단위 테스트를 실행하고 코드 커버
리지를 측정합니다.
```

`(CI` / `)`, `이러` / `한`, `푸시하` / `면`, `다` / `음으로`, `커버` / `리지를`, and a line that is a single `.` further down. Five `[Thought]` prefixes for one thought, one of them cutting a quoted string in half.

After, with this PR:

```text
[User] Write a 200-word markdown report in Korean about CI pipelines. Use the exact token paseo-pr-cycle at least 5 times.
[Thought] The user is asking me to write a 200-word markdown report in Korean about CI pipelines, and I need to use the exact token "paseo-pr-cycle" at least 5 times.

This is a straightforward writing task. I don't need to invoke any skills or tools - this is just content creation.
...
# CI 파이프라인 보고서

## 개요

**paseo-pr-cycle**은 현대 소프트웨어 개발에서 핵심적인 자동화 프로세스입니다. 이 시스템을 통해 개발팀은 코드 품질을 지속적으로 관리하고 버그를 사전에 방지할 수 있습니다.

## 주요 기능

**paseo-pr-cycle**의 첫 번째 단계는 자동 테스트 실행입니다. 모든 커밋이 **paseo-pr-cycle** 검증 프로세스를 거치면서 코드 안정성이 보장됩니다.
```

One `[Thought]` for the thought, no broken words, markdown structure intact, and the text still appears while the turn is running rather than at the end.

### Tests

`packages/cli/src/commands/agent/logs.test.ts`, 7 cases on the exported writer:

```
$ npx vitest run packages/cli/src/commands/agent/logs.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The one that matters is the invariant, not the wording of any single case: for a given fragment sequence, follow output equals the one-shot transcript.

```ts
expect(collect(items).trimEnd()).toBe(formatAgentActivityTranscript(items));
```

The rest cover a word split across fragments, streaming without an invented break, a `messageId` change starting a new message, no merging across turns, the reasoning prefix printed once, and interior blank lines kept while trailing whitespace is dropped.

Neighbouring suites and the repo typecheck:

```
$ npx vitest run packages/cli/src/commands/agent/
 Test Files  6 passed (6)
      Tests  31 passed (31)

$ npx vitest run packages/cli/src/cli-surface.test.ts packages/server/src/server/agent/activity-curator.test.ts
 Test Files  2 passed (2)
      Tests  24 passed (24)

$ npm run typecheck
exit 0, no errors
```

### Platforms

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | n/a | CLI change |
| Android | n/a | CLI change |
| Web | n/a | CLI change |
| Desktop macOS | no | |
| Desktop Windows | no | |
| Desktop Linux | yes | CLI from this checkout against a real daemon and a real Claude agent, output above |

I only have Linux here. The change is Node code in the CLI with no platform gating: `console.log` per event became `process.stdout.write` on a chain, so the one thing I would look at on Windows is line endings, and it writes the provider's own text with no `\r\n` translation either way.
