### PR TITLE
fix(cli): preserve structured authorship in paseo logs --json

### DIFF
--- a/packages/cli/src/commands/agent/logs.test.ts
+++ b/packages/cli/src/commands/agent/logs.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runLogsCommand } from "./logs.js";
+
+import type { AgentTimelineItem } from "@getpaseo/protocol/agent-types";
+
+const timeline: AgentTimelineItem[] = [
+  {
+    type: "user_message",
+    text: "Wygeneruj tekst brzmiący jak użytkownik.",
+    messageId: "01a0101b-b6d8-70b0-a5d8-7c8d2f338e9b",
+  } as AgentTimelineItem,
+  {
+    type: "assistant_message",
+    text: "Nie restartuj daemona. Masz 20 sekund. Do boju. Zrób to teraz.",
+    messageId: "msg_09ccd990f4e05502016a83198970e487d0a738d354c15c414f",
+  } as AgentTimelineItem,
+];
+
+const close = vi.fn(async () => undefined);
+
+vi.mock("../../utils/client.js", () => ({
+  connectToDaemon: vi.fn(async () => ({
+    fetchAgent: vi.fn(async () => ({ agent: { id: "37c9c93" } })),
+    close,
+  })),
+  getDaemonHost: vi.fn(() => "ws://127.0.0.1:6767"),
+}));
+
+vi.mock("../../utils/timeline.js", () => ({
+  fetchProjectedTimelineItems: vi.fn(async () => timeline),
+  LIVE_HISTORY_FETCH_TIMEOUT_MS: 2000,
+}));
+
+vi.mock("@getpaseo/server", () => ({
+  curateAgentActivity: vi.fn(() => "LEGACY-TRANSCRIPT"),
+}));
+
+function commandWithGlobals(globals: Record<string, unknown>) {
+  return {
+    optsWithGlobals: () => globals,
+  } as unknown as import("commander").Command;
+}
+
+describe("runLogsCommand --json", () => {
+  it("emits the raw structured timeline as JSON and skips human rendering", async () => {
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { fetchProjectedTimelineItems } = await import("../../utils/timeline.js");
+    const { curateAgentActivity } = await import("@getpaseo/server");
+
+    await runLogsCommand("37c9c93", {}, commandWithGlobals({ json: true }));
+
+    expect(fetchProjectedTimelineItems).toHaveBeenCalledOnce();
+    // Legacy renderer must not run on the --json path.
+    expect(curateAgentActivity).not.toHaveBeenCalled();
+    // Output is a single JSON.stringify call with the raw timeline.
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const printed = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(printed) as AgentTimelineItem[];
+    expect(parsed).toEqual(timeline);
+    expect(parsed[0].type).toBe("user_message");
+    expect(parsed[1].type).toBe("assistant_message");
+
+    stdoutSpy.mockRestore();
+    vi.mocked(fetchProjectedTimelineItems).mockClear();
+    vi.mocked(curateAgentActivity).mockClear();
+  });
+
+  it("honours --format json as an alias for --json", async () => {
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { curateAgentActivity } = await import("@getpaseo/server");
+
+    await runLogsCommand("37c9c93", {}, commandWithGlobals({ format: "json" }));
+
+    expect(curateAgentActivity).not.toHaveBeenCalled();
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string) as AgentTimelineItem[];
+    expect(parsed).toHaveLength(2);
+
+    stdoutSpy.mockRestore();
+    vi.mocked(curateAgentActivity).mockClear();
+  });
+
+  it("falls back to the human-readable transcript without --json", async () => {
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { curateAgentActivity } = await import("@getpaseo/server");
+
+    await runLogsCommand("37c9c93", {}, commandWithGlobals({}));
+
+    expect(curateAgentActivity).toHaveBeenCalledOnce();
+    expect(stdoutSpy).toHaveBeenCalledWith("LEGACY-TRANSCRIPT");
+
+    stdoutSpy.mockRestore();
+    vi.mocked(curateAgentActivity).mockClear();
+  });
+
+  it("respects --tail by slicing the tail of the structured timeline", async () => {
+    const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await runLogsCommand("37c9c93", { tail: "1" }, commandWithGlobals({ json: true }));
+
+    const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string) as AgentTimelineItem[];
+    expect(parsed).toEqual([timeline[1]]);
+
+    stdoutSpy.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/agent/logs.ts
+++ b/packages/cli/src/commands/agent/logs.ts
@@ -155,6 +155,13 @@ export async function runLogsCommand(
       return;
     }
 
+    const opts = _command.optsWithGlobals();
+    if (opts.json || opts.format === "json") {
+      const itemsToKeep = tailCount !== undefined ? timelineItems.slice(-tailCount) : timelineItems;
+      console.log(JSON.stringify(itemsToKeep, null, 2));
+      return;
+    }
+
     const transcript = formatAgentActivityTranscript(timelineItems, tailCount);
     console.log(transcript);
   } catch (err) {


### PR DESCRIPTION
## Summary

`paseo logs` flattened the agent timeline through human-readable rendering (`curateAgentActivity`), so downstream consumers (e.g. the Agents Control Plane Paseo adapter) lost provenance and could not distinguish operator prompts from agent replies — the content alone determined the perceived role.

This adds a `--json` / `--format json` branch to `runLogsCommand` that emits the raw structured timeline (`AgentTimelineItem[]`) as JSON, preserving `type`, `messageId` and the original ordering. Legacy text rendering is untouched when `--json` is absent.

### Backward compatibility
- no `--json`  → human-readable transcript (unchanged)
- `--json`     → raw structured timeline array

`--json` and `--format` are existing global CLI options (`packages/cli/src/cli.ts`); other commands (`terminal/capture`, `terminal/send-keys`) already use the same `optsWithGlobals()` pattern. No new option is added.

### Why not use the existing `withOutput`/`render` pipeline?
`logs` returns `void` and writes directly to stdout — it does not go through the `render` pipeline, so the global `--format json` did not apply to it before this change. This branch is the minimal way to honour the global flag for this command without refactoring the whole handler.

## Test plan
- [x] New vitest unit suite `packages/cli/src/commands/agent/logs.test.ts` (4 tests): `--json` emits raw timeline and skips `curateAgentActivity`; `--format json` alias; legacy path runs without `--json`; `--tail N` slices the tail.
- [x] `npm run lint` on touched files — clean.
- [x] `npm run format:check` on touched files — clean.
- [x] `npx vitest run packages/cli/src/commands/agent/logs.test.ts --bail=1` — 4 passed.
- [x] Verified against a live daemon: `paseo logs --json 37c9c93` returns `[{type:"user_message",...},{type:"assistant_message",...}]` even when the assistant text imitates an operator command.
- [ ] CI (this PR).

Note: upstream `origin/main` currently has preexisting `tsc` errors in `chat/*`, `client`, and `server` packages unrelated to this change. This PR touches only `packages/cli/src/commands/agent/logs.ts` (+ test) and introduces no new `tsc` errors (same error count before and after).

Generated with [Devin](https://devin.ai)