### PR TITLE
Fix self-hosted web UI bootstrap behind TLS proxies

### DIFF
--- a/packages/app/src/components/add-host-modal.tsx
+++ b/packages/app/src/components/add-host-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Pressable, Text, View } from "react-native";
 import { StyleSheet, useUnistyles } from "react-native-unistyles";
@@ -8,6 +8,7 @@ import type { HostProfile } from "@/types/host-connection";
 import { useHosts, useHostMutations } from "@/runtime/host-runtime";
 import {
   parseConnectionUri,
+  parseHostPort,
   serializeConnectionUri,
   serializeConnectionUriForStorage,
 } from "@/utils/daemon-endpoints";
@@ -279,6 +280,10 @@ function buildConnectionFailureCopy(input: {
 
 export interface AddHostModalProps {
   visible: boolean;
+  initialConnection?: {
+    endpoint: string;
+    useTls?: boolean;
+  };
   onClose: () => void;
   onCancel?: () => void;
   onSaved?: (result: {
@@ -289,7 +294,13 @@ export interface AddHostModalProps {
   }) => void;
 }
 
-export function AddHostModal({ visible, onClose, onCancel, onSaved }: AddHostModalProps) {
+export function AddHostModal({
+  visible,
+  initialConnection,
+  onClose,
+  onCancel,
+  onSaved,
+}: AddHostModalProps) {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
   const daemons = useHosts();
@@ -317,6 +328,25 @@ export function AddHostModal({ visible, onClose, onCancel, onSaved }: AddHostMod
     setAdvancedUri("");
     bumpInputResetKey();
   }, []);
+
+  useEffect(() => {
+    if (!visible || !initialConnection) {
+      return;
+    }
+    try {
+      const { host: initialHost, port: initialPort } = parseHostPort(initialConnection.endpoint);
+      setHost(initialHost);
+      setPort(String(initialPort));
+      setUseTls(initialConnection.useTls ?? false);
+      setPassword("");
+      setIsPasswordVisible(false);
+      setIsAdvancedOpen(false);
+      setAdvancedUri("");
+      bumpInputResetKey();
+    } catch {
+      return;
+    }
+  }, [initialConnection, visible]);
 
   const connectIcon = useMemo(
     () => <Link2 size={16} color={theme.colors.accentForeground} />,

--- a/packages/app/src/components/welcome-screen.tsx
+++ b/packages/app/src/components/welcome-screen.tsx
@@ -6,7 +6,12 @@ import { StyleSheet, useUnistyles } from "react-native-unistyles";
 import { QrCode, Link2, ClipboardPaste, ExternalLink, Settings } from "lucide-react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { HostProfile } from "@/types/host-connection";
-import { getHostRuntimeStore, isHostRuntimeConnected, useHosts } from "@/runtime/host-runtime";
+import {
+  getHostRuntimeStore,
+  isHostRuntimeConnected,
+  useHosts,
+  useInitialConnectionHintAuthentication,
+} from "@/runtime/host-runtime";
 import { AddHostModal } from "./add-host-modal";
 import { PairLinkModal } from "./pair-link-modal";
 import { Button } from "@/components/ui/button";
@@ -167,12 +172,19 @@ export function WelcomeScreen({ onHostAdded }: WelcomeScreenProps) {
   const [isDirectOpen, setIsDirectOpen] = useState(false);
   const [isPasteLinkOpen, setIsPasteLinkOpen] = useState(false);
   const hosts = useHosts();
+  const initialConnectionHintAuthentication = useInitialConnectionHintAuthentication();
   const anyOnlineServerId = useAnyHostOnline(hosts.map((h) => h.serverId));
 
   useEffect(() => {
     if (!anyOnlineServerId) return;
     router.replace(buildOpenProjectRoute());
   }, [anyOnlineServerId, router]);
+
+  useEffect(() => {
+    if (initialConnectionHintAuthentication?.type === "directTcp") {
+      setIsDirectOpen(true);
+    }
+  }, [initialConnectionHintAuthentication]);
 
   const finishOnboarding = useCallback(() => {
     router.replace(buildOpenProjectRoute());
@@ -296,6 +308,11 @@ export function WelcomeScreen({ onHostAdded }: WelcomeScreenProps) {
 
         <AddHostModal
           visible={isDirectOpen}
+          initialConnection={
+            initialConnectionHintAuthentication?.type === "directTcp"
+              ? initialConnectionHintAuthentication
+              : undefined
+          }
           onClose={handleCloseDirect}
           onSaved={handleHostSaved}
         />

--- a/packages/app/src/runtime/host-runtime.test.ts
+++ b/packages/app/src/runtime/host-runtime.test.ts
@@ -3408,6 +3408,37 @@ describe("HostRuntimeStore initial connection hint bootstrap", () => {
     store.syncHosts([]);
   });
 
+  it("surfaces a password-protected initial hint for direct connection", async () => {
+    const seenProbes: { endpoint: string; useTls?: boolean }[] = [];
+    const store = new HostRuntimeStore({
+      deps: {
+        createClient: () => new FakeDaemonClient() as unknown as DaemonClient,
+        connectToDaemon: async ({ connection }) => {
+          if (connection.type === "directTcp") {
+            seenProbes.push({ endpoint: connection.endpoint, useTls: connection.useTls });
+          }
+          throw new Error("Password required");
+        },
+        getClientId: async () => "cid_test_runtime",
+        readInitialConnectionHint: () => ({
+          listen: "paseo.example.com:443",
+          useTls: true,
+        }),
+      },
+      storage: createMemoryHostRuntimeStorage(),
+    });
+
+    await store.boot();
+
+    expect(seenProbes).toEqual([{ endpoint: "paseo.example.com:443", useTls: true }]);
+    expect(store.getInitialConnectionHintAuthentication()).toEqual({
+      id: "direct:paseo.example.com:443",
+      type: "directTcp",
+      endpoint: "paseo.example.com:443",
+      useTls: true,
+    });
+  });
+
   it("does not infer window.location.host when no explicit hint is present", async () => {
     const seenProbes: { endpoint: string; useTls?: boolean }[] = [];
     const firstProbe = createDeferred<void>();

--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -1330,6 +1330,10 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isPasswordRequiredError(error: unknown): boolean {
+  return toErrorMessage(error) === "Password required";
+}
+
 function rekeyMap<V>(map: Map<string, V>, oldKey: string, newKey: string): void {
   const value = map.get(oldKey);
   if (value === undefined) {
@@ -1365,6 +1369,7 @@ export class HostRuntimeStore {
   private directorySyncByServer = new Map<string, DirectorySync>();
   private configuredOverrideBootstrapInFlight: Promise<void> | null = null;
   private bootPromise: Promise<void> | null = null;
+  private initialConnectionHintAuthentication: HostConnection | null = null;
   private storage: HostRuntimeStorage;
   private replicaCache: ReplicaCache;
   private readonly revokePushNotifications: typeof revokePushNotifications;
@@ -1388,6 +1393,10 @@ export class HostRuntimeStore {
 
   getHostRegistryStatus(): HostRegistryStatus {
     return this.hostRegistryStatus;
+  }
+
+  getInitialConnectionHintAuthentication(): HostConnection | null {
+    return this.initialConnectionHintAuthentication;
   }
 
   recordUserActivity(): void {
@@ -1591,6 +1600,11 @@ export class HostRuntimeStore {
       });
       return true;
     } catch (error) {
+      if (isPasswordRequiredError(error)) {
+        this.initialConnectionHintAuthentication = connectionWithHint;
+        this.emitGlobal();
+        return true;
+      }
       console.warn("[HostRuntime] initial connection hint probe failed", {
         listen: hint.listen,
         useTls: hint.useTls,
@@ -1719,6 +1733,10 @@ export class HostRuntimeStore {
       connection: input.connection,
       existingClient: client,
     });
+    if (this.initialConnectionHintAuthentication?.id === input.connection.id) {
+      this.initialConnectionHintAuthentication = null;
+      this.emitGlobal();
+    }
     return { profile, serverId, hostname };
   }
 
@@ -2336,6 +2354,13 @@ export class HostRuntimeStore {
       listener();
     }
   }
+
+  private emitGlobal(): void {
+    this.version += 1;
+    for (const listener of this.globalListeners) {
+      listener();
+    }
+  }
 }
 
 let singletonHostRuntimeStore: HostRuntimeStore | null = null;
@@ -2471,6 +2496,15 @@ export function useHostRegistryLoaded(): boolean {
     (onStoreChange) => store.subscribeHostList(onStoreChange),
     () => store.isHostRegistryLoaded(),
     () => store.isHostRegistryLoaded(),
+  );
+}
+
+export function useInitialConnectionHintAuthentication(): HostConnection | null {
+  const store = getHostRuntimeStore();
+  return useSyncExternalStore(
+    (onStoreChange) => store.subscribeAll(onStoreChange),
+    () => store.getInitialConnectionHintAuthentication(),
+    () => store.getInitialConnectionHintAuthentication(),
   );
 }
 

--- a/packages/server/src/server/bootstrap-web-ui.test.ts
+++ b/packages/server/src/server/bootstrap-web-ui.test.ts
@@ -110,6 +110,35 @@ describe("daemon web UI bootstrap", () => {
     });
   });
 
+  test("uses the default HTTPS port for a password-protected UI behind a proxy", async () => {
+    const distDir = await createWebUiDist();
+
+    daemonHandle = await createTestPaseoDaemon({
+      auth: { password: "$2b$12$OLxyuuP9uLK30Uzc4wQX0O6liuU/Q1t5P2b0Ebf36mULvpVK3DRZW" },
+      mcpEnabled: false,
+      webUi: {
+        enabled: true,
+        distDir,
+      },
+    });
+
+    const hint = readInjectedConnectionHint(
+      await fetchDaemonWebUi({
+        port: daemonHandle.port,
+        headers: {
+          host: "paseo.example.com",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
+
+    expect(hint).toEqual({
+      listen: "paseo.example.com:443",
+      useTls: true,
+      label: os.hostname(),
+    });
+  });
+
   test("ignores forwarded HTTPS when proxy trust is disabled", async () => {
     const distDir = await createWebUiDist();
 

--- a/packages/server/src/server/web-ui.test.ts
+++ b/packages/server/src/server/web-ui.test.ts
@@ -157,6 +157,20 @@ describe("daemon web UI route module", () => {
     expect(res.body).toContain('"label":"test-label"');
   });
 
+  test("adds the default HTTPS port when the forwarded host omits it", async () => {
+    const app = createApp({ enabled: true, distDir, publicDir });
+    app.set("trust proxy", true);
+
+    const res = await request(app, "GET", "/", {
+      host: "paseo.example.com",
+      "x-forwarded-proto": "https",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('"listen":"paseo.example.com:443"');
+    expect(res.body).toContain('"useTls":true');
+  });
+
   test("injects hint before closing head tag", async () => {
     const app = createApp({ enabled: true, distDir, publicDir });
 

--- a/packages/server/src/server/web-ui.ts
+++ b/packages/server/src/server/web-ui.ts
@@ -250,15 +250,22 @@ function serializeInlineScriptJson(value: unknown): string {
     .replace(/&/g, "\\u0026");
 }
 
+function addDefaultPort(host: string, useTls: boolean): string {
+  if (!host || (host.includes(":") && !host.endsWith("]"))) {
+    return host;
+  }
+  return `${host}:${useTls ? 443 : 80}`;
+}
+
 function injectConnectionHint(
   html: string,
   req: Parameters<RequestHandler>[0],
   label: string,
 ): string {
-  const host = typeof req.headers.host === "string" ? req.headers.host : "";
   const useTls = req.protocol === "https";
+  const host = typeof req.headers.host === "string" ? req.headers.host : "";
   const hint = {
-    listen: host,
+    listen: addDefaultPort(host, useTls),
     useTls,
     label,
   };


### PR DESCRIPTION
Fixes the served web UI's same-origin bootstrap when TLS terminates at a reverse proxy.

The daemon now makes the implied standard port explicit in its connection hint. If the first connection reaches a password-protected daemon, the welcome screen opens Direct connection with the same host, port, and TLS setting already filled in, so the remaining input is the password.

Regression coverage uses a password-protected daemon behind a trusted HTTPS proxy and verifies the app's `Password required` path.

Raw production evidence and repro collected before this change:

```text
curl HTML:
<script>window.__PASEO_INITIAL_DAEMON_CONNECTION__={"listen":"paseo.example.com","useTls":true,"label":"my-server"}</script>

Firefox/camoufox DOM:
Array.from(document.querySelectorAll('script')).filter(s=>s.textContent.includes('PASEO_INITIAL'))
-> 1 inline script, len=118, no nonce

localStorage keys:
paseo-drafts
@paseo:app-settings
sidebar-view
@paseo:client-id-v1

@paseo:daemon-registry: EMPTY

curl -o /dev/null -w "%{http_code}" https://paseo.example.com/api/agents
401

curl -o /dev/null -w "%{http_code}" https://paseo.example.com/
200

WebSocket upgrade (--http1.1) to /ws
101
```

```text
paseo daemon start --foreground --web-ui --listen 127.0.0.1:6767 --hostnames paseo.example.com --no-relay

PASEO_PASSWORD=<configured>
PASEO_TRUSTED_PROXIES=127.0.0.1
PASEO_APP_BASE_URL=https://paseo.example.com
PASEO_CORS_ORIGINS=https://paseo.example.com
```

The proxy forwarded `Host` and `X-Forwarded-Proto`; on port 443, its forwarded `Host` was `paseo.example.com` without a port.

QA run on macOS:

```text
$ npx vitest run packages/server/src/server/web-ui.test.ts packages/server/src/server/bootstrap-web-ui.test.ts --bail=1
Test Files  2 passed (2)
Tests  22 passed (22)

$ npm test --workspace=@getpaseo/app -- --run src/runtime/host-runtime.test.ts --bail=1
Test Files  1 passed (1)
Tests  68 passed (68)

$ npm run typecheck:server
@getpaseo/relay, @getpaseo/protocol, @getpaseo/client, @getpaseo/server, and @getpaseo/cli passed

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run format:check
All matched files use the correct format.
```

I also ran the requested workspace suites. They have unrelated failures in this checkout:

```text
$ npm test --workspace=@getpaseo/server
Test Files  4 failed | 344 passed | 3 skipped (351)
Tests  4 failed | 5132 passed | 44 skipped (5180)

Failures: GitHub fork PR owner assertion; launch-with-spaces exit code; a /private vs /var temp-path assertion; Codex Microsoft Store path discovery.

$ npm test --workspace=@getpaseo/app
Test Files  1 failed | 563 passed (564)
Tests  9 failed | 4704 passed (4713)
Errors  30 errors

Failures are in svg-root-transform; the errors are AsyncStorage `setItem` unhandled rejections.
```

I did not test iOS, Android, Electron, Windows, Linux, or a live reverse-proxy browser session. The affected browser flow is covered by the daemon integration and app runtime tests above.
