### PR TITLE
fix(server): show Claude usage again on macOS

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -145,8 +145,6 @@ Kimi Code usage follows the CLI-managed credential file at `KIMI_CODE_HOME` or `
 
 Cursor usage reads the desktop `state.vscdb` token first, then `cursor-agent`'s `~/.config/cursor/auth.json`. Headless hosts only have the CLI file.
 
-Claude usage reads `~/.claude/.credentials.json` first, then the macOS Keychain. Name the account when you look the Keychain up: several items share the `Claude Code-credentials` service, one per account convention Claude Code has used over time, and a lookup without an account returns the oldest of them, whose token expired long ago. Claude Code derives that account from `$USER`, falling back to `claude-code-user` when the username carries a character a Keychain account may not — every email-shaped corporate login does.
-
 ---
 
 ## ACP Provider Checklist

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -145,6 +145,8 @@ Kimi Code usage follows the CLI-managed credential file at `KIMI_CODE_HOME` or `
 
 Cursor usage reads the desktop `state.vscdb` token first, then `cursor-agent`'s `~/.config/cursor/auth.json`. Headless hosts only have the CLI file.
 
+Claude usage reads `~/.claude/.credentials.json` first, then the macOS Keychain. Name the account when you look the Keychain up: several items share the `Claude Code-credentials` service, one per account convention Claude Code has used over time, and a lookup without an account returns the oldest of them, whose token expired long ago. Claude Code derives that account from `$USER`, falling back to `claude-code-user` when the username carries a character a Keychain account may not — every email-shaped corporate login does.
+
 ---
 
 ## ACP Provider Checklist

--- a/packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts
@@ -14,7 +14,17 @@ describe("claudeKeychainAccount", () => {
   // Corporate logins are email addresses, and "@" fails Claude Code's pattern. This is
   // the case that produced the bug: the account is not the username here.
   it("falls back to claude-code-user when the username carries a rejected character", () => {
-    expect(claudeKeychainAccount("thomas.benoit@yousign.com")).toBe("claude-code-user");
+    expect(claudeKeychainAccount("first.last@example.com")).toBe("claude-code-user");
+  });
+
+  // The provider never passes an account, so the default is the only path that runs in
+  // production. Without this, the wiring between $USER and the lookup is untested.
+  it("reads the username from $USER when no account is given", () => {
+    vi.stubEnv("USER", "ci-runner");
+    expect(claudeKeychainAccount()).toBe("ci-runner");
+
+    vi.stubEnv("USER", "first.last@example.com");
+    expect(claudeKeychainAccount()).toBe("claude-code-user");
   });
 });
 
@@ -53,6 +63,22 @@ describe("readClaudeKeychainCredentials", () => {
     expect(run).toHaveBeenNthCalledWith(2, ["find-generic-password", "-w", "-s", SERVICE]);
   });
 
+  // An item can parse and still be useless: a partially written or signed-out blob carries
+  // no access token. Returning it would strand a working legacy item behind it, which is
+  // worse than the bug this lookup exists to fix — that user sees usage today.
+  it("falls through when the account item carries no access token", async () => {
+    const run = vi.fn(async (args: string[]) =>
+      args.includes("-a")
+        ? JSON.stringify({ claudeAiOauth: { subscriptionType: "team" } })
+        : JSON.stringify({ claudeAiOauth: { accessToken: "at_legacy" } }),
+    );
+
+    const credentials = await readClaudeKeychainCredentials(run, "claude-code-user");
+
+    expect(credentials).toEqual({ claudeAiOauth: { accessToken: "at_legacy" } });
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
   it("is null when the Keychain holds no item at all", async () => {
     const run = vi.fn(async () => null);
 
@@ -62,11 +88,13 @@ describe("readClaudeKeychainCredentials", () => {
   // A truncated or non-JSON blob must not shadow an item a later lookup could still read.
   it("tries the next lookup when the item does not parse", async () => {
     const run = vi.fn(async (args: string[]) =>
-      args.includes("-a") ? "not-json" : JSON.stringify({ claudeAiOauth: {} }),
+      args.includes("-a")
+        ? "not-json"
+        : JSON.stringify({ claudeAiOauth: { accessToken: "at_legacy" } }),
     );
 
     expect(await readClaudeKeychainCredentials(run, "claude-code-user")).toEqual({
-      claudeAiOauth: {},
+      claudeAiOauth: { accessToken: "at_legacy" },
     });
   });
 });

--- a/packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts
@@ -1,24 +1,21 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { claudeKeychainAccount, readClaudeKeychainCredentials } from "./claude.js";
 
 const SERVICE = "Claude Code-credentials";
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("claudeKeychainAccount", () => {
-  // Claude Code derives the Keychain account from $USER, but only accepts the characters
-  // a Keychain account may carry. Paseo has to reproduce the derivation exactly or it
-  // looks up an account nothing was ever written under.
-  it("uses the username when the Keychain accepts it verbatim", () => {
+  it("uses a supported username verbatim", () => {
     expect(claudeKeychainAccount("thomas.benoit")).toBe("thomas.benoit");
   });
 
-  // Corporate logins are email addresses, and "@" fails Claude Code's pattern. This is
-  // the case that produced the bug: the account is not the username here.
   it("falls back to claude-code-user when the username carries a rejected character", () => {
     expect(claudeKeychainAccount("first.last@example.com")).toBe("claude-code-user");
   });
 
-  // The provider never passes an account, so the default is the only path that runs in
-  // production. Without this, the wiring between $USER and the lookup is untested.
   it("reads the username from $USER when no account is given", () => {
     vi.stubEnv("USER", "ci-runner");
     expect(claudeKeychainAccount()).toBe("ci-runner");
@@ -29,10 +26,6 @@ describe("claudeKeychainAccount", () => {
 });
 
 describe("readClaudeKeychainCredentials", () => {
-  // The regression this guards: several items share the service name, one per account
-  // convention Claude Code has used over time. A lookup without "-a" returns whichever
-  // one the Keychain finds first — in practice the oldest, whose token expired months
-  // ago. Naming the account is what selects the item Claude Code actually writes.
   it("looks the item up by account and stops there when it exists", async () => {
     const run = vi.fn(async () => JSON.stringify({ claudeAiOauth: { accessToken: "at_fresh" } }));
 
@@ -50,8 +43,6 @@ describe("readClaudeKeychainCredentials", () => {
     ]);
   });
 
-  // Claude Code versions before the account convention wrote the item with no account we
-  // can predict, so the account-less lookup stays as a fallback — but only as one.
   it("falls back to the account-less lookup when no item matches the account", async () => {
     const run = vi.fn(async (args: string[]) =>
       args.includes("-a") ? null : JSON.stringify({ claudeAiOauth: { accessToken: "at_legacy" } }),
@@ -63,9 +54,6 @@ describe("readClaudeKeychainCredentials", () => {
     expect(run).toHaveBeenNthCalledWith(2, ["find-generic-password", "-w", "-s", SERVICE]);
   });
 
-  // An item can parse and still be useless: a partially written or signed-out blob carries
-  // no access token. Returning it would strand a working legacy item behind it, which is
-  // worse than the bug this lookup exists to fix — that user sees usage today.
   it("falls through when the account item carries no access token", async () => {
     const run = vi.fn(async (args: string[]) =>
       args.includes("-a")
@@ -85,7 +73,6 @@ describe("readClaudeKeychainCredentials", () => {
     expect(await readClaudeKeychainCredentials(run, "claude-code-user")).toBeNull();
   });
 
-  // A truncated or non-JSON blob must not shadow an item a later lookup could still read.
   it("tries the next lookup when the item does not parse", async () => {
     const run = vi.fn(async (args: string[]) =>
       args.includes("-a")

--- a/packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { claudeKeychainAccount, readClaudeKeychainCredentials } from "./claude.js";
+
+const SERVICE = "Claude Code-credentials";
+
+describe("claudeKeychainAccount", () => {
+  // Claude Code derives the Keychain account from $USER, but only accepts the characters
+  // a Keychain account may carry. Paseo has to reproduce the derivation exactly or it
+  // looks up an account nothing was ever written under.
+  it("uses the username when the Keychain accepts it verbatim", () => {
+    expect(claudeKeychainAccount("thomas.benoit")).toBe("thomas.benoit");
+  });
+
+  // Corporate logins are email addresses, and "@" fails Claude Code's pattern. This is
+  // the case that produced the bug: the account is not the username here.
+  it("falls back to claude-code-user when the username carries a rejected character", () => {
+    expect(claudeKeychainAccount("thomas.benoit@yousign.com")).toBe("claude-code-user");
+  });
+});
+
+describe("readClaudeKeychainCredentials", () => {
+  // The regression this guards: several items share the service name, one per account
+  // convention Claude Code has used over time. A lookup without "-a" returns whichever
+  // one the Keychain finds first — in practice the oldest, whose token expired months
+  // ago. Naming the account is what selects the item Claude Code actually writes.
+  it("looks the item up by account and stops there when it exists", async () => {
+    const run = vi.fn(async () => JSON.stringify({ claudeAiOauth: { accessToken: "at_fresh" } }));
+
+    const credentials = await readClaudeKeychainCredentials(run, "claude-code-user");
+
+    expect(credentials).toEqual({ claudeAiOauth: { accessToken: "at_fresh" } });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith([
+      "find-generic-password",
+      "-a",
+      "claude-code-user",
+      "-w",
+      "-s",
+      SERVICE,
+    ]);
+  });
+
+  // Claude Code versions before the account convention wrote the item with no account we
+  // can predict, so the account-less lookup stays as a fallback — but only as one.
+  it("falls back to the account-less lookup when no item matches the account", async () => {
+    const run = vi.fn(async (args: string[]) =>
+      args.includes("-a") ? null : JSON.stringify({ claudeAiOauth: { accessToken: "at_legacy" } }),
+    );
+
+    const credentials = await readClaudeKeychainCredentials(run, "claude-code-user");
+
+    expect(credentials).toEqual({ claudeAiOauth: { accessToken: "at_legacy" } });
+    expect(run).toHaveBeenNthCalledWith(2, ["find-generic-password", "-w", "-s", SERVICE]);
+  });
+
+  it("is null when the Keychain holds no item at all", async () => {
+    const run = vi.fn(async () => null);
+
+    expect(await readClaudeKeychainCredentials(run, "claude-code-user")).toBeNull();
+  });
+
+  // A truncated or non-JSON blob must not shadow an item a later lookup could still read.
+  it("tries the next lookup when the item does not parse", async () => {
+    const run = vi.fn(async (args: string[]) =>
+      args.includes("-a") ? "not-json" : JSON.stringify({ claudeAiOauth: {} }),
+    );
+
+    expect(await readClaudeKeychainCredentials(run, "claude-code-user")).toEqual({
+      claudeAiOauth: {},
+    });
+  });
+});

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -297,12 +297,9 @@ function scopedWindows(limits: ScopedLimit[]): ProviderUsageWindow[] {
   });
 }
 
-export type ClaudeKeychainCommandRunner = (args: string[]) => Promise<string | null>;
+type ClaudeKeychainCommandRunner = (args: string[]) => Promise<string | null>;
 
-// Claude Code derives the Keychain account from $USER and falls back when the username
-// carries a character a Keychain account may not, which every email-shaped corporate
-// login does. Reproduce the derivation rather than guessing: the account is the only
-// thing that tells its item apart from the ones older versions left behind.
+// Keep this in sync with Claude Code's Keychain account derivation.
 const CLAUDE_KEYCHAIN_ACCOUNT_PATTERN = /^[a-zA-Z0-9._-]+$/;
 const CLAUDE_KEYCHAIN_FALLBACK_ACCOUNT = "claude-code-user";
 
@@ -323,21 +320,7 @@ async function runSecurityCommand(args: string[]): Promise<string | null> {
   }
 }
 
-/**
- * The Claude Code credentials, from the item Claude Code writes rather than whichever
- * item the Keychain happens to find first.
- *
- * Several items share this service name — one per account convention Claude Code has
- * used over time — and a lookup that names no account returns the first match, which is
- * the oldest and whose token expired long ago. Naming the account selects the live item;
- * the account-less lookup stays behind it for versions that predate the convention.
- *
- * A lookup counts as a hit only when its item carries an access token. Parsing is not
- * enough: a partially written or signed-out blob parses fine, and returning it would
- * strand a working item behind it — leaving a user whose usage works today without any,
- * which is worse than the bug this ordering exists to fix. Deciding usability is the
- * selector's job precisely because it is what tells it whether to keep looking.
- */
+/** Read Claude Code's account-specific Keychain item, then try the legacy lookup. */
 export async function readClaudeKeychainCredentials(
   run: ClaudeKeychainCommandRunner = runSecurityCommand,
   account: string = claudeKeychainAccount(),

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync, promises as fs } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { Logger } from "pino";
@@ -297,19 +297,60 @@ function scopedWindows(limits: ScopedLimit[]): ProviderUsageWindow[] {
   });
 }
 
-async function readClaudeKeychainCredentials(): Promise<unknown | null> {
+export type ClaudeKeychainCommandRunner = (args: string[]) => Promise<string | null>;
+
+// Claude Code derives the Keychain account from $USER and falls back when the username
+// carries a character a Keychain account may not, which every email-shaped corporate
+// login does. Reproduce the derivation rather than guessing: the account is the only
+// thing that tells its item apart from the ones older versions left behind.
+const CLAUDE_KEYCHAIN_ACCOUNT_PATTERN = /^[a-zA-Z0-9._-]+$/;
+const CLAUDE_KEYCHAIN_FALLBACK_ACCOUNT = "claude-code-user";
+
+export function claudeKeychainAccount(
+  user: string = process.env["USER"] || userInfo().username,
+): string {
+  return CLAUDE_KEYCHAIN_ACCOUNT_PATTERN.test(user) ? user : CLAUDE_KEYCHAIN_FALLBACK_ACCOUNT;
+}
+
+async function runSecurityCommand(args: string[]): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync(
-      "security",
-      ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"],
-      { timeout: CLAUDE_KEYCHAIN_TIMEOUT_MS },
-    );
-    const raw = stdout.trim();
-    if (!raw) return null;
-    return JSON.parse(raw);
+    const { stdout } = await execFileAsync("security", args, {
+      timeout: CLAUDE_KEYCHAIN_TIMEOUT_MS,
+    });
+    return stdout.trim() || null;
   } catch {
     return null;
   }
+}
+
+/**
+ * The Claude Code credentials, from the item Claude Code writes rather than whichever
+ * item the Keychain happens to find first.
+ *
+ * Several items share this service name — one per account convention Claude Code has
+ * used over time — and a lookup that names no account returns the first match, which is
+ * the oldest and whose token expired long ago. Naming the account selects the live item;
+ * the account-less lookup stays behind it for versions that predate the convention.
+ */
+export async function readClaudeKeychainCredentials(
+  run: ClaudeKeychainCommandRunner = runSecurityCommand,
+  account: string = claudeKeychainAccount(),
+): Promise<unknown | null> {
+  const lookups = [
+    ["find-generic-password", "-a", account, "-w", "-s", CLAUDE_KEYCHAIN_SERVICE],
+    ["find-generic-password", "-w", "-s", CLAUDE_KEYCHAIN_SERVICE],
+  ];
+
+  for (const args of lookups) {
+    const raw = await run(args);
+    if (!raw) continue;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // Unparseable blob: keep going, a later lookup may still hold a readable item.
+    }
+  }
+  return null;
 }
 
 export class ClaudeQuotaProvider implements ProviderUsageFetcher {

--- a/packages/server/src/services/quota-fetcher/providers/claude.ts
+++ b/packages/server/src/services/quota-fetcher/providers/claude.ts
@@ -331,6 +331,12 @@ async function runSecurityCommand(args: string[]): Promise<string | null> {
  * used over time — and a lookup that names no account returns the first match, which is
  * the oldest and whose token expired long ago. Naming the account selects the live item;
  * the account-less lookup stays behind it for versions that predate the convention.
+ *
+ * A lookup counts as a hit only when its item carries an access token. Parsing is not
+ * enough: a partially written or signed-out blob parses fine, and returning it would
+ * strand a working item behind it — leaving a user whose usage works today without any,
+ * which is worse than the bug this ordering exists to fix. Deciding usability is the
+ * selector's job precisely because it is what tells it whether to keep looking.
  */
 export async function readClaudeKeychainCredentials(
   run: ClaudeKeychainCommandRunner = runSecurityCommand,
@@ -344,11 +350,14 @@ export async function readClaudeKeychainCredentials(
   for (const args of lookups) {
     const raw = await run(args);
     if (!raw) continue;
+    let parsed: unknown;
     try {
-      return JSON.parse(raw);
+      parsed = JSON.parse(raw);
     } catch {
-      // Unparseable blob: keep going, a later lookup may still hold a readable item.
+      continue;
     }
+    const creds = ClaudeCredentialsSchema.safeParse(parsed);
+    if (creds.success && creds.data.claudeAiOauth?.accessToken) return parsed;
   }
   return null;
 }


### PR DESCRIPTION
### Linked issue

Closes #3595

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

On macOS the Claude usage card has been stuck on a blank `Unavailable` for anyone whose Keychain holds more than one `Claude Code-credentials` item.

The daemon looked the Keychain up by service only:

```
security find-generic-password -s "Claude Code-credentials" -w
```

Claude Code has used more than one account convention over time, so several items share that service, and a lookup that names no account returns whichever the Keychain finds first — the oldest. On my machine that item was last written 2026-04-28 and its token expired the next day, so every usage fetch got a 401 while Claude Code itself kept working.

Claude Code names the account on its own lookups, deriving it from `$USER` and falling back to `claude-code-user` when the username carries a character a Keychain account may not accept. Every email-shaped corporate login hits that fallback. This reproduces that derivation so the daemon reads the item Claude Code actually writes, and keeps the account-less lookup behind it for installs that predate the convention.

### Goals

- The Keychain lookup selects the item Claude Code writes, by account
- Installs predating the account convention keep working through the account-less lookup
- The real lookup gets test coverage: it had none, because the provider's test seam always injected `claudeKeychainReader`, so the argv handed to `security` was never asserted

### Non-goals

- **Reporting an expired sign-in in the UI.** All four give-up paths still return a blank `Unavailable` with `error: null`, and nothing is logged at `info` — that silence is why this took months to notice. #3474 is already open on exactly that surface and separates 401 from 403 there, so I left it alone rather than land a conflicting change.
- **Honouring `CLAUDE_CONFIG_DIR`.** Claude Code namespaces the Keychain service with a hash of the config dir, so a non-default config dir is missed entirely. That is #3589, and it needs a per-provider resolution rather than a global one.
- **Refreshing Keychain-sourced tokens.** Paseo cannot write the Keychain back, and refreshing rotates the refresh token, which would sign Claude Code itself out. Unchanged here, including its test.
- Routed-account setups such as #3228, where the running agent and the local credentials are different identities.
- Any other provider's credential handling.

### QA

**Automated**

New `packages/server/src/services/quota-fetcher/providers/claude-keychain.test.ts`, six tests over the account derivation and the lookup order. The one that carries the regression asserts that a successful account lookup does **not** fall through to the account-less one — that fall-through is the bug. On the old code the same assertions fail on the argv, which never contained `-a`.

No existing test changed.

```
$ npx vitest run src/services/quota-fetcher/
PASS (91) FAIL (0)          # 85 before this branch, +6

$ npm run typecheck
0 errors

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.
```

**Evidence for the diagnosis** — Keychain attributes only, no secrets read:

| account | created | last modified |
| --- | --- | --- |
| `claude-code-user` | 2026-04-28 09:04 | 2026-08-19 08:47 |
| `<my-unix-username>` | 2026-02-05 14:05 | 2026-04-28 16:10 |
| lookup without `-a` | — | returns the frozen one |

`GET /api/oauth/usage` with the token behind the account-less lookup: **401**. With the token from the `claude-code-user` item: **200**.

The frozen item's last write (2026-04-28 16:10) sits ten hours before its `expiresAt` (2026-04-29 02:10) — written once more, then abandoned. Claude Code created the `claude-code-user` item earlier the same day.

**Manual**

Ran the real fetcher against the live Keychain and API from a checkout-local daemon:

```
account resolved : claude-code-user
status           : available
planLabel        : Team 5x
windows          : 3
  - Session         30.0%   resets 2026-08-19T16:59:59Z
  - Weekly          26.0%   resets 2026-08-20T16:59:59Z
  - Weekly · Fable   0.0%
```

Then in the app, on a dev daemon built from this branch: Settings → Host → Provider usage shows the Claude card with its bars.

**Before** — packaged 0.4.0 build, still on the old code: the Claude card reads `Unavailable`, no bars, no message.

<img width="242" height="220" alt="paseo_claude_unavailabe_1" src="https://github.com/user-attachments/assets/684e57f3-25bb-4baf-aafa-94870c0e4faa" />
<img width="725" height="171" alt="paseo_claude_unavailable_2" src="https://github.com/user-attachments/assets/983f5c9f-5c18-4935-94c2-496d15c6dfbc" />


**After** — dev daemon built from this branch: the card reads the item Claude Code actually writes and shows its windows.

<img width="234" height="354" alt="paseo_claude_usage_1" src="https://github.com/user-attachments/assets/4623904d-5d41-4e74-88fb-02a50fbc44e1" />
<img width="721" height="313" alt="paseo_claude_usage_2" src="https://github.com/user-attachments/assets/b2d5958b-64be-4520-a700-4c39e3506580" />

**Platforms**

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | no | client-side only, unaffected |
| Android | no | client-side only, unaffected |
| Web | no | client-side only, unaffected |
| Desktop macOS | yes | where the change lives — the Keychain path is behind a `darwin` gate |
| Desktop Windows | no | no Keychain path; `server-tests (windows-latest)` covers the suite |
| Desktop Linux | no | no Keychain path; credentials come from the file source, untouched |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense

