### PR TITLE
fix(server): release the foreground turn when the codex client is disposed

### DIFF
--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -650,6 +650,22 @@ process.stdin.on("data", (chunk) => {
   }
 }
 
+describe("Codex client disposal", () => {
+  it("releases the foreground slot when the client is disposed", async () => {
+    // A failed reconnect disposes the client and clears the native turn id.
+    // If the foreground slot survived that, interrupt() would find no turn to
+    // interrupt and every later startTurn would refuse forever.
+    const session = createSession();
+    const internals = castInternals<{
+      activeForegroundTurnId: string | null;
+      disposeClient: () => Promise<void>;
+    }>(session);
+    expect(internals.activeForegroundTurnId).toBe("test-turn");
+    await internals.disposeClient();
+    expect(internals.activeForegroundTurnId).toBeNull();
+  });
+});
+
 describe("Codex app-server provider", () => {
   test("getAvailableModes includes auto-review when the Codex version supports it", async () => {
     const session = createSession({}, { autoReviewEnabled: true });

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -4675,6 +4675,22 @@ export class CodexAppServerAgentSession implements AgentSession {
     const client = this.client;
     this.client = null;
     this.connected = false;
+    // A disposed client cannot own a live turn, so release the foreground slot
+    // with it. Without this, a failed reconnect clears the native turn id and
+    // leaves activeForegroundTurnId held forever, and every later startTurn
+    // refuses with "A foreground turn is already active". close() already
+    // clears the slot before disposing, so this is a no-op on that path.
+    if (this.activeForegroundTurnId) {
+      this.emitEvent({
+        type: "turn_failed",
+        provider: CODEX_PROVIDER,
+        error: "Codex client was disposed while a foreground turn was active",
+      });
+      this.activeForegroundTurnId = null;
+      this.activeClientMessageId = null;
+      this.pendingForegroundTurnIdentification?.resolve(null);
+      this.pendingForegroundTurnIdentification = null;
+    }
     this.currentTurnId = null;
     if (client) {
       await client.dispose();


### PR DESCRIPTION
## Problem

`CodexAppServerAgentSession.disposeClient()` clears `currentTurnId` but leaves `activeForegroundTurnId` set. `close()` clears the slot itself before disposing, so the asymmetry only shows on the other caller — a **failed reconnect**.

The agent is then permanently wedged, and the state is invisible from outside: the manager reports `activeTurn: null` while the provider still holds the slot. `interrupt()` finds no turn to interrupt, the manager force-cancels its own run record and believes the agent free, and every later `startTurn` refuses with `A foreground turn is already active`. Scheduled runs cannot rescue it either, since the daemon refuses a scheduled run against an agent with an in-flight run.

Observed in production (0.5.0-beta.4) on a long-lived codex agent driven by frequent child-finish notifications: fifteen minutes of refused prompts and failed schedule runs, `paseo stop` reporting zero stopped runs, `send` answering `failed to start`, recovered only by restarting the daemon.

## Fix

A disposed client cannot own a live turn, so the foreground slot is released with it: emit `turn_failed` so the manager's run settles, clear the foreground and client-message ids, and resolve any pending turn identification. Idempotent on the `close()` path, which already cleared the slot.

## Test

One unit test beside the existing codex session harness: a session holding a foreground turn has no foreground turn after `disposeClient()`.

Related: #3674 (the same provider's teardown race, where a replacement turn arrives 4 ms before the slot clears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)