### PR TITLE
Use a dropdown for default send behavior

### DIFF
--- a/packages/app/e2e/browser/agent-message-submission.spec.ts
+++ b/packages/app/e2e/browser/agent-message-submission.spec.ts
@@ -315,10 +315,11 @@ async function configureInterruptInSettings(page: Page): Promise<void> {
 
 async function selectSendBehaviorInSettings(
   page: Page,
-  buttonName: string,
+  behaviorLabel: string,
   stored: string,
 ): Promise<void> {
-  await page.getByRole("button", { name: buttonName, exact: true }).click();
+  await page.getByRole("button", { name: /^Default send: / }).click();
+  await page.getByRole("menuitem", { name: behaviorLabel, exact: true }).click();
   await expect
     .poll(async () => {
       const raw = await page.evaluate(() => localStorage.getItem("@paseo:app-settings"));

--- a/packages/app/e2e/browser/settings-toggle-tab-regression.spec.ts
+++ b/packages/app/e2e/browser/settings-toggle-tab-regression.spec.ts
@@ -70,9 +70,28 @@ test.describe("Settings toggle tab regression", () => {
       await pressSettingsToggleShortcut(page);
       await expect(page).toHaveURL(/\/settings\/general$/);
 
-      await page.getByRole("button", { name: "Queue", exact: true }).click();
+      const defaultSendTrigger = page.getByRole("button", {
+        name: "Default send: Steer",
+        exact: true,
+      });
+      await expect(defaultSendTrigger).toBeVisible();
+      await expect(page.getByRole("menuitem", { name: "Queue", exact: true })).toHaveCount(0);
+
+      await defaultSendTrigger.click();
+      await expect(page.getByRole("menuitem", { name: "Steer", exact: true })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      await page.getByRole("menuitem", { name: "Queue", exact: true }).click();
       await expectSendBehavior(page, "queue");
-      await page.getByRole("button", { name: "Interrupt", exact: true }).click();
+      const queuedDefaultSendTrigger = page.getByRole("button", {
+        name: "Default send: Queue",
+        exact: true,
+      });
+      await expect(queuedDefaultSendTrigger).toBeVisible();
+
+      await queuedDefaultSendTrigger.click();
+      await page.getByRole("menuitem", { name: "Interrupt", exact: true }).click();
       await expectSendBehavior(page, "interrupt");
 
       await pressSettingsToggleShortcut(page);

--- a/packages/app/src/screens/settings-screen.tsx
+++ b/packages/app/src/screens/settings-screen.tsx
@@ -284,6 +284,24 @@ interface ServiceUrlBehaviorMenuItemProps {
   onChange: (value: ServiceUrlBehavior) => void;
 }
 
+interface SendBehaviorMenuItemProps {
+  value: SendBehavior;
+  label: string;
+  selected: boolean;
+  onChange: (value: SendBehavior) => void;
+}
+
+function SendBehaviorMenuItem({ value, label, selected, onChange }: SendBehaviorMenuItemProps) {
+  const handleSelect = useCallback(() => {
+    onChange(value);
+  }, [onChange, value]);
+  return (
+    <DropdownMenuItem selected={selected} onSelect={handleSelect}>
+      {label}
+    </DropdownMenuItem>
+  );
+}
+
 function ServiceUrlBehaviorMenuItem({
   value,
   label,
@@ -336,6 +354,9 @@ function GeneralSection({
   const { t, i18n } = useTranslation();
   const activeLocale = getActiveLocale(i18n.language);
   const sendBehaviorOptions = useMemo(() => getSendBehaviorOptions(t), [t]);
+  const selectedSendBehaviorLabel =
+    sendBehaviorOptions.find((option) => option.value === settings.sendBehavior)?.label ??
+    settings.sendBehavior;
   const sendBehaviorDescriptionKey = `settings.general.defaultSend.descriptions.${settings.sendBehavior}`;
   const selectedLanguageOption = LANGUAGE_OPTIONS.find(
     (option) => option.value === settings.language,
@@ -380,12 +401,26 @@ function GeneralSection({
             <Text style={settingsStyles.rowTitle}>{t("settings.general.defaultSend.label")}</Text>
             <Text style={settingsStyles.rowHint}>{t(sendBehaviorDescriptionKey)}</Text>
           </View>
-          <SegmentedControl
-            size="sm"
-            value={settings.sendBehavior}
-            onValueChange={handleSendBehaviorChange}
-            options={sendBehaviorOptions}
-          />
+          <DropdownMenu>
+            <DropdownTrigger
+              accessibilityRole="button"
+              accessibilityLabel={`${t("settings.general.defaultSend.label")}: ${selectedSendBehaviorLabel}`}
+              style={themeTriggerStyle}
+            >
+              <Text style={styles.themeTriggerText}>{selectedSendBehaviorLabel}</Text>
+            </DropdownTrigger>
+            <DropdownMenuContent side="bottom" align="end" width={200}>
+              {sendBehaviorOptions.map((option) => (
+                <SendBehaviorMenuItem
+                  key={option.value}
+                  value={option.value}
+                  label={option.label}
+                  selected={settings.sendBehavior === option.value}
+                  onChange={handleSendBehaviorChange}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </View>
         <View style={[settingsStyles.row, settingsStyles.rowBorder]}>
           <View style={settingsStyles.rowContent}>


### PR DESCRIPTION
### Linked issue

Refs #2972

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Default send is a small, fixed choice in a settings row. Showing all three values as an always-expanded segmented control makes the row unnecessarily wide; the existing anchored dropdown pattern keeps the current value visible and the alternatives available on demand.

### Goals

- Show the selected default send behavior in a single dropdown trigger
- Expose Interrupt, Steer, and Queue as checked menu choices
- Preserve the existing setting persistence and workspace-return flow
- Keep the trigger accessible with both the setting name and selected value

### Non-goals

- Change send behavior semantics or keyboard shortcuts
- Change other segmented controls in Settings
- Change the shared menu engine

### QA

Red/green regression:

- Before implementation: `npm --prefix packages/app run test:e2e -- settings-toggle-tab-regression.spec.ts --grep "toggling settings"` — failed because the collapsed Default send trigger did not exist
- `npm --prefix packages/app run test:e2e -- settings-toggle-tab-regression.spec.ts` — 2 passed
- `npm --prefix packages/app run test:e2e -- agent-message-submission.spec.ts` — 27 passed
- `npm --prefix packages/app run test:e2e -- settings-toggle-tab-regression.spec.ts settings-i18n.spec.ts changes-pane.spec.ts agent-consecutive-turns.spec.ts` — 41 passed
- `npm --prefix packages/app run test -- src/composer/input/labels.test.ts src/composer/input/state.test.ts src/hooks/use-settings/migrations.test.ts src/hooks/use-settings/storage.test.ts --bail=1` — 96 passed
- `npm run typecheck` — passed across all workspaces
- `npm run lint -- packages/app/src/screens/settings-screen.tsx packages/app/e2e/browser/settings-toggle-tab-regression.spec.ts packages/app/e2e/browser/agent-message-submission.spec.ts` — 0 warnings, 0 errors
- `npm run format` — passed
- `git diff --check` — passed

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Shared React Native view; not run locally |
| Android | No | Shared React Native view; not run locally |
| Web | Yes | Real Playwright flows against isolated daemons |
| Desktop macOS | No | Uses the same web implementation; not run in Electron |
| Desktop Windows | No | Not available locally |
| Desktop Linux | No | Not available locally |

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense