### PR TITLE
fix(pi): refresh context usage when compaction ends

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -1629,6 +1629,41 @@ describe("PiRpcAgentSession", () => {
       usage: { contextWindowUsedTokens: 160 },
     });
   });
+
+  test("refreshes context usage when compaction ends so the meter is not stale", async () => {
+    const { pi, session, events } = await createSession();
+    const fakeSession = pi.latestSession();
+    fakeSession.stats = { contextUsage: { contextWindow: 200_000, tokens: 93_000 } };
+
+    // Turn completes; the last usage snapshot is pre-compaction (93k).
+    const first = await session.startTurn("hello");
+    fakeSession.finishTurn();
+    await flushTurnScheduling();
+    expect(events.usageUpdatedEvents()).toHaveLength(1);
+    expect(events.usageUpdatedEvents()[0]).toMatchObject({
+      turnId: first.turnId,
+      usage: { contextWindowUsedTokens: 93_000 },
+    });
+
+    // Auto-compaction runs after agent_end and shrinks the context. Pi then
+    // reports the reduced size, so the meter must follow instead of staying
+    // stuck at the pre-compaction value.
+    fakeSession.stats = { contextUsage: { contextWindow: 200_000, tokens: 26_000 } };
+    fakeSession.emit({ type: "compaction_start", reason: "auto" });
+    fakeSession.emit({ type: "compaction_end", reason: "auto" });
+    await flushTurnScheduling();
+
+    expect(events.usageUpdatedEvents()).toHaveLength(2);
+    expect(events.usageUpdatedEvents()[1]).toMatchObject({
+      usage: { contextWindowUsedTokens: 26_000 },
+    });
+    expect(events.timelineItems()).toEqual(
+      expect.arrayContaining([
+        { type: "compaction", status: "loading", trigger: "auto" },
+        { type: "compaction", status: "completed", trigger: "auto" },
+      ]),
+    );
+  });
 });
 
 describe("PiRpcAgentClient", () => {

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -2149,6 +2149,13 @@ export class PiRpcAgentSession implements AgentSession {
             trigger: event.reason === "manual" ? "manual" : "auto",
           },
         });
+        // Pi runs auto-compaction after agent_end, so the last usage snapshot
+        // predates the compaction and the context meter would stay stale. Re-read
+        // stats so the meter reflects the post-compaction state. Pi reports
+        // contextUsage.tokens=null until the next assistant response, so the
+        // meter shows unknown, then the reduced size on the next turn. Manual
+        // /compact emits the same events and is covered by this path too.
+        void this.usagePoller.completeTurn(turnId);
         return;
       case "auto_retry_start":
         this.emit({


### PR DESCRIPTION
## Problem

After compaction (auto or manual) the context-window meter in the UI stays stuck at the stale pre-compaction value (e.g. ~93%) until the next user turn, making compaction look like it failed even though it succeeded.

Root cause: for the pi provider, usage is only snapshotted at turn boundaries (`agent_end` → `completeTurn` → usage poller `completeTurn`). But pi runs auto-compaction **after** `agent_end` (in `_handlePostAgentRun` → `_checkCompaction`), and the `compaction_end` handler only emitted the timeline chip — no usage re-read. Manual `/compact` emits the same `compaction_start`/`compaction_end` events, so it had the same gap.

## Fix

Re-read session stats on `compaction_end` via the existing `PiUsagePoller.completeTurn(turnId)`. One handler covers both auto and manual compaction since both emit the same events. The poller's existing dedupe means no spurious events when stats are unchanged.

Behavior: right after compaction pi reports `contextUsage.tokens=null` (no post-compaction assistant response yet), so the meter shows unknown; on the next assistant turn it shows the true reduced size.

## Test

Added `refreshes context usage when compaction ends so the meter is not stale` in `agent.test.ts`: completes a turn at 93k, shrinks stats to 26k, emits `compaction_start`/`compaction_end`, asserts a second `usage_updated` event with the reduced size (and the timeline chips). Verified the test fails without the fix and passes with it; full pi provider suite green (65 tests).

Repro context: with a 131k window and compaction triggering at ~115k (88%), the pre-compaction snapshot is always ~90%+, so the stale meter exactly matches user reports of "context still shows 90%+ after compaction".