### PR TITLE
Show latest thinking preview when folded

### DIFF
--- a/packages/protocol/src/tool-call-display.test.ts
+++ b/packages/protocol/src/tool-call-display.test.ts
@@ -38,6 +38,24 @@ describe("shared tool-call display mapping", () => {
     });
   });
 
+  it("shows the end of thinking as its folded summary", () => {
+    const display = buildToolCallDisplayModel({
+      name: "thinking",
+      status: "completed",
+      error: null,
+      detail: {
+        type: "unknown",
+        input: "Earlier thinking.\nAwaiting the final verification.",
+        output: null,
+      },
+    });
+
+    expect(display).toEqual({
+      displayName: "Thinking",
+      summary: "Awaiting the final verification.",
+    });
+  });
+
   it("uses sub-agent detail for task label and description", () => {
     const display = buildToolCallDisplayModel({
       name: "task",

--- a/packages/protocol/src/tool-call-display.ts
+++ b/packages/protocol/src/tool-call-display.ts
@@ -136,8 +136,11 @@ function buildUnknownDetailOverride(input: ToolCallDisplayInput): DetailDisplay 
     };
   }
   if (input.detail.type === "unknown" && lowerName === "thinking") {
+    const summary =
+      readString(input.detail.input)?.trim().replace(/\s+/g, " ").slice(-32) || undefined;
     return {
       displayName: "Thinking",
+      summary,
     };
   }
   if (lowerName === "terminal") {


### PR DESCRIPTION
## Problem

Collapsed thinking rows only show “Thinking”, so you have to expand each row to see the agent's latest progress.

## Change

Show the final 32 characters of the thinking block as the existing tool-call summary, collapsing whitespace so it stays on one line. This uses the shared `ExpandableBadge` secondary label and requires no platform-specific UI path.

## QA

- `npx vitest run packages/protocol/src/tool-call-display.test.ts --bail=1` — 13 passed
- `npm run typecheck --prefix packages/protocol` — passed
- `npm run lint -- packages/protocol/src/tool-call-display.ts packages/protocol/src/tool-call-display.test.ts` — 0 warnings, 0 errors
- `npm run format:files -- packages/protocol/src/tool-call-display.ts packages/protocol/src/tool-call-display.test.ts` — passed

Manual UI QA and screenshots are still pending, so this is a draft.

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Shared presentation mapping only |
| Android | No | Shared presentation mapping only |
| Web | No | Shared presentation mapping only |
| Desktop macOS | No | Shared presentation mapping only |
| Desktop Windows | No | Shared presentation mapping only |
| Desktop Linux | No | Shared presentation mapping only |

## Protocol compatibility

No wire schema or message shape changes. This only adds a derived display summary in the client-side protocol presentation helper.