### PR TITLE
fix(codex): serialize SQLite app-server initialization

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.spawn-error.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.spawn-error.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, test, vi } from "vitest";
 import { CodexAppServerAgentClient } from "./codex-app-server-agent.js";
 import { runProviderRefreshWithDeadline } from "../provider-refresh-deadline.js";
 import { createTestLogger } from "../../../test-utils/test-logger.js";
-import { createCodexAppServerChildProcess } from "./codex/test-utils/fake-app-server.js";
+import {
+  createCodexAppServerChildProcess,
+  createFakeCodexAppServer,
+} from "./codex/test-utils/fake-app-server.js";
 
 describe("CodexAppServerAgentClient spawn error handling", () => {
   const logger = createTestLogger();
@@ -35,15 +38,18 @@ describe("CodexAppServerAgentClient spawn error handling", () => {
   });
 
   test("fetchCatalog settles when the refresh deadline aborts an unanswered initialize", async () => {
-    const client = new CodexAppServerAgentClient(logger, {
-      command: {
-        mode: "replace",
-        argv: ["/nonexistent/codex-binary-that-does-not-exist"],
-      },
-    });
     const child = createCodexAppServerChildProcess();
+    const client = new CodexAppServerAgentClient(
+      logger,
+      {
+        command: {
+          mode: "replace",
+          argv: ["/nonexistent/codex-binary-that-does-not-exist"],
+        },
+      },
+      { _spawnAppServer: async () => child },
+    );
     const kill = vi.spyOn(child, "kill");
-    Object.assign(client, { spawnAppServer: async () => child });
 
     await expect(
       runProviderRefreshWithDeadline({
@@ -80,5 +86,35 @@ describe("CodexAppServerAgentClient spawn error handling", () => {
     } finally {
       process.off("uncaughtException", onUncaught);
     }
+  });
+
+  test("listImportableSessions retries a fresh app-server after SQLite initialization contention", async () => {
+    const sqliteError =
+      "failed to initialize sqlite state runtime under /tmp/codex-home: " +
+      "failed to initialize state runtime at /tmp/codex-home";
+    const contendedAppServer = createFakeCodexAppServer({
+      initialize: () => ({ __jsonRpcError: { message: sqliteError } }),
+    });
+    const healthyAppServer = createFakeCodexAppServer({
+      "thread/list": () => ({ data: [] }),
+    });
+    const appServers = [contendedAppServer, healthyAppServer];
+    const client = new CodexAppServerAgentClient(logger, undefined, {
+      _spawnAppServer: async () => {
+        const appServer = appServers.shift();
+        if (!appServer) throw new Error("No fake Codex app-server available");
+        return appServer.child;
+      },
+    });
+
+    await expect(client.listImportableSessions()).resolves.toEqual([]);
+
+    expect(appServers).toHaveLength(0);
+    expect(contendedAppServer.requests()).toContainEqual(
+      expect.objectContaining({ method: "initialize" }),
+    );
+    expect(healthyAppServer.requests()).toContainEqual(
+      expect.objectContaining({ method: "initialize" }),
+    );
   });
 });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -84,6 +84,7 @@ import {
   type CodexThreadRollbackResponse,
   type CodexAppServerTraceContext,
 } from "./codex/app-server-transport.js";
+import { runCodexAppServerStartup } from "./codex/app-server-startup.js";
 import { type CodexUserMessageTurnIndex, revertCodexConversation } from "./codex/rewind.js";
 import {
   materializeProviderImage,
@@ -264,6 +265,7 @@ interface CodexAppServerAgentDeps {
     logger: Logger,
     getTraceContext: () => CodexAppServerTraceContext,
   ) => CodexAppServerClientLike;
+  _spawnAppServer?: () => Promise<ChildProcessWithoutNullStreams>;
   resolveSlashCommandInvocation?: (
     prompt: AgentPromptInput,
   ) => Promise<{ commandName: string; args?: string } | null>;
@@ -3040,7 +3042,7 @@ const CodexNotificationSchema = z.union([
 ]);
 
 async function readCodexConfiguredDefaults(
-  client: CodexAppServerClient,
+  client: CodexAppServerClientLike,
   logger: Logger,
 ): Promise<CodexConfiguredDefaults> {
   let savedConfigDefaults: CodexConfiguredDefaults = {};
@@ -3206,6 +3208,21 @@ function buildCodexAppServerInitializeParams(): {
       mcpServerOpenaiFormElicitation: true,
     },
   };
+}
+
+async function disposeFailedCodexStartup(
+  client: CodexAppServerClientLike,
+  logger: Logger,
+  startupError: unknown,
+): Promise<void> {
+  try {
+    await client.dispose();
+  } catch (disposeError) {
+    logger.warn(
+      { err: disposeError, startupError },
+      "Failed to dispose Codex app-server after startup failure",
+    );
+  }
 }
 
 function normalizeOpenAICompatibleBaseUrl(value: string): string | null {
@@ -3448,22 +3465,46 @@ export class CodexAppServerAgentSession implements AgentSession {
   }
 
   private async establishConnection(): Promise<void> {
-    const child = await this.spawnAppServer();
-    const client = new CodexAppServerClient(child, this.logger, () => this.traceContext());
-    if (this.closed) {
-      await client.dispose();
-      throw this.createClosedError();
-    }
-    this.client = client;
-    client.setUnexpectedTerminationHandler((error) => {
-      this.handleUnexpectedTermination(error);
-    });
-    client.setNotificationHandler((method, params) => this.handleNotification(method, params));
-    this.registerRequestHandlers();
-
+    let client: CodexAppServerClient | null = null;
     try {
-      await client.request("initialize", buildCodexAppServerInitializeParams());
-      client.notify("initialized", {});
+      client = await runCodexAppServerStartup({
+        start: async () => {
+          const child = await this.spawnAppServer();
+          const attemptClient = new CodexAppServerClient(child, this.logger, () =>
+            this.traceContext(),
+          );
+          if (this.closed) {
+            await attemptClient.dispose();
+            throw this.createClosedError();
+          }
+          this.client = attemptClient;
+          attemptClient.setUnexpectedTerminationHandler((error) => {
+            this.handleUnexpectedTermination(error);
+          });
+          attemptClient.setNotificationHandler((method, params) =>
+            this.handleNotification(method, params),
+          );
+          this.registerRequestHandlers();
+          try {
+            await attemptClient.request("initialize", buildCodexAppServerInitializeParams());
+            attemptClient.notify("initialized", {});
+            return attemptClient;
+          } catch (error) {
+            if (this.client === attemptClient) {
+              this.client = null;
+            }
+            await disposeFailedCodexStartup(attemptClient, this.logger, error);
+            throw error;
+          }
+        },
+        onRetry: (error, nextAttempt, maxAttempts) => {
+          this.logger.warn(
+            { err: error, nextAttempt, maxAttempts },
+            "Retrying Codex app-server after SQLite initialization failure",
+          );
+        },
+      });
+      this.client = client;
 
       await this.loadResolvedWorkspaceWrite();
       await this.loadCollaborationModes();
@@ -3482,9 +3523,9 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.connected = true;
     } catch (error) {
       try {
-        if (this.client === client) {
+        if (client && this.client === client) {
           await this.disposeClient();
-        } else {
+        } else if (client) {
           await client.dispose();
         }
       } catch (disposeError) {
@@ -6904,6 +6945,9 @@ export class CodexAppServerAgentClient implements AgentClient {
     launchEnv?: Record<string, string>,
     options?: { goalsEnabled?: boolean; agentId?: string },
   ): Promise<ChildProcessWithoutNullStreams> {
+    if (this.deps._spawnAppServer) {
+      return await this.deps._spawnAppServer();
+    }
     const launchPrefix = await resolveCodexLaunchPrefix(this.runtimeSettings);
     const args = [...launchPrefix.args, "app-server"];
     if (options?.goalsEnabled) {
@@ -6928,6 +6972,31 @@ export class CodexAppServerAgentClient implements AgentClient {
     });
     assertChildWithPipes(child);
     return child;
+  }
+
+  private startInitializedAppServer(): Promise<CodexAppServerClientLike> {
+    return runCodexAppServerStartup({
+      start: async () => {
+        const child = await this.spawnAppServer();
+        const client =
+          this.deps._createCodexClient?.(child, this.logger, () => ({})) ??
+          new CodexAppServerClient(child, this.logger);
+        try {
+          await client.request("initialize", buildCodexAppServerInitializeParams());
+          client.notify("initialized", {});
+          return client;
+        } catch (error) {
+          await disposeFailedCodexStartup(client, this.logger, error);
+          throw error;
+        }
+      },
+      onRetry: (error, nextAttempt, maxAttempts) => {
+        this.logger.warn(
+          { err: error, nextAttempt, maxAttempts },
+          "Retrying Codex app-server after SQLite initialization failure",
+        );
+      },
+    });
   }
 
   async createSession(
@@ -6996,15 +7065,9 @@ export class CodexAppServerAgentClient implements AgentClient {
   async listImportableSessions(
     options?: ListImportableSessionsOptions,
   ): Promise<ImportableProviderSession[]> {
-    const child = await this.spawnAppServer();
-    const client =
-      this.deps._createCodexClient?.(child, this.logger, () => ({})) ??
-      new CodexAppServerClient(child, this.logger);
+    const client = await this.startInitializedAppServer();
 
     try {
-      await client.request("initialize", buildCodexAppServerInitializeParams());
-      client.notify("initialized", {});
-
       const limit = options?.limit ?? 20;
       const scanLimit = Math.min(options?.scanLimit ?? limit, 500);
       // thread/list returns the cheap `cwd` field. Fetch a wider window when
@@ -7081,7 +7144,7 @@ export class CodexAppServerAgentClient implements AgentClient {
     context?: ProviderRefreshContext,
   ): Promise<AgentModelDefinition[]> {
     // Codex model/list is global to the app server in this flow; cwd/force are intentionally ignored.
-    let client: CodexAppServerClient | undefined;
+    let client: CodexAppServerClientLike | undefined;
     let disposePromise: Promise<void> | undefined;
     const dispose = () => {
       if (!client) return Promise.resolve();
@@ -7092,16 +7155,35 @@ export class CodexAppServerAgentClient implements AgentClient {
     context?.signal.addEventListener("abort", handleAbort, { once: true });
 
     try {
-      await runProviderRefreshActivity(context, "app-server.start", async () => {
-        const child = await this.spawnAppServer();
-        client = new CodexAppServerClient(child, this.logger);
-        if (context?.signal.aborted) await dispose();
+      client = await runCodexAppServerStartup({
+        signal: context?.signal,
+        start: async () => {
+          await runProviderRefreshActivity(context, "app-server.start", async () => {
+            const child = await this.spawnAppServer();
+            client = new CodexAppServerClient(child, this.logger);
+            if (context?.signal.aborted) await dispose();
+          });
+          if (!client) throw new Error("Codex app-server did not start");
+          try {
+            await runProviderRefreshActivity(context, "initialize", () =>
+              client!.request("initialize", buildCodexAppServerInitializeParams()),
+            );
+            client.notify("initialized", {});
+            return client;
+          } catch (error) {
+            await disposeFailedCodexStartup(client, this.logger, error);
+            client = undefined;
+            disposePromise = undefined;
+            throw error;
+          }
+        },
+        onRetry: (error, nextAttempt, maxAttempts) => {
+          this.logger.warn(
+            { err: error, nextAttempt, maxAttempts },
+            "Retrying Codex app-server after SQLite initialization failure",
+          );
+        },
       });
-      if (!client) throw new Error("Codex app-server did not start");
-      await runProviderRefreshActivity(context, "initialize", () =>
-        client!.request("initialize", buildCodexAppServerInitializeParams()),
-      );
-      client.notify("initialized", {});
 
       const rawResponse = await runProviderRefreshActivity(context, "model/list", () =>
         client!.request("model/list", {}),
@@ -7145,12 +7227,9 @@ export class CodexAppServerAgentClient implements AgentClient {
     const threadId = handle.nativeHandle ?? handle.sessionId;
     if (!threadId) return;
 
-    const child = await this.spawnAppServer();
-    const client = new CodexAppServerClient(child, this.logger);
+    const client = await this.startInitializedAppServer();
 
     try {
-      await client.request("initialize", buildCodexAppServerInitializeParams());
-      client.notify("initialized", {});
       if (state === "archive") {
         await client.request("thread/archive", { threadId });
         return;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -3466,13 +3466,15 @@ export class CodexAppServerAgentSession implements AgentSession {
 
   private async establishConnection(): Promise<void> {
     let client: CodexAppServerClient | null = null;
+    let startupClient: CodexAppServerClient | null = null;
     try {
       client = await runCodexAppServerStartup({
-        start: async () => {
+        start: async (_attempt, signal) => {
           const child = await this.spawnAppServer();
           const attemptClient = new CodexAppServerClient(child, this.logger, () =>
             this.traceContext(),
           );
+          startupClient = attemptClient;
           if (this.closed) {
             await attemptClient.dispose();
             throw this.createClosedError();
@@ -3486,6 +3488,7 @@ export class CodexAppServerAgentSession implements AgentSession {
           );
           this.registerRequestHandlers();
           try {
+            signal.throwIfAborted();
             await attemptClient.request("initialize", buildCodexAppServerInitializeParams());
             attemptClient.notify("initialized", {});
             return attemptClient;
@@ -3495,8 +3498,13 @@ export class CodexAppServerAgentSession implements AgentSession {
             }
             await disposeFailedCodexStartup(attemptClient, this.logger, error);
             throw error;
+          } finally {
+            if (startupClient === attemptClient) {
+              startupClient = null;
+            }
           }
         },
+        onAbort: async () => await startupClient?.dispose(),
         onRetry: (error, nextAttempt, maxAttempts) => {
           this.logger.warn(
             { err: error, nextAttempt, maxAttempts },
@@ -6975,21 +6983,29 @@ export class CodexAppServerAgentClient implements AgentClient {
   }
 
   private startInitializedAppServer(): Promise<CodexAppServerClientLike> {
+    let startupClient: CodexAppServerClientLike | null = null;
     return runCodexAppServerStartup({
-      start: async () => {
+      start: async (_attempt, signal) => {
         const child = await this.spawnAppServer();
         const client =
           this.deps._createCodexClient?.(child, this.logger, () => ({})) ??
           new CodexAppServerClient(child, this.logger);
+        startupClient = client;
         try {
+          signal.throwIfAborted();
           await client.request("initialize", buildCodexAppServerInitializeParams());
           client.notify("initialized", {});
           return client;
         } catch (error) {
           await disposeFailedCodexStartup(client, this.logger, error);
           throw error;
+        } finally {
+          if (startupClient === client) {
+            startupClient = null;
+          }
         }
       },
+      onAbort: async () => await startupClient?.dispose(),
       onRetry: (error, nextAttempt, maxAttempts) => {
         this.logger.warn(
           { err: error, nextAttempt, maxAttempts },
@@ -7157,14 +7173,15 @@ export class CodexAppServerAgentClient implements AgentClient {
     try {
       client = await runCodexAppServerStartup({
         signal: context?.signal,
-        start: async () => {
+        start: async (_attempt, signal) => {
           await runProviderRefreshActivity(context, "app-server.start", async () => {
             const child = await this.spawnAppServer();
             client = new CodexAppServerClient(child, this.logger);
-            if (context?.signal.aborted) await dispose();
+            if (signal.aborted) await dispose();
           });
           if (!client) throw new Error("Codex app-server did not start");
           try {
+            signal.throwIfAborted();
             await runProviderRefreshActivity(context, "initialize", () =>
               client!.request("initialize", buildCodexAppServerInitializeParams()),
             );
@@ -7177,6 +7194,7 @@ export class CodexAppServerAgentClient implements AgentClient {
             throw error;
           }
         },
+        onAbort: dispose,
         onRetry: (error, nextAttempt, maxAttempts) => {
           this.logger.warn(
             { err: error, nextAttempt, maxAttempts },

--- a/packages/server/src/server/agent/providers/codex/app-server-startup.test.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-startup.test.ts
@@ -88,6 +88,41 @@ describe("Codex app-server startup", () => {
     await expect(first).resolves.toBe("first");
   });
 
+  test("releases the queue when a running startup never settles", async () => {
+    vi.useFakeTimers();
+    const firstStarted = deferred();
+    const firstAborted = deferred();
+    const cleanupAllowed = deferred();
+    const secondStart = vi.fn(async () => "second");
+
+    try {
+      const first = runCodexAppServerStartup({
+        timeoutMs: 100,
+        start: async (_attempt, signal) => {
+          firstStarted.resolve();
+          signal.addEventListener("abort", firstAborted.resolve, { once: true });
+          return await new Promise<never>(() => {});
+        },
+        onAbort: async () => await cleanupAllowed.promise,
+      });
+      await firstStarted.promise;
+      const second = runCodexAppServerStartup({ start: secondStart });
+
+      await vi.advanceTimersByTimeAsync(100);
+      await firstAborted.promise;
+      await Promise.resolve();
+      expect(secondStart).not.toHaveBeenCalled();
+
+      cleanupAllowed.resolve();
+
+      await expect(first).rejects.toThrow("startup timed out after 100ms");
+      await expect(second).resolves.toBe("second");
+      expect(secondStart).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("does not retry unrelated startup failures", async () => {
     const starts = vi.fn(async () => {
       throw new Error("Codex binary is not executable");

--- a/packages/server/src/server/agent/providers/codex/app-server-startup.test.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-startup.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { runCodexAppServerStartup } from "./app-server-startup.js";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("Codex app-server startup", () => {
+  test("serializes concurrent SQLite runtime initialization", async () => {
+    const firstStarted = deferred();
+    const releaseFirst = deferred();
+    const starts: string[] = [];
+
+    const first = runCodexAppServerStartup({
+      start: async () => {
+        starts.push("first");
+        firstStarted.resolve();
+        await releaseFirst.promise;
+        return "first";
+      },
+    });
+    await firstStarted.promise;
+
+    const second = runCodexAppServerStartup({
+      start: async () => {
+        starts.push("second");
+        return "second";
+      },
+    });
+    await Promise.resolve();
+
+    expect(starts).toEqual(["first"]);
+    releaseFirst.resolve();
+    await expect(Promise.all([first, second])).resolves.toEqual(["first", "second"]);
+    expect(starts).toEqual(["first", "second"]);
+  });
+
+  test("retries SQLite initialization failures with a fresh startup attempt", async () => {
+    const starts = vi.fn(async (attempt: number) => {
+      if (attempt < 3) {
+        throw new Error(
+          "Codex app-server exited with code 1 and signal null\n" +
+            "Error: failed to initialize sqlite state runtime under /tmp/codex-home: " +
+            "failed to initialize state runtime at /tmp/codex-home",
+        );
+      }
+      return `client-${attempt}`;
+    });
+    const retries = vi.fn();
+
+    await expect(runCodexAppServerStartup({ start: starts, onRetry: retries })).resolves.toBe(
+      "client-3",
+    );
+    expect(starts).toHaveBeenCalledTimes(3);
+    expect(retries).toHaveBeenCalledTimes(2);
+    expect(retries).toHaveBeenNthCalledWith(1, expect.any(Error), 2, 3);
+    expect(retries).toHaveBeenNthCalledWith(2, expect.any(Error), 3, 3);
+  });
+
+  test("rejects a queued startup as soon as its signal aborts", async () => {
+    const firstStarted = deferred();
+    const releaseFirst = deferred();
+    const first = runCodexAppServerStartup({
+      start: async () => {
+        firstStarted.resolve();
+        await releaseFirst.promise;
+        return "first";
+      },
+    });
+    await firstStarted.promise;
+
+    const controller = new AbortController();
+    const secondStart = vi.fn(async () => "second");
+    const second = runCodexAppServerStartup({
+      signal: controller.signal,
+      start: secondStart,
+    });
+    controller.abort(new Error("refresh expired"));
+
+    await expect(second).rejects.toThrow("refresh expired");
+    expect(secondStart).not.toHaveBeenCalled();
+    releaseFirst.resolve();
+    await expect(first).resolves.toBe("first");
+  });
+
+  test("does not retry unrelated startup failures", async () => {
+    const starts = vi.fn(async () => {
+      throw new Error("Codex binary is not executable");
+    });
+
+    await expect(runCodexAppServerStartup({ start: starts })).rejects.toThrow(
+      "Codex binary is not executable",
+    );
+    expect(starts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/src/server/agent/providers/codex/app-server-startup.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-startup.ts
@@ -1,11 +1,14 @@
 const CODEX_SQLITE_INITIALIZATION_ERROR = "failed to initialize sqlite state runtime";
 const CODEX_APP_SERVER_STARTUP_ATTEMPTS = 3;
+const CODEX_APP_SERVER_STARTUP_TIMEOUT_MS = 30_000;
 
 let startupQueue: Promise<void> = Promise.resolve();
 
 interface CodexAppServerStartupOptions<T> {
-  start: (attempt: number) => Promise<T>;
+  start: (attempt: number, signal: AbortSignal) => Promise<T>;
   signal?: AbortSignal;
+  timeoutMs?: number;
+  onAbort?: () => Promise<void>;
   onRetry?: (error: unknown, nextAttempt: number, maxAttempts: number) => void;
 }
 
@@ -39,19 +42,39 @@ function serializeStartup<T>(start: () => Promise<T>, signal?: AbortSignal): Pro
 
 export function runCodexAppServerStartup<T>(options: CodexAppServerStartupOptions<T>): Promise<T> {
   return serializeStartup(async () => {
-    for (let attempt = 1; attempt <= CODEX_APP_SERVER_STARTUP_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const handleExternalAbort = () => controller.abort(options.signal?.reason);
+    options.signal?.addEventListener("abort", handleExternalAbort, { once: true });
+    const timeoutMs = options.timeoutMs ?? CODEX_APP_SERVER_STARTUP_TIMEOUT_MS;
+    const timer = setTimeout(() => {
+      controller.abort(new Error(`Codex app-server startup timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    try {
       options.signal?.throwIfAborted();
-      try {
-        return await options.start(attempt);
-      } catch (error) {
-        const canRetry =
-          attempt < CODEX_APP_SERVER_STARTUP_ATTEMPTS && isCodexSqliteInitializationError(error);
-        if (!canRetry) {
-          throw error;
+      for (let attempt = 1; attempt <= CODEX_APP_SERVER_STARTUP_ATTEMPTS; attempt += 1) {
+        controller.signal.throwIfAborted();
+        try {
+          return await raceStartupWithAbort(
+            options.start(attempt, controller.signal),
+            controller.signal,
+          );
+        } catch (error) {
+          if (controller.signal.aborted) {
+            await options.onAbort?.();
+          }
+          const canRetry =
+            attempt < CODEX_APP_SERVER_STARTUP_ATTEMPTS && isCodexSqliteInitializationError(error);
+          if (!canRetry) {
+            throw error;
+          }
+          options.onRetry?.(error, attempt + 1, CODEX_APP_SERVER_STARTUP_ATTEMPTS);
         }
-        options.onRetry?.(error, attempt + 1, CODEX_APP_SERVER_STARTUP_ATTEMPTS);
       }
+      throw new Error("Codex app-server startup exhausted without a result");
+    } finally {
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", handleExternalAbort);
     }
-    throw new Error("Codex app-server startup exhausted without a result");
   }, options.signal);
 }

--- a/packages/server/src/server/agent/providers/codex/app-server-startup.ts
+++ b/packages/server/src/server/agent/providers/codex/app-server-startup.ts
@@ -1,0 +1,57 @@
+const CODEX_SQLITE_INITIALIZATION_ERROR = "failed to initialize sqlite state runtime";
+const CODEX_APP_SERVER_STARTUP_ATTEMPTS = 3;
+
+let startupQueue: Promise<void> = Promise.resolve();
+
+interface CodexAppServerStartupOptions<T> {
+  start: (attempt: number) => Promise<T>;
+  signal?: AbortSignal;
+  onRetry?: (error: unknown, nextAttempt: number, maxAttempts: number) => void;
+}
+
+function isCodexSqliteInitializationError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(CODEX_SQLITE_INITIALIZATION_ERROR);
+}
+
+function raceStartupWithAbort<T>(startup: Promise<T>, signal: AbortSignal): Promise<T> {
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const handleAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", handleAbort, { once: true });
+    void startup.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", handleAbort);
+    });
+  });
+}
+
+function serializeStartup<T>(start: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  const run = () => {
+    signal?.throwIfAborted();
+    return start();
+  };
+  const next = startupQueue.then(run, run);
+  startupQueue = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return signal ? raceStartupWithAbort(next, signal) : next;
+}
+
+export function runCodexAppServerStartup<T>(options: CodexAppServerStartupOptions<T>): Promise<T> {
+  return serializeStartup(async () => {
+    for (let attempt = 1; attempt <= CODEX_APP_SERVER_STARTUP_ATTEMPTS; attempt += 1) {
+      options.signal?.throwIfAborted();
+      try {
+        return await options.start(attempt);
+      } catch (error) {
+        const canRetry =
+          attempt < CODEX_APP_SERVER_STARTUP_ATTEMPTS && isCodexSqliteInitializationError(error);
+        if (!canRetry) {
+          throw error;
+        }
+        options.onRetry?.(error, attempt + 1, CODEX_APP_SERVER_STARTUP_ATTEMPTS);
+      }
+    }
+    throw new Error("Codex app-server startup exhausted without a result");
+  }, options.signal);
+}


### PR DESCRIPTION
## Summary

- serialize Codex app-server initialization across sessions, resume/history hydration, catalog refresh, imports, and archive operations
- retry the specific transient SQLite runtime initialization failure with a fresh process, bounded to three attempts
- preserve immediate failure behavior for unrelated startup errors

## Root cause

Paseo launches one Codex app-server per live session and additional short-lived app-servers for catalog, import, history, and archive work. Those processes initialize the same SQLite runtime concurrently under a shared `CODEX_HOME`.

The production databases passed read-only SQLite integrity checks. The same failure reproduced with a new temporary `CODEX_HOME`: 7 of 24 concurrent Codex 0.147.0 app-server initializations exited with `failed to initialize sqlite state runtime`. This rules out local state corruption as a required cause and confirms startup contention.

Long-lived turns remain concurrent; only app-server initialization is queued.

Related upstream Codex reports:

- https://github.com/openai/codex/issues/30105
- https://github.com/openai/codex/issues/35555

## Verification

- focused Vitest regression files: 6 tests passed
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
