### PR TITLE
fix(pi): support Tintinweb subagent lifecycle

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -129,7 +129,7 @@ The asymmetry is intentional: a subagent's persistent relationship lives in the 
 
 ## Workspace activity
 
-Agent lifecycle status stays literal: a parent agent is `idle` when its own turn is idle, even if a child is running.
+Stored agent lifecycle status stays literal: a parent agent is `idle` when its own turn is idle, even if a child is running. Session lists may project that parent as `running` while a provider-owned child runs; this does not make the parent turn busy.
 
 Workspace status is an aggregate activity signal computed **per `workspaceId`**. Ownership is never derived from `cwd` — many workspaces may share one directory, and same-`cwd` siblings do not clump under one status. Root agents and cross-workspace subagents contribute their normal state bucket to their own workspace. Same-workspace descendants contribute `running` to the nearest ancestor in that workspace; their non-running attention, permission, and error states stay in the parent's subagents track. This makes a cross-workspace subagent behave like a detached agent for workspace visibility and status without removing its parent relationship.
 
@@ -147,13 +147,17 @@ The rows combine two kinds of children:
 parentAgentId === thisAgent.id  AND  !archivedAt
 ```
 
-- **Provider subagents** are child executions owned by Claude, Codex, or OpenCode. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track.
+- **Provider subagents** are child executions owned by Claude, Codex, OpenCode, or Pi. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track.
 
 Clicking either kind opens a workspace tab. A Paseo subagent tab is a normal interactive agent pane. A provider subagent tab is a read-only timeline pane with no composer, archive, detach, rewind, or fork actions. Both panes use `AgentStreamView`, so message, reasoning, tool-call, and layout rendering stay identical.
 
 Provider timelines use the same structural timeline item format but deliberately have a separate lifecycle and transport. A provider thread/session identifier is not a Paseo agent identifier, and closing its tab is always layout-only.
 
 Provider descriptors may include one compact subtitle. The provider owns its contents and formatting; clients display and truncate it without interpreting provider-specific model, thinking, or usage fields.
+
+### Pi provider subagents
+
+Pi's RPC stream does not expose extension event-bus messages. Paseo's injected Pi extension listens for `pi-subagents` async start and completion events and forwards them through the RPC extension-notification channel. Foreground subagents need no bridge because their tool call keeps the parent turn running.
 
 ### Claude provider subagents: the task protocol
 

--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -157,7 +157,7 @@ Provider descriptors may include one compact subtitle. The provider owns its con
 
 ### Pi provider subagents
 
-Pi's RPC stream does not expose extension event-bus messages. Paseo's injected Pi extension listens for `pi-subagents` async start and completion events and forwards them through the RPC extension-notification channel. Foreground subagents need no bridge because their tool call keeps the parent turn running.
+Pi's RPC stream does not expose extension event-bus messages. Paseo's injected Pi extension listens for async start and completion events from supported subagent extensions, including background `Agent` runs from `@tintinweb/pi-subagents`, and forwards them through the RPC extension-notification channel. Foreground subagents need no bridge because their tool call keeps the parent turn running. The provider protocol has no queued state, so queued Pi children count as running activity until they settle.
 
 ### Claude provider subagents: the task protocol
 

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -545,13 +545,13 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
 
   useEffect(() => {
     if (!isConnected || !providerSubagentsSupported || agentDirectoryStatus !== "ready") return;
-    const parentAgentIds = [
-      ...(useSessionStore.getState().sessions[serverId]?.agents.keys() ?? []),
-    ];
     let canceled = false;
     let retryDelayMs = 1_000;
     let retryTimeout: ReturnType<typeof setTimeout> | null = null;
     const refresh = () => {
+      const parentAgentIds = [
+        ...(useSessionStore.getState().sessions[serverId]?.agents.keys() ?? []),
+      ];
       void Promise.all(
         parentAgentIds.map((parentAgentId) =>
           refreshProviderSubagents(client, serverId, parentAgentId),

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -545,10 +545,28 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
 
   useEffect(() => {
     if (!isConnected || !providerSubagentsSupported || agentDirectoryStatus !== "ready") return;
-    const agents = useSessionStore.getState().sessions[serverId]?.agents;
-    for (const parentAgentId of agents?.keys() ?? []) {
-      void refreshProviderSubagents(client, serverId, parentAgentId).catch(() => undefined);
-    }
+    const parentAgentIds = [
+      ...(useSessionStore.getState().sessions[serverId]?.agents.keys() ?? []),
+    ];
+    let canceled = false;
+    let retryDelayMs = 1_000;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    const refresh = () => {
+      void Promise.all(
+        parentAgentIds.map((parentAgentId) =>
+          refreshProviderSubagents(client, serverId, parentAgentId),
+        ),
+      ).catch(() => {
+        if (canceled) return;
+        retryTimeout = setTimeout(refresh, retryDelayMs);
+        retryDelayMs = Math.min(retryDelayMs * 2, 30_000);
+      });
+    };
+    refresh();
+    return () => {
+      canceled = true;
+      if (retryTimeout) clearTimeout(retryTimeout);
+    };
   }, [agentDirectoryStatus, client, isConnected, providerSubagentsSupported, serverId]);
 
   useEffect(

--- a/packages/app/src/contexts/session-context.tsx
+++ b/packages/app/src/contexts/session-context.tsx
@@ -41,7 +41,11 @@ import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import type { AgentSessionConfig } from "@getpaseo/protocol/agent-types";
 import type { GitSetupOptions } from "@getpaseo/protocol/messages";
 import type { AgentPermissionResponse } from "@getpaseo/protocol/agent-types";
-import { getHostRuntimeStore, useHostRuntimeIsConnected } from "@/runtime/host-runtime";
+import {
+  getHostRuntimeStore,
+  useHostRuntimeAgentDirectoryStatus,
+  useHostRuntimeIsConnected,
+} from "@/runtime/host-runtime";
 import { useVoiceAudioEngineOptional, useVoiceRuntimeOptional } from "@/contexts/voice-context";
 import type { AudioPlaybackSource } from "@/voice/audio-engine-types";
 import {
@@ -68,7 +72,11 @@ import { useToast } from "@/contexts/toast-context";
 import { toErrorMessage } from "@/utils/error-messages";
 import { showProviderNoticeToast } from "@/utils/provider-notice-toast";
 import { applyCheckoutStatusUpdateFromEvent } from "@/git/checkout-status-cache";
-import { useProviderSubagentStore } from "@/subagents/provider-store";
+import {
+  refreshProviderSubagents,
+  resetProviderSubagents,
+  useProviderSubagentStore,
+} from "@/subagents/provider-store";
 import { revalidateSessionAfterResume } from "@/contexts/session-resume-revalidation";
 
 type TimelineResponsePayload = Extract<
@@ -330,6 +338,7 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
   const voiceAudioEngine = useVoiceAudioEngineOptional();
   const queryClient = useQueryClient();
   const isConnected = useHostRuntimeIsConnected(serverId);
+  const agentDirectoryStatus = useHostRuntimeAgentDirectoryStatus(serverId);
   const toast = useToast();
 
   // Zustand store actions
@@ -357,6 +366,9 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
   const updateSessionServerInfo = useSessionStore((state) => state.updateSessionServerInfo);
   const setViewedTimelineSync = useSessionStore((state) => state.setViewedTimelineSync);
   const upsertWorkspaceSetupProgress = useWorkspaceSetupStore((state) => state.upsertProgress);
+  const providerSubagentsSupported = useSessionStore(
+    (state) => state.sessions[serverId]?.serverInfo?.features?.providerSubagents === true,
+  );
 
   // Track focused agent for heartbeat
   const focusedAgentId = useSessionStore(
@@ -527,8 +539,17 @@ function SessionProviderInternal({ children, serverId, client }: SessionProvider
     if (!isConnected) {
       flushAgentLastActivity();
       setInitializingAgents(serverId, new Map());
+      resetProviderSubagents(client, serverId);
     }
-  }, [flushAgentLastActivity, serverId, isConnected, setInitializingAgents]);
+  }, [client, flushAgentLastActivity, serverId, isConnected, setInitializingAgents]);
+
+  useEffect(() => {
+    if (!isConnected || !providerSubagentsSupported || agentDirectoryStatus !== "ready") return;
+    const agents = useSessionStore.getState().sessions[serverId]?.agents;
+    for (const parentAgentId of agents?.keys() ?? []) {
+      void refreshProviderSubagents(client, serverId, parentAgentId).catch(() => undefined);
+    }
+  }, [agentDirectoryStatus, client, isConnected, providerSubagentsSupported, serverId]);
 
   useEffect(
     () =>

--- a/packages/app/src/hooks/use-aggregated-agents.ts
+++ b/packages/app/src/hooks/use-aggregated-agents.ts
@@ -5,6 +5,7 @@ import { useSessionStore } from "@/stores/session-store";
 import type { AgentDirectoryEntry } from "@/types/agent-directory";
 import type { Agent } from "@/stores/session-store";
 import { getHostRuntimeStore, useHosts } from "@/runtime/host-runtime";
+import { hasRunningProviderSubagent, useProviderSubagentStore } from "@/subagents/provider-store";
 
 export interface AggregatedAgent extends AgentDirectoryEntry {
   serverId: string;
@@ -40,6 +41,7 @@ export function useAggregatedAgents(options?: {
       return result;
     }),
   );
+  const providerSubagentDescriptors = useProviderSubagentStore((state) => state.descriptors);
 
   const refreshAll = useCallback(() => {
     runtime.refreshAllAgentDirectories();
@@ -75,7 +77,11 @@ export function useAggregatedAgents(options?: {
           serverId,
           serverLabel,
           title: agent.title ?? null,
-          status: agent.status,
+          status:
+            agent.status === "idle" &&
+            hasRunningProviderSubagent(providerSubagentDescriptors, serverId, agent.id)
+              ? "running"
+              : agent.status,
           lastActivityAt: agent.lastActivityAt,
           cwd: agent.cwd,
           workspaceId: agent.workspaceId,
@@ -147,7 +153,14 @@ export function useAggregatedAgents(options?: {
       isInitialLoad,
       isRevalidating,
     };
-  }, [daemons, includeArchived, runtime, runtimeVersion, sessionAgents]);
+  }, [
+    daemons,
+    includeArchived,
+    providerSubagentDescriptors,
+    runtime,
+    runtimeVersion,
+    sessionAgents,
+  ]);
 
   return {
     ...result,

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { providerSubagentKey, useProviderSubagentStore } from "./provider-store";
+import {
+  hasRunningProviderSubagent,
+  providerSubagentKey,
+  useProviderSubagentStore,
+} from "./provider-store";
 
 const SERVER_ID = "server-1";
 const PARENT_ID = "parent-1";
@@ -14,6 +18,31 @@ afterEach(() => {
 });
 
 describe("provider subagent client store", () => {
+  test("reports running activity for the parent session", () => {
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: {
+        id: SUBAGENT_ID,
+        parentAgentId: PARENT_ID,
+        provider: "pi",
+        title: "reviewer",
+        description: "Review the change",
+        status: "running",
+        createdAt: "2026-07-12T10:00:00.000Z",
+        updatedAt: "2026-07-12T10:00:00.000Z",
+        toolCallId: null,
+      },
+    });
+
+    expect(
+      hasRunningProviderSubagent(
+        useProviderSubagentStore.getState().descriptors,
+        SERVER_ID,
+        PARENT_ID,
+      ),
+    ).toBe(true);
+  });
+
   test("builds a shared stream model from ordered provider updates", () => {
     const subagents = useProviderSubagentStore.getState();
     subagents.applyUpdate(SERVER_ID, {

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -66,10 +66,22 @@ describe("provider subagent client store", () => {
       updatedAt: "2026-07-12T10:00:00.000Z",
       toolCallId: null,
     };
+    const key = providerSubagentKey(SERVER_ID, PARENT_ID, SUBAGENT_ID);
     useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
       kind: "upsert",
       subagent: running,
     });
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "timeline",
+      parentAgentId: PARENT_ID,
+      subagentId: SUBAGENT_ID,
+      provider: "pi",
+      epoch: "epoch-1",
+      seq: 1,
+      timestamp: "2026-07-12T10:00:01.000Z",
+      item: { type: "assistant_message", text: "Partial result" },
+    });
+    useProviderSubagentStore.setState({ hiddenFromTrack: new Set([key]) });
     const staleRefresh = refreshProviderSubagents(client, SERVER_ID, PARENT_ID);
 
     resetProviderSubagents(client, SERVER_ID);
@@ -81,13 +93,10 @@ describe("provider subagent client store", () => {
     });
     await staleRefresh;
 
-    expect(
-      hasRunningProviderSubagent(
-        useProviderSubagentStore.getState().descriptors,
-        SERVER_ID,
-        PARENT_ID,
-      ),
-    ).toBe(false);
+    const state = useProviderSubagentStore.getState();
+    expect(hasRunningProviderSubagent(state.descriptors, SERVER_ID, PARENT_ID)).toBe(false);
+    expect(state.timelines.has(key)).toBe(false);
+    expect(state.hiddenFromTrack.has(key)).toBe(false);
   });
 
   test("builds a shared stream model from ordered provider updates", () => {

--- a/packages/app/src/subagents/provider-store.test.ts
+++ b/packages/app/src/subagents/provider-store.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, test } from "vitest";
+import type { DaemonClient } from "@getpaseo/client/internal/daemon-client";
 import {
   hasRunningProviderSubagent,
   providerSubagentKey,
+  refreshProviderSubagents,
+  resetProviderSubagents,
   useProviderSubagentStore,
 } from "./provider-store";
 
@@ -41,6 +44,50 @@ describe("provider subagent client store", () => {
         PARENT_ID,
       ),
     ).toBe(true);
+  });
+
+  test("clears disconnected activity and ignores an in-flight stale list", async () => {
+    type ListPayload = Awaited<ReturnType<DaemonClient["listProviderSubagents"]>>;
+    let resolveList!: (value: ListPayload) => void;
+    const client = {
+      listProviderSubagents: () =>
+        new Promise<ListPayload>((resolve) => {
+          resolveList = resolve;
+        }),
+    };
+    const running = {
+      id: SUBAGENT_ID,
+      parentAgentId: PARENT_ID,
+      provider: "pi" as const,
+      title: "reviewer",
+      description: "Review the change",
+      status: "running" as const,
+      createdAt: "2026-07-12T10:00:00.000Z",
+      updatedAt: "2026-07-12T10:00:00.000Z",
+      toolCallId: null,
+    };
+    useProviderSubagentStore.getState().applyUpdate(SERVER_ID, {
+      kind: "upsert",
+      subagent: running,
+    });
+    const staleRefresh = refreshProviderSubagents(client, SERVER_ID, PARENT_ID);
+
+    resetProviderSubagents(client, SERVER_ID);
+    resolveList({
+      requestId: "stale-request",
+      parentAgentId: PARENT_ID,
+      subagents: [running],
+      error: null,
+    });
+    await staleRefresh;
+
+    expect(
+      hasRunningProviderSubagent(
+        useProviderSubagentStore.getState().descriptors,
+        SERVER_ID,
+        PARENT_ID,
+      ),
+    ).toBe(false);
   });
 
   test("builds a shared stream model from ordered provider updates", () => {

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -63,6 +63,18 @@ export function providerSubagentKey(
   return `${serverId}\0${parentAgentId}\0${subagentId}`;
 }
 
+export function hasRunningProviderSubagent(
+  descriptors: ReadonlyMap<string, ProviderSubagentDescriptorPayload>,
+  serverId: string,
+  parentAgentId: string,
+): boolean {
+  const prefix = parentPrefix(serverId, parentAgentId);
+  for (const [key, subagent] of descriptors) {
+    if (key.startsWith(prefix) && subagent.status === "running") return true;
+  }
+  return false;
+}
+
 export function providerSubagentLifecycleStatus(
   status: ProviderSubagentDescriptorPayload["status"],
 ): AgentLifecycleStatus {

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -86,6 +86,19 @@ export function providerSubagentLifecycleStatus(
 type ProviderSubagentListClient = Pick<DaemonClient, "listProviderSubagents">;
 
 const pendingListRequests = new WeakMap<ProviderSubagentListClient, Map<string, Promise<void>>>();
+const serverGenerations = new Map<string, number>();
+
+export function resetProviderSubagents(client: ProviderSubagentListClient, serverId: string): void {
+  serverGenerations.set(serverId, (serverGenerations.get(serverId) ?? 0) + 1);
+  const prefix = `${serverId}\0`;
+  const requests = pendingListRequests.get(client);
+  for (const key of requests?.keys() ?? []) {
+    if (key.startsWith(prefix)) requests?.delete(key);
+  }
+  useProviderSubagentStore.setState((state) => ({
+    descriptors: new Map([...state.descriptors].filter(([key]) => !key.startsWith(prefix))),
+  }));
+}
 
 export function refreshProviderSubagents(
   client: ProviderSubagentListClient,
@@ -101,14 +114,17 @@ export function refreshProviderSubagents(
   const pending = clientRequests.get(requestKey);
   if (pending) return pending;
 
-  const request = client
+  const generation = serverGenerations.get(serverId) ?? 0;
+  let request: Promise<void>;
+  request = client
     .listProviderSubagents(parentAgentId)
     .then((payload) => {
+      if ((serverGenerations.get(serverId) ?? 0) !== generation) return;
       useProviderSubagentStore.getState().replaceList(serverId, parentAgentId, payload.subagents);
       return undefined;
     })
     .finally(() => {
-      clientRequests?.delete(requestKey);
+      if (clientRequests?.get(requestKey) === request) clientRequests.delete(requestKey);
     });
   clientRequests.set(requestKey, request);
   return request;

--- a/packages/app/src/subagents/provider-store.ts
+++ b/packages/app/src/subagents/provider-store.ts
@@ -97,6 +97,8 @@ export function resetProviderSubagents(client: ProviderSubagentListClient, serve
   }
   useProviderSubagentStore.setState((state) => ({
     descriptors: new Map([...state.descriptors].filter(([key]) => !key.startsWith(prefix))),
+    timelines: new Map([...state.timelines].filter(([key]) => !key.startsWith(prefix))),
+    hiddenFromTrack: new Set([...state.hiddenFromTrack].filter((key) => !key.startsWith(prefix))),
   }));
 }
 

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -85,20 +85,33 @@ function readUtf8File(pathname: string): string {
 }
 
 type PaseoExtensionListener = (event: unknown, context?: unknown) => unknown;
+type PaseoExtensionEventListener = (data: unknown) => void;
 
 async function loadPaseoExtensionListeners(
   extensionPath: string,
+  extensionEventListeners = new Map<string, Set<PaseoExtensionEventListener>>(),
 ): Promise<Map<string, PaseoExtensionListener>> {
   const listeners = new Map<string, PaseoExtensionListener>();
   const extension = (await import(pathToFileURL(extensionPath).href)) as {
     default: (piApi: {
       on: (event: string, listener: PaseoExtensionListener) => void;
       registerCommand: () => void;
+      events: {
+        on: (event: string, listener: PaseoExtensionEventListener) => () => void;
+      };
     }) => void;
   };
   extension.default({
     on: (event, listener) => listeners.set(event, listener),
     registerCommand: () => undefined,
+    events: {
+      on: (event, listener) => {
+        const eventListeners = extensionEventListeners.get(event) ?? new Set();
+        eventListeners.add(listener);
+        extensionEventListeners.set(event, eventListeners);
+        return () => eventListeners.delete(listener);
+      },
+    },
   });
   return listeners;
 }
@@ -229,6 +242,13 @@ class SessionEvents {
     );
   }
 
+  providerSubagentEvents() {
+    return this.events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+        event.type === "provider_subagent",
+    );
+  }
+
   nextTurnCompletion(): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
     return this.nextEvent(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
@@ -288,6 +308,47 @@ class SessionEvents {
 }
 
 describe("PiRpcAgentSession", () => {
+  test("maps Pi subagent lifecycle markers to provider subagents", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-started",
+      method: "notify",
+      message:
+        'PASEO_PI_SUBAGENT {"id":"run-1","title":"reviewer","description":"Review the change","status":"running","cwd":"/workspace"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-completed",
+      method: "notify",
+      message: 'PASEO_PI_SUBAGENT {"id":"run-1","status":"completed"}',
+    });
+
+    expect(events.providerSubagentEvents()).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "run-1",
+          title: "reviewer",
+          description: "Review the change",
+          status: "running",
+          cwd: "/workspace",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: { type: "upsert", id: "run-1", status: "completed" },
+      },
+    ]);
+
+    await session.close();
+  });
+
   test("bridges Pi RPC select extension UI requests through question permissions", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
@@ -1028,6 +1089,41 @@ describe("PiRpcAgentSession", () => {
     expect(notifications).toEqual([
       'PASEO_SUBMITTED_USER_ENTRY {"entry":{"id":"entry-new","parentId":"entry-old-assistant","text":"new prompt"}}',
     ]);
+
+    await session.close();
+  });
+
+  test("reports pi-subagents async lifecycle through the Paseo extension", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const session = await client.createSession(createConfig());
+    const extensionPath = pi.recordedLaunches[0]?.extensionPaths[0];
+    expect(extensionPath).toBeDefined();
+    const extensionEvents = new Map<string, Set<PaseoExtensionEventListener>>();
+    const listeners = await loadPaseoExtensionListeners(extensionPath!, extensionEvents);
+    const notifications: string[] = [];
+    const context = {
+      sessionManager: { getEntries: () => [] },
+      ui: { notify: (message: string) => notifications.push(message) },
+    };
+
+    await listeners.get("session_start")?.({}, context);
+    extensionEvents.get("subagent:async-started")?.forEach((listener) =>
+      listener({
+        id: "run-1",
+        agent: "reviewer",
+        goal: "Review the change",
+        cwd: "/workspace",
+      }),
+    );
+    extensionEvents
+      .get("subagent:async-complete")
+      ?.forEach((listener) => listener({ runId: "run-1", state: "complete", success: true }));
+
+    expect(notifications).toContain(
+      'PASEO_PI_SUBAGENT {"id":"run-1","title":"reviewer","description":"Review the change","status":"running","cwd":"/workspace"}',
+    );
+    expect(notifications).toContain('PASEO_PI_SUBAGENT {"id":"run-1","status":"completed"}');
 
     await session.close();
   });

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -1128,6 +1128,78 @@ describe("PiRpcAgentSession", () => {
     await session.close();
   });
 
+  test("reports Tintinweb background Agent lifecycle through the Paseo extension", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const session = await client.createSession(createConfig());
+    const extensionPath = pi.recordedLaunches[0]?.extensionPaths[0];
+    expect(extensionPath).toBeDefined();
+    const extensionEvents = new Map<string, Set<PaseoExtensionEventListener>>();
+    const listeners = await loadPaseoExtensionListeners(extensionPath!, extensionEvents);
+    const notifications: string[] = [];
+    const context = {
+      sessionManager: { getEntries: () => [] },
+      ui: { notify: (message: string) => notifications.push(message) },
+    };
+    const emitExtensionEvent = (name: string, payload: unknown) => {
+      extensionEvents.get(name)?.forEach((listener) => listener(payload));
+    };
+
+    await listeners.get("session_start")?.({}, context);
+    notifications.length = 0;
+    emitExtensionEvent("subagents:created", {
+      id: "foreground-1",
+      type: "Explore",
+      description: "Do not add a provider child",
+      isBackground: false,
+    });
+    emitExtensionEvent("subagents:completed", { id: "foreground-1", status: "completed" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-1",
+      type: "Explore",
+      description: "Trace the Pi mapper",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:completed", { id: "run-1", status: "steered" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-2",
+      type: "Plan",
+      description: "Plan a focused change",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:failed", { id: "run-2", status: "stopped" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-3",
+      type: "general-purpose",
+      description: "Implement the change",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:failed", { id: "run-3", status: "aborted" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-4",
+      type: "Explore",
+      description: "Cancel on shutdown",
+      isBackground: true,
+    });
+    await listeners.get("session_shutdown")?.({}, context);
+
+    expect(notifications).toEqual([
+      'PASEO_PI_SUBAGENT {"id":"run-1","title":"Explore","description":"Trace the Pi mapper","status":"running"}',
+      'PASEO_PI_SUBAGENT {"id":"run-1","status":"completed"}',
+      'PASEO_PI_SUBAGENT {"id":"run-2","title":"Plan","description":"Plan a focused change","status":"running"}',
+      'PASEO_PI_SUBAGENT {"id":"run-2","status":"canceled"}',
+      'PASEO_PI_SUBAGENT {"id":"run-3","title":"general-purpose","description":"Implement the change","status":"running"}',
+      'PASEO_PI_SUBAGENT {"id":"run-3","status":"failed"}',
+      'PASEO_PI_SUBAGENT {"id":"run-4","title":"Explore","description":"Cancel on shutdown","status":"running"}',
+      'PASEO_PI_SUBAGENT {"id":"run-4","status":"canceled"}',
+    ]);
+
+    expect([...extensionEvents.values()].every((eventListeners) => eventListeners.size === 0)).toBe(
+      true,
+    );
+    await session.close();
+  });
+
   test("appends agent and daemon prompts after Pi's discovered system prompt", async () => {
     const pi = new FakePi();
     const client = createClient(pi);

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -94,6 +94,7 @@ const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
 const PASEO_PI_SUBMITTED_USER_ENTRY_MARKER = "PASEO_SUBMITTED_USER_ENTRY";
 const PASEO_PI_COMMAND_RESULT_MARKER = "PASEO_COMMAND_RESULT";
+const PASEO_PI_SUBAGENT_MARKER = "PASEO_PI_SUBAGENT";
 const DEFAULT_PI_EXTENSION_RESULT_TIMEOUT_MS = 30_000;
 const QUESTION_RESPONSE_HEADER = "Response";
 const QUESTION_COMMENT_HEADER = "Comment";
@@ -648,8 +649,54 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	  );
 	}
 
+	function subagentId(payload) {
+	  const value = payload && (payload.runId || payload.id);
+	  return typeof value === "string" && value ? value : undefined;
+	}
+
+	function reportSubagent(ctx, event) {
+	  if (!ctx || !event.id) return;
+	  ctx.ui.notify("${PASEO_PI_SUBAGENT_MARKER} " + JSON.stringify(event), "info");
+	}
+
+	function reportSubagentStarted(ctx, payload) {
+	  const id = subagentId(payload);
+	  if (!id) return;
+	  const title = typeof payload.agent === "string"
+	    ? payload.agent
+	    : payload.mode === "workflow" ? "Workflow" : "Pi subagent";
+	  const description = typeof payload.goal === "string"
+	    ? payload.goal
+	    : typeof payload.task === "string" ? payload.task : undefined;
+	  reportSubagent(ctx, {
+	    id,
+	    title,
+	    description,
+	    status: "running",
+	    cwd: typeof payload.cwd === "string" ? payload.cwd : undefined,
+	  });
+	}
+
+	function reportSubagentCompleted(ctx, payload) {
+	  const id = subagentId(payload);
+	  if (!id) return;
+	  const status = payload.stopped || payload.state === "stopped" || payload.state === "paused"
+	    ? "canceled"
+	    : payload.success === false || payload.state === "failed" || payload.state === "rejected"
+	      ? "failed"
+	      : "completed";
+	  reportSubagent(ctx, { id, status });
+	}
+
 	export default function paseoIntegration(pi) {
 	  const submittedUserMessages = [];
+	  let subagentContext;
+	  const unsubscribeSubagentStarted = pi.events.on("subagent:async-started", (payload) => {
+	    reportSubagentStarted(subagentContext, payload);
+	  });
+	  const unsubscribeSubagentCompleted = pi.events.on("subagent:async-complete", (payload) => {
+	    reportSubagentCompleted(subagentContext, payload);
+	  });
 
 	  function emitSubmittedUserEntries(ctx) {
 	    const entries = ctx.sessionManager.getEntries();
@@ -682,7 +729,14 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
     }
 
 	  pi.on("session_start", async (_event, ctx) => {
+	    subagentContext = ctx;
 	    emitEntryCapture(ctx, "session_start");
+	  });
+
+	  pi.on("session_shutdown", async () => {
+	    subagentContext = undefined;
+	    unsubscribeSubagentStarted?.();
+	    unsubscribeSubagentCompleted?.();
 	  });
 
 	  pi.on("message_end", async (event) => {
@@ -1910,6 +1964,40 @@ export class PiRpcAgentSession implements AgentSession {
     return true;
   }
 
+  private handlePiSubagentMarker(message: string): boolean {
+    const payload = parseExtensionMarkerPayload(message, PASEO_PI_SUBAGENT_MARKER);
+    if (!payload) {
+      return false;
+    }
+    const id = optionalString(payload.id)?.trim();
+    const status = optionalString(payload.status);
+    if (
+      !id ||
+      (status !== "running" &&
+        status !== "completed" &&
+        status !== "failed" &&
+        status !== "canceled")
+    ) {
+      return true;
+    }
+    const title = optionalString(payload.title)?.trim();
+    const description = optionalString(payload.description)?.trim();
+    const cwd = optionalString(payload.cwd)?.trim();
+    this.emit({
+      type: "provider_subagent",
+      provider: this.provider,
+      event: {
+        type: "upsert",
+        id,
+        status,
+        ...(title ? { title } : {}),
+        ...(description ? { description } : {}),
+        ...(cwd ? { cwd } : {}),
+      },
+    });
+    return true;
+  }
+
   private handleExtensionUiRequest(
     event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
   ): void {
@@ -1918,7 +2006,8 @@ export class PiRpcAgentSession implements AgentSession {
       if (
         this.handleSubmittedUserEntryMarker(message) ||
         this.handleEntryCaptureMarker(message) ||
-        this.handleCommandResultMarker(message)
+        this.handleCommandResultMarker(message) ||
+        this.handlePiSubagentMarker(message)
       ) {
         return;
       }

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -695,13 +695,46 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 
 	export default function paseoIntegration(pi) {
 	  const submittedUserMessages = [];
+	  const activePiSubagentIds = new Set();
 	  let subagentContext;
-	  const unsubscribeSubagentStarted = pi.events.on("subagent:async-started", (payload) => {
-	    reportSubagentStarted(subagentContext, payload);
-	  });
-	  const unsubscribeSubagentCompleted = pi.events.on("subagent:async-complete", (payload) => {
-	    reportSubagentCompleted(subagentContext, payload);
-	  });
+	  const unsubscribeSubagentEvents = [
+	    pi.events.on("subagent:async-started", (payload) => {
+	      const id = subagentId(payload);
+	      if (id) activePiSubagentIds.add(id);
+	      reportSubagentStarted(subagentContext, payload);
+	    }),
+	    pi.events.on("subagent:async-complete", (payload) => {
+	      const id = subagentId(payload);
+	      if (id) activePiSubagentIds.delete(id);
+	      reportSubagentCompleted(subagentContext, payload);
+	    }),
+	    pi.events.on("subagents:created", (payload) => {
+	      const id = subagentId(payload);
+	      if (!id || payload?.isBackground !== true) return;
+	      // This event is the background marker and can also mean queued. Paseo treats queued work as active.
+	      activePiSubagentIds.add(id);
+	      reportSubagent(subagentContext, {
+	        id,
+	        title: typeof payload.type === "string" ? payload.type : "Pi subagent",
+	        description: typeof payload.description === "string" ? payload.description : undefined,
+	        status: "running",
+	        cwd: typeof payload.cwd === "string" ? payload.cwd : undefined,
+	      });
+	    }),
+	    pi.events.on("subagents:completed", (payload) => {
+	      const id = subagentId(payload);
+	      if (!id || !activePiSubagentIds.delete(id)) return;
+	      reportSubagent(subagentContext, { id, status: "completed" });
+	    }),
+	    pi.events.on("subagents:failed", (payload) => {
+	      const id = subagentId(payload);
+	      if (!id || !activePiSubagentIds.delete(id)) return;
+	      reportSubagent(subagentContext, {
+	        id,
+	        status: payload?.status === "stopped" ? "canceled" : "failed",
+	      });
+	    }),
+	  ];
 
 	  function emitSubmittedUserEntries(ctx) {
 	    const entries = ctx.sessionManager.getEntries();
@@ -739,9 +772,12 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	  });
 
 	  pi.on("session_shutdown", async () => {
+	    for (const id of activePiSubagentIds) {
+	      reportSubagent(subagentContext, { id, status: "canceled" });
+	    }
 	    subagentContext = undefined;
-	    unsubscribeSubagentStarted?.();
-	    unsubscribeSubagentCompleted?.();
+	    activePiSubagentIds.clear();
+	    for (const unsubscribe of unsubscribeSubagentEvents) unsubscribe?.();
 	  });
 
 	  pi.on("message_end", async (event) => {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -680,11 +680,16 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	function reportSubagentCompleted(ctx, payload) {
 	  const id = subagentId(payload);
 	  if (!id) return;
-	  const status = payload.stopped || payload.state === "stopped" || payload.state === "paused"
-	    ? "canceled"
-	    : payload.success === false || payload.state === "failed" || payload.state === "rejected"
-	      ? "failed"
-	      : "completed";
+	  let status = "completed";
+	  if (payload.stopped || payload.state === "stopped" || payload.state === "paused") {
+	    status = "canceled";
+	  } else if (
+	    payload.success === false ||
+	    payload.state === "failed" ||
+	    payload.state === "rejected"
+	  ) {
+	    status = "failed";
+	  }
 	  reportSubagent(ctx, { id, status });
 	}
 

--- a/packages/server/src/server/agent/providers/pi/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/tool-call-mapper.test.ts
@@ -167,6 +167,55 @@ describe("Pi tool call mapper", () => {
     });
   });
 
+  test("maps Tintinweb Agent calls to sub-agent detail", () => {
+    const toolCall = parseToolArgs("Agent", {
+      subagent_type: "Explore",
+      description: "Trace the Pi mapper",
+      prompt: "Find every Pi tool-call mapping path.",
+      run_in_background: false,
+    });
+    const result = parseToolResult({
+      content: [{ type: "text", text: "The mapping starts in mapToolDetail.\n" }],
+      details: { status: "completed", agentId: "agent-1" },
+    });
+
+    expect(mapToolDetail(toolCall, result)).toEqual({
+      type: "sub_agent",
+      subAgentType: "Explore",
+      description: "Trace the Pi mapper",
+      log: "The mapping starts in mapToolDetail.",
+    });
+  });
+
+  test("maps background Tintinweb Agent launches instead of showing raw JSON", () => {
+    const toolCall = parseToolArgs("Agent", {
+      subagent_type: "Plan",
+      description: "Plan the integration",
+      prompt: "Design the lifecycle bridge.",
+      run_in_background: true,
+    });
+
+    expect(mapToolDetail(toolCall, null)).toEqual({
+      type: "sub_agent",
+      subAgentType: "Plan",
+      description: "Plan the integration",
+      log: "",
+    });
+  });
+
+  test("keeps unrelated Agent tools on the unknown fallback", () => {
+    const toolCall = parseToolArgs("Agent", {
+      subagent_type: "Explore",
+      operation: "list",
+    });
+
+    expect(mapToolDetail(toolCall, null)).toEqual({
+      type: "unknown",
+      input: { subagent_type: "Explore", operation: "list" },
+      output: null,
+    });
+  });
+
   test("normalizes Pi MCP proxy calls from requested tool args while running", () => {
     const toolCall = parseToolArgs("mcp", {
       tool: "paseo_list_models",

--- a/packages/server/src/server/agent/providers/pi/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/tool-call-mapper.ts
@@ -396,7 +396,17 @@ function isTaskToolCall(toolCall: PiTrackedToolCall): boolean {
   if (toolCall.toolName === "task") {
     return true;
   }
-  if (toolCall.toolName !== "subagent" || !isRecord(toolCall.args)) {
+  if (!isRecord(toolCall.args)) {
+    return false;
+  }
+  if (toolCall.toolName === "Agent") {
+    return (
+      readNonEmptyString(toolCall.args.subagent_type) !== undefined &&
+      readNonEmptyString(toolCall.args.description) !== undefined &&
+      readNonEmptyString(toolCall.args.prompt) !== undefined
+    );
+  }
+  if (toolCall.toolName !== "subagent") {
     return false;
   }
   return (
@@ -410,8 +420,12 @@ function mapTaskToolDetail(args: unknown, result: PiToolResult): ToolCallDetail 
   const argRecord = isRecord(args) ? args : {};
   return {
     type: "sub_agent",
-    subAgentType: readNonEmptyString(argRecord.agent),
-    description: readNonEmptyString(argRecord.task),
+    subAgentType:
+      readNonEmptyString(argRecord.agent) ?? readNonEmptyString(argRecord.subagent_type),
+    description:
+      readNonEmptyString(argRecord.task) ??
+      readNonEmptyString(argRecord.description) ??
+      readNonEmptyString(argRecord.prompt),
     log: extractTextFromToolResult(result)?.trim() ?? "",
   };
 }


### PR DESCRIPTION
### Linked issue

Closes #3160.

Supersedes #3165. This branch preserves its three commits and original authorship, rebases them onto current `main`, resolves the existing test conflict, and adds compatibility for `@tintinweb/pi-subagents`.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Paseo maps Pi tools named `task` and `subagent` to native delegated-task cards. `@tintinweb/pi-subagents` registers `Agent` with a different argument schema, so Paseo displays its calls as unknown-tool JSON.

Background `Agent` calls finish their tool call after launch. Their later lifecycle is available only on Pi's extension event bus, which is not part of the Pi RPC stream. Without a bridge, the child is absent from Paseo's provider-subagent track and the parent appears idle while delegated work continues.

### Goals

- Render matching `Agent` calls with the existing native `sub_agent` detail.
- Show background Tintinweb children in Paseo's provider-subagent track.
- Keep parent and workspace activity visible while background work runs or waits for a slot.
- Map child completion, failure, cancellation, and session shutdown to terminal states.
- Preserve the unknown-tool fallback for malformed or unrelated `Agent` tools.
- Preserve existing `task`, `subagent`, and `subagent:async-*` behavior.
- Clear stale provider state on disconnect and reconcile it after reconnect.

### Non-goals

- Convert Pi-owned children to managed Paseo agents.
- Replay child events that finished before the live Pi connection.
- Import the Tintinweb output-file transcript into the provider-child timeline.
- Add an OMP dependency.

### Compatibility

- No protocol schema changes.
- Foreground lifecycle events stay out of the provider-subagent track through the extension's `isBackground` marker.
- Queued background work uses `running` because the provider-subagent contract has no queued state.

### QA

Focused tests:

```text
$ npx vitest run packages/server/src/server/agent/providers/pi/tool-call-mapper.test.ts packages/server/src/server/agent/providers/pi/agent.test.ts packages/app/src/subagents/provider-store.test.ts --bail=1
Test Files  3 passed (3)
Tests       91 passed (91)
```

Repository checks:

```text
$ npm run build:server
completed successfully

$ npm run format
Finished in 785ms on 3990 files.

$ npm run typecheck
completed successfully for all workspaces

$ npm run lint
Found 0 warnings and 0 errors.

$ git diff --check
exit 0
```

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| Desktop macOS | Automated only | Mapper, generated extension bridge, store, typecheck, and lint passed. |
| Web | No | Uses the shared provider-subagent client path. |
| iOS | No | Uses the shared provider-subagent client path. |
| Android | No | Uses the shared provider-subagent client path. |
| Windows | No | Not available locally. |
| Linux | No | Not available locally. |

Real-provider before/after UI evidence is still outstanding, so this PR is a draft.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense
