### PR TITLE
feat(cli): add --mcp-config support to paseo run

### DIFF
--- a/packages/cli/src/commands/agent/run.test.ts
+++ b/packages/cli/src/commands/agent/run.test.ts
@@ -1,10 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   resolveExistingRunWorkspace,
   resolveRunCallerAgentId,
   runRunCommand,
   type AgentRunOptions,
 } from "./run";
+
+const createAgent = vi.fn();
+const waitForFinish = vi.fn();
+const close = vi.fn();
+
+vi.mock("../../utils/client.js", () => ({
+  connectToDaemon: vi.fn(async () => ({
+    createAgent,
+    waitForFinish,
+    close,
+  })),
+  getDaemonHost: vi.fn(() => "ws://127.0.0.1:6767"),
+}));
 
 describe("managed agent caller context", () => {
   it("propagates a trimmed PASEO_AGENT_ID", () => {
@@ -104,5 +120,101 @@ describe("runRunCommand option validation", () => {
       { newWorkspace: "worktree", worktreeMode: "container" },
       /Unsupported worktree mode/,
     );
+  });
+});
+
+describe("--mcp-config", () => {
+  const originalCallerAgentId = process.env.PASEO_AGENT_ID;
+
+  function writeConfigFile(content: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "paseo-mcp-config-"));
+    const path = join(dir, "mcp.json");
+    writeFileSync(path, content, "utf8");
+    return path;
+  }
+
+  beforeEach(() => {
+    // Short-circuits workspace resolution so createAgent tests don't need to
+    // stub out createWorkspace as well.
+    process.env.PASEO_AGENT_ID = "parent-agent";
+    createAgent.mockReset();
+    waitForFinish.mockReset();
+    close.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalCallerAgentId === undefined) {
+      delete process.env.PASEO_AGENT_ID;
+    } else {
+      process.env.PASEO_AGENT_ID = originalCallerAgentId;
+    }
+  });
+
+  it("omits mcpServers when --mcp-config is not provided", async () => {
+    createAgent.mockResolvedValueOnce({
+      id: "agent-1",
+      status: "running",
+      provider: "codex",
+      cwd: "/tmp/project",
+      title: null,
+    });
+
+    await runRunCommand("do something", { provider: "codex", background: true }, {} as never);
+
+    expect(createAgent).toHaveBeenCalledWith(expect.objectContaining({ mcpServers: undefined }));
+  });
+
+  it("parses a valid --mcp-config file and passes mcpServers to createAgent", async () => {
+    const path = writeConfigFile(
+      JSON.stringify({
+        apify: { type: "stdio", command: "actors-mcp-server", args: [] },
+      }),
+    );
+    createAgent.mockResolvedValueOnce({
+      id: "agent-1",
+      status: "running",
+      provider: "codex",
+      cwd: "/tmp/project",
+      title: null,
+    });
+
+    await runRunCommand(
+      "do something",
+      { provider: "codex", background: true, mcpConfig: path },
+      {} as never,
+    );
+
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpServers: {
+          apify: { type: "stdio", command: "actors-mcp-server", args: [] },
+        },
+      }),
+    );
+  });
+
+  it("rejects a nonexistent --mcp-config path before connecting to the daemon", async () => {
+    await expect(
+      runRunCommand("do something", { mcpConfig: "/no/such/mcp-config.json" }, {} as never),
+    ).rejects.toMatchObject({ code: "INVALID_MCP_CONFIG" });
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid JSON in --mcp-config", async () => {
+    const path = writeConfigFile("{ not valid json");
+
+    await expect(
+      runRunCommand("do something", { mcpConfig: path }, {} as never),
+    ).rejects.toMatchObject({ code: "INVALID_MCP_CONFIG" });
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a --mcp-config file that fails MCP server schema validation", async () => {
+    const path = writeConfigFile(JSON.stringify({ apify: { type: "carrier-pigeon" } }));
+
+    await expect(
+      runRunCommand("do something", { mcpConfig: path }, {} as never),
+    ).rejects.toMatchObject({ code: "INVALID_MCP_CONFIG" });
+    expect(createAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/agent/run.ts
+++ b/packages/cli/src/commands/agent/run.ts
@@ -1,6 +1,8 @@
 import { Command, Option } from "commander";
 import { getStructuredAgentResponse, StructuredAgentResponseError } from "@getpaseo/server";
 import type { AgentSnapshotPayload } from "@getpaseo/protocol/messages";
+import { McpServersConfigSchema } from "@getpaseo/protocol/messages";
+import type { McpServerConfig } from "@getpaseo/protocol/agent-types";
 import { connectToDaemon, getDaemonHost } from "../../utils/client.js";
 import type {
   CommandOptions,
@@ -82,6 +84,10 @@ export function addRunOptions(cmd: Command): Command {
         "--output-schema <schema>",
         "Output JSON matching the provided schema file path or inline JSON schema",
       )
+      .option(
+        "--mcp-config <path>",
+        "Path to a JSON file of MCP servers (name -> server config) to attach to the agent",
+      )
   );
 }
 
@@ -131,6 +137,7 @@ export interface AgentRunOptions extends CommandOptions {
   label?: string[];
   waitTimeout?: string;
   outputSchema?: string;
+  mcpConfig?: string;
 }
 
 function resolveNewWorkspaceKind(options: AgentRunOptions): string | undefined {
@@ -213,6 +220,57 @@ function loadOutputSchema(value: string): Record<string, unknown> {
   }
 
   return parsed as Record<string, unknown>;
+}
+
+function loadMcpConfig(value: string): Record<string, McpServerConfig> {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    const error: CommandError = {
+      code: "INVALID_MCP_CONFIG",
+      message: "--mcp-config cannot be empty",
+      details: "Provide a path to a JSON file mapping MCP server names to server configs",
+    };
+    throw error;
+  }
+
+  const path = resolve(trimmed);
+  let source: string;
+  try {
+    source = readFileSync(path, "utf8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "INVALID_MCP_CONFIG",
+      message: `Failed to read MCP config file: ${trimmed}`,
+      details: message,
+    };
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error: CommandError = {
+      code: "INVALID_MCP_CONFIG",
+      message: `Failed to parse MCP config JSON: ${trimmed}`,
+      details: message,
+    };
+    throw error;
+  }
+
+  const result = McpServersConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    const error: CommandError = {
+      code: "INVALID_MCP_CONFIG",
+      message: `MCP config file does not match the expected schema: ${trimmed}`,
+      details: result.error.message,
+    };
+    throw error;
+  }
+
+  return result.data as Record<string, McpServerConfig>;
 }
 
 class StructuredRunStatusError extends Error {
@@ -588,6 +646,7 @@ export async function runRunCommand(
 ): Promise<SingleResult<AgentRunResult>> {
   const host = getDaemonHost({ host: options.host });
   const outputSchema = options.outputSchema ? loadOutputSchema(options.outputSchema) : undefined;
+  const mcpServers = options.mcpConfig ? loadMcpConfig(options.mcpConfig) : undefined;
 
   validateRunOptions(prompt, options, outputSchema);
   const waitTimeoutMs = parseWaitTimeoutOption(options.waitTimeout);
@@ -641,6 +700,7 @@ export async function runRunCommand(
             images,
             env: requestEnv,
             labels: Object.keys(labels).length > 0 ? labels : undefined,
+            mcpServers,
           });
         } else {
           await client.sendMessage(structuredAgent.id, structuredPrompt);
@@ -711,6 +771,7 @@ export async function runRunCommand(
       images,
       env: requestEnv,
       labels: Object.keys(labels).length > 0 ? labels : undefined,
+      mcpServers,
     });
 
     // Default run behavior is foreground: wait for completion unless background execution is set.

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -431,11 +431,13 @@ const McpSseServerConfigSchema = z.object({
   alwaysLoad: z.boolean().optional(),
 });
 
-const McpServerConfigSchema = z.discriminatedUnion("type", [
+export const McpServerConfigSchema = z.discriminatedUnion("type", [
   McpStdioServerConfigSchema,
   McpHttpServerConfigSchema,
   McpSseServerConfigSchema,
 ]);
+
+export const McpServersConfigSchema = z.record(z.string(), McpServerConfigSchema);
 
 const ProviderOptionsSchema = z.record(z.string(), z.json());
 


### PR DESCRIPTION
## Summary
- Adds optional `--mcp-config <path>` to `paseo run`, pointing at a JSON file (`server name -> McpServerConfig`).
- Validates MCP server config using the canonical protocol schema (`McpServerConfigSchema` / `McpServersConfigSchema` exported from the protocol package).
- Passes `mcpServers` into `createAgent` so MCP servers are attached to the new agent.
- Adds regression tests covering schema validation, file-not-found, and the `createAgent` wiring.
- Enables per-run MCP injection for consumers such as Delivery Manager / Runtimer.

Scope is limited to three files:
- `packages/cli/src/commands/agent/run.ts`
- `packages/cli/src/commands/agent/run.test.ts`
- `packages/protocol/src/messages.ts`

#### Test plan
- [ ] `packages/cli` unit tests pass (`run.test.ts`)
- [ ] `packages/protocol` tests pass (`messages.ts` schema export)
- [ ] Manual: `paseo run --mcp-config ./mcp.json` attaches MCP servers to the new agent

Generated with [Devin](https://devin.ai)