### PR TITLE
fix(dictation): avoid default English transcription prompt

### DIFF
--- a/packages/server/src/server/dictation/dictation-stream-manager.test.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.test.ts
@@ -54,11 +54,13 @@ class FakeRealtimeSession extends EventEmitter implements StreamingTranscription
 class FakeSttProvider implements SpeechToTextProvider {
   public readonly id = "fake";
   public lastLanguage?: string;
+  public lastPrompt?: string;
   constructor(private readonly session: FakeRealtimeSession) {}
   createSession(
     params: Parameters<SpeechToTextProvider["createSession"]>[0],
   ): StreamingTranscriptionSession {
     this.lastLanguage = params.language;
+    this.lastPrompt = params.prompt;
     return this.session;
   }
 }
@@ -216,6 +218,51 @@ describe("DictationStreamManager (provider-agnostic provider)", () => {
     });
 
     expect(sttProvider.lastLanguage).toBe("pt");
+  });
+
+  it("does not inject a transcription prompt when the override is unset", async () => {
+    const original = process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT;
+    delete process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT;
+
+    try {
+      const sttProvider = await startWithResolvedDictationLanguage({
+        persisted: {
+          features: {
+            dictation: {
+              stt: {
+                language: "zh",
+              },
+            },
+          },
+        },
+      });
+
+      expect(sttProvider.lastLanguage).toBe("zh");
+      expect(sttProvider.lastPrompt).toBeUndefined();
+    } finally {
+      if (original === undefined) {
+        delete process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT;
+      } else {
+        process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT = original;
+      }
+    }
+  });
+
+  it("forwards an explicit transcription prompt override", async () => {
+    const original = process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT;
+    process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT = "Keep Chinese product names verbatim.";
+
+    try {
+      const sttProvider = await startWithResolvedDictationLanguage({});
+
+      expect(sttProvider.lastPrompt).toBe("Keep Chinese product names verbatim.");
+    } finally {
+      if (original === undefined) {
+        delete process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT;
+      } else {
+        process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT = original;
+      }
+    }
   });
 
   it("does not require OPENAI_API_KEY", async () => {

--- a/packages/server/src/server/dictation/dictation-stream-manager.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.ts
@@ -171,9 +171,7 @@ export class DictationStreamManager {
       return;
     }
 
-    const transcriptionPrompt =
-      process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT ??
-      "Transcribe only what the speaker says. Do not add words. Preserve punctuation and casing. If the audio is silence or non-speech noise, return an empty transcript.";
+    const transcriptionPrompt = process.env.PASEO_DICTATION_TRANSCRIPTION_PROMPT;
 
     let stt: ReturnType<SpeechToTextProvider["createSession"]>;
     try {


### PR DESCRIPTION
## Problem

When dictation is configured with `language: "zh"`, `DictationStreamManager` still injects an English transcription prompt whenever `PASEO_DICTATION_TRANSCRIPTION_PROMPT` is unset. OpenAI-compatible Whisper endpoints can follow that prompt by translating Chinese speech to English.

Raw regression result before the fix:

```
expected "Transcribe only what the speaker says..." to be undefined
```

## Change

- Do not inject a default transcription prompt.
- Continue forwarding `PASEO_DICTATION_TRANSCRIPTION_PROMPT` when the user explicitly sets it.
- Keep the configured language and the existing streaming/finalization behavior unchanged.

## Automated QA

```
npx vitest run packages/server/src/server/dictation/dictation-stream-manager.test.ts --bail=1

Test Files  1 passed (1)
Tests       13 passed (13)
```

Also passed:

- `npm run build:server`
- `npm run typecheck`
- targeted `npm run lint`
- `npm run format:check`
- `git diff --check`

## Manual QA

This is a draft until the Chinese audio flow is verified against a real OpenAI-compatible STT endpoint and on iPhone.

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Physical-device QA pending |
| Android | No | Not tested |
| Web | No | Server-only behavior |
| Desktop | No | Server-only behavior |

Fixes #2899
