### PR TITLE
fix(server): codex startTurn waits out foreground turn teardown instead of refusing

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -674,16 +674,22 @@ describe("Codex foreground teardown wait (replace path)", () => {
     await expect(attempt).rejects.toThrow("Codex client not initialized");
   });
 
-  it("refuses only when the teardown never completes", async () => {
+  it("refuses only when the teardown never completes, retaining no waiter", async () => {
     vi.useFakeTimers();
     try {
       const session = createSession();
+      const internals = castInternals<{ foregroundTurnClearWaiters: Array<() => void> }>(
+        session,
+      );
       const attempt = session.startTurn("never clears");
       const expectation = expect(attempt).rejects.toThrow(
         "A foreground turn is already active",
       );
+      expect(internals.foregroundTurnClearWaiters).toHaveLength(1);
       await vi.advanceTimersByTimeAsync(10_000);
       await expectation;
+      // A stuck turn plus retrying prompts must not accumulate dead closures.
+      expect(internals.foregroundTurnClearWaiters).toHaveLength(0);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -650,6 +650,46 @@ process.stdin.on("data", (chunk) => {
   }
 }
 
+describe("Codex foreground teardown wait (replace path)", () => {
+  // The replace path can call startTurn while the interrupted turn is still
+  // tearing down: the manager's force-cancel settles its run record before
+  // this provider clears activeForegroundTurnId, and refusing immediately
+  // loses the incoming prompt and marks the agent errored.
+  it("waits out a clearing foreground turn instead of refusing", async () => {
+    const session = createSession();
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      flushForegroundTurnClearWaiters: () => void;
+    }>(session);
+    const attempt = session.startTurn("after teardown");
+    const raced = await Promise.race([
+      attempt.catch((error: unknown) => error),
+      new Promise((resolve) => setTimeout(resolve, 25, "pending")),
+    ]);
+    expect(raced).toBe("pending");
+    internals.activeForegroundTurnId = null;
+    internals.flushForegroundTurnClearWaiters();
+    // Getting past the foreground guard is the assertion; the harness spawns
+    // no app-server, so the next gate is the client-initialization error.
+    await expect(attempt).rejects.toThrow("Codex client not initialized");
+  });
+
+  it("refuses only when the teardown never completes", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = createSession();
+      const attempt = session.startTurn("never clears");
+      const expectation = expect(attempt).rejects.toThrow(
+        "A foreground turn is already active",
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("Codex app-server provider", () => {
   test("getAvailableModes includes auto-review when the Codex version supports it", async () => {
     const session = createSession({}, { autoReviewEnabled: true });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -135,6 +135,14 @@ function isCodexAlreadyUnarchivedError(error: unknown, threadId: string): boolea
   return message.includes(`no archived rollout found for thread id ${threadId}`);
 }
 
+// How long an incoming turn waits for the previous foreground turn's teardown
+// before refusing. A replace path can reach startTurn while the interrupted
+// turn is still tearing down: the manager's force-cancel settles its run
+// record before this provider clears activeForegroundTurnId (measured 4ms
+// apart in production), and refusing immediately loses the incoming prompt
+// and marks the agent errored.
+const FOREGROUND_TEARDOWN_WAIT_MS = 10_000;
+
 const TURN_START_TIMEOUT_MS = 90 * 1000;
 const INTERRUPT_TIMEOUT_MS = 2_000;
 const CODEX_PROVIDER = "codex" as const;
@@ -3231,6 +3239,9 @@ export class CodexAppServerAgentSession implements AgentSession {
   private readonly subscribers = new Set<(event: AgentStreamEvent) => void>();
   private nextTurnOrdinal = 0;
   private activeForegroundTurnId: string | null = null;
+  // Resolved whenever the foreground turn clears, so an incoming startTurn can
+  // wait out a teardown instead of refusing a milliseconds-wide race.
+  private foregroundTurnClearWaiters: Array<() => void> = [];
   private activeClientMessageId: string | null = null;
   private cachedRuntimeInfo: AgentRuntimeInfo | null = null;
   private serviceTier: "fast" | null = null;
@@ -3468,6 +3479,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
+    this.flushForegroundTurnClearWaiters();
     this.currentTurnId = null;
     this.pendingForegroundTurnIdentification?.resolve(null);
     this.pendingForegroundTurnIdentification = null;
@@ -4077,12 +4089,35 @@ export class CodexAppServerAgentSession implements AgentSession {
     });
   }
 
+  private flushForegroundTurnClearWaiters(): void {
+    if (this.foregroundTurnClearWaiters.length === 0) return;
+    const waiters = this.foregroundTurnClearWaiters;
+    this.foregroundTurnClearWaiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
+  private async waitForForegroundTurnClear(timeoutMs: number): Promise<void> {
+    if (!this.activeForegroundTurnId) return;
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs);
+      this.foregroundTurnClearWaiters.push(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
   async startTurn(
     prompt: AgentPromptInput,
     options?: AgentRunOptions,
   ): Promise<{ turnId: string }> {
     if (this.activeForegroundTurnId) {
-      throw new Error("A foreground turn is already active");
+      // Wait bounded for the previous turn's teardown; only a turn that
+      // genuinely will not end is refused.
+      await this.waitForForegroundTurnClear(FOREGROUND_TEARDOWN_WAIT_MS);
+      if (this.activeForegroundTurnId) {
+        throw new Error("A foreground turn is already active");
+      }
     }
 
     this.dismissPendingPlanApprovals("Dismissed by a new prompt");
@@ -4136,6 +4171,7 @@ export class CodexAppServerAgentSession implements AgentSession {
       this.pendingForegroundTurnIdentification = null;
       this.activeForegroundTurnId = null;
       this.activeClientMessageId = null;
+      this.flushForegroundTurnClearWaiters();
       throw error;
     }
   }
@@ -4652,6 +4688,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     this.subscribers.clear();
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
+    this.flushForegroundTurnClearWaiters();
     this.pendingForegroundTurnIdentification?.resolve(null);
     this.pendingForegroundTurnIdentification = null;
     await this.disposeClient();
@@ -5765,6 +5802,7 @@ export class CodexAppServerAgentSession implements AgentSession {
     }
     this.activeForegroundTurnId = null;
     this.activeClientMessageId = null;
+    this.flushForegroundTurnClearWaiters();
     this.currentTurnId = null;
     this.pendingForegroundTurnIdentification?.resolve(null);
     this.pendingForegroundTurnIdentification = null;

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -4099,11 +4099,20 @@ export class CodexAppServerAgentSession implements AgentSession {
   private async waitForForegroundTurnClear(timeoutMs: number): Promise<void> {
     if (!this.activeForegroundTurnId) return;
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, timeoutMs);
-      this.foregroundTurnClearWaiters.push(() => {
+      const waiter = () => {
         clearTimeout(timer);
         resolve();
-      });
+      };
+      // A timed-out waiter drops itself: a turn that never clears would
+      // otherwise retain one dead closure per retrying prompt until the
+      // session closes.
+      const timer = setTimeout(() => {
+        this.foregroundTurnClearWaiters = this.foregroundTurnClearWaiters.filter(
+          (entry) => entry !== waiter,
+        );
+        resolve();
+      }, timeoutMs);
+      this.foregroundTurnClearWaiters.push(waiter);
     });
   }
 


### PR DESCRIPTION
## Problem

A prompt injected while a codex turn is being cancelled races the teardown. `steerOrReplaceActiveTurn` falls back to replace when steering is unavailable; `cancelAgentRunBefore` returns once the **manager's** run record settles — and a force-cancel settles it without waiting for the provider — so `startTurn` finds `activeForegroundTurnId` still set and throws `A foreground turn is already active`.

Measured in production (0.5.0-beta.2, long-lived codex agent receiving frequent child-finish notifications): the force-cancel log line and the throw landed **4 ms apart**, six times in one session. Each occurrence turns a live notification prompt into a lost message, fails the stream (`turn_failed` → `Agent stream failed`), and leaves the agent in `error` status.

## Fix

Provider-local, no manager changes. `startTurn` waits up to `FOREGROUND_TEARDOWN_WAIT_MS` (10 s) for the previous turn's teardown to clear `activeForegroundTurnId` — the four sites that clear it flush the waiters — and refuses only a turn that genuinely will not end. The refusal semantics for a truly stuck turn are unchanged.

## Tests

Two unit tests beside the existing codex session harness: an in-flight `startTurn` parks while a foreground turn is active and proceeds the moment the teardown clears it; and a teardown that never completes still refuses with the original error after the bounded wait (fake timers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)