### PR TITLE
Navigate lists with Ctrl+N and Ctrl+P

### DIFF
--- a/docs/floating-panels.md
+++ b/docs/floating-panels.md
@@ -92,6 +92,12 @@ highest painted scope alone receives overlay keys, traps focus, and restores
 focus when it closes. Do not add component-local global Escape listeners: two
 stacked overlays would both close on one keypress.
 
+Search fields and menus that drive a result list also own Ctrl+N, Ctrl+P,
+ArrowUp, ArrowDown, and Enter. Mark the active web surface with the shared
+list-search dataset so capture-phase global shortcuts yield, and register the
+active native surface with the list-search dispatcher. Only the topmost open
+surface handles the event.
+
 If an overlay is rendered by a global host rather than beneath its opener in
 the React tree, carry the opener's current layer through the host store and
 restore it with `OverlayLayerProvider`. Otherwise painting and keyboard

--- a/packages/app/e2e/browser/command-center-scroll.spec.ts
+++ b/packages/app/e2e/browser/command-center-scroll.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "../support/fixtures";
+import { expect, test } from "../support/fixtures";
 import { gotoAppShell } from "../support/helpers/app";
 import {
   expectCommandCenterToRemainAtTheTop,
@@ -50,4 +50,25 @@ test("opening the command center keeps its first result fully visible", async ({
   } finally {
     await seeded.cleanup();
   }
+});
+
+test("Ctrl+N and Ctrl+P move the command center highlight", async ({ page }) => {
+  await gotoAppShell(page);
+  const panel = await openCommandCenterWithKeyboard(page);
+  const newWorkspace = panel.getByRole("button").filter({ hasText: "New workspace" });
+  const history = panel.getByRole("button").filter({ hasText: "History" });
+  const background = (locator: typeof newWorkspace) =>
+    locator.evaluate((element) => getComputedStyle(element).backgroundColor);
+
+  const activeBackground = await background(newWorkspace);
+  const inactiveBackground = await background(history);
+  expect(activeBackground).not.toBe(inactiveBackground);
+
+  await page.keyboard.press("Control+n");
+  await expect.poll(() => background(history)).toBe(activeBackground);
+  await expect(panel).toBeVisible();
+
+  await page.keyboard.press("Control+p");
+  await expect.poll(() => background(newWorkspace)).toBe(activeBackground);
+  await expect(panel).toBeVisible();
 });

--- a/packages/app/e2e/browser/command-center-scroll.spec.ts
+++ b/packages/app/e2e/browser/command-center-scroll.spec.ts
@@ -9,6 +9,10 @@ import {
   observeCommandCenterScroll,
   openCommandCenterWithKeyboard,
 } from "../support/helpers/command-center-scroll";
+import {
+  captureActiveListHighlight,
+  navigateToHighlightedListItem,
+} from "../support/helpers/list-navigation";
 import { seedWorkspace } from "../support/helpers/seed-client";
 
 test.use({
@@ -57,18 +61,11 @@ test("Ctrl+N and Ctrl+P move the command center highlight", async ({ page }) => 
   const panel = await openCommandCenterWithKeyboard(page);
   const newWorkspace = panel.getByRole("button").filter({ hasText: "New workspace" });
   const history = panel.getByRole("button").filter({ hasText: "History" });
-  const background = (locator: typeof newWorkspace) =>
-    locator.evaluate((element) => getComputedStyle(element).backgroundColor);
+  const activeBackground = await captureActiveListHighlight(newWorkspace, history);
 
-  const activeBackground = await background(newWorkspace);
-  const inactiveBackground = await background(history);
-  expect(activeBackground).not.toBe(inactiveBackground);
-
-  await page.keyboard.press("Control+n");
-  await expect.poll(() => background(history)).toBe(activeBackground);
+  await navigateToHighlightedListItem(page, "next", history, activeBackground);
   await expect(panel).toBeVisible();
 
-  await page.keyboard.press("Control+p");
-  await expect.poll(() => background(newWorkspace)).toBe(activeBackground);
+  await navigateToHighlightedListItem(page, "previous", newWorkspace, activeBackground);
   await expect(panel).toBeVisible();
 });

--- a/packages/app/e2e/browser/model-search-across-providers.spec.ts
+++ b/packages/app/e2e/browser/model-search-across-providers.spec.ts
@@ -1,4 +1,5 @@
-import { test } from "../support/fixtures";
+import type { Locator } from "@playwright/test";
+import { expect, test } from "../support/fixtures";
 import {
   closeModelPicker,
   expectModelSearchEmptyState,
@@ -50,6 +51,14 @@ const LARGE_CATALOG = {
   })),
 };
 
+function readBackground(locator: Locator): Promise<string> {
+  return locator.evaluate((element) => getComputedStyle(element).backgroundColor);
+}
+
+async function expectBackground(locator: Locator, expected: string): Promise<void> {
+  await expect.poll(() => readBackground(locator)).toBe(expected);
+}
+
 test.describe("Cross-provider model search", () => {
   test("one query over the picker root reaches every provider and names each result's provider", async ({
     page,
@@ -96,6 +105,23 @@ test.describe("Cross-provider model search", () => {
 
       await test.step("results replace the pinned profiles", async () => {
         await expectPinnedProfilesHidden(page);
+      });
+
+      await test.step("Ctrl+N and Ctrl+P move the model highlight", async () => {
+        await searchAllModels(page, "ten second stream");
+        const first = page.getByTestId("model-row-mock-ten-second-stream");
+        const second = page.getByTestId(`model-row-${STUDIO.id}-studio-fast`);
+        const inactiveBackground = await readBackground(first);
+
+        await page.keyboard.press("Control+n");
+        const activeBackground = await readBackground(first);
+        expect(activeBackground).not.toBe(inactiveBackground);
+
+        await page.keyboard.press("Control+n");
+        await expectBackground(second, activeBackground);
+
+        await page.keyboard.press("Control+p");
+        await expectBackground(first, activeBackground);
       });
 
       // Search falls back to subsequence matching, so "no matches" needs letters

--- a/packages/app/e2e/browser/model-search-across-providers.spec.ts
+++ b/packages/app/e2e/browser/model-search-across-providers.spec.ts
@@ -1,5 +1,4 @@
-import type { Locator } from "@playwright/test";
-import { expect, test } from "../support/fixtures";
+import { test } from "../support/fixtures";
 import {
   closeModelPicker,
   expectModelSearchEmptyState,
@@ -17,6 +16,10 @@ import {
 } from "../support/helpers/agent-profiles";
 import { expectComposerVisible } from "../support/helpers/composer";
 import { clickNewChat, gotoWorkspace } from "../support/helpers/launcher";
+import {
+  activateFirstListHighlight,
+  navigateToHighlightedListItem,
+} from "../support/helpers/list-navigation";
 import { seedWorkspace } from "../support/helpers/seed-client";
 
 const MOCK_PROVIDER_LABEL = "Mock Load Test";
@@ -50,14 +53,6 @@ const LARGE_CATALOG = {
     description: `Bulk search result ${index}`,
   })),
 };
-
-function readBackground(locator: Locator): Promise<string> {
-  return locator.evaluate((element) => getComputedStyle(element).backgroundColor);
-}
-
-async function expectBackground(locator: Locator, expected: string): Promise<void> {
-  await expect.poll(() => readBackground(locator)).toBe(expected);
-}
 
 test.describe("Cross-provider model search", () => {
   test("one query over the picker root reaches every provider and names each result's provider", async ({
@@ -111,17 +106,10 @@ test.describe("Cross-provider model search", () => {
         await searchAllModels(page, "ten second stream");
         const first = page.getByTestId("model-row-mock-ten-second-stream");
         const second = page.getByTestId(`model-row-${STUDIO.id}-studio-fast`);
-        const inactiveBackground = await readBackground(first);
+        const activeBackground = await activateFirstListHighlight(page, first);
 
-        await page.keyboard.press("Control+n");
-        const activeBackground = await readBackground(first);
-        expect(activeBackground).not.toBe(inactiveBackground);
-
-        await page.keyboard.press("Control+n");
-        await expectBackground(second, activeBackground);
-
-        await page.keyboard.press("Control+p");
-        await expectBackground(first, activeBackground);
+        await navigateToHighlightedListItem(page, "next", second, activeBackground);
+        await navigateToHighlightedListItem(page, "previous", first, activeBackground);
       });
 
       // Search falls back to subsequence matching, so "no matches" needs letters

--- a/packages/app/e2e/browser/sidebar-help.spec.ts
+++ b/packages/app/e2e/browser/sidebar-help.spec.ts
@@ -74,6 +74,20 @@ test("opens troubleshooting, support, and release destinations", async ({ page }
   });
 });
 
+test("navigates shared menus with Ctrl+N and Ctrl+P", async ({ page }) => {
+  await gotoAppShell(page);
+  await openHelpMenu(page);
+
+  await page.keyboard.press("Control+n");
+  await expect(page.getByTestId("sidebar-help-shortcuts")).toBeFocused();
+
+  await page.keyboard.press("Control+n");
+  await expect(page.getByTestId("sidebar-help-changelog")).toBeFocused();
+
+  await page.keyboard.press("Control+p");
+  await expect(page.getByTestId("sidebar-help-shortcuts")).toBeFocused();
+});
+
 test("searches keyboard shortcuts from the sidebar help menu", async ({ page }) => {
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "platform", { get: () => "MacIntel" });

--- a/packages/app/e2e/browser/sidebar-help.spec.ts
+++ b/packages/app/e2e/browser/sidebar-help.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from "../support/fixtures";
 import { gotoAppShell, openSettings } from "../support/helpers/app";
+import { navigateToFocusedListItem } from "../support/helpers/list-navigation";
 import { openSettingsSection } from "../support/helpers/settings";
 
 const DISCORD_DESTINATION =
@@ -78,14 +79,11 @@ test("navigates shared menus with Ctrl+N and Ctrl+P", async ({ page }) => {
   await gotoAppShell(page);
   await openHelpMenu(page);
 
-  await page.keyboard.press("Control+n");
-  await expect(page.getByTestId("sidebar-help-shortcuts")).toBeFocused();
-
-  await page.keyboard.press("Control+n");
-  await expect(page.getByTestId("sidebar-help-changelog")).toBeFocused();
-
-  await page.keyboard.press("Control+p");
-  await expect(page.getByTestId("sidebar-help-shortcuts")).toBeFocused();
+  const shortcuts = page.getByTestId("sidebar-help-shortcuts");
+  const changelog = page.getByTestId("sidebar-help-changelog");
+  await navigateToFocusedListItem(page, "next", shortcuts);
+  await navigateToFocusedListItem(page, "next", changelog);
+  await navigateToFocusedListItem(page, "previous", shortcuts);
 });
 
 test("searches keyboard shortcuts from the sidebar help menu", async ({ page }) => {

--- a/packages/app/e2e/support/helpers/list-navigation.ts
+++ b/packages/app/e2e/support/helpers/list-navigation.ts
@@ -1,0 +1,46 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+type ListNavigationDirection = "next" | "previous";
+
+function navigationKey(direction: ListNavigationDirection): string {
+  return direction === "next" ? "Control+n" : "Control+p";
+}
+
+async function readBackground(locator: Locator): Promise<string> {
+  return locator.evaluate((element) => getComputedStyle(element).backgroundColor);
+}
+
+export async function captureActiveListHighlight(
+  activeItem: Locator,
+  inactiveItem: Locator,
+): Promise<string> {
+  const activeBackground = await readBackground(activeItem);
+  expect(activeBackground).not.toBe(await readBackground(inactiveItem));
+  return activeBackground;
+}
+
+export async function activateFirstListHighlight(page: Page, item: Locator): Promise<string> {
+  const inactiveBackground = await readBackground(item);
+  await page.keyboard.press(navigationKey("next"));
+  await expect.poll(() => readBackground(item)).not.toBe(inactiveBackground);
+  return readBackground(item);
+}
+
+export async function navigateToHighlightedListItem(
+  page: Page,
+  direction: ListNavigationDirection,
+  item: Locator,
+  activeBackground: string,
+): Promise<void> {
+  await page.keyboard.press(navigationKey(direction));
+  await expect.poll(() => readBackground(item)).toBe(activeBackground);
+}
+
+export async function navigateToFocusedListItem(
+  page: Page,
+  direction: ListNavigationDirection,
+  item: Locator,
+): Promise<void> {
+  await page.keyboard.press(navigationKey(direction));
+  await expect(item).toBeFocused();
+}

--- a/packages/app/src/command-center/command-center.tsx
+++ b/packages/app/src/command-center/command-center.tsx
@@ -47,6 +47,12 @@ import {
 } from "@/stores/keyboard-shortcuts-store";
 import { navigateToWorkspace } from "@/stores/navigation-active-workspace-store";
 import { useKeyboardActionDispatcher } from "@/keyboard/keyboard-action-dispatcher-context";
+import { useListSearchHandler } from "@/keyboard/list-search-dispatcher";
+import {
+  listNavigationDataSet,
+  resolveListSearchKeyAction,
+  type ListSearchKeyEvent,
+} from "@/keyboard/list-search-keys";
 import {
   clearCommandCenterFocusRestoreElement,
   takeCommandCenterFocusRestoreElement,
@@ -237,7 +243,7 @@ interface CommandCenterState {
   fileSearchError: string | null;
   close(): void;
   select(result: CommandCenterResult): void;
-  key(key: string): boolean;
+  key(event: ListSearchKeyEvent): boolean;
 }
 
 function useCommandCenterState(): CommandCenterState {
@@ -316,9 +322,10 @@ function useCommandCenterState(): CommandCenterState {
     [setOpen],
   );
   const key = useCallback(
-    (pressed: string): boolean => {
+    (event: ListSearchKeyEvent): boolean => {
       if (!open) return false;
       const results = projection.selectableResults;
+      const pressed = event.key;
       if (pressed === "Escape") {
         close();
         return true;
@@ -327,16 +334,16 @@ function useCommandCenterState(): CommandCenterState {
         setScope(null);
         return true;
       }
-      if (pressed === "Enter") {
+      const action = resolveListSearchKeyAction(event);
+      if (action === "submit") {
         const selected = results.find((result) => result.id === resolvedActiveId);
         if (!selected) return false;
         select(selected);
         return true;
       }
-      if (pressed !== "ArrowDown" && pressed !== "ArrowUp") return false;
+      if (action !== "next" && action !== "previous") return false;
       if (results.length === 0) return false;
-      const direction = pressed === "ArrowDown" ? "next" : "previous";
-      setActiveId(moveActiveResultId(resolvedActiveId, results, direction));
+      setActiveId(moveActiveResultId(resolvedActiveId, results, action));
       return true;
     },
     [close, open, projection.selectableResults, query, resolvedActiveId, scope, select, setScope],
@@ -701,13 +708,18 @@ export function CommandCenter() {
     scrollEventThrottle: 16,
   };
   const keyPress = useCallback(
-    ({ nativeEvent: { key } }: { nativeEvent: { key: string } }) => state.key(key),
+    ({ nativeEvent: { key } }: { nativeEvent: { key: string } }) => state.key({ key }),
     [state],
   );
-  const submit = useCallback(() => state.key("Enter"), [state]);
+  const submit = useCallback(() => state.key({ key: "Enter" }), [state]);
+  useListSearchHandler({
+    active: isNative && state.open,
+    priority: 100,
+    handle: (_action, event) => state.key(event),
+  });
   const handleWebOverlayKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (!state.key(event.key)) return false;
+      if (!state.key(event)) return false;
       event.preventDefault();
       return true;
     },
@@ -781,7 +793,12 @@ export function CommandCenter() {
       <Modal visible transparent animationType="fade" onRequestClose={state.close}>
         <View style={styles.overlay}>
           <Pressable style={styles.backdrop} onPress={state.close} />
-          <View ref={setWebOverlayScope} testID="command-center-panel" style={styles.panel}>
+          <View
+            ref={setWebOverlayScope}
+            dataSet={listNavigationDataSet(state.open)}
+            testID="command-center-panel"
+            style={styles.panel}
+          >
             <View style={[styles.header, styles.searchRow]} testID="command-center-header">
               {state.scope === "files" ? (
                 <ScopeChip label={t("shell.commandCenter.files")} onRemove={state.clearScope} />

--- a/packages/app/src/components/adaptive-modal-sheet.tsx
+++ b/packages/app/src/components/adaptive-modal-sheet.tsx
@@ -3,7 +3,13 @@ import type { ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Modal, Platform, Pressable, Text, View } from "react-native";
-import type { DimensionValue, StyleProp, ViewStyle } from "react-native";
+import type {
+  DimensionValue,
+  NativeSyntheticEvent,
+  StyleProp,
+  TextInputKeyPressEventData,
+  ViewStyle,
+} from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { useIsCompactFormFactor } from "@/constants/layout";
 import {
@@ -30,6 +36,7 @@ import {
   getCompactSheetSafeAreaPadding,
 } from "@/components/adaptive-modal-sheet-layout";
 import { ScrollView } from "@/components/ui/scroll-view";
+import { listNavigationDataSet } from "@/keyboard/list-search-keys";
 import { isWeb } from "@/constants/platform";
 import { useKeyboardVisibility } from "@/hooks/use-keyboard-visibility";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -42,6 +49,15 @@ export { AdaptiveTextInput, type AdaptiveTextInputProps } from "@/components/ada
 // match this padding.
 export const SHEET_HORIZONTAL_PADDING_SCALE = 6;
 
+export type SheetSearchKeyPressEvent = NativeSyntheticEvent<
+  TextInputKeyPressEventData & {
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    altKey?: boolean;
+    shiftKey?: boolean;
+  }
+>;
+
 export interface SheetHeaderSearch {
   onChange: (value: string) => void;
   onFocus?: () => void;
@@ -50,6 +66,9 @@ export interface SheetHeaderSearch {
   placeholder?: string;
   autoFocus?: boolean;
   testID?: string;
+  onKeyPress?: (event: SheetSearchKeyPressEvent) => void;
+  onSubmit?: () => void;
+  ownsListNavigation?: boolean;
 }
 
 export interface SheetHeaderBack {
@@ -354,7 +373,10 @@ export function SheetHeaderView({
         ) : null}
       </View>
       {search ? (
-        <View style={styles.searchRow}>
+        <View
+          style={styles.searchRow}
+          dataSet={listNavigationDataSet(Boolean(search.ownsListNavigation))}
+        >
           <Search size={theme.iconSize.md} color={theme.colors.foregroundMuted} />
           <AdaptiveTextInput
             // @ts-expect-error - outlineStyle is web-only
@@ -362,6 +384,8 @@ export function SheetHeaderView({
             placeholder={search.placeholder ?? t("common.actions.search")}
             resetKey={search.resetKey}
             onChangeText={handleSearchChange}
+            onKeyPress={search.onKeyPress}
+            onSubmitEditing={search.onSubmit}
             onFocus={search.onFocus}
             onBlur={search.onBlur}
             autoCapitalize="none"
@@ -413,7 +437,10 @@ export function InlineHeaderView({ header }: { header: SheetHeader }) {
         </View>
       ) : null}
       {header.search ? (
-        <View style={styles.inlineSearchRow}>
+        <View
+          style={styles.inlineSearchRow}
+          dataSet={listNavigationDataSet(Boolean(header.search.ownsListNavigation))}
+        >
           <Search size={theme.iconSize.sm} color={theme.colors.foregroundMuted} />
           <AdaptiveTextInput
             // @ts-expect-error - outlineStyle is web-only
@@ -421,6 +448,8 @@ export function InlineHeaderView({ header }: { header: SheetHeader }) {
             placeholder={header.search.placeholder ?? t("common.actions.search")}
             resetKey={header.search.resetKey}
             onChangeText={header.search.onChange}
+            onKeyPress={header.search.onKeyPress}
+            onSubmitEditing={header.search.onSubmit}
             onFocus={header.search.onFocus}
             onBlur={header.search.onBlur}
             autoCapitalize="none"
@@ -460,6 +489,7 @@ export interface AdaptiveModalSheetProps {
   sizeContentToCurrentSnapPoint?: boolean;
   /** Re-establishes caller-owned contexts inside the compact bottom-sheet portal. */
   contextBridge?: ContextBridge | null;
+  onOverlayKeyDown?: (event: KeyboardEvent) => boolean;
 }
 
 export function AdaptiveModalSheet({
@@ -480,6 +510,7 @@ export function AdaptiveModalSheet({
   bodyStyle,
   sizeContentToCurrentSnapPoint = true,
   contextBridge = null,
+  onOverlayKeyDown,
 }: AdaptiveModalSheetProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
@@ -565,13 +596,14 @@ export function AdaptiveModalSheet({
 
   const handleWebOverlayKeyDown = useCallback(
     (event: KeyboardEvent) => {
+      if (onOverlayKeyDown?.(event)) return true;
       if (event.key !== "Escape") return false;
       event.preventDefault();
       event.stopPropagation();
       onClose();
       return true;
     },
-    [onClose],
+    [onClose, onOverlayKeyDown],
   );
   const setWebOverlayScope = useWebOverlayRegistration({
     active: isWeb && !isMobile && visible,

--- a/packages/app/src/components/combined-model-selector.tsx
+++ b/packages/app/src/components/combined-model-selector.tsx
@@ -94,12 +94,21 @@ export function CombinedModelSelector({
   const anchorRef = useRef<View>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [isContentReady, setIsContentReady] = useState(isWeb);
+  const openChangeRef = useRef<(open: boolean) => void>(noop);
+  const handleSelect = useCallback(
+    (provider: string, modelId: string) => {
+      onSelect(provider, modelId);
+      openChangeRef.current(false);
+    },
+    [onSelect],
+  );
   const browser = useModelBrowser({
     providers,
     selectedProvider,
     selectedModel,
     isLoading,
     profiles,
+    onSelect: handleSelect,
     serverId,
   });
   const { prepareToOpen, reset } = browser;
@@ -118,13 +127,9 @@ export function CombinedModelSelector({
     [onClose, onOpen, prepareToOpen, reset],
   );
 
-  const handleSelect = useCallback(
-    (provider: string, modelId: string) => {
-      onSelect(provider, modelId);
-      handleOpenChange(false);
-    },
-    [handleOpenChange, onSelect],
-  );
+  useEffect(() => {
+    openChangeRef.current = handleOpenChange;
+  }, [handleOpenChange]);
 
   useEffect(() => {
     if (isWeb) return () => {};
@@ -277,6 +282,7 @@ export function CombinedModelSelector({
         desktopFixedHeight={browser.desktopFixedHeight}
         desktopChildrenScrollEnabled={false}
         header={browser.header}
+        onOverlayKeyDown={browser.handleOverlayKeyDown}
         mobileChildrenScrollEnabled={!browser.isProviderView || !isNative}
         mobileChildrenContentContainerStyle={styles.mobileBrowserContent}
       >

--- a/packages/app/src/components/model-browser-keyboard.test.ts
+++ b/packages/app/src/components/model-browser-keyboard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderSelectionModelRow } from "@/provider-selection/provider-selection";
+import { moveModelHighlight, resolveModelSubmitRow } from "./model-browser-keyboard";
+
+const rows = [
+  { provider: "a", modelId: "one", favoriteKey: "a:one" },
+  { provider: "a", modelId: "two", favoriteKey: "a:two" },
+] as ProviderSelectionModelRow[];
+
+describe("model browser keyboard navigation", () => {
+  it("starts at the directional edge and wraps", () => {
+    expect(moveModelHighlight({ rows, highlightedKey: null, direction: "next" })).toBe("a:one");
+    expect(moveModelHighlight({ rows, highlightedKey: null, direction: "previous" })).toBe("a:two");
+    expect(moveModelHighlight({ rows, highlightedKey: "a:two", direction: "next" })).toBe("a:one");
+    expect(moveModelHighlight({ rows, highlightedKey: "a:one", direction: "previous" })).toBe(
+      "a:two",
+    );
+  });
+
+  it("submits the highlight or first row", () => {
+    expect(resolveModelSubmitRow(rows, "a:two")?.modelId).toBe("two");
+    expect(resolveModelSubmitRow(rows, null)?.modelId).toBe("one");
+    expect(resolveModelSubmitRow([], null)).toBeNull();
+  });
+});

--- a/packages/app/src/components/model-browser-keyboard.ts
+++ b/packages/app/src/components/model-browser-keyboard.ts
@@ -1,0 +1,25 @@
+import { getNextActiveIndex } from "@/components/ui/combobox-keyboard";
+import type { ProviderSelectionModelRow } from "@/provider-selection/provider-selection";
+
+export function moveModelHighlight(input: {
+  rows: ProviderSelectionModelRow[];
+  highlightedKey: string | null;
+  direction: "next" | "previous";
+}): string | null {
+  if (input.rows.length === 0) return null;
+  const currentIndex = input.rows.findIndex((row) => row.favoriteKey === input.highlightedKey);
+  const nextIndex = getNextActiveIndex({
+    currentIndex,
+    itemCount: input.rows.length,
+    key: input.direction === "next" ? "ArrowDown" : "ArrowUp",
+  });
+  return input.rows[nextIndex]?.favoriteKey ?? null;
+}
+
+export function resolveModelSubmitRow(
+  rows: ProviderSelectionModelRow[],
+  highlightedKey: string | null,
+): ProviderSelectionModelRow | null {
+  if (rows.length === 0) return null;
+  return rows.find((row) => row.favoriteKey === highlightedKey) ?? rows[0];
+}

--- a/packages/app/src/components/model-browser.tsx
+++ b/packages/app/src/components/model-browser.tsx
@@ -1,4 +1,13 @@
-import { createContext, useCallback, useContext, useMemo, useReducer, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import {
   FlatList,
@@ -35,7 +44,7 @@ import {
   type AgentProfilePickerRow as AgentProfilePickerRowModel,
   type AgentProfileSeed,
 } from "@/agent-profiles";
-import type { SheetHeader } from "@/components/adaptive-modal-sheet";
+import type { SheetHeader, SheetSearchKeyPressEvent } from "@/components/adaptive-modal-sheet";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -54,6 +63,14 @@ import {
 } from "@/provider-selection/provider-selection";
 import { useProviderSettingsStore } from "@/stores/provider-settings-store";
 import { useCurrentOverlayLayer } from "@/lib/overlay-root";
+import { moveModelHighlight, resolveModelSubmitRow } from "@/components/model-browser-keyboard";
+import { useListSearchHandler } from "@/keyboard/list-search-dispatcher";
+import {
+  LIST_SEARCH_SELECTOR,
+  resolveListSearchKeyAction,
+  type ListSearchKeyAction,
+  type ListSearchKeyEvent,
+} from "@/keyboard/list-search-keys";
 import { ICON_SIZE, type Theme } from "@/styles/theme";
 import {
   groupProfilesByProviderModel,
@@ -153,6 +170,7 @@ interface ModelBrowserInput {
   autoFocusSearch?: boolean;
   /** Pinned above the provider list on the root view. `null` hides the section. */
   profiles?: AgentProfilePicker | null;
+  onSelect: (provider: string, modelId: string) => void;
   serverId?: string | null;
 }
 
@@ -163,6 +181,7 @@ export interface ModelBrowserState {
   selectedModel: string;
   profiles: AgentProfilePicker | null;
   view: ModelBrowserView;
+  highlightedKey: string | null;
   searchQuery: string;
   isSearchFocused: boolean;
   header: SheetHeader;
@@ -170,6 +189,8 @@ export interface ModelBrowserState {
   triggerLabel: string;
   desktopFixedHeight: number | undefined;
   isProviderView: boolean;
+  handleListSearchAction: (action: ListSearchKeyAction) => boolean;
+  handleOverlayKeyDown: (event: KeyboardEvent) => boolean;
   prepareToOpen: () => void;
   showAll: () => void;
   reset: () => void;
@@ -204,6 +225,7 @@ interface ModelBrowserContentProps extends Omit<ModelBrowserProps, "state" | "sc
   searchQuery: string;
   isSearchFocused: boolean;
   profiles: AgentProfilePicker | null;
+  highlightedKey: string | null;
   onDrillDown: (providerId: string, providerLabel: string) => void;
   scrolling: "sheet" | "independent";
   searchAllOnFocus: boolean;
@@ -271,12 +293,14 @@ export function useModelBrowser({
   isLoading,
   autoFocusSearch = isWeb,
   profiles = null,
+  onSelect,
   serverId = null,
 }: ModelBrowserInput): ModelBrowserState {
   const { t } = useTranslation();
   const [view, setView] = useState<ModelBrowserView>({ kind: "all" });
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const [highlightedKey, setHighlightedKey] = useState<string | null>(null);
   const [searchResetKey, bumpSearchResetKey] = useReducer((key: number) => key + 1, 0);
   const hasProfiles = (profiles?.rows.length ?? 0) > 0;
 
@@ -298,6 +322,7 @@ export function useModelBrowser({
   const reset = useCallback(() => {
     setSearchQuery("");
     setIsSearchFocused(false);
+    setHighlightedKey(null);
     bumpSearchResetKey();
   }, []);
 
@@ -316,7 +341,68 @@ export function useModelBrowser({
 
   const handleSearchQueryChange = useCallback((value: string) => {
     setSearchQuery(value);
+    setHighlightedKey(null);
   }, []);
+
+  const normalizedQuery = useMemo(() => normalizeSearchQuery(searchQuery), [searchQuery]);
+  const keyboardRows = useMemo(() => {
+    if (view.kind === "all") {
+      const allView = resolveModelBrowserAllView({ providers, normalizedQuery, isSearchFocused });
+      return allView.kind === "searchResults" ? allView.rows : [];
+    }
+    const provider = providers.find((entry) => entry.id === view.providerId);
+    return provider ? filterAndRankModelRows(getProviderModelRows(provider), normalizedQuery) : [];
+  }, [isSearchFocused, normalizedQuery, providers, view]);
+
+  const handleListSearchAction = useCallback(
+    (action: ListSearchKeyAction): boolean => {
+      if (action === "submit") {
+        const row = resolveModelSubmitRow(keyboardRows, highlightedKey);
+        if (!row) return false;
+        onSelect(row.provider, row.modelId);
+        return true;
+      }
+      const nextKey = moveModelHighlight({
+        rows: keyboardRows,
+        highlightedKey,
+        direction: action,
+      });
+      if (!nextKey) return false;
+      setHighlightedKey(nextKey);
+      return true;
+    },
+    [highlightedKey, keyboardRows, onSelect],
+  );
+
+  const handleListSearchKey = useCallback(
+    (event: ListSearchKeyEvent): boolean => {
+      const action = resolveListSearchKeyAction(event);
+      return action ? handleListSearchAction(action) : false;
+    },
+    [handleListSearchAction],
+  );
+
+  const handleOverlayKeyDown = useCallback(
+    (event: KeyboardEvent): boolean => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement) || !target.closest(LIST_SEARCH_SELECTOR)) return false;
+      if (!handleListSearchKey(event)) return false;
+      event.preventDefault();
+      return true;
+    },
+    [handleListSearchKey],
+  );
+
+  const handleSearchKeyPress = useCallback(
+    (event: SheetSearchKeyPressEvent) => {
+      if (handleListSearchKey(event.nativeEvent)) event.preventDefault();
+    },
+    [handleListSearchKey],
+  );
+  const handleSearchSubmit = useCallback(
+    () => handleListSearchAction("submit"),
+    [handleListSearchAction],
+  );
 
   const singleProviderView = providers.length === 1;
   const header = useMemo<SheetHeader>(() => {
@@ -331,6 +417,9 @@ export function useModelBrowser({
           placeholder: t("modelSelector.searchAllPlaceholder"),
           autoFocus: autoFocusSearch,
           testID: "model-search-all-input",
+          onKeyPress: handleSearchKeyPress,
+          onSubmit: handleSearchSubmit,
+          ownsListNavigation: true,
         },
       };
     }
@@ -364,11 +453,16 @@ export function useModelBrowser({
         placeholder: t("modelSelector.searchPlaceholder"),
         autoFocus: autoFocusSearch,
         testID: "model-search-input",
+        onKeyPress: handleSearchKeyPress,
+        onSubmit: handleSearchSubmit,
+        ownsListNavigation: true,
       },
     };
   }, [
     autoFocusSearch,
     handleSearchQueryChange,
+    handleSearchKeyPress,
+    handleSearchSubmit,
     searchResetKey,
     serverId,
     singleProviderView,
@@ -407,6 +501,7 @@ export function useModelBrowser({
     selectedModel,
     profiles,
     view,
+    highlightedKey,
     searchQuery,
     isSearchFocused,
     header,
@@ -414,6 +509,8 @@ export function useModelBrowser({
     triggerLabel,
     desktopFixedHeight,
     isProviderView: view.kind === "provider",
+    handleListSearchAction,
+    handleOverlayKeyDown,
     prepareToOpen,
     showAll,
     reset,
@@ -527,12 +624,25 @@ function ModelBrowserPressable({
 
 type ModelBrowserRowTone = "default" | "elevated" | "drillDown";
 
+function useScrollHighlightIntoView(highlighted: boolean | undefined) {
+  const ref = useRef<View>(null);
+  useEffect(() => {
+    if (!isWeb || !highlighted) return;
+    const node = ref.current as unknown as {
+      scrollIntoView?: (options?: ScrollIntoViewOptions) => void;
+    } | null;
+    node?.scrollIntoView?.({ block: "nearest" });
+  }, [highlighted]);
+  return ref;
+}
+
 function ModelBrowserRow({
   label,
   description,
   leadingSlot,
   trailingSlot,
   selected = false,
+  highlighted,
   selectionIndicator = false,
   tone = "default",
   labelMuted = false,
@@ -545,6 +655,7 @@ function ModelBrowserRow({
   leadingSlot: React.ReactNode;
   trailingSlot?: React.ReactNode;
   selected?: boolean;
+  highlighted?: boolean;
   selectionIndicator?: boolean;
   tone?: ModelBrowserRowTone;
   /** For rows that offer an action rather than name a thing you can pick. */
@@ -553,15 +664,17 @@ function ModelBrowserRow({
   onPress: () => void;
   testID?: string;
 }) {
+  const highlightRef = useScrollHighlightIntoView(highlighted);
   const pressableStyle = useCallback(
     ({ hovered, pressed }: PressableStateCallbackType & { hovered?: boolean }) => [
       styles.browserRow,
       spacing === "model" && styles.browserModelRow,
       Boolean(hovered) &&
         (tone === "elevated" ? styles.browserRowHoveredElevated : styles.browserRowHovered),
+      highlighted && styles.browserRowHighlighted,
       pressed && (tone === "default" ? styles.browserRowPressed : styles.browserRowPressedElevated),
     ],
-    [spacing, tone],
+    [highlighted, spacing, tone],
   );
   const contentStyle = useMemo(
     () => [styles.browserRowText, description && styles.browserRowTextInline],
@@ -569,7 +682,7 @@ function ModelBrowserRow({
   );
   const hasTrailing = selected || trailingSlot;
 
-  return (
+  const row = (
     <ModelBrowserPressable
       onPress={onPress}
       style={pressableStyle}
@@ -607,6 +720,13 @@ function ModelBrowserRow({
         ) : null}
       </View>
     </ModelBrowserPressable>
+  );
+  return highlighted === undefined ? (
+    row
+  ) : (
+    <View ref={highlightRef} collapsable={false}>
+      {row}
+    </View>
   );
 }
 
@@ -667,6 +787,7 @@ function ModelRow({
   row,
   serverId,
   isSelected,
+  isHighlighted,
   showProviderLabel = false,
   onPress,
   profiledRows,
@@ -677,6 +798,7 @@ function ModelRow({
   row: ProviderSelectionModelRow;
   serverId: string | null;
   isSelected: boolean;
+  isHighlighted?: boolean;
   showProviderLabel?: boolean;
   onPress: () => void;
   profiledRows: AgentProfilePickerRowModel[];
@@ -693,6 +815,7 @@ function ModelRow({
 
   const description = showProviderLabel ? buildProviderQualifiedDescription(row) : row.description;
   const primary = profiledRows[profiledRows.length - 1];
+  const highlightRef = useScrollHighlightIntoView(isHighlighted);
 
   const handleCreateProfile = useCallback(() => {
     onCreateProfile?.({
@@ -780,13 +903,16 @@ function ModelRow({
       styles.browserRow,
       styles.browserModelRow,
       Boolean(hovered) && styles.browserRowHovered,
+      isHighlighted && styles.browserRowHighlighted,
       pressed && styles.browserRowPressed,
     ],
-    [],
+    [isHighlighted],
   );
 
   return (
     <View
+      ref={highlightRef}
+      collapsable={false}
       style={styles.modelRowHoverBoundary}
       onPointerEnter={handlePointerEnter}
       onPointerLeave={handlePointerLeave}
@@ -827,6 +953,7 @@ function SelectableModelRow({
   row,
   serverId,
   isSelected,
+  isHighlighted,
   showProviderLabel,
   onSelect,
   profiledRows,
@@ -837,6 +964,7 @@ function SelectableModelRow({
   row: ProviderSelectionModelRow;
   serverId: string | null;
   isSelected: boolean;
+  isHighlighted?: boolean;
   showProviderLabel?: boolean;
   onSelect: (provider: string, modelId: string) => void;
   profiledRows: AgentProfilePickerRowModel[];
@@ -852,6 +980,7 @@ function SelectableModelRow({
       row={row}
       serverId={serverId}
       isSelected={isSelected}
+      isHighlighted={isHighlighted}
       showProviderLabel={showProviderLabel}
       onPress={handlePress}
       profiledRows={profiledRows}
@@ -1136,6 +1265,7 @@ function ModelRowList({
   serverId,
   selectedProvider,
   selectedModel,
+  highlightedKey,
   onSelect,
   showProviderLabel = false,
   header,
@@ -1149,6 +1279,7 @@ function ModelRowList({
   serverId: string | null;
   selectedProvider: string;
   selectedModel: string;
+  highlightedKey: string | null;
   onSelect: (provider: string, modelId: string) => void;
   showProviderLabel?: boolean;
   header?: React.ReactElement;
@@ -1165,6 +1296,7 @@ function ModelRowList({
         row={item}
         serverId={serverId}
         isSelected={item.provider === selectedProvider && item.modelId === selectedModel}
+        isHighlighted={item.favoriteKey === highlightedKey}
         showProviderLabel={showProviderLabel}
         onSelect={onSelect}
         profiledRows={profiledLookup.get(`${item.provider}:${item.modelId}`) ?? []}
@@ -1174,6 +1306,7 @@ function ModelRowList({
       />
     ),
     [
+      highlightedKey,
       onEditProfile,
       onEditProfiles,
       onCreateProfile,
@@ -1261,6 +1394,7 @@ function ProviderModelBrowserContent({
   profiles,
   selectedProvider,
   selectedModel,
+  highlightedKey,
   normalizedQuery,
   onSelect,
   onApplyProfile,
@@ -1279,6 +1413,7 @@ function ProviderModelBrowserContent({
   profiles: AgentProfilePicker | null;
   selectedProvider: string;
   selectedModel: string;
+  highlightedKey: string | null;
   normalizedQuery: string;
   onSelect: (provider: string, modelId: string) => void;
   onApplyProfile?: (profileId: string) => void;
@@ -1350,6 +1485,7 @@ function ProviderModelBrowserContent({
       rows={visibleRows}
       selectedProvider={selectedProvider}
       selectedModel={selectedModel}
+      highlightedKey={highlightedKey}
       onSelect={onSelect}
       header={profileHeader}
       scrolling={scrolling}
@@ -1370,6 +1506,7 @@ function ModelBrowserContent({
   searchQuery,
   isSearchFocused,
   profiles,
+  highlightedKey,
   onSelect,
   onApplyProfile,
   onEditProfiles,
@@ -1416,6 +1553,7 @@ function ModelBrowserContent({
         profiles={profiles}
         selectedProvider={selectedProvider}
         selectedModel={selectedModel}
+        highlightedKey={highlightedKey}
         normalizedQuery={normalizedQuery}
         onSelect={onSelect}
         onApplyProfile={onApplyProfile}
@@ -1449,6 +1587,7 @@ function ModelBrowserContent({
         rows={allView.rows}
         selectedProvider={selectedProvider}
         selectedModel={selectedModel}
+        highlightedKey={highlightedKey}
         onSelect={onSelect}
         showProviderLabel
         scrolling={scrolling}
@@ -1521,6 +1660,11 @@ export function ModelBrowser({
   rootBrowseContent,
   showProfilesSection,
 }: ModelBrowserProps) {
+  useListSearchHandler({
+    active: isNative && state.isSearchFocused,
+    priority: 90,
+    handle: state.handleListSearchAction,
+  });
   return (
     <ModelBrowserContent
       serverId={state.serverId}
@@ -1531,6 +1675,7 @@ export function ModelBrowser({
       searchQuery={state.searchQuery}
       isSearchFocused={state.isSearchFocused}
       profiles={state.profiles}
+      highlightedKey={state.highlightedKey}
       onSelect={onSelect}
       onApplyProfile={onApplyProfile}
       onEditProfiles={onEditProfiles}
@@ -1596,6 +1741,9 @@ const styles = StyleSheet.create((theme) => ({
   },
   browserRowHoveredElevated: {
     backgroundColor: theme.colors.surface2,
+  },
+  browserRowHighlighted: {
+    backgroundColor: theme.colors.surface3,
   },
   browserRowPressed: {
     backgroundColor: theme.colors.surface1,

--- a/packages/app/src/components/ui/combobox.tsx
+++ b/packages/app/src/components/ui/combobox.tsx
@@ -50,7 +50,7 @@ import {
   shouldShowCustomComboboxOption,
 } from "./combobox-options";
 import type { ComboboxOptionModel } from "./combobox-options";
-import { isWeb } from "@/constants/platform";
+import { isNative, isWeb } from "@/constants/platform";
 import {
   IsolatedBottomSheetModal,
   useIsolatedBottomSheetVisibility,
@@ -62,6 +62,12 @@ import {
   type SheetHeader,
 } from "@/components/adaptive-modal-sheet";
 import { FloatingSurface } from "@/components/ui/floating";
+import { useListSearchHandler } from "@/keyboard/list-search-dispatcher";
+import {
+  LIST_SEARCH_DATASET,
+  resolveListSearchKeyAction,
+  type ListSearchKeyAction,
+} from "@/keyboard/list-search-keys";
 import { useDismissKeyboardOnOpen } from "@/components/ui/keyboard-dismiss";
 import {
   getOverlayRoot,
@@ -135,6 +141,7 @@ export interface ComboboxProps {
   /** When true, selecting an option does not close the picker (multi-select mode). */
   keepOpenOnSelect?: boolean;
   anchorRef: React.RefObject<View | null>;
+  onOverlayKeyDown?: (event: KeyboardEvent) => boolean;
   children?: ReactNode;
 }
 
@@ -865,8 +872,18 @@ function buildFloatingMiddleware(input: FloatingMiddlewareInput) {
   ];
 }
 
-function isDesktopKey(key: string): key is DesktopKey {
-  return key === "ArrowDown" || key === "ArrowUp" || key === "Enter" || key === "Escape";
+function resolveDesktopKey(event: KeyboardEvent): DesktopKey | null {
+  if (event.key === "Escape") return "Escape";
+  switch (resolveListSearchKeyAction(event)) {
+    case "next":
+      return "ArrowDown";
+    case "previous":
+      return "ArrowUp";
+    case "submit":
+      return "Enter";
+    default:
+      return null;
+  }
 }
 
 function dispatchDesktopKey(
@@ -894,6 +911,28 @@ function dispatchDesktopKey(
     return true;
   }
   return false;
+}
+
+function useNativeComboboxListNavigation(input: DesktopKeyHandlerInput & { hasChildren: boolean }) {
+  const handle = useCallback(
+    (action: ListSearchKeyAction) => {
+      if (!input.isOpen || input.hasChildren || input.orderedVisibleOptions.length === 0) {
+        return false;
+      }
+      if (action === "submit") {
+        handleDesktopEnterKey(input);
+        return true;
+      }
+      handleDesktopArrowKey(input, action === "next" ? "ArrowDown" : "ArrowUp");
+      return true;
+    },
+    [input],
+  );
+  useListSearchHandler({
+    active: isNative && input.isOpen && !input.hasChildren,
+    priority: 50,
+    handle,
+  });
 }
 
 function resolveInitialActiveIndex(
@@ -1047,6 +1086,7 @@ interface DesktopBodyProps {
   isOpen: boolean;
   handleClose: () => void;
   handleDesktopKey: (key: DesktopKey, event?: KeyboardEvent) => boolean;
+  onOverlayKeyDown: ((event: KeyboardEvent) => boolean) | undefined;
   refs: ReturnType<typeof useFloating>["refs"];
   shouldUseDesktopFade: boolean;
   desktopFrameStyle: StyleProp<ViewStyle>;
@@ -1173,12 +1213,15 @@ function DesktopComboboxOptionsBody(props: {
 
 function DesktopComboboxBody(props: DesktopBodyProps): ReactElement {
   const handleDesktopKey = props.handleDesktopKey;
+  const onOverlayKeyDown = props.onOverlayKeyDown;
   const handleWebOverlayKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (!isDesktopKey(event.key)) return false;
-      return handleDesktopKey(event.key, event);
+      if (onOverlayKeyDown?.(event)) return true;
+      const key = resolveDesktopKey(event);
+      if (!key) return false;
+      return handleDesktopKey(key, event);
     },
-    [handleDesktopKey],
+    [handleDesktopKey, onOverlayKeyDown],
   );
   const setWebOverlayScope = useWebOverlayRegistration({
     active: isWeb && props.isOpen,
@@ -1207,6 +1250,7 @@ function DesktopComboboxBody(props: DesktopBodyProps): ReactElement {
         <Pressable style={styles.desktopBackdrop} onPress={props.handleClose} />
         <FloatingSurface
           testID="combobox-desktop-container"
+          dataSet={LIST_SEARCH_DATASET}
           entering={props.shouldUseDesktopFade ? FadeIn.duration(100) : undefined}
           exiting={props.shouldUseDesktopFade ? FadeOut.duration(100) : undefined}
           style={styles.desktopContainer}
@@ -1303,6 +1347,7 @@ export function Combobox({
   footer,
   keepOpenOnSelect = false,
   anchorRef,
+  onOverlayKeyDown,
   children,
 }: ComboboxProps): ReactElement | null {
   const { t } = useTranslation();
@@ -1533,6 +1578,16 @@ export function Combobox({
     },
     [activeIndex, handleClose, handleSelect, isMobile, isOpen, orderedVisibleOptions],
   );
+  useNativeComboboxListNavigation({
+    isOpen,
+    isMobile,
+    orderedVisibleOptions,
+    activeIndex,
+    setActiveIndex,
+    handleSelect,
+    handleClose,
+    hasChildren: Boolean(children),
+  });
 
   useDismissKeyboardOnOpen(isOpen, isMobile);
 
@@ -1616,6 +1671,7 @@ export function Combobox({
       isOpen={isOpen}
       handleClose={handleClose}
       handleDesktopKey={handleDesktopKey}
+      onOverlayKeyDown={onOverlayKeyDown}
       refs={refs}
       shouldUseDesktopFade={shouldUseDesktopFade}
       desktopFrameStyle={desktopFrameStyle}

--- a/packages/app/src/components/ui/menu/menu-item.tsx
+++ b/packages/app/src/components/ui/menu/menu-item.tsx
@@ -1,6 +1,11 @@
 import {
+  createContext,
   useCallback,
+  useContext,
+  useEffect,
+  useId,
   useMemo,
+  useRef,
   useState,
   type PropsWithChildren,
   type ReactElement,
@@ -19,6 +24,9 @@ import { AdaptiveTextInput } from "@/components/adaptive-modal-sheet";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Theme } from "@/styles/theme";
+import { isNative } from "@/constants/platform";
+import { useListSearchHandler } from "@/keyboard/list-search-dispatcher";
+import { getNextActiveIndex } from "@/components/ui/combobox-keyboard";
 import { MenuDepthProvider, useMenuContext } from "./menu-context";
 import { MENU_ITEM_HEIGHT } from "./menu-geometry";
 
@@ -55,6 +63,37 @@ const MENU_ITEM_LINE_HEIGHT = 18;
  */
 const MENU_ROW_GAP = 0;
 
+interface MenuKeyboardItem {
+  isDisabled(): boolean;
+  select(): void;
+}
+
+interface MenuPageKeyboardContextValue {
+  highlightedId: string | null;
+  register(id: string, item: MenuKeyboardItem): () => void;
+}
+
+const MenuPageKeyboardContext = createContext<MenuPageKeyboardContextValue | null>(null);
+
+function useMenuItemKeyboard(isDisabled: boolean, select: () => void): boolean {
+  const keyboardContext = useContext(MenuPageKeyboardContext);
+  const keyboardId = useId();
+  const disabledRef = useRef(isDisabled);
+  const selectRef = useRef(select);
+  disabledRef.current = isDisabled;
+  selectRef.current = select;
+  const register = keyboardContext?.register;
+  useEffect(
+    () =>
+      register?.(keyboardId, {
+        isDisabled: () => disabledRef.current,
+        select: () => selectRef.current(),
+      }),
+    [keyboardId, register],
+  );
+  return keyboardContext?.highlightedId === keyboardId;
+}
+
 /** Action status for menu items with loading/success feedback. */
 export type ActionStatus = "idle" | "pending" | "success";
 
@@ -72,9 +111,49 @@ export type ActionStatus = "idle" | "pending" | "success";
  * It also carries the page's depth, so the two presentations cannot disagree about what a page is.
  */
 export function MenuPage({ depth, children }: PropsWithChildren<{ depth: number }>): ReactElement {
+  const menu = useMenuContext("MenuPage");
+  const itemsRef = useRef(new Map<string, MenuKeyboardItem>());
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const active = menu.open && depth === menu.path.length;
+  const register = useCallback((id: string, item: MenuKeyboardItem) => {
+    itemsRef.current.set(id, item);
+    return () => {
+      itemsRef.current.delete(id);
+    };
+  }, []);
+  const handleListAction = useCallback(
+    (action: "next" | "previous" | "submit") => {
+      const items = Array.from(itemsRef.current.entries()).filter(([, item]) => !item.isDisabled());
+      if (items.length === 0) return false;
+      const currentIndex = items.findIndex(([id]) => id === highlightedId);
+      if (action === "submit") {
+        items[currentIndex < 0 ? 0 : currentIndex]?.[1].select();
+        return true;
+      }
+      const nextIndex = getNextActiveIndex({
+        currentIndex,
+        itemCount: items.length,
+        key: action === "next" ? "ArrowDown" : "ArrowUp",
+      });
+      setHighlightedId(items[nextIndex]?.[0] ?? null);
+      return true;
+    },
+    [highlightedId],
+  );
+  useListSearchHandler({
+    active: isNative && active,
+    priority: 60 + depth,
+    handle: handleListAction,
+  });
+  useEffect(() => {
+    if (!active) setHighlightedId(null);
+  }, [active]);
+  const keyboardContext = useMemo(() => ({ highlightedId, register }), [highlightedId, register]);
   return (
     <MenuDepthProvider value={depth}>
-      <View style={styles.page}>{children}</View>
+      <MenuPageKeyboardContext.Provider value={keyboardContext}>
+        <View style={styles.page}>{children}</View>
+      </MenuPageKeyboardContext.Provider>
     </MenuDepthProvider>
   );
 }
@@ -294,6 +373,7 @@ export function MenuItem({
     if (isDisabled) return;
     selectItem(onSelect, closeOnSelect);
   }, [isDisabled, selectItem, onSelect, closeOnSelect]);
+  const keyboardHighlighted = useMenuItemKeyboard(Boolean(isDisabled), handleItemPress);
 
   // A row that draws a check has to say so as well: a multi-select page is a list of things that
   // are on or off, and the check is the only thing telling a sighted user which. Rows that answer
@@ -308,16 +388,18 @@ export function MenuItem({
       pressed,
       hovered = false,
       focused = false,
-    }: PressableStateCallbackType & { hovered?: boolean; focused?: boolean }) => [
-      styles.item,
-      active ? styles.itemActive : null,
-      isDisabled ? styles.itemDisabled : null,
-      muted && !isDisabled ? styles.itemMuted : null,
-      hovered && !pressed && !isDisabled ? styles.itemHovered : null,
-      focused && !isDisabled ? styles.itemHovered : null,
-      pressed && !isDisabled ? styles.itemPressed : null,
-    ],
-    [active, isDisabled, muted],
+    }: PressableStateCallbackType & { hovered?: boolean; focused?: boolean }) => {
+      const highlighted = hovered || focused || keyboardHighlighted;
+      return [
+        styles.item,
+        active ? styles.itemActive : null,
+        isDisabled ? styles.itemDisabled : null,
+        muted && !isDisabled ? styles.itemMuted : null,
+        highlighted && !pressed && !isDisabled ? styles.itemHovered : null,
+        pressed && !isDisabled ? styles.itemPressed : null,
+      ];
+    },
+    [active, isDisabled, keyboardHighlighted, muted],
   );
 
   const itemTextStyle = useMemo(

--- a/packages/app/src/components/ui/menu/menu-overlay.tsx
+++ b/packages/app/src/components/ui/menu/menu-overlay.tsx
@@ -30,6 +30,8 @@ import {
   useOverlayLayer,
   useWebOverlayRegistration,
 } from "@/lib/overlay-root";
+import { getNextActiveIndex } from "@/components/ui/combobox-keyboard";
+import { LIST_SEARCH_DATASET, resolveListSearchKeyAction } from "@/keyboard/list-search-keys";
 import {
   computePosition,
   getTransformOrigin,
@@ -444,12 +446,15 @@ export function MenuOverlay({
       );
       if (items.length === 0) return false;
       const currentIndex = items.findIndex((item) => item === document.activeElement);
+      const action = resolveListSearchKeyAction(event);
       let nextIndex: number | null = null;
-      if (event.key === "ArrowDown")
-        nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
-      if (event.key === "ArrowUp")
-        nextIndex =
-          currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length;
+      if (action === "next" || action === "previous") {
+        nextIndex = getNextActiveIndex({
+          currentIndex,
+          itemCount: items.length,
+          key: action === "next" ? "ArrowDown" : "ArrowUp",
+        });
+      }
       if (event.key === "Home") nextIndex = 0;
       if (event.key === "End") nextIndex = items.length - 1;
       if (nextIndex !== null) {
@@ -458,10 +463,10 @@ export function MenuOverlay({
         items[nextIndex]?.focus();
         return true;
       }
-      if ((event.key === "Enter" || event.key === " ") && currentIndex >= 0) {
+      if (action === "submit" || event.key === " ") {
         event.preventDefault();
         event.stopPropagation();
-        items[currentIndex]?.click();
+        items[currentIndex < 0 ? 0 : currentIndex]?.click();
         return true;
       }
       return false;
@@ -485,6 +490,7 @@ export function MenuOverlay({
         }}
         ref={setWebOverlayScope}
         collapsable={false}
+        dataSet={LIST_SEARCH_DATASET}
         style={[
           styles.overlay,
           isWeb ? styles.overlayWeb : null,

--- a/packages/app/src/composer/agent-controls/model-sheet.tsx
+++ b/packages/app/src/composer/agent-controls/model-sheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard, ScrollView, Text, View, type PressableStateCallbackType } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
@@ -23,6 +23,8 @@ const MODEL_ROW_STRIDE = 44;
 const MODEL_VIEWPORT_VISIBLE_ROWS = 4.5;
 const FIXED_MODEL_VIEWPORT_HEIGHT =
   MODEL_LIST_TOP_INSET + MODEL_ROW_STRIDE * MODEL_VIEWPORT_VISIBLE_ROWS;
+
+function noop() {}
 
 interface CompactModelSheetProps {
   providers: ProviderSelectorProvider[];
@@ -112,6 +114,14 @@ export function CompactModelSheet({
       providers.find((entry) => entry.id === selectedProvider) ?? providers[0] ?? null;
     return fixedProvider ? [fixedProvider] : [];
   }, [canSwitchProvider, providers, selectedProvider]);
+  const rootSelectRef = useRef<(provider: string, modelId: string) => void>(noop);
+  const browserSelectRef = useRef<(provider: string, modelId: string) => void>(noop);
+  const handleRootKeyboardSelect = useCallback((provider: string, modelId: string) => {
+    rootSelectRef.current(provider, modelId);
+  }, []);
+  const handleBrowserKeyboardSelect = useCallback((provider: string, modelId: string) => {
+    browserSelectRef.current(provider, modelId);
+  }, []);
   const rootBrowser = useModelBrowser({
     providers: availableProviders,
     selectedProvider,
@@ -119,6 +129,7 @@ export function CompactModelSheet({
     isLoading,
     autoFocusSearch: isWeb && !usesBottomSheet,
     profiles,
+    onSelect: handleRootKeyboardSelect,
     serverId,
   });
   const modelBrowser = useModelBrowser({
@@ -128,6 +139,7 @@ export function CompactModelSheet({
     isLoading,
     autoFocusSearch: isWeb && !usesBottomSheet,
     profiles,
+    onSelect: handleBrowserKeyboardSelect,
     serverId,
   });
   const ProviderIcon =
@@ -207,6 +219,11 @@ export function CompactModelSheet({
     },
     [close, onSelect],
   );
+
+  useEffect(() => {
+    rootSelectRef.current = usesBottomSheet ? handleSearchSelect : handleDesktopSelect;
+    browserSelectRef.current = handleBrowserSelect;
+  }, [handleBrowserSelect, handleDesktopSelect, handleSearchSelect, usesBottomSheet]);
 
   const handleApplyProfile = useCallback(
     (profileId: string) => {
@@ -303,6 +320,7 @@ export function CompactModelSheet({
         sizeContentToCurrentSnapPoint={usesBottomSheet}
         contentStyle={styles.sheetBody}
         testID="agent-controls-model-sheet"
+        onOverlayKeyDown={rootBrowser.handleOverlayKeyDown}
       >
         <View
           style={[
@@ -352,6 +370,7 @@ export function CompactModelSheet({
           presentation="push"
           contentStyle={styles.sheetBody}
           testID="agent-controls-model-browser-sheet"
+          onOverlayKeyDown={modelBrowser.handleOverlayKeyDown}
         >
           <View
             style={[styles.modelViewport, styles.flexibleModelViewport]}

--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -89,6 +89,7 @@ import {
   executePluginClientSlashCommand,
   resolvePluginClientSlashCommand,
 } from "@/plugins/client-slash-commands/model";
+import { useListSearchHandler } from "@/keyboard/list-search-dispatcher";
 import {
   useHostRuntimeAgentDirectoryStatus,
   useHostRuntimeClient,
@@ -2289,6 +2290,19 @@ function ComposerContentImpl({
     ? t("composer.github.searching")
     : t("composer.github.noResults");
   const autocompleteVisible = autocomplete.isVisible && mode.showAutocomplete;
+  useListSearchHandler({
+    active: isNative && autocompleteVisible,
+    priority: 80,
+    handle: (_action, event) =>
+      autocompleteOnKeyPressRef.current({
+        ...event,
+        preventDefault: () => {},
+        input: messageInputRef.current?.getInputSnapshot() ?? {
+          text: userInput,
+          selection: { start: cursorIndex, end: cursorIndex },
+        },
+      }),
+  });
 
   return (
     <>
@@ -2364,6 +2378,7 @@ function ComposerContentImpl({
                   onQueue={handleQueue}
                   onSubmitLoadingPress={submitLoadingPressHandler}
                   onKeyPress={handleCommandKeyPress}
+                  ownsListNavigation={autocompleteVisible}
                   onSelectionChange={handleSelectionChange}
                   onFocusChange={handleFocusChange}
                   onHeightChange={onComposerHeightChange}

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -50,6 +50,8 @@ import { useIosHardwareKeyboardSubmit } from "@/hooks/use-ios-hardware-keyboard-
 import { formatShortcut, type ShortcutKey } from "@/utils/format-shortcut";
 import { getShortcutOs } from "@/utils/shortcut-platform";
 import type { MessageInputKeyboardActionKind } from "@/keyboard/actions";
+import { listNavigationDataSet } from "@/keyboard/list-search-keys";
+import type { ListSearchKeyEvent } from "@/keyboard/list-search-keys";
 import { isImeComposingKeyboardEvent } from "@/utils/keyboard-ime";
 import { isWeb } from "@/constants/platform";
 import { useIsCompactFormFactor } from "@/constants/layout";
@@ -99,8 +101,7 @@ export interface ComposerInputSnapshot {
   selection: { start: number; end: number };
 }
 
-export interface ComposerKeyPressEvent {
-  key: string;
+export interface ComposerKeyPressEvent extends ListSearchKeyEvent {
   preventDefault: () => void;
   input: ComposerInputSnapshot;
 }
@@ -157,6 +158,7 @@ export interface MessageInputProps {
   onSubmitLoadingPress?: () => void;
   /** Intercept key press events before default handling. Return true to prevent default. */
   onKeyPress?: (event: ComposerKeyPressEvent) => boolean;
+  ownsListNavigation?: boolean;
   /** Reports cursor selection updates from the underlying input. */
   onSelectionChange?: (selection: { start: number; end: number }) => void;
   onFocusChange?: (focused: boolean) => void;
@@ -199,6 +201,7 @@ type WebTextInputKeyPressEvent = NativeSyntheticEvent<
     metaKey?: boolean;
     ctrlKey?: boolean;
     shiftKey?: boolean;
+    altKey?: boolean;
     // Web-only: present on DOM KeyboardEvent during IME composition (CJK input).
     isComposing?: boolean;
     keyCode?: number;
@@ -402,6 +405,10 @@ function handleDesktopKeyPressImpl(
   if (ctx.onKeyPressCallback) {
     const handled = ctx.onKeyPressCallback({
       key: event.nativeEvent.key,
+      ctrlKey: event.nativeEvent.ctrlKey,
+      metaKey: event.nativeEvent.metaKey,
+      altKey: event.nativeEvent.altKey,
+      shiftKey: event.nativeEvent.shiftKey,
       preventDefault: () => event.preventDefault(),
       input: ctx.input,
     });
@@ -1074,6 +1081,7 @@ interface ResolvedMessageInputProps {
   onQueue: ((payload: MessagePayload) => void) | undefined;
   onSubmitLoadingPress: (() => void) | undefined;
   onKeyPressCallback: ((event: ComposerKeyPressEvent) => boolean) | undefined;
+  ownsListNavigation: boolean;
   onSelectionChangeCallback: ((selection: { start: number; end: number }) => void) | undefined;
   onFocusChange: ((focused: boolean) => void) | undefined;
   onHeightChange: ((height: number) => void) | undefined;
@@ -1121,6 +1129,7 @@ function resolveMessageInputProps(props: MessageInputProps): ResolvedMessageInpu
     onQueue: props.onQueue,
     onSubmitLoadingPress: props.onSubmitLoadingPress,
     onKeyPressCallback: props.onKeyPress,
+    ownsListNavigation: props.ownsListNavigation ?? false,
     onSelectionChangeCallback: props.onSelectionChange,
     onFocusChange: props.onFocusChange,
     onHeightChange: props.onHeightChange,
@@ -1176,6 +1185,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       onQueue,
       onSubmitLoadingPress,
       onKeyPressCallback,
+      ownsListNavigation,
       onSelectionChangeCallback,
       onFocusChange,
       onHeightChange,
@@ -1777,6 +1787,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
         style={styles.container}
         testID="message-input-root"
         onLayout={handleComposerLayout}
+        dataSet={listNavigationDataSet(ownsListNavigation)}
       >
         <MessageInputAutoFocus
           enabled={autoFocus}

--- a/packages/app/src/hooks/use-agent-autocomplete.ts
+++ b/packages/app/src/hooks/use-agent-autocomplete.ts
@@ -9,7 +9,7 @@ import {
   type DraftCommandConfig,
 } from "./use-agent-commands-query";
 import { orderAutocompleteOptions } from "@/components/ui/autocomplete-utils";
-import { useAutocomplete } from "./use-autocomplete";
+import { useAutocomplete, type AutocompleteKeyPressEvent } from "./use-autocomplete";
 import { useSessionStore } from "@/stores/session-store";
 import { useHostRuntimeClient, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
 import { CLIENT_SLASH_COMMANDS, type ClientSlashCommand } from "@/client-slash-commands";
@@ -41,9 +41,7 @@ interface UseAgentAutocompleteInput {
   pluginClientSlashCommands?: readonly PluginClientSlashCommand[];
 }
 
-interface AgentAutocompleteKeyPressEvent {
-  key: string;
-  preventDefault: () => void;
+interface AgentAutocompleteKeyPressEvent extends AutocompleteKeyPressEvent {
   input: AgentAutocompleteInputSnapshot;
 }
 

--- a/packages/app/src/hooks/use-autocomplete.ts
+++ b/packages/app/src/hooks/use-autocomplete.ts
@@ -4,9 +4,9 @@ import {
   getAutocompleteNextIndex,
   type AutocompleteOptionsPosition,
 } from "@/components/ui/autocomplete-utils";
+import { resolveListSearchKeyAction, type ListSearchKeyEvent } from "@/keyboard/list-search-keys";
 
-interface AutocompleteKeyPressEvent {
-  key: string;
+export interface AutocompleteKeyPressEvent extends ListSearchKeyEvent {
   preventDefault: () => void;
 }
 
@@ -70,25 +70,14 @@ export function useAutocomplete<
         return false;
       }
 
-      if (event.key === "ArrowUp") {
+      const movement = resolveListSearchKeyAction(event);
+      if (movement === "next" || movement === "previous") {
         event.preventDefault();
         setSelectedIndex((current) =>
           getAutocompleteNextIndex({
             currentIndex: current,
             itemCount: input.options.length,
-            key: "ArrowUp",
-          }),
-        );
-        return true;
-      }
-
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setSelectedIndex((current) =>
-          getAutocompleteNextIndex({
-            currentIndex: current,
-            itemCount: input.options.length,
-            key: "ArrowDown",
+            key: movement === "next" ? "ArrowDown" : "ArrowUp",
           }),
         );
         return true;

--- a/packages/app/src/hooks/use-keyboard-shortcuts.ts
+++ b/packages/app/src/hooks/use-keyboard-shortcuts.ts
@@ -13,7 +13,8 @@ import {
   buildEffectiveBindings,
   getWorkspaceIndexJumpModifierKey,
 } from "@/keyboard/keyboard-shortcuts";
-import { resolveKeyboardFocusScope } from "@/keyboard/focus-scope";
+import { ownsListNavigationKeys, resolveKeyboardFocusScope } from "@/keyboard/focus-scope";
+import { resolveListSearchKeyAction } from "@/keyboard/list-search-keys";
 import {
   buildBrowserKeyboardPolicy,
   parseBrowserShortcutInput,
@@ -332,6 +333,10 @@ export function useKeyboardShortcuts({
 
       const store = useKeyboardShortcutsStore.getState();
       if (store.capturingShortcut) {
+        return;
+      }
+
+      if (resolveListSearchKeyAction(event) !== null && ownsListNavigationKeys(event.target)) {
         return;
       }
 

--- a/packages/app/src/keyboard/focus-scope.test.ts
+++ b/packages/app/src/keyboard/focus-scope.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveKeyboardFocusScope } from "./focus-scope";
+import { ownsListNavigationKeys, resolveKeyboardFocusScope } from "./focus-scope";
 
 class FakeNode {
   parentElement: FakeElement | null = null;
@@ -66,6 +66,26 @@ describe("resolveKeyboardFocusScope", () => {
       commandCenterOpen: false,
     });
     expect(scope).toBe("terminal");
+  });
+
+  it("detects list navigation ownership without changing the focus scope", () => {
+    const menu = new FakeElement({ selectors: ["[data-keyboard-scope='list-search']"] });
+    const composer = new FakeElement({ selectors: ["[data-testid='message-input-root']"] });
+    menu.parentElement = composer;
+    const target = new FakeElement({ tagName: "textarea" });
+    target.parentElement = menu;
+
+    expect(ownsListNavigationKeys(target as unknown as EventTarget)).toBe(true);
+    expect(
+      resolveKeyboardFocusScope({
+        target: target as unknown as EventTarget,
+        commandCenterOpen: false,
+      }),
+    ).toBe("message-input");
+  });
+
+  it("does not claim list navigation for an ordinary field", () => {
+    expect(ownsListNavigationKeys(new FakeElement() as unknown as EventTarget)).toBe(false);
   });
 
   it("detects editable scope from activeElement fallback", () => {

--- a/packages/app/src/keyboard/focus-scope.ts
+++ b/packages/app/src/keyboard/focus-scope.ts
@@ -1,4 +1,5 @@
 import type { KeyboardFocusScope } from "@/keyboard/actions";
+import { LIST_SEARCH_SELECTOR } from "@/keyboard/list-search-keys";
 
 function isElement(value: unknown): value is Element {
   return typeof Element !== "undefined" && value instanceof Element;
@@ -26,6 +27,12 @@ function getFocusCandidateElements(target: EventTarget | null): Element[] {
   }
 
   return candidates;
+}
+
+export function ownsListNavigationKeys(target: EventTarget | null): boolean {
+  return getFocusCandidateElements(target).some((element) =>
+    Boolean(element.closest(LIST_SEARCH_SELECTOR)),
+  );
 }
 
 export function resolveKeyboardFocusScope(input: {

--- a/packages/app/src/keyboard/list-search-dispatcher.test.ts
+++ b/packages/app/src/keyboard/list-search-dispatcher.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { createListSearchDispatcher } from "./list-search-dispatcher";
+
+describe("listSearchDispatcher", () => {
+  it("routes to the newest equally-prioritized handler", () => {
+    const dispatcher = createListSearchDispatcher();
+    const older = vi.fn(() => true);
+    const newer = vi.fn(() => true);
+    dispatcher.registerHandler({ handlerId: "older", enabled: true, handle: older });
+    dispatcher.registerHandler({ handlerId: "newer", enabled: true, handle: newer });
+
+    expect(dispatcher.dispatch({ key: "n", ctrlKey: true })).toBe(true);
+    expect(newer).toHaveBeenCalledWith("next", { key: "n", ctrlKey: true });
+    expect(older).not.toHaveBeenCalled();
+  });
+
+  it("falls through disabled and unhandled registrations", () => {
+    const dispatcher = createListSearchDispatcher();
+    const fallback = vi.fn(() => true);
+    dispatcher.registerHandler({ handlerId: "fallback", enabled: true, handle: fallback });
+    dispatcher.registerHandler({ handlerId: "disabled", enabled: false, handle: () => true });
+    dispatcher.registerHandler({
+      handlerId: "top",
+      enabled: true,
+      priority: 1,
+      handle: () => false,
+    });
+
+    expect(dispatcher.dispatch({ key: "p", ctrlKey: true })).toBe(true);
+    expect(fallback).toHaveBeenCalledWith("previous", { key: "p", ctrlKey: true });
+    expect(dispatcher.dispatch({ key: "x", ctrlKey: true })).toBe(false);
+  });
+});

--- a/packages/app/src/keyboard/list-search-dispatcher.ts
+++ b/packages/app/src/keyboard/list-search-dispatcher.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import {
+  resolveListSearchKeyAction,
+  type ListSearchKeyAction,
+  type ListSearchKeyEvent,
+} from "@/keyboard/list-search-keys";
+
+export interface ListSearchHandler {
+  handlerId: string;
+  enabled: boolean;
+  priority?: number;
+  handle(action: ListSearchKeyAction, event: ListSearchKeyEvent): boolean;
+}
+
+type RegisteredListSearchHandler = ListSearchHandler & { registeredAt: number };
+
+export function createListSearchDispatcher() {
+  let nextRegistrationOrder = 1;
+  const handlers = new Map<string, RegisteredListSearchHandler>();
+
+  return {
+    registerHandler(handler: ListSearchHandler) {
+      handlers.set(handler.handlerId, { ...handler, registeredAt: nextRegistrationOrder++ });
+      return () => {
+        handlers.delete(handler.handlerId);
+      };
+    },
+
+    dispatch(event: ListSearchKeyEvent): boolean {
+      const action = resolveListSearchKeyAction(event);
+      if (!action) return false;
+      const candidates = Array.from(handlers.values())
+        .filter((handler) => handler.enabled)
+        .sort(
+          (left, right) =>
+            (right.priority ?? 0) - (left.priority ?? 0) || right.registeredAt - left.registeredAt,
+        );
+      for (const handler of candidates) {
+        if (handler.handle(action, event)) return true;
+      }
+      return false;
+    },
+  };
+}
+
+export const listSearchDispatcher = createListSearchDispatcher();
+
+let nextHandlerId = 1;
+
+export function useListSearchHandler(input: {
+  active: boolean;
+  priority?: number;
+  handle(action: ListSearchKeyAction, event: ListSearchKeyEvent): boolean;
+}): void {
+  const handlerIdRef = useRef<string | null>(null);
+  const inputRef = useRef(input);
+  inputRef.current = input;
+  if (handlerIdRef.current === null) {
+    handlerIdRef.current = `list-search-${nextHandlerId++}`;
+  }
+
+  useEffect(() => {
+    if (!input.active) return;
+    return listSearchDispatcher.registerHandler({
+      handlerId: handlerIdRef.current!,
+      enabled: true,
+      priority: input.priority,
+      handle: (action, event) => inputRef.current.handle(action, event),
+    });
+  }, [input.active, input.priority]);
+}

--- a/packages/app/src/keyboard/list-search-keys.test.ts
+++ b/packages/app/src/keyboard/list-search-keys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveListSearchKeyAction } from "./list-search-keys";
+
+describe("resolveListSearchKeyAction", () => {
+  it("maps Ctrl+N and Ctrl+P case-insensitively", () => {
+    expect(resolveListSearchKeyAction({ key: "n", ctrlKey: true })).toBe("next");
+    expect(resolveListSearchKeyAction({ key: "N", ctrlKey: true })).toBe("next");
+    expect(resolveListSearchKeyAction({ key: "p", ctrlKey: true })).toBe("previous");
+    expect(resolveListSearchKeyAction({ key: "P", ctrlKey: true })).toBe("previous");
+  });
+
+  it("maps arrows and Enter", () => {
+    expect(resolveListSearchKeyAction({ key: "ArrowDown" })).toBe("next");
+    expect(resolveListSearchKeyAction({ key: "ArrowUp" })).toBe("previous");
+    expect(resolveListSearchKeyAction({ key: "Enter" })).toBe("submit");
+  });
+
+  it("leaves typing and other modified chords alone", () => {
+    expect(resolveListSearchKeyAction({ key: "n" })).toBeNull();
+    expect(resolveListSearchKeyAction({ key: "p" })).toBeNull();
+    expect(resolveListSearchKeyAction({ key: "n", ctrlKey: true, shiftKey: true })).toBeNull();
+    expect(resolveListSearchKeyAction({ key: "p", ctrlKey: true, altKey: true })).toBeNull();
+    expect(resolveListSearchKeyAction({ key: "n", ctrlKey: true, metaKey: true })).toBeNull();
+  });
+});

--- a/packages/app/src/keyboard/list-search-keys.ts
+++ b/packages/app/src/keyboard/list-search-keys.ts
@@ -1,0 +1,32 @@
+export type ListSearchKeyAction = "next" | "previous" | "submit";
+
+export interface ListSearchKeyEvent {
+  key: string;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  repeat?: boolean;
+}
+
+export const LIST_SEARCH_DATASET = { keyboardScope: "list-search" } as const;
+
+export const LIST_SEARCH_SELECTOR = "[data-keyboard-scope='list-search']";
+
+export function listNavigationDataSet(active: boolean): typeof LIST_SEARCH_DATASET | undefined {
+  return active ? LIST_SEARCH_DATASET : undefined;
+}
+
+export function resolveListSearchKeyAction(event: ListSearchKeyEvent): ListSearchKeyAction | null {
+  if (event.altKey || event.metaKey || event.shiftKey) return null;
+  if (event.ctrlKey) {
+    const key = event.key.toLowerCase();
+    if (key === "n") return "next";
+    if (key === "p") return "previous";
+    return null;
+  }
+  if (event.key === "ArrowDown") return "next";
+  if (event.key === "ArrowUp") return "previous";
+  if (event.key === "Enter") return "submit";
+  return null;
+}


### PR DESCRIPTION
Extends Emacs-style Ctrl+N/Ctrl+P list navigation across the Command Center, model browser, comboboxes, composer autocomplete, and shared menus. Lists wrap, skip disabled rows, reveal the active row, and retain Arrow/Enter behavior.

Adds shared key ownership and prioritized native dispatch support so the mobile hardware-keyboard work can route list keys ahead of global shortcuts.

Supersedes the reusable navigation portion of #2530 without restoring its obsolete model-setting changes. Coordinates with #2927 for iOS/Android hardware-key delivery.

Verification:
- focused Vitest: 27 passed
- npm run format
- npm run typecheck
- npm run lint
- browser specs added; local E2E daemon fixture timed out during setup before test execution