### PR TITLE
fix(pi): don't complete the active turn on a mid-turn custom message

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -793,6 +793,43 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("does not complete an active agent turn on a mid-turn custom message", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("do work");
+    // An agent turn is running; a real `agent_end` will close it.
+    fakeSession.emit({ type: "agent_start" });
+
+    // An extension emits a custom message mid-turn via `pi.sendMessage`. It
+    // surfaces as a timeline item but must not complete the turn.
+    fakeSession.emit({
+      type: "message_end",
+      message: {
+        role: "custom",
+        content: [{ type: "text", text: "extension side-channel output" }],
+      },
+    });
+
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      {
+        type: "timeline",
+        item: { type: "assistant_message", text: "extension side-channel output" },
+      },
+    ]);
+
+    // Only the real terminal signal completes the turn.
+    fakeSession.emit({ type: "agent_end", messages: [] });
+
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      {
+        type: "timeline",
+        item: { type: "assistant_message", text: "extension side-channel output" },
+      },
+      { type: "turn_completed" },
+    ]);
+  });
+
   test("canceling a silent Pi extension command leaves the session usable", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2247,7 +2247,14 @@ export class PiRpcAgentSession implements AgentSession {
           item: { type: "assistant_message", text },
         });
       }
-      this.completeTurn(turnId, []);
+      // Complete the turn only when this custom message is the whole turn: an
+      // extension command (e.g. `/show-status`) that never starts an agent
+      // turn, so no `agent_end` follows. During an active agent turn a custom
+      // message is side-channel output (an extension calling `pi.sendMessage`);
+      // the turn completes on `agent_end`.
+      if (!this.activeTurnStarted) {
+        this.completeTurn(turnId, []);
+      }
       return;
     }
   }


### PR DESCRIPTION
### Linked issue

Closes #3496

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A parent that delegates to a background pi agent relies on the finish notification. It was firing mid-task: `handleMessageEnd` completed the active turn on every `custom` message, and pi extensions emit `custom` messages during tool activity (injected guidance, lineage, usage stats). So a mid-turn `custom` message ended the turn early, and the parent got a `finished` whose body was the injected text instead of the result, with the agent's work cut short or continued under a synthetic turn.

Completing on a `custom` message is only correct for an extension command (e.g. `/show-status`) that emits one and never starts an agent turn, so no `agent_end` follows. An existing test covers that; the branch just didn't distinguish it from a mid-turn injection.

### Goals

- A mid-turn `custom` message no longer completes the active turn; the turn ends on `agent_end`.
- The extension-command case (custom message is the whole turn, no `agent_end`) still completes.

### Non-goals

- Scoped to the pi adapter's `handleMessageEnd`; no change to `agent-prompt.ts` or other providers.
- Does not touch the OMP variant of the same class (#3252).

### QA

Repro: a background pi agent (`cursor/composer-2.5`) with guidance-injecting extensions, given a read-heavy task, sent its parent a `finished` whose body was a raw guidance block, `outputTokens` ~170, task never done.

Fix gates completion on `!this.activeTurnStarted`. New regression test fails on the old code, passes on the new:

```
$ vitest run providers/pi/agent.test.ts -t "does not complete an active agent turn"   # old code
 Tests  1 failed | 56 skipped (57)

$ vitest run providers/pi/agent.test.ts                                                # with fix
 Tests  57 passed (57)
```

```
$ oxlint <the two files>                    → 0 warnings, 0 errors
$ oxfmt --check <the two files>             → correct format
$ npm run build:server && npm run typecheck → exit 0, 0 errors
```

Platforms: daemon unit tests on macOS. No UI change.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
