### PR TITLE
Keep Pi chats active through retry recovery

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -215,6 +215,20 @@ class SessionEvents {
     return this.events.map((event) => event.type);
   }
 
+  turnLifecycleEvents() {
+    return this.events.flatMap((event) => {
+      if (
+        event.type === "turn_started" ||
+        event.type === "turn_completed" ||
+        event.type === "turn_failed" ||
+        event.type === "turn_canceled"
+      ) {
+        return [{ type: event.type, turnId: event.turnId }];
+      }
+      return [];
+    });
+  }
+
   turnCompletedEvents() {
     return this.events.filter(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
@@ -942,6 +956,96 @@ describe("PiRpcAgentSession", () => {
         'Provider finish_reason: error (stopReason=error, model=openrouter/google/gemini-2.5-flash-lite, responseId=gen-test, partial="I will use the write tool for qa.txt.")',
       ),
     });
+  });
+
+  test("keeps a retryable Pi provider error inside the original foreground turn", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    const { turnId } = await session.startTurn("hello");
+
+    fakeSession.emit({ type: "turn_start" });
+    fakeSession.finishAgentRun(
+      {
+        role: "assistant",
+        provider: "test-provider",
+        model: "test-model",
+        stopReason: "error",
+        errorMessage: "Request timed out.",
+        content: [],
+      },
+      { willRetry: true },
+    );
+    fakeSession.emit({
+      type: "auto_retry_start",
+      attempt: 1,
+      maxAttempts: 3,
+      delayMs: 2000,
+      errorMessage: "Request timed out.",
+    });
+    fakeSession.emit({ type: "turn_start" });
+    fakeSession.finishAgentRun(
+      {
+        role: "assistant",
+        provider: "test-provider",
+        model: "test-model",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Recovered response" }],
+      },
+      { willRetry: false },
+    );
+    fakeSession.emit({ type: "auto_retry_end", success: true, attempt: 1 });
+    fakeSession.settleTurn();
+
+    expect(events.turnLifecycleEvents()).toEqual([
+      { type: "turn_started", turnId },
+      { type: "turn_completed", turnId },
+    ]);
+  });
+
+  test("waits for Pi to settle before failing a terminal provider error", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    const { turnId } = await session.startTurn("hello");
+
+    fakeSession.emit({ type: "turn_start" });
+    fakeSession.finishAgentRun(
+      {
+        role: "assistant",
+        provider: "test-provider",
+        model: "test-model",
+        stopReason: "error",
+        errorMessage: "Insufficient quota.",
+        content: [],
+      },
+      { willRetry: false },
+    );
+
+    expect(events.turnLifecycleEvents()).toEqual([{ type: "turn_started", turnId }]);
+
+    fakeSession.settleTurn();
+
+    expect(events.turnLifecycleEvents()).toEqual([
+      { type: "turn_started", turnId },
+      { type: "turn_failed", turnId },
+    ]);
+  });
+
+  test("completes legacy Pi turns that have no settlement metadata", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    const { turnId } = await session.startTurn("hello");
+
+    fakeSession.emit({ type: "turn_start" });
+    fakeSession.finishLegacyTurn({
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: "Legacy response" }],
+    });
+
+    expect(events.turnLifecycleEvents()).toEqual([
+      { type: "turn_started", turnId },
+      { type: "turn_completed", turnId },
+    ]);
   });
 
   test("resumes by launching Pi with the persisted session file and cwd metadata", async () => {

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -964,8 +964,8 @@ describe("PiRpcAgentSession", () => {
     const { turnId } = await session.startTurn("hello");
 
     fakeSession.emit({ type: "turn_start" });
-    fakeSession.finishAgentRun(
-      {
+    fakeSession.finishAgentRun({
+      message: {
         role: "assistant",
         provider: "test-provider",
         model: "test-model",
@@ -973,8 +973,8 @@ describe("PiRpcAgentSession", () => {
         errorMessage: "Request timed out.",
         content: [],
       },
-      { willRetry: true },
-    );
+      willRetry: true,
+    });
     fakeSession.emit({
       type: "auto_retry_start",
       attempt: 1,
@@ -990,16 +990,16 @@ describe("PiRpcAgentSession", () => {
     expect(events.turnLifecycleEvents()).toEqual([{ type: "turn_started", turnId }]);
 
     fakeSession.emit({ type: "turn_start" });
-    fakeSession.finishAgentRun(
-      {
+    fakeSession.finishAgentRun({
+      message: {
         role: "assistant",
         provider: "test-provider",
         model: "test-model",
         stopReason: "stop",
         content: [{ type: "text", text: "Recovered response" }],
       },
-      { willRetry: false },
-    );
+      willRetry: false,
+    });
     fakeSession.emit({ type: "auto_retry_end", success: true, attempt: 1 });
     fakeSession.settleTurn();
 
@@ -1015,8 +1015,8 @@ describe("PiRpcAgentSession", () => {
     const { turnId } = await session.startTurn("hello");
 
     fakeSession.emit({ type: "turn_start" });
-    fakeSession.finishAgentRun(
-      {
+    fakeSession.finishAgentRun({
+      message: {
         role: "assistant",
         provider: "test-provider",
         model: "test-model",
@@ -1024,8 +1024,8 @@ describe("PiRpcAgentSession", () => {
         errorMessage: "Request timed out.",
         content: [],
       },
-      { willRetry: true },
-    );
+      willRetry: true,
+    });
     fakeSession.emit({
       type: "auto_retry_start",
       attempt: 1,
@@ -1034,8 +1034,8 @@ describe("PiRpcAgentSession", () => {
       errorMessage: "Request timed out.",
     });
     fakeSession.emit({ type: "turn_start" });
-    fakeSession.finishAgentRun(
-      {
+    fakeSession.finishAgentRun({
+      message: {
         role: "assistant",
         provider: "test-provider",
         model: "test-model",
@@ -1043,8 +1043,8 @@ describe("PiRpcAgentSession", () => {
         errorMessage: "Insufficient quota.",
         content: [],
       },
-      { willRetry: false },
-    );
+      willRetry: false,
+    });
     fakeSession.emit({
       type: "auto_retry_end",
       success: false,

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -958,7 +958,7 @@ describe("PiRpcAgentSession", () => {
     });
   });
 
-  test("keeps a retryable Pi provider error inside the original foreground turn", async () => {
+  test("shows retry activity while keeping the original Pi turn active through recovery", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
     const { turnId } = await session.startTurn("hello");
@@ -982,6 +982,13 @@ describe("PiRpcAgentSession", () => {
       delayMs: 2000,
       errorMessage: "Request timed out.",
     });
+
+    expect(events.timelineItems()).toContainEqual({
+      type: "error",
+      message: "Provider retry (attempt 1): Request timed out.",
+    });
+    expect(events.turnLifecycleEvents()).toEqual([{ type: "turn_started", turnId }]);
+
     fakeSession.emit({ type: "turn_start" });
     fakeSession.finishAgentRun(
       {
@@ -1002,11 +1009,30 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
-  test("waits for Pi to settle before failing a terminal provider error", async () => {
+  test("fails an exhausted Pi recovery only after settlement", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
     const { turnId } = await session.startTurn("hello");
 
+    fakeSession.emit({ type: "turn_start" });
+    fakeSession.finishAgentRun(
+      {
+        role: "assistant",
+        provider: "test-provider",
+        model: "test-model",
+        stopReason: "error",
+        errorMessage: "Request timed out.",
+        content: [],
+      },
+      { willRetry: true },
+    );
+    fakeSession.emit({
+      type: "auto_retry_start",
+      attempt: 1,
+      maxAttempts: 1,
+      delayMs: 2000,
+      errorMessage: "Request timed out.",
+    });
     fakeSession.emit({ type: "turn_start" });
     fakeSession.finishAgentRun(
       {
@@ -1019,8 +1045,18 @@ describe("PiRpcAgentSession", () => {
       },
       { willRetry: false },
     );
+    fakeSession.emit({
+      type: "auto_retry_end",
+      success: false,
+      attempt: 1,
+      finalError: "Insufficient quota.",
+    });
 
     expect(events.turnLifecycleEvents()).toEqual([{ type: "turn_started", turnId }]);
+    expect(events.timelineItems()).toContainEqual({
+      type: "error",
+      message: "Provider retry (attempt 1): Request timed out.",
+    });
 
     fakeSession.settleTurn();
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1003,6 +1003,7 @@ function isPiAgentSessionEvent(event: PiRuntimeEvent): event is PiAgentSessionEv
     case "compaction_start":
     case "compaction_end":
     case "agent_end":
+    case "agent_settled":
       return true;
     default:
       return false;
@@ -1204,6 +1205,8 @@ export class PiRpcAgentSession implements AgentSession {
   private activeClientMessageId: string | null = null;
   private activeAssistantMessageId: string | null = null;
   private activeTurnStarted = false;
+  private activeTurnStartedEmitted = false;
+  private pendingSettledMessages: PiAgentMessage[] | null = null;
   private activeNoTurnPromptText: string | null = null;
   private readonly pendingNoTurnOutputs: Array<{ turnId: string; message: string }> = [];
   private activePromptRequestId: string | null = null;
@@ -1297,6 +1300,8 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeClientMessageId = options?.clientMessageId ?? null;
     this.activeAssistantMessageId = null;
     this.activeTurnStarted = false;
+    this.activeTurnStartedEmitted = false;
+    this.pendingSettledMessages = null;
     this.activePromptRequestId = null;
     this.clearNoTurnBuffers();
     this.activeNoTurnPromptText = payload.text;
@@ -1328,6 +1333,8 @@ export class PiRpcAgentSession implements AgentSession {
         this.activeTurnId = null;
         this.activeClientMessageId = null;
         this.activeTurnStarted = false;
+        this.activeTurnStartedEmitted = false;
+        this.pendingSettledMessages = null;
         this.activeAssistantMessageId = null;
         this.clearNoTurnBuffers();
         if (isPiRequestAbortError(error)) {
@@ -1456,6 +1463,8 @@ export class PiRpcAgentSession implements AgentSession {
         this.activeTurnId = null;
         this.activeClientMessageId = null;
         this.activeTurnStarted = false;
+        this.activeTurnStartedEmitted = false;
+        this.pendingSettledMessages = null;
         this.activeAssistantMessageId = null;
         this.clearNoTurnBuffers();
         this.emit({
@@ -1472,6 +1481,8 @@ export class PiRpcAgentSession implements AgentSession {
       this.activeTurnId = null;
       this.activeClientMessageId = null;
       this.activeTurnStarted = false;
+      this.activeTurnStartedEmitted = false;
+      this.pendingSettledMessages = null;
       this.activeAssistantMessageId = null;
       this.clearNoTurnBuffers();
       this.emit({
@@ -2047,6 +2058,8 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeTurnStarted = false;
+    this.activeTurnStartedEmitted = false;
+    this.pendingSettledMessages = null;
     this.clearNoTurnBuffers();
     this.emit({
       type: "turn_failed",
@@ -2058,6 +2071,10 @@ export class PiRpcAgentSession implements AgentSession {
 
   private handleSessionEvent(event: PiAgentSessionEvent): void {
     const turnId = this.currentTurnIdForEvent();
+    if (event.type === "agent_end" || event.type === "agent_settled") {
+      this.handleTurnBoundaryEvent(event, turnId);
+      return;
+    }
 
     switch (event.type) {
       case "agent_start":
@@ -2072,6 +2089,10 @@ export class PiRpcAgentSession implements AgentSession {
       case "turn_start":
         this.activeTurnStarted = true;
         this.clearNoTurnBuffers();
+        if (this.activeTurnStartedEmitted) {
+          return;
+        }
+        this.activeTurnStartedEmitted = true;
         this.emit({
           type: "turn_started",
           provider: this.provider,
@@ -2128,11 +2149,29 @@ export class PiRpcAgentSession implements AgentSession {
           },
         });
         return;
-      case "agent_end":
-        this.completeTurn(turnId, event.messages ?? []);
-        return;
       default:
         return;
+    }
+  }
+
+  private handleTurnBoundaryEvent(
+    event: Extract<PiAgentSessionEvent, { type: "agent_end" | "agent_settled" }>,
+    turnId: string | undefined,
+  ): void {
+    if (event.type === "agent_end") {
+      // COMPAT(piAgentSettled): added in v0.5.0, remove after 2027-02-21 once the Pi
+      // floor emits agent_settled and willRetry.
+      if (event.willRetry === undefined) {
+        this.completeTurn(turnId, event.messages ?? []);
+        return;
+      }
+      if (this.activeTurnId) {
+        this.pendingSettledMessages = event.messages ?? [];
+      }
+      return;
+    }
+    if (this.activeTurnId) {
+      this.completeTurn(turnId, this.pendingSettledMessages ?? []);
     }
   }
 
@@ -2305,6 +2344,8 @@ export class PiRpcAgentSession implements AgentSession {
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;
     this.activeTurnStarted = false;
+    this.activeTurnStartedEmitted = false;
+    this.pendingSettledMessages = null;
     this.clearNoTurnBuffers();
     const errorMessage = latestPiErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -1004,6 +1004,7 @@ function isPiAgentSessionEvent(event: PiRuntimeEvent): event is PiAgentSessionEv
     case "compaction_end":
     case "agent_end":
     case "agent_settled":
+    case "auto_retry_start":
       return true;
     default:
       return false;
@@ -2146,6 +2147,17 @@ export class PiRpcAgentSession implements AgentSession {
             type: "compaction",
             status: "completed",
             trigger: event.reason === "manual" ? "manual" : "auto",
+          },
+        });
+        return;
+      case "auto_retry_start":
+        this.emit({
+          type: "timeline",
+          provider: this.provider,
+          turnId,
+          item: {
+            type: "error",
+            message: `Provider retry (attempt ${event.attempt}): ${event.errorMessage}`,
           },
         });
         return;

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2073,7 +2073,7 @@ export class PiRpcAgentSession implements AgentSession {
   private handleSessionEvent(event: PiAgentSessionEvent): void {
     const turnId = this.currentTurnIdForEvent();
     if (event.type === "agent_end" || event.type === "agent_settled") {
-      this.handleTurnBoundaryEvent(event, turnId);
+      this.handleTurnBoundaryEvent({ event, turnId });
       return;
     }
 
@@ -2166,10 +2166,13 @@ export class PiRpcAgentSession implements AgentSession {
     }
   }
 
-  private handleTurnBoundaryEvent(
-    event: Extract<PiAgentSessionEvent, { type: "agent_end" | "agent_settled" }>,
-    turnId: string | undefined,
-  ): void {
+  private handleTurnBoundaryEvent({
+    event,
+    turnId,
+  }: {
+    event: Extract<PiAgentSessionEvent, { type: "agent_end" | "agent_settled" }>;
+    turnId: string | undefined;
+  }): void {
     if (event.type === "agent_end") {
       // COMPAT(piAgentSettled): added in v0.5.0, remove after 2027-02-21 once the Pi
       // floor emits agent_settled and willRetry.

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -187,7 +187,16 @@ export type PiAgentSessionEvent =
     }
   | { type: "compaction_start"; reason?: "manual" | "threshold" | "overflow" | string }
   | { type: "compaction_end"; reason?: string; errorMessage?: string; aborted?: boolean }
-  | { type: "agent_end"; messages?: PiAgentMessage[] };
+  | { type: "agent_end"; messages?: PiAgentMessage[]; willRetry?: boolean }
+  | { type: "agent_settled" }
+  | {
+      type: "auto_retry_start";
+      attempt: number;
+      maxAttempts: number;
+      delayMs: number;
+      errorMessage: string;
+    }
+  | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 
 export type PiRuntimeEvent =
   | PiAgentSessionEvent

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -354,7 +354,25 @@ export class FakePiSession implements PiRuntimeSession {
     }
   }
 
+  finishAgentRun(message: PiAgentMessage, options: { willRetry: boolean }): void {
+    this.messages = [...this.messages, message];
+    this.emit({
+      type: "agent_end",
+      messages: this.messages,
+      willRetry: options.willRetry,
+    });
+  }
+
+  settleTurn(): void {
+    this.emit({ type: "agent_settled" });
+  }
+
   finishTurn(message: PiAgentMessage = { role: "assistant", content: [] }): void {
+    this.finishAgentRun(message, { willRetry: false });
+    this.settleTurn();
+  }
+
+  finishLegacyTurn(message: PiAgentMessage = { role: "assistant", content: [] }): void {
     this.messages = [...this.messages, message];
     this.emit({ type: "agent_end", messages: this.messages });
   }

--- a/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
+++ b/packages/server/src/server/agent/providers/pi/test-utils/fake-pi.ts
@@ -354,12 +354,12 @@ export class FakePiSession implements PiRuntimeSession {
     }
   }
 
-  finishAgentRun(message: PiAgentMessage, options: { willRetry: boolean }): void {
+  finishAgentRun({ message, willRetry }: { message: PiAgentMessage; willRetry: boolean }): void {
     this.messages = [...this.messages, message];
     this.emit({
       type: "agent_end",
       messages: this.messages,
-      willRetry: options.willRetry,
+      willRetry,
     });
   }
 
@@ -368,7 +368,7 @@ export class FakePiSession implements PiRuntimeSession {
   }
 
   finishTurn(message: PiAgentMessage = { role: "assistant", content: [] }): void {
-    this.finishAgentRun(message, { willRetry: false });
+    this.finishAgentRun({ message, willRetry: false });
     this.settleTurn();
   }
 


### PR DESCRIPTION
### Linked issue

Refs #2889.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Pi reports each low-level provider attempt with `agent_end`, but `agent_settled` is the final boundary for a user turn. Treating an attempt end as final puts the chat into an error state while Pi retries and loses ownership of the recovered attempt. Hiding the attempt error entirely also leaves the user waiting without an explanation. This keeps the foreground turn alive until settlement and maps Pi's explicit `auto_retry_start` signal onto the existing non-terminal error activity row.

### Goals

- Keep the original Pi turn active across automatic retry attempts.
- Show a concise error activity row when Pi announces an automatic retry.
- Emit one Paseo turn start and one terminal result for a retried Pi request.
- Wait for settlement before reporting a terminal provider error.
- Preserve immediate completion for legacy Pi lifecycle streams.

### Non-goals

- Change Pi retry limits, backoff, or provider-error policy.
- Replay prompts from Paseo.
- Add or change UI components, protocol types, or shared timeline behavior.
- Change other provider adapters.

### Supersedes

- [PR #3236 — Keep Pi turns active through provider retries](https://github.com/getpaseo/paseo/pull/3236) — This PR takes over the same Pi retry workflow: it keeps the turn active until settlement, surfaces each retry through the existing error activity row, and preserves legacy completion without adding retry or UI machinery.

### QA

- `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts --bail=1` — 64 passed.
- `npm run typecheck` — passed across all workspaces.
- `npm run lint -- <changed Pi adapter files>` — 0 warnings and 0 errors.
- `npm run format:files -- <changed Pi adapter files>` and `git diff --check` — passed.

Risk surface: Pi lifecycle versions, terminal-state ownership, and retry visibility. Regression coverage exercises a retryable provider error followed by recovery, retry activity while the original turn remains active, terminal failure deferred to settlement, and legacy immediate completion.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
