### PR TITLE
feat(provider-usage): add Antigravity plan quota fetcher

### DIFF
--- a/packages/server/src/services/quota-fetcher/manifest.ts
+++ b/packages/server/src/services/quota-fetcher/manifest.ts
@@ -3,6 +3,7 @@ import type {
   ProviderUsageFetcherFactoryOptions,
   ProviderUsageFetcherManifestEntry,
 } from "./provider.js";
+import { AntigravityQuotaProvider } from "./providers/antigravity.js";
 import { ClaudeQuotaProvider } from "./providers/claude.js";
 import { CodexQuotaProvider } from "./providers/codex.js";
 import { CopilotQuotaProvider } from "./providers/copilot.js";
@@ -13,6 +14,13 @@ import { MiniMaxQuotaProvider } from "./providers/minimax.js";
 import { ZaiQuotaProvider } from "./providers/zai.js";
 
 export const PROVIDER_USAGE_FETCHERS: readonly ProviderUsageFetcherManifestEntry[] = [
+  {
+    providerId: "antigravity",
+    create: (options) =>
+      new AntigravityQuotaProvider({
+        logger: options.logger,
+      }),
+  },
   {
     providerId: "claude",
     create: (options) =>

--- a/packages/server/src/services/quota-fetcher/providers/antigravity.test.ts
+++ b/packages/server/src/services/quota-fetcher/providers/antigravity.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProviderUsage } from "../../../server/messages.js";
+import type { ApiEndpoint, RpcResult } from "./antigravity.js";
+import {
+  AntigravityQuotaProvider,
+  buildProviderUsage,
+  parseUserStatus,
+} from "./antigravity.js";
+
+function createLogger() {
+  const logger = {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger as never;
+}
+
+const sampleUserStatus = {
+  userStatus: {
+    name: "Test User",
+    email: "test@example.com",
+    planStatus: {
+      planInfo: {
+        planName: "Pro",
+        teamsTier: "TEAMS_TIER_PRO",
+        monthlyPromptCredits: 50000,
+      },
+      availablePromptCredits: 4200,
+      availableFlowCredits: 100,
+    },
+    cascadeModelConfigData: {
+      clientModelConfigs: [
+        {
+          label: "Gemini 3.7 Flash (High)",
+          modelOrAlias: { model: "gemini-3.7-flash-high" },
+          quotaInfo: { remainingFraction: 0.5, resetTime: "2026-08-24T00:00:00Z" },
+        },
+        {
+          label: "Claude Sonnet 4.6 (Thinking)",
+          modelOrAlias: { model: "claude-sonnet-4-6" },
+          quotaInfo: { remainingFraction: 0.1, resetTime: "2026-08-24T00:00:00Z" },
+        },
+      ],
+    },
+  },
+};
+
+function provider(overrides: {
+  findLanguageServer?: () => Promise<{ pid: number; csrfToken: string } | null>;
+  listListeningPorts?: (pid: number) => Promise<number[]>;
+  rpc?: (endpoint: ApiEndpoint, csrfToken: string, path: string) => Promise<RpcResult>;
+}) {
+  return new AntigravityQuotaProvider({
+    logger: createLogger(),
+    findLanguageServer: overrides.findLanguageServer,
+    listListeningPorts: overrides.listListeningPorts,
+    rpc: overrides.rpc,
+  });
+}
+
+function okRpc(result: RpcResult) {
+  return async () => result;
+}
+
+describe("AntigravityQuotaProvider", () => {
+  it("parses plan and per-model quotas from GetUserStatus", () => {
+    const quota = parseUserStatus(sampleUserStatus);
+    expect(quota).not.toBeNull();
+    expect(quota!.planLabel).toBe("Pro");
+    expect(quota!.tier).toBe("TEAMS_TIER_PRO");
+    expect(quota!.monthlyPromptCredits).toBe(50000);
+    expect(quota!.availablePromptCredits).toBe(4200);
+    expect(quota!.availableFlowCredits).toBe(100);
+    expect(quota!.models).toHaveLength(2);
+    expect(quota!.models[0].remainingFraction).toBe(0.5);
+  });
+
+  it("returns null for malformed responses", () => {
+    expect(parseUserStatus(null)).toBeNull();
+    expect(parseUserStatus({})).toBeNull();
+    expect(parseUserStatus({ userStatus: {} })).not.toBeNull();
+  });
+
+  it("maps quota into ProviderUsage with balances and most-constrained window", () => {
+    const quota = parseUserStatus(sampleUserStatus)!;
+    const usage = buildProviderUsage(quota) as ProviderUsage;
+    expect(usage.status).toBe("available");
+    expect(usage.providerId).toBe("antigravity");
+    expect(usage.planLabel).toBe("Pro · TEAMS_TIER_PRO");
+    expect(usage.windows).toHaveLength(1);
+    // Most constrained model (Claude, 10% left) drives the window.
+    expect(usage.windows[0].remainingPct).toBe(10);
+    expect(usage.windows[0].label).toBe("Daily request quota");
+    expect(usage.windows[0].tone).toBe("warning");
+    const credits = usage.balances!.find((b) => b.id === "prompt_credits")!;
+    expect(credits.limit).toBe(50000);
+    expect(credits.remaining).toBe(4200);
+    expect(credits.used).toBe(45800);
+    expect(credits.unit).toBe("credits");
+    const flow = usage.balances!.find((b) => b.id === "flow_credits")!;
+    expect(flow.remaining).toBe(100);
+    expect(usage.details).toHaveLength(2);
+  });
+
+  it("reports unavailable when no language server is running", async () => {
+    const p = provider({ findLanguageServer: async () => null });
+    const usage = await p.fetchUsage();
+    expect(usage.status).toBe("unavailable");
+    expect(usage.windows).toEqual([]);
+  });
+
+  it("reports unavailable when no API port is found", async () => {
+    const p = provider({
+      findLanguageServer: async () => ({ pid: 123, csrfToken: "csrf" }),
+      listListeningPorts: async () => [],
+    });
+    const usage = await p.fetchUsage();
+    expect(usage.status).toBe("unavailable");
+  });
+
+  it("discovers the API port via GetUnleashData and fetches quota", async () => {
+    const rpcCalls: string[] = [];
+    const p = provider({
+      findLanguageServer: async () => ({ pid: 123, csrfToken: "csrf" }),
+      listListeningPorts: async () => [4100, 4200],
+      rpc: async (endpoint, csrf, path) => {
+        rpcCalls.push(`${endpoint.port}:${path}`);
+        if (path.endsWith("GetUnleashData") && endpoint.port === 4200) {
+          return { status: 200, body: "{}" };
+        }
+        if (path.endsWith("GetUserStatus")) {
+          return { status: 200, body: JSON.stringify(sampleUserStatus) };
+        }
+        return { status: 404, body: "" };
+      },
+    });
+    const usage = await p.fetchUsage();
+    expect(usage.status).toBe("available");
+    expect(usage.planLabel).toContain("Pro");
+    expect(usage.balances!.length).toBe(2);
+    expect(rpcCalls).toContain("4200:/exa.language_server_pb.LanguageServerService/GetUnleashData");
+    expect(rpcCalls).toContain("4200:/exa.language_server_pb.LanguageServerService/GetUserStatus");
+  });
+
+  it("returns error status when the RPC fails", async () => {
+    const p = provider({
+      findLanguageServer: async () => ({ pid: 123, csrfToken: "csrf" }),
+      listListeningPorts: async () => [4100],
+      rpc: okRpc({ status: 500, body: "boom" }),
+    });
+    const usage = await p.fetchUsage();
+    expect(usage.status).toBe("unavailable");
+  });
+});

--- a/packages/server/src/services/quota-fetcher/providers/antigravity.ts
+++ b/packages/server/src/services/quota-fetcher/providers/antigravity.ts
@@ -1,0 +1,344 @@
+import { execFile } from "node:child_process";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest, type RequestOptions } from "node:https";
+import { promisify } from "node:util";
+import type { Logger } from "pino";
+import type {
+  ProviderUsage,
+  ProviderUsageBalance,
+  ProviderUsageWindow,
+} from "../../../server/messages.js";
+import type { ProviderUsageFetcher } from "../provider.js";
+import {
+  balanceToneFromRemaining,
+  toneFromUsedPct,
+  unavailableUsage,
+  windowFromUsedPct,
+} from "../usage.js";
+
+const execFileAsync = promisify(execFile);
+
+const GET_USER_STATUS_PATH =
+  "/exa.language_server_pb.LanguageServerService/GetUserStatus";
+const GET_UNLEASH_DATA_PATH =
+  "/exa.language_server_pb.LanguageServerService/GetUnleashData";
+const RPC_TIMEOUT_MS = 8_000;
+
+export interface LanguageServerInfo {
+  pid: number;
+  csrfToken: string;
+}
+
+export interface ApiEndpoint {
+  port: number;
+  tls: boolean;
+}
+
+export interface RpcResult {
+  status: number;
+  body: string;
+}
+
+interface AntigravityQuotaProviderOptions {
+  logger: Logger;
+  findLanguageServer?: () => Promise<LanguageServerInfo | null>;
+  listListeningPorts?: (pid: number) => Promise<number[]>;
+  rpc?: (
+    endpoint: ApiEndpoint,
+    csrfToken: string,
+    path: string,
+  ) => Promise<RpcResult>;
+}
+
+interface ModelQuota {
+  modelId: string;
+  label: string;
+  remainingFraction: number;
+  resetTime: string | null;
+}
+
+interface QuotaData {
+  planLabel: string | null;
+  tier: string | null;
+  monthlyPromptCredits: number | null;
+  availablePromptCredits: number | null;
+  availableFlowCredits: number | null;
+  models: ModelQuota[];
+}
+
+/** Locate the running Antigravity language server process (CLI or IDE). */
+export async function defaultFindLanguageServer(): Promise<LanguageServerInfo | null> {
+  let stdout: string;
+  try {
+    const { stdout: out } = await execFileAsync("ps", ["-ww", "-eo", "pid,ppid,args"]);
+    stdout = out;
+  } catch {
+    return null;
+  }
+  for (const line of stdout.split("\n")) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 3) continue;
+    const pid = Number(parts[0]);
+    if (!Number.isInteger(pid)) continue;
+    const cmd = parts.slice(2).join(" ");
+    if (!/language_server/.test(cmd)) continue;
+    if (!/--app_data_dir[=\s]+antigravity\b/.test(cmd)) continue;
+    const tokenMatch = cmd.match(/--csrf_token[=\s]+([a-zA-Z0-9-]+)/);
+    if (!tokenMatch) continue;
+    return { pid, csrfToken: tokenMatch[1] };
+  }
+  return null;
+}
+
+/** List TCP listen ports for a process via lsof, falling back to ss. */
+export async function defaultListListeningPorts(pid: number): Promise<number[]> {
+  const ports = new Set<number>();
+  try {
+    const { stdout } = await execFileAsync("lsof", [
+      "-nP",
+      "-a",
+      "-iTCP",
+      "-sTCP:LISTEN",
+      "-p",
+      String(pid),
+    ]);
+    for (const line of stdout.split("\n")) {
+      const m = line.match(/127\.0\.0\.1:(\d+)/);
+      if (m) ports.add(Number(m[1]));
+    }
+  } catch {
+    // lsof unavailable; fall back to ss below
+  }
+  if (ports.size === 0) {
+    try {
+      const { stdout } = await execFileAsync("ss", ["-tlnp"]);
+      for (const line of stdout.split("\n")) {
+        if (!line.includes(`pid=${pid}`)) continue;
+        const m = line.match(/:(\d+)\s/);
+        if (m) ports.add(Number(m[1]));
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return [...ports];
+}
+
+/** POST a JSON-RPC-style request to the local language server. */
+export async function defaultRpc(
+  endpoint: ApiEndpoint,
+  csrfToken: string,
+  path: string,
+): Promise<RpcResult> {
+  return new Promise((resolve) => {
+    const payload = JSON.stringify({
+      metadata: { ideName: "antigravity", extensionName: "antigravity", locale: "en" },
+    });
+    const options: RequestOptions = {
+      hostname: "127.0.0.1",
+      port: endpoint.port,
+      path,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(payload),
+        "Connect-Protocol-Version": "1",
+        "X-Codeium-Csrf-Token": csrfToken,
+      },
+    };
+    const reqFn = endpoint.tls ? httpsRequest : httpRequest;
+    if (endpoint.tls) {
+      options.rejectUnauthorized = false;
+    }
+    const req = reqFn(options, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c: Buffer) => chunks.push(c));
+      res.on("end", () => {
+        resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") });
+      });
+    });
+    req.on("error", () => resolve({ status: 0, body: "" }));
+    req.setTimeout(RPC_TIMEOUT_MS, () => req.destroy());
+    req.write(payload);
+    req.end();
+  });
+}
+
+export function parseUserStatus(raw: unknown): QuotaData | null {
+  if (!raw || typeof raw !== "object") return null;
+  const us = (raw as { userStatus?: unknown }).userStatus;
+  if (!us || typeof us !== "object") return null;
+  const record = us as Record<string, unknown>;
+  const planStatus = (record.planStatus ?? {}) as Record<string, unknown>;
+  const planInfo = (planStatus.planInfo ?? {}) as Record<string, unknown>;
+  const cascade = (record.cascadeModelConfigData ?? {}) as Record<string, unknown>;
+  const configs = Array.isArray(cascade.clientModelConfigs)
+    ? (cascade.clientModelConfigs as Array<Record<string, unknown>>)
+    : [];
+
+  const toNum = (v: unknown): number | null =>
+    typeof v === "number" && Number.isFinite(v) ? v : null;
+
+  const models: ModelQuota[] = [];
+  for (const m of configs) {
+    const quotaInfo = (m.quotaInfo ?? {}) as Record<string, unknown>;
+    if (typeof quotaInfo.remainingFraction !== "number") continue;
+    const modelOrAlias = (m.modelOrAlias ?? {}) as Record<string, unknown>;
+    models.push({
+      modelId: typeof modelOrAlias.model === "string" ? modelOrAlias.model : "unknown",
+      label: typeof m.label === "string" ? m.label : "Unknown model",
+      remainingFraction: quotaInfo.remainingFraction,
+      resetTime: typeof quotaInfo.resetTime === "string" ? quotaInfo.resetTime : null,
+    });
+  }
+
+  return {
+    planLabel: typeof planInfo.planName === "string" ? planInfo.planName : null,
+    tier: typeof planInfo.teamsTier === "string" ? planInfo.teamsTier : null,
+    monthlyPromptCredits: toNum(planInfo.monthlyPromptCredits),
+    availablePromptCredits: toNum(planStatus.availablePromptCredits),
+    availableFlowCredits: toNum(planStatus.availableFlowCredits),
+    models,
+  };
+}
+
+export function buildProviderUsage(quota: QuotaData): ProviderUsage {
+  const windows: ProviderUsageWindow[] = [];
+  const details: ProviderUsage["details"] = [];
+
+  let constrained: ModelQuota | null = null;
+  for (const m of quota.models) {
+    const usedPct = Math.round((1 - m.remainingFraction) * 10_000) / 100;
+    details?.push({
+      id: `model_${m.modelId}`,
+      label: m.label,
+      value: `${Math.round(m.remainingFraction * 100)}% left` +
+        (m.resetTime ? ` (resets ${m.resetTime})` : ""),
+      tone: toneFromUsedPct(usedPct),
+    });
+    if (!constrained || m.remainingFraction < constrained.remainingFraction) {
+      constrained = m;
+    }
+  }
+
+  if (constrained) {
+    const usedPct = Math.round((1 - constrained.remainingFraction) * 10_000) / 100;
+    windows.push(
+      windowFromUsedPct({
+        id: "daily_request_quota",
+        label: "Daily request quota",
+        utilizationPct: usedPct,
+        resetsAt: constrained.resetTime,
+        tone: toneFromUsedPct(usedPct),
+      }),
+    );
+  }
+
+  const balances: ProviderUsageBalance[] = [];
+  if (quota.monthlyPromptCredits !== null && quota.availablePromptCredits !== null) {
+    const used = Math.max(0, quota.monthlyPromptCredits - quota.availablePromptCredits);
+    balances.push({
+      id: "prompt_credits",
+      label: "Monthly prompt credits",
+      used,
+      remaining: quota.availablePromptCredits,
+      limit: quota.monthlyPromptCredits,
+      unit: "credits",
+      resetsAt: null,
+      tone: balanceToneFromRemaining(quota.availablePromptCredits),
+    });
+  } else if (quota.availablePromptCredits !== null) {
+    balances.push({
+      id: "prompt_credits",
+      label: "Prompt credits",
+      remaining: quota.availablePromptCredits,
+      unit: "credits",
+      tone: balanceToneFromRemaining(quota.availablePromptCredits),
+    });
+  }
+  if (quota.availableFlowCredits !== null) {
+    balances.push({
+      id: "flow_credits",
+      label: "Flow credits",
+      remaining: quota.availableFlowCredits,
+      unit: "credits",
+      tone: balanceToneFromRemaining(quota.availableFlowCredits),
+    });
+  }
+
+  const planLabel = [quota.planLabel, quota.tier].filter(Boolean).join(" · ") || null;
+
+  return {
+    providerId: "antigravity",
+    displayName: "Antigravity",
+    status: "available",
+    planLabel,
+    sourceLabel: "Antigravity language server",
+    windows,
+    balances,
+    details,
+  };
+}
+
+export class AntigravityQuotaProvider implements ProviderUsageFetcher {
+  readonly providerId = "antigravity";
+  readonly displayName = "Antigravity";
+
+  private readonly logger: Logger;
+  private readonly findLanguageServer: () => Promise<LanguageServerInfo | null>;
+  private readonly listListeningPorts: (pid: number) => Promise<number[]>;
+  private readonly rpc: (
+    endpoint: ApiEndpoint,
+    csrfToken: string,
+    path: string,
+  ) => Promise<RpcResult>;
+
+  constructor(options: AntigravityQuotaProviderOptions) {
+    this.logger = options.logger.child({ module: "antigravity-quota-provider" });
+    this.findLanguageServer = options.findLanguageServer ?? defaultFindLanguageServer;
+    this.listListeningPorts = options.listListeningPorts ?? defaultListListeningPorts;
+    this.rpc = options.rpc ?? defaultRpc;
+  }
+
+  private async findApiPort(server: LanguageServerInfo): Promise<ApiEndpoint | null> {
+    const ports = await this.listListeningPorts(server.pid);
+    for (const port of ports) {
+      for (const tls of [true, false]) {
+        const result = await this.rpc({ port, tls }, server.csrfToken, GET_UNLEASH_DATA_PATH);
+        if (result.status === 200) {
+          return { port, tls };
+        }
+      }
+    }
+    return null;
+  }
+
+  async fetchUsage(): Promise<ProviderUsage> {
+    const server = await this.findLanguageServer();
+    if (!server) {
+      this.logger.debug("Antigravity language server not found");
+      return unavailableUsage(this);
+    }
+    const api = await this.findApiPort(server);
+    if (!api) {
+      this.logger.debug("Antigravity API port not found");
+      return unavailableUsage(this);
+    }
+    const result = await this.rpc(api, server.csrfToken, GET_USER_STATUS_PATH);
+    if (result.status !== 200) {
+      this.logger.debug({ status: result.status }, "GetUserStatus failed");
+      return unavailableUsage(this);
+    }
+    let quota: QuotaData | null;
+    try {
+      quota = parseUserStatus(JSON.parse(result.body));
+    } catch (error) {
+      this.logger.debug({ err: error }, "Failed to parse GetUserStatus");
+      return unavailableUsage(this);
+    }
+    if (!quota) {
+      return unavailableUsage(this);
+    }
+    return buildProviderUsage(quota);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a provider-usage fetcher for Google Antigravity, so Paseo can show your Antigravity plan meter.

**Provider usage: Antigravity plan quota fetcher** (`packages/server/src/services/quota-fetcher/providers/antigravity.ts`)
Google Antigravity exposes no official ACP mode, and the Gemini CLI path for quota is dead (its OAuth client now returns `PERMISSION_DENIED` on the Code Assist quota endpoints). Instead, the fetcher reads the plan meter straight from the **running Antigravity language server's `GetUserStatus` RPC over 127.0.0.1** — the same local technique the Antigravity Quota Monitor extensions use. No OAuth, no Google API.

- Discovers the language server via `ps` (matches `language_server … --app_data_dir antigravity --csrf_token …`), finds its API port with `lsof`/probes `GetUnleashData`, then queries `GetUserStatus`.
- Reports: `planLabel`/tier, a `Daily request quota` window driven by the most-constrained model, monthly prompt credits + flow credits balances, and a per-model breakdown.
- Falls back to `unavailable` when the language server isn't running.
- Registered in `manifest.ts` for provider id `antigravity`. Unit tests cover parsing, mapping, port discovery, and failure paths (7 tests).

## Verified

- `paseo provider diagnostic antigravity` → Ready (14 models)
- End-to-end `paseo run --provider antigravity` (tools + text + usage)
- Live `GetUserStatus` read on a Pro plan (50000 monthly credits, per-model daily fractions)
- Unit tests pass: `npx vitest run src/services/quota-fetcher/providers/antigravity.test.ts` (7/7)

## Notes

- A full monorepo typecheck locally fails only on pre-existing unbuilt workspace packages (`@getpaseo/client`, `@getpaseo/plugin`, …) in a fresh checkout; the changed files typecheck clean. CI is authoritative.
- The Antigravity plan meter only works while `agy` or the Antigravity IDE is running and logged in.