### PR TITLE
fix(omp): preserve described select options

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -5,6 +5,7 @@ import type { PaseoToolCatalog } from "../../tools/types.js";
 import type { OmpNoTurnScheduler, OmpProviderIdleScheduler } from "./agent.js";
 import type { OmpUsagePollScheduler } from "./usage-poller.js";
 import { resolveOmpProviderParams } from "./provider-config.js";
+import { OmpRuntimeEventSchema } from "./rpc-types.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
 
 test("OMP ready timeout defaults to 20 seconds and RPC timeout overrides both", () => {
@@ -17,7 +18,6 @@ test("OMP ready timeout defaults to 20 seconds and RPC timeout overrides both", 
     rpcTimeoutMs: 90_000,
   });
 });
-
 class ManualIdleScheduler implements OmpProviderIdleScheduler {
   private readonly retries: Array<() => void> = [];
   private readonly waiters: Array<{ count: number; resolve: () => void }> = [];
@@ -536,6 +536,113 @@ describe("OMP agent client and session", () => {
     expect(omp.extensionUiResponses()).toEqual([
       { id: "approval-1", response: { value: "Approve" } },
     ]);
+  });
+
+  test("maps legacy select options without descriptions and preserves ordinary responses", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.emit({
+      type: "extension_ui_request",
+      id: "select-legacy",
+      method: "select",
+      title: "Choose",
+      options: ["Approve", "Deny"],
+    });
+
+    expect(omp.pendingPermissions()[0]?.input).toMatchObject({
+      questions: [{ options: [{ label: "Approve" }, { label: "Deny" }] }],
+    });
+    await omp.respondToPermission("select-legacy", {
+      behavior: "allow",
+      updatedInput: { answers: { Response: "Deny" } },
+    });
+    expect(omp.extensionUiResponses()).toContainEqual({
+      id: "select-legacy",
+      response: { value: "Deny" },
+    });
+  });
+
+  test("maps described and mixed select metadata by option index", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    omp.emit({
+      type: "extension_ui_request",
+      id: "select-described",
+      method: "select",
+      title: "Choose",
+      options: ["First", "Second", "Third"],
+      optionDetails: [{ description: "First detail" }, {}, { description: " \t" }],
+    });
+
+    expect(omp.pendingPermissions()[0]?.input).toMatchObject({
+      questions: [
+        {
+          options: [
+            { label: "First", description: "First detail" },
+            { label: "Second" },
+            { label: "Third" },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("accepts malformed or misaligned optional metadata and falls back to labels", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    const parsed = OmpRuntimeEventSchema.safeParse({
+      type: "extension_ui_request",
+      id: "select-malformed",
+      method: "select",
+      options: ["First", "Second"],
+      optionDetails: [{ description: 42 }, { description: "\n\t" }, { description: "extra" }],
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw new Error("Expected malformed metadata event to parse");
+
+    omp.emit(parsed.data);
+    expect(omp.pendingPermissions()[0]?.input).toMatchObject({
+      questions: [{ options: [{ label: "First" }, { label: "Second" }] }],
+    });
+  });
+
+  test("preserves combined selection descriptions and freeform sentinel behavior", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+    omp.emit({
+      type: "tool_execution_start",
+      toolCallId: "ask-user-1",
+      toolName: "ask_user",
+      args: { allowComment: true, allowFreeform: true, allowMultiple: false },
+    });
+    omp.emit({
+      type: "extension_ui_request",
+      id: "select-combined",
+      method: "select",
+      title: "Choose",
+      options: ["First", "✏️ Type custom response..."],
+      optionDetails: [{ description: "First detail" }, { description: "ignored" }],
+    });
+
+    expect(omp.pendingPermissions()[0]?.input).toMatchObject({
+      questions: [
+        {
+          options: [{ label: "First", description: "First detail" }],
+          allowOther: true,
+        },
+        { header: "Comment" },
+      ],
+    });
+    await omp.respondToPermission("select-combined", {
+      behavior: "allow",
+      updatedInput: { answers: { Response: "custom", Comment: "note" } },
+    });
+    expect(omp.extensionUiResponses()).toContainEqual({
+      id: "select-combined",
+      response: { value: "✏️ Type custom response..." },
+    });
   });
 
   test("exposes OMP modes and commands through the domain session", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -576,17 +576,11 @@ describe("OMP agent client and session", () => {
       optionDetails: [{ description: "First detail" }, {}, { description: " \t" }],
     });
 
-    expect(omp.pendingPermissions()[0]?.input).toMatchObject({
-      questions: [
-        {
-          options: [
-            { label: "First", description: "First detail" },
-            { label: "Second" },
-            { label: "Third" },
-          ],
-        },
-      ],
-    });
+    expect(omp.pendingPermissions()[0]?.input?.questions?.[0]?.options).toStrictEqual([
+      { label: "First", description: "First detail" },
+      { label: "Second" },
+      { label: "Third" },
+    ]);
   });
 
   test("accepts malformed or misaligned optional metadata and falls back to labels", async () => {
@@ -603,9 +597,10 @@ describe("OMP agent client and session", () => {
     if (!parsed.success) throw new Error("Expected malformed metadata event to parse");
 
     omp.emit(parsed.data);
-    expect(omp.pendingPermissions()[0]?.input).toMatchObject({
-      questions: [{ options: [{ label: "First" }, { label: "Second" }] }],
-    });
+    expect(omp.pendingPermissions()[0]?.input?.questions?.[0]?.options).toStrictEqual([
+      { label: "First" },
+      { label: "Second" },
+    ]);
   });
 
   test("preserves combined selection descriptions and freeform sentinel behavior", async () => {
@@ -626,14 +621,12 @@ describe("OMP agent client and session", () => {
       optionDetails: [{ description: "First detail" }, { description: "ignored" }],
     });
 
-    expect(omp.pendingPermissions()[0]?.input).toMatchObject({
-      questions: [
-        {
-          options: [{ label: "First", description: "First detail" }],
-          allowOther: true,
-        },
-        { header: "Comment" },
-      ],
+    const combinedInput = omp.pendingPermissions()[0]?.input;
+    expect(combinedInput?.questions?.[0]?.options).toStrictEqual([
+      { label: "First", description: "First detail" },
+    ]);
+    expect(combinedInput).toMatchObject({
+      questions: [{ allowOther: true }, { header: "Comment" }],
     });
     await omp.respondToPermission("select-combined", {
       behavior: "allow",

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -563,6 +563,24 @@ function getInputQuestionTitle(title: string | undefined, placeholder: string | 
   return "Optional response";
 }
 
+interface OmpSelectOption {
+  label: string;
+  description?: string;
+}
+
+function readSelectOptions(options: unknown, optionDetails: unknown): OmpSelectOption[] {
+  const labels = readStringArray(options);
+  const details = Array.isArray(optionDetails) ? optionDetails : [];
+  return labels.map((label, index) => {
+    const detail = details[index];
+    const description =
+      isRecord(detail) && typeof detail.description === "string" && detail.description.trim() !== ""
+        ? detail.description
+        : undefined;
+    return description === undefined ? { label } : { label, description };
+  });
+}
+
 function readStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string")
@@ -581,7 +599,7 @@ function mapExtensionUiRequestToPermission(
   const label = options.label ?? "OMP";
   switch (event.method) {
     case "select": {
-      const selectOptions = readStringArray(event.options);
+      const selectOptions = readSelectOptions(event.options, event.optionDetails);
       if (options.combineOptionalComment) {
         return buildCombinedAskUserQuestionPermission(event, {
           provider,
@@ -628,7 +646,7 @@ function mapExtensionUiRequestToPermission(
         question: [optionalString(event.title), optionalString(event.message)]
           .filter(Boolean)
           .join("\n\n"),
-        options: ["Yes", "No"],
+        options: [{ label: "Yes" }, { label: "No" }],
         multiSelect: false,
       });
     default:
@@ -673,7 +691,7 @@ function buildExtensionUiQuestionPermission(
     provider: AgentProvider;
     label: string;
     question: string;
-    options: string[];
+    options: OmpSelectOption[];
     multiSelect: boolean;
     placeholder?: string;
     allowEmpty?: boolean;
@@ -691,7 +709,10 @@ function buildExtensionUiQuestionPermission(
         {
           question: input.question,
           header: QUESTION_RESPONSE_HEADER,
-          options: input.options.map((label) => ({ label })),
+          options: input.options.map((option) => ({
+            label: option.label,
+            ...(option.description === undefined ? {} : { description: option.description }),
+          })),
           multiSelect: input.multiSelect,
           ...(input.placeholder ? { placeholder: input.placeholder } : {}),
           ...(input.allowEmpty ? { allowEmpty: true } : {}),
@@ -712,11 +733,13 @@ function buildCombinedAskUserQuestionPermission(
     provider: AgentProvider;
     label: string;
     question: string;
-    options: string[];
+    options: OmpSelectOption[];
     allowFreeform: boolean;
   },
 ): AgentPermissionRequest {
-  const visibleOptions = input.options.filter((option) => !isOmpAskUserFreeformOption(option));
+  const visibleOptions = input.options.filter(
+    (option) => !isOmpAskUserFreeformOption(option.label),
+  );
   const allowOther = input.allowFreeform || visibleOptions.length !== input.options.length;
   return {
     id: event.id,
@@ -729,7 +752,10 @@ function buildCombinedAskUserQuestionPermission(
         {
           question: input.question,
           header: QUESTION_RESPONSE_HEADER,
-          options: visibleOptions.map((label) => ({ label })),
+          options: visibleOptions.map((option) => ({
+            label: option.label,
+            ...(option.description === undefined ? {} : { description: option.description }),
+          })),
           multiSelect: false,
           ...(allowOther ? { allowOther: true } : {}),
         },
@@ -748,7 +774,7 @@ function buildCombinedAskUserQuestionPermission(
       answerHeader: QUESTION_RESPONSE_HEADER,
       commentHeader: QUESTION_COMMENT_HEADER,
       combinedAskUser: COMBINED_ASK_USER_METADATA,
-      selectOptions: visibleOptions,
+      selectOptions: visibleOptions.map((option) => option.label),
       ...(allowOther ? { freeformSentinel: OMP_ASK_USER_FREEFORM_SENTINEL } : {}),
     },
   };

--- a/packages/server/src/server/agent/providers/omp/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/omp/rpc-types.ts
@@ -444,6 +444,7 @@ const OmpExtensionUiRequestSchema = z
     title: z.string().optional(),
     message: z.string().optional(),
     options: z.array(z.string()).optional(),
+    optionDetails: z.unknown().optional(),
     placeholder: z.string().optional(),
     url: z.string().optional(),
     launchUrl: z.string().optional(),

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -19,7 +19,7 @@ import {
   type OmpProviderIdleScheduler,
 } from "../agent.js";
 import type { OmpUsagePollScheduler } from "../usage-poller.js";
-import type { OmpAgentMessage, OmpRpcSlashCommand } from "../rpc-types.js";
+import type { OmpAgentMessage, OmpRpcSlashCommand, OmpRuntimeEvent } from "../rpc-types.js";
 import { FakeOmp } from "./fake-omp.js";
 
 const CWD = "/tmp/paseo-omp-agent-test";
@@ -420,6 +420,10 @@ export class OmpHarness {
     detail: string;
   }): void {
     this.omp.latestSession().requestToolApproval(input);
+  }
+
+  emit(event: OmpRuntimeEvent): void {
+    this.omp.latestSession().emit(event);
   }
 
   pendingPermissions() {


### PR DESCRIPTION
### Linked issue

Closes #3527

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

OMP Ask can attach descriptions to select options, but Paseo currently reduces every RPC select option to its label. The question card therefore loses context that OMP users see in its native UI.

The companion OMP RPC schema addition was proposed in can1357/oh-my-pi#9175 and shipped in OMP 17.4.2 through can1357/oh-my-pi#9176. This PR implements the Paseo consumer. The metadata is optional, so older OMP versions remain supported with their existing label-only behavior.

### Goals

- Preserve valid positional option descriptions from OMP `extension_ui_request` select events.
- Keep labels and selected response values unchanged.
- Preserve ordinary, combined, and freeform Ask flows.
- Ignore malformed, missing, extra, or whitespace-only metadata per option without rejecting the dialog.
- Keep the RPC boundary backward-compatible with pre-17.4.2 OMP releases.

### Non-goals

- Raising Paseo's minimum supported OMP version. Descriptions require OMP 17.4.2+, but the provider does not.
- Adding a Paseo-specific recommended-option field. OMP currently carries this by appending ` (Recommended)` to the label.
- Changing the existing question-card UI.

### Before / after

<table>
<tr>
<th>Before — OMP descriptions were dropped</th>
<th>After — descriptions reach the question card</th>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/ZGEnergy/paseo/pr-assets-3628/pr-assets/3628/before.png" alt="Before: the OMP Ask card shows labels without descriptions"></td>
<td><img src="https://raw.githubusercontent.com/ZGEnergy/paseo/pr-assets-3628/pr-assets/3628/after.png" alt="After: the OMP Ask card shows each option description"></td>
</tr>
</table>

### QA

#### Automated

```text
$ npx vitest run packages/server/src/server/agent/providers/omp/agent.test.ts --bail=1
Test Files  1 passed (1)
Tests       32 passed (32)
```

`npm run build:server` passed. This refreshed the protocol, client, plugin, relay, server, and CLI declarations consumed across workspaces.

```text
$ npm run typecheck
@getpaseo/expo-two-way-audio  passed
@getpaseo/highlight           passed
@getpaseo/plugin              passed
@getpaseo/protocol            passed
@getpaseo/client              passed
@getpaseo/server              passed
@getpaseo/app                 passed
@getpaseo/relay               passed
@getpaseo/website             passed
@getpaseo/desktop             passed
@getpaseo/cli                 passed
```

`npm run lint -- <four changed files>`: 0 warnings, 0 errors.

`npm run format:files -- <four changed files>`: passed.

The fork's upstream-port preflight passed with exactly the four changed OMP provider paths. A focused reviewer found no blocker or advisory issue and rated the patch READY with 0.97 confidence.

#### Real OMP

Environment: Linux web client, Chromium, real `omp/18.0.6`, `openai-codex/gpt-5.6-sol`.

Prompted OMP to call Ask with two described options and mark the first recommended. Paseo rendered:

```text
Choose a rollout

Safe (Recommended)
Stages changes with verification

Fast
Applies everything immediately
```

Selecting and submitting `Safe (Recommended)` resolved the permission; OMP continued with `Safe selected.` The daemon recorded one `agent_permission_request`, one `agent_permission_response`, and one `permission_resolved`.

Legacy label-only behavior is covered by the provider harness. It was not manually exercised with an older OMP binary in this pass.

| Platform | Tested | Notes |
| --- | --- | --- |
| Web on Linux | Yes | Real OMP described Ask and selected response |
| Electron Linux | No | Server mapping is shared; no desktop run |
| Desktop macOS/Windows | No | Not available in this pass |
| iOS/Android | No | Not available in this pass |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes for changed files
- [x] QA evidence
- [x] Tests added or updated where it made sense
