### PR TITLE
fix(pi): render IRC messages as agent cards

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -793,6 +793,74 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("surfaces live exact IRC custom messages as completed sub-agent tool calls", async () => {
+    const { pi, session, events } = await createSession();
+    const rawText = `<irc>
+Incoming IRC message from agent \`Main\`:
+
+Envelope body
+
+Sent while waiting/working. Active interruptible wait stopped early for immediate reading.
+</irc>`;
+
+    await session.startTurn("wait for peer");
+    pi.latestSession().emit({
+      type: "message_end",
+      message: {
+        role: "custom",
+        customType: "irc:incoming",
+        content: rawText,
+        details: {
+          id: "irc-live-1",
+          from: "Main",
+          message: "Review this\nacross two lines",
+        },
+      },
+    });
+
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      {
+        type: "timeline",
+        item: {
+          type: "tool_call",
+          callId: "pi-irc:irc-live-1",
+          name: "agent_message",
+          status: "completed",
+          detail: {
+            type: "sub_agent",
+            subAgentType: "Main",
+            description: "Review this\nacross two lines",
+            log: rawText,
+          },
+          error: null,
+        },
+      },
+      { type: "turn_completed" },
+    ]);
+  });
+
+  test("keeps malformed live IRC custom messages on the assistant fallback", async () => {
+    const { pi, session, events } = await createSession();
+
+    await session.startTurn("wait for peer");
+    pi.latestSession().emit({
+      type: "message_end",
+      message: {
+        role: "custom",
+        customType: "irc:incoming",
+        content: "Malformed IRC transport text",
+      },
+    });
+
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      {
+        type: "timeline",
+        item: { type: "assistant_message", text: "Malformed IRC transport text" },
+      },
+      { type: "turn_completed" },
+    ]);
+  });
+
   test("canceling a silent Pi extension command leaves the session usable", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2240,7 +2240,7 @@ export class PiRpcAgentSession implements AgentSession {
     }
     if (event.message.role === "custom") {
       const text = getUserMessageText(event.message.content);
-      const ircMessage = mapPiIrcMessage(event.message, text);
+      const ircMessage = mapPiIrcMessage({ message: event.message, rawText: text });
       if (ircMessage || text) {
         this.emit({
           type: "timeline",

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -62,6 +62,7 @@ import {
   streamPiHistory,
   type PiCapturedUserMessageEntry,
 } from "./history-mapper.js";
+import { mapPiIrcMessage } from "./irc-message-mapper.js";
 import { materializeProviderImage } from "../provider-image-output.js";
 import { PiCliRuntime } from "./cli-runtime.js";
 import { revertPiConversation } from "./rewind.js";
@@ -2239,12 +2240,13 @@ export class PiRpcAgentSession implements AgentSession {
     }
     if (event.message.role === "custom") {
       const text = getUserMessageText(event.message.content);
-      if (text) {
+      const ircMessage = mapPiIrcMessage(event.message, text);
+      if (ircMessage || text) {
         this.emit({
           type: "timeline",
           provider: this.provider,
           turnId,
-          item: { type: "assistant_message", text },
+          item: ircMessage ?? { type: "assistant_message", text },
         });
       }
       this.completeTurn(turnId, []);

--- a/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
@@ -140,6 +140,64 @@ describe("Pi history mapper", () => {
     ]);
   });
 
+  test("replays exact IRC custom messages as completed sub-agent tool calls", async () => {
+    const rawText = `<irc>
+Incoming IRC message from agent \`Main\`:
+
+Review this
+across two lines
+
+Sent while waiting/working. Active interruptible wait stopped early for immediate reading.
+</irc>`;
+
+    await expect(
+      collectHistory([
+        {
+          role: "custom",
+          customType: "irc:incoming",
+          content: rawText,
+          details: { id: "irc-1", from: "Main", message: "Review this\nacross two lines" },
+        },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "timeline",
+        provider: "pi",
+        item: {
+          type: "tool_call",
+          callId: "pi-irc:irc-1",
+          name: "agent_message",
+          status: "completed",
+          detail: {
+            type: "sub_agent",
+            subAgentType: "Main",
+            description: "Review this\nacross two lines",
+            log: rawText,
+          },
+          error: null,
+        },
+      },
+    ]);
+  });
+
+  test("replays malformed IRC custom messages through the assistant fallback", async () => {
+    await expect(
+      collectHistory([
+        {
+          role: "custom",
+          customType: "irc:incoming",
+          content: "Malformed IRC transport text",
+        },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "timeline",
+        provider: "pi",
+        item: { type: "assistant_message", text: "Malformed IRC transport text" },
+      },
+    ]);
+  });
+
   test("uses Pi tree entry ids for replayed user messages", async () => {
     await expect(
       collectHistory(

--- a/packages/server/src/server/agent/providers/pi/history-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.ts
@@ -118,7 +118,7 @@ export class PiHistoryMapper {
     message: Extract<PiAgentMessage, { role: "custom" }>,
   ): AgentStreamEvent[] {
     const text = getUserMessageText(message.content);
-    const ircMessage = mapPiIrcMessage(message, text);
+    const ircMessage = mapPiIrcMessage({ message, rawText: text });
     if (ircMessage) {
       return [
         {

--- a/packages/server/src/server/agent/providers/pi/history-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.ts
@@ -9,6 +9,7 @@ import {
   type PiToolResult,
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
+import { mapPiIrcMessage } from "./irc-message-mapper.js";
 
 export interface PiCapturedUserMessageEntry {
   id: string;
@@ -117,6 +118,16 @@ export class PiHistoryMapper {
     message: Extract<PiAgentMessage, { role: "custom" }>,
   ): AgentStreamEvent[] {
     const text = getUserMessageText(message.content);
+    const ircMessage = mapPiIrcMessage(message, text);
+    if (ircMessage) {
+      return [
+        {
+          type: "timeline",
+          provider: this.provider,
+          item: ircMessage,
+        },
+      ];
+    }
     const mappedEvent = text ? this.hooks.mapCustomMessage?.(text, this.provider) : null;
     if (mappedEvent) {
       return [mappedEvent];

--- a/packages/server/src/server/agent/providers/pi/irc-message-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/irc-message-mapper.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+
+import { mapPiIrcMessage, parsePiIrcEnvelope } from "./irc-message-mapper.js";
+
+const currentEnvelope = `<irc>
+Incoming IRC message from agent \`AgentMessageUi\` (reply to msg-42):
+
+First line
+second line
+
+Sent while waiting/working. Active interruptible wait stopped early for immediate reading.
+
+If response expected, reply via hub.
+</irc>`;
+
+const historicalEnvelope = `<irc>
+Incoming IRC message from agent Main:
+
+Historical message
+
+An agent sent this while you were waiting or working. Read it before continuing.
+</irc>`;
+
+describe("Pi IRC message mapper", () => {
+  test("parses current and historical textual envelopes", () => {
+    expect(parsePiIrcEnvelope(currentEnvelope)).toEqual({
+      sender: "AgentMessageUi",
+      text: "First line\nsecond line",
+    });
+    expect(
+      mapPiIrcMessage(
+        { role: "custom", customType: "irc:incoming", content: currentEnvelope },
+        currentEnvelope,
+      ),
+    ).toEqual({
+      type: "tool_call",
+      callId: expect.stringMatching(/^pi-irc:[0-9a-f]{64}$/),
+      name: "agent_message",
+      status: "completed",
+      detail: {
+        type: "sub_agent",
+        subAgentType: "AgentMessageUi",
+        description: "First line\nsecond line",
+        log: currentEnvelope,
+      },
+      error: null,
+    });
+    expect(parsePiIrcEnvelope(historicalEnvelope)).toEqual({
+      sender: "Main",
+      text: "Historical message",
+    });
+  });
+
+  test("prefers structured details without interpreting message text as transport metadata", () => {
+    expect(
+      mapPiIrcMessage(
+        {
+          role: "custom",
+          customType: "irc:incoming",
+          content: currentEnvelope,
+          details: {
+            id: "msg-42",
+            from: "Main",
+            message: "Keep this line\n\nSent while waiting/working. This is message content.",
+          },
+        },
+        currentEnvelope,
+      ),
+    ).toEqual({
+      type: "tool_call",
+      callId: "pi-irc:msg-42",
+      name: "agent_message",
+      status: "completed",
+      detail: {
+        type: "sub_agent",
+        subAgentType: "Main",
+        description: "Keep this line\n\nSent while waiting/working. This is message content.",
+        log: currentEnvelope,
+      },
+      error: null,
+    });
+  });
+
+  test("rejects other custom types and malformed IRC envelopes", () => {
+    expect(
+      mapPiIrcMessage(
+        { role: "custom", customType: "other", content: currentEnvelope },
+        currentEnvelope,
+      ),
+    ).toBeNull();
+    expect(
+      mapPiIrcMessage(
+        {
+          role: "custom",
+          customType: "irc:incoming",
+          content: "Incoming IRC message without an envelope",
+        },
+        "Incoming IRC message without an envelope",
+      ),
+    ).toBeNull();
+    expect(
+      parsePiIrcEnvelope("<irc>\nIncoming IRC message from agent ``:\n\ntext\n</irc>"),
+    ).toBeNull();
+  });
+});

--- a/packages/server/src/server/agent/providers/pi/irc-message-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/irc-message-mapper.test.ts
@@ -28,10 +28,10 @@ describe("Pi IRC message mapper", () => {
       text: "First line\nsecond line",
     });
     expect(
-      mapPiIrcMessage(
-        { role: "custom", customType: "irc:incoming", content: currentEnvelope },
-        currentEnvelope,
-      ),
+      mapPiIrcMessage({
+        message: { role: "custom", customType: "irc:incoming", content: currentEnvelope },
+        rawText: currentEnvelope,
+      }),
     ).toEqual({
       type: "tool_call",
       callId: expect.stringMatching(/^pi-irc:[0-9a-f]{64}$/),
@@ -53,8 +53,8 @@ describe("Pi IRC message mapper", () => {
 
   test("prefers structured details without interpreting message text as transport metadata", () => {
     expect(
-      mapPiIrcMessage(
-        {
+      mapPiIrcMessage({
+        message: {
           role: "custom",
           customType: "irc:incoming",
           content: currentEnvelope,
@@ -64,8 +64,8 @@ describe("Pi IRC message mapper", () => {
             message: "Keep this line\n\nSent while waiting/working. This is message content.",
           },
         },
-        currentEnvelope,
-      ),
+        rawText: currentEnvelope,
+      }),
     ).toEqual({
       type: "tool_call",
       callId: "pi-irc:msg-42",
@@ -83,20 +83,20 @@ describe("Pi IRC message mapper", () => {
 
   test("rejects other custom types and malformed IRC envelopes", () => {
     expect(
-      mapPiIrcMessage(
-        { role: "custom", customType: "other", content: currentEnvelope },
-        currentEnvelope,
-      ),
+      mapPiIrcMessage({
+        message: { role: "custom", customType: "other", content: currentEnvelope },
+        rawText: currentEnvelope,
+      }),
     ).toBeNull();
     expect(
-      mapPiIrcMessage(
-        {
+      mapPiIrcMessage({
+        message: {
           role: "custom",
           customType: "irc:incoming",
           content: "Incoming IRC message without an envelope",
         },
-        "Incoming IRC message without an envelope",
-      ),
+        rawText: "Incoming IRC message without an envelope",
+      }),
     ).toBeNull();
     expect(
       parsePiIrcEnvelope("<irc>\nIncoming IRC message from agent ``:\n\ntext\n</irc>"),

--- a/packages/server/src/server/agent/providers/pi/irc-message-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/irc-message-mapper.ts
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+
+import type { ToolCallTimelineItem } from "../../agent-sdk-types.js";
+import type { PiAgentMessage } from "./rpc-types.js";
+
+const IRC_ENVELOPE_PATTERN =
+  /^<irc>\r?\nIncoming IRC message from agent (?:`([^`\r\n]+)`|([A-Za-z0-9][A-Za-z0-9._/@-]*))(?: \(reply to [^)\r\n]+\))?:\r?\n\r?\n([\s\S]*?)\r?\n\r?\n(?:Sent while waiting\/working\.|An agent sent this while you were waiting or working\.)[\s\S]*\r?\n<\/irc>$/;
+
+interface ParsedIrcMessage {
+  sender: string;
+  text: string;
+  id?: string;
+}
+
+function parseStructuredDetails(details: unknown): ParsedIrcMessage | null {
+  if (typeof details !== "object" || details === null || Array.isArray(details)) {
+    return null;
+  }
+  const from = Reflect.get(details, "from");
+  const message = Reflect.get(details, "message");
+  if (typeof from !== "string" || !from.trim() || typeof message !== "string") {
+    return null;
+  }
+  const id = Reflect.get(details, "id");
+  return {
+    sender: from.trim(),
+    text: message,
+    ...(typeof id === "string" && id.trim() ? { id: id.trim() } : {}),
+  };
+}
+
+export function parsePiIrcEnvelope(rawText: string): ParsedIrcMessage | null {
+  const match = IRC_ENVELOPE_PATTERN.exec(rawText);
+  if (!match) {
+    return null;
+  }
+  const sender = (match[1] ?? match[2] ?? "").trim();
+  const text = match[3];
+  if (!sender || text === undefined || !text.trim()) {
+    return null;
+  }
+  return { sender, text };
+}
+
+export function mapPiIrcMessage(
+  message: Extract<PiAgentMessage, { role: "custom" }>,
+  rawText: string,
+): ToolCallTimelineItem | null {
+  if (message.customType !== "irc:incoming") {
+    return null;
+  }
+  const structured = parseStructuredDetails(message.details);
+  const parsed = structured ?? parsePiIrcEnvelope(rawText);
+  if (!parsed) {
+    return null;
+  }
+  const callId = structured?.id
+    ? `pi-irc:${structured.id}`
+    : `pi-irc:${createHash("sha256").update(rawText).digest("hex")}`;
+  return {
+    type: "tool_call",
+    callId,
+    name: "agent_message",
+    status: "completed",
+    detail: {
+      type: "sub_agent",
+      subAgentType: parsed.sender,
+      description: parsed.text,
+      log: rawText,
+    },
+    error: null,
+  };
+}

--- a/packages/server/src/server/agent/providers/pi/irc-message-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/irc-message-mapper.ts
@@ -11,6 +11,10 @@ interface ParsedIrcMessage {
   text: string;
   id?: string;
 }
+interface MapPiIrcMessageInput {
+  message: Extract<PiAgentMessage, { role: "custom" }>;
+  rawText: string;
+}
 
 function parseStructuredDetails(details: unknown): ParsedIrcMessage | null {
   if (typeof details !== "object" || details === null || Array.isArray(details)) {
@@ -42,10 +46,10 @@ export function parsePiIrcEnvelope(rawText: string): ParsedIrcMessage | null {
   return { sender, text };
 }
 
-export function mapPiIrcMessage(
-  message: Extract<PiAgentMessage, { role: "custom" }>,
-  rawText: string,
-): ToolCallTimelineItem | null {
+export function mapPiIrcMessage({
+  message,
+  rawText,
+}: MapPiIrcMessageInput): ToolCallTimelineItem | null {
   if (message.customType !== "irc:incoming") {
     return null;
   }

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -41,6 +41,8 @@ export type PiAgentMessage =
   | {
       role: "custom";
       content: string | Array<PiTextContent | PiImageContent>;
+      customType?: string;
+      details?: unknown;
     }
   | {
       role: "assistant";


### PR DESCRIPTION
### Linked issue

Closes #3332

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Pi forwards multi-agent coordination as visible custom messages with `customType: "irc:incoming"`. Paseo flattened those messages into assistant text, so users saw the full `<irc>` transport envelope instead of the sender and message.

This maps IRC custom messages onto the existing `tool_call` / `sub_agent` presentation. Structured `details.from`, `details.message`, and `details.id` are preferred; a strict envelope parser supports older session data. Reusing the existing timeline shape keeps old app/new daemon protocol compatibility.

### Goals

- Show the sending agent and message in the compact timeline card.
- Keep raw transport text available in the existing expanded detail view.
- Handle live events and restored history identically.
- Preserve current assistant rendering for unrelated or malformed custom messages.

### Non-goals

- Introduce a new timeline protocol discriminator.
- Change generic Pi custom-message visibility behavior tracked by #2674.
- Redesign the existing sub-agent card.

### QA

Automated regression:

```text
npx vitest run packages/server/src/server/agent/providers/pi/irc-message-mapper.test.ts packages/server/src/server/agent/providers/pi/history-mapper.test.ts packages/server/src/server/agent/providers/pi/agent.test.ts packages/protocol/src/tool-call-display.test.ts

Test Files  4 passed (4)
Tests       79 passed (79)
```

Repository checks:

```text
npm run typecheck
# all 10 workspace typechecks passed

npm run lint
# 0 warnings, 0 errors

npm run format:check
# all matched files use the correct format
```

Manual smoke exercised the mapped timeline item through `buildToolCallDisplayModel`. Observed compact output:

```json
{
  "displayName": "SecurityLensReview",
  "summary": "Review complete."
}
```

The original envelope remained in `detail.log` for expansion. Tested on macOS. No mobile/web visual test; this change reuses the existing cross-platform `sub_agent` card without modifying app UI code.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense