### PR TITLE
Show Cursor Settings usage as official model-pool percentages

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -145,7 +145,7 @@ Keep the protocol shape provider-agnostic. Do not add provider-specific renderer
 
 Kimi Code usage follows the CLI-managed credential file at `KIMI_CODE_HOME` or `~/.kimi-code/credentials/kimi-code.json`; do not probe the legacy `~/.kimi` path as the primary source for current Kimi Code installs.
 
-Cursor usage reads the desktop `state.vscdb` token first, then `cursor-agent`'s `~/.config/cursor/auth.json`. Headless hosts only have the CLI file.
+Cursor usage uses `CURSOR_ACCESS_TOKEN` / `CURSOR_TOKEN` if set, otherwise the desktop `state.vscdb` token, then `cursor-agent`'s `~/.config/cursor/auth.json`. Headless hosts only have the CLI file.
 
 ---
 

--- a/packages/server/src/services/quota-fetcher/providers/cursor.ts
+++ b/packages/server/src/services/quota-fetcher/providers/cursor.ts
@@ -4,15 +4,22 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Logger } from "pino";
 import { z } from "zod";
-import type { ProviderUsage, ProviderUsageBalance } from "../../../server/messages.js";
+import type {
+  ProviderUsage,
+  ProviderUsageBalance,
+  ProviderUsageDetail,
+  ProviderUsageWindow,
+} from "../../../server/messages.js";
 import type { ProviderApiFetch, ProviderUsageFetcher } from "../provider.js";
 import {
   ApiNullableNumberSchema,
+  balanceToneFromRemaining,
   toneFromUsedPct,
   usedPctOf,
   fetchProviderApi,
   toIsoStringOrNull,
   unavailableUsage,
+  windowFromUsedPct,
 } from "../usage.js";
 
 // Cursor desktop stores auth in VS Code's ItemTable (state.vscdb). Modern builds keep
@@ -42,25 +49,66 @@ const CursorBillingCycleTimestampSchema = z.preprocess(
   z.union([z.string(), z.number()]).nullable(),
 );
 
+// cursor.com/dashboard/spending: Express/Start (India) is a single total-% bar
+// (`DW` / "Monthly usage"). Pro/Pro+/Ultra and current Teams use two pools.
+const SINGLE_POOL_PLAN_NAMES = new Set(["start", "express"]);
+
+const CursorPlanUsageSchema = z.object({
+  totalSpend: ApiNullableNumberSchema,
+  includedSpend: ApiNullableNumberSchema,
+  bonusSpend: ApiNullableNumberSchema,
+  remaining: ApiNullableNumberSchema,
+  limit: ApiNullableNumberSchema,
+  autoPercentUsed: ApiNullableNumberSchema,
+  apiPercentUsed: ApiNullableNumberSchema,
+  totalPercentUsed: ApiNullableNumberSchema,
+});
+
+const CursorSpendLimitUsageSchema = z.object({
+  totalSpend: ApiNullableNumberSchema,
+  pooledLimit: ApiNullableNumberSchema,
+  pooledUsed: ApiNullableNumberSchema,
+  pooledRemaining: ApiNullableNumberSchema,
+  individualLimit: ApiNullableNumberSchema,
+  individualUsed: ApiNullableNumberSchema,
+  individualRemaining: ApiNullableNumberSchema,
+  limitType: z.string().nullish(),
+});
+
 const CursorUsageResponseSchema = z.object({
-  planUsage: z
-    .object({
-      totalSpend: ApiNullableNumberSchema,
-      includedSpend: ApiNullableNumberSchema,
-      bonusSpend: ApiNullableNumberSchema,
-      remaining: ApiNullableNumberSchema,
-      limit: ApiNullableNumberSchema,
-    })
-    .nullish(),
+  planUsage: CursorPlanUsageSchema.nullish(),
+  spendLimitUsage: CursorSpendLimitUsageSchema.nullish(),
   billingCycleStart: CursorBillingCycleTimestampSchema,
   billingCycleEnd: CursorBillingCycleTimestampSchema,
+  autoModelSelectedDisplayMessage: z.string().nullish(),
+  namedModelSelectedDisplayMessage: z.string().nullish(),
 });
+
+const CursorPlanInfoResponseSchema = z.object({
+  planInfo: z
+    .object({
+      planName: z.string().optional(),
+    })
+    .nullish(),
+});
+
+const CursorHardLimitResponseSchema = z.object({
+  noUsageBasedAllowed: z.boolean().optional(),
+  hardLimit: z.union([z.number(), z.string()]).optional(),
+});
+
+type CursorHardLimitResponse = z.infer<typeof CursorHardLimitResponseSchema>;
+
+// Spending page `rz.UNLIMITED_CAP`: a hardLimit at or above this is "Unlimited".
+const CURSOR_UNLIMITED_HARD_LIMIT = 100_000_000;
+const ON_DEMAND_LABEL = "On-Demand Spending";
 
 const CursorAuthStatusSchema = z.object({
   accessToken: z.string().optional(),
 });
 
 type CursorUsageResponse = z.infer<typeof CursorUsageResponseSchema>;
+type CursorSpendLimitUsage = NonNullable<CursorUsageResponse["spendLimitUsage"]>;
 
 interface CursorQuotaProviderOptions {
   logger: Logger;
@@ -87,6 +135,231 @@ function parseCursorBillingCycleTimestamp(
 
 function centsToDollars(value: number | null): number | null {
   return value === null ? null : value / 100;
+}
+
+function parsePercentFromMessage(message: string | null | undefined): number | null {
+  if (!message) return null;
+  const match = message.match(/(\d+(?:\.\d+)?)\s*%/);
+  if (!match?.[1]) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isSinglePoolPlan(planName: string | null): boolean {
+  const name = planName?.trim().toLowerCase();
+  return name != null && SINGLE_POOL_PLAN_NAMES.has(name);
+}
+
+function percentWindow(input: {
+  id: string;
+  label: string;
+  utilizationPct: number;
+  resetsAt: string | null;
+}): ProviderUsageWindow {
+  return windowFromUsedPct({
+    id: input.id,
+    label: input.label,
+    utilizationPct: input.utilizationPct,
+    resetsAt: input.resetsAt,
+    tone: toneFromUsedPct(input.utilizationPct),
+  });
+}
+
+function monthlyUsageWindow(utilizationPct: number, resetsAt: string | null): ProviderUsageWindow {
+  return percentWindow({
+    id: "monthly_usage",
+    label: "Monthly usage",
+    utilizationPct,
+    resetsAt,
+  });
+}
+
+function poolPercent(
+  numeric: boolean,
+  value: number | null,
+  message: string | null | undefined,
+): number | null {
+  return numeric ? value : parsePercentFromMessage(message);
+}
+
+function modelPoolWindows(input: {
+  resp: CursorUsageResponse;
+  planName: string | null;
+  resetsAt: string | null;
+}): ProviderUsageWindow[] {
+  const { resp, planName, resetsAt } = input;
+  const planUsage = resp.planUsage;
+  const totalPct = planUsage?.totalPercentUsed ?? null;
+
+  // Official Spending `DK`: membershipType EXPRESS → one total-% bar, not the two pools.
+  if (isSinglePoolPlan(planName) && totalPct != null) {
+    return [monthlyUsageWindow(totalPct, resetsAt)];
+  }
+
+  const numeric = planUsage?.autoPercentUsed != null || planUsage?.apiPercentUsed != null;
+  const autoPct = poolPercent(
+    numeric,
+    planUsage?.autoPercentUsed ?? null,
+    resp.autoModelSelectedDisplayMessage,
+  );
+  const apiPct = poolPercent(
+    numeric,
+    planUsage?.apiPercentUsed ?? null,
+    resp.namedModelSelectedDisplayMessage,
+  );
+  const windows: ProviderUsageWindow[] = [];
+  for (const pool of [
+    { id: "cursor_models", label: "Cursor Models", pct: autoPct },
+    { id: "other_models", label: "Other Models", pct: apiPct },
+  ]) {
+    if (pool.pct != null) {
+      windows.push(
+        percentWindow({
+          id: pool.id,
+          label: pool.label,
+          utilizationPct: pool.pct,
+          resetsAt,
+        }),
+      );
+    }
+  }
+  if (windows.length > 0) return windows;
+
+  // Express/Start without a plan name, or a payload that only has the combined %.
+  if (totalPct != null) return [monthlyUsageWindow(totalPct, resetsAt)];
+  return [];
+}
+
+function usdBalance(input: {
+  id: string;
+  label: string;
+  usedCents: number | null;
+  remainingCents: number | null;
+  limitCents: number | null;
+  resetsAt: string | null;
+}): ProviderUsageBalance | null {
+  const used = centsToDollars(input.usedCents);
+  const remaining = centsToDollars(input.remainingCents);
+  const limit = centsToDollars(input.limitCents);
+  if (used == null && remaining == null && limit == null) return null;
+
+  const usedPct = usedPctOf(used, limit);
+  return {
+    id: input.id,
+    label: input.label,
+    used,
+    remaining,
+    limit,
+    unit: "usd",
+    resetsAt: input.resetsAt,
+    tone: usedPct != null ? toneFromUsedPct(usedPct) : balanceToneFromRemaining(remaining),
+  };
+}
+
+function appendUsdBalance(
+  balances: ProviderUsageBalance[],
+  input: Parameters<typeof usdBalance>[0],
+): void {
+  const balance = usdBalance(input);
+  if (balance) balances.push(balance);
+}
+
+function dollarBalances(input: {
+  resp: CursorUsageResponse;
+  hasWindows: boolean;
+  resetsAt: string | null;
+}): ProviderUsageBalance[] {
+  const { resp, hasWindows, resetsAt } = input;
+  // Official Spending never mixes included-% bars with planUsage dollars. Those
+  // cents include bonus/on-demand and are what used to render as `$135 / $20`.
+  if (hasWindows) return [];
+
+  const balances: ProviderUsageBalance[] = [];
+  if (resp.planUsage) {
+    appendUsdBalance(balances, {
+      id: "plan_usage",
+      label: "Plan usage",
+      usedCents: resp.planUsage.totalSpend,
+      remainingCents: resp.planUsage.remaining,
+      limitCents: resp.planUsage.limit,
+      resetsAt,
+    });
+  }
+
+  const spend = resp.spendLimitUsage;
+  if (spend?.pooledLimit != null) {
+    appendUsdBalance(balances, {
+      id: "team_usage",
+      label: "Team usage",
+      usedCents: spend.pooledUsed,
+      remainingCents: spend.pooledRemaining,
+      limitCents: spend.pooledLimit,
+      resetsAt,
+    });
+  }
+
+  return balances;
+}
+
+function numericHardLimitDollars(hardLimit: CursorHardLimitResponse["hardLimit"]): number | null {
+  if (typeof hardLimit === "number" && Number.isFinite(hardLimit)) return hardLimit;
+  if (typeof hardLimit === "string") {
+    const value = Number(hardLimit);
+    return Number.isFinite(value) ? value : null;
+  }
+  return null;
+}
+
+function isOnDemandDisabled(hardLimit: CursorHardLimitResponse | null): boolean {
+  return hardLimit?.noUsageBasedAllowed === true || hardLimit?.hardLimit === "no-usage-based";
+}
+
+function onDemandLimitCents(
+  limitDollars: number | null,
+  spend: CursorSpendLimitUsage | null | undefined,
+): number | null {
+  if (limitDollars != null && limitDollars >= CURSOR_UNLIMITED_HARD_LIMIT) return null;
+  if (limitDollars != null && limitDollars > 0) return limitDollars * 100;
+  const spendLimitCents = spend?.individualLimit;
+  return spendLimitCents != null && spendLimitCents > 0 ? spendLimitCents : null;
+}
+
+// cursor.com/dashboard/spending On-Demand cell (`DK`):
+// noUsageBasedAllowed / hardLimit === "no-usage-based" → "Disabled"
+// unlimited → "$used"; fixed → "$used / $limit" (used is cents, limit is dollars).
+function onDemandUsage(input: {
+  hardLimit: CursorHardLimitResponse | null;
+  spend: CursorSpendLimitUsage | null | undefined;
+  resetsAt: string | null;
+}): { balances: ProviderUsageBalance[]; details: ProviderUsageDetail[] } {
+  const { hardLimit, spend, resetsAt } = input;
+  if (isOnDemandDisabled(hardLimit)) {
+    return {
+      balances: [],
+      details: [{ id: "on_demand", label: ON_DEMAND_LABEL, value: "Disabled" }],
+    };
+  }
+
+  const limitDollars = numericHardLimitDollars(hardLimit?.hardLimit);
+  const unlimited = limitDollars != null && limitDollars >= CURSOR_UNLIMITED_HARD_LIMIT;
+  const limitCents = onDemandLimitCents(limitDollars, spend);
+  const enabled =
+    limitCents != null ||
+    unlimited ||
+    spend?.individualUsed != null ||
+    hardLimit?.noUsageBasedAllowed === false;
+  if (!enabled) return { balances: [], details: [] };
+
+  const balances: ProviderUsageBalance[] = [];
+  appendUsdBalance(balances, {
+    id: "on_demand",
+    label: ON_DEMAND_LABEL,
+    usedCents: spend?.individualUsed ?? 0,
+    remainingCents: limitCents == null ? null : (spend?.individualRemaining ?? null),
+    limitCents,
+    resetsAt,
+  });
+  return { balances, details: [] };
 }
 
 function readItemTableValue(db: CursorStateDatabase, key: string): string | null {
@@ -198,9 +471,48 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
 
     if (!token) return unavailableUsage(this);
 
-    const res = await fetchProviderApi(
+    const [resp, planName, hardLimit] = await Promise.all([
+      this.fetchCurrentPeriodUsage(token),
+      this.fetchPlanName(token),
+      this.fetchHardLimit(token),
+    ]);
+    if (!resp) return unavailableUsage(this);
+
+    // cursor.com/dashboard/spending Included usage: `Dq(planUsage)` → two %
+    // bars (personal `DK` and current Teams `DY`). Dollars are on-demand/admin,
+    // not this card. Fall back to cents only when the API has no percentages.
+    const billingCycleEnd = parseCursorBillingCycleTimestamp(resp.billingCycleEnd);
+    const windows = modelPoolWindows({ resp, planName, resetsAt: billingCycleEnd });
+    const includedBalances = dollarBalances({
+      resp,
+      hasWindows: windows.length > 0,
+      resetsAt: billingCycleEnd,
+    });
+    // Start/Express hides the On-Demand section (`!b && !B` in `DK`).
+    const onDemand = isSinglePoolPlan(planName)
+      ? { balances: [], details: [] }
+      : onDemandUsage({
+          hardLimit,
+          spend: resp.spendLimitUsage,
+          resetsAt: billingCycleEnd,
+        });
+
+    return {
+      providerId: this.providerId,
+      displayName: this.displayName,
+      status: "available",
+      planLabel: planName,
+      windows,
+      balances: [...includedBalances, ...onDemand.balances],
+      details: onDemand.details,
+      error: null,
+    };
+  }
+
+  private cursorDashboardRequest(token: string, method: string): Promise<Response> {
+    return fetchProviderApi(
       this.fetchApi,
-      "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+      `https://api2.cursor.sh/aiserver.v1.DashboardService/${method}`,
       {
         method: "POST",
         headers: {
@@ -211,40 +523,43 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
         body: JSON.stringify({}),
       },
     );
+  }
 
+  // Enrichment RPCs must not hide included usage from GetCurrentPeriodUsage.
+  private async fetchOptionalDashboard<T>(
+    token: string,
+    method: string,
+    schema: z.ZodType<T>,
+  ): Promise<T | null> {
+    try {
+      const res = await this.cursorDashboardRequest(token, method);
+      if (!res.ok) return null;
+      const parsed = schema.safeParse(await res.json());
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async fetchCurrentPeriodUsage(token: string): Promise<CursorUsageResponse | null> {
+    const res = await this.cursorDashboardRequest(token, "GetCurrentPeriodUsage");
     if (!res.ok) {
       this.logger.debug({ status: res.status }, "Cursor usage fetch failed");
-      return unavailableUsage(this);
+      return null;
     }
+    return CursorUsageResponseSchema.parse(await res.json());
+  }
 
-    const resp = CursorUsageResponseSchema.parse(await res.json());
-    const billingCycleEnd = parseCursorBillingCycleTimestamp(resp.billingCycleEnd);
-    const balances: ProviderUsageBalance[] = [];
-    if (resp.planUsage) {
-      const totalSpend = centsToDollars(resp.planUsage.totalSpend);
-      const remaining = centsToDollars(resp.planUsage.remaining);
-      const limit = centsToDollars(resp.planUsage.limit);
-      balances.push({
-        id: "plan_usage",
-        label: "Plan usage",
-        used: totalSpend,
-        remaining,
-        limit,
-        unit: "usd",
-        resetsAt: billingCycleEnd,
-        tone: toneFromUsedPct(usedPctOf(totalSpend, limit)),
-      });
-    }
+  private fetchHardLimit(token: string): Promise<CursorHardLimitResponse | null> {
+    return this.fetchOptionalDashboard(token, "GetHardLimit", CursorHardLimitResponseSchema);
+  }
 
-    return {
-      providerId: this.providerId,
-      displayName: this.displayName,
-      status: "available",
-      planLabel: null,
-      windows: [],
-      balances,
-      details: [],
-      error: null,
-    };
+  private async fetchPlanName(token: string): Promise<string | null> {
+    const parsed = await this.fetchOptionalDashboard(
+      token,
+      "GetPlanInfo",
+      CursorPlanInfoResponseSchema,
+    );
+    return parsed?.planInfo?.planName?.trim() || null;
   }
 }

--- a/packages/server/src/services/quota-fetcher/providers/cursor.ts
+++ b/packages/server/src/services/quota-fetcher/providers/cursor.ts
@@ -49,9 +49,12 @@ const CursorBillingCycleTimestampSchema = z.preprocess(
   z.union([z.string(), z.number()]).nullable(),
 );
 
-// cursor.com/dashboard/spending: Express/Start (India) is a single total-% bar
-// (`DW` / "Monthly usage"). Pro/Pro+/Ultra and current Teams use two pools.
 const SINGLE_POOL_PLAN_NAMES = new Set(["start", "express"]);
+
+// Request-based included usage is 500 requests per seat, at $0.04 each.
+const INCLUDED_REQUESTS_PER_SEAT = 500;
+const CENTS_PER_INCLUDED_REQUEST = 4;
+const FREE_OWNER_ROLES = new Set(["FREE_OWNER", "TEAM_ROLE_FREE_OWNER"]);
 
 const CursorPlanUsageSchema = z.object({
   totalSpend: ApiNullableNumberSchema,
@@ -97,9 +100,23 @@ const CursorHardLimitResponseSchema = z.object({
   hardLimit: z.union([z.number(), z.string()]).optional(),
 });
 
-type CursorHardLimitResponse = z.infer<typeof CursorHardLimitResponseSchema>;
+const CursorTeamSchema = z.object({
+  id: ApiNullableNumberSchema,
+  name: z.string().optional(),
+  role: z.string().optional(),
+  requestQuotaPerSeat: ApiNullableNumberSchema,
+  selfServeTieredPricingEnabled: z.boolean().optional(),
+  pricingStrategy: z.string().optional(),
+});
 
-// Spending page `rz.UNLIMITED_CAP`: a hardLimit at or above this is "Unlimited".
+const CursorTeamsResponseSchema = z.object({
+  teams: z.array(CursorTeamSchema).nullish(),
+});
+
+type CursorHardLimitResponse = z.infer<typeof CursorHardLimitResponseSchema>;
+type CursorTeam = z.infer<typeof CursorTeamSchema>;
+type CursorTeamWithId = CursorTeam & { id: number };
+
 const CURSOR_UNLIMITED_HARD_LIMIT = 100_000_000;
 const ON_DEMAND_LABEL = "On-Demand Spending";
 
@@ -150,6 +167,30 @@ function isSinglePoolPlan(planName: string | null): boolean {
   return name != null && SINGLE_POOL_PLAN_NAMES.has(name);
 }
 
+function isFreeOwnerRole(role: string | undefined): boolean {
+  return role != null && FREE_OWNER_ROLES.has(role);
+}
+
+function isCurrentTokenTeam(team: CursorTeam | null): boolean {
+  return team != null && team.selfServeTieredPricingEnabled === true && !isFreeOwnerRole(team.role);
+}
+
+// Token-priced teams without the current per-seat pools use a dollar included
+// meter. Everything else on a team is the older request-based included quota.
+function isRequestBasedTeam(team: CursorTeam | null): boolean {
+  if (team == null || isCurrentTokenTeam(team)) return false;
+  return team.pricingStrategy !== "tokens";
+}
+
+function usableTeam(team: CursorTeam | null): CursorTeamWithId | null {
+  if (team == null || team.id == null) return null;
+  return { ...team, id: team.id };
+}
+
+function requestCountFromSpendCents(cents: number): number {
+  return Math.ceil(cents / CENTS_PER_INCLUDED_REQUEST);
+}
+
 function percentWindow(input: {
   id: string;
   label: string;
@@ -174,58 +215,65 @@ function monthlyUsageWindow(utilizationPct: number, resetsAt: string | null): Pr
   });
 }
 
-function poolPercent(
-  numeric: boolean,
-  value: number | null,
-  message: string | null | undefined,
-): number | null {
-  return numeric ? value : parsePercentFromMessage(message);
+function poolPercent(input: {
+  value: number | null;
+  message: string | null | undefined;
+  numeric: boolean;
+  fillMissingZeros: boolean;
+}): number | null {
+  if (input.fillMissingZeros) return input.value ?? 0;
+  if (input.numeric) return input.value;
+  return parsePercentFromMessage(input.message);
 }
 
 function modelPoolWindows(input: {
   resp: CursorUsageResponse;
   planName: string | null;
   resetsAt: string | null;
+  fillMissingZeros?: boolean;
 }): ProviderUsageWindow[] {
-  const { resp, planName, resetsAt } = input;
+  const { resp, planName, resetsAt, fillMissingZeros = false } = input;
   const planUsage = resp.planUsage;
   const totalPct = planUsage?.totalPercentUsed ?? null;
 
-  // Official Spending `DK`: membershipType EXPRESS → one total-% bar, not the two pools.
   if (isSinglePoolPlan(planName) && totalPct != null) {
     return [monthlyUsageWindow(totalPct, resetsAt)];
   }
 
-  const numeric = planUsage?.autoPercentUsed != null || planUsage?.apiPercentUsed != null;
-  const autoPct = poolPercent(
-    numeric,
-    planUsage?.autoPercentUsed ?? null,
-    resp.autoModelSelectedDisplayMessage,
-  );
-  const apiPct = poolPercent(
-    numeric,
-    planUsage?.apiPercentUsed ?? null,
-    resp.namedModelSelectedDisplayMessage,
-  );
+  const numeric =
+    fillMissingZeros || planUsage?.autoPercentUsed != null || planUsage?.apiPercentUsed != null;
   const windows: ProviderUsageWindow[] = [];
   for (const pool of [
-    { id: "cursor_models", label: "Cursor Models", pct: autoPct },
-    { id: "other_models", label: "Other Models", pct: apiPct },
+    {
+      id: "cursor_models",
+      label: "Cursor Models",
+      value: planUsage?.autoPercentUsed ?? null,
+      message: resp.autoModelSelectedDisplayMessage,
+    },
+    {
+      id: "other_models",
+      label: "Other Models",
+      value: planUsage?.apiPercentUsed ?? null,
+      message: resp.namedModelSelectedDisplayMessage,
+    },
   ]) {
-    if (pool.pct != null) {
-      windows.push(
-        percentWindow({
-          id: pool.id,
-          label: pool.label,
-          utilizationPct: pool.pct,
-          resetsAt,
-        }),
-      );
-    }
+    const pct = poolPercent({
+      value: pool.value,
+      message: pool.message,
+      numeric,
+      fillMissingZeros,
+    });
+    if (pct == null) continue;
+    windows.push(
+      percentWindow({
+        id: pool.id,
+        label: pool.label,
+        utilizationPct: pct,
+        resetsAt,
+      }),
+    );
   }
   if (windows.length > 0) return windows;
-
-  // Express/Start without a plan name, or a payload that only has the combined %.
   if (totalPct != null) return [monthlyUsageWindow(totalPct, resetsAt)];
   return [];
 }
@@ -266,39 +314,77 @@ function appendUsdBalance(
 
 function dollarBalances(input: {
   resp: CursorUsageResponse;
-  hasWindows: boolean;
   resetsAt: string | null;
 }): ProviderUsageBalance[] {
-  const { resp, hasWindows, resetsAt } = input;
-  // Official Spending never mixes included-% bars with planUsage dollars. Those
-  // cents include bonus/on-demand and are what used to render as `$135 / $20`.
-  if (hasWindows) return [];
-
+  const { resp, resetsAt } = input;
   const balances: ProviderUsageBalance[] = [];
   if (resp.planUsage) {
     appendUsdBalance(balances, {
-      id: "plan_usage",
-      label: "Plan usage",
+      id: "included_usage",
+      label: "Your included usage",
       usedCents: resp.planUsage.totalSpend,
       remainingCents: resp.planUsage.remaining,
       limitCents: resp.planUsage.limit,
       resetsAt,
     });
-  }
-
-  const spend = resp.spendLimitUsage;
-  if (spend?.pooledLimit != null) {
+  } else if (resp.spendLimitUsage?.individualUsed != null) {
     appendUsdBalance(balances, {
-      id: "team_usage",
-      label: "Team usage",
-      usedCents: spend.pooledUsed,
-      remainingCents: spend.pooledRemaining,
-      limitCents: spend.pooledLimit,
+      id: "monthly_usage_usd",
+      label: "Your monthly usage",
+      usedCents: resp.spendLimitUsage.individualUsed,
+      remainingCents: resp.spendLimitUsage.individualRemaining ?? null,
+      limitCents: resp.spendLimitUsage.individualLimit ?? null,
       resetsAt,
     });
   }
 
   return balances;
+}
+
+function includedRequestBalance(input: {
+  team: CursorTeam;
+  resp: CursorUsageResponse;
+  resetsAt: string | null;
+}): ProviderUsageBalance | null {
+  const quota = input.team.requestQuotaPerSeat;
+  const limit = quota != null && quota > 0 ? INCLUDED_REQUESTS_PER_SEAT * quota : null;
+  const planUsedCents =
+    input.resp.planUsage?.includedSpend ?? input.resp.planUsage?.totalSpend ?? null;
+  const used =
+    planUsedCents != null && planUsedCents > 0 ? requestCountFromSpendCents(planUsedCents) : 0;
+  if (limit == null && (planUsedCents == null || planUsedCents <= 0)) return null;
+
+  const capped = limit != null ? Math.min(used, limit) : used;
+  const remaining = limit != null ? Math.max(0, limit - capped) : null;
+  const usedPct = usedPctOf(capped, limit);
+  return {
+    id: "included_requests",
+    label: "Included-Request Usage",
+    used: capped,
+    remaining,
+    limit,
+    unit: "requests",
+    resetsAt: input.resetsAt,
+    tone: usedPct != null ? toneFromUsedPct(usedPct) : balanceToneFromRemaining(remaining),
+  };
+}
+
+function includedBalances(input: {
+  team: CursorTeamWithId | null;
+  resp: CursorUsageResponse;
+  windows: ProviderUsageWindow[];
+  billingCycleEnd: string | null;
+}): ProviderUsageBalance[] {
+  if (input.windows.length > 0) return [];
+  if (input.team && isRequestBasedTeam(input.team)) {
+    const request = includedRequestBalance({
+      team: input.team,
+      resp: input.resp,
+      resetsAt: input.billingCycleEnd,
+    });
+    return request ? [request] : [];
+  }
+  return dollarBalances({ resp: input.resp, resetsAt: input.billingCycleEnd });
 }
 
 function numericHardLimitDollars(hardLimit: CursorHardLimitResponse["hardLimit"]): number | null {
@@ -324,9 +410,6 @@ function onDemandLimitCents(
   return spendLimitCents != null && spendLimitCents > 0 ? spendLimitCents : null;
 }
 
-// cursor.com/dashboard/spending On-Demand cell (`DK`):
-// noUsageBasedAllowed / hardLimit === "no-usage-based" → "Disabled"
-// unlimited → "$used"; fixed → "$used / $limit" (used is cents, limit is dollars).
 function onDemandUsage(input: {
   hardLimit: CursorHardLimitResponse | null;
   spend: CursorSpendLimitUsage | null | undefined;
@@ -412,7 +495,7 @@ async function readCursorTokenFromSqlite(homeDir: string, logger: Logger): Promi
     sqlite = (await import(sqliteSpecifier)) as unknown as NodeSqliteModule;
   } catch (err) {
     logger.debug({ err }, "node:sqlite unavailable; cannot read Cursor state.vscdb");
-    return null; // runtime without node:sqlite
+    return null;
   }
 
   for (const path of dbPaths) {
@@ -471,24 +554,21 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
 
     if (!token) return unavailableUsage(this);
 
+    const team = usableTeam(await this.fetchTeam(token));
     const [resp, planName, hardLimit] = await Promise.all([
-      this.fetchCurrentPeriodUsage(token),
+      this.fetchCurrentPeriodUsage(token, team?.id ?? null),
       this.fetchPlanName(token),
       this.fetchHardLimit(token),
     ]);
     if (!resp) return unavailableUsage(this);
 
-    // cursor.com/dashboard/spending Included usage: `Dq(planUsage)` → two %
-    // bars (personal `DK` and current Teams `DY`). Dollars are on-demand/admin,
-    // not this card. Fall back to cents only when the API has no percentages.
     const billingCycleEnd = parseCursorBillingCycleTimestamp(resp.billingCycleEnd);
-    const windows = modelPoolWindows({ resp, planName, resetsAt: billingCycleEnd });
-    const includedBalances = dollarBalances({
+    const windows = modelPoolWindows({
       resp,
-      hasWindows: windows.length > 0,
+      planName,
       resetsAt: billingCycleEnd,
+      fillMissingZeros: isCurrentTokenTeam(team),
     });
-    // Start/Express hides the On-Demand section (`!b && !B` in `DK`).
     const onDemand = isSinglePoolPlan(planName)
       ? { balances: [], details: [] }
       : onDemandUsage({
@@ -503,13 +583,20 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
       status: "available",
       planLabel: planName,
       windows,
-      balances: [...includedBalances, ...onDemand.balances],
+      balances: [
+        ...includedBalances({ team, resp, windows, billingCycleEnd }),
+        ...onDemand.balances,
+      ],
       details: onDemand.details,
       error: null,
     };
   }
 
-  private cursorDashboardRequest(token: string, method: string): Promise<Response> {
+  private cursorDashboardRequest(
+    token: string,
+    method: string,
+    body: Record<string, unknown> = {},
+  ): Promise<Response> {
     return fetchProviderApi(
       this.fetchApi,
       `https://api2.cursor.sh/aiserver.v1.DashboardService/${method}`,
@@ -520,29 +607,37 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
           "Content-Type": "application/json",
           "Connect-Protocol-Version": "1",
         },
-        body: JSON.stringify({}),
+        body: JSON.stringify(body),
       },
     );
   }
 
-  // Enrichment RPCs must not hide included usage from GetCurrentPeriodUsage.
-  private async fetchOptionalDashboard<T>(
-    token: string,
-    method: string,
-    schema: z.ZodType<T>,
-  ): Promise<T | null> {
+  // Plan name / hard limit / team lookup must not hide included usage if they fail.
+  private async fetchOptionalDashboard<T>(input: {
+    token: string;
+    method: string;
+    schema: z.ZodType<T>;
+  }): Promise<T | null> {
     try {
-      const res = await this.cursorDashboardRequest(token, method);
+      const res = await this.cursorDashboardRequest(input.token, input.method);
       if (!res.ok) return null;
-      const parsed = schema.safeParse(await res.json());
+      const parsed = input.schema.safeParse(await res.json());
       return parsed.success ? parsed.data : null;
     } catch {
       return null;
     }
   }
 
-  private async fetchCurrentPeriodUsage(token: string): Promise<CursorUsageResponse | null> {
-    const res = await this.cursorDashboardRequest(token, "GetCurrentPeriodUsage");
+  private async fetchCurrentPeriodUsage(
+    token: string,
+    teamId: number | null,
+  ): Promise<CursorUsageResponse | null> {
+    const res = await this.cursorDashboardRequest(
+      token,
+      "GetCurrentPeriodUsage",
+      // Team seats only populate period usage when the request is scoped to the team.
+      teamId == null ? {} : { teamId },
+    );
     if (!res.ok) {
       this.logger.debug({ status: res.status }, "Cursor usage fetch failed");
       return null;
@@ -551,15 +646,28 @@ export class CursorQuotaProvider implements ProviderUsageFetcher {
   }
 
   private fetchHardLimit(token: string): Promise<CursorHardLimitResponse | null> {
-    return this.fetchOptionalDashboard(token, "GetHardLimit", CursorHardLimitResponseSchema);
+    return this.fetchOptionalDashboard({
+      token,
+      method: "GetHardLimit",
+      schema: CursorHardLimitResponseSchema,
+    });
   }
 
   private async fetchPlanName(token: string): Promise<string | null> {
-    const parsed = await this.fetchOptionalDashboard(
+    const parsed = await this.fetchOptionalDashboard({
       token,
-      "GetPlanInfo",
-      CursorPlanInfoResponseSchema,
-    );
+      method: "GetPlanInfo",
+      schema: CursorPlanInfoResponseSchema,
+    });
     return parsed?.planInfo?.planName?.trim() || null;
+  }
+
+  private async fetchTeam(token: string): Promise<CursorTeam | null> {
+    const parsed = await this.fetchOptionalDashboard({
+      token,
+      method: "GetTeams",
+      schema: CursorTeamsResponseSchema,
+    });
+    return parsed?.teams?.[0] ?? null;
   }
 }

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -729,7 +729,7 @@ describe("real provider usage fetchers", () => {
       status: "available",
       balances: [
         expect.objectContaining({
-          id: "plan_usage",
+          id: "included_usage",
           used: 15,
           remaining: 25,
           limit: 40,
@@ -1015,19 +1015,184 @@ describe("real provider usage fetchers", () => {
       windows: [],
       balances: [
         expect.objectContaining({
-          id: "plan_usage",
+          id: "included_usage",
+          label: "Your included usage",
           used: 134,
           remaining: 66,
           limit: 200,
         }),
+      ],
+    });
+  });
+
+  it("maps an old request-based Cursor team seat to Included-Request Usage", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetTeams",
+          () =>
+            jsonResponse({
+              teams: [
+                {
+                  id: 42,
+                  name: "Acme",
+                  role: "TEAM_ROLE_MEMBER",
+                  requestQuotaPerSeat: 1,
+                  selfServeTieredPricingEnabled: false,
+                },
+              ],
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleStart: "1785884859130",
+              billingCycleEnd: "1785884859130",
+              displayThreshold: 100,
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Business" } }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      planLabel: "Business",
+      windows: [],
+      balances: [
         expect.objectContaining({
-          id: "team_usage",
-          used: 347.98,
-          remaining: 252.02,
-          limit: 600,
+          id: "included_requests",
+          label: "Included-Request Usage",
+          used: 0,
+          remaining: 500,
+          limit: 500,
+          unit: "requests",
+          resetsAt: "2026-08-04T23:07:39.130Z",
         }),
       ],
     });
+  });
+
+  it("maps a current token Team with no planUsage to official 0% / 0% bars", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetTeams",
+          () =>
+            jsonResponse({
+              teams: [
+                {
+                  id: 7,
+                  role: "TEAM_ROLE_MEMBER",
+                  selfServeTieredPricingEnabled: true,
+                },
+              ],
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () => jsonResponse({ billingCycleEnd: "2026-02-14T12:42:14.000Z" }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Team" } }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      planLabel: "Team",
+      windows: [
+        expect.objectContaining({ id: "cursor_models", usedPct: 0 }),
+        expect.objectContaining({ id: "other_models", usedPct: 0 }),
+      ],
+      balances: [],
+    });
+  });
+
+  it("converts request-based team planUsage included spend into request counts", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetTeams",
+          () =>
+            jsonResponse({
+              teams: [
+                {
+                  id: 42,
+                  requestQuotaPerSeat: 2,
+                  selfServeTieredPricingEnabled: false,
+                },
+              ],
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleEnd: "2026-02-14T12:42:14.000Z",
+              planUsage: { includedSpend: 804, totalSpend: 5000 },
+            }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor.balances).toEqual([
+      expect.objectContaining({
+        id: "included_requests",
+        used: 201,
+        limit: 1000,
+        unit: "requests",
+      }),
+    ]);
+  });
+
+  it("sends teamId on GetCurrentPeriodUsage the way the official dashboard does", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    let usageBody: unknown = null;
+    fetchApi = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const key = url.toString();
+      if (key.endsWith("/GetTeams")) {
+        return jsonResponse({
+          teams: [{ id: 99, selfServeTieredPricingEnabled: true }],
+        });
+      }
+      if (key.endsWith("/GetCurrentPeriodUsage")) {
+        usageBody = JSON.parse(String(init?.body ?? "{}"));
+        return jsonResponse({
+          planUsage: { autoPercentUsed: 10, apiPercentUsed: 2 },
+        });
+      }
+      if (key.endsWith("/GetPlanInfo")) {
+        return jsonResponse({ planInfo: { planName: "Team" } });
+      }
+      if (key.endsWith("/GetHardLimit")) {
+        return jsonResponse({});
+      }
+      throw new Error(`Unmocked fetch: ${key}`);
+    }) as unknown as typeof fetch;
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(usageBody).toEqual({ teamId: 99 });
+    expect(cursor.windows).toEqual([
+      expect.objectContaining({ id: "cursor_models", usedPct: 10 }),
+      expect.objectContaining({ id: "other_models", usedPct: 2 }),
+    ]);
   });
 
   it("reads Cursor model-pool percentages from display messages when numeric fields are absent", async () => {
@@ -1081,7 +1246,9 @@ describe("real provider usage fetchers", () => {
     expect(authorization).toBe("Bearer cursor_state_jwt");
     expect(cursor).toMatchObject({
       status: "available",
-      balances: [expect.objectContaining({ id: "plan_usage", used: 15, remaining: 25, limit: 40 })],
+      balances: [
+        expect.objectContaining({ id: "included_usage", used: 15, remaining: 25, limit: 40 }),
+      ],
     });
   });
 
@@ -1128,7 +1295,9 @@ describe("real provider usage fetchers", () => {
     expect(authorization).toBe("Bearer cursor_cli_jwt");
     expect(cursor).toMatchObject({
       status: "available",
-      balances: [expect.objectContaining({ id: "plan_usage", used: 15, remaining: 25, limit: 40 })],
+      balances: [
+        expect.objectContaining({ id: "included_usage", used: 15, remaining: 25, limit: 40 }),
+      ],
     });
   });
 

--- a/packages/server/src/services/quota-fetcher/service.test.ts
+++ b/packages/server/src/services/quota-fetcher/service.test.ts
@@ -739,6 +739,325 @@ describe("real provider usage fetchers", () => {
     });
   });
 
+  it("maps a personal Cursor plan to Cursor Models and Other Models percentages", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleStart: "1786552121000",
+              billingCycleEnd: "1789230521000",
+              planUsage: {
+                totalSpend: 13500,
+                includedSpend: 2000,
+                bonusSpend: 11500,
+                limit: 2000,
+                autoPercentUsed: 44.88,
+                apiPercentUsed: 0.8,
+                totalPercentUsed: 39.13,
+              },
+              spendLimitUsage: { limitType: "user" },
+              autoModelSelectedDisplayMessage: "You've used 39% of your included total usage",
+              namedModelSelectedDisplayMessage: "You've used 1% of your included API usage",
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Pro" } }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetHardLimit",
+          () => jsonResponse({ noUsageBasedAllowed: true }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      planLabel: "Pro",
+      windows: [
+        expect.objectContaining({
+          id: "cursor_models",
+          label: "Cursor Models",
+          usedPct: 44.88,
+        }),
+        expect.objectContaining({
+          id: "other_models",
+          label: "Other Models",
+          usedPct: 0.8,
+        }),
+      ],
+      balances: [],
+      details: [
+        expect.objectContaining({
+          id: "on_demand",
+          label: "On-Demand Spending",
+          value: "Disabled",
+        }),
+      ],
+    });
+  });
+
+  it("maps enabled Cursor on-demand spending to a dollar amount", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleEnd: "2026-02-14T12:42:14.000Z",
+              planUsage: {
+                autoPercentUsed: 20,
+                apiPercentUsed: 5,
+              },
+              spendLimitUsage: {
+                limitType: "user",
+                individualUsed: 1234,
+                individualRemaining: 3766,
+                individualLimit: 5000,
+              },
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Pro" } }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetHardLimit",
+          () => jsonResponse({ hardLimit: 50 }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      windows: [
+        expect.objectContaining({ id: "cursor_models", usedPct: 20 }),
+        expect.objectContaining({ id: "other_models", usedPct: 5 }),
+      ],
+      balances: [
+        expect.objectContaining({
+          id: "on_demand",
+          label: "On-Demand Spending",
+          used: 12.34,
+          remaining: 37.66,
+          limit: 50,
+        }),
+      ],
+      details: [],
+    });
+  });
+
+  it("maps unlimited Cursor on-demand spending to used dollars without a cap", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleEnd: "2026-02-14T12:42:14.000Z",
+              planUsage: { autoPercentUsed: 10, apiPercentUsed: 2 },
+              spendLimitUsage: { limitType: "user", individualUsed: 500 },
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Pro+" } }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetHardLimit",
+          () => jsonResponse({ hardLimit: 100_000_000 }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      balances: [
+        expect.objectContaining({
+          id: "on_demand",
+          label: "On-Demand Spending",
+          used: 5,
+          limit: null,
+        }),
+      ],
+      details: [],
+    });
+  });
+
+  it("maps a team Cursor plan to the same two model-pool percentages as personal", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleStart: "2026-01-14T12:42:14.000Z",
+              billingCycleEnd: "2026-02-14T12:42:14.000Z",
+              planUsage: {
+                totalSpend: 13400,
+                remaining: 6600,
+                limit: 20000,
+                autoPercentUsed: 42,
+                apiPercentUsed: 15,
+              },
+              spendLimitUsage: {
+                limitType: "team",
+                pooledUsed: 34798,
+                pooledRemaining: 25202,
+                pooledLimit: 60000,
+              },
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Team" } }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      planLabel: "Team",
+      windows: [
+        expect.objectContaining({ id: "cursor_models", usedPct: 42 }),
+        expect.objectContaining({ id: "other_models", usedPct: 15 }),
+      ],
+      balances: [],
+    });
+  });
+
+  it("maps a Cursor Start plan to a single Monthly usage percentage", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleEnd: "2026-02-14T12:42:14.000Z",
+              planUsage: {
+                autoPercentUsed: 12,
+                apiPercentUsed: 3,
+                totalPercentUsed: 18.4,
+              },
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Start" } }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetHardLimit",
+          () => jsonResponse({ noUsageBasedAllowed: true }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      planLabel: "Start",
+      windows: [expect.objectContaining({ id: "monthly_usage", usedPct: 18.4 })],
+      balances: [],
+      details: [],
+    });
+  });
+
+  it("maps pooled Cursor spend to dollars when the API has no percentages", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleEnd: "2026-02-14T12:42:14.000Z",
+              planUsage: {
+                totalSpend: 13400,
+                remaining: 6600,
+                limit: 20000,
+              },
+              spendLimitUsage: {
+                limitType: "team",
+                pooledUsed: 34798,
+                pooledRemaining: 25202,
+                pooledLimit: 60000,
+              },
+            }),
+        ],
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+          () => jsonResponse({ planInfo: { planName: "Enterprise" } }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      planLabel: "Enterprise",
+      windows: [],
+      balances: [
+        expect.objectContaining({
+          id: "plan_usage",
+          used: 134,
+          remaining: 66,
+          limit: 200,
+        }),
+        expect.objectContaining({
+          id: "team_usage",
+          used: 347.98,
+          remaining: 252.02,
+          limit: 600,
+        }),
+      ],
+    });
+  });
+
+  it("reads Cursor model-pool percentages from display messages when numeric fields are absent", async () => {
+    process.env["CURSOR_ACCESS_TOKEN"] = "cursor_test_token";
+    fetchApi = mockFetch(
+      new Map([
+        [
+          "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+          () =>
+            jsonResponse({
+              billingCycleEnd: "2026-02-14T12:42:14.000Z",
+              autoModelSelectedDisplayMessage: "You've used 42% of your included total usage",
+              namedModelSelectedDisplayMessage: "You've used 15% of your included API usage",
+            }),
+        ],
+      ]),
+    );
+
+    const cursor = findProvider(await service().listUsage(), "cursor");
+
+    expect(cursor).toMatchObject({
+      status: "available",
+      windows: [
+        expect.objectContaining({ id: "cursor_models", usedPct: 42 }),
+        expect.objectContaining({ id: "other_models", usedPct: 15 }),
+      ],
+      balances: [],
+    });
+  });
+
   it("reads the Cursor token from the modern cursorAuth/accessToken key in state.vscdb", async () => {
     writeCursorStateDb(homeDir, { "cursorAuth/accessToken": "cursor_state_jwt" });
     let authorization: string | null = null;


### PR DESCRIPTION
### Linked issue

Closes #2403

#3345 (Pro+ `$204 / $70` vs dashboard 25% / 1%) was already closed as a duplicate of #2403.

Related: #2877 (team seats with an empty `GetCurrentPeriodUsage` body). This PR does **not** use that issue's `GetTeamSpend` fallback. That response is a team spend table — a member token only sees its own row, and an admin token sees everyone. Settings usage is scoped to the signed-in seat, so we only call APIs the dashboard itself uses for that seat: `GetTeams`, `GetCurrentPeriodUsage` (with `teamId` when the seat is on a team), `GetPlanInfo`, and `GetHardLimit`.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Settings → Host → Usage showed Cursor as a single dollar bar (`$135 / $20` on a personal Pro account). That number comes from `planUsage.totalSpend / limit`, which includes bonus and on-demand spend. The live [cursor.com/dashboard/spending](https://cursor.com/dashboard/spending) page does not use that for Included usage.

### Goals

- Match official Included usage for personal, current Teams, Start/Express, old request-based teams, and Enterprise
- Show On-Demand Spending as Disabled or a dollar amount
- Work with a member token; do not require team admin

### Non-goals

- Changing the Settings Usage UI chrome or the 5-minute daemon usage cache
- Fetching website-only APIs (`/api/usage-summary`, Stripe `membershipType`); Start/Express is still inferred from `GetPlanInfo.planName`
- Controlling On-Demand from Paseo (display only)
- Rendering the team-wide spend table from `GetTeamSpend`

### How official vs Paseo Settings map

| Plan | Official dashboard | Settings → Usage | Where the numbers come from |
| --- | --- | --- | --- |
| Personal Pro / Pro+ / Ultra | Spending: **Cursor Models** and **Other Models** as `% used`; **On-Demand Spending** as Disabled / `$used` / `$used / $limit` | Same two percentage bars + the same On-Demand row | `GetCurrentPeriodUsage.planUsage.autoPercentUsed` / `apiPercentUsed`. On-Demand from `GetHardLimit` + `spendLimitUsage.individualUsed` (used is cents, limit is dollars). Plan name from `GetPlanInfo.planName`. |
| Start / Express | Spending: one **Monthly usage** bar; no On-Demand | Same | `GetCurrentPeriodUsage.planUsage.totalPercentUsed`. `GetPlanInfo.planName` is `Start` or `Express`. |
| Current Teams (per-seat token pools) | Spending: the same two percentage bars under Included usage | Same two bars. If the period payload has no percents, both bars render at 0% (same as the dashboard) | `GetTeams` (`selfServeTieredPricingEnabled`, not a free-owner role) then `GetCurrentPeriodUsage` **with `{ teamId }`**. Percents from `planUsage` as above. |
| Old request-based team | Overview: **Included-Request Usage** as `used / (500 × requestQuotaPerSeat)` | Same request meter | Seat quota from `GetTeams.requestQuotaPerSeat`. Used = `ceil(planUsage.includedSpend / 4)` when period usage has included cents; otherwise `0 / quota`. Period usage is `GetCurrentPeriodUsage` with `{ teamId }` — an empty `{}` body is why those seats used to render as a blank card. |
| Enterprise on token pricing without current team pools | Overview: **Your included usage** (or **Your monthly usage**) as `$used / $limit` | Same dollar included row | `GetCurrentPeriodUsage.planUsage` cents (`totalSpend` / `remaining` / `limit`), or `spendLimitUsage.individual*` when there is no `planUsage`. `GetTeams.pricingStrategy === "tokens"` selects this path instead of requests. |
| On-Demand (all paid plans except Start / Express) | Spending: Disabled, `$used`, or `$used / $limit` | Same | `GetHardLimit` (`noUsageBasedAllowed`, `hardLimit`) + `GetCurrentPeriodUsage.spendLimitUsage.individualUsed`. Not fetched from team spend or invoices. |

`planUsage.totalSpend` is never drawn as Included usage when the percentage pools exist. That is the `$135 / $20` bug.

No website-only cookie APIs (`/api/usage-summary`, Stripe membership). No admin-only RPCs (`GetTeamSpend` member table, `GetMonthlyInvoice`).

### QA

- Compared [cursor.com/dashboard/spending](https://cursor.com/dashboard/spending) against a signed-in personal Pro account. Official UI: Cursor Models 49% used, Other Models 1% used, On-Demand Spending Disabled. Live `GetCurrentPeriodUsage` had `autoPercentUsed ≈ 48.9`, `apiPercentUsed = 0.8`; `GetHardLimit` returned `{ noUsageBasedAllowed: true }`.
- `npx vitest run packages/server/src/services/quota-fetcher/service.test.ts --bail=1` — 84 passed
- `npm run typecheck`, `npm run lint`, `npm run format` — passed (pre-commit + local)
- Run locally, verify manually, and take screenshots.

Before:

<img width="1522" height="1400" alt="image" src="https://github.com/user-attachments/assets/e177bd52-a5eb-40b9-bacb-5d7eabd96396" />

After:

<img width="1650" height="1518" alt="image" src="https://github.com/user-attachments/assets/8f0122c2-e8bf-4066-8856-d6f65ccaeee9" />

Compared to the Cursor.com spending page:

<img width="2220" height="876" alt="image" src="https://github.com/user-attachments/assets/ced80ac6-f20b-416f-be34-d1698a231506" />

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence (screenshots)
- [x] Tests added or updated where it made sense