### PR TITLE
fix(codex): repair the foreground turn slot

### DIFF
--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -1194,6 +1194,8 @@ class McpCapableTestAgentClient extends TestAgentClient {
 
 class ControlledInterruptSession extends TestAgentSession {
   interruptCalled = false;
+  releasedForegroundTurnIds: string[] = [];
+  heldForegroundTurnId: string | null = null;
 
   constructor(
     config: AgentSessionConfig,
@@ -1204,6 +1206,7 @@ class ControlledInterruptSession extends TestAgentSession {
   }
 
   override async startTurn(): Promise<{ turnId: string }> {
+    this.heldForegroundTurnId = this.turnId;
     setTimeout(() => {
       this.pushEvent({ type: "turn_started", provider: this.provider, turnId: this.turnId });
     }, 0);
@@ -1213,6 +1216,16 @@ class ControlledInterruptSession extends TestAgentSession {
   override async interrupt(): Promise<void> {
     this.interruptCalled = true;
     await this.interruptBehavior(this);
+  }
+
+  // Mirrors the codex session's keyed release: only the slot this id owns.
+  releaseForegroundTurn(turnId: string): boolean {
+    this.releasedForegroundTurnIds.push(turnId);
+    if (this.heldForegroundTurnId !== turnId) {
+      return false;
+    }
+    this.heldForegroundTurnId = null;
+    return true;
   }
 }
 
@@ -2514,6 +2527,63 @@ test("cancelAgentRun preserves running state when the provider interrupt hangs",
     });
     expect(fixture.session.interruptCalled).toBe(true);
     expect(fixture.manager.getAgent(fixture.agentId)?.lifecycle).toBe("running");
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("cancelAgentRun force-cancels an acknowledged interrupt whose run never settles", async () => {
+  // The session lost its turn while the manager still tracked a run, so
+  // nothing would ever settle it. With interrupt() resolving as a no-op, the
+  // acknowledged-timeout force-cancel must settle the orphaned run instead of
+  // leaving stop and replace refused for the rest of the session.
+  const fixture = await createControlledInterruptFixture({
+    name: "interrupt-orphaned",
+    agentId: "00000000-0000-4000-8000-000000000305",
+    turnId: "orphaned-turn",
+    interrupt: async () => {},
+  });
+
+  try {
+    await fixture.startForegroundRun();
+
+    await expect(fixture.manager.cancelAgentRun(fixture.agentId)).resolves.toEqual({
+      status: "settled",
+    });
+    expect(fixture.session.interruptCalled).toBe(true);
+    await expect
+      .poll(() => fixture.manager.getAgent(fixture.agentId)?.lifecycle)
+      .not.toBe("running");
+    await expect(fixture.manager.cancelAgentRun(fixture.agentId)).resolves.toEqual({
+      status: "not_running",
+    });
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("cancelAgentRun force-cancel releases the session's foreground slot", async () => {
+  // The force-cancel dispatches turn_canceled, which resolves
+  // runs.getMatchingWaiters and settles this manager's run record. Nothing on
+  // that path reaches the session, and the session releases its foreground slot
+  // only when the provider reports the turn ended -- which a force-cancel
+  // happens precisely because it did not. Without the release the slot is held
+  // for the rest of the session and every later startTurn is refused.
+  const fixture = await createControlledInterruptFixture({
+    name: "interrupt-foreground-release",
+    agentId: "00000000-0000-4000-8000-000000000306",
+    turnId: "stuck-turn",
+    interrupt: async () => {},
+  });
+
+  try {
+    await fixture.startForegroundRun();
+    expect(fixture.session.heldForegroundTurnId).toBe("stuck-turn");
+
+    await fixture.manager.cancelAgentRun(fixture.agentId);
+
+    expect(fixture.session.releasedForegroundTurnIds).toContain("stuck-turn");
+    expect(fixture.session.heldForegroundTurnId).toBeNull();
   } finally {
     await fixture.cleanup();
   }

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -2857,6 +2857,19 @@ export class AgentManager {
         reason: "interrupted",
         turnId: runTurnId,
       });
+      // the dispatch above settles
+      // this manager's run record only, and the
+      // session clears its foreground slot only on a turn end that a
+      // force-cancel means is never coming. Release it here, before awaiting
+      // settlement so a settle that never arrives cannot strand the slot.
+      // (2026-09-07 sync: upstream reworked run tracking into AgentRunState, so
+      // the canceled run's turn id is `runTurnId` above, not `run.turnId`.)
+      if (agent.session.releaseForegroundTurn?.(runTurnId)) {
+        this.logger.warn(
+          { agentId, provider: agent.provider, turnId: runTurnId },
+          "cancelAgentRun.force_cancel_released_foreground",
+        );
+      }
       await run.settledPromise;
     } else if (settlement === "timed_out" && run.kind === "foreground") {
       this.logger.warn(

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -703,6 +703,17 @@ export interface AgentSession {
   tryHandleOutOfBand?(prompt: AgentPromptInput): {
     run(ctx: { emit: (event: AgentStreamEvent) => void }): Promise<void>;
   } | null;
+
+  /**
+   * Release the session's foreground-turn slot for `turnId`, returning whether
+   * it was released. The manager calls this after force-canceling a run: its
+   * own `turn_canceled` dispatch settles the run record only, and a session
+   * that tracks a foreground slot will otherwise hold it until the provider
+   * reports a turn end that a force-cancel means is never coming. Keyed, so a
+   * newer turn that already owns the slot keeps it. Optional: providers that
+   * do not track a foreground slot need not implement it.
+   */
+  releaseForegroundTurn?(turnId: string): boolean;
 }
 
 export type FetchCatalogOptions =

--- a/packages/server/src/server/agent/provider-registry-wrap.test.ts
+++ b/packages/server/src/server/agent/provider-registry-wrap.test.ts
@@ -26,6 +26,7 @@ const OPTIONAL_AGENT_SESSION_METHOD_NAMES = [
   "revertFiles",
   "revertBoth",
   "tryHandleOutOfBand",
+  "releaseForegroundTurn",
 ] as const satisfies readonly OptionalAgentSessionMethodName[];
 
 type MissingOptionalAgentSessionMethod = Exclude<
@@ -151,6 +152,11 @@ class FakeSession implements AgentSession {
     this.recordedCalls.push("revertBoth");
   }
 
+  releaseForegroundTurn(_turnId: string) {
+    this.recordedCalls.push("releaseForegroundTurn");
+    return true;
+  }
+
   tryHandleOutOfBand(_prompt: AgentPromptInput) {
     this.recordedCalls.push("tryHandleOutOfBand");
     return {
@@ -181,6 +187,7 @@ describe("wrapSessionProvider", () => {
     await wrapped.revertBoth?.({ messageId: "message-1" });
     const handler = wrapped.tryHandleOutOfBand?.("/compact");
     await handler?.run({ emit: () => {} });
+    wrapped.releaseForegroundTurn?.("turn-1");
 
     expect(session.recordedCalls).toEqual([
       "listCommands",
@@ -192,6 +199,7 @@ describe("wrapSessionProvider", () => {
       "revertBoth",
       "tryHandleOutOfBand",
       "tryHandleOutOfBand.run",
+      "releaseForegroundTurn",
     ]);
   });
 });

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -474,6 +474,7 @@ export function wrapSessionProvider(provider: AgentProvider, inner: AgentSession
     revertFiles: inner.revertFiles?.bind(inner),
     revertBoth: inner.revertBoth?.bind(inner),
     tryHandleOutOfBand: inner.tryHandleOutOfBand?.bind(inner),
+    releaseForegroundTurn: inner.releaseForegroundTurn?.bind(inner),
   };
 }
 

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -82,7 +82,7 @@ describe("Codex executable discovery", () => {
   });
 });
 
-import { CodexAppServerClient } from "./codex/app-server-transport.js";
+import { CodexAppServerClient, CodexAppServerRpcError } from "./codex/app-server-transport.js";
 import {
   createFakeCodexAppServer,
   type FakeCodexAppServer,
@@ -690,18 +690,110 @@ process.stdin.on("data", (chunk) => {
   }
 }
 
-describe("Codex app-server provider", () => {
-  test("getAvailableModes includes auto-review when the Codex version supports it", async () => {
-    const session = createSession({}, { autoReviewEnabled: true });
+describe("Codex foreground teardown wait (replace path)", () => {
+  // The replace path can call startTurn while the interrupted turn is still
+  // tearing down: the manager's force-cancel settles its run record before
+  // this provider clears activeForegroundTurnId, and refusing immediately
+  // loses the incoming prompt and marks the agent errored.
+  test("waits out a clearing foreground turn instead of refusing", async () => {
+    const session = createSession();
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      flushForegroundTurnClearWaiters: () => void;
+    }>(session);
+    const attempt = session.startTurn("after teardown");
+    const raced = await Promise.race([
+      attempt.catch((error: unknown) => error),
+      new Promise((resolve) => setTimeout(resolve, 25, "pending")),
+    ]);
+    expect(raced).toBe("pending");
+    internals.activeForegroundTurnId = null;
+    internals.flushForegroundTurnClearWaiters();
+    // Getting past the foreground guard is the assertion; the harness spawns
+    // no app-server, so the next gate is the client-initialization error.
+    await expect(attempt).rejects.toThrow("Codex client not initialized");
+  });
 
-    await expect(session.getAvailableModes()).resolves.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "auto-review",
-          label: "Auto-review",
-        }),
-      ]),
-    );
+  test("releases the foreground slot only for the turn that owns it", () => {
+    // The manager calls this after force-canceling a run, because its own
+    // turn_canceled dispatch settles only the run record and the provider will
+    // never report the turn end that would otherwise clear the slot. Keyed, so
+    // a force-cancel racing a newer turn into the slot cannot strip the live
+    // turn's ownership.
+    const session = createSession();
+    const internals = castInternals<{ activeForegroundTurnId: string | null }>(session);
+    const releaser = session as unknown as {
+      releaseForegroundTurn(turnId: string): boolean;
+    };
+    internals.activeForegroundTurnId = "owning-turn";
+
+    expect(releaser.releaseForegroundTurn("a-stale-turn")).toBe(false);
+    expect(internals.activeForegroundTurnId).toBe("owning-turn");
+    expect(releaser.releaseForegroundTurn("")).toBe(false);
+    expect(internals.activeForegroundTurnId).toBe("owning-turn");
+
+    expect(releaser.releaseForegroundTurn("owning-turn")).toBe(true);
+    expect(internals.activeForegroundTurnId).toBeNull();
+    expect(releaser.releaseForegroundTurn("owning-turn")).toBe(false);
+  });
+
+  test("frees a startTurn queued behind a stuck slot when the slot is released", () => {
+    // Without the release the waiter sits until FOREGROUND_TEARDOWN_WAIT_MS
+    // expires and the prompt is refused. Only the queue-release is asserted:
+    // once past the guard startTurn goes on to connect(), which this harness
+    // has no client for.
+    const session = createSession();
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      foregroundTurnClearWaiters: Array<() => void>;
+    }>(session);
+    const releaser = session as unknown as {
+      releaseForegroundTurn(turnId: string): boolean;
+    };
+
+    const owning = internals.activeForegroundTurnId;
+    expect(owning).toBeTruthy();
+
+    const attempt = session.startTurn("queued behind a stuck slot");
+    attempt.catch(() => {});
+    expect(internals.foregroundTurnClearWaiters).toHaveLength(1);
+
+    expect(releaser.releaseForegroundTurn(owning as string)).toBe(true);
+    expect(internals.foregroundTurnClearWaiters).toHaveLength(0);
+    expect(internals.activeForegroundTurnId).toBeNull();
+  });
+
+  test("refuses only when the teardown never completes, retaining no waiter", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = createSession();
+      const internals = castInternals<{ foregroundTurnClearWaiters: Array<() => void> }>(session);
+      const attempt = session.startTurn("never clears");
+      const expectation = expect(attempt).rejects.toThrow("A foreground turn is already active");
+      expect(internals.foregroundTurnClearWaiters).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expectation;
+      // A stuck turn plus retrying prompts must not accumulate dead closures.
+      expect(internals.foregroundTurnClearWaiters).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Codex client disposal", () => {
+  test("releases the foreground slot when the client is disposed", async () => {
+    // A failed reconnect disposes the client and clears the native turn id.
+    // If the foreground slot survived that, interrupt() would find no turn to
+    // interrupt and every later startTurn would refuse forever.
+    const session = createSession();
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      disposeClient: () => Promise<void>;
+    }>(session);
+    expect(internals.activeForegroundTurnId).toBe("test-turn");
+    await internals.disposeClient();
+    expect(internals.activeForegroundTurnId).toBeNull();
   });
 
   test("getAvailableModes excludes auto-review when the Codex version is too old", async () => {
@@ -3589,6 +3681,46 @@ describe("Codex app-server provider", () => {
     }
   });
 
+  test("flushes a queued startTurn when Codex reports the interrupted turn is already idle", async () => {
+    // Fork adaptation (, #3640): the
+    // already-idle interrupt response used to clear the slot field-by-field,
+    // leaving a startTurn queued on it to sleep out FOREGROUND_TEARDOWN_WAIT_MS
+    // before the guard re-checks. Releasing through the keyed path flushes the
+    // waiters immediately and resolves any pending turn identification.
+    const session = new CodexAppServerAgentSession(
+      createConfig({ cwd: "/workspace/project" }),
+      null,
+      createTestLogger(),
+      () => {
+        throw new Error("Test session cannot spawn Codex app-server");
+      },
+      {},
+      false,
+    );
+    session.connected = true;
+    session.currentThreadId = "test-thread";
+    session.activeForegroundTurnId = "test-turn";
+    session.currentTurnId = "test-turn";
+    (session as { client: unknown }).client = {
+      request: async () => {
+        throw new CodexAppServerRpcError("no active turn to interrupt", -32600, undefined);
+      },
+    };
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      foregroundTurnClearWaiters: Array<() => void>;
+    }>(session);
+
+    const attempt = session.startTurn("queued behind an already-idle turn");
+    attempt.catch(() => {});
+    expect(internals.foregroundTurnClearWaiters).toHaveLength(1);
+
+    await session.interrupt();
+
+    expect(internals.activeForegroundTurnId).toBeNull();
+    expect(internals.foregroundTurnClearWaiters).toHaveLength(0);
+  });
+
   test("waits for Codex to identify an accepted turn before interrupting it", async () => {
     const interruptedTurns: unknown[] = [];
     const appServer = createFakeCodexAppServer({
@@ -3642,6 +3774,8 @@ describe("Codex app-server provider", () => {
       const interruptPromise = session.interrupt();
       appServer.completeTurn();
 
+      // The turn was accepted but never identified, so there is nothing to
+      // interrupt and the call resolves as a no-op rather than throwing.
       await expect(interruptPromise).resolves.toBeUndefined();
       await resultPromise;
       expect(interruptedTurns).toEqual([]);
@@ -3649,6 +3783,81 @@ describe("Codex app-server provider", () => {
     } finally {
       await session.close();
     }
+  });
+
+  test("releases the foreground slot when no turn was ever identified", async () => {
+    // Codex accepted turn/start but never published a native turn id, so the
+    // interrupt no-ops. No turn-end event is coming to release the foreground
+    // slot, and holding it makes every later startTurn refuse.
+    const session = createSession();
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      currentTurnId: string | null;
+      client: unknown;
+    }>(session);
+    internals.client = {};
+    internals.currentTurnId = null;
+    expect(internals.activeForegroundTurnId).toBe("test-turn");
+
+    await expect(session.interrupt()).resolves.toBeUndefined();
+
+    expect(internals.activeForegroundTurnId).toBeNull();
+  });
+
+  test("keeps the foreground slot when the turn was identified", async () => {
+    const session = createSession();
+    const requests: string[] = [];
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      currentTurnId: string | null;
+      client: unknown;
+    }>(session);
+    internals.client = {
+      request: async (method: string) => {
+        requests.push(method);
+        return {};
+      },
+    };
+    internals.currentTurnId = "native-turn";
+
+    await session.interrupt();
+
+    // A live turn is being interrupted; Codex will report its end and release
+    // the slot. Releasing it here would free the slot under a running turn.
+    expect(requests).toEqual(["turn/interrupt"]);
+    expect(internals.activeForegroundTurnId).toBe("test-turn");
+  });
+
+  test("leaves the foreground slot to a newer turn that raced into it", async () => {
+    const session = createSession();
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      currentTurnId: string | null;
+      client: unknown;
+      pendingForegroundTurnIdentification: {
+        foregroundTurnId: string;
+        promise: Promise<string | null>;
+        resolve: (turnId: string | null) => void;
+      } | null;
+    }>(session);
+    internals.client = {};
+    internals.currentTurnId = null;
+    let identify!: (turnId: string | null) => void;
+    const promise = new Promise<string | null>((resolve) => {
+      identify = resolve;
+    });
+    internals.pendingForegroundTurnIdentification = {
+      foregroundTurnId: "test-turn",
+      promise,
+      resolve: identify,
+    };
+
+    const interrupted = session.interrupt();
+    internals.activeForegroundTurnId = "newer-turn";
+    identify(null);
+
+    await expect(interrupted).resolves.toBeUndefined();
+    expect(internals.activeForegroundTurnId).toBe("newer-turn");
   });
 
   test("acknowledges interruption before Codex initializes a thread", async () => {

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -135,6 +135,15 @@ function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolea
   return message.includes(`no archived rollout found for thread id ${threadId}`);
 }
 
+//
+// How long an incoming turn waits for the previous foreground turn's teardown
+// before refusing. A replace path can reach startTurn while the interrupted
+// turn is still tearing down: the manager's force-cancel settles its run
+// record before this provider clears activeForegroundTurnId (measured 4ms
+// apart in production), and refusing immediately loses the incoming prompt
+// and marks the agent errored.
+const FOREGROUND_TEARDOWN_WAIT_MS = 10_000;
+
 const TURN_START_TIMEOUT_MS = 90 * 1000;
 const INTERRUPT_TIMEOUT_MS = 2_000;
 const CODEX_PROVIDER = "codex" as const;
@@ -3316,6 +3325,10 @@ export class CodexAppServerAgentSession implements AgentSession {
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private nextTurnOrdinal = 0;
   private activeForegroundTurnId: string | null = null;
+  // resolved whenever the foreground turn
+  // clears, so an incoming startTurn can
+  // wait out a teardown instead of refusing a milliseconds-wide race.
+  private foregroundTurnClearWaiters: Array<() => void> = [];
   private activeClientMessageId: string | null = null;
   private cachedRuntimeInfo: AgentRuntimeInfo | null = null;
   private serviceTier: "fast" | null = null;
@@ -3554,6 +3567,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
+    this.flushForegroundTurnClearWaiters();
     this.currentTurnId = null;
     this.pendingForegroundTurnIdentification?.resolve(null);
     this.pendingForegroundTurnIdentification = null;
@@ -4157,12 +4171,47 @@ export class CodexAppServerAgentSession implements AgentSession {
     });
   }
 
+  private flushForegroundTurnClearWaiters(): void {
+    if (this.foregroundTurnClearWaiters.length === 0) return;
+    const waiters = this.foregroundTurnClearWaiters;
+    this.foregroundTurnClearWaiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
+  private async waitForForegroundTurnClear(timeoutMs: number): Promise<void> {
+    if (!this.activeForegroundTurnId) return;
+    await new Promise<void>((resolve) => {
+      const waiter = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      // A timed-out waiter drops itself: a turn that never clears would
+      // otherwise retain one dead closure per retrying prompt until the
+      // session closes.
+      const timer = setTimeout(() => {
+        this.foregroundTurnClearWaiters = this.foregroundTurnClearWaiters.filter(
+          (entry) => entry !== waiter,
+        );
+        resolve();
+      }, timeoutMs);
+      this.foregroundTurnClearWaiters.push(waiter);
+    });
+  }
+
   async startTurn(
     prompt: AgentPromptInput,
     options?: AgentRunOptions,
   ): Promise<{ turnId: string }> {
     if (this.activeForegroundTurnId || this.pendingForegroundStart) {
-      throw new Error("A foreground turn is already active");
+      // wait bounded for the previous
+      // turn's teardown; only a turn that
+      // genuinely will not end is refused. The wait tracks
+      // activeForegroundTurnId only, so a concurrent in-flight start returns
+      // from it immediately and still refuses, as upstream does.
+      await this.waitForForegroundTurnClear(FOREGROUND_TEARDOWN_WAIT_MS);
+      if (this.activeForegroundTurnId || this.pendingForegroundStart) {
+        throw new Error("A foreground turn is already active");
+      }
     }
 
     let resolveStart!: () => void;
@@ -4229,6 +4278,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.pendingForegroundTurnIdentification = null;
       this.activeForegroundTurnId = null;
       this.activeClientMessageId = null;
+      this.flushForegroundTurnClearWaiters();
       throw error;
     } finally {
       if (this.pendingForegroundStart === pendingStart) {
@@ -4765,7 +4815,30 @@ export class CodexAppServerAgentSession implements AgentSession {
       return;
     }
     if (!turnId || (foregroundTurnId && this.activeForegroundTurnId !== foregroundTurnId)) {
-      throw new Error("Cannot interrupt Codex before turn/started identifies the active turn");
+      // nothing identifiable to interrupt. Resolve
+      // rather than throw, matching
+      // the claude and acp providers: throwing leaves the manager reading the
+      // cancel as unacknowledged, so it refuses every later stop and replace
+      // for the rest of the session. Resolving lets the existing
+      // acknowledged-timeout force-cancel settle the orphaned run.
+      this.logger.warn(
+        {
+          agentId: this.agentId,
+          provider: CODEX_PROVIDER,
+          sessionId: this.currentThreadId,
+          turnId: this.activeForegroundTurnId ?? this.currentTurnId ?? undefined,
+        },
+        "provider.codex.interrupt.no_identified_turn_noop",
+      );
+      // the turn was never identified,
+      // so no turn-end event will arrive to
+      // release the foreground slot, and every later startTurn would refuse
+      // with "A foreground turn is already active". Release only the slot this
+      // call sampled: a newer turn that raced into it is live and keeps it.
+      if (!turnId && foregroundTurnId) {
+        this.releaseForegroundTurn(foregroundTurnId);
+      }
+      return;
     }
     try {
       await this.client.request(
@@ -4780,12 +4853,44 @@ export class CodexAppServerAgentSession implements AgentSession {
       if (!isCodexAlreadyIdleInterrupt(error)) {
         throw error;
       }
-      this.activeForegroundTurnId = null;
-      this.activeClientMessageId = null;
-      this.currentTurnId = null;
-      this.pendingForegroundTurnIdentification?.resolve(null);
-      this.pendingForegroundTurnIdentification = null;
+      // Codex reports the interrupted
+      // turn as already idle — the turn ended, so release through the keyed
+      // path: it flushes startTurn waiters blocked on this slot (otherwise they
+      // sleep out FOREGROUND_TEARDOWN_WAIT_MS) and resolves any pending turn
+      // identification, and it refuses to touch a newer turn that raced in.
+      if (foregroundTurnId) {
+        this.releaseForegroundTurn(foregroundTurnId);
+      } else {
+        this.activeClientMessageId = null;
+        this.currentTurnId = null;
+        this.pendingForegroundTurnIdentification?.resolve(null);
+        this.pendingForegroundTurnIdentification = null;
+      }
     }
+  }
+
+  // a force-canceled run settles
+  // the manager's run record, but nothing on that
+  // path clears this session's foreground slot. The slot is released only when
+  // Codex reports the turn ended, and a force-cancel happens precisely because
+  // it did not. startTurn then waits out FOREGROUND_TEARDOWN_WAIT_MS against a
+  // turn that will never end and refuses, and every retry is refused the same
+  // way, so the only repair is killing the app-server process.
+  //
+  // Release only the slot the cancel targeted. turnId is this session's own
+  // createTurnId() value, so a mismatch means a newer turn owns the slot and
+  // keeps it.
+  releaseForegroundTurn(turnId: string): boolean {
+    if (!turnId || this.activeForegroundTurnId !== turnId) {
+      return false;
+    }
+    this.activeForegroundTurnId = null;
+    this.activeClientMessageId = null;
+    this.currentTurnId = null;
+    this.flushForegroundTurnClearWaiters();
+    this.pendingForegroundTurnIdentification?.resolve(null);
+    this.pendingForegroundTurnIdentification = null;
+    return true;
   }
 
   async close(): Promise<void> {
@@ -4795,6 +4900,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.subscribers.clear();
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
+    this.flushForegroundTurnClearWaiters();
     this.pendingForegroundTurnIdentification?.resolve(null);
     this.pendingForegroundTurnIdentification = null;
     await this.disposeClient();
@@ -4817,6 +4923,21 @@ export class CodexAppServerAgentSession implements AgentSession {
   private async disposeClient(): Promise<void> {
     const client = this.client;
     this.connected = false;
+    // a disposed client cannot own a
+    // live turn, so release the foreground slot
+    // with it. Without this, a failed reconnect clears the native turn id and
+    // leaves activeForegroundTurnId held forever, and every later startTurn
+    // refuses with "A foreground turn is already active". close() already
+    // clears the slot before disposing, so this is a no-op on that path.
+    const disposedForegroundTurnId = this.activeForegroundTurnId;
+    if (disposedForegroundTurnId) {
+      this.emitEvent({
+        type: "turn_failed",
+        provider: CODEX_PROVIDER,
+        error: "Codex client was disposed while a foreground turn was active",
+      });
+      this.releaseForegroundTurn(disposedForegroundTurnId);
+    }
     this.currentTurnId = null;
     if (client) {
       await client.dispose();
@@ -5916,6 +6037,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
+    this.flushForegroundTurnClearWaiters();
     this.currentTurnId = null;
     this.pendingForegroundTurnIdentification?.resolve(null);
     this.pendingForegroundTurnIdentification = null;


### PR DESCRIPTION
Three repairs to one piece of state in the Codex provider: `activeForegroundTurnId`, the single foreground-turn slot. Each fixes a different way that slot is leaked or wrongly refused, and all were measured on long-lived Codex agents in production.

This supersedes #3674 and #3683, which are closed in favour of this PR. They are folded in rather than left standing because **two lines cannot exist in any of the three separately**: `interrupt()` and `disposeClient()` each release the slot, and each must wake the callers blocked on it via `flushForegroundTurnClearWaiters()` — a method introduced by #3674. Both other PRs were cut against a base that lacks it, so in *every* merge order the result would land slot releases that leave waiters asleep for the full 10s timeout. Consolidating is the only shape that carries them.

### The failures

| Path | Failure |
| --- | --- |
| `startTurn` races teardown | A prompt injected while a turn is being cancelled races the teardown. `cancelAgentRunBefore` returns once the **manager's** run record settles, and a force-cancel settles it without waiting for the provider, so `startTurn` finds the slot still set and throws. Measured 4 ms apart in production; six occurrences in one session, each losing the prompt and marking the agent errored. Now a bounded 10 s wait, refusing only a turn that genuinely will not end; a timed-out waiter drops itself so a stuck turn cannot retain one dead closure per retrying prompt. |
| `interrupt()` with no identified turn | Codex was the only provider that threw — claude and acp both return. The throw made the manager read the cancel as unacknowledged and refuse every later stop and replace for the rest of the session. Resolving alone is not enough: no turn-end event is coming for a turn Codex never identified, so the slot must be released too. Measured twice, over two hours each. |
| `disposeClient()` | Cleared `currentTurnId` but not the slot. `close()` clears it first, so the asymmetry only fires on a failed reconnect — and then the agent is wedged invisibly: the manager reports no active turn while the provider still holds the slot. Scheduled runs cannot rescue it, since the daemon refuses one against an agent with an in-flight run. Measured: fifteen minutes of refused prompts, `stop` reporting zero stopped runs, sends answering `failed to start`, recovered only by a daemon restart. |
| force-cancel | `cancelAgentRunNow`'s force-cancel dispatches `turn_canceled`, which resolves `runs.getMatchingWaiters` and settles the **manager's** run record. Nothing on that path reaches the session, and the session clears the slot only on a turn end that a force-cancel means is never coming. The slot is then held for the rest of the session and each retry is refused the same way. Measured four times in one hour with the other repairs live. |

### Why the registry commit is required

`wrapSessionProvider` returns a plain object literal that hand-enumerates the `AgentSession` surface, so a method added to a concrete session class is invisible through it and the manager's optional-method probe finds `undefined`. Every registry-defined provider is wrapped, so without the forward the force-cancel release is correct code that can never execute. It is declared on `AgentSession` and added to the wrap test's covered list, so the compile-time exhaustiveness guard — which exists for exactly this class of omission — now includes it.

### Scope

`codex-app-server-agent.ts` and its test file; `agent-manager.ts` and its test file for the force-cancel path, which is the manager's; and `agent-sdk-types.ts` + `provider-registry.ts` + the wrap test for the forward. The manager change is one call plus a log line, a no-op unless the session implements the optional method, so other providers are untouched. Refusal semantics for a turn that genuinely will not end are unchanged, as are the preserve-the-turn semantics for providers that hang on or reject an interrupt.

Not covered: the `run.kind === "foreground"` branch of the force-cancel has no `run.turnId` to key a release on, and the claude, acp and opencode sessions carry the same field but were not audited.

### Verification

- Every commit typechecks on its own; the three are file-disjoint.
- The five affected test files: 377 passed, 0 failed.
- `src/server/agent`: 1983 passed / 12 failed on this branch, against 1979 / 11 on plain `main`. No test fails here that does not also fail on `main` — the three that differ pass in isolation and flake only under parallel load.
- Deleting the two `flushForegroundTurnClearWaiters()` calls fails exactly the two tests written for them, and nothing else.
- Deleting the force-cancel release fails exactly the new manager-level test (`expected [] to include 'stuck-turn'`), and nothing else.
- Deleting the registry forward fails the wrap test's exhaustiveness assertion, and nothing else.
- Observed on a long-lived deployment: before the registry forward, force-cancels logged the release probe as unreachable and the wedge recurred; after it, twelve force-cancels each released the slot and the wedge has not recurred.
