### PR TITLE
fix(app): guard against duplicate agent creation on new workspace

### DIFF
--- a/packages/app/src/composer/draft/create-flow.test.ts
+++ b/packages/app/src/composer/draft/create-flow.test.ts
@@ -10,7 +10,7 @@ import { useDraftAgentCreateFlow, type DraftCreateAttempt } from "./create-flow"
 
 describe("useDraftAgentCreateFlow", () => {
   beforeEach(() => {
-    useCreateFlowStore.setState({ pendingByDraftId: {} });
+    useCreateFlowStore.setState({ pendingByDraftId: {}, createInFlightByWorkspace: {} });
   });
 
   it("renders a prepared new-workspace submission before continuing it", async () => {
@@ -145,5 +145,115 @@ describe("useDraftAgentCreateFlow", () => {
       cwd: "/repo",
     });
     expect(onCreateSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows only one create in flight per workspace", async () => {
+    // Mirrors a double-submit or two draft tabs consuming the same pending
+    // submission: both attempts target the same workspace, so only the first
+    // may proceed.
+    useCreateFlowStore.setState({
+      pendingByDraftId: {
+        "draft-a": {
+          draftId: "draft-a",
+          serverId: "server-1",
+          workspaceId: "wks-1",
+          agentId: null,
+          clientMessageId: "msg-a",
+          text: "hi",
+          timestamp: Date.now(),
+          lifecycle: "active",
+        },
+        "draft-b": {
+          draftId: "draft-b",
+          serverId: "server-1",
+          workspaceId: "wks-1",
+          agentId: null,
+          clientMessageId: "msg-b",
+          text: "hi",
+          timestamp: Date.now(),
+          lifecycle: "active",
+        },
+      },
+    });
+
+    const createRequestA = vi.fn(async () => ({ agentId: "agent-1", result: { id: "agent-1" } }));
+    const createRequestB = vi.fn(async () => ({ agentId: "agent-2", result: { id: "agent-2" } }));
+    const attemptA: DraftCreateAttempt = {
+      clientMessageId: "msg-a",
+      text: "hi",
+      timestamp: new Date("2026-05-25T00:00:00.000Z"),
+    };
+    const attemptB: DraftCreateAttempt = {
+      clientMessageId: "msg-b",
+      text: "hi",
+      timestamp: new Date("2026-05-25T00:00:00.000Z"),
+    };
+
+    const { result: hookA } = renderHook(() =>
+      useDraftAgentCreateFlow({
+        draftId: "draft-a",
+        getPendingServerId: () => "server-1",
+        initialAttempt: attemptA,
+        buildDraftAgent: (currentAttempt) => ({ currentAttempt }),
+        createRequest: createRequestA,
+        onCreateSuccess: vi.fn(),
+      }),
+    );
+    const { result: hookB } = renderHook(() =>
+      useDraftAgentCreateFlow({
+        draftId: "draft-b",
+        getPendingServerId: () => "server-1",
+        initialAttempt: attemptB,
+        buildDraftAgent: (currentAttempt) => ({ currentAttempt }),
+        createRequest: createRequestB,
+        onCreateSuccess: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await Promise.allSettled([
+        hookA.current.continueCreateFromAttempt({ attempt: attemptA, cwd: "/repo" }),
+        hookB.current.continueCreateFromAttempt({ attempt: attemptB, cwd: "/repo" }),
+      ]);
+    });
+
+    expect(createRequestA).toHaveBeenCalledTimes(1);
+    expect(createRequestB).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates handleCreateFromInput submissions for the same workspace", async () => {
+    const createRequestA = vi.fn(async () => ({ agentId: "agent-1", result: { id: "agent-1" } }));
+    const createRequestB = vi.fn(async () => ({ agentId: "agent-2", result: { id: "agent-2" } }));
+
+    const { result: hookA } = renderHook(() =>
+      useDraftAgentCreateFlow({
+        draftId: "draft-a",
+        getPendingServerId: () => "server-1",
+        getPendingWorkspaceId: () => "wks-1",
+        buildDraftAgent: (currentAttempt) => ({ currentAttempt }),
+        createRequest: createRequestA,
+        onCreateSuccess: vi.fn(),
+      }),
+    );
+    const { result: hookB } = renderHook(() =>
+      useDraftAgentCreateFlow({
+        draftId: "draft-b",
+        getPendingServerId: () => "server-1",
+        getPendingWorkspaceId: () => "wks-1",
+        buildDraftAgent: (currentAttempt) => ({ currentAttempt }),
+        createRequest: createRequestB,
+        onCreateSuccess: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await Promise.allSettled([
+        hookA.current.handleCreateFromInput({ text: "hi", attachments: [], cwd: "/repo" }),
+        hookB.current.handleCreateFromInput({ text: "hi", attachments: [], cwd: "/repo" }),
+      ]);
+    });
+
+    expect(createRequestA).toHaveBeenCalledTimes(1);
+    expect(createRequestB).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/composer/draft/create-flow.ts
+++ b/packages/app/src/composer/draft/create-flow.ts
@@ -87,6 +87,7 @@ interface CreateRequestContext {
 interface UseDraftAgentCreateFlowOptions<TDraftAgent, TCreateResult> {
   draftId: string;
   getPendingServerId: () => string | null;
+  getPendingWorkspaceId?: () => string | null;
   initialAttempt?: CreateAttempt | null;
   allowEmptyText?: boolean;
   validateBeforeSubmit?: (ctx: SubmitContext) => string | null;
@@ -101,6 +102,7 @@ interface UseDraftAgentCreateFlowOptions<TDraftAgent, TCreateResult> {
 export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
   draftId,
   getPendingServerId,
+  getPendingWorkspaceId,
   initialAttempt = null,
   allowEmptyText = false,
   validateBeforeSubmit,
@@ -179,15 +181,33 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
         throw error;
       }
 
-      await onBeforeSubmit?.({
-        attempt,
-        text: attempt.text,
-        images: attempt.images,
-        attachments: attempt.attachments,
-        cwd,
+      // Claim a per-workspace create slot synchronously so that concurrent
+      // submissions (double submit, or multiple draft tabs consuming the same
+      // pending submission) cannot both create an agent.
+      const workspaceId =
+        getPendingWorkspaceId?.() ??
+        useCreateFlowStore.getState().pendingByDraftId[draftId]?.workspaceId ??
+        null;
+      const canBeginCreate = useCreateFlowStore.getState().tryBeginCreate({
+        serverId: pendingServerId,
+        workspaceId,
+        clientMessageId: attempt.clientMessageId,
       });
+      if (!canBeginCreate) {
+        const error = new Error(t("composer.errors.alreadyLoading"));
+        dispatch({ type: "DRAFT_SET_ERROR", message: error.message });
+        throw error;
+      }
 
       try {
+        await onBeforeSubmit?.({
+          attempt,
+          text: attempt.text,
+          images: attempt.images,
+          attachments: attempt.attachments,
+          cwd,
+        });
+
         const createResult = await createRequest({
           attempt,
           text: attempt.text,
@@ -221,6 +241,8 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
         clearPendingCreateAttempt({ draftId });
         onCreateError?.(resolved);
         throw error;
+      } finally {
+        useCreateFlowStore.getState().endCreate({ serverId: pendingServerId, workspaceId });
       }
     },
     [
@@ -228,6 +250,7 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
       createRequest,
       draftId,
       getPendingServerId,
+      getPendingWorkspaceId,
       markPendingCreateLifecycle,
       onBeforeSubmit,
       onCreateError,
@@ -290,6 +313,7 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
       setPendingCreateAttempt({
         draftId,
         serverId: pendingServerId,
+        workspaceId: getPendingWorkspaceId?.() ?? undefined,
         agentId: null,
         clientMessageId: attempt.clientMessageId,
         text: attempt.text,
@@ -308,6 +332,7 @@ export function useDraftAgentCreateFlow<TDraftAgent, TCreateResult>({
       allowEmptyText,
       draftId,
       getPendingServerId,
+      getPendingWorkspaceId,
       isSubmitting,
       onCreateStart,
       runCreateAttempt,

--- a/packages/app/src/composer/draft/workspace-tab.tsx
+++ b/packages/app/src/composer/draft/workspace-tab.tsx
@@ -478,6 +478,7 @@ export function WorkspaceDraftAgentTab({
   } = useDraftAgentCreateFlow<Agent, AgentSnapshotPayload>({
     draftId,
     getPendingServerId: () => serverId,
+    getPendingWorkspaceId: () => workspaceFields?.id ?? null,
     initialAttempt: initialCreateAttempt,
     allowEmptyText: allowsEmptyAutoSubmit,
     validateBeforeSubmit: ({ text, attachments }) => {

--- a/packages/app/src/stores/create-flow-store.test.ts
+++ b/packages/app/src/stores/create-flow-store.test.ts
@@ -3,7 +3,7 @@ import { isActiveCreateFlowForDraft, useCreateFlowStore } from "./create-flow-st
 
 describe("create-flow-store", () => {
   beforeEach(() => {
-    useCreateFlowStore.setState({ pendingByDraftId: {} });
+    useCreateFlowStore.setState({ pendingByDraftId: {}, createInFlightByWorkspace: {} });
   });
 
   it("tracks lifecycle transitions explicitly", () => {
@@ -123,5 +123,50 @@ describe("create-flow-store", () => {
         draftId: "draft-1",
       }),
     ).toBe(false);
+  });
+
+  it("deduplicates in-flight creates per workspace", () => {
+    const store = useCreateFlowStore.getState();
+
+    expect(
+      store.tryBeginCreate({ serverId: "server-1", workspaceId: "wks-1", clientMessageId: "msg-1" }),
+    ).toBe(true);
+    expect(
+      store.tryBeginCreate({ serverId: "server-1", workspaceId: "wks-1", clientMessageId: "msg-2" }),
+    ).toBe(false);
+    expect(
+      store.tryBeginCreate({ serverId: "server-2", workspaceId: "wks-1", clientMessageId: "msg-3" }),
+    ).toBe(true);
+    expect(
+      store.tryBeginCreate({ serverId: "server-1", workspaceId: "wks-2", clientMessageId: "msg-4" }),
+    ).toBe(true);
+
+    useCreateFlowStore.getState().endCreate({ serverId: "server-1", workspaceId: "wks-1" });
+    expect(
+      useCreateFlowStore.getState().tryBeginCreate({
+        serverId: "server-1",
+        workspaceId: "wks-1",
+        clientMessageId: "msg-5",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not guard creates without a workspace id", () => {
+    const store = useCreateFlowStore.getState();
+
+    expect(
+      store.tryBeginCreate({ serverId: "server-1", workspaceId: null, clientMessageId: "msg-1" }),
+    ).toBe(true);
+    expect(
+      store.tryBeginCreate({
+        serverId: "server-1",
+        workspaceId: undefined,
+        clientMessageId: "msg-2",
+      }),
+    ).toBe(true);
+
+    useCreateFlowStore.getState().endCreate({ serverId: "server-1", workspaceId: null });
+    useCreateFlowStore.getState().endCreate({ serverId: "server-1", workspaceId: undefined });
+    expect(useCreateFlowStore.getState().createInFlightByWorkspace).toEqual({});
   });
 });

--- a/packages/app/src/stores/create-flow-store.ts
+++ b/packages/app/src/stores/create-flow-store.ts
@@ -33,6 +33,8 @@ export function isActiveCreateFlowForDraft(input: {
 
 interface CreateFlowState {
   pendingByDraftId: Record<string, PendingCreateAttempt>;
+  /** Create attempts that are in flight, keyed by `${serverId}:${workspaceId}`. */
+  createInFlightByWorkspace: Record<string, string>;
   setPending: (pending: Omit<PendingCreateAttempt, "lifecycle">) => void;
   updateAgentId: (input: { draftId: string; agentId: string }) => void;
   markLifecycle: (input: { draftId: string; lifecycle: CreateFlowLifecycleState }) => void;
@@ -40,10 +42,22 @@ interface CreateFlowState {
   clear: (input: { draftId: string }) => void;
   clearByAgent: (input: { serverId: string; agentId: string }) => void;
   clearAll: () => void;
+  /** Synchronously claim the create slot for a workspace; returns false when one is already in flight. */
+  tryBeginCreate: (input: {
+    serverId: string;
+    workspaceId: string | null | undefined;
+    clientMessageId: string;
+  }) => boolean;
+  endCreate: (input: { serverId: string; workspaceId: string | null | undefined }) => void;
 }
 
-export const useCreateFlowStore = create<CreateFlowState>((set) => ({
+function buildCreateInFlightKey(serverId: string, workspaceId: string): string {
+  return `${serverId}:${workspaceId}`;
+}
+
+export const useCreateFlowStore = create<CreateFlowState>((set, get) => ({
   pendingByDraftId: {},
+  createInFlightByWorkspace: {},
   setPending: (pending) =>
     set((state) => ({
       pendingByDraftId: {
@@ -120,5 +134,34 @@ export const useCreateFlowStore = create<CreateFlowState>((set) => ({
       }
       return { pendingByDraftId: next };
     }),
-  clearAll: () => set({ pendingByDraftId: {} }),
+  clearAll: () => set({ pendingByDraftId: {}, createInFlightByWorkspace: {} }),
+  tryBeginCreate: ({ serverId, workspaceId, clientMessageId }) => {
+    if (!workspaceId) {
+      return true;
+    }
+    const key = buildCreateInFlightKey(serverId, workspaceId);
+    if (get().createInFlightByWorkspace[key]) {
+      return false;
+    }
+    set({
+      createInFlightByWorkspace: {
+        ...get().createInFlightByWorkspace,
+        [key]: clientMessageId,
+      },
+    });
+    return true;
+  },
+  endCreate: ({ serverId, workspaceId }) => {
+    if (!workspaceId) {
+      return;
+    }
+    const key = buildCreateInFlightKey(serverId, workspaceId);
+    set((state) => {
+      if (!state.createInFlightByWorkspace[key]) {
+        return state;
+      }
+      const { [key]: _removed, ...rest } = state.createInFlightByWorkspace;
+      return { createInFlightByWorkspace: rest };
+    });
+  },
 }));


### PR DESCRIPTION
## Problem

Sending a message from a brand-new workspace (new-workspace flow) consistently creates **two** sessions. Repro and evidence in #3217.

## Root cause

Two compounding issues:

1. **Shipped bundle bug (v0.4.0).** `workspace-draft-submission-store.consumePending` was minified incorrectly — `omit(pendingByDraftId, [r].map(n))` where `var r` is never assigned, so `[r].map(n)` yields `[undefined]` and the pending is **never removed**. Multiple `WorkspaceDraftAgentTab` instances can therefore consume the same pending submission, each calling create once.
2. **No upstream guard.** `create-flow` only had a per-hook `isSubmitting` flag (per component instance), and the daemon has no idempotency on create — `clientMessageId` is passed as run options only. So two tabs both proceed to create.

## Fix

Add a synchronous **per-workspace in-flight guard** in the create-flow store, keyed by `serverId:workspaceId`:

- `create-flow-store`: new `tryBeginCreate` / `endCreate` actions on a `createInFlightByWorkspace` map. `tryBeginCreate` claims the slot synchronously and returns `false` if one is already in flight.
- `create-flow`: all create paths funnel through `runCreateAttempt`, which now claims the slot **before** `onBeforeSubmit`/`createRequest` and releases it in `finally`. The loser throws the existing `alreadyLoading` error instead of creating.
- `handleCreateFromInput` previously called `setPending` without a workspaceId, which would bypass the guard; a new optional `getPendingWorkspaceId` resolves the workspace from the tab, so the guard also covers the double-submit path.

## Testing

- 4 new unit tests: store-level dedupe, no-workspaceId passthrough, `continueCreateFromAttempt` concurrent dedupe across two tabs, `handleCreateFromInput` dedupe.
- `vitest run src/stores/create-flow-store.test.ts src/composer/draft/create-flow.test.ts` — 11 pass.
- `npm run typecheck --workspace=@getpaseo/app` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)