### PR TITLE
fix(server): bound the OpenCode SSE connect phase

### DIFF
--- a/packages/server/src/server/agent/providers/opencode/event-consumer.test.ts
+++ b/packages/server/src/server/agent/providers/opencode/event-consumer.test.ts
@@ -8,6 +8,12 @@ import {
   type OpenCodeEventSourceInput,
 } from "./event-consumer.js";
 
+// Deliberately independent literals rather than the production constants these tests
+// guard: deriving them from CONNECT_WATCHDOG_MS/WATCHDOG_MS would keep the tests green if
+// those constants were changed.
+const EXPECTED_CONNECT_WATCHDOG_MS = 10_000;
+const EXPECTED_STREAM_WATCHDOG_MS = 30_000;
+
 describe("OpenCodeEventConsumer", () => {
   const cleanups: Array<() => Promise<void>> = [];
   afterEach(async () => {
@@ -101,7 +107,13 @@ describe("OpenCodeEventConsumer", () => {
     await consumer.ready();
 
     timing.expireWatchdog();
-    expect(timing.watchdogDelays).toEqual([30_000, 30_000]);
+    // Connect deadline first, then the stream watchdog re-armed on the response and again
+    // on the delivered record.
+    expect(timing.watchdogDelays).toEqual([
+      EXPECTED_CONNECT_WATCHDOG_MS,
+      EXPECTED_STREAM_WATCHDOG_MS,
+      EXPECTED_STREAM_WATCHDOG_MS,
+    ]);
     await timing.waiting();
     timing.advanceWait();
     await upstream.connected(2);
@@ -227,6 +239,60 @@ describe("OpenCodeEventConsumer", () => {
     upstream.send(0, connectedRecord("/ready"));
     await consumer.ready();
     expect(timing.waitDelays).toEqual([100, 200]);
+  });
+
+  test("abandons a connect that never responds and recovers on the retry", async () => {
+    const upstream = await createSseUpstream();
+    const timing = new ControlledTiming();
+    const realClient = createOpencodeClient({ baseUrl: upstream.url });
+    let attempts = 0;
+    const consumer = new OpenCodeEventConsumer({
+      serverUrl: upstream.url,
+      processExit: new Promise<Error>(() => undefined),
+      timing,
+      createClient: () =>
+        ({
+          ...realClient,
+          global: {
+            ...realClient.global,
+            event: (options: { signal: AbortSignal }) => {
+              attempts += 1;
+              if (attempts > 1) return realClient.global.event(options as never);
+              // OpenCode can accept the socket and then never send a response, so this
+              // request only ever settles by being aborted.
+              return new Promise((_resolve, reject) => {
+                options.signal.addEventListener(
+                  "abort",
+                  () => reject(options.signal.reason ?? new Error("aborted")),
+                  { once: true },
+                );
+              });
+            },
+          },
+        }) as OpencodeClient,
+    });
+    cleanups.push(async () => {
+      await consumer.close();
+      await upstream.close();
+    });
+
+    // The connect deadline is armed without any response having arrived.
+    await eventually(() => expect(timing.watchdogDelays).toEqual([EXPECTED_CONNECT_WATCHDOG_MS]));
+    expect(attempts).toBe(1);
+    expect(upstream.requests).toHaveLength(0);
+    expect(await promiseState(consumer.ready())).toBe("pending");
+
+    timing.expireWatchdog();
+
+    await timing.waiting();
+    expect(timing.waitDelays).toEqual([100]);
+    expect(await promiseState(consumer.ready())).toBe("pending");
+    timing.advanceWait();
+
+    await upstream.connected(1);
+    expect(attempts).toBe(2);
+    upstream.send(0, connectedRecord("/recovered"));
+    await expect(consumer.ready()).resolves.toBeUndefined();
   });
 
   test("disables SDK SSE retries at the real request seam", async () => {

--- a/packages/server/src/server/agent/providers/opencode/event-consumer.ts
+++ b/packages/server/src/server/agent/providers/opencode/event-consumer.ts
@@ -27,6 +27,13 @@ export interface OpenCodeEventConsumerOptions {
 }
 
 const WATCHDOG_MS = 30_000;
+/**
+ * Deadline for the request itself to produce a response. OpenCode can accept the socket
+ * and then never send headers, which leaves the stream neither open nor failed, so the
+ * reconnect loop below never runs. A connect-phase deadline turns that into a normal
+ * failed connection the loop can retry.
+ */
+const CONNECT_WATCHDOG_MS = 10_000;
 const MAX_BACKOFF_MS = 5_000;
 
 const systemTiming: OpenCodeEventConsumerTiming = {
@@ -115,15 +122,17 @@ export class OpenCodeEventConsumer implements OpenCodeEventSource {
     signal.addEventListener("abort", abortRequest, { once: true });
     let cancelWatchdog: () => void = () => undefined;
     let delivered = false;
+    const armWatchdog = (delayMs: number = WATCHDOG_MS) => {
+      cancelWatchdog();
+      cancelWatchdog = this.timing.arm(delayMs, () => requestAbort.abort());
+    };
     try {
+      // Armed before the request so a response that never arrives is bounded too.
+      armWatchdog(CONNECT_WATCHDOG_MS);
       const result = await this.client.global.event({
         signal: requestAbort.signal,
         sseMaxRetryAttempts: 0,
       });
-      const armWatchdog = () => {
-        cancelWatchdog();
-        cancelWatchdog = this.timing.arm(WATCHDOG_MS, () => requestAbort.abort());
-      };
       armWatchdog();
       for await (const event of result.stream) {
         if (this.closed) return delivered;


### PR DESCRIPTION
### Linked issue

No separate issue filed yet. Same failure surface as #3571, which #3578 and #3621 (both
merged) addressed from the timeout side; this one is the remaining cause underneath them.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Agent creation intermittently fails with `OpenCode event stream first record` while the
OpenCode server is healthy and has already created the session. #3578 raised that wait to
30s and #3621 stops the outer run-start gate from firing first, but neither helps when the
SSE connection never produces a response at all: `consumeConnection()` awaits
`this.client.global.event(...)` with no deadline, and the silent-stream watchdog is armed
only after that await resolves. If the response never arrives, the request hangs forever,
the reconnect loop in `consume()` never runs because the connection never ends, and
`ready()` never settles until something outside kills the turn.

The trigger is on the OpenCode side: a client that subscribes to `/global/event` at the
instant the port starts accepting gets orphaned — the server keeps the socket but never
writes to it, not even the heartbeats it delivers to other listeners. Paseo connects as
early as it possibly can, so it lands in exactly that window. Raw repro below.

That's an OpenCode bug and it should be fixed there, but Paseo shouldn't hang indefinitely
on a socket that a provider has silently abandoned. This PR is the client-side defense: put
a deadline on the connect phase so an orphaned connection becomes an ordinary failed
connection, which the existing backoff loop already knows how to retry.

### Goals

- Bound the connect phase so a response that never arrives cannot hang the consumer forever.
- Recover through the existing reconnect/backoff path rather than adding a second one.
- Leave in-stream behavior exactly as it is: 30s of silence on an established stream still
  triggers the same reconnect.
- A regression test that fails on the current code for the reported reason.

### Non-goals

- Not fixing the OpenCode-side bug. The orphaned early subscriber is upstream's; this only
  stops Paseo from waiting on it forever.
- Not adding a delay or a readiness probe before subscribing. Connecting early is correct;
  it just needs a deadline.
- Not touching `WATCHDOG_MS`, the backoff schedule, `sseMaxRetryAttempts`, or any of the
  timeouts changed in #3578 / #3621.
- No new configuration surface.

### Repro: OpenCode orphans an early `/global/event` subscriber

OpenCode v1.18.18, plugins disabled via an empty config to rule them out. Start
`opencode serve`, then attach `curl` to `GET /global/event` at different delays measured
from the moment the TCP port starts accepting connections:

| curl attached at | First bytes received      | Subsequent `server.heartbeat` |
| ---------------- | ------------------------- | ----------------------------- |
| +0s              | none for 40s+             | none                          |
| +1s              | `server.connected`, ~80ms | every 10s                     |
| +2s              | `server.connected`, ~80ms | every 10s                     |
| +4s              | `server.connected`, ~80ms | every 10s                     |
| +8s              | `server.connected`, ~80ms | every 10s                     |

The +0s connection received no response headers and no records for the full 40s+ observation
window. It did not even receive the `server.heartbeat` events that the server delivered to
the other listeners at the 10s and 20s marks, so the connection is accepted and then never
written to. It is not slow; it is orphaned.

### Production failure this causes

Observed on a Linux daemon. The OpenCode server was healthy throughout — it accepted the
port and completed `session.create` in ~12.5s — but the daemon's event stream connection was
the one attached at the instant the port opened. It never received a record. Agent creation
then failed at the run-start gate in the 60-76s range with
`OpenCode event stream first record`.

Before this change, that connection is unbounded: nothing in `consumeConnection()` can end
it, so the retry that would have succeeded never happens. Per the table above, a connection
attached even one second later succeeds in ~80ms, so the dead window is sub-second and a
single retry clears it.

### How

`armWatchdog` takes an optional delay defaulting to `WATCHDOG_MS`, and is hoisted above the
request so the connect phase can be armed with a shorter `CONNECT_WATCHDOG_MS` (10s) before
`global.event(...)` is awaited. When it fires, it aborts the request exactly the way the
in-stream watchdog already does; `consume()` sees a connection that delivered nothing and
retries on its normal backoff. After the response arrives, the watchdog is re-armed at
`WATCHDOG_MS` and everything downstream is unchanged.

### QA

New and updated tests use the class's injectable `timing` and `createClient` seams, and
assert against independent literals rather than the production constants they guard, per the
review feedback on #3621.

Affected suite:

    $ npx vitest run src/server/agent/providers/opencode/event-consumer.test.ts
    Test Files  1 passed (1)
    Tests  12 passed (12)

    $ npx vitest run src/server/agent/providers/opencode --exclude "**/*.e2e.test.ts"
    Test Files  12 passed (12)
    Tests  247 passed | 1 skipped (248)

Mutation checks — the fix reverted or the constants moved, confirming the tests bind the
behavior and the values rather than passing by construction:

(a) arming moved back to after the `await` (the current `main` behavior):

    Tests  2 failed | 10 passed (12)
      × abandons a connect that never responds and recovers on the retry
        AssertionError: expected [] to deeply equal [ 10000 ]
      × reconnects a stalled response without publishing a terminal
        AssertionError: expected [ 30000, 30000 ] to deeply equal [ 10000, 30000, 30000 ]

The new test fails for the reported reason: with arming after the await, no watchdog exists
during the connect phase at all, so an unanswered request is never bounded.

(b) `CONNECT_WATCHDOG_MS` 10_000 -> 25_000:

    Tests  2 failed | 10 passed (12)
      × abandons a connect that never responds and recovers on the retry
        AssertionError: expected [ 25000 ] to deeply equal [ 10000 ]
      × reconnects a stalled response without publishing a terminal
        AssertionError: expected [ 25000, 30000, 30000 ] to deeply equal [ 10000, 30000, 30000 ]

(c) `WATCHDOG_MS` 30_000 -> 45_000:

    Tests  1 failed | 11 passed (12)
      × reconnects a stalled response without publishing a terminal
        AssertionError: expected [ 10000, 45000, 45000 ] to deeply equal [ 10000, 30000, 30000 ]

All values restored and re-verified green afterwards.

Full server unit suite:

    $ npm run test:unit --workspace=@getpaseo/server
    Test Files  2 failed | 346 passed | 3 skipped (351)
    Tests  6 failed | 5119 passed | 51 skipped (5176)

The 2 failing files are pre-existing in this environment and unrelated to this change:
`claude/agent.test.ts` needs a Claude binary that isn't installed here, and
`hub/relationship-controller.test.ts` fails on its own. Verified by stashing this branch's
changes and running both files against a clean checkout of the same commit:

    $ git stash && npx vitest run src/server/agent/providers/claude/agent.test.ts \
        src/server/hub/relationship-controller.test.ts
    Test Files  2 failed (2)
    Tests  7 failed | 109 passed (116)

Baseline fails the same files (7 failures without the change, 6 with — the hub suite is
flaky in this environment).

Repo checks:

    $ npm run typecheck    # exit 0
    $ npm run lint         # Found 0 warnings and 0 errors. (3749 files, 177 rules)
    $ npm run format:check # exit 0 (3998 files)

### Platforms

| Platform        | Tested | Notes                                                        |
| --------------- | ------ | ------------------------------------------------------------ |
| iOS             | No     | No client code changed                                        |
| Android         | No     | No client code changed                                        |
| Web             | No     | No client code changed                                        |
| Desktop macOS   | No     | Daemon-side change, not platform specific                     |
| Desktop Windows | No     | Daemon-side change, not platform specific                     |
| Desktop Linux   | Yes    | Automated suite above; repro and production failure both here |

This is a daemon-side change to the OpenCode transport with no UI surface, so there is
nothing to screenshot. The repro table and the production failure were both captured on
Linux against a real OpenCode v1.18.18 server; the fix itself is covered by the automated
tests above, driven through the consumer's injectable client and timing seams.

### Tests

- `event-consumer.test.ts` — "abandons a connect that never responds and recovers on the
  retry" (new): the first `global.event(...)` never resolves and only settles when aborted.
  Asserts the connect deadline is armed with no response present, that `ready()` is still
  pending at that point, that expiring it produces a normal backoff retry (100ms), and that
  the second attempt reaches a real stream and resolves `ready()`.
- `event-consumer.test.ts` — "reconnects a stalled response without publishing a terminal"
  (extended, not duplicated): now asserts the full arming sequence
  `[10_000, 30_000, 30_000]`, pinning both that the connect phase is armed first and that
  in-stream silence still uses the unchanged 30s watchdog.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
