### PR TITLE
fix(app): stop draft pending leaking past consume (#3217)

### DIFF
--- a/packages/app/no-computed-destructuring-omit.test.ts
+++ b/packages/app/no-computed-destructuring-omit.test.ts
@@ -1,0 +1,82 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+// Guard for #3217. babel-preset-expo miscompiles a destructuring-omit whose
+// computed key is a *property/element/call access* (it needs a temp):
+//   const { [obj.key]: _unused, ...rest } = src
+// The preset drops the temp's assignment, so the omit excludes `undefined` and
+// removes nothing. Upstream: https://github.com/expo/expo/issues/49231
+// Until that lands, keep this shape out of our source — use a plain-identifier
+// key, or `const rest = { ...src }; delete rest[obj.key];`.
+
+const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), "src");
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.(test|spec)\.(ts|tsx)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// A computed key that babel lowers through a temp (the shape that breaks).
+// Plain identifiers and literals are safe.
+function keyNeedsTemp(expr: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(expr) ||
+    ts.isElementAccessExpression(expr) ||
+    ts.isCallExpression(expr)
+  );
+}
+
+function findViolations(fileName: string, text: string): number[] {
+  const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const lines: number[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isObjectBindingPattern(node) && node.elements.some((e) => e.dotDotDotToken)) {
+      for (const el of node.elements) {
+        const pn = el.propertyName;
+        if (pn && ts.isComputedPropertyName(pn) && keyNeedsTemp(pn.expression)) {
+          lines.push(sf.getLineAndCharacterOfPosition(el.getStart(sf)).line + 1);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return lines;
+}
+
+describe("no computed property-access key in a destructuring-omit (#3217)", () => {
+  it("detects the dangerous shape (self-check)", () => {
+    const bad = `const { [input.draftId]: _removed, ...rest } = state.map;`;
+    expect(findViolations("bad.ts", bad)).toHaveLength(1);
+    const safe = `const { [draftId]: _removed, ...rest } = state.map;`;
+    expect(findViolations("safe.ts", safe)).toHaveLength(0);
+  });
+
+  it("is absent from packages/app/src", () => {
+    const offenders: string[] = [];
+    for (const file of listSourceFiles(SRC_DIR)) {
+      const text = readFileSync(file, "utf8");
+      // cheap prefilter: needs a rest (`...`) and a computed key that contains a
+      // member access (`[ ... . ... ]:`) — the only shape that can trip the bug.
+      if (!text.includes("...") || !/\[[^\]\n]*\.[^\]\n]*\]\s*:/.test(text)) continue;
+      for (const line of findViolations(file, text)) {
+        offenders.push(`${file}:${line}`);
+      }
+    }
+    expect(
+      offenders,
+      `computed property-access destructuring-omit (miscompiled by babel-preset-expo, #3217):\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/app/src/stores/workspace-draft-submission-store.test.ts
+++ b/packages/app/src/stores/workspace-draft-submission-store.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AgentProvider } from "@getpaseo/protocol/agent-types";
+import {
+  type PendingWorkspaceDraftSubmission,
+  useWorkspaceDraftSubmissionStore,
+} from "./workspace-draft-submission-store";
+
+function buildSubmission(
+  overrides: Partial<PendingWorkspaceDraftSubmission> = {},
+): PendingWorkspaceDraftSubmission {
+  return {
+    serverId: "server-1",
+    workspaceId: "workspace-1",
+    draftId: "draft-1",
+    text: "hello",
+    attachments: [],
+    cwd: "/repo",
+    provider: "claude" as AgentProvider,
+    clientMessageId: "msg-1",
+    timestamp: 1,
+    ...overrides,
+  };
+}
+
+describe("workspace-draft-submission-store", () => {
+  beforeEach(() => {
+    useWorkspaceDraftSubmissionStore.setState({ pendingByDraftId: {}, setupByDraftId: {} });
+  });
+
+  // This is the single cross-instance dedupe the create path relies on: the
+  // first draft tab consumes the pending, the entry is removed, and every later
+  // tab gets null so it does not create a second agent. Regression guard for
+  // #3217, where a minifier miscompilation left the removal a no-op and produced
+  // N duplicate agents.
+  it("removes the pending on consume so a second consume returns null", () => {
+    const store = useWorkspaceDraftSubmissionStore.getState();
+    store.setPending(buildSubmission());
+
+    const first = store.consumePending({
+      serverId: "server-1",
+      workspaceId: "workspace-1",
+      draftId: "draft-1",
+    });
+    const second = store.consumePending({
+      serverId: "server-1",
+      workspaceId: "workspace-1",
+      draftId: "draft-1",
+    });
+
+    expect(first).not.toBeNull();
+    expect(first?.clientMessageId).toBe("msg-1");
+    expect(second).toBeNull();
+    // The entry must be gone — this is exactly what the miscompiled omit failed to do.
+    expect(useWorkspaceDraftSubmissionStore.getState().pendingByDraftId).toEqual({});
+  });
+
+  it("only removes the consumed draft, leaving other pending submissions intact", () => {
+    const store = useWorkspaceDraftSubmissionStore.getState();
+    store.setPending(buildSubmission({ draftId: "draft-1", clientMessageId: "msg-1" }));
+    store.setPending(buildSubmission({ draftId: "draft-2", clientMessageId: "msg-2" }));
+
+    store.consumePending({ serverId: "server-1", workspaceId: "workspace-1", draftId: "draft-1" });
+
+    const remaining = useWorkspaceDraftSubmissionStore.getState().pendingByDraftId;
+    expect(remaining["draft-1"]).toBeUndefined();
+    expect(remaining["draft-2"]?.clientMessageId).toBe("msg-2");
+  });
+
+  it("returns null when the pending does not match the requested identity", () => {
+    const store = useWorkspaceDraftSubmissionStore.getState();
+    store.setPending(buildSubmission({ draftId: "draft-1", workspaceId: "workspace-1" }));
+
+    const result = store.consumePending({
+      serverId: "server-1",
+      workspaceId: "workspace-OTHER",
+      draftId: "draft-1",
+    });
+
+    expect(result).toBeNull();
+    // A non-matching consume must not remove the entry.
+    expect(
+      useWorkspaceDraftSubmissionStore.getState().pendingByDraftId["draft-1"],
+    ).not.toBeUndefined();
+  });
+});

--- a/packages/app/src/stores/workspace-draft-submission-store.ts
+++ b/packages/app/src/stores/workspace-draft-submission-store.ts
@@ -96,7 +96,15 @@ export const useWorkspaceDraftSubmissionStore = create<WorkspaceDraftSubmissionS
         if (!matchesPendingSubmission(state.pendingByDraftId[input.draftId], input)) {
           return state;
         }
-        const { [input.draftId]: _removed, ...rest } = state.pendingByDraftId;
+        // Remove via copy + delete, NOT computed-key destructuring-omit. The
+        // production minifier miscompiles
+        //   const { [input.draftId]: _removed, ...rest } = state.pendingByDraftId
+        // into an omit whose excluded-key array is built from an unassigned
+        // variable, so the entry is never removed. When that happens every
+        // concurrently-mounted draft tab re-consumes the same pending and creates
+        // a duplicate agent. Keep this in a form the minifier cannot drop. See #3217.
+        const rest = { ...state.pendingByDraftId };
+        delete rest[input.draftId];
         return { pendingByDraftId: rest };
       });
       return pending;


### PR DESCRIPTION
Fixes the #3217 class of bug: one "start chat from a new workspace" produced N identical agents (reporters saw N=6 and N=2), with a paired daemon signature of N failed `agent.timeline.list_prompts.request` **and** N `create_agent_request` for one draft id.

## Root cause (two layers)

**1. The trigger — a store removal that stops removing.**
`useWorkspaceDraftSubmissionStore.consumePending` is the *only* cross-instance dedupe in the draft-create path: it removes the consumed pending so any other `WorkspaceDraftAgentTab` mounted for the same draft reads `null` and does not create a second agent (the other three guards — `autoSubmitKeyRef`, the per-hook `isSubmitting` reducer, the create-flow-store lifecycle — are all per-instance). When several draft-tab instances share one draft, each that reads a truthy pending both calls `createAgent` **and** mounts its stream (`AgentStreamView agentId={tabId}`, and `tabId === draftId`) → one `list_prompts`. That is why the two counts are equal.

**2. Why the removal stops removing — a babel-preset-expo miscompile.**
The removal was written as a computed-key destructuring-omit:
```ts
const { [input.draftId]: _removed, ...rest } = state.pendingByDraftId;
```
In the shipped 0.5.0-beta.3 web bundle this compiles to an omit whose excluded-key array is built from an **unassigned** variable:
```js
var _input$draftId;                                              // never assigned → undefined
… _objectWithoutPropertiesLoose(_state$…, [_input$draftId].map(_toPropertyKey))   // removes nothing
```
This is **babel-preset-expo**, not terser: `@babel/preset-env` alone compiles the same input correctly. The break is specific to a computed key that is a **property access** (needs a temp); a plain-identifier key is fine — which is exactly why a sweep of the shipped bundle found only 2 broken omit sites (`consumePending` and a bundled `@react-navigation` `clearOptions`) out of 16. Filed upstream as **expo/expo#49232** (still present on the latest SDK 57 / babel-preset-expo 57.0.7; minimal repro: https://github.com/wangdengwu/babel-preset-expo-omit-repro).

Evidence: [macOS raw logs](https://github.com/getpaseo/paseo/issues/3217#issuecomment-5377325343) · [shipped-bundle miscompile + 16-site sweep](https://github.com/getpaseo/paseo/issues/3217#issuecomment-5377462812).

## Why not the other fixes

- The maintainer already wrote and **closed** server-side idempotency (#3265) and a client synchronous guard (#3272) for want of a repro predicting the full N:N — this PR fixes the actual producer instead of layering another guard.
- Server `clientMessageId` dedupe can't mask it: instances that take the `handleCreateFromInput` branch each mint a fresh `clientMessageId`, so the daemon sees N distinct messages.
- The only config-level toolchain fix (forcing `@babel/plugin-transform-destructuring` ahead of the preset) **force-lowers all destructuring app-wide** — a real bundle/runtime regression on modern web targets — so it isn't viable. `babel.config.js` is intentionally left unchanged.

## What this PR does

1. **Fix** — rewrite `consumePending`'s removal to a minifier-proof `copy + delete`, with a comment so it isn't "simplified" back:
   ```ts
   const rest = { ...state.pendingByDraftId };
   delete rest[input.draftId];
   ```
2. **Regression test** — `workspace-draft-submission-store.test.ts`: consume removes the entry (second consume returns `null`), only the consumed draft is removed, a non-matching consume removes nothing.
3. **Guard** — `no-computed-destructuring-omit.test.ts`: an AST scan of `packages/app/src` that fails if the property-access destructuring-omit shape reappears anywhere, so we can't reintroduce the babel-preset-expo landmine while expo/expo#49232 is open.

## Scope / non-goals

- No protocol change; no new client/server dedupe guard (restores the removal the store already intended).
- No global babel/minifier config change.
- The bundled `@react-navigation` `clearOptions` site (same miscompile, low severity) is left to the upstream fix.
- Out of scope: #3218 (archived-agent process cleanup), #3201 (draft-id `list_prompts` reporting).

## QA

```
npx vitest run packages/app/src/stores/workspace-draft-submission-store.test.ts --bail=1   # 3 passed
npx vitest run packages/app/no-computed-destructuring-omit.test.ts                          # 2 passed
npm run typecheck --workspace=@getpaseo/app                                                 # 0 errors
npm run lint -- packages/app/src/stores/workspace-draft-submission-store.ts packages/app/no-computed-destructuring-omit.test.ts   # clean
```

The source-level regression test passes on `main` too (the source is correct — the bug only appears after the babel transform); the load-bearing protection is the minifier-proof `copy + delete` shape, and the guard keeps the fragile shape out of the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
