### PR TITLE
fix(dictation): bound chunk and segment size in dictation streams

### DIFF
--- a/packages/server/src/server/agent/pcm16-resampler.test.ts
+++ b/packages/server/src/server/agent/pcm16-resampler.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { Pcm16MonoResampler, Pcm16ResamplerOutputLimitError } from "./pcm16-resampler.js";
+
+function buildPcmBuffer(sampleCount: number, sampleValue = 1000): Buffer {
+  const samples = new Int16Array(sampleCount);
+  samples.fill(sampleValue);
+  return Buffer.from(samples.buffer, samples.byteOffset, samples.byteLength);
+}
+
+describe("Pcm16MonoResampler", () => {
+  it("resamples a normal upsampled client format within expected output bounds", () => {
+    const resampler = new Pcm16MonoResampler({ inputRate: 8000, outputRate: 24000 });
+
+    const outSamples = resampler.processChunk(buildPcmBuffer(1000)).length / 2;
+
+    expect(outSamples).toBeGreaterThanOrEqual(2990);
+    expect(outSamples).toBeLessThanOrEqual(3010);
+  });
+
+  it("keeps output bounded across consecutive chunks", () => {
+    const resampler = new Pcm16MonoResampler({ inputRate: 8000, outputRate: 24000 });
+
+    let outSamples = 0;
+    for (let i = 0; i < 2; i += 1) {
+      outSamples += resampler.processChunk(buildPcmBuffer(1000)).length / 2;
+    }
+
+    expect(outSamples).toBeGreaterThanOrEqual(5980);
+    expect(outSamples).toBeLessThanOrEqual(6020);
+  });
+
+  it("downsamples high input rates without rejection", () => {
+    const resampler = new Pcm16MonoResampler({ inputRate: 192000, outputRate: 16000 });
+
+    const out = resampler.processChunk(buildPcmBuffer(1000));
+
+    expect(out.length / 2).toBeLessThanOrEqual(1000);
+    expect(out.length % 2).toBe(0);
+  });
+
+  it("rejects predicted output beyond the budget before allocating", () => {
+    const resampler = new Pcm16MonoResampler({ inputRate: 1, outputRate: 24000 });
+
+    let caught: unknown;
+    try {
+      resampler.processChunk(buildPcmBuffer(2048));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Pcm16ResamplerOutputLimitError);
+    if (caught instanceof Pcm16ResamplerOutputLimitError) {
+      expect(caught.maxSamples).toBe(2048 * 4 + 1024);
+      expect(caught.predictedSamples).toBeGreaterThan(49_000_000);
+      expect(caught.message).toContain("exceeds the 9216-sample output limit");
+    }
+  });
+});

--- a/packages/server/src/server/agent/pcm16-resampler.ts
+++ b/packages/server/src/server/agent/pcm16-resampler.ts
@@ -1,3 +1,21 @@
+// A chunk's output sample count tracks inputSampleCount * (outputRate / inputRate).
+// Client-supplied input rates can claim absurd ratios (e.g. rate=1), so predicted
+// output beyond this multiple of the input is rejected before any allocation.
+const MAX_UPSAMPLE_FACTOR = 4;
+const MAX_UPSAMPLE_SLACK_SAMPLES = 1024;
+
+export class Pcm16ResamplerOutputLimitError extends Error {
+  constructor(
+    public readonly predictedSamples: number,
+    public readonly maxSamples: number,
+  ) {
+    super(
+      `Resampled chunk of ~${predictedSamples} samples exceeds the ${maxSamples}-sample output limit`,
+    );
+    this.name = "Pcm16ResamplerOutputLimitError";
+  }
+}
+
 export class Pcm16MonoResampler {
   private readonly inputRate: number;
   private readonly outputRate: number;
@@ -35,6 +53,14 @@ export class Pcm16MonoResampler {
       return Buffer.alloc(0);
     }
 
+    const maxPos = srcLen - 1;
+    const remaining = maxPos - this.pos;
+    const predictedSamples = remaining > 0 ? Math.ceil(remaining / this.step) : 0;
+    const maxSamples = srcChunk.length * MAX_UPSAMPLE_FACTOR + MAX_UPSAMPLE_SLACK_SAMPLES;
+    if (predictedSamples > maxSamples) {
+      throw new Pcm16ResamplerOutputLimitError(predictedSamples, maxSamples);
+    }
+
     const src = new Float32Array(srcLen);
     let offset = 0;
     if (hasCarry) {
@@ -46,8 +72,6 @@ export class Pcm16MonoResampler {
     }
 
     const out: number[] = [];
-    const maxPos = src.length - 1;
-
     while (this.pos < maxPos) {
       const i = Math.floor(this.pos);
       const frac = this.pos - i;

--- a/packages/server/src/server/dictation/dictation-stream-manager.test.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.test.ts
@@ -411,3 +411,98 @@ describe("DictationStreamManager (provider-agnostic provider)", () => {
     }
   });
 });
+
+describe("DictationStreamManager (size limits)", () => {
+  const previousEnv = {
+    debug: process.env.PASEO_DICTATION_DEBUG,
+    hardSegment: process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES,
+    maxChunk: process.env.PASEO_DICTATION_MAX_CHUNK_BYTES,
+  };
+
+  beforeEach(() => {
+    process.env.PASEO_DICTATION_DEBUG = "false";
+  });
+
+  afterEach(() => {
+    process.env.PASEO_DICTATION_DEBUG = previousEnv.debug;
+    process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = previousEnv.hardSegment;
+    process.env.PASEO_DICTATION_MAX_CHUNK_BYTES = previousEnv.maxChunk;
+  });
+
+  it("fails the stream and drops audio when a single chunk exceeds the byte limit", async () => {
+    process.env.PASEO_DICTATION_MAX_CHUNK_BYTES = "1024";
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 15,
+    });
+
+    await manager.handleStart("d-big", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-big",
+      seq: 0,
+      audioBase64: buildPcmBase64(2000, 20000),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    await tick();
+
+    expect(session.appended).toHaveLength(0);
+    const error = emitted.find((msg) => msg.type === "dictation_stream_error");
+    expect(error).toBeDefined();
+    expect((error?.payload as { error?: string } | undefined)?.error).toContain(
+      "exceeds the 1024-byte limit",
+    );
+  });
+
+  it("forces a segment commit once uncommitted audio crosses the hard cap even with auto-commit disabled", async () => {
+    process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = "480";
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+    });
+
+    await manager.handleStart("d-cap", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-cap",
+      seq: 0,
+      audioBase64: buildPcmBase64(2000, 1000),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    expect(session.appended).toHaveLength(1);
+    expect(session.commitCalls).toBe(1);
+    expect(session.clearCalls).toBe(0);
+  });
+
+  it("clears instead of committing silent audio that reaches the hard cap", async () => {
+    process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = "480";
+    const session = new FakeRealtimeSession();
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: () => {},
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+    });
+
+    await manager.handleStart("d-quiet", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-quiet",
+      seq: 0,
+      audioBase64: buildPcmBase64(10, 1000),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+
+    expect(session.appended).toHaveLength(1);
+    expect(session.clearCalls).toBe(1);
+    expect(session.commitCalls).toBe(0);
+  });
+});

--- a/packages/server/src/server/dictation/dictation-stream-manager.test.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.test.ts
@@ -412,25 +412,51 @@ describe("DictationStreamManager (provider-agnostic provider)", () => {
   });
 });
 
-describe("DictationStreamManager (size limits)", () => {
+describe("DictationStreamManager (chunk and segment limits)", () => {
   const previousEnv = {
     debug: process.env.PASEO_DICTATION_DEBUG,
-    hardSegment: process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES,
     maxChunk: process.env.PASEO_DICTATION_MAX_CHUNK_BYTES,
+    hardSegment: process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES,
   };
 
   beforeEach(() => {
     process.env.PASEO_DICTATION_DEBUG = "false";
+    delete process.env.PASEO_DICTATION_MAX_CHUNK_BYTES;
+    delete process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES;
   });
 
   afterEach(() => {
-    process.env.PASEO_DICTATION_DEBUG = previousEnv.debug;
-    process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = previousEnv.hardSegment;
-    process.env.PASEO_DICTATION_MAX_CHUNK_BYTES = previousEnv.maxChunk;
+    if (previousEnv.debug === undefined) {
+      delete process.env.PASEO_DICTATION_DEBUG;
+    } else {
+      process.env.PASEO_DICTATION_DEBUG = previousEnv.debug;
+    }
+    if (previousEnv.maxChunk === undefined) {
+      delete process.env.PASEO_DICTATION_MAX_CHUNK_BYTES;
+    } else {
+      process.env.PASEO_DICTATION_MAX_CHUNK_BYTES = previousEnv.maxChunk;
+    }
+    if (previousEnv.hardSegment === undefined) {
+      delete process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES;
+    } else {
+      process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = previousEnv.hardSegment;
+    }
   });
 
-  it("fails the stream and drops audio when a single chunk exceeds the byte limit", async () => {
-    process.env.PASEO_DICTATION_MAX_CHUNK_BYTES = "1024";
+  // Raw byte payloads (odd lengths included); bytes are non-zero.
+  function buildBytesBase64(byteCount: number): string {
+    const bytes = Buffer.alloc(byteCount);
+    for (let i = 0; i < byteCount; i += 1) {
+      bytes[i] = (i % 251) + 1;
+    }
+    return bytes.toString("base64");
+  }
+
+  function emittedErrors(messages: Array<{ type: string; payload: unknown }>) {
+    return messages.filter((msg) => msg.type === "dictation_stream_error");
+  }
+
+  it("accepts a chunk that decodes to exactly maxChunkBytes", async () => {
     const session = new FakeRealtimeSession();
     const emitted: Array<{ type: string; payload: unknown }> = [];
     const manager = new DictationStreamManager({
@@ -438,28 +464,79 @@ describe("DictationStreamManager (size limits)", () => {
       emit: (msg) => emitted.push(msg),
       sessionId: "s1",
       stt: new FakeSttProvider(session),
-      autoCommitSeconds: 15,
+      autoCommitSeconds: 0,
+      maxChunkBytes: 1024,
     });
 
-    await manager.handleStart("d-big", "audio/pcm;rate=24000;bits=16");
+    await manager.handleStart("d-exact", "audio/pcm;rate=24000;bits=16");
     await manager.handleChunk({
-      dictationId: "d-big",
+      dictationId: "d-exact",
       seq: 0,
-      audioBase64: buildPcmBase64(2000, 20000),
+      audioBase64: buildBytesBase64(1024),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    await tick();
+
+    expect(session.appended).toHaveLength(1);
+    expect(session.appended[0]?.length).toBe(1024);
+    expect(emittedErrors(emitted)).toHaveLength(0);
+    expect(emitted.at(-1)).toEqual({
+      type: "dictation_stream_ack",
+      payload: { dictationId: "d-exact", ackSeq: 0 },
+    });
+  });
+
+  it("rejects a decoded chunk one byte over the limit even when its encoding passes the precheck", async () => {
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+      maxChunkBytes: 1024,
+    });
+
+    await manager.handleStart("d-over", "audio/pcm;rate=24000;bits=16");
+    // 1025 bytes encode to 1368 chars — the same encoded length as the accepted
+    // 1024-byte chunk above, so only the decoded-length check can catch it.
+    await manager.handleChunk({
+      dictationId: "d-over",
+      seq: 0,
+      audioBase64: buildBytesBase64(1025),
       format: "audio/pcm;rate=24000;bits=16",
     });
     await tick();
 
     expect(session.appended).toHaveLength(0);
-    const error = emitted.find((msg) => msg.type === "dictation_stream_error");
-    expect(error).toBeDefined();
-    expect((error?.payload as { error?: string } | undefined)?.error).toContain(
-      "exceeds the 1024-byte limit",
-    );
+    expect(session.closed).toBe(true);
+    const errors = emittedErrors(emitted);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload).toEqual({
+      dictationId: "d-over",
+      error: expect.stringContaining("exceeds the 1024-byte limit"),
+      retryable: true,
+    });
+
+    await manager.handleChunk({
+      dictationId: "d-over",
+      seq: 1,
+      audioBase64: buildBytesBase64(16),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    await tick();
+
+    const followUpErrors = emittedErrors(emitted);
+    expect(followUpErrors).toHaveLength(2);
+    expect(followUpErrors[1]?.payload).toEqual({
+      dictationId: "d-over",
+      error: "Dictation stream not started",
+      retryable: true,
+    });
   });
 
-  it("forces a segment commit once uncommitted audio crosses the hard cap even with auto-commit disabled", async () => {
-    process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = "480";
+  it("rejects unbounded resampler amplification from an attacker-controlled sample rate", async () => {
     const session = new FakeRealtimeSession();
     const emitted: Array<{ type: string; payload: unknown }> = [];
     const manager = new DictationStreamManager({
@@ -470,39 +547,341 @@ describe("DictationStreamManager (size limits)", () => {
       autoCommitSeconds: 0,
     });
 
-    await manager.handleStart("d-cap", "audio/pcm;rate=24000;bits=16");
+    await manager.handleStart("d-rate", "audio/pcm;rate=1;bits=16");
     await manager.handleChunk({
-      dictationId: "d-cap",
+      dictationId: "d-rate",
+      seq: 0,
+      audioBase64: buildPcmBase64(2000, 2048),
+      format: "audio/pcm;rate=1;bits=16",
+    });
+    await tick();
+
+    expect(session.appended).toHaveLength(0);
+    expect(session.closed).toBe(true);
+    const errors = emittedErrors(emitted);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload).toEqual({
+      dictationId: "d-rate",
+      error: expect.stringContaining("exceeds the 9216-sample output limit"),
+      retryable: false,
+    });
+
+    await manager.handleChunk({
+      dictationId: "d-rate",
+      seq: 1,
+      audioBase64: buildPcmBase64(2000, 8),
+      format: "audio/pcm;rate=1;bits=16",
+    });
+    await tick();
+    expect(emittedErrors(emitted)).toHaveLength(2);
+  });
+
+  it("keeps the hard segment cap committing loud audio while finish waits for missing chunks", async () => {
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+      hardSegmentBytes: 480,
+    });
+
+    await manager.handleStart("d-finish-loud", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-finish-loud",
       seq: 0,
       audioBase64: buildPcmBase64(2000, 1000),
       format: "audio/pcm;rate=24000;bits=16",
     });
-    expect(session.appended).toHaveLength(1);
     expect(session.commitCalls).toBe(1);
+
+    await manager.handleFinish("d-finish-loud", 500);
+    for (let seq = 1; seq <= 4; seq += 1) {
+      await manager.handleChunk({
+        dictationId: "d-finish-loud",
+        seq,
+        audioBase64: buildPcmBase64(2000, 1000),
+        format: "audio/pcm;rate=24000;bits=16",
+      });
+    }
+
+    expect(session.commitCalls).toBe(5);
     expect(session.clearCalls).toBe(0);
+    expect(emittedErrors(emitted)).toHaveLength(0);
+    expect(emitted.filter((msg) => msg.type === "dictation_stream_final")).toHaveLength(0);
+
+    manager.cleanupAll();
+    expect(session.closed).toBe(true);
   });
 
-  it("clears instead of committing silent audio that reaches the hard cap", async () => {
-    process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = "480";
+  it("keeps the hard segment cap clearing silent audio while finish waits for missing chunks", async () => {
     const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
     const manager = new DictationStreamManager({
       logger: pino({ level: "silent" }),
-      emit: () => {},
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+      hardSegmentBytes: 480,
+    });
+
+    await manager.handleStart("d-finish-quiet", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-finish-quiet",
+      seq: 0,
+      audioBase64: buildPcmBase64(10, 1000),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    expect(session.clearCalls).toBe(1);
+
+    await manager.handleFinish("d-finish-quiet", 500);
+    for (let seq = 1; seq <= 3; seq += 1) {
+      await manager.handleChunk({
+        dictationId: "d-finish-quiet",
+        seq,
+        audioBase64: buildPcmBase64(10, 1000),
+        format: "audio/pcm;rate=24000;bits=16",
+      });
+    }
+
+    expect(session.clearCalls).toBe(4);
+    expect(session.commitCalls).toBe(0);
+    expect(emittedErrors(emitted)).toHaveLength(0);
+
+    manager.cleanupAll();
+  });
+
+  it("accepts a chunk at the sequence window edge and fails past it", async () => {
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
       sessionId: "s1",
       stt: new FakeSttProvider(session),
       autoCommitSeconds: 0,
     });
 
-    await manager.handleStart("d-quiet", "audio/pcm;rate=24000;bits=16");
+    await manager.handleStart("d-window", "audio/pcm;rate=24000;bits=16");
     await manager.handleChunk({
-      dictationId: "d-quiet",
+      dictationId: "d-window",
+      seq: 4095,
+      audioBase64: buildPcmBase64(1000, 2),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    expect(emittedErrors(emitted)).toHaveLength(0);
+
+    await manager.handleChunk({
+      dictationId: "d-window",
+      seq: 4096,
+      audioBase64: buildPcmBase64(1000, 2),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    await tick();
+
+    expect(session.closed).toBe(true);
+    const errors = emittedErrors(emitted);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload).toEqual({
+      dictationId: "d-window",
+      error: expect.stringContaining("reorder buffer limit exceeded"),
+      retryable: true,
+    });
+  });
+
+  it("fails once more than the reorder entry cap buffers behind a gap", async () => {
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+    });
+
+    await manager.handleStart("d-entries", "audio/pcm;rate=24000;bits=16");
+    for (let seq = 1; seq <= 512; seq += 1) {
+      await manager.handleChunk({
+        dictationId: "d-entries",
+        seq,
+        audioBase64: buildPcmBase64(1000, 2),
+        format: "audio/pcm;rate=24000;bits=16",
+      });
+    }
+    expect(emittedErrors(emitted)).toHaveLength(0);
+
+    await manager.handleChunk({
+      dictationId: "d-entries",
+      seq: 513,
+      audioBase64: buildPcmBase64(1000, 2),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    await tick();
+
+    expect(session.closed).toBe(true);
+    const errors = emittedErrors(emitted);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload).toEqual({
+      dictationId: "d-entries",
+      error: expect.stringContaining("buffered=512 entries"),
+      retryable: true,
+    });
+  });
+
+  it("fails once buffered reorder bytes exceed the byte cap", async () => {
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+      maxChunkBytes: 1024 * 1024,
+    });
+
+    await manager.handleStart("d-bytes", "audio/pcm;rate=24000;bits=16");
+    for (let seq = 1; seq <= 16; seq += 1) {
+      await manager.handleChunk({
+        dictationId: "d-bytes",
+        seq,
+        audioBase64: Buffer.alloc(1024 * 1024, 7).toString("base64"),
+        format: "audio/pcm;rate=24000;bits=16",
+      });
+    }
+    expect(emittedErrors(emitted)).toHaveLength(0);
+
+    await manager.handleChunk({
+      dictationId: "d-bytes",
+      seq: 17,
+      audioBase64: Buffer.alloc(1024 * 1024, 7).toString("base64"),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    await tick();
+
+    expect(session.closed).toBe(true);
+    const errors = emittedErrors(emitted);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload).toEqual({
+      dictationId: "d-bytes",
+      error: expect.stringContaining("16777216 bytes"),
+      retryable: true,
+    });
+  }, 20000);
+
+  it("prefers explicit constructor limits over environment values", async () => {
+    process.env.PASEO_DICTATION_MAX_CHUNK_BYTES = "999999";
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+      maxChunkBytes: 64,
+    });
+
+    await manager.handleStart("d-config", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-config",
       seq: 0,
-      audioBase64: buildPcmBase64(10, 1000),
+      audioBase64: buildBytesBase64(65),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+    await tick();
+
+    const errors = emittedErrors(emitted);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload).toEqual({
+      dictationId: "d-config",
+      error: expect.stringContaining("exceeds the 64-byte limit"),
+      retryable: true,
+    });
+  });
+
+  it("falls back to default limits when environment values are invalid", async () => {
+    process.env.PASEO_DICTATION_MAX_CHUNK_BYTES = "not-a-number";
+    process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES = "junk";
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+    });
+
+    await manager.handleStart("d-defaults", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-defaults",
+      seq: 0,
+      audioBase64: buildPcmBase64(2000, 1000),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+
+    // Defaults applied (512KiB chunk cap, ~1.9MiB hard segment): a 2000-byte loud
+    // chunk forwards without tripping either limit or a broken zero/negative cap.
+    expect(session.appended).toHaveLength(1);
+    expect(session.commitCalls).toBe(0);
+    expect(session.clearCalls).toBe(0);
+    expect(emittedErrors(emitted)).toHaveLength(0);
+  });
+
+  it("falls back to resolved defaults when explicit constructor limits are invalid", async () => {
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+      maxChunkBytes: 0,
+      hardSegmentBytes: -480,
+    });
+
+    await manager.handleStart("d-invalid-limits", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-invalid-limits",
+      seq: 0,
+      audioBase64: buildPcmBase64(2000, 1000),
+      format: "audio/pcm;rate=24000;bits=16",
+    });
+
+    // A literal zero chunk cap would reject every chunk and a negative hard cap
+    // would commit immediately; both fall back to the defaults instead.
+    expect(session.appended).toHaveLength(1);
+    expect(session.commitCalls).toBe(0);
+    expect(emittedErrors(emitted)).toHaveLength(0);
+  });
+
+  it("uses the default for a fractional explicit limit", async () => {
+    const session = new FakeRealtimeSession();
+    const emitted: Array<{ type: string; payload: unknown }> = [];
+    const manager = new DictationStreamManager({
+      logger: pino({ level: "silent" }),
+      emit: (msg) => emitted.push(msg),
+      sessionId: "s1",
+      stt: new FakeSttProvider(session),
+      autoCommitSeconds: 0,
+      maxChunkBytes: 1.5,
+    });
+
+    await manager.handleStart("d-fractional-limit", "audio/pcm;rate=24000;bits=16");
+    await manager.handleChunk({
+      dictationId: "d-fractional-limit",
+      seq: 0,
+      audioBase64: buildPcmBase64(2000, 1000),
       format: "audio/pcm;rate=24000;bits=16",
     });
 
     expect(session.appended).toHaveLength(1);
-    expect(session.clearCalls).toBe(1);
-    expect(session.commitCalls).toBe(0);
+    expect(emittedErrors(emitted)).toHaveLength(0);
   });
 });

--- a/packages/server/src/server/dictation/dictation-stream-manager.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.ts
@@ -6,7 +6,7 @@ import {
   type DictationDebugChunkWriter,
 } from "../agent/dictation-debug.js";
 import { isPaseoDictationDebugEnabled } from "../agent/recordings-debug.js";
-import { Pcm16MonoResampler } from "../agent/pcm16-resampler.js";
+import { Pcm16MonoResampler, Pcm16ResamplerOutputLimitError } from "../agent/pcm16-resampler.js";
 import type {
   SpeechToTextProvider,
   StreamingTranscriptionSession,
@@ -28,6 +28,10 @@ const DICTATION_SILENCE_PEAK_THRESHOLD = Number.parseInt(
 );
 const DEFAULT_DICTATION_MAX_CHUNK_BYTES = 512 * 1024;
 const DEFAULT_DICTATION_HARD_SEGMENT_BYTES = 60 * 2 * 16000;
+const DICTATION_REORDER_SEQ_WINDOW = 4096;
+const DICTATION_REORDER_MAX_ENTRIES = 512;
+const DICTATION_REORDER_MAX_BYTES = 16 * 1024 * 1024;
+const DICTATION_DEBUG_TAIL_MAX_BYTES = 8 * 1024 * 1024;
 
 function parseNonNegativeNumber(value: string | undefined): number | null {
   if (value === undefined) {
@@ -38,6 +42,32 @@ function parseNonNegativeNumber(value: string | undefined): number | null {
     return null;
   }
   return parsed;
+}
+
+// Byte limits must be positive safe integers: 0, negatives, floats, NaN, and
+// junk strings all fall through to the next source instead of producing a
+// broken limit (e.g. a zero cap that rejects every chunk).
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function parsePositiveSafeInteger(value: string | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+  const parsed = Number(value);
+  return isPositiveSafeInteger(parsed) ? parsed : null;
+}
+
+function resolvePositiveSafeInteger(
+  explicit: number | undefined,
+  envValue: string | undefined,
+  fallback: number,
+): number {
+  if (isPositiveSafeInteger(explicit)) {
+    return explicit;
+  }
+  return parsePositiveSafeInteger(envValue) ?? fallback;
 }
 
 function convertPCMToWavBuffer(
@@ -77,10 +107,13 @@ interface DictationStreamState {
   inputRate: number;
   outputRate: number;
   resampler: Pcm16MonoResampler | null;
+  debugEnabled: boolean;
   debugAudioChunks: Buffer[];
+  debugAudioBytes: number;
   debugRecordingPath: string | null;
   debugChunkWriter: DictationDebugChunkWriter | null;
   receivedChunks: Map<number, Buffer>;
+  reorderBufferedBytes: number;
   nextSeqToForward: number;
   ackSeq: number;
   autoCommitBytes: number;
@@ -138,7 +171,6 @@ export class DictationStreamManager {
   private readonly maxChunkBytes: number;
   private readonly hardSegmentBytes: number;
   private readonly streams = new Map<string, DictationStreamState>();
-
   constructor(params: {
     logger: pino.Logger;
     emit: (msg: DictationStreamOutboundMessage) => void;
@@ -147,6 +179,8 @@ export class DictationStreamManager {
     language?: string;
     finalTimeoutMs?: number;
     autoCommitSeconds?: number;
+    maxChunkBytes?: number;
+    hardSegmentBytes?: number;
   }) {
     this.logger = params.logger.child({ component: "dictation-stream-manager" });
     this.emit = params.emit;
@@ -158,12 +192,16 @@ export class DictationStreamManager {
       params.autoCommitSeconds ??
       parseNonNegativeNumber(process.env.PASEO_DICTATION_AUTO_COMMIT_SECONDS) ??
       DEFAULT_DICTATION_AUTO_COMMIT_SECONDS;
-    this.maxChunkBytes =
-      parseNonNegativeNumber(process.env.PASEO_DICTATION_MAX_CHUNK_BYTES) ??
-      DEFAULT_DICTATION_MAX_CHUNK_BYTES;
-    this.hardSegmentBytes =
-      parseNonNegativeNumber(process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES) ??
-      DEFAULT_DICTATION_HARD_SEGMENT_BYTES;
+    this.maxChunkBytes = resolvePositiveSafeInteger(
+      params.maxChunkBytes,
+      process.env.PASEO_DICTATION_MAX_CHUNK_BYTES,
+      DEFAULT_DICTATION_MAX_CHUNK_BYTES,
+    );
+    this.hardSegmentBytes = resolvePositiveSafeInteger(
+      params.hardSegmentBytes,
+      process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES,
+      DEFAULT_DICTATION_HARD_SEGMENT_BYTES,
+    );
   }
 
   public cleanupAll(): void {
@@ -307,10 +345,13 @@ export class DictationStreamManager {
               inputRate,
               outputRate,
             }),
+      debugEnabled: isPaseoDictationDebugEnabled(),
       debugAudioChunks: [],
+      debugAudioBytes: 0,
       debugRecordingPath: null,
       debugChunkWriter,
       receivedChunks: new Map(),
+      reorderBufferedBytes: 0,
       nextSeqToForward: 0,
       ackSeq: -1,
       autoCommitBytes,
@@ -356,6 +397,7 @@ export class DictationStreamManager {
     }
 
     if (!state.receivedChunks.has(params.seq)) {
+      // Precheck bounds the decode allocation; the decoded length is the real limit.
       const maxEncodedLength = Math.ceil(this.maxChunkBytes / 3) * 4;
       if (params.audioBase64.length > maxEncodedLength) {
         const approxBytes = Math.floor((params.audioBase64.length * 3) / 4);
@@ -367,7 +409,28 @@ export class DictationStreamManager {
         return;
       }
       const decoded = Buffer.from(params.audioBase64, "base64");
+      if (decoded.length > this.maxChunkBytes) {
+        void this.failAndCleanupDictationStream(
+          params.dictationId,
+          `Dictation chunk of ${decoded.length} bytes exceeds the ${this.maxChunkBytes}-byte limit`,
+          true,
+        );
+        return;
+      }
+      const seqWindowExceeded = params.seq >= state.nextSeqToForward + DICTATION_REORDER_SEQ_WINDOW;
+      const entriesExceeded = state.receivedChunks.size >= DICTATION_REORDER_MAX_ENTRIES;
+      const bytesExceeded =
+        state.reorderBufferedBytes + decoded.length > DICTATION_REORDER_MAX_BYTES;
+      if (seqWindowExceeded || entriesExceeded || bytesExceeded) {
+        void this.failAndCleanupDictationStream(
+          params.dictationId,
+          `Dictation reorder buffer limit exceeded (seq=${params.seq}, nextToForward=${state.nextSeqToForward}, buffered=${state.receivedChunks.size} entries / ${state.reorderBufferedBytes} bytes)`,
+          true,
+        );
+        return;
+      }
       state.receivedChunks.set(params.seq, decoded);
+      state.reorderBufferedBytes += decoded.length;
     }
 
     while (state.receivedChunks.has(state.nextSeqToForward)) {
@@ -375,29 +438,33 @@ export class DictationStreamManager {
       const pcm16 = state.receivedChunks.get(seq)!;
       state.receivedChunks.delete(seq);
 
-      const resampled = state.resampler ? state.resampler.processChunk(pcm16) : pcm16;
-      if (resampled.length > 0) {
-        state.stt.appendPcm16(resampled);
-        state.debugAudioChunks.push(resampled);
-        state.bytesSinceCommit += resampled.length;
-        state.peakSinceCommit = Math.max(state.peakSinceCommit, pcm16lePeakAbs(resampled));
-        try {
+      let resampled: Buffer;
+      try {
+        resampled = state.resampler ? state.resampler.processChunk(pcm16) : pcm16;
+        if (resampled.length > 0) {
+          state.stt.appendPcm16(resampled);
+          this.retainDictationDebugAudio(state, resampled);
+          state.bytesSinceCommit += resampled.length;
+          state.peakSinceCommit = Math.max(state.peakSinceCommit, pcm16lePeakAbs(resampled));
           this.maybeAutoCommitDictationSegment(state);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          void this.failAndCleanupDictationStream(params.dictationId, message, true);
-          return;
         }
-
-        if (state.debugChunkWriter) {
-          void state.debugChunkWriter.writeChunk(seq, resampled).catch((err) => {
-            this.logger.warn(
-              { dictationId: params.dictationId, seq, err },
-              "Failed to write debug chunk",
-            );
-          });
-        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const retryable = !(error instanceof Pcm16ResamplerOutputLimitError);
+        void this.failAndCleanupDictationStream(params.dictationId, message, retryable);
+        return;
       }
+
+      if (resampled.length > 0 && state.debugChunkWriter) {
+        void state.debugChunkWriter.writeChunk(seq, resampled).catch((err) => {
+          this.logger.warn(
+            { dictationId: params.dictationId, seq, err },
+            "Failed to write debug chunk",
+          );
+        });
+      }
+
+      state.reorderBufferedBytes -= pcm16.length;
 
       state.nextSeqToForward += 1;
       state.ackSeq = state.nextSeqToForward - 1;
@@ -498,13 +565,35 @@ export class DictationStreamManager {
     this.emit({ type: "dictation_stream_partial", payload: { dictationId, text } });
   }
 
-  private async maybePersistDictationStreamAudio(dictationId: string): Promise<string | null> {
-    if (!isPaseoDictationDebugEnabled()) {
-      return null;
+  // Retains a bounded recent-audio tail for debug persistence. Streams that run
+  // with debug disabled never hold PCM; enabled streams drop the tail whenever
+  // it would exceed the cap and at every segment boundary (commit/clear).
+  private retainDictationDebugAudio(state: DictationStreamState, pcm16: Buffer): void {
+    if (!state.debugEnabled) {
+      return;
     }
+    // A single chunk larger than the tail cannot fit; dropping it whole keeps
+    // the retained bytes at or under the cap without copying a trimmed slice.
+    if (pcm16.length > DICTATION_DEBUG_TAIL_MAX_BYTES) {
+      state.debugAudioChunks.length = 0;
+      state.debugAudioBytes = 0;
+      return;
+    }
+    if (state.debugAudioBytes + pcm16.length > DICTATION_DEBUG_TAIL_MAX_BYTES) {
+      state.debugAudioChunks.length = 0;
+      state.debugAudioBytes = 0;
+    }
+    state.debugAudioChunks.push(pcm16);
+    state.debugAudioBytes += pcm16.length;
+  }
 
-    const state = this.streams.get(dictationId);
-    if (!state) {
+  private releaseDictationDebugTail(state: DictationStreamState): void {
+    state.debugAudioChunks.length = 0;
+    state.debugAudioBytes = 0;
+  }
+
+  private async persistDictationStreamAudio(state: DictationStreamState): Promise<string | null> {
+    if (!state.debugEnabled) {
       return null;
     }
     if (state.debugRecordingPath) {
@@ -543,7 +632,13 @@ export class DictationStreamManager {
     error: string,
     retryable: boolean,
   ): Promise<void> {
-    const debugRecordingPath = await this.maybePersistDictationStreamAudio(dictationId);
+    // Detach first so concurrent messages observe the stream as closed while
+    // the bounded debug persist runs, and so exactly one failure is emitted.
+    const state = this.detachDictationStream(dictationId);
+    if (!state) {
+      return;
+    }
+    const debugRecordingPath = await this.persistDictationStreamAudio(state);
     this.emit({
       type: "dictation_stream_error",
       payload: {
@@ -565,14 +660,14 @@ export class DictationStreamManager {
         },
       });
     }
-    this.cleanupDictationStream(dictationId);
   }
 
-  private cleanupDictationStream(dictationId: string): void {
-    const state = this.streams.get(dictationId) ?? null;
+  private detachDictationStream(dictationId: string): DictationStreamState | null {
+    const state = this.streams.get(dictationId);
     if (!state) {
-      return;
+      return null;
     }
+    this.streams.delete(dictationId);
     if (state.finalTimeout) {
       clearTimeout(state.finalTimeout);
     }
@@ -581,7 +676,11 @@ export class DictationStreamManager {
     } catch {
       // no-op
     }
-    this.streams.delete(dictationId);
+    return state;
+  }
+
+  private cleanupDictationStream(dictationId: string): void {
+    this.detachDictationStream(dictationId);
   }
 
   private estimateFinalizationTimeout(state: DictationStreamState): {
@@ -630,12 +729,13 @@ export class DictationStreamManager {
   }
 
   private maybeAutoCommitDictationSegment(state: DictationStreamState): void {
-    if (state.finishRequested) {
-      return;
-    }
-    const autoCommitReached =
-      state.autoCommitBytes > 0 && state.bytesSinceCommit >= state.autoCommitBytes;
+    // The hard cap stays active while finish is pending (missing/out-of-order chunks
+    // may keep arriving); only the periodic auto-commit pauses once finish is requested.
     const hardCapReached = state.bytesSinceCommit >= this.hardSegmentBytes;
+    const autoCommitReached =
+      !state.finishRequested &&
+      state.autoCommitBytes > 0 &&
+      state.bytesSinceCommit >= state.autoCommitBytes;
     if (!autoCommitReached && !hardCapReached) {
       return;
     }
@@ -643,12 +743,16 @@ export class DictationStreamManager {
       state.stt.clear();
       state.bytesSinceCommit = 0;
       state.peakSinceCommit = 0;
+      this.releaseDictationDebugTail(state);
       return;
     }
 
+    // Commit before resetting so a throwing commit fails the stream with the
+    // fault audio still retained for debug persistence.
+    state.stt.commit();
     state.bytesSinceCommit = 0;
     state.peakSinceCommit = 0;
-    state.stt.commit();
+    this.releaseDictationDebugTail(state);
   }
 
   private maybeSealDictationStreamFinish(dictationId: string): void {
@@ -679,6 +783,7 @@ export class DictationStreamManager {
         state.stt.clear();
         state.bytesSinceCommit = 0;
         state.peakSinceCommit = 0;
+        this.releaseDictationDebugTail(state);
         state.awaitingFinalCommit = false;
         const droppedSegments = this.dropUncommittedNonFinalTranscripts(state);
         if (droppedSegments > 0) {
@@ -749,7 +854,7 @@ export class DictationStreamManager {
 
     if (orderedSegmentIds.length === 0) {
       void (async () => {
-        const debugRecordingPath = await this.maybePersistDictationStreamAudio(dictationId);
+        const debugRecordingPath = await this.persistDictationStreamAudio(state);
         this.emit({
           type: "dictation_stream_final",
           payload: {
@@ -788,7 +893,7 @@ export class DictationStreamManager {
       .trim();
 
     void (async () => {
-      const debugRecordingPath = await this.maybePersistDictationStreamAudio(dictationId);
+      const debugRecordingPath = await this.persistDictationStreamAudio(state);
       this.emit({
         type: "dictation_stream_final",
         payload: {

--- a/packages/server/src/server/dictation/dictation-stream-manager.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.ts
@@ -26,6 +26,8 @@ const DICTATION_SILENCE_PEAK_THRESHOLD = Number.parseInt(
   process.env.PASEO_DICTATION_SILENCE_PEAK_THRESHOLD ?? "300",
   10,
 );
+const DEFAULT_DICTATION_MAX_CHUNK_BYTES = 512 * 1024;
+const DEFAULT_DICTATION_HARD_SEGMENT_BYTES = 60 * 2 * 16000;
 
 function parseNonNegativeNumber(value: string | undefined): number | null {
   if (value === undefined) {
@@ -133,6 +135,8 @@ export class DictationStreamManager {
   private readonly language: string;
   private readonly finalTimeoutMs: number;
   private readonly autoCommitSeconds: number;
+  private readonly maxChunkBytes: number;
+  private readonly hardSegmentBytes: number;
   private readonly streams = new Map<string, DictationStreamState>();
 
   constructor(params: {
@@ -154,6 +158,12 @@ export class DictationStreamManager {
       params.autoCommitSeconds ??
       parseNonNegativeNumber(process.env.PASEO_DICTATION_AUTO_COMMIT_SECONDS) ??
       DEFAULT_DICTATION_AUTO_COMMIT_SECONDS;
+    this.maxChunkBytes =
+      parseNonNegativeNumber(process.env.PASEO_DICTATION_MAX_CHUNK_BYTES) ??
+      DEFAULT_DICTATION_MAX_CHUNK_BYTES;
+    this.hardSegmentBytes =
+      parseNonNegativeNumber(process.env.PASEO_DICTATION_HARD_SEGMENT_BYTES) ??
+      DEFAULT_DICTATION_HARD_SEGMENT_BYTES;
   }
 
   public cleanupAll(): void {
@@ -346,7 +356,16 @@ export class DictationStreamManager {
     }
 
     if (!state.receivedChunks.has(params.seq)) {
-      state.receivedChunks.set(params.seq, Buffer.from(params.audioBase64, "base64"));
+      const decoded = Buffer.from(params.audioBase64, "base64");
+      if (decoded.length > this.maxChunkBytes) {
+        void this.failAndCleanupDictationStream(
+          params.dictationId,
+          `Dictation chunk of ${decoded.length} bytes exceeds the ${this.maxChunkBytes}-byte limit`,
+          true,
+        );
+        return;
+      }
+      state.receivedChunks.set(params.seq, decoded);
     }
 
     while (state.receivedChunks.has(state.nextSeqToForward)) {
@@ -612,7 +631,10 @@ export class DictationStreamManager {
     if (state.finishRequested) {
       return;
     }
-    if (state.autoCommitBytes <= 0 || state.bytesSinceCommit < state.autoCommitBytes) {
+    const autoCommitReached =
+      state.autoCommitBytes > 0 && state.bytesSinceCommit >= state.autoCommitBytes;
+    const hardCapReached = state.bytesSinceCommit >= this.hardSegmentBytes;
+    if (!autoCommitReached && !hardCapReached) {
       return;
     }
     if (state.peakSinceCommit < DICTATION_SILENCE_PEAK_THRESHOLD) {

--- a/packages/server/src/server/dictation/dictation-stream-manager.ts
+++ b/packages/server/src/server/dictation/dictation-stream-manager.ts
@@ -356,15 +356,17 @@ export class DictationStreamManager {
     }
 
     if (!state.receivedChunks.has(params.seq)) {
-      const decoded = Buffer.from(params.audioBase64, "base64");
-      if (decoded.length > this.maxChunkBytes) {
+      const maxEncodedLength = Math.ceil(this.maxChunkBytes / 3) * 4;
+      if (params.audioBase64.length > maxEncodedLength) {
+        const approxBytes = Math.floor((params.audioBase64.length * 3) / 4);
         void this.failAndCleanupDictationStream(
           params.dictationId,
-          `Dictation chunk of ${decoded.length} bytes exceeds the ${this.maxChunkBytes}-byte limit`,
+          `Dictation chunk of ~${approxBytes} bytes exceeds the ${this.maxChunkBytes}-byte limit`,
           true,
         );
         return;
       }
+      const decoded = Buffer.from(params.audioBase64, "base64");
       state.receivedChunks.set(params.seq, decoded);
     }
 


### PR DESCRIPTION
## Problem

A connected client can reach the local dictation pipeline with two unbounded inputs:

1. `dictation_stream_chunk` accepts an arbitrarily large base64 `audio` string; the manager decodes it into a full `Buffer` before any size check.
2. Uncommitted PCM accumulates in the streaming STT session without a cap. The 15 s auto-commit only runs *after* an oversized chunk has been appended, and setting `PASEO_DICTATION_AUTO_COMMIT_SECONDS=0` disables it entirely — so a client can stream indefinitely while every scheduled partial decode re-processes the entire accumulated buffer (memory growth plus superlinear CPU on the shared local-speech worker).

This affects every local offline model (Parakeet today, Paraformer incoming via #3689).

## Fix

Server-side only; no wire schema change (`.max()` on the inbound schema would narrow the protocol contract).

- **Chunk cap** — `handleChunk` rejects decoded PCM above `PASEO_DICTATION_MAX_CHUNK_BYTES` (default 512 KB ≈ 16 s @ 16 kHz mono) before it enters the reorder buffer, failing the stream with an explicit retryable error.
- **Segment cap** — `maybeAutoCommitDictationSegment` now also trips on a hard budget, `PASEO_DICTATION_HARD_SEGMENT_BYTES` (default 60 s @ 16 kHz mono ≈ 4× the default auto-commit window), independent of the silence threshold and of whether auto-commit is enabled. Silence semantics are preserved: a silent over-budget segment is cleared rather than decoded.

Normal clients (100 ms chunks, 15 s auto-commit) never approach either limit.

## Verification

- `dictation-stream-manager.test.ts` gains three regression tests: oversized chunk fails the stream without appending; a loud segment crossing the hard cap forces a commit with auto-commit disabled; a silent over-budget segment clears instead of committing. Full file: 14/14.
- `@getpaseo/server` typecheck green against the full workspace toolchain.

Related: #3689 discloses this as a known limitation and links here.