### PR TITLE
Prevent layout changes from restarting timeline retries

### DIFF
--- a/docs/timeline-sync.md
+++ b/docs/timeline-sync.md
@@ -49,7 +49,7 @@ A failed catch-up or subscription reconcile retries on its own, doubling from 1s
 A fixed 1s retry turned a persistent daemon-side refusal — a Codex thread that already has an active
 writer, say — into a request and a log line every second on an idle app. The delay resets on success,
 reconnect, delivery-mode change, and visibility change, so recovery is still immediate once the
-condition clears.
+condition clears. Republishing the same visibility set is a no-op and never bypasses backoff.
 
 Background retries are silent. The retry the user presses in the sync-error callout is a fallible
 user action and owns its pending state: `retrying` is a status the sync model publishes, not a React

--- a/packages/app/src/screens/workspace/visible-agent-ids.ts
+++ b/packages/app/src/screens/workspace/visible-agent-ids.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { collectAllPanes, type WorkspaceLayout } from "@/stores/workspace-layout-store";
 import type { WorkspaceTab } from "@/workspace-tabs/model";
 import { deriveWorkspacePaneState } from "./workspace-pane-state";
@@ -24,4 +25,21 @@ export function selectVisibleAgentIds(input: {
       }),
     ),
   ].sort();
+}
+
+export function useVisibleAgentIds(input: {
+  layout: WorkspaceLayout | null;
+  tabs: WorkspaceTab[];
+  routeFocused: boolean;
+  focusedPaneOnly: boolean;
+}): string[] {
+  const nextAgentIds = selectVisibleAgentIds(input);
+  const stableAgentIds = useRef<string[]>([]);
+  if (
+    stableAgentIds.current.length !== nextAgentIds.length ||
+    stableAgentIds.current.some((agentId, index) => agentId !== nextAgentIds[index])
+  ) {
+    stableAgentIds.current = nextAgentIds;
+  }
+  return stableAgentIds.current;
 }

--- a/packages/app/src/screens/workspace/workspace-screen.tsx
+++ b/packages/app/src/screens/workspace/workspace-screen.tsx
@@ -84,7 +84,7 @@ import type {
 } from "@/keyboard/keyboard-action-dispatcher";
 import { useCreateFlowStore } from "@/stores/create-flow-store";
 import { normalizeWorkspaceTabTarget, workspaceTabTargetsEqual } from "@/workspace-tabs/identity";
-import { selectVisibleAgentIds } from "./visible-agent-ids";
+import { useVisibleAgentIds } from "./visible-agent-ids";
 import {
   getHostRuntimeStore,
   useHostRuntimeClient,
@@ -1845,16 +1845,16 @@ function WorkspaceScreenContent({
   const viewedTimelineSync = useSessionStore(
     (state) => state.sessions[normalizedServerId]?.viewedTimelineSync ?? null,
   );
-  const visibleAgentIds = useMemo(
-    () =>
-      selectVisibleAgentIds({
-        layout: workspaceLayout,
-        tabs: uiTabs,
-        routeFocused: isRouteFocused,
-        focusedPaneOnly: isMobile || isFocusModeEnabled || !supportsDesktopPaneSplits(),
-      }),
-    [isFocusModeEnabled, isMobile, isRouteFocused, uiTabs, workspaceLayout],
+  const syncFocusedPaneOnly = useMemo(
+    () => isMobile || isFocusModeEnabled || !supportsDesktopPaneSplits(),
+    [isFocusModeEnabled, isMobile],
   );
+  const visibleAgentIds = useVisibleAgentIds({
+    layout: workspaceLayout,
+    tabs: uiTabs,
+    routeFocused: isRouteFocused,
+    focusedPaneOnly: syncFocusedPaneOnly,
+  });
   useLayoutEffect(() => {
     if (!persistenceKey || !viewedTimelineSync) {
       return;

--- a/packages/app/src/timeline/viewed-timeline-sync.test.ts
+++ b/packages/app/src/timeline/viewed-timeline-sync.test.ts
@@ -464,6 +464,24 @@ test("manual retries can immediately re-attempt a failed catch-up", async () => 
   await vi.waitFor(() => expect(world.sync.getAgentTimelineStatus("agent-a")).toBe("ready"));
 });
 
+test("redeclaring unchanged visibility does not bypass catch-up backoff", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+  const membership = await world.nextMembership();
+  membership.succeed();
+
+  const failed = await world.nextFetch("agent-a");
+  failed.fail("timeline unavailable");
+  await world.nextRetry();
+
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+
+  world.expectNoPendingMembership();
+  world.expectNoPendingFetch();
+  expect(world.sync.getAgentTimelineStatus("agent-a")).toBe("error");
+});
+
 test("a manual retry that fails returns to the error state", async () => {
   const world = new TimelineWorld();
   world.sync.setConnected(true);
@@ -584,6 +602,22 @@ test("membership failures retry with exponential backoff", async () => {
   const catchUp = await world.nextFetch("agent-a");
   catchUp.respond({ hasNewer: false });
   await vi.waitFor(() => expect(world.sync.getAgentTimelineStatus("agent-a")).toBe("ready"));
+});
+
+test("redeclaring unchanged visibility does not bypass membership backoff", async () => {
+  const world = new TimelineWorld();
+  world.sync.setConnected(true);
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+
+  const failed = await world.nextMembership();
+  failed.fail("subscription unavailable");
+  await world.nextRetry();
+
+  world.sync.replaceVisibleAgentIds("workspace", ["agent-a"]);
+
+  world.expectNoPendingMembership();
+  world.expectNoPendingFetch();
+  expect(world.sync.getAgentTimelineStatus("agent-a")).toBe("error");
 });
 
 test("backgrounding preserves the hot membership without catch-up on return", async () => {

--- a/packages/app/src/timeline/viewed-timeline-sync.ts
+++ b/packages/app/src/timeline/viewed-timeline-sync.ts
@@ -365,12 +365,6 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
     }
   };
 
-  const retryFailedCatchUps = () => {
-    for (const agentId of acknowledged) {
-      if (catchUps.get(agentId)?.status === "error") startCatchUp(agentId);
-    }
-  };
-
   const retryVisibleAgentTimeline = (agentId: string) => {
     if (!isDesired(agentId) || manualRetries.has(agentId)) return;
     const catchUp = catchUps.get(agentId);
@@ -407,8 +401,6 @@ export function createViewedTimelineSync(ports: ViewedTimelineSyncPorts): Viewed
     }
     if (sameAgentIds(nextDesired, desired)) {
       if (statusChanged) notifyListeners();
-      if (deliveryMode === "selective" && membershipNeedsRetry) void reconcileMembership();
-      retryFailedCatchUps();
       return;
     }
 


### PR DESCRIPTION
### Linked issue

None found after searching open issues and PRs for timeline synchronization, retries, visibility, and tab changes.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [x] Docs

### Reasoning

Creating tabs or changing workspace layout republishes the visible-agent set. Equivalent publications were restarting failed timeline catch-ups and subscription reconciliation immediately, bypassing exponential backoff and producing repeated work and warnings for retained agents.

Visibility declarations now retain semantic identity across unrelated layout changes, and an unchanged membership declaration performs no retry work. Immediate retry remains owned by the user's Retry action.

### Goals

- Keep visible-agent identity stable when layout changes do not change the semantic agent set.
- Make equivalent visibility declarations no-ops.
- Preserve exponential backoff for failed timeline catch-up and subscription reconciliation.
- Keep explicit user retries immediate.

### Non-goals

- Change which visible or recently viewed agents belong to the timeline hot set.
- Change background retry timing.
- Change retained-panel mounting behavior.

### QA

Focused regression coverage:

```text
npx vitest run packages/app/src/timeline/viewed-timeline-sync.test.ts --bail=1
Test Files  1 passed (1)
Tests  30 passed (30)

npx vitest run packages/app/src/screens/workspace/visible-agent-ids.test.ts --bail=1
Test Files  1 passed (1)
Tests  4 passed (4)
```

Repository checks:

```text
npm run format
Finished on 4017 files

npm run typecheck
All workspace typechecks passed

npm run lint
Found 0 warnings and 0 errors.
```

The catch-up regression test was confirmed red before the implementation: redeclaring the unchanged agent set produced an immediate pending timeline fetch. It is green after the change, and parallel coverage verifies subscription backoff is not bypassed either.

Desktop macOS: the changed Electron renderer built and launched. A full click-through against an isolated private daemon was attempted, but the route remained in its connecting state during the QA session, so no manual interaction claim is made. The change has no platform-specific branch and the behavior is covered at the synchronization boundary.

### Checklist

- [x] One focused change
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
