### PR TITLE
feat(app): attach videos from the iOS photo picker

### DIFF
--- a/packages/app/src/composer/index.tsx
+++ b/packages/app/src/composer/index.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Pressable,
   Text,
+  Platform,
   StyleSheet as RNStyleSheet,
   type PressableStateCallbackType,
 } from "react-native";
@@ -1348,7 +1349,7 @@ function ComposerContentImpl({
 
   useEffect(() => () => cursorPublication.cancel(), [cursorPublication]);
 
-  const { pickImages } = useImageAttachmentPicker();
+  const { pickMedia } = useImageAttachmentPicker();
   const { pickFiles } = useFilePicker();
   const agentIdRef = useRef(agentId);
   const sendAgentMessageRef = useRef<
@@ -1610,15 +1611,6 @@ function ComposerContentImpl({
     ],
   );
 
-  const handlePickImage = useCallback(async () => {
-    const newImages = await pickAndPersistImages({
-      pickImages,
-      persister: composerImageAttachmentPersister,
-    });
-    if (newImages.length === 0) return;
-    addImages(newImages);
-  }, [addImages, pickImages]);
-
   const handlePasteImage = useCallback(async () => {
     try {
       const newImages = await pickAndPersistImages({
@@ -1694,6 +1686,27 @@ function ComposerContentImpl({
     },
     [addFiles, client, t],
   );
+
+  const handlePickMedia = useCallback(async () => {
+    const pickedMedia = await pickMedia();
+    if (!pickedMedia) return;
+
+    const pickedImages = pickedMedia
+      .filter((attachment) => attachment.kind === "image")
+      .map((attachment) => attachment.attachment);
+    const pickedFiles = pickedMedia
+      .filter((attachment) => attachment.kind === "file")
+      .map((attachment) => attachment.file);
+
+    const newImages = await pickAndPersistImages({
+      pickImages: async () => pickedImages,
+      persister: composerImageAttachmentPersister,
+    });
+    if (newImages.length > 0) {
+      addImages(newImages);
+    }
+    await uploadPickedFiles(pickedFiles);
+  }, [addImages, pickMedia, uploadPickedFiles]);
 
   const handlePickFile = useCallback(async () => {
     if (!client) {
@@ -2032,10 +2045,13 @@ function ComposerContentImpl({
     const items: AttachmentMenuItem[] = [
       {
         id: "image",
-        label: t("composer.attachments.addImage"),
+        label:
+          Platform.OS === "ios"
+            ? t("composer.attachments.addImageOrVideo")
+            : t("composer.attachments.addImage"),
         icon: <ThemedImageIcon size={ICON_SIZE.md} uniProps={iconForegroundMutedMapping} />,
         onSelect: () => {
-          void handlePickImage();
+          void handlePickMedia();
         },
       },
     ];
@@ -2075,7 +2091,7 @@ function ComposerContentImpl({
     forgePresentation,
     handlePasteImage,
     handlePickFile,
-    handlePickImage,
+    handlePickMedia,
     pluginAttachments.menuItems,
     t,
   ]);

--- a/packages/app/src/hooks/image-attachment-picker.native.ts
+++ b/packages/app/src/hooks/image-attachment-picker.native.ts
@@ -1,9 +1,15 @@
 import { ImageManipulator, SaveFormat } from "expo-image-manipulator";
+import { File } from "expo-file-system";
 import {
   normalizePickedImageAssetsWith,
   type ExpoImagePickerAssetLike,
   type PickedImageAttachmentInput,
 } from "./picked-image-normalizer";
+import {
+  normalizePickedMediaAssetsWith,
+  type ExpoMediaPickerAssetLike,
+  type PickedMediaAttachmentInput,
+} from "./picked-media-normalizer";
 
 export type {
   ExportPickedImageAsPng,
@@ -11,6 +17,10 @@ export type {
   PickedImageAttachmentInput,
   PickedImageSource,
 } from "./picked-image-normalizer";
+export type {
+  ExpoMediaPickerAssetLike,
+  PickedMediaAttachmentInput,
+} from "./picked-media-normalizer";
 
 async function exportPickedImageAsPng(uri: string): Promise<string> {
   const context = ImageManipulator.manipulate(uri);
@@ -32,6 +42,22 @@ export async function normalizePickedImageAssets(
   assets: readonly ExpoImagePickerAssetLike[],
 ): Promise<PickedImageAttachmentInput[]> {
   return normalizePickedImageAssetsWith(assets, exportPickedImageAsPng);
+}
+
+export async function normalizePickedMediaAssets(
+  assets: readonly ExpoMediaPickerAssetLike[],
+): Promise<PickedMediaAttachmentInput[]> {
+  return normalizePickedMediaAssetsWith({
+    assets,
+    normalizeImage: async (asset) => {
+      const [attachment] = await normalizePickedImageAssets([asset]);
+      if (!attachment) {
+        throw new Error(`Failed to normalize picked image '${asset.uri}'.`);
+      }
+      return attachment;
+    },
+    readVideoBytes: async (uri) => await new File(uri).bytes(),
+  });
 }
 
 export async function pickImagesWithDesktopDialog(

--- a/packages/app/src/hooks/image-attachment-picker.ts
+++ b/packages/app/src/hooks/image-attachment-picker.ts
@@ -3,24 +3,24 @@ import { RASTER_IMAGE_FILE_EXTENSIONS, resolveRasterImageMimeType } from "@/atta
 import { getFileNameFromPath } from "@/attachments/utils";
 import { i18n } from "@/i18n/i18next";
 import { isAbsolutePath } from "@/utils/path";
+import type {
+  ExpoImagePickerAssetLike,
+  PickedImageAttachmentInput,
+} from "./picked-image-normalizer";
+import type {
+  ExpoMediaPickerAssetLike,
+  PickedMediaAttachmentInput,
+} from "./picked-media-normalizer";
 
-export type PickedImageSource =
-  | { kind: "file_uri"; uri: string }
-  | { kind: "blob"; blob: Blob }
-  | { kind: "data_url"; dataUrl: string };
-
-export interface PickedImageAttachmentInput {
-  source: PickedImageSource;
-  mimeType: string;
-  fileName?: string | null;
-}
-
-export interface ExpoImagePickerAssetLike {
-  uri: string;
-  mimeType?: string | null;
-  fileName?: string | null;
-  file?: File | null;
-}
+export type {
+  ExpoImagePickerAssetLike,
+  PickedImageAttachmentInput,
+  PickedImageSource,
+} from "./picked-image-normalizer";
+export type {
+  ExpoMediaPickerAssetLike,
+  PickedMediaAttachmentInput,
+} from "./picked-media-normalizer";
 
 function shouldTreatAsFileUri(uri: string): boolean {
   return uri.startsWith("file://") || isAbsolutePath(uri);
@@ -84,6 +84,13 @@ export async function normalizePickedImageAssets(
       };
     }),
   );
+}
+
+export async function normalizePickedMediaAssets(
+  assets: readonly ExpoMediaPickerAssetLike[],
+): Promise<PickedMediaAttachmentInput[]> {
+  const images = await normalizePickedImageAssets(assets);
+  return images.map((attachment) => ({ kind: "image", attachment }));
 }
 
 function normalizeDesktopDialogSelection(selection: string | string[] | null): string[] {

--- a/packages/app/src/hooks/image-picker-media-types.test.ts
+++ b/packages/app/src/hooks/image-picker-media-types.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { resolveImagePickerMediaTypes } from "./image-picker-media-types";
+
+describe("image picker media types", () => {
+  it("offers images and videos on iOS", () => {
+    expect(resolveImagePickerMediaTypes("ios")).toEqual(["images", "videos"]);
+  });
+
+  it("keeps other platforms image-only", () => {
+    expect(resolveImagePickerMediaTypes("android")).toEqual(["images"]);
+    expect(resolveImagePickerMediaTypes("web")).toEqual(["images"]);
+  });
+});

--- a/packages/app/src/hooks/image-picker-media-types.ts
+++ b/packages/app/src/hooks/image-picker-media-types.ts
@@ -1,0 +1,6 @@
+import type { MediaType } from "expo-image-picker";
+import type { PlatformOSType } from "react-native";
+
+export function resolveImagePickerMediaTypes(platform: PlatformOSType): MediaType[] {
+  return platform === "ios" ? ["images", "videos"] : ["images"];
+}

--- a/packages/app/src/hooks/picked-image-normalizer.ts
+++ b/packages/app/src/hooks/picked-image-normalizer.ts
@@ -1,4 +1,7 @@
-export type PickedImageSource = { kind: "file_uri"; uri: string } | { kind: "blob"; blob: Blob };
+export type PickedImageSource =
+  | { kind: "file_uri"; uri: string }
+  | { kind: "blob"; blob: Blob }
+  | { kind: "data_url"; dataUrl: string };
 
 export interface PickedImageAttachmentInput {
   source: PickedImageSource;

--- a/packages/app/src/hooks/picked-media-normalizer.test.ts
+++ b/packages/app/src/hooks/picked-media-normalizer.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { PickedImageAttachmentInput } from "./picked-image-normalizer";
+import { normalizePickedMediaAssetsWith } from "./picked-media-normalizer";
+
+describe("native media attachment picker", () => {
+  it("keeps images in the image attachment pipeline", async () => {
+    const image: PickedImageAttachmentInput = {
+      source: { kind: "file_uri", uri: "file:///photos/picked.jpg" },
+      mimeType: "image/jpeg",
+      fileName: "picked.jpg",
+    };
+
+    const result = await normalizePickedMediaAssetsWith({
+      assets: [
+        {
+          uri: "file:///photos/picked.jpg",
+          mimeType: "image/jpeg",
+          fileName: "picked.jpg",
+          type: "image",
+        },
+      ],
+      normalizeImage: async () => image,
+      readVideoBytes: async () => new Uint8Array(),
+    });
+
+    expect(result).toEqual([{ kind: "image", attachment: image }]);
+  });
+
+  it("turns videos into picked files without passing them to image conversion", async () => {
+    const recordedImageAssets: string[] = [];
+    const recordedVideoUris: string[] = [];
+    const videoBytes = new Uint8Array([1, 2, 3]);
+
+    const result = await normalizePickedMediaAssetsWith({
+      assets: [
+        {
+          uri: "file:///photos/demo.mov",
+          mimeType: "video/quicktime",
+          fileName: "demo.mov",
+          type: "video",
+        },
+      ],
+      normalizeImage: async (asset) => {
+        recordedImageAssets.push(asset.uri);
+        throw new Error("Video was sent to image normalization.");
+      },
+      readVideoBytes: async (uri) => {
+        recordedVideoUris.push(uri);
+        return videoBytes;
+      },
+    });
+
+    expect(result).toEqual([
+      {
+        kind: "file",
+        file: {
+          fileName: "demo.mov",
+          mimeType: "video/quicktime",
+          bytes: videoBytes,
+        },
+      },
+    ]);
+    expect(recordedImageAssets).toEqual([]);
+    expect(recordedVideoUris).toEqual(["file:///photos/demo.mov"]);
+  });
+
+  it("recognizes a video from MIME metadata when the picker omits its asset type", async () => {
+    const result = await normalizePickedMediaAssetsWith({
+      assets: [
+        {
+          uri: "file:///photos/clip.mp4",
+          mimeType: "video/mp4",
+          fileName: null,
+          type: null,
+        },
+      ],
+      normalizeImage: async () => {
+        throw new Error("Video was sent to image normalization.");
+      },
+      readVideoBytes: async () => new Uint8Array([4, 5]),
+    });
+
+    expect(result).toEqual([
+      {
+        kind: "file",
+        file: {
+          fileName: "clip.mp4",
+          mimeType: "video/mp4",
+          bytes: new Uint8Array([4, 5]),
+        },
+      },
+    ]);
+  });
+});

--- a/packages/app/src/hooks/picked-media-normalizer.ts
+++ b/packages/app/src/hooks/picked-media-normalizer.ts
@@ -1,0 +1,54 @@
+import { getMimeTypeFromPath } from "@/attachments/file-types";
+import type { PickedFile } from "@/attachments/picked-file";
+import { getFileNameFromPath } from "@/attachments/utils";
+import type {
+  ExpoImagePickerAssetLike,
+  PickedImageAttachmentInput,
+} from "./picked-image-normalizer";
+
+export interface ExpoMediaPickerAssetLike extends ExpoImagePickerAssetLike {
+  type?: "image" | "video" | "livePhoto" | "pairedVideo" | null;
+}
+
+export type PickedMediaAttachmentInput =
+  | { kind: "image"; attachment: PickedImageAttachmentInput }
+  | { kind: "file"; file: PickedFile };
+
+type NormalizePickedImage = (
+  asset: ExpoImagePickerAssetLike,
+) => Promise<PickedImageAttachmentInput>;
+
+type ReadPickedVideoBytes = (uri: string) => Promise<Uint8Array>;
+
+function isPickedVideo(asset: ExpoMediaPickerAssetLike): boolean {
+  return asset.type === "video" || asset.mimeType?.toLowerCase().startsWith("video/") === true;
+}
+
+function pickedVideoFileName(asset: ExpoMediaPickerAssetLike): string {
+  return asset.fileName ?? getFileNameFromPath(asset.uri) ?? "video";
+}
+
+export async function normalizePickedMediaAssetsWith(input: {
+  assets: readonly ExpoMediaPickerAssetLike[];
+  normalizeImage: NormalizePickedImage;
+  readVideoBytes: ReadPickedVideoBytes;
+}): Promise<PickedMediaAttachmentInput[]> {
+  return await Promise.all(
+    input.assets.map(async (asset) => {
+      if (isPickedVideo(asset)) {
+        const fileName = pickedVideoFileName(asset);
+        return {
+          kind: "file" as const,
+          file: {
+            fileName,
+            mimeType: asset.mimeType ?? getMimeTypeFromPath(fileName),
+            bytes: await input.readVideoBytes(asset.uri),
+          },
+        };
+      }
+
+      const attachment = await input.normalizeImage(asset);
+      return { kind: "image" as const, attachment };
+    }),
+  );
+}

--- a/packages/app/src/hooks/use-image-attachment-picker.ts
+++ b/packages/app/src/hooks/use-image-attachment-picker.ts
@@ -1,17 +1,18 @@
 import { useCallback, useRef } from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 import * as ImagePicker from "expo-image-picker";
 import { useTranslation } from "react-i18next";
 import { getDesktopHost, isElectronRuntime } from "@/desktop/host";
 import {
-  normalizePickedImageAssets,
+  normalizePickedMediaAssets,
   pickImagesWithDesktopDialog,
-  type PickedImageAttachmentInput,
+  type PickedMediaAttachmentInput,
 } from "@/hooks/image-attachment-picker";
 import { isWeb } from "@/constants/platform";
+import { resolveImagePickerMediaTypes } from "@/hooks/image-picker-media-types";
 
 interface UseImageAttachmentPickerResult {
-  pickImages: () => Promise<PickedImageAttachmentInput[] | null>;
+  pickMedia: () => Promise<PickedMediaAttachmentInput[] | null>;
 }
 
 export function useImageAttachmentPicker(): UseImageAttachmentPickerResult {
@@ -32,17 +33,18 @@ export function useImageAttachmentPicker(): UseImageAttachmentPickerResult {
     }
 
     if (!currentPermission?.granted) {
-      Alert.alert(
-        t("imageAttachmentPicker.permissionTitle"),
-        t("imageAttachmentPicker.permissionMessage"),
-      );
+      const permissionMessage =
+        Platform.OS === "ios"
+          ? t("imageAttachmentPicker.permissionMediaMessage")
+          : t("imageAttachmentPicker.permissionMessage");
+      Alert.alert(t("imageAttachmentPicker.permissionTitle"), permissionMessage);
       return false;
     }
 
     return true;
   }, [mediaPermission, requestMediaPermission, t]);
 
-  const pickImages = useCallback(async () => {
+  const pickMedia = useCallback(async () => {
     if (isPickingRef.current) {
       return null;
     }
@@ -55,7 +57,7 @@ export function useImageAttachmentPicker(): UseImageAttachmentPickerResult {
         if (selectedImages.length === 0) {
           return null;
         }
-        return selectedImages;
+        return selectedImages.map((attachment) => ({ kind: "image" as const, attachment }));
       }
 
       const hasPermission = await ensurePermission();
@@ -65,11 +67,12 @@ export function useImageAttachmentPicker(): UseImageAttachmentPickerResult {
 
       const pendingResult = await ImagePicker.getPendingResultAsync();
       if (pendingResult && "canceled" in pendingResult && !pendingResult.canceled) {
-        return await normalizePickedImageAssets(pendingResult.assets);
+        return await normalizePickedMediaAssets(pendingResult.assets);
       }
 
+      const mediaTypes = resolveImagePickerMediaTypes(Platform.OS);
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ["images"] as ImagePicker.MediaType[],
+        mediaTypes,
         allowsMultipleSelection: true,
         quality: 0.8,
       });
@@ -78,15 +81,19 @@ export function useImageAttachmentPicker(): UseImageAttachmentPickerResult {
         return null;
       }
 
-      return await normalizePickedImageAssets(result.assets);
+      return await normalizePickedMediaAssets(result.assets);
     } catch (error) {
-      console.error("[ImageAttachmentPicker] Failed to pick image:", error);
-      Alert.alert(t("imageAttachmentPicker.errorTitle"), t("imageAttachmentPicker.failedToSelect"));
+      console.error("[ImageAttachmentPicker] Failed to pick media:", error);
+      const errorMessage =
+        Platform.OS === "ios"
+          ? t("imageAttachmentPicker.failedToSelectMedia")
+          : t("imageAttachmentPicker.failedToSelect");
+      Alert.alert(t("imageAttachmentPicker.errorTitle"), errorMessage);
       return null;
     } finally {
       isPickingRef.current = false;
     }
   }, [ensurePermission, t]);
 
-  return { pickImages };
+  return { pickMedia };
 }

--- a/packages/app/src/i18n/resources.test.ts
+++ b/packages/app/src/i18n/resources.test.ts
@@ -467,12 +467,17 @@ describe("translation resources", () => {
   });
 
   it("includes hook and modal utility keys for the Batch 4M migration", () => {
+    expect(en.composer.attachments.addImageOrVideo).toBe("Add images or video");
     expect(en.imageAttachmentPicker.permissionTitle).toBe("Permission required");
     expect(en.imageAttachmentPicker.permissionMessage).toBe(
       "Please allow access to your photo library to attach images.",
     );
+    expect(en.imageAttachmentPicker.permissionMediaMessage).toBe(
+      "Please allow access to your photo library to attach images or videos.",
+    );
     expect(en.imageAttachmentPicker.errorTitle).toBe("Error");
     expect(en.imageAttachmentPicker.failedToSelect).toBe("Failed to select image");
+    expect(en.imageAttachmentPicker.failedToSelectMedia).toBe("Failed to select images or video");
     expect(en.imageAttachmentPicker.dialogTitle).toBe("Attach images");
     expect(en.imageAttachmentPicker.dialogFilterName).toBe("Images");
     expect(en.common.states.copied).toBe("Copied");

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -121,6 +121,7 @@ export const ar: TranslationResources = {
     },
     attachments: {
       addImage: "أضف صورة",
+      addImageOrVideo: "إضافة صور أو فيديو",
       pasteImage: "لصق صورة",
       addFile: "Upload file",
       addIssueOrPr: "أضف مشكلة أو PR",
@@ -1436,8 +1437,11 @@ export const ar: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "الإذن مطلوب",
     permissionMessage: "يرجى السماح بالوصول إلى مكتبة الصور الخاصة بك لإرفاق الصور.",
+    permissionMediaMessage:
+      "يرجى السماح بالوصول إلى مكتبة الصور الخاصة بك لإرفاق الصور أو مقاطع الفيديو.",
     errorTitle: "خطأ",
     failedToSelect: "فشل في تحديد الصورة",
+    failedToSelectMedia: "فشل في تحديد الصور أو الفيديو",
     dialogTitle: "إرفاق الصور",
     dialogFilterName: "الصور",
   },

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -118,6 +118,7 @@ export const en = {
     },
     attachments: {
       addImage: "Add image",
+      addImageOrVideo: "Add images or video",
       pasteImage: "Paste image",
       addFile: "Upload file",
       addIssueOrPr: "Add issue or PR",
@@ -1446,8 +1447,10 @@ export const en = {
   imageAttachmentPicker: {
     permissionTitle: "Permission required",
     permissionMessage: "Please allow access to your photo library to attach images.",
+    permissionMediaMessage: "Please allow access to your photo library to attach images or videos.",
     errorTitle: "Error",
     failedToSelect: "Failed to select image",
+    failedToSelectMedia: "Failed to select images or video",
     dialogTitle: "Attach images",
     dialogFilterName: "Images",
   },

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -121,6 +121,7 @@ export const es: TranslationResources = {
     },
     attachments: {
       addImage: "Agregar imagen",
+      addImageOrVideo: "Agregar imágenes o un video",
       pasteImage: "Pegar imagen",
       addFile: "Upload file",
       addIssueOrPr: "Agregar problema oPR",
@@ -1480,8 +1481,11 @@ export const es: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "Permiso requerido",
     permissionMessage: "Permita el acceso a su biblioteca de fotos para adjuntar imágenes.",
+    permissionMediaMessage:
+      "Permita el acceso a su biblioteca de fotos para adjuntar imágenes o videos.",
     errorTitle: "Error",
     failedToSelect: "No se pudo seleccionar la imagen",
+    failedToSelectMedia: "No se pudieron seleccionar las imágenes o el video",
     dialogTitle: "Adjuntar imágenes",
     dialogFilterName: "Imágenes",
   },

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -123,6 +123,7 @@ export const fr: TranslationResources = {
     },
     attachments: {
       addImage: "Ajouter une image",
+      addImageOrVideo: "Ajouter des images ou une vidéo",
       pasteImage: "Coller une image",
       addFile: "Upload file",
       addIssueOrPr: "Ajouter un problème ouPR",
@@ -1484,8 +1485,11 @@ export const fr: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "Autorisation requise",
     permissionMessage: "Veuillez autoriser l'accès à votre photothèque pour joindre des images.",
+    permissionMediaMessage:
+      "Veuillez autoriser l'accès à votre photothèque pour joindre des images ou des vidéos.",
     errorTitle: "Erreur",
     failedToSelect: "Échec de la sélection de l'image",
+    failedToSelectMedia: "Échec de la sélection des images ou de la vidéo",
     dialogTitle: "Joindre des images",
     dialogFilterName: "Images",
   },

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -121,6 +121,7 @@ export const ja: TranslationResources = {
     },
     attachments: {
       addImage: "画像を追加",
+      addImageOrVideo: "画像または動画を追加",
       pasteImage: "画像を貼り付け",
       addFile: "ファイルをアップロード",
       addIssueOrPr: "イシューまたはPRを追加",
@@ -1451,8 +1452,11 @@ export const ja: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "権限が必要です",
     permissionMessage: "画像を添付するにはフォトライブラリへのアクセスを許可してください。",
+    permissionMediaMessage:
+      "画像または動画を添付するにはフォトライブラリへのアクセスを許可してください。",
     errorTitle: "エラー",
     failedToSelect: "画像の選択に失敗しました",
+    failedToSelectMedia: "画像または動画の選択に失敗しました",
     dialogTitle: "画像を添付",
     dialogFilterName: "画像",
   },

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -121,6 +121,7 @@ export const ko: TranslationResources = {
     },
     attachments: {
       addImage: "이미지 추가",
+      addImageOrVideo: "이미지 또는 동영상 추가",
       pasteImage: "이미지 붙여넣기",
       addFile: "파일 업로드",
       addIssueOrPr: "이슈 또는 PR 추가",
@@ -1446,8 +1447,10 @@ export const ko: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "권한 필요",
     permissionMessage: "이미지를 첨부하려면 사진 라이브러리 접근을 허용해 주세요.",
+    permissionMediaMessage: "이미지 또는 동영상을 첨부하려면 사진 라이브러리 접근을 허용해 주세요.",
     errorTitle: "오류",
     failedToSelect: "이미지를 선택하지 못했습니다",
+    failedToSelectMedia: "이미지 또는 동영상을 선택하지 못했습니다",
     dialogTitle: "이미지 첨부",
     dialogFilterName: "이미지",
   },

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -121,6 +121,7 @@ export const ptBR: TranslationResources = {
     },
     attachments: {
       addImage: "Adicionar imagem",
+      addImageOrVideo: "Adicionar imagens ou vídeo",
       pasteImage: "Colar imagem",
       addFile: "Enviar arquivo",
       addIssueOrPr: "Adicionar issue ou PR",
@@ -1466,8 +1467,11 @@ export const ptBR: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "Permissão obrigatória",
     permissionMessage: "Permita acesso à sua biblioteca de fotos para anexar imagens.",
+    permissionMediaMessage:
+      "Permita acesso à sua biblioteca de fotos para anexar imagens ou vídeos.",
     errorTitle: "Erro",
     failedToSelect: "Falha ao selecionar imagem",
+    failedToSelectMedia: "Falha ao selecionar imagens ou vídeo",
     dialogTitle: "Anexar imagens",
     dialogFilterName: "Imagens",
   },

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -121,6 +121,7 @@ export const ru: TranslationResources = {
     },
     attachments: {
       addImage: "Добавить изображение",
+      addImageOrVideo: "Добавить изображения или видео",
       pasteImage: "Вставить изображение",
       addFile: "Загрузить файл",
       addIssueOrPr: "Добавить проблему или PR",
@@ -1463,8 +1464,11 @@ export const ru: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "Требуется разрешение",
     permissionMessage: "Разрешите доступ к медиатеке, чтобы прикреплять изображения.",
+    permissionMediaMessage:
+      "Разрешите доступ к медиатеке, чтобы прикреплять изображения или видео.",
     errorTitle: "Ошибка",
     failedToSelect: "Не удалось выбрать изображение",
+    failedToSelectMedia: "Не удалось выбрать изображения или видео",
     dialogTitle: "Прикрепить изображения",
     dialogFilterName: "Изображения",
   },

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -121,6 +121,7 @@ export const zhCN: TranslationResources = {
     },
     attachments: {
       addImage: "添加图片",
+      addImageOrVideo: "添加图片或视频",
       pasteImage: "粘贴图片",
       addFile: "Upload file",
       addIssueOrPr: "添加 issue 或 PR",
@@ -1419,8 +1420,10 @@ export const zhCN: TranslationResources = {
   imageAttachmentPicker: {
     permissionTitle: "需要权限",
     permissionMessage: "请允许访问照片图库以附加图片。",
+    permissionMediaMessage: "请允许访问照片图库以附加图片或视频。",
     errorTitle: "错误",
     failedToSelect: "选择图片失败",
+    failedToSelectMedia: "选择图片或视频失败",
     dialogTitle: "附加图片",
     dialogFilterName: "图片",
   },


### PR DESCRIPTION
### Linked issue

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

You can attach a screenshot from your phone, but not a screen recording. That's the
awkward half of the most common mobile hand-off: you record a bug on your phone, and
then have to get the file onto your Mac before an agent can look at it.

On iOS the composer's photo sheet now offers videos alongside images, and a picked
video lands in the composer as a normal file attachment — the same path `Upload file`
already uses. One selection can mix both.

### Goals

- iOS: the photo library sheet lists videos, and picking one attaches it.
- A mixed selection (images + a video) attaches both in one go.
- Videos reuse the existing file-upload path rather than growing a second one.
- iOS-only copy for the menu item, the permission alert, and the failure alert.

### Non-goals

- **Android and web stay images-only.** `resolveImagePickerMediaTypes` gates the video
  media type to iOS. Their upload paths aren't verified yet, and I didn't want to ship
  a picker that offers something that then fails.
- No transcoding, size cap, thumbnailing, or preview for video attachments. Whatever
  the daemon does with an uploaded `.mp4` today is what it does here.
- No camera capture.

### QA

Tested on a physical iPhone against a local daemon.

<img src="https://raw.githubusercontent.com/kaspesi/paseo/pr-assets/ios-video-picker.gif" width="300" alt="Attaching a video from the iOS photo picker" />

Composer `+` → **Add images or video** → the iOS library sheet, now listing videos →
select an image and a video → both appear as composer attachments (image chip +
`ScreenRecording_….MP4` file chip) → send → both land on the turn.

The photo grid is blurred because it's my real library, not because of a rendering bug.

**Automated coverage** — 40 tests across 3 files, all passing:

```
$ npx vitest run packages/app/src/hooks/image-picker-media-types.test.ts \
    packages/app/src/hooks/picked-media-normalizer.test.ts \
    packages/app/src/i18n/resources.test.ts --bail=1

Test Files  3 passed (3)
     Tests  40 passed (40)
```

- `image-picker-media-types.test.ts` — the iOS-only gate, per platform.
- `picked-media-normalizer.test.ts` — splitting a mixed selection: video detected by
  `asset.type` and by `video/*` mime, filename falling back to the URI, images still
  routed through the image normalizer.
- `resources.test.ts` — the three new i18n keys.

```
$ npm run typecheck   # passes
$ npm run lint        # Found 0 warnings and 0 errors.
```

| Platform        | Tested | Notes                                                                        |
| --------------- | ------ | ---------------------------------------------------------------------------- |
| iOS             | ✅     | Physical device. Video, and image + video in one selection.                  |
| Android         | ❌     | Still images-only by the gate. Not run — the picker call site changed shape. |
| Web             | ❌     | Still images-only. `normalizePickedMediaAssets` wraps the existing result.   |
| Desktop macOS   | ❌     | Desktop dialog path untouched apart from the wrapper. Not run.               |
| Desktop Windows | ❌     | n/a                                                                          |
| Desktop Linux   | ❌     | n/a                                                                          |

Every platform goes through the renamed `pickMedia`, so image attachment on Android,
web, and Electron is unchanged by intent but unverified by hand. Happy to run that pass
if you'd rather have it before merge than after.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
