### PR TITLE
fix: skip usage caches when Settings refresh is clicked

### DIFF
--- a/packages/app/e2e/browser/provider-usage-settings.spec.ts
+++ b/packages/app/e2e/browser/provider-usage-settings.spec.ts
@@ -109,6 +109,7 @@ test.describe("provider usage settings", () => {
     await usageFixture.waitForRequestCount(2);
 
     expect(usageFixture.requestCount()).toBe(2);
+    expect(usageFixture.forceRefreshFlags()).toEqual([false, true]);
     await expect(page.getByText("64%")).toBeVisible();
   });
 

--- a/packages/app/e2e/support/helpers/provider-usage.ts
+++ b/packages/app/e2e/support/helpers/provider-usage.ts
@@ -10,6 +10,7 @@ interface ProviderUsageFixturePayload {
 export interface ProviderUsageFixture {
   requestCount(): number;
   waitForRequestCount(count: number): Promise<void>;
+  forceRefreshFlags(): boolean[];
 }
 
 type WebSocketMessage = string | Buffer;
@@ -80,6 +81,7 @@ export async function installProviderUsageFixture(
   payloads: ProviderUsageFixturePayload[],
 ): Promise<ProviderUsageFixture> {
   let requests = 0;
+  const forceRefreshFlags: boolean[] = [];
   const waiters: Array<{ count: number; resolve: () => void }> = [];
 
   function notifyWaiters() {
@@ -108,6 +110,7 @@ export async function installProviderUsageFixture(
       const sessionMessage = getSessionMessage(message);
       if (sessionMessage?.type === "provider.usage.list.request") {
         requests += 1;
+        forceRefreshFlags.push(sessionMessage.forceRefresh === true);
         const requestId = sessionMessage.requestId;
         if (typeof requestId !== "string") {
           throw new Error("provider.usage.list.request missing requestId");
@@ -141,6 +144,9 @@ export async function installProviderUsageFixture(
   return {
     requestCount() {
       return requests;
+    },
+    forceRefreshFlags() {
+      return [...forceRefreshFlags];
     },
     waitForRequestCount(count: number) {
       if (requests >= count) {

--- a/packages/app/src/provider-usage/use-provider-usage.test.tsx
+++ b/packages/app/src/provider-usage/use-provider-usage.test.tsx
@@ -1,0 +1,122 @@
+/** @vitest-environment jsdom */
+import React, { type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderUsageListPayload } from "./types";
+import { useProviderUsage } from "./use-provider-usage";
+
+const runtime = vi.hoisted(() => ({
+  connected: true,
+  supported: true,
+  client: null as { listProviderUsage: ReturnType<typeof vi.fn> } | null,
+}));
+
+vi.mock("@/runtime/host-runtime", () => ({
+  useHostRuntimeClient: () => runtime.client,
+  useHostRuntimeIsConnected: () => runtime.connected,
+}));
+
+vi.mock("@/stores/session-store", () => ({
+  useSessionStore: (
+    selector: (state: {
+      sessions: Record<string, { serverInfo: { features: { providerUsageList: boolean } } }>;
+    }) => unknown,
+  ) =>
+    selector({
+      sessions: {
+        host: {
+          serverInfo: { features: { providerUsageList: runtime.supported } },
+        },
+      },
+    }),
+}));
+
+function usagePayload(usedPct: number): ProviderUsageListPayload {
+  return {
+    requestId: `usage-${usedPct}`,
+    fetchedAt: "2026-06-19T00:00:00.000Z",
+    providers: [
+      {
+        providerId: "claude",
+        displayName: "Claude",
+        status: "available",
+        planLabel: "Max 20x",
+        windows: [{ id: "session", label: "Session", usedPct }],
+      },
+    ],
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useProviderUsage", () => {
+  beforeEach(() => {
+    runtime.connected = true;
+    runtime.supported = true;
+    runtime.client = null;
+  });
+
+  it("loads usage without forcing a daemon refresh", async () => {
+    const listProviderUsage = vi.fn(async () => usagePayload(7));
+    runtime.client = { listProviderUsage };
+
+    const { result } = renderHook(() => useProviderUsage("host"), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.view.kind).toBe("ready"));
+
+    expect(listProviderUsage).toHaveBeenCalledOnce();
+    expect(listProviderUsage).toHaveBeenCalledWith();
+    expect(result.current.view).toEqual({
+      kind: "ready",
+      payload: usagePayload(7),
+      isRefreshing: false,
+    });
+  });
+
+  it("refetches React Query data without forcing the daemon cache", async () => {
+    const listProviderUsage = vi.fn(async () => usagePayload(7));
+    runtime.client = { listProviderUsage };
+
+    const { result } = renderHook(() => useProviderUsage("host"), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.view.kind).toBe("ready"));
+
+    await result.current.refresh();
+
+    expect(listProviderUsage).toHaveBeenCalledTimes(2);
+    expect(listProviderUsage).toHaveBeenNthCalledWith(2);
+  });
+
+  it("force-refreshes usage even while React Query still considers it fresh", async () => {
+    let usedPct = 7;
+    const listProviderUsage = vi.fn(async (options?: { forceRefresh?: boolean }) => {
+      if (options?.forceRefresh === true) {
+        usedPct += 1;
+      }
+      return usagePayload(usedPct);
+    });
+    runtime.client = { listProviderUsage };
+
+    const { result } = renderHook(() => useProviderUsage("host"), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.view.kind).toBe("ready"));
+    expect(listProviderUsage).toHaveBeenCalledOnce();
+
+    await result.current.refresh({ forceRefresh: true });
+    await result.current.refresh({ forceRefresh: true });
+
+    expect(listProviderUsage).toHaveBeenCalledTimes(3);
+    expect(listProviderUsage).toHaveBeenNthCalledWith(2, { forceRefresh: true });
+    expect(listProviderUsage).toHaveBeenNthCalledWith(3, { forceRefresh: true });
+    await waitFor(() =>
+      expect(result.current.view).toEqual({
+        kind: "ready",
+        payload: usagePayload(9),
+        isRefreshing: false,
+      }),
+    );
+  });
+});

--- a/packages/app/src/provider-usage/use-provider-usage.ts
+++ b/packages/app/src/provider-usage/use-provider-usage.ts
@@ -10,11 +10,21 @@ export const PROVIDER_USAGE_STALE_TIME_MS = 5 * 60 * 1000;
 
 type ProviderUsageClient = Pick<DaemonClient, "listProviderUsage">;
 
+export interface RefreshProviderUsageOptions {
+  forceRefresh?: boolean;
+}
+
 export function providerUsageQueryKey(serverId: string | null | undefined) {
   return ["providerUsage", serverId ?? ""] as const;
 }
 
-async function fetchProviderUsage(client: ProviderUsageClient): Promise<ProviderUsageListPayload> {
+async function fetchProviderUsage(
+  client: ProviderUsageClient,
+  options?: RefreshProviderUsageOptions,
+): Promise<ProviderUsageListPayload> {
+  if (options?.forceRefresh === true) {
+    return client.listProviderUsage({ forceRefresh: true });
+  }
   return client.listProviderUsage();
 }
 
@@ -27,7 +37,7 @@ export function useProviderUsage(
   options: UseProviderUsageOptions = {},
 ): {
   view: ProviderUsageView;
-  refresh: () => Promise<void>;
+  refresh: (options?: RefreshProviderUsageOptions) => Promise<void>;
   canFetch: boolean;
 } {
   const queryClient = useQueryClient();
@@ -57,15 +67,17 @@ export function useProviderUsage(
     refetchOnWindowFocus: false,
   });
 
-  const refresh = useCallback(async () => {
-    if (!canFetch) return;
-    await queryClient.invalidateQueries({ queryKey });
-    await queryClient.fetchQuery({
-      queryKey,
-      queryFn,
-      staleTime: PROVIDER_USAGE_STALE_TIME_MS,
-    });
-  }, [canFetch, queryClient, queryFn, queryKey]);
+  const refresh = useCallback(
+    async (refreshOptions?: RefreshProviderUsageOptions) => {
+      if (!canFetch || !client) return;
+      await queryClient.fetchQuery({
+        queryKey,
+        queryFn: () => fetchProviderUsage(client, refreshOptions),
+        staleTime: 0,
+      });
+    },
+    [canFetch, client, queryClient, queryKey],
+  );
 
   const view = useMemo<ProviderUsageView>(() => {
     if (!serverId || !client || !isConnected) {

--- a/packages/app/src/screens/settings/host-page.tsx
+++ b/packages/app/src/screens/settings/host-page.tsx
@@ -324,7 +324,7 @@ export function HostUsagePage({ serverId }: { serverId: string }) {
   const host = useHostProfile(serverId);
   const { view: providerUsageView, refresh: refreshProviderUsage } = useProviderUsage(serverId);
   const handleRefresh = useCallback(() => {
-    void refreshProviderUsage();
+    void refreshProviderUsage({ forceRefresh: true });
   }, [refreshProviderUsage]);
 
   if (!host) {

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -5903,6 +5903,52 @@ test("sends provider.usage.list.request and resolves provider.usage.list.respons
   });
 });
 
+test("sends provider.usage.list.request with forceRefresh when requested", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const usagePromise = client.listProviderUsage({ requestId: "usage-2", forceRefresh: true });
+
+  expect(JSON.parse(assertStr(mock.sent[0]))).toEqual({
+    type: "session",
+    message: {
+      type: "provider.usage.list.request",
+      requestId: "usage-2",
+      forceRefresh: true,
+    },
+  });
+
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "provider.usage.list.response",
+      payload: {
+        requestId: "usage-2",
+        fetchedAt: "2026-06-19T00:01:00.000Z",
+        providers: [],
+      },
+    }),
+  );
+
+  await expect(usagePromise).resolves.toEqual({
+    requestId: "usage-2",
+    fetchedAt: "2026-06-19T00:01:00.000Z",
+    providers: [],
+  });
+});
+
 test("sends close_items_request and resolves close_items_response", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -4801,11 +4801,15 @@ export class DaemonClient {
     });
   }
 
-  async listProviderUsage(options?: { requestId?: string }): Promise<ProviderUsageListPayload> {
+  async listProviderUsage(options?: {
+    requestId?: string;
+    forceRefresh?: boolean;
+  }): Promise<ProviderUsageListPayload> {
     return this.sendNamespacedCorrelatedSessionRequest({
       requestId: options?.requestId,
       message: {
         type: "provider.usage.list.request",
+        ...(options?.forceRefresh === true ? { forceRefresh: true } : {}),
       },
     });
   }

--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -182,6 +182,20 @@ describe("provider usage list message contract", () => {
     });
   });
 
+  test("accepts an optional forceRefresh flag on the usage list request", () => {
+    const parsed = SessionInboundMessageSchema.parse({
+      type: "provider.usage.list.request",
+      requestId: "usage-1",
+      forceRefresh: true,
+    });
+
+    expect(parsed).toEqual({
+      type: "provider.usage.list.request",
+      requestId: "usage-1",
+      forceRefresh: true,
+    });
+  });
+
   test("accepts new providers and new usage windows as normalized data", () => {
     const parsed = SessionOutboundMessageSchema.parse({
       type: "provider.usage.list.response",

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -1654,6 +1654,7 @@ export const ProviderDiagnosticRequestMessageSchema = z.object({
 export const ProviderUsageListRequestMessageSchema = z.object({
   type: z.literal("provider.usage.list.request"),
   requestId: z.string(),
+  forceRefresh: z.boolean().optional(),
 });
 
 export const ResumeAgentRequestMessageSchema = z.object({

--- a/packages/server/src/server/session/provider/provider-catalog-session.test.ts
+++ b/packages/server/src/server/session/provider/provider-catalog-session.test.ts
@@ -286,6 +286,41 @@ describe("ProviderCatalogSession", () => {
     });
   });
 
+  it("forwards forceRefresh to the usage service", async () => {
+    const listUsage = vi.fn(async () => ({
+      fetchedAt: "2026-06-19T00:00:00.000Z",
+      providers: [],
+    }));
+    const { subsystem } = makeSubsystem({
+      usage: { listUsage },
+    });
+
+    await subsystem.handleProviderUsageListRequest({
+      type: "provider.usage.list.request",
+      requestId: "u-force",
+      forceRefresh: true,
+    });
+
+    expect(listUsage).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+
+  it("lists cached usage when forceRefresh is omitted", async () => {
+    const listUsage = vi.fn(async () => ({
+      fetchedAt: "2026-06-19T00:00:00.000Z",
+      providers: [],
+    }));
+    const { subsystem } = makeSubsystem({
+      usage: { listUsage },
+    });
+
+    await subsystem.handleProviderUsageListRequest({
+      type: "provider.usage.list.request",
+      requestId: "u-cached",
+    });
+
+    expect(listUsage).toHaveBeenCalledWith({ forceRefresh: false });
+  });
+
   it("surfaces a usage-list failure as an rpc_error envelope", async () => {
     const { subsystem, emitted } = makeSubsystem({
       usage: {

--- a/packages/server/src/server/session/provider/provider-catalog-session.ts
+++ b/packages/server/src/server/session/provider/provider-catalog-session.ts
@@ -484,7 +484,9 @@ export class ProviderCatalogSession {
     msg: Extract<SessionInboundMessage, { type: "provider.usage.list.request" }>,
   ): Promise<void> {
     try {
-      const usage = await this.providerUsageService.listUsage();
+      const usage = await this.providerUsageService.listUsage({
+        forceRefresh: msg.forceRefresh === true,
+      });
       this.host.emit({
         type: "provider.usage.list.response",
         payload: {


### PR DESCRIPTION
### Linked issue

None — searched [getpaseo/paseo](https://github.com/getpaseo/paseo/issues) issues and discussions for usage refresh / cache / stale plan usage. Closest existing usage issues (#2440, #3228, #3589, #2877, #2403) are about missing or wrong provider numbers, not the Settings Refresh button ignoring live data.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Settings → Usage → Refresh looked like it worked (spinner, button disable) but often showed the same numbers. Two 5-minute caches sat in front of the provider APIs:

1. React Query `staleTime` on the usage query
2. Daemon `ProviderUsageService` TTL (already had `forceRefresh`, but nothing called it)

The old refresh path did `invalidateQueries` then `fetchQuery` with the same 5-minute `staleTime` and the default query function. `invalidateQueries` refetches the cached (no-force) request; the follow-up `fetchQuery` then treats that result as fresh and does not fetch again. The daemon also returned its cache because the RPC never sent `forceRefresh`.

This PR adds an optional `forceRefresh` field on the existing `provider.usage.list.request`, threads it through client and daemon, and makes the Settings Refresh button call `fetchQuery` with `staleTime: 0` and `forceRefresh: true`. Initial load and the context-meter tooltip still use the caches.

Protocol compatibility: `forceRefresh` is optional. An old app omits it and a new daemon keeps caching. A new app sending the field still parses on an old daemon (unknown keys are stripped); that old daemon keeps caching until it is updated.

### Goals

- Clicking Refresh on Settings → Usage fetches live provider usage even within the 5-minute cache window.
- Repeated Refresh clicks each send `forceRefresh: true` and update the same React Query key.
- First load and tooltip open still use the React Query / daemon caches.

### Non-goals

- Changing cache TTLs.
- A new capability flag for force refresh.
- Forcing a daemon refresh when the context-meter tooltip opens.
- Fixing per-provider usage accuracy (Cursor, Claude account mismatch, Z.ai unavailable, etc.).

### QA

**Automated**

- `npm run typecheck` — passed (pre-commit).
- `npm run lint` / format check — passed (pre-commit).
- `npx vitest run packages/app/src/provider-usage/use-provider-usage.test.tsx --bail=1` — 3 passed.
- `npx vitest run packages/protocol/src/messages.test.ts --bail=1` — 23 passed.
- `npx vitest run packages/client/src/daemon-client.test.ts -t "provider.usage.list.request" --bail=1` — 2 passed.
- `npx vitest run packages/server/src/server/session/provider/provider-catalog-session.test.ts packages/server/src/services/quota-fetcher/service.test.ts -t "forceRefresh|usage-list|caches usage" --bail=1` — 4 passed.

**Manual (web, checkout-local daemon on `:6768` + Expo on `:8081`)**

1. Opened Settings → Usage for the local host.
2. Clicked Refresh: Cursor plan usage moved `$183.78 / $20.00` → `$186.58 / $20.00`.
3. Clicked Refresh twice more in succession. WebSocket intercept showed two requests, both `{ forceRefresh: true }`. Cursor then moved to `$187.02 / $20.00`.
4. Daemon logs showed those list requests taking ~600ms–1600ms (live provider fetches, not cache hits).

| Platform        | Tested | Notes |
| --------------- | ------ | ----- |
| iOS             |        | Not tested |
| Android         |        | Not tested |
| Web             | x      | Chrome against checkout-local daemon |
| Desktop macOS   |        | Not tested; same React Query + RPC path |
| Desktop Windows |        | Not tested |
| Desktop Linux   |        | Not tested |

Before (not triggering actual refresh after first click):

https://github.com/user-attachments/assets/a90dc677-2488-4b3c-80af-1b11562d82ec

After (every click triggers a real refresh):

https://github.com/user-attachments/assets/e63bc5c0-aae1-4830-adac-acbaa777ec69

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense