### PR TITLE
feat(desktop): add Android Studio editor target

### DIFF
--- a/packages/desktop/src/features/editor-targets/registry.test.ts
+++ b/packages/desktop/src/features/editor-targets/registry.test.ts
@@ -233,6 +233,41 @@ describe("editor target registry", () => {
     ]);
   });
 
+  it("lists and opens Android Studio through its bundled macOS launcher", async () => {
+    const runtime = new FakeEditorTargets("darwin", { HOME: "/Users/me" });
+    const bundledCommand = "/Users/me/Applications/Android Studio.app/Contents/MacOS/studio";
+    runtime.installCommand(bundledCommand, bundledCommand);
+    runtime.addPath("/repo");
+    runtime.addPath("/repo/app/src/main/MainActivity.kt");
+
+    const targets = await listAvailableEditorTargets(runtime);
+
+    expect(targets).toContainEqual({
+      id: "android-studio",
+      label: "Android Studio",
+      kind: "editor",
+      icon: { kind: "symbol", name: "terminal" },
+    });
+
+    await openEditorTarget(
+      {
+        editorId: "android-studio",
+        workspacePath: "/repo",
+        filePath: "/repo/app/src/main/MainActivity.kt",
+        line: 18,
+        column: 3,
+      },
+      runtime,
+    );
+
+    expect(runtime.launches).toEqual([
+      {
+        command: bundledCommand,
+        args: ["/repo", "--line", "18", "--column", "3", "/repo/app/src/main/MainActivity.kt"],
+      },
+    ]);
+  });
+
   it("detects Cursor's installed Windows command when it is absent from PATH", async () => {
     const runtime = new FakeEditorTargets("win32", {
       LOCALAPPDATA: "C:/Users/me/AppData/Local",

--- a/packages/desktop/src/features/editor-targets/registry.ts
+++ b/packages/desktop/src/features/editor-targets/registry.ts
@@ -4,6 +4,7 @@ import type {
   EditorTargetLaunchInput,
   EditorTargetRuntime,
 } from "./target.js";
+import { androidStudioTarget } from "./targets/android-studio.js";
 import { antigravityTarget } from "./targets/antigravity.js";
 import { aquaTarget } from "./targets/aqua.js";
 import { clionTarget } from "./targets/clion.js";
@@ -35,6 +36,7 @@ export const EDITOR_TARGETS: readonly EditorTarget[] = [
   vscodiumTarget,
   zedTarget,
   antigravityTarget,
+  androidStudioTarget,
   intellijIdeaTarget,
   aquaTarget,
   clionTarget,

--- a/packages/desktop/src/features/editor-targets/targets/android-studio.ts
+++ b/packages/desktop/src/features/editor-targets/targets/android-studio.ts
@@ -1,0 +1,41 @@
+import type { EditorTarget, EditorTargetLaunchInput, EditorTargetRuntime } from "../target.js";
+
+function commands(runtime: EditorTargetRuntime): string[] {
+  const candidates = ["studio", "studio64"];
+  if (runtime.platform === "darwin") {
+    candidates.push("/Applications/Android Studio.app/Contents/MacOS/studio");
+    if (runtime.env.HOME) {
+      candidates.push(`${runtime.env.HOME}/Applications/Android Studio.app/Contents/MacOS/studio`);
+    }
+  }
+  return candidates;
+}
+
+function launchArgs(input: EditorTargetLaunchInput): string[] {
+  if (!input.filePath) return [input.workspacePath];
+  const args = [input.workspacePath];
+  if (input.line) args.push("--line", String(input.line));
+  if (input.column) args.push("--column", String(input.column));
+  args.push(input.filePath);
+  return args;
+}
+
+export const androidStudioTarget: EditorTarget = {
+  id: "android-studio",
+  async describe() {
+    return {
+      id: this.id,
+      label: "Android Studio",
+      kind: "editor",
+      icon: { kind: "symbol", name: "terminal" },
+    };
+  },
+  async isInstalled(runtime) {
+    return runtime.resolveCommand(commands(runtime)) !== null;
+  },
+  async launch(input, runtime) {
+    const command = runtime.resolveCommand(commands(runtime));
+    if (!command) throw new Error("Android Studio is not installed");
+    await runtime.spawnDetached({ command, args: launchArgs(input) });
+  },
+};


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, gh pr create, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

None. This draft requests direction feedback before the change is marked ready for review.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo's Open in editor menu only shows registered targets detected on the local desktop. Android developers with Android Studio installed currently have to open the workspace through Finder and switch applications manually. Registering Android Studio lets them open the workspace or active file directly from the existing menu, including the selected line and column when the bundled launcher is available.

### Goals

- List stable Android Studio when its launcher is on PATH or inside the system or user Applications directory on macOS.
- Open the workspace, or open the active file in that workspace at its selected line and column.
- Cover target discovery and exact launcher arguments through the existing editor registry test.

### Non-goals

- Detect Android Studio Preview, Beta, or Canary installations.
- Add Gradle-project discovery or change the plugin API.
- Add a new editor icon asset; this follows the existing JetBrains targets and uses the terminal symbol.

### QA

- Red test: npx vitest run packages/desktop/src/features/editor-targets/registry.test.ts --bail=1 failed because Android Studio was absent and only Finder was listed.
- Green test: the same command passed 10 tests in one test file.
- The pre-commit hook passed formatting, lint, and typecheck across every workspace.
- On macOS, the installed stable launcher at the user Applications path reports support for project directories and files with line and column arguments.
- Desktop Windows, Desktop Linux, and a packaged Paseo desktop build were not manually tested. The PR remains a draft for direction and CI feedback.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
