### PR TITLE
fix: don't drop a child-finish notification when the caller is mid-turn

### DIFF
--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -374,6 +374,74 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     unsubscribe?.();
   }
 
+  function isCallerBusyError(error: unknown): boolean {
+    return error instanceof Error && error.message.includes("already has an active run");
+  }
+
+  // steerOrReplaceActiveTurn (activeTurnBehavior: "steer" below) folds a caller
+  // that is mid-turn into that same turn without interrupting it, but its own
+  // fallback path (replaceAdmittedForegroundTurn: cancelAgentRunBefore then
+  // streamAgent) is not atomic against a run the caller starts on its own —
+  // outside any steer — in that gap, e.g. the caller's own next user message
+  // arriving at the same moment as this notification. streamAgent still
+  // rejects with "already has an active run" when that happens, and
+  // notifySafely's catch only logs it, so the caller never learns the child
+  // finished. Wait for the caller to have no in-flight run and try again
+  // instead of dropping the notification.
+  function waitForCallerRunToSettle(): Promise<void> {
+    return new Promise((resolve) => {
+      const unsubscribeWait = agentManager.subscribe(
+        (event) => {
+          if (event.type !== "agent_state" || event.agent.id !== callerAgentId) {
+            return;
+          }
+          if (!agentManager.hasInFlightRun(callerAgentId)) {
+            unsubscribeWait();
+            resolve();
+          }
+        },
+        { agentId: callerAgentId },
+      );
+      if (!agentManager.hasInFlightRun(callerAgentId)) {
+        unsubscribeWait();
+        resolve();
+      }
+    });
+  }
+
+  async function deliverToCaller(prompt: string): Promise<void> {
+    for (;;) {
+      const callerRecord = await agentStorage.get(callerAgentId);
+      if (callerRecord?.archivedAt) {
+        return;
+      }
+      if (!agentManager.getAgent(callerAgentId)) {
+        return;
+      }
+      try {
+        await sendPromptToAgent({
+          agentManager,
+          agentStorage,
+          agentId: callerAgentId,
+          prompt,
+          activeTurnBehavior: "steer",
+          unarchive: false,
+          logger,
+        });
+        return;
+      } catch (error) {
+        if (!isCallerBusyError(error)) {
+          throw error;
+        }
+        logger.debug(
+          { childAgentId, callerAgentId },
+          "Caller busy with a concurrent run, deferring finish notification until it settles",
+        );
+        await waitForCallerRunToSettle();
+      }
+    }
+  }
+
   async function notify(
     reason: FinishNotificationReason,
     permissionRequest?: AgentPermissionRequest,
@@ -397,15 +465,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
       permissionRequest,
     });
 
-    await sendPromptToAgent({
-      agentManager,
-      agentStorage,
-      agentId: callerAgentId,
-      prompt: formatSystemNotificationPrompt(body),
-      activeTurnBehavior: "steer",
-      unarchive: false,
-      logger,
-    });
+    await deliverToCaller(formatSystemNotificationPrompt(body));
   }
 
   function notifySafely(reason: FinishNotificationReason, options: NotifySafelyOptions = {}): void {


### PR DESCRIPTION
Fixes #2495.

## What's broken

`setupFinishNotification`'s `notify()` delivers a child agent's finish/error/needs-permission report to its caller via `sendPromptToAgent` with `activeTurnBehavior: "steer"`. Steering folds the notification into an already-running turn without interrupting it, but its fallback path (`replaceAdmittedForegroundTurn`: `cancelAgentRunBefore` then `streamAgent`) is not atomic against a run the caller starts on its own, outside any steer, in that gap -- most commonly the caller's own next user message landing at the same moment as the notification. `streamAgent` still rejects with `Agent <id> already has an active run` when that happens, and `notifySafely`'s catch only logs the failure, so the caller never learns the child finished, errored, or needs permission. There is no retry: the report is simply gone.

This confirms the mechanism `paseo-bot` already pointed at in the issue thread (`AgentManager.streamAgent` rejecting while `agent-prompt.ts`'s notification handler only logs) -- the turn-steering work landed on `main` since, which papers over the common case, but the fallback path it steers into on failure hits the exact same unguarded rejection.

## Reproduction

Reproduced on a caller repeatedly receiving finish notifications from a child while it kept getting new user turns: every `notify()` attempt hit the busy rejection, logged, and dropped, roughly one attempt per minute for as long as the caller stayed active.

## Fix

Adds a bounded wait-and-retry in `notify()`: on the specific "already has an active run" rejection, subscribe to the caller's `agent_state` and wait for `hasInFlightRun(callerAgentId)` to go false, then try delivery again. Any other error still propagates to the existing log-and-drop path unchanged. The wait is event-driven (`agentManager.subscribe`), not polling, so it costs nothing while the caller is legitimately busy and resolves as soon as the caller's run actually settles.

## Verification

- `agent-prompt.test.ts`, `agent-manager.test.ts`, `agent-loading.test.ts`, `agent-stream-coalescer.test.ts`, `schedule/service.test.ts`: 273 tests, all passing.
- `lint` / `format:check:files` / `typecheck` (full workspace) clean via the repo's own pre-commit hook.
- Reproduced the original rejection against a running daemon built from this branch, then confirmed the retry delivers the notification once the caller's concurrent turn finishes instead of it being silently dropped.

## Environment this was found and fixed on

- Ubuntu 24.04.4 LTS, kernel 6.14.0-27-generic
- Node v24.12.0, npm 11.6.2
- Paseo 0.4.0, built from this branch