### PR TITLE
Allow Git-valid branch names when creating worktrees

### DIFF
--- a/packages/server/src/server/workspace-create-worktree-source.e2e.test.ts
+++ b/packages/server/src/server/workspace-create-worktree-source.e2e.test.ts
@@ -96,6 +96,40 @@ test("workspace.create keeps a branch-off name separate from its worktree slug",
   }
 }, 180000);
 
+test("workspace.create accepts a Git-valid branch-off name outside Paseo slug syntax", async () => {
+  const daemon = await createTestPaseoDaemon();
+  const { repoDir, tempRoot } = createGitRepoWithBranch();
+  const client = new DaemonClient({
+    url: `ws://127.0.0.1:${daemon.port}/ws`,
+    appVersion: "0.1.82",
+  });
+
+  try {
+    await client.connect();
+
+    const result = await client.createWorkspace({
+      source: {
+        kind: "worktree",
+        cwd: repoDir,
+        action: "branch-off",
+        branchName: "ABC-123_Fix-Broken-Model-Relationships_Author_Name",
+        worktreeSlug: "git-valid-branch-name",
+        baseBranch: "main",
+      },
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.workspace?.gitRuntime?.currentBranch).toBe(
+      "ABC-123_Fix-Broken-Model-Relationships_Author_Name",
+    );
+    expect(path.basename(result.workspace?.workspaceDirectory ?? "")).toBe("git-valid-branch-name");
+  } finally {
+    await client.close().catch(() => undefined);
+    await daemon.close();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}, 180000);
+
 test("workspace.create always creates a new worktree when the slug is already occupied", async () => {
   const daemon = await createTestPaseoDaemon();
   const { repoDir, tempRoot } = createGitRepoWithBranch();

--- a/packages/server/src/server/worktree-core.ts
+++ b/packages/server/src/server/worktree-core.ts
@@ -62,9 +62,7 @@ async function createWorktreeCoreWithPriority(
   const requestedWorktreeSlug = input.worktreeSlug
     ? normalizeWorktreeSlug(input.worktreeSlug)
     : undefined;
-  const requestedBranchName = input.branchName
-    ? validateWorktreeSlug(input.branchName.trim())
-    : undefined;
+  const requestedBranchName = input.branchName?.trim();
 
   let intentInput: ResolveWorktreeCreationIntentInput;
   if (input.action === "checkout") {

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -655,15 +655,15 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       ).rejects.toThrow("Base branch not found: does-not-exist");
     });
 
-    it("fails with invalid branch name", async () => {
+    it("fails with a Git-invalid branch name", async () => {
       await expect(
         createLegacyWorktreeForTest({
-          branchName: "INVALID_UPPERCASE",
+          branchName: "bad..name",
           cwd: repoDir,
           baseBranch: "main",
           worktreeSlug: "test",
         }),
-      ).rejects.toThrow("Invalid branch name");
+      ).rejects.toThrow("Git rejected ref name 'bad..name'");
     });
 
     it("throws a typed error when checking out an invalid existing branch name", async () => {

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -42,7 +42,6 @@ import { spawnProcess } from "./spawn.js";
 import { resolvePaseoHome } from "../server/paseo-home.js";
 import { createExternalProcessEnv } from "../server/paseo-env.js";
 import { parseGitRevParsePath, resolveGitRevParsePath } from "./git-rev-parse-path.js";
-import { validateBranchSlug } from "@getpaseo/protocol/branch-slug";
 import { expandTilde, getRealpathAwareRelativePath, isPathInsideRoot } from "./path.js";
 import { terminateWithTreeKill } from "./tree-kill.js";
 
@@ -1310,7 +1309,7 @@ async function resolveWorktreeSourcePlan({
   switch (source.kind) {
     case "branch-off": {
       const branchName = source.branchName;
-      validateWorktreeBranchName(branchName);
+      await validateGitBranchName(cwd, branchName);
       const normalizedBaseBranch = normalizeRequiredBaseBranch(source.baseBranch);
       const resolvedBaseBranch = await resolveBaseBranchForWorktree(cwd, source.baseBranch);
       const branchExists = await localBranchExists(cwd, branchName);
@@ -1330,7 +1329,7 @@ async function resolveWorktreeSourcePlan({
       };
     }
     case "checkout-branch": {
-      await validateExistingWorktreeBranchName(cwd, source.branchName);
+      await validateGitBranchName(cwd, source.branchName);
       if (!(await localBranchExists(cwd, source.branchName))) {
         try {
           await runGitCommand(["fetch", "origin", `${source.branchName}:${source.branchName}`], {
@@ -1367,7 +1366,7 @@ async function resolveWorktreeSourcePlan({
     case "checkout-change-request":
     case "checkout-github-pr": {
       const localBranchCandidate = source.localBranchName ?? source.headRef;
-      await validateExistingWorktreeBranchName(cwd, localBranchCandidate);
+      await validateGitBranchName(cwd, localBranchCandidate);
       const localBranchName = await resolveUniqueLocalBranchName(cwd, localBranchCandidate);
       const normalizedBaseRefName = normalizeRequiredBaseBranch(source.baseRefName);
       const changeRequestNumber =
@@ -1589,14 +1588,7 @@ async function configureWorktreeTrackingRemote(options: {
   );
 }
 
-function validateWorktreeBranchName(branchName: string): void {
-  const validation = validateBranchSlug(branchName);
-  if (!validation.valid) {
-    throw new Error(`Invalid branch name: ${validation.error}`);
-  }
-}
-
-async function validateExistingWorktreeBranchName(cwd: string, branchName: string): Promise<void> {
+async function validateGitBranchName(cwd: string, branchName: string): Promise<void> {
   const result = await runGitCommand(["check-ref-format", "--branch", branchName], {
     cwd,
     timeout: 30_000,


### PR DESCRIPTION
Worktree-backed workspace creation now preserves Git-valid branch names containing uppercase letters, underscores, dots, and other ref-safe characters. The filesystem directory remains governed separately by the restricted worktree slug.

### Linked issue

Refs #2624

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The workspace creation protocol carries branchName and worktreeSlug as separate facts, but branch-off creation validated both with the filesystem slug rules. That rejected valid Git refs before Git was called. Branch validity now has one owner: the worktree operation asks Git to validate every new or existing branch ref, while worktree paths retain the stricter slug validation.

### Goals

- Preserve an explicit Git-valid branch name during branch-off workspace creation.
- Keep worktree directory slugs restricted and independent from branch refs.
- Reject branch names that Git itself rejects.
- Cover the public workspace.create flow through a real daemon.

### Non-goals

- Change worktree directory naming rules.
- Add or change branch-name controls in the app.
- Complete the legacy CLI separation tracked by #2624.

### QA

Red reproduction before the fix:

    npx vitest run packages/server/src/server/workspace-create-worktree-source.e2e.test.ts -t "accepts a Git-valid branch-off name outside Paseo slug syntax" --bail=1

Observed the real daemon return:

    Invalid worktree name: Branch name must contain only lowercase letters, numbers, hyphens, and forward slashes

Green verification after the fix:

    npx vitest run packages/server/src/server/workspace-create-worktree-source.e2e.test.ts --bail=1
    Test Files  1 passed (1)
    Tests       6 passed (6)

    npx vitest run packages/server/src/utils/worktree.posix.test.ts --bail=1
    Test Files  1 passed (1)
    Tests       46 passed | 1 skipped (47)

    npm run typecheck
    passed

    npm run lint
    Found 0 warnings and 0 errors

    npm run format
    passed

Tested on macOS with real temporary Git repositories and an isolated real daemon. No UI surface changed.

### Risk surface

The change affects server-side branch validation for new Paseo-owned worktrees. Existing checkout and change-request paths already used the same Git-native validator; invalid Git refs remain rejected, and worktree filesystem paths still use the existing slug rules.

### Checklist

- [x] One focused change
- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run format passes
- [x] QA evidence
- [x] Tests added or updated where it made sense