### PR TITLE
fix: launch AppImage with the sandbox flag on argv

### DIFF
--- a/packages/desktop/scripts/after-pack.js
+++ b/packages/desktop/scripts/after-pack.js
@@ -4,6 +4,16 @@ const path = require("path");
 const { smokePackagedDesktopApp } = require("../e2e/packaged-app-smoke.js");
 
 const EXECUTABLE_NAME = "Paseo";
+const LINUX_REAL_EXECUTABLE_NAME = `${EXECUTABLE_NAME}.bin`;
+const LINUX_LAUNCHER = `#!/bin/sh
+real_executable="\${0}.bin"
+
+if [ -n "\${APPIMAGE:-}" ]; then
+  exec "$real_executable" --no-sandbox "$@"
+fi
+
+exec "$real_executable" "$@"
+`;
 
 // electron-builder arch enum → Node.js arch string
 const ARCH_MAP = { 0: "ia32", 1: "x64", 2: "armv7l", 3: "arm64", 4: "universal" };
@@ -93,6 +103,18 @@ function pruneNativeModules(appOutDir, platform, arch) {
   console.log(`Pruned native modules: ${savedMB} MB removed (${fmtMB(before)} → ${fmtMB(after)})`);
 }
 
+function installLinuxLauncher(appOutDir) {
+  const launcherPath = path.join(appOutDir, EXECUTABLE_NAME);
+  const realExecutablePath = path.join(appOutDir, LINUX_REAL_EXECUTABLE_NAME);
+
+  if (!fs.existsSync(realExecutablePath)) {
+    fs.renameSync(launcherPath, realExecutablePath);
+  }
+
+  fs.writeFileSync(launcherPath, LINUX_LAUNCHER, "utf8");
+  fs.chmodSync(launcherPath, 0o755);
+}
+
 function dirSizeSync(dir) {
   let total = 0;
   for (const entry of fs.readdirSync(dir, { withFileTypes: true, recursive: true })) {
@@ -114,6 +136,10 @@ exports.default = async function afterPack(context) {
   const arch = ARCH_MAP[context.arch] || process.arch;
 
   pruneNativeModules(context.appOutDir, platform, arch);
+
+  if (platform === "linux") {
+    installLinuxLauncher(context.appOutDir);
+  }
 
   if (platform === "linux" || platform === "win32") {
     if (arch !== process.arch) {

--- a/packages/desktop/src/daemon/desktop-packaging.test.ts
+++ b/packages/desktop/src/daemon/desktop-packaging.test.ts
@@ -6,14 +6,22 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const requireFromHere = createRequire(import.meta.url);
+const afterPack = requireFromHere("../../scripts/after-pack.js").default as (context: {
+  appOutDir: string;
+  arch: number;
+  electronPlatformName: string;
+}) => Promise<void>;
 
 function writeExecutable(filePath: string, contents: string): void {
   writeFileSync(filePath, contents, "utf8");
@@ -62,7 +70,93 @@ function createFakeMacBundle(options: { includeHelper: boolean }): {
   return { root, shimPath };
 }
 
+function createFakeLinuxApp(): { executablePath: string; originalContents: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "paseo-linux-launcher-test-"));
+  const appOutDir = join(root, "packaged app [test]");
+  const executablePath = join(appOutDir, "Paseo");
+  const originalContents = [
+    "#!/usr/bin/env node",
+    "process.stdout.write(JSON.stringify(process.argv.slice(2)));",
+    "",
+  ].join("\n");
+
+  mkdirSync(appOutDir, { recursive: true });
+  writeExecutable(executablePath, originalContents);
+
+  return { executablePath, originalContents, root };
+}
+
+async function runLinuxAfterPack(appOutDir: string): Promise<void> {
+  await afterPack({
+    appOutDir,
+    arch: -1,
+    electronPlatformName: "linux",
+  });
+}
+
 describe("desktop packaging", () => {
+  it("adds --no-sandbox before user arguments for AppImage launches", async () => {
+    if (process.platform === "win32") return;
+
+    const app = createFakeLinuxApp();
+    try {
+      await runLinuxAfterPack(dirname(app.executablePath));
+
+      const userArgs = ["path with spaces", "$(touch should-not-run)", "semi;colon", "*.txt"];
+      const result = spawnSync(app.executablePath, userArgs, {
+        encoding: "utf8",
+        env: { ...process.env, APPIMAGE: "/tmp/Paseo image.AppImage" },
+      });
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual(["--no-sandbox", ...userArgs]);
+    } finally {
+      rmSync(app.root, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards non-AppImage Linux arguments without disabling the sandbox", async () => {
+    if (process.platform === "win32") return;
+
+    const app = createFakeLinuxApp();
+    try {
+      await runLinuxAfterPack(dirname(app.executablePath));
+      const env = { ...process.env };
+      delete env.APPIMAGE;
+
+      const userArgs = ["path with spaces", "--user-flag=value", "quote'argument"];
+      const result = spawnSync(app.executablePath, userArgs, { encoding: "utf8", env });
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual(userArgs);
+    } finally {
+      rmSync(app.root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the Linux launcher executable and the real executable intact when rerun", async () => {
+    if (process.platform === "win32") return;
+
+    const app = createFakeLinuxApp();
+    try {
+      const appOutDir = dirname(app.executablePath);
+      await runLinuxAfterPack(appOutDir);
+      await runLinuxAfterPack(appOutDir);
+
+      expect(readFileSync(`${app.executablePath}.bin`, "utf8")).toBe(app.originalContents);
+      expect(statSync(app.executablePath).mode & 0o111).toBe(0o111);
+
+      const result = spawnSync(app.executablePath, ["after rerun"], {
+        encoding: "utf8",
+        env: { ...process.env, APPIMAGE: "/tmp/Paseo.AppImage" },
+      });
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual(["--no-sandbox", "after rerun"]);
+    } finally {
+      rmSync(app.root, { recursive: true, force: true });
+    }
+  });
+
   it("unpacks server zsh shell integration files for external shells", () => {
     const config = readFileSync(join(packageRoot, "electron-builder.yml"), "utf8");
 

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -310,13 +310,6 @@ if (forcedUserDataDir) {
   }
 }
 
-// AppImage runtimes mount the app from /tmp under the user's UID, so the SUID
-// chrome-sandbox helper we ship in .deb/.rpm cannot work there. Disable the
-// sandbox only in that case; .deb/.rpm keep the sandbox on, matching VS Code.
-if (process.platform === "linux" && process.env.APPIMAGE) {
-  app.commandLine.appendSwitch("no-sandbox");
-}
-
 // Allow users to pass Chromium flags via PASEO_ELECTRON_FLAGS for debugging
 // rendering issues (e.g. "--disable-gpu --ozone-platform=x11").
 // Must run before app.whenReady().


### PR DESCRIPTION
### Linked issue

Closes #2853

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Extend the existing `afterPack` hook to replace the Linux app executable with a
small launcher that delegates to the renamed real executable, adding
`--no-sandbox` only when the AppImage runtime exposes `APPIMAGE`. All other
Linux package formats forward argv unchanged.

Remove the ineffective AppImage-specific `appendSwitch` block from `main.ts`,
leaving the existing argv parsers' handling of the injected flag intact.

Add filesystem-backed packaging tests that run the generated launcher against a
fake executable and assert exact argument forwarding with and without
`APPIMAGE`, including arguments containing spaces and user-supplied arguments.

### Goals

Make the AppImage build launch with the sandbox flag applied on argv, where it
actually takes effect, without altering behavior for deb/rpm/tar builds.

### Non-goals

No change to sandbox behavior on macOS or Windows, and no change to how the
argv parsers interpret the flag once present.

### QA

Automated only: the added packaging tests execute the generated launcher and
assert forwarded argv in both the `APPIMAGE` and non-`APPIMAGE` cases. A
packaged AppImage was **not** built and launched by hand, so manual QA evidence
is absent.

### Checklist

- [x] One focused change
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run format` passes
- [ ] QA evidence
- [x] Tests added or updated where it made sense

The three unchecked command boxes are unchecked because those commands were
**not run** in the environment that produced this change — no workspace test
command resolved. They are left for CI rather than claimed.

AI was used for assistance.
