### PR TITLE
Restore composer auto-growth on iOS

### DIFF
--- a/packages/app/src/composer/input/height-style.test.ts
+++ b/packages/app/src/composer/input/height-style.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveComposerInputHeightStyle, shouldScrollComposerInput } from "./height-style";
+
+describe("composer input height style", () => {
+  it("applies the measured height alongside its bounds", () => {
+    expect(
+      resolveComposerInputHeightStyle({
+        inputHeight: 96,
+        minInputHeight: 30,
+        maxInputHeight: 240,
+        applyMeasuredHeight: true,
+      }),
+    ).toEqual({
+      height: 96,
+      minHeight: 30,
+      maxHeight: 240,
+    });
+  });
+
+  it("lets a native multiline input expose its intrinsic content height", () => {
+    expect(
+      resolveComposerInputHeightStyle({
+        inputHeight: 96,
+        minInputHeight: 30,
+        maxInputHeight: 240,
+        applyMeasuredHeight: false,
+      }),
+    ).toEqual({
+      minHeight: 30,
+      maxHeight: 240,
+    });
+  });
+
+  it("keeps native measurement unconstrained until the composer reaches its cap", () => {
+    expect(shouldScrollComposerInput({ inputHeight: 30, maxInputHeight: 240 })).toBe(false);
+    expect(shouldScrollComposerInput({ inputHeight: 240, maxInputHeight: 240 })).toBe(true);
+  });
+});

--- a/packages/app/src/composer/input/height-style.ts
+++ b/packages/app/src/composer/input/height-style.ts
@@ -1,0 +1,24 @@
+interface ComposerInputHeightStyleInput {
+  inputHeight: number;
+  minInputHeight: number;
+  maxInputHeight: number;
+  applyMeasuredHeight: boolean;
+}
+
+export function resolveComposerInputHeightStyle(input: ComposerInputHeightStyleInput) {
+  // Native must remain intrinsically sized below the cap so
+  // onContentSizeChange can observe growth. Web gets its height from the DOM
+  // mirror and therefore needs that measurement applied explicitly.
+  return {
+    ...(input.applyMeasuredHeight ? { height: input.inputHeight } : {}),
+    minHeight: input.minInputHeight,
+    maxHeight: input.maxInputHeight,
+  };
+}
+
+export function shouldScrollComposerInput(input: {
+  inputHeight: number;
+  maxInputHeight: number;
+}): boolean {
+  return input.inputHeight >= input.maxInputHeight;
+}

--- a/packages/app/src/composer/input/input.tsx
+++ b/packages/app/src/composer/input/input.tsx
@@ -56,6 +56,7 @@ import { useIsCompactFormFactor } from "@/constants/layout";
 import { useComposerKeyboardScope } from "@/composer/keyboard-scope";
 import { RenderProfile } from "@/utils/render-profiler";
 import { useComposerHeightMirror } from "./height-mirror";
+import { resolveComposerInputHeightStyle, shouldScrollComposerInput } from "./height-style";
 import { resolveComposerInputMode, type ComposerInputMode } from "@/composer/input-mode";
 import type { NativePastedFile } from "@/composer/native-pasted-image";
 import {
@@ -990,20 +991,6 @@ function resolveMaxInputHeight(windowHeight: number): number {
   return Math.max(DEFAULT_MAX_INPUT_HEIGHT, Math.floor(windowHeight * MAX_INPUT_VIEWPORT_RATIO));
 }
 
-function computeTextInputHeightStyle(inputHeight: number, maxInputHeight: number) {
-  if (isWeb) {
-    return {
-      height: inputHeight,
-      minHeight: MIN_INPUT_HEIGHT,
-      maxHeight: maxInputHeight,
-    };
-  }
-  return {
-    minHeight: MIN_INPUT_HEIGHT,
-    maxHeight: maxInputHeight,
-  };
-}
-
 function isTextAreaLike(v: unknown): v is TextAreaHandle {
   return typeof v === "object" && v !== null && "scrollHeight" in v;
 }
@@ -1764,7 +1751,12 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
       () => [
         styles.textInput,
         mode.isMonospace && styles.textInputMonospace,
-        computeTextInputHeightStyle(inputHeight, maxInputHeight),
+        resolveComposerInputHeightStyle({
+          inputHeight,
+          minInputHeight: MIN_INPUT_HEIGHT,
+          maxInputHeight,
+          applyMeasuredHeight: isWeb,
+        }),
       ],
       [inputHeight, maxInputHeight, mode.isMonospace],
     );
@@ -1838,7 +1830,7 @@ export const MessageInput = forwardRef<MessageInputRef, MessageInputProps>(
               onFocus={handleInputFocus}
               onBlur={handleInputBlur}
               editable={!isDictating && !isRealtimeVoiceForCurrentAgent && !disabled}
-              scrollEnabled={isWeb ? inputHeight >= maxInputHeight : true}
+              scrollEnabled={shouldScrollComposerInput({ inputHeight, maxInputHeight })}
               autoFocus={false}
               onContentSizeChange={handleContentSizeChange}
               onKeyPress={shouldHandleWebKeyPress ? handleDesktopKeyPress : undefined}


### PR DESCRIPTION
### Linked issue

None found after searching issues and open pull requests for iOS composer growth and input-height reports.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

The iOS composer remained one line tall and scrolled its contents internally as text wrapped. Native inputs were always scrollable, which prevented iOS from exposing the intrinsic multiline content height that drives composer growth.

Keep native sizing intrinsic below the cap and enable internal scrolling only once the composer reaches that cap. Web continues to apply the height measured by its DOM mirror.

### Goals

- Grow the iOS composer as entered text wraps onto additional lines.
- Preserve Android and web composer growth behavior.
- Keep the composer bounded and switch to internal scrolling at its existing maximum height.
- Cover the cross-platform sizing and scrolling policy with a focused regression test.

### Non-goals

- Change the composer's maximum height or visual design.
- Change submission, keyboard, or draft persistence behavior.
- Rework the shared text-input implementation.

### QA

- Reproduced the failure in the running iPhone 17 Pro simulator: a long draft remained a 30-point text view and scrolled internally.
- iOS fix verification: the same multiline draft grew from 30 to 173 points, then shrank back to 30 points after restoring the original short draft.
- Android regression verification on the running Medium Phone API 36.1 emulator: the composer grew from 80 to 224 pixels, then shrank back to 80 pixels after clearing the draft.
- Web regression verification:
  - `npm run test:e2e --workspace=@getpaseo/app -- e2e/browser/composer-whitespace.spec.ts`
  - 2 tests passed, covering blank-line growth and bottom anchoring while the composer grows.
- Focused regression:
  - `npx vitest run packages/app/src/composer/input/height-style.test.ts --bail=1`
  - 3 tests passed.
- Repository checks:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run format:files -- packages/app/src/composer/input/height-style.ts packages/app/src/composer/input/height-style.test.ts packages/app/src/composer/input/input.tsx`

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
