### PR TITLE
fix: isolate Claude provider env from desktop host session

### DIFF
--- a/packages/server/src/server/agent/provider-launch-config.test.ts
+++ b/packages/server/src/server/agent/provider-launch-config.test.ts
@@ -265,6 +265,88 @@ describe("createProviderEnv", () => {
     expect(env.CLAUDE_AGENT_SDK_VERSION).toBeUndefined();
     expect(env.CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING).toBe("true");
   });
+
+  test("strips Claude host session auth and gateway env without removing user auth", () => {
+    const base = {
+      PATH: "/usr/bin",
+      CLAUDE_CODE_HOST_AUTH_ENV_VAR: "ANTHROPIC_AUTH_TOKEN",
+      CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: "1",
+      CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH: "1",
+      CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH: "1",
+      CLAUDE_CODE_SESSION_ID: "session",
+      CLAUDE_CODE_HOST_SESSION_ID: "host-session",
+      CLAUDE_CODE_CHILD_SESSION: "1",
+      CLAUDE_PID: "1234",
+      CLAUDE_CODE_EXECPATH: "/opt/claude",
+      CLAUDE_CODE_ATTRIBUTION_HEADER: "desktop",
+      CLAUDE_CODE_CLASSIFIER_SUMMARY: "1",
+      CLAUDE_CODE_DISABLE_CRON: "1",
+      CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1",
+      CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL: "1",
+      CLAUDE_CODE_EAGER_FLUSH: "1",
+      CLAUDE_CODE_EMIT_TOOL_USE_SUMMARIES: "1",
+      CLAUDE_CODE_ENABLE_ASK_USER_QUESTION_TOOL: "1",
+      CLAUDE_CODE_ENABLE_AUTO_MODE: "1",
+      CLAUDE_CODE_OAUTH_SCOPES: "user:inference",
+      CLAUDE_EFFORT: "high",
+      ANTHROPIC_BASE_URL: "http://desktop-gateway",
+      ANTHROPIC_DEFAULT_MYTHOS_MODEL: "",
+      ANTHROPIC_AUTH_TOKEN: "user-token",
+    };
+
+    const env = createProviderEnv({ baseEnv: base });
+
+    expect(env).toEqual({
+      PATH: "/usr/bin",
+      ANTHROPIC_AUTH_TOKEN: "user-token",
+    });
+  });
+
+  test.each(["CLAUDE_CODE_HOST_AUTH_ENV_VAR", "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST"])(
+    "detects a Claude host session from %s alone",
+    (marker) => {
+      const env = createProviderEnv({
+        baseEnv: {
+          [marker]: "1",
+          ANTHROPIC_BASE_URL: "http://desktop-gateway",
+        },
+      });
+
+      expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+    },
+  );
+
+  test("allows provider env to replace a stripped Claude host gateway", () => {
+    const base = {
+      CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: "1",
+      ANTHROPIC_BASE_URL: "http://desktop-gateway",
+    };
+    const runtime: ProviderRuntimeSettings = {
+      env: {
+        ANTHROPIC_BASE_URL: "https://my-relay.example",
+        ANTHROPIC_AUTH_TOKEN: "user-token",
+      },
+    };
+
+    const env = createProviderEnv({ baseEnv: base, runtimeSettings: runtime });
+
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://my-relay.example");
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("user-token");
+  });
+
+  test("preserves Anthropic env outside a Claude host session", () => {
+    const base = {
+      ANTHROPIC_BASE_URL: "https://my-relay.example",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus",
+      ANTHROPIC_AUTH_TOKEN: "user-token",
+    };
+
+    const env = createProviderEnv({ baseEnv: base });
+
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://my-relay.example");
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus");
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("user-token");
+  });
 });
 
 describe("ProviderOverrideSchema", () => {

--- a/packages/server/src/server/agent/provider-launch-config.ts
+++ b/packages/server/src/server/agent/provider-launch-config.ts
@@ -210,6 +210,33 @@ const PARENT_SESSION_ENV_VARS = [
   "CLAUDE_AGENT_SDK_VERSION",
 ];
 
+const CLAUDE_HOST_SESSION_MARKERS = [
+  "CLAUDE_CODE_HOST_AUTH_ENV_VAR",
+  "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+];
+
+const CLAUDE_HOST_SESSION_ENV_VARS = [
+  ...CLAUDE_HOST_SESSION_MARKERS,
+  "CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH",
+  "CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH",
+  "CLAUDE_CODE_SESSION_ID",
+  "CLAUDE_CODE_HOST_SESSION_ID",
+  "CLAUDE_CODE_CHILD_SESSION",
+  "CLAUDE_PID",
+  "CLAUDE_CODE_EXECPATH",
+  "CLAUDE_CODE_ATTRIBUTION_HEADER",
+  "CLAUDE_CODE_CLASSIFIER_SUMMARY",
+  "CLAUDE_CODE_DISABLE_CRON",
+  "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+  "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL",
+  "CLAUDE_CODE_EAGER_FLUSH",
+  "CLAUDE_CODE_EMIT_TOOL_USE_SUMMARIES",
+  "CLAUDE_CODE_ENABLE_ASK_USER_QUESTION_TOOL",
+  "CLAUDE_CODE_ENABLE_AUTO_MODE",
+  "CLAUDE_CODE_OAUTH_SCOPES",
+  "CLAUDE_EFFORT",
+];
+
 export interface ProviderEnvOptions {
   baseEnv?: ProcessEnvRecord;
   runtimeSettings?: ProviderRuntimeSettings;
@@ -230,14 +257,35 @@ function collectProviderEnvOverlays(
   );
 }
 
+function sanitizeClaudeHostSessionEnv(baseEnv: ProcessEnvRecord): ProcessEnvRecord | undefined {
+  const isClaudeHostSession = CLAUDE_HOST_SESSION_MARKERS.some((key) => baseEnv[key] !== undefined);
+  if (!isClaudeHostSession) {
+    return undefined;
+  }
+
+  const sanitizedBaseEnv = { ...baseEnv };
+  for (const key of CLAUDE_HOST_SESSION_ENV_VARS) {
+    delete sanitizedBaseEnv[key];
+  }
+  delete sanitizedBaseEnv.ANTHROPIC_BASE_URL;
+  for (const key of Object.keys(sanitizedBaseEnv)) {
+    if (key.startsWith("ANTHROPIC_DEFAULT_")) {
+      delete sanitizedBaseEnv[key];
+    }
+  }
+  return sanitizedBaseEnv;
+}
+
 export function createProviderEnvSpec(options: ProviderEnvOptions = {}): ProviderEnvSpec {
+  const sanitizedBaseEnv = sanitizeClaudeHostSessionEnv(options.baseEnv ?? process.env);
+  const baseEnv = sanitizedBaseEnv ?? options.baseEnv;
   const overlays = collectProviderEnvOverlays(options.runtimeSettings, options.overlays ?? []);
   const envOverlay: ProcessEnvRecord = Object.assign({}, ...overlays);
   for (const key of PARENT_SESSION_ENV_VARS) {
     envOverlay[key] = undefined;
   }
   return {
-    ...(options.baseEnv ? { baseEnv: options.baseEnv } : {}),
+    ...(baseEnv ? { baseEnv } : {}),
     envOverlay,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #3618.

When the Paseo daemon is started from a terminal inside a Claude Code Desktop session, Claude-specific host environment variables can leak into spawned Claude provider processes.

Those inherited variables can change Claude CLI authentication behavior in two ways:

* Host-managed auth markers such as `CLAUDE_CODE_HOST_AUTH_ENV_VAR` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` cause the spawned CLI to ignore credentials from the normal Claude settings environment.
* Claude Desktop can also inject an `ANTHROPIC_BASE_URL` pointing to its local gateway. Even after removing the host-auth markers, leaving that URL inherited can cause authentication to fail with a 401.

This change isolates spawned Claude providers from the host-owned Claude Desktop session environment while preserving user-owned provider configuration.

## Changes

* Detect a Claude host-managed session from the known host authentication markers.
* Strip host-owned Claude session variables before constructing the child provider environment.
* Remove the inherited Claude Desktop `ANTHROPIC_BASE_URL` when a host-managed session is detected.
* Remove host-owned `ANTHROPIC_DEFAULT_*` values from that inherited environment.
* Preserve `ANTHROPIC_AUTH_TOKEN`.
* Preserve Claude SDK child-process variables that are not part of the host session state.
* Keep explicit Paseo provider env overrides authoritative, so `agents.providers.claude.env` can still provide a user-configured `ANTHROPIC_BASE_URL` and credentials.

The change is intentionally scoped to the provider environment isolation reported in #3618. It does not add daemon startup warnings or unrelated provider behavior.

## Automated tests

Regression coverage was added to `provider-launch-config.test.ts` for:

* stripping the reported Claude host authentication markers
* stripping additional host-owned session variables
* removing the inherited host `ANTHROPIC_BASE_URL`
* preserving `ANTHROPIC_AUTH_TOKEN`
* allowing an explicit provider env override to restore a user-defined `ANTHROPIC_BASE_URL`
* preserving `ANTHROPIC_BASE_URL` in a normal non-host shell
* preserving existing Claude SDK child flags

Targeted test command:

```bash
npx vitest run packages/server/src/server/agent/provider-launch-config.test.ts --bail=1
```

Result:

```text
<Paste final test output here>
```

Additional checks:

```bash
npm run format:check:files -- packages/server/src/server/agent/provider-launch-config.ts packages/server/src/server/agent/provider-launch-config.test.ts

npm run lint -- packages/server/src/server/agent/provider-launch-config.ts packages/server/src/server/agent/provider-launch-config.test.ts

npm run typecheck --workspace=@getpaseo/server
```

Results:

```text
<Paste final outputs here>
```

## Manual QA

### Before

Environment:

* Windows 11
* Claude Desktop session terminal
* Claude CLI using the same authentication setup reported in #3618
* Paseo daemon started from the polluted Claude Desktop session environment

Relevant inherited variables included:

```text
CLAUDE_CODE_HOST_AUTH_ENV_VAR
CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
ANTHROPIC_BASE_URL
```

Observed failure before the fix:

```text
Not logged in · Please run /login
```

With the host auth markers removed but the Claude Desktop gateway URL still inherited, the request can instead fail with an authentication 401, matching the additional reproduction reported in #3618.

### After

The daemon was started again from the same Claude Desktop session environment.

Verified:

* Claude chat agent can authenticate and complete a request
* Claude structured generation can complete successfully
* inherited Claude Desktop host state is not propagated to the spawned provider
* an explicit `agents.providers.claude.env` override can still supply a custom `ANTHROPIC_BASE_URL`
* `ANTHROPIC_AUTH_TOKEN` remains available
* starting Paseo from a normal shell continues to preserve normal user environment configuration

Raw commands and output:

```text
<Paste commands and raw output here>
```

## Platforms

* Windows 11: tested
* macOS: not tested
* Linux: not tested
* Docker: not tested

## Notes

The reporter provided a detailed environment-level reproduction matrix and later confirmed that removing only the two host authentication markers is insufficient if Claude Desktop's inherited `ANTHROPIC_BASE_URL` remains present.

This implementation follows that evidence while keeping the change limited to the environment boundary between the Paseo daemon and spawned Claude provider processes.
