### PR TITLE
fix(server): honor Grok _x.ai/ask_user_question

### DIFF
--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1234,6 +1234,70 @@ describe("ACPAgentSession Zed parity", () => {
     });
   });
 
+  test("maps Grok _x.ai/ask_user_question onto a question permission", async () => {
+    const session = createSessionWithConfig({ provider: "grok" });
+    const events: AgentStreamEvent[] = [];
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    session.subscribe((event) => events.push(event));
+
+    const result = session.extMethod("_x.ai/ask_user_question", {
+      sessionId: "session-1",
+      toolCallId: "call-question-1",
+      questions: [
+        {
+          question: "S-13 hosting",
+          options: [{ label: "Azure Container Apps (Recommended)" }, { label: "This Mac Studio" }],
+        },
+      ],
+    });
+
+    await Promise.resolve();
+    const requested = events.find((event) => event.type === "permission_requested");
+    expect(requested).toMatchObject({
+      type: "permission_requested",
+      request: {
+        id: "call-question-1",
+        kind: "question",
+        name: "ask_user_question",
+        title: "S-13 hosting",
+      },
+    });
+    if (requested?.type !== "permission_requested") {
+      throw new Error("Expected permission request");
+    }
+
+    await session.respondToPermission(requested.request.id, {
+      behavior: "allow",
+      updatedInput: { answers: { "S-13 hosting": "Azure Container Apps (Recommended)" } },
+    });
+
+    await expect(result).resolves.toEqual({
+      outcome: "accepted",
+      answers: { "S-13 hosting": "Azure Container Apps (Recommended)" },
+      annotations: {},
+    });
+  });
+
+  test("cancels a Grok ask_user_question when the question is dismissed", async () => {
+    const session = createSessionWithConfig({ provider: "grok" });
+    asInternals<ACPSessionInternals>(session).sessionId = "session-1";
+    const result = session.extMethod("x.ai/ask_user_question", {
+      questions: [{ question: "Ship it?", options: [{ label: "Yes" }] }],
+    });
+    await Promise.resolve();
+    const pending = session.getPendingPermissions();
+    expect(pending).toHaveLength(1);
+    await session.respondToPermission(pending[0]!.id, { behavior: "deny" });
+    await expect(result).resolves.toEqual({ outcome: "cancelled" });
+  });
+
+  test("returns method-not-found for unrelated ACP extension requests", async () => {
+    const session = createSessionWithConfig({ provider: "grok" });
+    await expect(session.extMethod("_x.ai/session/update", {})).rejects.toMatchObject({
+      code: -32601,
+    });
+  });
+
   test("preserves ACP permission requests after invalid selected actions", async () => {
     const session = createSessionWithConfig({ provider: "generic-acp" });
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -16,6 +16,7 @@ import {
   PROTOCOL_VERSION,
   type AgentCapabilities as ACPAgentCapabilities,
   type Error as ACPError,
+  RequestError,
   type AnyMessage,
   type Client as ACPClient,
   type ClientCapabilities as ACPClientCapabilities,
@@ -114,6 +115,15 @@ import {
 } from "../provider-launch-config.js";
 import { renderPromptAttachmentAsText } from "../prompt-attachments.js";
 import { appendOrReplaceGrowingAssistantMessage, runProviderTurn } from "./provider-runner.js";
+import {
+  buildGrokAskUserQuestionAnswers,
+  formatGrokAskUserQuestionDetail,
+  formatGrokAskUserQuestionTitle,
+  isGrokAskUserQuestionMethod,
+  parseGrokAskUserQuestionParams,
+  type GrokAskUserQuestionPrompt,
+  type GrokAskUserQuestionResult,
+} from "./grok-ask-user-question.js";
 import {
   buildStringCommandShellInvocation,
   createStringCommandShellEnvOverlay,
@@ -505,6 +515,13 @@ interface PendingPermission {
   options: PermissionOption[];
   resolve: (response: RequestPermissionResponse) => void;
   reject: (error: Error) => void;
+  turnId: string | null;
+}
+
+interface PendingExtensionQuestion {
+  request: AgentPermissionRequest;
+  questions: GrokAskUserQuestionPrompt[];
+  resolve: (result: GrokAskUserQuestionResult) => void;
   turnId: string | null;
 }
 
@@ -1428,6 +1445,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private readonly launchEnv?: Record<string, string>;
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly pendingPermissions = new Map<string, PendingPermission>();
+  private readonly pendingExtensionQuestions = new Map<string, PendingExtensionQuestion>();
   private pendingUserMessage: PendingUserMessage | null = null;
   private submittedUserMessageTurnId: string | null = null;
   private readonly toolCalls = new Map<string, ACPToolSnapshot>();
@@ -2110,10 +2128,38 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   getPendingPermissions(): AgentPermissionRequest[] {
-    return Array.from(this.pendingPermissions.values(), (entry) => entry.request);
+    return [
+      ...Array.from(this.pendingPermissions.values(), (entry) => entry.request),
+      ...Array.from(this.pendingExtensionQuestions.values(), (entry) => entry.request),
+    ];
   }
 
   async respondToPermission(requestId: string, response: AgentPermissionResponse): Promise<void> {
+    const extensionQuestion = this.pendingExtensionQuestions.get(requestId);
+    if (extensionQuestion) {
+      this.pendingExtensionQuestions.delete(requestId);
+      if (response.behavior === "allow") {
+        extensionQuestion.resolve({
+          outcome: "accepted",
+          answers: buildGrokAskUserQuestionAnswers(
+            extensionQuestion.questions,
+            response.updatedInput?.answers,
+          ),
+          annotations: {},
+        });
+      } else {
+        extensionQuestion.resolve({ outcome: "cancelled" });
+      }
+      this.pushEvent({
+        type: "permission_resolved",
+        provider: this.provider,
+        requestId,
+        resolution: response,
+        turnId: extensionQuestion.turnId ?? undefined,
+      });
+      return;
+    }
+
     const pending = this.pendingPermissions.get(requestId);
     if (!pending) {
       throw new Error(`No pending permission request with id '${requestId}'`);
@@ -2175,6 +2221,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       pending.resolve({ outcome: { outcome: "cancelled" } });
     }
     this.pendingPermissions.clear();
+    this.cancelPendingExtensionQuestions();
 
     if (this.activeForegroundTurnId) {
       await this.connection.cancel({ sessionId: this.sessionId });
@@ -2194,6 +2241,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       pending.resolve({ outcome: { outcome: "cancelled" } });
     }
     this.pendingPermissions.clear();
+    this.cancelPendingExtensionQuestions();
 
     if (this.connection && this.sessionId) {
       try {
@@ -2317,6 +2365,66 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     for (const event of events) {
       this.pushEvent(event);
     }
+  }
+
+  async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (!isGrokAskUserQuestionMethod(method)) {
+      throw RequestError.methodNotFound(method);
+    }
+
+    const parsed = parseGrokAskUserQuestionParams(params);
+    if (
+      parsed.sessionId !== undefined &&
+      this.sessionId !== null &&
+      parsed.sessionId !== this.sessionId
+    ) {
+      throw RequestError.invalidParams({ reason: "sessionId does not match this session" });
+    }
+
+    const requestId = parsed.toolCallId ?? randomUUID();
+    const request: AgentPermissionRequest = {
+      id: requestId,
+      provider: this.provider,
+      name: "ask_user_question",
+      kind: "question",
+      title: formatGrokAskUserQuestionTitle(parsed.questions),
+      detail: {
+        type: "plain_text",
+        text: formatGrokAskUserQuestionDetail(parsed.questions),
+        icon: "brain",
+      },
+      input: {
+        questions: parsed.questions,
+      },
+      metadata: {
+        method,
+        toolCallId: parsed.toolCallId ?? null,
+      },
+    };
+
+    const result = await new Promise<GrokAskUserQuestionResult>((resolve) => {
+      this.pendingExtensionQuestions.set(requestId, {
+        request,
+        questions: parsed.questions,
+        resolve,
+        turnId: this.activeForegroundTurnId,
+      });
+      this.pushEvent({
+        type: "permission_requested",
+        provider: this.provider,
+        request,
+        turnId: this.activeForegroundTurnId ?? undefined,
+      });
+    });
+
+    return result;
+  }
+
+  private cancelPendingExtensionQuestions(): void {
+    for (const pending of this.pendingExtensionQuestions.values()) {
+      pending.resolve({ outcome: "cancelled" });
+    }
+    this.pendingExtensionQuestions.clear();
   }
 
   async extNotification(method: string, params: Record<string, unknown>): Promise<void> {

--- a/packages/server/src/server/agent/providers/grok-ask-user-question.test.ts
+++ b/packages/server/src/server/agent/providers/grok-ask-user-question.test.ts
@@ -1,0 +1,107 @@
+import { RequestError } from "@agentclientprotocol/sdk";
+import { describe, expect, test } from "vitest";
+
+import {
+  buildGrokAskUserQuestionAnswers,
+  formatGrokAskUserQuestionDetail,
+  formatGrokAskUserQuestionTitle,
+  isGrokAskUserQuestionMethod,
+  parseGrokAskUserQuestionParams,
+} from "./grok-ask-user-question.js";
+
+describe("isGrokAskUserQuestionMethod", () => {
+  test("accepts both ACP spellings and the bare tool name", () => {
+    expect(isGrokAskUserQuestionMethod("_x.ai/ask_user_question")).toBe(true);
+    expect(isGrokAskUserQuestionMethod("x.ai/ask_user_question")).toBe(true);
+    expect(isGrokAskUserQuestionMethod("ask_user_question")).toBe(true);
+    expect(isGrokAskUserQuestionMethod("_x.ai/session/update")).toBe(false);
+  });
+});
+
+describe("parseGrokAskUserQuestionParams", () => {
+  test("parses the live Grok ACP payload shape", () => {
+    expect(
+      parseGrokAskUserQuestionParams({
+        sessionId: "session-1",
+        toolCallId: "call-question-1",
+        mode: "default",
+        questions: [
+          {
+            question: "S-13 demo server — hosting",
+            options: [
+              { label: "Azure Container Apps (Recommended)", description: "Shared demo host" },
+              { label: "This Mac Studio" },
+            ],
+            multiSelect: null,
+          },
+        ],
+      }),
+    ).toEqual({
+      sessionId: "session-1",
+      toolCallId: "call-question-1",
+      questions: [
+        {
+          question: "S-13 demo server — hosting",
+          header: "S-13 demo server — hosting",
+          options: [
+            { label: "Azure Container Apps (Recommended)", description: "Shared demo host" },
+            { label: "This Mac Studio" },
+          ],
+          multiSelect: false,
+          allowOther: true,
+        },
+      ],
+    });
+  });
+
+  test("rejects an empty questions array", () => {
+    expect(() => parseGrokAskUserQuestionParams({ questions: [] })).toThrow(RequestError);
+  });
+});
+
+describe("buildGrokAskUserQuestionAnswers", () => {
+  const questions = [
+    {
+      question: "Which host?",
+      header: "Host",
+      options: [{ label: "Azure" }],
+      multiSelect: false,
+      allowOther: true,
+    },
+  ];
+
+  test("maps Paseo header-keyed answers onto Grok question text", () => {
+    expect(buildGrokAskUserQuestionAnswers(questions, { Host: "Azure" })).toEqual({
+      "Which host?": "Azure",
+    });
+  });
+
+  test("keeps answers already keyed by question text", () => {
+    expect(buildGrokAskUserQuestionAnswers(questions, { "Which host?": "Azure" })).toEqual({
+      "Which host?": "Azure",
+    });
+  });
+});
+
+describe("formatters", () => {
+  test("titles a multi-question request like the Grok tool chip", () => {
+    const questions = [
+      {
+        question: "One",
+        header: "One",
+        options: [],
+        multiSelect: false,
+        allowOther: true,
+      },
+      {
+        question: "Two",
+        header: "Two",
+        options: [],
+        multiSelect: false,
+        allowOther: true,
+      },
+    ];
+    expect(formatGrokAskUserQuestionTitle(questions)).toBe("Ask 2 questions");
+    expect(formatGrokAskUserQuestionDetail(questions)).toBe("One\nTwo");
+  });
+});

--- a/packages/server/src/server/agent/providers/grok-ask-user-question.ts
+++ b/packages/server/src/server/agent/providers/grok-ask-user-question.ts
@@ -1,0 +1,138 @@
+import { RequestError } from "@agentclientprotocol/sdk";
+
+export const GROK_ASK_USER_QUESTION_METHODS = [
+  "_x.ai/ask_user_question",
+  "x.ai/ask_user_question",
+  "ask_user_question",
+] as const;
+
+export type GrokAskUserQuestionMethod = (typeof GROK_ASK_USER_QUESTION_METHODS)[number];
+
+export interface GrokAskUserQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface GrokAskUserQuestionPrompt {
+  question: string;
+  header: string;
+  options: GrokAskUserQuestionOption[];
+  multiSelect: boolean;
+  allowOther: boolean;
+}
+
+export type GrokAskUserQuestionResult =
+  | { outcome: "accepted"; answers: Record<string, string>; annotations: Record<string, unknown> }
+  | { outcome: "cancelled" };
+
+export function isGrokAskUserQuestionMethod(method: string): method is GrokAskUserQuestionMethod {
+  return (GROK_ASK_USER_QUESTION_METHODS as readonly string[]).includes(method);
+}
+
+export function parseGrokAskUserQuestionParams(params: Record<string, unknown>): {
+  sessionId?: string;
+  toolCallId?: string;
+  questions: GrokAskUserQuestionPrompt[];
+} {
+  const rawQuestions = params.questions;
+  if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) {
+    throw RequestError.invalidParams({ reason: "questions must be a non-empty array" });
+  }
+
+  const questions = rawQuestions.map((item, index) => parseQuestion(item, index));
+  return {
+    sessionId: readOptionalString(params.sessionId),
+    toolCallId: readOptionalString(params.toolCallId),
+    questions,
+  };
+}
+
+export function buildGrokAskUserQuestionAnswers(
+  questions: GrokAskUserQuestionPrompt[],
+  rawAnswers: unknown,
+): Record<string, string> {
+  const answersRecord = isRecord(rawAnswers) ? rawAnswers : {};
+  const answers: Record<string, string> = {};
+
+  for (const question of questions) {
+    const raw =
+      readOptionalString(answersRecord[question.header]) ??
+      readOptionalString(answersRecord[question.question]);
+    if (!raw) {
+      continue;
+    }
+    answers[question.question] = raw;
+  }
+
+  return answers;
+}
+
+export function formatGrokAskUserQuestionTitle(questions: GrokAskUserQuestionPrompt[]): string {
+  if (questions.length === 1) {
+    return questions[0]?.question ?? "Question";
+  }
+  return `Ask ${questions.length} questions`;
+}
+
+export function formatGrokAskUserQuestionDetail(questions: GrokAskUserQuestionPrompt[]): string {
+  return questions
+    .map((question) => {
+      const labels = question.options.map((option) => option.label).filter(Boolean);
+      return labels.length > 0
+        ? `${question.question} - ${labels.join(" / ")}`
+        : question.question;
+    })
+    .join("\n");
+}
+
+function parseQuestion(item: unknown, index: number): GrokAskUserQuestionPrompt {
+  if (!isRecord(item)) {
+    throw RequestError.invalidParams({ reason: `questions[${index}] must be an object` });
+  }
+  const question = readOptionalString(item.question);
+  if (!question) {
+    throw RequestError.invalidParams({ reason: `questions[${index}].question is required` });
+  }
+
+  const options = Array.isArray(item.options)
+    ? item.options
+        .map((option) => parseOption(option))
+        .filter((option): option is GrokAskUserQuestionOption => option !== null)
+    : [];
+
+  return {
+    question,
+    header: readOptionalString(item.header) ?? question,
+    options,
+    multiSelect: item.multiSelect === true || item.multi_select === true,
+    allowOther: true,
+  };
+}
+
+function parseOption(item: unknown): GrokAskUserQuestionOption | null {
+  if (typeof item === "string") {
+    const label = item.trim();
+    return label ? { label } : null;
+  }
+  if (!isRecord(item)) {
+    return null;
+  }
+  const label =
+    readOptionalString(item.label) ??
+    readOptionalString(item.title) ??
+    readOptionalString(item.name) ??
+    readOptionalString(item.text);
+  if (!label) {
+    return null;
+  }
+  const description = readOptionalString(item.description);
+  return description ? { label, description } : { label };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Linked issue

Closes https://github.com/getpaseo/paseo/issues/3490

### Type of change

- Bug fix

### What does this PR do

Grok Build over `grok agent stdio` asks structured questions with a JSON-RPC **request**:

```
method: _x.ai/ask_user_question
params: { sessionId, toolCallId, questions, mode }
```

`ACPAgentSession` implemented `extNotification` but not `Client.extMethod`. The ACP SDK therefore returned `-32601 Method not found`. The Grok tool failed in a few milliseconds and the chat never showed a picker (Claude / Codex / OpenCode still do).

This PR:

- implements `extMethod` on `ACPAgentSession`
- accepts `_x.ai/ask_user_question`, `x.ai/ask_user_question`, and the bare `ask_user_question` spelling
- projects the payload onto the existing `kind: "question"` permission UI
- replies with `{ outcome: "accepted", answers: { "<question text>": "<label>" }, annotations: {} }` (or `{ outcome: "cancelled" }` on dismiss)
- remaps Paseo's header-keyed UI answers onto Grok's question-text keys
- leaves unrelated `_` extension methods as method-not-found

Wire reply shape matches [phuryn/grok-build-vscode](https://github.com/phuryn/grok-build-vscode) (`outcome` is required; an empty ACK is rejected).

### How did you verify it

```
cd packages/server
npx vitest run \
  src/server/agent/providers/grok-ask-user-question.test.ts \
  src/server/agent/providers/acp-agent.test.ts

Test Files  2 passed (2)
     Tests  105 passed (105)
```

New coverage:

- parse the live Grok ACP payload (`questions[].options[].label`, `multiSelect: null`)
- both ACP method spellings
- header-keyed UI answers → question-text keys
- dismiss → `{ outcome: "cancelled" }`
- unrelated `_x.ai/session/update` still returns `-32601`

Not tested on a live Desktop/daemon swap: replacing the running 0.4.0 daemon would kill in-flight agents on this machine. After merge, QA path is: start a Grok session, force `ask_user_question`, confirm the existing question card, pick an option, confirm the agent continues.

### Platforms

- Unit tests only (macOS 26.2 host)
- Not tested: iOS, Android, live Desktop/Web against a replaced daemon

### Checklist

- One focused change
- Links the bug
- Tests added
- Maintainer edits enabled
- Draft until live UI QA exists
