### PR TITLE
fix(omp): bound the post-agent_end completion gate (stacked on #3371)

### DIFF
--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -6,6 +6,14 @@ import type { OmpNoTurnScheduler, OmpProviderIdleScheduler } from "./agent.js";
 import type { OmpUsagePollScheduler } from "./usage-poller.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
 
+function lastToolCallStatus(omp: OmpHarness, callId: string): string | undefined {
+  const items = omp
+    .timeline()
+    .filter((item) => item.type === "tool_call" && item.callId === callId);
+  const last = items[items.length - 1];
+  return last?.type === "tool_call" ? last.status : undefined;
+}
+
 class ManualIdleScheduler implements OmpProviderIdleScheduler {
   private readonly retries: Array<() => void> = [];
   private readonly waiters: Array<{ count: number; resolve: () => void }> = [];
@@ -527,6 +535,130 @@ describe("OMP agent client and session", () => {
     await omp.waitForProviderStateChecks(2);
     await waitForImmediate();
     expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("holds a task tool call open when its OMP children appear after the result", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await omp.requireStartTurn("fan out");
+    const runtime = omp.runtime();
+    runtime.beginTurn();
+    runtime.acceptPrompt("fan out", "user-fanout");
+    runtime.streamAssistantText("delegating");
+    runtime.emit({
+      type: "tool_execution_start",
+      toolCallId: "task-1",
+      toolName: "task",
+      args: { description: "spawn workers" },
+    });
+    runtime.emit({
+      type: "tool_execution_end",
+      toolCallId: "task-1",
+      toolName: "task",
+      isError: false,
+      result: { text: "Spawned 1 background agent" },
+    });
+    expect(lastToolCallStatus(omp, "task-1")).toBe("running");
+    expect(omp.runningToolCallIds()).toEqual(["task-1"]);
+
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "Worker",
+        agent: "Worker",
+        status: "started",
+        parentToolCallId: "task-1",
+        index: 0,
+      },
+    });
+    expect(lastToolCallStatus(omp, "task-1")).toBe("running");
+    expect(omp.runningToolCallIds()).toEqual(["task-1"]);
+
+    runtime.emit({
+      type: "subagent_progress",
+      payload: {
+        index: 0,
+        agent: "Worker",
+        parentToolCallId: "task-1",
+        progress: { id: "Worker", status: "running", recentOutput: ["still working"] },
+      },
+    });
+    expect(lastToolCallStatus(omp, "task-1")).toBe("running");
+
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "Worker",
+        agent: "Worker",
+        status: "completed",
+        parentToolCallId: "task-1",
+        index: 0,
+      },
+    });
+    expect(lastToolCallStatus(omp, "task-1")).toBe("completed");
+    expect(omp.runningToolCallIds()).toEqual([]);
+  });
+
+  test("force-settles a task that never produced a child when the turn completes", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    const session = omp;
+    await session.requireStartTurn("no child");
+    const runtime = session.runtime();
+    runtime.beginTurn();
+    runtime.acceptPrompt("no child", "user-orphan");
+    runtime.streamAssistantText("done");
+    runtime.emit({
+      type: "tool_execution_start",
+      toolCallId: "task-orphan",
+      toolName: "task",
+      args: { description: "never spawned" },
+    });
+    runtime.emit({
+      type: "tool_execution_end",
+      toolCallId: "task-orphan",
+      toolName: "task",
+      isError: false,
+      result: { text: "Spawned 0 background agents" },
+    });
+    expect(lastToolCallStatus(session, "task-orphan")).toBe("running");
+
+    runtime.state = { ...runtime.state, isStreaming: false, isCompacting: false };
+    runtime.finishTurn({
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+    });
+    await waitForImmediate();
+    await waitForImmediate();
+    expect(session.completedTurnCount()).toBe(1);
+    expect(lastToolCallStatus(session, "task-orphan")).toBe("completed");
+    expect(session.runningToolCallIds()).toEqual([]);
+  });
+
+  test("completes a failed task immediately", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await omp.requireStartTurn("task fails");
+    const runtime = omp.runtime();
+    runtime.beginTurn();
+    runtime.emit({
+      type: "tool_execution_start",
+      toolCallId: "task-fail",
+      toolName: "task",
+      args: { description: "boom" },
+    });
+    runtime.emit({
+      type: "tool_execution_end",
+      toolCallId: "task-fail",
+      toolName: "task",
+      isError: true,
+      result: { text: "spawn failed" },
+    });
+    expect(lastToolCallStatus(omp, "task-fail")).toBe("failed");
+    expect(omp.runningToolCallIds()).toEqual([]);
   });
 
   test("does not complete on OMP's extension-notice agent_end", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { setImmediate as waitForImmediate } from "node:timers/promises";
+import { setImmediate as waitForImmediate, setTimeout as delay } from "node:timers/promises";
 
 import type { PaseoToolCatalog } from "../../tools/types.js";
 import type {
@@ -541,13 +541,28 @@ describe("OMP agent client and session", () => {
     const scheduler = createOmpProviderIdleScheduler();
 
     await expect(
-      scheduler.waitForRetry({ attempt: 1, consecutiveFailures: 0, elapsedMs: 0 }),
+      scheduler.waitForRetry({
+        attempt: 1,
+        consecutiveFailures: 0,
+        elapsedMs: 0,
+        isCompacting: false,
+      }),
     ).resolves.toEqual({ retry: true });
     await expect(
-      scheduler.waitForRetry({ attempt: 200, consecutiveFailures: 0, elapsedMs: 60_000 }),
+      scheduler.waitForRetry({
+        attempt: 200,
+        consecutiveFailures: 0,
+        elapsedMs: 60_000,
+        isCompacting: false,
+      }),
     ).resolves.toEqual({ retry: false, reason: "wait_budget" });
     await expect(
-      scheduler.waitForRetry({ attempt: 3, consecutiveFailures: 3, elapsedMs: 100 }),
+      scheduler.waitForRetry({
+        attempt: 3,
+        consecutiveFailures: 3,
+        elapsedMs: 100,
+        isCompacting: false,
+      }),
     ).resolves.toEqual({ retry: false, reason: "failure_budget" });
   });
 
@@ -575,6 +590,129 @@ describe("OMP agent client and session", () => {
     await expect(completion).rejects.toThrow(/idle/i);
 
     expect(omp.runningToolCallIds()).toEqual([]);
+  });
+
+  test("does not fail a turn that started after the gate was abandoned", async () => {
+    // The deny lands after ownership has moved on: get_state and waitForRetry are
+    // both awaits, so the turn can change under a parked gate.
+    let releaseDeny!: () => void;
+    let gateParked!: () => void;
+    const parked = new Promise<void>((resolve) => {
+      gateParked = resolve;
+    });
+    const scheduler: OmpProviderIdleScheduler = {
+      waitForRetry: () => {
+        gateParked();
+        return new Promise((resolve) => {
+          releaseDeny = () => resolve({ retry: false, reason: "wait_budget" });
+        });
+      },
+    };
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await parked;
+
+    // The user gives up on the stuck turn and sends another one.
+    await omp.interrupt();
+    await completion;
+    omp.reportProviderState({ isStreaming: false, isCompacting: false });
+    await omp.requireStartTurn("second");
+
+    releaseDeny();
+    for (let flush = 0; flush < 5; flush += 1) await waitForImmediate();
+
+    expect(omp.failedTurns()).toEqual([]);
+    const runtime = omp.runtime();
+    runtime.beginTurn();
+    runtime.streamAssistantText("second done");
+    runtime.finishTurn();
+    for (let flush = 0; flush < 5; flush += 1) await waitForImmediate();
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("keeps polling past the idle budget while OMP reports compacting", async () => {
+    const scheduler = createOmpProviderIdleScheduler();
+
+    await expect(
+      scheduler.waitForRetry({
+        attempt: 1,
+        consecutiveFailures: 0,
+        elapsedMs: 120_000,
+        isCompacting: true,
+      }),
+    ).resolves.toEqual({ retry: true });
+    await expect(
+      scheduler.waitForRetry({
+        attempt: 1,
+        consecutiveFailures: 0,
+        elapsedMs: 120_000,
+        isCompacting: false,
+      }),
+    ).resolves.toEqual({ retry: false, reason: "wait_budget" });
+  });
+
+  test("reports the observed compaction state and elapsed time to the scheduler", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: false,
+      isCompacting: true,
+    });
+    await scheduler.waitForWaits(1);
+    expect(scheduler.attempts()[0]?.isCompacting).toBe(true);
+
+    await delay(5);
+    scheduler.retryAll();
+    await scheduler.waitForWaits(2);
+    expect(scheduler.attempts()[1]?.elapsedMs).toBeGreaterThan(0);
+  });
+
+  test("keeps an earlier agent_end error when a later cycle reports none", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+
+    omp.runtime().finishTurn({ role: "assistant", content: [], errorMessage: "provider exploded" });
+    omp.runtime().finishTurn();
+    for (let flush = 0; flush < 5; flush += 1) await waitForImmediate();
+
+    omp.reportProviderState({ isStreaming: false, isCompacting: false });
+    scheduler.retryAll();
+
+    await expect(completion).rejects.toThrow(/provider exploded/);
+  });
+
+  test("reports an unavailable state path when no OMP state was ever observed", async () => {
+    const scheduler = new ManualIdleScheduler((attempt) =>
+      attempt.attempt < 2 ? { retry: true } : { retry: false, reason: "wait_budget" },
+    );
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+    omp.failProviderStateChecks(new Error("state unavailable"));
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+    scheduler.retryAll();
+
+    await expect(completion).rejects.toThrow(/state/i);
+    expect(omp.failedTurns()).toMatchObject([{ code: "omp_provider_state_unavailable" }]);
+    expect(omp.failedTurns()[0]?.diagnostic).not.toContain("after 0 consecutive failures");
   });
 
   // #2232: parent model loop can go idle while OMP-internal `task` children

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -329,6 +329,206 @@ describe("OMP agent client and session", () => {
     await expect(completion).resolves.toMatchObject({ finalText: "first done" });
   });
 
+  // #2232: parent model loop can go idle while OMP-internal `task` children
+  // keep writing. Wire order is tool_execution_end (dispatch ack) then
+  // subagent_lifecycle started — never the reverse.
+  test("stays active while OMP internal task subagents are still running", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const session = omp;
+    await session.requireStartTurn("critically audit the entire repo");
+    const runtime = session.runtime();
+    runtime.beginTurn();
+    runtime.acceptPrompt("critically audit the entire repo", "user-audit");
+    runtime.streamAssistantText("spawning fan-out workers");
+    runtime.emit({
+      type: "tool_execution_start",
+      toolCallId: "task-1",
+      toolName: "task",
+      args: { description: "audit API budget" },
+    });
+    runtime.emit({
+      type: "tool_execution_end",
+      toolCallId: "task-1",
+      toolName: "task",
+      isError: false,
+      result: { text: "Spawned 1 background agent" },
+    });
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "ApiBudgetAudit",
+        agent: "ApiBudgetAudit",
+        description: "audit API budget",
+        status: "started",
+        parentToolCallId: "task-1",
+        index: 0,
+      },
+    });
+    runtime.state = { ...runtime.state, isStreaming: false, isCompacting: false };
+    runtime.finishTurn({
+      role: "assistant",
+      content: [{ type: "text", text: "spawning fan-out workers" }],
+    });
+
+    await session.waitForProviderStateChecks(1);
+    await scheduler.waitForWaits(1);
+    expect(session.completedTurnCount()).toBe(0);
+    expect(session.subagentUpserts()).toContainEqual({ id: "ApiBudgetAudit", status: "running" });
+
+    scheduler.retry();
+    await session.waitForProviderStateChecks(2);
+    await scheduler.waitForWaits(2);
+    expect(session.completedTurnCount()).toBe(0);
+
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "ApiBudgetAudit",
+        agent: "ApiBudgetAudit",
+        status: "completed",
+        parentToolCallId: "task-1",
+        index: 0,
+      },
+    });
+    scheduler.retry();
+    await session.waitForProviderStateChecks(3);
+    await waitForImmediate();
+    expect(session.completedTurnCount()).toBe(1);
+    expect(session.subagentUpserts()).toContainEqual({
+      id: "ApiBudgetAudit",
+      status: "completed",
+    });
+  });
+
+  test("stays active when get_subagents reports running children without prior events", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    await omp.requireStartTurn("fan out");
+    const runtime = omp.runtime();
+    runtime.beginTurn();
+    runtime.acceptPrompt("fan out", "user-fanout");
+    runtime.streamAssistantText("delegating");
+    runtime.subagents = [
+      {
+        id: "PipelineFeedAudit",
+        index: 0,
+        agent: "PipelineFeedAudit",
+        status: "running",
+        parentToolCallId: "task-2",
+      },
+    ];
+    runtime.state = { ...runtime.state, isStreaming: false, isCompacting: false };
+    runtime.finishTurn({
+      role: "assistant",
+      content: [{ type: "text", text: "delegating" }],
+    });
+
+    await omp.waitForProviderStateChecks(1);
+    await scheduler.waitForWaits(1);
+    expect(omp.completedTurnCount()).toBe(0);
+
+    runtime.subagents = [];
+    scheduler.retry();
+    await omp.waitForProviderStateChecks(2);
+    await waitForImmediate();
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("does not treat an empty get_subagents reply as completion for never-listed children", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    await omp.requireStartTurn("audit");
+    const runtime = omp.runtime();
+    runtime.beginTurn();
+    runtime.acceptPrompt("audit", "user-audit");
+    runtime.streamAssistantText("working");
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "OnlyLifecycle",
+        agent: "OnlyLifecycle",
+        status: "started",
+        index: 0,
+      },
+    });
+    runtime.subagents = [];
+    runtime.state = { ...runtime.state, isStreaming: false, isCompacting: false };
+    runtime.finishTurn({
+      role: "assistant",
+      content: [{ type: "text", text: "working" }],
+    });
+
+    await omp.waitForProviderStateChecks(1);
+    await scheduler.waitForWaits(1);
+    expect(omp.completedTurnCount()).toBe(0);
+
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "OnlyLifecycle",
+        agent: "OnlyLifecycle",
+        status: "completed",
+        index: 0,
+      },
+    });
+    scheduler.retry();
+    await omp.waitForProviderStateChecks(2);
+    await waitForImmediate();
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("keeps the parent active when get_subagents is unavailable", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    await omp.requireStartTurn("legacy omp");
+    const runtime = omp.runtime();
+    runtime.getSubagentsError = new Error("unknown command get_subagents");
+    runtime.beginTurn();
+    runtime.acceptPrompt("legacy omp", "user-legacy");
+    runtime.streamAssistantText("delegating");
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "LegacyChild",
+        agent: "LegacyChild",
+        status: "started",
+        index: 0,
+      },
+    });
+    runtime.state = { ...runtime.state, isStreaming: false, isCompacting: false };
+    runtime.finishTurn({
+      role: "assistant",
+      content: [{ type: "text", text: "delegating" }],
+    });
+
+    await omp.waitForProviderStateChecks(1);
+    await scheduler.waitForWaits(1);
+    expect(omp.completedTurnCount()).toBe(0);
+
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: {
+        id: "LegacyChild",
+        agent: "LegacyChild",
+        status: "completed",
+        index: 0,
+      },
+    });
+    scheduler.retry();
+    await omp.waitForProviderStateChecks(2);
+    await waitForImmediate();
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
   test("does not complete on OMP's extension-notice agent_end", async () => {
     const omp = new OmpHarness();
     await omp.start();

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "vitest";
 import { setImmediate as waitForImmediate } from "node:timers/promises";
 
 import type { PaseoToolCatalog } from "../../tools/types.js";
-import type { OmpNoTurnScheduler, OmpProviderIdleScheduler } from "./agent.js";
+import type {
+  OmpNoTurnScheduler,
+  OmpProviderIdleAttempt,
+  OmpProviderIdleDecision,
+  OmpProviderIdleScheduler,
+} from "./agent.js";
+import { createOmpProviderIdleScheduler } from "./agent.js";
 import type { OmpUsagePollScheduler } from "./usage-poller.js";
 import { OmpHarness } from "./test-utils/omp-harness.js";
 
@@ -17,15 +23,38 @@ function lastToolCallStatus(omp: OmpHarness, callId: string): string | undefined
 class ManualIdleScheduler implements OmpProviderIdleScheduler {
   private readonly retries: Array<() => void> = [];
   private readonly waiters: Array<{ count: number; resolve: () => void }> = [];
+  private readonly seen: OmpProviderIdleAttempt[] = [];
   private waitCount = 0;
+  private abandoned = false;
 
-  waitForRetry(): Promise<void> {
+  constructor(
+    private readonly decide: (attempt: OmpProviderIdleAttempt) => OmpProviderIdleDecision = () => ({
+      retry: true,
+    }),
+  ) {}
+
+  waitForRetry(attempt: OmpProviderIdleAttempt): Promise<OmpProviderIdleDecision> {
     this.waitCount += 1;
+    this.seen.push(attempt);
     for (const waiter of this.waiters.splice(0)) {
       if (this.waitCount >= waiter.count) waiter.resolve();
       else this.waiters.push(waiter);
     }
-    return new Promise((resolve) => this.retries.push(resolve));
+    const decision = this.decide(attempt);
+    if (this.abandoned) {
+      // Without this the caller spins with no timer and exhausts memory before
+      // the test reports anything.
+      throw new Error("OMP kept polling after the idle scheduler abandoned the gate");
+    }
+    if (!decision.retry) {
+      this.abandoned = true;
+      return Promise.resolve(decision);
+    }
+    return new Promise((resolve) => this.retries.push(() => resolve(decision)));
+  }
+
+  attempts(): OmpProviderIdleAttempt[] {
+    return this.seen;
   }
 
   waitForWaits(count: number): Promise<void> {
@@ -37,6 +66,10 @@ class ManualIdleScheduler implements OmpProviderIdleScheduler {
     const resolve = this.retries.shift();
     if (!resolve) throw new Error("OMP has not requested an idle-state retry");
     resolve();
+  }
+
+  retryAll(): void {
+    for (const resolve of this.retries.splice(0)) resolve();
   }
 }
 
@@ -335,6 +368,213 @@ describe("OMP agent client and session", () => {
     omp.reportProviderState({ isStreaming: false, isCompacting: false });
     scheduler.retry();
     await expect(completion).resolves.toMatchObject({ finalText: "first done" });
+  });
+
+  test("completes once when OMP repeats agent_end for the same turn", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await omp.waitForProviderStateChecks(2);
+    await scheduler.waitForWaits(1);
+
+    // OMP can end a second cycle for the same prompt; the terminal assistant
+    // message it already streamed would otherwise open a second gate.
+    omp.runtime().finishTurn();
+    for (let flush = 0; flush < 5; flush += 1) await waitForImmediate();
+    expect(scheduler.attempts()).toHaveLength(1);
+
+    omp.reportProviderState({ isStreaming: false, isCompacting: false });
+    scheduler.retryAll();
+    await expect(completion).resolves.toMatchObject({ finalText: "first done" });
+    await waitForImmediate();
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("fails the turn when OMP never reports idle", async () => {
+    const scheduler = new ManualIdleScheduler((attempt) =>
+      attempt.attempt < 2 ? { retry: true } : { retry: false, reason: "wait_budget" },
+    );
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+    scheduler.retryAll();
+
+    await expect(completion).rejects.toThrow(/idle/i);
+    expect(omp.completedTurnCount()).toBe(0);
+    expect(omp.failedTurns()).toMatchObject([
+      {
+        code: "omp_provider_idle_timeout",
+        diagnostic: expect.stringContaining("isStreaming=true"),
+      },
+    ]);
+  });
+
+  test("fails the turn when OMP state checks keep failing", async () => {
+    const scheduler = new ManualIdleScheduler((attempt) =>
+      attempt.consecutiveFailures < 2
+        ? { retry: true }
+        : { retry: false, reason: "failure_budget" },
+    );
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+    omp.failProviderStateChecks(new Error("state unavailable"));
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+    scheduler.retryAll();
+
+    await expect(completion).rejects.toThrow(/state/i);
+    expect(omp.completedTurnCount()).toBe(0);
+    expect(omp.failedTurns()).toMatchObject([
+      {
+        code: "omp_provider_state_unavailable",
+        diagnostic: expect.stringContaining("state unavailable"),
+      },
+    ]);
+  });
+
+  test("accepts a new prompt after a stalled turn fails", async () => {
+    const scheduler = new ManualIdleScheduler((attempt) =>
+      attempt.attempt < 2 ? { retry: true } : { retry: false, reason: "wait_budget" },
+    );
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+    scheduler.retryAll();
+    await expect(completion).rejects.toThrow(/idle/i);
+
+    omp.reportProviderState({ isStreaming: false, isCompacting: false });
+    await expect(omp.runPrompt("second", "second done")).resolves.toMatchObject({
+      finalText: "second done",
+    });
+  });
+
+  test("completes an autonomous turn once when OMP repeats agent_end", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    omp.startAutonomousTurnUntilProviderIdle("autonomous done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+
+    omp.runtime().finishTurn();
+    for (let flush = 0; flush < 5; flush += 1) await waitForImmediate();
+    expect(scheduler.attempts()).toHaveLength(1);
+
+    omp.reportProviderState({ isStreaming: false, isCompacting: false });
+    scheduler.retryAll();
+    for (let flush = 0; flush < 5; flush += 1) await waitForImmediate();
+    expect(omp.completedTurnCount()).toBe(1);
+  });
+
+  test("reports the last OMP state when the idle wait budget expires after a failed check", async () => {
+    const scheduler = new ManualIdleScheduler((attempt) =>
+      attempt.attempt < 3 ? { retry: true } : { retry: false, reason: "wait_budget" },
+    );
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+    omp.failProviderStateChecks(new Error("state unavailable"));
+    scheduler.retryAll();
+    await scheduler.waitForWaits(2);
+    scheduler.retryAll();
+
+    await expect(completion).rejects.toThrow(/idle/i);
+    expect(omp.failedTurns()).toMatchObject([
+      {
+        code: "omp_provider_idle_timeout",
+        diagnostic: expect.stringContaining("isStreaming=true"),
+      },
+    ]);
+    // The failing check is still evidence; it must not be dropped.
+    expect(omp.failedTurns()[0]?.diagnostic).toContain("state unavailable");
+  });
+
+  test("fails the turn with the newest agent_end error", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    await scheduler.waitForWaits(1);
+
+    omp.runtime().finishTurn({ role: "assistant", content: [], errorMessage: "provider exploded" });
+    for (let flush = 0; flush < 5; flush += 1) await waitForImmediate();
+
+    omp.reportProviderState({ isStreaming: false, isCompacting: false });
+    scheduler.retryAll();
+
+    await expect(completion).rejects.toThrow(/provider exploded/);
+    expect(omp.completedTurnCount()).toBe(0);
+  });
+
+  test("the default idle scheduler stops on its wait and failure budgets", async () => {
+    const scheduler = createOmpProviderIdleScheduler();
+
+    await expect(
+      scheduler.waitForRetry({ attempt: 1, consecutiveFailures: 0, elapsedMs: 0 }),
+    ).resolves.toEqual({ retry: true });
+    await expect(
+      scheduler.waitForRetry({ attempt: 200, consecutiveFailures: 0, elapsedMs: 60_000 }),
+    ).resolves.toEqual({ retry: false, reason: "wait_budget" });
+    await expect(
+      scheduler.waitForRetry({ attempt: 3, consecutiveFailures: 3, elapsedMs: 100 }),
+    ).resolves.toEqual({ retry: false, reason: "failure_budget" });
+  });
+
+  test("cancels in-flight tool calls when a turn stalls", async () => {
+    const scheduler = new ManualIdleScheduler((attempt) =>
+      attempt.attempt < 2 ? { retry: true } : { retry: false, reason: "wait_budget" },
+    );
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    const { completion } = await omp.startPromptUntilProviderIdle("first", "first done", {
+      isStreaming: true,
+      isCompacting: false,
+    });
+    omp.runtime().emit({
+      type: "tool_execution_start",
+      toolCallId: "tool-1",
+      toolName: "bash",
+      args: { command: "sleep 30" },
+    });
+    expect(omp.runningToolCallIds()).toEqual(["tool-1"]);
+
+    await scheduler.waitForWaits(1);
+    scheduler.retryAll();
+    await expect(completion).rejects.toThrow(/idle/i);
+
+    expect(omp.runningToolCallIds()).toEqual([]);
   });
 
   // #2232: parent model loop can go idle while OMP-internal `task` children

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -546,6 +546,7 @@ describe("OMP agent client and session", () => {
         consecutiveFailures: 0,
         elapsedMs: 0,
         isCompacting: false,
+        isWaitingOnSubagents: false,
       }),
     ).resolves.toEqual({ retry: true });
     await expect(
@@ -554,6 +555,7 @@ describe("OMP agent client and session", () => {
         consecutiveFailures: 0,
         elapsedMs: 60_000,
         isCompacting: false,
+        isWaitingOnSubagents: false,
       }),
     ).resolves.toEqual({ retry: false, reason: "wait_budget" });
     await expect(
@@ -562,6 +564,7 @@ describe("OMP agent client and session", () => {
         consecutiveFailures: 3,
         elapsedMs: 100,
         isCompacting: false,
+        isWaitingOnSubagents: false,
       }),
     ).resolves.toEqual({ retry: false, reason: "failure_budget" });
   });
@@ -644,6 +647,7 @@ describe("OMP agent client and session", () => {
         consecutiveFailures: 0,
         elapsedMs: 120_000,
         isCompacting: true,
+        isWaitingOnSubagents: false,
       }),
     ).resolves.toEqual({ retry: true });
     await expect(
@@ -652,6 +656,7 @@ describe("OMP agent client and session", () => {
         consecutiveFailures: 0,
         elapsedMs: 120_000,
         isCompacting: false,
+        isWaitingOnSubagents: false,
       }),
     ).resolves.toEqual({ retry: false, reason: "wait_budget" });
   });
@@ -1037,6 +1042,47 @@ describe("OMP agent client and session", () => {
     });
     expect(lastToolCallStatus(omp, "task-fail")).toBe("failed");
     expect(omp.runningToolCallIds()).toEqual([]);
+  });
+
+  test("waits past the idle budget while OMP reports running subagents", async () => {
+    const scheduler = createOmpProviderIdleScheduler();
+
+    await expect(
+      scheduler.waitForRetry({
+        attempt: 1,
+        consecutiveFailures: 0,
+        elapsedMs: 120_000,
+        isCompacting: false,
+        isWaitingOnSubagents: true,
+      }),
+    ).resolves.toEqual({ retry: true });
+  });
+
+  test("stops trusting a subagent wait once get_subagents stops answering", async () => {
+    const scheduler = new ManualIdleScheduler();
+    const omp = new OmpHarness({ providerIdleScheduler: scheduler });
+    await omp.start();
+
+    await omp.requireStartTurn("fan out");
+    const runtime = omp.runtime();
+    runtime.beginTurn();
+    runtime.acceptPrompt("fan out", "user-fan");
+    runtime.streamAssistantText("dispatching");
+    runtime.emit({
+      type: "subagent_lifecycle",
+      payload: { id: "child-1", agent: "worker", status: "started", index: 0 },
+    });
+    runtime.state = { ...runtime.state, isStreaming: false, isCompacting: false };
+    runtime.finishTurn();
+
+    await scheduler.waitForWaits(1);
+    expect(scheduler.attempts()[0]?.isWaitingOnSubagents).toBe(true);
+
+    // A snapshot that cannot be fetched is not evidence that work continues.
+    runtime.getSubagentsError = new Error("subagents unavailable");
+    scheduler.retryAll();
+    await scheduler.waitForWaits(2);
+    expect(scheduler.attempts()[1]?.isWaitingOnSubagents).toBe(false);
   });
 
   test("does not complete on OMP's extension-notice agent_end", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -843,6 +843,10 @@ export class OmpAgentSession implements AgentSession {
 
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private readonly activeToolCalls = new Map<string, OmpTrackedToolCall>();
+  private readonly deferredTaskResults = new Map<
+    string,
+    { toolCall: OmpTrackedToolCall; result: OmpToolResult }
+  >();
   private readonly pendingExtensionUiRequests = new Map<string, AgentPermissionRequest>();
   private activeAskUserDialog: ActiveAskUserDialog | null = null;
   private pendingCombinedAskUserResponse: PendingCombinedAskUserResponse | null = null;
@@ -1173,6 +1177,7 @@ export class OmpAgentSession implements AgentSession {
 
   private clearOmpTurnState(): void {
     clearOmpHostToolState(this.runtimeSession);
+    this.deferredTaskResults.clear();
     this.subagentCardTracker.clear();
   }
 
@@ -1641,6 +1646,7 @@ export class OmpAgentSession implements AgentSession {
       for (const mapped of this.subagentIndex.handleLifecycle(this.runtimeSession, payload)) {
         this.emit(mapped);
       }
+      this.settleDeferredTaskCalls();
       return true;
     }
     if (event.type === "subagent_progress") {
@@ -1653,6 +1659,7 @@ export class OmpAgentSession implements AgentSession {
       for (const mapped of this.subagentIndex.handleProgress(this.runtimeSession, payload)) {
         this.emit(mapped);
       }
+      this.settleDeferredTaskCalls();
       return true;
     }
     if (event.type === "subagent_event") {
@@ -1901,7 +1908,6 @@ export class OmpAgentSession implements AgentSession {
   ): void {
     const toolCall =
       this.activeToolCalls.get(event.toolCallId) ?? parseToolArgs(event.toolName, null);
-    this.activeToolCalls.delete(event.toolCallId);
 
     if (event.toolName === "ask_user") {
       this.activeAskUserDialog = null;
@@ -1909,6 +1915,17 @@ export class OmpAgentSession implements AgentSession {
     }
 
     const result = parseToolResult(event.result);
+    // `task` tool_execution_end is a dispatch ack. Children start later, so keep
+    // the call active until the index has a linked child and none are running.
+    if (event.toolName === "task" && !event.isError) {
+      this.activeToolCalls.set(event.toolCallId, toolCall);
+      this.deferredTaskResults.set(event.toolCallId, { toolCall, result });
+      this.emitToolCallEvent(event.toolCallId, toolCall, "running", result, null);
+      this.settleDeferredTaskCalls();
+      return;
+    }
+
+    this.activeToolCalls.delete(event.toolCallId);
     const error = event.isError ? event.result : null;
     const status = event.isError ? "failed" : "completed";
     this.emitToolCallEvent(event.toolCallId, toolCall, status, result, error);
@@ -1923,6 +1940,36 @@ export class OmpAgentSession implements AgentSession {
         this.logger.debug({ event }, "Dropped malformed OMP todo tool result");
       }
     }
+  }
+
+  private settleDeferredTaskCalls(): void {
+    const pendingIds = Array.from(this.deferredTaskResults.keys());
+    for (const toolCallId of pendingIds) {
+      if (
+        this.subagentIndex.hasLinkedChild(this.runtimeSession, toolCallId) &&
+        !this.subagentIndex.hasRunningLinkedTo(this.runtimeSession, toolCallId)
+      ) {
+        this.finalizeDeferredTask(toolCallId);
+      }
+    }
+  }
+
+  private forceSettleDeferredTaskCalls(): void {
+    const pendingIds = Array.from(this.deferredTaskResults.keys());
+    for (const toolCallId of pendingIds) {
+      this.finalizeDeferredTask(toolCallId);
+    }
+  }
+
+  private finalizeDeferredTask(toolCallId: string): void {
+    const pending = this.deferredTaskResults.get(toolCallId);
+    if (!pending) {
+      return;
+    }
+    this.deferredTaskResults.delete(toolCallId);
+    this.activeToolCalls.delete(toolCallId);
+    this.emitToolCallEvent(toolCallId, pending.toolCall, "completed", pending.result, null);
+    this.subagentCardTracker.delete(toolCallId);
   }
 
   private emitCompactionTimeline(input: {
@@ -2123,6 +2170,7 @@ export class OmpAgentSession implements AgentSession {
   }
 
   private completeTurn(turnId: string | undefined, messages: OmpAgentMessage[]): void {
+    this.forceSettleDeferredTaskCalls();
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;
@@ -2180,6 +2228,7 @@ export class OmpAgentSession implements AgentSession {
     } catch (error) {
       this.logger.debug({ err: error }, "OMP get_subagents unavailable during idle gate");
     }
+    this.settleDeferredTaskCalls();
     return this.subagentIndex.hasRunning(this.runtimeSession);
   }
 

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -139,8 +139,26 @@ export interface OmpAgentClientOptions {
   usagePollScheduler?: OmpUsagePollScheduler;
 }
 
+export interface OmpProviderIdleAttempt {
+  /** State checks already made for this completion gate, 1-based. */
+  attempt: number;
+  /** Consecutive `get_state` rejections; any successful response resets it. */
+  consecutiveFailures: number;
+  /** Wall-clock time since the gate opened, covering waits and `get_state`. */
+  elapsedMs: number;
+}
+
+/**
+ * `reason` names the exhausted budget so the turn reports why it stopped rather
+ * than inferring it from whichever check happened to be last.
+ */
+export type OmpProviderIdleDecision =
+  | { retry: true }
+  | { retry: false; reason: "wait_budget" | "failure_budget" };
+
 export interface OmpProviderIdleScheduler {
-  waitForRetry(): Promise<void>;
+  /** Wait before the next state check, or abandon the gate so the turn fails. */
+  waitForRetry(attempt: OmpProviderIdleAttempt): Promise<OmpProviderIdleDecision>;
 }
 
 export interface OmpNoTurnScheduler {
@@ -194,10 +212,39 @@ interface OmpAgentSessionOptions {
   live?: boolean;
 }
 
-function createOmpProviderIdleScheduler(): OmpProviderIdleScheduler {
+// OMP processes a state request only once its RPC loop is promptable again, so
+// the first checks after agent_end usually miss. Poll fast at first, then back
+// off: a stalled provider otherwise costs 100 RPCs a second for as long as the
+// stall lasts.
+// Autonomous OMP cycles carry no turn ID; they still need a gate key of their own.
+const OMP_AUTONOMOUS_GATE_KEY = "autonomous";
+
+const OMP_PROVIDER_IDLE_MIN_RETRY_MS = 10;
+const OMP_PROVIDER_IDLE_MAX_RETRY_MS = 1_000;
+// Wall clock, not a retry count: each get_state carries the JSONL-RPC request
+// timeout, so counting attempts would let a slow-but-answering state path stretch
+// the wait to tens of minutes.
+const OMP_PROVIDER_IDLE_BUDGET_MS = 60_000;
+// A get_state rejection already costs a full RPC timeout, so a few in a row are
+// enough evidence that the state path is gone.
+const OMP_PROVIDER_IDLE_FAILURE_BUDGET = 3;
+
+function ompProviderIdleRetryDelayMs(attempt: number): number {
+  const backoff = OMP_PROVIDER_IDLE_MIN_RETRY_MS * 2 ** (attempt - 1);
+  return Math.min(OMP_PROVIDER_IDLE_MAX_RETRY_MS, backoff);
+}
+
+export function createOmpProviderIdleScheduler(): OmpProviderIdleScheduler {
   return {
-    waitForRetry: async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    waitForRetry: async ({ attempt, consecutiveFailures, elapsedMs }) => {
+      if (consecutiveFailures >= OMP_PROVIDER_IDLE_FAILURE_BUDGET) {
+        return { retry: false, reason: "failure_budget" };
+      }
+      if (elapsedMs >= OMP_PROVIDER_IDLE_BUDGET_MS) {
+        return { retry: false, reason: "wait_budget" };
+      }
+      await delay(ompProviderIdleRetryDelayMs(attempt));
+      return { retry: true };
     },
   };
 }
@@ -855,6 +902,7 @@ export class OmpAgentSession implements AgentSession {
   private activeAssistantMessageId: string | null = null;
   private activeTurnTerminalAssistantMessage: OmpAgentMessage | null = null;
   private activeTurnStarted = false;
+  private providerIdleGate: { key: string; messages: OmpAgentMessage[] } | null = null;
   private activeTurnHasUserMessage = false;
   private activeNoTurnPromptText: string | null = null;
   private readonly pendingNoTurnOutputs: Array<{ turnId: string; message: string }> = [];
@@ -1161,6 +1209,7 @@ export class OmpAgentSession implements AgentSession {
       return;
     }
     this.closed = true;
+    this.providerIdleGate = null;
     this.usagePoller.close();
     this.cancelNoTurnPromptCompletion();
     try {
@@ -1894,7 +1943,11 @@ export class OmpAgentSession implements AgentSession {
         }
         // A state request is processed after OMP's RPC loop becomes promptable,
         // so do not advertise Paseo idle until it reports that transition.
-        void this.completeTurnAfterProviderIdle(turnId, terminalMessages);
+        void this.completeTurnAfterProviderIdle(turnId, terminalMessages).catch(
+          (error: unknown) => {
+            this.logger.warn({ err: error }, "OMP provider idle gate failed");
+          },
+        );
         return;
       }
       default:
@@ -2169,8 +2222,7 @@ export class OmpAgentSession implements AgentSession {
     });
   }
 
-  private completeTurn(turnId: string | undefined, messages: OmpAgentMessage[]): void {
-    this.forceSettleDeferredTaskCalls();
+  private resetActiveTurn(): void {
     this.activeTurnId = null;
     this.activeClientMessageId = null;
     this.activeAssistantMessageId = null;
@@ -2178,6 +2230,11 @@ export class OmpAgentSession implements AgentSession {
     this.activeTurnStarted = false;
     this.activeTurnHasUserMessage = false;
     this.clearNoTurnBuffers();
+  }
+
+  private completeTurn(turnId: string | undefined, messages: OmpAgentMessage[]): void {
+    this.forceSettleDeferredTaskCalls();
+    this.resetActiveTurn();
     const errorMessage = latestOmpErrorMessage(messages);
     if (typeof errorMessage === "string" && errorMessage.length > 0) {
       this.usagePoller.stopTurn();
@@ -2202,20 +2259,65 @@ export class OmpAgentSession implements AgentSession {
     turnId: string | undefined,
     messages: OmpAgentMessage[],
   ): Promise<void> {
-    while (!this.closed && this.activeTurnStarted && this.currentTurnIdForEvent() === turnId) {
-      try {
-        const state = await this.runtimeSession.getState();
-        this.state = state;
-        // Parent model idle is not enough: OMP-internal `task` children keep
-        // writing after agent_end / isStreaming=false (#2232).
-        if (!state.isStreaming && !state.isCompacting && !(await this.hasRunningOmpSubagents())) {
-          this.completeTurn(turnId, messages);
+    // OMP can end more than one cycle for a single prompt. Without this gate a
+    // second loop races the first and completes the same turn twice. Autonomous
+    // cycles carry no turn ID, so they share one key: their loop polls too.
+    const key = turnId ?? OMP_AUTONOMOUS_GATE_KEY;
+    if (this.providerIdleGate?.key === key) {
+      // The newest agent_end owns the terminal payload; the running loop reads it
+      // at completion time so a late provider error is not dropped.
+      this.providerIdleGate.messages = messages;
+      return;
+    }
+    const gate = { key, messages };
+    this.providerIdleGate = gate;
+    try {
+      const startedAt = Date.now();
+      let attempt = 0;
+      let consecutiveFailures = 0;
+      let lastState: OmpSessionState | null = null;
+      let lastError: unknown = null;
+      while (!this.closed && this.activeTurnStarted && this.currentTurnIdForEvent() === turnId) {
+        attempt += 1;
+        try {
+          const state = await this.runtimeSession.getState();
+          this.state = state;
+          lastState = state;
+          consecutiveFailures = 0;
+          // Parent model idle is not enough: OMP-internal `task` children keep
+          // writing after agent_end / isStreaming=false (#2232).
+          if (!state.isStreaming && !state.isCompacting && !(await this.hasRunningOmpSubagents())) {
+            this.completeTurn(turnId, gate.messages);
+            return;
+          }
+        } catch (error) {
+          lastError = error;
+          consecutiveFailures += 1;
+          this.logger.debug(
+            { err: error },
+            "OMP state unavailable while waiting for provider idle",
+          );
+        }
+        const decision = await this.providerIdleScheduler.waitForRetry({
+          attempt,
+          consecutiveFailures,
+          elapsedMs: Date.now() - startedAt,
+        });
+        if (!decision.retry) {
+          this.failStalledTurn(turnId, {
+            reason: decision.reason,
+            attempt,
+            consecutiveFailures,
+            lastState,
+            lastError,
+          });
           return;
         }
-      } catch (error) {
-        this.logger.debug({ err: error }, "OMP state unavailable while waiting for provider idle");
       }
-      await this.providerIdleScheduler.waitForRetry();
+    } finally {
+      if (this.providerIdleGate === gate) {
+        this.providerIdleGate = null;
+      }
     }
   }
 
@@ -2230,6 +2332,52 @@ export class OmpAgentSession implements AgentSession {
     }
     this.settleDeferredTaskCalls();
     return this.subagentIndex.hasRunning(this.runtimeSession);
+  }
+
+  private failStalledTurn(
+    turnId: string | undefined,
+    context: {
+      reason: "wait_budget" | "failure_budget";
+      attempt: number;
+      consecutiveFailures: number;
+      lastState: OmpSessionState | null;
+      lastError: unknown;
+    },
+  ): void {
+    const stateUnavailable = context.reason === "failure_budget";
+    // Both observations go into every diagnostic: which budget ran out says what
+    // Paseo did, the last state and the last error say what OMP was doing.
+    const details = [`state checks: ${context.attempt}`];
+    if (context.lastState) {
+      details.push(
+        `last OMP state: isStreaming=${context.lastState.isStreaming}, isCompacting=${context.lastState.isCompacting}`,
+      );
+    }
+    if (context.lastError) {
+      details.push(
+        `last get_state error after ${context.consecutiveFailures} consecutive failures: ${toDiagnosticErrorMessage(context.lastError)}`,
+      );
+    }
+    const diagnostic = details.join("; ");
+    this.logger.warn(
+      { turnId, reason: context.reason, diagnostic },
+      "OMP never reported an idle state after ending its response",
+    );
+    // A stall leaves OMP's state unknown, so anything still marked running has no
+    // turn left to finish it.
+    this.terminalizeActiveWork();
+    this.resetActiveTurn();
+    this.usagePoller.stopTurn();
+    this.emit({
+      type: "turn_failed",
+      provider: this.provider,
+      turnId,
+      error: stateUnavailable
+        ? "OMP finished its response but its state is unavailable, so Paseo cannot confirm the turn ended."
+        : "OMP finished its response but never reported an idle state, so Paseo stopped waiting for the turn to end.",
+      code: stateUnavailable ? "omp_provider_state_unavailable" : "omp_provider_idle_timeout",
+      diagnostic,
+    });
   }
 
   private async refreshState(): Promise<void> {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -2158,7 +2158,9 @@ export class OmpAgentSession implements AgentSession {
       try {
         const state = await this.runtimeSession.getState();
         this.state = state;
-        if (!state.isStreaming && !state.isCompacting) {
+        // Parent model idle is not enough: OMP-internal `task` children keep
+        // writing after agent_end / isStreaming=false (#2232).
+        if (!state.isStreaming && !state.isCompacting && !(await this.hasRunningOmpSubagents())) {
           this.completeTurn(turnId, messages);
           return;
         }
@@ -2167,6 +2169,18 @@ export class OmpAgentSession implements AgentSession {
       }
       await this.providerIdleScheduler.waitForRetry();
     }
+  }
+
+  private async hasRunningOmpSubagents(): Promise<boolean> {
+    try {
+      const snapshots = await this.runtimeSession.getSubagents();
+      for (const event of this.subagentIndex.reconcileSnapshots(this.runtimeSession, snapshots)) {
+        this.emit(event);
+      }
+    } catch (error) {
+      this.logger.debug({ err: error }, "OMP get_subagents unavailable during idle gate");
+    }
+    return this.subagentIndex.hasRunning(this.runtimeSession);
   }
 
   private async refreshState(): Promise<void> {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -144,8 +144,10 @@ export interface OmpProviderIdleAttempt {
   attempt: number;
   /** Consecutive `get_state` rejections; any successful response resets it. */
   consecutiveFailures: number;
-  /** Wall-clock time since the gate opened, covering waits and `get_state`. */
+  /** Monotonic time since the gate opened, covering waits and `get_state`. */
   elapsedMs: number;
+  /** Whether the last observed state reported compaction in progress. */
+  isCompacting: boolean;
 }
 
 /**
@@ -212,19 +214,23 @@ interface OmpAgentSessionOptions {
   live?: boolean;
 }
 
+// Autonomous OMP cycles carry no turn ID; they still need a gate key of their own.
+const OMP_AUTONOMOUS_GATE_KEY = "autonomous";
+
 // OMP processes a state request only once its RPC loop is promptable again, so
 // the first checks after agent_end usually miss. Poll fast at first, then back
 // off: a stalled provider otherwise costs 100 RPCs a second for as long as the
 // stall lasts.
-// Autonomous OMP cycles carry no turn ID; they still need a gate key of their own.
-const OMP_AUTONOMOUS_GATE_KEY = "autonomous";
-
 const OMP_PROVIDER_IDLE_MIN_RETRY_MS = 10;
 const OMP_PROVIDER_IDLE_MAX_RETRY_MS = 1_000;
 // Wall clock, not a retry count: each get_state carries the JSONL-RPC request
 // timeout, so counting attempts would let a slow-but-answering state path stretch
 // the wait to tens of minutes.
 const OMP_PROVIDER_IDLE_BUDGET_MS = 60_000;
+// Compaction is a model call over the whole context, so it routinely outlasts the
+// idle budget. Waiting on a reported compaction is not the stall this gate guards
+// against, but it still needs an end.
+const OMP_PROVIDER_COMPACTING_BUDGET_MS = 600_000;
 // A get_state rejection already costs a full RPC timeout, so a few in a row are
 // enough evidence that the state path is gone.
 const OMP_PROVIDER_IDLE_FAILURE_BUDGET = 3;
@@ -236,11 +242,14 @@ function ompProviderIdleRetryDelayMs(attempt: number): number {
 
 export function createOmpProviderIdleScheduler(): OmpProviderIdleScheduler {
   return {
-    waitForRetry: async ({ attempt, consecutiveFailures, elapsedMs }) => {
+    waitForRetry: async ({ attempt, consecutiveFailures, elapsedMs, isCompacting }) => {
       if (consecutiveFailures >= OMP_PROVIDER_IDLE_FAILURE_BUDGET) {
         return { retry: false, reason: "failure_budget" };
       }
-      if (elapsedMs >= OMP_PROVIDER_IDLE_BUDGET_MS) {
+      const budgetMs = isCompacting
+        ? OMP_PROVIDER_COMPACTING_BUDGET_MS
+        : OMP_PROVIDER_IDLE_BUDGET_MS;
+      if (elapsedMs >= budgetMs) {
         return { retry: false, reason: "wait_budget" };
       }
       await delay(ompProviderIdleRetryDelayMs(attempt));
@@ -571,6 +580,17 @@ function latestOmpErrorMessage(messages: OmpAgentMessage[]): string | null {
     return null;
   }
   return formatOmpErrorMessage(latestAssistant);
+}
+
+/** Newest agent_end wins, unless it would discard an error the gate already holds. */
+function preferErroredOmpPayload(
+  current: OmpAgentMessage[],
+  incoming: OmpAgentMessage[],
+): OmpAgentMessage[] {
+  if (latestOmpErrorMessage(incoming)) {
+    return incoming;
+  }
+  return latestOmpErrorMessage(current) ? current : incoming;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -2255,6 +2275,19 @@ export class OmpAgentSession implements AgentSession {
     void this.refreshAfterTurn(finalUsage);
   }
 
+  /** Ownership can change across an await; completing a turn this gate no longer
+   * represents would clear the turn that replaced it. */
+  private completeTurnIfGateOwned(turnId: string | undefined, messages: OmpAgentMessage[]): void {
+    if (!this.ownsProviderIdleGate(turnId)) {
+      return;
+    }
+    this.completeTurn(turnId, messages);
+  }
+
+  private ownsProviderIdleGate(turnId: string | undefined): boolean {
+    return !this.closed && this.activeTurnStarted && this.currentTurnIdForEvent() === turnId;
+  }
+
   private async completeTurnAfterProviderIdle(
     turnId: string | undefined,
     messages: OmpAgentMessage[],
@@ -2264,20 +2297,23 @@ export class OmpAgentSession implements AgentSession {
     // cycles carry no turn ID, so they share one key: their loop polls too.
     const key = turnId ?? OMP_AUTONOMOUS_GATE_KEY;
     if (this.providerIdleGate?.key === key) {
-      // The newest agent_end owns the terminal payload; the running loop reads it
-      // at completion time so a late provider error is not dropped.
-      this.providerIdleGate.messages = messages;
+      // The newest agent_end owns the terminal payload so a later provider error
+      // is not dropped, except when it would drop one the gate already holds.
+      this.providerIdleGate.messages = preferErroredOmpPayload(
+        this.providerIdleGate.messages,
+        messages,
+      );
       return;
     }
     const gate = { key, messages };
     this.providerIdleGate = gate;
     try {
-      const startedAt = Date.now();
+      const startedAt = performance.now();
       let attempt = 0;
       let consecutiveFailures = 0;
       let lastState: OmpSessionState | null = null;
       let lastError: unknown = null;
-      while (!this.closed && this.activeTurnStarted && this.currentTurnIdForEvent() === turnId) {
+      while (this.ownsProviderIdleGate(turnId)) {
         attempt += 1;
         try {
           const state = await this.runtimeSession.getState();
@@ -2287,7 +2323,7 @@ export class OmpAgentSession implements AgentSession {
           // Parent model idle is not enough: OMP-internal `task` children keep
           // writing after agent_end / isStreaming=false (#2232).
           if (!state.isStreaming && !state.isCompacting && !(await this.hasRunningOmpSubagents())) {
-            this.completeTurn(turnId, gate.messages);
+            this.completeTurnIfGateOwned(turnId, gate.messages);
             return;
           }
         } catch (error) {
@@ -2301,9 +2337,13 @@ export class OmpAgentSession implements AgentSession {
         const decision = await this.providerIdleScheduler.waitForRetry({
           attempt,
           consecutiveFailures,
-          elapsedMs: Date.now() - startedAt,
+          elapsedMs: performance.now() - startedAt,
+          isCompacting: lastState?.isCompacting === true,
         });
         if (!decision.retry) {
+          if (!this.ownsProviderIdleGate(turnId)) {
+            return;
+          }
           this.failStalledTurn(turnId, {
             reason: decision.reason,
             attempt,
@@ -2344,7 +2384,10 @@ export class OmpAgentSession implements AgentSession {
       lastError: unknown;
     },
   ): void {
-    const stateUnavailable = context.reason === "failure_budget";
+    // A hanging state path burns the wait budget before the failure budget, so a
+    // gate that never saw a state is an unavailable state path whichever ran out.
+    const stateUnavailable =
+      context.reason === "failure_budget" || (!context.lastState && context.lastError !== null);
     // Both observations go into every diagnostic: which budget ran out says what
     // Paseo did, the last state and the last error say what OMP was doing.
     const details = [`state checks: ${context.attempt}`];
@@ -2354,8 +2397,12 @@ export class OmpAgentSession implements AgentSession {
       );
     }
     if (context.lastError) {
+      const failureCount =
+        context.consecutiveFailures > 0
+          ? ` after ${context.consecutiveFailures} consecutive failures`
+          : "";
       details.push(
-        `last get_state error after ${context.consecutiveFailures} consecutive failures: ${toDiagnosticErrorMessage(context.lastError)}`,
+        `last get_state error${failureCount}: ${toDiagnosticErrorMessage(context.lastError)}`,
       );
     }
     const diagnostic = details.join("; ");

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -148,6 +148,8 @@ export interface OmpProviderIdleAttempt {
   elapsedMs: number;
   /** Whether the last observed state reported compaction in progress. */
   isCompacting: boolean;
+  /** Whether a current get_subagents reply still reports running children. */
+  isWaitingOnSubagents: boolean;
 }
 
 /**
@@ -242,9 +244,22 @@ function ompProviderIdleRetryDelayMs(attempt: number): number {
 
 export function createOmpProviderIdleScheduler(): OmpProviderIdleScheduler {
   return {
-    waitForRetry: async ({ attempt, consecutiveFailures, elapsedMs, isCompacting }) => {
+    waitForRetry: async ({
+      attempt,
+      consecutiveFailures,
+      elapsedMs,
+      isCompacting,
+      isWaitingOnSubagents,
+    }) => {
       if (consecutiveFailures >= OMP_PROVIDER_IDLE_FAILURE_BUDGET) {
         return { retry: false, reason: "failure_budget" };
+      }
+      // A current snapshot reporting running children is positive evidence that
+      // OMP is working, and a fan-out has no bounded length. Stale evidence is
+      // not: the budget resumes as soon as get_subagents stops answering.
+      if (isWaitingOnSubagents) {
+        await delay(ompProviderIdleRetryDelayMs(attempt));
+        return { retry: true };
       }
       const budgetMs = isCompacting
         ? OMP_PROVIDER_COMPACTING_BUDGET_MS
@@ -2313,6 +2328,7 @@ export class OmpAgentSession implements AgentSession {
       let consecutiveFailures = 0;
       let lastState: OmpSessionState | null = null;
       let lastError: unknown = null;
+      let waitingOnSubagents = false;
       while (this.ownsProviderIdleGate(turnId)) {
         attempt += 1;
         try {
@@ -2322,7 +2338,10 @@ export class OmpAgentSession implements AgentSession {
           consecutiveFailures = 0;
           // Parent model idle is not enough: OMP-internal `task` children keep
           // writing after agent_end / isStreaming=false (#2232).
-          if (!state.isStreaming && !state.isCompacting && !(await this.hasRunningOmpSubagents())) {
+          const modelBusy = state.isStreaming || state.isCompacting;
+          const subagents = modelBusy ? null : await this.pollOmpSubagents();
+          waitingOnSubagents = subagents ? subagents.running && subagents.fresh : false;
+          if (subagents && !subagents.running) {
             this.completeTurnIfGateOwned(turnId, gate.messages);
             return;
           }
@@ -2339,6 +2358,7 @@ export class OmpAgentSession implements AgentSession {
           consecutiveFailures,
           elapsedMs: performance.now() - startedAt,
           isCompacting: lastState?.isCompacting === true,
+          isWaitingOnSubagents: waitingOnSubagents,
         });
         if (!decision.retry) {
           if (!this.ownsProviderIdleGate(turnId)) {
@@ -2350,6 +2370,7 @@ export class OmpAgentSession implements AgentSession {
             consecutiveFailures,
             lastState,
             lastError,
+            waitingOnSubagents,
           });
           return;
         }
@@ -2361,17 +2382,23 @@ export class OmpAgentSession implements AgentSession {
     }
   }
 
-  private async hasRunningOmpSubagents(): Promise<boolean> {
+  /**
+   * `fresh` reports whether this answer came from a snapshot OMP actually
+   * returned. The idle budget trusts running children only while it does.
+   */
+  private async pollOmpSubagents(): Promise<{ running: boolean; fresh: boolean }> {
+    let fresh = true;
     try {
       const snapshots = await this.runtimeSession.getSubagents();
       for (const event of this.subagentIndex.reconcileSnapshots(this.runtimeSession, snapshots)) {
         this.emit(event);
       }
     } catch (error) {
+      fresh = false;
       this.logger.debug({ err: error }, "OMP get_subagents unavailable during idle gate");
     }
     this.settleDeferredTaskCalls();
-    return this.subagentIndex.hasRunning(this.runtimeSession);
+    return { running: this.subagentIndex.hasRunning(this.runtimeSession), fresh };
   }
 
   private failStalledTurn(
@@ -2382,6 +2409,7 @@ export class OmpAgentSession implements AgentSession {
       consecutiveFailures: number;
       lastState: OmpSessionState | null;
       lastError: unknown;
+      waitingOnSubagents: boolean;
     },
   ): void {
     // A hanging state path burns the wait budget before the failure budget, so a
@@ -2404,6 +2432,9 @@ export class OmpAgentSession implements AgentSession {
       details.push(
         `last get_state error${failureCount}: ${toDiagnosticErrorMessage(context.lastError)}`,
       );
+    }
+    if (context.waitingOnSubagents) {
+      details.push("OMP still reported running subagents");
     }
     const diagnostic = details.join("; ");
     this.logger.warn(

--- a/packages/server/src/server/agent/providers/omp/cli-runtime.test.ts
+++ b/packages/server/src/server/agent/providers/omp/cli-runtime.test.ts
@@ -243,14 +243,19 @@ describe("OMP CLI runtime", () => {
     const commands: Record<string, unknown>[] = [];
     replyToCommands(child, (command) => {
       commands.push(command);
+      if (command.type === "get_subagents") {
+        return { subagents: [] };
+      }
       return undefined;
     });
     const session = await createRuntime(child).startSession({ cwd: "/workspace/project" });
 
     await session.setSubagentSubscription("events");
+    await session.getSubagents();
 
     expect(commands.map(withoutRequestId)).toEqual([
       { type: "set_subagent_subscription", level: "events" },
+      { type: "get_subagents" },
     ]);
   });
 

--- a/packages/server/src/server/agent/providers/omp/cli-runtime.ts
+++ b/packages/server/src/server/agent/providers/omp/cli-runtime.ts
@@ -28,6 +28,7 @@ import {
   OmpRuntimeEventSchema,
   OmpSessionStateSchema,
   OmpSessionStatsSchema,
+  OmpSubagentsResultSchema,
   type OmpThinkingLevel,
   type OmpAgentMessage,
   type OmpModel,
@@ -40,6 +41,7 @@ import {
   type OmpRuntimeEvent,
   type OmpSessionState,
   type OmpSessionStats,
+  type OmpSubagentSnapshot,
   type OmpSubagentSubscriptionLevel,
 } from "./rpc-types.js";
 
@@ -273,6 +275,11 @@ class OmpCliRuntimeSession implements OmpRuntimeSession {
 
   async setSubagentSubscription(level: OmpSubagentSubscriptionLevel): Promise<void> {
     await this.request({ type: "set_subagent_subscription", level });
+  }
+
+  async getSubagents(): Promise<OmpSubagentSnapshot[]> {
+    const data = OmpSubagentsResultSchema.parse(await this.request({ type: "get_subagents" }));
+    return data.subagents ?? [];
   }
 
   async setHostTools(tools: OmpRpcHostToolDefinition[]): Promise<string[]> {

--- a/packages/server/src/server/agent/providers/omp/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/omp/rpc-types.ts
@@ -512,6 +512,7 @@ export const OmpRpcCommandSchema = z.discriminatedUnion("type", [
   z.object({ ...OmpCommandBase, type: z.literal("set_auto_compaction"), enabled: z.boolean() }),
   z.object({ ...OmpCommandBase, type: z.literal("abort") }),
   z.object({ ...OmpCommandBase, type: z.literal("get_state") }),
+  z.object({ ...OmpCommandBase, type: z.literal("get_subagents") }),
   z.object({ ...OmpCommandBase, type: z.literal("get_messages") }),
   z.object({ ...OmpCommandBase, type: z.literal("get_available_models") }),
   z.object({
@@ -561,6 +562,23 @@ export const OmpCommandsResultSchema = z
   .passthrough();
 export const OmpHostToolsResultSchema = z
   .object({ toolNames: z.array(z.string()).optional() })
+  .passthrough();
+export const OmpSubagentSnapshotSchema = z
+  .object({
+    id: z.string(),
+    index: z.number().int().nonnegative(),
+    agent: z.string(),
+    description: z.string().optional(),
+    status: OmpSubagentStatusSchema,
+    task: z.string().optional(),
+    assignment: z.string().optional(),
+    sessionFile: z.string().optional(),
+    parentToolCallId: z.string().optional(),
+    lastUpdate: z.number().optional(),
+  })
+  .passthrough();
+export const OmpSubagentsResultSchema = z
+  .object({ subagents: z.array(OmpSubagentSnapshotSchema).optional() })
   .passthrough();
 export const OmpBranchResultSchema = z
   .object({ text: z.string().optional(), cancelled: z.boolean().optional() })
@@ -613,18 +631,7 @@ export type OmpAvailableCommandsUpdateEvent = z.infer<typeof OmpAvailableCommand
 export type OmpRpcCommand = z.infer<typeof OmpRpcCommandSchema>;
 export type OmpPromptAck = z.infer<typeof OmpPromptAckSchema> & { requestId?: string };
 
-export interface OmpSubagentSnapshot {
-  id: string;
-  index: number;
-  agent: string;
-  description?: string;
-  status: OmpSubagentStatus;
-  task?: string;
-  assignment?: string;
-  sessionFile?: string;
-  parentToolCallId?: string;
-  lastUpdate?: number;
-}
+export type OmpSubagentSnapshot = z.infer<typeof OmpSubagentSnapshotSchema>;
 
 export interface OmpSubagentMessagesResult {
   sessionFile: string;

--- a/packages/server/src/server/agent/providers/omp/runtime.ts
+++ b/packages/server/src/server/agent/providers/omp/runtime.ts
@@ -9,6 +9,7 @@ import type {
   OmpRuntimeEvent,
   OmpSessionState,
   OmpSessionStats,
+  OmpSubagentSnapshot,
   OmpSubagentSubscriptionLevel,
   OmpThinkingLevel,
 } from "./rpc-types.js";
@@ -52,6 +53,7 @@ export interface OmpRuntimeSession {
   setAutoCompaction(enabled: boolean): Promise<void>;
   abort(): Promise<void>;
   getState(): Promise<OmpSessionState>;
+  getSubagents(): Promise<OmpSubagentSnapshot[]>;
   getMessages(): Promise<OmpAgentMessage[]>;
   getAvailableModels(timeoutMs?: number | null): Promise<OmpModel[]>;
   setModel(provider: string, modelId: string): Promise<OmpModel>;

--- a/packages/server/src/server/agent/providers/omp/subagent-index.test.ts
+++ b/packages/server/src/server/agent/providers/omp/subagent-index.test.ts
@@ -114,4 +114,52 @@ describe("OMP provider subagent mapper", () => {
       })[0],
     ).toMatchObject({ event: { id: "child-1", status: "canceled" } });
   });
+
+  test("treats a listed snapshot as running and its later absence as completed", () => {
+    const index = new OmpSubagentIndex();
+    const parent = {};
+
+    expect(
+      index.reconcileSnapshots(parent, [
+        {
+          id: "child-1",
+          index: 0,
+          agent: "ApiBudgetAudit",
+          status: "running",
+          parentToolCallId: "task-1",
+        },
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        event: {
+          type: "upsert",
+          id: "child-1",
+          title: "ApiBudgetAudit",
+          description: null,
+          status: "running",
+          toolCallId: "task-1",
+        },
+      }),
+    ]);
+    expect(index.hasRunning(parent)).toBe(true);
+
+    expect(index.reconcileSnapshots(parent, [])[0]).toMatchObject({
+      event: { type: "upsert", id: "child-1", status: "completed" },
+    });
+    expect(index.hasRunning(parent)).toBe(false);
+  });
+
+  test("does not complete a lifecycle-only child from an empty snapshot", () => {
+    const index = new OmpSubagentIndex();
+    const parent = {};
+    index.handleLifecycle(parent, {
+      id: "child-1",
+      agent: "worker",
+      status: "started",
+      index: 0,
+    });
+
+    expect(index.reconcileSnapshots(parent, [])).toEqual([]);
+    expect(index.hasRunning(parent)).toBe(true);
+  });
 });

--- a/packages/server/src/server/agent/providers/omp/subagent-index.test.ts
+++ b/packages/server/src/server/agent/providers/omp/subagent-index.test.ts
@@ -162,4 +162,30 @@ describe("OMP provider subagent mapper", () => {
     expect(index.reconcileSnapshots(parent, [])).toEqual([]);
     expect(index.hasRunning(parent)).toBe(true);
   });
+
+  test("links children to their parent task call for deferred card settlement", () => {
+    const index = new OmpSubagentIndex();
+    const parent = {};
+    index.handleLifecycle(parent, {
+      id: "child-1",
+      agent: "worker",
+      status: "started",
+      parentToolCallId: "task-1",
+      index: 0,
+    });
+
+    expect(index.hasLinkedChild(parent, "task-1")).toBe(true);
+    expect(index.hasLinkedChild(parent, "task-other")).toBe(false);
+    expect(index.hasRunningLinkedTo(parent, "task-1")).toBe(true);
+
+    index.handleLifecycle(parent, {
+      id: "child-1",
+      agent: "worker",
+      status: "completed",
+      parentToolCallId: "task-1",
+      index: 0,
+    });
+    expect(index.hasLinkedChild(parent, "task-1")).toBe(true);
+    expect(index.hasRunningLinkedTo(parent, "task-1")).toBe(false);
+  });
 });

--- a/packages/server/src/server/agent/providers/omp/subagent-index.ts
+++ b/packages/server/src/server/agent/providers/omp/subagent-index.ts
@@ -7,6 +7,7 @@ import type {
   OmpSubagentEventPayload,
   OmpSubagentLifecyclePayload,
   OmpSubagentProgressPayload,
+  OmpSubagentSnapshot,
 } from "./rpc-types.js";
 
 interface OmpSubagentState {
@@ -15,6 +16,7 @@ interface OmpSubagentState {
   resolvedModel: string | null;
   toolCallId: string | null;
   status: "running" | "completed" | "failed" | "canceled";
+  seenInSnapshot: boolean;
   mapper: OmpHistoryMapper;
 }
 
@@ -64,6 +66,54 @@ export class OmpSubagentIndex {
     );
   }
 
+  hasRunning(parent: object): boolean {
+    const states = this.statesByParent.get(parent);
+    if (!states) {
+      return false;
+    }
+    for (const state of states.values()) {
+      if (state.status === "running") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Merge a successful `get_subagents` reply. That RPC lists only still-running
+   * children: an id that previously appeared and is now missing is finished.
+   * Never-listed lifecycle children stay running so an empty first reply cannot
+   * kill a child whose started frame beat the first snapshot.
+   */
+  reconcileSnapshots(parent: object, snapshots: OmpSubagentSnapshot[]): AgentStreamEvent[] {
+    const present = new Set<string>();
+    const events: AgentStreamEvent[] = [];
+
+    for (const snapshot of snapshots) {
+      present.add(snapshot.id);
+      const state = this.stateFor(parent, snapshot.id, snapshot.agent);
+      state.seenInSnapshot = true;
+      state.title = snapshot.agent || state.title;
+      state.description = snapshot.description ?? snapshot.assignment ?? state.description;
+      state.toolCallId = snapshot.parentToolCallId ?? state.toolCallId;
+      state.status = mapSnapshotStatus(snapshot.status);
+      events.push(this.upsert(snapshot.id, state.status, state));
+    }
+
+    const states = this.statesByParent.get(parent);
+    if (!states) {
+      return events;
+    }
+    for (const [id, state] of states) {
+      if (state.status !== "running" || !state.seenInSnapshot || present.has(id)) {
+        continue;
+      }
+      state.status = "completed";
+      events.push(this.upsert(id, state.status, state));
+    }
+    return events;
+  }
+
   terminalizeRunning(parent: object): AgentStreamEvent[] {
     const states = this.statesByParent.get(parent);
     if (!states) {
@@ -94,6 +144,7 @@ export class OmpSubagentIndex {
       resolvedModel: null,
       toolCallId: null,
       status: "running",
+      seenInSnapshot: false,
       mapper: new OmpHistoryMapper("omp", [], OMP_HISTORY_MAPPER_HOOKS),
     };
     states.set(id, state);
@@ -135,6 +186,13 @@ function mapLifecycleStatus(
 
 function mapProgressStatus(
   status: OmpSubagentProgressPayload["progress"]["status"],
+): "running" | "completed" | "failed" | "canceled" {
+  if (status === "completed" || status === "failed") return status;
+  return status === "aborted" ? "canceled" : "running";
+}
+
+function mapSnapshotStatus(
+  status: OmpSubagentSnapshot["status"],
 ): "running" | "completed" | "failed" | "canceled" {
   if (status === "completed" || status === "failed") return status;
   return status === "aborted" ? "canceled" : "running";

--- a/packages/server/src/server/agent/providers/omp/subagent-index.ts
+++ b/packages/server/src/server/agent/providers/omp/subagent-index.ts
@@ -79,6 +79,32 @@ export class OmpSubagentIndex {
     return false;
   }
 
+  hasLinkedChild(parent: object, toolCallId: string): boolean {
+    const states = this.statesByParent.get(parent);
+    if (!states) {
+      return false;
+    }
+    for (const state of states.values()) {
+      if (state.toolCallId === toolCallId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  hasRunningLinkedTo(parent: object, toolCallId: string): boolean {
+    const states = this.statesByParent.get(parent);
+    if (!states) {
+      return false;
+    }
+    for (const state of states.values()) {
+      if (state.toolCallId === toolCallId && state.status === "running") {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Merge a successful `get_subagents` reply. That RPC lists only still-running
    * children: an id that previously appeared and is now missing is finished.

--- a/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/fake-omp.ts
@@ -131,6 +131,7 @@ export class FakeOmpSession implements OmpRuntimeSession {
   compactError: Error | null = null;
   emitCompactEnd = true;
   getStateError: Error | null = null;
+  getSubagentsError: Error | null = null;
   promptAck: OmpPromptAck = {};
   branchResponse: { text?: string; cancelled?: boolean } = { text: "" };
   branchMessages: Array<{ entryId: string; text: string }> = [];
@@ -357,6 +358,9 @@ export class FakeOmpSession implements OmpRuntimeSession {
   }
 
   async getSubagents(): Promise<FakeOmpSubagentSnapshot[]> {
+    if (this.getSubagentsError) {
+      throw this.getSubagentsError;
+    }
     return this.subagents;
   }
 

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -247,6 +247,17 @@ export class OmpHarness {
     return { completion: run };
   }
 
+  startAutonomousTurnUntilProviderIdle(
+    output: string,
+    providerState: { isStreaming: boolean; isCompacting: boolean },
+  ): void {
+    const runtime = this.omp.latestSession();
+    runtime.beginTurn();
+    runtime.streamAssistantText(output);
+    runtime.state = { ...runtime.state, ...providerState };
+    runtime.finishTurn();
+  }
+
   waitForProviderStateChecks(count: number): Promise<void> {
     return this.omp.latestSession().waitForStateRequests(count);
   }
@@ -404,6 +415,10 @@ export class OmpHarness {
       if (event.type === "timeline") items.push(event.item);
     }
     return items;
+  }
+
+  failedTurns(): Array<Extract<AgentStreamEvent, { type: "turn_failed" }>> {
+    return this.events.flatMap((event) => (event.type === "turn_failed" ? [event] : []));
   }
 
   completedTurnCount(): number {


### PR DESCRIPTION
> **Draft, and not mine to merge. Do not merge before #3371.** The first two commits are @jasonhnd's, unmodified — merging this as-is would land #3371 without its own review. If @jasonhnd would rather take the last three commits onto `fix/2232-omp-idle-gate` and carry them in #3371, that's my preference too; say the word and I'll close this.

Fixes #3654. This branch is #3371's head (`fa9fc5e62`) plus three commits. GitHub shows all five until #3371 merges; **review only the last three**.

I cannot push to this repository, so I cannot open this against a base branch holding #3371's commits. Once #3371 lands on `main`, this narrows to its own three commits automatically. Merges cleanly into current `main` (`8f0c35e92`); no omp drift since #3371's base.

I cannot push to this repository, so I cannot open this against a base branch holding #3371's commits. If a maintainer creates that branch here, or once #3371 lands on `main`, this PR narrows to its own three commits automatically. Merges cleanly into current `main` (`8f0c35e92`); no omp drift since #3371's base.

## Problem

`completeTurnAfterProviderIdle()` polls `get_state` every 10 ms after an assistant-bearing `agent_end`, swallows every error, and has no deadline. If OMP reports a stale state or the state RPC keeps failing, the turn shows as running until the user cancels — and `startTurn` throws while a turn is active, so the session is wedged for new prompts. The only signal is a `logger.debug` line, and the daemon runs at info level, so nothing surfaces.

The loop has not changed since it shipped in #2067, and the two tests that pin the unbounded wait came in that same commit. #2261 and #2282 both fixed *reaching* the gate and explicitly kept it as-is ("the change does not synthesize idle or add a timeout"). #3371 adds a third reason to wait inside it — hence the stack.

`can1357/oh-my-pi#6916` is a field occurrence of the symptom: a session held `running` for 25m44s after the final answer, cleared only by a forced cancel. It is still open, waiting on RPC evidence the host never emitted.

## Change

**Budgets.** `OmpProviderIdleScheduler.waitForRetry()` takes `{ attempt, consecutiveFailures, elapsedMs, isCompacting, isWaitingOnSubagents }` and returns `{retry: true} | {retry: false, reason}`. The default scheduler backs off 10 ms → 1 s and gives up after 3 consecutive `get_state` rejections, after 60 s of monotonic wall clock, or after 10 minutes if OMP reports compaction. Wall clock rather than a retry count is deliberate: each `get_state` carries the JSONL-RPC request timeout, so counting attempts would let a slow-but-answering state path stretch the wait to tens of minutes. Compaction gets its own budget because the gate waits for `isCompacting` to clear and compacting a large context routinely outlasts 60 s.

**The subagent wait from #3371.** A `get_subagents` reply listing running children is positive evidence OMP is working, and a fan-out has no bounded length, so the wait budget does not apply while that evidence is current. It resumes the moment `get_subagents` stops answering — which is the stuck-parent risk that closed #2245: an index still holding children it can no longer confirm no longer holds the turn open forever. The `get_state` failure budget applies throughout.

**Structured failure.** On abandon the turn fails with `omp_provider_idle_timeout` or `omp_provider_state_unavailable`; a gate that never observed any state reports `state_unavailable` whichever budget ran out, because a hanging `get_state` burns the wait budget before three rejections can land. The diagnostic carries the last observed `isStreaming`/`isCompacting`, the last RPC error, and whether subagents were still reported running, and it logs at `warn`. `turn_failed` already carries `code` and `diagnostic`, so there is no `packages/protocol` change and nothing to gate on `server_info.features`. The turn state is cleared, so recovery is an ordinary prompt.

**One gate per turn.** Every `agent_end` used to open another concurrent loop, and two loops that both observed idle each called `completeTurn` — two `turn_completed` for one turn, reproduced in the harness. Gates are keyed on the turn ID, with a shared key for autonomous cycles, which poll like any other gate. The gate holds the terminal payload and the newest `agent_end` overwrites it, unless that would discard an error the gate already holds.

**Ownership.** Ownership is re-checked before completing and before failing, not only at the top of each poll. Both sites sit after two awaits, and a `get_state` carries the 30 s RPC timeout, so a cancel-then-reprompt could otherwise let a stale gate fail the cancelled turn, cancel the new turn's tool calls, and clear its turn ID — after which its events go out with no turn ID and the manager back-fills whatever turn is active.

**Terminalize on stall.** A stall leaves OMP's state unknown, so tool calls and subagents still marked running are cancelled; otherwise they spin with no turn left to finish them.

The safety property holds: no ordinary `turn_completed` while OMP reports streaming, compacting, or running children, and a healthy state response before the budget still completes exactly once. #3371's tests and the two pre-existing gate tests are unchanged and pass.

## Tests

Sixteen new tests in `packages/server/src/server/agent/providers/omp/agent.test.ts`, each written before its production change and watched fail — except the two that drive `createOmpProviderIdleScheduler()` directly, whose pre-change failure was an import error rather than a behavioral one.

- exactly one completion when OMP repeats `agent_end`, foreground and autonomous
- turn fails on wait-budget expiry and on repeated `get_state` failures, with the right code each time
- a wait-budget expiry whose last check failed keeps both the state and the error in the diagnostic
- a gate that never observed a state reports `state_unavailable`
- newest `agent_end` error wins over the first snapshot, and an earlier error survives a later error-free cycle
- a stale gate does not fail or clear a turn that started after it was abandoned
- the session reports observed compaction, elapsed time, and the subagent wait to the scheduler
- the subagent wait stops being trusted once `get_subagents` stops answering
- in-flight tool calls are cancelled when the gate gives up
- a new prompt is accepted after a stalled turn fails
- the default scheduler's budget decisions, including compaction and subagent waits

## QA

- `npx vitest run packages/server/src/server/agent/providers/omp` — 19 files, 143 tests pass
- `npm run lint` on the omp provider — 0 warnings, 0 errors
- `npm run format:check` — clean

`npm run typecheck` in my checkout reports missing-module errors for `@replit/codemirror-lang-csharp` and `@paseo/plugin` at this base; those come from resolving my `node_modules` against a different lockfile, not from these commits. CI is the authority.

Not exercised against a live OMP process; the harness reproduces every failure mode deterministically. This surfaces a stall with the last state and RPC error but does not persist raw child RPC frames, which is the evidence `oh-my-pi#6916` is still waiting on.
