### PR TITLE
feat(plugin): let a plugin's server contribute() push events to its own panel

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,6 +251,7 @@ New session RPCs use dotted names with `.request` and `.response` suffixes, such
 - `agent_permission_request` / `agent_permission_resolved` — Tool-call permission flow
 - `agent_deleted`, `agent_archived`, `agent_status`, `agent_list`
 - `checkout_status_update`, `checkout_diff_update`, and the full `checkout_*` request/response set for git operations
+- `plugin.event` — one-way push from a plugin's server `contribute()` to its client surfaces; see [plugins.md](plugins.md#events)
 
 Agent snapshots optionally carry the daemon-owned active turn identity, and turn lifecycle stream events
 optionally carry the same `turnId`. New clients use these fields when present and normalize an old daemon's

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -171,6 +171,32 @@ They use typed plugin RPC only for plugin-specific backend work. Navigation is l
 plugin's registered global surfaces and workspace panels; plugins do not receive Expo Router or
 workspace-layout store access.
 
+## Events
+
+A server-target `contribute()` pushes one-way events to its own client surfaces with
+`plugin.emit(eventName, data)`. Client code reads them with `useEvent(eventName, handler)` from
+`@getpaseo/plugin`. Use this for data a panel didn't ask for — a poll loop, a webhook, a timer —
+not as a replacement for RPC request/response.
+
+```ts
+// index.ts (server contribute)
+export default function contribute(plugin: PluginContext) {
+  const stop = pollUpstream((update) => plugin.emit("roster.updated", update));
+  return () => stop();
+}
+```
+
+```tsx
+// panel.client.tsx
+useEvent("roster.updated", (data) => setRoster(data as Roster));
+```
+
+The daemon forwards `plugin.emit` to every connected client, the same way it pushes
+`agent_update`/`workspace_update` (see [architecture.md](architecture.md#websocket-protocol)). Unlike
+those, scoping happens on the client: the app runtime binds each plugin surface to its own plugin ID
+and drops any event whose `pluginId` doesn't match before `useEvent` sees it. There is no API
+that lets one plugin's client code address another plugin's events.
+
 ## Contribute composer attachments
 
 Register a declarative attachment source backed by a plugin RPC. Paseo owns the attachment menu,

--- a/packages/app/src/plugins/command-center/contributions.test.ts
+++ b/packages/app/src/plugins/command-center/contributions.test.ts
@@ -128,6 +128,7 @@ function createRuntime(pluginId: string) {
       expect(method).toBe("review.inspect");
       return { value: inspect.input.parse(input).value + 1 };
     },
+    on: () => () => {},
   };
 }
 

--- a/packages/app/src/plugins/evaluate.ts
+++ b/packages/app/src/plugins/evaluate.ts
@@ -18,6 +18,7 @@ import {
   useAgent,
   useWorkspace,
   useRpc,
+  useEvent,
 } from "@getpaseo/plugin";
 import { createPluginContext, type PluginRegistrationCollector } from "@getpaseo/plugin/host";
 import type { EvaluatedPlugin } from "./types";
@@ -168,6 +169,7 @@ export function evaluatePluginClientBundle(id: string, bundle: string): Evaluate
         useAgent,
         useWorkspace,
         useRpc,
+        useEvent,
       };
     }
     if (name === "@getpaseo/plugin/server") {

--- a/packages/app/src/plugins/runtime-boundary.tsx
+++ b/packages/app/src/plugins/runtime-boundary.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { PaseoApiProvider, PluginRpcProvider } from "@getpaseo/plugin/host";
+import { PaseoApiProvider, PluginEventProvider, PluginRpcProvider } from "@getpaseo/plugin/host";
 import type { ReactNode } from "react";
 import type { InstalledPlugin } from "./types";
 import type { PluginSurfaceRuntime } from "./surface-runtime";
@@ -16,7 +16,9 @@ export function PluginRuntimeBoundary({
   return (
     <QueryClientProvider client={plugin.queryClient}>
       <PaseoApiProvider paseo={runtime.paseo}>
-        <PluginRpcProvider invoke={runtime.invoke}>{children}</PluginRpcProvider>
+        <PluginRpcProvider invoke={runtime.invoke}>
+          <PluginEventProvider on={runtime.on}>{children}</PluginEventProvider>
+        </PluginRpcProvider>
       </PaseoApiProvider>
     </QueryClientProvider>
   );

--- a/packages/app/src/plugins/surface-runtime.ts
+++ b/packages/app/src/plugins/surface-runtime.ts
@@ -4,6 +4,7 @@ import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 export interface PluginSurfaceRuntime {
   paseo: PaseoApi;
   invoke(method: string, input: unknown): Promise<unknown>;
+  on(eventName: string, handler: (data: unknown) => void): () => void;
 }
 
 export function createPluginSurfaceRuntime(
@@ -14,5 +15,11 @@ export function createPluginSurfaceRuntime(
   return {
     paseo: createPaseoApi(client),
     invoke: (method, input) => client.invokePluginRpc(pluginId, method, input),
+    on: (eventName, handler) =>
+      client.subscribe((event) => {
+        if (event.type !== "plugin_event") return;
+        if (event.pluginId !== pluginId || event.eventName !== eventName) return;
+        handler(event.data);
+      }),
   };
 }

--- a/packages/cli/src/commands/plugin/scaffold.ts
+++ b/packages/cli/src/commands/plugin/scaffold.ts
@@ -216,6 +216,14 @@ declare module "@getpaseo/plugin" {
         context: PluginHandlerContext,
       ) => ZodInput<OutputSchema> | Promise<ZodInput<OutputSchema>>,
     ): void;
+    /**
+     * Pushes a one-way event to every panel this plugin has open, delivered to
+     * \`useEvent(eventName, handler)\` on the client. Unlike \`handle\`, this has no
+     * caller waiting for a reply — call it whenever the plugin backend has new
+     * data a panel didn't ask for (e.g. a poll loop, a webhook, a timer).
+     * Server-target only, like \`handle\`.
+     */
+    emit(eventName: string, data: unknown): void;
     addSurface(id: string, Component: ComponentType<PluginSurfaceProps>): void;
     addSidebarItem(contribution: PluginSidebarContribution): void;
     addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;
@@ -242,6 +250,9 @@ declare module "@getpaseo/plugin" {
     agentId: string,
     selector: (agent: PluginAgentSnapshot) => Selection,
   ): Selection | null;
+
+  /** Subscribes to context.emit(eventName, data) calls from this plugin's server-target contribute(). */
+  export function useEvent(eventName: string, handler: (data: unknown) => void): void;
 }
 `;
 

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -298,6 +298,7 @@ export type DaemonEvent =
       type: "providers_snapshot_update";
       payload: Extract<SessionOutboundMessage, { type: "providers_snapshot_update" }>["payload"];
     }
+  | { type: "plugin_event"; pluginId: string; eventName: string; data: unknown }
   | { type: "error"; message: string };
 
 export type DaemonEventHandler = (event: DaemonEvent) => void;
@@ -6128,6 +6129,13 @@ export class DaemonClient {
         return {
           type: "providers_snapshot_update",
           payload: msg.payload,
+        };
+      case "plugin.event":
+        return {
+          type: "plugin_event",
+          pluginId: msg.payload.pluginId,
+          eventName: msg.payload.eventName,
+          data: msg.payload.data,
         };
       default:
         return null;

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -193,7 +193,7 @@ export interface PluginContext {
    * `useEvent(eventName, handler)` on the client. Unlike `handle`, this has no
    * caller waiting for a reply — call it whenever the plugin backend has new
    * data a panel didn't ask for (e.g. a poll loop, a webhook, a timer).
-   * Server-target only, mirroring `handle`'s client-target-only restriction.
+   * Server-target only, like `handle`.
    */
   emit(eventName: string, data: unknown): void;
   addSurface(id: string, Component: ComponentType<PluginSurfaceProps>): void;

--- a/packages/plugin/src/contracts.ts
+++ b/packages/plugin/src/contracts.ts
@@ -188,6 +188,14 @@ export interface PluginContext {
       context: PluginHandlerContext,
     ) => ZodInput<OutputSchema> | Promise<ZodInput<OutputSchema>>,
   ): void;
+  /**
+   * Pushes a one-way event to every panel this plugin has open, delivered to
+   * `useEvent(eventName, handler)` on the client. Unlike `handle`, this has no
+   * caller waiting for a reply — call it whenever the plugin backend has new
+   * data a panel didn't ask for (e.g. a poll loop, a webhook, a timer).
+   * Server-target only, mirroring `handle`'s client-target-only restriction.
+   */
+  emit(eventName: string, data: unknown): void;
   addSurface(id: string, Component: ComponentType<PluginSurfaceProps>): void;
   addSidebarItem(contribution: PluginSidebarContribution): void;
   addWorkspacePanel(contribution: PluginWorkspacePanelContribution): void;

--- a/packages/plugin/src/event-context.tsx
+++ b/packages/plugin/src/event-context.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from "react";
+
+interface PluginEventContextValue {
+  on(eventName: string, handler: (data: unknown) => void): () => void;
+}
+
+const PluginEventContext = createContext<PluginEventContextValue | null>(null);
+
+export function PluginEventProvider({
+  children,
+  on,
+}: {
+  children: ReactNode;
+  on(eventName: string, handler: (data: unknown) => void): () => void;
+}) {
+  // Memoized so useEvent's effect (keyed on this context object) doesn't tear down and
+  // re-subscribe on every render, which would drop any event that arrives in between.
+  const value = useMemo(() => ({ on }), [on]);
+  return <PluginEventContext.Provider value={value}>{children}</PluginEventContext.Provider>;
+}
+
+/**
+ * Subscribes to context.emit(eventName, data) calls from this plugin's server-target
+ * contribute(). The handler ref updates every render without resubscribing, so callers
+ * can pass an inline closure the same way they would to a plain useEffect.
+ */
+export function useEvent(eventName: string, handler: (data: unknown) => void): void {
+  const context = useContext(PluginEventContext);
+  if (!context) throw new Error("useEvent must run inside a contributed plugin surface");
+
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    return context.on(eventName, (data) => handlerRef.current(data));
+  }, [context, eventName]);
+}

--- a/packages/plugin/src/host.ts
+++ b/packages/plugin/src/host.ts
@@ -11,6 +11,7 @@ import type {
   PluginWorkspacePanelContribution,
 } from "./contracts.js";
 import { PluginRpcProvider } from "./rpc-context.js";
+import { PluginEventProvider } from "./event-context.js";
 import { PaseoApiProvider } from "./paseo-context.js";
 import { callPluginRpc } from "./rpc.js";
 import type { ComponentType } from "react";
@@ -75,4 +76,4 @@ export async function searchPluginAttachments(
   return PluginAttachmentSearchPayloadSchema.parseAsync(output);
 }
 
-export { callPluginRpc, PaseoApiProvider, PluginRpcProvider };
+export { callPluginRpc, PaseoApiProvider, PluginRpcProvider, PluginEventProvider };

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -34,3 +34,4 @@ export type {
 export { usePaseo } from "./paseo-context.js";
 export { useAgent, useWorkspace } from "./client-state.js";
 export { useRpc } from "./rpc-context.js";
+export { useEvent } from "./event-context.js";

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -6124,6 +6124,19 @@ export const PluginRpcInvokeResponseSchema = z.object({
   }),
 });
 
+// One-way push: a plugin's server-target contribute() called context.emit(eventName, data).
+// No matching request (this isn't RPC, hence "plugin.event" rather than "plugin.rpc.event")
+// — the daemon forwards it to every connected client the moment the plugin subprocess
+// reports it, the same way agent_update/workspace_update are pushed.
+export const PluginEventMessageSchema = z.object({
+  type: z.literal("plugin.event"),
+  payload: z.object({
+    pluginId: PluginIdSchema,
+    eventName: z.string().regex(/^[a-z][a-z0-9._-]*$/),
+    data: z.unknown(),
+  }),
+});
+
 function agentSkillsStatusResponse<const Type extends string>(type: Type) {
   return z.object({
     type: z.literal(type),
@@ -6170,6 +6183,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   PluginDisableResponseSchema,
   PluginRemoveResponseSchema,
   PluginRpcInvokeResponseSchema,
+  PluginEventMessageSchema,
   AgentSkillsGetStatusResponseSchema,
   AgentSkillsReconcileResponseSchema,
   AgentSkillsUninstallResponseSchema,

--- a/packages/server/src/server/plugins/compiler.ts
+++ b/packages/server/src/server/plugins/compiler.ts
@@ -74,8 +74,7 @@ interface SourceRange {
 }
 
 const REGISTRATIONS_REMOVED_BY_TARGET: Record<PluginBuildTarget, ReadonlySet<string>> = {
-  // "emit" is server-only (the subprocess pushes events out), same as "handle" is
-  // server-only-callable and stripped from the client build below it.
+  // handle and emit run only in the server subprocess.
   client: new Set(["handle", "emit"]),
   server: new Set([
     "addSurface",

--- a/packages/server/src/server/plugins/compiler.ts
+++ b/packages/server/src/server/plugins/compiler.ts
@@ -74,7 +74,9 @@ interface SourceRange {
 }
 
 const REGISTRATIONS_REMOVED_BY_TARGET: Record<PluginBuildTarget, ReadonlySet<string>> = {
-  client: new Set(["handle"]),
+  // "emit" is server-only (the subprocess pushes events out), same as "handle" is
+  // server-only-callable and stripped from the client build below it.
+  client: new Set(["handle", "emit"]),
   server: new Set([
     "addSurface",
     "addSidebarItem",

--- a/packages/server/src/server/plugins/index.ts
+++ b/packages/server/src/server/plugins/index.ts
@@ -19,6 +19,9 @@ interface PluginRuntimePort {
   stopPluginById(pluginId: string): Promise<boolean>;
   stopAll(): Promise<void>;
   subscribe(listener: (pluginId: string, error?: string) => void): () => void;
+  subscribeToEvents(
+    listener: (pluginId: string, eventName: string, data: unknown) => void,
+  ): () => void;
   bindPaseoSessionHost(sessionHost: Parameters<PluginRuntime["bindPaseoSessionHost"]>[0]): void;
 }
 
@@ -47,6 +50,13 @@ export class PluginService {
   subscribe(listener: (pluginId: string) => void): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
+  }
+
+  /** Passthrough — unlike subscribe() above, events carry no error/status bookkeeping. */
+  subscribeToEvents(
+    listener: (pluginId: string, eventName: string, data: unknown) => void,
+  ): () => void {
+    return this.runtime.subscribeToEvents(listener);
   }
 
   bindPaseoSessionHost(sessionHost: Parameters<PluginRuntime["bindPaseoSessionHost"]>[0]): void {

--- a/packages/server/src/server/plugins/plugin-process-protocol.ts
+++ b/packages/server/src/server/plugins/plugin-process-protocol.ts
@@ -10,5 +10,6 @@ export type PluginProcessMessage =
   | { type: "result"; requestId: string; output: unknown }
   | { type: "error"; requestId: string; error: string }
   | { type: "fatal"; error: string }
+  | { type: "plugin_event"; eventName: string; data: unknown }
   | { type: "paseo_frame"; data: string | Uint8Array; isBinary: boolean }
   | { type: "paseo_close" };

--- a/packages/server/src/server/plugins/plugin-process.ts
+++ b/packages/server/src/server/plugins/plugin-process.ts
@@ -62,6 +62,15 @@ function register(contract: PluginRpcContract, handler: RpcHandler): void {
   handlers.set(method, { contract: { ...contract, name: method }, handler });
 }
 
+const EVENT_NAME = /^[a-z][a-z0-9._-]*$/;
+
+function emitEvent(eventName: string, data: unknown): void {
+  if (!EVENT_NAME.test(eventName)) {
+    throw new Error(`Invalid plugin event name: ${eventName}`);
+  }
+  send({ type: "plugin_event", eventName, data });
+}
+
 const pluginAuthorRuntime = { defineAttachmentSource, defineRpc };
 
 function runtimeRequire(name: string): unknown {
@@ -79,7 +88,7 @@ function evaluateBundle(bundle: string): void {
   if (typeof setup !== "function") {
     throw new Error("Plugin server bundle must default export a function");
   }
-  const contributedCleanup = setup({ handle: register });
+  const contributedCleanup = setup({ handle: register, emit: emitEvent });
   if (typeof contributedCleanup !== "function") {
     throw new Error("Plugin contribution must return a cleanup function");
   }

--- a/packages/server/src/server/plugins/runtime.posix.test.ts
+++ b/packages/server/src/server/plugins/runtime.posix.test.ts
@@ -577,26 +577,34 @@ export default function contribute(plugin: PluginContext) {
     plugin.emit("pong", { echo: input.value, marker: "EMIT_PAYLOAD_MARKER" });
     return { ok: true };
   });
+  plugin.emit("boot", { phase: "contribute" });
   return () => undefined;
 }`,
     );
     const runtime = createTestRuntime();
+    const received: Array<[string, string, unknown]> = [];
+    const unsubscribe = runtime.subscribeToEvents((pluginId, eventName, data) => {
+      received.push([pluginId, eventName, data]);
+    });
+
     await runtime.startPlugin("ping-plugin", directory);
 
     // The client bundle must never see an emit() call execute: it strips the whole
     // statement the same way it strips handle() registrations from the client target.
     expect(runtime.catalog()[0]?.clientBundle).not.toContain("EMIT_PAYLOAD_MARKER");
 
-    const received: Array<[string, string, unknown]> = [];
-    const unsubscribe = runtime.subscribeToEvents((pluginId, eventName, data) => {
-      received.push([pluginId, eventName, data]);
-    });
+    // Events emitted synchronously from contribute() arrive before the ready
+    // handshake completes — they must be delivered, not dropped.
+    expect(received).toEqual([["ping-plugin", "boot", { phase: "contribute" }]]);
 
     await expect(runtime.invoke("ping-plugin", "ping", { value: 5 })).resolves.toEqual({
       ok: true,
     });
 
-    expect(received).toEqual([["ping-plugin", "pong", { echo: 5, marker: "EMIT_PAYLOAD_MARKER" }]]);
+    expect(received).toEqual([
+      ["ping-plugin", "boot", { phase: "contribute" }],
+      ["ping-plugin", "pong", { echo: 5, marker: "EMIT_PAYLOAD_MARKER" }],
+    ]);
 
     unsubscribe();
     await runtime.stopAll();

--- a/packages/server/src/server/plugins/runtime.posix.test.ts
+++ b/packages/server/src/server/plugins/runtime.posix.test.ts
@@ -560,6 +560,48 @@ export default function contribute(plugin: any) {
     await runtime.stopAll();
   });
 
+  it("delivers context.emit(eventName, data) to subscribeToEvents and strips it from the client bundle", async () => {
+    const directory = await createPlugin(
+      "ping-plugin",
+      `import { z } from "zod";
+import { defineRpc } from "@getpaseo/plugin";
+
+const pingRpc = defineRpc({
+  name: "ping",
+  input: z.object({ value: z.number() }),
+  output: z.object({ ok: z.boolean() }),
+});
+
+export default function contribute(plugin: any) {
+  plugin.handle(pingRpc, async (input: { value: number }) => {
+    plugin.emit("pong", { echo: input.value, marker: "EMIT_PAYLOAD_MARKER" });
+    return { ok: true };
+  });
+  return () => undefined;
+}`,
+    );
+    const runtime = createTestRuntime();
+    await runtime.startPlugin("ping-plugin", directory);
+
+    // The client bundle must never see an emit() call execute: it strips the whole
+    // statement the same way it strips handle() registrations from the client target.
+    expect(runtime.catalog()[0]?.clientBundle).not.toContain("EMIT_PAYLOAD_MARKER");
+
+    const received: Array<[string, string, unknown]> = [];
+    const unsubscribe = runtime.subscribeToEvents((pluginId, eventName, data) => {
+      received.push([pluginId, eventName, data]);
+    });
+
+    await expect(runtime.invoke("ping-plugin", "ping", { value: 5 })).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(received).toEqual([["ping-plugin", "pong", { echo: 5, marker: "EMIT_PAYLOAD_MARKER" }]]);
+
+    unsubscribe();
+    await runtime.stopAll();
+  });
+
   // COMPAT(plugin-sdk-scope): plugins scaffolded through 0.5.0-beta.1 import the unpublished
   // @paseo/plugin name. Drop with the specifiers in plugin-sdk-specifiers.ts.
   it("loads a plugin that imports the pre-rename @paseo/plugin specifier", async () => {

--- a/packages/server/src/server/plugins/runtime.posix.test.ts
+++ b/packages/server/src/server/plugins/runtime.posix.test.ts
@@ -564,7 +564,7 @@ export default function contribute(plugin: any) {
     const directory = await createPlugin(
       "ping-plugin",
       `import { z } from "zod";
-import { defineRpc } from "@getpaseo/plugin";
+import { defineRpc, type PluginContext } from "@getpaseo/plugin";
 
 const pingRpc = defineRpc({
   name: "ping",
@@ -572,8 +572,8 @@ const pingRpc = defineRpc({
   output: z.object({ ok: z.boolean() }),
 });
 
-export default function contribute(plugin: any) {
-  plugin.handle(pingRpc, async (input: { value: number }) => {
+export default function contribute(plugin: PluginContext) {
+  plugin.handle(pingRpc, async (input) => {
     plugin.emit("pong", { echo: input.value, marker: "EMIT_PAYLOAD_MARKER" });
     return { ok: true };
   });

--- a/packages/server/src/server/plugins/runtime.ts
+++ b/packages/server/src/server/plugins/runtime.ts
@@ -203,6 +203,9 @@ export class PluginRuntime {
   private readonly spawnChild: () => PluginChild;
   private sessionHost: PluginPaseoSessionHost | null;
   private readonly listeners = new Set<(pluginId: string, error?: string) => void>();
+  private readonly eventListeners = new Set<
+    (pluginId: string, eventName: string, data: unknown) => void
+  >();
 
   constructor(logger: pino.Logger, dependencies: PluginRuntimeDependencies = {}) {
     this.logger = logger.child({ module: "plugins" });
@@ -219,6 +222,14 @@ export class PluginRuntime {
   subscribe(listener: (pluginId: string, error?: string) => void): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
+  }
+
+  /** Fires for every context.emit(eventName, data) a running plugin's backend calls. */
+  subscribeToEvents(
+    listener: (pluginId: string, eventName: string, data: unknown) => void,
+  ): () => void {
+    this.eventListeners.add(listener);
+    return () => this.eventListeners.delete(listener);
   }
 
   async startPlugin(
@@ -387,6 +398,11 @@ export class PluginRuntime {
   }
 
   private handleChildMessage(loaded: LoadedPlugin, message: PluginProcessMessage): void {
+    if (message.type === "plugin_event") {
+      for (const listener of this.eventListeners)
+        listener(loaded.id, message.eventName, message.data);
+      return;
+    }
     if (message.type !== "result" && message.type !== "error") return;
     const pending = loaded.pending.get(message.requestId);
     if (!pending) return;

--- a/packages/server/src/server/plugins/runtime.ts
+++ b/packages/server/src/server/plugins/runtime.ts
@@ -359,6 +359,10 @@ export class PluginRuntime {
             resolve(message.methods);
           } else if (message.type === "fatal") {
             fail(new Error(message.error));
+          } else if (message.type === "plugin_event") {
+            // contribute() may emit synchronously, before the child reports ready
+            // and before `loaded` exists — deliver by id instead of dropping.
+            this.emitPluginEvent(pluginId, message.eventName, message.data);
           } else if (loaded) {
             this.handleChildMessage(loaded, message);
           }
@@ -397,12 +401,11 @@ export class PluginRuntime {
     return loaded;
   }
 
+  private emitPluginEvent(pluginId: string, eventName: string, data: unknown): void {
+    for (const listener of this.eventListeners) listener(pluginId, eventName, data);
+  }
+
   private handleChildMessage(loaded: LoadedPlugin, message: PluginProcessMessage): void {
-    if (message.type === "plugin_event") {
-      for (const listener of this.eventListeners)
-        listener(loaded.id, message.eventName, message.data);
-      return;
-    }
     if (message.type !== "result" && message.type !== "error") return;
     const pending = loaded.pending.get(message.requestId);
     if (!pending) return;

--- a/packages/server/src/server/plugins/runtime.ts
+++ b/packages/server/src/server/plugins/runtime.ts
@@ -362,7 +362,9 @@ export class PluginRuntime {
           } else if (message.type === "plugin_event") {
             // contribute() may emit synchronously, before the child reports ready
             // and before `loaded` exists — deliver by id instead of dropping.
-            this.emitPluginEvent(pluginId, message.eventName, message.data);
+            for (const listener of this.eventListeners) {
+              listener(pluginId, message.eventName, message.data);
+            }
           } else if (loaded) {
             this.handleChildMessage(loaded, message);
           }
@@ -399,10 +401,6 @@ export class PluginRuntime {
     };
     this.logger.info({ pluginId, methods }, "Loaded plugin");
     return loaded;
-  }
-
-  private emitPluginEvent(pluginId: string, eventName: string, data: unknown): void {
-    for (const listener of this.eventListeners) listener(pluginId, eventName, data);
   }
 
   private handleChildMessage(loaded: LoadedPlugin, message: PluginProcessMessage): void {

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -502,6 +502,7 @@ test("routes plugin requests and releases its owned catalog subscription on clea
       listeners.add(listener);
       return () => releasePluginSubscription(listener);
     },
+    subscribeToEvents: () => () => {},
     catalog: () => [{ id: "example", clientBundle: "bundle" }],
     invokePluginRpc: async () => ({ ok: true }),
   };

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -479,6 +479,9 @@ export interface SessionOptions {
     disablePlugin(pluginId: string): Promise<import("@getpaseo/protocol/messages").PluginListItem>;
     removePlugin(pluginId: string): Promise<void>;
     subscribe(listener: (pluginId: string) => void): () => void;
+    subscribeToEvents(
+      listener: (pluginId: string, eventName: string, data: unknown) => void,
+    ): () => void;
     catalog(): Array<{ id: string; clientBundle: string }>;
     invokePluginRpc(pluginId: string, method: string, input: unknown): Promise<unknown>;
   };
@@ -682,6 +685,7 @@ export class Session {
   private unsubscribeAgentEvents: (() => void) | null = null;
   private unsubscribeProjectMutations: (() => void) | null = null;
   private unsubscribePluginChanges: (() => void) | null = null;
+  private unsubscribePluginEvents: (() => void) | null = null;
   private unsubscribeWorkspaceMutations: (() => void) | null = null;
   private registryMutationQueue: Promise<void> = Promise.resolve();
   private projectUpdateQueue: Promise<void> = Promise.resolve();
@@ -813,6 +817,7 @@ export class Session {
     this.pluginRuntime = pluginRuntime;
     this.orchestrationSkills = orchestrationSkills;
     this.unsubscribePluginChanges = this.subscribeToPluginChanges(pluginRuntime);
+    this.unsubscribePluginEvents = this.subscribeToPluginEvents(pluginRuntime);
     this.sessionLogger = logger.child({
       module: "session",
       clientId: this.clientId,
@@ -2100,6 +2105,15 @@ export class Session {
     if (!pluginRuntime) return null;
     return pluginRuntime.subscribe((pluginId) => {
       this.emit({ type: "status", payload: { status: "plugin_catalog_changed", pluginId } });
+    });
+  }
+
+  private subscribeToPluginEvents(
+    pluginRuntime: SessionOptions["pluginRuntime"],
+  ): (() => void) | null {
+    if (!pluginRuntime) return null;
+    return pluginRuntime.subscribeToEvents((pluginId, eventName, data) => {
+      this.emit({ type: "plugin.event", payload: { pluginId, eventName, data } });
     });
   }
 
@@ -7449,6 +7463,8 @@ export class Session {
     this.unsubscribeProjectMutations = null;
     this.unsubscribePluginChanges?.();
     this.unsubscribePluginChanges = null;
+    this.unsubscribePluginEvents?.();
+    this.unsubscribePluginEvents = null;
     this.unsubscribeWorkspaceMutations?.();
     this.unsubscribeWorkspaceMutations = null;
     this.workspaceLabelSubscription?.unsubscribe();


### PR DESCRIPTION
## Summary
- Plugins today only have request/response RPC (`context.handle` / `useRpc`) between a plugin's server-target subprocess and its client-target panel — nothing lets the backend push data the panel didn't ask for. A real workspace panel needing live agent status had to fake this with polling.
- Adds `context.emit(eventName, data)` on the backend and `useEvent(eventName, handler)` on the frontend, riding the same push transport `agent_update`/`workspace_update` already use end to end: subprocess `emit` → `PluginRuntime` fan-out → `session.ts` pushes a new one-way `plugin.event` message → `DaemonClient` decodes it to a `plugin_event` `DaemonEvent` → the panel's surface runtime filters by `(pluginId, eventName)` → `useEvent` handler.
- `compiler.ts`'s existing AST strip-list (which already removes `context.handle` calls from the client-target bundle) now also strips `context.emit`, since it's a server-only capability — symmetric to how `handle` is already stripped from the client bundle. Without this, a plugin author's `context.emit(...)` call would crash the client bundle at runtime.
- Wired `useEvent` into the plugin client sandbox's module map (`evaluate.ts`) so it's actually importable from `@getpaseo/plugin` in real plugin code.

## Test plan
- [x] New end-to-end test (`runtime.posix.test.ts`) spawns a real plugin subprocess, calls `context.emit` from inside an RPC handler, and asserts both delivery (`subscribeToEvents` receives the payload) and isolation (the payload never reaches the compiled client bundle)
- [x] `npm run typecheck` clean across every workspace (via the pre-commit hook, including `desktop`/`cli`/`website`/`relay`)
- [x] Full test suites green: `server` (targeted plugin/session suites, 192/192), `client` (136/136), `app` (4,478/4,478 — one unrelated Playwright-browser-binary-missing environment error, no test failures), `plugin` (8/8)
- [x] Reviewed for simplification before opening; fixed two real bugs it surfaced (`useEvent` missing from the plugin sandbox module map; `PluginEventProvider`'s context value wasn't memoized, which would drop events between panel re-renders) plus two small cleanups (dropped a silent event-name-trimming normalization; renamed the wire message from `plugin.rpc.event` to `plugin.event` since it's a one-way push, not RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)