### PR TITLE
fix(app): preserve settings sidebar scroll position

### DIFF
--- a/packages/app/e2e/browser/settings-navigation.spec.ts
+++ b/packages/app/e2e/browser/settings-navigation.spec.ts
@@ -39,19 +39,17 @@ import {
   selectSettingsHost,
   expectSettingsHostPickerLabel,
   openSettingsHostSection,
+  openSettingsWithSeededHost,
   removeCurrentHostFromSettings,
+  scrollSettingsSidebarToBottom,
+  expectSettingsSidebarScrollTop,
 } from "../support/helpers/settings";
 import { getServerId } from "../support/helpers/server-id";
 import { expectAppRoute } from "../support/helpers/route-assertions";
-import { buildSeededHost } from "../support/helpers/daemon-registry";
 
 async function openWorkspace(page: Page, workspace: { workspaceId: string }) {
   await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
   await expect(page.getByTestId("menu-button")).toBeVisible();
-}
-
-async function readSettingsSidebarScrollTop(page: Page): Promise<number> {
-  return page.getByTestId("settings-sidebar-scroll-body").evaluate((element) => element.scrollTop);
 }
 
 test.describe("Settings sidebar navigation", () => {
@@ -161,27 +159,19 @@ test.describe("Settings sidebar navigation", () => {
 });
 
 metroTest.describe("Settings sidebar scroll persistence", () => {
+  metroTest.use({ viewport: { width: 900, height: 420 } });
+
   metroTest("keeps the scroll position across settings route boundaries", async ({ page }) => {
     const serverId = "srv_settings_scroll";
-    const nowIso = new Date().toISOString();
-    const host = buildSeededHost({ serverId, endpoint: "127.0.0.1:1", nowIso });
-    await page.addInitScript((seededHost) => {
-      localStorage.setItem("@paseo:daemon-registry", JSON.stringify([seededHost]));
-    }, host);
-    await page.setViewportSize({ width: 900, height: 420 });
-    await page.goto(buildSettingsSectionRoute("general"));
-
-    const scrollBody = page.getByTestId("settings-sidebar-scroll-body");
-    await expect(scrollBody).toBeVisible();
-    const scrollTop = await scrollBody.evaluate((element) => {
-      element.scrollTop = element.scrollHeight;
-      return element.scrollTop;
+    await openSettingsWithSeededHost(page, {
+      serverId,
+      label: "Settings scroll host",
+      endpoint: "127.0.0.1:1",
     });
-    expect(scrollTop).toBeGreaterThan(0);
 
-    await page.getByTestId("settings-host-section-usage").click();
-    await expectAppRoute(page, buildSettingsHostSectionRoute(serverId, "usage"));
-    await expect.poll(() => readSettingsSidebarScrollTop(page)).toBe(scrollTop);
+    const scrollTop = await scrollSettingsSidebarToBottom(page);
+    await openSettingsHostSection(page, serverId, "usage");
+    await expectSettingsSidebarScrollTop(page, scrollTop);
   });
 });
 

--- a/packages/app/e2e/browser/settings-navigation.spec.ts
+++ b/packages/app/e2e/browser/settings-navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../support/fixtures";
+import { test, metroTest, expect, type Page } from "../support/fixtures";
 import {
   buildHostWorkspaceRoute,
   buildOpenProjectRoute,
@@ -43,13 +43,15 @@ import {
 } from "../support/helpers/settings";
 import { getServerId } from "../support/helpers/server-id";
 import { expectAppRoute } from "../support/helpers/route-assertions";
+import { buildSeededHost } from "../support/helpers/daemon-registry";
 
-async function openWorkspace(
-  page: import("@playwright/test").Page,
-  workspace: { workspaceId: string },
-) {
+async function openWorkspace(page: Page, workspace: { workspaceId: string }) {
   await page.goto(buildHostWorkspaceRoute(getServerId(), workspace.workspaceId));
   await expect(page.getByTestId("menu-button")).toBeVisible();
+}
+
+async function readSettingsSidebarScrollTop(page: Page): Promise<number> {
+  return page.getByTestId("settings-sidebar-scroll-body").evaluate((element) => element.scrollTop);
 }
 
 test.describe("Settings sidebar navigation", () => {
@@ -155,6 +157,31 @@ test.describe("Settings sidebar navigation", () => {
       await expect(page.getByText("Add connection", { exact: true })).toHaveCount(0);
       await expect(page).toHaveURL(/\/settings(\/|$)/);
     });
+  });
+});
+
+metroTest.describe("Settings sidebar scroll persistence", () => {
+  metroTest("keeps the scroll position across settings route boundaries", async ({ page }) => {
+    const serverId = "srv_settings_scroll";
+    const nowIso = new Date().toISOString();
+    const host = buildSeededHost({ serverId, endpoint: "127.0.0.1:1", nowIso });
+    await page.addInitScript((seededHost) => {
+      localStorage.setItem("@paseo:daemon-registry", JSON.stringify([seededHost]));
+    }, host);
+    await page.setViewportSize({ width: 900, height: 420 });
+    await page.goto(buildSettingsSectionRoute("general"));
+
+    const scrollBody = page.getByTestId("settings-sidebar-scroll-body");
+    await expect(scrollBody).toBeVisible();
+    const scrollTop = await scrollBody.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+      return element.scrollTop;
+    });
+    expect(scrollTop).toBeGreaterThan(0);
+
+    await page.getByTestId("settings-host-section-usage").click();
+    await expectAppRoute(page, buildSettingsHostSectionRoute(serverId, "usage"));
+    await expect.poll(() => readSettingsSidebarScrollTop(page)).toBe(scrollTop);
   });
 });
 

--- a/packages/app/e2e/support/helpers/settings.ts
+++ b/packages/app/e2e/support/helpers/settings.ts
@@ -158,6 +158,21 @@ export async function seedSavedSettingsHosts(
   );
 }
 
+export async function openSettingsWithSeededHost(
+  page: Page,
+  host: SavedSettingsHostInput,
+): Promise<void> {
+  const seededHost = buildSeededHost({ ...host, nowIso: new Date().toISOString() });
+  await page.addInitScript(
+    ({ registryKey, storedHost }) => {
+      localStorage.setItem(registryKey, JSON.stringify([storedHost]));
+    },
+    { registryKey: REGISTRY_KEY, storedHost: seededHost },
+  );
+  await page.goto(buildSettingsSectionRoute("general"));
+  await expect(page.getByTestId("settings-sidebar")).toBeVisible();
+}
+
 export async function selectSettingsHost(page: Page, serverId: string): Promise<void> {
   await page.locator('[data-testid="settings-host-picker"]:visible').click();
   await page.locator(`[data-testid="settings-host-picker-item-${serverId}"]:visible`).click();
@@ -183,6 +198,28 @@ export async function expectSettingsSidebarVisible(page: Page): Promise<void> {
 
 export async function expectSettingsSidebarHidden(page: Page): Promise<void> {
   await expect(page.locator('[data-testid="settings-sidebar"]:visible')).toHaveCount(0);
+}
+
+export async function scrollSettingsSidebarToBottom(page: Page): Promise<number> {
+  const scrollBody = page.getByTestId("settings-sidebar-scroll-body");
+  await expect(scrollBody).toBeVisible();
+  const scrollTop = await scrollBody.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    return element.scrollTop;
+  });
+  expect(scrollTop).toBeGreaterThan(0);
+  return scrollTop;
+}
+
+export async function expectSettingsSidebarScrollTop(
+  page: Page,
+  expectedScrollTop: number,
+): Promise<void> {
+  await expect
+    .poll(() =>
+      page.getByTestId("settings-sidebar-scroll-body").evaluate((element) => element.scrollTop),
+    )
+    .toBe(expectedScrollTop);
 }
 
 export async function expectSettingsSidebarSections(

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -6,6 +6,8 @@ import {
   ScrollView,
   Text,
   View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   type PressableStateCallbackType,
 } from "react-native";
 import { EditingTextInput as TextInput } from "@/components/ui/text-input";
@@ -270,6 +272,8 @@ function getActiveLocale(language: string | undefined): SupportedLocale {
 }
 
 const SERVICE_URL_BEHAVIOR_VALUES: ServiceUrlBehavior[] = ["ask", "in-app", "external"];
+
+let desktopSidebarScrollOffset = { x: 0, y: 0 };
 
 // ---------------------------------------------------------------------------
 // Section components
@@ -1062,6 +1066,19 @@ function SettingsSidebar({
     () => [{ flex: 1 }, isDesktop ? { paddingTop: insets.top } : null],
     [insets.top, isDesktop],
   );
+  const desktopSidebarScrollRef = useRef<ScrollView>(null);
+  const handleDesktopSidebarScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      desktopSidebarScrollOffset = { ...event.nativeEvent.contentOffset };
+    },
+    [],
+  );
+  const restoreDesktopSidebarScroll = useCallback(() => {
+    desktopSidebarScrollRef.current?.scrollTo({
+      ...desktopSidebarScrollOffset,
+      animated: false,
+    });
+  }, []);
   const selectedSectionId = view.kind === "section" ? view.section : null;
   let selectedHostSection: HostSectionSlug | null = null;
   if (view.kind === "host") selectedHostSection = view.section;
@@ -1157,9 +1174,14 @@ function SettingsSidebar({
             />
           </View>
           <ScrollView
+            ref={desktopSidebarScrollRef}
             style={sidebarStyles.scrollBody}
             showsVerticalScrollIndicator={false}
             testID="settings-sidebar-scroll-body"
+            contentOffset={desktopSidebarScrollOffset}
+            onContentSizeChange={restoreDesktopSidebarScroll}
+            onScroll={handleDesktopSidebarScroll}
+            scrollEventThrottle={16}
           >
             {sidebarBody}
           </ScrollView>


### PR DESCRIPTION
## Summary

- preserve the wide settings sidebar's scroll offset while navigating between settings routes
- restore the saved offset after the remounted sidebar lays out its content
- cover the app-section to host-section route boundary with a focused browser regression

## Root cause

Foldable and other wide layouts keep the settings sidebar visible while route navigation swaps the settings screen component. The sidebar `ScrollView` was recreated at offset zero, so selecting a row across that route boundary made the sidebar jump to the top. Compact phone layouts hide the sidebar on the detail route, which made the same lifecycle less visible there.

## Validation

- focused Playwright regression: passed
- targeted lint: passed
- app typecheck: passed
- full pre-commit workspace typecheck, lint, and formatting checks: passed
