### PR TITLE
fix(server): run worktree.setup/teardown in one login shell session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,16 @@ jobs:
         if: ${{ needs.changes.outputs.full != 'false' || needs.changes.outputs.server != 'false' }}
         run: node scripts/npm-retry.mjs install -g @anthropic-ai/claude-code opencode-ai
 
+      # fish is exercised by the worktree.setup/teardown lifecycle-shell tests
+      # (packages/server/src/utils/worktree-lifecycle-shell.test.ts); without
+      # it those cases skip instead of running. Linux-only: this job's steps
+      # are shared with server-tests-windows via the *server_test_steps
+      # anchor, and fish isn't part of the lifecycle-shell dialect support on
+      # win32 (that platform always uses the legacy per-entry loop).
+      - name: Install fish
+        if: ${{ runner.os == 'Linux' && (needs.changes.outputs.full != 'false' || needs.changes.outputs.server != 'false') }}
+        run: sudo apt-get update && sudo apt-get install -y fish
+
       - name: Build server dependencies
         run: npm run build:server-deps
 

--- a/packages/server/src/server/worktree-bootstrap.ts
+++ b/packages/server/src/server/worktree-bootstrap.ts
@@ -322,7 +322,10 @@ export function buildWorktreeSetupDetail(input: {
       log: renderedLog.log,
       status: commandStatusFromResult(result),
       exitCode: result.exitCode,
-      ...(result.durationMs > 0 ? { durationMs: result.durationMs } : {}),
+      // durationMs is only meaningful once the command has actually
+      // completed — gate on exitCode rather than durationMs itself, since a
+      // completed command can genuinely finish in under a millisecond.
+      ...(result.exitCode !== null ? { durationMs: result.durationMs } : {}),
     };
   });
   const renderedLog = buildWorktreeSetupLog({

--- a/packages/server/src/utils/worktree-lifecycle-shell.test.ts
+++ b/packages/server/src/utils/worktree-lifecycle-shell.test.ts
@@ -1,0 +1,329 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWorktreeLifecycleScript,
+  buildWorktreeLifecycleShellInvocation,
+  createWorktreeLifecycleOutputParser,
+  resolveWorktreeLifecycleShell,
+} from "./worktree-lifecycle-shell.js";
+import type { WorktreeSetupCommandProgressEvent } from "./worktree.js";
+
+function hasCommandOnPath(command: string): boolean {
+  const result = spawnSync(command, ["-c", "true"], { stdio: "ignore" });
+  return !result.error && result.status === 0;
+}
+
+const bashAvailable = hasCommandOnPath("bash");
+const fishAvailable = hasCommandOnPath("fish");
+
+describe("resolveWorktreeLifecycleShell", () => {
+  it("returns null when SHELL is unset", () => {
+    expect(resolveWorktreeLifecycleShell({})).toBeNull();
+  });
+
+  it("returns null for unrecognized shells", () => {
+    expect(resolveWorktreeLifecycleShell({ SHELL: "/bin/dash" })).toBeNull();
+    expect(resolveWorktreeLifecycleShell({ SHELL: "/bin/tcsh" })).toBeNull();
+  });
+
+  it("recognizes zsh", () => {
+    expect(resolveWorktreeLifecycleShell({ SHELL: "/bin/zsh" })).toEqual({
+      shell: "/bin/zsh",
+      dialect: "zsh",
+    });
+  });
+
+  it("recognizes bash", () => {
+    expect(resolveWorktreeLifecycleShell({ SHELL: "/opt/homebrew/bin/bash" })).toEqual({
+      shell: "/opt/homebrew/bin/bash",
+      dialect: "bash",
+    });
+  });
+
+  it("recognizes fish", () => {
+    expect(resolveWorktreeLifecycleShell({ SHELL: "/usr/local/bin/fish" })).toEqual({
+      shell: "/usr/local/bin/fish",
+      dialect: "fish",
+    });
+  });
+});
+
+describe("buildWorktreeLifecycleShellInvocation", () => {
+  it("invokes the resolved shell as login and interactive", () => {
+    expect(buildWorktreeLifecycleShellInvocation({ shell: "/bin/zsh", script: "echo hi" })).toEqual(
+      {
+        shell: "/bin/zsh",
+        args: ["-i", "-l", "-c", "echo hi"],
+      },
+    );
+  });
+});
+
+describe("buildWorktreeLifecycleScript", () => {
+  it("omits the PATH preamble when no original PATH is supplied", () => {
+    const { script } = buildWorktreeLifecycleScript({
+      commands: ["true"],
+      originalPath: undefined,
+      dialect: "bash",
+    });
+    expect(script).not.toContain("export PATH=");
+  });
+
+  it("generates a distinct marker token per call", () => {
+    const first = buildWorktreeLifecycleScript({
+      commands: ["true"],
+      originalPath: undefined,
+      dialect: "bash",
+    });
+    const second = buildWorktreeLifecycleScript({
+      commands: ["true"],
+      originalPath: undefined,
+      dialect: "bash",
+    });
+    expect(first.markerToken).not.toBe(second.markerToken);
+    expect(first.markerToken).toMatch(/^__paseo_lifecycle_[0-9a-f]+__$/);
+  });
+
+  it("stops after the first non-zero exit (bash/zsh dialect)", () => {
+    const { script } = buildWorktreeLifecycleScript({
+      commands: ["true", "false"],
+      originalPath: undefined,
+      dialect: "bash",
+    });
+    expect(script).toContain('if [ "$__paseo_lifecycle_status" -ne 0 ]; then exit');
+  });
+
+  it("stops after the first non-zero exit (fish dialect)", () => {
+    const { script } = buildWorktreeLifecycleScript({
+      commands: ["true", "false"],
+      originalPath: undefined,
+      dialect: "fish",
+    });
+    expect(script).toContain('if test "$__paseo_lifecycle_status" -ne 0');
+    expect(script).not.toContain("export PATH=");
+  });
+
+  it("uses fish's list-valued PATH syntax instead of a colon-joined string", () => {
+    const { script } = buildWorktreeLifecycleScript({
+      commands: ["true"],
+      originalPath: "/from/daemon",
+      dialect: "fish",
+    });
+    expect(script).toContain("set -gx PATH $PATH (string split ':' -- '/from/daemon')");
+  });
+
+  it.skipIf(!bashAvailable)(
+    "appends the daemon's original PATH after whatever the script body sets, safely quoted (bash)",
+    () => {
+      const originalPath = "/from/daemon:/also with a ' quote";
+      // Starting PATH stands in for "whatever the profile left PATH as" —
+      // real bash must still be resolvable to spawn it at all, so prepend a
+      // marker directory to the real PATH rather than replacing it outright.
+      const startingPath = `/from/profile:${process.env.PATH ?? ""}`;
+      const { script } = buildWorktreeLifecycleScript({
+        commands: [`printf '%s' "$PATH"`],
+        originalPath,
+        dialect: "bash",
+      });
+      const result = spawnSync("bash", ["-c", script], {
+        encoding: "utf8",
+        env: { PATH: startingPath },
+      });
+      expect(result.status).toBe(0);
+      // The last marker-delimited stdout segment is the printf output; strip
+      // marker lines to isolate it.
+      const contentLines = (result.stdout ?? "")
+        .split("\n")
+        .filter((line) => !line.includes("__paseo_lifecycle_"));
+      expect(contentLines.join("")).toBe(`${startingPath}:${originalPath}`);
+    },
+  );
+
+  it.skipIf(!fishAvailable)(
+    "appends the daemon's original PATH after whatever the script body sets, safely quoted (fish)",
+    () => {
+      const originalPath = "/from/daemon:/also with a ' quote";
+      const startingPath = `/from/profile:${process.env.PATH ?? ""}`;
+      const { script } = buildWorktreeLifecycleScript({
+        commands: [`printf '%s' "$PATH"`],
+        originalPath,
+        dialect: "fish",
+      });
+      const result = spawnSync("fish", ["-c", script], {
+        encoding: "utf8",
+        env: { PATH: startingPath },
+      });
+      expect(result.status).toBe(0);
+      const contentLines = (result.stdout ?? "")
+        .split("\n")
+        .filter((line) => !line.includes("__paseo_lifecycle_"));
+      expect(contentLines.join("")).toBe(`${startingPath}:${originalPath}`);
+    },
+  );
+});
+
+describe("createWorktreeLifecycleOutputParser", () => {
+  const DIALECTS: Array<{
+    label: string;
+    dialect: "bash" | "fish";
+    shell: string;
+    available: boolean;
+  }> = [
+    { label: "bash", dialect: "bash", shell: "bash", available: bashAvailable },
+    { label: "fish", dialect: "fish", shell: "fish", available: fishAvailable },
+  ];
+
+  function runScript(dialect: "bash" | "fish", shell: string, commands: string[]) {
+    const { script, markerToken } = buildWorktreeLifecycleScript({
+      commands,
+      originalPath: undefined,
+      dialect,
+    });
+    const result = spawnSync(shell, ["-c", script], {
+      encoding: "utf8",
+      env: process.env,
+    });
+    return { result, markerToken };
+  }
+
+  function extractEventTypes(events: WorktreeSetupCommandProgressEvent[]): string[] {
+    return events.map((event) => event.type);
+  }
+
+  for (const { label, dialect, shell, available } of DIALECTS) {
+    it.skipIf(!available)(
+      `[${label}] reconstructs one result per command from a single shell process`,
+      () => {
+        const { result, markerToken } = runScript(dialect, shell, [
+          'echo "one stdout"',
+          'echo "two stdout"; echo "two stderr" 1>&2',
+        ]);
+        expect(result.status).toBe(0);
+
+        const parser = createWorktreeLifecycleOutputParser({
+          markerToken,
+          commands: ["cmd1", "cmd2"],
+          cwd: "/worktree",
+        });
+        parser.feed("stdout", result.stdout ?? "");
+        parser.feed("stderr", result.stderr ?? "");
+        const results = parser.finalize(result.status ?? null);
+
+        expect(results).toHaveLength(2);
+        expect(results[0]).toMatchObject({ command: "cmd1", cwd: "/worktree", exitCode: 0 });
+        expect(results[0]?.stdout).toContain("one stdout");
+        expect(results[1]).toMatchObject({ command: "cmd2", cwd: "/worktree", exitCode: 0 });
+        expect(results[1]?.stdout).toContain("two stdout");
+        expect(results[1]?.stderr).toContain("two stderr");
+      },
+    );
+
+    it.skipIf(!available)(
+      `[${label}] stops at the first failing command and never reports later entries`,
+      () => {
+        const { result, markerToken } = runScript(dialect, shell, [
+          "true",
+          "exit 7",
+          "echo should-not-run",
+        ]);
+        expect(result.status).toBe(7);
+
+        const parser = createWorktreeLifecycleOutputParser({
+          markerToken,
+          commands: ["cmd1", "cmd2", "cmd3"],
+          cwd: "/worktree",
+        });
+        parser.feed("stdout", result.stdout ?? "");
+        parser.feed("stderr", result.stderr ?? "");
+        const results = parser.finalize(result.status ?? null);
+
+        expect(results).toHaveLength(2);
+        expect(results[0]?.exitCode).toBe(0);
+        expect(results[1]?.exitCode).toBe(7);
+      },
+    );
+
+    it.skipIf(!available)(
+      `[${label}] emits command_started, output, and command_completed events in order`,
+      () => {
+        const { result, markerToken } = runScript(dialect, shell, ['echo "hello"']);
+        const parser = createWorktreeLifecycleOutputParser({
+          markerToken,
+          commands: ["cmd1"],
+          cwd: "/worktree",
+        });
+        const events: WorktreeSetupCommandProgressEvent[] = [
+          ...parser.feed("stdout", result.stdout ?? ""),
+          ...parser.feed("stderr", result.stderr ?? ""),
+        ];
+        expect(extractEventTypes(events)).toEqual([
+          "command_started",
+          "output",
+          "command_completed",
+        ]);
+      },
+    );
+
+    it.skipIf(!available)(
+      `[${label}] produces identical results whether output is fed whole or split into arbitrary chunks`,
+      () => {
+        const { result, markerToken } = runScript(dialect, shell, [
+          'echo "first"',
+          'echo "second"; echo "second-err" 1>&2',
+        ]);
+
+        const wholeParser = createWorktreeLifecycleOutputParser({
+          markerToken,
+          commands: ["cmd1", "cmd2"],
+          cwd: "/worktree",
+        });
+        wholeParser.feed("stdout", result.stdout ?? "");
+        wholeParser.feed("stderr", result.stderr ?? "");
+        const wholeResults = wholeParser.finalize(result.status ?? null);
+
+        const chunkedParser = createWorktreeLifecycleOutputParser({
+          markerToken,
+          commands: ["cmd1", "cmd2"],
+          cwd: "/worktree",
+        });
+        for (const char of result.stdout ?? "") {
+          chunkedParser.feed("stdout", char);
+        }
+        for (const char of result.stderr ?? "") {
+          chunkedParser.feed("stderr", char);
+        }
+        const chunkedResults = chunkedParser.finalize(result.status ?? null);
+
+        expect(chunkedResults).toEqual(wholeResults);
+      },
+    );
+  }
+
+  it("surfaces a shell that never reaches the first marker as command 1 failing", () => {
+    const parser = createWorktreeLifecycleOutputParser({
+      markerToken: "__paseo_lifecycle_test__",
+      commands: ["cmd1", "cmd2"],
+      cwd: "/worktree",
+    });
+    parser.feed("stderr", "zsh: command not found: oh-my-zsh\n");
+    const results = parser.finalize(127);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      command: "cmd1",
+      cwd: "/worktree",
+      exitCode: 127,
+    });
+    expect(results[0]?.stderr).toContain("command not found");
+  });
+
+  it("returns an empty array when there were no commands and no output", () => {
+    const parser = createWorktreeLifecycleOutputParser({
+      markerToken: "__paseo_lifecycle_test__",
+      commands: [],
+      cwd: "/worktree",
+    });
+    expect(parser.finalize(0)).toEqual([]);
+  });
+});

--- a/packages/server/src/utils/worktree-lifecycle-shell.test.ts
+++ b/packages/server/src/utils/worktree-lifecycle-shell.test.ts
@@ -328,6 +328,44 @@ describe("createWorktreeLifecycleOutputParser", () => {
     expect(stderrEvents[1]).toMatchObject({ index: 2, command: "cmd2" });
   });
 
+  it("defers multiple stacked starts without losing any when stdout races far ahead of stderr", () => {
+    // stdout can race arbitrarily far ahead, not just by one command: by the
+    // time stderr reports command 1's END, stdout may have already delivered
+    // START *and* END for commands 2 and 3 too. A single scalar "pending
+    // start" slot would let command 3's deferred start silently overwrite
+    // command 2's, causing command 2 to complete without ever having
+    // reported its start.
+    const parser = createWorktreeLifecycleOutputParser({
+      markerToken: "MARK",
+      commands: ["cmd1", "cmd2", "cmd3"],
+      cwd: "/worktree",
+    });
+
+    const stdoutEvents = [
+      ...parser.feed("stdout", "MARK|START|1\n"),
+      ...parser.feed("stdout", "MARK|END|1|0\n"),
+      ...parser.feed("stdout", "MARK|START|2\n"),
+      ...parser.feed("stdout", "MARK|END|2|0\n"),
+      ...parser.feed("stdout", "MARK|START|3\n"),
+    ];
+    // Only command 1's start fires immediately; 2 and 3 are both deferred,
+    // and stdout closing 2 doesn't complete it since stderr hasn't closed it.
+    expect(stdoutEvents.map((event) => event.type)).toEqual(["command_started"]);
+    expect(stdoutEvents[0]).toMatchObject({ index: 1 });
+
+    const firstStderrEvents = parser.feed("stderr", "MARK|END|1|0\n");
+    expect(firstStderrEvents.map((event) => `${event.type}:${event.index}`)).toEqual([
+      "command_completed:1",
+      "command_started:2",
+    ]);
+
+    const secondStderrEvents = parser.feed("stderr", "MARK|END|2|0\n");
+    expect(secondStderrEvents.map((event) => `${event.type}:${event.index}`)).toEqual([
+      "command_completed:2",
+      "command_started:3",
+    ]);
+  });
+
   it("surfaces a shell that never reaches the first marker as command 1 failing", () => {
     const parser = createWorktreeLifecycleOutputParser({
       markerToken: "__paseo_lifecycle_test__",

--- a/packages/server/src/utils/worktree-lifecycle-shell.test.ts
+++ b/packages/server/src/utils/worktree-lifecycle-shell.test.ts
@@ -300,6 +300,34 @@ describe("createWorktreeLifecycleOutputParser", () => {
     );
   }
 
+  it("defers command_started until the previous command's stderr also closes", () => {
+    // stdout and stderr are independent pipes: stdout can deliver command 2's
+    // START marker before stderr delivers command 1's END marker, even
+    // though the script writes them in that order. The live timeline must
+    // not show both commands "running" at once in that case.
+    const parser = createWorktreeLifecycleOutputParser({
+      markerToken: "MARK",
+      commands: ["cmd1", "cmd2"],
+      cwd: "/worktree",
+    });
+
+    const stdoutEvents = [
+      ...parser.feed("stdout", "MARK|START|1\n"),
+      ...parser.feed("stdout", "line-one\n"),
+      ...parser.feed("stdout", "MARK|END|1|0\n"),
+      ...parser.feed("stdout", "MARK|START|2\n"),
+    ];
+    expect(stdoutEvents.map((event) => event.type)).toEqual(["command_started", "output"]);
+
+    const stderrEvents = parser.feed("stderr", "MARK|END|1|0\n");
+    expect(stderrEvents.map((event) => event.type)).toEqual([
+      "command_completed",
+      "command_started",
+    ]);
+    expect(stderrEvents[0]).toMatchObject({ index: 1, exitCode: 0 });
+    expect(stderrEvents[1]).toMatchObject({ index: 2, command: "cmd2" });
+  });
+
   it("surfaces a shell that never reaches the first marker as command 1 failing", () => {
     const parser = createWorktreeLifecycleOutputParser({
       markerToken: "__paseo_lifecycle_test__",

--- a/packages/server/src/utils/worktree-lifecycle-shell.ts
+++ b/packages/server/src/utils/worktree-lifecycle-shell.ts
@@ -271,14 +271,16 @@ export function createWorktreeLifecycleOutputParser(
   let pendingBlankStdout = false;
   let pendingBlankStderr = false;
   // stdout and stderr are independent pipes with no delivery-order guarantee
-  // relative to each other, so stdout can deliver command N+1's START marker
-  // before stderr delivers command N's END marker (both were written to the
-  // script back-to-back, but arrive at different times). Emitting
-  // command_started for N+1 immediately in that case would show two commands
-  // "running" at once in the live timeline. Hold it back until command N has
-  // fully closed on both streams.
+  // relative to each other, so stdout can race arbitrarily far ahead of
+  // stderr — not just by one command. By the time stderr finally reports
+  // command N's END marker, stdout may have already delivered START (and
+  // even END) for N+1, N+2, and beyond. Emitting command_started for any of
+  // those immediately would show multiple commands "running" at once in the
+  // live timeline, so each is held back in this set until its immediate
+  // predecessor has fully closed on both streams. A single scalar slot here
+  // would let a later deferred index silently overwrite an earlier one.
   let lastCompletedIndex = 0;
-  let pendingStartIndex: number | null = null;
+  const pendingStartIndices = new Set<number>();
 
   function getOrCreateSegment(index: number): LifecycleSegmentState {
     let segment = segments.get(index);
@@ -384,7 +386,7 @@ export function createWorktreeLifecycleOutputParser(
               cwd: segment.cwd,
             });
           } else {
-            pendingStartIndex = marker.index;
+            pendingStartIndices.add(marker.index);
           }
         } else {
           activeStderrIndex = marker.index;
@@ -413,8 +415,10 @@ export function createWorktreeLifecycleOutputParser(
       if (completed) {
         events.push(completed);
         lastCompletedIndex = marker.index;
-        if (pendingStartIndex === marker.index + 1) {
-          const pendingSegment = getOrCreateSegment(pendingStartIndex);
+        const nextIndex = marker.index + 1;
+        if (pendingStartIndices.has(nextIndex)) {
+          pendingStartIndices.delete(nextIndex);
+          const pendingSegment = getOrCreateSegment(nextIndex);
           events.push({
             type: "command_started",
             index: pendingSegment.index,
@@ -422,7 +426,6 @@ export function createWorktreeLifecycleOutputParser(
             command: pendingSegment.command,
             cwd: pendingSegment.cwd,
           });
-          pendingStartIndex = null;
         }
       }
       return;

--- a/packages/server/src/utils/worktree-lifecycle-shell.ts
+++ b/packages/server/src/utils/worktree-lifecycle-shell.ts
@@ -43,10 +43,14 @@ export interface WorktreeLifecycleShellInvocation {
   args: string[];
 }
 
-export function buildWorktreeLifecycleShellInvocation(input: {
+export interface BuildWorktreeLifecycleShellInvocationOptions {
   shell: string;
   script: string;
-}): WorktreeLifecycleShellInvocation {
+}
+
+export function buildWorktreeLifecycleShellInvocation(
+  input: BuildWorktreeLifecycleShellInvocationOptions,
+): WorktreeLifecycleShellInvocation {
   // -i sources .bashrc/.zshrc (oh-my-zsh only loads under an interactive
   // shell); -l sources .bash_profile/.zprofile (e.g. Homebrew's shellenv).
   // fish reads config.fish either way, but its own plugins/activation
@@ -166,11 +170,15 @@ function buildFishLifecycleScript(input: WorktreeLifecycleScriptBodyInput): stri
  * control-flow/PATH syntax varies, isolated in the per-dialect builders
  * above.
  */
-export function buildWorktreeLifecycleScript(input: {
+export interface BuildWorktreeLifecycleScriptOptions {
   commands: string[];
   originalPath: string | undefined;
   dialect: WorktreeLifecycleShellDialect;
-}): WorktreeLifecycleScript {
+}
+
+export function buildWorktreeLifecycleScript(
+  input: BuildWorktreeLifecycleScriptOptions,
+): WorktreeLifecycleScript {
   const markerToken = `__paseo_lifecycle_${randomUUID().replace(/-/g, "")}__`;
   const bodyInput: WorktreeLifecycleScriptBodyInput = {
     commands: input.commands,
@@ -232,11 +240,15 @@ export interface WorktreeLifecycleOutputParser {
  * legacy one-process-per-entry loop produced, so callers (live timeline
  * emission, final result arrays) don't need to know execution was merged.
  */
-export function createWorktreeLifecycleOutputParser(input: {
+export interface CreateWorktreeLifecycleOutputParserOptions {
   markerToken: string;
   commands: string[];
   cwd: string;
-}): WorktreeLifecycleOutputParser {
+}
+
+export function createWorktreeLifecycleOutputParser(
+  input: CreateWorktreeLifecycleOutputParserOptions,
+): WorktreeLifecycleOutputParser {
   const total = input.commands.length;
   const segments = new Map<number, LifecycleSegmentState>();
   const order: number[] = [];
@@ -258,6 +270,15 @@ export function createWorktreeLifecycleOutputParser(input: {
   // gets flushed first, in order.
   let pendingBlankStdout = false;
   let pendingBlankStderr = false;
+  // stdout and stderr are independent pipes with no delivery-order guarantee
+  // relative to each other, so stdout can deliver command N+1's START marker
+  // before stderr delivers command N's END marker (both were written to the
+  // script back-to-back, but arrive at different times). Emitting
+  // command_started for N+1 immediately in that case would show two commands
+  // "running" at once in the live timeline. Hold it back until command N has
+  // fully closed on both streams.
+  let lastCompletedIndex = 0;
+  let pendingStartIndex: number | null = null;
 
   function getOrCreateSegment(index: number): LifecycleSegmentState {
     let segment = segments.get(index);
@@ -354,13 +375,17 @@ export function createWorktreeLifecycleOutputParser(input: {
         const segment = getOrCreateSegment(marker.index);
         if (stream === "stdout") {
           activeStdoutIndex = marker.index;
-          events.push({
-            type: "command_started",
-            index: segment.index,
-            total,
-            command: segment.command,
-            cwd: segment.cwd,
-          });
+          if (marker.index === lastCompletedIndex + 1) {
+            events.push({
+              type: "command_started",
+              index: segment.index,
+              total,
+              command: segment.command,
+              cwd: segment.cwd,
+            });
+          } else {
+            pendingStartIndex = marker.index;
+          }
         } else {
           activeStderrIndex = marker.index;
         }
@@ -387,6 +412,18 @@ export function createWorktreeLifecycleOutputParser(input: {
       const completed = maybeCompleted(marker.index);
       if (completed) {
         events.push(completed);
+        lastCompletedIndex = marker.index;
+        if (pendingStartIndex === marker.index + 1) {
+          const pendingSegment = getOrCreateSegment(pendingStartIndex);
+          events.push({
+            type: "command_started",
+            index: pendingSegment.index,
+            total,
+            command: pendingSegment.command,
+            cwd: pendingSegment.cwd,
+          });
+          pendingStartIndex = null;
+        }
       }
       return;
     }

--- a/packages/server/src/utils/worktree-lifecycle-shell.ts
+++ b/packages/server/src/utils/worktree-lifecycle-shell.ts
@@ -1,0 +1,488 @@
+import { basename } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { WorktreeSetupCommandProgressEvent, WorktreeSetupCommandResult } from "./worktree.js";
+
+export type WorktreeLifecycleShellDialect = "bash" | "zsh" | "fish";
+
+export interface WorktreeLifecycleShellChoice {
+  shell: string;
+  dialect: WorktreeLifecycleShellDialect;
+}
+
+const SUPPORTED_LIFECYCLE_SHELL_DIALECTS = new Set<WorktreeLifecycleShellDialect>([
+  "bash",
+  "zsh",
+  "fish",
+]);
+
+function isSupportedLifecycleShellDialect(value: string): value is WorktreeLifecycleShellDialect {
+  return SUPPORTED_LIFECYCLE_SHELL_DIALECTS.has(value as WorktreeLifecycleShellDialect);
+}
+
+/**
+ * Only bash/zsh/fish are recognized — `buildWorktreeLifecycleScript` emits a
+ * dialect-specific script for each. Any other `$SHELL` falls back to the
+ * legacy per-entry loop untouched.
+ */
+export function resolveWorktreeLifecycleShell(
+  env: NodeJS.ProcessEnv,
+): WorktreeLifecycleShellChoice | null {
+  const shellPath = env.SHELL?.trim();
+  if (!shellPath) {
+    return null;
+  }
+  const dialect = basename(shellPath);
+  if (!isSupportedLifecycleShellDialect(dialect)) {
+    return null;
+  }
+  return { shell: shellPath, dialect };
+}
+
+export interface WorktreeLifecycleShellInvocation {
+  shell: string;
+  args: string[];
+}
+
+export function buildWorktreeLifecycleShellInvocation(input: {
+  shell: string;
+  script: string;
+}): WorktreeLifecycleShellInvocation {
+  // -i sources .bashrc/.zshrc (oh-my-zsh only loads under an interactive
+  // shell); -l sources .bash_profile/.zprofile (e.g. Homebrew's shellenv).
+  // fish reads config.fish either way, but its own plugins/activation
+  // scripts commonly gate themselves on `status is-interactive` or
+  // `status is-login`, so both flags matter there too.
+  return {
+    shell: input.shell,
+    args: ["-i", "-l", "-c", input.script],
+  };
+}
+
+function quotePosixShellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+// fish single-quoted strings support exactly two escapes (\\ and \'), unlike
+// POSIX sh where single quotes admit no escapes at all.
+function quoteFishShellArg(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+export interface WorktreeLifecycleScript {
+  script: string;
+  markerToken: string;
+}
+
+interface WorktreeLifecycleScriptBodyInput {
+  commands: string[];
+  originalPath: string | undefined;
+  markerToken: string;
+}
+
+/**
+ * bash/zsh script body: POSIX sh-family syntax (`{ ...; }`, `$?`, `[ ... ]`).
+ */
+function buildPosixLifecycleScript(input: WorktreeLifecycleScriptBodyInput): string {
+  const lines: string[] = [];
+
+  if (input.originalPath) {
+    // The login/interactive shell above already sourced the user's profile
+    // (and whatever it did to PATH) by the time this line runs. Appending the
+    // daemon's own pre-invocation PATH as a fallback means profile-added
+    // entries (nvm/mise shims) win, but nothing the daemon needs becomes
+    // totally unreachable even if a profile replaces PATH outright.
+    lines.push(`export PATH="$PATH":${quotePosixShellArg(input.originalPath)}`);
+  }
+
+  input.commands.forEach((command, arrayIndex) => {
+    const index = arrayIndex + 1;
+    const startMarker = quotePosixShellArg(`${input.markerToken}|START|${index}`);
+    const quotedMarkerToken = quotePosixShellArg(input.markerToken);
+    lines.push(
+      // The leading \n guards against the *previous* command's last write
+      // lacking a trailing newline — without it, that leftover text and this
+      // marker would land on the same line and fail to parse as a marker.
+      `printf '\\n%s\\n' ${startMarker}`,
+      `printf '\\n%s\\n' ${startMarker} 1>&2`,
+      "{",
+      command,
+      "}",
+      "__paseo_lifecycle_status=$?",
+      `printf '\\n%s|END|${index}|%s\\n' ${quotedMarkerToken} "$__paseo_lifecycle_status"`,
+      `printf '\\n%s|END|${index}|%s\\n' ${quotedMarkerToken} "$__paseo_lifecycle_status" 1>&2`,
+      'if [ "$__paseo_lifecycle_status" -ne 0 ]; then exit "$__paseo_lifecycle_status"; fi',
+    );
+  });
+
+  return lines.join("\n");
+}
+
+/**
+ * fish script body: fish isn't POSIX and doesn't share bash/zsh's `{ ...; }`
+ * grouping, `$?`, or `[ ... ]` syntax, so it gets its own generator rather
+ * than reusing `buildPosixLifecycleScript`. `begin ... end` groups without a
+ * subshell (like `{ ...; }`), `$status` replaces `$?`, and PATH is a native
+ * list variable rather than a colon-joined string.
+ */
+function buildFishLifecycleScript(input: WorktreeLifecycleScriptBodyInput): string {
+  const lines: string[] = [];
+
+  if (input.originalPath) {
+    lines.push(`set -gx PATH $PATH (string split ':' -- ${quoteFishShellArg(input.originalPath)})`);
+  }
+
+  input.commands.forEach((command, arrayIndex) => {
+    const index = arrayIndex + 1;
+    const startMarker = quoteFishShellArg(`${input.markerToken}|START|${index}`);
+    const quotedMarkerToken = quoteFishShellArg(input.markerToken);
+    lines.push(
+      // See buildPosixLifecycleScript for why each marker printf leads with \n.
+      `printf '\\n%s\\n' ${startMarker}`,
+      `printf '\\n%s\\n' ${startMarker} 1>&2`,
+      "begin",
+      command,
+      "end",
+      "set -g __paseo_lifecycle_status $status",
+      `printf '\\n%s|END|${index}|%s\\n' ${quotedMarkerToken} "$__paseo_lifecycle_status"`,
+      `printf '\\n%s|END|${index}|%s\\n' ${quotedMarkerToken} "$__paseo_lifecycle_status" 1>&2`,
+      'if test "$__paseo_lifecycle_status" -ne 0',
+      '  exit "$__paseo_lifecycle_status"',
+      "end",
+    );
+  });
+
+  return lines.join("\n");
+}
+
+/**
+ * Builds one shell script that runs every `commands` entry sequentially in a
+ * single shell session (so exported vars, `cd`, and shell functions from one
+ * entry are visible to the next), while still reporting each entry's own
+ * output/exit code via marker lines an output parser can split back apart.
+ *
+ * Markers are echoed to both stdout and stderr so each stream can be
+ * segmented independently by `createWorktreeLifecycleOutputParser`, and the
+ * marker format itself is identical across dialects — only the surrounding
+ * control-flow/PATH syntax varies, isolated in the per-dialect builders
+ * above.
+ */
+export function buildWorktreeLifecycleScript(input: {
+  commands: string[];
+  originalPath: string | undefined;
+  dialect: WorktreeLifecycleShellDialect;
+}): WorktreeLifecycleScript {
+  const markerToken = `__paseo_lifecycle_${randomUUID().replace(/-/g, "")}__`;
+  const bodyInput: WorktreeLifecycleScriptBodyInput = {
+    commands: input.commands,
+    originalPath: input.originalPath,
+    markerToken,
+  };
+  const script =
+    input.dialect === "fish"
+      ? buildFishLifecycleScript(bodyInput)
+      : buildPosixLifecycleScript(bodyInput);
+
+  return { script, markerToken };
+}
+
+type MarkerLine = { kind: "start"; index: number } | { kind: "end"; index: number; status: number };
+
+function matchMarkerLine(line: string, markerToken: string): MarkerLine | null {
+  if (!line.startsWith(`${markerToken}|`)) {
+    return null;
+  }
+  const parts = line.split("|");
+  if (parts[1] === "START" && parts[2] !== undefined) {
+    const index = Number(parts[2]);
+    return Number.isInteger(index) ? { kind: "start", index } : null;
+  }
+  if (parts[1] === "END" && parts[2] !== undefined && parts[3] !== undefined) {
+    const index = Number(parts[2]);
+    const status = Number(parts[3]);
+    return Number.isInteger(index) && Number.isInteger(status)
+      ? { kind: "end", index, status }
+      : null;
+  }
+  return null;
+}
+
+type LifecycleStream = "stdout" | "stderr";
+
+interface LifecycleSegmentState {
+  index: number;
+  command: string;
+  cwd: string;
+  startedAt: number;
+  stdoutClosed: boolean;
+  stderrClosed: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+export interface WorktreeLifecycleOutputParser {
+  feed(stream: LifecycleStream, chunk: string): WorktreeSetupCommandProgressEvent[];
+  finalize(finalExitCode: number | null): WorktreeSetupCommandResult[];
+}
+
+/**
+ * Consumes raw stdout/stderr chunks from a single shell process running a
+ * `buildWorktreeLifecycleScript` script and reconstructs the same
+ * `WorktreeSetupCommandProgressEvent`/`WorktreeSetupCommandResult` shapes the
+ * legacy one-process-per-entry loop produced, so callers (live timeline
+ * emission, final result arrays) don't need to know execution was merged.
+ */
+export function createWorktreeLifecycleOutputParser(input: {
+  markerToken: string;
+  commands: string[];
+  cwd: string;
+}): WorktreeLifecycleOutputParser {
+  const total = input.commands.length;
+  const segments = new Map<number, LifecycleSegmentState>();
+  const order: number[] = [];
+  let activeStdoutIndex: number | null = null;
+  let activeStderrIndex: number | null = null;
+  let stdoutBuffer = "";
+  let stderrBuffer = "";
+  // Anything emitted before any marker is ever seen — only surfaced if the
+  // shell never reaches command 1 at all (e.g. it fails during its own
+  // interactive/login startup), so that failure isn't silently swallowed.
+  let preamble = "";
+  // Every marker printf is prefixed with a `\n` (see
+  // `buildWorktreeLifecycleScript`) so a preceding command's non-newline-
+  // terminated last write can't merge onto the same line as the marker text.
+  // That guard newline arrives as a blank line right before the closing
+  // marker. Hold the most recent blank line back instead of appending it
+  // immediately: if a marker follows, it was our own guard artifact and gets
+  // dropped; if real content follows instead, it's a genuine blank line and
+  // gets flushed first, in order.
+  let pendingBlankStdout = false;
+  let pendingBlankStderr = false;
+
+  function getOrCreateSegment(index: number): LifecycleSegmentState {
+    let segment = segments.get(index);
+    if (!segment) {
+      segment = {
+        index,
+        command: input.commands[index - 1] ?? "",
+        cwd: input.cwd,
+        startedAt: Date.now(),
+        stdoutClosed: false,
+        stderrClosed: false,
+        stdout: "",
+        stderr: "",
+        exitCode: null,
+      };
+      segments.set(index, segment);
+      order.push(index);
+    }
+    return segment;
+  }
+
+  function maybeCompleted(index: number): WorktreeSetupCommandProgressEvent | null {
+    const segment = segments.get(index);
+    if (!segment || !segment.stdoutClosed || !segment.stderrClosed) {
+      return null;
+    }
+    return {
+      type: "command_completed",
+      index,
+      total,
+      command: segment.command,
+      cwd: segment.cwd,
+      exitCode: segment.exitCode,
+      durationMs: Date.now() - segment.startedAt,
+      stdout: segment.stdout,
+      stderr: segment.stderr,
+    };
+  }
+
+  function appendContentLine(
+    stream: LifecycleStream,
+    index: number,
+    line: string,
+    events: WorktreeSetupCommandProgressEvent[],
+  ): void {
+    const segment = getOrCreateSegment(index);
+    const textLine = `${line}\n`;
+    if (stream === "stdout") {
+      segment.stdout += textLine;
+    } else {
+      segment.stderr += textLine;
+    }
+    events.push({
+      type: "output",
+      index,
+      total,
+      command: segment.command,
+      cwd: segment.cwd,
+      stream,
+      chunk: textLine,
+    });
+  }
+
+  function flushPendingBlank(
+    stream: LifecycleStream,
+    events: WorktreeSetupCommandProgressEvent[],
+  ): void {
+    const isPending = stream === "stdout" ? pendingBlankStdout : pendingBlankStderr;
+    if (!isPending) {
+      return;
+    }
+    if (stream === "stdout") {
+      pendingBlankStdout = false;
+    } else {
+      pendingBlankStderr = false;
+    }
+    const activeIndex = stream === "stdout" ? activeStdoutIndex : activeStderrIndex;
+    if (activeIndex === null) {
+      // Defensive only — a pending blank can't outlive its segment closing,
+      // since the END-marker branch below always clears it first.
+      return;
+    }
+    appendContentLine(stream, activeIndex, "", events);
+  }
+
+  function processLine(
+    stream: LifecycleStream,
+    line: string,
+    events: WorktreeSetupCommandProgressEvent[],
+  ): void {
+    const marker = matchMarkerLine(line, input.markerToken);
+    if (marker) {
+      if (marker.kind === "start") {
+        const segment = getOrCreateSegment(marker.index);
+        if (stream === "stdout") {
+          activeStdoutIndex = marker.index;
+          events.push({
+            type: "command_started",
+            index: segment.index,
+            total,
+            command: segment.command,
+            cwd: segment.cwd,
+          });
+        } else {
+          activeStderrIndex = marker.index;
+        }
+        return;
+      }
+
+      // The END marker's own leading guard newline is exactly the blank
+      // line we're holding back — discard it instead of flushing it.
+      if (stream === "stdout") {
+        pendingBlankStdout = false;
+      } else {
+        pendingBlankStderr = false;
+      }
+
+      const segment = getOrCreateSegment(marker.index);
+      segment.exitCode = marker.status;
+      if (stream === "stdout") {
+        segment.stdoutClosed = true;
+        activeStdoutIndex = null;
+      } else {
+        segment.stderrClosed = true;
+        activeStderrIndex = null;
+      }
+      const completed = maybeCompleted(marker.index);
+      if (completed) {
+        events.push(completed);
+      }
+      return;
+    }
+
+    const activeIndex = stream === "stdout" ? activeStdoutIndex : activeStderrIndex;
+    if (activeIndex === null) {
+      preamble += `${line}\n`;
+      return;
+    }
+
+    if (line === "") {
+      // Two blanks in a row means the first one was real content, not a
+      // guard artifact (there's only ever one guard newline per marker).
+      flushPendingBlank(stream, events);
+      if (stream === "stdout") {
+        pendingBlankStdout = true;
+      } else {
+        pendingBlankStderr = true;
+      }
+      return;
+    }
+
+    flushPendingBlank(stream, events);
+    appendContentLine(stream, activeIndex, line, events);
+  }
+
+  function feed(stream: LifecycleStream, chunk: string): WorktreeSetupCommandProgressEvent[] {
+    const events: WorktreeSetupCommandProgressEvent[] = [];
+    const combined = (stream === "stdout" ? stdoutBuffer : stderrBuffer) + chunk;
+    const lines = combined.split("\n");
+    const remainder = lines.pop() ?? "";
+    if (stream === "stdout") {
+      stdoutBuffer = remainder;
+    } else {
+      stderrBuffer = remainder;
+    }
+    for (const line of lines) {
+      processLine(stream, line, events);
+    }
+    return events;
+  }
+
+  function finalize(finalExitCode: number | null): WorktreeSetupCommandResult[] {
+    const discardedEvents: WorktreeSetupCommandProgressEvent[] = [];
+    if (stdoutBuffer) {
+      processLine("stdout", stdoutBuffer, discardedEvents);
+      stdoutBuffer = "";
+    }
+    if (stderrBuffer) {
+      processLine("stderr", stderrBuffer, discardedEvents);
+      stderrBuffer = "";
+    }
+    // Process exited before its next line told us whether these were real
+    // content or a guard artifact — treat abrupt termination as real content
+    // rather than silently dropping it.
+    flushPendingBlank("stdout", discardedEvents);
+    flushPendingBlank("stderr", discardedEvents);
+
+    if (order.length === 0) {
+      if (total === 0) {
+        return [];
+      }
+      // The shell never reached the first marker at all (e.g. it failed
+      // during its own interactive/login startup) — surface that as command
+      // 1 failing rather than silently returning an empty (success-shaped)
+      // result array.
+      return [
+        {
+          command: input.commands[0] ?? "",
+          cwd: input.cwd,
+          stdout: "",
+          stderr: preamble,
+          exitCode: finalExitCode,
+          durationMs: 0,
+        },
+      ];
+    }
+
+    return order.map((index) => {
+      const segment = segments.get(index);
+      if (!segment) {
+        throw new Error(`Missing worktree lifecycle segment for index ${index}`);
+      }
+      if (segment.exitCode === null) {
+        segment.exitCode = finalExitCode;
+      }
+      return {
+        command: segment.command,
+        cwd: segment.cwd,
+        stdout: segment.stdout,
+        stderr: segment.stderr,
+        exitCode: segment.exitCode,
+        durationMs: Date.now() - segment.startedAt,
+      };
+    });
+  }
+
+  return { feed, finalize };
+}

--- a/packages/server/src/utils/worktree.posix.test.ts
+++ b/packages/server/src/utils/worktree.posix.test.ts
@@ -17,6 +17,7 @@ import {
   resolveWorktreeRuntimeEnv,
   type WorktreeSetupCommandProgressEvent,
   runWorktreeSetupCommands,
+  WorktreeSetupError,
   type CreateWorktreeOptions,
   type WorktreeConfig,
 } from "./worktree";
@@ -51,6 +52,45 @@ import net from "node:net";
 function loadConfigForTest(repoRoot: string): PaseoConfig | null {
   const result = readPaseoConfig(repoRoot);
   return result.ok ? result.config : null;
+}
+
+function hasZshOnPath(): boolean {
+  try {
+    execFileSync("zsh", ["-c", "true"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const zshAvailable = hasZshOnPath();
+
+async function withEnvOverrides<T>(
+  overrides: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const originals = new Map<string, string | undefined>();
+  for (const key of Object.keys(overrides)) {
+    originals.set(key, process.env[key]);
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of originals) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
 }
 
 interface LegacyCreateWorktreeTestOptions {
@@ -812,67 +852,170 @@ describe.skipIf(isPlatform("win32"))("worktree POSIX-only", () => {
       );
     });
 
-    it("runs setup commands with the daemon PATH instead of login profile PATH", async () => {
-      const home = join(tempDir, "host-home");
-      const binDir = join(tempDir, "daemon-bin");
-      mkdirSync(home);
-      mkdirSync(binDir);
+    it.skipIf(!zshAvailable)(
+      "sources the login/interactive shell profile so tool activation is available to setup commands",
+      async () => {
+        // Regression test for #3629: oh-my-zsh (and nvm/mise-style activation
+        // commonly placed alongside it) only loads under an interactive
+        // shell, so a function defined in .zshrc must be callable from a
+        // setup command.
+        const zdotdir = join(tempDir, "zdotdir-activation");
+        mkdirSync(zdotdir);
+        writeFileSync(join(zdotdir, ".zshrc"), 'activate_tool() { printf "tool-activated"; }\n');
+        writeFileSync(
+          join(repoDir, "paseo.json"),
+          JSON.stringify({
+            worktree: {
+              setup: ["activate_tool > activation.log"],
+            },
+          }),
+        );
 
-      const shimPath = join(binDir, "paseo-shim");
-      writeFileSync(shimPath, "#!/bin/sh\nprintf 'shim:%s\\n' \"$1\"\n");
-      chmodSync(shimPath, 0o755);
-      writeFileSync(join(home, ".bash_profile"), "export PATH=/usr/bin:/bin\n");
-      const bashEnvPath = join(home, "bash-env");
-      writeFileSync(bashEnvPath, "export PATH=/usr/bin:/bin\n");
-      writeFileSync(
-        join(repoDir, "paseo.json"),
-        JSON.stringify({
-          worktree: {
-            setup: "command -v paseo-shim >/dev/null && paseo-shim ok > setup-path.log",
+        await withEnvOverrides({ SHELL: "/bin/zsh", ZDOTDIR: zdotdir }, () =>
+          runWorktreeSetupCommands({
+            worktreePath: repoDir,
+            branchName: "main",
+            cleanupOnFailure: false,
+            runtimeEnv: {
+              PASEO_SOURCE_CHECKOUT_PATH: repoDir,
+              PASEO_ROOT_PATH: repoDir,
+              PASEO_WORKTREE_PATH: repoDir,
+              PASEO_BRANCH_NAME: "main",
+              PASEO_WORKTREE_PORT: "12345",
+            },
+          }),
+        );
+
+        expect(readFileSync(join(repoDir, "activation.log"), "utf8")).toBe("tool-activated");
+      },
+    );
+
+    it.skipIf(!zshAvailable)(
+      "keeps the daemon's own PATH resolvable even when the shell profile replaces PATH outright",
+      async () => {
+        // Mirrors the #1908 incident shape (a profile that replaces PATH
+        // wholesale rather than prepending to it) to confirm the fallback
+        // append in buildWorktreeLifecycleScript still finds daemon-provided
+        // binaries even though the profile now runs.
+        const zdotdir = join(tempDir, "zdotdir-path-clobber");
+        const binDir = join(tempDir, "daemon-bin");
+        mkdirSync(zdotdir);
+        mkdirSync(binDir);
+
+        const shimPath = join(binDir, "paseo-shim");
+        writeFileSync(shimPath, "#!/bin/sh\nprintf 'shim:%s\\n' \"$1\"\n");
+        chmodSync(shimPath, 0o755);
+        writeFileSync(join(zdotdir, ".zshrc"), "export PATH=/usr/bin:/bin\n");
+        writeFileSync(
+          join(repoDir, "paseo.json"),
+          JSON.stringify({
+            worktree: {
+              setup: "command -v paseo-shim >/dev/null && paseo-shim ok > setup-path.log",
+            },
+          }),
+        );
+
+        const originalPath = process.env.PATH;
+        await withEnvOverrides(
+          {
+            SHELL: "/bin/zsh",
+            ZDOTDIR: zdotdir,
+            PATH: `${binDir}${delimiter}${originalPath ?? "/usr/bin:/bin"}`,
           },
-        }),
-      );
+          () =>
+            runWorktreeSetupCommands({
+              worktreePath: repoDir,
+              branchName: "main",
+              cleanupOnFailure: false,
+              runtimeEnv: {
+                PASEO_SOURCE_CHECKOUT_PATH: repoDir,
+                PASEO_ROOT_PATH: repoDir,
+                PASEO_WORKTREE_PATH: repoDir,
+                PASEO_BRANCH_NAME: "main",
+                PASEO_WORKTREE_PORT: "12345",
+              },
+            }),
+        );
 
-      const originalHome = process.env.HOME;
-      const originalPath = process.env.PATH;
-      const originalBashEnv = process.env.BASH_ENV;
-      process.env.HOME = home;
-      process.env.PATH = `${binDir}${delimiter}${originalPath ?? "/usr/bin:/bin"}`;
-      process.env.BASH_ENV = bashEnvPath;
+        expect(readFileSync(join(repoDir, "setup-path.log"), "utf8").trim()).toBe("shim:ok");
+      },
+    );
 
-      try {
-        await runWorktreeSetupCommands({
-          worktreePath: repoDir,
-          branchName: "main",
-          cleanupOnFailure: false,
-          runtimeEnv: {
-            PASEO_SOURCE_CHECKOUT_PATH: repoDir,
-            PASEO_ROOT_PATH: repoDir,
-            PASEO_WORKTREE_PATH: repoDir,
-            PASEO_BRANCH_NAME: "main",
-            PASEO_WORKTREE_PORT: "12345",
-          },
+    it.skipIf(!zshAvailable)(
+      "shares shell state across array entries within a single setup run",
+      async () => {
+        writeFileSync(
+          join(repoDir, "paseo.json"),
+          JSON.stringify({
+            worktree: {
+              setup: [
+                'export SETUP_TOKEN="from-entry-one"',
+                'printf "%s" "$SETUP_TOKEN" > shared-state.log',
+              ],
+            },
+          }),
+        );
+
+        await withEnvOverrides({ SHELL: "/bin/zsh" }, () =>
+          runWorktreeSetupCommands({
+            worktreePath: repoDir,
+            branchName: "main",
+            cleanupOnFailure: false,
+            runtimeEnv: {
+              PASEO_SOURCE_CHECKOUT_PATH: repoDir,
+              PASEO_ROOT_PATH: repoDir,
+              PASEO_WORKTREE_PATH: repoDir,
+              PASEO_BRANCH_NAME: "main",
+              PASEO_WORKTREE_PORT: "12345",
+            },
+          }),
+        );
+
+        expect(readFileSync(join(repoDir, "shared-state.log"), "utf8")).toBe("from-entry-one");
+      },
+    );
+
+    it.skipIf(!zshAvailable)(
+      "reports one result per array entry and stops at the first failure",
+      async () => {
+        writeFileSync(
+          join(repoDir, "paseo.json"),
+          JSON.stringify({
+            worktree: {
+              setup: ['echo "one" > one.log', "exit 3", 'echo "three" > three.log'],
+            },
+          }),
+        );
+
+        let caught: unknown;
+        await withEnvOverrides({ SHELL: "/bin/zsh" }, async () => {
+          try {
+            await runWorktreeSetupCommands({
+              worktreePath: repoDir,
+              branchName: "main",
+              cleanupOnFailure: false,
+              runtimeEnv: {
+                PASEO_SOURCE_CHECKOUT_PATH: repoDir,
+                PASEO_ROOT_PATH: repoDir,
+                PASEO_WORKTREE_PATH: repoDir,
+                PASEO_BRANCH_NAME: "main",
+                PASEO_WORKTREE_PORT: "12345",
+              },
+            });
+          } catch (error) {
+            caught = error;
+          }
         });
-      } finally {
-        if (originalHome === undefined) {
-          delete process.env.HOME;
-        } else {
-          process.env.HOME = originalHome;
-        }
-        if (originalPath === undefined) {
-          delete process.env.PATH;
-        } else {
-          process.env.PATH = originalPath;
-        }
-        if (originalBashEnv === undefined) {
-          delete process.env.BASH_ENV;
-        } else {
-          process.env.BASH_ENV = originalBashEnv;
-        }
-      }
 
-      expect(readFileSync(join(repoDir, "setup-path.log"), "utf8").trim()).toBe("shim:ok");
-    });
+        expect(caught).toBeInstanceOf(WorktreeSetupError);
+        const results = (caught as WorktreeSetupError).results;
+        expect(results).toHaveLength(2);
+        expect(results[0]?.exitCode).toBe(0);
+        expect(results[1]).toMatchObject({ command: "exit 3", exitCode: 3 });
+        expect(existsSync(join(repoDir, "one.log"))).toBe(true);
+        expect(existsSync(join(repoDir, "three.log"))).toBe(false);
+      },
+    );
 
     it("treats blank lifecycle strings as empty", () => {
       writeFileSync(

--- a/packages/server/src/utils/worktree.ts
+++ b/packages/server/src/utils/worktree.ts
@@ -17,6 +17,13 @@ import {
   buildStringCommandShellInvocation,
   createStringCommandShellEnv,
 } from "./string-command-shell.js";
+import {
+  buildWorktreeLifecycleScript,
+  buildWorktreeLifecycleShellInvocation,
+  createWorktreeLifecycleOutputParser,
+  resolveWorktreeLifecycleShell,
+  type WorktreeLifecycleShellChoice,
+} from "./worktree-lifecycle-shell.js";
 import { readPaseoConfigJson, resolvePaseoConfigPath } from "./paseo-config-file.js";
 export {
   PaseoConfigRawSchema,
@@ -631,6 +638,128 @@ async function inferRepoRootPathFromWorktreePath(worktreePath: string): Promise<
   }
 }
 
+/**
+ * Runs `commands` sequentially, one process per entry, with no shared shell
+ * state between entries. Used on win32 (no login-shell equivalent needed
+ * there) and for any POSIX `$SHELL` we don't recognize as bash/zsh/fish,
+ * where the marker-based script in `worktree-lifecycle-shell.ts` isn't
+ * verified.
+ */
+async function runWorktreeLifecycleCommandsLegacy(options: {
+  commands: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+  onEvent?: (event: WorktreeSetupCommandProgressEvent) => void;
+}): Promise<WorktreeSetupCommandResult[]> {
+  const { commands, cwd, env, signal, onEvent } = options;
+  const results: WorktreeSetupCommandResult[] = [];
+  for (const [index, cmd] of commands.entries()) {
+    const result = onEvent
+      ? await execSetupCommandStreamed({
+          command: cmd,
+          cwd,
+          env,
+          index: index + 1,
+          total: commands.length,
+          signal,
+          onEvent,
+        })
+      : await execSetupCommand(cmd, { cwd, env });
+    results.push(result);
+    if (result.exitCode !== 0) {
+      break;
+    }
+  }
+  return results;
+}
+
+/**
+ * Runs every `commands` entry inside a single login+interactive shell
+ * session (see `buildWorktreeLifecycleScript`), so shell functions/aliases
+ * and tool activation (nvm, mise, oh-my-zsh) sourced from the user's profile
+ * are available, and state one entry sets (exported vars, `cd`) is visible to
+ * the next. Reconstructs the same per-entry progress events/results the
+ * legacy per-process loop produced from the single process's output.
+ */
+async function runPosixWorktreeLifecycleCommands(options: {
+  commands: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  shellChoice: WorktreeLifecycleShellChoice;
+  signal?: AbortSignal;
+  onEvent?: (event: WorktreeSetupCommandProgressEvent) => void;
+}): Promise<WorktreeSetupCommandResult[]> {
+  const { commands, cwd, env, shellChoice, signal, onEvent } = options;
+  const { script, markerToken } = buildWorktreeLifecycleScript({
+    commands,
+    originalPath: env.PATH,
+    dialect: shellChoice.dialect,
+  });
+  const invocation = buildWorktreeLifecycleShellInvocation({ shell: shellChoice.shell, script });
+  const parser = createWorktreeLifecycleOutputParser({ markerToken, commands, cwd });
+
+  return new Promise((resolvePromise) => {
+    let settled = false;
+    let termination: Promise<unknown> | null = null;
+
+    const emit = (events: WorktreeSetupCommandProgressEvent[]) => {
+      if (!onEvent) {
+        return;
+      }
+      for (const event of events) {
+        onEvent(event);
+      }
+    };
+
+    const child = spawnProcess(invocation.shell, invocation.args, {
+      cwd,
+      env,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const abort = () => {
+      termination ??= terminateWithTreeKill(child, {
+        gracefulTimeoutMs: 1000,
+        forceTimeoutMs: 1000,
+      });
+    };
+    if (signal?.aborted) {
+      abort();
+    } else {
+      signal?.addEventListener("abort", abort, { once: true });
+    }
+
+    const finish = async (exitCode: number | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      signal?.removeEventListener("abort", abort);
+      await termination;
+      resolvePromise(parser.finalize(exitCode));
+    };
+
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      emit(parser.feed("stdout", stripAnsi(chunk.toString())));
+    });
+
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      emit(parser.feed("stderr", stripAnsi(chunk.toString())));
+    });
+
+    child.on("error", (error) => {
+      emit(parser.feed("stderr", `${error instanceof Error ? error.message : String(error)}\n`));
+      void finish(null);
+    });
+
+    child.on("close", (code) => {
+      void finish(typeof code === "number" ? code : null);
+    });
+  });
+}
+
 export async function runWorktreeSetupCommands(options: {
   worktreePath: string;
   branchName: string;
@@ -655,40 +784,40 @@ export async function runWorktreeSetupCommands(options: {
     }));
   const setupEnv = createStringCommandShellEnv(createExternalProcessEnv(process.env, runtimeEnv));
 
-  const results: WorktreeSetupCommandResult[] = [];
-  for (const [index, cmd] of setupCommands.entries()) {
-    const result = options.onEvent
-      ? await execSetupCommandStreamed({
-          command: cmd,
-          cwd: options.worktreePath,
-          env: setupEnv,
-          index: index + 1,
-          total: setupCommands.length,
-          signal: options.signal,
-          onEvent: options.onEvent,
-        })
-      : await execSetupCommand(cmd, {
-          cwd: options.worktreePath,
-          env: setupEnv,
-        });
-    results.push(result);
+  const shellChoice = process.platform !== "win32" ? resolveWorktreeLifecycleShell(setupEnv) : null;
+  const results = shellChoice
+    ? await runPosixWorktreeLifecycleCommands({
+        commands: setupCommands,
+        cwd: options.worktreePath,
+        env: setupEnv,
+        shellChoice,
+        signal: options.signal,
+        onEvent: options.onEvent,
+      })
+    : await runWorktreeLifecycleCommandsLegacy({
+        commands: setupCommands,
+        cwd: options.worktreePath,
+        env: setupEnv,
+        signal: options.signal,
+        onEvent: options.onEvent,
+      });
 
-    if (result.exitCode !== 0) {
-      if (options.cleanupOnFailure) {
-        try {
-          await runGitCommand(["worktree", "remove", options.worktreePath, "--force"], {
-            cwd: options.worktreePath,
-            timeout: 120_000,
-          });
-        } catch {
-          rmSync(options.worktreePath, { recursive: true, force: true });
-        }
+  const failed = results.find((result) => result.exitCode !== 0);
+  if (failed) {
+    if (options.cleanupOnFailure) {
+      try {
+        await runGitCommand(["worktree", "remove", options.worktreePath, "--force"], {
+          cwd: options.worktreePath,
+          timeout: 120_000,
+        });
+      } catch {
+        rmSync(options.worktreePath, { recursive: true, force: true });
       }
-      throw new WorktreeSetupError(
-        `Worktree setup command failed: ${cmd}\n${result.stderr}`.trim(),
-        results,
-      );
     }
+    throw new WorktreeSetupError(
+      `Worktree setup command failed: ${failed.command}\n${failed.stderr}`.trim(),
+      results,
+    );
   }
 
   return results;
@@ -780,20 +909,27 @@ export async function runWorktreeTeardownCommands(options: {
     }),
   );
 
-  const results: WorktreeTeardownCommandResult[] = [];
-  for (const cmd of teardownCommands) {
-    const result = await execSetupCommand(cmd, {
-      cwd: teardownCwd,
-      env: teardownEnv,
-    });
-    results.push(result);
+  const shellChoice =
+    process.platform !== "win32" ? resolveWorktreeLifecycleShell(teardownEnv) : null;
+  const results = shellChoice
+    ? await runPosixWorktreeLifecycleCommands({
+        commands: teardownCommands,
+        cwd: teardownCwd,
+        env: teardownEnv,
+        shellChoice,
+      })
+    : await runWorktreeLifecycleCommandsLegacy({
+        commands: teardownCommands,
+        cwd: teardownCwd,
+        env: teardownEnv,
+      });
 
-    if (result.exitCode !== 0) {
-      throw new WorktreeTeardownError(
-        `Worktree teardown command failed: ${cmd}\n${result.stderr}`.trim(),
-        results,
-      );
-    }
+  const failed = results.find((result) => result.exitCode !== 0);
+  if (failed) {
+    throw new WorktreeTeardownError(
+      `Worktree teardown command failed: ${failed.command}\n${failed.stderr}`.trim(),
+      results,
+    );
   }
 
   return results;

--- a/public-docs/worktrees.md
+++ b/public-docs/worktrees.md
@@ -112,6 +112,8 @@ Both fields accept a multiline shell script or an array of commands; commands ru
 
 Commands run with the worktree as `cwd`. Use `$PASEO_SOURCE_CHECKOUT_PATH` to reach files in the original checkout (untracked config, local caches, etc).
 
+On macOS and Linux, when `$SHELL` is `bash`, `zsh`, or `fish`, every entry in a `setup`/`teardown` run shares one login+interactive shell session — the same session sources your profile (`.zshrc`, `.bash_profile`, `config.fish`, nvm, mise, Homebrew's `shellenv`, etc.), so tool activation and shell functions defined there are available to your commands. Because it's one session, state from one entry — an exported variable, a `cd`, a sourced function — carries into the next entry. The daemon's own `PATH` is kept reachable as a fallback even if your profile replaces `PATH` outright. Commands run in your shell's own syntax: if `$SHELL` is fish, write `setup`/`teardown` entries in fish syntax (`set -x FOO bar`, not `export FOO=bar`), not bash. Any other `$SHELL` (or Windows) runs each entry in its own isolated, non-interactive process instead, with no shared state between entries.
+
 ## Scripts and services
 
 `scripts` are named commands you can run inside a worktree on demand. Mark one as a _service_ and Paseo supervises it as a long-running process, assigns it a port, and routes HTTP traffic to it through the daemon's reverse proxy.


### PR DESCRIPTION
## Summary
- `worktree.setup`/`worktree.teardown` array entries each ran as their own isolated, non-interactive `bash -c` process. `.zshrc`/`.zprofile` never sourced (oh-my-zsh refuses to load under a non-interactive shell), so shell functions/tool activation (nvm, mise, etc.) defined there were unavailable, and state from one entry (exported vars, `cd`) never carried to the next.
- Array entries now run inside a single login+interactive shell session (bash/zsh/fish, detected from `$SHELL`), so profile-sourced activation works and state persists across entries — the shell/login cost is paid once per run instead of once per entry.
- The existing per-entry timeline UI (per-command log, status, exit code, duration in the app) is preserved by reconstructing it from the single process's output via a marker-delimited script, rather than collapsing to one combined result.
- The daemon's own `PATH` is kept reachable as a fallback even if a profile replaces `PATH` outright, preserving the guarantee added in #1908 (which removed login-shell invocation after a profile PATH-clobbering incident).
- Windows and any `$SHELL` we don't recognize (fish is supported; anything else) fall back to the previous per-entry-process behavior, unchanged.

Fixes #3629.

## Test plan
- [x] New unit tests: `packages/server/src/utils/worktree-lifecycle-shell.test.ts` — script generation (marker placement, PATH preamble, fail-fast exit) and the output parser (interleaved/split stdout+stderr chunks, per-index segmentation, exit codes, event ordering), parametrized across bash and fish
- [x] `packages/server/src/utils/worktree.posix.test.ts` — regression tests for profile-sourced tool activation, PATH fallback under a profile that clobbers PATH, cross-entry state sharing, and per-entry fail-fast reporting
- [x] `npm run typecheck` / `npm run lint` / `npm run format:check` (also ran automatically via pre-commit hook)
- [x] Targeted vitest run across the affected files (108 passed, 6 skipped — 5 gated on fish availability, 1 pre-existing unrelated skip)
- [x] CI: added an `Install fish` step to `server-tests-ubuntu` so the fish-dialect tests actually execute in CI instead of skipping
- [ ] Not yet verified end-to-end against a live daemon / real worktree creation flow in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)