### PR TITLE
fix(grok): surface context compaction in timeline

### DIFF
--- a/packages/server/src/server/agent/provider-registry.test.ts
+++ b/packages/server/src/server/agent/provider-registry.test.ts
@@ -38,6 +38,11 @@ const mockState = vi.hoisted(() => {
         env?: Record<string, string>;
         providerParams?: unknown;
       }>,
+      grok: [] as Array<{
+        command: string[];
+        env?: Record<string, string>;
+        providerParams?: unknown;
+      }>,
       trae: [] as Array<{
         command: string[];
         env?: Record<string, string>;
@@ -65,6 +70,7 @@ const mockState = vi.hoisted(() => {
       this.constructorArgs.codex = [];
       this.constructorArgs.copilot = [];
       this.constructorArgs.cursor = [];
+      this.constructorArgs.grok = [];
       this.constructorArgs.trae = [];
       this.constructorArgs.kimi = [];
       this.constructorArgs.pi = [];
@@ -418,6 +424,56 @@ vi.mock("./providers/cursor-acp-agent.js", () => ({
           options: [{ id: "false", label: "Off" }],
         },
       ];
+    }
+  },
+}));
+
+vi.mock("./providers/grok-acp-agent.js", () => ({
+  GrokACPAgentClient: class GrokACPAgentClient {
+    readonly capabilities = {
+      supportsStreaming: true,
+      supportsSessionPersistence: true,
+      supportsDynamicModes: true,
+      supportsMcpServers: true,
+      supportsReasoningStream: true,
+      supportsToolInvocations: true,
+    };
+    readonly provider = "acp";
+    readonly runtimeSettings?: unknown;
+
+    constructor(options: {
+      command: string[];
+      env?: Record<string, string>;
+      providerParams?: unknown;
+    }) {
+      this.runtimeSettings = {
+        command: {
+          mode: "replace",
+          argv: options.command,
+        },
+        env: options.env,
+      };
+      mockState.constructorArgs.grok.push({
+        command: options.command,
+        env: options.env,
+        providerParams: options.providerParams,
+      });
+    }
+
+    async createSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async resumeSession(): Promise<never> {
+      throw new Error("not implemented");
+    }
+
+    async fetchCatalog(): Promise<ProviderCatalog> {
+      return { models: [], modes: [] };
+    }
+
+    async isAvailable(): Promise<boolean> {
+      return true;
     }
   },
 }));
@@ -853,6 +909,33 @@ test("cursor provider extending acp uses CursorACPAgentClient", () => {
       env: {
         CURSOR_AGENT_LOG: "debug",
       },
+      providerParams: undefined,
+    },
+  ]);
+  expect(mockState.constructorArgs.genericAcp).toEqual([]);
+});
+
+test("grok provider extending acp uses GrokACPAgentClient", () => {
+  const registry = buildProviderRegistry(logger, {
+    providerOverrides: {
+      grok: {
+        extends: "acp",
+        label: "Grok",
+        command: ["grok", "agent", "stdio"],
+      },
+    },
+  });
+
+  expect(registry.grok.createClient(logger).provider).toBe("grok");
+  expect(mockState.constructorArgs.grok).toEqual([
+    {
+      command: ["grok", "agent", "stdio"],
+      env: undefined,
+      providerParams: undefined,
+    },
+    {
+      command: ["grok", "agent", "stdio"],
+      env: undefined,
       providerParams: undefined,
     },
   ]);

--- a/packages/server/src/server/agent/provider-registry.ts
+++ b/packages/server/src/server/agent/provider-registry.ts
@@ -39,6 +39,7 @@ import { CodexAppServerAgentClient } from "./providers/codex-app-server-agent.js
 import { CopilotACPAgentClient } from "./providers/copilot-acp-agent.js";
 import { CursorACPAgentClient } from "./providers/cursor-acp-agent.js";
 import { GenericACPAgentClient } from "./providers/generic-acp-agent.js";
+import { GrokACPAgentClient } from "./providers/grok-acp-agent.js";
 import { KimiACPAgentClient } from "./providers/kimi-acp-agent.js";
 import { KiroACPAgentClient } from "./providers/kiro-acp-agent.js";
 import { OpenCodeAgentClient } from "./providers/opencode-agent.js";
@@ -792,6 +793,9 @@ function addDerivedProviders(
           };
           if (providerId === "cursor") {
             return new CursorACPAgentClient(acpOptions);
+          }
+          if (providerId === "grok") {
+            return new GrokACPAgentClient(acpOptions);
           }
           if (providerId === "kimi") {
             return new KimiACPAgentClient(acpOptions);

--- a/packages/server/src/server/agent/providers/acp-agent.ts
+++ b/packages/server/src/server/agent/providers/acp-agent.ts
@@ -379,6 +379,21 @@ export type ACPExtensionCommandsParser = (
   params: Record<string, unknown>,
 ) => AgentSlashCommand[] | null;
 
+export interface ACPExtensionNotificationContext {
+  sessionId: string | null;
+}
+
+/**
+ * Provider-owned ACP extension notification to timeline items. Return null
+ * when the method is not owned by this handler, or an empty array when the
+ * method is owned but the payload should be ignored.
+ */
+export type ACPExtensionNotificationHandler = (
+  method: string,
+  params: Record<string, unknown>,
+  context: ACPExtensionNotificationContext,
+) => AgentTimelineItem[] | null;
+
 /**
  * Context handed to an {@link ACPCatalogModelResolver} during `fetchCatalog`. It exposes
  * the already-derived models plus the live probe session so a resolver can refine them
@@ -432,6 +447,7 @@ interface ACPAgentClientOptions {
   ) => Promise<void>;
   capabilities?: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
   waitForInitialCommands?: boolean;
   initialCommandsWaitTimeoutMs?: number;
   terminateProcess?: ProcessTerminator;
@@ -462,6 +478,7 @@ interface ACPAgentSessionOptions {
   ) => Promise<void>;
   capabilities: AgentCapabilityFlags;
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
   handle?: AgentPersistenceHandle;
   agentId?: string;
   launchEnv?: Record<string, string>;
@@ -822,6 +839,7 @@ export class ACPAgentClient implements AgentClient {
   private readonly waitForInitialCommands: boolean;
   private readonly initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly extensionNotificationHandler?: ACPExtensionNotificationHandler;
   protected readonly terminateProcess: ProcessTerminator;
 
   constructor(options: ACPAgentClientOptions) {
@@ -850,6 +868,7 @@ export class ACPAgentClient implements AgentClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.extensionNotificationHandler = options.extensionNotificationHandler;
   }
 
   async createSession(
@@ -880,6 +899,7 @@ export class ACPAgentClient implements AgentClient {
         agentId: launchContext?.agentId,
         launchEnv: launchContext?.env,
         extensionCommandsParser: this.extensionCommandsParser,
+        extensionNotificationHandler: this.extensionNotificationHandler,
         waitForInitialCommands: this.waitForInitialCommands,
         initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
       },
@@ -931,6 +951,7 @@ export class ACPAgentClient implements AgentClient {
       agentId: launchContext?.agentId,
       launchEnv: launchContext?.env,
       extensionCommandsParser: this.extensionCommandsParser,
+      extensionNotificationHandler: this.extensionNotificationHandler,
       waitForInitialCommands: this.waitForInitialCommands,
       initialCommandsWaitTimeoutMs: this.initialCommandsWaitTimeoutMs,
     });
@@ -1454,6 +1475,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
   private waitForInitialCommands: boolean;
   private initialCommandsWaitTimeoutMs: number;
   private readonly extensionCommandsParser?: ACPExtensionCommandsParser;
+  private readonly extensionNotificationHandler?: ACPExtensionNotificationHandler;
   private currentTurnUsage: AgentUsage | undefined;
   private activeForegroundTurnId: string | null = null;
   private fallbackAssistantMessageId: string | null = null;
@@ -1494,6 +1516,7 @@ export class ACPAgentSession implements AgentSession, ACPClient {
     this.waitForInitialCommands = options.waitForInitialCommands ?? false;
     this.initialCommandsWaitTimeoutMs = options.initialCommandsWaitTimeoutMs ?? 1500;
     this.extensionCommandsParser = options.extensionCommandsParser;
+    this.extensionNotificationHandler = options.extensionNotificationHandler;
   }
 
   get id(): string | null {
@@ -2336,6 +2359,13 @@ export class ACPAgentSession implements AgentSession, ACPClient {
       this.applyResolvedCommands(parsedCommands, {
         sessionId: typeof params.sessionId === "string" ? params.sessionId : undefined,
       });
+    }
+
+    const timelineItems = this.extensionNotificationHandler?.(method, params, {
+      sessionId: this.sessionId,
+    });
+    if (timelineItems) {
+      this.deliverTranslatedEvents(timelineItems.map((item) => this.wrapTimeline(item)));
     }
   }
 

--- a/packages/server/src/server/agent/providers/generic-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/generic-acp-agent.ts
@@ -10,6 +10,7 @@ import {
   type ACPConfigFeatureOption,
   DEFAULT_ACP_CAPABILITIES,
   type ACPExtensionCommandsParser,
+  type ACPExtensionNotificationHandler,
 } from "./acp-agent.js";
 import {
   buildBinaryDiagnosticRows,
@@ -50,6 +51,7 @@ interface GenericACPAgentClientOptions {
   clientCapabilityMeta?: ACPClientCapabilityMeta;
   configFeatureOptions?: ACPConfigFeatureOption[];
   extensionCommandsParser?: ACPExtensionCommandsParser;
+  extensionNotificationHandler?: ACPExtensionNotificationHandler;
   catalogModelResolver?: ACPCatalogModelResolver;
 }
 
@@ -75,6 +77,7 @@ export class GenericACPAgentClient extends ACPAgentClient {
       clientCapabilityMeta: options.clientCapabilityMeta,
       configFeatureOptions: options.configFeatureOptions,
       extensionCommandsParser: options.extensionCommandsParser,
+      extensionNotificationHandler: options.extensionNotificationHandler,
       catalogModelResolver: options.catalogModelResolver,
     });
 

--- a/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.test.ts
@@ -1,0 +1,237 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+import { createTestLogger } from "../../../test-utils/test-logger.js";
+import type { AgentStreamEvent } from "../agent-sdk-types.js";
+import {
+  GROK_SESSION_UPDATE_METHOD,
+  GrokACPAgentClient,
+  mapGrokCompactionExtensionNotification,
+} from "./grok-acp-agent.js";
+
+const context = { sessionId: "session-1" };
+
+describe("mapGrokCompactionExtensionNotification", () => {
+  test("ignores extension methods and sessions it does not own", () => {
+    expect(
+      mapGrokCompactionExtensionNotification(
+        "_other.ai/session/update",
+        { sessionId: "session-1" },
+        context,
+      ),
+    ).toBeNull();
+    expect(
+      mapGrokCompactionExtensionNotification(
+        GROK_SESSION_UPDATE_METHOD,
+        {
+          sessionId: "session-2",
+          update: { sessionUpdate: "auto_compact_started", tokens_used: 400_000 },
+        },
+        context,
+      ),
+    ).toEqual([]);
+  });
+
+  test("maps Grok auto-compaction start and completion into the shared marker", () => {
+    expect(
+      mapGrokCompactionExtensionNotification(
+        GROK_SESSION_UPDATE_METHOD,
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "auto_compact_started",
+            tokens_used: 423_901,
+            context_window: 500_000,
+            percentage: 85,
+            reason: "Context window 85% full",
+          },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        type: "compaction",
+        status: "loading",
+        trigger: "auto",
+      },
+    ]);
+
+    expect(
+      mapGrokCompactionExtensionNotification(
+        GROK_SESSION_UPDATE_METHOD,
+        {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "auto_compact_completed",
+            tokens_before: 423_901,
+            tokens_after: 18_914,
+            elapsed_ms: 151_577,
+            summary_preview: null,
+          },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        type: "compaction",
+        status: "completed",
+        trigger: "auto",
+      },
+    ]);
+  });
+
+  test("settles failed and canceled compactions without leaving a loading marker", () => {
+    expect(
+      mapGrokCompactionExtensionNotification(
+        GROK_SESSION_UPDATE_METHOD,
+        {
+          sessionId: "session-1",
+          update: { sessionUpdate: "auto_compact_failed" },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        type: "compaction",
+        status: "completed",
+        trigger: "auto",
+      },
+    ]);
+    expect(
+      mapGrokCompactionExtensionNotification(
+        GROK_SESSION_UPDATE_METHOD,
+        {
+          sessionId: "session-1",
+          update: { sessionUpdate: "auto_compact_cancelled" },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        type: "compaction",
+        status: "completed",
+        trigger: "auto",
+      },
+    ]);
+  });
+
+  test("ignores checkpoints and unknown updates", () => {
+    expect(
+      mapGrokCompactionExtensionNotification(
+        GROK_SESSION_UPDATE_METHOD,
+        {
+          sessionId: "session-1",
+          update: { sessionUpdate: "compaction_checkpoint", checkpoint_id: "checkpoint-1" },
+        },
+        context,
+      ),
+    ).toEqual([]);
+    expect(
+      mapGrokCompactionExtensionNotification(
+        GROK_SESSION_UPDATE_METHOD,
+        { sessionId: "session-1", update: { sessionUpdate: "something_else" } },
+        context,
+      ),
+    ).toEqual([]);
+  });
+});
+
+test("replays Grok compaction extension notifications from session/load into history", async () => {
+  await withFakeGrokACPAgent(async (testDir, scriptPath) => {
+    const client = new GrokACPAgentClient({
+      logger: createTestLogger(),
+      command: [process.execPath, scriptPath],
+    });
+    const session = await client.resumeSession(
+      { provider: "acp", sessionId: "grok-session-1" },
+      { cwd: testDir },
+    );
+
+    try {
+      const history: AgentStreamEvent[] = [];
+      for await (const event of session.streamHistory()) {
+        history.push(event);
+      }
+
+      expect(history).toEqual([
+        {
+          type: "timeline",
+          provider: "acp",
+          item: {
+            type: "compaction",
+            status: "loading",
+            trigger: "auto",
+          },
+        },
+        {
+          type: "timeline",
+          provider: "acp",
+          item: {
+            type: "compaction",
+            status: "completed",
+            trigger: "auto",
+          },
+        },
+      ]);
+    } finally {
+      await session.close();
+    }
+  });
+});
+
+async function withFakeGrokACPAgent(
+  run: (testDir: string, scriptPath: string) => Promise<void>,
+): Promise<void> {
+  const testDir = await mkdtemp(path.join(tmpdir(), "paseo-grok-acp-history-"));
+  try {
+    const scriptPath = path.join(testDir, "fake-grok-acp-agent.cjs");
+    await writeFile(scriptPath, fakeGrokACPAgentScript, "utf8");
+    await run(testDir, scriptPath);
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+}
+
+const fakeGrokACPAgentScript = `
+const readline = require("node:readline");
+
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+}
+
+function notify(method, params) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\\n");
+}
+
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send(message.id, {
+      protocolVersion: message.params?.protocolVersion ?? 1,
+      agentCapabilities: { loadSession: true },
+    });
+    return;
+  }
+
+  if (message.method === "session/load") {
+    notify("_x.ai/session/update", {
+      sessionId: "grok-session-1",
+      update: { sessionUpdate: "auto_compact_started", tokens_used: 423901 },
+    });
+    notify("_x.ai/session/update", {
+      sessionId: "grok-session-1",
+      update: { sessionUpdate: "compaction_checkpoint" },
+    });
+    notify("_x.ai/session/update", {
+      sessionId: "grok-session-1",
+      update: { sessionUpdate: "auto_compact_completed", tokens_before: 423901 },
+    });
+    send(message.id, { configOptions: [], modes: null, models: null });
+  }
+});
+`;

--- a/packages/server/src/server/agent/providers/grok-acp-agent.ts
+++ b/packages/server/src/server/agent/providers/grok-acp-agent.ts
@@ -1,0 +1,83 @@
+import type { Logger } from "pino";
+import { z } from "zod";
+
+import type { AgentTimelineItem } from "../agent-sdk-types.js";
+import type { ACPExtensionNotificationContext } from "./acp-agent.js";
+import { GenericACPAgentClient } from "./generic-acp-agent.js";
+
+// Grok's bundled docs name x.ai/session_notification, but recorded Grok 1.0.5
+// auto-compaction traffic uses this extension notification method.
+export const GROK_SESSION_UPDATE_METHOD = "_x.ai/session/update";
+
+const GrokCompactionUpdateSchema = z
+  .object({
+    sessionUpdate: z.string(),
+  })
+  .passthrough();
+
+const GrokCompactionNotificationSchema = z
+  .object({
+    sessionId: z.string(),
+    update: GrokCompactionUpdateSchema,
+  })
+  .passthrough();
+
+interface GrokACPAgentClientOptions {
+  logger: Logger;
+  command: [string, ...string[]];
+  env?: Record<string, string>;
+  providerId?: string;
+  label?: string;
+  providerParams?: unknown;
+}
+
+export function mapGrokCompactionExtensionNotification(
+  method: string,
+  params: Record<string, unknown>,
+  context: ACPExtensionNotificationContext,
+): AgentTimelineItem[] | null {
+  if (method !== GROK_SESSION_UPDATE_METHOD) {
+    return null;
+  }
+
+  const parsed = GrokCompactionNotificationSchema.safeParse(params);
+  if (!parsed.success || parsed.data.sessionId !== context.sessionId) {
+    return [];
+  }
+
+  const update = parsed.data.update;
+  switch (update.sessionUpdate) {
+    case "auto_compact_started":
+      return [compactionItem("loading")];
+    case "auto_compact_completed":
+    case "auto_compact_failed":
+    case "auto_compact_cancelled":
+      return [compactionItem("completed")];
+    default:
+      return [];
+  }
+}
+
+function compactionItem(
+  status: "loading" | "completed",
+): Extract<AgentTimelineItem, { type: "compaction" }> {
+  return {
+    type: "compaction",
+    status,
+    trigger: "auto",
+  };
+}
+
+export class GrokACPAgentClient extends GenericACPAgentClient {
+  constructor(options: GrokACPAgentClientOptions) {
+    super({
+      logger: options.logger,
+      command: options.command,
+      env: options.env,
+      providerId: options.providerId ?? "grok",
+      label: options.label ?? "Grok",
+      providerParams: options.providerParams,
+      extensionNotificationHandler: mapGrokCompactionExtensionNotification,
+    });
+  }
+}


### PR DESCRIPTION
### Linked issue

N/A — reproduced from real Grok 1.0.5 ACP session logs.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Grok publishes context compaction through vendor `_x.ai/session/update` notifications. Paseo's existing compaction indicator already works for providers that emit the shared timeline item, but the generic ACP adapter did not translate Grok's vendor events. As a result, Grok could spend minutes compacting without showing progress in Paseo.

This PR brings Grok to parity by mapping its notifications onto the existing compaction timeline shape. It does not change the shared protocol or UI.

### Goals

- Map `auto_compact_started` to the existing loading compaction marker.
- Map completed, failed, and canceled notifications to the existing terminal marker so the spinner settles.
- Ignore `compaction_checkpoint`, which is a Grok persistence detail.
- Preserve Grok compaction markers replayed during `session/load`.
- Leave every other provider's behavior unchanged.

### Implementation scope

- Add a thin `GrokACPAgentClient` with the Grok-specific notification parser.
- Register that client for the built-in Grok ACP provider.
- Add a provider-neutral, default-absent ACP extension-notification mapper so the Grok subclass can feed existing timeline items through the normal live and history paths. Only Grok configures it.

### Non-goals

- Richer token-count display.
- Failed/canceled compaction UI states.
- Generic compaction lifecycle synthesis.
- Changes to app rendering, protocol schemas, replica cache, localization, activity summaries, or other providers.
- Grok background task, subagent, usage, reasoning, or ask-user extension events.

### Release and overlap verification

This was not included in [v0.5.0-beta.5](https://paseo.sh/changelog#release-0.5.0-beta.5). The [beta.4 → beta.5 range](https://github.com/getpaseo/paseo/compare/v0.5.0-beta.4...v0.5.0-beta.5) contains none of `auto_compact_started`, `auto_compact_completed`, `compaction_checkpoint`, or a Grok compaction mapping.

### QA

The Grok parser is covered for:

- start and successful completion;
- failed and canceled terminal notifications;
- unrelated methods, another session, malformed payloads, checkpoints, and unknown updates;
- a spawned ACP child replaying Grok notifications through `session/load` into timeline history;
- registry selection of the Grok-specific ACP client.

The compaction indicator was also manually verified against the local dev daemon before this scope reduction. The final branch removes the richer shared behavior while retaining the same existing marker path.

Focused automated coverage:

```text
2 files / 55 tests passed
```

Repository checks:

```text
npm run typecheck  # passed
npm run lint       # 0 warnings, 0 errors
npm run format     # passed
```

Platform coverage:

| Platform | Tested | Notes |
| --- | --- | --- |
| iOS | No | Existing shared marker; no app code changed |
| Android | No | Existing shared marker; no app code changed |
| Web | Manual | Existing shared marker validated with the local dev daemon |
| Desktop | No | Existing shared web renderer; no app code changed |

### Checklist

- [x] One focused change
- [x] Based directly on current `main`
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] QA evidence
- [x] Tests added or updated where it made sense
