### PR TITLE
fix: reject a question permission that would deliver no answer

### DIFF
--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -1360,6 +1360,91 @@ describe("normalizeClaudeAskUserQuestionUpdatedInput", () => {
     }
   });
 
+  test("a rejected question answer leaves the request answerable by a corrected retry", async () => {
+    // The question-answer-required rule guards this: the deliverability check runs
+    // before the request is deleted, so a non-deliverable answer costs the caller a
+    // retry rather than the request. Upstream consumed the request on entry and the
+    // retry failed with "No pending permission request".
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+    });
+
+    const request = {
+      id: "permission-question-retry",
+      provider: "claude",
+      name: "AskUserQuestion",
+      kind: "question",
+      input: {
+        questions: [
+          {
+            question: "Which colour?",
+            header: "Colour",
+            options: [],
+            multiSelect: false,
+          },
+        ],
+      },
+    };
+
+    const resultPromise = new Promise<unknown>((resolve, reject) => {
+      (
+        session as unknown as {
+          pendingPermissions: Map<
+            string,
+            {
+              request: typeof request;
+              resolve: (value: unknown) => void;
+              reject: (error: Error) => void;
+            }
+          >;
+        }
+      ).pendingPermissions.set(request.id, { request, resolve, reject });
+    });
+
+    try {
+      // A non-deliverable answer: allow with no answers at all.
+      await expect(
+        session.respondToPermission(request.id, {
+          behavior: "allow",
+          updatedInput: {},
+        }),
+      ).rejects.toThrow(/Permission request/);
+
+      // The request survived the rejection: a corrected retry is accepted and the
+      // waiting agent gets the answer. If the request had been consumed, this would
+      // throw "No pending permission request with id ...".
+      await expect(
+        session.respondToPermission(request.id, {
+          behavior: "allow",
+          updatedInput: { answers: { Colour: "Viridian" } },
+        }),
+      ).resolves.toBeUndefined();
+
+      await expect(resultPromise).resolves.toEqual({
+        behavior: "allow",
+        updatedInput: {
+          questions: [
+            {
+              question: "Which colour?",
+              header: "Colour",
+              options: [],
+              multiSelect: false,
+            },
+          ],
+          answers: { "Which colour?": "Viridian" },
+        },
+        updatedPermissions: undefined,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
   test("denying a plan leaves the plan readable in the timeline", async () => {
     const client = new ClaudeAgentClient({
       logger: createTestLogger(),

--- a/packages/server/src/server/agent/providers/claude/agent.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.test.ts
@@ -9,6 +9,7 @@ import * as executableUtils from "../../../../executable-resolution/executable-r
 import { buildAgentAttentionNotificationPayload } from "@getpaseo/protocol/agent-attention-notification";
 import {
   ClaudeAgentClient,
+  claudeQuestionAnswerRejection,
   convertClaudeHistoryEntry,
   normalizeClaudeAskUserQuestionRequestInput,
   normalizeClaudeAskUserQuestionUpdatedInput,
@@ -17,7 +18,12 @@ import {
 } from "./agent.js";
 import { claudeProjectDirSync } from "./project-dir.js";
 import { streamSession } from "../test-utils/session-stream-adapter.js";
-import type { AgentSession, AgentTimelineItem, AgentStreamEvent } from "../../agent-sdk-types.js";
+import type {
+  AgentPermissionRequest,
+  AgentSession,
+  AgentTimelineItem,
+  AgentStreamEvent,
+} from "../../agent-sdk-types.js";
 
 interface TestClaudeSession {
   translateMessageToEvents(message: SDKMessage): AgentStreamEvent[];
@@ -3276,5 +3282,134 @@ describe("Claude question permission notifications", () => {
 
     expect(request.title).toBeUndefined();
     expect(request.description).toBeUndefined();
+  });
+});
+
+describe("claudeQuestionAnswerRejection", () => {
+  const questionRequest = (...questions: unknown[]): AgentPermissionRequest =>
+    ({
+      id: "permission-1",
+      provider: "claude",
+      name: "AskUserQuestion",
+      kind: "question",
+      input: {
+        questions: questions.length
+          ? questions
+          : [{ question: "Which colour?", header: "Colour", options: [] }],
+      },
+    }) as unknown as AgentPermissionRequest;
+
+  // A question whose text carries padding: `readNonEmptyString` tests the
+  // trimmed value for emptiness but returns the original, so the padding is
+  // part of the key.
+  const paddedRequest = questionRequest({ question: " Which colour? ", header: " Colour " });
+
+  const rejected: Array<[string, AgentPermissionRequest, Record<string, unknown>]> = [
+    // The shape the incident used: valid as a string, read only for `plan` kinds.
+    ["selectedActionId instead of answers", questionRequest(), { selectedActionId: "Viridian" }],
+    ["updatedInput without answers", questionRequest(), { updatedInput: { choice: "Viridian" } }],
+    ["an empty answers map", questionRequest(), { updatedInput: { answers: {} } }],
+    ["an answers array", questionRequest(), { updatedInput: { answers: ["Viridian"] } }],
+    ["a key matching no question", questionRequest(), { updatedInput: { answers: { Hue: "V" } } }],
+    ["a blank answer", questionRequest(), { updatedInput: { answers: { Colour: "  " } } }],
+    ["a non-string answer", questionRequest(), { updatedInput: { answers: { Colour: 1 } } }],
+    [
+      "a trimmed key for a padded question",
+      paddedRequest,
+      {
+        updatedInput: { answers: { "Which colour?": "V" } },
+      },
+    ],
+    // `Array.isArray([])` is true, so an empty echoed list wins over the
+    // request's own questions and maps nothing.
+    [
+      "an empty echoed question list",
+      questionRequest(),
+      {
+        updatedInput: { questions: [], answers: { Colour: "V" } },
+      },
+    ],
+  ];
+
+  for (const [label, request, response] of rejected) {
+    test(`rejects ${label}`, () => {
+      expect(claudeQuestionAnswerRejection(request, { behavior: "allow", ...response })).toContain(
+        "still pending",
+      );
+    });
+  }
+
+  const accepted: Array<[string, AgentPermissionRequest, Record<string, unknown>]> = [
+    ["keyed by header", questionRequest(), { updatedInput: { answers: { Colour: "V" } } }],
+    [
+      "keyed by full question text",
+      questionRequest(),
+      {
+        updatedInput: { answers: { "Which colour?": "V" } },
+      },
+    ],
+    [
+      "keyed by a padded question's exact text",
+      paddedRequest,
+      {
+        updatedInput: { answers: { " Which colour? ": "V" } },
+      },
+    ],
+    [
+      "keyed by a padded header",
+      paddedRequest,
+      {
+        updatedInput: { answers: { " Colour ": "V" } },
+      },
+    ],
+    // The normalizer keeps whatever it can map, so a partial answer delivers.
+    [
+      "answering one of two questions",
+      questionRequest(
+        { question: "Which colour?", header: "Colour" },
+        { question: "Ship it?", header: "Ship" },
+      ),
+      { updatedInput: { answers: { Ship: "Yes" } } },
+    ],
+    [
+      "questions the caller echoed back",
+      questionRequest(),
+      {
+        updatedInput: {
+          questions: [{ question: "Ship it?", header: "Ship" }],
+          answers: { Ship: "Y" },
+        },
+      },
+    ],
+  ];
+
+  for (const [label, request, response] of accepted) {
+    test(`accepts an answer ${label}`, () => {
+      expect(claudeQuestionAnswerRejection(request, { behavior: "allow", ...response })).toBeNull();
+    });
+  }
+
+  test("leaves deny alone, which needs no answers", () => {
+    expect(claudeQuestionAnswerRejection(questionRequest(), { behavior: "deny" })).toBeNull();
+  });
+
+  test("leaves non-question requests alone", () => {
+    const toolRequest = { ...questionRequest(), kind: "tool" } as AgentPermissionRequest;
+    expect(claudeQuestionAnswerRejection(toolRequest, { behavior: "allow" })).toBeNull();
+  });
+
+  test("names the keys the request accepts, padding included", () => {
+    const message = claudeQuestionAnswerRejection(paddedRequest, { behavior: "allow" });
+    expect(message).toContain('" Which colour? "');
+    expect(message).toContain('" Colour "');
+  });
+
+  test("names the echoed keys when the caller supplied their own questions", () => {
+    const message = claudeQuestionAnswerRejection(questionRequest(), {
+      behavior: "allow",
+      updatedInput: { questions: [{ question: "Ship it?", header: "Ship" }], answers: {} },
+    });
+    expect(message).toContain("Ship it?");
+    expect(message).not.toContain("Which colour?");
   });
 });

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -195,24 +195,26 @@ function stripClaudeAskUserQuestionUiMetadata(input: AgentMetadata): AgentMetada
   };
 }
 
-export function normalizeClaudeAskUserQuestionUpdatedInput(
+/**
+ * The answers this response will actually deliver, keyed by full question text,
+ * or null when there is no question list and answers map to work from.
+ *
+ * Shared by the normalizer and by the check that rejects an undeliverable
+ * answer, so the two can never disagree about what "deliverable" means.
+ */
+function resolveClaudeAskUserQuestionAnswers(
   updatedInput: AgentMetadata | undefined,
   fallbackInput: AgentMetadata | undefined,
-): AgentMetadata {
+): Record<string, string> | null {
   const fallback = isMetadata(fallbackInput) ? fallbackInput : {};
   const base = isMetadata(updatedInput) ? updatedInput : {};
-  // Paseo's shared question UI serializes answers by question header, but Claude's
-  // AskUserQuestion tool expects answer keys to match the full question text. Merge
-  // the original request payload back in so provider callbacks that only return
-  // `{ answers }` still satisfy Claude's full tool input schema.
-  const merged = stripClaudeAskUserQuestionUiMetadata({ ...fallback, ...base });
   const questions =
     (Array.isArray(base.questions) ? base.questions : null) ??
     (Array.isArray(fallback.questions) ? fallback.questions : null);
   const answers = isMetadata(base.answers) ? base.answers : null;
 
   if (!questions || !answers) {
-    return merged;
+    return null;
   }
 
   const normalizedAnswers: Record<string, string> = {};
@@ -236,7 +238,23 @@ export function normalizeClaudeAskUserQuestionUpdatedInput(
     }
   }
 
-  if (Object.keys(normalizedAnswers).length === 0) {
+  return normalizedAnswers;
+}
+
+export function normalizeClaudeAskUserQuestionUpdatedInput(
+  updatedInput: AgentMetadata | undefined,
+  fallbackInput: AgentMetadata | undefined,
+): AgentMetadata {
+  const fallback = isMetadata(fallbackInput) ? fallbackInput : {};
+  const base = isMetadata(updatedInput) ? updatedInput : {};
+  // Paseo's shared question UI serializes answers by question header, but Claude's
+  // AskUserQuestion tool expects answer keys to match the full question text. Merge
+  // the original request payload back in so provider callbacks that only return
+  // `{ answers }` still satisfy Claude's full tool input schema.
+  const merged = stripClaudeAskUserQuestionUiMetadata({ ...fallback, ...base });
+  const normalizedAnswers = resolveClaudeAskUserQuestionAnswers(updatedInput, fallbackInput);
+
+  if (!normalizedAnswers || Object.keys(normalizedAnswers).length === 0) {
     return merged;
   }
 
@@ -244,6 +262,86 @@ export function normalizeClaudeAskUserQuestionUpdatedInput(
     ...merged,
     answers: normalizedAnswers,
   };
+}
+
+/**
+ * The reason an `allow` on a question permission would deliver no answer, or
+ * null when it delivers one.
+ *
+ * A question answered in any shape but `updatedInput.answers` keyed by one of
+ * its questions resolves as `allow` and delivers nothing, and the waiting agent
+ * is told "The user did not answer the questions." — an affirmative falsehood
+ * rather than silence, so neither side sees the failure. The field most natural
+ * to reach for cannot work: `selectedActionId` is optional with no membership
+ * check and is read only for `plan` kinds, while a question advertises no
+ * actions at all.
+ *
+ * This asks `resolveClaudeAskUserQuestionAnswers` rather than restating its
+ * rule, so the check cannot drift from the mapping it guards — including the
+ * two details easiest to get wrong, that `readNonEmptyString` returns the
+ * original string rather than a trimmed one, and that an empty
+ * `updatedInput.questions` array is a list that wins over the request's own.
+ */
+export function claudeQuestionAnswerRejection(
+  request: AgentPermissionRequest,
+  response: AgentPermissionResponse,
+): string | null {
+  if (request.kind !== "question" || response.behavior !== "allow") {
+    return null;
+  }
+
+  const answers = resolveClaudeAskUserQuestionAnswers(response.updatedInput, request.input);
+  if (answers && Object.keys(answers).length > 0) {
+    return null;
+  }
+
+  const echoed = response.updatedInput?.questions;
+  const stored = request.input?.questions;
+  let questions: unknown[] = [];
+  if (Array.isArray(echoed)) {
+    questions = echoed;
+  } else if (Array.isArray(stored)) {
+    questions = stored;
+  }
+
+  const acceptedKeys: string[] = [];
+  for (const item of questions) {
+    const question = isMetadata(item) ? item : null;
+    const questionText = question ? readNonEmptyString(question.question) : null;
+    if (!questionText) {
+      continue;
+    }
+    acceptedKeys.push(questionText);
+    const header = readNonEmptyString(question?.header);
+    if (header) {
+      acceptedKeys.push(header);
+    }
+  }
+
+  const example = acceptedKeys[0] ?? "<question text or header>";
+  const accepted =
+    acceptedKeys.length > 0
+      ? ` Accepted keys: ${acceptedKeys.map((key) => JSON.stringify(key)).join(", ")}.`
+      : "";
+  return (
+    `Permission request '${request.id}' is a question: allow requires ` +
+    `updatedInput.answers keyed by a question's full text or its header, with a ` +
+    `non-empty string value, e.g. {"answers":{${JSON.stringify(example)}:"<answer>"}}.` +
+    `${accepted} ` +
+    `selectedActionId is ignored for question requests. ` +
+    `The request is still pending; answer it again with that shape.`
+  );
+}
+
+/** Throws `claudeQuestionAnswerRejection`'s reason, or returns. */
+function assertClaudeQuestionAnswerDeliverable(
+  request: AgentPermissionRequest,
+  response: AgentPermissionResponse,
+): void {
+  const rejection = claudeQuestionAnswerRejection(request, response);
+  if (rejection) {
+    throw new Error(rejection);
+  }
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -2596,6 +2694,12 @@ class ClaudeAgentSession implements AgentSession {
     if (!pending) {
       throw new Error(`No pending permission request with id '${requestId}'`);
     }
+
+    // Before the delete below, so a rejected answer leaves the request pending
+    // and answerable rather than consuming it for nothing. AgentManager only
+    // drops its own copy once this resolves, so both maps survive the throw.
+    assertClaudeQuestionAnswerDeliverable(pending.request, response);
+
     this.pendingPermissions.delete(requestId);
     pending.cleanup?.();
 


### PR DESCRIPTION
Answering an `AskUserQuestion` permission in any shape but `updatedInput.answers` keyed by one of its questions resolves as `allow` and delivers nothing. The waiting agent is told **"The user did not answer the questions."** — an affirmative falsehood rather than silence, so neither side can see that anything failed. The responder sees success; the agent believes the human declined and acts on that.

The field it is most natural to reach for cannot work. `selectedActionId` is `z.string().optional()` with no membership check, and is read only for `plan` kinds; a question advertises `actions: undefined`, so there is no action id to name in the first place.

It is also unrecoverable. `respondToPermission` deletes the request from `pendingPermissions` on entry, so the malformed answer consumes it and the retry fails with `No pending permission request`. The guard runs **before** that delete, and `AgentManager` drops its own copy only once the call resolves, so both maps survive the throw and the request stays answerable.

## Why it sits in the Claude provider

The answer contract is per provider, not shared:

| provider | mapping | unmapped answer |
| --- | --- | --- |
| claude | key is a question's full text **or** its header, value a non-empty string | nothing is delivered — the defect |
| codex | `mapCodexQuestionResponseByHeader`, headers only | **selects each question's first option** — a supported path |
| opencode | headers only | an empty answer list per question |

An earlier revision of this PR put the check in `AgentManager.respondToPermission`, the join point for all three. That forced it to restate Claude's rule and to scope itself with `provider === "claude"`, and the restatement was wrong twice — it trimmed keys the normalizer does not trim, and read an empty `updatedInput.questions` array as an absent one.

Putting the guard beside the rule makes both classes of bug impossible. `resolveClaudeAskUserQuestionAnswers` is extracted from `normalizeClaudeAskUserQuestionUpdatedInput` with **no change in behaviour** — the 69 existing tests in this file pass untouched — and both it and the guard now call it. So "would this deliver anything" is answered by the code that does the delivering.

That matters more than it looks, because the rule has two details that are easy to restate wrongly:

- `readNonEmptyString` tests `value.trim()` for emptiness but returns the **original** string, so a question named `" Which colour? "` is keyed by that padding. A trimming check would accept `{"answers":{"Which colour?":…}}`, which cannot be mapped — preserving the exact destructive path this PR closes — and reject `{"answers":{" Which colour? ":…}}`, which can.
- An empty `updatedInput.questions` array is a **list**, tested with `Array.isArray`: it wins over the request's own questions and maps nothing.

Neither needs stating in the guard now, because the guard does not restate the rule at all.

## Verification

On a live daemon over the MCP `respond_to_permission` path, against a `claude` agent whose question text is literally `" Which colour? "`:

| response | result |
| --- | --- |
| `{"behavior":"allow","selectedActionId":"Viridian"}` | rejected, request still pending |
| `{"answers":{"Which colour?":"Viridian"}}` | rejected, still pending |
| `{"questions":[],"answers":{"Colour":"Viridian"}}` | rejected, still pending |
| `{"answers":{"Colour":1}}` | rejected, still pending |
| `{"answers":{" Which colour? ":"Ochre"}}` | `success: true`, and the agent replies `Ochre` |

19 new tests in `providers/claude/agent.test.ts`, next to the normalizer tests they extend. No new files; `agent-manager.ts` is untouched.

## Regression test for the retry ordering

Added a test that asserts the ordering the fix depends on: a non-deliverable answer is rejected, the pending request survives the rejection, and a corrected retry against the same request is accepted — the waiting agent receives the answer.

Mutation testing on this change found that the existing suite doesn't pin that ordering: moving the deliverability check to run after the request is deleted from `pendingPermissions` still leaves every existing test in the file green. This test fails against that change.

## Known limit

The WebSocket path (`session.ts handleAgentPermissionResponse`) catches the throw and emits an `activity_log` error rather than failing the caller's call, because a permission response is modelled as a notification rather than a request. So `paseo permit allow` still prints `allowed` and exits 0 for a rejected shape. The destructive half is closed on every path — the request survives and the agent is never told a falsehood — but closing the reporting half needs a protocol change and is left out of this PR.
