### PR TITLE
Add compact project workspace indicators

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -385,16 +385,17 @@ One file per schedule. ID is 8 hex characters.
 
 ### Nested: ScheduleRun
 
-| Field          | Type                                   | Description             |
-| -------------- | -------------------------------------- | ----------------------- |
-| `id`           | `string`                               | Run ID                  |
-| `scheduledFor` | `string` (ISO 8601)                    | Intended execution time |
-| `startedAt`    | `string` (ISO 8601)                    |                         |
-| `endedAt`      | `string?` (ISO 8601)                   |                         |
-| `status`       | `"running" \| "succeeded" \| "failed"` |                         |
-| `agentId`      | `string?` (UUID)                       | Agent used for this run |
-| `output`       | `string?`                              | Agent output text       |
-| `error`        | `string?`                              | Error message if failed |
+| Field          | Type                                   | Description                    |
+| -------------- | -------------------------------------- | ------------------------------ |
+| `id`           | `string`                               | Run ID                         |
+| `scheduledFor` | `string` (ISO 8601)                    | Intended execution time        |
+| `startedAt`    | `string` (ISO 8601)                    |                                |
+| `endedAt`      | `string?` (ISO 8601)                   |                                |
+| `status`       | `"running" \| "succeeded" \| "failed"` |                                |
+| `agentId`      | `string?` (UUID)                       | Agent used for this run        |
+| `workspaceId`  | `string?`                              | Workspace created for this run |
+| `output`       | `string?`                              | Agent output text              |
+| `error`        | `string?`                              | Error message if failed        |
 
 ---
 
@@ -458,6 +459,7 @@ Array of workspace records. A workspace is a specific working directory within a
 | `autoArchivedChangeRequestUrl` | `string \| null`                                | Change request whose merged state triggered auto-archive. Restore replaces it with the current merged change request, when present, so repeated snapshots cannot archive the workspace again. |
 | `labels`                       | `string[]?`                                     | Normalized display names assigned from this host's shared label catalog. Missing means unlabelled.                                                                                            |
 | `pinnedAt`                     | `string \| null` (ISO 8601)                     | Pinned-to-top-of-sidebar timestamp; null means "not pinned"                                                                                                                                   |
+| `scheduleId`                   | `string?`                                       | Schedule that created the workspace. Startup reconciliation restores this from retained run history for records written before the field existed.                                             |
 
 > **Opaque-ID invariant:** `workspaceId` is opaque identity, never a filesystem path. Filesystem and git operations take `cwd`/`workspaceDirectory` only — never the id. A compatibility-only first-materialization bootstrap still groups pre-registry agent records by path and Git remote so existing installs retain their legacy records. That grouping never runs against a live registry, and its keys are not runtime project or workspace identity.
 

--- a/packages/app/e2e/browser/sidebar-workspace.spec.ts
+++ b/packages/app/e2e/browser/sidebar-workspace.spec.ts
@@ -6,12 +6,37 @@ import {
   expectMobileAgentSidebarHidden,
   expectMobileAgentSidebarVisible,
   openMobileAgentSidebar,
+  openSidebarDisplayPage,
   pinWorkspaceFromSidebar,
 } from "../support/helpers/sidebar";
 import { seedWorkspace } from "../support/helpers/seed-client";
 import { expectWorkspaceHeader } from "../support/helpers/workspace-ui";
 import { getServerId } from "../support/helpers/server-id";
 import { projectEquivalenceViewKey } from "../support/helpers/project-view-key";
+
+interface SidebarScheduleClient {
+  scheduleCreate(input: {
+    prompt: string;
+    cadence: { type: "cron"; expression: string };
+    target: {
+      type: "new-agent";
+      config: {
+        provider: "mock";
+        cwd: string;
+        model: string;
+        modeId: string;
+        archiveOnFinish: false;
+        isolation: "local";
+      };
+    };
+    runOnCreate: false;
+  }): Promise<{ schedule: { id: string } | null; error: string | null }>;
+  scheduleRunOnce(input: { id: string }): Promise<{
+    schedule: { runs: Array<{ workspaceId?: string | null }> } | null;
+    error: string | null;
+  }>;
+  scheduleDelete(input: { id: string }): Promise<{ error: string | null }>;
+}
 import { escapeRegex } from "../support/helpers/regex";
 import { openFilesPanel } from "../support/helpers/workspace-tabs";
 
@@ -115,6 +140,119 @@ test.describe("Sidebar workspace list", () => {
       await expect(projectRow).not.toContainText("test-owner/test-repo");
     } finally {
       await workspace.cleanup();
+    }
+  });
+
+  test("compact project rows expose workspace status targets without child rows", async ({
+    page,
+  }) => {
+    const seeded = await seedWorkspace({ repoPrefix: "sidebar-compact-workspaces-" });
+    const created = await seeded.client.createWorkspace({
+      source: {
+        kind: "directory",
+        path: seeded.repoPath,
+        projectId: seeded.projectId,
+      },
+      title: "Compact target",
+    });
+    if (!created.workspace) throw new Error(created.error ?? "Failed to create workspace");
+    const scheduleClient = seeded.client as unknown as SidebarScheduleClient;
+    const scheduleResult = await scheduleClient.scheduleCreate({
+      prompt: "Nightly sync",
+      cadence: { type: "cron", expression: "0 9 * * *" },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "mock",
+          cwd: seeded.repoPath,
+          model: "e2e-fast-stream",
+          modeId: "load-test",
+          archiveOnFinish: false,
+          isolation: "local",
+        },
+      },
+      runOnCreate: false,
+    });
+    if (!scheduleResult.schedule) {
+      throw new Error(scheduleResult.error ?? "Failed to create compact workspace schedule");
+    }
+    const scheduleId = scheduleResult.schedule.id;
+    const scheduleWorkspaceIds: string[] = [];
+    for (let runIndex = 0; runIndex < 2; runIndex += 1) {
+      const runResult = await scheduleClient.scheduleRunOnce({ id: scheduleId });
+      const workspaceId = runResult.schedule?.runs.at(-1)?.workspaceId;
+      if (!workspaceId) throw new Error(runResult.error ?? "Scheduled run has no workspace");
+      scheduleWorkspaceIds.push(workspaceId);
+    }
+    const [firstScheduleWorkspaceId, secondScheduleWorkspaceId] = scheduleWorkspaceIds;
+
+    try {
+      await gotoAppShell(page);
+      const serverId = getServerId();
+      const projectViewKey = projectEquivalenceViewKey(seeded.projectKey);
+      const projectRow = page.getByTestId(`sidebar-project-row-${projectViewKey}`);
+      const firstRow = page.getByTestId(getWorkspaceRowTestId(seeded.workspaceId));
+      const secondRow = page.getByTestId(getWorkspaceRowTestId(created.workspace.id));
+      const firstScheduleRow = page.getByTestId(getWorkspaceRowTestId(firstScheduleWorkspaceId));
+      const secondScheduleRow = page.getByTestId(getWorkspaceRowTestId(secondScheduleWorkspaceId));
+      const workTarget = page.getByTestId(
+        `sidebar-project-workspace-target-project:${projectViewKey}:work`,
+      );
+      const scheduleTarget = page.getByTestId(
+        `sidebar-project-workspace-target-project:${projectViewKey}:schedule`,
+      );
+
+      await expect(firstRow).toBeVisible({ timeout: 30_000 });
+      await expect(secondRow).toBeVisible({ timeout: 30_000 });
+      await expect(firstScheduleRow).toBeVisible({ timeout: 30_000 });
+      await expect(secondScheduleRow).toBeVisible({ timeout: 30_000 });
+      await openSidebarDisplayPage(page, "sidebar-display-project-workspaces");
+      await page.getByTestId("sidebar-project-workspace-display-compact").click();
+      await page.keyboard.press("Escape");
+
+      await expect(firstRow).toHaveCount(0);
+      await expect(secondRow).toHaveCount(0);
+      await expect(firstScheduleRow).toHaveCount(0);
+      await expect(secondScheduleRow).toHaveCount(0);
+      await expect(workTarget).toHaveCount(1);
+      await expect(scheduleTarget).toHaveCount(1);
+      await expect(
+        page.getByTestId(
+          `sidebar-project-workspace-target-${serverId}:${firstScheduleWorkspaceId}`,
+        ),
+      ).toHaveCount(0);
+
+      await workTarget.hover();
+      await expect(
+        page.getByTestId(`sidebar-project-workspace-tooltip-project:${projectViewKey}:work`),
+      ).toHaveText("Compact target");
+
+      await scheduleTarget.hover();
+      await expect(
+        page.getByTestId(`sidebar-project-workspace-tooltip-project:${projectViewKey}:schedule`),
+      ).toHaveText("Nightly sync");
+
+      await projectRow.click();
+      await expect(firstRow).toHaveCount(0);
+      await expect(secondRow).toHaveCount(0);
+      await expect(firstScheduleRow).toHaveCount(0);
+      await expect(secondScheduleRow).toHaveCount(0);
+
+      await workTarget.click();
+      await expectWorkspaceHeader(page, {
+        title: "Compact target",
+        subtitle: path.basename(seeded.repoPath),
+      });
+
+      await page.reload();
+      await expect(firstRow).toHaveCount(0);
+      await expect(secondRow).toHaveCount(0);
+      await expect(workTarget).toBeVisible({ timeout: 30_000 });
+      await expect(workTarget).toHaveCount(1);
+      await expect(scheduleTarget).toHaveCount(1);
+    } finally {
+      await scheduleClient.scheduleDelete({ id: scheduleId }).catch(() => undefined);
+      await seeded.cleanup();
     }
   });
 

--- a/packages/app/e2e/browser/sidebar-workspace.spec.ts
+++ b/packages/app/e2e/browser/sidebar-workspace.spec.ts
@@ -3,40 +3,21 @@ import { test, expect } from "../support/fixtures";
 import { gotoAppShell } from "../support/helpers/app";
 import {
   closeMobileAgentSidebar,
+  compactProjectWorkspaceTarget,
+  expectCompactProjectWorkspaceTargets,
+  expectCompactProjectWorkspaceTooltip,
   expectMobileAgentSidebarHidden,
   expectMobileAgentSidebarVisible,
+  expectSidebarWorkspaceRows,
   openMobileAgentSidebar,
-  openSidebarDisplayPage,
   pinWorkspaceFromSidebar,
+  selectSidebarProjectWorkspaceDisplay,
 } from "../support/helpers/sidebar";
+import { seedCompactProjectWorkspaces } from "../support/helpers/sidebar-compact-workspaces";
 import { seedWorkspace } from "../support/helpers/seed-client";
 import { expectWorkspaceHeader } from "../support/helpers/workspace-ui";
 import { getServerId } from "../support/helpers/server-id";
 import { projectEquivalenceViewKey } from "../support/helpers/project-view-key";
-
-interface SidebarScheduleClient {
-  scheduleCreate(input: {
-    prompt: string;
-    cadence: { type: "cron"; expression: string };
-    target: {
-      type: "new-agent";
-      config: {
-        provider: "mock";
-        cwd: string;
-        model: string;
-        modeId: string;
-        archiveOnFinish: false;
-        isolation: "local";
-      };
-    };
-    runOnCreate: false;
-  }): Promise<{ schedule: { id: string } | null; error: string | null }>;
-  scheduleRunOnce(input: { id: string }): Promise<{
-    schedule: { runs: Array<{ workspaceId?: string | null }> } | null;
-    error: string | null;
-  }>;
-  scheduleDelete(input: { id: string }): Promise<{ error: string | null }>;
-}
 import { escapeRegex } from "../support/helpers/regex";
 import { openFilesPanel } from "../support/helpers/workspace-tabs";
 
@@ -146,113 +127,38 @@ test.describe("Sidebar workspace list", () => {
   test("compact project rows expose workspace status targets without child rows", async ({
     page,
   }) => {
-    const seeded = await seedWorkspace({ repoPrefix: "sidebar-compact-workspaces-" });
-    const created = await seeded.client.createWorkspace({
-      source: {
-        kind: "directory",
-        path: seeded.repoPath,
-        projectId: seeded.projectId,
-      },
-      title: "Compact target",
-    });
-    if (!created.workspace) throw new Error(created.error ?? "Failed to create workspace");
-    const scheduleClient = seeded.client as unknown as SidebarScheduleClient;
-    const scheduleResult = await scheduleClient.scheduleCreate({
-      prompt: "Nightly sync",
-      cadence: { type: "cron", expression: "0 9 * * *" },
-      target: {
-        type: "new-agent",
-        config: {
-          provider: "mock",
-          cwd: seeded.repoPath,
-          model: "e2e-fast-stream",
-          modeId: "load-test",
-          archiveOnFinish: false,
-          isolation: "local",
-        },
-      },
-      runOnCreate: false,
-    });
-    if (!scheduleResult.schedule) {
-      throw new Error(scheduleResult.error ?? "Failed to create compact workspace schedule");
-    }
-    const scheduleId = scheduleResult.schedule.id;
-    const scheduleWorkspaceIds: string[] = [];
-    for (let runIndex = 0; runIndex < 2; runIndex += 1) {
-      const runResult = await scheduleClient.scheduleRunOnce({ id: scheduleId });
-      const workspaceId = runResult.schedule?.runs.at(-1)?.workspaceId;
-      if (!workspaceId) throw new Error(runResult.error ?? "Scheduled run has no workspace");
-      scheduleWorkspaceIds.push(workspaceId);
-    }
-    const [firstScheduleWorkspaceId, secondScheduleWorkspaceId] = scheduleWorkspaceIds;
+    const project = await seedCompactProjectWorkspaces();
 
     try {
       await gotoAppShell(page);
-      const serverId = getServerId();
-      const projectViewKey = projectEquivalenceViewKey(seeded.projectKey);
-      const projectRow = page.getByTestId(`sidebar-project-row-${projectViewKey}`);
-      const firstRow = page.getByTestId(getWorkspaceRowTestId(seeded.workspaceId));
-      const secondRow = page.getByTestId(getWorkspaceRowTestId(created.workspace.id));
-      const firstScheduleRow = page.getByTestId(getWorkspaceRowTestId(firstScheduleWorkspaceId));
-      const secondScheduleRow = page.getByTestId(getWorkspaceRowTestId(secondScheduleWorkspaceId));
-      const workTarget = page.getByTestId(
-        `sidebar-project-workspace-target-project:${projectViewKey}:work`,
-      );
-      const scheduleTarget = page.getByTestId(
-        `sidebar-project-workspace-target-project:${projectViewKey}:schedule`,
-      );
+      await expectSidebarWorkspaceRows(page, project.workspaceIds);
+      await selectSidebarProjectWorkspaceDisplay(page, "compact");
+      await expectCompactProjectWorkspaceTargets(page, project);
 
-      await expect(firstRow).toBeVisible({ timeout: 30_000 });
-      await expect(secondRow).toBeVisible({ timeout: 30_000 });
-      await expect(firstScheduleRow).toBeVisible({ timeout: 30_000 });
-      await expect(secondScheduleRow).toBeVisible({ timeout: 30_000 });
-      await openSidebarDisplayPage(page, "sidebar-display-project-workspaces");
-      await page.getByTestId("sidebar-project-workspace-display-compact").click();
-      await page.keyboard.press("Escape");
+      await expectCompactProjectWorkspaceTooltip(page, {
+        projectViewKey: project.projectViewKey,
+        kind: "work",
+        title: "Compact target",
+      });
+      await expectCompactProjectWorkspaceTooltip(page, {
+        projectViewKey: project.projectViewKey,
+        kind: "schedule",
+        title: "Nightly sync",
+      });
 
-      await expect(firstRow).toHaveCount(0);
-      await expect(secondRow).toHaveCount(0);
-      await expect(firstScheduleRow).toHaveCount(0);
-      await expect(secondScheduleRow).toHaveCount(0);
-      await expect(workTarget).toHaveCount(1);
-      await expect(scheduleTarget).toHaveCount(1);
-      await expect(
-        page.getByTestId(
-          `sidebar-project-workspace-target-${serverId}:${firstScheduleWorkspaceId}`,
-        ),
-      ).toHaveCount(0);
+      await page.getByTestId(`sidebar-project-row-${project.projectViewKey}`).click();
+      await expectCompactProjectWorkspaceTargets(page, project);
 
-      await workTarget.hover();
-      await expect(
-        page.getByTestId(`sidebar-project-workspace-tooltip-project:${projectViewKey}:work`),
-      ).toHaveText("Compact target");
-
-      await scheduleTarget.hover();
-      await expect(
-        page.getByTestId(`sidebar-project-workspace-tooltip-project:${projectViewKey}:schedule`),
-      ).toHaveText("Nightly sync");
-
-      await projectRow.click();
-      await expect(firstRow).toHaveCount(0);
-      await expect(secondRow).toHaveCount(0);
-      await expect(firstScheduleRow).toHaveCount(0);
-      await expect(secondScheduleRow).toHaveCount(0);
-
-      await workTarget.click();
+      await compactProjectWorkspaceTarget(page, project.projectViewKey, "work").click();
       await expectWorkspaceHeader(page, {
         title: "Compact target",
-        subtitle: path.basename(seeded.repoPath),
+        subtitle: path.basename(project.repoPath),
       });
 
       await page.reload();
-      await expect(firstRow).toHaveCount(0);
-      await expect(secondRow).toHaveCount(0);
-      await expect(workTarget).toBeVisible({ timeout: 30_000 });
-      await expect(workTarget).toHaveCount(1);
-      await expect(scheduleTarget).toHaveCount(1);
+      await expectCompactProjectWorkspaceTargets(page, project);
     } finally {
-      await scheduleClient.scheduleDelete({ id: scheduleId }).catch(() => undefined);
-      await seeded.cleanup();
+      await project.cleanup();
     }
   });
 

--- a/packages/app/e2e/support/helpers/sidebar-compact-workspaces.ts
+++ b/packages/app/e2e/support/helpers/sidebar-compact-workspaces.ts
@@ -1,0 +1,98 @@
+import { seedWorkspace } from "./seed-client";
+import { projectEquivalenceViewKey } from "./project-view-key";
+
+interface SidebarScheduleClient {
+  scheduleCreate(input: {
+    prompt: string;
+    cadence: { type: "cron"; expression: string };
+    target: {
+      type: "new-agent";
+      config: {
+        provider: "mock";
+        cwd: string;
+        model: string;
+        modeId: string;
+        archiveOnFinish: false;
+        isolation: "local";
+      };
+    };
+    runOnCreate: false;
+  }): Promise<{ schedule: { id: string } | null; error: string | null }>;
+  scheduleRunOnce(input: { id: string }): Promise<{
+    schedule: { runs: Array<{ workspaceId?: string | null }> } | null;
+    error: string | null;
+  }>;
+  scheduleDelete(input: { id: string }): Promise<{ error: string | null }>;
+}
+
+export interface CompactProjectWorkspaces {
+  projectViewKey: string;
+  repoPath: string;
+  workspaceIds: string[];
+  cleanup(): Promise<void>;
+}
+
+async function runScheduleOnce(client: SidebarScheduleClient, scheduleId: string): Promise<string> {
+  const runResult = await client.scheduleRunOnce({ id: scheduleId });
+  const workspaceId = runResult.schedule?.runs.at(-1)?.workspaceId;
+  if (!workspaceId) throw new Error(runResult.error ?? "Scheduled run has no workspace");
+  return workspaceId;
+}
+
+/**
+ * Seeds a project with two ordinary workspaces and two retained schedule runs so
+ * compact sidebar mode has both a work target and a schedule target to collapse.
+ */
+export async function seedCompactProjectWorkspaces(): Promise<CompactProjectWorkspaces> {
+  const seeded = await seedWorkspace({ repoPrefix: "sidebar-compact-workspaces-" });
+  try {
+    const created = await seeded.client.createWorkspace({
+      source: {
+        kind: "directory",
+        path: seeded.repoPath,
+        projectId: seeded.projectId,
+      },
+      title: "Compact target",
+    });
+    if (!created.workspace) throw new Error(created.error ?? "Failed to create workspace");
+
+    const scheduleClient = seeded.client as unknown as SidebarScheduleClient;
+    const scheduleResult = await scheduleClient.scheduleCreate({
+      prompt: "Nightly sync",
+      cadence: { type: "cron", expression: "0 9 * * *" },
+      target: {
+        type: "new-agent",
+        config: {
+          provider: "mock",
+          cwd: seeded.repoPath,
+          model: "e2e-fast-stream",
+          modeId: "load-test",
+          archiveOnFinish: false,
+          isolation: "local",
+        },
+      },
+      runOnCreate: false,
+    });
+    if (!scheduleResult.schedule) {
+      throw new Error(scheduleResult.error ?? "Failed to create compact workspace schedule");
+    }
+    const scheduleId = scheduleResult.schedule.id;
+    const scheduleWorkspaceIds = [
+      await runScheduleOnce(scheduleClient, scheduleId),
+      await runScheduleOnce(scheduleClient, scheduleId),
+    ];
+
+    return {
+      projectViewKey: projectEquivalenceViewKey(seeded.projectKey),
+      repoPath: seeded.repoPath,
+      workspaceIds: [seeded.workspaceId, created.workspace.id, ...scheduleWorkspaceIds],
+      cleanup: async () => {
+        await scheduleClient.scheduleDelete({ id: scheduleId }).catch(() => undefined);
+        await seeded.cleanup();
+      },
+    };
+  } catch (error) {
+    await seeded.cleanup();
+    throw error;
+  }
+}

--- a/packages/app/e2e/support/helpers/sidebar.ts
+++ b/packages/app/e2e/support/helpers/sidebar.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { getServerId } from "./server-id";
 
 interface ContextMenuAnchor {
@@ -198,6 +198,64 @@ export async function closeSidebarDisplayPreferences(page: Page): Promise<void> 
 export async function selectSidebarStatusGrouping(page: Page): Promise<void> {
   await openSidebarDisplayPage(page, "sidebar-display-grouping");
   await page.getByTestId("sidebar-grouping-status").click();
+}
+
+export async function selectSidebarProjectWorkspaceDisplay(
+  page: Page,
+  display: "rows" | "compact",
+): Promise<void> {
+  await openSidebarDisplayPage(page, "sidebar-display-project-workspaces");
+  await page.getByTestId(`sidebar-project-workspace-display-${display}`).click();
+  await closeSidebarDisplayPreferences(page);
+}
+
+export function sidebarWorkspaceRow(page: Page, workspaceId: string): Locator {
+  return page.getByTestId(`sidebar-workspace-row-${getServerId()}:${workspaceId}`);
+}
+
+export function compactProjectWorkspaceTarget(
+  page: Page,
+  projectViewKey: string,
+  kind: "work" | "schedule",
+): Locator {
+  return page.getByTestId(`sidebar-project-workspace-target-project:${projectViewKey}:${kind}`);
+}
+
+export async function expectSidebarWorkspaceRows(
+  page: Page,
+  workspaceIds: readonly string[],
+): Promise<void> {
+  for (const workspaceId of workspaceIds) {
+    await expect(sidebarWorkspaceRow(page, workspaceId)).toBeVisible({ timeout: 30_000 });
+  }
+}
+
+export async function expectCompactProjectWorkspaceTargets(
+  page: Page,
+  input: { projectViewKey: string; workspaceIds: readonly string[] },
+): Promise<void> {
+  for (const workspaceId of input.workspaceIds) {
+    await expect(sidebarWorkspaceRow(page, workspaceId)).toHaveCount(0);
+  }
+  await expect(compactProjectWorkspaceTarget(page, input.projectViewKey, "work")).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await expect(compactProjectWorkspaceTarget(page, input.projectViewKey, "schedule")).toHaveCount(
+    1,
+    { timeout: 30_000 },
+  );
+}
+
+export async function expectCompactProjectWorkspaceTooltip(
+  page: Page,
+  input: { projectViewKey: string; kind: "work" | "schedule"; title: string },
+): Promise<void> {
+  await compactProjectWorkspaceTarget(page, input.projectViewKey, input.kind).hover();
+  await expect(
+    page.getByTestId(
+      `sidebar-project-workspace-tooltip-project:${input.projectViewKey}:${input.kind}`,
+    ),
+  ).toHaveText(input.title);
 }
 
 export async function openMobileAgentSidebar(page: Page): Promise<void> {

--- a/packages/app/src/components/sidebar-workspace-list.tsx
+++ b/packages/app/src/components/sidebar-workspace-list.tsx
@@ -103,11 +103,13 @@ import {
   SidebarWorkspaceRowFrame,
   SidebarWorkspaceRowContent,
   SidebarWorkspaceShortcutBadge,
+  WorkspaceStatusIndicator,
   resolveTrailingActionVisibility,
   SidebarWorkspaceTrailingActionBase,
   SidebarWorkspaceTrailingActionOverlay,
   SidebarWorkspaceTrailingActionSlot,
 } from "@/components/sidebar/sidebar-workspace-row-content";
+import { resolveSidebarWorkspacePrimaryLabel } from "@/components/sidebar/sidebar-workspace-title";
 import { useOpenKebabMenuVisibility } from "@/components/sidebar/use-open-kebab-menu-visibility";
 import {
   SidebarFilterEmptyState,
@@ -151,6 +153,15 @@ import type { HostBadgeModel } from "@/hosts/appearance";
 import { useHostBadges } from "@/hosts/use-host-badges";
 import { useSidebarRowItems } from "@/components/sidebar/display-preferences/model";
 import { PullRequestStateIcon } from "@/git/pull-request-state-icon";
+import {
+  buildCompactProjectWorkspaceTargets,
+  type CompactProjectWorkspaceTarget as CompactProjectWorkspaceTargetModel,
+} from "@/components/sidebar/compact-project-workspaces";
+import {
+  useAppSettings,
+  type SidebarProjectWorkspaceDisplay,
+  type WorkspaceTitleSource,
+} from "@/hooks/use-settings";
 
 const workspaceKeyExtractor = (workspace: SidebarWorkspacePlacement) => workspace.workspaceKey;
 
@@ -258,6 +269,9 @@ interface ProjectHeaderRowProps {
   onRemoveProject?: () => void;
   removeProjectStatus?: "idle" | "pending";
   dragHandleProps?: DraggableListDragHandleProps;
+  compactWorkspaces: CompactProjectWorkspaceTargetModel[];
+  creatingWorkspaceIds: ReadonlySet<string>;
+  workspaceTitleSource: WorkspaceTitleSource;
 }
 
 interface WorkspaceRowInnerProps {
@@ -450,6 +464,108 @@ function ProjectRowTrailingActions({
           />
         </View>
       ) : null}
+    </View>
+  );
+}
+
+function CompactWorkspaceTarget({
+  target,
+  isCreating,
+  onWorkspacePress,
+  workspaceTitleSource,
+}: {
+  target: CompactProjectWorkspaceTargetModel;
+  isCreating: boolean;
+  onWorkspacePress?: () => void;
+  workspaceTitleSource: WorkspaceTitleSource;
+}) {
+  const { workspace } = target;
+  const [isHovered, setIsHovered] = useState(false);
+  const workspaceLabel = resolveSidebarWorkspacePrimaryLabel({ workspace, workspaceTitleSource });
+  const accessibilityState = useMemo(() => ({ selected: target.selected }), [target.selected]);
+  const handlePressIn = useCallback((event: GestureResponderEvent) => {
+    event.stopPropagation();
+  }, []);
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      event.stopPropagation();
+      onWorkspacePress?.();
+      navigateToWorkspace({ serverId: workspace.serverId, workspaceId: workspace.workspaceId });
+    },
+    [onWorkspacePress, workspace.serverId, workspace.workspaceId],
+  );
+  const handlePointerEnter = useCallback(() => setIsHovered(true), []);
+  const handlePointerLeave = useCallback(() => setIsHovered(false), []);
+  const targetStyle = useCallback(
+    ({ pressed }: PressableStateCallbackType) => [
+      styles.compactWorkspaceTargetPressable,
+      target.selected && styles.compactWorkspaceTargetSelected,
+      (isHovered || pressed) && styles.compactWorkspaceTargetHovered,
+    ],
+    [isHovered, target.selected],
+  );
+
+  return (
+    <Tooltip delayDuration={200} enabledOnDesktop enabledOnMobile={false}>
+      <TooltipTrigger asChild>
+        <View
+          style={styles.compactWorkspaceTarget}
+          onPointerEnter={handlePointerEnter}
+          onPointerLeave={handlePointerLeave}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={workspaceLabel}
+            accessibilityState={accessibilityState}
+            onPressIn={handlePressIn}
+            onPress={handlePress}
+            style={targetStyle}
+            testID={`sidebar-project-workspace-target-${target.key}`}
+          >
+            <WorkspaceStatusIndicator
+              bucket={target.statusBucket}
+              workspaceKind={workspace.workspaceKind}
+              loading={isCreating}
+            />
+          </Pressable>
+        </View>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="center"
+        offset={6}
+        testID={`sidebar-project-workspace-tooltip-${target.key}`}
+      >
+        <Text style={styles.compactWorkspaceTooltipText}>{workspaceLabel}</Text>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CompactWorkspaceTargets({
+  targets,
+  creatingWorkspaceIds,
+  onWorkspacePress,
+  workspaceTitleSource,
+}: {
+  targets: CompactProjectWorkspaceTargetModel[];
+  creatingWorkspaceIds: ReadonlySet<string>;
+  onWorkspacePress?: () => void;
+  workspaceTitleSource: WorkspaceTitleSource;
+}) {
+  if (targets.length === 0) return null;
+
+  return (
+    <View style={styles.compactWorkspaceTargets}>
+      {targets.map((target) => (
+        <CompactWorkspaceTarget
+          key={target.key}
+          target={target}
+          isCreating={creatingWorkspaceIds.has(target.workspace.workspaceId)}
+          onWorkspacePress={onWorkspacePress}
+          workspaceTitleSource={workspaceTitleSource}
+        />
+      ))}
     </View>
   );
 }
@@ -863,6 +979,9 @@ function ProjectHeaderRow({
   onRemoveProject,
   removeProjectStatus = "idle",
   dragHandleProps,
+  compactWorkspaces,
+  creatingWorkspaceIds,
+  workspaceTitleSource,
 }: ProjectHeaderRowProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
@@ -955,6 +1074,12 @@ function ProjectHeaderRow({
           </Text>
         </View>
       </View>
+      <CompactWorkspaceTargets
+        targets={compactWorkspaces}
+        creatingWorkspaceIds={creatingWorkspaceIds}
+        onWorkspacePress={onWorkspacePress}
+        workspaceTitleSource={workspaceTitleSource}
+      />
       <ProjectRowTrailingActions
         projectViewKey={project.viewKey}
         displayName={displayName}
@@ -1547,6 +1672,8 @@ function ProjectBlock({
   supportsMultiplicityByServerId,
   supportsPinningByServerId,
   onToggleWorkspacePin,
+  projectWorkspaceDisplay,
+  workspaceTitleSource,
 }: {
   project: SidebarProjectEntry;
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
@@ -1572,29 +1699,46 @@ function ProjectBlock({
   supportsMultiplicityByServerId: ReadonlyMap<string, boolean>;
   supportsPinningByServerId: ReadonlyMap<string, boolean>;
   onToggleWorkspacePin: ToggleSidebarWorkspacePin;
+  projectWorkspaceDisplay: SidebarProjectWorkspaceDisplay;
+  workspaceTitleSource: WorkspaceTitleSource;
 }) {
+  const compact = projectWorkspaceDisplay === "compact";
   const {
     visibleItems: visibleWorkspaces,
     expanded: workspacesExpanded,
     canToggle: canToggleWorkspaces,
     toggleExpanded: toggleWorkspacesExpanded,
   } = useLimitedSidebarGroup(project.workspaces);
+  const projectCollapsed = compact || collapsed;
   const rowModel = useMemo(
     () =>
       buildSidebarProjectRowModel({
         project,
-        collapsed,
+        collapsed: projectCollapsed,
         supportsMultiplicityByServerId,
       }),
-    [collapsed, project, supportsMultiplicityByServerId],
+    [project, projectCollapsed, supportsMultiplicityByServerId],
   );
 
   // Collapsed rows hide their workspace rows, so the project row carries the most urgent
   // status among them; expanded rows leave the signal to the child rows themselves.
   const aggregateStatusBucket = useSidebarProjectStatusBucket({
     workspaces: project.workspaces,
-    enabled: collapsed,
+    enabled: collapsed && !compact,
   });
+
+  const compactWorkspaces = useMemo(() => {
+    if (!compact) return [];
+    const entries: SidebarWorkspaceEntry[] = [];
+    for (const workspace of project.workspaces) {
+      const entry = workspaceEntriesByKey.get(workspace.workspaceKey);
+      if (entry) entries.push(entry);
+    }
+    return buildCompactProjectWorkspaceTargets({
+      workspaces: entries,
+      selection: activeWorkspaceSelection,
+    });
+  }, [activeWorkspaceSelection, compact, project.workspaces, workspaceEntriesByKey]);
 
   const active = isProjectSelectedByRoute({
     selection: activeWorkspaceSelection,
@@ -1728,9 +1872,19 @@ function ProjectBlock({
   const handleToggleCollapsed = useCallback(() => {
     onToggleCollapsed(project.viewKey);
   }, [onToggleCollapsed, project.viewKey]);
+  const handleProjectPress = useCallback(() => {
+    if (!compact) {
+      handleToggleCollapsed();
+      return;
+    }
+    const workspace = compactWorkspaces[0]?.workspace;
+    if (!workspace) return;
+    onWorkspacePress?.();
+    navigateToWorkspace({ serverId: workspace.serverId, workspaceId: workspace.workspaceId });
+  }, [compact, compactWorkspaces, handleToggleCollapsed, onWorkspacePress]);
 
   let projectChildren = null;
-  if (!collapsed) {
+  if (!projectCollapsed) {
     if (project.workspaces.length > 0) {
       projectChildren = (
         <>
@@ -1781,8 +1935,8 @@ function ProjectBlock({
         iconDataUri={iconDataUri}
         statusBucket={aggregateStatusBucket}
         selected={false}
-        chevron={rowModel.chevron}
-        onPress={handleToggleCollapsed}
+        chevron={compact ? null : rowModel.chevron}
+        onPress={handleProjectPress}
         worktreeTarget={
           rowModel.trailingAction.kind === "new_workspace" ? rowModel.trailingAction.target : null
         }
@@ -1796,6 +1950,9 @@ function ProjectBlock({
         onRemoveProject={handleRemoveProject}
         removeProjectStatus={isRemovingProject ? "pending" : "idle"}
         dragHandleProps={dragHandleProps}
+        compactWorkspaces={compactWorkspaces}
+        creatingWorkspaceIds={creatingWorkspaceIds}
+        workspaceTitleSource={workspaceTitleSource}
       />
 
       {projectChildren}
@@ -1820,6 +1977,8 @@ function areProjectBlockPropsEqual(previous: ProjectBlockProps, next: ProjectBlo
     previous.supportsMultiplicityByServerId === next.supportsMultiplicityByServerId &&
     previous.supportsPinningByServerId === next.supportsPinningByServerId &&
     previous.onToggleWorkspacePin === next.onToggleWorkspacePin &&
+    previous.projectWorkspaceDisplay === next.projectWorkspaceDisplay &&
+    previous.workspaceTitleSource === next.workspaceTitleSource &&
     previous.parentGestureRef === next.parentGestureRef &&
     previous.onToggleCollapsed === next.onToggleCollapsed &&
     previous.onWorkspacePress === next.onWorkspacePress &&
@@ -2099,6 +2258,9 @@ function ProjectModeList({
   onPinnedWorkspaceReorder: (workspaces: SidebarWorkspacePlacement[]) => void;
 }) {
   const hasActiveHostFilter = useSidebarViewStore((state) => state.hostFilters.length > 0);
+  const {
+    settings: { sidebarProjectWorkspaceDisplay, workspaceTitleSource },
+  } = useAppSettings();
   const [creatingWorkspaceIds, setCreatingWorkspaceIds] = useState<Set<string>>(() => new Set());
   const creatingWorkspaceTimeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
@@ -2296,6 +2458,8 @@ function ProjectModeList({
           supportsMultiplicityByServerId={supportsMultiplicityByServerId}
           supportsPinningByServerId={supportsPinningByServerId}
           onToggleWorkspacePin={onToggleWorkspacePin}
+          projectWorkspaceDisplay={sidebarProjectWorkspaceDisplay}
+          workspaceTitleSource={workspaceTitleSource}
         />
       );
     },
@@ -2308,6 +2472,8 @@ function ProjectModeList({
       supportsMultiplicityByServerId,
       supportsPinningByServerId,
       onToggleWorkspacePin,
+      sidebarProjectWorkspaceDisplay,
+      workspaceTitleSource,
       onWorkspacePress,
       onToggleProjectCollapsed,
       parentGestureRef,
@@ -2591,6 +2757,33 @@ const styles = StyleSheet.create((theme) => ({
     fontWeight: "400",
     minWidth: 0,
     flexShrink: 1,
+  },
+  compactWorkspaceTargets: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 1,
+    flexShrink: 0,
+  },
+  compactWorkspaceTarget: {
+    width: 20,
+    height: 24,
+  },
+  compactWorkspaceTargetPressable: {
+    width: "100%",
+    height: "100%",
+    borderRadius: theme.borderRadius.full,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  compactWorkspaceTargetHovered: {
+    backgroundColor: theme.colors.surface2,
+  },
+  compactWorkspaceTargetSelected: {
+    backgroundColor: theme.colors.surfaceSidebarHover,
+  },
+  compactWorkspaceTooltipText: {
+    color: theme.colors.foreground,
+    fontSize: theme.fontSize.sm,
   },
   projectActionButton: {
     flexDirection: "row",

--- a/packages/app/src/components/sidebar/compact-project-workspaces.test.ts
+++ b/packages/app/src/components/sidebar/compact-project-workspaces.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
+import { buildCompactProjectWorkspaceTargets } from "./compact-project-workspaces";
+
+function workspace(
+  input: Pick<SidebarWorkspaceEntry, "workspaceKey" | "workspaceId"> &
+    Partial<SidebarWorkspaceEntry>,
+): SidebarWorkspaceEntry {
+  return {
+    serverId: "host-a",
+    projectViewKey: "project-a",
+    projectName: "Project A",
+    projectRootPath: "/repo",
+    workspaceDirectory: "/repo",
+    workspaceDirectoryLabel: "repo",
+    projectKind: "git",
+    workspaceKind: "local_checkout",
+    name: input.workspaceId,
+    title: null,
+    currentBranch: "main",
+    statusBucket: "done",
+    statusEnteredAt: null,
+    archivingAt: null,
+    diffStat: null,
+    prHint: null,
+    archiveHasUncommittedChanges: false,
+    archiveUnpushedCommitCount: 0,
+    scripts: [],
+    hasRunningScripts: false,
+    scheduleId: null,
+    ...input,
+  };
+}
+
+describe("compact project workspace targets", () => {
+  it("groups normal workspaces and schedule runs into one target each", () => {
+    const oldWork = workspace({
+      workspaceKey: "host-a:work-old",
+      workspaceId: "work-old",
+      statusEnteredAt: new Date("2026-08-24T10:00:00.000Z"),
+    });
+    const runningWork = workspace({
+      workspaceKey: "host-a:work-new",
+      workspaceId: "work-new",
+      statusBucket: "running",
+      statusEnteredAt: new Date("2026-08-26T10:00:00.000Z"),
+    });
+    const oldRun = workspace({
+      workspaceKey: "host-a:run-old",
+      workspaceId: "run-old",
+      scheduleId: "schedule-1",
+      statusEnteredAt: new Date("2026-08-25T10:00:00.000Z"),
+    });
+    const runningRun = workspace({
+      workspaceKey: "host-a:run-new",
+      workspaceId: "run-new",
+      scheduleId: "schedule-2",
+      statusBucket: "running",
+      statusEnteredAt: new Date("2026-08-26T10:00:00.000Z"),
+    });
+
+    const targets = buildCompactProjectWorkspaceTargets({
+      workspaces: [oldWork, runningWork, oldRun, runningRun],
+      selection: null,
+    });
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({
+      key: "project:project-a:work",
+      workspace: runningWork,
+      statusBucket: "running",
+      selected: false,
+    });
+    expect(targets[1]).toMatchObject({
+      key: "project:project-a:schedule",
+      workspace: runningRun,
+      statusBucket: "running",
+      selected: false,
+    });
+  });
+
+  it("keeps the selected run as the grouped navigation target", () => {
+    const selectedRun = workspace({
+      workspaceKey: "host-a:run-old",
+      workspaceId: "run-old",
+      scheduleId: "schedule-1",
+      statusEnteredAt: new Date("2026-08-25T10:00:00.000Z"),
+    });
+    const runningRun = workspace({
+      workspaceKey: "host-a:run-new",
+      workspaceId: "run-new",
+      scheduleId: "schedule-1",
+      statusBucket: "running",
+      statusEnteredAt: new Date("2026-08-26T10:00:00.000Z"),
+    });
+
+    const [target] = buildCompactProjectWorkspaceTargets({
+      workspaces: [selectedRun, runningRun],
+      selection: { serverId: "host-a", workspaceId: selectedRun.workspaceId },
+    });
+
+    expect(target).toMatchObject({
+      workspace: selectedRun,
+      statusBucket: "running",
+      selected: true,
+    });
+  });
+
+  it("keeps different projects separate", () => {
+    const projectA = workspace({
+      workspaceKey: "host-a:project-a",
+      workspaceId: "project-a",
+    });
+    const projectB = workspace({
+      workspaceKey: "host-a:project-b",
+      workspaceId: "project-b",
+      projectViewKey: "project-b",
+    });
+
+    expect(
+      buildCompactProjectWorkspaceTargets({
+        workspaces: [projectA, projectB],
+        selection: null,
+      }).map((target) => target.key),
+    ).toEqual(["project:project-a:work", "project:project-b:work"]);
+  });
+});

--- a/packages/app/src/components/sidebar/compact-project-workspaces.test.ts
+++ b/packages/app/src/components/sidebar/compact-project-workspaces.test.ts
@@ -79,7 +79,7 @@ describe("compact project workspace targets", () => {
     });
   });
 
-  it("keeps the selected run as the grouped navigation target", () => {
+  it("navigates to the workspace that owns the aggregated status", () => {
     const selectedRun = workspace({
       workspaceKey: "host-a:run-old",
       workspaceId: "run-old",
@@ -96,6 +96,34 @@ describe("compact project workspace targets", () => {
 
     const [target] = buildCompactProjectWorkspaceTargets({
       workspaces: [selectedRun, runningRun],
+      selection: { serverId: "host-a", workspaceId: selectedRun.workspaceId },
+    });
+
+    expect(target).toMatchObject({
+      workspace: runningRun,
+      statusBucket: "running",
+      selected: true,
+    });
+  });
+
+  it("keeps the selected workspace when it owns the aggregated status", () => {
+    const selectedRun = workspace({
+      workspaceKey: "host-a:run-selected",
+      workspaceId: "run-selected",
+      scheduleId: "schedule-1",
+      statusBucket: "running",
+      statusEnteredAt: new Date("2026-08-25T10:00:00.000Z"),
+    });
+    const olderRun = workspace({
+      workspaceKey: "host-a:run-old",
+      workspaceId: "run-old",
+      scheduleId: "schedule-1",
+      statusBucket: "running",
+      statusEnteredAt: new Date("2026-08-24T10:00:00.000Z"),
+    });
+
+    const [target] = buildCompactProjectWorkspaceTargets({
+      workspaces: [selectedRun, olderRun],
       selection: { serverId: "host-a", workspaceId: selectedRun.workspaceId },
     });
 

--- a/packages/app/src/components/sidebar/compact-project-workspaces.ts
+++ b/packages/app/src/components/sidebar/compact-project-workspaces.ts
@@ -1,0 +1,77 @@
+import type { SidebarWorkspaceEntry } from "@/hooks/use-sidebar-workspaces-list";
+import { aggregateSidebarStateBuckets } from "@/utils/sidebar-agent-state";
+
+interface WorkspaceSelection {
+  serverId: string;
+  workspaceId: string;
+}
+
+export interface CompactProjectWorkspaceTarget {
+  key: string;
+  workspace: SidebarWorkspaceEntry;
+  statusBucket: SidebarWorkspaceEntry["statusBucket"];
+  selected: boolean;
+}
+
+interface TargetGroup {
+  key: string;
+  workspaces: SidebarWorkspaceEntry[];
+}
+
+function isSelected(
+  workspace: SidebarWorkspaceEntry,
+  selection: WorkspaceSelection | null,
+): boolean {
+  return (
+    workspace.serverId === selection?.serverId && workspace.workspaceId === selection.workspaceId
+  );
+}
+
+function enteredAt(workspace: SidebarWorkspaceEntry): number {
+  return workspace.statusEnteredAt?.getTime() ?? Number.NEGATIVE_INFINITY;
+}
+
+function pickLatest(workspaces: SidebarWorkspaceEntry[]): SidebarWorkspaceEntry {
+  return workspaces.reduce((latest, workspace) =>
+    enteredAt(workspace) > enteredAt(latest) ? workspace : latest,
+  );
+}
+
+export function buildCompactProjectWorkspaceTargets(input: {
+  workspaces: SidebarWorkspaceEntry[];
+  selection: WorkspaceSelection | null;
+}): CompactProjectWorkspaceTarget[] {
+  const groups = new Map<string, TargetGroup>();
+
+  for (const workspace of input.workspaces) {
+    // Compact mode exposes one work target and one schedule target per project. Rows mode
+    // still exposes every underlying workspace and schedule run.
+    const kind = workspace.scheduleId ? "schedule" : "work";
+    const key = `project:${workspace.projectViewKey}:${kind}`;
+    const group = groups.get(key);
+    if (group) {
+      group.workspaces.push(workspace);
+    } else {
+      groups.set(key, { key, workspaces: [workspace] });
+    }
+  }
+
+  return Array.from(groups.values(), (group) => {
+    const statusBucket = aggregateSidebarStateBuckets(
+      group.workspaces.map((workspace) => workspace.statusBucket),
+    );
+    const selectedWorkspace = group.workspaces.find((workspace) =>
+      isSelected(workspace, input.selection),
+    );
+    const statusCandidates = group.workspaces.filter(
+      (workspace) => workspace.statusBucket === statusBucket,
+    );
+    const workspace = selectedWorkspace ?? pickLatest(statusCandidates);
+    return {
+      key: group.key,
+      workspace,
+      statusBucket,
+      selected: selectedWorkspace !== undefined,
+    };
+  });
+}

--- a/packages/app/src/components/sidebar/compact-project-workspaces.ts
+++ b/packages/app/src/components/sidebar/compact-project-workspaces.ts
@@ -66,7 +66,12 @@ export function buildCompactProjectWorkspaceTargets(input: {
     const statusCandidates = group.workspaces.filter(
       (workspace) => workspace.statusBucket === statusBucket,
     );
-    const workspace = selectedWorkspace ?? pickLatest(statusCandidates);
+    // Compact indicators show one aggregated status; the click target has to be
+    // a workspace that actually has that status, not merely the selected one.
+    const workspace =
+      selectedWorkspace?.statusBucket === statusBucket
+        ? selectedWorkspace
+        : pickLatest(statusCandidates);
     return {
       key: group.key,
       workspace,

--- a/packages/app/src/components/sidebar/display-preferences/menu.tsx
+++ b/packages/app/src/components/sidebar/display-preferences/menu.tsx
@@ -21,6 +21,7 @@ import {
   GitBranch,
   GitPullRequest,
   Globe,
+  List,
   Server,
   Settings2,
   Tag,
@@ -55,6 +56,10 @@ import type { WorkspaceTitleSource } from "@/hooks/use-settings";
 import { SIDEBAR_CHECKS_DISPLAYS, type SidebarChecksDisplay } from "./checks-display";
 import { useSidebarDisplayPreferences, type SidebarTrailingChoice } from "./model";
 import { SIDEBAR_ROW_ITEMS, type SidebarRowItem } from "./row-items";
+import {
+  SIDEBAR_PROJECT_WORKSPACE_DISPLAYS,
+  type SidebarProjectWorkspaceDisplay,
+} from "./project-workspaces";
 import { useWorkspaceLabelProjection } from "@/workspace-labels";
 import { WorkspaceLabelDot } from "@/workspace-labels/swatch";
 import { WorkspaceLabelManagerModal } from "@/workspace-labels/manager-modal";
@@ -96,6 +101,11 @@ const TITLE_SOURCE_ICONS: Record<WorkspaceTitleSource, OptionIcon> = {
   branch: withUnistyles(GitBranch),
 };
 
+const PROJECT_WORKSPACE_DISPLAY_ICONS: Record<SidebarProjectWorkspaceDisplay, OptionIcon> = {
+  rows: withUnistyles(Captions),
+  compact: withUnistyles(List),
+};
+
 // The same marks these things carry on the workspace row itself, so the menu and the row it
 // configures name each item the same way twice.
 const ROW_ITEM_ICONS: Record<SidebarRowItem, OptionIcon> = {
@@ -122,6 +132,8 @@ const TRAILING_ICONS: Record<SidebarTrailingChoice, OptionIcon> = {
 
 const GROUPING_MODES: readonly SidebarGroupMode[] = ["project", "status"];
 const TITLE_SOURCES: readonly WorkspaceTitleSource[] = ["title", "branch"];
+const PROJECT_WORKSPACE_DISPLAYS: readonly SidebarProjectWorkspaceDisplay[] =
+  SIDEBAR_PROJECT_WORKSPACE_DISPLAYS;
 const TRAILING_CHOICES: readonly SidebarTrailingChoice[] = ["diff", "timestamp"];
 
 const GROUPING_LABEL_KEYS: Record<SidebarGroupMode, string> = {
@@ -132,6 +144,11 @@ const GROUPING_LABEL_KEYS: Record<SidebarGroupMode, string> = {
 const TITLE_SOURCE_LABEL_KEYS: Record<WorkspaceTitleSource, string> = {
   title: "sidebar.display.titleSource.title",
   branch: "sidebar.display.titleSource.branch",
+};
+
+const PROJECT_WORKSPACE_DISPLAY_LABEL_KEYS: Record<SidebarProjectWorkspaceDisplay, string> = {
+  rows: "sidebar.display.projectWorkspaces.rows",
+  compact: "sidebar.display.projectWorkspaces.compact",
 };
 
 const ROW_ITEM_LABEL_KEYS: Record<SidebarRowItem, string> = {
@@ -202,6 +219,20 @@ export function SidebarDisplayPreferencesMenu(): ReactElement {
             selectedValue={preferences.grouping}
             onSelect={preferences.setGrouping}
             testIDPrefix="sidebar-grouping"
+          />
+        ),
+      },
+      {
+        id: "projectWorkspaces",
+        title: t("sidebar.display.projectWorkspaces.label"),
+        content: (
+          <OptionList
+            values={PROJECT_WORKSPACE_DISPLAYS}
+            icons={PROJECT_WORKSPACE_DISPLAY_ICONS}
+            labelKeys={PROJECT_WORKSPACE_DISPLAY_LABEL_KEYS}
+            selectedValue={preferences.projectWorkspaceDisplay}
+            onSelect={preferences.setProjectWorkspaceDisplay}
+            testIDPrefix="sidebar-project-workspace-display"
           />
         ),
       },
@@ -307,6 +338,13 @@ export function SidebarDisplayPreferencesMenu(): ReactElement {
             testID="sidebar-display-grouping"
           >
             {t("sidebar.display.grouping.label")}
+          </MenuSubTrigger>
+          <MenuSubTrigger
+            id="projectWorkspaces"
+            value={t(PROJECT_WORKSPACE_DISPLAY_LABEL_KEYS[preferences.projectWorkspaceDisplay])}
+            testID="sidebar-display-project-workspaces"
+          >
+            {t("sidebar.display.projectWorkspaces.label")}
           </MenuSubTrigger>
           <MenuSubTrigger
             id="titleSource"

--- a/packages/app/src/components/sidebar/display-preferences/model.ts
+++ b/packages/app/src/components/sidebar/display-preferences/model.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import {
   useAppSettings,
+  type SidebarProjectWorkspaceDisplay,
   type SidebarWorkspaceTrailing,
   type WorkspaceTitleSource,
 } from "@/hooks/use-settings";
@@ -20,6 +21,8 @@ export interface SidebarDisplayPreferences {
   setGrouping: (mode: SidebarGroupMode) => void;
   titleSource: WorkspaceTitleSource;
   setTitleSource: (source: WorkspaceTitleSource) => void;
+  projectWorkspaceDisplay: SidebarProjectWorkspaceDisplay;
+  setProjectWorkspaceDisplay: (display: SidebarProjectWorkspaceDisplay) => void;
   rowItems: SidebarRowItems;
   toggleRowItem: (item: SidebarRowItem) => void;
   checksDisplay: SidebarChecksDisplay;
@@ -63,6 +66,7 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
   const {
     settings: {
       workspaceTitleSource,
+      sidebarProjectWorkspaceDisplay,
       sidebarWorkspaceTrailing,
       sidebarRowItems,
       sidebarChecksDisplay,
@@ -73,6 +77,13 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
   const setTitleSource = useCallback(
     (source: WorkspaceTitleSource) => {
       void updateSettings({ workspaceTitleSource: source });
+    },
+    [updateSettings],
+  );
+
+  const setProjectWorkspaceDisplay = useCallback(
+    (display: SidebarProjectWorkspaceDisplay) => {
+      void updateSettings({ sidebarProjectWorkspaceDisplay: display });
     },
     [updateSettings],
   );
@@ -108,6 +119,8 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
       setGrouping,
       titleSource: workspaceTitleSource,
       setTitleSource,
+      projectWorkspaceDisplay: sidebarProjectWorkspaceDisplay,
+      setProjectWorkspaceDisplay,
       rowItems: sidebarRowItems,
       toggleRowItem,
       checksDisplay: sidebarChecksDisplay,
@@ -129,6 +142,8 @@ export function useSidebarDisplayPreferences(): SidebarDisplayPreferences {
       setGrouping,
       workspaceTitleSource,
       setTitleSource,
+      sidebarProjectWorkspaceDisplay,
+      setProjectWorkspaceDisplay,
       sidebarRowItems,
       toggleRowItem,
       sidebarChecksDisplay,

--- a/packages/app/src/components/sidebar/display-preferences/project-workspaces.ts
+++ b/packages/app/src/components/sidebar/display-preferences/project-workspaces.ts
@@ -1,0 +1,6 @@
+/** How project groups expose their workspaces in the sidebar. */
+export const SIDEBAR_PROJECT_WORKSPACE_DISPLAYS = ["rows", "compact"] as const;
+
+export type SidebarProjectWorkspaceDisplay = (typeof SIDEBAR_PROJECT_WORKSPACE_DISPLAYS)[number];
+
+export const DEFAULT_SIDEBAR_PROJECT_WORKSPACE_DISPLAY: SidebarProjectWorkspaceDisplay = "rows";

--- a/packages/app/src/components/sidebar/sidebar-model.tsx
+++ b/packages/app/src/components/sidebar/sidebar-model.tsx
@@ -23,6 +23,7 @@ import {
   hasAuthoritativeWorkspaceLabelCatalog,
   useWorkspaceLabelProjection,
 } from "@/workspace-labels";
+import { useAppSettings } from "@/hooks/use-settings";
 
 interface SidebarModel extends SidebarWorkspacesListResult {
   workspaceEntriesByKey: ReadonlyMap<string, SidebarWorkspaceEntry>;
@@ -46,6 +47,7 @@ interface SidebarModel extends SidebarWorkspacesListResult {
 }
 
 const SidebarModelContext = createContext<SidebarModel | null>(null);
+const EMPTY_COLLAPSED_PROJECT_KEYS = new Set<string>();
 
 export function SidebarModelProvider({
   active,
@@ -56,6 +58,9 @@ export function SidebarModelProvider({
 }) {
   const list = useSidebarWorkspacesList({ enabled: active });
   const groupMode = useSidebarViewStore((state) => state.groupMode);
+  const {
+    settings: { sidebarProjectWorkspaceDisplay },
+  } = useAppSettings();
   const labelFilter = useSidebarViewStore((state) => state.labelFilter);
   const projectFilters = useSidebarViewStore((state) => state.projectFilters);
   const reconcileLabelFilter = useSidebarViewStore((state) => state.reconcileLabelFilter);
@@ -148,11 +153,15 @@ export function SidebarModelProvider({
       projectNamesByViewKey: list.projectNamesByViewKey,
       groupMode,
       pinnedCollapsed,
-      collapsedProjectKeys,
+      collapsedProjectKeys:
+        sidebarProjectWorkspaceDisplay === "compact"
+          ? EMPTY_COLLAPSED_PROJECT_KEYS
+          : collapsedProjectKeys,
       collapsedWorkspaceGroupKeys,
     }),
     [
       collapsedProjectKeys,
+      sidebarProjectWorkspaceDisplay,
       collapsedWorkspaceGroupKeys,
       groupMode,
       list.projectNamesByViewKey,

--- a/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
+++ b/packages/app/src/components/sidebar/sidebar-workspace-row-content.tsx
@@ -182,7 +182,7 @@ export const SidebarWorkspaceRowContent = memo(function SidebarWorkspaceRowConte
   );
 });
 
-function WorkspaceStatusIndicator({
+export function WorkspaceStatusIndicator({
   bucket,
   workspaceKind,
   loading = false,

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.test.ts
@@ -89,6 +89,19 @@ describe("createSidebarWorkspaceEntry workspace directory label", () => {
   });
 });
 
+describe("createSidebarWorkspaceEntry schedule metadata", () => {
+  it("threads persisted schedule identity from the workspace", () => {
+    const descriptor = workspaceWithForge(undefined, "https://github.com/acme/repo/pull/42");
+    descriptor.scheduleId = "schedule-1";
+    const entry = createSidebarWorkspaceEntry({
+      serverId: "srv",
+      workspace: descriptor,
+    });
+
+    expect(entry.scheduleId).toBe("schedule-1");
+  });
+});
+
 interface OrderedItem {
   key: string;
 }

--- a/packages/app/src/hooks/sidebar-workspaces-view-model.ts
+++ b/packages/app/src/hooks/sidebar-workspaces-view-model.ts
@@ -52,6 +52,7 @@ export interface SidebarWorkspaceEntry extends SidebarStatusWorkspacePlacement {
   archiveUnpushedCommitCount: number | null;
   scripts: WorkspaceDescriptor["scripts"];
   hasRunningScripts: boolean;
+  scheduleId?: string | null;
 }
 
 export interface SidebarProjectEntry {
@@ -181,6 +182,7 @@ export function createSidebarWorkspaceEntry(input: {
     archiveUnpushedCommitCount: input.workspace.gitRuntime?.aheadOfOrigin ?? null,
     scripts: input.workspace.scripts,
     hasRunningScripts: input.workspace.scripts.some((script) => script.lifecycle === "running"),
+    scheduleId: input.workspace.scheduleId ?? null,
   };
 }
 

--- a/packages/app/src/hooks/use-settings/index.ts
+++ b/packages/app/src/hooks/use-settings/index.ts
@@ -45,6 +45,7 @@ import {
   type ServiceUrlBehavior,
   type Settings,
   type SidebarWorkspaceTrailing,
+  type SidebarProjectWorkspaceDisplay,
   type SettingsDeps,
   type WorkspaceTitleSource,
 } from "./storage";
@@ -83,6 +84,7 @@ export type {
   Settings,
   SettingsDeps,
   SidebarWorkspaceTrailing,
+  SidebarProjectWorkspaceDisplay,
   WorkspaceTitleSource,
 };
 

--- a/packages/app/src/hooks/use-settings/storage.test.ts
+++ b/packages/app/src/hooks/use-settings/storage.test.ts
@@ -177,6 +177,14 @@ describe("loadAppSettingsFromStorage", () => {
     expect(result.workspaceTitleSource).toBe("title");
   });
 
+  it("defaults project workspaces to rows", async () => {
+    const deps = makeDeps();
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.sidebarProjectWorkspaceDisplay).toBe("rows");
+  });
+
   it("enables the chat outline by default", async () => {
     const deps = makeDeps();
 
@@ -282,6 +290,30 @@ describe("loadAppSettingsFromStorage", () => {
     const result = await loadAppSettingsFromStorage(deps);
 
     expect(result.workspaceTitleSource).toBe("title");
+  });
+
+  it("loads compact project workspaces from app settings", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ sidebarProjectWorkspaceDisplay: "compact" }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.sidebarProjectWorkspaceDisplay).toBe("compact");
+  });
+
+  it("drops an unknown project workspace display back to rows", async () => {
+    const deps = makeDeps({
+      storage: createInMemoryKeyValueStorage({
+        [APP_SETTINGS_KEY]: JSON.stringify({ sidebarProjectWorkspaceDisplay: "dense" }),
+      }),
+    });
+
+    const result = await loadAppSettingsFromStorage(deps);
+
+    expect(result.sidebarProjectWorkspaceDisplay).toBe("rows");
   });
 
   it("normalizes terminal scrollback lines from storage", async () => {

--- a/packages/app/src/hooks/use-settings/storage.ts
+++ b/packages/app/src/hooks/use-settings/storage.ts
@@ -12,6 +12,10 @@ import {
   isChecksHiddenByLegacyRowItem,
   type SidebarRowItems,
 } from "@/components/sidebar/display-preferences/row-items";
+import {
+  DEFAULT_SIDEBAR_PROJECT_WORKSPACE_DISPLAY,
+  type SidebarProjectWorkspaceDisplay,
+} from "@/components/sidebar/display-preferences/project-workspaces";
 import { isNative } from "@/constants/platform";
 import {
   FONT_SIZE,
@@ -24,6 +28,7 @@ import { APP_SETTINGS_KEY, LEGACY_SETTINGS_KEY } from "./keys";
 import { migrateAppSettings } from "./migrations";
 
 export { APP_SETTINGS_KEY } from "./keys";
+export type { SidebarProjectWorkspaceDisplay } from "@/components/sidebar/display-preferences/project-workspaces";
 export const APP_SETTINGS_QUERY_KEY = ["app-settings"];
 
 export type SendBehavior = ActiveTurnBehavior | "queue";
@@ -80,6 +85,7 @@ export interface AppSettings {
   syntaxTheme: SyntaxThemeId; // default "one"
   workspaceTitleSource: WorkspaceTitleSource;
   sidebarWorkspaceTrailing: SidebarWorkspaceTrailing;
+  sidebarProjectWorkspaceDisplay: SidebarProjectWorkspaceDisplay;
   sidebarRowItems: SidebarRowItems;
   sidebarChecksDisplay: SidebarChecksDisplay;
   autoExpandReasoning: boolean;
@@ -128,6 +134,7 @@ export const DEFAULT_CLIENT_SETTINGS: AppSettings = {
   syntaxTheme: "one",
   workspaceTitleSource: "title",
   sidebarWorkspaceTrailing: "diff",
+  sidebarProjectWorkspaceDisplay: DEFAULT_SIDEBAR_PROJECT_WORKSPACE_DISPLAY,
   sidebarRowItems: DEFAULT_SIDEBAR_ROW_ITEMS,
   sidebarChecksDisplay: DEFAULT_SIDEBAR_CHECKS_DISPLAY,
   autoExpandReasoning: false,
@@ -213,6 +220,9 @@ const StoredAppSettingsSchema = z
     syntaxTheme: z.string().refine(isSyntaxThemeId).catch("one"),
     workspaceTitleSource: z.enum(["title", "branch"]).catch("title"),
     sidebarWorkspaceTrailing: z.enum(["diff", "timestamp", "none"]).catch("diff"),
+    sidebarProjectWorkspaceDisplay: z
+      .enum(["rows", "compact"])
+      .catch(DEFAULT_SIDEBAR_PROJECT_WORKSPACE_DISPLAY),
     sidebarRowItems: SidebarRowItemsSchema,
     sidebarChecksDisplay: z
       .enum(["iconAndText", "icon", "none"])

--- a/packages/app/src/i18n/resources/ar.ts
+++ b/packages/app/src/i18n/resources/ar.ts
@@ -1038,6 +1038,11 @@ export const ar: TranslationResources = {
         title: "العنوان",
         branch: "اسم الفرع",
       },
+      projectWorkspaces: {
+        label: "مساحات عمل المشروع",
+        rows: "صفوف",
+        compact: "مضغوطة",
+      },
       show: {
         label: "إظهار",
         branch: "الفرع",

--- a/packages/app/src/i18n/resources/en.ts
+++ b/packages/app/src/i18n/resources/en.ts
@@ -1047,6 +1047,11 @@ export const en = {
         title: "Title",
         branch: "Branch name",
       },
+      projectWorkspaces: {
+        label: "Project workspaces",
+        rows: "Rows",
+        compact: "Compact",
+      },
       show: {
         label: "Show",
         branch: "Branch",

--- a/packages/app/src/i18n/resources/es.ts
+++ b/packages/app/src/i18n/resources/es.ts
@@ -1072,6 +1072,11 @@ export const es: TranslationResources = {
         title: "Título",
         branch: "Nombre de rama",
       },
+      projectWorkspaces: {
+        label: "Espacios de trabajo del proyecto",
+        rows: "Filas",
+        compact: "Compactos",
+      },
       show: {
         label: "Mostrar",
         branch: "Rama",

--- a/packages/app/src/i18n/resources/fr.ts
+++ b/packages/app/src/i18n/resources/fr.ts
@@ -1071,6 +1071,11 @@ export const fr: TranslationResources = {
         title: "Titre",
         branch: "Nom de branche",
       },
+      projectWorkspaces: {
+        label: "Espaces de travail du projet",
+        rows: "Lignes",
+        compact: "Compacts",
+      },
       show: {
         label: "Afficher",
         branch: "Branche",

--- a/packages/app/src/i18n/resources/ja.ts
+++ b/packages/app/src/i18n/resources/ja.ts
@@ -1049,6 +1049,11 @@ export const ja: TranslationResources = {
         title: "タイトル",
         branch: "ブランチ名",
       },
+      projectWorkspaces: {
+        label: "プロジェクトのワークスペース",
+        rows: "行",
+        compact: "コンパクト",
+      },
       show: {
         label: "表示項目",
         branch: "ブランチ",

--- a/packages/app/src/i18n/resources/ko.ts
+++ b/packages/app/src/i18n/resources/ko.ts
@@ -1045,6 +1045,11 @@ export const ko: TranslationResources = {
         title: "제목",
         branch: "브랜치 이름",
       },
+      projectWorkspaces: {
+        label: "프로젝트 워크스페이스",
+        rows: "행",
+        compact: "컴팩트",
+      },
       show: {
         label: "표시 항목",
         branch: "브랜치",

--- a/packages/app/src/i18n/resources/pt-BR.ts
+++ b/packages/app/src/i18n/resources/pt-BR.ts
@@ -1063,6 +1063,11 @@ export const ptBR: TranslationResources = {
         title: "Título",
         branch: "Nome da branch",
       },
+      projectWorkspaces: {
+        label: "Espaços de trabalho do projeto",
+        rows: "Linhas",
+        compact: "Compactos",
+      },
       show: {
         label: "Mostrar",
         branch: "Branch",

--- a/packages/app/src/i18n/resources/ru.ts
+++ b/packages/app/src/i18n/resources/ru.ts
@@ -1053,6 +1053,11 @@ export const ru: TranslationResources = {
         title: "Заголовок",
         branch: "Имя ветки",
       },
+      projectWorkspaces: {
+        label: "Рабочие пространства проекта",
+        rows: "Строки",
+        compact: "Компактно",
+      },
       show: {
         label: "Показывать",
         branch: "Ветка",

--- a/packages/app/src/i18n/resources/zh-CN.ts
+++ b/packages/app/src/i18n/resources/zh-CN.ts
@@ -1030,6 +1030,11 @@ export const zhCN: TranslationResources = {
         title: "标题",
         branch: "分支名称",
       },
+      projectWorkspaces: {
+        label: "项目工作区",
+        rows: "行",
+        compact: "紧凑",
+      },
       show: {
         label: "显示",
         branch: "分支",

--- a/packages/app/src/stores/session-store.test.ts
+++ b/packages/app/src/stores/session-store.test.ts
@@ -399,6 +399,28 @@ describe("message submission ordering", () => {
 });
 
 describe("normalizeWorkspaceDescriptor", () => {
+  it("preserves schedule workspace identity", () => {
+    const workspace = normalizeWorkspaceDescriptor({
+      id: "1",
+      projectId: "1",
+      projectDisplayName: "Project 1",
+      projectRootPath: "/repo",
+      workspaceDirectory: "/repo",
+      projectKind: "git",
+      workspaceKind: "checkout",
+      name: "scheduled run",
+      scheduleId: "schedule-1",
+      archivingAt: null,
+      status: "done",
+      statusEnteredAt: null,
+      activityAt: null,
+      diffStat: null,
+      scripts: [],
+    });
+
+    expect(workspace.scheduleId).toBe("schedule-1");
+  });
+
   it("normalizes workspace scripts and invalid activity timestamps", () => {
     const scripts = [
       {

--- a/packages/app/src/stores/session-store.ts
+++ b/packages/app/src/stores/session-store.ts
@@ -118,6 +118,7 @@ export interface WorkspaceDescriptor {
   name: string;
   title?: string | null;
   pinnedAt?: string | null;
+  scheduleId?: string;
   labels?: string[];
   status: WorkspaceDescriptorPayload["status"];
   statusEnteredAt: Date | null;
@@ -155,6 +156,7 @@ export function normalizeWorkspaceDescriptor(
     name: payload.name,
     title: payload.title ?? null,
     pinnedAt: payload.pinnedAt ?? null,
+    scheduleId: payload.scheduleId,
     // COMPAT(workspaceLabels): old daemons omit assignments.
     labels: payload.labels ?? [],
     status: payload.status,

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -3790,6 +3790,8 @@ export const WorkspaceDescriptorPayloadSchema = z
     title: z.string().nullable().optional(),
     // COMPAT(workspacePinning): added in v0.1.107, remove optional after 2027-01-12.
     pinnedAt: z.string().nullable().optional(),
+    // COMPAT(scheduleWorkspaceIdentity): added in v0.6.2, remove optional after 2027-08-27.
+    scheduleId: z.string().optional(),
     // COMPAT(workspaceLabels): added in v0.5.0, remove optional after 2027-08-14.
     labels: z.array(z.string()).optional(),
     archivingAt: z.string().nullable().optional().default(null),

--- a/packages/protocol/src/messages.workspaces.test.ts
+++ b/packages/protocol/src/messages.workspaces.test.ts
@@ -574,6 +574,27 @@ describe("workspace message schemas", () => {
     expect(parsed.worktreeSlug).toBe("feature");
   });
 
+  test("preserves schedule workspace identity and accepts legacy omission", () => {
+    const workspace = {
+      id: "scheduled-workspace",
+      projectId: "project",
+      projectDisplayName: "repo",
+      projectRootPath: "/repo",
+      workspaceDirectory: "/repo",
+      projectKind: "git",
+      workspaceKind: "local_checkout",
+      name: "scheduled run",
+      status: "done",
+      activityAt: null,
+      scripts: [],
+    } as const;
+
+    expect(WorkspaceDescriptorPayloadSchema.parse(workspace).scheduleId).toBeUndefined();
+    expect(
+      WorkspaceDescriptorPayloadSchema.parse({ ...workspace, scheduleId: "schedule-1" }).scheduleId,
+    ).toBe("schedule-1");
+  });
+
   test("defaults omitted workspace archiving state and preserves present timestamps", () => {
     const baseWorkspace = {
       id: "ws-archiving",

--- a/packages/server/src/server/bootstrap.ts
+++ b/packages/server/src/server/bootstrap.ts
@@ -1244,10 +1244,13 @@ export async function createPaseoDaemon(
   const createScheduleLocalWorkspaceExternal = async (input: {
     cwd: string;
     firstAgentContext: FirstAgentContext;
+    scheduleId: string;
   }) => {
     const workspace = await workspaceProvisioning.createWorkspaceForDirectory(
       input.cwd,
       resolveFirstAgentPromptTitle(input.firstAgentContext),
+      undefined,
+      { scheduleId: input.scheduleId },
     );
     workspaceAutoName.scheduleForDirectory({
       workspaceId: workspace.workspaceId,
@@ -1260,10 +1263,12 @@ export async function createPaseoDaemon(
   const createSchedulePaseoWorktreeExternal = async (input: {
     cwd: string;
     firstAgentContext: FirstAgentContext;
+    scheduleId: string;
   }) => {
     const result = await createPaseoWorktreeForTools({
       cwd: input.cwd,
       firstAgentContext: input.firstAgentContext,
+      scheduleId: input.scheduleId,
     });
     await emitWorkspaceUpdatesExternal([result.workspace.workspaceId]);
     return result;
@@ -1310,6 +1315,14 @@ export async function createPaseoDaemon(
     createDirectoryWorkspace: createScheduleLocalWorkspaceExternal,
     createPaseoWorktreeWorkspace: createSchedulePaseoWorktreeExternal,
     archiveWorkspace: archiveScheduleWorkspaceExternal,
+    setWorkspaceScheduleId: async (workspaceId, scheduleId) => {
+      const workspace = await workspaceRegistry.get(workspaceId);
+      if (!workspace || workspace.scheduleId === scheduleId) return;
+      await workspaceRegistry.update(workspaceId, (current) => ({
+        ...current,
+        scheduleId,
+      }));
+    },
   });
   await scheduleService.start();
   agentManager.setAgentArchivedCallback(async (agentId) => {

--- a/packages/server/src/server/paseo-worktree-service.ts
+++ b/packages/server/src/server/paseo-worktree-service.ts
@@ -33,6 +33,7 @@ import { runWithGitCommandPriority } from "../utils/run-git-command.js";
 export interface CreatePaseoWorktreeInput extends CreateWorktreeCoreInput {
   projectId?: string;
   title?: string;
+  scheduleId?: string;
 }
 
 export interface CreatePaseoWorktreeResult {
@@ -100,6 +101,7 @@ async function createPaseoWorktreeWithPriority(
       baseBranch: resolveIntentBaseBranch(createdWorktree.intent),
       title: input.title?.trim() || resolveFirstAgentPromptTitle(input.firstAgentContext),
       expectsInitialAgent: Boolean(input.firstAgentContext),
+      scheduleId: input.scheduleId,
     });
 
     deps.github.invalidate({ cwd: createdWorktree.worktree.worktreePath });

--- a/packages/server/src/server/schedule-run-lifecycle.e2e.test.ts
+++ b/packages/server/src/server/schedule-run-lifecycle.e2e.test.ts
@@ -232,6 +232,9 @@ test("archiveOnFinish=false local scheduled run emits upserts and remains active
 
   expect(workspaceId).toMatch(/^wks_/);
   await waitForWorkspaceUpsert(events.workspaceUpdates, workspaceId!);
+  expect(requireWorkspaceUpsert(events.workspaceUpdates, workspaceId!).scheduleId).toBe(
+    schedule.id,
+  );
   await waitForAgentUpsert(events.agentUpdates, agentId);
   expect(workspaceWasRemoved(events.workspaceUpdates, workspaceId!)).toBe(false);
   expect(await activeAgentIds()).toContain(agentId);

--- a/packages/server/src/server/schedule/service.test.ts
+++ b/packages/server/src/server/schedule/service.test.ts
@@ -78,7 +78,11 @@ let workspaceArchiveInProgress = false;
 
 type TestScheduleServiceOptions = Omit<
   ScheduleServiceOptions,
-  "createAgent" | "createDirectoryWorkspace" | "createPaseoWorktreeWorkspace" | "archiveWorkspace"
+  | "createAgent"
+  | "createDirectoryWorkspace"
+  | "createPaseoWorktreeWorkspace"
+  | "archiveWorkspace"
+  | "setWorkspaceScheduleId"
 > & {
   agentManager: AgentManager;
   providerSnapshotManager: Pick<ProviderSnapshotManager, "resolveCreateConfig">;
@@ -86,6 +90,7 @@ type TestScheduleServiceOptions = Omit<
   createDirectoryWorkspace?: ScheduleServiceOptions["createDirectoryWorkspace"];
   createPaseoWorktreeWorkspace?: ScheduleServiceOptions["createPaseoWorktreeWorkspace"];
   archiveWorkspace?: ScheduleServiceOptions["archiveWorkspace"];
+  setWorkspaceScheduleId?: ScheduleServiceOptions["setWorkspaceScheduleId"];
 };
 
 function createScheduleService(options: TestScheduleServiceOptions): ScheduleService {
@@ -104,6 +109,7 @@ function createScheduleService(options: TestScheduleServiceOptions): ScheduleSer
       kind: "directory",
       displayName: "test-project",
       title: input.firstAgentContext.prompt,
+      scheduleId: input.scheduleId,
       branch: null,
       baseBranch: null,
       createdAt: timestamp,
@@ -185,6 +191,12 @@ function createScheduleService(options: TestScheduleServiceOptions): ScheduleSer
         };
       }),
     archiveWorkspace: options.archiveWorkspace ?? archiveDefaultWorkspace,
+    setWorkspaceScheduleId:
+      options.setWorkspaceScheduleId ??
+      (async (workspaceId, scheduleId) => {
+        const workspace = workspaces.get(workspaceId);
+        if (workspace) workspaces.set(workspaceId, { ...workspace, scheduleId });
+      }),
   });
 }
 
@@ -219,6 +231,8 @@ async function createRegistryBackedScheduleWorkspaceDeps(rootDir: string): Promi
       return workspaceProvisioning.createWorkspaceForDirectory(
         input.cwd,
         input.firstAgentContext.prompt,
+        undefined,
+        { scheduleId: input.scheduleId },
       );
     },
     createArchiveWorkspace:
@@ -631,11 +645,13 @@ describe("ScheduleService", () => {
         workspaceId: firstAgent?.workspaceId,
         cwd: tempDir,
         archivedAt: null,
+        scheduleId: created.id,
       }),
       expect.objectContaining({
         workspaceId: secondAgent?.workspaceId,
         cwd: tempDir,
         archivedAt: null,
+        scheduleId: created.id,
       }),
     ]);
   });
@@ -1898,6 +1914,58 @@ describe("ScheduleService", () => {
 
     const inspected = await service2.inspect(created.id);
     expect(new Date(inspected.nextRunAt!).getTime()).toBeGreaterThan(now.getTime());
+    await service2.stop();
+  });
+
+  test("restores schedule identity on existing run workspaces at startup", async () => {
+    const service1 = createScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: new AgentManager({ logger: createTestLogger() }),
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      now: () => now,
+      runner: async () => ({ agentId: null, output: "ok" }),
+    });
+    const created = await service1.create({
+      prompt: "Retained run",
+      cadence: { type: "every", everyMs: 60_000 },
+      target: { type: "new-agent", config: { provider: "claude", cwd: tempDir } },
+      runOnCreate: false,
+    });
+    const workspaceId = "wks_existing_schedule_run";
+    const store = new ScheduleStore(join(tempDir, "schedules"));
+    await store.update(created.id, (schedule) => ({
+      ...schedule,
+      runs: [
+        {
+          id: "existing-run",
+          scheduledFor: now.toISOString(),
+          startedAt: now.toISOString(),
+          endedAt: now.toISOString(),
+          status: "succeeded",
+          agentId: null,
+          workspaceId,
+          output: "ok",
+          error: null,
+        },
+      ],
+    }));
+
+    const setWorkspaceScheduleId = vi.fn(async () => undefined);
+    const service2 = createScheduleService({
+      paseoHome: tempDir,
+      logger: createTestLogger(),
+      agentManager: new AgentManager({ logger: createTestLogger() }),
+      agentStorage,
+      providerSnapshotManager: NO_UNATTENDED_SCHEDULE_POLICY,
+      now: () => now,
+      runner: async () => ({ agentId: null, output: "ok" }),
+      setWorkspaceScheduleId,
+    });
+    await service2.start();
+
+    expect(setWorkspaceScheduleId).toHaveBeenCalledWith(workspaceId, created.id);
     await service2.stop();
   });
 

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -222,6 +222,7 @@ type ScheduleAgentManager = Pick<
 interface ScheduleWorkspaceCreateInput {
   cwd: string;
   firstAgentContext: FirstAgentContext;
+  scheduleId: string;
 }
 
 export interface ScheduleServiceOptions {
@@ -237,6 +238,7 @@ export interface ScheduleServiceOptions {
     input: ScheduleWorkspaceCreateInput,
   ) => Promise<CreatePaseoWorktreeWorkflowResult>;
   archiveWorkspace: (workspaceId: string) => Promise<void>;
+  setWorkspaceScheduleId: (workspaceId: string, scheduleId: string) => Promise<void>;
   now?: () => Date;
   runner?: (schedule: StoredSchedule, runId: string) => Promise<ScheduleExecutionResult>;
 }
@@ -254,6 +256,10 @@ export class ScheduleService {
     input: ScheduleWorkspaceCreateInput,
   ) => Promise<CreatePaseoWorktreeWorkflowResult>;
   private readonly archiveWorkspace: (workspaceId: string) => Promise<void>;
+  private readonly setWorkspaceScheduleId: (
+    workspaceId: string,
+    scheduleId: string,
+  ) => Promise<void>;
   private readonly now: () => Date;
   private readonly runner: (
     schedule: StoredSchedule,
@@ -271,11 +277,13 @@ export class ScheduleService {
     this.createDirectoryWorkspace = options.createDirectoryWorkspace;
     this.createPaseoWorktreeWorkspace = options.createPaseoWorktreeWorkspace;
     this.archiveWorkspace = options.archiveWorkspace;
+    this.setWorkspaceScheduleId = options.setWorkspaceScheduleId;
     this.now = options.now ?? (() => new Date());
     this.runner = options.runner ?? ((schedule, runId) => this.executeSchedule(schedule, runId));
   }
 
   async start(): Promise<void> {
+    await this.reconcileScheduleWorkspaceIds();
     await this.recoverInterruptedRuns();
     await this.sweepOrphanedSchedules();
     if (this.tickTimer) {
@@ -288,6 +296,17 @@ export class ScheduleService {
     }, SCHEDULE_TICK_INTERVAL_MS);
     (timer as unknown as { unref?: () => void }).unref?.();
     this.tickTimer = timer;
+  }
+
+  private async reconcileScheduleWorkspaceIds(): Promise<void> {
+    const schedules = await this.store.list();
+    await Promise.all(
+      schedules.flatMap((schedule) =>
+        schedule.runs.flatMap((run) =>
+          run.workspaceId ? [this.setWorkspaceScheduleId(run.workspaceId, schedule.id)] : [],
+        ),
+      ),
+    );
   }
 
   async stop(): Promise<void> {
@@ -885,7 +904,7 @@ export class ScheduleService {
     let workspace: PersistedWorkspaceRecord | null = null;
     let agentId: string | null = null;
     try {
-      workspace = await this.createScheduleRunWorkspace(config, schedule.prompt);
+      workspace = await this.createScheduleRunWorkspace(config, schedule.prompt, schedule.id);
       await this.recordRunWorkspace({
         scheduleId: schedule.id,
         runId,
@@ -971,14 +990,14 @@ export class ScheduleService {
   private async createScheduleRunWorkspace(
     config: Extract<ScheduleTarget, { type: "new-agent" }>["config"],
     prompt: string,
+    scheduleId: string,
   ): Promise<PersistedWorkspaceRecord> {
-    const firstAgentContext = { prompt };
+    const input = { cwd: config.cwd, firstAgentContext: { prompt }, scheduleId };
     switch (config.isolation ?? "local") {
       case "local":
-        return this.createDirectoryWorkspace({ cwd: config.cwd, firstAgentContext });
+        return this.createDirectoryWorkspace(input);
       case "worktree":
-        return (await this.createPaseoWorktreeWorkspace({ cwd: config.cwd, firstAgentContext }))
-          .workspace;
+        return (await this.createPaseoWorktreeWorkspace(input)).workspace;
     }
   }
 

--- a/packages/server/src/server/schedule/service.ts
+++ b/packages/server/src/server/schedule/service.ts
@@ -283,7 +283,9 @@ export class ScheduleService {
   }
 
   async start(): Promise<void> {
-    await this.reconcileScheduleWorkspaceIds();
+    void this.reconcileScheduleWorkspaceIds().catch((error) => {
+      this.logger.warn({ err: error }, "Failed to reconcile schedule workspace IDs");
+    });
     await this.recoverInterruptedRuns();
     await this.sweepOrphanedSchedules();
     if (this.tickTimer) {

--- a/packages/server/src/server/session.ts
+++ b/packages/server/src/server/session.ts
@@ -4875,6 +4875,7 @@ export class Session {
       name: resolveWorkspaceDisplayName(workspace),
       title: workspace.title,
       pinnedAt: workspace.pinnedAt,
+      scheduleId: workspace.scheduleId,
       ...(workspace.labels && workspace.labels.length > 0 ? { labels: workspace.labels } : {}),
       archivingAt: null,
       status: "done",
@@ -4967,6 +4968,7 @@ export class Session {
       }),
       title: result.workspace.title,
       pinnedAt: result.workspace.pinnedAt,
+      scheduleId: result.workspace.scheduleId,
       ...(result.workspace.labels && result.workspace.labels.length > 0
         ? { labels: result.workspace.labels }
         : {}),

--- a/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
+++ b/packages/server/src/server/session/workspace-provisioning/workspace-provisioning-service.ts
@@ -44,6 +44,7 @@ export interface CreateWorktreeWorkspaceInput {
   baseBranch: string | null;
   title: string | null;
   expectsInitialAgent?: boolean;
+  scheduleId?: string;
 }
 
 export interface WorkspaceProvisioningService {
@@ -57,7 +58,7 @@ export interface WorkspaceProvisioningService {
     cwd: string,
     title?: string | null,
     projectId?: string,
-    context?: { expectsInitialAgent?: boolean },
+    context?: { expectsInitialAgent?: boolean; scheduleId?: string },
   ): Promise<PersistedWorkspaceRecord>;
   createWorkspaceForWorktree(
     input: CreateWorktreeWorkspaceInput,
@@ -186,7 +187,7 @@ export function createWorkspaceProvisioningService(deps: {
     cwd: string,
     title?: string | null,
     projectId?: string,
-    context?: { expectsInitialAgent?: boolean },
+    context?: { expectsInitialAgent?: boolean; scheduleId?: string },
   ): Promise<PersistedWorkspaceRecord> {
     const normalizedCwd = resolve(cwd);
     const checkout = await workspaceGitService.getCheckout(normalizedCwd);
@@ -200,6 +201,7 @@ export function createWorkspaceProvisioningService(deps: {
       projectId: project.projectId,
       ...initialWorkspacePlacement({ source: "checkout", cwd: normalizedCwd, checkout }),
       title: title?.trim() || null,
+      scheduleId: context?.scheduleId,
       createdAt: timestamp,
       updatedAt: timestamp,
     });
@@ -232,6 +234,7 @@ export function createWorkspaceProvisioningService(deps: {
         mainRepoRoot: repoRoot,
       }),
       title: input.title,
+      scheduleId: input.scheduleId,
       createdAt: timestamp,
       updatedAt: timestamp,
     });

--- a/packages/server/src/server/workspace-registry.test.ts
+++ b/packages/server/src/server/workspace-registry.test.ts
@@ -42,6 +42,21 @@ describe("resolveWorkspaceName", () => {
     expect(resolveWorkspaceDisplayName(record)).toBe("Renamed");
     expect(resolveWorkspaceDisplayName({ ...record, title: null })).toBe("main");
   });
+
+  test("persists schedule workspace identity when present", () => {
+    const record = createPersistedWorkspaceRecord({
+      workspaceId: "ws-scheduled",
+      projectId: "proj-1",
+      cwd: "/tmp/repo",
+      kind: "local_checkout",
+      displayName: "scheduled run",
+      scheduleId: "schedule-1",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-01T00:00:00.000Z",
+    });
+
+    expect(record.scheduleId).toBe("schedule-1");
+  });
 });
 
 describe("workspace registries", () => {

--- a/packages/server/src/server/workspace-registry.ts
+++ b/packages/server/src/server/workspace-registry.ts
@@ -92,6 +92,8 @@ const PersistedWorkspaceRecordSchema = z.object({
     .nullable()
     .optional()
     .transform((value) => value ?? null),
+  // COMPAT(scheduleWorkspaceIdentity): added in v0.6.2, remove optional parsing after 2027-08-27.
+  scheduleId: z.string().optional(),
   labels: z.array(z.string()).optional(),
 });
 
@@ -673,6 +675,7 @@ export function createPersistedWorkspaceRecord(input: {
   archivedAt?: string | null;
   autoArchivedChangeRequestUrl?: string | null;
   pinnedAt?: string | null;
+  scheduleId?: string;
   labels?: string[];
 }): PersistedWorkspaceRecord {
   return PersistedWorkspaceRecordSchema.parse({
@@ -686,6 +689,7 @@ export function createPersistedWorkspaceRecord(input: {
     archivedAt: input.archivedAt ?? null,
     autoArchivedChangeRequestUrl: input.autoArchivedChangeRequestUrl ?? null,
     pinnedAt: input.pinnedAt ?? null,
+    scheduleId: input.scheduleId,
   });
 }
 


### PR DESCRIPTION
## Summary

- Add a Project workspaces → Rows / Compact display preference.
- Keep compact projects on one line with clickable status indicators and title tooltips.
- Persist schedule ownership on run workspaces and reconcile older retained runs so each schedule stays one indicator.

## QA

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- Focused Vitest: 190 passed
- Focused browser Playwright: 1 passed
- Browser web tested
- Packaged desktop, iOS, and Android not tested after rebase

![Compact project workspace indicators](https://gist.githubusercontent.com/fbettag/8a65fed734458f5ae1b446fca4d5a5f5/raw/d3c22ef35d0b42770408ab1238cd750d43f44d38/compact-project-workspaces.svg)