### PR TITLE
fix(app): make mouse back/forward buttons navigate on desktop

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -84,6 +84,7 @@ import { useGlobalNewWorkspaceAction } from "@/hooks/use-global-new-workspace-ac
 import { useLatchedBoolean } from "@/hooks/use-latched-boolean";
 import { useFaviconStatus } from "@/hooks/use-favicon-status";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { useMouseNavigationButtons } from "@/hooks/use-mouse-navigation-buttons";
 import { KeyboardShiftProvider } from "@/hooks/use-keyboard-shift-style";
 import { useCompactWebViewportZoomLock } from "@/hooks/use-compact-web-viewport-zoom-lock";
 import { useOpenProject } from "@/hooks/use-open-project";
@@ -520,6 +521,8 @@ function AppContainer({ children, chromeEnabled: chromeEnabledOverride }: AppCon
     exitFocusMode,
     cycleTheme,
   });
+
+  useMouseNavigationButtons();
 
   useActiveWorktreeNewAction();
   useGlobalNewWorkspaceAction();

--- a/packages/app/src/hooks/use-mouse-navigation-buttons.test.tsx
+++ b/packages/app/src/hooks/use-mouse-navigation-buttons.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useMouseNavigationButtons } from "./use-mouse-navigation-buttons";
+
+const electronState = vi.hoisted(() => ({ isElectron: true }));
+const navState = vi.hoisted(() => ({
+  pathname: "/welcome",
+  pushCalls: [] as string[],
+  workspaceCalls: [] as Array<{ serverId: string; workspaceId: string }>,
+}));
+
+vi.mock("@/constants/platform", () => ({
+  isWeb: true,
+  isNative: false,
+  getIsElectron: () => electronState.isElectron,
+}));
+
+vi.mock("expo-router", () => ({
+  usePathname: () => navState.pathname,
+  useRouter: () => ({
+    push: (route: string) => {
+      navState.pushCalls.push(route);
+    },
+  }),
+}));
+
+vi.mock("@/stores/navigation-active-workspace-store", () => ({
+  navigateToWorkspace: (input: { serverId: string; workspaceId: string }) => {
+    navState.workspaceCalls.push(input);
+    return `${input.serverId}/${input.workspaceId}`;
+  },
+}));
+
+function press(button: number): { downDefaultPrevented: boolean; upDefaultPrevented: boolean } {
+  // jsdom lacks PointerEvent; the handlers only read .button, so a MouseEvent
+  // dispatched under the pointerdown/pointerup type is enough.
+  const down = new MouseEvent("pointerdown", { button, cancelable: true });
+  const up = new MouseEvent("pointerup", { button, cancelable: true });
+  window.dispatchEvent(down);
+  window.dispatchEvent(up);
+  return { downDefaultPrevented: down.defaultPrevented, upDefaultPrevented: up.defaultPrevented };
+}
+
+/** Wait out the tracker's settle delay so a pathname gets recorded. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 120));
+  });
+}
+
+function renderWithPathname(pathname: string) {
+  navState.pathname = pathname;
+  return renderHook(() => useMouseNavigationButtons());
+}
+
+async function navigateTo(
+  hook: ReturnType<typeof renderWithPathname>,
+  pathname: string,
+  options?: { commit?: boolean },
+) {
+  navState.pathname = pathname;
+  hook.rerender();
+  if (options?.commit !== false) {
+    await settle();
+  }
+}
+
+describe("useMouseNavigationButtons", () => {
+  afterEach(() => {
+    cleanup();
+    electronState.isElectron = true;
+    navState.pathname = "/welcome";
+    navState.pushCalls = [];
+    navState.workspaceCalls = [];
+  });
+
+  it("walks back and forward through recorded views", async () => {
+    const hook = renderWithPathname("/welcome");
+    await settle();
+    await navigateTo(hook, "/h/srv_1/workspace/ws_1");
+    await navigateTo(hook, "/settings/general");
+
+    press(3);
+    expect(navState.workspaceCalls).toEqual([{ serverId: "srv_1", workspaceId: "ws_1" }]);
+
+    // The back navigation commits: pathname lands on the tracker target and
+    // must not be re-recorded (or the forward stack would be truncated).
+    await navigateTo(hook, "/h/srv_1/workspace/ws_1", { commit: false });
+
+    press(3);
+    expect(navState.pushCalls).toEqual(["/welcome"]);
+
+    await navigateTo(hook, "/welcome", { commit: false });
+
+    press(4);
+    expect(navState.workspaceCalls).toHaveLength(2);
+    await navigateTo(hook, "/h/srv_1/workspace/ws_1", { commit: false });
+    press(4);
+    expect(navState.pushCalls).toEqual(["/welcome", "/settings/general"]);
+  });
+
+  it("prevents the Chromium default navigation on both pointerdown and pointerup", async () => {
+    renderWithPathname("/welcome");
+    await settle();
+
+    const result = press(3);
+
+    expect(result.downDefaultPrevented).toBe(true);
+    expect(result.upDefaultPrevented).toBe(true);
+  });
+
+  it("does nothing at the oldest entry", async () => {
+    renderWithPathname("/welcome");
+    await settle();
+
+    press(3);
+
+    expect(navState.workspaceCalls).toEqual([]);
+    expect(navState.pushCalls).toEqual([]);
+  });
+
+  it("ignores primary, middle, and secondary buttons", async () => {
+    renderWithPathname("/welcome");
+    await settle();
+
+    press(0);
+    press(1);
+    press(2);
+
+    expect(navState.workspaceCalls).toEqual([]);
+    expect(navState.pushCalls).toEqual([]);
+  });
+
+  it("does not record transient redirect routes", async () => {
+    const hook = renderWithPathname("/");
+    await settle();
+    await navigateTo(hook, "/h/srv_1");
+    await navigateTo(hook, "/h/srv_1/agent/agent_1");
+    await navigateTo(hook, "/h/srv_1/workspace/ws_1");
+
+    press(3);
+
+    // "/", the host index, and the agent redirector were skipped, so the
+    // first recorded view is the workspace itself and there is nowhere to go.
+    expect(navState.workspaceCalls).toEqual([]);
+    expect(navState.pushCalls).toEqual([]);
+  });
+
+  it("does not record pathnames that redirect away before settling", async () => {
+    const hook = renderWithPathname("/open-project");
+    await settle();
+    // /settings immediately replaces itself with /settings/general.
+    await navigateTo(hook, "/settings", { commit: false });
+    await navigateTo(hook, "/settings/general");
+
+    press(3);
+
+    // Back goes straight to /open-project, not the /settings redirector.
+    expect(navState.pushCalls).toEqual(["/open-project"]);
+  });
+
+  it("truncates the forward stack when a fresh view is visited after going back", async () => {
+    const hook = renderWithPathname("/h/srv_1/workspace/ws_1");
+    await settle();
+    await navigateTo(hook, "/h/srv_1/workspace/ws_2");
+
+    press(3);
+    expect(navState.workspaceCalls).toEqual([{ serverId: "srv_1", workspaceId: "ws_1" }]);
+    await navigateTo(hook, "/h/srv_1/workspace/ws_1", { commit: false });
+
+    // User navigates somewhere new instead of going forward.
+    await navigateTo(hook, "/h/srv_1/workspace/ws_3");
+
+    press(4);
+    expect(navState.workspaceCalls).toHaveLength(1);
+    expect(navState.pushCalls).toEqual([]);
+  });
+
+  it("does not intercept the buttons in a plain browser", async () => {
+    electronState.isElectron = false;
+    renderWithPathname("/welcome");
+    await settle();
+
+    const result = press(3);
+
+    expect(result.downDefaultPrevented).toBe(false);
+    expect(result.upDefaultPrevented).toBe(false);
+    expect(navState.workspaceCalls).toEqual([]);
+    expect(navState.pushCalls).toEqual([]);
+  });
+
+  it("removes the listeners on unmount", async () => {
+    const hook = renderWithPathname("/welcome");
+    await settle();
+    hook.unmount();
+
+    const result = press(3);
+
+    expect(result.downDefaultPrevented).toBe(false);
+  });
+});

--- a/packages/app/src/hooks/use-mouse-navigation-buttons.ts
+++ b/packages/app/src/hooks/use-mouse-navigation-buttons.ts
@@ -1,0 +1,4 @@
+// Native no-op — mice with back/forward buttons are a desktop concern. The web
+// implementation lives in ./use-mouse-navigation-buttons.web.ts; Metro resolves
+// that file on web builds.
+export function useMouseNavigationButtons(): void {}

--- a/packages/app/src/hooks/use-mouse-navigation-buttons.web.ts
+++ b/packages/app/src/hooks/use-mouse-navigation-buttons.web.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react";
+import { usePathname, useRouter, type Href } from "expo-router";
+import { getIsElectron } from "@/constants/platform";
+import { createViewHistoryTracker, shouldRecordPathname } from "@/navigation/view-history-tracker";
+import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
+import { parseHostWorkspaceRouteFromPathname } from "@/utils/host-routes";
+
+// Mouse button 3 is "back" (X1), button 4 is "forward" (X2). Chromium navigates
+// browser history on these natively, but in-app navigation mostly uses
+// dismissTo()/replace(), so browser history has no entries to walk and the
+// default no-ops. The app therefore keeps its own view history and suppresses
+// the Chromium default: preventDefault() on pointerdown cancels it (on
+// mousedown it does not) and also suppresses the compat mouse events for the
+// press — harmless, nothing in the app reads button 3/4 mouse events.
+//
+// Electron-only: in a plain browser the default navigation already works for
+// pushed routes and intercepting the buttons would change browser-back
+// semantics.
+const BACK_BUTTON = 3;
+const FORWARD_BUTTON = 4;
+
+// Section redirects (e.g. /settings -> /settings/general) replace themselves
+// within a tick. Wait for a pathname to actually rest before recording it so
+// back never lands on a route that flings you forward again.
+const SETTLE_MS = 80;
+
+export function useMouseNavigationButtons(): void {
+  const pathname = usePathname();
+  const router = useRouter();
+  const trackerRef = useRef(createViewHistoryTracker());
+  const expectedNavigationRef = useRef<string | null>(null);
+  const routerRef = useRef(router);
+  routerRef.current = router;
+
+  useEffect(() => {
+    // Back/forward navigation resolves to this pathname next; the tracker
+    // already moved its index, so don't re-record it as a fresh view — that
+    // would truncate the forward stack.
+    if (expectedNavigationRef.current === pathname) {
+      expectedNavigationRef.current = null;
+      return;
+    }
+    expectedNavigationRef.current = null;
+    if (!shouldRecordPathname(pathname)) {
+      return;
+    }
+    const timer = setTimeout(() => trackerRef.current.record(pathname), SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!getIsElectron()) {
+      return () => {};
+    }
+
+    const navigateTo = (target: string | null) => {
+      if (!target) return;
+      expectedNavigationRef.current = target;
+      const workspace = parseHostWorkspaceRouteFromPathname(target);
+      if (workspace) {
+        navigateToWorkspace(workspace);
+      } else {
+        routerRef.current.push(target as Href);
+      }
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.button === BACK_BUTTON || event.button === FORWARD_BUTTON) {
+        event.preventDefault();
+      }
+    };
+    const handlePointerUp = (event: PointerEvent) => {
+      if (event.button === BACK_BUTTON) {
+        event.preventDefault();
+        navigateTo(trackerRef.current.goBack());
+      } else if (event.button === FORWARD_BUTTON) {
+        event.preventDefault();
+        navigateTo(trackerRef.current.goForward());
+      }
+    };
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    window.addEventListener("pointerup", handlePointerUp, true);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("pointerup", handlePointerUp, true);
+    };
+  }, []);
+}

--- a/packages/app/src/navigation/view-history-tracker.test.ts
+++ b/packages/app/src/navigation/view-history-tracker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createViewHistoryTracker, shouldRecordPathname } from "@/navigation/view-history-tracker";
+
+describe("createViewHistoryTracker", () => {
+  it("walks back and forward through recorded views", () => {
+    const tracker = createViewHistoryTracker();
+    tracker.record("/a");
+    tracker.record("/b");
+    tracker.record("/c");
+
+    expect(tracker.goBack()).toBe("/b");
+    expect(tracker.goBack()).toBe("/a");
+    expect(tracker.goForward()).toBe("/b");
+    expect(tracker.goForward()).toBe("/c");
+  });
+
+  it("returns null at the boundaries", () => {
+    const tracker = createViewHistoryTracker();
+    expect(tracker.goBack()).toBeNull();
+    expect(tracker.goForward()).toBeNull();
+
+    tracker.record("/a");
+    expect(tracker.goBack()).toBeNull();
+    expect(tracker.goForward()).toBeNull();
+  });
+
+  it("ignores consecutive duplicates", () => {
+    const tracker = createViewHistoryTracker();
+    tracker.record("/a");
+    tracker.record("/a");
+    tracker.record("/b");
+
+    expect(tracker.goBack()).toBe("/a");
+    expect(tracker.goBack()).toBeNull();
+  });
+
+  it("truncates the forward stack when a new view is recorded after going back", () => {
+    const tracker = createViewHistoryTracker();
+    tracker.record("/a");
+    tracker.record("/b");
+    tracker.record("/c");
+
+    expect(tracker.goBack()).toBe("/b");
+    tracker.record("/d");
+
+    expect(tracker.goForward()).toBeNull();
+    expect(tracker.goBack()).toBe("/b");
+    expect(tracker.goBack()).toBe("/a");
+  });
+});
+
+describe("shouldRecordPathname", () => {
+  it("records ordinary app and workspace routes", () => {
+    expect(shouldRecordPathname("/settings/general")).toBe(true);
+    expect(shouldRecordPathname("/h/srv_1/workspace/ws_1")).toBe(true);
+    expect(shouldRecordPathname("/new")).toBe(true);
+  });
+
+  it("skips transient redirect routes", () => {
+    expect(shouldRecordPathname("/")).toBe(false);
+    expect(shouldRecordPathname("/h/srv_1")).toBe(false);
+    expect(shouldRecordPathname("/h/srv_1/")).toBe(false);
+    expect(shouldRecordPathname("/h/srv_1/agent/agent_1")).toBe(false);
+  });
+});

--- a/packages/app/src/navigation/view-history-tracker.ts
+++ b/packages/app/src/navigation/view-history-tracker.ts
@@ -1,0 +1,59 @@
+import { parseHostAgentRouteFromPathname } from "@/utils/host-routes";
+
+/**
+ * App-level back/forward view history, driven by the desktop app's mouse
+ * back/forward buttons.
+ *
+ * Why this exists: in-app navigation mostly uses dismissTo()/replace(), so
+ * browser history almost never accumulates entries (history.length stays 1)
+ * and Chromium's built-in mouse-button navigation has nothing to walk. This
+ * tracker records committed pathnames and answers "where was I before" —
+ * Slack-style previous/next view.
+ */
+export interface ViewHistoryTracker {
+  /** Record a newly committed pathname as the current view. */
+  record(pathname: string): void;
+  /** Move back; returns the pathname to show, or null at the oldest entry. */
+  goBack(): string | null;
+  /** Move forward; returns the pathname to show, or null at the newest entry. */
+  goForward(): string | null;
+}
+
+export function createViewHistoryTracker(): ViewHistoryTracker {
+  let entries: string[] = [];
+  let index = -1;
+
+  return {
+    record(pathname) {
+      if (index >= 0 && entries[index] === pathname) return;
+      // A fresh view after going back truncates the forward stack, matching
+      // browser history semantics.
+      entries = entries.slice(0, index + 1);
+      entries.push(pathname);
+      index = entries.length - 1;
+    },
+    goBack() {
+      if (index <= 0) return null;
+      index -= 1;
+      return entries[index] ?? null;
+    },
+    goForward() {
+      if (index >= entries.length - 1) return null;
+      index += 1;
+      return entries[index] ?? null;
+    },
+  };
+}
+
+/**
+ * Routes that bounce straight through to somewhere else: the startup chooser
+ * (/), the host index (restores the remembered workspace), and the agent
+ * detail route (resolves then redirects into the workspace). Recording them
+ * would make "back" land on a redirect that flings you forward again.
+ */
+export function shouldRecordPathname(pathname: string): boolean {
+  if (pathname === "/") return false;
+  if (/^\/h\/[^/]+\/?$/.test(pathname)) return false;
+  if (parseHostAgentRouteFromPathname(pathname)) return false;
+  return true;
+}


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Reasoning

In the desktop app, mouse back/forward buttons receive genuine button 3/4 events, but Paseo navigation mostly uses `dismissTo()` and `replace()`. Chromium's browser history therefore has no useful entries to traverse, and the button presses silently do nothing.

This change suppresses Chromium's default handling in Electron and drives an app-level view history so the buttons traverse the routes the user actually visited.

### What changed

- Record settled app pathnames in an Electron-only view history.
- Route workspace history targets through `navigateToWorkspace()` and other targets through Expo Router.
- Skip transient redirect routes, including `/`, host indexes, and agent redirectors.
- Keep plain browser behavior unchanged and provide a native no-op module.

### Non-goals

- Agent-tab-level history; this is route/workspace-level navigation.
- Handling presses over in-app browser `<webview>` panes, which have separate web contents.

### QA

Validation against current upstream `main`:

- `npx vitest run packages/app/src/navigation/view-history-tracker.test.ts packages/app/src/hooks/use-mouse-navigation-buttons.test.tsx --bail=1` — 15 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 warnings and 0 errors.
- `npm run format:check` — passed.
- `PASEO_WEB_PLATFORM=electron npx expo export --platform web` from `packages/app` — exported successfully.

The source PR documents end-to-end validation in the real Electron desktop app and with physical mouse hardware on macOS. That manual hardware pass was not repeated while porting the commit to upstream.

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Native implementation is a no-op. |
| Android | No | Native implementation is a no-op. |
| Web | Automated | Plain-browser interception is disabled and unit-covered. |
| Desktop macOS | Source PR | Electron 41.2.0 dev and installed builds with physical hardware. |
| Desktop Windows | No | Same Electron code path; hardware unverified. |
| Desktop Linux | No | Same Electron code path; hardware unverified. |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] Tests added where they cover the regression
