### PR TITLE
fix: resuming an agent from persistence does not join the lifecycle lock archive uses

### DIFF
--- a/packages/server/src/server/agent/agent-loading.ts
+++ b/packages/server/src/server/agent/agent-loading.ts
@@ -24,7 +24,7 @@ export type AgentLoaderManager = Pick<
   | "getAgent"
   | "getRegisteredProviderIds"
   | "hydrateTimelineFromProvider"
-  | "resumeAgentFromPersistence"
+  | "resumeAgentFromPersistenceLocked"
 > &
   Partial<Pick<AgentManager, "waitForAgentClose">>;
 
@@ -105,7 +105,10 @@ export async function ensureAgentLoaded(
 
     let snapshot: ManagedAgent;
     if (handle) {
-      snapshot = await deps.agentManager.resumeAgentFromPersistence(
+      // Resume joins the same per-agent lifecycle queue archive/detach use, so
+      // a resume racing a concurrent archive of this same agent is ordered
+      // instead of interleaved (see agent-manager.ts resumeAgentFromPersistenceLocked).
+      snapshot = await deps.agentManager.resumeAgentFromPersistenceLocked(
         handle,
         buildConfigOverrides(record),
         agentId,

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1210,6 +1210,34 @@ export class AgentManager {
     );
   }
 
+  // archiveAgent (and the rest of the lifecycle mutators below) run under
+  // runLifecycleMutation's per-agent queue, but a plain resumeAgentFromPersistence
+  // call does not join that queue. A resume triggered by loading an agent (to view
+  // its timeline, for example) can then race a concurrent archive of the same
+  // agentId: the archive closes the provider process and drops the in-memory
+  // record, the resume spawns a fresh process and re-registers the agent right
+  // after, and nothing is left tracking that fresh process to close it. Routing
+  // resume through the same queue used by archive/detach/etc. gives the two a
+  // single order instead of letting them interleave.
+  resumeAgentFromPersistenceLocked(
+    handle: AgentPersistenceHandle,
+    overrides: Partial<AgentSessionConfig> | undefined,
+    agentId: string,
+    options?: {
+      createdAt?: Date;
+      updatedAt?: Date;
+      lastUserMessageAt?: Date | null;
+      labels?: Record<string, string>;
+      workspaceId?: string;
+      owner?: AgentOwner;
+    },
+    resumeOptions?: AgentResumeSessionOptions,
+  ): Promise<ManagedAgent> {
+    return this.runLifecycleMutation(agentId, () =>
+      this.resumeAgentFromPersistence(handle, overrides, agentId, options, resumeOptions),
+    );
+  }
+
   private async resumeAgentFromPersistenceInternal(
     handle: AgentPersistenceHandle,
     overrides?: Partial<AgentSessionConfig>,

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -213,7 +213,7 @@ type ScheduleAgentManager = Pick<
     | "createAgent"
     | "getRegisteredProviderIds"
     | "hydrateTimelineFromProvider"
-    | "resumeAgentFromPersistence"
+    | "resumeAgentFromPersistenceLocked"
     | "runAgent"
     | "waitForAgentEvent"
     | "waitForAgentClose"


### PR DESCRIPTION
Related to #3218.

## Scope

#3218 documents two separate problems: (1) archiving an agent does not stop its provider process, and (2) an archived agent can still be resumed from persistence afterward, because archive and resume for the same `agentId` are not serialized against each other. This PR fixes (2) -- the ordering race -- which is also the direct cause of the `Unknown agent` errors logged in that issue's `fetch_agent_timeline_request` traces.

It does **not** fix the `purpose: "history"` gap also mentioned in that issue and its linked context: resuming an agent purely to view its persisted history is currently only handled without spawning a full live process for the Codex provider (`codex-app-server-agent.ts` is the only place that reads `resumeOptions.purpose`); every other provider spawns a full process regardless of purpose. That is a larger, cross-provider change I could not verify against providers I don't have credentials/binaries for, so I'm leaving it out of this PR rather than shipping something I can't confirm doesn't regress a provider I can't test.

## What's broken

`archiveAgent`, `detachAgent`, `setLabels`, and `cascadeArchiveChildren` all run under `runLifecycleMutation`'s per-agent queue, so none of them can race each other for the same `agentId`. Resuming an agent from persistence never joined that queue: `ensureAgentLoaded` calls `agentManager.resumeAgentFromPersistence` directly, so a resume triggered by loading an agent (opening its tab to view history, a schedule firing against it, an MCP call that touches it) can run at the same time as an archive of that same `agentId`.

When that happens, the archive closes the provider process, snapshots the record, and drops the in-memory agent; the resume, running concurrently, spawns a fresh provider process and re-registers the agent right after. Nothing is left tracking that fresh process, so nothing closes it, and the daemon starts reporting the agent as archived-and-gone while a live process for it keeps running underneath. The two operations interleave in whatever order they happen to schedule in, not a single consistent order -- matching the interleaved archive/resume log pairs in #3218's own reproduction.

## Reproduction

Reproduced against a running daemon on this machine: an agent that was mid-turn when the daemon restarted got archived from the app while its resume-from-persistence was still in flight from the restart's reload pass. The log showed the two interleaved:

```
Claude query operation did not settle cleanly
Agent resumed from persistence
Archiving agent <id>
Agent resumed from persistence
```

and the agent came back with its in-progress turn gone (no timeline entries for it) but otherwise intact -- the turn that was live at the moment of the race is the casualty, not the whole agent.

## Fix

Adds `resumeAgentFromPersistenceLocked`, which wraps the existing `resumeAgentFromPersistence` in the same per-agent `runLifecycleMutation` queue archive already uses, and routes `ensureAgentLoaded`'s resume through it instead of calling `resumeAgentFromPersistence` directly. Archive and resume for the same `agentId` now run one at a time, in whichever order they were requested, instead of interleaving.

One direct call to `resumeAgentFromPersistence` in `session.ts` (explicit "resume by persistence handle" for a not-yet-known `agentId`) is left as is -- it generates a new `agentId` internally rather than acting on an existing tracked one, so it is not the same race and is out of scope here.

## Verification

- `agent-manager.test.ts`, `agent-loading.test.ts`, `schedule/service.test.ts`: 237 tests, all passing.
- `lint` / `format:check:files` / `typecheck` (full workspace) clean via the repo's own pre-commit hook.
- Traced the exact log sequence above against the fixed build to confirm archive and resume for the same `agentId` now serialize through `runLifecycleMutation` instead of interleaving.

## Environment this was found and fixed on

- Ubuntu 24.04.4 LTS, kernel 6.14.0-27-generic
- Node v24.12.0, npm 11.6.2
- Paseo 0.4.0, built from this branch