### PR TITLE
fix(app): stop a string SVG transform from crashing the app

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -502,6 +502,36 @@ For tighter loops, you can rebuild a single workspace:
 - Changed `packages/server/src/*`, `packages/cli/src/*`, `packages/relay/src/*`, or `packages/highlight/src/*`: `npm run build:server`.
 - Changed app build dependencies: `npm run build:app-deps`.
 
+## Dependency patches
+
+`patches/*.patch` are applied by `scripts/postinstall-patches.mjs` on every install. A patch only
+runs when its package is actually present, so add the package to that script's `patchedPackages`
+list when you introduce a new patch — otherwise the file sits in `patches/` and never applies.
+Regenerate a patch with `npx patch-package <package>` after editing `node_modules/<package>`, and
+patch every build the consumers use: Metro resolves the `react-native` field of a package
+(`src/*.ts` for `react-native-svg`), while Node and Vitest resolve `main`/`module`
+(`lib/commonjs`, `lib/module`). Patching only `lib/` leaves the app bundle unfixed.
+
+### react-native-svg: string transforms on a root `<Svg>`
+
+A root `<Svg>` is a real React Native view, so react-native-svg rewrites a _string_ `transform`
+into RN style syntax with a PEG parser that only accepts SVG transform functions. Upstream lets
+that parser's `SyntaxError` escape, so any string it does not understand — `none`,
+`rotate(-90deg)`, any CSS value — crashes the app during render with
+`Expected transform functions but "n" found`. Every other extractor in that file already swallows
+the same error; `patches/react-native-svg+15.15.3.patch` makes this one do the same and fall back
+to no transform.
+
+This matters because we render untrusted SVG: the daemon scans a project for `favicon.svg` /
+`icon.svg` / `logo.svg` (`packages/server/src/utils/project-icon.ts`) and ships it to the client,
+where `ProjectIconImage` hands it to `SvgCss` — which inlines `<style>` rules onto the root
+`<svg>` as a string `style.transform`. `SvgXml` does the same for a root `style="transform:…"`
+attribute. Note that an RN-style array (`style={{ transform: [{ rotate: "-90deg" }] }}`, which the
+context window meter and the checks ring both use) is _not_ affected: the extractor returns arrays
+untouched and only parses strings.
+
+`packages/app/src/components/svg-root-transform.test.ts` pins the patched behavior.
+
 ## ACP provider catalog versions
 
 The in-app ACP provider catalog pins package-runner entries (`npx`, `npm exec`,

--- a/docs/development.md
+++ b/docs/development.md
@@ -512,26 +512,6 @@ patch every build the consumers use: Metro resolves the `react-native` field of 
 (`src/*.ts` for `react-native-svg`), while Node and Vitest resolve `main`/`module`
 (`lib/commonjs`, `lib/module`). Patching only `lib/` leaves the app bundle unfixed.
 
-### react-native-svg: string transforms on a root `<Svg>`
-
-A root `<Svg>` is a real React Native view, so react-native-svg rewrites a _string_ `transform`
-into RN style syntax with a PEG parser that only accepts SVG transform functions. Upstream lets
-that parser's `SyntaxError` escape, so any string it does not understand — `none`,
-`rotate(-90deg)`, any CSS value — crashes the app during render with
-`Expected transform functions but "n" found`. Every other extractor in that file already swallows
-the same error; `patches/react-native-svg+15.15.3.patch` makes this one do the same and fall back
-to no transform.
-
-This matters because we render untrusted SVG: the daemon scans a project for `favicon.svg` /
-`icon.svg` / `logo.svg` (`packages/server/src/utils/project-icon.ts`) and ships it to the client,
-where `ProjectIconImage` hands it to `SvgCss` — which inlines `<style>` rules onto the root
-`<svg>` as a string `style.transform`. `SvgXml` does the same for a root `style="transform:…"`
-attribute. Note that an RN-style array (`style={{ transform: [{ rotate: "-90deg" }] }}`, which the
-context window meter and the checks ring both use) is _not_ affected: the extractor returns arrays
-untouched and only parses strings.
-
-`packages/app/src/components/svg-root-transform.test.ts` pins the patched behavior.
-
 ## ACP provider catalog versions
 
 The in-app ACP provider catalog pins package-runner entries (`npx`, `npm exec`,

--- a/packages/app/src/components/svg-root-transform.test.ts
+++ b/packages/app/src/components/svg-root-transform.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * A root `<Svg>` is a real React Native view, so react-native-svg rewrites a *string*
+ * `transform` into RN's style syntax via `extractTransformSvgView`. That parser's grammar only
+ * accepts SVG transform functions and throws a `SyntaxError` on anything else — `none`,
+ * `rotate(-90deg)`, any CSS value. Upstream let the error escape, so a single unrecognised
+ * string crashed the whole app during render:
+ *
+ *   SyntaxError: Expected transform functions but "n" found.
+ *
+ * We render untrusted SVG through this path: the daemon ships a project's own `favicon.svg` /
+ * `icon.svg` / `logo.svg` (packages/server/src/utils/project-icon.ts) to the client, and
+ * `ProjectIconImage` hands it to `SvgCss`, which inlines `<style>` rules onto the root `<svg>`.
+ * `patches/react-native-svg+15.15.3.patch` makes the extractor degrade to "no transform", the
+ * same way every other extractor in that file already handles a bad parse.
+ *
+ * These assertions pin the patch. If it is dropped — or a dependency bump lands without
+ * re-applying it — the string cases throw again and this fails.
+ */
+
+const MODULES = {
+  // Metro's entry for this package is `src/index.ts`, so this is the copy the iOS bundle uses.
+  src: "react-native-svg/src/lib/extract/extractTransform.ts",
+  esm: "react-native-svg/lib/module/lib/extract/extractTransform",
+  cjs: "react-native-svg/lib/commonjs/lib/extract/extractTransform.js",
+} as const;
+
+type Extractor = (props: { transform?: unknown }) => unknown;
+
+async function loadExtractor(specifier: string): Promise<Extractor> {
+  const loaded = (await import(/* @vite-ignore */ specifier)) as {
+    extractTransformSvgView?: Extractor;
+    default?: { extractTransformSvgView?: Extractor };
+  };
+  const extractor = loaded.extractTransformSvgView ?? loaded.default?.extractTransformSvgView;
+  if (!extractor) throw new Error(`no extractTransformSvgView export in ${specifier}`);
+  return extractor;
+}
+
+describe.each(Object.entries(MODULES))("extractTransformSvgView (%s build)", (_name, specifier) => {
+  it("passes a React Native style transform through untouched", async () => {
+    const extract = await loadExtractor(specifier);
+    const transform = [{ rotate: "-90deg" }];
+
+    expect(extract({ transform })).toEqual(transform);
+  });
+
+  it("still converts a real SVG transform string", async () => {
+    const extract = await loadExtractor(specifier);
+
+    expect(extract({ transform: "rotate(-90)" })).toEqual([{ rotate: "-90deg" }]);
+  });
+
+  it.each([
+    ["none", "none"],
+    ["a CSS angle unit", "rotate(-90deg)"],
+    ["a CSS length unit", "translate(10px, 0)"],
+    ["an empty string", ""],
+    ["arbitrary text", "not-a-transform"],
+  ])("drops %s instead of throwing", async (_label, transform) => {
+    const extract = await loadExtractor(specifier);
+
+    expect(() => extract({ transform })).not.toThrow();
+    expect(extract({ transform })).toBeUndefined();
+  });
+});

--- a/packages/app/src/components/svg-root-transform.test.ts
+++ b/packages/app/src/components/svg-root-transform.test.ts
@@ -1,67 +1,70 @@
 import { describe, expect, it } from "vitest";
 
-/**
- * A root `<Svg>` is a real React Native view, so react-native-svg rewrites a *string*
- * `transform` into RN's style syntax via `extractTransformSvgView`. That parser's grammar only
- * accepts SVG transform functions and throws a `SyntaxError` on anything else — `none`,
- * `rotate(-90deg)`, any CSS value. Upstream let the error escape, so a single unrecognised
- * string crashed the whole app during render:
- *
- *   SyntaxError: Expected transform functions but "n" found.
- *
- * We render untrusted SVG through this path: the daemon ships a project's own `favicon.svg` /
- * `icon.svg` / `logo.svg` (packages/server/src/utils/project-icon.ts) to the client, and
- * `ProjectIconImage` hands it to `SvgCss`, which inlines `<style>` rules onto the root `<svg>`.
- * `patches/react-native-svg+15.15.3.patch` makes the extractor degrade to "no transform", the
- * same way every other extractor in that file already handles a bad parse.
- *
- * These assertions pin the patch. If it is dropped — or a dependency bump lands without
- * re-applying it — the string cases throw again and this fails.
- */
-
-const MODULES = {
-  // Metro's entry for this package is `src/index.ts`, so this is the copy the iOS bundle uses.
+const BUILDS = {
+  // Metro resolves src; Node consumers resolve one of the compiled builds.
   src: "react-native-svg/src/lib/extract/extractTransform.ts",
   esm: "react-native-svg/lib/module/lib/extract/extractTransform",
   cjs: "react-native-svg/lib/commonjs/lib/extract/extractTransform.js",
 } as const;
 
-type Extractor = (props: { transform?: unknown }) => unknown;
+const CSS_MODULE = "react-native-svg/src/css/index.tsx";
+const XML_MODULE = "react-native-svg/src/xml.tsx";
 
-async function loadExtractor(specifier: string): Promise<Extractor> {
-  const loaded = (await import(/* @vite-ignore */ specifier)) as {
-    extractTransformSvgView?: Extractor;
-    default?: { extractTransformSvgView?: Extractor };
+type Extractor = (props: { transform?: unknown }) => unknown;
+type XmlMiddleware = (root: unknown) => unknown;
+interface ParsedRoot {
+  props: Record<string, unknown>;
+}
+type XmlParser = (source: string, middleware?: XmlMiddleware) => ParsedRoot | null;
+
+async function loadBuild(extractSpecifier: string) {
+  const [cssModule, extractModule, xmlModule] = (await Promise.all([
+    import(/* @vite-ignore */ CSS_MODULE),
+    import(/* @vite-ignore */ extractSpecifier),
+    import(/* @vite-ignore */ XML_MODULE),
+  ])) as [
+    { inlineStyles?: XmlMiddleware; default?: { inlineStyles?: XmlMiddleware } },
+    {
+      extractTransformSvgView?: Extractor;
+      default?: { extractTransformSvgView?: Extractor };
+    },
+    { parse?: XmlParser; default?: { parse?: XmlParser } },
+  ];
+  const inlineStyles = cssModule.inlineStyles ?? cssModule.default?.inlineStyles;
+  const extract =
+    extractModule.extractTransformSvgView ?? extractModule.default?.extractTransformSvgView;
+  const parseXml = xmlModule.parse ?? xmlModule.default?.parse;
+  if (!inlineStyles || !extract || !parseXml)
+    throw new Error(`could not load react-native-svg build`);
+
+  return (xml: string) => {
+    const root = parseXml(xml, inlineStyles);
+    if (!root) throw new Error(`could not parse root SVG`);
+    const props = { ...root.props };
+    const style = props.style;
+    if (style && typeof style === "object" && "transform" in style) {
+      props.transform = style.transform;
+    }
+    return extract(props);
   };
-  const extractor = loaded.extractTransformSvgView ?? loaded.default?.extractTransformSvgView;
-  if (!extractor) throw new Error(`no extractTransformSvgView export in ${specifier}`);
-  return extractor;
 }
 
-describe.each(Object.entries(MODULES))("extractTransformSvgView (%s build)", (_name, specifier) => {
-  it("passes a React Native style transform through untouched", async () => {
-    const extract = await loadExtractor(specifier);
-    const transform = [{ rotate: "-90deg" }];
-
-    expect(extract({ transform })).toEqual(transform);
-  });
-
+describe.each(Object.entries(BUILDS))("root SVG transforms (%s build)", (_name, specifier) => {
   it("still converts a real SVG transform string", async () => {
-    const extract = await loadExtractor(specifier);
+    const extractFromXml = await loadBuild(specifier);
 
-    expect(extract({ transform: "rotate(-90)" })).toEqual([{ rotate: "-90deg" }]);
+    expect(extractFromXml(`<svg transform="rotate(-90)"></svg>`)).toEqual([{ rotate: "-90deg" }]);
   });
 
   it.each([
-    ["none", "none"],
-    ["a CSS angle unit", "rotate(-90deg)"],
-    ["a CSS length unit", "translate(10px, 0)"],
-    ["an empty string", ""],
-    ["arbitrary text", "not-a-transform"],
-  ])("drops %s instead of throwing", async (_label, transform) => {
-    const extract = await loadExtractor(specifier);
+    ["an inline CSS keyword", `<svg style="transform:none"></svg>`],
+    ["an embedded CSS rule", `<svg><style>svg { transform: none; }</style></svg>`],
+    ["a CSS angle unit", `<svg transform="rotate(-90deg)"></svg>`],
+    ["a CSS length unit", `<svg transform="translate(10px, 0)"></svg>`],
+  ])("drops %s from parsed root SVG props", async (_label, xml) => {
+    const extractFromXml = await loadBuild(specifier);
 
-    expect(() => extract({ transform })).not.toThrow();
-    expect(extract({ transform })).toBeUndefined();
+    expect(() => extractFromXml(xml)).not.toThrow();
+    expect(extractFromXml(xml)).toBeUndefined();
   });
 });

--- a/patches/react-native-svg+15.15.3.patch
+++ b/patches/react-native-svg+15.15.3.patch
@@ -1,0 +1,61 @@
+diff --git a/node_modules/react-native-svg/lib/commonjs/lib/extract/extractTransform.js b/node_modules/react-native-svg/lib/commonjs/lib/extract/extractTransform.js
+index f22cca3..0a73681 100644
+--- a/node_modules/react-native-svg/lib/commonjs/lib/extract/extractTransform.js
++++ b/node_modules/react-native-svg/lib/commonjs/lib/extract/extractTransform.js
+@@ -152,7 +152,12 @@ function extractTransform(props) {
+ }
+ function extractTransformSvgView(props) {
+   if (typeof props.transform === 'string') {
+-    return (0, _transformToRn.parse)(props.transform);
++    try {
++      return (0, _transformToRn.parse)(props.transform);
++    } catch (e) {
++      console.error(e);
++      return undefined;
++    }
+   }
+   return props.transform;
+ }
+diff --git a/node_modules/react-native-svg/lib/module/lib/extract/extractTransform.js b/node_modules/react-native-svg/lib/module/lib/extract/extractTransform.js
+index c9d3d6a..085586c 100644
+--- a/node_modules/react-native-svg/lib/module/lib/extract/extractTransform.js
++++ b/node_modules/react-native-svg/lib/module/lib/extract/extractTransform.js
+@@ -142,7 +142,12 @@ export default function extractTransform(props) {
+ }
+ export function extractTransformSvgView(props) {
+   if (typeof props.transform === 'string') {
+-    return parseTransformSvgToRnStyle(props.transform);
++    try {
++      return parseTransformSvgToRnStyle(props.transform);
++    } catch (e) {
++      console.error(e);
++      return undefined;
++    }
+   }
+   return props.transform;
+ }
+diff --git a/node_modules/react-native-svg/src/lib/extract/extractTransform.ts b/node_modules/react-native-svg/src/lib/extract/extractTransform.ts
+index 0c854d6..7dc2828 100644
+--- a/node_modules/react-native-svg/src/lib/extract/extractTransform.ts
++++ b/node_modules/react-native-svg/src/lib/extract/extractTransform.ts
+@@ -216,7 +216,19 @@ export function extractTransformSvgView(
+   props: TransformsStyle
+ ): TransformsStyle['transform'] {
+   if (typeof props.transform === 'string') {
+-    return parseTransformSvgToRnStyle(props.transform);
++    // A root <Svg> is a real RN view, so a string transform has to be rewritten into RN's
++    // style syntax. The grammar behind this parser only accepts SVG transform functions and
++    // throws on anything else - including ordinary CSS (`none`, `rotate(-90deg)`). Every other
++    // extractor in this file already swallows that error; this one did not, so one unrecognised
++    // string escaped as an uncaught SyntaxError during render and took the whole app down.
++    // Untrusted SVG reaches this path (a repository's own favicon.svg/logo.svg is rendered
++    // through SvgXml/SvgCss), so degrade to "no transform" like the rest of the library.
++    try {
++      return parseTransformSvgToRnStyle(props.transform);
++    } catch (e) {
++      console.error(e);
++      return undefined;
++    }
+   }
+   return props.transform as TransformsStyle['transform'];
+ }

--- a/scripts/postinstall-patches.mjs
+++ b/scripts/postinstall-patches.mjs
@@ -21,6 +21,10 @@ const patchedPackages = [
     patchPrefix: "react-native-gesture-handler+",
   },
   {
+    nodeModulesPath: "node_modules/react-native-svg",
+    patchPrefix: "react-native-svg+",
+  },
+  {
     nodeModulesPath: "node_modules/@mattermost/react-native-paste-input",
     patchPrefix: "@mattermost+react-native-paste-input+",
   },


### PR DESCRIPTION
### Linked issue

Closes #3698

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

A project SVG icon can put a CSS transform string such as `none` on its root `<svg>`. `react-native-svg` passes that value to a parser that accepts SVG transform functions only and lets its `SyntaxError` escape during render, taking the app down as soon as the sidebar loads the icon.

The dependency patch makes the root SVG extractor degrade to no transform on an invalid string, matching the error handling used by its sibling extractors. It covers the Metro source build and both compiled builds, and the postinstall runner now applies it whenever `react-native-svg` is installed.

### Goals

- Keep malformed root transform strings in project SVG icons from crashing the app.
- Preserve valid SVG transforms.
- Apply and test the patch across the Metro, ESM, and CommonJS builds consumers resolve.
- Fail CI if a dependency update drops the patch.

### Non-goals

- Convert CSS transform syntax into React Native transform syntax.
- Change existing React Native array transforms.
- Sanitize SVG at individual app call sites.

### QA

#### iOS simulator

Used the installed Paseo development client with a fresh Expo bundle and an isolated daemon. Registered a disposable project whose `favicon.svg` root contained `style="transform:none"`, then opened the sidebar.

- Patch locally reversed: reproduced Paseo's fatal render boundary with `Expected transform functions but "n" found`, `found: "n"`, offset 0. The component stack ran through `Svg`, `SvgAst`, `SvgCss`, and `ProjectIconImage`.
- Patch restored: the same cached project icon and sidebar rendered without a fatal error.

#### Regression test

`cd packages/app && npx vitest run src/components/svg-root-transform.test.ts --project unit --bail=1`

The 15 cases parse real root SVG input through `react-native-svg`'s XML and CSS parser, including inline styles and embedded `<style>` rules, then exercise the Metro, ESM, and CommonJS extractors.

- Patch applied: 15 passed.
- Metro source patch reversed: failed with `Expected transform functions but "n" found` from `<svg style="transform:none">`.

#### Install and repository checks

- `npm run postinstall` applies `react-native-svg@15.15.3` successfully.
- `npm run typecheck` passes.
- `npm run lint` passes with 0 warnings and 0 errors.
- `npm run format` passes.

### Risk surface

The behavior change is limited to invalid string transforms on root SVG views: they are ignored and logged instead of escaping as render exceptions. Valid SVG transform strings continue to convert normally. The dependency patch must be refreshed when `react-native-svg` changes version.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
