### PR TITLE
fix(server): route WebSocket upgrades through a single dispatcher (#638)

### DIFF
--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -842,11 +842,22 @@ export async function createPaseoDaemon(
 
   const httpServer = createHTTPServer(app);
 
-  // Script proxy WebSocket upgrade handler — must be registered before the
-  // VoiceAssistantWebSocketServer attaches its own "upgrade" listener so that
-  // script-bound upgrades are forwarded first. The handler is a no-op for
-  // requests that don't match a registered script route.
-  httpServer.on("upgrade", serviceProxy.upgradeHandler({ passthroughUnknown: true }));
+  // Single upgrade dispatcher. The daemon WebSocket server runs in noServer
+  // mode (it exposes handleUpgrade), so the only "upgrade" listener on this
+  // HTTP server is here. Script-proxy hosts are forwarded first; everything
+  // else is handed to the daemon WebSocket server. A single dispatcher is
+  // required because Node "upgrade" listeners cannot short-circuit one
+  // another, and letting both the script proxy and the daemon claim the same
+  // socket double-handled proxied upgrades (see the script-proxy upgrade
+  // issue).
+  httpServer.on("upgrade", (req, socket, head) => {
+    const route = serviceProxy.routeForHost(req.headers.host);
+    if (route) {
+      serviceProxy.upgradeHandler({ passthroughUnknown: false })(req, socket, head);
+      return;
+    }
+    wsServer?.handleUpgrade(req, socket, head);
+  });
 
   if (config.serviceProxy?.standaloneListen) {
     serviceProxyListenTarget = parseListenString(config.serviceProxy.standaloneListen);

--- a/packages/server/src/server/script-proxy-upgrade-dispatcher.test.ts
+++ b/packages/server/src/server/script-proxy-upgrade-dispatcher.test.ts
@@ -1,0 +1,186 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import net from "node:net";
+import { WebSocketServer } from "ws";
+import express from "express";
+import { describe, expect, it } from "vitest";
+import pino from "pino";
+import { createServiceProxySubsystem, findFreePort } from "./service-proxy.js";
+
+const logger = pino({ level: "silent" });
+
+interface DispatcherFixture {
+  daemonPort: number;
+  scriptHostname: string;
+  daemonConnections(): number;
+  close(): Promise<void>;
+}
+
+/**
+ * Reproduces how bootstrap.ts wires its single upgrade dispatcher: script
+ * hosts are forwarded through the service proxy, everything else is handed to
+ * the daemon WebSocket server via handleUpgrade. No other "upgrade" listener is
+ * attached to the shared HTTP server, because the daemon WebSocket server runs
+ * in noServer mode.
+ *
+ * The upstream is a bare WS endpoint that accepts any connection and echoes a
+ * marker. The daemon WebSocket server counts every connection it completes, so
+ * a script-bound upgrade that is ALSO completed by the daemon WebSocket server
+ * (the double-handling this test guards against) would bump that count.
+ */
+async function startDispatcherFixture(): Promise<DispatcherFixture> {
+  const upstreamPort = await findFreePort();
+  const upstreamHttp = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("upstream");
+  });
+  const upstreamWss = new WebSocketServer({ noServer: true });
+  upstreamWss.on("connection", (ws) => {
+    ws.send("upstream-connected");
+    ws.on("message", (data) => ws.send(data));
+  });
+  upstreamHttp.on("upgrade", (req, socket, head) => {
+    upstreamWss.handleUpgrade(req, socket, head, (ws, request) => {
+      upstreamWss.emit("connection", ws, request);
+    });
+  });
+  await new Promise<void>((resolve) => upstreamHttp.listen(upstreamPort, "127.0.0.1", resolve));
+
+  const serviceProxy = createServiceProxySubsystem({ logger });
+  const route = serviceProxy.registerWorkspaceService({
+    workspaceId: "workspace-a",
+    projectSlug: "repo",
+    branchName: "feature",
+    scriptName: "api",
+    port: upstreamPort,
+  });
+
+  const daemonPort = await findFreePort();
+  const app = express();
+  app.set("trust proxy", true);
+  app.use(serviceProxy.middleware());
+  app.use((_req, res) => {
+    res.status(404).send("404 Not Found");
+  });
+  const daemon = http.createServer(app);
+
+  // The daemon WebSocket server runs detached and exposes handleUpgrade.
+  const wss = new WebSocketServer({ noServer: true, path: "/ws" });
+  let daemonConnections = 0;
+  wss.on("connection", () => {
+    daemonConnections += 1;
+  });
+
+  daemon.on("upgrade", (req, socket, head) => {
+    const routeMatch = serviceProxy.routeForHost(req.headers.host);
+    if (routeMatch) {
+      serviceProxy.upgradeHandler({ passthroughUnknown: false })(req, socket, head);
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws, request) => {
+      wss.emit("connection", ws, request);
+    });
+  });
+
+  await new Promise<void>((resolve) => daemon.listen(daemonPort, "127.0.0.1", resolve));
+
+  return {
+    daemonPort,
+    scriptHostname: route.hostname,
+    daemonConnections: () => daemonConnections,
+    async close() {
+      wss.close();
+      upstreamWss.close();
+      daemon.closeAllConnections();
+      await new Promise<void>((resolve) => daemon.close(() => resolve()));
+      upstreamHttp.closeAllConnections();
+      await new Promise<void>((resolve) => upstreamHttp.close(() => resolve()));
+    },
+  };
+}
+
+/**
+ * Sends a raw WebSocket upgrade to the daemon listener and resolves once the
+ * server has replied 101 (or rejects on a non-upgrade response / connection
+ * close before the handshake completes).
+ */
+function openRawUpgrade(
+  port: number,
+  host: string,
+): Promise<{ statusLine: string; responseBody: string }> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: "127.0.0.1", port }, () => {
+      const lines = [
+        "GET /ws HTTP/1.1",
+        `Host: ${host}`,
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Version: 13",
+        "",
+        "",
+      ];
+      socket.write(lines.join("\r\n"));
+    });
+    let raw = "";
+    let settled = false;
+    function fail(reason: string) {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      reject(new Error(`${reason} (received ${raw.length} bytes)`));
+    }
+    socket.on("data", (chunk: Buffer) => {
+      raw += chunk.toString();
+      const separator = raw.indexOf("\r\n\r\n");
+      if (separator === -1) return;
+      settled = true;
+      socket.destroy();
+      const statusLine = raw.slice(0, raw.indexOf("\r\n"));
+      resolve({ statusLine, responseBody: raw.slice(separator + 4) });
+    });
+    socket.on("close", () => fail("socket closed before the handshake completed"));
+    socket.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      reject(err);
+    });
+  });
+}
+
+describe("single upgrade dispatcher", () => {
+  it("forwards script-bound upgrades to the proxy and never to the daemon WebSocket server", async () => {
+    const fixture = await startDispatcherFixture();
+    try {
+      // Script host: a clean 101 from the upstream (rather than a 400/405 or
+      // corrupted frame from a competing WebSocket upgrade on the same socket)
+      // proves the dispatcher handed the upgrade to the proxy alone.
+      const response = await openRawUpgrade(fixture.daemonPort, fixture.scriptHostname);
+      expect(response.statusLine).toContain("101 Switching Protocols");
+
+      // The daemon WebSocket server must not have claimed the script-bound
+      // socket. If it had double-handled the upgrade, it would have completed
+      // a connection (or errored) alongside the proxy.
+      expect(fixture.daemonConnections()).toBe(0);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("routes daemon-bound upgrades to the daemon WebSocket server", async () => {
+    const fixture = await startDispatcherFixture();
+    try {
+      // A host that is not a script route (and does not resolve to one) must
+      // reach the daemon WebSocket server. A 101 here proves handleUpgrade ran.
+      const response = await openRawUpgrade(
+        fixture.daemonPort,
+        `daemon.localhost:${fixture.daemonPort}`,
+      );
+
+      expect(response.statusLine).toContain("101 Switching Protocols");
+      expect(fixture.daemonConnections()).toBe(1);
+    } finally {
+      await fixture.close();
+    }
+  });
+});

--- a/packages/server/src/server/service-proxy.ts
+++ b/packages/server/src/server/service-proxy.ts
@@ -1,5 +1,6 @@
 import http, { createServer as createHTTPServer } from "node:http";
 import net from "node:net";
+import type { Duplex } from "node:stream";
 import { createHash } from "node:crypto";
 import { existsSync, unlinkSync } from "node:fs";
 import type { IncomingMessage } from "node:http";
@@ -363,7 +364,7 @@ function proxyUpgradeRequest({
   logger,
 }: {
   req: IncomingMessage;
-  socket: net.Socket;
+  socket: Duplex;
   head: Buffer;
   route: ServiceProxyRoute;
   logger: Logger;
@@ -783,7 +784,7 @@ export function createScriptProxyUpgradeHandler({
   routeStore: ServiceProxyRouteRegistry;
   logger: Logger;
   passthroughUnknown?: boolean;
-}): (req: IncomingMessage, socket: net.Socket, head: Buffer) => void {
+}): (req: IncomingMessage, socket: Duplex, head: Buffer) => void {
   return (req, socket, head) => {
     const classification = routeStore.classifyHost(req.headers.host);
     if (classification.type !== "registered-service") {
@@ -829,7 +830,13 @@ export interface ServiceProxySubsystem {
   middleware(): RequestHandler;
   upgradeHandler(options: {
     passthroughUnknown: boolean;
-  }): (req: IncomingMessage, socket: net.Socket, head: Buffer) => void;
+  }): (req: IncomingMessage, socket: Duplex, head: Buffer) => void;
+  /**
+   * Returns the proxy route a Host header should be forwarded to, or null when
+   * the host does not belong to a registered service. Lets the bootstrapper
+   * build a single upgrade dispatcher (proxy first, daemon WebSocket after).
+   */
+  routeForHost(host: string | undefined): ServiceProxyRoute | null;
   startStandalone(options: {
     listenTarget: ServiceProxyListenTarget;
   }): Promise<ServiceProxyListenTarget>;
@@ -921,9 +928,13 @@ class NodeServiceProxySubsystem implements ServiceProxySubsystem {
     return createScriptProxyMiddleware({ routeStore: this.routes, logger: this.logger });
   }
 
+  routeForHost(host: string | undefined): ServiceProxyRoute | null {
+    return this.routes.findRoute(host ?? "");
+  }
+
   upgradeHandler(options: {
     passthroughUnknown: boolean;
-  }): (req: IncomingMessage, socket: net.Socket, head: Buffer) => void {
+  }): (req: IncomingMessage, socket: Duplex, head: Buffer) => void {
     // Pass passthroughUnknown explicitly: the factory defaults it to true, the
     // subsystem requires callers to choose.
     return createScriptProxyUpgradeHandler({

--- a/packages/server/src/server/websocket-server.browser-tools.test.ts
+++ b/packages/server/src/server/websocket-server.browser-tools.test.ts
@@ -202,6 +202,12 @@ async function startBrowserToolsDaemonHarness(): Promise<BrowserToolsDaemonHarne
   const wsServer = createVoiceAssistantWebSocketServer({ httpServer, broker });
   const clients = new Set<DaemonClient>();
 
+  // The WebSocket server runs detached (noServer); route upgrades to it the
+  // same way the bootstrapper does with its single upgrade dispatcher.
+  httpServer.on("upgrade", (req, socket, head) => {
+    wsServer.handleUpgrade(req, socket, head);
+  });
+
   await listen(httpServer);
   const url = `ws://127.0.0.1:${getPort(httpServer)}/ws`;
 

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1,5 +1,6 @@
 import { WebSocket, WebSocketServer } from "ws";
 import type { IncomingMessage, Server as HTTPServer } from "http";
+import type { Duplex } from "node:stream";
 import { join } from "path";
 import { hostname as getHostname } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -654,6 +655,10 @@ export class VoiceAssistantWebSocketServer {
     workspaceLabelService?: WorkspaceLabelService,
   ) {
     this.logger = logger.child({ module: "websocket-server" });
+    // The shared HTTP server is passed by the bootstrapper but the WebSocket
+    // server runs detached (noServer) so it never attaches its own upgrade
+    // listener; the bootstrapper routes upgrades to handleUpgrade instead.
+    void server;
     this.workspaceSetupRuntime = workspaceSetupRuntime;
     this.advertiseDaemonStatusRpc = wsConfig.daemonStatusRpc !== false;
     this.advertiseRelayConfig = wsConfig.relayConfig !== false;
@@ -741,7 +746,7 @@ export class VoiceAssistantWebSocketServer {
       logger: this.logger,
     });
 
-    this.wss = this.createWebSocketServer(server, wsConfig, auth);
+    this.wss = this.createWebSocketServer(wsConfig, auth);
     this.startRuntimeMetricsInterval();
     this.startApplicationSocketLeaseInterval();
 
@@ -800,14 +805,21 @@ export class VoiceAssistantWebSocketServer {
     this.resolveScriptHealth = params.resolveScriptHealth ?? null;
   }
 
+  // The daemon HTTP server is shared with the script proxy, whose upgrades must
+  // be forwarded before the daemon WebSocket server sees the socket. Node's
+  // "upgrade" listeners cannot short-circuit one another (they are event
+  // listeners, not middleware), so handing the daemon its own listener on the
+  // same HTTP server would let both claim a script-bound upgrade. Instead the
+  // WebSocket server operates in noServer mode and the bootstrapper owns a
+  // single "upgrade" dispatcher that routes script hosts to the proxy and
+  // everything else to this handleUpgrade.
   private createWebSocketServer(
-    server: HTTPServer,
     wsConfig: WebSocketServerConfig,
     auth: DaemonAuthConfig | undefined,
   ): WebSocketServer {
     const password = auth?.password;
     const wss = new WebSocketServer({
-      server,
+      noServer: true,
       path: "/ws",
       handleProtocols: (protocols) => selectWebSocketProtocol(protocols, password),
       verifyClient: ({ req }, callback) => {
@@ -823,6 +835,21 @@ export class VoiceAssistantWebSocketServer {
       void this.attachAuthenticatedSocket(ws, request, password);
     });
     return wss;
+  }
+
+  /**
+   * Completes a WebSocket upgrade for a request the bootstrapper routed to the
+   * daemon (i.e. one whose Host did not match a script-proxy route).
+   */
+  public handleUpgrade(
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    wss: WebSocketServer = this.wss,
+  ): void {
+    wss.handleUpgrade(req, socket, head, (ws, request) => {
+      wss.emit("connection", ws, request);
+    });
   }
 
   private startRuntimeMetricsInterval(): void {


### PR DESCRIPTION
### Linked issue

Closes #638

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A client that reaches a worktree daemon through the `*.paseo.localhost:6767` script proxy can end up in a reconnect loop with `Invalid frame header` in DevTools, because the same WebSocket upgrade is handled twice: once by the script-proxy upgrade handler and again by the daemon `VoiceAssistantWebSocketServer` upgrade listener on the same HTTP server/socket.

Node's `upgrade` listeners are event listeners, not middleware — returning from the script-proxy handler does not stop the daemon WebSocket server's handler from also running on the already-forwarded socket. The fix moves to a single upgrade dispatch point: the daemon WebSocket server runs detached (`noServer`), and the bootstrapper owns the one `upgrade` listener which forwards script-proxy hostnames to the proxy and routes everything else to the daemon via `handleUpgrade`.

### Goals

- A script-proxy-bound upgrade is handled by exactly one component: the proxy.
- A daemon-bound upgrade (`/ws`) continues to reach the daemon WebSocket server.
- No change in HTTP behaviour (middleware path untouched).

### Non-goals

- No change to the script-proxy HTTP middleware or route registration.
- No change to how the daemon validates origins/hostnames or selects the subprotocol — `handleUpgrade` runs the same `verifyClient`/`handleProtocols` as before.

### QA

Unit/integration tests (`packages/server`), run with `--no-file-parallelism --maxWorkers 1`:

- `script-proxy-upgrade-dispatcher.test.ts` (new): drives a real listener through the same single-dispatcher wiring as bootstrap, verifying (a) a script-bound host completes the upstream handshake and never bumps the daemon WebSocket connection count, and (b) a daemon-bound host reaches the daemon WebSocket server. I confirmed the first test fails against the previous dual-listener wiring (daemon connection count was `1`, not `0`).
- Existing `service-proxy.test.ts`, `websocket-server.browser-tools.test.ts`, `websocket-server.notifications.test.ts`, `websocket-server.terminal-notifications.test.ts`, `websocket-server.relay-reconnect.test.ts`, `websocket-server.origin.test.ts` — all pass.
- `npm run typecheck`, `npm run lint`, `npm run format:check` all pass.

Not tested manually on a real worktree because the proxy upgrade path requires a live worktree daemon; the regression test exercises the same dispatcher code path.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
