### PR TITLE
feat(agent): add ORR-20 burn controls

### DIFF
--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
+  AgentGroupFieldsSchema,
+  CreateOrchestrationGroupInputSchema,
   FileExplorerRequestSchema,
   PaseoWorktreeArchiveRequestSchema,
   parseServerInfoStatusPayload,
@@ -50,6 +52,32 @@ describe("project icon message security", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+});
+
+describe("harness orchestration contracts", () => {
+  test("accepts only finite explicit group settings and identity", () => {
+    expect(
+      CreateOrchestrationGroupInputSchema.safeParse({
+        continuationPolicy: "batch",
+        timeoutMs: 10_000,
+        maxSummaryCharsPerChild: 256,
+      }).success,
+    ).toBe(true);
+    expect(
+      CreateOrchestrationGroupInputSchema.safeParse({
+        continuationPolicy: "batch",
+        timeoutMs: Infinity,
+        maxSummaryCharsPerChild: 256,
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentGroupFieldsSchema.safeParse({
+        groupId: "not-a-uuid",
+        capabilityClass: "read_only",
+        policyProfileId: "builder",
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -6374,3 +6374,53 @@ export function parseServerInfoStatusPayload(payload: unknown): ServerInfoStatus
   }
   return parsed.data;
 }
+
+// ============================================================================
+// Harness orchestration contracts
+// ============================================================================
+
+/** Explicit groups replace completion-notification-driven parent wakes. */
+export const CreateOrchestrationGroupInputSchema = z
+  .object({
+    continuationPolicy: z.enum(["batch", "none"]),
+    timeoutMs: z.number().int().min(1_000).max(86_400_000),
+    maxSummaryCharsPerChild: z.number().int().min(256).max(4_000),
+  })
+  .strict();
+
+export const AgentGroupFieldsSchema = z
+  .object({
+    groupId: z.string().uuid(),
+    capabilityClass: z.enum(["read_only", "write_capable"]),
+    policyProfileId: z.enum(["operating", "builder", "reviewer"]),
+  })
+  .strict();
+
+export const OrchestrationGroupResultSchema = z
+  .object({
+    groupId: z.string().uuid(),
+    state: z.enum([
+      "open",
+      "sealed",
+      "terminal",
+      "continuation_claimed",
+      "continued",
+      "held",
+      "expired",
+    ]),
+    children: z.array(
+      z.object({
+        agentId: z.string().min(1),
+        terminalState: z.enum(["completed", "failed", "cancelled", "held", "timed_out"]).nullable(),
+        summary: z.string().nullable(),
+        resultPointer: z.string().nullable(),
+      }),
+    ),
+    continuationTurnId: z.string().nullable(),
+    holdReason: z.string().nullable(),
+  })
+  .strict();
+
+export type CreateOrchestrationGroupInput = z.infer<typeof CreateOrchestrationGroupInputSchema>;
+export type AgentGroupFields = z.infer<typeof AgentGroupFieldsSchema>;
+export type OrchestrationGroupResult = z.infer<typeof OrchestrationGroupResultSchema>;

--- a/packages/server/src/server/agent/agent-prompt.test.ts
+++ b/packages/server/src/server/agent/agent-prompt.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, test, vi } from "vitest";
-import pino, { type Logger } from "pino";
+import type { Logger } from "pino";
 
 import { createTestLogger } from "../../test-utils/test-logger.js";
 import { AgentManager } from "./agent-manager.js";
@@ -11,30 +11,6 @@ import {
   setupFinishNotification,
 } from "./agent-prompt.js";
 import type { AgentManagerEvent, ManagedAgent } from "./agent-manager.js";
-
-interface CapturedLogger {
-  logger: Logger;
-  records: Array<Record<string, unknown>>;
-  nextRecord: Promise<void>;
-}
-
-function createCapturedLogger(): CapturedLogger {
-  const records: Array<Record<string, unknown>> = [];
-  let resolveNextRecord!: () => void;
-  const nextRecord = new Promise<void>((resolve) => {
-    resolveNextRecord = resolve;
-  });
-  const logger = pino(
-    { level: "error" },
-    {
-      write(line: string) {
-        records.push(JSON.parse(line) as Record<string, unknown>);
-        resolveNextRecord();
-      },
-    },
-  );
-  return { logger, records, nextRecord };
-}
 
 interface FinishNotificationScenarioOptions {
   childLastAssistantMessage?: string | null;
@@ -54,6 +30,7 @@ interface FinishNotificationScenario {
   finishChildAndReadParentPrompt(): Promise<string>;
   closeChildAndReadParentPrompt(): Promise<string>;
   parentPrompts(): string[];
+  notifications(): string[];
   wasParentPrompted(): boolean;
 }
 
@@ -64,6 +41,7 @@ function createFinishNotificationScenario(
   let resolveParentPrompt: ((prompt: string) => void) | null = null;
   let parentPrompted = false;
   const parentPrompts: string[] = [];
+  const notifications: string[] = [];
 
   const childAgent: ManagedAgent = Object.create(null);
   Reflect.set(childAgent, "id", "child-agent");
@@ -129,6 +107,10 @@ function createFinishNotificationScenario(
         childAgentId: "child-agent",
         callerAgentId: "caller-agent",
         requireParentOwnership: options?.requireParentOwnership,
+        onNotification: ({ body }) => {
+          notifications.push(body);
+          resolveParentPrompt?.(body);
+        },
         logger: options?.logger ?? createTestLogger(),
       });
     },
@@ -234,6 +216,9 @@ function createFinishNotificationScenario(
     parentPrompts() {
       return parentPrompts;
     },
+    notifications() {
+      return notifications;
+    },
     wasParentPrompted() {
       return parentPrompted;
     },
@@ -290,13 +275,12 @@ test("finish notifications tell the parent the child's last assistant message", 
   });
 
   scenario.startWatchingChild();
-  const parentPrompt = await scenario.finishChildAndReadParentPrompt();
+  const notification = await scenario.finishChildAndReadParentPrompt();
 
-  expect(parentPrompt).toEqual(
-    formatSystemNotificationPrompt(
-      "Agent child-agent (Child Agent) finished.\n\n<agent-response>\nImplemented the cleanup and all checks pass.\n</agent-response>",
-    ),
+  expect(notification).toEqual(
+    "Agent child-agent (Child Agent) finished.\n\n<agent-response>\nImplemented the cleanup and all checks pass.\n</agent-response>",
   );
+  expect(scenario.parentPrompts()).toEqual([]);
 });
 
 test("finish notifications truncate oversized child responses", async () => {
@@ -307,24 +291,24 @@ test("finish notifications truncate oversized child responses", async () => {
   });
 
   scenario.startWatchingChild();
-  const parentPrompt = await scenario.finishChildAndReadParentPrompt();
+  const notification = await scenario.finishChildAndReadParentPrompt();
 
-  expect(parentPrompt).toContain(included);
-  expect(parentPrompt).toContain(
+  expect(notification).toContain(included);
+  expect(notification).toContain(
     `[truncated ${omitted.length} chars; use get_agent_activity for the full response]`,
   );
-  expect(parentPrompt).not.toContain("TAIL-MARKER");
+  expect(notification).not.toContain("TAIL-MARKER");
+  expect(scenario.parentPrompts()).toEqual([]);
 });
 
 test("closing a watched child notifies the caller", async () => {
   const scenario = createFinishNotificationScenario();
 
   scenario.startWatchingChild();
-  const parentPrompt = await scenario.closeChildAndReadParentPrompt();
+  const notification = await scenario.closeChildAndReadParentPrompt();
 
-  expect(parentPrompt).toEqual(
-    formatSystemNotificationPrompt("Agent child-agent (Child Agent) was closed."),
-  );
+  expect(notification).toEqual("Agent child-agent (Child Agent) was closed.");
+  expect(scenario.parentPrompts()).toEqual([]);
 });
 
 test("finish notifications survive permission responses", async () => {
@@ -334,11 +318,11 @@ test("finish notifications survive permission responses", async () => {
   scenario.requestChildPermission();
 
   await vi.waitFor(() => {
-    expect(scenario.parentPrompts()).toHaveLength(1);
+    expect(scenario.notifications()).toHaveLength(1);
   });
-  expect(scenario.parentPrompts()[0]).toContain("needs permission.");
+  expect(scenario.notifications()[0]).toContain("needs permission.");
   const permissionPayload = scenario
-    .parentPrompts()[0]
+    .notifications()[0]
     .match(/<permission-request>\n([\s\S]+?)\n<\/permission-request>/)?.[1];
   expect(permissionPayload).toBeDefined();
   expect(JSON.parse(permissionPayload!)).toEqual({
@@ -361,9 +345,10 @@ test("finish notifications survive permission responses", async () => {
   scenario.finishChild();
 
   await vi.waitFor(() => {
-    expect(scenario.parentPrompts()).toHaveLength(2);
+    expect(scenario.notifications()).toHaveLength(2);
   });
-  expect(scenario.parentPrompts()[1]).toContain("finished.");
+  expect(scenario.notifications()[1]).toContain("finished.");
+  expect(scenario.parentPrompts()).toEqual([]);
 });
 
 test("an idle permission resolution waits for the resumed run to finish", async () => {
@@ -371,19 +356,19 @@ test("an idle permission resolution waits for the resumed run to finish", async 
 
   scenario.startWatchingChild();
   scenario.requestChildPermission();
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(1));
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(1));
 
   scenario.resolveChildPermissionWhileIdle();
   scenario.requestChildPermission("permission-2");
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(2));
-  expect(scenario.parentPrompts().every((prompt) => prompt.includes("needs permission."))).toBe(
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(2));
+  expect(scenario.notifications().every((prompt) => prompt.includes("needs permission."))).toBe(
     true,
   );
 
   scenario.resolveChildPermission("permission-2");
   scenario.finishChild();
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(3));
-  expect(scenario.parentPrompts()[2]).toContain("finished.");
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(3));
+  expect(scenario.notifications()[2]).toContain("finished.");
 });
 
 test("finish notifications report every concurrently pending permission", async () => {
@@ -393,9 +378,9 @@ test("finish notifications report every concurrently pending permission", async 
   scenario.requestChildPermission("permission-1");
   scenario.requestChildPermission("permission-2");
 
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(2));
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(2));
   expect(
-    scenario.parentPrompts().map((prompt) => {
+    scenario.notifications().map((prompt) => {
       const payload = prompt.match(/<permission-request>\n([\s\S]+?)\n<\/permission-request>/)?.[1];
       return JSON.parse(payload!).requestId;
     }),
@@ -405,8 +390,8 @@ test("finish notifications report every concurrently pending permission", async 
   scenario.resolveChildPermission("permission-2");
   scenario.finishChild();
 
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(3));
-  expect(scenario.parentPrompts()[2]).toContain("finished.");
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(3));
+  expect(scenario.notifications()[2]).toContain("finished.");
 });
 
 test("finish notifications survive repeated permission cycles", async () => {
@@ -414,17 +399,17 @@ test("finish notifications survive repeated permission cycles", async () => {
 
   scenario.startWatchingChild();
   scenario.requestChildPermission();
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(1));
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(1));
   scenario.resolveChildPermissionFromState();
 
   scenario.requestChildPermission();
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(2));
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(2));
   scenario.resolveChildPermission();
   scenario.finishChild();
 
-  await vi.waitFor(() => expect(scenario.parentPrompts()).toHaveLength(3));
+  await vi.waitFor(() => expect(scenario.notifications()).toHaveLength(3));
   expect(
-    scenario.parentPrompts().map((prompt) => prompt.match(/(needs permission|finished)\./)?.[1]),
+    scenario.notifications().map((prompt) => prompt.match(/(needs permission|finished)\./)?.[1]),
   ).toEqual(["needs permission", "needs permission", "finished"]);
 });
 
@@ -443,31 +428,20 @@ test("follow-up finish notifications do not require a parent relationship", asyn
   const scenario = createFinishNotificationScenario({ childParentAgentId: "another-agent" });
 
   scenario.startWatchingChild();
-  const parentPrompt = await scenario.finishChildAndReadParentPrompt();
+  const notification = await scenario.finishChildAndReadParentPrompt();
 
-  expect(parentPrompt).toContain("Agent child-agent (Child Agent) finished.");
+  expect(notification).toContain("Agent child-agent (Child Agent) finished.");
+  expect(scenario.parentPrompts()).toEqual([]);
 });
 
-test("finish notifications log a rejected parent prompt without an unhandled rejection", async () => {
-  const captured = createCapturedLogger();
+test("finish notifications never attempt a parent provider prompt", async () => {
   const scenario = createFinishNotificationScenario({
     parentPromptError: new Error("parent provider rejected replacement"),
-    logger: captured.logger,
   });
 
   scenario.startWatchingChild();
   await scenario.finishChildAndReadParentPrompt();
-  await captured.nextRecord;
-
-  expect(captured.records).toEqual([
-    expect.objectContaining({
-      msg: "Failed to notify caller agent",
-      childAgentId: "child-agent",
-      callerAgentId: "caller-agent",
-      reason: "finished",
-      err: expect.objectContaining({ message: "parent provider rejected replacement" }),
-    }),
-  ]);
+  expect(scenario.parentPrompts()).toEqual([]);
 });
 
 it("does not notify archived callers", async () => {

--- a/packages/server/src/server/agent/agent-prompt.ts
+++ b/packages/server/src/server/agent/agent-prompt.ts
@@ -250,10 +250,22 @@ export interface SetupFinishNotificationParams {
   childAgentId: string;
   callerAgentId: string;
   requireParentOwnership?: boolean;
+  /**
+   * UI/persistence adapter. It deliberately receives a notification instead of a
+   * prompt so child lifecycle observation cannot become provider dispatch authority.
+   */
+  onNotification?: (notification: FinishNotification) => Promise<void> | void;
   logger: Logger;
 }
 
 type FinishNotificationReason = "finished" | "errored" | "needs permission" | "was closed";
+
+export interface FinishNotification {
+  callerAgentId: string;
+  childAgentId: string;
+  reason: FinishNotificationReason;
+  body: string;
+}
 
 const FINISH_NOTIFICATION_MESSAGE_LIMIT = 4000;
 
@@ -305,6 +317,7 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
     childAgentId,
     callerAgentId,
     requireParentOwnership = false,
+    onNotification,
     logger,
   } = params;
   let hasSeenRunning = false;
@@ -342,14 +355,11 @@ export function setupFinishNotification(params: SetupFinishNotificationParams): 
       permissionRequest,
     });
 
-    await sendPromptToAgent({
-      agentManager,
-      agentStorage,
-      agentId: callerAgentId,
-      prompt: formatSystemNotificationPrompt(body),
-      unarchive: false,
-      logger,
-    });
+    await onNotification?.({ callerAgentId, childAgentId, reason, body });
+    logger.info(
+      { callerAgentId, childAgentId, reason },
+      "Recorded child lifecycle notification without provider continuation",
+    );
   }
 
   function notifySafely(reason: FinishNotificationReason, options: NotifySafelyOptions = {}): void {

--- a/packages/server/src/server/agent/fixtures/version-baseline.json
+++ b/packages/server/src/server/agent/fixtures/version-baseline.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "packageVersion": "0.4.0-beta.2",
+  "daemonVersion": "0.4.0-beta.2",
+  "sourceSha": "36312352db88b2b5c4024465c40ff97fe48f67f0"
+}

--- a/packages/server/src/server/agent/orchestration-group-store.test.ts
+++ b/packages/server/src/server/agent/orchestration-group-store.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { OrchestrationGroupStore } from "./orchestration-group-store.js";
+import { renderOrchestrationResult } from "./orchestration-result-renderer.js";
+
+function createStore() {
+  let now = new Date("2026-08-13T00:00:00.000Z");
+  return {
+    now: () => now,
+    advance(ms: number) {
+      now = new Date(now.getTime() + ms);
+    },
+    store: new OrchestrationGroupStore(join(tmpdir(), `paseo-groups-${Math.random()}`), () => now),
+  };
+}
+
+async function sealedTenChildGroup() {
+  const harness = createStore();
+  const group = await harness.store.create({
+    lineageId: "lineage-1",
+    callerAgentId: "parent-1",
+    workspaceId: "workspace-1",
+    continuationPolicy: "batch",
+    timeoutMs: 10_000,
+    maxSummaryCharsPerChild: 256,
+  });
+  for (let index = 0; index < 10; index += 1) {
+    await harness.store.registerChild(group.id, `child-${index}`);
+  }
+  await harness.store.seal(group.id);
+  return { ...harness, group };
+}
+
+describe("OrchestrationGroupStore", () => {
+  test("AC-01: ten terminal events have one idempotent continuation claim", async () => {
+    const { store, group } = await sealedTenChildGroup();
+    await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        store.recordTerminalEvent(group.id, {
+          agentId: `child-${index}`,
+          eventKey: `event-${index}`,
+          terminalState: "completed",
+          summary: `${index}: ${"x".repeat(300)}`,
+          resultPointer: `agents/child-${index}/results/event-${index}.txt`,
+        }),
+      ),
+    );
+
+    const claimed = await Promise.all([
+      store.claimContinuation(group.id),
+      store.claimContinuation(group.id),
+    ]);
+    expect(claimed.map((result) => result.claimed)).toEqual([true, false]);
+    expect(claimed[0]!.group.children["child-0"]!.summary).toHaveLength(256);
+
+    const duplicate = await store.recordTerminalEvent(group.id, {
+      agentId: "child-0",
+      eventKey: "event-0",
+      terminalState: "completed",
+      summary: "ignored",
+      resultPointer: "ignored",
+    });
+    expect(duplicate.recorded).toBe(false);
+    expect((await store.claimContinuation(group.id)).claimed).toBe(false);
+  });
+
+  test("AC-02: late events after a continuation claim are stored but cannot create another turn", async () => {
+    const { store, group } = await sealedTenChildGroup();
+    for (let index = 0; index < 10; index += 1) {
+      await store.recordTerminalEvent(group.id, {
+        agentId: `child-${index}`,
+        eventKey: `event-${index}`,
+        terminalState: "completed",
+        summary: `summary ${index}`,
+        resultPointer: `agents/child-${index}/result.txt`,
+      });
+    }
+    await store.claimContinuation(group.id);
+    const late = await store.recordTerminalEvent(group.id, {
+      agentId: "child-0",
+      eventKey: "late-provider-observation",
+      terminalState: "failed",
+      summary: "must not replace the terminal result",
+      resultPointer: "agents/child-0/late.txt",
+    });
+    expect(late.recorded).toBe(true);
+    expect(late.group.children["child-0"]!.terminalState).toBe("completed");
+    expect((await store.claimContinuation(group.id)).claimed).toBe(false);
+  });
+
+  test("holds an unconfirmed persisted claim after restart instead of retrying", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "paseo-group-restart-"));
+    const store = new OrchestrationGroupStore(dir, () => new Date("2026-08-13T00:00:00.000Z"));
+    const group = await store.create({
+      lineageId: "lineage-1",
+      callerAgentId: "parent-1",
+      workspaceId: "workspace-1",
+      continuationPolicy: "batch",
+      timeoutMs: 10_000,
+      maxSummaryCharsPerChild: 256,
+    });
+    await store.registerChild(group.id, "child-1");
+    await store.seal(group.id);
+    await store.recordTerminalEvent(group.id, {
+      agentId: "child-1",
+      eventKey: "complete-1",
+      terminalState: "completed",
+      summary: "done",
+      resultPointer: "agents/child-1/result.txt",
+    });
+    await store.claimContinuation(group.id);
+
+    const restarted = new OrchestrationGroupStore(dir);
+    const held = await restarted.recoverUnconfirmedClaims();
+    expect(held).toHaveLength(1);
+    expect(held[0]).toMatchObject({ state: "held", holdReason: "continuation_dispatch_unknown" });
+    expect((await restarted.claimContinuation(group.id)).claimed).toBe(false);
+  });
+
+  test("renders only bounded summaries and inspectable pointers", async () => {
+    const { store, group } = await sealedTenChildGroup();
+    for (let index = 0; index < 10; index += 1) {
+      await store.recordTerminalEvent(group.id, {
+        agentId: `child-${index}`,
+        eventKey: `event-${index}`,
+        terminalState: index === 0 ? "held" : "completed",
+        summary: `summary-${index}`,
+        resultPointer: `agents/child-${index}/result.txt`,
+      });
+    }
+    const result = renderOrchestrationResult((await store.get(group.id))!);
+    expect(result).toContain('"resultPointer":"agents/child-0/result.txt"');
+    expect(result).not.toContain("full private transcript");
+  });
+});

--- a/packages/server/src/server/agent/orchestration-group-store.ts
+++ b/packages/server/src/server/agent/orchestration-group-store.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+
+import { writeJsonFileAtomic } from "../atomic-file.js";
+
+export const OrchestrationTerminalStateSchema = z.enum([
+  "completed",
+  "failed",
+  "cancelled",
+  "held",
+  "timed_out",
+]);
+
+export const OrchestrationGroupSchema = z.object({
+  schemaVersion: z.literal(1),
+  id: z.string().uuid(),
+  lineageId: z.string().min(1),
+  callerAgentId: z.string().min(1),
+  workspaceId: z.string().min(1),
+  repositoryId: z.string().nullable(),
+  checkoutId: z.string().nullable(),
+  expectedChildIds: z.array(z.string().min(1)),
+  children: z.record(
+    z.string(),
+    z.object({
+      terminalState: OrchestrationTerminalStateSchema.nullable(),
+      eventKeys: z.array(z.string().min(1)),
+      summary: z.string().nullable(),
+      resultPointer: z.string().nullable(),
+      terminalAt: z.string().nullable(),
+    }),
+  ),
+  continuationPolicy: z.enum(["batch", "none"]),
+  state: z.enum([
+    "open",
+    "sealed",
+    "terminal",
+    "continuation_claimed",
+    "continued",
+    "held",
+    "expired",
+  ]),
+  maxSummaryCharsPerChild: z.number().int().min(256).max(4000),
+  continuationKey: z.string().nullable(),
+  continuationClaimedAt: z.string().nullable(),
+  continuationTurnId: z.string().nullable(),
+  holdReason: z.string().nullable(),
+  createdAt: z.string(),
+  sealedAt: z.string().nullable(),
+  expiresAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type OrchestrationGroup = z.infer<typeof OrchestrationGroupSchema>;
+export type OrchestrationTerminalState = z.infer<typeof OrchestrationTerminalStateSchema>;
+
+export interface CreateOrchestrationGroupInput {
+  lineageId: string;
+  callerAgentId: string;
+  workspaceId: string;
+  repositoryId?: string | null;
+  checkoutId?: string | null;
+  continuationPolicy: "batch" | "none";
+  timeoutMs: number;
+  maxSummaryCharsPerChild: number;
+}
+
+export interface RecordTerminalEventInput {
+  agentId: string;
+  eventKey: string;
+  terminalState: OrchestrationTerminalState;
+  summary: string | null;
+  resultPointer: string | null;
+}
+
+/**
+ * Durable, per-group mutation serialization. A continuation claim is written before a
+ * dispatcher is allowed to run, making a process crash fail closed instead of retrying.
+ */
+export class OrchestrationGroupStore {
+  private readonly pending = new Map<string, Promise<unknown>>();
+
+  constructor(
+    private readonly dir: string,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  private path(id: string): string {
+    return join(this.dir, `${id}.json`);
+  }
+
+  private async getUnsafe(id: string): Promise<OrchestrationGroup | null> {
+    try {
+      return OrchestrationGroupSchema.parse(JSON.parse(await readFile(this.path(id), "utf8")));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+  }
+
+  private async write(group: OrchestrationGroup): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+    await writeJsonFileAtomic(this.path(group.id), group);
+  }
+
+  private mutate<T>(id: string, fn: (group: OrchestrationGroup) => T | Promise<T>): Promise<T> {
+    const previous = this.pending.get(id) ?? Promise.resolve();
+    const next = previous.then(async () => {
+      const group = await this.getUnsafe(id);
+      if (!group) throw new Error(`Orchestration group ${id} not found`);
+      const result = await fn(group);
+      await this.write(group);
+      return result;
+    });
+    const tracked = next.finally(() => {
+      if (this.pending.get(id) === tracked) this.pending.delete(id);
+    });
+    this.pending.set(id, tracked);
+    return tracked;
+  }
+
+  async create(input: CreateOrchestrationGroupInput): Promise<OrchestrationGroup> {
+    if (
+      !Number.isInteger(input.timeoutMs) ||
+      input.timeoutMs < 1000 ||
+      input.timeoutMs > 86_400_000
+    ) {
+      throw new Error("timeoutMs must be an integer between 1,000 and 86,400,000");
+    }
+    if (
+      !Number.isInteger(input.maxSummaryCharsPerChild) ||
+      input.maxSummaryCharsPerChild < 256 ||
+      input.maxSummaryCharsPerChild > 4000
+    ) {
+      throw new Error("maxSummaryCharsPerChild must be an integer between 256 and 4,000");
+    }
+    const createdAt = this.now().toISOString();
+    const group = OrchestrationGroupSchema.parse({
+      schemaVersion: 1,
+      id: randomUUID(),
+      ...input,
+      repositoryId: input.repositoryId ?? null,
+      checkoutId: input.checkoutId ?? null,
+      expectedChildIds: [],
+      children: {},
+      state: "open",
+      continuationKey: null,
+      continuationClaimedAt: null,
+      continuationTurnId: null,
+      holdReason: null,
+      createdAt,
+      sealedAt: null,
+      expiresAt: new Date(this.now().getTime() + input.timeoutMs).toISOString(),
+      updatedAt: createdAt,
+    });
+    await this.write(group);
+    return group;
+  }
+
+  async get(id: string): Promise<OrchestrationGroup | null> {
+    return this.getUnsafe(id);
+  }
+
+  async registerChild(id: string, agentId: string): Promise<OrchestrationGroup> {
+    return this.mutate(id, (group) => {
+      if (group.state !== "open")
+        throw new Error("Cannot register a child after a group is sealed");
+      if (!group.children[agentId]) {
+        group.expectedChildIds.push(agentId);
+        group.children[agentId] = {
+          terminalState: null,
+          eventKeys: [],
+          summary: null,
+          resultPointer: null,
+          terminalAt: null,
+        };
+      }
+      group.updatedAt = this.now().toISOString();
+      return group;
+    });
+  }
+
+  async seal(id: string): Promise<OrchestrationGroup> {
+    return this.mutate(id, (group) => {
+      if (group.state === "open") {
+        group.state = "sealed";
+        group.sealedAt = this.now().toISOString();
+      }
+      this.evaluateTerminal(group);
+      group.updatedAt = this.now().toISOString();
+      return group;
+    });
+  }
+
+  async recordTerminalEvent(
+    id: string,
+    input: RecordTerminalEventInput,
+  ): Promise<{
+    group: OrchestrationGroup;
+    recorded: boolean;
+  }> {
+    return this.mutate(id, (group) => {
+      const child = group.children[input.agentId];
+      if (!child) throw new Error("Child is not registered in this orchestration group");
+      if (child.eventKeys.includes(input.eventKey)) return { group, recorded: false };
+      child.eventKeys.push(input.eventKey);
+      // First terminal event wins. Later provider observations are retained as keys only.
+      if (child.terminalState === null) {
+        child.terminalState = input.terminalState;
+        child.summary = input.summary?.slice(0, group.maxSummaryCharsPerChild) ?? null;
+        child.resultPointer = input.resultPointer;
+        child.terminalAt = this.now().toISOString();
+      }
+      this.evaluateTerminal(group);
+      group.updatedAt = this.now().toISOString();
+      return { group, recorded: true };
+    });
+  }
+
+  async claimContinuation(id: string): Promise<{ group: OrchestrationGroup; claimed: boolean }> {
+    return this.mutate(id, (group) => {
+      this.evaluateTerminal(group);
+      if (
+        (group.state !== "terminal" && group.state !== "expired") ||
+        group.continuationPolicy !== "batch"
+      ) {
+        return { group, claimed: false };
+      }
+      group.state = "continuation_claimed";
+      group.continuationKey = `${group.id}:completion`;
+      group.continuationClaimedAt = this.now().toISOString();
+      group.updatedAt = this.now().toISOString();
+      return { group, claimed: true };
+    });
+  }
+
+  async confirmContinuation(id: string, turnId: string): Promise<OrchestrationGroup> {
+    return this.mutate(id, (group) => {
+      if (group.state !== "continuation_claimed") throw new Error("Continuation was not claimed");
+      group.state = "continued";
+      group.continuationTurnId = turnId;
+      group.updatedAt = this.now().toISOString();
+      return group;
+    });
+  }
+
+  async recoverUnconfirmedClaims(): Promise<OrchestrationGroup[]> {
+    await mkdir(this.dir, { recursive: true });
+    const { readdir } = await import("node:fs/promises");
+    const files = await readdir(this.dir);
+    const held: OrchestrationGroup[] = [];
+    for (const file of files.filter((entry) => entry.endsWith(".json"))) {
+      const id = file.slice(0, -5);
+      const result = await this.mutate(id, (group) => {
+        if (group.state === "continuation_claimed" && !group.continuationTurnId) {
+          group.state = "held";
+          group.holdReason = "continuation_dispatch_unknown";
+          group.updatedAt = this.now().toISOString();
+          held.push(group);
+        }
+        return group;
+      });
+      void result;
+    }
+    return held;
+  }
+
+  private evaluateTerminal(group: OrchestrationGroup): void {
+    if (group.state !== "sealed") return;
+    const expired = new Date(group.expiresAt).getTime() <= this.now().getTime();
+    const allTerminal = group.expectedChildIds.every(
+      (id) => group.children[id]?.terminalState !== null,
+    );
+    if (!expired && !allTerminal) return;
+    if (expired) {
+      for (const id of group.expectedChildIds) {
+        const child = group.children[id]!;
+        if (child.terminalState === null) {
+          child.terminalState = "timed_out";
+          child.terminalAt = this.now().toISOString();
+        }
+      }
+      group.state = "expired";
+    } else {
+      group.state = "terminal";
+    }
+  }
+}

--- a/packages/server/src/server/agent/orchestration-result-renderer.ts
+++ b/packages/server/src/server/agent/orchestration-result-renderer.ts
@@ -1,0 +1,15 @@
+import type { OrchestrationGroup } from "./orchestration-group-store.js";
+
+/** The only completion payload suitable for a parent context: bounded summaries and pointers. */
+export function renderOrchestrationResult(group: OrchestrationGroup): string {
+  const children = group.expectedChildIds.map((agentId) => {
+    const child = group.children[agentId]!;
+    return {
+      agentId,
+      terminalState: child.terminalState,
+      summary: child.summary,
+      resultPointer: child.resultPointer,
+    };
+  });
+  return JSON.stringify({ groupId: group.id, state: group.state, children });
+}

--- a/packages/server/src/server/agent/source-identity.test.ts
+++ b/packages/server/src/server/agent/source-identity.test.ts
@@ -1,0 +1,15 @@
+import baseline from "./fixtures/version-baseline.json" with { type: "json" };
+import { expect, test } from "vitest";
+
+import { verifyReviewedSourceIdentity } from "./source-identity.js";
+
+test("fails closed unless installed daemon, package, and reviewed source identities match", () => {
+  expect(verifyReviewedSourceIdentity(baseline, baseline)).toEqual({ allowed: true });
+  expect(
+    verifyReviewedSourceIdentity(baseline, { ...baseline, daemonVersion: "0.4.0-beta.1" }),
+  ).toEqual({ allowed: false, reason: "source_identity_mismatch" });
+  expect(verifyReviewedSourceIdentity(baseline, { ...baseline, sourceSha: null })).toEqual({
+    allowed: false,
+    reason: "source_identity_mismatch",
+  });
+});

--- a/packages/server/src/server/agent/source-identity.ts
+++ b/packages/server/src/server/agent/source-identity.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+const SourceBaselineSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    packageVersion: z.string().min(1),
+    daemonVersion: z.string().min(1),
+    sourceSha: z.string().regex(/^[0-9a-f]{40}$/),
+  })
+  .strict();
+
+export type SourceBaseline = z.infer<typeof SourceBaselineSchema>;
+
+export function verifyReviewedSourceIdentity(
+  baseline: unknown,
+  observed: {
+    packageVersion: string | null;
+    daemonVersion: string | null;
+    sourceSha: string | null;
+  },
+): { allowed: true } | { allowed: false; reason: "source_identity_mismatch" } {
+  const expected = SourceBaselineSchema.parse(baseline);
+  if (
+    observed.packageVersion !== expected.packageVersion ||
+    observed.daemonVersion !== expected.daemonVersion ||
+    observed.sourceSha !== expected.sourceSha
+  ) {
+    return { allowed: false, reason: "source_identity_mismatch" };
+  }
+  return { allowed: true };
+}


### PR DESCRIPTION
## Summary
- separate child lifecycle notifications from provider prompts
- add durable bounded orchestration groups and at-most-once continuation claims
- add reviewed-source identity evidence with fail-closed validation

## Validation
- pnpm test
- pnpm exec tsc --noEmit
- npm run build:server