### PR TITLE
fix(app): show the clamped value after an out-of-range size entry

### DIFF
--- a/packages/app/src/screens/settings/appearance/appearance-section.tsx
+++ b/packages/app/src/screens/settings/appearance/appearance-section.tsx
@@ -20,6 +20,7 @@ import { Switch } from "@/components/ui/switch";
 import { SettingsSection } from "@/screens/settings/settings-section";
 import { useContributedThemes } from "@/appearance/provider";
 import { EditingTextInput as TextInput } from "@/components/ui/text-input";
+import { FontSizeRow } from "./font-size-row";
 import {
   MAX_CODE_FONT_SIZE,
   MAX_CONTENT_FONT_SIZE,
@@ -401,49 +402,6 @@ function FontFamilyRow({
   );
 }
 
-interface FontSizeRowProps {
-  title: string;
-  hint: string;
-  accessibilityLabel: string;
-  draft: string;
-  withBorder?: boolean;
-  onChangeDraft: (value: string) => void;
-  onCommit: () => void;
-}
-
-function FontSizeRow({
-  title,
-  hint,
-  accessibilityLabel,
-  draft,
-  withBorder = true,
-  onChangeDraft,
-  onCommit,
-}: FontSizeRowProps) {
-  return (
-    <View style={withBorder ? styles.rowWithBorder : settingsStyles.row}>
-      <View style={settingsStyles.rowContent}>
-        <Text style={settingsStyles.rowTitle}>{title}</Text>
-        <Text style={settingsStyles.rowHint}>{hint}</Text>
-      </View>
-      <View style={styles.sizeField}>
-        <TextInput
-          initialValue={draft}
-          onChangeText={onChangeDraft}
-          onBlur={onCommit}
-          onSubmitEditing={onCommit}
-          keyboardType="number-pad"
-          inputMode="numeric"
-          selectTextOnFocus
-          style={styles.sizeInput}
-          accessibilityLabel={accessibilityLabel}
-        />
-        <Text style={styles.unit}>px</Text>
-      </View>
-    </View>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Syntax highlight theme picker (commits immediately)
 // ---------------------------------------------------------------------------
@@ -640,6 +598,7 @@ export function AppearanceSection() {
     if (next !== settings.uiBaseFontSize) {
       void updateSettings({ uiBaseFontSize: next });
     }
+    return String(next);
   }, [settings.uiBaseFontSize, uiBaseSizeDraft, updateSettings]);
 
   const commitCodeSize = useCallback(() => {
@@ -652,6 +611,7 @@ export function AppearanceSection() {
     if (next !== settings.codeFontSize) {
       void updateSettings({ codeFontSize: next });
     }
+    return String(next);
   }, [codeSizeDraft, settings.codeFontSize, updateSettings]);
 
   const commitContentSize = useCallback(() => {
@@ -664,6 +624,7 @@ export function AppearanceSection() {
     if (next !== settings.contentFontSize) {
       void updateSettings({ contentFontSize: next });
     }
+    return String(next);
   }, [contentSizeDraft, settings.contentFontSize, updateSettings]);
 
   // Live-while-typing: the in-progress drafts drive the preview without
@@ -825,28 +786,6 @@ const styles = StyleSheet.create((theme) => ({
     color: theme.colors.foreground,
     fontSize: theme.fontSize.base,
     textAlign: "left",
-  },
-  sizeField: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing[2],
-  },
-  sizeInput: {
-    width: 64,
-    minHeight: 36,
-    paddingVertical: theme.spacing[2],
-    paddingHorizontal: theme.spacing[3],
-    borderRadius: theme.borderRadius.md,
-    borderWidth: theme.borderWidth[1],
-    borderColor: theme.colors.border,
-    backgroundColor: theme.colors.surface2,
-    color: theme.colors.foreground,
-    fontSize: theme.fontSize.base,
-    textAlign: "right",
-  },
-  unit: {
-    color: theme.colors.foregroundMuted,
-    fontSize: theme.fontSize.base,
   },
   placeholderColor: {
     color: theme.colors.foregroundMuted,

--- a/packages/app/src/screens/settings/appearance/font-size-row.test.tsx
+++ b/packages/app/src/screens/settings/appearance/font-size-row.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The real Unistyles web runtime touches `matchMedia` at import time, which jsdom
+// does not provide. Stand in a theme that answers any token lookup with a number so
+// the style factories in this module tree evaluate without enumerating the tokens.
+vi.mock("react-native-unistyles", () => {
+  const token: unknown = new Proxy(
+    {},
+    {
+      get: (_target, key) => (key === Symbol.toPrimitive ? () => 0 : token),
+    },
+  );
+  return {
+    StyleSheet: {
+      create: (factory: unknown) => (typeof factory === "function" ? factory(token) : factory),
+    },
+    withUnistyles: (Component: unknown) => Component,
+    useUnistyles: () => ({ theme: token, rt: { breakpoint: "lg" } }),
+    UnistylesRuntime: { themeName: "dark", updateTheme: () => {} },
+  };
+});
+
+import { FontSizeRow } from "./font-size-row";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  if (root && container) {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+  }
+  root = null;
+  container = null;
+});
+
+function getInput(): HTMLInputElement {
+  const input = container?.querySelector("input");
+  if (!input) throw new Error("size input not rendered");
+  return input as HTMLInputElement;
+}
+
+/**
+ * Type into the field the way a user would. React installs a value tracker on the
+ * DOM node and drops change events whose value it believes it already saw, so the
+ * write has to go through the native setter rather than `input.value = …`.
+ */
+function type(input: HTMLInputElement, text: string): void {
+  const setValue = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  act(() => {
+    setValue?.call(input, text);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/** React delegates `onBlur` from the bubbling `focusout` event, not `blur`. */
+function blur(input: HTMLInputElement): void {
+  act(() => {
+    input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+}
+
+interface RenderOptions {
+  draft: string;
+  /** The clamped value the parent reports back on commit. */
+  committed: string;
+}
+
+function renderRow({ draft, committed }: RenderOptions) {
+  const onCommit = vi.fn(() => committed);
+  const onChangeDraft = vi.fn();
+  act(() => {
+    root?.render(
+      <FontSizeRow
+        title="Code size"
+        hint="Used for code, diffs, and terminal output"
+        accessibilityLabel="Code font size"
+        draft={draft}
+        onChangeDraft={onChangeDraft}
+        onCommit={onCommit}
+      />,
+    );
+  });
+  return { onCommit, onChangeDraft };
+}
+
+describe("FontSizeRow", () => {
+  it("shows the clamped value when an out-of-range entry clamps to the stored value", () => {
+    // The field is uncontrolled and the committed setting does not change, so nothing
+    // else re-syncs it. Without the imperative resync the rejected 99 stays on screen.
+    const { onCommit } = renderRow({ draft: "22", committed: "22" });
+    const input = getInput();
+
+    type(input, "99");
+    expect(input.value).toBe("99");
+
+    blur(input);
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe("22");
+  });
+
+  it("shows the clamped value when the commit does change the stored value", () => {
+    const { onCommit } = renderRow({ draft: "12", committed: "22" });
+    const input = getInput();
+
+    type(input, "99");
+    blur(input);
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe("22");
+  });
+
+  it("leaves an in-range entry exactly as typed", () => {
+    const { onCommit } = renderRow({ draft: "12", committed: "18" });
+    const input = getInput();
+
+    type(input, "18");
+    blur(input);
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe("18");
+  });
+
+  it("reports each keystroke to the parent as draft text", () => {
+    const { onChangeDraft } = renderRow({ draft: "12", committed: "12" });
+    const input = getInput();
+
+    type(input, "1");
+    type(input, "16");
+
+    expect(onChangeDraft).toHaveBeenNthCalledWith(1, "1");
+    expect(onChangeDraft).toHaveBeenNthCalledWith(2, "16");
+  });
+});

--- a/packages/app/src/screens/settings/appearance/font-size-row.tsx
+++ b/packages/app/src/screens/settings/appearance/font-size-row.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useRef } from "react";
+import { Text, View } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+import { EditingTextInput as TextInput } from "@/components/ui/text-input";
+import type { EditingTextInputHandle } from "@/components/ui/text-input";
+import { settingsStyles } from "@/styles/settings";
+
+export interface FontSizeRowProps {
+  title: string;
+  hint: string;
+  accessibilityLabel: string;
+  draft: string;
+  withBorder?: boolean;
+  onChangeDraft: (value: string) => void;
+  /** Commits the draft and returns the clamped value the field should now show. */
+  onCommit: () => string;
+}
+
+/**
+ * A numeric px field on a settings row. Commits on blur or submit; the owner
+ * clamps and reports back the value that was actually stored.
+ */
+export function FontSizeRow({
+  title,
+  hint,
+  accessibilityLabel,
+  draft,
+  withBorder = true,
+  onChangeDraft,
+  onCommit,
+}: FontSizeRowProps) {
+  const inputRef = useRef<EditingTextInputHandle>(null);
+
+  // The field is uncontrolled, so re-rendering with a corrected `draft` does not
+  // change what is on screen. Push the clamped value through the imperative handle
+  // instead. This matters most when an out-of-range entry clamps to the value that
+  // was already stored: nothing else re-syncs the field, so the rejected number
+  // would sit there looking accepted until the screen was left and reopened.
+  const handleCommit = useCallback(() => {
+    const committed = onCommit();
+    if (committed !== inputRef.current?.getText()) {
+      inputRef.current?.replaceText(committed);
+    }
+  }, [onCommit]);
+
+  return (
+    <View style={withBorder ? styles.rowWithBorder : settingsStyles.row}>
+      <View style={settingsStyles.rowContent}>
+        <Text style={settingsStyles.rowTitle}>{title}</Text>
+        <Text style={settingsStyles.rowHint}>{hint}</Text>
+      </View>
+      <View style={styles.sizeField}>
+        <TextInput
+          ref={inputRef}
+          initialValue={draft}
+          onChangeText={onChangeDraft}
+          onBlur={handleCommit}
+          onSubmitEditing={handleCommit}
+          keyboardType="number-pad"
+          inputMode="numeric"
+          selectTextOnFocus
+          style={styles.sizeInput}
+          accessibilityLabel={accessibilityLabel}
+        />
+        <Text style={styles.unit}>px</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  // Mirrors the divider row in appearance-section.tsx, which still owns the font
+  // *family* rows. Kept local so this module carries its own style identity.
+  rowWithBorder: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: theme.spacing[4],
+    paddingHorizontal: theme.spacing[4],
+    borderTopWidth: theme.borderWidth[1],
+    borderTopColor: theme.colors.border,
+  },
+  sizeField: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2],
+  },
+  sizeInput: {
+    width: 64,
+    minHeight: 36,
+    paddingVertical: theme.spacing[2],
+    paddingHorizontal: theme.spacing[3],
+    borderRadius: theme.borderRadius.md,
+    borderWidth: theme.borderWidth[1],
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface2,
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.base,
+    textAlign: "right",
+  },
+  unit: {
+    color: theme.colors.foregroundMuted,
+    fontSize: theme.fontSize.base,
+  },
+}));


### PR DESCRIPTION
### Linked issue

None — found while working on #3652 and split out so it can be reviewed on its own. This branch is cut from `main`, not from that one; the two are independent and can merge in either order.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Type a size outside the allowed range into an Appearance field and it clamps and stores correctly, but the field can keep showing the number you typed. Code size caps at 22:

| Starting value | Typed | Field shows | Setting stored |
| --- | --- | --- | --- |
| 12 | 99 | 22 ✅ | 22 |
| **22** | **99** | **99 ❌** | **22** |
| 9 (the floor) | 1 | 1 ❌ | 9 |

Only the display is wrong — reopening Appearance shows the real value. But it is wrong in the case where the feedback matters most. Nothing about the row says there is a limit or that the entry was refused, so the field reading `99` is the only signal available, and it says the opposite of what happened.

### Root cause

`EditingTextInput` is uncontrolled by design — `text-input.web.tsx` captures `initialValue` into a ref and renders `defaultValue`, which never updates. So `setCodeSizeDraft(String(next))` corrects React state but cannot change what is on screen.

The field only appears to self-correct as a **side effect**: when the committed setting actually changes, `applyAppearance` patches the theme, `appearanceStyleBoundaryKey` changes, and the appearance boundary remounts the subtree — which remounts the input with the corrected value. When the clamped result equals the value already stored, there is no commit, no theme patch, no remount, and the stale text survives.

That is why the first row of the table works and the second does not.

### The fix

`onCommit` now returns the value that was actually stored, and the row pushes it through the `replaceText` handle `EditingTextInput` already exposes. The correction no longer depends on something else happening to remount the field. `replaceText` also updates the component's internal text ref, so the next change event compares against the right baseline.

Chose the imperative handle over remounting on a changing `key`: a remount would drop focus after Enter, which `replaceText` does not.

Applies to all three size rows — Interface size, Content size, Code size.

`FontSizeRow` moves into its own module. That is not tidying: `@/hooks/use-settings` cannot be imported under jsdom (it throws `SyntaxError: Unexpected token 'typeof'` before any test runs, on `main`, unrelated to this change), so a test that reaches the row through `appearance-section` cannot load at all. In its own module the row has a small enough import graph to render.

### Goals

- An out-of-range entry always ends up showing the value that was stored.
- Works at both ends of the range, and when the clamped value equals the current one.
- Keep focus behaviour as it is.

### Non-goals

- Not changing any clamp bounds.
- Not adding validation messaging or an error state — this only makes the field tell the truth.
- Not touching the font *family* rows, which commit strings and have no clamp.

### QA

**Automated**

```
npx vitest run packages/app/src/screens/settings/appearance/font-size-row.test.tsx \
  packages/app/src/components/ui/text-input/text-input.native.test.tsx \
  packages/app/src/screens/settings/terminal-profile-edit-modal.test.tsx
→ 3 files, 14 passed
```

Four new tests render the real row in jsdom and drive it through real DOM events. I checked they fail without the fix rather than assuming:

```
with the fix reverted → 2 failed | 2 passed
with the fix          → 4 passed
```

The two that flip are the clamp-display cases; the other two (in-range entry untouched, keystrokes reported as draft) guard against the fix breaking normal typing.

**Manual — browser, real app**

[clamp-resync-demo.webm](https://github.com/user-attachments/assets/12c9e0f0-1ce8-457b-95f4-edb2987b6d00)

Code size row, each step committed with Enter:

```
start at 12; type 99 -> 22   ✅
now at 22;  type 99  -> 22   ✅  (was 99 before this change)
now at 22;  type 500 -> 22   ✅
below min;  type 1   -> 9    ✅
at 9;       type 1   -> 9    ✅  (the same bug at the floor)
in range;   type 15  -> 15   ✅  (unchanged, not clobbered)
```

`npm run typecheck`, `npm run lint`, `npm run format:check`, `git diff --check` all clean.

**Platforms**

- ✅ Browser (Chromium)
- ❌ **iOS — not tested.** No macOS host available.
- ❌ **Android — not tested.** No emulator image available on this machine.

Worth a native check before merge if you have a device handy: `replaceText` is implemented separately for native (`text-input.tsx` delegates to the native input's own `replaceText`, covered by `text-input.native.test.tsx`), so the path is exercised by tests but I have not seen it run on a device.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
