### PR TITLE
Prevent managed agents from stopping the daemon

### DIFF
--- a/packages/cli/src/commands/daemon/agent-process-control.test.ts
+++ b/packages/cli/src/commands/daemon/agent-process-control.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { rejectAgentProcessControl } from "./agent-process-control.js";
+
+describe("rejectAgentProcessControl", () => {
+  test("allows daemon process control outside a managed agent", () => {
+    expect(() => rejectAgentProcessControl("stop", {})).not.toThrow();
+    expect(() => rejectAgentProcessControl("restart", { PASEO_AGENT_ID: "  " })).not.toThrow();
+  });
+
+  test.each(["stop", "restart"] as const)(
+    "rejects daemon %s from a managed agent and directs it to supervised restart",
+    (action) => {
+      expect(() => rejectAgentProcessControl(action, { PASEO_AGENT_ID: "agent-1" })).toThrow(
+        expect.objectContaining({
+          code: "UNSAFE_AGENT_DAEMON_PROCESS_CONTROL",
+          message: `A managed Paseo agent cannot run 'paseo daemon ${action}' safely.`,
+          details:
+            "Use the restart_daemon Paseo tool. The supervisor will restart the worker and monitor its heartbeat.",
+        }),
+      );
+    },
+  );
+});

--- a/packages/cli/src/commands/daemon/agent-process-control.ts
+++ b/packages/cli/src/commands/daemon/agent-process-control.ts
@@ -1,0 +1,20 @@
+import type { CommandError } from "../../output/index.js";
+
+type AgentProcessControlAction = "stop" | "restart";
+
+export function rejectAgentProcessControl(
+  action: AgentProcessControlAction,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!env.PASEO_AGENT_ID?.trim()) {
+    return;
+  }
+
+  const error: CommandError = {
+    code: "UNSAFE_AGENT_DAEMON_PROCESS_CONTROL",
+    message: `A managed Paseo agent cannot run 'paseo daemon ${action}' safely.`,
+    details:
+      "Use the restart_daemon Paseo tool. The supervisor will restart the worker and monitor its heartbeat.",
+  };
+  throw error;
+}

--- a/packages/cli/src/commands/daemon/restart.ts
+++ b/packages/cli/src/commands/daemon/restart.ts
@@ -11,6 +11,7 @@ import type {
   OutputSchema,
   CommandError,
 } from "../../output/index.js";
+import { rejectAgentProcessControl } from "./agent-process-control.js";
 
 interface RestartResult {
   action: "restarted";
@@ -80,6 +81,7 @@ export async function runRestartCommand(
   options: CommandOptions,
   _command: Command,
 ): Promise<RestartCommandResult> {
+  rejectAgentProcessControl("restart");
   const timeoutMs = parseTimeoutMs(options.timeout);
   const force = options.force === true;
   const startOptions = toStartOptions(options);

--- a/packages/cli/src/commands/daemon/stop.ts
+++ b/packages/cli/src/commands/daemon/stop.ts
@@ -10,6 +10,7 @@ import type {
   OutputSchema,
   CommandError,
 } from "../../output/index.js";
+import { rejectAgentProcessControl } from "./agent-process-control.js";
 
 interface StopResult {
   action: "stopped" | "not_running";
@@ -59,6 +60,7 @@ export async function runStopCommand(
   options: CommandOptions,
   _command: Command,
 ): Promise<StopCommandResult> {
+  rejectAgentProcessControl("stop");
   const home = typeof options.home === "string" ? options.home : undefined;
   const force = options.force === true;
   const timeoutMs = parseSecondsOption(options.timeout, DEFAULT_STOP_TIMEOUT_MS, "timeout");

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -1564,6 +1564,35 @@ describe("create_agent MCP tool", () => {
     expect(lookupTool(server, "update_heartbeat")).toBeUndefined();
   });
 
+  it("exposes supervised daemon restart only to agent-scoped tool catalogs", async () => {
+    const { agentManager, agentStorage } = createTestDeps();
+    const restartRequests: string[] = [];
+    const agentServer = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      callerAgentId: "agent-1",
+      requestDaemonRestart: (callerAgentId) => restartRequests.push(callerAgentId),
+      logger,
+    });
+    const topLevelServer = await createAgentMcpServer({
+      agentManager,
+      agentStorage,
+      providerSnapshotManager: createOpenCodeManager().manager,
+      requestDaemonRestart: (callerAgentId) => restartRequests.push(callerAgentId),
+      logger,
+    });
+
+    expect(lookupTool(topLevelServer, "restart_daemon")).toBeUndefined();
+    const response = await invokeToolWithParsedInput(
+      registeredTool(agentServer, "restart_daemon"),
+      {},
+    );
+
+    expect(response.structuredContent).toEqual({ status: "restart_requested" });
+    expect(restartRequests).toEqual(["agent-1"]);
+  });
+
   it("surfaces createAgent validation failures", async () => {
     const { agentManager, agentStorage, spies } = createTestDeps();
     spies.agentManager.createAgent.mockRejectedValue(

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -141,6 +141,7 @@ export interface PaseoToolHostDependencies {
    */
   resolveSpeakHandler?: (callerAgentId: string) => VoiceSpeakHandler | null;
   resolveCallerContext?: (callerAgentId: string) => VoiceCallerContext | null;
+  requestDaemonRestart?: (callerAgentId: string) => void;
   enableVoiceTools?: boolean;
   voiceOnly?: boolean;
   logger: Logger;
@@ -1206,6 +1207,26 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
       callerAgentId,
       resolveCallerAgent,
     });
+  }
+
+  if (callerAgentId && options.requestDaemonRestart) {
+    registerTool(
+      "restart_daemon",
+      {
+        title: "Restart daemon",
+        description:
+          "Request one atomic supervisor-owned daemon restart. Use this instead of stopping and starting the daemon. Your connection will drop while the supervisor starts a healthy worker; do not retry the request.",
+        inputSchema: {},
+        outputSchema: { status: z.literal("restart_requested") },
+      },
+      async () => {
+        options.requestDaemonRestart?.(callerAgentId);
+        return {
+          content: [],
+          structuredContent: ensureValidJson({ status: "restart_requested" }),
+        };
+      },
+    );
   }
 
   registerTool(

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -1370,6 +1370,15 @@ export async function createPaseoDaemon(
     voiceOnly: runtime.voiceOnly,
     resolveSpeakHandler: (agentId) => wsServer?.resolveVoiceSpeakHandler(agentId) ?? null,
     resolveCallerContext: (agentId) => wsServer?.resolveVoiceCallerContext(agentId) ?? null,
+    requestDaemonRestart: config.onLifecycleIntent
+      ? (agentId) =>
+          config.onLifecycleIntent?.({
+            type: "restart",
+            clientId: `agent:${agentId}`,
+            requestId: `tool:restart_daemon:${agentId}`,
+            reason: "agent_tool_restart",
+          })
+      : undefined,
     logger,
   });
   const createAgentToolCatalog = (runtime: PaseoToolRuntimeContext) =>


### PR DESCRIPTION
## Summary
- add an agent-scoped `restart_daemon` tool that requests an atomic supervisor-owned worker restart
- reject process-level `paseo daemon stop` and `paseo daemon restart` from managed-agent environments
- direct agents to the supervised restart path backed by the existing worker heartbeat watchdog

## Validation
- `npx vitest run packages/cli/src/commands/daemon/agent-process-control.test.ts --bail=1` (3 passed)
- `npx vitest run packages/server/src/server/agent/mcp-server.test.ts --bail=1` (118 passed)
- `npm run build:server`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

## LLM Agent Disclosure
This PR was generated and validated by an LLM agent (Codex), with user-directed oversight.
