### PR TITLE
feat(app): open modified file links in selected target

### DIFF
--- a/packages/app/src/agent-stream/view.tsx
+++ b/packages/app/src/agent-stream/view.tsx
@@ -106,6 +106,7 @@ import type { Theme } from "@/styles/theme";
 import { recordRenderProfileReasons } from "@/utils/render-profiler";
 import { useRetainedPanelActive } from "@/components/retained-panel";
 import { useStreamHistoryWindow } from "./use-stream-history-window";
+import { usePreferredFileOpenTarget } from "@/workspace/use-preferred-file-open-target";
 
 function renderLiveAuxiliaryNode(input: {
   pendingPermissions: ReactNode;
@@ -374,6 +375,10 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
     );
 
     const workspaceRoot = context.cwd?.trim() || "";
+    const openFileInPreferredTarget = usePreferredFileOpenTarget({
+      serverId: resolvedServerId,
+      workspaceDirectory: workspaceRoot,
+    });
     const { requestDirectoryListing } = useFileExplorerActions({
       serverId: resolvedServerId,
       workspaceId: context.workspaceId,
@@ -470,6 +475,24 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           },
           view: "files",
         });
+      },
+    );
+
+    const handleInlinePathPreferredTargetPress = useStableEvent(
+      async (target: InlinePathTarget): Promise<boolean> => {
+        if (!target.path) {
+          return false;
+        }
+        const normalized = normalizeInlinePathTarget(target.path, context.cwd);
+        if (!normalized?.file) {
+          return false;
+        }
+        const location = normalizeWorkspaceFileLocation({
+          path: normalized.file,
+          lineStart: target.lineStart,
+          lineEnd: target.lineEnd,
+        });
+        return location ? openFileInPreferredTarget(location) : false;
       },
     );
 
@@ -696,6 +719,7 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
             serverId={resolvedServerId}
             workspaceRoot={workspaceRoot}
             onOpenWorkspaceFile={handleInlinePathPress}
+            onOpenWorkspaceFileInPreferredTarget={handleInlinePathPreferredTargetPress}
             toast={toast}
           >
             <AssistantMessage
@@ -711,7 +735,15 @@ const AgentStreamViewComponent = forwardRef<AgentStreamViewHandle, AgentStreamVi
           </AssistantFileLinkResolverProvider>
         );
       },
-      [agentId, client, handleInlinePathPress, resolvedServerId, toast, workspaceRoot],
+      [
+        agentId,
+        client,
+        handleInlinePathPress,
+        handleInlinePathPreferredTargetPress,
+        resolvedServerId,
+        toast,
+        workspaceRoot,
+      ],
     );
 
     const renderThoughtItem = useCallback(

--- a/packages/app/src/assistant-file-links/link.tsx
+++ b/packages/app/src/assistant-file-links/link.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type CSSProperties, type MouseEvent, type ReactNode } from "react";
+import { useCallback, useMemo, type CSSProperties, type MouseEvent, type ReactNode } from "react";
 import { Platform, Text, View, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
 import { StyleSheet } from "react-native-unistyles";
 import { isNative, isWeb } from "@/constants/platform";
@@ -30,7 +30,7 @@ export function AssistantMarkdownLink({
   monoSurface,
   children,
 }: AssistantMarkdownLinkProps) {
-  const { target, onHoverIn, onPress } = useFileLink(source);
+  const { target, onHoverIn, onPress, onOpenInPreferredTarget } = useFileLink(source);
   const { configRef } = useAssistantFileLinkResolverContext();
   const workspaceRoot = configRef.current.workspaceRoot;
   const tooltipPath = useMemo(
@@ -42,6 +42,17 @@ export function AssistantMarkdownLink({
     [onPress],
   );
   const unwrapForMarkdownCopy = source.sourceType === "inline-code" || source.markup === "linkify";
+  const handleClickCapture = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      if (!event.ctrlKey && !event.metaKey) {
+        return;
+      }
+      event.stopPropagation();
+      onOpenInPreferredTarget();
+    },
+    [onOpenInPreferredTarget],
+  );
 
   if (isNative) {
     // Must be a MarkdownTextSpan, not a plain <Text>: on iOS the link renders
@@ -83,7 +94,7 @@ export function AssistantMarkdownLink({
       {...(unwrapForMarkdownCopy ? { "data-paseo-markdown-unwrap": "true" } : {})}
       href={source.href}
       title={source.title}
-      onClickCapture={preventAnchorNavigation}
+      onClickCapture={handleClickCapture}
       onAuxClickCapture={preventAnchorNavigation}
       style={LINK_ANCHOR_STYLE}
     >

--- a/packages/app/src/assistant-file-links/provider.tsx
+++ b/packages/app/src/assistant-file-links/provider.tsx
@@ -22,6 +22,7 @@ export interface AssistantFileLinkResolverConfig {
   serverId?: string;
   workspaceRoot?: string;
   onOpenWorkspaceFile?: (target: InlinePathTarget, disposition: OpenFileDisposition) => void;
+  onOpenWorkspaceFileInPreferredTarget?: (target: InlinePathTarget) => Promise<boolean>;
   toast?: ToastApi | null;
 }
 
@@ -42,6 +43,7 @@ export function AssistantFileLinkResolverProvider({
   serverId,
   workspaceRoot,
   onOpenWorkspaceFile,
+  onOpenWorkspaceFileInPreferredTarget,
   toast,
   children,
 }: AssistantFileLinkResolverProviderProps) {
@@ -50,9 +52,17 @@ export function AssistantFileLinkResolverProvider({
     serverId,
     workspaceRoot,
     onOpenWorkspaceFile,
+    onOpenWorkspaceFileInPreferredTarget,
     toast,
   });
-  configRef.current = { client, serverId, workspaceRoot, onOpenWorkspaceFile, toast };
+  configRef.current = {
+    client,
+    serverId,
+    workspaceRoot,
+    onOpenWorkspaceFile,
+    onOpenWorkspaceFileInPreferredTarget,
+    toast,
+  };
 
   const getDirectorySuggestions = useCallback<GetDirectorySuggestions>(async (input) => {
     const activeClient = configRef.current.client;

--- a/packages/app/src/assistant-file-links/use-file-link.test.tsx
+++ b/packages/app/src/assistant-file-links/use-file-link.test.tsx
@@ -72,7 +72,12 @@ function createToast(): ToastApi {
   };
 }
 
-function createWrapper(input: { client: TestClient; openedFiles: OpenedFile[]; toast?: ToastApi }) {
+function createWrapper(input: {
+  client: TestClient;
+  openedFiles: OpenedFile[];
+  openInPreferredTarget?: (target: InlinePathTarget) => Promise<boolean>;
+  toast?: ToastApi;
+}) {
   const queryClient = createQueryClient();
   return function Wrapper({ children }: { children: ReactNode }) {
     const openWorkspaceFile = useCallback(
@@ -89,6 +94,7 @@ function createWrapper(input: { client: TestClient; openedFiles: OpenedFile[]; t
           serverId="server-1"
           workspaceRoot="/Users/test/project"
           onOpenWorkspaceFile={openWorkspaceFile}
+          onOpenWorkspaceFileInPreferredTarget={input.openInPreferredTarget}
           toast={input.toast}
         >
           {children}
@@ -269,6 +275,67 @@ describe("useFileLink", () => {
       expect(openedFiles).toHaveLength(1);
     });
     expect(getDirectorySuggestions).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a modified-click file in the preferred target", async () => {
+    const getDirectorySuggestions = vi.fn(async () =>
+      resolvedSuggestions([{ path: "docs/dumm.md", kind: "file" }]),
+    );
+    const openedFiles: OpenedFile[] = [];
+    const openInPreferredTarget = vi.fn(async () => true);
+    const { result } = renderHook(() => useFileLink(SOURCE), {
+      wrapper: createWrapper({
+        client: { getDirectorySuggestions },
+        openedFiles,
+        openInPreferredTarget,
+      }),
+    });
+
+    act(() => {
+      result.current.onOpenInPreferredTarget();
+    });
+
+    await waitFor(() => {
+      expect(openInPreferredTarget).toHaveBeenCalledWith({
+        raw: "dumm.md",
+        path: "/Users/test/project/docs/dumm.md",
+        lineStart: undefined,
+        lineEnd: undefined,
+      });
+    });
+    expect(openedFiles).toEqual([]);
+  });
+
+  it("falls back to the Paseo side pane when no preferred target can open the file", async () => {
+    const getDirectorySuggestions = vi.fn(async () =>
+      resolvedSuggestions([{ path: "docs/dumm.md", kind: "file" }]),
+    );
+    const openedFiles: OpenedFile[] = [];
+    const { result } = renderHook(() => useFileLink(SOURCE), {
+      wrapper: createWrapper({
+        client: { getDirectorySuggestions },
+        openedFiles,
+        openInPreferredTarget: async () => false,
+      }),
+    });
+
+    act(() => {
+      result.current.onOpenInPreferredTarget();
+    });
+
+    await waitFor(() => {
+      expect(openedFiles).toEqual([
+        {
+          target: {
+            raw: "dumm.md",
+            path: "/Users/test/project/docs/dumm.md",
+            lineStart: undefined,
+            lineEnd: undefined,
+          },
+          disposition: "side",
+        },
+      ]);
+    });
   });
 
   it("does not open a stale result after the workspace changes", async () => {

--- a/packages/app/src/assistant-file-links/use-file-link.ts
+++ b/packages/app/src/assistant-file-links/use-file-link.ts
@@ -20,6 +20,7 @@ export interface UseFileLinkResult {
   target: InlinePathTarget | null;
   onHoverIn: () => void;
   onPress: () => void;
+  onOpenInPreferredTarget: () => void;
   open: (source: AssistantFileLinkSource, disposition: OpenFileDisposition) => void;
 }
 
@@ -35,6 +36,8 @@ type AssistantFileLinkQueryKey = readonly [
   string | null,
   string,
 ];
+
+type AssistantFileLinkDisposition = OpenFileDisposition | "preferred-target";
 
 const DISABLED_QUERY_KEY = ["assistantFileLink", null, null, ""] as const;
 
@@ -120,6 +123,16 @@ export function useFileLink(source: AssistantFileLinkSource): UseFileLinkResult 
     open(stableSource, "side");
   });
 
+  const onOpenInPreferredTarget = useStableEvent(() => {
+    openAssistantFileLink({
+      source: stableSource,
+      disposition: "preferred-target",
+      context,
+      queryClient,
+      formatNoFileFoundMessage: (token) => t("common.errors.noFileFound", { token }),
+    });
+  });
+
   const target = useMemo(() => {
     if (resolution.kind === "resolved") {
       return resolution.value.kind === "file" ? resolution.value.target : null;
@@ -127,7 +140,10 @@ export function useFileLink(source: AssistantFileLinkSource): UseFileLinkResult 
     return query.data ?? null;
   }, [query.data, resolution]);
 
-  return useMemo(() => ({ target, onHoverIn, onPress, open }), [target, onHoverIn, onPress, open]);
+  return useMemo(
+    () => ({ target, onHoverIn, onPress, onOpenInPreferredTarget, open }),
+    [target, onHoverIn, onPress, onOpenInPreferredTarget, open],
+  );
 }
 
 export function useAssistantFileLinkActions(): AssistantFileLinkActions {
@@ -155,7 +171,7 @@ export function useAssistantFileLinkActions(): AssistantFileLinkActions {
 
 function openAssistantFileLink(input: {
   source: AssistantFileLinkSource;
-  disposition: OpenFileDisposition;
+  disposition: AssistantFileLinkDisposition;
   context: AssistantFileLinkResolverContextValue;
   queryClient: ReturnType<typeof useQueryClient>;
   formatNoFileFoundMessage: (token: string) => string;
@@ -183,8 +199,9 @@ function openAssistantFileLink(input: {
   });
 
   const run = async () => {
+    let target: InlinePathTarget;
     try {
-      const target = await input.queryClient.fetchQuery({
+      target = await input.queryClient.fetchQuery({
         queryKey: capturedQueryKey,
         queryFn: () =>
           fetchDaemonResolution({
@@ -197,13 +214,6 @@ function openAssistantFileLink(input: {
         retry: 0,
         staleTime: Infinity,
       });
-      await dispatchFileTarget({
-        target,
-        disposition: input.disposition,
-        capturedServerId: capturedConfig.serverId,
-        capturedWorkspaceRoot: capturedConfig.workspaceRoot,
-        context: input.context,
-      });
     } catch (error) {
       await dispatchUnresolvedError({
         error,
@@ -212,7 +222,15 @@ function openAssistantFileLink(input: {
         capturedWorkspaceRoot: capturedConfig.workspaceRoot,
         context: input.context,
       });
+      return;
     }
+    await dispatchFileTarget({
+      target,
+      disposition: input.disposition,
+      capturedServerId: capturedConfig.serverId,
+      capturedWorkspaceRoot: capturedConfig.workspaceRoot,
+      context: input.context,
+    });
   };
 
   void run();
@@ -257,7 +275,7 @@ function assistantFileLinkQueryKey(input: {
 
 async function dispatchResolvedLink(input: {
   resolution: Extract<AssistantFileLinkResolution, { kind: "resolved" }>;
-  disposition: OpenFileDisposition;
+  disposition: AssistantFileLinkDisposition;
   capturedServerId?: string;
   capturedWorkspaceRoot?: string;
   context: AssistantFileLinkResolverContextValue;
@@ -285,7 +303,7 @@ async function dispatchResolvedLink(input: {
 
 async function dispatchFileTarget(input: {
   target: InlinePathTarget;
-  disposition: OpenFileDisposition;
+  disposition: AssistantFileLinkDisposition;
   capturedServerId?: string;
   capturedWorkspaceRoot?: string;
   context: AssistantFileLinkResolverContextValue;
@@ -295,6 +313,19 @@ async function dispatchFileTarget(input: {
     current.serverId !== input.capturedServerId ||
     current.workspaceRoot !== input.capturedWorkspaceRoot
   ) {
+    return;
+  }
+  if (input.disposition === "preferred-target") {
+    try {
+      const handled = await current.onOpenWorkspaceFileInPreferredTarget?.(input.target);
+      if (handled) {
+        return;
+      }
+    } catch (error) {
+      current.toast?.error(error instanceof Error ? error.message : "Failed to open file");
+      return;
+    }
+    current.onOpenWorkspaceFile?.(input.target, "side");
     return;
   }
   current.onOpenWorkspaceFile?.(input.target, input.disposition);

--- a/packages/app/src/workspace/use-preferred-file-open-target.ts
+++ b/packages/app/src/workspace/use-preferred-file-open-target.ts
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import { useCheckoutPrStatusQuery } from "@/git/use-pr-status-query";
+import { useCheckoutStatusQuery } from "@/git/use-status-query";
+import { useIsLocalDaemon } from "@/hooks/use-is-local-daemon";
+import { resolvePreferredEditorId, usePreferredEditor } from "@/hooks/use-preferred-editor";
+import { useStableEvent } from "@/hooks/use-stable-event";
+import { isWeb } from "@/constants/platform";
+import { isAbsolutePath } from "@/utils/path";
+import { openExternalUrl } from "@/utils/open-external-url";
+import { openDesktopTarget, useDesktopOpenTargets } from "@/workspace/desktop-open-targets";
+import type { WorkspaceFileLocation } from "@/workspace/file-open";
+import {
+  planWorkspaceOpenTargets,
+  type PlannedWorkspaceOpenTarget,
+} from "@/workspace/open-target-planner";
+
+export function resolvePreferredWorkspaceOpenTarget(
+  targets: readonly PlannedWorkspaceOpenTarget[],
+  preferredTargetId: string | null | undefined,
+): PlannedWorkspaceOpenTarget | null {
+  const targetId = resolvePreferredEditorId(
+    targets.map((target) => target.id),
+    preferredTargetId,
+  );
+  return targets.find((target) => target.id === targetId) ?? null;
+}
+
+export function usePreferredFileOpenTarget(input: {
+  serverId: string;
+  workspaceDirectory: string;
+}): (file: WorkspaceFileLocation) => Promise<boolean> {
+  const canResolveWorkspace =
+    isWeb &&
+    input.serverId.trim().length > 0 &&
+    input.workspaceDirectory.trim().length > 0 &&
+    isAbsolutePath(input.workspaceDirectory);
+  const isLocalDaemon = useIsLocalDaemon(input.serverId);
+  const { preferredEditorId } = usePreferredEditor();
+  const { targets: desktopOpenTargets, isAvailable: isDesktopOpenAvailable } =
+    useDesktopOpenTargets({
+      isLocalExecution: isLocalDaemon,
+    });
+  const { status: checkoutStatus } = useCheckoutStatusQuery({
+    serverId: input.serverId,
+    cwd: canResolveWorkspace ? input.workspaceDirectory : "",
+  });
+  const { resolvedForge } = useCheckoutPrStatusQuery({
+    serverId: input.serverId,
+    cwd: canResolveWorkspace ? input.workspaceDirectory : "",
+  });
+
+  const planningContext = useMemo(
+    () => ({
+      workspaceDirectory: input.workspaceDirectory,
+      desktopTargets: desktopOpenTargets,
+      canUseDesktopBridge: isDesktopOpenAvailable,
+      isLocalExecution: isLocalDaemon,
+      checkoutStatus,
+      forge: resolvedForge,
+    }),
+    [
+      checkoutStatus,
+      desktopOpenTargets,
+      input.workspaceDirectory,
+      isDesktopOpenAvailable,
+      isLocalDaemon,
+      resolvedForge,
+    ],
+  );
+
+  return useStableEvent(async (file: WorkspaceFileLocation) => {
+    if (!canResolveWorkspace) {
+      return false;
+    }
+    const target = resolvePreferredWorkspaceOpenTarget(
+      planWorkspaceOpenTargets({
+        ...planningContext,
+        activeFile: file,
+      }),
+      preferredEditorId,
+    );
+    if (!target) {
+      return false;
+    }
+    if (target.source === "desktop") {
+      await openDesktopTarget(target.openInput);
+    } else {
+      await openExternalUrl(target.url);
+    }
+    return true;
+  });
+}

--- a/packages/desktop/e2e/open-in-editor.spec.ts
+++ b/packages/desktop/e2e/open-in-editor.spec.ts
@@ -1,8 +1,10 @@
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { expect, test, type Page } from "../../app/e2e/support/fixtures";
 import { gotoAppShell, openSettings } from "../../app/e2e/support/helpers/app";
 import { installDesktopRuntime } from "./support/runtime";
 import { clickSettingsBackToWorkspace } from "../../app/e2e/support/helpers/settings";
+import { openAgentRoute, seedMockAgentWorkspace } from "../../app/e2e/support/helpers/mock-agent";
 
 interface EditorOpenRecord {
   editorId: string;
@@ -66,6 +68,67 @@ async function expectEditorOpened(input: {
 }
 
 test.describe("Workspace open in editor", () => {
+  test("opens a Ctrl-clicked assistant file link in the selected target", async ({ page }) => {
+    test.setTimeout(90_000);
+
+    const serverId = requireE2EEnv("E2E_SERVER_ID");
+    const recordPath = requireE2EEnv("E2E_EDITOR_RECORD_PATH");
+    await rm(recordPath, { force: true });
+    await installDesktopRuntime(page, {
+      serverId,
+      editorTargets: [
+        {
+          id: "cursor",
+          label: "Cursor",
+          kind: "editor",
+          icon: { kind: "symbol", name: "terminal" },
+        },
+        {
+          id: "vscode",
+          label: "VS Code",
+          kind: "editor",
+          icon: { kind: "symbol", name: "terminal" },
+        },
+      ],
+      editorRecordPath: recordPath,
+    });
+    const target = "target.ts:42";
+    const session = await seedMockAgentWorkspace({
+      repoPrefix: "desktop-assistant-file-link-",
+      title: "Desktop assistant file link",
+      initialPrompt: [
+        "Generate a title and a git branch name for a coding agent from the user prompt and attachments.",
+        "Return JSON only with fields 'title' and 'branch'.",
+        "",
+        "<user-prompt>",
+        `Open \`${target}\` now`,
+        "</user-prompt>",
+      ].join("\n"),
+    });
+    await writeFile(path.join(session.cwd, "target.ts"), "export const target = true;\n", "utf8");
+
+    try {
+      await openAgentRoute(page, session);
+      await chooseEditorTarget(page, "vscode");
+      const recordCount = (await readEditorOpenRecords(recordPath)).length;
+      const fileLink = page.getByText(target, { exact: true });
+      await expect(fileLink).toBeVisible({ timeout: 15_000 });
+
+      await fileLink.click({ modifiers: ["Control"] });
+
+      await expect
+        .poll(async () => (await readEditorOpenRecords(recordPath)).slice(recordCount))
+        .toContainEqual({
+          editorId: "vscode",
+          workspacePath: session.cwd,
+          filePath: path.join(session.cwd, "target.ts"),
+          line: 42,
+        });
+    } finally {
+      await session.cleanup();
+    }
+  });
+
   test("keeps the selected editor target after leaving and returning to the workspace", async ({
     page,
     withWorkspace,

--- a/packages/desktop/src/features/editor-targets/registry.test.ts
+++ b/packages/desktop/src/features/editor-targets/registry.test.ts
@@ -175,7 +175,7 @@ describe("editor target registry", () => {
       { command: "/bin/zeditor", args: ["/repo", "/repo/src/app.ts:7:2"] },
       {
         command: "/bin/webstorm",
-        args: ["--line", "7", "--column", "2", "/repo", "/repo/src/app.ts"],
+        args: ["/repo", "--line", "7", "--column", "2", "/repo/src/app.ts"],
       },
       { command: "/bin/idea", args: ["/repo"] },
     ]);

--- a/packages/desktop/src/features/editor-targets/targets/webstorm.ts
+++ b/packages/desktop/src/features/editor-targets/targets/webstorm.ts
@@ -22,10 +22,10 @@ export const webstormTarget: EditorTarget = {
       await runtime.spawnDetached({ command, args: [input.workspacePath] });
       return;
     }
-    const args: string[] = [];
+    const args: string[] = [input.workspacePath];
     if (input.line) args.push("--line", String(input.line));
     if (input.column) args.push("--column", String(input.column));
-    args.push(input.workspacePath, input.filePath);
+    args.push(input.filePath);
     await runtime.spawnDetached({ command, args });
   },
 };


### PR DESCRIPTION
Hey, I've forked paseo to expand with a few features I need for my own setup, and correct some bugs that bugged me.

I'm having my agent create this PR, in case there is any interest in merging it.

Purpose: Allow you to Ctrl+Click on link to open in your editor instead of Paseo tab (like T3 Code)

The rest of the text is AI generated.

---

## Summary

This adds a modified-click path for assistant file links. Ctrl-click, or Cmd-click on macOS, resolves the link and opens the file in the currently selected file-aware workspace target.

The change:

- reuses the existing target planner for installed editors, platform file managers, and supported forges;
- forwards file paths and referenced line positions to editor targets;
- reveals individual files in Finder, Explorer, or Files;
- opens forge blob URLs for repository files;
- falls back to Paseo's side pane when no external target can handle the workspace;
- fixes WebStorm argument ordering so line and column options apply to the file rather than the workspace directory.

## Why

Assistant responses frequently reference exact source locations. Opening those links inside Paseo is useful for inspection, but desktop users often want to continue in their selected editor or another configured Open target. Reusing the existing preference and target planner keeps that gesture consistent with the workspace header and avoids a second editor-selection setting.

## Verification

- `npx vitest run packages/app/src/assistant-file-links/use-file-link.test.tsx packages/app/src/workspace/open-target-planner.test.ts packages/desktop/src/features/editor-targets/registry.test.ts --bail=1` (26 passed)
- `npm run test:e2e:renderer --workspace=@getpaseo/desktop -- open-in-editor.spec.ts` (2 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

All verification ran on the isolated one-commit PR branch rebased onto current `upstream/main`.
