### PR TITLE
Add provider-aware context management APIs

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,7 +12,8 @@ prompt, environment, session identity, MCP transport, callbacks, and hooks canno
 
 This Paseo version accepts these keys:
 
-- **Codex:** `approval_policy`, `sandbox_mode`,
+- **Codex:** `approval_policy`, `model_auto_compact_token_limit`,
+  `model_auto_compact_token_limit_scope` (`total` or `body_after_prefix`), `sandbox_mode`,
   `sandbox_workspace_write.{writable_roots,network_access,exclude_slash_tmp,exclude_tmpdir_env_var}`,
   `web_search`, `features.multi_agent_v2`, and `features.network_proxy`. A network proxy object may
   contain `enabled`, `proxy_url`, `socks_url`, `enable_socks5`, `enable_socks5_udp`,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -24,7 +24,8 @@ This Paseo version accepts these keys:
   The accepted sandbox fields cover enablement, fail-if-unavailable behavior, excluded and
   unsandboxed commands, filesystem read/write rules, network domain/socket/local-binding rules,
   weaker nested sandboxing, ignored violations, and the ripgrep command. `settings` accepts native
-  `permissions.{allow,ask,deny}` and sandbox settings. See the
+  `autoCompactEnabled`, `autoCompactWindow` (100,000–1,000,000),
+  `permissions.{allow,ask,deny}`, and sandbox settings. See the
   [Claude Agent SDK TypeScript reference](https://platform.claude.com/docs/en/agent-sdk/typescript)
   and [Claude settings reference](https://code.claude.com/docs/en/settings).
 - **OpenCode:** `permission`, either one `ask`/`allow`/`deny` action or the native per-tool rule
@@ -85,6 +86,19 @@ OpenCode owns user message IDs. Do not pass Paseo-generated IDs to OpenCode prom
 `AgentManager` owns the one canonical timeline row for a foreground prompt carrying a Paseo `clientMessageId`. It records that row when `startTurn` accepts, with the wire `messageId` set to the same value. Provider adapters still emit their native user-message echo with the same `clientMessageId` when available; the manager records its provider identity on the internal row without changing or redispatching the wire item. If an adapter emits the echo before `startTurn` resolves, the manager records the provider identity with the row at acceptance. Provider adapters continue to own externally initiated user rows that have no Paseo client identity. Do not perform global transcript text dedupe.
 
 Active-turn steering is an optional `AgentSession.steerActiveTurn` operation. The manager owns admission against its exact foreground turn, canonical user-message creation, echo reconciliation, and falls back to the normal interrupt-and-replace path only when the adapter reports `unavailable`. An adapter error leaves the steer's fate ambiguous and must surface without an interrupt or retry. Codex calls `turn/steer` with the native expected turn and Paseo client user-message ID. Claude pushes an admitted steer into the exact active SDK query input; isolated control commands remain unavailable. OpenCode calls `session/prompt_async` with an OpenCode-generated message ID; the server queues the prompt while busy and the next LLM call in the same Paseo turn includes it. A missing session reports `unavailable` and uses the normal interrupt fallback.
+
+Context management is provider-capability driven. Provider snapshots publish `supportsContextWindowPolicy` only when a provider has a per-session native working-window control, and `supportsSameSessionCompaction` only when `AgentSession.compact` can wait for native completion without replacing the session. `agent.compact.request` returns `confirmed` only when the native session id reads back unchanged; unavailable identity, provider failure, or an id change returns `failed`, while an unmapped provider returns `unsupported`.
+
+| Provider                        | Per-session context policy                                                                      | Same-session compact       |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------- |
+| Codex                           | Exact native trigger through `model_auto_compact_token_limit`                                   | `thread/compact/start`     |
+| Claude                          | Effective native window through `settings.autoCompactWindow`; Claude derives an earlier trigger | Not exposed by the SDK     |
+| OpenCode                        | Not supported; model-relative automatic compaction is not an absolute token policy              | Native `session.summarize` |
+| Pi                              | Not supported as an absolute token policy                                                       | Native compact RPC         |
+| OMP                             | Not supported as an absolute token policy                                                       | Native compact RPC         |
+| ACP providers, including Cursor | Not supported                                                                                   | Not supported              |
+
+Do not infer one capability from the other, send slash commands as prompt text, or emulate compaction by creating or reloading a session.
 
 A steering adapter also owes its interrupt: stopping a turn must discard the steers the provider has not read yet, or one of them resumes the turn the user just stopped. Codex clears pending input when it aborts a turn; Claude does not, so its adapter cancels the SDK messages it queued before calling `query.interrupt()`.
 

--- a/packages/client/src/daemon-client.test.ts
+++ b/packages/client/src/daemon-client.test.ts
@@ -4325,6 +4325,46 @@ test("detaches an agent through the namespaced detach RPC", async () => {
   await expect(promise).resolves.toBeUndefined();
 });
 
+test("compacts an agent through the namespaced compact RPC", async () => {
+  const logger = createMockLogger();
+  const mock = createMockTransport();
+  const client = new DaemonClient({
+    url: "ws://test",
+    clientId: "clsk_unit_test",
+    logger,
+    reconnect: { enabled: false },
+    transportFactory: () => mock.transport,
+  });
+  clients.push(client);
+  const connectPromise = client.connect();
+  mock.triggerOpen();
+  await connectPromise;
+
+  const promise = client.compactAgent("agent-1");
+  const request = parseSentFrame(mock.sent[0]);
+  expect(request).toMatchObject({ type: "agent.compact.request", agentId: "agent-1" });
+  mock.triggerMessage(
+    wrapSessionMessage({
+      type: "agent.compact.response",
+      payload: {
+        requestId: request.requestId,
+        agentId: "agent-1",
+        provider: "codex",
+        status: "confirmed",
+        nativeSessionIdBefore: "native-1",
+        nativeSessionIdAfter: "native-1",
+        error: null,
+      },
+    }),
+  );
+
+  await expect(promise).resolves.toMatchObject({
+    status: "confirmed",
+    nativeSessionIdBefore: "native-1",
+    nativeSessionIdAfter: "native-1",
+  });
+});
+
 test("sends active-scoped fetch_agents_request", async () => {
   const logger = createMockLogger();
   const mock = createMockTransport();

--- a/packages/client/src/daemon-client.ts
+++ b/packages/client/src/daemon-client.ts
@@ -87,6 +87,7 @@ import type {
   DaemonGetPairingOfferResponse,
   DaemonConfigReloadResponse,
   DiagnosticsResponse,
+  AgentCompactResponseMessage,
   AgentRewindResponseMessage,
   ListTerminalsResponse,
   CreateTerminalResponse,
@@ -2592,6 +2593,12 @@ export class DaemonClient {
     if (!payload.accepted) {
       throw new Error(payload.error ?? "detachAgent rejected");
     }
+  }
+
+  async compactAgent(agentId: string): Promise<AgentCompactResponseMessage["payload"]> {
+    return await this.sendNamespacedCorrelatedSessionRequest<"agent.compact.response">({
+      message: { type: "agent.compact.request", agentId },
+    });
   }
 
   async updateAgent(

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -737,6 +737,28 @@ test("agent handles delegate create, send, timeline refetch, archive, and local 
   await timelinePromise;
   expect(agent.current()).toEqual(timelineAgent);
 
+  const compactPromise = agent.compact();
+  const compactRequest = parseSentSessionMessage(ws.sent.at(-1));
+  expect(compactRequest).toMatchObject({
+    type: "agent.compact.request",
+    agentId: "agent_sdk",
+  });
+  ws.message(
+    sessionMessage({
+      type: "agent.compact.response",
+      payload: {
+        requestId: compactRequest.requestId,
+        agentId: "agent_sdk",
+        provider: "codex",
+        status: "confirmed",
+        nativeSessionIdBefore: "native-sdk",
+        nativeSessionIdAfter: "native-sdk",
+        error: null,
+      },
+    }),
+  );
+  await expect(compactPromise).resolves.toMatchObject({ status: "confirmed" });
+
   const archivePromise = agent.archive();
   const archiveRequest = parseSentSessionMessage(ws.sent.at(-1));
   expect(archiveRequest).toMatchObject({

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentCompactResponseMessage,
   AgentSnapshotPayload,
   CreateAgentRequestMessage,
   FetchWorkspacesRequestMessage,
@@ -302,6 +303,7 @@ export interface PaseoAgentHandle {
    */
   commands(options?: PaseoAgentCommandsOptions): Promise<PaseoAgentCommandsResult>;
   archive(): Promise<{ archivedAt: string }>;
+  compact(): Promise<AgentCompactResponseMessage["payload"]>;
   detach(): Promise<void>;
   subscribe(handler: (update: PaseoAgentUpdate) => void): () => void;
 }
@@ -695,6 +697,7 @@ function createAgentHandleFactory(daemonClient: DaemonClient): AgentHandleFactor
         }
         return result;
       },
+      compact: () => daemonClient.compactAgent(id),
       detach: async () => {
         await daemonClient.detachAgent(id);
       },

--- a/packages/protocol/src/agent-types.ts
+++ b/packages/protocol/src/agent-types.ts
@@ -114,6 +114,7 @@ export interface ProviderSnapshotEntry {
   label?: string;
   description?: string;
   defaultModeId?: string | null;
+  capabilities?: AgentCapabilityFlags;
 }
 
 export interface AgentFeatureToggle {
@@ -151,6 +152,8 @@ export interface AgentCapabilityFlags {
   supportsRewindConversation?: boolean;
   supportsRewindFiles?: boolean;
   supportsRewindBoth?: boolean;
+  supportsContextWindowPolicy?: boolean;
+  supportsSameSessionCompaction?: boolean;
 }
 
 export interface AgentPersistenceHandle {

--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -330,6 +330,21 @@ describe("agent detach RPC", () => {
     expect(parsed.features?.agentDetach).toBe(true);
   });
 
+  test("parses the Codex auto-compaction server feature gate", () => {
+    const parsed = parseServerInfoStatusPayload({
+      status: "server_info",
+      serverId: "srv-test",
+      features: {
+        codexAutoCompactTokenLimit: true,
+      },
+    });
+
+    if (!parsed) {
+      throw new Error("Expected server info payload to parse");
+    }
+    expect(parsed.features?.codexAutoCompactTokenLimit).toBe(true);
+  });
+
   test("parses the workspace-targeted session import feature gate", () => {
     const parsed = parseServerInfoStatusPayload({
       status: "server_info",

--- a/packages/protocol/src/messages.test.ts
+++ b/packages/protocol/src/messages.test.ts
@@ -330,19 +330,47 @@ describe("agent detach RPC", () => {
     expect(parsed.features?.agentDetach).toBe(true);
   });
 
-  test("parses the Codex auto-compaction server feature gate", () => {
+  test("parses the context-management server feature gate", () => {
     const parsed = parseServerInfoStatusPayload({
       status: "server_info",
       serverId: "srv-test",
       features: {
-        codexAutoCompactTokenLimit: true,
+        contextManagement: true,
       },
     });
 
     if (!parsed) {
       throw new Error("Expected server info payload to parse");
     }
-    expect(parsed.features?.codexAutoCompactTokenLimit).toBe(true);
+    expect(parsed.features?.contextManagement).toBe(true);
+  });
+
+  test("parses a same-session compact request and confirmed response", () => {
+    expect(
+      SessionInboundMessageSchema.parse({
+        type: "agent.compact.request",
+        agentId: "agent-1",
+        requestId: "compact-1",
+      }),
+    ).toEqual({
+      type: "agent.compact.request",
+      agentId: "agent-1",
+      requestId: "compact-1",
+    });
+
+    const response = SessionOutboundMessageSchema.parse({
+      type: "agent.compact.response",
+      payload: {
+        requestId: "compact-1",
+        agentId: "agent-1",
+        provider: "codex",
+        status: "confirmed",
+        nativeSessionIdBefore: "native-1",
+        nativeSessionIdAfter: "native-1",
+        error: null,
+      },
+    });
+    expect(response.type).toBe("agent.compact.response");
   });
 
   test("parses the workspace-targeted session import feature gate", () => {

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -345,6 +345,24 @@ const AgentModelDefinitionSchema = z.object({
   defaultThinkingOptionId: z.string().optional(),
 }) satisfies z.ZodType<AgentModelDefinition>;
 
+const AgentCapabilityFlagsSchema: z.ZodType<AgentCapabilityFlags> = z
+  .object({
+    supportsStreaming: z.boolean(),
+    supportsSessionPersistence: z.boolean(),
+    supportsSessionListing: z.boolean().optional(),
+    supportsDynamicModes: z.boolean(),
+    supportsMcpServers: z.boolean(),
+    supportsReasoningStream: z.boolean(),
+    supportsToolInvocations: z.boolean(),
+    // COMPAT(rewind): added in v0.1.X, drop when floor >= v0.1.X.
+    supportsRewindConversation: z.boolean().optional().default(false),
+    // COMPAT(rewind): added in v0.1.X, drop when floor >= v0.1.X.
+    supportsRewindFiles: z.boolean().optional().default(false),
+    // COMPAT(rewind): added in v0.1.X, drop when floor >= v0.1.X.
+    supportsRewindBoth: z.boolean().optional().default(false),
+  })
+  .catchall(z.boolean());
+
 export const ProviderSnapshotEntrySchema = z.object({
   provider: AgentProviderSchema,
   status: ProviderStatusSchema,
@@ -357,6 +375,7 @@ export const ProviderSnapshotEntrySchema = z.object({
   label: z.string().optional(),
   description: z.string().optional(),
   defaultModeId: z.string().nullable().optional(),
+  capabilities: AgentCapabilityFlagsSchema.optional(),
 });
 
 export const CompactProviderSnapshotModelSchema = AgentModelDefinitionSchema.omit({
@@ -381,24 +400,6 @@ export const CompactProviderSnapshotSchema = z.object({
   entries: z.array(CompactProviderSnapshotEntrySchema),
   thinkingSets: z.array(ProviderSnapshotThinkingSetSchema),
 });
-
-const AgentCapabilityFlagsSchema: z.ZodType<AgentCapabilityFlags> = z
-  .object({
-    supportsStreaming: z.boolean(),
-    supportsSessionPersistence: z.boolean(),
-    supportsSessionListing: z.boolean().optional(),
-    supportsDynamicModes: z.boolean(),
-    supportsMcpServers: z.boolean(),
-    supportsReasoningStream: z.boolean(),
-    supportsToolInvocations: z.boolean(),
-    // COMPAT(rewind): added in v0.1.X, drop when floor >= v0.1.X.
-    supportsRewindConversation: z.boolean().optional().default(false),
-    // COMPAT(rewind): added in v0.1.X, drop when floor >= v0.1.X.
-    supportsRewindFiles: z.boolean().optional().default(false),
-    // COMPAT(rewind): added in v0.1.X, drop when floor >= v0.1.X.
-    supportsRewindBoth: z.boolean().optional().default(false),
-  })
-  .catchall(z.boolean());
 
 const AgentUsageSchema: z.ZodType<AgentUsage> = z.object({
   inputTokens: z.number().optional(),
@@ -1906,6 +1907,25 @@ export const AgentRewindResponseMessageSchema = z.object({
   }),
 });
 
+export const AgentCompactRequestMessageSchema = z.object({
+  type: z.literal("agent.compact.request"),
+  agentId: z.string(),
+  requestId: z.string(),
+});
+
+export const AgentCompactResponseMessageSchema = z.object({
+  type: z.literal("agent.compact.response"),
+  payload: z.object({
+    requestId: z.string(),
+    agentId: z.string(),
+    provider: AgentProviderSchema.nullable(),
+    status: z.enum(["confirmed", "unsupported", "failed"]),
+    nativeSessionIdBefore: z.string().nullable(),
+    nativeSessionIdAfter: z.string().nullable(),
+    error: z.string().nullable(),
+  }),
+});
+
 export const UpdateAgentResponseMessageSchema = z.object({
   type: z.literal("update_agent_response"),
   payload: AgentActionResponsePayloadSchema,
@@ -3067,6 +3087,7 @@ export const SessionInboundMessageSchema = z.discriminatedUnion("type", [
   AgentConfigApplyRequestMessageSchema,
   AgentDetachRequestMessageSchema,
   AgentRewindRequestMessageSchema,
+  AgentCompactRequestMessageSchema,
   AgentPermissionResponseMessageSchema,
   CheckoutStatusRequestSchema,
   SubscribeCheckoutDiffRequestSchema,
@@ -3334,8 +3355,8 @@ export const ServerInfoStatusPayloadSchema = z
         providersSnapshot: z.boolean().optional(),
         // COMPAT(providersSnapshotCwd): added in v0.3.2, remove gate after 2027-02-10.
         providersSnapshotCwd: z.boolean().optional(),
-        // COMPAT(codexAutoCompactTokenLimit): added in v0.5.x, remove gate after 2027-08-23.
-        codexAutoCompactTokenLimit: z.boolean().optional(),
+        // COMPAT(contextManagement): added in v0.5.x, remove gate after 2027-08-23.
+        contextManagement: z.boolean().optional(),
         // COMPAT(directorySync): added in v0.3.x, remove gate after 2027-02-12.
         directorySync: z.boolean().optional(),
         // COMPAT(workspaceLabels): added in v0.5.0, remove after 2027-08-14.
@@ -6376,6 +6397,7 @@ export const SessionOutboundMessageSchema = z.discriminatedUnion("type", [
   AgentConfigApplyResponseMessageSchema,
   AgentDetachResponseMessageSchema,
   AgentRewindResponseMessageSchema,
+  AgentCompactResponseMessageSchema,
   UpdateAgentResponseMessageSchema,
   ProjectRenameResponseSchema,
   ProjectIconSetResponseSchema,
@@ -6571,6 +6593,8 @@ export type SetAgentFeatureResponseMessage = z.infer<typeof SetAgentFeatureRespo
 export type AgentConfigApplyResponseMessage = z.infer<typeof AgentConfigApplyResponseMessageSchema>;
 export type AgentDetachResponseMessage = z.infer<typeof AgentDetachResponseMessageSchema>;
 export type AgentRewindResponseMessage = z.infer<typeof AgentRewindResponseMessageSchema>;
+export type AgentCompactRequestMessage = z.infer<typeof AgentCompactRequestMessageSchema>;
+export type AgentCompactResponseMessage = z.infer<typeof AgentCompactResponseMessageSchema>;
 export type UpdateAgentResponseMessage = z.infer<typeof UpdateAgentResponseMessageSchema>;
 export type ProjectRenameResponse = z.infer<typeof ProjectRenameResponseSchema>;
 export type ProjectIconSetResponse = z.infer<typeof ProjectIconSetResponseSchema>;

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3334,6 +3334,8 @@ export const ServerInfoStatusPayloadSchema = z
         providersSnapshot: z.boolean().optional(),
         // COMPAT(providersSnapshotCwd): added in v0.3.2, remove gate after 2027-02-10.
         providersSnapshotCwd: z.boolean().optional(),
+        // COMPAT(codexAutoCompactTokenLimit): added in v0.5.x, remove gate after 2027-08-23.
+        codexAutoCompactTokenLimit: z.boolean().optional(),
         // COMPAT(directorySync): added in v0.3.x, remove gate after 2027-02-12.
         directorySync: z.boolean().optional(),
         // COMPAT(workspaceLabels): added in v0.5.0, remove after 2027-08-14.

--- a/packages/server/src/server/agent/agent-manager.test.ts
+++ b/packages/server/src/server/agent/agent-manager.test.ts
@@ -658,6 +658,61 @@ test("uses an injected timeline store without making it a production requirement
   }
 });
 
+test("only confirms compaction when the native session identity is unchanged", async () => {
+  async function run(changesIdentity: boolean) {
+    const workdir = mkdtempSync(join(tmpdir(), "agent-manager-compact-"));
+    class CompactSession extends TestAgentSession {
+      override readonly capabilities = {
+        ...TEST_CAPABILITIES,
+        supportsSameSessionCompaction: true,
+      };
+      private nativeSessionId = "native-session-1";
+
+      override async compact(): Promise<void> {
+        if (changesIdentity) this.nativeSessionId = "native-session-2";
+      }
+
+      override describePersistence() {
+        return { provider: this.provider, sessionId: this.nativeSessionId };
+      }
+    }
+    const manager = new AgentManager({
+      clients: {
+        codex: new (class extends TestAgentClient {
+          override async createSession(config: AgentSessionConfig): Promise<AgentSession> {
+            return new CompactSession(config);
+          }
+        })(),
+      },
+      logger,
+    });
+    const agent = await manager.createAgent({ provider: "codex", cwd: workdir }, undefined, {
+      workspaceId: undefined,
+    });
+    try {
+      return await manager.compactAgent(agent.id);
+    } finally {
+      await manager.closeAgent(agent.id);
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  }
+
+  await expect(run(false)).resolves.toEqual({
+    status: "confirmed",
+    provider: "codex",
+    nativeSessionIdBefore: "native-session-1",
+    nativeSessionIdAfter: "native-session-1",
+    error: null,
+  });
+  await expect(run(true)).resolves.toEqual({
+    status: "failed",
+    provider: "codex",
+    nativeSessionIdBefore: "native-session-1",
+    nativeSessionIdAfter: "native-session-2",
+    error: "Native session identity changed during compaction",
+  });
+});
+
 test("retries provider history hydration after a stream failure", async () => {
   const workdir = mkdtempSync(join(tmpdir(), "agent-manager-history-retry-"));
   let attempts = 0;

--- a/packages/server/src/server/agent/agent-manager.ts
+++ b/packages/server/src/server/agent/agent-manager.ts
@@ -129,6 +129,14 @@ export type AgentRunCancellationResult =
   | { status: "settled" }
   | { status: "refused" };
 
+export interface AgentCompactionResult {
+  status: "confirmed" | "unsupported" | "failed";
+  provider: AgentProvider;
+  nativeSessionIdBefore: string | null;
+  nativeSessionIdAfter: string | null;
+  error: string | null;
+}
+
 interface PreparedSessionConfig {
   storedConfig: AgentSessionConfig;
   launchConfig: AgentSessionConfig;
@@ -2112,6 +2120,62 @@ export class AgentManager {
       }
     })();
     return true;
+  }
+
+  async compactAgent(agentId: string): Promise<AgentCompactionResult> {
+    return await this.runLifecycleMutation(agentId, () => this.compactAgentUnlocked(agentId));
+  }
+
+  private async compactAgentUnlocked(agentId: string): Promise<AgentCompactionResult> {
+    const agent = this.requireSessionAgent(agentId);
+    const before = agent.session.describePersistence()?.sessionId ?? null;
+    if (!agent.session.capabilities.supportsSameSessionCompaction || !agent.session.compact) {
+      return {
+        status: "unsupported",
+        provider: agent.provider,
+        nativeSessionIdBefore: before,
+        nativeSessionIdAfter: before,
+        error: `${agent.provider} does not support same-session compaction`,
+      };
+    }
+    if (!before) {
+      return {
+        status: "failed",
+        provider: agent.provider,
+        nativeSessionIdBefore: null,
+        nativeSessionIdAfter: null,
+        error: "Native session identity is unavailable before compaction",
+      };
+    }
+    try {
+      await agent.session.compact();
+      await this.drainSessionEvents(agent.id);
+    } catch (error) {
+      return {
+        status: "failed",
+        provider: agent.provider,
+        nativeSessionIdBefore: before,
+        nativeSessionIdAfter: agent.session.describePersistence()?.sessionId ?? null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    const after = agent.session.describePersistence()?.sessionId ?? null;
+    if (after !== before) {
+      return {
+        status: "failed",
+        provider: agent.provider,
+        nativeSessionIdBefore: before,
+        nativeSessionIdAfter: after,
+        error: "Native session identity changed during compaction",
+      };
+    }
+    return {
+      status: "confirmed",
+      provider: agent.provider,
+      nativeSessionIdBefore: before,
+      nativeSessionIdAfter: after,
+      error: null,
+    };
   }
 
   async appendTimelineItem(agentId: string, item: AgentTimelineItem): Promise<void> {

--- a/packages/server/src/server/agent/agent-sdk-types.ts
+++ b/packages/server/src/server/agent/agent-sdk-types.ts
@@ -125,6 +125,7 @@ export interface ProviderSnapshotEntry {
   label?: string;
   description?: string;
   defaultModeId?: string | null;
+  capabilities?: AgentCapabilityFlags;
 }
 
 export interface AgentCreateConfigParent {
@@ -190,6 +191,8 @@ export interface AgentCapabilityFlags {
   supportsRewindConversation?: boolean;
   supportsRewindFiles?: boolean;
   supportsRewindBoth?: boolean;
+  supportsContextWindowPolicy?: boolean;
+  supportsSameSessionCompaction?: boolean;
 }
 
 export interface AgentPersistenceHandle {
@@ -668,6 +671,7 @@ export interface AgentSession {
   revertConversation?(input: { messageId: string }): Promise<void>;
   revertFiles?(input: { messageId: string }): Promise<void>;
   revertBoth?(input: { messageId: string }): Promise<void>;
+  compact?(): Promise<void>;
   /**
    * Out-of-band prompt handler. When non-null, the manager runs the returned
    * handler instead of allocating a turn. The handler emits stream events

--- a/packages/server/src/server/agent/mcp-server.test.ts
+++ b/packages/server/src/server/agent/mcp-server.test.ts
@@ -1228,13 +1228,17 @@ describe("create_agent MCP tool", () => {
     await registeredTool(server, "create_agent").handler({
       title: "Top-level agent",
       provider: "codex/gpt-5.4",
+      providerOptions: { model_auto_compact_token_limit: 256_000 },
       initialPrompt: "Do work",
       background: true,
     });
 
     expect(ensureWorkspace).toHaveBeenCalledWith(existingCwd, { prompt: "Do work" });
     expect(spies.agentManager.createAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ cwd: existingCwd }),
+      expect.objectContaining({
+        cwd: existingCwd,
+        providerOptions: { model_auto_compact_token_limit: 256_000 },
+      }),
       undefined,
       { workspaceId: "workspace-created" },
     );

--- a/packages/server/src/server/agent/provider-options.test.ts
+++ b/packages/server/src/server/agent/provider-options.test.ts
@@ -73,10 +73,28 @@ describe("provider-owned option schemas", () => {
             allowUnixSockets: ["/var/run/docker.sock"],
           },
         },
-        settings: { permissions: { ask: ["Bash(*)"], deny: ["Edit(.env)"] } },
+        settings: {
+          autoCompactEnabled: true,
+          autoCompactWindow: 256_000,
+          permissions: { ask: ["Bash(*)"], deny: ["Edit(.env)"] },
+        },
       }),
-    ).toMatchObject({ sandbox: { enabled: true, failIfUnavailable: true } });
+    ).toMatchObject({
+      sandbox: { enabled: true, failIfUnavailable: true },
+      settings: { autoCompactEnabled: true, autoCompactWindow: 256_000 },
+    });
   });
+
+  test.each([99_999, 1_000_001, 128_000.5])(
+    "rejects invalid Claude auto-compaction window %s",
+    (window) => {
+      expect(() =>
+        validateProviderOptions("claude", ClaudeProviderOptionsSchema, {
+          settings: { autoCompactWindow: window },
+        }),
+      ).toThrow("providerOptions.settings.autoCompactWindow");
+    },
+  );
 
   test("reports the exact invalid Claude option path", () => {
     expect(() =>

--- a/packages/server/src/server/agent/provider-options.test.ts
+++ b/packages/server/src/server/agent/provider-options.test.ts
@@ -20,6 +20,8 @@ describe("provider-owned option schemas", () => {
     expect(
       CodexProviderOptionsSchema.parse({
         approval_policy: "never",
+        model_auto_compact_token_limit: 256_000,
+        model_auto_compact_token_limit_scope: "body_after_prefix",
         sandbox_mode: "workspace-write",
         sandbox_workspace_write: {
           writable_roots: ["/var/cache/npm"],
@@ -34,8 +36,18 @@ describe("provider-owned option schemas", () => {
         },
       }),
     ).toMatchObject({
+      model_auto_compact_token_limit: 256_000,
+      model_auto_compact_token_limit_scope: "body_after_prefix",
       sandbox_workspace_write: { writable_roots: ["/var/cache/npm"] },
     });
+  });
+
+  test.each([0, -1, 1.5])("rejects invalid Codex auto-compaction limit %s", (limit) => {
+    expect(() =>
+      validateProviderOptions("codex", CodexProviderOptionsSchema, {
+        model_auto_compact_token_limit: limit,
+      }),
+    ).toThrow("providerOptions.model_auto_compact_token_limit");
   });
 
   test("reports the exact invalid Codex option path", () => {

--- a/packages/server/src/server/agent/provider-snapshot-manager.test.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.test.ts
@@ -320,7 +320,11 @@ describe("ProviderSnapshotManager public surface", () => {
     manager.on("change", listener);
     try {
       const [first] = await manager.listProviders({ cwd, providers: ["codex"], wait: true });
-      expect(first).toMatchObject({ provider: "codex", status: "ready" });
+      expect(first).toMatchObject({
+        provider: "codex",
+        status: "ready",
+        capabilities: TEST_CAPABILITIES,
+      });
       expect(isAvailable).toHaveBeenCalledTimes(1);
       expect(fetchCatalog).toHaveBeenCalledTimes(1);
 

--- a/packages/server/src/server/agent/provider-snapshot-manager.ts
+++ b/packages/server/src/server/agent/provider-snapshot-manager.ts
@@ -955,6 +955,7 @@ export class ProviderSnapshotManager {
         enabled: true,
         models: catalog.models,
         modes: catalog.modes,
+        capabilities: client.capabilities,
         fetchedAt: new Date().toISOString(),
       });
     } catch (error) {
@@ -1127,6 +1128,7 @@ function entriesToArray(
 function cloneEntry(entry: ProviderSnapshotEntry): ProviderSnapshotEntry {
   return {
     ...entry,
+    capabilities: entry.capabilities ? { ...entry.capabilities } : undefined,
     models: entry.models?.map((model) => ({ ...model })),
     modes: entry.modes?.map((mode) => ({ ...mode })),
   };

--- a/packages/server/src/server/agent/providers/claude/agent.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.real.e2e.test.ts
@@ -3,7 +3,11 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pino from "pino";
-import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  Query,
+  SDKControlGetContextUsageResponse,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
 
 import type {
   AgentSession,
@@ -143,8 +147,8 @@ function getLatestCompletedBashCall(events: AgentStreamEvent[]): ToolCallTimelin
     .find((item) => item.status === "completed" && item.name.toLowerCase() === "bash");
 }
 
-function getInternalQuery(session: AgentSession): unknown {
-  return (session as AgentSession & { query?: unknown }).query ?? null;
+function getInternalQuery(session: AgentSession): Query | null {
+  return (session as AgentSession & { query?: Query }).query ?? null;
 }
 
 async function createSession(params?: {
@@ -217,6 +221,50 @@ describe("ClaudeAgentSession integration", () => {
       await cleanupSession(handle);
     }
   }, 60_000);
+
+  test("auto-compacts inside the configured window without replacing the native session", async () => {
+    const cwd = tmpCwd("claude-auto-compact-");
+    const session = await client.createSession({
+      ...getRealProviderConfig("claude"),
+      cwd,
+      providerOptions: {
+        settings: { autoCompactEnabled: true, autoCompactWindow: 100_000 },
+      },
+    });
+
+    try {
+      const first = await session.run("Reply exactly: AUTO_COMPACT_READY");
+      const nativeSessionId = first.sessionId;
+      const query = getInternalQuery(session);
+      if (!query) throw new Error("Claude query was not initialized");
+
+      const configured = await query.getContextUsage();
+      expect(configured.isAutoCompactEnabled).toBe(true);
+      expect(configured.autoCompactThreshold).toBeGreaterThan(0);
+      expect(configured.autoCompactThreshold).toBeLessThanOrEqual(100_000);
+
+      const chunk = Array.from({ length: 18_000 }, (_, index) => `f${index % 997}`).join(" ");
+      let compacted = false;
+      let beforeCompaction: SDKControlGetContextUsageResponse = configured;
+      for (let turn = 0; turn < 8 && !compacted; turn += 1) {
+        beforeCompaction = await query.getContextUsage();
+        const result = await session.run(
+          `Keep this synthetic context for this test, then reply exactly ACK_${turn}: ${chunk}`,
+        );
+        expect(result.sessionId).toBe(nativeSessionId);
+        compacted = result.timeline.some(
+          (item) => item.type === "compaction" && item.status === "completed",
+        );
+      }
+
+      expect(compacted).toBe(true);
+      expect(session.describePersistence()?.sessionId).toBe(nativeSessionId);
+      const afterCompaction = await query.getContextUsage();
+      expect(afterCompaction.totalTokens).toBeLessThan(beforeCompaction.totalTokens);
+    } finally {
+      await cleanupSession({ cwd, session });
+    }
+  }, 360_000);
 
   test("keeps bypassPermissions available after a thinking-option restart", async () => {
     const handle = await createSession({

--- a/packages/server/src/server/agent/providers/claude/agent.spawn.test.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.spawn.test.ts
@@ -102,4 +102,49 @@ describe("Claude spawn override", () => {
     const spawnOptions = claudeSpawnCall?.[2];
     expect(spawnOptions?.shell).toBe(false);
   });
+
+  test("forwards the native auto-compaction window to Claude settings", async () => {
+    let capturedOptions: Options | undefined;
+    const queryFactory = vi.fn(({ options }: ClaudeQueryInput) => {
+      capturedOptions = options;
+      return createQueryMock([
+        {
+          type: "system",
+          subtype: "init",
+          session_id: "claude-auto-compact-session",
+          permissionMode: "default",
+          model: "opus",
+        },
+        {
+          type: "result",
+          subtype: "success",
+          usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+          total_cost_usd: 0,
+        },
+      ]);
+    });
+    const client = new ClaudeAgentClient({
+      logger: createTestLogger(),
+      queryFactory,
+      resolveBinary: async () => "/test/claude/bin",
+    });
+    const session = await client.createSession({
+      provider: "claude",
+      cwd: process.cwd(),
+      providerOptions: {
+        settings: { autoCompactEnabled: true, autoCompactWindow: 256_000 },
+      },
+    });
+
+    try {
+      await session.run("auto compact settings");
+    } finally {
+      await session.close();
+    }
+
+    expect(capturedOptions?.settings).toMatchObject({
+      autoCompactEnabled: true,
+      autoCompactWindow: 256_000,
+    });
+  });
 });

--- a/packages/server/src/server/agent/providers/claude/agent.ts
+++ b/packages/server/src/server/agent/providers/claude/agent.ts
@@ -312,6 +312,7 @@ const CLAUDE_CAPABILITIES: AgentCapabilityFlags = {
   supportsRewindConversation: true,
   supportsRewindFiles: true,
   supportsRewindBoth: true,
+  supportsContextWindowPolicy: true,
 };
 
 const DEFAULT_MODES: AgentMode[] = [

--- a/packages/server/src/server/agent/providers/claude/options.ts
+++ b/packages/server/src/server/agent/providers/claude/options.ts
@@ -68,6 +68,8 @@ export const ClaudeProviderOptionsSchema = z
       .optional(),
     settings: z
       .object({
+        autoCompactEnabled: z.boolean().optional(),
+        autoCompactWindow: z.number().int().min(100_000).max(1_000_000).optional(),
         permissions: PermissionRulesSchema.optional(),
         sandbox: z
           .object({

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.real.e2e.test.ts
@@ -46,6 +46,55 @@ describe("Codex app-server provider (real)", () => {
     }
   }, 30_000);
 
+  test("auto-compacts at the configured threshold without replacing the native thread", async () => {
+    const client = new CodexAppServerAgentClient(createTestLogger());
+    const cwd = mkdtempSync(path.join(os.tmpdir(), "codex-auto-compact-e2e-"));
+    try {
+      const { models } = await client.fetchCatalog({ scope: "workspace", cwd, force: false });
+      const model = models.find((candidate) => candidate.isDefault) ?? models[0];
+      if (!model) {
+        throw new Error("Native Codex app-server returned no models");
+      }
+      const session = await client.createSession({
+        provider: "codex",
+        model: model.id,
+        cwd,
+        modeId: "auto",
+        providerOptions: {
+          model_auto_compact_token_limit: 30_000,
+          model_auto_compact_token_limit_scope: "total",
+        },
+      });
+
+      try {
+        await session.run(`${"context ".repeat(8_000)}\nReply with exactly OK.`);
+        const before = await session.run("Reply with exactly OK again.");
+        const nativeThreadId = before.sessionId;
+        expect(nativeThreadId).toBeTruthy();
+        const events: AgentStreamEvent[] = [];
+        const unsubscribe = session.subscribe((event) => events.push(event));
+        const after = await session.run("Reply with exactly OK once more.");
+        unsubscribe();
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            type: "timeline",
+            item: expect.objectContaining({ type: "compaction", status: "completed" }),
+          }),
+        );
+        expect(before.usage?.contextWindowUsedTokens).toBeGreaterThan(30_000);
+        expect(after.usage?.contextWindowUsedTokens).toBeLessThan(
+          before.usage?.contextWindowUsedTokens ?? 0,
+        );
+        expect(after.sessionId).toBe(nativeThreadId);
+        expect(session.id).toBe(nativeThreadId);
+      } finally {
+        await session.close();
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   test("keeps a real MultiAgentV2 child inside its parent turn", async () => {
     const client = new CodexAppServerAgentClient(createTestLogger());
     const cwd = mkdtempSync(path.join(os.tmpdir(), "codex-multi-agent-v2-e2e-"));

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -4719,6 +4719,31 @@ describe("Codex app-server provider", () => {
     ]);
   });
 
+  test("compact waits for native completion", async () => {
+    const session = createSession();
+    session.activeForegroundTurnId = null;
+    session.client = {
+      request: vi.fn(async () => ({})),
+    };
+
+    const compact = session.compact?.();
+    await vi.waitFor(() => {
+      expect(session.client?.request).toHaveBeenCalledWith("thread/compact/start", {
+        threadId: "test-thread",
+      });
+    });
+    asInternals(session).handleNotification("item/started", {
+      threadId: "test-thread",
+      item: { type: "contextCompaction", id: "rpc-compact" },
+    });
+    asInternals(session).handleNotification("item/completed", {
+      threadId: "test-thread",
+      item: { type: "contextCompaction", id: "rpc-compact" },
+    });
+
+    await expect(compact).resolves.toBeUndefined();
+  });
+
   test("maps question responses from headers back to question ids and completes the tool call", async () => {
     const session = createSession();
     const events: AgentStreamEvent[] = [];

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.test.ts
@@ -872,6 +872,40 @@ describe("Codex app-server provider", () => {
     });
   });
 
+  test("forwards the native auto-compaction threshold to thread and turn start", async () => {
+    const session = createSession({
+      modeId: undefined,
+      providerOptions: {
+        model_auto_compact_token_limit: 256_000,
+        model_auto_compact_token_limit_scope: "body_after_prefix",
+      },
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "model/list") {
+        return { data: [{ id: "gpt-5.4", isDefault: true, defaultReasoningEffort: "medium" }] };
+      }
+      if (method === "thread/start") return { thread: { id: "compact-thread" } };
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    session.currentThreadId = null;
+    session.activeForegroundTurnId = null;
+    session.client = createStub<CodexClientLike>({ request });
+
+    await session.startTurn("use the configured threshold");
+
+    const expectedConfig = {
+      model_auto_compact_token_limit: 256_000,
+      model_auto_compact_token_limit_scope: "body_after_prefix",
+    };
+    expect(request.mock.calls.find(([method]) => method === "thread/start")?.[1]).toMatchObject({
+      config: expectedConfig,
+    });
+    expect(request.mock.calls.find(([method]) => method === "turn/start")?.[1]).toMatchObject({
+      config: expectedConfig,
+    });
+  });
+
   test("preserves cwd-resolved Codex writable roots under an explicit workflow mode", async () => {
     const appServer = createFakeCodexAppServer({
       "config/read": () => ({

--- a/packages/server/src/server/agent/providers/codex-app-server-agent.ts
+++ b/packages/server/src/server/agent/providers/codex-app-server-agent.ts
@@ -71,6 +71,7 @@ import {
 } from "../../../executable-resolution/executable-resolution.js";
 import { createPathEquivalenceMatcher } from "../../../utils/path.js";
 import { spawnProcess } from "../../../utils/spawn.js";
+import { withTimeout } from "../../../utils/promise-timeout.js";
 import { extractCodexTerminalSessionId, nonEmptyString } from "./tool-call-mapper-utils.js";
 import { buildCodexFeatures, codexModelSupportsFastMode } from "./codex-feature-definitions.js";
 import {
@@ -220,6 +221,8 @@ const CODEX_APP_SERVER_CAPABILITIES: AgentCapabilityFlags = {
   supportsRewindConversation: true,
   supportsRewindFiles: false,
   supportsRewindBoth: false,
+  supportsContextWindowPolicy: true,
+  supportsSameSessionCompaction: true,
 };
 
 const CODEX_MODES: AgentMode[] = [
@@ -4830,6 +4833,34 @@ export class CodexAppServerAgentSession implements AgentSession {
         });
       },
     };
+  }
+
+  async compact(): Promise<void> {
+    if (this.activeForegroundTurnId) {
+      throw new Error("Cannot compact Codex context while a foreground turn is active");
+    }
+    let unsubscribe: () => void = () => undefined;
+    const completed = new Promise<void>((resolve) => {
+      unsubscribe = this.subscribe((event) => {
+        if (
+          event.type === "timeline" &&
+          event.item.type === "compaction" &&
+          event.item.status === "completed" &&
+          event.item.trigger === "manual"
+        ) {
+          resolve();
+        }
+      });
+    });
+    try {
+      const error = await this.executeCompactCommand();
+      if (error) {
+        throw new Error(error);
+      }
+      await withTimeout(completed, 300_000, "Timed out waiting for Codex context compaction");
+    } finally {
+      unsubscribe();
+    }
   }
 
   private async executeCompactCommand(): Promise<string | null> {

--- a/packages/server/src/server/agent/providers/codex/options.ts
+++ b/packages/server/src/server/agent/providers/codex/options.ts
@@ -38,6 +38,8 @@ const NetworkPolicySchema = z
 export const CodexProviderOptionsSchema = z
   .object({
     approval_policy: ApprovalPolicySchema.optional(),
+    model_auto_compact_token_limit: z.number().int().positive().optional(),
+    model_auto_compact_token_limit_scope: z.enum(["total", "body_after_prefix"]).optional(),
     sandbox_mode: z.enum(["read-only", "workspace-write", "danger-full-access"]).optional(),
     sandbox_workspace_write: z
       .object({

--- a/packages/server/src/server/agent/providers/omp/agent.test.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.test.ts
@@ -131,7 +131,18 @@ describe("OMP agent client and session", () => {
     expect(omp.capabilities()).toMatchObject({
       supportsMcpServers: false,
       supportsNativePaseoTools: true,
+      supportsSameSessionCompaction: true,
     });
+  });
+
+  test("compacts through the native RPC without prompt text", async () => {
+    const omp = new OmpHarness();
+    await omp.start();
+
+    await expect(omp.compact()).resolves.toBeUndefined();
+
+    expect(omp.runtime().compactRequests).toEqual([{}]);
+    expect(omp.runtime().prompts).toEqual([]);
   });
 
   test("preserves max as the selected thinking option", async () => {

--- a/packages/server/src/server/agent/providers/omp/agent.ts
+++ b/packages/server/src/server/agent/providers/omp/agent.ts
@@ -126,6 +126,7 @@ const OMP_CORE_CAPABILITIES: AgentCapabilityFlags = {
   supportsRewindConversation: true,
   supportsRewindFiles: false,
   supportsRewindBoth: false,
+  supportsSameSessionCompaction: true,
 };
 
 export interface OmpAgentClientOptions {
@@ -1166,6 +1167,17 @@ export class OmpAgentSession implements AgentSession {
     } finally {
       this.clearOmpSessionState();
     }
+  }
+
+  async compact(): Promise<void> {
+    if (this.closed) {
+      throw new Error("OMP session is closed");
+    }
+    if (this.activeTurnId) {
+      throw new Error("Cannot compact OMP context while a turn is active");
+    }
+    await this.runtimeSession.compact();
+    await this.refreshState();
   }
 
   private clearOmpSessionState(): void {

--- a/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
+++ b/packages/server/src/server/agent/providers/omp/test-utils/omp-harness.ts
@@ -451,6 +451,10 @@ export class OmpHarness {
     await this.requireSession().revertConversation({ messageId });
   }
 
+  async compact(): Promise<void> {
+    await this.requireSession().compact();
+  }
+
   branchRequests(): string[] {
     return this.omp.latestSession().branchRequests;
   }

--- a/packages/server/src/server/agent/providers/opencode-agent.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.test.ts
@@ -612,6 +612,37 @@ describe("OpenCodeAgentClient adapter smoke tests", () => {
     rmSync(cwd, { recursive: true, force: true });
   }, 120_000);
 
+  test("compact uses native summarize and waits for same-session completion", async () => {
+    const cwd = tmpCwd();
+    const runtime = new TestOpenCodeHarness();
+    const openCodeClient = new TestOpenCodeClient();
+    openCodeClient.sessionSummarizeEvents = manualCompactEvents();
+    runtime.enqueueClient(openCodeClient);
+    const client = new OpenCodeAgentClient(logger, undefined, {
+      serverManager: runtime,
+      createClient: runtime.createClient,
+    });
+    const session = await client.createSession({
+      provider: "opencode",
+      cwd,
+      model: "test-provider/gpt-5.5",
+    });
+
+    await expect(session.compact?.()).resolves.toBeUndefined();
+    expect(openCodeClient.calls.sessionSummarize).toEqual([
+      expect.objectContaining({
+        sessionID: "session-1",
+        directory: cwd,
+        providerID: "test-provider",
+        modelID: "gpt-5.5",
+      }),
+    ]);
+    expect(session.describePersistence?.()?.sessionId).toBe("session-1");
+
+    await session.close();
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
   test("fetchCatalog returns models with required fields", async () => {
     const runtime = new TestOpenCodeHarness();
     const openCodeClient = new TestOpenCodeClient();

--- a/packages/server/src/server/agent/providers/opencode-agent.ts
+++ b/packages/server/src/server/agent/providers/opencode-agent.ts
@@ -136,6 +136,7 @@ const OPENCODE_CAPABILITIES: AgentCapabilityFlags = {
   supportsRewindConversation: false,
   supportsRewindFiles: false,
   supportsRewindBoth: true,
+  supportsSameSessionCompaction: true,
 };
 
 const OPENCODE_BUILD_MODE_ID = "build";
@@ -3379,6 +3380,50 @@ class OpenCodeAgentSession implements AgentSession {
     };
   }
 
+  async compact(): Promise<void> {
+    if (this.closed) {
+      throw new Error("OpenCode session is closed");
+    }
+    if (this.turnState.status !== "idle") {
+      throw new Error("Cannot compact OpenCode context while a turn is active");
+    }
+    await withTimeout(
+      this.events.ready(),
+      OPENCODE_SERVER_STARTUP_TIMEOUT_MS,
+      "OpenCode event stream first record",
+    );
+    const completed = createDeferred<void>();
+    const unsubscribe = this.subscribe((event) => {
+      if (
+        event.type === "timeline" &&
+        event.item.type === "compaction" &&
+        event.item.status === "completed"
+      ) {
+        completed.resolve();
+      }
+    });
+    try {
+      const model = this.parseModel(this.config.model);
+      const response = await this.client.session.summarize({
+        sessionID: this.sessionId,
+        directory: this.config.cwd,
+        ...(model ? { providerID: model.providerID, modelID: model.modelID } : {}),
+      });
+      if (response.error) {
+        throw new Error(
+          `OpenCode session.summarize failed: ${toDiagnosticErrorMessage(response.error)}`,
+        );
+      }
+      await withTimeout(
+        completed.promise,
+        300_000,
+        "Timed out waiting for OpenCode context compaction",
+      );
+    } finally {
+      unsubscribe();
+    }
+  }
+
   async setModel(modelId: string | null): Promise<void> {
     const normalizedModelId =
       typeof modelId === "string" && modelId.trim().length > 0 ? modelId : null;
@@ -4399,7 +4444,7 @@ class OpenCodeAgentSession implements AgentSession {
       turnId = this.startAutonomousTurn();
     }
     if (!turnId) {
-      this.emitBackgroundPermissionRequests(foregroundEvents);
+      this.emitBackgroundEvents(foregroundEvents);
       this.traceOpenCode("provider.opencode.event.skip", {
         n: eventCount,
         reason: "no_active_turn",
@@ -4457,9 +4502,12 @@ class OpenCodeAgentSession implements AgentSession {
     return true;
   }
 
-  private emitBackgroundPermissionRequests(events: readonly AgentStreamEvent[]): void {
+  private emitBackgroundEvents(events: readonly AgentStreamEvent[]): void {
     for (const event of events) {
-      if (event.type === "permission_requested") {
+      if (
+        event.type === "permission_requested" ||
+        (event.type === "timeline" && event.item.type === "compaction")
+      ) {
         this.notifySubscribers(event, null);
       }
     }

--- a/packages/server/src/server/agent/providers/opencode-compact-event-dump.real.e2e.test.ts
+++ b/packages/server/src/server/agent/providers/opencode-compact-event-dump.real.e2e.test.ts
@@ -19,34 +19,6 @@ function tmpCwd(): string {
   return mkdtempSync(path.join(tmpdir(), "opencode-compact-dump-"));
 }
 
-function waitForTurnToFinish(session: {
-  subscribe: (callback: (event: AgentStreamEvent) => void) => () => void;
-}): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let unsubscribe: () => void = () => undefined;
-    const timeout = setTimeout(() => {
-      unsubscribe();
-      reject(new Error("Timed out waiting for OpenCode compact turn to finish"));
-    }, 60_000);
-    unsubscribe = session.subscribe((event) => {
-      if (
-        event.type !== "turn_completed" &&
-        event.type !== "turn_failed" &&
-        event.type !== "turn_canceled"
-      ) {
-        return;
-      }
-      clearTimeout(timeout);
-      unsubscribe();
-      if (event.type === "turn_failed") {
-        reject(new Error(event.error));
-        return;
-      }
-      resolve();
-    });
-  });
-}
-
 function dumpCompactEvents(events: AgentStreamEvent[]): void {
   console.info(
     "OPENCODE_COMPACT_EVENT_DUMP",
@@ -80,7 +52,7 @@ describe("OpenCode compact event dump (real)", () => {
     await OpenCodeServerManager.getInstance(logger).shutdown();
   });
 
-  test("dumps live events emitted by a real /compact turn", async () => {
+  test("compacts the existing native session through the provider API", async () => {
     const cwd = tmpCwd();
     const client = createRealProviderClient("opencode", logger);
 
@@ -92,29 +64,34 @@ describe("OpenCode compact event dump (real)", () => {
         modeId: "build",
       });
 
-      await session.run("Reply with exactly: COMPACT_SEED_OK");
-
-      const compactEvents: AgentStreamEvent[] = [];
-      const unsubscribe = session.subscribe((event) => {
-        compactEvents.push(event);
-      });
-      const compactFinished = waitForTurnToFinish(session);
-
       try {
-        await session.startTurn("/compact");
-        await compactFinished;
+        const seed = await session.run("Reply with exactly: COMPACT_SEED_OK");
+        const nativeSessionId = seed.sessionId;
+
+        const compactEvents: AgentStreamEvent[] = [];
+        const unsubscribe = session.subscribe((event) => {
+          compactEvents.push(event);
+        });
+        try {
+          await session.compact?.();
+        } finally {
+          unsubscribe();
+        }
+
+        dumpCompactEvents(compactEvents);
+
+        expect(session.describePersistence?.()?.sessionId).toBe(nativeSessionId);
+        expect(
+          compactEvents.some(
+            (event) =>
+              event.type === "timeline" &&
+              event.item.type === "compaction" &&
+              event.item.status === "completed",
+          ),
+        ).toBe(true);
       } finally {
-        unsubscribe();
+        await session.close();
       }
-
-      dumpCompactEvents(compactEvents);
-
-      expect(compactEvents.some((event) => event.type === "turn_completed")).toBe(true);
-      expect(
-        compactEvents.filter(
-          (event) => event.type === "timeline" && event.item.type === "assistant_message",
-        ),
-      ).toEqual([]);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/packages/server/src/server/agent/providers/pi/agent.test.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.test.ts
@@ -1966,6 +1966,16 @@ describe("PiRpcAgentClient", () => {
     ]);
   });
 
+  test("compact uses the native RPC without prompt text", async () => {
+    const { pi, session } = await createSession();
+    const fakeSession = pi.latestSession();
+
+    await expect((session as AgentSession).compact?.()).resolves.toBeUndefined();
+
+    expect(fakeSession.compactRequests).toEqual([{ customInstructions: undefined }]);
+    expect(fakeSession.prompts).toEqual([]);
+  });
+
   test("closes Pi compact loading marker when RPC rejects after compaction starts", async () => {
     const { pi, session } = await createSession();
     const fakeSession = pi.latestSession();

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -163,6 +163,7 @@ const PI_CAPABILITIES: AgentCapabilityFlags = {
   supportsRewindConversation: true,
   supportsRewindFiles: false,
   supportsRewindBoth: false,
+  supportsSameSessionCompaction: true,
 };
 
 const PI_THINKING_OPTIONS: ReadonlyArray<{
@@ -1548,6 +1549,17 @@ export class PiRpcAgentSession implements AgentSession {
       this.rejectAllExtensionResults(new Error("Pi session closed"));
       this.cleanup?.();
     }
+  }
+
+  async compact(): Promise<void> {
+    if (this.closed) {
+      throw new Error("Pi session is closed");
+    }
+    if (this.activeTurnId) {
+      throw new Error("Cannot compact Pi context while a turn is active");
+    }
+    await this.runtimeSession.compact();
+    await this.refreshState();
   }
 
   async listCommands(): Promise<AgentSlashCommand[]> {

--- a/packages/server/src/server/agent/tools/paseo-tools.ts
+++ b/packages/server/src/server/agent/tools/paseo-tools.ts
@@ -636,9 +636,17 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
     return parentAgent;
   };
 
-  const resolveInheritedProviderConfig = (
+  const resolveCreateProviderConfig = (
+    args: ResolvedCreateAgentToolArgs,
     selectedProvider: string,
   ): Pick<AgentSessionConfig, "providerOptions"> | undefined => {
+    if (
+      args.kind === "top-level" &&
+      "providerOptions" in args.parsedArgs &&
+      args.parsedArgs.providerOptions
+    ) {
+      return { providerOptions: args.parsedArgs.providerOptions };
+    }
     const callerAgent = resolveCallerAgent();
     if (callerAgent?.provider !== selectedProvider || !callerAgent.config?.providerOptions) {
       return undefined;
@@ -1022,6 +1030,10 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
   };
   const canonicalTopLevelInputSchema = {
     ...canonicalCreateAgentFields,
+    providerOptions: z
+      .record(z.string(), z.json())
+      .optional()
+      .describe("Provider-native options validated before the agent starts."),
     background: z
       .boolean()
       .optional()
@@ -1430,7 +1442,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
         notifyOnFinish = resolvedArgs.parsedArgs.notifyOnFinish ?? false;
       }
       const selectedProvider = resolveRequiredProviderModel(parsedArgs.provider).provider;
-      const inheritedConfig = resolveInheritedProviderConfig(selectedProvider);
+      const config = resolveCreateProviderConfig(resolvedArgs, selectedProvider);
       const {
         snapshot,
         background: createdInBackground,
@@ -1454,7 +1466,7 @@ export function createPaseoToolCatalog(options: PaseoToolHostDependencies): Pase
           provider: parsedArgs.provider,
           title: parsedArgs.title,
           initialPrompt: parsedArgs.initialPrompt,
-          config: inheritedConfig,
+          config,
           cwd: resolvedArgs.cwd,
           workspaceId: resolvedArgs.workspaceId,
           thinking: parsedArgs.settings?.thinkingOptionId,

--- a/packages/server/src/server/session.test.ts
+++ b/packages/server/src/server/session.test.ts
@@ -1499,6 +1499,48 @@ describe("agent detach RPC", () => {
   });
 });
 
+describe("agent compact RPC", () => {
+  test("returns the provider identity receipt", async () => {
+    const messages: SessionOutboundMessage[] = [];
+    const compactAgent = vi.fn().mockResolvedValue({
+      status: "confirmed",
+      provider: "opencode",
+      nativeSessionIdBefore: "session-1",
+      nativeSessionIdAfter: "session-1",
+      error: null,
+    });
+    const session = createSessionForTest({
+      messages,
+      agentManager: { compactAgent },
+      agentStorage: {
+        list: vi
+          .fn()
+          .mockResolvedValue([createStoredAgentRecord({ id: "agent-1", cwd: "/tmp/agent-1" })]),
+      },
+    });
+
+    await session.handleMessage({
+      type: "agent.compact.request",
+      agentId: "agent-1",
+      requestId: "compact-1",
+    });
+
+    expect(compactAgent).toHaveBeenCalledWith("agent-1");
+    expect(messages).toContainEqual({
+      type: "agent.compact.response",
+      payload: {
+        requestId: "compact-1",
+        agentId: "agent-1",
+        provider: "opencode",
+        status: "confirmed",
+        nativeSessionIdBefore: "session-1",
+        nativeSessionIdAfter: "session-1",
+        error: null,
+      },
+    });
+  });
+});
+
 function createProjectRecord(rootPath: string, archivedAt: string | null = null) {
   return {
     projectId: `project:${rootPath}`,

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -1925,7 +1925,7 @@ export class Session {
   private async dispatchInboundMessage(msg: SessionInboundMessage, source?: object): Promise<void> {
     const promise =
       this.dispatchVoiceAndControlMessage(msg) ??
-      this.dispatchAgentRewindMessage(msg, source) ??
+      this.dispatchAgentContextMessage(msg, source) ??
       this.dispatchAgentRelationshipMessage(msg) ??
       this.dispatchAgentTimelineMessage(msg, source) ??
       this.dispatchHubExecutionMessage(msg) ??
@@ -2208,13 +2208,15 @@ export class Session {
     }
   }
 
-  private dispatchAgentRewindMessage(
+  private dispatchAgentContextMessage(
     msg: SessionInboundMessage,
     source?: object,
   ): Promise<void> | undefined {
     switch (msg.type) {
       case "agent.rewind.request":
         return this.handleAgentRewindRequest(msg, source);
+      case "agent.compact.request":
+        return this.handleAgentCompactRequest(msg);
       default:
         return undefined;
     }
@@ -4020,6 +4022,47 @@ export class Session {
         },
         source,
       );
+    }
+  }
+
+  private async handleAgentCompactRequest(
+    msg: Extract<SessionInboundMessage, { type: "agent.compact.request" }>,
+  ): Promise<void> {
+    const resolved = await this.resolveAgentIdentifier(msg.agentId);
+    if (!resolved.ok) {
+      this.emit({
+        type: "agent.compact.response",
+        payload: {
+          requestId: msg.requestId,
+          agentId: msg.agentId,
+          provider: null,
+          status: "failed",
+          nativeSessionIdBefore: null,
+          nativeSessionIdAfter: null,
+          error: resolved.error,
+        },
+      });
+      return;
+    }
+    try {
+      const result = await this.agentManager.compactAgent(resolved.agentId);
+      this.emit({
+        type: "agent.compact.response",
+        payload: { requestId: msg.requestId, agentId: resolved.agentId, ...result },
+      });
+    } catch (error) {
+      this.emit({
+        type: "agent.compact.response",
+        payload: {
+          requestId: msg.requestId,
+          agentId: resolved.agentId,
+          provider: this.agentManager.getAgent(resolved.agentId)?.provider ?? null,
+          status: "failed",
+          nativeSessionIdBefore: null,
+          nativeSessionIdAfter: null,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
     }
   }
 

--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -978,7 +978,7 @@ describe("relay external socket reconnect behavior", () => {
     expect(serverInfo.features?.stableProjectIdentity).toBe(true);
     expect(serverInfo.features?.canonicalSubmittedPrompts).toBe(true);
     expect(serverInfo.features?.providersSnapshotCwd).toBe(true);
-    expect(serverInfo.features?.codexAutoCompactTokenLimit).toBe(true);
+    expect(serverInfo.features?.contextManagement).toBe(true);
     expect(serverInfo.features?.pluginLogs).toBe(true);
     expect(serverInfo.features?.["terminal-input-mode-replay"]).toBe(true);
     expect(serverInfo.features?.["terminal-size-ownership"]).toBe(true);

--- a/packages/server/src/server/websocket-server.relay-reconnect.test.ts
+++ b/packages/server/src/server/websocket-server.relay-reconnect.test.ts
@@ -978,6 +978,7 @@ describe("relay external socket reconnect behavior", () => {
     expect(serverInfo.features?.stableProjectIdentity).toBe(true);
     expect(serverInfo.features?.canonicalSubmittedPrompts).toBe(true);
     expect(serverInfo.features?.providersSnapshotCwd).toBe(true);
+    expect(serverInfo.features?.codexAutoCompactTokenLimit).toBe(true);
     expect(serverInfo.features?.pluginLogs).toBe(true);
     expect(serverInfo.features?.["terminal-input-mode-replay"]).toBe(true);
     expect(serverInfo.features?.["terminal-size-ownership"]).toBe(true);

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1654,6 +1654,8 @@ export class VoiceAssistantWebSocketServer {
         providersSnapshot: true,
         // COMPAT(providersSnapshotCwd): added in v0.3.2, remove gate after 2027-02-10.
         providersSnapshotCwd: true,
+        // COMPAT(codexAutoCompactTokenLimit): added in v0.5.x, remove gate after 2027-08-23.
+        codexAutoCompactTokenLimit: true,
         // COMPAT(checkoutForgeSetAutoMerge): added in v0.2.0-beta.1. Remove the
         // feature gate and legacy fallback after 2027-01-17 once the supported
         // daemon floor is >= v0.2.0.

--- a/packages/server/src/server/websocket-server.ts
+++ b/packages/server/src/server/websocket-server.ts
@@ -1654,8 +1654,8 @@ export class VoiceAssistantWebSocketServer {
         providersSnapshot: true,
         // COMPAT(providersSnapshotCwd): added in v0.3.2, remove gate after 2027-02-10.
         providersSnapshotCwd: true,
-        // COMPAT(codexAutoCompactTokenLimit): added in v0.5.x, remove gate after 2027-08-23.
-        codexAutoCompactTokenLimit: true,
+        // COMPAT(contextManagement): added in v0.5.x, remove gate after 2027-08-23.
+        contextManagement: true,
         // COMPAT(checkoutForgeSetAutoMerge): added in v0.2.0-beta.1. Remove the
         // feature gate and legacy fallback after 2027-01-17 once the supported
         // daemon floor is >= v0.2.0.

--- a/public-docs/mcp.md
+++ b/public-docs/mcp.md
@@ -44,6 +44,10 @@ MCP does not expose an agent-detach tool. Detaching is a manual user action in t
 | `get_agent_activity` | Return recent agent timeline entries as a curated summary.                              |
 | `set_agent_mode`     | Switch an agent's session mode.                                                         |
 
+A top-level `create_agent` call may include `providerOptions`. Paseo validates these native
+options against the selected provider before launch. Agent-scoped calls cannot override them;
+same-provider children inherit their caller's options.
+
 ### Workspaces
 
 | Tool                | Function                                                                                              |

--- a/public-docs/sdk/agents.md
+++ b/public-docs/sdk/agents.md
@@ -177,6 +177,18 @@ The answer comes from the running session, not from a directory scan, so it incl
 
 A provider that cannot produce a list reports that in `error` and returns an empty `commands` array. The call does not reject.
 
+## Compact an existing session
+
+```ts
+const receipt = await agent.compact();
+if (receipt.status !== "confirmed") {
+  throw new Error(receipt.error ?? "Compaction was not confirmed");
+}
+console.log(receipt.nativeSessionIdBefore === receipt.nativeSessionIdAfter); // true
+```
+
+Paseo returns `confirmed` only after the provider completes compaction and the native session ID reads back unchanged. Providers without a native same-session operation return `unsupported`; provider errors or an identity change return `failed`.
+
 ## Archive or detach
 
 ```ts

--- a/public-docs/sdk/provider-options.md
+++ b/public-docs/sdk/provider-options.md
@@ -77,6 +77,10 @@ const agent = await client.agents.create({
     provider: "claude/claude-sonnet-5",
     options: {
       disallowedTools: ["WebFetch"],
+      settings: {
+        autoCompactEnabled: true,
+        autoCompactWindow: 400_000,
+      },
       sandbox: {
         enabled: true,
         failIfUnavailable: true,
@@ -108,9 +112,11 @@ await client.close();
 | `disallowedTools`       | Tool names the agent may never use                                                                      |
 | `additionalDirectories` | Extra directories the agent may access                                                                  |
 | `sandbox`               | `enabled`, `failIfUnavailable`, `allowUnsandboxedCommands`, `excludedCommands`, `filesystem`, `network` |
-| `settings`              | `permissions` (`allow`/`ask`/`deny` rule lists) and a nested `sandbox`                                  |
+| `settings`              | `autoCompactEnabled`, `autoCompactWindow` (100,000–1,000,000), `permissions`, and a nested `sandbox`    |
 
 `failIfUnavailable: true` makes agent startup fail when the sandbox cannot be established. Leave it off and Claude runs unsandboxed instead.
+
+`autoCompactWindow` is Claude's effective context capacity for that session. Claude derives an earlier compaction trigger from it, so it is a working-window ceiling rather than an exact trigger token.
 
 `sandbox.filesystem` takes `allowWrite`, `denyWrite`, `allowRead`, and `denyRead`. `sandbox.network` takes `allowedDomains`, `deniedDomains`, `strictAllowlist`, and proxy settings.
 

--- a/public-docs/sdk/provider-options.md
+++ b/public-docs/sdk/provider-options.md
@@ -29,6 +29,8 @@ const agent = await client.agents.create({
     provider: "codex/gpt-5.5",
     options: {
       approval_policy: "never",
+      model_auto_compact_token_limit: 256_000,
+      model_auto_compact_token_limit_scope: "body_after_prefix",
       sandbox_mode: "workspace-write",
       sandbox_workspace_write: {
         writable_roots: ["/Users/me/dev/storefront"],
@@ -48,13 +50,15 @@ console.log(result.status, result.lastMessage);
 await client.close();
 ```
 
-| Option                    | Values                                                                            |
-| ------------------------- | --------------------------------------------------------------------------------- |
-| `approval_policy`         | `untrusted`, `on-request`, `never`, or `{ granular: { … } }`                      |
-| `sandbox_mode`            | `read-only`, `workspace-write`, `danger-full-access`                              |
-| `sandbox_workspace_write` | `writable_roots`, `network_access`, `exclude_slash_tmp`, `exclude_tmpdir_env_var` |
-| `web_search`              | `disabled`, `cached`, `indexed`, `live`                                           |
-| `features`                | `multi_agent_v2`, `network_proxy` (boolean or a proxy/domain policy object)       |
+| Option                                 | Values                                                                            |
+| -------------------------------------- | --------------------------------------------------------------------------------- |
+| `approval_policy`                      | `untrusted`, `on-request`, `never`, or `{ granular: { … } }`                      |
+| `model_auto_compact_token_limit`       | Positive integer token threshold                                                  |
+| `model_auto_compact_token_limit_scope` | `total` or `body_after_prefix`                                                    |
+| `sandbox_mode`                         | `read-only`, `workspace-write`, `danger-full-access`                              |
+| `sandbox_workspace_write`              | `writable_roots`, `network_access`, `exclude_slash_tmp`, `exclude_tmpdir_env_var` |
+| `web_search`                           | `disabled`, `cached`, `indexed`, `live`                                           |
+| `features`                             | `multi_agent_v2`, `network_proxy` (boolean or a proxy/domain policy object)       |
 
 `approval_policy: "never"` only removes the prompts. What the agent is allowed to touch is `sandbox_mode`. Setting `never` without a sandbox mode gives an unattended agent full access.
 

--- a/public-docs/sdk/providers.md
+++ b/public-docs/sdk/providers.md
@@ -59,6 +59,8 @@ const snapshot = await client.providers.waitForReady({
 for (const entry of snapshot.entries) {
   if (entry.status !== "ready") continue;
 
+  console.log(entry.provider, entry.capabilities?.supportsContextWindowPolicy);
+
   for (const model of entry.models ?? []) {
     console.log(`${entry.provider}/${model.id}`);
   }
@@ -66,6 +68,8 @@ for (const entry of snapshot.entries) {
 ```
 
 An entry finishes as `ready`, `unavailable`, or `error`. `snapshot()` returns immediately and can include `loading` entries.
+
+`entry.capabilities` reports provider operations that the running daemon can actually perform. Context-window policy and same-session compaction are separate flags; do not infer one from the other.
 
 ## Select a discovered model
 


### PR DESCRIPTION
### Linked issue

Discussion: #3737

Related transport work: #3077

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Docs

### Reasoning

Long-lived agents need provider-native context controls without replacing their native sessions. The providers do not expose one uniform operation: Codex has an exact automatic-compaction trigger and a compact RPC, Claude has a per-session effective context window, OpenCode has a same-session summarize endpoint but no absolute automatic threshold, and Pi/OMP expose compact RPCs only.

This change keeps those differences explicit. Provider snapshots advertise two independent capabilities, provider options carry native launch settings, and a provider-neutral compact RPC returns a confirmed receipt only after native completion and unchanged session identity.

### Goals

- Publish `supportsContextWindowPolicy` and `supportsSameSessionCompaction` in provider snapshots only where the running adapter implements them.
- Keep the existing Codex native threshold mapping through `model_auto_compact_token_limit` and its scope.
- Add Claude native `settings.autoCompactEnabled` and `settings.autoCompactWindow` validation and forwarding.
- Add `agent.compact.request` / `agent.compact.response` and `agent.compact()` in the TypeScript SDK.
- Implement same-session compact for Codex (`thread/compact/start`), OpenCode (`session.summarize`), Pi, and OMP.
- Return `confirmed` only after native completion and unchanged native session ID; otherwise return `unsupported` or `failed`.

### Provider behavior

| Provider | Per-session context policy | Same-session compact |
| --- | --- | --- |
| Codex | Exact native token trigger | Yes |
| Claude | Effective native window; Claude derives an earlier trigger | No SDK operation |
| OpenCode | No absolute token policy | Yes |
| Pi / OMP | No absolute token policy | Yes |
| ACP providers, including Cursor | No | No |

### Non-goals

- A Paseo-owned context class system or cross-provider threshold emulation.
- Claiming OpenCode model-relative auto-compaction as an absolute token policy.
- Sending `/compact` as user prompt text from the new API.
- Replacing, reloading, archiving, or recreating a native session to compact it.
- Machine-wide provider configuration.
- UI changes.

### QA

Platform: macOS Darwin arm64. Paseo `0.5.0-beta.5`, rebased onto current `main` (`35cde075a`). Native Codex CLI `0.147.0`, Claude Code `2.1.223`, OpenCode `1.18.15`.

- 911 focused tests passed across protocol, SDK, provider discovery/options, session routing, manager identity checks, Codex, Claude, OpenCode, Pi, and OMP.
- The pre-commit contribution gates passed: typecheck for every workspace, lint with zero warnings/errors, and formatting checks.
- Real Codex: native compaction completed, thread `01a02e44-6c50-77f3-a6d2-3d8e2cf0c66d` remained unchanged, reported usage `31,474 -> 29,373`, model max `258,400`.
- Real Claude: a `100,000` effective window enabled native auto-compaction, the derived trigger was at or below the configured window, post-compaction usage was lower, and session `dc2314f3-b732-4772-be7a-8c401db35364` remained unchanged.
- Real OpenCode: the adapter called native `session.summarize`, observed native compaction completion, and session `ses_fd18173e9ffeCf3pL7sk0Z62vc` remained unchanged.
- Pi and OMP use hermetic native-RPC fakes in this change; they were not live-tested.

### Checklist

- [x] One coherent provider-context change
- [x] Backward-compatible optional wire fields and feature gate
- [x] Strict provider-native validation
- [x] `npm run typecheck` passes
- [x] Lint passes
- [x] Format passes
- [x] Hermetic and live QA evidence
