### PR TITLE
feat(pi): map todo extension results into timeline tasks

### DIFF
--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -85,7 +85,7 @@ import {
   type PiToolResult,
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
-import { mapPiTodoReminderEvent, mapPiTodoState, mapPiTodoToolResult } from "./todo-mapper.js";
+import { mapPiTodoMessages, mapPiTodoToolResult } from "./todo-mapper.js";
 
 const PI_PROVIDER = "pi";
 const DEFAULT_PI_THINKING_LEVEL: PiThinkingLevel = "medium";
@@ -1373,16 +1373,14 @@ export class PiRpcAgentSession implements AgentSession {
 
   async *streamHistory(): AsyncGenerator<AgentStreamEvent> {
     await this.requestEntryCapture("history");
-    yield* streamPiHistory(
-      this.provider,
-      await this.runtimeSession.getMessages(),
-      this.capturedUserEntries,
-    );
-    for (const item of mapPiTodoState(this.state)) {
+    const messages = await this.runtimeSession.getMessages();
+    yield* streamPiHistory(this.provider, messages, this.capturedUserEntries);
+    const todoItem = mapPiTodoMessages(messages);
+    if (todoItem) {
       yield {
         type: "timeline",
         provider: this.provider,
-        item,
+        item: todoItem,
       };
     }
   }
@@ -2042,15 +2040,6 @@ export class PiRpcAgentSession implements AgentSession {
   }
 
   private handleRuntimeEvent(event: PiRuntimeEvent): void {
-    if (event.type === "todo_reminder") {
-      const item = mapPiTodoReminderEvent(event);
-      if (item) {
-        this.emitTodoItem(item, this.currentTurnIdForEvent());
-      } else {
-        this.logger.debug({ event }, "Dropped malformed Pi todo reminder event");
-      }
-      return;
-    }
     if (isExtensionUiRequestEvent(event)) {
       this.handleExtensionUiRequest(event);
       return;

--- a/packages/server/src/server/agent/providers/pi/agent.ts
+++ b/packages/server/src/server/agent/providers/pi/agent.ts
@@ -85,6 +85,7 @@ import {
   type PiToolResult,
   type PiTrackedToolCall,
 } from "./tool-call-mapper.js";
+import { mapPiTodoReminderEvent, mapPiTodoState, mapPiTodoToolResult } from "./todo-mapper.js";
 
 const PI_PROVIDER = "pi";
 const DEFAULT_PI_THINKING_LEVEL: PiThinkingLevel = "medium";
@@ -1213,6 +1214,10 @@ export class PiRpcAgentSession implements AgentSession {
   private activePromptRequestId: string | null = null;
   private readonly pendingPromptResults = new Map<string, boolean>();
   private lastKnownThinkingOptionId: string | null;
+  private lastTodoItem: Extract<
+    import("../../agent-sdk-types.js").AgentTimelineItem,
+    { type: "todo" }
+  > | null = null;
   currentLeafOverrideId: string | null | undefined;
   private readonly capturedUserEntries: PiCapturedEntry[] = [];
   private readonly capturedUserEntriesById = new Map<string, PiCapturedEntry>();
@@ -1373,6 +1378,13 @@ export class PiRpcAgentSession implements AgentSession {
       await this.runtimeSession.getMessages(),
       this.capturedUserEntries,
     );
+    for (const item of mapPiTodoState(this.state)) {
+      yield {
+        type: "timeline",
+        provider: this.provider,
+        item,
+      };
+    }
   }
 
   async getRuntimeInfo(): Promise<AgentRuntimeInfo> {
@@ -2011,7 +2023,34 @@ export class PiRpcAgentSession implements AgentSession {
     });
   }
 
+  private emitTodoItem(
+    item: import("../../agent-sdk-types.js").AgentTimelineItem,
+    turnId?: string,
+  ): void {
+    if (item.type === "todo") {
+      const previous = this.lastTodoItem;
+      const isDuplicate =
+        previous?.items.length === item.items.length &&
+        previous.items.every((prev, index) => {
+          const next = item.items[index];
+          return next?.text === prev.text && next.completed === prev.completed;
+        });
+      if (isDuplicate) return;
+      this.lastTodoItem = item;
+    }
+    this.emit({ type: "timeline", provider: this.provider, turnId, item });
+  }
+
   private handleRuntimeEvent(event: PiRuntimeEvent): void {
+    if (event.type === "todo_reminder") {
+      const item = mapPiTodoReminderEvent(event);
+      if (item) {
+        this.emitTodoItem(item, this.currentTurnIdForEvent());
+      } else {
+        this.logger.debug({ event }, "Dropped malformed Pi todo reminder event");
+      }
+      return;
+    }
     if (isExtensionUiRequestEvent(event)) {
       this.handleExtensionUiRequest(event);
       return;
@@ -2203,6 +2242,14 @@ export class PiRpcAgentSession implements AgentSession {
     }
 
     const result = parseToolResult(event.result);
+    if (event.toolName === "todo") {
+      const item = mapPiTodoToolResult(result);
+      if (item) {
+        this.emitTodoItem(item, this.currentTurnIdForEvent());
+        return;
+      }
+      this.logger.debug({ event }, "Dropped malformed Pi todo tool result");
+    }
     const error = event.isError ? event.result : null;
     const status = event.isError ? "failed" : "completed";
     this.emitToolCallEvent(event.toolCallId, toolCall, status, result, error);

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface PiImageContent {
@@ -198,6 +200,23 @@ export type PiAgentSessionEvent =
     }
   | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 
+export const PiTodoItemSchema = z
+  .object({
+    content: z.string(),
+    status: z.enum(["pending", "in_progress", "completed", "abandoned"]),
+  })
+  .passthrough();
+export const PiTodoPhaseSchema = z
+  .object({ name: z.string(), tasks: z.array(PiTodoItemSchema) })
+  .passthrough();
+export const PiTodoReminderEventSchema = z
+  .object({ type: z.literal("todo_reminder"), todos: z.array(PiTodoItemSchema) })
+  .passthrough();
+
+export type PiTodoItem = z.infer<typeof PiTodoItemSchema>;
+export type PiTodoPhase = z.infer<typeof PiTodoPhaseSchema>;
+export type PiTodoReminderEvent = z.infer<typeof PiTodoReminderEventSchema>;
+
 export type PiRuntimeEvent =
   | PiAgentSessionEvent
   | {
@@ -214,6 +233,7 @@ export type PiRuntimeEvent =
       type: "process_exit";
       error: string;
     }
+  | PiTodoReminderEvent
   | {
       type: string;
       [key: string]: unknown;

--- a/packages/server/src/server/agent/providers/pi/rpc-types.ts
+++ b/packages/server/src/server/agent/providers/pi/rpc-types.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 export type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface PiImageContent {
@@ -200,23 +198,6 @@ export type PiAgentSessionEvent =
     }
   | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 
-export const PiTodoItemSchema = z
-  .object({
-    content: z.string(),
-    status: z.enum(["pending", "in_progress", "completed", "abandoned"]),
-  })
-  .passthrough();
-export const PiTodoPhaseSchema = z
-  .object({ name: z.string(), tasks: z.array(PiTodoItemSchema) })
-  .passthrough();
-export const PiTodoReminderEventSchema = z
-  .object({ type: z.literal("todo_reminder"), todos: z.array(PiTodoItemSchema) })
-  .passthrough();
-
-export type PiTodoItem = z.infer<typeof PiTodoItemSchema>;
-export type PiTodoPhase = z.infer<typeof PiTodoPhaseSchema>;
-export type PiTodoReminderEvent = z.infer<typeof PiTodoReminderEventSchema>;
-
 export type PiRuntimeEvent =
   | PiAgentSessionEvent
   | {
@@ -233,7 +214,6 @@ export type PiRuntimeEvent =
       type: "process_exit";
       error: string;
     }
-  | PiTodoReminderEvent
   | {
       type: string;
       [key: string]: unknown;

--- a/packages/server/src/server/agent/providers/pi/todo-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/todo-mapper.test.ts
@@ -4,7 +4,35 @@ import { parseToolResult } from "./tool-call-mapper.js";
 import { mapPiTodoMessages, mapPiTodoToolResult } from "./todo-mapper.js";
 
 describe("Pi todo mapper", () => {
-  test("maps todo extension tool results", () => {
+  test("maps rpiv-todo tool results, preserving in_progress and dropping tombstones", () => {
+    expect(
+      mapPiTodoToolResult(
+        parseToolResult({
+          content: [{ type: "text", text: "Created #2" }],
+          details: {
+            action: "create",
+            params: {},
+            tasks: [
+              { id: 1, subject: "alpha task", status: "completed", owner: "agent" },
+              { id: 2, subject: "beta task", status: "in_progress" },
+              { id: 3, subject: "gamma task", status: "pending" },
+              { id: 4, subject: "deleted task", status: "deleted" },
+            ],
+            nextId: 5,
+          },
+        }),
+      ),
+    ).toEqual({
+      type: "todo",
+      items: [
+        { text: "alpha task", status: "completed", completed: true },
+        { text: "beta task", status: "in_progress", completed: false },
+        { text: "gamma task", status: "pending", completed: false },
+      ],
+    });
+  });
+
+  test("maps the example todo.ts tool results", () => {
     expect(
       mapPiTodoToolResult(
         parseToolResult({
@@ -48,9 +76,9 @@ describe("Pi todo mapper", () => {
           toolName: "todo",
           content: [],
           details: {
-            todos: [
-              { id: 1, text: "stale", done: true },
-              { id: 2, text: "fresh", done: false },
+            tasks: [
+              { id: 1, subject: "stale", status: "completed" },
+              { id: 2, subject: "fresh", status: "pending" },
             ],
             nextId: 3,
           },
@@ -68,6 +96,11 @@ describe("Pi todo mapper", () => {
   test("drops malformed or absent todo inputs", () => {
     expect(
       mapPiTodoToolResult(parseToolResult({ content: [], details: { todos: [{ id: 1 }] } })),
+    ).toBeNull();
+    expect(
+      mapPiTodoToolResult(
+        parseToolResult({ content: [], details: { tasks: [{ subject: "x", status: "bogus" }] } }),
+      ),
     ).toBeNull();
     expect(
       mapPiTodoToolResult(parseToolResult({ content: [], details: { phases: [] } })),

--- a/packages/server/src/server/agent/providers/pi/todo-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/todo-mapper.test.ts
@@ -1,103 +1,88 @@
 import { describe, expect, test } from "vitest";
 
 import { parseToolResult } from "./tool-call-mapper.js";
-import { mapPiTodoReminderEvent, mapPiTodoState, mapPiTodoToolResult } from "./todo-mapper.js";
-
-const TODO_PHASES = [
-  {
-    name: "Tasks",
-    tasks: [
-      { content: "alpha task", status: "completed" },
-      { content: "beta task", status: "in_progress" },
-      { content: "gamma task", status: "pending" },
-    ],
-  },
-] as const;
+import { mapPiTodoMessages, mapPiTodoToolResult } from "./todo-mapper.js";
 
 describe("Pi todo mapper", () => {
-  test("maps todo tool results without losing progress status", () => {
+  test("maps todo extension tool results", () => {
     expect(
       mapPiTodoToolResult(
         parseToolResult({
-          content: [],
+          content: [{ type: "text", text: "Added todo #2" }],
           details: {
-            phases: [
-              {
-                name: "Tasks",
-                tasks: [
-                  { content: "alpha task", status: "in_progress" },
-                  { content: "beta task", status: "pending" },
-                  { content: "gamma task", status: "pending" },
-                ],
-              },
+            action: "add",
+            todos: [
+              { id: 1, text: "alpha task", done: true },
+              { id: 2, text: "beta task", done: false },
             ],
+            nextId: 3,
           },
         }),
       ),
     ).toEqual({
       type: "todo",
       items: [
-        { text: "alpha task", status: "in_progress", completed: false },
-        { text: "beta task", status: "pending", completed: false },
-        { text: "gamma task", status: "pending", completed: false },
-      ],
-    });
-
-    expect(
-      mapPiTodoToolResult(parseToolResult({ content: [], details: { phases: TODO_PHASES } })),
-    ).toEqual({
-      type: "todo",
-      items: [
         { text: "alpha task", status: "completed", completed: true },
-        { text: "beta task", status: "in_progress", completed: false },
-        { text: "gamma task", status: "pending", completed: false },
+        { text: "beta task", status: "pending", completed: false },
       ],
     });
   });
 
-  test("maps todo reminder events", () => {
+  test("hydrates todos from the most recent todo tool result in message history", () => {
     expect(
-      mapPiTodoReminderEvent({
-        type: "todo_reminder",
-        todos: [
-          { content: "beta task", status: "in_progress" },
-          { content: "gamma task", status: "pending" },
-        ],
-      }),
+      mapPiTodoMessages([
+        {
+          role: "toolResult",
+          toolCallId: "1",
+          toolName: "todo",
+          content: [],
+          details: { todos: [{ id: 1, text: "stale", done: false }], nextId: 2 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "working..." }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "2",
+          toolName: "todo",
+          content: [],
+          details: {
+            todos: [
+              { id: 1, text: "stale", done: true },
+              { id: 2, text: "fresh", done: false },
+            ],
+            nextId: 3,
+          },
+        },
+      ]),
     ).toEqual({
       type: "todo",
       items: [
-        { text: "beta task", status: "in_progress", completed: false },
-        { text: "gamma task", status: "pending", completed: false },
+        { text: "stale", status: "completed", completed: true },
+        { text: "fresh", status: "pending", completed: false },
       ],
     });
   });
 
-  test("hydrates current todos from session state", () => {
+  test("drops malformed or absent todo inputs", () => {
     expect(
-      mapPiTodoState({
-        thinkingLevel: "medium",
-        isStreaming: false,
-        isCompacting: false,
-        sessionId: "session",
-        messageCount: 0,
-        pendingMessageCount: 0,
-        todoPhases: TODO_PHASES,
-      }),
-    ).toEqual([
-      {
-        type: "todo",
-        items: [
-          { text: "alpha task", status: "completed", completed: true },
-          { text: "beta task", status: "in_progress", completed: false },
-          { text: "gamma task", status: "pending", completed: false },
-        ],
-      },
-    ]);
-  });
-
-  test("drops malformed todo inputs", () => {
-    expect(mapPiTodoReminderEvent({ type: "todo_reminder", todos: [{ content: 1 }] })).toBeNull();
-    expect(mapPiTodoToolResult({ details: { phases: [{ name: "Bad", tasks: [{}] }] } })).toBeNull();
+      mapPiTodoToolResult(parseToolResult({ content: [], details: { todos: [{ id: 1 }] } })),
+    ).toBeNull();
+    expect(
+      mapPiTodoToolResult(parseToolResult({ content: [], details: { phases: [] } })),
+    ).toBeNull();
+    expect(mapPiTodoToolResult(parseToolResult("no todos"))).toBeNull();
+    expect(
+      mapPiTodoMessages([
+        {
+          role: "toolResult",
+          toolCallId: "1",
+          toolName: "write",
+          content: [],
+          details: { todos: [{ id: 1, text: "wrong tool", done: false }] },
+        },
+      ]),
+    ).toBeNull();
   });
 });

--- a/packages/server/src/server/agent/providers/pi/todo-mapper.test.ts
+++ b/packages/server/src/server/agent/providers/pi/todo-mapper.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import { parseToolResult } from "./tool-call-mapper.js";
+import { mapPiTodoReminderEvent, mapPiTodoState, mapPiTodoToolResult } from "./todo-mapper.js";
+
+const TODO_PHASES = [
+  {
+    name: "Tasks",
+    tasks: [
+      { content: "alpha task", status: "completed" },
+      { content: "beta task", status: "in_progress" },
+      { content: "gamma task", status: "pending" },
+    ],
+  },
+] as const;
+
+describe("Pi todo mapper", () => {
+  test("maps todo tool results without losing progress status", () => {
+    expect(
+      mapPiTodoToolResult(
+        parseToolResult({
+          content: [],
+          details: {
+            phases: [
+              {
+                name: "Tasks",
+                tasks: [
+                  { content: "alpha task", status: "in_progress" },
+                  { content: "beta task", status: "pending" },
+                  { content: "gamma task", status: "pending" },
+                ],
+              },
+            ],
+          },
+        }),
+      ),
+    ).toEqual({
+      type: "todo",
+      items: [
+        { text: "alpha task", status: "in_progress", completed: false },
+        { text: "beta task", status: "pending", completed: false },
+        { text: "gamma task", status: "pending", completed: false },
+      ],
+    });
+
+    expect(
+      mapPiTodoToolResult(parseToolResult({ content: [], details: { phases: TODO_PHASES } })),
+    ).toEqual({
+      type: "todo",
+      items: [
+        { text: "alpha task", status: "completed", completed: true },
+        { text: "beta task", status: "in_progress", completed: false },
+        { text: "gamma task", status: "pending", completed: false },
+      ],
+    });
+  });
+
+  test("maps todo reminder events", () => {
+    expect(
+      mapPiTodoReminderEvent({
+        type: "todo_reminder",
+        todos: [
+          { content: "beta task", status: "in_progress" },
+          { content: "gamma task", status: "pending" },
+        ],
+      }),
+    ).toEqual({
+      type: "todo",
+      items: [
+        { text: "beta task", status: "in_progress", completed: false },
+        { text: "gamma task", status: "pending", completed: false },
+      ],
+    });
+  });
+
+  test("hydrates current todos from session state", () => {
+    expect(
+      mapPiTodoState({
+        thinkingLevel: "medium",
+        isStreaming: false,
+        isCompacting: false,
+        sessionId: "session",
+        messageCount: 0,
+        pendingMessageCount: 0,
+        todoPhases: TODO_PHASES,
+      }),
+    ).toEqual([
+      {
+        type: "todo",
+        items: [
+          { text: "alpha task", status: "completed", completed: true },
+          { text: "beta task", status: "in_progress", completed: false },
+          { text: "gamma task", status: "pending", completed: false },
+        ],
+      },
+    ]);
+  });
+
+  test("drops malformed todo inputs", () => {
+    expect(mapPiTodoReminderEvent({ type: "todo_reminder", todos: [{ content: 1 }] })).toBeNull();
+    expect(mapPiTodoToolResult({ details: { phases: [{ name: "Bad", tasks: [{}] }] } })).toBeNull();
+  });
+});

--- a/packages/server/src/server/agent/providers/pi/todo-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/todo-mapper.ts
@@ -4,26 +4,30 @@ import type { AgentTimelineItem } from "../../agent-sdk-types.js";
 import type { PiAgentMessage } from "./rpc-types.js";
 import type { PiToolResult } from "./tool-call-mapper.js";
 
-// Pi core has no todo state: todos come from the `todo` extension tool, which
-// returns details {todos: [{id, text, done}], nextId} (see pi's
-// examples/extensions/todo.ts).
-export const PiTodoExtensionItemSchema = z
+// Supported shapes for `todo` tool results:
+// - @juicesharp/rpiv-todo: details {tasks: [{id, subject, status, ...}], nextId}
+// - pi's examples/extensions/todo.ts: details {todos: [{id, text, done}], nextId}
+const RpivTodoItemSchema = z
   .object({
-    id: z.number().int().optional(),
-    text: z.string(),
-    done: z.boolean(),
+    subject: z.string(),
+    status: z.enum(["pending", "in_progress", "completed", "deleted"]),
   })
   .passthrough();
-export const PiTodoDetailsSchema = z
-  .object({ todos: z.array(PiTodoExtensionItemSchema) })
-  .passthrough();
+const RpivTodoDetailsSchema = z.object({ tasks: z.array(RpivTodoItemSchema) }).passthrough();
 
-export type PiTodoExtensionItem = z.infer<typeof PiTodoExtensionItemSchema>;
+const DemoTodoItemSchema = z
+  .object({ id: z.number().int().optional(), text: z.string(), done: z.boolean() })
+  .passthrough();
+const DemoTodoDetailsSchema = z.object({ todos: z.array(DemoTodoItemSchema) }).passthrough();
+
+interface PiTodoSnapshot {
+  text: string;
+  status: "pending" | "in_progress" | "completed";
+}
 
 export function mapPiTodoToolResult(result: PiToolResult): AgentTimelineItem | null {
   const details = resultDetails(result);
-  const todos = PiTodoDetailsSchema.safeParse(details);
-  return todos.success ? mapPiTodoItems(todos.data.todos) : null;
+  return mapPiTodoDetails(details);
 }
 
 export function mapPiTodoMessages(messages: readonly PiAgentMessage[]): AgentTimelineItem | null {
@@ -32,15 +36,39 @@ export function mapPiTodoMessages(messages: readonly PiAgentMessage[]): AgentTim
     if (message.role !== "toolResult" || message.toolName !== "todo") {
       continue;
     }
-    const todos = PiTodoDetailsSchema.safeParse(message.details);
-    if (todos.success) {
-      return mapPiTodoItems(todos.data.todos);
+    const item = mapPiTodoDetails(isRecord(message.details) ? message.details : null);
+    if (item) {
+      return item;
     }
   }
   return null;
 }
 
-export function mapPiTodoItems(items: readonly PiTodoExtensionItem[]): AgentTimelineItem | null {
+function mapPiTodoDetails(details: Record<string, unknown> | null): AgentTimelineItem | null {
+  if (!details) {
+    return null;
+  }
+  const rpiv = RpivTodoDetailsSchema.safeParse(details);
+  if (rpiv.success) {
+    return mapPiTodoSnapshots(
+      rpiv.data.tasks.flatMap((task): PiTodoSnapshot[] =>
+        task.status === "deleted" ? [] : [{ text: task.subject, status: task.status }],
+      ),
+    );
+  }
+  const demo = DemoTodoDetailsSchema.safeParse(details);
+  if (demo.success) {
+    return mapPiTodoSnapshots(
+      demo.data.todos.map((todo) => ({
+        text: todo.text,
+        status: todo.done ? "completed" : "pending",
+      })),
+    );
+  }
+  return null;
+}
+
+function mapPiTodoSnapshots(items: readonly PiTodoSnapshot[]): AgentTimelineItem | null {
   if (items.length === 0) {
     return null;
   }
@@ -48,8 +76,8 @@ export function mapPiTodoItems(items: readonly PiTodoExtensionItem[]): AgentTime
     type: "todo",
     items: items.map((item) => ({
       text: item.text,
-      status: item.done ? ("completed" as const) : ("pending" as const),
-      completed: item.done,
+      status: item.status,
+      completed: item.status === "completed",
     })),
   };
 }

--- a/packages/server/src/server/agent/providers/pi/todo-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/todo-mapper.ts
@@ -1,56 +1,57 @@
+import { z } from "zod";
+
 import type { AgentTimelineItem } from "../../agent-sdk-types.js";
-import type { PiSessionState } from "./rpc-types.js";
+import type { PiAgentMessage } from "./rpc-types.js";
 import type { PiToolResult } from "./tool-call-mapper.js";
-import {
-  PiTodoPhaseSchema,
-  PiTodoReminderEventSchema,
-  type PiTodoItem,
-  type PiTodoPhase,
-} from "./rpc-types.js";
+
+// Pi core has no todo state: todos come from the `todo` extension tool, which
+// returns details {todos: [{id, text, done}], nextId} (see pi's
+// examples/extensions/todo.ts).
+export const PiTodoExtensionItemSchema = z
+  .object({
+    id: z.number().int().optional(),
+    text: z.string(),
+    done: z.boolean(),
+  })
+  .passthrough();
+export const PiTodoDetailsSchema = z
+  .object({ todos: z.array(PiTodoExtensionItemSchema) })
+  .passthrough();
+
+export type PiTodoExtensionItem = z.infer<typeof PiTodoExtensionItemSchema>;
 
 export function mapPiTodoToolResult(result: PiToolResult): AgentTimelineItem | null {
   const details = resultDetails(result);
-  const phases = PiTodoPhaseSchema.array().safeParse(details?.phases);
-  return phases.success ? mapPiTodoPhases(phases.data) : null;
+  const todos = PiTodoDetailsSchema.safeParse(details);
+  return todos.success ? mapPiTodoItems(todos.data.todos) : null;
 }
 
-export function mapPiTodoReminderEvent(event: unknown): AgentTimelineItem | null {
-  const parsed = PiTodoReminderEventSchema.safeParse(event);
-  return parsed.success ? mapPiTodoItems(parsed.data.todos) : null;
-}
-
-export function mapPiTodoState(state: PiSessionState): AgentTimelineItem[] {
-  const phases = PiTodoPhaseSchema.array().safeParse(state.todoPhases);
-  if (!phases.success) {
-    return [];
+export function mapPiTodoMessages(messages: readonly PiAgentMessage[]): AgentTimelineItem | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== "toolResult" || message.toolName !== "todo") {
+      continue;
+    }
+    const todos = PiTodoDetailsSchema.safeParse(message.details);
+    if (todos.success) {
+      return mapPiTodoItems(todos.data.todos);
+    }
   }
-  const item = mapPiTodoPhases(phases.data);
-  return item ? [item] : [];
+  return null;
 }
 
-export function mapPiTodoPhases(phases: readonly PiTodoPhase[]): AgentTimelineItem | null {
-  const todos = phases.flatMap((phase) => phase.tasks);
-  return mapPiTodoItems(todos);
-}
-
-function mapPiTodoItems(items: readonly PiTodoItem[]): AgentTimelineItem | null {
+export function mapPiTodoItems(items: readonly PiTodoExtensionItem[]): AgentTimelineItem | null {
   if (items.length === 0) {
     return null;
   }
   return {
     type: "todo",
     items: items.map((item) => ({
-      text: item.content,
-      status: normalizePiTodoStatus(item.status),
-      completed: item.status === "completed",
+      text: item.text,
+      status: item.done ? ("completed" as const) : ("pending" as const),
+      completed: item.done,
     })),
   };
-}
-
-function normalizePiTodoStatus(status: PiTodoItem["status"]) {
-  if (status === "completed") return "completed" as const;
-  if (status === "in_progress") return "in_progress" as const;
-  return "pending" as const;
 }
 
 function resultDetails(result: PiToolResult): Record<string, unknown> | null {

--- a/packages/server/src/server/agent/providers/pi/todo-mapper.ts
+++ b/packages/server/src/server/agent/providers/pi/todo-mapper.ts
@@ -1,0 +1,65 @@
+import type { AgentTimelineItem } from "../../agent-sdk-types.js";
+import type { PiSessionState } from "./rpc-types.js";
+import type { PiToolResult } from "./tool-call-mapper.js";
+import {
+  PiTodoPhaseSchema,
+  PiTodoReminderEventSchema,
+  type PiTodoItem,
+  type PiTodoPhase,
+} from "./rpc-types.js";
+
+export function mapPiTodoToolResult(result: PiToolResult): AgentTimelineItem | null {
+  const details = resultDetails(result);
+  const phases = PiTodoPhaseSchema.array().safeParse(details?.phases);
+  return phases.success ? mapPiTodoPhases(phases.data) : null;
+}
+
+export function mapPiTodoReminderEvent(event: unknown): AgentTimelineItem | null {
+  const parsed = PiTodoReminderEventSchema.safeParse(event);
+  return parsed.success ? mapPiTodoItems(parsed.data.todos) : null;
+}
+
+export function mapPiTodoState(state: PiSessionState): AgentTimelineItem[] {
+  const phases = PiTodoPhaseSchema.array().safeParse(state.todoPhases);
+  if (!phases.success) {
+    return [];
+  }
+  const item = mapPiTodoPhases(phases.data);
+  return item ? [item] : [];
+}
+
+export function mapPiTodoPhases(phases: readonly PiTodoPhase[]): AgentTimelineItem | null {
+  const todos = phases.flatMap((phase) => phase.tasks);
+  return mapPiTodoItems(todos);
+}
+
+function mapPiTodoItems(items: readonly PiTodoItem[]): AgentTimelineItem | null {
+  if (items.length === 0) {
+    return null;
+  }
+  return {
+    type: "todo",
+    items: items.map((item) => ({
+      text: item.content,
+      status: normalizePiTodoStatus(item.status),
+      completed: item.status === "completed",
+    })),
+  };
+}
+
+function normalizePiTodoStatus(status: PiTodoItem["status"]) {
+  if (status === "completed") return "completed" as const;
+  if (status === "in_progress") return "in_progress" as const;
+  return "pending" as const;
+}
+
+function resultDetails(result: PiToolResult): Record<string, unknown> | null {
+  if (typeof result === "string" || result === null) {
+    return null;
+  }
+  return isRecord(result.details) ? result.details : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
Maps the pi `todo` extension tool's results into timeline `todo` items and hydrates them from message history, so pi sessions show tasks in the Tasks pill like omp does. Supports both todo extensions: `@juicesharp/rpiv-todo` (the most popular todo extension on pi.dev/packages) and pi's `examples/extensions/todo.ts`.

## Changes
- **`todo-mapper`**: parses both payload shapes — rpiv-todo's `details.tasks` (`subject` + `pending`/`in_progress`/`completed`/`deleted`, tombstones dropped) and the example extension's `details.todos` (`text` + `done`). `mapPiTodoToolResult` handles live results; `mapPiTodoMessages` finds the most recent `todo` toolResult in message history for hydration.
- **`agent`**: `streamHistory` emits the hydrated todo item after replaying messages; `tool_execution_end` with `toolName === "todo"` emits a `todo` timeline item instead of a `tool_call` badge (deduped).
- No `rpc-types` changes (removed the fictional phase/reminder schemas).

## Testing
- `npx vitest run packages/server/src/server/agent/providers/pi/todo-mapper.test.ts` — 4/4 pass (both shapes, tombstones, malformed payloads, hydration)
- `npx vitest run packages/server/src/server/agent/providers/pi/agent.test.ts` and `history-mapper.test.ts` — pass
