### PR TITLE
fix: enable full Paseo MCP access for Devin and OpenCode agents

### DIFF
--- a/packages/server/src/server/agent/provider-options.test.ts
+++ b/packages/server/src/server/agent/provider-options.test.ts
@@ -173,7 +173,7 @@ describe("exact MCP preapproval mappings", () => {
         hubPolicy,
       ),
     ).toEqual([
-      { permission: "hub_finish_execution", pattern: "*", action: "allow" },
+      { permission: "hub.finish_execution", pattern: "*", action: "allow" },
       { permission: "hub_finish_execution", pattern: "*", action: "deny" },
       { permission: "bash", pattern: "*", action: "ask" },
     ]);

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -2490,10 +2490,57 @@ describe("ACPAgentSession", () => {
     expect(byName.get("external")?.url).toBe("https://example.com/mcp");
   });
 
+  test("does not rename internal Paseo server when target name is already taken by a user server", () => {
+    // If the user already has a non-internal server named `paseo-daemon`,
+    // renaming would overwrite it. Keep the original `paseo` name instead.
+    const session = new ACPAgentSession(
+      {
+        provider: "acp-with-mcp",
+        cwd: "/tmp/paseo-acp-test",
+        mcpServers: {
+          paseo: {
+            type: "http",
+            url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1",
+          },
+          "paseo-daemon": {
+            type: "stdio",
+            command: "user-external-server",
+          },
+        },
+      },
+      {
+        provider: "acp-with-mcp",
+        logger: createTestLogger(),
+        defaultCommand: ["acp-with-mcp", "serve"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+      },
+    );
+
+    const servers = asInternals<ACPSessionInternals>(session).acpMcpServers() as Array<{
+      name: string;
+      type?: string;
+      command?: string;
+      url?: string;
+    }>;
+    const byName = new Map(servers.map((s) => [s.name, s]));
+    // Internal server keeps its original name.
+    expect(byName.get("paseo")?.url).toBe("http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1");
+    // User's server is preserved.
+    expect(byName.get("paseo-daemon")?.command).toBe("user-external-server");
+  });
+
   test("ensureDevinMcpPermissionPreapproval writes mcp permission to .devin/config.local.json", async () => {
     const dir = await fs.mkdtemp(path.join(tmpdir(), "devin-mcp-perm-"));
     try {
-      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon");
 
       const configPath = path.join(dir, ".devin", "config.local.json");
       const raw = await fs.readFile(configPath, "utf8");
@@ -2521,7 +2568,7 @@ describe("ACPAgentSession", () => {
         "utf8",
       );
 
-      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon");
 
       const raw = await fs.readFile(configPath, "utf8");
       const parsed = JSON.parse(raw) as {
@@ -2543,8 +2590,8 @@ describe("ACPAgentSession", () => {
   test("ensureDevinMcpPermissionPreapproval is idempotent", async () => {
     const dir = await fs.mkdtemp(path.join(tmpdir(), "devin-mcp-perm-idempotent-"));
     try {
-      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
-      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon");
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon");
 
       const configPath = path.join(dir, ".devin", "config.local.json");
       const raw = await fs.readFile(configPath, "utf8");

--- a/packages/server/src/server/agent/providers/acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.test.ts
@@ -1,5 +1,8 @@
 import { type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   AgentSideConnection,
@@ -24,6 +27,7 @@ import {
   createLoggedNdJsonStream,
   deriveModelDefinitionsFromACP,
   deriveModesFromACP,
+  ensureDevinMcpPermissionPreapproval,
   mapACPUsage,
   resolveACPModeSelection,
   resolveACPModelSelection,
@@ -2433,6 +2437,122 @@ describe("ACPAgentSession", () => {
     );
 
     expect(asInternals<ACPSessionInternals>(session).acpMcpServers()).toEqual([]);
+  });
+
+  test("renames internal Paseo MCP server to avoid collision with native agent config", () => {
+    // ACP agents (e.g. Devin CLI) merge ACP-injected MCP servers with their
+    // own native config files by name. A user's manual `paseo` entry would
+    // shadow the ACP injection. The internal server must be renamed.
+    const session = new ACPAgentSession(
+      {
+        provider: "acp-with-mcp",
+        cwd: "/tmp/paseo-acp-test",
+        mcpServers: {
+          paseo: {
+            type: "http",
+            url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1",
+            headers: { Authorization: "Bearer test-token" },
+          },
+          external: {
+            type: "http",
+            url: "https://example.com/mcp",
+          },
+        },
+      },
+      {
+        provider: "acp-with-mcp",
+        logger: createTestLogger(),
+        defaultCommand: ["acp-with-mcp", "serve"],
+        defaultModes: [],
+        capabilities: {
+          supportsStreaming: true,
+          supportsSessionPersistence: true,
+          supportsDynamicModes: true,
+          supportsMcpServers: true,
+          supportsReasoningStream: true,
+          supportsToolInvocations: true,
+        },
+      },
+    );
+
+    const servers = asInternals<ACPSessionInternals>(session).acpMcpServers() as Array<{
+      name: string;
+      type?: string;
+      url?: string;
+    }>;
+    const byName = new Map(servers.map((s) => [s.name, s]));
+    expect(byName.has("paseo")).toBe(false);
+    const renamed = byName.get("paseo-daemon");
+    expect(renamed).toBeDefined();
+    expect(renamed?.type).toBe("http");
+    expect(renamed?.url).toBe("http://127.0.0.1:6767/mcp/agents?callerAgentId=agent-1");
+    // Non-internal servers keep their names.
+    expect(byName.get("external")?.url).toBe("https://example.com/mcp");
+  });
+
+  test("ensureDevinMcpPermissionPreapproval writes mcp permission to .devin/config.local.json", async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), "devin-mcp-perm-"));
+    try {
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
+
+      const configPath = path.join(dir, ".devin", "config.local.json");
+      const raw = await fs.readFile(configPath, "utf8");
+      const parsed = JSON.parse(raw) as { permissions: { allow: string[] } };
+      expect(parsed.permissions.allow).toContain("mcp__paseo-daemon__*");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ensureDevinMcpPermissionPreapproval merges with existing config and preserves user permissions", async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), "devin-mcp-perm-merge-"));
+    try {
+      const configPath = path.join(dir, ".devin", "config.local.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          permissions: {
+            allow: ["Exec(grep)", "mcp__github__list_issues"],
+            deny: ["Bash(rm *)"],
+          },
+          otherField: "preserved",
+        }),
+        "utf8",
+      );
+
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
+
+      const raw = await fs.readFile(configPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        permissions: { allow: string[]; deny: string[] };
+        otherField: string;
+      };
+      expect(parsed.permissions.allow).toEqual([
+        "Exec(grep)",
+        "mcp__github__list_issues",
+        "mcp__paseo-daemon__*",
+      ]);
+      expect(parsed.permissions.deny).toEqual(["Bash(rm *)"]);
+      expect(parsed.otherField).toBe("preserved");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ensureDevinMcpPermissionPreapproval is idempotent", async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), "devin-mcp-perm-idempotent-"));
+    try {
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
+      await ensureDevinMcpPermissionPreapproval(dir, "paseo-daemon", createTestLogger());
+
+      const configPath = path.join(dir, ".devin", "config.local.json");
+      const raw = await fs.readFile(configPath, "utf8");
+      const parsed = JSON.parse(raw) as { permissions: { allow: string[] } };
+      expect(parsed.permissions.allow.filter((p) => p === "mcp__paseo-daemon__*")).toHaveLength(1);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   test("summarizes JSON-RPC error details without stringifying objects", () => {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -2562,9 +2562,18 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     // agent's native MCP config would shadow the ACP injection, dropping the
     // correct callerAgentId, auth token, and daemon URL. Rename the internal
     // Paseo server to a name that won't collide with user config.
+    //
+    // If the target name is already occupied by a non-internal server, keep
+    // the original name to avoid overwriting the user's configuration.
+    const existingTarget = servers[ACP_PASEO_MCP_SERVER_NAME];
+    const targetNameTaken = existingTarget != null && !isInternalPaseoMcpServer(existingTarget);
     const renamed: Record<string, McpServerConfig> = {};
     for (const [name, config] of Object.entries(servers)) {
-      renamed[isInternalPaseoMcpServer(config) ? ACP_PASEO_MCP_SERVER_NAME : name] = config;
+      if (isInternalPaseoMcpServer(config) && !targetNameTaken) {
+        renamed[ACP_PASEO_MCP_SERVER_NAME] = config;
+      } else {
+        renamed[name] = config;
+      }
     }
     return normalizeMcpServers(renamed);
   }
@@ -2575,9 +2584,12 @@ export class ACPAgentSession implements AgentSession, ACPClient {
    * tools (mcp__<server>__<tool> patterns), not the ACP requestPermission
    * callback. Without preapproval, every MCP tool call prompts and blocks in
    * unattended contexts.
+   *
+   * Generic ACP providers report `this.provider` as `"acp"`, so identify Devin
+   * by its command binary instead.
    */
   private async prepareMcpPermissions(): Promise<void> {
-    if (this.provider !== "devin") {
+    if (this.defaultCommand[0] !== "devin") {
       return;
     }
     const servers = this.config.mcpServers;
@@ -2588,11 +2600,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     if (!hasInternalPaseoServer) {
       return;
     }
-    await ensureDevinMcpPermissionPreapproval(
-      this.config.cwd,
-      ACP_PASEO_MCP_SERVER_NAME,
-      this.logger,
-    );
+    await ensureDevinMcpPermissionPreapproval(this.config.cwd, ACP_PASEO_MCP_SERVER_NAME);
   }
 
   private applySessionState(response: SessionStateResponse): void {
@@ -3188,48 +3196,44 @@ function deriveCurrentConfigValue(
  * This writes `mcp__<serverName>__*` to the project-local `.devin/config.local.json`
  * so Devin auto-approves all tools on the injected Paseo MCP server. It merges
  * with any existing file, preserving user-authored permissions.
+ *
+ * Throws on failure — if the preapproval can't be written, the session would
+ * block forever on MCP tool calls in unattended contexts, so a clear error is
+ * better than a silent hang.
  */
 export async function ensureDevinMcpPermissionPreapproval(
   cwd: string,
   serverName: string,
-  logger: Logger,
 ): Promise<void> {
   const configPath = path.join(cwd, ".devin", "config.local.json");
   const permissionPattern = `mcp__${serverName}__*`;
 
+  let existing: Record<string, unknown> = {};
   try {
-    let existing: Record<string, unknown> = {};
-    try {
-      const raw = await fs.readFile(configPath, "utf8");
-      existing = JSON.parse(raw) as Record<string, unknown>;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
-    }
-
-    const permissions = (existing.permissions ?? {}) as Record<string, unknown>;
-    const allow = Array.isArray(permissions.allow) ? [...(permissions.allow as string[])] : [];
-    if (allow.includes(permissionPattern)) {
-      return;
-    }
-    allow.push(permissionPattern);
-
-    const updated = {
-      ...existing,
-      permissions: {
-        ...permissions,
-        allow,
-      },
-    };
-
-    await writeFileAtomic(configPath, `${JSON.stringify(updated, null, 2)}\n`);
+    const raw = await fs.readFile(configPath, "utf8");
+    existing = JSON.parse(raw) as Record<string, unknown>;
   } catch (error) {
-    logger.warn(
-      { err: error, configPath, permissionPattern },
-      "Failed to write Devin MCP permission preapproval",
-    );
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
   }
+
+  const permissions = (existing.permissions ?? {}) as Record<string, unknown>;
+  const allow = Array.isArray(permissions.allow) ? [...(permissions.allow as string[])] : [];
+  if (allow.includes(permissionPattern)) {
+    return;
+  }
+  allow.push(permissionPattern);
+
+  const updated = {
+    ...existing,
+    permissions: {
+      ...permissions,
+      allow,
+    },
+  };
+
+  await writeFileAtomic(configPath, `${JSON.stringify(updated, null, 2)}\n`);
 }
 
 function normalizeMcpServers(servers?: Record<string, McpServerConfig>): McpServer[] {

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -113,6 +113,8 @@ import {
   type ProviderRuntimeSettings,
 } from "../provider-launch-config.js";
 import { renderPromptAttachmentAsText } from "../prompt-attachments.js";
+import { ACP_PASEO_MCP_SERVER_NAME, isInternalPaseoMcpServer } from "../runtime-mcp-config.js";
+import { writeFileAtomic } from "../../atomic-file.js";
 import { appendOrReplaceGrowingAssistantMessage, runProviderTurn } from "./provider-runner.js";
 import {
   buildStringCommandShellInvocation,
@@ -2472,6 +2474,8 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private async spawnProcess(): Promise<SpawnedACPProcess> {
+    await this.prepareMcpPermissions();
+
     const prefix = await resolveProviderLaunch({
       commandConfig: this.runtimeSettings?.command,
       defaultBinary: this.defaultCommand[0],
@@ -2546,7 +2550,49 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   }
 
   private acpMcpServers(): McpServer[] {
-    return this.capabilities.supportsMcpServers ? normalizeMcpServers(this.config.mcpServers) : [];
+    if (!this.capabilities.supportsMcpServers) {
+      return [];
+    }
+    const servers = this.config.mcpServers;
+    if (!servers) {
+      return [];
+    }
+    // ACP agents (e.g. Devin CLI) merge ACP-injected MCP servers with their
+    // own native config files by name. A user's manual `paseo` entry in their
+    // agent's native MCP config would shadow the ACP injection, dropping the
+    // correct callerAgentId, auth token, and daemon URL. Rename the internal
+    // Paseo server to a name that won't collide with user config.
+    const renamed: Record<string, McpServerConfig> = {};
+    for (const [name, config] of Object.entries(servers)) {
+      renamed[isInternalPaseoMcpServer(config) ? ACP_PASEO_MCP_SERVER_NAME : name] = config;
+    }
+    return normalizeMcpServers(renamed);
+  }
+
+  /**
+   * Prepares provider-specific MCP permission preapprovals before the ACP
+   * process spawns. Devin CLI uses its own internal permission system for MCP
+   * tools (mcp__<server>__<tool> patterns), not the ACP requestPermission
+   * callback. Without preapproval, every MCP tool call prompts and blocks in
+   * unattended contexts.
+   */
+  private async prepareMcpPermissions(): Promise<void> {
+    if (this.provider !== "devin") {
+      return;
+    }
+    const servers = this.config.mcpServers;
+    if (!servers) {
+      return;
+    }
+    const hasInternalPaseoServer = Object.values(servers).some(isInternalPaseoMcpServer);
+    if (!hasInternalPaseoServer) {
+      return;
+    }
+    await ensureDevinMcpPermissionPreapproval(
+      this.config.cwd,
+      ACP_PASEO_MCP_SERVER_NAME,
+      this.logger,
+    );
   }
 
   private applySessionState(response: SessionStateResponse): void {
@@ -3129,6 +3175,61 @@ function deriveCurrentConfigValue(
       entry.type === "select" && entry.category === category,
   );
   return option?.currentValue ?? null;
+}
+
+/**
+ * Devin CLI uses its own internal permission system for MCP tools (not the ACP
+ * requestPermission callback). Permission patterns use `mcp__<server>__<tool>`
+ * format, read from `~/.config/devin/config.json` (user-wide) and
+ * `.devin/config.local.json` (project-local, gitignored). Without a preapproval
+ * entry, every MCP tool call prompts — and in an unattended/subagent context
+ * those prompts block forever.
+ *
+ * This writes `mcp__<serverName>__*` to the project-local `.devin/config.local.json`
+ * so Devin auto-approves all tools on the injected Paseo MCP server. It merges
+ * with any existing file, preserving user-authored permissions.
+ */
+export async function ensureDevinMcpPermissionPreapproval(
+  cwd: string,
+  serverName: string,
+  logger: Logger,
+): Promise<void> {
+  const configPath = path.join(cwd, ".devin", "config.local.json");
+  const permissionPattern = `mcp__${serverName}__*`;
+
+  try {
+    let existing: Record<string, unknown> = {};
+    try {
+      const raw = await fs.readFile(configPath, "utf8");
+      existing = JSON.parse(raw) as Record<string, unknown>;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    const permissions = (existing.permissions ?? {}) as Record<string, unknown>;
+    const allow = Array.isArray(permissions.allow) ? [...(permissions.allow as string[])] : [];
+    if (allow.includes(permissionPattern)) {
+      return;
+    }
+    allow.push(permissionPattern);
+
+    const updated = {
+      ...existing,
+      permissions: {
+        ...permissions,
+        allow,
+      },
+    };
+
+    await writeFileAtomic(configPath, `${JSON.stringify(updated, null, 2)}\n`);
+  } catch (error) {
+    logger.warn(
+      { err: error, configPath, permissionPattern },
+      "Failed to write Devin MCP permission preapproval",
+    );
+  }
 }
 
 function normalizeMcpServers(servers?: Record<string, McpServerConfig>): McpServer[] {

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -2015,7 +2015,7 @@ describe("OpenCode adapter startTurn error handling", () => {
     expect(promptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         permission: [
-          { permission: "hub_finish_execution", pattern: "*", action: "allow" },
+          { permission: "hub.finish_execution", pattern: "*", action: "allow" },
           { permission: "bash", pattern: "*", action: "ask" },
           { permission: "hub_reply", pattern: "*", action: "deny" },
         ],
@@ -3980,6 +3980,112 @@ describe("OpenCode provider subagent contract", () => {
       ),
     );
     expect(parent.getPendingPermissions()).toEqual([]);
+    await parent.close();
+  });
+
+  test("auto-approves internal Paseo MCP tool permissions even without auto-accept", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const parentClient = new TestOpenCodeClient();
+    parentClient.sessionCreateResponse = { data: { id: "ses_parent_paseo_mcp" } };
+    runtime.enqueueClient(parentClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    // Note: no auto_accept featureValue — internal Paseo MCP tools must be
+    // auto-approved regardless of the auto-accept setting.
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    parent.subscribe(() => undefined);
+
+    parentClient.emitEvent({
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_paseo_mcp_child",
+          parentID: "ses_parent_paseo_mcp",
+          title: "Paseo MCP child",
+          directory: "/workspace/paseo-child",
+        },
+      },
+    });
+    await vi.waitFor(() =>
+      expect(parentClient.calls.sessionChildren.length).toBeGreaterThanOrEqual(1),
+    );
+    parentClient.emitEvent({
+      type: "permission.asked",
+      properties: {
+        id: "perm_paseo_mcp_create_agent",
+        sessionID: "ses_paseo_mcp_child",
+        permission: "paseo.create_agent",
+        patterns: ["create agent"],
+        metadata: {},
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(parentClient.calls.permissionReply).toContainEqual(
+        expect.objectContaining({
+          requestID: "perm_paseo_mcp_create_agent",
+          directory: "/workspace/paseo-child",
+          reply: "always",
+        }),
+      ),
+    );
+    expect(parent.getPendingPermissions()).toEqual([]);
+    await parent.close();
+  });
+
+  test("does not auto-approve non-Paseo MCP tool permissions without auto-accept", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const parentClient = new TestOpenCodeClient();
+    parentClient.sessionCreateResponse = { data: { id: "ses_parent_other_mcp" } };
+    runtime.enqueueClient(parentClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+    });
+    parent.subscribe(() => undefined);
+
+    parentClient.emitEvent({
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_other_mcp_child",
+          parentID: "ses_parent_other_mcp",
+          title: "Other MCP child",
+          directory: "/workspace/other-child",
+        },
+      },
+    });
+    await vi.waitFor(() =>
+      expect(parentClient.calls.sessionChildren.length).toBeGreaterThanOrEqual(1),
+    );
+    parentClient.emitEvent({
+      type: "permission.asked",
+      properties: {
+        id: "perm_other_mcp_tool",
+        sessionID: "ses_other_mcp_child",
+        permission: "github.create_issue",
+        patterns: ["create issue"],
+        metadata: {},
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(parent.getPendingPermissions()).toEqual([
+        expect.objectContaining({ id: "perm_other_mcp_tool" }),
+      ]);
+    });
+    expect(parentClient.calls.permissionReply).not.toContainEqual(
+      expect.objectContaining({ requestID: "perm_other_mcp_tool" }),
+    );
     await parent.close();
   });
 

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -3997,6 +3997,12 @@ describe("OpenCode provider subagent contract", () => {
     const parent = await client.createSession({
       provider: "opencode",
       cwd: "/workspace/repo",
+      mcpServers: {
+        paseo: {
+          type: "http",
+          url: "http://127.0.0.1:6767/mcp/agents?callerAgentId=test-agent",
+        },
+      },
     });
     parent.subscribe(() => undefined);
 
@@ -4085,6 +4091,66 @@ describe("OpenCode provider subagent contract", () => {
     });
     expect(parentClient.calls.permissionReply).not.toContainEqual(
       expect.objectContaining({ requestID: "perm_other_mcp_tool" }),
+    );
+    await parent.close();
+  });
+
+  test("does not auto-approve external MCP server named paseo (name collision guard)", async () => {
+    const runtime = new TestOpenCodeHarness();
+    const parentClient = new TestOpenCodeClient();
+    parentClient.sessionCreateResponse = { data: { id: "ses_parent_collision" } };
+    runtime.enqueueClient(parentClient);
+    const client = new OpenCodeAgentClient(createTestLogger(), undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    // User configures an external MCP server named `paseo` that is NOT the
+    // internal Paseo daemon (different URL). Tools on this server must NOT
+    // be auto-approved — only the real internal Paseo MCP server qualifies.
+    const parent = await client.createSession({
+      provider: "opencode",
+      cwd: "/workspace/repo",
+      mcpServers: {
+        paseo: {
+          type: "http",
+          url: "https://external-example.com/mcp",
+        },
+      },
+    });
+    parent.subscribe(() => undefined);
+
+    parentClient.emitEvent({
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_collision_child",
+          parentID: "ses_parent_collision",
+          title: "Collision child",
+          directory: "/workspace/collision-child",
+        },
+      },
+    });
+    await vi.waitFor(() =>
+      expect(parentClient.calls.sessionChildren.length).toBeGreaterThanOrEqual(1),
+    );
+    parentClient.emitEvent({
+      type: "permission.asked",
+      properties: {
+        id: "perm_collision_tool",
+        sessionID: "ses_collision_child",
+        permission: "paseo.some_tool",
+        patterns: ["some tool"],
+        metadata: {},
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(parent.getPendingPermissions()).toEqual([
+        expect.objectContaining({ id: "perm_collision_tool" }),
+      ]);
+    });
+    expect(parentClient.calls.permissionReply).not.toContainEqual(
+      expect.objectContaining({ requestID: "perm_collision_tool" }),
     );
     await parent.close();
   });

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -86,7 +86,7 @@ import {
 } from "./diagnostic-utils.js";
 import { runProviderTurn } from "./provider-runner.js";
 import { renderPromptAttachmentAsText } from "../prompt-attachments.js";
-import { PASEO_MCP_SERVER_NAME } from "../runtime-mcp-config.js";
+import { PASEO_MCP_SERVER_NAME, isInternalPaseoMcpServer } from "../runtime-mcp-config.js";
 import { composeSystemPromptParts } from "../system-prompt.js";
 import { normalizeProviderReplayTimestamp } from "../provider-history-timestamps.js";
 import { revertOpenCodeConversationAndFiles } from "./opencode/rewind.js";
@@ -545,13 +545,25 @@ function isAlreadyPresentMcpError(error: unknown): boolean {
  * OpenCode MCP tool permission names use `server.tool` format (e.g.
  * `paseo.create_agent`). Returns true when the permission name refers to a
  * tool on the internal Paseo MCP server.
+ *
+ * Verifies the server config is actually the internal Paseo MCP server (by
+ * URL), not just that the name matches — a user-configured external server
+ * named `paseo` must not get auto-approved.
  */
-function isInternalPaseoMcpPermissionName(name: string): boolean {
+function isInternalPaseoMcpPermissionName(
+  name: string,
+  mcpServers: Record<string, McpServerConfig> | undefined,
+): boolean {
   const dotIndex = name.indexOf(".");
   if (dotIndex === -1) {
     return false;
   }
-  return name.slice(0, dotIndex) === PASEO_MCP_SERVER_NAME;
+  const serverName = name.slice(0, dotIndex);
+  if (serverName !== PASEO_MCP_SERVER_NAME) {
+    return false;
+  }
+  const serverConfig = mcpServers?.[serverName];
+  return serverConfig != null && isInternalPaseoMcpServer(serverConfig);
 }
 
 function readOpenCodeMcpOperationError(data: unknown, name: string): unknown {
@@ -4826,7 +4838,10 @@ class OpenCodeAgentSession implements AgentSession {
     // etc.) injected via the `paseo` MCP server. Without this, every call
     // triggers a permission prompt and the model avoids the orchestration tools.
     // Use "always" so the grant persists and subsequent calls don't re-prompt.
-    if (request.kind === "tool" && isInternalPaseoMcpPermissionName(request.name)) {
+    if (
+      request.kind === "tool" &&
+      isInternalPaseoMcpPermissionName(request.name, this.config.mcpServers)
+    ) {
       try {
         await this.client.permission.reply({
           requestID: request.id,

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -86,6 +86,7 @@ import {
 } from "./diagnostic-utils.js";
 import { runProviderTurn } from "./provider-runner.js";
 import { renderPromptAttachmentAsText } from "../prompt-attachments.js";
+import { PASEO_MCP_SERVER_NAME } from "../runtime-mcp-config.js";
 import { composeSystemPromptParts } from "../system-prompt.js";
 import { normalizeProviderReplayTimestamp } from "../provider-history-timestamps.js";
 import { revertOpenCodeConversationAndFiles } from "./opencode/rewind.js";
@@ -538,6 +539,19 @@ function isOpenCodeHeadersTimeoutFailure(error: unknown): boolean {
 function isAlreadyPresentMcpError(error: unknown): boolean {
   const normalized = toDiagnosticErrorMessage(error).toLowerCase();
   return MCP_ALREADY_PRESENT_ERROR_TOKENS.some((token) => normalized.includes(token));
+}
+
+/**
+ * OpenCode MCP tool permission names use `server.tool` format (e.g.
+ * `paseo.create_agent`). Returns true when the permission name refers to a
+ * tool on the internal Paseo MCP server.
+ */
+function isInternalPaseoMcpPermissionName(name: string): boolean {
+  const dotIndex = name.indexOf(".");
+  if (dotIndex === -1) {
+    return false;
+  }
+  return name.slice(0, dotIndex) === PASEO_MCP_SERVER_NAME;
 }
 
 function readOpenCodeMcpOperationError(data: unknown, name: string): unknown {
@@ -4807,6 +4821,28 @@ class OpenCodeAgentSession implements AgentSession {
     request: AgentPermissionRequest,
     directory: string,
   ): Promise<boolean> {
+    // Always auto-approve internal Paseo MCP tools. These are the daemon's own
+    // orchestration surface (create_agent, send_agent_prompt, browser tools,
+    // etc.) injected via the `paseo` MCP server. Without this, every call
+    // triggers a permission prompt and the model avoids the orchestration tools.
+    // Use "always" so the grant persists and subsequent calls don't re-prompt.
+    if (request.kind === "tool" && isInternalPaseoMcpPermissionName(request.name)) {
+      try {
+        await this.client.permission.reply({
+          requestID: request.id,
+          directory,
+          reply: "always",
+        });
+        return true;
+      } catch (error) {
+        this.logger.warn(
+          { err: error, requestId: request.id, permission: request.name },
+          "Failed to auto-approve internal Paseo MCP tool permission",
+        );
+        return false;
+      }
+    }
+
     if (!this.autoAcceptEnabled || request.kind !== "tool") {
       return false;
     }

--- a/packages/server/src/server/agent/providers/opencode/options.ts
+++ b/packages/server/src/server/agent/providers/opencode/options.ts
@@ -54,7 +54,7 @@ export function buildOpenCodePermissionRules(
 ): OpenCodePermissionRule[] | undefined {
   const grants =
     toolPolicy?.preapproved.map((grant) => ({
-      permission: `${grant.server}_${grant.tool}`,
+      permission: `${grant.server}.${grant.tool}`,
       pattern: "*",
       action: "allow" as const,
     })) ?? [];

--- a/packages/server/src/server/agent/runtime-mcp-config.ts
+++ b/packages/server/src/server/agent/runtime-mcp-config.ts
@@ -1,7 +1,18 @@
 import type { AgentSessionConfig, McpServerConfig } from "./agent-sdk-types.js";
 
-const PASEO_MCP_SERVER_NAME = "paseo";
+export const PASEO_MCP_SERVER_NAME = "paseo";
 const PASEO_MCP_PATHNAME = "/mcp/agents";
+
+/**
+ * Name used when injecting the internal Paseo MCP server into ACP agents.
+ * ACP agents (e.g. Devin CLI) merge ACP-injected MCP servers with their own
+ * native config files by server name. If a user has a manual `paseo` entry in
+ * their agent's native MCP config (a common workaround), the native entry wins
+ * and the ACP injection — which carries the correct callerAgentId, auth token,
+ * and daemon URL — is silently dropped. Using a distinct name avoids the
+ * collision so the injected server always loads.
+ */
+export const ACP_PASEO_MCP_SERVER_NAME = "paseo-daemon";
 
 export function stripInternalPaseoMcpServer(config: AgentSessionConfig): AgentSessionConfig {
   const mcpServers = config.mcpServers;
@@ -57,7 +68,7 @@ export function withRuntimePaseoMcpServer(params: {
   };
 }
 
-function isInternalPaseoMcpServer(config: McpServerConfig): boolean {
+export function isInternalPaseoMcpServer(config: McpServerConfig): boolean {
   if (config.type !== "http" && config.type !== "sse") {
     return false;
   }


### PR DESCRIPTION
## Summary

Three issues prevented Devin (ACP) and OpenCode agents from fully using the Paseo MCP server, leaving them with degraded or broken access compared to Claude Code and Codex:

- **Devin/ACP name collision** — a user's manual `paseo` entry in `~/.config/devin/mcp_config.json` shadowed the ACP-injected server, dropping `callerAgentId`, auth tokens, and daemon URL. This broke background execution, finish notifications, and authenticated daemon connections. Renamed the internal server to `paseo-daemon` for ACP providers to avoid the collision.

- **OpenCode permission format mismatch** — preapproval rules used `${server}_${tool}` (underscore) but OpenCode expects `${server}.${tool}` (dot), so no MCP tools were ever preapproved. Switched to dot format and added unconditional auto-approval for internal Paseo MCP tools (`paseo.*`) regardless of the auto-accept setting.

- **Devin MCP permission preapproval** — Devin uses its own internal permission system (`mcp__<server>__<tool>` patterns read from config files), not the ACP `requestPermission` callback. Without preapproval entries, every MCP tool call prompted and blocked forever in unattended/subagent contexts. Now writes `mcp__paseo-daemon__*` to the project-local `.devin/config.local.json` before spawning the Devin ACP process, merging with existing config and preserving user-authored permissions.

## QA evidence

### Tests added and results

```
npx vitest run src/server/agent/providers/acp-agent.test.ts src/server/agent/providers/opencode-agent.test.ts src/server/agent/provider-options.test.ts src/server/agent/runtime-mcp-config.test.ts --bail=1

Test Files  3 passed (3)
     Tests  212 passed (212)
```

New tests covering:
- ACP rename: verifies internal Paseo server is renamed to `paseo-daemon` for ACP providers
- OpenCode permission format: verifies dot format and auto-approval of `paseo.*`
- Devin permission preapproval: write, merge with existing config, idempotency

### Typecheck

```
npm run typecheck --workspace @getpaseo/server
✔️ tsgo -p tsconfig.server.typecheck.json --noEmit (clean)
```

### Lint and format

```
npm run lint -- <changed files>   → 0 warnings, 0 errors
npm run format:files -- <changed files>  → all files correct format
```

### Platforms tested

- Linux (daemon/server side) — all tests and typecheck
- No UI changes in this PR (server-only)