### PR TITLE
feat(claude): allow native skills option in provider options

### DIFF
--- a/packages/server/src/server/agent/provider-options.test.ts
+++ b/packages/server/src/server/agent/provider-options.test.ts
@@ -66,6 +66,19 @@ describe("provider-owned option schemas", () => {
     ).toMatchObject({ sandbox: { enabled: true, failIfUnavailable: true } });
   });
 
+  test("accepts the native Claude skills context filter", () => {
+    expect(ClaudeProviderOptionsSchema.parse({ skills: ["research", "code-review"] })).toEqual({
+      skills: ["research", "code-review"],
+    });
+    expect(ClaudeProviderOptionsSchema.parse({ skills: "all" })).toEqual({ skills: "all" });
+  });
+
+  test("rejects an invalid Claude skills value", () => {
+    expect(() =>
+      validateProviderOptions("claude", ClaudeProviderOptionsSchema, { skills: "some" }),
+    ).toThrow("providerOptions.skills");
+  });
+
   test("reports the exact invalid Claude option path", () => {
     expect(() =>
       validateProviderOptions("claude", ClaudeProviderOptionsSchema, {

--- a/packages/server/src/server/agent/providers/claude/options.ts
+++ b/packages/server/src/server/agent/providers/claude/options.ts
@@ -48,6 +48,12 @@ export const ClaudeProviderOptionsSchema = z
     allowedTools: z.array(z.string()).optional(),
     disallowedTools: z.array(z.string()).optional(),
     additionalDirectories: z.array(z.string()).optional(),
+    // Native SDK skill context filter. `string[]` enables only the listed
+    // skills (by SKILL.md name / dir, or `plugin:skill`); `"all"` enables every
+    // discovered skill. Unlisted skills are hidden from the model's listing and
+    // rejected by the Skill tool. Restrictive-only, so it fits the fail-closed
+    // policy — flows through the `...providerOptions` spread in agent.ts.
+    skills: z.union([z.array(z.string()), z.literal("all")]).optional(),
     sandbox: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds the Claude Agent SDK's native **`skills`** option to `ClaudeProviderOptionsSchema`, so callers can control which skills a spawned Claude agent loads via `providerOptions`:

```jsonc
config.options = { "skills": ["research", "code-review"] }  // or "all"
```

The value is `string[]` (enable only the listed skills, by SKILL.md `name`/dir or `plugin:skill`) or `"all"`. Per the SDK, unlisted skills are **hidden from the model's listing and rejected by the Skill tool** — a true context filter across user, project, and plugin skill tiers.

## Why

Today the strict provider-options schema rejects the key:

```
Invalid providerOptions for 'claude': providerOptions: Unrecognized key: "skills"
```

Yet the plumbing already exists — `buildOptions()` spreads `...providerOptions` into the SDK `Options`, and the bundled `@anthropic-ai/claude-agent-sdk@^0.3.220` supports `skills?: string[] | 'all'`. The key was simply never added to the allowlist. Without it there is no way to give a spawned agent a scoped skill set (the closest levers — `permissions.deny` and `.claude/settings.local.json` `skillOverrides` — either don't remove skills from context or don't cover plugin skills).

`skills` is a **restrictive-only** native field, so it fits the same fail-closed philosophy as the already-allowed `allowedTools` / `disallowedTools` / `permissions`.

## Changes

- `packages/server/src/server/agent/providers/claude/options.ts` — add `skills: z.union([z.array(z.string()), z.literal("all")]).optional()` to `ClaudeProviderOptionsSchema` (flows through the existing `...providerOptions` spread; no other wiring needed).
- `packages/server/src/server/agent/provider-options.test.ts` — accepts `skills: [...]` and `"all"`; rejects an invalid value with the exact `providerOptions.skills` path.

## Testing

- `provider-options.test.ts` — 16/16 pass (incl. the two new skills tests).
- Full `typecheck` / `lint` / `format` green (pre-commit hook, all workspaces).
- Verified end-to-end against a local **0.4.0** daemon: before this change `providerOptions.skills` is rejected; the mechanism (spread → SDK) is otherwise intact.

## Notes

This is a context filter, not a sandbox — skill files remain readable via Read/Bash, same caveat the SDK documents.
