### PR TITLE
Keep released agent SDK versions reproducible

### DIFF
--- a/nix/npm-deps.hash
+++ b/nix/npm-deps.hash
@@ -1,1 +1,1 @@
-sha256-TNwqDZ9gJP613iYmDzVfK5vfye5NBloKN5Jt9t7yhx8=
+sha256-+fewwjlLlJN9VXiBOGvALNQgNxnoVXYQzBDra3ylJhA=

--- a/package-lock.json
+++ b/package-lock.json
@@ -38881,7 +38881,7 @@
       "version": "0.5.0-beta.4",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.17.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+        "@anthropic-ai/claude-agent-sdk": "0.3.220",
         "@anthropic-ai/sdk": "^0.104.2",
         "@babel/parser": "^7.29.8",
         "@getpaseo/client": "0.5.0-beta.4",
@@ -38890,7 +38890,7 @@
         "@getpaseo/protocol": "0.5.0-beta.4",
         "@getpaseo/relay": "0.5.0-beta.4",
         "@isaacs/ttlcache": "^2.1.4",
-        "@modelcontextprotocol/sdk": "^1.20.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@opencode-ai/sdk": "1.14.46",
         "@xterm/headless": "^6.0.0",
         "ai": "5.0.78",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.17.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+    "@anthropic-ai/claude-agent-sdk": "0.3.220",
     "@anthropic-ai/sdk": "^0.104.2",
     "@babel/parser": "^7.29.8",
     "@getpaseo/client": "0.5.0-beta.4",
@@ -78,7 +78,7 @@
     "@getpaseo/protocol": "0.5.0-beta.4",
     "@getpaseo/relay": "0.5.0-beta.4",
     "@isaacs/ttlcache": "^2.1.4",
-    "@modelcontextprotocol/sdk": "^1.20.1",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@opencode-ai/sdk": "1.14.46",
     "@xterm/headless": "^6.0.0",
     "ai": "5.0.78",


### PR DESCRIPTION
### Linked issue

Refs #3599

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Fresh installs of an already-published Paseo release could resolve newer provider and protocol SDK versions than the release was validated against. That allowed upstream publications to change agent startup behavior without a new Paseo release.

Pin the known-good SDK pair so installs of the same Paseo version remain reproducible. Issue #3599 contains a related future-protocol probe from another provider; its missing injected tools remain outside this PR.

### Goals

- Keep fresh installs on the provider SDK version validated for this release.
- Keep the MCP runtime on the matching validated protocol SDK version.
- Restore the pre-upgrade MCP handshake without changing provider behavior.

### Non-goals

- Add support for the future MCP protocol revision.
- Diagnose or change Codex MCP tool injection.
- Add or change automated tests for this dependency-only pin.

### QA

- Ran a fresh isolated install and confirmed the resolved versions are provider SDK `0.3.220` / runtime `2.1.220` and MCP SDK `1.29.0`.
- Launched the bundled provider runtime against a real local MCP HTTP transport. It exposed `Bash`, initialized MCP, and requested `tools/list`.
- Confirmed the runtime did not send the `2026-07-28` discovery probe and the MCP transport reported no errors.
- Updated the Nix npm dependency hash to the value computed by the Darwin CI builder after the lockfile changed. The local update script could not be run because this host does not have `nix` installed.
- `npm run typecheck`
- `npm run lint`
- `npm run format`

Not tested on Linux or Windows.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
