### PR TITLE
fix(app): keep the composer input growing as you type on native

### DIFF
--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -990,15 +990,13 @@ function resolveMaxInputHeight(windowHeight: number): number {
   return Math.max(DEFAULT_MAX_INPUT_HEIGHT, Math.floor(windowHeight * MAX_INPUT_VIEWPORT_RATIO));
 }
 
+// The composer input is uncontrolled on native (PasteInput owns the text), so it
+// no longer re-measures itself as you type the way a controlled RN TextInput did.
+// Drive the height explicitly from the onContentSizeChange measurement on every
+// platform so the box grows instead of scrolling inside a fixed min-height frame.
 function computeTextInputHeightStyle(inputHeight: number, maxInputHeight: number) {
-  if (isWeb) {
-    return {
-      height: inputHeight,
-      minHeight: MIN_INPUT_HEIGHT,
-      maxHeight: maxInputHeight,
-    };
-  }
   return {
+    height: inputHeight,
     minHeight: MIN_INPUT_HEIGHT,
     maxHeight: maxInputHeight,
   };
@@ -1838,7 +1836,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               onFocus={handleInputFocus}
               onBlur={handleInputBlur}
               editable={!isDictating && !isRealtimeVoiceForCurrentAgent && !disabled}
-              scrollEnabled={isWeb ? inputHeight >= maxInputHeight : true}
+              scrollEnabled={inputHeight >= maxInputHeight}
               autoFocus={false}
               onContentSizeChange={handleContentSizeChange}
               onKeyPress={shouldHandleWebKeyPress ? handleDesktopKeyPress : undefined}


### PR DESCRIPTION
## Problem

In the 0.5.0 beta the chat composer's text input no longer grows taller as you add lines on native (iOS/Android) — it stays at its minimum height and scrolls internally instead of expanding up to the max height like it did in v0.4.0.

## Root cause

The composer's native auto-grow was never self-contained. It relied on the input being a **controlled** RN `TextInput` (`value=`), whose per-keystroke value change forced the native shadow node to re-measure and grow the frame.

[#3343](https://github.com/getpaseo/paseo/pull/3343) (first shipped in `v0.5.0-beta.1`) routed the composer through `@mattermost/react-native-paste-input`'s `PasteInput`, rendered **uncontrolled** (`defaultValue=`, via `EditingTextInput`). The native view now owns the text and JS no longer re-renders per keystroke, so the implicit re-measure disappears.

Meanwhile `computeTextInputHeightStyle` only applied the `onContentSizeChange`-measured `inputHeight` on **web** — on native it set just `minHeight`/`maxHeight` and never applied the measured height. That was harmless while the input was controlled, but with the uncontrolled `PasteInput` nothing drives the height anymore, so the box is stuck at `MIN_INPUT_HEIGHT` and scrolls internally (`scrollEnabled` was hard-coded `true` on native).

Return still inserts a newline — what regressed is the container growing.

## Fix

- Apply `height: inputHeight` on **every** platform in `computeTextInputHeightStyle`, so the existing `onContentSizeChange → setBoundedInputHeight → inputHeight` loop actually resizes the box. This removes the dependence on the input being controlled.
- Gate `scrollEnabled` on `inputHeight >= maxInputHeight` on native the same way web already did, so it scrolls only after hitting the cap.

The web branches of both expressions are unchanged, so web behavior is identical by construction; the only behavioral change is native.

## Verification

- [x] `npm run typecheck` / `npm run lint` / `npm run format:check` all pass.
- [ ] On-device / iOS simulator QA: type several lines in the composer and confirm the box grows to the max height then scrolls (see docs/qa.md evidence bar).

RCA: `vault/rca/RCA-2026-08-21-paseo-composer-input-stops-auto-growing-ios.md`