### PR TITLE
fix(app): add a drag handle for pinned sidebar chats

### DIFF
--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -101,6 +101,7 @@ import {
 } from "@/components/sidebar/sidebar-workspace-menu";
 import { useLongPressDragInteraction } from "@/components/sidebar/use-long-press-drag-interaction";
 import { PinnedSectionHeader } from "@/components/sidebar/pinned-section-header";
+import { PinnedDraggableRowChrome } from "@/components/sidebar/sidebar-pinned-drag-handle";
 import { SidebarGroupToggleRow } from "@/components/sidebar/sidebar-group-toggle-row";
 import { useLimitedSidebarGroup } from "@/components/sidebar/use-limited-sidebar-group";
 import {
@@ -1515,6 +1516,54 @@ function areWorkspaceRowItemPropsEqual(
 
 const MemoWorkspaceRowItem = memo(WorkspaceRowItem, areWorkspaceRowItemPropsEqual);
 
+function PinnedChatDraggableRow({
+  workspace,
+  workspaceEntry,
+  hostBadge,
+  leadingProjectIconDataUri,
+  shortcutNumber,
+  showShortcutBadge,
+  canCopyBranchName,
+  canPin,
+  onToggleWorkspacePin,
+  isCreating,
+  selectionEnabled,
+  activeWorkspaceSelection,
+  onWorkspacePress,
+  drag,
+  isDragging,
+  dragHandleProps,
+}: Omit<WorkspaceRowItemProps, "leadingProjectName" | "isDragging"> & {
+  isDragging: boolean;
+}) {
+  return (
+    <PinnedDraggableRowChrome
+      workspaceKey={workspace.workspaceKey}
+      dragHandleProps={dragHandleProps}
+      isDragging={isDragging}
+    >
+      <MemoWorkspaceRowItem
+        workspace={workspace}
+        workspaceEntry={workspaceEntry}
+        hostBadge={hostBadge}
+        leadingProjectName={workspace.projectName}
+        leadingProjectIconDataUri={leadingProjectIconDataUri}
+        shortcutNumber={shortcutNumber}
+        showShortcutBadge={showShortcutBadge}
+        canCopyBranchName={canCopyBranchName}
+        canPin={canPin}
+        onToggleWorkspacePin={onToggleWorkspacePin}
+        isCreating={isCreating}
+        selectionEnabled={selectionEnabled}
+        activeWorkspaceSelection={activeWorkspaceSelection}
+        onWorkspacePress={onWorkspacePress}
+        drag={drag}
+        isDragging={isDragging}
+      />
+    </PinnedDraggableRowChrome>
+  );
+}
+
 function WorkspaceRow({
   workspaceEntry,
   hostBadge,
@@ -2355,11 +2404,10 @@ function ProjectModeList({
       dragHandleProps,
     }: DraggableRenderItemInfo<SidebarWorkspacePlacement>) => {
       return (
-        <MemoWorkspaceRowItem
+        <PinnedChatDraggableRow
           workspace={workspace}
           workspaceEntry={workspaceEntriesByKey.get(workspace.workspaceKey) ?? null}
           hostBadge={hostBadgeByServerId.get(workspace.serverId) ?? null}
-          leadingProjectName={workspace.projectName}
           leadingProjectIconDataUri={
             projectIconByProjectViewKey.get(workspace.projectViewKey) ?? null
           }

--- a/packages/app/src/components/sidebar/sidebar-pinned-drag-handle.test.ts
+++ b/packages/app/src/components/sidebar/sidebar-pinned-drag-handle.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isPinnedDragHandleVisible } from "./sidebar-pinned-drag-handle";
+
+describe("isPinnedDragHandleVisible", () => {
+  it("stays reserved-but-hidden until hover on desktop", () => {
+    expect(
+      isPinnedDragHandleVisible({ hovered: false, dragging: false, alwaysVisible: false }),
+    ).toBe(false);
+  });
+
+  it("appears on hover or while dragging", () => {
+    expect(
+      isPinnedDragHandleVisible({ hovered: true, dragging: false, alwaysVisible: false }),
+    ).toBe(true);
+    expect(
+      isPinnedDragHandleVisible({ hovered: false, dragging: true, alwaysVisible: false }),
+    ).toBe(true);
+  });
+
+  it("stays visible on touch so the affordance is not hover-only", () => {
+    expect(
+      isPinnedDragHandleVisible({ hovered: false, dragging: false, alwaysVisible: true }),
+    ).toBe(true);
+  });
+});

--- a/packages/app/src/components/sidebar/sidebar-pinned-drag-handle.tsx
+++ b/packages/app/src/components/sidebar/sidebar-pinned-drag-handle.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useState, type ReactElement, type ReactNode } from "react";
+import { View } from "react-native";
+import { GripVertical } from "lucide-react-native";
+import { useTranslation } from "react-i18next";
+import { StyleSheet, withUnistyles } from "react-native-unistyles";
+import type { Theme } from "@/styles/theme";
+import { isNative, isWeb } from "@/constants/platform";
+import type { DraggableListDragHandleProps } from "@/components/draggable-list.types";
+
+const ThemedGripVertical = withUnistyles(GripVertical);
+const gripColor = (theme: Theme) => ({ color: theme.colors.foregroundMuted });
+
+export function isPinnedDragHandleVisible(input: {
+  hovered: boolean;
+  dragging: boolean;
+  alwaysVisible: boolean;
+}): boolean {
+  return input.alwaysVisible || input.hovered || input.dragging;
+}
+
+export function SidebarPinnedDragHandle({
+  workspaceKey,
+  dragHandleProps,
+  visible,
+}: {
+  workspaceKey: string;
+  dragHandleProps?: DraggableListDragHandleProps;
+  visible: boolean;
+}): ReactElement {
+  const { t } = useTranslation();
+  const {
+    role: _dragRole,
+    tabIndex: _dragTabIndex,
+    "aria-roledescription": _dragRoleDescription,
+    ...dragAttributes
+  } = dragHandleProps?.attributes ?? {};
+
+  return (
+    <View
+      {...dragAttributes}
+      {...dragHandleProps?.listeners}
+      ref={dragHandleProps?.setActivatorNodeRef as never}
+      accessibilityRole="adjustable"
+      accessibilityLabel={t("sidebar.pinned.reorder")}
+      testID={`sidebar-pinned-drag-handle-${workspaceKey}`}
+      style={[styles.handle, visible ? styles.handleVisible : styles.handleHidden]}
+    >
+      <ThemedGripVertical size={12} uniProps={gripColor} />
+    </View>
+  );
+}
+
+export function PinnedDraggableRowChrome({
+  workspaceKey,
+  dragHandleProps,
+  isDragging,
+  children,
+}: {
+  workspaceKey: string;
+  dragHandleProps?: DraggableListDragHandleProps;
+  isDragging: boolean;
+  children: ReactNode;
+}): ReactElement {
+  const [hovered, setHovered] = useState(false);
+  const handlePointerEnter = useCallback(() => setHovered(true), []);
+  const handlePointerLeave = useCallback(() => setHovered(false), []);
+
+  return (
+    <View
+      style={styles.row}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+    >
+      <SidebarPinnedDragHandle
+        workspaceKey={workspaceKey}
+        dragHandleProps={dragHandleProps}
+        visible={isPinnedDragHandleVisible({
+          hovered,
+          dragging: isDragging,
+          alwaysVisible: isNative,
+        })}
+      />
+      <View style={styles.body}>{children}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    minWidth: 0,
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+  },
+  handle: {
+    width: theme.spacing[4],
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    ...(isWeb ? { cursor: "grab" } : null),
+  },
+  handleVisible: {
+    opacity: 1,
+  },
+  handleHidden: {
+    opacity: 0,
+  },
+}));

--- a/packages/app/src/components/sidebar/sidebar-status-list.tsx
+++ b/packages/app/src/components/sidebar/sidebar-status-list.tsx
@@ -73,6 +73,7 @@ import {
   SidebarWorkspaceMenu,
 } from "@/components/sidebar/sidebar-workspace-menu";
 import { PinnedSectionHeader } from "@/components/sidebar/pinned-section-header";
+import { PinnedDraggableRowChrome } from "@/components/sidebar/sidebar-pinned-drag-handle";
 import { SidebarGroupToggleRow } from "@/components/sidebar/sidebar-group-toggle-row";
 import { useLimitedSidebarGroup } from "@/components/sidebar/use-limited-sidebar-group";
 import type { ToggleSidebarWorkspacePin } from "@/hooks/use-sidebar-workspace-pin";
@@ -166,23 +167,28 @@ export function SidebarStatusWorkspaceList({
       isActive,
       dragHandleProps,
     }: DraggableRenderItemInfo<SidebarWorkspaceEntry>) => (
-      <StatusWorkspaceRow
-        workspace={workspace}
-        {...buildStatusRowProjectPresentation({
-          workspace,
-          projectIconByProjectViewKey,
-          hostBadgeByServerId,
-        })}
-        inStatusGroup={false}
-        shortcutNumber={statusShortcutIndex.get(workspace.workspaceKey) ?? null}
-        showShortcutBadge={showShortcutBadges}
-        canPin={supportsPinningByServerId.get(workspace.serverId) === true}
-        onToggleWorkspacePin={onToggleWorkspacePin}
-        onWorkspacePress={onWorkspacePress}
-        drag={drag}
-        isDragging={isActive}
+      <PinnedDraggableRowChrome
+        workspaceKey={workspace.workspaceKey}
         dragHandleProps={dragHandleProps}
-      />
+        isDragging={isActive}
+      >
+        <StatusWorkspaceRow
+          workspace={workspace}
+          {...buildStatusRowProjectPresentation({
+            workspace,
+            projectIconByProjectViewKey,
+            hostBadgeByServerId,
+          })}
+          inStatusGroup={false}
+          shortcutNumber={statusShortcutIndex.get(workspace.workspaceKey) ?? null}
+          showShortcutBadge={showShortcutBadges}
+          canPin={supportsPinningByServerId.get(workspace.serverId) === true}
+          onToggleWorkspacePin={onToggleWorkspacePin}
+          onWorkspacePress={onWorkspacePress}
+          drag={drag}
+          isDragging={isActive}
+        />
+      </PinnedDraggableRowChrome>
     ),
     [
       hostBadgeByServerId,

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -995,6 +995,7 @@ export const ar: TranslationResources = {
     },
     pinned: {
       title: "المثبتة",
+      reorder: "اسحب لإعادة الترتيب",
     },
     host: {
       noHost: "لا مضيف",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1004,6 +1004,7 @@ export const en = {
     },
     pinned: {
       title: "Pinned",
+      reorder: "Drag to reorder",
     },
     host: {
       noHost: "No host",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1026,6 +1026,7 @@ export const es: TranslationResources = {
     },
     pinned: {
       title: "Anclados",
+      reorder: "Arrastra para reordenar",
     },
     host: {
       noHost: "Sin anfitrión",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1025,6 +1025,7 @@ export const fr: TranslationResources = {
     },
     pinned: {
       title: "Épinglés",
+      reorder: "Glisser pour réorganiser",
     },
     host: {
       noHost: "Aucun hôte",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1006,6 +1006,7 @@ export const ja: TranslationResources = {
     },
     pinned: {
       title: "固定済み",
+      reorder: "ドラッグして並べ替え",
     },
     host: {
       noHost: "ホストなし",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1002,6 +1002,7 @@ export const ko: TranslationResources = {
     },
     pinned: {
       title: "고정됨",
+      reorder: "드래그하여 순서 변경",
     },
     host: {
       noHost: "호스트 없음",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1017,6 +1017,7 @@ export const ptBR: TranslationResources = {
     },
     pinned: {
       title: "Fixados",
+      reorder: "Arraste para reordenar",
     },
     host: {
       noHost: "Nenhum host",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1017,6 +1017,7 @@ export const ru: TranslationResources = {
     },
     pinned: {
       title: "Закреплённые",
+      reorder: "Перетащите, чтобы изменить порядок",
     },
     host: {
       noHost: "Нет хоста",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -987,6 +987,7 @@ export const zhCN: TranslationResources = {
     },
     pinned: {
       title: "已置顶",
+      reorder: "拖动以重新排序",
     },
     host: {
       noHost: "没有 Host",


### PR DESCRIPTION
## What does this PR do

The sidebar already stores a custom order for pinned chats (`pinnedWorkspaceOrder`) and has a `DraggableList`. On desktop that gesture is easy to miss: the whole row is also the click + context-menu target, so a drag never feels like a first-class action.

This adds a dedicated grip next to each pinned row (project mode and status mode). Hover (desktop) or always-on (native) shows it. Drag starts from the handle so opening a chat still works.

Saved-order merge is unchanged: new pins still land first, then the stored order.

### Type of change

- Bug fix / UX (existing reorder path was not usable)

### How did you verify it

```
cd packages/app
npx vitest run \
  src/components/sidebar/sidebar-pinned-drag-handle.test.ts \
  src/hooks/use-sidebar-pins.test.ts \
  src/stores/sidebar-order-store.test.ts

Test Files  3 passed (3)
     Tests  10 passed (10)
```

Not live-tested in Desktop against a replaced daemon (would kill in-flight agents on this machine). After merge: pin 3 workspaces, hover the Pinned list, drag the grip, reload, confirm order sticks.

### Platforms

- Unit tests only (macOS)
- Not tested: iOS, Android, live Desktop/Web

### Checklist

- One focused change
- Tests added
- Maintainer edits enabled
- Draft until live UI QA exists
