### PR TITLE
fix(pi): render Tintinweb Agent lifecycle and activity

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -156,13 +156,21 @@ The rows combine two kinds of children:
 parentAgentId === thisAgent.id  AND  !archivedAt
 ```
 
-- **Provider subagents** are child executions owned by Claude, Codex, or OpenCode. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track.
+- **Provider subagents** are child executions owned by Claude, Codex, OpenCode, or Pi. They are not inserted into `AgentManager` as managed agents. Providers emit a separate descriptor and timeline stream through `agent.provider_subagents.*`; the client keeps that state outside the normal agent store and merges only the presentation rows into the track.
 
 Clicking either kind opens a workspace tab. A Paseo subagent tab is a normal interactive agent pane. A provider subagent tab is a read-only timeline pane with no composer, archive, detach, rewind, or fork actions. Both panes use `AgentStreamView`, so message, reasoning, tool-call, and layout rendering stay identical.
 
 Provider timelines use the same structural timeline item format but deliberately have a separate lifecycle and transport. A provider thread/session identifier is not a Paseo agent identifier, and closing its tab is always layout-only.
 
 Provider descriptors may include one compact subtitle. The provider owns its contents and formatting; clients display and truncate it without interpreting provider-specific model, thinking, or usage fields.
+
+### Pi provider subagents
+
+Pi RPC does not expose extension event-bus messages. The daemon's injected Pi extension forwards background `Agent` events from `@tintinweb/pi-subagents` through Pi's extension-notification channel. It uses Tintinweb's cross-package manager registry to subscribe to each running child session, then sends completed turns through the provider timeline stream. The lifecycle event remains the fallback source for a terminal result or error when no child session was available.
+
+Tintinweb also sends the parent model a `subagent-notification` custom message when background work finishes. Paseo keeps that message in the model context but displays its structured details as a compact summary instead of the XML content. The XML parser is a fallback for older notifications that have no details.
+
+Queued children use the provider `running` state because the provider-subagent contract has no queued state. A queued child starts timeline forwarding when Tintinweb announces that it is running. Session shutdown cancels active descriptors and removes child subscriptions. The parent agent lifecycle stays literal; the provider child contributes to the daemon-owned workspace activity projection. Pi cannot rebuild these child timelines after a daemon restart because Tintinweb does not expose them through provider history.
 
 ### Claude provider subagents: the task protocol
 

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import pino from "pino";
 import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
+import { createContext, runInContext } from "node:vm";
 import { describe, expect, onTestFinished, test } from "vitest";
 
 import type { AgentSession, AgentSessionConfig, AgentStreamEvent } from "../../agent-sdk-types.js";
@@ -95,22 +96,85 @@ function readUtf8File(pathname: string): string {
 }
 
 type PaseoExtensionListener = (event: unknown, context?: unknown) => unknown;
+type PaseoExtensionEventListener = (data: unknown) => void;
 
 async function loadPaseoExtensionListeners(
   extensionPath: string,
+  extensionEventListeners = new Map<string, Set<PaseoExtensionEventListener>>(),
 ): Promise<Map<string, PaseoExtensionListener>> {
   const listeners = new Map<string, PaseoExtensionListener>();
   const extension = (await import(pathToFileURL(extensionPath).href)) as {
     default: (piApi: {
       on: (event: string, listener: PaseoExtensionListener) => void;
       registerCommand: () => void;
+      events: {
+        on: (event: string, listener: PaseoExtensionEventListener) => () => void;
+      };
     }) => void;
   };
   extension.default({
     on: (event, listener) => listeners.set(event, listener),
     registerCommand: () => undefined,
+    events: {
+      on: (event, listener) => {
+        const eventListeners = extensionEventListeners.get(event) ?? new Set();
+        eventListeners.add(listener);
+        extensionEventListeners.set(event, eventListeners);
+        return () => eventListeners.delete(listener);
+      },
+    },
   });
   return listeners;
+}
+
+async function loadPaseoExtensionListenersWithTintinwebManager(
+  extensionPath: string,
+  manager: { getRecord(id: string): unknown },
+  extensionEventListeners = new Map<string, Set<PaseoExtensionEventListener>>(),
+): Promise<Map<string, PaseoExtensionListener>> {
+  const listeners = new Map<string, PaseoExtensionListener>();
+  const source = readUtf8File(extensionPath).replace(
+    "export default function paseoIntegration(pi)",
+    "globalThis.paseoIntegration = function paseoIntegration(pi)",
+  );
+  const context = createContext({ Buffer, clearTimeout, queueMicrotask, setTimeout });
+  Reflect.set(context, Symbol.for("pi-subagents:manager"), manager);
+  runInContext(source, context);
+  const extension = Reflect.get(context, "paseoIntegration");
+  if (typeof extension !== "function") {
+    throw new Error("Paseo extension did not register its entry point");
+  }
+  extension({
+    on: (event: string, listener: PaseoExtensionListener) => listeners.set(event, listener),
+    registerCommand: () => undefined,
+    events: {
+      on: (event: string, listener: PaseoExtensionEventListener) => {
+        const eventListeners = extensionEventListeners.get(event) ?? new Set();
+        eventListeners.add(listener);
+        extensionEventListeners.set(event, eventListeners);
+        return () => eventListeners.delete(listener);
+      },
+    },
+  });
+  return listeners;
+}
+
+class FakeTintinwebChildSession {
+  readonly messages: unknown[] = [{ role: "user", content: "Private effective prompt" }];
+  private readonly listeners = new Set<(event: Record<string, unknown>) => void>();
+
+  subscribe(listener: (event: Record<string, unknown>) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(event: Record<string, unknown>): void {
+    for (const listener of this.listeners) listener(event);
+  }
+
+  listenerCount(): number {
+    return this.listeners.size;
+  }
 }
 
 async function applyPaseoExtensionSystemPrompt(
@@ -253,6 +317,13 @@ class SessionEvents {
     );
   }
 
+  providerSubagentEvents() {
+    return this.events.filter(
+      (event): event is Extract<AgentStreamEvent, { type: "provider_subagent" }> =>
+        event.type === "provider_subagent",
+    );
+  }
+
   nextTurnCompletion(): Promise<Extract<AgentStreamEvent, { type: "turn_completed" }>> {
     return this.nextEvent(
       (event): event is Extract<AgentStreamEvent, { type: "turn_completed" }> =>
@@ -312,6 +383,268 @@ class SessionEvents {
 }
 
 describe("PiRpcAgentSession", () => {
+  test("maps Tintinweb lifecycle markers to provider subagents", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-started",
+      method: "notify",
+      message:
+        'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","title":"Explore","description":"Trace the change","status":"running"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-completed",
+      method: "notify",
+      message: 'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","status":"completed"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-invalid",
+      method: "notify",
+      message: 'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-2","status":"queued"}',
+    });
+
+    expect(events.providerSubagentEvents()).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "run-1",
+          title: "Explore",
+          description: "Trace the change",
+          status: "running",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: { type: "upsert", id: "run-1", status: "completed" },
+      },
+    ]);
+
+    await session.close();
+  });
+
+  test("maps Tintinweb child activity markers to provider subagent timelines", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-started",
+      method: "notify",
+      message: 'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","title":"Explore","status":"running"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-presentation",
+      method: "notify",
+      message:
+        'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","subtitle":"Explore · gpt-5 · High · 1.2k tokens","toolCallId":"parent-tool-1"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-compaction-started",
+      method: "notify",
+      message:
+        'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"compaction","id":"run-1","status":"loading","trigger":"auto"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-compaction-completed",
+      method: "notify",
+      message:
+        'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"compaction","id":"run-1","status":"completed"}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-messages",
+      method: "notify",
+      message:
+        'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"messages","id":"run-1","messages":[{"role":"assistant","responseId":"response-1","content":[{"type":"thinking","thinking":"Trace the path"},{"type":"text","text":"Reading the source"},{"type":"toolCall","id":"tool-1","name":"bash","arguments":{"command":"pwd"}}]},{"role":"toolResult","toolCallId":"tool-1","toolName":"bash","content":[{"type":"text","text":"/workspace\\n"}],"details":{"output":"/workspace\\n","exitCode":0}}]}',
+    });
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-error",
+      method: "notify",
+      message:
+        'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"error","id":"run-1","message":"Child retry failed"}',
+    });
+
+    expect(events.providerSubagentEvents()).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: { type: "upsert", id: "run-1", title: "Explore", status: "running" },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "run-1",
+          subtitle: "Explore · gpt-5 · High · 1.2k tokens",
+          toolCallId: "parent-tool-1",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "timeline",
+          id: "run-1",
+          item: { type: "compaction", status: "loading", trigger: "auto" },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "timeline",
+          id: "run-1",
+          item: { type: "compaction", status: "completed" },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "timeline",
+          id: "run-1",
+          item: { type: "reasoning", text: "Trace the path" },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "timeline",
+          id: "run-1",
+          item: {
+            type: "assistant_message",
+            text: "Reading the source",
+            messageId: "response-1",
+          },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "timeline",
+          id: "run-1",
+          item: {
+            type: "tool_call",
+            callId: "tool-1",
+            name: "bash",
+            status: "running",
+            detail: {
+              type: "shell",
+              command: "pwd",
+              output: undefined,
+              exitCode: undefined,
+            },
+            error: null,
+          },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "timeline",
+          id: "run-1",
+          item: {
+            type: "tool_call",
+            callId: "tool-1",
+            name: "bash",
+            status: "completed",
+            detail: { type: "shell", command: "pwd", output: "/workspace\n", exitCode: null },
+            error: null,
+          },
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "timeline",
+          id: "run-1",
+          item: { type: "error", message: "Child retry failed" },
+        },
+      },
+    ]);
+
+    await session.close();
+  });
+
+  test("fails active Tintinweb children when the Pi process exits", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    fakeSession.emit({
+      type: "extension_ui_request",
+      id: "subagent-started",
+      method: "notify",
+      message: 'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","title":"Explore","status":"running"}',
+    });
+    fakeSession.emit({ type: "process_exit", error: "Pi exited" });
+
+    expect(events.providerSubagentEvents()).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "run-1",
+          title: "Explore",
+          status: "running",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: { type: "upsert", id: "run-1", status: "failed" },
+      },
+    ]);
+
+    await session.close();
+  });
+
+  test("cancels active Tintinweb children when the Pi session closes", async () => {
+    const { pi, session, events } = await createSession();
+
+    pi.latestSession().emit({
+      type: "extension_ui_request",
+      id: "subagent-started",
+      method: "notify",
+      message: 'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","title":"Explore","status":"running"}',
+    });
+    await session.close();
+
+    expect(events.providerSubagentEvents()).toEqual([
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: {
+          type: "upsert",
+          id: "run-1",
+          title: "Explore",
+          status: "running",
+        },
+      },
+      {
+        type: "provider_subagent",
+        provider: "pi",
+        event: { type: "upsert", id: "run-1", status: "canceled" },
+      },
+    ]);
+  });
+
   test("bridges Pi RPC select extension UI requests through question permissions", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
@@ -854,6 +1187,47 @@ describe("PiRpcAgentSession", () => {
     ]);
   });
 
+  test("formats Tintinweb custom notifications instead of exposing their XML", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await session.startTurn("/wait-for-agent");
+    fakeSession.emit({
+      type: "message_end",
+      message: {
+        role: "custom",
+        customType: "subagent-notification",
+        content: "<task-notification>raw XML</task-notification>",
+        details: {
+          id: "agent-1",
+          description: "inspect Paseo pin",
+          status: "completed",
+          toolUses: 10,
+          turnCount: 0,
+          totalTokens: 101_088,
+          durationMs: 36_787,
+          resultPreview: "Found the source pins.",
+        },
+      },
+    });
+
+    expect(events.timelineAndCompletionEvents()).toEqual([
+      {
+        type: "timeline",
+        item: {
+          type: "assistant_message",
+          text: [
+            "**Agent completed: inspect Paseo pin**",
+            "10 tool uses | 101.1k tokens | 36.8s",
+            "",
+            "Found the source pins.",
+          ].join("\n"),
+        },
+      },
+      { type: "turn_completed" },
+    ]);
+  });
+
   test("canceling a silent Pi extension command leaves the session usable", async () => {
     const { pi, session, events } = await createSession();
     const fakeSession = pi.latestSession();
@@ -1200,6 +1574,242 @@ describe("PiRpcAgentSession", () => {
       'PASEO_SUBMITTED_USER_ENTRY {"entry":{"id":"entry-new","parentId":"entry-old-assistant","text":"new prompt"}}',
     ]);
 
+    await session.close();
+  });
+
+  test("reports Tintinweb background Agent lifecycle through the Paseo extension", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const session = await client.createSession(createConfig());
+    const extensionPath = pi.recordedLaunches[0]?.extensionPaths[0];
+    expect(extensionPath).toBeDefined();
+    const extensionEvents = new Map<string, Set<PaseoExtensionEventListener>>();
+    const listeners = await loadPaseoExtensionListeners(extensionPath!, extensionEvents);
+    const notifications: string[] = [];
+    const context = {
+      sessionManager: { getEntries: () => [] },
+      ui: { notify: (message: string) => notifications.push(message) },
+    };
+    const emitExtensionEvent = (name: string, payload: unknown) => {
+      extensionEvents.get(name)?.forEach((listener) => listener(payload));
+    };
+
+    await listeners.get("session_start")?.({}, context);
+    notifications.length = 0;
+    emitExtensionEvent("subagents:created", {
+      id: "foreground-1",
+      type: "Explore",
+      description: "Do not add a provider child",
+      isBackground: false,
+    });
+    emitExtensionEvent("subagents:completed", { id: "missing-1", status: "completed" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-1",
+      type: "Explore",
+      description: "Trace the Pi mapper",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:created", {
+      id: "run-1",
+      type: "Explore",
+      description: "Trace the Pi mapper",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:completed", {
+      id: "run-1",
+      type: "Explore",
+      status: "steered",
+      result: "Mapped the Pi provider",
+      tokens: { input: 800, output: 400, total: 1200 },
+    });
+    emitExtensionEvent("subagents:completed", { id: "run-1", status: "completed" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-2",
+      type: "Plan",
+      description: "Plan a focused change",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:failed", { id: "run-2", status: "stopped" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-3",
+      type: "general-purpose",
+      description: "Implement the change",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:failed", { id: "run-3", status: "aborted" });
+    emitExtensionEvent("subagents:created", {
+      id: "run-4",
+      type: "general-purpose",
+      description: "Check the change",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:failed", {
+      id: "run-4",
+      status: "error",
+      error: "Child provider failed",
+    });
+    emitExtensionEvent("subagents:created", {
+      id: "run-5",
+      type: "Explore",
+      description: "Cancel on shutdown",
+      isBackground: true,
+    });
+    emitExtensionEvent("subagents:failed", { id: "run-5", status: "unknown" });
+    await listeners.get("session_shutdown")?.({}, context);
+
+    expect(notifications).toEqual([
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","title":"Explore","description":"Trace the Pi mapper","status":"running"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","subtitle":"Explore · 1.2k tokens"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"messages","id":"run-1","messages":[{"role":"assistant","content":[{"type":"text","text":"Mapped the Pi provider"}]}]}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","status":"completed"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-2","title":"Plan","description":"Plan a focused change","status":"running"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-2","status":"canceled"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-3","title":"general-purpose","description":"Implement the change","status":"running"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-3","status":"failed"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-4","title":"general-purpose","description":"Check the change","status":"running"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"error","id":"run-4","message":"Child provider failed"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-4","status":"failed"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-5","title":"Explore","description":"Cancel on shutdown","status":"running"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-5","status":"canceled"}',
+    ]);
+    expect([...extensionEvents.values()].every((eventListeners) => eventListeners.size === 0)).toBe(
+      true,
+    );
+
+    await session.close();
+  });
+
+  test("streams Tintinweb child turns through the Paseo extension", async () => {
+    const pi = new FakePi();
+    const client = createClient(pi);
+    const session = await client.createSession(createConfig());
+    const extensionPath = pi.recordedLaunches[0]?.extensionPaths[0];
+    expect(extensionPath).toBeDefined();
+
+    const childSession = new FakeTintinwebChildSession();
+    const record = {
+      id: "run-1",
+      type: "Explore",
+      status: "running",
+      isBackground: true,
+      toolCallId: "parent-tool-1",
+      invocation: { modelName: "gpt-5", thinking: "high" },
+      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      session: childSession,
+    };
+    const queuedChildSession = new FakeTintinwebChildSession();
+    const queuedRecord = {
+      id: "run-2",
+      type: "Plan",
+      status: "queued",
+      isBackground: true,
+      invocation: { modelName: "gpt-5", thinking: "low" },
+      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      session: queuedChildSession,
+    };
+    const records = new Map([
+      [record.id, record],
+      [queuedRecord.id, queuedRecord],
+    ]);
+    const extensionEvents = new Map<string, Set<PaseoExtensionEventListener>>();
+    const listeners = await loadPaseoExtensionListenersWithTintinwebManager(
+      extensionPath!,
+      { getRecord: (id) => records.get(id) },
+      extensionEvents,
+    );
+    const notifications: string[] = [];
+    const context = {
+      sessionManager: { getEntries: () => [] },
+      ui: { notify: (message: string) => notifications.push(message) },
+    };
+    const emitExtensionEvent = (name: string, payload: unknown) => {
+      extensionEvents.get(name)?.forEach((listener) => listener(payload));
+    };
+
+    await listeners.get("session_start")?.({}, context);
+    notifications.length = 0;
+    emitExtensionEvent("subagents:started", {
+      id: "run-1",
+      type: "Explore",
+      description: "Trace the Pi mapper",
+    });
+    emitExtensionEvent("subagents:created", {
+      id: "run-1",
+      type: "Explore",
+      description: "Trace the Pi mapper",
+      isBackground: true,
+    });
+
+    childSession.messages.push(
+      {
+        role: "assistant",
+        responseId: "response-1",
+        content: [
+          { type: "thinking", thinking: "Trace the path" },
+          { type: "text", text: "Reading the source" },
+          { type: "toolCall", id: "tool-1", name: "read", arguments: { path: "agent.ts" } },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        content: [{ type: "text", text: "source" }],
+      },
+    );
+    record.lifetimeUsage.input = 800;
+    record.lifetimeUsage.output = 400;
+    childSession.emit({ type: "turn_end" });
+    childSession.emit({ type: "compaction_start", reason: "threshold" });
+    childSession.emit({ type: "compaction_end", result: { tokensBefore: 1200 } });
+    childSession.emit({ type: "compaction_start", reason: "manual" });
+    childSession.emit({ type: "compaction_end", aborted: true, errorMessage: "Canceled" });
+    emitExtensionEvent("subagents:completed", {
+      id: "run-1",
+      type: "Explore",
+      status: "completed",
+      result: "Reading the source",
+      tokens: { input: 800, output: 400, total: 1200 },
+    });
+
+    emitExtensionEvent("subagents:created", {
+      id: "run-2",
+      type: "Plan",
+      description: "Wait for a slot",
+      isBackground: true,
+    });
+    expect(queuedChildSession.listenerCount()).toBe(0);
+    queuedRecord.status = "running";
+    emitExtensionEvent("subagents:started", {
+      id: "run-2",
+      type: "Plan",
+      description: "Wait for a slot",
+    });
+    queuedChildSession.messages.push({
+      role: "assistant",
+      content: [{ type: "text", text: "The slot is active" }],
+    });
+    queuedChildSession.emit({ type: "turn_end" });
+    emitExtensionEvent("subagents:failed", { id: "run-2", status: "stopped" });
+
+    expect(notifications).toEqual([
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","title":"Explore","description":"Trace the Pi mapper","status":"running","subtitle":"Explore · gpt-5 · High","toolCallId":"parent-tool-1"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"messages","id":"run-1","messages":[{"role":"assistant","responseId":"response-1","content":[{"type":"thinking","thinking":"Trace the path"},{"type":"text","text":"Reading the source"},{"type":"toolCall","id":"tool-1","name":"read","arguments":{"path":"agent.ts"}}]}]}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"messages","id":"run-1","messages":[{"role":"toolResult","toolCallId":"tool-1","toolName":"read","content":[{"type":"text","text":"source"}]}]}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","subtitle":"Explore · gpt-5 · High · 1.2k tokens"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"compaction","id":"run-1","status":"loading","trigger":"auto"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"compaction","id":"run-1","status":"completed"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"compaction","id":"run-1","status":"loading","trigger":"manual"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"compaction","id":"run-1","status":"completed"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-1","status":"completed"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-2","title":"Plan","description":"Wait for a slot","status":"running","subtitle":"Plan · gpt-5 · Low"}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"kind":"messages","id":"run-2","messages":[{"role":"assistant","content":[{"type":"text","text":"The slot is active"}]}]}',
+      'PASEO_PI_TINTINWEB_SUBAGENT {"id":"run-2","status":"canceled"}',
+    ]);
+    expect(childSession.listenerCount()).toBe(0);
+    expect(queuedChildSession.listenerCount()).toBe(0);
+
+    await listeners.get("session_shutdown")?.({}, context);
     await session.close();
   });
 

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -60,6 +60,7 @@ import {
 } from "../diagnostic-utils.js";
 import {
   getUserMessageText,
+  PiHistoryMapper,
   streamPiHistory,
   type PiCapturedUserMessageEntry,
 } from "./history-mapper.js";
@@ -87,6 +88,7 @@ import {
   type PiToolResult,
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
+import { formatTintinwebSubagentNotification } from "./tintinweb-notification.js";
 
 const PI_PROVIDER = "pi";
 const DEFAULT_PI_THINKING_LEVEL: PiThinkingLevel = "medium";
@@ -96,12 +98,73 @@ const PASEO_PI_CAPTURE_EXTENSION_COMMAND = "paseo_capture_entries";
 const PASEO_PI_ENTRY_CAPTURE_MARKER = "PASEO_ENTRY_CAPTURE";
 const PASEO_PI_SUBMITTED_USER_ENTRY_MARKER = "PASEO_SUBMITTED_USER_ENTRY";
 const PASEO_PI_COMMAND_RESULT_MARKER = "PASEO_COMMAND_RESULT";
+const PASEO_PI_TINTINWEB_SUBAGENT_MARKER = "PASEO_PI_TINTINWEB_SUBAGENT";
 const DEFAULT_PI_EXTENSION_RESULT_TIMEOUT_MS = 30_000;
 const DEFAULT_PI_RPC_TIMEOUT_MS = 60_000;
 const QUESTION_RESPONSE_HEADER = "Response";
 const QUESTION_COMMENT_HEADER = "Comment";
 const PI_ASK_USER_FREEFORM_SENTINEL = "✏️ Type custom response...";
 const COMBINED_ASK_USER_METADATA = "ask_user_select_optional_comment";
+
+const PiTextContentSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+const PiImageContentSchema = z.object({
+  type: z.literal("image"),
+  data: z.string(),
+  mimeType: z.string(),
+});
+const PiAssistantContentSchema = z.discriminatedUnion("type", [
+  PiTextContentSchema,
+  z.object({ type: z.literal("thinking"), thinking: z.string() }),
+  z.object({
+    type: z.literal("toolCall"),
+    id: z.string(),
+    name: z.string(),
+    arguments: z.unknown(),
+  }),
+]);
+const PiAgentMessageSchema: z.ZodType<PiAgentMessage> = z.discriminatedUnion("role", [
+  z.object({
+    role: z.literal("user"),
+    content: z.union([z.string(), z.array(z.union([PiTextContentSchema, PiImageContentSchema]))]),
+  }),
+  z.object({
+    role: z.literal("custom"),
+    content: z.union([z.string(), z.array(z.union([PiTextContentSchema, PiImageContentSchema]))]),
+    customType: z.string().optional(),
+    display: z.boolean().optional(),
+    details: z.unknown().optional(),
+  }),
+  z.object({
+    role: z.literal("assistant"),
+    content: z.array(PiAssistantContentSchema),
+    provider: z.string().optional(),
+    model: z.string().optional(),
+    responseId: z.string().optional(),
+    responseModel: z.string().optional(),
+    errorMessage: z.string().nullable().optional(),
+    stopReason: z.string().optional(),
+  }),
+  z.object({
+    role: z.literal("toolResult"),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    content: z.unknown(),
+    isError: z.boolean().optional(),
+    details: z.unknown().optional(),
+  }),
+  z.object({
+    role: z.literal("bashExecution"),
+    command: z.string(),
+    output: z.string().optional(),
+    exitCode: z.number().nullable().optional(),
+    cancelled: z.boolean().optional(),
+    timestamp: z.number(),
+  }),
+]);
+const PiAgentMessagesSchema = z.array(PiAgentMessageSchema);
 
 export const PiProviderParamsSchema = z
   .object({
@@ -667,8 +730,255 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
 	  );
 	}
 
+	function tintinwebSubagentId(payload) {
+	  const value = payload?.id;
+	  if (typeof value !== "string") return undefined;
+	  return value.trim() || undefined;
+	}
+
+	function tintinwebManager() {
+	  const manager = globalThis[Symbol.for("pi-subagents:manager")];
+	  return manager && typeof manager.getRecord === "function" ? manager : undefined;
+	}
+
+	function tintinwebRecord(id) {
+	  return tintinwebManager()?.getRecord(id);
+	}
+
+	function tintinwebTokenTotal(record, payload) {
+	  if (typeof payload?.tokens?.total === "number") return payload.tokens.total;
+	  const usage = record?.lifetimeUsage;
+	  if (!usage) return 0;
+	  return (usage.input || 0) + (usage.output || 0) + (usage.cacheWrite || 0);
+	}
+
+	function formatTintinwebTokens(total) {
+	  if (total <= 0) return undefined;
+	  if (total < 1000) return Math.round(total) + " tokens";
+	  return Math.round(total / 100) / 10 + "k tokens";
+	}
+
+	function formatTintinwebThinking(value) {
+	  if (typeof value !== "string" || !value.trim()) return undefined;
+	  if (value === "xhigh") return "Extra High";
+	  return value
+	    .split(/[-_\\s]+/)
+	    .filter(Boolean)
+	    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+	    .join(" ");
+	}
+
+	function tintinwebSubtitle(record, payload) {
+	  const type =
+	    typeof payload?.type === "string" && payload.type.trim()
+	      ? payload.type.trim()
+	      : record?.type;
+	  const model = record?.invocation?.modelName;
+	  const thinking = formatTintinwebThinking(record?.invocation?.thinking);
+	  const tokens = formatTintinwebTokens(tintinwebTokenTotal(record, payload));
+	  const parts = [type, model, thinking, tokens].filter(Boolean);
+	  return parts.length > 1 ? parts.join(" · ") : undefined;
+	}
+
+	function reportTintinwebSubagent(ctx, event) {
+	  if (!ctx) return;
+	  ctx.ui.notify(
+	    "${PASEO_PI_TINTINWEB_SUBAGENT_MARKER} " + JSON.stringify(event),
+	    "info",
+	  );
+	}
+
 	export default function paseoIntegration(pi) {
 	  const submittedUserMessages = [];
+	  const activeTintinwebSubagentIds = new Set();
+	  const tintinwebAttachTimers = new Map();
+	  const tintinwebStreams = new Map();
+	  const tintinwebSubtitles = new Map();
+	  let tintinwebContext;
+	  let unsubscribeTintinwebEvents = [];
+
+	  function reportTintinwebPresentation(id, payload) {
+	    const record = tintinwebRecord(id);
+	    const subtitle = tintinwebSubtitle(record, payload);
+	    if (!subtitle || tintinwebSubtitles.get(id) === subtitle) return;
+	    tintinwebSubtitles.set(id, subtitle);
+	    reportTintinwebSubagent(tintinwebContext, { id, subtitle });
+	  }
+
+	  function flushTintinwebStream(id) {
+	    const stream = tintinwebStreams.get(id);
+	    if (!stream) return;
+	    const messages = stream.session.messages;
+	    while (stream.writtenCount < messages.length) {
+	      const message = messages[stream.writtenCount];
+	      stream.writtenCount += 1;
+	      if (stream.skipNextUser && message?.role === "user") {
+	        stream.skipNextUser = false;
+	        continue;
+	      }
+	      if (message?.role === "assistant") stream.hasAssistantMessage = true;
+	      reportTintinwebSubagent(tintinwebContext, {
+	        kind: "messages",
+	        id,
+	        messages: [message],
+	      });
+	    }
+	  }
+
+	  function attachTintinwebStream(id, startAtCurrentMessages) {
+	    if (tintinwebStreams.has(id)) return true;
+	    const record = tintinwebRecord(id);
+	    const session = record?.session;
+	    if (!session || !Array.isArray(session.messages) || typeof session.subscribe !== "function") {
+	      return false;
+	    }
+	    const stream = {
+	      session,
+	      writtenCount: startAtCurrentMessages ? session.messages.length : 0,
+	      skipNextUser: true,
+	      hasAssistantMessage: false,
+	      unsubscribe: undefined,
+	    };
+	    tintinwebStreams.set(id, stream);
+	    stream.unsubscribe = session.subscribe((event) => {
+	      if (event.type === "turn_end") {
+	        flushTintinwebStream(id);
+	        reportTintinwebPresentation(id);
+	      }
+	      if (event.type === "compaction_start") {
+	        flushTintinwebStream(id);
+	        const trigger = event.reason === "manual" ? "manual" : "auto";
+	        reportTintinwebSubagent(tintinwebContext, {
+	          kind: "compaction",
+	          id,
+	          status: "loading",
+	          trigger,
+	        });
+	      }
+	      if (event.type === "compaction_end") {
+	        reportTintinwebSubagent(tintinwebContext, {
+	          kind: "compaction",
+	          id,
+	          status: "completed",
+	        });
+	        if (!event.aborted && event.result) {
+	          queueMicrotask(() => {
+	            stream.writtenCount = session.messages.length;
+	          });
+	        }
+	      }
+	    });
+	    flushTintinwebStream(id);
+	    return true;
+	  }
+
+	  function scheduleTintinwebStream(id, startAtCurrentMessages = false) {
+	    if (tintinwebStreams.has(id) || tintinwebAttachTimers.has(id)) return;
+	    const attach = () => {
+	      tintinwebAttachTimers.delete(id);
+	      if (!activeTintinwebSubagentIds.has(id)) return;
+	      if (attachTintinwebStream(id, startAtCurrentMessages)) return;
+	      tintinwebAttachTimers.set(id, setTimeout(attach, 250));
+	    };
+	    attach();
+	  }
+
+	  function stopTintinwebStream(id) {
+	    const timer = tintinwebAttachTimers.get(id);
+	    if (timer) clearTimeout(timer);
+	    tintinwebAttachTimers.delete(id);
+	    flushTintinwebStream(id);
+	    const stream = tintinwebStreams.get(id);
+	    stream?.unsubscribe?.();
+	    tintinwebStreams.delete(id);
+	    return stream?.hasAssistantMessage === true;
+	  }
+
+	  function finishTintinwebSubagent(payload, status) {
+	    const id = tintinwebSubagentId(payload);
+	    if (!id || !activeTintinwebSubagentIds.delete(id)) return;
+	    if (!tintinwebStreams.has(id)) attachTintinwebStream(id, false);
+	    const hasAssistantMessage = stopTintinwebStream(id);
+	    reportTintinwebPresentation(id, payload);
+	    const result = typeof payload?.result === "string" ? payload.result.trim() : "";
+	    const error = typeof payload?.error === "string" ? payload.error.trim() : "";
+	    if (status === "completed" && result && !hasAssistantMessage) {
+	      reportTintinwebSubagent(tintinwebContext, {
+	        kind: "messages",
+	        id,
+	        messages: [{ role: "assistant", content: [{ type: "text", text: result }] }],
+	      });
+	    }
+	    if (status === "failed" && error) {
+	      reportTintinwebSubagent(tintinwebContext, { kind: "error", id, message: error });
+	    }
+	    tintinwebSubtitles.delete(id);
+	    reportTintinwebSubagent(tintinwebContext, { id, status });
+	  }
+
+	  function stopTintinwebEvents() {
+	    for (const id of activeTintinwebSubagentIds) {
+	      stopTintinwebStream(id);
+	      reportTintinwebSubagent(tintinwebContext, { id, status: "canceled" });
+	    }
+	    activeTintinwebSubagentIds.clear();
+	    tintinwebSubtitles.clear();
+	    for (const unsubscribe of unsubscribeTintinwebEvents) unsubscribe();
+	    unsubscribeTintinwebEvents = [];
+	    tintinwebContext = undefined;
+	  }
+
+	  function startTintinwebEvents(ctx) {
+	    stopTintinwebEvents();
+	    tintinwebContext = ctx;
+	    unsubscribeTintinwebEvents = [
+	      pi.events.on("subagents:started", (payload) => {
+	        const id = tintinwebSubagentId(payload);
+	        const record = id ? tintinwebRecord(id) : undefined;
+	        if (id && record?.isBackground === true && activeTintinwebSubagentIds.has(id)) {
+	          scheduleTintinwebStream(id);
+	        }
+	      }),
+	      pi.events.on("subagents:created", (payload) => {
+	        const id = tintinwebSubagentId(payload);
+	        if (!id || payload?.isBackground !== true || activeTintinwebSubagentIds.has(id)) return;
+	        // Tintinweb uses this event for queued and running work; Paseo has no queued child status.
+	        activeTintinwebSubagentIds.add(id);
+	        const type = typeof payload.type === "string" ? payload.type.trim() : "";
+	        const description =
+	          typeof payload.description === "string" ? payload.description.trim() : "";
+	        const record = tintinwebRecord(id);
+	        const subtitle = tintinwebSubtitle(record, payload);
+	        const toolCallId =
+	          typeof record?.toolCallId === "string" && record.toolCallId.trim()
+	            ? record.toolCallId.trim()
+	            : undefined;
+	        reportTintinwebSubagent(tintinwebContext, {
+	          id,
+	          title: type || "Pi subagent",
+	          description: description || undefined,
+	          status: "running",
+	          subtitle,
+	          toolCallId,
+	        });
+	        if (subtitle) tintinwebSubtitles.set(id, subtitle);
+	        if (record?.status === "running") scheduleTintinwebStream(id);
+	      }),
+	      pi.events.on("subagents:completed", (payload) => {
+	        if (payload?.status !== "completed" && payload?.status !== "steered") return;
+	        finishTintinwebSubagent(payload, "completed");
+	      }),
+	      pi.events.on("subagents:failed", (payload) => {
+	        if (payload?.status === "stopped") {
+	          finishTintinwebSubagent(payload, "canceled");
+	          return;
+	        }
+	        if (payload?.status === "aborted" || payload?.status === "error") {
+	          finishTintinwebSubagent(payload, "failed");
+	        }
+	      }),
+	    ];
+	  }
 
 	  function emitSubmittedUserEntries(ctx) {
 	    const entries = ctx.sessionManager.getEntries();
@@ -701,7 +1011,12 @@ function createPiPaseoExtensionFile(systemPrompt?: string): PiTempFile {
     }
 
 	  pi.on("session_start", async (_event, ctx) => {
+	    startTintinwebEvents(ctx);
 	    emitEntryCapture(ctx, "session_start");
+	  });
+
+	  pi.on("session_shutdown", async () => {
+	    stopTintinwebEvents();
 	  });
 
 	  pi.on("message_end", async (event) => {
@@ -853,6 +1168,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+function parseTintinwebLifecycleStatus(
+  value: unknown,
+): "running" | "completed" | "failed" | "canceled" | null {
+  if (value === "running" || value === "completed" || value === "failed" || value === "canceled") {
+    return value;
+  }
+  return null;
 }
 
 function parseExtensionMarkerPayload(
@@ -1223,6 +1547,8 @@ export class PiRpcAgentSession implements AgentSession {
 
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly activeToolCalls = new Map<string, PiTrackedToolCall>();
+  private readonly activeTintinwebSubagentIds = new Set<string>();
+  private readonly tintinwebSubagentMappers = new Map<string, PiHistoryMapper>();
   private readonly pendingExtensionUiRequests = new Map<string, AgentPermissionRequest>();
   private activeAskUserDialog: ActiveAskUserDialog | null = null;
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
@@ -1629,6 +1955,7 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
     this.closed = true;
+    this.settleActiveTintinwebSubagents("canceled");
     this.usagePoller.close();
     try {
       await this.runtimeSession.close();
@@ -2021,6 +2348,121 @@ export class PiRpcAgentSession implements AgentSession {
     return true;
   }
 
+  private handleTintinwebSubagentMarker(message: string): boolean {
+    const payload = parseExtensionMarkerPayload(message, PASEO_PI_TINTINWEB_SUBAGENT_MARKER);
+    if (!payload) {
+      return false;
+    }
+    if (this.closed) {
+      return true;
+    }
+    const id = optionalString(payload.id)?.trim();
+    if (!id) {
+      return true;
+    }
+    switch (optionalString(payload.kind)) {
+      case "messages":
+        this.emitTintinwebMessages(id, payload.messages);
+        break;
+      case "error":
+        this.emitTintinwebError(id, payload.message);
+        break;
+      case "compaction":
+        this.emitTintinwebCompaction(id, payload);
+        break;
+      default:
+        this.emitTintinwebUpsert(id, payload);
+    }
+    return true;
+  }
+
+  private emitTintinwebMessages(id: string, value: unknown): void {
+    const parsed = PiAgentMessagesSchema.safeParse(value);
+    if (!parsed.success) {
+      return;
+    }
+    const mapper = this.tintinwebSubagentMappers.get(id) ?? new PiHistoryMapper(this.provider);
+    this.tintinwebSubagentMappers.set(id, mapper);
+    for (const event of mapper.mapMessages(parsed.data)) {
+      if (event.type !== "timeline") {
+        continue;
+      }
+      this.emit({
+        type: "provider_subagent",
+        provider: this.provider,
+        event: {
+          type: "timeline",
+          id,
+          item: event.item,
+          ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+        },
+      });
+    }
+  }
+
+  private emitTintinwebError(id: string, value: unknown): void {
+    const error = optionalString(value)?.trim();
+    if (!error) {
+      return;
+    }
+    this.emit({
+      type: "provider_subagent",
+      provider: this.provider,
+      event: { type: "timeline", id, item: { type: "error", message: error } },
+    });
+  }
+
+  private emitTintinwebCompaction(id: string, payload: Record<string, unknown>): void {
+    const status = optionalString(payload.status);
+    if (status !== "loading" && status !== "completed") {
+      return;
+    }
+    const trigger = optionalString(payload.trigger);
+    this.emit({
+      type: "provider_subagent",
+      provider: this.provider,
+      event: {
+        type: "timeline",
+        id,
+        item: {
+          type: "compaction",
+          status,
+          ...(trigger === "auto" || trigger === "manual" ? { trigger } : {}),
+        },
+      },
+    });
+  }
+
+  private emitTintinwebUpsert(id: string, payload: Record<string, unknown>): void {
+    const status = parseTintinwebLifecycleStatus(payload.status);
+    const title = optionalString(payload.title)?.trim();
+    const description = optionalString(payload.description)?.trim();
+    const subtitle = optionalString(payload.subtitle)?.trim();
+    const toolCallId = optionalString(payload.toolCallId)?.trim();
+    if (!status && !title && !description && !subtitle && !toolCallId) {
+      return;
+    }
+    if (status === "running") {
+      this.activeTintinwebSubagentIds.add(id);
+    } else if (status) {
+      this.activeTintinwebSubagentIds.delete(id);
+      this.tintinwebSubagentMappers.delete(id);
+    }
+    this.emit({
+      type: "provider_subagent",
+      provider: this.provider,
+      event: {
+        type: "upsert",
+        id,
+        ...(status ? { status } : {}),
+        ...(title ? { title } : {}),
+        ...(description ? { description } : {}),
+        ...(subtitle ? { subtitle } : {}),
+        ...(toolCallId ? { toolCallId } : {}),
+      },
+    });
+  }
+
   private handleExtensionUiRequest(
     event: Extract<PiRuntimeEvent, { type: "extension_ui_request" }>,
   ): void {
@@ -2029,7 +2471,8 @@ export class PiRpcAgentSession implements AgentSession {
       if (
         this.handleSubmittedUserEntryMarker(message) ||
         this.handleEntryCaptureMarker(message) ||
-        this.handleCommandResultMarker(message)
+        this.handleCommandResultMarker(message) ||
+        this.handleTintinwebSubagentMarker(message)
       ) {
         return;
       }
@@ -2148,8 +2591,21 @@ export class PiRpcAgentSession implements AgentSession {
     }
   }
 
+  private settleActiveTintinwebSubagents(status: "failed" | "canceled"): void {
+    for (const id of this.activeTintinwebSubagentIds) {
+      this.emit({
+        type: "provider_subagent",
+        provider: this.provider,
+        event: { type: "upsert", id, status },
+      });
+    }
+    this.activeTintinwebSubagentIds.clear();
+    this.tintinwebSubagentMappers.clear();
+  }
+
   private handleProcessExit(error: string): void {
     this.rejectAllExtensionResults(new Error(error));
+    this.settleActiveTintinwebSubagents("failed");
     if (!this.activeTurnId) {
       return;
     }
@@ -2389,7 +2845,9 @@ export class PiRpcAgentSession implements AgentSession {
       return;
     }
     if (event.message.role === "custom") {
-      const text = getUserMessageText(event.message.content);
+      const text =
+        formatTintinwebSubagentNotification(event.message) ??
+        getUserMessageText(event.message.content);
       if (text) {
         this.emit({
           type: "timeline",

--- a/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.test.ts
@@ -140,6 +140,114 @@ describe("Pi history mapper", () => {
     ]);
   });
 
+  test("formats structured Tintinweb agent notifications as compact summaries", async () => {
+    await expect(
+      collectHistory([
+        {
+          role: "custom",
+          customType: "subagent-notification",
+          content: [
+            "Background agent group completed: 2 agent(s) finished (partial - others still running)",
+            "",
+            "<task-notification>raw XML</task-notification>",
+            "",
+            "Use get_subagent_result for full output.",
+          ].join("\n"),
+          details: {
+            id: "agent-1",
+            description: "inspect Paseo pin",
+            status: "completed",
+            toolUses: 10,
+            turnCount: 4,
+            maxTurns: 12,
+            totalTokens: 101_088,
+            durationMs: 36_787,
+            outputFile: "/tmp/agent-1.output",
+            resultPreview: "- Source pins: `flake.nix`",
+            others: [
+              {
+                id: "agent-2",
+                description: "trace Paseo services",
+                status: "steered",
+                toolUses: 19,
+                turnCount: 8,
+                totalTokens: 110_374,
+                durationMs: 47_904,
+                outputFile: "/tmp/agent-2.output",
+                resultPreview: "Read-only findings; no files changed.",
+              },
+            ],
+          },
+        },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "timeline",
+        provider: "pi",
+        item: {
+          type: "assistant_message",
+          text: [
+            "**Background agent results (other agents still running)**",
+            "",
+            "**Agent completed: inspect Paseo pin**",
+            "4/12 turns | 10 tool uses | 101.1k tokens | 36.8s",
+            "",
+            "- Source pins: `flake.nix`",
+            "",
+            "Transcript: `/tmp/agent-1.output`",
+            "",
+            "---",
+            "",
+            "**Agent completed at turn limit: trace Paseo services**",
+            "8 turns | 19 tool uses | 110.4k tokens | 47.9s",
+            "",
+            "Read-only findings; no files changed.",
+            "",
+            "Transcript: `/tmp/agent-2.output`",
+            "",
+            "Use `get_subagent_result` for full output.",
+          ].join("\n"),
+        },
+      },
+    ]);
+  });
+
+  test("falls back to Tintinweb task notification XML when details are unavailable", async () => {
+    await expect(
+      collectHistory([
+        {
+          role: "custom",
+          customType: "subagent-notification",
+          content: [
+            "<task-notification>",
+            "<task-id>agent-1</task-id>",
+            "<output-file>/tmp/agent-1.output</output-file>",
+            '<summary>Agent "inspect Paseo pin" completed</summary>',
+            "<result>- Source &lt;pin&gt;</result>",
+            "<usage><total_tokens>101088</total_tokens><tool_uses>10</tool_uses><duration_ms>36787</duration_ms></usage>",
+            "</task-notification>",
+          ].join("\n"),
+        },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "timeline",
+        provider: "pi",
+        item: {
+          type: "assistant_message",
+          text: [
+            '**Agent "inspect Paseo pin" completed**',
+            "10 tool uses | 101.1k tokens | 36.8s",
+            "",
+            "- Source <pin>",
+            "",
+            "Transcript: `/tmp/agent-1.output`",
+          ].join("\n"),
+        },
+      },
+    ]);
+  });
+
   test("uses Pi tree entry ids for replayed user messages", async () => {
     await expect(
       collectHistory(

--- a/packages/server/src/server/agent/providers/pi/history-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/history-mapper.ts
@@ -9,6 +9,7 @@ import {
   type PiToolResult,
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
+import { formatTintinwebSubagentNotification } from "./tintinweb-notification.js";
 
 export interface PiCapturedUserMessageEntry {
   id: string;
@@ -121,12 +122,13 @@ export class PiHistoryMapper {
     if (mappedEvent) {
       return [mappedEvent];
     }
-    return text
+    const displayText = formatTintinwebSubagentNotification(message) ?? text;
+    return displayText
       ? [
           {
             type: "timeline",
             provider: this.provider,
-            item: { type: "assistant_message", text },
+            item: { type: "assistant_message", text: displayText },
           },
         ]
       : [];

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -41,6 +41,9 @@ export type PiAgentMessage =
   | {
       role: "custom";
       content: string | Array<PiTextContent | PiImageContent>;
+      customType?: string;
+      display?: boolean;
+      details?: unknown;
     }
   | {
       role: "assistant";

--- a/packages/server/src/server/agent/providers/pi/tintinweb-notification.ts
+++ b/packages/server/src/server/agent/providers/pi/tintinweb-notification.ts
@@ -1,0 +1,223 @@
+import type { PiAgentMessage } from "./rpc-types.js";
+
+type PiCustomMessage = Extract<PiAgentMessage, { role: "custom" }>;
+
+const TINTINWEB_NOTIFICATION_TYPE = "subagent-notification";
+const TASK_NOTIFICATION_PATTERN = /<task-notification>([\s\S]*?)<\/task-notification>/g;
+
+interface NotificationPresentation {
+  heading: string;
+  result: string | null;
+  error: string | null;
+  turnCount: number | null;
+  maxTurns: number | null;
+  toolUses: number | null;
+  totalTokens: number | null;
+  durationMs: number | null;
+  outputFile: string | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function optionalCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : null;
+}
+
+function statusPhrase(status: string): string {
+  switch (status.trim().toLowerCase()) {
+    case "completed":
+      return "completed";
+    case "error":
+    case "failed":
+      return "failed";
+    case "aborted":
+      return "stopped at turn limit";
+    case "steered":
+      return "completed at turn limit";
+    case "stopped":
+      return "stopped";
+    case "canceled":
+    case "cancelled":
+      return "canceled";
+    default:
+      return `finished (${status.trim()})`;
+  }
+}
+
+function parseDetailsEntry(value: unknown): NotificationPresentation | null {
+  const details = asRecord(value);
+  if (!details) {
+    return null;
+  }
+  const description = optionalString(details.description);
+  const status = optionalString(details.status);
+  if (!description || !status) {
+    return null;
+  }
+  return {
+    heading: `Agent ${statusPhrase(status)}: ${description}`,
+    result: optionalString(details.resultPreview),
+    error: optionalString(details.error),
+    turnCount: optionalCount(details.turnCount),
+    maxTurns: optionalCount(details.maxTurns),
+    toolUses: optionalCount(details.toolUses),
+    totalTokens: optionalCount(details.totalTokens),
+    durationMs: optionalCount(details.durationMs),
+    outputFile: optionalString(details.outputFile),
+  };
+}
+
+function parseDetails(value: unknown): NotificationPresentation[] {
+  const details = asRecord(value);
+  if (!details) {
+    return [];
+  }
+  const first = parseDetailsEntry(details);
+  if (!first) {
+    return [];
+  }
+  const others = Array.isArray(details.others)
+    ? details.others.flatMap((entry) => {
+        const parsed = parseDetailsEntry(entry);
+        return parsed ? [parsed] : [];
+      })
+    : [];
+  return [first, ...others];
+}
+
+function decodeXmlText(value: string): string {
+  return value
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&amp;", "&");
+}
+
+function readXmlTag(block: string, tag: string): string | null {
+  const match = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(block);
+  return match ? optionalString(decodeXmlText(match[1])) : null;
+}
+
+function readXmlCount(block: string, tag: string): number | null {
+  const value = readXmlTag(block, tag);
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : null;
+}
+
+function parseXml(content: string): NotificationPresentation[] {
+  return Array.from(content.matchAll(TASK_NOTIFICATION_PATTERN)).flatMap((match) => {
+    const block = match[1];
+    const summary = readXmlTag(block, "summary");
+    if (!summary) {
+      return [];
+    }
+    return [
+      {
+        heading: summary,
+        result: readXmlTag(block, "result"),
+        error: null,
+        turnCount: null,
+        maxTurns: null,
+        toolUses: readXmlCount(block, "tool_uses"),
+        totalTokens: readXmlCount(block, "total_tokens"),
+        durationMs: readXmlCount(block, "duration_ms"),
+        outputFile: readXmlTag(block, "output-file"),
+      },
+    ];
+  });
+}
+
+function messageText(message: PiCustomMessage): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  return message.content
+    .filter((block) => block.type === "text")
+    .map((block) => (block.type === "text" ? block.text : ""))
+    .join("\n\n");
+}
+
+function formatTokens(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M tokens`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1)}k tokens`;
+  }
+  return `${count} token${count === 1 ? "" : "s"}`;
+}
+
+function formatStats(notification: NotificationPresentation): string | null {
+  const stats: string[] = [];
+  if (notification.turnCount && notification.turnCount > 0) {
+    const count = notification.maxTurns
+      ? `${notification.turnCount}/${notification.maxTurns}`
+      : String(notification.turnCount);
+    stats.push(`${count} turn${notification.turnCount === 1 ? "" : "s"}`);
+  }
+  if (notification.toolUses && notification.toolUses > 0) {
+    stats.push(`${notification.toolUses} tool use${notification.toolUses === 1 ? "" : "s"}`);
+  }
+  if (notification.totalTokens && notification.totalTokens > 0) {
+    stats.push(formatTokens(notification.totalTokens));
+  }
+  if (notification.durationMs && notification.durationMs > 0) {
+    stats.push(`${(notification.durationMs / 1000).toFixed(1)}s`);
+  }
+  return stats.length > 0 ? stats.join(" | ") : null;
+}
+
+function formatNotification(notification: NotificationPresentation): string {
+  const lines = [`**${notification.heading}**`];
+  const stats = formatStats(notification);
+  if (stats) {
+    lines.push(stats);
+  }
+  if (notification.error) {
+    lines.push("", `Error: ${notification.error}`);
+  }
+  if (notification.result && notification.result !== "No output.") {
+    lines.push("", notification.result);
+  }
+  if (notification.outputFile) {
+    lines.push("", `Transcript: \`${notification.outputFile}\``);
+  }
+  return lines.join("\n");
+}
+
+export function formatTintinwebSubagentNotification(message: PiCustomMessage): string | null {
+  if (message.customType !== TINTINWEB_NOTIFICATION_TYPE) {
+    return null;
+  }
+  const content = messageText(message);
+  const notifications = parseDetails(message.details);
+  const parsed = notifications.length > 0 ? notifications : parseXml(content);
+  if (parsed.length === 0) {
+    return null;
+  }
+  const isGroup = content.startsWith("Background agent group completed:");
+  const isPartialGroup = isGroup && content.split("\n", 1)[0]?.includes("partial");
+  const parts = [parsed.map(formatNotification).join("\n\n---\n\n")];
+  if (isGroup || parsed.length > 1) {
+    const qualifier = isPartialGroup ? " (other agents still running)" : "";
+    parts.unshift(`**Background agent results${qualifier}**`);
+  }
+  if (content.includes("Use get_subagent_result for full output.")) {
+    parts.push("Use `get_subagent_result` for full output.");
+  }
+  return parts.join("\n\n");
+}

--- a/packages/server/src/server/agent/providers/pi/tool-call-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/tool-call-mapper.test.ts
@@ -167,6 +167,55 @@ describe("Pi tool call mapper", () => {
     });
   });
 
+  test("maps completed Tintinweb Agent calls to sub-agent detail", () => {
+    const toolCall = parseToolArgs("Agent", {
+      subagent_type: "Explore",
+      description: "Trace the Pi mapper",
+      prompt: "Find every Pi tool-call mapping path.",
+      run_in_background: false,
+    });
+    const result = parseToolResult({
+      content: [{ type: "text", text: "The mapping starts in mapToolDetail.\n" }],
+      details: { status: "completed", agentId: "agent-1" },
+    });
+
+    expect(mapToolDetail(toolCall, result)).toEqual({
+      type: "sub_agent",
+      subAgentType: "Explore",
+      description: "Trace the Pi mapper",
+      log: "The mapping starts in mapToolDetail.",
+    });
+  });
+
+  test("maps background Tintinweb Agent launches instead of showing raw JSON", () => {
+    const toolCall = parseToolArgs("Agent", {
+      subagent_type: "Plan",
+      description: "Plan the integration",
+      prompt: "Design the lifecycle bridge.",
+      run_in_background: true,
+    });
+
+    expect(mapToolDetail(toolCall, null)).toEqual({
+      type: "sub_agent",
+      subAgentType: "Plan",
+      description: "Plan the integration",
+      log: "",
+    });
+  });
+
+  test("keeps unrelated Agent tools on the unknown fallback", () => {
+    const toolCall = parseToolArgs("Agent", {
+      subagent_type: "Explore",
+      operation: "list",
+    });
+
+    expect(mapToolDetail(toolCall, null)).toEqual({
+      type: "unknown",
+      input: { subagent_type: "Explore", operation: "list" },
+      output: null,
+    });
+  });
+
   test("normalizes Pi MCP proxy calls from requested tool args while running", () => {
     const toolCall = parseToolArgs("mcp", {
       tool: "paseo_list_models",

--- a/packages/server/src/server/agent/providers/pi/tool-call-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/tool-call-mapper.ts
@@ -396,7 +396,17 @@ function isTaskToolCall(toolCall: PiTrackedToolCall): boolean {
   if (toolCall.toolName === "task") {
     return true;
   }
-  if (toolCall.toolName !== "subagent" || !isRecord(toolCall.args)) {
+  if (!isRecord(toolCall.args)) {
+    return false;
+  }
+  if (toolCall.toolName === "Agent") {
+    return (
+      readNonEmptyString(toolCall.args.subagent_type) !== undefined &&
+      readNonEmptyString(toolCall.args.description) !== undefined &&
+      readNonEmptyString(toolCall.args.prompt) !== undefined
+    );
+  }
+  if (toolCall.toolName !== "subagent") {
     return false;
   }
   return (
@@ -410,8 +420,12 @@ function mapTaskToolDetail(args: unknown, result: PiToolResult): ToolCallDetail 
   const argRecord = isRecord(args) ? args : {};
   return {
     type: "sub_agent",
-    subAgentType: readNonEmptyString(argRecord.agent),
-    description: readNonEmptyString(argRecord.task),
+    subAgentType:
+      readNonEmptyString(argRecord.agent) ?? readNonEmptyString(argRecord.subagent_type),
+    description:
+      readNonEmptyString(argRecord.task) ??
+      readNonEmptyString(argRecord.description) ??
+      readNonEmptyString(argRecord.prompt),
     log: extractTextFromToolResult(result)?.trim() ?? "",
   };
 }


### PR DESCRIPTION
### Linked issue

Related to #3160. Replaces #3622 after the maintainer ownership feedback on that PR.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Pi users with `@tintinweb/pi-subagents` see `Agent` calls as unknown-tool JSON because Paseo only recognizes the `task` and `subagent` tool schemas. Background Tintinweb children also keep their lifecycle and child session activity outside the Pi RPC stream. Paseo therefore cannot add those children and their work to its existing provider-subagent track.

The previous PR derived parent activity in the app. This revision is based on stable release `v0.7.2` (`9400a49af670fdb5db4af58e73f8df98588dbea9`), removes all app/client changes, and keeps the parent lifecycle literal. The Pi daemon adapter observes Tintinweb through Paseo's injected Pi extension and emits the existing server-owned `provider_subagent` descriptor and timeline events. The existing `WorkspaceDirectory` provider contribution remains the sole workspace activity projection.

No Tintinweb, app, client, or protocol change is required. The injected extension uses Tintinweb's existing cross-package manager registry to subscribe to each accepted background child session. The Pi adapter also recognizes Tintinweb's structured `subagent-notification` custom messages and displays compact summaries instead of raw XML; the original content remains in the parent model context.

### Goals

- Map the case-sensitive Tintinweb `Agent` signature to the existing native `sub_agent` card.
- Forward background `subagents:created`, `subagents:started`, `subagents:completed`, and `subagents:failed` events through the Pi RPC extension-notification path.
- Forward completed child turns as existing provider-subagent timeline items: assistant text, reasoning, tool calls, and compaction.
- Add the parent tool-call link and a provider-owned subtitle with available type, model, thinking, and lifetime token facts.
- Use the lifecycle result or error as a terminal timeline fallback when no child session was available.
- Format individual, grouped, and partial completion notices from their structured details, with an XML fallback for older messages.
- Preserve result previews, transcript paths, status, usage facts, partial-group state, and the grouped full-result instruction.
- Ignore foreground Tintinweb children in the provider-subagent track.
- Map completion, stop, abort, error, session shutdown, and unexpected Pi process exit to terminal provider-child states.
- Keep queued background work visible as running because the provider-child contract has no queued state, then attach its timeline when Tintinweb starts it.
- Preserve the unknown-tool fallback for malformed or unrelated `Agent` calls.

### Non-goals

- Change app/client state or rendering code.
- Change or project the parent agent lifecycle.
- Add protocol fields or statuses.
- Support another package's `subagent:async-*` event vocabulary.
- Add detached cross-extension RPC children with no explicit background declaration.
- Replay child events after a daemon restart.
- Import Tintinweb output-file transcripts into the provider-child timeline.
- Stream token deltas; child turns are forwarded when they complete.

### QA

#### Current v0.7.2 revision

The three Tintinweb commits were rebased onto `v0.7.2` without conflicts, then combined into one commit. `git range-diff` confirmed that all three patches were unchanged before combining them. The combined commit has the same file tree as the rebased commits.

- Formatting: `npm run format` passed with no tracked file changes.
- Lint: `npm run lint` passed with zero warnings and errors.
- Whitespace: `git diff --check` passed.
- Typecheck: blocked by missing workspace dependencies, including `expo-modules-core`, `react`, and `expo-module-scripts`.
- Focused tests: not rerun; Vitest is not available in this checkout.
- Real-provider and visual checks: not repeated on `v0.7.2`. The evidence below is from the earlier `v0.5.2` revision.

The system `npm` command redirects to pnpm. Checks used the installed upstream npm executable instead. The generated pnpm files were removed; this remains an npm workspace.

#### Earlier real-provider evidence (v0.5.2)

Verified on macOS against:

- Paseo `v0.5.2`
- Pi `0.84.2`
- `@tintinweb/pi-subagents` `0.14.1`
- An isolated in-process daemon and a checkout-local daemon on `6768`; the main daemon on `6767` was not restarted

A focused real-provider test created a Pi parent, launched one background Tintinweb `Agent`, made the child run a shell command, and fetched the daemon-owned descriptor and provider timeline. It passed in 18.46 seconds.

Observed evidence:

```json
{
  "providerSubagent": {
    "provider": "pi",
    "title": "general-purpose",
    "description": "Visual child activity proof",
    "status": "completed",
    "toolCallId": "<parent Agent tool call>",
    "subtitle": "general-purpose · 10.6k tokens"
  },
  "timeline": [
    { "type": "reasoning" },
    { "type": "tool_call", "name": "bash", "status": "running" },
    { "type": "tool_call", "name": "bash", "status": "completed" },
    { "type": "assistant_message", "text": "PASEO_VISUAL_CHILD_TIMELINE_OK" }
  ]
}
```

Full machine-readable evidence: [provider child descriptor and timeline](https://raw.githubusercontent.com/p0ns/paseo/qa/tintinweb-subagent-lifecycle/qa/tintinweb-provider-subagent-timeline.json)

#### Visual evidence

Native `Agent` card:

![Tintinweb Agent rendered as a native subagent card](https://raw.githubusercontent.com/p0ns/paseo/qa/tintinweb-subagent-lifecycle/qa/tintinweb-native-agent-card.png)

Provider-subagent track with runtime facts:

![Completed Tintinweb child in the provider-subagent track](https://raw.githubusercontent.com/p0ns/paseo/qa/tintinweb-subagent-lifecycle/qa/tintinweb-provider-subagent-track-v2.png)

Opened provider-child timeline with native reasoning, shell, and assistant rows:

![Tintinweb child activity in the native provider-subagent pane](https://raw.githubusercontent.com/p0ns/paseo/qa/tintinweb-subagent-lifecycle/qa/tintinweb-provider-subagent-timeline.png)

#### Earlier automated checks (v0.5.2)

```text
$ npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts packages/server/src/server/agent/providers/pi/history-mapper.test.ts packages/server/src/server/agent/providers/pi/tool-call-mapper.test.ts --bail=1
Test Files  3 passed (3)
Tests       91 passed (91)

$ npm run build:server
completed successfully

$ npm run format:check
All matched files use the correct format (4018 files).

$ npm run typecheck
completed successfully for all workspaces

$ npm run lint
Found 0 warnings and 0 errors (3769 files).

$ git diff --check
exit 0
```

#### Platform coverage

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Server-only provider path. |
| Android | No | Server-only provider path. |
| Web | Yes | Chrome against the checkout-local Expo app and isolated daemon; screenshots included. |
| Desktop macOS | Partial | Real Pi daemon/provider path tested; Electron wrapper not tested. |
| Desktop Windows | No | Not available locally. |
| Desktop Linux | No | Not available locally. |

### Checklist

- [x] One focused server-owned change
- [ ] `npm run typecheck` passes on the v0.7.2 revision (missing dependencies)
- [x] `npm run lint` passes
- [x] `npm run format` passes with no tracked file changes
- [x] Earlier real-provider and visual QA evidence attached (v0.5.2)
- [x] Tests added or updated where it made sense


