### PR TITLE
feat(app): add Ruby syntax highlighting

### DIFF
--- a/packages/highlight/src/__tests__/highlighter.test.ts
+++ b/packages/highlight/src/__tests__/highlighter.test.ts
@@ -62,6 +62,20 @@ describe("highlightCode", () => {
     expect(stringToken?.style).toBe("string");
   });
 
+  it("highlights Ruby code", () => {
+    const code = 'class Greeter\n  def greet(name)\n    puts "Hello, #{name}!"\n  end\nend';
+    const result = highlightCode(code, "greeter.rb");
+
+    const classToken = result[0].find((token) => token.text === "class");
+    expect(classToken?.style).toBe("keyword");
+
+    const defToken = result[1].find((token) => token.text === "def");
+    expect(defToken?.style).toBe("keyword");
+
+    const stringToken = result[2].find((token) => token.text.includes("Hello"));
+    expect(stringToken?.style).toBe("string");
+  });
+
   it("highlights C# code", () => {
     const code = 'class Greeter {\n    string message = "hello";\n}';
     const result = highlightCode(code, "test.cs");

--- a/packages/highlight/src/__tests__/parsers.test.ts
+++ b/packages/highlight/src/__tests__/parsers.test.ts
@@ -20,6 +20,7 @@ describe("isLanguageSupported", () => {
     expect(isLanguageSupported("test.java")).toBe(true);
     expect(isLanguageSupported("test.swift")).toBe(true);
     expect(isLanguageSupported("test.dart")).toBe(true);
+    expect(isLanguageSupported("test.rb")).toBe(true);
     expect(isLanguageSupported("test.cs")).toBe(true);
     expect(isLanguageSupported("test.nix")).toBe(true);
     expect(isLanguageSupported("test.ex")).toBe(true);
@@ -61,6 +62,7 @@ describe("getSupportedExtensions", () => {
     expect(extensions).toContain("rs");
     expect(extensions).toContain("swift");
     expect(extensions).toContain("dart");
+    expect(extensions).toContain("rb");
     expect(extensions).toContain("cs");
     expect(extensions).toContain("nix");
     expect(extensions).toContain("json");

--- a/packages/highlight/src/parsers.ts
+++ b/packages/highlight/src/parsers.ts
@@ -1,5 +1,6 @@
 import { defineLanguageFacet, Language, StreamLanguage } from "@codemirror/language";
 import { dart } from "@codemirror/legacy-modes/mode/clike";
+import { ruby } from "@codemirror/legacy-modes/mode/ruby";
 import { swift } from "@codemirror/legacy-modes/mode/swift";
 import { parser as jsParser } from "@lezer/javascript";
 import { parser as jsonParser } from "@lezer/json";
@@ -72,6 +73,8 @@ const languagesByExtension: Record<string, Language> = {
   swift: StreamLanguage.define(swift),
   // Dart
   dart: StreamLanguage.define(dart),
+  // Ruby
+  rb: StreamLanguage.define(ruby),
   // C#
   cs: csharpLanguage,
   // Nix


### PR DESCRIPTION
### Linked issue

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Ruby files currently fall through the shared highlighting registry, so `.rb` code renders without language-aware tokens in surfaces backed by `@getpaseo/highlight`. Registering CodeMirror's Ruby stream mode gives Ruby files the same keyword and string highlighting as the other supported languages without adding another dependency.

### Goals

- Recognize `.rb` as a supported extension.
- Highlight Ruby syntax through `@codemirror/legacy-modes/mode/ruby`.
- Cover extension detection and Ruby keyword/string tokenization with automated tests.

### Non-goals

- Detect extensionless Ruby files such as `Gemfile` and `Rakefile`.
- Add Ruby language services, formatting, or linting.
- Change highlighting themes or UI layout.

### QA

Focused parser and highlighter tests:

```text
$ npx vitest run packages/highlight/src/__tests__/parsers.test.ts packages/highlight/src/__tests__/highlighter.test.ts --bail=1

 RUN  v4.1.7 paseo

 Test Files  2 passed (2)
      Tests  27 passed (27)
   Duration  198ms
```

Workspace typecheck:

```text
$ npm run typecheck

> paseo@0.5.0-beta.4 typecheck
> npm run typecheck --workspaces --if-present

@getpaseo/expo-two-way-audio: passed
@getpaseo/highlight: passed
@getpaseo/plugin: passed
@getpaseo/protocol: passed
@getpaseo/client: passed
@getpaseo/server: passed
@getpaseo/app: passed
@getpaseo/relay: passed
@getpaseo/website: passed
@getpaseo/desktop: passed
@getpaseo/cli: passed
```

Lint:

```text
$ npm run lint

> paseo@0.5.0-beta.4 lint
> oxlint

Found 0 warnings and 0 errors.
Finished in 1.3s on 3746 files with 177 rules using 18 threads.
```

Format:

```text
$ npm run format

> paseo@0.5.0-beta.4 format
> oxfmt .

Finished in 609ms on 3995 files using 18 threads.
```

Manual platform testing was not run. This change contains no UI or layout code; the automated tests exercise the shared language registry and token highlighter used by the app and daemon.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense