### PR TITLE
fix(server): proxy services through localhost upstream

### DIFF
--- a/docs/service-proxy.md
+++ b/docs/service-proxy.md
@@ -4,7 +4,9 @@ Paseo proxies HTTP traffic to services running inside your workspaces. Localhost
 
 ## How it works
 
-When a `paseo.json` script of `"type": "service"` starts, Paseo assigns it a local port and registers a route in the service proxy. Incoming requests whose `Host` header matches the script's generated hostname are forwarded to that port.
+When a `paseo.json` script of `"type": "service"` starts, Paseo assigns it a local port and registers a route in the service proxy. Incoming requests whose `Host` header matches the script's generated hostname are forwarded to that route's upstream target.
+
+Workspace service routes store both the generated hostname and the upstream target. By default the upstream host is `localhost`, not a fixed loopback address. This lets services that bind only to IPv4 `127.0.0.1` or only to IPv6 `::1` work behind the same generated hostname, and keeps proxy forwarding and health checks pointed at the same target. Service commands should still bind to the injected `HOST` value when the framework supports it.
 
 The generated hostname is built from the script name, branch, and project:
 

--- a/packages/server/src/server/script-health-monitor.test.ts
+++ b/packages/server/src/server/script-health-monitor.test.ts
@@ -99,14 +99,15 @@ function createStubTerminalManager(
   };
 }
 
-async function startTcpServer(): Promise<TcpServerHandle> {
+async function startTcpServer(options: { host?: string } = {}): Promise<TcpServerHandle> {
+  const host = options.host ?? "127.0.0.1";
   const server = net.createServer((socket) => {
     socket.end();
   });
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, host, () => {
       server.off("error", reject);
       resolve();
     });
@@ -143,6 +144,13 @@ async function advancePoll(ms: number): Promise<void> {
   }
 }
 
+function registerIpv4Route(
+  routeStore: ScriptRouteStore,
+  input: Parameters<ScriptRouteStore["registerRoute"]>[0],
+): void {
+  routeStore.registerRoute({ upstreamHost: "127.0.0.1", ...input });
+}
+
 describe("ScriptHealthMonitor", () => {
   const servers = new Set<net.Server>();
 
@@ -170,7 +178,7 @@ describe("ScriptHealthMonitor", () => {
     });
 
     monitor.start();
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-b.example.localhost",
       port: healthy.port,
       workspaceId: "workspace-a",
@@ -199,12 +207,52 @@ describe("ScriptHealthMonitor", () => {
     ]);
   });
 
+  it("probes service routes through their registered upstream host", async () => {
+    vi.useFakeTimers();
+
+    const healthy = await startTcpServer({ host: "::1" });
+    servers.add(healthy.server);
+
+    const routeStore = new ScriptRouteStore();
+    const onChange = vi.fn<(workspaceId: string, services: ScriptHealthEntry[]) => void>();
+    const monitor = new ScriptHealthMonitor({
+      serviceProxy: routeStore,
+      onChange,
+      pollIntervalMs: 1_000,
+      probeTimeoutMs: 100,
+      graceMs: 5_000,
+    });
+
+    monitor.start();
+    routeStore.registerRoute({
+      hostname: "route-ipv6.example.localhost",
+      upstreamHost: "::1",
+      port: healthy.port,
+      workspaceId: "workspace-a",
+      projectSlug: "repo",
+      scriptName: "api",
+    });
+
+    expect(monitor.getHealthForHostname("route-ipv6.example.localhost")).toBe("pending");
+    await advancePoll(5_000);
+
+    expect(monitor.getHealthForHostname("route-ipv6.example.localhost")).toBe("healthy");
+    expect(onChange).toHaveBeenCalledWith("workspace-a", [
+      {
+        scriptName: "api",
+        hostname: "route-ipv6.example.localhost",
+        port: healthy.port,
+        health: "healthy",
+      },
+    ]);
+  });
+
   it("transitions pending services to unhealthy after the grace period and required failures", async () => {
     vi.useFakeTimers();
 
     const deadPort = await findFreePort();
     const routeStore = new ScriptRouteStore();
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-b.example.localhost",
       port: deadPort,
       workspaceId: "workspace-a",
@@ -251,7 +299,7 @@ describe("ScriptHealthMonitor", () => {
     servers.add(healthy.server);
 
     const routeStore = new ScriptRouteStore();
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-b.example.localhost",
       port: healthy.port,
       workspaceId: "workspace-a",
@@ -282,7 +330,7 @@ describe("ScriptHealthMonitor", () => {
     servers.add(healthy.server);
 
     const routeStore = new ScriptRouteStore();
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-b.example.localhost",
       port: healthy.port,
       workspaceId: "workspace-a",
@@ -333,7 +381,7 @@ describe("ScriptHealthMonitor", () => {
     servers.add(healthy.server);
 
     const routeStore = new ScriptRouteStore();
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-b.example.localhost",
       port: healthy.port,
       workspaceId: "workspace-a",
@@ -376,14 +424,14 @@ describe("ScriptHealthMonitor", () => {
     servers.add(web.server);
 
     const routeStore = new ScriptRouteStore();
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-b.example.localhost",
       port: api.port,
       workspaceId: "workspace-a",
       projectSlug: "repo",
       scriptName: "api",
     });
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-c.example.localhost",
       port: web.port,
       workspaceId: "workspace-a",
@@ -463,12 +511,18 @@ describe("ScriptHealthMonitor", () => {
       expect(routeStore.listRoutes()).toEqual([
         {
           hostname: "api--repo.localhost",
+          upstreamHost: "localhost",
           port: service.port,
           workspaceId: workspace.repoDir,
           projectSlug: "repo",
           scriptName: "api",
         },
       ]);
+      const [serviceRoute] = routeStore.listRoutes();
+      if (!serviceRoute) {
+        throw new Error("Expected service route to be registered");
+      }
+      routeStore.registerRoute({ ...serviceRoute, upstreamHost: "127.0.0.1" });
 
       const onChange = vi.fn<(workspaceId: string, services: ScriptHealthEntry[]) => void>();
       const monitor = new ScriptHealthMonitor({
@@ -507,14 +561,14 @@ describe("ScriptHealthMonitor", () => {
     servers.add(web.server);
 
     const routeStore = new ScriptRouteStore();
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-b.example.localhost",
       port: api.port,
       workspaceId: "workspace-a",
       projectSlug: "repo",
       scriptName: "api",
     });
-    routeStore.registerRoute({
+    registerIpv4Route(routeStore, {
       hostname: "route-c.example.localhost",
       port: web.port,
       workspaceId: "workspace-a",

--- a/packages/server/src/server/script-health-monitor.ts
+++ b/packages/server/src/server/script-health-monitor.ts
@@ -102,7 +102,7 @@ export class ScriptHealthMonitor {
         .map((route) => ({ route, state: this.getOrCreateState(route, now) }))
         .filter(({ state }) => now - state.registeredAt >= this.graceMs);
       const healthResults = await Promise.all(
-        probeTargets.map(({ route }) => this.probeRoute(route.port)),
+        probeTargets.map(({ route }) => this.probeRoute(route.upstreamHost, route.port)),
       );
       for (let i = 0; i < probeTargets.length; i += 1) {
         const { route, state } = probeTargets[i];
@@ -206,9 +206,9 @@ export class ScriptHealthMonitor {
     };
   }
 
-  private probeRoute(port: number): Promise<boolean> {
+  private probeRoute(upstreamHost: string, port: number): Promise<boolean> {
     return new Promise((resolve) => {
-      const socket = net.connect({ host: "127.0.0.1", port });
+      const socket = net.connect({ host: upstreamHost, port, autoSelectFamily: true });
       let settled = false;
 
       const finish = (healthy: boolean) => {

--- a/packages/server/src/server/script-route-branch-handler.test.ts
+++ b/packages/server/src/server/script-route-branch-handler.test.ts
@@ -92,6 +92,7 @@ describe("script-route-branch-handler", () => {
     expect(routeStore.findRoute("api--feature-auth--paseo.localhost")).toBeNull();
     expect(routeStore.findRoute("api--feature-billing--paseo.localhost")).toEqual({
       hostname: "api--feature-billing--paseo.localhost",
+      upstreamHost: "localhost",
       port: 3001,
     });
   });
@@ -129,6 +130,7 @@ describe("script-route-branch-handler", () => {
     expect(routeStore.listRoutesForWorkspace("workspace-a")).toEqual([
       {
         hostname: "api--paseo.localhost",
+        upstreamHost: "localhost",
         port: 3001,
         workspaceId: "workspace-a",
         projectSlug: "paseo",
@@ -178,6 +180,7 @@ describe("script-route-branch-handler", () => {
     expect(routeStore.findRoute("api--feature-auth--paseo.services.example.com")).toBeNull();
     expect(routeStore.findRoute("api--feature-billing--paseo.services.example.com")).toEqual({
       hostname: "api--feature-billing--paseo.localhost",
+      upstreamHost: "localhost",
       port: 3001,
     });
     expect(routeStore.listRoutesForWorkspace("workspace-a")).toEqual([
@@ -185,6 +188,7 @@ describe("script-route-branch-handler", () => {
         hostname: "api--feature-billing--paseo.localhost",
         publicHostname: "api--feature-billing--paseo.services.example.com",
         publicBaseUrl: "https://services.example.com:8443",
+        upstreamHost: "localhost",
         port: 3001,
         workspaceId: "workspace-a",
         projectSlug: "paseo",
@@ -224,6 +228,7 @@ describe("script-route-branch-handler", () => {
     expect(routeStore.listRoutesForWorkspace("workspace-a")).toEqual([
       {
         hostname: "api--feature-billing--paseo.localhost",
+        upstreamHost: "localhost",
         port: 3001,
         workspaceId: "workspace-a",
         projectSlug: "paseo",
@@ -231,6 +236,7 @@ describe("script-route-branch-handler", () => {
       },
       {
         hostname: "web--feature-billing--paseo.localhost",
+        upstreamHost: "localhost",
         port: 3002,
         workspaceId: "workspace-a",
         projectSlug: "paseo",
@@ -240,6 +246,7 @@ describe("script-route-branch-handler", () => {
     expect(routeStore.listRoutesForWorkspace("workspace-b")).toEqual([
       {
         hostname: "docs--docs-app.localhost",
+        upstreamHost: "localhost",
         port: 3003,
         workspaceId: "workspace-b",
         projectSlug: "docs-app",
@@ -298,6 +305,7 @@ describe("script-route-branch-handler", () => {
       expect(routeStore.listRoutesForWorkspace(workspace.repoDir)).toEqual([
         {
           hostname: "api--feature-billing--repo.localhost",
+          upstreamHost: "localhost",
           port: 3001,
           workspaceId: workspace.repoDir,
           projectSlug: "repo",
@@ -346,6 +354,7 @@ describe("script-route-branch-handler", () => {
         hostname: "api--feature-auth--repo.localhost",
         publicHostname: "api--feature-auth--repo.services.example.com",
         publicBaseUrl: "https://services.example.com",
+        upstreamHost: "localhost",
         port: 3001,
         workspaceId: "workspace-a",
         projectSlug: "repo",

--- a/packages/server/src/server/service-proxy.test.ts
+++ b/packages/server/src/server/service-proxy.test.ts
@@ -297,7 +297,30 @@ describe("service proxy subsystem shape", () => {
     });
 
     expect(serviceProxy.getHealthTargetForHostname("api--repo.localhost")).toMatchObject({
+      upstreamHost: "localhost",
       port: 4000,
+    });
+  });
+
+  it("stores an explicit upstream host for route lookup and health checks", () => {
+    const serviceProxy = new ServiceProxyRouteRegistry();
+    serviceProxy.registerWorkspaceService({
+      workspaceId: "workspace-a",
+      projectSlug: "repo",
+      branchName: "main",
+      scriptName: "api",
+      upstreamHost: "::1",
+      port: 3000,
+    });
+
+    expect(serviceProxy.findRoute("api--repo.localhost")).toMatchObject({
+      hostname: "api--repo.localhost",
+      upstreamHost: "::1",
+      port: 3000,
+    });
+    expect(serviceProxy.getHealthTargetForHostname("api--repo.localhost")).toMatchObject({
+      upstreamHost: "::1",
+      port: 3000,
     });
   });
 });
@@ -313,7 +336,10 @@ interface ForwardedFixture {
  * echoes the headers it received so tests can assert what actually crossed the
  * proxy, not what a helper returned.
  */
-async function startForwardedHeadersFixture(): Promise<ForwardedFixture> {
+async function startForwardedHeadersFixture(
+  options: { upstreamHost?: string } = {},
+): Promise<ForwardedFixture> {
+  const upstreamHost = options.upstreamHost ?? "127.0.0.1";
   const upstreamPort = await findFreePort();
   const upstream = http.createServer((req, res) => {
     res.writeHead(200, { "content-type": "application/json" });
@@ -331,7 +357,7 @@ async function startForwardedHeadersFixture(): Promise<ForwardedFixture> {
       `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nX-Echo-Length: ${payload.length}\r\n\r\n${payload}`,
     );
   });
-  await new Promise<void>((resolve) => upstream.listen(upstreamPort, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => upstream.listen(upstreamPort, upstreamHost, resolve));
 
   const serviceProxy = createServiceProxySubsystem({ logger });
   const route = serviceProxy.registerWorkspaceService({
@@ -417,6 +443,21 @@ function upgradeThroughProxy(
 }
 
 describe("service proxy forwarded headers", () => {
+  it("reaches services that only bind to IPv6 localhost", async () => {
+    const fixture = await startForwardedHeadersFixture({ upstreamHost: "::1" });
+    try {
+      const response = await httpGet(
+        fixture.daemonPort,
+        `${fixture.hostname}:${fixture.daemonPort}`,
+        { path: "/" },
+      );
+
+      expect(response.status).toBe(200);
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("forwards the client authority with its port so services build reachable URLs", async () => {
     const fixture = await startForwardedHeadersFixture();
     try {

--- a/packages/server/src/server/service-proxy.ts
+++ b/packages/server/src/server/service-proxy.ts
@@ -13,6 +13,7 @@ export type ServiceProxyListenTarget =
 
 export interface ServiceProxyRoute {
   hostname: string;
+  upstreamHost: string;
   port: number;
 }
 
@@ -24,6 +25,10 @@ export interface ServiceProxyRouteEntry extends ServiceProxyRoute {
   publicHostname?: string | null;
   publicBaseUrl?: string | null;
 }
+
+type ServiceProxyRouteRegistration = Omit<ServiceProxyRouteEntry, "upstreamHost"> & {
+  upstreamHost?: string | null;
+};
 
 export interface ServiceProxyUrlProjection {
   localProxyUrl: string | null;
@@ -43,6 +48,7 @@ export interface ServiceProxyHealthTarget {
   workspaceId: string;
   scriptName: string;
   hostname: string;
+  upstreamHost: string;
   port: number;
 }
 
@@ -55,6 +61,7 @@ export interface WorkspaceServiceIdentity {
 
 export interface RegisterWorkspaceServiceInput extends WorkspaceServiceIdentity {
   port: number;
+  upstreamHost?: string | null;
   publicBaseUrl?: string | null;
 }
 
@@ -78,6 +85,7 @@ type HostClassification =
 
 const MAX_DNS_LABEL_LENGTH = 63;
 const HASH_SUFFIX_LENGTH = 8;
+const DEFAULT_SERVICE_UPSTREAM_HOST = "localhost";
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -240,6 +248,7 @@ function toHealthTarget(route: ServiceProxyRouteEntry): ServiceProxyHealthTarget
     workspaceId: route.workspaceId,
     scriptName: route.scriptName,
     hostname: route.hostname,
+    upstreamHost: route.upstreamHost,
     port: route.port,
   };
 }
@@ -330,7 +339,7 @@ function proxyHttpRequest({
 
   const proxyReq = http.request(
     {
-      hostname: "127.0.0.1",
+      hostname: route.upstreamHost,
       port: route.port,
       path: req.originalUrl,
       method: req.method,
@@ -344,7 +353,7 @@ function proxyHttpRequest({
   );
   proxyReq.on("error", (err) => {
     logger.warn(
-      { err, hostname: route.hostname, port: route.port },
+      { err, hostname: route.hostname, upstreamHost: route.upstreamHost, port: route.port },
       "Service proxy: upstream unreachable",
     );
     if (!res.headersSent) {
@@ -368,29 +377,32 @@ function proxyUpgradeRequest({
   route: ServiceProxyRoute;
   logger: Logger;
 }): void {
-  const targetSocket = net.connect({ host: "127.0.0.1", port: route.port }, () => {
-    const forwardedHeaders = buildForwardedHeaders({ req, route, protocol: "http" });
-    forwardedHeaders.connection = "Upgrade";
-    forwardedHeaders.upgrade = req.headers.upgrade ?? "websocket";
+  const targetSocket = net.connect(
+    { host: route.upstreamHost, port: route.port, autoSelectFamily: true },
+    () => {
+      const forwardedHeaders = buildForwardedHeaders({ req, route, protocol: "http" });
+      forwardedHeaders.connection = "Upgrade";
+      forwardedHeaders.upgrade = req.headers.upgrade ?? "websocket";
 
-    const headerLines: string[] = [];
-    headerLines.push(`${req.method ?? "GET"} ${req.url ?? "/"} HTTP/${req.httpVersion}`);
-    for (const [key, value] of Object.entries(forwardedHeaders)) {
-      if (Array.isArray(value)) {
-        for (const v of value) headerLines.push(`${key}: ${v}`);
-      } else {
-        headerLines.push(`${key}: ${value}`);
+      const headerLines: string[] = [];
+      headerLines.push(`${req.method ?? "GET"} ${req.url ?? "/"} HTTP/${req.httpVersion}`);
+      for (const [key, value] of Object.entries(forwardedHeaders)) {
+        if (Array.isArray(value)) {
+          for (const v of value) headerLines.push(`${key}: ${v}`);
+        } else {
+          headerLines.push(`${key}: ${value}`);
+        }
       }
-    }
-    headerLines.push("\r\n");
-    targetSocket.write(headerLines.join("\r\n"));
-    if (head.length > 0) targetSocket.write(head);
-    targetSocket.pipe(socket);
-    socket.pipe(targetSocket);
-  });
+      headerLines.push("\r\n");
+      targetSocket.write(headerLines.join("\r\n"));
+      if (head.length > 0) targetSocket.write(head);
+      targetSocket.pipe(socket);
+      socket.pipe(targetSocket);
+    },
+  );
   targetSocket.on("error", (err) => {
     logger.warn(
-      { err, hostname: route.hostname, port: route.port },
+      { err, hostname: route.hostname, upstreamHost: route.upstreamHost, port: route.port },
       "Service proxy: WebSocket upstream unreachable",
     );
     socket.end();
@@ -400,7 +412,10 @@ function proxyUpgradeRequest({
   });
 }
 
-function sameRouteOwner(left: ServiceProxyRouteEntry, right: ServiceProxyRouteEntry): boolean {
+function sameRouteOwner(
+  left: Pick<ServiceProxyRouteEntry, "workspaceId" | "scriptName">,
+  right: Pick<ServiceProxyRouteEntry, "workspaceId" | "scriptName">,
+): boolean {
   return left.workspaceId === right.workspaceId && left.scriptName === right.scriptName;
 }
 
@@ -439,6 +454,7 @@ export class ServiceProxyRouteRegistry {
       : null;
     const entry: ServiceProxyRouteEntry = {
       hostname: localHostname,
+      upstreamHost: input.upstreamHost ?? DEFAULT_SERVICE_UPSTREAM_HOST,
       ...(publicHostname ? { publicHostname } : {}),
       ...(input.publicBaseUrl ? { publicBaseUrl: input.publicBaseUrl } : {}),
       port: input.port,
@@ -450,7 +466,7 @@ export class ServiceProxyRouteRegistry {
     return { ...entry };
   }
 
-  registerRoute(entry: ServiceProxyRouteEntry): void {
+  registerRoute(entry: ServiceProxyRouteRegistration): void {
     this.assertCanRegister(entry);
     const previous = this.routes.get(entry.hostname);
     if (previous) {
@@ -628,7 +644,11 @@ export class ServiceProxyRouteRegistry {
     if (exactRoute) {
       return {
         type: "registered-service",
-        route: { hostname: exactRoute.hostname, port: exactRoute.port },
+        route: {
+          hostname: exactRoute.hostname,
+          upstreamHost: exactRoute.upstreamHost,
+          port: exactRoute.port,
+        },
       };
     }
     if (hostname.endsWith(".localhost") && hostname.split(".")[0]?.includes("--")) {
@@ -672,7 +692,7 @@ export class ServiceProxyRouteRegistry {
   }
 
   private assertCanRegister(
-    entry: ServiceProxyRouteEntry,
+    entry: ServiceProxyRouteRegistration,
     replacingHostnames = new Set<string>(),
   ): void {
     const incomingHostnames = this.getRouteHostnames(entry);
@@ -701,10 +721,11 @@ export class ServiceProxyRouteRegistry {
     }
   }
 
-  private toStoredEntry(entry: ServiceProxyRouteEntry): ServiceProxyRouteEntry {
-    const { publicHostname, publicBaseUrl, ...requiredEntry } = entry;
+  private toStoredEntry(entry: ServiceProxyRouteRegistration): ServiceProxyRouteEntry {
+    const { publicHostname, publicBaseUrl, upstreamHost, ...requiredEntry } = entry;
     return {
       ...requiredEntry,
+      upstreamHost: upstreamHost ?? DEFAULT_SERVICE_UPSTREAM_HOST,
       ...(publicHostname ? { publicHostname } : {}),
       ...(publicBaseUrl ? { publicBaseUrl } : {}),
     };

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -718,6 +718,7 @@ export interface SpawnWorkspaceScriptOptions {
 
 interface ServiceScriptSetupResult {
   hostname: string;
+  upstreamHost: string;
   port: number;
   env: Record<string, string>;
 }
@@ -822,7 +823,12 @@ async function setupServiceScriptRoute(params: {
     scriptName,
     publicBaseUrl: serviceProxyPublicBaseUrl ?? null,
   });
-  return { hostname: registeredRoute.hostname, port, env };
+  return {
+    hostname: registeredRoute.hostname,
+    upstreamHost: registeredRoute.upstreamHost,
+    port,
+    env,
+  };
 }
 
 async function acquireWorkspaceScriptTerminal(params: {
@@ -891,6 +897,7 @@ export async function spawnWorkspaceScript(
   const serviceScript = isServiceScript(config);
   const scriptType = serviceScript ? "service" : "script";
   let hostname: string | null = null;
+  let upstreamHost: string | null = null;
   let port: number | null = null;
   let runtimeRegistered = false;
   let routeRegistered = false;
@@ -920,6 +927,7 @@ export async function spawnWorkspaceScript(
         servicePortAllocation: configResult.config?.worktree?.servicePorts ?? globalServicePorts,
       });
       hostname = serviceSetup.hostname;
+      upstreamHost = serviceSetup.upstreamHost;
       port = serviceSetup.port;
       env = serviceSetup.env;
       routeRegistered = true;
@@ -1004,12 +1012,13 @@ export async function spawnWorkspaceScript(
       {
         scriptName,
         hostname,
+        upstreamHost,
         port,
         terminalId: terminal.id,
         type: scriptType,
       },
       serviceScript
-        ? `Registered script proxy: ${hostname} -> 127.0.0.1:${port}`
+        ? `Registered script proxy: ${hostname} -> ${upstreamHost}:${port}`
         : "Started workspace script",
     );
 


### PR DESCRIPTION
### Linked issue

Part of #678

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Workspace service proxy routes currently forward HTTP and WebSocket traffic to a fixed `127.0.0.1` upstream. That breaks local service URLs when the launched dev server binds only to IPv6 localhost (`::1`), which has been confirmed in #678 as a reachable 502 failure.

This change stores an upstream host on service routes and defaults it to `localhost`, then uses that same target for proxy forwarding and service health checks. Node can then select the reachable loopback family instead of Paseo forcing IPv4.

### Goals

- Let generated `.localhost` service URLs reach services that bind only to IPv4 `127.0.0.1` or only to IPv6 `::1`.
- Keep HTTP proxying, WebSocket upgrades, and health checks aligned on the same upstream target.
- Preserve existing route registration callers by defaulting omitted upstream hosts to `localhost`.
- Document that workspace routes store a generated hostname plus an upstream target.

### Non-goals

- Does not change remote client service-link selection or make `.localhost` names resolvable off the daemon machine.
- Does not expose service ports on the LAN; service commands still need to bind appropriately for direct remote access.

### QA

Before this patch, `origin/main` still contained fixed IPv4 forwarding:

```bash
git show origin/main:packages/server/src/server/service-proxy.ts | rg -n "http.request|net.connect|127\\.0\\.0\\.1"
# 331:  const proxyReq = http.request(
# 333:      hostname: "127.0.0.1",
# 371:  const targetSocket = net.connect({ host: "127.0.0.1", port: route.port }, () => {
```

Focused tests added/updated and passing:

```bash
npx vitest run packages/server/src/server/service-proxy.test.ts packages/server/src/server/script-health-monitor.test.ts packages/server/src/server/script-route-branch-handler.test.ts --bail=1
# Test Files  3 passed (3)
# Tests  39 passed (39)
```

Build/typecheck/lint:

```bash
npm run build:server
# passed

npm run typecheck --workspace=@getpaseo/server
# passed

npm run lint
# Found 0 warnings and 0 errors.

npm run format
# Finished successfully.
```

I also ran the repository-wide typecheck after updating this branch to current `origin/main`. It failed outside this patch in `packages/app/src/components/draggable-list.native.tsx`:

```bash
npm run typecheck
# src/components/draggable-list.native.tsx(122,7): error TS2322: Property 'dragGestureHostPresented' does not exist ...
```

This PR does not touch `packages/app`.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
