### PR TITLE
fix(server): close the previous Codex app-server before reload resume

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -3017,6 +3017,69 @@ test("setAgentMode persists the selected mode across session reload", async () =
   expect(reloaded.currentModeId).toBe("full-access");
 });
 
+test("reloadAgentSession closes the previous session before resuming the replacement", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-close-before-resume-"));
+  const storagePath = join(workdir, "agents");
+  const storage = new AgentStorage(storagePath, logger);
+  const order: string[] = [];
+
+  class OrderTrackingSession extends TestAgentSession {
+    override async close(): Promise<void> {
+      order.push("close");
+    }
+  }
+
+  class OrderTrackingClient extends TestAgentClient {
+    readonly firstSession = new OrderTrackingSession({
+      provider: "codex",
+      cwd: workdir,
+    });
+
+    override async createSession(): Promise<AgentSession> {
+      return this.firstSession;
+    }
+
+    override async resumeSession(
+      _handle: AgentPersistenceHandle,
+      config?: Partial<AgentSessionConfig>,
+    ): Promise<AgentSession> {
+      order.push("resume");
+      return new TestAgentSession({
+        provider: "codex",
+        cwd: config?.cwd ?? workdir,
+      });
+    }
+  }
+
+  const client = new OrderTrackingClient();
+  const manager = new AgentManager({
+    clients: {
+      codex: client,
+    },
+    registry: storage,
+    logger,
+    idFactory: () => "00000000-0000-4000-8000-000000000307",
+  });
+
+  try {
+    const snapshot = await manager.createAgent(
+      {
+        provider: "codex",
+        cwd: workdir,
+      },
+      undefined,
+      { workspaceId: undefined },
+    );
+
+    const reloaded = await manager.reloadAgentSession(snapshot.id);
+
+    expect(reloaded.id).toBe(snapshot.id);
+    expect(order).toEqual(["close", "resume"]);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
 test("reloadAgentSession completes when the previous session close hangs", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-close-timeout-"));
   const storagePath = join(workdir, "agents");
@@ -3543,7 +3606,7 @@ test("resumeAgentFromPersistence closes and rejects a session that cannot honor 
   }
 });
 
-test("reloadAgentSession preserves the live session when its replacement cannot honor external MCP", async () => {
+test("reloadAgentSession closes the previous session even when replacement MCP support fails", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const original = new CloseRecordingTestAgentSession({ provider: "codex", cwd: workdir });
   const replacement = new CloseRecordingTestAgentSession({ provider: "codex", cwd: workdir });
@@ -3580,7 +3643,7 @@ test("reloadAgentSession preserves the live session when its replacement cannot 
     ).rejects.toThrow("Provider 'codex' does not support MCP servers");
 
     expect(replacement.closed).toBe(true);
-    expect(original.closed).toBe(false);
+    expect(original.closed).toBe(true);
     expect(manager.getAgent(created.id)?.session).toBe(original);
     expect(manager.getAgent(created.id)?.lifecycle).toBe("idle");
   } finally {

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1082,6 +1082,12 @@ class McpCapableTestAgentSession extends TestAgentSession {
 
 class CloseRecordingTestAgentSession extends TestAgentSession {
   closed = false;
+  startTurnCalls = 0;
+
+  override async startTurn(): Promise<{ turnId: string }> {
+    this.startTurnCalls += 1;
+    return super.startTurn();
+  }
 
   override async close(): Promise<void> {
     this.closed = true;
@@ -3030,13 +3036,11 @@ test("reloadAgentSession closes the previous session before resuming the replace
   }
 
   class OrderTrackingClient extends TestAgentClient {
-    readonly firstSession = new OrderTrackingSession({
-      provider: "codex",
-      cwd: workdir,
-    });
-
     override async createSession(): Promise<AgentSession> {
-      return this.firstSession;
+      return new OrderTrackingSession({
+        provider: "codex",
+        cwd: workdir,
+      });
     }
 
     override async resumeSession(
@@ -3044,7 +3048,7 @@ test("reloadAgentSession closes the previous session before resuming the replace
       config?: Partial<AgentSessionConfig>,
     ): Promise<AgentSession> {
       order.push("resume");
-      return new TestAgentSession({
+      return new OrderTrackingSession({
         provider: "codex",
         cwd: config?.cwd ?? workdir,
       });
@@ -3075,6 +3079,11 @@ test("reloadAgentSession closes the previous session before resuming the replace
 
     expect(reloaded.id).toBe(snapshot.id);
     expect(order).toEqual(["close", "resume"]);
+
+    const reloadedAgain = await manager.reloadAgentSession(snapshot.id);
+    expect(reloadedAgain.id).toBe(snapshot.id);
+    expect(reloadedAgain.lifecycle).toBe("idle");
+    expect(order).toEqual(["close", "resume", "close", "resume"]);
   } finally {
     rmSync(workdir, { recursive: true, force: true });
   }
@@ -3606,10 +3615,11 @@ test("resumeAgentFromPersistence closes and rejects a session that cannot honor 
   }
 });
 
-test("reloadAgentSession closes the previous session even when replacement MCP support fails", async () => {
+test("reloadAgentSession keeps the agent in error when replacement MCP support fails", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-test-"));
   const original = new CloseRecordingTestAgentSession({ provider: "codex", cwd: workdir });
   const replacement = new CloseRecordingTestAgentSession({ provider: "codex", cwd: workdir });
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
 
   class UnsupportedReloadClient extends TestAgentClient {
     override async createSession(): Promise<AgentSession> {
@@ -3623,7 +3633,7 @@ test("reloadAgentSession closes the previous session even when replacement MCP s
 
   const manager = new AgentManager({
     clients: { codex: new UnsupportedReloadClient() },
-    registry: new AgentStorage(join(workdir, "agents"), logger),
+    registry: storage,
     logger,
   });
 
@@ -3644,8 +3654,142 @@ test("reloadAgentSession closes the previous session even when replacement MCP s
 
     expect(replacement.closed).toBe(true);
     expect(original.closed).toBe(true);
-    expect(manager.getAgent(created.id)?.session).toBe(original);
-    expect(manager.getAgent(created.id)?.lifecycle).toBe("idle");
+    expect(manager.getAgent(created.id)).toMatchObject({
+      lifecycle: "error",
+      lastError: "Reload failed: Provider 'codex' does not support MCP servers",
+      providerSessionClosed: true,
+    });
+    expect(await storage.get(created.id)).toMatchObject({
+      lastStatus: "error",
+      lastError: "Reload failed: Provider 'codex' does not support MCP servers",
+    });
+    await expect(manager.runAgent(created.id, "continue")).rejects.toThrow(
+      "Reload failed: Provider 'codex' does not support MCP servers",
+    );
+    expect(original.startTurnCalls).toBe(0);
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("reloadAgentSession keeps the agent in error when replacement resume fails", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-resume-failure-"));
+  const original = new CloseRecordingTestAgentSession({ provider: "codex", cwd: workdir });
+  const storage = new AgentStorage(join(workdir, "agents"), logger);
+
+  class FailingResumeClient extends TestAgentClient {
+    resumeCalls = 0;
+
+    override async createSession(): Promise<AgentSession> {
+      return original;
+    }
+
+    override async resumeSession(): Promise<AgentSession> {
+      this.resumeCalls += 1;
+      if (this.resumeCalls === 1) {
+        throw new Error("resume exploded");
+      }
+      return new TestAgentSession({
+        provider: "codex",
+        cwd: workdir,
+      });
+    }
+  }
+
+  const client = new FailingResumeClient();
+  const manager = new AgentManager({
+    clients: { codex: client },
+    registry: storage,
+    logger,
+  });
+
+  try {
+    const created = await manager.createAgent(
+      { provider: "codex", cwd: workdir },
+      "00000000-0000-4000-8000-00000000010a",
+      { workspaceId: undefined },
+    );
+
+    await expect(manager.reloadAgentSession(created.id)).rejects.toThrow("resume exploded");
+
+    expect(original.closed).toBe(true);
+    expect(manager.getAgent(created.id)).toMatchObject({
+      lifecycle: "error",
+      lastError: "Reload failed: resume exploded",
+      providerSessionClosed: true,
+    });
+    expect(await storage.get(created.id)).toMatchObject({ lastStatus: "error" });
+    await expect(manager.runAgent(created.id, "continue")).rejects.toThrow(
+      "Reload failed: resume exploded",
+    );
+    expect(original.startTurnCalls).toBe(0);
+
+    const reloaded = await manager.reloadAgentSession(created.id);
+    expect(reloaded.id).toBe(created.id);
+    expect(reloaded.lifecycle).not.toBe("error");
+    expect(reloaded.providerSessionClosed).toBeUndefined();
+    await manager.runAgent(created.id, "continue");
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+});
+
+test("reload keeps the live error agent when error snapshot persist fails after replacement failure", async () => {
+  const workdir = mkdtempSync(join(tmpdir(), "agent-manager-reload-persist-fallback-remove-"));
+  const original = new CloseRecordingTestAgentSession({ provider: "codex", cwd: workdir });
+  const storagePath = join(workdir, "agents");
+
+  class PersistFailingStorage extends AgentStorage {
+    failNextApply = false;
+
+    override async applySnapshot(
+      agent: ManagedAgent,
+      options?: { title?: string | null; internal?: boolean },
+    ): Promise<void> {
+      if (this.failNextApply) {
+        throw new Error("snapshot write failed");
+      }
+      return super.applySnapshot(agent, options);
+    }
+  }
+
+  class FailingResumeClient extends TestAgentClient {
+    override async createSession(): Promise<AgentSession> {
+      return original;
+    }
+
+    override async resumeSession(): Promise<AgentSession> {
+      throw new Error("resume exploded");
+    }
+  }
+
+  const storage = new PersistFailingStorage(storagePath, logger);
+  const manager = new AgentManager({
+    clients: { codex: new FailingResumeClient() },
+    registry: storage,
+    logger,
+  });
+
+  try {
+    const created = await manager.createAgent(
+      { provider: "codex", cwd: workdir },
+      "00000000-0000-4000-8000-00000000010b",
+      { workspaceId: undefined },
+    );
+    storage.failNextApply = true;
+
+    await expect(manager.reloadAgentSession(created.id)).rejects.toThrow("resume exploded");
+
+    expect(original.closed).toBe(true);
+    expect(manager.getAgent(created.id)).toMatchObject({
+      lifecycle: "error",
+      lastError: "Reload failed: resume exploded",
+      providerSessionClosed: true,
+    });
+    await expect(manager.runAgent(created.id, "continue")).rejects.toThrow(
+      "Reload failed: resume exploded",
+    );
+    expect(original.startTurnCalls).toBe(0);
   } finally {
     rmSync(workdir, { recursive: true, force: true });
   }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1383,10 +1383,7 @@ export class AgentManager {
     // Spawning the replacement and calling thread/resume first deadlocks reload:
     // the new process fails with "already has an active writer".
     this.cancelRunningProviderSubagents(agentId);
-    this.logger.debug(
-      { agentId, provider },
-      "Closing previous session before reload resume",
-    );
+    this.logger.debug({ agentId, provider }, "Closing previous session before reload resume");
     await this.closeReloadedSession(existing.session, agentId);
 
     const session = handle

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -365,6 +365,12 @@ interface ManagedAgentBase {
   >;
   inFlightPermissionResponses: Set<string>;
   pendingReplacement: boolean;
+  /**
+   * True when the provider session was closed without a replacement (failed
+   * reload after close-before-resume). Prompts must not call startTurn until a
+   * later reload succeeds. In-memory only; not persisted.
+   */
+  providerSessionClosed?: boolean;
   persistence: AgentPersistenceHandle | null;
   historyPrimed: boolean;
   lastUserMessageAt: Date | null;
@@ -1365,7 +1371,7 @@ export class AgentManager {
     const rehydrateFromDisk = options?.rehydrateFromDisk ?? false;
     const preservedHistoryPrimed = existing.historyPrimed;
     const preservedLastUsage = existing.lastUsage;
-    const preservedLastError = existing.lastError;
+    const preservedLastError = existing.providerSessionClosed ? undefined : existing.lastError;
     const preservedAttention = existing.attention;
     const handle = existing.persistence;
     const provider = handle?.provider ?? existing.provider;
@@ -1386,10 +1392,18 @@ export class AgentManager {
     this.logger.debug({ agentId, provider }, "Closing previous session before reload resume");
     await this.closeReloadedSession(existing.session, agentId);
 
-    const session = handle
-      ? await client.resumeSession(handle, providerLaunchConfig, launchContext)
-      : await client.createSession(providerLaunchConfig, launchContext);
-    await this.requireExternalMcpSupport(session, storedConfig);
+    let session: AgentSession;
+    try {
+      session = handle
+        ? await client.resumeSession(handle, providerLaunchConfig, launchContext)
+        : await client.createSession(providerLaunchConfig, launchContext);
+      await this.requireExternalMcpSupport(session, storedConfig);
+    } catch (error) {
+      // The previous writer is already gone. Keep the agent visible in error
+      // instead of closing it, but do not leave it idle for startTurn.
+      await this.finalizeFailedReload(existing, error);
+      throw error;
+    }
 
     let handedToRegistration = false;
     try {
@@ -1428,6 +1442,39 @@ export class AgentManager {
         await this.closeUnregisteredSession(session);
       }
     }
+  }
+
+  private formatReloadFailureMessage(error: unknown): string {
+    const detail =
+      error instanceof Error && error.message.trim().length > 0
+        ? error.message.trim()
+        : "replacement session setup failed";
+    return `Reload failed: ${detail}`;
+  }
+
+  private async finalizeFailedReload(existing: LiveManagedAgent, error: unknown): Promise<void> {
+    if (existing.unsubscribeSession) {
+      existing.unsubscribeSession();
+      existing.unsubscribeSession = null;
+    }
+
+    const failed = existing as ManagedAgentError;
+    failed.lifecycle = "error";
+    failed.lastError = this.formatReloadFailureMessage(error);
+    failed.providerSessionClosed = true;
+    failed.activeForegroundTurnId = null;
+    this.touchUpdatedAt(failed);
+    await this.appendSystemErrorTimelineMessage(failed, failed.provider, failed.lastError);
+
+    try {
+      await this.persistSnapshot(failed);
+    } catch (persistError) {
+      this.logger.warn(
+        { err: persistError, agentId: failed.id },
+        "Failed to persist error snapshot after reload replacement failure",
+      );
+    }
+    this.emitState(failed, { persist: false });
   }
 
   private async closeReloadedSession(session: AgentSession, agentId: string): Promise<void> {
@@ -2162,6 +2209,11 @@ export class AgentManager {
     options?: AgentRunOptions,
   ): AsyncGenerator<AgentStreamEvent> {
     const existingAgent = this.requireSessionAgent(agentId);
+    if (existingAgent.providerSessionClosed) {
+      throw new Error(
+        existingAgent.lastError ?? `Agent ${agentId} provider session closed after a failed reload`,
+      );
+    }
     this.logger.trace(
       {
         agentId,

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -1379,6 +1379,16 @@ export class AgentManager {
     const launchContext = await this.buildLaunchContext(agentId, client, storedConfig.cwd);
     const providerLaunchConfig = this.resolveProviderLaunchConfig(launchConfig, launchContext);
 
+    // Codex holds an exclusive thread writer until the previous app-server exits.
+    // Spawning the replacement and calling thread/resume first deadlocks reload:
+    // the new process fails with "already has an active writer".
+    this.cancelRunningProviderSubagents(agentId);
+    this.logger.debug(
+      { agentId, provider },
+      "Closing previous session before reload resume",
+    );
+    await this.closeReloadedSession(existing.session, agentId);
+
     const session = handle
       ? await client.resumeSession(handle, providerLaunchConfig, launchContext)
       : await client.createSession(providerLaunchConfig, launchContext);
@@ -1388,13 +1398,8 @@ export class AgentManager {
     try {
       this.assertAcceptingAgentRegistrations();
 
-      this.cancelRunningProviderSubagents(agentId);
       const closedExisting = this.prepareAgentForClosure(existing, "agent reloaded");
-      try {
-        await this.persistSnapshot(closedExisting);
-      } finally {
-        await this.closeReloadedSession(existing.session, agentId);
-      }
+      await this.persistSnapshot(closedExisting);
 
       if (rehydrateFromDisk) {
         // Wipe both durable and in-memory timeline so registerSession mints a


### PR DESCRIPTION
<!--
Please follow this template. The PR template applies whether you opened the PR via the web UI, `gh pr create`, or any other tool.

You MUST read CONTRIBUTING.md before sending a PR.
-->

### Linked issue

Closes #3573

Related: #3105 (same Codex writer error, different trigger; not retested here)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Reloading a Codex agent fails as soon as that agent already has a live `codex app-server` holding the thread writer. That is the normal state after the thread exists, so the first reload fails.

`reloadAgentSessionInternal` currently calls `resumeSession()` first. For Codex that spawns a new `codex app-server` and immediately does `thread/resume` on the same thread. The previous app-server is only closed afterward. Codex will not hand the writer to the new process while the old one is still alive, so reload deadlocks against Paseo's own child.

If someone kills that child first, reload can succeed once (lock is free). The replacement then becomes the live writer, and the next reload fails the same way. That is not a second-reload-only bug.

This PR closes the previous session before spawning/resuming the replacement.

### Goals

- Close the previous provider session before `resumeSession` / `createSession` during reload
- Make Codex reload succeed while a live app-server still holds the thread writer
- Keep existing reload timeout behavior: if `session.close()` hangs, reload still continues after `reloadSessionCloseMs`
- Cover the close-before-resume order with a unit test
- Keep shutdown-during-reload and persist-failure reload tests green

### Non-goals

- A Codex `thread/release` / takeover API (that would be a Codex-side change)
- Fixing #3105 (voice mode). It may share this path, but I did not enable voice mode to check
- Changing Cursor/desktop Codex helper processes, or how `~/.codex` is shared
- UI changes

### QA

**Before (0.5.0-beta.2, unpatched):**

1. Open a Codex agent that already has a live `codex app-server --enable goals` child.
2. Reload → client `refresh_agent_request` / `agent_refresh_failed`.

Daemon:

```
{"level":40,"pid":1717715,"daemonVersion":"0.5.0-beta.2","provider":"codex","agentId":"d15878f7-ee07-4fef-b0a2-672593df6308","error":{"code":-32600,"name":"CodexAppServerRpcError"},"threadId":"01a01b9f-994f-7353-a392-b41e8b7bbc8f","msg":"Failed to resume persisted Codex thread"}
```

```
Failed to resume Codex thread 01a01b9f-994f-7353-a392-b41e8b7bbc8f: thread ... already has an active writer
    at CodexAppServerAgentSession.ensureThreadLoaded
    at CodexAppServerAgentClient.resumeSession
    at AgentManager.reloadAgentSessionInternal
```

The lock holder is Paseo's own live child, not a leftover desktop helper:

```
lsof ~/.codex/thread-writer-locks/01a01b9f-994f-7353-a392-b41e8b7bbc8f.lock
codex   1731330  ... 01a01b9f-994f-7353-a392-b41e8b7bbc8f.lock

1731323  1717715  node .../codex app-server --enable goals
1731330  1731323  vendor/.../codex app-server --enable goals
1717715           Paseo Daemon
```

Killing that app-server first made one reload succeed; that was an empty lock, not a working first-reload path.

**After (this change, daemon restarted):**

Reload of a live Codex agent succeeds, including consecutive reloads. Conversation stays usable. I did not re-test voice mode.

**Unit tests** (from this branch, `packages/server`):

```
npx vitest run src/server/agent/agent-manager.test.ts -t "reloadAgentSession closes the previous session before resuming|reloadAgentSession completes when the previous session close hangs|reloadAgentSession closes the previous session even when replacement MCP|reload leaves a closed durable snapshot when shutdown starts during the swap|reload closes both sessions when the closed snapshot cannot be persisted"

 Test Files  1 passed (1)
      Tests  5 passed | 173 skipped (178)
   Duration  1.06s
```

New test asserts close happens before resume. MCP-unsupported reload now closes the original session before the replacement is created (Codex cannot keep the old writer alive). Hanging-close, shutdown-during-swap, and persist-failure tests still pass.

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | not tested |
| Android         |        | not tested |
| Web (browser)   | x      | reload via paired client / relay |
| Desktop macOS   |        | not tested |
| Desktop Windows |        | not tested |
| Desktop Linux   | x      | daemon on RHEL 9, Codex 0.148.0, Paseo 0.5.0-beta.2 |

I did not run full-repo `npm run typecheck`, `lint`, or `format` (this machine cannot take a full monorepo install). The change is two server files.

I did not run full-repo `npm run typecheck` (`typecheck --workspaces`). That walks app/website/desktop, and this machine only has a daemon-package install, so missing SDKs fail before our files. `npm run typecheck:server` hit the same missing-dep errors in Claude/OpenCode/speech code we did not touch.

On this branch I did run:

- `npm run lint` → oxlint, 0 warnings / 0 errors, 3716 files
- `npm run format:check` → oxfmt --check ., all matched files correct (after oxfmt on the debug log wrap)

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes (full workspaces not run here; see QA)
- [x] `npm run lint` passes
- [x] `npm run format` passes (`format:check`; equivalent to `oxfmt --check .`)
- [x] QA evidence
- [x] Tests added or updated where it made sense
